### PR TITLE
disabled saving after death

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -189,6 +189,7 @@ interface "load menu"
 		size 14
 		color dim
 		align center
+	if "!pilot alive"
 	label "_Add Snapshot" -60 148
 		size 14
 		color dim
@@ -221,6 +222,7 @@ interface "load menu"
 	
 	button a -60 155
 		size 120 30
+	if "pilot alive"
 	label "_Add Snapshot" -60 148
 		size 14
 		color bright

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -78,6 +78,8 @@ void LoadPanel::Draw() const
 	
 	if(!selectedPilot.empty())
 		info.SetCondition("pilot selected");
+	if(!player.IsDead() && player.IsLoaded() && !selectedPilot.empty())
+		info.SetCondition("pilot alive");
 	if(selectedFile.find('~') != string::npos)
 		info.SetCondition("snapshot selected");
 	if(loadedInfo.IsLoaded())
@@ -219,7 +221,7 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			"Are you sure you want to delete the selected pilot, \""
 				+ selectedPilot + "\", and all their saved games?"));
 	}
-	else if(key == 'a')
+	else if(key == 'a' && !player.IsDead() && player.IsLoaded())
 	{
 		string wasSelected = selectedPilot;
 		auto it = files.find(selectedPilot);
@@ -231,11 +233,13 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 	}
 	else if(key == 'r' && !selectedFile.empty())
 	{
-		GetUI()->Push(new Dialog(this, &LoadPanel::DeleteSave,
-			"Are you sure you want to delete the selected saved game file, \""
-				+ selectedFile + "\"?"));
+		string fileName = selectedFile.substr(selectedFile.rfind('/') + 1);
+		if(!(fileName == selectedPilot + ".txt"))
+			GetUI()->Push(new Dialog(this, &LoadPanel::DeleteSave,
+				"Are you sure you want to delete the selected saved game file, \""
+					+ selectedFile + "\"?"));
 	}
-	else if(key == 'l' || key == 'e')
+	else if((key == 'l' || key == 'e') && !selectedPilot.empty())
 	{
 		// Is the selected file a snapshot or the pilot's main file?
 		string fileName = selectedFile.substr(selectedFile.rfind('/') + 1);


### PR DESCRIPTION
removed the ability to save a snapshot after you die
this could have made sense before autosave was in but it's extraneous now and is in the way of possible options like permadeath or possible hardcore modes

fixed being able to press load game when no save files exist
stopped add snapshot from being an option when no player is loaded
removed ability to delete main save file as is suggested by the greying of the ui