### PR TITLE
Correct minor mistakes in transport missions.txt

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1428,7 +1428,7 @@ mission "Rescue Miners 1"
 
 mission "Rescue Miners 2"
 	landing
-	description "Participate in the medical evacuation of some miners injured in a recent accident on <planet>."
+	description "Participate in the medical evacuation of some miners injured in a recent accident on <origin>."
 	name "Rescue Miners"
 	minor
 	destination

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -993,7 +993,7 @@ mission "Rim Archaeology 1"
 					goto telepath
 			label telepath
 			`	You expect him to laugh at you, but instead he's so shocked that he drops the data pad he's holding. "An Archon?" he says. "How the hell did you get tangled up with one of those?" You tell him the story, and he listens intently.`
-			`	"It's feasible," he says. "We've heard rumors from the Quarg that an alien civilization used to exist in the Rim, a hundred of thousand years ago. No signs of it, of course - any artifacts they left behind have been destroyed by the elements, or perhaps intentionally removed. But if a city were encased in lava, that could preserve signs of it even over such a long time frame."`
+			`	"It's feasible," he says. "We've heard rumors from the Quarg that an alien civilization used to exist in the Rim, a hundred of thousand years ago. No signs of it, of course - any artifacts they left behind have been destroyed by the elements, or perhaps intentionally removed. But if a city was encased in lava, that could preserve signs of it even over such a long time frame."`
 			`	Foster makes a few phone calls to cancel his upcoming plans, and then shows up at your ship with a large collection of geological surveying tools. "Let's go check it out," he says.`
 				accept
 	


### PR DESCRIPTION
Accident happened on planet injured miners are transported from, not to, hence origin instead of planet in the second mission.
Also corrected a minor mistake in Rim Archaeology.