### PR TITLE
Remove unused 'forget' defintion

### DIFF
--- a/source/Engine.h
+++ b/source/Engine.h
@@ -147,9 +147,6 @@ private:
 	std::list<Projectile> projectiles;
 	std::list<std::shared_ptr<Flotsam>> flotsam;
 	std::list<Effect> effects;
-	// Keep track of which ships we have not seen for long enough that it is
-	// time to stop tracking their movements.
-	std::map<std::list<Ship>::iterator, int> forget;
 	
 	std::list<ShipEvent> eventQueue;
 	std::list<ShipEvent> events;


### PR DESCRIPTION
Ship 'forget' tracking is done internally within the Ship class.