### PR TITLE
enhancement: Store "critical" cargo in flagship first

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -28,6 +28,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Person.h"
 #include "Planet.h"
 #include "Politics.h"
+#include "Preferences.h"
 #include "Random.h"
 #include "SavedGame.h"
 #include "Ship.h"
@@ -1176,10 +1177,16 @@ bool PlayerInfo::TakeOff(UI *ui)
 			}
 			else
 			{
-				// Your flagship takes first priority for passengers but last for cargo.
+				// Your flagship takes first priority for passengers but last for cargo,
+				// unless you have chosen to give it special mission cargo.
 				ship->Cargo().SetBunks(ship->Attributes().Get("bunks") - ship->Crew());
 				for(const auto &it : cargo.PassengerList())
 					cargo.TransferPassengers(it.first, it.second, &ship->Cargo());
+				if(Preferences::Has("Special cargo fills flagship first"))
+					for(const auto &it : cargo.MissionCargo())
+						if(it.first->RecommendsAutosave() || it.first->HasPriority() || it.first->IsUnique()
+								|| it.first->IllegalCargoFine() || it.first->FailIfDiscovered())
+							cargo.Transfer(it.first, it.second, &ship->Cargo());
 			}
 		}
 	// Load up your flagship last, so that it will have space free for any

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -436,7 +436,8 @@ void PreferencesPanel::DrawSettings()
 		REACTIVATE_HELP,
 		SCROLL_SPEED,
 		"Warning siren",
-		"Hide unexplored map regions"
+		"Hide unexplored map regions",
+		"Special cargo fills flagship first"
 	};
 	bool isCategory = true;
 	for(const string &setting : SETTINGS)


### PR DESCRIPTION
**Refs #2746**
Introduce a preference setting "Special cargo fills flagship first" that
 - stores cargo from missions with 'autosave'
 - stores cargo from missions marked 'priority'
 - stores cargo from one-time-only missions
 - stores cargo with illegal fines
 - stores cargo from missions with 'stealth'

into the flagship, and then if/when full, into your available escorts.

The default behavior of filling available escort holds before the flagship is preserved when the preference is off.


![image](https://user-images.githubusercontent.com/20871346/28124733-2c2b9024-66ea-11e7-96f0-45c6abebf8ae.png)
