### PR TITLE
Rescue Miners 2 correctly references place of the accident

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1428,7 +1428,7 @@ mission "Rescue Miners 1"
 
 mission "Rescue Miners 2"
 	landing
-	description "Participate in the medical evacuation of some miners injured in a recent accident on <planet>."
+	description "Participate in the medical evacuation of some miners injured in a recent accident on <origin>."
 	name "Rescue Miners"
 	minor
 	destination


### PR DESCRIPTION
The mine explosion happened on planet injured miners are transported from, not to, hence origin instead of planet in the second mission.