### PR TITLE
Add ability for projectiles to retarget after losing a lock (WIP)

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1122,7 +1122,13 @@ void Engine::CalculateStep()
 			it = projectiles.erase(it);
 		}
 		else
+		{
+			// Missiles have a chance to target nearby ships if they have no target,
+			// or have failed to lock their current target for a
+			if(it->MissileStrength())
+				it->AcquireTarget(shipCollisions);
 			++it;
+		}
 	}
 	projectiles.splice(projectiles.end(), newProjectiles);
 	

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -20,6 +20,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <list>
 #include <memory>
 
+class CollisionSet;
 class Effect;
 class Government;
 class Outfit;
@@ -69,11 +70,12 @@ public:
 	// Find out which ship this projectile is targeting. Note: this pointer is
 	// not guaranteed to be dereferenceable, so only use it for comparing.
 	const Ship *Target() const;
+	void AcquireTarget(const CollisionSet &possibleTargets);
 	
 	
 private:
 	void CheckLock(const Ship &target);
-	
+	double LockStrength(const Ship &target) const;
 	
 private:
 	const Outfit *weapon = nullptr;
@@ -83,6 +85,7 @@ private:
 	const Government *targetGovernment = nullptr;
 	
 	int lifetime = 0;
+	int lockLifetime = 0;
 	bool hasLock = true;
 };
 


### PR DESCRIPTION
Makes new missile types possible, such as opportunistic mines

Also makes missiles with `homing 1` not so bad, as they will pick up a new target after no longer facing the original target.

Comments and questions welcomed.