### PR TITLE
[bug] Variant Sprites Are Reset to The Base Model's

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -251,7 +251,7 @@ void Ship::FinishLoading()
 	// Exception: uncapturable and "never disabled" flags don't carry over.
 	if(base && base != this)
 	{
-		if(!HasSprite())
+		if(!GetSprite())
 			reinterpret_cast<Body &>(*this) = *base;
 		if(baseAttributes.Attributes().empty())
 			baseAttributes = base->baseAttributes;


### PR DESCRIPTION
Ship::FinishLoading will reset the sprite of variants to the base model's sprite, because at load time Body::HasSprite() is very likely to return false.
While Body::LoadSprite will set `sprite` there's nothing forcing the sprite to have loaded frames at that point since GameData::spriteQueue is asynchronous, resulting in Body::HasSprite() returning false.

As a fix Ship::FinishLoading could use Body::GetSprite instead of Body::HasSprite, or some guarantee could be made about sprites being loaded but that's more complicated.