### PR TITLE
enhancement: Use user-defined colors for status overlays and escort attributes

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -42,6 +42,13 @@ color "escort not ready" .9 .8 0. 1.
 color "escort blocked" .9 .2 0. 1.
 color "escort selected" .2 .8 0. 1.
 
+color "overlay friendly shields" 0., .5, 0., .25
+color "overlay friendly hull" .45, .5, 0., .25
+color "overlay hostile shields" .5, .15, 0., .25
+color "overlay hostile hull" .5, .3, 0., .25
+color "overlay outfit scan" .5, .5, .5, .25
+color "overlay cargo scan" .7, .7, .7, .25
+
 
 
 interface "menu background"

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -645,6 +645,7 @@ const list<ShipEvent> &Engine::Events() const
 void Engine::Draw() const
 {
 	GameData::Background().Draw(center, centerVelocity, zoom);
+	static const Set<Color> &colors = GameData::Colors();
 	
 	// Draw any active planet labels.
 	for(const PlanetLabel &label : labels)
@@ -655,12 +656,12 @@ void Engine::Draw() const
 	for(const auto &it : statuses)
 	{
 		static const Color color[6] = {
-			Color(0., .5, 0., .25),
-			Color(.5, .15, 0., .25),
-			Color(.5, .5, .5, .25),
-			Color(.45, .5, 0., .25),
-			Color(.5, .3, 0., .25),
-			Color(.7, .7, .7, .25)
+			*colors.Get("overlay friendly shields"),
+			*colors.Get("overlay hostile shields"),
+			*colors.Get("overlay outfit scan"),
+			*colors.Get("overlay friendly hull"),
+			*colors.Get("overlay hostile hull"),
+			*colors.Get("overlay cargo scan")
 		};
 		Point pos = it.position * zoom;
 		double radius = it.radius * zoom;
@@ -675,7 +676,7 @@ void Engine::Draw() const
 	if(highlightSprite)
 	{
 		Point size(highlightSprite->Width(), highlightSprite->Height());
-		const Color &color = *GameData::Colors().Get("flagship highlight");
+		const Color &color = *colors.Get("flagship highlight");
 		// The flagship is always in the dead center of the screen.
 		OutlineShader::Draw(highlightSprite, Point(), size, color, highlightUnit, highlightFrame);
 	}
@@ -748,8 +749,8 @@ void Engine::Draw() const
 	Point pos(Screen::Right() - 80, Screen::Bottom());
 	const Sprite *selectedSprite = SpriteSet::Get("ui/ammo selected");
 	const Sprite *unselectedSprite = SpriteSet::Get("ui/ammo unselected");
-	Color selectedColor = *GameData::Colors().Get("bright");
-	Color unselectedColor = *GameData::Colors().Get("dim");
+	Color selectedColor = *colors.Get("bright");
+	Color unselectedColor = *colors.Get("dim");
 	for(const pair<const Outfit *, int> &it : ammo)
 	{
 		pos.Y() -= 30.;
@@ -780,7 +781,7 @@ void Engine::Draw() const
 	if(Preferences::Has("Show CPU / GPU load"))
 	{
 		string loadString = to_string(static_cast<int>(load * 100. + .5)) + "% CPU";
-		Color color = *GameData::Colors().Get("medium");
+		Color color = *colors.Get("medium");
 		font.Draw(loadString,
 			Point(-10 - font.Width(loadString), Screen::Height() * -.5 + 5.), color);
 	}

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -54,15 +54,16 @@ void EscortDisplay::Draw() const
 	icons.sort();
 	stacks.clear();
 	zones.clear();
+	static const Set<Color> &colors = GameData::Colors();
 	
 	// Draw escort status.
 	const Font &font = FontSet::Get(14);
 	Point pos = Point(Screen::Left() + 20., Screen::Bottom());
-	const Color &elsewhereColor = *GameData::Colors().Get("escort elsewhere");
-	const Color &cannotJumpColor = *GameData::Colors().Get("escort blocked");
-	const Color &notReadyToJumpColor = *GameData::Colors().Get("escort not ready");
-	const Color &selectedColor = *GameData::Colors().Get("escort selected");
-	const Color &hereColor = *GameData::Colors().Get("escort present");
+	const Color &elsewhereColor = *colors.Get("escort elsewhere");
+	const Color &cannotJumpColor = *colors.Get("escort blocked");
+	const Color &notReadyToJumpColor = *colors.Get("escort not ready");
+	const Color &selectedColor = *colors.Get("escort selected");
+	const Color &hereColor = *colors.Get("escort present");
 	for(const Icon &escort : icons)
 	{
 		if(!escort.sprite)
@@ -110,12 +111,12 @@ void EscortDisplay::Draw() const
 		
 		// Draw the status bars.
 		static const Color fullColor[5] = {
-			Color(.44, .56, .70, 0), Color(.70, .62, .44, 0),
-			Color(.60, .60, .60, 0), Color(.70, .44, .44, 0), Color(.70, .62, .44, 0)
+			colors.Get("shields")->Additive(1.), colors.Get("hull")->Additive(1.),
+			colors.Get("energy")->Additive(1.), colors.Get("heat")->Additive(1.), colors.Get("fuel")->Additive(1.)
 		};
 		static const Color halfColor[5] = {
-			Color(.22, .28, .35, 0), Color(.35, .31, .22, 0),
-			Color(.30, .30, .30, 0), Color(.35, .22, .22, 0), Color(.35, .31, .22, 0)
+			fullColor[0].Additive(.5), fullColor[1].Additive(.5),
+			fullColor[2].Additive(.5), fullColor[3].Additive(.5), fullColor[4].Additive(.5),
 		};
 		Point from(pos.X() + 15., pos.Y() - 8.5);
 		for(int i = 0; i < 5; ++i)

--- a/source/EscortDisplay.h
+++ b/source/EscortDisplay.h
@@ -72,7 +72,7 @@ private:
 private:
 	mutable std::list<Icon> icons;
 	mutable std::vector<std::vector<const Ship *>> stacks;
-	mutable std::vector<Point> zones; 
+	mutable std::vector<Point> zones;
 };
 
 


### PR DESCRIPTION
Status overlays (shields, hull, scanning progress) were previously fixed
 - New colors are added to data/interfaces.txt to allow custom colors

Escort attributes (shields, hull, fuel, heat, energy) were previously hard-coded to the default values assigned to the flagship.
 - Escort colors now mimic the custom values given to the user's flagship's attributes.
 - The existing "overlapping bar" behavior for displaying attributes that differ between like-model escorts is preserved.

These changes to user-colors allow players (and mods) to define more visually accessible color schemes as needed.

Acknowledgements to @jafdy for the PR request.