### PR TITLE
enhancement: add individual variant(s) to a fleet definition

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -69,6 +69,11 @@ void Fleet::Load(const DataNode &node)
 			variants.emplace_back(child);
 			total += variants.back().weight;
 		}
+		else if(child.Token(0) == "variant add")
+		{
+			variants.emplace_back(child);
+			total += variants.back().weight;
+		}
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}


### PR DESCRIPTION
This PR is the first step towards solving #2549.

With this PR, content creators can add variants to fleets without caring about the existing fleet definition, i.e. they dont need to know which variants already exist. This allows to avoid content conflicts and should in my opinion become the favored way to alter fleets.
*This PR does not introduce a way to remove a specific variant or to replace a specific variant in order to replace it by another one (like changing from Mk I to Mk II ships), so it does not address all thinkable usecases and is not meant to do so.*