### PR TITLE
whitespace trim in transport missions.txt

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -82,15 +82,15 @@ mission "Pookie, Part 2"
 					goto interrupt
 				"	(Wait to see if someone else shows up.)"
 					goto wait
-		
+
 			label interrupt
 			`	"Excuse me," you say. She looks up at you with a withering glare. "I'm looking for someone named Pookie."`
 				goto response
-		
+
 			label wait
 			`	Eventually she looks up from the paper and sees you standing there. "Are you Captain <last>?" she asks. You nod.`
 				goto response
-		
+
 			label response
 			`	"Thank heavens," she says. "She's all yours." She hands you the leash and a large bag that appears to be full of chew toys. "Here are her toys, her food, and her... outfits. Which she hates. Feed her twice a day, or she will go berserk. Do not feed her more than twice a day, or she will throw up..."`
 			`	As she continues rattling off instructions, you ask, "Wait, Pookie is the dog?"`
@@ -116,10 +116,10 @@ mission "Smuggler's Den, Part 1"
 				`	(Get out of here.)`
 				`	(Wait and see what they want.)`
 					goto meet
-			
+
 			`	You've heard too many stories of kidnappings and murders on this station to be willing to take any risks. You quickly get up and leave the bar, and walk down the passageway back toward your ship. Glancing behind you, you see that the hooded figures have decided not to follow you.`
 				decline
-			
+
 			label meet
 			`	The hooded figures turn out to be a boy and a girl, both perhaps thirteen or fourteen years old. The bundle in the girl's arms is a baby. "Are you a captain?" the boy asks.`
 			`	"Yes," you say.`
@@ -129,17 +129,17 @@ mission "Smuggler's Den, Part 1"
 					goto legal
 				`	"Well, how much would you be able to pay me?"`
 					goto payment
-			
+
 			label legal
 			`	The boy grins. "No, not at all. I mean, aside from the fact that we're pirates."`
 			`	Seeing the incredulous look on your face, the girl says, "Members of a pirate gang. Crew on a pirate ship. Captains are usually older, but most of the pirate ships you see out there are crewed by kids like us. It's a hard place to grow up. We want something better for our daughter."`
 				goto search
-			
+
 			label payment
 			`	They are silent for a long moment, looking down at the table. Finally, the boy says, "We're crew on a pirate ship, hardly better than slaves. The captain keeps our wages. We don't get paid anything unless they agree to let us go. But if you help us start a new life, we'll work hard and some day we'll pay you back."`
 			`	The girl adds, "You don't know what it's like for a little girl to grow up on a pirate ship. We want something better than that for our daughter."`
 				goto search
-			
+
 			label search
 			`	As you are conversing a bearded man and a rough-looking teenage boy enter the bar and begin looking around the room. "That's our captain," she says. "Please, you have to help us. There's a service tunnel that connects to the back entrance of the bar. We can escape through there."`
 			`	You've heard of these service passageways: the most dangerous part of this lawless station, dimly lit and seldom travelled, except by drug addicts and prostitutes. This whole thing might just be a ruse to lure you into one, where they can attack you without anyone interfering. "No," says the boy, "if we head for the service tunnel, they'll be sure to notice us. Let's just stay at the table until they go away."`
@@ -150,10 +150,10 @@ mission "Smuggler's Den, Part 1"
 				`	(Wait.)`
 					goto outside
 				`	"I'm sorry, this isn't worth risking my life for. I'm leaving."`
-	
+
 			`	You stand up and leave. The men in the doorway make no effort to stop you.`
 				decline
-			
+
 			label `tunnel`
 			`	The boy stands up. "Wait ten seconds, then head to the tunnel," he says. He walks into the bathroom, which is right next to back entrance that she pointed out. You wait for a few seconds, then stand up. "Don't run," says the girl. "Walk slowly. Pretend. You've had a bit too much to drink. We're headed out back to find some privacy." You don't dare look behind you to see if the men in the doorway are watching you.`
 			`	Finally, you reach the back entrance, and she spins the wheel to unlock it. The hinges squeal, but it opens enough for you to squeeze through. You find yourselves in a narrow corridor lit only by flickering sodium lamps. In the yellow lamplight her face and hands look pale, jaundiced. The floor of the corridor is littered with beer bottles and discarded hypodermic needles. To one side of the door are several over-stuffed trash cans. As you step into the corridor, a rat scurries away into the darkness.`
@@ -161,14 +161,14 @@ mission "Smuggler's Den, Part 1"
 			`	You begin running down the corridor, in the direction of your ship. You pass a man, slumped over in a corner; there is no time to see if he is dead, or just sleeping. In places the lights have gone out, and it is so dim that you can barely see the floor beneath you. Your footsteps pounding on the metal decking ring terribly loud up and down the empty hallway.`
 			`	Eventually the passageway widens out into a maintenance room, full of humming equipment and large tanks. You duck behind one of them and listen for sounds of pursuit. "I think we're safe," says the boy. He walks over to another airlock door on the opposite wall and tugs it open. Light pours in, almost blinding at first. You are looking out into the rimway, the main passage in this ring of the station. Crowds of people are walking past, paying no attention to you. He glances quickly in both directions, then gestures for you to follow.`
 				goto ship
-			
+
 			label outside
 			`	You wait at the table, pretending that you are busy placing a drink order. The men at the door do not leave. Instead, they step into the room and begin circling around the edge of it. "What berth is your ship in?" asks the boy. You tell him. "Wait ten seconds, then follow," he says. He stands up and walks through the door. The searchers glance at him as he leaves, but they must be looking for two people together, because they ignore him.`
 			`	The searchers approach the bar and begin talking to one of the bartenders. You and the girl stand up. "Walk slowly," she hisses under her breath. "Saunter. Don't run." You put an arm around her shoulders and do your best to act like an ordinary bar patron headed home with a new friend after having a bit too much to drink. You don't dare to glance at the bar to see if you are being watched.`
 			`	Finally you reach the door. You are in the rimway, the main passage in this ring of the station. It is crowded and brightly lit. You quicken your pace slightly and begin walking toward your ship, still afraid that if you break into a run, you will attract attention. The girl keeps glancing at the shop windows that you pass by: checking the reflection to see if anyone is following you. "They're leaving the bar," she says. And then, "They're walking in the other direction. I think we're safe."`
 			`	You pass a narrow doorway, probably an entrance to one of the service tunnels. The boy is standing there, holding a gun by his side. His grim expression softens somewhat when he sees you approaching.`
 				goto ship
-			
+
 			label ship
 			`	You quickly make your way back to your ship. As soon as the door has closed behind you, all three of you breathe a sigh of relief. A second later, the baby begins to wail, loudly. As you show them to their bunks, they introduce themselves as Joe and Maria; the baby's name is Jesse. "I don't know how to thank you," says Maria.`
 			`	"Please don't take too long leaving the station," adds Joe. "But, I think we'll be safe here until you're ready to leave. There's no way they can search all the ships at the dock."`
@@ -193,7 +193,7 @@ mission "Smuggler's Den, Part 2"
 				`	(Volunteer to take them to <planet>.)`
 				`	(Leave them here and hope for the best.)`
 					decline
-			
+
 			`	Despite his shock and grief, Joe is quite grateful. "You know we can't pay you, right?"`
 			`	"Don't worry about it," you say. You return to your ship and tell the bad news to Maria.`
 				accept
@@ -213,7 +213,7 @@ mission "Smuggler's Den: Payment"
 		government "Republic" "Free Worlds" "Syndicate" "Quarg" "Neutral"
 	to offer
 		has "event: smuggler's den: payment"
-	
+
 	on offer
 		payment 35000
 		conversation
@@ -227,7 +227,7 @@ mission "Smuggler's Den: Follow Up"
 	source Millrace
 	to offer
 		has "Smuggler's Den: Payment: offered"
-	
+
 	on offer
 		conversation
 			`As you're coming in for a landing, you realize that Millrace is where Joe and Maria live, the couple you transported from Smuggler's Den. They recently wrote to you thanking you for helping them to begin a new life. Do you want to stop by and see how they are doing?`
@@ -252,7 +252,7 @@ mission "Expedition to Hope 1"
 		random < 40
 	cargo "scientific equipment" 4
 	passengers 4
-	
+
 	on offer
 		conversation
 			`A group of scientists approaches you and asks if you would be willing to take them to the abandoned planet of Hope, and then back home from there. "The transport we'd arranged for bailed out on us at the last moment," says their leader, a middle-aged man wearing thick-rimmed glasses.`
@@ -271,7 +271,7 @@ mission "Expedition to Hope 1"
 			label yes
 			`	"Thank you," he says. You help them to load their meteorological equipment onto your ship.`
 				accept
-	
+
 	on complete
 		payment 40000
 
@@ -289,13 +289,13 @@ mission "Expedition to Hope 2"
 	to offer
 		has "Expedition to Hope 1: done"
 	passengers 4
-	
+
 	on offer
 		conversation
 			`You fly around the planet to several different sites that the scientists have identified as good places for their equipment. They also make some deep radar scans of the glaciers. "That's my old house, down there," says one of the scientists, pointing to the radar picture of one of the buried villages. "Under thirty meters of ice, now."`
 			`	The lead scientist hands you forty thousand credits, and says, "Here's the first part of your payment. Now we need to get home to <planet>. I'll pay you the rest once we get there."`
 				accept
-	
+
 	on complete
 		payment 40000
 		dialog `You drop the team of scientists off on <planet>. They thank you for helping them out, and pay you <payment>.`
@@ -315,10 +315,10 @@ mission "Transport Workers A"
 		random < 5
 	passengers 4
 	cargo "household goods" 2
-	
+
 	on offer
 		dialog `In one of the corners of the spaceport, you meet a family with two kids, and a pile of trunks and boxes spread out next to them. They tell you that they are trying to book passage to <planet>. "Work has gotten way too hard to come by here," explains the father. "I've had seven different jobs in the past year, and none of them lasted more than a month. So we thought we'd try our luck on a Syndicate world."`
-	
+
 	on complete
 		payment
 		payment 20000
@@ -338,7 +338,7 @@ mission "Transport Workers B"
 	to offer
 		random < 5
 	passengers 1
-	
+
 	on offer
 		conversation
 			`As you are walking through the spaceport, a young man approaches you and says, "Excuse me, Captain. Is there any chance you're traveling towards the Core?" He's probably in his late teens, barely more than a kid.`
@@ -370,7 +370,7 @@ mission "Transport Workers B"
 			label thanks
 			`	"Thank you, Captain," he says, shaking your hand. You bring him aboard your ship and show him to one of the empty bunks.`
 				accept
-	
+
 	on complete
 		payment
 		payment 10000
@@ -392,7 +392,7 @@ mission "Transport Workers C"
 		random < 15
 	passengers 5
 	cargo "farm animals" 10
-	
+
 	on offer
 		conversation
 			`On the dirt near your landing pad is parked a large wagon, hitched to a draft horse and loaded down with furniture and various farming implements. A family is gathered in the shade of the cart, and several goats and sheep are tied up behind it. Do you approach them and find out where they are headed?`
@@ -406,7 +406,7 @@ mission "Transport Workers C"
 					accept
 				`	"Sorry, that's way too far from here."`
 					decline
-	
+
 	on complete
 		payment
 		payment 10000
@@ -426,10 +426,10 @@ mission "WR Star 1"
 		random < 20
 	passengers 3
 	cargo "sensors" 2
-	
+
 	on offer
 		dialog `A group of scientists approaches you and asks if you will be headed to the Rim any time soon. "We're doing research on Wolf-Rayet stars," they explain, "and we're hoping to find a captain who can do a fly-by of Ildaria." Scientific research in the Deep is notoriously well-funded, so they will probably pay you quite well.`
-	
+
 	on complete
 		payment 250000
 		dialog `The team of scientists thanks you for bringing them to Ildaria and back, and pays you <payment>. They seem eager to get back to their lab and start analyzing their measurements.`
@@ -448,7 +448,7 @@ mission "Deep Archaeology 1"
 		random < 15
 		"combat rating" > 15
 	passengers 1
-	
+
 	on offer
 		conversation
 			`As you are walking through the spaceport, a man in an expensive suit approaches you. "Pardon me, Captain," he says. "I wonder if you would be willing to talk privately about a very lucrative job opportunity."`
@@ -492,7 +492,7 @@ mission "Deep Archaeology 2"
 	destination Midgard
 	to offer
 		has "Deep Archaeology 1: done"
-	
+
 	on offer
 		conversation
 			`	You drop off the archaeologist (who still has not told you his name) on <origin>. "Remember," he says, "I only need a tiny splinter. Just make sure it really is from the building and not anything more recent."`
@@ -508,7 +508,7 @@ mission "Deep Archaeology 3"
 	destination Vinci
 	to offer
 		has "Deep Archaeology 2: done"
-	
+
 	on offer
 		conversation
 			`	Following the map that the archaeologist gave you, you make your way to a small village in the mountains on <origin>, with two envelopes in your pocket for samples. As you approach the church, you break a dead twig off one of the trees along the path, put it into the first envelope, and pocket it. One sample collected, one more to go.`
@@ -529,24 +529,24 @@ mission "Deep Archaeology 3"
 					decline
 			`	Pretending to pray, you kneel on the ground, take your pocket knife, and shave the tiniest sliver off the bottom corner of the pew in front of you. It leaves a small white scar in the dark weathered wood of the pew. You pocket the sample, wait a few more minutes, and then leave and walk back to the spaceport. Although you see no one following you, you cannot shake the feeling that you are being watched.`
 				accept
-	
+
 	npc
 		personality waiting
 		government Republic
 		ship "Raven (Afterburner)" "D.P.S. Wyrd"
-	
+
 	npc
 		personality waiting
 		system Aspidiske
 		government Republic
 		ship "Raven (Afterburner)" "D.P.S. Skuld"
-	
+
 	npc
 		personality waiting
 		system Gomeisa
 		government Republic
 		ship "Raven (Afterburner)" "D.P.S. Verthandi"
-	
+
 	on complete
 		payment 200000
 		conversation
@@ -572,7 +572,7 @@ mission "Deep Archaeology 4"
 		has "Deep Archaeology 3: done"
 	cargo "mapping equipment" 4
 	passengers 2
-	
+
 	on offer
 		conversation
 			`You find John the lab tech in one of the spaceport bars, along with the archaeologist, who says, "I suppose I should introduce myself. Albert Foster. You may have heard of me." Indeed, you have: he made headlines about a decade ago by being driven out of Quarg space after trying unsuccessfully to collect an alloy sample from their ringworld.`
@@ -596,7 +596,7 @@ mission "Deep Archaeology 5"
 		has "Deep Archaeology 4: done"
 	cargo "mapping equipment" 4
 	passengers 2
-	
+
 	on offer
 		conversation
 			`You cruise high above the surface of <origin> as John calibrates his instruments. "Sorry it's taking so long," he says, "there's some sort of glitch in the gravitational sensors, messing up my measurements."`
@@ -617,14 +617,14 @@ mission "Deep Archaeology 5"
 			label attack
 			`	Suddenly, a warning light flashes on your ship's radar. Three ships have taken off from the planet's surface and are headed straight towards you. "Let's get out of here," says Albert. "Head back to <planet>!"`
 				launch
-	
+
 	npc
 		personality heroic
 		government Deep
 		ship "Raven (Afterburner)" "D.P.S. Wyrd"
 		ship "Raven (Afterburner)" "D.P.S. Skuld"
 		ship "Raven (Afterburner)" "D.P.S. Verthandi"
-	
+
 	on complete
 		payment 300000
 		conversation
@@ -663,7 +663,7 @@ mission "There Might Be Riots 1"
 	passengers 8
 	to offer
 		random < 15
-	
+
 	on offer
 		conversation
 			`A woman in a well-tailored suit approaches you. "Captain <last>?" she asks. You nod. "My name is Becca," she says. "I'm a stage manager for a band, and the transport we had under contract bailed out on us. Any chance you could take us to <destination>? Given the circumstances, we can pay quite well."`
@@ -678,7 +678,7 @@ mission "There Might Be Riots 1"
 			`	"Oh," Ulrich says, "we call ourselves, 'There Might Be Riots.'"`
 			`	Eventually, the spaceport police arrive and disperse the crowd, and the band settles in for their trip to <destination>.`
 				accept
-	
+
 	on complete
 		payment
 		payment 100000
@@ -709,7 +709,7 @@ mission "There Might Be Riots part 2"
 		has "There Might Be Riots 1: done"
 		has "Deep Archaeology 5: done"
 		random < 30
-	
+
 	on offer
 		conversation
 			`As you walk through the spaceport, you see a large crowd gathered outside a small pub, and hear the unmistakable music of There Might Be Riots from inside. The concert seems to be just winding down. Do you want to wait around and say hello to them?`
@@ -741,7 +741,7 @@ mission "There Might Be Riots part 2"
 			label transport
 			`	"Then I suggest you do your job and transport them. Immediately." The guards leave. As soon as the band is packed up, you leave the planet...`
 				launch
-	
+
 	on complete
 		payment
 		payment 200000
@@ -780,7 +780,7 @@ mission "There Might Be Riots part 3A"
 		has "There Might Be Riots part 2: done"
 		has "First Contact: Hai: offered"
 		random < 30
-	
+
 	on offer
 		conversation
 			`As you walk through the spaceport, you see a distinctive group of people lugging a collection of instruments: the band There Might Be Riots. Would you like to see if there is anything more you can do for them?`
@@ -847,7 +847,7 @@ mission "There Might Be Riots part 3B"
 	passengers 8
 	to offer
 		has "There Might Be Riots part 3A: done"
-	
+
 	on offer
 		conversation
 			`You bring your ship to a gingerly landing in a section of the testing range that doesn't look too pockmarked with craters, and the band begins setting up their equipment and video cameras. "This is great," says Ulrich. "We'll be broadcasting live over the Net. It's time people started asking why the government thinks it needs all these weapons of war."`
@@ -867,7 +867,7 @@ mission "There Might Be Riots part 3B"
 			`	He swears, then shouts to the rest of the band, "Gentlemen, time to pack it up posthaste, before we get turned into a tragic industrial accident!"`
 			`	The band has just packed the last of their equipment away when the ships come into view. It's a swarm of unpiloted combat drones, and they seem to be engaged in mock combat with each other. But, their flight path is taking them straight in your direction. You power up your shields just as the first of the drones decide that your ship is a valid target for their lasers...`
 				launch
-	
+
 	npc
 		government "Team Red"
 		personality heroic nemesis
@@ -886,7 +886,7 @@ mission "There Might Be Riots part 3B"
 		fleet
 			variant
 				"Combat Drone" 35
-	
+
 	on complete
 		payment 500000
 		conversation
@@ -939,7 +939,7 @@ mission "Sad Archie"
 	to offer
 		has "There Might Be Riots part 3B: done"
 	destination "Zug"
-	
+
 	npc disable
 		government "Test Dummy"
 		system "Ildaria"
@@ -951,7 +951,7 @@ mission "Sad Archie"
 			`You dream that you leave this star system and return to Zug, but when you land there everything is different: the cities you remember are gone, and in their place are other cities with strange architecture, populated by gargantuan dragon-like creatures.`
 			`	Time speeds up, and you watch as the dragon cities grow and spread out. You see one city buried under a massive lava flow, starships buzzing around it like a cloud of flies to carry people and goods to safety. Other cities are destroyed by war, and then abruptly the dragon-people are all gone and their cities lie vacant. Buildings crumble, and the forests reclaim the land.`
 			`	Then you wake up and find yourself back in your ship, in the Ildaria system. Weird.`
-	
+
 	on complete
 		conversation
 			`On a whim, as you're landing on Zug you pull up a geological map of the planet and find that the geography you dreamt of while drifting in the Ildaria system was surprisingly close to the real thing. There's even a massive basalt outcropping right where you saw a lava flow burying a city. There's no way your ship's sensors can tell what's underneath it, though.`
@@ -967,7 +967,7 @@ mission "Rim Archaeology 1"
 	passengers 1
 	to offer
 		has "Sad Archie: done"
-	
+
 	on offer
 		conversation
 			`This planet is where the archaeologist Albert Foster has his lab, the one who sent you on a mission to collect samples from a planet in the Deep. Would you like to try to convince him to look for signs of an ancient alien civilization in the Rim systems?`
@@ -997,7 +997,7 @@ mission "Rim Archaeology 1"
 			`	"It's feasible," he says. "We've heard rumors from the Quarg that an alien civilization used to exist in the Rim, a hundred of thousand years ago. No signs of it, of course - any artifacts they left behind have been destroyed by the elements, or perhaps intentionally removed. But if a city were encased in lava, that could preserve signs of it even over such a long time frame."`
 			`	Foster makes a few phone calls to cancel his upcoming plans, and then shows up at your ship with a large collection of geological surveying tools. "Let's go check it out," he says.`
 				accept
-	
+
 	on complete
 		conversation
 			`You land your ship on the lava flow, and Albert Foster fires up his surveying equipment. "This will show me a density profile of different layers of rock beneath us," he says. As he gradually dials the instrument down to deeper and deeper layers, a few irregular white spots appear on the screen.`
@@ -1020,7 +1020,7 @@ mission "Rim Archaeology 2A"
 	destination "Crossroads"
 	to offer
 		has "Rim Archaeology 1: done"
-	
+
 	on offer
 		conversation
 			`When you meet up with Foster, he tells you, "This is going to be tricky. We're going to have to dig through a twenty meter thick slab of solid basalt to get at those ruins. We have to work fast, or my competitors will catch wind of what we're doing and beat us to the punch. But we have to work delicately, too, or we'll damage what's underneath. Blasting won't work. I think some of the Syndicate's strip mining equipment could do the job, though. Would you be able to pick up maybe twenty or thirty tons of heavy machinery from <planet>?"`
@@ -1047,12 +1047,12 @@ mission "Rim Archaeology 2B"
 	to offer
 		has "Rim Archaeology 2A: done"
 	blocked "You do not have enough cargo space to carry the equipment for Albert Foster's archaeological dig. Return here when you have at least 28 tons of space free."
-	
+
 	on offer
 		conversation
 			`When you arrive on <origin>, the excavation machines requested by Albert Foster are already waiting for you at the spaceport. They are some of the largest terrestrial vehicles you have ever seen: a truck with enormous toothed grinding wheels for cutting through stone, and a front-end loader for carrying the loose stone away. You are barely able to fit them through the entrance of your cargo bay.`
 				accept
-	
+
 	on complete
 		payment 300000
 
@@ -1066,7 +1066,7 @@ mission "Rim Archaeology 3A"
 	destination "Asgard"
 	to offer
 		has "Rim Archaeology 2B: done"
-	
+
 	on offer
 		conversation
 			`You drop off the excavation machines at the dig site on Zug, and receive your payment of three hundred thousand credits. Foster has already marked out lines of where he wants to dig and has completed a much more detailed geological scan. "We'll be starting with a narrow trench," he tells you, "and expanding out from there. It'll need to be wide enough to include a ramp for the vehicles, of course, so we'll still need to move a lot of rock. And when we get within the last five meters or so, I'm worried that the vibration from the grinders may be too destructive. So, I need some laser excavation equipment from <planet>, next."`
@@ -1085,22 +1085,22 @@ mission "Rim Archaeology 3B"
 	to offer
 		has "Rim Archaeology 3A: done"
 	blocked "You do not have enough cargo space to carry the equipment for Albert Foster's archaeological dig. Return here when you have at least 17 tons of space free."
-	
+
 	on offer
 		conversation
 			`Once again, the equipment that Foster needs is waiting for you when you land. It's a truck carrying a power generator and an articulated arm with a laser cannon mounted on the end. You can't help imagining what would happen if it malfunctioned and began firing while inside your cargo bay, but the engineer who delivers it assures you that it has many redundant safeties in place.`
 			`	Also waiting for you is an encrypted message from Foster: "Hi there, <first>. I've been told that one of my competitors, Sibyl Greythatch, has been asking around trying to figure out where my dig site is. She's an antiquities thief - robs archaeological sites and sells the artifacts on the black market. I think my equipment purchase on <origin> may have caught her attention. If so, her ship, the Oxyrhynchus, will be following you. Don't return to the dig site until you're certain you've shaken her."`
 				accept
-	
+
 	npc evade
 		government Independent
 		personality waiting
 		ship "Marauder Falcon (Engines)" "Oxyrhynchus"
-	
+
 	on visit
 		dialog
 			`As you are approaching Zug, you notice on your radar that the ship Foster warned you about has been following you: the Oxyrhynchus. You land in the main spaceport to avoid leading her to the dig site. You will need to shake her pursuit before delivering the equipment.`
-	
+
 	on complete
 		payment 300000
 
@@ -1114,7 +1114,7 @@ mission "Rim Archaeology 4A"
 	destination "Lagrange"
 	to offer
 		has "Rim Archaeology 3B: done"
-	
+
 	on offer
 		conversation
 			`When you return to the dig, Foster's trench is already almost ten meters deep. You tell him that you saw the Oxyrhynchus on your scanners, but you were able to evade it. "Good job," he says. "Now, we need a xenobiologist who can help us make sense of what we find. A friend of mine, Amelia Lee, has been living on the Quarg ringworld for the last decade or so, and she agreed to come visit the dig, and also to see what the Quarg can tell us about this old alien civilization. Also, here's your pay for transporting the laser cutter." He hands you another three hundred thousand credits.`
@@ -1133,7 +1133,7 @@ mission "Rim Archaeology 4B"
 	to offer
 		has "Rim Archaeology 4A: done"
 	blocked "You will need two bunks free to transport the xenobiologist that Albert Foster asked you to fetch. Return here when you have space available."
-	
+
 	on offer
 		conversation
 			`Amelia Lee meets you at the spaceport, along with a Quarg who is a bit shorter than normal, but still tall enough to tower over you. "Captain <last>?" she says. "Let me introduce my friend Yarthis Amorthee Dek-Farsook Nai," she says. "Yarthis will be accompanying us to the site."`
@@ -1145,13 +1145,13 @@ mission "Rim Archaeology 4B"
 			label welcome
 			`	As both of them board your ship, Amelia chats enthusiastically with you. "One ringworld can sustain a population in excess of a trillion," she says, "so the Quarg need long names in order to unambiguously identify themselves." She goes on to ask questions about the progress of the dig, using so much technical jargon that at times it almost sounds like she is speaking the Quarg language rather than your own. Clearly she is very knowledgeable about the study of alien societies, and you are surprised to learn that she was actually born in Hai space, as the granddaughter of some of the first humans who settled there.`
 				accept
-	
+
 	npc
 		government Merchant
 		personality waiting
 		system Dabih
 		ship "Marauder Arrow (Engines)" "Naukratis"
-	
+
 	on complete
 		payment 200000
 
@@ -1164,7 +1164,7 @@ mission "Rim Archaeology 5A"
 	source "Zug"
 	to offer
 		has "Rim Archaeology 4B: done"
-	
+
 	on offer
 		conversation
 			`Foster greets Amelia enthusiastically when you land, but seems less enthusiastic about having Yarthis here as well. The dig has nearly reached the target depth, and at the deepest part of the trench they are now slicing out blocks of stone with the laser and hoisting them out of the pit rather than just grinding through the rock. "Thanks again, Captain," he says, as he hands you a chip worth two hundred thousand credits.`
@@ -1178,7 +1178,7 @@ mission "Rim Archaeology 5A"
 			label end
 			`	As you run for your ship, you see Yarthis pull out some sort of communication device and speak into it. Perhaps the Quarg will be joining in this fight as well...`
 				launch
-	
+
 	npc evade
 		government Pirate
 		personality heroic waiting
@@ -1190,17 +1190,17 @@ mission "Rim Archaeology 5A"
 		ship "Marauder Quicksilver (Weapons)" "Philae"
 		ship "Marauder Raven (Weapons)" "Esna"
 		dialog `The last of the pirate raiders have been driven off. Time to land and check if any damage was done to the dig.`
-	
+
 	npc
 		government Quarg
 		system "Gamma Corvi"
 		personality heroic
 		ship "Quarg Wardragon" "Gloref Esa Kurayi"
-	
+
 	on visit
 		dialog
 			`You try to land near the dig, but pirate ships are still circling nearby. Better deal with them before returning to check in on Foster.`
-	
+
 	on complete
 		payment 400000
 		event "rim archaeology results" 97
@@ -1261,15 +1261,15 @@ mission "Drug Running 1"
 	to offer
 		random < 10
 		"said no to drugs" < 4
-	
+
 	on offer
 		dialog `As you are walking through the spaceport, a man pulls you aside and asks if you would like to help transport some "recreational pharmaceuticals" to <planet>. (This sounds like an illegal mission, so you'll need to avoid getting scanned or landing on planets with high security.)`
-	
+
 	on accept
 		"said no to drugs" --
 	on decline
 		"said no to drugs" ++
-	
+
 	on complete
 		payment
 		payment 80000
@@ -1292,10 +1292,10 @@ mission "Drug Running 2"
 	to offer
 		random < 10
 		has "Drug Running 1: done"
-	
+
 	on offer
 		dialog `When you walk into the local bar, a man sitting in the corner waves you over and says in a hushed voice, "Captain, we've got a shipment of the good stuff that needs to get to <planet>. I promise you this will be a very lucrative operation. What do you say?"`
-	
+
 	on complete
 		payment
 		payment 100000
@@ -1318,10 +1318,10 @@ mission "Drug Running 3"
 	to offer
 		random < 10
 		has "Drug Running 2: done"
-	
+
 	on offer
 		dialog `A well-dressed woman approaches you as you are walking through the spaceport and asks quietly if you would be willing to help facilitate the transport of some "naughty substances" to a certain individual on <planet>.`
-	
+
 	on complete
 		payment
 		payment 120000
@@ -1386,7 +1386,7 @@ mission "Hallucination"
 	to offer
 		has "Drug Running 2: active"
 		random < 50
-	
+
 	on offer
 		conversation
 			`During your brief stop on <origin>, it occurs to you that it really is a shame to have a cargo hold full of the finest of illegal drugs, and not to take even a small sample for yourself. There is no way the loss of a tiny bit of drugs could be noticed. Give it a try?`
@@ -1396,7 +1396,7 @@ mission "Hallucination"
 				`	(Sure, sounds like fun!)`
 			`	The room begins to spin, and strange things happen...`
 				launch
-	
+
 	npc kill
 		government "Bad Trip"
 		personality nemesis heroic
@@ -1421,7 +1421,7 @@ mission "Rescue Miners 1"
 	cargo "emergency supplies" 15
 	to offer
 		random < 60
-	
+
 	on offer
 		dialog `You've just sat down in the spaceport bar and ordered a drink when someone in uniform runs into the room and shouts, "There's been a mine explosion on <planet>! We need all available ships to carry relief workers and supplies and to evacuate the injured to a world where there are better medical facilities." Do you volunteer?`
 
@@ -1439,10 +1439,10 @@ mission "Rescue Miners 2"
 	passengers 15
 	to offer
 		has "Rescue Miners 1: done"
-	
+
 	on offer
 		dialog `You drop off the medical personnel on <origin>. There are nearly a hundred injured miners waiting for medical evacuation to <planet>. Do you volunteer to carry some of them?`
-	
+
 	on complete
 		payment 80000
 		dialog `You drop off the injured miners at one of the medical facilities on <planet> that has agreed to care for the survivors. It's a somewhat chaotic process, but eventually someone thanks you for your help and pays you <payment>.`
@@ -1544,7 +1544,7 @@ mission "Courier 4"
 					decline
 			`	"Excellent!" he says. "Come, let me introduce you to your cargo." He leads you to a supply shed where an enormous lizard, taller than you and probably weighing several tons, is being held in a cage that looks far too flimsy for it. "I'll have my men load her aboard your ship at once," says the man, "along with some meat for her to eat on the journey. Watch out for your fingers when you feed her, by the way. Thank you!"`
 				accept
-	
+
 	on complete
 		payment
 		payment 100000
@@ -1562,7 +1562,7 @@ mission "Migrant Workers 1"
 	destination Rand
 	to offer
 		random < 5
-	
+
 	on offer
 		conversation
 			`In the spaceport, you can't help but notice a group of six or seven men in ragged farm clothing, sitting by the edge of one of the launch pads. They are probably migrant workers looking for a lift.`
@@ -1576,7 +1576,7 @@ mission "Migrant Workers 1"
 					accept
 				`	"No, sorry, I'm not headed in that direction."`
 					decline
-	
+
 	on complete
 		payment
 		payment 20000
@@ -1598,7 +1598,7 @@ mission "Humanitarian 1"
 		government "Pirate"
 		distance 2 10
 	clearance
-	
+
 	on offer
 		conversation
 			`While you are sitting at a table in a local cafe, a woman sits down across from you and says, "Pardon me, Captain. I wonder if you would be interested in helping with a humanitarian mission."`
@@ -1613,7 +1613,7 @@ mission "Humanitarian 1"
 					decline
 			`	"Thank you," she says. "Your contact on <planet> will be a man named 'Raven Hunter.' Don't let anyone but him trick you into giving them the supplies."`
 				accept
-	
+
 	on complete
 		payment
 		payment 50000
@@ -1636,7 +1636,7 @@ mission "Humanitarian 2"
 		government "Pirate"
 		distance 2 10
 	clearance
-	
+
 	on offer
 		conversation
 			`As you are walking through the local market, a man says, "Captain, do you have room in your hold to bring food to a starving planet?"`
@@ -1650,7 +1650,7 @@ mission "Humanitarian 2"
 					decline
 				`	"Well, even so, no one deserves to starve to death. I'll help them."`
 					accept
-	
+
 	on complete
 		payment
 		payment 50000
@@ -1666,7 +1666,7 @@ mission "Terraforming 1"
 	source Rand
 	destination Glory
 	passengers 2
-	
+
 	on offer
 		conversation
 			`	You stop in to the spaceport bar for a drink. The bar seems to be frequented mostly by the managers of the mining corporation; you suspect the workers don't earn enough to visit a bar very frequently. In one corner, two of the managers are having a very animated discussion. When they see you, they say, "Hello there, Captain! Interested in taking us on a business trip?"`
@@ -1692,7 +1692,7 @@ mission "Terraforming 2"
 	passengers 2
 	to offer
 		has "Terraforming 1: done"
-	
+
 	on offer
 		conversation
 			`You drop off the two managers from Rand, whose names are Eric and Alaric, at the Academy. While you wait for their meeting to end, you look around the lobby. The students have apparently just had some sort of science symposium, and poster boards are on display all along the walls. One of them catches your eye: the title is "Affordable Terraforming through Equilibrium Mapping."`
@@ -1705,11 +1705,11 @@ mission "Terraforming 2"
 			choice
 				`	"Have a look at this poster. Maybe this student would help us. We could bill it as a sort of internship for her."`
 				`	"Indeed. They gave this student a failing grade just for suggesting it could be done more cheaply."`
-			
+
 			`	They look at the poster. "Sounds almost too good to be true," says Alaric. "Hang on, I'll look her up in the campus directory." A few minutes later, he is on the phone with the student who made the poster. Her name is Amy. It turns out she is about to flunk out anyway, and is more than willing to travel back to Rand with you when offered a tiny fraction of what the consultant would have received.`
 			`	An hour later, you meet up with Amy, and arrange for her to join you on your ship before it takes off. Eric and Alaric are very excited, but you are a bit worried about the wisdom of entrusting their planet's future to someone so young and inexperienced.`
 				accept
-	
+
 	on complete
 		payment 140000
 		dialog `On the entire return journey, Eric and Alaric have been busy showing Amy geological survey maps of Rand and asking her for ideas. The moment you land, they hurry out of the ship. "I'm going to show Amy around," says Eric, "but meet us in the spaceport bar later if you want to help out with whatever we do next." Alaric hands you <payment> as payment for your services, and then follows after them.`
@@ -1724,7 +1724,7 @@ mission "Terraforming 3"
 	source Rand
 	to offer
 		has "Terraforming 2: done"
-	
+
 	on offer
 		conversation
 			`Alaric, Eric, and Amy are having a heated conversation at a table in the bar. When they see you, Alaric says, "Okay, let's let Captain <last> be the tie breaker." He motions to you to join them.`
@@ -1752,7 +1752,7 @@ mission "Terraforming 3"
 			`	"Great!" says Amy. "I'll mark the asteroid on your radar. You just need to board it, install a small ion thruster, and return here."`
 			`	Eric contacts some spaceport workers and has them load a small thruster onto your ship, along with the equipment you will need to mount it on the asteroid.`
 				accept
-	
+
 	npc assist
 		government Uninhabited
 		personality derelict fleeing uninterested waiting pacifist mute
@@ -1777,7 +1777,7 @@ mission "Terraforming 3"
 			explode "medium explosion" 35
 			explode "large explosion" 45
 			explode "huge explosion" 30
-	
+
 	on complete
 		payment 20000
 		dialog
@@ -1793,7 +1793,7 @@ mission "Terraforming 4"
 	to offer
 		has "Terraforming 3: done"
 	passengers 1
-	
+
 	on offer
 		conversation
 			`By the time you meet up with Eric, Alaric, and Amy, the cloud cover already seems to have visibly increased. Amy is very enthusiastic. "Atmospheric water vapor is on the rise," she says. "The impact vaporized enough ice to form a small ocean. I wouldn't be surprised if we get a rainstorm here in a day or two."`
@@ -1804,7 +1804,7 @@ mission "Terraforming 4"
 					accept
 				`	"Sorry, I need to move on to some other work now."`
 					decline
-	
+
 	on complete
 		dialog `As soon as you land, Amy heads off to meet with some local biologists who she contacted during the trip over here. "We'll be back in the spaceport in two hours," she says. "Be sure to have ten tons of cargo space free."`
 
@@ -1819,7 +1819,7 @@ mission "Terraforming 5"
 		has "Terraforming 4: done"
 	passengers 1
 	cargo "seeds and plants" 10
-	
+
 	on offer
 		conversation
 			`You meet up with Amy, and load the seeds and plant cuttings onto your ship.`
@@ -1839,7 +1839,7 @@ mission "Terraforming 5"
 				`	"Wait, they're going to have to keep smashing asteroids into their world in perpetuity to maintain the new environment?"`
 			`	"For a century or so, yes," she says. "But that's a whole lot more economical than vaporizing the ice caps using traditional terraforming equipment. Come on, let's get back to <planet>."`
 				accept
-	
+
 	on complete
 		payment 60000
 		conversation
@@ -1864,12 +1864,12 @@ mission "A wolf, a goat, and a cabbage"
 		distance 3 5
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	cargo "wolf" 1
-	
+
 	on enter
 		dialog
 			`As soon as you take off, you hear a worrisome munching sound from the cargo hold, followed by a horrific shrieking bleating noise and then an equally horrific silence. Turning on your cargo hold's security camera, you discover that there is nothing left of the goat and the cabbage that you were transporting except a few scraps of cabbage, some bones, and a lot of blood.`
 			`	Meanwhile, the wolf is calmly gnawing on what you suspect is the goat's femur, with a rather self-satisfied look in its eyes. Apparently the goat ate the cabbage, and shortly after that the wolf ate the goat.`
-	
+
 	on complete
 		payment 33000
 		dialog


### PR DESCRIPTION
Removed lots of trailing whitespace (thanks tehhowch).

Edit: nvm, this is just a whitespace fix. I'll PR the `passengers 6` change in another PR, because the 2 are unrelated.

