### PR TITLE
Enhancement: Consider next refuel stop when traveling to parent ship's system

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1246,7 +1246,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 						break;
 					}
 				}
-				// Is next refuel system?
+				// Stop tallying fuel use once the next system with fuel is located.
 				if(to->HasFuelFor(ship))
 					break;
 				// Try with the next system in the route.

--- a/source/DistanceMap.cpp
+++ b/source/DistanceMap.cpp
@@ -107,6 +107,17 @@ set<const System *> DistanceMap::Systems() const
 
 
 
+int DistanceMap::RequiredFuel(const System *system1, const System *system2) const
+{
+	auto it1 = route.find(system1);
+	auto it2 = route.find(system2);
+	if(it1 == route.end() || it2 == route.end())
+		return -1;
+	return abs(it1->second.fuel - it2->second.fuel);
+}
+
+
+
 DistanceMap::Edge::Edge(const System *system)
 	: next(system)
 {

--- a/source/DistanceMap.h
+++ b/source/DistanceMap.h
@@ -53,6 +53,9 @@ public:
 	// Get a set containing all the systems.
 	std::set<const System *> Systems() const;
 	
+	// How much fuel is needed to travel between two systems.
+	int RequiredFuel(const System *system1, const System *system2) const;
+	
 	
 private:
 	// For each system, track how much fuel it will take to get there, how many

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -441,6 +441,13 @@ bool Planet::IsAccessible(const Ship *ship) const
 
 // Below are convenience functions which access the game state in Politics,
 // but do so with a less convoluted syntax:
+bool Planet::HasFuelFor(const Ship &ship) const
+{
+	return !IsWormhole() && HasSpaceport() && CanLand(ship);
+}
+
+
+
 bool Planet::CanLand(const Ship &ship) const
 {
 	return IsAccessible(&ship) && GameData::GetPolitics().CanLand(ship, this);

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -109,6 +109,7 @@ public:
 	bool IsAccessible(const Ship *ship) const;
 	// Below are convenience functions which access the game state in Politics,
 	// but do so with a less convoluted syntax:
+	bool HasFuelFor(const Ship &ship) const;
 	bool CanLand(const Ship &ship) const;
 	bool CanLand() const;
 	bool CanUseServices() const;

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -501,12 +501,8 @@ bool System::IsInhabited(const Ship *ship) const
 bool System::HasFuelFor(const Ship &ship) const
 {
 	for(const StellarObject &object : objects)
-		if(object.GetPlanet())
-		{
-			const Planet &planet = *object.GetPlanet();
-			if(!planet.IsWormhole() && planet.HasSpaceport() && planet.CanLand(ship))
-				return true;
-		}
+		if(object.GetPlanet() && object.GetPlanet()->HasFuelFor(ship))
+			return true;
 	
 	return false;
 }


### PR DESCRIPTION
An escort traveling to the parent ship's system could get stuck when it encountered two consecutive system where it could not refuel because it only checked if it had enough fuel for the next system.

Now it checks how much fuel is required to reach the next refuel stop and uses that to decide if it should refuel in the current system.