### PR TITLE
Fix partial commodity flotsam lifetime.

### DIFF
--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -37,7 +37,7 @@ Flotsam::Flotsam(const string &commodity, int count)
 	lifetime = Random::Int(300) + 360;
 	// Scale lifetime in proportion to the expected amount per box.
 	if(count != TONS_PER_BOX)
-		lifetime = sqrt(count / TONS_PER_BOX) * lifetime;
+		lifetime = sqrt(count * (1. / TONS_PER_BOX)) * lifetime;
 }
 
 


### PR DESCRIPTION
When I made the last commit of #2962 (57d3a7a) I introduced a bug while cleaning up the lifetime formulas I had been testing.

`count / TONS_PER_BOX` is an integer division and will produce a 0 lifetime for 1-4 ton flotsams.

Turned it into `count * (1. / TONS_PER_BOX)`, which is floating point multiplication with a one side constant.

Sorry about that. :(