### PR TITLE
Capturing ships should affect reputation

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -384,6 +384,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			else if(!victim->Crew())
 			{
 				messages.push_back("You have succeeded in capturing this ship.");
+				victim->GetGovernment()->Offend(ShipEvent::CAPTURE, victim->RequiredCrew());
 				victim->WasCaptured(you);
 				if(!victim->JumpsRemaining() && you->CanRefuel(*victim))
 					you->TransferFuel(victim->JumpFuelMissing(), &*victim);


### PR DESCRIPTION
```
Previously, capturing a ship didn't actually change your reputation with
the ship's government. The event never went into the eventQueue, so
wasn't processed by AI::UpdateEvents and didn't flow into Offend. This
fix directly runs Offend when you capture a ship.
```

Credit to Farteous (on Discord) for noticing this when delving into how to capture a Heliarch Interdictor. It doesn't look like capturing has ever changed reputation, as far as we can see.

Disabling, boarding and capturing a Heliarch Interdictor (RequiredCrew = 44) should give you -79.2 reputation ([0.5+0.3+1](https://github.com/endless-sky/endless-sky/blob/master/source/Government.cpp#L36-L38) times [44](https://github.com/endless-sky/endless-sky/blob/master/source/AI.cpp#L223)), but we only saw -35.2, consistently.

Looking in the code, reputation changes are handled by `eventQueue` swapping into `events` in the next Engine::Step, and being run through AI::UpdateEvents. But capturing happens in BoardingPanel::KeyDown, and never goes into `eventQueue`.

I couldn't think of a nice way to get it into `eventQueue`. If doing that is the best solution, feel free to close this. What I've done here is directly run Offend just before WasCaptured. Has to be before, as otherwise you're Offending yourself.