### PR TITLE
bugfix: Carriers should only wait if they have bays free

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -574,8 +574,12 @@ void AI::Step(const PlayerInfo &player)
 				if(escort && escort->CanBeCarried() && escort->GetSystem() == it->GetSystem()
 						&& !escort->IsDisabled())
 				{
-					mustRecall = true;
-					break;
+					const string &category = escort->Attributes().Category();
+					if(it->BaysFree(category == "Fighter"))
+					{
+						mustRecall = true;
+						break;
+					}
 				}
 			}
 		


### PR DESCRIPTION
The reparenting fix af9e646be could result in fleets which have carry-capable ships and also more fighters to carry than bays available. This commit allows a full carrier to begin moving again, instead of remaining paralyzed while the escort feebly attempts to board.