### PR TITLE
Play jump drive audio when the player is using the jump drive

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1010,7 +1010,7 @@ void Engine::CalculateStep()
 	}
 	
 	if(!wasHyperspacing && flagship && flagship->IsEnteringHyperspace())
-		Audio::Play(Audio::Get(flagship->IsUsingJumpDrive() ? "jump drive" : "hyperdrive"));
+		Audio::Play(Audio::Get(flagship->WillUseJumpDrive() ? "jump drive" : "hyperdrive"));
 	
 	if(flagship && player.GetSystem() != flagship->GetSystem())
 	{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1674,6 +1674,14 @@ bool Ship::IsUsingJumpDrive() const
 
 
 
+// Check if this ship will use the jump drive to make its next jump
+bool Ship::WillUseJumpDrive() const
+{
+	return IsEnteringHyperspace() && isUsingJumpDrive;
+}
+
+
+
 // Check if this ship is currently able to enter hyperspace to it target.
 bool Ship::IsReadyToJump() const
 {

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -200,7 +200,9 @@ public:
 	bool IsHyperspacing() const;
 	// Check if this ship is hyperspacing, specifically via a jump drive.
 	bool IsUsingJumpDrive() const;
-	// Check if this ship is currently able to enter hyperspace to it target.
+	// Check if this ship is ready to hyperspace via a jump drive
+	bool WillUseJumpDrive() const;
+	// Check if this ship is currently able to enter hyperspace to its target.
 	bool IsReadyToJump() const;
 	
 	// Check if the ship is thrusting. If so, the engine sound should be played.


### PR DESCRIPTION
After c795aae8 the flagship would only play hyperdrive audio when jumping, even if the jump was made with the Jump Drive.

This is tracked to [L1012](https://github.com/endless-sky/endless-sky/blob/b3c808a7e30cb9374680423814d14f27bd9cdbc0/source/Engine.cpp#L1012): 
```
if(!wasHyperspacing && flagship && flagship->IsEnteringHyperspace())
    Audio::Play(Audio::Get(flagship->IsUsingJumpDrive() ? "jump drive" : "hyperdrive"));
```
IsEnteringHyperspace() is the gateway check, but at that time, IsUsingJumpDrive() is false, because IsUsingJumpDrive() requires the ship to be [IsHyperspacing](https://github.com/endless-sky/endless-sky/blob/b3c808a7e30cb9374680423814d14f27bd9cdbc0/source/Ship.cpp#L1670):
```
bool Ship::IsUsingJumpDrive() const
{
    return IsHyperspacing() && isUsingJumpDrive;
}
```
As soon as your ship IsHyperspacing() (e.g. jump drive in use), the engine sees you as having already entered hyperspace, and thus IsEnteringHyperspace() will evaluate to false (guaranteeing the audio only plays once, when you start to jump)

Changing the gateway check from IsEnteringHyperspace to IsHyperspacing for example, will correctly play the jump drive audio instead of the hyperdrive audio when your ship is placed into the new system (e.g not at the correct time, and more than once).

The simplest fix I could think was to declare a new ship method, WillUseJumpDrive(), which checks that the ship will use the jump drive, and it has a hyperspace target.