### PR TITLE
ignore harvesting when cargo space is full

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1673,6 +1673,8 @@ bool AI::DoHarvesting(Ship &ship, Command &command)
 		double bestTime = 600.;
 		for(const shared_ptr<Flotsam> &it : flotsam)
 		{
+			if (ship.Cargo().Free() < it->UnitSize())
+				continue;
 			// Only pick up flotsam that is nearby and that you are facing toward.
 			Point p = it->Position() - ship.Position();
 			double range = p.Length();
@@ -1688,7 +1690,7 @@ bool AI::DoHarvesting(Ship &ship, Command &command)
 			
 			double degreesToTurn = TO_DEG * acos(min(1., max(-1., p.Unit().Dot(ship.Facing().Unit()))));
 			time += degreesToTurn / ship.TurnRate();
-			if(time < bestTime && ship.Cargo().Free() >= it->UnitSize())
+			if(time < bestTime)
 			{
 				bestTime = time;
 				target = it;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1659,6 +1659,10 @@ void AI::DoMining(Ship &ship, Command &command)
 
 bool AI::DoHarvesting(Ship &ship, Command &command)
 {
+	// Only consider harvesting if the ship has free cargo space.
+	if(ship.Cargo().Used() >= ship.Attributes().Get("cargo space"))
+		return false;
+
 	// If the ship has no target to pick up, do nothing.
 	shared_ptr<Flotsam> target = ship.GetTargetFlotsam();
 	if(!target)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1659,12 +1659,10 @@ void AI::DoMining(Ship &ship, Command &command)
 
 bool AI::DoHarvesting(Ship &ship, Command &command)
 {
-	// Only consider harvesting if the ship has free cargo space.
-	if(!ship.Cargo().Free())
-		return false;
-
 	// If the ship has no target to pick up, do nothing.
 	shared_ptr<Flotsam> target = ship.GetTargetFlotsam();
+	if(target && ship.Cargo().Free() < target->UnitSize())
+		target.reset();
 	if(!target)
 	{
 		// Only check for new targets every 10 frames, on average.
@@ -1690,7 +1688,7 @@ bool AI::DoHarvesting(Ship &ship, Command &command)
 			
 			double degreesToTurn = TO_DEG * acos(min(1., max(-1., p.Unit().Dot(ship.Facing().Unit()))));
 			time += degreesToTurn / ship.TurnRate();
-			if(time < bestTime)
+			if(time < bestTime && ship.Cargo().Free() >= it->UnitSize())
 			{
 				bestTime = time;
 				target = it;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1660,7 +1660,7 @@ void AI::DoMining(Ship &ship, Command &command)
 bool AI::DoHarvesting(Ship &ship, Command &command)
 {
 	// Only consider harvesting if the ship has free cargo space.
-	if(ship.Cargo().Used() >= ship.Attributes().Get("cargo space"))
+	if(!ship.Cargo().Free())
 		return false;
 
 	// If the ship has no target to pick up, do nothing.


### PR DESCRIPTION
As the title says: ships shall not attempt to harvest flotsam if their cargo space is full. Before this PR they do/did.
Note that a ship still may follow its mining personality and crack those asteroids, even if cargo space is full. That happened before and was not changed.

Suggestion: If a ship has HARVESTS and MINING, then it should stop mining. A ship which has only MINING but not HARVESTS, should mine no matter if the cargo space is full - because that personality profile assumes, that some other ship(s) will harvest.