### PR TITLE
Pirate raid rebalance

### DIFF
--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -146,6 +146,18 @@ int Armament::GunCount() const
 	return hardpoints.size() - TurretCount();
 }
 
+int Armament::WeaponSpaceUsed() const
+{
+	double weapon_space=0;
+	for( auto arm: hardpoints){
+		const Outfit * outfit = arm.GetOutfit();
+		if( outfit && ! outfit->Get("AntiMissile") ){
+			weapon_space += -outfit->Get("weapon capacity");
+		}
+	}
+	return weapon_space;
+}
+
 
 
 // Determine how many turret hardpoints are on this ship.

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -57,6 +57,7 @@ public:
 	const std::vector<Hardpoint> &Get() const;
 	int GunCount() const;
 	int TurretCount() const;
+	int WeaponSpaceUsed() const;
 	
 	// Fire the given weapon, if it is ready. If it did not fire because it is
 	// not ready, return false.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -862,11 +862,14 @@ void Engine::EnterSystem()
 			weapon_mass += ship->GetArmament().WeaponSpaceUsed();
 		}
 
-		long int  attraction = pow(cargo_capacity - weapon_mass, 0.5) * 250000;
-		printf("wep: %f, cargo: %f att: %li\n",weapon_mass, cargo_capacity, attraction);
+        double mod_cargo = 9*pow(cargo_capacity, 0.89);
+        double mod_weapon=0.9 * pow(weapon_mass, 1.2);
+		long int  attraction = (mod_cargo - mod_weapon) * 250000;
+		printf("wep: %f, cargo: %f att: %li\n",mod_weapon, mod_cargo, attraction);
 		while(attraction > raidFleet->Strength()){
-			attraction -= raidFleet->Strength() /1 * Random::Real()*0.5 + 0.5;
-			printf("fleet strength %li\n",raidFleet->Strength());
+			attraction -= raidFleet->Strength();
+            attraction *= 0.99;
+			printf("fleet strength %li att left %li\n",raidFleet->Strength(), attraction);
 			raidFleet->Place(*system, ships);
 		}
 	}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -852,23 +852,22 @@ void Engine::EnterSystem()
 	{
 		// Find out how attractive the player's fleet is to pirates. Aside from a
 		// heavy freighter, no single ship should attract extra pirate attention.
-		unsigned attraction = 0;
+		double weapon_mass=0.0;
+		double cargo_capacity=0.0;
 		for(const shared_ptr<Ship> &ship : player.Ships())
 		{
 			if(ship->IsParked())
 				continue;
-		
-			const string &category = ship->Attributes().Category();
-			if(category == "Light Freighter")
-				attraction += 1;
-			if(category == "Heavy Freighter")
-				attraction += 2;
+			cargo_capacity += ship->Attributes().Get("cargo space");
+			weapon_mass += ship->GetArmament().WeaponSpaceUsed();
 		}
-		if(attraction > 2)
-		{
-			for(int i = 0; i < 10; ++i)
-				if(Random::Int(200) + 1 < attraction)
-					raidFleet->Place(*system, ships);
+
+		long int  attraction = pow(cargo_capacity - weapon_mass, 0.5) * 250000;
+		printf("wep: %f, cargo: %f att: %li\n",weapon_mass, cargo_capacity, attraction);
+		while(attraction > raidFleet->Strength()){
+			attraction -= raidFleet->Strength() /1 * Random::Real()*0.5 + 0.5;
+			printf("fleet strength %li\n",raidFleet->Strength());
+			raidFleet->Place(*system, ships);
 		}
 	}
 	

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -864,7 +864,7 @@ void Engine::EnterSystem()
 
         double mod_cargo = 9*pow(cargo_capacity, 0.89);
         double mod_weapon=0.9 * pow(weapon_mass, 1.2);
-		long int  attraction = (mod_cargo - mod_weapon) * 250000;
+		long int  attraction = (mod_cargo - mod_weapon) * 25000;
 		printf("wep: %f, cargo: %f att: %li\n",mod_weapon, mod_cargo, attraction);
 		while(attraction > raidFleet->Strength()){
 			attraction -= raidFleet->Strength();


### PR DESCRIPTION
With this pull request pirate raids are triggered based on the cargo capacity and weapon mass of your fleet. This means even a fleet of heavy warships can trigger pirate attacks if they have light armament.


This addresses #2223 