### PR TITLE
Refactor AI::Step's "Find someone to assist me" section

### DIFF
--- a/source/AI.h
+++ b/source/AI.h
@@ -64,6 +64,7 @@ template <class Type>
 	
 	
 private:
+	void AskForHelp(const std::shared_ptr<Ship> &ship, bool &isStranded, const Ship *flagship);
 	// Pick a new target for the given ship.
 	std::shared_ptr<Ship> FindTarget(const Ship &ship) const;
 	

--- a/source/AI.h
+++ b/source/AI.h
@@ -64,7 +64,9 @@ template <class Type>
 	
 	
 private:
-	void AskForHelp(const std::shared_ptr<Ship> &ship, bool &isStranded, const Ship *flagship);
+	void AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship);
+	static bool CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel);
+	bool HasHelper(const Ship &ship, const bool needsFuel);
 	// Pick a new target for the given ship.
 	std::shared_ptr<Ship> FindTarget(const Ship &ship) const;
 	
@@ -172,6 +174,7 @@ private:
 	std::map<std::weak_ptr<const Ship>, std::map<std::weak_ptr<const Ship>, int, Comp>, Comp> actions;
 	std::map<const Government *, std::map<std::weak_ptr<const Ship>, int, Comp>> governmentActions;
 	std::map<std::weak_ptr<const Ship>, int, Comp> playerActions;
+	std::map<const Ship *, std::weak_ptr<Ship>> helperList;
 	std::map<const Ship *, int> swarmCount;
 	std::map<const Ship *, Angle> miningAngle;
 	std::map<const Ship *, int> miningTime;


### PR DESCRIPTION
Ref #2835 , #2846, perhaps some steam issues.

This PR dramatically reduces the game lockup seen when entering an uninhabited system with a large number of out-of-fuel escorts, to the point where it is almost indistinguishable from that of the normal game.

Summary
 - Move "can anyone help me" code into into separate function
 - Use std::vector to store possible choices instead of 2 pointers.
 - Randomly choose a possible helper (must check all ships in the system in order to determine if there is an enemy present)
 - Reduce frequency of calls to avg. 2 per second rather than every step for every stranded/disabled ship.

