### PR TITLE
add cloak call to fix stark cloak fade

### DIFF
--- a/source/DrawList.cpp
+++ b/source/DrawList.cpp
@@ -188,6 +188,9 @@ DrawList::Item::Item(const Body &body, Point pos, Point blur, float cloak, float
 	// Calculate the blur vector, in texture coordinates.
 	this->blur[0] = unit.Cross(blur) / (width * 4.);
 	this->blur[1] = -unit.Dot(blur) / (height * 4.);
+
+	if(cloak > 0.)
+		Cloak(cloak);
 }
 
 


### PR DESCRIPTION
Recent changes in b5aee26abb0f8a35459bc5230a3b7aba057b35c5 made cloaking a stark transition at cloak value 1.0 instead of a fade.
Used a call instead of moving the logic from, and removing, DrawList::Item::Cloak function despite only being used one place in case it finds use elsewhere with recent ongoing refactoring.