### PR TITLE
Update Remnant faction knowledge based on friendly/hostile relationship

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -56,8 +56,8 @@ mission "First Contact: Remnant"
 	on accept
 		"reputation: Remnant" <?= -10
 		log "Refused to give a blood sample to a group of strange-looking humans that live south of the Core. Upon takeoff, their ships attacked."
-		log "Factions" "Remnant" `A group of unusual-looking humans that live in a secluded section of the galaxy. They are openly hostile to those who refuse to submit blood samples.`
-			`The buildings of the Remnant people seem to be alien in origin, and they communicate amongst each other primarily with sign language. When they do use their voices, they sing or chant, rather than speak.`
+		log "Factions" "Remnant" `The Remnant are a group of unusual-looking humans that live in a secluded section of the galaxy. It is unclear how long they have lived apart from the rest of humanity, but they have been free of human influences for long enough that their culture is wildly different from any found in human record. Their buildings seem to be alien in origin, and they communicate amongst each other primarily with sign language. When they do use their voices they sing or chant, rather than speak.`
+			`The Remnant seem fearful - or at least especially wary - of contact with humans. Visitors that do not undergo medical examination are not allowed to remain in their territory.`
 	on decline
 		event "ember waste label"
 		log "Met a group of strange-looking humans that live in a secluded section of the galaxy south of the Core. After submitting a blood sample, they became very friendly."

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -14,8 +14,6 @@ mission "First Contact: Remnant"
 	source
 		government "Remnant"
 	on offer
-		log "Factions" "Remnant" `Half a millennium ago, during the Alpha Wars, a group of humans fleeing the conflict and looking for a safer place to live discovered a wormhole into a region of space known as the Ember Waste. They built settlements there, and chose to call themselves the Remnant. Although they no longer fear the Alphas as much as they once did, they still have not rejoined human society.`
-			`Since their colonies were first formed, the Remnant's culture has changed drastically. They communicate in sign language, using their voices only for singing. Their food and architecture and much of their technology is strange, and much of it has been borrowed or stolen from nearby alien species.`
 		conversation
 			`Although they are unusually tall and dark-skinned, the people here appear to be human. You wouldn't know it from the architecture, however: the buildings with their curved, twisted surfaces and ramifying arches look more alien than any human dwelling you have seen before.`
 			`	Stranger still, no one is speaking: the usual background murmur of voices that you would associate with a spaceport is absent here. Instead, the locals are communicating in a rapid and graceful sign language, their hands tracing arcs through the air almost faster than your eyes can follow.`
@@ -57,8 +55,14 @@ mission "First Contact: Remnant"
 				decline
 	on accept
 		"reputation: Remnant" <?= -10
+		log "Refused to give a blood sample to a group of strange-looking humans that live south of the Core. Upon takeoff, their ships attacked."
+		log "Factions" "Remnant" `A group of unusual-looking humans that live in a secluded section of the galaxy. They are openly hostile to those who refuse to submit blood samples.`
+			`The buildings of the Remnant people seem to be alien in origin, and they communicate amongst each other primarily with sign language. When they do use their voices, they sing or chant, rather than speak.`
 	on decline
 		event "ember waste label"
+		log "Met a group of strange-looking humans that live in a secluded section of the galaxy south of the Core. After submitting a blood sample, they became very friendly."
+		log "Factions" "Remnant" `Half a millennium ago, during the Alpha Wars, a group of humans fleeing the conflict and looking for a safer place to live discovered a wormhole into a region of space known as the Ember Waste. They built settlements there, and chose to call themselves the Remnant. Although they no longer fear the Alphas as much as they once did, they still have not rejoined human society.`
+			`Since their colonies were first formed, the Remnant's culture has changed drastically. They communicate in sign language, using their voices only for singing. Their food and architecture and much of their technology is strange, and much of it has been borrowed or stolen from nearby alien species.`
 	
 	npc kill
 		government "Remnant"


### PR DESCRIPTION
Refs #2866 

 - Move the existing faction log for the Remnant to the `on decline` so that it is learned only if the player could logically have learned it.
 - Created a replacement faction log with the observed information at the time of flight, if the player refuses.
 - Added a regular log message so that the player can remember when the Remnant was first met.

If a method to improve Remnant rep is added, a mission which adds the missing information to the special logs can be added when the player is able to learn of the Remnant's history.