### PR TITLE
Bank Panel, Pay Extra to Other one time

### DIFF
--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -266,13 +266,19 @@ bool BankPanel::Click(int x, int y)
 void BankPanel::PayExtra(const string &str)
 {
 	int64_t amount = static_cast<int64_t>(Format::Parse(str));
+	int64_t i = 0;
+	// Pay the mortgage, if it's from Other pay it again until done
+	do {
+		// You cannot pay more than you have or more than the mortgage principal.
+		i = min(amount, min(player.Accounts().Credits(),
+			player.Accounts().Mortgages()[selectedRow].Principal()));
+		if (i < 1)
+			break;
 	
-	// You cannot pay more than you have or more than the mortgage principal.
-	amount = min(amount, min(player.Accounts().Credits(),
-		player.Accounts().Mortgages()[selectedRow].Principal()));
-	
-	if(amount > 0)
-		player.Accounts().PayExtra(selectedRow, amount);
+		player.Accounts().PayExtra(selectedRow, i);
+		amount -= i;
+		
+	} while (selectedRow == 6 + !player.Salaries()); //row Other check
 	
 	qualify = player.Accounts().Prequalify();
 }

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -266,19 +266,22 @@ bool BankPanel::Click(int x, int y)
 void BankPanel::PayExtra(const string &str)
 {
 	int64_t amount = static_cast<int64_t>(Format::Parse(str));
-	int64_t i = 0;
-	// Pay the mortgage, if it's from Other pay it again until done
+	int64_t payment = 0;
+	bool isOther = selectedRow == 6 + !player.Salaries();
+
+	// Pay the mortgage, if it's from Other pay it again until done.
+	// You cannot pay more than you have or more than the mortgage principal.
 	do {
-		// You cannot pay more than you have or more than the mortgage principal.
-		i = min(amount, min(player.Accounts().Credits(),
+		payment = min(amount, min(player.Accounts().Credits(),
 			player.Accounts().Mortgages()[selectedRow].Principal()));
-		if (i < 1)
+		if (payment < 1)
 			break;
 	
-		player.Accounts().PayExtra(selectedRow, i);
-		amount -= i;
-		
-	} while (selectedRow == 6 + !player.Salaries()); //row Other check
+		player.Accounts().PayExtra(selectedRow, payment);
+		amount -= payment;
+
+	} while (isOther && static_cast<unsigned>(selectedRow) <
+			player.Accounts().Mortgages().size());
 	
 	qualify = player.Accounts().Prequalify();
 }


### PR DESCRIPTION
In the Bank panel, allowed 'pay extra' when used on Other to pay to more than just the first account

https://github.com/endless-sky/endless-sky/issues/1215

I created an issue for this because I wasn't sure about the PR etiquette and people's input can be helpful but I see that the contributing guide suggests going ahead and making a PR if you have something so here goes.