### PR TITLE
Transfer outfits in reverse size order

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -468,8 +468,9 @@ void CargoHold::TransferAll(CargoHold *to)
 		else
 			++mit;
 	}
-	for(const auto &it : outfits)
-		Transfer(it.first, it.second, to);
+	const std::vector<const Outfit *> outfitOrder = GetOutfitOrder();
+	for(const auto &outfit : outfitOrder)
+		Transfer(outfit, outfits[outfit], to);
 	for(const auto &it : commodities)
 		Transfer(it.first, it.second, to);
 }
@@ -569,4 +570,28 @@ int CargoHold::IllegalCargoFine() const
 		worst = max(worst, fine);
 	}
 	return worst;
+}
+
+
+
+// Retrieve vector of pointers to the outfits, sorted descending by size.
+const vector<const Outfit *> CargoHold::GetOutfitOrder() const
+{
+	vector<const Outfit *> sortedOutfits;
+	if(!outfits.size())
+		return sortedOutfits;
+	
+	for(const auto &outfit : outfits)
+		sortedOutfits.emplace_back(outfit.first);
+	sort(sortedOutfits.begin(), sortedOutfits.end(),
+		[] (const Outfit *lhs, const Outfit *rhs)
+		{
+			if(lhs->Get("mass") == rhs->Get("mass"))
+				return lhs->Name() < rhs->Name();
+			else
+				return lhs->Get("mass") > rhs->Get("mass");
+		}
+	);
+	
+	return sortedOutfits;
 }

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -586,10 +586,7 @@ const vector<const Outfit *> CargoHold::GetOutfitOrder() const
 	sort(sortedOutfits.begin(), sortedOutfits.end(),
 		[] (const Outfit *lhs, const Outfit *rhs)
 		{
-			if(lhs->Get("mass") == rhs->Get("mass"))
-				return lhs->Name() < rhs->Name();
-			else
-				return lhs->Get("mass") > rhs->Get("mass");
+			return lhs->Get("mass") > rhs->Get("mass");
 		}
 	);
 	

--- a/source/CargoHold.h
+++ b/source/CargoHold.h
@@ -16,6 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <cstdint>
 #include <map>
 #include <string>
+#include <vector>
 
 class DataNode;
 class DataWriter;
@@ -103,6 +104,9 @@ public:
 	// so bad that it warrants a death sentence.
 	int IllegalCargoFine() const;
 	
+	
+private:
+	const std::vector<const Outfit *> GetOutfitOrder() const;
 	
 private:
 	// Use -1 to indicate unlimited capacity.


### PR DESCRIPTION
When performing a TransferAll(), first obtain a descending-by-mass sorted vector of the outfits to be transferred, and then move outfits by iterating over that vector. If an outfit does not have a specified mass, outfit->Get("mass") will return 0 and there is no limit to the number that can be in a given cargo hold.

This means that the largest outfits that can fit in escort holds are guaranteed to be in escort holds.
edit: this is a First-Fit-Decreasing bin-packing implementation, minus the bits where new bins can be added and the bins are all the same size.

Photo proof:
My cargo while landed:
![total_cargo](https://user-images.githubusercontent.com/20871346/28158787-796bbf08-6780-11e7-8d4c-411290c121d6.png)
1 Jump Drive, 1 Large Heat Shunt, 2 System Core (Medium), 1 System Core (Small).
This order is also the order of the items in the `outfits` variable used by CargoHold.

To takeoff, on `master`, this list is iterated left-to-right, beginning in my 2nd escort (the Solifuge), until it can no longer hold the next outfit:
![master_2ndescort](https://user-images.githubusercontent.com/20871346/28158875-c255d2b2-6780-11e7-931d-a534eb7e759e.png)

My other ships have insufficient space to hold the outfits left, so my flagship gets the remaining outfits:
![master_flagship](https://user-images.githubusercontent.com/20871346/28158897-d3f5d9cc-6780-11e7-862d-64c0034d25f2.png)


With this PR, the System Core (Medium) are added first:
![pr_2ndescort](https://user-images.githubusercontent.com/20871346/28158915-e62e0290-6780-11e7-9dc1-ea8bfa32e111.png)

And my flagship again receives the rest:
![pr_flagship](https://user-images.githubusercontent.com/20871346/28158923-ef3bfc98-6780-11e7-934b-fbae8bc4e4a5.png)

But by maximizing the storage of large items in my escorts, I now have more free space in my flagship's hold.

Refs #2754 