### PR TITLE
AI TravelPlan actions should not target inaccessible StellarObjects

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2266,8 +2266,8 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 	{
 		const System *system = player.TravelPlan().back();
 		for(const StellarObject &object : ship.GetSystem()->Objects())
-			if(object.GetPlanet() && object.GetPlanet()->WormholeDestination(ship.GetSystem()) == system
-				&& player.HasVisited(object.GetPlanet()) && player.HasVisited(system))
+			if(object.GetPlanet() && object.GetPlanet()->IsAccessible(&ship) && player.HasVisited(object.GetPlanet())
+				&& object.GetPlanet()->WormholeDestination(ship.GetSystem()) == system && player.HasVisited(system))
 			{
 				isWormhole = true;
 				ship.SetTargetStellar(&object);
@@ -2421,8 +2421,8 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 	}
 	else if(keyDown.Has(Command::LAND))
 	{
-		// If the player is right over an uninhabited planet, display a message
-		// explaining why they cannot land there.
+		// If the player is right over an uninhabited or inaccessible planet, display
+		// the default message explaining why they cannot land there.
 		string message;
 		for(const StellarObject &object : ship.GetSystem()->Objects())
 			if((!object.GetPlanet() || !object.GetPlanet()->IsAccessible(&ship)) && object.HasSprite())
@@ -2633,7 +2633,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		// The player completed their travel plan, which may have indicated a destination within the final system
 		keyStuck.Clear(Command::JUMP);
 		const Planet *planet = player.TravelDestination();
-		if(planet && planet->IsInSystem(ship.GetSystem()))
+		if(planet && planet->IsInSystem(ship.GetSystem()) && planet->IsAccessible(&ship))
 		{
 			Messages::Add("Autopilot: landing on " + planet->Name() + ".");
 			keyStuck |= Command::LAND;


### PR DESCRIPTION
These steps prevent the player from toggling LAND in an otherwise "uninhabited" system with a StellarObject already targeted, which will generate a segfault at AI.cpp:2472.

With this PR, the following issues can be closed: #2487, #2596

The functionality of #2601 (TravelPlan Validation upon Takeoff) still has merit, as it will prevent the player from automated traveling that will not get them to their final destination (and further guard against invalid StellarObject targeting).