### PR TITLE
Fix near death escorts doing nothing.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -932,7 +932,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	}
 	
 	// Run away if your target is not disabled and you are badly damaged.
-	if(!isDisabled && target && (person.IsFleeing() || 
+	if(!isDisabled && target && !ship.IsYours() && (person.IsFleeing() || 
 			(.5 * ship.Shields() + ship.Hull() < 1.
 				&& !person.IsHeroic() && !person.IsStaying() && !parentIsEnemy)))
 	{


### PR DESCRIPTION
With no enemies around the escort behavior defaults to KeepStation. If they were near death mid-battle they would lose their target, defaulting to KeepStation and resulting in them just sitting there taking damage. Since they are prime targets, that behavior is suicide.

Now escorts no longer lose their target when near death.

Reference: #3004