### PR TITLE
Fix iterator bug in BoardingPanel

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -78,8 +78,10 @@ BoardingPanel::BoardingPanel(PlayerInfo &player, const shared_ptr<Ship> &victim)
 		int count = 0;
 		// Merge the outfit lists from the ship itself and its cargo bay. If an
 		// outfit exists in both locations, combine the counts.
-		bool shipIsFirst = (cit == victim->Outfits().end() || sit->first <= cit->first);
-		bool cargoIsFirst = (sit == victim->Outfits().end() || cit->first <= sit->first);
+		bool shipIsFirst = (cit == victim->Cargo().Outfits().end() || sit->first <= cit->first)
+				&& (sit != victim->Outfits().end());
+		bool cargoIsFirst = (sit == victim->Outfits().end() || cit->first <= sit->first)
+				&& (cit != victim->Cargo().Outfits().end());
 		if(shipIsFirst)
 		{
 			outfit = sit->first;


### PR DESCRIPTION
Closes #2516 

The ship-first and cargo-first booleans didn't consider if their iterator was already at the end of their respective iterable stream.
Also made sure the cargo outfits iterator is comparing to cargo outfits (spotted by @EndrosG )