### PR TITLE
Fix not being able to take back orders that require a target

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3010,6 +3010,10 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 		if(ship == newTarget)
 			continue;
 		
+		// Never issue orders that target a ship in another system.
+		if(newTarget && ship->GetSystem() != newTarget->GetSystem())
+			continue;
+		
 		gaveOrder = true;
 		hasMismatch |= !orders.count(ship);
 		


### PR DESCRIPTION
To take back an order like "gather" or "focus fire" you issue it again.

When one of your ships is unparked in another system it will first travel to your system. While it is traveling, orders that require a target could be given but not taken back.
