### PR TITLE
Support 'visit' & 'visit planet' in events

### DIFF
--- a/source/GameEvent.cpp
+++ b/source/GameEvent.cpp
@@ -19,6 +19,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "PlayerInfo.h"
 #include "System.h"
 
+#include <set>
+#include <string>
+
 using namespace std;
 
 
@@ -30,18 +33,32 @@ void GameEvent::Load(const DataNode &node)
 	if(node.Size() >= 2)
 		conditionsToApply.Add("set", "event: " + node.Token(1));
 	
+	static const set<string> allowedChanges = {
+		"fleet",
+		"galaxy",
+		"government",
+		"link",
+		"outfitter",
+		"planet",
+		"shipyard",
+		"system",
+		"unlink"
+	};
+	
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "date" && child.Size() >= 4)
+		const string &key = child.Token(0);
+		if(key == "date" && child.Size() >= 4)
 			date = Date(child.Value(1), child.Value(2), child.Value(3));
-		else if(child.Token(0) == "unvisit" && child.Size() >= 2)
+		else if(key == "unvisit" && child.Size() >= 2)
 			systemsToUnvisit.push_back(GameData::Systems().Get(child.Token(1)));
-		else if(child.Token(0) == "unvisit planet" && child.Size() >= 2)
+		else if(key == "visit" && child.Size() >= 2)
+			systemsToVisit.push_back(GameData::Systems().Get(child.Token(1)));
+		else if(key == "unvisit planet" && child.Size() >= 2)
 			planetsToUnvisit.push_back(GameData::Planets().Get(child.Token(1)));
-		else if(child.Token(0) == "system" || child.Token(0) == "planet" || child.Token(0) == "galaxy"
-				|| child.Token(0) == "shipyard" || child.Token(0) == "outfitter"
-				|| child.Token(0) == "fleet" || child.Token(0) == "government"
-				|| child.Token(0) == "link" || child.Token(0) == "unlink")
+		else if(key == "visit planet" && child.Size() >= 2)
+			planetsToVisit.push_back(GameData::Planets().Get(child.Token(1)));
+		else if(allowedChanges.count(key))
 			changes.push_back(child);
 		else
 			conditionsToApply.Add(child);
@@ -65,6 +82,13 @@ void GameEvent::Save(DataWriter &out) const
 		for(const Planet *planet : planetsToUnvisit)
 			if(planet && !planet->Name().empty())
 				out.Write("unvisit planet", planet->Name());
+		
+		for(const System *system : systemsToVisit)
+			if(system && !system->Name().empty())
+				out.Write("visit", system->Name());
+		for(const Planet *planet : planetsToVisit)
+			if(planet && !planet->Name().empty())
+				out.Write("visit planet", planet->Name());
 		
 		for(const DataNode &change : changes)
 			out.Write(change);
@@ -111,4 +135,11 @@ void GameEvent::Apply(PlayerInfo &player)
 		player.Unvisit(system);
 	for(const Planet *planet : planetsToUnvisit)
 		player.Unvisit(planet);
+	
+	// Perform visits after unvisits, as "unvisit <system>"
+	// will unvisit any planets in that system.
+	for(const System *system : systemsToVisit)
+		player.Visit(system);
+	for(const Planet *planet : planetsToVisit)
+		player.Visit(planet);
 }

--- a/source/GameEvent.h
+++ b/source/GameEvent.h
@@ -49,6 +49,8 @@ private:
 	Date date;
 	ConditionSet conditionsToApply;
 	std::list<DataNode> changes;
+	std::vector<const System *> systemsToVisit;
+	std::vector<const Planet *> planetsToVisit;
 	std::vector<const System *> systemsToUnvisit; 
 	std::vector<const Planet *> planetsToUnvisit; 
 };

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1751,7 +1751,7 @@ void PlayerInfo::Visit(const System *system)
 
 
 
-// Mark the given system as visited, and mark all its neighbors as seen.
+// Mark the given planet as visited.
 void PlayerInfo::Visit(const Planet *planet)
 {
 	if(planet && !planet->TrueName().empty())


### PR DESCRIPTION
Refs #3110 

 - Adds ability for a game event to give the player knowledge of a system or planet.
 - Visit actions occur after any 'unvisit' actions in the same event
 - Update the structure of GameEvent::Load