### PR TITLE
bugfix: Do not allow scanning of cloaked ships

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -561,7 +561,7 @@ void Engine::Step(bool isActive)
 			info.SetBar("target hull", 0.);
 		}
 	}
-	if(target && !target->IsDestroyed() && target->GetSystem() == currentSystem 
+	if(target && target->IsTargetable() && target->GetSystem() == currentSystem
 		&& (flagship->CargoScanFraction() || flagship->OutfitScanFraction()))
 	{
 		double width = max(target->Width(), target->Height());

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1408,7 +1408,7 @@ int Ship::Scan()
 		return 0;
 	
 	shared_ptr<const Ship> target = GetTargetShip();
-	if(!target)
+	if(!(target && target->IsTargetable()))
 		return 0;
 	
 	// The range of a scanner is proportional to the square root of its power.


### PR DESCRIPTION
When a ship cloaks, any "scan circles" will be removed
If your targeted ship is cloaked, you cannot attempt to scan it.

This PR makes this no longer possible:

![scan cloaked ships](https://user-images.githubusercontent.com/20871346/27612522-8ea0a71a-5b5c-11e7-833d-894778e97f2f.png)

(that Arfecta scan circle was drawn *while the Arfecta was completely cloaked*)