### PR TITLE
Help messages no longer assume a fixed start date

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -39,6 +39,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "SpriteSet.h"
 #include "SpriteShader.h"
 #include "StarField.h"
+#include "StartConditions.h"
 #include "System.h"
 
 #include <algorithm>
@@ -902,7 +903,7 @@ void Engine::EnterSystem()
 	
 	// Help message for new players. Show this message for the first four days,
 	// since the new player ships can make at most four jumps before landing.
-	if(today <= Date(21, 11, 3013))
+	if(today <= GameData::Start().GetDate() + 4)
 	{
 		Messages::Add(GameData::HelpMessage("basics 1"));
 		Messages::Add(GameData::HelpMessage("basics 2"));


### PR DESCRIPTION
In the `master` branch, modders can use StartConditions.txt to specify an alternative starting date from the default. Unfortunately for them, the help messages typically shown for the first 4 days of a vanilla game... assume modders don't do that, for some reason.
This PR switches the help message cutoff to be 4 days ahead of the actual defined starting date, whatever this may be. This has 2 effects:
1) If plugins set the start date ahead of the vanilla start date, the basics help messages will still be shown
2) If plugins set the start date way _behind_ the vanilla start date, the basics help messages will not continue to be shown for literally the entire playthrough.