### PR TITLE
Now records when player selected a planet by clicking it

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1524,11 +1524,23 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, const list<shared_ptr<
 					message = object.LandingMessage();
 			}
 		const StellarObject *target = ship.GetTargetPlanet();
-		if(target && ship.Position().Distance(target->Position()) < target->Radius())
+		if(target && (ship.PlanetSelectedByClick() || ship.Position().Distance(target->Position()) < target->Radius()))
 		{
 			// Special case: if there are two planets in system and you have one
 			// selected, then press "land" again, do not toggle to the other if
 			// you are within landing range of the one you have selected.
+			
+			// Or, if the player selected a planet by clicking it, attempt to land
+			// on it with first land press, but then clear click status.
+			if (ship.PlanetSelectedByClick())
+			{
+				message = "Landing on selected planet, ";
+				if(ship.GetTargetPlanet()->Name().empty())
+					message += "???.";
+				else
+					message += ship.GetTargetPlanet()->Name() + ".";
+				ship.ClearPlanetClick();
+			}
 		}
 		else if(message.empty() && target && landKeyInterval < 60)
 		{

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -810,7 +810,7 @@ void Engine::CalculateStep()
 				object.GetPlanet()->DeployDefense(ships);
 			
 			if(doClick && object.GetPlanet() && (clickPoint - position).Length() < object.Radius())
-				player.Flagship()->SetTargetPlanet(&object);
+				player.Flagship()->SetTargetPlanet(&object, true);
 		}
 	
 	// Add all neighboring systems to the radar.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2055,6 +2055,13 @@ const Planet *Ship::GetDestination() const
 
 
 
+bool Ship::PlanetSelectedByClick() const
+{
+	return planetSelectedByClick;
+}
+
+
+
 // Set this ship's targets.
 void Ship::SetTargetShip(const shared_ptr<Ship> &ship)
 {
@@ -2071,9 +2078,10 @@ void Ship::SetShipToAssist(const shared_ptr<Ship> &ship)
 
 
 
-void Ship::SetTargetPlanet(const StellarObject *object)
+void Ship::SetTargetPlanet(const StellarObject *object, bool clickSelected)
 {
 	targetPlanet = object;
+	planetSelectedByClick = clickSelected;
 }
 
 
@@ -2087,6 +2095,13 @@ void Ship::SetTargetSystem(const System *system)
 void Ship::SetDestination(const Planet *planet)
 {
 	destination = planet;
+}
+
+
+
+void Ship::ClearPlanetClick()
+{
+	planetSelectedByClick = false;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -256,13 +256,15 @@ public:
 	const StellarObject *GetTargetPlanet() const;
 	const System *GetTargetSystem() const;
 	const Planet *GetDestination() const;
+	bool PlanetSelectedByClick() const;
 	
 	// Set this ship's targets.
 	void SetTargetShip(const std::shared_ptr<Ship> &ship);
 	void SetShipToAssist(const std::shared_ptr<Ship> &ship);
-	void SetTargetPlanet(const StellarObject *object);
+	void SetTargetPlanet(const StellarObject *object, bool clickSelected = false);
 	void SetTargetSystem(const System *system);
 	void SetDestination(const Planet *planet);
+	void ClearPlanetClick();
 	
 	// Manage escorts. When you set this ship's parent, it will automatically
 	// register itself as an escort of that ship, and unregister itself from any
@@ -386,6 +388,7 @@ private:
 	const StellarObject *targetPlanet = nullptr;
 	const System *targetSystem = nullptr;
 	const Planet *destination = nullptr;
+	bool planetSelectedByClick = false;
 	
 	// Links between escorts and parents.
 	std::vector<std::weak_ptr<const Ship>> escorts;


### PR DESCRIPTION
Avoid switching targets with the first press of the "L" key. A special message is produced to show that a planet is being landed upon because it was clicked:

![image](https://cloud.githubusercontent.com/assets/4998058/11610904/906fd022-9b80-11e5-882c-e9365af69299.png)

(Addresses this issue: https://github.com/endless-sky/endless-sky/issues/381)