### PR TITLE
Add autoscroll to ShopPanel to bring item details into view

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -81,6 +81,7 @@ void OutfitterPanel::Step()
 			"\tAs in the trading panel, you can hold down Shift or Control "
 			"to buy 5 or 20 of an outfit at once, or both keys to buy 100."));
 	}
+	ShopPanel::Step();
 }
 
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -76,6 +76,19 @@ void ShopPanel::Draw() const
 
 
 
+void ShopPanel::Step() {
+	// perform autoscroll to bring item details into view.
+	if (scrollDetailsIntoView && selectedBottomY > 0)
+	{
+		if (selectedBottomY > Screen::Bottom())
+			DoScroll(-30.);
+		else
+			scrollDetailsIntoView = false;
+	}
+}
+
+
+
 void ShopPanel::DrawSidebar() const
 {
 	const Font &font = FontSet::Get(14);
@@ -288,6 +301,7 @@ void ShopPanel::DrawMain() const
 				
 				mainDetailHeight = DrawDetails(center);
 				nextY += mainDetailHeight;
+				selectedBottomY = nextY - TILE_SIZE / 2;
 			}
 			
 			point.X() += columnWidth;
@@ -378,6 +392,7 @@ bool ShopPanel::CanSellMultiple() const
 // Only override the ones you need; the default action is to return false.
 bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 {
+	scrollDetailsIntoView = false;
 	if((key == 'l' || key == SDLK_ESCAPE || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI)))) && FlightCheck())
 	{
 		player.UpdateCargoCapacities();
@@ -500,6 +515,10 @@ bool ShopPanel::Click(int x, int y)
 			else
 				selectedOutfit = zone.GetOutfit();
 			
+			scrollDetailsIntoView = true;
+			// reset selectedBottomY so that Step() waits for it to be updated
+			// with the proper value computed in Draw().
+			selectedBottomY = 0;
 			mainScroll = max(0, mainScroll + zone.ScrollY());
 			return true;
 		}
@@ -541,7 +560,10 @@ bool ShopPanel::Drag(int dx, int dy)
 				}
 	}
 	else
+	{
+		scrollDetailsIntoView = false;
 		DoScroll(dy);
+	}
 	
 	return true;
 }
@@ -558,6 +580,7 @@ bool ShopPanel::Release(int x, int y)
 
 bool ShopPanel::Scroll(int dx, int dy)
 {
+	scrollDetailsIntoView = false;
 	return DoScroll(dy * 50);
 }
 

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -36,7 +36,7 @@ public:
 	ShopPanel(PlayerInfo &player, const std::vector<std::string> &categories);
 	
 	virtual void Draw() const override;
-	
+	virtual void Step() override;
 	
 protected:
 	void DrawSidebar() const;
@@ -120,6 +120,8 @@ protected:
 	bool dragMain = true;
 	mutable int mainDetailHeight = 0;
 	mutable int sideDetailHeight = 0;
+	bool scrollDetailsIntoView = false;
+	mutable int selectedBottomY = 0;
 	
 	mutable std::vector<ClickZone> zones;
 	


### PR DESCRIPTION
When clicking on an item located near the bottom of the screen, the user needs to scroll the window in order to see the details. This PR implements an autoscroll feature that will automatically bring the item details into view. 

A quick demo:

[![Autoscroll demo](http://img.youtube.com/vi/C0G-QprMBWs/0.jpg)](http://www.youtube.com/watch?v=C0G-QprMBWs)