### PR TITLE
Generic Wanderer jobs

### DIFF
--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1490,10 +1490,10 @@ mission "Cargo [0]"
 	description "Deliver <cargo> to <destination>. Payment is <payment>."
 	cargo random 5 2 .1
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 2 8
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
@@ -1507,10 +1507,10 @@ mission "Cargo [1]"
 	to offer
 		random < 90
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
@@ -1580,10 +1580,10 @@ mission "Bulk Delivery [0]"
 	to offer
 		random < 70
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 2 8
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
@@ -1597,10 +1597,10 @@ mission "Bulk Delivery [1]"
 	to offer
 		random < 60
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		payment 2000
@@ -1635,10 +1635,10 @@ mission "Rush Delivery [0]"
 	to offer
 		random < 90
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 4 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		payment 16000
@@ -1712,10 +1712,10 @@ mission "Passengers [0]"
 	description "Bring <fare> to <destination>. Payment is <payment>."
 	passengers 1 10 .9
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		payment 2000
@@ -1730,10 +1730,10 @@ mission "Passengers [1]"
 	to offer
 		random < 75
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
@@ -1989,10 +1989,10 @@ mission "Family [0]"
 		random < 60
 		"passenger space" > 10
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 4 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		payment 4000
@@ -2167,10 +2167,10 @@ mission "Large Bulk Delivery [0]"
 		random < 70
 		"cargo space" > 160
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 2 8
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		payment 4000
@@ -2186,10 +2186,10 @@ mission "Large Bulk Delivery [1]"
 		random < 60
 		"cargo space" > 160
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		payment 6000
@@ -2226,10 +2226,10 @@ mission "Large Rush Delivery [0]"
 		random < 90
 		"cargo space" > 80
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	destination
 		distance 4 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai"
 	on complete
 		payment
 		payment 36000

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -1,0 +1,577 @@
+# Copyright (c) 2014 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+mission "Wanderer Workers [0]"
+	name "Wanderer workers to <planet>"
+	job
+	repeat
+	description `These <bunk> Wanderer workers require transportation to <destination>. They will pay you <payment> to take them there.`
+	passengers 5 8 .2
+	to offer
+		has "language: Wanderer"
+		random < 80
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+		attributes factory urban
+	on complete
+		payment
+		payment 10000
+		dialog "You say farewell to your <passengers> on <planet>, and collect your payment of <payment>."
+
+mission "Wanderer Workers [1]"
+	name "Wanderer workers to <planet>"
+	job
+	repeat
+	description `These <bunk> Wanderer workers require transportation to <destination>. They will pay you <payment> to take them there.`
+	passengers 5 5 .1
+	to offer
+		has "language: Wanderer"
+		random < 70
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+		attributes factory urban
+	on complete
+		payment
+		payment 15000
+		dialog "You say farewell to your <passengers> on <planet>, and collect your payment of <payment>."
+
+mission "Wanderer Farmers [0]"
+	name "Wanderer farmers to <planet>"
+	job
+	repeat
+	description `These <bunk> Wanderer farmers require transportation to <destination>. They will pay you <payment> to take them there.`
+	passengers 5 8 .2
+	to offer
+		has "language: Wanderer"
+		random < 80
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+		attributes farming
+	on complete
+		payment
+		payment 10000
+		dialog "You say farewell to your <passengers> on <planet>, and collect your payment of <payment>."
+
+mission "Wanderer Farmers [1]"
+	name "Wanderer farmers to <planet>"
+	job
+	repeat
+	description `These <bunk> Wanderer farmers require transportation to <destination>. They will pay you <payment> to take them there.`
+	passengers 5 5 .1
+	to offer
+		has "language: Wanderer"
+		random < 70
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+		attributes farming
+	on complete
+		payment
+		payment 15000
+		dialog "You say farewell to your <passengers> on <planet>, and collect your payment of <payment>."
+
+mission "Wanderer Younglings [0]"
+	name "Wanderer younglings to <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer younglings are looking for transport to <destination> to learn more about the Wanderer terraforming process. The adult with them will pay you <payment>.`
+	passengers 11 31
+	to offer
+		has "language: Wanderer"
+		random < 70
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 10000
+		dialog `The younglings depart your ship and meet up with another group of Wanderers across the spaceport. Before following after the younglings, the adult Wanderer thanks you and hands you <payment>.`
+
+mission "Wanderer Younglings [1]"
+	name "Wanderer younglings to <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer younglings are looking for transport to <destination> to learn more about the Wanderer terraforming process. The adult with them will pay you <payment>.`
+	passengers 11 31
+	to offer
+		has "language: Wanderer"
+		random < 60
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 10000
+		dialog `The younglings depart your ship and meet up with another group of Wanderers across the spaceport. Before following after the younglings, the adult Wanderer thanks you and hands you <payment>.`
+
+mission "Wanderer Scientists (Pollution) [0]"
+	name "Spike in pollution on <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer scientists wish to get to <destination> with their <cargo> by <date> to investigate a strange spike in atmospheric pollutants. Payment will be <payment>.`
+	passengers 4 4 .2
+	cargo "scientific equipment" 5 2 .1
+	deadline
+	to offer
+		has "language: Wanderer"
+		random < 40
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+		attributes mining oil factory
+	on complete
+		payment 15000 180
+		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
+
+mission "Wanderer Scientists (Pollution) [1]"
+	name "Spike in pollution on <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer scientists wish to get to <destination> with their <cargo> by <date> to investigate a strange spike in atmospheric pollutants. Payment will be <payment>.`
+	passengers 4 4 .1
+	cargo "scientific equipment" 5 2 .1
+	deadline
+	to offer
+		has "language: Wanderer"
+		random < 30
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+		attributes mining oil factory
+	on complete
+		payment 20000 180
+		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
+
+mission "Wanderer Scientists (Phenomenon) [0]"
+	name "Natural phenomenon on <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer scientists wish to get to <destination> with their <cargo> by <date> to observe a rare natural phenomenon. Payment will be <payment>.`
+	passengers 4 4 .2
+	cargo "scientific equipment" 5 2 .1
+	deadline
+	to offer
+		has "language: Wanderer"
+		random < 40
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment 15000 180
+		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
+
+mission "Wanderer Scientists (Phenomenon) [1]"
+	name "Natural phenomenon on <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer scientists wish to get to <destination> with their <cargo> by <date> to observe a rare natural phenomenon. Payment will be <payment>.`
+	passengers 4 4 .1
+	cargo "scientific equipment" 5 2 .1
+	deadline
+	to offer
+		has "language: Wanderer"
+		random < 30
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment 20000 180
+		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
+
+mission "Wanderer Biologists [0]"
+	name "New animal found on <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer biologists wish to get to <destination> with their <cargo> to study a recently discovered animal species. Payment will be <payment>.`
+	passengers 4 4 .2
+	cargo "scientific equipment" 5 2 .1
+	to offer
+		has "language: Wanderer"
+		random < 70
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 15000
+		dialog "You wish the biologists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
+
+mission "Wanderer Biologists [1]"
+	name "New animal found on <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer biologists wish to get to <destination> with their <cargo> to study a recently discovered animal species. Payment will be <payment>.`
+	passengers 4 4 .1
+	cargo "scientific equipment" 5 2 .1
+	to offer
+		has "language: Wanderer"
+		random < 60
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 20000
+		dialog "You wish the biologists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
+
+mission "Wanderer Botanists [0]"
+	name "New plant found on <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer botanists wish to get to <destination> with their <cargo> to study a recently discovered plant species. Payment will be <payment>.`
+	passengers 4 4 .2
+	cargo "scientific equipment" 5 2 .1
+	to offer
+		has "language: Wanderer"
+		random < 70
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 15000
+		dialog "You wish the botanists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
+
+mission "Wanderer Botanists [1]"
+	name "New plant found on <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer botanists wish to get to <destination> with their <cargo> to study a recently discovered plant species. Payment will be <payment>.`
+	passengers 4 4 .1
+	cargo "scientific equipment" 5 2 .1
+	to offer
+		has "language: Wanderer"
+		random < 60
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 20000
+		dialog "You wish the botanists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
+
+mission "Wanderer Harvest [0]"
+	name "Food harvest on <planet>"
+	job
+	repeat
+	description `Bring these <bunks> Wanderers to <destination> to assist in the food harvest. Payment is <payment>.`
+	passengers 2 10 .3
+	to offer
+		has "language: Wanderer"
+		random < 60
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+		attributes farming
+	on complete
+		payment
+		payment 15000
+		dialog "You wish the Wanderers the best of luck on <planet> and collect your payment."
+
+mission "Wanderer Harvest [1]"
+	name "Food harvest on <planet>"
+	job
+	repeat
+	description `Bring these <bunks> Wanderers to <destination> to assist in the food harvest. Payment is <payment>.`
+	passengers 2 10 .2
+	to offer
+		has "language: Wanderer"
+		random < 50
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+		attributes farming
+	on complete
+		payment
+		payment 20000
+		dialog "You wish the Wanderers the best of luck on <planet> and collect your payment."
+
+mission "Wanderer Invasive Species [0]"
+	name "Invasive species on <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer need to get to <stopovers> with their <cargo> by <date> to contain an invasive animal species. Return the Wanderers here with the animals for a payment of <payment>.`
+	passengers 4 4 .2
+	cargo "containers" 5 2 .1
+	deadline
+	to offer
+		has "language: Wanderer"
+		random < 40
+	source
+		government "Wanderer"
+	stopover
+		distance 2 8
+		government "Wanderer"
+	on stopover
+		dialog `The Wanderers quickly make their way out of your ship with their equipment to contain the invasive animals. After roughly an hour, they return to your ship with cages that they place into your cargo hold. Now return to <origin> for payment.`
+	on complete
+		payment 25000 200
+		dialog `After releasing the animals, the <bunks> Wanderers each thank you for assisting them in returning the animals to <planet> and hand you <payment>.`
+
+mission "Wanderer Invasive Species [1]"
+	name "Invasive species on <planet>"
+	job
+	repeat
+	description `These <bunks> Wanderer need to get to <stopovers> with their <cargo> by <date> to contain an invasive plant species. Return the Wanderers here with the animals for a payment of <payment>.`
+	passengers 4 4 .1
+	cargo "containers" 5 2 .1
+	deadline
+	to offer
+		has "language: Wanderer"
+		random < 30
+	source
+		government "Wanderer"
+	stopover
+		distance 2 8
+		government "Wanderer"
+	on stopover
+		dialog `The Wanderers quickly make their way out of your ship with their equipment to contain the invasive plant. After roughly an hour, they return to your ship with plants in containers of some sort that they place into your cargo hold. Now return to <origin> for payment.`
+	on complete
+		payment 30000 200
+		dialog `After handing the plants off to other Wanderers to plant elsewhere, the <bunks> Wanderers each thank you for assisting them in keeping the plants on <planet> and hand you <payment>.`
+
+mission "Wanderer Cargo [0]"
+	name "Delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination>. Payment is <payment>.`
+	cargo random 4 6 .3
+	to offer
+		has "language: Wanderer"
+		random < 80
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 2000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Cargo [1]"
+	name "Delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination>. Payment is <payment>.`
+	cargo random 4 8 .3
+	to offer
+		has "language: Wanderer"
+		random < 70
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 4000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Cargo [2]"
+	name "Delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination>. Payment is <payment>.`
+	cargo random 4 11 .3
+	to offer
+		has "language: Wanderer"
+		random < 60
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 6000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Cargo [3]"
+	name "Delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination>. Payment is <payment>.`
+	cargo random 4 13 .3
+	to offer
+		has "language: Wanderer"
+		random < 50
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 8000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Cargo [4]"
+	name "Delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination>. Payment is <payment>.`
+	cargo random 4 15 .3
+	to offer
+		has "language: Wanderer"
+		random < 40
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 10000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Rush Delivery [0]"
+	name "Rush delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	cargo random 10 8 .2
+	deadline
+	to offer
+		has "language: Wanderer"
+		random < 60
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 32000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Rush Delivery [1]"
+	name "Rush delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	cargo random 10 12 .2
+	deadline
+	to offer
+		has "language: Wanderer"
+		random < 50
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 40000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Rush Delivery [2]"
+	name "Rush delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	cargo random 10 15 .2
+	deadline
+	to offer
+		has "language: Wanderer"
+		random < 40
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 44000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Rush Delivery [3]"
+	name "Rush delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	cargo random 10 18 .2
+	deadline
+	to offer
+		has "language: Wanderer"
+		random < 30
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 50000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Bulk Delivery [0]"
+	name "Bulk delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination>. Payment is <payment>.`
+	cargo random 20 6 .1
+	to offer
+		has "language: Wanderer"
+		random < 60
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 10000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Bulk Delivery [1]"
+	name "Bulk delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination>. Payment is <payment>.`
+	cargo random 30 9 .1
+	to offer
+		has "language: Wanderer"
+		random < 50
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 14000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+
+mission "Wanderer Bulk Delivery [2]"
+	name "Bulk delivery to <planet>"
+	job
+	repeat
+	description `Deliver <cargo> to <destination>. Payment is <payment>.`
+	cargo random 40 15 .1
+	to offer
+		has "language: Wanderer"
+		random < 40
+	source
+		government "Wanderer"
+	destination
+		distance 2 8
+	on complete
+		payment
+		payment 20000
+		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -332,7 +332,7 @@ mission "Wanderer Invasive Species [0]"
 	name "Invasive species on <planet>"
 	job
 	repeat
-	description `These <bunks> Wanderers need to get to <stopovers> with their <cargo> by <date> to contain an invasive animal species. Return the Wanderers here with the animals for a payment of <payment>.`
+	description `These <bunks> Wanderers need to get to <stopovers> with their <cargo> by <date> to contain an invasive animal species. Return the Wanderers to <origin> with the animals for a payment of <payment>.`
 	passengers 4 4 .2
 	cargo "containers" 5 2 .1
 	deadline
@@ -354,7 +354,7 @@ mission "Wanderer Invasive Species [1]"
 	name "Invasive species on <planet>"
 	job
 	repeat
-	description `These <bunks> Wanderers need to get to <stopovers> with their <cargo> by <date> to contain an invasive plant species. Return the Wanderers here with the animals for a payment of <payment>.`
+	description `These <bunks> Wanderers need to get to <stopovers> with their <cargo> by <date> to contain an invasive plant species. Return the Wanderers to <origin> with the animals for a payment of <payment>.`
 	passengers 4 4 .1
 	cargo "containers" 5 2 .1
 	deadline

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -22,6 +22,7 @@ mission "Wanderer Workers [0]"
 	destination
 		distance 2 8
 		attributes factory urban
+		government "Wanderer"
 	on complete
 		payment
 		payment 10000
@@ -41,6 +42,7 @@ mission "Wanderer Workers [1]"
 	destination
 		distance 2 8
 		attributes factory urban
+		government "Wanderer"
 	on complete
 		payment
 		payment 15000
@@ -60,6 +62,7 @@ mission "Wanderer Farmers [0]"
 	destination
 		distance 2 8
 		attributes farming
+		government "Wanderer"
 	on complete
 		payment
 		payment 10000
@@ -79,6 +82,7 @@ mission "Wanderer Farmers [1]"
 	destination
 		distance 2 8
 		attributes farming
+		government "Wanderer"
 	on complete
 		payment
 		payment 15000
@@ -97,6 +101,7 @@ mission "Wanderer Younglings [0]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 10000
@@ -115,6 +120,7 @@ mission "Wanderer Younglings [1]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 10000
@@ -136,6 +142,7 @@ mission "Wanderer Scientists (Pollution) [0]"
 	destination
 		distance 2 8
 		attributes mining oil factory
+		government "Wanderer"
 	on complete
 		payment 15000 180
 		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
@@ -156,6 +163,7 @@ mission "Wanderer Scientists (Pollution) [1]"
 	destination
 		distance 2 8
 		attributes mining oil factory
+		government "Wanderer"
 	on complete
 		payment 20000 180
 		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
@@ -175,6 +183,7 @@ mission "Wanderer Scientists (Phenomenon) [0]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment 15000 180
 		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
@@ -194,6 +203,7 @@ mission "Wanderer Scientists (Phenomenon) [1]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment 20000 180
 		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment."
@@ -212,6 +222,7 @@ mission "Wanderer Biologists [0]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 15000
@@ -231,6 +242,7 @@ mission "Wanderer Biologists [1]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 20000
@@ -250,6 +262,7 @@ mission "Wanderer Botanists [0]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 15000
@@ -269,6 +282,7 @@ mission "Wanderer Botanists [1]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 20000
@@ -288,6 +302,7 @@ mission "Wanderer Harvest [0]"
 	destination
 		distance 2 8
 		attributes farming
+		government "Wanderer"
 	on complete
 		payment
 		payment 15000
@@ -307,6 +322,7 @@ mission "Wanderer Harvest [1]"
 	destination
 		distance 2 8
 		attributes farming
+		government "Wanderer"
 	on complete
 		payment
 		payment 20000
@@ -369,6 +385,7 @@ mission "Wanderer Cargo [0]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 2000
@@ -387,6 +404,7 @@ mission "Wanderer Cargo [1]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 4000
@@ -405,6 +423,7 @@ mission "Wanderer Cargo [2]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 6000
@@ -423,6 +442,7 @@ mission "Wanderer Cargo [3]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 8000
@@ -441,6 +461,7 @@ mission "Wanderer Cargo [4]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 10000
@@ -460,6 +481,7 @@ mission "Wanderer Rush Delivery [0]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 32000
@@ -479,6 +501,7 @@ mission "Wanderer Rush Delivery [1]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 40000
@@ -498,6 +521,7 @@ mission "Wanderer Rush Delivery [2]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 44000
@@ -517,6 +541,7 @@ mission "Wanderer Rush Delivery [3]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 50000
@@ -535,6 +560,7 @@ mission "Wanderer Bulk Delivery [0]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 10000
@@ -553,6 +579,7 @@ mission "Wanderer Bulk Delivery [1]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 14000
@@ -571,6 +598,7 @@ mission "Wanderer Bulk Delivery [2]"
 		government "Wanderer"
 	destination
 		distance 2 8
+		government "Wanderer"
 	on complete
 		payment
 		payment 20000

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -316,7 +316,7 @@ mission "Wanderer Invasive Species [0]"
 	name "Invasive species on <planet>"
 	job
 	repeat
-	description `These <bunks> Wanderer need to get to <stopovers> with their <cargo> by <date> to contain an invasive animal species. Return the Wanderers here with the animals for a payment of <payment>.`
+	description `These <bunks> Wanderers need to get to <stopovers> with their <cargo> by <date> to contain an invasive animal species. Return the Wanderers here with the animals for a payment of <payment>.`
 	passengers 4 4 .2
 	cargo "containers" 5 2 .1
 	deadline
@@ -338,7 +338,7 @@ mission "Wanderer Invasive Species [1]"
 	name "Invasive species on <planet>"
 	job
 	repeat
-	description `These <bunks> Wanderer need to get to <stopovers> with their <cargo> by <date> to contain an invasive plant species. Return the Wanderers here with the animals for a payment of <payment>.`
+	description `These <bunks> Wanderers need to get to <stopovers> with their <cargo> by <date> to contain an invasive plant species. Return the Wanderers here with the animals for a payment of <payment>.`
 	passengers 4 4 .1
 	cargo "containers" 5 2 .1
 	deadline

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -16,7 +16,7 @@ mission "Wanderer Workers [0]"
 	passengers 5 5 .1
 	to offer
 		has "language: Wanderer"
-		random < 80
+		random < 70
 	source
 		government "Wanderer"
 	destination
@@ -36,7 +36,7 @@ mission "Wanderer Workers [1]"
 	passengers 5 3 .08
 	to offer
 		has "language: Wanderer"
-		random < 70
+		random < 60
 	source
 		government "Wanderer"
 	destination
@@ -56,7 +56,7 @@ mission "Wanderer Farmers [0]"
 	passengers 5 5 .1
 	to offer
 		has "language: Wanderer"
-		random < 80
+		random < 70
 	source
 		government "Wanderer"
 	destination
@@ -76,7 +76,7 @@ mission "Wanderer Farmers [1]"
 	passengers 5 3 .05
 	to offer
 		has "language: Wanderer"
-		random < 70
+		random < 60
 	source
 		government "Wanderer"
 	destination
@@ -96,7 +96,7 @@ mission "Wanderer Younglings [0]"
 	passengers 5 8 .2
 	to offer
 		has "language: Wanderer"
-		random < 70
+		random < 60
 	source
 		government "Wanderer"
 	destination
@@ -115,7 +115,7 @@ mission "Wanderer Younglings [1]"
 	passengers 5 5 .1
 	to offer
 		has "language: Wanderer"
-		random < 60
+		random < 50
 	source
 		government "Wanderer"
 	destination
@@ -136,7 +136,7 @@ mission "Wanderer Scientists (Pollution) [0]"
 	deadline
 	to offer
 		has "language: Wanderer"
-		random < 40
+		random < 30
 	source
 		government "Wanderer"
 	destination
@@ -157,7 +157,7 @@ mission "Wanderer Scientists (Pollution) [1]"
 	deadline
 	to offer
 		has "language: Wanderer"
-		random < 30
+		random < 20
 	source
 		government "Wanderer"
 	destination
@@ -178,7 +178,7 @@ mission "Wanderer Scientists (Phenomenon) [0]"
 	deadline
 	to offer
 		has "language: Wanderer"
-		random < 40
+		random < 30
 	source
 		government "Wanderer"
 	destination
@@ -198,7 +198,7 @@ mission "Wanderer Scientists (Phenomenon) [1]"
 	deadline
 	to offer
 		has "language: Wanderer"
-		random < 30
+		random < 20
 	source
 		government "Wanderer"
 	destination
@@ -217,7 +217,7 @@ mission "Wanderer Biologists [0]"
 	cargo "scientific equipment" 5 2 .1
 	to offer
 		has "language: Wanderer"
-		random < 70
+		random < 60
 	source
 		government "Wanderer"
 	destination
@@ -237,7 +237,7 @@ mission "Wanderer Biologists [1]"
 	cargo "scientific equipment" 5 2 .1
 	to offer
 		has "language: Wanderer"
-		random < 60
+		random < 50
 	source
 		government "Wanderer"
 	destination
@@ -257,7 +257,7 @@ mission "Wanderer Botanists [0]"
 	cargo "scientific equipment" 5 2 .1
 	to offer
 		has "language: Wanderer"
-		random < 70
+		random < 60
 	source
 		government "Wanderer"
 	destination
@@ -277,7 +277,7 @@ mission "Wanderer Botanists [1]"
 	cargo "scientific equipment" 5 2 .1
 	to offer
 		has "language: Wanderer"
-		random < 60
+		random < 50
 	source
 		government "Wanderer"
 	destination
@@ -296,7 +296,7 @@ mission "Wanderer Harvest [0]"
 	passengers 5 3 .02
 	to offer
 		has "language: Wanderer"
-		random < 60
+		random < 50
 	source
 		government "Wanderer"
 	destination
@@ -316,7 +316,7 @@ mission "Wanderer Harvest [1]"
 	passengers 5 3 .01
 	to offer
 		has "language: Wanderer"
-		random < 50
+		random < 40
 	source
 		government "Wanderer"
 	destination
@@ -338,7 +338,7 @@ mission "Wanderer Invasive Species [0]"
 	deadline
 	to offer
 		has "language: Wanderer"
-		random < 40
+		random < 30
 	source
 		government "Wanderer"
 	stopover
@@ -380,7 +380,7 @@ mission "Wanderer Cargo [0]"
 	cargo random 4 4 .2
 	to offer
 		has "language: Wanderer"
-		random < 80
+		random < 70
 	source
 		government "Wanderer"
 	destination
@@ -399,7 +399,7 @@ mission "Wanderer Cargo [1]"
 	cargo random 4 4 .17
 	to offer
 		has "language: Wanderer"
-		random < 70
+		random < 60
 	source
 		government "Wanderer"
 	destination
@@ -418,7 +418,7 @@ mission "Wanderer Cargo [2]"
 	cargo random 4 4 .15
 	to offer
 		has "language: Wanderer"
-		random < 60
+		random < 50
 	source
 		government "Wanderer"
 	destination
@@ -437,7 +437,7 @@ mission "Wanderer Cargo [3]"
 	cargo random 4 4 .12
 	to offer
 		has "language: Wanderer"
-		random < 50
+		random < 40
 	source
 		government "Wanderer"
 	destination
@@ -456,7 +456,7 @@ mission "Wanderer Cargo [4]"
 	cargo random 4 4 .1
 	to offer
 		has "language: Wanderer"
-		random < 40
+		random < 30
 	source
 		government "Wanderer"
 	destination
@@ -476,7 +476,7 @@ mission "Wanderer Rush Delivery [0]"
 	deadline
 	to offer
 		has "language: Wanderer"
-		random < 60
+		random < 50
 	source
 		government "Wanderer"
 	destination
@@ -496,7 +496,7 @@ mission "Wanderer Rush Delivery [1]"
 	deadline
 	to offer
 		has "language: Wanderer"
-		random < 50
+		random < 40
 	source
 		government "Wanderer"
 	destination
@@ -516,7 +516,7 @@ mission "Wanderer Rush Delivery [2]"
 	deadline
 	to offer
 		has "language: Wanderer"
-		random < 40
+		random < 30
 	source
 		government "Wanderer"
 	destination
@@ -536,7 +536,7 @@ mission "Wanderer Rush Delivery [3]"
 	deadline
 	to offer
 		has "language: Wanderer"
-		random < 30
+		random < 20
 	source
 		government "Wanderer"
 	destination
@@ -555,7 +555,7 @@ mission "Wanderer Bulk Delivery [0]"
 	cargo random 30 4 .1
 	to offer
 		has "language: Wanderer"
-		random < 60
+		random < 50
 	source
 		government "Wanderer"
 	destination
@@ -574,7 +574,7 @@ mission "Wanderer Bulk Delivery [1]"
 	cargo random 40 6 .1
 	to offer
 		has "language: Wanderer"
-		random < 50
+		random < 40
 	source
 		government "Wanderer"
 	destination
@@ -593,7 +593,7 @@ mission "Wanderer Bulk Delivery [2]"
 	cargo random 50 10 .1
 	to offer
 		has "language: Wanderer"
-		random < 40
+		random < 30
 	source
 		government "Wanderer"
 	destination

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -12,7 +12,7 @@ mission "Wanderer Workers [0]"
 	name "Wanderer workers to <planet>"
 	job
 	repeat
-	description `These <bunk> Wanderer workers require transportation to <destination>. They will pay you <payment> to take them there.`
+	description `These <bunks> Wanderer workers require transportation to <destination>. They will pay you <payment> to take them there.`
 	passengers 5 8 .2
 	to offer
 		has "language: Wanderer"
@@ -31,7 +31,7 @@ mission "Wanderer Workers [1]"
 	name "Wanderer workers to <planet>"
 	job
 	repeat
-	description `These <bunk> Wanderer workers require transportation to <destination>. They will pay you <payment> to take them there.`
+	description `These <bunks> Wanderer workers require transportation to <destination>. They will pay you <payment> to take them there.`
 	passengers 5 5 .1
 	to offer
 		has "language: Wanderer"
@@ -50,7 +50,7 @@ mission "Wanderer Farmers [0]"
 	name "Wanderer farmers to <planet>"
 	job
 	repeat
-	description `These <bunk> Wanderer farmers require transportation to <destination>. They will pay you <payment> to take them there.`
+	description `These <bunks> Wanderer farmers require transportation to <destination>. They will pay you <payment> to take them there.`
 	passengers 5 8 .2
 	to offer
 		has "language: Wanderer"
@@ -69,7 +69,7 @@ mission "Wanderer Farmers [1]"
 	name "Wanderer farmers to <planet>"
 	job
 	repeat
-	description `These <bunk> Wanderer farmers require transportation to <destination>. They will pay you <payment> to take them there.`
+	description `These <bunks> Wanderer farmers require transportation to <destination>. They will pay you <payment> to take them there.`
 	passengers 5 5 .1
 	to offer
 		has "language: Wanderer"

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -13,7 +13,7 @@ mission "Wanderer Workers [0]"
 	job
 	repeat
 	description `These <bunks> Wanderer workers require transportation to <destination>. They will pay you <payment> to take them there.`
-	passengers 5 8 .2
+	passengers 5 5 .1
 	to offer
 		has "language: Wanderer"
 		random < 80
@@ -33,7 +33,7 @@ mission "Wanderer Workers [1]"
 	job
 	repeat
 	description `These <bunks> Wanderer workers require transportation to <destination>. They will pay you <payment> to take them there.`
-	passengers 5 5 .1
+	passengers 5 3 .08
 	to offer
 		has "language: Wanderer"
 		random < 70
@@ -53,7 +53,7 @@ mission "Wanderer Farmers [0]"
 	job
 	repeat
 	description `These <bunks> Wanderer farmers require transportation to <destination>. They will pay you <payment> to take them there.`
-	passengers 5 8 .2
+	passengers 5 5 .1
 	to offer
 		has "language: Wanderer"
 		random < 80
@@ -73,7 +73,7 @@ mission "Wanderer Farmers [1]"
 	job
 	repeat
 	description `These <bunks> Wanderer farmers require transportation to <destination>. They will pay you <payment> to take them there.`
-	passengers 5 5 .1
+	passengers 5 3 .05
 	to offer
 		has "language: Wanderer"
 		random < 70
@@ -93,7 +93,7 @@ mission "Wanderer Younglings [0]"
 	job
 	repeat
 	description `These <bunks> Wanderer younglings are looking for transport to <destination> to learn more about the Wanderer terraforming process. The adult with them will pay you <payment>.`
-	passengers 11 31
+	passengers 5 8 .2
 	to offer
 		has "language: Wanderer"
 		random < 70
@@ -112,7 +112,7 @@ mission "Wanderer Younglings [1]"
 	job
 	repeat
 	description `These <bunks> Wanderer younglings are looking for transport to <destination> to learn more about the Wanderer terraforming process. The adult with them will pay you <payment>.`
-	passengers 11 31
+	passengers 5 5 .1
 	to offer
 		has "language: Wanderer"
 		random < 60
@@ -131,7 +131,7 @@ mission "Wanderer Scientists (Pollution) [0]"
 	job
 	repeat
 	description `These <bunks> Wanderer scientists wish to get to <destination> with their <cargo> by <date> to investigate a strange spike in atmospheric pollutants. Payment will be <payment>.`
-	passengers 4 4 .2
+	passengers 4 4 .1
 	cargo "scientific equipment" 5 2 .1
 	deadline
 	to offer
@@ -152,7 +152,7 @@ mission "Wanderer Scientists (Pollution) [1]"
 	job
 	repeat
 	description `These <bunks> Wanderer scientists wish to get to <destination> with their <cargo> by <date> to investigate a strange spike in atmospheric pollutants. Payment will be <payment>.`
-	passengers 4 4 .1
+	passengers 4 4 .05
 	cargo "scientific equipment" 5 2 .1
 	deadline
 	to offer
@@ -173,7 +173,7 @@ mission "Wanderer Scientists (Phenomenon) [0]"
 	job
 	repeat
 	description `These <bunks> Wanderer scientists wish to get to <destination> with their <cargo> by <date> to observe a rare natural phenomenon. Payment will be <payment>.`
-	passengers 4 4 .2
+	passengers 4 4 .1
 	cargo "scientific equipment" 5 2 .1
 	deadline
 	to offer
@@ -193,7 +193,7 @@ mission "Wanderer Scientists (Phenomenon) [1]"
 	job
 	repeat
 	description `These <bunks> Wanderer scientists wish to get to <destination> with their <cargo> by <date> to observe a rare natural phenomenon. Payment will be <payment>.`
-	passengers 4 4 .1
+	passengers 4 4 .05
 	cargo "scientific equipment" 5 2 .1
 	deadline
 	to offer
@@ -213,7 +213,7 @@ mission "Wanderer Biologists [0]"
 	job
 	repeat
 	description `These <bunks> Wanderer biologists wish to get to <destination> with their <cargo> to study a recently discovered animal species. Payment will be <payment>.`
-	passengers 4 4 .2
+	passengers 4 4 .1
 	cargo "scientific equipment" 5 2 .1
 	to offer
 		has "language: Wanderer"
@@ -233,7 +233,7 @@ mission "Wanderer Biologists [1]"
 	job
 	repeat
 	description `These <bunks> Wanderer biologists wish to get to <destination> with their <cargo> to study a recently discovered animal species. Payment will be <payment>.`
-	passengers 4 4 .1
+	passengers 4 4 .05
 	cargo "scientific equipment" 5 2 .1
 	to offer
 		has "language: Wanderer"
@@ -253,7 +253,7 @@ mission "Wanderer Botanists [0]"
 	job
 	repeat
 	description `These <bunks> Wanderer botanists wish to get to <destination> with their <cargo> to study a recently discovered plant species. Payment will be <payment>.`
-	passengers 4 4 .2
+	passengers 4 4 .1
 	cargo "scientific equipment" 5 2 .1
 	to offer
 		has "language: Wanderer"
@@ -273,7 +273,7 @@ mission "Wanderer Botanists [1]"
 	job
 	repeat
 	description `These <bunks> Wanderer botanists wish to get to <destination> with their <cargo> to study a recently discovered plant species. Payment will be <payment>.`
-	passengers 4 4 .1
+	passengers 4 4 .05
 	cargo "scientific equipment" 5 2 .1
 	to offer
 		has "language: Wanderer"
@@ -293,7 +293,7 @@ mission "Wanderer Harvest [0]"
 	job
 	repeat
 	description `Bring these <bunks> Wanderers to <destination> to assist in the food harvest. Payment is <payment>.`
-	passengers 2 10 .3
+	passengers 5 3 .02
 	to offer
 		has "language: Wanderer"
 		random < 60
@@ -313,7 +313,7 @@ mission "Wanderer Harvest [1]"
 	job
 	repeat
 	description `Bring these <bunks> Wanderers to <destination> to assist in the food harvest. Payment is <payment>.`
-	passengers 2 10 .2
+	passengers 5 3 .01
 	to offer
 		has "language: Wanderer"
 		random < 50
@@ -333,7 +333,7 @@ mission "Wanderer Invasive Species [0]"
 	job
 	repeat
 	description `These <bunks> Wanderers need to get to <stopovers> with their <cargo> by <date> to contain an invasive animal species. Return the Wanderers to <origin> with the animals for a payment of <payment>.`
-	passengers 4 4 .2
+	passengers 4 4 .1
 	cargo "containers" 5 2 .1
 	deadline
 	to offer
@@ -377,7 +377,7 @@ mission "Wanderer Cargo [0]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination>. Payment is <payment>.`
-	cargo random 4 6 .3
+	cargo random 4 4 .2
 	to offer
 		has "language: Wanderer"
 		random < 80
@@ -396,7 +396,7 @@ mission "Wanderer Cargo [1]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination>. Payment is <payment>.`
-	cargo random 4 8 .3
+	cargo random 4 4 .17
 	to offer
 		has "language: Wanderer"
 		random < 70
@@ -415,7 +415,7 @@ mission "Wanderer Cargo [2]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination>. Payment is <payment>.`
-	cargo random 4 11 .3
+	cargo random 4 4 .15
 	to offer
 		has "language: Wanderer"
 		random < 60
@@ -434,7 +434,7 @@ mission "Wanderer Cargo [3]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination>. Payment is <payment>.`
-	cargo random 4 13 .3
+	cargo random 4 4 .12
 	to offer
 		has "language: Wanderer"
 		random < 50
@@ -453,7 +453,7 @@ mission "Wanderer Cargo [4]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination>. Payment is <payment>.`
-	cargo random 4 15 .3
+	cargo random 4 4 .1
 	to offer
 		has "language: Wanderer"
 		random < 40
@@ -472,7 +472,7 @@ mission "Wanderer Rush Delivery [0]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
-	cargo random 10 8 .2
+	cargo random 10 8 .1
 	deadline
 	to offer
 		has "language: Wanderer"
@@ -492,7 +492,7 @@ mission "Wanderer Rush Delivery [1]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
-	cargo random 10 12 .2
+	cargo random 10 12 .1
 	deadline
 	to offer
 		has "language: Wanderer"
@@ -512,7 +512,7 @@ mission "Wanderer Rush Delivery [2]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
-	cargo random 10 15 .2
+	cargo random 10 15 .1
 	deadline
 	to offer
 		has "language: Wanderer"
@@ -532,7 +532,7 @@ mission "Wanderer Rush Delivery [3]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
-	cargo random 10 18 .2
+	cargo random 10 18 .1
 	deadline
 	to offer
 		has "language: Wanderer"
@@ -552,7 +552,7 @@ mission "Wanderer Bulk Delivery [0]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination>. Payment is <payment>.`
-	cargo random 20 6 .1
+	cargo random 30 4 .1
 	to offer
 		has "language: Wanderer"
 		random < 60
@@ -571,7 +571,7 @@ mission "Wanderer Bulk Delivery [1]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination>. Payment is <payment>.`
-	cargo random 30 9 .1
+	cargo random 40 6 .1
 	to offer
 		has "language: Wanderer"
 		random < 50
@@ -590,7 +590,7 @@ mission "Wanderer Bulk Delivery [2]"
 	job
 	repeat
 	description `Deliver <cargo> to <destination>. Payment is <payment>.`
-	cargo random 40 15 .1
+	cargo random 50 10 .1
 	to offer
 		has "language: Wanderer"
 		random < 40


### PR DESCRIPTION
12 unique (30 total) generic Wanderer jobs. Just passenger transport and cargo delivery, all available after you can speak with the Wanderers. 

I specify generic because I plan to later do story-specific jobs that are available between certain parts of the story, like special jobs to transport Wanderers through the Eye or assist the Mereti in building their Greenhouses by giving them materials that they don't have.

The passenger/cargo sizes and payments are based off of Coalition jobs. Just tell me if you want it higher or lower.

I also received some help from PompanoZombie on Steam with these, working off of some stuff that he had done.