### PR TITLE
Added underscores beneath hotkey of most in-game buttons

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -1007,12 +1007,12 @@ interface "hail panel"
 		align left
 	
 	if "can dominate"
-	label "_Demand Tribute" -20 108
+	label "Demand _Tribute" -20 108
 		size 14
 		color bright
 		align center
 	if "cannot dominate"
-	label "_Demand Tribute" -20 108
+	label "Demand _Tribute" -20 108
 		size 14
 		color dim
 		align center

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -90,14 +90,14 @@ interface "main menu"
 	if "pilot loaded"
 	button e 435 155
 		size 90 30
-	label "Enter Ship" 435 148
+	label "_Enter Ship" 435 148
 		size 14
 		color bright
 		align center
 	if "no pilot loaded"
 	button n 435 155
 		size 90 30
-	label "New Pilot" 435 148
+	label "_New Pilot" 435 148
 		size 14
 		color bright
 		align center
@@ -105,7 +105,7 @@ interface "main menu"
 	
 	button l 300 155
 		size 120 30
-	label "Load / Save..." 300 148
+	label "_Load / Save..." 300 148
 		size 14
 		color bright
 		align center
@@ -113,13 +113,13 @@ interface "main menu"
 	# Left panel:
 	button q -285 155
 		size 90 30
-	label "Quit" -285 148
+	label "_Quit" -285 148
 		size 14
 		color bright
 		align center
 	button p -420 155
 		size 120 30
-	label "Preferences..." -420 148
+	label "_Preferences..." -420 148
 		size 14
 		color bright
 		align center
@@ -184,16 +184,16 @@ interface "load menu"
 	
 	# Greyed out buttons:
 	if "!pilot selected"
-	label "Delete" -285 148
+	label "_Delete" -285 148
 		size 14
 		color dim
 		align center
-	label "Add Snapshot" -60 148
+	label "_Add Snapshot" -60 148
 		size 14
 		color dim
 		align center
 	if "!snapshot selected"
-	label "Remove" 75 148
+	label "_Remove" 75 148
 		size 14
 		color dim
 		align center
@@ -206,28 +206,28 @@ interface "load menu"
 	
 	button n -420 155
 		size 120 30
-	label "New Pilot" -420 148
+	label "_New Pilot" -420 148
 		size 14
 		color bright
 		align center
 	if "pilot selected"
 	button d -285 155
 		size 90 30
-	label "Delete" -285 148
+	label "_Delete" -285 148
 		size 14
 		color bright
 		align center
 	
 	button a -60 155
 		size 120 30
-	label "Add Snapshot" -60 148
+	label "_Add Snapshot" -60 148
 		size 14
 		color bright
 		align center
 	if "snapshot selected"
 	button r 75 155
 		size 90 30
-	label "Remove" 75 148
+	label "_Remove" 75 148
 		size 14
 		color bright
 		align center
@@ -235,7 +235,7 @@ interface "load menu"
 	
 	button b 300 155
 		size 120 30
-	label "Back to Menu" 300 148
+	label "_Back to Menu" 300 148
 		size 14
 		color bright
 		align center
@@ -255,7 +255,7 @@ interface "preferences"
 	sprite "ui/keys panel" -65 -20
 	button b 195 205
 		size 120 30
-	label "Back to Menu..." 195 198
+	label "_Back to Menu..." 195 198
 		size 14
 		color bright
 		align center
@@ -516,12 +516,12 @@ interface "boarding"
 		align right
 	
 	if "!can take"
-	label "Take" -235 107
+	label "_Take" -235 107
 		size 14
 		color dim
 		align center
 	if "can take"
-	label "Take" -235 107
+	label "_Take" -235 107
 		size 14
 		color bright
 		align center
@@ -530,12 +530,12 @@ interface "boarding"
 	endif
 	
 	if "!can exit"
-	label "Done" -155 107
+	label "_Done" -155 107
 		size 14
 		color dim
 		align center
 	if "can exit"
-	label "Done" -155 107
+	label "_Done" -155 107
 		size 14
 		color bright
 		align center
@@ -544,12 +544,12 @@ interface "boarding"
 	endif
 	
 	if "!can capture"
-	label "Attempt Capture" -40 107
+	label "Attempt _Capture" -40 107
 		size 14
 		color dim
 		align center
 	if "can capture"
-	label "Attempt Capture" -40 107
+	label "Attempt _Capture" -40 107
 		size 14
 		color bright
 		align center
@@ -558,12 +558,12 @@ interface "boarding"
 	endif
 	
 	if "!can attack"
-	label "Attack" 120 177
+	label "_Attack" 120 177
 		size 14
 		color dim
 		align center
 	if "can attack"
-	label "Attack" 120 177
+	label "_Attack" 120 177
 		size 14
 		color bright
 		align center
@@ -572,12 +572,12 @@ interface "boarding"
 	endif
 	
 	if "!can defend"
-	label "Defend" 210 177
+	label "_Defend" 210 177
 		size 14
 		color dim
 		align center
 	if "can defend"
-	label "Defend" 210 177
+	label "_Defend" 210 177
 		size 14
 		color bright
 		align center
@@ -648,12 +648,12 @@ interface "hiring"
 	button h 140 355
 		size 80 40
 	if "!can hire"
-	label "Hire" 140 348
+	label "_Hire" 140 348
 		size 14
 		color dim
 		align center
 	if "can hire"
-	label "Hire" 140 348
+	label "_Hire" 140 348
 		size 14
 		color bright
 		align center
@@ -663,12 +663,12 @@ interface "hiring"
 	button f 60 355
 		size 80 40
 	if "!can fire"
-	label "Fire" 60 348
+	label "_Fire" 60 348
 		size 14
 		color dim
 		align center
 	if "can fire"
-	label "Fire" 60 348
+	label "_Fire" 60 348
 		size 14
 		color bright
 		align center
@@ -745,12 +745,12 @@ interface "bank"
 	button a 140 355
 		size 80 40
 	if "!can pay"
-	label "Pay All" 140 348
+	label "Pay _All" 140 348
 		size 14
 		color dim
 		align center
 	if "can pay"
-	label "Pay All" 140 348
+	label "Pay _All" 140 348
 		size 14
 		color bright
 		align center
@@ -788,25 +788,25 @@ interface "mission"
 		align center
 	
 	if "can accept"
-	label "Accept Mission" -45 -33
+	label "_Accept Mission" -45 -33
 		size 14
 		color bright
 		align center
 	endif
 	if "can abort"
-	label "Abort Mission" -45 -33
+	label "_Abort Mission" -45 -33
 		size 14
 		color bright
 		align center
 	endif
 	if "cannot accept"
-	label "Accept Mission" -45 -33
+	label "_Accept Mission" -45 -33
 		size 14
 		color dim
 		align center
 	endif
 	if "cannot abort"
-	label "Abort Mission" -45 -33
+	label "_Abort Mission" -45 -33
 		size 14
 		color dim
 		align center
@@ -814,7 +814,7 @@ interface "mission"
 	button a -45 -10
 		size 130 30
 	
-	label "Done" 70 -33
+	label "_Done" 70 -33
 		size 14
 		color bright
 		align center
@@ -829,13 +829,13 @@ interface "map buttons"
 	sprite "ui/wide button" -260 0
 	
 	if "!is ports"
-	label "Ports" -45 -33
+	label "_Ports" -45 -33
 		size 14
 		color bright
 		align center
 	endif
 	if "is ports"
-	label "Ports" -45 -33
+	label "_Ports" -45 -33
 		size 14
 		color dim
 		align center
@@ -844,13 +844,13 @@ interface "map buttons"
 		size 70 30
 	
 	if "!is missions"
-	label "Missions" -125 -33
+	label "M_issions" -125 -33
 		size 14
 		color bright
 		align center
 	endif
 	if "is missions"
-	label "Missions" -125 -33
+	label "M_issions" -125 -33
 		size 14
 		color dim
 		align center
@@ -859,13 +859,13 @@ interface "map buttons"
 		size 70 30
 	
 	if "!is outfitters"
-	label "Outfitters" -215 -33
+	label "_Outfitters" -215 -33
 		size 14
 		color bright
 		align center
 	endif
 	if "is outfitters"
-	label "Outfitters" -215 -33
+	label "_Outfitters" -215 -33
 		size 14
 		color dim
 		align center
@@ -874,13 +874,13 @@ interface "map buttons"
 		size 90 30
 	
 	if "!is shipyards"
-	label "Shipyards" -315 -33
+	label "_Shipyards" -315 -33
 		size 14
 		color bright
 		align center
 	endif
 	if "is shipyards"
-	label "Shipyards" -315 -33
+	label "_Shipyards" -315 -33
 		size 14
 		color dim
 		align center
@@ -890,7 +890,7 @@ interface "map buttons"
 	
 	if "!is missions"
 	sprite "ui/dialog cancel" -370 0
-	label "Done" -415 -33
+	label "_Done" -415 -33
 		size 14
 		color bright
 		align center
@@ -912,11 +912,11 @@ interface "info panel"
 	
 	if "ship tab"
 	sprite "ui/ship tab" 0 -300
-	label "Ship Info" -300 -303
+	label "_Ship Info" -300 -303
 		size 14
 		color bright
 		align center
-	label "Player Info" -420 -303
+	label "_Player Info" -420 -303
 		size 14
 		color medium
 		align center
@@ -926,11 +926,11 @@ interface "info panel"
 	
 	if "player tab"
 	sprite "ui/player tab" 0 -300
-	label "Ship Info" -300 -303
+	label "_Ship Info" -300 -303
 		size 14
 		color medium
 		align center
-	label "Player Info" -420 -303
+	label "_Player Info" -420 -303
 		size 14
 		color bright
 		align center
@@ -938,14 +938,14 @@ interface "info panel"
 		size 120 30
 	endif
 	
-	label "Done" 455 287
+	label "_Done" 455 287
 		size 14
 		color bright
 		align center
 	button d 455 295
 		size 90 30
 	
-	label "Missions..." 355 287
+	label "_Missions..." 355 287
 		size 14
 		color bright
 		align center
@@ -1007,22 +1007,22 @@ interface "hail panel"
 		align left
 	
 	if "can dominate"
-	label "Demand Tribute" -20 108
+	label "_Demand Tribute" -20 108
 		size 14
 		color bright
 		align center
 	if "cannot dominate"
-	label "Demand Tribute" -20 108
+	label "_Demand Tribute" -20 108
 		size 14
 		color dim
 		align center
 	if "can assist"
-	label "Ask For Help" -20 108
+	label "_Ask For _Help" -20 108
 		size 14
 		color bright
 		align center
 	if "cannot assist"
-	label "Ask For Help" -20 108
+	label "_Ask For _Help" -20 108
 		size 14
 		color dim
 		align center
@@ -1031,12 +1031,12 @@ interface "hail panel"
 		size 140 30
 	
 	if "can bribe"
-	label "Offer Bribe" 130 108
+	label "_Offer _Bribe" 130 108
 		size 14
 		color bright
 		align center
 	if "!can bribe"
-	label "Offer Bribe" 130 108
+	label "_Offer _Bribe" 130 108
 		size 14
 		color dim
 		align center
@@ -1044,7 +1044,7 @@ interface "hail panel"
 	button b 130 115
 		size 140 30
 	
-	label "Done" 250 108
+	label "_Done" 250 108
 		size 14
 		color bright
 		align center

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -340,7 +340,7 @@ interface "planet"
 	
 	if "has shipyard"
 	sprite "ui/planet dialog button" 280 90
-	label "Shipyard" 340 82
+	label "_Shipyard" 340 82
 		size 18
 		color bright
 		align right
@@ -349,7 +349,7 @@ interface "planet"
 	
 	if "has outfitter"
 	sprite "ui/planet dialog button" 280 150
-	label "Outfitter" 340 142
+	label "_Outfitter" 340 142
 		size 18
 		color bright
 		align right
@@ -358,7 +358,7 @@ interface "planet"
 	
 	if "is inhabited"
 	sprite "ui/planet dialog button" -400 150
-	label "Job Board" -460 142
+	label "_Job Board" -460 142
 		size 18
 		color bright
 		align left
@@ -366,7 +366,7 @@ interface "planet"
 		size 140 40
 	
 	sprite "ui/planet dialog button" -400 90
-	label "Trading" -460 82
+	label "_Trading" -460 82
 		size 18
 		color bright
 		align left
@@ -374,7 +374,7 @@ interface "planet"
 		size 140 40
 	
 	sprite "ui/planet dialog button" 280 210
-	label "Hire Crew" 340 202
+	label "_Hire Crew" 340 202
 		size 18
 		color bright
 		align right
@@ -383,7 +383,7 @@ interface "planet"
 	
 	if "has bank"
 	sprite "ui/planet dialog button" -400 210
-	label "Bank" -460 202
+	label "_Bank" -460 202
 		size 18
 		color bright
 		align left
@@ -392,7 +392,7 @@ interface "planet"
 	
 	if "has spaceport"
 	sprite "ui/planet dialog button" -400 270
-	label "Space Port" -460 262
+	label "Space _Port" -460 262
 		size 18
 		color bright
 		align left
@@ -401,7 +401,7 @@ interface "planet"
 	
 	if "has ship"
 	sprite "ui/planet dialog button" 280 270
-	label "Depart" 340 262
+	label "_Depart" 340 262
 		size 18
 		color bright
 		align right

--- a/source/Font.cpp
+++ b/source/Font.cpp
@@ -118,6 +118,7 @@ void Font::Draw(const string &str, const Point &point, const Color &color) const
 		static_cast<float>(round(point.X() - 1.)),
 		static_cast<float>(round(point.Y()))};
 	int previous = 0;
+	char prevc = ' ';
 	
 	for(char c : str)
 	{
@@ -130,12 +131,13 @@ void Font::Draw(const string &str, const Point &point, const Color &color) const
 		
 		glUniform1i(shader.Uniform("glyph"), glyph);
 		
-		textPos[0] += advance[previous * GLYPHS + glyph] + KERN;
+		if(prevc != '_') textPos[0] += advance[previous * GLYPHS + glyph] + KERN;
 		glUniform2fv(shader.Uniform("position"), 1, textPos);
 		
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 		
 		previous = glyph;
+		prevc = c;
 	}
 }
 

--- a/source/Font.cpp
+++ b/source/Font.cpp
@@ -30,6 +30,8 @@ namespace {
 		"uniform vec2 position;\n"
 		// The glyph to draw. (ASCII value - 32).
 		"uniform int glyph;\n"
+		// Aspect ratio of rendered glyph (unity by default).
+		"uniform float aspect = 1.f;\n"
 		
 		// Inputs from the VBO.
 		"in vec2 vert;\n"
@@ -41,7 +43,7 @@ namespace {
 		// Pick the proper glyph out of the texture.
 		"void main() {\n"
 		"  texCoord = vec2((glyph + corner.x) / 96.f, corner.y);\n"
-		"  gl_Position = vec4((vert + position) * scale, 0, 1);\n"
+		"  gl_Position = vec4((aspect * vert.x + position.x) * scale.x, (vert.y + position.y) * scale.y, 0, 1);\n"
 		"}\n";
 	
 	static const char *fragmentCode =
@@ -118,10 +120,16 @@ void Font::Draw(const string &str, const Point &point, const Color &color) const
 		static_cast<float>(round(point.X() - 1.)),
 		static_cast<float>(round(point.Y()))};
 	int previous = 0;
-	char prevc = ' ';
+	bool underlineChar = false;
+	const int underscoreGlyph = max(0, min(GLYPHS - 1, '_' - 32));
 	
 	for(char c : str)
 	{
+		if (c == '_') {
+			underlineChar = true;
+			continue;
+		}
+		
 		int glyph = max(0, min(GLYPHS - 1, c - 32));
 		if(!glyph)
 		{
@@ -130,14 +138,26 @@ void Font::Draw(const string &str, const Point &point, const Color &color) const
 		}
 		
 		glUniform1i(shader.Uniform("glyph"), glyph);
+		glUniform1f(shader.Uniform("aspect"), 1.f);
 		
-		if(prevc != '_') textPos[0] += advance[previous * GLYPHS + glyph] + KERN;
+		textPos[0] += advance[previous * GLYPHS + glyph] + KERN;
 		glUniform2fv(shader.Uniform("position"), 1, textPos);
 		
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 		
+		if (underlineChar)
+		{
+			glUniform1i(shader.Uniform("glyph"), underscoreGlyph);
+			glUniform1f(shader.Uniform("aspect"), (float) (advance[glyph * GLYPHS] + KERN)/
+						(advance[underscoreGlyph * GLYPHS] + KERN));
+			
+			glUniform2fv(shader.Uniform("position"), 1, textPos);
+			
+			glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+			underlineChar = false;
+		}
+		
 		previous = glyph;
-		prevc = c;
 	}
 }
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -189,18 +189,27 @@ void ShopPanel::DrawButtons() const
 	Point buyCenter = Screen::BottomRight() - Point(210, 25);
 	FillShader::Fill(buyCenter, Point(60, 30), Color(.1, 1.));
 	string buy = (selectedOutfit && player.Cargo().Get(selectedOutfit)) ? "Install" : "Buy";
+	bigFont.Draw("_",
+				 buyCenter - .5 * Point(bigFont.Width(buy), bigFont.Height()),
+				 CanBuy() ? bright : dim);
 	bigFont.Draw(buy,
 		buyCenter - .5 * Point(bigFont.Width(buy), bigFont.Height()),
 		CanBuy() ? bright : dim);
 	
 	Point sellCenter = Screen::BottomRight() - Point(130, 25);
 	FillShader::Fill(sellCenter, Point(60, 30), Color(.1, 1.));
+	bigFont.Draw("_",
+				 sellCenter - .5 * Point(bigFont.Width("Sell"), bigFont.Height()),
+				 CanSell() ? bright : dim);
 	bigFont.Draw("Sell",
 		sellCenter - .5 * Point(bigFont.Width("Sell"), bigFont.Height()),
 		CanSell() ? bright : dim);
 	
 	Point leaveCenter = Screen::BottomRight() - Point(45, 25);
 	FillShader::Fill(leaveCenter, Point(70, 30), Color(.1, 1.));
+	bigFont.Draw("_",
+				 leaveCenter - .5 * Point(bigFont.Width("Leave"), bigFont.Height()),
+				 bright);
 	bigFont.Draw("Leave",
 		leaveCenter - .5 * Point(bigFont.Width("Leave"), bigFont.Height()),
 		bright);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -188,29 +188,20 @@ void ShopPanel::DrawButtons() const
 	
 	Point buyCenter = Screen::BottomRight() - Point(210, 25);
 	FillShader::Fill(buyCenter, Point(60, 30), Color(.1, 1.));
-	string buy = (selectedOutfit && player.Cargo().Get(selectedOutfit)) ? "Install" : "Buy";
-	bigFont.Draw("_",
-				 buyCenter - .5 * Point(bigFont.Width(buy), bigFont.Height()),
-				 CanBuy() ? bright : dim);
+	string buy = (selectedOutfit && player.Cargo().Get(selectedOutfit)) ? "_Install" : "_Buy";
 	bigFont.Draw(buy,
 		buyCenter - .5 * Point(bigFont.Width(buy), bigFont.Height()),
 		CanBuy() ? bright : dim);
 	
 	Point sellCenter = Screen::BottomRight() - Point(130, 25);
 	FillShader::Fill(sellCenter, Point(60, 30), Color(.1, 1.));
-	bigFont.Draw("_",
-				 sellCenter - .5 * Point(bigFont.Width("Sell"), bigFont.Height()),
-				 CanSell() ? bright : dim);
-	bigFont.Draw("Sell",
+	bigFont.Draw("_Sell",
 		sellCenter - .5 * Point(bigFont.Width("Sell"), bigFont.Height()),
 		CanSell() ? bright : dim);
 	
 	Point leaveCenter = Screen::BottomRight() - Point(45, 25);
 	FillShader::Fill(leaveCenter, Point(70, 30), Color(.1, 1.));
-	bigFont.Draw("_",
-				 leaveCenter - .5 * Point(bigFont.Width("Leave"), bigFont.Height()),
-				 bright);
-	bigFont.Draw("Leave",
+	bigFont.Draw("_Leave",
 		leaveCenter - .5 * Point(bigFont.Width("Leave"), bigFont.Height()),
 		bright);
 	


### PR DESCRIPTION
I noticed that there are many hotkeys in all of the game dialogs, but there is no visual indication of the hotkeys on any of the buttons, currently the player has to find out through trial and error. To make these hotkeys much more obvious, I've added the ability to underline a character in a label by preceding the character with an underscore, e.g. "_Shipyard" would display as S&#818;hipyard. I went ahead and added underscores to all labels in the game (I believe) that have hotkeys defined.

~~For the most part it looks good, but there are some wide characters for which the underscore doesn't quite underline the whole character (capital "O", for example).~~

~~One exception was the ShopPanel, which draws the buttons differently; for this function I drew the underscores slightly differently.~~