### PR TITLE
Remove "Skybound" declaration

### DIFF
--- a/source/Personality.h
+++ b/source/Personality.h
@@ -58,7 +58,6 @@ public:
 	bool IsFleeing() const;
 	bool IsDerelict() const;
 	bool IsUninterested() const;
-	bool IsSkybound() const;
 	
 	// Non-combat goals:
 	bool IsSurveillance() const;


### PR DESCRIPTION
With the addition of the Marked personality, `Personality::IsSkybound()` was effectively removed from the game. ...Except for the declaration in Personality.h. This PR fixes that.