### PR TITLE
Out-of-system escort tweaks

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1145,7 +1145,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 	for(auto it = ships.begin(); it != ships.end(); )
 	{
 		shared_ptr<Ship> &ship = *it;
-		if(ship->IsParked() || ship->IsDisabled() || ship->GetSystem() != system)
+		if(ship->IsParked() || ship->IsDisabled())
 		{
 			++it;
 			continue;
@@ -1165,7 +1165,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 					break;
 				}
 		}
-		if(!fit)
+		if(!fit && ship->GetSystem() == system)
 		{
 			++shipsSold[isFighter];
 			int64_t cost = depreciation.Value(*ship, day);


### PR DESCRIPTION
 - Carried ships that are in remote systems when the player takes off will start out loaded into their carrier ship, just as they would in the player's system, rather than needing to board.
    - This prevents any possible "dropped fighters" in case 1) the carrier is Stepped before the fighter is able to ask it to become its parent, and 2) the carrier is Placed in such a manner that it can jump immediately
 - Ships in remote systems will recharge their shields, hull, and energy, if they have the equipment to do so, rather than starting out with whatever shields/hull they had a day ago, and 0 energy (if loading save) or their previous energy.