### PR TITLE
smart refuelling

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -355,7 +355,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 				messages.push_back("You have succeeded in capturing this ship.");
 				victim->WasCaptured(you);
 				if(!victim->JumpsRemaining() && you->CanRefuel(*victim))
-					you->TransferFuel(victim->JumpFuel(), &*victim);
+					you->TransferFuel(victim->JumpFuelMissing(), &*victim);
 				player.AddShip(victim);
 				isCapturing = false;
 				

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1919,6 +1919,7 @@ double Ship::JumpFuelMissing() const
 	// includes checking if fuel cap is high enough at all
 	if(!JumpsRemaining() && attributes.Get("fuel capacity") > JumpFuel())
 		return JumpFuel() - fuel;
+	return 0.;
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1917,7 +1917,7 @@ double Ship::JumpFuelMissing() const
 {
 	// Used for smart refuelling: transfer only as much as really needed
 	// includes checking if fuel cap is high enough at all
-	if(!JumpsRemaining() && attributes.Get("fuel capacity") > JumpFuel())
+	if(!JumpsRemaining() && attributes.Get("fuel capacity") >= JumpFuel())
 		return JumpFuel() - fuel;
 	return 0.;
 }

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -233,6 +233,8 @@ public:
 	int JumpsRemaining() const;
 	// Get the amount of fuel expended per jump.
 	double JumpFuel() const;
+	// Get the amount of fuel missing for the next jump (smart refuelling)
+	double JumpFuelMissing() const;
 	// Get the heat level at idle.
 	double IdleHeat() const;
 	// Calculate the multiplier for cooling efficiency.


### PR DESCRIPTION
Okay, this doesnt look perfect in terms of the number of commits as I was struggeling a bit with the number of branches in my profile, but that's my first attempt to contribute to the code.
**Warning:** I am not used to write C++ && I dont have tested this since I dont have downloaded the code to my system (where, since it is Debian, a compiler must be available, lol). --> Hence some dev needs to check what I wrote.

Purpose: Give the friendly boarding (with respect to refuelling) a better AI allowing to refuel in more cases.
Currently, Sparrow 1 with 152 fuel cant refuel Sparrow 2 with 51 fuel because 0.9.6 always wants to transfer the full 100 (given a Hyperdrive).

Stripped savegame for testing attached
[Lydia S~non-smart refuelling in Sirius system.txt](https://github.com/endless-sky/endless-sky/files/903577/Lydia.S.non-smart.refuelling.in.Sirius.system.txt)