### PR TITLE
Edited Amy's instructions and added "thruster equipment" cargo in Terraforming Rand 3

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1718,6 +1718,8 @@ mission "Terraforming 2"
 mission "Terraforming 3"
 	name "Terraforming Rand"
 	description "Plant a thruster on an asteroid to guide it into a collision with the northern pole of Rand."
+	blocked "You'll need more cargo space in order to take the next mission from Eric and Alaric. Return here when you have at least <capacity>."
+	cargo "small ion thruster" 10
 	source Rand
 	to offer
 		has "Terraforming 2: done"
@@ -1746,7 +1748,7 @@ mission "Terraforming 3"
 				`	"That is a stupid idea, and I want nothing to do with it."`
 					decline
 				`	"Well, if you think it will work, I'm willing to try it!"`
-			`	"Great!" says Amy. "I'll mark the asteroid on your radar. You just need to board it, install a small ion thruster, and wait for it to land on the planet, then return here."`
+			`	"Great!" says Amy. "I'll mark the asteroid on your radar. You just need to board it, install a small ion thruster we will give you, and return here."`
 				accept
 	
 	npc assist

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1719,7 +1719,7 @@ mission "Terraforming 3"
 	name "Terraforming Rand"
 	description "Plant a thruster on an asteroid to guide it into a collision with the northern pole of Rand."
 	blocked "You'll need more cargo space in order to take the next mission from Eric and Alaric. Return here when you have at least <capacity>."
-	cargo "small ion thruster" 10
+	cargo "thruster equipment" 10
 	source Rand
 	to offer
 		has "Terraforming 2: done"
@@ -1748,7 +1748,8 @@ mission "Terraforming 3"
 				`	"That is a stupid idea, and I want nothing to do with it."`
 					decline
 				`	"Well, if you think it will work, I'm willing to try it!"`
-			`	"Great!" says Amy. "I'll mark the asteroid on your radar. You just need to board it, install a small ion thruster we will give you, and return here."`
+			`	"Great!" says Amy. "I'll mark the asteroid on your radar. You just need to board it, install a small ion thruster, and return here."
+			`	Eric contacts some spaceport workers and has them load a small thruster onto your ship, along with the equipment you will need to mount it on the asteroid.			
 				accept
 	
 	npc assist

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1748,8 +1748,8 @@ mission "Terraforming 3"
 				`	"That is a stupid idea, and I want nothing to do with it."`
 					decline
 				`	"Well, if you think it will work, I'm willing to try it!"`
-			`	"Great!" says Amy. "I'll mark the asteroid on your radar. You just need to board it, install a small ion thruster, and return here."`			
-			`	Eric contacts some spaceport workers and has them load a small thruster onto your ship, along with the equipment you will need to mount it on the asteroid.`			
+			`	"Great!" says Amy. "I'll mark the asteroid on your radar. You just need to board it, install a small ion thruster, and return here."`
+			`	Eric contacts some spaceport workers and has them load a small thruster onto your ship, along with the equipment you will need to mount it on the asteroid.`
 				accept
 	
 	npc assist

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1748,8 +1748,8 @@ mission "Terraforming 3"
 				`	"That is a stupid idea, and I want nothing to do with it."`
 					decline
 				`	"Well, if you think it will work, I'm willing to try it!"`
-			`	"Great!" says Amy. "I'll mark the asteroid on your radar. You just need to board it, install a small ion thruster, and return here."
-			`	Eric contacts some spaceport workers and has them load a small thruster onto your ship, along with the equipment you will need to mount it on the asteroid.			
+			`	"Great!" says Amy. "I'll mark the asteroid on your radar. You just need to board it, install a small ion thruster, and return here."`			
+			`	Eric contacts some spaceport workers and has them load a small thruster onto your ship, along with the equipment you will need to mount it on the asteroid.`			
 				accept
 	
 	npc assist


### PR DESCRIPTION
Now player is given a bit more precise instructions, and said ion thruster takes up 10 t of cargo space. (Initially was going to make it take up 20 t (as X1050) or 16 t (as even smaller thruster + steering), but decided against it in order for the mission being doable with Sparrow.)