### PR TITLE
bugfix: Call FinishLoading for all ships in an NPC block when instantiating missions

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -392,7 +392,7 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 		ship->SetGovernment(result.government);
 		ship->SetIsSpecial();
 		ship->SetPersonality(result.personality);
-		result.ships.back()->FinishLoading(true);
+		ship->FinishLoading(true);
 		
 		if(personality.IsEntering())
 			Fleet::Enter(*result.system, *ship);


### PR DESCRIPTION
Appeared in ee9d339f: when multiple ships are present in an NPC specification, only the last one would get FinishLoading() called while instantiating the parent mission.

e.g.
```
npc
    ship "Ship A" "Something"
    ship "Ship B" "Something 2"
```
Ship A would not call FinishLoading(), while Ship B would call FinishLoading() twice.