### PR TITLE
Refactor DoSurveillance

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1715,9 +1715,11 @@ void AI::PickUp(Ship &ship, Command &command, const Body &target)
 
 void AI::DoSurveillance(Ship &ship, Command &command) const
 {
-	const shared_ptr<Ship> &target = ship.GetTargetShip();
-	if(target && (!target->IsTargetable() || target->GetSystem() != ship.GetSystem()))
-		ship.SetTargetShip(shared_ptr<Ship>());
+	// Since DoSurveillance is called after target-seeking and firing, if this
+	// ship has a target, that target is guaranteed to be targetable.
+	shared_ptr<Ship> target = ship.GetTargetShip();
+	if(target && (target->GetSystem() != ship.GetSystem() || target->IsEnteringHyperspace()))
+		target.reset();
 	if(target && ship.GetGovernment()->IsEnemy(target->GetGovernment()))
 	{
 		// Automatic aiming and firing already occurred.
@@ -1747,13 +1749,12 @@ void AI::DoSurveillance(Ship &ship, Command &command) const
 		else
 			command |= Command::LAND;
 	}
-	else if(ship.GetTargetShip() && ship.GetTargetShip()->IsTargetable()
-			&& ship.GetTargetShip()->GetSystem() == ship.GetSystem())
+	else if(target)
 	{
+		// If the pointer to the target ship exists, it is targetable and in-system.
 		bool mustScanCargo = cargoScan && !Has(ship, target, ShipEvent::SCAN_CARGO);
 		bool mustScanOutfits = outfitScan && !Has(ship, target, ShipEvent::SCAN_OUTFITS);
-		bool isInSystem = (ship.GetSystem() == target->GetSystem() && !target->IsEnteringHyperspace());
-		if(!isInSystem || (!mustScanCargo && !mustScanOutfits))
+		if(!mustScanCargo && !mustScanOutfits)
 			ship.SetTargetShip(shared_ptr<Ship>());
 		else
 		{
@@ -1779,9 +1780,10 @@ void AI::DoSurveillance(Ship &ship, Command &command) const
 				if(it->GetGovernment() != ship.GetGovernment() && it->IsTargetable()
 						&& it->GetSystem() == ship.GetSystem())
 				{
-					if(Has(ship, it, ShipEvent::SCAN_CARGO) && Has(ship, it, ShipEvent::SCAN_OUTFITS))
+					if((!cargoScan || Has(ship, it, ShipEvent::SCAN_CARGO))
+							&& (!outfitScan || Has(ship, it, ShipEvent::SCAN_OUTFITS)))
 						continue;
-				
+					
 					targetShips.push_back(it);
 				}
 		
@@ -1790,13 +1792,12 @@ void AI::DoSurveillance(Ship &ship, Command &command) const
 				if(!object.IsStar() && object.Radius() < 130.)
 					targetPlanets.push_back(&object);
 		
-		bool canJump = (ship.JumpsRemaining() != 0);
-		if(jumpDrive && canJump)
-			for(const System *link : ship.GetSystem()->Neighbors())
+		if(ship.JumpsRemaining() && (jumpDrive || hyperdrive))
+		{
+			const set<const System *> &links = jumpDrive ? ship.GetSystem()->Neighbors() : ship.GetSystem()->Links();
+			for(const System *link : links)
 				targetSystems.push_back(link);
-		else if(hyperdrive && canJump)
-			for(const System *link : ship.GetSystem()->Links())
-				targetSystems.push_back(link);
+		}
 		
 		unsigned total = targetShips.size() + targetPlanets.size() + targetSystems.size();
 		if(!total)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1719,7 +1719,10 @@ void AI::DoSurveillance(Ship &ship, Command &command) const
 	// ship has a target, that target is guaranteed to be targetable.
 	shared_ptr<Ship> target = ship.GetTargetShip();
 	if(target && (target->GetSystem() != ship.GetSystem() || target->IsEnteringHyperspace()))
+	{
 		target.reset();
+		ship.SetTargetShip(target);
+	}
 	if(target && ship.GetGovernment()->IsEnemy(target->GetGovernment()))
 	{
 		// Automatic aiming and firing already occurred.


### PR DESCRIPTION
There are some checks that are no longer required due to the updated order of AI::Step, making personality-based actions such as Surveillance come after combat.
 - If the ship's target ship is not targetable, FindTarget gives it a new one that is.
 - This target ship may have left the system since being targeted on a previous iteration of AI::Step, so this must still be checked.
 
 - Since the start of DoSurveillance checks that the ship is in-system (and staying in-system), this does not need to be checked again before performing ship-based surveillance actions. (This section existed before the checks were originally added to the start of DoSurveillance in https://github.com/endless-sky/endless-sky/commit/eb149c335b22021af6cb317a8c20ea23ce191995).
 - Removed now-unnecessary `isInSystem` boolean (was added in https://github.com/endless-sky/endless-sky/commit/42f361ba0c0908ba0a089d91c3686fb66b97f249 when no other in-system checks were used).
 - Don't consider ships for scanning unless this ship has the ability to perform a scan that has not already been performed (e.g. no cargo scan ability and already did an outfit scan -> don't consider that ship).

I considered replacing the `Stop` action for when the ship has no ability to scan planets, no ability to jump (currently), and no new ships to scan with a call to MoveEscort or MoveIndependent, but those can result in the ship deciding to land and stop surveilling new ships that enter.