### PR TITLE
Carried fighters/drones no longer clear orders needing a target.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -185,13 +185,13 @@ void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 		newOrders.target = player.FlagshipPtr();
 		IssueOrders(player, newOrders, "gathering around your flagship.");
 	}
-	// Get rid of any invalid orders.
+	// Get rid of any invalid orders. Carried ships will retain orders in case they are deployed.
 	for(auto it = orders.begin(); it != orders.end(); )
 	{
 		if(it->second.type & Orders::REQUIRES_TARGET)
 		{
 			shared_ptr<Ship> ship = it->second.target.lock();
-			if(!ship || !ship->IsTargetable() || ship->GetSystem() != it->first->GetSystem()
+			if(!ship || !ship->IsTargetable() || (it->first->GetSystem() && ship->GetSystem() != it->first->GetSystem())
 					|| (ship->IsDisabled() && it->second.type == Orders::ATTACK))
 			{
 				it = orders.erase(it);


### PR DESCRIPTION
This is an implementation of solution 2 as identified in #2608

With this fix, carried fighters and drones will remember any assigned orders that require a target, so long as the target is valid (e.g. exactly like normal escorts). This allows commands which toggle on a target (such as GATHER or ATTACK) to correctly function, no matter if your fighters/drones are deployed or in their bays. Without this fix, commands which toggle on a target can only be set if any of your fighters are being carried. Attempting to revoke / toggle the command will instead re-issue the command.