### PR TITLE
added ammo storages to ships and did the lay-outs a lot (#2269 retry)

### DIFF
--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -32,13 +32,16 @@ ship "Aphid"
 			"hit force" 450
 	outfits
 		"Pulse Turret"
+		
 		"Pebble Core"
 		"Hai Fissure Batteries"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
+		
 		`"Basrem" Atomic Thruster`
 		`"Basrem" Atomic Steering`
 		"Hyperdrive"
+		
 	engine -8 40
 	engine 8 40
 	turret 0 24 "Pulse Turret"
@@ -50,13 +53,17 @@ ship "Aphid"
 ship "Aphid" "Aphid (Anti-Missile)"
 	outfits
 		"Chameleon Anti-Missile"
+		
 		"Pebble Core"
 		"Hai Fissure Batteries"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
+		
 		`"Benga" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
+
+
 
 ship "Flea"
 	sprite "ship/hai flea"
@@ -80,14 +87,18 @@ ship "Flea"
 	outfits
 		"Railgun"
 		"Railgun Slug" 160
+		
 		"Sand Cell"
 		"Hai Chasm Batteries"
+		
 		`"Baellie" Atomic Engines`
-
+		
 	engine 0 27
 	gun 0 -27 "Railgun"
 	explode "tiny explosion 15"
 	description `This is a combat drone designed to help contain Unfettered aggression with a minimum risk to Hai life.`
+
+
 
 ship "Lightning Bug"
 	sprite "ship/hai lightning bug"
@@ -114,13 +125,16 @@ ship "Lightning Bug"
 	outfits
 		"Ion Cannon"
 		"Bullfrog Anti-Missile" 2
+		
 		"Geode Reactor"
 		"Hai Gorge Batteries"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
+		
 		`"Benga" Atomic Thruster`
 		`"Biroo" Atomic Steering`
 		"Hyperdrive"
+		
 	engine -40 22
 	engine 40 22
 	gun 0 -40 "Ion Cannon"
@@ -138,12 +152,16 @@ ship "Lightning Bug" "Lightning Bug (Pulse)"
 		"Hai Tracker Pod"
 		"Hai Tracker" 56
 		"Pulse Turret" 2
+		
 		"Geode Reactor"
 		"Hai Gorge Batteries"
 		"Hai Corundum Regenerator"
+		
 		`"Biroo" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
+
+
 
 ship "Pond Strider"
 	sprite "ship/hai pond strider"
@@ -172,14 +190,16 @@ ship "Pond Strider"
 		"Railgun Slug" 320
 		"Pulse Cannon"
 		"Pulse Turret" 2
-		"Bullfrog Anti-Missile" 
+		"Bullfrog Anti-Missile"
+		
 		"Hai Diamond Regenerator"
 		"Hai Chasm Batteries"
 		"Hai Gorge Batteries"
 		"Geode Reactor"
+		"Hai Williwaw Cooling" 3
+		
 		`"Benga" Atomic Thruster`
 		`"Biroo" Atomic Steering`
-		"Hai Williwaw Cooling" 3
 		"Hyperdrive"
 		
 	engine -23 80
@@ -206,6 +226,8 @@ ship "Pond Strider"
 	"final explode" "final explosion large"
 	description "This short range drone carrier was built by the Hai to contain the increasingly aggressive Unfettered with their new Solifuge and Violin Spider ships. The Hai's greater value for life is evident in the remotely-piloted robotic fighter craft, preferring to keep valuable pilots out of harm's way."
 
+
+
 ship "Shield Beetle"
 	sprite "ship/hai shield beetle"
 	attributes
@@ -231,17 +253,21 @@ ship "Shield Beetle"
 	outfits
 		"Ion Cannon" 4
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 224
+		"Hai Tracker" 280
+		"Tracker Storage Pod" 2
 		"Chameleon Anti-Missile" 2
+		
 		"Boulder Reactor"
 		"Geode Reactor"
 		"Hai Gorge Batteries"
 		"Hai Ravine Batteries"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 2
+		
 		`"Bondir" Atomic Thruster`
 		`"Bufaer" Atomic Steering`
 		"Hyperdrive"
+		
 	engine -44 133
 	engine 44 133
 	gun -22 -102 "Ion Cannon"
@@ -264,33 +290,22 @@ ship "Shield Beetle"
 	"final explode" "final explosion large"
 	description "The Shield Beetle is a versatile warship used by the Hai to guard their merchant convoys."
 
-ship "Shield Beetle" "Shield Beetle (Tracker)"
-	outfits
-		"Hai Tracker Pod" 8
-		"Hai Tracker" 448
-		"Pulse Turret" 4
-		"Boulder Reactor"
-		"Geode Reactor"
-		"Hai Valley Batteries"
-		"Hai Diamond Regenerator"
-		"Hai Williwaw Cooling" 2
-		`"Bondir" Atomic Thruster`
-		`"Bufaer" Atomic Steering`
-		"Hyperdrive"
-
 ship "Shield Beetle" "Shield Beetle (Pulse)"
 	outfits
 		"Ion Cannon" 2
 		"Pulse Cannon" 6
 		"Pulse Turret" 4
+		
 		"Boulder Reactor"
 		"Geode Reactor"
 		"Hai Ravine Batteries"
 		"Hai Diamond Regenerator" 2
 		"Hai Williwaw Cooling" 3
+		
 		`"Bondir" Atomic Thruster`
 		`"Bufaer" Atomic Steering`
 		"Hyperdrive"
+		
 	gun "Ion Cannon"
 	gun "Ion Cannon"
 	gun "Pulse Cannon"
@@ -299,6 +314,23 @@ ship "Shield Beetle" "Shield Beetle (Pulse)"
 	gun "Pulse Cannon"
 	gun "Pulse Cannon"
 	gun "Pulse Cannon"
+
+ship "Shield Beetle" "Shield Beetle (Tracker)"
+	outfits
+		"Hai Tracker Pod" 8
+		"Hai Tracker" 672
+		"Tracker Storage Pod" 8
+		"Pulse Turret" 4
+		
+		"Boulder Reactor"
+		"Geode Reactor"
+		"Hai Valley Batteries"
+		"Hai Diamond Regenerator"
+		"Hai Williwaw Cooling" 2
+		
+		`"Bondir" Atomic Thruster`
+		`"Bufaer" Atomic Steering`
+		"Hyperdrive"
 
 ship "Shield Beetle" "Shield Beetle (Jump)"
 	outfits
@@ -306,6 +338,7 @@ ship "Shield Beetle" "Shield Beetle (Jump)"
 		"Hai Tracker Pod" 4
 		"Hai Tracker" 224
 		"Chameleon Anti-Missile" 2
+		
 		"Boulder Reactor" 2
 		"Hai Chasm Batteries" 2
 		"Hai Fissure Batteries"
@@ -314,9 +347,11 @@ ship "Shield Beetle" "Shield Beetle (Jump)"
 		"Hai Diamond Regenerator" 2
 		"Fuel Pod" 3
 		"Hai Williwaw Cooling" 4
+		
 		`"Bondir" Atomic Thruster`
 		`"Bufaer" Atomic Steering`
 		"Jump Drive"
+		
 	gun "Ion Cannon"
 	gun "Ion Cannon"
 	gun "Hai Tracker Pod"
@@ -335,16 +370,20 @@ ship "Shield Beetle" "Shield Beetle (Jump, Tracker)"
 		"Hai Tracker Pod" 8
 		"Hai Tracker" 448
 		"Pulse Turret" 4
+		
 		"Boulder Reactor" 2
 		"Hai Ravine Batteries"
 		"Mass Expansion" 4
 		"Hai Diamond Regenerator" 2
 		"Fuel Pod" 3
 		"Hai Williwaw Cooling" 6
+		
 		`"Bondir" Atomic Thruster`
 		`"Bufaer" Atomic Steering`
 		"Jump Drive"
-	
+
+
+
 ship "Solifuge"
 	sprite "ship/hai solifuge"
 	licenses
@@ -376,15 +415,17 @@ ship "Solifuge"
 		"Pulse Turret" 2
 		"Chameleon Anti-Missile"
 		"Bullfrog Anti-Missile" 4
+		
 		"Boulder Reactor" 2
 		"Hai Gorge Batteries"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 6
+		
+		`"Bondir" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		`"Bufaer" Atomic Steering`
-		`"Bondir" Atomic Thruster`
 		Hyperdrive
-			
+		
 	engine -28 135.5
 	engine 28 135,5
 	gun 0 -140 "Hai Tracker Pod"
@@ -419,15 +460,18 @@ ship "Solifuge" "Solifuge (Pulse)"
 		"Pulse Cannon" 3
 		"Pulse Turret" 5
 		"Bullfrog Anti-Missile" 2
+		
 		"Boulder Reactor" 2
 		"Hai Fissure Batteries"
 		"Hai Corundum Regenerator"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 8
+		
+		`"Bondir" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		`"Bufaer" Atomic Steering`
-		`"Bondir" Atomic Thruster`
 		Hyperdrive
+		
 	gun "Pulse Cannon"
 	gun "Pulse Cannon"
 	gun "Pulse Cannon"
@@ -441,14 +485,16 @@ ship "Solifuge" "Solifuge (Tracker)"
 		"Pulse Turret" 4
 		"Chameleon Anti-Missile"
 		"Bullfrog Anti-Missile" 2
+		
 		"Boulder Reactor" 2
 		"Hai Gorge Batteries"
 		"Hai Corundum Regenerator"
 		"Hai Diamond Regenerator" 2
 		"Hai Williwaw Cooling" 6
+		
+		`"Bondir" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		`"Bufaer" Atomic Steering`
-		`"Bondir" Atomic Thruster`
 		Hyperdrive
 
 ship "Solifuge" "Solifuge (Jump)"
@@ -459,13 +505,15 @@ ship "Solifuge" "Solifuge (Jump)"
 		"Pulse Turret" 2
 		"Chameleon Anti-Missile"
 		"Bullfrog Anti-Missile" 4
+		
 		"Boulder Reactor" 2
 		"Hai Gorge Batteries"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 6
+		
+		`"Bondir" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		`"Bufaer" Atomic Steering`
-		`"Bondir" Atomic Thruster`
 		"Jump Drive"
 
 ship "Solifuge" "Solifuge (Jump, Pulse)"
@@ -474,15 +522,18 @@ ship "Solifuge" "Solifuge (Jump, Pulse)"
 		"Pulse Cannon" 3
 		"Pulse Turret" 5
 		"Bullfrog Anti-Missile" 2
+		
 		"Boulder Reactor" 2
 		"Hai Fissure Batteries"
 		"Hai Corundum Regenerator"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 8
+		
+		`"Bondir" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		`"Bufaer" Atomic Steering`
-		`"Bondir" Atomic Thruster`
 		"Jump Drive"
+		
 	gun "Pulse Cannon"
 	gun "Pulse Cannon"
 	gun "Pulse Cannon"
@@ -496,15 +547,19 @@ ship "Solifuge" "Solifuge (Jump, Tracker)"
 		"Pulse Turret" 4
 		"Chameleon Anti-Missile"
 		"Bullfrog Anti-Missile" 2
+		
 		"Boulder Reactor" 2
 		"Hai Gorge Batteries"
 		"Hai Corundum Regenerator"
 		"Hai Diamond Regenerator" 2
 		"Hai Williwaw Cooling" 6
+		
+		`"Bondir" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		`"Bufaer" Atomic Steering`
-		`"Bondir" Atomic Thruster`
 		"Jump Drive"
+
+
 
 ship "Violin Spider"
 	sprite "ship/hai violin spider"
@@ -529,12 +584,14 @@ ship "Violin Spider"
 	outfits
 		"Hai Tracker Pod"
 		"Hai Tracker" 56
+		
 		"Pebble Core"
 		Supercapacitor
 		"Hai Williwaw Cooling"
-		`"Basrem" Atomic Steering`
+		
 		`"Basrem" Atomic Thruster`
-
+		`"Basrem" Atomic Steering`
+		
 	engine -15 30
 	engine 15 30
 	gun 0 -31 "Hai Tracker Pod"
@@ -546,11 +603,15 @@ ship "Violin Spider"
 ship "Violin Spider" "Violin Spider (Pulse)"
 	outfits
 		"Pulse Cannon"
+		
 		"Pebble Core"
 		"Hai Chasm Batteries"
 		"Hai Williwaw Cooling"
-		`"Basrem" Atomic Steering`
+		
 		`"Basrem" Atomic Thruster`
+		`"Basrem" Atomic Steering`
+
+
 
 ship "Water Bug"
 	sprite "ship/hai water bug"
@@ -576,17 +637,21 @@ ship "Water Bug"
 			"hit force" 1860
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Hai Tracker" 140
+		"Tracker Storage Pod"
 		"Pulse Turret"
 		"Chameleon Anti-Missile" 2
+		
 		"Geode Reactor"
 		"Hai Gorge Batteries"
 		"Hai Chasm Batteries"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling"
+		
 		`"Benga" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
+		
 	engine -50 33
 	engine 50 33
 	gun -24 -53 "Hai Tracker Pod"
@@ -604,13 +669,16 @@ ship "Water Bug"
 ship "Water Bug" "Water Bug (Pulse)"
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Hai Tracker" 140
+		"Tracker Storage Pod"
 		"Pulse Turret" 3
+		
 		"Geode Reactor"
 		"Hai Gorge Batteries"
 		"Hai Chasm Batteries"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling"
+		
 		`"Benga" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
@@ -618,14 +686,17 @@ ship "Water Bug" "Water Bug (Pulse)"
 ship "Water Bug" "Water Bug (Jump)"
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Hai Tracker" 196
+		"Tracker Storage Pod" 3
 		"Pulse Turret"
 		"Chameleon Anti-Missile" 2
+		
 		"Geode Reactor"
 		"Hai Gorge Batteries"
 		"Hai Chasm Batteries"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling"
+		
 		`"Benga" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		"Jump Drive"

--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -318,13 +318,14 @@ ship "Shield Beetle" "Shield Beetle (Pulse)"
 ship "Shield Beetle" "Shield Beetle (Tracker)"
 	outfits
 		"Hai Tracker Pod" 8
-		"Hai Tracker" 672
-		"Tracker Storage Pod" 8
+		"Hai Tracker" 560
+		"Tracker Storage Pod" 4
 		"Pulse Turret" 4
 		
 		"Boulder Reactor"
 		"Geode Reactor"
 		"Hai Valley Batteries"
+		"Mass Expansion" 2
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 2
 		

--- a/data/korath ships.txt
+++ b/data/korath ships.txt
@@ -45,7 +45,7 @@ ship "Korath Raider"
 		"Thruster (Planetary Class)"
 		"Steering (Planetary Class)"
 		"Jump Drive"
-	
+		
 	engine -20 130
 	engine 20 130
 	turret -34 -143 "Korath Grab-Strike"
@@ -94,7 +94,7 @@ ship "Korath Chaser"
 		
 		"Thruster (Asteroid Class)"
 		"Steering (Asteroid Class)"
-	
+		
 	engine -7 23
 	engine 7 23
 	gun 0 -28 "Korath Fire-Lance"
@@ -139,7 +139,7 @@ ship "Korath World-Ship"
 		"Thruster (Planetary Class)"
 		"Steering (Planetary Class)"
 		"Hyperdrive"
-	
+		
 	engine -37 343 .8
 	engine 0 343 .9
 	engine 37 343 .8
@@ -196,7 +196,7 @@ ship "Korath World-Ship" "Korath World-Ship A (Jump)"
 		"Thruster (Planetary Class)"
 		"Steering (Planetary Class)"
 		"Jump Drive"
-	
+		
 	turret -76 -157 "Korath Grab-Strike"
 	turret 76 -157 "Korath Banisher"
 	turret -59 -135 "Korath Warder"
@@ -222,7 +222,7 @@ ship "Korath World-Ship" "Korath World-Ship B (Jump)"
 		"Thruster (Planetary Class)"
 		"Steering (Planetary Class)"
 		"Jump Drive"
-	
+		
 	turret -76 -219 "Korath Grab-Strike"
 	turret 76 -219 "Korath Grab-Strike"
 	turret -75 -112 "Korath Banisher"
@@ -248,7 +248,7 @@ ship "Korath World-Ship" "Korath World-Ship C (Jump)"
 		"Thruster (Planetary Class)"
 		"Steering (Planetary Class)"
 		"Jump Drive"
-	
+		
 	turret -45 -247 "Korath Warder"
 	turret 45 -247 "Korath Grab-Strike"
 	turret -47 -140 "Korath Grab-Strike"
@@ -286,7 +286,8 @@ ship "Kar Ik Vot 349"
 	outfits
 		"Korath Detainer" 2
 		"Korath Piercer Launcher" 2
-		"Korath Piercer" 62
+		"Korath Piercer" 94
+		"Korath Piercer Rack" 2
 		"Korath Warder" 2
 		"Korath Repeater Turret" 6
 		
@@ -300,7 +301,7 @@ ship "Kar Ik Vot 349"
 		"Thruster (Planetary Class)"
 		"Steering (Stellar Class)"
 		Hyperdrive
-	
+		
 	engine -24 237
 	engine 24 237
 	gun -8 -212 "Korath Detainer"
@@ -342,7 +343,7 @@ ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Offense)"
 		"Thruster (Asteroid Class)"
 		"Steering (Stellar Class)"
 		Hyperdrive
-	
+		
 	turret "Korath Repeater Turret"
 	turret "Korath Repeater Turret"
 	turret "Korath Repeater Turret"
@@ -355,7 +356,8 @@ ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Offense)"
 ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Defense)"
 	outfits
 		"Korath Piercer Launcher" 4
-		"Korath Piercer" 124
+		"Korath Piercer" 172
+		"Korath Piercer Rack" 3
 		"Korath Warder" 3
 		"Korath Grab-Strike" 3
 		"Korath Banisher" 2
@@ -371,7 +373,7 @@ ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Defense)"
 		"Thruster (Stellar Class)"
 		"Steering (Planetary Class)"
 		Hyperdrive
-	
+		
 	turret "Korath Warder"
 	turret "Korath Grab-Strike"
 	turret "Korath Grab-Strike"
@@ -399,7 +401,7 @@ ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Trapper)"
 		"Thruster (Planetary Class)"
 		"Steering (Stellar Class)"
 		Hyperdrive
-	
+		
 	gun "Korath Detainer"
 	gun "Korath Detainer"
 	gun
@@ -412,6 +414,7 @@ ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Trapper)"
 	turret "Korath Banisher"
 	turret
 	turret
+
 
 
 ship "Tek Far 71 - Lek"
@@ -453,7 +456,7 @@ ship "Tek Far 71 - Lek"
 		"Thruster (Lunar Class)"
 		"Steering (Lunar Class)"
 		"Hyperdrive"
-	
+		
 	engine -9 219
 	engine 9 219
 	gun 10 -180 "Korath Detainer"
@@ -499,11 +502,12 @@ ship "Tek Far 71 - Lek" "Tek Far 71 - Lek (Close Quarters)"
 		"Thruster (Lunar Class)"
 		"Steering (Lunar Class)"
 		"Hyperdrive"
-	
+		
 	turret "Korath Repeater Turret"
 	turret "Korath Repeater Turret"
 	turret "Korath Warder"
 	turret "Korath Repeater Turret"
+
 
 
 ship "Tek Far 78 - Osk"
@@ -634,7 +638,7 @@ ship "Tek Far 109"
 		"Thruster (Lunar Class)"
 		"Steering (Planetary Class)"
 		Hyperdrive
-	
+		
 	engine -9 205
 	engine 9 205
 	gun 0 -214 "Korath Detainer"
@@ -665,6 +669,7 @@ ship "Tek Far 109"
 	explode "huge explosion" 8
 	"final explode" "final explosion medium"
 	description "The TF109 is designed almost solely for the purpose of carrying a fleet of Kor Sestor fighters and drones. Without them to serve as a protective screen, the ship itself is relatively helpless."
+
 
 
 ship "Met Par Tek 53"
@@ -703,7 +708,7 @@ ship "Met Par Tek 53"
 		"Thruster (Lunar Class)"
 		"Steering (Planetary Class)"
 		"Hyperdrive"
-	
+		
 	engine -24 132
 	engine 24 132
 	gun 0 -92 "Korath Repeater"
@@ -743,7 +748,7 @@ ship "Met Par Tek 53" "Met Par Tek 53 (Sniper)"
 		"Steering (Planetary Class)"
 		"Steering (Comet Class)"
 		"Hyperdrive"
-	
+		
 	gun "Korath Detainer"
 	gun "Korath Piercer Launcher"
 	gun "Korath Piercer Launcher"
@@ -753,6 +758,7 @@ ship "Met Par Tek 53" "Met Par Tek 53 (Sniper)"
 	turret
 	turret
 	turret
+
 
 
 ship "Far Lek 14"
@@ -833,6 +839,7 @@ ship "Far Osk 27"
 	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to carry far more weaponry than any comparable human ship."
 
 
+
 ship "Model 8"
 	sprite "ship/model 8"
 	attributes
@@ -867,7 +874,7 @@ ship "Model 8"
 		"Thruster (Comet Class)"
 		"Steering (Lunar Class)"
 		Hyperdrive
-	
+		
 	engine -11 49
 	engine 11 49
 	gun 9 -36 "Korath Slicer"
@@ -876,6 +883,7 @@ ship "Model 8"
 	explode "small explosion" 10
 	"final explode" "final explosion small"
 	description "The primary role of the smallest Kor Mereti drones is asteroid mining, but their lasers can also be employed as offensive weapons when necessary."
+
 
 
 ship "Model 16"
@@ -916,7 +924,7 @@ ship "Model 16"
 		"Thruster (Planetary Class)"
 		"Steering (Lunar Class)"
 		Hyperdrive
-	
+		
 	engine -10 99
 	engine 10 99
 	gun 0 -99 "Korath Minelayer"
@@ -928,6 +936,7 @@ ship "Model 16"
 	explode "large explosion" 10
 	"final explode" "final explosion small"
 	description "The Kor Mereti war drones are constructed in a modular fashion, which allows them to grow over time as more materials become available. This one is recently built, and relatively small."
+
 
 
 ship "Model 32"
@@ -968,7 +977,7 @@ ship "Model 32"
 		"Thruster (Planetary Class)"
 		"Steering (Lunar Class)"
 		Hyperdrive
-
+		
 	engine -10 128
 	engine 10 128
 	gun 0 -129 "Korath Minelayer"
@@ -981,6 +990,7 @@ ship "Model 32"
 	explode "large explosion" 15
 	"final explode" "final explosion medium"
 	description "The Kor Mereti built their drones to mimic life: capable of growth and development throughout their life cycles. Their automated factories can convert the drones from one configuration to another by adding or removing modules."
+
 
 
 ship "Model 64"
@@ -1008,7 +1018,8 @@ ship "Model 64"
 			"hit force" 6000
 	outfits
 		"Korath Minelayer"
-		"Korath Mine" 17
+		"Korath Mine" 35
+		"Korath Mine Rack" 2
 		"Korath Disruptor" 2
 		"Korath Slicer Turret" 2
 		
@@ -1021,13 +1032,13 @@ ship "Model 64"
 		"Thruster (Asteroid Class)"
 		"Steering (Planetary Class)"
 		Hyperdrive
-	
+		
 	engine -19 159
 	engine 19 159
 	gun 0 -159 "Korath Minelayer"
 	turret 20 -74 "Korath Slicer Turret"
-	turret -29 71 "Korath Slicer Turret"
 	turret -35 -69 "Korath Disruptor"
+	turret -29 71 "Korath Slicer Turret"
 	turret 34 77 "Korath Disruptor"
 	explode "tiny explosion" 100
 	explode "small explosion" 70
@@ -1035,6 +1046,7 @@ ship "Model 64"
 	explode "large explosion" 20
 	"final explode" "final explosion medium"
 	description "This medium-sized drone serves the Kor Mereti fleets in much the same way as a human Frigate, but in terms of total firepower it is far beyond anything humans have constructed."
+
 
 
 ship "Model 128"
@@ -1075,7 +1087,7 @@ ship "Model 128"
 		"Steering (Planetary Class)"
 		"Steering (Asteroid Class)"
 		Hyperdrive
-
+		
 	engine -14 178
 	engine 14 178
 	gun -11 -166 "Korath Minelayer"
@@ -1091,6 +1103,7 @@ ship "Model 128"
 	explode "large explosion" 25
 	"final explode" "final explosion large"
 	description "As Kor Mereti drones continue to grow and develop into their final form, they split down the middle. At the same time, their shielding and weaponry continue to become stronger."
+
 
 
 ship "Model 256"
@@ -1118,7 +1131,8 @@ ship "Model 256"
 			"hit force" 7800
 	outfits
 		"Korath Minelayer" 2
-		"Korath Mine" 34
+		"Korath Mine" 52
+		"Korath Mine Rack" 2
 		"Korath Disruptor" 3
 		"Korath Slicer Turret" 3
 		
@@ -1131,7 +1145,7 @@ ship "Model 256"
 		"Steering (Planetary Class)"
 		"Steering (Comet Class)"
 		Hyperdrive
-
+		
 	engine -60 147
 	engine 60 147
 	gun -22 -148 "Korath Minelayer"
@@ -1148,6 +1162,7 @@ ship "Model 256"
 	explode "large explosion" 30
 	"final explode" "final explosion large"
 	description "There is a saying among the Quarg that every species which insists on studying war will eventually construct a weapon that outlives its creators. For the Korath, their war drones have very nearly done so."
+
 
 
 ship "Model 512"
@@ -1175,7 +1190,8 @@ ship "Model 512"
 			"hit force" 8400
 	outfits
 		"Korath Minelayer" 2
-		"Korath Mine" 34
+		"Korath Mine" 52
+		"Korath Mine Rack" 2
 		"Korath Disruptor" 3
 		"Korath Slicer Turret" 4
 		
@@ -1189,7 +1205,7 @@ ship "Model 512"
 		"Thruster (Planetary Class)"
 		"Steering (Stellar Class)"
 		Hyperdrive
-
+		
 	engine -145 97
 	engine 145 97
 	gun -22 -143 "Korath Minelayer"

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -334,7 +334,7 @@ ship "Bastion"
 	outfits
 		"Plasma Cannon" 2
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
+		"Heavy Rocket" 60
 		"Heavy Rocket Rack" 2
 		"Blaster Turret" 3
 		

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -190,7 +190,8 @@ ship "Bactrian"
 			"hit force" 3900
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile" 150
+		"Sidewinder Missile Rack" 2
 		"Torpedo Launcher" 2
 		"Torpedo" 60
 		"Heavy Laser Turret" 4
@@ -334,6 +335,7 @@ ship "Bastion"
 		"Plasma Cannon" 2
 		"Heavy Rocket Launcher" 2
 		"Heavy Rocket" 40
+		"Heavy Rocket Rack" 2
 		"Blaster Turret" 3
 		
 		"S3 Thermionic"
@@ -578,9 +580,9 @@ ship "Boxwing"
 			"hit force" 180
 	outfits
 		"nGVF-AA Fuel Cell"
-
+		
 		"X1050 Ion Engines"
-
+		
 	engine 23 -1
 	engine -23 -1
 	engine 19 29
@@ -588,6 +590,7 @@ ship "Boxwing"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description `After introducing the "Type F" cargo pod for the Hauler, it became apparent to merchant captains that the new carriers could offer more flexibility within their fleet, if there were a cargo box they could attach to the fighter arms. Enter the "F6-C: Boxwing", the Fighter that doesn't fight, but carries cargo instead. Cargo preservation equipment gives the Boxwing much more mass and very poor heat dissipation characteristics compared to other fighters. That it cannot carry any weapons is only part of the reason jocks call it "Flying Coffin" amongst themselves; besides the ship resembling one and being very sluggish, the pilot "seat" doubles as a bunk, and is cramped beyond the comfort level of most. The interactive panoramic window H.U.D. is the only thing that keeps claustrophobic episodes from becoming a major problem.`
+
 
 
 ship "Bulk Freighter"
@@ -672,7 +675,8 @@ ship "Carrier"
 	outfits
 		"Particle Cannon" 4
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
+		"Meteor Missile" 248
+		"Meteor Missile Box" 6
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
 		
@@ -758,8 +762,8 @@ ship "Class C Freighter"
 	engine 22 198
 	turret -12 -155 "Heavy Laser Turret"
 	turret 12 -155 "Heavy Anti-Missile Turret"
-	turret 30 175 "Heavy Laser Turret"
 	turret -30 175 "Heavy Anti-Missile Turret"
+	turret 30 175 "Heavy Laser Turret"
 	drone -66 -115 left
 	drone -66 -65 left
 	drone -66 -15 left
@@ -947,7 +951,8 @@ ship "Cruiser"
 	outfits
 		"Particle Cannon" 4
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile" 250
+		"Sidewinder Storage Rack" 6
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
 		
@@ -1110,7 +1115,8 @@ ship "Falcon"
 	outfits
 		"Plasma Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 90
+		"Torpedo Storage Rack" 2
 		"Quad Blaster Turret" 4
 		
 		"Breeder Reactor"
@@ -1354,7 +1360,8 @@ ship "Frigate"
 	outfits
 		"Particle Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 90
+		"Torpedo Storage Rack" 2
 		"Blaster Turret" 3
 		
 		"NT-200 Nucleovoltaic"
@@ -1996,7 +2003,8 @@ ship "Mule"
 			"hit force" 1500
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile" 150
+		"Sidewinder Missile Rack" 2
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
 		
@@ -2051,7 +2059,8 @@ ship "Nest"
 			"hit force" 900
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile" 142
+		"Meteor Missile Box" 4
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -2160,13 +2169,14 @@ ship "Protector"
 			"hit force" 2400
 	outfits
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 90
+		"Torpedo Storage Rack" 2
 		"Quad Blaster Turret" 6
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
 		"D67-TM Shield Generator"
-		"Small Radar Jammer" 3
+		"Small Radar Jammer"
 		"Liquid Nitrogen Cooler"
 		
 		"X3700 Ion Thruster"
@@ -2264,7 +2274,8 @@ ship "Rainmaker"
 	outfits
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
+		"Meteor Missile" 284
+		"Meteor Missile Box" 8
 		
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
@@ -2362,7 +2373,8 @@ ship "Roost"
 			"hit force" 1200
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile" 106
+		"Meteor Missile Box" 2
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -2799,7 +2811,7 @@ ship "Vanguard"
 	outfits
 		"Proton Gun" 7
 		"Anti-Missile Turret"
-
+		
 		"Fusion Reactor"
 		"LP072a Battery Pack"
 		"D67-TM Shield Generator"
@@ -2808,7 +2820,7 @@ ship "Vanguard"
 		"X3700 Ion Thruster"
 		"X4200 Ion Steering"
 		"Hyperdrive"
-	
+		
 	engine -15 130
 	engine 15 130
 	gun 0 -132 "Proton Gun"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -8,8 +8,6 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-# Human variants (other list is Alien variants; Hai outfitted ships).
-
 ship "Argosy" "Argosy (Blaster)"
 	outfits
 		"Energy Blaster" 4
@@ -125,8 +123,6 @@ ship "Bastion" "Bastion (Laser)"
 	turret "Heavy Laser Turret"
 
 
-
-# The Behemoth (Heavy) isn't used in any fleets, only in the Bloodsea spaceport string.
 
 ship "Behemoth" "Behemoth (Heavy)"
 	outfits
@@ -1311,8 +1307,6 @@ ship "Wasp" "Wasp (Proton)"
 
 
 
-# Alien variants.
-
 ship "Arrow" "Arrow (Hai)"
 	outfits
 		"Sidewinder Missile Launcher" 2
@@ -1692,8 +1686,6 @@ ship "Mule" "Mule (Hai Weapons)"
 		"Hyperdrive"
 
 
-
-# The Osprey (Alien Weapons) isn't used in any fleets, only in a special bounty mission.
 
 ship "Osprey" "Osprey (Alien Weapons)"
 	outfits

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -8,138 +8,298 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-ship "Star Barge" "Star Barge (Armed)"
+# Human variants (other list is Alien variants; Hai outfitted ships).
+
+ship "Argosy" "Argosy (Blaster)"
 	outfits
-		"Blaster Turret"
-		"nGVF-BB Fuel Cell"
-		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
-		"Chipmunk Plasma Thruster"
-		"Chipmunk Plasma Steering"
+		"Energy Blaster" 4
+		"Quad Blaster Turret" 2
+		
+		"Fission Reactor"
+		"LP072a Battery Pack"
+		"D41-HY Shield Generator"
+		"Mass Expansion"
+		
+		"Greyhound Plasma Thruster"
+		"Impala Plasma Steering"
 		"Hyperdrive"
 
-
-
-ship "Sparrow" "Sparrow (Patrol)"
+ship "Argosy" "Argosy (Laser)"
 	outfits
 		"Beam Laser" 2
-		"nGVF-BB Fuel Cell"
-		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
-		"Cargo Scanner"
-		"Outfit Scanner"
-		"Chipmunk Plasma Thruster"
-		"Chipmunk Plasma Steering"
-		"Hyperdrive"
-
-
-
-ship "Raven" "Raven (Afterburner)"
-	outfits
-		"Heavy Laser" 4
+		"Heavy Laser" 2
+		"Laser Turret" 2
+		
 		"NT-200 Nucleovoltaic"
-		"D41-HY Shield Generator"
-		"X3700 Ion Thruster"
-		"X3200 Ion Steering"
-		"Hyperdrive"
-		"Afterburner"
-
-
-
-ship "Wasp" "Wasp (Proton)"
-	outfits
-		"Proton Gun"
-		"nGVF-BB Fuel Cell"
-		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
-		"X2700 Ion Thruster"
-		"X2200 Ion Steering"
-		"Hyperdrive"
-
-
-
-ship "Manta" "Manta (Proton)"
-	outfits
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
-		"Proton Gun" 4
-		"RT-I Radiothermal"
-		"LP144a Battery Pack"
-		"D14-RN Shield Generator"
-		"X3700 Ion Thruster"
-		"X3200 Ion Steering"
-		"Hyperdrive"
-	gun "Meteor Missile Launcher"
-	gun "Meteor Missile Launcher"
-	gun "Proton Gun"
-	gun "Proton Gun"
-	gun "Proton Gun"
-	gun "Proton Gun"
-
-
-
-ship "Quicksilver" "Quicksilver (Proton)"
-	outfits
-		"Proton Gun" 2
-		"RT-I Radiothermal"
-		"LP036a Battery Pack"
-		"D23-QP Shield Generator"
-		"Cooling Ducts"
+		"Supercapacitor"
+		"D67-TM Shield Generator"
+		"Mass Expansion" 2
+		
 		"Greyhound Plasma Thruster"
+		"Impala Plasma Steering"
+		"Hyperdrive"
+
+ship "Argosy" "Argosy (Missile)"
+	outfits
+		"Meteor Missile Launcher" 4
+		"Meteor Missile" 140
+		"Anti-Missile Turret"
+		"Heavy Anti-Missile Turret"
+		
+		"Fission Reactor"
+		"Supercapacitor"
+		"D41-HY Shield Generator"
+		"Mass Expansion"
+		
+		"A370 Atomic Thruster"
+		"A255 Atomic Steering"
+		"Hyperdrive"
+		
+	turret "Anti-Missile Turret"
+	turret "Heavy Anti-Missile Turret"
+
+ship "Argosy" "Argosy (Turret)"
+	outfits
+		"Heavy Laser Turret" 2
+		
+		"S3 Thermionic"
+		"LP072a Battery Pack"
+		"D41-HY Shield Generator"
+		"Small Radar Jammer"
+		"Mass Expansion"
+		
+		"X3700 Ion Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
 
 
 
-ship "Cruiser" "Cruiser (Heavy)"
+ship "Barb" "Barb (Gatling)"
 	outfits
-		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
-		"Particle Cannon" 4
-		"Heavy Laser Turret" 2
+		"Gatling Gun"
+		"Gatling Gun Ammo" 3000
+		
+		"Anti-Missile Turret"
+		"nGVF-AA Fuel Cell"
+		Supercapacitor 3
+		"D14-RN Shield Generator"
+		
+		"X1050 Ion Engines"
+
+
+
+ship "Bastion" "Bastion (Heavy)"
+	outfits
+		"Plasma Cannon" 4
+		"Quad Blaster Turret" 3
+		
+		"Fusion Reactor"
+		"LP072a Battery Pack"
+		"D67-TM Shield Generator"
+		"Liquid Nitrogen Cooler"
+		"Mass Expansion" 2
+		
+		"X3700 Ion Thruster"
+		"Orca Plasma Steering"
+		"Hyperdrive"
+
+ship "Bastion" "Bastion (Laser)"
+	outfits
+		"Heavy Laser" 4
 		"Heavy Anti-Missile Turret"
-		"Quad Blaster Turret"
-		"Laser Rifle" 20
-		"Fragmentation Grenades" 20
-		"Armageddon Core"
-		"Dwarf Core"
+		"Heavy Laser Turret" 2
+		
+		"Fusion Reactor"
+		"Supercapacitor" 4
+		"D94-YV Shield Generator"
+		"Small Radar Jammer"
+		"Water Coolant System"
+		"Mass Expansion"
+		
+		"A370 Atomic Thruster"
+		"A525 Atomic Steering"
+		"Hyperdrive"
+		
+	turret "Heavy Anti-Missile Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+
+
+
+# The Behemoth (Heavy) isn't used in any fleets, only in the Bloodsea spaceport string.
+
+ship "Behemoth" "Behemoth (Heavy)"
+	outfits
+		"Torpedo Launcher" 2
+		Torpedo 60
+		"Quad Blaster Turret" 2
+		"Plasma Turret" 2
+		"Heavy Anti-Missile Turret" 2
+		
+		"Laser Rifle" 16
+		"Breeder Reactor"
+		"Fission Reactor"
 		"Supercapacitor"
 		"D94-YV Shield Generator"
 		"Liquid Helium Cooler"
-		"Ramscoop"
-		"Mass Expansion"
-		"A520 Atomic Thruster"
-		"A525 Atomic Steering"
-		"X2200 Ion Steering"
+		"Liquid Nitrogen Cooler"
+		"Mass Expansion" 9
+		
+		"Greyhound Plasma Thruster"
+		"Impala Plasma Steering"
+		"Hyperdrive"
+		
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
+	turret "Plasma Turret"
+	turret "Plasma Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Heavy Anti-Missile Turret"
+
+ship "Behemoth" "Behemoth (Speedy)"
+	outfits
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 100
+		"Heavy Laser Turret" 6
+		
+		"Breeder Reactor"
+		"LP144a Battery Pack"
+		"D94-YV Shield Generator"
+		"Large Radar Jammer"
+		"Liquid Nitrogen Cooler"
+		"Mass Expansion" 6
+		
+		"A250 Atomic Thruster"
+		"A125 Atomic Steering"
+		"A375 Atomic Steering"
 		"Scram Drive"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Heavy Rocket Launcher"
-	gun "Heavy Rocket Launcher"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	turret "Heavy Laser Turret"
+
+
+
+ship "Berserker" "Berserker (Afterburner)"
+	outfits
+		"Energy Blaster" 2
+		"Javelin Pod" 2
+		"Javelin" 400
+		
+		"nGVF-CC Fuel Cell"
+		"LP036a Battery Pack"
+		"D23-QP Shield Generator"
+		"Ramscoop"
+		
+		"Chipmunk Plasma Thruster"
+		"Greyhound Plasma Steering"
+		"Afterburner"
+		"Hyperdrive"
+
+
+
+ship "Bulk Freighter" "Bulk Freighter (Blaster)"
+	outfits
+		"Quad Blaster Turret" 5
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		
+		"Fusion Reactor"
+		"LP072a Battery Pack"
+		"D94-YV Shield Generator"
+		"Water Coolant System"
+		"Mass Expansion" 2
+		
+		"A250 Atomic Thruster"
+		"A375 Atomic Steering"
+		"Scram Drive"
+
+ship "Bulk Freighter" "Bulk Freighter (Heavy)"
+	outfits
+		"Laser Turret" 2
+		"Heavy Laser Turret" 2
+		"Heavy Anti-Missile Turret"
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		
+		"Fission Reactor"
+		"LP072a Battery Pack"
+		"D94-YV Shield Generator"
+		"Mass Expansion"
+		
+		"A250 Atomic Thruster"
+		"A375 Atomic Steering"
+		"Scram Drive"
+		
+	turret "Laser Turret"
+	turret "Laser Turret"
 	turret "Heavy Anti-Missile Turret"
 	turret "Heavy Laser Turret"
-	turret "Quad Blaster Turret"
+	turret "Heavy Laser Turret"
 
 
 
-ship "Scout" "Scout (Speedy)"
+ship "Carrier" "Carrier (Jump)"
 	outfits
-		"Meteor Missile Launcher"
-		"Meteor Missile" 35
-		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 50
-		"Anti-Missile Turret"
-		"NT-200 Nucleovoltaic"
-		"Supercapacitor"
-		"D23-QP Shield Generator"
-		"Cooling Ducts"
-		"Mass Expansion"
-		"A370 Atomic Thruster"
-		"A255 Atomic Steering"
+		"Particle Cannon" 4
+		"Sidewinder Missile Launcher" 4
+		"Sidewinder Missile" 200
+		"Electron Turret" 3
+		"Heavy Anti-Missile Turret"
+		
+		"Armageddon Core"
+		"Dwarf Core"
+		"LP072a Battery Pack"
+		"D94-YV Shield Generator"
+		"Liquid Helium Cooler"
+		"Water Coolant System"
+		"Fuel Pod"
+		"Mass Expansion" 4
+		
+		"A860 Atomic Thruster"
+		"A525 Atomic Steering"
+		"Jump Drive"
+		
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	turret "Electron Turret"
+	turret "Electron Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Electron Turret"
+
+ship "Carrier" "Carrier (Mark II)"
+	outfits
+		"Particle Cannon" 4
+		"Sidewinder Missile Launcher" 4
+		"Sidewinder Missile" 200
+		"Electron Turret" 3
+		"Heavy Anti-Missile Turret"
+		
+		"Armageddon Core"
+		"Dwarf Core"
+		"LP072a Battery Pack"
+		"D94-YV Shield Generator"
+		"Liquid Helium Cooler"
+		"Mass Expansion" 3
+		
+		"A860 Atomic Thruster"
+		"A525 Atomic Steering"
 		"Hyperdrive"
+		
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	turret "Electron Turret"
+	turret "Electron Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Electron Turret"
 
 
 
@@ -149,260 +309,40 @@ ship "Clipper" "Clipper (Heavy)"
 		"Heavy Rocket" 40
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 70
+		
 		"RT-I Radiothermal"
 		"Supercapacitor"
 		"D67-TM Shield Generator"
+		
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Scram Drive"
 
-
+ship "Clipper" "Clipper (Nuclear)"
+	outfits
+		"Nuclear Missile" 4
+		
+		"S3 Thermionic"
+		"Supercapacitor"
+		"D67-TM Shield Generator"
+		"Catalytic Ramscoop"
+		
+		"A250 Atomic Thruster"
+		"A255 Atomic Steering"
+		"Hyperdrive"
+		"Afterburner"
 
 ship "Clipper" "Clipper (Speedy)"
 	outfits
 		"Heavy Laser" 4
+		
 		"Fission Reactor"
 		"Supercapacitor"
 		"D41-HY Shield Generator"
 		"Cooling Ducts"
+		
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
-		"Hyperdrive"
-
-
-
-ship "Freighter" "Freighter (Fancy)"
-	outfits
-		"Laser Turret" 2
-		"Heavy Anti-Missile Turret"
-		"NT-200 Nucleovoltaic"
-		"Supercapacitor"
-		"D14-RN Shield Generator"
-		"Ramscoop"
-		"Mass Expansion"
-		"Greyhound Plasma Thruster"
-		"X3200 Ion Steering"
-		"Scram Drive"
-	turret "Laser Turret"
-	turret "Laser Turret"
-	turret "Heavy Anti-Missile Turret"
-
-
-
-ship "Argosy" "Argosy (Laser)"
-	outfits
-		"Beam Laser" 2
-		"Heavy Laser" 2
-		"Laser Turret" 2
-		"NT-200 Nucleovoltaic"
-		"Supercapacitor"
-		"D67-TM Shield Generator"
-		"Mass Expansion" 2
-		"Greyhound Plasma Thruster"
-		"Impala Plasma Steering"
-		"Hyperdrive"
-
-
-
-ship "Argosy" "Argosy (Missile)"
-	outfits
-		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
-		"Anti-Missile Turret"
-		"Heavy Anti-Missile Turret"
-		"Fission Reactor"
-		"Supercapacitor"
-		"D41-HY Shield Generator"
-		"Mass Expansion"
-		"A370 Atomic Thruster"
-		"A255 Atomic Steering"
-		"Hyperdrive"
-	turret "Anti-Missile Turret"
-	turret "Heavy Anti-Missile Turret"
-
-
-
-ship "Argosy" "Argosy (Turret)"
-	outfits
-		"Heavy Laser Turret" 2
-		"S3 Thermionic"
-		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
-		"Small Radar Jammer"
-		"Mass Expansion"
-		"X3700 Ion Thruster"
-		"Greyhound Plasma Steering"
-		"Hyperdrive"
-
-
-
-ship "Argosy" "Argosy (Blaster)"
-	outfits
-		"Energy Blaster" 4
-		"Quad Blaster Turret" 2
-		"Fission Reactor"
-		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
-		"Mass Expansion"
-		"Greyhound Plasma Thruster"
-		"Impala Plasma Steering"
-		"Hyperdrive"
-
-
-
-ship "Behemoth" "Behemoth (Speedy)"
-	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
-		"Heavy Laser Turret" 6
-		"Breeder Reactor"
-		"LP144a Battery Pack"
-		"D94-YV Shield Generator"
-		"Large Radar Jammer"
-		"Liquid Nitrogen Cooler"
-		"Mass Expansion" 6
-		"A250 Atomic Thruster"
-		"A125 Atomic Steering"
-		"A375 Atomic Steering"
-		"Scram Drive"
-
-
-
-ship "Bulk Freighter" "Bulk Freighter (Heavy)"
-	outfits
-		"Laser Turret" 2
-		"Heavy Laser Turret" 2
-		"Heavy Anti-Missile Turret"
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
-		"Fission Reactor"
-		"LP072a Battery Pack"
-		"D94-YV Shield Generator"
-		"Mass Expansion"
-		"A250 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Scram Drive"
-	turret "Laser Turret"
-	turret "Laser Turret"
-	turret "Heavy Anti-Missile Turret"
-	turret "Heavy Laser Turret"
-	turret "Heavy Laser Turret"
-
-
-
-ship "Bulk Freighter" "Bulk Freighter (Blaster)"
-	outfits
-		"Quad Blaster Turret" 5
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
-		"Fusion Reactor"
-		"LP072a Battery Pack"
-		"D94-YV Shield Generator"
-		"Water Coolant System"
-		"Mass Expansion" 2
-		"A250 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Scram Drive"
-
-
-
-ship "Fury" "Fury (Missile)"
-	outfits
-		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
-		"nGVF-BB Fuel Cell"
-		"Supercapacitor" 3
-		"D14-RN Shield Generator"
-		"Greyhound Plasma Thruster"
-		"Chipmunk Plasma Steering"
-		"Hyperdrive"
-
-
-
-ship "Fury" "Fury (Laser)"
-	outfits
-		"Heavy Laser" 2
-		"RT-I Radiothermal"
-		"Supercapacitor"
-		"D23-QP Shield Generator"
-		"Cooling Ducts"
-		"Chipmunk Plasma Thruster"
-		"A125 Atomic Steering"
-		"Hyperdrive"
-
-
-
-ship "Hawk" "Hawk (Speedy)"
-	outfits
-		"Heavy Laser" 2
-		"S3 Thermionic"
-		"Supercapacitor" 3
-		"D41-HY Shield Generator"
-		"A250 Atomic Thruster"
-		"A255 Atomic Steering"
-		"Hyperdrive"
-
-
-
-ship "Hawk" "Hawk (Rocket)"
-	outfits
-		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
-		"RT-I Radiothermal"
-		"Supercapacitor" 2
-		"D41-HY Shield Generator"
-		"Greyhound Plasma Thruster"
-		"Greyhound Plasma Steering"
-		"Hyperdrive"
-
-
-
-ship "Bastion" "Bastion (Heavy)"
-	outfits
-		"Plasma Cannon" 4
-		"Quad Blaster Turret" 3
-		"Fusion Reactor"
-		"LP072a Battery Pack"
-		"D67-TM Shield Generator"
-		"Liquid Nitrogen Cooler"
-		"Mass Expansion" 2
-		"X3700 Ion Thruster"
-		"Orca Plasma Steering"
-		"Hyperdrive"
-
-
-
-ship "Bastion" "Bastion (Laser)"
-	outfits
-		"Heavy Laser" 4
-		"Heavy Anti-Missile Turret"
-		"Heavy Laser Turret" 2
-		"Fusion Reactor"
-		"Supercapacitor" 4
-		"D94-YV Shield Generator"
-		"Small Radar Jammer"
-		"Water Coolant System"
-		"Mass Expansion"
-		"A370 Atomic Thruster"
-		"A525 Atomic Steering"
-		"Hyperdrive"
-	turret "Heavy Anti-Missile Turret"
-	turret "Heavy Laser Turret"
-	turret "Heavy Laser Turret"
-
-
-
-ship "Corvette" "Corvette (Speedy)"
-	outfits
-		"Particle Cannon" 4
-		"Heavy Anti-Missile Turret"
-		"Fusion Reactor"
-		"Supercapacitor"
-		"D41-HY Shield Generator"
-		"Liquid Nitrogen Cooler"
-		"Cooling Ducts"
-		"A370 Atomic Thruster"
-		"A375 Atomic Steering"
 		"Hyperdrive"
 
 
@@ -414,33 +354,207 @@ ship "Corvette" "Corvette (Missile)"
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 100
 		"Heavy Anti-Missile Turret" 2
+		
 		"Fission Reactor"
 		"LP036a Battery Pack"
 		"D94-YV Shield Generator"
 		"Cooling Ducts"
 		"Cargo Expansion"
+		
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
 
-
-
-ship "Firebird" "Firebird (Plasma)"
+ship "Corvette" "Corvette (Speedy)"
 	outfits
-		"Plasma Cannon" 4
-		"Quad Blaster Turret" 2
-		"Breeder Reactor"
-		"LP072a Battery Pack"
-		"LP036a Battery Pack"
+		"Particle Cannon" 4
+		"Heavy Anti-Missile Turret"
+		
+		"Fusion Reactor"
+		"Supercapacitor"
 		"D41-HY Shield Generator"
 		"Liquid Nitrogen Cooler"
-		"Mass Expansion"
-		"X3700 Ion Thruster"
+		"Cooling Ducts"
+		
+		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
+		"Hyperdrive"
+
+
+
+ship "Cruiser" "Cruiser (Heavy)"
+	outfits
+		"Heavy Rocket Launcher" 2
+		"Heavy Rocket" 50
+		"Heavy Rocket Rack"
+		"Particle Cannon" 4
+		"Heavy Laser Turret" 2
+		"Heavy Anti-Missile Turret"
+		"Quad Blaster Turret"
+		
+		"Laser Rifle" 20
+		"Fragmentation Grenades" 20
+		"Armageddon Core"
+		"Dwarf Core"
+		"Supercapacitor"
+		"D94-YV Shield Generator"
+		"Liquid Helium Cooler"
+		"Ramscoop"
+		"Mass Expansion"
+		
+		"A520 Atomic Thruster"
+		"A525 Atomic Steering"
+		"X2200 Ion Steering"
+		"Scram Drive"
+		
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Heavy Rocket Launcher"
+	gun "Heavy Rocket Launcher"
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	turret "Heavy Laser Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Heavy Laser Turret"
+	turret "Quad Blaster Turret"
+
+ship "Cruiser" "Cruiser (Jump)"
+	outfits
+		"Typhoon Launcher" 2
+		"Typhoon Torpedo" 60
+		"Sidewinder Missile Launcher" 4
+		"Sidewinder Missile" 200
+		"Electron Turret" 3
+		"Heavy Anti-Missile Turret"
+		
+		"Armageddon Core"
+		"LP144a Battery Pack"
+		"LP036a Battery Pack"
+		"D94-YV Shield Generator"
+		"Liquid Helium Cooler"
+		"Fuel Pod" 2
+		"Ramscoop"
+		"Mass Expansion" 2
+		
+		"A520 Atomic Thruster"
+		"A525 Atomic Steering"
+		"Jump Drive"
+		
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Typhoon Launcher"
+	gun "Typhoon Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	turret "Electron Turret"
+	turret "Electron Turret"
+	turret "Electron Turret"
+	turret "Heavy Anti-Missile Turret"
+
+ship "Cruiser" "Cruiser (Mark II)"
+	outfits
+		"Typhoon Launcher" 2
+		"Typhoon Torpedo" 90
+		"Typhoon Storage Tube" 2
+		"Sidewinder Missile Launcher" 4
+		"Sidewinder Missile" 200
+		"Electron Turret" 3
+		"Heavy Anti-Missile Turret"
+		
+		"Armageddon Core"
+		"LP144a Battery Pack"
+		"D94-YV Shield Generator"
+		"Liquid Helium Cooler"
+		"Mass Expansion"
+		
+		"A520 Atomic Thruster"
+		"A525 Atomic Steering"
+		"Hyperdrive"
+		
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Typhoon Launcher"
+	gun "Typhoon Launcher"
+	turret "Electron Turret"
+	turret "Electron Turret"
+	turret "Electron Turret"
+	turret "Heavy Anti-Missile Turret"
+
+
+
+ship "Dreadnought" "Dreadnought (Jump)"
+	outfits
+		"Meteor Missile Launcher" 4
+		"Meteor Missile" 140
+		"Plasma Turret" 5
+		
+		"Stack Core"
+		"LP144a Battery Pack"
+		"D41-HY Shield Generator"
+		"Small Radar Jammer"
+		"Liquid Helium Cooler"
+		
+		"Orca Plasma Thruster"
+		"Orca Plasma Steering"
+		"Jump Drive"
+
+
+
+ship "Falcon" "Falcon (Heavy)"
+	outfits
+		"Torpedo Launcher" 2
+		"Torpedo" 60
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 88
+		"Meteor Missile Box"
+		"Heavy Laser Turret" 4
+		
+		"Fusion Reactor"
+		"D67-TM Shield Generator"
+		"Small Radar Jammer"
+		
+		"Orca Plasma Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"
+		
+	gun "Torpedo Launcher"
+	gun "Torpedo Launcher"
+	gun "Meteor Missile Launcher"
+	gun "Meteor Missile Launcher"
+
+ship "Falcon" "Falcon (Laser)"
+	outfits
+		"Heavy Laser" 4
+		"Heavy Laser Turret" 4
+		
+		"Breeder Reactor"
+		"LP072a Battery Pack"
+		"D94-YV Shield Generator"
+		"Small Radar Jammer"
+		
+		"Impala Plasma Thruster"
+		"Orca Plasma Steering"
+		"Hyperdrive"
+
+ship "Falcon" "Falcon (Plasma)"
+	outfits
+		"Plasma Turret" 4
+		
+		"Breeder Reactor"
+		"LP144a Battery Pack"
+		"D41-HY Shield Generator"
+		"Small Radar Jammer"
+		"Liquid Nitrogen Cooler"
+		
+		"Impala Plasma Thruster"
+		"Impala Plasma Steering"
 		"Hyperdrive"
 
 
@@ -452,235 +566,35 @@ ship "Firebird" "Firebird (Missile)"
 		"Torpedo Launcher" 2
 		Torpedo 60
 		"Heavy Laser Turret" 2
+		
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
 		"Mass Expansion"
+		
 		"Impala Plasma Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
 
-
-
-ship "Mule" "Mule (Heavy)"
+ship "Firebird" "Firebird (Plasma)"
 	outfits
-		"Heavy Laser Turret" 4
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
-		"Fission Reactor"
+		"Plasma Cannon" 4
+		"Quad Blaster Turret" 2
+		
+		"Breeder Reactor"
 		"LP072a Battery Pack"
-		"Supercapacitor" 4
-		"D67-TM Shield Generator"
-		"Water Coolant System"
-		"Mass Expansion"
-		"Ramscoop"
-		"A370 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-
-
-
-ship "Osprey" "Osprey (Laser)"
-	outfits
-		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
-		"Breeder Reactor"
 		"LP036a Battery Pack"
-		"Supercapacitor" 4
-		"D94-YV Shield Generator"
-		"Water Coolant System"
-		"Impala Plasma Thruster"
-		"X4200 Ion Steering"
-		"Hyperdrive"
-
-
-
-ship "Osprey" "Osprey (Missile)"
-	outfits
-		"Torpedo Launcher" 2
-		"Torpedo" 60
-		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
-		"Heavy Laser Turret" 2
-		"Breeder Reactor"
-		"LP036a Battery Pack"
-		"Supercapacitor" 3
 		"D41-HY Shield Generator"
-		"Water Coolant System"
-		"A520 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-	gun "Heavy Rocket Launcher"
-	gun "Heavy Rocket Launcher"
-	gun "Torpedo Launcher"
-	gun "Torpedo Launcher"
-
-
-
-ship "Raven" "Raven (Heavy)"
-	outfits
-		"Particle Cannon" 2
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
-		"Fission Reactor"
-		"Supercapacitor" 3
-		"D23-QP Shield Generator"
-		"Water Coolant System"
-		"Cooling Ducts"
-		"A250 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Meteor Missile Launcher"
-	gun "Meteor Missile Launcher"
-
-
-
-ship "Splinter" "Splinter (Laser)"
-	outfits
-		"Heavy Laser" 2
-		"Heavy Laser Turret" 2
-		"Heavy Anti-Missile Turret"
-		"Water Coolant System"
-		"Fission Reactor"
-		"LP036a Battery Pack"
-		"D94-YV Shield Generator"
-		"X3700 Ion Thruster"
-		"Impala Plasma Steering"
-		"Hyperdrive"
-	turret "Heavy Laser Turret"
-	turret "Heavy Laser Turret"
-	turret "Heavy Anti-Missile Turret"
-
-
-
-ship "Falcon" "Falcon (Laser)"
-	outfits
-		"Heavy Laser" 4
-		"Heavy Laser Turret" 4
-		"Breeder Reactor"
-		"LP072a Battery Pack"
-		"D94-YV Shield Generator"
-		"Small Radar Jammer"
-		"Impala Plasma Thruster"
-		"Orca Plasma Steering"
-		"Hyperdrive"
-
-
-
-ship "Falcon" "Falcon (Heavy)"
-	outfits
-		"Torpedo Launcher" 2
-		"Torpedo" 60
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
-		"Heavy Laser Turret" 4
-		"Fusion Reactor"
-		"D67-TM Shield Generator"
-		"Small Radar Jammer"
-		"Orca Plasma Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-	gun "Torpedo Launcher"
-	gun "Torpedo Launcher"
-	gun "Meteor Missile Launcher"
-	gun "Meteor Missile Launcher"
-
-
-
-ship "Leviathan" "Leviathan (Laser)"
-	outfits
-		"Heavy Laser" 4
-		"Heavy Laser Turret" 4
-		"Armageddon Core"
-		"LP036a Battery Pack"
-		"Supercapacitor"
-		"D94-YV Shield Generator"
-		"Liquid Helium Cooler"
-		"Ramscoop"
-		"A370 Atomic Thruster"
-		"A525 Atomic Steering"
-		"Hyperdrive"
-
-
-
-ship "Leviathan" "Leviathan (Heavy)"
-	outfits
-		"Torpedo Launcher" 2
-		"Torpedo" 60
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
-		"Heavy Laser Turret" 4
-		"Breeder Reactor"
-		"LP036a Battery Pack"
-		"D94-YV Shield Generator" 2
 		"Liquid Nitrogen Cooler"
-		"Impala Plasma Thruster"
-		"A375 Atomic Steering"
-		"Afterburner"
-		"Scram Drive"
-		"Ramscoop"
-	gun "Meteor Missile Launcher"
-	gun "Meteor Missile Launcher"
-	gun "Torpedo Launcher"
-	gun "Torpedo Launcher"
-
-
-
-ship "Protector" "Protector (Laser)"
-	outfits
-		"Laser Turret" 2
-		"Heavy Laser Turret" 4
-		"Fusion Reactor"
-		"LP036a Battery Pack"
-		"Supercapacitor" 3
-		"D94-YV Shield Generator" 2
-		"Water Coolant System"
-		"A370 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-	turret "Laser Turret"
-	turret "Laser Turret"
-	turret "Heavy Laser Turret"
-	turret "Heavy Laser Turret"
-	turret "Heavy Laser Turret"
-	turret "Heavy Laser Turret"
-
-
-
-ship "Vanguard" "Vanguard (Particle)"
-	outfits
-		"Particle Cannon" 7
-		"Fusion Reactor"
-		"LP072a Battery Pack"
-		"D67-TM Shield Generator"
-		"Liquid Nitrogen Cooler"
+		"Mass Expansion"
+		
 		"X3700 Ion Thruster"
-		"X4200 Ion Steering"
-		"Hyperdrive"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-
-
-
-ship "Heavy Shuttle" "Heavy Shuttle (Armed)"
-	outfits
-		"Energy Blaster" 2
-		"nGVF-BB Fuel Cell"
-		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
-		"Chipmunk Plasma Thruster"
-		"Chipmunk Plasma Steering"
+		"A375 Atomic Steering"
 		"Hyperdrive"
 
 
@@ -690,24 +604,152 @@ ship "Flivver" "Flivver (Racing)"
 		"RT-I Radiothermal"
 		"D14-RN Shield Generator"
 		"Water Coolant System"
+		
 		"A120 Atomic Thruster"
 		"A125 Atomic Steering"
 		"Hyperdrive"
 
 
 
-ship "Berserker" "Berserker (Afterburner)"
+ship "Freighter" "Freighter (Fancy)"
 	outfits
-		"Energy Blaster" 2
-		"Javelin Pod" 2
-		"Javelin" 400
-		"nGVF-CC Fuel Cell"
-		"LP036a Battery Pack"
-		"D23-QP Shield Generator"
+		"Laser Turret" 2
+		"Heavy Anti-Missile Turret"
+		
+		"NT-200 Nucleovoltaic"
+		"Supercapacitor"
+		"D14-RN Shield Generator"
 		"Ramscoop"
+		"Mass Expansion"
+		
+		"Greyhound Plasma Thruster"
+		"X3200 Ion Steering"
+		"Scram Drive"
+		
+	turret "Laser Turret"
+	turret "Laser Turret"
+	turret "Heavy Anti-Missile Turret"
+
+
+
+ship "Frigate" "Frigate (Mark II)"
+	outfits
+		"Particle Cannon" 4
+		"Anti-Missile Turret"
+		"Blaster Turret" 2
+		
+		"NT-200 Nucleovoltaic"
+		"Dwarf Core"
+		"LP036a Battery Pack"
+		"D41-HY Shield Generator"
+		"Water Coolant System"
+		"Mass Expansion"
+		
+		"X3700 Ion Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"
+		
+	turret "Anti-Missile Turret"
+	turret "Blaster Turret"
+	turret "Blaster Turret"
+
+
+
+ship "Fury" "Fury (Flamethrower)"
+	outfits
+		"Flamethrower" 4
+		
+		"nGVF-BB Fuel Cell"
+		"Supercapacitor"
+		"D14-RN Shield Generator"
+		"Ramscoop"
+		
+		"X2700 Ion Thruster"
+		"X2200 Ion Steering"
+		"Hyperdrive"
+
+ship "Fury" "Fury (Gatling)"
+	outfits
+		"Gatling Gun" 4
+		"Gatling Gun Ammo" 9000
+		
+		"nGVF-CC Fuel Cell"
+		"Supercapacitor"
+		"D23-QP Shield Generator"
+		
+		"X2700 Ion Thruster"
+		"A125 Atomic Steering"
+		"Hyperdrive"
+
+
+ship "Fury" "Fury (Laser)"
+	outfits
+		"Heavy Laser" 2
+		
+		"RT-I Radiothermal"
+		"Supercapacitor"
+		"D23-QP Shield Generator"
+		"Cooling Ducts"
+		
 		"Chipmunk Plasma Thruster"
+		"A125 Atomic Steering"
+		"Hyperdrive"
+
+ship "Fury" "Fury (Missile)"
+	outfits
+		"Meteor Missile Launcher" 4
+		"Meteor Missile" 140
+		
+		"nGVF-BB Fuel Cell"
+		"Supercapacitor" 3
+		"D14-RN Shield Generator"
+		
+		"Greyhound Plasma Thruster"
+		"Chipmunk Plasma Steering"
+		"Hyperdrive"
+
+
+
+ship "Gunboat" "Gunboat (Mark II)"
+	outfits
+		"Electron Beam" 2
+		"Electron Turret"
+		
+		"Fission Reactor"
+		"LP072a Battery Pack"
+		"D41-HY Shield Generator"
+		"Water Coolant System"
+		"Mass Expansion" 2
+		
+		"A250 Atomic Thruster"
+		"A255 Atomic Steering"
+		"Hyperdrive"
+
+
+
+ship "Hawk" "Hawk (Rocket)"
+	outfits
+		"Heavy Rocket Launcher" 2
+		"Heavy Rocket" 40
+		
+		"RT-I Radiothermal"
+		"Supercapacitor" 2
+		"D41-HY Shield Generator"
+		
+		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
-		"Afterburner"
+		"Hyperdrive"
+
+ship "Hawk" "Hawk (Speedy)"
+	outfits
+		"Heavy Laser" 2
+		
+		"S3 Thermionic"
+		"Supercapacitor" 3
+		"D41-HY Shield Generator"
+		
+		"A250 Atomic Thruster"
+		"A255 Atomic Steering"
 		"Hyperdrive"
 
 
@@ -715,26 +757,154 @@ ship "Berserker" "Berserker (Afterburner)"
 ship "Headhunter" "Headhunter (Particle)"
 	outfits
 		"Particle Cannon" 2
+		
 		"NT-200 Nucleovoltaic"
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
+		
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 
 
 
-ship "Modified Argosy" "Modified Argosy (Heavy)"
+ship "Heavy Shuttle" "Heavy Shuttle (Armed)"
+	outfits
+		"Energy Blaster" 2
+		
+		"nGVF-BB Fuel Cell"
+		"LP036a Battery Pack"
+		"D14-RN Shield Generator"
+		
+		"Chipmunk Plasma Thruster"
+		"Chipmunk Plasma Steering"
+		"Hyperdrive"
+
+
+
+ship "Lance" "Lance (Gatling)"
+	outfits
+		"Gatling Gun" 2
+		"Gatling Gun Ammo" 6000
+		
+		Supercapacitor
+		"nGVF-BB Fuel Cell"
+		"D14-RN Shield Generator"
+		
+		"X1700 Ion Thruster"
+		"X1200 Ion Steering"
+
+
+
+ship "Leviathan" "Leviathan (Heavy)"
+	outfits
+		"Torpedo Launcher" 2
+		"Torpedo" 60
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 88
+		"Meteor Missile Box"
+		"Heavy Laser Turret" 4
+		
+		"Breeder Reactor"
+		"LP036a Battery Pack"
+		"D94-YV Shield Generator" 2
+		"Liquid Nitrogen Cooler"
+		"Ramscoop"
+		
+		"Impala Plasma Thruster"
+		"A375 Atomic Steering"
+		"Afterburner"
+		"Scram Drive"
+		
+	gun "Torpedo Launcher"
+	gun "Torpedo Launcher"
+	gun "Meteor Missile Launcher"
+	gun "Meteor Missile Launcher"
+
+ship "Leviathan" "Leviathan (Laser)"
 	outfits
 		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
-		"Fission Reactor"
+		"Heavy Laser Turret" 4
+		
+		"Armageddon Core"
 		"LP036a Battery Pack"
-		"D23-QP Shield Generator"
+		"Supercapacitor"
+		"D94-YV Shield Generator"
+		"Liquid Helium Cooler"
+		"Ramscoop"
+		
+		"A370 Atomic Thruster"
+		"A525 Atomic Steering"
+		"Hyperdrive"
+
+
+
+ship "Manta" "Manta (Mark II)"
+	outfits
+		"Particle Cannon" 4
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		
+		"Fission Reactor"
+		"LP072a Battery Pack"
+		"S-270 Regenerator"
 		"Water Coolant System"
+		"Mass Expansion"
+		
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Ionic Afterburner"
+		
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Meteor Missile Launcher"
+	gun "Meteor Missile Launcher"
+
+ship "Manta" "Manta (Nuclear)"
+	outfits
+		"Particle Cannon" 4
+		"Nuclear Missile" 2
+		
+		"Fission Reactor"
+		"LP072a Battery Pack"
+		"S-270 Regenerator"
+		"Water Coolant System"
+		"Mass Expansion"
+		
+		"A250 Atomic Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"
+		
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Nuclear Missile"
+	gun "Nuclear Missile"
+
+ship "Manta" "Manta (Proton)"
+	outfits
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		"Proton Gun" 4
+		
+		"RT-I Radiothermal"
+		"LP144a Battery Pack"
+		"D14-RN Shield Generator"
+		
+		"X3700 Ion Thruster"
+		"X3200 Ion Steering"
+		"Hyperdrive"
+		
+	gun "Meteor Missile Launcher"
+	gun "Meteor Missile Launcher"
+	gun "Proton Gun"
+	gun "Proton Gun"
+	gun "Proton Gun"
+	gun "Proton Gun"
 
 
 
@@ -742,16 +912,30 @@ ship "Modified Argosy" "Modified Argosy (Blaster)"
 	outfits
 		"Modified Blaster" 4
 		"Quad Blaster Turret" 2
+		
 		"Fission Reactor"
 		"LP144a Battery Pack"
 		"D67-TM Shield Generator"
 		"Small Radar Jammer"
 		"Liquid Nitrogen Cooler"
+		
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
 
-
+ship "Modified Argosy" "Modified Argosy (Heavy)"
+	outfits
+		"Heavy Laser" 4
+		"Heavy Laser Turret" 2
+		
+		"Fission Reactor"
+		"LP036a Battery Pack"
+		"D23-QP Shield Generator"
+		"Water Coolant System"
+		
+		"A250 Atomic Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"
 
 ship "Modified Argosy" "Modified Argosy (Missile)"
 	outfits
@@ -761,364 +945,34 @@ ship "Modified Argosy" "Modified Argosy (Missile)"
 		"Torpedo" 60
 		"Heavy Laser Turret"
 		"Heavy Anti-Missile Turret"
+		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
 		"D41-HY Shield Generator"
+		
 		"X3700 Ion Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
 
 
 
-ship "Falcon" "Falcon (Plasma)"
+ship "Mule" "Mule (Heavy)"
 	outfits
-		"Plasma Turret" 4
-		"Breeder Reactor"
-		"LP144a Battery Pack"
-		"D41-HY Shield Generator"
-		"Small Radar Jammer"
-		"Liquid Nitrogen Cooler"
-		"Impala Plasma Thruster"
-		"Impala Plasma Steering"
-		"Hyperdrive"
-
-
-
-ship "Fury" "Fury (Flamethrower)"
-	outfits
-		"Flamethrower" 4
-		"nGVF-BB Fuel Cell"
-		"Supercapacitor"
-		"D14-RN Shield Generator"
-		"Ramscoop"
-		"X2700 Ion Thruster"
-		"X2200 Ion Steering"
-		"Hyperdrive"
-
-
-
-ship "Rainmaker" "Rainmaker (Mark II)"
-	outfits
-		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 200
-		"nGVF-CC Fuel Cell"
-		"LP036a Battery Pack"
+		"Heavy Laser Turret" 4
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 100
+		
+		"Fission Reactor"
+		"LP072a Battery Pack"
+		"Supercapacitor" 4
 		"D67-TM Shield Generator"
-		"Fuel Pod"
-		"A120 Atomic Thruster"
-		"A125 Atomic Steering"
-		"Scram Drive"
-	gun
-	gun
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-
-
-
-ship "Gunboat" "Gunboat (Mark II)"
-	outfits
-		"Electron Beam" 2
-		"Electron Turret"
-		"Fission Reactor"
-		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
 		"Water Coolant System"
-		"Mass Expansion" 2
-		"A250 Atomic Thruster"
-		"A255 Atomic Steering"
-		"Hyperdrive"
-
-
-
-ship "Frigate" "Frigate (Mark II)"
-	outfits
-		"Particle Cannon" 4
-		"Anti-Missile Turret"
-		"Blaster Turret" 2
-		"NT-200 Nucleovoltaic"
-		"Dwarf Core"
-		"LP036a Battery Pack"
-		"D41-HY Shield Generator"
-		"Water Coolant System"
-		"Mass Expansion"
-		"X3700 Ion Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-	turret "Anti-Missile Turret"
-	turret "Blaster Turret"
-	turret "Blaster Turret"
-
-
-
-ship "Cruiser" "Cruiser (Mark II)"
-	outfits
-		"Typhoon Launcher" 2
-		"Typhoon Torpedo" 60
-		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 200
-		"Electron Turret" 3
-		"Heavy Anti-Missile Turret"
-		"Armageddon Core"
-		"LP144a Battery Pack"
-		"D94-YV Shield Generator"
-		"Liquid Helium Cooler"
-		"A520 Atomic Thruster"
-		"A525 Atomic Steering"
-		"Hyperdrive"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Typhoon Launcher"
-	gun "Typhoon Launcher"
-	turret "Electron Turret"
-	turret "Electron Turret"
-	turret "Electron Turret"
-	turret "Heavy Anti-Missile Turret"
-
-
-
-ship "Carrier" "Carrier (Mark II)"
-	outfits
-		"Particle Cannon" 4
-		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 200
-		"Electron Turret" 3
-		"Heavy Anti-Missile Turret"
-		"Armageddon Core"
-		"Dwarf Core"
-		"LP072a Battery Pack"
-		"D94-YV Shield Generator"
-		"Liquid Helium Cooler"
-		"Mass Expansion" 3
-		"A860 Atomic Thruster"
-		"A525 Atomic Steering"
-		"Hyperdrive"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	turret "Electron Turret"
-	turret "Electron Turret"
-	turret "Heavy Anti-Missile Turret"
-	turret "Electron Turret"
-
-
-
-ship "Behemoth" "Behemoth (Heavy)"
-	outfits
-		"Torpedo Launcher" 2
-		Torpedo 60
-		"Quad Blaster Turret" 2
-		"Plasma Turret" 2
-		"Heavy Anti-Missile Turret" 2
-		"Laser Rifle" 16
-		"Breeder Reactor"
-		"Fission Reactor"
-		"Supercapacitor"
-		"D94-YV Shield Generator"
-		"Mass Expansion" 9
-		"Liquid Helium Cooler"
-		"Liquid Nitrogen Cooler"
-		"Greyhound Plasma Thruster"
-		"Impala Plasma Steering"
-		"Hyperdrive"
-	turret "Quad Blaster Turret"
-	turret "Quad Blaster Turret"
-	turret "Plasma Turret"
-	turret "Plasma Turret"
-	turret "Heavy Anti-Missile Turret"
-	turret "Heavy Anti-Missile Turret"
-
-
-
-ship "Splinter" "Splinter (Mark II)"
-	outfits
-		"Particle Cannon" 2
-		"Quad Blaster Turret" 3
-		"Fusion Reactor"
-		"Supercapacitor"
-		"S-970 Regenerator"
-		"Water Coolant System" 4
-		"Mass Expansion" 2
-		"A250 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-		"Ionic Afterburner"
-
-
-
-ship "Manta" "Manta (Mark II)"
-	outfits
-		"Particle Cannon" 4
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
-		"Fission Reactor"
-		"LP072a Battery Pack"
-		"S-270 Regenerator"
-		"Water Coolant System"
-		"Mass Expansion"
-		"A250 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-		"Ionic Afterburner"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Meteor Missile Launcher"
-	gun "Meteor Missile Launcher"
-
-
-
-ship "Quicksilver" "Quicksilver (Mark II)"
-	outfits
-		"Particle Cannon" 2
-		"RT-I Radiothermal"
-		"LP036a Battery Pack"
-		"D23-QP Shield Generator"
-		"Cooling Ducts"
-		"Greyhound Plasma Thruster"
-		"Greyhound Plasma Steering"
-		"Hyperdrive"
-
-
-
-ship "Manta" "Manta (Nuclear)"
-	outfits
-		"Particle Cannon" 4
-		"Nuclear Missile" 2
-		"Fission Reactor"
-		"LP072a Battery Pack"
-		"S-270 Regenerator"
-		"Water Coolant System"
-		"Mass Expansion"
-		"A250 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Nuclear Missile"
-	gun "Nuclear Missile"
-
-
-
-ship "Cruiser" "Cruiser (Jump)"
-	outfits
-		"Typhoon Launcher" 2
-		"Typhoon Torpedo" 60
-		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 200
-		"Electron Turret" 3
-		"Heavy Anti-Missile Turret"
-		"Armageddon Core"
-		"LP144a Battery Pack"
-		"LP036a Battery Pack"
-		"D94-YV Shield Generator"
-		"Liquid Helium Cooler"
-		"Fuel Pod" 2
 		"Ramscoop"
-		"Mass Expansion" 2
-		"A520 Atomic Thruster"
-		"A525 Atomic Steering"
-		"Jump Drive"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Typhoon Launcher"
-	gun "Typhoon Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	turret "Electron Turret"
-	turret "Electron Turret"
-	turret "Electron Turret"
-	turret "Heavy Anti-Missile Turret"
-
-
-
-ship "Carrier" "Carrier (Jump)"
-	outfits
-		"Particle Cannon" 4
-		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 200
-		"Electron Turret" 3
-		"Heavy Anti-Missile Turret"
-		"Armageddon Core"
-		"Dwarf Core"
-		"LP072a Battery Pack"
-		"D94-YV Shield Generator"
-		"Liquid Helium Cooler"
-		"Water Coolant System"
-		"Fuel Pod"
-		"Mass Expansion" 4
-		"A860 Atomic Thruster"
-		"A525 Atomic Steering"
-		"Jump Drive"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Particle Cannon"
-	gun "Particle Cannon"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	turret "Electron Turret"
-	turret "Electron Turret"
-	turret "Heavy Anti-Missile Turret"
-	turret "Electron Turret"
-
-
-
-ship "Dreadnought" "Dreadnought (Jump)"
-	outfits
-		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
-		"Plasma Turret" 5
-		"Stack Core"
-		"LP144a Battery Pack"
-		"D41-HY Shield Generator"
-		"Small Radar Jammer"
-		"Liquid Helium Cooler"
-		"Orca Plasma Thruster"
-		"Orca Plasma Steering"
-		"Jump Drive"
-
-
-
-ship "Clipper" "Clipper (Nuclear)"
-	outfits
-		"Nuclear Missile" 4
-		"S3 Thermionic"
-		"Supercapacitor"
-		"D67-TM Shield Generator"
-		"Catalytic Ramscoop"
-		"A250 Atomic Thruster"
-		"A255 Atomic Steering"
+		"Mass Expansion"
+		
+		"A370 Atomic Thruster"
+		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Afterburner"
-
-
-
-ship "Osprey" "Osprey (Alien Weapons)"
-	outfits
-		"Ion Cannon" 2
-		"Pulse Cannon" 2
-		"Pulse Turret"
-		"Chameleon Anti-Missile"
-		"Boulder Reactor"
-		"Hai Fissure Batteries"
-		"Hai Corundum Regenerator"
-		"Liquid Nitrogen Cooler"
-		`"Bondir" Atomic Thruster`
-		`"Bondir" Atomic Steering`
-		Hyperdrive
 
 
 
@@ -1128,13 +982,165 @@ ship "Nest" "Nest (Sidewinder)"
 		"Sidewinder Missile" 100
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
+		
 		"S3 Thermionic"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
 		"Large Radar Jammer"
+		
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
+
+
+
+ship "Osprey" "Osprey (Laser)"
+	outfits
+		"Heavy Laser" 4
+		"Heavy Laser Turret" 2
+		
+		"Breeder Reactor"
+		"LP036a Battery Pack"
+		"Supercapacitor" 4
+		"D94-YV Shield Generator"
+		"Water Coolant System"
+		
+		"Impala Plasma Thruster"
+		"X4200 Ion Steering"
+		"Hyperdrive"
+
+ship "Osprey" "Osprey (Missile)"
+	outfits
+		"Torpedo Launcher" 2
+		"Torpedo" 60
+		"Heavy Rocket Launcher" 2
+		"Heavy Rocket" 40
+		"Heavy Laser Turret" 2
+		
+		"Breeder Reactor"
+		"LP036a Battery Pack"
+		"Supercapacitor" 3
+		"D41-HY Shield Generator"
+		"Water Coolant System"
+		
+		"A520 Atomic Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"
+		
+	gun "Heavy Rocket Launcher"
+	gun "Heavy Rocket Launcher"
+	gun "Torpedo Launcher"
+	gun "Torpedo Launcher"
+
+
+
+ship "Protector" "Protector (Laser)"
+	outfits
+		"Laser Turret" 2
+		"Heavy Laser Turret" 4
+		
+		"Fusion Reactor"
+		"LP036a Battery Pack"
+		"Supercapacitor" 3
+		"D94-YV Shield Generator" 2
+		"Water Coolant System"
+		
+		"A370 Atomic Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"
+		
+	turret "Laser Turret"
+	turret "Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+
+
+
+ship "Quicksilver" "Quicksilver (Mark II)"
+	outfits
+		"Particle Cannon" 2
+		
+		"RT-I Radiothermal"
+		"LP036a Battery Pack"
+		"D23-QP Shield Generator"
+		"Cooling Ducts"
+		
+		"Greyhound Plasma Thruster"
+		"Greyhound Plasma Steering"
+		"Hyperdrive"
+
+ship "Quicksilver" "Quicksilver (Proton)"
+	outfits
+		"Proton Gun" 2
+		
+		"RT-I Radiothermal"
+		"LP036a Battery Pack"
+		"D23-QP Shield Generator"
+		"Cooling Ducts"
+		
+		"Greyhound Plasma Thruster"
+		"Greyhound Plasma Steering"
+		"Hyperdrive"
+
+
+
+ship "Rainmaker" "Rainmaker (Mark II)"
+	outfits
+		"Sidewinder Missile Launcher" 4
+		"Sidewinder Missile" 200
+		
+		"nGVF-CC Fuel Cell"
+		"LP036a Battery Pack"
+		"D67-TM Shield Generator"
+		"Fuel Pod"
+		
+		"A120 Atomic Thruster"
+		"A125 Atomic Steering"
+		"Scram Drive"
+		
+	gun
+	gun
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+
+
+
+ship "Raven" "Raven (Afterburner)"
+	outfits
+		"Heavy Laser" 4
+		
+		"NT-200 Nucleovoltaic"
+		"D41-HY Shield Generator"
+		
+		"X3700 Ion Thruster"
+		"X3200 Ion Steering"
+		"Hyperdrive"
+		"Afterburner"
+
+ship "Raven" "Raven (Heavy)"
+	outfits
+		"Particle Cannon" 2
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		
+		"Fission Reactor"
+		"Supercapacitor" 3
+		"D23-QP Shield Generator"
+		"Water Coolant System"
+		"Cooling Ducts"
+		
+		"A250 Atomic Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"
+		
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Meteor Missile Launcher"
+	gun "Meteor Missile Launcher"
 
 
 
@@ -1144,13 +1150,35 @@ ship "Roost" "Roost (Sidewinder)"
 		"Sidewinder Missile" 100
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
+		
 		"LP144a Battery Pack"
 		"S3 Thermionic"
 		"D94-YV Shield Generator" 2
 		"Small Radar Jammer"
+		
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
+
+
+
+ship "Scout" "Scout (Speedy)"
+	outfits
+		"Meteor Missile Launcher"
+		"Meteor Missile" 35
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 50
+		"Anti-Missile Turret"
+		
+		"NT-200 Nucleovoltaic"
+		"Supercapacitor"
+		"D23-QP Shield Generator"
+		"Cooling Ducts"
+		"Mass Expansion"
+		
+		"A370 Atomic Thruster"
+		"A255 Atomic Steering"
+		"Hyperdrive"
 
 
 
@@ -1160,90 +1188,222 @@ ship "Skein" "Skein (Sidewinder)"
 		"Sidewinder Missile" 100
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
+		
 		"LP144a Battery Pack"
 		"Fission Reactor"
 		"D94-YV Shield Generator" 3
 		"Large Radar Jammer"
 		"Mass Expansion" 2
+	
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
 
 
 
-ship "Lance" "Lance (Gatling)"
-	outfits
-		"Gatling Gun" 2
-		"Gatling Gun Ammo" 6000
-		Supercapacitor
-		"nGVF-BB Fuel Cell"
-		"D14-RN Shield Generator"
-		"X1700 Ion Thruster"
-		"X1200 Ion Steering"
-
-
-
-ship "Barb" "Barb (Gatling)"
-	outfits
-		"Gatling Gun"
-		"Gatling Gun Ammo" 3000
-		"Anti-Missile Turret"
-		"nGVF-AA Fuel Cell"
-		Supercapacitor 3
-		"D14-RN Shield Generator"
-		"X1050 Ion Engines"
-
-
-
-ship "Fury" "Fury (Gatling)"
-	outfits
-		"Gatling Gun" 4
-		"Gatling Gun Ammo" 6000
-		"nGVF-CC Fuel Cell"
-		"Supercapacitor"
-		"D23-QP Shield Generator"
-		"X2700 Ion Thruster"
-		"A125 Atomic Steering"
-		"Hyperdrive"
-
-
-
 ship "Sparrow" "Sparrow (Gatling)"
 	outfits
 		"Gatling Gun" 2
-		"Gatling Gun Ammo" 6000
+		"Gatling Gun Ammo" 7500
+		"Bullet Boxes"
+		
 		"nGVF-AA Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		
+		"Chipmunk Plasma Thruster"
+		"Chipmunk Plasma Steering"
+		"Hyperdrive"
+
+ship "Sparrow" "Sparrow (Patrol)"
+	outfits
+		"Beam Laser" 2
+		
+		"nGVF-BB Fuel Cell"
+		"LP036a Battery Pack"
+		"D14-RN Shield Generator"
+		"Cargo Scanner"
+		"Outfit Scanner"
+		
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
 
 
 
-ship "Flivver" "Flivver (Hai)"
+ship "Splinter" "Splinter (Laser)"
 	outfits
-		"RT-I Radiothermal"
+		"Heavy Laser" 2
+		"Heavy Laser Turret" 2
+		"Heavy Anti-Missile Turret"
+		
+		"Water Coolant System"
+		"Fission Reactor"
+		"LP036a Battery Pack"
+		"D94-YV Shield Generator"
+		
+		"X3700 Ion Thruster"
+		"Impala Plasma Steering"
+		"Hyperdrive"
+		
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Anti-Missile Turret"
+
+ship "Splinter" "Splinter (Mark II)"
+	outfits
+		"Particle Cannon" 2
+		"Quad Blaster Turret" 3
+		
+		"Fusion Reactor"
+		"Supercapacitor"
+		"S-970 Regenerator"
+		"Water Coolant System" 4
+		"Mass Expansion" 2
+		
+		"A250 Atomic Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"
+		"Ionic Afterburner"
+
+
+
+ship "Star Barge" "Star Barge (Armed)"
+	outfits
+		"Blaster Turret"
+		
+		"nGVF-BB Fuel Cell"
+		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
-		"Hai Williwaw Cooling"
-		`"Basrem" Atomic Thruster`
-		`"Benga" Atomic Steering`
+		
+		"Chipmunk Plasma Thruster"
+		"Chipmunk Plasma Steering"
 		"Hyperdrive"
 
 
+
+ship "Vanguard" "Vanguard (Particle)"
+	outfits
+		"Particle Cannon" 7
+		
+		"Fusion Reactor"
+		"LP072a Battery Pack"
+		"D67-TM Shield Generator"
+		"Liquid Nitrogen Cooler"
+		
+		"X3700 Ion Thruster"
+		"X4200 Ion Steering"
+		"Hyperdrive"
+
+
+
+ship "Wasp" "Wasp (Proton)"
+	outfits
+		"Proton Gun"
+		
+		"nGVF-BB Fuel Cell"
+		"LP036a Battery Pack"
+		"D14-RN Shield Generator"
+		
+		"X2700 Ion Thruster"
+		"X2200 Ion Steering"
+		"Hyperdrive"
+
+
+
+# Alien variants.
 
 ship "Arrow" "Arrow (Hai)"
 	outfits
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 100
 		"Bullfrog Anti-Missile"
+		
 		"Pebble Core"
 		"Supercapacitor" 2
 		"D14-RN Shield Generator"
 		"Small Radar Jammer"
+		
 		`"Benga" Atomic Thruster`
 		`"Biroo" Atomic Steering`
 		"Hyperdrive"
+
+
+
+ship "Bactrian" "Bactrian (Hai Engines)"
+	outfits
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 100
+		"Torpedo Launcher" 2
+		"Torpedo" 60
+		
+		"Heavy Laser Turret" 4
+		"Heavy Anti-Missile Turret" 2
+		"Fusion Reactor"
+		"Geode Reactor"
+		"Hai Gorge Batteries"
+		"D67-TM Shield Generator"
+		"Hai Williwaw Cooling" 3
+		"Ramscoop"
+		"Mass Expansion"
+		
+		`"Bufaer" Atomic Thruster`
+		`"Bufaer" Atomic Steering`
+		"Hyperdrive"
+
+ship "Bactrian" "Bactrian (Hai Weapons)"
+	outfits
+		"Pulse Cannon" 2
+		"Hai Tracker Pod" 2
+		"Hai Tracker" 112
+		"Chameleon Anti-Missile" 2
+		"Pulse Turret" 2
+		"Heavy Laser Turret" 2
+		
+		"Fusion Reactor"
+		"Pebble Core"
+		"Hai Ravine Batteries"
+		"Hai Diamond Regenerator"
+		"Large Radar Jammer"
+		"Hai Williwaw Cooling" 2
+		"Ramscoop"
+		
+		"X4700 Ion Thruster"
+		"X5200 Ion Steering"
+		"Hyperdrive"
+		
+	gun "Pulse Cannon"
+	gun "Pulse Cannon"
+	gun "Hai Tracker Pod"
+	gun "Hai Tracker Pod"
+	turret "Chameleon Anti-Missile"
+	turret "Heavy Laser Turret"
+	turret "Pulse Turret"
+	turret "Pulse Turret"
+	turret "Chameleon Anti-Missile"
+	turret "Heavy Laser Turret"
+
+
+
+
+ship "Behemoth" "Behemoth (Hai)"
+	outfits
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 150
+		"Sidewinder Missile Rack" 2
+		"Pulse Turret" 6
+		
+		"Boulder Reactor"
+		"Hai Ravine Batteries"
+		"Hai Diamond Regenerator"
+		"Large Radar Jammer"
+		"Liquid Nitrogen Cooler"
+		"Mass Expansion" 6
+		
+		`"Benga" Atomic Thruster`
+		`"Biroo" Atomic Steering`
+		`"Benga" Atomic Steering`
+		"Scram Drive"
 
 
 
@@ -1251,128 +1411,15 @@ ship "Bounder" "Bounder (Hai)"
 	outfits
 		"Pulse Turret"
 		"Bullfrog Anti-Missile"
+		
 		"Pebble Core"
 		"Hai Fissure Batteries"
 		"D14-RN Shield Generator"
 		"Hai Williwaw Cooling"
+		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-
-
-
-ship "Star Queen" "Star Queen (Hai)"
-	outfits
-		"Hai Tracker Pod" 3
-		"Hai Tracker" 168
-		"Chameleon Anti-Missile" 2
-		"NT-200 Nucleovoltaic"
-		"Hai Fissure Batteries"
-		"D94-YV Shield Generator"
-		"Small Radar Jammer"
-		"X3700 Ion Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-
-
-
-ship "Freighter" "Freighter (Hai)"
-	outfits
-		"Pulse Turret"
-		"Laser Turret"
-		"Bullfrog Anti-Missile"
-		"Geode Reactor"
-		"Hai Chasm Batteries"
-		"D14-RN Shield Generator"
-		"Ramscoop"
-		"Mass Expansion"
-		"Greyhound Plasma Thruster"
-		"X3200 Ion Steering"
-		"Scram Drive"
-	turret "Pulse Turret"
-	turret "Laser Turret"
-	turret "Bullfrog Anti-Missile"
-
-
-
-ship "Hauler" "Hauler (Hai)"
-	outfits
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
-		"Quad Blaster Turret" 2
-		"Chameleon Anti-Missile" 2
-		"Geode Reactor"
-		"Hai Gorge Batteries"
-		"Hai Corundum Regenerator"
-		"Hai Williwaw Cooling"
-		"Small Radar Jammer"
-		"Greyhound Plasma Thruster"
-		"Impala Plasma Steering"
-		"Hyperdrive"
-	turret "Quad Blaster Turret"
-	turret "Chameleon Anti-Missile"
-	turret "Chameleon Anti-Missile"
-	turret "Quad Blaster Turret"
-
-
-
-ship "Hauler II" "Hauler II (Hai)"
-	outfits
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
-		"Quad Blaster Turret" 2
-		"Chameleon Anti-Missile" 2
-		"Geode Reactor"
-		"Hai Gorge Batteries"
-		"Hai Corundum Regenerator"
-		"Hai Williwaw Cooling"
-		"Small Radar Jammer"
-		"Greyhound Plasma Thruster"
-		"Impala Plasma Steering"
-		"Hyperdrive"
-	turret "Quad Blaster Turret"
-	turret "Chameleon Anti-Missile"
-	turret "Chameleon Anti-Missile"
-	turret "Quad Blaster Turret"
-
-
-
-ship "Hauler III" "Hauler III (Hai)"
-	outfits
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
-		"Quad Blaster Turret" 2
-		"Chameleon Anti-Missile" 2
-		"Geode Reactor"
-		"Hai Gorge Batteries"
-		"Hai Corundum Regenerator"
-		"Hai Williwaw Cooling"
-		"Small Radar Jammer"
-		"Greyhound Plasma Thruster"
-		"Impala Plasma Steering"
-		"Hyperdrive"
-	turret "Quad Blaster Turret"
-	turret "Chameleon Anti-Missile"
-	turret "Chameleon Anti-Missile"
-	turret "Quad Blaster Turret"
-
-
-
-ship "Behemoth" "Behemoth (Hai)"
-	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
-		"Pulse Turret" 6
-		"Boulder Reactor"
-		"Hai Ravine Batteries"
-		"Hai Diamond Regenerator"
-		"Large Radar Jammer"
-		"Liquid Nitrogen Cooler"
-		"Mass Expansion" 6
-		`"Benga" Atomic Thruster`
-		`"Biroo" Atomic Steering`
-		`"Benga" Atomic Steering`
-		"Scram Drive"
 
 
 
@@ -1397,19 +1444,6 @@ ship "Bulk Freighter" "Bulk Freighter (Hai)"
 
 
 
-ship "Headhunter" "Headhunter (Hai)"
-	outfits
-		"Particle Cannon" 2
-		"Geode Reactor"
-		"Hai Chasm Batteries"
-		"Hai Corundum Regenerator"
-		"Hai Williwaw Cooling"
-		"A250 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-
-
-
 ship "Corvette" "Corvette (Hai)"
 	outfits
 		"Hai Tracker Pod" 4
@@ -1426,26 +1460,11 @@ ship "Corvette" "Corvette (Hai)"
 
 
 
-ship "Firebird" "Firebird (Hai Weapons)"
-	outfits
-		"Ion Cannon" 2
-		"Pulse Cannon" 2
-		"Chameleon Anti-Missile"
-		"Bullfrog Anti-Missile"
-		"Geode Reactor"
-		"Hai Gorge Batteries"
-		"D41-HY Shield Generator"
-		"Hai Williwaw Cooling" 2
-		"X3700 Ion Thruster"
-		"X3200 Ion Steering"
-		"Hyperdrive"
-
-
-
 ship "Firebird" "Firebird (Hai Shields)"
 	outfits
 		"Plasma Cannon" 4
 		"Bullfrog Anti-Missile" 2
+		
 		"Breeder Reactor"
 		"Hai Fissure Batteries"
 		"Hai Diamond Regenerator"
@@ -1453,45 +1472,147 @@ ship "Firebird" "Firebird (Hai Shields)"
 		"Liquid Nitrogen Cooler"
 		"Hai Williwaw Cooling"
 		"Mass Expansion" 2
+		
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 
-
-
-ship "Mule" "Mule (Hai Engines)"
+ship "Firebird" "Firebird (Hai Weapons)"
 	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
-		"Heavy Laser Turret" 3
+		"Ion Cannon" 2
+		"Pulse Cannon" 2
 		"Chameleon Anti-Missile"
-		"Boulder Reactor"
-		"Hai Fissure Batteries"
+		"Bullfrog Anti-Missile"
+		
+		"Geode Reactor"
+		"Hai Gorge Batteries"
 		"D41-HY Shield Generator"
-		"Small Radar Jammer" 2
-		"Water Coolant System"
-		"Cooling Ducts"
-		"Mass Expansion"
-		"Ramscoop"
-		`"Bondir" Atomic Thruster`
-		`"Biroo" Atomic Steering`
-		`"Basrem" Atomic Steering`
+		"Hai Williwaw Cooling" 2
+		
+		"X3700 Ion Thruster"
+		"X3200 Ion Steering"
 		"Hyperdrive"
 
 
 
-ship "Mule" "Mule (Hai Weapons)"
+ship "Flivver" "Flivver (Hai)"
 	outfits
-		"Ion Cannon"
-		"Pulse Turret" 4
+		"RT-I Radiothermal"
+		"D14-RN Shield Generator"
+		"Hai Williwaw Cooling"
+		
+		`"Basrem" Atomic Thruster`
+		`"Benga" Atomic Steering`
+		"Hyperdrive"
+
+
+
+ship "Freighter" "Freighter (Hai)"
+	outfits
+		"Pulse Turret"
+		"Laser Turret"
+		"Bullfrog Anti-Missile"
+		
 		"Geode Reactor"
-		"Hai Ravine Batteries"
-		"Hai Fissure Batteries"
-		"D67-TM Shield Generator"
-		"Water Coolant System"
-		"Mass Expansion" 3
+		"Hai Chasm Batteries"
+		"D14-RN Shield Generator"
 		"Ramscoop"
-		"A370 Atomic Thruster"
+		"Mass Expansion"
+		
+		"Greyhound Plasma Thruster"
+		"X3200 Ion Steering"
+		"Scram Drive"
+		
+	turret "Pulse Turret"
+	turret "Laser Turret"
+	turret "Bullfrog Anti-Missile"
+
+
+
+ship "Hauler" "Hauler (Hai)"
+	outfits
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		"Quad Blaster Turret" 2
+		"Chameleon Anti-Missile" 2
+		
+		"Geode Reactor"
+		"Hai Gorge Batteries"
+		"Hai Corundum Regenerator"
+		"Hai Williwaw Cooling"
+		"Small Radar Jammer"
+		
+		"Greyhound Plasma Thruster"
+		"Impala Plasma Steering"
+		"Hyperdrive"
+		
+	turret "Quad Blaster Turret"
+	turret "Chameleon Anti-Missile"
+	turret "Chameleon Anti-Missile"
+	turret "Quad Blaster Turret"
+
+
+
+ship "Hauler II" "Hauler II (Hai)"
+	outfits
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 106
+		"Meteor Missile Box" 2
+		"Quad Blaster Turret" 2
+		"Chameleon Anti-Missile" 2
+		
+		"Geode Reactor"
+		"Hai Gorge Batteries"
+		"Hai Corundum Regenerator"
+		"Hai Williwaw Cooling"
+		"Small Radar Jammer"
+		
+		"Greyhound Plasma Thruster"
+		"Impala Plasma Steering"
+		"Hyperdrive"
+		
+	turret "Quad Blaster Turret"
+	turret "Chameleon Anti-Missile"
+	turret "Chameleon Anti-Missile"
+	turret "Quad Blaster Turret"
+
+
+
+ship "Hauler III" "Hauler III (Hai)"
+	outfits
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 142
+		"Meteor Missile Box" 4
+		"Quad Blaster Turret" 2
+		"Chameleon Anti-Missile" 2
+		
+		"Geode Reactor"
+		"Hai Gorge Batteries"
+		"Hai Corundum Regenerator"
+		"Hai Williwaw Cooling"
+		"Small Radar Jammer"
+		
+		"Greyhound Plasma Thruster"
+		"Impala Plasma Steering"
+		"Hyperdrive"
+		
+	turret "Quad Blaster Turret"
+	turret "Chameleon Anti-Missile"
+	turret "Chameleon Anti-Missile"
+	turret "Quad Blaster Turret"
+
+
+
+ship "Headhunter" "Headhunter (Hai)"
+	outfits
+		"Particle Cannon" 2
+		
+		"Geode Reactor"
+		"Hai Chasm Batteries"
+		"Hai Corundum Regenerator"
+		"Hai Williwaw Cooling"
+		
+		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 
@@ -1502,79 +1623,107 @@ ship "Leviathan" "Leviathan (Hai Engines)"
 		"Particle Cannon" 4
 		"Quad Blaster Turret" 2
 		"Chameleon Anti-Missile" 2
+		
 		"Boulder Reactor"
 		"Hai Ravine Batteries"
 		"D67-TM Shield Generator"
 		"Liquid Helium Cooler"
+		
 		`"Bondir" Atomic Thruster`
 		`"Bondir" Atomic Steering`
 		"Hyperdrive"
 
-
-
 ship "Leviathan" "Leviathan (Hai Weapons)"
 	outfits
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 224
+		"Hai Tracker" 252
+		"Tracker Storage Pod"
 		"Heavy Laser Turret" 4
+		
 		"Boulder Reactor"
 		"Hai Ravine Batteries"
 		"Hai Diamond Regenerator"
 		"Liquid Nitrogen Cooler"
+		"Ramscoop"
+		
 		"Impala Plasma Thruster"
 		"A375 Atomic Steering"
 		"Afterburner"
 		"Scram Drive"
-		"Ramscoop"
 
 
 
-ship "Bactrian" "Bactrian (Hai Engines)"
+ship "Mule" "Mule (Hai Engines)"
 	outfits
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 100
-		"Torpedo Launcher" 2
-		"Torpedo" 60
-		"Heavy Laser Turret" 4
-		"Heavy Anti-Missile Turret" 2
-		"Fusion Reactor"
-		"Geode Reactor"
-		"Hai Gorge Batteries"
-		"D67-TM Shield Generator"
-		"Hai Williwaw Cooling" 3
-		"Ramscoop"
+		"Heavy Laser Turret" 3
+		"Chameleon Anti-Missile"
+		
+		"Boulder Reactor"
+		"Hai Fissure Batteries"
+		"D41-HY Shield Generator"
+		"Small Radar Jammer" 2
+		"Water Coolant System"
+		"Cooling Ducts"
 		"Mass Expansion"
-		`"Bufaer" Atomic Thruster`
-		`"Bufaer" Atomic Steering`
-		"Hyperdrive"
-
-
-
-ship "Bactrian" "Bactrian (Hai Weapons)"
-	outfits
-		"Pulse Cannon" 2
-		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
-		"Chameleon Anti-Missile" 2
-		"Pulse Turret" 2
-		"Heavy Laser Turret" 2
-		"Fusion Reactor"
-		"Pebble Core"
-		"Hai Ravine Batteries"
-		"Hai Diamond Regenerator"
-		"Hai Williwaw Cooling" 2
 		"Ramscoop"
-		"Large Radar Jammer"
-		"X4700 Ion Thruster"
-		"X5200 Ion Steering"
+		
+		`"Bondir" Atomic Thruster`
+		`"Biroo" Atomic Steering`
+		`"Basrem" Atomic Steering`
 		"Hyperdrive"
-	gun "Pulse Cannon"
-	gun "Pulse Cannon"
-	gun "Hai Tracker Pod"
-	gun "Hai Tracker Pod"
-	turret "Chameleon Anti-Missile"
-	turret "Heavy Laser Turret"
-	turret "Pulse Turret"
-	turret "Pulse Turret"
-	turret "Chameleon Anti-Missile"
-	turret "Heavy Laser Turret"
+
+ship "Mule" "Mule (Hai Weapons)"
+	outfits
+		"Ion Cannon"
+		"Pulse Turret" 4
+		
+		"Geode Reactor"
+		"Hai Ravine Batteries"
+		"Hai Fissure Batteries"
+		"D67-TM Shield Generator"
+		"Water Coolant System"
+		"Mass Expansion" 3
+		"Ramscoop"
+		
+		"A370 Atomic Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"
+
+
+
+# The Osprey (Alien Weapons) isn't used in any fleets, only in a special bounty mission.
+
+ship "Osprey" "Osprey (Alien Weapons)"
+	outfits
+		"Ion Cannon" 2
+		"Pulse Cannon" 2
+		"Pulse Turret"
+		"Chameleon Anti-Missile"
+		
+		"Boulder Reactor"
+		"Hai Fissure Batteries"
+		"Hai Corundum Regenerator"
+		"Liquid Nitrogen Cooler"
+		
+		`"Bondir" Atomic Thruster`
+		`"Bondir" Atomic Steering`
+		Hyperdrive
+
+
+
+ship "Star Queen" "Star Queen (Hai)"
+	outfits
+		"Hai Tracker Pod" 3
+		"Hai Tracker" 168
+		"Chameleon Anti-Missile" 2
+		
+		"NT-200 Nucleovoltaic"
+		"Hai Fissure Batteries"
+		"D94-YV Shield Generator"
+		"Small Radar Jammer"
+		
+		"X3700 Ion Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"

--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -205,7 +205,8 @@ ship "Strong Wind"
 	outfits
 		"Sunbeam" 4
 		"Thunderhead Launcher" 2
-		"Thunderhead Missile" 80
+		"Thunderhead Missile" 120
+		"Thunderhead Storage Array" 2
 		
 		"White Sun Reactor"
 		"Dark Storm Shielding"
@@ -258,7 +259,8 @@ ship "Tempest"
 	outfits
 		"Sunbeam" 2
 		"Thunderhead Launcher" 2
-		"Thunderhead Missile" 80
+		"Thunderhead Missile" 100
+		"Thunderhead Storage Array"
 		"Dual Sunbeam Turret"
 		"Wanderer Anti-Missile" 2
 		
@@ -269,7 +271,7 @@ ship "Tempest"
 		"Type 4 Radiant Thruster"
 		"Type 4 Radiant Steering"
 		"Hyperdrive"
-	
+		
 	engine -22 129
 	engine 22 129
 	gun -16 -100 "Sunbeam"
@@ -301,7 +303,7 @@ ship "Tempest" "Tempest (Heavy)"
 		"Type 4 Radiant Steering"
 		"Type 2 Radiant Steering"
 		"Hyperdrive"
-	
+		
 	turret "Dual Sunbeam Turret"
 	turret "Wanderer Anti-Missile"
 	turret "Wanderer Anti-Missile"
@@ -309,7 +311,8 @@ ship "Tempest" "Tempest (Heavy)"
 ship "Tempest" "Tempest (Missile)"
 	outfits
 		"Thunderhead Launcher" 4
-		"Thunderhead Missile" 160
+		"Thunderhead Missile" 180
+		"Thunderhead Storage Array"
 		"Dual Sunbeam Turret" 2
 		
 		"White Sun Reactor"
@@ -320,7 +323,7 @@ ship "Tempest" "Tempest (Missile)"
 		"Type 4 Radiant Thruster"
 		"Type 4 Radiant Steering"
 		"Hyperdrive"
-	
+		
 	turret
 	turret "Dual Sunbeam Turret"
 	turret "Dual Sunbeam Turret"
@@ -354,7 +357,8 @@ ship "Derecho"
 	outfits
 		"Sunbeam" 2
 		"Thunderhead Launcher" 2
-		"Thunderhead Missile" 80
+		"Thunderhead Missile" 100
+		"Thunderhead Storage Array"
 		"Dual Sunbeam Turret" 2
 		"Wanderer Anti-Missile" 2
 		
@@ -562,7 +566,8 @@ ship "Deep River"
 			"hit force" 4200
 	outfits
 		"Thunderhead Launcher" 6
-		"Thunderhead Missile" 240
+		"Thunderhead Missile" 320
+		"Thunderhead Storage Array" 4
 		
 		"Large Biochemical Cell"
 		"Bright Cloud Shielding"

--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -566,8 +566,8 @@ ship "Deep River"
 			"hit force" 4200
 	outfits
 		"Thunderhead Launcher" 6
-		"Thunderhead Missile" 320
-		"Thunderhead Storage Array" 4
+		"Thunderhead Missile" 300
+		"Thunderhead Storage Array" 3
 		
 		"Large Biochemical Cell"
 		"Bright Cloud Shielding"


### PR DESCRIPTION
I retried manually copy-pasting the 5 files in my fork instead and made it a much cleaner PR than #2269 (same PR though), closing that one and this will be my PR

copy-pasted over what I  did:
- added ammo storages to some ships that had missiles and room left (only the stock Protector lost 2 of the 3 small radar jammers for 2 torpedo storages), also added the ammo for them
- made a lot of lay-out fixes and improvements
- ordened all variants in variants.txt alphabetically & even ordened the variants per ship), and put all Hai outfitted human ship variants to the bottom seperately
- had to manually add the hardpoint fix commit but that's 100% fine now

as far as I know I made 0 mistakes (perfectionism) but please tell me if I made any (found 1 myself: the base Bastion didn't have extra ammo for the boxes, re-checked everything and didn't see any mistakes myself)
edit: also I manually calculated the remaining outfit space on every ship and variant I changed, so I'm 99% sure none have negative outfit space