### PR TITLE
NPCs which cannot land on a stellar object will not get stuck trying to.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1063,7 +1063,8 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 	else if(ship.GetTargetStellar())
 	{
 		MoveToPlanet(ship, command);
-		if(!shouldStay && !ship.GetPersonality().IsSkybound() && ship.Attributes().Get("fuel capacity"))
+		if(!shouldStay && !ship.GetPersonality().IsSkybound() && ship.Attributes().Get("fuel capacity")
+				&& ship.GetTargetStellar()->GetPlanet() && ship.GetTargetStellar()->GetPlanet()->CanLand(ship))
 			command |= Command::LAND;
 		else if(ship.Position().Distance(ship.GetTargetStellar()->Position()) < 100.)
 			ship.SetTargetStellar(nullptr);


### PR DESCRIPTION
See [comment](https://github.com/endless-sky/endless-sky/issues/2251#issuecomment-314875350)

Now if a ship cannot make a jump and is flitting about the star, it will jump away when it has enough fuel to do so.