### PR TITLE
Fix NPC HasSucceeded() to use only recorded ShipEvent information

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -280,15 +280,18 @@ bool NPC::HasSucceeded(const System *playerSystem) const
 		for(const shared_ptr<Ship> &ship : ships)
 		{
 			auto it = actions.find(ship.get());
-			bool isImmobile = false;
+			// If a derelict ship has not received any ShipEvents, it is immobile.
+			bool isImmobile = ship->GetPersonality().IsDerelict();
 			// The success status calculation can only be based on recorded
-			// events (and the current system). Both DISABLE and DESTROY
-			// events must be checked, as some ships are be listed "never
-			// disabled", and thus have no record of ShipEvent::DISABLE.
+			// events (and the current system).
 			if(it != actions.end())
 			{
-				isImmobile |= (it->second
+				// A ship that was disabled, captured, or destroyed is considered 'immobile'.
+				isImmobile = (it->second
 					& (ShipEvent::DISABLE | ShipEvent::CAPTURE | ShipEvent::DESTROY));
+				// if this NPC is 'derelict' and has no ASSIST on record, it is immobile.
+				isImmobile |= ship->GetPersonality().IsDerelict()
+					&& !(it->second & ShipEvent::ASSIST);
 			}
 			bool isHere = (!ship->GetSystem() || ship->GetSystem() == playerSystem);
 			if((isHere && !isImmobile) ^ mustAccompany)


### PR DESCRIPTION
Refs #2855 

NPC::Do calculates whether a given ShipEvent causes success or failure by comparing the value of HasSucceeded before and after recording the ShipEvent.
 - The previous implementation inherited knowledge about the ship's Disabled status from the ship itself, and not from the recorded information.
This meant that `evade` missions could never determine that the incoming ShipEvent::DISABLE was the one that allowed for success criteria.
 - Learning of a new ShipEvent::ASSIST will appropriately remove a ship's known ShipEvent::DISABLE flag.
 - It should now be possible to `evade` a ship which is `never disabled` by destroying it (in addition to being in a different system)


This PR resolves all the issues I mentioned in 2855
 - `npc evade` dialogs are shown when all required evaded npcs are evaded.
 - capturing each npc ship when all have been disabled / destroyed will not throw the dialog again
 - 'derelict' ships are correctly counted as unable to accompany if they have not been assisted.

I do not address the bug in which an assisted `derelict` NPC is spawned as `derelict` again if it was previously assisted and the player landed when it was in a `not disabled` state, then restarted the game, or that a derelict ship's hull/shields do not regenerate if it lands with you and then you take off again. These should be solvable by referencing the NPC actions table when doing ship placements / personality assignments (in a different PR).