### PR TITLE
Add default non-landable message to restricted red wormholes

### DIFF
--- a/data/landing messages.txt
+++ b/data/landing messages.txt
@@ -54,3 +54,4 @@
 "landing message" "You are not sure what this is, but it's not something you can land on."
 	"planet/wisp"
 	"planet/wormhole"
+	"planet/wormhole-red"


### PR DESCRIPTION
The relevant sprite was missing.


This was added in my other PR, but given the other commits I chose to separate the related-but-not-totally updates into separate PRs.