### PR TITLE
Use a wormhole's actual position instead of the previous day's position

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -865,7 +865,7 @@ void Engine::EnterSystem()
 		// If ships use a wormhole, they are emitted from its center in
 		// its destination system. Player travel causes a date change,
 		// thus the wormhole's new position should be used.
-		flagship->Place(usedWormhole->Position(), flagship->Velocity(), flagship->Facing(), false);
+		flagship->SetPosition(usedWormhole->Position());
 		if(player.HasTravelPlan())
 		{
 			// Wormhole travel generally invalidates travel plans

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -536,32 +536,38 @@ int64_t Ship::ChassisCost() const
 
 
 
-void Ship::Place(Point position, Point velocity, Angle angle)
+// Non-member methods can use Ship::Place() with the boolean false to only
+// modify this ship's position, angle, and velocity.
+void Ship::Place(Point position, Point velocity, Angle angle, bool isNew)
 {
 	this->position = position;
 	this->velocity = velocity;
 	this->angle = angle;
-	// If landed, place the ship right above the planet.
-	if(landingPlanet)
+	
+	if(isNew)
 	{
-		landingPlanet = nullptr;
-		zoom = parent.lock() ? (-.2 + -.8 * Random::Real()) : 0.;
+		// If landed, place the ship right above the planet.
+		if(landingPlanet)
+		{
+			landingPlanet = nullptr;
+			zoom = parent.lock() ? (-.2 + -.8 * Random::Real()) : 0.;
+		}
+		else
+			zoom = 1.;
+		// Make sure various special status values are reset.
+		heat = IdleHeat();
+		ionization = 0.;
+		disruption = 0.;
+		slowness = 0.;
+		isInvisible = !HasSprite();
+		jettisoned.clear();
+		hyperspaceCount = 0;
+		forget = 1;
+		targetShip.reset();
+		shipToAssist.reset();
+		if(government)
+			SetSwizzle(customSwizzle >= 0 ? customSwizzle : government->GetSwizzle());
 	}
-	else
-		zoom = 1.;
-	// Make sure various special status values are reset.
-	heat = IdleHeat();
-	ionization = 0.;
-	disruption = 0.;
-	slowness = 0.;
-	isInvisible = !HasSprite();
-	jettisoned.clear();
-	hyperspaceCount = 0;
-	forget = 1;
-	targetShip.reset();
-	shipToAssist.reset();
-	if(government)
-		SetSwizzle(customSwizzle >= 0 ? customSwizzle : government->GetSwizzle());
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -536,38 +536,41 @@ int64_t Ship::ChassisCost() const
 
 
 
-// Non-member methods can use Ship::Place() with the boolean false to only
-// modify this ship's position, angle, and velocity.
-void Ship::Place(Point position, Point velocity, Angle angle, bool isNew)
+void Ship::SetPosition(Point position)
+{
+	this->position = position;
+}
+
+
+
+// Instantiate a newly-created ship in-flight.
+void Ship::Place(Point position, Point velocity, Angle angle)
 {
 	this->position = position;
 	this->velocity = velocity;
 	this->angle = angle;
 	
-	if(isNew)
+	// If landed, place the ship right above the planet.
+	if(landingPlanet)
 	{
-		// If landed, place the ship right above the planet.
-		if(landingPlanet)
-		{
-			landingPlanet = nullptr;
-			zoom = parent.lock() ? (-.2 + -.8 * Random::Real()) : 0.;
-		}
-		else
-			zoom = 1.;
-		// Make sure various special status values are reset.
-		heat = IdleHeat();
-		ionization = 0.;
-		disruption = 0.;
-		slowness = 0.;
-		isInvisible = !HasSprite();
-		jettisoned.clear();
-		hyperspaceCount = 0;
-		forget = 1;
-		targetShip.reset();
-		shipToAssist.reset();
-		if(government)
-			SetSwizzle(customSwizzle >= 0 ? customSwizzle : government->GetSwizzle());
+		landingPlanet = nullptr;
+		zoom = parent.lock() ? (-.2 + -.8 * Random::Real()) : 0.;
 	}
+	else
+		zoom = 1.;
+	// Make sure various special status values are reset.
+	heat = IdleHeat();
+	ionization = 0.;
+	disruption = 0.;
+	slowness = 0.;
+	isInvisible = !HasSprite();
+	jettisoned.clear();
+	hyperspaceCount = 0;
+	forget = 1;
+	targetShip.reset();
+	shipToAssist.reset();
+	if(government)
+		SetSwizzle(customSwizzle >= 0 ? customSwizzle : government->GetSwizzle());
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -122,7 +122,7 @@ public:
 	int64_t ChassisCost() const;
 	
 	// When creating a new ship, you must set the following:
-	void Place(Point position = Point(), Point velocity = Point(), Angle angle = Angle());
+	void Place(Point position = Point(), Point velocity = Point(), Angle angle = Angle(), bool isNew = true);
 	void SetName(const std::string &name);
 	void SetSystem(const System *system);
 	void SetPlanet(const Planet *planet);

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -121,8 +121,9 @@ public:
 	int64_t Cost() const;
 	int64_t ChassisCost() const;
 	
+	void SetPosition(Point position);
 	// When creating a new ship, you must set the following:
-	void Place(Point position = Point(), Point velocity = Point(), Angle angle = Angle(), bool isNew = true);
+	void Place(Point position = Point(), Point velocity = Point(), Angle angle = Angle());
 	void SetName(const std::string &name);
 	void SetSystem(const System *system);
 	void SetPlanet(const Planet *planet);


### PR DESCRIPTION
Refs #3083  

While no wormhole-like objects in the base game move far enough each day that the flagship's position is noticeably incorrect, mods do exist and the game might eventually have something like this.
