### PR TITLE
Allow mission target blink color to be set independently of ships the player is targeting

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -57,6 +57,7 @@ color "radar hostile" 1. .6 .4 0.
 color "radar inactive" .4 .4 .4 0.
 color "radar special" 1. 1. 1. 0.
 color "radar anomalous" .7 0. 1. 0.
+color "radar blink" 1. 1. 1. 0.
 
 
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -69,7 +69,7 @@ namespace {
 			// If a ship is a "target," double-blink it a few times per second.
 			int count = (step / 6) % 7;
 			if(count == 0 || count == 2)
-				return Radar::SPECIAL;
+				return Radar::BLINK;
 		}
 		if(ship.IsDisabled() || (ship.IsOverheated() && ((step / 20) % 2)))
 			return Radar::INACTIVE;

--- a/source/Radar.cpp
+++ b/source/Radar.cpp
@@ -25,6 +25,7 @@ const int Radar::HOSTILE = 3;
 const int Radar::INACTIVE = 4;
 const int Radar::SPECIAL = 5;
 const int Radar::ANOMALOUS = 6;
+const int Radar::BLINK = 7;
 
 
 
@@ -93,7 +94,8 @@ const Color &Radar::GetColor(int type)
 		*GameData::Colors().Get("radar hostile"),
 		*GameData::Colors().Get("radar inactive"),
 		*GameData::Colors().Get("radar special"),
-		*GameData::Colors().Get("radar anomalous")
+		*GameData::Colors().Get("radar anomalous"),
+		*GameData::Colors().Get("radar blink")
 	};
 	
 	if(static_cast<size_t>(type) >= color.size())

--- a/source/Radar.h
+++ b/source/Radar.h
@@ -32,6 +32,7 @@ public:
 	static const int INACTIVE;
 	static const int SPECIAL;
 	static const int ANOMALOUS;
+	static const int BLINK;
 	
 public:
 	void Clear();


### PR DESCRIPTION
This PR adds a "radar blink" color that mission targets use to mark themselves. It can be set independently of the color of the ships the player's flagship is targeting.