### PR TITLE
Mission NPCs can be given individual travel instructions

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -797,13 +797,12 @@ void AI::Step(const PlayerInfo &player)
 		// escort behavior when in a different system from you. Otherwise,
 		// the behavior depends on what the parent is doing, whether there
 		// are hostile targets nearby, and whether the escort has any
-		// immediate needs (like refueling).
-		else if(!parent)
+		// immediate needs (like refueling or performing a survey).
+		else if(!parent || it->IsSurveying())
 			MoveIndependent(*it, command);
 		else if(parent->GetSystem() != it->GetSystem())
 		{
-			// NPCs needing to perform StellarObject flybys (surveying) need to use MoveIndependent.
-			if(it->IsSurveying() || personality.IsStaying() || !it->Attributes().Get("fuel capacity"))
+			if(personality.IsStaying() || !it->Attributes().Get("fuel capacity"))
 				MoveIndependent(*it, command);
 			else
 				MoveEscort(*it, command);
@@ -812,8 +811,8 @@ void AI::Step(const PlayerInfo &player)
 		// which is in the same system as them.
 		else if(parent->GetGovernment()->IsEnemy(gov))
 		{
-			// Fight your target, if you have one, or continue your survey.
-			if(target || it->IsSurveying())
+			// Fight your target, if you have one.
+			if(target)
 				MoveIndependent(*it, command);
 			// Otherwise try to find and fight your parent. If your parent
 			// can't be both targeted and pursued, then don't follow them.
@@ -833,7 +832,7 @@ void AI::Step(const PlayerInfo &player)
 			else
 				CircleAround(*it, command, *parent);
 		}
-		else if(personality.IsStaying() || it->IsSurveying())
+		else if(personality.IsStaying())
 			MoveIndependent(*it, command);
 		// This is a friendly escort. If the parent is getting ready to
 		// jump, always follow.

--- a/source/AI.h
+++ b/source/AI.h
@@ -51,7 +51,7 @@ template <class Type>
 	AI(const List<Ship> &ships, const List<Minable> &minables, const List<Flotsam> &flotsam);
 	
 	// NPC commands from mission events.
-	void IssueNPCTravelOrders(Ship &ship, const System *moveToSystem, const Planet *targetPlanet);
+	void IssueNPCTravelOrders(Ship &ship, const System *moveToSystem, std::map<const Planet *, bool> targetPlanets);
 	
 	// Fleet commands from the player.
 	void IssueShipTarget(const PlayerInfo &player, const std::shared_ptr<Ship> &target);

--- a/source/AI.h
+++ b/source/AI.h
@@ -50,9 +50,6 @@ template <class Type>
 	// Constructor, giving the AI access to various object lists.
 	AI(const List<Ship> &ships, const List<Minable> &minables, const List<Flotsam> &flotsam);
 	
-	// NPC commands from mission events.
-	void IssueNPCTravelOrders(Ship &ship, const System *moveToSystem, std::map<const Planet *, bool> targetPlanets);
-	
 	// Fleet commands from the player.
 	void IssueShipTarget(const PlayerInfo &player, const std::shared_ptr<Ship> &target);
 	void IssueMoveTarget(const PlayerInfo &player, const Point &target, const System *moveToSystem);
@@ -173,6 +170,8 @@ private:
 	void IssueOrders(const PlayerInfo &player, const Orders &newOrders, const std::string &description);
 	// Convert order types based on fulfillment status.
 	void UpdateOrders(const Ship &ship);
+	// NPC commands from mission events.
+	void IssueNPCOrders(Ship &ship, const System *waypoint, const std::map<const Planet *, bool> stopovers);
 	
 	
 private:

--- a/source/AI.h
+++ b/source/AI.h
@@ -27,6 +27,7 @@ class Body;
 class Flotsam;
 class Government;
 class Minable;
+class Planet;
 class PlayerInfo;
 class Ship;
 class ShipEvent;
@@ -48,6 +49,9 @@ template <class Type>
 	using List = std::list<std::shared_ptr<Type>>;
 	// Constructor, giving the AI access to various object lists.
 	AI(const List<Ship> &ships, const List<Minable> &minables, const List<Flotsam> &flotsam);
+	
+	// NPC commands from mission events.
+	void IssueNPCTravelOrders(const Ship &ship, const System *moveToSystem, const Planet *targetPlanet);
 	
 	// Fleet commands from the player.
 	void IssueShipTarget(const PlayerInfo &player, const std::shared_ptr<Ship> &target);
@@ -147,6 +151,8 @@ private:
 	public:
 		static const int HOLD_POSITION = 0x000;
 		static const int MOVE_TO = 0x001;
+		static const int TRAVEL_TO = 0x002;
+		static const int LAND_ON = 0x003;
 		static const int KEEP_STATION = 0x100;
 		static const int GATHER = 0x101;
 		static const int ATTACK = 0x102;
@@ -159,6 +165,7 @@ private:
 		std::weak_ptr<Ship> target;
 		Point point;
 		const System *targetSystem = nullptr;
+		const Planet *targetPlanet = nullptr;
 	};
 
 
@@ -189,8 +196,8 @@ private:
 	// Pressing "land" rapidly toggles targets; pressing it once re-engages landing.
 	int landKeyInterval = 0;
 	
-	// Current orders for the player's ships. Because this map only applies to
-	// player ships, which are never deleted except when landed, it can use
+	// Current orders for the player's ships or NPCs. Because this map only applies
+	// to special ships, which are never deleted except when landed, it can use
 	// ordinary pointers instead of weak pointers.
 	std::map<const Ship *, Orders> orders;
 	

--- a/source/AI.h
+++ b/source/AI.h
@@ -51,7 +51,7 @@ template <class Type>
 	AI(const List<Ship> &ships, const List<Minable> &minables, const List<Flotsam> &flotsam);
 	
 	// NPC commands from mission events.
-	void IssueNPCTravelOrders(const Ship &ship, const System *moveToSystem, const Planet *targetPlanet);
+	void IssueNPCTravelOrders(Ship &ship, const System *moveToSystem, const Planet *targetPlanet);
 	
 	// Fleet commands from the player.
 	void IssueShipTarget(const PlayerInfo &player, const std::shared_ptr<Ship> &target);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1359,6 +1359,9 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 		// self-destruct.
 		if(ship->IsDestroyed())
 			eventQueue.emplace_back(nullptr, ship, ShipEvent::DESTROY);
+		else if(ship->HasLanded() && ship->IsSpecial())
+			eventQueue.emplace_back(nullptr, ship, ShipEvent::LAND);
+		// No additional actions can occur for this ship.
 		return;
 	}
 	

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -302,10 +302,6 @@ void Engine::Place()
 					ship->SetParent(flagship);
 				else
 					ship->SetParent(nullptr);
-				
-				// Missions may have given an NPC a destination system that is not its current system.
-				if(ship->GetDestinationSystem() || ship->GetTravelDestination())
-					ai.IssueNPCTravelOrders(*ship, ship->GetDestinationSystem(), ship->GetTravelDestination());
 			}
 		}
 	

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -248,7 +248,7 @@ void Engine::Place()
 			for(const shared_ptr<Ship> &ship : npc.Ships())
 			{
 				// Skip ships that have been destroyed.
-				if(ship->IsDestroyed() || ship->IsDisabled())
+				if(ship->IsDestroyed() || ship->IsDisabled() || ship->HasLanded())
 					continue;
 				
 				if(ship->BaysFree(false))
@@ -262,8 +262,8 @@ void Engine::Place()
 			shared_ptr<Ship> npcFlagship;
 			for(const shared_ptr<Ship> &ship : npc.Ships())
 			{
-				// Skip ships that have been destroyed.
-				if(ship->IsDestroyed())
+				// Skip ships that have been destroyed or permanently landed.
+				if(ship->IsDestroyed() || ship->HasLanded())
 					continue;
 				
 				// Avoid the exploit where the player can wear down an NPC's
@@ -503,8 +503,8 @@ void Engine::Step(bool isActive)
 		{
 			if(!it->GetGovernment() || it->GetSystem() != currentSystem || it->Cloaking() == 1.)
 				continue;
-			// Don't show status for dead ships.
-			if(it->IsDestroyed())
+			// Don't show status for dead or permanently landed ships.
+			if(it->IsDestroyed() || it->HasLanded())
 				continue;
 			
 			bool isEnemy = it->GetGovernment()->IsEnemy();
@@ -1352,7 +1352,7 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 	// Give the ship the list of visuals so that it can draw explosions,
 	// ion sparks, jump drive flashes, etc.
 	ship->Move(newVisuals, newFlotsam);
-	// Bail out if the ship just died.
+	// Ships which are dead or landed should report that event.
 	if(ship->ShouldBeRemoved())
 	{
 		// Make sure this ship's destruction was recorded, even if it died from

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -302,6 +302,10 @@ void Engine::Place()
 					ship->SetParent(flagship);
 				else
 					ship->SetParent(nullptr);
+				
+				// Missions may have given an NPC a destination system that is not its current system.
+				if(ship->GetDestinationSystem() || ship->GetTravelDestination())
+					ai.IssueNPCTravelOrders(*ship, ship->GetDestinationSystem(), ship->GetTravelDestination());
 			}
 		}
 	

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -391,9 +391,8 @@ bool MainPanel::ShowHailPanel()
 	{
 		// If the target is out of system, always report a generic response
 		// because the player has no way of telling if it's presently jumping or
-		// not. If it's in system and jumping, report that.
-		if(target->Zoom() < 1. || target->IsDestroyed() || target->GetSystem() != player.GetSystem()
-				|| target->Cloaking() == 1.)
+		// not. If it's in system and has begun jumping, report that.
+		if(!target->IsTargetable() || target->GetSystem() != player.GetSystem())
 			Messages::Add("Unable to hail target " + target->Noun() + ".");
 		else if(target->IsEnteringHyperspace())
 			Messages::Add("Unable to send hail: " + target->Noun() + " is entering hyperspace.");

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1060,7 +1060,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	
 	// Instantiate the NPCs. This also fills in the "<npc>" substitution.
 	for(const NPC &npc : npcs)
-		result.npcs.push_back(npc.Instantiate(subs, source, result.destination->GetSystem()));
+		result.npcs.push_back(npc.Instantiate(subs, source, result.destination));
 	
 	// Instantiate the actions. The "complete" action is always first so that
 	// the "<payment>" substitution can be filled in.

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -463,8 +463,8 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Plan
 		if(result.personality.IsDerelict())
 			ship->Disable();
 		
-		if(landingTarget)
-			ship->SetTravelDestination(landingTarget);
+		if(result.landingTarget)
+			ship->SetTravelDestination(result.landingTarget);
 		if(result.targetSystem)
 			ship->SetDestinationSystem(result.targetSystem);
 		

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -187,6 +187,10 @@ void NPC::Load(const DataNode &node)
 		ship->SetPersonality(personality);
 		ship->SetIsSpecial();
 		ship->FinishLoading(false);
+		if(targetSystem)
+			ship->SetDestinationSystem(targetSystem);
+		if(landingTarget)
+			ship->SetTravelDestination(landingTarget);
 	}
 }
 
@@ -410,9 +414,10 @@ bool NPC::HasFailed() const
 
 // Create a copy of this NPC but with the fleets replaced by the actual
 // ships they represent, wildcards in the conversation text replaced, etc.
-NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const System *destination) const
+NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Planet *destinationPlanet) const
 {
 	NPC result;
+	const System *destination = destinationPlanet->GetSystem();
 	result.government = government;
 	if(!result.government)
 		result.government = GameData::PlayerGovernment();
@@ -421,6 +426,8 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	result.failIf = failIf;
 	result.mustEvade = mustEvade;
 	result.mustAccompany = mustAccompany;
+	result.targetSystem = needsTravelTarget ? destination : targetSystem;
+	result.landingTarget = needsLandingTarget ? destinationPlanet : landingTarget;
 	
 	// Pick the system for this NPC to start out in.
 	result.system = system;
@@ -458,10 +465,8 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 		
 		if(landingTarget)
 			ship->SetTravelDestination(landingTarget);
-		if(targetSystem)
-			ship->SetDestinationSystem(targetSystem);
-		if(needsTravelTarget)
-			ship->SetDestinationSystem(destination);
+		if(result.targetSystem)
+			ship->SetDestinationSystem(result.targetSystem);
 		
 		if(personality.IsEntering())
 			Fleet::Enter(*result.system, *ship);

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -77,13 +77,16 @@ private:
 	const System *destination = nullptr;
 	bool isAtDestination = false;
 	
-	// NPCs may have been given a destination system or planet.
-	std::vector<const System *> targetSystems;
-	const Planet *landingTarget = nullptr;
-	std::vector<const Planet *> landingTargets;
-	bool needsTravelTarget = false;
-	bool needsLandingTarget = false;
+	// NPCs may have been given a waypoint or stopover.
+	std::vector<const System *> waypoints;
+	std::vector<const Planet *> stopovers;
+	bool needsWaypoint = false;
+	bool needsStopover = false;
+	std::list<LocationFilter> waypointFilters;
+	std::list<LocationFilter> stopoverFilters;
+	// Default behavior is to travel once through the waypoints.
 	bool doPatrol = false;
+	// Default behavior is to permanently land on the destination planet.
 	bool doVisit = false;
 	size_t destinationQueue = 0;
 	

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -62,7 +62,7 @@ public:
 	
 	// Create a copy of this NPC but with the fleets replaced by the actual
 	// ships they represent, wildcards in the conversation text replaced, etc.
-	NPC Instantiate(std::map<std::string, std::string> &subs, const System *origin, const System *destination) const;
+	NPC Instantiate(std::map<std::string, std::string> &subs, const System *origin, const Planet *destinationPlanet) const;
 	
 	
 private:

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -26,6 +26,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 class DataNode;
 class DataWriter;
 class Government;
+class Planet;
 class PlayerInfo;
 class Ship;
 class ShipEvent;
@@ -73,6 +74,12 @@ private:
 	LocationFilter location;
 	const System *system = nullptr;
 	bool isAtDestination = false;
+	
+	// NPCs may have been given a destination system or planet.
+	const System *targetSystem = nullptr;
+	const Planet *landingTarget = nullptr;
+	bool needsTravelTarget = false;
+	bool needsLandingTarget = false;
 	
 	// Dialog or conversation to show when all requirements for this NPC are met:
 	std::string dialogText;

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -18,10 +18,11 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "LocationFilter.h"
 #include "Personality.h"
 
-#include <string>
 #include <list>
 #include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 class DataNode;
 class DataWriter;
@@ -73,13 +74,16 @@ private:
 	// Start out in a location matching this filter, or in a particular system:
 	LocationFilter location;
 	const System *system = nullptr;
+	const System *destination = nullptr;
 	bool isAtDestination = false;
 	
 	// NPCs may have been given a destination system or planet.
-	const System *targetSystem = nullptr;
+	std::vector<const System *> targetSystems;
 	const Planet *landingTarget = nullptr;
 	bool needsTravelTarget = false;
 	bool needsLandingTarget = false;
+	bool doPatrol = false;
+	size_t destinationQueue = 0;
 	
 	// Dialog or conversation to show when all requirements for this NPC are met:
 	std::string dialogText;

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -80,9 +80,11 @@ private:
 	// NPCs may have been given a destination system or planet.
 	std::vector<const System *> targetSystems;
 	const Planet *landingTarget = nullptr;
+	std::vector<const Planet *> landingTargets;
 	bool needsTravelTarget = false;
 	bool needsLandingTarget = false;
 	bool doPatrol = false;
+	bool doVisit = false;
 	size_t destinationQueue = 0;
 	
 	// Dialog or conversation to show when all requirements for this NPC are met:

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2303,13 +2303,21 @@ void PlayerInfo::CreateMissions()
 // Visit, Complete, Fail), and remove now-complete or now-failed missions.
 void PlayerInfo::StepMissions(UI *ui)
 {
-	// Check for NPCs that have been destroyed without their destruction
-	// being registered, e.g. by self-destruct:
+	// Check for NPCs that have been destroyed without their destruction being
+	// registered, e.g. by self-destruct, or landed due to the player landing.
 	for(Mission &mission : missions)
 		for(const NPC &npc : mission.NPCs())
 			for(const shared_ptr<Ship> &ship : npc.Ships())
+			{
 				if(ship->IsDestroyed())
 					mission.Do(ShipEvent(nullptr, ship, ShipEvent::DESTROY), *this, ui);
+				else if(ship->GetSystem() == system && !ship->IsDisabled()
+						&& ship->GetStopovers().count(planet) && !ship->GetStopovers().at(planet))
+				{
+					ship->Land();
+					mission.Do(ShipEvent(nullptr, ship, ShipEvent::LAND), *this, ui);
+				}
+			}
 	
 	auto mit = missions.begin();
 	while(mit != missions.end())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1194,8 +1194,8 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		if(isDisabled)
 			landingPlanet = nullptr;
 		
-		// Special ships do not disappear forever when they land; they
-		// just slowly refuel.
+		// Special ships do not disappear forever when they land; they just slowly refuel.
+		// Exception: mission NPCs given the 'land' directive will delete when they land on their target.
 		if(landingPlanet && zoom)
 		{
 			// Move the ship toward the center of the planet while landing.
@@ -1216,7 +1216,8 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 					SetTargetStellar(nullptr);
 					landingPlanet = nullptr;
 				}
-				else if(!isSpecial || personality.IsFleeing())
+				else if(!isSpecial || personality.IsFleeing()
+						|| (isSpecial && !isYours && travelDestination && travelDestination == landingPlanet))
 				{
 					MarkForRemoval();
 					return;
@@ -2192,6 +2193,8 @@ void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 	targetFlotsam.reset();
 	hyperspaceSystem = nullptr;
 	landingPlanet = nullptr;
+	travelDestination = nullptr;
+	destinationSystem = nullptr;
 	
 	// This ship behaves like its new parent does.
 	isSpecial = capturer->isSpecial;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2873,6 +2873,21 @@ const System *Ship::GetTargetSystem() const
 
 
 
+// Persistent targets for mission NPCs.
+const Planet *Ship::GetTravelDestination() const
+{
+	return travelDestination;
+}
+
+
+
+const System *Ship::GetDestinationSystem() const
+{
+	return destinationSystem;
+}
+
+
+
 // Mining target.
 shared_ptr<Minable> Ship::GetTargetAsteroid() const
 {
@@ -2919,6 +2934,21 @@ void Ship::SetTargetStellar(const StellarObject *object)
 void Ship::SetTargetSystem(const System *system)
 {
 	targetSystem = system;
+}
+
+
+
+// Persistent targets for mission NPCs.
+void Ship::SetTravelDestination(const Planet *planet)
+{
+	travelDestination = planet;
+}
+
+
+
+void Ship::SetDestinationSystem(const System *system)
+{
+	destinationSystem = system;
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2894,9 +2894,9 @@ const System *Ship::GetTargetSystem() const
 
 
 // Persistent targets for mission NPCs.
-const Planet *Ship::GetTravelDestination() const
+std::map<const Planet *, bool> Ship::GetTravelDestination() const
 {
-	return travelDestination;
+	return travelDestinations;
 }
 
 
@@ -2959,9 +2959,12 @@ void Ship::SetTargetSystem(const System *system)
 
 
 // Persistent targets for mission NPCs.
-void Ship::SetTravelDestination(const Planet *planet)
+void Ship::SetTravelDestination(std::vector<const Planet *> planets, bool doVisit)
 {
-	travelDestination = planet;
+	this->doVisit = doVisit;
+	
+	for(size_t i = 0; i < planets.size(); ++i)
+		travelDestinations[planets[i]] = false;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -352,8 +352,10 @@ public:
 	const StellarObject *GetTargetStellar() const;
 	const System *GetTargetSystem() const;
 	// Targets for persistent ships (i.e. mission NPCs).
-	std::map<const Planet *, bool> GetTravelDestination() const;
+	const bool HasTravelDirective() const;
+	const std::map<const Planet *, bool> GetStopovers() const;
 	const System *GetDestinationSystem() const;
+	const bool IsSurveying() const;
 	
 	// Mining target.
 	std::shared_ptr<Minable> GetTargetAsteroid() const;
@@ -364,10 +366,15 @@ public:
 	void SetShipToAssist(const std::shared_ptr<Ship> &ship);
 	void SetTargetStellar(const StellarObject *object);
 	void SetTargetSystem(const System *system);
-	// Persistent ship targets.
-	void SetTravelDestination(std::vector<const Planet *> planets, bool doVisit);
-	void SetDestinationSystem(std::vector<const System *> systems, bool doPatrol);
-	void NextDestinationSystem();
+	// Persistent targets associated with mission NPCs.
+	void SetStopovers(const std::vector<const Planet *> planets, const bool shouldRelaunch);
+	void SetWaypoints(const std::vector<const System *> waypoints, const bool repeatTravel);
+	const System *NextWaypoint();
+	void EraseWaypoint(const System *system);
+	void PrepareSurvey(const int surveyDuration = 120);
+	void DoSurvey();
+	void AbortSurvey();
+	
 	// Mining target.
 	void SetTargetAsteroid(const std::shared_ptr<Minable> &asteroid);
 	void SetTargetFlotsam(const std::shared_ptr<Flotsam> &flotsam);
@@ -393,6 +400,7 @@ private:
 	void CreateExplosion(std::vector<Visual> &visuals, bool spread = false);
 	// Place a "spark" effect, like ionization or disruption.
 	void CreateSparks(std::vector<Visual> &visuals, const std::string &name, double amount);
+	void ResetStopovers();
 	
 	
 private:
@@ -419,7 +427,8 @@ private:
 	int forget = 0;
 	bool isInSystem = true;
 	// "Special" ships cannot be forgotten, and if they land on a planet, they
-	// continue to exist and refuel instead of being deleted.
+	// continue to exist and refuel instead of being deleted, unless explicitly
+	// designed to do so by a mission's NPC specification.
 	bool isSpecial = false;
 	bool isYours = false;
 	bool isParked = false;
@@ -521,16 +530,23 @@ private:
 	std::weak_ptr<Ship> shipToAssist;
 	const StellarObject *targetPlanet = nullptr;
 	const System *targetSystem = nullptr;
-	std::vector<const System *> targetSystems;
-	size_t destinationQueue = 0;
-	bool doPatrol = false;
-	bool doVisit = false;
-	const Planet *travelDestination = nullptr;
-	const System *destinationSystem = nullptr;
-	std::vector<const System *> destinationSystems;
-	std::map<const Planet *, bool> travelDestinations;
 	std::weak_ptr<Minable> targetAsteroid;
 	std::weak_ptr<Flotsam> targetFlotsam;
+	
+	// NPC travel directives
+	const System *destinationSystem = nullptr;
+	// The list of consecutive NPC destination systems (or a patrol sequence).
+	std::vector<const System *> waypoints;
+	size_t waypoint = 0;
+	// NPCs may patrol the set of destination systems, in order A B C A.
+	bool doPatrol = false;
+	int stayingTime = 0;
+	// The list of planets this NPC may land on, and if they have already
+	// been landed on in this sequence.
+	std::map<const Planet *, bool> travelDestinations;
+	// NPCs with a landing directive may only visit the destination
+	// planet, or they may permanently land.
+	bool doVisit = false;
 	
 	// Links between escorts and parents.
 	std::vector<std::weak_ptr<Ship>> escorts;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -230,6 +230,8 @@ public:
 	void Restore();
 	// Check if this ship has been destroyed.
 	bool IsDestroyed() const;
+	// Check if this ship has permanently landed.
+	bool HasLanded() const;
 	// Recharge and repair this ship (e.g. because it has landed).
 	void Recharge(bool atSpaceport = true);
 	// Check if this ship is able to give the given ship enough fuel to jump.
@@ -364,7 +366,8 @@ public:
 	void SetTargetSystem(const System *system);
 	// Persistent ship targets.
 	void SetTravelDestination(const Planet *planet);
-	void SetDestinationSystem(const System *system);
+	void SetDestinationSystem(std::vector<const System *> systems, bool doPatrol);
+	void NextDestinationSystem();
 	// Mining target.
 	void SetTargetAsteroid(const std::shared_ptr<Minable> &asteroid);
 	void SetTargetFlotsam(const std::shared_ptr<Flotsam> &flotsam);
@@ -428,6 +431,7 @@ private:
 	bool neverDisabled = false;
 	bool isCapturable = true;
 	bool isInvisible = false;
+	bool hasLanded = false;
 	int customSwizzle = -1;
 	double cloak = 0.;
 	double cloakDisruption = 0.;
@@ -517,8 +521,12 @@ private:
 	std::weak_ptr<Ship> shipToAssist;
 	const StellarObject *targetPlanet = nullptr;
 	const System *targetSystem = nullptr;
+	std::vector<const System *> targetSystems;
+	size_t destinationQueue = 0;
+	bool doPatrol = false;
 	const Planet *travelDestination = nullptr;
 	const System *destinationSystem = nullptr;
+	std::vector<const System *> destinationSystems;
 	std::weak_ptr<Minable> targetAsteroid;
 	std::weak_ptr<Flotsam> targetFlotsam;
 	

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -349,6 +349,10 @@ public:
 	std::shared_ptr<Ship> GetShipToAssist() const;
 	const StellarObject *GetTargetStellar() const;
 	const System *GetTargetSystem() const;
+	// Targets for persistent ships (i.e. mission NPCs).
+	const Planet *GetTravelDestination() const;
+	const System *GetDestinationSystem() const;
+	
 	// Mining target.
 	std::shared_ptr<Minable> GetTargetAsteroid() const;
 	std::shared_ptr<Flotsam> GetTargetFlotsam() const;
@@ -358,6 +362,9 @@ public:
 	void SetShipToAssist(const std::shared_ptr<Ship> &ship);
 	void SetTargetStellar(const StellarObject *object);
 	void SetTargetSystem(const System *system);
+	// Persistent ship targets.
+	void SetTravelDestination(const Planet *planet);
+	void SetDestinationSystem(const System *system);
 	// Mining target.
 	void SetTargetAsteroid(const std::shared_ptr<Minable> &asteroid);
 	void SetTargetFlotsam(const std::shared_ptr<Flotsam> &flotsam);
@@ -510,6 +517,8 @@ private:
 	std::weak_ptr<Ship> shipToAssist;
 	const StellarObject *targetPlanet = nullptr;
 	const System *targetSystem = nullptr;
+	const Planet *travelDestination = nullptr;
+	const System *destinationSystem = nullptr;
 	std::weak_ptr<Minable> targetAsteroid;
 	std::weak_ptr<Flotsam> targetFlotsam;
 	

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -230,7 +230,8 @@ public:
 	void Restore();
 	// Check if this ship has been destroyed.
 	bool IsDestroyed() const;
-	// Check if this ship has permanently landed.
+	// Land/Check if this ship has permanently landed.
+	void Land();
 	bool HasLanded() const;
 	// Recharge and repair this ship (e.g. because it has landed).
 	void Recharge(bool atSpaceport = true);

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -352,7 +352,7 @@ public:
 	const StellarObject *GetTargetStellar() const;
 	const System *GetTargetSystem() const;
 	// Targets for persistent ships (i.e. mission NPCs).
-	const Planet *GetTravelDestination() const;
+	std::map<const Planet *, bool> GetTravelDestination() const;
 	const System *GetDestinationSystem() const;
 	
 	// Mining target.
@@ -365,7 +365,7 @@ public:
 	void SetTargetStellar(const StellarObject *object);
 	void SetTargetSystem(const System *system);
 	// Persistent ship targets.
-	void SetTravelDestination(const Planet *planet);
+	void SetTravelDestination(std::vector<const Planet *> planets, bool doVisit);
 	void SetDestinationSystem(std::vector<const System *> systems, bool doPatrol);
 	void NextDestinationSystem();
 	// Mining target.
@@ -524,9 +524,11 @@ private:
 	std::vector<const System *> targetSystems;
 	size_t destinationQueue = 0;
 	bool doPatrol = false;
+	bool doVisit = false;
 	const Planet *travelDestination = nullptr;
 	const System *destinationSystem = nullptr;
 	std::vector<const System *> destinationSystems;
+	std::map<const Planet *, bool> travelDestinations;
 	std::weak_ptr<Minable> targetAsteroid;
 	std::weak_ptr<Flotsam> targetFlotsam;
 	

--- a/source/ShipEvent.h
+++ b/source/ShipEvent.h
@@ -62,7 +62,9 @@ public:
 		// you had with the given government, first.
 		ATROCITY = (1 << 8),
 		// This ship just jumped into a different system.
-		JUMP = (1 << 9)
+		JUMP = (1 << 9),
+		// This ship has permanently landed on a planet.
+		LAND = (1 << 10)
 	};
 	
 	


### PR DESCRIPTION
Kudos to @Elyssaen for the inspiration and collaborative work on this feature.

This PR introduces 4 keywords for the NPC node and 1 new NPC success criteria:
Keywords:
 - `waypoint`
 - `patrol`
 - `land`
 - `visit`

Succeed criteria:
 - `land`
______________

The `waypoint` and `patrol` keywords assign a system or set of systems to the ships in the NPC block. These systems will be traveled to, if they are accessible, in the order they are specified (though LocationFilter systems are created after all non-LocationFilter waypoints). If a system is inaccessible, it is removed in-flight. If no value is specified, the mission destination system is used. If `patrol` is used, passing no value creates a patrol between the mission's `origin` and `destination` systems. Both keywords can utilize LocationFilters to randomly select the waypoints. If the `distance` argument for LocationFilters is used, it is sequential, e.g. the distance is measured relative to the previous waypoint. All methods can be used together to specify the NPC's waypoints. 
Upon reaching the final system in the list, the NPCs will either behave as normal escorts would, or if `patrol` was used, begin traveling again with the first specified waypoint. The `staying` personality takes effect when the NPC no longer has waypoints to visit.
<details><summary>Usage:</summary>


```
waypoint/patrol (no value given)

waypoint/patrol <system 1> ... <system N>

waypoint <system 1> <system 2>
waypoint ...
waypoint <system N>

waypoint/patrol
    LocationFilter 1, line 1
    ...
    LocationFilter 1, line N
waypoint/patrol
    LocationFilter 2, line 1
    ...
    LocationFilter 2, line N
...
```
</details>
______________

The `land` and `visit` keywords assign a planet or a set of planets to the ships in the NPC block. These planets will be landed on, if they are accessible, if the NPC enters the system that contains the planet. If the keyword was `land`, the ship will not take off again from the planet - it has landed permanently. If the keyword was `visit`, the ship will not force itself to land on that planet again unless it also has `patrol`, and has finished its current loop.
As with the waypoint/patrol keywords, passing no value results in the mission's destination being used as the target. LocationFilters can similarly be used to randomly select the landing targets.
<details><summary>Usage:</summary>


```
land/visit (no value given)

land/visit <planet 1> ... <planet N>

land/visit <planet 1> <planet 2>
land/visit ...
land/visit <planet N>

land/visit
    LocationFilter 1, line 1
    ...
    LocationFilter 1, line N
land/visit
    LocationFilter 2, line 1
    ...
    LocationFilter 2, line N
...
```
</details>
______________

The `land` success criteria puts the NPC in a success state when it has landed on a planet in its stopover list, either temporarily (via `visit`) or permanently (via `land`). This can be paired with other npc success criteria.
<details><summary>Usage:</summary>


```
npc land
    (npc specification)
    land/visit (as above)
```
</details>
______________

Example missions: 
[npc_travel_to.txt](https://github.com/endless-sky/endless-sky/files/1271292/npc_travel_to.txt)

These parameters should allow content creators significant flexibility, especially with defining adversarial targets or targets that should not originate or appear to coordinate with the player.

Some uses:
 - Escort mission updates with patrolling pirate fleets, and escorts that will attempt to land when you bring them into their destination system.
 - Escort missions where the npc is supposed to avoid a certain system, and if the player leaves the escort behind (rather than leading the ship around that system), normal route-to-parent behavior will send it into that system where it will land and fail the mission.
 - Interception missions (destroy these ships before they can reach \<destination\>)
 - Guided tours (bring the NPC to system A, B, C, let it land on the planets, then return to origin, without the player needing to land as well)
 - Finally fix Corporate Espionage so that it isn't nigh impossible to complete.
______________

<details><summary>Quirks</summary>


 - If `staying` is combined with `visit` or `land`, the NPC will briefly land on an accessible planet in the system it is staying in, if that planet's StellarObject is selected for a flyby.
 - If a hostile NPC is supposed to flee from the player when attacked, it should be given `pacifist` or `fleeing` so that it does not actively target the player's ship (its turrets will still happily aim and autofire at the player if it is just `fleeing`).
 - If `fleeing` NPCs are also given a travel directive, they will not land permanently until having completed all travel specified for it (this enables them to refuel).
 - As with current missions involving landing escorts on the mission destination, the player can simply wait for the ship to enter the system and then land their flagship, rather than be forced to wait for the NPC to land itself. This is a conscious choice, and was done to mirror the existing behavior.
Ideally, the player should have to wait for the NPC to land its own ship (presumably defending the NPC while it does so), but due to the current limitations on non-player-system combat, the player could simply wait in a neighboring system to let the NPC land itself in peace. If combat is ever extended to systems containing player escorts/personality.IsEscort, the first code snippet [here](https://github.com/tehhowch/endless-sky/pull/3#issuecomment-326076935) should be used and then this possible "exploit" is removed.
</details>

The original development branch (no squashes) is located here: https://github.com/tehhowch/endless-sky/tree/NPC_TravelTo