### PR TITLE
enhancement: add or remove individual planet attributes

### DIFF
--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -62,6 +62,17 @@ void Planet::Load(const DataNode &node, const Set<Sale<Ship>> &ships, const Set<
 			for(int i = 1; i < child.Size(); ++i)
 				attributes.insert(child.Token(i));
 		}
+		else if(child.Token(0) == "attributes add" && child.Size() >= 2)
+		{
+			for(int i = 1; i < child.Size(); ++i)
+				// std::set::insert checks whether the element already exists, and if so, the element is not inserted
+				attributes.insert(child.Token(i));
+		}
+		else if(child.Token(0) == "attributes remove" && child.Size() >= 2)
+		{
+			for(int i = 1; i < child.Size(); ++i)
+				attributes.erase(child.Token(i));
+		}
 		else if(child.Token(0) == "description" && child.Size() >= 2)
 		{
 			if(resetDescription)


### PR DESCRIPTION
With this PR, content creators can alter the attributes list of a planet by adding or removing a single attribute or even a set of attributes without caring about all other attributes of that planet.

_I wasn't first sure if I should remove the braces or not, because it is not a "single expression", but looking at some examples in PlayerInfo.cpp the braces are used in such cases in the ES code._