### PR TITLE
Reverse Thrust while turning.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2774,18 +2774,18 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		AutoFire(ship, command, false);
 	if(keyHeld)
 	{
+		if(keyHeld.Has(Command::FORWARD))
+			command |= Command::FORWARD;
 		if(keyHeld.Has(Command::RIGHT | Command::LEFT))
 			command.SetTurn(keyHeld.Has(Command::RIGHT) - keyHeld.Has(Command::LEFT));
-		else if(keyHeld.Has(Command::BACK))
+		if(keyHeld.Has(Command::BACK))
 		{
-			if(ship.Attributes().Get("reverse thrust"))
+			if(!keyHeld.Has(Command::FORWARD) && ship.Attributes().Get("reverse thrust"))
 				command |= Command::BACK;
-			else
+			else if (!keyHeld.Has(Command::RIGHT | Command::LEFT))
 				command.SetTurn(TurnBackward(ship));
 		}
 		
-		if(keyHeld.Has(Command::FORWARD))
-			command |= Command::FORWARD;
 		if(keyHeld.Has(Command::PRIMARY))
 		{
 			int index = 0;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2782,7 +2782,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		{
 			if(!keyHeld.Has(Command::FORWARD) && ship.Attributes().Get("reverse thrust"))
 				command |= Command::BACK;
-			else if (!keyHeld.Has(Command::RIGHT | Command::LEFT))
+			else if(!keyHeld.Has(Command::RIGHT | Command::LEFT))
 				command.SetTurn(TurnBackward(ship));
 		}
 		

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -271,12 +271,10 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	attributesHeight += 20;
 	tableLabels.push_back("moving:");
 	energyTable.push_back(Format::Number(
-		-60. * (attributes.Get("thrusting energy")
-			+ attributes.Get("reverse thrusting energy")
+		-60. * (max(attributes.Get("thrusting energy"), attributes.Get("reverse thrusting energy"))
 			+ attributes.Get("turning energy"))));
 	heatTable.push_back(Format::Number(
-		60. * (attributes.Get("thrusting heat")
-			+ attributes.Get("reverse thrusting heat")
+		60. * (max(attributes.Get("thrusting heat"), attributes.Get("reverse thrusting heat"))
 			+ attributes.Get("turning heat"))));
 	attributesHeight += 20;
 	double firingEnergy = 0.;


### PR DESCRIPTION
Key Press   Command
[Up]        Engage Forward Thrust (and disable Reverse Thrust).
[Left]      Turn Left.
[Right]     Turn Right.
[Down]      If Reverse Thrust installed and not engaging Forward Thrust,
            engage Reverse Thrust,
            else if not turning Left nor Right,
            turn to the reverse direction the ship is moving to.

Behavior Changes:
- Can no longer engage both Forward and Reverse Thrust at the same time.
- Turning Left or Right, will no longer disable Reverse Thrust.
- Can Reverse Thrust while turning Left or Right.
- Engaging Forward Thrust will always behave as if Reverse Thrust is not installed.