### PR TITLE
Value of dumped outfits missing message

### DIFF
--- a/source/InfoPanel.cpp
+++ b/source/InfoPanel.cpp
@@ -842,10 +842,15 @@ void InfoPanel::Dump()
 
 void InfoPanel::DumpPlunder(int count)
 {
+	int64_t loss = 0;
 	count = min(count, (*shipIt)->Cargo().Get(selectedPlunder));
 	if(count > 0)
 	{
+		loss += count * selectedPlunder->Cost();
 		(*shipIt)->Jettison(selectedPlunder, count);
 		info.Update(**shipIt);
+		
+		if(loss)
+			Messages::Add("You jettisoned " + Format::Number(loss) + " credits worth of cargo.");
 	}
 }


### PR DESCRIPTION
Dumping a specific number (>1) of outfits from cargo wasn't displaying the credit value of the dump because DumpPlunder is called for that instead of Dump and DumpPlunder doesn't have Message logic.

Tangentially there's a bit of code repetition between InfoPanel::Dump, InfoPanel::DumpPlunder, and the logic that fires them in InfoPanel::KeyDown. I'm not sure how best to reduce that due to the ui callbacks involved.