### PR TITLE
Reactivate Autopilot Landing Sequence

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -129,17 +129,6 @@ void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 		keyStuck.Clear();
 	}
 	const Ship *flagship = player.Flagship();
-	if(keyStuck.Has(Command::JUMP) && !player.HasTravelPlan())
-	{
-		keyStuck.Clear(Command::JUMP);
-		const Planet *planet = player.TravelDestination();
-		if(planet && planet->IsInSystem(flagship->GetSystem()))
-		{
-			// The MovePlayer() code will already have targeted this planet.
-			Messages::Add("Autopilot: landing on " + planet->Name() + ".");
-			keyStuck |= Command::LAND;
-		}
-	}
 	
 	if(!isActive || !flagship || flagship->IsDestroyed())
 		return;
@@ -2476,6 +2465,18 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		Point distance = ship.GetTargetShip()->Position() - ship.Position();
 		if(distance.Unit().Dot(ship.Facing().Unit()) >= .8)
 			command.SetTurn(TurnToward(ship, TargetAim(ship)));
+	}
+	
+	if(keyStuck.Has(Command::JUMP) && !player.HasTravelPlan())
+	{
+		// The player completed their travel plan, which may have indicated a destination within the final system
+		keyStuck.Clear(Command::JUMP);
+		const Planet *planet = player.TravelDestination();
+		if(planet && planet->IsInSystem(ship.GetSystem()))
+		{
+			Messages::Add("Autopilot: landing on " + planet->Name() + ".");
+			keyStuck |= Command::LAND;
+		}
 	}
 	
 	// Clear "stuck" keys if actions can't be performed.


### PR DESCRIPTION
This PR closes #2503 

Autopilot landing was added in 8483cff
In 3d66260, code was added that acted before the autopilot AI could issue its landing order.
This PR moves the relevant block from UpdateKeys to MovePlayer, just before the keyStuck commands are evaluated.
I had thought that perhaps modifying the lines introduced by 3d66260 would be simplest, but including ship.GetTargetStellar() in the keyStuck.Has(Command::JUMP) comparison results in a segfault upon arrival in the destination system, while moving the code block (this PR) results in successful autopilot reactivation:

![image](https://cloud.githubusercontent.com/assets/20871346/25863663/48d6efda-34b2-11e7-83ed-a974029f701f.png)

