### PR TITLE
Made a mission fail if it becomes impossible to complete

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -329,10 +329,19 @@ bool NPC::IsLeftBehind(const System *playerSystem) const
 
 bool NPC::HasFailed() const
 {
+	static const int mustLiveFor = ShipEvent::SCAN_CARGO | ShipEvent::SCAN_OUTFITS | ShipEvent::BOARD;
+						
 	for(const auto &it : actions)
+	{
 		if(it.second & failIf)
 			return true;
 	
+		// If we still need to perform an action that requires the NPC ship be
+		// alive, then that ship being destroyed should cause the mission to fail.
+		if((~it.second & succeedIf & mustLiveFor) && (it.second & ShipEvent::DESTROY))
+			return true;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
```
If you need to board or scan a ship, and that ship is destroyed before
you do so, the mission will now fail.
```

If you try to write an `npc board` mission that isn't also an `npc save` mission, you'll run into this. If the target is destroyed before you can board it, the mission is stuck in limbo and there's no good way out of it as a mission creator.

To fix this, I've modified NPC::HasFailed so that a mission is marked as failed in this situation. It now:

- defines a bit field mustLiveFor, the mission actions that require the target be alive for (boarding and scanning).
- returns the failed state if:

```
(~it.second & succeedIf & mustLiveFor) && (it.second & ShipEvent::DESTROY)
```

in plain English:

- there's an action we haven't performed yet (~it.second)
- that we need to perform (succeedIf)
- that requires the target be alive (mustLiveFor)
- but the target's dead (it.second & ShipEvent::DESTROY).