### PR TITLE
Fixing number of passenger for "Terraforming 2"

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1690,7 +1690,7 @@ mission "Terraforming 2"
 	description "Return to Rand with a student who thinks she can terraform the planet cheaply."
 	source Glory
 	destination Rand
-	passengers 2
+	passengers 3
 	to offer
 		has "Terraforming 1: done"
 	


### PR DESCRIPTION
It was pointed out to me by the user fgntlucas that "Terraforming 2" has 2 passengers, despite the fact that you pick up Amy on Glory, which means you should have 3 passengers.
 