### PR TITLE
Toggled autosteering

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -40,8 +40,10 @@ namespace {
 	const Command &AutopilotCancelKeys()
 	{
 		static const Command keys(Command::LAND | Command::JUMP | Command::BOARD
-			| Command::BACK | Command::FORWARD | Command::LEFT | Command::RIGHT);
-		
+			| Command::BACK | Command::FORWARD | Command::LEFT | Command::RIGHT
+			| Command::AUTOSTEER
+			);
+
 		return keys;
 	}
 	
@@ -1727,7 +1729,24 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, const list<shared_ptr<
 			else
 				command.SetTurn(TurnBackward(ship));
 		}
-		
+		else if(keyHeld.Has(Command::AUTOSTEER))
+		{
+			// Point at our target ship, planet, or system.
+			shared_ptr<const Ship> target = ship.GetTargetShip();
+			if (target && (ship.GetSystem() == target->GetSystem())) {
+				Point direction = target->Position() - ship.Position();
+				// Only compute aiming if the ship is in front of us
+				if(direction.Unit().Dot(ship.Facing().Unit()) >= .8)
+					direction = TargetAim(ship);
+				command.SetTurn(TurnToward(ship, direction));
+			} else if (ship.GetTargetPlanet()) {
+				Point direction = ship.GetTargetPlanet()->Position() - ship.Position();
+				command.SetTurn(TurnToward(ship, direction));
+			} else if (ship.GetTargetSystem()) {
+				Point direction = ship.GetTargetSystem()->Position() - ship.GetSystem()->Position();
+				command.SetTurn(TurnToward(ship, direction));
+			}
+		}
 		if(keyHeld.Has(Command::FORWARD))
 			command |= Command::FORWARD;
 		if(keyHeld.Has(Command::PRIMARY))

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -37,6 +37,15 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
+	const Command &AutosteerCancelKeys()
+	{
+		static const Command keys(Command::LAND | Command::JUMP | Command::BOARD
+				| Command::BACK | Command::LEFT | Command::RIGHT
+				);
+
+		return keys;
+	}
+
 	const Command &AutopilotCancelKeys()
 	{
 		static const Command keys(Command::LAND | Command::JUMP | Command::BOARD
@@ -86,8 +95,15 @@ void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 	keyHeld |= clickCommands;
 	clickCommands.Clear();
 	keyDown = keyHeld.AndNot(oldHeld);
-	if(keyHeld.Has(AutopilotCancelKeys()))
-		keyStuck.Clear();
+	if(keyHeld.Has(AutopilotCancelKeys())) {
+		// Accelerating shouldn't cancel autosteering
+		if (!keyStuck.Has(Command::AUTOSTEER) || keyHeld.Has(AutosteerCancelKeys())) {
+			keyStuck.Clear();
+		} else {
+			keyStuck.Clear();
+			keyStuck |= Command::AUTOSTEER;
+		}
+	}
 	if(keyStuck.Has(Command::JUMP) && !player.HasTravelPlan())
 		keyStuck.Clear(Command::JUMP);
 	
@@ -1729,24 +1745,6 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, const list<shared_ptr<
 			else
 				command.SetTurn(TurnBackward(ship));
 		}
-		else if(keyHeld.Has(Command::AUTOSTEER))
-		{
-			// Point at our target ship, planet, or system.
-			shared_ptr<const Ship> target = ship.GetTargetShip();
-			if (target && (ship.GetSystem() == target->GetSystem())) {
-				Point direction = target->Position() - ship.Position();
-				// Only compute aiming if the ship is in front of us
-				if(direction.Unit().Dot(ship.Facing().Unit()) >= .8)
-					direction = TargetAim(ship);
-				command.SetTurn(TurnToward(ship, direction));
-			} else if (ship.GetTargetPlanet()) {
-				Point direction = ship.GetTargetPlanet()->Position() - ship.Position();
-				command.SetTurn(TurnToward(ship, direction));
-			} else if (ship.GetTargetSystem()) {
-				Point direction = ship.GetTargetSystem()->Position() - ship.GetSystem()->Position();
-				command.SetTurn(TurnToward(ship, direction));
-			}
-		}
 		if(keyHeld.Has(Command::FORWARD))
 			command |= Command::FORWARD;
 		if(keyHeld.Has(Command::PRIMARY))
@@ -1777,8 +1775,13 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, const list<shared_ptr<
 		if(keyHeld.Has(Command::AFTERBURNER))
 			command |= Command::AFTERBURNER;
 		
-		if(keyHeld.Has(AutopilotCancelKeys()))
-			keyStuck = keyHeld;
+		if(keyHeld.Has(AutopilotCancelKeys())){
+			if (!keyStuck.Has(Command::AUTOSTEER) || keyHeld.Has(AutosteerCancelKeys())) {
+				keyStuck = keyHeld;
+			} else {
+				keyStuck = keyHeld | Command::AUTOSTEER;
+			}
+		}
 	}
 	if(hasGuns && Preferences::Has("Automatic aiming") && !command.Turn()
 			&& ship.GetTargetShip() && ship.GetTargetShip()->GetSystem() == ship.GetSystem()
@@ -1838,7 +1841,25 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, const list<shared_ptr<
 			command |= Command::BOARD;
 		}
 	}
-	
+	else if(keyStuck.Has(Command::AUTOSTEER))
+	{
+		// Point at our target ship, planet, or system.
+		shared_ptr<const Ship> target = ship.GetTargetShip();
+		if (target && (ship.GetSystem() == target->GetSystem())) {
+			Point direction = target->Position() - ship.Position();
+			// Only compute aiming if the ship is in front of us
+			if(direction.Unit().Dot(ship.Facing().Unit()) >= .8)
+				direction = TargetAim(ship);
+			command.SetTurn(TurnToward(ship, direction));
+		} else if (ship.GetTargetPlanet()) {
+			Point direction = ship.GetTargetPlanet()->Position() - ship.Position();
+			command.SetTurn(TurnToward(ship, direction));
+		} else if (ship.GetTargetSystem()) {
+			Point direction = ship.GetTargetSystem()->Position() - ship.GetSystem()->Position();
+			command.SetTurn(TurnToward(ship, direction));
+		}
+	}
+
 	if(isLaunching)
 		command |= Command::DEPLOY;
 	if(isCloaking)

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -57,6 +57,7 @@ const Command Command::FIGHT(1uL << 21, "Fleet: Fight my target");
 const Command Command::GATHER(1uL << 22, "Fleet: Gather around me");
 const Command Command::HOLD(1uL << 23, "Fleet: Hold position");
 const Command Command::WAIT(1uL << 24, "");
+const Command Command::AUTOSTEER(1uL << 25, "Face selected ship");
 
 
 

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -298,6 +298,26 @@ Command &Command::operator|=(const Command &command)
 
 
 
+// Get the commands that are set in both of these commands.
+Command Command::operator&(const Command &command) const
+{
+	Command result = *this;
+	result &= command;
+	return result;
+}
+
+
+
+Command &Command::operator&=(const Command &command)
+{
+	state &= command.state;
+	if(turn && command.turn)
+		turn = command.turn;
+	return *this;
+}
+
+
+
 Command::Command(uint64_t state)
 	: state(state)
 {

--- a/source/Command.h
+++ b/source/Command.h
@@ -48,7 +48,8 @@ public:
 	static const Command GATHER;
 	static const Command HOLD;
 	static const Command WAIT;
-	
+	static const Command AUTOSTEER;
+
 public:
 	Command() = default;
 	// Assume SDL_Keycode is a signed int, so I don't need to include SDL.h.

--- a/source/Command.h
+++ b/source/Command.h
@@ -95,6 +95,9 @@ public:
 	Command operator|(const Command &command) const;
 	Command &operator|=(const Command &command);
 	
+	// Get the commands that are set in both of these commands.
+	Command operator&(const Command &command) const;
+	Command &operator&=(const Command &command);
 	
 private:
 	Command(uint64_t state);

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -111,6 +111,7 @@ void PreferencesPanel::Draw() const
 		Command::HAIL,
 		Command::BOARD,
 		Command::SCAN,
+		Command::AUTOSTEER,
 		Command::NONE,
 		Command::MENU,
 		Command::MAP,


### PR DESCRIPTION
This is an alternative to #314 that makes autosteering behave more like landing, etc. - instead of holding down the autosteer button, you press it once and you will continue autosteering until you manually turn (or activate a different autopilot feature like jumping or landing).

Note that this and #314 now make the Preferences pane look weird - I originally just made the controls slightly taller to fit in the autosteering option, but now the scan button is filling that space and I'm not sure how best to add this to the Preferences without re-rendering the image.

@endless-sky Have you considered using a GUI toolkit like [libRocket](http://librocket.com/) or [CEGUI](http://cegui.org.uk/) so that it would be easier to extend some of the gui elements?