### PR TITLE
Rebalanced Star Queen

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -4237,26 +4237,24 @@ ship "Star Queen"
 	attributes
 		category "Transport"
 		"cost" 5500000
-		"shields" 4100
-		"hull" 2200
-		"required crew" 43
-		"bunks" 112
-		"mass" 230
-		"drag" 5.5
+		"shields" 4400
+		"hull" 1800
+		"required crew" 32
+		"bunks" 96
+		"mass" 200
+		"drag" 4.8
 		"heat dissipation" .65
-		"fuel capacity" 500
-		"cargo space" 60
-		"outfit space" 360
-		"weapon capacity" 120
-		"engine capacity" 100
+		"fuel capacity" 600
+		"cargo space" 65
+		"outfit space" 355
+		"weapon capacity" 100
+		"engine capacity" 120
 		weapon
 			"blast radius" 60
 			"shield damage" 600
 			"hull damage" 300
 			"hit force" 900
 	outfits
-		"Sidewinder Missile Launcher" 3
-		"Sidewinder Missile" 150
 		"Heavy Anti-Missile Turret" 2
 		
 		"NT-200 Nucleovoltaic"
@@ -4266,13 +4264,13 @@ ship "Star Queen"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
-		"Hyperdrive"
+		"Scram Drive"
 		
 	engine -18 116
 	engine 18 116
-	gun 0 -116 "Sidewinder Missile Launcher"
-	gun -22 -80 "Sidewinder Missile Launcher"
-	gun 22 -80 "Sidewinder Missile Launcher"
+	gun 0 -116
+	gun -22 -80
+	gun 22 -80
 	turret -28 -9 "Heavy Anti-Missile Turret"
 	turret 28 -9 "Heavy Anti-Missile Turret"
 	explode "tiny explosion" 10


### PR DESCRIPTION
This PR was made with permission from @kikotheexile and @Sinsling.
I take no credit whatsoever, as they have done all the work and it seems that they do not know how to make Pull Requests.

Quoting @Sinsling's issue:
> First time posting here, let me know if I miss anything important on this post;
> 
> When looking at the Star Queen's price tag, I couldn't figure out why it had such low profit potential. The current vanilla queen requires a profit of 143 credits per day/ton just to pay crew wages, meaning you need to make 246 when moving one sector after taking off. The types of missions that are suppose to make this ship profitable -ferry missions, presumably- can be done with a fleet of 2 mules providing more free passanger space when their turrets are removed with a fraction of the crew cost and 8 times the cargo space.
> 
> Perhaps I am missing something, but after discussing it with Kiko the Exile on steam, we played with some numbers to provide a more competitive ship for the 7m+ base price without (hopefully) making its' capture play too good.

> For a quick summary of the changes;
> -Lowered the min crew and max passengers
> -Increased shields, lowered hull
> -Removed the starting missile launchers
> -Added extra engine space to fit third tier atomic engines
> -Added scram drive, ram scoop, and increased fuel
> -Lowered max outfit space to account for on-board "luxuries"; also reduces crew bunk spam
> 
> Over-all, the ship feels much more like a luxury liner, and doesn't have such a harsh cargo:crew cost. It can also be fitted into a good capture ship for the cost, making for some more interesting uses of the star queen.