### PR TITLE
Scanners' descriptions mention the benefit of installing more than one

### DIFF
--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -199,7 +199,7 @@ outfit "Cargo Scanner"
 	"outfit space" -1
 	"cargo scan power" 9
 	"cargo scan speed" 1
-	description "This scanner allows you to scan the cargo holds of the ship you are currently targeting, as long as you are flying close enough to it. Patrol craft use cargo scanners to detect illegal contraband."
+	description "This scanner allows you to scan the cargo holds of the ship you are currently targeting, as long as you are flying close enough to it. Patrol craft use cargo scanners to detect illegal contraband. Installing more than one increases the scan range and speed."
 
 outfit "Outfit Scanner"
 	category "Systems"
@@ -209,7 +209,7 @@ outfit "Outfit Scanner"
 	"outfit space" -2
 	"outfit scan power" 25
 	"outfit scan speed" 1
-	description "This scanner allows you to determine what outfits are installed in the ship you are currently targeting, if you are willing to risk flying close enough to it to get a reading! The Republic Navy uses these scanners to detect when ships are equipped with illegal weaponry."
+	description "This scanner allows you to determine what outfits are installed in the ship you are currently targeting, if you are willing to risk flying close enough to it to get a reading! The Republic Navy uses these scanners to detect when ships are equipped with illegal weaponry. Installing more than one increases the scan range and speed."
 
 outfit "Surveillance Pod"
 	category "Systems"
@@ -222,7 +222,7 @@ outfit "Surveillance Pod"
 	"cargo scan power" 4
 	"cargo scan speed" 2
 	"atmosphere scan" 100
-	description "This is Republic military technology, a collection of scanners designed to fit perfectly inside one of their surveillance drones. Since the outputs are fairly standard, you could connect it to your own ship's systems if you want."
+	description "This is Republic military technology, a collection of scanners designed to fit perfectly inside one of their surveillance drones. Since the outputs are fairly standard, you could connect it to your own ship's systems if you want. Installing more than one increases the scan range and speed."
 
 
 outfit "Cloaking Device"


### PR DESCRIPTION
It's not obvious that scanners' attributes are additive, with the range and speed increasing with every additional scanner you install. I changed the descriptions to mention this.