### PR TITLE
add check for park button visiblity, off for flagship and disabled ships

### DIFF
--- a/source/InfoPanel.cpp
+++ b/source/InfoPanel.cpp
@@ -160,14 +160,19 @@ void InfoPanel::Draw() const
 			
 			if(!allSelected.empty())
 			{
+				bool parkable = false;
 				allParked = true;
 				for(int i : allSelected)
 				{
 					const Ship &ship = *player.Ships()[i];
 					if(!ship.IsDisabled() && &ship != flagship)
+					{
 						allParked &= ship.IsParked();
+						parkable = true;
+					}
 				}
-				interfaceInfo.SetCondition(allParked ? "show unpark" : "show park");
+				if(parkable)
+					interfaceInfo.SetCondition(allParked ? "show unpark" : "show park");
 			}
 		}
 		interfaceInfo.SetCondition("two buttons");


### PR DESCRIPTION
https://github.com/endless-sky/endless-sky/issues/1266

unpark button was showing for flagship and disabled ships despite them being unable to park or unpark