### PR TITLE
bugfix: Fail FW Bounty missions upon choosing a side

### DIFF
--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1573,6 +1573,8 @@ mission "FW Bounty 1"
 		"combat rating" > 200
 		random <= 25
 		not "chosen sides"
+	to fail
+		has "chosen sides"
 	
 	on offer
 		conversation
@@ -1611,6 +1613,8 @@ mission "FW Bounty 2"
 		has "FW Bounty 1: done"
 		random <= 30
 		not "chosen sides"
+	to fail
+		has "chosen sides"
 	
 	on offer
 		conversation
@@ -1644,6 +1648,8 @@ mission "FW Bounty 3"
 		has "FW Bounty 2: done"
 		random <= 30
 		not "chosen sides"
+	to fail
+		has "chosen sides"
 	
 	on offer
 		conversation

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1601,6 +1601,8 @@ mission "FW Bounty 1"
 	on complete
 		payment 200000
 		dialog `The militia officer who asked you to hunt down the "Rat Pack" arrives at your ship soon after you land and thanks you profusely. "Now we won't have to worry about them bothering ships in this sector anymore." She pays you <payment> and says she'll tell other militia leaders how helpful you were.`
+	on fail
+		dialog `You abandon hunting the "Rat Pack" since you are now a member of the Free Worlds militia.`
 
 
 
@@ -1636,6 +1638,8 @@ mission "FW Bounty 2"
 	on complete
 		payment 200000
 		dialog `The militia officer who asked you to hunt down the <npc> meets you in the spaceport and pays you <payment>. "Once again, thank you for assisting us," he says.`
+	on fail
+		dialog `You abandon hunting the <npc> since you are now a member of the Free Worlds militia.`
 
 
 
@@ -1671,6 +1675,8 @@ mission "FW Bounty 3"
 		"assisted free worlds" ++
 		payment 300000
 		dialog `The militia officer who asked you to hunt down the <npc> contacts you soon after you land. "You've done us a great service," he says. "I'll be telling the Council how helpful you were." He hands you a payment of <payment>.`
+	on fail
+		dialog `You abandon hunting the <npc> since you are now a member of the Free Worlds militia.`
 
 
 

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1602,7 +1602,29 @@ mission "FW Bounty 1"
 		payment 200000
 		dialog `The militia officer who asked you to hunt down the "Rat Pack" arrives at your ship soon after you land and thanks you profusely. "Now we won't have to worry about them bothering ships in this sector anymore." She pays you <payment> and says she'll tell other militia leaders how helpful you were.`
 	on fail
-		dialog `You abandon hunting the "Rat Pack" since you are now a member of the Free Worlds militia.`
+		conversation
+			branch "Free Worlds"
+				or
+					has "Rescue Katya 1: active"
+					has "joined the free worlds"
+				
+			`You receive a sealed message from a courier who bears a Free Worlds insignia. You open it and read:`
+			``
+			`Captain <last>:`
+			`	Since you have decided to actively oppose the Free Worlds and our independence, we must retract the reward being offered to hunt the "Rat Pack" pirates. It disappoints us that you have chosen this path, but as members of the Free Worlds, we must respect your decision as a free individual.`
+			`	However, let this message also serve as a notification: do not enter Free Worlds territory without permission, or you will be fired upon.`
+			``
+			``
+			`	Though the message bears no signature, you can't help but feel that it came from someone you have now disappointed, someone who was beginning to like working with you.`
+				decline
+			
+			label "Free Worlds"
+			`You receive a call from the Free Worlds militia member who asked you to hunt down the "Rat Pack". "Hello, Captain <last>", she says. "My superiors have indicated you are on some sort of high-priority mission for the Council. I'd rather not have you delay their task, so I've asked a different merchant captain to eliminate the 'Rat Pack'."`
+			choice
+				`	"Sorry I can't be of more help,"`
+				`	"I really must get going."`
+				`	"They were too strong for me, anyway."`
+					decline
 
 
 
@@ -1639,7 +1661,29 @@ mission "FW Bounty 2"
 		payment 200000
 		dialog `The militia officer who asked you to hunt down the <npc> meets you in the spaceport and pays you <payment>. "Once again, thank you for assisting us," he says.`
 	on fail
-		dialog `You abandon hunting the <npc> since you are now a member of the Free Worlds militia.`
+		conversation
+			branch "Free Worlds"
+				or
+					has "Rescue Katya 1: active"
+					has "joined the free worlds"
+				
+			`You receive a sealed message from a courier who bears a Free Worlds insignia. You open it and read:`
+			``
+			`Captain <last>:`
+			`	Since you have decided to actively oppose the Free Worlds and our independence, we must retract the reward being offered to hunt the <npc>. It disappoints us that you have chosen this path, but as members of the Free Worlds, we must respect your decision as a free individual.`
+			`	However, let this message also serve as a notification: do not enter Free Worlds territory without permission, or you will be fired upon.`
+			``
+			``
+			`	Though the message bears no signature, you can't help but feel that it came from someone you have now disappointed, someone who was beginning to like working with you.`
+				decline
+			
+			label "Free Worlds"
+			`You receive a call from the Free Worlds militia member who asked you to hunt down the <npc>. "Hello, Captain <last>", he says. "My superiors have indicated you are on some sort of high-priority mission for the Council. I'd rather not have you delay their task, so I've asked a different merchant captain to eliminate the <npc>."`
+			choice
+				`	"Sorry I can't be of more help,"`
+				`	"I really must get going."`
+				`	"It was too strong for me, anyway."`
+					decline
 
 
 
@@ -1676,7 +1720,29 @@ mission "FW Bounty 3"
 		payment 300000
 		dialog `The militia officer who asked you to hunt down the <npc> contacts you soon after you land. "You've done us a great service," he says. "I'll be telling the Council how helpful you were." He hands you a payment of <payment>.`
 	on fail
-		dialog `You abandon hunting the <npc> since you are now a member of the Free Worlds militia.`
+		conversation
+			branch "Free Worlds"
+				or
+					has "Rescue Katya 1: active"
+					has "joined the free worlds"
+				
+			`You receive a sealed message from a courier who bears a Free Worlds insignia. You open it and read:`
+			``
+			`Captain <last>:`
+			`	Since you have decided to actively oppose the Free Worlds and our independence, we must retract the reward being offered to hunt the <npc>. It disappoints us that you have chosen this path, but as members of the Free Worlds, we must respect your decision as a free individual.`
+			`	However, let this message also serve as a notification: do not enter Free Worlds territory without permission, or you will be fired upon.`
+			``
+			``
+			`	Though the message bears no signature, you can't help but feel that it came from someone you have now disappointed, someone who was beginning to like working with you.`
+				decline
+			
+			label "Free Worlds"
+			`You receive a call from the Free Worlds militia member who asked you to hunt down the <npc>. "Hello, Captain <last>", he says. "My superiors have indicated you are on some sort of high-priority mission for the Council. I'd rather not have you delay their task, so I've asked a different merchant captain to eliminate the <npc>."`
+			choice
+				`	"Sorry I can't be of more help,"`
+				`	"I really must get going."`
+				`	"It was too strong for me anyway."`
+					decline
 
 
 


### PR DESCRIPTION
As noted in the FW Bounty mission text, you are not supposed to do these missions as a member of the FW militia.
Credit to @Bladewood for spotting the inconsistency.
Closes #2544