### PR TITLE
Need to include algorithm for min function

### DIFF
--- a/source/FrameTimer.cpp
+++ b/source/FrameTimer.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "FrameTimer.h"
 
 #include <thread>
+#include <algorithm>
 
 using namespace std;
 

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -39,18 +39,18 @@ public:
 	
 	
 protected:
-	virtual int TileSize() const;
-	virtual int DrawPlayerShipInfo(const Point &point) const;
-	virtual bool DrawItem(const std::string &name, const Point &point, int scrollY) const;
-	virtual int DividerOffset() const;
-	virtual int DetailWidth() const;
-	virtual int DrawDetails(const Point &center) const;
-	virtual bool CanBuy() const;
-	virtual void Buy();
-	virtual void FailBuy();
-	virtual bool CanSell() const;
-	virtual void Sell();
-	virtual bool FlightCheck();
+	virtual int TileSize() const override;
+	virtual int DrawPlayerShipInfo(const Point &point) const override;
+	virtual bool DrawItem(const std::string &name, const Point &point, int scrollY) const override;
+	virtual int DividerOffset() const override;
+	virtual int DetailWidth() const override;
+	virtual int DrawDetails(const Point &center) const override;
+	virtual bool CanBuy() const override;
+	virtual void Buy() override;
+	virtual void FailBuy() override;
+	virtual bool CanSell() const override;
+	virtual void Sell() override;
+	virtual bool FlightCheck() override;
 	
 	
 private:

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -33,18 +33,18 @@ public:
 	
 	
 protected:
-	virtual int TileSize() const;
-	virtual int DrawPlayerShipInfo(const Point &point) const;
-	virtual bool DrawItem(const std::string &name, const Point &point, int scrollY) const;
-	virtual int DividerOffset() const;
-	virtual int DetailWidth() const;
-	virtual int DrawDetails(const Point &center) const;
-	virtual bool CanBuy() const;
-	virtual void Buy();
-	virtual void FailBuy();
-	virtual bool CanSell() const;
-	virtual void Sell();
-	virtual bool FlightCheck();
+	virtual int TileSize() const override;
+	virtual int DrawPlayerShipInfo(const Point &point) const override;
+	virtual bool DrawItem(const std::string &name, const Point &point, int scrollY) const override;
+	virtual int DividerOffset() const override;
+	virtual int DetailWidth() const override;
+	virtual int DrawDetails(const Point &center) const override;
+	virtual bool CanBuy() const override;
+	virtual void Buy() override;
+	virtual void FailBuy() override;
+	virtual bool CanSell() const override;
+	virtual void Sell() override;
+	virtual bool FlightCheck() override;
 	virtual bool CanSellMultiple() const override;
 	
 	


### PR DESCRIPTION
At least in Xcode, the 'min' function added in https://github.com/endless-sky/endless-sky/commit/3604254dde093dc268e3c13a897afaef2e7bc5f6 is undefined unless algorithm is included. I am unsure about this change because either a) builds everywhere are broken without it, and I don't expect all builds to be broken, or b) I don't know why it's required here but not elsewhere. Full disclosure: this is probably the first line of c++ I've ever written ;)