### PR TITLE
Add Mining jobs

### DIFF
--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2180,7 +2180,7 @@ mission "Large Bulk Delivery [0]"
 	description "Deliver <cargo> to <destination>. Payment is <payment>."
 	cargo random 40 2 .02
 	to offer
-		random < 70
+		random < 65
 		"cargo space" > 160
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
@@ -2199,7 +2199,7 @@ mission "Large Bulk Delivery [1]"
 	description "Deliver <cargo> to <destination>. Payment is <payment>."
 	cargo random 40 2 .02
 	to offer
-		random < 60
+		random < 55
 		"cargo space" > 160
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
@@ -2218,7 +2218,7 @@ mission "Large Bulk Delivery [2]"
 	description "Deliver <cargo> to <destination>. Payment is <payment>."
 	cargo random 40 2 .02
 	to offer
-		random < 50
+		random < 45
 		"cargo space" > 160
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
@@ -2307,7 +2307,7 @@ mission "Large Rush Delivery [0]"
 	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
 	cargo random 20 6 .1
 	to offer
-		random < 90
+		random < 85
 		"cargo space" > 80
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
@@ -2327,7 +2327,7 @@ mission "Large Rush Delivery [1]"
 	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
 	cargo random 20 6 .1
 	to offer
-		random < 80
+		random < 75
 		"cargo space" > 80
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
@@ -2347,7 +2347,7 @@ mission "Large Rush Delivery [2]"
 	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
 	cargo random 20 6 .1
 	to offer
-		random < 70
+		random < 65
 		"cargo space" > 80
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
@@ -2368,7 +2368,7 @@ mission "Large Rush Delivery [3]"
 	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
 	cargo random 20 6 .1
 	to offer
-		random < 60
+		random < 55
 		"cargo space" > 80
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1573,134 +1573,6 @@ mission "Cargo [4]"
 
 
 
-mission "Small Mining [0]"
-	name "Mining for <planet>"
-	description "Mine 10 tons of iron from asteroids and deliver it to the factories on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 40
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes factory
-	on complete
-		outfit Iron -10
-		payment 16000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Mining [1]"
-	name "Mining for <planet>"
-	description "Mine 10 tons of aluminum from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 35
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 3
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes shipyard
-	on complete
-		outfit Aluminum -10
-		payment 22000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Mining [2]"
-	name "Mining for <planet>"
-	description "Mine 10 tons of titanium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 30
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 3
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes shipyard
-	on complete
-		outfit Titanium -10
-		payment 29000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Mining [3]"
-	name "Mining for <planet>"
-	description "Mine 10 tons of copper from asteroids and deliver it to <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 25
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes shipyard factory
-	on complete
-		outfit Copper -10
-		payment 34000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Mining [4]"
-	name "Mining for <planet>"
-	description "Mine 10 tons of neodynium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 20
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 3
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes shipyard
-	on complete
-		outfit Neodynium -10
-		payment 42000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Mining [5]"
-	name "Mining for <planet>"
-	description "Mine 5 tons of tungsten from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 15
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 3
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Tungsten -5
-		payment 25000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Mining [6]"
-	name "Mining for <planet>"
-	description "Mine 5 tons of uranium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 15
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 3
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Uranium -5
-		payment 28000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-
-
 mission "Bulk Delivery [0]"
 	name "Bulk delivery to <planet>"
 	job
@@ -1745,7 +1617,7 @@ mission "Bulk Delivery [2]"
 	to offer
 		random < 50
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	destination
 		distance 4 16
@@ -1754,336 +1626,6 @@ mission "Bulk Delivery [2]"
 		payment
 		payment 4000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-
-
-mission "Medium Mining [0]"
-	name "Mining for <planet>"
-	description "Mine 30 tons of iron from asteroids and deliver it to the factories on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 40
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 5
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes factory
-	on complete
-		outfit Iron -30
-		payment 48000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Mining [1]"
-	name "Mining for <planet>"
-	description "Mine 25 tons of aluminum from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 35
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes shipyard
-	on complete
-		outfit Aluminum -25
-		payment 55000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Mining [2]"
-	name "Mining for <planet>"
-	description "Mine 20 tons of titanium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 30
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Titanium -20
-		payment 58000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Mining [3]"
-	name "Mining for <planet>"
-	description "Mine 20 tons of copper from asteroids and deliver it to <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 25
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 5
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor factory
-	on complete
-		outfit Copper -20
-		payment 68000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Mining [4]"
-	name "Mining for <planet>"
-	description "Mine 20 tons of neodynium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 20
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Neodynium -20
-		payment 84000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Mining [5]"
-	name "Mining for <planet>"
-	description "Mine 15 tons of tungsten from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 15
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Tungsten -15
-		payment 75000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Mining [6]"
-	name "Mining for <planet>"
-	description "Mine 15 tons of uranium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 15
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Uranium -15
-		payment 84000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-
-
-mission "Large Mining [s]"
-	name "Large mining for <planet>"
-	description "Mine 60 tons of silicon from asteroids and deliver it to the factories on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 20
-		"cargo space" > 100
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 5
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes factory
-	on complete
-		outfit Silicon -60
-		payment 48000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Large Mining [0]"
-	name "Large mining for <planet>"
-	description "Mine 50 tons of iron from asteroids and deliver it to the factories on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 15
-		"cargo space" > 100
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 5
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes factory
-	on complete
-		outfit Iron -50
-		payment 82000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Large Mining [1]"
-	name "Large mining for <planet>"
-	description "Mine 40 tons of aluminum from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 10
-		"cargo space" > 100
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 5
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Aluminum -40
-		payment 90000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-
-
-mission "Large Bulk Delivery [0]"
-	name "Large bulk delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to <destination>. Payment is <payment>."
-	cargo random 40 2 .02
-	to offer
-		random < 70
-		"cargo space" > 160
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 2 8
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 4000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Bulk Delivery [1]"
-	name "Large bulk delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to <destination>. Payment is <payment>."
-	cargo random 40 2 .02
-	to offer
-		random < 60
-		"cargo space" > 160
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 6000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Bulk Delivery [2]"
-	name "Large bulk delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to <destination>. Payment is <payment>."
-	cargo random 40 2 .02
-	to offer
-		random < 50
-		"cargo space" > 160
-	source
-		attributes mining textiles factory farming fishing oil
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 4 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 8000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Bulk Delivery [3]"
-	name "Large bulk delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
-	cargo "Metal" 40 4 .02
-	to offer
-		random < 40
-		"cargo space" > 160
-	source
-		attributes mining
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 2 8
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-		attributes syMajor
-	on complete
-		payment
-		payment 4000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Bulk Delivery [4]"
-	name "Large bulk delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
-	cargo "Heavy Metals" 40 4 .02
-	to offer
-		random < 30
-		"cargo space" > 160
-	source
-		attributes mining
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-		attributes syMajor
-	on complete
-		payment
-		payment 6000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Bulk Delivery [5]"
-	name "Large bulk delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
-	cargo "Electronics" 40 4 .02
-	to offer
-		random < 20
-		"cargo space" > 160
-	source
-		attributes factory
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 4 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-		attributes syMajor
-	on complete
-		payment
-		payment 8000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-
-
-mission "Recycle garbage"
-	name "Recycle garbage"
-	description "<origin> produces a lot of garbage that needs to be disposed of off-station. Transport <cargo> to the industrial solid waste recycler on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 70
-	cargo "Garbage" 15 100
-	source
-		attributes station
-	destination
-		attributes factory mining "dirt belt"
-		distance 9 12
-	on complete
-		dialog "You drop off the <commodity> at an especially smelly solid waste recycler and collect your payment of <payment>."
-		payment
-		payment 20000
 
 
 
@@ -2135,7 +1677,7 @@ mission "Rush Delivery [2]"
 	to offer
 		random < 70
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	destination
 		distance 6 14
@@ -2155,7 +1697,7 @@ mission "Rush Delivery [3]"
 	to offer
 		random < 60
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	destination
 		distance 7 16
@@ -2164,485 +1706,6 @@ mission "Rush Delivery [3]"
 		payment
 		payment 22000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-
-
-mission "Small Rush Mining [0]"
-	name "Rush mining for <planet>"
-	description "Mine 10 tons of iron from asteroids and deliver it to the factories on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 40
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes factory
-	on complete
-		outfit Iron -10
-		payment 18000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Rush Mining [1]"
-	name "Rush mining for <planet>"
-	description "Mine 10 tons of aluminum from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 35
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 3
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes shipyard
-	on complete
-		outfit Aluminum -10
-		payment 24000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Rush Mining [2]"
-	name "Rush mining for <planet>"
-	description "Mine 10 tons of titanium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 30
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 3
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes shipyard
-	on complete
-		outfit Titanium -10
-		payment 31000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Rush Mining [3]"
-	name "Rush mining for <planet>"
-	description "Mine 10 tons of copper from asteroids and deliver it to <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 25
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes shipyard factory
-	on complete
-		outfit Copper -10
-		payment 36000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Rush Mining [4]"
-	name "Rush mining for <planet>"
-	description "Mine 10 tons of neodynium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 20
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 3
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes shipyard
-	on complete
-		outfit Neodynium -10
-		payment 44000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Rush Mining [5]"
-	name "Rush mining for <planet>"
-	description "Mine 5 tons of tungsten from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 15
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 3
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Tungsten -5
-		payment 27000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Small Rush Mining [6]"
-	name "Rush mining for <planet>"
-	description "Mine 5 tons of uranium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 15
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 3
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Uranium -5
-		payment 30000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-
-
-mission "Large Rush Delivery [0]"
-	name "Large rush delivery to <planet>"
-	job
-	repeat
-	deadline
-	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
-	cargo random 20 6 .1
-	to offer
-		random < 90
-		"cargo space" > 80
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 4 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 36000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Rush Delivery [1]"
-	name "Large rush delivery to <planet>"
-	job
-	repeat
-	deadline
-	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
-	cargo random 20 6 .1
-	to offer
-		random < 80
-		"cargo space" > 80
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 5 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 38000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Rush Delivery [2]"
-	name "Large rush delivery to <planet>"
-	job
-	repeat
-	deadline
-	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
-	cargo random 20 6 .1
-	to offer
-		random < 70
-		"cargo space" > 80
-	source
-		attributes mining textiles factory farming fishing oil
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 6 14
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 40000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Rush Delivery [3]"
-	name "Large rush delivery to <planet>"
-	job
-	repeat
-	deadline
-	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
-	cargo random 20 6 .1
-	to offer
-		random < 60
-		"cargo space" > 80
-	source
-		attributes mining textiles factory farming fishing oil
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 7 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 42000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Rush Delivery [4]"
-	name "Large rush delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
-	cargo "Metal" 40 4 .02
-	to offer
-		random < 40
-		"cargo space" > 160
-	source
-		attributes mining
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 4 8
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-		attributes syMajor
-	on complete
-		payment
-		payment 60000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Rush Delivery [5]"
-	name "Large rush delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
-	cargo "Heavy Metals" 40 4 .02
-	to offer
-		random < 30
-		"cargo space" > 160
-	source
-		attributes mining
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 6 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-		attributes syMajor
-	on complete
-		payment
-		payment 65000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Rush Delivery [6]"
-	name "Large Rush delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
-	cargo "Electronics" 40 4 .02
-	to offer
-		random < 20
-		"cargo space" > 160
-	source
-		attributes factory
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 8 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-		attributes syMajor
-	on complete
-		payment
-		payment 70000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-
-
-mission "Medium Rush Mining [0]"
-	name "Rush mining for <planet>"
-	description "Mine 30 tons of iron from asteroids and deliver it to the factories on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 40
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 5
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes factory
-	on complete
-		outfit Iron -30
-		payment 54000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Rush Mining [1]"
-	name "Rush mining for <planet>"
-	description "Mine 25 tons of aluminum from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 35
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes shipyard
-	on complete
-		outfit Aluminum -25
-		payment 60000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Rush Mining [2]"
-	name "Rush mining for <planet>"
-	description "Mine 20 tons of titanium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 30
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Titanium -20
-		payment 62000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Rush Mining [3]"
-	name "Rush mining for <planet>"
-	description "Mine 20 tons of copper from asteroids and deliver it to <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 25
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 5
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor factory
-	on complete
-		outfit Copper -20
-		payment 72000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Rush Mining [4]"
-	name "Rush mining for <planet>"
-	description "Mine 20 tons of neodynium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 20
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Neodynium -20
-		payment 88000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Rush Mining [5]"
-	name "Rush mining for <planet>"
-	description "Mine 15 tons of tungsten from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 15
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Tungsten -15
-		payment 81000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Medium Rush Mining [6]"
-	name "Rush mining for <planet>"
-	description "Mine 15 tons of uranium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 15
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 4
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Uranium -15
-		payment 90000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-
-
-mission "Large Rush Mining [s]"
-	name "Large rush mining for <planet>"
-	description "Mine 60 tons of silicon from asteroids and deliver it to the factories on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 20
-		"cargo space" > 100
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 5
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes factory
-	on complete
-		outfit Silicon -60
-		payment 60000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Large Rush Mining [0]"
-	name "Large rush mining for <planet>"
-	description "Mine 50 tons of iron from asteroids and deliver it to the factories on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 15
-		"cargo space" > 100
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 5
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes factory
-	on complete
-		outfit Iron -50
-		payment 93000
-		dialog "You drop off your cargo and collect your payment of <payment>."
-
-mission "Large Rush Mining [1]"
-	name "Large rush mining for <planet>"
-	description "Mine 40 tons of aluminum from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
-	job
-	repeat
-	deadline 10
-	to offer
-		random < 10
-		"cargo space" > 100
-	source
-		government Republic "Free Worlds" Syndicate Neutral
-	destination
-		distance 0 5
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes syMajor
-	on complete
-		outfit Aluminum -40
-		payment 100000
-		dialog "You drop off your cargo and collect your payment of <payment>."
 
 
 
@@ -3107,6 +2170,302 @@ mission "Colonists [1]"
 		payment
 		payment 10000
 		dialog "The colonists depart your ship after paying you <payment>."
+
+
+
+mission "Large Bulk Delivery [0]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to <destination>. Payment is <payment>."
+	cargo random 40 2 .02
+	to offer
+		random < 70
+		"cargo space" > 160
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 2 8
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+	on complete
+		payment
+		payment 4000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Bulk Delivery [1]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to <destination>. Payment is <payment>."
+	cargo random 40 2 .02
+	to offer
+		random < 60
+		"cargo space" > 160
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 3 12
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+	on complete
+		payment
+		payment 6000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Bulk Delivery [2]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to <destination>. Payment is <payment>."
+	cargo random 40 2 .02
+	to offer
+		random < 50
+		"cargo space" > 160
+	source
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 4 16
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+	on complete
+		payment
+		payment 8000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Bulk Delivery [3]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Metal" 40 4 .02
+	to offer
+		random < 15
+		"cargo space" > 160
+	source
+		attributes "mining"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 2 8
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		payment
+		payment 4000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Bulk Delivery [4]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Heavy Metals" 40 4 .02
+	to offer
+		random < 10
+		"cargo space" > 160
+	source
+		attributes "mining"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 3 12
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		payment
+		payment 6000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Bulk Delivery [5]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Electronics" 40 4 .02
+	to offer
+		random < 5
+		"cargo space" > 160
+	source
+		attributes "factory"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 4 16
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		payment
+		payment 8000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+
+
+mission "Large Rush Delivery [0]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	deadline
+	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
+	cargo random 20 6 .1
+	to offer
+		random < 90
+		"cargo space" > 80
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 4 10
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+	on complete
+		payment
+		payment 36000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [1]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	deadline
+	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
+	cargo random 20 6 .1
+	to offer
+		random < 80
+		"cargo space" > 80
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 5 12
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+	on complete
+		payment
+		payment 38000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [2]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	deadline
+	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
+	cargo random 20 6 .1
+	to offer
+		random < 70
+		"cargo space" > 80
+	source
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 6 14
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+	on complete
+		payment
+		payment 40000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [3]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	deadline
+	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
+	cargo random 20 6 .1
+	to offer
+		random < 60
+		"cargo space" > 80
+	source
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 7 16
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+	on complete
+		payment
+		payment 42000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [4]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Metal" 40 4 .02
+	to offer
+		random < 15
+		"cargo space" > 160
+	source
+		attributes "mining"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 4 8
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		payment
+		payment 60000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [5]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Heavy Metals" 40 4 .02
+	to offer
+		random < 10
+		"cargo space" > 160
+	source
+		attributes "mining"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 6 12
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		payment
+		payment 65000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [6]"
+	name "Large Rush delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Electronics" 40 4 .02
+	to offer
+		random < 5
+		"cargo space" > 160
+	source
+		attributes "factory"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 8 16
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		payment
+		payment 70000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+
+
+mission "Recycle garbage"
+	name "Recycle garbage"
+	description "<origin> produces a lot of garbage that needs to be disposed of off-station. Transport <cargo> to the industrial solid waste recycler on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 70
+	cargo "Garbage" 15 100
+	source
+		attributes station
+	destination
+		attributes "factory" "mining" "dirt belt"
+		distance 9 12
+	on complete
+		dialog "You drop off the <commodity> at an especially smelly solid waste recycler and collect your payment of <payment>."
+		payment
+		payment 20000
 
 
 

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1264,6 +1264,7 @@ mission "Escort (Extra Large, Southern, Dangerous Origin or Destination)"
 		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
 
 
+
 mission "Bounty Hunting (Big)"
 	name "Hunt down <npc>"
 	description "A pirate vessel named <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
@@ -1379,6 +1380,8 @@ mission "Bounty Hunting (Small)"
 		payment 150000
 		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc>."
 
+
+
 mission "Southern Pirate Attack"
 	name "Defend <planet>"
 	description "Defeat a pirate raid on <destination>."
@@ -1478,6 +1481,8 @@ mission "Core Pirate Attack"
 		payment 200000
 		dialog "The government of <planet> pays you <payment> for helping to drive off the pirates."
 
+
+
 mission "Cargo [0]"
 	name "Delivery to <planet>"
 	job
@@ -1566,6 +1571,136 @@ mission "Cargo [4]"
 		payment 4000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
 
+
+
+mission "Small Mining [0]"
+	name "Mining for <planet>"
+	description "Mine 10 tons of iron from asteroids and deliver it to the factories on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 40
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes factory
+	on complete
+		outfit Iron -10
+		payment 16000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Mining [1]"
+	name "Mining for <planet>"
+	description "Mine 10 tons of aluminum from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 35
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 3
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes shipyard
+	on complete
+		outfit Aluminum -10
+		payment 22000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Mining [2]"
+	name "Mining for <planet>"
+	description "Mine 10 tons of titanium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 30
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 3
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes shipyard
+	on complete
+		outfit Titanium -10
+		payment 29000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Mining [3]"
+	name "Mining for <planet>"
+	description "Mine 10 tons of copper from asteroids and deliver it to <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 25
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes shipyard factory
+	on complete
+		outfit Copper -10
+		payment 34000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Mining [4]"
+	name "Mining for <planet>"
+	description "Mine 10 tons of neodynium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 20
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 3
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes shipyard
+	on complete
+		outfit Neodynium -10
+		payment 42000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Mining [5]"
+	name "Mining for <planet>"
+	description "Mine 5 tons of tungsten from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 15
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 3
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Tungsten -5
+		payment 25000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Mining [6]"
+	name "Mining for <planet>"
+	description "Mine 5 tons of uranium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 15
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 3
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Uranium -5
+		payment 28000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+
+
 mission "Bulk Delivery [0]"
 	name "Bulk delivery to <planet>"
 	job
@@ -1619,6 +1754,338 @@ mission "Bulk Delivery [2]"
 		payment
 		payment 4000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+
+
+mission "Medium Mining [0]"
+	name "Mining for <planet>"
+	description "Mine 30 tons of iron from asteroids and deliver it to the factories on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 40
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 5
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes factory
+	on complete
+		outfit Iron -30
+		payment 48000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Mining [1]"
+	name "Mining for <planet>"
+	description "Mine 25 tons of aluminum from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 35
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes shipyard
+	on complete
+		outfit Aluminum -25
+		payment 55000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Mining [2]"
+	name "Mining for <planet>"
+	description "Mine 20 tons of titanium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 30
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Titanium -20
+		payment 58000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Mining [3]"
+	name "Mining for <planet>"
+	description "Mine 20 tons of copper from asteroids and deliver it to <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 25
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 5
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor factory
+	on complete
+		outfit Copper -20
+		payment 68000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Mining [4]"
+	name "Mining for <planet>"
+	description "Mine 20 tons of neodynium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 20
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Neodynium -20
+		payment 84000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Mining [5]"
+	name "Mining for <planet>"
+	description "Mine 15 tons of tungsten from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 15
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Tungsten -15
+		payment 75000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Mining [6]"
+	name "Mining for <planet>"
+	description "Mine 15 tons of uranium from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 15
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Uranium -15
+		payment 84000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+
+
+mission "Large Mining [s]"
+	name "Large mining for <planet>"
+	description "Mine 60 tons of silicon from asteroids and deliver it to the factories on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 20
+		"cargo space" > 100
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 5
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes factory
+	on complete
+		outfit Silicon -60
+		payment 48000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Large Mining [0]"
+	name "Large mining for <planet>"
+	description "Mine 50 tons of iron from asteroids and deliver it to the factories on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 15
+		"cargo space" > 100
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 5
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes factory
+	on complete
+		outfit Iron -50
+		payment 82000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Large Mining [1]"
+	name "Large mining for <planet>"
+	description "Mine 40 tons of aluminum from asteroids and deliver it to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 10
+		"cargo space" > 100
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 5
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Aluminum -40
+		payment 90000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+
+
+mission "Large Bulk Delivery [0]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to <destination>. Payment is <payment>."
+	cargo random 40 2 .02
+	to offer
+		random < 70
+		"cargo space" > 160
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 2 8
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on complete
+		payment
+		payment 4000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Bulk Delivery [1]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to <destination>. Payment is <payment>."
+	cargo random 40 2 .02
+	to offer
+		random < 60
+		"cargo space" > 160
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 3 12
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on complete
+		payment
+		payment 6000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Bulk Delivery [2]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to <destination>. Payment is <payment>."
+	cargo random 40 2 .02
+	to offer
+		random < 50
+		"cargo space" > 160
+	source
+		attributes mining textiles factory farming fishing oil
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 4 16
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on complete
+		payment
+		payment 8000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Bulk Delivery [3]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Metal" 40 4 .02
+	to offer
+		random < 40
+		"cargo space" > 160
+	source
+		attributes mining
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 2 8
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes syMajor
+	on complete
+		payment
+		payment 4000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Bulk Delivery [4]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Heavy Metals" 40 4 .02
+	to offer
+		random < 30
+		"cargo space" > 160
+	source
+		attributes mining
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 3 12
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes syMajor
+	on complete
+		payment
+		payment 6000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Bulk Delivery [5]"
+	name "Large bulk delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Electronics" 40 4 .02
+	to offer
+		random < 20
+		"cargo space" > 160
+	source
+		attributes factory
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 4 16
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes syMajor
+	on complete
+		payment
+		payment 8000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+
+
+mission "Recycle garbage"
+	name "Recycle garbage"
+	description "<origin> produces a lot of garbage that needs to be disposed of off-station. Transport <cargo> to the industrial solid waste recycler on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 70
+	cargo "Garbage" 15 100
+	source
+		attributes station
+	destination
+		attributes factory mining "dirt belt"
+		distance 9 12
+	on complete
+		dialog "You drop off the <commodity> at an especially smelly solid waste recycler and collect your payment of <payment>."
+		payment
+		payment 20000
+
+
 
 mission "Rush Delivery [0]"
 	name "Rush delivery to <planet>"
@@ -1697,6 +2164,485 @@ mission "Rush Delivery [3]"
 		payment
 		payment 22000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+
+
+mission "Small Rush Mining [0]"
+	name "Rush mining for <planet>"
+	description "Mine 10 tons of iron from asteroids and deliver it to the factories on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 40
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes factory
+	on complete
+		outfit Iron -10
+		payment 18000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Rush Mining [1]"
+	name "Rush mining for <planet>"
+	description "Mine 10 tons of aluminum from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 35
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 3
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes shipyard
+	on complete
+		outfit Aluminum -10
+		payment 24000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Rush Mining [2]"
+	name "Rush mining for <planet>"
+	description "Mine 10 tons of titanium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 30
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 3
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes shipyard
+	on complete
+		outfit Titanium -10
+		payment 31000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Rush Mining [3]"
+	name "Rush mining for <planet>"
+	description "Mine 10 tons of copper from asteroids and deliver it to <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 25
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes shipyard factory
+	on complete
+		outfit Copper -10
+		payment 36000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Rush Mining [4]"
+	name "Rush mining for <planet>"
+	description "Mine 10 tons of neodynium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 20
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 3
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes shipyard
+	on complete
+		outfit Neodynium -10
+		payment 44000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Rush Mining [5]"
+	name "Rush mining for <planet>"
+	description "Mine 5 tons of tungsten from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 15
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 3
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Tungsten -5
+		payment 27000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Small Rush Mining [6]"
+	name "Rush mining for <planet>"
+	description "Mine 5 tons of uranium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 15
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 3
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Uranium -5
+		payment 30000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+
+
+mission "Large Rush Delivery [0]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	deadline
+	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
+	cargo random 20 6 .1
+	to offer
+		random < 90
+		"cargo space" > 80
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 4 10
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on complete
+		payment
+		payment 36000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [1]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	deadline
+	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
+	cargo random 20 6 .1
+	to offer
+		random < 80
+		"cargo space" > 80
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 5 12
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on complete
+		payment
+		payment 38000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [2]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	deadline
+	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
+	cargo random 20 6 .1
+	to offer
+		random < 70
+		"cargo space" > 80
+	source
+		attributes mining textiles factory farming fishing oil
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 6 14
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on complete
+		payment
+		payment 40000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [3]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	deadline
+	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
+	cargo random 20 6 .1
+	to offer
+		random < 60
+		"cargo space" > 80
+	source
+		attributes mining textiles factory farming fishing oil
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 7 16
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on complete
+		payment
+		payment 42000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [4]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Metal" 40 4 .02
+	to offer
+		random < 40
+		"cargo space" > 160
+	source
+		attributes mining
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 4 8
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes syMajor
+	on complete
+		payment
+		payment 60000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [5]"
+	name "Large rush delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Heavy Metals" 40 4 .02
+	to offer
+		random < 30
+		"cargo space" > 160
+	source
+		attributes mining
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 6 12
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes syMajor
+	on complete
+		payment
+		payment 65000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+mission "Large Rush Delivery [6]"
+	name "Large Rush delivery to <planet>"
+	job
+	repeat
+	description "Deliver <cargo> to the shipyard on <destination>. Payment is <payment>."
+	cargo "Electronics" 40 4 .02
+	to offer
+		random < 20
+		"cargo space" > 160
+	source
+		attributes factory
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination
+		distance 8 16
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes syMajor
+	on complete
+		payment
+		payment 70000
+		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+
+
+
+mission "Medium Rush Mining [0]"
+	name "Rush mining for <planet>"
+	description "Mine 30 tons of iron from asteroids and deliver it to the factories on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 40
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 5
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes factory
+	on complete
+		outfit Iron -30
+		payment 54000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Rush Mining [1]"
+	name "Rush mining for <planet>"
+	description "Mine 25 tons of aluminum from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 35
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes shipyard
+	on complete
+		outfit Aluminum -25
+		payment 60000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Rush Mining [2]"
+	name "Rush mining for <planet>"
+	description "Mine 20 tons of titanium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 30
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Titanium -20
+		payment 62000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Rush Mining [3]"
+	name "Rush mining for <planet>"
+	description "Mine 20 tons of copper from asteroids and deliver it to <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 25
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 5
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor factory
+	on complete
+		outfit Copper -20
+		payment 72000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Rush Mining [4]"
+	name "Rush mining for <planet>"
+	description "Mine 20 tons of neodynium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 20
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Neodynium -20
+		payment 88000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Rush Mining [5]"
+	name "Rush mining for <planet>"
+	description "Mine 15 tons of tungsten from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 15
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Tungsten -15
+		payment 81000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Medium Rush Mining [6]"
+	name "Rush mining for <planet>"
+	description "Mine 15 tons of uranium from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 15
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 4
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Uranium -15
+		payment 90000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+
+
+mission "Large Rush Mining [s]"
+	name "Large rush mining for <planet>"
+	description "Mine 60 tons of silicon from asteroids and deliver it to the factories on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 20
+		"cargo space" > 100
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 5
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes factory
+	on complete
+		outfit Silicon -60
+		payment 60000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Large Rush Mining [0]"
+	name "Large rush mining for <planet>"
+	description "Mine 50 tons of iron from asteroids and deliver it to the factories on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 15
+		"cargo space" > 100
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 5
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes factory
+	on complete
+		outfit Iron -50
+		payment 93000
+		dialog "You drop off your cargo and collect your payment of <payment>."
+
+mission "Large Rush Mining [1]"
+	name "Large rush mining for <planet>"
+	description "Mine 40 tons of aluminum from asteroids and deliver it to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 10
+	to offer
+		random < 10
+		"cargo space" > 100
+	source
+		government Republic "Free Worlds" Syndicate Neutral
+	destination
+		distance 0 5
+		government Republic "Free Worlds" Syndicate Neutral
+		attributes syMajor
+	on complete
+		outfit Aluminum -40
+		payment 100000
+		dialog "You drop off your cargo and collect your payment of <payment>."
 
 
 
@@ -1786,6 +2732,8 @@ mission "Passengers [4]"
 		payment 2000
 		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
 
+
+
 mission "Transport miners to <planet>"
 	job
 	repeat
@@ -1857,6 +2805,8 @@ mission "Transport workers to <planet>"
 		payment
 		payment 2000
 		dialog "You wish the workers the best of luck on <planet>, and collect your payment of <payment>."
+
+
 
 mission "Tourists out [0]"
 	name "Bring a tourist to <planet>"
@@ -1974,6 +2924,8 @@ mission "Tourists back [2]"
 		payment 8000
 		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
 
+
+
 mission "Family [0]"
 	name "Transport family to <planet>"
 	job
@@ -2050,6 +3002,8 @@ mission "Family [3]"
 		payment 10000
 		dialog "The family you have been transporting departs your ship after paying you <payment>."
 
+
+
 mission "Strike Breakers [mining]"
 	name "Strike breakers to <planet>"
 	job
@@ -2110,6 +3064,8 @@ mission "Strike Breakers [factory]"
 		payment 10000
 		dialog "You unload the strike breakers amid an angry crowd of protesters held back by police. When you return to your ship, you find that the company has transferred the agreed-upon payment of <payment> into your account."
 
+
+
 mission "Colonists [0]"
 	name "Colonists to <planet>"
 	job
@@ -2152,163 +3108,7 @@ mission "Colonists [1]"
 		payment 10000
 		dialog "The colonists depart your ship after paying you <payment>."
 
-mission "Large Bulk Delivery [0]"
-	name "Large bulk delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to <destination>. Payment is <payment>."
-	cargo random 40 2 .02
-	to offer
-		random < 70
-		"cargo space" > 160
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 2 8
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 4000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
 
-mission "Large Bulk Delivery [1]"
-	name "Large bulk delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to <destination>. Payment is <payment>."
-	cargo random 40 2 .02
-	to offer
-		random < 60
-		"cargo space" > 160
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 6000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Bulk Delivery [2]"
-	name "Large bulk delivery to <planet>"
-	job
-	repeat
-	description "Deliver <cargo> to <destination>. Payment is <payment>."
-	cargo random 40 2 .02
-	to offer
-		random < 50
-		"cargo space" > 160
-	source
-		attributes mining textiles factory farming fishing oil
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 4 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 8000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Rush Delivery [0]"
-	name "Large rush delivery to <planet>"
-	job
-	repeat
-	deadline
-	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
-	cargo random 20 6 .1
-	to offer
-		random < 90
-		"cargo space" > 80
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 4 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 36000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Rush Delivery [1]"
-	name "Large rush delivery to <planet>"
-	job
-	repeat
-	deadline
-	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
-	cargo random 20 6 .1
-	to offer
-		random < 80
-		"cargo space" > 80
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 5 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 38000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Rush Delivery [2]"
-	name "Large rush delivery to <planet>"
-	job
-	repeat
-	deadline
-	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
-	cargo random 20 6 .1
-	to offer
-		random < 70
-		"cargo space" > 80
-	source
-		attributes mining textiles factory farming fishing oil
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 6 14
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 40000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Large Rush Delivery [3]"
-	name "Large rush delivery to <planet>"
-	job
-	repeat
-	deadline
-	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
-	cargo random 20 6 .1
-	to offer
-		random < 60
-		"cargo space" > 80
-	source
-		attributes mining textiles factory farming fishing oil
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	destination
-		distance 7 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
-	on complete
-		payment
-		payment 42000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
-
-mission "Recycle garbage"
-	name "Recycle garbage"
-	description "<origin> produces a lot of garbage that needs to be disposed of off-station. Transport <cargo> to the industrial solid waste recycler on <destination>. Payment is <payment>."
-	job
-	repeat
-	to offer
-		random < 70
-	cargo "Garbage" 15 100
-	source
-		attributes station
-	destination
-		attributes factory mining "dirt belt"
-		distance 9 12
-	on complete
-		dialog "You drop off the <commodity> at an especially smelly solid waste recycler and collect your payment of <payment>."
-		payment
-		payment 20000
 
 mission "Bounty Hunting (Marauder I)"
 	name "Hunt down <npc>"

--- a/data/map.txt
+++ b/data/map.txt
@@ -65,6 +65,7 @@ galaxy "label arachi"
 galaxy "label waste"
 	pos 80 315
 
+
 system "1 Axis"
 	pos -1274.63 267.214
 	government Coalition
@@ -23900,6 +23901,8 @@ system Zubeneschamali
 		distance 2218.25
 		period 1182.01
 
+
+
 planet "Ablub's Invention"
 	attributes arach factory
 	landscape land/sky3
@@ -24073,7 +24076,7 @@ planet Asgard
 		fleet "Large Deep Security" 39
 
 planet "Ashy Reach"
-	attributes kimek shipping moon
+	attributes kimek moon shipping
 	landscape land/canyon2
 	description `The thin, unbreathable atmosphere and low gravity mean that Ashy Reach will never become popular as a residential world, but it serves a useful role as a hub for shipping and commercial exchange. There is only one settlement here, built around the spaceport, and consisting mostly of pressurized underground caverns. Outside the settlement, the planet's surface is drab and almost lifeless.`
 	spaceport `Only a handful of towers, most of them windowless, protrude above the planet's surface at the center of the spaceport settlement. The hangars and warehouses are all underground. The surface is visible through a few thick acrylic polymer windows on the lower levels of the towers. Lit by the glow of the gas giant that this moon orbits, the towers form a surreal landscape, like a city abandoned and only halfway formed.`
@@ -24562,6 +24565,7 @@ planet Delve
 	spaceport `The spaceport is an enormous hollow carved out of the side of a mountain, with a network of steel beams and mesh holding the rock in place. Inside the hollow, the landings are caves carved into the rock itself, again with steel beams above to protect the ships within. A tiered set of cog railways transport passengers and cargo between the landings and the large town at the base of the hollow. Beyond the hollow, the mountainside falls off into a steep cliff and a mist-filled valley below. Although the port is well-built and modern, you cannot help an irrational fear that the whole place will slide off the edge of the mountain one day.`
 	shipyard "Basic Ships"
 	shipyard "Syndicate Basics"
+	shipyard "Megaparsec Basics"
 	outfitter "Syndicate Advanced"
 	outfitter "Basic Outfits"
 	outfitter "Ammo North"
@@ -24637,7 +24641,7 @@ planet "Dusk Companion"
 	"required reputation" 15
 
 planet Dustmaker
-	attributes hai manufacturing "hai tourism"
+	attributes hai factory "hai tourism"
 	landscape land/badlands0
 	description `The surface of this planet, when it is not obscured by dust storms, receives enough sunlight to power not only large solar farms, but solar furnaces as well, which the Hai use for manufacturing a large variety of goods. Some of the solar farms are so large that from orbit, the light reflecting off them could almost be mistaken for lakes and small oceans. However, there is almost no water on the planet's surface except near the poles.`
 	spaceport `Like most Hai architecture, the spaceport is made of bare, unpainted metal, so weathered that you would not be surprised to learn that it is tens of thousands of years old. Tall, curved walls around the outskirts of the port create a sort of labyrinth with the port building itself at the center; they are probably intended to block sandstorms while allowing gentler breezes to pass through.`
@@ -25111,7 +25115,7 @@ planet "Gresku Fodar"
 	security 0
 
 planet Hai-home
-	attributes hai
+	attributes hai urban
 	landscape land/valley2
 	description `This is the home world of the Hai. Well over half the planet's surface is oceans. The land is mostly covered by sprawling cities, except for some mountain ranges too high or too snowy to build on. Despite its population of nearly eight billion, Hai-home is relatively free of pollution or overcrowding.`
 	spaceport `The spaceport in the capital city of Haimat is massive, with towers well over a kilometer high and hangars large enough to park an entire fleet of capital ships in. Although the port is bustling, with ships taking off and landing almost every minute, nearly three quarters of the landing pads and hangars are empty, and whole sections of the spaceport appear to be unused. Clearly, this port was designed to handle far more traffic than this.`
@@ -25183,7 +25187,7 @@ planet Heartland
 		fleet "Large Republic" 4
 
 planet Heartvalley
-	attributes hai manufacturing "hai tourism"
+	attributes hai factory oil "hai tourism"
 	landscape land/fog0
 	description `An extreme amount of tectonic activity in its distant past has left Heartvalley with mountain ranges five to ten kilometers high in some places. Most of the Hai settlements here are in the valleys closer to sea level, where the air is dense enough for them to breathe comfortably. The tectonic activity has left many ancient sea-beds exposed, providing access to bountiful supplies of oil. To the Hai, oil is too precious a resource to be used for fuel; instead they process it into plastic and use the byproducts in other chemical processes.`
 	spaceport `The spaceport is built halfway up the slope of one of the most heavily settled valleys. Farther down the valley, the tallest buildings of the city seem tiny compared to the mountains that surround them. On the outskirts of the city sit strange engines the size of a spacecraft, with pipes snaking out from them in all directions and sinking deep into the ground.`
@@ -25335,7 +25339,7 @@ planet Icelake
 	outfitter "Hai Advanced"
 
 planet Ingot
-	attributes "dirt belt" volcanic mining moon
+	attributes "dirt belt" moon volcanic mining
 	landscape land/mountain8
 	description `Ingot is a volcanic moon, totally unsuitable for life but rich in metal. The miners who work here must spend all their time inside pressurized buildings. Because Ingot has almost no atmosphere to slow them down, meteorites are a constant danger to the colonists. The shells of the buildings have multiple layers, designed to be self-sealing in any but the largest of impacts. Most of the mining is done remotely by robotic vehicles, but someone still needs to be present to control them and to make repairs when something goes wrong.`
 	spaceport `In this spaceport, ships dock inside a hangar whose ceiling protects them from meteorite impacts. The hangar is not pressurized, so there are also landing tubes that connect to each of the visiting ships. Many of the people inside are carrying emergency oxygen masks in case a sudden impact ruptures the building.`
@@ -25374,7 +25378,7 @@ planet "Kasichara Fet"
 	security 0
 
 planet "Keneska Fek"
-	attributes korath
+	attributes korath mining
 	landscape land/canyon6
 	description `The Kor Sestor apparently use this as a mining world, but rather than digging for minerals they have been intentionally crashing metal-rich asteroids into undeveloped sections of the desert where the robots can then break them apart and extract the ore. Predictably, the ecological effects of this sort of mining are devastating.`
 	spaceport `The Kor Sestor refineries are laid out in a grid pattern. Each square of the grid is a few kilometers on each side, and is laid out in exactly the same way: a central power station, surrounded by smelters and repair bays and factories and storehouses laid out like spokes of a wheel. Each square produces and maintains a fleet of worker robots that occasionally collaborate to construct a new square, extending the city farther outward. Lines of harvester robots snake out from the refineries to the downed asteroids like trails of ants.`
@@ -25452,7 +25456,7 @@ planet "Kuwaru Efreti"
 	security 1
 
 planet Lagrange
-	attributes quarg tourism station
+	attributes quarg station tourism
 	landscape land/station2
 	description `The Quarg built this station centuries ago, before they began construction on the ringworld. From the dark side of the station, the ring is visible as a thin bright filament stretching out to either side of the system's sun. The ring itself is closed to human visitors, but tour shuttles depart from here on a regular basis, giving human tourists a closer view of this engineering feat that is so far beyond anything human beings have ever attempted to build.`
 	spaceport `In the docking section are flexible, oddly organic-looking tubes that snaked out to connect to your ship as it approached. Walking through the tube and into the station was a somewhat disconcerting experience. Inside, crowds of human tourists gawk at the tall, thin Quargs, who for the most part seem unfazed by the attention. The station is perfectly clean; every surface shines.`
@@ -25460,7 +25464,7 @@ planet Lagrange
 	security 0.9
 
 planet "Laki Nemparu"
-	attributes korath efret
+	attributes korath efret oil factory
 	landscape land/sea2
 	description `This is an old factory world, so shrouded in smog that only tiny glimpses of the land are visible from above. Deep under the oceans of Laki Nemparu are oil reservoirs so vast that centuries of industry have not yet drained them dry. All but the hardiest of the native vegetation and wildlife is now long extinct from lack of direct sunlight or from pollution and chemical exposure.`
 	spaceport `All the Korath you encounter in the spaceport are wearing ventilator masks, and if you were staying here for longer you would probably do the same. The air leaves a metallic taste in your mouth, and your eyes feel dry and sting when the wind hits them. On the outskirts of the city, factory smokestacks are belching more pollution into the air; the Korath have either given up on preserving this planet, or simply have too great a need for the goods manufactured here to be willing to shut the factories down.`
@@ -25518,7 +25522,7 @@ planet Longjump
 		fleet "Large Militia" 9
 
 planet Luna
-	attributes "near earth" tourism factory moon
+	attributes "near earth" moon tourism factory
 	landscape land/earthrise
 	description `In the early days of space travel, back when engines were still so inefficient that escaping from a planet's gravity was costly and difficult, an enormous shipyard was built on the Moon where asteroids, harvested from the asteroid belt, were mined for raw materials for ships.`
 	description `	The facility is still in operation, although it is now overshadowed by the far more advanced shipbuilding centers like Geminus in the Castor system.`
@@ -25582,7 +25586,7 @@ planet Maker
 		fleet "Large Syndicate" 10
 
 planet Makerplace
-	attributes hai manufacturing "hai tourism"
+	attributes hai factory "hai tourism"
 	landscape land/lava0
 	description `Makerplace has an unusual degree of volcanic activity due to high concentrations of radioactive elements in the planet's mantle. Although it is warm by Hai standards, the abundance of geothermal energy, combined with plentiful solar energy and wind power, has made it an ideal world for manufacturing. Several cities in the temperate regions have populations of over a hundred million Hai, and the factories surrounding the cities spread out for dozens of kilometers in all directions. Near the equator, much of the land is desert or volcanic wasteland.`
 	spaceport `A fair number of the Hai walking through this spaceport are wearing no clothing at all, perhaps as a response to the warm temperatures. Given that they seem to attract no notice or disapproval by doing so, it appears that this is perfectly normal behavior. Others appear to have trimmed their fur shorter than normal as an alternative way to deal with the heat.`
@@ -25670,7 +25674,7 @@ planet Mere
 		fleet "Large Militia" 14
 
 planet "Mereti Station"
-	attributes korath station
+	attributes korath station military
 	landscape land/space7
 	description `This large station serves as the "mission control" for the robotic ships of the Kor Mereti faction. Warships of every shape and design are clustered in its docking bays or flying patrol outside.`
 	spaceport `The central core of this station is entirely sealed off, running on its own power generators serviced by self-maintaining repair robots. Inside the core are the advanced computers that direct the Kor Mereti war effort.`
@@ -26029,7 +26033,7 @@ planet Nimbus
 		fleet "Small Syndicate" 4
 
 planet Norn
-	attributes deep fishing moon
+	attributes deep moon fishing
 	landscape land/beach4
 	description `Norn is a water world, with low gravity but an atmosphere dense enough to breathe easily. Large mats of seaweed and algae form natural rafts that drift around with the ocean currents, and a few intrepid settlers have colonized them, people who prefer a life of relative solitude and are willing to trust their fates to wherever the winds might take them. Others have settled the few, low islands, which are prone to frequent flooding. Fish are common here, including a few species of flying fish which travel in large packs and are a considerable nuisance for the land-dwellers.`
 	spaceport `The spaceport is on one of the larger islands, a network of small buildings connected by bridges and raised up on enormous stilts about fifty meters high. Cargo winches are used to load and unload cargo from the boats that dock below. Starships dock in individual hangars, to protect them from the wind. The whole complex sways slightly, almost imperceptibly, as if it were a large boat at sea. The walkways all have tall railings, but you still find yourself afraid to venture too near the edge or to look down at the island and the sea below. The locals, however, walk swiftly and gracefully, with no sign of fear.`
@@ -26180,6 +26184,7 @@ planet Prime
 		fleet "Large Republic" 17
 
 planet Pugglemug
+	attributes pug
 	landscape land/myrabella5
 	description `This planet appears to be the Pug capital. Cities with impossibly high towers, connected by arches and bridges, are sprinkled across the landscape, and surrounding the cities are shorter, uglier buildings used as factories. However, a surprising amount of the land area is unsettled, its natural beauty untouched. Given how much damage humans did to Earth before discovering the hyperdrive, you find it hard to fathom how a species isolated in a single star system could have enough restraint to leave their home so pristine.`
 	spaceport `The primary spaceport here is marked by an enormous collection of arches forming an open-air dome. Based on the power cables and devices attached to the sides of the arches, you suspect that the entire dome can be protected by an energy shield if necessary. Inside it, landing platforms jut out from the arches at many different levels.`
@@ -26187,6 +26192,7 @@ planet Pugglemug
 	security 1
 
 planet Pugglequat
+	attributes pug mining oil
 	landscape land/forest2
 	description `This planet has a handful of Pug cities on it, full of tall, graceful spires and arches. However, most of the land area is either left in its natural state, or in use for mining; it seems to abound in both oil reserves and metal ore. The climate is somewhat cold by human standards, but still quite livable. You are not sure if that is because the Pug were just lucky enough to have a star system with two hospitable planets, or whether they have employed some sort of terraforming.`
 	spaceport `The spaceport here is a set of seven tall towers of varying heights, each with landing pads jutting out from its sides like leaves from the stalk of a plant. The towers are joined to each other at various levels by arches.`
@@ -26356,7 +26362,7 @@ planet "Sandy Two"
 	outfitter "Coalition Basics"
 
 planet "Sapira Mereti"
-	attributes korath
+	attributes korath factory
 	landscape land/lava6
 	description `This was the seat of government and last military stronghold of the Kor Mereti faction during the Korath civil war. Here they built the factories and shipyards that churned out autonomous warships to prosecute their war against the Kor Sestor. The machines now rule this world alone, and have made it entirely uninhabitable for living creatures as they delve ever deeper into the planet's crust to harvest metal and fuel, and construct more and more factories to build new generations of robotic warships.`
 	spaceport `With no living creatures in sight, the only noises in this refuelling depot are the roaring engines as robot ships land and take off, communicating silently with each other via radio. The autonomous ships land and take off with perfect precision in a steady, unbroken stream. Many of them have been damaged by weapons fire, and as soon as they land they are covered by a swarm of welding and repair robots that attach new layers of hull armor and replace weapons and engines that have been destroyed.`
@@ -26455,7 +26461,7 @@ planet "Separa Tiklar"
 	security 0
 
 planet "Septar Lorku"
-	attributes korath station
+	attributes korath station mining
 	landscape land/loc0
 	description `This system has a high concentration of metallic asteroids, which the Korath are harvesting to provide iron ore for their space ships and fissionable materials for their reactor cores. Smelting metal in a high-temperature blast furnace in the interior of a space station is, of course, an incredibly risky proposition.`
 	spaceport `Despite your lack of knowledge of Korath health and anatomy, it is clear that the inhabitants of this station are under-fed and overworked. Also, an alarming number of them are missing fingers, hands, or entire limbs. It is quite possible that the work in the refineries is even more dangerous than the job of the raiders attacking human space.`
@@ -26472,14 +26478,14 @@ planet Serpens
 		fleet "Large Republic" 3
 
 planet "Sessiliki Far"
-	attributes korath station
+	attributes korath station mining
 	landscape land/loc2
 	description `This is a Korath mining station, where ore extracted from asteroids is refined and processed. The Korath seem to have an aversion to harvesting raw materials from actual planets, preferring to work with lifeless asteroids instead.`
 	spaceport `A smelter is never a safe place to work, and some of the machinery looks very old, but you get the feeling that the Korath on this station are in relatively good spirits nonetheless. The cafe in the spaceport is bustling, and every few hours a bell rings and about a third of the workers leave the factory floor and are replaced by fresh and rested ones.`
 	security 0
 
 planet "Sestor Ikfar"
-	attributes korath
+	attributes korath factory
 	landscape land/hills1
 	description `This dry, hot world is home to almost no native life, but is ideal for the Korath automata because of its abundant solar energy. In the places where the Korath cities once were, the Kor Sestor have built massive factories with buildings sometimes close to a kilometer in height. In other places the land remains undeveloped, but the factories are constantly expanding outward.`
 	spaceport `In place of streets, massive tunnels and shafts run through the factory cities, wide enough for two capital ships to pass each other traveling in opposite directions without the risk of collision. The tunnels branch out into smaller and smaller passageways like capillaries branching out from an artery.`
@@ -26711,7 +26717,7 @@ planet Starcross
 		fleet "Small Militia" 22
 
 planet Stonebreak
-	attributes hai manufacturing
+	attributes hai factory urban
 	landscape land/fog7
 	description `Stonebreak is home to some of the largest cities in Hai space aside from their homeworld: massive planned communities built in concentric rings, where housing space and community buildings alternate with zones of factories and shipyards. This star system has an unusual number of metallic asteroids, which the Hai harvest for the raw materials for Stonebreak's industries.`
 	spaceport `From above, this city has almost perfect radial symmetry, a sure sign that it was planned and built as a single unit rather than expanding at random over time. Every single building in the city is made from the same metal alloy, a dull and slightly irregular grey color. The corners of each building are slightly beveled instead of meeting at right angles.`
@@ -26935,7 +26941,7 @@ planet "Turquoise Four"
 	"required reputation" 15
 
 planet Twinstar
-	attributes south tourism frontier moon
+	attributes south moon tourism frontier
 	landscape land/lava3
 	description `The only settlement on this small world is Twinstar Depot, a village created mostly just to service the spaceport, where food and equipment from the southern galactic arm is stored and sent out in all directions to supply the rest of human space. The gravity is far less than ideal for human development, but the atmosphere is breathable and some tourists come to the planet just for the experience of being able to run and jump in low gravity without the need for a suit or oxygen tanks.`
 	spaceport `The depot consists mostly of large storage racks, with automatic lifts constantly clanking up and down. Very few people are in sight, aside from a small cafe near the center of the port. It is not a hospitable place.`
@@ -27008,7 +27014,7 @@ planet "Var' Kayi"
 	bribe 0
 
 planet "Var' Roi"
-	attributes wanderer research moon
+	attributes wanderer moon research
 	landscape land/snow9
 	description `The surface of this small icy moon is constantly cracked and broken by tidal force from the gas giant that it orbits. The tidal disturbances also heat the moon enough to keep its oceans warm enough to support life despite the small amount of sunlight that reaches here.`
 	spaceport `The only habitation on this moon is a Wanderer research station suspended on metal pylons well above the icy surface of the ocean. The gravity here is low enough that even though the atmosphere is thin, the Wanderers who work in the station can fly out across the ocean on their own power, wearing some sort of breathing gear. The researchers also have a fleet of submarine ships, sturdy enough to pierce through the shifting ice and travel deep below the ocean surface.`
@@ -27111,7 +27117,7 @@ planet "Varu Mer'ek"
 	bribe 0
 
 planet "Varu Tek'kai"
-	attributes wanderer factory moon
+	attributes wanderer moon factory
 	landscape land/badlands4
 	description `This Wanderer world is almost uninhabited and devoid of any indigenous ecosystem, except perhaps on the microscopic level. It has none of the beauty of other Wanderer settlements. Here, factories have been built to process the most dangerous and destructive of industrial chemicals. If disaster strikes one of the factories, the only result will be the contamination of a world that is already dead and lifeless - far better, in the judgment of the Wanderers, than allowing such risky industries to operate on a living world.`
 	spaceport `Nearly all the operations of the factories here are automated, and the outside atmosphere is too thin for even the Wanderers to breathe. The workers live in dormitory apartments in a ring surrounding a large central dome. Inside the dome, protected from the elements, is a park whose gardens contain everything from towering conifers to fields of wildflowers; a necessary place of sanctuary and rest for the Wanderers who must spend the rest of their time servicing machines in the bleak environment outside the spaceport.`
@@ -27176,7 +27182,7 @@ planet "Warm Wind"
 	"required reputation" 15
 
 planet Watcher
-	attributes "dirt belt" research uninhabited moon
+	attributes uninhabited "dirt belt" moon research
 	landscape land/hills4
 	description `Watcher is a small moon, the only world in this system that sustains any indigenous life. Because of the low gravity, humans have not yet built a permanent settlement here, but it is occasionally visited by biologists interested in studying low-gravity life forms. There are forests here where the trees grow over two hundred meters tall.`
 	security 0
@@ -27280,4 +27286,3 @@ planet Zug
 	tribute 1200
 		threshold 3000
 		fleet "Large Militia" 18
-

--- a/data/mining jobs.txt
+++ b/data/mining jobs.txt
@@ -11,18 +11,18 @@
 # The payment for mining jobs is the normal sale value, plus the larger of 400
 # credits per ton or 10% of the payload's value.
 
-mission "Small Mining [0]"
+mission "Mining, Small [0]"
 	name "Mine iron for <planet>"
 	description "Mine 10 tons of iron from asteroids and deliver them to the factories on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 25
-		"Small Mining [0]: active" < 3
+		"Mining, Small [0]: active" < 3
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 3
+		distance 1 3
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes "factory"
 	on complete
@@ -31,18 +31,18 @@ mission "Small Mining [0]"
 		payment 16000
 		dialog "You drop off the iron ore and collect your payment of <payment>."
 
-mission "Small Mining [1]"
+mission "Mining, Small [1]"
 	name "Mine aluminum for <planet>"
 	description "Mine 10 tons of aluminum from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 25
-		"Small Mining [1]: active" < 3
+		"Mining, Small [1]: active" < 3
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 3
+		distance 1 3
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 	on complete
@@ -51,18 +51,18 @@ mission "Small Mining [1]"
 		payment 22000
 		dialog "You drop off the aluminum ore and collect your payment of <payment>."
 
-mission "Small Mining [2]"
+mission "Mining, Small [2]"
 	name "Mine titanium for <planet>"
 	description "Mine 10 tons of titanium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 25
-		"Small Mining [2]: active" < 3
+		"Mining, Small [2]: active" < 3
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 3
+		distance 1 3
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 	on complete
@@ -71,18 +71,18 @@ mission "Small Mining [2]"
 		payment 29000
 		dialog "You drop off the titanium ore and collect your payment of <payment>."
 
-mission "Small Mining [3]"
+mission "Mining, Small [3]"
 	name "Mine copper for <planet>"
 	description "Mine 10 tons of copper from asteroids and deliver them to <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 20
-		"Small Mining [3]: active" < 3
+		"Mining, Small [3]: active" < 3
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 4
+		distance 1 4
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 		attributes "military" "factory"
@@ -92,18 +92,18 @@ mission "Small Mining [3]"
 		payment 34500
 		dialog "You drop off the copper ore and collect your payment of <payment>."
 
-mission "Small Mining [4]"
+mission "Mining, Small [4]"
 	name "Mine neodymium for <planet>"
 	description "Mine 10 tons of neodymium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 20
-		"Small Mining [4]: active" < 3
+		"Mining, Small [4]: active" < 3
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 3
+		distance 1 3
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 	on complete
@@ -112,18 +112,18 @@ mission "Small Mining [4]"
 		payment 43700
 		dialog "You drop off the neodymium ore and collect your payment of <payment>."
 
-mission "Small Mining [5]"
+mission "Mining, Small [5]"
 	name "Mine tungsten for <planet>"
 	description "Mine 5 tons of tungsten from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 10
-		"Small Mining [5]: active" < 3
+		"Mining, Small [5]: active" < 3
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 3
+		distance 1 3
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
 		attributes shipyard
 		attributes "military" "factory"
@@ -133,18 +133,18 @@ mission "Small Mining [5]"
 		payment 25875
 		dialog "You drop off the tungsten ore and collect your payment of <payment>."
 
-mission "Small Mining [6]"
+mission "Mining, Small [6]"
 	name "Mine uranium for <planet>"
 	description "Mine 5 tons of uranium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 10
-		"Small Mining [6]: active" < 3
+		"Mining, Small [6]: active" < 3
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 3
+		distance 1 3
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
 		attributes shipyard
 		attributes "military" "factory"
@@ -156,20 +156,19 @@ mission "Small Mining [6]"
 
 
 
-mission "Medium Mining [0]"
+mission "Mining, Medium [0]"
 	name "Mine iron for <planet>"
 	description "Mine 30 tons of iron from asteroids and deliver them to the factories on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 15
-		"completed Fe orders" = "Small Mining [0]: done"
-		"completed Fe orders" += "Small Rush Mining [0]: done"
-		random < "completed iron orders"
+		"completed Fe orders" = "Mining, Small [0]: done" + "Mining, Expedited, Small [0]: done" + "Mining, Medium [0]: done"
+		random < "completed Fe orders"
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 5
+		distance 1 5
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes "factory"
 	on complete
@@ -178,20 +177,19 @@ mission "Medium Mining [0]"
 		payment 48000
 		dialog "You drop off the iron ore and collect your payment of <payment>."
 
-mission "Medium Mining [1]"
+mission "Mining, Medium [1]"
 	name "Mine aluminum for <planet>"
 	description "Mine 30 tons of aluminum from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 15
-		"completed Al orders" = "Small Mining [1]: done"
-		"completed Al orders" += "Small Rush Mining [1]: done"
+		"completed Al orders" = "Mining, Small [1]: done" + "Mining, Expedited, Small [1]: done" + "Mining, Medium [1]: done"
 		random < "completed Al orders"
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 4
+		distance 1 4
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 	on complete
@@ -200,20 +198,19 @@ mission "Medium Mining [1]"
 		payment 66000
 		dialog "You drop off the aluminum ore and collect your payment of <payment>."
 
-mission "Medium Mining [2]"
+mission "Mining, Medium [2]"
 	name "Mine titanium for <planet>"
 	description "Mine 30 tons of titanium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 15
-		"completed Ti orders" = "Small Mining [2]: done"
-		"completed Ti orders" += "Small Rush Mining [2]: done"
+		"completed Ti orders" = "Mining, Small [2]: done" + "Mining, Expedited, Small [2]: done" + "Mining, Medium [2]: done"
 		random < "completed Ti orders"
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 4
+		distance 1 4
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 		attributes "military" "factory"
@@ -223,20 +220,19 @@ mission "Medium Mining [2]"
 		payment 87000
 		dialog "You drop off the titanium ore and collect your payment of <payment>."
 
-mission "Medium Mining [3]"
+mission "Mining, Medium [3]"
 	name "Mine copper for <planet>"
 	description "Mine 30 tons of copper from asteroids and deliver them to <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 10
-		"completed Cu orders" = "Small Mining [3]: done"
-		"completed Cu orders" += "Small Rush Mining [3]: done"
+		"completed Cu orders" = "Mining, Small [3]: done" + "Mining, Expedited, Small [3]: done" + "Mining, Medium [3]: done"
 		random < "completed Cu orders"
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 5
+		distance 1 5
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 		attributes "military" "factory"
@@ -246,20 +242,19 @@ mission "Medium Mining [3]"
 		payment 103500
 		dialog "You drop off the copper ore and collect your payment of <payment>."
 
-mission "Medium Mining [4]"
+mission "Mining, Medium [4]"
 	name "Mine neodymium for <planet>"
 	description "Mine 30 tons of neodymium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 10
-		"completed Nd orders" = "Small Mining [4]: done"
-		"completed Nd orders" += "Small Rush Mining [4]: done"
+		"completed Nd orders" = "Mining, Small [4]: done" + "Mining, Expedited, Small [4]: done" + "Mining, Medium [4]: done"
 		random < "completed Nd orders"
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 4
+		distance 1 4
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 		attributes "military" "factory"
@@ -269,20 +264,19 @@ mission "Medium Mining [4]"
 		payment 131100
 		dialog "You drop off the neodymium ore and collect your payment of <payment>."
 
-mission "Medium Mining [5]"
+mission "Mining, Medium [5]"
 	name "Mine tungsten for <planet>"
 	description "Mine 15 tons of tungsten from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 5
-		"completed W orders" = "Small Mining [5]: done"
-		"completed W orders" += "Small Rush Mining [5]: done"
+		"completed W orders" = "Mining, Small [5]: done" + "Mining, Expedited, Small [5]: done" + "Mining, Medium [5]: done"
 		random < "completed W orders"
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 4
+		distance 1 4
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
 		attributes shipyard
 		attributes "military" "factory"
@@ -292,20 +286,19 @@ mission "Medium Mining [5]"
 		payment 77625
 		dialog "You drop off the tungsten ore and collect your payment of <payment>."
 
-mission "Medium Mining [6]"
+mission "Mining, Medium [6]"
 	name "Mine uranium for <planet>"
 	description "Mine 15 tons of uranium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
 	repeat
 	to offer
 		random < 5
-		"completed U orders" = "Small Mining [6]: done"
-		"completed U orders" += "Small Rush Mining [6]: done"
+		"completed U orders" = "Mining, Small [6]: done" + "Mining, Expedited, Small [6]: done" + "Mining, Medium [6]: done"
 		random < "completed U orders"
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 4
+		distance 1 4
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
 		attributes shipyard
 		attributes "military" "factory"
@@ -317,7 +310,7 @@ mission "Medium Mining [6]"
 
 
 
-mission "Large Mining [0]"
+mission "Mining, Large [0]"
 	name "Mine iron for <planet>"
 	description "Mine 150 tons of iron from asteroids and deliver them to the factories on <destination>. Payment is <payment>."
 	job
@@ -329,7 +322,7 @@ mission "Large Mining [0]"
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 5
+		distance 1 5
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes "factory"
 	on complete
@@ -338,7 +331,7 @@ mission "Large Mining [0]"
 		payment 240000
 		dialog "You drop off the iron ore and collect your payment of <payment>."
 
-mission "Large Mining [1]"
+mission "Mining, Large [1]"
 	name "Mine aluminum for <planet>"
 	description "Mine 120 tons of aluminum from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
 	job
@@ -350,7 +343,7 @@ mission "Large Mining [1]"
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 5
+		distance 1 5
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 		attributes "military" "factory"
@@ -360,7 +353,7 @@ mission "Large Mining [1]"
 		payment 264000
 		dialog "You drop off the aluminum ore and collect your payment of <payment>."
 
-mission "Large Mining [Si]"
+mission "Mining, Large [Si]"
 	name "Mine silicon for <planet>"
 	description "Mine 150 tons of silicon from asteroids and deliver them to the factories on <destination>. Payment is <payment>."
 	job
@@ -372,7 +365,7 @@ mission "Large Mining [Si]"
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 5
+		distance 1 5
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes "factory"
 	on complete
@@ -384,7 +377,8 @@ mission "Large Mining [Si]"
 
 
 # Rush mining pays a bonus of 800 per ton, or 25% of the payload value.
-mission "Small Rush Mining [0]"
+# "Expedited" used so that all rush mining jobs are checked before non-rush mining jobs.
+mission "Mining, Expedited, Small [0]"
 	name "Urgent iron mining request"
 	description "Mine 10 tons of iron from asteroids and deliver them to the factories on <destination> by <date>. Payment is <payment>."
 	job
@@ -393,11 +387,11 @@ mission "Small Rush Mining [0]"
 	cargo "Rush Order: Iron" 1
 	to offer
 		random < 15
-		"Small Mining [0]: done" > 4
+		"Mining, Small [0]: done" > 4
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 4
+		distance 1 4
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes "factory"
 	on complete
@@ -405,9 +399,9 @@ mission "Small Rush Mining [0]"
 		"rush mining deliveries"++
 		outfit "Iron" -10
 		payment 20000 31
-		dialog "You drop off the iron ore and collect your payment of <payment>."
+		dialog "The factory's supervisor thanks you for delivering the iron ore on time and pays you <payment>."
 
-mission "Small Rush Mining [1]"
+mission "Mining, Expedited, Small [1]"
 	name "Urgent aluminum mining request"
 	description "Mine 10 tons of aluminum from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -416,11 +410,11 @@ mission "Small Rush Mining [1]"
 	cargo "Rush Order: Aluminum" 1
 	to offer
 		random < 15
-		"Small Mining [1]: done" > 4
+		"Mining, Small [1]: done" > 4
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 3
+		distance 1 3
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 	on complete
@@ -428,9 +422,9 @@ mission "Small Rush Mining [1]"
 		"rush mining deliveries"++
 		outfit "Aluminum" -10
 		payment 26000 31
-		dialog "You drop off the aluminum ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the aluminum ore on time and pays you <payment>."
 
-mission "Small Rush Mining [2]"
+mission "Mining, Expedited, Small [2]"
 	name "Urgent titanium mining request"
 	description "Mine 10 tons of titanium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -439,11 +433,11 @@ mission "Small Rush Mining [2]"
 	cargo "Rush Order: Titanium" 1
 	to offer
 		random < 15
-		"Small Mining [2]: done" > 4
+		"Mining, Small [2]: done" > 4
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 3
+		distance 1 3
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 	on complete
@@ -451,9 +445,9 @@ mission "Small Rush Mining [2]"
 		"rush mining deliveries"++
 		outfit "Titanium" -10
 		payment 33000 31
-		dialog "You drop off the titanium ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the titanium ore on time and pays you <payment>."
 
-mission "Small Rush Mining [3]"
+mission "Mining, Expedited, Small [3]"
 	name "Urgent copper mining request"
 	description "Mine 10 tons of copper from asteroids and deliver them to <destination> by <date>. Payment is <payment>."
 	job
@@ -462,12 +456,11 @@ mission "Small Rush Mining [3]"
 	cargo "Rush Order: Copper" 1
 	to offer
 		random < 10
-		"Small Mining [3]: done" > 4
+		"Mining, Small [3]: done" > 4
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		"mining deliveries"++
-		distance 0 7
+		distance 1 7
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 		attributes "military" "factory"
@@ -478,7 +471,7 @@ mission "Small Rush Mining [3]"
 		payment 38000 31
 		dialog "You drop off the copper ore and collect your payment of <payment>."
 
-mission "Small Rush Mining [4]"
+mission "Mining, Expedited, Small [4]"
 	name "Urgent neodymium mining request"
 	description "Mine 10 tons of neodymium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -487,11 +480,11 @@ mission "Small Rush Mining [4]"
 	cargo "Rush Order: Neodymium" 1
 	to offer
 		random < 10
-		"Small Mining [4]: done" > 4
+		"Mining, Small [4]: done" > 4
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 3
+		distance 1 3
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 	on complete
@@ -499,9 +492,9 @@ mission "Small Rush Mining [4]"
 		"rush mining deliveries"++
 		outfit "Neodymium" -10
 		payment 47500 31
-		dialog "You drop off the neodymium ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the neodymium ore on time and pays you <payment>."
 
-mission "Small Rush Mining [5]"
+mission "Mining, Expedited, Small [5]"
 	name "Urgent tungsten mining request"
 	description "Mine 5 tons of tungsten from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -510,7 +503,7 @@ mission "Small Rush Mining [5]"
 	cargo "Rush Order: Tungsten" 1
 	to offer
 		random < 5
-		"Small Mining [5]: done" > 4
+		"Mining, Small [5]: done" > 4
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
@@ -523,9 +516,9 @@ mission "Small Rush Mining [5]"
 		"rush mining deliveries"++
 		outfit "Tungsten" -5
 		payment 28125 31
-		dialog "You drop off the tungsten ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the tungsten ore on time and pays you <payment>."
 
-mission "Small Rush Mining [6]"
+mission "Mining, Expedited, Small [6]"
 	name "Urgent uranium mining request"
 	description "Mine 5 tons of uranium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -534,7 +527,7 @@ mission "Small Rush Mining [6]"
 	cargo "Rush Order: Uranium" 1
 	to offer
 		random < 5
-		"Small Mining [6]: done" > 4
+		"Mining, Small [6]: done" > 4
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
@@ -547,11 +540,11 @@ mission "Small Rush Mining [6]"
 		"rush mining deliveries"++
 		outfit "Uranium" -5
 		payment 31250 31
-		dialog "You drop off the uranium ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the uranium ore on time and pays you <payment>."
 
 
 
-mission "Medium Rush Mining [0]"
+mission "Mining, Expedited, Medium [0]"
 	name "Urgent iron mining request"
 	description "Mine 30 tons of iron from asteroids and deliver them to the factories on <destination> by <date>. Payment is <payment>."
 	job
@@ -561,11 +554,11 @@ mission "Medium Rush Mining [0]"
 	to offer
 		random < 15
 		"rush mining deliveries" > 20
-		"Small Rush Mining [0]: done" > 2
+		"Mining, Expedited, Small [0]: done" > 2
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 5
+		distance 1 5
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes "factory"
 	on complete
@@ -573,9 +566,9 @@ mission "Medium Rush Mining [0]"
 		"rush mining deliveries"++
 		outfit "Iron" -30
 		payment 60000 41
-		dialog "You drop off the iron ore and collect your payment of <payment>."
+		dialog "The factory's supervisor thanks you for delivering the iron ore on time and pays you <payment>."
 
-mission "Medium Rush Mining [1]"
+mission "Mining, Expedited, Medium [1]"
 	name "Urgent aluminum mining request"
 	description "Mine 30 tons of aluminum from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -585,11 +578,11 @@ mission "Medium Rush Mining [1]"
 	to offer
 		random < 15
 		"rush mining deliveries" > 20
-		"Small Rush Mining [1]: done" > 2
+		"Mining, Expedited, Small [1]: done" > 2
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
-		distance 0 4
+		distance 1 4
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 		attributes shipyard
 	on complete
@@ -597,9 +590,9 @@ mission "Medium Rush Mining [1]"
 		"rush mining deliveries"++
 		outfit "Aluminum" -30
 		payment 78000 41
-		dialog "You drop off the aluminum ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the aluminum ore on time and pays you <payment>."
 
-mission "Medium Rush Mining [2]"
+mission "Mining, Expedited, Medium [2]"
 	name "Urgent titanium mining request"
 	description "Mine 30 tons of titanium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -609,7 +602,7 @@ mission "Medium Rush Mining [2]"
 	to offer
 		random < 15
 		"rush mining deliveries" > 20
-		"Small Rush Mining [2]: done" > 2
+		"Mining, Expedited, Small [2]: done" > 2
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
@@ -622,9 +615,9 @@ mission "Medium Rush Mining [2]"
 		"rush mining deliveries"++
 		outfit "Titanium" -30
 		payment 99000 41
-		dialog "You drop off the titanium ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the titanium ore on time and pays you <payment>."
 
-mission "Medium Rush Mining [3]"
+mission "Mining, Expedited, Medium [3]"
 	name "Urgent copper mining request"
 	description "Mine 30 tons of copper from asteroids and deliver them to <destination> by <date>. Payment is <payment>."
 	job
@@ -634,7 +627,7 @@ mission "Medium Rush Mining [3]"
 	to offer
 		random < 10
 		"rush mining deliveries" > 20
-		"Small Rush Mining [3]: done" > 2
+		"Mining, Expedited, Small [3]: done" > 2
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
@@ -649,7 +642,7 @@ mission "Medium Rush Mining [3]"
 		payment 114000 41
 		dialog "You drop off the copper ore and collect your payment of <payment>."
 
-mission "Medium Rush Mining [4]"
+mission "Mining, Expedited, Medium [4]"
 	name "Urgent neodymium mining request"
 	description "Mine 30 tons of neodymium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -659,7 +652,7 @@ mission "Medium Rush Mining [4]"
 	to offer
 		random < 10
 		"rush mining deliveries" > 20
-		"Small Rush Mining [4]: done" > 2
+		"Mining, Expedited, Small [4]: done" > 2
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
@@ -672,9 +665,9 @@ mission "Medium Rush Mining [4]"
 		"rush mining deliveries"++
 		outfit "Neodymium" -30
 		payment 142500 41
-		dialog "You drop off the neodymium ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the neodymium ore on time and pays you <payment>."
 
-mission "Medium Rush Mining [5]"
+mission "Mining, Expedited, Medium [5]"
 	name "Urgent tungsten mining request"
 	description "Mine 15 tons of tungsten from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -684,7 +677,7 @@ mission "Medium Rush Mining [5]"
 	to offer
 		random < 5
 		"rush mining deliveries" > 20
-		"Small Rush Mining [5]: done" > 2
+		"Mining, Expedited, Small [5]: done" > 2
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
@@ -697,9 +690,9 @@ mission "Medium Rush Mining [5]"
 		"rush mining deliveries"++
 		outfit "Tungsten" -15
 		payment 84375 41
-		dialog "You drop off the tungsten ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the tungsten ore on time and pays you <payment>."
 
-mission "Medium Rush Mining [6]"
+mission "Mining, Expedited, Medium [6]"
 	name "Urgent uranium mining request"
 	description "Mine 15 tons of uranium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -709,7 +702,7 @@ mission "Medium Rush Mining [6]"
 	to offer
 		random < 5
 		"rush mining deliveries" > 20
-		"Small Rush Mining [6]: done" > 2
+		"Mining, Expedited, Small [6]: done" > 2
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
@@ -722,11 +715,11 @@ mission "Medium Rush Mining [6]"
 		"rush mining deliveries"++
 		outfit "Uranium" -15
 		payment 93750 41
-		dialog "You drop off the uranium ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the uranium ore on time and pays you <payment>."
 
 
 
-mission "Large Rush Mining [0]"
+mission "Mining, Expedited, Large [0]"
 	name "Large urgent iron mining request"
 	description "Mine 150 tons of iron from asteroids and deliver them to the factories on <destination> by <date>. Payment is <payment>."
 	job
@@ -736,7 +729,7 @@ mission "Large Rush Mining [0]"
 	to offer
 		random < 10
 		"cargo space" > 150
-		"Medium Rush Mining [0]: done" > 5
+		"Mining, Expedited, Medium [0]: done" > 5
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
@@ -748,9 +741,9 @@ mission "Large Rush Mining [0]"
 		"rush mining deliveries"++
 		outfit "Iron" -150
 		payment 300000 53
-		dialog "You drop off the iron ore and collect your payment of <payment>."
+		dialog "The factory's supervisor thanks you for delivering the iron ore on time and pays you <payment>."
 
-mission "Large Rush Mining [1]"
+mission "Mining, Expedited, Large [1]"
 	name "Large urgent aluminum mining request"
 	description "Mine 120 tons of aluminum from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
 	job
@@ -760,7 +753,7 @@ mission "Large Rush Mining [1]"
 	to offer
 		random < 10
 		"cargo space" > 120
-		"Medium Rush Mining [1]: done" > 5
+		"Mining, Expedited, Medium [1]: done" > 5
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
@@ -773,9 +766,9 @@ mission "Large Rush Mining [1]"
 		"rush mining deliveries"++
 		outfit "Aluminum" -120
 		payment 312000 53
-		dialog "You drop off the aluminum ore and collect your payment of <payment>."
+		dialog "The shipyard's supervisor thanks you for delivering the aluminum ore on time and pays you <payment>."
 
-mission "Large Rush Mining [Si]"
+mission "Mining, Expedited, Large [Si]"
 	name "Large urgent silicon mining request"
 	description "Mine 150 tons of silicon from asteroids and deliver them to the factories on <destination> by <date>. Payment is <payment>."
 	job
@@ -785,7 +778,7 @@ mission "Large Rush Mining [Si]"
 	to offer
 		random < 10
 		"cargo space" > 150
-		"Large Mining [Si]: done" > 5
+		"Mining, Large [Si]: done" > 5
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
 	destination
@@ -797,4 +790,76 @@ mission "Large Rush Mining [Si]"
 		"rush mining deliveries"++
 		outfit "Silicon" -150
 		payment 180000 53
-		dialog "You drop off the silicon ore and collect your payment of <payment>."
+		dialog "The factory's supervisor thanks you for delivering the silicon ore on time and pays you <payment>."
+
+
+
+# Since mission NPCs will fill up on cargo, they should always be given the
+# `uninterested` personality, at least until there is a way to tell an NPC to
+# travel to a planet after it fills up on cargo (rather than follow the player).
+# A random condition is given in the `to fail` to ensure active competition
+# missions actually offer competition for minables. Note that this condition
+# is checked twice before the mission is active when offered.
+
+# Competition for mining jobs in human space. Will not follow the player around.
+mission "Human Mining Competition [0]"
+	invisible
+	landing
+	repeat
+	minor
+	name "Human Miners"
+	source
+		near "Sol" 100
+	to offer
+		"Human Mining Competition [0]: active" < 10
+		"small_mining" = "Mining, Small [0]: active" + 2 * "Mining, Expedited, Small [0]: active"
+		"small_mining" += "Mining, Small [1]: active" + 2 * "Mining, Expedited, Small [1]: active"
+		"small_mining" += "Mining, Small [2]: active" + 2 * "Mining, Expedited, Small [2]: active"
+		"small_mining" += "Mining, Small [3]: active" + 2 * "Mining, Expedited, Small [3]: active"
+		"small_mining" += "Mining, Small [4]: active" + 2 * "Mining, Expedited, Small [4]: active"
+		"small_mining" += "Mining, Small [5]: active" + 2 * "Mining, Expedited, Small [5]: active"
+		"small_mining" += "Mining, Small [6]: active" + 2 * "Mining, Expedited, Small [6]: active"
+		"med_mining" = "Mining, Medium [0]: active" + 2 * "Mining, Expedited, Medium [0]: active"
+		"med_mining" += "Mining, Medium [1]: active" + 2 * "Mining, Expedited, Medium [1]: active"
+		"med_mining" += "Mining, Medium [2]: active" + 2 * "Mining, Expedited, Medium [2]: active"
+		"med_mining" += "Mining, Medium [3]: active" + 2 * "Mining, Expedited, Medium [3]: active"
+		"med_mining" += "Mining, Medium [4]: active" + 2 * "Mining, Expedited, Medium [4]: active"
+		"med_mining" += "Mining, Medium [5]: active" + 2 * "Mining, Expedited, Medium [5]: active"
+		"med_mining" += "Mining, Medium [6]: active" + 2 * "Mining, Expedited, Medium [6]: active"
+		"large_mining" = "Mining, Large [0]: active" + 2 * "Mining, Expedited, Large [0]: active"
+		"large_mining" += "Mining, Large [1]: active" + 2 * "Mining, Expedited, Large [1]: active"
+		"large_mining" += "Mining, Large [Si]: active" + 2 * "Mining, Expedited, Large [Si]: active"
+		"mission_weight" = "small mining" * ( 1 + "med_mining" ) * ( 1 + "large_mining" )
+		random < "mission_weight"
+	to fail
+		random < 25
+	npc kill
+		government "Independent"
+		personality mining harvests uninterested
+		system
+			distance 4
+		fleet "Human Miners"
+	npc kill
+		government "Independent"
+		personality mining harvests uninterested
+		system
+			distance 4
+		fleet "Human Miners"
+	npc kill
+		government "Independent"
+		personality mining harvests uninterested
+		system
+			distance 4
+		fleet "Human Miners"
+	npc kill
+		government "Independent"
+		personality mining harvests uninterested
+		system
+			distance 4
+		fleet "Human Miners"
+	npc kill
+		government "Independent"
+		personality mining harvests uninterested
+		system
+			distance 4
+		fleet "Human Miners"

--- a/data/mining jobs.txt
+++ b/data/mining jobs.txt
@@ -1,0 +1,800 @@
+# Copyright (c) 2017 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+# The payment for mining jobs is the normal sale value, plus the larger of 400
+# credits per ton or 10% of the payload's value.
+
+mission "Small Mining [0]"
+	name "Mine iron for <planet>"
+	description "Mine 10 tons of iron from asteroids and deliver them to the factories on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 25
+		"Small Mining [0]: active" < 3
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 3
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Iron" -10
+		payment 16000
+		dialog "You drop off the iron ore and collect your payment of <payment>."
+
+mission "Small Mining [1]"
+	name "Mine aluminum for <planet>"
+	description "Mine 10 tons of aluminum from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 25
+		"Small Mining [1]: active" < 3
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 3
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+	on complete
+		"mining deliveries"++
+		outfit "Aluminum" -10
+		payment 22000
+		dialog "You drop off the aluminum ore and collect your payment of <payment>."
+
+mission "Small Mining [2]"
+	name "Mine titanium for <planet>"
+	description "Mine 10 tons of titanium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 25
+		"Small Mining [2]: active" < 3
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 3
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+	on complete
+		"mining deliveries"++
+		outfit "Titanium" -10
+		payment 29000
+		dialog "You drop off the titanium ore and collect your payment of <payment>."
+
+mission "Small Mining [3]"
+	name "Mine copper for <planet>"
+	description "Mine 10 tons of copper from asteroids and deliver them to <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 20
+		"Small Mining [3]: active" < 3
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 4
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Copper" -10
+		payment 34500
+		dialog "You drop off the copper ore and collect your payment of <payment>."
+
+mission "Small Mining [4]"
+	name "Mine neodymium for <planet>"
+	description "Mine 10 tons of neodymium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 20
+		"Small Mining [4]: active" < 3
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 3
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+	on complete
+		"mining deliveries"++
+		outfit "Neodymium" -10
+		payment 43700
+		dialog "You drop off the neodymium ore and collect your payment of <payment>."
+
+mission "Small Mining [5]"
+	name "Mine tungsten for <planet>"
+	description "Mine 5 tons of tungsten from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 10
+		"Small Mining [5]: active" < 3
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 3
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Tungsten" -5
+		payment 25875
+		dialog "You drop off the tungsten ore and collect your payment of <payment>."
+
+mission "Small Mining [6]"
+	name "Mine uranium for <planet>"
+	description "Mine 5 tons of uranium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 10
+		"Small Mining [6]: active" < 3
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 3
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Uranium" -5
+		payment 28750
+		dialog "You drop off the uranium ore and collect your payment of <payment>."
+
+
+
+mission "Medium Mining [0]"
+	name "Mine iron for <planet>"
+	description "Mine 30 tons of iron from asteroids and deliver them to the factories on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 15
+		"completed Fe orders" = "Small Mining [0]: done"
+		"completed Fe orders" += "Small Rush Mining [0]: done"
+		random < "completed iron orders"
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 5
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Iron" -30
+		payment 48000
+		dialog "You drop off the iron ore and collect your payment of <payment>."
+
+mission "Medium Mining [1]"
+	name "Mine aluminum for <planet>"
+	description "Mine 30 tons of aluminum from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 15
+		"completed Al orders" = "Small Mining [1]: done"
+		"completed Al orders" += "Small Rush Mining [1]: done"
+		random < "completed Al orders"
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 4
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+	on complete
+		"mining deliveries"++
+		outfit "Aluminum" -30
+		payment 66000
+		dialog "You drop off the aluminum ore and collect your payment of <payment>."
+
+mission "Medium Mining [2]"
+	name "Mine titanium for <planet>"
+	description "Mine 30 tons of titanium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 15
+		"completed Ti orders" = "Small Mining [2]: done"
+		"completed Ti orders" += "Small Rush Mining [2]: done"
+		random < "completed Ti orders"
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 4
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Titanium" -30
+		payment 87000
+		dialog "You drop off the titanium ore and collect your payment of <payment>."
+
+mission "Medium Mining [3]"
+	name "Mine copper for <planet>"
+	description "Mine 30 tons of copper from asteroids and deliver them to <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 10
+		"completed Cu orders" = "Small Mining [3]: done"
+		"completed Cu orders" += "Small Rush Mining [3]: done"
+		random < "completed Cu orders"
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 5
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Copper" -30
+		payment 103500
+		dialog "You drop off the copper ore and collect your payment of <payment>."
+
+mission "Medium Mining [4]"
+	name "Mine neodymium for <planet>"
+	description "Mine 30 tons of neodymium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 10
+		"completed Nd orders" = "Small Mining [4]: done"
+		"completed Nd orders" += "Small Rush Mining [4]: done"
+		random < "completed Nd orders"
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 4
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Neodymium" -30
+		payment 131100
+		dialog "You drop off the neodymium ore and collect your payment of <payment>."
+
+mission "Medium Mining [5]"
+	name "Mine tungsten for <planet>"
+	description "Mine 15 tons of tungsten from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 5
+		"completed W orders" = "Small Mining [5]: done"
+		"completed W orders" += "Small Rush Mining [5]: done"
+		random < "completed W orders"
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 4
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Tungsten" -15
+		payment 77625
+		dialog "You drop off the tungsten ore and collect your payment of <payment>."
+
+mission "Medium Mining [6]"
+	name "Mine uranium for <planet>"
+	description "Mine 15 tons of uranium from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 5
+		"completed U orders" = "Small Mining [6]: done"
+		"completed U orders" += "Small Rush Mining [6]: done"
+		random < "completed U orders"
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 4
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Uranium" -15
+		payment 86250
+		dialog "You drop off the uranium ore and collect your payment of <payment>."
+
+
+
+mission "Large Mining [0]"
+	name "Mine iron for <planet>"
+	description "Mine 150 tons of iron from asteroids and deliver them to the factories on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 10
+		"cargo space" > 150
+		"mining deliveries" > 50
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 5
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Iron" -150
+		payment 240000
+		dialog "You drop off the iron ore and collect your payment of <payment>."
+
+mission "Large Mining [1]"
+	name "Mine aluminum for <planet>"
+	description "Mine 120 tons of aluminum from asteroids and deliver them to the shipyard on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 10
+		"cargo space" > 150
+		"mining deliveries" > 50
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 5
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Aluminum" -120
+		payment 264000
+		dialog "You drop off the aluminum ore and collect your payment of <payment>."
+
+mission "Large Mining [Si]"
+	name "Mine silicon for <planet>"
+	description "Mine 150 tons of silicon from asteroids and deliver them to the factories on <destination>. Payment is <payment>."
+	job
+	repeat
+	to offer
+		random < 10
+		"cargo space" > 150
+		"mining deliveries" > 50
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 5
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes "factory"
+	on complete
+		"mining deliveries"++
+		outfit "Silicon" -150
+		payment 120000
+		dialog "You drop off the silicon ore and collect your payment of <payment>."
+
+
+
+# Rush mining pays a bonus of 800 per ton, or 25% of the payload value.
+mission "Small Rush Mining [0]"
+	name "Urgent iron mining request"
+	description "Mine 10 tons of iron from asteroids and deliver them to the factories on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Iron" 1
+	to offer
+		random < 15
+		"Small Mining [0]: done" > 4
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 4
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Iron" -10
+		payment 20000 31
+		dialog "You drop off the iron ore and collect your payment of <payment>."
+
+mission "Small Rush Mining [1]"
+	name "Urgent aluminum mining request"
+	description "Mine 10 tons of aluminum from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Aluminum" 1
+	to offer
+		random < 15
+		"Small Mining [1]: done" > 4
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 3
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Aluminum" -10
+		payment 26000 31
+		dialog "You drop off the aluminum ore and collect your payment of <payment>."
+
+mission "Small Rush Mining [2]"
+	name "Urgent titanium mining request"
+	description "Mine 10 tons of titanium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Titanium" 1
+	to offer
+		random < 15
+		"Small Mining [2]: done" > 4
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 3
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Titanium" -10
+		payment 33000 31
+		dialog "You drop off the titanium ore and collect your payment of <payment>."
+
+mission "Small Rush Mining [3]"
+	name "Urgent copper mining request"
+	description "Mine 10 tons of copper from asteroids and deliver them to <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Copper" 1
+	to offer
+		random < 10
+		"Small Mining [3]: done" > 4
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		"mining deliveries"++
+		distance 0 7
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Copper" -10
+		payment 38000 31
+		dialog "You drop off the copper ore and collect your payment of <payment>."
+
+mission "Small Rush Mining [4]"
+	name "Urgent neodymium mining request"
+	description "Mine 10 tons of neodymium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Neodymium" 1
+	to offer
+		random < 10
+		"Small Mining [4]: done" > 4
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 3
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Neodymium" -10
+		payment 47500 31
+		dialog "You drop off the neodymium ore and collect your payment of <payment>."
+
+mission "Small Rush Mining [5]"
+	name "Urgent tungsten mining request"
+	description "Mine 5 tons of tungsten from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Tungsten" 1
+	to offer
+		random < 5
+		"Small Mining [5]: done" > 4
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 1 7
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Tungsten" -5
+		payment 28125 31
+		dialog "You drop off the tungsten ore and collect your payment of <payment>."
+
+mission "Small Rush Mining [6]"
+	name "Urgent uranium mining request"
+	description "Mine 5 tons of uranium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Uranium" 1
+	to offer
+		random < 5
+		"Small Mining [6]: done" > 4
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 1 7
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Uranium" -5
+		payment 31250 31
+		dialog "You drop off the uranium ore and collect your payment of <payment>."
+
+
+
+mission "Medium Rush Mining [0]"
+	name "Urgent iron mining request"
+	description "Mine 30 tons of iron from asteroids and deliver them to the factories on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Iron" 1
+	to offer
+		random < 15
+		"rush mining deliveries" > 20
+		"Small Rush Mining [0]: done" > 2
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 5
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Iron" -30
+		payment 60000 41
+		dialog "You drop off the iron ore and collect your payment of <payment>."
+
+mission "Medium Rush Mining [1]"
+	name "Urgent aluminum mining request"
+	description "Mine 30 tons of aluminum from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Aluminum" 1
+	to offer
+		random < 15
+		"rush mining deliveries" > 20
+		"Small Rush Mining [1]: done" > 2
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 0 4
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Aluminum" -30
+		payment 78000 41
+		dialog "You drop off the aluminum ore and collect your payment of <payment>."
+
+mission "Medium Rush Mining [2]"
+	name "Urgent titanium mining request"
+	description "Mine 30 tons of titanium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Titanium" 1
+	to offer
+		random < 15
+		"rush mining deliveries" > 20
+		"Small Rush Mining [2]: done" > 2
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 1 7
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Titanium" -30
+		payment 99000 41
+		dialog "You drop off the titanium ore and collect your payment of <payment>."
+
+mission "Medium Rush Mining [3]"
+	name "Urgent copper mining request"
+	description "Mine 30 tons of copper from asteroids and deliver them to <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Copper" 1
+	to offer
+		random < 10
+		"rush mining deliveries" > 20
+		"Small Rush Mining [3]: done" > 2
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 1 7
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Copper" -30
+		payment 114000 41
+		dialog "You drop off the copper ore and collect your payment of <payment>."
+
+mission "Medium Rush Mining [4]"
+	name "Urgent neodymium mining request"
+	description "Mine 30 tons of neodymium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Neodymium" 1
+	to offer
+		random < 10
+		"rush mining deliveries" > 20
+		"Small Rush Mining [4]: done" > 2
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 1 7
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Neodymium" -30
+		payment 142500 41
+		dialog "You drop off the neodymium ore and collect your payment of <payment>."
+
+mission "Medium Rush Mining [5]"
+	name "Urgent tungsten mining request"
+	description "Mine 15 tons of tungsten from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Tungsten" 1
+	to offer
+		random < 5
+		"rush mining deliveries" > 20
+		"Small Rush Mining [5]: done" > 2
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 1 7
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Tungsten" -15
+		payment 84375 41
+		dialog "You drop off the tungsten ore and collect your payment of <payment>."
+
+mission "Medium Rush Mining [6]"
+	name "Urgent uranium mining request"
+	description "Mine 15 tons of uranium from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 3 1.5
+	cargo "Rush Order: Uranium" 1
+	to offer
+		random < 5
+		"rush mining deliveries" > 20
+		"Small Rush Mining [6]: done" > 2
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 1 7
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Heliarch"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Uranium" -15
+		payment 93750 41
+		dialog "You drop off the uranium ore and collect your payment of <payment>."
+
+
+
+mission "Large Rush Mining [0]"
+	name "Large urgent iron mining request"
+	description "Mine 150 tons of iron from asteroids and deliver them to the factories on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 4 1.3
+	cargo "Rush Order: Iron" 1
+	to offer
+		random < 10
+		"cargo space" > 150
+		"Medium Rush Mining [0]: done" > 5
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 1 6
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Iron" -150
+		payment 300000 53
+		dialog "You drop off the iron ore and collect your payment of <payment>."
+
+mission "Large Rush Mining [1]"
+	name "Large urgent aluminum mining request"
+	description "Mine 120 tons of aluminum from asteroids and deliver them to the shipyard on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 4 1.3
+	cargo "Rush Order: Aluminum" 1
+	to offer
+		random < 10
+		"cargo space" > 120
+		"Medium Rush Mining [1]: done" > 5
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 1 6
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes shipyard
+		attributes "military" "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Aluminum" -120
+		payment 312000 53
+		dialog "You drop off the aluminum ore and collect your payment of <payment>."
+
+mission "Large Rush Mining [Si]"
+	name "Large urgent silicon mining request"
+	description "Mine 150 tons of silicon from asteroids and deliver them to the factories on <destination> by <date>. Payment is <payment>."
+	job
+	repeat
+	deadline 4 1.3
+	cargo "Rush Order: Silicon" 1
+	to offer
+		random < 10
+		"cargo space" > 150
+		"Large Mining [Si]: done" > 5
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+	destination
+		distance 1 6
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Wanderer" "Coalition"
+		attributes "factory"
+	on complete
+		"mining deliveries"++
+		"rush mining deliveries"++
+		outfit "Silicon" -150
+		payment 180000 53
+		dialog "You drop off the silicon ore and collect your payment of <payment>."

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -963,7 +963,7 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	
 	// Set the deadline, if requested.
 	if(deadlineBase || deadlineMultiplier)
-		result.deadline = player.GetDate() + deadlineBase + deadlineMultiplier * jumps;
+		result.deadline = player.GetDate() + deadlineBase + lround(deadlineMultiplier * jumps);
 	
 	// Copy the conditions. The offer conditions must be copied too, because they
 	// may depend on a condition that other mission offers might change.

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -160,7 +160,7 @@ private:
 	bool autosave = false;
 	Date deadline;
 	int deadlineBase = 0;
-	int deadlineMultiplier = 0;
+	double deadlineMultiplier = 0.;
 	std::string clearance;
 	LocationFilter clearanceFilter;
 	bool hasFullClearance = true;


### PR DESCRIPTION
Closes #2449 
Refs #2101 

Given the latest mission/job toolset in https://github.com/endless-sky/endless-sky/commit/11a30e0efc309d67f18d5e7212c81eac89fce8cd, I've updated @EndrosG 's PR to use the automatic shipyard attributes.
I've expanded upon her work and also clarified the file diffs, to simply the pre-merge review needed. To prevent the player from starting a bunch of high-quantity or rush jobs without knowing where to find some of the needed outfits, the player has to complete smaller jobs for a given minable first (which will place a marker for those minables in the player's map file when viewing the map->Outfitter and selecting the minable).

Summary:
 - Mining jobs for
    - Human
    - Hai
    - Coalition
    - Wanderer
 - Shipyard-based Delivery missions


While working on this, I came across a deprecated function declaration, and also determined that any missions that completed based on the ability to gift outfits do not display this dependence visually. Those two issues are rectified in #3075 