### PR TITLE
Fix crash when disowning all ships ahead of the flagship

### DIFF
--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -738,7 +738,7 @@ void ShipInfoPanel::Disown()
 	const Ship *ship = shipIt->get();
 	if(shipIt != player.Ships().begin())
 		--shipIt;
-	else
+	else if(player.Ships().size() > 2)
 		++shipIt;
 	
 	player.DisownShip(ship);


### PR DESCRIPTION
If the flagship was the last ship in the player's list of ships, and all ships ahead of it were disowned, the ShipInfoPanel would attempt to access invalid data.

Refs #2820 