### PR TITLE
Re-balanced heavy warships (and two medium warships)

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -888,11 +888,11 @@ ship "Falcon"
 		"cost" 10900000
 		"shields" 12800
 		"hull" 3700
-		"required crew" 52
+		"required crew" 38
 		"bunks" 75
 		"mass" 510
 		"drag" 6.7
-		"heat dissipation" .7
+		"heat dissipation" .8
 		"fuel capacity" 600
 		"cargo space" 90
 		"outfit space" 540
@@ -915,7 +915,7 @@ ship "Falcon"
 		"Liquid Nitrogen Cooler"
 		
 		"Impala Plasma Thruster"
-		"Impala Plasma Steering"
+		"Orca Plasma Steering"
 		"Hyperdrive"
 		
 	engine -17 143
@@ -1558,12 +1558,12 @@ ship "Leviathan"
 	sprite "ship/leviathan"
 	attributes
 		category "Heavy Warship"
-		"cost" 9800000
+		"cost" 9100000
 		"shields" 14400
 		"hull" 5000
 		"required crew" 43
 		"bunks" 64
-		"mass" 480
+		"mass" 580
 		"drag" 7.6
 		"heat dissipation" .5
 		"fuel capacity" 500
@@ -1620,7 +1620,7 @@ ship "Manta"
 		"drag" 4.7
 		"heat dissipation" .8
 		"fuel capacity" 400
-		"cargo space" 20
+		"cargo space" 40
 		"outfit space" 350
 		"weapon capacity" 140
 		"engine capacity" 100
@@ -1712,7 +1712,7 @@ ship "Mule"
 	attributes
 		category "Medium Warship"
 		"cost" 2580000
-		"shields" 5400
+		"shields" 4400
 		"hull" 4400
 		"required crew" 6
 		"bunks" 43
@@ -1815,18 +1815,18 @@ ship "Protector"
 	sprite "ship/protector"
 	attributes
 		category "Heavy Warship"
-		"cost" 5500000
-		"shields" 9500
+		"cost" 6800000
+		"shields" 11500
 		"hull" 6500
 		"required crew" 30
 		"bunks" 69
-		"mass" 500
-		"drag" 10.3
-		"heat dissipation" .6
+		"mass" 520
+		"drag" 11
+		"heat dissipation" .5
 		"fuel capacity" 400
 		"cargo space" 50
-		"outfit space" 570
-		"weapon capacity" 220
+		"outfit space" 590
+		"weapon capacity" 240
 		"engine capacity" 100
 		weapon
 			"blast radius" 160
@@ -1869,19 +1869,19 @@ ship "Vanguard"
 	sprite "ship/vanguard"
 	attributes
 		category "Heavy Warship"
-		"cost" 7200000
-		"shields" 9800
+		"cost" 7000000
+		"shields" 11000
 		"hull" 6000
 		"required crew" 23
 		"bunks" 45
 		"mass" 500
-		"drag" 8
-		"heat dissipation" .6
+		"drag" 7
+		"heat dissipation" .5
 		"fuel capacity" 400
 		"cargo space" 50
 		"outfit space" 560
-		"weapon capacity" 220
-		"engine capacity" 120
+		"weapon capacity" 230
+		"engine capacity" 130
 		weapon
 			"blast radius" 160
 			"shield damage" 1600
@@ -1900,8 +1900,8 @@ ship "Vanguard"
 		"X4200 Ion Steering"
 		"Hyperdrive"
 	
-	engine -15 145
-	engine 15 145
+	engine -15 141
+	engine 15 141
 	gun 0 -140 "Proton Gun"
 	gun -18 -140 "Proton Gun"
 	gun 18 -140 "Proton Gun"


### PR DESCRIPTION
I thought that the heavy warships especially use some differentiation, and the Syndicate ones especially needed some improvement.

Here was my general outline:

#### Falcon -- The Destroyer: Fast, well armed, and moderately durable
- Lower crew requirements and better heat dissipation because it's a more advanced and recent starship
- Bigger standard steering to make it more maneuverable than the Leviathan on all metrics

#### Leviathan -- The Battleship: Tough but slow well-rounded heavy warship
- Increased mass to make it a bit less maneuverable
- Lowered cost to make it a bit more accessible and not so close in price to the Dreadnought

#### Protector -- The Pillbox: Slow, lots of short and long-ranged firepower
- Increased shields to boost survivability
- Increased outfit and weapon capacity to increase flexibility
- Increased price and reduced heat dissipation and maneuverability to compensate

#### Vanguard -- The Rhinoceros: Powerful offense against targets straight ahead
- Increased shields to boost survivability
- Slightly increased weapon and engine capacity to increase flexibility
- Increased maneuverability
- Reduced heat dissipation
- Fixed engine exhaust locations



#### Other changes:
- Mule: reduced shields to make it less of a no-brainer for its price point
- Manta: increased cargo space to 40 tons to increase flexibility and put it in line with other medium warships