### PR TITLE
Improve resource search

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -116,8 +116,7 @@ void Files::Init(const char * const *argv)
 #elif defined __APPLE__
 	// Special case for Mac OS X: the resources are in ../Resources relative to
 	// the folder the binary is in.
-	size_t pos = resources.rfind('/', resources.length() - 2) + 1;
-	resources = resources.substr(0, pos) + "Resources/";
+	resources = resources + "../Resources/";
 #endif
 	// If the resources are not here, search in the directories containing this
 	// one. This allows, for example, a Mac app that does not actually have the
@@ -125,7 +124,7 @@ void Files::Init(const char * const *argv)
 	while(!Exists(resources + "credits.txt"))
 	{
 		size_t pos = resources.rfind('/', resources.length() - 2);
-		if(pos == string::npos)
+		if(pos == string::npos || pos == 0)
 			throw runtime_error("Unable to find the resource directories!");
 		resources.erase(pos + 1);
 	}


### PR DESCRIPTION
I ran into this problem when building the program on OS X via scons (i.e. without using XCode). The first problem is that on Macs the program assumes resources are in `../Resources`, which is only true if you build a full application bundle, so I changed it to just add `../Resources` to the end of the current path, so that the current directory will still be searched if `../Resources` doesn't exist.

The other issue is that if you fail to find resources it goes into an infinite loop checking `/` over and over again; this patch fixes that as well.

Thanks for making this game!