### PR TITLE
Changed z index of bays "under"

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1523,6 +1523,15 @@ void Engine::AddSprites(const Ship &ship)
 	double cloak = ship.Cloaking();
 	bool drawCloaked = (cloak && ship.GetGovernment()->IsPlayer());
 	
+	if(hasFighters)
+		for(const Ship::Bay &bay : ship.Bays())
+			if(bay.side == Ship::Bay::UNDER && bay.ship)
+			{
+				if(drawCloaked)
+					draw[calcTickTock].AddSwizzled(*bay.ship, 7);
+				draw[calcTickTock].Add(*bay.ship, cloak);
+			}
+	
 	if(ship.IsThrusting())
 		for(const Ship::EnginePoint &point : ship.EnginePoints())
 		{
@@ -1536,15 +1545,6 @@ void Engine::AddSprites(const Ship &ship)
 					draw[calcTickTock].Add(sprite, cloak);
 				}
 		}
-	
-	if(hasFighters)
-		for(const Ship::Bay &bay : ship.Bays())
-			if(bay.side == Ship::Bay::UNDER && bay.ship)
-			{
-				if(drawCloaked)
-					draw[calcTickTock].AddSwizzled(*bay.ship, 7);
-				draw[calcTickTock].Add(*bay.ship, cloak);
-			}
 	
 	if(drawCloaked)
 		draw[calcTickTock].AddSwizzled(ship, 7);


### PR DESCRIPTION
Fighters and drones "under" should be under any engine flares.
I simply swapped the two code blocks, drawing "under" bays before drawing engine flares now.