### PR TITLE
Resolving Punctuation Errors in Coalition Jobs

### DIFF
--- a/data/coalition jobs.txt
+++ b/data/coalition jobs.txt
@@ -904,7 +904,7 @@ mission "Coalition: Rush 1"
 	job
 	repeat
 	name "Rush Delivery to <planet>"
-	description "<destination>, needs a shipment of <cargo> by <date>. Payment will be <payment>."
+	description "<destination> needs a shipment of <cargo> by <date>. Payment will be <payment>."
 	deadline
 	cargo random 10 8 .2
 	to offer
@@ -925,7 +925,7 @@ mission "Coalition: Rush 2"
 	job
 	repeat
 	name "Rush Delivery to <planet>"
-	description "<destination>, needs a shipment of <cargo> by <date>. Payment will be <payment>."
+	description "<destination> needs a shipment of <cargo> by <date>. Payment will be <payment>."
 	deadline
 	cargo random 10 12 .2
 	to offer
@@ -946,7 +946,7 @@ mission "Coalition: Rush 3"
 	job
 	repeat
 	name "Rush Delivery to <planet>"
-	description "<destination>, needs a shipment of <cargo> by <date>. Payment will be <payment>."
+	description "<destination> needs a shipment of <cargo> by <date>. Payment will be <payment>."
 	deadline
 	cargo random 10 18 .2
 	to offer

--- a/data/coalition jobs.txt
+++ b/data/coalition jobs.txt
@@ -441,7 +441,7 @@ mission "Coalition: Arach Interspecies 1"
 	job
 	repeat
 	name "Arachi to <planet>"
-	description "As part of the Interspecies Exchange Program, transport these <bunks> volunteer settlers to <destination>. The government will pay their transport fee of <payment>."
+	description "As part of the Interspecies Exchange Program, these <bunks> volunteer settlers need transportation to <destination>. The government will pay their transport fee of <payment>."
 	passengers 4 2 .1
 	to offer
 		has "known to the heliarchs"
@@ -460,7 +460,7 @@ mission "Coalition: Arach Interspecies 2"
 	job
 	repeat
 	name "Arachi to <planet>"
-	description "As part of the Interspecies Exchange Program, transport these <bunks> volunteer settlers to <destination>. The government will pay their transport fee of <payment>."
+	description "As part of the Interspecies Exchange Program, these <bunks> volunteer settlers need transportation to <destination>. The government will pay their transport fee of <payment>."
 	passengers 4 4 .1
 	to offer
 		has "known to the heliarchs"

--- a/data/coalition jobs.txt
+++ b/data/coalition jobs.txt
@@ -365,7 +365,7 @@ mission "Coalition: Saryd Interspecies 1"
 	job
 	repeat
 	name "Saryds to <planet>"
-	description "As part of the Interspecies Exchange Program, transport these <bunks> volunteer settlers to <destination>. The government will pay their transport fee of <payment>."
+	description "As part of the Interspecies Exchange Program, these <bunks> volunteer settlers need transportation to <destination>. The government will pay their transport fee of <payment>."
 	passengers 4 2 .1
 	to offer
 		has "known to the heliarchs"
@@ -384,7 +384,7 @@ mission "Coalition: Saryd Interspecies 2"
 	job
 	repeat
 	name "Saryds to <planet>"
-	description "As part of the Interspecies Exchange Program, transport these <bunks> volunteer settlers to <destination>. The government will pay their transport fee of <payment>."
+	description "As part of the Interspecies Exchange Program, these <bunks> volunteer settlers need transportation to <destination>. The government will pay their transport fee of <payment>."
 	passengers 4 4 .1
 	to offer
 		has "known to the heliarchs"
@@ -403,7 +403,7 @@ mission "Coalition: Kimek Interspecies 1"
 	job
 	repeat
 	name "Kimek to <planet>"
-	description "As part of the Interspecies Exchange Program, transport these <bunks> volunteer settlers to <destination>. The government will pay their transport fee of <payment>."
+	description "As part of the Interspecies Exchange Program, these <bunks> volunteer settlers need transportation to <destination>. The government will pay their transport fee of <payment>."
 	passengers 4 2 .1
 	to offer
 		has "known to the heliarchs"
@@ -422,7 +422,7 @@ mission "Coalition: Kimek Interspecies 2"
 	job
 	repeat
 	name "Kimek to <planet>"
-	description "As part of the Interspecies Exchange Program, transport these <bunks> volunteer settlers to <destination>. The government will pay their transport fee of <payment>."
+	description "As part of the Interspecies Exchange Program, these <bunks> volunteer settlers need transportation to <destination>. The government will pay their transport fee of <payment>."
 	passengers 4 4 .1
 	to offer
 		has "known to the heliarchs"

--- a/data/coalition jobs.txt
+++ b/data/coalition jobs.txt
@@ -678,7 +678,7 @@ mission "Coalition: Fast Courier 1"
 	job
 	repeat
 	name "Fast courier to <planet>"
-	description "Deliver <cargo> to <destination>, by <date>. The payment is <payment>."
+	description "Deliver <cargo> to <destination> by <date>. The payment is <payment>."
 	deadline 5 1
 	cargo random 2 20 .6
 	to offer
@@ -699,7 +699,7 @@ mission "Coalition: Fast Courier 2"
 	job
 	repeat
 	name "Fast courier to <planet>"
-	description "Deliver <cargo> to <destination>, by <date>. The payment is <payment>."
+	description "Deliver <cargo> to <destination> by <date>. The payment is <payment>."
 	deadline 5 1
 	cargo random 2 30 .6
 	to offer
@@ -720,7 +720,7 @@ mission "Coalition: Fast Courier 3"
 	job
 	repeat
 	name "Fast courier to <planet>"
-	description "Deliver <cargo> to <destination>, by <date>. The payment is <payment>."
+	description "Deliver <cargo> to <destination> by <date>. The payment is <payment>."
 	deadline 5 1
 	cargo random 2 40 .6
 	to offer

--- a/data/coalition jobs.txt
+++ b/data/coalition jobs.txt
@@ -326,7 +326,7 @@ mission "Coalition: Peacekeepers 1"
 	job
 	repeat
 	name "Peacekeepers to <planet>"
-	description "Transport this corps of <bunks> peacekeepers to <destination>, to investigate reports of Resistance activity. Payment is <payment>."
+	description "Transport this corps of <bunks> peacekeepers to <destination> to investigate reports of Resistance activity. Payment is <payment>."
 	passengers 10 10 .2
 	to offer
 		has "known to the heliarchs"
@@ -345,7 +345,7 @@ mission "Coalition: Peacekeepers 2"
 	job
 	repeat
 	name "Peacekeepers to <planet>"
-	description "Transport this corps of <bunks> peacekeepers to <destination>, to investigate reports of Resistance activity. Payment is <payment>."
+	description "Transport this corps of <bunks> peacekeepers to <destination> to investigate reports of Resistance activity. Payment is <payment>."
 	passengers 10 5 .1
 	to offer
 		has "known to the heliarchs"


### PR DESCRIPTION
For reference:
http://www.dailywritingtips.com/punctuation-mistakes-1-unnecessary-commas/

Removing unnecessary commas:

Commit 1: "I, need food" would be incorrect, it is "I need food".

Commit 2: "I need a car, to get food" should be "I need a car to get food". The extra comma is extraneous.

Commit 3: "As part of a retirement plan, transport these 500 retirees" is incorrect. (https://owl.english.purdue.edu/owl/resource/597/01/) The phrase "as part of the retirement plan" does not apply to you, who is transporting the retirees. Instead, it should be "As part of a retirement plan, these 500 retirees need transportation". It's a grammatical error otherwise.

Commit 4: Same as above. The Arach interspecies are done correctly, so I just changed everything to fit the Arach.

Commit 5: "I need a car, by tuesday" --> "I need a car by tuesday".

