### PR TITLE
No nerve gas on Trinket

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -25319,7 +25319,6 @@ planet Trinket
 	outfitter "Delta V Basics"
 	outfitter "Ammo North"
 	outfitter "Ammo South"
-	outfitter "Pirate Outfits"
 	bribe 0.02
 	security 0.4
 	tribute 500


### PR DESCRIPTION
Removed pirate outfits from Trinket so that you can't buy nerve gas et al. on what's presented as a tourist planet.