### PR TITLE
Deselect ship on click in shop interface

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -79,6 +79,7 @@ void ShopPanel::Draw()
 	// Clear the list of clickable zones.
 	zones.clear();
 	categoryZones.clear();
+	delete listZone;
 	
 	DrawSidebar();
 	DrawButtons();
@@ -166,6 +167,10 @@ void ShopPanel::DrawSidebar()
 		point.X() += ICON_TILE;
 	}
 	point.Y() += ICON_TILE;
+
+	listZone = new ClickZone<std::string>(Point(Screen::Right() - SIDE_WIDTH/2, (point.Y() + Screen::Top())/2),
+			Point(SIDE_WIDTH, point.Y() - Screen::Top()),
+			"ListZone");
 	
 	if(playerShip)
 	{
@@ -599,7 +604,9 @@ bool ShopPanel::Click(int x, int y, int clicks)
 				selectedShip = zone.GetShip();
 			}
 			else
+			{
 				selectedOutfit = zone.GetOutfit();
+			}
 			
 			scrollDetailsIntoView = true;
 			// Reset selectedBottomY so that Step() waits for it to be updated
@@ -608,7 +615,13 @@ bool ShopPanel::Click(int x, int y, int clicks)
 			mainScroll = max(0., mainScroll + zone.ScrollY());
 			return true;
 		}
-		
+	if(listZone->Contains(point))
+	{
+	// check whether click is inside the ship field, but outside any ship fields
+		playerShips.clear();
+		playerShip = nullptr;
+
+	}
 	return true;
 }
 

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -124,6 +124,7 @@ protected:
 	
 	std::vector<Zone> zones;
 	std::vector<ClickZone<std::string>> categoryZones;
+	ClickZone<std::string> *listZone = nullptr;
 	
 	std::map<std::string, std::set<std::string>> catalog;
 	const std::vector<std::string> &categories;


### PR DESCRIPTION
This simple patch lets the user deselect a ship with normal clicks, which makes buying outfits into cargo a lot more discoverable as proposed in #2182.

Currently the two commits represent different deselection methods.
1. Deselect on simple click. Drag and drop doesn't work as expected, as dragging a ship would deselect it.
2. Deselect on double click. Drag and drop is not altered. -- Current version.

I have directly added the clicks variable into the SideSelect function, if this is considered bad style, I would be glad for corrections.