### PR TITLE
Fleet list: hitting 'up' with no selection now goes to the end of the fleet

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -211,9 +211,13 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 			allSelected.insert(selectedIndex);
 		
 		// Update the scroll if necessary to keep the selected ship on screen.
-		int scrollDirection = ((selectedIndex >= scroll + LINES_PER_PAGE) - (selectedIndex < scroll));
-		if(Scroll((LINES_PER_PAGE - 2) * scrollDirection))
-			hoverIndex = -1;
+		int scrollDirection = 1;
+		while(scrollDirection && selectedIndex >= 0)
+		{
+			scrollDirection = ((selectedIndex >= scroll + LINES_PER_PAGE) - (selectedIndex < scroll));
+			if(Scroll((LINES_PER_PAGE - 2) * scrollDirection))
+				hoverIndex = -1;
+		}
 	}
 	else if(canEdit && key == 'P' && !allSelected.empty())
 	{


### PR DESCRIPTION
```
At present, if you open Player Info and hit 'up', the bottom ship is
selected but the page will scroll only one page down from the top. With
this tweak, it will now scroll down as many pages as needed.

Note that as before, between the first ship (index 0) and the last is
'index -1', which is no ships selected. The current view won't move when
you move to index -1.
```

Credit to Startome (on Discord) for bringing this up. To make sense of what I'm saying, it might be worth getting a fleet of 50+ ships, and then opening up Player Info and hitting 'up' a few times and try to work out what's going wrong.

This fixes that by paging down as many times as it has to. I looked at other ways to do it and got bogged down in complexity that I couldn't see being easy to maintain. If there's a better way to do this, go for it.