### PR TITLE
F.S. Starry Warrior shouldn't change its prefix in FW Prisoner Parole 2

### DIFF
--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -218,7 +218,7 @@ mission "FW Prisoner Parole 2"
 	npc accompany save
 		government "Escort"
 		personality timid escort
-		ship "Falcon (Heavy)" "R.N.S. Starry Warrior"
+		ship "Falcon (Heavy)" "F.S. Starry Warrior"
 		ship "Blackbird" "Flight of Fancy"
 		ship "Blackbird" "Southern Luxury"
 	


### PR DESCRIPTION
In FW Prisoner Parole 2 mission F.S. Starry Warrior became R.N.S. Starry Warrior. Corrected that.