### PR TITLE
Fix dangling mission reference in condition

### DIFF
--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -965,7 +965,7 @@ mission "FW Northern 4.1A"
 	destination "New Tibet"
 	to offer
 		has "FW Northern 4: done"
-		not "FW Northern 4.1B: offered"
+		not "FW Northern 4.2A: offered"
 		karma >= 2
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`


### PR DESCRIPTION
A mission named "FW Northern 4.1B" is referenced here [free worlds middle.txt#L959-L969](https://github.com/endless-sky/endless-sky/blob/93979842e1bdaa023fe52dd530b8b2dee0a3ad1b/data/free%20worlds%20middle.txt#L959-L969) but is never declared. You probably wanted to reference "[FW Northern 4.2A](https://github.com/endless-sky/endless-sky/blob/master/data/free%20worlds%20middle.txt#L998)" here.