### PR TITLE
Hai atomic engine balance

### DIFF
--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -345,12 +345,12 @@ outfit `"Baellie" Atomic Engines`
 	"mass" 24
 	"outfit space" -24
 	"engine capacity" -24
-	"turn" 300
-	"turning energy" .8
-	"turning heat" 1.8
-	"thrust" 7.5
-	"thrusting energy" .8
-	"thrusting heat" 1.6
+	"turn" 309
+	"turning energy" .7
+	"turning heat" 1.6
+	"thrust" 8.0
+	"thrusting energy" .9
+	"thrusting heat" 1.7
 	"flare sprite" "effect/atomic flare/tiny"
 	    "frame rate" 14
 	"flare sound" "atomic tiny"
@@ -363,9 +363,9 @@ outfit `"Basrem" Atomic Thruster`
 	"mass" 18
 	"outfit space" -18
 	"engine capacity" -18
-	"thrust" 12.1
-	"thrusting energy" 1.4
-	"thrusting heat" 2.8
+	"thrust" 13.2
+	"thrusting energy" 1.5
+	"thrusting heat" 2.9
 	"flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"flare sound" "atomic tiny"
@@ -378,9 +378,9 @@ outfit `"Benga" Atomic Thruster`
 	"mass" 28
 	"outfit space" -28
 	"engine capacity" -28
-	"thrust" 21
-	"thrusting energy" 2.4
-	"thrusting heat" 4.8
+	"thrust" 23.6
+	"thrusting energy" 2.6
+	"thrusting heat" 5.0
 	"flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"flare sound" "atomic tiny"
@@ -393,9 +393,9 @@ outfit `"Biroo" Atomic Thruster`
 	"mass" 44
 	"outfit space" -44
 	"engine capacity" -44
-	"thrust" 37
-	"thrusting energy" 4
-	"thrusting heat" 7.7
+	"thrust" 41.5
+	"thrusting energy" 4.2
+	"thrusting heat" 8.6
 	"flare sprite" "effect/atomic flare/small"
 		"frame rate" 13
 	"flare sound" "atomic small"
@@ -408,9 +408,9 @@ outfit `"Bondir" Atomic Thruster`
 	"mass" 63
 	"outfit space" -63
 	"engine capacity" -63
-	"thrust" 59.4
-	"thrusting energy" 6.3
-	"thrusting heat" 12.1
+	"thrust" 66.1
+	"thrusting energy" 6.4
+	"thrusting heat" 13.4
 	"flare sprite" "effect/atomic flare/medium"
 		"frame rate" 12
 	"flare sound" "atomic medium"
@@ -423,9 +423,9 @@ outfit `"Bufaer" Atomic Thruster`
 	"mass" 104
 	"outfit space" -104
 	"engine capacity" -104
-	"thrust" 113
-	"thrusting energy" 11.6
-	"thrusting heat" 22.1
+	"thrust" 120.1
+	"thrusting energy" 10.9
+	"thrusting heat" 23.8
 	"flare sprite" "effect/atomic flare/large"
 		"frame rate" 11
 	"flare sound" "atomic large"
@@ -438,7 +438,7 @@ outfit `"Basrem" Atomic Steering`
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
-	"turn" 318
+	"turn" 309
 	"turning energy" .7
 	"turning heat" 1.6
 	description "Hai atomic engines are too expensive to buy for most humans. All but the smallest of the engines are worth more than many of the most common ships flown in human space."
@@ -450,9 +450,9 @@ outfit `"Benga" Atomic Steering`
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
-	"turn" 588
-	"turning energy" 1.2
-	"turning heat" 2.9
+	"turn" 577
+	"turning energy" 1.1
+	"turning heat" 2.8
 	description "Hai atomic engines allow for some of the most customizable ships in known space due to their size and efficiency. The few humans that are able to save up enough money to buy a set of Hai engines usually astound others in human space with the efficiency of their ship."
 
 outfit `"Biroo" Atomic Steering`
@@ -462,9 +462,9 @@ outfit `"Biroo" Atomic Steering`
 	"mass" 32
 	"outfit space" -32
 	"engine capacity" -32
-	"turn" 1014
-	"turning energy" 1.9
-	"turning heat" 4.8
+	"turn" 1054
+	"turning energy" 2.0
+	"turning heat" 5.1
 	description  "Having such powerful engines is a double edged sword for the Hai, as the Unfettered Hai too own these powerful wonders. These engines allow most Hai ships to turn at amazing speeds, making them extremely deadly in combat."
 
 outfit `"Bondir" Atomic Steering`
@@ -474,9 +474,9 @@ outfit `"Bondir" Atomic Steering`
 	"mass" 49
 	"outfit space" -49
 	"engine capacity" -49
-	"turn" 1686
-	"turning energy" 3.1
-	"turning heat" 7.9
+	"turn" 1758
+	"turning energy" 3.2
+	"turning heat" 8.2
 	description "Reserved for special use on only a small number of Hai ships, these engines are one of the most expensive outfits that one could buy. Considerably more efficient than any other engine of the same size, Hai atomic engines are a go to choice for anyone in need of a high turn speed."
 
 outfit `"Bufaer" Atomic Steering`
@@ -486,7 +486,7 @@ outfit `"Bufaer" Atomic Steering`
 	"mass" 76
 	"outfit space" -76
 	"engine capacity" -76
-	"turn" 2838
-	"turning energy" 5.1
-	"turning heat" 13.0
+	"turn" 3043
+	"turning energy" 5.2
+	"turning heat" 13.8
 	description "Nine out of every ten human captains interviewed in Hai space as to whose atomic engines they prefer say that they would choose Hai atomic engines over those of Deep Sky any day; that is if they could afford such expensive engines."

--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -340,17 +340,17 @@ outfit "Sand Cell"
 
 outfit `"Baellie" Atomic Engines`
     category "Engines"
-	"cost" 135000
+	"cost" 240000
 	thumbnail "outfit/tiny atomic engines hai"
 	"mass" 24
 	"outfit space" -24
 	"engine capacity" -24
-	"turn" 309
-	"turning energy" .7
-	"turning heat" 1.6
-	"thrust" 8.0
-	"thrusting energy" .9
-	"thrusting heat" 1.7
+	"turn" 250
+	"turning energy" .6
+	"turning heat" 1.3
+	"thrust" 10.1
+	"thrusting energy" 1.2
+	"thrusting heat" 2.4
 	"flare sprite" "effect/atomic flare/tiny"
 	    "frame rate" 14
 	"flare sound" "atomic tiny"
@@ -358,7 +358,7 @@ outfit `"Baellie" Atomic Engines`
 
 outfit `"Basrem" Atomic Thruster`
 	category "Engines"
-	"cost" 95000
+	"cost" 150000
 	thumbnail "outfit/tiny atomic thruster hai"
 	"mass" 18
 	"outfit space" -18
@@ -373,7 +373,7 @@ outfit `"Basrem" Atomic Thruster`
 
 outfit `"Benga" Atomic Thruster`
 	category "Engines"
-	"cost" 210000
+	"cost" 300000
 	thumbnail "outfit/small atomic thruster hai"
 	"mass" 28
 	"outfit space" -28
@@ -388,7 +388,7 @@ outfit `"Benga" Atomic Thruster`
 
 outfit `"Biroo" Atomic Thruster`
 	category "Engines"
-	"cost" 420000
+	"cost" 610000
 	thumbnail "outfit/medium atomic thruster hai"
 	"mass" 44
 	"outfit space" -44
@@ -403,7 +403,7 @@ outfit `"Biroo" Atomic Thruster`
 
 outfit `"Bondir" Atomic Thruster`
 	category "Engines"
-	"cost" 780000
+	"cost" 1100000
 	thumbnail "outfit/large atomic thruster hai"
 	"mass" 63
 	"outfit space" -63
@@ -418,7 +418,7 @@ outfit `"Bondir" Atomic Thruster`
 
 outfit `"Bufaer" Atomic Thruster`
 	category "Engines"
-	"cost" 1680000
+	"cost" 2400000
 	thumbnail "outfit/huge atomic thruster hai"
 	"mass" 104
 	"outfit space" -104
@@ -433,7 +433,7 @@ outfit `"Bufaer" Atomic Thruster`
 
 outfit `"Basrem" Atomic Steering`
 	category "Engines"
-	"cost" 90000
+	"cost" 120000
 	thumbnail "outfit/tiny atomic steering hai"
 	"mass" 12
 	"outfit space" -12
@@ -445,7 +445,7 @@ outfit `"Basrem" Atomic Steering`
 
 outfit `"Benga" Atomic Steering`
 	category "Engines"
-	"cost" 180000
+	"cost" 250000
 	thumbnail "outfit/small atomic steering hai"
 	"mass" 20
 	"outfit space" -20
@@ -457,7 +457,7 @@ outfit `"Benga" Atomic Steering`
 
 outfit `"Biroo" Atomic Steering`
 	category "Engines"
-	"cost" 360000
+	"cost" 530000
 	thumbnail "outfit/medium atomic steering hai"
 	"mass" 32
 	"outfit space" -32
@@ -469,7 +469,7 @@ outfit `"Biroo" Atomic Steering`
 
 outfit `"Bondir" Atomic Steering`
 	category "Engines"
-	"cost" 720000
+	"cost" 950000
 	thumbnail "outfit/large atomic steering hai"
 	"mass" 49
 	"outfit space" -49
@@ -481,7 +481,7 @@ outfit `"Bondir" Atomic Steering`
 
 outfit `"Bufaer" Atomic Steering`
 	category "Engines"
-	"cost" 1440000
+	"cost" 2100000
 	thumbnail "outfit/huge atomic steering hai"
 	"mass" 76
 	"outfit space" -76

--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -364,8 +364,8 @@ outfit `"Basrem" Atomic Thruster`
 	"outfit space" -18
 	"engine capacity" -18
 	"thrust" 12.1
-	"thrusting energy" 1.3
-	"thrusting heat" 2.5
+	"thrusting energy" 1.4
+	"thrusting heat" 2.8
 	"flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"flare sound" "atomic tiny"
@@ -378,7 +378,7 @@ outfit `"Benga" Atomic Thruster`
 	"mass" 28
 	"outfit space" -28
 	"engine capacity" -28
-	"thrust" 19.5
+	"thrust" 21
 	"thrusting energy" 2.4
 	"thrusting heat" 4.8
 	"flare sprite" "effect/atomic flare/tiny"
@@ -393,7 +393,7 @@ outfit `"Biroo" Atomic Thruster`
 	"mass" 44
 	"outfit space" -44
 	"engine capacity" -44
-	"thrust" 38.2
+	"thrust" 37
 	"thrusting energy" 4
 	"thrusting heat" 7.7
 	"flare sprite" "effect/atomic flare/small"
@@ -409,8 +409,8 @@ outfit `"Bondir" Atomic Thruster`
 	"outfit space" -63
 	"engine capacity" -63
 	"thrust" 59.4
-	"thrusting energy" 6.5
-	"thrusting heat" 13.7
+	"thrusting energy" 6.3
+	"thrusting heat" 12.1
 	"flare sprite" "effect/atomic flare/medium"
 		"frame rate" 12
 	"flare sound" "atomic medium"
@@ -424,7 +424,7 @@ outfit `"Bufaer" Atomic Thruster`
 	"outfit space" -104
 	"engine capacity" -104
 	"thrust" 113
-	"thrusting energy" 10.6
+	"thrusting energy" 11.6
 	"thrusting heat" 22.1
 	"flare sprite" "effect/atomic flare/large"
 		"frame rate" 11
@@ -438,9 +438,9 @@ outfit `"Basrem" Atomic Steering`
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
-	"turn" 312
+	"turn" 318
 	"turning energy" .7
-	"turning heat" 1.7
+	"turning heat" 1.6
 	description "Hai atomic engines are too expensive to buy for most humans. All but the smallest of the engines are worth more than many of the most common ships flown in human space."
 
 outfit `"Benga" Atomic Steering`
@@ -450,7 +450,7 @@ outfit `"Benga" Atomic Steering`
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
-	"turn" 492.4
+	"turn" 588
 	"turning energy" 1.2
 	"turning heat" 2.9
 	description "Hai atomic engines allow for some of the most customizable ships in known space due to their size and efficiency. The few humans that are able to save up enough money to buy a set of Hai engines usually astound others in human space with the efficiency of their ship."
@@ -462,7 +462,7 @@ outfit `"Biroo" Atomic Steering`
 	"mass" 32
 	"outfit space" -32
 	"engine capacity" -32
-	"turn" 958.5
+	"turn" 1014
 	"turning energy" 1.9
 	"turning heat" 4.8
 	description  "Having such powerful engines is a double edged sword for the Hai, as the Unfettered Hai too own these powerful wonders. These engines allow most Hai ships to turn at amazing speeds, making them extremely deadly in combat."
@@ -474,9 +474,9 @@ outfit `"Bondir" Atomic Steering`
 	"mass" 49
 	"outfit space" -49
 	"engine capacity" -49
-	"turn" 1482.4
-	"turning energy" 3.2
-	"turning heat" 8.3
+	"turn" 1686
+	"turning energy" 3.1
+	"turning heat" 7.9
 	description "Reserved for special use on only a small number of Hai ships, these engines are one of the most expensive outfits that one could buy. Considerably more efficient than any other engine of the same size, Hai atomic engines are a go to choice for anyone in need of a high turn speed."
 
 outfit `"Bufaer" Atomic Steering`
@@ -486,7 +486,7 @@ outfit `"Bufaer" Atomic Steering`
 	"mass" 76
 	"outfit space" -76
 	"engine capacity" -76
-	"turn" 2835
-	"turning energy" 5.2
-	"turning heat" 13.3
+	"turn" 2838
+	"turning energy" 5.1
+	"turning heat" 13.0
 	description "Nine out of every ten human captains interviewed in Hai space as to whose atomic engines they prefer say that they would choose Hai atomic engines over those of Deep Sky any day; that is if they could afford such expensive engines."


### PR DESCRIPTION
Someone pointed out [over on the Steam forums](http://steamcommunity.com/app/404410/discussions/0/312265782622433578/) that the Hai engines, unlike the other engines in the game, are all over the place when it comes to the increase in efficiency per level. These changes make the increase in efficiency less spastic (and fix the Basrem Atomic Steering being more efficient than the Benga Atomic Steering, despite the Benga being a level above the Basrem).

@LocalGod79 Given that these were originally your doing, does it look alright to you?