### PR TITLE
Allow events to modify a fleet's personality

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -48,6 +48,8 @@ void Fleet::Load(const DataNode &node)
 		// clearing the rest of the existing definition.
 		bool add = (key == "add" && hasValue && child.Token(1) == "variant");
 		bool remove = (key == "remove" && hasValue && child.Token(1) == "variant");
+		bool addPersonality = (key == "add" && hasValue && child.Token(1) == "personality");
+		bool removePersonality = (key == "remove" && hasValue && child.Token(1) == "personality");
 		
 		if(key == "government" && hasValue)
 			government = GameData::Governments().Get(child.Token(1));
@@ -63,8 +65,12 @@ void Fleet::Load(const DataNode &node)
 			for(int i = 1; i < child.Size(); ++i)
 				commodities.push_back(child.Token(i));
 		}
+		else if(addPersonality)
+			personality.Load(child, false, false);
+		else if(removePersonality)
+			personality.Load(child, false, true);
 		else if(key == "personality")
-			personality.Load(child);
+			personality.Load(child, true, false);
 		else if(key == "variant" || add)
 		{
 			if(resetVariants && !add)

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -84,7 +84,7 @@ void NPC::Load(const DataNode &node)
 		else if(child.Token(0) == "government" && child.Size() >= 2)
 			government = GameData::Governments().Get(child.Token(1));
 		else if(child.Token(0) == "personality")
-			personality.Load(child);
+			personality.Load(child, true, false);
 		else if(child.Token(0) == "dialog")
 		{
 			for(int i = 1; i < child.Size(); ++i)
@@ -171,17 +171,8 @@ void NPC::Save(DataWriter &out) const
 			out.BeginChild();
 			{
 				// Break the text up into paragraphs.
-				size_t begin = 0;
-				while(true)
-				{
-					size_t pos = dialogText.find("\n\t", begin);
-					if(pos == string::npos)
-						pos = dialogText.length();
-					out.Write(dialogText.substr(begin, pos - begin));
-					if(pos == dialogText.length())
-						break;
-					begin = pos + 2;
-				}
+				for(const string &line : Format::Split(dialogText, "\n\t"))
+					out.Write(line);
 			}
 			out.EndChild();
 		}

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -39,7 +39,7 @@ void Person::Load(const DataNode &node)
 		else if(child.Token(0) == "government" && child.Size() >= 2)
 			government = GameData::Governments().Get(child.Token(1));
 		else if(child.Token(0) == "personality")
-			personality.Load(child);
+			personality.Load(child, true, false);
 		else if(child.Token(0) == "phrase")
 			hail.Load(child);
 		else

--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -46,6 +46,8 @@ namespace {
 	static const int APPEASING = (1 << 22);
 	static const int MUTE = (1 << 23);
 	static const int OPPORTUNISTIC = (1 << 24);
+	static const int TARGET = (1 << 25);
+	static const int SKYBOUND = (1 << 26);
 	
 	static const map<string, int> TOKEN = {
 		{"pacifist", PACIFIST},
@@ -72,7 +74,9 @@ namespace {
 		{"harvests", HARVESTS},
 		{"appeasing", APPEASING},
 		{"mute", MUTE},
-		{"opportunistic", OPPORTUNISTIC}
+		{"opportunistic", OPPORTUNISTIC},
+		{"target", TARGET},
+		{"skybound", SKYBOUND}
 	};
 	
 	double DEFAULT_CONFUSION = 10.;
@@ -88,11 +92,17 @@ Personality::Personality()
 
 
 
-void Personality::Load(const DataNode &node)
+void Personality::Load(const DataNode &node, bool reset, bool remove)
 {
-	flags = 0;
+	if(reset)
+		flags = 0;
 	for(int i = 1; i < node.Size(); ++i)
-		Parse(node.Token(i));
+	{
+		if(node.Token(i) == "personality")
+			continue;
+		Parse(node.Token(i), remove);
+	}
+	
 	
 	for(const DataNode &child : node)
 	{
@@ -101,7 +111,11 @@ void Personality::Load(const DataNode &node)
 		else
 		{
 			for(int i = 0; i < child.Size(); ++i)
-				Parse(child.Token(i));
+			{
+				if(child.Token(i) == "personality")
+					continue;
+				Parse(child.Token(i), remove);
+			}
 		}
 	}
 }
@@ -256,6 +270,13 @@ bool Personality::IsUninterested() const
 
 
 
+bool Personality::IsSkybound() const
+{
+	return flags & SKYBOUND;
+}
+
+
+
 bool Personality::IsSurveillance() const
 {
 	return flags & SURVEILLANCE;
@@ -287,6 +308,13 @@ bool Personality::IsSwarming() const
 bool Personality::IsEscort() const
 {
 	return flags & ESCORT;
+}
+
+
+
+bool Personality::IsTarget() const
+{
+	return flags & TARGET;
 }
 
 
@@ -333,9 +361,14 @@ Personality Personality::Defender()
 
 
 
-void Personality::Parse(const string &token)
+void Personality::Parse(const string &token, bool remove)
 {
 	auto it = TOKEN.find(token);
 	if(it != TOKEN.end())
-		flags |= it->second;
+	{
+		if(remove)
+			flags &= ~it->second;
+		else
+			flags |= it->second;
+	}
 }

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -31,7 +31,7 @@ class Personality {
 public:
 	Personality();
 	
-	void Load(const DataNode &node);
+	void Load(const DataNode &node, bool reset, bool remove);
 	void Save(DataWriter &out) const;
 	
 	// Who a ship decides to attack:
@@ -58,6 +58,7 @@ public:
 	bool IsFleeing() const;
 	bool IsDerelict() const;
 	bool IsUninterested() const;
+	bool IsSkybound() const;
 	
 	// Non-combat goals:
 	bool IsSurveillance() const;
@@ -68,6 +69,7 @@ public:
 	// Special flags:
 	bool IsEscort() const;
 	bool IsMute() const;
+	bool IsTarget() const;
 	
 	// Current inaccuracy in this ship's targeting:
 	const Point &Confusion() const;
@@ -78,7 +80,7 @@ public:
 	
 	
 private:
-	void Parse(const std::string &token);
+	void Parse(const std::string &token, bool remove);
 	
 	
 private:


### PR DESCRIPTION
Add the ability for events to modify a fleet's personality without replacing the fleet's definition. 

With this PR, if you want an event to change a fleet's personality, you can simply put
`event SomeEvent`
`    fleet SomeFleet`
`        personality add <whatever> `
or `personality remove <whatever>` instead of rewriting the personality definition.