### PR TITLE
Introduce mission condition: "weapon capacity" (total)

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2029,11 +2029,13 @@ void PlayerInfo::UpdateAutoConditions()
 	// Store special conditions for cargo and passenger space.
 	conditions["cargo space"] = 0;
 	conditions["passenger space"] = 0;
+	conditions["weapon capacity"] = 0;
 	for(const shared_ptr<Ship> &ship : ships)
 		if(!ship->IsParked() && !ship->IsDisabled() && ship->GetSystem() == system)
 		{
 			conditions["cargo space"] += ship->Attributes().Get("cargo space");
 			conditions["passenger space"] += ship->Attributes().Get("bunks") - ship->RequiredCrew();
+			conditions["weapon capacity"] += ship->BaseAttributes().Get("weapon capacity");
 			++conditions["ships: " + ship->Attributes().Category()];
 		}
 }


### PR DESCRIPTION
While "cargo space" and "passenger space" reflect civilian capacities of the players fleet, the "weapon capacity" reflects it's maximum total armament.
This can be useful for mission conditions. Particularly it is now possible to compare between "cargo space" and "weapon capacity" as a rough estimation whether the player has a rather military fleet, mostly of warships, or a rather peaceful fleet, mostly of freighters.