### PR TITLE
Support "unplunderable" attribute for outfits.

### DIFF
--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -219,6 +219,7 @@ outfit "Mass Expansion"
 	"mass" 5
 	"outfit space" 15
 	"cargo space" -20
+	unplunderable 1
 	description "A mass expansion allows you to sacrifice some cargo space in order to make room for more outfits, in situations where you need just a bit more space to install a particular system. It does not increase your weapon or engine space unfortunately."
 	
 outfit "Cargo Expansion"

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -64,7 +64,8 @@ BoardingPanel::BoardingPanel(PlayerInfo &player, const shared_ptr<Ship> &victim)
 	// You cannot plunder hand to hand weapons, because they are kept in the
 	// crew's quarters, not mounted on the exterior of the ship.
 	for(const auto &it : victim->Outfits())
-		if(it.first->Category() != "Hand to Hand")
+		if(it.first->Category() != "Hand to Hand" &&
+			!it.first->Get("unplunderable"))
 			plunder.emplace_back(it.first, it.second);
 	
 	sort(plunder.begin(), plunder.end());

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -44,6 +44,10 @@ namespace {
 		"turning energy",
 		"turning heat"
 	};
+	
+	static const set<string> BOOLEAN_ATTRIBUTES = {
+		"unplunderable"
+	};
 }
 
 
@@ -135,9 +139,18 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		else if(ATTRIBUTES_TO_SCALE.find(it.first) != ATTRIBUTES_TO_SCALE.end())
 			scale = 60.;
 		
-		attributeLabels.push_back(it.first + ':');
-		attributeValues.push_back(Format::Number(it.second * scale));
-		attributesHeight += 20;
+		if (BOOLEAN_ATTRIBUTES.find(it.first) != BOOLEAN_ATTRIBUTES.end()) 
+		{
+			attributeLabels.push_back("This outfit is " + it.first + ".");
+			attributeValues.push_back("");
+			attributesHeight += 20;
+		}
+		else
+		{
+			attributeLabels.push_back(it.first + ':');
+			attributeValues.push_back(Format::Number(it.second * scale));
+			attributesHeight += 20;
+		}
 	}
 	
 	if(!outfit.IsWeapon())


### PR DESCRIPTION
Only the mass expansion was actually made unplunderable in this pull request, because plundering them can result in impossible ship configurations with negative outfit space available. 

For the record, I don't want reactors or other popular plundering targets to become unplunderable; I think there are better ways to improve economic balance.  However, having support for the attribute is certainly a good thing. 