### PR TITLE
(bug fix) scale wide sprites properly @ map sales panels

### DIFF
--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -329,7 +329,7 @@ void MapSalesPanel::DrawSprite(const Point &corner, const Sprite *sprite) const
 	if(sprite)
 	{
 		Point iconOffset(.5 * ICON_HEIGHT, .5 * ICON_HEIGHT);
-		double scale = min(.5, (ICON_HEIGHT - 2.) / sprite->Height());
+		double scale = min(.5, min((ICON_HEIGHT - 2.) / sprite->Height(), (ICON_HEIGHT - 2.) / sprite->Width()));
 		SpriteShader::Draw(sprite, corner + iconOffset, scale, swizzle);
 	}
 }


### PR DESCRIPTION
This mini change takes sprite->Width() into account when scaling a sprite (to be displayed in a map sales panel).
Without that, wide sprites didnt look as expected but overlapped the bounding box.

Attached the sprite which made me find this and motivated me to solve this.
![marsian g1 drone](https://cloud.githubusercontent.com/assets/26883037/25562806/7497bc82-2d8f-11e7-99bf-bffc5b86881b.png)
