### PR TITLE
Rebalancing the Bactrian as a transport

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -225,7 +225,7 @@ ship "Bactrian"
 	explode "huge explosion" 30
 	"final explode" "final explosion large"
 	description "The Lionheart Bactrian is the last of the great city-ships, a design hearkening back to the early days of space colonization when a long-distance vessel needed to be a self-contained world, able to survive at times for weeks without encountering an inhabited planet."
-	description "During the caravan era of the 27th century, the Bactrian was among the most powerful warships in human space, as well as being one of the best freighters and carriers. However, more modern times have seen the Bactrian become among the weakest of the warships, and it was not too many years ago that the Bactrian was recategorized as a transport vessel, and as such the Deep no longer requires for those who wish to purchase this massive ship to be vetted."
+	description "During the caravan era of the 27th century, heavily-armed Bactrians were among the most powerful warships in human space, and sales were tightly controlled by the local government of the Deep. No longer a match for today's modern warships, the Bactrian has been reclassified as a transport and is now sold freely to civilians."
 
 
 

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -169,31 +169,29 @@ ship "Arrow"
 ship "Bactrian"
 	sprite "ship/bactrian"
 	attributes
-		category "Heavy Warship"
+		category "Transport"
 		"cost" 17600000
-		"shields" 17500
-		"hull" 8600
+		"shields" 12300
+		"hull" 7700
 		"required crew" 70
 		"bunks" 245
 		"mass" 940
 		"drag" 16.1
 		"heat dissipation" .4
 		"fuel capacity" 700
-		"cargo space" 530
-		"outfit space" 740
-		"weapon capacity" 300
+		"cargo space" 320
+		"outfit space" 700
+		"weapon capacity" 210
 		"engine capacity" 180
 		weapon
-			"blast radius" 260
-			"shield damage" 2600
-			"hull damage" 1300
-			"hit force" 3900
+			"blast radius" 200
+			"shield damage" 2000
+			"hull damage" 1000
+			"hit force" 3000
 	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
-		"Torpedo Launcher" 2
-		"Torpedo" 60
-		"Heavy Laser Turret" 4
+		"Sidewinder Missile Launcher" 4
+		"Sidewinder Missile" 200
+		"Laser Turret" 4
 		"Heavy Anti-Missile Turret" 2
 		
 		"Fusion Reactor"
@@ -208,15 +206,15 @@ ship "Bactrian"
 		
 	engine -18 230
 	engine 18 230
-	gun -15 -226 "Torpedo Launcher"
-	gun 15 -226 "Torpedo Launcher"
+	gun -15 -226 "Sidewinder Missile Launcher"
+	gun 15 -226 "Sidewinder Missile Launcher"
 	gun -40 -133 "Sidewinder Missile Launcher"
 	gun -45 -128 "Sidewinder Missile Launcher"
-	turret -22 -148 "Heavy Laser Turret"
+	turret -22 -148 "Laser Turret"
 	turret 26 -80 "Heavy Anti-Missile Turret"
-	turret -41 -20 "Heavy Laser Turret"
-	turret 32 -7 "Heavy Laser Turret"
-	turret 53 82 "Heavy Laser Turret"
+	turret -41 -20 "Laser Turret"
+	turret 32 -7 "Laser Turret"
+	turret 53 82 "Laser Turret"
 	turret -37 186 "Heavy Anti-Missile Turret"
 	fighter -38 -26
 	fighter 35 36
@@ -226,7 +224,8 @@ ship "Bactrian"
 	explode "large explosion" 45
 	explode "huge explosion" 30
 	"final explode" "final explosion large"
-	description "The Lionheart Bactrian is the last of the great city-ships, a design hearkening back to the early days of space colonization when a long-distance vessel needed to be a self-contained world, able to survive at times for weeks without encountering an inhabited planet. It is not only a freighter, but a carrier, and a capable warship either at short range or at a distance. Naturally, this versatility also makes it extremely expensive, and the Bactrian is not normally for sale to ordinary citizens who have not been vetted by the local government of the Deep."
+	description "The Lionheart Bactrian is the last of the great city-ships, a design hearkening back to the early days of space colonization when a long-distance vessel needed to be a self-contained world, able to survive at times for weeks without encountering an inhabited planet."
+	description "During the caravan era of the 27th century, the Bactrian was among the most powerful warships in human space, as well as being one of the best freighters and carriers. However, more modern times have seen the Bactrian become among the weakest of the warships, and it was not too many years ago that the Bactrian was recategorized as a transport vessel, and as such the Deep no longer requires for those who wish to purchase this massive ship to be vetted."
 
 
 


### PR DESCRIPTION
This is a more radical change than in #2076 that sees the Bactrian becoming a transport-freighter hybrid instead of being a highly versatile warship.  I didn't touch the Mule here because that can be more of a seperate issue and I haven't changed the outfits on the Bactrian variants yet, so they're going to have negative outfit and weapon space.