### PR TITLE
Add a combat rating check to "Hunted by State" missions.

### DIFF
--- a/data/pirate jobs.txt
+++ b/data/pirate jobs.txt
@@ -2475,6 +2475,7 @@ mission "Hunted by State [0]"
 		government "Republic" "Syndicate" "Free Worlds" "Neutral" "Pirate"
 	to offer
 		random < 10
+		"combat rating" > 1100
 		or
 			not "chosen sides"
 			has "main plot completed"
@@ -2500,6 +2501,7 @@ mission "Hunted by State [1]"
 		government "Republic" "Syndicate" "Free Worlds" "Neutral" "Pirate"
 	to offer
 		random > 95
+		"combat rating" > 3000
 		or
 			not "chosen sides"
 			has "main plot completed"

--- a/data/pirate jobs.txt
+++ b/data/pirate jobs.txt
@@ -2475,7 +2475,7 @@ mission "Hunted by State [0]"
 		government "Republic" "Syndicate" "Free Worlds" "Neutral" "Pirate"
 	to offer
 		random < 10
-		"combat rating" > 1100
+		"combat rating" > 150
 		or
 			not "chosen sides"
 			has "main plot completed"
@@ -2501,7 +2501,7 @@ mission "Hunted by State [1]"
 		government "Republic" "Syndicate" "Free Worlds" "Neutral" "Pirate"
 	to offer
 		random > 95
-		"combat rating" > 3000
+		"combat rating" > 1100
 		or
 			not "chosen sides"
 			has "main plot completed"


### PR DESCRIPTION
Under certain circumstances, or when using mods, it's possible to get a very negative rep while still too weak to handle the bounty hunters.