### PR TITLE
added fast forward hotkeys

### DIFF
--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -66,6 +66,10 @@ const Command Command::HOLD(1uL << 23, "Fleet: Hold position");
 const Command Command::AMMO(1uL << 24, "Fleet: Toggle ammo usage");
 const Command Command::WAIT(1uL << 25, "");
 const Command Command::STOP(1ul << 26, "");
+const Command Command::FRAMERATE_2(1ul<<27, "Double game play speed");
+const Command Command::FRAMERATE_4(1ul<<28, "Quadruple game play speed");
+const Command Command::FRAMERATE_8(1ul<<29, "Octuple game play speed");
+const Command Command::FRAMERATE_MAX(1ul<<30, "Maximum game play speed");
 
 
 

--- a/source/Command.h
+++ b/source/Command.h
@@ -61,6 +61,14 @@ public:
 	// This command from the AI tells a ship that if possible, it should apply
 	// less than its full thrust in order to come to a complete stop.
 	static const Command STOP;
+
+	//change the game's framerate temporarly to enable fast forwarding
+	static const Command FRAMERATE_2;
+	static const Command FRAMERATE_4;
+	static const Command FRAMERATE_8;
+	static const Command FRAMERATE_MAX;
+
+
 	
 public:
 	// In the given text, replace any instances of command names (in angle

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -322,7 +322,11 @@ void PreferencesPanel::DrawControls()
 		Command::FIGHT,
 		Command::GATHER,
 		Command::HOLD,
-		Command::AMMO
+		Command::AMMO,
+		Command::FRAMERATE_2,
+		Command::FRAMERATE_4,
+		Command::FRAMERATE_8,
+		Command::FRAMERATE_MAX
 	};
 	static const Command *BREAK = &COMMANDS[19];
 	for(const Command &command : COMMANDS)

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -242,25 +242,25 @@ int main(int argc, char *argv[])
 				{
 					timer.SetFrameRate((event.key.keysym.mod & KMOD_CAPS) ? 10 : 60);
 				} else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
-						&& event.key.keysym.sym == SDLK_SLASH)
-                {
+						&& Command(event.key.keysym.sym).Has(Command::FRAMERATE_2))
+				{
 					timer.SetFrameRate((event.type == SDL_KEYDOWN) ? 60*2 : 60);
 				} 
-                else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
-						&& event.key.keysym.sym == SDLK_PERIOD)
-                {
+				else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
+						&& Command(event.key.keysym.sym).Has(Command::FRAMERATE_4))
+				{
 					timer.SetFrameRate((event.type == SDL_KEYDOWN) ? 60 * 4 : 60);
-                }
-                else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
-						&& event.key.keysym.sym == SDLK_COMMA)
-                {
+				}
+				else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
+						&& Command(event.key.keysym.sym).Has(Command::FRAMERATE_8))
+				{
 					timer.SetFrameRate((event.type == SDL_KEYDOWN) ? 60 * 8 : 60);
-                }
-                else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
-						&& event.key.keysym.sym == SDLK_QUOTE)
-                {
+				}
+				else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
+						&& Command(event.key.keysym.sym).Has(Command::FRAMERATE_MAX))
+				{
 					timer.SetFrameRate((event.type == SDL_KEYDOWN) ? INT_MAX : 60);
-                }
+				}
 
 				else if(debugMode && event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_BACKQUOTE)
 				{

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -41,6 +41,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <stdexcept>
 #include <string>
 
+#include <limits.h>
+
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -239,7 +241,27 @@ int main(int argc, char *argv[])
 						&& event.key.keysym.sym == SDLK_CAPSLOCK)
 				{
 					timer.SetFrameRate((event.key.keysym.mod & KMOD_CAPS) ? 10 : 60);
-				}
+				} else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
+						&& event.key.keysym.sym == SDLK_SLASH)
+                {
+					timer.SetFrameRate((event.type == SDL_KEYDOWN) ? 60*2 : 60);
+				} 
+                else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
+						&& event.key.keysym.sym == SDLK_PERIOD)
+                {
+					timer.SetFrameRate((event.type == SDL_KEYDOWN) ? 60 * 4 : 60);
+                }
+                else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
+						&& event.key.keysym.sym == SDLK_COMMA)
+                {
+					timer.SetFrameRate((event.type == SDL_KEYDOWN) ? 60 * 8 : 60);
+                }
+                else if((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
+						&& event.key.keysym.sym == SDLK_QUOTE)
+                {
+					timer.SetFrameRate((event.type == SDL_KEYDOWN) ? INT_MAX : 60);
+                }
+
 				else if(debugMode && event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_BACKQUOTE)
 				{
 					isPaused = !isPaused;


### PR DESCRIPTION
This branch enables fast forwarding.

When HELD the following hotkeys will speed up the game clock:
speed multiplier | button
2 /
4 .
8 ,
maximum '


I don't think this should be accepted as is, but this game greatly benefits from the ability to speed up boring parts. From waiting for the ram scoops to do their job to running a long jump route the game has long stretches where the player has nothing to do but wait for the game to finish the requested action. This PR gives the player hotkeys to up the frame rate so that they can skip boring parts.  How can this be improved?