### PR TITLE
Little fixes, hails, volume, fighters and drones

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -165,7 +165,7 @@ interface "preferences"
 		center 195 210
 		dimensions 120 30
 	bar "volume"
-		from 280.5 15
+		from 280.5 -85
 		dimensions 0 -200
 		color "energy"
 		size 3

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -365,82 +365,82 @@ interface "boarding"
 	sprite "ui/boarding dialog"
 	
 	label "item"
-		from -320 -197
+		from -320 -189
 		align left
 	label "value"
-		from -60 -197
+		from -60 -189
 		align right
 	label "size"
-		from 10 -197
+		from 10 -189
 		align right
 	
 	label "cargo space free:"
-		from -320 67
+		from -320 75
 		align left
 	string "cargo space"
-		from 10 67
+		from 10 75
 		align right
 	
 	label "crew"
-		from 190 -120
+		from 190 -112
 		align right
 	label "attack"
-		from 260 -120
+		from 260 -112
 		align right
 	label "defense"
-		from 330 -120
+		from 330 -112
 		align right
 	
 	label "your ship:"
-		from 50 -100
+		from 50 -92
 		align left
 	string "your crew"
-		from 190 -100
+		from 190 -92
 		align right
 	string "your attack"
-		from 260 -100
+		from 260 -92
 		align right
 	string "your defense"
-		from 330 -100
+		from 330 -92
 		align right
 	
 	label "enemy ship:"
-		from 50 -80
+		from 50 -72
 		align left
 	string "enemy crew"
-		from 190 -80
+		from 190 -72
 		align right
 	string "enemy attack"
-		from 260 -80
+		from 260 -72
 		align right
 	string "enemy defense"
-		from 330 -80
+		from 330 -72
 		align right
 	
 	label "capture odds (attacking):"
-		from 50 -50
+		from 50 -42
 		align left
 	string "attack odds"
-		from 330 -50
+		from 330 -42
 		align right
 	label "expected casualties:"
-		from 50 -30
+		from 50 -22
 		align left
 	string "attack casualties"
-		from 330 -30
+		from 330 -22
 		align right
 	
 	label "survival odds (defending):"
-		from 50 0
+		from 50 8
 		align left
 	string "defense odds"
-		from 330 0
+		from 330 8
 		align right
 	label "expected casualties:"
-		from 50 20
+		from 50 28
 		align left
 	string "defense casualties"
-		from 330 20
+		from 330 28
 		align right
 	
 	active if "can take"

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -412,9 +412,8 @@ void AI::Step(const list<shared_ptr<Ship>> &ships, const PlayerInfo &player)
 		
 		// Handle fighters:
 		const string &category = it->Attributes().Category();
-		bool isDrone = (category == "Drone");
 		bool isFighter = (category == "Fighter");
-		if(isDrone || isFighter)
+		if(it->CanBeCarried())
 		{
 			bool hasSpace = (parent && parent->BaysFree(isFighter) && !parent->GetGovernment()->IsEnemy(gov));
 			if(!hasSpace || parent->IsDestroyed() || parent->GetSystem() != it->GetSystem())
@@ -424,7 +423,7 @@ void AI::Step(const list<shared_ptr<Ship>> &ships, const PlayerInfo &player)
 				it->SetParent(parent);
 				for(const auto &other : ships)
 					if(other->GetGovernment() == gov && !other->IsDisabled()
-							&& other->GetSystem() == it->GetSystem() && !other->CanBeCarried())
+							&& other->GetSystem() == it->GetSystem() && !other->CanBeCarried() && other->CanCarry(*it.get()))
 					{
 						parent = other;
 						it->SetParent(other);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1294,7 +1294,7 @@ void Engine::CalculateStep()
 	}
 	
 	// Occasionally have some ship hail you.
-	if(!Random::Int(600) && !ships.empty())
+	if(!Random::Int(600) && !player.IsDead() && !ships.empty())
 	{
 		shared_ptr<Ship> source;
 		unsigned i = Random::Int(ships.size());

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -221,7 +221,7 @@ void PlayerInfo::Load(const string &path)
 	// specified its location, but this is to avoid null locations.)
 	for(shared_ptr<Ship> &ship : ships)
 	{
-		if(!ship->GetSystem() && !ship->CanBeCarried())
+		if(!ship->GetSystem())
 			ship->SetSystem(system);
 		if(ship->GetSystem() == system)
 			ship->SetPlanet(planet);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -221,7 +221,7 @@ void PlayerInfo::Load(const string &path)
 	// specified its location, but this is to avoid null locations.)
 	for(shared_ptr<Ship> &ship : ships)
 	{
-		if(!ship->GetSystem())
+		if(!ship->GetSystem() && !ship->CanBeCarried())
 			ship->SetSystem(system);
 		if(ship->GetSystem() == system)
 			ship->SetPlanet(planet);
@@ -825,9 +825,10 @@ void PlayerInfo::Land(UI *ui)
 				if(ship->IsDestroyed())
 					mission.Do(ShipEvent(nullptr, ship, ShipEvent::DESTROY), *this, ui);
 	
-	// "Unload" all fighters, so they will get recharged, etc.
+	// "Unload" fighters that are with you, so they will get recharged, etc.
 	for(const shared_ptr<Ship> &ship : ships)
-		ship->UnloadBays();
+		if(ship->GetSystem() == system && !ship->IsDisabled())
+			ship->UnloadBays();
 	
 	// Recharge any ships that are landed with you on the planet.
 	bool hasSpaceport = planet->HasSpaceport() && planet->CanUseServices();

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -825,10 +825,9 @@ void PlayerInfo::Land(UI *ui)
 				if(ship->IsDestroyed())
 					mission.Do(ShipEvent(nullptr, ship, ShipEvent::DESTROY), *this, ui);
 	
-	// "Unload" fighters that are with you, so they will get recharged, etc.
+	// "Unload" all fighters, so they will get recharged, etc.
 	for(const shared_ptr<Ship> &ship : ships)
-		if(ship->GetSystem() == system && !ship->IsDisabled())
-			ship->UnloadBays();
+		ship->UnloadBays();
 	
 	// Recharge any ships that are landed with you on the planet.
 	bool hasSpaceport = planet->HasSpaceport() && planet->CanUseServices();


### PR DESCRIPTION
Small fixes including the position of the volume level bar, hails occuring for dead players, preventing carried ships from being unloaded if they can't actually land with you, and checking for reserved bay space before choosing a parent.
The last issue was causing stranded fighters/drones because their potential parent would leave before being asked to pick them up since they were all trying to dock with one ship.