### PR TITLE
fix flagship target system sticking on map

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -353,7 +353,11 @@ void MapPanel::Select(const System *system)
 	
 	bool shift = (SDL_GetModState() & KMOD_SHIFT) && !plan.empty();
 	if(system == playerSystem && !shift)
+	{
 		plan.clear();
+		if(player.Flagship())
+			player.Flagship()->SetTargetSystem(nullptr);
+	}
 	else if((distance.Distance(system) > 0 || shift) && player.Flagship())
 	{
 		if(shift)
@@ -372,6 +376,7 @@ void MapPanel::Select(const System *system)
 		else if(playerSystem)
 		{
 			plan.clear();
+			player.Flagship()->SetTargetSystem(nullptr);
 			while(system != playerSystem)
 			{
 				plan.push_back(system);


### PR DESCRIPTION
Engine.cpp sets the travel plan to the flagship's target if there isn't one so you couldn't truly clear your travel plan

clearing the travel plan in MapPanel::Select now clears the flagship target system as well

re: https://github.com/endless-sky/endless-sky/issues/1272
re: https://github.com/endless-sky/endless-sky/issues/744