### PR TITLE
debt response for mission triggers

### DIFF
--- a/XCode/EndlessSky-Info.plist
+++ b/XCode/EndlessSky-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.1</string>
+	<string>0.9.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/changelog
+++ b/changelog
@@ -1,3 +1,71 @@
+Version 0.9.2:
+  * Bug fixes:
+    * Typo fixes. (@Alkallid, @egony, @lheckemann, @MarcelineVQ)
+    * You now get paid for outfits sold for lack of space when taking off. (@MarcelineVQ)
+    * Corrected the credit amount shown when jettisoning spare outfits. (@MarcelineVQ)
+    * Fixed the ammo dialog showing up even if the ammo is not for sale. (@MarcelineVQ)
+    * Holding the jump key while jumping no longer causes a crash.
+    * Attacking a ship that's trying to assist you now makes it stop trying to assist.
+    * Double-clicking a planet to land on it now always works correctly.
+    * The game no longer crashes if you press "land" in a system with nothing to land on.
+    * Fixed irregular escort icon "merging" due to a memory access error.
+    * Your fleet's "shared target" is now cleared if that ship leaves the system.
+    * Fixed a bug where selecting Food in the map didn't select it in the trade panel.
+    * Cargo capacity now updates immediately when you buy or sell outfits.
+    * It's now impossible for an "invisible" mission to be selected in the mission panel.
+    * Fixed the size of the "click box" around ship icons in the shops.
+    * Fixed two Hai ship variants that had no thrusters.
+    * Disabled ships no longer show the "moving erratically" message.
+    * NPC fighters in "staying" fleets now use the proper fighter names.
+    * Fixed a bug that made it impossible for plugins to change the interface colors.
+  * Game content:
+    * Rebalanced the new Hai outfits. (@LocalGod79)
+    * Androids are no longer sold - they're just too unbalanced.
+    * Added an event after the main story line where the shipyard at Geminus is rebuilt.
+    * The Wanderers vs. Alphas missions are now only offered after the human story line.
+    * Added an Unfettered invasion event as the next step in that story line.
+    * Fixed a typo that kept the Wanderer Anti-Missile from being offered for sale.
+    * Shrunk the Korath Piercer sprite to be less absurdly large compared to other missiles.
+    * Made the Korath Tek Far 109 a bit more common.
+    * New Shield Beetle variant with lots of pulse cannons (mainly for Unfettered fleets).
+    * Fixed a mission that could be offered on uninhabited Hai planets.
+    * Cleaned up the Marauder mission text and definitions a bit.
+    * Made some Free Worlds side missions "minor" so they won't interrupt the main story.
+    * Tweaked the Kor Sestor fleets for better balance against the Kor Mereti.
+  * Game mechanics:
+    * You're now allowed to capture fighters even if you cannot carry them.
+    * Landing on an uninhabited planet recharges shields (and hull, if your ship can repair).
+    * All missiles now have some "mass" so you can't have infinite numbers of them in cargo.
+    * NPCs that self-destruct now count as "destroyed" as soon as they explode.
+    * A ship's accuracy now improves after firing at the same target for a few seconds.
+    * When told to "gather," escorts use the old behavior, not the new station-keeping one.
+    * Ships with 50% hull now flee even if they have 100% shields.
+    * Weapons can now have a "random lifetime" rather than all shots lasting the same time.
+    * The saved game now remembers what outfits are "in stock" because you just sold them.
+  * User interface:
+    * In the Bank you can now "pay extra" for the "Other" debts. (@MarcelineVQ)
+    * Three previous save files are now always automatically kept as backups.
+    * Added explanatory tooltips when you hover the mouse over any ship or outfit attribute.
+    * Added a confirmation dialog before taking off if you will be forced to sell something.
+    * Added a subtle blue "haze" in the background to make the stars a bit less boring.
+    * You can now select multiple ships in the info panel and park or unpark them all at once.
+    * The navigation buttons are now in the same place on all four map panels.
+    * It's now possible to buy outfits into cargo even if you only have one ship.
+    * Made the active mission pointers a bit bigger to look less similar to blocked missions.
+    * Added a preference (accessible by editing the preferences file) to reduce VRAM usage.
+    * Added hidden preferences to disable the warning siren, mini-map, and planet labels.
+    * Added a preference to disable the hyperspace flash (by editing the preferences file).
+    * Wormholes now count as distance 1, not distance 0, for pathfinding purposes.
+    * The ammo refill dialog now takes into account that using ammo from cargo is free.
+  * Under the hood:
+    * Added "debug" and "profile" builds to the Scons script (for Linux builds).
+    * Optimized the check for whether a ship is invisible or cloaked.
+    * Optimized anti-missiles by adding a range check before doing more complex calculations.
+    * Limited the "sparks" (ionization, etc.) drawn over a ship, to avoid graphics lag.
+    * On Windows, saved games and preferences will now use Windows line endings.
+    * Removed a lot of duplicated and fragile code in the Fleet class.
+    * Cleaned up some superfluous namespace qualifiers.
+ 
 Version 0.9.1:
   * Bug fixes:
     * Typo fixes. (@Alkallid, @Wrzlprnft, @toilethinges)

--- a/credits.txt
+++ b/credits.txt
@@ -1,5 +1,5 @@
 Welcome to Endless Sky!
-version 0.9.1
+version 0.9.2
 
 Programming
   Michael Zahniser

--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -1632,6 +1632,28 @@ fleet "Quarg"
 	variant
 		"Quarg Wardragon"
 
+fleet "Large Quarg"
+	government "Quarg"
+	names "quarg"
+	cargo 1
+	personality
+		forbearing
+	variant 2
+		"Quarg Skylark" 2
+		"Quarg Wardragon"
+	variant 2
+		"Quarg Wardragon" 2
+		"Quarg Skylark"
+	variant
+		"Quarg Skylark" 2
+		"Quarg Wardragon" 2
+	variant
+		"Quarg Wardragon" 3
+		"Quarg Skylark"
+	variant
+		"Quarg Skylark" 3
+		"Quarg Wardragon"
+
 fleet "Small Pug"
 	government "Pug"
 	names "pug"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -69,7 +69,7 @@ government "Free Worlds"
 
 government "Hai"
 	swizzle 0
-	color .69 .33 .82
+	color .84 .42 .81
 	
 	"player reputation" 0
 	"attitude toward"
@@ -81,7 +81,7 @@ government "Hai"
 
 government "Hai (Unfettered)"
 	swizzle 4
-	color .84 .42 .81
+	color .69 .33 .82
 	
 	"player reputation" -1000
 	"attitude toward"

--- a/data/map.txt
+++ b/data/map.txt
@@ -3448,7 +3448,7 @@ system Chikatip
 	asteroids "small metal" 18 2.5415
 	asteroids "medium metal" 89 2.6979
 	asteroids "large metal" 22 4.0664
-	fleet Quarg 2000
+	fleet "Large Quarg" 2000
 	object
 		sprite star/k5
 		period 10
@@ -3593,7 +3593,7 @@ system Chornifath
 	asteroids "small metal" 5 6.0368
 	asteroids "medium metal" 2 9.4864
 	asteroids "large metal" 4 5.0176
-	fleet Quarg 1000
+	fleet "Large Quarg" 1000
 	object
 		sprite star/k0
 		period 10
@@ -4320,7 +4320,8 @@ system Dokdobaru
 	trade Medical 750
 	trade Metal 385
 	trade Plastic 379
-	fleet Quarg 500
+	fleet Quarg 600
+	fleet "Large Quarg" 800
 	fleet "Kor Efret Home" 1500
 	object
 		sprite star/g5
@@ -5480,7 +5481,7 @@ system Farbutero
 	asteroids "small metal" 2 4.4689
 	asteroids "medium metal" 1 6.7367
 	asteroids "large metal" 1 6.8701
-	fleet Quarg 2000
+	fleet "Large Quarg" 2000
 	fleet "Small Kor Mereti" 9400
 	fleet "Large Kor Mereti" 5000
 	object
@@ -5621,7 +5622,7 @@ system Feroteri
 	asteroids "small metal" 3 3.081
 	asteroids "medium metal" 12 5.265
 	asteroids "large metal" 11 4.758
-	fleet Quarg 3000
+	fleet "Large Quarg" 3000
 	fleet "Small Kor Mereti" 12000
 	fleet "Large Kor Mereti" 6400
 	object
@@ -5842,7 +5843,7 @@ system Fornarep
 	asteroids "small metal" 7 2.8224
 	asteroids "medium metal" 11 3.2928
 	asteroids "large metal" 13 4.5024
-	fleet Quarg 2000
+	fleet "Large Quarg" 2000
 	fleet "Small Kor Mereti" 9000
 	fleet "Large Kor Mereti" 5800
 	object
@@ -5889,7 +5890,7 @@ system Furmeliki
 	link Kashikt
 	link Skeruto
 	asteroids "large metal" 1 3.5511
-	fleet Quarg 1000
+	fleet "Large Quarg" 1000
 	object
 		sprite star/k0
 		period 10
@@ -6749,7 +6750,7 @@ system Hesselpost
 	asteroids "small metal" 83 2.366
 	asteroids "medium metal" 93 1.0985
 	asteroids "large metal" 89 1.7407
-	fleet Quarg 1000
+	fleet "Large Quarg" 1000
 	object
 		sprite star/k0
 		period 10
@@ -7706,7 +7707,7 @@ system Kaliptari
 	asteroids "medium rock" 11 6.9498
 	asteroids "large rock" 25 5.4918
 	asteroids "large metal" 1 3.2562
-	fleet Quarg 3000
+	fleet "Large Quarg" 3000
 	fleet "Small Kor Mereti" 10000
 	fleet "Large Kor Mereti" 4800
 	object
@@ -7837,6 +7838,7 @@ system Kashikt
 	trade Metal 315
 	trade Plastic 438
 	fleet Quarg 1000
+	fleet "Large Quarg" 2000
 	fleet "Kor Efret Home" 1000
 	object
 		sprite star/f5
@@ -8571,7 +8573,7 @@ system Korsmanath
 	asteroids "medium rock" 1 2.5993
 	asteroids "large rock" 4 1.3277
 	asteroids "large metal" 2 1.6456
-	fleet Quarg 3000
+	fleet "Large Quarg" 3000
 	fleet "Small Kor Mereti" 8000
 	object
 		sprite star/k0
@@ -9370,7 +9372,7 @@ system Meftarkata
 	asteroids "large rock" 14 0.8892
 	asteroids "medium metal" 4 1.5288
 	asteroids "large metal" 1 1.9344
-	fleet Quarg 1000
+	fleet "Large Quarg" 1000
 	object
 		sprite star/f5
 		distance 21.8839
@@ -12373,7 +12375,7 @@ system Sabriset
 	asteroids "small metal" 21 4.374
 	asteroids "medium metal" 4 5.1435
 	asteroids "large metal" 7 4.3335
-	fleet Quarg 4000
+	fleet "Large Quarg" 4000
 	object
 		sprite star/g0
 		distance 35.1028
@@ -12998,7 +13000,7 @@ system Seketra
 	link Skeruto
 	link Chikatip
 	asteroids "large metal" 1 1.7556
-	fleet Quarg 3000
+	fleet "Large Quarg" 3000
 	object
 		sprite star/k5
 		period 10
@@ -13090,7 +13092,7 @@ system Sepriaptu
 	asteroids "small metal" 4 10.5
 	asteroids "medium metal" 53 6.23
 	asteroids "large metal" 1 9.24
-	fleet Quarg 4000
+	fleet "Large Quarg" 4000
 	object
 		sprite star/f5
 		distance 16.1966
@@ -13134,6 +13136,7 @@ system Sevrelect
 	trade Metal 207
 	trade Plastic 534
 	fleet Quarg 1000
+	fleet "Large Quarg" 3000
 	fleet "Kor Efret Home" 1000
 	object
 		sprite star/m0
@@ -13569,7 +13572,7 @@ system Skeruto
 	link Kaliptari
 	link Seketra
 	asteroids "large metal" 1 1.5554
-	fleet Quarg 2000
+	fleet "Large Quarg" 2000
 	object
 		sprite star/m0
 		period 10
@@ -13782,7 +13785,7 @@ system Solifar
 	asteroids "small metal" 2 7.134
 	asteroids "medium metal" 80 7.946
 	asteroids "large metal" 26 7.076
-	fleet Quarg 4000
+	fleet "Large Quarg" 4000
 	object
 		sprite star/m0
 		period 10
@@ -14059,6 +14062,7 @@ system Sumprast
 	trade Metal 236
 	trade Plastic 500
 	fleet Quarg 1000
+	fleet "Large Quarg" 2500
 	fleet "Kor Efret Home" 1000
 	object
 		sprite star/k0

--- a/data/map.txt
+++ b/data/map.txt
@@ -16081,7 +16081,7 @@ planet Alfheim
 planet Allhome
 	attributes hai
 	landscape land/dmottl0
-	description `This earthlike planet has been settled both by human beings and by the Hai, the species that controls this region of space. The human settlements are relatively small, mostly farming communities founded by people who came here to escape the chaos and uncertainty of human space.`
+	description `This Earth-like planet has been settled both by human beings and by the Hai, the species that controls this region of space. The human settlements are relatively small, mostly farming communities founded by people who came here to escape the chaos and uncertainty of human space.`
 	spaceport `In the spaceport, a handful of human merchants and colonists wander about amid throngs of Hai - vaguely squirrel-like aliens who are somewhat shorter than the average human being, but make up for it with an abundance of energy. You feel a little bit like an adult wading through a sea of hyperactive children as you try to locate the commodity exchange and the other services offered here.`
 	outfitter "Hai Basics"
 
@@ -17093,7 +17093,7 @@ planet Hope
 planet Hopper
 	attributes "dirt belt" mining
 	landscape land/myrabella1
-	description `Hopper is a temperate world of oceans, mountains, and plains, but with unfortunately high levels of sulfuric acid in its atmosphere. Metal and stone that are exposed to the atmosphere corrode quickly, requiring frequent maintenance. As a result, Hopper has only a few small settlements on it, and most of the industry is focused on underground mining. The oceans are populated only by a few indigenous life forms that have adapted to their high acidity; earth fish could not be introduced successfully here.`
+	description `Hopper is a temperate world of oceans, mountains, and plains, but with unfortunately high levels of sulfuric acid in its atmosphere. Metal and stone that are exposed to the atmosphere corrode quickly, requiring frequent maintenance. As a result, Hopper has only a few small settlements on it, and most of the industry is focused on underground mining. The oceans are populated only by a few indigenous life forms that have adapted to their high acidity; Earth fish could not be introduced successfully here.`
 	spaceport `The spaceport consists mostly of a cluster of steel-framed warehouses with tin roofs, surrounded by concrete slabs for ships to land on. Scattered among the warehouses are a few smaller wooden buildings, housing a pub, a restaurant, and a small inn. Some of the warehouses are relatively new, with metal that still gleams; others are covered in rust, and a few stand in ruins, with large holes worn through their roofs and rusted girders poking through like dead trees.`
 	outfitter "Ammo South"
 	security 0.05
@@ -18138,7 +18138,7 @@ planet Shiver
 planet Shorebreak
 	attributes rim research medical
 	landscape land/beach1
-	description `Shorebreak is an ocean world which is home to a stunning profusion of alien life, some of which is not too dissimilar from life on earth. The first settlement, centuries ago, was built as a marine biology laboratory, and from there the planet gradually grew into a regional center for bioengineering, where local life forms are tested for possible use in human medicine.`
+	description `Shorebreak is an ocean world which is home to a stunning profusion of alien life, some of which is not too dissimilar from life on Earth. The first settlement, centuries ago, was built as a marine biology laboratory, and from there the planet gradually grew into a regional center for bioengineering, where local life forms are tested for possible use in human medicine.`
 	description `	Outside the laboratories, much of the planet's land mass remains in its natural state, but the planet is currently struggling with a large increase in immigration.`
 	spaceport `The spaceport on Shorebreak is built on its own separate island, perhaps as a way to keep any contamination isolated from the main continents. The hangar where you were directed to land your ship was hermetically sealed before you were allowed to land, and the customs officer informs you that any cargo you wish to trade must first be screened for "rats, mice, invasive insects, or wild pigs."`
 	"required reputation" 2

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -123,6 +123,7 @@ person "Cap'n Pester"
 			"Intrusion Countermeasures" 160
 			"Cargo Scanner"
 			"Outfit Scanner"
+			"Wanderer Ramscoop"
 		
 			"Medium Graviton Thruster"
 			"Medium Graviton Steering"

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2592,6 +2592,7 @@ ship "Marauder Fury"
 		"outfit space" 240
 		"weapon capacity" 80
 		"engine capacity" 100
+		"ramscoop" 2
 		weapon
 			"blast radius" 36
 			"shield damage" 360

--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -217,7 +217,7 @@ ship "Strong Wind"
 	gun 32 57 "Thunderhead Launcher"
 	explode "small explosion" 60
 	explode "medium explosion" 40
-	explode "large explosion" 20
+	explode "big explosion" 20
 	"final explode" "final explosion medium"
 	description "The Strong Wind is a Wanderer warship, an ancient design that they make use of only on the rare occasions when they find it necessary to defend themselves."
 
@@ -268,7 +268,7 @@ ship "Deep River"
 	gun 56 -217
 	explode "small explosion" 80
 	explode "medium explosion" 60
-	explode "large explosion" 30
+	explode "big explosion" 30
 	explode "huge explosion" 20
 	"final explode" "final explosion large"
 	description "The Deep River is a bulk freighter, designed to carry cargo in detachable pods."

--- a/endless-sky.6
+++ b/endless-sky.6
@@ -1,4 +1,4 @@
-.TH endless\-sky 6 "27 May 2016" "ver. 0.9.1" "Endless Sky"
+.TH endless\-sky 6 "24 Jun 2016" "ver. 0.9.2" "Endless Sky"
 
 .SH NAME
 endless\-sky \- a space exploration and combat game.

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -245,6 +245,9 @@ void Account::AddBonus(int64_t bonus)
 
 void Account::AddMissionDebt(int64_t principal, double interest, int term)
 {
+	// An interest of 0 isn't a loan, use the player's creditScore
+	if(!interest)
+		interest = (600 - creditScore / 2) * .00001;
 	mortgages.emplace_back(principal, interest, term, "Mission");
 }
 

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -243,6 +243,11 @@ void Account::AddBonus(int64_t bonus)
 	mortgages.emplace_back(bonus, 1000, 60);
 }
 
+void Account::AddMissionDebt(int64_t principal, double interest, int term)
+{
+	mortgages.emplace_back(principal, interest, term, "Mission");
+}
+
 
 
 int64_t Account::Prequalify() const

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -245,8 +245,8 @@ void Account::AddBonus(int64_t bonus)
 
 void Account::AddMissionDebt(int64_t principal, double interest, int term)
 {
-	// An interest of 0 isn't a loan, use the player's creditScore
-	if(!interest)
+	// A negative isn't a debt, use the player's creditScore
+	if(interest < 0.)
 		interest = (600 - creditScore / 2) * .00001;
 	mortgages.emplace_back(principal, interest, term, "Mission");
 }

--- a/source/Account.h
+++ b/source/Account.h
@@ -48,6 +48,7 @@ public:
 	void AddMortgage(int64_t principal);
 	void AddFine(int64_t amount);
 	void AddBonus(int64_t bonus);
+	void AddMissionDebt(int64_t principal, double interest, int term);
 	int64_t Prequalify() const;
 	// Assets:
 	int64_t NetWorth() const;

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -120,7 +120,7 @@ void BoardingPanel::Draw() const
 		info.SetCondition("can take");
 	if(CanCapture())
 		info.SetCondition("can capture");
-	if(CanAttack() && you->Crew() > 1)
+	if(CanAttack() && (you->Crew() > 1 || !victim->RequiredCrew()))
 		info.SetCondition("can attack");
 	if(CanAttack())
 		info.SetCondition("can defend");
@@ -259,7 +259,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		int enemyStartCrew = victim->Crew();
 		
 		// Figure out what action the other ship will take.
-		bool youAttack = (key == 'a' && yourStartCrew > 1);
+		bool youAttack = (key == 'a' && (yourStartCrew > 1 || !victim->RequiredCrew()));
 		bool enemyAttacks = defenseOdds.Odds(enemyStartCrew, yourStartCrew) > .5;
 		if(isFirstCaptureAction && !youAttack)
 			enemyAttacks = false;

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -35,7 +35,6 @@ Fleet::Fleet()
 {
 	government = GameData::Governments().Get("Merchant");
 	names = GameData::Phrases().Get("civilian");
-	fighterNames = GameData::Phrases().Get("deep fighter");
 }
 
 
@@ -89,118 +88,100 @@ const Government *Fleet::GetGovernment() const
 
 void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Planet *planet) const
 {
-	if(!total || !government)
+	if(!total || !government || variants.empty())
 		return;
 	
-	// Pick a random variant based on the weights.
-	unsigned index = 0;
-	for(int choice = Random::Int(total); choice >= variants[index].weight; ++index)
-		choice -= variants[index].weight;
-	
-	if(variants[index].ships.empty())
+	// Pick a fleet variant to instantiate.
+	const Variant &variant = ChooseVariant();
+	if(variant.ships.empty())
 		return;
 	
-	bool isEnemy = system.GetGovernment()->IsEnemy(government);
-	bool hasJump = variants[index].ships.front()->Attributes().Get("jump drive");
+	// Where this ship can come from depends on whether it is friendly to any
+	// planets in this system and whether it has a jump drive.
+	bool hasJump = variant.ships.front()->Attributes().Get("jump drive");
 	const vector<const System *> &linkVector = hasJump ? system.Neighbors() : system.Links();
-	int links = linkVector.size();
-	// Count the inhabited planets in this system.
-	int planets = 0;
-	if(!isEnemy && !personality.IsSurveillance())
-		for(const StellarObject &object : system.Objects())
-			if(object.GetPlanet() && object.GetPlanet()->HasSpaceport())
-				++planets;
 	
-	if(!(links + planets))
+	// Find all the inhabited planets this fleet could take off from.
+	vector<const Planet *> planetVector;
+	if(!personality.IsSurveillance())
+		for(const StellarObject &object : system.Objects())
+			if(object.GetPlanet() && object.GetPlanet()->HasSpaceport()
+					&& !object.GetPlanet()->GetGovernment()->IsEnemy(government))
+				planetVector.push_back(object.GetPlanet());
+	
+	// If there is nowhere for this fleet to come from, don't create it.
+	size_t options = linkVector.size() + planetVector.size();
+	if(!options)
 		return;
 	
-	int choice = Random::Int(links + planets);
+	// Choose a random planet or star system to come from.
+	size_t choice = Random::Int(options);
 	
+	// Figure out what system the ship is starting in, where it is going, and
+	// what position it should start from in the system.
 	const System *source = &system;
 	const System *target = &system;
 	Point position;
-	unsigned radius = 0;
+	double radius = 0.;
 	
+	// If a planet is chosen, also pick a system to travel to after taking off.
+	if(choice >= linkVector.size())
+	{
+		planet = planetVector[choice - linkVector.size()];
+		if(!linkVector.empty())
+			target = linkVector[Random::Int(linkVector.size())];
+	}
+	
+	// Find the stellar object for the given planet, and place the ships there.
 	if(planet)
 	{
 		for(const StellarObject &object : system.Objects())
 			if(object.GetPlanet() == planet)
 			{
 				position = object.Position();
-				radius = max(0, static_cast<int>(object.Radius()));
+				radius = object.Radius();
 				break;
 			}
 	}
-	else if(choice >= links)
+	else if(choice < linkVector.size())
 	{
-		choice -= links;
-		
-		planets = 0;
-		for(const StellarObject &object : system.Objects())
-			if(object.GetPlanet() && object.GetPlanet()->HasSpaceport())
-			{
-				if(planets++ != choice)
-					continue;
-				
-				position = object.Position();
-				planet = object.GetPlanet();
-				radius = max(0, static_cast<int>(object.Radius()));
-				break;
-			}
-		if(links)
-			target = linkVector[Random::Int(links)];
-	}
-	else
-	{
-		radius = 1000;
+		// We are entering this system via hyperspace, not taking off from a planet.
+		radius = 1000.;
 		source = linkVector[choice];
 	}
 	
-	vector<shared_ptr<Ship>> placed;
-	for(const Ship *ship : variants[index].ships)
+	// Place all the ships in the chosen fleet variant.
+	shared_ptr<Ship> flagship;
+	vector<shared_ptr<Ship>> placed = Instantiate(variant);
+	for(shared_ptr<Ship> &ship : placed)
 	{
-		if(ship->ModelName().empty())
-		{
-			Files::LogError("Skipping unknown ship in fleet \"" + fleetName + "\".");
+		// If this is a fighter and someone can carry it, no need to position it.
+		if(PlaceFighter(ship, placed))
 			continue;
-		}
-		if(ship->CanBeCarried())
-		{
-			shared_ptr<Ship> fighter(new Ship(*ship));
-			fighter->SetGovernment(government);
-			fighter->SetName((fighterNames ? fighterNames : names)->Get());
-			fighter->SetPersonality(personality);
-			for(const shared_ptr<Ship> &parent : placed)
-				if(parent->Carry(fighter))
-					break;
-			continue;
-		}
-		Angle angle = Angle::Random(360.);
-		Point pos = position + angle.Unit() * (Random::Int(radius + 1));
 		
-		ships.push_front(shared_ptr<Ship>(new Ship(*ship)));
-		ships.front()->SetSystem(source);
-		ships.front()->SetPlanet(planet);
+		Angle angle = Angle::Random(360.);
+		Point pos = position + angle.Unit() * (Random::Real() * radius);
+		
+		ships.push_front(ship);
+		ship->SetSystem(source);
+		ship->SetPlanet(planet);
 		if(source == &system)
-			ships.front()->Place(pos, angle.Unit(), angle);
+			ship->Place(pos, angle.Unit(), angle);
 		else
 		{
 			Point offset = system.Position() - source->Position();
 			angle = TO_DEG * atan2(offset.X(), -offset.Y());
-			ships.front()->Place(pos, Point(), angle);
+			ship->Place(pos, Point(), angle);
 		}
 		if(target != source)
-			ships.front()->SetTargetSystem(target);
-		ships.front()->SetGovernment(government);
-		ships.front()->SetName(names->Get());
-		ships.front()->SetPersonality(personality);
+			ship->SetTargetSystem(target);
 		
-		if(!placed.empty())
-			ships.front()->SetParent(placed.front());
+		if(flagship)
+			ship->SetParent(flagship);
+		else
+			flagship = ship;
 		
-		placed.push_back(ships.front());
-		
-		SetCargo(&*ships.front());
+		SetCargo(&*ship);
 	}
 }
 
@@ -209,73 +190,40 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 // Place a fleet in the given system, already "in action."
 void Fleet::Place(const System &system, list<shared_ptr<Ship>> &ships, bool carried) const
 {
-	if(!total || !government)
+	if(!total || !government || variants.empty())
 		return;
 	
-	// Pick a random variant based on the weights.
-	unsigned index = 0;
-	for(int choice = Random::Int(total); choice >= variants[index].weight; ++index)
-		choice -= variants[index].weight;
-	
-	// Count the inhabited planets in this system.
-	int planets = 0;
-	for(const StellarObject &object : system.Objects())
-		if(object.GetPlanet() && object.GetPlanet()->HasSpaceport())
-			++planets;
+	// Pick a fleet variant to instantiate.
+	const Variant &variant = ChooseVariant();
+	if(variant.ships.empty())
+		return;
 	
 	// Determine where the fleet is going to or coming from.
-	Point center;
-	if(planets)
-	{
-		int index = Random::Int(planets);
-		for(const StellarObject &object : system.Objects())
-			if(object.GetPlanet() && object.GetPlanet()->HasSpaceport())
-				if(!index--)
-					center = object.Position();
-	}
+	Point center = ChooseCenter(system);
 	
-	vector<shared_ptr<Ship>> placed;
-	for(const Ship *ship : variants[index].ships)
+	// Place all the ships in the chosen fleet variant.
+	shared_ptr<Ship> flagship;
+	vector<shared_ptr<Ship>> placed = Instantiate(variant);
+	for(shared_ptr<Ship> &ship : placed)
 	{
-		if(ship->ModelName().empty())
-		{
-			Files::LogError("Skipping unknown ship in fleet \"" + fleetName + "\".");
+		// If this is a fighter and someone can carry it, no need to position it.
+		if(carried && PlaceFighter(ship, placed))
 			continue;
-		}
-		if(carried && ship->CanBeCarried())
-		{
-			shared_ptr<Ship> fighter(new Ship(*ship));
-			fighter->SetGovernment(government);
-			fighter->SetName((fighterNames ? fighterNames : names)->Get());
-			fighter->SetPersonality(personality);
-			bool isCarried = false;
-			for(const shared_ptr<Ship> &parent : placed)
-				if(parent->Carry(fighter))
-				{
-					isCarried = true;
-					break;
-				}
-			if(isCarried)
-				continue;
-		}
+		
 		Angle angle = Angle::Random();
 		Point pos = center + Angle::Random().Unit() * Random::Real() * 400.;
-		
 		double velocity = Random::Real() * ship->MaxVelocity();
 		
-		ships.push_front(shared_ptr<Ship>(new Ship(*ship)));
-		ships.front()->SetSystem(&system);
-		ships.front()->Place(pos, velocity * angle.Unit(), angle);
-		ships.front()->SetGovernment(government);
-		ships.front()->SetName(names->Get());
-		ships.front()->SetPersonality(personality);
+		ships.push_front(ship);
+		ship->SetSystem(&system);
+		ship->Place(pos, velocity * angle.Unit(), angle);
 		
-		if(!placed.empty())
-			ships.front()->SetParent(placed.front());
+		if(flagship)
+			ship->SetParent(flagship);
+		else
+			flagship = ship;
 		
-		placed.push_back(ships.front());
-		
-		SetCargo(&*ships.front());
+		SetCargo(&*ship);
 	}
 }
 
@@ -303,25 +251,8 @@ void Fleet::Enter(const System &system, Ship &ship)
 
 void Fleet::Place(const System &system, Ship &ship)
 {
-	// Count the inhabited planets in this system.
-	int planets = 0;
-	for(const StellarObject &object : system.Objects())
-		if(object.GetPlanet() && object.GetPlanet()->HasSpaceport())
-			++planets;
-	
-	// Determine where the fleet is going to or coming from.
-	Point center;
-	if(planets)
-	{
-		int index = Random::Int(planets);
-		for(const StellarObject &object : system.Objects())
-			if(object.GetPlanet() && object.GetPlanet()->HasSpaceport())
-				if(!index--)
-					center = object.Position();
-	}
-	
 	// Move out a random distance from that object, facing toward it or away.
-	Point pos = center + Angle::Random().Unit() * Random::Real() * 400.;
+	Point pos = ChooseCenter(system) + Angle::Random().Unit() * Random::Real() * 400.;
 	
 	double velocity = Random::Real() * ship.MaxVelocity();
 	
@@ -347,6 +278,86 @@ int64_t Fleet::Strength() const
 
 
 
+Fleet::Variant::Variant(const DataNode &node)
+{
+	weight = (node.Size() < 2) ? 1 : static_cast<int>(node.Value(1));
+	
+	for(const DataNode &child : node)
+	{
+		int n = 1;
+		if(child.Size() > 1 && child.Value(1) >= 1.)
+			n = static_cast<int>(child.Value(1));
+		ships.insert(ships.end(), n, GameData::Ships().Get(child.Token(0)));
+	}
+}
+
+
+
+const Fleet::Variant &Fleet::ChooseVariant() const
+{
+	// Pick a random variant based on the weights.
+	unsigned index = 0;
+	for(int choice = Random::Int(total); choice >= variants[index].weight; ++index)
+		choice -= variants[index].weight;
+	
+	return variants[index];
+}
+
+
+
+Point Fleet::ChooseCenter(const System &system)
+{
+	vector<Point> centers;
+	for(const StellarObject &object : system.Objects())
+		if(object.GetPlanet() && object.GetPlanet()->HasSpaceport())
+			centers.push_back(object.Position());
+	
+	if(centers.empty())
+		return Point();
+	return centers[Random::Int(centers.size())];
+}
+
+
+
+vector<shared_ptr<Ship>> Fleet::Instantiate(const Variant &variant) const
+{
+	vector<shared_ptr<Ship>> placed;
+	for(const Ship *model : variant.ships)
+	{
+		if(model->ModelName().empty())
+		{
+			Files::LogError("Skipping unknown ship in fleet \"" + fleetName + "\".");
+			continue;
+		}
+		
+		shared_ptr<Ship> ship(new Ship(*model));
+		
+		bool isFighter = ship->CanBeCarried();
+		ship->SetName(((isFighter && fighterNames) ? fighterNames : names)->Get());
+		ship->SetGovernment(government);
+		ship->SetPersonality(personality);
+		
+		placed.push_back(ship);
+	}
+	return placed;
+}
+
+
+
+bool Fleet::PlaceFighter(shared_ptr<Ship> fighter, vector<shared_ptr<Ship>> &placed) const
+{
+	if(!fighter->CanBeCarried())
+		return false;
+	
+	for(const shared_ptr<Ship> &parent : placed)
+		if(parent->Carry(fighter))
+			return true;
+	
+	return false;
+}
+
+
+
 void Fleet::SetCargo(Ship *ship) const
 {
 	for(int i = 0; i < cargo; ++i)
@@ -363,19 +374,4 @@ void Fleet::SetCargo(Ship *ship) const
 	int extraCrew = ship->Attributes().Get("bunks") - ship->RequiredCrew();
 	if(extraCrew > 0)
 		ship->AddCrew(Random::Int(extraCrew + 1));
-}
-
-
-
-Fleet::Variant::Variant(const DataNode &node)
-{
-	weight = (node.Size() < 2) ? 1 : static_cast<int>(node.Value(1));
-	
-	for(const DataNode &child : node)
-	{
-		int n = 1;
-		if(child.Size() > 1 && child.Value(1) >= 1.)
-			n = static_cast<int>(child.Value(1));
-		ships.insert(ships.end(), n, GameData::Ships().Get(child.Token(0)));
-	}
 }

--- a/source/Fleet.h
+++ b/source/Fleet.h
@@ -56,10 +56,6 @@ public:
 	
 	
 private:
-	void SetCargo(Ship *ship) const;
-	
-	
-private:
 	class Variant {
 	public:
 		Variant(const DataNode &node);
@@ -67,6 +63,14 @@ private:
 		int weight;
 		std::vector<const Ship *> ships;
 	};
+	
+	
+private:
+	const Variant &ChooseVariant() const;
+	static Point ChooseCenter(const System &system);
+	std::vector<std::shared_ptr<Ship>> Instantiate(const Variant &variant) const;
+	bool PlaceFighter(std::shared_ptr<Ship> fighter, std::vector<std::shared_ptr<Ship>> &placed) const;
+	void SetCargo(Ship *ship) const;
 	
 	
 private:

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -46,7 +46,7 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 	hasLanguage = (gov->Language().empty() || player.GetCondition("language: " + gov->Language()));
 	
 	if(gov->GetName() == "Derelict")
-		message = "There is no response to your hail.";
+		message = "(There is no response to your hail.)";
 	else if(!hasLanguage)
 		message = "(An alien voice says something in a language you do not recognize.)";
 	else if(gov->IsEnemy())
@@ -86,6 +86,12 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 			canRepair = true;
 		}
 		
+		if(ship->GetPersonality().IsSurveillance())
+		{
+			canGiveFuel = false;
+			canRepair = false;
+		}
+			
 		if(canGiveFuel || canRepair)
 			message = "Looks like you've gotten yourself into a bit of trouble. "
 				"Would you like us to ";
@@ -237,7 +243,9 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			return false;
 		if(playerNeedsHelp)
 		{
-			if(canGiveFuel || canRepair)
+			if(ship->GetPersonality().IsSurveillance())
+				message = "Sorry, I'm too busy to help you right now.";
+			else if(canGiveFuel || canRepair)
 			{
 				ship->SetShipToAssist(player.FlagshipPtr());
 				message = "Hang on, we'll be there in a minute.";

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -261,7 +261,7 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		if(!hasLanguage)
 			return true;
 		// Make sure it actually makes sense to bribe this ship.
-		if(ship && (!shipIsEnemy || ship->GetGovernment()->GetName() == "Derelict"))
+		if((ship && (!shipIsEnemy || ship->GetGovernment()->GetName() == "Derelict")) || (planet && planet->CanLand()))
 			return true;
 		
 		if(bribe > player.Accounts().Credits())

--- a/source/ItemInfoDisplay.cpp
+++ b/source/ItemInfoDisplay.cpp
@@ -93,7 +93,7 @@ void ItemInfoDisplay::DrawTooltips() const
 	if(!hoverCount || hoverCount-- < HOVER_TIME || !hoverText.Height())
 		return;
 	
-	Point textSize(hoverText.WrapWidth(), hoverText.Height());
+	Point textSize(hoverText.WrapWidth(), hoverText.Height() - hoverText.ParagraphBreak());
 	Point boxSize = textSize + Point(20., 20.);
 	
 	Point topLeft = hoverPoint;

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -134,8 +134,10 @@ void MainPanel::Step()
 		const Government *actor = event.ActorGovernment();
 		
 		player.HandleEvent(event, GetUI());
-		if((event.Type() & (ShipEvent::BOARD | ShipEvent::ASSIST)) && isActive && actor->IsPlayer())
+		if((event.Type() & (ShipEvent::BOARD | ShipEvent::ASSIST)) && isActive && actor->IsPlayer()
+				&& event.Actor().get() == player.Flagship())
 		{
+			// Boarding events are only triggered by your flagship.
 			Mission *mission = player.BoardingMission(event.Target());
 			if(mission)
 				mission->Do(Mission::OFFER, player, GetUI());

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -152,7 +152,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 		{
 			if(child.Size() >= 2)
 				debt = child.Value(1);
-			if(child.Size() >= 3)
+			if(child.Size() >= 3 && !(child.Token(2) == "rating"))
 				interest = child.Value(2);
 			if(child.Size() >= 4)
 				term = child.Value(3);

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -219,12 +219,9 @@ int MissionAction::Payment() const
 
 
 // Check if this action can be completed right now. It cannot be completed
-// if it takes away money or outfits that the player does not have.
+// if it takes away outfits that the player does not have.
 bool MissionAction::CanBeDone(const PlayerInfo &player) const
 {
-	//if(player.Accounts().Credits() < -payment)
-		//return false;
-	
 	const Ship *flagship = player.Flagship();
 	for(const auto &it : gifts)
 	{
@@ -288,16 +285,11 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination) co
 	{
 		if (payment < 0 && (player.Accounts().Credits() < -payment))
 		{
-			// We want mortgage rates but not mortgage credits
 			player.Accounts().AddMortgage(-payment);
-			player.Accounts().AddCredits(payment);
 			
-			string message;
-			message = "You were unable to afford fees for this mission and they have been deferred to your Bank.";
-			Messages::Add(message);
+			Messages::Add("You were unable to afford fees for this mission and they have been deferred to your Bank.");
 		}
-		else
-			player.Accounts().AddCredits(payment);
+		player.Accounts().AddCredits(payment);
 	}
 	
 	for(const auto &it : events)

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -222,8 +222,8 @@ int MissionAction::Payment() const
 // if it takes away money or outfits that the player does not have.
 bool MissionAction::CanBeDone(const PlayerInfo &player) const
 {
-	if(player.Accounts().Credits() < -payment)
-		return false;
+	//if(player.Accounts().Credits() < -payment)
+		//return false;
 	
 	const Ship *flagship = player.Flagship();
 	for(const auto &it : gifts)
@@ -285,7 +285,20 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination) co
 			DoGift(player, it.first, it.second, ui);
 	
 	if(payment)
-		player.Accounts().AddCredits(payment);
+	{
+		if (payment < 0 && (player.Accounts().Credits() < -payment))
+		{
+			// We want mortgage rates but not mortgage credits
+			player.Accounts().AddMortgage(-payment);
+			player.Accounts().AddCredits(payment);
+			
+			string message;
+			message = "You were unable to afford fees for this mission and they have been deferred to your Bank.";
+			Messages::Add(message);
+		}
+		else
+			player.Accounts().AddCredits(payment);
+	}
 	
 	for(const auto &it : events)
 		player.AddEvent(*GameData::Events().Get(it.first), player.GetDate() + it.second);

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -57,6 +57,10 @@ public:
 	// destination, payment, cargo, etc.
 	MissionAction Instantiate(std::map<std::string, std::string> &subs, int jumps, int payload) const;
 	
+	void MissionDebt(const std::string &bleh, double bloo) const;
+	void MissionDebt(const std::string &bleh, double bloo, double bah) const;
+	
+		
 	
 private:
 	std::string trigger;

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -72,7 +72,7 @@ private:
 	int payment = 0;
 	int paymentMultiplier = 0;
 	int debt = 0;
-	double interest = 0.004;
+	double interest = -1.;
 	int term = 365;
 	
 	// When this action is performed, the missions with these names fail.

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -57,10 +57,6 @@ public:
 	// destination, payment, cargo, etc.
 	MissionAction Instantiate(std::map<std::string, std::string> &subs, int jumps, int payload) const;
 	
-	void MissionDebt(const std::string &bleh, double bloo) const;
-	void MissionDebt(const std::string &bleh, double bloo, double bah) const;
-	
-		
 	
 private:
 	std::string trigger;
@@ -75,6 +71,9 @@ private:
 	std::map<const Outfit *, int> gifts;
 	int payment = 0;
 	int paymentMultiplier = 0;
+	int debt = 0;
+	double interest = 0.4;
+	int term = 365;
 	
 	// When this action is performed, the missions with these names fail.
 	std::set<std::string> fail;

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -72,7 +72,7 @@ private:
 	int payment = 0;
 	int paymentMultiplier = 0;
 	int debt = 0;
-	double interest = 0.4;
+	double interest = 0.004;
 	int term = 365;
 	
 	// When this action is performed, the missions with these names fail.

--- a/source/Mortgage.cpp
+++ b/source/Mortgage.cpp
@@ -49,6 +49,17 @@ Mortgage::Mortgage(int64_t principal, int creditScore, int term)
 {
 }
 
+// This lets you specify the type of mortgage so prefer to make a function to
+// use this instead of using it directly. e.g. Account::AddMissionDebt
+Mortgage::Mortgage(int64_t principal, double interest, int term, const string &type)
+	: type(type),
+	principal(principal),
+	interest(interest),
+	interestString("0." + to_string(static_cast<int>(interest * 100000)) + "%"),
+	term(term)
+{
+}
+
 
 
 // Load or save mortgage data.

--- a/source/Mortgage.h
+++ b/source/Mortgage.h
@@ -37,6 +37,8 @@ public:
 	// credit score to zero for a higher interest rate.
 	Mortgage(int64_t principal, int creditScore, int term = 365);
 	
+	Mortgage(int64_t principal, double interest, int term, const std::string &type);
+
 	// Load or save mortgage data.
 	void Load(const DataNode &node);
 	void Save(DataWriter &out) const;

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -722,7 +722,7 @@ void OutfitterPanel::CheckRefill()
 		for(const Outfit *outfit : toRefill)
 		{
 			int amount = ship->Attributes().CanAdd(*outfit, 1000000);
-			if(amount)
+			if(amount && HasItem(outfit->Name()))
 				needed[outfit] += amount;
 		}
 	}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -198,7 +198,7 @@ void PlayerInfo::Load(const string &path)
 	
 	// Strip anything after the "~" from snapshots, so that the file we save
 	// will be the auto-save, not the snapshot.
-	size_t pos = filePath.rfind('~');
+	size_t pos = filePath.find('~');
 	size_t namePos = filePath.length() - Files::Name(filePath).length();
 	if(pos != string::npos && pos > namePos)
 		filePath = filePath.substr(0, pos) + ".txt";

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -131,9 +131,8 @@ bool Politics::CanLand(const Ship &ship, const Planet *planet) const
 		return true;
 	
 	const Government *gov = ship.GetGovernment();
-	const Government *systemGov = planet->GetGovernment();
 	if(!gov->IsPlayer())
-		return !IsEnemy(gov, systemGov);
+		return !IsEnemy(gov, planet->GetGovernment());
 	
 	return CanLand(planet);
 }

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -147,10 +147,10 @@ bool Politics::CanLand(const Planet *planet) const
 		return true;
 	if(dominatedPlanets.count(planet))
 		return true;
-	if(provoked.count(planet->GetGovernment()))
-		return false;
 	if(bribedPlanets.count(planet))
 		return true;
+	if(provoked.count(planet->GetGovernment()))
+		return false;
 	
 	return Reputation(planet->GetGovernment()) >= planet->RequiredReputation();
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1106,7 +1106,11 @@ bool Ship::Move(list<Effect> &effects, list<Flotsam> &flotsam)
 	// Boarding:
 	if(isBoarding && (commands.Has(Command::FORWARD | Command::BACK) || commands.Turn()))
 		isBoarding = false;
-	shared_ptr<const Ship> target = (CanBeCarried() ? GetParent() : GetTargetShip());
+	shared_ptr<const Ship> target = GetTargetShip();
+	// If this is a fighter or drone and it is not assisting someone at the
+	// moment, its boarding target should be its parent ship.
+	if(CanBeCarried() && !(target && target == GetShipToAssist()))
+		target = GetParent();
 	if(target && !isDisabled)
 	{
 		Point dp = (target->position - position);

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -119,6 +119,10 @@ void ShipInfoDisplay::UpdateDescription(const Ship &ship)
 		string text = ship.Description() + "\tTo purchase this ship you must have ";
 		for(unsigned i = 0; i < licenses.size(); ++i)
 		{
+			bool isVoweled = false;
+			for(const char &c : "aeiou")
+				if(*licenses[i].begin() == c || *licenses[i].begin() == toupper(c))
+					isVoweled = true;
 			if(i)
 			{
 				if(licenses.size() > 2)
@@ -128,7 +132,8 @@ void ShipInfoDisplay::UpdateDescription(const Ship &ship)
 			}
 			if(i && i == licenses.size() - 1)
 				text += "and ";
-			text += "a " + licenses[i] + " License";
+			text += (isVoweled ? "an " : "a ") + licenses[i] + " License";
+
 		}
 		text += ".";
 		ItemInfoDisplay::UpdateDescription(text);

--- a/source/WrappedText.cpp
+++ b/source/WrappedText.cpp
@@ -286,7 +286,7 @@ void WrappedText::Wrap()
 	}
 	AdjustLine(lineBegin, lineWidth, true);
 	
-	height = word.y - paragraphBreak;
+	height = word.y;
 }
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -365,7 +365,7 @@ void PrintHelp()
 void PrintVersion()
 {
 	cerr << endl;
-	cerr << "Endless Sky 0.9.1" << endl;
+	cerr << "Endless Sky 0.9.2" << endl;
 	cerr << "License GPLv3+: GNU GPL version 3 or later: <https://gnu.org/licenses/gpl.html>" << endl;
 	cerr << "This is free software: you are free to change and redistribute it." << endl;
 	cerr << "There is NO WARRANTY, to the extent permitted by law." << endl;


### PR DESCRIPTION
re: https://github.com/endless-sky/endless-sky/issues/1216

Allowed mission triggers to use more credits than you have but if they do they apply a mortgage instead of subtracting credits. Decided against subtracting any credit if you can't afford it all so you have money to complete the mission if you need supplies.

I've tested this a fair bit but I don't typically make missions so it'd be great if someone could try it out in a few circumstances.