### PR TITLE
Give feedback to user about blocked mission

### DIFF
--- a/data/wanderer missions.txt
+++ b/data/wanderer missions.txt
@@ -204,7 +204,7 @@ mission "Earn Credits to Buy Data Card"
 			`You had wondered how you would get a copy of the entire cultural archive, but it turns out to be easier than expected. The station has a small museum gift shop, which sells a copy of the archives on a data card. ("The perfect gift for the budding historian in your family! Hold all of human history in the palm of your hand. On sale now for only 39.99!") You reach into your pocket to realize that you don't even have enough credits. You will need to earn enough credits to buy the data card.`
 				accept
 	to complete
-		has "Cultural Data to Greenwater 2: offered"
+		has "Cultural Data to Greenwater 2: done"
 
 mission "Cultural Data to Greenwater"
 	description "Bring a copy of the human cultural archives to <destination>, in exchange for a translation machine."

--- a/data/wanderer missions.txt
+++ b/data/wanderer missions.txt
@@ -200,9 +200,11 @@ mission "Earn Credits to Buy Data Card"
 		has "Human Cultural Archives: done"
 		not "Cultural Data to Greenwater: offered"
 	on offer
-		dialog "The station has a small museum gift shop, which sells a copy of the archives on a data card. Although, you do not have enough credits to pay for the measly 39.99 credits that the data card costs. Earn enough credits and return to <destination> to buy the data card"
+		conversation "
+			`You had wondered how you would get a copy of the entire cultural archive, but it turns out to be easier than expected. The station has a small museum gift shop, which sells a copy of the archives on a data card. ("The perfect gift for the budding historian in your family! Hold all of human history in the palm of your hand. On sale now for only 39.99!") You reach into your pocket to realize that you don't even have enough credits. You will need to earn enough credits to buy the data card.`
+				accept
 	to complete
-		has "Cultural Data to Greenwater: offered"
+		has "Cultural Data to Greenwater 2: offered"
 
 mission "Cultural Data to Greenwater"
 	description "Bring a copy of the human cultural archives to <destination>, in exchange for a translation machine."
@@ -211,10 +213,26 @@ mission "Cultural Data to Greenwater"
 	destination "Greenwater"
 	to offer
 		has "Human Cultural Archives: done"
+		not "Earn Credits to Buy Data Card: offered"
 	on offer
 		payment -40
 		conversation
 			`You had wondered how you would get a copy of the entire cultural archive, but it turns out to be easier than expected. The station has a small museum gift shop, which sells a copy of the archives on a data card. ("The perfect gift for the budding historian in your family! Hold all of human history in the palm of your hand. On sale now for only 39.99!") Given that a cheap data card costs a fraction of a credit, it's a bit of a rip-off, but you gladly buy one to take back to Eruk.`
+				accept
+				
+mission "Cultural Data to Greenwater 2"
+	name "Cultural Data to Greenwater"
+	description "Bring a copy of the human cultural archives to <destination>, in exchange for a translation machine."
+	landing
+	source "Alexandria"
+	destination "Greenwater"
+	to offer
+		has "Human Cultural Archives: done"
+		has ""Earn Credits to Buy Data Card: offered"
+	on offer
+		payment -40
+		conversation
+			`You return to Alexandria, this time with enough credits to pay the measly 39.99 credit data card. Given that a cheap data card costs a fraction of a credit, it's a bit of a rip-off, but you gladly buy one to take back to Eruk.`
 				accept
 
 mission "Visit Wanderers Again"

--- a/data/wanderer missions.txt
+++ b/data/wanderer missions.txt
@@ -191,17 +191,27 @@ mission "Human Cultural Archives"
 				`	"How will I convince them to give me a copy of their data?"`
 			`	Your question seems to utterly confuse him. "Information," he says. "It is what you call a non-rival good, is it not? When I give information, I do not lose it. Sharing it costs me nothing. The librarians, surely they will understand this. Have no fear."`
 				accept
-	on complete
-		payment -40
+
+mission "Earn Credits to Buy Data Card"
+	description "You did not have enough credits to purchase the data card. You will need to earn at least 40 credits in order to buy it."
+	landing
+	destination "Alexandria"
+	to offer
+		has "Human Cultural Archives: done"
+		not "Cultural Data to Greenwater: offered"
+	to complete
+		has "Cultural Data to Greenwater: done"
 
 mission "Cultural Data to Greenwater"
 	description "Bring a copy of the human cultural archives to <destination>, in exchange for a translation machine."
 	landing
 	source "Alexandria"
 	destination "Greenwater"
+	blocked "The station has a small museum gift shop, which sells a copy of the archives on a data card. Although, you do not have enough credits to pay for the measly 39.99 credits that the data card costs. Earn enough credits and return to <origin> to buy the data card"
 	to offer
 		has "Human Cultural Archives: done"
 	on offer
+		payment -40
 		conversation
 			`You had wondered how you would get a copy of the entire cultural archive, but it turns out to be easier than expected. The station has a small museum gift shop, which sells a copy of the archives on a data card. ("The perfect gift for the budding historian in your family! Hold all of human history in the palm of your hand. On sale now for only 39.99!") Given that a cheap data card costs a fraction of a credit, it's a bit of a rip-off, but you gladly buy one to take back to Eruk.`
 				accept

--- a/data/wanderer missions.txt
+++ b/data/wanderer missions.txt
@@ -199,15 +199,16 @@ mission "Earn Credits to Buy Data Card"
 	to offer
 		has "Human Cultural Archives: done"
 		not "Cultural Data to Greenwater: offered"
+	on offer
+		dialog "The station has a small museum gift shop, which sells a copy of the archives on a data card. Although, you do not have enough credits to pay for the measly 39.99 credits that the data card costs. Earn enough credits and return to <destination> to buy the data card"
 	to complete
-		has "Cultural Data to Greenwater: done"
+		has "Cultural Data to Greenwater: offered"
 
 mission "Cultural Data to Greenwater"
 	description "Bring a copy of the human cultural archives to <destination>, in exchange for a translation machine."
 	landing
 	source "Alexandria"
 	destination "Greenwater"
-	blocked "The station has a small museum gift shop, which sells a copy of the archives on a data card. Although, you do not have enough credits to pay for the measly 39.99 credits that the data card costs. Earn enough credits and return to <origin> to buy the data card"
 	to offer
 		has "Human Cultural Archives: done"
 	on offer

--- a/data/wanderer missions.txt
+++ b/data/wanderer missions.txt
@@ -228,7 +228,7 @@ mission "Cultural Data to Greenwater 2"
 	destination "Greenwater"
 	to offer
 		has "Human Cultural Archives: done"
-		has ""Earn Credits to Buy Data Card: offered"
+		has "Earn Credits to Buy Data Card: offered"
 	on offer
 		payment -40
 		conversation
@@ -242,6 +242,7 @@ mission "Visit Wanderers Again"
 	destination "Vara K'chrai"
 	to offer
 		has "Human Cultural Archives: done"
+		not "Earn Credits to Buy Data Card: active"
 	on offer
 		conversation
 			`You return to Eruk's workshop and give him the data card. His eyes light up with excitement. "I have spent my whole life studying human culture," he says. "This is a treasure to me. And now, here is your speaking machine." He hands you a small, spherical device, with speakers and microphones mounted on it, as well as what look like camera lenses. "The device is programmed with the human and Hai languages," he says. "It is not always possible to translate perfectly between our two languages, but it will try to give you a sense of the range of meanings in what is being said."`

--- a/data/wanderer missions.txt
+++ b/data/wanderer missions.txt
@@ -204,7 +204,7 @@ mission "Earn Credits to Buy Data Card"
 			`You had wondered how you would get a copy of the entire cultural archive, but it turns out to be easier than expected. The station has a small museum gift shop, which sells a copy of the archives on a data card. ("The perfect gift for the budding historian in your family! Hold all of human history in the palm of your hand. On sale now for only 39.99!") You reach into your pocket to realize that you don't even have enough credits. You will need to earn enough credits to buy the data card.`
 				accept
 	to complete
-		has "Cultural Data to Greenwater 2: done"
+		has "Cultural Data to Greenwater 2: offered"
 
 mission "Cultural Data to Greenwater"
 	description "Bring a copy of the human cultural archives to <destination>, in exchange for a translation machine."


### PR DESCRIPTION
http://steamcommunity.com/app/404410/discussions/0/360671247404843393/?tscn=1470191154

The mission would not complete if the player does not have 40 credits (something that only happened for this player because of all the death benefits and fines that needed to be paid), and the player would also not be informed as to why the mission would not complete. 

This pull informs the player that the mission can not be completed at that moment by prompting such with a blocked dialog as well as creating a reminder mission that will make sure that the player still knows to go to Alexandria.

Pretty sure I got this right. Just wrote it up and didn't test it. I'll do that in a bit.