### PR TITLE
Allow blinking of mission targets to be disabled in the Preferences menu

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -64,7 +64,7 @@ namespace {
 	
 	int RadarType(const Ship &ship, int step)
 	{
-		if(ship.GetPersonality().IsTarget() && !ship.IsDestroyed())
+		if(ship.GetPersonality().IsTarget() && !ship.IsDestroyed() && Preferences::Has("Highlight mission targets"))
 		{
 			// If a ship is a "target," double-blink it a few times per second.
 			int count = (step / 6) % 7;

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -53,6 +53,7 @@ void Preferences::Load()
 	settings["Draw background haze"] = true;
 	settings["Hide unexplored map regions"] = true;
 	settings["Turrets focus fire"] = true;
+	settings["Highlight mission targets"] = true;
 	
 	DataFile prefs(Files::Config() + "preferences.txt");
 	for(const DataNode &node : prefs)

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -436,7 +436,8 @@ void PreferencesPanel::DrawSettings()
 		REACTIVATE_HELP,
 		SCROLL_SPEED,
 		"Warning siren",
-		"Hide unexplored map regions"
+		"Hide unexplored map regions",
+		"Highlight mission targets"
 	};
 	bool isCategory = true;
 	for(const string &setting : SETTINGS)


### PR DESCRIPTION
In the `master` branch, ships with the `target` personality will double-blink on the radar. This PR adds a preference to disable this if players want to do so.

![highlight mission targets](https://user-images.githubusercontent.com/24595528/28592446-3677f5b6-7146-11e7-8fd8-1ff1c8232c45.jpg)
