### PR TITLE
create parameters.txt file for: *ship categories* *depreciation* *pirate raids*, allow extending of data nodes (adding to existing ship without blowing away values), add sorting of missions by: *system* *payment* *deadline*

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -685,47 +685,63 @@ interface "mission" bottom
 		center 70 -25
 		dimensions 80 30
 
+interface "mission sort" bottom right
+	sprite "ui/wide button"
+		from -190 -90 to -80 -40
+	button e "D_eadline"
+		from -180 -80 to -90 -50
+
+	sprite "ui/dialog cancel"
+		from -270 -90 to -180 -40
+	button y "Pa_yment"
+		from -260 -80 to -190 -50
+
+	sprite "ui/dialog cancel"
+		from -350 -90 to -260 -40
+	button t "Sys_tem"
+		from -340 -80 to -270 -50
+
 
 
 interface "map buttons" bottom right
 	sprite "ui/dialog cancel"
 		from -450 -50 to -360 0
 	button d "_Done"
-		from -450 -50 to -360 0
+		from -440 -40 to -370 -10
 	
 	active if "!is shipyards"
 	sprite "ui/wide button"
 		from -370 -50 to -260 0
 	button s "_Shipyards"
-		from -370 -50 to -260 0
+		from -360 -40 to -270 -10
 	
 	active if "!is outfitters"
 	sprite "ui/wide button"
 		from -270 -50 to -160 0
 	button o "_Outfitters"
-		from -270 -50 to -160 0
+		from -260 -40 to -170 -10
 	
 	active if "!is missions"
 	sprite "ui/dialog cancel"
 		from -170 -50 to -80 0
 	button i "M_issions"
-		from -170 -50 to -80 0
+		from -160 -40 to -90 -10
 	
 	active if "!is ports"
 	sprite "ui/dialog cancel"
 		from -90 -50 to 0 0
 	button p "_Ports"
-		from -90 -50 to 0 0
+		from -80 -40 to -10 -10
 	
 	sprite "ui/zoom"
-		from 0 -40 to -90 -90
+		from -90 -90 to 0 -40
 	active if "!max zoom"
 	button + "_+"
-		from -10 -50 to -40 -80
+		from -40 -80 to -10 -50
 		size 18
 	active if "!min zoom"
 	button - "_-"
-		from -50 -50 to -80 -80
+		from -80 -80 to -50 -50
 		size 18
 
 

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -686,16 +686,19 @@ interface "mission" bottom
 		dimensions 80 30
 
 interface "mission sort" bottom right
+	active if "!by deadline"
 	sprite "ui/wide button"
 		from -190 -90 to -80 -40
 	button e "D_eadline"
 		from -180 -80 to -90 -50
 
+	active if "!by payment"
 	sprite "ui/dialog cancel"
 		from -270 -90 to -180 -40
 	button y "Pa_yment"
 		from -260 -80 to -190 -50
 
+	active if "!by system"
 	sprite "ui/dialog cancel"
 		from -350 -90 to -260 -40
 	button t "Sys_tem"

--- a/data/parameters.txt
+++ b/data/parameters.txt
@@ -1,0 +1,16 @@
+"parameters"
+	"depreciation"
+		"full" 1
+		"daily" 0.99
+		"max age" 1000
+
+	"ship categories"
+		"Transport"
+		"Light Freighter"
+		"Heavy Freighter"
+		"Interceptor"
+		"Light Warship"
+		"Medium Warship"
+		"Heavy Warship"
+		"Fighter"
+		"Drone"

--- a/data/parameters.txt
+++ b/data/parameters.txt
@@ -14,3 +14,11 @@
 		"Heavy Warship"
 		"Fighter"
 		"Drone"
+
+	"pirate attraction"
+		"min outfit space" 200
+		"damage per second factor" -1000
+		"hull repair rate factor" -1
+		"shield generation factor" -1
+		"outfit value factor" 4000000
+		"cargo tonnage factor" 100

--- a/data/parameters.txt
+++ b/data/parameters.txt
@@ -1,6 +1,6 @@
 "parameters"
 	"depreciation"
-		"full" 1
+		"full" 0.25
 		"daily" 0.99
 		"max age" 1000
 

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -486,7 +486,7 @@ BoardingPanel::Plunder::Plunder(const string &commodity, int count, int unitValu
 
 // Constructor (outfit installed in the victim ship).
 BoardingPanel::Plunder::Plunder(const Outfit *outfit, int count)
-	: name(outfit->Name()), outfit(outfit), count(count), unitValue(outfit->Cost() * GameData::Parameters().DepreciationMaxAge())
+	: name(outfit->Name()), outfit(outfit), count(count), unitValue(outfit->Cost() * GameData::Parameters().DepreciationFull())
 {
 	UpdateStrings();
 }

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -20,6 +20,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "FontSet.h"
 #include "Format.h"
 #include "GameData.h"
+#include "GameParameters.h"
 #include "Government.h"
 #include "InfoPanel.h"
 #include "Information.h"
@@ -485,7 +486,7 @@ BoardingPanel::Plunder::Plunder(const string &commodity, int count, int unitValu
 
 // Constructor (outfit installed in the victim ship).
 BoardingPanel::Plunder::Plunder(const Outfit *outfit, int count)
-	: name(outfit->Name()), outfit(outfit), count(count), unitValue(outfit->Cost() * Depreciation::Full())
+	: name(outfit->Name()), outfit(outfit), count(count), unitValue(outfit->Cost() * GameData::Parameters().DepreciationMaxAge())
 {
 	UpdateStrings();
 }

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -16,6 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataWriter.h"
 #include "Depreciation.h"
 #include "GameData.h"
+#include "GameParameters.h"
 #include "Mission.h"
 #include "Outfit.h"
 #include "System.h"
@@ -545,7 +546,7 @@ int64_t CargoHold::Value(const System *system) const
 	// For outfits, assume they're fully depreciated, since that will always be
 	// the case unless the player bought into cargo for some reason.
 	for(const auto &it : outfits)
-		value += it.first->Cost() * it.second * Depreciation::Full();
+		value += it.first->Cost() * it.second * GameData::Parameters().DepreciationFull();
 	return value;
 }
 

--- a/source/DataFile.cpp
+++ b/source/DataFile.cpp
@@ -150,9 +150,22 @@ void DataFile::Load(const char *it, const char *end)
 			// range, but it appears that some libraries do not handle that case
 			// correctly. So:
 			if(start == it)
+			{
 				node.tokens.emplace_back();
+			}
 			else
-				node.tokens.emplace_back(start, it);
+			{
+				string token = string(start, it);
+				if (!token.compare("--extend"))
+				{
+					node.isExtension = true;
+				}
+				else
+				{
+					node.tokens.emplace_back(token);					
+				}
+			}
+
 			// This is not a fatal error, but it may indicate a format mistake:
 			if(isQuoted && *it == '\n')
 				node.PrintTrace("Closing quotation mark is missing:");

--- a/source/DataNode.cpp
+++ b/source/DataNode.cpp
@@ -25,6 +25,7 @@ using namespace std;
 // Construct a DataNode and remember what its parent is.
 DataNode::DataNode(const DataNode *parent)
 	: parent(parent)
+	, isExtension(false)
 {
 	// To avoid a lot of memory reallocation, have every node start out with
 	// capacity for four tokens. This makes file loading slightly faster, at the

--- a/source/DataNode.h
+++ b/source/DataNode.h
@@ -52,7 +52,8 @@ public:
 	// Print a message followed by a "trace" of this node and its parents.
 	int PrintTrace(const std::string &message = "") const;
 	
-	
+	bool IsExtension() const { return isExtension; }
+
 private:
 	// These are "child" nodes found on subsequent lines with deeper indentation.
 	std::list<DataNode> children;
@@ -61,6 +62,9 @@ private:
 	// The parent pointer is used only for printing stack traces.
 	const DataNode *parent = nullptr;
 	
+	// usually a mod, is desiring only extension behavior; do not delete anything from the current node only add to it
+	bool isExtension;
+
 	// Allow DataFile to modify the internal structure of DataNodes.
 	friend class DataFile;
 };

--- a/source/Depreciation.h
+++ b/source/Depreciation.h
@@ -13,6 +13,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef DEPRECIATION_H_
 #define DEPRECIATION_H_
 
+#include "DataFile.h"
+
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -30,11 +32,6 @@ class Ship;
 // outfit or ship was purchased. Any ship or outfit for which no record exists,
 // for example because it is plunder, counts as full depreciated.
 class Depreciation {
-public:
-	// What fraction of its cost a fully depreciated item has left:
-	static double Full();
-	
-	
 public:
 	// Load or save depreciation records. Multiple records may be saved in the
 	// player info, under different names (e.g. fleet and stock depreciation).
@@ -61,6 +58,9 @@ public:
 	
 	
 private:
+	static void GetDepreciationValues(double &full, double &daily, int &maxAge);
+	static void GetDepreciationValues(double &full, double &daily, int &maxAge, DataFile &dataFile);
+
 	// "Sell" an item, removing it from the given record and returning the base
 	// day for its depreciation.
 	int Sell(std::map<int, int> &record);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Audio.h"
 #include "Effect.h"
 #include "FillShader.h"
+#include "FleetAttractionToPiratesCalculator.h"
 #include "Font.h"
 #include "FontSet.h"
 #include "Format.h"
@@ -850,21 +851,10 @@ void Engine::EnterSystem()
 	const Fleet *raidFleet = system->GetGovernment()->RaidFleet();
 	if(raidFleet)
 	{
-		// Find out how attractive the player's fleet is to pirates. Aside from a
-		// heavy freighter, no single ship should attract extra pirate attention.
-		unsigned attraction = 0;
-		for(const shared_ptr<Ship> &ship : player.Ships())
-		{
-			if(ship->IsParked())
-				continue;
-		
-			const string &category = ship->Attributes().Category();
-			if(category == "Light Freighter")
-				attraction += 1;
-			if(category == "Heavy Freighter")
-				attraction += 2;
-		}
-		if(attraction > 2)
+		FleetAttractionToPiratesCalculator calc(player.Ships());
+		unsigned attraction = calc.AttractionFactor();
+
+		if(attraction)
 		{
 			for(int i = 0; i < 10; ++i)
 				if(Random::Int(200) + 1 < attraction)

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -182,6 +182,8 @@ void Files::Init(const char * const *argv)
 		throw runtime_error("Unable to find the resource directories!");
 	if(!Exists(saves))
 		throw runtime_error("Unable to create config directory!");
+
+	cerr << config;
 }
 
 

--- a/source/FleetAttractionToPiratesCalculator.cpp
+++ b/source/FleetAttractionToPiratesCalculator.cpp
@@ -83,9 +83,6 @@ FleetAttractionToPiratesCalculator::FleetAttractionToPiratesCalculator(const std
 			attractionFactor = numeric_limits<unsigned int>::max();
 		else
 			attractionFactor = temp;
-
-		Messages::Add("dps:" + to_string(damagePerSecondFactor) + " sh:" + to_string(shieldGenerationFactor) + " $:" +
-			to_string(outfitValueFactor) + " car:" + to_string(cargoTonnageFactor) + " = " + to_string(temp));
 	}
 }
 

--- a/source/FleetAttractionToPiratesCalculator.cpp
+++ b/source/FleetAttractionToPiratesCalculator.cpp
@@ -1,0 +1,95 @@
+/* FleetAttractionToPiratesCalculator.cpp
+Copyright (c) 2014 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "Ship.h"
+#include "FleetAttractionToPiratesCalculator.h"
+#include "GameData.h"
+#include "GameParameters.h"
+#include "Messages.h"
+
+#include <limits>
+
+using namespace std;
+
+
+
+FleetAttractionToPiratesCalculator::FleetAttractionToPiratesCalculator(const std::vector<std::shared_ptr<Ship>> &ships)
+	: totalDamagePerSecond(0)
+	, totalHullRepairRate(0)
+	, totalShieldGeneration(0)
+	, totalOutfitValue(0)
+	, totalCargoTonnage(0)
+	, attractionFactor(0)
+{
+	// don't pick on new players.
+	// if the total outfit space is less than a threshold and the player only owns one ship don't spawn any additional pirate raids
+	double totalOutfitSpace = 0;
+
+	for(const shared_ptr<Ship> &ship : ships)
+	{
+		totalOutfitSpace += ship->Attributes().Get("outfit space");
+		totalCargoTonnage += ship->Cargo().Used();
+
+		for(auto &it : ship->Outfits())
+		{
+			if(ship->IsParked())
+				continue;
+
+			const Outfit *outfit = it.first;
+			const int count = it.second;
+
+			totalOutfitValue += outfit->Cost() * count;
+
+			if(outfit->IsWeapon())
+			{
+				double dps = outfit->ShieldDamagePerSecond()
+					+ outfit->HullDamagePerSecond()
+					+ outfit->HeatDamagePerSecond()
+					+ outfit->IonDamagePerSecond()
+					+ outfit->DisruptionDamagePerSecond();
+
+				totalDamagePerSecond += dps * count;
+			}
+			else
+			{
+				totalHullRepairRate += outfit->Get("hull repair rate") * count;
+				totalShieldGeneration += outfit->Get("shield generation") * count;
+			}
+		}
+	}
+
+	if(totalOutfitSpace > GameData::Parameters().PirateAttractionMinimumOutfitSpace())
+	{
+		double damagePerSecondFactor = totalDamagePerSecond / GameData::Parameters().PirateAttractionFactorDamagePerSecond();
+		double hullRepairRateFactor = totalHullRepairRate / GameData::Parameters().PirateAttractionFactorHullRepairRate();
+		double shieldGenerationFactor = totalShieldGeneration / GameData::Parameters().PirateAttractionFactorShieldGeneration();
+		double outfitValueFactor = totalOutfitValue / GameData::Parameters().PirateAttractionFactorOutfitValue();
+		double cargoTonnageFactor = totalCargoTonnage / GameData::Parameters().PirateAttractionFactorCargoTonnage();
+
+		double temp = damagePerSecondFactor + hullRepairRateFactor + shieldGenerationFactor + outfitValueFactor + cargoTonnageFactor + .5;
+
+		if(temp <= 0)
+			attractionFactor = 0;
+		else if(temp >= numeric_limits<unsigned int>::max())
+			attractionFactor = numeric_limits<unsigned int>::max();
+		else
+			attractionFactor = temp;
+
+		Messages::Add("dps:" + to_string(damagePerSecondFactor) + " sh:" + to_string(shieldGenerationFactor) + " $:" +
+			to_string(outfitValueFactor) + " car:" + to_string(cargoTonnageFactor) + " = " + to_string(temp));
+	}
+}
+
+FleetAttractionToPiratesCalculator::~FleetAttractionToPiratesCalculator()
+{
+}
+

--- a/source/FleetAttractionToPiratesCalculator.h
+++ b/source/FleetAttractionToPiratesCalculator.h
@@ -1,0 +1,43 @@
+/* FleetAttractionToPiratesCalculator.h
+Copyright (c) 2014 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef FLEETATTRACTIONTOPIRATESCALCULATOR_H_
+#define FLEETATTRACTIONTOPIRATESCALCULATOR_H_
+
+#include <vector>
+
+class Ship;
+
+
+
+// wrapper for determining if a pirate raid fleet is attracted to another fleet
+class FleetAttractionToPiratesCalculator {
+public:
+	explicit FleetAttractionToPiratesCalculator(const std::vector<std::shared_ptr<Ship>> &ships);
+	~FleetAttractionToPiratesCalculator();
+	
+	unsigned AttractionFactor() const;
+
+private:
+	double totalDamagePerSecond;
+	double totalHullRepairRate;
+	double totalShieldGeneration;
+	double totalOutfitValue;
+	double totalCargoTonnage;
+
+	// number between 0 and 200; 0 == no attraction, dont roll for pirates, 1 = 0.5%, 200 == 100%
+	unsigned attractionFactor;
+};
+
+inline unsigned FleetAttractionToPiratesCalculator::AttractionFactor() const { return attractionFactor; }
+
+#endif

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -27,6 +27,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "FontSet.h"
 #include "Galaxy.h"
 #include "GameEvent.h"
+#include "GameParameters.h"
 #include "Government.h"
 #include "Interface.h"
 #include "LineShader.h"
@@ -111,6 +112,8 @@ namespace {
 	map<const Sprite *, int> preloaded;
 	
 	const Government *playerGovernment = nullptr;
+
+	GameParameters parameters;
 }
 
 
@@ -683,6 +686,13 @@ const map<string, string> &GameData::PluginAboutText()
 
 
 
+const GameParameters &GameData::Parameters()
+{
+	return parameters;
+}
+
+
+
 void GameData::LoadSources()
 {
 	sources.clear();
@@ -803,6 +813,10 @@ void GameData::LoadFile(const string &path, bool debugMode)
 				}
 				text += child.Token(0);
 			}
+		}
+		else if(key == "parameters")
+		{
+			parameters.Load(node);
 		}
 		else
 			node.PrintTrace("Skipping unrecognized root object:");

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -29,6 +29,7 @@ class Effect;
 class Fleet;
 class Galaxy;
 class GameEvent;
+class GameParameters;
 class Government;
 class Interface;
 class Minable;
@@ -115,7 +116,8 @@ public:
 	static const std::map<std::string, std::string> &HelpTemplates();
 	
 	static const std::map<std::string, std::string> &PluginAboutText();
-	
+
+	static const GameParameters &Parameters();
 	
 private:
 	static void LoadSources();

--- a/source/GameParameters.cpp
+++ b/source/GameParameters.cpp
@@ -28,13 +28,17 @@ namespace {
 	};
 
 	// What fraction of its cost a fully depreciated item has left:
-	double depreciationFull = 0.25;
-	
-	double depreciationDaily = 0.99;
-	
+	double depreciationFull = 0.25;	
+	double depreciationDaily = 0.99;	
 	int depreciationMaxAge = 1000;
-}
 
+	double pirateAttractionMinimumOutfitSpace = 200.;
+	double pirateAttractionFactorDamagePerSecond = -1000.;
+	double pirateAttractionFactorHullRepairRate = -1.;
+	double pirateAttractionFactorShieldGeneration = -1.;
+	double pirateAttractionFactorOutfitValue = 2500000.;
+	double pirateAttractionFactorCargoTonnage = 50.;
+}
 
 
 
@@ -50,6 +54,10 @@ void GameParameters::Load(const DataNode &node)
 		else if(key == "ship categories")
 		{
 			LoadShipCategories(node);
+		}
+		else if(key == "pirate attraction")
+		{
+			LoadPirateAttraction(node);
 		}
 	}
 }
@@ -84,6 +92,40 @@ void GameParameters::LoadShipCategories(const DataNode &node)
 	}
 }
 
+void GameParameters::LoadPirateAttraction(const DataNode &node)
+{
+	for(const DataNode &node : node)
+	{
+		const string &key = node.Token(0);
+		if(key == "min outfit space")
+		{
+			pirateAttractionMinimumOutfitSpace = node.Value(1);
+		}
+		else if(key == "damage per second factor")
+		{
+			pirateAttractionFactorDamagePerSecond = node.Value(1);
+		}
+		else if(key == "hull repair rate factor")
+		{
+			pirateAttractionFactorHullRepairRate = node.Value(1);
+		}
+		else if(key == "shield generation factor")
+		{
+			pirateAttractionFactorShieldGeneration = node.Value(1);
+		}
+		else if(key == "outfit value factor")
+		{
+			pirateAttractionFactorOutfitValue = node.Value(1);
+		}
+		else if(key == "cargo tonnage factor")
+		{
+			pirateAttractionFactorCargoTonnage = node.Value(1);
+		}
+	}
+}
+
+
+
 const vector<string> &GameParameters::ShipCategories() const
 {
 	return shipCategories;
@@ -102,4 +144,34 @@ double GameParameters::DepreciationDaily() const
 int GameParameters::DepreciationMaxAge() const
 {
 	return depreciationMaxAge;
+}
+
+double GameParameters::PirateAttractionMinimumOutfitSpace() const
+{
+	return pirateAttractionMinimumOutfitSpace;
+}
+
+double GameParameters::PirateAttractionFactorDamagePerSecond() const
+{
+	return pirateAttractionFactorDamagePerSecond;
+}
+
+double GameParameters::PirateAttractionFactorHullRepairRate() const
+{
+	return pirateAttractionFactorHullRepairRate;
+}
+
+double GameParameters::PirateAttractionFactorShieldGeneration() const
+{
+	return pirateAttractionFactorShieldGeneration;
+}
+
+double GameParameters::PirateAttractionFactorOutfitValue() const
+{
+	return pirateAttractionFactorOutfitValue;
+}
+
+double GameParameters::PirateAttractionFactorCargoTonnage() const
+{
+	return pirateAttractionFactorCargoTonnage;
 }

--- a/source/GameParameters.cpp
+++ b/source/GameParameters.cpp
@@ -1,0 +1,105 @@
+/* GameParameters.cpp
+Copyright (c) 2016 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "GameParameters.h"
+
+using namespace std;
+
+namespace {
+	vector<string> shipCategories = {
+		"Transport",
+		"Light Freighter",
+		"Heavy Freighter",
+		"Interceptor",
+		"Light Warship",
+		"Medium Warship",
+		"Heavy Warship",
+		"Fighter",
+		"Drone"
+	};
+
+	// What fraction of its cost a fully depreciated item has left:
+	double depreciationFull = 0.25;
+	
+	double depreciationDaily = 0.99;
+	
+	int depreciationMaxAge = 1000;
+}
+
+
+
+
+void GameParameters::Load(const DataNode &node)
+{
+	for(const DataNode &node : node)
+	{
+		const string &key = node.Token(0);
+		if(key == "depreciation")
+		{
+			LoadDepreciation(node);
+		}
+		else if(key == "ship categories")
+		{
+			LoadShipCategories(node);
+		}
+	}
+}
+
+void GameParameters::LoadDepreciation(const DataNode &node)
+{
+	for(const DataNode &node : node)
+	{
+		const string &key = node.Token(0);
+		if(key == "full")
+		{
+			depreciationFull = node.Value(1);
+		}
+		else if(key == "daily")
+		{
+			depreciationDaily = node.Value(1);
+		}
+		else if(key == "max age")
+		{
+			depreciationMaxAge = (int)node.Value(1);
+		}
+	}
+}
+
+void GameParameters::LoadShipCategories(const DataNode &node)
+{
+	shipCategories.clear();
+
+	for(const DataNode &node : node)
+	{
+		shipCategories.push_back(node.Token(0));
+	}
+}
+
+const vector<string> &GameParameters::ShipCategories() const
+{
+	return shipCategories;
+}
+
+double GameParameters::DepreciationFull() const
+{
+	return depreciationFull;
+}
+
+double GameParameters::DepreciationDaily() const
+{
+	return depreciationDaily;
+}
+
+int GameParameters::DepreciationMaxAge() const
+{
+	return depreciationMaxAge;
+}

--- a/source/GameParameters.h
+++ b/source/GameParameters.h
@@ -1,0 +1,40 @@
+/* GameParameters.h
+Copyright (c) 2016 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef GAMEPARAMETERS_H_
+#define GAMEPARAMETERS_H_
+
+#include "DataNode.h"
+
+#include <vector>
+#include <string>
+
+
+
+class GameParameters {
+public:
+	void Load(const DataNode &node);
+
+	// These are all the possible category strings for ships.
+	const std::vector<std::string> &ShipCategories() const;
+
+	double DepreciationFull() const;
+	double DepreciationDaily() const;
+	int DepreciationMaxAge() const;
+
+private:
+	void LoadDepreciation(const DataNode &node);
+	void LoadShipCategories(const DataNode &node);
+};
+
+
+#endif

--- a/source/GameParameters.h
+++ b/source/GameParameters.h
@@ -31,9 +31,18 @@ public:
 	double DepreciationDaily() const;
 	int DepreciationMaxAge() const;
 
+	// factors dealing with pirate attraction
+	double PirateAttractionMinimumOutfitSpace() const;
+	double PirateAttractionFactorDamagePerSecond() const;
+	double PirateAttractionFactorHullRepairRate() const;
+	double PirateAttractionFactorShieldGeneration() const;
+	double PirateAttractionFactorOutfitValue() const;
+	double PirateAttractionFactorCargoTonnage() const;
+
 private:
 	void LoadDepreciation(const DataNode &node);
 	void LoadShipCategories(const DataNode &node);
+	void LoadPirateAttraction(const DataNode &node);
 };
 
 

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Font.h"
 #include "FontSet.h"
 #include "GameData.h"
+#include "GameParameters.h"
 #include "Government.h"
 #include "ItemInfoDisplay.h"
 #include "Outfit.h"
@@ -49,7 +50,7 @@ using namespace std;
 
 MapSalesPanel::MapSalesPanel(PlayerInfo &player, bool isOutfitters)
 	: MapPanel(player, SHOW_SPECIAL),
-	categories(isOutfitters ? Outfit::CATEGORIES : Ship::CATEGORIES),
+	categories(isOutfitters ? Outfit::CATEGORIES : GameData::Parameters().ShipCategories()),
 	isOutfitters(isOutfitters),
 	collapsed(player.Collapsed(isOutfitters ? "outfitter map" : "shipyard map"))
 {
@@ -61,7 +62,7 @@ MapSalesPanel::MapSalesPanel(PlayerInfo &player, bool isOutfitters)
 
 MapSalesPanel::MapSalesPanel(const MapPanel &panel, bool isOutfitters)
 	: MapPanel(panel),
-	categories(isOutfitters ? Outfit::CATEGORIES : Ship::CATEGORIES),
+	categories(isOutfitters ? Outfit::CATEGORIES : GameData::Parameters().ShipCategories()),
 	isOutfitters(isOutfitters),
 	collapsed(player.Collapsed(isOutfitters ? "outfitter map" : "shipyard map"))
 {

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -65,6 +65,47 @@ namespace {
 
 
 
+bool Mission::compare_system(const Mission& first, const Mission& second)
+{
+	const Planet *firstPlanet = first.Destination();
+	const Planet *secondPlanet = second.Destination();
+
+	const string firstString(firstPlanet ? (firstPlanet->GetSystem()->Name() + "::" + firstPlanet->Name()) : "");
+	const string secondString(secondPlanet ? (secondPlanet->GetSystem()->Name() + "::" + secondPlanet->Name()) : "");
+	
+	return firstString.compare(secondString) < 0;
+}
+
+
+
+bool Mission::compare_payment(const Mission& first, const Mission& second)
+{
+	const auto &firstIt = first.actions.find(COMPLETE);
+	const auto &secondIt = second.actions.find(COMPLETE);
+	
+	const int firstPayment = firstIt == first.actions.end() ? 0 : firstIt->second.Payment();
+	const int secondPayment = secondIt == second.actions.end() ? 0 : secondIt->second.Payment();
+	
+	// inverse sort, show largest rewards first
+	return firstPayment > secondPayment;
+}
+
+
+
+bool Mission::compare_deadline(const Mission& first, const Mission& second)
+{
+	// inverse sort, show sooner dates first
+	if (first.deadline && !second.deadline)
+		return true;
+
+	if (!first.deadline && second.deadline)
+		return false;
+
+	return first.deadline < second.deadline;
+}
+
+
+
 // Load a mission, either from the game data or from a saved game.
 void Mission::Load(const DataNode &node)
 {

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -41,6 +41,12 @@ class UI;
 // exactly the same every time you replay the game.
 class Mission {
 public:
+	enum MissionSort {BY_DEFAULT, BY_SYSTEM, BY_PAYMENT, BY_DEADLINE};
+
+	static bool compare_system(const Mission& first, const Mission& second);
+	static bool compare_payment(const Mission& first, const Mission& second);
+	static bool compare_deadline(const Mission& first, const Mission& second);
+
 	// Load a mission, either from the game data or from a saved game.
 	void Load(const DataNode &node);
 	// Save a mission. It is safe to assume that any mission that is being saved

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -244,15 +244,15 @@ bool MissionPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 	}
 	else if(key == 'e') 
 	{
-		player.SortMissions(Mission::BY_DEADLINE);
+		player.SetSortMissions(Mission::BY_DEADLINE);
 	}
 	else if(key == 'y')
 	{
-		player.SortMissions(Mission::BY_PAYMENT);
+		player.SetSortMissions(Mission::BY_PAYMENT);
 	}
 	else if(key == 't')
 	{
-		player.SortMissions(Mission::BY_SYSTEM);
+		player.SetSortMissions(Mission::BY_SYSTEM);
 	}
 	else
 		return MapPanel::KeyDown(key, mod, command);
@@ -619,6 +619,24 @@ void MissionPanel::DrawMissionInfo()
 	
 	info.SetString("today", player.GetDate().ToString());
 	
+	switch(player.MissionSort())
+	{
+	case Mission::BY_SYSTEM:
+		info.SetCondition("by system");
+		break;
+
+	case Mission::BY_PAYMENT:
+		info.SetCondition("by payment");
+		break;
+
+	case Mission::BY_DEADLINE:
+		info.SetCondition("by deadline");
+		break;
+
+	default:
+		break;
+	}
+
 	const Interface *missionInterface = GameData::Interfaces().Get("mission");
 	missionInterface->Draw(info, this);
 	

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -242,6 +242,18 @@ bool MissionPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			} while(!acceptedIt->IsVisible());
 		}
 	}
+	else if(key == 'e') 
+	{
+		player.SortMissions(Mission::BY_DEADLINE);
+	}
+	else if(key == 'y')
+	{
+		player.SortMissions(Mission::BY_PAYMENT);
+	}
+	else if(key == 't')
+	{
+		player.SortMissions(Mission::BY_SYSTEM);
+	}
 	else
 		return MapPanel::KeyDown(key, mod, command);
 	
@@ -557,7 +569,7 @@ Point MissionPanel::DrawList(const list<Mission> &list, Point pos) const
 	Color unselected = *GameData::Colors().Get("medium");
 	Color selected = *GameData::Colors().Get("bright");
 	Color dim = *GameData::Colors().Get("dim");
-	
+
 	for(auto it = list.begin(); it != list.end(); ++it)
 	{
 		if(!it->IsVisible())
@@ -607,9 +619,12 @@ void MissionPanel::DrawMissionInfo()
 	
 	info.SetString("today", player.GetDate().ToString());
 	
-	const Interface *interface = GameData::Interfaces().Get("mission");
-	interface->Draw(info, this);
+	const Interface *missionInterface = GameData::Interfaces().Get("mission");
+	missionInterface->Draw(info, this);
 	
+	const Interface *missionSortInterface = GameData::Interfaces().Get("mission sort");
+	missionSortInterface->Draw(info, this);
+
 	// If a mission is selected, draw its descriptive text.
 	if(availableIt != available.end())
 		wrap.Wrap(availableIt->Description());

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -211,45 +211,45 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	attributeValues.push_back(Format::Number(outfit.Range()));
 	attributesHeight += 20;
 	
-	if(outfit.ShieldDamage() && outfit.Reload())
+	if(double dps = outfit.ShieldDamagePerSecond())
 	{
 		attributeLabels.push_back("shield damage / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.ShieldDamage() / outfit.Reload()));
+		attributeValues.push_back(Format::Number(dps));
 		attributesHeight += 20;
 	}
 	
-	if(outfit.HullDamage() && outfit.Reload())
+	if(double dps = outfit.HullDamagePerSecond())
 	{
 		attributeLabels.push_back("hull damage / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.HullDamage() / outfit.Reload()));
+		attributeValues.push_back(Format::Number(dps));
 		attributesHeight += 20;
 	}
 	
-	if(outfit.HeatDamage() && outfit.Reload())
+	if(double dps = outfit.HeatDamagePerSecond())
 	{
 		attributeLabels.push_back("heat damage / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.HeatDamage() / outfit.Reload()));
+		attributeValues.push_back(Format::Number(dps));
 		attributesHeight += 20;
 	}
 	
-	if(outfit.IonDamage() && outfit.Reload())
+	if(double dps = outfit.IonDamagePerSecond())
 	{
 		attributeLabels.push_back("ion damage / second:");
-		attributeValues.push_back(Format::Number(6000. * outfit.IonDamage() / outfit.Reload()));
+		attributeValues.push_back(Format::Number(dps));
 		attributesHeight += 20;
 	}
 	
-	if(outfit.SlowingDamage() && outfit.Reload())
+	if(double dps = outfit.SlowingDamagePerSecond())
 	{
 		attributeLabels.push_back("slowing damage / second:");
-		attributeValues.push_back(Format::Number(6000. * outfit.SlowingDamage() / outfit.Reload()));
+		attributeValues.push_back(Format::Number(dps));
 		attributesHeight += 20;
 	}
 	
-	if(outfit.DisruptionDamage() && outfit.Reload())
+	if(double dps = outfit.DisruptionDamagePerSecond())
 	{
 		attributeLabels.push_back("disruption damage / second:");
-		attributeValues.push_back(Format::Number(6000. * outfit.DisruptionDamage() / outfit.Reload()));
+		attributeValues.push_back(Format::Number(dps));
 		attributesHeight += 20;
 	}
 	

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -91,6 +91,8 @@ void PlayerInfo::New()
 	for(const auto &it : GameData::Events())
 		if(it.second.GetDate())
 			AddEvent(it.second, it.second.GetDate());
+
+	missionSort = Mission::MissionSort::BY_DEFAULT;
 }
 
 
@@ -104,6 +106,8 @@ void PlayerInfo::Load(const string &path)
 	filePath = path;
 	DataFile file(path);
 	
+	missionSort = Mission::MissionSort::BY_DEFAULT;
+
 	hasFullClearance = false;
 	for(const DataNode &child : file)
 	{
@@ -112,6 +116,8 @@ void PlayerInfo::Load(const string &path)
 			firstName = child.Token(1);
 			lastName = child.Token(2);
 		}
+		else if(child.Token(0) == "mission sort" && child.Size() >= 2)
+			missionSort = static_cast<Mission::MissionSort>(child.Value(1));
 		else if(child.Token(0) == "date" && child.Size() >= 4)
 			date = Date(child.Value(1), child.Value(2), child.Value(3));
 		else if(child.Token(0) == "system" && child.Size() >= 2)
@@ -1325,8 +1331,31 @@ void PlayerInfo::AcceptJob(const Mission &mission, UI *ui)
 			it->Do(Mission::ACCEPT, *this, ui);
 			auto spliceIt = it->IsUnique() ? missions.begin() : missions.end();
 			missions.splice(spliceIt, availableJobs, it);
+			SortMissions(missionSort);
 			break;
 		}
+}
+
+
+
+void PlayerInfo::SortMissions(const Mission::MissionSort sort)
+{
+	missionSort = sort;
+
+	switch (sort)
+	{
+	case Mission::BY_SYSTEM:
+		missions.sort(Mission::compare_system);
+		break;
+	case Mission::BY_PAYMENT:
+		missions.sort(Mission::compare_payment);
+		break;
+	case Mission::BY_DEADLINE:
+		missions.sort(Mission::compare_deadline);
+		break;
+	default:
+		break;
+	}	
 }
 
 
@@ -2127,6 +2156,7 @@ void PlayerInfo::Save(const string &path) const
 	
 	out.Write("pilot", firstName, lastName);
 	out.Write("date", date.Day(), date.Month(), date.Year());
+	out.Write("mission sort", static_cast<int>(missionSort));
 	if(system)
 		out.Write("system", system->Name());
 	if(planet)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1331,14 +1331,21 @@ void PlayerInfo::AcceptJob(const Mission &mission, UI *ui)
 			it->Do(Mission::ACCEPT, *this, ui);
 			auto spliceIt = it->IsUnique() ? missions.begin() : missions.end();
 			missions.splice(spliceIt, availableJobs, it);
-			SortMissions(missionSort);
+			SetSortMissions(missionSort);
 			break;
 		}
 }
 
 
 
-void PlayerInfo::SortMissions(const Mission::MissionSort sort)
+const Mission::MissionSort PlayerInfo::MissionSort() const
+{
+	return missionSort;
+}
+
+
+
+void PlayerInfo::SetSortMissions(const Mission::MissionSort sort)
 {
 	missionSort = sort;
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -146,7 +146,9 @@ public:
 	const std::list<Mission> &Missions() const;
 	const std::list<Mission> &AvailableJobs() const;
 	void AcceptJob(const Mission &mission, UI *ui);
-	void SortMissions(const Mission::MissionSort sort);
+	
+	const Mission::MissionSort MissionSort() const;
+	void SetSortMissions(const Mission::MissionSort sort);
 
 	// Check to see if there is any mission to offer in the spaceport right now.
 	Mission *MissionToOffer(Mission::Location location);

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -146,6 +146,8 @@ public:
 	const std::list<Mission> &Missions() const;
 	const std::list<Mission> &AvailableJobs() const;
 	void AcceptJob(const Mission &mission, UI *ui);
+	void SortMissions(const Mission::MissionSort sort);
+
 	// Check to see if there is any mission to offer in the spaceport right now.
 	Mission *MissionToOffer(Mission::Location location);
 	Mission *BoardingMission(const std::shared_ptr<Ship> &ship);
@@ -266,6 +268,7 @@ private:
 	CargoHold cargo;
 	std::map<std::string, int64_t> costBasis;
 	
+	Mission::MissionSort missionSort;
 	std::list<Mission> missions;
 	// These lists are populated when you land on a planet, and saved so that
 	// they will not change if you reload the game.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -16,6 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataNode.h"
 #include "DataWriter.h"
 #include "Effect.h"
+#include "Files.h"
 #include "GameData.h"
 #include "Government.h"
 #include "Mask.h"
@@ -32,18 +33,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <iostream>
 
 using namespace std;
-
-const vector<string> Ship::CATEGORIES = {
-	"Transport",
-	"Light Freighter",
-	"Heavy Freighter",
-	"Interceptor",
-	"Light Warship",
-	"Medium Warship",
-	"Heavy Warship",
-	"Fighter",
-	"Drone"
-};
 
 namespace {
 	const string BAY_TYPE[2] = {"drone", "fighter"};

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -19,6 +19,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Armament.h"
 #include "CargoHold.h"
 #include "Command.h"
+#include "DataFile.h"
 #include "Flotsam.h"
 #include "Outfit.h"
 #include "Personality.h"
@@ -49,9 +50,6 @@ class System;
 // limits of what the AI knows how to command them to do.
 class Ship : public Body, public std::enable_shared_from_this<Ship> {
 public:
-	// These are all the possible category strings for ships.
-	static const std::vector<std::string> CATEGORIES;
-	
 	class Bay {
 	public:
 		Bay(double x, double y, bool isFighter) : point(x * .5, y * .5), isFighter(isFighter) {}

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "FontSet.h"
 #include "Format.h"
 #include "GameData.h"
+#include "GameParameters.h"
 #include "Government.h"
 #include "OutlineShader.h"
 #include "PlayerInfo.h"
@@ -46,7 +47,7 @@ namespace {
 ShopPanel::ShopPanel(PlayerInfo &player, bool isOutfitter)
 	: player(player), day(player.GetDate().DaysSinceEpoch()),
 	planet(player.GetPlanet()), playerShip(player.Flagship()),
-	categories(isOutfitter ? Outfit::CATEGORIES : Ship::CATEGORIES),
+	categories(isOutfitter ? Outfit::CATEGORIES : GameData::Parameters().ShipCategories()),
 	collapsed(player.Collapsed(isOutfitter ? "outfitter" : "shipyard"))
 {
 	if(playerShip)

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -89,11 +89,17 @@ public:
 	
 	// These values include all submunitions:
 	double ShieldDamage() const;
+	double ShieldDamagePerSecond() const;
 	double HullDamage() const;
+	double HullDamagePerSecond() const;
 	double HeatDamage() const;
+	double HeatDamagePerSecond() const;
 	double IonDamage() const;
+	double IonDamagePerSecond() const;
 	double DisruptionDamage() const;
+	double DisruptionDamagePerSecond() const;
 	double SlowingDamage() const;
+	double SlowingDamagePerSecond() const;
 	
 	double Piercing() const;
 	
@@ -215,11 +221,17 @@ inline double Weapon::BlastRadius() const { return blastRadius; }
 inline double Weapon::HitForce() const { return hitForce; }
 
 inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); }
+inline double Weapon::ShieldDamagePerSecond() const { return reload ? 60. * TotalDamage(SHIELD_DAMAGE) / reload: 0; }
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }
+inline double Weapon::HullDamagePerSecond() const { return reload ? 60. * TotalDamage(HULL_DAMAGE) / reload : 0; }
 inline double Weapon::HeatDamage() const { return TotalDamage(HEAT_DAMAGE); }
+inline double Weapon::HeatDamagePerSecond() const { return reload ? 60. * TotalDamage(HEAT_DAMAGE) / reload : 0; }
 inline double Weapon::IonDamage() const { return TotalDamage(ION_DAMAGE); }
+inline double Weapon::IonDamagePerSecond() const { return reload ? 6000. * TotalDamage(ION_DAMAGE) / reload : 0; }
 inline double Weapon::DisruptionDamage() const { return TotalDamage(DISRUPTION_DAMAGE); }
+inline double Weapon::DisruptionDamagePerSecond() const { return reload ? 6000. * TotalDamage(DISRUPTION_DAMAGE) / reload : 0; }
 inline double Weapon::SlowingDamage() const { return TotalDamage(SLOWING_DAMAGE); }
+inline double Weapon::SlowingDamagePerSecond() const { return reload ? 6000. * TotalDamage(SLOWING_DAMAGE) / reload : 0; }
 
 
 


### PR DESCRIPTION
current modifiable parameters include
*ship categories
*depreciation
*pirate raids

add --extend to data nodes to flag them as extension (i like to add jump drives to korath world ships in my addons, and not have to copypaste all their stats) and soon i'll have code ready for adding custom ships to fleets (and events) without having to copypaste all fleets/events

sort missions (and save preferences to file) by system, payment, or deadline