### PR TITLE
Add Control usage to Outfitter help screen

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -50,6 +50,7 @@ help "outfitter"
 	`Some types of outfits have other requirements as well. For example, only some of your outfit space can be used for engines or weapons; this is your ship's "engine capacity" and "weapon capacity." Guns and missile launchers also require a free "gun port," and turrets require a free "turret mount." Also, missiles can only be bought if you have the right launcher installed.`
 	`Use your scroll wheel, or click and drag, to scroll the view.`
 	`As in the trading panel, you can hold down Shift or Control to buy 5 or 20 of an outfit at once, or both keys to buy 100.`
+	`If you want to buy an outfit into your cargo hold, you can hold down Control while clicking any selected ships to deselect them.`
 
 help "stranded"
 	`Oops! You just ran out of fuel in an uninhabited star system. Fortunately, other ships are willing to help you.`


### PR DESCRIPTION
Refs #2946, #2182, #1765, #1481, perhaps more.

This PR would supply the simple hint that using Control allows the player to modify their ship selection in the outfitter. I opted to omit information about multiple ship selection with Shift to avoid "information overload" at the game start - the player is in no position to think about buying a second ship when they first enter the Outfitter tab.
As noted in some of the referenced issues, this is information that is available in the Steam FAQ and the Player Manual, but there are still many players that miss this information.