### PR TITLE
enable solar collection attribute

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -714,6 +714,8 @@ bool Ship::Move(list<Effect> &effects)
 		fuel += .03 * scale * (sqrt(attributes.Get("ramscoop") + .05 * scale));
 		fuel = min(fuel, attributes.Get("fuel capacity"));
 		
+		energy += scale * attributes.Get("solar collection");
+		
 		energy += attributes.Get("energy generation") - ionization;
 		energy = max(0., energy);
 		heat += attributes.Get("heat generation");


### PR DESCRIPTION
Outfits can now be given a "solar collection" attribute, which will generate a variable amount of power, based on distance from the current system's star, using a similar formula to that which determines ramscoop effectiveness.

Given the current formula, a solar collection value of .5 will effectively power a shuttle as long as the star is close enough to be visible.

This was suggested by @DingusShingleton.