### PR TITLE
Load grayscale pngs properly.

### DIFF
--- a/source/ImageBuffer.cpp
+++ b/source/ImageBuffer.cpp
@@ -201,6 +201,9 @@ namespace {
 			png_set_palette_to_rgb(png);
 		if(colorType == PNG_COLOR_TYPE_GRAY && bitDepth < 8)
 			png_set_expand_gray_1_2_4_to_8(png);
+		if (colorType == PNG_COLOR_TYPE_GRAY ||
+				colorType == PNG_COLOR_TYPE_GRAY_ALPHA)
+					png_set_gray_to_rgb(png);
 		if(colorType & PNG_COLOR_MASK_COLOR)
 			png_set_bgr(png);
 		png_read_update_info(png, info);

--- a/source/ImageBuffer.cpp
+++ b/source/ImageBuffer.cpp
@@ -201,9 +201,8 @@ namespace {
 			png_set_palette_to_rgb(png);
 		if(colorType == PNG_COLOR_TYPE_GRAY && bitDepth < 8)
 			png_set_expand_gray_1_2_4_to_8(png);
-		if (colorType == PNG_COLOR_TYPE_GRAY ||
-				colorType == PNG_COLOR_TYPE_GRAY_ALPHA)
-					png_set_gray_to_rgb(png);
+		if(colorType == PNG_COLOR_TYPE_GRAY || colorType == PNG_COLOR_TYPE_GRAY_ALPHA)
+			png_set_gray_to_rgb(png);
 		if(colorType & PNG_COLOR_MASK_COLOR)
 			png_set_bgr(png);
 		png_read_update_info(png, info);


### PR DESCRIPTION
This patch fixes an issue where the png loader feeds grayscale png data to OpenGL as BGR data.

To reproduce, replace images/_menu/side panel.png with this image:
![side panel](https://user-images.githubusercontent.com/107468/30350739-0c6eba4a-97e6-11e7-9c7d-53bbc0a597e4.png)

This image is visually identical to the one that currently ships, but since it's one-channel it appears in the game like this:

<img width="282" alt="sidebar" src="https://user-images.githubusercontent.com/107468/30350764-226b7496-97e6-11e7-96b5-4120d62265fe.png">

The fix is just to make sure to call `png_set_gray_to_rgb` if needed.