### PR TITLE
introduce "random" to the right side of conditions

### DIFF
--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -40,6 +40,7 @@ namespace {
 			{"=", [](int a, int b) { return b; }},
 			{"+=", [](int a, int b) { return a + b; }},
 			{"-=", [](int a, int b) { return a - b; }},
+			{"*=", [](int a, int b) { return a * b; }},
 			{"<?=", [](int a, int b) { return min(a, b); }},
 			{">?=", [](int a, int b) { return max(a, b); }}
 		};

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -66,7 +66,10 @@ void ConditionSet::Load(const DataNode &node)
 void ConditionSet::Save(DataWriter &out) const
 {
 	for(const Expression &expression : expressions)
-		out.Write(expression.name, expression.op, expression.value);
+		if (!expression.value && !expression.svalue.empty())
+			out.Write(expression.name, expression.op, expression.svalue);
+		else
+			out.Write(expression.name, expression.op, expression.value);
 	for(const ConditionSet &child : children)
 	{
 		out.Write(child.isOr ? "or" : "and");

--- a/source/ConditionSet.h
+++ b/source/ConditionSet.h
@@ -40,6 +40,7 @@ public:
 	void Add(const DataNode &node);
 	bool Add(const std::string &firstToken, const std::string &secondToken);
 	bool Add(const std::string &name, const std::string &op, int value);
+	bool Add(const std::string &name, const std::string &op, const std::string &svalue);
 	
 	// Check if the given condition values satisfy this set of conditions.
 	bool Test(const std::map<std::string, int> &conditions) const;
@@ -63,6 +64,8 @@ private:
 		int (*fun)(int, int);
 		// Constant value specified in the expression.
 		int value;
+		// Allow for dynamic values.
+		std::string svalue;
 	};
 	
 	

--- a/source/ConditionSet.h
+++ b/source/ConditionSet.h
@@ -49,6 +49,11 @@ public:
 	
 	
 private:
+	// Check if the passed token is numeric or a string which has to be replaced, and return its value
+	double TokenValue(int numValue, const std::string &strValue, const std::map<std::string, int> &conditions) const;
+	
+	
+private:
 	// This class represents a single expression involving a condition - either
 	// testing what value it has, or modifying it in some way.
 	class Expression {


### PR DESCRIPTION
Introduce "random" and playerConditions to the right side of conditions, allowing for:
- "random var" <= random
- "random var" = random
- "CoalitionJobsOld" = "CoalitionJobs"
- "reputation: Navy Intelligence" >= "reputation: Republic"