### PR TITLE
bugfix: Restore follow-parent behavior for hostile NPCs which began patrolling

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1081,8 +1081,12 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 		Refuel(ship, command);
 	else if(!parentIsHere && !isStaying)
 	{
-		// Check whether the ship has a target system and is able to jump to it.
+		// Check whether the ship has a target system and is able to jump to it,
+		// and that the targeted stellar object can be landed on.
 		bool hasJump = (ship.GetTargetSystem() && ship.JumpFuel(ship.GetTargetSystem()));
+		if(ship.GetTargetStellar() && (!ship.GetTargetStellar()->GetPlanet()
+				|| !(ship.GetTargetStellar()->GetPlanet() && ship.GetTargetStellar()->GetPlanet()->CanLand(ship))))
+			ship.SetTargetStellar(nullptr);
 		if(!hasJump && !ship.GetTargetStellar())
 		{
 			// If we're stranded and haven't decided where to go, figure out a

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1084,8 +1084,8 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 		// Check whether the ship has a target system and is able to jump to it,
 		// and that the targeted stellar object can be landed on.
 		bool hasJump = (ship.GetTargetSystem() && ship.JumpFuel(ship.GetTargetSystem()));
-		if(ship.GetTargetStellar() && (!ship.GetTargetStellar()->GetPlanet()
-				|| !(ship.GetTargetStellar()->GetPlanet() && ship.GetTargetStellar()->GetPlanet()->CanLand(ship))))
+		if(ship.GetTargetStellar()
+				&& !(ship.GetTargetStellar()->GetPlanet() && ship.GetTargetStellar()->GetPlanet()->CanLand(ship)))
 			ship.SetTargetStellar(nullptr);
 		if(!hasJump && !ship.GetTargetStellar())
 		{


### PR DESCRIPTION
In 4ab74b5bc8 hostile, non-staying NPCs which could not target any ships in a system were instructed to patrol it instead of jump away and then jump back. However, if the player left the system while remaining untargetable, the NPCs would get stuck landing if they were targeting a non-planet at the time of your jump.
This commit resolves the logic bug in MoveEscort that assumed the ship's stellar target was a landable planet by verifying that it is indeed a landable planet. If it is not, the ship will clear the target and resume tracking down the player.

This simple mission illustrates the issue: accept the job, then cloak and jump away once the bounty ship is targeting a non-landable object in the system.
[hostile_shouldfollow_stuck.txt](https://github.com/endless-sky/endless-sky/files/1129776/hostile_shouldfollow_stuck.txt)
