### PR TITLE
Enhancement: Show outfit mass in the cargo of the ship panel.

### DIFF
--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -549,7 +549,14 @@ void ShipInfoPanel::DrawCargo(const Rectangle &bounds)
 			
 			bool isSingular = (it.second == 1 || it.first->Get("installable") < 0.);
 			table.Draw(isSingular ? it.first->Name() : it.first->PluralName(), dim);
-			table.Draw(to_string(it.second), bright);
+			
+			// Show the size in the format "<count> x <unit mass>".
+			// If the mass is 1, only the count is reported.
+			string size = to_string(it.second);
+			double mass = it.first->Get("mass");
+			if(mass != 1.)
+				size += " x " + Format::Number(mass);
+			table.Draw(size, bright);
 			
 			// Truncate the list if there is not enough space.
 			if(table.GetRowBounds().Bottom() >= endY)


### PR DESCRIPTION
This commit will show the cargo size as "(count) x (unit mass)".
If the mass is 1, only the count is reported.
Commodities have of mass of 1 so no change is required.

This allows a player to better decide what to jettison from existing cargo to make space for a big outfit which is about to be plundered.