### PR TITLE
One-character fix for dev docs

### DIFF
--- a/readme-developer.txt
+++ b/readme-developer.txt
@@ -26,7 +26,7 @@ RPM-based distros:
    mesa-libGL-devel \
    sglew-devel \
    openal-soft-devel \
-   libmad0-devel
+   libmad-devel
 
 You can then just navigate to the source code folder in a terminal and type:
 


### PR DESCRIPTION
In the RPM world, the libmad dev package is named "libmad-devel", not "libmad0-devel" (no such package is available).