### PR TITLE
Pop-ups cancel drag actions

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -25,6 +25,8 @@ color "fuel" .70 .62 .43 .75
 
 color "flagship highlight" .5 .8 .2 0.
 
+color "drag select" .2 1. 0. 0.
+
 color "available job" .9 .6 0. 1.
 color "available back" .5 .3 0. .5
 color "unavailable job" .5 .3 0. 1.

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -151,17 +151,22 @@ void MainPanel::Draw()
 	
 	if(isDragging)
 	{
-		Color color(.2, 1., 0., 0.);
-		LineShader::Draw(dragSource, Point(dragSource.X(), dragPoint.Y()), .8, color);
-		LineShader::Draw(Point(dragSource.X(), dragPoint.Y()), dragPoint, .8, color);
-		LineShader::Draw(dragPoint, Point(dragPoint.X(), dragSource.Y()), .8, color);
-		LineShader::Draw(Point(dragPoint.X(), dragSource.Y()), dragSource, .8, color);
+		if(canDrag)
+		{
+			static const Color dragColor = *GameData::Colors().Get("drag select");
+			LineShader::Draw(dragSource, Point(dragSource.X(), dragPoint.Y()), .8, dragColor);
+			LineShader::Draw(Point(dragSource.X(), dragPoint.Y()), dragPoint, .8, dragColor);
+			LineShader::Draw(dragPoint, Point(dragPoint.X(), dragSource.Y()), .8, dragColor);
+			LineShader::Draw(Point(dragPoint.X(), dragSource.Y()), dragSource, .8, dragColor);
+		}
+		else
+			isDragging = false;
 	}
 	
 	if(Preferences::Has("Show CPU / GPU load"))
 	{
 		string loadString = to_string(lround(load * 100.)) + "% GPU";
-		Color color = *GameData::Colors().Get("medium");
+		static const Color color = *GameData::Colors().Get("medium");
 		FontSet::Get(14).Draw(loadString, Point(10., Screen::Height() * -.5 + 5.), color);
 	
 		loadSum += loadTimer.Time();

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -153,7 +153,7 @@ void MainPanel::Draw()
 	{
 		if(canDrag)
 		{
-			static const Color dragColor = *GameData::Colors().Get("drag select");
+			const Color &dragColor = *GameData::Colors().Get("drag select");
 			LineShader::Draw(dragSource, Point(dragSource.X(), dragPoint.Y()), .8, dragColor);
 			LineShader::Draw(Point(dragSource.X(), dragPoint.Y()), dragPoint, .8, dragColor);
 			LineShader::Draw(dragPoint, Point(dragPoint.X(), dragSource.Y()), .8, dragColor);
@@ -166,7 +166,7 @@ void MainPanel::Draw()
 	if(Preferences::Has("Show CPU / GPU load"))
 	{
 		string loadString = to_string(lround(load * 100.)) + "% GPU";
-		static const Color color = *GameData::Colors().Get("medium");
+		const Color &color = *GameData::Colors().Get("medium");
 		FontSet::Get(14).Draw(loadString, Point(10., Screen::Height() * -.5 + 5.), color);
 	
 		loadSum += loadTimer.Time();


### PR DESCRIPTION
 - If a conversation, dialog, or other panel is generated while the player is dragging, stop drawing the drag box and reset the drag status.

Refs #3093 