### PR TITLE
require <outfit> can require a specific number, or specifically zero

### DIFF
--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -143,8 +143,11 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			int count = (child.Size() < 3 ? 1 : static_cast<int>(child.Value(2)));
 			gifts[GameData::Outfits().Get(child.Token(1))] = count;
 		}
-		else if(key == "require" && hasValue)
-			gifts[GameData::Outfits().Get(child.Token(1))] = 0;
+		else if(key == "require" && hasValue))
+		{
+			int count = (child.Size() < 3 ? 1 : static_cast<int>(child.Value(2)));
+			requiredOutfits[GameData::Outfits().Get(child.Token(1))] = count;			
+		}
 		else if(key == "payment")
 		{
 			if(child.Size() == 1)
@@ -203,6 +206,8 @@ void MissionAction::Save(DataWriter &out) const
 		
 		for(const auto &it : gifts)
 			out.Write("outfit", it.first->Name(), it.second);
+		for(const auto &it : requiredOutfits)
+			out.Write("require", it.first->Name(), it.second);
 		if(payment)
 			out.Write("payment", payment);
 		for(const auto &it : events)
@@ -245,8 +250,26 @@ bool MissionAction::CanBeDone(const PlayerInfo &player) const
 			available += flagship->OutfitCount(it.first);
 		
 		// If the gift "count" is 0, that means to check that the player has at
-		// least one of these items.
+		// least one of these items. This is for backward compatibility before
+		// requiredOutfits was introduced.
 		if(available < -it.second + !it.second)
+			return false;
+	}
+	
+	for(const auto &it : requiredOutfits)
+	{
+		// The required outfit can be in the player's cargo or from the flagship.
+		int available = player.Cargo().Get(it.first);
+		for(const auto &ship : player.Ships())
+			available += ship->Cargo().Get(it.first);
+		if(flagship)
+			available += flagship->OutfitCount(it.first);		
+		
+		if(available < it.second)
+			return false;
+		
+		// If the required count is 0, the player must not have any of the outfit.	
+		if(it.second == 0 && available > 0)
 			return false;
 	}
 	return true;

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -71,6 +71,7 @@ private:
 	
 	std::map<std::string, int> events;
 	std::map<const Outfit *, int> gifts;
+	std::map<const Outfit *, int> requiredOutfits;
 	int64_t payment = 0;
 	int64_t paymentMultiplier = 0;
 	


### PR DESCRIPTION
**Update:** lot of great discussion below, but for newcomers: most of it's, I think, talking about other ways this could be extended (in a different PR). As of 10/05/17 I'm still suggesting this PR is merge-worthy and merge-ready, as a starting point if nothing else.

_____________________

With this PR, instead of only being able to write (in an mission's `on` clause)

`require <outfit>`

to always require at least one copy, you can now also write

`require <outfit> 3`
`require <outfit> 0`

respectively requiring at _least_ 3, or _exactly_ 0. (0 is the only one that will look for an exact match: any other number is happy with at least that many.) You can still use the existing syntax which will require at least one copy.

`outfit <outfit> [<number>]` is completely unchanged: it will still add/remove according to the number. `require` is for if you want to check the player has a certain number, but not change it.