### PR TITLE
Set Remnant space's "raid fleet"

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -293,6 +293,7 @@ government "Remnant"
 	"player reputation" 1
 	"attitude toward"
 		"Korath" -.01
+	raid "Korath Raid"
 
 government "Republic"
 	swizzle 0


### PR DESCRIPTION
#2964 : This PR sets the Remnant's raid fleet (for having too much unguarded cargo space) to be the Korath Raider + 2x Chaser fleet.