### PR TITLE
Enhancement: Allow government color in interface strings

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -354,7 +354,7 @@ interface "targets" top left
 		color "medium"
 	string "target government"
 		center 75 435
-		color "medium"
+		color "medium" government
 	string "mission target"
 		center 75 455
 		color "medium"

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -16,6 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Font.h"
 #include "FontSet.h"
 #include "GameData.h"
+#include "Government.h"
 #include "Information.h"
 #include "LineShader.h"
 #include "OutlineShader.h"
@@ -487,11 +488,23 @@ bool Interface::TextElement::ParseLine(const DataNode &node)
 	if(node.Token(0) == "size" && node.Size() >= 2)
 		fontSize = node.Value(1);
 	else if(node.Token(0) == "color" && node.Size() >= 2)
+	{
 		color[Element::ACTIVE] = GameData::Colors().Get(node.Token(1));
+		if(node.Size() >= 3 && node.Token(2) == "government")
+			useGovernmentColor[Element::ACTIVE] = true;
+	}
 	else if(node.Token(0) == "inactive" && node.Size() >= 2)
+	{
 		color[Element::INACTIVE] = GameData::Colors().Get(node.Token(1));
+		if(node.Size() >= 3 && node.Token(2) == "government")
+			useGovernmentColor[Element::INACTIVE] = true;
+	}
 	else if(node.Token(0) == "hover" && node.Size() >= 2)
+	{
 		color[Element::HOVER] = GameData::Colors().Get(node.Token(1));
+		if(node.Size() >= 3 && node.Token(2) == "government")
+			useGovernmentColor[Element::HOVER] = true;
+	}
 	else
 		return false;
 	
@@ -513,11 +526,19 @@ Point Interface::TextElement::NativeDimensions(const Information &info, int stat
 // Draw this element in the given rectangle.
 void Interface::TextElement::Draw(const Rectangle &rect, const Information &info, int state) const
 {
+	const Color *fontColor = color[state];
+	if(useGovernmentColor[state])
+	{
+		const Government *government = GameData::Governments().Find(GetString(info));
+		if(government)
+			fontColor = &(government->GetColor());
+	}
+
 	// Avoid crashes for malformed interface elements that are not fully loaded.
-	if(!color[state])
+	if(!fontColor)
 		return;
 	
-	FontSet::Get(fontSize).Draw(GetString(info), rect.TopLeft(), *color[state]);
+	FontSet::Get(fontSize).Draw(GetString(info), rect.TopLeft(), *fontColor);
 }
 
 

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -152,6 +152,8 @@ private:
 		std::string str;
 		// Color for inactive, active, and hover states.
 		const Color *color[3] = {nullptr, nullptr, nullptr};
+		// Use the government color when the string matches a government name.
+		bool useGovernmentColor[3] = {false, false, false};
 		int fontSize = 14;
 		char buttonKey = '\0';
 		bool isDynamic = false;


### PR DESCRIPTION
I'm currently playing with a Mule and a permanent fleet of 7 Headhunters (mid-game). I'm no longer interested in some of the small pirate ships, so when one of those ships appears as my target for boarding (after pressing B) I tell my fleet to focus fire on it to destroy it. Unfortunately sometimes I end up killing disabled allies by mistake.

When a ship is disabled the only way to know if it's an ally is by reading the government text, which forces me to take focus away from ongoing battles. To be able to **know if the disabled target is an ally** at a glance, this pull request is coloring the **government name** with the **government color**.