### PR TITLE
Rename korath to korath exiles

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -138,6 +138,18 @@ government "Korath"
 	
 	"attitude toward"
 		"Kor Sestor" -.01
+		"Korath Exiles" 1
+	
+	"player reputation" -10
+
+government "Korath Exiles"
+	swizzle 0
+	color .8 .5 .1
+	language "Korath"
+	
+	"attitude toward"
+		"Kor Sestor" -.01
+		"Korath" 1
 	
 	"player reputation" -10
 

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -773,6 +773,17 @@ event "Rename Korath Exiles"
 		government "Korath Exiles"
 
 
+#Patching in for older saves.
+mission "Rename Korath Exiles patch"
+	landing
+	invisible
+	to offer
+		has "Wanderers: Kor Efret 4: offered"
+	on offer
+		event "Rename Korath Exiles"
+		fail
+
+
 
 mission "Wanderers: Kor Efret 4"
 	landing

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -753,6 +753,7 @@ mission "Wanderers: Kor Efret 3"
 
 
 event "Rename Korath Exiles"
+	"reputation: Korath Exiles" = "reputation: Korath"
 	system "Kor Ak'Mari"
 		government "Korath Exiles"
 	system "Kor En'lakfar"

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -798,7 +798,6 @@ mission "Wanderers: Kor Efret 4"
 	to offer
 		has "Wanderers: Kor Efret 3: done"
 	on offer
-		event "Rename Korath Exiles"
 		conversation
 			`When you land back on the planet, Rek and several of the Korath meet you at your ship. "They would like to thank you for your assistance in defending their home," says Rek, "and they apologize for being so dismissive of the Wanderer plans to defeat the drones. They still think that hacking or corrupting the Mereti network is impossible, though."`
 			choice

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -752,6 +752,28 @@ mission "Wanderers: Kor Efret 3"
 
 
 
+event "Rename Korath Exiles"
+	system "Kor Ak'Mari"
+		government "Korath Exiles"
+	system "Kor En'lakfar"
+		government "Korath Exiles"
+	system "Kor Fel'tar"
+		government "Korath Exiles"
+	system "Kor Men"
+		government "Korath Exiles"
+	system "Kor Nor'peli"
+		government "Korath Exiles"
+	system "Kor Tar'bei"
+		government "Korath Exiles"
+	system "Kor Zena'i"
+		government "Korath Exiles"
+	fleet "Korath Raid"
+		government "Korath Exiles"
+	fleet "Korath Home"
+		government "Korath Exiles"
+
+
+
 mission "Wanderers: Kor Efret 4"
 	landing
 	name "Return to <planet>"
@@ -764,6 +786,7 @@ mission "Wanderers: Kor Efret 4"
 	to offer
 		has "Wanderers: Kor Efret 3: done"
 	on offer
+		event "Rename Korath Exiles"
 		conversation
 			`When you land back on the planet, Rek and several of the Korath meet you at your ship. "They would like to thank you for your assistance in defending their home," says Rek, "and they apologize for being so dismissive of the Wanderer plans to defeat the drones. They still think that hacking or corrupting the Mereti network is impossible, though."`
 			choice
@@ -2789,37 +2812,37 @@ mission "Wanderers: Sestor: Exiles 2"
 			`	Rek makes herself comfortable in one of your bunk rooms, and you prepare for a visit to the territory of the Korath exiles. "We must somehow earn their trust," she says, "so do not fire on any of their ships. Instead we must find a way to communicate with them or a place where they will meet with us peacefully."`
 				accept
 	npc save
-		government "Korath"
+		government "Korath Exiles"
 		system "Kor Fel'tar"
 		personality heroic staying
 		fleet "Korath Home"
 	npc save
-		government "Korath"
+		government "Korath Exiles"
 		system "Kor En'lakfar"
 		personality heroic staying
 		fleet "Korath Raid"
 	npc save
-		government "Korath"
+		government "Korath Exiles"
 		system "Kor Men"
 		personality heroic staying
 		fleet "Korath Raid"
 	npc save
-		government "Korath"
+		government "Korath Exiles"
 		system "Kor Ak'Mari"
 		personality heroic staying
 		fleet "Korath Raid"
 	npc save
-		government "Korath"
+		government "Korath Exiles"
 		system "Kor Zena'i"
 		personality heroic staying
 		fleet "Korath Raid"
 	npc save
-		government "Korath"
+		government "Korath Exiles"
 		system "Kor Tar'bei"
 		personality heroic staying
 		fleet "Korath Home"
 	npc save
-		government "Korath"
+		government "Korath Exiles"
 		system "Kor Nor'peli"
 		personality heroic staying
 		fleet "Korath Home"
@@ -2829,7 +2852,7 @@ mission "Wanderers: Sestor: Exiles 2"
 
 
 event "wanderers: exiles peaceful"
-	"reputation: Korath" >?= 1
+	"reputation: Korath Exiles" >?= 1
 
 mission "Wanderers: Sestor: Exiles 3"
 	landing
@@ -2860,7 +2883,7 @@ mission "Wanderers: Sestor: Exiles 3"
 			`	Rek speaks with the Korath again, and then tells you, "They say that three of their 'world-ships' will travel with us to meet with the Wanderer leaders. If they are able to work out favorable terms, and are convinced that the Wanderers have peaceful intentions, they will go with us to the Sestor factory world and shut it down."`
 				accept
 	npc accompany save
-		government "Korath"
+		government "Korath Exiles"
 		personality escort
 		ship "Korath World-Ship A (Jump)" "Seskerat Pratka"
 		ship "Korath World-Ship B (Jump)" "Eskretakfakta"
@@ -2892,7 +2915,7 @@ mission "Wanderers: Sestor: Factory 1"
 			`	You return to your ship, and get ready for the trip to <planet>.`
 				accept
 	npc accompany save
-		government "Korath"
+		government "Korath Exiles"
 		personality escort
 		ship "Korath World-Ship A (Jump)" "Seskerat Pratka"
 		ship "Korath World-Ship B (Jump)" "Eskretakfakta"
@@ -3031,7 +3054,7 @@ mission "Wanderers: Sestor: Factory 3"
 
 
 event "wanderers: exiles hostile"
-	"reputation: Korath" = -1000
+	"reputation: Korath Exiles" = -1000
 
 event "wanderers: exiles have drones"
 	fleet "Korath Home"
@@ -3154,7 +3177,7 @@ mission "Wanderers: Sestor: Final"
 				accept
 	npc
 		system "Kor Fel'tar"
-		government "Korath"
+		government "Korath Exiles"
 		personality heroic staying
 		fleet
 			names "korath"


### PR DESCRIPTION
This should rename the exiles after the player is told about them in Wanderers: Kor Efret 4. I'm confident I have caught all the cases after that point where they appear. 
I haven't had a chance to check whether the fleet governments can be changed the way I just did.