### PR TITLE
Mission NPCs use fleet movement behavior to travel in groups

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -365,16 +365,14 @@ void AI::Step(const PlayerInfo &player)
 				command |= Command::CLOAK;
 		}
 		
-		// If your parent is destroyed, you are no longer an escort.
 		shared_ptr<Ship> parent = it->GetParent();
 		if(parent && parent->IsDestroyed())
 		{
-			// NPCs that lose their fleet leader follow the next most senior ship
-			// (which is the player, unless the NPC is "uninterested").
-			if(it->IsSpecial())
-				parent = parent->GetParent();
-			else
-				parent.reset();
+			// An NPC that loses its fleet leader should attempt to
+			// follow that leader's parent. For most mission NPCs,
+			// this is the player. Any regular NPCs and mission NPCs
+			// with "personality uninterested" become independent.
+			parent = parent->GetParent();
 			it->SetParent(parent);
 		}
 		

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -369,7 +369,12 @@ void AI::Step(const PlayerInfo &player)
 		shared_ptr<Ship> parent = it->GetParent();
 		if(parent && parent->IsDestroyed())
 		{
-			parent.reset();
+			// NPCs that lose their fleet leader follow the next most senior ship
+			// (which is the player, unless the NPC is "uninterested").
+			if(it->IsSpecial())
+				parent = parent->GetParent();
+			else
+				parent.reset();
 			it->SetParent(parent);
 		}
 		


### PR DESCRIPTION
This PR represents a big change in the way that mission NPCs behave - up until now, every mission NPC has had the parent ship of the player's flagship (unless `personality uninterested`), which means that the NPCs have always wanted to route to the player's system, and follow the player's ship around in-system. With this PR, only a single ship from a fleet specified in an NPC definition will behave in this manner, and the rest of the ships in that NPC block will follow it. This means the ships will travel as a fleet - jumping together - rather than an every-man-for-itself race to the the player's side.

(edited per comments below: )
The ship to be made the fleet leader of each NPC block is chosen on as the first ship specified, consistent with flagship assignment for regular NPC fleets When this ship is destroyed, every remaining NPC in its block will inherit the player as their parent - reverting to the original behavior. The next time the player departs a planet, the NPCs will appoint a new fleet leader, chosen from the remaining ships, again picking the first in the list to be the leader.

I believe the most noticeable impact of this will be in `Escort to ...` missions and those that spawn Bounty Hunters, as if the specified opponent fleets have more than one ship, those ships are much more likely to arrive together than separately, especially if spawned at a distance. For example - the Bounty Hunters will arrive together, rather than first the Arrow / Bounder, then the Quicksilver, etc, and lastly (after you've had ample time to defeat the others, the Leviathan).

This will also open up slightly differing behaviors based on how the NPCs in a mission are defined, even for the same personality ( #2995 ). Specifying a mission's opponent NPCs, or allied NPCs, in separate NPC blocks will result in each block moving semi-independently of the others, depending on the specific personalities used. I say semi-independently since each block is still referenced to the player, but only one of the block is rather than all. Additionally, some personalities (e.g. `heroic`) tend to quash any possible differences that would arise from the altered parent relationship.

Illustrated example:
```
npc
    fleet "Large Southern Pirates" 10
```
vs
```
npc
    fleet "Large Southern Pirates" 5
    fleet "Large Southern Pirates" 5
```
vs
```
npc
    fleet "Large Southern Pirates" 5
npc
    fleet "Large Southern Pirates" 5
```
The first two methods are functionally identical - 10 instances of the "Large Southern Pirates" fleet are instantiated, and a single ship from the group of 10 instantiated fleets is set to be the flagship of those ships. The final method will also create 10 instances of the "Large Southern Pirates" fleet, but these ships will be divided into two groups, each with their own flagship to follow.

Closes #2995 