### PR TITLE
"Follow" order uses station-keeping rather than circle-around

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -123,7 +123,7 @@ void AI::IssueShipTarget(const PlayerInfo &player, const std::shared_ptr<Ship> &
 {
 	Orders newOrders;
 	bool isEnemy = target->GetGovernment()->IsEnemy();
-	newOrders.type = (!isEnemy ? Orders::GATHER
+	newOrders.type = (!isEnemy ? Orders::KEEP_STATION
 		: target->IsDisabled() ? Orders::FINISH_OFF : Orders::ATTACK); 
 	newOrders.target = target;
 	string description = (isEnemy ? "focusing fire on" : "following") + (" \"" + target->Name() + "\".");


### PR DESCRIPTION
Orders::KEEP_STATION is currently unused (never set by a command issued by the player), but code to handle it is implemented.

This PR changes the order given when right-clicking a non-hostile ship from `Orders::GATHER` (which calls `AI::CircleAround`) to `Orders::KEEP_STATION` (which calls `AI::KeepStation`).

With this change, telling an escort to follow a ship will result in your escort matching that ships' orientation, position, and speed - which is ostensibly more of a "follow" behavior than circling.