### PR TITLE
Allow events to freeze the player's reputation with a given government

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -321,4 +321,3 @@ void Government::SetReputation(double value) const
 {
 	GameData::GetPolitics().SetReputation(this, value);
 }
-

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -58,6 +58,8 @@ void Government::Load(const DataNode &node)
 			color = Color(child.Value(1), child.Value(2), child.Value(3));
 		else if(child.Token(0) == "player reputation" && child.Size() >= 2)
 			initialPlayerReputation = child.Value(1);
+		else if(child.Token(0) == "unwavering" && child.Size() >= 2)
+			repLocked = (child.Value(1) > 0);
 		else if(child.Token(0) == "attitude toward")
 		{
 			for(const DataNode &grand : child)
@@ -311,4 +313,11 @@ void Government::AddReputation(double value) const
 void Government::SetReputation(double value) const
 {
 	GameData::GetPolitics().SetReputation(this, value);
+}
+
+
+
+bool Government::IsReputationLocked() const
+{
+	    return repLocked;
 }

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -242,6 +242,13 @@ const Fleet *Government::RaidFleet() const
 
 
 	
+bool Government::IsReputationLocked() const
+{
+	return repLocked;
+}
+
+
+
 // Check if, according to the politics stored by GameData, this government is
 // an enemy of the given government right now.
 bool Government::IsEnemy(const Government *other) const
@@ -315,9 +322,3 @@ void Government::SetReputation(double value) const
 	GameData::GetPolitics().SetReputation(this, value);
 }
 
-
-
-bool Government::IsReputationLocked() const
-{
-	    return repLocked;
-}

--- a/source/Government.h
+++ b/source/Government.h
@@ -75,6 +75,8 @@ public:
 	// it is null, there are no pirate raids.
 	const Fleet *RaidFleet() const;
 	
+	bool IsReputationLocked() const;
+	
 	// Check if, according to the politics stored by GameData, this government is
 	// an enemy of the given government right now.
 	bool IsEnemy(const Government *other) const;
@@ -121,6 +123,7 @@ private:
 	const Phrase *hostileDisabledHail = nullptr;
 	std::string language;
 	const Fleet *raidFleet = nullptr;
+	bool repLocked = false;
 };
 
 

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -110,7 +110,8 @@ void Politics::Offend(const Government *gov, int eventType, int count)
 			if(eventType & ShipEvent::ATROCITY)
 				reputationWith[other] = min(0., reputationWith[other]);
 			
-			reputationWith[other] -= penalty;
+			if(!other->IsReputationLocked() || (eventType & ShipEvent::ATROCITY))
+				reputationWith[other] -= penalty;
 		}
 	}
 }


### PR DESCRIPTION
This would allow events to prevent the player from changing his/her reputation with a government with one attribute. Then, if you want the player in a story where he/she is fighting another faction, you wouldn't need to repeatedly tank the player's reputation with that faction. With this PR, you could just set it to -1, set `unwavering 1`, and forget about it until he/she reaches the end of the storyline, at which point, just set `unwavering 0` to unlock the reputation.

Example:
`event "SomeEvent"`
`    government SomeGov`
`        unwavering 1`

...unset:
`event "SomeOtherEvent"`
`    government SomeGov`
`        unwavering 0`

You could theoretically use the attitude matrix to do this in the `master` branch, but you would need to specify each enemy of the faction whose reputation you want to "lock".

This PR doesn't prevent the reputation drop from committing an atrocity, though. (Maybe it should, but I kinda wanted to prevent an exploit due to the fact that you are no longer penalized for killing stuff with the lock in place)