### PR TITLE
Getting scanned can now optionally fail any mission with illegal cargo

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -425,7 +425,6 @@ int Mission::IllegalCargoFine() const
 
 bool Mission::FailIfDiscovered() const
 {
-	printf("Mission::FailIfDiscovered called. Will this fail if you are discovered? %s\n", (failIfDiscovered)?"true":"false");
 	return failIfDiscovered;
 }
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -244,15 +244,7 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			{
 				out.BeginChild();
 				{
-					out.Write("illegal", illegalCargoFine);
-				}
-				out.EndChild();
-			}
-			if(!illegalCargoMessage.empty())
-			{
-				out.BeginChild();
-				{
-					out.Write("illegalCargoMessage", illegalCargoMessage);
+					out.Write("illegal", illegalCargoFine, illegalCargoMessage);
 				}
 				out.EndChild();
 			}

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -103,8 +103,13 @@ void Mission::Load(const DataNode &node)
 			
 			for(const DataNode &grand : child)
 			{
-				if(grand.Token(0) == "illegal" && grand.Size() >= 2)
+				if(grand.Token(0) == "illegal" && grand.Size() == 2)
 					illegalCargoFine = grand.Value(1);
+				else if(grand.Token(0) == "illegal" && grand.Size() == 3)
+				{
+					illegalCargoFine = grand.Value(1);
+					illegalCargoMessage = grand.Token(2);
+				}
 				else if(grand.Token(0) == "stealth")
 					failIfDiscovered = true;
 				else
@@ -240,6 +245,14 @@ void Mission::Save(DataWriter &out, const string &tag) const
 				out.BeginChild();
 				{
 					out.Write("illegal", illegalCargoFine);
+				}
+				out.EndChild();
+			}
+			if(!illegalCargoMessage.empty())
+			{
+				out.BeginChild();
+				{
+					out.Write("illegalCargoMessage", illegalCargoMessage);
 				}
 				out.EndChild();
 			}
@@ -419,6 +432,13 @@ int Mission::CargoSize() const
 int Mission::IllegalCargoFine() const
 {
 	return illegalCargoFine;
+}
+
+
+
+std::string Mission::IllegalCargoMessage() const
+{
+	return illegalCargoMessage;
 }
 
 
@@ -898,6 +918,7 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 			result.passengers = passengers;
 	}
 	result.illegalCargoFine = illegalCargoFine;
+	result.illegalCargoMessage = illegalCargoMessage;
 	result.failIfDiscovered = failIfDiscovered;
 	
 	// Estimate how far the player will have to travel to visit all the waypoints

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -105,6 +105,8 @@ void Mission::Load(const DataNode &node)
 			{
 				if(grand.Token(0) == "illegal" && grand.Size() >= 2)
 					illegalCargoFine = grand.Value(1);
+				else if(grand.Token(0) == "stealth")
+					failIfDiscovered = true;
 				else
 					grand.PrintTrace("Skipping unrecognized attribute:");
 			}
@@ -238,6 +240,14 @@ void Mission::Save(DataWriter &out, const string &tag) const
 				out.BeginChild();
 				{
 					out.Write("illegal", illegalCargoFine);
+				}
+				out.EndChild();
+			}
+			if(failIfDiscovered)
+			{
+				out.BeginChild();
+				{
+					out.Write("stealth");
 				}
 				out.EndChild();
 			}
@@ -409,6 +419,14 @@ int Mission::CargoSize() const
 int Mission::IllegalCargoFine() const
 {
 	return illegalCargoFine;
+}
+
+
+
+bool Mission::FailIfDiscovered() const
+{
+	printf("Mission::FailIfDiscovered called. Will this fail if you are discovered? %s\n", (failIfDiscovered)?"true":"false");
+	return failIfDiscovered;
 }
 
 
@@ -881,6 +899,7 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 			result.passengers = passengers;
 	}
 	result.illegalCargoFine = illegalCargoFine;
+	result.failIfDiscovered = failIfDiscovered;
 	
 	// Estimate how far the player will have to travel to visit all the waypoints
 	// and stopovers and then to land on the destination planet. Rather than a

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -72,6 +72,7 @@ public:
 	const std::string &Cargo() const;
 	int CargoSize() const;
 	int IllegalCargoFine() const;
+	std::string IllegalCargoMessage() const;
 	bool FailIfDiscovered() const;
 	int Passengers() const;
 	// The mission must be completed by this deadline (if there is a deadline).
@@ -167,6 +168,7 @@ private:
 	int cargoLimit = 0;
 	double cargoProb = 0.;
 	int illegalCargoFine = 0;
+	std::string illegalCargoMessage;
 	bool failIfDiscovered = false;
 	int passengers = 0;
 	// Parameters for generating random passenger amounts:

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -72,6 +72,7 @@ public:
 	const std::string &Cargo() const;
 	int CargoSize() const;
 	int IllegalCargoFine() const;
+	bool FailIfDiscovered() const;
 	int Passengers() const;
 	// The mission must be completed by this deadline (if there is a deadline).
 	const Date &Deadline() const;
@@ -166,6 +167,7 @@ private:
 	int cargoLimit = 0;
 	double cargoProb = 0.;
 	int illegalCargoFine = 0;
+	bool failIfDiscovered = false;
 	int passengers = 0;
 	// Parameters for generating random passenger amounts:
 	int passengerLimit = 0;

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -223,6 +223,16 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 			{
 				maxFine = fine;
 				reason = "carrying illegal cargo.";
+
+				// Fail any missions with illegal cargo
+				for(const Mission &mission : player.Missions())
+				{
+					// Found a mission with illegal cargo we should fail
+					if(mission.IllegalCargoFine() > 0)
+					{
+						player.FailMission(mission);
+					}
+				}
 			}
 		}
 		if(!scan || (scan & ShipEvent::SCAN_OUTFITS))

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -224,10 +224,16 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 				maxFine = fine;
 				reason = "carrying illegal cargo.";
 
-				// Fail any missions with illegal cargo
 				for(const Mission &mission : player.Missions())
 				{
-					// Found a mission with illegal cargo that's supposed to remain undiscovered
+					// Append the illegalCargoMessage from each applicable mission, if available
+					std::string illegalCargoMessage = mission.IllegalCargoMessage();
+					if(!illegalCargoMessage.empty())
+					{
+						reason.append("\n");
+						reason.append(illegalCargoMessage);
+					}
+					// Fail any missions with illegal cargo and "Stealth" set
 					if(mission.IllegalCargoFine() > 0 && mission.FailIfDiscovered())
 						player.FailMission(mission);
 				}

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -230,7 +230,7 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 					std::string illegalCargoMessage = mission.IllegalCargoMessage();
 					if(!illegalCargoMessage.empty())
 					{
-						reason = ".\n";
+						reason = ".\n\t";
 						reason.append(illegalCargoMessage);
 					}
 					// Fail any missions with illegal cargo and "Stealth" set

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -227,11 +227,9 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 				// Fail any missions with illegal cargo
 				for(const Mission &mission : player.Missions())
 				{
-					// Found a mission with illegal cargo we should fail
-					if(mission.IllegalCargoFine() > 0)
-					{
+					// Found a mission with illegal cargo that's supposed to remain undiscovered
+					if(mission.IllegalCargoFine() > 0 && mission.FailIfDiscovered())
 						player.FailMission(mission);
-					}
 				}
 			}
 		}

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -222,7 +222,7 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 			if((fine > maxFine && maxFine >= 0) || fine < 0)
 			{
 				maxFine = fine;
-				reason = "carrying illegal cargo.";
+				reason = " for carrying illegal cargo.";
 
 				for(const Mission &mission : player.Missions())
 				{
@@ -230,7 +230,7 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 					std::string illegalCargoMessage = mission.IllegalCargoMessage();
 					if(!illegalCargoMessage.empty())
 					{
-						reason.append("\n");
+						reason = ".\n";
 						reason.append(illegalCargoMessage);
 					}
 					// Fail any missions with illegal cargo and "Stealth" set
@@ -248,7 +248,7 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 					if((fine > maxFine && maxFine >= 0) || fine < 0)
 					{
 						maxFine = fine;
-						reason = "having illegal outfits installed on your ship.";
+						reason = " for having illegal outfits installed on your ship.";
 					}
 				}
 		}
@@ -269,7 +269,7 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 		// Scale the fine based on how lenient this government is.
 		maxFine = maxFine * gov->GetFineFraction() + .5;
 		reason = "The " + gov->GetName() + " authorities fine you "
-			+ Format::Number(maxFine) + " credits for " + reason;
+			+ Format::Number(maxFine) + " credits" + reason;
 		player.Accounts().AddFine(maxFine);
 		fined.insert(gov);
 	}


### PR DESCRIPTION
This addresses https://github.com/endless-sky/endless-sky/issues/556. The new behavior is triggered by adding "stealth" under "illegal" in the mission description. You can now additionally add an optional message after the fine to have it displayed when you're scanned. Example:

```
mission "Transport partiers [1]"
	name "Transport partiers to <planet>"
	job
	repeat
	description "This group of <bunks> university students is willing to pay <payment> to have a huge party on <destination>, along with <tons> of their completely legal pharmaceuticals."
	passengers 7 12
	cargo "completely legal pharmaceuticals" 2 4
		illegal 1000 "It turns out that the completely legal pharmaceuticals in your hold are not so completely legal after all. The officers who confiscate the goods spend a long time talking with one of the students, whom you suspect to be politically connected. You're not surprised by the small size of the fine you receive as well as the fact that nobody was arrested."
		stealth
```

If scanned, you'll see this:
<img width="322" alt="scanned" src="https://cloud.githubusercontent.com/assets/1097249/18611434/68b84804-7cf6-11e6-8cf1-ff3e7df53ebe.png">


There's only one wrinkle: the actual mission failure only happens the next time you land, not as soon as you get scanned. `player.FailMission()` seems to wait until you land, and I haven't yet found the way to make it immediately fail.

I did not modify any of the existing illegal missions to use this new feature, but can if you'd prefer.