### PR TITLE
bugfix: Add missing newline to scan dialog for uninstallable outfits in cargo

### DIFF
--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -316,7 +316,7 @@ void MainPanel::ShowScanDialog(const ShipEvent &event)
 				if(it.first->Get("installable") < 0.)
 				{
 					int tons = ceil(it.second * it.first->Get("mass"));
-					out << (tons == 1 ? " ton of " : " tons of ") << Format::LowerCase(it.first->PluralName());
+					out << (tons == 1 ? " ton of " : " tons of ") << Format::LowerCase(it.first->PluralName()) << "\n";
 				}
 				else	
 					out << " " << (it.second == 1 ? it.first->Name(): it.first->PluralName()) << "\n";


### PR DESCRIPTION
Without it, things kinda jumble up:
![image](https://media.discordapp.net/attachments/266345072554016768/342065787046985728/Screenshot_67.png)

The idea of knowing what's in a void sprite's stomach is a different matter :laughing: 