### PR TITLE
enhancement: Let System class report StellarObject counts

### DIFF
--- a/source/System.cpp
+++ b/source/System.cpp
@@ -410,6 +410,30 @@ int System::StarCount() const
 
 
 
+// Get the number of planets in the system
+int System::PlanetCount() const
+{
+	return planetCount;
+}
+
+
+
+// Get the number of moons in the system
+int System::MoonCount() const
+{
+	return moonCount;
+}
+
+
+
+// Get the number of space stations in the system
+int System::StationCount() const
+{
+	return stationCount;
+}
+
+
+
 // Check if this system is inhabited.
 bool System::IsInhabited(const Ship *ship) const
 {
@@ -586,8 +610,15 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 				object.isStation = !child.Token(1).compare(0, 14, "planet/station");
 				object.isMoon = (!object.isStation && parent >= 0 && !objects[parent].IsStar());
 			}
-			else
+			
+			if(object.isStar)
 				++starCount;
+			else if(object.isStation)
+				++stationCount;
+			else if(object.isMoon)
+				++moonCount;
+			else
+				++planetCount;
 		}
 		else if(child.Token(0) == "distance" && child.Size() >= 2)
 			object.distance = child.Value(1);

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -402,6 +402,14 @@ double System::AsteroidBelt() const
 
 
 
+// Get the number of stars in the system
+int System::StarCount() const
+{
+	return starCount;
+}
+
+
+
 // Check if this system is inhabited.
 bool System::IsInhabited(const Ship *ship) const
 {
@@ -578,6 +586,8 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 				object.isStation = !child.Token(1).compare(0, 14, "planet/station");
 				object.isMoon = (!object.isStation && parent >= 0 && !objects[parent].IsStar());
 			}
+			else
+				++starCount;
 		}
 		else if(child.Token(0) == "distance" && child.Size() >= 2)
 			object.distance = child.Value(1);

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -402,7 +402,7 @@ double System::AsteroidBelt() const
 
 
 
-// Get the number of stars in the system
+// Get the number of stars in the system.
 int System::StarCount() const
 {
 	return starCount;
@@ -410,7 +410,7 @@ int System::StarCount() const
 
 
 
-// Get the number of planets in the system
+// Get the number of planets in the system.
 int System::PlanetCount() const
 {
 	return planetCount;
@@ -418,7 +418,7 @@ int System::PlanetCount() const
 
 
 
-// Get the number of moons in the system
+// Get the number of moons in the system.
 int System::MoonCount() const
 {
 	return moonCount;
@@ -426,10 +426,26 @@ int System::MoonCount() const
 
 
 
-// Get the number of space stations in the system
+// Get the number of space stations in the system.
 int System::StationCount() const
 {
 	return stationCount;
+}
+
+
+
+// Get the number of inhabited objects in the system.
+int System::InhabitedCount() const
+{
+	int inhabitedCount = 0;
+	for(const StellarObject &object : objects)
+		if(object.GetPlanet())
+		{
+			if(object.GetPlanet()->IsInhabited())
+				++inhabitedCount;
+		}
+	
+	return inhabitedCount;
 }
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -105,6 +105,8 @@ public:
 	double HabitableZone() const;
 	// Get the radius of the asteroid belt.
 	double AsteroidBelt() const;
+	// Get the number of stars in this system
+	int StarCount() const;
 	// Check if this system is inhabited.
 	bool IsInhabited(const Ship *ship) const;
 	// Check if ships of the given government can refuel in this system.
@@ -173,6 +175,7 @@ private:
 	std::vector<FleetProbability> fleets;
 	double habitable = 1000.;
 	double asteroidBelt = 1500.;
+	int starCount = 0;
 	
 	// Commodity prices.
 	std::map<std::string, Price> trade;

--- a/source/System.h
+++ b/source/System.h
@@ -105,8 +105,11 @@ public:
 	double HabitableZone() const;
 	// Get the radius of the asteroid belt.
 	double AsteroidBelt() const;
-	// Get the number of stars in this system
+	// Get the number of ____ in this system
 	int StarCount() const;
+	int PlanetCount() const;
+	int MoonCount() const;
+	int StationCount() const;
 	// Check if this system is inhabited.
 	bool IsInhabited(const Ship *ship) const;
 	// Check if ships of the given government can refuel in this system.
@@ -176,6 +179,9 @@ private:
 	double habitable = 1000.;
 	double asteroidBelt = 1500.;
 	int starCount = 0;
+	int planetCount = 0;
+	int moonCount = 0;
+	int stationCount = 0;
 	
 	// Commodity prices.
 	std::map<std::string, Price> trade;

--- a/source/System.h
+++ b/source/System.h
@@ -105,11 +105,12 @@ public:
 	double HabitableZone() const;
 	// Get the radius of the asteroid belt.
 	double AsteroidBelt() const;
-	// Get the number of ____ in this system
+	// Get the number of the type of object in this system.
 	int StarCount() const;
 	int PlanetCount() const;
 	int MoonCount() const;
 	int StationCount() const;
+	int InhabitedCount() const;
 	// Check if this system is inhabited.
 	bool IsInhabited(const Ship *ship) const;
 	// Check if ships of the given government can refuel in this system.


### PR DESCRIPTION
While not immediately useful, these seem like basic quantities that can be useful for more advanced things with the game and mission engines.

For example, if a system is able to report that it has no stars, ramscoop and solar collection could be turned off entirely (except for perhaps some tiny background amount), or optical tracking can be degraded due to lack of light... If a system has multiple stars, the collection rate of ramscoops / solar collectors can scale appropriately due to the higher luminosity or solar wind, optical tracking becomes more effective while radar and infrared tracking slightly decrease (due to higher background levels).
Coded example usage: https://github.com/tehhowch/endless-sky/commit/f3f26a6abda14fd524b57ee1106974f04f24797b

For missions, (if the current filtering system supports it) a system with two planets could be randomly picked to have a civil war, or a system with two stars can be randomly chosen for a special science expedition, or some warring faction can target a random nearby systems having space stations...