### PR TITLE
fix check for submunitions in PrintWeaponTable()

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -968,7 +968,7 @@ void GameData::PrintWeaponTable()
 	for(auto &it : outfits)
 	{
 		// Skip non-weapons and submunitions.
-		if(!it.second.IsWeapon() || !it.second.Reload())
+		if(!it.second.IsWeapon() || it.second.Category().empty())
 			continue;
 		
 		const Outfit &outfit = it.second;


### PR DESCRIPTION
https://github.com/endless-sky/endless-sky/commit/dfa06d6afd0f3f5ad91c9d4bd9db567327a2f4fc made the submunition check in GameData::PrintWeaponTable() always fail. This PR uses an empty category to detect submunitions instead.