### PR TITLE
fix, negative bunk space allowed hires

### DIFF
--- a/source/HiringPanel.cpp
+++ b/source/HiringPanel.cpp
@@ -98,7 +98,7 @@ void HiringPanel::Draw() const
 		info.SetString("modifier", "x " + to_string(modifier));
 	
 	maxFire = max(flagshipExtra, 0);
-	maxHire = min(flagshipUnused, fleetUnused - passengers);
+	maxHire = max(min(flagshipUnused, fleetUnused - passengers), 0);
 	
 	if(maxHire)
 		info.SetCondition("can hire");


### PR DESCRIPTION
You could still hit the hire button if your bunk space was negative due to accepting a passenger mission