### PR TITLE
preferences for: escort harvest & mining

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -463,13 +463,14 @@ void AI::Step(const PlayerInfo &player)
 			
 			command |= AutoFire(*it);
 		}
-		if(isPresent && personality.Harvests() && DoHarvesting(*it, command))
+		if(isPresent && (personality.Harvests() || (it->IsYours() && Preferences::Has("Escorts harvest flotsam")))
+				&& DoHarvesting(*it, command))
 		{
 			it->SetCommands(command);
 			continue;
 		}
-		if(isPresent && personality.IsMining() && !target
-				&& it->Cargo().Free() >= 5 && ++miningTime[&*it] < 3600 && ++minerCount < 9)
+		if(isPresent && (personality.IsMining() || (it->IsYours() && Preferences::Has("Escorts target asteroids")))
+				&& !target && it->Cargo().Free() >= 5 && ++miningTime[&*it] < 3600 && ++minerCount < 9)
 		{
 			DoMining(*it, command);
 			it->SetCommands(command);

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -463,13 +463,13 @@ void AI::Step(const PlayerInfo &player)
 			
 			command |= AutoFire(*it);
 		}
-		if(isPresent && (personality.Harvests() || (it->IsYours() && Preferences::Has("Escorts harvest flotsam")))
+		if(isPresent && (personality.Harvests() || (it->IsYours() && !orders.count(it.get()) && Preferences::Has("Escorts harvest flotsam")))
 				&& DoHarvesting(*it, command))
 		{
 			it->SetCommands(command);
 			continue;
 		}
-		if(isPresent && (personality.IsMining() || (it->IsYours() && Preferences::Has("Escorts target asteroids")))
+		if(isPresent && (personality.IsMining() || (it->IsYours() && !orders.count(it.get()) && Preferences::Has("Escorts target asteroids")))
 				&& !target && it->Cargo().Free() >= 5 && ++miningTime[&*it] < 3600 && ++minerCount < 9)
 		{
 			DoMining(*it, command);

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -28,6 +28,10 @@ namespace {
 	map<string, bool> settings;
 	int scrollSpeed = 60;
 	
+	// Strings for automatic harvesting/mining:
+	static const string ESCORT_HARVEST = "Escorts harvest flotsam";
+	static const string ESCORT_MINING = "Escorts target asteroids";
+	
 	// Strings for ammo expenditure:
 	static const string EXPEND_AMMO = "Escorts expend ammo";
 	static const string FRUGAL_ESCORTS = "Escorts use ammo frugally";

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -103,6 +103,23 @@ void Preferences::Set(const string &name, bool on)
 
 
 
+void Preferences::ToggleEscortHarvesting()
+{
+	bool harvest = Has(ESCORT_HARVEST);
+	bool mining = Has(ESCORT_MINING);
+	Preferences::Set(ESCORT_HARVEST, !mining);
+	Preferences::Set(ESCORT_MINING, harvest && !mining);
+}
+
+
+
+string Preferences::EscortHarvesting()
+{
+	return Has(ESCORT_HARVEST) ? Has(ESCORT_MINING) ? "mine asteroids" : "harvest flotsam" : "uninterested";
+}
+
+
+
 void Preferences::ToggleAmmoUsage()
 {
 	bool expend = Has(EXPEND_AMMO);
@@ -117,6 +134,8 @@ string Preferences::AmmoUsage()
 {
 	return Has(EXPEND_AMMO) ? Has(FRUGAL_ESCORTS) ? "frugally" : "always" : "never";
 }
+
+
 
 // Scroll speed preference.
 int Preferences::ScrollSpeed()

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -25,6 +25,11 @@ public:
 	static bool Has(const std::string &name);
 	static void Set(const std::string &name, bool on = true);
 	
+	// Toogle the automatic harvesting/mining preferences, cycling between "uninterested," "harvest,"
+	// and "active mining."
+	static void ToggleEscortHarvesting();
+	static std::string EscortHarvesting();
+	
 	// Toogle the ammo usage preferences, cycling between "never," "frugally,"
 	// and "always."
 	static void ToggleAmmoUsage();

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -39,6 +39,7 @@ namespace {
 	// Settings that require special handling.
 	static const string ZOOM_FACTOR = "Main zoom factor";
 	static const string VIEW_ZOOM_FACTOR = "View zoom factor";
+	static const string ESCORT_HARVEST = "Harvest behaviour";
 	static const string EXPEND_AMMO = "Escorts expend ammo";
 	static const string FRUGAL_ESCORTS = "Escorts use ammo frugally";
 	static const string REACTIVATE_HELP = "Reactivate first-time help";
@@ -159,7 +160,9 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 				if(!Preferences::ZoomViewIn())
 					while(Preferences::ZoomViewOut()) {}
 			}
-			if(zone.Value() == EXPEND_AMMO)
+			if(zone.Value() == ESCORT_HARVEST)
+				Preferences::ToggleEscortHarvesting();
+			else if(zone.Value() == EXPEND_AMMO)
 				Preferences::ToggleAmmoUsage();
 			else if(zone.Value() == REACTIVATE_HELP)
 			{
@@ -417,15 +420,16 @@ void PreferencesPanel::DrawSettings()
 		"AI",
 		"Automatic aiming",
 		"Automatic firing",
+		ESCORT_HARVEST,
 		EXPEND_AMMO,
-		"",
+		"\n",
 		"Performance",
 		"Show CPU / GPU load",
 		"Render motion blur",
 		"Reduce large graphics",
 		"Draw background haze",
 		"Show hyperspace flash",
-		"\n",
+		"",
 		"Other",
 		REACTIVATE_HELP,
 		SCROLL_SPEED,
@@ -470,6 +474,11 @@ void PreferencesPanel::DrawSettings()
 		{
 			isOn = true;
 			text = to_string(static_cast<int>(100. * Preferences::ViewZoom()));
+		}
+		else if(setting == ESCORT_HARVEST)
+		{
+			text = Preferences::EscortHarvesting();
+			isOn = (text == "uninterested" ? false : true);
 		}
 		else if(setting == EXPEND_AMMO)
 			text = Preferences::AmmoUsage();


### PR DESCRIPTION
I added a combined preference (similar to the ammo usage) controlling whether escort ships:
- pretty much ignore flotsam (current behaviour)
- use the "harvest" personality
- use the "mining" (and the harvest!) personality.

I currently dont find where it was previously mentioned to be on a potential roadmap. I struggle getting the correct search tags to find good results.

This PR completely solves #2264.
This PR is compatible with #2384 : the setting applies only for ships (of the player, not NPCs) who dont have the proper personalities already.

This PR does not address issue #2274 - I think that it is reasonable to defer the deployment part of #2274 is deferred until in-space cargo transfer is implemented.
This PR does not solve #2355. In-space cargo transfer could help a bit, but would not solve it.

