### PR TITLE
Fix to scanned ships that jump away still having scan circles visible

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -560,7 +560,8 @@ void Engine::Step(bool isActive)
 			info.SetBar("target hull", 0.);
 		}
 	}
-	if(target && !target->IsDestroyed() && (flagship->CargoScanFraction() || flagship->OutfitScanFraction()))
+	if(target && !target->IsDestroyed() && target->GetSystem() == currentSystem 
+		&& (flagship->CargoScanFraction() || flagship->OutfitScanFraction()))
 	{
 		double width = max(target->Width(), target->Height());
 		Point pos = target->Position() - center;


### PR DESCRIPTION
![ghost_scan_circle](https://cloud.githubusercontent.com/assets/23544894/25776594/1d76ec54-32ba-11e7-9f0c-0a59f874e4fc.png)
