### PR TITLE
Restore Archon (Cloaked) turret assignments

### DIFF
--- a/data/drak.txt
+++ b/data/drak.txt
@@ -249,3 +249,11 @@ ship Archon "Archon (Cloaked)"
 		"heat generation" 17
 		"ramscoop" 100
 		"cloak" .04
+	turret "Drak Anti-Missile Field"
+	turret "Drak Anti-Missile Field"
+	turret "Drak Draining Field"
+	turret "Drak Turret"
+	turret "Drak Turret"
+	turret "Drak Turret"
+	turret "Drak Distancer"
+	turret "Drak Distancer"


### PR DESCRIPTION
Spotted by Steam user [insanity](https://steamcommunity.com/profiles/76561198132906458), reported [here](https://steamcommunity.com/app/404410/discussions/0/1458455461480814723/#c1458455461482195536)

Since the variant has multiple turret types, they were being placed differently than the normal Archon's weapons..