### PR TITLE
Keep partially collected flotsam

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1170,7 +1170,7 @@ void Engine::CalculateStep()
 			}
 			string commodity;
 			string message;
-			double amount = 0.;
+			int amount = 0;
 			if((*it)->OutfitType())
 			{
 				const Outfit *outfit = (*it)->OutfitType();
@@ -1181,11 +1181,10 @@ void Engine::CalculateStep()
 					{
 						commodity = outfit->Name();
 						player.Harvest(outfit);
-						amount *= (*it)->UnitSize();
 					}
 					else
 						message = name + Format::Number(amount) + " "
-							+ (amount == 1. ? outfit->Name() : outfit->PluralName()) + ".";
+							+ (amount == 1 ? outfit->Name() : outfit->PluralName()) + ".";
 				}
 			}
 			else
@@ -1196,7 +1195,8 @@ void Engine::CalculateStep()
 			}
 			if(!commodity.empty())
 			{
-				message = name + (amount == 1. ? "a ton" : Format::Number(amount) + " tons")
+				double amountInTons = amount * (*it)->UnitSize();
+				message = name + (amountInTons == 1. ? "a ton" : Format::Number(amountInTons) + " tons")
 					+ " of " + Format::LowerCase(commodity) + ".";
 			}
 			if(!message.empty())
@@ -1207,8 +1207,14 @@ void Engine::CalculateStep()
 				Messages::Add(message);
 			}
 			
-			it = flotsam.erase(it);
-			continue;
+			// This flotsam will dissapear if it's fully moved to the cargo hold.
+			// No other ships will collect from this flotsam in this step.
+			(*it)->Remove(amount);
+			if((*it)->Count() == 0)
+			{
+				it = flotsam.erase(it);
+				continue;
+			}
 		}
 		
 		// Draw this flotsam.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1207,13 +1207,18 @@ void Engine::CalculateStep()
 				Messages::Add(message);
 			}
 			
-			// This flotsam will dissapear if it's fully moved to the cargo hold.
-			// No other ships will collect from this flotsam in this step.
 			(*it)->Remove(amount);
 			if((*it)->Count() == 0)
 			{
+				// Flotsam was fully moved to the cargo hold.
 				it = flotsam.erase(it);
 				continue;
+			}
+			else
+			{
+				// Flotsam was collected, partially stripped, and then thrown back out.
+				// No other ships will collect from this flotsam in this step.
+				(*it)->Place(*collector);
 			}
 		}
 		

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1170,11 +1170,10 @@ void Engine::CalculateStep()
 			}
 			string commodity;
 			string message;
-			int amount = 0;
+			int amount = (*it)->TransferTo(collector);
 			if((*it)->OutfitType())
 			{
 				const Outfit *outfit = (*it)->OutfitType();
-				amount = collector->Cargo().Add(outfit, (*it)->Count());
 				if(!name.empty())
 				{
 					if(outfit->Get("installable") < 0.)
@@ -1189,7 +1188,6 @@ void Engine::CalculateStep()
 			}
 			else
 			{
-				amount = collector->Cargo().Add((*it)->CommodityType(), (*it)->Count());
 				if(!name.empty())
 					commodity = (*it)->CommodityType();
 			}
@@ -1207,19 +1205,14 @@ void Engine::CalculateStep()
 				Messages::Add(message);
 			}
 			
-			(*it)->Remove(amount);
-			if((*it)->Count() == 0)
+			if((*it)->Count() <= 0)
 			{
-				// Flotsam was fully moved to the cargo hold.
 				it = flotsam.erase(it);
 				continue;
 			}
-			else
-			{
-				// Flotsam was collected, partially stripped, and then thrown back out.
-				// No other ships will collect from this flotsam in this step.
-				(*it)->Place(*collector);
-			}
+			
+			// Flotsam was partially stipped.
+			// No other ships will collect from this flotsam in this step.
 		}
 		
 		// Draw this flotsam.

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -154,7 +154,7 @@ int Flotsam::TransferTo(Ship *collector)
 		collector->Cargo().Add(commodity, count);
 	
 	Point relative = collector->Velocity() - velocity;
-	double proportion = (double)amount / count;
+	double proportion = static_cast<double>(amount) / count;
 	velocity += relative * proportion;
 	
 	count -= amount;

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -142,3 +142,14 @@ double Flotsam::UnitSize() const
 {
 	return outfit ? outfit->Get("mass") : 1;
 }
+
+
+
+// Remove "units" from the flotsam.
+void Flotsam::Remove(int amount)
+{
+	if(amount < this->count)
+		this->count -= amount;
+	else
+		this->count = 0;
+}

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -145,11 +145,18 @@ double Flotsam::UnitSize() const
 
 
 
-// Remove "units" from the flotsam.
-void Flotsam::Remove(int amount)
+// Transfer contents to the collector ship. The flotsam velocity is
+// stabilized in proportion to the amount being transferred.
+int Flotsam::TransferTo(Ship *collector)
 {
-	if(amount < this->count)
-		this->count -= amount;
-	else
-		this->count = 0;
+	int amount = outfit ?
+		collector->Cargo().Add(outfit, count) :
+		collector->Cargo().Add(commodity, count);
+	
+	Point relative = collector->Velocity() - velocity;
+	double proportion = (double)amount / count;
+	velocity += relative * proportion;
+	
+	count -= amount;
+	return amount;
 }

--- a/source/Flotsam.h
+++ b/source/Flotsam.h
@@ -62,6 +62,9 @@ public:
 	// less than this amount of space, it can't pick up anything here.
 	double UnitSize() const;
 	
+	// Remove "units" from the flotsam.
+	void Remove(int amount);
+	
 	
 private:
 	Angle spin;

--- a/source/Flotsam.h
+++ b/source/Flotsam.h
@@ -62,8 +62,9 @@ public:
 	// less than this amount of space, it can't pick up anything here.
 	double UnitSize() const;
 	
-	// Remove "units" from the flotsam.
-	void Remove(int amount);
+	// Transfer contents to the collector ship. The flotsam velocity is
+	// stabilized in proportion to the amount being transferred.
+	int TransferTo(Ship *collector);
 	
 	
 private:


### PR DESCRIPTION
The leftover units would vanish when only part of the flotsam fits the
cargo hold. This means that you can lose cargo just by transfering it
to another ship of your fleet (jettison cargo, then guide other ships to
the flotsam).

This commit changes that behaviour, only removing the flotsam when there
are no more units. Only 1 ship can collect from the flotsam on each step.