### PR TITLE
enhancement: Logbook selection wraps around

### DIFF
--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -183,7 +183,7 @@ bool LogbookPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		{
 			++i;
 			if(i >= contents.size())
-				return true;
+				i = 0;
 		}
 		else if(i)
 		{
@@ -192,6 +192,8 @@ bool LogbookPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			if(dates[i] && !dates[i].Month())
 				--i;
 		}
+		else
+			i = contents.size() - 1;
 		if(contents[i] != selectedName)
 		{
 			selectedDate = dates[i];


### PR DESCRIPTION
Pressing Up while at the top entry will select the bottommost entry.
Pressing Down while at the bottom entry will select the topmost entry.

Right now, the logbook does not wrap its scroll. This seems weird, considering every other interface with selectable elements does wrap. This PR adds scrolling wraparound to the logbook.