### PR TITLE
fix overflow of fleet cost in hail panel

### DIFF
--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -320,7 +320,7 @@ bool HailPanel::Click(int x, int y)
 void HailPanel::SetBribe(double scale)
 {
 	// Find the total value of your fleet.
-	int value = 0;
+	int64_t value = 0;
 	for(const shared_ptr<Ship> &it : player.Ships())
 		value += it->Cost();
 	


### PR DESCRIPTION
re: https://github.com/endless-sky/endless-sky/issues/1342

Fleet cost total can overflow singed or unsigned int for eager players resulting in oddities in bribe totals.

The actual bribe calc/value should be fine as int for now as you'd need a fleet cost of 10T to overflow the result.