### PR TITLE
Make drives a bit more customizable (for modders)

### DIFF
--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -167,6 +167,7 @@ outfit "Hyperdrive"
 	"outfit space" -20
 	"jump speed" .2
 	"hyperdrive" 1
+	"hyperdrive fuel" 100
 	description "This mysterious box sits quietly at the heart of your ship, thinking its own inscrutable thoughts. When it comes time to travel between the stars it sets off a nuclear fusion reaction powerful enough to level an entire city, and then somehow tucks the resulting explosion in between the folds of regular space-time like a wasp stinging an oak leaf to lay her eggs inside. Your ship rides the resulting ripple in the fabric of space."
 	description "	They say that fewer than a dozen human beings alive today understand the inner workings of the hyperdrive."
 
@@ -176,8 +177,9 @@ outfit "Scram Drive"
 	thumbnail "outfit/hyperdrive"
 	"mass" 30
 	"outfit space" -30
-	"scram drive" .2
-	"hyperdrive" 1
+	"scram drive" 1
+	deviation .2
+	"scram fuel" 150
 	description "A Scram Drive is a specially designed hyperdrive that works even if your ship is traveling at a much higher speed, at the expense of using more fuel. If you are being pursued by pirates (or just want to get somewhere in a hurry) that extra bit of speed can make a big difference."
 
 outfit "Jump Drive"
@@ -188,6 +190,7 @@ outfit "Jump Drive"
 	"outfit space" -20
 	"jump speed" .3
 	"jump drive" 1
+	"jump fuel" 200
 	description "The workings of the Jump Drive are a total mystery. The best that human scientists have been able to find out is that this device is a containment field for matter in a state that cannot normally exist in this universe; if the drive is opened up, the field collapses and its contents disappear. Therefore, even though a few jump drives have been captured over the years, it has so far proved impossible to reverse engineer them."
 
 

--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -178,7 +178,7 @@ outfit "Scram Drive"
 	"mass" 30
 	"outfit space" -30
 	"scram drive" 1
-	deviation .2
+	"scram deviation" .2
 	"scram fuel" 150
 	description "A Scram Drive is a specially designed hyperdrive that works even if your ship is traveling at a much higher speed, at the expense of using more fuel. If you are being pursued by pirates (or just want to get somewhere in a hurry) that extra bit of speed can make a big difference."
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1275,7 +1275,7 @@ void AI::PrepareForHyperspace(Ship &ship, Command &command)
 		Point normal(-direction.Y(), direction.X());
 
 		double deviation = ship.Velocity().Dot(normal);
-		if(fabs(deviation) > ship.Attributes().Get("deviation"))
+		if(fabs(deviation) > ship.Attributes().Get("scram deviation"))
 		{
 			// Need to maneuver; not ready to jump
 			if((ship.Facing().Unit().Dot(normal) < 0) == (deviation < 0))
@@ -1293,7 +1293,7 @@ void AI::PrepareForHyperspace(Ship &ship, Command &command)
 				double correctionWhileTurning = fabs(1 - cos) * ship.Acceleration() / turnRateRadians;
 				// (Note that this will always underestimate because thrust happens before turn)
 
-				if(fabs(deviation) - correctionWhileTurning > ship.Attributes().Get("deviation"))
+				if(fabs(deviation) - correctionWhileTurning > ship.Attributes().Get("scram deviation"))
 					// Want to thrust from an even sharper angle
 					direction = -deviation * normal;
 			}

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -44,16 +44,16 @@ namespace {
 	{
 		static const Command keys(Command::LAND | Command::JUMP | Command::BOARD | Command::AFTERBURNER
 			| Command::BACK | Command::FORWARD | Command::LEFT | Command::RIGHT);
-		
+
 		return keys;
 	}
-	
+
 	bool IsStranded(const Ship &ship)
 	{
 		return ship.GetSystem() && !ship.GetSystem()->HasFuelFor(ship) && ship.JumpFuel()
 			&& ship.Attributes().Get("fuel capacity") && !ship.JumpsRemaining();
 	}
-	
+
 	bool CanBoard(const Ship &ship, const Ship &target)
 	{
 		if(&ship == &target)
@@ -64,13 +64,13 @@ namespace {
 			return true;
 		return target.IsDisabled();
 	}
-	
+
 	double AngleDiff(double a, double b)
 	{
 		a = abs(a - b);
 		return min(a, 360. - a);
 	}
-	
+
 	static const double MAX_DISTANCE_FROM_CENTER = 10000.;
 }
 
@@ -82,14 +82,14 @@ AI::AI(const List<Ship> &ships, const List<Minable> &minables, const List<Flotsa
 }
 
 
-	
+
 // Fleet commands from the player.
 void AI::IssueShipTarget(const PlayerInfo &player, const std::shared_ptr<Ship> &target)
 {
 	Orders newOrders;
 	bool isEnemy = target->GetGovernment()->IsEnemy();
 	newOrders.type = (!isEnemy ? Orders::GATHER
-		: target->IsDisabled() ? Orders::FINISH_OFF : Orders::ATTACK); 
+		: target->IsDisabled() ? Orders::FINISH_OFF : Orders::ATTACK);
 	newOrders.target = target;
 	string description = (isEnemy ? "focusing fire on" : "following") + (" \"" + target->Name() + "\".");
 	IssueOrders(player, newOrders, description);
@@ -113,7 +113,7 @@ void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 	shift = (SDL_GetModState() & KMOD_SHIFT);
 	escortsUseAmmo = Preferences::Has("Escorts expend ammo");
 	escortsAreFrugal = Preferences::Has("Escorts use ammo frugally");
-	
+
 	Command oldHeld = keyHeld;
 	keyHeld.ReadKeyboard();
 	keyStuck |= clickCommands;
@@ -140,14 +140,14 @@ void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 			keyStuck |= Command::LAND;
 		}
 	}
-	
+
 	if(!isActive || !flagship || flagship->IsDestroyed())
 		return;
-	
+
 	++landKeyInterval;
 	if(oldHeld.Has(Command::LAND))
 		landKeyInterval = 0;
-	
+
 	// Only toggle the "cloak" command if one of your ships has a cloaking device.
 	if(keyDown.Has(Command::CLOAK))
 		for(const auto &it : player.Ships())
@@ -157,15 +157,15 @@ void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 				Messages::Add(isCloaking ? "Engaging cloaking device." : "Disengaging cloaking device.");
 				break;
 			}
-	
+
 	// Toggle your secondary weapon.
 	if(keyDown.Has(Command::SELECT))
 		player.SelectNext();
-	
+
 	// The commands below here only apply if you have escorts or fighters.
 	if(player.Ships().size() < 2)
 		return;
-	
+
 	// Only toggle the "deploy" command if one of your ships has fighter bays.
 	if(keyDown.Has(Command::DEPLOY))
 		for(const auto &it : player.Ships())
@@ -175,7 +175,7 @@ void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 				Messages::Add(isLaunching ? "Deploying fighters." : "Recalling fighters.");
 				break;
 			}
-	
+
 	shared_ptr<Ship> target = flagship->GetTargetShip();
 	Orders newOrders;
 	if(keyDown.Has(Command::FIGHT) && target && !target->IsYours())
@@ -281,19 +281,19 @@ void AI::Step(const PlayerInfo &player)
 		// Only have ships update their strength estimate once per second on average.
 		if(!gov || it->GetSystem() != player.GetSystem() || it->IsDisabled() || Random::Int(60))
 			continue;
-		
+
 		int64_t &strength = shipStrength[it.get()];
 		for(const auto &oit : ships)
 		{
 			const Government *ogov = oit->GetGovernment();
 			if(!ogov || oit->GetSystem() != player.GetSystem() || oit->IsDisabled())
 				continue;
-			
+
 			if(ogov->AttitudeToward(gov) > 0. && oit->Position().Distance(it->Position()) < 2000.)
 				strength += oit->Cost();
 		}
-	}		
-	
+	}
+
 	const Ship *flagship = player.Flagship();
 	step = (step + 1) & 31;
 	int targetTurn = 0;
@@ -303,13 +303,13 @@ void AI::Step(const PlayerInfo &player)
 		// Skip any carried fighters or drones that are somehow in the list.
 		if(!it->GetSystem())
 			continue;
-		
+
 		if(it.get() == flagship)
 		{
 			MovePlayer(*it, player);
 			continue;
 		}
-		
+
 		const Government *gov = it->GetGovernment();
 		double health = .5 * it->Shields() + it->Hull();
 		bool isPresent = (it->GetSystem() == player.GetSystem());
@@ -319,7 +319,7 @@ void AI::Step(const PlayerInfo &player)
 		{
 			if(it->IsDestroyed() || it->GetPersonality().IsDerelict())
 				continue;
-			
+
 			bool hasEnemy = false;
 			Ship *firstAlly = nullptr;
 			bool selectNext = false;
@@ -334,7 +334,7 @@ void AI::Step(const PlayerInfo &player)
 				// Fighters and drones can't offer assistance.
 				if(ship->CanBeCarried())
 					continue;
-				
+
 				const Government *otherGov = ship->GetGovernment();
 				// If any enemies of this ship are in system, it cannot call for help.
 				if(otherGov->IsEnemy(gov) && isPresent)
@@ -351,12 +351,12 @@ void AI::Step(const PlayerInfo &player)
 				// Your escorts should not help each other if already under orders.
 				if(otherGov->IsPlayer() && gov->IsPlayer() && orders.count(ship.get()))
 					continue;
-				
+
 				if(it->IsDisabled() ? (otherGov == gov) : (!otherGov->IsEnemy(gov)))
 				{
 					if(isStranded && !ship->CanRefuel(*it))
 						continue;
-					
+
 					if(!firstAlly)
 						firstAlly = &*ship;
 					else if(ship == it)
@@ -365,7 +365,7 @@ void AI::Step(const PlayerInfo &player)
 						nextAlly = &*ship;
 				}
 			}
-			
+
 			isStranded = false;
 			if(!hasEnemy)
 			{
@@ -392,7 +392,7 @@ void AI::Step(const PlayerInfo &player)
 		// refuel it, that escort should hold position for boarding.
 		isStranded |= (flagship && it == flagship->GetTargetShip() && CanBoard(*flagship, *it)
 			&& keyStuck.Has(Command::BOARD));
-		
+
 		Command command;
 		if(it->IsYours())
 		{
@@ -401,11 +401,11 @@ void AI::Step(const PlayerInfo &player)
 			if(isCloaking)
 				command |= Command::CLOAK;
 		}
-		
+
 		const Personality &personality = it->GetPersonality();
 		shared_ptr<Ship> parent = it->GetParent();
 		shared_ptr<const Ship> target = it->GetTargetShip();
-		
+
 		if(isPresent && personality.IsSwarming())
 		{
 			parent.reset();
@@ -444,7 +444,7 @@ void AI::Step(const PlayerInfo &player)
 			it->SetCommands(command);
 			continue;
 		}
-		
+
 		if(isPresent && personality.IsSurveillance())
 		{
 			DoSurveillance(*it, command);
@@ -460,7 +460,7 @@ void AI::Step(const PlayerInfo &player)
 			if(targetTurn == step || !target || !target->IsTargetable() || target->IsDestroyed()
 					|| (target->IsDisabled() && personality.Disables()))
 				it->SetTargetShip(FindTarget(*it));
-			
+
 			command |= AutoFire(*it);
 		}
 		if(isPresent && personality.Harvests() && DoHarvesting(*it, command))
@@ -475,7 +475,7 @@ void AI::Step(const PlayerInfo &player)
 			it->SetCommands(command);
 			continue;
 		}
-		
+
 		// Special actions when a ship is near death:
 		if(health < 1.)
 		{
@@ -505,12 +505,12 @@ void AI::Step(const PlayerInfo &player)
 				}
 			}
 		}
-		
+
 		double targetDistance = numeric_limits<double>::infinity();
 		target = it->GetTargetShip();
 		if(target)
 			targetDistance = target->Position().Distance(it->Position());
-		
+
 		// Handle fighters:
 		const string &category = it->Attributes().Category();
 		bool isFighter = (category == "Fighter");
@@ -553,7 +553,7 @@ void AI::Step(const PlayerInfo &player)
 					break;
 				}
 			}
-		
+
 		shared_ptr<Ship> shipToAssist = it->GetShipToAssist();
 		if(shipToAssist)
 		{
@@ -571,7 +571,7 @@ void AI::Step(const PlayerInfo &player)
 			it->SetCommands(command);
 			continue;
 		}
-		
+
 		bool isPlayerEscort = it->IsYours();
 		if(mustRecall || isStranded)
 		{
@@ -619,7 +619,7 @@ void AI::Step(const PlayerInfo &player)
 		// This ship does not feel like fighting.
 		else
 			MoveEscort(*it, command);
-		
+
 		// Apply the afterburner if you're in a heated battle and it will not
 		// use up your last jump worth of fuel.
 		if(it->Attributes().Get("afterburner thrust") && target && !target->IsDisabled()
@@ -634,10 +634,10 @@ void AI::Step(const PlayerInfo &player)
 		// AI considers it appropriate.
 		if(!it->IsYours())
 			DoCloak(*it, command);
-		
+
 		// Force ships that are overlapping each other to "scatter":
 		DoScatter(*it, command);
-		
+
 		it->SetCommands(command);
 	}
 }
@@ -652,7 +652,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	const Government *gov = ship.GetGovernment();
 	if(!gov || ship.GetPersonality().IsPacifist())
 		return target;
-	
+
 	bool isPlayerEscort = ship.IsYours();
 	if(isPlayerEscort)
 	{
@@ -660,7 +660,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 		if(it != orders.end() && (it->second.type == Orders::ATTACK || it->second.type == Orders::FINISH_OFF))
 			return it->second.target.lock();
 	}
-	
+
 	// If this ship is not armed, do not make it fight.
 	double minRange = numeric_limits<double>::infinity();
 	double maxRange = 0.;
@@ -672,7 +672,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 		}
 	if(!maxRange)
 		return target;
-	
+
 	const Personality &person = ship.GetPersonality();
 	shared_ptr<Ship> oldTarget = ship.GetTargetShip();
 	if(oldTarget && !oldTarget->IsTargetable())
@@ -709,7 +709,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 			// ships to target, it will not go after anything else.
 			if(hasNemesis && !it->GetGovernment()->IsPlayer())
 				continue;
-			
+
 			// Calculate what the range will be a second from now, so that ships
 			// will prefer targets that they are headed toward.
 			double range = (it->Position() + 60. * it->Velocity()).Distance(
@@ -718,7 +718,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 			// target if they are nearby.
 			if(it == oldTarget || it == parentTarget)
 				range -= 500.;
-			
+
 			// Unless this ship is heroic, it will not chase much stronger ships
 			// unless it has strong allies nearby.
 			if(maxStrength && range > 1000. && !it->IsDisabled())
@@ -727,13 +727,13 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 				if(otherStrengthIt != shipStrength.end() && otherStrengthIt->second > maxStrength)
 					continue;
 			}
-			
+
 			// If your personality it to disable ships rather than destroy them,
 			// never target disabled ships.
 			if(it->IsDisabled() && !person.Plunders()
 					&& (person.Disables() || (!person.IsNemesis() && it != oldTarget)))
 				continue;
-			
+
 			if(!person.Plunders())
 				range += 5000. * it->IsDisabled();
 			else
@@ -763,7 +763,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 				hasNemesis = isPotentialNemesis;
 			}
 		}
-	
+
 	bool cargoScan = ship.Attributes().Get("cargo scan") || ship.Attributes().Get("cargo scan power");
 	bool outfitScan = ship.Attributes().Get("outfit scan") || ship.Attributes().Get("outfit scan power");
 	if(!target && (cargoScan || outfitScan) && !isPlayerEscort)
@@ -784,9 +784,9 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 				}
 			}
 	}
-	
+
 	// Run away if your target is not disabled and you are badly damaged.
-	if(!isDisabled && target && (person.IsFleeing() || 
+	if(!isDisabled && target && (person.IsFleeing() ||
 			(.5 * ship.Shields() + ship.Hull() < 1.
 				&& !person.IsHeroic() && !person.IsStaying() && !parentIsEnemy)))
 	{
@@ -809,7 +809,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 		if(target && target->Cloaking() == 1.)
 			target.reset();
 	}
-	
+
 	return target;
 }
 
@@ -820,9 +820,9 @@ bool AI::FollowOrders(Ship &ship, Command &command) const
 	auto it = orders.find(&ship);
 	if(it == orders.end())
 		return false;
-	
+
 	int type = it->second.type;
-	
+
 	// If your parent is jumping or absent, that overrides your orders unless
 	// your orders are to hold position.
 	shared_ptr<Ship> parent = ship.GetParent();
@@ -833,7 +833,7 @@ bool AI::FollowOrders(Ship &ship, Command &command) const
 		if(parent->Commands().Has(Command::JUMP) && ship.JumpsRemaining())
 			return false;
 	}
-	
+
 	shared_ptr<Ship> target = it->second.target.lock();
 	if(type == Orders::MOVE_TO && ship.Position().Distance(it->second.point) > 20.)
 		MoveTo(ship, command, it->second.point, Point(), 10., .1);
@@ -856,7 +856,7 @@ bool AI::FollowOrders(Ship &ship, Command &command) const
 		CircleAround(ship, command, *target);
 	else
 		MoveIndependent(ship, command);
-	
+
 	return true;
 }
 
@@ -913,7 +913,7 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		}
 		return;
 	}
-	
+
 	// If this ship is moving independently because it has a target, not because
 	// it has no parent, don't let it make travel plans.
 	if(ship.GetParent() && !ship.GetPersonality().IsStaying())
@@ -922,14 +922,14 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 			Refuel(ship, command);
 		return;
 	}
-	
+
 	if(!ship.GetTargetSystem() && !ship.GetTargetStellar() && !ship.GetPersonality().IsStaying())
 	{
 		int jumps = ship.JumpsRemaining();
 		// Each destination system has an average priority of 10.
 		// If you only have one jump left, landing should be high priority.
 		int planetWeight = jumps ? (1 + 40 / jumps) : 1;
-		
+
 		vector<int> systemWeights;
 		int totalWeight = 0;
 		const vector<const System *> &links = ship.Attributes().Get("jump drive")
@@ -942,13 +942,13 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 				Point direction = link->Position() - ship.GetSystem()->Position();
 				int weight = static_cast<int>(
 					11. + 10. * ship.Facing().Unit().Dot(direction.Unit()));
-				
+
 				systemWeights.push_back(weight);
 				totalWeight += weight;
 			}
 		}
 		int systemTotalWeight = totalWeight;
-		
+
 		// Anywhere you can land that has a port has the same weight. Ships will
 		// not land anywhere without a port.
 		vector<const StellarObject *> planets;
@@ -968,7 +968,7 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 			totalWeight = 1;
 			planets.push_back(&ship.GetSystem()->Objects().front());
 		}
-		
+
 		int choice = Random::Int(totalWeight);
 		if(choice < systemTotalWeight)
 		{
@@ -988,7 +988,7 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 			ship.SetTargetStellar(planets[choice]);
 		}
 	}
-	
+
 	if(ship.GetTargetSystem())
 	{
 		PrepareForHyperspace(ship, command);
@@ -999,7 +999,7 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 				shared_ptr<const Ship> locked = escort.lock();
 				mustWait |= locked && locked->CanBeCarried() && !locked->IsDisabled();
 			}
-		
+
 		if(!mustWait)
 			command |= Command::JUMP;
 	}
@@ -1035,7 +1035,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 		Refuel(ship, command);
 	else if(!parentIsHere && !isStaying)
 	{
-		if(!ship.HyperspaceType() && !ship.GetTargetStellar())
+		if(ship.HyperspaceTypes() == Ship::NONE && !ship.GetTargetStellar())
 		{
 			// If we're stranded and haven't decided where to go, figure out a
 			// path to the parent ship's system.
@@ -1050,7 +1050,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 				}
 			ship.SetTargetSystem(to);
 			// Check if we need to refuel. Wormhole travel does not require fuel.
-			if(!ship.GetTargetStellar() && (!to || 
+			if(!ship.GetTargetStellar() && (!to ||
 					(from->HasFuelFor(ship) && !to->HasFuelFor(ship) && ship.JumpsRemaining() == 1)))
 				Refuel(ship, command);
 		}
@@ -1127,17 +1127,17 @@ bool AI::CanRefuel(const Ship &ship, const StellarObject *target)
 {
 	if(!target)
 		return false;
-	
+
 	const Planet *planet = target->GetPlanet();
 	if(!planet)
 		return false;
-	
+
 	if(!planet->IsInSystem(ship.GetSystem()))
 		return false;
-	
+
 	if(!planet->HasSpaceport() || planet->IsWormhole() || !planet->CanLand(ship))
 		return false;
-	
+
 	return true;
 }
 
@@ -1154,14 +1154,14 @@ double AI::TurnToward(const Ship &ship, const Point &vector)
 {
 	Point facing = ship.Facing().Unit();
 	double cross = vector.Cross(facing);
-	
+
 	if(vector.Dot(facing) > 0.)
 	{
 		double angle = asin(min(1., max(-1., cross / vector.Length()))) * TO_DEG;
 		if(fabs(angle) <= ship.TurnRate())
 			return -angle / ship.TurnRate();
 	}
-	
+
 	bool left = cross < 0.;
 	return left - !left;
 }
@@ -1172,7 +1172,7 @@ bool AI::MoveToPlanet(Ship &ship, Command &command)
 {
 	if(!ship.GetTargetStellar())
 		return false;
-	
+
 	const Point &target = ship.GetTargetStellar()->Position();
 	return MoveTo(ship, command, target, Point(), ship.GetTargetStellar()->Radius(), 1.);
 }
@@ -1187,13 +1187,13 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition, const
 	const Angle &angle = ship.Facing();
 	Point dp = targetPosition - position;
 	Point dv = targetVelocity - velocity;
-	
+
 	double speed = dv.Length();
-	
+
 	bool isClose = (dp.Length() < radius);
 	if(isClose && speed < slow)
 		return true;
-	
+
 	bool shouldReverse = false;
 	dp = targetPosition - StoppingPoint(ship, targetVelocity, shouldReverse);
 	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .8);
@@ -1203,7 +1203,7 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition, const
 		command |= Command::FORWARD;
 	else if(shouldReverse)
 		command |= Command::BACK;
-	
+
 	return false;
 }
 
@@ -1213,15 +1213,15 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed)
 {
 	const Point &velocity = ship.Velocity();
 	const Angle &angle = ship.Facing();
-	
+
 	double speed = velocity.Length();
-	
+
 	// If asked for a complete stop, the ship needs to be going much slower.
 	if(speed <= (maxSpeed ? maxSpeed : .001))
 		return true;
 	if(!maxSpeed)
 		command |= Command::STOP;
-	
+
 	// If you're moving slow enough that one frame of acceleration could bring
 	// you to a stop, make sure you're pointed perfectly in the right direction.
 	// This is a fudge factor for how straight you must be facing: it increases
@@ -1229,7 +1229,7 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed)
 	// take less than 1 frame to stop.
 	double stopTime = speed / ship.Acceleration();
 	double limit = .8 + .2 / (1. + stopTime * stopTime * stopTime * .001);
-	
+
 	// If you have a reverse thruster, figure out whether using it is faster
 	// than turning around and using your main thruster.
 	if(ship.Attributes().Get("reverse thrust"))
@@ -1238,12 +1238,12 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed)
 		double degreesToTurn = TO_DEG * acos(min(1., max(-1., -velocity.Unit().Dot(angle.Unit()))));
 		double forwardTime = degreesToTurn / ship.TurnRate();
 		forwardTime += stopTime;
-		
+
 		// Figure out your reverse thruster stopping time:
 		double reverseAcceleration = ship.Attributes().Get("reverse thrust") / ship.Mass();
 		double reverseTime = (180. - degreesToTurn) / ship.TurnRate();
 		reverseTime += speed / reverseAcceleration;
-		
+
 		if(reverseTime < forwardTime)
 		{
 			command.SetTurn(TurnToward(ship, velocity));
@@ -1252,11 +1252,11 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed)
 			return false;
 		}
 	}
-	
+
 	command.SetTurn(TurnBackward(ship));
 	if(velocity.Unit().Dot(angle.Unit()) < -limit)
 		command |= Command::FORWARD;
-	
+
 	return false;
 }
 
@@ -1264,18 +1264,18 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed)
 
 void AI::PrepareForHyperspace(Ship &ship, Command &command)
 {
-	int type = ship.HyperspaceType();
-	if(!type)
+	Ship::JumpType type = ship.HyperspaceType();
+	if(type == Ship::NONE)
 		return;
-	
+
 	Point direction = ship.GetTargetSystem()->Position() - ship.GetSystem()->Position();
-	if(type == 150)
+	if(type == Ship::SCRAM)
 	{
 		direction = direction.Unit();
 		Point normal(-direction.Y(), direction.X());
-		
+
 		double deviation = ship.Velocity().Dot(normal);
-		if(fabs(deviation) > ship.Attributes().Get("scram drive"))
+		if(fabs(deviation) > ship.Attributes().Get("deviation"))
 		{
 			// Need to maneuver; not ready to jump
 			if((ship.Facing().Unit().Dot(normal) < 0) == (deviation < 0))
@@ -1284,7 +1284,7 @@ void AI::PrepareForHyperspace(Ship &ship, Command &command)
 			else
 			{
 				command |= Command::FORWARD;
-				
+
 				// How much correction will be applied to deviation by thrusting
 				// as I turn back toward the jump direction.
 				double turnRateRadians = ship.TurnRate() * TO_RAD;
@@ -1292,8 +1292,8 @@ void AI::PrepareForHyperspace(Ship &ship, Command &command)
 				// integral(t*sin(r*x), angle/r, 0) = t/r * (1 - cos(angle)), so:
 				double correctionWhileTurning = fabs(1 - cos) * ship.Acceleration() / turnRateRadians;
 				// (Note that this will always underestimate because thrust happens before turn)
-				
-				if(fabs(deviation) - correctionWhileTurning > ship.Attributes().Get("scram drive"))
+
+				if(fabs(deviation) - correctionWhileTurning > ship.Attributes().Get("deviation"))
 					// Want to thrust from an even sharper angle
 					direction = -deviation * normal;
 			}
@@ -1303,13 +1303,13 @@ void AI::PrepareForHyperspace(Ship &ship, Command &command)
 	// If we are moving too fast, point in the right direction.
 	else if(Stop(ship, command, ship.Attributes().Get("jump speed")))
 	{
-		if(type != 200)
+		if(type != Ship::JUMP)
 			command.SetTurn(TurnToward(ship, direction));
 	}
 }
 
 
-	
+
 void AI::CircleAround(Ship &ship, Command &command, const Ship &target)
 {
 	Point direction = target.Position() - ship.Position();
@@ -1319,7 +1319,7 @@ void AI::CircleAround(Ship &ship, Command &command, const Ship &target)
 }
 
 
-	
+
 void AI::Swarm(Ship &ship, Command &command, const Ship &target)
 {
 	Point direction = target.Position() - ship.Position();
@@ -1341,7 +1341,7 @@ void AI::KeepStation(Ship &ship, Command &command, const Ship &target)
 	static const double VELOCITY_DEADBAND = 1.5;
 	static const double TIME_DEADBAND = 120.;
 	static const double THRUST_DEADBAND = .5;
-	
+
 	// Current properties of the two ships:
 	double maxV = ship.MaxVelocity();
 	double accel = ship.Acceleration();
@@ -1358,7 +1358,7 @@ void AI::KeepStation(Ship &ship, Command &command, const Ship &target)
 	velocityDelta -= unit * VELOCITY_DEADBAND;
 	double velocitySize = velocityDelta.Length();
 	double velocityWeight = velocitySize / (velocitySize + VELOCITY_DEADBAND);
-	
+
 	// Time it will take (roughly) to move to the target ship:
 	double positionTime = Armament::RendezvousTime(positionDelta, target.Velocity(), maxV);
 	if(positionTime != positionTime || positionTime > MAX_TIME)
@@ -1369,20 +1369,20 @@ void AI::KeepStation(Ship &ship, Command &command, const Ship &target)
 	positionTime += (rendezvous.Unit() * maxV - ship.Velocity()).Length() / accel;
 	// If you are very close, stop trying to adjust:
 	positionTime *= positionWeight * positionWeight;
-	
+
 	// Time it will take (roughly) to adjust your velocity to match the target:
 	double velocityTime = velocityDelta.Length() / accel;
 	double velocityAngle = Angle(velocityDelta).Degrees();
 	velocityTime += AngleDiff(currentAngle, velocityAngle) / turn;
 	// If you are very close, stop trying to adjust:
 	velocityTime *= velocityWeight * velocityWeight;
-	
+
 	// Focus on matching position or velocity depending on which will take longer.
 	double totalTime = positionTime + velocityTime + TIME_DEADBAND;
 	positionWeight = positionTime / totalTime;
 	velocityWeight = velocityTime / totalTime;
 	double facingWeight = TIME_DEADBAND / totalTime;
-	
+
 	// Determine the angle we want to face, interpolating smoothly between three options.
 	Point facingGoal = rendezvous.Unit() * positionWeight
 		+ velocityDelta.Unit() * velocityWeight
@@ -1394,7 +1394,7 @@ void AI::KeepStation(Ship &ship, Command &command, const Ship &target)
 		command.SetTurn(targetAngle / turn);
 	else
 		command.SetTurn(targetAngle < 0. ? -1. : 1.);
-	
+
 	// Determine whether to apply thrust.
 	Point drag = ship.Velocity() * (ship.Attributes().Get("drag") / mass);
 	if(ship.Attributes().Get("reverse thrust"))
@@ -1445,7 +1445,7 @@ void AI::Attack(Ship &ship, Command &command, const Ship &target)
 	// they are trying to hunt down and kill the last missile boat in a fleet.
 	if(isArmed && !hasAmmo)
 		shortestRange = 0.;
-	
+
 	// Deploy any fighters you are carrying.
 	if(!ship.IsYours())
 		command |= Command::DEPLOY;
@@ -1459,25 +1459,25 @@ void AI::Attack(Ship &ship, Command &command, const Ship &target)
 			command |= Command::FORWARD;
 		return;
 	}
-	
+
 	MoveToAttack(ship, command, target);
 }
 
 
-	
+
 void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 {
 	Point d = target.Position() - ship.Position();
-	
+
 	// First of all, aim in the direction that will hit this target.
 	command.SetTurn(TurnToward(ship, TargetAim(ship, target)));
-	
+
 	// Calculate this ship's "turning radius; that is, the smallest circle it
 	// can make while at full speed.
 	double stepsInFullTurn = 360. / ship.TurnRate();
 	double circumference = stepsInFullTurn * ship.Velocity().Length();
 	double diameter = max(200., circumference / PI);
-	
+
 	// This isn't perfect, but it works well enough.
 	if((ship.Facing().Unit().Dot(d) >= 0. && d.Length() > diameter)
 			|| (ship.Velocity().Dot(d) < 0. && ship.Facing().Unit().Dot(d.Unit()) >= .9))
@@ -1492,7 +1492,7 @@ void AI::PickUp(Ship &ship, Command &command, const Body &target)
 	Point p = target.Position() - ship.Position();
 	Point v = target.Velocity() - ship.Velocity();
 	double vMax = ship.MaxVelocity();
-	
+
 	// Estimate where the target will be by the time we reach it.
 	double time = Armament::RendezvousTime(p, v, vMax);
 	if(std::isnan(time))
@@ -1500,7 +1500,7 @@ void AI::PickUp(Ship &ship, Command &command, const Body &target)
 	double degreesToTurn = TO_DEG * acos(min(1., max(-1., p.Unit().Dot(ship.Facing().Unit()))));
 	time += degreesToTurn / ship.TurnRate();
 	p += v * time;
-	
+
 	// Move toward the target.
 	command.SetTurn(TurnToward(ship, p));
 	if(p.Unit().Dot(ship.Facing().Unit()) > .7)
@@ -1520,13 +1520,13 @@ void AI::DoSurveillance(Ship &ship, Command &command) const
 		command |= AutoFire(ship);
 		return;
 	}
-	
+
 	bool cargoScan = ship.Attributes().Get("cargo scan") || ship.Attributes().Get("cargo scan power");
 	bool outfitScan = ship.Attributes().Get("outfit scan") || ship.Attributes().Get("outfit scan power");
 	double atmosphereScan = ship.Attributes().Get("atmosphere scan");
 	bool jumpDrive = ship.Attributes().Get("jump drive");
-	bool hyperdrive = ship.Attributes().Get("hyperdrive");
-	
+	bool hyperdrive = ship.Attributes().Get("hyperdrive") || ship.Attributes().Get("scram drive");
+
 	// This function is only called for ships that are in the player's system.
 	if(ship.GetTargetSystem())
 	{
@@ -1565,11 +1565,11 @@ void AI::DoSurveillance(Ship &ship, Command &command) const
 			ship.SetTargetShip(newTarget);
 			return;
 		}
-		
+
 		vector<shared_ptr<Ship>> targetShips;
 		vector<const StellarObject *> targetPlanets;
 		vector<const System *> targetSystems;
-		
+
 		if(cargoScan || outfitScan)
 			for(const auto &it : ships)
 				if(it->GetGovernment() != ship.GetGovernment() && it->IsTargetable()
@@ -1577,15 +1577,15 @@ void AI::DoSurveillance(Ship &ship, Command &command) const
 				{
 					if(Has(ship, it, ShipEvent::SCAN_CARGO) && Has(ship, it, ShipEvent::SCAN_OUTFITS))
 						continue;
-				
+
 					targetShips.push_back(it);
 				}
-		
+
 		if(atmosphereScan)
 			for(const StellarObject &object : ship.GetSystem()->Objects())
 				if(!object.IsStar() && object.Radius() < 130.)
 					targetPlanets.push_back(&object);
-		
+
 		bool canJump = (ship.JumpsRemaining() != 0);
 		if(jumpDrive && canJump)
 			for(const System *link : ship.GetSystem()->Neighbors())
@@ -1593,7 +1593,7 @@ void AI::DoSurveillance(Ship &ship, Command &command) const
 		else if(hyperdrive && canJump)
 			for(const System *link : ship.GetSystem()->Links())
 				targetSystems.push_back(link);
-		
+
 		unsigned total = targetShips.size() + targetPlanets.size() + targetSystems.size();
 		if(!total)
 		{
@@ -1602,7 +1602,7 @@ void AI::DoSurveillance(Ship &ship, Command &command) const
 			Stop(ship, command);
 			return;
 		}
-		
+
 		unsigned index = Random::Int(total);
 		if(index < targetShips.size())
 			ship.SetTargetShip(targetShips[index]);
@@ -1629,7 +1629,7 @@ void AI::DoMining(Ship &ship, Command &command)
 		angle = Angle::Random();
 	angle += Angle::Random(1.) - Angle::Random(1.);
 	double miningRadius = ship.GetSystem()->AsteroidBelt() * pow(2., angle.Unit().X());
-	
+
 	shared_ptr<Minable> target = ship.GetTargetAsteroid();
 	if(!target)
 	{
@@ -1650,7 +1650,7 @@ void AI::DoMining(Ship &ship, Command &command)
 		command |= AutoFire(ship, *target);
 		return;
 	}
-	
+
 	Point heading = Angle(30.).Rotate(ship.Position().Unit() * miningRadius) - ship.Position();
 	command.SetTurn(TurnToward(ship, heading));
 	if(ship.Velocity().Dot(heading.Unit()) < .7 * ship.MaxVelocity())
@@ -1670,7 +1670,7 @@ bool AI::DoHarvesting(Ship &ship, Command &command)
 		// Only check for new targets every 10 frames, on average.
 		if(Random::Int(10))
 			return false;
-		
+
 		// Don't chase anything that will take more than 10 seconds to reach.
 		double bestTime = 600.;
 		for(const shared_ptr<Flotsam> &it : flotsam)
@@ -1682,14 +1682,14 @@ bool AI::DoHarvesting(Ship &ship, Command &command)
 			double range = p.Length();
 			if(range > 800. || (range > 100. && p.Unit().Dot(ship.Facing().Unit()) < .9))
 				continue;
-			
+
 			// Estimate how long it would take to intercept this flotsam.
 			Point v = it->Velocity() - ship.Velocity();
 			double vMax = ship.MaxVelocity();
 			double time = Armament::RendezvousTime(p, v, vMax);
 			if(std::isnan(time))
 				continue;
-			
+
 			double degreesToTurn = TO_DEG * acos(min(1., max(-1., p.Unit().Dot(ship.Facing().Unit()))));
 			time += degreesToTurn / ship.TurnRate();
 			if(time < bestTime)
@@ -1700,10 +1700,10 @@ bool AI::DoHarvesting(Ship &ship, Command &command)
 		}
 		if(!target)
 			return false;
-		
+
 		ship.SetTargetFlotsam(target);
 	}
-	
+
 	PickUp(ship, command, *target);
 	return true;
 }
@@ -1731,7 +1731,7 @@ void AI::DoCloak(Ship &ship, Command &command)
 					&& !other->IsDisabled())
 				nearestEnemy = min(nearestEnemy,
 					ship.Position().Distance(other->Position()));
-		
+
 		// If this ship has started cloaking, it must get at least 40% repaired
 		// or 40% farther away before it begins decloaking again.
 		double hysteresis = ship.Cloaking() ? 1.4 : 1.;
@@ -1739,7 +1739,7 @@ void AI::DoCloak(Ship &ship, Command &command)
 		if(ship.Hull() + .5 * ship.Shields() < hysteresis
 				&& (cloakIsFree || nearestEnemy < 2000. * hysteresis))
 			command |= Command::CLOAK;
-		
+
 		// Also cloak if there are no enemies nearby and cloaking does
 		// not cost you fuel.
 		if(nearestEnemy == MAX_RANGE && cloakIsFree && !ship.GetTargetShip())
@@ -1753,14 +1753,14 @@ void AI::DoScatter(Ship &ship, Command &command)
 {
 	if(!command.Has(Command::FORWARD))
 		return;
-	
+
 	double turnRate = ship.TurnRate();
 	double acceleration = ship.Acceleration();
 	for(const shared_ptr<Ship> &other : ships)
 	{
 		if(other.get() == &ship)
 			continue;
-		
+
 		// Check for any ships that have nearly the same movement profile as
 		// this ship and are in nearly the same location.
 		Point offset = other->Position() - ship.Position();
@@ -1770,7 +1770,7 @@ void AI::DoScatter(Ship &ship, Command &command)
 			continue;
 		if(fabs(other->Acceleration() / acceleration - 1.) > .05)
 			continue;
-		
+
 		// Move away from this ship. What side of me is it on?
 		command.SetTurn(offset.Cross(ship.Facing().Unit()) > 0. ? 1. : -1.);
 		return;
@@ -1788,12 +1788,12 @@ Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &sho
 	double acceleration = ship.Acceleration();
 	double turnRate = ship.TurnRate();
 	shouldReverse = false;
-	
+
 	// If I were to turn around and stop now the relative movement, where would that put me?
 	double v = velocity.Length();
 	if(!v)
 		return position;
-	
+
 	// This assumes you're facing exactly the wrong way.
 	double degreesToTurn = TO_DEG * acos(min(1., max(-1., -velocity.Unit().Dot(angle.Unit()))));
 	double stopDistance = v * (degreesToTurn / turnRate);
@@ -1801,21 +1801,21 @@ Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &sho
 	// The number of terms will be v / a.
 	// The average term's value will be v / 2. So:
 	stopDistance += .5 * v * v / acceleration;
-	
+
 	if(ship.Attributes().Get("reverse thrust"))
 	{
 		// Figure out your reverse thruster stopping distance:
 		double reverseAcceleration = ship.Attributes().Get("reverse thrust") / ship.Mass();
 		double reverseDistance = v * (180. - degreesToTurn) / turnRate;
 		reverseDistance += .5 * v * v / reverseAcceleration;
-		
+
 		if(reverseDistance < stopDistance)
 		{
 			shouldReverse = true;
 			stopDistance = reverseDistance;
 		}
 	}
-	
+
 	return position + stopDistance * velocity.Unit();
 }
 
@@ -1841,21 +1841,21 @@ Point AI::TargetAim(const Ship &ship, const Body &target)
 		const Outfit *outfit = weapon.GetOutfit();
 		if(!outfit || weapon.IsHoming() || weapon.IsTurret())
 			continue;
-		
+
 		Point start = ship.Position() + ship.Facing().Rotate(weapon.GetPoint());
 		Point p = target.Position() - start + ship.GetPersonality().Confusion();
 		Point v = target.Velocity() - ship.Velocity();
 		double steps = Armament::RendezvousTime(p, v, outfit->Velocity() + .5 * outfit->RandomVelocity());
 		if(!(steps == steps))
 			continue;
-		
+
 		steps = min(steps, outfit->TotalLifetime());
 		p += steps * v;
-		
+
 		double damage = outfit->ShieldDamage() + outfit->HullDamage();
 		result += p.Unit() * abs(damage);
 	}
-	
+
 	return result ? result : target.Position() - ship.Position();
 }
 
@@ -1868,7 +1868,7 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 	if(ship.GetPersonality().IsPacifist())
 		return command;
 	int index = -1;
-	
+
 	bool beFrugal = (ship.IsYours() && !escortsUseAmmo);
 	if(ship.GetPersonality().IsFrugal() || (ship.IsYours() && escortsAreFrugal && escortsUseAmmo))
 	{
@@ -1880,7 +1880,7 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 		if(ait != allyStrength.end() && eit != enemyStrength.end() && ait->second < eit->second)
 			beFrugal = false;
 	}
-	
+
 	// Special case: your target is not your enemy. Do not fire, because you do
 	// not want to risk damaging that target. The only time a ship other than
 	// the player will target a friendly ship is if the player has asked a ship
@@ -1903,10 +1903,10 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 		&& currentTarget->GetSystem() == ship.GetSystem();
 	if(currentTarget && !(currentIsEnemy || friendlyOverride))
 		currentTarget.reset();
-	
+
 	// Only fire on disabled targets if you don't want to plunder them.
 	bool spareDisabled = (ship.GetPersonality().Disables() || ship.GetPersonality().Plunders());
-	
+
 	// Find the longest range of any of your non-homing weapons.
 	double maxRange = 0.;
 	for(const Hardpoint &weapon : ship.Weapons())
@@ -1914,7 +1914,7 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 			maxRange = max(maxRange, weapon.GetOutfit()->Range());
 	// Extend the weapon range slightly to account for velocity differences.
 	maxRange *= 1.5;
-	
+
 	// Find all enemy ships within range of at least one weapon.
 	vector<shared_ptr<const Ship>> enemies;
 	if(currentTarget)
@@ -1926,7 +1926,7 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 				&& target->Position().Distance(ship.Position()) < maxRange
 				&& target != currentTarget)
 			enemies.push_back(target);
-	
+
 	for(const Hardpoint &weapon : ship.Weapons())
 	{
 		++index;
@@ -1938,7 +1938,7 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 			continue;
 		if(beFrugal && weapon.GetOutfit()->Ammo())
 			continue;
-		
+
 		// Special case: if the weapon uses fuel, be careful not to spend so much
 		// fuel that you cannot leave the system if necessary.
 		if(weapon.GetOutfit()->FiringFuel())
@@ -1955,11 +1955,11 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 		// depending on how accurate this ship's pilot is.
 		Point start = ship.Position() + ship.Facing().Rotate(weapon.GetPoint());
 		start += ship.GetPersonality().Confusion();
-		
+
 		const Outfit *outfit = weapon.GetOutfit();
 		double vp = outfit->Velocity() + .5 * outfit->RandomVelocity();
 		double lifetime = outfit->TotalLifetime();
-		
+
 		if(currentTarget && (weapon.IsHoming() || weapon.IsTurret()))
 		{
 			bool hasBoarded = Has(ship, currentTarget, ShipEvent::BOARD);
@@ -1972,16 +1972,16 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 			// Don't fire secondary weapons as targets that have started jumping.
 			if(outfit->Icon() && currentTarget->IsEnteringHyperspace())
 				continue;
-			
+
 			Point p = currentTarget->Position() - start;
 			Point v = currentTarget->Velocity() - ship.Velocity();
 			// By the time this action is performed, the ships will have moved
 			// forward one time step.
 			p += v;
-			
+
 			if(p.Length() < outfit->BlastRadius())
 				continue;
-			
+
 			// If this is a homing weapon, it is not necessary to take the
 			// velocity of the ship firing it into account.
 			if(weapon.IsHoming())
@@ -1997,25 +1997,25 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 		// Don't fire homing weapons with no target.
 		if(weapon.IsHoming())
 			continue;
-		
+
 		for(const shared_ptr<const Ship> &target : enemies)
 		{
 			// Don't shoot ships we want to plunder.
 			bool hasBoarded = Has(ship, target, ShipEvent::BOARD);
 			if(target->IsDisabled() && spareDisabled && !hasBoarded && !disabledOverride)
 				continue;
-			
+
 			Point p = target->Position() - start;
 			Point v = target->Velocity() - ship.Velocity();
 			// By the time this action is performed, the ships will have moved
 			// forward one time step.
 			p += v;
-			
+
 			// Get the vector the weapon will travel along.
 			v = (ship.Facing() + weapon.GetAngle()).Unit() * vp - v;
 			// Extrapolate over the lifetime of the projectile.
 			v *= lifetime;
-			
+
 			const Mask &mask = target->GetMask(step);
 			if(mask.Collide(-p, v, target->Facing()) < 1.)
 			{
@@ -2024,7 +2024,7 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 			}
 		}
 	}
-	
+
 	return command;
 }
 
@@ -2033,7 +2033,7 @@ Command AI::AutoFire(const Ship &ship, bool secondary) const
 Command AI::AutoFire(const Ship &ship, const Body &target) const
 {
 	Command command;
-	
+
 	int index = -1;
 	for(const Hardpoint &weapon : ship.Weapons())
 	{
@@ -2041,27 +2041,27 @@ Command AI::AutoFire(const Ship &ship, const Body &target) const
 		// Only auto-fire primary weapons that take no ammunition.
 		if(!weapon.IsReady() || weapon.GetOutfit()->Icon() || weapon.GetOutfit()->Ammo())
 			continue;
-		
+
 		// Figure out where this weapon will fire from, but add some randomness
 		// depending on how accurate this ship's pilot is.
 		Point start = ship.Position() + ship.Facing().Rotate(weapon.GetPoint());
 		start += ship.GetPersonality().Confusion();
-		
+
 		const Outfit *outfit = weapon.GetOutfit();
 		double vp = outfit->Velocity();
 		double lifetime = outfit->TotalLifetime();
-		
+
 		Point p = target.Position() - start;
 		Point v = target.Velocity() - ship.Velocity();
 		// By the time this action is performed, the ships will have moved
 		// forward one time step.
 		p += v;
-		
+
 		// Get the vector the weapon will travel along.
 		v = (ship.Facing() + weapon.GetAngle()).Unit() * vp - v;
 		// Extrapolate over the lifetime of the projectile.
 		v *= lifetime;
-		
+
 		const Mask &mask = target.GetMask(step);
 		if(mask.Collide(-p, v, target.Facing()) < 1.)
 			command.SetFire(index);
@@ -2074,7 +2074,7 @@ Command AI::AutoFire(const Ship &ship, const Body &target) const
 void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 {
 	Command command;
-	
+
 	bool isWormhole = false;
 	if(player.HasTravelPlan())
 	{
@@ -2102,7 +2102,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 			// Don't include invisible missions in the check.
 			if(!mission.IsVisible())
 				continue;
-			
+
 			if(mission.Destination() && mission.Destination()->IsInSystem(system))
 			{
 				destinations.insert(mission.Destination());
@@ -2128,7 +2128,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		// Special case: the player has manually specified a destination.
 		if(player.TravelDestination() && player.TravelDestination()->IsInSystem(system))
 			bestDestination = player.TravelDestination();
-		
+
 		// Inform the player of any destinations in the system they are jumping to.
 		if(!destinations.empty())
 		{
@@ -2159,7 +2159,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		}
 	}
 	wasHyperspacing = ship.IsEnteringHyperspace();
-	
+
 	if(keyDown.Has(Command::NEAREST))
 	{
 		double closest = numeric_limits<double>::infinity();
@@ -2176,11 +2176,11 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 				// ships as soon as the last one is gone.
 				if((!state && !shift) || other->GetGovernment()->IsPlayer())
 					continue;
-				
+
 				state += state * !other->IsDisabled();
-				
+
 				double d = other->Position().Distance(ship.Position());
-				
+
 				if(state > closeState || (state == closeState && d < closest))
 				{
 					ship.SetTargetShip(other);
@@ -2215,7 +2215,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		{
 			if(shift)
 				ship.SetTargetShip(shared_ptr<Ship>());
-			
+
 			double closest = numeric_limits<double>::infinity();
 			bool foundEnemy = false;
 			bool foundAnything = false;
@@ -2224,7 +2224,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 				{
 					if(shift && !other->IsYours())
 						continue;
-					
+
 					bool isEnemy = other->GetGovernment()->IsEnemy(ship.GetGovernment());
 					double d = other->Position().Distance(ship.Position());
 					if((isEnemy && !foundEnemy) || (d < closest && isEnemy == foundEnemy))
@@ -2253,7 +2253,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 			}
 		if(!message.empty())
 			Audio::Play(Audio::Get("fail"));
-		
+
 		const StellarObject *target = ship.GetTargetStellar();
 		if(target && ship.Position().Distance(target->Position()) < target->Radius())
 		{
@@ -2288,7 +2288,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 					}
 			}
 			ship.SetTargetStellar(next);
-			
+
 			if(next->GetPlanet() && !next->GetPlanet()->CanLand())
 			{
 				message = "The authorities on this " + ship.GetTargetStellar()->GetPlanet()->Noun() +
@@ -2314,7 +2314,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 						const Planet *planet = object.GetPlanet();
 						if((!planet->CanLand() || !planet->HasSpaceport()) && !planet->IsWormhole())
 							distance += 10000.;
-					
+
 						if(distance < closest)
 						{
 							ship.SetTargetStellar(&object);
@@ -2379,13 +2379,13 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 			string name = "selected star";
 			if(player.KnowsName(ship.GetTargetSystem()))
 				name = ship.GetTargetSystem()->Name();
-			
+
 			Messages::Add("Engaging autopilot to jump to the " + name + " system.");
 		}
 	}
 	else if(keyHeld.Has(Command::SCAN))
 		command |= Command::SCAN;
-	
+
 	bool hasGuns = Preferences::Has("Automatic firing") && !ship.IsBoarding()
 		&& !(keyStuck | keyHeld).Has(Command::LAND | Command::JUMP | Command::BOARD)
 		&& (!ship.GetTargetShip() || ship.GetTargetShip()->GetGovernment()->IsEnemy());
@@ -2403,7 +2403,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 			else
 				command.SetTurn(TurnBackward(ship));
 		}
-		
+
 		if(keyHeld.Has(Command::FORWARD))
 			command |= Command::FORWARD;
 		if(keyHeld.Has(Command::PRIMARY))
@@ -2433,7 +2433,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		}
 		if(keyHeld.Has(Command::AFTERBURNER))
 			command |= Command::AFTERBURNER;
-		
+
 		if(keyHeld.Has(AutopilotCancelKeys()))
 			keyStuck = keyHeld;
 	}
@@ -2446,7 +2446,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		if(distance.Unit().Dot(ship.Facing().Unit()) >= .8)
 			command.SetTurn(TurnToward(ship, TargetAim(ship)));
 	}
-	
+
 	// Clear "stuck" keys if actions can't be performed.
 	if(keyStuck.Has(Command::LAND) && !ship.GetTargetStellar())
 		keyStuck.Clear(Command::LAND);
@@ -2454,7 +2454,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		keyStuck.Clear(Command::JUMP);
 	if(keyStuck.Has(Command::BOARD) && !ship.GetTargetShip())
 		keyStuck.Clear(Command::BOARD);
-	
+
 	if(ship.IsBoarding())
 		keyStuck.Clear();
 	else if(keyStuck.Has(Command::LAND) || (keyStuck.Has(Command::JUMP) && isWormhole))
@@ -2469,13 +2469,13 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 	}
 	else if(keyStuck.Has(Command::JUMP))
 	{
-		if(!ship.Attributes().Get("hyperdrive") && !ship.Attributes().Get("jump drive"))
+		if(!ship.Attributes().Get("hyperdrive") && !ship.Attributes().Get("scram drive") && !ship.Attributes().Get("jump drive"))
 		{
 			Messages::Add("You do not have a hyperdrive installed.");
 			keyStuck.Clear();
 			Audio::Play(Audio::Get("fail"));
 		}
-		else if(!ship.HyperspaceType())
+		else if(ship.HyperspaceTypes() == Ship::NONE)
 		{
 			Messages::Add("You cannot jump to the selected system.");
 			keyStuck.Clear();
@@ -2507,12 +2507,12 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 			command |= Command::BOARD;
 		}
 	}
-	
+
 	if(isLaunching)
 		command |= Command::DEPLOY;
 	if(isCloaking)
 		command |= Command::CLOAK;
-	
+
 	ship.SetCommands(command);
 }
 
@@ -2523,11 +2523,11 @@ bool AI::Has(const Ship &ship, const weak_ptr<const Ship> &other, int type) cons
 	auto sit = actions.find(ship.shared_from_this());
 	if(sit == actions.end())
 		return false;
-	
+
 	auto oit = sit->second.find(other);
 	if(oit == sit->second.end())
 		return false;
-	
+
 	return (oit->second & type);
 }
 
@@ -2538,11 +2538,11 @@ bool AI::Has(const Government *government, const weak_ptr<const Ship> &other, in
 	auto git = governmentActions.find(government);
 	if(git == governmentActions.end())
 		return false;
-	
+
 	auto oit = git->second.find(other);
 	if(oit == git->second.end())
 		return false;
-	
+
 	return (oit->second & type);
 }
 
@@ -2551,7 +2551,7 @@ bool AI::Has(const Government *government, const weak_ptr<const Ship> &other, in
 void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const string &description)
 {
 	string who;
-	
+
 	// Figure out what ships we are giving orders to.
 	vector<const Ship *> ships;
 	if(player.SelectedShips().empty())
@@ -2574,7 +2574,7 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 	// This should never happen, but just in case:
 	if(ships.empty())
 		return;
-	
+
 	Point centerOfGravity;
 	bool isMoveOrder = (newOrders.type == Orders::MOVE_TO);
 	int squadCount = 0;
@@ -2592,7 +2592,7 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 	// If this is a move command, make sure the fleet is bunched together
 	// enough that each ship takes up no more than about 30,000 square pixels.
 	double maxSquadOffset = sqrt(10000. * squadCount);
-	
+
 	// Now, go through all the given ships and set their orders to the new
 	// orders. But, if it turns out that they already had the given orders,
 	// their orders will be cleared instead. The only command that does not
@@ -2601,12 +2601,12 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 	for(const Ship *ship : ships)
 	{
 		hasMismatch |= !orders.count(ship);
-		
+
 		Orders &existing = orders[ship];
 		hasMismatch |= (existing.type != newOrders.type);
 		hasMismatch |= (existing.target.lock() != newOrders.target.lock());
 		existing = newOrders;
-		
+
 		if(isMoveOrder)
 		{
 			// In a move order, rather than commanding every ship to move to the

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -116,7 +116,7 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 		// Don't try to make a fleet "enter" from another system if none of the
 		// ships have jump drives.
 		bool isWelcomeHere = !system.GetGovernment()->IsEnemy(government);
-		for(const System *neighbor : system.Links())
+		for(const System *neighbor : (jumpType == Ship::JUMP ? system.Neighbors() : system.Links()))
 		{
 			// If this ship is not "welcome" in the current system, prefer to have
 			// it enter from a system that is friendly to it. (This is for realism,

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -107,24 +107,16 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 	vector<const System *> linkVector;
 	// Find out what the "best" jump method the fleet has is. Assume that if the
 	// others don't have that jump method, they are being carried as fighters.
-	// That is, content creators should avoid creating fleets with a mix of jump
-	// drives and hyperdrives.
-	bool hasJumpDrive = false;
-	double jumpType = 0.;
+	Ship::JumpType jumpType = Ship::NONE;
 	for(const Ship *ship : variant.ships)
-	{
-		hasJumpDrive |= static_cast<bool>(ship->Attributes().Get("jump drive"));
-		jumpType = max(jumpType,
-			 ship->Attributes().Get("jump drive") ? ship->Attributes().Get("jump fuel") :
-			 ship->Attributes().Get("hyperdrive") ? ship->Attributes().Get("hyperdrive fuel") :
-			 ship->Attributes().Get("scram drive") ? ship->Attributes().Get("scram fuel") : 0.);
-	}
-	if(jumpType)
+		jumpType |= ship->HyperspaceType();
+
+	if(jumpType != Ship::NONE)
 	{
 		// Don't try to make a fleet "enter" from another system if none of the
 		// ships have jump drives.
 		bool isWelcomeHere = !system.GetGovernment()->IsEnemy(government);
-		for(const System *neighbor : (hasJumpDrive ? system.Neighbors() : system.Links()))
+		for(const System *neighbor : system.Links())
 		{
 			// If this ship is not "welcome" in the current system, prefer to have
 			// it enter from a system that is friendly to it. (This is for realism,

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -66,7 +66,7 @@ MapPanel::MapPanel(PlayerInfo &player, int commodity, const System *special)
 	// Recalculate the fog each time the map is opened, just in case the player
 	// bought a map since the last time they viewed the map.
 	FogShader::Redraw();
-	
+
 	if(selectedSystem)
 		center = Point(0., 0.) - selectedSystem->Position();
 }
@@ -76,15 +76,15 @@ MapPanel::MapPanel(PlayerInfo &player, int commodity, const System *special)
 void MapPanel::Draw()
 {
 	glClear(GL_COLOR_BUFFER_BIT);
-	
+
 	for(const auto &it : GameData::Galaxies())
 		SpriteShader::Draw(it.second.GetSprite(), Zoom() * (center + it.second.Position()), Zoom());
-	
+
 	if(Preferences::Has("Hide unexplored map regions"))
 		FogShader::Draw(center, Zoom(), player);
-	
+
 	DrawTravelPlan();
-	
+
 	// Draw the "visible range" circle around your current location.
 	Color dimColor(.1, 0.);
 	RingShader::Draw(Zoom() * (playerSystem ? playerSystem->Position() + center : center),
@@ -92,22 +92,22 @@ void MapPanel::Draw()
 	Color brightColor(.4, 0.);
 	RingShader::Draw(Zoom() * (selectedSystem ? selectedSystem->Position() + center : center),
 		11., 9., brightColor);
-	
+
 	DrawWormholes();
 	DrawLinks();
 	DrawSystems();
 	DrawNames();
 	DrawMissions();
-	
+
 	if(!distance.HasRoute(selectedSystem))
 	{
 		const Font &font = FontSet::Get(18);
-		
+
 		static const string NO_ROUTE = "You have not yet mapped a route to this system.";
 		Color black(0., 1.);
 		Color red(1., 0., 0., 1.);
 		Point point(-font.Width(NO_ROUTE) / 2, Screen::Top() + 40);
-		
+
 		font.Draw(NO_ROUTE, point + Point(1, 1), black);
 		font.Draw(NO_ROUTE, point, red);
 	}
@@ -119,7 +119,7 @@ void MapPanel::DrawButtons(const string &condition)
 {
 	// Remember which buttons we're showing.
 	buttonCondition = condition;
-	
+
 	// Draw the buttons to switch to other map modes.
 	Information info;
 	info.SetCondition(condition);
@@ -146,7 +146,7 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, double alpha, const System 
 	Color currentColor = colors.Get("active mission")->Additive(alpha * 2.);
 	Color blockedColor = colors.Get("blocked mission")->Additive(alpha * 2.);
 	Color waypointColor = colors.Get("waypoint")->Additive(alpha * 2.);
-	
+
 	for(int i = 0; i < 2; ++i)
 	{
 		const System *system = jump[i];
@@ -155,7 +155,7 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, double alpha, const System 
 		Point from = system->Position() - center + drawPos;
 		string name = isKnown ? system->Name() : "Unexplored System";
 		font.Draw(name, from + Point(6., -.5 * font.Height()), lineColor);
-		
+
 		Color color = Color(.5 * alpha, 0.);
 		if(player.HasVisited(system) && system->IsInhabited() && gov)
 			color = Color(
@@ -163,21 +163,21 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, double alpha, const System 
 				alpha * gov->GetColor().Get()[1],
 				alpha * gov->GetColor().Get()[2], 0.);
 		RingShader::Draw(from, 6., 3.5, color);
-		
+
 		for(const System *link : system->Links())
 		{
 			if(!player.HasVisited(system) && !player.HasVisited(link))
 				continue;
-			
+
 			Point to = link->Position() - center + drawPos;
 			Point unit = (from - to).Unit() * 7.;
 			LineShader::Draw(from - unit, to + unit, 1.2, lineColor);
-			
+
 			isLink |= (link == jump[!i]);
 			if(seen.count(link) || link == jump[!i])
 				continue;
 			seen.insert(link);
-			
+
 			gov = link->GetGovernment();
 			Color color = Color(.5 * alpha, 0.);
 			if(player.HasVisited(link) && link->IsInhabited() && gov)
@@ -187,13 +187,13 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, double alpha, const System 
 					alpha * gov->GetColor().Get()[2], 0.);
 			RingShader::Draw(to, 6., 3.5, color);
 		}
-		
+
 		Angle angle;
 		for(const Mission &mission : player.Missions())
 		{
 			if(!mission.IsVisible())
 				continue;
-			
+
 			if(mission.Destination()->IsInSystem(system))
 			{
 				bool blink = false;
@@ -209,7 +209,7 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, double alpha, const System 
 					DrawPointer(from, angle, isSatisfied ? currentColor : blockedColor, false);
 				}
 			}
-			
+
 			for(const System *waypoint : mission.Waypoints())
 				if(waypoint == system)
 					DrawPointer(from, angle, waypointColor, false);
@@ -218,7 +218,7 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, double alpha, const System 
 					DrawPointer(from, angle, waypointColor, false);
 		}
 	}
-	
+
 	Point from = jump[0]->Position() - center + drawPos;
 	Point to = jump[1]->Position() - center + drawPos;
 	Point unit = (to - from).Unit();
@@ -278,7 +278,7 @@ bool MapPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		player.SetMapZoom(max(-2, player.MapZoom() - 1));
 	else
 		return false;
-	
+
 	return true;
 }
 
@@ -295,7 +295,7 @@ bool MapPanel::Click(int x, int y, int clicks)
 			Select(&it.second);
 			break;
 		}
-	
+
 	return true;
 }
 
@@ -318,7 +318,7 @@ bool MapPanel::Scroll(double dx, double dy)
 		player.SetMapZoom(min(2, player.MapZoom() + 1));
 	else
 		player.SetMapZoom(max(-2, player.MapZoom() - 1));
-	
+
 	// Now, Zoom() has changed (unless at one of the limits). But, we still want
 	// anchor to be the same, so:
 	center = mouse / Zoom() - anchor;
@@ -331,7 +331,7 @@ Color MapPanel::MapColor(double value)
 {
 	if(std::isnan(value))
 		return UninhabitedColor();
-	
+
 	value = min(1., max(-1., value));
 	if(value < 0.)
 		return Color(
@@ -355,7 +355,7 @@ Color MapPanel::ReputationColor(double reputation, bool canLand, bool hasDominat
 	// government is hostile.
 	if(canLand)
 		reputation = max(reputation, 0.);
-	
+
 	if(hasDominated)
 		return Color(.1, .6, 0., .4);
 	else if(reputation < 0.)
@@ -378,7 +378,7 @@ Color MapPanel::GovernmentColor(const Government *government)
 {
 	if(!government)
 		return UninhabitedColor();
-	
+
 	return Color(
 		.6 * government->GetColor().Get()[0],
 		.6 * government->GetColor().Get()[1],
@@ -417,10 +417,10 @@ void MapPanel::Select(const System *system)
 	vector<const System *> &plan = player.TravelPlan();
 	if(!player.Flagship() || (!plan.empty() && system == plan.front()))
 		return;
-	
+
 	bool isJumping = player.Flagship()->IsEnteringHyperspace();
 	const System *source = isJumping ? player.Flagship()->GetTargetSystem() : player.GetSystem();
-	
+
 	bool shift = (SDL_GetModState() & KMOD_SHIFT) && !plan.empty();
 	if(system == source && !shift)
 	{
@@ -435,7 +435,7 @@ void MapPanel::Select(const System *system)
 		DistanceMap localDistance(player, plan.front());
 		if(localDistance.Distance(system) <= 0)
 			return;
-		
+
 		auto it = plan.begin();
 		while(system != *it)
 		{
@@ -448,7 +448,7 @@ void MapPanel::Select(const System *system)
 		plan.clear();
 		if(!isJumping)
 			player.Flagship()->SetTargetSystem(nullptr);
-		
+
 		while(system != source)
 		{
 			plan.push_back(system);
@@ -521,7 +521,7 @@ bool MapPanel::IsSatisfied(const PlayerInfo &player, const Mission &mission)
 	for(const NPC &npc : mission.NPCs())
 		if(!npc.HasSucceeded(player.GetSystem()))
 			return false;
-	
+
 	return mission.Waypoints().empty() && mission.Stopovers().empty();
 }
 
@@ -542,19 +542,27 @@ void MapPanel::DrawTravelPlan()
 	Color outOfFlagshipFuelRangeColor(.55, .1, .0, 0.);
 	Color withinFleetFuelRangeColor(.2, .5, .0, 0.);
 	Color wormholeColor(0.5, 0.2, 0.9, 1.);
-	
+
 	Ship *ship = player.Flagship();
 	bool hasHyper = ship ? ship->Attributes().Get("hyperdrive") : false;
+	bool hasScram = ship ? ship->Attributes().Get("scram drive") : false;
 	bool hasJump = ship ? ship->Attributes().Get("jump drive") : false;
-	
+
 	// Find out how much fuel your ship and your escorts use per jump.
 	double flagshipCapacity = 0.;
 	if(ship)
 		flagshipCapacity = ship->Attributes().Get("fuel capacity") * ship->Fuel();
 	double flagshipJumpFuel = 0.;
 	if(ship)
-		flagshipJumpFuel = hasHyper ? ship->Attributes().Get("scram drive") ? 150. : 100. : 200.;
-	double escortCapacity = 0.;
+	{
+		if(hasScram)
+			flagshipJumpFuel = ship->Attributes().Get("scram fuel");
+		else if(hasHyper)
+			flagshipJumpFuel = ship->Attributes().Get("hyperdrive fuel");
+		else if(hasJump)
+			flagshipJumpFuel = ship->Attributes().Get("jump fuel");
+	}
+	double escortCapacity = player.Ships().size() > 1 ? std::numeric_limits<double>::max() : 0.;
 	double escortJumpFuel = 1.;
 	bool escortHasJump = false;
 	// Skip your flagship, parked ships, and fighters.
@@ -562,16 +570,22 @@ void MapPanel::DrawTravelPlan()
 		if(it.get() != ship && !it->IsParked() && !it->CanBeCarried())
 		{
 			double capacity = it->Attributes().Get("fuel capacity") * it->Fuel();
-			double jumpFuel = it->Attributes().Get("hyperdrive") ?
-				it->Attributes().Get("scram drive") ? 150. : 100. : 200.;
-			if(escortJumpFuel < 100. || capacity / jumpFuel < escortCapacity / escortJumpFuel)
+			double jumpFuel = 0.;
+			if(it->Attributes().Get("scram drive"))
+				jumpFuel = it->Attributes().Get("scram fuel");
+			else if(it->Attributes().Get("hyperdrive"))
+				jumpFuel = it->Attributes().Get("hyperdrive fuel");
+			else if(it->Attributes().Get("jump drive"))
+				jumpFuel = it->Attributes().Get("jump fuel");
+
+			if(capacity / jumpFuel < escortCapacity / escortJumpFuel)
 			{
 				escortCapacity = capacity;
 				escortJumpFuel = jumpFuel;
 				escortHasJump = it->Attributes().Get("jump drive");
 			}
 		}
-	
+
 	// Draw your current travel plan.
 	if(!playerSystem)
 		return;
@@ -579,47 +593,42 @@ void MapPanel::DrawTravelPlan()
 	for(int i = player.TravelPlan().size() - 1; i >= 0; --i)
 	{
 		const System *next = player.TravelPlan()[i];
-		
+
 		// Figure out what kind of jump this is, and check if the player is able
 		// to make jumps of that kind.
-		bool isHyper = 
+		bool isHyper =
 			(find(previous->Links().begin(), previous->Links().end(), next)
 				!= previous->Links().end());
 		bool isJump = isHyper ||
 			(find(previous->Neighbors().begin(), previous->Neighbors().end(), next)
 				!= previous->Neighbors().end());
 		bool isWormhole = false;
-		if(!((isHyper && hasHyper) || (isJump && hasJump)))
+		if(!((isHyper && (hasHyper || hasScram)) || (isJump && hasJump)))
 		{
 			for(const StellarObject &object : previous->Objects())
 				isWormhole |= (object.GetPlanet() && object.GetPlanet()->WormholeDestination(previous) == next);
 			if(!isWormhole)
 				break;
 		}
-		
+
 		Point from = Zoom() * (next->Position() + center);
 		Point to = Zoom() * (previous->Position() + center);
 		Point unit = (from - to).Unit() * 7.;
 		from -= unit;
 		to += unit;
-		
+
 		if(isWormhole)
 		{
 			// Wormholes cost no fuel to travel through.
 		}
-		else if(!isHyper)
-		{
-			if(!escortHasJump)
-				escortCapacity = 0.;
-			flagshipCapacity -= 200.;
-			escortCapacity -= 200.;
-		}
 		else
 		{
+			if(!isHyper && !escortHasJump)
+				escortCapacity = 0.;
 			flagshipCapacity -= flagshipJumpFuel;
 			escortCapacity -= escortJumpFuel;
 		}
-		
+
 		Color drawColor = outOfFlagshipFuelRangeColor;
 		if(isWormhole)
 			drawColor = wormholeColor;
@@ -627,9 +636,9 @@ void MapPanel::DrawTravelPlan()
 			drawColor = withinFleetFuelRangeColor;
 		else if(flagshipCapacity >= 0. || escortCapacity >= 0.)
 			drawColor = defaultColor;
-		
+
 		LineShader::Draw(from, to, 3., drawColor);
-		
+
 		previous = next;
 	}
 }
@@ -643,7 +652,7 @@ void MapPanel::DrawWormholes()
 	const double wormholeWidth = 1.2;
 	const double wormholeLength = 4.;
 	const double wormholeArrowHeadRatio = .3;
-	
+
 	map<const System *, const System *> drawn;
 	for(const auto &it : GameData::Systems())
 	{
@@ -658,14 +667,14 @@ void MapPanel::DrawWormholes()
 				Point unit = (from - to).Unit() * 7.;
 				from -= unit;
 				to += unit;
-				
+
 				Angle left(45.);
 				Angle right(-45.);
-				
+
 				Point wormholeUnit = Zoom() * wormholeLength * unit;
 				Point arrowLeft = left.Rotate(wormholeUnit * wormholeArrowHeadRatio);
 				Point arrowRight = right.Rotate(wormholeUnit * wormholeArrowHeadRatio);
-				
+
 				// Don't double-draw the links.
 				if(drawn[next] != previous)
 					LineShader::Draw(from, to, wormholeWidth, wormholeDimColor);
@@ -688,7 +697,7 @@ void MapPanel::DrawLinks()
 		const System *system = &it.second;
 		if(!player.HasSeen(system))
 			continue;
-		
+
 		for(const System *link : system->Links())
 			if(link < system || !player.HasSeen(link))
 			{
@@ -697,13 +706,13 @@ void MapPanel::DrawLinks()
 				// direction of increasing pointer values.
 				if(!player.HasVisited(system) && !player.HasVisited(link))
 					continue;
-				
+
 				Point from = Zoom() * (system->Position() + center);
 				Point to = Zoom() * (link->Position() + center);
 				Point unit = (from - to).Unit() * 7.;
 				from -= unit;
 				to += unit;
-				
+
 				bool isClose = (system == playerSystem || link == playerSystem);
 				LineShader::Draw(from, to, 1.2, isClose ? closeColor : farColor);
 			}
@@ -716,7 +725,7 @@ void MapPanel::DrawSystems()
 {
 	if(commodity == SHOW_GOVERNMENT)
 		closeGovernments.clear();
-	
+
 	// Draw the circles for the systems, colored based on the selected criterion,
 	// which may be government, services, or commodity prices.
 	for(const auto &it : GameData::Systems())
@@ -728,9 +737,9 @@ void MapPanel::DrawSystems()
 			continue;
 		if(!player.HasSeen(&system) && &system != specialSystem)
 			continue;
-		
+
 		Point pos = Zoom() * (system.Position() + center);
-		
+
 		Color color = UninhabitedColor();
 		if(!player.HasVisited(&system))
 			color = UnexploredColor();
@@ -779,14 +788,14 @@ void MapPanel::DrawSystems()
 				}
 				else
 					value = SystemValue(&system);
-				
+
 				color = MapColor(value);
 			}
 			else if(commodity == SHOW_GOVERNMENT)
 			{
 				const Government *gov = system.GetGovernment();
 				color = GovernmentColor(gov);
-				
+
 				// For every government that is draw, keep track of how close it
 				// is to the center of the view. The four closest governments
 				// will be displayed in the key.
@@ -800,7 +809,7 @@ void MapPanel::DrawSystems()
 			else
 			{
 				double reputation = system.GetGovernment()->Reputation();
-				
+
 				// A system should show up as dominated if it contains at least
 				// one inhabited planet and all inhabited planets have been
 				// dominated. It should show up as restricted if you cannot land
@@ -821,7 +830,7 @@ void MapPanel::DrawSystems()
 				color = ReputationColor(reputation, canLand, canLand && hasDominated);
 			}
 		}
-		
+
 		RingShader::Draw(pos, OUTER, INNER, color);
 	}
 }
@@ -833,7 +842,7 @@ void MapPanel::DrawNames()
 	// Don't draw if too small.
 	if(Zoom() <= 0.5)
 		return;
-	
+
 	// Draw names for all systems you have visited.
 	const Font &font = FontSet::Get((Zoom() > 2.0) ? 18 : 14);
 	Color closeColor(.6, .6);
@@ -844,7 +853,7 @@ void MapPanel::DrawNames()
 		const System &system = it.second;
 		if(!player.KnowsName(&system) || system.Name().empty())
 			continue;
-		
+
 		font.Draw(system.Name(), Zoom() * (system.Position() + center) + offset,
 			(&system == playerSystem) ? closeColor : farColor);
 	}
@@ -858,7 +867,7 @@ void MapPanel::DrawMissions()
 	map<const System *, Angle> angle;
 	Color black(0., 1.);
 	Color white(1., 1.);
-	
+
 	const Set<Color> &colors = GameData::Colors();
 	const Color &availableColor = *colors.Get("available job");
 	const Color &unavailableColor = *colors.Get("unavailable job");
@@ -875,7 +884,7 @@ void MapPanel::DrawMissions()
 	{
 		if(!mission.IsVisible())
 			continue;
-		
+
 		const System *system = mission.Destination()->GetSystem();
 		bool blink = false;
 		if(mission.Deadline())
@@ -886,7 +895,7 @@ void MapPanel::DrawMissions()
 		}
 		bool isSatisfied = IsSatisfied(player, mission);
 		DrawPointer(system, angle[system], blink ? black : isSatisfied ? currentColor : blockedColor, isSatisfied);
-		
+
 		for(const System *waypoint : mission.Waypoints())
 			DrawPointer(waypoint, angle[waypoint], waypointColor);
 		for(const Planet *stopover : mission.Stopovers())
@@ -914,7 +923,7 @@ void MapPanel::DrawPointer(const System *system, Angle &angle, const Color &colo
 void MapPanel::DrawPointer(Point position, Angle &angle, const Color &color, bool drawBack, bool bigger)
 {
 	static const Color black(0., 1.);
-	
+
 	angle += Angle(30.);
 	if(drawBack)
 		PointerShader::Draw(position, angle.Unit(), 14. + bigger, 19. + 2 * bigger, -4., black);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -54,6 +54,16 @@ namespace {
 
 
 
+inline constexpr Ship::JumpType operator|(const Ship::JumpType first, const Ship::JumpType second) noexcept {
+	return static_cast<Ship::JumpType>(static_cast<unsigned int>(first) | static_cast<unsigned int>(second));
+}
+
+inline Ship::JumpType& operator|=(Ship::JumpType& first, const Ship::JumpType second) noexcept {
+	return first = first | second;
+}
+
+
+
 void Ship::Load(const DataNode &node)
 {
 	if(node.Size() >= 2)
@@ -63,10 +73,10 @@ void Ship::Load(const DataNode &node)
 	}
 	if(node.Size() >= 3)
 		base = GameData::Ships().Get(modelName);
-	
+
 	government = GameData::PlayerGovernment();
 	equipped.clear();
-	
+
 	// Note: I do not clear the attributes list here so that it is permissible
 	// to override one ship definition with another.
 	bool hasEngine = false;
@@ -227,7 +237,7 @@ void Ship::Load(const DataNode &node)
 		else if(child.Token(0) != "actions")
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
-	
+
 	// Check that all the "equipped" outfits actually match what your ship has.
 	if(!outfits.empty())
 		for(auto &it : equipped)
@@ -254,7 +264,7 @@ void Ship::FinishLoading()
 	// until GameData is when the program quits.
 	if(GameData::Ships().Has(modelName))
 		explosionWeapon = &GameData::Ships().Get(modelName)->BaseAttributes();
-	
+
 	// If this ship has a base class, copy any attributes not defined here.
 	// Exception: uncapturable and "never disabled" flags don't carry over.
 	if(base && base != this)
@@ -279,12 +289,12 @@ void Ship::FinishLoading()
 			outfits = base->outfits;
 		if(description.empty())
 			description = base->description;
-		
+
 		bool hasHardpoints = false;
 		for(const Hardpoint &weapon : armament.Get())
 			if(weapon.GetPoint())
 				hasHardpoints = true;
-		
+
 		if(!hasHardpoints)
 		{
 			// Check if any hardpoint locations were not specified.
@@ -318,15 +328,15 @@ void Ship::FinishLoading()
 			armament = merged;
 		}
 	}
-	
+
 	// Mark any drone that has no "automaton" value as an automaton, to
 	// grandfather in the drones from before that attribute existed.
 	if(baseAttributes.Category() == "Drone" && !baseAttributes.Attributes().count("automaton"))
 		baseAttributes.Add("automaton", 1.);
-	
+
 	baseAttributes.Reset("gun ports", armament.GunCount());
 	baseAttributes.Reset("turret mounts", armament.TurretCount());
-	
+
 	// Add the attributes of all your outfits to the ship's base attributes.
 	attributes = baseAttributes;
 	for(const auto &it : outfits)
@@ -343,7 +353,7 @@ void Ship::FinishLoading()
 			auto eit = equipped.find(it.first);
 			if(eit != equipped.end())
 				count -= eit->second;
-			
+
 			if(count)
 				armament.Add(it.first, count);
 		}
@@ -351,12 +361,12 @@ void Ship::FinishLoading()
 	cargo.SetSize(attributes.Get("cargo space"));
 	equipped.clear();
 	armament.FinishLoading();
-	
+
 	// Figure out how far from center the farthest weapon it.
 	weaponRadius = 0.;
 	for(const Hardpoint &weapon : armament.Get())
 		weaponRadius = max(weaponRadius, weapon.GetPoint().Length());
-	
+
 	// Recharge, but don't recharge crew or fuel if not in the parent's system.
 	// Do not recharge if this ship's starting state was saved.
 	if(!hull)
@@ -383,12 +393,12 @@ void Ship::Save(DataWriter &out) const
 		if(pluralModelName != modelName + 's')
 			out.Write("plural", pluralModelName);
 		SaveSprite(out);
-		
+
 		if(neverDisabled)
 			out.Write("never disabled");
 		if(!isCapturable)
 			out.Write("uncapturable");
-		
+
 		out.Write("attributes");
 		out.BeginChild();
 		{
@@ -399,7 +409,7 @@ void Ship::Save(DataWriter &out) const
 					out.Write(it.first, it.second);
 		}
 		out.EndChild();
-		
+
 		out.Write("outfits");
 		out.BeginChild();
 		{
@@ -413,14 +423,14 @@ void Ship::Save(DataWriter &out) const
 				}
 		}
 		out.EndChild();
-		
+
 		cargo.Save(out);
 		out.Write("crew", crew);
 		out.Write("fuel", fuel);
 		out.Write("shields", shields);
 		out.Write("hull", hull);
 		out.Write("position", position.X(), position.Y());
-		
+
 		for(const EnginePoint &point : enginePoints)
 			out.Write("engine", 2. * point.X(), 2. * point.Y(), point.Zoom());
 		for(const Hardpoint &weapon : armament.Get())
@@ -451,7 +461,7 @@ void Ship::Save(DataWriter &out) const
 		for(const auto &it : finalExplosions)
 			if(it.first && it.second)
 				out.Write("final explode", it.first->Name(), it.second);
-		
+
 		if(currentSystem)
 			out.Write("system", currentSystem->Name());
 		else
@@ -546,7 +556,7 @@ void Ship::Place(Point position, Point velocity, Angle angle)
 	isInvisible = !HasSprite();
 	jettisoned.clear();
 	hyperspaceCount = 0;
-	hyperspaceType = 0;
+	hyperspaceType = NONE;
 	forget = 1;
 	targetShip.reset();
 	shipToAssist.reset();
@@ -694,12 +704,12 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 	if((!isSpecial && forget >= 1000) || !currentSystem)
 		return false;
 	isInSystem = false;
-	if(!fuel || !(attributes.Get("hyperdrive") || attributes.Get("jump drive")))
+	if(!fuel || !(attributes.Get("hyperdrive") || attributes.Get("scram drive") || attributes.Get("jump drive")))
 		hyperspaceSystem = nullptr;
-	
+
 	// Adjust the error in the pilot's targeting.
 	personality.UpdateConfusion(commands.IsFiring());
-	
+
 	// Handle ionization effects, etc.
 	if(ionization)
 	{
@@ -723,27 +733,27 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		jettisoned.front()->Place(*this);
 		flotsam.splice(flotsam.end(), jettisoned, jettisoned.begin());
 	}
-	
+
 	// When ships recharge, what actually happens is that they can exceed their
 	// maximum capacity for the rest of the turn, but must be clamped to the
 	// maximum here before they gain more. This is so that, for example, a ship
 	// with no batteries but a good generator can still move.
 	energy = min(energy, attributes.Get("energy capacity"));
-	
+
 	heat -= .001 * heat * attributes.Get("heat dissipation");
 	if(heat > Mass() * 100.)
 		isOverheated = true;
 	else if(heat < Mass() * 90.)
 		isOverheated = false;
-	
+
 	double maxShields = attributes.Get("shields");
 	shields = min(shields, maxShields);
 	double maxHull = attributes.Get("hull");
 	hull = min(hull, maxHull);
-	
+
 	int requiredCrew = RequiredCrew();
 	isDisabled = isOverheated || hull < MinimumHull() || (!crew && requiredCrew);
-	
+
 	// Update ship supply levels.
 	if(!isDisabled)
 	{
@@ -753,16 +763,16 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		double scale = .2 + 1.8 / (.001 * position.Length() + 1);
 		fuel += .03 * scale * (sqrt(attributes.Get("ramscoop")) + .05 * scale);
 		fuel = min(fuel, attributes.Get("fuel capacity"));
-		
+
 		energy += scale * attributes.Get("solar collection");
-		
+
 		double coolingEfficiency = CoolingEfficiency();
 		energy += attributes.Get("energy generation") - ionization;
 		energy = max(0., energy);
 		heat += attributes.Get("heat generation");
 		heat -= coolingEfficiency * attributes.Get("cooling");
 		heat = max(0., heat);
-		
+
 		// Apply active cooling. The fraction of full cooling to apply equals
 		// your ship's current fraction of its maximum temperature.
 		double activeCooling = coolingEfficiency * attributes.Get("active cooling");
@@ -779,11 +789,11 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			}
 			else
 				heat -= activeCooling;
-			
+
 			heat = max(0., heat);
 		}
 	}
-	
+
 	if(!isInvisible)
 	{
 		double cloakingSpeed = attributes.Get("cloak");
@@ -801,12 +811,12 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		else
 			cloak = 0.;
 	}
-	
+
 	if(IsDestroyed())
 	{
 		// Make sure the shields are zero, as well as the hull.
 		shields = 0.;
-		
+
 		// Once we've created enough little explosions, die.
 		if(explosionCount == explosionTotal || forget)
 		{
@@ -820,13 +830,13 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 				for(int i = 0; i < debrisCount; ++i)
 				{
 					effects.push_back(*effect);
-					
+
 					Angle angle = Angle::Random();
 					Point effectVelocity = velocity + angle.Unit() * (scale * Random::Real());
 					Point effectPosition = position + radius * angle.Unit();
 					effects.back().Place(effectPosition, effectVelocity, angle);
 				}
-					
+
 				for(unsigned i = 0; i < explosionTotal / 2; ++i)
 					CreateExplosion(effects, true);
 				for(const auto &it : finalExplosions)
@@ -850,7 +860,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			fuel = 0.;
 			return false;
 		}
-		
+
 		// If the ship is dead, it first creates explosions at an increasing
 		// rate, then disappears in one big explosion.
 		++explosionRate;
@@ -861,22 +871,31 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 	{
 		// Don't apply external acceleration while jumping.
 		acceleration = Point();
-		
-		fuel -= (hyperspaceSystem != nullptr) * hyperspaceType * .01;
-		
+
+		// Get the fuel needed for the current jump
+		double jumpFuel = 0.;
+		if(hyperspaceType == SCRAM)
+			jumpFuel = attributes.Get("scram fuel");
+		else if(hyperspaceType == HYPER)
+			jumpFuel = attributes.Get("hyperdrive fuel");
+		else if(hyperspaceType == JUMP)
+			jumpFuel = attributes.Get("jump fuel");
+
+		fuel -= (hyperspaceSystem != nullptr) * jumpFuel * .01;
+
 		// Enter hyperspace.
 		int direction = (hyperspaceSystem != nullptr) - (hyperspaceSystem == nullptr);
 		hyperspaceCount += direction;
 		static const int HYPER_C = 100;
 		static const double HYPER_A = 2.;
 		static const double HYPER_D = 1000.;
-		bool hasJumpDrive = (hyperspaceType == 200);
-		
+		bool hasJumpDrive = (hyperspaceType == JUMP);
+
 		// Create the particle effects for the jump drive. This may create 100
 		// or more particles per ship per turn at the peak of the jump.
 		if(hasJumpDrive && !forget)
 			CreateSparks(effects, "jump drive", hyperspaceCount * Width() * Height() * .000006);
-		
+
 		if(hyperspaceCount == HYPER_C)
 		{
 			currentSystem = hyperspaceSystem;
@@ -895,7 +914,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 					targetPlanet = parent->targetPlanet;
 			}
 			direction = -1;
-			
+
 			// If you have a target planet in the destination system, exit
 			// hyperpace aimed at it. Otherwise, target the first planet that
 			// has a spaceport.
@@ -911,13 +930,13 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 						break;
 					}
 			}
-			
+
 			if(hasJumpDrive)
 			{
 				position = target + Angle::Random().Unit() * 300. * (Random::Real() + 1.);
 				return true;
 			}
-			
+
 			// Have all ships exit hyperspace at the same distance so that
 			// your escorts always stay with you.
 			double distance = (HYPER_C * HYPER_C) * .5 * HYPER_A + HYPER_D;
@@ -965,19 +984,19 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			if(length > 1000.)
 				hyperspaceOffset *= 1000. / length;
 		}
-		
+
 		return true;
 	}
 	else if(landingPlanet || zoom < 1.)
 	{
 		// Don't apply external acceleration while landing.
 		acceleration = Point();
-		
+
 		// If a ship was disabled at the very moment it began landing, do not
 		// allow it to continue landing.
 		if(isDisabled)
 			landingPlanet = nullptr;
-		
+
 		// Special ships do not disappear forever when they land; they
 		// just slowly refuel.
 		if(landingPlanet && zoom)
@@ -1002,7 +1021,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 				}
 				else if(!isSpecial || personality.IsFleeing())
 					return false;
-				
+
 				zoom = 0.;
 			}
 		}
@@ -1016,12 +1035,12 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		}
 		else
 			fuel = min(fuel + 1., attributes.Get("fuel capacity"));
-		
+
 		// Move the ship at the velocity it had when it began landing, but
 		// scaled based on how small it is now.
 		if(zoom > 0.)
 			position += velocity * zoom;
-		
+
 		return true;
 	}
 	if(isDisabled)
@@ -1033,10 +1052,10 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 	else if(commands.Has(Command::JUMP))
 	{
 		hyperspaceType = CheckHyperspace();
-		if(hyperspaceType)
+		if(hyperspaceType != NONE)
 			hyperspaceSystem = GetTargetSystem();
 	}
-	
+
 	if(pilotError)
 		--pilotError;
 	else if(pilotOkay)
@@ -1055,7 +1074,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 	}
 	else
 		pilotOkay = 30;
-	
+
 	// This ship is not landing or entering hyperspace. So, move it. If it is
 	// disabled, all it can do is slow down to a stop.
 	double mass = Mass();
@@ -1101,7 +1120,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 				fuel -= cost;
 				energy -= energyCost;
 				acceleration += angle.Unit() * thrust / mass;
-				
+
 				if(!forget)
 					for(const EnginePoint &point : enginePoints)
 					{
@@ -1139,7 +1158,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			// What direction will the net acceleration be if this drag is applied?
 			// If the net acceleration will be opposite the thrust, do not apply drag.
 			dragAcceleration *= .5 * (acceleration.Unit().Dot(dragAcceleration.Unit()) + 1.);
-			
+
 			// A ship can only "cheat" to stop if it is moving slow enough that
 			// it could stop completely this frame. This is to avoid overshooting
 			// when trying to stop and ending up headed in the other direction.
@@ -1160,7 +1179,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		}
 		acceleration = Point();
 	}
-	
+
 	// Boarding:
 	if(isBoarding && (commands.Has(Command::FORWARD | Command::BACK) || commands.Turn()))
 		isBoarding = false;
@@ -1189,7 +1208,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			Angle facing = angle;
 			bool left = target->Unit().Cross(facing.Unit()) < 0.;
 			double turn = left - !left;
-			
+
 			// Check if the ship will still be pointing to the same side of the target
 			// angle if it turns by this amount.
 			facing += TurnRate() * turn;
@@ -1197,10 +1216,10 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			if(left != stillLeft)
 				turn = 0.;
 			angle += TurnRate() * turn;
-			
+
 			velocity += dv.Unit() * .1;
 			position += dp.Unit() * .5;
-			
+
 			if(distance < 10. && speed < 1. && (CanBeCarried() || !turn))
 			{
 				if(cloak)
@@ -1227,7 +1246,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			}
 		}
 	}
-	
+
 	// Shield and hull recharge. This comes after movement so that engines take
 	// priority over shield recharge.
 	if(!isDisabled)
@@ -1243,7 +1262,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			energy -= hullEnergy * hullAdded / hullRate;
 			heat += hullHeat * hullAdded / hullRate;
 		}
-		
+
 		double shieldRate = attributes.Get("shield generation");
 		if(shieldRate > 0.)
 		{
@@ -1254,16 +1273,16 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			heat += shieldHeat * shieldsAdded / shieldRate;
 		}
 	}
-	
+
 	// Clear your target if it is destroyed. This is only important for NPCs,
 	// because ordinary ships cease to exist once they are destroyed.
 	target = targetShip.lock();
 	if(target && target->IsDestroyed() && target->explosionCount >= target->explosionTotal)
 		targetShip.reset();
-	
+
 	// And finally: move the ship!
 	position += velocity;
-	
+
 	return true;
 }
 
@@ -1276,7 +1295,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 	// is landing, jumping, or cloaked.
 	if(!IsDestroyed() && (!commands.Has(Command::DEPLOY) || zoom != 1. || hyperspaceCount || cloak))
 		return;
-	
+
 	for(Bay &bay : bays)
 		if(bay.ship && !Random::Int(40 + 20 * bay.isFighter))
 		{
@@ -1293,7 +1312,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 			// same temperature.
 			bay.ship->heat = heat * bay.ship->Mass() / Mass();
 			heat -= bay.ship->heat;
-			
+
 			bay.ship.reset();
 		}
 }
@@ -1306,11 +1325,11 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder)
 	if(!hasBoarded)
 		return shared_ptr<Ship>();
 	hasBoarded = false;
-	
+
 	shared_ptr<Ship> victim = GetTargetShip();
 	if(CannotAct() || !victim || victim->IsDestroyed() || victim->GetSystem() != GetSystem())
 		return shared_ptr<Ship>();
-	
+
 	// For a fighter or drone, "board" means "return to ship."
 	if(CanBeCarried())
 	{
@@ -1319,7 +1338,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder)
 			victim->Carry(shared_from_this());
 		return shared_ptr<Ship>();
 	}
-	
+
 	// Board a ship of your own government to repair/refuel it.
 	if(!government->IsEnemy(victim->GetGovernment()))
 	{
@@ -1342,7 +1361,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder)
 	}
 	if(!victim->IsDisabled())
 		return shared_ptr<Ship>();
-	
+
 	// If the boarding ship is the player, they will choose what to plunder.
 	// Always take fuel if you can.
 	victim->TransferFuel(victim->fuel, this);
@@ -1352,11 +1371,11 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder)
 		victim->cargo.TransferAll(&cargo);
 		// Stop targeting this ship.
 		SetTargetShip(shared_ptr<Ship>());
-		
+
 		// Pause for two seconds before moving on.
 		pilotError = 120;
 	}
-	
+
 	// Stop targeting this ship (so you will not board it again right away).
 	SetTargetShip(shared_ptr<Ship>());
 	return victim;
@@ -1379,21 +1398,21 @@ int Ship::Scan()
 		outfitScan = max(0., outfitScan - 1.);
 	if(!commands.Has(Command::SCAN) || CannotAct())
 		return 0;
-	
+
 	shared_ptr<const Ship> target = GetTargetShip();
 	if(!target)
 		return 0;
-	
+
 	// The range of a scanner is proportional to the square root of its power.
 	double cargoPower = attributes.Get("cargo scan power");
 	double cargoDistance = cargoPower ? 100. * sqrt(cargoPower) : attributes.Get("cargo scan");
 	double outfitPower = attributes.Get("outfit scan power");
 	double outfitDistance = outfitPower ? 100. * sqrt(outfitPower) : attributes.Get("outfit scan");
-	
+
 	// Bail out if this ship has no scanners.
 	if(!cargoDistance && !outfitDistance)
 		return 0;
-	
+
 	// Scanning speed also uses a square root, so you need four scanners to get
 	// twice the speed out of them.
 	double cargoSpeed = sqrt(attributes.Get("cargo scan speed"));
@@ -1402,10 +1421,10 @@ int Ship::Scan()
 	double outfitSpeed = sqrt(attributes.Get("outfit scan speed"));
 	if(!outfitSpeed)
 		outfitSpeed = 1.;
-	
+
 	// Check how close this ship is to the target it is trying to scan.
 	double distance = (target->position - position).Length();
-	
+
 	// Check if either scanner has finished scanning.
 	bool startedScanning = false;
 	bool activeScanning = false;
@@ -1434,17 +1453,17 @@ int Ship::Scan()
 				result |= ShipEvent::SCAN_OUTFITS;
 		}
 	}
-	
+
 	// Play the scanning sound if the actor or the target is the player's ship.
 	if(government->IsPlayer() || (target->GetGovernment()->IsPlayer() && activeScanning))
 		Audio::Play(Audio::Get("scan"), Position());
-	
+
 	if(startedScanning && government->IsPlayer())
 		Messages::Add("Attempting to scan the ship \"" + target->Name() + "\".", false);
 	else if(startedScanning && target->GetGovernment()->IsPlayer())
 		Messages::Add("The " + government->GetName() + " ship \""
 			+ Name() + "\" is attempting to scan you.", false);
-	
+
 	if(target->GetGovernment()->IsPlayer() && (result & ShipEvent::SCAN_CARGO))
 	{
 		Messages::Add("The " + government->GetName() + " ship \""
@@ -1455,7 +1474,7 @@ int Ship::Scan()
 		Messages::Add("The " + government->GetName() + " ship \""
 			+ Name() + "\" completed its scan of your outfits.");
 	}
-	
+
 	return result;
 }
 
@@ -1468,17 +1487,17 @@ bool Ship::Fire(list<Projectile> &projectiles, list<Effect> &effects)
 {
 	isInSystem = true;
 	forget = 0;
-	
+
 	// A ship that is about to die creates a special single-turn "projectile"
 	// representing its death explosion.
 	if(IsDestroyed() && explosionCount == explosionTotal && explosionWeapon)
 		projectiles.emplace_back(position, explosionWeapon);
-	
+
 	if(CannotAct())
 		return false;
-	
+
 	antiMissileRange = 0.;
-	
+
 	const vector<Hardpoint> &weapons = armament.Get();
 	for(unsigned i = 0; i < weapons.size(); ++i)
 	{
@@ -1491,9 +1510,9 @@ bool Ship::Fire(list<Projectile> &projectiles, list<Effect> &effects)
 				armament.Fire(i, *this, projectiles, effects);
 		}
 	}
-	
+
 	armament.Step(*this);
-	
+
 	return antiMissileRange;
 }
 
@@ -1506,7 +1525,7 @@ bool Ship::FireAntiMissile(const Projectile &projectile, list<Effect> &effects)
 		return false;
 	if(CannotAct())
 		return false;
-	
+
 	const vector<Hardpoint> &weapons = armament.Get();
 	for(unsigned i = 0; i < weapons.size(); ++i)
 	{
@@ -1515,7 +1534,7 @@ bool Ship::FireAntiMissile(const Projectile &projectile, list<Effect> &effects)
 			if(armament.FireAntiMissile(i, *this, projectile, effects))
 				return true;
 	}
-	
+
 	return false;
 }
 
@@ -1561,7 +1580,7 @@ bool Ship::IsDisabled() const
 {
 	if(!isDisabled)
 		return false;
-	
+
 	double minimumHull = MinimumHull();
 	bool needsCrew = RequiredCrew() != 0;
 	return (hull < minimumHull || (!crew && needsCrew));
@@ -1588,13 +1607,13 @@ bool Ship::CanLand() const
 {
 	if(!GetTargetStellar() || !GetTargetStellar()->GetPlanet() || isDisabled || IsDestroyed())
 		return false;
-	
+
 	if(!GetTargetStellar()->GetPlanet()->CanLand(*this))
 		return false;
-	
+
 	Point distance = GetTargetStellar()->Position() - position;
 	double speed = velocity.Length();
-	
+
 	return (speed < 1. && distance.Length() < GetTargetStellar()->Radius());
 }
 
@@ -1637,81 +1656,99 @@ bool Ship::IsHyperspacing() const
 
 
 
-// Check if this ship is currently able to enter hyperspace to it target.
-int Ship::CheckHyperspace() const
+// Check if this ship is currently able to enter hyperspace to its target.
+Ship::JumpType Ship::CheckHyperspace() const
 {
 	// You can't jump if you're waiting for someone else or are already jumping.
 	if(commands.Has(Command::WAIT) || hyperspaceCount)
-		return 0;
-	
-	// Find out where we're going and how we're getting there,
+		return NONE;
+
+	// Find out where we're going and how we're getting there.
 	const System *destination = GetTargetSystem();
-	int type = HyperspaceType();
-	
+	JumpType type = HyperspaceType();
+
 	// You can't jump to a system with no link to it.
-	if(!type)
-		return 0;
-	
-	if(fuel < type)
-		return 0;
-	
+	if(type == NONE)
+		return NONE;
+
 	Point direction = destination->Position() - currentSystem->Position();
-	
+
 	// The ship can only enter hyperspace if it is traveling slowly enough
 	// and pointed in the right direction.
-	if(type == 150)
+	if(type == SCRAM)
 	{
 		double deviation = fabs(direction.Unit().Cross(velocity));
-		if(deviation > attributes.Get("scram drive"))
-			return 0;
+		if(deviation > attributes.Get("deviation"))
+			return NONE;
 	}
 	else if(velocity.Length() > attributes.Get("jump speed"))
-		return 0;
-	
-	if(type != 200)
+		return NONE;
+
+	if(type != JUMP)
 	{
 		// Figure out if we're within one turn step of facing this system.
 		bool left = direction.Cross(angle.Unit()) < 0.;
 		Angle turned = angle + TurnRate() * (left - !left);
 		bool stillLeft = direction.Cross(turned.Unit()) < 0.;
-	
+
 		if(left == stillLeft)
-			return 0;
+			return NONE;
 	}
-	
+
 	return type;
 }
 
 
 
-// Check what type of hyperspce jump this ship is making (0 = not allowed,
-// 100 = hyperdrive, 150 = scram drive, 200 = jump drive).
-int Ship::HyperspaceType() const
+// Check what types of hyperspace jumps this ship can make.
+Ship::JumpType Ship::HyperspaceTypes() const
 {
 	if(IsDisabled())
-		return 0;
+		return NONE;
 	const System *destination = GetTargetSystem();
 	if(!destination)
-		return 0;
-	
+		return NONE;
+
 	// Check what equipment this ship has.
 	bool hasHyperdrive = attributes.Get("hyperdrive");
 	bool hasScramDrive = attributes.Get("scram drive");
 	bool hasJumpDrive = attributes.Get("jump drive");
-	
-	// Figure out what sort of jump we're making. 100 = normal hyperspace,
-	// 150 = scram drive, 200 = jump drive.
+	JumpType type = NONE;
+
+	// Figure out what sort of jump we're making.
 	if(hasHyperdrive || hasScramDrive)
 		for(const System *link : currentSystem->Links())
 			if(link == destination)
-				return hasScramDrive ? 150 : 100;
-	
+			{
+				type |= hasHyperdrive ? HYPER : NONE;
+				type |= hasScramDrive ? SCRAM : NONE;
+			}
+
 	if(hasJumpDrive)
 		for(const System *link : currentSystem->Neighbors())
 			if(link == destination)
-				return 200;
-	
-	return 0;
+				type |= JUMP;
+
+	return type;
+}
+
+
+
+// Check what type of hyperspace jump this ship will make.
+Ship::JumpType Ship::HyperspaceType() const
+{
+	JumpType types = HyperspaceTypes();
+
+	// Choose drive from the following order: Scram Drive -> Hyperdrive -> Jump Drive
+	JumpType drive = NONE;
+	if((types & SCRAM) != 0 && fuel >= attributes.Get("scram fuel"))
+		drive = SCRAM;
+	else if((types & HYPER) != 0 && fuel >= attributes.Get("hyperdrive fuel"))
+		drive = HYPER;
+	else if((types & JUMP) != 0 && fuel >= attributes.Get("jump fuel"))
+		drive = JUMP;
+
+	return drive;
 }
 
 
@@ -1769,7 +1806,7 @@ void Ship::Recharge(bool atSpaceport)
 {
 	if(IsDestroyed())
 		return;
-	
+
 	if(atSpaceport)
 	{
 		crew = min<int>(max(crew, RequiredCrew()), attributes.Get("bunks"));
@@ -1777,7 +1814,7 @@ void Ship::Recharge(bool atSpaceport)
 	}
 	pilotError = 0;
 	pilotOkay = 0;
-	
+
 	if(!personality.IsDerelict())
 	{
 		if(atSpaceport || attributes.Get("shield generation"))
@@ -1820,10 +1857,10 @@ void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 {
 	// Repair up to the point where it is just barely not disabled.
 	hull = max(hull, MinimumHull());
-	
+
 	// Set the new government.
 	government = capturer->GetGovernment();
-	
+
 	// Transfer some crew over. Only transfer the bare minimum unless even that
 	// is not possible, in which case, share evenly.
 	int totalRequired = capturer->RequiredCrew() + RequiredCrew();
@@ -1832,7 +1869,7 @@ void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 		transfer = max(1, (capturer->Crew() * RequiredCrew()) / totalRequired);
 	capturer->AddCrew(-transfer);
 	AddCrew(transfer);
-	
+
 	// Set the capturer as this ship's parent.
 	SetParent(capturer);
 	SetTargetShip(shared_ptr<Ship>());
@@ -1843,10 +1880,10 @@ void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 	isDisabled = false;
 	hyperspaceSystem = nullptr;
 	landingPlanet = nullptr;
-	
+
 	isSpecial = capturer->isSpecial;
 	personality = capturer->personality;
-	
+
 	// Fighters should flee a disabled ship, but if the player manages to capture
 	// the ship before they flee, the fighters are captured, too.
 	for(const Bay &bay : bays)
@@ -1909,12 +1946,17 @@ int Ship::JumpsRemaining() const
 
 double Ship::JumpFuel() const
 {
-	int type = HyperspaceType();
-	if(type)
-		return type;
-	return attributes.Get("jump drive") ? 200. :
-		attributes.Get("scram drive") ? 150. : 
-		attributes.Get("hyperdrive") ? 100. : 0.;
+	JumpType type = HyperspaceType();
+	if(type == JUMP)
+		return attributes.Get("jump fuel");
+	else if(type == SCRAM)
+		return attributes.Get("scram fuel");
+	else if(type == HYPER)
+		return attributes.Get("hyperdrive fuel");
+
+	return attributes.Get("jump drive") ? attributes.Get("jump fuel") :
+		attributes.Get("scram drive") ? attributes.Get("scram fuel") :
+		attributes.Get("hyperdrive") ? attributes.Get("hyperdrive fuel") : 0.;
 }
 
 
@@ -1926,7 +1968,7 @@ double Ship::IdleHeat() const
 	double coolingEfficiency = CoolingEfficiency();
 	double cooling = coolingEfficiency * attributes.Get("cooling");
 	double activeCooling = coolingEfficiency * attributes.Get("active cooling");
-	
+
 	// Idle heat is the heat level where:
 	// heat = heat * diss + heatGen - cool - activeCool * heat / (100 * mass)
 	// heat = heat * (diss - activeCool / (100 * mass)) + (heatGen - cool)
@@ -1961,7 +2003,7 @@ int Ship::RequiredCrew() const
 {
 	if(attributes.Get("automaton"))
 		return 0;
-	
+
 	// Drones do not need crew, but all other ships need at least one.
 	return max<int>(1, attributes.Get("required crew"));
 }
@@ -2023,7 +2065,7 @@ double Ship::MaxVelocity() const
 int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 {
 	int type = 0;
-	
+
 	const Outfit &weapon = projectile.GetWeapon();
 	double shieldDamage = weapon.ShieldDamage();
 	double hullDamage = weapon.HullDamage();
@@ -2034,7 +2076,7 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 	double slowingDamage = weapon.SlowingDamage();
 	bool wasDisabled = IsDisabled();
 	bool wasDestroyed = IsDestroyed();
-	
+
 	double shieldFraction = 1. - weapon.Piercing();
 	shieldFraction *= 1. / (1. + disruption * .01);
 	if(shields <= 0.)
@@ -2047,7 +2089,7 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 	ionization += ionDamage * (1. - .5 * shieldFraction);
 	disruption += disruptionDamage * (1. - .5 * shieldFraction);
 	slowness += slowingDamage * (1. - .5 * shieldFraction);
-	
+
 	if(hitForce)
 	{
 		Point d = position - projectile.Position();
@@ -2055,7 +2097,7 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 		if(distance)
 			ApplyForce((hitForce / distance) * d);
 	}
-	
+
 	// Recalculate the disabled ship check.
 	isDisabled = true;
 	isDisabled = IsDisabled();
@@ -2069,7 +2111,7 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 			&& (Shields() < .9 || Hull() < .9 || !personality.IsForbearing())
 			&& !personality.IsPacifist() && (shieldDamage > 0. || hullDamage > 0.))
 		type |= ShipEvent::PROVOKE;
-	
+
 	return type;
 }
 
@@ -2082,7 +2124,7 @@ void Ship::ApplyForce(const Point &force)
 	double currentMass = Mass();
 	if(!currentMass)
 		return;
-	
+
 	acceleration += force / currentMass;
 }
 
@@ -2112,11 +2154,11 @@ bool Ship::CanCarry(const Ship &ship) const
 	bool isFighter = (ship.attributes.Category() == "Fighter");
 	if(!isFighter && ship.attributes.Category() != "Drone")
 		return false;
-	
+
 	int free = BaysFree(isFighter);
 	if(!free)
 		return false;
-	
+
 	for(const auto &it : escorts)
 	{
 		auto escort = it.lock();
@@ -2140,12 +2182,12 @@ bool Ship::Carry(const shared_ptr<Ship> &ship)
 {
 	if(!ship)
 		return false;
-	
+
 	bool isFighter = ship->attributes.Category() == "Fighter";
 	bool isDrone = ship->attributes.Category() == "Drone";
 	if(!(isFighter || isDrone))
 		return false;
-	
+
 	for(Bay &bay : bays)
 		if((bay.isFighter == isFighter) && !bay.ship)
 		{
@@ -2221,12 +2263,12 @@ const CargoHold &Ship::Cargo() const
 void Ship::Jettison(const string &commodity, int tons)
 {
 	cargo.Remove(commodity, tons);
-	
+
 	// Jettisoned cargo must carry some of the ship's heat with it. Otherwise
 	// jettisoning cargo would increase the ship's temperature.
 	double shipMass = Mass();
 	heat *= shipMass / (shipMass + tons);
-	
+
 	static const int perBox = 5;
 	for( ; tons >= perBox; tons -= perBox)
 		jettisoned.emplace_back(new Flotsam(commodity, perBox));
@@ -2240,13 +2282,13 @@ void Ship::Jettison(const Outfit *outfit, int count)
 		return;
 
 	cargo.Remove(outfit, count);
-	
+
 	// Jettisoned cargo must carry some of the ship's heat with it. Otherwise
 	// jettisoning cargo would increase the ship's temperature.
 	double mass = outfit->Get("mass");
 	double shipMass = Mass();
 	heat *= shipMass / (shipMass + count * mass);
-	
+
 	const int perBox = (mass <= 0.) ? count : (mass > 5.) ? 1 : static_cast<int>(5. / mass);
 	while(count > 0)
 	{
@@ -2304,7 +2346,7 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		attributes.Add(*outfit, count);
 		if(outfit->IsWeapon())
 			armament.Add(outfit, count);
-		
+
 		if(outfit->Get("cargo space"))
 			cargo.SetSize(attributes.Get("cargo space"));
 		if(outfit->Get("hull"))
@@ -2335,19 +2377,19 @@ bool Ship::CanFire(const Outfit *outfit) const
 {
 	if(!outfit || !outfit->IsWeapon())
 		return false;
-	
+
 	if(outfit->Ammo())
 	{
 		auto it = outfits.find(outfit->Ammo());
 		if(it == outfits.end() || it->second <= 0)
 			return false;
 	}
-	
+
 	if(energy < outfit->FiringEnergy())
 		return false;
 	if(fuel < outfit->FiringFuel())
 		return false;
-	
+
 	return true;
 }
 
@@ -2361,7 +2403,7 @@ void Ship::ExpendAmmo(const Outfit *outfit)
 		return;
 	if(outfit->Ammo())
 		AddOutfit(outfit->Ammo(), -1);
-	
+
 	energy -= outfit->FiringEnergy();
 	fuel -= outfit->FiringFuel();
 	heat += outfit->FiringHeat();
@@ -2469,7 +2511,7 @@ void Ship::SetParent(const shared_ptr<Ship> &ship)
 	shared_ptr<Ship> oldParent = parent.lock();
 	if(oldParent)
 		oldParent->RemoveEscort(*this);
-	
+
 	parent = ship;
 	if(ship)
 		ship->AddEscort(*this);
@@ -2517,7 +2559,7 @@ double Ship::MinimumHull() const
 {
 	if(neverDisabled)
 		return 0.;
-	
+
 	double maximumHull = attributes.Get("hull");
 	return max(.20 * maximumHull, min(.50 * maximumHull, 400.));
 }
@@ -2531,12 +2573,12 @@ double Ship::AddHull(double rate)
 	double added = min(rate, attributes.Get("hull") - hull);
 	hull += added;
 	rate -= added;
-	
+
 	for(Bay &bay : bays)
 	{
 		if(!bay.ship)
 			continue;
-		
+
 		double myGen = bay.ship->Attributes().Get("hull repair rate");
 		double myMax = bay.ship->Attributes().Get("hull");
 		bay.ship->hull = min(myMax, bay.ship->hull + myGen);
@@ -2558,12 +2600,12 @@ double Ship::AddShields(double rate)
 	double added = min(rate, attributes.Get("shields") - shields);
 	shields += added;
 	rate -= added;
-	
+
 	for(Bay &bay : bays)
 	{
 		if(!bay.ship)
 			continue;
-		
+
 		double myGen = bay.ship->Attributes().Get("shield generation");
 		double myMax = bay.ship->Attributes().Get("shields");
 		bay.ship->shields = min(myMax, bay.ship->shields + myGen);
@@ -2584,7 +2626,7 @@ void Ship::CreateExplosion(list<Effect> &effects, bool spread)
 {
 	if(!HasSprite() || !GetMask().IsLoaded() || explosionEffects.empty())
 		return;
-	
+
 	// Bail out if this loops enough times, just in case.
 	for(int i = 0; i < 10; ++i)
 	{
@@ -2622,17 +2664,17 @@ void Ship::CreateSparks(list<Effect> &effects, const string &name, double amount
 {
 	if(forget)
 		return;
-	
+
 	// Limit the number of sparks, depending on the size of the sprite.
 	amount = min(amount, Width() * Height() * .0006);
-	
+
 	const Effect *effect = GameData::Effects().Get(name);
 	while(true)
 	{
 		amount -= Random::Real();
 		if(amount <= 0.)
 			break;
-		
+
 		Point point((Random::Real() - .5) * Width(),
 			(Random::Real() - .5) * Height());
 		if(GetMask().Contains(point, Angle()))

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -54,16 +54,6 @@ namespace {
 
 
 
-inline constexpr Ship::JumpType operator|(const Ship::JumpType first, const Ship::JumpType second) noexcept {
-	return static_cast<Ship::JumpType>(static_cast<unsigned int>(first) | static_cast<unsigned int>(second));
-}
-
-inline Ship::JumpType& operator|=(Ship::JumpType& first, const Ship::JumpType second) noexcept {
-	return first = first | second;
-}
-
-
-
 void Ship::Load(const DataNode &node)
 {
 	if(node.Size() >= 2)
@@ -1678,7 +1668,7 @@ Ship::JumpType Ship::CheckHyperspace() const
 	if(type == SCRAM)
 	{
 		double deviation = fabs(direction.Unit().Cross(velocity));
-		if(deviation > attributes.Get("deviation"))
+		if(deviation > attributes.Get("scram deviation"))
 			return NONE;
 	}
 	else if(velocity.Length() > attributes.Get("jump speed"))

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -477,4 +477,14 @@ private:
 
 
 
+inline constexpr Ship::JumpType operator|(const Ship::JumpType first, const Ship::JumpType second) noexcept {
+	return static_cast<Ship::JumpType>(static_cast<unsigned int>(first) | static_cast<unsigned int>(second));
+}
+
+inline Ship::JumpType& operator|=(Ship::JumpType& first, const Ship::JumpType second) noexcept {
+	return first = first | second;
+}
+
+
+
 #endif

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -51,22 +51,22 @@ class Ship : public Body, public std::enable_shared_from_this<Ship> {
 public:
 	// These are all the possible category strings for ships.
 	static const std::vector<std::string> CATEGORIES;
-	
+
 	class Bay {
 	public:
 		Bay(double x, double y, bool isFighter) : point(x * .5, y * .5), isFighter(isFighter) {}
 		// Copying a bay does not copy the ship inside it.
 		Bay(const Bay &b) : point(b.point), isFighter(b.isFighter), side(b.side), facing(b.facing) {}
-		
+
 		Point point;
 		std::shared_ptr<Ship> ship;
 		bool isFighter = false;
-		
+
 		uint8_t side = 0;
 		static const uint8_t INSIDE = 0;
 		static const uint8_t OVER = 1;
 		static const uint8_t UNDER = 2;
-		
+
 		uint8_t facing = 0;
 		static const uint8_t FORWARD = 0;
 		static const uint8_t LEFT = 1;
@@ -77,11 +77,19 @@ public:
 	public:
 		EnginePoint(double x, double y, double zoom) : Point(x, y), zoom(zoom) {}
 		double Zoom() const { return zoom; }
-		
+
 	private:
 		double zoom;
 	};
-	
+
+	enum JumpType : unsigned int
+	{
+		NONE = 0x0,
+		HYPER = 0x1,
+		SCRAM = 0x2,
+		JUMP = 0x4
+	};
+
 public:
 	/* Functions provided by the Body base class:
 	bool HasSprite() const;
@@ -106,10 +114,10 @@ public:
 	void FinishLoading();
 	// Save a full description of this ship, as currently configured.
 	void Save(DataWriter &out) const;
-	
+
 	// Get the name of this particular ship.
 	const std::string &Name() const;
-	
+
 	// Get the name of this model of ship.
 	const std::string &ModelName() const;
 	const std::string &PluralModelName() const;
@@ -120,7 +128,7 @@ public:
 	int64_t ChassisCost() const;
 	// Get the licenses needed to buy or operate this ship.
 	const std::vector<std::string> &Licenses() const;
-	
+
 	// When creating a new ship, you must set the following:
 	void Place(Point position = Point(), Point velocity = Point(), Angle angle = Angle());
 	void SetName(const std::string &name);
@@ -129,14 +137,14 @@ public:
 	void SetGovernment(const Government *government);
 	void SetIsSpecial(bool special = true);
 	bool IsSpecial() const;
-	
+
 	// If a ship belongs to the player, the player can give it commands.
 	void SetIsYours(bool yours = true);
 	bool IsYours() const;
 	// A parked ship stays on a planet and requires no daily salary payments.
 	void SetIsParked(bool parked = true);
 	bool IsParked() const;
-	
+
 	// Access the ship's personality, which affects how the AI behaves.
 	const Personality &GetPersonality() const;
 	void SetPersonality(const Personality &other);
@@ -144,7 +152,7 @@ public:
 	// object is given the government's default will be used.
 	void SetHail(const Phrase &phrase);
 	std::string GetHail() const;
-	
+
 	// Set the commands for this ship to follow this timestep.
 	void SetCommands(const Command &command);
 	const Command &Commands() const;
@@ -161,19 +169,19 @@ public:
 	// Scan the target, if able and commanded to. Return a ShipEvent bitmask
 	// giving the types of scan that succeeded.
 	int Scan();
-	
+
 	// Fire any weapons that are ready to fire. If an anti-missile is ready,
 	// instead of firing here this function returns true and it can be fired if
 	// collision detection finds a missile in range.
 	bool Fire(std::list<Projectile> &projectiles, std::list<Effect> &effects);
 	// Fire an anti-missile. Returns true if the missile was killed.
 	bool FireAntiMissile(const Projectile &projectile, std::list<Effect> &effects);
-	
+
 	// Get the system this ship is in.
 	const System *GetSystem() const;
 	// If the ship is landed, get the planet it has landed on.
 	const Planet *GetPlanet() const;
-	
+
 	// Check the status of this ship.
 	bool IsCapturable() const;
 	bool IsTargetable() const;
@@ -196,17 +204,18 @@ public:
 	bool IsEnteringHyperspace() const;
 	// Check if this ship is entering or leaving hyperspace.
 	bool IsHyperspacing() const;
-	// Check if this ship is currently able to enter hyperspace to it target.
-	int CheckHyperspace() const;
-	// Check what type of hyperspce jump this ship is making (0 = not allowed,
-	// 100 = hyperdrive, 150 = scram drive, 200 = jump drive).
-	int HyperspaceType() const;
-	
+	// Check if this ship is currently able to enter hyperspace to its target.
+	JumpType CheckHyperspace() const;
+	// Check what type of hyperspace jump this ship can make.
+	JumpType HyperspaceTypes() const;
+	// Check what type of hyperspace jump this ship will make.
+	JumpType HyperspaceType() const;
+
 	// Check if the ship is thrusting. If so, the engine sound should be played.
 	bool IsThrusting() const;
 	// Get the points from which engine flares should be drawn.
 	const std::vector<EnginePoint> &EnginePoints() const;
-	
+
 	// Mark a ship as destroyed, or bring back a destroyed ship.
 	void Destroy();
 	void SelfDestruct();
@@ -221,7 +230,7 @@ public:
 	double TransferFuel(double amount, Ship *to);
 	// Mark this ship as property of the given ship.
 	void WasCaptured(const std::shared_ptr<Ship> &capturer);
-	
+
 	// Get characteristics of this ship, as a fraction between 0 and 1.
 	double Shields() const;
 	double Hull() const;
@@ -237,20 +246,20 @@ public:
 	double IdleHeat() const;
 	// Calculate the multiplier for cooling efficiency.
 	double CoolingEfficiency() const;
-	
+
 	// Access how many crew members this ship has or needs.
 	int Crew() const;
 	int RequiredCrew() const;
 	void AddCrew(int count);
 	// Check if this is a ship that can be used as a flagship.
 	bool CanBeFlagship() const;
-	
+
 	// Get this ship's movement characteristics.
 	double Mass() const;
 	double TurnRate() const;
 	double Acceleration() const;
 	double MaxVelocity() const;
-	
+
 	// This ship just got hit by the given projectile. Take damage according to
 	// what sort of weapon the projectile it. The return value is a ShipEvent
 	// type, which may be a combination of PROVOKED, DISABLED, and DESTROYED.
@@ -260,7 +269,7 @@ public:
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.
 	void ApplyForce(const Point &force);
-	
+
 	// Check if this ship has fighter or drone bays.
 	bool HasBays() const;
 	// Check how many fighter and drone bays are not occupied at present. This
@@ -282,14 +291,14 @@ public:
 	// Adjust the positions and velocities of any visible carried fighters or
 	// drones. If any are visible, return true.
 	bool PositionFighters() const;
-	
+
 	// Get cargo information.
 	CargoHold &Cargo();
 	const CargoHold &Cargo() const;
 	// Display box effects from jettisoning this much cargo.
 	void Jettison(const std::string &commodity, int tons);
 	void Jettison(const Outfit *outfit, int count);
-	
+
 	// Get the current attributes of this ship.
 	const Outfit &Attributes() const;
 	// Get the attributes of this ship chassis before any outfits were added.
@@ -300,7 +309,7 @@ public:
 	int OutfitCount(const Outfit *outfit) const;
 	// Add or remove outfits. (To remove, pass a negative number.)
 	void AddOutfit(const Outfit *outfit, int count);
-	
+
 	// Get the list of weapons.
 	Armament &GetArmament();
 	const std::vector<Hardpoint> &Weapons() const;
@@ -310,7 +319,7 @@ public:
 	// Fire the given weapon (i.e. deduct whatever energy, ammo, or fuel it uses
 	// and add whatever heat it generates. Assume that CanFire() is true.
 	void ExpendAmmo(const Outfit *outfit);
-	
+
 	// Each ship can have a target system (to travel to), a target planet (to
 	// land on) and a target ship (to move to, and attack if hostile).
 	std::shared_ptr<Ship> GetTargetShip() const;
@@ -320,7 +329,7 @@ public:
 	// Mining target.
 	std::shared_ptr<Minable> GetTargetAsteroid() const;
 	std::shared_ptr<Flotsam> GetTargetFlotsam() const;
-	
+
 	// Set this ship's targets.
 	void SetTargetShip(const std::shared_ptr<Ship> &ship);
 	void SetShipToAssist(const std::shared_ptr<Ship> &ship);
@@ -329,15 +338,15 @@ public:
 	// Mining target.
 	void SetTargetAsteroid(const std::shared_ptr<Minable> &asteroid);
 	void SetTargetFlotsam(const std::shared_ptr<Flotsam> &flotsam);
-	
+
 	// Manage escorts. When you set this ship's parent, it will automatically
 	// register itself as an escort of that ship, and unregister itself from any
 	// previous parent it had.
 	void SetParent(const std::shared_ptr<Ship> &ship);
 	std::shared_ptr<Ship> GetParent() const;
 	const std::vector<std::weak_ptr<const Ship>> &GetEscorts() const;
-	
-	
+
+
 private:
 	// Add or remove a ship from this ship's list of escorts.
 	void AddEscort(const Ship &ship);
@@ -353,8 +362,8 @@ private:
 	void CreateExplosion(std::list<Effect> &effects, bool spread = false);
 	// Place a "spark" effect, like ionization or disruption.
 	void CreateSparks(std::list<Effect> &effects, const std::string &name, double amount);
-	
-	
+
+
 private:
 	/* Protected member variables of the Body class:
 	Point position;
@@ -364,7 +373,7 @@ private:
 	int swizzle;
 	const Government *government;
 	*/
-	
+
 	// Characteristics of the chassis:
 	const Ship *base = nullptr;
 	std::string modelName;
@@ -372,10 +381,10 @@ private:
 	std::string description;
 	// Characteristics of this particular ship:
 	std::string name;
-	
+
 	// Licenses needed to operate this ship.
 	std::vector<std::string> licenses;
-	
+
 	int forget = 0;
 	bool isInSystem = true;
 	// "Special" ships cannot be forgotten, and if they land on a planet, they
@@ -398,12 +407,12 @@ private:
 	// Cargo and outfit scanning takes time.
 	double cargoScan = 0.;
 	double outfitScan = 0.;
-	
+
 	Command commands;
-	
+
 	Personality personality;
 	const Phrase *hail = nullptr;
-	
+
 	// Installed outfits, cargo, etc.:
 	Outfit attributes;
 	Outfit baseAttributes;
@@ -411,15 +420,15 @@ private:
 	std::map<const Outfit *, int> outfits;
 	CargoHold cargo;
 	std::list<std::shared_ptr<Flotsam>> jettisoned;
-	
+
 	std::vector<Bay> bays;
-	
+
 	std::vector<EnginePoint> enginePoints;
 	Armament armament;
 	// While loading, keep track of which outfits already have been equipped.
 	// (That is, they were specified as linked to a given gun or turret point.)
 	std::map<const Outfit *, int> equipped;
-	
+
 	// Various energy levels:
 	double shields = 0.;
 	double hull = 0.;
@@ -431,28 +440,28 @@ private:
 	double slowness = 0.;
 	// Acceleration can be created by engines, firing weapons, or weapon impacts.
 	Point acceleration;
-	
+
 	int crew = 0;
 	int pilotError = 0;
 	int pilotOkay = 0;
-	
+
 	// Current status of this particular ship:
 	const System *currentSystem = nullptr;
 	// A Ship can be locked into one of three special states: landing,
 	// hyperspacing, and exploding. Each one must track some special counters:
 	const Planet *landingPlanet = nullptr;
-	
+
 	int hyperspaceCount = 0;
 	const System *hyperspaceSystem = nullptr;
-	int hyperspaceType = 0;
+	JumpType hyperspaceType = NONE;
 	Point hyperspaceOffset;
-	
+
 	std::map<const Effect *, int> explosionEffects;
 	unsigned explosionRate = 0;
 	unsigned explosionCount = 0;
 	unsigned explosionTotal = 0;
 	std::map<const Effect *, int> finalExplosions;
-	
+
 	// Target ships, planets, systems, etc.
 	std::weak_ptr<Ship> targetShip;
 	std::weak_ptr<Ship> shipToAssist;
@@ -460,7 +469,7 @@ private:
 	const System *targetSystem = nullptr;
 	std::weak_ptr<Minable> targetAsteroid;
 	std::weak_ptr<Flotsam> targetFlotsam;
-	
+
 	// Links between escorts and parents.
 	std::vector<std::weak_ptr<const Ship>> escorts;
 	std::weak_ptr<Ship> parent;


### PR DESCRIPTION
This PR makes the drives (hyper, scam and jump) more customizable for modders. For instance, you can now change the amount of fuel a hyperdrive uses per jump, make a drive that is both scram and jump, and stuff like that. Not much more really. It also fixes https://github.com/endless-sky/endless-sky/issues/1238. 

My code editor strips lines with just whitespaces, so I hope that's not a big problem. Also, I noticed several typos in the comments related to the drives, so I fixed them. If I misunderstood a comment, please tell me.
As for as I know, my code follows the style guide, but a lot of stuff (like scoped enum or unscoped enum?) are missing, so I used the convention already in the code base.

Any comments appreciated! Thanks