### PR TITLE
Hai assist mission

### DIFF
--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -28,13 +28,13 @@ mission "Assisting Hai"
 	assisting
 	repeat
 	to offer
-		random < 20
+		random < 27
 	source
 		government Hai
 	on offer
-		payment 25000
+		payment 30000
 		conversation
-			`Knowing you risked your life just to save the <origin>, the pilot gives you <payment>.`
+			`Knowing you risked your life to save the <origin>, the pilot gives you <payment>.`
 				decline
 	# A mission with no destination will not be offered, so give it one.
 	# What the destination is doesn't matter, because you always 'decline' this.

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -18,7 +18,7 @@ mission "Assisting Merchant"
 	on offer
 		payment 10000
 		conversation
-			`When you repair the <origin>, the pilot thanks you for your assistance and pays you <payment>.`
+			`When you repair the <origin>, the captain thanks you for your assistance and pays you <payment>.`
 				decline
 	# A mission with no destination will not be offered, so give it one.
 	# What the destination is doesn't matter, because you always 'decline' this.
@@ -34,6 +34,6 @@ mission "Assisting Hai"
 	on offer
 		payment 30000
 		conversation
-			`Knowing you risked your life to save the <origin>, the pilot gives you <payment>.`
+			`Knowing you risked your life to save the <origin>, the captain gives you <payment>.`
 				decline
 	destination Hai-home

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -39,3 +39,19 @@ mission "Assisting Hai"
 	# A mission with no destination will not be offered, so give it one.
 	# What the destination is doesn't matter, because you always 'decline' this.
 	destination Hai-home
+	
+mission "Assisting Quarg"
+	assisting
+	repeat
+	to offer
+		random < 75
+	source
+		government Quarg
+	on offer
+		payment 10000000
+		conversation
+			`The Quarg inside the <origin> gratefully pay you <payment>, knowing that the enemies outside your ships are very powerful, and it is no small task to help an abandoned ship.`
+				decline
+	# A mission with no destination will not be offered, so give it one.
+	# What the destination is doesn't matter, because you always 'decline' this.
+	destination Lagrange

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -37,17 +37,3 @@ mission "Assisting Hai"
 			`Knowing you risked your life to save the <origin>, the pilot gives you <payment>.`
 				decline
 	destination Hai-home
-	
-mission "Assisting Quarg"
-	assisting
-	repeat
-	to offer
-		random < 75
-	source
-		government Quarg
-	on offer
-		payment 1000000
-		conversation
-			`The Quarg inside the <origin> gratefully pay you <payment>, knowing that the enemies outside your ships are very powerful, and it is no small task to help an abandoned ship.`
-				decline
-	destination Lagrange

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -28,7 +28,7 @@ mission "Assisting Hai"
 	assisting
 	repeat
 	to offer
-		random < 5
+		random < 30
 	source
 		government Hai
 	on offer

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -28,7 +28,7 @@ mission "Assisting Hai"
 	assisting
 	repeat
 	to offer
-		random < 30
+		random < 20
 	source
 		government Hai
 	on offer

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -36,8 +36,6 @@ mission "Assisting Hai"
 		conversation
 			`Knowing you risked your life to save the <origin>, the pilot gives you <payment>.`
 				decline
-	# A mission with no destination will not be offered, so give it one.
-	# What the destination is doesn't matter, because you always 'decline' this.
 	destination Hai-home
 	
 mission "Assisting Quarg"
@@ -48,10 +46,8 @@ mission "Assisting Quarg"
 	source
 		government Quarg
 	on offer
-		payment 10000000
+		payment 1000000
 		conversation
 			`The Quarg inside the <origin> gratefully pay you <payment>, knowing that the enemies outside your ships are very powerful, and it is no small task to help an abandoned ship.`
 				decline
-	# A mission with no destination will not be offered, so give it one.
-	# What the destination is doesn't matter, because you always 'decline' this.
 	destination Lagrange

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -8,7 +8,7 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-mission "Assisting"
+mission "Assisting Merchant"
 	assisting
 	repeat
 	to offer
@@ -23,3 +23,19 @@ mission "Assisting"
 	# A mission with no destination will not be offered, so give it one.
 	# What the destination is doesn't matter, because you always 'decline' this.
 	destination Earth
+
+mission "Assisting Hai"
+	assisting
+	repeat
+	to offer
+		random < 5
+	source
+		government Hai
+	on offer
+		payment 25000
+		conversation
+			`Knowing you risked your life just to save the <origin>, the pilot gives you <payment>.`
+				decline
+	# A mission with no destination will not be offered, so give it one.
+	# What the destination is doesn't matter, because you always 'decline' this.
+	destination Hai-home


### PR DESCRIPTION
Merchants occasionally pay you for helping them - why not the extremely friendly, peaceful, Hai?

I made it so it pays more, and has more of a chance, for two reasons:
a) The only place they get disabled is on the border between theirs and the Unfettered's borders, making it extremely dangerous, with a high chance of death.
b) They are the Hai, who are more friendly, more generous, etc.

The missions pay much more than the original (30k as opposed to 10) and are more common (< 27 as opposed to < 10.)

Similiar issues: #333 and #1002.