### PR TITLE
Updated development readme for RPM-based distros

### DIFF
--- a/readme-developer.txt
+++ b/readme-developer.txt
@@ -6,6 +6,7 @@ Linux:
 
 Use your favorite package manager to install the following (version numbers may vary depending on your distribution):
 
+DEB-based distros:
    g++ \
    scons \
    libsdl2-dev \
@@ -14,6 +15,16 @@ Use your favorite package manager to install the following (version numbers may 
    libgl1-mesa-dev \
    libglew-dev \
    libopenal-dev
+
+RPM-based distros:
+   gcc-c++ \
+   scons \
+   SDL2-devel \
+   libpng-devel \
+   libjpeg-turbo-devel \
+   mesa-libGL-devel \
+   sglew-devel \
+   openal-soft-devel \
 
 You can then just navigate to the source code folder in a terminal and type:
 


### PR DESCRIPTION
I just moved from Mac to Fedora and found that the package names in the development readme are only accurate for DEB-based distros. Updated it with the correct package names for RPM-based distros.

Regardless, *man* was that easier than setting up a development environment on macOS.