### PR TITLE
A derelict ship shouldn't recover crew

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -187,7 +187,9 @@ void Engine::Place()
 					continue;
 				// Avoid the exploit where the player can wear down an NPC's
 				// crew by attrition over the course of many days.
-				ship->AddCrew(max(0, ship->RequiredCrew() - ship->Crew()));
+				if(!ship->GetPersonality().IsDerelict())
+					ship->AddCrew(max(0, ship->RequiredCrew() - ship->Crew()));
+
 				if(!ship->IsDisabled())
 					ship->Recharge();
 				


### PR DESCRIPTION
The exploit fix in 2f63019 to prevent capturing Quarg Wardragons et al
through attrition doesn't need to apply to ships with a personality of
derelict. If it does, it creates a barrier for content creators making
derelict ships: see issue #2418.