### PR TITLE
Added Energy and Heat Summary to Ship Info Panel

### DIFF
--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -42,7 +42,7 @@ void ShipInfoDisplay::Update(const Ship &ship, const Depreciation &depreciation,
 	UpdateDescription(ship);
 	UpdateAttributes(ship, depreciation, day);
 	UpdateOutfits(ship, depreciation, day);
-
+	
 	maximumHeight = max(descriptionHeight, max(attributesHeight, outfitsHeight));
 }
 
@@ -66,11 +66,11 @@ int ShipInfoDisplay::SaleHeight() const
 void ShipInfoDisplay::DrawAttributes(const Point &topLeft) const
 {
 	Point point = Draw(topLeft, attributeLabels, attributeValues);
-
+	
 	// Get standard colors to draw with.
 	Color labelColor = *GameData::Colors().Get("medium");
 	Color valueColor = *GameData::Colors().Get("bright");
-
+	
 	Table table;
 	table.AddColumn(10, Table::LEFT);
 	table.AddColumn(WIDTH - 90, Table::RIGHT);
@@ -78,11 +78,11 @@ void ShipInfoDisplay::DrawAttributes(const Point &topLeft) const
 	table.SetHighlight(0, WIDTH);
 	table.DrawAt(point);
 	table.DrawGap(10.);
-
+	
 	table.Advance();
 	table.Draw("energy", labelColor);
 	table.Draw("heat", labelColor);
-
+	
 	for(unsigned i = 0; i < tableLabels.size(); ++i)
 	{
 		CheckHover(table, tableLabels[i]);
@@ -104,7 +104,7 @@ void ShipInfoDisplay::DrawOutfits(const Point &topLeft) const
 void ShipInfoDisplay::DrawSale(const Point &topLeft) const
 {
 	Draw(topLeft, saleLabels, saleValues);
-
+	
 	Color color = *GameData::Colors().Get("medium");
 	FillShader::Fill(topLeft + Point(.5 * WIDTH, saleHeight + 8.), Point(WIDTH - 20., 1.), color);
 }
@@ -147,13 +147,13 @@ void ShipInfoDisplay::UpdateDescription(const Ship &ship)
 void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &depreciation, int day)
 {
 	bool isGeneric = ship.Name().empty() || ship.GetPlanet();
-
+	
 	attributeLabels.clear();
 	attributeValues.clear();
 	attributesHeight = 20;
-
+	
 	const Outfit &attributes = ship.Attributes();
-
+	
 	int64_t fullCost = ship.Cost();
 	int64_t depreciated = depreciation.Value(ship, day);
 	if(depreciated == fullCost)
@@ -166,7 +166,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	}
 	attributeValues.push_back(Format::Number(depreciated));
 	attributesHeight += 20;
-
+	
 	attributeLabels.push_back(string());
 	attributeValues.push_back(string());
 	attributesHeight += 10;
@@ -217,7 +217,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(Format::Number(ship.Fuel() * fuelCapacity)
 			+ " / " + Format::Number(fuelCapacity));
 	attributesHeight += 20;
-
+	
 	double fullMass = emptyMass + (isGeneric ? attributes.Get("cargo space") : ship.Cargo().Used());
 	isGeneric &= (fullMass != emptyMass);
 	attributeLabels.push_back(string());
@@ -229,7 +229,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	attributeLabels.push_back("max speed:");
 	attributeValues.push_back(Format::Number(60. * attributes.Get("thrust") / attributes.Get("drag")));
 	attributesHeight += 20;
-
+	
 	attributeLabels.push_back("acceleration:");
 	if(!isGeneric)
 		attributeValues.push_back(Format::Number(3600. * attributes.Get("thrust") / fullMass));
@@ -237,7 +237,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(Format::Number(3600. * attributes.Get("thrust") / fullMass)
 			+ " / " + Format::Number(3600. * attributes.Get("thrust") / emptyMass));
 	attributesHeight += 20;
-
+	
 	attributeLabels.push_back("turning:");
 	if(!isGeneric)
 		attributeValues.push_back(Format::Number(60. * attributes.Get("turn") / fullMass));
@@ -245,7 +245,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(Format::Number(60. * attributes.Get("turn") / fullMass)
 			+ " / " + Format::Number(60. * attributes.Get("turn") / emptyMass));
 	attributesHeight += 20;
-
+	
 	// Find out how much outfit, engine, and weapon space the chassis has.
 	map<string, double> chassis;
 	static const string names[] = {
@@ -261,7 +261,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	for(const auto &it : ship.Outfits())
 		for(auto &cit : chassis)
 			cit.second -= it.second * it.first->Get(cit.first);
-
+	
 	attributeLabels.push_back(string());
 	attributeValues.push_back(string());
 	attributesHeight += 10;
@@ -272,7 +272,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 			+ " / " + Format::Number(chassis[names[i + 1]]));
 		attributesHeight += 20;
 	}
-
+	
 	if(ship.BaysFree(false))
 	{
 		attributeLabels.push_back("drone bays:");
@@ -285,36 +285,33 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(to_string(ship.BaysFree(true)));
 		attributesHeight += 20;
 	}
-
-
+	
 	tableLabels.clear();
 	energyTable.clear();
 	heatTable.clear();
 	// Skip a spacer and the table header.
 	attributesHeight += 30;
-
+	
 	tableLabels.push_back("idle:");
-	double idleEnergy = 60. * (attributes.Get("energy generation")
+	energyTable.push_back(Format::Number(
+		60. * (attributes.Get("energy generation")
 			+ attributes.Get("solar collection")
-			- attributes.Get("cooling energy"));
-	double idleHeat = 60. * (attributes.Get("heat generation")
+			- attributes.Get("cooling energy"))));
+	heatTable.push_back(Format::Number(
+		60. * (attributes.Get("heat generation")
 			- attributes.Get("cooling")
-			- attributes.Get("active cooling"));
-	energyTable.push_back(Format::Number(idleEnergy));
-	heatTable.push_back(Format::Number(idleHeat));
+			- attributes.Get("active cooling"))));
 	attributesHeight += 20;
-
 	tableLabels.push_back("moving:");
-	double movingEnergy = 60. * (attributes.Get("thrusting energy")
+	energyTable.push_back(Format::Number(
+		-60. * (attributes.Get("thrusting energy")
 			+ attributes.Get("reverse thrusting energy")
-			+ attributes.Get("turning energy"));
-	double movingHeat = 60. * (attributes.Get("thrusting heat")
+			+ attributes.Get("turning energy"))));
+	heatTable.push_back(Format::Number(
+		60. * (attributes.Get("thrusting heat")
 			+ attributes.Get("reverse thrusting heat")
-			+ attributes.Get("turning heat"));
-	energyTable.push_back(Format::Number(-1. * movingEnergy));
-	heatTable.push_back(Format::Number(movingHeat));
+			+ attributes.Get("turning heat"))));
 	attributesHeight += 20;
-
 	double firingEnergy = 0.;
 	double firingHeat = 0.;
 	for(const auto &it : ship.Outfits())
@@ -327,7 +324,6 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	energyTable.push_back(Format::Number(-60. * firingEnergy));
 	heatTable.push_back(Format::Number(60. * firingHeat));
 	attributesHeight += 20;
-
 	double shieldEnergy = attributes.Get("shield energy");
 	double hullEnergy = attributes.Get("hull energy");
 	tableLabels.push_back((shieldEnergy && hullEnergy) ? "shields / hull:" :
@@ -337,50 +333,11 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	double hullHeat = attributes.Get("hull heat");
 	heatTable.push_back(Format::Number(60. * (shieldHeat + hullHeat)));
 	attributesHeight += 20;
-
-	tableLabels.push_back("total:");
-	double totalEnergyLeft = idleEnergy - movingEnergy - (60. * (firingEnergy + shieldEnergy + hullEnergy));
-	double totalHeatGenerated = idleHeat + movingHeat + (60. * (firingHeat + shieldHeat + hullHeat));
-	energyTable.push_back(Format::Number(totalEnergyLeft));
-	heatTable.push_back(Format::Number(totalHeatGenerated));
-	attributesHeight += 20;
-
 	tableLabels.push_back("max:");
-	double energyCapacity = attributes.Get("energy capacity");
-	double heatMaximum = 60. * emptyMass * .1 * attributes.Get("heat dissipation");
-	energyTable.push_back(Format::Number(energyCapacity));
-	heatTable.push_back(Format::Number(heatMaximum));
-	attributesHeight += 20;
-
-	if ((energyCapacity > 0 && totalEnergyLeft < 0.1) || (totalHeatGenerated > heatMaximum))
-	{
-		//Either we're using too much energy or generating too much heat, so show that
-		//  to the user so they can make a decision on what to do
-		tableLabels.push_back("");
-
-		if (energyCapacity > 0 && totalEnergyLeft < -0.1)
-		{
-			energyTable.push_back(Format::Number(energyCapacity / totalEnergyLeft * -1) + " sec");
-		}
-		else
-		{
-			energyTable.push_back(string());
-		}
-
-		if (totalHeatGenerated > heatMaximum)
-		{
-			heatTable.push_back(Format::Number(totalHeatGenerated - heatMaximum) + " over");
-		}
-		else
-		{
-			heatTable.push_back(string());
-		}
-
-		attributesHeight += 20;
-	}
-
+	energyTable.push_back(Format::Number(attributes.Get("energy capacity")));
+	heatTable.push_back(Format::Number(60. * emptyMass * .1 * attributes.Get("heat dissipation")));
 	// Pad by 10 pixels on the top and bottom.
-	attributesHeight += 10;
+	attributesHeight += 30;
 }
 
 
@@ -390,11 +347,11 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 	outfitLabels.clear();
 	outfitValues.clear();
 	outfitsHeight = 20;
-
+	
 	map<string, map<string, int>> listing;
 	for(const auto &it : ship.Outfits())
 		listing[it.first->Category()][it.first->Name()] += it.second;
-
+	
 	for(const auto &cit : listing)
 	{
 		// Pad by 10 pixels before each category.
@@ -404,11 +361,11 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 			outfitValues.push_back(string());
 			outfitsHeight += 10;
 		}
-
+				
 		outfitLabels.push_back(cit.first + ':');
 		outfitValues.push_back(string());
 		outfitsHeight += 20;
-
+		
 		for(const auto &it : cit.second)
 		{
 			outfitLabels.push_back(it.first);
@@ -416,14 +373,14 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 			outfitsHeight += 20;
 		}
 	}
-
-
+	
+	
 	int64_t totalCost = depreciation.Value(ship, day);
 	int64_t chassisCost = depreciation.Value(GameData::Ships().Get(ship.ModelName()), day);
 	saleLabels.clear();
 	saleValues.clear();
 	saleHeight = 20;
-
+	
 	saleLabels.push_back("This ship will sell for:");
 	saleValues.push_back(string());
 	saleHeight += 20;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -286,7 +286,6 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributesHeight += 20;
 	}
 	
-
 	tableLabels.clear();
 	energyTable.clear();
 	heatTable.clear();
@@ -294,27 +293,25 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	attributesHeight += 30;
 	
 	tableLabels.push_back("idle:");
-	double idleEnergy = 60. * (attributes.Get("energy generation")
+	energyTable.push_back(Format::Number(
+		60. * (attributes.Get("energy generation")
 			+ attributes.Get("solar collection")
-			- attributes.Get("cooling energy"));
-	double idleHeat = 60. * (attributes.Get("heat generation")
+			- attributes.Get("cooling energy"))));
+	heatTable.push_back(Format::Number(
+		60. * (attributes.Get("heat generation")
 			- attributes.Get("cooling")
-			- attributes.Get("active cooling"));
-	energyTable.push_back(Format::Number(idleEnergy));
-	heatTable.push_back(Format::Number(idleHeat));
+			- attributes.Get("active cooling"))));
 	attributesHeight += 20;
-
 	tableLabels.push_back("moving:");
-	double movingEnergy = 60. * (attributes.Get("thrusting energy")
+	energyTable.push_back(Format::Number(
+		-60. * (attributes.Get("thrusting energy")
 			+ attributes.Get("reverse thrusting energy")
-			+ attributes.Get("turning energy"));
-	double movingHeat = 60. * (attributes.Get("thrusting heat")
+			+ attributes.Get("turning energy"))));
+	heatTable.push_back(Format::Number(
+		60. * (attributes.Get("thrusting heat")
 			+ attributes.Get("reverse thrusting heat")
-			+ attributes.Get("turning heat"));
-	energyTable.push_back(Format::Number(-1. * movingEnergy));
-	heatTable.push_back(Format::Number(movingHeat));
+			+ attributes.Get("turning heat"))));
 	attributesHeight += 20;
-
 	double firingEnergy = 0.;
 	double firingHeat = 0.;
 	for(const auto &it : ship.Outfits())
@@ -327,7 +324,6 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	energyTable.push_back(Format::Number(-60. * firingEnergy));
 	heatTable.push_back(Format::Number(60. * firingHeat));
 	attributesHeight += 20;
-
 	double shieldEnergy = attributes.Get("shield energy");
 	double hullEnergy = attributes.Get("hull energy");
 	tableLabels.push_back((shieldEnergy && hullEnergy) ? "shields / hull:" :
@@ -337,50 +333,11 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	double hullHeat = attributes.Get("hull heat");
 	heatTable.push_back(Format::Number(60. * (shieldHeat + hullHeat)));
 	attributesHeight += 20;
-
-	tableLabels.push_back("total:");
-	double totalEnergyLeft = idleEnergy - movingEnergy - (60. * (firingEnergy + shieldEnergy + hullEnergy));
-	double totalHeatGenerated = idleHeat + movingHeat + (60. * (firingHeat + shieldHeat + hullHeat));
-	energyTable.push_back(Format::Number(totalEnergyLeft));
-	heatTable.push_back(Format::Number(totalHeatGenerated));
-	attributesHeight += 20;
-
 	tableLabels.push_back("max:");
-	double energyCapacity = attributes.Get("energy capacity");
-	double heatMaximum = 60. * emptyMass * .1 * attributes.Get("heat dissipation");
-	energyTable.push_back(Format::Number(energyCapacity));
-	heatTable.push_back(Format::Number(heatMaximum));
-	attributesHeight += 20;
-
-	if ((energyCapacity > 0 && totalEnergyLeft < 0.1) || (totalHeatGenerated > heatMaximum))
-	{
-		//Either we're using too much energy or generating too much heat, so show that
-		//  to the user so they can make a decision on what to do
-		tableLabels.push_back("");
-
-		if (energyCapacity > 0 && totalEnergyLeft < -0.1)
-		{
-			energyTable.push_back(Format::Number(energyCapacity / totalEnergyLeft * -1) + " sec");
-		}
-		else
-		{
-			energyTable.push_back(string());
-		}
-
-		if (totalHeatGenerated > heatMaximum)
-		{
-			heatTable.push_back(Format::Number(totalHeatGenerated - heatMaximum) + " over");
-		}
-		else
-		{
-			heatTable.push_back(string());
-		}
-
-		attributesHeight += 20;
-	}
-
+	energyTable.push_back(Format::Number(attributes.Get("energy capacity")));
+	heatTable.push_back(Format::Number(60. * emptyMass * .1 * attributes.Get("heat dissipation")));
 	// Pad by 10 pixels on the top and bottom.
-	attributesHeight += 10;
+	attributesHeight += 30;
 }
 
 
@@ -390,11 +347,11 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 	outfitLabels.clear();
 	outfitValues.clear();
 	outfitsHeight = 20;
-
+	
 	map<string, map<string, int>> listing;
 	for(const auto &it : ship.Outfits())
 		listing[it.first->Category()][it.first->Name()] += it.second;
-
+	
 	for(const auto &cit : listing)
 	{
 		// Pad by 10 pixels before each category.
@@ -404,11 +361,11 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 			outfitValues.push_back(string());
 			outfitsHeight += 10;
 		}
-
+				
 		outfitLabels.push_back(cit.first + ':');
 		outfitValues.push_back(string());
 		outfitsHeight += 20;
-
+		
 		for(const auto &it : cit.second)
 		{
 			outfitLabels.push_back(it.first);
@@ -416,14 +373,14 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 			outfitsHeight += 20;
 		}
 	}
-
-
+	
+	
 	int64_t totalCost = depreciation.Value(ship, day);
 	int64_t chassisCost = depreciation.Value(GameData::Ships().Get(ship.ModelName()), day);
 	saleLabels.clear();
 	saleValues.clear();
 	saleHeight = 20;
-
+	
 	saleLabels.push_back("This ship will sell for:");
 	saleValues.push_back(string());
 	saleHeight += 20;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -286,6 +286,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributesHeight += 20;
 	}
 	
+
 	tableLabels.clear();
 	energyTable.clear();
 	heatTable.clear();
@@ -293,25 +294,27 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	attributesHeight += 30;
 	
 	tableLabels.push_back("idle:");
-	energyTable.push_back(Format::Number(
-		60. * (attributes.Get("energy generation")
+	double idleEnergy = 60. * (attributes.Get("energy generation")
 			+ attributes.Get("solar collection")
-			- attributes.Get("cooling energy"))));
-	heatTable.push_back(Format::Number(
-		60. * (attributes.Get("heat generation")
+			- attributes.Get("cooling energy"));
+	double idleHeat = 60. * (attributes.Get("heat generation")
 			- attributes.Get("cooling")
-			- attributes.Get("active cooling"))));
+			- attributes.Get("active cooling"));
+	energyTable.push_back(Format::Number(idleEnergy));
+	heatTable.push_back(Format::Number(idleHeat));
 	attributesHeight += 20;
+
 	tableLabels.push_back("moving:");
-	energyTable.push_back(Format::Number(
-		-60. * (attributes.Get("thrusting energy")
+	double movingEnergy = 60. * (attributes.Get("thrusting energy")
 			+ attributes.Get("reverse thrusting energy")
-			+ attributes.Get("turning energy"))));
-	heatTable.push_back(Format::Number(
-		60. * (attributes.Get("thrusting heat")
+			+ attributes.Get("turning energy"));
+	double movingHeat = 60. * (attributes.Get("thrusting heat")
 			+ attributes.Get("reverse thrusting heat")
-			+ attributes.Get("turning heat"))));
+			+ attributes.Get("turning heat"));
+	energyTable.push_back(Format::Number(-1. * movingEnergy));
+	heatTable.push_back(Format::Number(movingHeat));
 	attributesHeight += 20;
+
 	double firingEnergy = 0.;
 	double firingHeat = 0.;
 	for(const auto &it : ship.Outfits())
@@ -324,6 +327,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	energyTable.push_back(Format::Number(-60. * firingEnergy));
 	heatTable.push_back(Format::Number(60. * firingHeat));
 	attributesHeight += 20;
+
 	double shieldEnergy = attributes.Get("shield energy");
 	double hullEnergy = attributes.Get("hull energy");
 	tableLabels.push_back((shieldEnergy && hullEnergy) ? "shields / hull:" :
@@ -333,11 +337,50 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	double hullHeat = attributes.Get("hull heat");
 	heatTable.push_back(Format::Number(60. * (shieldHeat + hullHeat)));
 	attributesHeight += 20;
+
+	tableLabels.push_back("total:");
+	double totalEnergyLeft = idleEnergy - movingEnergy - (60. * (firingEnergy + shieldEnergy + hullEnergy));
+	double totalHeatGenerated = idleHeat + movingHeat + (60. * (firingHeat + shieldHeat + hullHeat));
+	energyTable.push_back(Format::Number(totalEnergyLeft));
+	heatTable.push_back(Format::Number(totalHeatGenerated));
+	attributesHeight += 20;
+
 	tableLabels.push_back("max:");
-	energyTable.push_back(Format::Number(attributes.Get("energy capacity")));
-	heatTable.push_back(Format::Number(60. * emptyMass * .1 * attributes.Get("heat dissipation")));
+	double energyCapacity = attributes.Get("energy capacity");
+	double heatMaximum = 60. * emptyMass * .1 * attributes.Get("heat dissipation");
+	energyTable.push_back(Format::Number(energyCapacity));
+	heatTable.push_back(Format::Number(heatMaximum));
+	attributesHeight += 20;
+
+	if ((energyCapacity > 0 && totalEnergyLeft < 0.1) || (totalHeatGenerated > heatMaximum))
+	{
+		//Either we're using too much energy or generating too much heat, so show that
+		//  to the user so they can make a decision on what to do
+		tableLabels.push_back("");
+
+		if (energyCapacity > 0 && totalEnergyLeft < -0.1)
+		{
+			energyTable.push_back(Format::Number(energyCapacity / totalEnergyLeft * -1) + " sec");
+		}
+		else
+		{
+			energyTable.push_back(string());
+		}
+
+		if (totalHeatGenerated > heatMaximum)
+		{
+			heatTable.push_back(Format::Number(totalHeatGenerated - heatMaximum) + " over");
+		}
+		else
+		{
+			heatTable.push_back(string());
+		}
+
+		attributesHeight += 20;
+	}
+
 	// Pad by 10 pixels on the top and bottom.
-	attributesHeight += 30;
+	attributesHeight += 10;
 }
 
 
@@ -347,11 +390,11 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 	outfitLabels.clear();
 	outfitValues.clear();
 	outfitsHeight = 20;
-	
+
 	map<string, map<string, int>> listing;
 	for(const auto &it : ship.Outfits())
 		listing[it.first->Category()][it.first->Name()] += it.second;
-	
+
 	for(const auto &cit : listing)
 	{
 		// Pad by 10 pixels before each category.
@@ -361,11 +404,11 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 			outfitValues.push_back(string());
 			outfitsHeight += 10;
 		}
-				
+
 		outfitLabels.push_back(cit.first + ':');
 		outfitValues.push_back(string());
 		outfitsHeight += 20;
-		
+
 		for(const auto &it : cit.second)
 		{
 			outfitLabels.push_back(it.first);
@@ -373,14 +416,14 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 			outfitsHeight += 20;
 		}
 	}
-	
-	
+
+
 	int64_t totalCost = depreciation.Value(ship, day);
 	int64_t chassisCost = depreciation.Value(GameData::Ships().Get(ship.ModelName()), day);
 	saleLabels.clear();
 	saleValues.clear();
 	saleHeight = 20;
-	
+
 	saleLabels.push_back("This ship will sell for:");
 	saleValues.push_back(string());
 	saleHeight += 20;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -42,7 +42,7 @@ void ShipInfoDisplay::Update(const Ship &ship, const Depreciation &depreciation,
 	UpdateDescription(ship);
 	UpdateAttributes(ship, depreciation, day);
 	UpdateOutfits(ship, depreciation, day);
-	
+
 	maximumHeight = max(descriptionHeight, max(attributesHeight, outfitsHeight));
 }
 
@@ -66,11 +66,11 @@ int ShipInfoDisplay::SaleHeight() const
 void ShipInfoDisplay::DrawAttributes(const Point &topLeft) const
 {
 	Point point = Draw(topLeft, attributeLabels, attributeValues);
-	
+
 	// Get standard colors to draw with.
 	Color labelColor = *GameData::Colors().Get("medium");
 	Color valueColor = *GameData::Colors().Get("bright");
-	
+
 	Table table;
 	table.AddColumn(10, Table::LEFT);
 	table.AddColumn(WIDTH - 90, Table::RIGHT);
@@ -78,11 +78,11 @@ void ShipInfoDisplay::DrawAttributes(const Point &topLeft) const
 	table.SetHighlight(0, WIDTH);
 	table.DrawAt(point);
 	table.DrawGap(10.);
-	
+
 	table.Advance();
 	table.Draw("energy", labelColor);
 	table.Draw("heat", labelColor);
-	
+
 	for(unsigned i = 0; i < tableLabels.size(); ++i)
 	{
 		CheckHover(table, tableLabels[i]);
@@ -104,7 +104,7 @@ void ShipInfoDisplay::DrawOutfits(const Point &topLeft) const
 void ShipInfoDisplay::DrawSale(const Point &topLeft) const
 {
 	Draw(topLeft, saleLabels, saleValues);
-	
+
 	Color color = *GameData::Colors().Get("medium");
 	FillShader::Fill(topLeft + Point(.5 * WIDTH, saleHeight + 8.), Point(WIDTH - 20., 1.), color);
 }
@@ -147,13 +147,13 @@ void ShipInfoDisplay::UpdateDescription(const Ship &ship)
 void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &depreciation, int day)
 {
 	bool isGeneric = ship.Name().empty() || ship.GetPlanet();
-	
+
 	attributeLabels.clear();
 	attributeValues.clear();
 	attributesHeight = 20;
-	
+
 	const Outfit &attributes = ship.Attributes();
-	
+
 	int64_t fullCost = ship.Cost();
 	int64_t depreciated = depreciation.Value(ship, day);
 	if(depreciated == fullCost)
@@ -166,7 +166,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	}
 	attributeValues.push_back(Format::Number(depreciated));
 	attributesHeight += 20;
-	
+
 	attributeLabels.push_back(string());
 	attributeValues.push_back(string());
 	attributesHeight += 10;
@@ -217,7 +217,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(Format::Number(ship.Fuel() * fuelCapacity)
 			+ " / " + Format::Number(fuelCapacity));
 	attributesHeight += 20;
-	
+
 	double fullMass = emptyMass + (isGeneric ? attributes.Get("cargo space") : ship.Cargo().Used());
 	isGeneric &= (fullMass != emptyMass);
 	attributeLabels.push_back(string());
@@ -229,7 +229,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	attributeLabels.push_back("max speed:");
 	attributeValues.push_back(Format::Number(60. * attributes.Get("thrust") / attributes.Get("drag")));
 	attributesHeight += 20;
-	
+
 	attributeLabels.push_back("acceleration:");
 	if(!isGeneric)
 		attributeValues.push_back(Format::Number(3600. * attributes.Get("thrust") / fullMass));
@@ -237,7 +237,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(Format::Number(3600. * attributes.Get("thrust") / fullMass)
 			+ " / " + Format::Number(3600. * attributes.Get("thrust") / emptyMass));
 	attributesHeight += 20;
-	
+
 	attributeLabels.push_back("turning:");
 	if(!isGeneric)
 		attributeValues.push_back(Format::Number(60. * attributes.Get("turn") / fullMass));
@@ -245,7 +245,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(Format::Number(60. * attributes.Get("turn") / fullMass)
 			+ " / " + Format::Number(60. * attributes.Get("turn") / emptyMass));
 	attributesHeight += 20;
-	
+
 	// Find out how much outfit, engine, and weapon space the chassis has.
 	map<string, double> chassis;
 	static const string names[] = {
@@ -261,7 +261,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	for(const auto &it : ship.Outfits())
 		for(auto &cit : chassis)
 			cit.second -= it.second * it.first->Get(cit.first);
-	
+
 	attributeLabels.push_back(string());
 	attributeValues.push_back(string());
 	attributesHeight += 10;
@@ -272,7 +272,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 			+ " / " + Format::Number(chassis[names[i + 1]]));
 		attributesHeight += 20;
 	}
-	
+
 	if(ship.BaysFree(false))
 	{
 		attributeLabels.push_back("drone bays:");
@@ -285,33 +285,36 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(to_string(ship.BaysFree(true)));
 		attributesHeight += 20;
 	}
-	
+
+
 	tableLabels.clear();
 	energyTable.clear();
 	heatTable.clear();
 	// Skip a spacer and the table header.
 	attributesHeight += 30;
-	
+
 	tableLabels.push_back("idle:");
-	energyTable.push_back(Format::Number(
-		60. * (attributes.Get("energy generation")
+	double idleEnergy = 60. * (attributes.Get("energy generation")
 			+ attributes.Get("solar collection")
-			- attributes.Get("cooling energy"))));
-	heatTable.push_back(Format::Number(
-		60. * (attributes.Get("heat generation")
+			- attributes.Get("cooling energy"));
+	double idleHeat = 60. * (attributes.Get("heat generation")
 			- attributes.Get("cooling")
-			- attributes.Get("active cooling"))));
+			- attributes.Get("active cooling"));
+	energyTable.push_back(Format::Number(idleEnergy));
+	heatTable.push_back(Format::Number(idleHeat));
 	attributesHeight += 20;
+
 	tableLabels.push_back("moving:");
-	energyTable.push_back(Format::Number(
-		-60. * (attributes.Get("thrusting energy")
+	double movingEnergy = 60. * (attributes.Get("thrusting energy")
 			+ attributes.Get("reverse thrusting energy")
-			+ attributes.Get("turning energy"))));
-	heatTable.push_back(Format::Number(
-		60. * (attributes.Get("thrusting heat")
+			+ attributes.Get("turning energy"));
+	double movingHeat = 60. * (attributes.Get("thrusting heat")
 			+ attributes.Get("reverse thrusting heat")
-			+ attributes.Get("turning heat"))));
+			+ attributes.Get("turning heat"));
+	energyTable.push_back(Format::Number(-1. * movingEnergy));
+	heatTable.push_back(Format::Number(movingHeat));
 	attributesHeight += 20;
+
 	double firingEnergy = 0.;
 	double firingHeat = 0.;
 	for(const auto &it : ship.Outfits())
@@ -324,6 +327,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	energyTable.push_back(Format::Number(-60. * firingEnergy));
 	heatTable.push_back(Format::Number(60. * firingHeat));
 	attributesHeight += 20;
+
 	double shieldEnergy = attributes.Get("shield energy");
 	double hullEnergy = attributes.Get("hull energy");
 	tableLabels.push_back((shieldEnergy && hullEnergy) ? "shields / hull:" :
@@ -333,11 +337,50 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	double hullHeat = attributes.Get("hull heat");
 	heatTable.push_back(Format::Number(60. * (shieldHeat + hullHeat)));
 	attributesHeight += 20;
+
+	tableLabels.push_back("total:");
+	double totalEnergyLeft = idleEnergy - movingEnergy - (60. * (firingEnergy + shieldEnergy + hullEnergy));
+	double totalHeatGenerated = idleHeat + movingHeat + (60. * (firingHeat + shieldHeat + hullHeat));
+	energyTable.push_back(Format::Number(totalEnergyLeft));
+	heatTable.push_back(Format::Number(totalHeatGenerated));
+	attributesHeight += 20;
+
 	tableLabels.push_back("max:");
-	energyTable.push_back(Format::Number(attributes.Get("energy capacity")));
-	heatTable.push_back(Format::Number(60. * emptyMass * .1 * attributes.Get("heat dissipation")));
+	double energyCapacity = attributes.Get("energy capacity");
+	double heatMaximum = 60. * emptyMass * .1 * attributes.Get("heat dissipation");
+	energyTable.push_back(Format::Number(energyCapacity));
+	heatTable.push_back(Format::Number(heatMaximum));
+	attributesHeight += 20;
+
+	if ((energyCapacity > 0 && totalEnergyLeft < 0.1) || (totalHeatGenerated > heatMaximum))
+	{
+		//Either we're using too much energy or generating too much heat, so show that
+		//  to the user so they can make a decision on what to do
+		tableLabels.push_back("");
+
+		if (energyCapacity > 0 && totalEnergyLeft < -0.1)
+		{
+			energyTable.push_back(Format::Number(energyCapacity / totalEnergyLeft * -1) + " sec");
+		}
+		else
+		{
+			energyTable.push_back(string());
+		}
+
+		if (totalHeatGenerated > heatMaximum)
+		{
+			heatTable.push_back(Format::Number(totalHeatGenerated - heatMaximum) + " over");
+		}
+		else
+		{
+			heatTable.push_back(string());
+		}
+
+		attributesHeight += 20;
+	}
+
 	// Pad by 10 pixels on the top and bottom.
-	attributesHeight += 30;
+	attributesHeight += 10;
 }
 
 
@@ -347,11 +390,11 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 	outfitLabels.clear();
 	outfitValues.clear();
 	outfitsHeight = 20;
-	
+
 	map<string, map<string, int>> listing;
 	for(const auto &it : ship.Outfits())
 		listing[it.first->Category()][it.first->Name()] += it.second;
-	
+
 	for(const auto &cit : listing)
 	{
 		// Pad by 10 pixels before each category.
@@ -361,11 +404,11 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 			outfitValues.push_back(string());
 			outfitsHeight += 10;
 		}
-				
+
 		outfitLabels.push_back(cit.first + ':');
 		outfitValues.push_back(string());
 		outfitsHeight += 20;
-		
+
 		for(const auto &it : cit.second)
 		{
 			outfitLabels.push_back(it.first);
@@ -373,14 +416,14 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 			outfitsHeight += 20;
 		}
 	}
-	
-	
+
+
 	int64_t totalCost = depreciation.Value(ship, day);
 	int64_t chassisCost = depreciation.Value(GameData::Ships().Get(ship.ModelName()), day);
 	saleLabels.clear();
 	saleValues.clear();
 	saleHeight = 20;
-	
+
 	saleLabels.push_back("This ship will sell for:");
 	saleValues.push_back(string());
 	saleHeight += 20;


### PR DESCRIPTION
Added a summation of energy expenditure and heat generation to the ship panel, including battery depletion time and overheating amount. This should help players better understand their chosen loadout and whether they need to adjust their power generation or cooling outfits.