### PR TITLE
bugfix: Vindictive ships only remember in-system targets

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -838,7 +838,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	if(!target && person.IsVindictive())
 	{
 		target = ship.GetTargetShip();
-		if(target && target->Cloaking() == 1.)
+		if(target && (target->Cloaking() == 1. || target->GetSystem() != ship.GetSystem()))
 			target.reset();
 	}
 	


### PR DESCRIPTION
If a vindictive NPC targets a ship that can leave the system while not ceasing to exist (e.g. certain NPCs or a carried ship), that ship leaves the system, and there are no new targets to acquire, the vindictive NPC will fail to behave normally (e.g. KeepStation with its parent), and instead simply drift.

This PR updates the vindictive targeting logic to consider if that target has left the system in some manner.
A simpler check is to replace the cloaking and GetSystem checks with IsTargetable(), but that would remove the "vindictive" flavor wherein the NPC continues to unload into the already-dead and exploding target (since IsTargetable() checks that the target's hull is > 0 and it is not exploding).