### PR TITLE
Selected target is white on radar

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -969,7 +969,8 @@ void Engine::CalculateStep()
 			
 			auto target = ship->GetTargetShip();
 			radar[calcTickTock].Add(
-				(ship->GetGovernment()->IsPlayer() || ship->GetPersonality().IsEscort()) ? Radar::PLAYER :
+				(ship == flagship->GetTargetShip()) ? Radar::SPECIAL :
+					(ship->GetGovernment()->IsPlayer() || ship->GetPersonality().IsEscort()) ? Radar::PLAYER :
 					(ship->IsDisabled() || ship->IsOverheated()) ? Radar::INACTIVE :
 					!ship->GetGovernment()->IsEnemy() ? Radar::FRIENDLY :
 					(target && target->GetGovernment()->IsPlayer()) ?


### PR DESCRIPTION
Selected target is colored Radar::SPECIAL on radar. This is how it worked in EV and was missing it in ES. The white dot stands out enough to be easily distinguishable, yet subtle enough to not overcast the other dots on the radar.

![White dot for selected target]
(https://lh3.googleusercontent.com/-S0KCQZ2zNLI/VkCXyh8d80I/AAAAAAAABlQ/kD7SOQlP2FA/s1600/Screen%2BShot%2B2015-11-09%2Bat%2B6.55.21%2BAM.png) 