### PR TITLE
Added a hotkey to clear the current ship target selection

### DIFF
--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -1405,7 +1405,7 @@ mission "FWC Pug 2C"
 			`	Katya says, "I still don't understand what makes you think you have the right to interfere in human affairs."`
 		
 			label interfere
-			`	"'Interfere'?" says the alien. "We have 'interfered' many times before, and always you have benefitted. If you do not believe us, ask those who live in the place you call the Deep. We helped them defeat the twisted half-human beings that you created in your foolish attempts to improve your race's genetic code. We have helped keep those creatures in check in the centuries since then. And we have helped in many other ways."`
+			`	"'Interfere'?" says the alien. "We have 'interfered' many times before, and always you have benefited. If you do not believe us, ask those who live in the place you call the Deep. We helped them defeat the twisted half-human beings that you created in your foolish attempts to improve your race's genetic code. We have helped keep those creatures in check in the centuries since then. And we have helped in many other ways."`
 			choice
 				`	"What do you want from us in return?"`
 				`	"What are you planning to do with these systems you have occupied?"`

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -919,7 +919,7 @@ mission "FW Northern 3B"
 	
 	on offer
 		conversation
-			`Freya turns out to be a whisky drinker, like Tomek. By the time she has finished her first drink, she is chattering quite passionately about starship design: load balancing, stress lines, shield matrices, shipboard computers. Rather than dulling her intelligence, alcohol just seems to reduce her ability to explain things in ways a non-specialist can understand. You try to steer the conversation towards something less technical...`
+			`Freya turns out to be a whiskey drinker, like Tomek. By the time she has finished her first drink, she is chattering quite passionately about starship design: load balancing, stress lines, shield matrices, shipboard computers. Rather than dulling her intelligence, alcohol just seems to reduce her ability to explain things in ways a non-specialist can understand. You try to steer the conversation towards something less technical...`
 			choice
 				`	"So, why did you join the Council, initially?"`
 					goto council

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -1307,7 +1307,7 @@ mission "FW Pug 3"
 			`	Alondo says, "I still don't understand what makes you think you have the right to interfere in human affairs."`
 		
 			label interfere
-			`	"'Interfere'?" says the alien. "We have 'interfered' many times before, and always you have benefitted. If you do not believe us, ask those who live in the place you call the Deep. We helped them defeat the twisted half-human beings that you created in your foolish attempts to improve your race's genetic code. We have helped keep those creatures in check in the centuries since then. And we have helped in many other ways."`
+			`	"'Interfere'?" says the alien. "We have 'interfered' many times before, and always you have benefited. If you do not believe us, ask those who live in the place you call the Deep. We helped them defeat the twisted half-human beings that you created in your foolish attempts to improve your race's genetic code. We have helped keep those creatures in check in the centuries since then. And we have helped in many other ways."`
 			choice
 				`	"What do you want from us in return?"`
 				`	"What are you planning to do with these systems you have occupied?"`

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -1289,7 +1289,7 @@ mission "FW Pirates 3.2"
 	
 	on offer
 		conversation
-			`Tomek meets you outside the spaceport bar and pulls you roughly aside into an alley. "Do you still think that an all-out assault on Greenrock is our best option?" he asks. Standing so close to him, you can't help notice the whisky on his breath.`
+			`Tomek meets you outside the spaceport bar and pulls you roughly aside into an alley. "Do you still think that an all-out assault on Greenrock is our best option?" he asks. Standing so close to him, you can't help notice the whiskey on his breath.`
 			choice
 				`	"Yes, it's our best chance for eliminating the pirates."`
 					goto yes
@@ -1301,7 +1301,7 @@ mission "FW Pirates 3.2"
 			`	"Then head to <planet> immediately. There are some militia captains there who will join you in a battle fleet. It's now or never, before the Senate finishes their work of castrating our military."`
 			label others
 			`	Just then, JJ walks out of the bar and sees you talking with Tomek. "Tomek," he says, "what are you doing? Freya and I are waiting inside." He beckons you into the bar.`
-			`	Inside, Freya is sitting at a table looking at Tomek's battered and whisky-stained galactic map. As you all sit down, JJ explains, "We've been asked to deliver an ultimatum to each pirate world, starting with the ruling authorities on Thule, in the Men system. The Free Worlds maintains the right to attack any ships engaged in piracy. Any world that continues to support piracy, slavery, or illegal weapons manufacture will be a valid military target for us. But first, we are to offer each world the opportunity to become truly autonomous and free from outside intervention, if they will pledge to cease those activities."`
+			`	Inside, Freya is sitting at a table looking at Tomek's battered and whiskey-stained galactic map. As you all sit down, JJ explains, "We've been asked to deliver an ultimatum to each pirate world, starting with the ruling authorities on Thule, in the Men system. The Free Worlds maintains the right to attack any ships engaged in piracy. Any world that continues to support piracy, slavery, or illegal weapons manufacture will be a valid military target for us. But first, we are to offer each world the opportunity to become truly autonomous and free from outside intervention, if they will pledge to cease those activities."`
 			`	Freya says, "The thing is, just like any other world, most people on the 'pirate' planets are just ordinary farmers, or factory workers, or whatever. The only difference is, they want no off-world government telling them how to live. So that's what we're going to offer them."`
 			`	JJ says, "Captain <last>, the Senate wants you to travel to Thule and deliver their ultimatum. You will be given a single Falcon as an escort: not enough for a battle fleet, just enough to keep you safe. You are to avoid engaging any pirates you meet, if possible. Understood?"`
 			choice

--- a/data/map.txt
+++ b/data/map.txt
@@ -12968,7 +12968,7 @@ planet Alfheim
 	landscape land/nasa3
 	description `Alfheim is a world of wide grassy plains, deserts, a few small oceans, and scattered rainforests. Not a pleasant enough planet to support large cities, it is instead mostly a site for oil drilling and manufacturing. So far only a tiny fraction of the surface has been developed, mostly clustered around the sites where the largest oil deposits have been discovered.`
 	description `	Settlements show up as small bright points on the dark side of the planet - not from city lights, but from natural gas burnoff at the drilling stations.`
-	spaceport `The spaceport is in the middle of a field of oil derricks so vast that from above, the desert seemed to be covered in spiky grey fur. The spaceport itself is a soaring canopy, made to look like a tent, or sails on a ship. But it is built of a sturdy composite of plastic and carbon fiber, and coated in reflective plastic. Inside, hovercrafts and massive sand-crawlers are bringing cargo to and from the refineries and factories scattered across the planet's surface.`
+	spaceport `The spaceport is in the middle of a field of oil derricks so vast that from above, the desert seemed to be covered in spiky grey fur. The spaceport itself is a soaring canopy, made to look like a tent, or sails on a ship. But it is built of a sturdy composite of plastic and carbon fiber, and coated in reflective plastic. Inside, hovercraft and massive sand-crawlers are bringing cargo to and from the refineries and factories scattered across the planet's surface.`
 	outfitter "Basic Outfits"
 	outfitter "Deep Sky Basics"
 	outfitter "Ammo North"
@@ -13164,7 +13164,7 @@ planet Calda
 	description `Calda is a tropical resort world, a pleasant place to unwind after a few days skiing on its sister planet, Vail. The most popular tourist destination is the hot springs, and the spa complexes that have been built up around them. Constant pesticide use has nearly eliminated insect pests. Because of the uncomfortably warm and humid summer months, the very rich view Calda more as a tourist destination than as a place to live.`
 	description `	In Calda's early days as a spa planet, a nearly silent eruption of carbon dioxide filled a resort valley and suffocated the whole population in moments. This incident has had hardly any effect on the tourism industry. Many of the regulars believe they are rich enough that no volcano would dare provoke them in such a way.`
 	spaceport `This is one of the few planets in this sector whose spaceport does not include private hangars, or at least gangway tunnels connecting to ships that land. The reason, of course, is so that visitors can experience the warm and pleasant air the moment they disembark. There is, however, a network of canvas-covered awnings branching out from the main buildings, offering shade and protection from the weather.`
-	spaceport `	Inside, the counters for hotel shuttles and rental vehicles (including hovercrafts and helicopters!) are far more prominent than the amenities that interest a captain like yourself.`
+	spaceport `	Inside, the counters for hotel shuttles and rental vehicles (including hovercraft and helicopters!) are far more prominent than the amenities that interest a captain like yourself.`
 	bribe 0.05
 	security 0.5
 	tribute 3300
@@ -13440,7 +13440,7 @@ planet Echo
 
 planet "Far'en Lai"
 	landscape land/dune3
-	description `When the Korath were banished to the Core, they were left with only one living world, a planet they call "Far'en Lai," meaning, "the last candle-flame." Afraid that this planet's biosphere will turn to dust in their hands like all the other worlds they once controlled, they Korath have left Far'en Lai entirely unsettled and un-exploited. It is rumored that the terms of their exile dictate that if Far'en Lai withers and dies, the remaining Korath exiles will be exterminated, but that if they can learn to make the planet flourish, their place in the galaxy will be restored.`
+	description `When the Korath were banished to the Core, they were left with only one living world, a planet they call "Far'en Lai," meaning, "the last candle-flame." Afraid that this planet's biosphere will turn to dust in their hands like all the other worlds they once controlled, they Korath have left Far'en Lai entirely unsettled and unexploited. It is rumored that the terms of their exile dictate that if Far'en Lai withers and dies, the remaining Korath exiles will be exterminated, but that if they can learn to make the planet flourish, their place in the galaxy will be restored.`
 	"required reputation" -1000
 	bribe 0
 	security 0

--- a/data/map.txt
+++ b/data/map.txt
@@ -13493,7 +13493,7 @@ planet "Fenrir Station"
 	attributes deep station
 	landscape land/space5
 	description `Fenrir Station is a bustling refinery, and from the way the foremen looked at you when you stepped off your ship, they seem to be eager for new recruits. In addition to harvesting deuterium, this is one of the few refinery stations in human space which also collects helium-3, an isotope with some exotic uses in medical imaging and in energy research.`
-	description `	The diversity of isotopes found here is partly due to the station being a relatively new construction and benefitting from modern technology. But the gas giant which the station harvests from also has a composition unlike any other known planet. One theory is that it is on the cusp of becoming a brown dwarf star, in which case the isotopes now being stirred into the upper atmosphere by convection will eventually be depleted by fusion.`
+	description `	The diversity of isotopes found here is partly due to the station being a relatively new construction and benefiting from modern technology. But the gas giant which the station harvests from also has a composition unlike any other known planet. One theory is that it is on the cusp of becoming a brown dwarf star, in which case the isotopes now being stirred into the upper atmosphere by convection will eventually be depleted by fusion.`
 	spaceport `This station is composed of two rings, one containing the refinery and the other, the living quarters and cafeteria for the workers, in addition to a docking bay for visiting freighters. The workers all seem to be very busy, and few of them pay any attention to you.`
 	bribe 0.05
 	security 0.8

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1510,7 +1510,7 @@ ship "Heavy Shuttle"
 	gun 7 -37
 	explode "tiny explosion" 10
 	explode "small explosion" 5
-	description "The Heavy Shuttle is an updated shuttle model from Betelgeuse Shipyards, attempting to improve on their perrenial classic by offering slightly better cargo and passenger capacity, at the expense of some speed and maneuverability."
+	description "The Heavy Shuttle is an updated shuttle model from Betelgeuse Shipyards, attempting to improve on their perennial classic by offering slightly better cargo and passenger capacity, at the expense of some speed and maneuverability."
 
 
 
@@ -1807,7 +1807,7 @@ ship "Osprey"
 	explode "big explosion" 16
 	explode "small explosion" 40
 	explode "tiny explosion" 28
-	description "After the Blackbird gained surprising popularity as an agile light warship despite its original design as a transport, Tarazed decided to produce a new design specifically intended as a warship. The Osprey was the result. Although it is considered overpriced by most savvy pilots, it is nevertheless a perrenial favorite among those who have the extra cash to spend on it."
+	description "After the Blackbird gained surprising popularity as an agile light warship despite its original design as a transport, Tarazed decided to produce a new design specifically intended as a warship. The Osprey was the result. Although it is considered overpriced by most savvy pilots, it is nevertheless a perennial favorite among those who have the extra cash to spend on it."
 
 
 

--- a/keys.txt
+++ b/keys.txt
@@ -13,6 +13,7 @@
 "Initiate hyperspace jump" 106
 "Select next ship" 110
 "Select nearest hostile ship" 114
+"Clear selection" 8
 "Deploy / recall fighters" 100
 "Fire afterburner" 97
 "Toggle cloaking device" 99

--- a/readme-developer.txt
+++ b/readme-developer.txt
@@ -72,7 +72,7 @@ SDL2
 
 Just downloading the SDL binary won't work, because XCode 5 checks that the framework is signed, and it isn't. Instead, build it from source:
 
-hg clone https://hg.libsdl.org/SDL open SDL/Xcode/SDL/SDL.xcodeproj
+hg clone https://hg.libsdl.org/SDL; open SDL/Xcode/SDL/SDL.xcodeproj
 
 Build the framework, then copy it into /Library/Frameworks. When I did this, for some reason it built to some obscure directory that I had to look up in the logs.
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1475,6 +1475,10 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, const list<shared_ptr<
 		if(selectNext)
 			ship.SetTargetShip(shared_ptr<Ship>());
 	}
+    else if(keyDown.Has(Command::CLEAR))
+    {
+        ship.SetTargetShip(shared_ptr<Ship>());
+    }
 	else if(keyDown.Has(Command::BOARD))
 	{
 		shared_ptr<const Ship> target = ship.GetTargetShip();

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -57,6 +57,7 @@ const Command Command::FIGHT(1uL << 21, "Fleet: Fight my target");
 const Command Command::GATHER(1uL << 22, "Fleet: Gather around me");
 const Command Command::HOLD(1uL << 23, "Fleet: Hold position");
 const Command Command::WAIT(1uL << 24, "");
+const Command Command::CLEAR(1uL << 25, "Clear selection");
 
 
 

--- a/source/Command.h
+++ b/source/Command.h
@@ -47,7 +47,8 @@ public:
 	static const Command FIGHT;
 	static const Command GATHER;
 	static const Command HOLD;
-	static const Command WAIT;
+    static const Command WAIT;
+    static const Command CLEAR;
 	
 public:
 	Command() = default;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -106,7 +106,8 @@ void PreferencesPanel::Draw() const
 		Command::NEAREST,
 		Command::TARGET,
 		Command::HAIL,
-		Command::BOARD,
+        Command::BOARD,
+        Command::CLEAR,
 		Command::NONE,
 		Command::MENU,
 		Command::MAP,
@@ -119,7 +120,7 @@ void PreferencesPanel::Draw() const
 		Command::GATHER,
 		Command::HOLD
 	};
-	static const Command *BREAK = &COMMANDS[18];
+	static const Command *BREAK = &COMMANDS[19];
 	for(const Command &command : COMMANDS)
 	{
 		// The "BREAK" line is where to go to the next column.
@@ -131,7 +132,7 @@ void PreferencesPanel::Draw() const
 		
 		if(!command)
 		{
-			table.DrawGap(10);
+			table.DrawGap(7);
 			table.DrawUnderline(medium);
 			if(category != end(CATEGORIES))
 				table.Draw(*category++, bright);


### PR DESCRIPTION
I added a new command to the game that will clear the currently selected ship target, the hotkey preference has been added to the preference pane and a default value for the hotkey (the "backspace" key) has been set in keys.txt. I think this is a very useful keyboard shortcut to include.