### PR TITLE
Enhancement: Select previous ship with Ctrl

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -116,6 +116,7 @@ void AI::IssueMoveTarget(const PlayerInfo &player, const Point &target, const Sy
 void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 {
 	shift = (SDL_GetModState() & KMOD_SHIFT);
+	ctrl = (SDL_GetModState() & KMOD_CTRL);
 	escortsUseAmmo = Preferences::Has("Escorts expend ammo");
 	escortsAreFrugal = Preferences::Has("Escorts use ammo frugally");
 	
@@ -2564,21 +2565,38 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 	else if(keyDown.Has(Command::TARGET))
 	{
 		shared_ptr<const Ship> target = ship.GetTargetShip();
-		bool selectNext = !target || !target->IsTargetable();
+		shared_ptr<Ship> previous;
+		bool selectNext =  !ctrl && (!target || !target->IsTargetable());
 		for(const shared_ptr<Ship> &other : ships)
 		{
 			bool isPlayer = other->GetGovernment()->IsPlayer() || other->GetPersonality().IsEscort();
 			if(other == target)
-				selectNext = true;
-			else if(other.get() != &ship && selectNext && other->IsTargetable() && isPlayer == shift)
 			{
-				ship.SetTargetShip(other);
-				selectNext = false;
-				break;
+				if(ctrl)
+				{
+					ship.SetTargetShip(previous);
+					break;
+				}
+				selectNext = true;
+			}
+			else if(other.get() != &ship && other->IsTargetable() && isPlayer == shift)
+			{
+				if(selectNext)
+				{
+					ship.SetTargetShip(other);
+					selectNext = false;
+					break;
+				}
+				previous = other;
 			}
 		}
-		if(selectNext)
-			ship.SetTargetShip(shared_ptr<Ship>());
+		if(target == ship.GetTargetShip())
+		{
+			if(selectNext)
+				ship.SetTargetShip(shared_ptr<Ship>());
+			else
+				ship.SetTargetShip(previous);
+		}
 	}
 	else if(keyDown.Has(Command::BOARD))
 	{

--- a/source/AI.h
+++ b/source/AI.h
@@ -158,6 +158,7 @@ private:
 	bool isLaunching = false;
 	bool isCloaking = false;
 	bool shift = false;
+	bool ctrl = false;
 	
 	bool escortsAreFrugal = true;
 	bool escortsUseAmmo = true;


### PR DESCRIPTION
This commit extends the "Select next ship" command, N key by default, to get the previous ship when Ctrl is being held.

With N you get the next targetable ship.
With Ctrl+N you get previous targetable ship.
With Shift+N you get the next player ship.
With Ctrl+Shift+N you get the previous player ship.

This allows a player to quickly repeat N until the intended target is selected and go back if N was pressed to many times by mistake.