### PR TITLE
Implement add/remove syntax for the Wanderers campaign

### DIFF
--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -231,12 +231,11 @@ event "wanderers: kaliptari battle begins"
 
 event "wanderers: kaliptari battle ends"
 	system Kaliptari
-		fleet "Large Quarg" 2000
-		fleet "Small Kor Mereti" 8000
-		fleet "Large Kor Mereti" 3600
-		fleet "Wanderer Defense" 1000
-		fleet "Wanderer Drones" 500
-		fleet "Wanderer Flycatchers" 500
+		add fleet "Large Quarg" 2000
+		add fleet "Small Kor Mereti" 8000
+		add fleet "Large Kor Mereti" 3600
+		add fleet "Wanderer Defense" 1000
+		add fleet "Wanderer Drones" 500
 
 mission "Wanderers: First Mereti Attack"
 	landing
@@ -1094,11 +1093,10 @@ mission "Wanderers: Mind 6"
 
 event "wanderers: kor mereti transformation"
 	system Chimitarp
-		fleet "Small Kor Mereti" 200
-		fleet "Large Kor Mereti" 400
+		add fleet "Small Kor Mereti" 250
+		add fleet "Large Kor Mereti" 450
 	planet "Korbatri Eska"
-		description `The cities on this world have been hit by an astonishing variety of weapons. Some were leveled by massive explosions, while others show signs of strafing by low-flying ships or of orbital bombardment. Outside the cities, the land is fruitful and varied: forests, mountains, oceans, desert, and tundra.`
-		description `	Far from the ruined cities, the Kor Mereti have begun building a sort of village of their own: a sprawling complex of greenhouses containing a wide variety of plant samples.`
+		add description `	Far from the ruined cities, the Kor Mereti have begun building a sort of village of their own: a sprawling complex of greenhouses containing a wide variety of plant samples.`
 
 mission "Wanderers: Mind 7"
 	landing
@@ -1662,30 +1660,18 @@ event "wanderers: kor sestor are aimless"
 		fleet "Large Kor Mereti" 900
 		fleet "Large Kor Sestor" 5000
 	system Eshkoshtar
-		fleet "Small Kor Mereti" 800
-		fleet "Large Kor Mereti" 1600
-		fleet "Kor Mereti Miners" 3000
+		remove fleet "Large Kor Sestor"
 	system Salipastart
-		fleet "Small Kor Mereti" 800
-		fleet "Large Kor Mereti" 1600
-		fleet "Kor Mereti Miners" 3000
+		remove fleet "Large Kor Sestor"
 	system Mekislepti
-		fleet "Small Kor Mereti" 1000
-		fleet "Large Kor Mereti" 3000
-		fleet "Kor Mereti Miners" 2000
+		remove fleet "Large Kor Sestor"
 	system Similisti
-		fleet "Large Kor Mereti" 1600
-		fleet "Small Kor Mereti" 600
-		fleet "Kor Mereti Miners" 1600
+		remove fleet "Large Kor Sestor"
 	system Faronektu
-		fleet "Small Kor Mereti" 1200
-		fleet "Large Kor Mereti" 2000
-		fleet "Kor Mereti Miners" 2000
+		remove fleet "Large Kor Sestor"
 	planet "Varu K'prai"
-		attributes wanderer oil
 		landscape land/beach1
-		description `This is one of the only Wanderer worlds that still has large reserves of oil, albeit deep below the ocean surface where mining is difficult. Aside from the drilling companies and refineries, the largest local employer is the local government's safety oversight department, whose inspectors are constantly visiting the drilling platforms and shipping hubs to ensure that all the regulations for preventing oil spills are being followed.`
-		description `	There used to be a thriving spaceport here, but it has been razed to the ground by the Kor Sestor fleet.`
+		add description `	There used to be a thriving spaceport here, but it has been razed to the ground by the Kor Sestor fleet.`
 		remove spaceport
 		remove outfitter
 		remove "required reputation"
@@ -3039,8 +3025,8 @@ event "wanderers: sestor shutdown"
 		fleet "Small Kor Sestor" 3200
 		fleet "Large Kor Sestor" 4800
 	system "Mesuket"
-		fleet "Large Kor Mereti" 900
-		fleet "Large Kor Sestor" 10000
+		remove fleet "Large Kor Sestor"
+		add fleet "Large Kor Sestor" 10000
 
 mission "Wanderers: Sestor: Factory 3"
 	landing
@@ -3148,7 +3134,7 @@ event "wanderers: sestor eliminated"
 		government "Uninhabited"
 		fleet "Large Kor Mereti" 2000
 	system "Mesuket"
-		fleet "Large Kor Mereti" 900
+		remove fleet "Large Kor Sestor"
 
 event "wanderers: sabira eseskrai colony"
 	system "Skeruto"
@@ -3158,9 +3144,9 @@ event "wanderers: sabira eseskrai colony"
 		fleet "Wanderer Drones" 800
 		fleet "Kor Efret Home" 800
 	system "Furmeliki"
-		fleet "Large Quarg" 1000
-		fleet "Kor Efret Home" 800
+		add fleet "Kor Efret Home" 800
 	planet "Sabira Eseskrai"
+		add attributes wanderer
 		description `Long ago, this planet was home to several Korath oil mining settlements, but now all that remains visible are the tops of a few dozen of the tallest buildings. Everything else has been buried by sandstorms.`
 		description `	Due to a recent shift in climate the deserts have begun shrinking once more, with local vegetation growing to cover more and more land each year. The Wanderers, working together with the Kor Efreti, have founded a settlement here and begun working to accelerate the process of rejuvenating the wastelands.`
 		spaceport `This small settlement is populated by a roughly equal number of Korath and Wanderer settlers. Since most of them do not speak each other's language, the two groups do not mingle much, and communicate mostly via gestures and drawings. It's not much, but it's at least a start for the two species to begin learning from each other.`

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -434,9 +434,8 @@ event "Sich'ka'ara empty"
 
 event "Sich'ka'ara restored"
 	system "Sich'ka'ara"
-		fleet "Wanderer Freight" 600
-		fleet "Wanderer Drones" 3000
-		fleet "Wanderer Defense" 2000
+		add fleet "Wanderer Freight" 600
+		add fleet "Wanderer Defense" 2000
 
 
 
@@ -573,19 +572,14 @@ event "wanderer / unfettered peace"
 		"attitude toward"
 			"Wanderer" 0
 	system "Ehma Ti"
-		fleet "Small Unfettered" 500
-		fleet "Large Unfettered" 500
-		fleet "Unfettered Tribute" 1000
+		remove fleet "Unfettered Raid"
+		add fleet "Unfettered Tribute" 1000
 	system "Chy'chra"
-		fleet "Wanderer Freight" 1500
-		fleet "Wanderer Drones" 1000
-		fleet "Wanderer Defense" 300
-		fleet "Unfettered Tribute" 2000
+		remove fleet "Unfettered Raid"
+		add fleet "Unfettered Tribute" 2000
 	system "Prakacha'a"
-		fleet "Wanderer Freight" 400
-		fleet "Wanderer Drones" 400
-		fleet "Wanderer Defense" 400
-		fleet "Unfettered Tribute" 2000
+		remove fleet "Unfettered Raid"
+		add fleet "Unfettered Tribute" 2000
 
 
 
@@ -2060,10 +2054,9 @@ mission "Wanderers Defend Sich'ka'ara"
 
 event "battle for sich'ka'ara ends"
 	system "Sich'ka'ara"
-		fleet "Wanderer Freight" 900
-		fleet "Wanderer Defense" 400
-		fleet "Wanderer Flycatchers" 300
-		fleet "Large Unfettered" 400
+		add fleet "Wanderer Freight" 900
+		add fleet "Wanderer Defense" 400
+		add fleet "Large Unfettered" 400
 	system "Chirr'ay'akai"
 		government "Hai (Unfettered)"
 		fleet "Wanderer Defense" 800
@@ -2347,11 +2340,10 @@ event "battle for ap'arak"
 
 event "battle for ap'arak ends"
 	system "Ap'arak"
-		fleet "Wanderer Freight" 2000
-		fleet "Wanderer Drones" 4000
-		fleet "Wanderer Defense" 600
-		fleet "Wanderer Flycatchers" 400
-		fleet "Large Unfettered" 700
+		add fleet "Wanderer Freight" 2000
+		add fleet "Wanderer Drones" 4000
+		add fleet "Wanderer Defense" 600
+		add fleet "Large Unfettered" 700
 
 mission "Wanderers Ap'arak 2"
 	landing

--- a/data/wanderers.txt
+++ b/data/wanderers.txt
@@ -594,39 +594,19 @@ phrase "hostile disabled wanderer"
 
 event "wanderers: first tech increase"
 	system "Ik'kara'ka"
-		fleet "Wanderer Freight" 600
-		fleet "Wanderer Drones" 700
-		fleet "Wanderer Defense" 600
-		fleet "Wanderer Flycatchers" 400
+		add fleet "Wanderer Flycatchers" 400
 	system "Chy'chra"
-		fleet "Wanderer Freight" 1500
-		fleet "Wanderer Drones" 1000
-		fleet "Wanderer Defense" 300
-		fleet "Wanderer Flycatchers" 300
+		add fleet "Wanderer Flycatchers" 300
 	system "Prakacha'a"
-		fleet "Wanderer Freight" 400
-		fleet "Wanderer Drones" 400
-		fleet "Wanderer Defense" 400
+		remove fleet "Unfettered Tribute"
 	system "Sich'ka'ara"
-		fleet "Wanderer Freight" 600
-		fleet "Wanderer Drones" 3000
-		fleet "Wanderer Defense" 2000
-		fleet "Wanderer Flycatchers" 600
+		add fleet "Wanderer Flycatchers" 600
 	system "Chirr'ay'akai"
-		fleet "Wanderer Freight" 800
-		fleet "Wanderer Drones" 600
-		fleet "Wanderer Defense" 2000
-		fleet "Wanderer Flycatchers" 800
+		add fleet "Wanderer Flycatchers" 800
 	system "Kiro'ku"
-		fleet "Wanderer Freight" 800
-		fleet "Wanderer Drones" 3000
-		fleet "Wanderer Defense" 7000
-		fleet "Wanderer Flycatchers" 1000
+		add fleet "Wanderer Flycatchers" 1000
 	system "Ap'arak"
-		fleet "Wanderer Freight" 500
-		fleet "Wanderer Drones" 2000
-		fleet "Wanderer Defense" 3000
-		fleet "Wanderer Flycatchers" 1200
+		add fleet "Wanderer Flycatchers" 1200
 	fleet "Wanderer Defense"
 		add variant 2
 			"Autumn Leaf" 2
@@ -676,26 +656,19 @@ event "wanderers: unfettered invasion starts"
 		fleet "Small Unfettered" 1800
 		fleet "Large Unfettered" 800
 	system "Ehma Ti"
-		fleet "Small Unfettered" 500
-		fleet "Large Unfettered" 500
+		remove fleet "Unfettered Tribute"
 	system "Sich'ka'ara"
-		fleet "Wanderer Freight" 600
-		fleet "Wanderer Drones" 3000
-		fleet "Wanderer Defense" 400
-		fleet "Wanderer Flycatchers" 300
-		fleet "Large Unfettered" 1200
+		add fleet "Wanderer Defense" 500
+		add fleet "Wanderer Flycatchers" 600
+		add fleet "Large Unfettered" 1200
 	system "Chirr'ay'akai"
-		fleet "Wanderer Freight" 800
-		fleet "Wanderer Drones" 600
-		fleet "Wanderer Defense" 400
-		fleet "Wanderer Flycatchers" 300
-		fleet "Large Unfettered" 1200
+		add fleet "Wanderer Defense" 500
+		add fleet "Wanderer Flycatchers" 480
+		add fleet "Large Unfettered" 1200
 	"reputation: Hai (Unfettered)" <?= -100
 	government "Hai (Unfettered)"
 		"attitude toward"
 			"Wanderer" -.01
-	outfitter "Wanderer Advanced"
-		"Wanderer Anti-Missile"
 	planet "Varu K'est"
 		attributes unfettered
 		description `Varu K'est is a spare, ancient planet of arid plateaus and deep, meandering canyons, with too little rainfall to support any but the hardiest of shrubs. Before the Unfettered invaded, the only Wanderer settlements remaining here were the military bases they had set up to defend their frontier. Now, it is home to an ever-growing number of Unfettered settlements, including many civilians who have come here just for the chance to live on a world that is not overcrowded and polluted.`
@@ -786,34 +759,7 @@ planet "The Eye"
 event "wanderers: the eye begins to open"
 	system Sko'karak
 		fleet "Wanderer Defense" 500
-		object
-			sprite star/m0
-			period 10
-		object
-			sprite planet/rock8
-			distance 154.36
-			period 42.8832
-		object
-			sprite planet/rock18
-			distance 384.05
-			period 168.293
-		object
-			sprite planet/desert1
-			distance 617.3
-			period 342.949
-		object
-			sprite planet/gas4
-			distance 1227.46
-			period 961.603
-			object
-				sprite planet/callisto
-				distance 272
-				period 15.8216
-			object
-				sprite planet/rock3
-				distance 406
-				period 28.8527
-		object
+		add object
 			sprite planet/wisp
 			distance 2331.95
 			period 2518.05
@@ -821,44 +767,16 @@ event "wanderers: the eye begins to open"
 event "wanderers: the eye opens"
 	unvisit Sabriset
 	system Sabriset
-		fleet "Large Quarg" 4000
-		fleet "Wanderer Defense" 1200
-		fleet "Wanderer Drones" 600
-		fleet "Wanderer Freight" 4000
-		object
-			sprite star/g0
-			distance 35.1028
-			period 12.1391
-		object
-			sprite star/k0
-			distance 77.8972
-			period 12.1391
-			offset 180
-		object
-			sprite planet/desert1
-			distance 279.387
-			period 47.1932
-		object
-			sprite planet/lava7
-			distance 738.015
-			period 202.613
-			offset 212.423
-		object
-			sprite planet/desert2
-			distance 1012.78
-			period 325.718
-		object
-			sprite planet/rock5
-			distance 1367.84
-			period 511.237
-		object "The Eye"
+		add fleet "Wanderer Defense" 1200
+		add fleet "Wanderer Drones" 600
+		add fleet "Wanderer Freight" 4000
+		add object "The Eye"
 			sprite planet/wormhole
 			distance 2022.87
 			period 919.438
 	system Sepriaptu
-		fleet "Large Quarg" 4000
-		fleet "Wanderer Defense" 1600
-		fleet "Wanderer Drones" 800
+		add fleet "Wanderer Defense" 1600
+		add fleet "Wanderer Drones" 800
 	system Kaliptari
 		fleet "Large Quarg" 2000
 		fleet "Small Kor Mereti" 8000
@@ -876,15 +794,13 @@ event "wanderers: the eye opens"
 	system Skeruto
 		fleet "Large Quarg" 1000
 	system Mekislepti
-		fleet "Small Kor Mereti" 800
-		fleet "Large Kor Mereti" 2400
-		fleet "Large Kor Sestor" 8000
-		fleet "Wanderer Drones" 2000
+		add fleet "Small Kor Mereti" 4000
+		add fleet "Large Kor Mereti" 12000
+		add fleet "Wanderer Drones" 2000
 	unvisit Sko'karak
 	system Sko'karak
-		fleet "Wanderer Defense" 500
-		fleet "Wanderer Drones" 400
-		fleet "Wanderer Freight" 2000
+		add fleet "Wanderer Drones" 400
+		add fleet "Wanderer Freight" 2000
 		object
 			sprite star/m0
 			period 10
@@ -947,17 +863,13 @@ event "wanderers: derecho mass production"
 
 event "wanderers: spera anatrusk colony"
 	system Ap'arak
-		fleet "Wanderer Freight" 2000
-		fleet "Wanderer Drones" 4000
-		fleet "Wanderer Defense" 600
-		fleet "Wanderer Flycatchers" 400
-		fleet "Large Unfettered" 8000
+		remove fleet "Large Unfettered"
+		add fleet "Large Unfettered" 8000
 	system Kaliptari
 		government "Wanderer"
 	planet "Spera Anatrusk"
 		attributes wanderer
-		description `This is a relatively dry planet, and the only Korath cities were close to the poles where the temperatures are more mild and the lifeless deserts give way to grasslands and even a few scattered forests. The largest city was clearly destroyed by orbital bombardment. The other cities seem to have been done in by rioting or looting, leaving smashed windows and burned-out buildings behind. Some of the damage is very recent; the Korath survivors here held out for a long time.`
-		description `	Hidden deep in a canyon, the Wanderers have begun establishing a military base here.`
+		add description `	Hidden deep in a canyon, the Wanderers have begun establishing a military base here.`
 		spaceport `The Wanderers have hollowed out hangars and caves in the soft sandstone walls of this canyon and have begun to build a military base where they can store supplies and repair their ships while trying to decide how best to deal with the new challenges that face them in Korath space.`
 		spaceport `	Oddly enough, they have also found enough time to plant a large garden on a terrace near the base of the canyon, where they are experimenting to find out which plant species will best grow in this arid environment. The Wanderer drive to understand and transform the local ecology is strong, indeed.`
 
@@ -992,5 +904,5 @@ event "wanderers: desi seledrak"
 	planet "Desi Seledrak"
 		attributes wanderer
 		description `Plumes of soot and ash rise from a cluster of several dozen volcanoes on this planet's main continent, shrouding the planet in a thick layer of clouds and choking out the sunlight. The ruins of several Korath cities and the geometric grids of cleared land surrounding them show that this was once a farming world, but now few plants are able to survive and kilometer-high glaciers have begun creeping down from the poles.`
-		description `	With some help from the Mereti drones, the Wanderers have set up factories here that are pumping carbon dioxide and methane to warm the atmosphere. In a few decades, the glaciers may start to recede.`
+		description `	With some help from the Mereti drones, the Wanderers have set up factories here that are pumping out carbon dioxide and methane to warm the atmosphere. In a few decades, the glaciers may start to recede.`
 		spaceport `This odd settlement was built half by the Wanderers and half by the Mereti drones. The layout of the streets is completely chaotic, and they have planted rows of trees and bushes everywhere: some inside greenhouses, and some hardier species out in the open air. The settlement is near the equator, but it is still not particularly warm.`


### PR DESCRIPTION
This work is taken from my PR that adds more mining variants (to capitalize on #2726 ) and extends mining from just humans and the Kor Mereti to almost all factions. When it came time to add to the Wanderers, I noticed that while we had updated the fleet definitions with add/remove, we had entirely neglected to do the same for system definitions. 

This PR splits the work of changing how the fleets are defined in Wanderer events from the tangentially related "update fleets and races to utilize mining" that is #2752 