### PR TITLE
fix loading a non-existent save from recent.txt

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -310,7 +310,7 @@ void PlayerInfo::LoadRecent()
 	while(!recentPath.empty() && recentPath.back() <= ' ')
 		recentPath.pop_back();
 	
-	if(recentPath.empty())
+	if(recentPath.empty() || !Files::Exists(recentPath))
 		Clear();
 	else
 		Load(recentPath);


### PR DESCRIPTION
If you ended up with a path in recent.txt that pointed to a non-existent file (via deleting it outside the game and not clearing recent.txt) the game would create a harmless but useless save instead of ignoring it.

ex. [df df.txt](https://github.com/endless-sky/endless-sky/files/1288686/df.df.txt)


This PR adds a Files::Exists() check to PlayerInfo::LoadRecent().