### PR TITLE
Added an non-neutrality event to trigger at the end of the FW storyline

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -3369,7 +3369,6 @@ mission "Graffias non-neutrality patch"
 
 
 
-
 event "geminus rebuilt"
 	planet Geminus
 		description `Geminus, although not the most hospitable of worlds, is a young enough planet that large stores of iron, titanium, and other metals are easily accessible near the surface. The constant volcanic activity leaves the planet perpetually shrouded in a twilight haze of ash and fog.`

--- a/data/events.txt
+++ b/data/events.txt
@@ -3331,7 +3331,7 @@ event "syndicate tech available"
 
 
 
-event "Tarazed Graffias non-neutrality"
+event "Tarazed non-neutrality"
 	system "Tarazed"
 		government "Free Worlds"
 	system "Dabih"
@@ -3340,18 +3340,31 @@ event "Tarazed Graffias non-neutrality"
 		government "Free Worlds"
 	system "Girtab"
 		government "Free Worlds"
+
+event "Graffias non-neutrality"
 	system Graffias
 		government "Republic"
 
 
-#Patching the non-neutrality event into older saves as well.
-mission "Tarazed Graffias non-neutrality patch"
+#Patching the non-neutrality events into older saves as well.
+mission "Tarazed non-neutrality patch"
+	landing
+	invisible
+	to offer
+		or
+			has "FW Pug 3B: offered"
+			has "free worlds plot completed"
+	on offer
+		event "Tarazed non-neutrality" 30
+		fail
+
+mission "Graffias non-neutrality patch"
 	landing
 	invisible
 	to offer
 		has "free worlds plot completed"
 	on offer
-		event "Tarazed Graffias non-neutrality" 7
+		event "Graffias non-neutrality" 14
 		fail
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -3344,6 +3344,18 @@ event "Tarazed Graffias non-neutrality"
 		government "Republic"
 
 
+#Patching the non-neutrality event into older saves as well.
+mission "Tarazed Graffias non-neutrality patch"
+	landing
+	invisible
+	to offer
+		has "free worlds plot completed"
+	on offer
+		event "Tarazed Graffias non-neutrality" 7
+		fail
+
+
+
 
 event "geminus rebuilt"
 	planet Geminus

--- a/data/events.txt
+++ b/data/events.txt
@@ -3331,6 +3331,20 @@ event "syndicate tech available"
 
 
 
+event "Tarazed Graffias non-neutrality"
+	system "Tarazed"
+		government "Free Worlds"
+	system "Dabih"
+		government "Free Worlds"
+	system "Albireo"
+		government "Free Worlds"
+	system "Girtab"
+		government "Free Worlds"
+	system Graffias
+		government "Republic"
+
+
+
 event "geminus rebuilt"
 	planet Geminus
 		description `Geminus, although not the most hospitable of worlds, is a young enough planet that large stores of iron, titanium, and other metals are easily accessible near the surface. The constant volcanic activity leaves the planet perpetually shrouded in a twilight haze of ash and fog.`

--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -2627,6 +2627,7 @@ mission "FWC End"
 		event "syndicate tech available"
 		set "main plot completed"
 		set "free worlds plot completed"
+		event "Tarazed Graffias non-neutrality" 7
 		conversation
 			`You arrive in the Parliament building just as Alondo and Katya have finished meeting with them. "Good news," says Katya. "We're all officially pardoned. And you, Captain <last>, have become something of a hero."`
 			`	"Better yet," says Alondo, "the war with the Republic is over. We agreed to limiting our territory to its current size, and to a very minor tax to cover the cost of Navy protection if the aliens attack again or some other major catastrophe strikes. In return, the Free Worlds have been granted autonomy from the Republic."`

--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -2627,10 +2627,11 @@ mission "FWC End"
 		event "syndicate tech available"
 		set "main plot completed"
 		set "free worlds plot completed"
-		event "Tarazed Graffias non-neutrality" 7
+		event "Tarazed non-neutrality" 30
+		event "Graffias non-neutrality" 14
 		conversation
 			`You arrive in the Parliament building just as Alondo and Katya have finished meeting with them. "Good news," says Katya. "We're all officially pardoned. And you, Captain <last>, have become something of a hero."`
-			`	"Better yet," says Alondo, "the war with the Republic is over. We agreed to limiting our territory to its current size, and to a very minor tax to cover the cost of Navy protection if the aliens attack again or some other major catastrophe strikes. In return, the Free Worlds have been granted autonomy from the Republic."`
+			`	"Better yet," says Alondo, "the war with the Republic is over. We agreed to limiting our territory to its current size plus Tarazed if they wish to join us, and to a very minor tax to cover the cost of Navy protection if the aliens attack again or some other major catastrophe strikes. In return, the Free Worlds have been granted autonomy from the Republic."`
 			`	"Also," says Katya, "as their own expression of gratitude, the Syndicate members of Parliament have offered to make some of their new technology, developed during the war, available to us at an affordable price."`
 			choice
 				`	"That's very generous of them."`

--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -2627,8 +2627,6 @@ mission "FWC End"
 		event "syndicate tech available"
 		set "main plot completed"
 		set "free worlds plot completed"
-		event "Tarazed non-neutrality" 30
-		event "Graffias non-neutrality" 14
 		conversation
 			`You arrive in the Parliament building just as Alondo and Katya have finished meeting with them. "Good news," says Katya. "We're all officially pardoned. And you, Captain <last>, have become something of a hero."`
 			`	"Better yet," says Alondo, "the war with the Republic is over. We agreed to limiting our territory to its current size plus Tarazed if they wish to join us, and to a very minor tax to cover the cost of Navy protection if the aliens attack again or some other major catastrophe strikes. In return, the Free Worlds have been granted autonomy from the Republic."`

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -1492,9 +1492,10 @@ mission "FW Pug 3B"
 	
 	on offer
 		"salary: Free Worlds" = 6000
+		event "Tarazed non-neutrality" 30
 		conversation
 			`Freya meets you soon after you land. "I've heard the news," she says. "I talked to the Senate, and they think that I should travel with you during your assault on the Pug, in case I can help figure out their technology, maybe even how to restore the hyperspace links. And they say they need Alondo back here to do diplomatic visits and help keep people from panicking."`
-			`	"I guess that makes sense," says Alondo.`
+			`	"I guess that makes sense," says Alondo "I hope to also get a chance to visit Wayfarer, seeing as we are not at war with the Republic any more there is no reason for them not to join us officially."`
 			`	"Also," says Freya, "the Senate approved a raise for you, <first>. Your new salary will be six thousand credits a day. I hope that means you'll be able to go into battle against the Pug with the strongest ship possible, because I suspect we'll need all the firepower we can get."`
 			`	Alondo wishes you the best of luck and leaves to catch a transport to Bourne, while Freya takes you to the spaceport and introduces you to the captains of the two Dreadnoughts that have volunteered to fight the Pug. She also asks you all sorts of technical questions: what sort of propulsion and energy sources the Pug seem to use, what their weapon capabilities are, and whether you saw any sign of the technology that was used to destroy the hyperspace links. You have a hard time answering her, but are glad that she will be with you this time to see the aliens firsthand.`
 				accept
@@ -2509,7 +2510,7 @@ mission "FW Syndicate Extremists 1C"
 		payment 5000000
 		set "main plot completed"
 		set "free worlds plot completed"
-		event "Tarazed Graffias non-neutrality" 7
+		event "Graffias non-neutrality" 14
 		conversation
 			`On Earth, you return to something of a hero's welcome, far different from the first time you were here on a diplomatic mission. A crowd of locals gathers in the spaceport to watch your ship land. With the Free Worlds having been instrumental in defeating the aliens, and absolved of any guilt in the terrorist attacks, it seems that most people here are ready to see you as a hero rather than a criminal.`
 			`	You discover that Parliament has made a treaty with the Free Worlds, agreeing that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, your war against the Republic is officially over.`

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -2509,6 +2509,7 @@ mission "FW Syndicate Extremists 1C"
 		payment 5000000
 		set "main plot completed"
 		set "free worlds plot completed"
+		event "Tarazed Graffias non-neutrality" 7
 		conversation
 			`On Earth, you return to something of a hero's welcome, far different from the first time you were here on a diplomatic mission. A crowd of locals gathers in the spaceport to watch your ship land. With the Free Worlds having been instrumental in defeating the aliens, and absolved of any guilt in the terrorist attacks, it seems that most people here are ready to see you as a hero rather than a criminal.`
 			`	You discover that Parliament has made a treaty with the Free Worlds, agreeing that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, your war against the Republic is officially over.`

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -1492,7 +1492,6 @@ mission "FW Pug 3B"
 	
 	on offer
 		"salary: Free Worlds" = 6000
-		event "Tarazed non-neutrality" 30
 		conversation
 			`Freya meets you soon after you land. "I've heard the news," she says. "I talked to the Senate, and they think that I should travel with you during your assault on the Pug, in case I can help figure out their technology, maybe even how to restore the hyperspace links. And they say they need Alondo back here to do diplomatic visits and help keep people from panicking."`
 			`	"I guess that makes sense," says Alondo "I hope to also get a chance to visit Wayfarer, seeing as we are not at war with the Republic any more there is no reason for them not to join us officially."`
@@ -2510,7 +2509,6 @@ mission "FW Syndicate Extremists 1C"
 		payment 5000000
 		set "main plot completed"
 		set "free worlds plot completed"
-		event "Graffias non-neutrality" 14
 		conversation
 			`On Earth, you return to something of a hero's welcome, far different from the first time you were here on a diplomatic mission. A crowd of locals gathers in the spaceport to watch your ship land. With the Free Worlds having been instrumental in defeating the aliens, and absolved of any guilt in the terrorist attacks, it seems that most people here are ready to see you as a hero rather than a criminal.`
 			`	You discover that Parliament has made a treaty with the Free Worlds, agreeing that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, your war against the Republic is officially over.`


### PR DESCRIPTION
It feels odd to have these 5 systems continuing to be neutral after the war is over. So I added an event that would make them either FW (for near Tarazed) and Republic for Poisonwood.