### PR TITLE
Allow dominated planets to be freed

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -1065,6 +1065,11 @@ interface "hail panel"
 		size 14
 		color dim
 		align center
+	if "can relinquish"
+	label "_Relinquish Planet" -20 108
+		size 14
+		color bright
+		align center
 	if "can assist"
 	label "Ask For _Help" -20 108
 		size 14

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -22,6 +22,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Phrase.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
+#include "Politics.h"
 #include "Ship.h"
 #include "Sprite.h"
 #include "SpriteShader.h"
@@ -183,8 +184,11 @@ void HailPanel::Draw() const
 				interfaceInfo.SetCondition("can bribe");
 			else
 				interfaceInfo.SetCondition("cannot bribe");
-		
-			interfaceInfo.SetCondition("can dominate");
+
+			if (!GameData::GetPolitics().HasDominated(planet))
+				interfaceInfo.SetCondition("can dominate");
+			else
+				interfaceInfo.SetCondition("can relinquish");
 		}
 	}
 	
@@ -230,7 +234,11 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			return true;
 		if(planet)
 		{
-			message = planet->DemandTribute(player);
+			if (!GameData::GetPolitics().HasDominated(planet)) {
+				message = planet->DemandTribute(player);
+			} else {
+				message = planet->RelinquishTribute(player);
+			}
 			return true;
 		}
 		else if(shipIsEnemy || ship->GetGovernment()->GetName() == "Derelict")

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -419,6 +419,19 @@ string Planet::DemandTribute(PlayerInfo &player) const
 
 
 
+string Planet::RelinquishTribute(PlayerInfo &player) const
+{
+	if (!player.GetCondition("tribute: " + name))
+		return "We aren't giving you any tribute at the moment";
+
+	player.Conditions().erase("tribute: " + name);
+	GameData::GetPolitics().RelinquishPlanet(this);
+
+	return "So long, beloved overlord, and thanks for all the fish !";
+}
+
+
+
 void Planet::DeployDefense(list<shared_ptr<Ship>> &ships) const
 {
 	if(!isDefending || Random::Int(60) || defenseDeployed == defenseCount)

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -108,6 +108,7 @@ public:
 	
 	// Demand tribute, and get the planet's response.
 	std::string DemandTribute(PlayerInfo &player) const;
+	std::string RelinquishTribute(PlayerInfo &player) const;
 	void DeployDefense(std::list<std::shared_ptr<Ship>> &ships) const;
 	void ResetDefense() const;
 	

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -196,6 +196,13 @@ void Politics::DominatePlanet(const Planet *planet)
 
 
 
+void Politics::RelinquishPlanet(const Planet *planet)
+{
+	dominatedPlanets.erase(planet);
+}
+
+
+
 bool Politics::HasDominated(const Planet *planet) const
 {
 	return (dominatedPlanets.find(planet) != dominatedPlanets.end());

--- a/source/Politics.h
+++ b/source/Politics.h
@@ -52,6 +52,7 @@ public:
 	void BribePlanet(const Planet *planet, bool fullAccess);
 	void DominatePlanet(const Planet *planet);
 	bool HasDominated(const Planet *planet) const;
+	void RelinquishPlanet(const Planet *planet);
 	
 	// Check to see if the player has done anything they should be fined for.
 	// Each government can only fine you once per day.


### PR DESCRIPTION
First PR, please be gentle ! This makes it possible to give back planets after you dominated them, just because I dominated a few pirate worlds while doing the FW storyline, namely Gienah, Algenib & Almach, but as the first two are switched to Federation after the last battle I felt bad ;-).
