### PR TITLE
Unify refueling and routing code

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -150,14 +150,17 @@ namespace {
 		}
 		return false;
 	}
-	// Wrapper for ship-system uses.
+	// Wrapper for ship - target system uses.
 	bool ShouldRefuel(const Ship &ship, const System *to)
 	{
 		if(!to || ship.Fuel() == 1. || !ship.GetSystem()->HasFuelFor(ship))
 			return false;
+		double fuelCapacity = ship.Attributes().Get("fuel capacity");
+		if(!fuelCapacity)
+			return false;
 		double needed = ship.JumpFuel(to);
 		if(needed && to->HasFuelFor(ship))
-			return ship.Fuel() * ship.Attributes().Get("fuel capacity") < needed;
+			return ship.Fuel() * fuelCapacity < needed;
 		else
 		{
 			// If no direct jump route, or the target system has no

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -124,6 +124,109 @@ namespace {
 				bay.ship->SetCommands(Command::DEPLOY);
 	}
 	
+	// Determine if the ship with the given travel plan should refuel in
+	// its current system, or if it should keep travelling.
+	bool ShouldRefuel(const Ship &ship, const DistanceMap &route)
+	{
+		double fuelCapacity = ship.Attributes().Get("fuel capacity");
+		const bool hasFuel = fuelCapacity && ship.JumpFuel();
+		
+		const System *from = ship.GetSystem();
+		const bool systemHasFuel = from->HasFuelFor(ship);
+		
+		// Calculate the fuel needed to reach the next system with fuel.
+		const System *to = route.Route(from);
+		if(systemHasFuel && hasFuel && ship.Fuel() < 1.)
+		{
+			while(to && !to->HasFuelFor(ship))
+				to = route.Route(to);
+			
+			// If the ship cannot route further (!to), or needs more
+			// fuel to reach the next system with fuel, refuel.
+			if(!to || ship.Fuel() * fuelCapacity < route.RequiredFuel(from, to))
+				return true;
+			else
+				return false;
+		}
+		return false;
+	}
+	// Wrapper for ship-system uses.
+	bool ShouldRefuel(const Ship &ship, const System *to)
+	{
+		if(!to || ship.Fuel() == 1. || !ship.GetSystem()->HasFuelFor(ship))
+			return false;
+		double needed = ship.JumpFuel(to);
+		if(needed && to->HasFuelFor(ship))
+			return ship.Fuel() * ship.Attributes().Get("fuel capacity") < needed;
+		else
+		{
+			// If no direct jump route, or the target system has no
+			// fuel, perform a more elaborate refueling check.
+			const DistanceMap distance(ship, to);
+			return ShouldRefuel(ship, distance);
+		}
+	}
+	
+	const StellarObject *GetRefuelLocation(const Ship &ship)
+	{
+		const StellarObject *target = nullptr;
+		const System *system = ship.GetSystem();
+		if(system)
+		{
+			// Determine which, if any, planet with fuel is closest.
+			double closest = numeric_limits<double>::infinity();
+			const Point &p = ship.Position();
+			for(const StellarObject &object : system->Objects())
+				if(object.GetPlanet() && object.GetPlanet()->HasFuelFor(ship))
+				{
+					double distance = p.Distance(object.Position());
+					if(distance < closest)
+					{
+						target = &object;
+						closest = distance;
+					}
+				}
+		}
+		return target;
+	}
+	
+	// Set the ship's TargetStellar or TargetSystem in order to reach the
+	// next desired system. Will target a landable planet to refuel.
+	void SelectRoute(Ship &ship, const System *targetSystem)
+	{
+		const System *from = ship.GetSystem();
+		if(from == targetSystem || !targetSystem)
+			return;
+		const DistanceMap route(ship, targetSystem);
+		const bool needsRefuel = ShouldRefuel(ship, route);
+		const System *to = route.Route(from);
+		// The destination may be accessible by both jump and wormhole.
+		// Prefer wormhole travel in these cases, to conserve fuel. Must
+		// check accessibility as DistanceMap may only see the jump path.
+		if(to && !needsRefuel)
+			for(const StellarObject &object : from->Objects())
+			{
+				const Planet *planet = object.GetPlanet();
+				if(planet && planet->IsWormhole() && planet->IsAccessible(&ship)
+						&& planet->WormholeDestination(from) == to)
+				{
+					ship.SetTargetStellar(&object);
+					ship.SetTargetSystem(nullptr);
+					return;
+				}
+			}
+		else if(needsRefuel)
+		{
+			// There is at least one planet that can refuel the ship.
+			ship.SetTargetStellar(GetRefuelLocation(ship));
+			return;
+		}
+		// Either there is no viable wormhole route to this system, or
+		// the target system cannot be reached.
+		ship.SetTargetSystem(to);
+		ship.SetTargetStellar(nullptr);
+	}
+	
 	const double MAX_DISTANCE_FROM_CENTER = 10000.;
 	// Constants for the invisible fence timer.
 	const int FENCE_DECAY = 4;
@@ -1059,10 +1162,10 @@ bool AI::FollowOrders(Ship &ship, Command &command) const
 	shared_ptr<Ship> target = it->second.target.lock();
 	if(type == Orders::MOVE_TO && it->second.targetSystem && ship.GetSystem() != it->second.targetSystem)
 	{
-		// The desired position is in a different system.
-		DistanceMap distance(ship, it->second.targetSystem);
-		const System *to = distance.Route(ship.GetSystem());
-		ship.SetTargetSystem(to);
+		// The desired position is in a different system. Find the best
+		// way to reach that system (via wormhole or jumping). This may
+		// result in the ship landing to refuel.
+		SelectRoute(ship, it->second.targetSystem);
 		return false;
 	}
 	else if(type == Orders::MOVE_TO && ship.Position().Distance(it->second.point) > 20.)
@@ -1113,7 +1216,8 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		if(it != orders.end() && it->second.target.lock() == target)
 			friendlyOverride = (it->second.type == Orders::ATTACK || it->second.type == Orders::FINISH_OFF);
 	}
-	if(target && (ship.GetGovernment()->IsEnemy(target->GetGovernment()) || friendlyOverride))
+	const Government *gov = ship.GetGovernment();
+	if(target && (gov->IsEnemy(target->GetGovernment()) || friendlyOverride))
 	{
 		bool shouldBoard = ship.Cargo().Free() && ship.GetPersonality().Plunders();
 		bool hasBoarded = Has(ship, target, ShipEvent::BOARD);
@@ -1132,8 +1236,8 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 	{
 		bool cargoScan = ship.Attributes().Get("cargo scan") || ship.Attributes().Get("cargo scan power");
 		bool outfitScan = ship.Attributes().Get("outfit scan") || ship.Attributes().Get("outfit scan power");
-		if((!cargoScan || Has(ship.GetGovernment(), target, ShipEvent::SCAN_CARGO))
-				&& (!outfitScan || Has(ship.GetGovernment(), target, ShipEvent::SCAN_OUTFITS)))
+		if((!cargoScan || Has(gov, target, ShipEvent::SCAN_CARGO))
+				&& (!outfitScan || Has(gov, target, ShipEvent::SCAN_OUTFITS)))
 			target.reset();
 		else
 		{
@@ -1144,8 +1248,12 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		return;
 	}
 	
+	// A ship has restricted movement options if it is 'staying' or is hostile to its parent.
 	const bool shouldStay = ship.GetPersonality().IsStaying()
-			|| (ship.GetParent() && ship.GetParent()->GetGovernment()->IsEnemy(ship.GetGovernment()));
+			|| (ship.GetParent() && ship.GetParent()->GetGovernment()->IsEnemy(gov));
+	// Ships should choose a random system/planet for travel if they do not
+	// already have a system/planet in mind, and are free to move about.
+	const System *origin = ship.GetSystem();
 	if(!ship.GetTargetSystem() && !ship.GetTargetStellar() && !shouldStay)
 	{
 		int jumps = ship.JumpsRemaining();
@@ -1156,13 +1264,13 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		vector<int> systemWeights;
 		int totalWeight = 0;
 		const set<const System *> &links = ship.Attributes().Get("jump drive")
-			? ship.GetSystem()->Neighbors() : ship.GetSystem()->Links();
+			? origin->Neighbors() : origin->Links();
 		if(jumps)
 		{
 			for(const System *link : links)
 			{
 				// Prefer systems in the direction we're facing.
-				Point direction = link->Position() - ship.GetSystem()->Position();
+				Point direction = link->Position() - origin->Position();
 				int weight = static_cast<int>(
 					11. + 10. * ship.Facing().Unit().Dot(direction.Unit()));
 				
@@ -1175,7 +1283,7 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		// Anywhere you can land that has a port has the same weight. Ships will
 		// not land anywhere without a port.
 		vector<const StellarObject *> planets;
-		for(const StellarObject &object : ship.GetSystem()->Objects())
+		for(const StellarObject &object : origin->Objects())
 			if(object.GetPlanet() && object.GetPlanet()->HasSpaceport()
 					&& object.GetPlanet()->CanLand(ship))
 			{
@@ -1185,7 +1293,7 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		// If there are no ports to land on and this ship cannot jump, consider
 		// landing on uninhabited planets.
 		if(!totalWeight)
-			for(const StellarObject &object : ship.GetSystem()->Objects())
+			for(const StellarObject &object : origin->Objects())
 				if(object.GetPlanet() && object.GetPlanet()->CanLand(ship))
 				{
 					planets.push_back(&object);
@@ -1195,10 +1303,10 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		{
 			// If there is nothing this ship can land on, have it just go to the
 			// star and hover over it rather than drifting far away.
-			if(ship.GetSystem()->Objects().empty())
+			if(origin->Objects().empty())
 				return;
 			totalWeight = 1;
-			planets.push_back(&ship.GetSystem()->Objects().front());
+			planets.push_back(&origin->Objects().front());
 		}
 		
 		set<const System *>::const_iterator it = links.begin();
@@ -1221,6 +1329,10 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 			ship.SetTargetStellar(planets[choice]);
 		}
 	}
+	// Choose the best method of reaching the target system, which may mean
+	// using a local wormhole rather than jumping. If this ship has chosen
+	// to land, this decision will not be altered.
+	SelectRoute(ship, ship.GetTargetSystem());
 	
 	if(ship.GetTargetSystem())
 	{
@@ -1244,8 +1356,8 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 	}
 	else if(shouldStay && !ship.GetSystem()->Objects().empty())
 	{
-		unsigned i = Random::Int(ship.GetSystem()->Objects().size());
-		ship.SetTargetStellar(&ship.GetSystem()->Objects()[i]);
+		unsigned i = Random::Int(origin->Objects().size());
+		ship.SetTargetStellar(&origin->Objects()[i]);
 	}
 }
 
@@ -1269,53 +1381,19 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 	{
 		if(ship.GetTargetStellar())
 		{
+			// An escort with an out-of-system parent only lands to
+			// refuel or use a wormhole to route toward the parent.
 			const Planet *targetPlanet = ship.GetTargetStellar()->GetPlanet();
-			if(!targetPlanet || !targetPlanet->CanLand(ship))
-				ship.SetTargetStellar(nullptr);
-			// If this ship has already refuelled, and its parent has left the
-			// system, no need to land on a planet again.
-			else if(!targetPlanet->IsWormhole() && ship.Fuel() == 1.)
+			if(!targetPlanet || !targetPlanet->CanLand(ship)
+					|| (!targetPlanet->IsWormhole() && ship.Fuel() == 1.))
 				ship.SetTargetStellar(nullptr);
 		}
 		
 		if(!ship.GetTargetStellar() && !ship.GetTargetSystem())
 		{
-			// Figure out a path to the parent ship's system and check whether the
-			// ship should refuel, land on a wormhole or jump to the next system.
-			DistanceMap distance(ship, parent.GetSystem());
-			const System *from = ship.GetSystem();
-			
-			// Check how much fuel is required to reach the next refuel system.
-			if(systemHasFuel && ship.Fuel() < 1.)
-			{
-				const System *to = distance.Route(from);
-				while(to && !to->HasFuelFor(ship))
-					to = distance.Route(to);
-				
-				// Refuel.
-				if(!to || ship.Fuel() < distance.RequiredFuel(from, to) / ship.Attributes().Get("fuel capacity"))
-					Refuel(ship, command);
-			}
-			
-			if(!ship.GetTargetStellar())
-			{
-				const System *to = distance.Route(from);
-				
-				// Land on wormhole.
-				for(const StellarObject &object : from->Objects())
-				{
-					const Planet *planet = object.GetPlanet();
-					if(planet && planet->IsWormhole() && planet->CanLand(ship) && planet->WormholeDestination(from) == to)
-					{
-						ship.SetTargetStellar(&object);
-						break;
-					}
-				}
-				
-				// Jump to the next system.
-				if(!ship.GetTargetStellar())
-					ship.SetTargetSystem(to);
-			}
+			// Route to the parent ship's system and check whether
+			// the ship should land (refuel or wormhole) or jump.
+			SelectRoute(ship, parent.GetSystem());
 		}
 		
 		// Perform the action that this ship previously decided on.
@@ -1358,7 +1436,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 		if(!dest)
 			// This ship has no route to the parent's destination system, so protect it until it jumps away.
 			KeepStation(ship, command, parent);
-		else if(systemHasFuel && !dest->HasFuelFor(ship) && ship.JumpsRemaining() == 1)
+		else if(ShouldRefuel(ship, dest))
 			Refuel(ship, command);
 		else if(!ship.JumpsRemaining())
 			MoveTo(ship, command, Point(), Point(), 40., 0.1);
@@ -1376,25 +1454,16 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 
 
 
+// Prefer your parent's target planet for refueling, but if it and your current
+// target planet can't fuel you, try to find one that can.
 void AI::Refuel(Ship &ship, Command &command)
 {
 	const StellarObject *parentTarget = (ship.GetParent() ? ship.GetParent()->GetTargetStellar() : nullptr);
 	if(CanRefuel(ship, parentTarget))
 		ship.SetTargetStellar(parentTarget);
 	else if(!CanRefuel(ship, ship.GetTargetStellar()))
-	{
-		double closest = numeric_limits<double>::infinity();
-		for(const StellarObject &object : ship.GetSystem()->Objects())
-			if(CanRefuel(ship, &object))
-			{
-				double distance = ship.Position().Distance(object.Position());
-				if(distance < closest)
-				{
-					ship.SetTargetStellar(&object);
-					closest = distance;
-				}
-			}
-	}
+		ship.SetTargetStellar(GetRefuelLocation(ship));
+
 	if(ship.GetTargetStellar())
 	{
 		MoveToPlanet(ship, command);

--- a/source/DistanceMap.cpp
+++ b/source/DistanceMap.cpp
@@ -26,9 +26,9 @@ using namespace std;
 // it is a limit on how many systems should be returned. If it is below zero
 // it specifies the maximum distance away that paths should be found.
 DistanceMap::DistanceMap(const System *center, int maxCount, int maxDistance)
-	: maxCount(maxCount), maxDistance(maxDistance), useWormholes(false)
+	: center(center), maxCount(maxCount), maxDistance(maxDistance), useWormholes(false)
 {
-	Init(center);
+	Init();
 }
 
 
@@ -51,8 +51,10 @@ DistanceMap::DistanceMap(const PlayerInfo &player, const System *center)
 	}
 	if(!center)
 		return;
+	else
+		this->center = center;
 	
-	Init(center, player.Flagship());
+	Init(player.Flagship());
 }
 
 
@@ -61,12 +63,12 @@ DistanceMap::DistanceMap(const PlayerInfo &player, const System *center)
 // ship will use a jump drive or hyperdrive depending on what it has. The
 // pathfinding will stop once a path to the destination is found.
 DistanceMap::DistanceMap(const Ship &ship, const System *destination)
-	: source(ship.GetSystem())
+	: source(ship.GetSystem()), center(destination)
 {
 	if(!source || !destination)
 		return;
 	
-	Init(destination, &ship);
+	Init(&ship);
 }
 
 
@@ -108,6 +110,14 @@ set<const System *> DistanceMap::Systems() const
 
 
 
+// Return the destination system - the 'center' system.
+const System *DistanceMap::End() const
+{
+	return center;
+}
+
+
+
 int DistanceMap::RequiredFuel(const System *system1, const System *system2) const
 {
 	auto it1 = route.find(system1);
@@ -145,7 +155,7 @@ bool DistanceMap::Edge::operator<(const Edge &other) const
 // Depending on the capabilities of the given ship, use hyperspace paths,
 // jump drive paths, or both to find the shortest route. Bail out if the
 // source system or the maximum count is reached.
-void DistanceMap::Init(const System *center, const Ship *ship)
+void DistanceMap::Init(const Ship *ship)
 {
 	if(!center)
 		return;
@@ -192,6 +202,8 @@ void DistanceMap::Init(const System *center, const Ship *ship)
 		Edge top = edges.top();
 		edges.pop();
 		
+		// Source is only defined when given a ship and a destination system.
+		// Once we have a route between them, stop searching for more routes.
 		if(top.next == source)
 			break;
 		// Increment the danger and the travel time to include this system. The
@@ -201,7 +213,7 @@ void DistanceMap::Init(const System *center, const Ship *ship)
 		++top.days;
 		
 		// Check for wormholes (which cost zero fuel). Wormhole travel should
-		// not be included in maps or mission itineraries.
+		// not be included in Local Maps or mission itineraries.
 		if(useWormholes)
 			for(const StellarObject &object : top.next->Objects())
 				if(object.GetPlanet() && object.GetPlanet()->IsWormhole())
@@ -242,7 +254,6 @@ void DistanceMap::Init(const System *center, const Ship *ship)
 // Add the given links to the map. Return false if an end condition is hit.
 bool DistanceMap::Propagate(Edge edge, bool useJump)
 {
-	// The "length" of this link is 2 if using a jump drive.
 	edge.fuel += (useJump ? jumpFuel : hyperspaceFuel);
 	for(const System *link : (useJump ? edge.next->Neighbors() : edge.next->Links()))
 	{

--- a/source/DistanceMap.h
+++ b/source/DistanceMap.h
@@ -52,6 +52,8 @@ public:
 	
 	// Get a set containing all the systems.
 	std::set<const System *> Systems() const;
+	// Get the end of the route.
+	const System *End() const;
 	
 	// How much fuel is needed to travel between two systems.
 	int RequiredFuel(const System *system1, const System *system2) const;
@@ -80,7 +82,7 @@ private:
 	// Depending on the capabilities of the given ship, use hyperspace paths,
 	// jump drive paths, or both to find the shortest route. Bail out if the
 	// source system or the maximum count is reached.
-	void Init(const System *center, const Ship *ship = nullptr);
+	void Init(const Ship *ship = nullptr);
 	// Add the given links to the map. Return false if an end condition is hit.
 	bool Propagate(Edge edge, bool useJump);
 	// Check if we already have a better path to the given system.
@@ -100,6 +102,7 @@ private:
 	std::priority_queue<Edge> edges;
 	const PlayerInfo *player = nullptr;
 	const System *source = nullptr;
+	const System *center = nullptr;
 	int maxCount = -1;
 	int maxDistance = -1;
 	// How much fuel is used for travel. If either value is zero, it means that


### PR DESCRIPTION
 - Extends advanced refueling logic to ships moving independently & following orders
 - Extends advanced refueling logic to in-system escorts
 - Chooses the best route for a ship to reach its destination system

@flaviojs please check this pull for differences in escort behavior compared to your pull - I'm pretty sure it keeps all the behaviors you added while extending them to MoveIndependent (where they can serve `personality uninterested` and #2990 ).