### PR TITLE
Nerf cloaking device

### DIFF
--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -231,8 +231,9 @@ outfit "Cloaking Device"
 	"mass" 10
 	"outfit space" -10
 	"cloak" .01
-	"cloaking energy" 1
-	"cloaking fuel" .2
+	"cloaking energy" 7.5
+	"cloaking heat" 3.5
+	"cloaking fuel" .22
 	description "You're sure the cloaking device is here somewhere, but you can't see it."
 
 

--- a/data/pug.txt
+++ b/data/pug.txt
@@ -461,7 +461,7 @@ ship "Pug Arfecta"
 		"hull energy" 5
 		"heat generation" 10
 		"energy capacity" 10000
-		"cloaking fuel" -.2
+		"cloaking fuel" -.22
 		weapon
 			"blast radius" 320
 			"shield damage" 9000


### PR DESCRIPTION
Multiply energy by 7.5x, fuel by 1.1x and heat by... some amount, it wasn't there before.

450 energy drain and 210 heat caused, as well as draining ten percent more fuel than before.

Taking suggestions on number changes.