### PR TITLE
Autosteering

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -40,8 +40,10 @@ namespace {
 	const Command &AutopilotCancelKeys()
 	{
 		static const Command keys(Command::LAND | Command::JUMP | Command::BOARD
-			| Command::BACK | Command::FORWARD | Command::LEFT | Command::RIGHT);
-		
+			| Command::BACK | Command::FORWARD | Command::LEFT | Command::RIGHT
+			| Command::AUTOSTEER
+			);
+
 		return keys;
 	}
 	
@@ -1727,7 +1729,24 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, const list<shared_ptr<
 			else
 				command.SetTurn(TurnBackward(ship));
 		}
-		
+		else if(keyHeld.Has(Command::AUTOSTEER))
+		{
+			// Point at our target ship, planet, or system.
+			shared_ptr<const Ship> target = ship.GetTargetShip();
+			if (target && (ship.GetSystem() == target->GetSystem())) {
+				Point direction = target->Position() - ship.Position();
+				// Only compute aiming if the ship is in front of us
+				if(direction.Unit().Dot(ship.Facing().Unit()) >= .8)
+					direction = TargetAim(ship);
+				command.SetTurn(TurnToward(ship, direction));
+			} else if (ship.GetTargetPlanet()) {
+				Point direction = ship.GetTargetPlanet()->Position() - ship.Position();
+				command.SetTurn(TurnToward(ship, direction));
+			} else if (ship.GetTargetSystem()) {
+				Point direction = ship.GetTargetSystem()->Position() - ship.GetSystem()->Position();
+				command.SetTurn(TurnToward(ship, direction));
+			}
+		}
 		if(keyHeld.Has(Command::FORWARD))
 			command |= Command::FORWARD;
 		if(keyHeld.Has(Command::PRIMARY))

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -57,6 +57,7 @@ const Command Command::FIGHT(1uL << 21, "Fleet: Fight my target");
 const Command Command::GATHER(1uL << 22, "Fleet: Gather around me");
 const Command Command::HOLD(1uL << 23, "Fleet: Hold position");
 const Command Command::WAIT(1uL << 24, "");
+const Command Command::AUTOSTEER(1uL << 25, "Face selected ship");
 
 
 

--- a/source/Command.h
+++ b/source/Command.h
@@ -48,7 +48,8 @@ public:
 	static const Command GATHER;
 	static const Command HOLD;
 	static const Command WAIT;
-	
+	static const Command AUTOSTEER;
+
 public:
 	Command() = default;
 	// Assume SDL_Keycode is a signed int, so I don't need to include SDL.h.

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -111,6 +111,7 @@ void PreferencesPanel::Draw() const
 		Command::HAIL,
 		Command::BOARD,
 		Command::SCAN,
+		Command::AUTOSTEER,
 		Command::NONE,
 		Command::MENU,
 		Command::MAP,


### PR DESCRIPTION
This is a possible patch for #166 - it adds an auto-steering button that has the following behavior when you hold it down:
 * If you have a target ship in this system, this is the same as turning on auto-aiming
 * Otherwise, if you have a target planet, this turns you to face that planet
 * Otherwise, if you have a target system, this turns you to face that system

I had to move all the text on the key settings panel up a few pixels to avoid running off the bottom.