### PR TITLE
Add comma delimiter between thousands in formated number output

### DIFF
--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -62,10 +62,10 @@ string Format::Number(double value)
 		right = min(right, 3);
 	nonzero |= !right;
 	int rounded = round(fabs(value) * pow(10., right));
-    int dellimiterIndex = -1;
-    
-    if (left > 3)
-        dellimiterIndex = left - 3;
+	int delimiterIndex = -1;
+	
+	if (left > 3)
+		delimiterIndex = left - 3;
 	
 	while(rounded | right)
 	{
@@ -87,12 +87,12 @@ string Format::Number(double value)
 				nonzero = true;
 			}
 		}
-        else
-        {
-            --left;
-            if(left == dellimiterIndex)
-                result += ',';
-        }
+		else
+		{
+			--left;
+			if(left == delimiterIndex)
+				result += ',';
+		}
 	}
 	
 	// Add the negative sign if needed.

--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -62,6 +62,10 @@ string Format::Number(double value)
 		right = min(right, 3);
 	nonzero |= !right;
 	int rounded = round(fabs(value) * pow(10., right));
+    int dellimiterIndex = -1;
+    
+    if (left > 3)
+        dellimiterIndex = left - 3;
 	
 	while(rounded | right)
 	{
@@ -83,6 +87,12 @@ string Format::Number(double value)
 				nonzero = true;
 			}
 		}
+        else
+        {
+            --left;
+            if(left == dellimiterIndex)
+                result += ',';
+        }
 	}
 	
 	// Add the negative sign if needed.


### PR DESCRIPTION
So, how do you feel about delimiters? 

Maybe something like commas:
![screenshot from 2015-06-20 12 51 55](https://cloud.githubusercontent.com/assets/5718014/8266989/77581378-174c-11e5-8bcf-ce1b40b2aaa2.png)
^ This is how it looks in version I committed.

Or spaces:
![screenshot from 2015-06-20 12 57 06](https://cloud.githubusercontent.com/assets/5718014/8266990/9766d4f6-174c-11e5-85fa-cef41cf709ba.png)

As opposed to the way it's displayed now:
![screenshot from 2015-06-20 12 58 16](https://cloud.githubusercontent.com/assets/5718014/8266997/f54ffd90-174c-11e5-9f6b-c523e1c4ac72.png)

I personally think it would improve readability. Especially in range of hundreds of thousands as you can see in Principal column. I know it seems trivial but I just wanted to take a quick jab at modifying something and this was easiest on my list of issues I found.