### PR TITLE
Typo fix, Sestor Search?

### DIFF
--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -1662,7 +1662,7 @@ mission "Wanderers: Sestor Search"
 		has "wanderers: found the sestor fleet"
 	on enter "Aya'k'k"
 		dialog
-			`A major battle was fought here. The burned-out hulks of several Wanderer ships are floating around in space, along with a handful of disabled Kor Sestor ships. Meanwhile, Wanderer ships are engaged in some sort of rescue or evacuation process on the surface of <planet>. But there is no sign of the bulk of the Kor Sestor fleet.`
+			`A major battle was fought here. The burned-out hulks of several Wanderer ships are floating around in space, along with a handful of disabled Kor Sestor ships. Meanwhile, Wanderer ships are engaged in some sort of rescue or evacuation process on the surface of Varu K'prai. But there is no sign of the bulk of the Kor Sestor fleet.`
 	npc
 		system "Aya'k'k"
 		government "Wanderer"


### PR DESCRIPTION
Wanderers: Sestor Search. When entering Aya'k'k during the mission, a "planet" tag is used, which refers to Vara K'chrai and not the planet in the system, Varu K'prai. Instead, I just hard-typed "Varu K'prai" to resolve this. If anyone has more elegant solutions, I'll be happy to amend it.