### PR TITLE
ammo and flotsam

### DIFF
--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -130,7 +130,7 @@ int Flotsam::Count() const
 
 // This is how big one "unit" of the flotsam is (in tons). If a ship has
 // less than this amount of space, it can't pick up anything here.
-int Flotsam::UnitSize() const
+double Flotsam::UnitSize() const
 {
 	return outfit ? outfit->Get("mass") : 1;
 }

--- a/source/Flotsam.h
+++ b/source/Flotsam.h
@@ -58,7 +58,7 @@ public:
 	int Count() const;
 	// This is how big one "unit" of the flotsam is (in tons). If a ship has
 	// less than this amount of space, it can't pick up anything here.
-	int UnitSize() const;
+	double UnitSize() const;
 	
 	
 private:

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2019,12 +2019,18 @@ void Ship::Jettison(const string &commodity, int tons)
 
 void Ship::Jettison(const Outfit *outfit, int count)
 {
+	if(count < 0)
+		return;
+
 	cargo.Remove(outfit, count);
 	
 	double mass = outfit->Get("mass");
-	static const int perBox = (mass <= 0.) ? count : (mass > 5.) ? 1 : static_cast<int>(5. / mass);
-	for( ; count >= perBox; count -= perBox)
-		jettisoned.emplace_back(outfit, perBox);
+	const int perBox = (mass <= 0.) ? count : (mass > 5.) ? 1 : static_cast<int>(5. / mass);
+	while(count > 0)
+	{
+		jettisoned.emplace_back(outfit, (perBox < count) ? perBox : count);
+		count -= perBox;
+	}
 }
 
 


### PR DESCRIPTION
re: https://github.com/endless-sky/endless-sky/issues/1453

Two changes to floatsam and ammo:

change Flosam::UnitSize() to use double
This change allows UnitSize to accurately describe the size of what it contains since some items have fractional masses which UnitSize() reported as 0
This fixes ships trying to pick up flotsam they don't have room for, typically ammo

change Ship::Jettison outfit to allow non-full flotsam boxes
This is to stop fractional mass items from disappearing if they don't completely fill a flotsam box.
removed static keyword to allow box sizes to be appropriate for each item