### PR TITLE
Fewer bounty hunting jobs

### DIFF
--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -636,7 +636,7 @@ mission "Bounty Hunting (Big)"
 	job
 	to offer
 		"combat rating" > 500
-		random < 20
+		random < 10
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -675,7 +675,7 @@ mission "Bounty Hunting (Medium)"
 	job
 	to offer
 		"combat rating" > 400
-		random < 20
+		random < 15
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -710,7 +710,7 @@ mission "Bounty Hunting (Small)"
 	job
 	to offer
 		"combat rating" > 300
-		random < 40
+		random < 15
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1868,7 +1868,7 @@ mission "Bounty Hunting (Marauder I)"
 	job
 	to offer
 		"combat rating" > 600
-		random < 35
+		random < 10
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1890,7 +1890,7 @@ mission "Bounty Hunting (Marauder II)"
 	job
 	to offer
 		"combat rating" > 750
-		random < 30
+		random < 10
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1913,7 +1913,7 @@ mission "Bounty Hunting (Marauder III)"
 	job
 	to offer
 		"combat rating" > 1097
-		random < 25
+		random < 10
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1935,7 +1935,7 @@ mission "Bounty Hunting (Marauder IV)"
 	job
 	to offer
 		"combat rating" > 1550
-		random < 30
+		random < 10
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1957,7 +1957,7 @@ mission "Bounty Hunting (Marauder V)"
 	job
 	to offer
 		"combat rating" > 2000
-		random < 25
+		random < 10
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1980,7 +1980,7 @@ mission "Bounty Hunting (Marauder VI)"
 	job
 	to offer
 		"combat rating" > 2500
-		random < 20
+		random < 10
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -2002,7 +2002,7 @@ mission "Bounty Hunting (Marauder VII)"
 	job
 	to offer
 		"combat rating" > 2980
-		random < 20
+		random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -2024,7 +2024,7 @@ mission "Bounty Hunting (Marauder VIII)"
 	job
 	to offer
 		"combat rating" > 4000
-		random < 15
+		random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -2046,7 +2046,7 @@ mission "Bounty Hunting (Marauder IX)"
 	job
 	to offer
 		"combat rating" > 6000
-		random < 10
+		random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -636,7 +636,7 @@ mission "Bounty Hunting (Big)"
 	job
 	to offer
 		"combat rating" > 500
-		random < 10
+		random < 15
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -675,7 +675,7 @@ mission "Bounty Hunting (Medium)"
 	job
 	to offer
 		"combat rating" > 400
-		random < 15
+		random < 20
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -710,7 +710,7 @@ mission "Bounty Hunting (Small)"
 	job
 	to offer
 		"combat rating" > 300
-		random < 15
+		random < 25
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1867,8 +1867,13 @@ mission "Bounty Hunting (Marauder I)"
 	repeat
 	job
 	to offer
-		"combat rating" > 600
-		random < 10
+		or
+			and
+				"combat rating" > 600
+				random < 20
+			and
+				"combat rating" < 1097
+				random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1889,8 +1894,13 @@ mission "Bounty Hunting (Marauder II)"
 	repeat
 	job
 	to offer
-		"combat rating" > 750
-		random < 10
+		or
+			and
+				"combat rating" > 750
+				random < 20
+			and
+				"combat rating" < 1550
+				random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1912,8 +1922,13 @@ mission "Bounty Hunting (Marauder III)"
 	repeat
 	job
 	to offer
-		"combat rating" > 1097
-		random < 10
+		or
+			and
+				"combat rating" > 1097
+				random < 20
+			and
+				"combat rating" < 2000
+				random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1934,8 +1949,13 @@ mission "Bounty Hunting (Marauder IV)"
 	repeat
 	job
 	to offer
-		"combat rating" > 1550
-		random < 10
+		or
+			and
+				"combat rating" > 1555
+				random < 20
+			and
+				"combat rating" < 2500
+				random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1956,8 +1976,13 @@ mission "Bounty Hunting (Marauder V)"
 	repeat
 	job
 	to offer
-		"combat rating" > 2000
-		random < 10
+		or
+			and
+				"combat rating" > 2000
+				random < 20
+			and
+				"combat rating" < 2980
+				random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1979,8 +2004,13 @@ mission "Bounty Hunting (Marauder VI)"
 	repeat
 	job
 	to offer
-		"combat rating" > 2500
-		random < 10
+		or
+			and
+				"combat rating" > 2200
+				random < 20
+			and
+				"combat rating" < 4000
+				random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -2001,8 +2031,13 @@ mission "Bounty Hunting (Marauder VII)"
 	repeat
 	job
 	to offer
-		"combat rating" > 2980
-		random < 5
+		or
+			and
+				"combat rating" > 2980
+				random < 20
+			and
+				"combat rating" < 6000
+				random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -2023,8 +2058,13 @@ mission "Bounty Hunting (Marauder VIII)"
 	repeat
 	job
 	to offer
-		"combat rating" > 4000
-		random < 5
+		or
+			and
+				"combat rating" > 4000
+				random < 20
+			and
+				"combat rating" < 8103
+				random < 5
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -2045,8 +2085,10 @@ mission "Bounty Hunting (Marauder IX)"
 	repeat
 	job
 	to offer
-		"combat rating" > 6000
-		random < 5
+		or
+			and
+				"combat rating" > 6000
+				random < 20
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1868,11 +1868,8 @@ mission "Bounty Hunting (Marauder I)"
 	job
 	to offer
 		"combat rating" > 600
-		or
-			random < 20
-			and
-				"combat rating" < 1097
-				random < 5
+		"combat rating" < 1097
+		random < 20
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1894,11 +1891,8 @@ mission "Bounty Hunting (Marauder II)"
 	job
 	to offer
 		"combat rating" > 750
-		or
-			random < 20
-			and
-				"combat rating" < 1550
-				random < 5
+		"combat rating" < 1550
+		random < 20
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1921,11 +1915,8 @@ mission "Bounty Hunting (Marauder III)"
 	job
 	to offer
 		"combat rating" > 1097
-		or
-			random < 20
-			and
-				"combat rating" < 2000
-				random < 5
+		"combat rating" < 2000
+		random < 20
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1947,11 +1938,8 @@ mission "Bounty Hunting (Marauder IV)"
 	job
 	to offer
 		"combat rating" > 1555
-		or
-			random < 20
-			and
-				"combat rating" < 2500
-				random < 5
+		"combat rating" < 2500
+		random < 20
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -1973,11 +1961,8 @@ mission "Bounty Hunting (Marauder V)"
 	job
 	to offer
 		"combat rating" > 2000
-		or
-			random < 20
-			and
-				"combat rating" < 2980
-				random < 5
+		"combat rating" < 2980
+		random < 20
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -2000,11 +1985,8 @@ mission "Bounty Hunting (Marauder VI)"
 	job
 	to offer
 		"combat rating" > 2200
-		or
-			random < 20
-			and
-				"combat rating" < 4000
-				random < 5
+		"combat rating" < 4000
+		random < 20
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -2026,11 +2008,8 @@ mission "Bounty Hunting (Marauder VII)"
 	job
 	to offer
 		"combat rating" > 2980
-		or
-			random < 20
-			and
-				"combat rating" < 6000
-				random < 5
+		"combat rating" < 6000
+		random < 20
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -2052,11 +2031,7 @@ mission "Bounty Hunting (Marauder VIII)"
 	job
 	to offer
 		"combat rating" > 4000
-		or
-			random < 20
-			and
-				"combat rating" < 8103
-				random < 5
+		random < 15
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier
@@ -2078,7 +2053,7 @@ mission "Bounty Hunting (Marauder IX)"
 	job
 	to offer
 		"combat rating" > 6000
-		random < 20
+		random < 15
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1867,10 +1867,9 @@ mission "Bounty Hunting (Marauder I)"
 	repeat
 	job
 	to offer
+		"combat rating" > 600
 		or
-			and
-				"combat rating" > 600
-				random < 20
+			random < 20
 			and
 				"combat rating" < 1097
 				random < 5
@@ -1894,10 +1893,9 @@ mission "Bounty Hunting (Marauder II)"
 	repeat
 	job
 	to offer
+		"combat rating" > 750
 		or
-			and
-				"combat rating" > 750
-				random < 20
+			random < 20
 			and
 				"combat rating" < 1550
 				random < 5
@@ -1922,10 +1920,9 @@ mission "Bounty Hunting (Marauder III)"
 	repeat
 	job
 	to offer
+		"combat rating" > 1097
 		or
-			and
-				"combat rating" > 1097
-				random < 20
+			random < 20
 			and
 				"combat rating" < 2000
 				random < 5
@@ -1949,10 +1946,9 @@ mission "Bounty Hunting (Marauder IV)"
 	repeat
 	job
 	to offer
+		"combat rating" > 1555
 		or
-			and
-				"combat rating" > 1555
-				random < 20
+			random < 20
 			and
 				"combat rating" < 2500
 				random < 5
@@ -1976,10 +1972,9 @@ mission "Bounty Hunting (Marauder V)"
 	repeat
 	job
 	to offer
+		"combat rating" > 2000
 		or
-			and
-				"combat rating" > 2000
-				random < 20
+			random < 20
 			and
 				"combat rating" < 2980
 				random < 5
@@ -2004,10 +1999,9 @@ mission "Bounty Hunting (Marauder VI)"
 	repeat
 	job
 	to offer
+		"combat rating" > 2200
 		or
-			and
-				"combat rating" > 2200
-				random < 20
+			random < 20
 			and
 				"combat rating" < 4000
 				random < 5
@@ -2031,10 +2025,9 @@ mission "Bounty Hunting (Marauder VII)"
 	repeat
 	job
 	to offer
+		"combat rating" > 2980
 		or
-			and
-				"combat rating" > 2980
-				random < 20
+			random < 20
 			and
 				"combat rating" < 6000
 				random < 5
@@ -2058,10 +2051,9 @@ mission "Bounty Hunting (Marauder VIII)"
 	repeat
 	job
 	to offer
+		"combat rating" > 4000
 		or
-			and
-				"combat rating" > 4000
-				random < 20
+			random < 20
 			and
 				"combat rating" < 8103
 				random < 5
@@ -2085,10 +2077,8 @@ mission "Bounty Hunting (Marauder IX)"
 	repeat
 	job
 	to offer
-		or
-			and
-				"combat rating" > 6000
-				random < 20
+		"combat rating" > 6000
+		random < 20
 	source
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes rim south north "dirt belt" core frontier


### PR DESCRIPTION
Wow, the capital of the Syndicate has quite a pirate problem!

![big problem](https://cloud.githubusercontent.com/assets/1097249/18880618/be033f48-8495-11e6-94ea-00455f1d1167.png)

That seems a bit unrealistic. It seems that the offer frequency was not adjusted down when the Marauder bounty hunting jobs were added, leading to way too many being offered. I changed this, and now things seem more reasonable:

![better](https://cloud.githubusercontent.com/assets/1097249/18880670/eb684604-8495-11e6-8202-9191c883a9fe.png)
