### PR TITLE
Fixing projectile steady state speed

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -209,8 +209,8 @@ bool Projectile::Move(list<Effect> &effects)
 	
 	if(accel)
 	{
-		velocity += accel * angle.Unit();
 		velocity *= 1. - weapon->Drag();
+		velocity += accel * angle.Unit();
 	}
 	
 	position += velocity;


### PR DESCRIPTION
The Wiki describes the steady state of projectiles as being
acceleration/drag, but it's currently acceleration/drag - acceleration.
This fixes that by tweaking the order of adding acceleration and scaling
by drag.

Noticed this in response to https://github.com/endless-sky/endless-sky/issues/1939#issuecomment-305274004, and it seems to mean that most missiles in the game are a little slower than expected.

The current code in Projectile::Move is:

```
	if(accel)
	{
		velocity += accel * angle.Unit();
		velocity *= 1. - weapon->Drag();	
	}
```

Take a [Meteor Missile](https://github.com/endless-sky/endless-sky/blob/master/data/weapons.txt#L504-L510): velocity 10, acceleration 1 and drag 0.1. In the first frame, it will gain 1 speed, and then be dragged back 10% to 9.9. The steady state is 9, when it would gain 1 and be dragged 10% back to 9.

This doesn't seem to be intended, as per the Wiki:

> drag: percent loss of speed per frame. For example, a projectile with an acceleration of 1 and a drag of .1 will have a maximum speed (acceleration / drag) of 10.

and the intercept calculations which use `trueVelocity = accel / drag`.

If you switch the order of the two lines, i.e.,

```
		velocity *= 1. - weapon->Drag();	
		velocity += accel * angle.Unit();	
```

then the steady state is accel/drag as expected. (In the Meteor Missile case, 10 drops to 9 and the acceleration brings it back up to 10.)