### PR TITLE
Changed Panel::Drag and Panel::Scroll to take double dx/dy

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -378,7 +378,7 @@ bool BoardingPanel::Drag(double dx, double dy)
 	// The list is 240 pixels tall, and there are 10 pixels padding on the top
 	// and the bottom, so:
 	double maximumScroll = max(0., 20. * plunder.size() - 220.);
-	scroll = max(0., min(maximumScroll, scroll + dy));
+	scroll = max(0., min(maximumScroll, scroll - dy));
 	
 	return true;
 }

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -229,8 +229,8 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 				++selected;
 			
 			// Scroll down at least far enough to view the current item.
-			int minimumScroll = max(0, static_cast<int>(20 * selected - 200));
-			int maximumScroll = static_cast<int>(20 * selected);
+			double minimumScroll = max(0., 20. * selected - 200.);
+			double maximumScroll = 20. * selected;
 			scroll = max(minimumScroll, min(maximumScroll, scroll));
 		}
 	}
@@ -373,21 +373,21 @@ bool BoardingPanel::Click(int x, int y)
 
 
 
-bool BoardingPanel::Drag(int dx, int dy)
+bool BoardingPanel::Drag(double dx, double dy)
 {
 	// The list is 240 pixels tall, and there are 10 pixels padding on the top
 	// and the bottom, so:
-	int maximumScroll = max(0, static_cast<int>(20 * plunder.size() - 220));
-	scroll = max(0, min(maximumScroll, scroll + dy));
+	double maximumScroll = max(0., 20. * plunder.size() - 220.);
+	scroll = max(0., min(maximumScroll, scroll + dy));
 	
 	return true;
 }
 
 
 
-bool BoardingPanel::Scroll(int dx, int dy)
+bool BoardingPanel::Scroll(double dx, double dy)
 {
-	return Drag(dx, dy * -50);
+	return Drag(dx, dy * -50.);
 }
 
 

--- a/source/BoardingPanel.h
+++ b/source/BoardingPanel.h
@@ -47,8 +47,8 @@ protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command) override;
 	virtual bool Click(int x, int y) override;
-	virtual bool Drag(int dx, int dy) override;
-	virtual bool Scroll(int dx, int dy) override;
+	virtual bool Drag(double dx, double dy) override;
+	virtual bool Scroll(double dx, double dy) override;
 	
 	
 private:
@@ -110,7 +110,7 @@ private:
 	
 	std::vector<Plunder> plunder;
 	int selected = 0;
-	int scroll = 0;
+	double scroll = 0.;
 	
 	bool playerDied = false;
 	bool isCapturing = false;

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -44,7 +44,7 @@ namespace {
 
 
 ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &conversation, const System *system)
-	: player(player), conversation(conversation), scroll(0), system(system)
+	: player(player), conversation(conversation), scroll(0.), system(system)
 {
 	subs["<first>"] = player.FirstName();
 	subs["<last>"] = player.LastName();
@@ -265,18 +265,18 @@ bool ConversationPanel::Click(int x, int y)
 
 
 
-bool ConversationPanel::Drag(int dx, int dy)
+bool ConversationPanel::Drag(double dx, double dy)
 {
-	scroll = min(0, scroll + dy);
+	scroll = min(0., scroll + dy);
 	
 	return true;
 }
 
 
 
-bool ConversationPanel::Scroll(int dx, int dy)
+bool ConversationPanel::Scroll(double dx, double dy)
 {
-	return Drag(50 * dx, 50 * dy);
+	return Drag(50. * dx, 50. * dy);
 }
 
 

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -64,7 +64,7 @@ void ConversationPanel::Draw() const
 	Color back(0.125, 1.);
 	FillShader::Fill(
 		Point(Screen::Width() * -.5 + WIDTH * .5 + 15., 0.),
-		Point(WIDTH + 30., Screen::Height()), 
+		Point(WIDTH + 30., Screen::Height()),
 		back);
 	
 	const Sprite *edgeSprite = SpriteSet::Get("ui/right edge");
@@ -95,11 +95,13 @@ void ConversationPanel::Draw() const
 	{
 		static const string done = "[done]";
 		int width = font.Width(done);
+		int height = font.Height();
 		Point off(Screen::Left() + 20 + WIDTH - width, point.Y());
 		font.Draw(done, off, bright);
 		
-		Point size(width, font.Height());
+		Point size(width, height);
 		zones.emplace_back(off + .5 * size, size);
+		maxScroll = min(0, Screen::Top() - static_cast<int>(point.Y() - scroll) + height / 2);
 		return;
 	}
 	if(choices.empty())
@@ -108,6 +110,7 @@ void ConversationPanel::Draw() const
 		Point size(150, 20);
 		FillShader::Fill(center, size, selectionColor);
 		int width = font.Width(choice ? lastName : firstName);
+		int height = font.Height();
 		center.X() += width - 67;
 		FillShader::Fill(center, Point(1., 16.), dim);
 		
@@ -121,9 +124,10 @@ void ConversationPanel::Draw() const
 		width = font.Width(ok);
 		Point off(Screen::Left() + 20 + WIDTH - width, point.Y());
 		font.Draw(ok, off, bright);
-		size = Point(width, font.Height());
+		size = Point(width, height);
 		zones.emplace_back(off + .5 * size, size);
-		
+		maxScroll = min(0, Screen::Top() - static_cast<int>(point.Y() - scroll) + height / 2);
+
 		return;
 	}
 	
@@ -142,6 +146,7 @@ void ConversationPanel::Draw() const
 		font.Draw(label, point + Point(-15, 0), dim);
 		it.Draw(point, bright);
 	}
+	maxScroll = min(0, Screen::Top() - static_cast<int>(point.Y() - scroll) + font.Height() + 15);
 }
 
 
@@ -267,7 +272,7 @@ bool ConversationPanel::Click(int x, int y)
 
 bool ConversationPanel::Drag(double dx, double dy)
 {
-	scroll = min(0., scroll + dy);
+	scroll = min(0., max(static_cast<double>(maxScroll), scroll + dy));
 	
 	return true;
 }

--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -92,6 +92,7 @@ private:
 	std::map<std::string, std::string> subs;
 	
 	mutable std::vector<ClickZone<int>> zones;
+	mutable int maxScroll = 0.;
 	
 	const System *system;
 };

--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -51,8 +51,8 @@ protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command) override;
 	virtual bool Click(int x, int y) override;
-	virtual bool Drag(int dx, int dy) override;
-	virtual bool Scroll(int dx, int dy) override;
+	virtual bool Drag(double dx, double dy) override;
+	virtual bool Scroll(double dx, double dy) override;
 	
 	
 private:
@@ -81,7 +81,7 @@ private:
 	int node;
 	std::function<void(int)> callback = nullptr;
 	
-	int scroll;
+	double scroll;
 	
 	std::list<Paragraph> text;
 	std::list<Paragraph> choices;

--- a/source/InfoPanel.cpp
+++ b/source/InfoPanel.cpp
@@ -323,7 +323,7 @@ bool InfoPanel::Hover(double x, double y) {
 				|| weapons[selected].IsTurret() == weapons[zone.Value()].IsTurret()))
 			hover = zone.Value();
 	
-	return true;	
+	return true;
 }
 
 bool InfoPanel::Hover(int x, int y)

--- a/source/InfoPanel.cpp
+++ b/source/InfoPanel.cpp
@@ -313,10 +313,7 @@ bool InfoPanel::Click(int x, int y)
 	return true;
 }
 
-
-
-bool InfoPanel::Hover(int x, int y)
-{
+bool InfoPanel::Hover(double x, double y) {
 	hoverPoint = Point(x, y);
 	
 	const vector<Armament::Weapon> &weapons = (**shipIt).Weapons();
@@ -326,12 +323,17 @@ bool InfoPanel::Hover(int x, int y)
 				|| weapons[selected].IsTurret() == weapons[zone.Value()].IsTurret()))
 			hover = zone.Value();
 	
-	return true;
+	return true;	
+}
+
+bool InfoPanel::Hover(int x, int y)
+{
+	return Hover(static_cast<double>(x), static_cast<double>(y));
 }
 
 
 
-bool InfoPanel::Drag(int dx, int dy)
+bool InfoPanel::Drag(double dx, double dy)
 {
 	Hover(hoverPoint.X() + dx, hoverPoint.Y() + dy);
 	if(hoverPoint.Distance(dragStart) > 10.)
@@ -374,10 +376,10 @@ bool InfoPanel::Release(int x, int y)
 
 
 
-bool InfoPanel::Scroll(int dx, int dy)
+bool InfoPanel::Scroll(double dx, double dy)
 {
 	if(!showShip)
-		scroll = max(0, min(static_cast<int>(player.Ships().size() - 25), scroll - 4 * dy));
+		scroll = max(0., min(player.Ships().size() - 25., scroll - 4. * dy));
 	return true;
 }
 

--- a/source/InfoPanel.h
+++ b/source/InfoPanel.h
@@ -45,9 +45,9 @@ protected:
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command) override;
 	virtual bool Click(int x, int y) override;
 	virtual bool Hover(int x, int y) override;
-	virtual bool Drag(int dx, int dy) override;
+	virtual bool Drag(double dx, double dy) override;
 	virtual bool Release(int x, int y) override;
-	virtual bool Scroll(int dx, int dy) override;
+	virtual bool Scroll(double dx, double dy) override;
 	
 	
 private:
@@ -59,6 +59,7 @@ private:
 	bool CanDump() const;
 	void Dump();
 	void DumpPlunder(int count);
+	bool Hover(double x, double y);
 	
 	
 private:
@@ -73,7 +74,7 @@ private:
 	mutable std::vector<ClickZone<const Outfit *>> plunderZones;
 	int selected;
 	int hover;
-	int scroll = 0;
+	double scroll = 0.;
 	Point hoverPoint;
 	Point dragStart;
 	bool showShip;

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -360,21 +360,21 @@ bool LoadPanel::Hover(int x, int y)
 
 
 
-bool LoadPanel::Drag(int dx, int dy)
+bool LoadPanel::Drag(double dx, double dy)
 {
 	auto it = files.find(selectedPilot);
 	if(sideHasFocus)
-		sideScroll = max(0, min(static_cast<int>(20 * files.size()) - 280, sideScroll - dy));
+		sideScroll = max(0., min(20. * files.size() - 280., sideScroll - dy));
 	else if(!selectedPilot.empty() && it != files.end())
-		centerScroll = max(0, min(static_cast<int>(20 * it->second.size()) - 280, centerScroll - dy));
+		centerScroll = max(0., min(20. * it->second.size() - 280., centerScroll - dy));
 	return true;
 }
 
 
 
-bool LoadPanel::Scroll(int dx, int dy)
+bool LoadPanel::Scroll(double dx, double dy)
 {
-	return Drag(50 * dx, 50 * dy);
+	return Drag(50. * dx, 50. * dy);
 }
 
 

--- a/source/LoadPanel.h
+++ b/source/LoadPanel.h
@@ -47,8 +47,8 @@ protected:
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command) override;
 	virtual bool Click(int x, int y) override;
 	virtual bool Hover(int x, int y) override;
-	virtual bool Drag(int dx, int dy) override;
-	virtual bool Scroll(int dx, int dy) override;
+	virtual bool Drag(double dx, double dy) override;
+	virtual bool Scroll(double dx, double dy) override;
 	
 	
 private:
@@ -67,8 +67,8 @@ private:
 	std::string selectedFile;
 	
 	bool sideHasFocus = false;
-	int sideScroll = 0;
-	int centerScroll = 0;
+	double sideScroll = 0;
+	double centerScroll = 0;
 };
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -130,7 +130,7 @@ bool MapPanel::Click(int x, int y)
 
 
 
-bool MapPanel::Drag(int dx, int dy)
+bool MapPanel::Drag(double dx, double dy)
 {
 	center += Point(dx, dy) / Zoom();
 	return true;
@@ -138,12 +138,12 @@ bool MapPanel::Drag(int dx, int dy)
 
 
 
-bool MapPanel::Scroll(int dx, int dy)
+bool MapPanel::Scroll(double dx, double dy)
 {
 	// The mouse should be pointing to the same map position before and after zooming.
 	Point mouse = UI::GetMouse();
 	Point anchor = mouse / Zoom() - center;
-	if(dy > 0)
+	if(dy > 0.)
 		ZoomMap();
 	else
 		UnzoomMap();

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -60,8 +60,8 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool Click(int x, int y) override;
-	virtual bool Drag(int dx, int dy) override;
-	virtual bool Scroll(int dx, int dy) override;
+	virtual bool Drag(double dx, double dy) override;
+	virtual bool Scroll(double dx, double dy) override;
 	
 	// Get the color mapping for various system attributes.
 	static Color MapColor(double value);

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -115,8 +115,8 @@ bool MapSalesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 	}
 	else if(key == SDLK_PAGEUP || key == SDLK_PAGEDOWN)
 	{
-		scroll += (Screen::Height() - 100) * ((key == SDLK_PAGEUP) - (key == SDLK_PAGEDOWN));
-		scroll = min(0, max(-maxScroll, scroll));
+		scroll += static_cast<double>((Screen::Height() - 100) * ((key == SDLK_PAGEUP) - (key == SDLK_PAGEDOWN)));
+		scroll = min(0., max(-maxScroll, scroll));
 	}
 	else if((key == SDLK_DOWN || key == SDLK_UP) && !zones.empty())
 	{
@@ -206,10 +206,10 @@ bool MapSalesPanel::Hover(int x, int y)
 
 
 
-bool MapSalesPanel::Drag(int dx, int dy)
+bool MapSalesPanel::Drag(double dx, double dy)
 {
 	if(isDragging)
-		scroll = min(0, max(-maxScroll, scroll + dy));
+		scroll = min(0., max(-maxScroll, scroll + dy));
 	else
 		return MapPanel::Drag(dx, dy);
 	
@@ -218,10 +218,10 @@ bool MapSalesPanel::Drag(int dx, int dy)
 
 
 
-bool MapSalesPanel::Scroll(int dx, int dy)
+bool MapSalesPanel::Scroll(double dx, double dy)
 {
 	if(isDragging)
-		scroll = min(0, max(-maxScroll, scroll + 50 * dy));
+		scroll = min(0., max(-maxScroll, scroll + 50 * dy));
 	else
 		return MapPanel::Scroll(dx, dy);
 	

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -38,8 +38,8 @@ public:
 	bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command);
 	bool Click(int x, int y);
 	bool Hover(int x, int y);
-	bool Drag(int dx, int dy);
-	bool Scroll(int dx, int dy);
+	bool Drag(double dx, double dy);
+	bool Scroll(double dx, double dy);
 	double SystemValue(const System *system) const;
 	
 	
@@ -78,8 +78,8 @@ protected:
 	
 	
 protected:
-	int scroll = 0;
-	mutable int maxScroll = 0;
+	double scroll = 0.;
+	mutable double maxScroll = 0.;
 
 	const std::vector<std::string> &categories;
 	

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -310,7 +310,7 @@ bool MissionPanel::Click(int x, int y)
 	
 	if(x < Screen::Left() + SIDE_WIDTH)
 	{
-		unsigned index = max(0, (y + availableScroll - 36 - Screen::Top()) / 20);
+		unsigned index = max(0, (y + static_cast<int>(availableScroll) - 36 - Screen::Top()) / 20);
 		if(index < available.size())
 		{
 			availableIt = available.begin();
@@ -325,7 +325,7 @@ bool MissionPanel::Click(int x, int y)
 	}
 	else if(x >= Screen::Right() - SIDE_WIDTH)
 	{
-		int index = max(0, (y + acceptedScroll - 36 - Screen::Top()) / 20);
+		int index = max(0, (y + static_cast<int>(acceptedScroll) - 36 - Screen::Top()) / 20);
 		if(index < AcceptedVisible())
 		{
 			acceptedIt = accepted.begin();
@@ -404,18 +404,18 @@ bool MissionPanel::Click(int x, int y)
 
 
 
-bool MissionPanel::Drag(int dx, int dy)
+bool MissionPanel::Drag(double dx, double dy)
 {
 	if(dragSide < 0)
 	{
-		availableScroll = max(0,
-			min(static_cast<int>(available.size() * 20 + 190 - Screen::Height()),
+		availableScroll = max(0.,
+			min(available.size() * 20. + 190. - Screen::Height(),
 				availableScroll - dy));
 	}
 	else if(dragSide > 0)
 	{
-		acceptedScroll = max(0,
-			min(static_cast<int>(accepted.size() * 20 + 160 - Screen::Height()),
+		acceptedScroll = max(0.,
+			min(accepted.size() * 20. + 160. - Screen::Height(),
 				acceptedScroll - dy));
 	}
 	else
@@ -429,7 +429,7 @@ bool MissionPanel::Drag(int dx, int dy)
 bool MissionPanel::Hover(int x, int y)
 {
 	dragSide = 0;
-	unsigned index = max(0, (y + availableScroll - 36 - Screen::Top()) / 20);
+	unsigned index = max(0, (y + static_cast<int>(availableScroll) - 36 - Screen::Top()) / 20);
 	if(x < Screen::Left() + SIDE_WIDTH)
 	{
 		if(index < available.size())
@@ -445,10 +445,10 @@ bool MissionPanel::Hover(int x, int y)
 
 
 
-bool MissionPanel::Scroll(int dx, int dy)
+bool MissionPanel::Scroll(double dx, double dy)
 {
 	if(dragSide)
-		return Drag(0, dy * 50);
+		return Drag(0., dy * 50.);
 	
 	return MapPanel::Scroll(dx, dy);
 }

--- a/source/MissionPanel.h
+++ b/source/MissionPanel.h
@@ -41,9 +41,9 @@ protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command) override;
 	virtual bool Click(int x, int y) override;
-	virtual bool Drag(int dx, int dy) override;
+	virtual bool Drag(double dx, double dy) override;
 	virtual bool Hover(int x, int y) override;
-	virtual bool Scroll(int dx, int dy) override;
+	virtual bool Scroll(double dx, double dy) override;
 	
 	
 private:
@@ -69,8 +69,8 @@ private:
 	const std::list<Mission> &accepted;
 	std::list<Mission>::const_iterator availableIt;
 	std::list<Mission>::const_iterator acceptedIt;
-	int availableScroll = 0;
-	int acceptedScroll = 0;
+	double availableScroll = 0.;
+	double acceptedScroll = 0.;
 	
 	int dragSide = 0;
 	mutable WrappedText wrap;

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -98,14 +98,14 @@ bool Panel::Hover(int x, int y)
 
 
 
-bool Panel::Drag(int dx, int dy)
+bool Panel::Drag(double dx, double dy)
 {
 	return false;
 }
 
 
 
-bool Panel::Scroll(int dx, int dy)
+bool Panel::Scroll(double dx, double dy)
 {
 	return false;
 }

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -52,9 +52,9 @@ protected:
 	virtual bool Click(int x, int y);
 	virtual bool RClick(int x, int y);
 	virtual bool Hover(int x, int y);
-	virtual bool Drag(int dx, int dy);
+	virtual bool Drag(double dx, double dy);
 	virtual bool Release(int x, int y);
-	virtual bool Scroll(int dx, int dy);
+	virtual bool Scroll(double dx, double dy);
 	
 	void SetIsFullScreen(bool set);
 	void SetTrapAllEvents(bool set);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -500,7 +500,7 @@ bool ShopPanel::Click(int x, int y)
 			else
 				selectedOutfit = zone.GetOutfit();
 			
-			mainScroll = max(0, mainScroll + zone.ScrollY());
+			mainScroll = max(0., mainScroll + zone.ScrollY());
 			return true;
 		}
 		
@@ -517,7 +517,7 @@ bool ShopPanel::Hover(int x, int y)
 
 
 
-bool ShopPanel::Drag(int dx, int dy)
+bool ShopPanel::Drag(double dx, double dy)
 {
 	if(dragShip)
 	{
@@ -556,14 +556,14 @@ bool ShopPanel::Release(int x, int y)
 
 
 
-bool ShopPanel::Scroll(int dx, int dy)
+bool ShopPanel::Scroll(double dx, double dy)
 {
-	return DoScroll(dy * 50);
+	return DoScroll(dy * 50.);
 }
 
 
 
-ShopPanel::ClickZone::ClickZone(int x, int y, int rx, int ry, const Ship *ship, int scrollY)
+ShopPanel::ClickZone::ClickZone(int x, int y, int rx, int ry, const Ship *ship, double scrollY)
 	: left(x - rx), top(y - ry), right(x + rx), bottom(y + ry), scrollY(scrollY),
 	ship(ship), outfit(nullptr)
 {
@@ -571,7 +571,7 @@ ShopPanel::ClickZone::ClickZone(int x, int y, int rx, int ry, const Ship *ship, 
 
 
 
-ShopPanel::ClickZone::ClickZone(int x, int y, int rx, int ry, const Outfit *outfit, int scrollY)
+ShopPanel::ClickZone::ClickZone(int x, int y, int rx, int ry, const Outfit *outfit, double scrollY)
 	: left(x - rx), top(y - ry), right(x + rx), bottom(y + ry), scrollY(scrollY),
 	ship(nullptr), outfit(outfit)
 {
@@ -614,19 +614,19 @@ int ShopPanel::ClickZone::CenterY() const
 
 
 
-int ShopPanel::ClickZone::ScrollY() const
+double ShopPanel::ClickZone::ScrollY() const
 {
 	return scrollY;
 }
 
 
 
-bool ShopPanel::DoScroll(int dy)
+bool ShopPanel::DoScroll(double dy)
 {
-	int &scroll = dragMain ? mainScroll : sideScroll;
+	double &scroll = dragMain ? mainScroll : sideScroll;
 	const int &maximum = dragMain ? maxMainScroll : maxSideScroll;
 	
-	scroll = max(0, min(maximum, scroll - dy));
+	scroll = max(0., min(static_cast<double>(maximum), scroll - dy));
 	
 	return true;
 }

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -65,16 +65,16 @@ protected:
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command) override;
 	virtual bool Click(int x, int y) override;
 	virtual bool Hover(int x, int y) override;
-	virtual bool Drag(int dx, int dy) override;
+	virtual bool Drag(double dx, double dy) override;
 	virtual bool Release(int x, int y) override;
-	virtual bool Scroll(int dx, int dy) override;
+	virtual bool Scroll(double dx, double dy) override;
 	
 	
 protected:
 	class ClickZone {
 	public:
-		ClickZone(int x, int y, int rx, int ry, const Ship *ship, int scrollY = 0);
-		ClickZone(int x, int y, int rx, int ry, const Outfit *outfit, int scrollY = 0);
+		ClickZone(int x, int y, int rx, int ry, const Ship *ship, double scrollY = 0.);
+		ClickZone(int x, int y, int rx, int ry, const Outfit *outfit, double scrollY = 0.);
 		
 		bool Contains(int x, int y) const;
 		const Ship *GetShip() const;
@@ -82,14 +82,14 @@ protected:
 		
 		int CenterX() const;
 		int CenterY() const;
-		int ScrollY() const;
+		double ScrollY() const;
 		
 	private:
 		int left;
 		int top;
 		int right;
 		int bottom;
-		int scrollY;
+		double scrollY;
 		
 		const Ship *ship;
 		const Outfit *outfit;
@@ -113,8 +113,8 @@ protected:
 	const Ship *selectedShip = nullptr;
 	const Outfit *selectedOutfit = nullptr;
 	
-	int mainScroll = 0;
-	int sideScroll = 0;
+	double mainScroll = 0;
+	double sideScroll = 0;
 	mutable int maxMainScroll = 0;
 	mutable int maxSideScroll = 0;
 	bool dragMain = true;
@@ -128,7 +128,7 @@ protected:
 	
 	
 private:
-	bool DoScroll(int dy);
+	bool DoScroll(double dy);
 	void SideSelect(int count);
 	void SideSelect(Ship *ship);
 	void MainLeft();

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -44,8 +44,8 @@ bool UI::Handle(const SDL_Event &event)
 		{
 			if(event.motion.state & SDL_BUTTON(1))
 				handled = (*it)->Drag(
-					event.motion.xrel * 100 / Screen::Zoom(),
-					event.motion.yrel * 100 / Screen::Zoom());
+					event.motion.xrel * 100. / Screen::Zoom(),
+					event.motion.yrel * 100. / Screen::Zoom());
 			else
 				handled = (*it)->Hover(
 					Screen::Left() + event.motion.x * 100 / Screen::Zoom(),


### PR DESCRIPTION
Fixes endless-sky/endless-sky#805

This PR changes the prototype of `Panel::Drag(int, int)` and `Panel::Scroll(int, int)` to `Drag(double, double)` and `Scroll(double, double)`. `Scroll` did not absolutely need to be changed since it's mostly used to scroll Panels in large increments from keyboard shortcuts, but I did change it for the sake of consistency.

Other methods like Click() do not need a change since the click coordinates are always compared to integer coordinates. The only exception is InfoPanel::Hover() which required special treatment.

All Panels that handle scrolling have seen their various scrolling related attributes changed from int to double.

I have not been able to test proper dragging/scrolling for the following panels:

- BoardingPanel
- ConversationPanel
- LoadPanel
- MissionPanel (tested that accepted missions work, not been able to test available missions panel)

I'll update the PR has soon as I've done more tests.