### PR TITLE
'your' before 'passengers' is removed

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -795,7 +795,7 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	subs["<tons>"] = to_string(result.cargoSize) + (result.cargoSize == 1 ? " ton" : " tons");
 	subs["<cargo>"] = subs["<tons>"] + " of " + subs["<commodity>"];
 	subs["<bunks>"] = to_string(result.passengers);
-	subs["<passengers>"] = (result.passengers == 1) ? "your passenger" : "your passengers";
+	subs["<passengers>"] = (result.passengers == 1) ? "passenger" : "passengers";
 	subs["<fare>"] = (result.passengers == 1) ? "a passenger" : (subs["<bunks>"] + " passengers");
 	if(player.GetPlanet())
 		subs["<origin>"] = player.GetPlanet()->Name();


### PR DESCRIPTION
Everywhere <passengers> is used in the project, there is already a 'your', usually reading "You wish your your passenger..."