### PR TITLE
Outfits in cargo can be scanned and plundered

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -72,12 +72,12 @@ BoardingPanel::BoardingPanel(PlayerInfo &player, const shared_ptr<Ship> &victim)
 	// outfits are also unplunderable, like mass expansions.
 	for(const auto &it : victim->Outfits())
 		if(!it.first->Get("unplunderable") && it.second)
-			plunder.emplace_back(it.first, it.second);
+			plunder.emplace_back(it.first, it.second, "equipped");
 
 	// Outfits stored in cargo can always be plundered.
 	for(const auto &it : victim->Cargo().Outfits())
 		if(it.second)
-			plunder.emplace_back(it.first, it.second);	
+			plunder.emplace_back(it.first, it.second, "cargo");	
 	
 	// Some "ships" do not represent something the player could actually pilot.
 	if(!victim->IsCapturable())
@@ -226,7 +226,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 					for( ; count && you->Attributes().CanAdd(*outfit); --count)
 					{
 						you->AddOutfit(outfit, 1);
-						if(victim->Outfits().find(outfit) != victim->Outfits().end())
+						if(plunder[selected].Location() == "equipped")
 							victim->AddOutfit(outfit, -1);
 						else
 							victim->Cargo().Remove(outfit, 1);	
@@ -235,7 +235,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 				}
 			// Transfer as many as possible of these outfits to your cargo hold.
 			count = cargo.Add(outfit, count);
-			if(victim->Outfits().find(outfit) != victim->Outfits().end())
+			if(plunder[selected].Location() == "equipped")
 				victim->AddOutfit(outfit, -count);
 			else
 				victim->Cargo().Remove(outfit, count);	
@@ -502,8 +502,9 @@ BoardingPanel::Plunder::Plunder(const string &commodity, int count, int unitValu
 
 
 // Constructor (outfit installed in the victim ship).
-BoardingPanel::Plunder::Plunder(const Outfit *outfit, int count)
-	: name(outfit->Name()), outfit(outfit), count(count), unitValue(outfit->Cost() * Depreciation::Full())
+BoardingPanel::Plunder::Plunder(const Outfit *outfit, int count, string location)
+	: name(outfit->Name()), outfit(outfit), count(count), unitValue(outfit->Cost() * Depreciation::Full()),
+	location(location)
 {
 	UpdateStrings();
 }
@@ -532,6 +533,14 @@ int BoardingPanel::Plunder::Count() const
 int64_t BoardingPanel::Plunder::UnitValue() const
 {
 	return unitValue;
+}
+
+
+
+// Get the location of the outfit to be plundered.
+const string &BoardingPanel::Plunder::Location() const
+{
+	return location;
 }
 
 

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -73,6 +73,10 @@ BoardingPanel::BoardingPanel(PlayerInfo &player, const shared_ptr<Ship> &victim)
 	for(const auto &it : victim->Outfits())
 		if(!it.first->Get("unplunderable") && it.second)
 			plunder.emplace_back(it.first, it.second);
+
+	// Outfits stored in cargo can always be plundered.
+	for(const auto &it : victim->Cargo().Outfits())
+		plunder.emplace_back(it.first, it.second);	
 	
 	// Some "ships" do not represent something the player could actually pilot.
 	if(!victim->IsCapturable())

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -76,7 +76,8 @@ BoardingPanel::BoardingPanel(PlayerInfo &player, const shared_ptr<Ship> &victim)
 
 	// Outfits stored in cargo can always be plundered.
 	for(const auto &it : victim->Cargo().Outfits())
-		plunder.emplace_back(it.first, it.second);	
+		if(it.second)
+			plunder.emplace_back(it.first, it.second);	
 	
 	// Some "ships" do not represent something the player could actually pilot.
 	if(!victim->IsCapturable())
@@ -225,13 +226,19 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 					for( ; count && you->Attributes().CanAdd(*outfit); --count)
 					{
 						you->AddOutfit(outfit, 1);
-						victim->AddOutfit(outfit, -1);
+						if(victim->Outfits().find(outfit) != victim->Outfits().end())
+							victim->AddOutfit(outfit, -1);
+						else
+							victim->Cargo().Remove(outfit, 1);	
 					}
 					break;
 				}
 			// Transfer as many as possible of these outfits to your cargo hold.
 			count = cargo.Add(outfit, count);
-			victim->AddOutfit(outfit, -count);
+			if(victim->Outfits().find(outfit) != victim->Outfits().end())
+				victim->AddOutfit(outfit, -count);
+			else
+				victim->Cargo().Remove(outfit, count);	
 		}
 		else
 			count = victim->Cargo().Transfer(plunder[selected].Name(), count, &cargo);

--- a/source/BoardingPanel.h
+++ b/source/BoardingPanel.h
@@ -63,7 +63,7 @@ private:
 	public:
 		// Plunder can be either outfits or commodities.
 		Plunder(const std::string &commodity, int count, int unitValue);
-		Plunder(const Outfit *outfit, int count);
+		Plunder(const Outfit *outfit, int count, std::string location);
 		
 		// Sort by value per ton of mass.
 		bool operator<(const Plunder &other) const;
@@ -74,6 +74,8 @@ private:
 		// Get the value of each unit of this plunder item.
 		int64_t UnitValue() const;
 		
+		// Get the location of the outfit to be plundered.
+		const std::string &Location() const;
 		// Get the name of this item. If it is a commodity, this is its name.
 		const std::string &Name() const;
 		// Get the mass, in the format "<count> x <unit mass>". If this is a
@@ -100,6 +102,7 @@ private:
 		const Outfit *outfit;
 		int count;
 		int64_t unitValue;
+		std::string location;
 		std::string size;
 		std::string value;
 	};

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -303,6 +303,16 @@ void MainPanel::ShowScanDialog(const ShipEvent &event)
 					<< (it.second == 1 ? " ton of " : " tons of ")
 					<< it.first << "\n";
 			}
+		for(const auto &it : target->Cargo().Outfits())
+			if(it.second)
+			{
+				if(first)
+					out << "This " + target->Noun() + " is carrying:\n";
+				first = false;
+		
+				out << "\t" << it.second << " "
+					<< (it.second == 1 ? it.first->Name(): it.first->PluralName()) << "\n";
+			}
 		if(first)
 			out << "This " + target->Noun() + " is not carrying any cargo.\n";
 	}


### PR DESCRIPTION
Previously, an NPC with an outfit in cargo would not show that cargo
when scanned, and it could not be plundered. This makes an outfit in
cargo behave like ordinary cargo for scanning and plundering.

For example:

![scan_cargo](https://cloud.githubusercontent.com/assets/23544894/25785265/5b96b770-3374-11e7-9cc1-69dfab8e94c8.JPG)
![board](https://cloud.githubusercontent.com/assets/23544894/25785266/5c82fdb0-3374-11e7-93c0-f7f8641a509c.JPG)
```
	npc save "scan cargo"
		personality timid staying
		government Syndicate
		system "Menkar"
		ship "Quicksilver" "Quicksilver (Syndicate Insecurity)"
			name "S-83A6"
			outfits
				"Particle Cannon" 2
				"RT-I Radiothermal"
				"LP036a Battery Pack"
				"D23-QP Shield Generator"
				"Cooling Ducts"
				"Greyhound Plasma Thruster"
				"Greyhound Plasma Steering"
				"Hyperdrive"
			cargo
				outfits
					"Sealed Consignment 25045" 1
```