### PR TITLE
Fix MoveEscort bugs when using wormholes or unreachable destinations

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1107,9 +1107,10 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 	// Check if the parent has a target planet that is in the parent's system.
 	const Planet *parentPlanet = (parent.GetTargetStellar() ? parent.GetTargetStellar()->GetPlanet() : nullptr);
 	bool planetIsHere = (parentPlanet && parentPlanet->IsInSystem(parent.GetSystem()));
+	bool systemHasFuel = ship.GetSystem()->HasFuelFor(ship);
 	// If an escort is out of fuel, they should refuel without waiting for the
 	// "parent" to land (because the parent may not be planning on landing).
-	if(hasFuelCapacity && !ship.JumpsRemaining() && ship.GetSystem()->HasFuelFor(ship))
+	if(hasFuelCapacity && systemHasFuel && !ship.JumpsRemaining())
 		Refuel(ship, command);
 	else if(!parentIsHere && !isStaying)
 	{
@@ -1132,11 +1133,14 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 					ship.SetTargetStellar(&object);
 					break;
 				}
-			ship.SetTargetSystem(to);
-			// Check if we need to refuel. Wormhole travel does not require fuel.
-			if(!ship.GetTargetStellar() && (!to || 
-					(from->HasFuelFor(ship) && !to->HasFuelFor(ship) && ship.JumpsRemaining() == 1)))
-				Refuel(ship, command);
+			// Only set a target system if there is no wormhole route to that system.
+			if(!ship.GetTargetStellar())
+			{
+				ship.SetTargetSystem(to);
+				// Check if we need to refuel. Wormhole travel does not require fuel.
+				if(to && systemHasFuel && !to->HasFuelFor(ship) && ship.JumpsRemaining() == 1)
+					Refuel(ship, command);
+			}
 		}
 		// Perform the action that this ship previously decided on.
 		if(ship.GetTargetStellar())
@@ -1149,6 +1153,12 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 			PrepareForHyperspace(ship, command);
 			command |= Command::JUMP;
 		}
+		else if(hasFuelCapacity && systemHasFuel && ship.Fuel() < 1.)
+			// Refuel so that when the parent returns, this ship is ready to rendezvous with it.
+			Refuel(ship, command);
+		else
+			// This ship has no route to the parent's system, so park at the system's center.
+			MoveTo(ship, command, Point(), Point(), 40., 0.);
 	}
 	else if(parent.Commands().Has(Command::LAND) && parentIsHere && planetIsHere && parentPlanet->CanLand(ship))
 	{
@@ -1164,7 +1174,10 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 		DistanceMap distance(ship, parent.GetTargetSystem());
 		const System *dest = distance.Route(ship.GetSystem());
 		ship.SetTargetSystem(dest);
-		if(!dest || (ship.GetSystem()->HasFuelFor(ship) && !dest->HasFuelFor(ship) && ship.JumpsRemaining() == 1))
+		if(!dest)
+			// This ship has no route to the parent's destination system, so protect it until it jumps away.
+			KeepStation(ship, command, parent);
+		else if(systemHasFuel && !dest->HasFuelFor(ship) && ship.JumpsRemaining() == 1)
 			Refuel(ship, command);
 		else
 		{


### PR DESCRIPTION
Ref #2829, and probably others.
Ref: https://steamcommunity.com/app/404410/discussions/1/1458455461497401563/ and probably others

Summary:
 - Escorts that are routing through wormholes to reach their parent will not set both a target planet (wormhole) to land on, and a target system to jump to.
   - This fixes a bug causing Ship::JumpsRemaining() to erroneously return 0 when the ship's targetSystem is its current system instead of nullptr (e.g. making ships think they were stranded when they were not).
 - Escorts that cannot jump to their flagship's target system will not attempt to refuel until the flagship leaves their system, and after attempting to refuel, will wait at the system center until a route to the parent's system exists.
   - No more "landing dance" while the player holds the jump key.
