### PR TITLE
fixed typo @Mine Launcher hit force

### DIFF
--- a/data/korath weapons.txt
+++ b/data/korath weapons.txt
@@ -426,7 +426,7 @@ outfit "Korath Minelayer"
 		"missile strength" 35
 		"shield damage" -3200
 		"hull damage" -2400
-		"hit force" 150
+		"hit force" -150
 		"stream"
 	description "This launcher fires cluster munitions that split into a cloud of stationary mines that each do a considerable amount of damage if a ship crashes into them. However, if a ship hits the mine before it has a chance to deploy, the damage is considerably reduced."
 


### PR DESCRIPTION
According to the description, the hitforce should be negative as well. Otherwise hitting the mine before it deploys generates more hit force when after deploy.
Alternatively, remove the hitforce from the Launcher and use only the hit force from the submunition, if a negative hit force for the launcher seems inappropriate.