### PR TITLE
enhancement: Visual feedback for outfit transfer missions while in-flight

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -518,11 +518,7 @@ bool MapPanel::IsSatisfied(const Mission &mission) const
 
 bool MapPanel::IsSatisfied(const PlayerInfo &player, const Mission &mission)
 {
-	for(const NPC &npc : mission.NPCs())
-		if(!npc.HasSucceeded(player.GetSystem()))
-			return false;
-	
-	return mission.Waypoints().empty() && mission.Stopovers().empty() && !mission.HasFailed(player);
+	return mission.IsSatisfied(player) && !mission.HasFailed(player);
 }
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -574,10 +574,7 @@ bool Mission::CanComplete(const PlayerInfo &player) const
 	if(!toComplete.Test(player.Conditions()))
 		return false;
 	
-	if(!IsSatisfied(player))
-		return false;
-	
-	return true;
+	return IsSatisfied(player);
 }
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -568,16 +568,34 @@ bool Mission::HasSpace(const PlayerInfo &player) const
 
 bool Mission::CanComplete(const PlayerInfo &player) const
 {
-	if(player.GetPlanet() != destination || !waypoints.empty() || !stopovers.empty())
+	if(player.GetPlanet() != destination)
 		return false;
 	
 	if(!toComplete.Test(player.Conditions()))
 		return false;
 	
+	if(!IsSatisfied(player))
+		return false;
+	
+	return true;
+}
+
+
+
+// This function dictates whether missions on the player's map are shown in
+// bright or dim text colors.
+bool Mission::IsSatisfied(const PlayerInfo &player) const
+{
+	if(!waypoints.empty() || !stopovers.empty())
+		return false;
+	
+	// Determine if any fines or outfits that must be transferred, can.
 	auto it = actions.find(COMPLETE);
 	if(it != actions.end() && !it->second.CanBeDone(player))
 		return false;
 	
+	// NPCs which must be accompanied or evaded must be present (or not),
+	// and any needed scans, boarding, or assisting must also be completed.
 	for(const NPC &npc : npcs)
 		if(!npc.HasSucceeded(player.GetSystem()))
 			return false;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -96,6 +96,7 @@ public:
 	bool CanOffer(const PlayerInfo &player) const;
 	bool HasSpace(const PlayerInfo &player) const;
 	bool CanComplete(const PlayerInfo &player) const;
+	bool IsSatisfied(const PlayerInfo &player) const;
 	bool HasFailed(const PlayerInfo &player) const;
 	// Mark a mission failed (e.g. due to a "fail" action in another mission).
 	void Fail();

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -264,9 +264,14 @@ bool MissionAction::CanBeDone(const PlayerInfo &player) const
 			continue;
 		
 		// The outfit can be taken from the player's cargo or from the flagship.
-		// This function is only called when the player is landed, so don't
-		// bother to check for cargo in any of the player's ships.
+		// If the player is landed, all available cargo is transferred from the
+		// player's ships to the player. If checking mission completion status
+		// in-flight, cargo is present in the player's ships.
 		int available = player.Cargo().Get(it.first);
+		if(!player.GetPlanet())
+			for(const auto &ship : player.Ships())
+				if(ship->GetSystem() == player.GetSystem() && !ship->IsDisabled())
+					available += ship->Cargo().Get(it.first);
 		if(flagship)
 			available += flagship->OutfitCount(it.first);
 		

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -43,9 +43,6 @@ public:
 	void Save(DataWriter &out) const;
 	
 	int Payment() const;
-	// Tell this object what the default payment for this mission turned out to
-	// be. It will ignore this information if it is not giving default payment.
-	void SetDefaultPayment(int credits);
 	
 	// Check if this action can be completed right now. It cannot be completed
 	// if it takes away money or outfits that the player does not have.


### PR DESCRIPTION
With 3bfa5eee6e0a4942857e240a4614e1f2c1975bb2 players lost the ability to observe in-flight if any current missions they had that use outfit gifting were able to be completed.

This PR changes the display state of the mission in the MissionPanel view based on whether or not the player has the required outfits to perform the exchange.

For example, if the player takes a mission to mine 100 tons of Aluminum and lands in-between harvests, some of the haul is on an escort ship (potentially multiple). The only way to determine if this mission can be completed is to manually toggle through all of the player's ships and keep a running total of stored Aluminum. With this PR, the game will only color the mission in white when the player has 100 Aluminum  in ships that are present in-system.

The guards added to the cargo check should prevent #3034 from occurring again, while making it simple for the player to check if they have harvested enough of a given mineral and can now land.