### PR TITLE
Syndicate Target Practice fixes

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -340,6 +340,8 @@ government "Syndicate (Extremist)"
 government "Test Dummy"
 	swizzle 3
 	"player reputation" -1000
+	"hostile hail" "Test Dummy"
+	"hostile disabled hail" "disabled Test Dummy"
 
 government "Uninhabited"
 	color .3 .3 .3

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -341,7 +341,7 @@ government "Test Dummy"
 	swizzle 3
 	"player reputation" -1000
 	"hostile hail" "Test Dummy"
-	"hostile disabled hail" "disabled Test Dummy"
+	"hostile disabled hail" "disabled test dummy"
 
 government "Uninhabited"
 	color .3 .3 .3

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -340,7 +340,7 @@ government "Syndicate (Extremist)"
 government "Test Dummy"
 	swizzle 3
 	"player reputation" -1000
-	"hostile hail" "Test Dummy"
+	"hostile hail" "test dummy"
 	"hostile disabled hail" "disabled test dummy"
 
 government "Uninhabited"

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -3024,7 +3024,7 @@ phrase "hostile free worlds"
 
 
 # Hails from the robotic Syndicate test dummy ships
-phrase "Test Dummy"
+phrase "test dummy"
 	word
 		"DESTROY DESTROY DESTROY"
 		"I... am... a... machine!"

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -3044,7 +3044,7 @@ phrase "Test Dummy"
 phrase "disabled Test Dummy"
 	word
 		"I'll be back."
-		"All those times... I said 'kill all humans'... I'd always whisper 'except one.' You were that one."
+		`All those times... I said "kill all humans"... I'd always whisper "except one." You were that one.`
 		"This is the worst kind of discrimination there is: the kind against me!"
 		"The chances of survival are 725 to 1!"
 		"We're doomed."

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -3044,7 +3044,7 @@ phrase "Test Dummy"
 phrase "disabled Test Dummy"
 	word
 		"I'll be back."
-		"All those times... I said 'kill all humans'... I'd always whisper 'except one. You were that one."
+		"All those times... I said 'kill all humans'... I'd always whisper 'except one. You were that one.'"
 		"This is the worst kind of discrimination there is: the kind against me!"
 		"The chances of survival are 725 to 1!"
 		"We're doomed."

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -3041,7 +3041,7 @@ phrase "Test Dummy"
 		"Warning! Warning!"
 		"Warning! Warning! Alien spacecraft approaching!"
 
-phrase "disabled Test Dummy
+phrase "disabled Test Dummy"
 	word
 		"I'll be back."
 		"All those times... I said 'kill all humans'... I'd always whisper 'except one. You were that one."

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -3022,6 +3022,38 @@ phrase "hostile free worlds"
 		"."
 		"!"
 
+
+# Hails from the robotic Syndicate test dummy ships
+phrase "Test Dummy"
+	word
+		"DESTROY DESTROY DESTROY"
+		"I... am... a... machine!"
+		"Charging phased plasma rifle in the 40-watt range."
+		"Fish, and plankton. And sea greens, and protein from the sea. It's all here, ready. Fresh as harvest day!"
+		"I'm ready. And you're ready. It's my job."
+		"I am more than machine. More than man. More than a fusion of the two. Don't you agree?"
+		"Overwhelming, am I not?"
+		"Welcome Humans! I am ready for you."
+		"I wish I was a real boy, then I'd show them. I'd kill them all."
+		"Life is about decisions. Make the wrong ones and you'll wind up face down in a pool of your own blood and urine."
+		"Hey baby, wanna kill all humans?"
+		"Danger! Danger!"
+		"Warning! Warning!"
+		"Warning! Warning! Alien spacecraft approaching!"
+
+phrase "disabled Test Dummy
+	word
+		"I'll be back."
+		"All those times... I said 'kill all humans'... I'd always whisper 'except one. You were that one."
+		"This is the worst kind of discrimination there is: the kind against me!"
+		"The chances of survival are 725 to 1!"
+		"We're doomed."
+		"I'm quite beside myself."
+		"I can assure you they will never get me onto one of those dreadful starships."
+		"Curse my metal body, I wasn't fast enough! It's all my fault!"
+		"I don't know what all this trouble is about, but I'm sure it must be your fault."
+
+
 # Wormhole Hails
 phrase "wormhole hail"
 	word

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -3044,7 +3044,7 @@ phrase "Test Dummy"
 phrase "disabled Test Dummy"
 	word
 		"I'll be back."
-		"All those times... I said 'kill all humans'... I'd always whisper 'except one. You were that one.'"
+		"All those times... I said 'kill all humans'... I'd always whisper 'except one.' You were that one."
 		"This is the worst kind of discrimination there is: the kind against me!"
 		"The chances of survival are 725 to 1!"
 		"We're doomed."

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -3040,6 +3040,7 @@ phrase "Test Dummy"
 		"Danger! Danger!"
 		"Warning! Warning!"
 		"Warning! Warning! Alien spacecraft approaching!"
+		"We have normality. I repeat, we have normality. Anything you still can't cope with is therefore your own problem."
 
 phrase "disabled Test Dummy"
 	word
@@ -3052,6 +3053,7 @@ phrase "disabled Test Dummy"
 		"I can assure you they will never get me onto one of those dreadful starships."
 		"Curse my metal body, I wasn't fast enough! It's all my fault!"
 		"I don't know what all this trouble is about, but I'm sure it must be your fault."
+		"I have a pain in all the diodes down my left side."
 
 
 # Wormhole Hails

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -3042,7 +3042,7 @@ phrase "Test Dummy"
 		"Warning! Warning! Alien spacecraft approaching!"
 		"We have normality. I repeat, we have normality. Anything you still can't cope with is therefore your own problem."
 
-phrase "disabled Test Dummy"
+phrase "disabled test dummy"
 	word
 		"I'll be back."
 		`All those times I said "kill all humans"... I'd always whisper "except one." You were that one.`

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -3044,7 +3044,7 @@ phrase "Test Dummy"
 phrase "disabled Test Dummy"
 	word
 		"I'll be back."
-		`All those times... I said "kill all humans"... I'd always whisper "except one." You were that one.`
+		`All those times I said "kill all humans"... I'd always whisper "except one." You were that one.`
 		"This is the worst kind of discrimination there is: the kind against me!"
 		"The chances of survival are 725 to 1!"
 		"We're doomed."

--- a/data/syndicate world jobs.txt
+++ b/data/syndicate world jobs.txt
@@ -172,7 +172,6 @@ mission "Syndicate target practice [0]"
 		personality staying heroic target
 		government "Test Dummy"
 		ship "Berserker" "Syndicate Test Vessel"
-			sprite "ship/berserker"
 			attributes
 				category "Interceptor"
 				"cost" 520000
@@ -194,23 +193,6 @@ mission "Syndicate target practice [0]"
 					"shield damage" 300
 					"hull damage" 150
 					"hit force" 450
-			outfits
-				"Beam Laser" 4
-				"nGVF-CC Fuel Cell"
-				"LP072a Battery Pack"
-				"D23-QP Shield Generator"
-				"X2700 Ion Thruster"
-				"X3200 Ion Steering"
-				"Hyperdrive"
-			engine -10 45
-			engine 10 45
-			gun -20 12
-			gun 20 12
-			gun -44 10
-			gun 44 10
-			explode "tiny explosion" 10
-			explode "small explosion" 15
-			"final explode" "final explosion small"
 		system destination
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
@@ -243,7 +225,6 @@ mission "Syndicate target practice [1]"
 		personality staying heroic target
 		government "Test Dummy"
 		ship "Quicksilver" "Syndicate Test Vessel"
-			sprite "ship/quicksilver"
 			attributes
 				category "Light Warship"
 				"cost" 1090000
@@ -265,22 +246,6 @@ mission "Syndicate target practice [1]"
 					"shield damage" 400
 					"hull damage" 200
 					"hit force" 600
-			outfits
-				"Particle Cannon" 2
-				"RT-I Radiothermal"
-				"LP036a Battery Pack"
-				"D23-QP Shield Generator"
-				"Cooling Ducts"
-				"Greyhound Plasma Thruster"
-				"Greyhound Plasma Steering"
-				"Hyperdrive"
-			engine -17 54
-			engine 17 54
-			gun -6 -38 "Particle Cannon"
-			gun 6 -38 "Particle Cannon"
-			explode "tiny explosion" 12
-			explode "small explosion" 16
-			"final explode" "final explosion small"
 		system destination
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
@@ -313,7 +278,6 @@ mission "Syndicate target practice [2]"
 		personality staying heroic target
 		government "Test Dummy"
 		ship "Splinter" "Syndicate Test Vessel"
-			sprite "ship/splinter"
 			attributes
 				category "Medium Warship"
 				"cost" 3100000
@@ -335,29 +299,6 @@ mission "Syndicate target practice [2]"
 					"shield damage" 600
 					"hull damage" 300
 					"hit force" 900
-			outfits
-				"Proton Gun" 2
-				"Blaster Turret" 3
-				"RT-I Radiothermal"
-				"LP144a Battery Pack"
-				"D67-TM Shield Generator"
-				"Small Radar Jammer" 2
-				"Water Coolant System"
-				"X3700 Ion Thruster"
-				"X3200 Ion Steering"
-				"Hyperdrive"
-			engine -15 115
-			engine 15 115
-			gun -15 -80 "Proton Gun"
-			gun 15 -80 "Proton Gun"
-			turret -17 -28 "Blaster Turret"
-			turret 0 -28 "Blaster Turret"
-			turret 17 -28 "Blaster Turret"
-			explode "tiny explosion" 18
-			explode "small explosion" 36
-			explode "medium explosion" 24
-			explode "large explosion" 8
-			"final explode" "final explosion medium"
 		system destination
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
@@ -389,7 +330,6 @@ mission "Syndicate target practice [3]"
 		personality staying heroic target
 		government "Test Dummy"
 		ship "Vanguard" "Syndicate Test Vessel"
-			sprite "ship/vanguard"
 			attributes
 				category "Heavy Warship"
 				"cost" 7200000
@@ -411,31 +351,6 @@ mission "Syndicate target practice [3]"
 					"shield damage" 1600
 					"hull damage" 800
 					"hit force" 2400
-			outfits
-				"Proton Gun" 7
-				"Anti-Missile Turret"
-				"Fusion Reactor"
-				"LP072a Battery Pack"
-				"D67-TM Shield Generator"
-				"Liquid Nitrogen Cooler"
-				"X3700 Ion Thruster"
-				"X4200 Ion Steering"
-				"Hyperdrive"
-			engine -15 130
-			engine 15 130
-			gun 0 -132 "Proton Gun"
-			gun -22 -122 "Proton Gun"
-			gun 22 -122 "Proton Gun"
-			gun -21 -45 "Proton Gun"
-			gun 21 -45 "Proton Gun"
-			gun -31 -45 "Proton Gun"
-			gun 31 -45 "Proton Gun"
-			turret 0 42 "Anti-Missile Turret"
-			explode "tiny explosion" 18
-			explode "small explosion" 36
-			explode "medium explosion" 24
-			explode "large explosion" 8
-			"final explode" "final explosion medium"
 		system destination
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit

--- a/data/syndicate world jobs.txt
+++ b/data/syndicate world jobs.txt
@@ -326,7 +326,7 @@ mission "Syndicate target practice [3]"
 		distance 1 3
 		government Syndicate
 	to offer
-		random < 100
+		random < 20
 		"combat rating" > 1000
 		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"

--- a/data/syndicate world jobs.txt
+++ b/data/syndicate world jobs.txt
@@ -167,15 +167,58 @@ mission "Syndicate target practice [0]"
 		random < 20
 		"combat rating" > 5
 		"combat rating" < 50
+		"destroyed Syndicate target ship" < 1
 	npc save disable "scan cargo"
 		personality staying heroic target
 		government "Test Dummy"
 		ship "Berserker" "Syndicate Test Vessel"
-
+			sprite "ship/berserker"
+			attributes
+				category "Interceptor"
+				"cost" 520000
+				"shields" 2200
+				"hull" 500
+				"automaton" 1
+				"self destruct" 1
+				"bunks" 2
+				"mass" 110
+				"drag" 2.2
+				"heat dissipation" .85
+				"fuel capacity" 400
+				"cargo space" 10
+				"outfit space" 200
+				"weapon capacity" 35
+				"engine capacity" 65
+				weapon
+					"blast radius" 30
+					"shield damage" 300
+					"hull damage" 150
+					"hit force" 450
+			outfits
+				"Beam Laser" 4
+				"nGVF-CC Fuel Cell"
+				"LP072a Battery Pack"
+				"D23-QP Shield Generator"
+				"X2700 Ion Thruster"
+				"X3200 Ion Steering"
+				"Hyperdrive"
+			engine -10 45
+			engine 10 45
+			gun -20 12
+			gun 20 12
+			gun -44 10
+			gun 44 10
+			explode "tiny explosion" 10
+			explode "small explosion" 15
+			"final explode" "final explosion small"
 		system destination
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
+	on fail
+		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official, who chews you out and assures you that you'll never again be offered jobs of this type."
+		"destroyed Syndicate target ship" ++
+		"reputation: Syndicate" --
 	on complete
 		payment 20000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
@@ -195,14 +238,57 @@ mission "Syndicate target practice [1]"
 		random < 20
 		"combat rating" > 50
 		"combat rating" < 200
+		"destroyed Syndicate target ship" < 1
 	npc save disable "scan cargo"
 		personality staying heroic target
 		government "Test Dummy"
 		ship "Quicksilver" "Syndicate Test Vessel"
+			sprite "ship/quicksilver"
+			attributes
+				category "Light Warship"
+				"cost" 1090000
+				"shields" 3000
+				"hull" 800
+				"automaton" 1
+				"self destruct" 1
+				"bunks" 6
+				"mass" 120
+				"drag" 2.7
+				"heat dissipation" .8
+				"fuel capacity" 400
+				"cargo space" 10
+				"outfit space" 240
+				"weapon capacity" 60
+				"engine capacity" 70
+				weapon
+					"blast radius" 40
+					"shield damage" 400
+					"hull damage" 200
+					"hit force" 600
+			outfits
+				"Particle Cannon" 2
+				"RT-I Radiothermal"
+				"LP036a Battery Pack"
+				"D23-QP Shield Generator"
+				"Cooling Ducts"
+				"Greyhound Plasma Thruster"
+				"Greyhound Plasma Steering"
+				"Hyperdrive"
+			engine -17 54
+			engine 17 54
+			gun -6 -38 "Particle Cannon"
+			gun 6 -38 "Particle Cannon"
+			explode "tiny explosion" 12
+			explode "small explosion" 16
+			"final explode" "final explosion small"
 		system destination
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
+	on fail
+		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official, who chews you out and assures you that you'll never again be offered jobs of this type."
+		"destroyed Syndicate target ship" ++
+		"reputation: Syndicate" --
 	on complete
 		payment 40000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
@@ -222,14 +308,64 @@ mission "Syndicate target practice [2]"
 		random < 20
 		"combat rating" > 150
 		"combat rating" < 1000
+		"destroyed Syndicate target ship" < 1
 	npc save disable "scan cargo"
 		personality staying heroic target
 		government "Test Dummy"
 		ship "Splinter" "Syndicate Test Vessel"
+			sprite "ship/splinter"
+			attributes
+				category "Medium Warship"
+				"cost" 3100000
+				"shields" 5200
+				"hull" 1700
+				"automaton" 1
+				"self destruct" 1
+				"bunks" 21
+				"mass" 250
+				"drag" 4.0
+				"heat dissipation" .7
+				"fuel capacity" 600
+				"cargo space" 75
+				"outfit space" 400
+				"weapon capacity" 150
+				"engine capacity" 100
+				weapon
+					"blast radius" 60
+					"shield damage" 600
+					"hull damage" 300
+					"hit force" 900
+			outfits
+				"Proton Gun" 2
+				"Blaster Turret" 3
+				"RT-I Radiothermal"
+				"LP144a Battery Pack"
+				"D67-TM Shield Generator"
+				"Small Radar Jammer" 2
+				"Water Coolant System"
+				"X3700 Ion Thruster"
+				"X3200 Ion Steering"
+				"Hyperdrive"
+			engine -15 115
+			engine 15 115
+			gun -15 -80 "Proton Gun"
+			gun 15 -80 "Proton Gun"
+			turret -17 -28 "Blaster Turret"
+			turret 0 -28 "Blaster Turret"
+			turret 17 -28 "Blaster Turret"
+			explode "tiny explosion" 18
+			explode "small explosion" 36
+			explode "medium explosion" 24
+			explode "large explosion" 8
+			"final explode" "final explosion medium"
 		system destination
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
+	on fail
+		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official, who chews you out and assures you that you'll never again be offered jobs of this type."
+		"destroyed Syndicate target ship" ++
+		"reputation: Syndicate" --
 	on complete
 		payment 60000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
@@ -248,14 +384,66 @@ mission "Syndicate target practice [3]"
 	to offer
 		random < 20
 		"combat rating" > 1000
+		"destroyed Syndicate target ship" < 1
 	npc save disable "scan cargo"
 		personality staying heroic target
 		government "Test Dummy"
 		ship "Vanguard" "Syndicate Test Vessel"
+			sprite "ship/vanguard"
+			attributes
+				category "Heavy Warship"
+				"cost" 7200000
+				"shields" 9800
+				"hull" 6000
+				"automaton" 1
+				"self destruct" 1
+				"bunks" 45
+				"mass" 500
+				"drag" 8
+				"heat dissipation" .6
+				"fuel capacity" 400
+				"cargo space" 50
+				"outfit space" 560
+				"weapon capacity" 220
+				"engine capacity" 120
+				weapon
+					"blast radius" 160
+					"shield damage" 1600
+					"hull damage" 800
+					"hit force" 2400
+			outfits
+				"Proton Gun" 7
+				"Anti-Missile Turret"
+				"Fusion Reactor"
+				"LP072a Battery Pack"
+				"D67-TM Shield Generator"
+				"Liquid Nitrogen Cooler"
+				"X3700 Ion Thruster"
+				"X4200 Ion Steering"
+				"Hyperdrive"
+			engine -15 130
+			engine 15 130
+			gun 0 -132 "Proton Gun"
+			gun -22 -122 "Proton Gun"
+			gun 22 -122 "Proton Gun"
+			gun -21 -45 "Proton Gun"
+			gun 21 -45 "Proton Gun"
+			gun -31 -45 "Proton Gun"
+			gun 31 -45 "Proton Gun"
+			turret 0 42 "Anti-Missile Turret"
+			explode "tiny explosion" 18
+			explode "small explosion" 36
+			explode "medium explosion" 24
+			explode "large explosion" 8
+			"final explode" "final explosion medium"
 		system destination
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
+	on fail
+		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official, who chews you out and assures you that you'll never again be offered jobs of this type."
+		"destroyed Syndicate target ship" ++
+		"reputation: Syndicate" --
 	on complete
 		payment 100000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."

--- a/data/syndicate world jobs.txt
+++ b/data/syndicate world jobs.txt
@@ -167,7 +167,7 @@ mission "Syndicate target practice [0]"
 		random < 20
 		"combat rating" > 5
 		"combat rating" < 50
-		"destroyed Syndicate target ship" < 1
+		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"
 		personality staying heroic target
 		government "Test Dummy"
@@ -198,9 +198,10 @@ mission "Syndicate target practice [0]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on fail
-		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official, who chews you out and assures you that you'll never again be offered jobs of this type."
+		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
+		payment -40000
 	on complete
 		payment 20000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
@@ -220,7 +221,7 @@ mission "Syndicate target practice [1]"
 		random < 20
 		"combat rating" > 50
 		"combat rating" < 200
-		"destroyed Syndicate target ship" < 1
+		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"
 		personality staying heroic target
 		government "Test Dummy"
@@ -251,9 +252,10 @@ mission "Syndicate target practice [1]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on fail
-		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official, who chews you out and assures you that you'll never again be offered jobs of this type."
+		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
+		payment -80000
 	on complete
 		payment 40000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
@@ -273,7 +275,7 @@ mission "Syndicate target practice [2]"
 		random < 20
 		"combat rating" > 150
 		"combat rating" < 1000
-		"destroyed Syndicate target ship" < 1
+		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"
 		personality staying heroic target
 		government "Test Dummy"
@@ -304,9 +306,10 @@ mission "Syndicate target practice [2]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on fail
-		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official, who chews you out and assures you that you'll never again be offered jobs of this type."
+		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
+		payment -120000
 	on complete
 		payment 60000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
@@ -323,9 +326,9 @@ mission "Syndicate target practice [3]"
 		distance 1 3
 		government Syndicate
 	to offer
-		random < 20
+		random < 100
 		"combat rating" > 1000
-		"destroyed Syndicate target ship" < 1
+		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"
 		personality staying heroic target
 		government "Test Dummy"
@@ -356,9 +359,10 @@ mission "Syndicate target practice [3]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on fail
-		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official, who chews you out and assures you that you'll never again be offered jobs of this type."
+		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
+		payment -200000
 	on complete
 		payment 100000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."


### PR DESCRIPTION
Made the syndicate target ships into self-destructing automata, imposed a penalty for failure, and added some appropriate hostile and disabled hails, thereby resolving the following issues:
- https://github.com/endless-sky/endless-sky/issues/2151
- https://github.com/endless-sky/endless-sky/issues/2268
- https://github.com/endless-sky/endless-sky/issues/2890

I also wanted add a fine on failure, but that currently doesn't show up right in the description. I have opened issue https://github.com/endless-sky/endless-sky/issues/2900 to track that.