### PR TITLE
Every outfit and ship now has tags that missions can use (#2481)

### DIFF
--- a/data/coalition outfits.txt
+++ b/data/coalition outfits.txt
@@ -12,6 +12,7 @@ outfit "Small Collector Module"
 	category "Power"
 	licenses
 		Coalition
+	tags alien coalition
 	cost 60000
 	thumbnail "outfit/small collector module"
 	"mass" 8
@@ -24,6 +25,7 @@ outfit "Large Collector Module"
 	category "Power"
 	licenses
 		Coalition
+	tags alien coalition
 	cost 300000
 	thumbnail "outfit/large collector module"
 	"mass" 28
@@ -36,6 +38,7 @@ outfit "Small Reactor Module"
 	category "Power"
 	licenses
 		Heliarch
+	tags alien coalition heliarch
 	cost 5497000
 	thumbnail "outfit/small reactor module"
 	"mass" 42
@@ -48,6 +51,7 @@ outfit "Large Reactor Module"
 	category "Power"
 	licenses
 		Heliarch
+	tags alien coalition heliarch
 	cost 17754000
 	thumbnail "outfit/large reactor module"
 	"mass" 98
@@ -60,6 +64,7 @@ outfit "Small Battery Module"
 	category "Power"
 	licenses
 		Coalition
+	tags alien coalition
 	cost 44000
 	thumbnail "outfit/small battery module"
 	"mass" 4
@@ -71,6 +76,7 @@ outfit "Large Battery Module"
 	category "Power"
 	licenses
 		Coalition
+	tags alien coalition
 	cost 340000
 	thumbnail "outfit/large battery module"
 	"mass" 18
@@ -83,6 +89,7 @@ outfit "Small Shield Module"
 	category "Systems"
 	licenses
 		Coalition
+	tags alien coalition
 	cost 84000
 	thumbnail "outfit/small shield module"
 	"mass" 11
@@ -96,6 +103,7 @@ outfit "Large Shield Module"
 	category "Systems"
 	licenses
 		Coalition
+	tags alien coalition
 	cost 553000
 	thumbnail "outfit/large shield module"
 	"mass" 39
@@ -109,6 +117,7 @@ outfit "Small Repair Module"
 	category "Systems"
 	licenses
 		Coalition
+	tags alien coalition
 	cost 64000
 	thumbnail "outfit/small repair module"
 	"mass" 6
@@ -122,6 +131,7 @@ outfit "Large Repair Module"
 	category "Systems"
 	licenses
 		Coalition
+	tags alien coalition
 	cost 553000
 	thumbnail "outfit/large repair module"
 	"mass" 21
@@ -135,6 +145,7 @@ outfit "Cooling Module"
 	category "Systems"
 	licenses
 		Coalition
+	tags alien coalition
 	cost 160000
 	thumbnail "outfit/cooling module"
 	"mass" 5
@@ -148,6 +159,7 @@ outfit "Small Thrust Module"
 	category "Engines"
 	licenses
 		Coalition
+	tags alien coalition
 	"cost" 66000
 	thumbnail "outfit/small thrust module"
 	"mass" 9
@@ -165,6 +177,7 @@ outfit "Large Thrust Module"
 	category "Engines"
 	licenses
 		Coalition
+	tags alien coalition
 	"cost" 292000
 	thumbnail "outfit/large thrust module"
 	"mass" 32
@@ -182,6 +195,7 @@ outfit "Small Steering Module"
 	category "Engines"
 	licenses
 		Coalition
+	tags alien coalition
 	"cost" 60000
 	thumbnail "outfit/small steering module"
 	"mass" 7
@@ -196,6 +210,7 @@ outfit "Large Steering Module"
 	category "Engines"
 	licenses
 		Coalition
+	tags alien coalition
 	"cost" 269000
 	thumbnail "outfit/large steering module"
 	"mass" 25

--- a/data/coalition ships.txt
+++ b/data/coalition ships.txt
@@ -14,6 +14,7 @@ ship "Arach Courier"
 		category "Light Freighter"
 		licenses
 			Coalition
+		tags alien coalition arach freighter
 		"cost" 723000
 		"shields" 1200
 		"hull" 2000
@@ -58,6 +59,7 @@ ship "Arach Freighter"
 		category "Light Freighter"
 		licenses
 			Coalition
+		tags alien coalition arach freighter
 		"cost" 4580000
 		"shields" 3400
 		"hull" 8500
@@ -107,6 +109,7 @@ ship "Arach Hulk"
 		category "Heavy Freighter"
 		licenses
 			Coalition
+		tags alien coalition arach freighter
 		"cost" 9978000
 		"shields" 5700
 		"hull" 13800
@@ -160,6 +163,7 @@ ship "Arach Spindle"
 		category "Heavy Freighter"
 		licenses
 			Coalition
+		tags alien coalition arach freighter
 		"cost" 6652000
 		"shields" 5000
 		"hull" 9700
@@ -211,6 +215,7 @@ ship "Arach Transport"
 		category "Light Freighter"
 		licenses
 			Coalition
+		tags alien coalition arach freighter
 		"cost" 2772000
 		"shields" 2300
 		"hull" 4800
@@ -260,6 +265,7 @@ ship "Heliarch Interdictor"
 		category "Medium Warship"
 		licenses
 			Heliarch
+		tags alien coalition heliarch warship
 		"cost" 35487000
 		"shields" 65300
 		"hull" 54600
@@ -335,6 +341,7 @@ ship "Heliarch Neutralizer"
 		category "Light Warship"
 		licenses
 			Heliarch
+		tags alien coalition heliarch warship
 		"cost" 18847000
 		"shields" 36400
 		"hull" 32800
@@ -442,6 +449,7 @@ ship "Heliarch Punisher"
 		category "Heavy Warship"
 		licenses
 			Heliarch
+		tags alien coalition heliarch warship
 		"cost" 58487000
 		"shields" 108000
 		"hull" 85000
@@ -579,6 +587,7 @@ ship "Kimek Briar"
 		category "Transport"
 		licenses
 			Coalition
+		tags alien coalition kimek transport
 		"cost" 1532000
 		"shields" 3600
 		"hull" 1700
@@ -624,6 +633,7 @@ ship "Kimek Spire"
 		category "Transport"
 		licenses
 			Coalition
+		tags alien coalition kimek transport
 		"cost" 9375000
 		"shields" 14200
 		"hull" 4900
@@ -677,6 +687,7 @@ ship "Kimek Thistle"
 		category "Transport"
 		licenses
 			Coalition
+		tags alien coalition kimek transport
 		"cost" 2904000
 		"shields" 7500
 		"hull" 2800
@@ -725,6 +736,7 @@ ship "Kimek Thorn"
 		category "Transport"
 		licenses
 			Coalition
+		tags alien coalition kimek transport
 		"cost" 440000
 		"shields" 1400
 		"hull" 800
@@ -769,6 +781,7 @@ ship "Saryd Runabout"
 		category "Light Freighter"
 		licenses
 			Coalition
+		tags alien coalition saryd freighter
 		"cost" 942000
 		"shields" 2000
 		"hull" 1400
@@ -811,6 +824,7 @@ ship "Saryd Sojourner"
 		category "Heavy Freighter"
 		licenses
 			Coalition
+		tags alien coalition saryd freighter
 		"cost" 11075000
 		"shields" 13000
 		"hull" 7700
@@ -865,6 +879,7 @@ ship "Saryd Traveler"
 		category "Heavy Freighter"
 		licenses
 			Coalition
+		tags alien coalition saryd freighter
 		"cost" 3385000
 		"shields" 6500
 		"hull" 4000
@@ -917,6 +932,7 @@ ship "Saryd Visitor"
 		category "Light Freighter"
 		licenses
 			Coalition
+		tags alien coalition saryd freighter
 		"cost" 1982000
 		"shields" 4000
 		"hull" 2400

--- a/data/coalition weapons.txt
+++ b/data/coalition weapons.txt
@@ -12,6 +12,7 @@ outfit "Bombardment Cannon"
 	category "Guns"
 	licenses
 		Heliarch
+	tags alien coalition heliarch weapon
 	cost 437000
 	thumbnail "outfit/bombardment cannon"
 	"mass" 12
@@ -39,6 +40,7 @@ outfit "Bombardment Turret"
 	category "Turrets"
 	licenses
 		Heliarch
+	tags alien coalition heliarch weapon
 	cost 1845000
 	thumbnail "outfit/bombardment turret"
 	"mass" 43
@@ -81,6 +83,7 @@ outfit "Finisher Pod"
 	category "Secondary Weapons"
 	licenses
 		Heliarch
+	tags alien coalition heliarch weapon
 	cost 1370000
 	thumbnail "outfit/finisher pod"
 	"mass" 16
@@ -137,6 +140,7 @@ outfit "Active Finisher"
 outfit "Finisher Torpedo"
 	plural "Finisher Torpedoes"
 	category "Ammunition"
+	tags alien coalition heliarch weapon
 	cost 32000
 	thumbnail "outfit/finisher"
 	"mass" .5
@@ -185,6 +189,7 @@ outfit "Heliarch Attractor"
 	category "Turrets"
 	licenses
 		Heliarch
+	tags alien coalition heliarch weapon
 	cost 2187000
 	thumbnail "outfit/heliarch attractor"
 	"mass" 49
@@ -228,6 +233,7 @@ outfit "Heliarch Repulsor"
 	category "Turrets"
 	licenses
 		Heliarch
+	tags alien coalition heliarch weapon
 	cost 2549000
 	thumbnail "outfit/heliarch repulsor"
 	"mass" 56
@@ -272,6 +278,7 @@ outfit "Ion Rain Gun"
 	category "Guns"
 	licenses
 		Heliarch
+	tags alien coalition heliarch weapon
 	cost 798000
 	thumbnail "outfit/ion rain gun"
 	"mass" 17

--- a/data/deprecated outfits.txt
+++ b/data/deprecated outfits.txt
@@ -13,6 +13,7 @@
 
 outfit "Korath Tek'far Reactor"
 	category "Power"
+	tags alien korath
 	cost 1200000
 	thumbnail "outfit/unknown"
 	"mass" 25
@@ -23,6 +24,7 @@ outfit "Korath Tek'far Reactor"
 
 outfit "Korath Tek'nel Reactor"
 	category "Power"
+	tags alien korath
 	cost 14000000
 	thumbnail "outfit/unknown"
 	"mass" 140
@@ -31,9 +33,9 @@ outfit "Korath Tek'nel Reactor"
 	"heat generation" 80
 	description "This massive reactor was designed by the Korath to meet the power needs of their largest ships."
 
-
 outfit "Korath Shield Generator"
 	category "Systems"
+	tags alien korath
 	cost 1700000
 	thumbnail "outfit/unknown"
 	"mass" 52
@@ -44,6 +46,7 @@ outfit "Korath Shield Generator"
 
 outfit "Korath Heat Shunt"
 	category "Systems"
+	tags alien korath
 	cost 450000
 	thumbnail "outfit/unknown"
 	"mass" 34
@@ -53,6 +56,7 @@ outfit "Korath Heat Shunt"
 
 outfit "Korath Ark'torbal Thruster"
 	category "Engines"
+	tags alien korath
 	"cost" 40000
 	thumbnail "outfit/unknown"
 	"mass" 17
@@ -68,6 +72,7 @@ outfit "Korath Ark'torbal Thruster"
 
 outfit "Korath Ark'parat Steering"
 	category "Engines"
+	tags alien korath
 	"cost" 36000
 	thumbnail "outfit/unknown"
 	"mass" 12
@@ -80,6 +85,7 @@ outfit "Korath Ark'parat Steering"
 
 outfit "Korath Jak'torbal Thruster"
 	category "Engines"
+	tags alien korath
 	"cost" 317000
 	thumbnail "outfit/unknown"
 	"mass" 89
@@ -95,6 +101,7 @@ outfit "Korath Jak'torbal Thruster"
 
 outfit "Korath Jak'parat Steering"
 	category "Engines"
+	tags alien korath
 	"cost" 2740000
 	thumbnail "outfit/unknown"
 	"mass" 67
@@ -104,7 +111,6 @@ outfit "Korath Jak'parat Steering"
 	"turning energy" 3.1
 	"turning heat" 7.9
 	description "This engine is used in the Korath capital ships."
-
 
 # Deprecated in favor of the Outfits Expansion, which has a cooling penalty that
 # stacks up and limits how many you can install.
@@ -121,6 +127,7 @@ outfit "Mass Expansion"
 # Deprecated to give it a less generic name.
 outfit "Reverse Thruster"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 140000
 	thumbnail "outfit/reverse thruster"
 	"mass" 22
@@ -133,6 +140,7 @@ outfit "Reverse Thruster"
 # Deprecated because it unbalances the capture dynamics, among other things.
 outfit "NDR-114 Android"
 	category "Systems"
+	tags human
 	cost 80000
 	thumbnail "outfit/android"
 	"required crew" -1
@@ -142,6 +150,7 @@ outfit "NDR-114 Android"
 # Deprecated for 0.9.2 due to long outfit names.
 outfit "Bullfrog Anti-Missile Turret"
 	category "Turrets"
+	tags alien hai anti-missile
 	cost 55000
 	thumbnail "outfit/anti-missile hai"
 	"mass" 10
@@ -161,6 +170,7 @@ outfit "Bullfrog Anti-Missile Turret"
 
 outfit "Chameleon Anti-Missile Turret"
 	category "Turrets"
+	tags alien hai anti-missile
 	cost 140000
 	thumbnail "outfit/heavy anti-missile hai"
 	"mass" 22

--- a/data/drak.txt
+++ b/data/drak.txt
@@ -10,6 +10,7 @@
 
 outfit "Drak Distancer"
 	category "Turrets"
+	tags alien drak
 	cost 1000000
 	thumbnail "outfit/unknown"
 	"mass" 64
@@ -34,6 +35,7 @@ effect "distancer flare"
 
 outfit "Drak Draining Field"
 	category "Turrets"
+	tags alien drak weapon
 	cost 1000000
 	thumbnail "outfit/unknown"
 	"mass" 84
@@ -54,6 +56,7 @@ outfit "Drak Draining Field"
 
 outfit "Drak Anti-Missile Field"
 	category "Turrets"
+	tags alien drak weapon anti-missile
 	cost 1000000
 	thumbnail "outfit/unknown"
 	"mass" 66
@@ -71,6 +74,7 @@ outfit "Drak Anti-Missile Field"
 
 outfit "Drak Turret"
 	category "Turrets"
+	tags alien drak weapon
 	cost 1000000
 	thumbnail "outfit/unknown"
 	"mass" 48
@@ -105,6 +109,7 @@ effect "drak bolt impact"
 
 outfit "Drak Antimatter Cannon"
 	category "Guns"
+	tags alien drak weapon
 	cost 10000000
 	thumbnail "outfit/unknown"
 	"mass" 96
@@ -169,6 +174,7 @@ ship Archon
 	"never disabled"
 	attributes
 		category "Heavy Warship"
+		tags alien drak warship
 		"cost" 1000000000
 		"shields" 4000000
 		"hull" 1000000

--- a/data/engines.txt
+++ b/data/engines.txt
@@ -10,6 +10,7 @@
 
 outfit "Afterburner"
 	category "Engines"
+	tags human
 	"cost" 70000
 	thumbnail "outfit/afterburner"
 	"mass" 15
@@ -23,6 +24,7 @@ outfit "Afterburner"
 
 outfit "Ionic Afterburner"
 	category "Engines"
+	tags human syndicate
 	"cost" 340000
 	thumbnail "outfit/ionic afterburner"
 	"mass" 24
@@ -37,6 +39,7 @@ outfit "Ionic Afterburner"
 
 outfit "X1050 Ion Engines"
 	category "Engines"
+	tags human
 	"cost" 20000
 	thumbnail "outfit/tiny ion engines"
 	"mass" 20
@@ -56,6 +59,7 @@ outfit "X1050 Ion Engines"
 
 outfit "X1700 Ion Thruster"
 	category "Engines"
+	tags human
 	"cost" 12000
 	thumbnail "outfit/tiny ion thruster"
 	"mass" 16
@@ -72,6 +76,7 @@ outfit "X1700 Ion Thruster"
 
 outfit "X2700 Ion Thruster"
 	category "Engines"
+	tags human
 	"cost" 26000
 	thumbnail "outfit/small ion thruster"
 	"mass" 27
@@ -88,6 +93,7 @@ outfit "X2700 Ion Thruster"
 
 outfit "X3700 Ion Thruster"
 	category "Engines"
+	tags human
 	"cost" 58000
 	thumbnail "outfit/medium ion thruster"
 	"mass" 46
@@ -104,6 +110,7 @@ outfit "X3700 Ion Thruster"
 
 outfit "X4700 Ion Thruster"
 	category "Engines"
+	tags human
 	"cost" 128000
 	thumbnail "outfit/large ion thruster"
 	"mass" 79
@@ -120,6 +127,7 @@ outfit "X4700 Ion Thruster"
 
 outfit "X5700 Ion Thruster"
 	category "Engines"
+	tags human
 	"cost" 281000
 	thumbnail "outfit/huge ion thruster"
 	"mass" 134
@@ -136,6 +144,7 @@ outfit "X5700 Ion Thruster"
 
 outfit "X1200 Ion Steering"
 	category "Engines"
+	tags human
 	"cost" 10000
 	thumbnail "outfit/tiny ion steering"
 	"mass" 12
@@ -149,6 +158,7 @@ outfit "X1200 Ion Steering"
 
 outfit "X2200 Ion Steering"
 	category "Engines"
+	tags human
 	"cost" 21000
 	thumbnail "outfit/small ion steering"
 	"mass" 20
@@ -162,6 +172,7 @@ outfit "X2200 Ion Steering"
 
 outfit "X3200 Ion Steering"
 	category "Engines"
+	tags human
 	"cost" 46000
 	thumbnail "outfit/medium ion steering"
 	"mass" 35
@@ -175,6 +186,7 @@ outfit "X3200 Ion Steering"
 
 outfit "X4200 Ion Steering"
 	category "Engines"
+	tags human
 	"cost" 102000
 	thumbnail "outfit/large ion steering"
 	"mass" 59
@@ -188,6 +200,7 @@ outfit "X4200 Ion Steering"
 
 outfit "X5200 Ion Steering"
 	category "Engines"
+	tags human
 	"cost" 225000
 	thumbnail "outfit/huge ion steering"
 	"mass" 100
@@ -202,6 +215,7 @@ outfit "X5200 Ion Steering"
 
 outfit "Chipmunk Plasma Thruster"
 	category "Engines"
+	tags human "delta v"
 	"cost" 20000
 	thumbnail "outfit/tiny plasma thruster"
 	"mass" 20
@@ -218,6 +232,7 @@ outfit "Chipmunk Plasma Thruster"
 
 outfit "Greyhound Plasma Thruster"
 	category "Engines"
+	tags human "delta v"
 	"cost" 45000
 	thumbnail "outfit/small plasma thruster"
 	"mass" 34
@@ -234,6 +249,7 @@ outfit "Greyhound Plasma Thruster"
 
 outfit "Impala Plasma Thruster"
 	category "Engines"
+	tags human "delta v"
 	"cost" 99000
 	thumbnail "outfit/medium plasma thruster"
 	"mass" 58
@@ -250,6 +266,7 @@ outfit "Impala Plasma Thruster"
 
 outfit "Orca Plasma Thruster"
 	category "Engines"
+	tags human "delta v"
 	"cost" 217000
 	thumbnail "outfit/large plasma thruster"
 	"mass" 98
@@ -266,6 +283,7 @@ outfit "Orca Plasma Thruster"
 
 outfit "Tyrant Plasma Thruster"
 	category "Engines"
+	tags human "delta v"
 	"cost" 478000
 	thumbnail "outfit/huge plasma thruster"
 	"mass" 167
@@ -282,6 +300,7 @@ outfit "Tyrant Plasma Thruster"
 
 outfit "Chipmunk Plasma Steering"
 	category "Engines"
+	tags human "delta v"
 	"cost" 16000
 	thumbnail "outfit/tiny plasma steering"
 	"mass" 15
@@ -295,6 +314,7 @@ outfit "Chipmunk Plasma Steering"
 
 outfit "Greyhound Plasma Steering"
 	category "Engines"
+	tags human "delta v"
 	"cost" 36000
 	thumbnail "outfit/small plasma steering"
 	"mass" 26
@@ -308,6 +328,7 @@ outfit "Greyhound Plasma Steering"
 
 outfit "Impala Plasma Steering"
 	category "Engines"
+	tags human "delta v"
 	"cost" 79000
 	thumbnail "outfit/medium plasma steering"
 	"mass" 43
@@ -321,6 +342,7 @@ outfit "Impala Plasma Steering"
 
 outfit "Orca Plasma Steering"
 	category "Engines"
+	tags human "delta v"
 	"cost" 174000
 	thumbnail "outfit/large plasma steering"
 	"mass" 74
@@ -334,6 +356,7 @@ outfit "Orca Plasma Steering"
 
 outfit "Tyrant Plasma Steering"
 	category "Engines"
+	tags human "delta v"
 	"cost" 382000
 	thumbnail "outfit/huge plasma steering"
 	"mass" 125
@@ -348,6 +371,7 @@ outfit "Tyrant Plasma Steering"
 
 outfit "A120 Atomic Thruster"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 140000
 	thumbnail "outfit/tiny atomic thruster"
 	"mass" 22
@@ -363,6 +387,7 @@ outfit "A120 Atomic Thruster"
 
 outfit "A250 Atomic Thruster"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 280000
 	thumbnail "outfit/small atomic thruster"
 	"mass" 34
@@ -378,6 +403,7 @@ outfit "A250 Atomic Thruster"
 
 outfit "A370 Atomic Thruster"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 560000
 	thumbnail "outfit/medium atomic thruster"
 	"mass" 53
@@ -393,6 +419,7 @@ outfit "A370 Atomic Thruster"
 
 outfit "A520 Atomic Thruster"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 1120000
 	thumbnail "outfit/large atomic thruster"
 	"mass" 82
@@ -408,6 +435,7 @@ outfit "A520 Atomic Thruster"
 
 outfit "A860 Atomic Thruster"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 2240000
 	thumbnail "outfit/huge atomic thruster"
 	"mass" 127
@@ -423,6 +451,7 @@ outfit "A860 Atomic Thruster"
 
 outfit "A125 Atomic Steering"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 120000
 	thumbnail "outfit/tiny atomic steering"
 	"mass" 16
@@ -435,6 +464,7 @@ outfit "A125 Atomic Steering"
 
 outfit "A255 Atomic Steering"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 240000
 	thumbnail "outfit/small atomic steering"
 	"mass" 25
@@ -447,6 +477,7 @@ outfit "A255 Atomic Steering"
 
 outfit "A375 Atomic Steering"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 480000
 	thumbnail "outfit/medium atomic steering"
 	"mass" 38
@@ -459,6 +490,7 @@ outfit "A375 Atomic Steering"
 
 outfit "A525 Atomic Steering"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 960000
 	thumbnail "outfit/large atomic steering"
 	"mass" 60
@@ -471,6 +503,7 @@ outfit "A525 Atomic Steering"
 
 outfit "A865 Atomic Steering"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 1920000
 	thumbnail "outfit/huge atomic steering"
 	"mass" 92
@@ -483,6 +516,7 @@ outfit "A865 Atomic Steering"
 
 outfit "AR120 Reverse Thruster"
 	category "Engines"
+	tags human "deep sky"
 	"cost" 140000
 	thumbnail "outfit/reverse thruster"
 	"mass" 22

--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -10,6 +10,7 @@
 
 outfit "Pulse Cannon"
 	category "Guns"
+	tags alien hai weapon
 	cost 130000
 	thumbnail "outfit/pulse cannon"
 	"mass" 13
@@ -32,6 +33,7 @@ outfit "Pulse Cannon"
 
 outfit "Pulse Turret"
 	category "Turrets"
+	tags alien hai weapon
 	cost 590000
 	thumbnail "outfit/pulse turret"
 	"mass" 34
@@ -58,6 +60,7 @@ outfit "Pulse Turret"
 
 outfit "Ion Cannon"
 	category "Guns"
+	tags alien hai weapon
 	cost 490000
 	thumbnail "outfit/ion cannon"
 	"mass" 47
@@ -84,6 +87,7 @@ outfit "Ion Cannon"
 
 outfit "Railgun Slug"
 	category "Ammunition"
+	tags alien hai
 	cost 60
 	thumbnail "outfit/railslug"
 	"mass" 0.02
@@ -92,6 +96,7 @@ outfit "Railgun Slug"
 
 outfit "Railgun"
 	category "Secondary Weapons"
+	tags alien hai weapon
 	cost 20000
 	thumbnail "outfit/railgun"
 	"mass" 4
@@ -139,6 +144,7 @@ outfit "rslug"
 
 outfit "Hai Tracker"
 	category "Ammunition"
+	tags alien hai
 	cost 1000
 	thumbnail "outfit/hai tracker"
 	"mass" .2
@@ -147,6 +153,7 @@ outfit "Hai Tracker"
 
 outfit "Tracker Storage Pod"
 	category "Ammunition"
+	tags alien hai
 	cost 28000
 	thumbnail "outfit/hai tracker storage"
 	"mass" 4.4
@@ -157,6 +164,7 @@ outfit "Tracker Storage Pod"
 
 outfit "Hai Tracker Pod"
 	category "Secondary Weapons"
+	tags alien hai weapon
 	cost 150000
 	thumbnail "outfit/hai tracker pod"
 	"mass" 8
@@ -195,6 +203,7 @@ outfit "Hai Tracker Pod"
 
 outfit "Bullfrog Anti-Missile"
 	category "Turrets"
+	tags alien hai anti-missile
 	cost 55000
 	thumbnail "outfit/anti-missile hai"
 	"mass" 10
@@ -216,6 +225,7 @@ outfit "Bullfrog Anti-Missile"
 
 outfit "Chameleon Anti-Missile"
 	category "Turrets"
+	tags alien hai anti-missile
 	cost 140000
 	thumbnail "outfit/heavy anti-missile hai"
 	"mass" 22
@@ -237,6 +247,7 @@ outfit "Chameleon Anti-Missile"
 
 outfit "Hai Corundum Regenerator"
 	category "Systems"
+	tags alien hai
 	cost 300000
 	thumbnail "outfit/small regenerator hai"
 	"mass" 16
@@ -249,6 +260,7 @@ outfit "Hai Corundum Regenerator"
 
 outfit "Hai Diamond Regenerator"
 	category "Systems"
+	tags alien hai
 	cost 1150000
 	thumbnail "outfit/large regenerator hai"
 	"mass" 49
@@ -261,6 +273,7 @@ outfit "Hai Diamond Regenerator"
 
 outfit "Hai Williwaw Cooling"
 	category "Systems"
+	tags alien hai
 	cost 15000
 	thumbnail "outfit/cooling ducts hai"
 	"mass" 8
@@ -281,6 +294,7 @@ outfit "Quantum Keystone"
 
 outfit "Hai Chasm Batteries"
 	plural "Hai Chasm Batteries"
+	tags alien hai
 	category "Power"
 	cost 18000
 	thumbnail "outfit/tiny battery hai"
@@ -291,6 +305,7 @@ outfit "Hai Chasm Batteries"
 
 outfit "Hai Fissure Batteries"
 	plural "Hai Fissure Batteries"
+	tags alien hai
 	category "Power"
 	cost 22000
 	thumbnail "outfit/small battery hai"
@@ -301,6 +316,7 @@ outfit "Hai Fissure Batteries"
 
 outfit "Hai Gorge Batteries"
 	plural "Hai Gorge Batteries"
+	tags alien hai
 	category "Power"
 	cost 55000
 	thumbnail "outfit/medium battery hai"
@@ -311,6 +327,7 @@ outfit "Hai Gorge Batteries"
 
 outfit "Hai Ravine Batteries"
 	plural "Hai Ravine Batteries"
+	tags alien hai
 	category "Power"
 	cost 124000
 	thumbnail "outfit/large battery hai"
@@ -321,6 +338,7 @@ outfit "Hai Ravine Batteries"
 
 outfit "Hai Valley Batteries"
 	plural "Hai Valley Batteries"
+	tags alien hai
 	category "Power"
 	cost 300000
 	thumbnail "outfit/huge battery hai"
@@ -332,6 +350,7 @@ outfit "Hai Valley Batteries"
 
 outfit "Boulder Reactor"
 	category "Power"
+	tags alien hai
 	cost 5750000
 	thumbnail "outfit/fusion hai"
 	"mass" 90
@@ -342,6 +361,7 @@ outfit "Boulder Reactor"
 
 outfit "Geode Reactor"
 	category "Power"
+	tags alien hai
 	cost 1750000
 	thumbnail "outfit/fission hai"
 	"mass" 58
@@ -352,6 +372,7 @@ outfit "Geode Reactor"
 
 outfit "Pebble Core"
 	category "Power"
+	tags alien hai
 	cost 1050000
 	thumbnail "outfit/dwarf core hai"
 	"mass" 32
@@ -362,6 +383,7 @@ outfit "Pebble Core"
 
 outfit "Sand Cell"
 	category "Power"
+	tags alien hai
 	cost 45000
 	thumbnail "outfit/fuel cell hai"
 	"mass" 24
@@ -374,6 +396,7 @@ outfit "Sand Cell"
 outfit `"Baellie" Atomic Engines`
 	plural `"Baellie" Atomic Engines`
 	category "Engines"
+	tags alien hai
 	"cost" 240000
 	thumbnail "outfit/tiny atomic engines hai"
 	"mass" 24
@@ -392,6 +415,7 @@ outfit `"Baellie" Atomic Engines`
 
 outfit `"Basrem" Atomic Thruster`
 	category "Engines"
+	tags alien hai
 	"cost" 150000
 	thumbnail "outfit/tiny atomic thruster hai"
 	"mass" 18
@@ -407,6 +431,7 @@ outfit `"Basrem" Atomic Thruster`
 
 outfit `"Benga" Atomic Thruster`
 	category "Engines"
+	tags alien hai
 	"cost" 300000
 	thumbnail "outfit/small atomic thruster hai"
 	"mass" 28
@@ -422,6 +447,7 @@ outfit `"Benga" Atomic Thruster`
 
 outfit `"Biroo" Atomic Thruster`
 	category "Engines"
+	tags alien hai
 	"cost" 610000
 	thumbnail "outfit/medium atomic thruster hai"
 	"mass" 44
@@ -437,6 +463,7 @@ outfit `"Biroo" Atomic Thruster`
 
 outfit `"Bondir" Atomic Thruster`
 	category "Engines"
+	tags alien hai
 	"cost" 1100000
 	thumbnail "outfit/large atomic thruster hai"
 	"mass" 63
@@ -452,6 +479,7 @@ outfit `"Bondir" Atomic Thruster`
 
 outfit `"Bufaer" Atomic Thruster`
 	category "Engines"
+	tags alien hai
 	"cost" 2400000
 	thumbnail "outfit/huge atomic thruster hai"
 	"mass" 104
@@ -467,6 +495,7 @@ outfit `"Bufaer" Atomic Thruster`
 
 outfit `"Basrem" Atomic Steering`
 	category "Engines"
+	tags alien hai
 	"cost" 120000
 	thumbnail "outfit/tiny atomic steering hai"
 	"mass" 12
@@ -479,6 +508,7 @@ outfit `"Basrem" Atomic Steering`
 
 outfit `"Benga" Atomic Steering`
 	category "Engines"
+	tags alien hai
 	"cost" 250000
 	thumbnail "outfit/small atomic steering hai"
 	"mass" 20
@@ -491,6 +521,7 @@ outfit `"Benga" Atomic Steering`
 
 outfit `"Biroo" Atomic Steering`
 	category "Engines"
+	tags alien hai
 	"cost" 530000
 	thumbnail "outfit/medium atomic steering hai"
 	"mass" 32
@@ -503,6 +534,7 @@ outfit `"Biroo" Atomic Steering`
 
 outfit `"Bondir" Atomic Steering`
 	category "Engines"
+	tags alien hai
 	"cost" 950000
 	thumbnail "outfit/large atomic steering hai"
 	"mass" 49
@@ -515,6 +547,7 @@ outfit `"Bondir" Atomic Steering`
 
 outfit `"Bufaer" Atomic Steering`
 	category "Engines"
+	tags alien hai
 	"cost" 2100000
 	thumbnail "outfit/huge atomic steering hai"
 	"mass" 76

--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -12,6 +12,7 @@ ship "Aphid"
 	sprite "ship/hai aphid"
 	attributes
 		category "Light Freighter"
+		tags alien hai freighter
 		"cost" 570000
 		"shields" 1700
 		"hull" 1400
@@ -62,6 +63,7 @@ ship "Flea"
 	sprite "ship/hai flea"
 	attributes
 		category "Drone"
+		tags alien hai
 		"cost" 122400
 		"shields" 200
 		"hull" 700
@@ -93,6 +95,7 @@ ship "Lightning Bug"
 	sprite "ship/hai lightning bug"
 	attributes
 		category "Light Warship"
+		tags alien hai warship
 		"cost" 3200000
 		"shields" 6700
 		"hull" 1700
@@ -149,6 +152,7 @@ ship "Pond Strider"
 	sprite "ship/hai pond strider"
 	attributes
 		category "Medium Warship"
+		tags alien hai warship
 		"cost" 5250000
 		"shields" 10000
 		"hull" 3000
@@ -210,6 +214,7 @@ ship "Shield Beetle"
 	sprite "ship/hai shield beetle"
 	attributes
 		category "Heavy Warship"
+		tags alien hai warship
 		"cost" 17900000
 		"shields" 32000
 		"hull" 9800
@@ -351,6 +356,7 @@ ship "Solifuge"
 		category "Heavy Warship"
 		licenses
 			"Unfettered Militia"
+		tags alien hai unfettered warship
 		"cost" 22800000
 		"shields" 37800
 		"hull" 11000
@@ -510,6 +516,7 @@ ship "Violin Spider"
 	sprite "ship/hai violin spider"
 	attributes
 		category "Fighter"
+		tags alien hai unfettered
 		"cost" 139000
 		"shields" 1400
 		"hull" 600
@@ -556,6 +563,7 @@ ship "Water Bug"
 	sprite "ship/hai water bug"
 	attributes
 		category "Heavy Freighter"
+		tags alien hai freighter
 		"cost" 6500000
 		"shields" 7900
 		"hull" 4500

--- a/data/indigenous.txt
+++ b/data/indigenous.txt
@@ -16,6 +16,7 @@ ship "Void Sprite"
 	"never disabled"
 	attributes
 		category "Medium Warship"
+		tags alien indigenous warship
 		"hull" 9600
 		"required crew" 4
 		"bunks" 4
@@ -44,6 +45,7 @@ ship "Void Sprite" "Void Sprite (Infant)"
 	"never disabled"
 	attributes
 		category "Light Warship"
+		tags alien indigenous warship
 		"hull" 2800
 		"required crew" 2
 		"bunks" 2
@@ -66,6 +68,7 @@ ship "Void Sprite" "Void Sprite (Infant)"
 
 outfit Mouthparts?
 	category "Guns"
+	tags alien indigenous weapon
 	"gun ports" -1
 	weapon
 		sound "crunch"

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -212,6 +212,7 @@ ship "Unknown Ship Type"
 	sprite ship/kestrel
 	attributes
 		category "Heavy Warship"
+		tags human tarazed warship
 		"cost" 10300000
 		"shields" 17400
 		"hull" 6200
@@ -264,6 +265,7 @@ ship "Kestrel"
 	sprite ship/kestrel
 	attributes
 		category "Heavy Warship"
+		tags human tarazed warship
 		"cost" 10300000
 		"shields" 17400
 		"hull" 6200

--- a/data/korath outfits.txt
+++ b/data/korath outfits.txt
@@ -11,6 +11,7 @@
 outfit "Generator (Candle Class)"
 	plural "Generators (Candle Class)"
 	category "Power"
+	tags alien korath
 	cost 493000
 	thumbnail "outfit/small korath generator"
 	"mass" 23
@@ -22,6 +23,7 @@ outfit "Generator (Candle Class)"
 outfit "Generator (Furnace Class)"
 	plural "Generators (Furnace Class)"
 	category "Power"
+	tags alien korath
 	cost 925000
 	thumbnail "outfit/medium korath generator"
 	"mass" 39
@@ -33,6 +35,7 @@ outfit "Generator (Furnace Class)"
 outfit "Generator (Inferno Class)"
 	plural "Generators (Inferno Class)"
 	category "Power"
+	tags alien korath
 	cost 1877000
 	thumbnail "outfit/large korath generator"
 	"mass" 71
@@ -43,6 +46,7 @@ outfit "Generator (Inferno Class)"
 
 outfit "Plasma Core"
 	category "Power"
+	tags alien korath
 	cost 4188000
 	thumbnail "outfit/plasma core"
 	"mass" 54
@@ -53,6 +57,7 @@ outfit "Plasma Core"
 
 outfit "Double Plasma Core"
 	category "Power"
+	tags alien korath
 	cost 9321000
 	thumbnail "outfit/double plasma core"
 	"mass" 93
@@ -63,6 +68,7 @@ outfit "Double Plasma Core"
 
 outfit "Triple Plasma Core"
 	category "Power"
+	tags alien korath
 	cost 20460000
 	thumbnail "outfit/triple plasma core"
 	"mass" 169
@@ -75,6 +81,7 @@ outfit "Triple Plasma Core"
 
 outfit "Small Heat Shunt"
 	category "Systems"
+	tags alien korath
 	cost 180000
 	thumbnail "outfit/small heat shunt"
 	"mass" 7
@@ -84,6 +91,7 @@ outfit "Small Heat Shunt"
 
 outfit "Large Heat Shunt"
 	category "Systems"
+	tags alien korath
 	cost 790000
 	thumbnail "outfit/large heat shunt"
 	"mass" 24
@@ -94,6 +102,7 @@ outfit "Large Heat Shunt"
 
 outfit "Systems Core (Small)"
 	plural "Systems Cores (Small)"
+	tags alien korath
 	category "Systems"
 	cost 1452000
 	thumbnail "outfit/small systems core"
@@ -109,6 +118,7 @@ outfit "Systems Core (Small)"
 
 outfit "Systems Core (Medium)"
 	plural "Systems Cores (Medium)"
+	tags alien korath
 	category "Systems"
 	cost 3630000
 	thumbnail "outfit/medium systems core"
@@ -124,6 +134,7 @@ outfit "Systems Core (Medium)"
 
 outfit "Systems Core (Large)"
 	plural "Systems Cores (Large)"
+	tags alien korath
 	category "Systems"
 	cost 9075000
 	thumbnail "outfit/large systems core"
@@ -139,6 +150,7 @@ outfit "Systems Core (Large)"
 
 outfit "Command Center"
 	category "Systems"
+	tags alien korath
 	cost 437000
 	thumbnail "outfit/command center"
 	"mass" 8
@@ -150,6 +162,7 @@ outfit "Command Center"
 
 outfit "Reasoning Node"
 	category "Systems"
+	tags alien korath "kor mereti"
 	cost "23000"
 	thumbnail "outfit/reasoning node"
 	"mass" 1
@@ -158,6 +171,7 @@ outfit "Reasoning Node"
 
 outfit "Control Transceiver"
 	category "Systems"
+	tags alien korath "kor sestor"
 	cost "7000"
 	thumbnail "outfit/control transceiver"
 	"mass" 1
@@ -169,6 +183,7 @@ outfit "Control Transceiver"
 outfit "Thruster (Asteroid Class)"
 	plural "Thrusters (Asteroid Class)"
 	category "Engines"
+	tags alien korath
 	"cost" 113000
 	thumbnail "outfit/tiny korath thruster"
 	"mass" 14
@@ -185,6 +200,7 @@ outfit "Thruster (Asteroid Class)"
 outfit "Thruster (Comet Class)"
 	plural "Thrusters (Comet Class)"
 	category "Engines"
+	tags alien korath
 	"cost" 249000
 	thumbnail "outfit/small korath thruster"
 	"mass" 24
@@ -201,6 +217,7 @@ outfit "Thruster (Comet Class)"
 outfit "Thruster (Lunar Class)"
 	plural "Thrusters (Lunar Class)"
 	category "Engines"
+	tags alien korath
 	"cost" 539000
 	thumbnail "outfit/medium korath thruster"
 	"mass" 40
@@ -217,6 +234,7 @@ outfit "Thruster (Lunar Class)"
 outfit "Thruster (Planetary Class)"
 	plural "Thrusters (Planetary Class)"
 	category "Engines"
+	tags alien korath
 	"cost" 1216000
 	thumbnail "outfit/large korath thruster"
 	"mass" 69
@@ -233,6 +251,7 @@ outfit "Thruster (Planetary Class)"
 outfit "Thruster (Stellar Class)"
 	plural "Thrusters (Stellar Class)"
 	category "Engines"
+	tags alien korath
 	"cost" 2733000
 	thumbnail "outfit/huge korath thruster"
 	"mass" 118
@@ -249,6 +268,7 @@ outfit "Thruster (Stellar Class)"
 outfit "Steering (Asteroid Class)"
 	plural "Steerings (Asteroid Class)"
 	category "Engines"
+	tags alien korath
 	"cost" 95000
 	thumbnail "outfit/tiny korath steering"
 	"mass" 10
@@ -262,6 +282,7 @@ outfit "Steering (Asteroid Class)"
 outfit "Steering (Comet Class)"
 	plural "Steerings (Comet Class)"
 	category "Engines"
+	tags alien korath
 	"cost" 221000
 	thumbnail "outfit/small korath steering"
 	"mass" 18
@@ -275,6 +296,7 @@ outfit "Steering (Comet Class)"
 outfit "Steering (Lunar Class)"
 	plural "Steerings (Lunar Class)"
 	category "Engines"
+	tags alien korath
 	"cost" 473000
 	thumbnail "outfit/medium korath steering"
 	"mass" 30
@@ -288,6 +310,7 @@ outfit "Steering (Lunar Class)"
 outfit "Steering (Planetary Class)"
 	plural "Steerings (Planetary Class)"
 	category "Engines"
+	tags alien korath
 	"cost" 1077000
 	thumbnail "outfit/large korath steering"
 	"mass" 52
@@ -301,6 +324,7 @@ outfit "Steering (Planetary Class)"
 outfit "Steering (Stellar Class)"
 	plural "Steerings (Stellar Class)"
 	category "Engines"
+	tags alien korath
 	"cost" 2435000
 	thumbnail "outfit/huge korath steering"
 	"mass" 89

--- a/data/korath ships.txt
+++ b/data/korath ships.txt
@@ -12,6 +12,7 @@ ship "Korath Raider"
 	sprite "ship/raider"
 	attributes
 		category "Heavy Warship"
+		tags alien korath warship
 		"cost" 16570000
 		"shields" 27000
 		"hull" 9000
@@ -70,6 +71,7 @@ ship "Korath Chaser"
 	sprite "ship/chaser"
 	attributes
 		category "Fighter"
+		tags alien korath
 		"cost" 671000
 		"shields" 2300
 		"hull" 900
@@ -107,6 +109,7 @@ ship "Korath World-Ship"
 	sprite "ship/world-ship a"
 	attributes
 		category "Heavy Freighter"
+		tags alien korath freighter
 		cost 27690000
 		shields 47000
 		hull 34000
@@ -264,6 +267,7 @@ ship "Kar Ik Vot 349"
 	sprite "ship/kar ik vot 349"
 	attributes
 		category "Heavy Warship"
+		tags alien korath "kor sestor" warship
 		"cost" 41280000
 		"shields" 57200
 		"hull" 65400
@@ -418,6 +422,7 @@ ship "Tek Far 71 - Lek"
 	sprite "ship/tek far 71 lek"
 	attributes
 		category "Medium Warship"
+		tags alien korath "kor sestor" warship
 		"cost" 22870000
 		"shields" 25400
 		"hull" 29500
@@ -510,6 +515,7 @@ ship "Tek Far 78 - Osk"
 	sprite "ship/tek far 78 osk"
 	attributes
 		category "Medium Warship"
+		tags alien korath "kor sestor" warship
 		"cost" 25630000
 		"shields" 27600
 		"hull" 34100
@@ -601,6 +607,7 @@ ship "Tek Far 109"
 	sprite "ship/tek far 109"
 	attributes
 		category "Medium Warship"
+		tags alien korath "kor sestor" warship
 		"cost" 18290000
 		"shields" 17900
 		"hull" 15800
@@ -671,6 +678,7 @@ ship "Met Par Tek 53"
 	sprite "ship/met par tek 53"
 	attributes
 		category "Light Warship"
+		tags alien korath "kor sestor" warship
 		"cost" 14480000
 		"shields" 15100
 		"hull" 22200
@@ -759,6 +767,7 @@ ship "Far Lek 14"
 	sprite "ship/far lek 14"
 	attributes
 		category "Drone"
+		tags alien korath "kor sestor"
 		"cost" 573000
 		"shields" 900
 		"hull" 1600
@@ -798,6 +807,7 @@ ship "Far Osk 27"
 	sprite "ship/far osk 27"
 	attributes
 		category "Fighter"
+		tags alien korath "kor sestor"
 		"cost" 761000
 		"shields" 1500
 		"hull" 2400
@@ -837,6 +847,7 @@ ship "Model 8"
 	sprite "ship/model 8"
 	attributes
 		category "Interceptor"
+		tags alien korath "kor mereti"
 		"cost" 3725000
 		"shields" 5450
 		"hull" 3320
@@ -882,6 +893,7 @@ ship "Model 16"
 	sprite "ship/model 16"
 	attributes
 		category "Light Warship"
+		tags alien korath "kor mereti" warship
 		"cost" 8449000
 		"shields" 15700
 		"hull" 9800
@@ -934,6 +946,7 @@ ship "Model 32"
 	sprite "ship/model 32"
 	attributes
 		category "Light Warship"
+		tags alien korath "kor mereti" warship
 		"cost" 12765000
 		"shields" 27900
 		"hull" 13400
@@ -987,6 +1000,7 @@ ship "Model 64"
 	sprite "ship/model 64"
 	attributes
 		category "Medium Warship"
+		tags alien korath "kor mereti" warship
 		"cost" 19552000
 		"shields" 41700
 		"hull" 18000
@@ -1041,6 +1055,7 @@ ship "Model 128"
 	sprite "ship/model 128"
 	attributes
 		category "Medium Warship"
+		tags alien korath "kor mereti" warship
 		"cost" 24073000
 		"shields" 57000
 		"hull" 23100
@@ -1097,6 +1112,7 @@ ship "Model 256"
 	sprite "ship/model 256"
 	attributes
 		category "Heavy Warship"
+		tags alien korath "kor mereti" warship
 		"cost" 34920000
 		"shields" 71700
 		"hull" 28700
@@ -1154,6 +1170,7 @@ ship "Model 512"
 	sprite "ship/model 512"
 	attributes
 		category "Heavy Warship"
+		tags alien korath "kor mereti" warship
 		"cost" 40375000
 		"shields" 86400
 		"hull" 34200

--- a/data/korath weapons.txt
+++ b/data/korath weapons.txt
@@ -10,6 +10,7 @@
 
 outfit "Korath Grab-Strike"
 	category "Turrets"
+	tags alien korath weapon
 	cost 821000
 	thumbnail "outfit/grab-strike"
 	"mass" 52
@@ -55,6 +56,7 @@ effect "grab-strike impact"
 
 outfit "Korath Banisher"
 	category "Turrets"
+	tags alien korath weapon
 	cost 943000
 	thumbnail "outfit/banisher"
 	"mass" 41
@@ -91,6 +93,7 @@ effect "banisher impact"
 
 outfit "Korath Warder"
 	category "Turrets"
+	tags alien korath anti-missile
 	cost 845000
 	thumbnail "outfit/warder"
 	"mass" 28
@@ -121,6 +124,7 @@ effect "korath warder"
 
 outfit "Korath Fire-Lance"
 	category "Guns"
+	tags alien korath weapon
 	cost 697000
 	thumbnail "outfit/fire-lance"
 	"mass" 22
@@ -155,6 +159,7 @@ effect "fire-lance impact"
 
 outfit "Korath Repeater"
 	category "Guns"
+	tags alien korath "kor sestor" weapon
 	cost 306000
 	thumbnail "outfit/repeater"
 	"mass" 11
@@ -193,6 +198,7 @@ effect "repeater impact"
 
 outfit "Korath Repeater Turret"
 	category "Turrets"
+	tags alien korath "kor sestor" weapon
 	cost 874000
 	thumbnail "outfit/repeater turret"
 	"mass" 29
@@ -226,6 +232,7 @@ outfit "Korath Repeater Turret"
 
 outfit "Korath Piercer"
 	category "Ammunition"
+	tags alien korath "kor sestor"
 	cost 3500
 	thumbnail "outfit/piercer"
 	"mass" .3
@@ -234,6 +241,7 @@ outfit "Korath Piercer"
 
 outfit "Korath Piercer Rack"
 	category "Ammunition"
+	tags alien korath "kor sestor"
 	cost 56000
 	thumbnail "outfit/korath piercer storage"
 	"mass" 2.2
@@ -244,6 +252,7 @@ outfit "Korath Piercer Rack"
 
 outfit "Korath Piercer Launcher"
 	category "Secondary Weapons"
+	tags alien korath "kor sestor" weapon
 	cost 593000
 	thumbnail "outfit/piercer launcher"
 	"mass" 18
@@ -316,6 +325,7 @@ effect "piercer explosion"
 
 outfit "Korath Detainer"
 	category "Guns"
+	tags alien korath "kor sestor" weapon
 	cost 1340000
 	thumbnail "outfit/detainer"
 	"mass" 76
@@ -378,6 +388,7 @@ effect "detainer smoke"
 
 outfit "Korath Mine"
 	category "Ammunition"
+	tags alien korath "kor mereti"
 	cost 3500
 	thumbnail "outfit/korath mine"
 	"mass" .7
@@ -386,6 +397,7 @@ outfit "Korath Mine"
 
 outfit "Korath Mine Rack"
 	category "Ammunition"
+	tags alien korath "kor mereti"
 	cost 31500
 	thumbnail "outfit/korath mine storage"
 	"mass" 2.7
@@ -396,6 +408,7 @@ outfit "Korath Mine Rack"
 
 outfit "Korath Minelayer"
 	category "Secondary Weapons"
+	tags alien korath "kor mereti" weapon
 	cost 1073000
 	thumbnail "outfit/korath minelayer"
 	"mass" 36
@@ -476,6 +489,7 @@ effect "minelayer split"
 
 outfit "Korath Disruptor"
 	category "Turrets"
+	tags alien korath "kor mereti" weapon
 	cost 983000
 	thumbnail "outfit/disruptor"
 	"mass" 35
@@ -515,6 +529,7 @@ effect "disruptor impact"
 
 outfit "Korath Slicer"
 	category "Guns"
+	tags alien korath "kor mereti" weapon
 	cost 832000
 	thumbnail "outfit/slicer"
 	"mass" 46
@@ -540,6 +555,7 @@ outfit "Korath Slicer"
 
 outfit "Korath Slicer Turret"
 	category "Turrets"
+	tags alien korath "kor mereti" weapon
 	cost 1473000
 	thumbnail "outfit/slicer turret"
 	"mass" 59

--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -12,6 +12,7 @@ ship "Marauder Arrow"
 	sprite "ship/marrows"
 	attributes
 		category "Interceptor"
+		tags human syndicate marauder transport
 		"cost" 1320000
 		"shields" 2300
 		"hull" 500
@@ -62,6 +63,7 @@ ship "Marauder Arrow" "Marauder Arrow (Engines)"
 	sprite "ship/marrowe"
 	attributes
 		category "Interceptor"
+		tags human syndicate marauder transport
 		"cost" 1320000
 		"shields" 2300
 		"hull" 500
@@ -106,6 +108,7 @@ ship "Marauder Arrow" "Marauder Arrow (Weapons)"
 	sprite "ship/marroww"
 	attributes
 		category "Interceptor"
+		tags human syndicate marauder transport
 		"cost" 1320000
 		"shields" 2300
 		"hull" 500
@@ -153,6 +156,7 @@ ship "Marauder Bounder"
 	sprite "ship/mbounders"
 	attributes
 		category "Interceptor"
+		tags human megaparsec marauder transport
 		"cost" 1250000
 		"shields" 2500
 		"hull" 700
@@ -206,6 +210,7 @@ ship "Marauder Bounder" "Marauder Bounder (Engines)"
 	sprite "ship/mboundere"
 	attributes
 		category "Interceptor"
+		tags human megaparsec marauder transport
 		"cost" 1250000
 		"shields" 2500
 		"hull" 700
@@ -253,6 +258,7 @@ ship "Marauder Bounder" "Marauder Bounder (Weapons)"
 	sprite "ship/mbounderw"
 	attributes
 		category "Interceptor"
+		tags human megaparsec marauder transport
 		"cost" 1250000
 		"shields" 2500
 		"hull" 700
@@ -301,6 +307,7 @@ ship "Marauder Falcon"
 	sprite "ship/mfalcons"
 	attributes
 		category "Heavy Warship"
+		tags human tarazed marauder warship
 		"cost" 13900000
 		"shields" 14100
 		"hull" 4100
@@ -359,6 +366,7 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 	sprite "ship/mfalcone"
 	attributes
 		category "Heavy Warship"
+		tags human tarazed marauder warship
 		"cost" 13900000
 		"shields" 14100
 		"hull" 4100
@@ -415,6 +423,7 @@ ship "Marauder Falcon" "Marauder Falcon (Weapons)"
 	sprite "ship/mfalconw"
 	attributes
 		category "Heavy Warship"
+		tags human tarazed marauder warship
 		"cost" 13900000
 		"shields" 14100
 		"hull" 4100
@@ -470,6 +479,7 @@ ship "Marauder Firebird"
 	sprite "ship/mfirebirds"
 	attributes
 		category "Medium Warship"
+		tags human betelgeuse marauder warship
 		"cost" 4100000
 		"shields" 7000
 		"hull" 3000
@@ -526,6 +536,7 @@ ship "Marauder Firebird" "Marauder Firebird (Engines)"
 	sprite "ship/mfirebirde"
 	attributes
 		category "Medium Warship"
+		tags human betelgeuse marauder warship
 		"cost" 4100000
 		"shields" 7000
 		"hull" 3000
@@ -580,6 +591,7 @@ ship "Marauder Firebird" "Marauder Firebird (Weapons)"
 	sprite "ship/mfirebirdw"
 	attributes
 		category "Medium Warship"
+		tags human betelgeuse marauder warship
 		"cost" 4100000
 		"shields" 7000
 		"hull" 3000
@@ -632,6 +644,7 @@ ship "Marauder Fury"
 	sprite "ship/mfury"
 	attributes
 		category "Interceptor"
+		tags human southbound marauder
 		"cost" 750000
 		"shields" 3000
 		"hull" 600
@@ -687,6 +700,7 @@ ship "Marauder Leviathan"
 	sprite "ship/mleviathans"
 	attributes
 		category "Heavy Warship"
+		tags human betelgeuse marauder warship
 		"cost" 10800000
 		"shields" 16000
 		"hull" 5500
@@ -747,6 +761,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 	sprite "ship/mleviathane"
 	attributes
 		category "Heavy Warship"
+		tags human betelgeuse marauder warship
 		"cost" 10800000
 		"shields" 16000
 		"hull" 5500
@@ -801,6 +816,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
 	sprite "ship/mleviathanw"
 	attributes
 		category "Heavy Warship"
+		tags human betelgeuse marauder warship
 		"cost" 10800000
 		"shields" 16000
 		"hull" 5500
@@ -855,6 +871,7 @@ ship "Marauder Manta"
 	sprite "ship/mmantas"
 	attributes
 		category "Medium Warship"
+		tags human megaparsec marauder warship
 		"cost" 3740000
 		"shields" 6500
 		"hull" 1750
@@ -913,6 +930,7 @@ ship "Marauder Manta" "Marauder Manta (Engines)"
 	sprite "ship/mmantae"
 	attributes
 		category "Medium Warship"
+		tags human megaparsec marauder warship
 		"cost" 3740000
 		"shields" 6500
 		"hull" 1750
@@ -965,6 +983,7 @@ ship "Marauder Manta" "Marauder Manta (Weapons)"
 	sprite "ship/mmantaw"
 	attributes
 		category "Medium Warship"
+		tags human megaparsec marauder warship
 		"cost" 3740000
 		"shields" 6500
 		"hull" 1750
@@ -1019,6 +1038,7 @@ ship "Marauder Quicksilver"
 	sprite "ship/mquicksilvers"
 	attributes
 		category "Light Warship"
+		tags human megaparsec marauder warship
 		"cost" 1200000
 		"shields" 3500
 		"hull" 900
@@ -1069,6 +1089,7 @@ ship "Marauder Quicksilver" "Marauder Quicksilver (Engines)"
 	sprite "ship/mquicksilvere"
 	attributes
 		category "Light Warship"
+		tags human megaparsec marauder warship
 		"cost" 1200000
 		"shields" 3500
 		"hull" 900
@@ -1115,6 +1136,7 @@ ship "Marauder Quicksilver" "Marauder Quicksilver (Weapons)"
 	sprite "ship/mquicksilverw"
 	attributes
 		category "Light Warship"
+		tags human megaparsec marauder warship
 		"cost" 1200000
 		"shields" 3500
 		"hull" 900
@@ -1161,6 +1183,7 @@ ship "Marauder Raven"
 	sprite "ship/mravens"
 	attributes
 		category "Light Warship"
+		tags human lionheart marauder warship
 		"cost" 2250000
 		"shields" 5200
 		"hull" 1600
@@ -1215,6 +1238,7 @@ ship "Marauder Raven" "Marauder Raven (Engines)"
 	sprite "ship/mravene"
 	attributes
 		category "Light Warship"
+		tags human lionheart marauder warship
 		"cost" 2250000
 		"shields" 5200
 		"hull" 1600
@@ -1264,6 +1288,7 @@ ship "Marauder Raven" "Marauder Raven (Weapons)"
 	sprite "ship/mravenw"
 	attributes
 		category "Light Warship"
+		tags human lionheart marauder warship
 		"cost" 2250000
 		"shields" 5200
 		"hull" 1600
@@ -1313,6 +1338,7 @@ ship "Marauder Splinter"
 	sprite "ship/msplinters"
 	attributes
 		category "Medium Warship"
+		tags human megaparsec marauder warship
 		"cost" 3400000
 		"shields" 5700
 		"hull" 1950
@@ -1367,6 +1393,7 @@ ship "Marauder Splinter" "Marauder Splinter (Engines)"
 	sprite "ship/msplintere"
 	attributes
 		category "Medium Warship"
+		tags human megaparsec marauder warship
 		"cost" 3400000
 		"shields" 5700
 		"hull" 1950
@@ -1419,6 +1446,7 @@ ship "Marauder Splinter" "Marauder Splinter (Weapons)"
 	sprite "ship/msplinterw"
 	attributes
 		category "Medium Warship"
+		tags human megaparsec marauder warship
 		"cost" 3400000
 		"shields" 5700
 		"hull" 1950

--- a/data/nanobots.txt
+++ b/data/nanobots.txt
@@ -10,6 +10,7 @@
 
 ship "Nanobot"
 	attributes
+		tags alien korath
 		"hull" 100
 		"automaton" 1
 		"mass" 10
@@ -33,6 +34,7 @@ ship "Nanobot"
 
 outfit "Nano Strike"
 	category "Guns"
+	tags alien korath weapon
 	thumbnail "outfit/unknown"
 	"mass" 5
 	"outfit space" -5

--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -10,6 +10,7 @@
 
 outfit "Cooling Ducts"
 	plural "Cooling Ducts"
+	tags human
 	category "Systems"
 	cost 10000
 	thumbnail "outfit/cooling ducts"
@@ -20,6 +21,7 @@ outfit "Cooling Ducts"
 
 outfit "Water Coolant System"
 	category "Systems"
+	tags human
 	cost 25000
 	thumbnail "outfit/water cooling"
 	"mass" 10
@@ -29,6 +31,7 @@ outfit "Water Coolant System"
 
 outfit "Liquid Nitrogen Cooler"
 	category "Systems"
+	tags human
 	cost 60000
 	thumbnail "outfit/liquid nitrogen"
 	"mass" 20
@@ -38,6 +41,7 @@ outfit "Liquid Nitrogen Cooler"
 
 outfit "Liquid Helium Cooler"
 	category "Systems"
+	tags human
 	cost 150000
 	thumbnail "outfit/liquid helium"
 	"mass" 40
@@ -48,6 +52,7 @@ outfit "Liquid Helium Cooler"
 
 outfit "D14-RN Shield Generator"
 	category "Systems"
+	tags human
 	cost 20000
 	thumbnail "outfit/tiny shield"
 	"mass" 15
@@ -58,6 +63,7 @@ outfit "D14-RN Shield Generator"
 
 outfit "D23-QP Shield Generator"
 	category "Systems"
+	tags human
 	cost 35000
 	thumbnail "outfit/small shield"
 	"mass" 22
@@ -68,6 +74,7 @@ outfit "D23-QP Shield Generator"
 
 outfit "D41-HY Shield Generator"
 	category "Systems"
+	tags human
 	cost 65000
 	thumbnail "outfit/medium shield"
 	"mass" 30
@@ -78,6 +85,7 @@ outfit "D41-HY Shield Generator"
 
 outfit "D67-TM Shield Generator"
 	category "Systems"
+	tags human
 	cost 120000
 	thumbnail "outfit/large shield"
 	"mass" 45
@@ -88,6 +96,7 @@ outfit "D67-TM Shield Generator"
 
 outfit "D94-YV Shield Generator"
 	category "Systems"
+	tags human
 	cost 200000
 	thumbnail "outfit/huge shield"
 	"mass" 60
@@ -98,6 +107,7 @@ outfit "D94-YV Shield Generator"
 
 outfit "S-270 Regenerator"
 	category "Systems"
+	tags human syndicate
 	cost 220000
 	thumbnail "outfit/small regenerator"
 	"mass" 12
@@ -110,6 +120,7 @@ outfit "S-270 Regenerator"
 
 outfit "S-970 Regenerator"
 	category "Systems"
+	tags human syndicate
 	cost 800000
 	thumbnail "outfit/large regenerator"
 	"mass" 37
@@ -123,6 +134,7 @@ outfit "S-970 Regenerator"
 
 outfit "Small Radar Jammer"
 	category "Systems"
+	tags human
 	cost 70000
 	thumbnail "outfit/small radar jammer"
 	"mass" 4
@@ -132,6 +144,7 @@ outfit "Small Radar Jammer"
 
 outfit "Large Radar Jammer"
 	category "Systems"
+	tags human
 	cost 490000
 	thumbnail "outfit/large radar jammer"
 	"mass" 14
@@ -142,6 +155,7 @@ outfit "Large Radar Jammer"
 
 outfit "Ramscoop"
 	category "Systems"
+	tags human
 	cost 60000
 	thumbnail "outfit/ramscoop"
 	"mass" 10
@@ -152,6 +166,7 @@ outfit "Ramscoop"
 
 outfit "Catalytic Ramscoop"
 	category "Systems"
+	tags human "deep sky"
 	cost 320000
 	thumbnail "outfit/catalytic ramscoop"
 	"mass" 16
@@ -173,6 +188,7 @@ outfit "Hyperdrive"
 
 outfit "Scram Drive"
 	category "Systems"
+	tags human
 	cost 90000
 	thumbnail "outfit/hyperdrive"
 	"mass" 30
@@ -184,6 +200,7 @@ outfit "Scram Drive"
 
 outfit "Jump Drive"
 	category "Systems"
+	tags alien
 	cost 1000000
 	thumbnail "outfit/jump drive"
 	"mass" 20
@@ -196,6 +213,7 @@ outfit "Jump Drive"
 
 outfit "Cargo Scanner"
 	category "Systems"
+	tags human
 	cost 8000
 	thumbnail "outfit/cargo scanner"
 	"mass" 1
@@ -206,6 +224,7 @@ outfit "Cargo Scanner"
 
 outfit "Outfit Scanner"
 	category "Systems"
+	tags human
 	cost 24000
 	thumbnail "outfit/outfit scanner"
 	"mass" 2
@@ -216,6 +235,7 @@ outfit "Outfit Scanner"
 
 outfit "Surveillance Pod"
 	category "Systems"
+	tags human
 	cost 42000
 	thumbnail "outfit/outfit scanner"
 	"mass" 5
@@ -230,6 +250,7 @@ outfit "Surveillance Pod"
 
 outfit "Cloaking Device"
 	category "Systems"
+	tags alien "cloak"
 	cost 1200000
 	"mass" 10
 	"outfit space" -10
@@ -293,6 +314,7 @@ outfit "Fuel Pod"
 
 outfit "Interference Plating"
 	category "Systems"
+	tags human pirate
 	cost 50000
 	thumbnail "outfit/interference plating"
 	"mass" 4
@@ -300,10 +322,9 @@ outfit "Interference Plating"
 	"scan interference" .5
 	description "If you're in the habit of carrying illegal cargo or outfits, this plating increases the odds that a scan of your ship will fail to detect it. The more of these you install, the better your chances of evading detection. They won't keep anyone from noticing if you're flying an unlicensed ship, however."
 
-
-
 outfit "Laser Rifle"
 	category "Hand to Hand"
+	tags human
 	cost 8000
 	thumbnail "outfit/laser rifle"
 	"capture attack" .6
@@ -313,6 +334,7 @@ outfit "Laser Rifle"
 
 outfit "Fragmentation Grenades"
 	plural "Fragmentation Grenades"
+	tags human pirate
 	category "Hand to Hand"
 	cost 17000
 	thumbnail "outfit/fragmentation grenades"
@@ -323,6 +345,7 @@ outfit "Fragmentation Grenades"
 
 outfit "Security Station"
 	category "Hand to Hand"
+	tags human
 	cost 42000
 	thumbnail "outfit/security station"
 	"mass" 2
@@ -333,6 +356,7 @@ outfit "Security Station"
 
 outfit "Nerve Gas"
 	plural "Nerve Gas"
+	tags human pirate
 	category "Hand to Hand"
 	cost 75000
 	thumbnail "outfit/nerve gas"

--- a/data/power.txt
+++ b/data/power.txt
@@ -10,6 +10,7 @@
 
 outfit "Supercapacitor"
 	category "Power"
+	tags human
 	cost 25000
 	thumbnail "outfit/supercapacitor"
 	"mass" 2
@@ -19,6 +20,7 @@ outfit "Supercapacitor"
 
 outfit "LP036a Battery Pack"
 	category "Power"
+	tags human
 	cost 12000
 	thumbnail "outfit/tiny battery"
 	"mass" 10
@@ -28,6 +30,7 @@ outfit "LP036a Battery Pack"
 
 outfit "LP072a Battery Pack"
 	category "Power"
+	tags human
 	cost 30000
 	thumbnail "outfit/small battery"
 	"mass" 20
@@ -37,6 +40,7 @@ outfit "LP072a Battery Pack"
 
 outfit "LP144a Battery Pack"
 	category "Power"
+	tags human
 	cost 67000
 	thumbnail "outfit/medium battery"
 	"mass" 40
@@ -46,6 +50,7 @@ outfit "LP144a Battery Pack"
 
 outfit "LP288a Battery Pack"
 	category "Power"
+	tags human
 	cost 150000
 	thumbnail "outfit/large battery"
 	"mass" 80
@@ -55,6 +60,7 @@ outfit "LP288a Battery Pack"
 
 outfit "LP576a Battery Pack"
 	category "Power"
+	tags human
 	cost 380000
 	thumbnail "outfit/huge battery"
 	"mass" 160
@@ -65,6 +71,7 @@ outfit "LP576a Battery Pack"
 
 outfit "KP-6 Photovoltaic Panel"
 	category "Power"
+	tags human
 	cost 10000
 	thumbnail "outfit/tiny photovoltaic"
 	"mass" 3
@@ -74,6 +81,7 @@ outfit "KP-6 Photovoltaic Panel"
 
 outfit "KP-6 Photovoltaic Array"
 	category "Power"
+	tags human
 	cost 90000
 	thumbnail "outfit/small photovoltaic"
 	"mass" 24
@@ -84,6 +92,7 @@ outfit "KP-6 Photovoltaic Array"
 
 outfit "nGVF-AA Fuel Cell"
 	category "Power"
+	tags human
 	cost 40000
 	thumbnail "outfit/tiny fuel cell"
 	"mass" 20
@@ -94,6 +103,7 @@ outfit "nGVF-AA Fuel Cell"
 
 outfit "nGVF-BB Fuel Cell"
 	category "Power"
+	tags human
 	cost 47000
 	thumbnail "outfit/small fuel cell"
 	"mass" 30
@@ -104,6 +114,7 @@ outfit "nGVF-BB Fuel Cell"
 
 outfit "nGVF-CC Fuel Cell"
 	category "Power"
+	tags human
 	cost 72000
 	thumbnail "outfit/medium fuel cell"
 	"mass" 40
@@ -114,6 +125,7 @@ outfit "nGVF-CC Fuel Cell"
 
 outfit "nGVF-DD Fuel Cell"
 	category "Power"
+	tags human
 	cost 118000
 	thumbnail "outfit/large fuel cell"
 	"mass" 60
@@ -124,6 +136,7 @@ outfit "nGVF-DD Fuel Cell"
 
 outfit "nGVF-EE Fuel Cell"
 	category "Power"
+	tags human
 	cost 177000
 	thumbnail "outfit/huge fuel cell"
 	"mass" 80
@@ -135,6 +148,7 @@ outfit "nGVF-EE Fuel Cell"
 
 outfit "RT-I Radiothermal"
 	category "Power"
+	tags human
 	cost 300000
 	thumbnail "outfit/small radiothermal"
 	"mass" 45
@@ -145,6 +159,7 @@ outfit "RT-I Radiothermal"
 
 outfit "S3 Thermionic"
 	category "Power"
+	tags human
 	cost 360000
 	thumbnail "outfit/small thermionic"
 	"mass" 55
@@ -155,6 +170,7 @@ outfit "S3 Thermionic"
 
 outfit "NT-200 Nucleovoltaic"
 	category "Power"
+	tags human
 	cost 570000
 	thumbnail "outfit/small nucleovoltaic"
 	"mass" 65
@@ -166,6 +182,7 @@ outfit "NT-200 Nucleovoltaic"
 
 outfit "Dwarf Core"
 	category "Power"
+	tags human "deep sky"
 	cost 800000
 	thumbnail "outfit/dwarf core"
 	"mass" 36
@@ -176,6 +193,7 @@ outfit "Dwarf Core"
 
 outfit "Fission Reactor"
 	category "Power"
+	tags human
 	cost 1500000
 	thumbnail "outfit/fission"
 	"mass" 65
@@ -186,6 +204,7 @@ outfit "Fission Reactor"
 
 outfit "Breeder Reactor"
 	category "Power"
+	tags human "delta v"
 	cost 2500000
 	thumbnail "outfit/breeder"
 	"mass" 80
@@ -196,6 +215,7 @@ outfit "Breeder Reactor"
 
 outfit "Fusion Reactor"
 	category "Power"
+	tags human
 	cost 5000000
 	thumbnail "outfit/fusion"
 	"mass" 100
@@ -206,6 +226,7 @@ outfit "Fusion Reactor"
 
 outfit "Armageddon Core"
 	category "Power"
+	tags human
 	cost 9000000
 	thumbnail "outfit/core"
 	"mass" 130
@@ -216,6 +237,7 @@ outfit "Armageddon Core"
 
 outfit "Stack Core"
 	category "Power"
+	tags human "delta v"
 	cost 4500000
 	thumbnail "outfit/stack core"
 	"mass" 140

--- a/data/pug.txt
+++ b/data/pug.txt
@@ -20,6 +20,7 @@ effect "seeker impact"
 
 outfit "Pug Zapper"
 	category "Guns"
+	tags alien pug weapon
 	cost 290000
 	thumbnail "outfit/pug zapper"
 	"mass" 25
@@ -45,6 +46,7 @@ outfit "Pug Zapper"
 
 outfit "Pug Zapper Turret"
 	category "Turrets"
+	tags alien pug weapon
 	cost 860000
 	thumbnail "outfit/pug zapper turret"
 	"mass" 66
@@ -73,6 +75,7 @@ outfit "Pug Zapper Turret"
 
 outfit "Pug Seeker"
 	category "Guns"
+	tags alien pug weapon
 	cost 540000
 	thumbnail "outfit/pug seeker"
 	"mass" 34
@@ -105,6 +108,7 @@ outfit "Pug Seeker"
 
 outfit "Pug Anti-Missile"
 	category "Turrets"
+	tags alien pug anti-missile
 	cost 350000
 	thumbnail "outfit/pug anti-missile"
 	"mass" 41
@@ -125,6 +129,7 @@ outfit "Pug Anti-Missile"
 
 outfit "Tier 3 Anti-Missile"
 	category "Turrets"
+	tags alien pug "tier 3 pug" anti-missile
 	cost 12000000
 	thumbnail "outfit/unknown"
 	"mass" 67
@@ -159,6 +164,7 @@ effect "tier 3 anti-missile die"
 
 outfit "Pug Gridfire Turret"
 	category "Turrets"
+	tags alien pug "tier 3 pug" weapon
 	cost 24000000
 	thumbnail "outfit/unknown"
 	"mass" 83
@@ -209,6 +215,7 @@ effect "gridfire cloud"
 
 outfit "Pug Akfar Thruster"
 	category "Engines"
+	tags alien pug
 	"cost" 608000
 	thumbnail "outfit/pug akfar thruster"
 	"mass" 43
@@ -224,6 +231,7 @@ outfit "Pug Akfar Thruster"
 
 outfit "Pug Akfar Steering"
 	category "Engines"
+	tags alien pug
 	"cost" 472000
 	thumbnail "outfit/pug akfar steering"
 	"mass" 33
@@ -236,6 +244,7 @@ outfit "Pug Akfar Steering"
 
 outfit "Pug Cormet Thruster"
 	category "Engines"
+	tags alien pug
 	"cost" 1050000
 	thumbnail "outfit/pug cormet thruster"
 	"mass" 60
@@ -251,6 +260,7 @@ outfit "Pug Cormet Thruster"
 
 outfit "Pug Cormet Steering"
 	category "Engines"
+	tags alien pug
 	"cost" 880000
 	thumbnail "outfit/pug cormet steering"
 	"mass" 46
@@ -263,6 +273,7 @@ outfit "Pug Cormet Steering"
 
 outfit "Pug Lohmar Thruster"
 	category "Engines"
+	tags alien pug
 	"cost" 1740000
 	thumbnail "outfit/pug lohmar thruster"
 	"mass" 84
@@ -278,6 +289,7 @@ outfit "Pug Lohmar Thruster"
 
 outfit "Pug Lohmar Steering"
 	category "Engines"
+	tags alien pug
 	"cost" 1580000
 	thumbnail "outfit/pug lohmar steering"
 	"mass" 64
@@ -292,6 +304,7 @@ outfit "Pug Lohmar Steering"
 outfit "Pug Biodefenses"
 	plural "Pug Biodefenses"
 	category "Hand to Hand"
+	tags alien pug
 	cost 100000
 	thumbnail "outfit/pug biodefenses"
 	"capture defense" 250
@@ -303,6 +316,7 @@ ship "Pug Zibruka"
 	sprite "ship/pug zibruka"
 	attributes
 		category "Light Warship"
+		tags alien pug warship
 		"cost" 1900000
 		"shields" 4000
 		"hull" 1000
@@ -347,6 +361,7 @@ ship "Pug Enfolta"
 	sprite "ship/pug enfolta"
 	attributes
 		category "Medium Warship"
+		tags alien pug warship
 		"cost" 6300000
 		"shields" 6800
 		"hull" 1700
@@ -396,6 +411,7 @@ ship "Pug Maboro"
 	sprite "ship/pug maboro"
 	attributes
 		category "Heavy Warship"
+		tags alien pug warship
 		"cost" 9500000
 		"shields" 12600
 		"hull" 2700
@@ -447,6 +463,7 @@ ship "Pug Arfecta"
 	sprite "ship/pug arfecta"
 	attributes
 		category "Medium Warship"
+		tags alien pug "tier 3 pug" warship
 		"cost" 90000000
 		"shields" 98000
 		"hull" 80000

--- a/data/quarg outfits.txt
+++ b/data/quarg outfits.txt
@@ -10,6 +10,7 @@
 
 outfit "Nanotech Battery"
 	plural "Nanotech Batteries"
+	tags alien quarg
 	category "Power"
 	cost 3000000
 	thumbnail "outfit/unknown"
@@ -19,6 +20,7 @@ outfit "Nanotech Battery"
 
 outfit "Antimatter Core"
 	category "Power"
+	tags alien quarg
 	cost 100000000
 	thumbnail "outfit/unknown"
 	"mass" 80
@@ -29,6 +31,7 @@ outfit "Antimatter Core"
 
 outfit "Quarg Skylance"
 	category "Turrets"
+	tags alien quarg weapon
 	cost 18000000
 	thumbnail "outfit/unknown"
 	"mass" 60
@@ -62,6 +65,7 @@ effect "skylance impact"
 
 outfit "Quarg Anti-Missile"
 	category "Turrets"
+	tags alien quarg anti-missile
 	cost 6000000
 	thumbnail "outfit/unknown"
 	"mass" 40
@@ -88,6 +92,7 @@ effect "quarg anti-missile"
 outfit "Intrusion Countermeasures"
 	plural "Intrusion Countermeasures"
 	category "Hand to Hand"
+	tags alien quarg
 	thumbnail "outfit/unknown"
 	"capture defense" 60
 	"unplunderable" 1
@@ -95,6 +100,7 @@ outfit "Intrusion Countermeasures"
 
 outfit "Medium Graviton Thruster"
 	category "Engines"
+	tags alien quarg
 	"cost" 20000000
 	thumbnail "outfit/unknown"
 	"mass" 70
@@ -107,6 +113,7 @@ outfit "Medium Graviton Thruster"
 
 outfit "Medium Graviton Steering"
 	category "Engines"
+	tags alien quarg
 	"cost" 16000000
 	thumbnail "outfit/unknown"
 	"mass" 50
@@ -118,6 +125,7 @@ outfit "Medium Graviton Steering"
 
 outfit "Quantum Shield Generator"
 	category "Systems"
+	tags alien quarg
 	cost 30000000
 	thumbnail "outfit/unknown"
 	"mass" 120

--- a/data/quarg ships.txt
+++ b/data/quarg ships.txt
@@ -12,6 +12,7 @@ ship "Quarg Skylark"
 	sprite "ship/skylark"
 	attributes
 		category "Heavy Warship"
+		tags alien quarg warship
 		"cost" 5900000
 		"shields" 120000
 		"hull" 70000
@@ -59,6 +60,7 @@ ship "Quarg Wardragon"
 	sprite "ship/wardragon"
 	attributes
 		category "Heavy Warship"
+		tags alien quarg warship
 		"cost" 5900000
 		"shields" 160000
 		"hull" 50000

--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -14,6 +14,7 @@ outfit "Inhibitor Cannon"
 	category "Guns"
 	licenses
 		Remnant
+	tags alien remnant weapon
 	cost 471000
 	thumbnail "outfit/unknown"
 	"mass" 16
@@ -56,6 +57,7 @@ outfit "Thrasher Cannon"
 	category "Guns"
 	licenses
 		Remnant
+	tags alien remnant
 	cost 218000
 	thumbnail "outfit/unknown"
 	"mass" 10
@@ -94,6 +96,7 @@ outfit "Thrasher Turret"
 	category "Turrets"
 	licenses
 		Remnant
+	tags alien remnant
 	cost 980000
 	thumbnail "outfit/unknown"
 	"mass" 49
@@ -124,6 +127,7 @@ outfit "Point Defense Turret"
 	category "Turrets"
 	licenses
 		Remnant
+	tags alien anti-missile
 	cost 1120000
 	thumbnail "outfit/unknown"
 	"mass" 33
@@ -171,6 +175,7 @@ outfit "Crystal Capacitor"
 	category "Power"
 	licenses
 		Remnant
+	tags alien remnant
 	cost 280000
 	thumbnail "outfit/unknown"
 	"mass" 12
@@ -183,6 +188,7 @@ outfit "Millennium Cell"
 	category "Power"
 	licenses
 		Remnant
+	tags alien remnant
 	cost 767000
 	thumbnail "outfit/unknown"
 	"mass" 29
@@ -195,6 +201,7 @@ outfit "Epoch Cell"
 	category "Power"
 	licenses
 		Remnant
+	tags alien remnant
 	cost 3060000
 	thumbnail "outfit/unknown"
 	"mass" 98
@@ -207,6 +214,7 @@ outfit "Aeon Cell"
 	category "Power"
 	licenses
 		Remnant
+	tags alien remnant
 	cost 6600000
 	thumbnail "outfit/unknown"
 	"mass" 160
@@ -220,6 +228,7 @@ outfit "Thermoelectric Cooler"
 	category "Systems"
 	licenses
 		Remnant
+	tags alien remnant
 	cost 160000
 	thumbnail "outfit/unknown"
 	"mass" 4
@@ -233,6 +242,8 @@ outfit "Emergency Ramscoop"
 	licenses
 		Remnant
 	cost 72000
+	tags alien remnant ramscoop
+	cost "72000"
 	thumbnail "outfit/unknown"
 	"mass" 4
 	"outfit space" -4
@@ -259,6 +270,7 @@ outfit "Crucible-Class Thruster"
 	category "Engines"
 	licenses
 		Remnant
+	tags alien remnant
 	"cost" 200000
 	thumbnail "outfit/unknown"
 	"mass" 20
@@ -276,6 +288,7 @@ outfit "Forge-Class Thruster"
 	category "Engines"
 	licenses
 		Remnant
+	tags alien remnant
 	"cost" 441000
 	thumbnail "outfit/unknown"
 	"mass" 39
@@ -293,6 +306,7 @@ outfit "Smelter-Class Thruster"
 	category "Engines"
 	licenses
 		Remnant
+	tags alien remnant
 	"cost" 984000
 	thumbnail "outfit/unknown"
 	"mass" 76
@@ -311,6 +325,7 @@ outfit "Crucible-Class Steering"
 	category "Engines"
 	licenses
 		Remnant
+	tags alien remnant
 	"cost" 172000
 	thumbnail "outfit/unknown"
 	"mass" 14
@@ -325,6 +340,7 @@ outfit "Forge-Class Steering"
 	category "Engines"
 	licenses
 		Remnant
+	tags alien remnant
 	"cost" 393000
 	thumbnail "outfit/unknown"
 	"mass" 28
@@ -339,6 +355,7 @@ outfit "Smelter-Class Steering"
 	category "Engines"
 	licenses
 		Remnant
+	tags alien remnant
 	"cost" 880000
 	thumbnail "outfit/unknown"
 	"mass" 55

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -14,6 +14,7 @@ ship "Starling"
 		category "Light Warship"
 		licenses
 			Remnant
+		tags alien remnant warship cloak
 		cost 8800000
 		"shields" 8800
 		"hull" 4900
@@ -137,6 +138,7 @@ ship "Albatross"
 		category "Heavy Warship"
 		licenses
 			Remnant
+		tags alien remnant warship
 		cost 20000000
 		"shields" 34200
 		"hull" 12600

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -12,6 +12,7 @@ ship "Aerie"
 	sprite "ship/aerie"
 	attributes
 		category "Medium Warship"
+		tags human lionheart warship
 		"cost" 3500000
 		"shields" 5700
 		"hull" 1900
@@ -67,6 +68,7 @@ ship "Argosy"
 	sprite "ship/argosy"
 	attributes
 		category "Light Freighter"
+		tags human southbound freighter
 		"cost" 1960000
 		"shields" 4200
 		"hull" 2600
@@ -121,6 +123,7 @@ ship "Arrow"
 	sprite "ship/arrow"
 	attributes
 		category "Transport"
+		tags human syndicate transport
 		"cost" 1200000
 		"shields" 2000
 		"hull" 400
@@ -170,6 +173,7 @@ ship "Bactrian"
 	sprite "ship/bactrian"
 	attributes
 		category "Heavy Warship"
+		tags human lionheart warship
 		"cost" 17600000
 		"shields" 17500
 		"hull" 8600
@@ -234,6 +238,7 @@ ship "Barb"
 	sprite "ship/barb"
 	attributes
 		category "Fighter"
+		tags human syndicate
 		"cost" 50000
 		"shields" 800
 		"hull" 200
@@ -312,6 +317,7 @@ ship "Bastion"
 	sprite "ship/bastion"
 	attributes
 		category "Medium Warship"
+		tags human southbound warship
 		"cost" 3560000
 		"shields" 6700
 		"hull" 4200
@@ -368,6 +374,7 @@ ship "Behemoth"
 	sprite "ship/behemoth"
 	attributes
 		category "Heavy Freighter"
+		tags human betelgeuse freighter
 		"cost" 10800000
 		"shields" 7600
 		"hull" 6300
@@ -422,6 +429,7 @@ ship "Berserker"
 	sprite "ship/berserker"
 	attributes
 		category "Interceptor"
+		tags human betelgeuse
 		"cost" 520000
 		"shields" 2200
 		"hull" 500
@@ -468,6 +476,7 @@ ship "Blackbird"
 	sprite "ship/blackbird"
 	attributes
 		category "Transport"
+		tags human tarazed transport
 		"cost" 2230000
 		"shields" 4400
 		"hull" 900
@@ -515,6 +524,7 @@ ship "Bounder"
 	sprite "ship/bounder"
 	attributes
 		category "Transport"
+		tags human megaparsec transport
 		"cost" 1140000
 		"shields" 2200
 		"hull" 700
@@ -560,6 +570,7 @@ ship "Boxwing"
 	sprite "ship/boxwing"
 	attributes
 		category "Fighter"
+		tags human
 		cost 369000
 		"shields" 400
 		"hull" 800
@@ -594,6 +605,7 @@ ship "Bulk Freighter"
 	sprite "ship/bulk freighter"
 	attributes
 		category "Heavy Freighter"
+		tags human syndicate freighter
 		"cost" 9400000
 		"shields" 4000
 		"hull" 7600
@@ -651,6 +663,7 @@ ship "Carrier"
 		licenses
 			Navy
 			Carrier
+		tags human "republic navy" warship
 		"cost" 15200000
 		"shields" 21400
 		"hull" 8300
@@ -724,6 +737,7 @@ ship "Class C Freighter"
 	sprite "ship/bulk freighter"
 	attributes
 		category "Heavy Warship"
+		tags human syndicate warship
 		"cost" 11400000
 		"shields" 13500
 		"hull" 7600
@@ -785,6 +799,7 @@ ship "Clipper"
 	sprite "ship/clipper"
 	attributes
 		category "Light Freighter"
+		tags human southbound freighter
 		"cost" 900000
 		"shields" 2700
 		"hull" 800
@@ -836,6 +851,7 @@ ship "Combat Drone"
 		category "Drone"
 		licenses
 			Navy
+		tags human "republic navy"
 		"cost" 83000
 		"hull" 700
 		"mass" 20
@@ -871,6 +887,7 @@ ship "Corvette"
 	sprite "ship/corvette"
 	attributes
 		category "Medium Warship"
+		tags human lionheart warship
 		"cost" 4400000
 		"shields" 6100
 		"hull" 1200
@@ -926,6 +943,7 @@ ship "Cruiser"
 		licenses
 			Navy
 			Cruiser
+		tags human "republic navy" warship
 		"cost" 11200000
 		"shields" 19600
 		"hull" 6400
@@ -991,6 +1009,7 @@ ship "Dagger"
 	sprite "ship/dagger"
 	attributes
 		category "Fighter"
+		tags human lionheart
 		"cost" 129000
 		"shields" 1000
 		"hull" 300
@@ -1030,6 +1049,7 @@ ship "Dreadnought"
 	sprite "ship/dreadnought"
 	attributes
 		category "Heavy Warship"
+		tags human southbound warship
 		"cost" 11900000
 		"shields" 18100
 		"hull" 7300
@@ -1089,6 +1109,7 @@ ship "Falcon"
 	sprite "ship/falcon"
 	attributes
 		category "Heavy Warship"
+		tags human tarazed warship
 		"cost" 10900000
 		"shields" 12800
 		"hull" 3700
@@ -1147,6 +1168,7 @@ ship "Finch"
 	sprite "ship/finch"
 	attributes
 		category "Fighter"
+		tags human tarazed
 		"cost" 126000
 		"shields" 1100
 		"hull" 200
@@ -1187,6 +1209,7 @@ ship "Firebird"
 	sprite "ship/firebird"
 	attributes
 		category "Medium Warship"
+		tags human betelgeuse warship
 		"cost" 3700000
 		"shields" 6400
 		"hull" 2800
@@ -1239,6 +1262,7 @@ ship "Flivver"
 	sprite "ship/flivver"
 	attributes
 		category "Transport"
+		tags human lionheart transport
 		"cost" 180000
 		"shields" 1400
 		"hull" 200
@@ -1283,6 +1307,7 @@ ship "Freighter"
 	sprite "ship/freighter"
 	attributes
 		category "Light Freighter"
+		tags human syndicate freighter
 		"cost" 730000
 		"shields" 2000
 		"hull" 2000
@@ -1333,6 +1358,7 @@ ship "Frigate"
 		category "Medium Warship"
 		licenses
 			Navy
+		tags human "republic navy" warship
 		"cost" 5200000
 		"shields" 8000
 		"hull" 2500
@@ -1388,6 +1414,7 @@ ship "Fury"
 	sprite "ship/fury"
 	attributes
 		category "Interceptor"
+		tags human southbound
 		"cost" 490000
 		"shields" 2000
 		"hull" 400
@@ -1435,6 +1462,7 @@ ship "Gunboat"
 		category "Light Warship"
 		licenses
 			Navy
+		tags human "republic navy" warship
 		"cost" 3200000
 		"shields" 5800
 		"hull" 1400
@@ -1484,6 +1512,7 @@ ship "Hauler"
 	sprite "ship/hauler i"
 	attributes
 		category "Light Freighter"
+		tags human freighter
 		"cost" 1430000
 		"shields" 2500
 		"hull" 3700
@@ -1538,6 +1567,7 @@ ship "Hauler II"
 	sprite "ship/hauler ii"
 	attributes
 		category "Heavy Freighter"
+		tags human freighter
 		"cost" 2340000
 		"shields" 2900
 		"hull" 5200
@@ -1592,6 +1622,7 @@ ship "Hauler III"
 	sprite "ship/hauler iii"
 	attributes
 		category "Heavy Freighter"
+		tags human freighter
 		"cost" 3260000
 		"shields" 3300
 		"hull" 6700
@@ -1646,6 +1677,7 @@ ship "Hawk"
 	sprite "ship/hawk"
 	attributes
 		category "Interceptor"
+		tags human tarazed
 		"cost" 670000
 		"shields" 2500
 		"hull" 500
@@ -1690,6 +1722,7 @@ ship "Headhunter"
 	sprite "ship/headhunter"
 	attributes
 		category "Light Warship"
+		tags human lionheart warship
 		"cost" 1850000
 		"shields" 3800
 		"hull" 700
@@ -1737,6 +1770,7 @@ ship "Heavy Shuttle"
 	sprite "ship/heavy shuttle"
 	attributes
 		category "Transport"
+		tags human betelgeuse transport
 		"cost" 320000
 		"shields" 700
 		"hull" 700
@@ -1778,6 +1812,7 @@ ship "Lance"
 	sprite "ship/lance"
 	attributes
 		category "Fighter"
+		tags human "republic navy"
 		"cost" 93000
 		"shields" 800
 		"hull" 400
@@ -1818,6 +1853,7 @@ ship "Leviathan"
 	sprite "ship/leviathan"
 	attributes
 		category "Heavy Warship"
+		tags human betelgeuse warship
 		"cost" 9800000
 		"shields" 14400
 		"hull" 5000
@@ -1872,6 +1908,7 @@ ship "Manta"
 	sprite "ship/manta"
 	attributes
 		category "Medium Warship"
+		tags human megaparsec warship
 		"cost" 3400000
 		"shields" 5900
 		"hull" 1500
@@ -1924,6 +1961,7 @@ ship "Modified Argosy"
 	sprite "ship/modified argosy"
 	attributes
 		category "Light Warship"
+		tags human southbound pirate warship
 		"cost" 1960000
 		"shields" 4800
 		"hull" 1900
@@ -1976,6 +2014,7 @@ ship "Mule"
 	sprite "ship/mule"
 	attributes
 		category "Medium Warship"
+		tags human lionheart warship
 		"cost" 4580000
 		"shields" 5400
 		"hull" 4400
@@ -2031,6 +2070,7 @@ ship "Nest"
 	sprite "ship/nest"
 	attributes
 		category "Medium Warship"
+		tags human southbound warship
 		"cost" 2500000
 		"shields" 2500
 		"hull" 3700
@@ -2087,6 +2127,7 @@ ship "Osprey"
 	sprite "ship/osprey"
 	attributes
 		category "Medium Warship"
+		tags human tarazed warship
 		"cost" 4400000
 		"shields" 7200
 		"hull" 1600
@@ -2140,6 +2181,7 @@ ship "Protector"
 	sprite "ship/protector"
 	attributes
 		category "Heavy Warship"
+		tags human syndicate warship
 		"cost" 5500000
 		"shields" 9500
 		"hull" 6500
@@ -2196,6 +2238,7 @@ ship "Quicksilver"
 	sprite "ship/quicksilver"
 	attributes
 		category "Light Warship"
+		tags human megaparsec warship
 		"cost" 1090000
 		"shields" 3000
 		"hull" 800
@@ -2243,6 +2286,7 @@ ship "Rainmaker"
 		category "Light Warship"
 		licenses
 			Navy
+		tags human "republic navy" warship
 		"cost" 1580000
 		"shields" 3500
 		"hull" 1200
@@ -2294,6 +2338,7 @@ ship "Raven"
 	sprite "ship/raven"
 	attributes
 		category "Light Warship"
+		tags human lionheart warship
 		"cost" 1800000
 		"shields" 4700
 		"hull" 1400
@@ -2342,6 +2387,7 @@ ship "Roost"
 	sprite "ship/roost"
 	attributes
 		category "Medium Warship"
+		tags human southbound warship
 		"cost" 3000000
 		"shields" 2900
 		"hull" 5200
@@ -2400,6 +2446,7 @@ ship "Scout"
 	sprite "ship/scout"
 	attributes
 		category "Transport"
+		tags human lionheart transport
 		"cost" 850000
 		"shields" 1200
 		"hull" 400
@@ -2452,6 +2499,7 @@ ship "Shuttle"
 		"random start frame"
 	attributes
 		category "Transport"
+		tags human betelgeuse transport
 		"cost" 180000
 		"shields" 500
 		"hull" 600
@@ -2495,6 +2543,7 @@ ship "Skein"
 		category "Medium Warship"
 		licenses
 			"Militia Carrier"
+		tags human southbounds warship
 		"cost" 3500000
 		"shields" 3300
 		"hull" 6700
@@ -2555,6 +2604,7 @@ ship "Sparrow"
 	sprite "ship/sparrow"
 	attributes
 		category "Interceptor"
+		tags human tarazed
 		"cost" 225000
 		"shields" 1200
 		"hull" 300
@@ -2599,6 +2649,7 @@ ship "Splinter"
 	sprite "ship/splinter"
 	attributes
 		category "Medium Warship"
+		tags human megaparsec warship
 		"cost" 3100000
 		"shields" 5200
 		"hull" 1700
@@ -2651,6 +2702,7 @@ ship "Star Barge"
 	sprite "ship/star barge"
 	attributes
 		category "Light Freighter"
+		tags human syndicate freighter
 		"cost" 210000
 		"shields" 600
 		"hull" 1000
@@ -2692,6 +2744,7 @@ ship "Star Queen"
 	sprite "ship/star queen"
 	attributes
 		category "Transport"
+		tags human transport
 		"cost" 5500000
 		"shields" 4100
 		"hull" 2200
@@ -2746,6 +2799,7 @@ ship "Surveillance Drone"
 		category "Drone"
 		licenses
 			Navy
+		tags human "republic navy"
 		"cost" 50000
 		"hull" 300
 		"mass" 15
@@ -2778,6 +2832,7 @@ ship "Vanguard"
 	sprite "ship/vanguard"
 	attributes
 		category "Heavy Warship"
+		tags human syndicate warship
 		"cost" 7200000
 		"shields" 9800
 		"hull" 6000
@@ -2832,6 +2887,7 @@ ship "Wasp"
 	sprite "ship/wasp"
 	attributes
 		category "Interceptor"
+		tags human syndicate
 		"cost" 400000
 		"shields" 1500
 		"hull" 500

--- a/data/wanderer outfits.txt
+++ b/data/wanderer outfits.txt
@@ -12,6 +12,7 @@ outfit "Sunbeam"
 	category "Guns"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer weapon
 	cost 1390000
 	thumbnail "outfit/sunbeam"
 	"mass" 34
@@ -49,6 +50,7 @@ outfit "Sunbeam Turret"
 	category "Turrets"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer weapons
 	cost 1970000
 	thumbnail "outfit/sunbeam turret"
 	"mass" 46
@@ -80,6 +82,7 @@ outfit "Dual Sunbeam Turret"
 	category "Turrets"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer weapon
 	cost 3720000
 	thumbnail "outfit/dual sunbeam turret"
 	"mass" 83
@@ -111,6 +114,7 @@ outfit "Wanderer Anti-Missile"
 	category "Turrets"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer anti-missile
 	cost 850000
 	thumbnail "outfit/wanderer anti-missile"
 	"mass" 24
@@ -141,6 +145,7 @@ outfit "Thunderhead Launcher"
 	category "Secondary Weapons"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer weapon
 	cost 450000
 	thumbnail "outfit/thunderhead launcher"
 	"mass" 14
@@ -177,6 +182,7 @@ outfit "Thunderhead Launcher"
 
 outfit "Thunderhead Missile"
 	category "Ammunition"
+	tags alien wanderer
 	cost 1800
 	thumbnail "outfit/thunderhead"
 	mass .3
@@ -208,6 +214,7 @@ outfit "Thunderhead Storage Array"
 	category "Ammunition"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	cost 36000
 	thumbnail "outfit/thunderhead storage"
 	"mass" 2
@@ -220,6 +227,7 @@ outfit "Small Biochemical Cell"
 	category "Power"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	cost 230000
 	thumbnail "outfit/small biochemical"
 	"mass" 17
@@ -233,6 +241,7 @@ outfit "Large Biochemical Cell"
 	category "Power"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	cost 940000
 	thumbnail "outfit/large biochemical"
 	"mass" 63
@@ -246,6 +255,7 @@ outfit "Red Sun Reactor"
 	category "Power"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	cost 3800000
 	thumbnail "outfit/red sun"
 	"mass" 47
@@ -259,6 +269,7 @@ outfit "Yellow Sun Reactor"
 	category "Power"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	cost 7500000
 	thumbnail "outfit/yellow sun"
 	"mass" 82
@@ -272,6 +283,7 @@ outfit "White Sun Reactor"
 	category "Power"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	cost 13900000
 	thumbnail "outfit/white sun"
 	"mass" 127
@@ -285,6 +297,7 @@ outfit "Blue Sun Reactor"
 	category "Power"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	cost 21500000
 	thumbnail "outfit/blue sun"
 	"mass" 152
@@ -299,6 +312,7 @@ outfit "Bright Cloud Shielding"
 	category "Systems"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	cost 220000
 	thumbnail "outfit/bright cloud"
 	"mass" 19
@@ -311,6 +325,7 @@ outfit "Dark Storm Shielding"
 	category "Systems"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	cost 800000
 	thumbnail "outfit/dark storm"
 	"mass" 41
@@ -323,6 +338,7 @@ outfit "Wanderer Ramscoop"
 	category "Systems"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer ramscoop
 	cost 460000
 	thumbnail "outfit/wanderer ramscoop"
 	"mass" 7
@@ -335,6 +351,7 @@ outfit "Wanderer Heat Sink"
 	category "Systems"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	cost 94000
 	thumbnail "outfit/wanderer heat sink"
 	"mass" 12
@@ -347,6 +364,7 @@ outfit "Type 1 Radiant Thruster"
 	category "Engines"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	"cost" 135000
 	thumbnail "outfit/tiny radiant thruster"
 	"mass" 12
@@ -365,6 +383,7 @@ outfit "Type 2 Radiant Thruster"
 	category "Engines"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	"cost" 390000
 	thumbnail "outfit/small radiant thruster"
 	"mass" 27
@@ -383,6 +402,7 @@ outfit "Type 3 Radiant Thruster"
 	category "Engines"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	"cost" 750000
 	thumbnail "outfit/medium radiant thruster"
 	"mass" 42
@@ -401,6 +421,7 @@ outfit "Type 4 Radiant Thruster"
 	category "Engines"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	"cost" 1370000
 	thumbnail "outfit/large radiant thruster"
 	"mass" 65
@@ -419,6 +440,7 @@ outfit "Type 1 Radiant Steering"
 	category "Engines"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	"cost" 115000
 	thumbnail "outfit/tiny radiant steering"
 	"mass" 9
@@ -434,6 +456,7 @@ outfit "Type 2 Radiant Steering"
 	category "Engines"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	"cost" 325000
 	thumbnail "outfit/small radiant steering"
 	"mass" 20
@@ -449,6 +472,7 @@ outfit "Type 3 Radiant Steering"
 	category "Engines"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	"cost" 590000
 	thumbnail "outfit/medium radiant steering"
 	"mass" 30
@@ -464,6 +488,7 @@ outfit "Type 4 Radiant Steering"
 	category "Engines"
 	licenses
 		"Wanderer Outfits"
+	tags alien wanderer
 	"cost" 1100000
 	thumbnail "outfit/large radiant steering"
 	"mass" 47

--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -14,6 +14,7 @@ ship "Earth Shaper"
 		category "Light Freighter"
 		licenses
 			Wanderer
+		tags alien wanderer freighter "atmosphere scan"
 		"cost" 500000
 		"hull" 3300
 		"mass" 30
@@ -51,6 +52,7 @@ ship "Flycatcher"
 		category "Drone"
 		licenses
 			Wanderer
+		tags alien wanderer
 		"cost" 830000
 		"hull" 4700
 		"mass" 40
@@ -88,6 +90,7 @@ ship "Summer Leaf"
 		category "Light Warship"
 		licenses
 			Wanderer
+		tags alien wanderer warship
 		"cost" 9500000
 		"shields" 14400
 		"hull" 6700
@@ -135,6 +138,7 @@ ship "Autumn Leaf"
 		category "Light Warship"
 		licenses
 			Wanderer
+		tags alien wanderer warship
 		"cost" 12500000
 		"shields" 18700
 		"hull" 7400
@@ -184,6 +188,7 @@ ship "Strong Wind"
 		category "Medium Warship"
 		licenses
 			"Wanderer Military"
+		tags alien wanderer warship
 		"cost" 16100000
 		"shields" 28500
 		"hull" 19600
@@ -237,6 +242,7 @@ ship "Tempest"
 		category "Medium Warship"
 		licenses
 			"Wanderer Military"
+		tags alien wanderer warship
 		"cost" 19700000
 		"shields" 42100
 		"hull" 25900
@@ -333,6 +339,7 @@ ship "Derecho"
 		category "Heavy Warship"
 		licenses
 			"Wanderer Military"
+		tags alien wanderer warship
 		"cost" 30500000
 		"shields" 53200
 		"hull" 32700
@@ -433,6 +440,7 @@ ship "Hurricane"
 		category "Heavy Warship"
 		licenses
 			"Wanderer Military"
+		tags alien wanderer warship
 		"cost" 39100000
 		"shields" 72400
 		"hull" 46500
@@ -542,6 +550,7 @@ ship "Deep River"
 		category "Heavy Freighter"
 		licenses
 			Wanderer
+		tags alien wanderer freighter
 		"cost" 18300000
 		"shields" 17600
 		"hull" 47500
@@ -684,6 +693,7 @@ ship "Deep River Transport"
 		category "Heavy Freighter"
 		licenses
 			Wanderer
+		tags alien wanderer transport
 		"cost" 18300000
 		"shields" 17600
 		"hull" 47500

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -10,6 +10,7 @@
 
 outfit "Energy Blaster"
 	category "Guns"
+	tags human weapon
 	cost 16000
 	thumbnail "outfit/blaster"
 	"mass" 5
@@ -32,6 +33,7 @@ outfit "Energy Blaster"
 
 outfit "Modified Blaster"
 	category "Guns"
+	tags human weapon
 	cost 35000
 	thumbnail "outfit/mod blaster"
 	"mass" 6
@@ -54,6 +56,7 @@ outfit "Modified Blaster"
 
 outfit "Blaster Turret"
 	category "Turrets"
+	tags human weapon
 	cost 100000
 	thumbnail "outfit/blaster turret"
 	"mass" 15
@@ -80,6 +83,7 @@ outfit "Blaster Turret"
 
 outfit "Modified Blaster Turret"
 	category "Turrets"
+	tags human weapon
 	cost 170000
 	thumbnail "outfit/mod blaster turret"
 	"mass" 18
@@ -106,6 +110,7 @@ outfit "Modified Blaster Turret"
 
 outfit "Quad Blaster Turret"
 	category "Turrets"
+	tags human weapon
 	cost 230000
 	thumbnail "outfit/quad blaster turret"
 	"mass" 25
@@ -132,6 +137,7 @@ outfit "Quad Blaster Turret"
 
 outfit "Beam Laser"
 	category "Guns"
+	tags human weapon
 	cost 29000
 	thumbnail "outfit/laser"
 	"mass" 8
@@ -155,6 +161,7 @@ outfit "Beam Laser"
 
 outfit "Heavy Laser"
 	category "Guns"
+	tags human weapon
 	cost 60000
 	thumbnail "outfit/heavy laser"
 	"mass" 15
@@ -178,6 +185,7 @@ outfit "Heavy Laser"
 
 outfit "Electron Beam"
 	category "Guns"
+	tags human weapon "deep sky"
 	cost 170000
 	thumbnail "outfit/electron beam"
 	"mass" 21
@@ -201,6 +209,7 @@ outfit "Electron Beam"
 
 outfit "Laser Turret"
 	category "Turrets"
+	tags human weapon
 	cost 140000
 	thumbnail "outfit/laser turret"
 	"mass" 22
@@ -228,6 +237,7 @@ outfit "Laser Turret"
 
 outfit "Heavy Laser Turret"
 	category "Turrets"
+	tags human weapon
 	cost 320000
 	thumbnail "outfit/heavy laser turret"
 	"mass" 40
@@ -255,6 +265,7 @@ outfit "Heavy Laser Turret"
 
 outfit "Electron Turret"
 	category "Turrets"
+	tags human weapon "deep sky"
 	cost 720000
 	thumbnail "outfit/electron turret"
 	"mass" 54
@@ -282,6 +293,7 @@ outfit "Electron Turret"
 
 outfit "Anti-Missile Turret"
 	category "Turrets"
+	tags human anti-missile lovelace
 	cost 60000
 	thumbnail "outfit/anti-missile"
 	"mass" 16
@@ -302,6 +314,7 @@ outfit "Anti-Missile Turret"
 
 outfit "Heavy Anti-Missile Turret"
 	category "Turrets"
+	tags human anti-missile lovelace
 	cost 150000
 	thumbnail "outfit/heavy anti-missile"
 	"mass" 30
@@ -322,6 +335,7 @@ outfit "Heavy Anti-Missile Turret"
 
 outfit "Particle Cannon"
 	category "Guns"
+	tags human weapon
 	cost 220000
 	thumbnail "outfit/particle cannon"
 	"mass" 30
@@ -346,6 +360,7 @@ outfit "Particle Cannon"
 
 outfit "Proton Gun"
 	category "Guns"
+	tags human syndicate weapon
 	cost 150000
 	thumbnail "outfit/proton gun"
 	"mass" 28
@@ -380,6 +395,7 @@ outfit "Proton Fragment"
 
 outfit "Plasma Cannon"
 	category "Guns"
+	tags human weapon
 	cost 190000
 	thumbnail "outfit/plasma cannon"
 	"mass" 25
@@ -405,6 +421,7 @@ outfit "Plasma Cannon"
 
 outfit "Plasma Turret"
 	category "Turrets"
+	tags human weapon
 	cost 520000
 	thumbnail "outfit/plasma turret"
 	"mass" 60
@@ -434,6 +451,7 @@ outfit "Plasma Turret"
 
 outfit "Flamethrower"
 	category "Secondary Weapons"
+	tags human weapon kraz
 	cost 190000
 	thumbnail "outfit/flamethrower"
 	"mass" 9
@@ -471,6 +489,7 @@ outfit "Flamethrower Projectile"
 
 outfit "Meteor Missile"
 	category "Ammunition"
+	tags human
 	cost 500
 	thumbnail "outfit/meteor"
 	"mass" .2
@@ -479,6 +498,7 @@ outfit "Meteor Missile"
 
 outfit "Meteor Missile Box"
 	plural "Meteor Missile Boxes"
+	tags human
 	category "Ammunition"
 	cost 9000
 	thumbnail "outfit/meteor storage"
@@ -490,6 +510,7 @@ outfit "Meteor Missile Box"
 
 outfit "Meteor Missile Launcher"
 	category "Secondary Weapons"
+	tags human weapon
 	cost 15000
 	thumbnail "outfit/meteor launcher"
 	"mass" 3
@@ -526,6 +547,7 @@ outfit "Meteor Missile Launcher"
 
 outfit "Sidewinder Missile"
 	category "Ammunition"
+	tags human lovelace
 	cost 800
 	thumbnail "outfit/sidewinder"
 	"mass" .2
@@ -534,6 +556,7 @@ outfit "Sidewinder Missile"
 
 outfit "Sidewinder Missile Rack"
 	category "Ammunition"
+	tags human lovelace
 	cost 20000
 	thumbnail "outfit/sidewinder storage"
 	"mass" 2
@@ -544,6 +567,7 @@ outfit "Sidewinder Missile Rack"
 
 outfit "Sidewinder Missile Launcher"
 	category "Secondary Weapons"
+	tags human weapon lovelace
 	cost 60000
 	thumbnail "outfit/sidewinder launcher"
 	"mass" 4
@@ -581,6 +605,7 @@ outfit "Sidewinder Missile Launcher"
 
 outfit "Javelin"
 	category "Ammunition"
+	tags human
 	cost 50
 	thumbnail "outfit/javelin"
 	"mass" .04
@@ -589,6 +614,7 @@ outfit "Javelin"
 
 outfit "Javelin Storage Crate"
 	category "Ammunition"
+	tags human
 	cost 5000
 	thumbnail "outfit/javelin storage"
 	"mass" 2
@@ -599,6 +625,7 @@ outfit "Javelin Storage Crate"
 
 outfit "Javelin Pod"
 	category "Secondary Weapons"
+	tags human weapon
 	cost 20000
 	thumbnail "outfit/javelin pod"
 	"mass" 4
@@ -626,6 +653,7 @@ outfit "Javelin Pod"
 
 outfit "Torpedo"
 	plural "Torpedoes"
+	tags human
 	category "Ammunition"
 	cost 1400
 	thumbnail "outfit/torpedo"
@@ -635,6 +663,7 @@ outfit "Torpedo"
 
 outfit "Torpedo Storage Rack"
 	category "Ammunition"
+	tags human
 	cost 21000
 	thumbnail "outfit/torpedo storage"
 	"mass" 3
@@ -645,6 +674,7 @@ outfit "Torpedo Storage Rack"
 
 outfit "Torpedo Launcher"
 	category "Secondary Weapons"
+	tags human weapon
 	cost 80000
 	thumbnail "outfit/torpedo launcher"
 	"mass" 13
@@ -682,6 +712,7 @@ outfit "Torpedo Launcher"
 outfit "Typhoon Torpedo"
 	plural "Typhoon Torpedoes"
 	category "Ammunition"
+	tags human "deep sky"
 	cost 2700
 	thumbnail "outfit/typhoon"
 	"mass" .5
@@ -690,6 +721,7 @@ outfit "Typhoon Torpedo"
 
 outfit "Typhoon Storage Tube"
 	category "Ammunition"
+	tags human "deep sky"
 	cost 40500
 	thumbnail "outfit/typhoon storage"
 	"mass" 2.5
@@ -700,6 +732,7 @@ outfit "Typhoon Storage Tube"
 
 outfit "Typhoon Launcher"
 	category "Secondary Weapons"
+	tags human "deep sky" weapon
 	cost 260000
 	thumbnail "outfit/typhoon launcher"
 	"mass" 20
@@ -736,6 +769,7 @@ outfit "Typhoon Launcher"
 
 outfit "Heavy Rocket"
 	category "Ammunition"
+	tags human
 	cost 2000
 	thumbnail "outfit/rocket"
 	"mass" .5
@@ -744,6 +778,7 @@ outfit "Heavy Rocket"
 
 outfit "Heavy Rocket Rack"
 	category "Ammunition"
+	tags human
 	cost 20000
 	thumbnail "outfit/rocket storage"
 	"mass" 2
@@ -754,6 +789,7 @@ outfit "Heavy Rocket Rack"
 
 outfit "Heavy Rocket Launcher"
 	category "Secondary Weapons"
+	tags human weapon
 	cost 40000
 	thumbnail "outfit/rocket launcher"
 	"mass" 10
@@ -787,6 +823,7 @@ outfit "Heavy Rocket Launcher"
 
 outfit "Nuclear Missile"
 	category "Secondary Weapons"
+	tags human weapon
 	cost 1000000
 	thumbnail "outfit/nuke"
 	"mass" 10
@@ -829,6 +866,7 @@ outfit "Nuclear Missile"
 outfit "Gatling Gun Ammo"
 	plural "Gatling Gun Ammo"
 	category "Ammunition"
+	tags human pirate
 	cost 2
 	thumbnail "outfit/bullet"
 	"mass" .002
@@ -838,6 +876,7 @@ outfit "Gatling Gun Ammo"
 outfit "Bullet Boxes"
 	plural "Bullet Boxes"
 	category "Ammunition"
+	tags human pirate
 	cost 3000
 	thumbnail "outfit/bullet storage"
 	"mass" 2
@@ -848,6 +887,7 @@ outfit "Bullet Boxes"
 
 outfit "Gatling Gun"
 	category "Secondary Weapons"
+	tags human pirate weapon
 	cost 20000
 	thumbnail "outfit/gat"
 	"mass" 2

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -83,6 +83,9 @@ void Outfit::Load(const DataNode &node)
 			for(const DataNode &grand : child)
 				licenses.push_back(grand.Token(0));
 		}
+		else if(child.Token(0) == "tags" && child.Size() >= 2)
+			for(int i = 1; i < child.Size(); ++i)
+				tags[child.Token(i)] = 1;
 		else if(child.Size() >= 2)
 			attributes[child.Token(0)] = child.Value(1);
 		else
@@ -155,6 +158,13 @@ const map<string, double> &Outfit::Attributes() const
 
 
 
+const map<string, double> &Outfit::Tags() const
+{
+	return tags;
+}
+
+
+
 // Determine whether the given number of instances of the given outfit can
 // be added to a ship with the attributes represented by this instance. If
 // not, return the maximum number that can be added.
@@ -184,6 +194,8 @@ void Outfit::Add(const Outfit &other, int count)
 		if(fabs(attributes[at.first]) < EPS)
 			attributes[at.first] = 0.;
 	}
+	for(const auto &it : other.tags)
+		tags[it.first] += it.second * count;
 	
 	for(const auto &it : other.flareSprites)
 	{
@@ -221,6 +233,13 @@ void Outfit::Reset(const string &attribute, double value)
 	attributes[attribute] = value;
 }
 
+
+// Copy tags from another outfit: used to set the base tags of one
+// ship to its base class values.
+void Outfit::CopyTags(const Outfit &base)
+{
+	tags = base.tags;
+}
 
 	
 // Get this outfit's engine flare sprite, if any.

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -56,6 +56,7 @@ public:
 	
 	double Get(const std::string &attribute) const;
 	const std::map<std::string, double> &Attributes() const;
+	const std::map<std::string, double> &Tags() const;
 	
 	// Determine whether the given number of instances of the given outfit can
 	// be added to a ship with the attributes represented by this instance. If
@@ -67,6 +68,9 @@ public:
 	// Modify this outfit's attributes.
 	void Add(const std::string &attribute, double value = 1.);
 	void Reset(const std::string &attribute, double value = 0.);
+	// Copy tags from another outfit: used to set the base tags of one
+	// ship to its base class values.
+	void CopyTags (const Outfit &base);
 	
 	// Get this outfit's engine flare sprites, if any.
 	const std::vector<std::pair<Body, int>> &FlareSprites() const;
@@ -88,6 +92,7 @@ private:
 	std::vector<std::string> licenses;
 	
 	std::map<std::string, double> attributes;
+	std::map<std::string, double> tags;
 	
 	std::vector<std::pair<Body, int>> flareSprites;
 	std::map<const Sound *, int> flareSounds;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2070,16 +2070,37 @@ void PlayerInfo::UpdateAutoConditions()
 	auto last = conditions.lower_bound("ships:!");
 	if(first != last)
 		conditions.erase(first, last);
+		
+	// Clear any existing tags: conditions.
+	first = conditions.lower_bound("tag: ");
+	last = conditions.lower_bound("tag:!");
+	if(first != last)
+		conditions.erase(first, last);
+	first = conditions.lower_bound("fleet tag: ");
+	last = conditions.lower_bound("fleet tag:!");
+	if(first != last)
+		conditions.erase(first, last);
+		
 	// Store special conditions for cargo and passenger space.
 	conditions["cargo space"] = 0;
 	conditions["passenger space"] = 0;
+	
+	// Set outfit tags for your flagship in conditions.
+	if(flagship)
+		for(const auto &at : flagship->Attributes().Tags())
+			conditions["tag: " + at.first] += at.second;	
+			
 	for(const shared_ptr<Ship> &ship : ships)
 		if(!ship->IsParked() && !ship->IsDisabled() && ship->GetSystem() == system)
 		{
 			conditions["cargo space"] += ship->Attributes().Get("cargo space");
 			conditions["passenger space"] += ship->Attributes().Get("bunks") - ship->RequiredCrew();
 			++conditions["ships: " + ship->Attributes().Category()];
-		}
+			
+			// Set outfit tags for your fleet in conditions.
+			for(const auto &at : ship->Attributes().Tags())
+					conditions["fleet tag: " + at.first] += at.second;
+		}		
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -251,6 +251,7 @@ void Ship::FinishLoading()
 		explosionWeapon = &model->BaseAttributes();
 		pluralModelName = model->pluralModelName;
 		noun = model->noun;
+		baseAttributes.CopyTags(model->baseAttributes);
 	}
 	
 	// If this ship has a base class, copy any attributes not defined here.


### PR DESCRIPTION
```
Any outfit or ship can have a series of tags, e.g. tags alien remnant
warship, and each tag is turned into auto-conditions that can be used
for mission logic. This can allow, for instance, a mission that triggers
if you have Quarg technology, a sponsorship deal if you use Lovelace
weapons, or a mission requiring you have the ability to scan cargo
(instead of specifically the Cargo Scanner outfit).
```

See issue #2481 from last month for the original idea and discussion. Worth mentioning: the first commit is all the code work, and second is actually adding tags.

_____________

I've added to every outfit and ship in the game a series of tags that look like this:

```
outfit "Surveillance Pod"
	category "Systems"
	tags "cargo scanner" "outfit scanner"
	cost 42000
```

You can condition missions on them like this:

```
	to offer
		has "tag: cargo scanner"

		# Alternatively:
		"tag: cargo scanner" >= 2
```

Here are the advantages:
1. Your mission requires a cargo scanner? `require outfit` doesn't let players use a Surveillance Pod – tags do.
2. You have a ship with an intrinsic attribute (like a cloak) that's messing up your mission requiring a cloaking device? Ships have these tags too.
3. You want to make a mission that notices you've stolen Quarg technology, or you're using Lovelace weapons? You can do this with tags.
4. You want a mission where you have to show up unarmed? Weapons are tagged as such, so you can.
5. Want to either look at what's on your flagship, or what's in your _fleet_? Got you covered: use "fleet tag: X" to count items tagged X in the player's entire fleet, and "tag: X" to just look at their flagship.
6. Want to offer a mission based on the number of warships in your fleet, not differentiating by Light/Medium/Heavy? I've added `warship` tags that will let you do this.