### PR TITLE
error message for installing outfits in cargo

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -225,21 +225,20 @@ bool OutfitterPanel::CanBuy() const
 	if(!planet || !selectedOutfit || !playerShip)
 		return false;
 	
-	// If you have this in your cargo hold, installing it is free.
-	if(player.Cargo().Get(selectedOutfit))
-		return true;
-	
-	if(!(outfitter.Has(selectedOutfit) || available[selectedOutfit]))
+	if(!(outfitter.Has(selectedOutfit) || available[selectedOutfit] ||
+	     player.Cargo().Get(selectedOutfit)))
 		return false;
 	
 	int mapSize = selectedOutfit->Get("map");
 	if(mapSize > 0 && HasMapped(mapSize))
 		return false;
 	
-	if(HasLicense(selectedOutfit->Name()))
+	// If you have this in your cargo hold, installing it is free.
+	if(selectedOutfit->Cost() > player.Accounts().Credits() &&
+	   !player.Cargo().Get(selectedOutfit))
 		return false;
 	
-	if(selectedOutfit->Cost() > player.Accounts().Credits())
+	if(HasLicense(selectedOutfit->Name()))
 		return false;
 	
 	for(const Ship *ship : playerShips)


### PR DESCRIPTION
Fixes #740 by making `OutfitterPanel::CanBuy()` return false for outfits in cargo that cannot be installed.

With these changes, having an outfit in cargo does *not* allow a player to install an outfit for which they do not have a license. I do not know if this prevents players from being able to do something they would have been able to do, looking into it.