### PR TITLE
Fix to changing a system's music in an event

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -828,13 +828,14 @@ void Engine::EnterSystem()
 	if(!flagship)
 		return;
 	
-	const System *system = flagship->GetSystem();
-	Audio::PlayMusic(system->MusicName());
-	GameData::SetHaze(system->Haze());
-	
 	doEnter = true;
 	player.IncrementDate();
 	const Date &today = player.GetDate();
+	
+	const System *system = flagship->GetSystem();
+	Audio::PlayMusic(system->MusicName());
+	GameData::SetHaze(system->Haze());	
+	
 	Messages::Add("Entering the " + system->Name() + " system on "
 		+ today.ToString() + (system->IsInhabited(flagship) ?
 			"." : ". No inhabited planets detected."));


### PR DESCRIPTION
At the moment, Engine::EnterSystem plays music before IncrementDate is
run (which manages event handling). This means that if an event changes
the music of the system you're in, you won't get the change until a day
later. This fixes that by reordering the code. Should also fix the same
issue with haze, if an event changes that.