### PR TITLE
Create an auto condition for your credit balance

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2064,6 +2064,7 @@ void PlayerInfo::UpdateAutoConditions()
 	// Set a condition for the player's net worth. Limit it to the range of a 32-bit int.
 	static const int64_t limit = 2000000000;
 	conditions["net worth"] = min(limit, max(-limit, accounts.NetWorth()));
+	conditions["credits"] = min(limit, max(-limit, accounts.Credits()));
 	SetReputationConditions();
 	// Clear any existing ships: conditions. (Note: '!' = ' ' + 1.)
 	auto first = conditions.lower_bound("ships: ");

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2064,7 +2064,7 @@ void PlayerInfo::UpdateAutoConditions()
 	// Set a condition for the player's net worth. Limit it to the range of a 32-bit int.
 	static const int64_t limit = 2000000000;
 	conditions["net worth"] = min(limit, max(-limit, accounts.NetWorth()));
-	conditions["credits"] = min(limit, max(-limit, accounts.Credits()));
+	conditions["credits"] = min(limit, accounts.Credits());
 	SetReputationConditions();
 	// Clear any existing ships: conditions. (Note: '!' = ' ' + 1.)
 	auto first = conditions.lower_bound("ships: ");


### PR DESCRIPTION
This is parallel to the "net worth" auto condition, and allows missions
to require you have >=, <, etc. a certain credit balance. This is
necessary for negative payment missions (missions where you pay a bribe,
etc.) to be handled correctly if you can't afford it. Without this, they
just don't appear. With this, you can create a mirror 'blocking' mission
if you don't have enough money.

**Context:** I _promised_ myself I'd finish a minor story without requiring any changes to the code. But a sideline to the first mission is the ability to bribe someone for more information on the mission. If you can't afford this, the mission doesn't appear at all – without explanation. With this auto condition, I can do the following:

<details>
<summary>Mission snippet</summary>

```
mission "Syndicate Insecurity 1 (Canyon: Investigate)"
	...
	to offer
		...
		"credits" >= 5000

	on offer
		conversation
			...
			choice
				`	(Pay 5,000 credits for access to the traffic logs.) `
					goto logs
				`	(Don't bother.) `
					decline
					
			label logs
			...
				accept
			
	on accept
		payment -5000
		fail

mission "Syndicate Insecurity 1 (Canyon: Blocked)"
	...
	to offer
		...
		"credits" < 5000

	on offer
		conversation
			...
			choice
				`	(I can't afford that.) `
					decline
```

</details>
<br /> 

@endless-sky, as always I'd appreciate your review. This is really simple and generally useful, so I hope there's no problem merging it. Only question I see is around handling the min/max limiting. I was going to skip the max(-limit, ...) clause, but was convinced to keep it the same on Discord.
