### PR TITLE
fix unlanded fighters being sold on takeoff

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1012,7 +1012,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 	for(auto it = ships.begin(); it != ships.end(); )
 	{
 		shared_ptr<Ship> &ship = *it;
-		if(ship->IsParked() || ship->IsDisabled())
+		if(ship->IsParked() || ship->IsDisabled() || ship->GetSystem() != system)
 		{
 			++it;
 			continue;


### PR DESCRIPTION
fighter's not in your system were being sold off instead of remaining stranded