### PR TITLE
Fix #2482: Ships with only Jump Drives performing Hyperdrive actions

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1060,7 +1060,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 	else if(commands.Has(Command::JUMP) && IsReadyToJump())
 	{
 		hyperspaceSystem = GetTargetSystem();
-		isUsingJumpDrive = !attributes.Get("hyperdrive") || !currentSystem->Links().count(targetSystem);
+		isUsingJumpDrive = !attributes.Get("hyperdrive") || !currentSystem->Links().count(hyperspaceSystem);
 		hyperspaceFuelCost = JumpFuel(hyperspaceSystem);
 	}
 	

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1060,7 +1060,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 	else if(commands.Has(Command::JUMP) && IsReadyToJump())
 	{
 		hyperspaceSystem = GetTargetSystem();
-		isUsingJumpDrive = !currentSystem->Links().count(hyperspaceSystem);
+		isUsingJumpDrive = !attributes.Get("hyperdrive") || !currentSystem->Links().count(targetSystem);
 		hyperspaceFuelCost = JumpFuel(hyperspaceSystem);
 	}
 	


### PR DESCRIPTION
Closes #2482 .

(PS I really wanted to trim the trailing whitespace)