### PR TITLE
Adding Thumbs.db files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build/
 /.sconsign.dblite
 .DS_Store
+*.db
 /EndlessSky.xcodeproj/project.xcworkspace/
 /EndlessSky.xcodeproj/xcuserdata/
 /obj/Debug/


### PR DESCRIPTION
Kind of the Windows equivalent of .DS_Store files

These come up a lot when making PRs on Windows that involve images.