### PR TITLE
Shortening events with add variant (Wanderer Defense + Mk2 Republic)

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -1078,105 +1078,40 @@ event "fw safe passage ends"
 
 event "navy using mark ii ships"
 	fleet "Small Republic"
-		remove variant
-			"Rainmaker" 2
-		add variant 4
+		add variant 12
 			"Rainmaker (Mark II)" 2
-		add variant 2
-			"Rainmaker" 2
-		remove variant
-			"Gunboat"
-			"Rainmaker"
-		add variant 4
+		add variant 12
 			"Gunboat (Mark II)"
 			"Rainmaker (Mark II)"
-		add variant 1
-			"Gunboat"
-			"Rainmaker"
-		remove variant
-			"Frigate"
-		add variant 3
+		add variant 9
 			"Frigate (Mark II)"
-		add variant 1
-			"Frigate"
-		remove variant
-			"Gunboat" 2
-		add variant 2
+		add variant 6
 			"Gunboat (Mark II)" 2
-		add variant 1
-			"Gunboat" 2
-		remove variant
-			"Rainmaker" 3
-		add variant 1
+		add variant 3
 			"Rainmaker (Mark II)" 3
-		remove variant
-			"Gunboat"
-		add variant 4
+		add variant 12
 			"Gunboat (Mark II)"
-		add variant 2
-			"Gunboat"
 		remove variant
 			"Protector"
 	
 	fleet "Large Republic"
-		remove variant
-			"Frigate" 2
-			"Rainmaker"
-			"Gunboat"
-		add variant 4
+		add variant 12
 			"Frigate (Mark II)" 2
 			"Rainmaker (Mark II)"
 			"Gunboat (Mark II)"
-		add variant 1
-			"Frigate" 2
-			"Rainmaker"
-			"Gunboat"
-		remove variant
-			"Cruiser"
-			"Combat Drone" 4
-		add variant 2
+		add variant 6
 			"Cruiser (Mark II)"
 			"Combat Drone" 4
-		add variant 1
-			"Cruiser"
-			"Combat Drone" 4
-		remove variant
-			"Cruiser"
-			"Combat Drone" 4
-			"Frigate"
-			"Rainmaker"
-		add variant 2
+		add variant 6
 			"Cruiser (Mark II)"
 			"Combat Drone" 4
 			"Frigate (Mark II)"
 			"Rainmaker (Mark II)"
-		add variant 1
-			"Cruiser"
-			"Combat Drone" 4
-			"Frigate"
-			"Rainmaker"
-		remove variant
-			"Carrier"
-			"Lance" 4
-			"Combat Drone" 6
-		add variant 2
+		add variant 6
 			"Carrier (Mark II)"
 			"Lance" 4
 			"Combat Drone" 6
-		add variant 1
-			"Carrier"
-			"Lance" 4
-			"Combat Drone" 6
-		remove variant
-			"Carrier"
-			"Lance" 4
-			"Combat Drone" 6
-			"Cruiser"
-			"Combat Drone" 4
-			"Frigate" 2
-			"Rainmaker" 2
-			"Gunboat" 2
-		add variant 1
+		add variant 3
 			"Carrier (Mark II)"
 			"Lance" 4
 			"Combat Drone" 6
@@ -1185,19 +1120,11 @@ event "navy using mark ii ships"
 			"Frigate (Mark II)" 2
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)" 2
-		remove variant
-			"Cruiser"
-			"Combat Drone" 4
-			"Frigate" 2
-		add variant 1
+		add variant 3
 			"Cruiser (Mark II)"
 			"Combat Drone" 4
 			"Frigate (Mark II)" 2
-		remove variant
-			"Frigate"
-			"Rainmaker" 2
-			"Gunboat"
-		add variant 1
+		add variant 3
 			"Frigate (Mark II)"
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)"

--- a/data/events.txt
+++ b/data/events.txt
@@ -1078,13 +1078,13 @@ event "fw safe passage ends"
 
 event "navy using mark ii ships"
 	fleet "Small Republic"
-		remove variant 6
+		remove variant
 			"Rainmaker" 2
 		add variant 4
 			"Rainmaker (Mark II)" 2
 		add variant 2
 			"Rainmaker" 2
-		remove variant 5
+		remove variant
 			"Gunboat"
 			"Rainmaker"
 		add variant 4
@@ -1093,33 +1093,33 @@ event "navy using mark ii ships"
 		add variant 1
 			"Gunboat"
 			"Rainmaker"
-		remove variant 4
+		remove variant
 			"Frigate"
 		add variant 3
 			"Frigate (Mark II)"
 		add variant 1
 			"Frigate"
-		remove variant 3
+		remove variant
 			"Gunboat" 2
 		add variant 2
 			"Gunboat (Mark II)" 2
 		add variant 1
 			"Gunboat" 2
-		remove variant 1
+		remove variant
 			"Rainmaker" 3
 		add variant 1
 			"Rainmaker (Mark II)" 3
-		remove variant 6
+		remove variant
 			"Gunboat"
 		add variant 4
 			"Gunboat (Mark II)"
 		add variant 2
 			"Gunboat"
-		remove variant 10
+		remove variant
 			"Protector"
 	
 	fleet "Large Republic"
-		remove variant 5
+		remove variant
 			"Frigate" 2
 			"Rainmaker"
 			"Gunboat"
@@ -1131,7 +1131,7 @@ event "navy using mark ii ships"
 			"Frigate" 2
 			"Rainmaker"
 			"Gunboat"
-		remove variant 3
+		remove variant
 			"Cruiser"
 			"Combat Drone" 4
 		add variant 2
@@ -1140,7 +1140,7 @@ event "navy using mark ii ships"
 		add variant 1
 			"Cruiser"
 			"Combat Drone" 4
-		remove variant 3
+		remove variant
 			"Cruiser"
 			"Combat Drone" 4
 			"Frigate"
@@ -1155,7 +1155,7 @@ event "navy using mark ii ships"
 			"Combat Drone" 4
 			"Frigate"
 			"Rainmaker"
-		remove variant 2
+		remove variant
 			"Carrier"
 			"Lance" 4
 			"Combat Drone" 6
@@ -1167,7 +1167,7 @@ event "navy using mark ii ships"
 			"Carrier"
 			"Lance" 4
 			"Combat Drone" 6
-		remove variant 1
+		remove variant
 			"Carrier"
 			"Lance" 4
 			"Combat Drone" 6
@@ -1185,7 +1185,7 @@ event "navy using mark ii ships"
 			"Frigate (Mark II)" 2
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)" 2
-		remove variant 1
+		remove variant
 			"Cruiser"
 			"Combat Drone" 4
 			"Frigate" 2
@@ -1193,7 +1193,7 @@ event "navy using mark ii ships"
 			"Cruiser (Mark II)"
 			"Combat Drone" 4
 			"Frigate (Mark II)" 2
-		remove variant 1
+		remove variant
 			"Frigate"
 			"Rainmaker" 2
 			"Gunboat"

--- a/data/events.txt
+++ b/data/events.txt
@@ -1078,65 +1078,105 @@ event "fw safe passage ends"
 
 event "navy using mark ii ships"
 	fleet "Small Republic"
-		variant 4
-			"Rainmaker (Mark II)" 2
-		variant 2
+		remove variant 6
 			"Rainmaker" 2
-		variant 4
-			"Gunboat (Mark II)"
-			"Rainmaker (Mark II)"
-		variant 1
+		add variant 4
+			"Rainmaker (Mark II)" 2
+		add variant 2
+			"Rainmaker" 2
+		remove variant 5
 			"Gunboat"
 			"Rainmaker"
-		variant 3
-			"Frigate (Mark II)"
-		variant 1
-			"Frigate"
-		variant 2
-			"Gunboat (Mark II)" 2
-		variant 1
-			"Gunboat" 2
-		variant 1
-			"Rainmaker (Mark II)" 3
-		variant 4
+		add variant 4
 			"Gunboat (Mark II)"
-		variant 2
-			"Gunboat"
-
-	fleet "Large Republic"
-		variant 4
-			"Frigate (Mark II)" 2
 			"Rainmaker (Mark II)"
+		add variant 1
+			"Gunboat"
+			"Rainmaker"
+		remove variant 4
+			"Frigate"
+		add variant 3
+			"Frigate (Mark II)"
+		add variant 1
+			"Frigate"
+		remove variant 3
+			"Gunboat" 2
+		add variant 2
+			"Gunboat (Mark II)" 2
+		add variant 1
+			"Gunboat" 2
+		remove variant 1
+			"Rainmaker" 3
+		add variant 1
+			"Rainmaker (Mark II)" 3
+		remove variant 6
+			"Gunboat"
+		add variant 4
 			"Gunboat (Mark II)"
-		variant 1
+		add variant 2
+			"Gunboat"
+		remove variant 10
+			"Protector"
+	
+	fleet "Large Republic"
+		remove variant 5
 			"Frigate" 2
 			"Rainmaker"
 			"Gunboat"
-		variant 2
-			"Cruiser (Mark II)"
-			"Combat Drone" 4
-		variant 1
+		add variant 4
+			"Frigate (Mark II)" 2
+			"Rainmaker (Mark II)"
+			"Gunboat (Mark II)"
+		add variant 1
+			"Frigate" 2
+			"Rainmaker"
+			"Gunboat"
+		remove variant 3
 			"Cruiser"
 			"Combat Drone" 4
-		variant 2
+		add variant 2
 			"Cruiser (Mark II)"
 			"Combat Drone" 4
-			"Frigate (Mark II)"
-			"Rainmaker (Mark II)"
-		variant 1
+		add variant 1
+			"Cruiser"
+			"Combat Drone" 4
+		remove variant 3
 			"Cruiser"
 			"Combat Drone" 4
 			"Frigate"
 			"Rainmaker"
-		variant 2
-			"Carrier (Mark II)"
-			"Lance" 4
-			"Combat Drone" 6
-		variant 1
+		add variant 2
+			"Cruiser (Mark II)"
+			"Combat Drone" 4
+			"Frigate (Mark II)"
+			"Rainmaker (Mark II)"
+		add variant 1
+			"Cruiser"
+			"Combat Drone" 4
+			"Frigate"
+			"Rainmaker"
+		remove variant 2
 			"Carrier"
 			"Lance" 4
 			"Combat Drone" 6
-		variant 1
+		add variant 2
+			"Carrier (Mark II)"
+			"Lance" 4
+			"Combat Drone" 6
+		add variant 1
+			"Carrier"
+			"Lance" 4
+			"Combat Drone" 6
+		remove variant 1
+			"Carrier"
+			"Lance" 4
+			"Combat Drone" 6
+			"Cruiser"
+			"Combat Drone" 4
+			"Frigate" 2
+			"Rainmaker" 2
+			"Gunboat" 2
+		add variant 1
 			"Carrier (Mark II)"
 			"Lance" 4
 			"Combat Drone" 6
@@ -1145,11 +1185,19 @@ event "navy using mark ii ships"
 			"Frigate (Mark II)" 2
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)" 2
-		variant 1
+		remove variant 1
+			"Cruiser"
+			"Combat Drone" 4
+			"Frigate" 2
+		add variant 1
 			"Cruiser (Mark II)"
 			"Combat Drone" 4
 			"Frigate (Mark II)" 2
-		variant 1
+		remove variant 1
+			"Frigate"
+			"Rainmaker" 2
+			"Gunboat"
+		add variant 1
 			"Frigate (Mark II)"
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)"

--- a/data/wanderers.txt
+++ b/data/wanderers.txt
@@ -628,38 +628,19 @@ event "wanderers: first tech increase"
 		fleet "Wanderer Defense" 3000
 		fleet "Wanderer Flycatchers" 1200
 	fleet "Wanderer Defense"
-		government "Wanderer"
-		names "wanderer"
-		personality
-			heroic
-		variant 3
-			"Strong Wind"
-			"Summer Leaf" 2
-		variant
-			"Summer Leaf" 5
-		variant 2
-			"Strong Wind" 2
-		variant 2
-			"Strong Wind"
-			"Summer Leaf"
-		variant
-			"Strong Wind"
-			"Summer Leaf" 3
-		variant
-			"Strong Wind" 3
-		variant 2
+		add variant 2
 			"Autumn Leaf" 2
-		variant 2
+		add variant 2
 			"Strong Wind"
 			"Autumn Leaf" 2
-		variant
+		add variant
 			"Strong Wind"
 			"Autumn Leaf"
 			"Summer Leaf"
-		variant
+		add variant
 			"Autumn Leaf"
 			"Summer Leaf" 2
-		variant 2
+		add variant 2
 			"Autumn Leaf"
 			"Summer Leaf"
 	shipyard "Wanderer Basics"
@@ -724,47 +705,45 @@ event "wanderers: unfettered invasion starts"
 
 event "wanderers: tempest mass production"
 	fleet "Wanderer Defense"
-		government "Wanderer"
-		names "wanderer"
-		personality
-			heroic
-		variant 6
+		add variant 6
 			"Tempest"
 			"Summer Leaf"
 			"Autumn Leaf"
-		variant 4
+		add variant 4
 			"Tempest (Heavy)"
 			"Strong Wind"
-		variant 1
+		add variant 1
 			"Tempest (Heavy)"
 			"Tempest"
 			"Tempest (Missile)"
-		variant 2
+		add variant 2
 			"Tempest (Heavy)"
 			"Tempest"
-		variant 1
+		add variant 1
 			"Tempest (Missile)" 2
-		variant 3
-			"Strong Wind"
-			"Summer Leaf" 2
-		variant 2
-			"Strong Wind" 2
-		variant 2
+		add variant 2
 			"Strong Wind"
 			"Autumn Leaf"
-		variant
-			"Strong Wind" 3
-		variant 2
+		add variant 2
 			"Autumn Leaf" 3
-		variant
+		add variant 1
+			"Summer Leaf" 4
+		remove variant
+			"Summer Leaf" 5
+		remove variant
 			"Strong Wind"
+			"Summer Leaf"
+		remove variant
+			"Strong Wind"
+			"Summer Leaf" 3
+		remove variant
+			"Autumn Leaf" 2
+		remove variant
+			"Strong Wind"
+			"Autumn Leaf" 2
+		remove variant
 			"Autumn Leaf"
 			"Summer Leaf"
-		variant
-			"Autumn Leaf"
-			"Summer Leaf" 2
-		variant
-			"Summer Leaf" 4
 	shipyard "Wanderer Advanced"
 		"Tempest"
 	outfitter "Wanderer Advanced"
@@ -940,67 +919,26 @@ event "wanderers: the eye opens"
 
 event "wanderers: derecho mass production"
 	fleet "Wanderer Defense"
-		government "Wanderer"
-		names "wanderer"
-		personality
-			heroic
-		variant 4
+		add variant 4
 			"Derecho"
 			"Tempest"
-		variant 3
+		add variant 3
 			"Derecho (Turret)"
 			"Tempest (Missile)"
-		variant 2
+		add variant 2
 			"Derecho (Tough)"
 			"Tempest (Heavy)"
-		variant 4
+		add variant 4
 			"Derecho"
 			"Strong Wind" 2
-		variant 3
+		add variant 3
 			"Derecho (Tough)"
 			"Autumn Leaf"
 			"Summer Leaf" 2
-		variant 2
+		add variant 2
 			"Derecho (Turret)"
 			"Tempest (Heavy)"
 			"Tempest"
-		variant 6
-			"Tempest"
-			"Summer Leaf"
-			"Autumn Leaf"
-		variant 4
-			"Tempest (Heavy)"
-			"Strong Wind"
-		variant 1
-			"Tempest (Heavy)"
-			"Tempest"
-			"Tempest (Missile)"
-		variant 2
-			"Tempest (Heavy)"
-			"Tempest"
-		variant 1
-			"Tempest (Missile)" 2
-		variant 3
-			"Strong Wind"
-			"Summer Leaf" 2
-		variant 2
-			"Strong Wind" 2
-		variant 2
-			"Strong Wind"
-			"Autumn Leaf"
-		variant
-			"Strong Wind" 3
-		variant 2
-			"Autumn Leaf" 3
-		variant
-			"Strong Wind"
-			"Autumn Leaf"
-			"Summer Leaf"
-		variant
-			"Autumn Leaf"
-			"Summer Leaf" 2
-		variant
-			"Summer Leaf" 4
 	shipyard "Wanderer Advanced"
 		"Derecho"
 	outfitter "Wanderer Advanced"
@@ -1025,87 +963,26 @@ event "wanderers: spera anatrusk colony"
 
 event "wanderers: hurricane mass production"
 	fleet "Wanderer Defense"
-		government "Wanderer"
-		names "wanderer"
-		personality
-			heroic
-		variant 5
+		add variant 5
 			"Hurricane"
-		variant 2
+		add variant 2
 			"Hurricane (Turret)"
-		variant 2
+		add variant 2
 			"Hurricane (Tough)"
-		variant 3
+		add variant 3
 			"Hurricane"
 			"Derecho"
 			"Tempest"
-		variant 2
+		add variant 2
 			"Hurricane"
 			"Tempest" 2
-		variant 3
+		add variant 3
 			"Hurricane (Turret)"
 			"Derecho (Turret)"
 			"Tempest (Heavy)"
-		variant 2
+		add variant 2
 			"Hurricane (Tough)"
 			"Tempest (Missile)" 2
-		variant 4
-			"Derecho"
-			"Tempest"
-		variant 3
-			"Derecho (Turret)"
-			"Tempest (Missile)"
-		variant 2
-			"Derecho (Tough)"
-			"Tempest (Heavy)"
-		variant 4
-			"Derecho"
-			"Strong Wind" 2
-		variant 3
-			"Derecho (Tough)"
-			"Autumn Leaf"
-			"Summer Leaf" 2
-		variant 2
-			"Derecho (Turret)"
-			"Tempest (Heavy)"
-			"Tempest"
-		variant 6
-			"Tempest"
-			"Summer Leaf"
-			"Autumn Leaf"
-		variant 4
-			"Tempest (Heavy)"
-			"Strong Wind"
-		variant 1
-			"Tempest (Heavy)"
-			"Tempest"
-			"Tempest (Missile)"
-		variant 2
-			"Tempest (Heavy)"
-			"Tempest"
-		variant 1
-			"Tempest (Missile)" 2
-		variant 3
-			"Strong Wind"
-			"Summer Leaf" 2
-		variant 2
-			"Strong Wind" 2
-		variant 2
-			"Strong Wind"
-			"Autumn Leaf"
-		variant
-			"Strong Wind" 3
-		variant 2
-			"Autumn Leaf" 3
-		variant
-			"Strong Wind"
-			"Autumn Leaf"
-			"Summer Leaf"
-		variant
-			"Autumn Leaf"
-			"Summer Leaf" 2
-		variant
-			"Summer Leaf" 4
 	shipyard "Wanderer Advanced"
 		"Hurricane"
 


### PR DESCRIPTION
One fleet got missed (Wanderer Defense). I also incorporated the #2577 functionality to change the mk2 republic event from redefinition to dynamic update. Using the dynamic method adds back a few lines, but will prevent squashing any content added to these fleets by plugins, and also help introduce this syntax & use to content-creators.