### PR TITLE
bugfix: Ships which cloaked to repair should fully decloak after repairing

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1836,7 +1836,7 @@ void AI::DoCloak(Ship &ship, Command &command)
 		
 		// If this ship has started cloaking, it must get at least 40% repaired
 		// or 40% farther away before it begins decloaking again.
-		double hysteresis = ship.Cloaking() ? 1.4 : 1.;
+		double hysteresis = ship.Commands().Has(Command::CLOAK) ? 1.4 : 1.;
 		double cloakIsFree = !ship.Attributes().Get("cloaking fuel");
 		if(ship.Hull() + .5 * ship.Shields() < hysteresis
 				&& (cloakIsFree || nearestEnemy < 2000. * hysteresis))


### PR DESCRIPTION
**Refs #2836**
Instead of checking `ship.Cloaking()`, access the ships Commands to determine if it is cloaking/maintaining cloak, or is decloaking. This allows the higher hysteresis value to only apply when the ship is trying to cloak, rather than while the ship has any degree of cloak, preventing the ship from immediately recloaking if it takes any damage while decloaking.

Test save (courtesy of Steam user): 
On `master`, the Archon will cloak to repair after being reduced to health = 1, but then after repairing to health = 1.4, it will rapidly cycle its cloak if it is in your fleet's weapons range and takes damage before decloaking.
With this PR, the Archon has to be damaged back to health = 1 once it has started decloaking before it will cloak to repair.
[Travion Expectra.txt](https://github.com/endless-sky/endless-sky/files/1180121/Travion.Expectra.txt)

