### PR TITLE
Objects properly referred to as station/moon/planet

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -13250,7 +13250,7 @@ planet Clark
 		fleet "Small Militia" 30
 
 planet Clink
-	attributes mining
+	attributes mining moon
 	landscape land/desert3
 	description `About a decade ago, a mining corporation from Zug planted a colony on Clink for harvesting some rare earth minerals that are present in this moon's crust due to its unusually high rate of asteroid impacts. The atmosphere here is too thin to breathe without a respirator, and because of the low gravity, the dust raised by the mining operations hangs perpetually in the air.`
 	description `	The miners who work here are a tight-knit group, since most of them were part of the original colonization team. They are not particularly open to outsiders, and the facilities here are so rudimentary that they do not even stock fuel for visiting ships.`
@@ -13431,7 +13431,7 @@ planet Earth
 		fleet "Large Republic" 50
 
 planet Echo
-	attributes quarg
+	attributes quarg moon
 	landscape land/desert2
 	description `This is a small Quarg outpost, which you suspect was built mostly to keep an eye on Tarazed Corporation and their alien-influenced research on the planet below. Like most Quarg worlds, the gravity is much too low here for it to be a feasible human colony, and although there is an atmosphere, it is too thin for a human being to breathe. Supposedly the Quarg have lungs designed for a continuous one way airflow, like a bird's lungs, rather than the ordinary in and out flow of human lungs; this is what enables them to survive on low-gravity, low-atmosphere worlds.`
 	spaceport `This outpost was really not designed with human beings in mind. The indoor air is not pressurized, so even there you need an oxygen mask to be able to breathe comfortably. And all the rooms and hallways are taller and narrower than you are used to. The station feels like a maze, full of winding passageways with no clear order or pattern to them, although perhaps the order would be readily apparent if you had an alien mind.`
@@ -13537,7 +13537,7 @@ planet Follower
 		fleet "Small Republic" 86
 
 planet Forpelog
-	attributes quarg
+	attributes quarg moon
 	landscape land/badlands4
 	description `Forpelog is a Quarg mining world, barely habitable by their standards and, because of its low gravity, unsuitable for long-term human habitation. The Quarg city is a marvel of advanced technology, entirely enclosed within glass and steel, with gardens and terraces where alien trees and plants grow. Outside the city, the landscape is rugged and beautiful, but the atmosphere is too thin to breathe and contains almost no oxygen.`
 	spaceport `Your ship is docked on a metal pad immediately outside the dome of the city, which towers over you. Immediately after you landed, a smaller canopy unfolded around your ship, sealing it in and providing enough air for you to breathe as you make your way inside. The stark, lifeless badlands outside give way to bustling streets and lush blue foliage within. No other human beings are in sight.`
@@ -13590,7 +13590,7 @@ planet Frostmark
 	spaceport `Every Hai city has an appearance of great age and permanence, but this one, even more so. In Hai cities, transport vehicles carry freight and passengers along underground passages or elevated railways, while the pathways at ground level are reserved for foot traffic. Here, millennia of foot traffic have rounded off the corners of every metal staircase, and polished the railings as smooth as glass. The Hai locals do not seem to have trouble keeping their footing, but you wish your shoes gave you more traction.`
 
 planet Furnace
-	attributes core military
+	attributes core military moon
 	landscape land/bwerner4
 	description `Furnace is a nearly uninhabited world, used mostly as a waypoint for shipping and as a staging point for the Syndicate fleets that seek to keep this region of space free from pirates. The atmosphere is barely thick enough to be breathable, and none of the plants that grow here are useful for eating. However, because it is only a large moon instead of a full-sized planet, moving cargo and fleets of ships to and from its surface is fairly easy and inexpensive.`
 	description `	Conducting any business here is a nightmare of tedium. Syndicate doctrine claims that corporate structure and process produce a leaner and more effective military force without the perceived wastage of the Republic Navy. But in practice, they seem to have combined all the worst aspects of military and corporate bureaucracy.`
@@ -13691,7 +13691,7 @@ planet Glory
 		fleet "Large Republic" 16
 
 planet Grakhord
-	attributes quarg
+	attributes quarg moon
 	landscape land/badlands6
 	description `Although human beings who do not mind living in low gravity are welcome to settle here, Grakhord is part of Quarg territory, and has been terraformed to meet their environmental needs rather than those of human beings. The full extent of the Quarg mining operations here are not known, but rumors say that they have tunnels reaching down almost halfway to the moon's core, and Quarg ships can also sometimes be seen harvesting hydrogen gas from the upper atmosphere of the gas giant that Grakhord orbits.`
 	spaceport `Here, you feel like a young child lost among a crowd of tall, indifferent adults. The average adult Quarg is over three meters tall, and although they move slowly and gracefully, on their long legs they easily speed by you. Worse, the counters for the merchant exchange, bank, and job board are high enough that you can barely see over them. But, the Quargs have helpfully provided stepping stools stashed under the counters so that shorter humans can carry out business without having to constantly crane their necks upwards.`
@@ -13945,7 +13945,7 @@ planet Icelake
 	outfitter "Hai Advanced"
 
 planet Ingot
-	attributes "dirt belt" volcanic mining
+	attributes "dirt belt" volcanic mining moon
 	landscape land/mountain8
 	description `Ingot is a volcanic moon, totally unsuitable for life but rich in metal. The miners who work here must spend all their time inside pressurized buildings. Because Ingot has almost no atmosphere to slow them down, meteorites are a constant danger to the colonists. The shells of the buildings have multiple layers, designed to be self-sealing in any but the largest of impacts. Most of the mining is done remotely by robotic vehicles, but someone still needs to be present to control them and to make repairs when something goes wrong.`
 	spaceport `In this spaceport, ships dock inside a hangar whose ceiling protects them from meteorite impacts. The hangar is not pressurized, so there are also landing tubes that connect to each of the visiting ships. Many of the people inside are carrying emergency oxygen masks in case a sudden impact ruptures the building.`
@@ -14025,7 +14025,7 @@ planet Longjump
 		fleet "Large Militia" 9
 
 planet Luna
-	attributes "near earth" tourism factory
+	attributes "near earth" tourism factory moon
 	landscape land/earthrise
 	description `In the early days of space travel, back when engines were still so inefficient that escaping from a planet's gravity was costly and difficult, an enormous shipyard was built on the Moon where asteroids, harvested from the asteroid belt, were mined for raw materials for ships.`
 	description `	The facility is still in operation, although it is now overshadowed by the far more advanced shipbuilding centers like Geminus in the Castor system.`
@@ -14097,7 +14097,7 @@ planet Makerplace
 	outfitter "Hai Advanced"
 
 planet Mani
-	attributes deep
+	attributes deep moon
 	landscape land/nasa6
 	description `Mani is a small moon, with an atmosphere thick enough to keep your blood from boiling off but too thin to breathe without assistance. It is used only as a cargo depot and a spot for refueling and repairs. The native plant life mostly consists of pale-colored lichens and a few species of grass. The only animals are insects.`
 	spaceport `The spaceport is shaped like a wheel with no rim: a series of spokes jutting out from a central hub, where each spoke is a docking tunnel that can connect to any ship that lands beside it. Inside are about a dozen people and a couple hundred robots. The people and robots alike seem uninterested in any interactions with you. It is a strange sort of aloofness that you have heard is common to all the worlds in the Deep.`
@@ -14185,7 +14185,7 @@ planet Millrace
 		fleet "Large Syndicate" 8
 
 planet Mirrorlake
-	attributes hai
+	attributes hai moon
 	landscape land/bwerner1
 	description `The Hai homeworld is orbited by a moon that is large and dense enough to have been able to hold on to its own supply of surface water, and although the atmosphere is cold, much of that water is in liquid form due to the strong tides. In a few places, granite and basalt cliffs rise out of the water, and the Hai have built a few small settlements on the moon, as well.`
 	spaceport `This spaceport appears to be a tourist destination. The architecture is different than on other Hai worlds, and much more primitive: stone and mortar instead of polished metal. However, all the buildings are in good repair: despite their ancient appearance, they must be maintained and rebuilt on a regular basis.`
@@ -14783,7 +14783,7 @@ planet Skillet
 		fleet "Small Republic" 22
 
 planet Skyfarm
-	attributes hai
+	attributes hai moon
 	landscape land/myrabella6
 	description `Due to the low gravity here, some of the alien crops planted by the Hai grow to heights of five meters or more. The air is too thin for humans or Hai to breathe without carrying supplemental oxygen tanks, so the population is very small. The fields are tended by enormous spider-like robots which are equipped not only for irrigation and harvesting, but also for pollination, since the thin atmosphere has made it impossible for native insects to evolve here.`
 	spaceport `The spaceport is a small city built under a pressurized glass dome, with a ring of hangars and landing pads around its periphery. As with most Hai architecture, the dome and the buildings within it are simple and sparsely decorated, but as you walk through the city everything feels very solid, and ancient. Everything is metal, even the roads and walkways, and the center of many of the roads dips down slightly due to millennia of foot traffic slowly wearing down the metal.`
@@ -15020,7 +15020,7 @@ planet "Triton Station"
 		fleet "Small Republic" 24
 
 planet Trove
-	attributes core mining
+	attributes core mining moon
 	landscape land/badlands3
 	description `Trove is a tiny moon, too small to have a breathable atmosphere. It is home to an experimental "jack mining" operation that has split is surface open in order to gain access to the metal-rich core. Most of the work here is done by machines, but a few people live inside an airtight complex in order to supervise the work and to sell ore and metal to visiting ships.`
 	spaceport `Within the mining complex, you find a small cafeteria with an uninspiring menu, and windows overlooking offices where dozens of people are staring at flickering video screens. Because of the low gravity, everyone moves languidly, as if in a dream. It is nearly silent.`
@@ -15108,7 +15108,7 @@ planet Warfeed
 	spaceport `This spaceport is a collection of ramshackle wooden buildings and packed dirt landing pads. The wagons piled high with produce and bags of grain would not look out of place in many human ports, but they are being drawn by giant lizards instead of horses or oxen. There are no human beings here, and most of the Hai eye you with suspicion and distaste.`
 
 planet Watcher
-	attributes "dirt belt" research uninhabited
+	attributes "dirt belt" research uninhabited moon
 	landscape land/hills4
 	description `Watcher is a small moon, the only world in this system that sustains any indigenous life. Because of the low gravity, humans have not yet built a permanent settlement here, but it is occasionally visited by biologists interested in studying low-gravity life forms. There are forests here where the trees grow over two hundred meters tall.`
 	security 0

--- a/keys.txt
+++ b/keys.txt
@@ -6,7 +6,7 @@
 "Fire primary weapon" 9
 "Fire secondary weapon" 113
 "Select secondary weapon" 119
-"Land on planet / station" 108
+"Land on planet / moon / station" 108
 "Board selected ship" 98
 "Talk to selected ship" 116
 "Scan selected ship" 115

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1548,7 +1548,8 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, const list<shared_ptr<
 			ship.SetTargetPlanet(next);
 			
 			if(next->GetPlanet() && !next->GetPlanet()->CanLand())
-				message = "The authorities on this planet refuse to clear you to land here.";
+				message = "The authorities on this " + ship.GetTargetPlanet()->GetPlanet()->Noun() +
+					" refuse to clear you to land here.";
 			else if(count > 1)
 			{
 				message = "Switching landing targets. Now landing on ";
@@ -1580,12 +1581,13 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, const list<shared_ptr<
 					}
 				}
 			if(!ship.GetTargetPlanet())
-				message = "There are no planets in this system that you can land on.";
+				message = "There are no objects in this system that you can land on.";
 			else if(!ship.GetTargetPlanet()->GetPlanet()->CanLand())
-				message = "The authorities on this planet refuse to clear you to land here.";
+				message = "The authorities on this " + ship.GetTargetPlanet()->GetPlanet()->Noun() +
+					" refuse to clear you to land here.";
 			else if(count > 1)
 			{
-				message = "You can land on more than one planet in this system. Landing on ";
+				message = "You can land or dock with more than one object in this system. Landing on ";
 				if(ship.GetTargetPlanet()->Name().empty())
 					message += "???.";
 				else

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -40,7 +40,7 @@ const Command Command::BACK(1uL << 4, "Reverse");
 const Command Command::PRIMARY(1uL << 5, "Fire primary weapon");
 const Command Command::SECONDARY(1uL << 6, "Fire secondary weapon");
 const Command Command::SELECT(1uL << 7, "Select secondary weapon");
-const Command Command::LAND(1uL << 8, "Land on planet / station");
+const Command Command::LAND(1uL << 8, "Land on planet / moon / station");
 const Command Command::BOARD(1uL << 9, "Board selected ship");
 const Command Command::HAIL(1uL << 10, "Talk to selected ship");
 const Command Command::SCAN(1uL << 11, "Scan selected ship");

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -623,7 +623,7 @@ void Engine::EnterSystem()
 	const Date &today = player.GetDate();
 	Messages::Add("Entering the " + system->Name() + " system on "
 		+ today.ToString() + (system->IsInhabited() ?
-			"." : ". No inhabited planets detected."));
+			"." : ". No inhabited objects detected."));
 	
 	for(const StellarObject &object : system->Objects())
 		if(object.GetPlanet())

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -100,7 +100,7 @@ HailPanel::HailPanel(PlayerInfo &player, const StellarObject *object)
 	
 	const Government *gov = player.GetSystem()->GetGovernment();
 	if(planet)
-		header = gov->GetName() + " planet \"" + planet->Name() + "\":";
+		header = gov->GetName() + " " + planet->Noun() + " \"" + planet->Name() + "\":";
 	
 	if(planet && player.Flagship())
 	{

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -94,7 +94,7 @@ void MainPanel::Step()
 			<< "you can hold the key to get them ready to jump, "
 			<< "then release it to have them all jump simultaneously.\n"
 			<< "\tWhen you reach a new system, you can press \""
-			<< Command::LAND.KeyName() << "\" to land on any inhabited planets that are there.\n"
+			<< Command::LAND.KeyName() << "\" to land on any inhabited objects that are there.\n"
 			<< "\tAlso, don't worry about crashing into asteroids or other ships; "
 			<< "your ship will fly safely below or above them.";
 		GetUI()->Push(new Dialog(out.str()));
@@ -106,7 +106,7 @@ void MainPanel::Step()
 		Preferences::Set("help: dead");
 		ostringstream out;
 		out << "Uh-oh! You just died. The universe can a dangerous place for new captains!\n"
-			<< "\tFortunately, your game is automatically saved every time you leave a planet. "
+			<< "\tFortunately, your game is automatically saved every time you leave a planet / moon / station. "
 			<< "To load your most recent saved game, press \"" + Command::MENU.KeyName()
 			<< "\" to return to the main menu, then click on \"Load / Save\" and \"Enter Ship.\"";
 		GetUI()->Push(new Dialog(out.str()));
@@ -314,7 +314,7 @@ void MainPanel::ShowHailPanel()
 		if(planet && planet->IsInhabited())
 			GetUI()->Push(new HailPanel(player, flagship->GetTargetPlanet()));
 		else
-			Messages::Add("Unable to send hail: planet is not inhabited.");
+			Messages::Add("Unable to send hail: " + planet->Noun() + " is not inhabited.");
 	}
 	else
 		Messages::Add("Unable to send hail: no target selected.");

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -328,7 +328,7 @@ void OutfitterPanel::FailBuy()
 	{
 		GetUI()->Push(new Dialog("You cannot buy this outfit here. "
 			"It is being shown in the list because you have one installed in your ship, "
-			"but this planet does not sell additional copies of it."));
+			"but this " + planet->Noun() + " does not sell additional copies of it."));
 		return;
 	}
 	

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -148,7 +148,21 @@ const set<string> &Planet::Attributes() const
 }
 
 
+// Get planet's noun descriptor from attributes
+string Planet::Noun() const
+{
+	string noun = "planet";
+//	for(const string &attribute : attributes) {
+//		if (attribute == "moon")
+//			noun = "moon";
+//		else if (attribute == "station")
+//			noun = "station";
+//	}
 	
+	return noun;
+}
+
+
 // Check whether there is a spaceport (which implies there is also trading,
 // jobs, banking, and hiring).
 bool Planet::HasSpaceport() const

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -152,12 +152,12 @@ const set<string> &Planet::Attributes() const
 string Planet::Noun() const
 {
 	string noun = "planet";
-//	for(const string &attribute : attributes) {
-//		if (attribute == "moon")
-//			noun = "moon";
-//		else if (attribute == "station")
-//			noun = "station";
-//	}
+	for(const string &attribute : attributes) {
+		if (attribute == "moon")
+			noun = "moon";
+		else if (attribute == "station")
+			noun = "station";
+	}
 	
 	return noun;
 }

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -148,6 +148,7 @@ const set<string> &Planet::Attributes() const
 }
 
 
+
 // Get planet's noun descriptor from attributes
 string Planet::Noun() const
 {
@@ -161,6 +162,7 @@ string Planet::Noun() const
 	
 	return noun;
 }
+
 
 
 // Check whether there is a spaceport (which implies there is also trading,

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -50,6 +50,9 @@ public:
 	// Get the list of "attributes" of the planet.
 	const std::set<std::string> &Attributes() const;
 	
+	// Get planet's noun descriptor from attributes
+	std::string Noun() const;
+	
 	// Check whether there is a spaceport (which implies there is also trading,
 	// jobs, banking, and hiring).
 	bool HasSpaceport() const;

--- a/source/StellarObject.cpp
+++ b/source/StellarObject.cpp
@@ -108,6 +108,22 @@ bool StellarObject::IsStar() const
 
 
 
+// Check if this is a station.
+bool StellarObject::IsStation() const
+{
+	return isStation;
+}
+
+
+
+// Check if this is a moon.
+bool StellarObject::IsMoon() const
+{
+	return isMoon;
+}
+
+
+
 // Get this object's parent index (in the System's vector of objects).
 int StellarObject::Parent() const
 {

--- a/source/StellarObject.h
+++ b/source/StellarObject.h
@@ -51,6 +51,10 @@ public:
 	
 	// Check if this is a star.
 	bool IsStar() const;
+	// Check if this is a station.
+	bool IsStation() const;
+	// Check if this is a moon.
+	bool IsMoon() const;
 	// Get this object's parent index (in the System's vector of objects).
 	int Parent() const;
 	// Find out how far this object is from its parent.
@@ -70,6 +74,8 @@ private:
 	
 	const std::string *message;
 	bool isStar;
+	bool isStation;
+	bool isMoon;
 	
 	// Let System handle setting all the values of an Object.
 	friend class System;

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -160,19 +160,37 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			root = &objects[root->parent];
 		
 		static const string STAR = "You cannot land on a star!";
-		static const string HOT = "This planet is too hot to land on.";
-		static const string COLD = "This planet is too cold to land on.";
-		static const string UNINHABITED = "This planet is uninhabited.";
+		static const string HOTPLANET = "This planet is too hot to land on.";
+		static const string COLDPLANET = "This planet is too cold to land on.";
+		static const string UNINHABITEDPLANET = "This planet is uninhabited.";
+		static const string HOTMOON = "This moon is too hot to land on.";
+		static const string COLDMOON = "This moon is too cold to land on.";
+		static const string UNINHABITEDMOON = "This moon is uninhabited.";
+		static const string STATION = "This station cannot be docked with.";
 		
 		double fraction = root->distance / habitable;
 		if(object.IsStar())
 			object.message = &STAR;
-		else if(fraction < .5)
-			object.message = &HOT;
-		else if(fraction >= 2.)
-			object.message = &COLD;
+		else if (object.IsStation())
+			object.message = &STATION;
+		else if (object.IsMoon())
+		{
+			if(fraction < .5)
+				object.message = &HOTMOON;
+			else if(fraction >= 2.)
+				object.message = &COLDMOON;
+			else
+				object.message = &UNINHABITEDMOON;
+		}
 		else
-			object.message = &UNINHABITED;
+		{
+			if(fraction < .5)
+				object.message = &HOTPLANET;
+			else if(fraction >= 2.)
+				object.message = &COLDPLANET;
+			else
+				object.message = &UNINHABITEDPLANET;
+		}
 	}
 }
 
@@ -408,6 +426,11 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 		{
 			object.animation.Load(child);
 			object.isStar = !child.Token(1).compare(0, 5, "star/");
+			if (!object.isStar)
+			{
+				object.isStation = !child.Token(1).compare(0, 14, "planet/station");
+				object.isMoon = (!object.isStation && parent >= 0 && !objects[parent].IsStar());
+			}
 		}
 		else if(child.Token(0) == "distance" && child.Size() >= 2)
 			object.distance = child.Value(1);


### PR DESCRIPTION
I have added a new member function to the Planet class that returns an improper noun for a given object depending on its attributes. For instance, any object with "station" amongst its attributes will be referred to as a station within the in-game dialog, rather than a "planet" as before. Additionally, I have added a "moon" attribute to all named moons within map.txt (as stations have the "station" attribute), this facilitates referring to these objects as "moon" within the in-game dialog. If "moon" or "station" are not amongst the attributes, the default "planet" is used.

For objects that cannot be landed on, I have added two new properties to the StellarObject class: IsMoon and IsStation. This enables the messages generated upon attempting to land on these objects to be more accurate (e.g. "This moon is too hot to land on" if the object is a moon). An object is determined to be a moon if it has a parent and that parent is not a star. 