### PR TITLE
Preference toggle to always show the button underlines

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -40,6 +40,7 @@ namespace {
 	static const string EXPEND_AMMO = "Escorts expend ammo";
 	static const string FRUGAL_ESCORTS = "Escorts use ammo frugally";
 	static const string SETTINGS[] = {
+        "Always show keyboard shortcuts",
 		"Show CPU / GPU load",
 		"Render motion blur",
 		"",

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -40,7 +40,7 @@ namespace {
 	static const string EXPEND_AMMO = "Escorts expend ammo";
 	static const string FRUGAL_ESCORTS = "Escorts use ammo frugally";
 	static const string SETTINGS[] = {
-        "Always show keyboard shortcuts",
+		"Always show keyboard shortcuts",
 		"Show CPU / GPU load",
 		"Render motion blur",
 		"",

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -306,7 +306,7 @@ int main(int argc, char *argv[])
 					// No need to do anything more!
 				}
 			}
-			Font::ShowUnderlines(SDL_GetModState() & KMOD_ALT);
+			Font::ShowUnderlines(SDL_GetModState() & KMOD_ALT || Preferences::Has("Always show keyboard shortcuts") );
 			
 			// Tell all the panels to step forward, then draw them.
 			((!isPaused && menuPanels.IsEmpty()) ? gamePanels : menuPanels).StepAll();


### PR DESCRIPTION
This simple code change adds a preferences toggle to make the keyboard shortcut underlines on buttons always visible.