### PR TITLE
Update Afterburner Logic

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1706,12 +1706,9 @@ void AI::PickUp(Ship &ship, Command &command, const Body &target)
 		command |= Command::FORWARD;
 	
 	// Use the afterburner if it will not cause you to miss your target.
-	double distance = p.Length();
+	double squareDistance = p.LengthSquared();
 	if(command.Has(Command::FORWARD) && ShouldUseAfterburner(ship))
-		if(dp > .9999 || (distance > 1000. && dp > .9)
-				|| (distance > 500. && dp > .975)
-				|| (distance > 250. && dp > .995)
-				|| (distance > 100. && dp > .999))
+		if(dp > max(.9, min(.9999, 1. - squareDistance / 10000000.)))
 			command |= Command::AFTERBURNER;
 }
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -648,16 +648,6 @@ void AI::Step(const PlayerInfo &player)
 		else
 			MoveEscort(*it, command);
 		
-		// Apply the afterburner if you're in a heated battle and it will not
-		// use up your last jump worth of fuel.
-		if(it->Attributes().Get("afterburner thrust") && target && !target->IsDisabled()
-				&& target->IsTargetable() && target->GetSystem() == it->GetSystem())
-		{
-			double fuel = it->Fuel() * it->Attributes().Get("fuel capacity");
-			if(fuel - it->Attributes().Get("afterburner fuel") >= it->JumpFuel())
-				if(command.Has(Command::FORWARD) && targetDistance < 1000.)
-					command |= Command::AFTERBURNER;
-		}
 		// Your own ships cloak on your command; all others do it when the
 		// AI considers it appropriate.
 		if(!it->IsYours())
@@ -1686,6 +1676,10 @@ void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 	if((ship.Facing().Unit().Dot(d) >= 0. && d.Length() > diameter)
 			|| (ship.Velocity().Dot(d) < 0. && ship.Facing().Unit().Dot(d.Unit()) >= .9))
 		command |= Command::FORWARD;
+	
+	// Use an equipped afterburner if possible.
+	if(command.Has(Command::FORWARD) && d.Length() < 1000. && ShouldUseAfterburner(ship))
+		command |= Command::AFTERBURNER;
 }
 
 
@@ -1707,8 +1701,44 @@ void AI::PickUp(Ship &ship, Command &command, const Body &target)
 	
 	// Move toward the target.
 	command.SetTurn(TurnToward(ship, p));
-	if(p.Unit().Dot(ship.Facing().Unit()) > .7)
+	double dp = p.Unit().Dot(ship.Facing().Unit());
+	if(dp > .7)
 		command |= Command::FORWARD;
+	
+	// Use the afterburner if it will not cause you to miss your target.
+	double distance = p.Length();
+	if(command.Has(Command::FORWARD) && ShouldUseAfterburner(ship))
+		if(dp > .9999 || (distance > 1000. && dp > .9)
+				|| (distance > 500. && dp > .975)
+				|| (distance > 250. && dp > .995)
+				|| (distance > 100. && dp > .999))
+			command |= Command::AFTERBURNER;
+}
+
+
+
+// Determine if using an afterburner does not use up reserve fuel, cause undue
+// energy strain, or undue thermal loads if almost overheated.
+bool AI::ShouldUseAfterburner(Ship &ship)
+{
+	if(!ship.Attributes().Get("afterburner thrust"))
+		return false;
+	
+	double fuel = ship.Fuel() * ship.Attributes().Get("fuel capacity");
+	double neededFuel = ship.Attributes().Get("afterburner fuel");
+	double energy = ship.Energy() * ship.Attributes().Get("energy capacity");
+	double neededEnergy = ship.Attributes().Get("afterburner energy");
+	if(energy == 0.)
+		energy = ship.Attributes().Get("energy generation")
+				+ 0.2 * ship.Attributes().Get("solar collection")
+				- ship.Attributes().Get("energy consumption");
+	double outputHeat = ship.Attributes().Get("afterburner heat") / (100 * ship.Mass());
+	if((!neededFuel || fuel - neededFuel > ship.JumpFuel())
+			&& (!neededEnergy || neededEnergy / energy < 0.25)
+			&& (!outputHeat || ship.Heat() + outputHeat < .9))
+		return true;
+	
+	return false;
 }
 
 

--- a/source/AI.h
+++ b/source/AI.h
@@ -88,6 +88,7 @@ private:
 	static void Attack(Ship &ship, Command &command, const Ship &target);
 	static void MoveToAttack(Ship &ship, Command &command, const Body &target);
 	static void PickUp(Ship &ship, Command &command, const Body &target);
+	static bool ShouldUseAfterburner(Ship &ship);
 	void DoSurveillance(Ship &ship, Command &command) const;
 	void DoMining(Ship &ship, Command &command);
 	bool DoHarvesting(Ship &ship, Command &command);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1116,6 +1116,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 			}
 		}
 		double thrustCommand = commands.Has(Command::FORWARD) - commands.Has(Command::BACK);
+		double thrust = 0.;
 		if(thrustCommand)
 		{
 			// Check if we are able to apply this thrust.
@@ -1129,7 +1130,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 				// If a reverse thrust is commanded and the capability does not
 				// exist, ignore it (do not even slow under drag).
 				isThrusting = (thrustCommand > 0.);
-				double thrust = attributes.Get(isThrusting ? "thrust" : "reverse thrust");
+				thrust = attributes.Get(isThrusting ? "thrust" : "reverse thrust");
 				if(thrust)
 				{
 					double scale = fabs(thrustCommand);
@@ -1139,11 +1140,11 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 				}
 			}
 		}
-		bool applyAfterburner = (commands.Has(Command::AFTERBURNER) || (commands.Has(Command::FORWARD)
-				&& !attributes.Get("thrust"))) && !CannotAct();
+		bool applyAfterburner = (commands.Has(Command::AFTERBURNER) || (thrustCommand > 0. && !thrust))
+				&& !CannotAct();
 		if(applyAfterburner)
 		{
-			double thrust = attributes.Get("afterburner thrust");
+			thrust = attributes.Get("afterburner thrust");
 			double cost = attributes.Get("afterburner fuel");
 			double energyCost = attributes.Get("afterburner energy");
 			if(thrust && fuel >= cost && energy >= energyCost)
@@ -2076,8 +2077,8 @@ double Ship::TurnRate() const
 
 double Ship::Acceleration() const
 {
-	return (attributes.Get("thrust") ? attributes.Get("thrust")
-			: attributes.Get("afterburner thrust")) / Mass();
+	double thrust = attributes.Get("thrust");
+	return (thrust ? thrust : attributes.Get("afterburner thrust")) / Mass();
 }
 
 
@@ -2087,8 +2088,8 @@ double Ship::MaxVelocity() const
 	// v * drag / mass == thrust / mass
 	// v * drag == thrust
 	// v = thrust / drag
-	return (attributes.Get("thrust") ? attributes.Get("thrust")
-			: attributes.Get("afterburner thrust")) / attributes.Get("drag");
+	double thrust = attributes.Get("thrust");
+	return (thrust ? thrust : attributes.Get("afterburner thrust")) / attributes.Get("drag");
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1139,7 +1139,8 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 				}
 			}
 		}
-		bool applyAfterburner = commands.Has(Command::AFTERBURNER) && !CannotAct();
+		bool applyAfterburner = (commands.Has(Command::AFTERBURNER) || (commands.Has(Command::FORWARD)
+				&& !attributes.Get("thrust"))) && !CannotAct();
 		if(applyAfterburner)
 		{
 			double thrust = attributes.Get("afterburner thrust");
@@ -2075,7 +2076,8 @@ double Ship::TurnRate() const
 
 double Ship::Acceleration() const
 {
-	return attributes.Get("thrust") / Mass();
+	return (attributes.Get("thrust") ? attributes.Get("thrust")
+			: attributes.Get("afterburner thrust")) / Mass();
 }
 
 
@@ -2085,7 +2087,8 @@ double Ship::MaxVelocity() const
 	// v * drag / mass == thrust / mass
 	// v * drag == thrust
 	// v = thrust / drag
-	return attributes.Get("thrust") / attributes.Get("drag");
+	return (attributes.Get("thrust") ? attributes.Get("thrust")
+			: attributes.Get("afterburner thrust")) / attributes.Get("drag");
 }
 
 

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -187,6 +187,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	
 	double fullMass = emptyMass + (isGeneric ? attributes.Get("cargo space") : ship.Cargo().Used());
 	isGeneric &= (fullMass != emptyMass);
+	double forwardThrust = attributes.Get("thrust") ? attributes.Get("thrust") : attributes.Get("afterburner thrust");
 	attributeLabels.push_back(string());
 	attributeValues.push_back(string());
 	attributesHeight += 10;
@@ -194,15 +195,15 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	attributeValues.push_back(string());
 	attributesHeight += 20;
 	attributeLabels.push_back("max speed:");
-	attributeValues.push_back(Format::Number(60. * attributes.Get("thrust") / attributes.Get("drag")));
+	attributeValues.push_back(Format::Number(60. * forwardThrust / attributes.Get("drag")));
 	attributesHeight += 20;
 	
 	attributeLabels.push_back("acceleration:");
 	if(!isGeneric)
-		attributeValues.push_back(Format::Number(3600. * attributes.Get("thrust") / fullMass));
+		attributeValues.push_back(Format::Number(3600. * forwardThrust / fullMass));
 	else
-		attributeValues.push_back(Format::Number(3600. * attributes.Get("thrust") / fullMass)
-			+ " / " + Format::Number(3600. * attributes.Get("thrust") / emptyMass));
+		attributeValues.push_back(Format::Number(3600. * forwardThrust / fullMass)
+			+ " / " + Format::Number(3600. *forwardThrust / emptyMass));
 	attributesHeight += 20;
 	
 	attributeLabels.push_back("turning:");
@@ -272,10 +273,12 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	tableLabels.push_back("moving:");
 	energyTable.push_back(Format::Number(
 		-60. * (max(attributes.Get("thrusting energy"), attributes.Get("reverse thrusting energy"))
-			+ attributes.Get("turning energy"))));
+			+ attributes.Get("turning energy")
+			+ attributes.Get("afterburner energy"))));
 	heatTable.push_back(Format::Number(
 		60. * (max(attributes.Get("thrusting heat"), attributes.Get("reverse thrusting heat"))
-			+ attributes.Get("turning heat"))));
+			+ attributes.Get("turning heat")
+			+ attributes.Get("afterburner heat"))));
 	attributesHeight += 20;
 	double firingEnergy = 0.;
 	double firingHeat = 0.;
@@ -356,4 +359,3 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const Depreciation &deprec
 	saleValues.push_back(Format::Number(totalCost - chassisCost));
 	saleHeight += 5;
 }
-


### PR DESCRIPTION
 - Support fully automated ship movement for ships with afterburners but no other forward thrust mechanism.
   - If no forward thrusters are installed, the displayed MaxVelocity and Acceleration values are determined by using the afterburner values. If forward thrusters are installed, adding or removing afterburners do not alter their values (since they are no longer used by default).
 - Afterburner heat and energy usage are added to the ShipInfo display table.
 - In addition to fuel usage, NPCs consider the afterburner's energy use and thermal output before deciding to use it (endless-sky#1819), when usage is optional. If usage is not optional (no forward thrust), these checks are bypassed.
 - Consider afterburner usage whenever MoveToAttack is used (ships, asteroids)
 - Consider afterburner usage if picking up flotsam.

The dot product and distance relationships in AI::Pickup were extrapolated from the existing afterburner relationship, at a distance of 1000 and an angle mismatch of ~45deg (dp = 0.9). For each halving of the distance to the flotsam, the allowed angular mismatch is also roughly cut in half, preventing the ship from over-thrusting before it can effectively point at the target flotsam (i.e. don't use the afterburner if using it means you'll miss your target because you weren't pointing at it closely enough).