### PR TITLE
Little fixes, bank pay all, info panel targeting

### DIFF
--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -236,6 +236,7 @@ bool BankPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			else
 				++i;
 		}
+		qualify = player.Accounts().Prequalify();
 	}
 	else
 		return false;

--- a/source/InfoPanel.cpp
+++ b/source/InfoPanel.cpp
@@ -455,6 +455,8 @@ void InfoPanel::UpdateInfo()
 	
 	const Ship &ship = **shipIt;
 	info.Update(ship);
+	if(player.Flagship() && ship.GetSystem() == player.GetSystem())
+		player.Flagship()->SetTargetShip(*shipIt);
 	
 	outfits.clear();
 	for(const auto &it : ship.Outfits())


### PR DESCRIPTION
Details of the whys are in the commit messages, fixes include
* updating the loan qualification when the pay all button is used
* viewing a ship in your system from the info panel while in space will select that ship

They're separate commits in case you wanted to cherry pick items, if you prefer single commits let me know.