### PR TITLE
More escort tags in the entire Free Worlds campaign

### DIFF
--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -96,7 +96,8 @@ mission "FWC Attack Kaus Borealis"
 		event "fwc capture kaus borealis"
 	
 	npc
-		personality heroic
+		personality escort heroic
+		government "Free Worlds"
 		fleet
 			names "free worlds capital"
 			fighters "free worlds fighters"
@@ -263,7 +264,8 @@ mission "FWC Cebalrai 1B"
 		event "fwc capture cebalrai"
 	
 	npc
-		personality heroic
+		personality escort heroic
+		government "Free Worlds"
 		fleet
 			names "free worlds capital"
 			variant
@@ -513,7 +515,8 @@ mission "FWC Diplomacy 1B"
 				accept
 	
 	npc accompany save
-		personality timid
+		personality escort timid
+		government "Free Worlds"
 		ship "Argosy" "F.S. Big Brother"
 
 	on visit
@@ -555,7 +558,8 @@ mission "FWC Diplomacy 1C"
 				launch
 	
 	npc
-		personality timid
+		personality escort timid waiting
+		government "Free Worlds"
 		ship "Argosy" "F.S. Big Brother"
 
 	npc
@@ -909,7 +913,8 @@ mission "FWC Checkmate 1B"
 		event "fwc capture menkent"
 
 	npc
-		personality heroic
+		personality escort heroic
+		government "Free Worlds"
 		fleet
 			names "free worlds capital"
 			fighters "free worlds fighters"
@@ -1031,7 +1036,8 @@ mission "FWC Checkmate Escorts"
 		has "FWC Pug 4: done"
 	
 	npc kill
-		personality heroic disables
+		personality escort heroic disables
+		government "Escort"
 		fleet
 			names "free worlds capital"
 			variant
@@ -1108,7 +1114,7 @@ mission "FWC Pug 1"
 				launch
 	
 	npc
-		personality waiting heroic
+		personality escort heroic waiting
 		government "Free Worlds"
 		fleet
 			names "free worlds small"
@@ -1623,7 +1629,8 @@ mission "FWC Pug 3B"
 				launch
 	
 	npc
-		personality heroic
+		personality escort heroic
+		government "Free Worlds"
 		fleet
 			names "free worlds capital"
 			fighters "free worlds fighters"
@@ -1740,7 +1747,7 @@ mission "FWC Pug 3D: Reinforcements"
 	
 	npc kill
 		government "Navy (Oathkeeper)"
-		personality heroic waiting
+		personality escort heroic waiting
 		fleet
 			names "republic capital"
 			fighters "republic fighter"
@@ -1758,7 +1765,7 @@ mission "FWC Pug 3D: Reinforcements"
 				"Gunboat (Mark II)" 3
 	npc kill
 		government Republic
-		personality heroic waiting
+		personality escort heroic waiting
 		fleet
 			names "republic capital"
 			fighters "republic fighter"
@@ -1775,7 +1782,8 @@ mission "FWC Pug 3D: Reinforcements"
 				"Combat Drone" 6
 				"Gunboat" 2
 	npc kill
-		personality heroic waiting
+		personality escort heroic waiting
+		government "Free Worlds"
 		fleet
 			names "free worlds capital"
 			variant
@@ -2363,7 +2371,7 @@ mission "FWC Pug 5C"
 	npc
 		government Republic
 		system Sol
-		personality heroic waiting
+		personality escort heroic waiting
 		fleet
 			names "republic capital"
 			fighters "republic fighter"
@@ -2437,7 +2445,7 @@ mission "FWC Pug 6"
 	
 	npc
 		government Republic
-		personality heroic
+		personality escort heroic
 		fleet
 			names "republic capital"
 			fighters "republic fighter"
@@ -2476,7 +2484,7 @@ mission "FWC Pug 6"
 				"Rainmaker (Mark II)" 2
 	npc
 		government "Navy (Oathkeeper)"
-		personality heroic
+		personality escort heroic
 		system Cebalrai
 		fleet
 			names "republic capital"
@@ -2509,7 +2517,7 @@ mission "FWC Pug 6"
 				"Combat Drone" 6
 				"Gunboat (Mark II)" 3
 	npc
-		personality heroic
+		personality escort heroic
 		system Cebalrai
 		government "Free Worlds"
 		fleet

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1875,7 +1875,7 @@ mission "Defend Sabik"
 				"Rainmaker" 3
 	
 	npc
-		personality heroic disables
+		personality escort heroic disables
 		government "Free Worlds"
 		fleet
 			names "free worlds capital"
@@ -1893,7 +1893,7 @@ mission "Defend Sabik"
 				"Hawk"
 				"Fury" 2
 	npc
-		personality heroic disables
+		personality escort heroic disables
 		government "Free Worlds"
 		system "Zubenelgenubi"
 		fleet
@@ -1904,7 +1904,7 @@ mission "Defend Sabik"
 				"Hawk" 3
 				"Sparrow" 5
 	npc
-		personality heroic disables
+		personality escort heroic disables
 		government "Free Worlds"
 		system "Zubeneschamali"
 		fleet
@@ -1919,7 +1919,7 @@ mission "Defend Sabik"
 				"Bastion" 2
 				"Argosy" 4
 	npc
-		personality heroic disables
+		personality escort heroic disables
 		government "Free Worlds"
 		system "Unukalhai"
 		fleet
@@ -1927,7 +1927,7 @@ mission "Defend Sabik"
 			variant
 				"Falcon" 2
 	npc
-		personality heroic waiting disables
+		personality escort heroic waiting disables
 		government "Free Worlds"
 		fleet
 			names "free worlds small"

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -972,7 +972,8 @@ mission "FW Northern 3B"
 				accept
 	
 	npc accompany save
-		personality timid
+		personality escort timid
+		government "Free Worlds"
 		ship Dreadnought "F.S. Bartlett"
 		ship Dreadnought "F.S. Magnolia"
 	
@@ -1535,7 +1536,8 @@ mission "FW Bloodsea 1.2A"
 				accept
 	
 	npc
-		personality heroic
+		personality escort heroic
+		government "Free Worlds"
 		ship "Dreadnought" "F.S. Bombastic"
 		ship "Falcon (Plasma)" "F.S. Equalizer"
 		ship "Falcon (Plasma)" "F.S. Enforcer"
@@ -1767,7 +1769,8 @@ mission "FW Rand 1"
 				accept
 	
 	npc
-		personality heroic disables
+		personality escort heroic disables
+		government "Free Worlds"
 		ship "Dreadnought" "F.S. Elder"
 		ship "Falcon (Plasma)" "F.S. Reliant"
 		ship "Falcon (Heavy)" "F.S. Bismark"
@@ -1781,7 +1784,7 @@ mission "FW Rand 1"
 		ship "Hawk (Rocket)" "F.S. Echo"
 		ship "Hawk" "F.S. Shadow"
 	npc
-		personality heroic disables
+		personality escort heroic disables
 		government "Free Worlds"
 		system "Kochab"
 		ship "Dreadnought" "F.S. Linden"
@@ -1987,7 +1990,8 @@ mission "FW Defend New Tibet"
 				"Manta (Mark II)" 3
 				"Quicksilver (Mark II)" 5
 	npc
-		personality heroic disables
+		personality escort heroic disables
+		government "Free Worlds"
 		ship "Dreadnought" "F.S. Holly"
 		ship "Falcon (Plasma)" "F.S. Nebula"
 		ship "Skein" "F.S. Larkspur"
@@ -2109,7 +2113,8 @@ mission "FW Liberate Delta Sagittarii"
 		event "fwc southern liberation"
 	
 	npc
-		personality heroic
+		personality escort heroic
+		government "Free Worlds"
 		fleet
 			names "free worlds capital"
 			variant

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -593,6 +593,7 @@ mission "FW Embassy 1C"
 	
 	npc accompany save
 		personality escort heroic
+		government "Free Worlds"
 		ship "Dreadnought" "F.S. Gibraltar"
 	
 	on visit
@@ -657,6 +658,7 @@ mission "FW Syndicate Capture 1"
 	
 	npc accompany save
 		personality escort heroic
+		government "Free Worlds"
 		ship "Dreadnought" "F.S. Gibraltar"
 	
 	npc accompany save
@@ -694,6 +696,7 @@ mission "FW Syndicate Capture 1B"
 	
 	npc
 		personality escort heroic
+		government "Free Worlds"
 		ship "Dreadnought" "F.S. Gibraltar"
 	npc
 		personality escort heroic waiting
@@ -1501,6 +1504,7 @@ mission "FW Pug 3B"
 	
 	npc accompany save
 		personality escort disables
+		government "Free Worlds"
 		ship "Dreadnought" "F.S. Independence"
 		ship "Dreadnought" "F.S. Freedom"
 	
@@ -1542,6 +1546,7 @@ mission "FW Pug 3C"
 	
 	npc accompany save
 		personality escort
+		government "Free Worlds"
 		ship "Dreadnought" "F.S. Independence"
 		ship "Dreadnought" "F.S. Freedom"
 	npc accompany save
@@ -1569,6 +1574,7 @@ mission "FW Pug 4: Escorts"
 	
 	npc kill
 		personality escort heroic disables
+		government "Free Worlds"
 		ship "Dreadnought (Jump)" "F.S. Independence"
 		ship "Dreadnought (Jump)" "F.S. Freedom"
 	npc kill

--- a/data/free worlds side plots.txt
+++ b/data/free worlds side plots.txt
@@ -515,6 +515,8 @@ mission "FW Stack Core 1B"
 				accept
 	
 	npc accompany save
+		government Merchant
+		personality escort timid
 		fleet
 			names "civilian"
 			cargo 3

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -41,7 +41,7 @@ mission "Liberate Kornephoros"
 		event "prepare for battle of Kornephoros"
 	
 	npc
-		personality heroic disables
+		personality escort heroic disables
 		government "Free Worlds"
 		fleet
 			names "free worlds capital"
@@ -56,7 +56,7 @@ mission "Liberate Kornephoros"
 				"Hawk" 2
 				"Hawk (Rocket)" 1
 	npc
-		personality heroic disables
+		personality escort heroic disables
 		government "Free Worlds"
 		system Zubenelgenubi
 		fleet


### PR DESCRIPTION
Checked all current FW campaing files. Added many escort tags to personality. Added government "Free Worlds" tags quite often.
Minor changes and things not changed are explicitely mentioned in each commit.

Note: Adding the government "Free Worlds" tags feels safer with respect to the user having any plugins which might change his colors/swizzle to something else like having joined some alien forces before finishing the main plot / free worlds plot.

Relates to #2364 and extends fc1372a of @endless-sky 