### PR TITLE
changed SHIELD EXCHANGE RATE to SHIELD EFFICIENCY

### DIFF
--- a/data/wanderers.txt
+++ b/data/wanderers.txt
@@ -654,7 +654,7 @@ outfit "Bright Cloud Shielding"
 	"mass" 19
 	"outfit space" -19
 	"shield generation" 1.2
-	"shield energy" 1.8
+	"shield energy" 1.5
 	description "This small Wanderer shield generator is able to recharge a ship's shields at a considerable rate, but it also consumes more energy than some other shield generators do."
 
 outfit "Dark Storm Shielding"
@@ -664,7 +664,7 @@ outfit "Dark Storm Shielding"
 	"mass" 41
 	"outfit space" -41
 	"shield generation" 2.8
-	"shield energy" 4.2
+	"shield energy" 2.5
 	description "This Wanderer shield generator can restore a ship's shield strength more quickly than any human shielding technology, but while recharging shields it also draws a much larger amount of power."
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1109,9 +1109,8 @@ bool Ship::Move(list<Effect> &effects)
 		// energy, use it to recharge fighters and drones.
 		double shieldGeneration = attributes.Get("shield generation");
 		shields += shieldGeneration;
-		double SHIELD_EXCHANGE_RATE = 1. +
-			(shieldGeneration ? attributes.Get("shield energy") / shieldGeneration : 0.);
-		energy -= SHIELD_EXCHANGE_RATE * shieldGeneration;
+		double SHIELD_EFFICIENCY = attributes.Get("shield energy");
+		energy -= SHIELD_EFFICIENCY * shieldGeneration;
 		double excessShields = max(0., shields - maxShields);
 		shields -= excessShields;
 		
@@ -1133,10 +1132,10 @@ bool Ship::Move(list<Effect> &effects)
 		// If you do not need the shield generation, apply the extra back to
 		// your energy. On the other hand, if recharging shields drives your
 		// energy negative, undo that part of the recharge.
-		energy += SHIELD_EXCHANGE_RATE * excessShields;
+		energy += SHIELD_EFFICIENCY * excessShields;
 		if(energy < 0.)
 		{
-			shields += energy / SHIELD_EXCHANGE_RATE;
+			shields += energy / SHIELD_EFFICIENCY;
 			energy = 0.;
 		}
 	}


### PR DESCRIPTION
potential mods cannot assign a negative value (or trigger negative
value error in outfits)

“shield energy” now behaves as a proportion multiplier, so attributes
between 0 and 1 use less energy per unit of shields regenerated, while
> 1 takes more energy per unit.

wanderer outfits adjusted accordingly.