### PR TITLE
Fixed an issue with events changing system fleets

### DIFF
--- a/source/System.cpp
+++ b/source/System.cpp
@@ -158,7 +158,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			else if(key == "trade")
 				trade.clear();
 			else if(key == "fleet")
-				haze = nullptr;
+				fleets.clear();
 			else if(key == "object")
 			{
 				// Make sure any planets that were linked to this system know


### PR DESCRIPTION
When an event should replace the fleet presence in a system, it was
instead always adding. This is due to a typo, where the haze is cleared
instead. Best way to see this is, in a post-Free Worlds save, going to
Altair and watching the Pug show up.