### PR TITLE
fix ammo problems from negative CanAdd and mass change

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -329,16 +329,16 @@ int CargoHold::Transfer(const string &commodity, int amount, CargoHold *to)
 
 int CargoHold::Transfer(const Outfit *outfit, int amount, CargoHold *to)
 {
-	int mass = outfit->Get("mass");
+	double mass = outfit->Get("mass");
 	
 	amount = min(amount, Get(outfit));
 	if(size >= 0 && mass)
-		amount = max(amount, -max(Free(), 0) / mass);
+		amount = max(amount, static_cast<int>(-max(Free(), 0) / mass));
 	if(to)
 	{
 		amount = max(amount, -to->Get(outfit));
 		if(to->size >= 0 && mass)
-			amount = min(amount, max(to->Free(), 0) / mass);
+			amount = min(amount, static_cast<int>(max(to->Free(), 0) / mass));
 	}
 	if(!amount)
 		return 0;

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -617,7 +617,7 @@ bool OutfitterPanel::FlightCheck()
 
 bool OutfitterPanel::ShipCanBuy(const Ship *ship, const Outfit *outfit)
 {
-	return ship->Attributes().CanAdd(*outfit, 1);
+	return (ship->Attributes().CanAdd(*outfit, 1) > 0);
 }
 
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -722,7 +722,7 @@ void OutfitterPanel::CheckRefill()
 		for(const Outfit *outfit : toRefill)
 		{
 			int amount = ship->Attributes().CanAdd(*outfit, 1000000);
-			if(amount && HasItem(outfit->Name()))
+			if(amount > 0 && HasItem(outfit->Name()))
 				needed[outfit] += amount;
 		}
 	}


### PR DESCRIPTION
re: https://github.com/endless-sky/endless-sky/issues/1277

A better fix might be to have CanAdd restrict itself to positive numbers in the first place and have a CanRemove function for its counterpart but since both jobs are being done by CanAdd currently I don't know if that's desired, some people don't like too many functions all over the place.