### PR TITLE
Auto conditions updated on landing before mission completion check

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -81,6 +81,7 @@ void PlayerInfo::New()
 	SetPlanet(GameData::Start().GetPlanet());
 	accounts = GameData::Start().GetAccounts();
 	GameData::Start().GetConditions().Apply(conditions);
+	UpdateAutoConditions();
 	
 	// Generate missions that will be available on the first day.
 	CreateMissions();
@@ -926,6 +927,9 @@ void PlayerInfo::Land(UI *ui)
 	// Adjust cargo cost basis for any cargo lost due to a ship being destroyed.
 	for(const auto &it : lostCargo)
 		AdjustBasis(it.first, -(costBasis[it.first] * it.second) / (cargo.Get(it.first) + it.second));
+	
+	// Bring auto conditions up-to-date for missions to check your current status.
+	UpdateAutoConditions();
 	
 	// Check for missions that are completed.
 	auto mit = missions.begin();
@@ -1803,7 +1807,6 @@ void PlayerInfo::UpdateAutoConditions()
 // New missions are generated each time you land on a planet.
 void PlayerInfo::CreateMissions()
 {
-	UpdateAutoConditions();
 	boardingMissions.clear();
 	boardingShip.reset();
 	


### PR DESCRIPTION
Previously, the "on complete" check of a mission could check out-of-date auto conditions. Now, UpdateAutoConditions() is run directly before checking for missions that can be completed.

To keep this tidy, CreateMissions() no longer runs UpdateAutoConditions at all, and PlayerInfo::New() (the only other function to run CreateMissions) runs UpdateAutoConditions itself just before.

This PR is to fix a scenario I was finding particularly with conditions like "ships: Medium Warship". If a mission has an `on complete` condition based on them, it'd check the condition as it was when you _last landed_, not as you're landing now. Leave ships behind, allow ships to catch up, have your ships destroyed or even just park/unpark since you last landed, and you'd have trouble.