### PR TITLE
Removed the passenger requirement for the science vessel escort job

### DIFF
--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1645,7 +1645,6 @@ mission "Escort science vessel"
 	to offer
 		random < 40
 		"combat rating" > 10
-	passengers 7 12
 	source
 		attributes research
 	stopover


### PR DESCRIPTION
This was left over from a previous incarnation of the job where there was no NPC ship to escort.