### PR TITLE
Lore friendly Quarg Rep

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -352,3 +352,639 @@ government "Wanderer"
 	"friendly hail" "wanderer untranslated"
 	"hostile hail" "wanderer untranslated"
 	"hostile disabled hail" "wanderer untranslated"
+# Copyright (c) 2014 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+government "Alpha"
+	swizzle 1
+	"player reputation" -1000
+	"bribe" 0
+
+government "Author"
+	"player reputation" 1
+	"bribe" 0
+
+government "Bounty"
+	swizzle 6
+	"player reputation" -1000
+	"fine" 0
+	"hostile hail" "hostile bounty"
+
+government "Bounty Hunter"
+	swizzle 6
+	color .78 0 0
+
+	"player reputation" -1000
+	"bribe" .2
+	"fine" 0
+	"hostile hail" "hostile bounty hunter"
+
+government "Coalition"
+	swizzle 5
+	color 1 .6 .7
+	language "Coalition"
+	"player reputation" 1
+	"attitude toward"
+		"Heliarch" 1
+
+government "Deep"
+	swizzle 0
+	"player reputation" -1000
+
+government "Drak"
+	swizzle 5
+	color 1 1 1
+	"player reputation" 1
+	"fine" 0
+	"attitude toward"
+		"Indigenous Lifeform" 1
+
+government "Escort"
+	swizzle 5
+	"fine" 0
+
+government "Free Worlds"
+	swizzle 2
+	color .06 .68 0
+	
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .3
+		"Militia" .3
+		"Pirate" -.4
+		"Neutral" .1
+	"bribe" .1
+	"friendly hail" "friendly free worlds"
+	"hostile hail" "hostile free worlds"
+	raid "pirate raid"
+
+government "Hai"
+	swizzle 0
+	color .84 .42 .81
+	
+	"player reputation" 0
+	"attitude toward"
+		"Hai (Unfettered)" -.5
+	"bribe" .02
+	"fine" 0
+	"friendly hail" "friendly hai"
+	"hostile hail" "hostile hai"
+
+government "Hai (Unfettered)"
+	swizzle 4
+	color .69 .33 .82
+	
+	"player reputation" -1000
+	"attitude toward"
+		"Hai" -.01
+		"Wanderer" -.01
+		"Pug" -.01
+		"Merchant" -.01
+		"Kor Efret" -.01
+	"bribe" .02
+	"fine" 0
+	"friendly hail" "friendly unfettered"
+	"hostile hail" "hostile unfettered"
+
+government "Heliarch"
+	swizzle 0
+	color 1 .8 .5
+	"player reputation" 1
+	"friendly hail" "friendly heliarch"
+	"attitude toward"
+		"Quarg" -.01
+		"Coalition" 1
+
+government "Independent"
+	swizzle 6
+	color .78 .36 .36
+	
+	"player reputation" 10
+	"bribe" .05
+	"fine" 0
+	"friendly hail" "friendly civilian"
+	"hostile hail" "hostile civilian"
+	raid "Large Southern Pirates"
+
+government "Indigenous Lifeform"
+	# Nothing you do permanently angers indigenous creatures, because they are
+	# not sentient and do not remember you as an individual.
+	"player reputation" 1
+	"penalty for"
+		assist 0
+		disable 0
+		board 0
+		capture 0
+		destroy 0
+		atrocity 0
+
+government "Korath"
+	swizzle 0
+	color .8 .5 .1
+	language "Korath"
+	
+	"attitude toward"
+		"Kor Sestor" -.01
+	
+	"player reputation" -10
+
+government "Korath Nanobots"
+	"player reputation" -1000
+
+government "Kor Efret"
+	swizzle 4
+	color .49 .33 .69
+	language "Korath"
+	
+	"attitude toward"
+		"Kor Mereti" -.01
+		"Kor Sestor" -.01
+	
+	"player reputation" 1
+
+government "Kor Mereti"
+	swizzle 5
+	color .32 .36 .65
+	language "Korath"
+	
+	"attitude toward"
+		"Kor Sestor" -.01
+		"Wanderer" -.01
+	
+	"player reputation" -1000
+
+government "Kor Sestor"
+	swizzle 0
+	color .75 .27 .37
+	language "Korath"
+	
+	"attitude toward"
+		"Kor Mereti" -.01
+		"Wanderer" -.01
+		"Republic" -.01
+		"Merchant" -.01
+		"Navy (Oathkeeper)" -.01
+		"Syndicate" -.01
+	
+	"player reputation" -1000
+
+government "Merchant"
+	swizzle 5
+	
+	"player reputation" 10
+	"attitude toward"
+		"Pirate" -.2
+		"Korath" -.2
+	"bribe" .05
+	"fine" 0
+	"friendly hail" "friendly civilian"
+	"hostile hail" "hostile civilian"
+
+government "Militia"
+	swizzle 2
+	color .06 .68 0
+	
+	"player reputation" 0
+	"attitude toward"
+		"Merchant" .3
+		"Pirate" -.4
+	"bribe" .1
+	"friendly hail" "friendly militia"
+	"hostile hail" "hostile militia"
+
+government "Navy Intelligence"
+	swizzle 0
+	"attitude toward"
+		"Syndicate" -.1
+		"Pirate" -.3
+
+government "Navy (Oathkeeper)"
+	swizzle 0
+	color .91 .42 .09
+	
+	"player reputation" 100
+	"attitude toward"
+		"Alpha" -.3
+		"Merchant" .25
+		"Militia" .1
+		"Pirate" -.3
+		"Kor Sestor" -.1
+		"Kor Mereti" -.1
+		"Navy Intelligence" 1
+	"friendly hail" "friendly navy"
+	"hostile hail" "hostile navy"
+
+government "Neutral"
+	swizzle 0
+	color .84 .61 .37
+	
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .3
+		"Pirate" -.2
+	"bribe" .05
+	"friendly hail" "friendly civilian"
+	"hostile hail" "hostile civilian"
+	raid "pirate raid"
+
+government "Parrot"
+	swizzle 2
+	"player reputation" 1
+	"bribe" 0
+
+government "Pirate"
+	swizzle 6
+	color .78 0 0
+	
+	"player reputation" -10
+	"attitude toward"
+		"Merchant" -.1
+		"Syndicate" -.01
+		"Korath" -.01
+		"Author" -.01
+	"bribe" .05
+	"fine" 0
+	"friendly hail" "friendly pirate"
+	"hostile hail" "hostile pirate"
+	raid "pirate raid"
+
+government "Pug"
+	swizzle 0
+	color .99 .89 .70
+	
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .1
+		"Pirate" -.1
+	"friendly hail" "friendly pug"
+	"hostile hail" "hostile pug"
+
+government "Quarg"
+	swizzle 0
+	color .88 .77 0
+	
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .01
+		"Kor Efret" .01
+		"Kor Mereti" -.01
+		"Kor Sestor" -.01
+		"Hai" .01
+		"Pirate" -.01
+	"hostile hail" "hostile quarg"
+
+government "Remnant"
+	swizzle 0
+	color .89 .38 .62
+	
+	"player reputation" 1
+	"attitude toward"
+		"Korath" -.01
+
+government "Republic"
+	swizzle 0
+# Copyright (c) 2014 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+government "Alpha"
+	swizzle 1
+	"player reputation" -1000
+	"bribe" 0
+
+government "Author"
+	"player reputation" 1
+	"bribe" 0
+
+government "Bounty"
+	swizzle 6
+	"player reputation" -1000
+	"fine" 0
+	"hostile hail" "hostile pirate"
+
+government "Bounty Hunter"
+	swizzle 6
+	color .78 0 0
+
+	"player reputation" -1000
+	"bribe" .2
+	"fine" 0
+	"hostile hail" "hostile bounty hunter"
+
+government "Coalition"
+	swizzle 5
+	color 1 .6 .7
+	language "Coalition"
+	"player reputation" 1
+	"attitude toward"
+		"Heliarch" 1
+		"Quarg" -.08
+
+government "Deep"
+	swizzle 0
+	"player reputation" -1000
+
+government "Derelict"
+	swizzle 0
+	"player reputation" 10
+
+government "Drak"
+	swizzle 5
+	color 1 1 1
+	"player reputation" 1
+	"fine" 0
+
+government "Escort"
+	swizzle 5
+	"fine" 0
+
+government "Free Worlds"
+	swizzle 2
+	color .06 .68 0
+	
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .3
+		"Militia" .3
+		"Pirate" -.4
+		"Neutral" .1
+	"bribe" .1
+	"friendly hail" "friendly free worlds"
+	"hostile hail" "hostile free worlds"
+	raid "pirate raid"
+
+government "Hai"
+	swizzle 0
+	color .84 .42 .81
+	
+	"player reputation" 0
+	"attitude toward"
+		"Hai (Unfettered)" -.5
+	"bribe" .02
+	"fine" 0
+	"friendly hail" "friendly hai"
+	"hostile hail" "hostile hai"
+
+government "Hai (Unfettered)"
+	swizzle 4
+	color .69 .33 .82
+	
+	"player reputation" -1000
+	"attitude toward"
+		"Hai" -.01
+		"Wanderer" -.01
+		"Pug" -.01
+		"Merchant" -.01
+		"Kor Efret" -.01
+	"bribe" .02
+	"fine" 0
+	"hostile hail" "hostile unfettered"
+
+government "Heliarch"
+	swizzle 0
+	color 1 .8 .5
+	"player reputation" 1
+	"friendly hail" "friendly heliarch"
+	"attitude toward"
+		"Quarg" -.08
+		"Coalition" 1
+
+government "Independent"
+	swizzle 6
+	color .78 .36 .36
+	
+	"player reputation" 10
+	"bribe" .05
+	"fine" 0
+	"friendly hail" "friendly civilian"
+	"hostile hail" "hostile civilian"
+	raid "Large Southern Pirates"
+
+government "Korath"
+	swizzle 0
+	color .8 .5 .1
+	language "Korath"
+	
+	"attitude toward"
+		"Kor Sestor" -.01
+	
+	"player reputation" -10
+
+government "Korath Nanobots"
+	"player reputation" -1000
+
+government "Kor Efret"
+	swizzle 4
+	color .49 .33 .69
+	language "Korath"
+	
+	"attitude toward"
+		"Kor Mereti" -.01
+		"Kor Sestor" -.01
+	
+	"player reputation" 1
+
+government "Kor Mereti"
+	swizzle 5
+	color .32 .36 .65
+	language "Korath"
+	
+	"attitude toward"
+		"Kor Sestor" -.01
+		"Wanderer" -.01
+	
+	"player reputation" -1000
+
+government "Kor Sestor"
+	swizzle 0
+	color .75 .27 .37
+	language "Korath"
+	
+	"attitude toward"
+		"Kor Mereti" -.01
+		"Wanderer" -.01
+		"Republic" -.01
+		"Merchant" -.01
+		"Navy (Oathkeeper)" -.01
+		"Syndicate" -.01
+	
+	"player reputation" -1000
+
+government "Merchant"
+	swizzle 5
+	
+	"player reputation" 10
+	"attitude toward"
+		"Pirate" -.2
+		"Korath" -.2
+	"bribe" .05
+	"fine" 0
+	"friendly hail" "friendly civilian"
+	"hostile hail" "hostile civilian"
+
+government "Militia"
+	swizzle 2
+	color .06 .68 0
+	
+	"player reputation" 0
+	"attitude toward"
+		"Merchant" .3
+		"Pirate" -.4
+	"bribe" .1
+	"friendly hail" "friendly militia"
+	"hostile hail" "hostile militia"
+
+government "Navy Intelligence"
+	swizzle 0
+	"attitude toward"
+		"Syndicate" -.1
+		"Pirate" -.3
+
+government "Navy (Oathkeeper)"
+	swizzle 0
+	color .91 .42 .09
+	
+	"player reputation" 100
+	"attitude toward"
+		"Alpha" -.3
+		"Merchant" .25
+		"Militia" .1
+		"Pirate" -.3
+		"Kor Sestor" -.1
+		"Kor Mereti" -.1
+		"Navy Intelligence" 1
+	"friendly hail" "friendly navy"
+	"hostile hail" "hostile navy"
+
+government "Neutral"
+	swizzle 0
+	color .84 .61 .37
+	
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .3
+		"Pirate" -.2
+	"bribe" .05
+	"friendly hail" "friendly civilian"
+	"hostile hail" "hostile civilian"
+	raid "pirate raid"
+
+government "Parrot"
+	swizzle 2
+	"player reputation" 1
+	"bribe" 0
+
+government "Pirate"
+	swizzle 6
+	color .78 0 0
+	
+	"player reputation" -10
+	"attitude toward"
+		"Merchant" -.1
+		"Syndicate" -.1
+		"Korath" -.1
+		"Author" -.1
+	"bribe" .05
+	"fine" 0
+	"friendly hail" "friendly pirate"
+	"hostile hail" "hostile pirate"
+	raid "Large Southern Pirates"
+
+government "Pug"
+	swizzle 0
+	color .99 .89 .70
+	
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .1
+		"Quarg" -.08
+		"Pirate" -.1
+	"friendly hail" "friendly pug"
+	"hostile hail" "hostile pug"
+
+government "Quarg"
+	swizzle 0
+	color .88 .77 0
+	
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .01
+		"Pug" -.08
+		"Coalition" -.08
+		"Kor Efret" .01
+		"Kor Mereti" -.01
+		"Kor Sestor" -.01
+		"Hai" .01
+		"Pirate" -.01
+	"hostile hail" "hostile quarg"
+
+government "Republic"
+	swizzle 0
+	color .91 .42 .09
+	
+	"player reputation" 2
+	"attitude toward"
+		"Alpha" -.3
+		"Merchant" .25
+		"Militia" .1
+		"Pirate" -.3
+		"Navy Intelligence" 1
+		"Navy (Oathkeeper)" 1
+		"Neutral" .1
+	"friendly hail" "friendly navy"
+	"hostile hail" "hostile navy"
+	raid "pirate raid"
+
+government "Syndicate"
+	swizzle 4
+	color 0 .41 .71
+	
+	"player reputation" 2
+	"attitude toward"
+		"Merchant" .3
+		"Pirate" -.4
+		"Korath" -.5
+	"bribe" .08
+	"friendly hail" "friendly syndicate"
+	"hostile hail" "hostile syndicate"
+	raid "Small Core Pirates"
+
+government "Syndicate (Extremist)"
+	swizzle 1
+	color 0 .41 .71
+	
+	"player reputation" -1000
+	"attitude toward"
+		"Syndicate" -.01
+		"Republic" -.01
+		"Free Worlds" -.01
+	"bribe" 0
+	"hostile hail" "hostile syndicate"
+
+government "Test Dummy"
+	swizzle 3
+	"player reputation" -1000
+
+government "Uninhabited"
+	color .3 .3 .3
+
+government "Wanderer"
+	swizzle 2
+	color .70 .91 .12
+	"player reputation" 1
+	language "Wanderer"
+	"friendly hail" "wanderer untranslated"
+	"hostile hail" "wanderer untranslated"


### PR DESCRIPTION
During the Wanderers campaign, the Quarg mention their dislike for the Pug, and the Pug express similar feelings. When talking to the Coalition/Heliarchs, they mention their dislike for the Quarg, and you can assume that the feeling is mutual. With this in mind, I changed the Quarg/Pug and Quarg/Coalition/Heliarch so that killing Pug, gives a small rep increase to Quarg, and visa versa, and killing Quarg increases Coalition/Heliarch rep and visa versa.