### PR TITLE
added Local Map to coalition & heliarch outfitters

### DIFF
--- a/data/coalition.txt
+++ b/data/coalition.txt
@@ -223,6 +223,7 @@ outfitter "Coalition Basics"
 	"Cargo Expansion"
 	"Outfits Expansion"
 	"Hyperdrive"
+	"Local Map"
 
 outfitter "Coalition Advanced"
 	"Small Collector Module"
@@ -241,6 +242,7 @@ outfitter "Coalition Advanced"
 	"Cargo Expansion"
 	"Outfits Expansion"
 	"Hyperdrive"
+	"Local Map"
 
 outfitter "Heliarch"
 	"Small Reactor Module"
@@ -252,6 +254,7 @@ outfitter "Heliarch"
 	"Heliarch Attractor"
 	"Heliarch Repulsor"
 	"Ion Rain Gun"
+	"Local Map"
 
 
 shipyard "Arach"


### PR DESCRIPTION
Note: the heliarch outfitter is not used in v0.9.6 at all, but I changed it as well for consistency. Currently, every planet outside coalition space which has an outfitter, sells a Local Map. I.e. human space, hai, wanderer and kor efreti.

> mission "Coalition: First Contact"
> 			`	The centaur pulls out a map printed on a thin sheet of plastic. You recognize it as a star map of this region. Lines mark out three different territories, and where they meet are three star systems colored yellow. The centaur points to the southernmost of the three. "Where you must go, here it is," it says.`

They know what a map is and they even have hard copies.

----------
Possible reason to reject this pull: The player does not yet understand any of the 3 languages. Only the coalition species have the translation boxes. Thus eventually the player might not be able to read the names of the systems and planets (plus shipyard / outfitter information) and the prizes of the commodities.
On the other hand: The moment `event "coalition: shipyard and outfitters"` applies, the player immediately knows the details for any system he/she already has visited.