### PR TITLE
bugfix: NPC turrets not autofiring

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2111,7 +2111,7 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 	for(const Hardpoint &weapon : ship.Weapons())
 		if(weapon.IsReady()
 				&& !(weapon.IsHoming() && currentTarget && weapon.GetOutfit()->Ammo())
-				&& !(secondary && !weapon.GetOutfit()->Icon())
+				&& !(secondary && weapon.GetOutfit()->Icon())
 				&& !(beFrugal && weapon.GetOutfit()->Ammo()))
 			maxRange = max(maxRange, weapon.GetOutfit()->Range());
 	// Extend the weapon range slightly to account for velocity differences.


### PR DESCRIPTION
Extra ! in a boolean condition during the maxRange setup prevented some turrets from autofiring.
https://github.com/endless-sky/endless-sky/commit/957f6c077b78e0ea6a674ef19b83c9e6b20176fa#diff-80825e2b1f90be6b565f227d9ddb18ccL2107
As seen in the above commit, the condition did not change despite now being &&'d instead of ||'d.

In `master`, a hostile NPC which is given `fleeing` (no ship target) will not fire its turrets despite them clearly aiming at a hostile and taking no ammunition.
![fail to fire](https://user-images.githubusercontent.com/20871346/27942203-b26e3190-629a-11e7-94b8-4cd721e36e53.png)
With this commit, the `fleeing` NPC will happily fire:
![now can fire](https://user-images.githubusercontent.com/20871346/27942218-c9f4c478-629a-11e7-9938-61cad8453322.png)
Even homing turrets will work:
![even grabstrikes](https://user-images.githubusercontent.com/20871346/27942226-dea7e832-629a-11e7-8720-fcb77daee31f.png)
