### PR TITLE
Update Pirate, Hai relationships

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -78,6 +78,7 @@ government "Hai"
 	"player reputation" 0
 	"attitude toward"
 		"Hai (Unfettered)" -.5
+		"Merchant" .01
 	"bribe" .02
 	"fine" 0
 	"friendly hail" "friendly hai"
@@ -251,10 +252,11 @@ government "Pirate"
 	
 	"player reputation" -10
 	"attitude toward"
+		"Author" -.01
+		"Hai" -.01
+		"Korath" -.01
 		"Merchant" -.1
 		"Syndicate" -.01
-		"Korath" -.01
-		"Author" -.01
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly pirate"


### PR DESCRIPTION
Refs #2931 

If the player attacks Merchants in Hai space, they will have to fight against the local Hai as well.
The Hai will also defend any Merchant fleets against Pirate ships that may have been led into Hai space somehow.
Ideally the Pirate would not need an attitude towards the Hai (e.g. the attack on Merchants would be enough to make the Hai intervene, but pirates simply being present would not), but that level of provoke escalation behavior currently only exists for the player, and introducing such a mechanic would require considerable review of the existing attitude relationships, along with every mission, to ensure no unintended side effects.