### PR TITLE
bugfix: Issuing MoveTo order to out-of-system escorts

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -575,6 +575,9 @@ void AI::Step(const PlayerInfo &player)
 		{
 			// If this is an escort and it has orders to follow, no need for the
 			// AI to figure out what action it must perform.
+			// Update Hold/MoveTo positioning orders if we have reached the position
+			// or are not near the desired position.
+			ConvertPositioningOrder(*it);
 		}
 		// Hostile "escorts" (i.e. NPCs that are trailing you) only revert to
 		// escort behavior when in a different system from you. Otherwise,
@@ -815,7 +818,7 @@ bool AI::FollowOrders(Ship &ship, Command &command) const
 	// If your parent is jumping or absent, that overrides your orders unless
 	// your orders are to hold position.
 	shared_ptr<Ship> parent = ship.GetParent();
-	if(parent && type != Orders::HOLD_POSITION && type != Orders::MOVE_TO)
+	if(parent && type != Orders::HOLD_POSITION)
 	{
 		if(parent->GetSystem() != ship.GetSystem())
 			return false;
@@ -2663,5 +2666,25 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 		Messages::Add(who + "no longer " + description);
 		for(const Ship *ship : ships)
 			orders.erase(ship);
+	}
+}
+
+
+
+void AI::ConvertPositioningOrder(Ship &ship)
+{
+	auto it = orders.find(&ship);
+	Orders &existing = orders[it->first];
+	if(existing.type == Orders::MOVE_TO)
+	{
+		// If we are nearly stopped on our desired point, convert to a HOLD_POSITION order.
+		if(ship.Position().Distance(existing.point) < 20. && ship.Velocity().Length() < .001)
+			existing.type = Orders::HOLD_POSITION;
+	}
+	else if(existing.type == Orders::HOLD_POSITION)
+	{
+		// If we have a defined target point and we are far from it, MOVE_TO it.
+		if(existing.point && ship.Position().Distance(existing.point) > 20.)
+			existing.type = Orders::MOVE_TO;
 	}
 }

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -198,11 +198,11 @@ void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 			}
 		}
 		
-		// Jump commands cancel in-progress MOVE_TO orders.
+		// Jump commands force-convert in-progress MOVE_TO orders into HOLD_POSITION .
 		if(keyStuck.Has(Command::JUMP) && it->second.type == Orders::MOVE_TO)
 		{
-			it = orders.erase(it);
-			continue;
+			newOrders.type = Orders::HOLD_POSITION;
+			it->second = newOrders;
 		}
 		++it;
 	}

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -197,6 +197,13 @@ void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 				continue;
 			}
 		}
+		
+		// Jump commands cancel in-progress MOVE_TO orders.
+		if(keyStuck.Has(Command::JUMP) && it->second.type == Orders::MOVE_TO)
+		{
+			it = orders.erase(it);
+			continue;
+		}
 		++it;
 	}
 }

--- a/source/AI.h
+++ b/source/AI.h
@@ -129,7 +129,7 @@ private:
 
 private:
 	void IssueOrders(const PlayerInfo &player, const Orders &newOrders, const std::string &description);
-	
+	void ConvertPositioningOrder(Ship &ship);
 	
 private:
 	// Data from the game engine.


### PR DESCRIPTION
Closes issues #2580 and #2382 

The existing fix to #2382 creates unexpected behavior when issuing the `Move To` fleet command while your fleet is not entirely in system (see issue #2580 ).

This PR solves both issues, opting to have a positioning order be binding until a new positioning order is given, e.g. if you jump, existing positioning orders are still obeyed.
Reverting the last commit (13a093e) would result in a PR in which Jump orders override any in-progress movement orders.