### PR TITLE
Add cloaking heat attribute

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -49,6 +49,9 @@ tip "cloaking energy:"
 
 tip "cloaking fuel:"
 	`Fuel per second required to maintain cloaking.`
+	
+tip "cloaking heat:"
+	`Heat generated per second while cloaked.`
 
 tip "cooling:"
 	`Reduces heat by this amount per second. This is for when your ship's built-in heat dissipation is not sufficient to keep it from overheating.`

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -33,6 +33,7 @@ namespace {
 		{"afterburner heat", 60.},
 		{"cloaking energy", 60.},
 		{"cloaking fuel", 60.},
+		{"cloaking heat", 60.},
 		{"cooling", 60.},
 		{"cooling energy", 60.},
 		{"energy consumption", 60.},

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -815,8 +815,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		double cloakingSpeed = attributes.Get("cloak");
 		bool canCloak = (!isDisabled && cloakingSpeed > 0. && !cloakDisruption
 			&& fuel >= attributes.Get("cloaking fuel")
-			&& energy >= attributes.Get("cloaking energy")
-			&& heat < (90. * Mass()) - attributes.Get("cloaking heat"));
+			&& energy >= attributes.Get("cloaking energy"));
 		if(commands.Has(Command::CLOAK) && canCloak)
 		{
 			cloak = min(1., cloak + cloakingSpeed);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -816,7 +816,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		bool canCloak = (!isDisabled && cloakingSpeed > 0. && !cloakDisruption
 			&& fuel >= attributes.Get("cloaking fuel")
 			&& energy >= attributes.Get("cloaking energy")
-			&& heat < ((.9 * Mass()) - attributes.Get("cloaking heat")));
+			&& heat < (90. * Mass()) - attributes.Get("cloaking heat"));
 		if(commands.Has(Command::CLOAK) && canCloak)
 		{
 			cloak = min(1., cloak + cloakingSpeed);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -815,12 +815,14 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		double cloakingSpeed = attributes.Get("cloak");
 		bool canCloak = (!isDisabled && cloakingSpeed > 0. && !cloakDisruption
 			&& fuel >= attributes.Get("cloaking fuel")
-			&& energy >= attributes.Get("cloaking energy"));
+			&& energy >= attributes.Get("cloaking energy")
+			&& heat < ((.9 * Mass()) - attributes.Get("cloaking heat")));
 		if(commands.Has(Command::CLOAK) && canCloak)
 		{
 			cloak = min(1., cloak + cloakingSpeed);
 			fuel -= attributes.Get("cloaking fuel");
 			energy -= attributes.Get("cloaking energy");
+			heat += attributes.Get("cloaking heat");
 		}
 		else if(cloakingSpeed)
 		{


### PR DESCRIPTION
This PR adds a `cloaking heat` attribute for further customization of outfits, (specifically, cloaking devices).

Requested by @TheUnfetteredOne 