### PR TITLE
Fix to string definition of token in Sales.h

### DIFF
--- a/source/Sale.h
+++ b/source/Sale.h
@@ -41,7 +41,7 @@ void Sale<Item>::Load(const DataNode &node, const Set<Item> &items)
 {
 	for(const DataNode &child : node)
 	{
-		const string &token = child.Token(0);
+		const std::string &token = child.Token(0);
 		bool remove = (token == "clear" || token == "remove");
 		if(remove && child.Size() == 1)
 			this->clear();


### PR DESCRIPTION
As per https://github.com/endless-sky/endless-sky/issues/2559, 5d955787ccc74c09b04e9b9708de32fd1b594345 doesn't compile. This fixes it by using `std::string` instead of `string`.