### PR TITLE
Enhancement: Show depreciated stock of items that can be bought.

### DIFF
--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -169,10 +169,10 @@ void Depreciation::Buy(const Ship &ship, int day, Depreciation *source)
 
 
 // Add a single outfit to the depreciation record.
-void Depreciation::Buy(const Outfit *outfit, int day, Depreciation *source)
+bool Depreciation::Buy(const Outfit *outfit, int day, Depreciation *source, int unlimitedStockDay)
 {
 	if(outfit->Get("installable") < 0.)
-		return;
+		return false;
 	
 	if(source)
 	{
@@ -192,8 +192,13 @@ void Depreciation::Buy(const Outfit *outfit, int day, Depreciation *source)
 		}
 	}
 	
+	// Put new outfits in the infinite stock
+	if(day == unlimitedStockDay)
+		return false;
+	
 	// Increment our count for this outfit on this day.
 	++outfits[outfit][day];
+	return true;
 }
 
 

--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -172,7 +172,7 @@ void Depreciation::Buy(const Ship &ship, int day, Depreciation *source)
 bool Depreciation::Buy(const Outfit *outfit, int day, Depreciation *source, int unlimitedStockDay)
 {
 	if(outfit->Get("installable") < 0.)
-		return false;
+		return true;
 	
 	if(source)
 	{

--- a/source/Depreciation.h
+++ b/source/Depreciation.h
@@ -48,7 +48,7 @@ public:
 	// Add a ship, and all its outfits, to the depreciation record.
 	void Buy(const Ship &ship, int day, Depreciation *source = nullptr);
 	// Add a single outfit to the depreciation record.
-	void Buy(const Outfit *outfit, int day, Depreciation *source = nullptr);
+	bool Buy(const Outfit *outfit, int day, Depreciation *source = nullptr, int unlimitedStockDay = -1);
 	
 	// Get the value of an entire fleet.
 	int64_t Value(const std::vector<std::shared_ptr<Ship>> &fleet, int day) const;

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -150,10 +150,9 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point, int scroll
 			font.Draw(label, labelPos, bright);
 		}
 	}
-	// Don't show the "in stock" amount if the outfit has an unlimited stock or
-	// if it is not something that you can buy.
+	// Don't show the "in stock" amount if it is not something that you can buy.
 	int stock = 0;
-	if(!outfitter.Has(outfit) && outfit->Get("installable") >= 0.)
+	if(outfit->Get("installable") >= 0.)
 		stock = max(0, player.Stock(outfit));
 	int cargo = player.Cargo().Get(outfit);
 	
@@ -490,7 +489,7 @@ void OutfitterPanel::Sell(bool toCargo)
 		player.Cargo().Remove(selectedOutfit);
 		int64_t price = player.FleetDepreciation().Value(selectedOutfit, day);
 		player.Accounts().AddCredits(price);
-		player.AddStock(selectedOutfit, 1);
+		player.AddStock(selectedOutfit, 1, outfitter.Has(selectedOutfit));
 	}
 	else
 	{
@@ -511,7 +510,7 @@ void OutfitterPanel::Sell(bool toCargo)
 			{
 				int64_t price = player.FleetDepreciation().Value(selectedOutfit, day);
 				player.Accounts().AddCredits(price);
-				player.AddStock(selectedOutfit, 1);
+				player.AddStock(selectedOutfit, 1, outfitter.Has(selectedOutfit));
 			}
 			
 			const Outfit *ammo = selectedOutfit->Ammo();
@@ -532,7 +531,7 @@ void OutfitterPanel::Sell(bool toCargo)
 					{
 						int64_t price = player.FleetDepreciation().Value(ammo, day, mustSell);
 						player.Accounts().AddCredits(price);
-						player.AddStock(ammo, mustSell);
+						player.AddStock(ammo, mustSell, outfitter.Has(selectedOutfit));
 					}
 				}
 			}

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -150,10 +150,7 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point, int scroll
 			font.Draw(label, labelPos, bright);
 		}
 	}
-	// Don't show the "in stock" amount if it is not something that you can buy.
-	int stock = 0;
-	if(outfit->Get("installable") >= 0.)
-		stock = max(0, player.Stock(outfit));
+	int stock = max(0, player.Stock(outfit));
 	int cargo = player.Cargo().Get(outfit);
 	
 	string message;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2043,30 +2043,33 @@ int PlayerInfo::Stock(const Outfit *outfit) const
 
 
 // Transfer outfits from the player to the planet or vice versa.
-void PlayerInfo::AddStock(const Outfit *outfit, int count)
+void PlayerInfo::AddStock(const Outfit *outfit, int count, bool unlimitedStock)
 {
-	// If you sell an individual outfit that is not sold here and that you
-	// acquired by buying a ship here, have it appear as "in stock" in case you
-	// change your mind about selling it. (On the other hand, if you sell an
-	// entire ship right after buying it, its outfits will not be "in stock.")
-	if(count > 0 && stock[outfit] < 0)
-		stock[outfit] = 0;
-	stock[outfit] += count;
-	
+	int stocked = 0;
 	int day = date.DaysSinceEpoch();
 	if(count > 0)
 	{
+		// If you sell an individual outfit that is not sold here and that you
+		// acquired by buying a ship here, have it appear as "in stock" in case you
+		// change your mind about selling it. (On the other hand, if you sell an
+		// entire ship right after buying it, its outfits will not be "in stock.")
+		if(stock[outfit] < 0)
+			stock[outfit] = 0;
+		
 		// Remember how depreciated these items are.
 		for(int i = 0; i < count; ++i)
-			stockDepreciation.Buy(outfit, day, &depreciation);
+			if(stockDepreciation.Buy(outfit, day, &depreciation, unlimitedStock ? day : -1))
+				++stocked;
 	}
 	else
 	{
 		// If the count is negative, outfits are being transferred from stock
 		// into the player's possession.
 		for(int i = 0; i < -count; ++i)
-			depreciation.Buy(outfit, day, &stockDepreciation);
+			if(depreciation.Buy(outfit, day, &stockDepreciation))
+				--stocked;
 	}
+	stock[outfit] += stocked;
 }
 
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -219,7 +219,7 @@ public:
 	// Keep track of any outfits that you have sold since landing. These will be
 	// available to buy back until you take off.
 	int Stock(const Outfit *outfit) const;
-	void AddStock(const Outfit *outfit, int count);
+	void AddStock(const Outfit *outfit, int count, bool unlimitedStock = false);
 	// Get depreciation information.
 	const Depreciation &FleetDepreciation() const;
 	const Depreciation &StockDepreciation() const;


### PR DESCRIPTION
An outfitter has a unlimited stock of outfits that can be bought. When you bought and sold back an outfit it would be placed with the depreciated stock which would give incorrect stock numbers (if displayed).

Now new outfits are sent back to the infinite stock and the depreciated stock is shown.
