### PR TITLE
Make restricted planets a separate color from hostile ones

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -59,6 +59,8 @@ namespace {
 			return Radar::PLAYER;
 		if(object.GetPlanet()->CanLand())
 			return Radar::FRIENDLY;
+		if(!object.GetPlanet()->GetGovernment()->IsEnemy())
+			return Radar::UNFRIENDLY;
 		return Radar::HOSTILE;
 	}
 	


### PR DESCRIPTION
This PR makes restricted planets show up yellow on the radar, instead of red. (Red is still used for hostile planets).

I felt like there should be a difference between "you can't land here because this planet is restricted" and "you can't land here because we hate your guts".

To be fair, there _is_ a difference in the `master` branch: The little spikes on the planet label. You'd have to be really attentive to notice it, though.

EDIT: I just now noticed how this change is nicely consistent with the way restricted planets appear in the map view :)