### PR TITLE
enhancement: Remove variants from Fleet definitions

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -355,7 +355,7 @@ Fleet::Variant::Variant(const DataNode &node)
 	weight = 1;
 	if(node.Token(0) == "variant" && node.Size() >= 2)
 		weight = node.Value(1);
-	else if((node.Token(0) == "add" || node.Token(0) == "remove") && node.Size() >= 3)
+	else if(node.Token(0) == "add" && node.Size() >= 3)
 		weight = node.Value(2);
 	
 	for(const DataNode &child : node)


### PR DESCRIPTION
In a fleet definition, using the node `remove variant` and then supplying a valid existing variant for that fleet will result in the removal of that variant from the instantiated fleet definition.
 - A valid existing variant is one which contains the same ship specifications (in any order).
 - `remove variant` ignores any supplied weight value and always removes the variant if a matching variant is found, starting with the first variant (and ordered as listed in the original fleet definition).
 - If no match is found, a stack trace is printed to aid in debugging content. This can be removed / altered but should only appear for malformed or unnecessary removal requests.

Issues addressed/enabled: #2549, #1520

<details>
<summary>Functionality Verification Files:</summary>

modding text: 
[variant_remove_test.txt](https://github.com/endless-sky/endless-sky/files/1037440/variant_remove_test.txt)

original fleets:
[es_fleets_orig.txt](https://github.com/endless-sky/endless-sky/files/1037437/es_fleets_orig.txt)

post-mod fleets:
[es_fleets_with_removals.txt](https://github.com/endless-sky/endless-sky/files/1037438/es_fleets_with_removals.txt)

These fleet files were generated from my [writeAllFleets](https://github.com/endless-sky/endless-sky/compare/master...tehhowch:writeAllFleets) branch, which has a function to print all instantiated fleets to a file after the game finishes loading.</details>