### PR TITLE
Substitutions in conditions

### DIFF
--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -40,6 +40,7 @@ namespace {
 			{"=", [](int a, int b) { return b; }},
 			{"+=", [](int a, int b) { return a + b; }},
 			{"-=", [](int a, int b) { return a - b; }},
+			{"*=", [](int a, int b) { return a * b; }},
 			{"<?=", [](int a, int b) { return min(a, b); }},
 			{">?=", [](int a, int b) { return max(a, b); }}
 		};

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "DataNode.h"
 #include "DataWriter.h"
+#include "Format.h"
 #include "Random.h"
 
 #include <cmath>

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -92,6 +92,29 @@ bool ConditionSet::IsEmpty() const
 
 
 
+// Do text replacement throughout this ConditionSet.
+ConditionSet ConditionSet::Substitute(const map<string, string> &subs) const
+{
+	ConditionSet result = *this;
+	DataNode someNode = DataNode();
+	for(Expression &expression : result.expressions)
+	{
+		expression.name = Format::Replace(expression.name, subs);
+		expression.strValue = Format::Replace(expression.strValue, subs);
+		if (expression.value == 0 && expression.strValue.length() > 0 && someNode.IsNumber(expression.strValue) && someNode.Value(expression.strValue) != 0)
+		{
+			expression.value = someNode.Value(expression.strValue);
+			expression.strValue = "";
+		}
+	}
+	for(ConditionSet &child : result.children) {
+		child = child.Substitute(subs);
+	}
+	return result;
+}
+
+
+
 // Read a single condition from a data node.
 void ConditionSet::Add(const DataNode &node)
 {

--- a/source/ConditionSet.h
+++ b/source/ConditionSet.h
@@ -36,6 +36,10 @@ public:
 	// Check if there are any entries in this set.
 	bool IsEmpty() const;
 	
+	// Do text replacement throughout this ConditionSet. This returns a new
+	// ConditionSet object with things like the player's name filled in.
+	ConditionSet Substitute(const std::map<std::string, std::string> &subs) const;
+	
 	// Read a single condition from a data node.
 	void Add(const DataNode &node);
 	bool Add(const std::string &firstToken, const std::string &secondToken);

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -291,8 +291,12 @@ Conversation Conversation::Substitute(const map<string, string> &subs) const
 {
 	Conversation result = *this;
 	for(Node &node : result.nodes)
+	{
 		for(pair<string, int> &choice : node.data)
 			choice.first = Format::Replace(choice.first, subs);
+		if(!node.conditions.IsEmpty())
+			node.conditions = node.conditions.Substitute(subs);
+	}
 	return result;
 }
 

--- a/source/DataNode.cpp
+++ b/source/DataNode.cpp
@@ -77,12 +77,19 @@ double DataNode::Value(int index) const
 		PrintTrace("Requested token index (" + to_string(index) + ") is out of bounds:");
 		return 0.;
 	}
-	
+	return Value(tokens[index]);
+}
+
+
+
+// Convert the given string to a numerical value.
+double DataNode::Value(const string &numString) const
+{
 	// Allowed format: "[+-]?[0-9]*[.]?[0-9]*([eE][+-]?[0-9]*)?".
-	const char *it = tokens[index].c_str();
+	const char *it = numString.c_str();
 	if(*it != '-' && *it != '.' && *it != '+' && !(*it >= '0' && *it <= '9'))
 	{
-		PrintTrace("Cannot convert value \"" + tokens[index] + "\" to a number:");
+		PrintTrace("Cannot convert value \"" + numString + "\" to a number:");
 		return 0.;
 	}
 	
@@ -134,11 +141,18 @@ bool DataNode::IsNumber(int index) const
 	// Make sure this token exists and is not empty.
 	if(static_cast<size_t>(index) >= tokens.size() || tokens[index].empty())
 		return false;
-	
+	return IsNumber(tokens[index]);
+}
+
+
+
+// Check if the given string is a number in a format that this class is able to parse.
+bool DataNode::IsNumber(const string &testString) const
+{
 	bool hasDecimalPoint = false;
 	bool hasExponent = false;
 	bool isLeading = true;
-	for(const char *it = tokens[index].c_str(); *it; ++it)
+	for(const char *it = testString.c_str(); *it; ++it)
 	{
 		// If this is the start of the number or the exponent, it is allowed to
 		// be a '-' or '+' sign.

--- a/source/DataNode.h
+++ b/source/DataNode.h
@@ -42,9 +42,11 @@ public:
 	// Convert the token at the given index to a number. This returns 0 if the
 	// index is out of range or the token cannot be interpreted as a number.
 	double Value(int index) const;
+	double Value(const std::string &numString = "") const;
 	// Check if the token at the given index is a number in a format that this
 	// class is able to parse.
 	bool IsNumber(int index) const;
+	bool IsNumber(const std::string &testString = "") const;
 	
 	// Check if this node has any children. If so, the iterator functions below
 	// can be used to access them.

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -508,6 +508,7 @@ bool Mission::HasFullClearance() const
 // Check if it's possible to offer or complete this mission right now.
 bool Mission::CanOffer(const PlayerInfo &player) const
 {
+	map<string, string> subs;
 	if(location == BOARDING || location == ASSISTING)
 	{
 		if(!player.BoardingShip())
@@ -515,20 +516,26 @@ bool Mission::CanOffer(const PlayerInfo &player) const
 		
 		if(!sourceFilter.Matches(*player.BoardingShip()))
 			return false;
+		
+		subs["<origin>"] = player.BoardingShip()->Name();
+		subs["<originGov>"] = player.BoardingShip()->GetGovernment()->GetName();
 	}
 	else
 	{
 		if(source && source != player.GetPlanet())
 			return false;
-	
+		
 		if(!sourceFilter.Matches(player.GetPlanet()))
 			return false;
+		
+		subs["<origin>"] = player.GetPlanet()->Name();
+		subs["<originGov>"] = player.GetPlanet()->GetGovernment()->GetName();
 	}
 	
-	if(!toOffer.Test(player.Conditions()))
+	if(!toOffer.Substitute(subs).Test(player.Conditions()))
 		return false;
 	
-	if(!toFail.IsEmpty() && toFail.Test(player.Conditions()))
+	if(!toFail.IsEmpty() && toFail.Substitute(subs).Test(player.Conditions()))
 		return false;
 	
 	if(repeat)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -973,9 +973,9 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 		subs["<originGov>"] = player.BoardingShip()->GetGovernment()->GetName();
 	}
 	subs["<planet>"] = result.destination ? result.destination->Name() : "";
-	subs["<planetGov>"] = result.destination ? result.destination->GetGovernment()->Name() : "";
+	subs["<planetGov>"] = result.destination ? result.destination->GetGovernment()->GetName() : "";
 	subs["<system>"] = result.destination ? result.destination->GetSystem()->Name() : "";
-	subs["<systemGov>"] = result.destination ? result.destination->GetSystem()->GetGovernment()->Name() : "";
+	subs["<systemGov>"] = result.destination ? result.destination->GetSystem()->GetGovernment()->GetName() : "";
 	subs["<destination>"] = subs["<planet>"] + " in the " + subs["<system>"] + " system";
 	subs["<date>"] = result.deadline.ToString();
 	subs["<day>"] = result.deadline.LongString();

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -953,26 +953,29 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	if(deadlineBase || deadlineMultiplier)
 		result.deadline = player.GetDate() + deadlineBase + deadlineMultiplier * jumps;
 	
-	// Copy the conditions. The offer conditions must be copied too, because they
-	// may depend on a condition that other mission offers might change.
-	result.toOffer = toOffer;
-	result.toComplete = toComplete;
-	result.toFail = toFail;
-	
 	// Generate the substitutions map.
 	map<string, string> subs;
 	subs["<commodity>"] = result.cargo;
 	subs["<tons>"] = to_string(result.cargoSize) + (result.cargoSize == 1 ? " ton" : " tons");
+	subs["<tonsNum>"] = to_string(result.cargoSize);
 	subs["<cargo>"] = subs["<tons>"] + " of " + subs["<commodity>"];
 	subs["<bunks>"] = to_string(result.passengers);
 	subs["<passengers>"] = (result.passengers == 1) ? "passenger" : "passengers";
 	subs["<fare>"] = (result.passengers == 1) ? "a passenger" : (subs["<bunks>"] + " passengers");
 	if(player.GetPlanet())
+	{
 		subs["<origin>"] = player.GetPlanet()->Name();
+		subs["<originGov>"] = player.GetPlanet()->GetGovernment()->GetName();
+	}
 	else if(player.BoardingShip())
+	{
 		subs["<origin>"] = player.BoardingShip()->Name();
+		subs["<originGov>"] = player.BoardingShip()->GetGovernment()->GetName();
+	}
 	subs["<planet>"] = result.destination ? result.destination->Name() : "";
+	subs["<planetGov>"] = result.destination ? result.destination->GetGovernment()->Name() : "";
 	subs["<system>"] = result.destination ? result.destination->GetSystem()->Name() : "";
+	subs["<systemGov>"] = result.destination ? result.destination->GetSystem()->GetGovernment()->Name() : "";
 	subs["<destination>"] = subs["<planet>"] + " in the " + subs["<system>"] + " system";
 	subs["<date>"] = result.deadline.ToString();
 	subs["<day>"] = result.deadline.LongString();
@@ -995,6 +998,12 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	// Instantiate the NPCs. This also fills in the "<npc>" substitution.
 	for(const NPC &npc : npcs)
 		result.npcs.push_back(npc.Instantiate(subs, player.GetSystem(), result.destination->GetSystem()));
+	
+	// Copy the conditions. The offer conditions must be copied too, because they
+	// may depend on a condition that other mission offers might change.
+	result.toOffer = toOffer.Substitute(subs);
+	result.toComplete = toComplete.Substitute(subs);
+	result.toFail = toFail.Substitute(subs);
 	
 	// Instantiate the actions. The "complete" action is always first so that
 	// the "<payment>" substitution can be filled in.

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -322,8 +322,11 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, int jumps, i
 	// Fill in the payment amount if this is the "complete" action (which comes
 	// before all the others in the list).
 	if(trigger == "complete" || result.payment)
+	{
+		subs["<paymentNum>"] = to_string(result.payment);
 		subs["<payment>"] = Format::Number(result.payment)
 			+ (result.payment == 1 ? " credit" : " credits");
+	}
 	
 	if(!dialogText.empty())
 		result.dialogText = Format::Replace(dialogText, subs);
@@ -335,7 +338,7 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, int jumps, i
 	
 	result.fail = fail;
 	
-	result.conditions = conditions;
+	result.conditions = conditions.Substitute(subs);
 	
 	return result;
 }


### PR DESCRIPTION
I think I got it done (#2351). At least it works now on my local build, after a few failed attempts. :-)

The `<...>` substitution now also applies to all conditions and not only to conversation texts. All = all: conditions in conversations (i.e. `branch` conditions and `apply` conditions), and conditions outside conversations, i.e. in each of the on-triggers as well as in the to-triggers (`toOffer`, `toFail`, `toComplete`).
For the toOffer trigger, the substitution mostly can only apply after the CanOffer has been checked, but at least `<origin>` and *new* `<originGov>` are available in the `toOffer` by now.

I added a few new replacements:
- `<originGov>`, `<planetGov>`, `<systemGov>` - all 3 yielding the GovernmentName of the origin, (dest.) planet, (dest.) system respectively.
- `<tonsNum>` and `<paymentNum>` since I wanted the first one already for a while now.

This patch allows for, but is not limited to:
- missions / jobs being offered depending on your reputation at the origin
```
	to offer
		"reputation: <originGov>" > 100
```
- modifying your reputation with either source or destination
- keeping track of certain things (I will provide examples for that, but may be I will wait until #2449 is merged because it will be another modification of the jobs.txt)
- up to certain limits, this even allows for job chains, I will provide an example later.

Attachments:
The testing mission I used during coding and one of the instances created by the latest code version (the one I hereby open/submit as pull)
[testing_mission_substitute_conditions.txt](https://github.com/endless-sky/endless-sky/files/965627/testing_mission_substitute_conditions.txt)
[Endros G~instance of TEST Substitute Condition.txt](https://github.com/endless-sky/endless-sky/files/965628/Endros.G.instance.of.TEST.Substitute.Condition.txt)

