### PR TITLE
Fix missing jettisoned commodities

### DIFF
--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -20,7 +20,13 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Ship.h"
 #include "SpriteSet.h"
 
+#include <cmath>
+
 using namespace std;
+
+
+
+const int Flotsam::TONS_PER_BOX = 5;
 
 
 
@@ -29,6 +35,9 @@ Flotsam::Flotsam(const string &commodity, int count)
 	: commodity(commodity), count(count)
 {
 	lifetime = Random::Int(300) + 360;
+	// Scale lifetime in proportion to the expected amount per box.
+	if(count != TONS_PER_BOX)
+		lifetime = sqrt(count / TONS_PER_BOX) * lifetime;
 }
 
 

--- a/source/Flotsam.h
+++ b/source/Flotsam.h
@@ -63,6 +63,11 @@ public:
 	double UnitSize() const;
 	
 	
+public:
+	// Amount of tons that is expected per box.
+	static const int TONS_PER_BOX;
+	
+	
 private:
 	Angle spin;
 	int lifetime = 0;

--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -137,10 +137,9 @@ bool Minable::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		{
 			// Each payload object has a 25% chance of surviving. This creates
 			// a distribution with occasional very good payoffs.
-			static const int PER_BOX = 5;
-			for(int amount = Random::Binomial(it.second, .25); amount > 0; amount -= PER_BOX)
+			for(int amount = Random::Binomial(it.second, .25); amount > 0; amount -= Flotsam::TONS_PER_BOX)
 			{
-				flotsam.emplace_back(new Flotsam(it.first, min(amount, PER_BOX)));
+				flotsam.emplace_back(new Flotsam(it.first, min(amount, Flotsam::TONS_PER_BOX)));
 				flotsam.back()->Place(*this);
 			}
 		}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2290,9 +2290,8 @@ void Ship::Jettison(const string &commodity, int tons)
 	double shipMass = Mass();
 	heat *= shipMass / (shipMass + tons);
 	
-	static const int perBox = 5;
-	for( ; tons > 0; tons -= perBox)
-		jettisoned.emplace_back(new Flotsam(commodity, (perBox < tons) ? perBox : tons));
+	for( ; tons > 0; tons -= Flotsam::TONS_PER_BOX)
+		jettisoned.emplace_back(new Flotsam(commodity, (Flotsam::TONS_PER_BOX < tons) ? Flotsam::TONS_PER_BOX : tons));
 }
 
 
@@ -2310,7 +2309,7 @@ void Ship::Jettison(const Outfit *outfit, int count)
 	double shipMass = Mass();
 	heat *= shipMass / (shipMass + count * mass);
 	
-	const int perBox = (mass <= 0.) ? count : (mass > 5.) ? 1 : static_cast<int>(5. / mass);
+	const int perBox = (mass <= 0.) ? count : (mass > Flotsam::TONS_PER_BOX) ? 1 : static_cast<int>(Flotsam::TONS_PER_BOX / mass);
 	while(count > 0)
 	{
 		jettisoned.emplace_back(new Flotsam(outfit, (perBox < count) ? perBox : count));

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2291,8 +2291,8 @@ void Ship::Jettison(const string &commodity, int tons)
 	heat *= shipMass / (shipMass + tons);
 	
 	static const int perBox = 5;
-	for( ; tons >= perBox; tons -= perBox)
-		jettisoned.emplace_back(new Flotsam(commodity, perBox));
+	for( ; tons > 0; tons -= perBox)
+		jettisoned.emplace_back(new Flotsam(commodity, (perBox < tons) ? perBox : tons));
 }
 
 


### PR DESCRIPTION
The last box of commodities was not being jettisoned unless it was a multiple of 5, which is the maximum number of commodities per box.

Note that this will also allow players to send out more flotsam to distract pirates (select commodity, dump a quantity lower than 5, repeat).