### PR TITLE
Use the Target personality with Corporate Espionage

### DIFF
--- a/data/syndicate world jobs.txt
+++ b/data/syndicate world jobs.txt
@@ -63,7 +63,7 @@ mission "Corporate espionage"
 		distance 3 12
 	npc "scan cargo"
 		government Merchant
-		personality timid fleeing uninterested entering
+		personality fleeing uninterested entering target
 		fleet
 			names "civilian"
 			variant
@@ -72,7 +72,7 @@ mission "Corporate espionage"
 				"Bounder"
 		dialog "You manage to make the requested scans of the <npc>'s cargo. Time to head to <planet>."
 	on complete
-		dialog `You transmit your scans and receive a hearty congratulations, as well as <payment>. "This will set them back months!" you hear someone say in the background as you close the audio link.`
+		dialog `You transmit your scans and receive a hearty congratulations, as well as <payment>. "This will save us months!" you hear someone say in the background as you close the audio link.`
 		payment 50000
 
 


### PR DESCRIPTION
Removed the `timid` personality, as the espionage target is already `uninterested` and all timid does is force an escort to be near its parent (and `uninterested` means it has no parent)
Added the new `target` personality so the player can begin tracking this NPC as soon as it enters the system, and not only after somehow managing to cycle through all the possible ships in the system.

This doesn't address the sheer insanity of trying to keep up with a Bounder or Scout that is forbidden from accepting a ship target (by `fleeing`), but does make it a little easier.

Also changed the "overheard" snippet, as I'm not quite sure how scanning the ship's cargo could set someone else back, rather than advance the party receiving the scan..