### PR TITLE
Ships can have a "no swizzle" property (#1357)

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -88,6 +88,8 @@ void Ship::Load(const DataNode &node)
 			pluralModelName = child.Token(1);
 		else if(child.Token(0) == "noun" && child.Size() >= 2)
 			noun = child.Token(1);
+		if(child.Token(0) == "no swizzle")
+			noSwizzle = true;
 		else if(child.Token(0) == "attributes")
 			baseAttributes.Load(child);
 		else if(child.Token(0) == "engine" && child.Size() >= 3)
@@ -259,6 +261,8 @@ void Ship::FinishLoading()
 	{
 		if(!GetSprite())
 			reinterpret_cast<Body &>(*this) = *base;
+		if(base->NoSwizzle())
+			noSwizzle = true;
 		if(baseAttributes.Attributes().empty())
 			baseAttributes = base->baseAttributes;
 		if(bays.empty() && !base->bays.empty())
@@ -387,6 +391,8 @@ void Ship::Save(DataWriter &out) const
 			out.Write("never disabled");
 		if(!isCapturable)
 			out.Write("uncapturable");
+		if(noSwizzle)
+			out.Write("no swizzle");
 		
 		out.Write("attributes");
 		out.BeginChild();
@@ -549,7 +555,7 @@ void Ship::Place(Point position, Point velocity, Angle angle)
 	forget = 1;
 	targetShip.reset();
 	shipToAssist.reset();
-	if(government)
+	if(government && !noSwizzle)
 		SetSwizzle(government->GetSwizzle());
 }
 
@@ -582,7 +588,7 @@ void Ship::SetPlanet(const Planet *planet)
 
 void Ship::SetGovernment(const Government *government)
 {
-	if(government)
+	if(government && !noSwizzle)
 		SetSwizzle(government->GetSwizzle());
 	this->government = government;
 }
@@ -1715,6 +1721,13 @@ bool Ship::IsReadyToJump() const
 	return true;
 }
 
+
+
+// Check if this ship should not be swizzled.
+bool Ship::NoSwizzle() const
+{
+	return noSwizzle;
+}
 
 
 // Check if the ship is thrusting. If so, the engine sound should be played.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -200,6 +200,8 @@ public:
 	bool IsUsingJumpDrive() const;
 	// Check if this ship is currently able to enter hyperspace to it target.
 	bool IsReadyToJump() const;
+	// Check if this ship should not be swizzled.
+	bool NoSwizzle() const;
 	
 	// Check if the ship is thrusting. If so, the engine sound should be played.
 	bool IsThrusting() const;
@@ -395,6 +397,7 @@ private:
 	bool neverDisabled = false;
 	bool isCapturable = true;
 	bool isInvisible = false;
+	bool noSwizzle = false;
 	double cloak = 0.;
 	double cloakDisruption = 0.;
 	// Cached values for figuring out when anti-missile is in range.

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -406,7 +406,7 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 	if(sprite)
 	{
 		float zoom = min(1.f, zoomSize / max(sprite->Width(), sprite->Height()));
-		int swizzle = GameData::PlayerGovernment()->GetSwizzle();
+		int swizzle = ship.NoSwizzle() ? 0 : GameData::PlayerGovernment()->GetSwizzle();
 		
 		SpriteShader::Draw(sprite, center, zoom, swizzle);
 	}


### PR DESCRIPTION
Fairly self-explanatory, and as I understand it it's on the list for 1.0.0 (#1357).

```
ship "Trin Piranha"
	sprite "ship/trin piranha"
	"no swizzle"
	attributes
		...
```

Anything in the game this should be added to? Archons and Void Sprites, obviously, but it won't ever matter for them. Wonder if it'd be wanted for Pug ships.

Ref. @Amazinite, @comnom. And @endless-sky, if you give me the go-ahead, I'll rework the commit to also include updating Ship::Load to use `key` instead of `child.Token(0)`. Just didn't want to confuse matters when asking you to first take a look at it, but I know you're making that shift when you come to update each Load function.