### PR TITLE
add !isInvisible to Ship::IsTargetable

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1379,7 +1379,7 @@ bool Ship::IsCapturable() const
 
 bool Ship::IsTargetable() const
 {
-	return (zoom == 1. && !explosionRate && !forget && cloak < 1. && hull >= 0. && hyperspaceCount < 70);
+	return (zoom == 1. && !explosionRate && !forget && !isInvisible && cloak < 1. && hull >= 0. && hyperspaceCount < 70);
 }
 
 


### PR DESCRIPTION
re: https://github.com/endless-sky/endless-sky/issues/1349

The change to make invisibility separate from cloaking missed the targeting check, making spriteless ships targetable