### PR TITLE
Disabled hail (friendly and hostile)

### DIFF
--- a/data/hails.txt
+++ b/data/hails.txt
@@ -1822,6 +1822,10 @@ phrase "friendly"
 	word
 		"."
 
+phrase "friendly disabled"
+	word
+		"Our ship has been disabled! Please come board our ship and patch us up!"
+		
 # Shakespearean insults.
 phrase "hostile disabled"
 	word

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -101,6 +101,8 @@ void Government::Load(const DataNode &node)
 			deathSentence = GameData::Conversations().Get(child.Token(1));
 		else if(child.Token(0) == "friendly hail" && child.Size() >= 2)
 			friendlyHail = GameData::Phrases().Get(child.Token(1));
+		else if(child.Token(0) == "friendly disabled hail" && child.Size() >= 2)
+			friendlyDisabledHail = GameData::Phrases().Get(child.Token(1));
 		else if(child.Token(0) == "hostile hail" && child.Size() >= 2)
 			hostileHail = GameData::Phrases().Get(child.Token(1));
 		else if(child.Token(0) == "hostile disabled hail" && child.Size() >= 2)
@@ -113,7 +115,9 @@ void Government::Load(const DataNode &node)
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
 	
-	// Default to the standard hostile disabled hail messages.
+	// Default to the standard disabled hail messages.
+	if(!friendlyDisabledHail)
+		friendlyDisabledHail = GameData::Phrases().Get("friendly disabled");
 	if(!hostileDisabledHail)
 		hostileDisabledHail = GameData::Phrases().Get("hostile disabled");
 }
@@ -210,12 +214,9 @@ string Government::GetHail(bool isDisabled) const
 	const Phrase *phrase = nullptr;
 	
 	if(IsEnemy())
-		if(isDisabled)
-			phrase = hostileDisabledHail;
-		else
-			phrase = hostileHail;
+		phrase = isDisabled ? hostileDisabledHail : hostileHail;
 	else
-		phrase = friendlyHail;
+		phrase = isDisabled ? friendlyDisabledHail : friendlyHail;
 		
 	return phrase ? phrase->Get() : "";
 }

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -103,6 +103,8 @@ void Government::Load(const DataNode &node)
 			friendlyHail = GameData::Phrases().Get(child.Token(1));
 		else if(child.Token(0) == "hostile hail" && child.Size() >= 2)
 			hostileHail = GameData::Phrases().Get(child.Token(1));
+		else if(child.Token(0) == "hostile disabled hail" && child.Size() >= 2)
+			hostileDisabledHail = GameData::Phrases().Get(child.Token(1));
 		else if(child.Token(0) == "language" && child.Size() >= 2)
 			language = child.Token(1);
 		else if(child.Token(0) == "raid" && child.Size() >= 2)
@@ -110,6 +112,10 @@ void Government::Load(const DataNode &node)
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
+	
+	// Default to the standard hostile disabled hail messages.
+	if(!hostileDisabledHail)
+		hostileDisabledHail = GameData::Phrases().Get("hostile disabled");
 }
 
 
@@ -197,10 +203,20 @@ const Conversation *Government::DeathSentence() const
 
 
 
-// Get a random hail message (depending on whether this is an enemy government).
-string Government::GetHail() const
+// Get a hail message (which depends on whether this is an enemy government
+// and if the ship is disabled).
+string Government::GetHail(bool isDisabled) const
 {
-	const Phrase *phrase = IsEnemy() ? hostileHail : friendlyHail;
+	const Phrase *phrase = nullptr;
+	
+	if(IsEnemy())
+		if(isDisabled)
+			phrase = hostileDisabledHail;
+		else
+			phrase = hostileHail;
+	else
+		phrase = friendlyHail;
+		
 	return phrase ? phrase->Get() : "";
 }
 

--- a/source/Government.h
+++ b/source/Government.h
@@ -116,6 +116,7 @@ private:
 	double fine = 1.;
 	const Conversation *deathSentence = nullptr;
 	const Phrase *friendlyHail = nullptr;
+	const Phrase *friendlyDisabledHail = nullptr;
 	const Phrase *hostileHail = nullptr;
 	const Phrase *hostileDisabledHail = nullptr;
 	std::string language;

--- a/source/Government.h
+++ b/source/Government.h
@@ -66,8 +66,9 @@ public:
 	// sentence to the player (for carrying highly illegal cargo).
 	const Conversation *DeathSentence() const;
 	
-	// Get a hail message (which depends on whether this is an enemy government).
-	std::string GetHail() const;
+	// Get a hail message (which depends on whether this is an enemy government
+	// and if the ship is disabled).
+	std::string GetHail(bool isDisabled) const;
 	// Find out if this government speaks a different language.
 	const std::string &Language() const;
 	// Pirate raids in this government's systems use this fleet definition. If
@@ -116,6 +117,7 @@ private:
 	const Conversation *deathSentence = nullptr;
 	const Phrase *friendlyHail = nullptr;
 	const Phrase *hostileHail = nullptr;
+	const Phrase *hostileDisabledHail = nullptr;
 	std::string language;
 	const Fleet *raidFleet = nullptr;
 };

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -55,12 +55,16 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 		message = "(There is no response to your hail.)";
 	else if(!hasLanguage)
 		message = "(An alien voice says something in a language you do not recognize.)";
-	else if(gov->IsEnemy() && !ship->IsDisabled())
+	// Update default hail responses based on the hailed ship's government and status condition.
+	else if(gov->IsEnemy())
 	{
-		SetBribe(gov->GetBribeFraction());
-		if(bribe)
-			message = "If you want us to leave you alone, it'll cost you "
-				+ Format::Number(bribe) + " credits.";
+		if(!ship->IsDisabled())
+		{
+			SetBribe(gov->GetBribeFraction());
+			if(bribe)
+				message = "If you want us to leave you alone, it'll cost you "
+					+ Format::Number(bribe) + " credits.";
+		}
 	}
 	else if(!gov->IsEnemy() && ship->IsDisabled())
 	{

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -66,7 +66,7 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 					+ Format::Number(bribe) + " credits.";
 		}
 	}
-	else if(!gov->IsEnemy() && ship->IsDisabled())
+	else if(ship->IsDisabled())
 	{
 		const Ship *flagship = player.Flagship();
 		if(!flagship->JumpsRemaining() || flagship->IsDisabled())

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -55,19 +55,14 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 		message = "(There is no response to your hail.)";
 	else if(!hasLanguage)
 		message = "(An alien voice says something in a language you do not recognize.)";
-	else if(gov->IsEnemy())
+	else if(gov->IsEnemy() && !ship->IsDisabled())
 	{
-		if(ship->IsDisabled())
-			message = GameData::Phrases().Get("hostile disabled")->Get();
-		else
-		{
-			SetBribe(gov->GetBribeFraction());
-			if(bribe)
-				message = "If you want us to leave you alone, it'll cost you "
-					+ Format::Number(bribe) + " credits.";
-		}
+		SetBribe(gov->GetBribeFraction());
+		if(bribe)
+			message = "If you want us to leave you alone, it'll cost you "
+				+ Format::Number(bribe) + " credits.";
 	}
-	else if(ship->IsDisabled())
+	else if(!gov->IsEnemy() && ship->IsDisabled())
 	{
 		const Ship *flagship = player.Flagship();
 		if(!flagship->JumpsRemaining() || flagship->IsDisabled())

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -67,8 +67,6 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 		const Ship *flagship = player.Flagship();
 		if(!flagship->JumpsRemaining() || flagship->IsDisabled())
 			message = "Sorry, we can't help you, because our ship is disabled.";
-		else
-			message = "Our ship has been disabled! Please come board our ship and patch us up!";
 	}
 	else
 	{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -679,7 +679,7 @@ void Ship::SetHail(const Phrase &phrase)
 
 string Ship::GetHail() const
 {
-	return hail ? hail->Get() : government ? government->GetHail() : "";
+	return hail ? hail->Get() : government ? government->GetHail(isDisabled) : "";
 }
 
 


### PR DESCRIPTION
@Amazinite suggested in #2526 that it'd be useful to be able to define a custom `hostile disabled hail`, rather than Wanderers, Unfettered, Heliarch etc. calling you a fobbing dizzy-eyed codpiece. @EndrosG suggested (https://github.com/endless-sky/endless-sky/issues/2531) we should, at the same time, permit a custom `friendly disabled hail`.

@EndrosG, @tehhowch and I have put together this PR to do this. The format is as follows:

```
government "Heliarch"
	...
	"friendly hail" "friendly heliarch"
	"hostile hail" "hostile heliarch"
	"friendly disabled hail" "friendly disabled heliarch"
	"hostile disabled hail" "hostile disabled heliarch
```

with each line being completely optional. This PR shouldn't change anything in-game by itself: content creators will need to PR/propose changes to governments.txt, but now they have the facility.

One last thought – we felt, working through HailPanel, that we'd like to rewrite it further to make it localisation-friendly. I felt we were tinkering around the edges a bit, but we didn't want to change any more than we needed to for this one issue. We'd appreciate MZ's input on whether some refactoring would be welcome as a follow-up.