### PR TITLE
Fix to AimTurret to use TotalLifetime instead of Lifetime

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2000,7 +2000,7 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
 				double turnTime = fabs(degrees) / outfit->TurretTurn();
 				// All ships that are within weapons range have the same basic
 				// weight. Outside that range, give them lower priority.
-				rendezvousTime = max(0., rendezvousTime - outfit->Lifetime());
+				rendezvousTime = max(0., rendezvousTime - outfit->TotalLifetime());
 				// Always prefer ships that you are able to hit.
 				double score = turnTime + (180. / outfit->TurretTurn()) * rendezvousTime;
 				if(score < bestScore)


### PR DESCRIPTION
**Problem:** although a weapon's Range() is mostly correct (though I still hope #1826 can be merged, as submunition velocities still aren't considered), the new AimTurrets function effectively recalculates it, and uses Lifetime rather than TotalLifetime. This means that a turret using submunitions will struggle to aim, as follows:

![image](https://user-images.githubusercontent.com/23544894/27007451-f0b6e090-4e4b-11e7-9c2b-a07c609520cd.png)

![image](https://user-images.githubusercontent.com/23544894/27007454-142ed262-4e4c-11e7-9b0a-9dba4f8f2ac0.png)

Well within range, but the turret won't turn to hit. It'll only turn within 240 range, as per:

```
outfit "Matrix Battery"
	category "Turrets"
	...
	weapon
		...
		"submunition" "Matrix Bolt 1" 1
		"lifetime" 12
		"velocity" 20
```

**Solution:** just switched Lifetime for TotalLifetime. Seems to solve the problem.