### PR TITLE
Ships that flash no longer repeatedly trigger the warning siren

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1275,8 +1275,10 @@ void Engine::CalculateStep()
 			
 			double size = sqrt(ship->Width() + ship->Height()) * .14 + .5;
 			bool isYourTarget = (flagship && ship == flagship->GetTargetShip());
+			bool isTargetingYou = (ship && ship->GetTargetShip()) && (ship->GetTargetShip()->GetGovernment()->IsPlayer())
+			&& !(ship->IsDisabled() || ship->IsDestroyed());
+			hasHostiles |= (isTargetingYou && (ship && ship->GetGovernment()->IsEnemy()));
 			int type = RadarType(*ship, step);
-			hasHostiles |= (type == Radar::HOSTILE);
 			radar[calcTickTock].Add(isYourTarget ? Radar::SPECIAL : type, ship->Position(), size);
 		}
 	if(flagship && showFlagship)


### PR DESCRIPTION
Something I've noticed is that if one has the "warning siren" preference on, then hostile ships that flash on the radar (i.e. are overheated or have the `target` personality) will also trigger the warning siren... repeatedly. This PR stops that behavior by querying the ship's target, rather than its radar type.