### PR TITLE
Request help when all enemies remaining are disabled

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -695,7 +695,7 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 			const Government *otherGov = helper->GetGovernment();
 			if(otherGov->IsEnemy(gov) && flagship && system == flagship->GetSystem())
 			{
-				hasEnemy |= (system == helper->GetSystem());
+				hasEnemy |= (system == helper->GetSystem() && !helper->IsDisabled());
 				if(hasEnemy)
 					break;
 			}


### PR DESCRIPTION
AI ships would not attempt to help any of their faction's disabled ships if the only enemy in system was disabled.

With this PR, once the danger to their faction has ceased (all enemies destroyed or disabled), they will request repairs.