### PR TITLE
Fix to escort jobs: ships defined as fleet>variant not loading

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -31,6 +31,13 @@ using namespace std;
 
 
 
+Fleet::Fleet()
+{
+	government = GameData::Governments().Get("Merchant");
+	names = GameData::Phrases().Get("civilian");
+}
+
+
 void Fleet::Load(const DataNode &node)
 {
 	if(node.Size() >= 2)

--- a/source/Fleet.h
+++ b/source/Fleet.h
@@ -37,6 +37,7 @@ class System;
 // names are chosen based on a given random "phrase" generator.
 class Fleet {
 public:
+	Fleet();
 	void Load(const DataNode &node);
 	
 	// Get the government of this fleet.


### PR DESCRIPTION
Revert to a change in commit fddf673 to Fleet.cpp/Fleet.h that
introduced a problem loading ships for missions where they were defined
as a variant in a fleet specification.

**Note:** I've been away for a while and am out of practice. And to be honest, I haven't spent the time to learn about _why_ this revert fixes the problem, or why exactly the lines were removed. MZ, you know better than me: if this is the right change, here's a PR ready for you to click through. Otherwise, no worries.