### PR TITLE
Show licenses in outfitter

### DIFF
--- a/data/coalition missions.txt
+++ b/data/coalition missions.txt
@@ -117,6 +117,7 @@ mission "Coalition: Contributor"
 		"reputation: Coalition" += 10
 		"reputation: Heliarch" += 10
 		set "license: Coalition"
+		log "Completed a lot of Coalition jobs and received permission to purchase civilian technology and ships."
 		log "Factions" "Saryds" `Saryds are an alien species who look suspiciously similar to the centaurs found in early human mythology. They prefer to live on worlds with as much green space as possible, and even their major cities are full of parks and gardens. Most Saryds live in small communes with up to a few dozen of them per house.`
 		log "Factions" "Kimek" `The Kimek are large insectoid aliens, and are members of the Coalition. They discovered spaceflight after the Saryds, but before the Arachi. They are intensely social creatures, preferring to live together in massive buildings with thousands of inhabitants, and many of their worlds have populations in the tens of billions, far more than any human world.`
 		log "Factions" "Arachi" `The spider-like Arachi were the last of the three Coalition species to discover interstellar travel. Most members of their society owe allegiance to one of the great Arachi "Houses," organizations that are somewhat similar to guilds and that each specialize in one particular form of industry or technology.`

--- a/data/coalition outfits.txt
+++ b/data/coalition outfits.txt
@@ -205,3 +205,8 @@ outfit "Large Steering Module"
 	"turning energy" 1.0
 	"turning heat" 8.2
 	description "By focusing on small, modular engines rather than the massive capital ship drives that most other species develop, the Coalition loses some of the potential efficiency for very large ships, but gains a considerable amount of flexibility."
+
+outfit "Coalition License"
+	category "Special"
+	thumbnail "outfit/license"
+	description "Completed a lot of Coalition jobs and received permission to purchase civilian technology and ships."

--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -356,3 +356,8 @@ outfit "Pilot's License"
 	cost 50000
 	thumbnail "outfit/license"
 	description "Without a pilot's license, you cannot purchase a ship on a Republic planet. And if you buy an unlicensed ship on another planet and then bring it into Republic space, you can be fined until you cough up the money for a license. Needless to say, this policy is not terribly popular with freelance merchant captains."
+
+outfit "Militia Carrier License"
+	category "Special"
+	thumbnail "outfit/license"
+	description "Officially joined the Free Worlds. Received permission to purchase their Militia-only carriers."

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -485,6 +485,7 @@ mission "Remnant: Technology Available"
 	on offer
 		payment 2000000
 		set "license: Remnant"
+		log "The prefects have reached a consensus that you should be considered a valuable friend of the Remnant, and shall be given permission to purchase their ships and technology."
 		conversation
 			`An elderly man approaches your ship and introduces himself as a local "prefect," presumably some sort of government position. In a song so elaborate that he must have composed and practiced it ahead of time, he informs you that a scientific study on the void sprites has just been published, and as the co-author you are entitled to a payment of two million credits, which he presents to you.`
 			`	"When your name came up in the study," he says, "I asked around and discovered that you have helped us in other ways as well. The other prefects have reached a consensus that you should be considered a valuable friend of the Remnant, and shall henceforth be given permission to purchase our ships and technology."`

--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -354,3 +354,8 @@ outfit "Smelter-Class Steering"
 	"turning energy" 5.21
 	"turning heat" 6.2
 	description "It's unclear whether the Remnant's powerful engine systems are purely their own invention, or whether they are partly inspired by alien technology."
+
+outfit "Remnant License"
+	category "Special"
+	thumbnail "outfit/license"
+	description "The prefects have reached a consensus that you should be considered a valuable friend of the Remnant, and shall be given permission to purchase their ships and technology."

--- a/data/wanderer outfits.txt
+++ b/data/wanderer outfits.txt
@@ -484,3 +484,8 @@ outfit "Wanderer License"
 	category "Special"
 	thumbnail "outfit/license"
 	description "Managed to broker a temporary ceasefire between the Unfettered Hai and the Wanderers. Was granted access to purchase the non-military Wanderer ships, as a reward."
+
+outfit "Wanderer Military License"
+	category "Special"
+	thumbnail "outfit/license"
+	description "Received permission to purchase warships from the Wanderers, including a new one called the Tempest."

--- a/data/wanderer outfits.txt
+++ b/data/wanderer outfits.txt
@@ -474,3 +474,8 @@ outfit "Type 4 Radiant Steering"
 	"turning heat" 4.5
 	"cooling" 6.7
 	description "This is the largest steering system that the Wanderers sell."
+
+outfit "Wanderer Outfits License"
+	category "Special"
+	thumbnail "outfit/license"
+	description "Spoke with a Wanderer ambassador named Iktat Rek using the translation device and received permission to purchase some of their technology, but not their ships."

--- a/data/wanderer outfits.txt
+++ b/data/wanderer outfits.txt
@@ -479,3 +479,8 @@ outfit "Wanderer Outfits License"
 	category "Special"
 	thumbnail "outfit/license"
 	description "Spoke with a Wanderer ambassador named Iktat Rek using the translation device and received permission to purchase some of their technology, but not their ships."
+
+outfit "Wanderer License"
+	category "Special"
+	thumbnail "outfit/license"
+	description "Managed to broker a temporary ceasefire between the Unfettered Hai and the Wanderers. Was granted access to purchase the non-military Wanderer ships, as a reward."

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -53,6 +53,17 @@ OutfitterPanel::OutfitterPanel(PlayerInfo &player)
 	for(const pair<const string, Outfit> &it : GameData::Outfits())
 		catalog[it.second.Category()].insert(it.first);
 	
+	// Add owned licenses
+	const string PREFIX = "license: ";
+	for(auto &it : player.Conditions())
+		if(it.first.compare(0, PREFIX.length(), PREFIX) == 0 && it.second > 0)
+		{
+			const string name = it.first.substr(PREFIX.length()) + " License";
+			const Outfit *outfit = GameData::Outfits().Get(name);
+			if(outfit)
+				catalog[outfit->Category()].insert(name);
+		}
+	
 	if(player.GetPlanet())
 		outfitter = player.GetPlanet()->Outfitter();
 }
@@ -97,6 +108,9 @@ bool OutfitterPanel::HasItem(const string &name) const
 	for(const Ship *ship : playerShips)
 		if(ship->OutfitCount(outfit))
 			return true;
+	
+	if(showForSale && HasLicense(name))
+		return true;
 	
 	return false;
 }


### PR DESCRIPTION
Reference: #2177

The licenses are the "materialization" of the log entries that mention getting permission to purchase something, so the descriptions are copies of the log entries or are based on them.

**Changes in this commit**:

- outfitter shows the licenses you own when there is an outfit for them.
- new outfits "Militia Carrier License", "Coalition License", "Wanderer Outfits License", "Wanderer License", "Wanderer Military License", and "Remnant License".
- new matching log entries for "Coalition License" and "Remnant License".