### PR TITLE
Fixed segfaults on end() iterator dereference

### DIFF
--- a/source/InfoPanel.cpp
+++ b/source/InfoPanel.cpp
@@ -131,7 +131,8 @@ void InfoPanel::Draw() const
 	if(showShip)
 	{
 		interfaceInfo.SetCondition("ship tab");
-		if(canEdit && ((shipIt->get() != player.Flagship() && !(*shipIt)->IsDisabled()) || (*shipIt)->IsParked()))
+		if(canEdit && (shipIt != player.Ships().end())
+					&& ((shipIt->get() != player.Flagship() && !(*shipIt)->IsDisabled()) || (*shipIt)->IsParked()))
 			interfaceInfo.SetCondition((*shipIt)->IsParked() ? "show unpark" : "show park");
 		else if(!canEdit)
 			interfaceInfo.SetCondition(CanDump() ? "enable dump" : "show dump");
@@ -317,6 +318,9 @@ bool InfoPanel::Click(int x, int y)
 
 bool InfoPanel::Hover(int x, int y)
 {
+	if(shipIt == player.Ships().end())
+		return true;
+
 	hoverPoint = Point(x, y);
 	
 	const vector<Armament::Weapon> &weapons = (**shipIt).Weapons();


### PR DESCRIPTION
Info panel crashes when no ships on new or just loaded game. Start new game but don't buy a ship and leave shipyard. Press Shift-I, switch to Ships tab. Move mouse over panel as bug in Hover() method. 
Tested on Windows and Linux.