### PR TITLE
bugfix: Prevent out-of-range dates[] access

### DIFF
--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -189,7 +189,7 @@ bool LogbookPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		{
 			--i;
 			// Skip the entry that is just the currently selected year.
-			if(dates[i] && !dates[i].Month())
+			if(i && dates[i] && !dates[i].Month())
 				--i;
 		}
 		if(contents[i] != selectedName)


### PR DESCRIPTION
If a player has no Special Logs, pressing the Up key will cause a segfault if at the top of the list of dated entries.
Closes #2655 