### PR TITLE
Allows specification of insufficient NPC crew (#2512, #2418)

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -187,9 +187,9 @@ void Engine::Place()
 					continue;
 				// Avoid the exploit where the player can wear down an NPC's
 				// crew by attrition over the course of many days.
-				ship->AddCrew(max(0, ship->RequiredCrew() - ship->Crew()));
+				ship->AddCrew(max(0, ship->FillCrew() - ship->Crew()));
 				if(!ship->IsDisabled())
-					ship->Recharge();
+					ship->Repair();
 				
 				if(ship->CanBeCarried())
 				{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -190,7 +190,10 @@ void Ship::Load(const DataNode &node)
 		else if(key == "cargo")
 			cargo.Load(child);
 		else if(key == "crew" && child.Size() >= 2)
+		{
 			crew = static_cast<int>(child.Value(1));
+			assignedCrew = crew;			
+		}
 		else if(key == "fuel" && child.Size() >= 2)
 			fuel = child.Value(1);
 		else if(key == "shields" && child.Size() >= 2)
@@ -359,18 +362,28 @@ void Ship::FinishLoading()
 	for(const Hardpoint &weapon : armament.Get())
 		weaponRadius = max(weaponRadius, weapon.GetPoint().Length());
 	
-	// Recharge, but don't recharge crew or fuel if not in the parent's system.
-	// Do not recharge if this ship's starting state was saved.
-	if(!hull)
-	{
-		shared_ptr<const Ship> parent = GetParent();
-		Recharge(!parent || currentSystem == parent->currentSystem);
-	}
+	// Finish initializing the loaded ship, but don't recharge if not in the
+	// parent's system, and don't recharge any saved value.
+	shared_ptr<const Ship> parent = GetParent();
+	bool recharge = !parent || currentSystem == parent->currentSystem;
+	
+	if((assignedCrew == -1) && recharge)
+		crew = min<int>(max(crew, RequiredCrew()), attributes.Get("bunks"));
+	if(!fuel && recharge)
+		fuel = attributes.Get("fuel capacity");
+	if(!shields && (recharge || attributes.Get("hull repair rate")))
+		shields = attributes.Get("shields");
+	if(!hull && (recharge || attributes.Get("shield generation")))
+		hull = attributes.Get("hull");
 	else
 	{
 		isDisabled = true;
 		isDisabled = IsDisabled();
 	}
+	if(!energy && (recharge || attributes.Get("energy generation")))
+		energy = attributes.Get("energy capacity");
+		
+	heat = IdleHeat();
 }
 
 
@@ -1781,20 +1794,9 @@ bool Ship::IsDestroyed() const
 
 
 
-// Recharge and repair this ship (e.g. because it has landed).
-void Ship::Recharge(bool atSpaceport)
+// Repair this ship.
+void Ship::Repair(bool atSpaceport)
 {
-	if(IsDestroyed())
-		return;
-	
-	if(atSpaceport)
-	{
-		crew = min<int>(max(crew, RequiredCrew()), attributes.Get("bunks"));
-		fuel = attributes.Get("fuel capacity");
-	}
-	pilotError = 0;
-	pilotOkay = 0;
-	
 	if(!personality.IsDerelict())
 	{
 		if(atSpaceport || attributes.Get("shield generation"))
@@ -1804,6 +1806,27 @@ void Ship::Recharge(bool atSpaceport)
 		if(atSpaceport || attributes.Get("energy generation"))
 			energy = attributes.Get("energy capacity");
 	}
+}
+
+
+
+// Recharge and repair this ship (e.g. because it has landed).
+void Ship::Recharge(bool atSpaceport)
+{
+	if(IsDestroyed())
+		return;
+	
+	if(atSpaceport)
+	{
+		// Clear any assigned crew state from an initial load.
+		assignedCrew = -1;
+		crew = min<int>(max(crew, RequiredCrew()), attributes.Get("bunks"));
+		fuel = attributes.Get("fuel capacity");
+	}
+	pilotError = 0;
+	pilotOkay = 0;
+	
+	Repair(atSpaceport);
 	heat = IdleHeat();
 	ionization = 0.;
 	disruption = 0.;
@@ -2027,6 +2050,13 @@ int Ship::RequiredCrew() const
 	
 	// Drones do not need crew, but all other ships need at least one.
 	return max<int>(1, attributes.Get("required crew"));
+}
+
+
+
+int Ship::FillCrew() const
+{	
+	return (assignedCrew != -1) ? assignedCrew : RequiredCrew();
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -214,6 +214,8 @@ public:
 	void Restore();
 	// Check if this ship has been destroyed.
 	bool IsDestroyed() const;
+	// Repair this ship (e.g. because it has landed).
+	void Repair(bool atSpaceport = true);
 	// Recharge and repair this ship (e.g. because it has landed).
 	void Recharge(bool atSpaceport = true);
 	// Check if this ship is able to give the given ship enough fuel to jump.
@@ -247,6 +249,7 @@ public:
 	// Access how many crew members this ship has or needs.
 	int Crew() const;
 	int RequiredCrew() const;
+	int FillCrew() const;
 	void AddCrew(int count);
 	// Check if this is a ship that can be used as a flagship.
 	bool CanBeFlagship() const;
@@ -441,6 +444,9 @@ private:
 	Point acceleration;
 	
 	int crew = 0;
+	// Crew number as assigned by NPC specification. A value of -1 indicates no
+	// assignment.
+	int assignedCrew = -1;
 	int pilotError = 0;
 	int pilotOkay = 0;
 	


### PR DESCRIPTION
```
If a loaded ship specifies crew < requiredCrew, the value is not
overwritten and is retained until that ship has a chance to land at a
spaceport. This also applies to e.g. fuel.

The exploit fix preventing wearing ships' crew down by attrition now no
longer refills their fuel, as it explicitly refills crew and repairs
only.
```

**Problem:** you can't write a mission that creates a ship with a skeleton crew. The game will fill it back up to the required level.

**Solution:** this one took quite a bit of thought, which I went into in issue #2512 a month back. The conversation started in #2418. This wasn't the first strategy that occurred to me (I spent a good few hours on it), but I didn't get much of a discussion going last month so am hopeful to move it forward here.

Sorry, as well, if it seems like this has 'unrelated changes'. It's all related and fixing the original problem, but just trying to do so in a way that's sane. The semi-related consequences here are: 

a) the boarding-attrition exploit fix doesn't restore fuel anymore and doesn't try to recover crew twice, 
b) you can also define an NPC with a specific amount of fuel, shields and energy.
c) the Recharge function has the Repair functions divided out, because there are now use cases where we want to do a repair but not everything in Recharge.