### PR TITLE
New outfit attributes: disruption, ion, piercing and slowing resistance

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -63,8 +63,8 @@ tip "cost:"
 	`Cost, in credits. If you have sold any used (depreciated) items today, you can buy them back for the same price you sold them for.`
 
 tip "disruption resistance:"
-	`Resistance to weapons that have a disruption effect. A value of 1 cuts the effect in half, and 2 cuts it to a third of what it would otherwise be.`
-
+	`The amount of disruption damage, per second, that your ship will resist.`
+	
 tip "drag:"
 	`Limits the maximum speed of a ship.`
 
@@ -129,7 +129,7 @@ tip "illegal:"
 	`Amount of credits you can be fined for carrying this outfit.`
 
 tip "ion resistance:"
-	`Resistance to weapons that do ion damage. A value of 1 cuts the effect in half, and 2 cuts it to a third of what it would otherwise be.`
+	`The amount of ion damage, per second, that your ship will resist.`
 
 tip "jump speed:"
 	`How slow the ship must be moving to make a jump.`
@@ -167,6 +167,9 @@ tip "radar jamming:"
 tip "ramscoop:"
 	`Replenishes fuel by harvesting the stellar wind. Ramscoops are more effective when closer to a star. If you add more than one ramscoop, each additional one is less effective: you need four ramscoops to achieve double the recharge rate that one ramscoop provides.`
 
+tip "piercing resistance:"
+	`The amount of piercing hull damage, per second, that your ship will resist.`	
+	
 tip "required crew / bunks:"
 	`How many crew members are required to operate this ship, and how many total bunks are available. Extra bunks can be used for passengers or extra crew.`
 
@@ -210,7 +213,7 @@ tip "shields:"
 	`Total shield strength. Most weapons cannot damage your hull until your shields are depleted. Some weapon effects, such as heat damage, become more severe once shields are down.`
 
 tip "slowing resistance:"
-	`Resistance to weapons that have a slowing effect. A value of 1 cuts the effect in half, and 2 cuts it to a third of what it would otherwise be.`
+	`The amount of slowing damage, per second, that your ship will resist.`
 
 tip "solar collection:"
 	`Produces a variable amount of energy depending on how far this ship is from the star at the center of the system.`
@@ -218,6 +221,9 @@ tip "solar collection:"
 tip "max speed:"
 	`The fastest this ship can travel when using ordinary thrusters (as opposed to an afterburner).`
 
+tip "slowing resistance:"
+	`The amount of slowing damage, per second, that your ship will resist.`
+	
 tip "acceleration:"
 	`How quickly this ship gains speed. The higher a ship's mass (including the mass of any cargo or fighters it is carrying), the slower it accelerates.`
 

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -173,6 +173,12 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		double scale = 1.;
 		if(it.first == "thrust" || it.first == "reverse thrust" || it.first == "afterburner thrust")
 			scale = 60. * 60.;
+		// As resisted ion/etc. damage decays with *= .99, it follows a geometric series with convergence
+		// to 100 times the initial value. The 'value' of resisting 1 point is therefore eventually 100.
+		else if(it.first == "ion resistance" || 
+				it.first == "slowing resistance" || 
+				it.first == "disruption resistance")
+			scale = 60. * 100.;
 		else if(ATTRIBUTES_TO_SCALE.count(it.first))
 			scale = 60.;
 		

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2118,10 +2118,10 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 	double shieldDamage = weapon.ShieldDamage();
 	double hullDamage = weapon.HullDamage();
 	double hitForce = weapon.HitForce();
-	double heatDamage = weapon.HeatDamage() / (1. + attributes.Get("heat resistance"));
-	double ionDamage = weapon.IonDamage() / (1. + attributes.Get("ion resistance"));
-	double disruptionDamage = weapon.DisruptionDamage() / (1. + attributes.Get("disruption resistance"));
-	double slowingDamage = weapon.SlowingDamage() / (1. + attributes.Get("slowing resistance"));
+	double heatDamage = weapon.HeatDamage();
+	double ionDamage = weapon.IonDamage();
+	double disruptionDamage = weapon.DisruptionDamage();
+	double slowingDamage = weapon.SlowingDamage();
 	bool wasDisabled = IsDisabled();
 	bool wasDestroyed = IsDestroyed();
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -437,6 +437,10 @@ private:
 	double ionization = 0.;
 	double disruption = 0.;
 	double slowness = 0.;
+	double ionResistance = 0.;
+	double disruptionResistance = 0.;
+	double slowingResistance = 0.;
+	double piercingResistance = 0.;
 	// Acceleration can be created by engines, firing weapons, or weapon impacts.
 	Point acceleration;
 	


### PR DESCRIPTION
```
Adds outfit attributes that resist the effect of disruption, ion,
piercing and slowing damage, respectively. Each functions by 'shaking
off' an amount of damage each second, immediately if possible.
```

@endless-sky, given your commit 2bf7c0f089d72aef14a301bbdd09b9639f17c1e0 in the last half an hour, I thought I should finally PR this piece of work. It includes piercing resistance but not heat resistance. It's been tested (by myself and a few others in the community) and quite a bit of work's gone into it.

It follows a slightly different approach to your fractional scaling of the damage. In this PR, the resistance is an amount of that type of damage you ignore each second. This means your resistance values are pegged to the strength of the effect. You can be completely immune to a weak disruptive effect, but that same resistance might not be worth much against a very strong (Tier 3/4) disruption. I playtested other approaches, but this one seemed to be most resilient across tiers.

Working on the 'resisted value' approach rather than 'percentage reduction' approach, `piercing resistance` was a little more complicated, as I didn't want to make a piercing beam too weak or a piercing missile too strong. The proposed method here is that your piercing resistance covers a second of play and slowly restores, so a continuous beam can wear it down.