### PR TITLE
Allow passing of a specific directory for compiler output.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -17,12 +17,12 @@ if 'CPPPATH' in os.environ:
 if 'SCHROOT_CHROOT_NAME' in os.environ and 'steamrt' in os.environ['SCHROOT_CHROOT_NAME']:
 	env.Append(LINKFLAGS = ["-static-libstdc++"])
 
-AddOption('--comp-dir', dest='comp-dir', type='string', nargs=1, action='store', default='master', help='Compilation directory')
-
 opts = Variables()
 opts.Add(PathVariable("PREFIX", "Directory to install under", "/usr/local", PathVariable.PathIsDirCreate))
 opts.Add(PathVariable("DESTDIR", "Destination root directory", "", PathVariable.PathAccept))
+opts.Add('comp_dir', 'Compilation directory', 'build')
 opts.Add(EnumVariable("mode", "Compilation mode", "release", allowed_values=("release", "debug", "profile")))
+opts.Add('branch', 'Directory inside mode coresponding to current banch. If git is instlled current branch can be found with, git rev-parse --symbolic-full-name --abbrev-ref HEAD', '.')
 opts.Update(env)
 
 Help(opts.GenerateHelpText(env))
@@ -62,9 +62,9 @@ env["CC"] = os.getenv("CC") or env["CC"]
 env["CXX"] = os.getenv("CXX") or env["CXX"]
 env["ENV"].update(x for x in os.environ.items() if x[0].startswith("CCC_"))
 
-VariantDir("build/" + env["mode"] + "/" + GetOption('comp-dir'), "source", duplicate = 0)
+VariantDir(env["comp_dir"] + "/" + env["mode"] + "/" + env["branch"], "source", duplicate = 0)
 
-sky = env.Program("endless-sky", Glob("build/" + env["mode"] + "/" + GetOption('comp-dir') + "/*.cpp"))
+sky = env.Program("endless-sky", Glob(env["comp_dir"] + "/" + env["mode"] + "/" + env["branch"] + "/*.cpp"))
 
 
 # Install the binary:

--- a/SConstruct
+++ b/SConstruct
@@ -17,6 +17,8 @@ if 'CPPPATH' in os.environ:
 if 'SCHROOT_CHROOT_NAME' in os.environ and 'steamrt' in os.environ['SCHROOT_CHROOT_NAME']:
 	env.Append(LINKFLAGS = ["-static-libstdc++"])
 
+AddOption('--comp-dir', dest='comp-dir', type='string', nargs=1, action='store', default='master', help='Compilation directory')
+
 opts = Variables()
 opts.Add(PathVariable("PREFIX", "Directory to install under", "/usr/local", PathVariable.PathIsDirCreate))
 opts.Add(PathVariable("DESTDIR", "Destination root directory", "", PathVariable.PathAccept))
@@ -60,9 +62,9 @@ env["CC"] = os.getenv("CC") or env["CC"]
 env["CXX"] = os.getenv("CXX") or env["CXX"]
 env["ENV"].update(x for x in os.environ.items() if x[0].startswith("CCC_"))
 
-VariantDir("build/" + env["mode"], "source", duplicate = 0)
+VariantDir("build/" + env["mode"] + "/" + GetOption('comp-dir'), "source", duplicate = 0)
 
-sky = env.Program("endless-sky", Glob("build/" + env["mode"] + "/*.cpp"))
+sky = env.Program("endless-sky", Glob("build/" + env["mode"] + "/" + GetOption('comp-dir') + "/*.cpp"))
 
 
 # Install the binary:

--- a/SConstruct
+++ b/SConstruct
@@ -22,7 +22,7 @@ opts.Add(PathVariable("PREFIX", "Directory to install under", "/usr/local", Path
 opts.Add(PathVariable("DESTDIR", "Destination root directory", "", PathVariable.PathAccept))
 opts.Add('comp_dir', 'Compilation directory', 'build')
 opts.Add(EnumVariable("mode", "Compilation mode", "release", allowed_values=("release", "debug", "profile")))
-opts.Add('branch', 'Directory inside mode coresponding to current banch. If git is instlled current branch can be found with, git rev-parse --symbolic-full-name --abbrev-ref HEAD', '.')
+opts.Add('branch', 'Directory inside mode corresponding to current branch. If git is installed current branch can be found with, git rev-parse --symbolic-full-name --abbrev-ref HEAD', '.')
 opts.Update(env)
 
 Help(opts.GenerateHelpText(env))


### PR DESCRIPTION
- Base directory is still `[local endless-sky repository]/build/[build mode]/`
- Default subdirectory thereunder is `master/`
- Allows for scripts to use something along the lines of `scons --comp-dir=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)` to compile specifically for the currently active branch and prevents the need to fully recompile every time a new branch is checked out.