### PR TITLE
MOVE_TO orders should not stack ships on the same position

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2793,7 +2793,7 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 	if(isMoveOrder)
 	{
 		for(const Ship *ship : ships)
-			if(ship->GetSystem() == player.GetSystem() && !ship->IsDisabled())
+			if(ship->GetSystem() && !ship->IsDisabled())
 			{
 				centerOfGravity += ship->Position();
 				++squadCount;


### PR DESCRIPTION
When cross-system MOVE_TO was implemented, the check to space out ships that were in the player's system did not get updated.

With this PR, any ship in the command group will offset its target point from the group's target point by a small amount. This will prevent ships that were not in the player's system at the time of the order issuance from stacking on the same exact spot, except in the rare case that they are already in the same spot.