### PR TITLE
Mission NPCs ignore mining time/count limits

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -541,10 +541,12 @@ void AI::Step(const PlayerInfo &player)
 		}
 		
 		// Attacking a hostile ship and stopping to be refueled are more important than mining.
-		if(isPresent && personality.IsMining() && !target && !isStranded)
+		if(isPresent && personality.IsMining() && !target && !isStranded && maxMinerCount)
 		{
-			// Miners with free cargo space and available mining time should mine.
-			if(it->Cargo().Free() >= 5 && IsArmed(*it) && ++miningTime[&*it] < 3600 && ++minerCount < maxMinerCount)
+			// Miners with free cargo space and available mining time should mine. Mission NPCs
+			// should mine even if there are other miners or they have been mining a while.
+			if(it->Cargo().Free() >= 5 && IsArmed(*it) && (it->IsSpecial()
+					|| (++miningTime[&*it] < 3600 && ++minerCount < maxMinerCount)))
 			{
 				if(it->HasBays())
 					command |= Command::DEPLOY;


### PR DESCRIPTION
This makes them behave more like the player. They're not total jerks though - they still respect cargo space limits.

This will be useful for any missions that offer "competitors" to the player, if the player is tasked with collecting items from minables.