### PR TITLE
Bugfix: do not transfer crew to automatons when short on crew

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1845,10 +1845,13 @@ void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 	// is not possible, in which case, share evenly.
 	int totalRequired = capturer->RequiredCrew() + RequiredCrew();
 	int transfer = RequiredCrew();
-	if(totalRequired > capturer->Crew())
-		transfer = max(1, (capturer->Crew() * RequiredCrew()) / totalRequired);
-	capturer->AddCrew(-transfer);
-	AddCrew(transfer);
+	if(transfer)
+	{
+		if(totalRequired > capturer->Crew())
+			transfer = max(1, (capturer->Crew() * RequiredCrew()) / totalRequired);
+		capturer->AddCrew(-transfer);
+		AddCrew(transfer);
+	}
 	
 	// Set the capturer as this ship's parent.
 	SetParent(capturer);


### PR DESCRIPTION
If the flagship is below its required crew count, the transfer amount was always set to at least 1, even if the captured ship was an automaton.

Ref #2789 