### PR TITLE
Improving the range calculation (Ref #1826)

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2174,7 +2174,7 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 		start += ship.GetPersonality().Confusion();
 		
 		const Outfit *outfit = weapon.GetOutfit();
-		double vp = outfit->Velocity() + .5 * outfit->RandomVelocity();
+		double vp = outfit->WeightedVelocity();
 		double lifetime = outfit->TotalLifetime();
 		
 		// Homing weapons revert to "dumb firing" if they have no target.

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -79,6 +79,7 @@ void Weapon::LoadWeapon(const DataNode &node)
 		}
 		else
 		{
+<<<<<<< HEAD
 			double value = child.Value(1);
 			if(key == "lifetime")
 				lifetime = max(0., value);
@@ -150,6 +151,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 				hitForce = value;
 			else if(key == "piercing")
 				piercing = max(0., min(1., value));
+			else if((key  == "optimal range")
+				optimalRange = max(0., value);
 			else
 				child.PrintTrace("Unrecognized weapon attribute: \"" + key + "\":");
 		}
@@ -272,16 +275,38 @@ double Weapon::TotalLifetime() const
 		totalLifetime = 0.;
 		for(const auto &it : submunitions)
 			totalLifetime = max(totalLifetime, it.first->TotalLifetime());
-		totalLifetime += lifetime;
+		totalLifetime += lifetime + .5 * randomLifetime;;
 	}
 	return totalLifetime;
 }
 
 
 
+// Calculate the range of a weapon to display in the outfitter panel.
+// Has to take into account the relative velocity a parent munition
+// gives its submunitions.
 double Weapon::Range() const
 {
-	return Velocity() * TotalLifetime();
+	double range = 0.;
+
+	for(const auto &it : submunitions)
+		range = max(range, it.first->Range());
+	range += (Velocity() + .5 * RandomVelocity()) * TotalLifetime();
+
+	return range;
+}
+
+
+
+// Calculate a weighted velocity to inform AI firing decisions.
+double Weapon::WeightedVelocity() const
+{
+	if(optimalRange > 0.)
+		return optimalRange/TotalLifetime();
+	else
+	{
+		return Range()/TotalLifetime();
+	}
 }
 
 

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -108,6 +108,7 @@ public:
 	
 	double TotalLifetime() const;
 	double Range() const;
+	double WeightedVelocity() const;
 	
 	
 protected:
@@ -187,6 +188,8 @@ private:
 	mutable double damage[6] = {0., 0., 0., 0., 0., 0.};
 	
 	double piercing = 0.;
+	
+	double optimalRange = 0.;
 	
 	// Cache the calculation of these values, for faster access.
 	mutable bool calculatedDamage[6] = {false, false, false, false, false, false};


### PR DESCRIPTION
1. Random lifetime and random velocity are now supported for range calculations (Outfitter Panel, AI firing decisions).
2. The range calculation now uses full, correct submunition velocities.
3. As @Amazinite suggested, I've added an "optimal range" weapon attribute that can be specified which will override these calculations for AI firing decisions only, particularly useful for weapons with high inaccuracy / randomness where the AI would do better with a custom range.

Repost of #1857 from my rebuilt fork, original issue #1826.

@endless-sky, I hope it's okay that I've tried out building a fix for this myself. I'm really enthusiastic about this game and when I had some problems with the existing calculation it was much too tempting to try to figure out how to resolve it. Is this a realistic, reasonable PR? Would it be better if I cut out the "optimal range" part?