### PR TITLE
bugfix: Ships no longer mine if they have offered assistance

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -336,6 +336,9 @@ void AI::Step(const PlayerInfo &player)
 				// Don't ask for help from a ship that is already helping someone.
 				if(ship->GetShipToAssist() && ship->GetShipToAssist().get() != it.get())
 					continue;
+				// Don't ask ships that are busy mining or harvesting for help.
+				if(ship->GetTargetAsteroid() || ship->GetTargetFlotsam())
+					continue;
 				// Your escorts only help other escorts, and your flagship never helps.
 				if((otherGov->IsPlayer() && !gov->IsPlayer()) || ship.get() == flagship)
 					continue;
@@ -466,7 +469,7 @@ void AI::Step(const PlayerInfo &player)
 			it->SetCommands(command);
 			continue;
 		}
-		if(isPresent && personality.IsMining() && !target
+		if(isPresent && personality.IsMining() && !target && !it->GetShipToAssist()
 				&& it->Cargo().Free() >= 5 && ++miningTime[&*it] < 3600 && ++minerCount < 9)
 		{
 			DoMining(*it, command);


### PR DESCRIPTION
@Amazinite  tipped me off that ships which are mining may completely ignore that they promised to help.

He was right.
This PR fixes that by preventing a ship that is mining from starting a new mining cycle if it has promised to help someone. Additionally, the AI will not request the help of a ship that has targeted an asteroid (e.g. is actually mining, not just able to mine), or is trying to pick up some space debris.