### PR TITLE
fix mission failure from eager event queue

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -808,7 +808,7 @@ void Engine::CalculateStep()
 		// create explosions. Eventually ships might create other effects too.
 		// Note that engine flares are handled separately, so that they will be
 		// drawn immediately under the ship.
-		if(!(*it)->Move(effects, flotsam))
+		if(!(*it)->Move(effects, flotsam) && (*it)->IsDestroyed())
 		{
 			eventQueue.emplace_back(nullptr, *it, ShipEvent::DESTROY);
 			it = ships.erase(it);


### PR DESCRIPTION
re: https://github.com/endless-sky/endless-sky/issues/1339
Cargo related missions failed when stored in fighters because in-bay fighters were triggering ShipEvent::DESTROY