### PR TITLE
Repaired derelicts spawn as repaired, and repair fully when landing at spaceports. 

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -138,7 +138,7 @@ void NPC::Load(const DataNode &node)
 	{
 		ship->FinishLoading();
 		ship->SetGovernment(government);
-		ship->SetPersonality(personality);
+		ship->SetPersonality(personality, actions[ship.get()]);
 		ship->SetIsSpecial();
 	}
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1795,7 +1795,8 @@ void Ship::Recharge(bool atSpaceport)
 	pilotError = 0;
 	pilotOkay = 0;
 	
-	if(!personality.IsDerelict())
+	// All ships landed at a friendly spaceport can be repaired fully.
+	if(!personality.IsDerelict() || atSpaceport)
 	{
 		if(atSpaceport || attributes.Get("shield generation"))
 			shields = attributes.Get("shields");

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -645,10 +645,13 @@ const Personality &Ship::GetPersonality() const
 
 
 
-void Ship::SetPersonality(const Personality &other)
+void Ship::SetPersonality(const Personality &other, const int actions)
 {
 	personality = other;
-	if(personality.IsDerelict())
+	// If this ship is derelict but has been repaired, do not automatically
+	// disable it. If it was disabled after the repair, its shields and hull
+	// will reflect its current status.
+	if(personality.IsDerelict() && !(actions & ShipEvent::ASSIST))
 	{
 		shields = 0.;
 		hull = min(hull, .5 * MinimumHull());

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -139,7 +139,7 @@ public:
 	
 	// Access the ship's personality, which affects how the AI behaves.
 	const Personality &GetPersonality() const;
-	void SetPersonality(const Personality &other);
+	void SetPersonality(const Personality &other, const int actions = 0);
 	// Get a random hail message, or set the object used to generate them. If no
 	// object is given the government's default will be used.
 	void SetHail(const Phrase &phrase);


### PR DESCRIPTION
Refs #2910 

If you have not repaired a derelict, it cannot land -> no change from master
If you have repaired a derelict, it can land:
 - landing at a friendly spaceport -> "extra tools available" -> derelict ships can be fully repaired
 - landing on an uninhabited planet / planet with no spaceport -> no "extra tools available" -> no change from master
 - reopening the game after you have repaired the derelict ship will not require you to repair it again
