### PR TITLE
can bribe but still not land on provoked planets

### DIFF
--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -261,12 +261,12 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		if(!hasLanguage)
 			return true;
 		// Make sure it actually makes sense to bribe this ship.
-		if(ship && (!shipIsEnemy || planet->CanLand() || ship->GetGovernment()->GetName() == "Derelict"))
+		if((ship && (!shipIsEnemy || ship->GetGovernment()->GetName() == "Derelict")) || (planet && planet->CanLand()))
 			return true;
 		
 		if(bribe > player.Accounts().Credits())
 			message = "Sorry, but you don't have enough money to be worth my while.";
-		else if(bribe)
+		else if(bribe && (ship || planet))
 		{
 			if(ship)
 			{

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -261,7 +261,7 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		if(!hasLanguage)
 			return true;
 		// Make sure it actually makes sense to bribe this ship.
-		if(ship && (!shipIsEnemy || ship->GetGovernment()->GetName() == "Derelict"))
+		if(ship && (!shipIsEnemy || planet->CanLand() || ship->GetGovernment()->GetName() == "Derelict"))
 			return true;
 		
 		if(bribe > player.Accounts().Credits())

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -266,7 +266,7 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		
 		if(bribe > player.Accounts().Credits())
 			message = "Sorry, but you don't have enough money to be worth my while.";
-		else if(bribe && (ship || planet))
+		else if(bribe)
 		{
 			if(ship)
 			{

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -147,10 +147,10 @@ bool Politics::CanLand(const Planet *planet) const
 		return true;
 	if(dominatedPlanets.count(planet))
 		return true;
-	if(provoked.count(planet->GetGovernment()))
-		return false;
 	if(bribedPlanets.count(planet))
 		return true;
+	if(provoked.count(planet->GetGovernment()))
+		return false;
 	
 	return Reputation(planet->GetGovernment()) >= planet->RequiredReputation();
 }


### PR DESCRIPTION
causing a planet to be temporarily hostile to you by provoking its government which was friendly causes bribes-to-land to be accepted but you're unable to land

swapped check to make bribes matter before provocation, the other option is making provoked governments not accept bribes
