### PR TITLE
Only apply drag when speeding.

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -997,12 +997,13 @@ bool Ship::Move(list<Effect> &effects)
 			}
 		}
 		if(acceleration)
+			velocity += acceleration;
+		// There's no actual drag in space, so we only apply it to our speed
+		// above our speed limit
+		if (velocity.Length() > MaxVelocity())
 		{
-			Point dragAcceleration = acceleration - velocity * (attributes.Get("drag") / mass);
-			// What direction will the net acceleration be if this drag is applied?
-			// If the net acceleration will be opposite the thrust, do not apply drag.
-			dragAcceleration *= .5 * (acceleration.Unit().Dot(dragAcceleration.Unit()) + 1.);
-			velocity += dragAcceleration;
+			Point excessVelocity = velocity - velocity.Unit()*MaxVelocity();
+			velocity -= excessVelocity * (attributes.Get("drag") / mass);
 		}
 		if(commands.Turn())
 		{


### PR DESCRIPTION
Proposed fix for #353.

I think this makes more sense than conditionally applying drag based on where you're accelerating - for example, it fixes the physics for a ship that's been thrown by an explosion or a Korath World-Ship. Without this patch, a ship thrown by an external force experiences no drag until it turns on its engines, which is really weird - you can be flying super fast across the system because several World-Ships repulsed you at once, and then when you turn on your tiny Chipmunk engine you stop immediately because suddenly drag applies when it didn't before.

This changes the drag equation so that drag affects a ship regardless of whether it's currently accelerating, but only reduces your velocity in excess of your maximum speed.