### PR TITLE
Remove compiler warnings

### DIFF
--- a/source/Font.cpp
+++ b/source/Font.cpp
@@ -70,14 +70,15 @@ namespace {
 
 
 Font::Font()
-	: texture(0), vao(0), vbo(0), height(0), space(0)
+	: texture(0), vao(0), vbo(0), colorI(0), scaleI(0), glyphI(0), aspectI(0),
+	  positionI(0), height(0), space(0), screenWidth(0), screenHeight(0)
 {
 }
 
 
 
 Font::Font(const string &imagePath)
-	: texture(0), vao(0), vbo(0), height(0), space(0)
+	: Font()
 {
 	Load(imagePath);
 }

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -360,7 +360,7 @@ Interface::StringSpec::StringSpec(const string &str, const Point &position)
 
 
 Interface::BarSpec::BarSpec(const string &name, const Point &position)
-	: name(name), position(position)
+	: name(name), position(position), width(0.0)
 {
 }
 

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 
 ShipyardPanel::ShipyardPanel(PlayerInfo &player)
-	: ShopPanel(player, Ship::CATEGORIES)
+	: ShopPanel(player, Ship::CATEGORIES), modifier(0)
 {
 	for(const auto &it : GameData::Ships())
 		catalog[it.second.Attributes().Category()].insert(it.first);

--- a/source/WrappedText.cpp
+++ b/source/WrappedText.cpp
@@ -23,7 +23,8 @@ using namespace std;
 
 
 WrappedText::WrappedText()
-	: font(nullptr), wrapWidth(1000), alignment(JUSTIFIED), height(0)
+	: font(nullptr), space(0), wrapWidth(1000), tabWidth(0),
+	  lineHeight(0), paragraphBreak(0), alignment(JUSTIFIED), height(0)
 {
 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
 				}
 				else if(event.type == SDL_KEYDOWN
 						&& (Command(event.key.keysym.sym).Has(Command::FULLSCREEN)
-						|| (event.key.keysym.sym == SDLK_RETURN && event.key.keysym.mod & KMOD_ALT)))
+						|| (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT))))
 				{
 					if(restoreWidth)
 					{


### PR DESCRIPTION
Per the "No compiler warnings" rule in the style guide, resolve compiler warnings for uninitialized members and recommended parentheses.