### PR TITLE
Move_to & Hold_Position orders convert based on distance to position

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -619,8 +619,9 @@ void AI::Step(const PlayerInfo &player)
 		}
 		else if(FollowOrders(*it, command))
 		{
-			// If this is an escort and it has orders to follow, no need for the
-			// AI to figure out what action it must perform.
+			// If this is an escort and it followed orders, its only final task
+			// is to convert completed MOVE_TO orders into HOLD_POSITION orders.
+			UpdateOrders(*it);
 		}
 		// Hostile "escorts" (i.e. NPCs that are trailing you) only revert to
 		// escort behavior when in a different system from you. Otherwise,
@@ -3098,6 +3099,13 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 				offset = offset.Unit() * maxSquadOffset;
 			existing.point += offset;
 		}
+		else if(existing.type == Orders::HOLD_POSITION)
+		{
+			bool shouldReverse = false;
+			// Set the point this ship will "guard.", so it can return
+			// to it if knocked away by projectiles / explosions.
+			existing.point = StoppingPoint(*ship, Point(), shouldReverse);
+		}
 	}
 	if(!gaveOrder)
 		return;
@@ -3109,5 +3117,31 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 		Messages::Add(who + "no longer " + description);
 		for(const Ship *ship : ships)
 			orders.erase(ship);
+	}
+}
+
+
+
+// Change the ship's order based on its current fulfillment of the order.
+void AI::UpdateOrders(const Ship &ship)
+{
+	// This should only be called for ships with orders that can be carried out.
+	auto it = orders.find(&ship);
+	if(it == orders.end())
+		return;
+	
+	Orders &order = it->second;
+	if(order.type == Orders::MOVE_TO && ship.GetSystem() == order.targetSystem)
+	{
+		// If nearly stopped on the desired point, switch to a HOLD_POSITION order.
+		if(ship.Position().Distance(order.point) < 20. && ship.Velocity().Length() < .001)
+			order.type = Orders::HOLD_POSITION;
+	}
+	else if(order.type == Orders::HOLD_POSITION && ship.Position().Distance(order.point) > 20.)
+	{
+		// If far from the defined target point, return via a MOVE_TO order.
+		order.type = Orders::MOVE_TO;
+		// Ensure the system reference is maintained.
+		order.targetSystem = ship.GetSystem();
 	}
 }

--- a/source/AI.h
+++ b/source/AI.h
@@ -136,12 +136,14 @@ private:
 		int type = 0;
 		std::weak_ptr<Ship> target;
 		Point point;
-		const System * targetSystem;
+		const System *targetSystem;
 	};
 
 
 private:
 	void IssueOrders(const PlayerInfo &player, const Orders &newOrders, const std::string &description);
+	// Convert order types based on fulfillment status.
+	void UpdateOrders(const Ship &ship);
 	
 	
 private:


### PR DESCRIPTION
 - A ship which reaches the position it was sent to changes its MOVE_TO order into HOLD_POSITION.
 - All HOLD_POSITION orders now include a point definition.
    - When taking off from a planet, escorts will return to where they were told to HOLD_POSITION rather than freeze upon takeoff.
    - If hit by an explosion and "dislodged", escorts will return to their original point. Fighters and other light ships will not be permanently scattered if an enemy ship explodes in close proximity.