### PR TITLE
Update allowed travel plan creation conditions

### DIFF
--- a/source/DistanceMap.cpp
+++ b/source/DistanceMap.cpp
@@ -153,9 +153,21 @@ void DistanceMap::Init(const System *center, const Ship *ship)
 		if(hyperspaceFuel == jumpFuel)
 			hyperspaceFuel = 0.;
 		
-		// If this ship has no mode of hyperspace travel, bail out.
-		if(!hyperspaceFuel && !jumpFuel && !player)
-			return;
+		// If this ship has no mode of hyperspace travel, and no local
+		// wormhole to use, bail out.
+		if(!jumpFuel && !hyperspaceFuel)
+		{
+			bool hasWormhole = false;
+			for(const StellarObject &object : ship->GetSystem()->Objects())
+				if(object.GetPlanet() && object.GetPlanet()->IsWormhole())
+				{
+					hasWormhole = true;
+					break;
+				}
+			
+			if(!hasWormhole)
+				return;
+		}
 	}
 	
 	// Find the route with lowest fuel use. If multiple routes use the same fuel,

--- a/source/DistanceMap.cpp
+++ b/source/DistanceMap.cpp
@@ -154,7 +154,7 @@ void DistanceMap::Init(const System *center, const Ship *ship)
 			hyperspaceFuel = 0.;
 		
 		// If this ship has no mode of hyperspace travel, bail out.
-		if(!hyperspaceFuel && !jumpFuel)
+		if(!hyperspaceFuel && !jumpFuel && !player)
 			return;
 	}
 	

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -101,19 +101,16 @@ void MapPanel::Draw()
 	
 	if(!distance.HasRoute(selectedSystem))
 	{
+		static const string UNAVAILABLE = "You have no available route to this system.";
+		static const string UNKNOWN = "You have not yet mapped a route to this system.";
 		const Font &font = FontSet::Get(18);
 		Color black(0., 1.);
 		Color red(1., 0., 0., 1.);
 		
-		string errorMessage;
-		if(player.HasVisited(selectedSystem))
-			errorMessage = "You have no available route to this system.";
-		else
-			errorMessage = "You have not yet mapped a route to this system.";
-		
-		Point point(-font.Width(errorMessage) / 2, Screen::Top() + 40);
-		font.Draw(errorMessage, point + Point(1, 1), black);
-		font.Draw(errorMessage, point, red);
+		const string &message = player.HasVisited(selectedSystem) ? UNAVAILABLE : UNKNOWN;
+		Point point(-font.Width(message) / 2, Screen::Top() + 40);
+		font.Draw(message, point + Point(1, 1), black);
+		font.Draw(message, point, red);
 	}
 }
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -102,14 +102,18 @@ void MapPanel::Draw()
 	if(!distance.HasRoute(selectedSystem))
 	{
 		const Font &font = FontSet::Get(18);
-		
-		static const string NO_ROUTE = "You have not yet mapped a route to this system.";
 		Color black(0., 1.);
 		Color red(1., 0., 0., 1.);
-		Point point(-font.Width(NO_ROUTE) / 2, Screen::Top() + 40);
 		
-		font.Draw(NO_ROUTE, point + Point(1, 1), black);
-		font.Draw(NO_ROUTE, point, red);
+		string errormsg = "You have no";
+		if(player.HasSeen(selectedSystem))
+			errormsg += " available route to this system.";
+		else
+			errormsg += "t yet mapped a route to this system.";
+		
+		Point point(-font.Width(errormsg) / 2, Screen::Top() + 40);
+		font.Draw(errormsg, point + Point(1, 1), black);
+		font.Draw(errormsg, point, red);
 	}
 }
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -105,15 +105,15 @@ void MapPanel::Draw()
 		Color black(0., 1.);
 		Color red(1., 0., 0., 1.);
 		
-		string errormsg = "You have no";
-		if(player.HasSeen(selectedSystem))
-			errormsg += " available route to this system.";
+		string errorMessage;
+		if(player.HasVisited(selectedSystem))
+			errorMessage = "You have no available route to this system.";
 		else
-			errormsg += "t yet mapped a route to this system.";
+			errorMessage = "You have not yet mapped a route to this system.";
 		
-		Point point(-font.Width(errormsg) / 2, Screen::Top() + 40);
-		font.Draw(errormsg, point + Point(1, 1), black);
-		font.Draw(errormsg, point, red);
+		Point point(-font.Width(errorMessage) / 2, Screen::Top() + 40);
+		font.Draw(errorMessage, point + Point(1, 1), black);
+		font.Draw(errorMessage, point, red);
 	}
 }
 


### PR DESCRIPTION
Refs #2936 

 - Removes incorrect/vague MapPanel error message when the player's flagship has no hyperdrive/jump drive installed.
 - Wormhole-only travel plan creation is possible for the player when no hyperdrive/jump drive is installed.

If a player has no hyperdrive or jump drive installed, this PR will enable them to make appropriate & allowed travel plans that use only wormholes.
The error message shown when attempting to route to an unrouteable system now properly indicates if you know how to get to that system but do not have the correct equipment which makes said travel possible, or if you actually do not know how to get to that system.