### PR TITLE
Added system dependency for ramscoop and solar panel effectiveness.

### DIFF
--- a/EndlessSky.cbp
+++ b/EndlessSky.cbp
@@ -43,16 +43,16 @@
 				<Linker>
 					<Add option="-Wl,--subsystem,windows" />
 					<Add option="-lwinmm" />
-					<Add library="C:\Program Files (x86)\mingw-w64\i686-5.2.0-posix-dwarf-rt_v4-rev0\mingw32\i686-w64-mingw32\lib\libmingw32.a" />
-					<Add library="C:\dev32\lib\libsdl2main.a" />
-					<Add library="C:\dev32\lib\libsdl2.dll.a" />
-					<Add library="C:\dev32\lib\libpng.dll.a" />
-					<Add library="C:\dev32\lib\libturbojpeg.dll.a" />
-					<Add library="C:\dev32\lib\libjpeg.dll.a" />
-					<Add library="C:\dev32\lib\libmad.dll.a" />
-					<Add library="C:\dev32\lib\libopenal32.dll.a" />
-					<Add library="C:\dev32\lib\libglew32.dll.a" />
-					<Add library="C:\Program Files (x86)\mingw-w64\i686-5.2.0-posix-dwarf-rt_v4-rev0\mingw32\i686-w64-mingw32\lib\libopengl32.a" />
+					<Add library="C:/Program Files (x86)/mingw-w64/i686-5.2.0-posix-dwarf-rt_v4-rev0/mingw32/i686-w64-mingw32/lib/libmingw32.a" />
+					<Add library="C:/dev32/lib/libsdl2main.a" />
+					<Add library="C:/dev32/lib/libsdl2.dll.a" />
+					<Add library="C:/dev32/lib/libpng.dll.a" />
+					<Add library="C:/dev32/lib/libturbojpeg.dll.a" />
+					<Add library="C:/dev32/lib/libjpeg.dll.a" />
+					<Add library="C:/dev32/lib/libmad.dll.a" />
+					<Add library="C:/dev32/lib/libopenal32.dll.a" />
+					<Add library="C:/dev32/lib/libglew32.dll.a" />
+					<Add library="C:/Program Files (x86)/mingw-w64/i686-5.2.0-posix-dwarf-rt_v4-rev0/mingw32/i686-w64-mingw32/lib/libopengl32.a" />
 					<Add directory="C:/dev32/lib" />
 				</Linker>
 			</Target>
@@ -65,16 +65,16 @@
 		<Linker>
 			<Add option="-Wl,--subsystem,windows" />
 			<Add option="-lwinmm" />
-			<Add library="C:\Program Files\mingw64\x86_64-w64-mingw32\lib\libmingw32.a" />
-			<Add library="C:\dev64\lib\libsdl2main.a" />
-			<Add library="C:\dev64\lib\libsdl2.dll.a" />
-			<Add library="C:\dev64\lib\libpng.dll.a" />
-			<Add library="C:\dev64\lib\libturbojpeg.dll.a" />
-			<Add library="C:\dev64\lib\libjpeg.dll.a" />
-			<Add library="C:\dev64\lib\libmad.dll.a" />
-			<Add library="C:\dev64\lib\libopenal32.dll.a" />
-			<Add library="C:\dev64\lib\libglew32.dll.a" />
-			<Add library="C:\Program Files\mingw64\x86_64-w64-mingw32\lib\libopengl32.a" />
+			<Add library="C:/Program Files (x86)/mingw64/x86_64-w64-mingw32/lib/libmingw32.a" />
+			<Add library="C:/dev64/lib/libsdl2main.a" />
+			<Add library="C:/dev64/lib/libsdl2.dll.a" />
+			<Add library="C:/dev64/lib/libpng.dll.a" />
+			<Add library="C:/dev64/lib/libturbojpeg.dll.a" />
+			<Add library="C:/dev64/lib/libjpeg.dll.a" />
+			<Add library="C:/dev64/lib/libmad.dll.a" />
+			<Add library="C:/dev64/lib/libopenal32.dll.a" />
+			<Add library="C:/dev64/lib/libglew32.dll.a" />
+			<Add library="C:/Program Files (x86)/mingw64/x86_64-w64-mingw32/lib/libopengl32.a" />
 			<Add directory="C:/dev64/lib" />
 		</Linker>
 		<Unit filename="source/AI.cpp" />
@@ -274,10 +274,10 @@
 		<Unit filename="source/Ship.h" />
 		<Unit filename="source/ShipEvent.cpp" />
 		<Unit filename="source/ShipEvent.h" />
-		<Unit filename="source/ShipInfoPanel.cpp" />
-		<Unit filename="source/ShipInfoPanel.h" />
 		<Unit filename="source/ShipInfoDisplay.cpp" />
 		<Unit filename="source/ShipInfoDisplay.h" />
+		<Unit filename="source/ShipInfoPanel.cpp" />
+		<Unit filename="source/ShipInfoPanel.h" />
 		<Unit filename="source/ShipyardPanel.cpp" />
 		<Unit filename="source/ShipyardPanel.h" />
 		<Unit filename="source/ShopPanel.cpp" />
@@ -296,6 +296,8 @@
 		<Unit filename="source/SpriteShader.h" />
 		<Unit filename="source/StarField.cpp" />
 		<Unit filename="source/StarField.h" />
+		<Unit filename="source/StarType.cpp" />
+		<Unit filename="source/StarType.h" />
 		<Unit filename="source/StartConditions.cpp" />
 		<Unit filename="source/StartConditions.h" />
 		<Unit filename="source/StellarObject.cpp" />

--- a/data/1star types.txt
+++ b/data/1star types.txt
@@ -1,0 +1,89 @@
+# Copyright (c) 2015 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+star a0
+	luminosity 1.8
+	wind 0.8
+
+star a5
+	luminosity 1.6
+	wind 0.85
+
+star b5
+	luminosity 2.0
+	wind 0.75
+
+star f0
+	luminosity 1.5
+	wind 0.9
+
+star f5
+	luminosity 1.2
+	wind 0.95
+
+star f5-old
+	luminosity 1.2
+	wind .95
+
+star g0
+	luminosity 1.0
+	wind 1.0
+
+star g0-old
+	luminosity 1.0
+	wind 1.0
+
+star g5
+	luminosity 0.9
+	wind 0.9
+
+star g5-old
+	luminosity 0.9
+	wind 0.9
+
+star giant
+	luminosity 1.3
+	wind 2.0
+
+star k0
+	luminosity 0.85
+	wind 0.8
+
+star k0-old
+	luminosity 0.85 
+	wind 0.8
+
+star k5
+	luminosity 0.8
+	wind 0.7
+
+star k5-old
+	luminosity 0.8
+	wind 0.7
+
+star m0
+	luminosity 0.7
+	wind 0.6
+
+star m4 
+	luminosity 0.6
+	wind 0.5
+
+star m8
+	luminosity 0.5
+	wind 0.4
+
+star nova
+	luminosity 0.5
+	wind 4.0
+
+star wr
+	luminosity 2.0
+	wind 4.0

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -48,6 +48,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "SpriteQueue.h"
 #include "SpriteSet.h"
 #include "SpriteShader.h"
+#include "StarType.h"
 #include "StarField.h"
 #include "StartConditions.h"
 #include "System.h"
@@ -78,6 +79,7 @@ namespace {
 	Set<Phrase> phrases;
 	Set<Planet> planets;
 	Set<Ship> ships;
+	Set<StarType> starTypes;
 	Set<System> systems;
 	
 	Set<Sale<Ship>> shipSales;
@@ -598,6 +600,13 @@ const Set<Ship> &GameData::Ships()
 
 
 
+const Set<StarType> &GameData::Stars()
+{
+	return starTypes;
+}
+
+
+
 const Set<System> &GameData::Systems()
 {
 	return systems;
@@ -813,6 +822,8 @@ void GameData::LoadFile(const string &path, bool debugMode)
 		}
 		else if(key == "shipyard" && node.Size() >= 2)
 			shipSales.Get(node.Token(1))->Load(node, ships);
+		else if(key == "star" && node.Size() >= 2)
+			starTypes.Get(node.Token(1))->Load(node);
 		else if(key == "start")
 			startConditions.Load(node);
 		else if(key == "system" && node.Size() >= 2)

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -40,6 +40,7 @@ class Planet;
 class Politics;
 class Ship;
 class Sprite;
+class StarType;
 class StarField;
 class StartConditions;
 class System;
@@ -96,6 +97,7 @@ public:
 	static const Set<Phrase> &Phrases();
 	static const Set<Planet> &Planets();
 	static const Set<Ship> &Ships();
+	static const Set<StarType> &Stars();
 	static const Set<System> &Systems();
 	
 	static const Government *PlayerGovernment();

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -765,17 +765,17 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 	else
 	{
 		// Ramscoops and solar panels work better in some systems than others.
-		double ramscoopModifier = GetSystem()->RamscoopEffectiveness();
-		double solarPanelModifier = GetSystem()->SolarPanelEffectiveness();
+		double solarWindStrength = GetSystem()->GetStellarWindStrength();
+		double systemLuminosity = GetSystem()->GetLuminosity();
 		
 		// Ramscoops and solar panels work much better when close to the system center. Even if a
 		// ship has no ramscoop, it can harvest a tiny bit of fuel by flying
-		// close to the star.		
+		// close to the star.
 		double scale = .2 + 1.8 / (.001 * position.Length() + 1);
-		fuel += .03 * scale * (sqrt(attributes.Get("ramscoop")) + .05 * scale) * ramscoopModifier;
+		fuel += .03 * scale * (sqrt(attributes.Get("ramscoop")) + .05 * scale) * solarWindStrength;
 		fuel = min(fuel, attributes.Get("fuel capacity"));
 		
-		energy += scale * attributes.Get("solar collection") * solarPanelModifier;
+		energy += scale * attributes.Get("solar collection") * systemLuminosity;
 		
 		double coolingEfficiency = CoolingEfficiency();
 		energy += attributes.Get("energy generation") - attributes.Get("energy consumption");

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -764,14 +764,18 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		PauseAnimation();
 	else
 	{
-		// Ramscoops work much better when close to the system center. Even if a
+		// Ramscoops and solar panels work better in some systems than others.
+		double ramscoopModifier = GetSystem()->RamscoopEffectiveness();
+		double solarPanelModifier = GetSystem()->SolarPanelEffectiveness();
+		
+		// Ramscoops and solar panels work much better when close to the system center. Even if a
 		// ship has no ramscoop, it can harvest a tiny bit of fuel by flying
-		// close to the star.
+		// close to the star.		
 		double scale = .2 + 1.8 / (.001 * position.Length() + 1);
-		fuel += .03 * scale * (sqrt(attributes.Get("ramscoop")) + .05 * scale);
+		fuel += .03 * scale * (sqrt(attributes.Get("ramscoop")) + .05 * scale) * ramscoopModifier;
 		fuel = min(fuel, attributes.Get("fuel capacity"));
 		
-		energy += scale * attributes.Get("solar collection");
+		energy += scale * attributes.Get("solar collection") * solarPanelModifier;
 		
 		double coolingEfficiency = CoolingEfficiency();
 		energy += attributes.Get("energy generation") - attributes.Get("energy consumption");

--- a/source/StarType.cpp
+++ b/source/StarType.cpp
@@ -1,0 +1,65 @@
+/* StarType.cpp
+Copyright (c) 2014 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "StarType.h"
+
+#include "DataNode.h"
+
+using namespace std;
+
+
+
+StarType::StarType()
+{
+	name = "Name not found";
+	stellarWind = 1;
+	luminosity = 1;	
+}
+
+
+
+void StarType::Load(DataNode node)
+{
+	if(node.Size() < 2)
+		return;
+	name = node.Token(1);
+	
+	for(const DataNode &child : node)
+	{
+		const string &key = child.Token(0);
+		if(key == "wind")
+			stellarWind = child.Value(1);
+		else if(key == "luminosity")
+			luminosity = child.Value(1);
+	}
+}
+
+
+
+string StarType::GetName() const
+{
+	return name;
+}
+
+
+
+double StarType::GetStellarWind() const
+{
+	return stellarWind;
+}
+
+
+
+double StarType::GetLuminosity() const
+{
+	return luminosity;
+}

--- a/source/StarType.h
+++ b/source/StarType.h
@@ -1,0 +1,53 @@
+/* StarType.h
+Copyright (c) 2014 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef STAR_H
+#define STAR_H
+
+#include <string>
+
+class DataNode;
+
+
+
+// Class that represents a type of star. It holds the name of the star's sprite,
+// and the values for how much stellar wind and light that type of star gives emits. 
+class StarType {
+public:
+	// Constructor for new star object
+	//Star(std::string name, double stellarWind, double luminosity);
+	StarType();
+		
+	// Set this Star to hold the given values.
+	void Load(DataNode node);
+		
+	std::string GetName() const;
+		
+	double GetStellarWind() const;
+		
+	double GetLuminosity() const;
+
+
+private:
+	// Represents the name of a type of star. Must correspond to name of 
+	// sprite in "endless-sky/images/star/"
+	std::string name;
+		
+	// Values that represent the stellar wind and luminosity that a star
+	// of this type emits.
+	double stellarWind;
+	double luminosity;
+};
+
+
+
+#endif

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -23,6 +23,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Random.h"
 #include "Sprite.h"
 #include "SpriteSet.h"
+#include "StarType.h"
 
 #include <cmath>
 
@@ -116,7 +117,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 	// For the following keys, if this data node defines a new value for that
 	// key, the old values should be cleared (unless using the "add" keyword).
 	set<string> shouldOverwrite = {"link", "asteroids", "fleet", "object"};
-	
+		
 	for(const DataNode &child : node)
 	{
 		// Check for the "add" or "remove" keyword.
@@ -261,6 +262,11 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
 	
+	// Reset stellarWindStrength and luminosity before recalculating their values in
+	// the following loop.
+	stellarWindStrength = 0;
+	luminosity = 0;
+	
 	// Set planet messages based on what zone they are in, and calculate the luminosity
 	// and stellar wind values for the stars in the system.
 	for(StellarObject &object : objects)
@@ -286,7 +292,9 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		
 		double fraction = root->distance / habitable;
 		if(object.IsStar())
+		{
 			object.message = &STAR;
+		}
 		else if (object.IsStation())
 			object.message = &STATION;
 		else if (object.IsMoon())
@@ -308,7 +316,6 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 				object.message = &UNINHABITEDPLANET;
 		}
 	}
-
 	// Make sure that the stellarWindStrength and luminosity are reasonable.
 	stellarWindStrength = std::max(0.25, stellarWindStrength);
 	luminosity = std::max(0.5, luminosity);
@@ -700,79 +707,12 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 
 
 // Update stellarWindStrength and luminosity to include the star's effects in the system.
-void System::AddStar(const std::string starName)
+void System::AddStar(const string starName)
 {
-	static const double A0_LUMINOSITY = 1.8;
-	static const double A0_WIND = 0.8;
-	static const double A5_LUMINOSITY = 1.6;
-	static const double A5_WIND = 0.85;
-	static const double B5_LUMINOSITY = 2.0;
-	static const double B5_WIND = 0.75;
-	static const double F0_LUMINOSITY = 1.5;
-	static const double F0_WIND = 0.9;
-	static const double F5_LUMINOSITY = 1.2;
-	static const double F5_WIND = 0.95;
-	static const double G0_LUMINOSITY = 1.0;
-	static const double G0_WIND = 1.0;
-	static const double G5_LUMINOSITY = 0.9;
-	static const double G5_WIND = 0.9;
-	static const double GIANT_LUMINOSITY = 1.3;
-	static const double GIANT_WIND = 2.0;
-	static const double K0_LUMINOSITY = 0.85;
-	static const double K0_WIND = 0.8;
-	static const double K5_LUMINOSITY = 0.8;
-	static const double K5_WIND = 0.7;
-	static const double M0_LUMINOSITY = 0.7;
-	static const double M0_WIND = 0.6;
-	static const double M4_LUMINOSITY = 0.6;
-	static const double M4_WIND = 0.5;
-	static const double M8_LUMINOSITY = 0.5;
-	static const double M8_WIND = 0.4;
-	static const double NOVA_LUMINOSITY = 0.5;
-	static const double NOVA_WIND = 4.0;
-	static const double WR_LUMINOSITY = 2.0;
-	static const double WR_WIND = 4.0;
-	
-	if(starName == "star/a0")
-		ApplyNewStar(A0_WIND, A0_LUMINOSITY);
-	else if(starName == "star/a5")
-		ApplyNewStar(A5_WIND, A5_LUMINOSITY);
-	else if(starName == "star/b5")
-		ApplyNewStar(B5_WIND, B5_LUMINOSITY);
-	else if(starName == "star/f0")
-		ApplyNewStar(F0_WIND, F0_LUMINOSITY);
-	else if(starName == "star/f5" || starName == "star/f5-old")
-		ApplyNewStar(F5_WIND, F5_LUMINOSITY);
-	else if(starName == "star/g0" || starName == "star/g0-old")
-		ApplyNewStar(G0_WIND, G0_LUMINOSITY);
-	else if(starName == "star/g5" || starName == "star/g5-old")
-		ApplyNewStar(G5_WIND, G5_LUMINOSITY);
-	else if(starName == "star/giant")
-		ApplyNewStar(GIANT_WIND, GIANT_LUMINOSITY);
-	else if(starName == "star/k0" || starName == "star/k0-old")
-		ApplyNewStar(K0_WIND, K0_LUMINOSITY);
-	else if(starName == "star/k5" || starName == "star/k5-old")
-		ApplyNewStar(K5_WIND, K5_LUMINOSITY);
-	else if(starName == "star/m0")
-		ApplyNewStar(M0_WIND, M0_LUMINOSITY);
-	else if(starName == "star/m4")
-		ApplyNewStar(M4_WIND, M4_LUMINOSITY);
-	else if(starName == "star/m8")
-		ApplyNewStar(M8_WIND, M8_LUMINOSITY);
-	else if(starName == "star/nova")
-		ApplyNewStar(NOVA_WIND, NOVA_LUMINOSITY);
-	else if(starName == "star/wr")
-		ApplyNewStar(WR_WIND, WR_LUMINOSITY);
-	else
-		ApplyNewStar(1.0, 1.0);
-}
+	const StarType *starType = GameData::Stars().Get(starName.substr(5));
 
-
-
-void System::ApplyNewStar(double starWind, double starLuminosity)
-{
-	stellarWindStrength += starWind;
-	luminosity += starLuminosity;
+	stellarWindStrength += starType->GetStellarWind();
+	luminosity += starType->GetLuminosity();
 }
 
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -261,9 +261,13 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
 	
-	// Set planet messages based on what zone they are in.
+	// Set planet messages based on what zone they are in, and calculate the luminosity
+	// and stellar wind values for the stars in the system.
 	for(StellarObject &object : objects)
 	{
+		if(object.IsStar())
+            AddStar(object.GetSprite()->Name());
+		
 		if(object.message || object.planet)
 			continue;
 		
@@ -305,147 +309,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		}
 	}
 	
-	// Calculate efficiency of ramscoops and solar panels.
-	std::list<double> stellarWindModifiers;
-	std::list<double> luminosityModifiers;
-	
-	// Get list of modifiers associated with each star in the system and remember how many.
-	int starCount = 0;
-	for(StellarObject &object : objects)
-    {
-        if(!object.IsStar())
-            continue;
-
-        string starName = object.GetSprite()->Name();
-        
-        // Add the correct value to the lists. 
-        static const double A0BRIGHTNESS = 1.8;
-        static const double A0WIND = 0.8;
-        static const double A5BRIGHTNESS = 1.6;
-        static const double A5WIND = 0.85;
-        static const double B5BRIGHTNESS = 2.0;
-        static const double B5WIND = 0.75;
-        static const double F0BRIGHTNESS = 1.5;
-        static const double F0WIND = 0.9;
-        static const double F5BRIGHTNESS = 1.2;
-        static const double F5WIND = 0.95;
-        static const double G0BRIGHTNESS = 1.0;
-        static const double G0WIND = 1.0;
-        static const double G5BRIGHTNESS = 0.9;
-        static const double G5WIND = 0.9;
-        static const double GIANTBRIGHTNESS = 1.3;
-        static const double GIANTWIND = 2.0;
-        static const double K0BRIGHTNESS = 0.85;
-        static const double K0WIND = 0.8;
-        static const double K5BRIGHTNESS = 0.8;
-        static const double K5WIND = 0.7;
-        static const double M0BRIGHTNESS = 0.7;
-        static const double M0WIND = 0.6;
-        static const double M4BRIGHTNESS = 0.6;
-        static const double M4WIND = 0.5;
-        static const double M8BRIGHTNESS = 0.5;
-        static const double M8WIND = 0.4;
-        static const double NOVABRIGHTNESS = 0.5;
-        static const double NOVAWIND = 4.0;
-        static const double WRBRIGHTNESS = 2.0;
-        static const double WRWIND = 4.0;
-        
-        if(starName == "star/a0")
-        {
-            stellarWindModifiers.push_back(A0WIND);
-            luminosityModifiers.push_back(A0BRIGHTNESS);
-        }
-        else if(starName == "star/a5")
-        {
-            stellarWindModifiers.push_back(A5WIND);
-            luminosityModifiers.push_back(A5BRIGHTNESS);
-        }
-        else if(starName == "star/b5")
-        {
-            stellarWindModifiers.push_back(B5WIND);
-            luminosityModifiers.push_back(B5BRIGHTNESS);
-        }
-        else if(starName == "star/f0")
-        {
-            stellarWindModifiers.push_back(F0WIND);
-            luminosityModifiers.push_back(F0BRIGHTNESS);
-        }
-        else if(starName == "star/f5" || starName == "star/f5-old")
-        {
-            stellarWindModifiers.push_back(F5WIND);
-            luminosityModifiers.push_back(F5BRIGHTNESS);
-        }
-        else if(starName == "star/g0" || starName == "star/g0-old")
-        {
-            stellarWindModifiers.push_back(G0WIND);
-            luminosityModifiers.push_back(G0BRIGHTNESS);
-        }
-        else if(starName == "star/g5" || starName == "star/g5-old")
-        {
-            stellarWindModifiers.push_back(G5WIND);
-            luminosityModifiers.push_back(G5BRIGHTNESS);
-        }
-        else if(starName == "star/giant")
-        {
-            stellarWindModifiers.push_back(GIANTWIND);
-            luminosityModifiers.push_back(GIANTBRIGHTNESS);
-        }
-        else if(starName == "star/k0" || starName == "star/k0-old")
-        {
-            stellarWindModifiers.push_back(K0WIND);
-            luminosityModifiers.push_back(K0BRIGHTNESS);
-        }
-        else if(starName == "star/k5" || starName == "star/k5-old")
-        {
-            stellarWindModifiers.push_back(K5WIND);
-            luminosityModifiers.push_back(K5BRIGHTNESS);
-        }
-        else if(starName == "star/m0")
-        {
-            stellarWindModifiers.push_back(M0WIND);
-            luminosityModifiers.push_back(M0BRIGHTNESS);
-        }else if(starName == "star/m4")
-        {
-            stellarWindModifiers.push_back(M4WIND);
-            luminosityModifiers.push_back(M4BRIGHTNESS);
-        }else if(starName == "star/m8")
-        {
-            stellarWindModifiers.push_back(M8WIND);
-            luminosityModifiers.push_back(M8BRIGHTNESS);
-        }
-        else if(starName == "star/nova")
-        {
-            stellarWindModifiers.push_back(NOVAWIND);
-            luminosityModifiers.push_back(NOVABRIGHTNESS);
-        }
-        else if(starName == "star/wr")
-        {
-            stellarWindModifiers.push_back(WRWIND);
-            luminosityModifiers.push_back(WRBRIGHTNESS);
-        }
-        else
-        {
-            stellarWindModifiers.push_back(1);
-            luminosityModifiers.push_back(1);
-        }
-        ++starCount;
-	}
-	stellarWindModifiers.sort();
-	luminosityModifiers.sort();
-	
-	// Sum up modifiers (currently using 1/n to normalize the sum).
-	stellarWindStrength = 0;
-	luminosity = 0;
-	for(int i = 0; i < starCount; i++)
-    {
-        stellarWindStrength += (stellarWindModifiers.back()/(i + 1));
-        luminosity += (luminosityModifiers.back()/(i + 1));
-        
-        stellarWindModifiers.pop_back();
-        luminosityModifiers.pop_back();
-    }
-    
-    // Make sure that the effectiveness modifiers are not game brakeingly low or high.
+    // Make sure that the stellarWindStrength and luminosity are not game brakeingly low or high.
     stellarWindStrength = std::max(0.25, stellarWindStrength);
     luminosity = std::max(0.5, luminosity);
     luminosity = std::min(2.0, luminosity);
@@ -831,6 +695,84 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
+}
+
+
+
+// Update stellarWindStrength and luminosity to include the star's effects in the system.
+void System::AddStar(const std::string starName)
+{
+    static const double A0_LUMINOSITY = 1.8;
+    static const double A0_WIND = 0.8;
+    static const double A5_LUMINOSITY = 1.6;
+    static const double A5_WIND = 0.85;
+    static const double B5_LUMINOSITY = 2.0;
+    static const double B5_WIND = 0.75;
+    static const double F0_LUMINOSITY = 1.5;
+    static const double F0_WIND = 0.9;
+    static const double F5_LUMINOSITY = 1.2;
+    static const double F5_WIND = 0.95;
+    static const double G0_LUMINOSITY = 1.0;
+    static const double G0_WIND = 1.0;
+    static const double G5_LUMINOSITY = 0.9;
+    static const double G5_WIND = 0.9;
+    static const double GIANT_LUMINOSITY = 1.3;
+    static const double GIANT_WIND = 2.0;
+    static const double K0_LUMINOSITY = 0.85;
+    static const double K0_WIND = 0.8;
+    static const double K5_LUMINOSITY = 0.8;
+    static const double K5_WIND = 0.7;
+    static const double M0_LUMINOSITY = 0.7;
+    static const double M0_WIND = 0.6;
+    static const double M4_LUMINOSITY = 0.6;
+    static const double M4_WIND = 0.5;
+    static const double M8_LUMINOSITY = 0.5;
+    static const double M8_WIND = 0.4;
+    static const double NOVA_LUMINOSITY = 0.5;
+    static const double NOVA_WIND = 4.0;
+    static const double WR_LUMINOSITY = 2.0;
+    static const double WR_WIND = 4.0;
+    
+    if(starName == "star/a0")
+        ApplyNewStar(A0_WIND, A0_LUMINOSITY);
+    else if(starName == "star/a5")
+        ApplyNewStar(A5_WIND, A5_LUMINOSITY);
+    else if(starName == "star/b5")
+        ApplyNewStar(B5_WIND, B5_LUMINOSITY);
+    else if(starName == "star/f0")
+        ApplyNewStar(F0_WIND, F0_LUMINOSITY);
+    else if(starName == "star/f5" || starName == "star/f5-old")
+        ApplyNewStar(F5_WIND, F5_LUMINOSITY);
+    else if(starName == "star/g0" || starName == "star/g0-old")
+        ApplyNewStar(G0_WIND, G0_LUMINOSITY);
+    else if(starName == "star/g5" || starName == "star/g5-old")
+        ApplyNewStar(G5_WIND, G5_LUMINOSITY);
+    else if(starName == "star/giant")
+        ApplyNewStar(GIANT_WIND, GIANT_LUMINOSITY);
+    else if(starName == "star/k0" || starName == "star/k0-old")
+        ApplyNewStar(K0_WIND, K0_LUMINOSITY);
+    else if(starName == "star/k5" || starName == "star/k5-old")
+        ApplyNewStar(K5_WIND, K5_LUMINOSITY);
+    else if(starName == "star/m0")
+        ApplyNewStar(M0_WIND, M0_LUMINOSITY);
+    else if(starName == "star/m4")
+        ApplyNewStar(M4_WIND, M4_LUMINOSITY);
+    else if(starName == "star/m8")
+        ApplyNewStar(M8_WIND, M8_LUMINOSITY);
+    else if(starName == "star/nova")
+        ApplyNewStar(NOVA_WIND, NOVA_LUMINOSITY);
+    else if(starName == "star/wr")
+        ApplyNewStar(WR_WIND, WR_LUMINOSITY);
+    else
+        ApplyNewStar(1.0, 1.0);
+}
+
+
+
+void System::ApplyNewStar(double starWind, double starLuminosity)
+{
+    stellarWindStrength += starWind;
+    luminosity += starLuminosity;
 }
 
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -21,8 +21,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Minable.h"
 #include "Planet.h"
 #include "Random.h"
-#include "SpriteSet.h"
 #include "Sprite.h"
+#include "SpriteSet.h"
 
 #include <cmath>
 
@@ -306,8 +306,8 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 	}
 	
 	// Calculate efficiency of ramscoops and solar panels.
-	std::list<double> ramscoopModifiers;
-	std::list<double> solarPanelModifiers;
+	std::list<double> stellarWindModifiers;
+	std::list<double> luminosityModifiers;
 	
 	// Get list of modifiers associated with each star in the system and remember how many.
 	int starCount = 0;
@@ -352,107 +352,103 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
         
         if(starName == "star/a0")
         {
-            ramscoopModifiers.push_back(A0WIND);
-            solarPanelModifiers.push_back(A0BRIGHTNESS);
+            stellarWindModifiers.push_back(A0WIND);
+            luminosityModifiers.push_back(A0BRIGHTNESS);
         }
         else if(starName == "star/a5")
         {
-            ramscoopModifiers.push_back(A5WIND);
-            solarPanelModifiers.push_back(A5BRIGHTNESS);
+            stellarWindModifiers.push_back(A5WIND);
+            luminosityModifiers.push_back(A5BRIGHTNESS);
         }
         else if(starName == "star/b5")
         {
-            ramscoopModifiers.push_back(B5WIND);
-            solarPanelModifiers.push_back(B5BRIGHTNESS);
+            stellarWindModifiers.push_back(B5WIND);
+            luminosityModifiers.push_back(B5BRIGHTNESS);
         }
         else if(starName == "star/f0")
         {
-            ramscoopModifiers.push_back(F0WIND);
-            solarPanelModifiers.push_back(F0BRIGHTNESS);
+            stellarWindModifiers.push_back(F0WIND);
+            luminosityModifiers.push_back(F0BRIGHTNESS);
         }
         else if(starName == "star/f5" || starName == "star/f5-old")
         {
-            ramscoopModifiers.push_back(F5WIND);
-            solarPanelModifiers.push_back(F5BRIGHTNESS);
+            stellarWindModifiers.push_back(F5WIND);
+            luminosityModifiers.push_back(F5BRIGHTNESS);
         }
         else if(starName == "star/g0" || starName == "star/g0-old")
         {
-            ramscoopModifiers.push_back(G0WIND);
-            solarPanelModifiers.push_back(G0BRIGHTNESS);
+            stellarWindModifiers.push_back(G0WIND);
+            luminosityModifiers.push_back(G0BRIGHTNESS);
         }
         else if(starName == "star/g5" || starName == "star/g5-old")
         {
-            ramscoopModifiers.push_back(G5WIND);
-            solarPanelModifiers.push_back(G5BRIGHTNESS);
+            stellarWindModifiers.push_back(G5WIND);
+            luminosityModifiers.push_back(G5BRIGHTNESS);
         }
         else if(starName == "star/giant")
         {
-            ramscoopModifiers.push_back(GIANTWIND);
-            solarPanelModifiers.push_back(GIANTBRIGHTNESS);
+            stellarWindModifiers.push_back(GIANTWIND);
+            luminosityModifiers.push_back(GIANTBRIGHTNESS);
         }
         else if(starName == "star/k0" || starName == "star/k0-old")
         {
-            ramscoopModifiers.push_back(K0WIND);
-            solarPanelModifiers.push_back(K0BRIGHTNESS);
+            stellarWindModifiers.push_back(K0WIND);
+            luminosityModifiers.push_back(K0BRIGHTNESS);
         }
         else if(starName == "star/k5" || starName == "star/k5-old")
         {
-            ramscoopModifiers.push_back(K5WIND);
-            solarPanelModifiers.push_back(K5BRIGHTNESS);
+            stellarWindModifiers.push_back(K5WIND);
+            luminosityModifiers.push_back(K5BRIGHTNESS);
         }
         else if(starName == "star/m0")
         {
-            ramscoopModifiers.push_back(M0WIND);
-            solarPanelModifiers.push_back(M0BRIGHTNESS);
+            stellarWindModifiers.push_back(M0WIND);
+            luminosityModifiers.push_back(M0BRIGHTNESS);
         }else if(starName == "star/m4")
         {
-            ramscoopModifiers.push_back(M4WIND);
-            solarPanelModifiers.push_back(M4BRIGHTNESS);
+            stellarWindModifiers.push_back(M4WIND);
+            luminosityModifiers.push_back(M4BRIGHTNESS);
         }else if(starName == "star/m8")
         {
-            ramscoopModifiers.push_back(M8WIND);
-            solarPanelModifiers.push_back(M8BRIGHTNESS);
+            stellarWindModifiers.push_back(M8WIND);
+            luminosityModifiers.push_back(M8BRIGHTNESS);
         }
         else if(starName == "star/nova")
         {
-            ramscoopModifiers.push_back(NOVAWIND);
-            solarPanelModifiers.push_back(NOVABRIGHTNESS);
+            stellarWindModifiers.push_back(NOVAWIND);
+            luminosityModifiers.push_back(NOVABRIGHTNESS);
         }
         else if(starName == "star/wr")
         {
-            ramscoopModifiers.push_back(WRWIND);
-            solarPanelModifiers.push_back(WRBRIGHTNESS);
+            stellarWindModifiers.push_back(WRWIND);
+            luminosityModifiers.push_back(WRBRIGHTNESS);
         }
         else
         {
-            ramscoopModifiers.push_back(1);
-            solarPanelModifiers.push_back(1);
-            // TOTO(Jeremy) get rid of this message statement.
-            Messages::Add("there is an unacounted for star type!");
-            Messages::Add(starName);
+            stellarWindModifiers.push_back(1);
+            luminosityModifiers.push_back(1);
         }
-        
-        starCount++;
+        ++starCount;
 	}
-	ramscoopModifiers.sort();
-	solarPanelModifiers.sort();
+	stellarWindModifiers.sort();
+	luminosityModifiers.sort();
 	
 	// Sum up modifiers (currently using 1/n to normalize the sum).
-	ramscoopEffectiveness = 0;
-	solarPanelEffectiveness = 0;
+	stellarWindStrength = 0;
+	luminosity = 0;
 	for(int i = 0; i < starCount; i++)
     {
-        ramscoopEffectiveness += (ramscoopModifiers.back()/(i + 1));
-        solarPanelEffectiveness += (solarPanelModifiers.back()/(i + 1));
+        stellarWindStrength += (stellarWindModifiers.back()/(i + 1));
+        luminosity += (luminosityModifiers.back()/(i + 1));
         
-        ramscoopModifiers.pop_back();
-        solarPanelModifiers.pop_back();
+        stellarWindModifiers.pop_back();
+        luminosityModifiers.pop_back();
     }
     
     // Make sure that the effectiveness modifiers are not game brakeingly low or high.
-    ramscoopEffectiveness = std::max(0.25, ramscoopEffectiveness);
-    solarPanelEffectiveness = std::max(0.5, solarPanelEffectiveness);
-    solarPanelEffectiveness = std::min(2.0, solarPanelEffectiveness);
+    stellarWindStrength = std::max(0.25, stellarWindStrength);
+    luminosity = std::max(0.5, luminosity);
+    luminosity = std::min(2.0, luminosity);
 }
 
 
@@ -783,17 +779,17 @@ double System::Danger() const
 
 
 // Get the modifier for ramscoop effectiveness.
-double System::RamscoopEffectiveness() const
+double System::GetStellarWindStrength() const
 {
-    return ramscoopEffectiveness;
+    return stellarWindStrength;
 }
 
 
 
 // Get the modifier for solar panel effectiveness.
-double System::SolarPanelEffectiveness() const
+double System::GetLuminosity() const
 {
-    return solarPanelEffectiveness;
+    return luminosity;
 }
 
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -265,9 +265,9 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 	// and stellar wind values for the stars in the system.
 	for(StellarObject &object : objects)
 	{
-		if(object.IsStar())
+        if(object.IsStar())
             AddStar(object.GetSprite()->Name());
-		
+        
 		if(object.message || object.planet)
 			continue;
 		
@@ -308,8 +308,8 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 				object.message = &UNINHABITEDPLANET;
 		}
 	}
-	
-    // Make sure that the stellarWindStrength and luminosity are not game brakeingly low or high.
+
+    // Make sure that the stellarWindStrength and luminosity are reasonable.
     stellarWindStrength = std::max(0.25, stellarWindStrength);
     luminosity = std::max(0.5, luminosity);
     luminosity = std::min(2.0, luminosity);

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -265,9 +265,9 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 	// and stellar wind values for the stars in the system.
 	for(StellarObject &object : objects)
 	{
-        if(object.IsStar())
-            AddStar(object.GetSprite()->Name());
-        
+		if(object.IsStar())
+			AddStar(object.GetSprite()->Name());
+		
 		if(object.message || object.planet)
 			continue;
 		
@@ -309,10 +309,10 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		}
 	}
 
-    // Make sure that the stellarWindStrength and luminosity are reasonable.
-    stellarWindStrength = std::max(0.25, stellarWindStrength);
-    luminosity = std::max(0.5, luminosity);
-    luminosity = std::min(2.0, luminosity);
+	// Make sure that the stellarWindStrength and luminosity are reasonable.
+	stellarWindStrength = std::max(0.25, stellarWindStrength);
+	luminosity = std::max(0.5, luminosity);
+	luminosity = std::min(2.0, luminosity);
 }
 
 
@@ -645,7 +645,7 @@ double System::Danger() const
 // Get the modifier for ramscoop effectiveness.
 double System::GetStellarWindStrength() const
 {
-    return stellarWindStrength;
+	return stellarWindStrength;
 }
 
 
@@ -653,7 +653,7 @@ double System::GetStellarWindStrength() const
 // Get the modifier for solar panel effectiveness.
 double System::GetLuminosity() const
 {
-    return luminosity;
+	return luminosity;
 }
 
 
@@ -702,77 +702,77 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 // Update stellarWindStrength and luminosity to include the star's effects in the system.
 void System::AddStar(const std::string starName)
 {
-    static const double A0_LUMINOSITY = 1.8;
-    static const double A0_WIND = 0.8;
-    static const double A5_LUMINOSITY = 1.6;
-    static const double A5_WIND = 0.85;
-    static const double B5_LUMINOSITY = 2.0;
-    static const double B5_WIND = 0.75;
-    static const double F0_LUMINOSITY = 1.5;
-    static const double F0_WIND = 0.9;
-    static const double F5_LUMINOSITY = 1.2;
-    static const double F5_WIND = 0.95;
-    static const double G0_LUMINOSITY = 1.0;
-    static const double G0_WIND = 1.0;
-    static const double G5_LUMINOSITY = 0.9;
-    static const double G5_WIND = 0.9;
-    static const double GIANT_LUMINOSITY = 1.3;
-    static const double GIANT_WIND = 2.0;
-    static const double K0_LUMINOSITY = 0.85;
-    static const double K0_WIND = 0.8;
-    static const double K5_LUMINOSITY = 0.8;
-    static const double K5_WIND = 0.7;
-    static const double M0_LUMINOSITY = 0.7;
-    static const double M0_WIND = 0.6;
-    static const double M4_LUMINOSITY = 0.6;
-    static const double M4_WIND = 0.5;
-    static const double M8_LUMINOSITY = 0.5;
-    static const double M8_WIND = 0.4;
-    static const double NOVA_LUMINOSITY = 0.5;
-    static const double NOVA_WIND = 4.0;
-    static const double WR_LUMINOSITY = 2.0;
-    static const double WR_WIND = 4.0;
-    
-    if(starName == "star/a0")
-        ApplyNewStar(A0_WIND, A0_LUMINOSITY);
-    else if(starName == "star/a5")
-        ApplyNewStar(A5_WIND, A5_LUMINOSITY);
-    else if(starName == "star/b5")
-        ApplyNewStar(B5_WIND, B5_LUMINOSITY);
-    else if(starName == "star/f0")
-        ApplyNewStar(F0_WIND, F0_LUMINOSITY);
-    else if(starName == "star/f5" || starName == "star/f5-old")
-        ApplyNewStar(F5_WIND, F5_LUMINOSITY);
-    else if(starName == "star/g0" || starName == "star/g0-old")
-        ApplyNewStar(G0_WIND, G0_LUMINOSITY);
-    else if(starName == "star/g5" || starName == "star/g5-old")
-        ApplyNewStar(G5_WIND, G5_LUMINOSITY);
-    else if(starName == "star/giant")
-        ApplyNewStar(GIANT_WIND, GIANT_LUMINOSITY);
-    else if(starName == "star/k0" || starName == "star/k0-old")
-        ApplyNewStar(K0_WIND, K0_LUMINOSITY);
-    else if(starName == "star/k5" || starName == "star/k5-old")
-        ApplyNewStar(K5_WIND, K5_LUMINOSITY);
-    else if(starName == "star/m0")
-        ApplyNewStar(M0_WIND, M0_LUMINOSITY);
-    else if(starName == "star/m4")
-        ApplyNewStar(M4_WIND, M4_LUMINOSITY);
-    else if(starName == "star/m8")
-        ApplyNewStar(M8_WIND, M8_LUMINOSITY);
-    else if(starName == "star/nova")
-        ApplyNewStar(NOVA_WIND, NOVA_LUMINOSITY);
-    else if(starName == "star/wr")
-        ApplyNewStar(WR_WIND, WR_LUMINOSITY);
-    else
-        ApplyNewStar(1.0, 1.0);
+	static const double A0_LUMINOSITY = 1.8;
+	static const double A0_WIND = 0.8;
+	static const double A5_LUMINOSITY = 1.6;
+	static const double A5_WIND = 0.85;
+	static const double B5_LUMINOSITY = 2.0;
+	static const double B5_WIND = 0.75;
+	static const double F0_LUMINOSITY = 1.5;
+	static const double F0_WIND = 0.9;
+	static const double F5_LUMINOSITY = 1.2;
+	static const double F5_WIND = 0.95;
+	static const double G0_LUMINOSITY = 1.0;
+	static const double G0_WIND = 1.0;
+	static const double G5_LUMINOSITY = 0.9;
+	static const double G5_WIND = 0.9;
+	static const double GIANT_LUMINOSITY = 1.3;
+	static const double GIANT_WIND = 2.0;
+	static const double K0_LUMINOSITY = 0.85;
+	static const double K0_WIND = 0.8;
+	static const double K5_LUMINOSITY = 0.8;
+	static const double K5_WIND = 0.7;
+	static const double M0_LUMINOSITY = 0.7;
+	static const double M0_WIND = 0.6;
+	static const double M4_LUMINOSITY = 0.6;
+	static const double M4_WIND = 0.5;
+	static const double M8_LUMINOSITY = 0.5;
+	static const double M8_WIND = 0.4;
+	static const double NOVA_LUMINOSITY = 0.5;
+	static const double NOVA_WIND = 4.0;
+	static const double WR_LUMINOSITY = 2.0;
+	static const double WR_WIND = 4.0;
+	
+	if(starName == "star/a0")
+		ApplyNewStar(A0_WIND, A0_LUMINOSITY);
+	else if(starName == "star/a5")
+		ApplyNewStar(A5_WIND, A5_LUMINOSITY);
+	else if(starName == "star/b5")
+		ApplyNewStar(B5_WIND, B5_LUMINOSITY);
+	else if(starName == "star/f0")
+		ApplyNewStar(F0_WIND, F0_LUMINOSITY);
+	else if(starName == "star/f5" || starName == "star/f5-old")
+		ApplyNewStar(F5_WIND, F5_LUMINOSITY);
+	else if(starName == "star/g0" || starName == "star/g0-old")
+		ApplyNewStar(G0_WIND, G0_LUMINOSITY);
+	else if(starName == "star/g5" || starName == "star/g5-old")
+		ApplyNewStar(G5_WIND, G5_LUMINOSITY);
+	else if(starName == "star/giant")
+		ApplyNewStar(GIANT_WIND, GIANT_LUMINOSITY);
+	else if(starName == "star/k0" || starName == "star/k0-old")
+		ApplyNewStar(K0_WIND, K0_LUMINOSITY);
+	else if(starName == "star/k5" || starName == "star/k5-old")
+		ApplyNewStar(K5_WIND, K5_LUMINOSITY);
+	else if(starName == "star/m0")
+		ApplyNewStar(M0_WIND, M0_LUMINOSITY);
+	else if(starName == "star/m4")
+		ApplyNewStar(M4_WIND, M4_LUMINOSITY);
+	else if(starName == "star/m8")
+		ApplyNewStar(M8_WIND, M8_LUMINOSITY);
+	else if(starName == "star/nova")
+		ApplyNewStar(NOVA_WIND, NOVA_LUMINOSITY);
+	else if(starName == "star/wr")
+		ApplyNewStar(WR_WIND, WR_LUMINOSITY);
+	else
+		ApplyNewStar(1.0, 1.0);
 }
 
 
 
 void System::ApplyNewStar(double starWind, double starLuminosity)
 {
-    stellarWindStrength += starWind;
-    luminosity += starLuminosity;
+	stellarWindStrength += starWind;
+	luminosity += starLuminosity;
 }
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -137,18 +137,18 @@ public:
 	double Danger() const;
 	
 	// Get the effectiveness of ramscoops and solar panels in this system.
-    double GetStellarWindStrength() const;
-    double GetLuminosity() const;
+	double GetStellarWindStrength() const;
+	double GetLuminosity() const;
 	
 	
 private:
 	void LoadObject(const DataNode &node, Set<Planet> &planets, int parent = -1);
 
-    // Update stellarWindStrength and luminosity to include the star's effects in the system.
-    void AddStar(const std::string starName);
-    // Helper function for AddStar() that does the actual value 
-    // incrementation of luminosity and stellarWindStrength.
-    void ApplyNewStar(double starWind, double starLuminosity);
+	// Update stellarWindStrength and luminosity to include the star's effects in the system.
+	void AddStar(const std::string starName);
+	// Helper function for AddStar() that does the actual value 
+	// incrementation of luminosity and stellarWindStrength.
+	void ApplyNewStar(double starWind, double starLuminosity);
 
 
 private:
@@ -191,8 +191,8 @@ private:
 		
 	// Physical attributes of the space in the system. They effect things
 	// such as ramscoops and solar panels.
-    double stellarWindStrength;
-    double luminosity;
+	double stellarWindStrength;
+	double luminosity;
 };
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -137,8 +137,8 @@ public:
 	double Danger() const;
 	
 	// Get the effectiveness of ramscoops and solar panels in this system.
-	double RamscoopEffectiveness() const;
-	double SolarPanelEffectiveness() const;
+	double GetStellarWindStrength() const;
+	double GetLuminosity() const;
 	
 	
 private:
@@ -184,8 +184,8 @@ private:
 	std::map<std::string, Price> trade;
 		
 	// Effectiveness of ramscoop and solar panels in this system.
-	double ramscoopEffectiveness;
-	double solarPanelEffectiveness; 
+	double stellarWindStrength;
+	double luminosity; 
 };
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -137,20 +137,20 @@ public:
 	double Danger() const;
 	
 	// Get the effectiveness of ramscoops and solar panels in this system.
-	double GetStellarWindStrength() const;
-	double GetLuminosity() const;
+    double GetStellarWindStrength() const;
+    double GetLuminosity() const;
 	
 	
 private:
 	void LoadObject(const DataNode &node, Set<Planet> &planets, int parent = -1);
 
     // Update stellarWindStrength and luminosity to include the star's effects in the system.
-	void AddStar(const std::string starName);
-	// Helper function for AddStar() that does the actual value 
-	// incrementation of luminosity and stellarWindStrength.
-	void ApplyNewStar(double starWind, double starLuminosity);
-	
-	
+    void AddStar(const std::string starName);
+    // Helper function for AddStar() that does the actual value 
+    // incrementation of luminosity and stellarWindStrength.
+    void ApplyNewStar(double starWind, double starLuminosity);
+
+
 private:
 	class Price {
 	public:
@@ -190,8 +190,8 @@ private:
 	std::map<std::string, Price> trade;
 		
 	// Effectiveness of ramscoop and solar panels in this system.
-	double stellarWindStrength;
-	double luminosity;
+    double stellarWindStrength;
+    double luminosity;
 };
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -136,6 +136,10 @@ public:
 	// in per frame).
 	double Danger() const;
 	
+	// Get the effectiveness of ramscoops and solar panels in this system.
+	double RamscoopEffectiveness() const;
+	double SolarPanelEffectiveness() const;
+	
 	
 private:
 	void LoadObject(const DataNode &node, Set<Planet> &planets, int parent = -1);
@@ -178,6 +182,10 @@ private:
 	
 	// Commodity prices.
 	std::map<std::string, Price> trade;
+		
+	// Effectiveness of ramscoop and solar panels in this system.
+	double ramscoopEffectiveness;
+	double solarPanelEffectiveness; 
 };
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -190,6 +190,11 @@ private:
 	// such as ramscoops and solar panels.
 	double stellarWindStrength = 0;
 	double luminosity = 0;
+	
+	// For remembering whether stellarWindStrength or luminosity were manually
+	// overwritten in this system.
+	bool overrideStellarWind = false;
+	bool overrideLuminosity = false;
 };
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -189,7 +189,8 @@ private:
 	// Commodity prices.
 	std::map<std::string, Price> trade;
 		
-	// Effectiveness of ramscoop and solar panels in this system.
+	// Physical attributes of the space in the system. They effect things
+	// such as ramscoops and solar panels.
     double stellarWindStrength;
     double luminosity;
 };

--- a/source/System.h
+++ b/source/System.h
@@ -143,6 +143,12 @@ public:
 	
 private:
 	void LoadObject(const DataNode &node, Set<Planet> &planets, int parent = -1);
+
+    // Update stellarWindStrength and luminosity to include the star's effects in the system.
+	void AddStar(const std::string starName);
+	// Helper function for AddStar() that does the actual value 
+	// incrementation of luminosity and stellarWindStrength.
+	void ApplyNewStar(double starWind, double starLuminosity);
 	
 	
 private:
@@ -185,7 +191,7 @@ private:
 		
 	// Effectiveness of ramscoop and solar panels in this system.
 	double stellarWindStrength;
-	double luminosity; 
+	double luminosity;
 };
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -146,10 +146,7 @@ private:
 
 	// Update stellarWindStrength and luminosity to include the star's effects in the system.
 	void AddStar(const std::string starName);
-	// Helper function for AddStar() that does the actual value 
-	// incrementation of luminosity and stellarWindStrength.
-	void ApplyNewStar(double starWind, double starLuminosity);
-
+	
 
 private:
 	class Price {
@@ -191,8 +188,8 @@ private:
 		
 	// Physical attributes of the space in the system. They effect things
 	// such as ramscoops and solar panels.
-	double stellarWindStrength;
-	double luminosity;
+	double stellarWindStrength = 0;
+	double luminosity = 0;
 };
 
 


### PR DESCRIPTION
This is in reference to issue #2759. The solution presented is pretty much exactly as I had outlined in the issue.  ~~(Including how modifiers are added together for multiple star, star systems.)~~

EDIT: Modifiers are now summed without any weighting.

The modifiers that are implemented in this pull request are just numbers that I came up with after about an hour on Wikipedia. That is to say that they try to be a little realistic and hopefully still fit into the scope of the game. For example, red dwarfs have low brightness and wind, and W-R stars have large wind and brightness (apparently they are some of the brightest objects in the sky). All of the numbers are trying to be relative to the G0 class stars (the ones similar to Sol) which have default values for both wind and brightness. 

Here is a complete table of the modifiers as they currently are in this pull request:

| Star Type  | Luminosity | Stellar Wind |
| --- | --- | --- |
| A0  | 1.8  | .8 |
| A5  | 1.6  | .85 |
| B5  | 2  | .75 |
| F0  | 1.5  | .9 |
| F5  | 1.2  | .95 |
| G0  | 1  | 1 |
| G5  | .9  | .9 |
| Giant  | 1.3  | 2 |
| K0 | .85  | .8 |
| K5  | .8  | .7 |
| M0  | .7  | .6 |
| M4  | .6  | .5 |
| M8  | .5  | .4 |
| Nova  | .5  | 4 |
| W-R  | 2  | 4 |

The modifiers all live in system.cpp right now and it's a little messy. I am open to changing where the this code lives and updating the pull request with those changes and any good suggestions on changes to the modifiers.