### PR TITLE
Fix hallucinations not moving

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1375,6 +1375,7 @@ ship "Hallucination"
 		"jump fuel" 100
 		"jump speed" 1
 		"jump drive" 1
+		"automaton" 1
 		"thrust" 30
 		"turn" 500
 		"energy generation" 1


### PR DESCRIPTION
The hallucinated ships weren't moving and weren't firing. Now they do.
A more generic solution could be to make "never disabled" imply that the [RequiredCrew](https://github.com/endless-sky/endless-sky/blob/899829760b9dc2fa7563d973ecb13056d3574ef8/source/Ship.cpp#L2032) is zero. Right now it seams to only imply that the [MinimumHull](https://github.com/endless-sky/endless-sky/blob/899829760b9dc2fa7563d973ecb13056d3574ef8/source/Ship.cpp#L2588) is zero.