### PR TITLE
Add "fuel damage" weapon attribute.

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -338,6 +338,9 @@ tip "heat damage / second:"
 tip "ion damage / second:"
 	`Reduces the target's energy. Ionization slowly wears off over time.`
 
+tip "fuel damage / second:"
+	`Amount of fuel removed from target each second.`
+
 tip "slowing damage / second:"
 	`Reduces the target's turn rate, acceleration, and top speed. Slowing wears off over time.`
 
@@ -388,6 +391,9 @@ tip "heat damage / shot:"
 
 tip "ion damage / shot:"
 	`Each shot increases the target's ionization by this amount. Total energy lost is 100 times this amount.`
+
+tip "fuel damage / shot:"
+	`Amount of fuel removed from target per shot.`
 
 tip "slowing damage / shot:"
 	`Reduces the target's turn rate, acceleration, and top speed. Slowing wears off over time.`

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -229,6 +229,13 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		attributeValues.push_back(Format::Number(60. * outfit.HeatDamage() / outfit.Reload()));
 		attributesHeight += 20;
 	}
+
+	if(outfit.FuelDamage() && outfit.Reload())
+        {
+                attributeLabels.push_back("fuel damage / second:");
+                attributeValues.push_back(Format::Number(60. * outfit.FuelDamage() / outfit.Reload()));
+                attributesHeight += 20;
+        }
 	
 	if(outfit.IonDamage() && outfit.Reload())
 	{
@@ -332,6 +339,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		"shield damage / shot:",
 		"hull damage / shot:",
 		"heat damage / shot:",
+		"fuel damage / shot:",
 		"ion damage / shot:",
 		"slowing damage / shot:",
 		"disruption damage / shot:",
@@ -347,6 +355,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		outfit.ShieldDamage(),
 		outfit.HullDamage(),
 		outfit.HeatDamage(),
+		outfit.FuelDamage(),
 		outfit.IonDamage() * 100.,
 		outfit.SlowingDamage() * 100.,
 		outfit.DisruptionDamage() * 100.,

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2119,7 +2119,8 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 	double maxFuel = attributes.Get("fuel capacity");
 	if(fuel < 0.)
 		fuel = 0.;
-	else if(fuelDamage > 0. && fuel > 0.)
+	
+	if(fuelDamage > 0. && fuel > 0.)
 		fuel = max(0., fuel - fuelDamage * (1. - .5 * shieldFraction));
 	else if(fuelDamage < 0. && fuel < maxFuel)
 		fuel = min(maxFuel, fuel - fuelDamage);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1002,6 +1002,9 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 				hyperspaceOffset *= 1000. / length;
 		}
 		
+		if(fuel < 0.)
+			fuel = 0.;
+		
 		return true;
 	}
 	else if(landingPlanet || zoom < 1.)
@@ -2112,20 +2115,14 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 	disruption += disruptionDamage * (1. - .5 * shieldFraction);
 	slowness += slowingDamage * (1. - .5 * shieldFraction);
 
-	// Prevent fuel from going negative and allow recharge through shields.
+	// Prevent fuel from going negative on hit and allow recharge through shields.
 	double maxFuel = attributes.Get("fuel capacity");
-	if(fuelDamage > 0. && fuel > 0.)
-	{
-		fuel -= fuelDamage * (1. - .5 * shieldFraction);
-		if(fuel < 0.)
-			fuel = 0.;
-	}
+	if(fuel < 0.)
+		fuel = 0.;
+	else if(fuelDamage > 0. && fuel > 0.)
+		fuel = max(0., fuel - fuelDamage * (1. - .5 * shieldFraction));
 	else if(fuelDamage < 0. && fuel < maxFuel)
-	{
-		fuel -= fuelDamage;
-		if(fuel > maxFuel)
-			fuel = maxFuel;
-	}
+		fuel = min(maxFuel, fuel - fuelDamage);
 	
 	if(hitForce)
 	{

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -138,6 +138,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 				damage[HEAT_DAMAGE] = value;
 			else if(key == "ion damage")
 				damage[ION_DAMAGE] = value;
+			else if(child.Token(0) == "fuel damage")
+				damage[FUEL_DAMAGE] = child.Value(1);
 			else if(key == "disruption damage")
 				damage[DISRUPTION_DAMAGE] = value;
 			else if(key == "slowing damage")

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -95,6 +95,7 @@ public:
 	double HullDamage() const;
 	double HeatDamage() const;
 	double IonDamage() const;
+	double FuelDamage() const;
 	double DisruptionDamage() const;
 	double SlowingDamage() const;
 	
@@ -174,14 +175,15 @@ private:
 	static const int HULL_DAMAGE = 1;
 	static const int HEAT_DAMAGE = 2;
 	static const int ION_DAMAGE = 3;
-	static const int DISRUPTION_DAMAGE = 4;
-	static const int SLOWING_DAMAGE = 5;
-	mutable double damage[6] = {0., 0., 0., 0., 0., 0.};
+	static const int FUEL_DAMAGE = 4; 
+	static const int DISRUPTION_DAMAGE = 5;
+	static const int SLOWING_DAMAGE = 6;
+	mutable double damage[7] = {0., 0., 0., 0., 0., 0., 0.};
 	
 	double piercing = 0.;
 	
 	// Cache the calculation of these values, for faster access.
-	mutable bool calculatedDamage[6] = {false, false, false, false, false, false};
+	mutable bool calculatedDamage[7] = {false, false, false, false, false, false, false};
 	mutable double totalLifetime = -1.;
 };
 
@@ -230,6 +232,7 @@ inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); 
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }
 inline double Weapon::HeatDamage() const { return TotalDamage(HEAT_DAMAGE); }
 inline double Weapon::IonDamage() const { return TotalDamage(ION_DAMAGE); }
+inline double Weapon::FuelDamage() const { return TotalDamage(FUEL_DAMAGE); }
 inline double Weapon::DisruptionDamage() const { return TotalDamage(DISRUPTION_DAMAGE); }
 inline double Weapon::SlowingDamage() const { return TotalDamage(SLOWING_DAMAGE); }
 


### PR DESCRIPTION
Less effective against ships with shields active when draining. (positive values)
Ignores shields when giving. (negative values)
Ships are provoked upon fuel drainage.