### PR TITLE
Pathfind via accessible objects only

### DIFF
--- a/source/DistanceMap.cpp
+++ b/source/DistanceMap.cpp
@@ -195,7 +195,7 @@ void DistanceMap::Init(const System *center, const Ship *ship)
 					// the wormhole and both endpoint systems. (If this is a
 					// multi-stop wormhole, you may know about some paths that
 					// it takes but not others.)
-					if(player && !object.GetPlanet()->IsAccessible(player->Flagship()))
+					if(ship && !object.GetPlanet()->IsAccessible(ship))
 						continue;
 					if(player && !player->HasVisited(object.GetPlanet()))
 						continue;


### PR DESCRIPTION
Escorts will not attempt to pathfind via wormholes that are inaccessible to them but are accessible to the player.
Closes #2490

This does not solve the sub-issue raised by the unique situation in #2490 where, after the player uses a route that the escorts cannot, then returns to regions available via accessible routes, escorts "misbehave". It should, however, prevent such a situation from arising in the first place.