### PR TITLE
"Nemesis" target selection now considers NPCs escorted by the player

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -720,8 +720,11 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 		if(it->GetSystem() == system && it->IsTargetable() && gov->IsEnemy(it->GetGovernment()))
 		{
 			// If this is a "nemesis" ship and it has found one of the player's
-			// ships to target, it will not go after anything else.
-			if(hasNemesis && !it->GetGovernment()->IsPlayer())
+			// ships to target, it will only consider the player's owned fleet,
+			// or NPCs allied with the player.
+			const bool isPotentialNemesis = person.IsNemesis()
+					&& (it->GetGovernment()->IsPlayer() || it->GetPersonality().IsEscort());
+			if(hasNemesis && !isPotentialNemesis)
 				continue;
 			
 			// Calculate what the range will be a second from now, so that ships
@@ -768,7 +771,6 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 			range += 1000. * (!isArmed * (1 + !person.Plunders()));
 			// Focus on nearly dead ships.
 			range += 500. * (it->Shields() + it->Hull());
-			bool isPotentialNemesis = (person.IsNemesis() && it->GetGovernment()->IsPlayer());
 			if((isPotentialNemesis && !hasNemesis) || range < closest)
 			{
 				closest = range;


### PR DESCRIPTION
Added a check of the target's personality for the "escort" tag, which indicates a ship important enough to the player that it appears in the HUD.

Should fully address #2586

This will both increase and decrease the difficulty of "Escort to ____" missions, as they spawn opposition with the "nemesis" personality:
1. A single-ship player is no longer the sole target of the pirates.
2. The player will need to help defend the NPCs being escorted, rather than simply get close enough to become the target and then fly away from the freighters.

Things affected:
- Escort to ___ jobs
- Planetary defense spaceport missions
- FW mid: Ryk Bartlet
- FWR 1B/1C: Syndicate ships will more readily target the `timid` Navy Intelligence ship
- FWR Embassy: Pirate ships will more actively target your Dreadnought escort (which is heroic and would have targeted them anyway)
- FWR Syndicate Capture: The nuclear-armed mantas will shoot NM's at both you and the npcs (which are not save/accompany, and can be destroyed)

Things unaffected:
- Bounty hunting jobs
- Being hunted by Bounty Hunters
- FWC Nuke Supply: the freighter you are escorting has Merchant government (e.g. unaffected)
- Wanderer start/middle: Why are you bringing mission NPCs into automaton space?? :man_shrugging: 
- There are more flavor missions with "nemesis" personalities, but in general they also have governments that are only hostile to the player (e.g. wouldn't target Merchants anyway).

Photos of the change in action (120k escort mission)
1. Current `master` behavior
![master2](https://user-images.githubusercontent.com/20871346/27346217-0f65769c-55b2-11e7-9e80-7cb78a7bb0f9.png)

Note that the pirates are happily targeting my flagship, despite being much closer to the freighter.

2. With this PR
![et2](https://user-images.githubusercontent.com/20871346/27346222-13869c6a-55b2-11e7-984d-2972e173b086.png)

I will need to intervene quickly to save this freighter 
