### PR TITLE
bugfix: Turrets only track targetable ships

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1891,7 +1891,7 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
 	const Ship *currentTarget = ship.GetTargetShip().get();
 	// If the ship has a target selected, that ship is always in the running as
 	// something to aim at, even if it is too far away.
-	if(currentTarget)
+	if(currentTarget && currentTarget->IsTargetable())
 		enemies.push_back(currentTarget);
 	if(opportunistic || !currentTarget)
 	{


### PR DESCRIPTION
The previous fix to #2331 was 3cf5f95 and 525c6196, but the latest update to targeting removed this check for player-defined targets. This commit restores this check, preventing turrets from tracking cloaked ships.

Without the fix, the player is able to target cloaked ships:
![image](https://cloud.githubusercontent.com/assets/20871346/26774063/eb4aa2de-4993-11e7-8c1f-a8f4292e7fb0.png)
