### PR TITLE
Make decloaking caused by insufficient fuel faster than normal decloaking

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -808,8 +808,10 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			fuel -= attributes.Get("cloaking fuel");
 			energy -= attributes.Get("cloaking energy");
 		}
+		// If your ship cannot sustain the cloaking field, it fades much
+		// faster than if you properly power down your cloak generator.
 		else if(cloakingSpeed)
-			cloak = max(0., cloak - cloakingSpeed);
+			cloak = max(0., cloak - cloakingSpeed - (commands.Has(Command::CLOAK) ? cloak * .1 : 0.));
 		else
 			cloak = 0.;
 	}


### PR DESCRIPTION
This PR addresses #2557 (erratic AI targeting of persistently-almost-cloaked ships) by increasing the time between becoming targetable (`cloak < 1`) and not targetable (`cloak = 1`).

Current game mechanics allow IsTargetable to toggle as often as every frame, which causes AI targeting and firing behavior to appear erratic and seemingly broken. If instead a forced decloak (due to insufficient fuel or energy for the cloaking device) causes the cloak to drop by an additional amount (i.e. 10% cloak), there is a twofold effect:
1) The system radius in which the player can elicit the "erratic" targeting behavior is significantly reduced, due to the change in fuel generation (11 out of 12 frames must be fully powered & fueled instead of 1 out of 2)
2) A minimum of 11 frames will occur between the decloaked ship becoming targetable and then non-targetable, so the erratic targeting - even when active - is not as fast.


TLDR: instead of 
`cloak = 1 -> cloak = .99 -> cloak = 1 -> cloak = .99 ...`
I propose
`cloak = 1 -> cloak = .89 -> cloak = .90 -> ... -> cloak = .99 -> cloak = 1 -> cloak = .89 ...`
