### PR TITLE
Fix typo in package list for RPM based distros

### DIFF
--- a/readme-developer.txt
+++ b/readme-developer.txt
@@ -24,7 +24,7 @@ RPM-based distros:
    libpng-devel \
    libjpeg-turbo-devel \
    mesa-libGL-devel \
-   sglew-devel \
+   glew-devel \
    openal-soft-devel \
    libmad-devel
 


### PR DESCRIPTION
I was worried you meant something different (Super-GLEW?) but...considering it's a one character difference, I think it's just a typo.