### PR TITLE
Improve support for missions offered and actions performed while assisting/boarding

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -28,6 +28,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Mask.h"
 #include "Messages.h"
 #include "Minable.h"
+#include "Mission.h"
 #include "NPC.h"
 #include "OutlineShader.h"
 #include "Person.h"
@@ -241,69 +242,7 @@ void Engine::Place()
 	// and all but "uninterested" ships should follow the player.
 	shared_ptr<Ship> flagship = player.FlagshipPtr();
 	for(const Mission &mission : player.Missions())
-		for(const NPC &npc : mission.NPCs())
-		{
-			map<Ship *, int> droneCarriers;
-			map<Ship *, int> fighterCarriers;
-			for(const shared_ptr<Ship> &ship : npc.Ships())
-			{
-				// Skip ships that have been destroyed.
-				if(ship->IsDestroyed() || ship->IsDisabled())
-					continue;
-				
-				if(ship->BaysFree(false))
-					droneCarriers[&*ship] = ship->BaysFree(false);
-				if(ship->BaysFree(true))
-					fighterCarriers[&*ship] = ship->BaysFree(true);
-				// Redo the loading up of fighters.
-				ship->UnloadBays();
-			}
-			
-			shared_ptr<Ship> npcFlagship;
-			for(const shared_ptr<Ship> &ship : npc.Ships())
-			{
-				// Skip ships that have been destroyed.
-				if(ship->IsDestroyed())
-					continue;
-				
-				// Avoid the exploit where the player can wear down an NPC's
-				// crew by attrition over the course of many days.
-				ship->AddCrew(max(0, ship->RequiredCrew() - ship->Crew()));
-				if(!ship->IsDisabled())
-					ship->Recharge();
-				
-				if(ship->CanBeCarried())
-				{
-					bool docked = false;
-					map<Ship *, int> &carriers = (ship->Attributes().Category() == "Drone") ?
-						droneCarriers : fighterCarriers;
-					for(auto &it : carriers)
-						if(it.second && it.first->Carry(ship))
-						{
-							--it.second;
-							docked = true;
-							break;
-						}
-					if(docked)
-						continue;
-				}
-				
-				ships.push_back(ship);
-				// The first (alive) ship in an NPC block
-				// serves as the flagship of the group.
-				if(!npcFlagship)
-					npcFlagship = ship;
-				
-				// Only the flagship of an NPC considers the
-				// player: the rest of the NPC track it.
-				if(npcFlagship && ship != npcFlagship)
-					ship->SetParent(npcFlagship);
-				else if(!ship->GetPersonality().IsUninterested())
-					ship->SetParent(flagship);
-				else
-					ship->SetParent(nullptr);
-			}
-		}
+		Place(mission.NPCs(), flagship);
 	
 	// Get the coordinates of the planet the player is leaving.
 	Point planetPos;
@@ -350,6 +289,78 @@ void Engine::Place()
 	ships.splice(ships.end(), newShips);
 	
 	player.SetPlanet(nullptr);
+}
+
+
+
+// Add NPC ships to the known ships. These may have been freshly instantiated
+// from an accepted assisting/boarding mission, or from existing missions when
+// the player departs a planet.
+void Engine::Place(const list<NPC> &npcs, shared_ptr<Ship> flagship)
+{
+	for(const NPC &npc : npcs)
+	{
+		map<Ship *, int> droneCarriers;
+		map<Ship *, int> fighterCarriers;
+		for(const shared_ptr<Ship> &ship : npc.Ships())
+		{
+			// Skip ships that have been destroyed.
+			if(ship->IsDestroyed() || ship->IsDisabled())
+				continue;
+			
+			if(ship->BaysFree(false))
+				droneCarriers[&*ship] = ship->BaysFree(false);
+			if(ship->BaysFree(true))
+				fighterCarriers[&*ship] = ship->BaysFree(true);
+			// Redo the loading up of fighters.
+			ship->UnloadBays();
+		}
+		
+		shared_ptr<Ship> npcFlagship;
+		for(const shared_ptr<Ship> &ship : npc.Ships())
+		{
+			// Skip ships that have been destroyed.
+			if(ship->IsDestroyed())
+				continue;
+			
+			// Avoid the exploit where the player can wear down an NPC's
+			// crew by attrition over the course of many days.
+			ship->AddCrew(max(0, ship->RequiredCrew() - ship->Crew()));
+			if(!ship->IsDisabled())
+				ship->Recharge();
+			
+			if(ship->CanBeCarried())
+			{
+				bool docked = false;
+				map<Ship *, int> &carriers = (ship->Attributes().Category() == "Drone") ?
+					droneCarriers : fighterCarriers;
+				for(auto &it : carriers)
+					if(it.second && it.first->Carry(ship))
+					{
+						--it.second;
+						docked = true;
+						break;
+					}
+				if(docked)
+					continue;
+			}
+			
+			ships.push_back(ship);
+			// The first (alive) ship in an NPC block
+			// serves as the flagship of the group.
+			if(!npcFlagship)
+				npcFlagship = ship;
+			
+			// Only the flagship of an NPC considers the
+			// player: the rest of the NPC track it.
+			if(npcFlagship && ship != npcFlagship)
+				ship->SetParent(npcFlagship);
+			else if(!ship->GetPersonality().IsUninterested())
+				ship->SetParent(flagship);
+			else
+				ship->SetParent(nullptr);
+		}
+	}
 }
 
 
@@ -1422,10 +1433,19 @@ void Engine::FillCollisionSets()
 
 
 
-// At random intervals, crete new fleets in neighboring systems or coming from
-// planets in the current one.
+// Spawn NPC (both mission and "regular") ships into the player's universe. Non-
+// mission NPCs are only spawned in or adjacent to the player's system.
 void Engine::SpawnFleets()
 {
+	// If the player has a pending boarding mission, spawn its NPCs.
+	if(player.ActiveBoardingMission())
+	{
+		Place(player.ActiveBoardingMission()->NPCs(), player.FlagshipPtr());
+		player.ClearActiveBoardingMission();
+	}
+	
+	// Non-mission NPCs spawn at random intervals in neighboring systems,
+	// or coming from planets in the current one.
 	for(const System::FleetProbability &fleet : player.GetSystem()->Fleets())
 		if(!Random::Int(fleet.Period()))
 		{

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -35,6 +35,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 class Flotsam;
 class Government;
+class NPC;
 class Outfit;
 class PlanetLabel;
 class PlayerInfo;
@@ -60,6 +61,8 @@ public:
 	
 	// Place all the player's ships, and "enter" the system the player is in.
 	void Place();
+	// Place NPCs spawned by a mission that offers when the player is not landed.
+	void Place(const std::list<NPC> &npcs, std::shared_ptr<Ship> flagship = nullptr);
 	
 	// Wait for the previous calculations (if any) to be done.
 	void Wait();

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -24,6 +24,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "LineShader.h"
 #include "MapDetailPanel.h"
 #include "Messages.h"
+#include "Mission.h"
 #include "Phrase.h"
 #include "Planet.h"
 #include "PlanetPanel.h"
@@ -469,8 +470,7 @@ void MainPanel::StepEvents(bool &isActive)
 				&& !event.Target()->IsDestroyed() && flagship && event.Actor().get() == flagship)
 		{
 			Mission *mission = player.BoardingMission(event.Target());
-			const CargoHold &cargo = flagship->Cargo();
-			if(mission && mission->CargoSize() <= cargo.Free() && mission->Passengers() <= cargo.BunksFree())
+			if(mission && mission->HasSpace(*flagship))
 				mission->Do(Mission::OFFER, player, GetUI());
 			else if(mission)
 				player.HandleBlockedMissions((event.Type() & ShipEvent::BOARD)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -565,15 +565,15 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 	}
 	
 	auto it = actions.find(OFFER);
-	if(it != actions.end() && !it->second.CanBeDone(player))
+	if(it != actions.end() && !it->second.CanBeDone(player, boardingShip))
 		return false;
 	
 	it = actions.find(ACCEPT);
-	if(it != actions.end() && !it->second.CanBeDone(player))
+	if(it != actions.end() && !it->second.CanBeDone(player, boardingShip))
 		return false;
 	
 	it = actions.find(DECLINE);
-	if(it != actions.end() && !it->second.CanBeDone(player))
+	if(it != actions.end() && !it->second.CanBeDone(player, boardingShip))
 		return false;
 	
 	return true;
@@ -763,7 +763,7 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	}
 	// Don't update any conditions if this action exists and can't be completed.
 	auto it = actions.find(trigger);
-	if(it != actions.end() && !it->second.CanBeDone(player))
+	if(it != actions.end() && !it->second.CanBeDone(player, boardingShip))
 		return false;
 	
 	if(trigger == ACCEPT)

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -29,6 +29,7 @@ class DataNode;
 class DataWriter;
 class Planet;
 class PlayerInfo;
+class Ship;
 class ShipEvent;
 class System;
 class UI;
@@ -102,6 +103,7 @@ public:
 	// if the player has enough space.
 	bool CanOffer(const PlayerInfo &player, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
 	bool HasSpace(const PlayerInfo &player) const;
+	bool HasSpace(const Ship &ship) const;
 	bool CanComplete(const PlayerInfo &player) const;
 	bool IsSatisfied(const PlayerInfo &player) const;
 	bool HasFailed(const PlayerInfo &player) const;

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -54,7 +54,7 @@ public:
 	// Check if this action can be completed right now. It cannot be completed
 	// if it takes away money or outfits that the player does not have, or should
 	// take place in a system that does not match the specified LocationFilter.
-	bool CanBeDone(const PlayerInfo &player) const;
+	bool CanBeDone(const PlayerInfo &player, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
 	// Perform this action. If a conversation is shown, the given destination
 	// will be highlighted in the map if you bring it up.
 	void Do(PlayerInfo &player, UI *ui = nullptr, const System *destination = nullptr, const std::shared_ptr<Ship> &ship = nullptr) const;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1429,6 +1429,7 @@ Mission *PlayerInfo::BoardingMission(const shared_ptr<Ship> &ship)
 	// Ensure that boarding this NPC again does not create a mission.
 	ship->SetIsSpecial();
 	
+	// Update auto conditions to reflect the player's flagship's free capacity.
 	UpdateAutoConditions(true);
 	boardingMissions.clear();
 	
@@ -1458,10 +1459,13 @@ void PlayerInfo::HandleBlockedMissions(Mission::Location location, UI *ui)
 {
 	if(ships.empty())
 		return;
+	list<Mission> &missionList = availableMissions.empty() ? boardingMissions : availableMissions;
+	if(missionList.empty())
+		return;
 	
 	// If a mission can be offered right now, move it to the start of the list
 	// so we know what mission the callback is referring to, and return it.
-	for(auto it = availableMissions.begin(); it != availableMissions.end(); ++it)
+	for(auto it = missionList.begin(); it != missionList.end(); ++it)
 		if(it->IsAtLocation(location) && it->CanOffer(*this) && !it->HasSpace(*this))
 		{
 			string message = it->BlockedMessage(*this);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1383,6 +1383,14 @@ const list<Mission> &PlayerInfo::AvailableJobs() const
 
 
 
+// Return a pointer to the mission that was most recently accepted while in-flight.
+const Mission *PlayerInfo::ActiveBoardingMission() const
+{
+	return activeBoardingMission;
+}
+
+
+
 // Accept the given job.
 void PlayerInfo::AcceptJob(const Mission &mission, UI *ui)
 {
@@ -1421,6 +1429,8 @@ Mission *PlayerInfo::MissionToOffer(Mission::Location location)
 
 
 
+// Check if any of the game's missions can be offered from this ship, given its
+// relationship with the player. If none offer, return nullptr.
 Mission *PlayerInfo::BoardingMission(const shared_ptr<Ship> &ship)
 {
 	// Do not create missions from existing mission NPC's, or the player's ships.
@@ -1431,10 +1441,11 @@ Mission *PlayerInfo::BoardingMission(const shared_ptr<Ship> &ship)
 	
 	// Update auto conditions to reflect the player's flagship's free capacity.
 	UpdateAutoConditions(true);
+	// "boardingMissions" is emptied by MissionCallback, but to be sure:
 	boardingMissions.clear();
 	
-	bool isEnemy = ship->GetGovernment()->IsEnemy();
-	Mission::Location location = (isEnemy ? Mission::BOARDING : Mission::ASSISTING);
+	Mission::Location location = (ship->GetGovernment()->IsEnemy()
+			? Mission::BOARDING : Mission::ASSISTING);
 	
 	// Check for available boarding or assisting missions.
 	for(const pair<const string, const Mission> &it : GameData::Missions())
@@ -1452,19 +1463,23 @@ Mission *PlayerInfo::BoardingMission(const shared_ptr<Ship> &ship)
 
 
 
+// Engine calls this after placing the boarding mission's NPCs.
+void PlayerInfo::ClearActiveBoardingMission()
+{
+	activeBoardingMission = nullptr;
+}
+
+
+
 // If one of your missions cannot be offered because you do not have enough
 // space for it, and it specifies a message to be shown in that situation,
 // show that message.
 void PlayerInfo::HandleBlockedMissions(Mission::Location location, UI *ui)
 {
-	if(ships.empty())
-		return;
 	list<Mission> &missionList = availableMissions.empty() ? boardingMissions : availableMissions;
-	if(missionList.empty())
+	if(ships.empty() || missionList.empty())
 		return;
 	
-	// If a mission can be offered right now, move it to the start of the list
-	// so we know what mission the callback is referring to, and return it.
 	for(auto it = missionList.begin(); it != missionList.end(); ++it)
 		if(it->IsAtLocation(location) && it->CanOffer(*this) && !it->HasSpace(*this))
 		{
@@ -1505,11 +1520,19 @@ void PlayerInfo::MissionCallback(int response)
 		else
 			return;
 		
+		// Move this mission from the offering list into the "accepted"
+		// list, viewable on the MissionPanel. Unique missions are moved
+		// to the front, so they appear at the top of the list if viewed.
 		auto spliceIt = mission.IsUnique() ? missions.begin() : missions.end();
 		missions.splice(spliceIt, missionList, missionList.begin());
 		mission.Do(Mission::ACCEPT, *this);
 		if(shouldAutosave)
 			Autosave();
+		// If this is a mission offered in-flight, expose a pointer to it
+		// so Engine::SpawnFleets can add its ships without requiring the
+		// player to land.
+		if(mission.IsAtLocation(Mission::BOARDING) || mission.IsAtLocation(Mission::ASSISTING))
+			activeBoardingMission = &*--spliceIt;
 	}
 	else if(response == Conversation::DECLINE || response == Conversation::FLEE)
 	{

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -151,10 +151,12 @@ public:
 	// Get mission information.
 	const std::list<Mission> &Missions() const;
 	const std::list<Mission> &AvailableJobs() const;
+	const Mission *ActiveBoardingMission() const;
 	void AcceptJob(const Mission &mission, UI *ui);
-	// Check to see if there is any mission to offer in the spaceport right now.
+	// Check to see if there is any mission to offer right now.
 	Mission *MissionToOffer(Mission::Location location);
 	Mission *BoardingMission(const std::shared_ptr<Ship> &ship);
+	void ClearActiveBoardingMission();
 	// If one of your missions cannot be offered because you do not have enough
 	// space for it, and it specifies a message to be shown in that situation,
 	// show that message.
@@ -288,13 +290,19 @@ private:
 	std::multimap<Date, std::string> logbook;
 	std::map<std::string, std::map<std::string, std::string>> specialLogs;
 	
+	// A list of the player's active, accepted missions.
 	std::list<Mission> missions;
 	// These lists are populated when you land on a planet, and saved so that
 	// they will not change if you reload the game.
 	std::list<Mission> availableJobs;
 	std::list<Mission> availableMissions;
-	std::list<Mission> boardingMissions;
+	// Missions that are failed or aborted, but not yet deleted, and any
+	// missions offered while in-flight are not saved.
 	std::list<Mission> doneMissions;
+	std::list<Mission> boardingMissions;
+	// This pointer to the most recently accepted boarding mission enables
+	// its NPCs to be placed before the player lands, and is then cleared.
+	Mission *activeBoardingMission = nullptr;
 	
 	std::map<std::string, int> conditions;
 	


### PR DESCRIPTION
@Kryes-Omega mentioned that there were some issues with missions that offered on boarding, and I took a look into it.

This PR fixes a host of issues with missions that offer from ships, primarily
 - ~~Offering when the player has insufficient cargo space / bunks~~ (ref https://github.com/endless-sky/endless-sky/commit/1d780317b9cfb4e1afb42bcd288dde344667a480)
 - ~~Shifted / missing displayed cargo~~
 - No "blocked" messages would be displayed
 - Mission NPCs would not spawn until after the player next took off from a planet
 - Gifting of outfits assumes the player is landed

With this PR
 - Missions chosen to be offered, but unable to be offered due to insufficient space, will show a blocked message if one was specified.
 - ~~If having accepted a mission from boarding/assisting a ship requires the player to jettison some cargo, the ShipInfoPanel is displayed and cannot be closed until the player has non-negative free space remaining.~~
 - ~~When jettisoning excess cargo, the minimum amount to jettison is pre-filled, instead of however much of the selected item was present (e.g. if only 1 ton of space is needed, don't jettison 30 Jump Drives).~~
 - Any NPCs spawned by accepting the mission will appear immediately, without requiring the player to land and depart again.
Diligent and mindful mission writers will avoid in-flight spawning of ships in the player's current system, preferring instead `system + distance 1 N` or `personality entering`, or other methods of locating the NPCs in a non-origin system.
 - Gifting (outfit transfer in Mission Actions) will use the proper `CargoHold` based on if the flagship is boarding or landed.
 - `require 0` means actually 0 - you can't have the outfit on a ship that is parked, disabled, or out-of-system either.

Notes:
 - ~~If making missions which offer from hostile targets, use `on offer` conversations ending with `launch` or `flee` unless the missions are sufficiently low probability (or not `repeat`), lest the player receive the mission again upon re-boarding the same target.~~ (once boarded, a ship becomes incapable of offering a mission upon reboarding).
   - ~~If making a "silent" mission (no `on offer` conversation or dialog) that offers for hostile targets, the player will have to issue the `board` command a second time, as the first command is consumed by spawning the mission. This means the player can always notice if a call for reinforcements is made, as the first boarding attempt appears to fail. If the mission always offers & accepts, then the ship cannot be boarded.~~
 