### PR TITLE
Jump Cruisers now have Catalytic Ramscoops.

### DIFF
--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1025,6 +1025,7 @@ ship "Cruiser" "Cruiser (Jump)"
 		"D94-YV Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Water Coolant System"
+		"Cooling Ducts"
 		"Fuel Pod" 2
 		"Catalytic Ramscoop"
 		"Mass Expansion" 2

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1025,7 +1025,7 @@ ship "Cruiser" "Cruiser (Jump)"
 		"D94-YV Shield Generator"
 		"Liquid Helium Cooler"
 		"Fuel Pod" 2
-		"Ramscoop"
+		"Catalytic Ramscoop"
 		"Mass Expansion" 2
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1023,7 +1023,8 @@ ship "Cruiser" "Cruiser (Jump)"
 		"LP144a Battery Pack"
 		"LP036a Battery Pack"
 		"D94-YV Shield Generator"
-		"Liquid Helium Cooler"
+		"Liquid Nitrogen Cooler"
+		"Water Coolant System"
 		"Fuel Pod" 2
 		"Catalytic Ramscoop"
 		"Mass Expansion" 2


### PR DESCRIPTION
Makes long-range travel (like for the "Hunt the Alpha Base" mission)
less annoying.