### PR TITLE
Outfits in cargo can be scanned

### DIFF
--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -303,6 +303,16 @@ void MainPanel::ShowScanDialog(const ShipEvent &event)
 					<< (it.second == 1 ? " ton of " : " tons of ")
 					<< it.first << "\n";
 			}
+		for(const auto &it : target->Cargo().Outfits())
+			if(it.second)
+			{
+				if(first)
+					out << "This " + target->Noun() + " is carrying:\n";
+				first = false;
+		
+				out << "\t" << it.second << " "
+					<< (it.second == 1 ? it.first->Name(): it.first->PluralName()) << "\n";
+			}
 		if(first)
 			out << "This " + target->Noun() + " is not carrying any cargo.\n";
 	}


### PR DESCRIPTION
Previously, an NPC with an outfit in cargo would not show that cargo
when scanned. This makes an outfit in
cargo behave like ordinary cargo for scanning.

@endless-sky, your commit 80593fc9c734e178ef9989a2b0697775637e92f5 only included the plundering side of #2495, not the scanning.

With @tehhowch's PR #2517 and without this, we get this:

![scan](https://cloud.githubusercontent.com/assets/23544894/26030253/834208c6-3845-11e7-8e5f-6fc8aea95903.JPG)
![boarding](https://cloud.githubusercontent.com/assets/23544894/26030254/84429ab0-3845-11e7-9086-4542f9e6fbb7.JPG)
