### PR TITLE
Simplifying NPC::HasFailed by cutting mustLiveFor

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -319,17 +319,15 @@ bool NPC::IsLeftBehind(const System *playerSystem) const
 
 
 bool NPC::HasFailed() const
-{
-	static const int mustLiveFor = ShipEvent::SCAN_CARGO | ShipEvent::SCAN_OUTFITS | ShipEvent::BOARD;
-						
+{					
 	for(const auto &it : actions)
 	{
 		if(it.second & failIf)
 			return true;
 	
-		// If we still need to perform an action that requires the NPC ship be
-		// alive, then that ship being destroyed should cause the mission to fail.
-		if((~it.second & succeedIf & mustLiveFor) && (it.second & ShipEvent::DESTROY))
+		// If we still need to perform an action on this NPC, then that ship
+		// being destroyed should cause the mission to fail.
+		if((~it.second & succeedIf) && (it.second & ShipEvent::DESTROY))
 			return true;
 	}
 


### PR DESCRIPTION
Hey, so the way I did e6e7c0ae11039c6dc00bd9682fffe7b6bac5f095 originally was a bit more complicated than necessary: `mustLiveFor` isn't needed.

The gist was: if you need to do something to an NPC (`succeedIf`) that you haven't done (`~it.second`) and that requires them be alive (`mustLiveFor`), then if they got destroyed the mission has failed.

Practically, an NPC has to be alive for anything you need to do to it. The only reason I made `mustLiveFor` was for if what you needed to do to the NPC was kill it, but I hadn't thought through that that really isn't a problem.