### PR TITLE
Carried ships assist in NPC mining operations

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -472,7 +472,18 @@ void AI::Step(const PlayerInfo &player)
 		if(isPresent && personality.IsMining() && !target && !it->GetShipToAssist()
 				&& it->Cargo().Free() >= 5 && ++miningTime[&*it] < 3600 && ++minerCount < 9)
 		{
+			if(it->HasBays())
+				command |= Command::DEPLOY;
 			DoMining(*it, command);
+			it->SetCommands(command);
+			continue;
+		}
+		else if(isPresent && !target && it->CanBeCarried() && parent && miningTime[&*parent] < 3601
+				&& parent->GetTargetAsteroid() && parent->GetTargetAsteroid()->Position().Distance(parent->Position()) < 800.)
+		{
+			// Assist your parent in mining its nearby targeted asteroid.
+			MoveToAttack(*it, command, *parent->GetTargetAsteroid());
+			AutoFire(*it, command, *parent->GetTargetAsteroid());
 			it->SetCommands(command);
 			continue;
 		}


### PR DESCRIPTION
The mining personality will now deploy any carried ships while actively mining.
These carried ships inherit the mining personality, so if they have cargo space free, they will mine independently.
After filling their cargo space, carried ships will assist their parent ship in destroying its target asteroid.

The restriction to carried ships is arbitrary, and could be removed, in which case any member of a fleet that is not actively mining or in combat, but has a fleet leader with the `mining` personality, would choose to assist that fleet leader in destroying its target asteroid. Removing the carried ship restriction would necessitate adding a check for a shipToAssist.

If the DoMining routine is updated to allow changing the target asteroid if it gets too far away from the ship that is mining, then the distance check used here can be dropped. Without the distance check, nimble fighters will engage target asteroids at distances too great for the parent to pick up the flotsam.