### PR TITLE
Use selected ship/outfit as scroll reference.

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -66,8 +66,8 @@ void ShopPanel::Step()
 	// Perform autoscroll to bring item details into view.
 	if(scrollDetailsIntoView && mainDetailHeight > 0)
 	{
-		int mainTopY = Screen::Height() / -2;
-		int mainBottomY = Screen::Height() / 2 - 40;
+		int mainTopY = Screen::Top();
+		int mainBottomY = Screen::Bottom() - 40;
 		double selectedBottomY = selectedTopY + TileSize() + mainDetailHeight;
 		// Scroll up until the bottoms match.
 		if(selectedBottomY > mainBottomY)

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -657,6 +657,12 @@ bool ShopPanel::Click(int x, int y, int clicks)
 			return true;
 		}
 		
+	// Deselect selected item when you click on other areas of the main panel.
+	if(dragMain)
+	{
+		selectedShip = nullptr;
+		selectedOutfit = nullptr;
+	}
 	return true;
 }
 

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -122,7 +122,8 @@ protected:
 	int mainDetailHeight = 0;
 	int sideDetailHeight = 0;
 	bool scrollDetailsIntoView = false;
-	double selectedBottomY = 0.;
+	double selectedTopY = 0.;
+	bool sameSelectedTopY = false;
 	
 	std::vector<Zone> zones;
 	std::vector<ClickZone<std::string>> categoryZones;


### PR DESCRIPTION
~~In the outfitter, when you have an outfit selected and choose a different ship it will auto-scroll the outfit description back to the same place it was relative to the screen.~~ In the outfitter, when you have an outfit selected and choose a different ship it will keep the selected outfit in the same screen height.
This is needed because when a new ship is selected it can add or remove outfits before the selected outfit, causing the selected outfit to be placed in a different position.

It is also able to auto-scroll down and tries to make the ~~outfit~~ image visible.

You can deselect the ~~outfit~~ item and cancel the auto-scroll by clicking on other areas of the main panel.