### PR TITLE
NPC "accompany" requires failIf value

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -56,7 +56,10 @@ void NPC::Load(const DataNode &node)
 		else if(node.Token(i) == "evade")
 			mustEvade = true;
 		else if(node.Token(i) == "accompany")
+		{
 			mustAccompany = true;
+			failIf |= ShipEvent::DESTROY;
+		}
 	}
 	
 	for(const DataNode &child : node)


### PR DESCRIPTION
This effectively makes `npc accompany` become `npc save accompany`.

If it was the intent of `accompany` to allow ships to be destroyed and still be able to be completed, then this is currently not working as intended (and a different fix is required).

By adding a failIf value, the player is immediately shown the "Mission failed" message and the mission will be removed upon landing when the mission becomes impossible to complete.

