### PR TITLE
Fix warnings about member function overrides by adding override specifiers

### DIFF
--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -39,18 +39,18 @@ public:
 	
 	
 protected:
-	virtual int TileSize() const;
-	virtual int DrawPlayerShipInfo(const Point &point) const;
-	virtual bool DrawItem(const std::string &name, const Point &point, int scrollY) const;
-	virtual int DividerOffset() const;
-	virtual int DetailWidth() const;
-	virtual int DrawDetails(const Point &center) const;
-	virtual bool CanBuy() const;
-	virtual void Buy();
-	virtual void FailBuy();
-	virtual bool CanSell() const;
-	virtual void Sell();
-	virtual bool FlightCheck();
+	virtual int TileSize() const override;
+	virtual int DrawPlayerShipInfo(const Point &point) const override;
+	virtual bool DrawItem(const std::string &name, const Point &point, int scrollY) const override;
+	virtual int DividerOffset() const override;
+	virtual int DetailWidth() const override;
+	virtual int DrawDetails(const Point &center) const override;
+	virtual bool CanBuy() const override;
+	virtual void Buy() override;
+	virtual void FailBuy() override;
+	virtual bool CanSell() const override;
+	virtual void Sell() override;
+	virtual bool FlightCheck() override;
 	
 	
 private:

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -33,18 +33,18 @@ public:
 	
 	
 protected:
-	virtual int TileSize() const;
-	virtual int DrawPlayerShipInfo(const Point &point) const;
-	virtual bool DrawItem(const std::string &name, const Point &point, int scrollY) const;
-	virtual int DividerOffset() const;
-	virtual int DetailWidth() const;
-	virtual int DrawDetails(const Point &center) const;
-	virtual bool CanBuy() const;
-	virtual void Buy();
-	virtual void FailBuy();
-	virtual bool CanSell() const;
-	virtual void Sell();
-	virtual bool FlightCheck();
+	virtual int TileSize() const override;
+	virtual int DrawPlayerShipInfo(const Point &point) const override;
+	virtual bool DrawItem(const std::string &name, const Point &point, int scrollY) const override;
+	virtual int DividerOffset() const override;
+	virtual int DetailWidth() const override;
+	virtual int DrawDetails(const Point &center) const override;
+	virtual bool CanBuy() const override;
+	virtual void Buy() override;
+	virtual void FailBuy() override;
+	virtual bool CanSell() const override;
+	virtual void Sell() override;
+	virtual bool FlightCheck() override;
 	virtual bool CanSellMultiple() const override;
 	
 	


### PR DESCRIPTION
Functions in OutfitterPanel.h and ShipyardPanel.h are intended to override the ones in ShopPanel.h according to [this comment](https://github.com/endless-sky/endless-sky/blob/master/source/ShopPanel.h#L48). Adding the 'override' specifier eliminates the (Xcode 7) warning: "... overrides a member function but is not marked 'override'"