### PR TITLE
Fix to 'inactive' Next/Previous buttons when you have no Log entries

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -801,6 +801,7 @@ interface "info panel"
 	button l "_Logbook..."
 		center 255 305
 		dimensions 90 30
+	active
 	
 	visible if "five buttons"
 	button n "_Next"


### PR DESCRIPTION
```
Adding the Logbook button, and the condition for when it's active has
incidentally attached that condition to the Next and Previous buttons in
Ship Info. This means they're greyed out unless you have log entries.

This fix just adds the line "active" so that Next/Previous are always
active.
```

My Ship Info screen right now:
![image](https://user-images.githubusercontent.com/23544894/27167058-ad4b1364-5196-11e7-9090-42f7e6231828.png)

The problem is that this block in interfaces.txt:

```
	active if "enable logbook"
	button l "_Logbook..."
		center 255 305
		dimensions 90 30
	
	visible if "five buttons"
	button n "_Next"
		center 145 305
		dimensions 90 30
	button p "_Previous"
		center 45 305
		dimensions 90 30
```

causes the "enable logbook" condition to apply to the next two buttons as well. (But no further, because after that a new "can park" active-if applies.) Switching these two sections around escapes that. Alternatively, one could add a line `active if "five buttons"`, I think.

**Edit:** added `active` instead and changed commit message (including the bit at the top, so just the last paragraph is out-of-date as per @Amazinite's point.)