### PR TITLE
minor enhancement: soft warning for more than 32 hardpoints

### DIFF
--- a/source/Command.h
+++ b/source/Command.h
@@ -125,6 +125,7 @@ private:
 private:
 	// The key commands and weapons to fire are stored in a single bitmask, with
 	// 32 bits for key commands and 32 bits for individual weapons.
+	// Ship::Load gives a soft warning for ships with more than 32 weapons.
 	uint64_t state = 0;
 	// Turning amount is stored as a separate double to allow fractional values.
 	double turn = 0.;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -125,8 +125,8 @@ void Ship::Load(const DataNode &node)
 				armament.AddGunPort(hardpoint, outfit);
 			else
 				armament.AddTurret(hardpoint, outfit);
-			// print a warning for the first hardpoint after 32, i.e. only 1 warning per ship
-			if (armament.Get().size() == 33)
+			// Print a warning for the first hardpoint after 32, i.e. only 1 warning per ship.
+			if(armament.Get().size() == 33)
 				child.PrintTrace("Warning: ship has more than 32 weapon hardpoints. Some weapons may not fire:");
 		}
 		else if(child.Token(0) == "licenses")

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -125,6 +125,8 @@ void Ship::Load(const DataNode &node)
 				armament.AddGunPort(hardpoint, outfit);
 			else
 				armament.AddTurret(hardpoint, outfit);
+			if (armament.Get().size() > 32)
+				child.PrintTrace("Warning: only the first 32 hardpoints will fire:");
 		}
 		else if(child.Token(0) == "licenses")
 		{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -125,8 +125,9 @@ void Ship::Load(const DataNode &node)
 				armament.AddGunPort(hardpoint, outfit);
 			else
 				armament.AddTurret(hardpoint, outfit);
-			if (armament.Get().size() > 32)
-				child.PrintTrace("Warning: Ships with more than 32 hardpoints do not behave as one would expect:");
+			// print a warning for the first hardpoint after 32, i.e. only 1 warning per ship
+			if (armament.Get().size() == 33)
+				child.PrintTrace("Warning: ship has more than 32 weapon hardpoints. Some weapons may not fire:");
 		}
 		else if(child.Token(0) == "licenses")
 		{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -126,7 +126,7 @@ void Ship::Load(const DataNode &node)
 			else
 				armament.AddTurret(hardpoint, outfit);
 			if (armament.Get().size() > 32)
-				child.PrintTrace("Warning: only the first 32 hardpoints will fire:");
+				child.PrintTrace("Warning: Ships with more than 32 hardpoints do not behave as one would expect:");
 		}
 		else if(child.Token(0) == "licenses")
 		{


### PR DESCRIPTION
This small PR adds a soft warning for each weapon (gun or turret) hardpoint beyond the first 32.
For ship definitions and for ships in savegames.

Reason: Command.h / Command.cpp only support the first 32 weapons to actively fire because a 32 bit mask is used there.
Relates to #2473.