### PR TITLE
Wandering typo fixes

### DIFF
--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -305,7 +305,7 @@ mission "Wanderers: Rek To Kor Efret"
 		has "Wanderers: First Mereti Attack: done"
 	on offer
 		conversation
-			`When you enter the meeting room, Sobari Tele'ek is in a heated argument with the Wanderer child who was here earlier, the one who speaks your language. The child is saying, "The Eye has sent us not to a place of [empty, abandoned] worlds but to a place of [living beings?]. To complete our [calling, work] here we must collaborate with those beings, just as we would collaborate with the [ecosystem? personality] of a planet we sought to repair."`
+			`When you enter the meeting room, Sobari Tele'ek is in a heated argument with the Wanderer child who was here earlier, the one who speaks your language. The child is saying, "The Eye has sent us not to a place of [empty, abandoned] worlds but to a place of [living beings?]. To complete our [calling, work] here we must collaborate with those beings, just as we would collaborate with the [ecosystem? personality?] of a planet we sought to repair."`
 			`	"What do you [propose, intend], Firstborn?" asks Tele'ek.`
 			`	"I would visit the [remaining, surviving] Korath," she says. "I would learn their [language? viewpoint? history?]. I would offer them our [companionship, assistance]."`
 			`	"No," says Tele'ek. "How could I [endanger, gamble with] your life? You are too [precious, unique] to be sent on such a [mission, assignment]."`
@@ -467,7 +467,7 @@ mission "Wanderers: Pug Assistance 1"
 					goto pug
 
 			label peace
-				"Well," says Tele'ek, "if they really [desire, hope] for these worlds to be [fruitful, habitable] once more, the best thing we can do is prove our [value, virtue] by beginning our work. We are a [patient, deliberate] species too, and we understand that gaining the [trust, goodwill] of another may take time."
+			`	"Well," says Tele'ek, "if they really [desire, hope] for these worlds to be [fruitful, habitable] once more, the best thing we can do is prove our [value, virtue] by beginning our work. We are a [patient, deliberate] species too, and we understand that gaining the [trust, goodwill] of another may take time."`
 				goto next
 
 			label displace
@@ -2764,7 +2764,7 @@ mission "Wanderers: Sestor: Exiles 3"
 		fail "Wanderers: Sestor: Exiles 2"
 		event "wanderers: exiles peaceful"
 		conversation
-			`The Korath ships tail you to the planet's surface, but they do not fire on you.  Instead, they hover above your ship for a long, indecisive moment. You hold your fire, and they eventually land in the sand next to you. Their airlocks open, and a few of them step out and approach your ship. They do not appear to be armed. Perhaps they have a cultural taboo against using weapons on this world.`
+			`The Korath ships tail you to the planet's surface, but they do not fire on you. Instead, they hover above your ship for a long, indecisive moment. You hold your fire, and they eventually land in the sand next to you. Their airlocks open, and a few of them step out and approach your ship. They do not appear to be armed. Perhaps they have a cultural taboo against using weapons on this world.`
 			choice
 				`	(Go outside to meet them.)`
 				`	(Leave the planet while I still can.)`

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -55,7 +55,7 @@ mission "First Contact: Wanderer"
 			
 			label hai
 			`	The other aliens standing beside it are inspecting you with equal curiosity. Finally, one of them says to the leader, "Ek kalek kiro suk i'hai, sek speru siyek ka'hai esek'ru fer'ek." The leader gestures in response, turning up open palms, and the second alien steps forward and begins speaking in an entirely different language. After a moment, you are startled to realize that it is speaking the language of the Hai.`
-			`	"Hai, You speak the Hai language?" you ask. You cup your hands above your ears to mimic the large, rodent-like ears of the Hai.`
+			`	"Hai, you speak the Hai language?" you ask. You cup your hands above your ears to mimic the large, rodent-like ears of the Hai.`
 			`	"Iy, ka'hai!" says the alien, rustling its wings in what you take as a gesture of excitement, "Speru ek ka'hai?" At the same time, though, one of the other aliens takes a step back and flexes its talons at you. It occurs to you that the Hai may or may not be viewed favorably here.`
 			choice
 				`	"Sorry, I don't speak their language."`
@@ -99,7 +99,7 @@ mission "Wanderers: Diplomacy"
 		conversation
 			`As you are approaching Hai-home, you contact the Hai government and ask if they would be willing to provide an ambassador to help you communicate with the aliens to the north, who seem to speak the Hai language. They immediately direct you to a private government hangar, where a diplomat meets you. She holds out a paw to greet you, and says, "My name is Sayari. I was the envoy to the human government, a century ago." To the best of your knowledge, the Republic has never mentioned the Hai or publicly acknowledged receiving an envoy from them.`
 			choice
-				`	"Wait, the human Republic knows that the Hai exists? I had heard nothing but vague rumors of your existence before I found the wormhole."`
+				`	"Wait, the human Republic knows that the Hai exist? I had heard nothing but vague rumors of your existence before I found the wormhole."`
 				`	"I'm pleased to meet you. Are you willing to travel with me?"`
 					goto travel
 			
@@ -277,7 +277,7 @@ mission "Wanderers Conversation"
 				goto food
 			
 			label language
-			`	"Recently we managed to [take, capture] some of them as prisoners," he says. "They have been [raiding, visiting] us for twenty [years, cycles]. At first they only stole unguarded stores of food, and fled if we approached. We allowed them to take it, because in our culture it is a [duty, obligation] to share our food with those who [ask for, demand] it. But recently they have become far more [aggressive, desperate]. They captured one of our worlds and killed many Wanderers, and we built warships  and drove them back. Some of them tried to hide on the planet, and we made them our [prisoners, guests] and slowly learned their language."`
+			`	"Recently we managed to [take, capture] some of them as prisoners," he says. "They have been [raiding, visiting] us for twenty [years, cycles]. At first they only stole unguarded stores of food, and fled if we approached. We allowed them to take it, because in our culture it is a [duty, obligation] to share our food with those who [ask for, demand] it. But recently they have become far more [aggressive, desperate]. They captured one of our worlds and killed many Wanderers, and we built warships and drove them back. Some of them tried to hide on the planet, and we made them our [prisoners, guests] and slowly learned their language."`
 			label food
 			`	"Do you know what the Unfettered want?" you ask.`
 			`	"They want food, and [land, elbowroom]," says Rek. "This we guessed when they first raided us, and the Hai named Sayari has confirmed this to me, that the Unfettered have [squandered, consumed] their own worlds and now make war to gain others."`
@@ -1234,7 +1234,7 @@ mission "Wanderers: Alpha Surveillance I"
 			`Danforth looks relieved to see you both alive. "Damned Republic Intelligence Agency," he says. "They think they're above the law. And after all that they decided you both are clean?" He looks intently at Elias.`
 			choice
 				`	"Yes, in fact now they're trying to get us to work together with them against the Alphas."`
-				`	"Yes and they think Elias can help them against the Alphas."`
+				`	"Yes, and they think Elias can help them against the Alphas."`
 			`	"I see," says Danforth. "I wish I could tell you that they can be trusted. I wish I could tell you that there is no safer place for an enemy of the Alphas than here with me."`
 			branch know
 				has "event: death of nguyen"
@@ -1325,7 +1325,7 @@ mission "Wanderers Invaded 1"
 		has "event: wanderers: unfettered invasion starts"
 	on offer
 		conversation
-			`Iktat Rek looks more harried and anxious than you have ever seen him: his feathers, normally perfectly preened, stick out at odd angles in patches on his face and shoulders, and he paces back and forth restlessly as you converse. "We have begun building warships," he says, "but do not yet have the [strength, numbers] to resist the invaders. We must retreat to a more [narrow? defensible?] position. Will you assist us in the evacuation?`
+			`Iktat Rek looks more harried and anxious than you have ever seen him: his feathers, normally perfectly preened, stick out at odd angles in patches on his face and shoulders, and he paces back and forth restlessly as you converse. "We have begun building warships," he says, "but do not yet have the [strength, numbers] to resist the invaders. We must retreat to a more [narrow? defensible?] position. Will you assist us in the evacuation?"`
 			choice
 				`	"I would be glad to."`
 					goto end


### PR DESCRIPTION
A bunch of typo fixes for the Wanderer start and middle files.

One thing perplexes me:
Kor Efret or Kor Efreti?