### PR TITLE
Change travel plan color when distance exceeds jumps remaining

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -199,9 +199,9 @@ const Planet *MapPanel::Find(const string &name)
 
 void MapPanel::DrawTravelPlan() const
 {
-	Color defaultColor(.2, .2, .6, 0.);
-	Color outOfFlagshipFuelRangeColor(.4, .2, 0., 0.);
-	Color outOfFleetFuelRangeColor(.4, .4, 0., 0.);
+	Color defaultColor(.2, .4, .1, 0.);
+	Color outOfFlagshipFuelRangeColor(.6, .2, .1, 0.);
+	Color outOfFleetFuelRangeColor(.5, .4, 0., 0.);
 	
 	Ship *ship = player.Flagship();
 	bool hasHyper = ship ? ship->Attributes().Get("hyperdrive") : false;

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -199,9 +199,9 @@ const Planet *MapPanel::Find(const string &name)
 
 void MapPanel::DrawTravelPlan() const
 {
-	Color defaultColor(.2, .4, .1, 0.);
-	Color outOfFlagshipFuelRangeColor(.6, .2, .1, 0.);
-	Color outOfFleetFuelRangeColor(.5, .4, 0., 0.);
+	Color defaultColor(.5, .4, 0., 0.);
+	Color outOfFlagshipFuelRangeColor(.55, .1, .0, 0.);
+	Color withinFleetFuelRangeColor(.2, .5, .0, 0.);
 	
 	Ship *ship = player.Flagship();
 	bool hasHyper = ship ? ship->Attributes().Get("hyperdrive") : false;
@@ -236,8 +236,8 @@ void MapPanel::DrawTravelPlan() const
 		to += unit;
 		
 		Color drawColor = defaultColor;
-		if(player.TravelPlan().size() - i >= fleetMaxJumpsRemaining)
-			drawColor = outOfFleetFuelRangeColor;
+		if(player.Ships().size() > 0 && player.TravelPlan().size() - i < fleetMaxJumpsRemaining)
+			drawColor = withinFleetFuelRangeColor;
 		if(player.TravelPlan().size() - i >= ship->JumpsRemaining())
 			drawColor = outOfFlagshipFuelRangeColor;
         

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -207,11 +207,11 @@ void MapPanel::DrawTravelPlan() const
 	bool hasHyper = ship ? ship->Attributes().Get("hyperdrive") : false;
 	bool hasJump = ship ? ship->Attributes().Get("jump drive") : false;
 	
-	int fleetMaxJumpsRemaining = 0;
+	int fleetMinJumpsRemaining = 999;
 	auto it = player.Ships().begin() + 1;
 	for( ; it != player.Ships().end(); ++it)
 		if (!(*it)->IsParked())
-			fleetMaxJumpsRemaining = max(fleetMaxJumpsRemaining,(*it)->JumpsRemaining());
+			fleetMinJumpsRemaining = min(fleetMinJumpsRemaining,(*it)->JumpsRemaining());
 	
 	// Draw your current travel plan.
 	const System *previous = playerSystem;
@@ -236,7 +236,7 @@ void MapPanel::DrawTravelPlan() const
 		to += unit;
 		
 		Color drawColor = defaultColor;
-		if(player.Ships().size() > 0 && player.TravelPlan().size() - i < fleetMaxJumpsRemaining)
+		if(fleetMinJumpsRemaining < 999 && player.TravelPlan().size() - i <= fleetMinJumpsRemaining)
 			drawColor = withinFleetFuelRangeColor;
 		if(player.TravelPlan().size() - i >= ship->JumpsRemaining())
 			drawColor = outOfFlagshipFuelRangeColor;

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -229,8 +229,8 @@ void MapPanel::DrawTravelPlan() const
 		from -= unit;
 		to += unit;
 		
-        Color drawColor = defaultColor;
-        if(player.TravelPlan().size() - i > ship->JumpsRemaining())
+		Color drawColor = defaultColor;
+		if(player.TravelPlan().size() - i > ship->JumpsRemaining())
             drawColor = outOfCurrentFuelRangeColor;
         
 		LineShader::Draw(from, to, 3., drawColor);

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -197,15 +197,20 @@ const Planet *MapPanel::Find(const string &name)
 }
 
 
-
 void MapPanel::DrawTravelPlan() const
 {
-	Color defaultColor(.4, .4, 0., 0.);
-	Color outOfCurrentFuelRangeColor(.4, .2, 0., 0.);
+	Color defaultColor(.2, .2, .6, 0.);
+	Color outOfFlagshipFuelRangeColor(.4, .2, 0., 0.);
+	Color outOfFleetFuelRangeColor(.4, .4, 0., 0.);
 	
 	Ship *ship = player.Flagship();
 	bool hasHyper = ship ? ship->Attributes().Get("hyperdrive") : false;
 	bool hasJump = ship ? ship->Attributes().Get("jump drive") : false;
+	
+	int fleetMaxJumpsRemaining = 0;
+	auto it = player.Ships().begin() + 1;
+	for( ; it != player.Ships().end(); ++it)
+		fleetMaxJumpsRemaining = max(fleetMaxJumpsRemaining,(*it)->JumpsRemaining());
 	
 	// Draw your current travel plan.
 	const System *previous = playerSystem;
@@ -230,8 +235,10 @@ void MapPanel::DrawTravelPlan() const
 		to += unit;
 		
 		Color drawColor = defaultColor;
-		if(player.TravelPlan().size() - i > ship->JumpsRemaining())
-			drawColor = outOfCurrentFuelRangeColor;
+		if(player.TravelPlan().size() - i >= fleetMaxJumpsRemaining)
+			drawColor = outOfFleetFuelRangeColor;
+		if(player.TravelPlan().size() - i >= ship->JumpsRemaining())
+			drawColor = outOfFlagshipFuelRangeColor;
         
 		LineShader::Draw(from, to, 3., drawColor);
 		

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -200,8 +200,8 @@ const Planet *MapPanel::Find(const string &name)
 
 void MapPanel::DrawTravelPlan() const
 {
-    Color defaultColor(.4, .4, 0., 0.);
-    Color outOfCurrentFuelRangeColor(.4, .2, 0., 0.);
+	Color defaultColor(.4, .4, 0., 0.);
+	Color outOfCurrentFuelRangeColor(.4, .2, 0., 0.);
 	
 	Ship *ship = player.Flagship();
 	bool hasHyper = ship ? ship->Attributes().Get("hyperdrive") : false;
@@ -231,7 +231,7 @@ void MapPanel::DrawTravelPlan() const
 		
 		Color drawColor = defaultColor;
 		if(player.TravelPlan().size() - i > ship->JumpsRemaining())
-            drawColor = outOfCurrentFuelRangeColor;
+        	drawColor = outOfCurrentFuelRangeColor;
         
 		LineShader::Draw(from, to, 3., drawColor);
 		

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -231,7 +231,7 @@ void MapPanel::DrawTravelPlan() const
 		
 		Color drawColor = defaultColor;
 		if(player.TravelPlan().size() - i > ship->JumpsRemaining())
-        	drawColor = outOfCurrentFuelRangeColor;
+			drawColor = outOfCurrentFuelRangeColor;
         
 		LineShader::Draw(from, to, 3., drawColor);
 		

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -210,7 +210,8 @@ void MapPanel::DrawTravelPlan() const
 	int fleetMaxJumpsRemaining = 0;
 	auto it = player.Ships().begin() + 1;
 	for( ; it != player.Ships().end(); ++it)
-		fleetMaxJumpsRemaining = max(fleetMaxJumpsRemaining,(*it)->JumpsRemaining());
+		if (!(*it)->IsParked())
+			fleetMaxJumpsRemaining = max(fleetMaxJumpsRemaining,(*it)->JumpsRemaining());
 	
 	// Draw your current travel plan.
 	const System *previous = playerSystem;

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -200,7 +200,8 @@ const Planet *MapPanel::Find(const string &name)
 
 void MapPanel::DrawTravelPlan() const
 {
-	Color color(.4, .4, 0., 0.);
+    Color defaultColor(.4, .4, 0., 0.);
+    Color outOfCurrentFuelRangeColor(.4, .2, 0., 0.);
 	
 	Ship *ship = player.Flagship();
 	bool hasHyper = ship ? ship->Attributes().Get("hyperdrive") : false;
@@ -228,7 +229,11 @@ void MapPanel::DrawTravelPlan() const
 		from -= unit;
 		to += unit;
 		
-		LineShader::Draw(from, to, 3., color);
+        Color drawColor = defaultColor;
+        if(player.TravelPlan().size() - i > ship->JumpsRemaining())
+            drawColor = outOfCurrentFuelRangeColor;
+        
+		LineShader::Draw(from, to, 3., drawColor);
 		
 		previous = next;
 	}


### PR DESCRIPTION
Change the travel plan draw color to a more orange-ish color when distance exceeds jumps remaining.

Just playing with stuff and wanted to try modifying something simple and making a PR. As a player, I sometimes need to calculate how far i get through hostile or unpopulated territory without needing to land and refuel. To do this currently, I have to check my fuel gauge and then manually count jumps on the map. With this change, I can easily tell when a travel path extends beyond the range of my current fuel. 

Update: If you have a fleet with you, you get a green line for your fleet's maximum fuel range.

![Image of map with change](http://i.imgur.com/nJHCdwb.png)