### PR TITLE
Reload advanced by landing/jumping (Ref #2502)

### DIFF
--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -192,16 +192,16 @@ bool Armament::FireAntiMissile(int index, Ship &ship, const Projectile &projecti
 
 
 
-// Update the reload counters.
-void Armament::Step(const Ship &ship)
+// Update the reload counters for a given number of frames.
+void Armament::Step(const Ship &ship, int frames)
 {
 	for(Hardpoint &hardpoint : hardpoints)
-		hardpoint.Step();
+		hardpoint.Step(frames);
 	
 	for(auto &it : streamReload)
 	{
 		int count = ship.OutfitCount(it.first);
-		it.second -= count;
+		it.second -= frames * count;
 		// Always reload to the quickest firing interval.
 		it.second = max(it.second, 1 - count);
 	}

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -65,7 +65,7 @@ public:
 	bool FireAntiMissile(int index, Ship &ship, const Projectile &projectile, std::list<Effect> &effects);
 	
 	// Update the reload counters.
-	void Step(const Ship &ship);
+	void Step(const Ship &ship, int frames = 1);
 	
 	// Calculate how long it will take a projectile to reach a target given the
 	// target's relative position and velocity and the velocity of the

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -124,20 +124,26 @@ int Hardpoint::BurstRemaining() const
 
 
 
-// Perform one step (i.e. decrement the reload count).
-void Hardpoint::Step()
+// Perform steps.
+void Hardpoint::Step(int frames)
 {
 	if(!outfit)
 		return;
 	
 	wasFiring = isFiring;
 	if(reload > 0.)
-		--reload;
+	{
+		reload -= frames;
+		reload = max(reload, -1.);
+	}
 	// If the full reload time is elapsed, reset the burst counter.
 	if(reload <= 0.)
 		burstCount = outfit->BurstCount();
 	if(burstReload > 0.)
-		--burstReload;
+	{
+		burstReload -= frames;
+		burstReload = max(burstReload, -1.);		
+	}
 	// If the burst reload time has elapsed, this weapon will not count as firing
 	// continuously if it is not fired this frame.
 	if(burstReload <= 0.)

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -51,8 +51,8 @@ public:
 	bool WasFiring() const;
 	// If this is a burst weapon, get the number of shots left in the burst.
 	int BurstRemaining() const;
-	// Perform one step (i.e. decrement the reload count).
-	void Step();
+	// Perform steps.
+	void Step(int frames = 1);	
 	
 	// Fire this weapon. If it is a turret, it automatically points toward
 	// the given ship's target. If the weapon requires ammunition, it will

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -43,6 +43,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 using namespace std;
 
+namespace {
+	static constexpr int FRAMES_PER_DAY = 24 * 60 * 60 * 60;
+}
+
 
 
 // Completely clear all loaded information, to prepare for loading a file or
@@ -577,6 +581,10 @@ void PlayerInfo::IncrementDate()
 	string message = accounts.Step(assets, Salaries());
 	if(!message.empty())
 		Messages::Add(message);
+	
+	// Advance the reload counters on all the player's weapons by a day's frames.
+	for(const shared_ptr<Ship> &ship : ships)
+		ship->GetArmament().Step(*ship, FRAMES_PER_DAY);
 }
 
 


### PR DESCRIPTION
When the date is advanced by landing/jumping (particularly the method
IncrementDate), reload counters are advanced by the appropriate number
of frames. This will, in every case in the game, reset the reload
completely.

This is based on issue #2502. The only consideration we found for deciding _how_ to implement this was whether to a) completely reset the reload counter or b) advance it by the appropriate number of frames.

For everything in the game right now, it makes no difference. I've implemented b) because it's no more difficult and is technically more correct – and I can't think of a good reason to block content creators from wanting ultra-long reload times. (Maybe it has no place in _this_ game, but maybe some plug-in or TC might want a superweapon one day...)

<details>
<summary>Technical details</summary>
<br />
1. The starting point is <b>PlayerInfo.cpp</b> and the IncrementDate() method, line 521. I added a few lines to the end of this. <br />
2. I defined advanceFrames manually as 24 * 60 * 60 * 60. I don't like magic numbers in coding, but writing 60 instead of defining some FRAMES_PER_SECOND seems the standard in the code, and equally defining SECONDS_PER_DAY = 86400 didn't seem in keeping with this. <br />
3. Reloading a weapon is split between Armament::Step and Hardpoint::Step. The first is for <i>all</i> weapons of a ship, and the second is for an individual weapon/hardpoint. The first calls the second. <br />
4. Instead of changing Step, I've defined a parallel method which takes an integer parameter, a number of frames. <br />
5. I'm not 100% confident with this part of Armament::Step: "Always reload to the quickest firing interval." I think it's right as is, but feedback's really appreciated. <br />
</details>