### PR TITLE
Stabilize escort order and extend escort display

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -687,6 +687,7 @@ void Engine::Draw() const
 		Screen::Bottom() - 20. * messages.size());
 	auto it = messages.begin();
 	double firstY = Screen::Top() - font.Height();
+	int visibleMessages = 0;
 	if(messagePoint.Y() < firstY)
 	{
 		int skip = (firstY - messagePoint.Y()) / 20.;
@@ -699,6 +700,8 @@ void Engine::Draw() const
 		Color color(alpha, 0.);
 		font.Draw(it->message, messagePoint, color);
 		messagePoint.Y() += 20.;
+		if(visibleMessages || alpha > 0.f)
+			++visibleMessages;
 	}
 	
 	// Draw crosshairs around anything that is targeted.
@@ -767,7 +770,7 @@ void Engine::Draw() const
 	}
 	
 	// Draw escort status.
-	escorts.Draw();
+	escorts.Draw(visibleMessages);
 	
 	// Upload any preloaded sprites that are now available. This is to avoid
 	// filling the entire backlog of sprites before landing on a planet.

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -19,6 +19,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Government.h"
 #include "LineShader.h"
 #include "Point.h"
+#include "Preferences.h"
 #include "OutlineShader.h"
 #include "Screen.h"
 #include "Ship.h"
@@ -48,7 +49,7 @@ void EscortDisplay::Add(const Ship &ship, bool isHere, bool fleetIsJumping, bool
 
 
 // The display starts in the lower left corner of the screen and takes up
-// all but the top 450 pixels of the screen. It shows aditional columns
+// all but the top 450 pixels of the screen. It can show additional columns
 // up to the center of the screen.
 void EscortDisplay::Draw() const
 {
@@ -82,10 +83,9 @@ void EscortDisplay::Draw() const
 		if(pos.Y() <= Screen::Top() + 450.)
 		{
 			// Show only as many escorts as we have room for on screen.
-			if(pos.X() > -200)
+			if(!Preferences::Has("Show more escorts") || pos.X() > -200)
 			{
 				hiddenEscorts = escort.ships.size();
-				pos.Y() += escort.Height();
 				continue;
 			}
 			pos = Point(pos.X() + 110., Screen::Bottom() - escort.Height());

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -83,12 +83,13 @@ void EscortDisplay::Draw(int visibleMessages) const
 		if(pos.Y() <= Screen::Top() + 450.)
 		{
 			// Show only as many escorts as we have room for on screen.
-			if(!Preferences::Has("Show more escorts") || pos.X() > -200)
+			Point columnPos = Point(pos.X() + 110., Screen::Bottom() - escort.Height() - 20. * visibleMessages);
+			if(!Preferences::Has("Show more escorts") || columnPos.X() > -90 || columnPos.Y() <= Screen::Top() + 450.)
 			{
 				hiddenEscorts = escort.ships.size();
 				continue;
 			}
-			pos = Point(pos.X() + 110., Screen::Bottom() - escort.Height() - 20. * visibleMessages);
+			pos = columnPos;
 		}
 		
 		// Draw the system name for any escort not in the current system.

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -51,7 +51,7 @@ void EscortDisplay::Add(const Ship &ship, bool isHere, bool fleetIsJumping, bool
 // The display starts in the lower left corner of the screen and takes up
 // all but the top 450 pixels of the screen. It can show additional columns
 // up to the center of the screen.
-void EscortDisplay::Draw() const
+void EscortDisplay::Draw(int visibleMessages) const
 {
 	MergeStacks();
 	stacks.clear();
@@ -88,7 +88,7 @@ void EscortDisplay::Draw() const
 				hiddenEscorts = escort.ships.size();
 				continue;
 			}
-			pos = Point(pos.X() + 110., Screen::Bottom() - escort.Height());
+			pos = Point(pos.X() + 110., Screen::Bottom() - escort.Height() - 20. * visibleMessages);
 		}
 		
 		// Draw the system name for any escort not in the current system.

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -216,7 +216,7 @@ bool EscortDisplay::Icon::operator<(const Icon &other) const
 {
 	if(isHere != other.isHere)
 		return isHere;
-	if(system != other.system);
+	if(system != other.system)
 		return system < other.system;
 	return (cost > other.cost);
 }

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -100,7 +100,7 @@ void EscortDisplay::Draw(int visibleMessages) const
 		Color color;
 		if(escort.isHostile)
 			color = hostileColor;
-		else if(!escort.isHere)
+		else if(!escort.isActiveHere)
 			color = elsewhereColor;
 		else if(escort.cannotJump)
 			color = cannotJumpColor;
@@ -194,7 +194,7 @@ const vector<const Ship *> &EscortDisplay::Click(const Point &point) const
 
 EscortDisplay::Icon::Icon(const Ship &ship, bool isHere, bool fleetIsJumping, bool isSelected)
 	: sprite(ship.GetSprite()),
-	isHere(isHere && !ship.IsDisabled()),
+	isActiveHere(isHere && !ship.IsDisabled()),
 	isHostile(ship.GetGovernment() && ship.GetGovernment()->IsEnemy()),
 	notReadyToJump(fleetIsJumping && !ship.IsHyperspacing() && !ship.IsReadyToJump()),
 	cannotJump(fleetIsJumping && !ship.IsHyperspacing() && !ship.JumpsRemaining()),
@@ -214,8 +214,8 @@ EscortDisplay::Icon::Icon(const Ship &ship, bool isHere, bool fleetIsJumping, bo
 // It comes sooner if it's here, then by system name, then if it costs more.
 bool EscortDisplay::Icon::operator<(const Icon &other) const
 {
-	if(isHere != other.isHere)
-		return isHere;
+	if(isActiveHere != other.isActiveHere)
+		return isActiveHere;
 	if(system != other.system)
 		return system < other.system;
 	return (cost > other.cost);
@@ -232,7 +232,7 @@ int EscortDisplay::Icon::Height() const
 
 void EscortDisplay::Icon::Merge(const Icon &other)
 {
-	isHere &= other.isHere;
+	isActiveHere &= other.isActiveHere;
 	isHostile |= other.isHostile;
 	notReadyToJump |= other.notReadyToJump;
 	cannotJump |= other.cannotJump;
@@ -262,7 +262,7 @@ void EscortDisplay::MergeStacks() const
 	string currentSystem;
 	for(Icon &icon : icons)
 	{
-		icon.withSystem = (!icon.isHere && icon.system != currentSystem);
+		icon.withSystem = (!icon.isActiveHere && icon.system != currentSystem);
 		if(icon.withSystem)
 			currentSystem = icon.system;
 	}
@@ -299,7 +299,7 @@ void EscortDisplay::MergeStacks() const
 				
 				// Same system? Icons are ordered by system first so we stop merging
 				// when we encounter a different system.
-				if(stack->isHere != stackable->isHere || stack->system != stackable->system)
+				if(stack->isActiveHere != stackable->isActiveHere || stack->system != stackable->system)
 					break;
 				
 				// Same sprite and attitude?

--- a/source/EscortDisplay.h
+++ b/source/EscortDisplay.h
@@ -33,7 +33,7 @@ public:
 	void Add(const Ship &ship, bool isHere, bool fleetIsJumping, bool isSelected);
 	
 	// The display starts in the lower left corner of the screen and takes up
-	// all but the top 450 pixels of the screen. It shows aditional columns
+	// all but the top 450 pixels of the screen. It can show additional columns
 	// up to the center of the screen.
 	void Draw() const;
 	

--- a/source/EscortDisplay.h
+++ b/source/EscortDisplay.h
@@ -49,7 +49,7 @@ private:
 		// Sorting operator.
 		bool operator<(const Icon &other) const;
 		
-		int Height() const;
+		int Height(bool withSystem = false) const;
 		void Merge(const Icon &other);
 		
 		const Sprite *sprite;

--- a/source/EscortDisplay.h
+++ b/source/EscortDisplay.h
@@ -35,7 +35,7 @@ public:
 	// The display starts in the lower left corner of the screen and takes up
 	// all but the top 450 pixels of the screen. It can show additional columns
 	// up to the center of the screen.
-	void Draw() const;
+	void Draw(int visibleMessages) const;
 	
 	// Check if the given point is a click on an escort icon. If so, return the
 	// stack of ships represented by the icon. Otherwise, return an empty stack.

--- a/source/EscortDisplay.h
+++ b/source/EscortDisplay.h
@@ -33,7 +33,8 @@ public:
 	void Add(const Ship &ship, bool isHere, bool fleetIsJumping, bool isSelected);
 	
 	// The display starts in the lower left corner of the screen and takes up
-	// all but the top 450 pixels of the screen.
+	// all but the top 450 pixels of the screen. It shows aditional columns
+	// up to the center of the screen.
 	void Draw() const;
 	
 	// Check if the given point is a click on an escort icon. If so, return the
@@ -49,7 +50,7 @@ private:
 		// Sorting operator.
 		bool operator<(const Icon &other) const;
 		
-		int Height(bool withSystem = false) const;
+		int Height() const;
 		void Merge(const Icon &other);
 		
 		const Sprite *sprite;
@@ -58,6 +59,7 @@ private:
 		bool notReadyToJump;
 		bool cannotJump;
 		bool isSelected;
+		bool withSystem;
 		int64_t cost;
 		std::string system;
 		std::vector<double> low;

--- a/source/EscortDisplay.h
+++ b/source/EscortDisplay.h
@@ -54,7 +54,7 @@ private:
 		void Merge(const Icon &other);
 		
 		const Sprite *sprite;
-		bool isHere;
+		bool isActiveHere;
 		bool isHostile;
 		bool notReadyToJump;
 		bool cannotJump;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -438,7 +438,8 @@ void PreferencesPanel::DrawSettings()
 		REACTIVATE_HELP,
 		SCROLL_SPEED,
 		"Warning siren",
-		"Hide unexplored map regions"
+		"Hide unexplored map regions",
+		"Show more escorts"
 	};
 	bool isCategory = true;
 	for(const string &setting : SETTINGS)


### PR DESCRIPTION
The escort list was unusable if I unparked lots of ships from different systems. The ships would jump all over the list and I would have no idea how many were not being displayed.

Escorts are ordered first by being in the current system, second by system name, and third by the biggest cost.

The system name is only displayed below his first ship stack.

There can be aditional columns of escorts up to the center.

The number of hidden escorts is displayed.

Screenshot with a smaller window to showcase this:
![endless_sky_2017-08-31_14-46-37](https://user-images.githubusercontent.com/1009600/29928076-f281c3fa-8e5f-11e7-93ab-9b68fe0c7daf.png)
