### PR TITLE
Add some inaccuracy at the moment of firing

### DIFF
--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -184,6 +184,11 @@ void Hardpoint::Fire(Ship &ship, list<Projectile> &projectiles, list<Effect> &ef
 		// the projectile dies (to avoid over-correcting).
 		if(!(steps < outfit->TotalLifetime()))
 			steps = outfit->TotalLifetime();
+
+		// Add some inaccuracy in guessing the number of steps
+		double inaccuracy = outfit->Inaccuracy();
+		if(inaccuracy)
+			steps += inaccuracy * Random::Normal();
 		
 		// Aim toward where the target will be at the calculated rendezvous time.
 		aim = Angle(p + steps * v);


### PR DESCRIPTION
Using the existing inaccuracy flag of weapons, I added another way of inaccuracy by adding some error to the rendezvous time estimation.