### PR TITLE
Hot keys/buttons in planet panel will now return back to planet descr…

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -374,7 +374,7 @@ interface "planet"
 		size 140 40
 	
 	sprite "ui/planet dialog button" 280 210
-	label "_Hire Crew" 340 202
+	label "Hire _Crew" 340 202
 		size 18
 		color bright
 		align right

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -179,7 +179,9 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 	else if((key == 'h' || key == 'c') && flagship && planet.IsInhabited() && hasAccess)
 	{
 		if (selectedPanel == hiring.get())
+		{
 			if (key == 'c') selectedPanel = nullptr;
+		}
 		else
 		{
 			selectedPanel = hiring.get();

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -133,18 +133,33 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 	}
 	else if(key == 't' && flagship && planet.IsInhabited() && hasAccess)
 	{
-		selectedPanel = trading.get();
-		GetUI()->Push(trading);
+		if (selectedPanel == trading.get())
+			selectedPanel = nullptr;
+		else
+		{
+			selectedPanel = trading.get();
+			GetUI()->Push(trading);
+		}
 	}
 	else if(key == 'b' && planet.IsInhabited() && hasAccess)
 	{
-		selectedPanel = bank.get();
-		GetUI()->Push(bank);
+		if (selectedPanel == bank.get())
+			selectedPanel = nullptr;
+		else
+		{
+			selectedPanel = bank.get();
+			GetUI()->Push(bank);
+		}
 	}
 	else if(key == 'p' && flagship && planet.HasSpaceport() && hasAccess)
 	{
-		selectedPanel = spaceport.get();
-		GetUI()->Push(spaceport);
+		if (selectedPanel == spaceport.get())
+			selectedPanel = nullptr;
+		else
+		{
+			selectedPanel = spaceport.get();
+			GetUI()->Push(spaceport);
+		}
 	}
 	else if(key == 's' && planet.HasShipyard() && hasAccess)
 	{
@@ -161,10 +176,15 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		GetUI()->Push(new MissionPanel(player));
 		return true;
 	}
-	else if(key == 'h' && flagship && planet.IsInhabited() && hasAccess)
+	else if((key == 'h' || key == 'c') && flagship && planet.IsInhabited() && hasAccess)
 	{
-		selectedPanel = hiring.get();
-		GetUI()->Push(hiring);
+		if (selectedPanel == hiring.get() && key == 'c')
+			selectedPanel = nullptr;
+		else
+		{
+			selectedPanel = hiring.get();
+			GetUI()->Push(hiring);
+		}
 	}
 	else if(command.Has(Command::MAP))
 	{

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -178,8 +178,8 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 	}
 	else if((key == 'h' || key == 'c') && flagship && planet.IsInhabited() && hasAccess)
 	{
-		if (selectedPanel == hiring.get() && key == 'c')
-			selectedPanel = nullptr;
+		if (selectedPanel == hiring.get())
+			if (key == 'c') selectedPanel = nullptr;
 		else
 		{
 			selectedPanel = hiring.get();


### PR DESCRIPTION
…iption if pressed again. To avoid a hotkey conflict with the "Hire" button once that panel has been opened, I've changed the preferred "Hire Crew" hotkey to "c", although "h" will still work if the hire panel is not already open.