### PR TITLE
Intercept (dock with moving targets)

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1195,7 +1195,7 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition, const
 		return true;
 	
 	bool shouldReverse = false;
-	dp = targetPosition - AdjustPoint(ship, targetVelocity, shouldReverse);
+	dp = targetPosition - StoppingPoint(ship, targetVelocity, shouldReverse);
 	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .8);
 	if(!isClose || (!isFacing && !shouldReverse))
 		command.SetTurn(TurnToward(ship, dp));
@@ -1367,14 +1367,14 @@ void AI::KeepStation(Ship &ship, Command &command, const Ship &target)
 	double positionAngle = Angle(rendezvous).Degrees();
 	positionTime += AngleDiff(currentAngle, positionAngle) / turn;
 	positionTime += (rendezvous.Unit() * maxV - ship.Velocity()).Length() / accel;
-	// If you are very close,stop trying to adjust:
+	// If you are very close, stop trying to adjust:
 	positionTime *= positionWeight * positionWeight;
 	
 	// Time it will take (roughly) to adjust your velocity to match the target:
 	double velocityTime = velocityDelta.Length() / accel;
 	double velocityAngle = Angle(velocityDelta).Degrees();
 	velocityTime += AngleDiff(currentAngle, velocityAngle) / turn;
-	// If you are very close,stop trying to adjust:
+	// If you are very close, stop trying to adjust:
 	velocityTime *= velocityWeight * velocityWeight;
 	
 	// Focus on matching position or velocity depending on which will take longer.
@@ -1776,10 +1776,10 @@ void AI::DoScatter(Ship &ship, Command &command)
 
 
 // Instead of coming to a full stop, adjust to a target velocity vector
-Point AI::AdjustPoint(const Ship &ship, const Point &targetVelocity, bool &shouldReverse)
+Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &shouldReverse)
 {
 	const Point &position = ship.Position();
-	const Point &velocity = ship.Velocity() - targetVelocity;
+	Point velocity = ship.Velocity() - targetVelocity;
 	const Angle &angle = ship.Facing();
 	double acceleration = ship.Acceleration();
 	double turnRate = ship.TurnRate();
@@ -1814,6 +1814,7 @@ Point AI::AdjustPoint(const Ship &ship, const Point &targetVelocity, bool &shoul
 	
 	return position + stopDistance * velocity.Unit();
 }
+
 
 
 // Get a vector giving the direction this ship should aim in in order to do

--- a/source/AI.h
+++ b/source/AI.h
@@ -75,8 +75,7 @@ private:
 	static double TurnBackward(const Ship &ship);
 	static double TurnToward(const Ship &ship, const Point &vector);
 	static bool MoveToPlanet(Ship &ship, Command &command);
-	static bool MoveTo(Ship &ship, Command &command, const Point &target, double radius, double slow);
-	static bool Intercept(Ship &ship, Command &command, const Ship &target, double radius, double slow);
+	static bool MoveTo(Ship &ship, Command &command, const Point &targetPosition, const Point &targetVelocity, double radius, double slow);
 	static bool Stop(Ship &ship, Command &command, double maxSpeed = 0.);
 	static void PrepareForHyperspace(Ship &ship, Command &command);
 	static void CircleAround(Ship &ship, Command &command, const Ship &target);
@@ -91,7 +90,6 @@ private:
 	void DoCloak(Ship &ship, Command &command);
 	void DoScatter(Ship &ship, Command &command);
 	
-	static Point StoppingPoint(const Ship &ship, bool &shouldReverse);
 	static Point AdjustPoint(const Ship &ship, const Point &targetVelocity, bool &shouldReverse);
 	// Get a vector giving the direction this ship should aim in in order to do
 	// maximum damaged to a target at the given position with its non-turret,

--- a/source/AI.h
+++ b/source/AI.h
@@ -90,7 +90,7 @@ private:
 	void DoCloak(Ship &ship, Command &command);
 	void DoScatter(Ship &ship, Command &command);
 	
-	static Point AdjustPoint(const Ship &ship, const Point &targetVelocity, bool &shouldReverse);
+	static Point StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &shouldReverse);
 	// Get a vector giving the direction this ship should aim in in order to do
 	// maximum damaged to a target at the given position with its non-turret,
 	// non-homing weapons. If the ship has no non-homing weapons, this just

--- a/source/AI.h
+++ b/source/AI.h
@@ -76,6 +76,7 @@ private:
 	static double TurnToward(const Ship &ship, const Point &vector);
 	static bool MoveToPlanet(Ship &ship, Command &command);
 	static bool MoveTo(Ship &ship, Command &command, const Point &target, double radius, double slow);
+	static bool Intercept(Ship &ship, Command &command, const Ship &target, double radius, double slow);
 	static bool Stop(Ship &ship, Command &command, double maxSpeed = 0.);
 	static void PrepareForHyperspace(Ship &ship, Command &command);
 	static void CircleAround(Ship &ship, Command &command, const Ship &target);
@@ -91,6 +92,7 @@ private:
 	void DoScatter(Ship &ship, Command &command);
 	
 	static Point StoppingPoint(const Ship &ship, bool &shouldReverse);
+	static Point AdjustPoint(const Ship &ship, const Point &targetVelocity, bool &shouldReverse);
 	// Get a vector giving the direction this ship should aim in in order to do
 	// maximum damaged to a target at the given position with its non-turret,
 	// non-homing weapons. If the ship has no non-homing weapons, this just


### PR DESCRIPTION
relates to: #2356 
In my local build it works like a charm.
Fighters can dock (my flagship) at "any speed" because they are now told to adjust to the carrier's velocity vector.
This PR does not modify the general behaviour of the carrier ships, i.e. AI controlled carriers (own escorts and NPCs) still come to a full stop. This should be done in a separate PR, imho. This is just a required step...