### PR TITLE
Added ship government update during PlayerInfo::ApplyChanges()

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -309,6 +309,10 @@ void PlayerInfo::ApplyChanges()
 	GameData::ReadEconomy(economy);
 	economy = DataNode();
 	
+	// government changes may have changed the player's ship swizzles
+	for(shared_ptr<Ship> &ship : ships)
+		ship->SetGovernment(GameData::PlayerGovernment());
+
 	// Make sure all stellar objects are correctly positioned. This is needed
 	// because EnterSystem() is not called the first time through.
 	GameData::SetDate(GetDate());


### PR DESCRIPTION
drones and fighters kept the swizzle they were initially loaded with until manually launched

re: https://github.com/endless-sky/endless-sky/issues/1462