### PR TITLE
Allow zooming the main view independent of the UI zoom

### DIFF
--- a/source/DrawList.cpp
+++ b/source/DrawList.cpp
@@ -55,11 +55,21 @@ bool DrawList::Add(const Animation &animation, Point pos, Point unit, Point blur
 		.5 * (fabs(unit.X() * animation.Width()) + fabs(unit.Y() * animation.Height()) + fabs(blur.Y())));
 	Point topLeft = pos - size;
 	Point bottomRight = pos + size;
-	if(bottomRight.X() < Screen::Left() || bottomRight.Y() < Screen::Top())
-		return false;
-	if(topLeft.X() > Screen::Right() || topLeft.Y() > Screen::Bottom())
-		return false;
-		
+	if(drawableSize.X())
+	{
+		if(bottomRight.X() < -drawableSize.X() || bottomRight.Y() < -drawableSize.Y())
+			return false;
+		if(topLeft.X() > drawableSize.X() || topLeft.Y() > drawableSize.Y())
+			return false;
+	}
+	else
+	{
+		if(bottomRight.X() < Screen::Left() || bottomRight.Y() < Screen::Top())
+			return false;
+		if(topLeft.X() > Screen::Right() || topLeft.Y() > Screen::Bottom())
+			return false;
+	}
+
 	items.emplace_back(animation, pos, unit, blur, clip, step);
 	return true;
 }
@@ -97,6 +107,20 @@ void DrawList::Draw() const
 			item.Swizzle(), item.Clip(), item.Fade(), showBlur ? item.Blur() : nullptr);
 
 	SpriteShader::Unbind();
+}
+
+
+
+// Sets the width and height of the drawable screen region.
+void DrawList::SetDrawableSize(int width, int height)
+{
+	if(width == 0 || height == 0)
+		// Will get Screen::Width() and Screen::Height() when needed.
+		drawableSize = Point(0, 0);
+	else
+		// the drawable area is actually (width/-2, height/-2) - (width/2, height/2)
+		// so we just keep the precomputed half.
+		drawableSize = Point(width/2, height/2);
 }
 
 

--- a/source/DrawList.h
+++ b/source/DrawList.h
@@ -45,7 +45,12 @@ public:
 	// Draw all the items in this list. The shader object may be shared between
 	// multiple DrawLists, so pass it in here.
 	void Draw() const;
-	
+
+	// Sets the width and height of the drawable screen region (centered on the
+	// screen). Items outside of this region are just ignored but no real
+	// clipping occurs.
+	// If set to (0, 0), it falls back to Screen::Width() and Screen::height().
+	void SetDrawableSize(int width, int height);
 	
 private:
 	class Item {
@@ -87,6 +92,7 @@ private:
 private:
 	int step;
 	std::vector<Item> items;
+	Point drawableSize;
 };
 
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -624,7 +624,7 @@ void Engine::Draw() const
 void Engine::Click(const Point &point)
 {
 	doClick = true;
-	clickPoint = point;
+	clickPoint = point * 100 / zoom;
 }
 
 

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -69,6 +69,7 @@ public:
 	// Select the object the player clicked on.
 	void Click(const Point &point);
 	
+	void Zoom(int increment);
 	
 private:
 	void EnterSystem();
@@ -120,6 +121,7 @@ private:
 	// Viewport position and velocity.
 	Point position;
 	Point velocity;
+	int zoom { 100 };
 	// Other information to display.
 	Information info;
 	std::vector<Target> targets;

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -240,6 +240,14 @@ bool MainPanel::Click(int x, int y)
 
 
 
+bool MainPanel::Scroll(double, double dy)
+{
+	engine.Zoom(dy < 0 ? -10 : 10);
+	return true;
+}
+
+
+
 void MainPanel::ShowScanDialog(const ShipEvent &event)
 {
 	shared_ptr<Ship> target = event.Target();

--- a/source/MainPanel.h
+++ b/source/MainPanel.h
@@ -42,7 +42,7 @@ protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command) override;
 	virtual bool Click(int x, int y) override;
-	
+	virtual bool Scroll(double dx, double dy) override;
 	
 private:
 	void ShowScanDialog(const ShipEvent &event);

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -284,11 +284,11 @@ bool PreferencesPanel::Click(int x, int y)
 				Preferences::Set(zone.Value(), !Preferences::Has(zone.Value()));
 			else
 			{
-				int zoom = Screen::Zoom();
-				Screen::SetZoom(zoom == 100 ? 150 : zoom == 150 ? 200 : 100);
+				int zoom = Screen::Zoom() + 10;
+				Screen::SetZoom(zoom);
 				// Make sure there is enough vertical space for the full UI.
-				if(Screen::Height() < 700)
-					Screen::SetZoom(100);
+				if(zoom > 200 || Screen::Height() < 700)
+					Screen::SetZoom(70);
 				
 				// Convert to raw window coordinates, at the new zoom level.
 				point *= Screen::Zoom() / 100.;

--- a/source/Screen.cpp
+++ b/source/Screen.cpp
@@ -47,7 +47,7 @@ int Screen::Zoom()
 
 void Screen::SetZoom(int percent)
 {
-	ZOOM = max(100, min(200, percent));
+	ZOOM = max(70, min(200, percent));
 	WIDTH = RAW_WIDTH * 100 / ZOOM;
 	HEIGHT = RAW_HEIGHT * 100 / ZOOM;
 }


### PR DESCRIPTION
Also allows changing the UI Zoom from 70% to 200% by increments of 10% (the default jump from 100% to 150% is just too much for me).

In the main view, the mouse wheel changes the zoom level. The current zoom level is displayed in the messages panel (is this desirable?). The view can be zoomed out!

However, I'm not terribly happy with the implementation:
- change Screen::Zoom in the middle of Engine::Draw
- changes to DrawList so that classes with special needs can specify a custom clipping region instead of the default Screen::Width/Height.

This could however alleviate issues like #814 and #627.
