### PR TITLE
Hostile NPCs should not KeepStation with cloaked parents

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -604,7 +604,7 @@ void AI::Step(const PlayerInfo &player)
 		{
 			// If your parent is your enemy, move toward them until you have
 			// selected a target to fight. Then, fight it.
-			if(target)
+			if(target || !parent->IsTargetable())
 				MoveIndependent(*it, command);
 			else
 				MoveEscort(*it, command);

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -936,7 +936,9 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		return;
 	}
 	
-	if(!ship.GetTargetSystem() && !ship.GetTargetStellar() && !ship.GetPersonality().IsStaying())
+	const bool shouldStay = ship.GetPersonality().IsStaying()
+			||  (ship.GetParent() && ship.GetParent()->GetGovernment()->IsEnemy(ship.GetGovernment()));
+	if(!ship.GetTargetSystem() && !ship.GetTargetStellar() && !shouldStay)
 	{
 		int jumps = ship.JumpsRemaining();
 		// Each destination system has an average priority of 10.
@@ -1029,12 +1031,12 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 	else if(ship.GetTargetStellar())
 	{
 		MoveToPlanet(ship, command);
-		if(!ship.GetPersonality().IsStaying() && ship.Attributes().Get("fuel capacity"))
+		if(!shouldStay && ship.Attributes().Get("fuel capacity"))
 			command |= Command::LAND;
 		else if(ship.Position().Distance(ship.GetTargetStellar()->Position()) < 100.)
 			ship.SetTargetStellar(nullptr);
 	}
-	else if(ship.GetPersonality().IsStaying() && ship.GetSystem()->Objects().size())
+	else if(shouldStay && ship.GetSystem()->Objects().size())
 	{
 		unsigned i = Random::Int(ship.GetSystem()->Objects().size());
 		ship.SetTargetStellar(&ship.GetSystem()->Objects()[i]);


### PR DESCRIPTION
Commit c162a34a44ca749f3edebeae92afde1bd8c4a833 adjusted the default behavior of parented ships (e.g. ships in a fleet, your owned escorts, or mission NPCs (friendly or hostile)), but it has some oddities with hostile escorts in systems in which they have no other targets:
![hostile_ai_keepstation](https://user-images.githubusercontent.com/20871346/27243342-0758b062-52a7-11e7-9609-17b445e886fd.png)

These pirate fleets in Wah Ki have no natural enemies (no `attitude toward` / from either Hai or Unfettered) except for the relatively rare Merchant fleet spawning. If you happen to not feel like fighting at the moment and cloak, c162a34a44ca749f3edebeae92afde1bd8c4a833 instructs them to follow the MoveEscort routine. MoveEscort logic will fail due to the lack of target and parent commands, and sends the hostile escorts to the KeepStation() method, with their parent as the target. Parent is your flagship, and thus you can tow around a group of Pirates, at least until they find someone they feel they should fire upon.

This PR lets hostile mission NPCs instead fall back to MoveIndependent's `patrol this system` behavior if you are otherwise untargetable and no other targets exist.
