### PR TITLE
Some desktop file improvements

### DIFF
--- a/endless-sky.desktop
+++ b/endless-sky.desktop
@@ -1,9 +1,14 @@
 [Desktop Entry]
 Name=Endless Sky
+GenericName=Space game
+GenericName[de]=Weltraumspiel
+GenericName[fr]=Jeu spatial
+Comment=Space exploration and combat game
+Comment[de]=Weltraumhandels und Kampfsimulator
+Comment[fr]=Jeu d'exploration et de combat dans l'espace
 Exec=endless-sky
 Icon=endless-sky
 Terminal=false
 Type=Application
 Keywords=game;simulator;space;sandbox;rpg;
 Categories=Game;Simulation;
-Comment=Space exploration and combat game

--- a/endless-sky.desktop
+++ b/endless-sky.desktop
@@ -5,5 +5,5 @@ Icon=endless-sky
 Terminal=false
 Type=Application
 Keywords=game;simulator;space;sandbox;rpg;
+Categories=Game;Simulation;
 Comment=Space exploration and combat game
-


### PR DESCRIPTION
The Categories field is necessary at least on my distro to get the game entry in the proper menu (Games > Simulation).

GenericName is meant to be a very short description of the "type of software", like "Web browser" or "Text editor" (the tag name is poorly chosen IMO, but there is more info about its purpose here: http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys

Some desktop environments show "Comment" in the tooltip when you hover the game name, while other use "GenericName" (like KDE).