### PR TITLE
Small fix to avoid out of bounds memory access in InfoPanel::DrawList…

### DIFF
--- a/source/InfoPanel.cpp
+++ b/source/InfoPanel.cpp
@@ -77,7 +77,8 @@ namespace {
 			return;
 		
 		int otherCount = list.size() - maxCount;
-		if(otherCount > 0)
+		
+		if(otherCount > 0 && maxCount > 0)
 		{
 			list[maxCount - 1].second = "(" + to_string(otherCount + 1) + " Others)";
 			while(otherCount--)


### PR DESCRIPTION
… (happens if maxCount = 0 and list.size() = 1).