### PR TITLE
refer to Reunion 'local legislature' and Republic 'Parliament'

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -17868,7 +17868,7 @@ planet Reunion
 	attributes "near earth" urban factory
 	landscape land/mfield4
 	description `Reunion is one of the most Earth-like planets found by the early settlers, all the way down to its moon and tides. It has grown into a mostly urban world, which supplies manufactured goods of all sorts to the neighboring systems.`
-	description `	Local politics are unusually lively for a Republic world, to the point where a seat in the local parliament is often more hotly contested than one in the Republic Senate. Topics of debate include trade and taxation, of course, but also seemingly fringe issues like biodiversity regulations for city green space. It may be that a world with no terraforming needs is focusing instead on tweaking society itself.`
+	description `	Local politics are unusually lively for a Republic world, to the point where a seat in the local legislature is often more hotly contested than one in the Republic Parliament. Topics of debate include trade and taxation, of course, but also seemingly fringe issues like biodiversity regulations for city green space. It may be that a world with no terraforming needs is focusing instead on tweaking society itself.`
 	spaceport `The spaceport, although designed as a clean and modern building, is a place of barely controlled chaos: vendors selling food on the sides of the hallways, tourist families with young children, and even a few farmers driving cattle. People of every age and race and occupation rub shoulders here, but there is no sign of the extreme sort of poverty that you have seen on some other worlds.`
 	shipyard "Basic Ships"
 	shipyard "Syndicate Basics"


### PR DESCRIPTION
I fixed the mention of "Republic Senate" in the description for Reunion, and changed Reunion's local government to "Senate" to avoid having to restructure the sentence.