### PR TITLE
Made the shipInfo display consistent for outfit, weapon, and engine capacities

### DIFF
--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -250,8 +250,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	map<string, double> chassis;
 	static const string names[] = {
 		"outfit space free:", "outfit space",
-		"    weapon capacity:", "weapon capacity",
-		"    engine capacity:", "engine capacity",
+		"    weapon capacity free:", "weapon capacity",
+		"    engine capacity free:", "engine capacity",
 		"gun ports free:", "gun ports",
 		"turret mounts free:", "turret mounts"
 	};

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -250,8 +250,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	map<string, double> chassis;
 	static const string names[] = {
 		"outfit space free:", "outfit space",
-		"    weapon capacity free:", "weapon capacity",
-		"    engine capacity free:", "engine capacity",
+		"    weapon space free:", "weapon capacity",
+		"    engine space free:", "engine capacity",
 		"gun ports free:", "gun ports",
 		"turret mounts free:", "turret mounts"
 	};


### PR DESCRIPTION
In the ShipInfo display, the outfit section says "Outfit space **free**", but the weapon and engine sub-sections use slightly different wording ("capacity" instead of "space", and no "free"). This was recently a source of confusion for a player: https://www.reddit.com/r/endlesssky/comments/5thqwc/super_nooby_help_needed_outfits_are_really/

This PR standardizes the wording.