### PR TITLE
Allow modders to override default crew attack/defense values per government

### DIFF
--- a/source/CaptureOdds.cpp
+++ b/source/CaptureOdds.cpp
@@ -169,7 +169,7 @@ vector<double> CaptureOdds::Power(const Ship &ship, bool isDefender)
 	
 	// Check for any outfits that assist with attacking or defending:
 	const string attribute = (isDefender ? "capture defense" : "capture attack");
-	const double crewPower = (isDefender ? 2. : 1.);
+	const double crewPower = (isDefender ? ship.GetGovernment()->CrewDefense() : ship.GetGovernment()->CrewAttack());
 	
 	// Each crew member can wield one weapon. They use the most powerful ones
 	// that can be wielded by the remaining crew.

--- a/source/CaptureOdds.cpp
+++ b/source/CaptureOdds.cpp
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Outfit.h"
 #include "Ship.h"
+#include "Government.h"
 
 #include <algorithm>
 

--- a/source/CaptureOdds.cpp
+++ b/source/CaptureOdds.cpp
@@ -12,9 +12,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "CaptureOdds.h"
 
+#include "Government.h"
 #include "Outfit.h"
 #include "Ship.h"
-#include "Government.h"
 
 #include <algorithm>
 

--- a/source/CaptureOdds.cpp
+++ b/source/CaptureOdds.cpp
@@ -170,7 +170,7 @@ vector<double> CaptureOdds::Power(const Ship &ship, bool isDefender)
 	
 	// Check for any outfits that assist with attacking or defending:
 	const string attribute = (isDefender ? "capture defense" : "capture attack");
-	const double crewPower = (isDefender ? ship.GetGovernment()->CrewDefense() : ship.GetGovernment()->CrewAttack());
+	const double crewPower = (isDefender ? max(0., ship.GetGovernment()->CrewDefense()) : max(0., ship.GetGovernment()->CrewAttack()));
 	
 	// Each crew member can wield one weapon. They use the most powerful ones
 	// that can be wielded by the remaining crew.

--- a/source/CaptureOdds.h
+++ b/source/CaptureOdds.h
@@ -14,8 +14,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #define CAPTURE_ODDS_H_
 
 #include <vector>
+#include "Government.h"
 
 class Ship;
+class Government;
 
 
 

--- a/source/CaptureOdds.h
+++ b/source/CaptureOdds.h
@@ -14,10 +14,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #define CAPTURE_ODDS_H_
 
 #include <vector>
-#include "Government.h"
 
 class Ship;
-class Government;
 
 
 

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -59,13 +59,9 @@ void Government::Load(const DataNode &node)
 		else if(child.Token(0) == "player reputation" && child.Size() >= 2)
 			initialPlayerReputation = child.Value(1);
 		else if(child.Token(0) == "crew attack" && child.Size() >= 2)
-		{
 			crewAttack = child.Value(1);
-		}
 		else if(child.Token(0) == "crew defense" && child.Size() >= 2)
-		{
 			crewDefense = child.Value(1);
-		}
 		else if(child.Token(0) == "attitude toward")
 		{
 			for(const DataNode &grand : child)
@@ -332,6 +328,6 @@ double Government::CrewAttack() const
 
 double Government::CrewDefense() const
 {
-	return crewDefense
+	return crewDefense;
 }
 

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -323,14 +323,14 @@ void Government::SetReputation(double value) const
 
 
 
-int64_t Government::CrewAttack() const
+double Government::CrewAttack() const
 {
 	return crewAttack;
 }
 
 
 
-int64_t Government::CrewDefense() const
+double Government::CrewDefense() const
 {
 	return crewDefense
 }

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -58,6 +58,14 @@ void Government::Load(const DataNode &node)
 			color = Color(child.Value(1), child.Value(2), child.Value(3));
 		else if(child.Token(0) == "player reputation" && child.Size() >= 2)
 			initialPlayerReputation = child.Value(1);
+		else if(child.Token(0) == "crew attack" && child.Size() >= 2)
+		{
+			crewAttack = child.Value(1);
+		}
+		else if(child.Token(0) == "crew defense" && child.Size() >= 2)
+		{
+			crewDefense = child.Value(1);
+		}
 		else if(child.Token(0) == "attitude toward")
 		{
 			for(const DataNode &grand : child)
@@ -312,3 +320,18 @@ void Government::SetReputation(double value) const
 {
 	GameData::GetPolitics().SetReputation(this, value);
 }
+
+
+
+int64_t Government::CrewAttack() const
+{
+	return crewAttack;
+}
+
+
+
+int64_t Government::CrewDefense() const
+{
+	return crewDefense
+}
+

--- a/source/Government.h
+++ b/source/Government.h
@@ -103,8 +103,8 @@ public:
 	void SetReputation(double value) const;
 	
 	// Get the government's crew attack/defense values
-	int64_t CrewAttack() const;
-	int64_t CrewDefense() const;
+	double CrewAttack() const;
+	double CrewDefense() const;
 	
 	
 private:
@@ -125,8 +125,8 @@ private:
 	const Phrase *hostileDisabledHail = nullptr;
 	std::string language;
 	const Fleet *raidFleet = nullptr;
-	int64_t crewAttack = 1;
-	int64_t crewDefense = 2;
+	double crewAttack = 1.;
+	double crewDefense = 2.;
 };
 
 

--- a/source/Government.h
+++ b/source/Government.h
@@ -102,6 +102,10 @@ public:
 	void AddReputation(double value) const;
 	void SetReputation(double value) const;
 	
+	// Get the government's crew attack/defense values
+	int64_t CrewAttack() const;
+	int64_t CrewDefense() const;
+	
 	
 private:
 	unsigned id;
@@ -121,6 +125,8 @@ private:
 	const Phrase *hostileDisabledHail = nullptr;
 	std::string language;
 	const Fleet *raidFleet = nullptr;
+	int64_t crewAttack = 1;
+	int64_t crewDefense = 2;
 };
 
 


### PR DESCRIPTION
Adds 2 new optional attributes to governments: `crew attack` and `crew defense`. This would be the strength per crew member of that government's ships. (If one or both attributes are omitted, the default values of 1 for attacking and 2 for defending will be used.) This allows one to create alien governments whose ships are easier or harder to capture than normal. 