### PR TITLE
Also show minimap while preparing to jump.

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -288,8 +288,7 @@ void Engine::Step(bool isActive)
 			doEnter = false;
 			events.emplace_back(flagship, flagship, ShipEvent::JUMP);
 		}
-		if(flagship->IsEnteringHyperspace() || flagship->Commands().Has(Command::JUMP)
-				|| (flagship->Commands().Has(Command::WAIT) && !flagship->IsHyperspacing()))
+		if(flagship->IsEnteringHyperspace() || flagship->Commands().Has(Command::JUMP))
 		{
 			if(jumpCount < 100)
 				++jumpCount;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -288,7 +288,7 @@ void Engine::Step(bool isActive)
 			doEnter = false;
 			events.emplace_back(flagship, flagship, ShipEvent::JUMP);
 		}
-		if(flagship->IsEnteringHyperspace()
+		if(flagship->IsEnteringHyperspace() || flagship->Commands().Has(Command::JUMP)
 				|| (flagship->Commands().Has(Command::WAIT) && !flagship->IsHyperspacing()))
 		{
 			if(jumpCount < 100)


### PR DESCRIPTION
I can see when all jumps are done (minimap disappears).
It is easier to cancel a wrong jump (minimap is visible longer).

I also wanted to show the travel plan in the minimap but that is better done after some refactoring, which I'm not comfortable in doing right now.