### PR TITLE
Mission NPCs added to the escort display are drawn with hostile colors as appropriate.

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -49,6 +49,14 @@ color "overlay hostile hull" .5, .3, 0., .25
 color "overlay outfit scan" .5, .5, .5, .25
 color "overlay cargo scan" .7, .7, .7, .25
 
+color "radar player" .2, 1., 0., 0.
+color "radar friendly" .4, .6, 1., 0.
+color "radar unfriendly" .8, .8, .4, 0.
+color "radar hostile" 1., .6, .4, 0.
+color "radar inactive" .4, .4, .4, 0.
+color "radar special" 1., 1., 1., 0.
+color "radar anomalous" .7, 0., 1., 0.
+
 
 
 interface "menu background"

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -73,7 +73,7 @@ namespace {
 		}
 		if(ship.IsDisabled() || (ship.IsOverheated() && ((step / 20) % 2)))
 			return Radar::INACTIVE;
-		if(ship.GetGovernment()->IsPlayer() || ship.GetPersonality().IsEscort())
+		if(ship.GetGovernment()->IsPlayer() || (ship.GetPersonality().IsEscort() && !ship.GetGovernment()->IsEnemy()))
 			return Radar::PLAYER;
 		if(!ship.GetGovernment()->IsEnemy())
 			return Radar::FRIENDLY;

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -16,6 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Font.h"
 #include "FontSet.h"
 #include "GameData.h"
+#include "Government.h"
 #include "LineShader.h"
 #include "Point.h"
 #include "OutlineShader.h"
@@ -64,6 +65,7 @@ void EscortDisplay::Draw() const
 	const Color &notReadyToJumpColor = *colors.Get("escort not ready");
 	const Color &selectedColor = *colors.Get("escort selected");
 	const Color &hereColor = *colors.Get("escort present");
+	const Color &hostileColor = colors.Get("radar hostile")->Opaque();
 	for(const Icon &escort : icons)
 	{
 		if(!escort.sprite)
@@ -79,7 +81,9 @@ void EscortDisplay::Draw() const
 			font.Draw(escort.system, pos + Point(-10., 10.), elsewhereColor);
 
 		Color color;
-		if(!escort.isHere)
+		if(escort.isHostile)
+			color = hostileColor;
+		else if(!escort.isHere)
 			color = elsewhereColor;
 		else if(escort.cannotJump)
 			color = cannotJumpColor;
@@ -166,6 +170,7 @@ const vector<const Ship *> &EscortDisplay::Click(const Point &point) const
 EscortDisplay::Icon::Icon(const Ship &ship, bool isHere, bool fleetIsJumping, bool isSelected)
 	: sprite(ship.GetSprite()),
 	isHere(isHere && !ship.IsDisabled()),
+	isHostile(ship.GetGovernment() && ship.GetGovernment()->IsEnemy(GameData::PlayerGovernment())),
 	notReadyToJump(fleetIsJumping && !ship.IsHyperspacing() && !ship.IsReadyToJump()),
 	cannotJump(fleetIsJumping && !ship.IsHyperspacing() && !ship.JumpsRemaining()),
 	isSelected(isSelected),
@@ -197,6 +202,7 @@ int EscortDisplay::Icon::Height() const
 void EscortDisplay::Icon::Merge(const Icon &other)
 {
 	isHere &= other.isHere;
+	isHostile |= other.isHostile;
 	notReadyToJump |= other.notReadyToJump;
 	cannotJump |= other.cannotJump;
 	isSelected |= other.isSelected;
@@ -236,9 +242,9 @@ void EscortDisplay::MergeStacks() const
 		if(height < maxHeight || !cheapest)
 			break;
 		
-		// Merge together each group of escorts that have this icon annd are in
-		// the same system.
-		map<string, Icon *> merged;
+		// Merge together each group of escorts that have this icon and are in
+		// the same system and have the same attitude towards the player.
+		map<const bool, map<string, Icon *>> merged;
 		
 		// The "cheapest" element in the list may be removed to merge it with an
 		// earlier ship of the same type, so store a copy of its sprite pointer:
@@ -254,10 +260,10 @@ void EscortDisplay::MergeStacks() const
 			
 			// If this is the first escort we've seen so far in its system, it
 			// is the one we will merge all others in this system into.
-			auto mit = merged.find(it->system);
-			if(mit == merged.end())
+			auto mit = merged[it->isHostile].find(it->system);
+			if(mit == merged[it->isHostile].end())
 			{
-				merged[it->system] = &*it;
+				merged[it->isHostile][it->system] = &*it;
 				++it;
 			}
 			else

--- a/source/EscortDisplay.h
+++ b/source/EscortDisplay.h
@@ -54,6 +54,7 @@ private:
 		
 		const Sprite *sprite;
 		bool isHere;
+		bool isHostile;
 		bool notReadyToJump;
 		bool cannotJump;
 		bool isSelected;

--- a/source/Radar.cpp
+++ b/source/Radar.cpp
@@ -12,8 +12,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Radar.h"
 
+#include "GameData.h"
 #include "PointerShader.h"
 #include "RingShader.h"
+#include "Set.h"
 
 using namespace std;
 
@@ -28,14 +30,15 @@ static const int SIZE = 7;
 
 namespace {
 	// Colors.
+	static const Set<Color> &colors = GameData::Colors();
 	static const Color color[SIZE] = {
-		Color(.2, 1., 0., 0.), // PLAYER: green
-		Color(.4, .6, 1., 0.), // FRIENDLY: blue
-		Color(.8, .8, .4, 0.), // UNFRIENDLY: yellow
-		Color(1., .6, .4, 0.), // HOSTILE: red
-		Color(.4, .4, .4, 0.), // INACTIVE: grey
-		Color(1., 1., 1., 0.),  // SPECIAL: white
-		Color(.7, 0., 1., 0.)  // ANOMALOUS: magenta
+		*colors.Get("radar player"),
+		*colors.Get("radar friendly"),
+		*colors.Get("radar unfriendly"),
+		*colors.Get("radar hostile"),
+		*colors.Get("radar inactive"),
+		*colors.Get("radar special"),
+		*colors.Get("radar anomalous")
 	};
 }
 

--- a/source/Radar.cpp
+++ b/source/Radar.cpp
@@ -12,10 +12,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Radar.h"
 
-#include "GameData.h"
 #include "PointerShader.h"
 #include "RingShader.h"
-#include "Set.h"
 
 using namespace std;
 
@@ -30,15 +28,14 @@ static const int SIZE = 7;
 
 namespace {
 	// Colors.
-	static const Set<Color> &colors = GameData::Colors();
 	static const Color color[SIZE] = {
-		*colors.Get("radar player"),
-		*colors.Get("radar friendly"),
-		*colors.Get("radar unfriendly"),
-		*colors.Get("radar hostile"),
-		*colors.Get("radar inactive"),
-		*colors.Get("radar special"),
-		*colors.Get("radar anomalous")
+		Color(.2, 1., 0., 0.), // PLAYER: green
+		Color(.4, .6, 1., 0.), // FRIENDLY: blue
+		Color(.8, .8, .4, 0.), // UNFRIENDLY: yellow
+		Color(1., .6, .4, 0.), // HOSTILE: red
+		Color(.4, .4, .4, 0.), // INACTIVE: grey
+		Color(1., 1., 1., 0.),  // SPECIAL: white
+		Color(.7, 0., 1., 0.)  // ANOMALOUS: magenta
 	};
 }
 


### PR DESCRIPTION
If a mission adds a hostile ship to the escort display so that the player can track its whereabouts, this ship will appear under the player's colors (green) on the radar and in the target reticle, rather than the orange-red hostile colors:
![single fired turret](https://user-images.githubusercontent.com/20871346/27942698-8c38835a-629e-11e7-8338-fdef8e86c063.png)


This commit prevents drawing hostile escorts as assumed friendlies:
![hostile escort radar](https://user-images.githubusercontent.com/20871346/27942701-9166c828-629e-11e7-9e4f-8f412272ccda.png)
