### PR TITLE
find first ~ instead of last during pilot load

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -198,7 +198,7 @@ void PlayerInfo::Load(const string &path)
 	
 	// Strip anything after the "~" from snapshots, so that the file we save
 	// will be the auto-save, not the snapshot.
-	size_t pos = filePath.rfind('~');
+	size_t pos = filePath.find('~');
 	size_t namePos = filePath.length() - Files::Name(filePath).length();
 	if(pos != string::npos && pos > namePos)
 		filePath = filePath.substr(0, pos) + ".txt";


### PR DESCRIPTION
re: https://github.com/endless-sky/endless-sky/issues/1245
formatting of filePath with ~ in the snapshot name causing missing pilot info on load screen and sometimes pileup of ~ in snapshot names