### PR TITLE
Prevent players from switching landing targets if they are already landing on a planet

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2663,7 +2663,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 			Audio::Play(Audio::Get("fail"));
 		
 		const StellarObject *target = ship.GetTargetStellar();
-		if(target && ship.Position().Distance(target->Position()) < target->Radius())
+		if(target && (ship.Position().Distance(target->Position()) < target->Radius() || ship.Zoom() < 1.))
 		{
 			// Special case: if there are two planets in system and you have one
 			// selected, then press "land" again, do not toggle to the other if

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1082,26 +1082,32 @@ void Engine::CalculateStep()
 			double r = max(2., object.Radius() * .03 + .5);
 			radar[calcTickTock].Add(object.RadarType(flagship), object.Position(), r, r - 1.);
 			
-			if(object.GetPlanet())
-				object.GetPlanet()->DeployDefense(ships);
-			
-			Point position = object.Position() - newCenter;
-			if(checkClicks && !isRightClick && object.GetPlanet() && object.GetPlanet()->IsAccessible(flagship)
-					&& (clickPoint - position).Length() < object.Radius() && flagship->Zoom() == 1.)
+			const Planet *planet = object.GetPlanet();
+			if(planet)
 			{
-				if(&object == player.Flagship()->GetTargetStellar())
+				planet->DeployDefense(ships);
+				
+				// If the player clicked to land on a planet,
+				// do so unless already landing elsewhere.
+				Point position = object.Position() - newCenter;
+				if(checkClicks && !isRightClick && flagship->Zoom() == 1.
+						&& planet->IsAccessible(flagship)
+						&& (clickPoint - position).Length() < object.Radius())
 				{
-					if(!object.GetPlanet()->CanLand(*flagship))
-						Messages::Add("The authorities on " + object.GetPlanet()->Name() +
-							" refuse to let you land.");
-					else
+					if(&object == flagship->GetTargetStellar())
 					{
-						clickCommands |= Command::LAND;
-						Messages::Add("Landing on " + object.GetPlanet()->Name() + ".");
+						if(!planet->CanLand(*flagship))
+							Messages::Add("The authorities on " + planet->Name()
+									+ " refuse to let you land.");
+						else
+						{
+							clickCommands |= Command::LAND;
+							Messages::Add("Landing on " + planet->Name() + ".");
+						}
 					}
+					else
+						player.Flagship()->SetTargetStellar(&object);
 				}
-				else
-					player.Flagship()->SetTargetStellar(&object);
 			}
 		}
 	

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1087,7 +1087,7 @@ void Engine::CalculateStep()
 			
 			Point position = object.Position() - newCenter;
 			if(checkClicks && !isRightClick && object.GetPlanet() && object.GetPlanet()->IsAccessible(flagship)
-					&& (clickPoint - position).Length() < object.Radius())
+					&& (clickPoint - position).Length() < object.Radius() && flagship->Zoom() == 1.)
 			{
 				if(&object == player.Flagship()->GetTargetStellar())
 				{


### PR DESCRIPTION
In the `master` branch, I have noticed that if there is more than one planet in a system, you can land on one planet, then just before the planet panel pops up, you can click on the other planet. This makes your ship (which is _really_ small by now) fly off toward the second planet you clicked on - but it brings up the first planet's panel. 

This PR prevents this by not allowing other planets to be targeted (besides the current one) if the player is already in the process of landing.