### PR TITLE
Added message reminder of mission stops; simple implementation of #1383.

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -697,6 +697,39 @@ void Engine::EnterSystem()
 		if(mission.ClearanceMessage() == "auto")
 			mission.Destination()->Bribe(mission.HasFullClearance());
 	
+	// If the system contains a mission destination or waypoint,
+	// show a message
+	for(const Mission &mission : player.Missions())
+	{
+		// No message about a mission the player should not be aware of
+		if(!mission.IsVisible())
+			continue;
+		
+		const Planet *destination = mission.Destination();
+		if(destination->GetSystem() == system)
+		{
+			// Don't notify about incomplete bounties
+			bool npcsComplete = true;
+			for(const NPC &npc : mission.NPCs())
+				if(!npc.HasSucceeded(player.GetSystem()))
+				{
+					npcsComplete = false;
+					break;
+				}
+			
+			if(npcsComplete)
+				Messages::Add("You have a stop to make on "
+							  + destination->Name() + ".");
+		}
+		else
+		{
+			for(const Planet *stopover : mission.Stopovers())
+				if(stopover->GetSystem() == system)
+					Messages::Add("You have a stop to make on " +
+								  stopover->Name());
+		}
+	}
+
 	asteroids.Clear();
 	for(const System::Asteroid &a : system->Asteroids())
 		asteroids.Add(a.Name(), a.Count(), a.Energy());


### PR DESCRIPTION
This is the "dumb version" talked about in issue #1383, to get feedback from players before bothering to make it more complicated. In `Engine::EnterSystem()`, a check is made for missions with either destinations or stopovers in the newly-entered system. If any are found, `Messages` spits out "You have a stop to make on $PLANET." There's also a check made on the `Mission`'s `NPCs`, to avoid a reminder for an unfinished bounty.

Making this more elaborate looks like it would involve duplicating the logic inside `Mission::CanComplete()` (or ginning up a set of `PlayerInfo` objects with the planet changed).
