### PR TITLE
Fail missions if mission cargo/passengers are stolen from the player

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -522,7 +522,7 @@ bool MapPanel::IsSatisfied(const PlayerInfo &player, const Mission &mission)
 		if(!npc.HasSucceeded(player.GetSystem()))
 			return false;
 	
-	return mission.Waypoints().empty() && mission.Stopovers().empty();
+	return mission.Waypoints().empty() && mission.Stopovers().empty() && !mission.HasFailed(player);
 }
 
 


### PR DESCRIPTION
Refs #3055 

 - When NPCs plunder the player's ships, the respective missions whose cargo or passengers were taken are now failed.
 - While in-flight, any failed missions are no longer colored as though they are able to be completed.