### PR TITLE
fixed ammo dialogue popping up regardless of availability

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -722,7 +722,7 @@ void OutfitterPanel::CheckRefill()
 		for(const Outfit *outfit : toRefill)
 		{
 			int amount = ship->Attributes().CanAdd(*outfit, 1000000);
-			if(amount)
+			if(amount && HasItem(outfit->Name()))
 				needed[outfit] += amount;
 		}
 	}


### PR DESCRIPTION
"Do you want to reload all the ammunition for your ship" message would pop up regardless of whether you could source the ammo while at that outfitter