### PR TITLE
bugfix: MOVE_TO orders refer to a specific System

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -833,11 +833,11 @@ bool AI::FollowOrders(Ship &ship, Command &command) const
 		ship.SetTargetSystem(to);
 		return false;
 	}
+	else if(type == Orders::MOVE_TO && ship.Position().Distance(it->second.point) > 20.)
+		MoveTo(ship, command, it->second.point, Point(), 10., .1);
 	else if(type == Orders::HOLD_POSITION || type == Orders::MOVE_TO)
 	{
-		if(it->second.point && ship.Position().Distance(it->second.point) > 20.)
-			MoveTo(ship, command, it->second.point, Point(), 10., .1);
-		else if(ship.Velocity().Length() > .001 || !ship.GetTargetShip())
+		if(ship.Velocity().Length() > .001 || !ship.GetTargetShip())
 			Stop(ship, command);
 		else
 			command.SetTurn(TurnToward(ship, TargetAim(ship)));

--- a/source/AI.h
+++ b/source/AI.h
@@ -30,6 +30,7 @@ class Minable;
 class Ship;
 class ShipEvent;
 class StellarObject;
+class System;
 class PlayerInfo;
 
 
@@ -50,7 +51,7 @@ template <class Type>
 	
 	// Fleet commands from the player.
 	void IssueShipTarget(const PlayerInfo &player, const std::shared_ptr<Ship> &target);
-	void IssueMoveTarget(const PlayerInfo &player, const Point &target);
+	void IssueMoveTarget(const PlayerInfo &player, const Point &target, const System *moveToSystem);
 	// Commands issued via the keyboard (mostly, to the flagship).
 	void UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive);
 	
@@ -124,6 +125,7 @@ private:
 		int type = 0;
 		std::weak_ptr<Ship> target;
 		Point point;
+		const System * targetSystem;
 	};
 
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1308,7 +1308,7 @@ void Engine::CalculateStep()
 		}
 	}
 	else if(doClick && isRightClick)
-		ai.IssueMoveTarget(player, clickPoint + newCenter);
+		ai.IssueMoveTarget(player, clickPoint + newCenter, player.GetSystem());
 	
 	if(alarmTime)
 		--alarmTime;


### PR DESCRIPTION
Issuing MOVE_TO orders now includes a target system, allowing selected escorts to navigate across system boundaries to the specified position, instead of navigating to that point in their current system.

Ref #2584, Closes #2580, Closes #2382