### PR TITLE
Remove impossible Korath fleet (Korath Home) from Kor Ak'Mari

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -7143,7 +7143,6 @@ system "Kor Ak'Mari"
 	asteroids "medium metal" 99 3.0744
 	asteroids "large metal" 32 1.5624
 	fleet "Korath Raid" 2800
-	fleet "Korath Home" 2000
 	object
 		sprite star/wr
 		period 100


### PR DESCRIPTION
Illogical placement of Korath Home in Kor Ak'Mari (it has no hyperlinks, therefore no way for worldships to get to the system. Home ships that spawn here glitch when their hull is damaged and basically give up on life