### PR TITLE
Fix ships selected by number keys in Shipyard/Outfitter

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -546,11 +546,28 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			if(allWereSelected)
 				added.clear();
 			
+			const System *here = player.GetSystem();
 			for(Ship *ship : added)
-				playerShips.insert(ship);
+				if(!ship->IsDisabled() && ship->GetSystem() == here)
+					playerShips.insert(ship);
+			
+			if(!playerShips.count(playerShip))
+				playerShip = playerShips.empty() ? nullptr : *playerShips.begin();
 		}
 		else
-			playerShips = player.GetGroup(group);
+		{
+			// Change the selection to the desired ships, if they are landed here.
+			playerShips.clear();
+			set<Ship *> wanted = player.GetGroup(group);
+			
+			const System *here = player.GetSystem();
+			for(Ship *ship : wanted)
+				if(!ship->IsDisabled() && ship->GetSystem() == here)
+					playerShips.insert(ship);
+			
+			if(!playerShips.count(playerShip))
+				playerShip = playerShips.empty() ? nullptr : *playerShips.begin();
+		}
 	}
 	else
 		return false;
@@ -843,6 +860,7 @@ void ShopPanel::SideSelect(int count)
 	}
 	
 	
+	const System *here = player.GetSystem();
 	if(count < 0)
 	{
 		while(count)
@@ -851,7 +869,7 @@ void ShopPanel::SideSelect(int count)
 				it = player.Ships().end();
 			--it;
 			
-			if((*it)->GetSystem() == player.GetSystem() && !(*it)->IsDisabled())
+			if((*it)->GetSystem() == here && !(*it)->IsDisabled())
 				++count;
 		}
 	}
@@ -863,7 +881,7 @@ void ShopPanel::SideSelect(int count)
 			if(it == player.Ships().end())
 				it = player.Ships().begin();
 			
-			if((*it)->GetSystem() == player.GetSystem() && !(*it)->IsDisabled())
+			if((*it)->GetSystem() == here && !(*it)->IsDisabled())
 				--count;
 		}
 	}
@@ -880,10 +898,11 @@ void ShopPanel::SideSelect(Ship *ship)
 	if(shift)
 	{
 		bool on = false;
+		const System *here = player.GetSystem();
 		for(const shared_ptr<Ship> &other : player.Ships())
 		{
 			// Skip any ships that are "absent" for whatever reason.
-			if(other->GetSystem() != player.GetSystem() || other->IsDisabled())
+			if(other->GetSystem() != here || other->IsDisabled())
 				continue;
 			
 			if(other.get() == ship || other.get() == playerShip)


### PR DESCRIPTION
Refs #3115 

 - Ensure only ships which can appear in the Shipyard/Outfitter are selected.
 - If the currently selected ship is not in the new selection of ships, update it.

