### PR TITLE
Press R or U in Outfitter to uninstall selected outfit directly to cargo.

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -604,7 +604,7 @@ void OutfitterPanel::FailSell() const
 
 
 
-bool OutfitterPanel::CanRemove() const
+bool OutfitterPanel::CanUninstall() const
 {
 	if(!planet || !selectedOutfit)
 		return false;
@@ -626,7 +626,7 @@ bool OutfitterPanel::CanRemove() const
 			else
 			{
 				// Not all of the ship's ammo necessarily needs to
-				// be removed along with remove the outfit, but this
+				// be removed along with uninstalling the outfit, but this
 				// is not a straightforward check and requires modifying
 				// the ship's attributes outfit after removing the outfit.
 				continue;
@@ -641,9 +641,9 @@ bool OutfitterPanel::CanRemove() const
 
 
 
-void OutfitterPanel::Remove()
+void OutfitterPanel::Uninstall()
 {
-	// Find the ships that have the most of this outfit to remove.
+	// Find the ships that have the most of this outfit to uninstall.
 	int most = 0;
 	vector<Ship *> shipsToOutfit;
 	for(Ship *ship : playerShips)
@@ -678,7 +678,7 @@ void OutfitterPanel::Remove()
 		const Outfit *ammo = selectedOutfit->Ammo();
 		if(ammo && ship->OutfitCount(ammo))
 		{
-			// Determine how many of this ammo must be removed/sold to also remove the launcher.
+			// Determine how many of this ammo must be uninstalled/sold to also remove the launcher.
 			// Those that can be stored will be stored, and the remainder will be sold.
 			int mustSell = 0;
 			for(const auto &it : ship->Attributes().Attributes())
@@ -688,7 +688,7 @@ void OutfitterPanel::Remove()
 			if(mustSell)
 			{
 				// Transfer as many of the outfits into the player's cargohold as possible.
-				// If 10 need to be removed, and there is space for 4, Transfer returns -4.
+				// If 10 need to be uninstalled, and there is space for 4, Transfer returns -4.
 				ship->AddOutfit(ammo, -mustSell);
 				mustSell += player.Cargo().Transfer(ammo, -mustSell);
 				int64_t price = player.FleetDepreciation().Value(ammo, day, mustSell);
@@ -701,7 +701,7 @@ void OutfitterPanel::Remove()
 
 
 
-void OutfitterPanel::FailRemove() const
+void OutfitterPanel::FailUninstall() const
 {
 	if(!planet || !selectedOutfit)
 		return;
@@ -719,10 +719,10 @@ void OutfitterPanel::FailRemove() const
 				break;
 			}
 		if(!hasOutfit)
-			GetUI()->Push(new Dialog("You do not have any of these outfits to remove."));
+			GetUI()->Push(new Dialog("You do not have any of these outfits to uninstall."));
 		else if(player.Cargo().Free() < selectedOutfit->Get("mass"))
 		{
-			GetUI()->Push(new Dialog("You cannot remove this outfit and place it in your cargo bay,"
+			GetUI()->Push(new Dialog("You cannot uninstall this outfit and place it in your cargo bay,"
 				" because you do not have sufficient cargo space to hold it."));
 		}
 		else
@@ -734,19 +734,19 @@ void OutfitterPanel::FailRemove() const
 						for(const auto &sit : ship->Outfits())
 							if(sit.first->Get(it.first) < 0.)
 							{
-								GetUI()->Push(new Dialog("You cannot remove this outfit, "
+								GetUI()->Push(new Dialog("You cannot uninstall this outfit, "
 									"because that would cause your ship's \"" + it.first +
 									"\" value to be reduced to less than zero. "
-									"To remove this outfit, you must sell or remove the " +
+									"To uninstall this outfit, you must sell or uninstall the " +
 									sit.first->Name() + " outfit first."));
 								return;
 							}
-						GetUI()->Push(new Dialog("You cannot remove this outfit, "
+						GetUI()->Push(new Dialog("You cannot uninstall this outfit, "
 							"because that would cause your ship's \"" + it.first +
 							"\" value to be reduced to less than zero."));
 						return;
 					}
-			GetUI()->Push(new Dialog("You cannot remove this outfit, "
+			GetUI()->Push(new Dialog("You cannot uninstall this outfit, "
 				"because something else in your ship depends on it."));
 		}
 	}

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -53,12 +53,9 @@ protected:
 	virtual bool CanBuy() const override;
 	virtual void Buy() override;
 	virtual void FailBuy() const override;
-	virtual bool CanSell() const override;
-	virtual void Sell() override;
-	virtual void FailSell() const override;
-	virtual bool CanUninstall() const override;
-	virtual void Uninstall() override;
-	virtual void FailUninstall() const override;
+	virtual bool CanSell(bool toCargo = false) const override;
+	virtual void Sell(bool toCargo = false) override;
+	virtual void FailSell(bool toCargo = false) const override;
 	virtual bool FlightCheck() override;
 	virtual void DrawKey();
 	

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -54,6 +54,9 @@ protected:
 	virtual bool CanSell() const override;
 	virtual void Sell() override;
 	virtual void FailSell() const override;
+	virtual bool CanRemove() const override;
+	virtual void Remove() override;
+	virtual void FailRemove() const override;
 	virtual bool FlightCheck() override;
 	virtual void DrawKey();
 	

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -54,9 +54,9 @@ protected:
 	virtual bool CanSell() const override;
 	virtual void Sell() override;
 	virtual void FailSell() const override;
-	virtual bool CanRemove() const override;
-	virtual void Remove() override;
-	virtual void FailRemove() const override;
+	virtual bool CanUninstall() const override;
+	virtual void Uninstall() override;
+	virtual void FailUninstall() const override;
 	virtual bool FlightCheck() override;
 	virtual void DrawKey();
 	

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -19,10 +19,12 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <map>
 #include <string>
+#include <vector>
 
 class Outfit;
 class PlayerInfo;
 class Point;
+class Ship;
 
 
 
@@ -71,7 +73,9 @@ private:
 	std::string LicenseName(const std::string &name) const;
 	void CheckRefill();
 	void Refill();
-	
+	// Shared code for reducing the selected ships to those that have the
+	// same quantity of the selected outfit.
+	const std::vector<Ship *> GetShipsToOutfit(bool isBuy = false) const;
 	
 private:
 	// Record whether we've checked if the player needs ammo refilled.

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -228,14 +228,14 @@ void ShipyardPanel::FailBuy() const
 
 
 
-bool ShipyardPanel::CanSell() const
+bool ShipyardPanel::CanSell(bool toCargo) const
 {
 	return playerShip;
 }
 
 
 
-void ShipyardPanel::Sell()
+void ShipyardPanel::Sell(bool toCargo)
 {
 	static const int MAX_LIST = 20;
 	static const int MAX_NAME_WIDTH = 250 - 30;

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -46,8 +46,8 @@ protected:
 	virtual bool CanBuy() const override;
 	virtual void Buy() override;
 	virtual void FailBuy() const override;
-	virtual bool CanSell() const override;
-	virtual void Sell() override;
+	virtual bool CanSell(bool toCargo = false) const override;
+	virtual void Sell(bool toCargo = false) override;
 	virtual bool FlightCheck() override;
 	virtual bool CanSellMultiple() const override;
 	

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -420,6 +420,25 @@ void ShopPanel::FailSell() const
 
 
 
+bool ShopPanel::CanRemove() const
+{
+	return false;
+}
+
+
+
+void ShopPanel::Remove()
+{
+}
+
+
+
+void ShopPanel::FailRemove() const
+{
+}
+
+
+
 bool ShopPanel::CanSellMultiple() const
 {
 	return true;
@@ -451,6 +470,20 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		{
 			Buy();
 			player.UpdateCargoCapacities();
+		}
+	}
+	else if(key == 'r' && selectedOutfit)
+	{
+		if(!CanRemove())
+			FailRemove();
+		else
+		{
+			int modifier = CanSellMultiple() ? Modifier() : 1;
+			for(int i = 0; i < modifier && CanRemove(); ++i)
+			{
+				Remove();
+				player.UpdateCargoCapacities();
+			}
 		}
 	}
 	else if(key == 's')

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -437,6 +437,7 @@ void ShopPanel::DrawKey()
 bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 {
 	scrollDetailsIntoView = false;
+	bool toCargo = selectedOutfit && (key == 'r' || key == 'u');
 	if((key == 'l' || key == 'd' || key == SDLK_ESCAPE
 			|| (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI)))) && FlightCheck())
 	{
@@ -453,30 +454,15 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			player.UpdateCargoCapacities();
 		}
 	}
-	else if((key == 'r' || key == 'u') && selectedOutfit)
+	else if(key == 's' || toCargo)
 	{
-		// "Sell" the outfit into cargo.
-		if(!CanSell(true))
-			FailSell(true);
+		if(!CanSell(toCargo))
+			FailSell(toCargo);
 		else
 		{
 			int modifier = CanSellMultiple() ? Modifier() : 1;
-			for(int i = 0; i < modifier && CanSell(true); ++i)
-			{
-				Sell(true);
-				player.UpdateCargoCapacities();
-			}
-		}
-	}
-	else if(key == 's')
-	{
-		if(!CanSell())
-			FailSell();
-		else
-		{
-			int modifier = CanSellMultiple() ? Modifier() : 1;
-			for(int i = 0; i < modifier && CanSell(); ++i)
-				Sell();
+			for(int i = 0; i < modifier && CanSell(toCargo); ++i)
+				Sell(toCargo);
 			player.UpdateCargoCapacities();
 		}
 	}

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -420,20 +420,20 @@ void ShopPanel::FailSell() const
 
 
 
-bool ShopPanel::CanRemove() const
+bool ShopPanel::CanUninstall() const
 {
 	return false;
 }
 
 
 
-void ShopPanel::Remove()
+void ShopPanel::Uninstall()
 {
 }
 
 
 
-void ShopPanel::FailRemove() const
+void ShopPanel::FailUninstall() const
 {
 }
 
@@ -472,16 +472,16 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			player.UpdateCargoCapacities();
 		}
 	}
-	else if(key == 'r' && selectedOutfit)
+	else if((key == 'r' || key == 'u') && selectedOutfit)
 	{
-		if(!CanRemove())
-			FailRemove();
+		if(!CanUninstall())
+			FailUninstall();
 		else
 		{
 			int modifier = CanSellMultiple() ? Modifier() : 1;
-			for(int i = 0; i < modifier && CanRemove(); ++i)
+			for(int i = 0; i < modifier && CanUninstall(); ++i)
 			{
-				Remove();
+				Uninstall();
 				player.UpdateCargoCapacities();
 			}
 		}

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -414,26 +414,7 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 
 
 
-void ShopPanel::FailSell() const
-{
-}
-
-
-
-bool ShopPanel::CanUninstall() const
-{
-	return false;
-}
-
-
-
-void ShopPanel::Uninstall()
-{
-}
-
-
-
-void ShopPanel::FailUninstall() const
+void ShopPanel::FailSell(bool toCargo) const
 {
 }
 
@@ -474,14 +455,15 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 	}
 	else if((key == 'r' || key == 'u') && selectedOutfit)
 	{
-		if(!CanUninstall())
-			FailUninstall();
+		// "Sell" the outfit into cargo.
+		if(!CanSell(true))
+			FailSell(true);
 		else
 		{
 			int modifier = CanSellMultiple() ? Modifier() : 1;
-			for(int i = 0; i < modifier && CanUninstall(); ++i)
+			for(int i = 0; i < modifier && CanSell(true); ++i)
 			{
-				Uninstall();
+				Sell(true);
 				player.UpdateCargoCapacities();
 			}
 		}

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -62,9 +62,9 @@ protected:
 	virtual bool CanSell() const = 0;
 	virtual void Sell() = 0;
 	virtual void FailSell() const;
-	virtual bool CanRemove() const;
-	virtual void Remove();
-	virtual void FailRemove() const;
+	virtual bool CanUninstall() const;
+	virtual void Uninstall();
+	virtual void FailUninstall() const;
 	virtual bool FlightCheck() = 0;
 	virtual bool CanSellMultiple() const;
 	virtual void DrawKey();

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -59,12 +59,9 @@ protected:
 	virtual bool CanBuy() const = 0;
 	virtual void Buy() = 0;
 	virtual void FailBuy() const = 0;
-	virtual bool CanSell() const = 0;
-	virtual void Sell() = 0;
-	virtual void FailSell() const;
-	virtual bool CanUninstall() const;
-	virtual void Uninstall();
-	virtual void FailUninstall() const;
+	virtual bool CanSell(bool toCargo = false) const = 0;
+	virtual void Sell(bool toCargo = false) = 0;
+	virtual void FailSell(bool toCargo = false) const;
 	virtual bool FlightCheck() = 0;
 	virtual bool CanSellMultiple() const;
 	virtual void DrawKey();

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -62,6 +62,9 @@ protected:
 	virtual bool CanSell() const = 0;
 	virtual void Sell() = 0;
 	virtual void FailSell() const;
+	virtual bool CanRemove() const;
+	virtual void Remove();
+	virtual void FailRemove() const;
 	virtual bool FlightCheck() = 0;
 	virtual bool CanSellMultiple() const;
 	virtual void DrawKey();


### PR DESCRIPTION
Pressing `r` or `u` will uninstall the selected outfit and place it in to your cargo hold, if there is sufficient room. If there is not sufficient room for the outfit in cargo, it will be sold.
Excess ammunition that needed to be stored but cannot fit in the remaining space will be sold.
As expected, the normal modifier keys work to multiply the quantity moved to cargo.

This makes it possible to move an outfit installed on a ship directly into cargo, or to more simply sell an outfit from a ship when you have some in cargo that you want to keep (uninstall once + sell once vs sell every copy in cargo, then the one from the ship, then buy back into cargo).