### PR TITLE
Fix errors/inconsistencies in jobs.txt files

### DIFF
--- a/data/hai jobs.txt
+++ b/data/hai jobs.txt
@@ -223,7 +223,7 @@ mission "Unfettered Aid [0]"
 		dialog `The Hai dockworkers load the food for the Unfettered onto your ship. One of them says to you, "Thank you. This is far better than watching our kinfolk starve."`
 	on complete
 		payment 5000 1600
-		dialog "You drop off the aid (or as they like to refer to it as, "tribute") for the Unfettered, and they pay you <payment>."
+		dialog `You drop off the aid (or as they like to refer to it, "tribute") for the Unfettered, and they pay you <payment>.`
 
 mission "Unfettered Aid [1]"
 	name "Aid shipment to Unfettered"
@@ -245,7 +245,7 @@ mission "Unfettered Aid [1]"
 		dialog `As the Hai load the food onto your ship, one of them says, "Tell our brothers and sisters that if they will only repent, they will be welcome to come home."`
 	on complete
 		payment 6000 1800
-		dialog "You drop off the aid (or as they like to refer to it as, "tribute") for the Unfettered, and they pay you <payment>."
+		dialog `You drop off the aid (or as they like to refer to it, "tribute") for the Unfettered, and they pay you <payment>.`
 
 mission "Unfettered Aid [2]"
 	name "Aid shipment to Unfettered"
@@ -267,7 +267,7 @@ mission "Unfettered Aid [2]"
 		dialog `The Hai dockworkers load the food for the Unfettered onto your ship. One of them says to you, "Tell our brothers and sisters that if they will only repent, they will be welcome to come home."`
 	on complete
 		payment 7000 2000
-		dialog "You drop off the aid (or as they like to refer to it as, "tribute") for the Unfettered, and they pay you <payment>."
+		dialog `You drop off the aid (or as they like to refer to it, "tribute") for the Unfettered, and they pay you <payment>.`
 
 mission "Unfettered Tribute 1"
 	name "Hai Tribute to <planet>"

--- a/data/syndicate world jobs.txt
+++ b/data/syndicate world jobs.txt
@@ -28,7 +28,7 @@ mission "Transport executive to <planet>"
 		dialog "The executive rushes off your ship without even a goodbye, fancy briefcase in hand. You collect your payment of <payment>."
 
 
-mission "Corporate retreat on <planet>"
+mission "Corporate retreat from <origin>"
 	job
 	repeat
 	deadline
@@ -171,7 +171,7 @@ mission "Syndicate target practice [0]"
 		personality staying heroic
 		government "Test Dummy"
 		ship "Berserker" "Syndicate Test Vessel"
-			
+
 		system destination
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -329,7 +329,7 @@ mission "Wanderer Harvest [1]"
 		dialog "You wish the Wanderers the best of luck on <planet> and collect your payment of <payment>."
 
 mission "Wanderer Invasive Species [0]"
-	name "Invasive species on <planet>"
+	name "Quarantine an invasive species"
 	job
 	repeat
 	description `These <bunks> Wanderers need to get to <stopovers> with their <cargo> by <date> to contain an invasive animal species. Return the Wanderers to <origin> with the animals for a payment of <payment>.`
@@ -351,7 +351,7 @@ mission "Wanderer Invasive Species [0]"
 		dialog `After releasing the animals, the <bunks> Wanderers each thank you for assisting them in returning the animals to <planet> and hand you <payment>.`
 
 mission "Wanderer Invasive Species [1]"
-	name "Invasive species on <planet>"
+	name "Quarantine an invasive species"
 	job
 	repeat
 	description `These <bunks> Wanderers need to get to <stopovers> with their <cargo> by <date> to contain an invasive plant species. Return the Wanderers to <origin> with the animals for a payment of <payment>.`


### PR DESCRIPTION
 - hai jobs: dialog strings contained improperly escaped doublequotes. Fixed by using `` instead of "", as is done with other jobs/dialogs that have embedded doublequotes.
Before: ![tribute to firelode](https://cloud.githubusercontent.com/assets/20871346/24784259/e023186a-1b16-11e7-9292-8b88f503004e.png)
After: 
![post-fix tribute](https://cloud.githubusercontent.com/assets/20871346/24784260/e0232f6c-1b16-11e7-82e2-287aa2321c55.png)

 - syndicate world jobs: Updated the "Corporate retreat" mission displayname to avoid confusion
 - wanderer jobs: Updated the "Invasive Species" missions to avoid confusion

Use of <planet> in the display name does not load the name of the intermediate destination that the planet has to visit, but is the same as <origin>.
Using <stopovers> would be better, but this text replacement hotword also gets the system name, so it will overflow the "Missions available" panel. It also may have more than one value.

![invasive species post-fix](https://cloud.githubusercontent.com/assets/20871346/24784257/e021a714-1b16-11e7-9a57-2bff1d0e7d84.png)
![invasive species pre-fix](https://cloud.githubusercontent.com/assets/20871346/24784258/e022f236-1b16-11e7-8571-4ca5d8cbf759.png)
