### PR TITLE
rotate player sprite according to facing

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -440,7 +440,10 @@ void Engine::Step(bool isActive)
 		Messages::Add("Your ship has overheated.");
 	
 	if(flagship && flagship->Hull())
-		info.SetSprite("player sprite", flagship->GetSprite());
+	{
+		Point shipFacingUnit = flagship->Facing().Unit();
+		info.SetSprite("player sprite", flagship->GetSprite(), shipFacingUnit);
+	}
 	else
 		info.SetSprite("player sprite", nullptr);
 	if(currentSystem)

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -441,8 +441,13 @@ void Engine::Step(bool isActive)
 	
 	if(flagship && flagship->Hull())
 	{
-		Point shipFacingUnit = flagship->Facing().Unit();
-		info.SetSprite("player sprite", flagship->GetSprite(), shipFacingUnit);
+		if(Preferences::Has("Rotate flagship in HUD"))
+		{
+			Point shipFacingUnit = flagship->Facing().Unit();
+			info.SetSprite("player sprite", flagship->GetSprite(), shipFacingUnit);
+		}
+		else
+			info.SetSprite("player sprite", flagship->GetSprite());
 	}
 	else
 		info.SetSprite("player sprite", nullptr);

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -411,6 +411,7 @@ void PreferencesPanel::DrawSettings()
 		VIEW_ZOOM_FACTOR,
 		"Show status overlays",
 		"Highlight player's flagship",
+		"Rotate flagship in HUD",
 		"Show planet labels",
 		"Show mini-map",
 		"",


### PR DESCRIPTION
I adapted the code from the `target sprite` section, some 70 lines below.
Rotating the sprite of the flagship in the HUD helps particularly, if your escorts are "over" your flagship.