### PR TITLE
More feedback in HailPanel

### DIFF
--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -165,7 +165,7 @@ void HailPanel::Draw()
 		{
 			if(ship->GetGovernment()->IsEnemy())
 				info.SetCondition("can bribe");
-			else if(!ship->CanBeCarried())
+			else if(!ship->CanBeCarried() && ship->GetShipToAssist() != player.FlagshipPtr())
 				info.SetCondition("can assist");
 		}
 	}

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -96,16 +96,20 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 			canGiveFuel = false;
 			canRepair = false;
 		}
-			
-		if(canGiveFuel || canRepair)
+		
+		if(ship->GetShipToAssist() == player.FlagshipPtr())
+			message = "Hang on, we'll be there in a minute.";
+		else if(canGiveFuel || canRepair)
+		{
 			message = "Looks like you've gotten yourself into a bit of trouble. "
 				"Would you like us to ";
-		if(canGiveFuel && canRepair)
-			message += "patch you up and give you some fuel?";
-		else if(canGiveFuel)
-			message += "give you some fuel?";
-		else if(canRepair)
-			message += "patch you up?";
+			if(canGiveFuel && canRepair)
+				message += "patch you up and give you some fuel?";
+			else if(canGiveFuel)
+				message += "give you some fuel?";
+			else if(canRepair)
+				message += "patch you up?";
+		}
 	}
 	
 	if(message.empty())


### PR DESCRIPTION
When you asked for help you had to read the text to know if the ship was really coming to assisting you.

Now you just have to glance at the grayed out help button to see that they decided to assist you.
To keep the dialog consistent in other hail attempts, it will repeat the positive reply message if it's already coming to assist you.