### PR TITLE
enhancement: Add Ammunition outfits to explosion flotsam

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -868,6 +868,10 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 					Jettison(it.first, Random::Binomial(it.second, .25));
 				for(const auto &it : cargo.Outfits())
 					Jettison(it.first, Random::Binomial(it.second, .25));
+				// Ammunition has a 5% chance to survive as flotsam
+				for(const auto &it : outfits)
+					if(it.first->Category() == "Ammunition")
+						Jettison(it.first, Random::Binomial(it.second, .05));
 				for(shared_ptr<Flotsam> &it : jettisoned)
 					it->Place(*this);
 				flotsam.splice(flotsam.end(), jettisoned);


### PR DESCRIPTION
When a ship dies, in addition to any items in its cargo hold, any ammunition it was using may also be jettisoned as flotsam (5% probability vs 25% for cargo).

![image](https://cloud.githubusercontent.com/assets/20871346/25788435/a1e2553c-336e-11e7-9c64-6c6937960a6a.png)

This may be better done with a double check, first at a low rate (e.g. 1%) and then normal quantity (25%) if successful. This method may be more attractive if there is a lot of pickup spam from ships which are disabled before using their complement.