### PR TITLE
Merged wormhole-links with new way of traversing wormholes that avoids links

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -15159,6 +15159,8 @@ planet Winter
 		threshold 2500
 		fleet "Large Militia" 5
 
+planet "Wormhole Alpha"
+
 planet "Wyvern Station"
 	attributes rim station
 	landscape land/station0

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -768,18 +768,12 @@ void Engine::CalculateStep()
 	// If the player has entered a new system, update the asteroids, etc.
 	if(wasHyperspacing && !flagship->IsEnteringHyperspace())
 	{
-		doFlash = true;
-		player.SetSystem(flagship->GetSystem());
-		EnterSystem();
-	}
-	else if(flagship && player.GetSystem() != flagship->GetSystem())
-	{
 		// Wormhole travel:
 		for (const auto &it : player.GetSystem()->Objects())
 			if (it.GetPlanet() && it.GetPlanet()->IsWormhole() &&
 				it.GetPlanet()->WormholeDestination(flagship->GetSystem()))
 				player.Visit(it.GetPlanet());
-		//player.ClearTravel();
+		
 		doFlash = true;
 		player.SetSystem(flagship->GetSystem());
 		EnterSystem();

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -768,6 +768,12 @@ void Engine::CalculateStep()
 	// If the player has entered a new system, update the asteroids, etc.
 	if(wasHyperspacing && !flagship->IsEnteringHyperspace())
 	{
+		doFlash = true;
+		player.SetSystem(flagship->GetSystem());
+		EnterSystem();
+	}
+	else if(flagship && player.GetSystem() != flagship->GetSystem())
+	{
 		// Wormhole travel:
 		for (const auto &it : player.GetSystem()->Objects())
 			if (it.GetPlanet() && it.GetPlanet()->IsWormhole() &&

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -378,7 +378,9 @@ void Engine::Step(bool isActive)
 		const StellarObject *object = flagship->GetTargetPlanet();
 		info.SetString("navigation mode", "Landing on:");
 		const string &name = object->Name();
-		info.SetString("destination", name.empty() ? "???" : name);
+		info.SetString("destination",
+			((object->GetPlanet()->IsWormhole() && !player.HasVisited(object->GetPlanet())) ||
+			 name.empty()) ? "???" : name);
 		
 		targets.push_back({
 			object->Position() - flagship->Position(),
@@ -764,8 +766,20 @@ void Engine::CalculateStep()
 		Audio::Play(Audio::Get(flagship->HyperspaceType() >= 200 ? "jump drive" : "hyperdrive"));
 	
 	// If the player has entered a new system, update the asteroids, etc.
-	if(flagship && player.GetSystem() != flagship->GetSystem())
+	if(wasHyperspacing && !flagship->IsEnteringHyperspace())
 	{
+		doFlash = true;
+		player.SetSystem(flagship->GetSystem());
+		EnterSystem();
+	}
+	else if(flagship && player.GetSystem() != flagship->GetSystem())
+	{
+		// Wormhole travel:
+		for (const auto &it : player.GetSystem()->Objects())
+			if (it.GetPlanet() && it.GetPlanet()->IsWormhole() &&
+				it.GetPlanet()->WormholeDestination(flagship->GetSystem()))
+				player.Visit(it.GetPlanet());
+		//player.ClearTravel();
 		doFlash = true;
 		player.SetSystem(flagship->GetSystem());
 		EnterSystem();

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -374,14 +374,13 @@ void MapPanel::DrawWormholes() const
 		{
 			const System *next = &it2.second;
 		
-			bool isWormhole = false;
 			const Planet *wormholePlanet = nullptr;
 			for(const StellarObject &object : previous->Objects())
-			{
-				isWormhole |= (object.GetPlanet() && object.GetPlanet()->WormholeDestination(previous) == next);
-				if(isWormhole)
+				if(object.GetPlanet() && object.GetPlanet()->WormholeDestination(previous) == next)
+				{
 					wormholePlanet = object.GetPlanet();
-			}
+					continue;
+				}
 			
 			if(wormholePlanet && player.HasVisited(wormholePlanet))
 			{

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -379,7 +379,7 @@ void MapPanel::DrawWormholes() const
 				if(object.GetPlanet() && object.GetPlanet()->WormholeDestination(previous) == next)
 				{
 					wormholePlanet = object.GetPlanet();
-					continue;
+					break;
 				}
 			
 			if(wormholePlanet && player.HasVisited(wormholePlanet))

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -79,6 +79,7 @@ protected:
 	
 private:
 	void DrawTravelPlan() const;
+	void DrawWormholes() const;
 	void DrawLinks() const;
 	void DrawSystems() const;
 	void DrawNames() const;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -123,6 +123,8 @@ void PlayerInfo::Load(const string &path)
 			accounts.Load(child);
 		else if(child.Token(0) == "visited" && child.Size() >= 2)
 			Visit(GameData::Systems().Get(child.Token(1)));
+		else if(child.Token(0) == "visited planet" && child.Size() >= 2)
+			Visit(GameData::Planets().Get(child.Token(1)));
 		else if(child.Token(0) == "destroyed" && child.Size() >= 2)
 			destroyedPersons.push_back(GameData::Persons().Get(child.Token(1)));
 		else if(child.Token(0) == "cargo")
@@ -711,6 +713,9 @@ void PlayerInfo::Land(UI *ui)
 		return;
 	
 	Audio::Play(Audio::Get("landing"));
+	
+	// Mark this planet as visited.
+	Visit(planet);
 	
 	// Remove any ships that have been destroyed or captured.
 	map<string, int> lostCargo;
@@ -1309,7 +1314,15 @@ bool PlayerInfo::HasSeen(const System *system) const
 // Check if the player has visited the given system.
 bool PlayerInfo::HasVisited(const System *system) const
 {
-	return (visited.find(system) != visited.end());
+	return (visitedSystems.find(system) != visitedSystems.end());
+}
+
+
+
+// Check if the player has visited the given system.
+bool PlayerInfo::HasVisited(const Planet *planet) const
+{
+	return (visitedPlanets.find(planet) != visitedPlanets.end());
 }
 
 
@@ -1337,7 +1350,7 @@ bool PlayerInfo::KnowsName(const System *system) const
 // Mark the given system as visited, and mark all its neighbors as seen.
 void PlayerInfo::Visit(const System *system)
 {
-	visited.insert(system);
+	visitedSystems.insert(system);
 	seen.insert(system);
 	for(const System *neighbor : system->Neighbors())
 		seen.insert(neighbor);
@@ -1345,12 +1358,31 @@ void PlayerInfo::Visit(const System *system)
 
 
 
+// Mark the given system as visited, and mark all its neighbors as seen.
+void PlayerInfo::Visit(const Planet *planet)
+{
+	static const string EMPTY;
+	if (planet->Name() != EMPTY)
+		visitedPlanets.insert(planet);
+}
+
+
+
 // Mark a system as unvisited, even if visited previously.
 void PlayerInfo::Unvisit(const System *system)
 {
-	auto it = visited.find(system);
-	if(it != visited.end())
-		visited.erase(it);
+	auto it = visitedSystems.find(system);
+	if(it != visitedSystems.end())
+	{
+		visitedSystems.erase(it);
+		for(const StellarObject &object : system->Objects())
+			if(object.GetPlanet())
+			{
+				auto it2 = visitedPlanets.find(object.GetPlanet());
+				if(it2 != visitedPlanets.end())
+					visitedPlanets.erase(it2);
+			}
+	}
 }
 
 
@@ -1637,6 +1669,10 @@ void PlayerInfo::Save(const string &path) const
 			out.Write("destroyed", it.first);
 	
 	// Save a list of systems the player has visited.
-	for(const System *system : visited)
+	for(const System *system : visitedSystems)
 		out.Write("visited", system->Name());
+	
+	// Save a list of planets the player has visited.
+	for(const Planet *planet : visitedPlanets)
+		out.Write("visited planet", planet->Name());
 }

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Date.h"
 #include "GameEvent.h"
 #include "Mission.h"
+#include "Planet.h"
 
 #include <list>
 #include <map>
@@ -158,12 +159,14 @@ public:
 	std::map<std::string, int> &Conditions();
 	const std::map<std::string, int> &Conditions() const;
 	
-	// Check what the player knows about the given system.
+	// Check what the player knows about the given system or planet.
 	bool HasSeen(const System *system) const;
 	bool HasVisited(const System *system) const;
+	bool HasVisited(const Planet *planet) const;
 	bool KnowsName(const System *system) const;
 	void Visit(const System *system);
-	// Mark a system as unvisited, even if visited previously.
+	void Visit(const Planet *planet);
+	// Mark a system and its planets as unvisited, even if visited previously.
 	void Unvisit(const System *system);
 	
 	// Access the player's travel plan.
@@ -228,7 +231,8 @@ private:
 	std::map<std::string, int> conditions;
 	
 	std::set<const System *> seen;
-	std::set<const System *> visited;
+	std::set<const System *> visitedSystems;
+	std::set<const Planet *> visitedPlanets;
 	std::vector<const System *> travelPlan;
 	
 	const Outfit *selectedWeapon = nullptr;


### PR DESCRIPTION
Created function specifically for drawing wormholes (DrawWormholes), this way the wormholes can be guaranteed to be drawn under all other links. To appear as a wormhole link on the map, the wormhole *must* have a planet entry, I have added one for Wormhole Alpha, but not for the Pug wormhole (Although we could choose to do so).

This also adds the visitedPlanets data structure and saves/loads that information to the pilot file, as before. This could be quite useful for story-telling purposes.

This supersedes https://github.com/endless-sky/endless-sky/pull/398, which I have closed.