### PR TITLE
Switch C++ standard to gnu++11

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -22,7 +22,7 @@ opts.Update(env)
 
 Help(opts.GenerateHelpText(env))
 
-flags = ["-std=c++11", "-Wall"]
+flags = ["-std=gnu++11", "-Wall"]
 if env["mode"] != "debug":
 	flags += ["-O3"]
 if env["mode"] == "debug":


### PR DESCRIPTION
This fixes a FTBFS on ppc64le architecture. This appears to have no impact to builds on other architectures like x86_64 and i686.