### PR TITLE
Truncate displayed ship names to prevent overflowing containers

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -524,7 +524,7 @@ void Engine::Step(bool isActive)
 		if(target->GetSystem() == player.GetSystem() && target->Cloaking() < 1.)
 			targetUnit = target->Facing().Unit();
 		info.SetSprite("target sprite", target->GetSprite(), targetUnit, target->GetFrameIndex(step));
-		info.SetString("target name", font.TruncateFront(target->Name(), 150));
+		info.SetString("target name", font.TruncateMiddle(target->Name(), 150));
 		info.SetString("target type", target->ModelName());
 		if(!target->GetGovernment())
 			info.SetString("target government", "No Government");

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -520,10 +520,11 @@ void Engine::Step(bool isActive)
 	}
 	else
 	{
+		const Font &font = FontSet::Get(14);
 		if(target->GetSystem() == player.GetSystem() && target->Cloaking() < 1.)
 			targetUnit = target->Facing().Unit();
 		info.SetSprite("target sprite", target->GetSprite(), targetUnit, target->GetFrameIndex(step));
-		info.SetString("target name", target->Name());
+		info.SetString("target name", font.TruncateFront(target->Name(), 150));
 		info.SetString("target type", target->ModelName());
 		if(!target->GetGovernment())
 			info.SetString("target government", "No Government");

--- a/source/Font.cpp
+++ b/source/Font.cpp
@@ -282,6 +282,46 @@ string Font::TruncateFront(const string &str, int width) const
 
 
 
+string Font::TruncateMiddle(const string &str, int width) const
+{
+	int prevChars = str.size();
+	int prevWidth = Width(str);
+	if(prevWidth <= width)
+		return str;
+	
+	width -= Width("...");
+	// As a safety against infinite loops (even though they won't be possible if
+	// this implementation is correct), limit the number of loops to the number
+	// of characters in the string.
+	for(size_t i = 0; i < str.length(); ++i)
+	{
+		// Loop until the previous width we tried was too long and this one is
+		// too short, or vice versa. Each time, the next string length we try is
+		// interpolated from the previous width.
+		int nextChars = (prevChars * width) / prevWidth;
+		bool isSame = (nextChars == prevChars);
+		bool prevWorks = (prevWidth <= width);
+		nextChars += (prevWorks ? isSame : -isSame);
+		
+		int leftChars = nextChars / 2;
+		int rightChars = nextChars - leftChars;
+		int nextWidth = Width(str.substr(0, leftChars) + str.substr(str.size() - rightChars));
+		bool nextWorks = (nextWidth <= width);
+		if(prevWorks != nextWorks && abs(nextChars - prevChars) == 1)
+		{
+			leftChars = min(prevChars,nextChars) / 2;
+			rightChars = min(prevChars, nextChars) - leftChars;
+			return str.substr(0, leftChars) + "..." + str.substr(str.size() - rightChars);
+		}
+		
+		prevChars = nextChars;
+		prevWidth = nextWidth;
+	}
+	return str;
+}
+
+
+
 int Font::Height() const
 {
 	return height;

--- a/source/Font.h
+++ b/source/Font.h
@@ -43,6 +43,7 @@ public:
 	int Width(const char *str, char after = ' ') const;
 	std::string Truncate(const std::string &str, int width) const;
 	std::string TruncateFront(const std::string &str, int width) const;
+	std::string TruncateMiddle(const std::string &str, int width) const;
 	
 	int Height() const;
 	

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "HailPanel.h"
 
 #include "DrawList.h"
+#include "Font.h"
 #include "FontSet.h"
 #include "Format.h"
 #include "GameData.h"
@@ -43,8 +44,9 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 	SetInterruptible(false);
 	
 	const Government *gov = ship->GetGovernment();
+	const Font &font = FontSet::Get(14);
 	if(!ship->Name().empty())
-		header = gov->GetName() + " " + ship->Noun() + " \"" + ship->Name() + "\":";
+		header = font.Truncate(gov->GetName() + " " + ship->Noun() + " \"" + ship->Name(), 330) + "\":";
 	else
 		header = ship->ModelName() + " (" + gov->GetName() + "): ";
 	// Drones are always unpiloted, so they never respond to hails.

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -46,7 +46,7 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 	const Government *gov = ship->GetGovernment();
 	const Font &font = FontSet::Get(14);
 	if(!ship->Name().empty())
-		header = font.Truncate(gov->GetName() + " " + ship->Noun() + " \"" + ship->Name(), 330) + "\":";
+		header = font.Truncate(gov->GetName() + " " + ship->Noun() + " \"" + ship->Name(), 328) + "\":";
 	else
 		header = ship->ModelName() + " (" + gov->GetName() + "): ";
 	// Drones are always unpiloted, so they never respond to hails.

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -451,6 +451,7 @@ void PlayerInfoPanel::DrawFleet(const Rectangle &bounds)
 	// Loop through all the player's ships.
 	int index = scroll;
 	auto sit = player.Ships().begin() + scroll;
+	const Font &font = FontSet::Get(14);
 	for( ; sit < player.Ships().end(); ++sit)
 	{
 		// Bail out if we've used out the whole drawing area.
@@ -472,7 +473,7 @@ void PlayerInfoPanel::DrawFleet(const Rectangle &bounds)
 		zones.emplace_back(table.GetCenterPoint(), table.GetRowSize(), index);
 		
 		// Indent the ship name if it is a fighter or drone.
-		table.Draw(ship.CanBeCarried() ? "    " + ship.Name() : ship.Name());
+		table.Draw(font.Truncate(ship.CanBeCarried() ? "    " + ship.Name() : ship.Name(), 219));
 		table.Draw(ship.ModelName());
 		
 		const System *system = ship.GetSystem();

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -473,7 +473,7 @@ void PlayerInfoPanel::DrawFleet(const Rectangle &bounds)
 		zones.emplace_back(table.GetCenterPoint(), table.GetRowSize(), index);
 		
 		// Indent the ship name if it is a fighter or drone.
-		table.Draw(font.Truncate(ship.CanBeCarried() ? "    " + ship.Name() : ship.Name(), 219));
+		table.Draw(font.TruncateMiddle(ship.CanBeCarried() ? "    " + ship.Name() : ship.Name(), 217));
 		table.Draw(ship.ModelName());
 		
 		const System *system = ship.GetSystem();

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -294,7 +294,7 @@ void ShipInfoPanel::DrawShipStats(const Rectangle &bounds)
 	
 	// Draw the ship information.
 	table.Draw("ship:", dim);
-	table.Draw(font.TruncateFront(ship.Name(), WIDTH - 45), bright);
+	table.Draw(font.TruncateMiddle(ship.Name(), WIDTH - 50), bright);
 	
 	table.Draw("model:", dim);
 	table.Draw(ship.ModelName(), bright);

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -37,6 +37,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 using namespace std;
 
+namespace {
+	static const double WIDTH = 250.;
+}
 
 
 ShipInfoPanel::ShipInfoPanel(PlayerInfo &player, int index)
@@ -273,24 +276,25 @@ void ShipInfoPanel::UpdateInfo()
 void ShipInfoPanel::DrawShipStats(const Rectangle &bounds)
 {
 	// Check that the specified area is big enough.
-	if(bounds.Width() < 250.)
+	if(bounds.Width() < WIDTH)
 		return;
 	
 	// Colors to draw with.
 	Color dim = *GameData::Colors().Get("medium");
 	Color bright = *GameData::Colors().Get("bright");
 	const Ship &ship = **shipIt;
+	const Font &font = FontSet::Get(14);
 	
 	// Table attributes.
 	Table table;
 	table.AddColumn(0, Table::LEFT);
-	table.AddColumn(230, Table::RIGHT);
-	table.SetUnderline(0, 230);
+	table.AddColumn(WIDTH - 20, Table::RIGHT);
+	table.SetUnderline(0, WIDTH - 20);
 	table.DrawAt(bounds.TopLeft() + Point(10., 8.));
 	
 	// Draw the ship information.
 	table.Draw("ship:", dim);
-	table.Draw(ship.Name(), bright);
+	table.Draw(font.TruncateFront(ship.Name(), WIDTH - 45), bright);
 	
 	table.Draw("model:", dim);
 	table.Draw(ship.ModelName(), bright);
@@ -303,7 +307,7 @@ void ShipInfoPanel::DrawShipStats(const Rectangle &bounds)
 void ShipInfoPanel::DrawOutfits(const Rectangle &bounds, Rectangle &cargoBounds)
 {
 	// Check that the specified area is big enough.
-	if(bounds.Width() < 250.)
+	if(bounds.Width() < WIDTH)
 		return;
 	
 	// Colors to draw with.
@@ -314,8 +318,8 @@ void ShipInfoPanel::DrawOutfits(const Rectangle &bounds, Rectangle &cargoBounds)
 	// Table attributes.
 	Table table;
 	table.AddColumn(0, Table::LEFT);
-	table.AddColumn(230, Table::RIGHT);
-	table.SetUnderline(0, 230);
+	table.AddColumn(WIDTH - 20, Table::RIGHT);
+	table.SetUnderline(0, WIDTH - 20);
 	Point start = bounds.TopLeft() + Point(10., 8.);
 	table.DrawAt(start);
 	
@@ -330,8 +334,8 @@ void ShipInfoPanel::DrawOutfits(const Rectangle &bounds, Rectangle &cargoBounds)
 		// plus at least one outfit.
 		if(table.GetRowBounds().Bottom() + 40. > bounds.Bottom())
 		{
-			start += Point(250., 0.);
-			if(start.X() + 230. > bounds.Right())
+			start += Point(WIDTH, 0.);
+			if(start.X() + WIDTH - 20 > bounds.Right())
 				break;
 			table.DrawAt(start);
 		}
@@ -344,8 +348,8 @@ void ShipInfoPanel::DrawOutfits(const Rectangle &bounds, Rectangle &cargoBounds)
 			// Check if we've gone below the bottom of the bounds.
 			if(table.GetRowBounds().Bottom() > bounds.Bottom())
 			{
-				start += Point(250., 0.);
-				if(start.X() + 230. > bounds.Right())
+				start += Point(WIDTH, 0.);
+				if(start.X() + WIDTH - 20 > bounds.Right())
 					break;
 				table.DrawAt(start);
 				table.Draw(category, bright);
@@ -385,7 +389,7 @@ void ShipInfoPanel::DrawWeapons(const Rectangle &bounds)
 	const Sprite *sprite = ship.GetSprite();
 	double scale = 0.;
 	if(sprite)
-		scale = min(240. / sprite->Width(), 240. / sprite->Height());
+		scale = min((WIDTH - 10) / sprite->Width(), (WIDTH - 10) / sprite->Height());
 	
 	// Figure out the left- and right-most hardpoints on the ship. If they are
 	// too far apart, the scale may need to be reduced.
@@ -497,8 +501,8 @@ void ShipInfoPanel::DrawCargo(const Rectangle &bounds)
 	const CargoHold &cargo = (player.Cargo().Used() ? player.Cargo() : ship.Cargo());
 	Table table;
 	table.AddColumn(0, Table::LEFT);
-	table.AddColumn(230, Table::RIGHT);
-	table.SetUnderline(-5, 235);
+	table.AddColumn(WIDTH - 20, Table::RIGHT);
+	table.SetUnderline(-5, WIDTH - 15);
 	table.DrawAt(bounds.TopLeft() + Point(10., 8.));
 	
 	double endY = bounds.Bottom() - 30. * (cargo.Passengers() != 0);

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -238,10 +238,12 @@ bool ShipyardPanel::CanSell() const
 void ShipyardPanel::Sell()
 {
 	static const int MAX_LIST = 20;
+	static const int DIALOG_MAX_WIDTH = 250;
 	
 	int count = playerShips.size();
 	int initialCount = count;
 	string message = "Sell ";
+	const Font &font = FontSet::Get(14);
 	if(count == 1)
 		message += playerShip->Name();
 	else if(count <= MAX_LIST)
@@ -255,7 +257,7 @@ void ShipyardPanel::Sell()
 		else
 		{
 			while(count-- > 1)
-				message += ",\n" + (*it++)->Name();
+				message += ",\n" + font.TruncateFront((*it++)->Name(), DIALOG_MAX_WIDTH - 33);
 			message += ",\nand ";
 		}
 		message += (*it)->Name();
@@ -263,8 +265,9 @@ void ShipyardPanel::Sell()
 	else
 	{
 		auto it = playerShips.begin();
-		for(int i = 0; i < MAX_LIST - 1; ++i)
-			message += (*it++)->Name() + ",\n";
+		message += (*it++)->Name() + ",\n";
+		for(int i = 1; i < MAX_LIST - 1; ++i)
+			message += font.TruncateFront((*it++)->Name() + ",\n", DIALOG_MAX_WIDTH - 33);
 		
 		message += "and " + Format::Number(count - (MAX_LIST - 1)) + " other ships";
 	}

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -238,7 +238,7 @@ bool ShipyardPanel::CanSell() const
 void ShipyardPanel::Sell()
 {
 	static const int MAX_LIST = 20;
-	static const int DIALOG_MAX_WIDTH = 250;
+	static const int MAX_NAME_WIDTH = 250 - 30;
 	
 	int count = playerShips.size();
 	int initialCount = count;
@@ -257,7 +257,7 @@ void ShipyardPanel::Sell()
 		else
 		{
 			while(count-- > 1)
-				message += ",\n" + font.TruncateFront((*it++)->Name(), DIALOG_MAX_WIDTH - 33);
+				message += ",\n" + font.TruncateMiddle((*it++)->Name(), MAX_NAME_WIDTH);
 			message += ",\nand ";
 		}
 		message += (*it)->Name();
@@ -267,7 +267,7 @@ void ShipyardPanel::Sell()
 		auto it = playerShips.begin();
 		message += (*it++)->Name() + ",\n";
 		for(int i = 1; i < MAX_LIST - 1; ++i)
-			message += font.TruncateFront((*it++)->Name() + ",\n", DIALOG_MAX_WIDTH - 33);
+			message += font.TruncateMiddle((*it++)->Name(), MAX_NAME_WIDTH) + ",\n";
 		
 		message += "and " + Format::Number(count - (MAX_LIST - 1)) + " other ships";
 	}

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -397,8 +397,8 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 	float zoomSize = SHIP_SIZE - 60.f;
 	
 	// Draw the ship name.
-	const string &name = ship.Name().empty() ? ship.ModelName() : ship.Name();
 	const Font &font = FontSet::Get(14);
+	const string &name = ship.Name().empty() ? ship.ModelName() : font.TruncateFront(ship.Name(), 205);
 	Point offset(-.5f * font.Width(name), -.5f * SHIP_SIZE + 10.f);
 	font.Draw(name, center + offset, *GameData::Colors().Get("bright"));
 	

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -398,7 +398,7 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 	
 	// Draw the ship name.
 	const Font &font = FontSet::Get(14);
-	const string &name = ship.Name().empty() ? ship.ModelName() : font.TruncateFront(ship.Name(), 205);
+	const string &name = ship.Name().empty() ? ship.ModelName() : font.TruncateFront(ship.Name(), SIDE_WIDTH - 61);
 	Point offset(-.5f * font.Width(name), -.5f * SHIP_SIZE + 10.f);
 	font.Draw(name, center + offset, *GameData::Colors().Get("bright"));
 	

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -398,7 +398,7 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 	
 	// Draw the ship name.
 	const Font &font = FontSet::Get(14);
-	const string &name = ship.Name().empty() ? ship.ModelName() : font.TruncateFront(ship.Name(), SIDE_WIDTH - 61);
+	const string &name = ship.Name().empty() ? ship.ModelName() : font.TruncateMiddle(ship.Name(), SIDE_WIDTH - 61);
 	Point offset(-.5f * font.Width(name), -.5f * SHIP_SIZE + 10.f);
 	font.Draw(name, center + offset, *GameData::Colors().Get("bright"));
 	


### PR DESCRIPTION
Adds front or end string truncation to the following locations:
 - Shipyard sale confirmation dialog: each ship occupies a maximum of one line instead of possibly overflowing onto multiple (#2249)
 - Shipyard/Outfitter ship details panel: no overflow out of rounded square border
 - Hailing screen: no overflow off right edge for combinations of long ship names and/or long government names.
 - Targeting reticle: no overflow off left edge of ship name
 - Player Info fleet list: no overflow of ship name across category
 - Ship detail screen: no overlap of "ship:" and the ship name

I have applied front truncation where sensible to preserve any identifying numbers that may have been added to the end of the ship name when buying in bulk.

<details>
<summary>Appearance with this PR:</summary>


Selling multiple ships:
![pr_sell_5](https://user-images.githubusercontent.com/20871346/27143383-ccf06ba4-50f3-11e7-8024-a2c7c909ef04.png)

Shipyard/Outfitter details panel:
![pr_shoppanel](https://user-images.githubusercontent.com/20871346/27144359-1cd3a1b0-50f7-11e7-91ba-5cfdf0000009.png)


Hailing a very long-named ship:
![pr_hail](https://user-images.githubusercontent.com/20871346/27143438-f60f0a22-50f3-11e7-88c5-608a93ceac87.png)

Targeting ships (this is a rather small field due to its position and because it is center-aligned):
![pr_target_1](https://user-images.githubusercontent.com/20871346/27143843-5806e87a-50f5-11e7-8fde-fde2615f1bf0.png)
![pr_target_2](https://user-images.githubusercontent.com/20871346/27143851-5ba382ea-50f5-11e7-858d-de80dfce2a22.png)

Player Info screen:
![pr_playerinfo](https://user-images.githubusercontent.com/20871346/27143611-90c95ffe-50f4-11e7-8b94-e36a47bc0e99.png)

Ship detail screen:
![pr_shipinfo](https://user-images.githubusercontent.com/20871346/27143603-88abe0b2-50f4-11e7-8f1b-d552e28d5cc1.png)
</details>