### PR TITLE
Allow for negative (total) hull repair rate

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1235,7 +1235,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		// Recharge is limited by available energy. Extra recharge capacity can
 		// be used on fighters this ship is carrying.
 		double hullRate = attributes.Get("hull repair rate");
-		if(hullRate > 0.)
+		if(hullRate)
 		{
 			double hullEnergy = attributes.Get("hull energy");
 			double hullHeat = attributes.Get("hull heat");
@@ -1245,7 +1245,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		}
 		
 		double shieldRate = attributes.Get("shield generation");
-		if(shieldRate > 0.)
+		if(shieldRate)
 		{
 			double shieldEnergy = attributes.Get("shield energy");
 			double shieldHeat = attributes.Get("shield heat");
@@ -2528,7 +2528,7 @@ double Ship::MinimumHull() const
 // ship is carrying fighters, add to them as well.
 double Ship::AddHull(double rate)
 {
-	double added = min(rate, attributes.Get("hull") - hull);
+	double added = max(min(rate, attributes.Get("hull") - hull), -hull);
 	hull += added;
 	rate -= added;
 	
@@ -2555,7 +2555,7 @@ double Ship::AddHull(double rate)
 
 double Ship::AddShields(double rate)
 {
-	double added = min(rate, attributes.Get("shields") - shields);
+	double added = max(min(rate, attributes.Get("shields") - shields), -shields);
 	shields += added;
 	rate -= added;
 	


### PR DESCRIPTION
This Pull simply allows the total hull repair rate and shield generation of a ship to become negative.
I did not touch the bays, i.e. fighters and drones are not affected by negative repair rates of their carriers.

I want this for:
- my ancient wreckage (#2369)
- my dead alien bioships (#2372)
- my "hull breach" outfit (#2420)

I am fully aware that ships with a negative hull repair rate get stuck in space if they get disabled in space (either in combat or due to the negative hull repair rate). In the next frame after you assist that ship, it drops below the MinimumHull() again and get's instantly disabled again.
That ship in question is simply too damaged that a standard crew of non-experts could easily repair it in space.