### PR TITLE
Add incremental save backup

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -300,7 +300,7 @@ void PlayerInfo::Save() const
 			// delete older backups
 			auto saves = Files::List(Files::Saves());
 			auto last = remove_if(saves.begin(), saves.end(),
-				[&baseName](const string& item){ return item.find(baseName) != 0; });
+				[&baseName](const string& item){ return item.compare(0, baseName.length(), baseName); });
 			sort(saves.begin(), last);
 			size_t count = distance(saves.begin(), last);
 			for (auto it = saves.begin(); count > savesToKeep && it != last; it++, count--)

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -26,6 +26,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <set>
 #include <vector>
 #include <string>
+#include <future>
 
 class DataNode;
 class Government;
@@ -62,7 +63,9 @@ public:
 	void LoadRecent();
 	// Save this player (using the Identifier() as the file name).
 	void Save() const;
-	
+	// Number of save backups to keep
+	static std::size_t SaveBackups();
+	static void SetSaveBackups(std::size_t count);
 	// Get the root filename used for this player's saved game files. (If there
 	// are multiple pilots with the same name it may have a digit appended.)
 	std::string Identifier() const;
@@ -249,6 +252,10 @@ private:
 	std::list<GameEvent> gameEvents;
 	
 	bool freshlyLoaded = true;
+	// Keeps track of the std::async call performing save backups.
+	// When destroyed, it will automatically wait for the thread to finish,
+	// so declaring it as mutable is safe in this use case.
+	mutable std::shared_future<void> saveBackupDone;
 };
 
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataWriter.h"
 #include "Files.h"
 #include "Screen.h"
+#include "PlayerInfo.h"
 
 #include <map>
 
@@ -45,6 +46,8 @@ void Preferences::Load()
 			Screen::SetZoom(node.Value(1));
 		else if(node.Token(0) == "volume" && node.Size() >= 2)
 			Audio::SetVolume(node.Value(1));
+		else if(node.Token(0) == "save backups" && node.Size() >= 2)
+			PlayerInfo::SetSaveBackups(node.Value(1));
 		else
 			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));
 	}
@@ -56,6 +59,7 @@ void Preferences::Save()
 {
 	DataWriter out(Files::Config() + "preferences.txt");
 	
+	out.Write("save backups", PlayerInfo::SaveBackups());
 	out.Write("volume", Audio::Volume());
 	out.Write("window size", Screen::RawWidth(), Screen::RawHeight());
 	out.Write("zoom", Screen::Zoom());


### PR DESCRIPTION
This PR adds an incremental save backup functionality. Since I initially implemented this in order to help troubleshooting game issues, it is disabled by default. To enable it, set the following in your preferences.txt:

    "save backups" 5

this will make the game keep a backup of the last 5 saves for a given pilot. In the snapshot list of the Load/Save panel, the saves are presented like this:

    Galileo Galilei
    autosave-3035-09-27
    autosave-3035-09-29
    autosave-3035-10-01
    autosave-3035-10-04
    autosave-3035-10-07
    autosave

The last one was created when accepting a mission recommending an autosave. For these, there is no automated backup. ~~Note that the latest autosave (...-2035-10-07 in the example above) is just a copy of the player's latest save.~~

This is done asynchronously. If the user has a large amount of files in his saves folder, this may affect performance if launching/landing in quick succession (who would do that anyway?), or introduce a short delay when exiting the game (but only visible when launching from the command line IIRC).