### PR TITLE
Omicron Forty-two (WIP - looking for feedback only)

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1870,7 +1870,7 @@ mission "A wolf, a goat, and a cabbage"
 
 mission "Omicron Forty-two 0"
 	name "Recover <npc>"
-	description "A surveillance drone named <npc> was left in the Kugel system by a Navy fleet, and they would like you to retrieve the scanner logs using an outfit scanner and drop them off at <destination>. Do not destroy or repair the ship, only scan it."
+	description "A surveillance drone named <npc> was left in the Kugel system by a Navy fleet, and they would like you to retrieve the scanner logs using an outfit scanner and drop them off at <destination>."
 	source
 		attributes paradise
 	destination "Carbuncle Station"
@@ -1883,7 +1883,7 @@ mission "Omicron Forty-two 0"
 					accept
 				`	(Decline.)`
 					decline
-	npc "scan outfits" save disable
+	npc "scan outfits"
 		personality derelict staying
 		government Republic
 		system "Kugel"

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1877,7 +1877,7 @@ mission "Omicron Forty-two 0"
 	waypoint "Kugel"
 	on offer
 		conversation
-			`	A Navy captain stands at the corner of the spaceport, apparently scanning through the crowd for someone. He sees you, and calls you over. "You look like a respectable captain," he says, obviously in a hurry. "One of our ships recently lost a surveillance drone in Kugel. Could you scan its cargo and bring back its scanner logs to Carbuncle Station? We do not want you to retrieve or repair it - it has certain defense systems that need to be disabled by... specialists, from Lovelace Labs. I would do it myself," he adds, "but I don't have the time. You will be paid, of course."`
+			`	A Navy captain stands at the corner of the spaceport, apparently scanning through the crowd for someone. He sees you, and calls you over. "You look like a respectable captain," he says, obviously in a hurry. "One of our ships recently lost an important surveillance drone in Kugel. Could you scan its cargo and bring back its scanner logs to Carbuncle Station? We do not want you to retrieve or repair it - it has certain defense systems that need to be disabled by... specialists, from Lovelace Labs. I would do it myself," he adds, "but I don't have the time. You will be paid, of course."`
 			choice
 				`	(Accept.)`
 					accept
@@ -1888,7 +1888,7 @@ mission "Omicron Forty-two 0"
 		government Republic
 		system "Kugel"
 		ship "Surveillance Drone (Secure)" "Omicron Forty-two"
-		dialog `You scan the surveillance drone and prepare to return the diagnostics to <destination>.`
+		dialog `You scan the surveillance drone and prepare to return the logs to <destination>.`
 	on complete
 		conversation
 			`	A group of Lovelace technicians, along with an intimidating man in a dark suit, meet you in <destination>'s docking bay and take the sensor logs from you. "Thank you, Captain <last>. This will help us greatly," says the man in the suit. He signals for the technicians to leave, and then pays you <payment>.`

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1870,14 +1870,14 @@ mission "A wolf, a goat, and a cabbage"
 
 mission "Omicron Forty-two 0"
 	name "Recover <npc>"
-	description "A surveillance drone named <npc> was left in the Kugel system by a Navy fleet, and they would like you to retrieve the scanner logs using a cargo scanner and drop them off at <destination>."
+	description "A surveillance drone named <npc> was left in the Kugel system by a Navy fleet, and they would like you to retrieve the scanner logs using a cargo scanner and drop them off at <destination>. Do not destroy or repair the ship, only scan it."
 	source
 		attributes paradise
 	destination "Carbuncle Station"
 	waypoint "Kugel"
 	on offer
 		conversation
-			`	A Navy captain stands at the corner of the spaceport, apparently scanning through the crowd for someone. He sees you, and calls you over. "You look like a respectable captain," he says, obviously in a hurry. "One of our ships recently lost an surveillance drone in Kugel. Could you scan its and bring back its cargo diagnostics to Carbuncle Station? We do not want you to retrieve it - it has certain defense systems that need to be disabled by... specialists, from Lovelace Labs. I would do it myself," he adds, "but I don't have the time. You will be paid, of course."`
+			`	A Navy captain stands at the corner of the spaceport, apparently scanning through the crowd for someone. He sees you, and calls you over. "You look like a respectable captain," he says, obviously in a hurry. "One of our ships recently lost a surveillance drone in Kugel. Could you scan its cargo and bring back its scanner logs to Carbuncle Station? We do not want you to retrieve or repair it - it has certain defense systems that need to be disabled by... specialists, from Lovelace Labs. I would do it myself," he adds, "but I don't have the time. You will be paid, of course."`
 			choice
 				`	(Accept.)`
 					accept

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1870,20 +1870,20 @@ mission "A wolf, a goat, and a cabbage"
 
 mission "Omicron Forty-two 0"
 	name "Recover <npc>"
-	description "A surveillance drone named <npc> was left in the Kugel system by a Navy fleet, and they would like you to retrieve the scanner logs using a cargo scanner and drop them off at <destination>. Do not destroy or repair the ship, only scan it."
+	description "A surveillance drone named <npc> was left in the Kugel system by a Navy fleet, and they would like you to retrieve the scanner logs using an outfit scanner and drop them off at <destination>. Do not destroy or repair the ship, only scan it."
 	source
 		attributes paradise
 	destination "Carbuncle Station"
 	waypoint "Kugel"
 	on offer
 		conversation
-			`	A Navy captain stands at the corner of the spaceport, apparently scanning through the crowd for someone. He sees you, and calls you over. "You look like a respectable captain," he says, obviously in a hurry. "One of our ships recently lost an important surveillance drone in Kugel. Could you scan its cargo and bring back its scanner logs to Carbuncle Station? We do not want you to retrieve or repair it - it has certain defense systems that need to be disabled by... specialists, from Lovelace Labs. I would do it myself," he adds, "but I don't have the time. You will be paid, of course."`
+			`	A Navy captain stands at the corner of the spaceport, apparently scanning through the crowd for someone. He sees you, and calls you over. "You look like a respectable captain," he says, obviously in a hurry. "One of our ships recently lost an important surveillance drone in Kugel. Could you scan its outfits and bring back your scanner logs to Carbuncle Station? We do not want you to retrieve or repair it - it has certain defense systems that need to be disabled by... specialists, from Lovelace Labs. I would do it myself," he adds, "but I don't have the time. You will be paid, of course."`
 			choice
 				`	(Accept.)`
 					accept
 				`	(Decline.)`
 					decline
-	npc "scan cargo" save disable
+	npc "scan outfits" save disable
 		personality derelict staying
 		government Republic
 		system "Kugel"

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1880,9 +1880,9 @@ mission "Omicron Forty-two 0"
 			`	A Navy captain stands at the corner of the spaceport, apparently scanning through the crowd for someone. He sees you, and calls you over. "You look like a respectable captain," he says, obviously in a hurry. "One of our ships recently lost an surveillance drone in Kugel. Could you scan its and bring back its cargo diagnostics to Carbuncle Station? We do not want you to retrieve it - it has certain defense systems that need to be disabled by... specialists, from Lovelace Labs. I would do it myself," he adds, "but I don't have the time. You will be paid, of course."`
 			choice
 				`	(Accept.)`
-					decline
-				`	(Decline.)`
 					accept
+				`	(Decline.)`
+					decline
 	npc "scan cargo" save disable
 		personality derelict staying
 		government Republic

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1865,3 +1865,31 @@ mission "A wolf, a goat, and a cabbage"
 		dialog
 			`The man who collects the wolf from you on the landing pad is furious. "I told the shipping company not to put the goat in the same ship as the wolf or the cabbage," he says, "but I guess they tried to save money by subcontracting it all to the same captain."`
 			`	Because you only delivered a third of the cargo safely, he only pays you 33,000 credits.`
+
+
+
+mission "Omicron Forty-two 0"
+	name "Recover <npc>"
+	description "A surveillance drone named <npc> was left in the Kugel system by a Navy fleet, and they would like you to retrieve the scanner logs using a cargo scanner and drop them off at <destination>."
+	source
+		attributes paradise
+	destination "Carbuncle Station"
+	waypoint "Kugel"
+	on offer
+		conversation
+			`	A Navy captain stands at the corner of the spaceport, apparently scanning through the crowd for someone. He sees you, and calls you over. "You look like a respectable captain," he says, obviously in a hurry. "One of our ships recently lost an surveillance drone in Kugel. Could you scan its and bring back its cargo diagnostics to Carbuncle Station? We do not want you to retrieve it - it has certain defense systems that need to be disabled by... specialists, from Lovelace Labs. I would do it myself," he adds, "but I don't have the time. You will be paid, of course."`
+			choice
+				`	(Accept.)`
+					decline
+				`	(Decline.)`
+					accept
+	npc "scan cargo" save disable
+		personality derelict staying
+		government Republic
+		system "Kugel"
+		ship "Surveillance Drone (Secure)" "Omicron Forty-two"
+		dialog `You scan the surveillance drone and prepare to return the diagnostics to <destination>.`
+	on complete
+		conversation
+			`	A group of Lovelace technicians, along with an intimidating man in a dark suit, meet you in <destination>'s docking bay and take the sensor logs from you. "Thank you, Captain <last>. This will help us greatly," says the man in the suit. He signals for the technicians to leave, and then pays you <payment>.`
+		payment 125000

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1205,3 +1205,26 @@ ship "Sparrow" "Sparrow (Gatling)"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
+
+ship "Surveillance Drone" "Surveillance Drone (Secure)"
+	sprite "ship/surveillance drone"
+	licenses
+		Navy
+	attributes
+		category "Drone"
+		"cost" 50000
+		"hull" 300
+		"mass" 15
+		"drag" .53
+		"heat dissipation" .9
+		"outfit space" 53
+		"weapon capacity" 0
+		"engine capacity" 28
+		"self destruct" 1
+		"automaton" 1
+	outfits
+		"nGVF-AA Fuel Cell"
+		"Surveillance Pod"
+		
+		"X1700 Ion Thruster"
+		"X1200 Ion Steering"


### PR DESCRIPTION
Added the first part of the first mission for the Omicron Forty-two mission chain - will be a Navy-related mission chain available before and after the civil war, but not during (nope, not a Navy mission arc).


I am currently only looking for feedback, this might take a while to finish.

- [ ] Set it up so that it can't be accepted during the war.
- [ ] All the missions.
- [ ] Make sure (with feedback from others) everything inside is lore-friendly.
- [ ] Spellcheck (look through from grammar issues/typos after I'm finished).

Hey, just so you know, it doesn't work yet, at all.
