### PR TITLE
proposal/work-in-progress: Use countof(array) instead of sizeof(array)/sizeof(array[0]), with a clean C++11 implementation

### DIFF
--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -235,15 +235,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		attributeValues.push_back(Format::Number(60. * outfit.FiringFuel() / outfit.Reload()));
 		attributesHeight += 20;
 	}
-	
-	bool isContinuous = (outfit.Reload() <= 1);
-	attributeLabels.push_back("shots / second:");
-	if(isContinuous)
-		attributeValues.push_back("continuous");
-	else
-		attributeValues.push_back(Format::Number(60. / outfit.Reload()));
-	attributesHeight += 20;
-	
+
+
 	int homing = outfit.Homing();
 	if(homing)
 	{
@@ -284,7 +277,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	attributeLabels.push_back(string());
 	attributeValues.push_back(string());
 	attributesHeight += 10;
-	
+
+// per-shot info
 	static const string names[] = {
 		"shield damage / shot:",
 		"hull damage / shot:",
@@ -295,12 +289,12 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		"firing energy / shot:",
 		"firing heat / shot:",
 		"firing fuel / shot:",
-		"inaccuracy:",
+		"inaccuracy:",                      // loop starts here for continuous-fire weapons
 		"blast radius:",
 		"missile strength:",
-		"anti-missile:",
+		"anti-missile damage / shot:",      // having this next to shots/second is important
 	};
-	double values[] = {
+	const double values[] = {
 		outfit.ShieldDamage(),
 		outfit.HullDamage(),
 		outfit.HeatDamage(),
@@ -315,6 +309,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		static_cast<double>(outfit.MissileStrength()),
 		static_cast<double>(outfit.AntiMissile())
 	};
+	bool isContinuous = (outfit.Reload() <= 1);
 	static const int NAMES = sizeof(names) / sizeof(names[0]);
 	for(int i = (isContinuous ? 9 : 0); i < NAMES; ++i)
 		if(values[i])
@@ -323,4 +318,11 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 			attributeValues.push_back(Format::Number(values[i]));
 			attributesHeight += 20;
 		}
+
+	attributeLabels.push_back("shots / second:");
+	if(isContinuous)
+		attributeValues.push_back("continuous");
+	else
+		attributeValues.push_back(Format::Number(60. / outfit.Reload()));
+	attributesHeight += 20;
 }

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -173,67 +173,40 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	attributeValues.push_back(Format::Number(outfit.Range()));
 	attributesHeight += 20;
 	
-	if(outfit.ShieldDamage() && outfit.Reload())
+	if(outfit.Reload())
 	{
-		attributeLabels.push_back("shield damage / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.ShieldDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.HullDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("hull damage / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.HullDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.HeatDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("heat damage / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.HeatDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.IonDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("ion damage / second:");
-		attributeValues.push_back(Format::Number(6000. * outfit.IonDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.SlowingDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("slowing damage / second:");
-		attributeValues.push_back(Format::Number(6000. * outfit.SlowingDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.DisruptionDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("disruption damage / second:");
-		attributeValues.push_back(Format::Number(6000. * outfit.DisruptionDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.FiringEnergy() && outfit.Reload())
-	{
-		attributeLabels.push_back("firing energy / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.FiringEnergy() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.FiringHeat() && outfit.Reload())
-	{
-		attributeLabels.push_back("firing heat / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.FiringHeat() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.FiringFuel() && outfit.Reload())
-	{
-		attributeLabels.push_back("firing fuel / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.FiringFuel() / outfit.Reload()));
-		attributesHeight += 20;
+		static const string perSecondLabels[] = {
+			"shield damage / second:",
+			"hull damage / second:",
+			"heat damage / second:",
+			"ion damage / second:",
+			"slowing damage / second:",
+			"disruption damage / second:",
+			"firing energy / second:",
+			"firing heat / second:",
+			"firing fuel / second:"
+		};
+		const double values[] = {                 // TODO: eliminate redundancy with per-shot values
+		    outfit.ShieldDamage(),
+		    outfit.HullDamage(),
+		    outfit.HeatDamage(),
+		    100. * outfit.IonDamage(),
+		    100. * outfit.SlowingDamage(),
+		    100. * outfit.DisruptionDamage(),
+		    outfit.FiringEnergy(),
+		    outfit.FiringHeat(),
+		    outfit.FiringFuel()
+		};
+		//static_assert(countof(values) == countof(perSecondLabels), "labels / values size mismatch");
+		static const int PER_SECOND_LABELS = sizeof(perSecondLabels) / sizeof(perSecondLabels[0]);
+		const double shotsPerSec = 60. / outfit.Reload();
+		for(int i = 0; i < PER_SECOND_LABELS; ++i)
+			if(values[i])
+			{
+				attributeLabels.push_back(perSecondLabels[i]);
+				attributeValues.push_back(Format::Number(shotsPerSec * values[i]));
+				attributesHeight += 20;
+			}
 	}
 
 

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -22,6 +22,14 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 using namespace std;
 
+// TODO: move this to a common header file
+// C++11 replacement for sizeof(a)/sizeof(a[0]), from https://www.g-truc.net/post-0708.html
+template <typename T, std::size_t N>
+constexpr std::size_t countof(T const (&)[N]) noexcept
+{
+    return N;
+}
+
 namespace {
 	static const set<string> ATTRIBUTES_TO_SCALE = {
 		"afterburner energy",
@@ -104,8 +112,7 @@ void OutfitInfoDisplay::UpdateRequirements(const Outfit &outfit)
 		"gun ports needed:", "gun ports",
 		"turret mounts needed:", "turret mounts"
 	};
-	static const int NAMES =  sizeof(names) / sizeof(names[0]);
-	for(int i = 0; i + 1 < NAMES; i += 2)
+	for(unsigned i = 0; i + 1 < countof(names); i += 2)
 		if(outfit.Get(names[i + 1]))
 		{
 			requirementLabels.push_back(string());
@@ -197,10 +204,10 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		    outfit.FiringHeat(),
 		    outfit.FiringFuel()
 		};
-		//static_assert(countof(values) == countof(perSecondLabels), "labels / values size mismatch");
-		static const int PER_SECOND_LABELS = sizeof(perSecondLabels) / sizeof(perSecondLabels[0]);
+		static_assert(countof(values) == countof(perSecondLabels), "labels / values size mismatch");
+
 		const double shotsPerSec = 60. / outfit.Reload();
-		for(int i = 0; i < PER_SECOND_LABELS; ++i)
+		for(unsigned i = 0; i < countof(perSecondLabels); ++i)
 			if(values[i])
 			{
 				attributeLabels.push_back(perSecondLabels[i]);
@@ -238,7 +245,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		outfit.RadarTracking(),
 		outfit.Piercing()
 	};
-	for(unsigned i = 0; i < sizeof(percentValues) / sizeof(percentValues[0]); ++i)
+	for(unsigned i = 0; i < countof(percentValues); ++i)
 		if(percentValues[i])
 		{
 			int percent = 100. * percentValues[i] + .5;
@@ -283,8 +290,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		static_cast<double>(outfit.AntiMissile())
 	};
 	bool isContinuous = (outfit.Reload() <= 1);
-	static const int NAMES = sizeof(names) / sizeof(names[0]);
-	for(int i = (isContinuous ? 9 : 0); i < NAMES; ++i)
+	for(unsigned i = (isContinuous ? 9 : 0); i < countof(names); ++i)
 		if(values[i])
 		{
 			attributeLabels.push_back(names[i]);


### PR DESCRIPTION
C++11 provides a way to implement a clean non-macro `countof()` that should break compile time with comprehensible error messages if you use it wrong.  https://www.g-truc.net/post-0708.html.

We should use it.

This branch isn't really ready for a merge, though, more of a request for comment.  (I didn't mean to include the parent branch; I guess I'd need to cherry-pick / rebase it manually.  Won't fix yet since this pull request isn't really ready for merging.)

Putting it in just one .cpp is silly, because there are other files that could use it, but I didn't see a "utility.h" type of header that all files include.  Where should it go?  A new file, like countof.h?  Or should we make a "utility.h"?

Another utility function that might be useful is `clamp(minval, x, maxval)`, to replace stuff like `max(0, min(4, homing))`.  I always find it easy to get it backwards and use max when I want to set an upper-bound.  Anyway, calling a new file "countof.h" seems like a bad precendent if we don't want a thousand tiny files and more `#include` noise than the helper functions save.
