### PR TITLE
Simple logic to determine if missile boat AI will reverse or turn around

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1520,10 +1520,23 @@ void AI::Attack(Ship &ship, Command &command, const Ship &target)
 	Point d = target.Position() - ship.Position();
 	if(shortestRange > 1000. && d.Length() < .5 * shortestRange)
 	{
-		command.SetTurn(TurnToward(ship, -d));
-		if(ship.Facing().Unit().Dot(d) <= 0.)
-			command |= Command::FORWARD;
-		return;
+		// If this ship can use reverse thrusters, consider doing so.
+		double reverseSpeed = ship.MaxReverseVelocity();
+		if(reverseSpeed && (reverseSpeed >= min(target.MaxVelocity(), ship.MaxVelocity())
+				|| target.Velocity().Dot(-d.Unit()) <= reverseSpeed))
+		{
+			command.SetTurn(TurnToward(ship, d));
+			if(ship.Facing().Unit().Dot(d) >= 0.)
+				command |= Command::BACK;
+			return;
+		}
+		else
+		{
+			command.SetTurn(TurnToward(ship, -d));
+			if(ship.Facing().Unit().Dot(d) <= 0.)
+				command |= Command::FORWARD;
+			return;
+		}
 	}
 	
 	MoveToAttack(ship, command, target);
@@ -1538,7 +1551,7 @@ void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 	// First of all, aim in the direction that will hit this target.
 	command.SetTurn(TurnToward(ship, TargetAim(ship, target)));
 	
-	// Calculate this ship's "turning radius; that is, the smallest circle it
+	// Calculate this ship's "turning radius"; that is, the smallest circle it
 	// can make while at full speed.
 	double stepsInFullTurn = 360. / ship.TurnRate();
 	double circumference = stepsInFullTurn * ship.Velocity().Length();

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2088,6 +2088,13 @@ double Ship::MaxVelocity() const
 
 
 
+double Ship::MaxReverseVelocity() const
+{
+	return attributes.Get("reverse thrust") / attributes.Get("drag");
+}
+
+
+
 // This ship just got hit by the given projectile. Take damage according to
 // what sort of weapon the projectile it.
 int Ship::TakeDamage(const Projectile &projectile, bool isBlast)

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -256,6 +256,7 @@ public:
 	double TurnRate() const;
 	double Acceleration() const;
 	double MaxVelocity() const;
+	double MaxReverseVelocity() const;
 	
 	// This ship just got hit by the given projectile. Take damage according to
 	// what sort of weapon the projectile it. The return value is a ShipEvent


### PR DESCRIPTION
Use reverse thrust if its capability exceeds:
 - the target's ability to close the distance
 - the current closing rate of the target
 - the ship's forward thrust capability

Otherwise, turn around to use the better thrusters.

Ref #2716