### PR TITLE
Add "Pug Wormhole" planet definition

### DIFF
--- a/data/pug.txt
+++ b/data/pug.txt
@@ -650,6 +650,8 @@ system "World's End"
 		period 360
 		offset 290
 
+planet "Pug Wormhole"
+
 planet Ruin
 	attributes uninhabited
 	landscape land/hills3

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -227,7 +227,7 @@ void GameData::CheckReferences()
 		if(it.second.Name().empty())
 			Files::LogError("Warning: phrase \"" + it.first + "\" is referred to, but never defined.");
 	for(const auto &it : planets)
-		if(it.second.Name().empty() && !it.second.GetSystem())
+		if(it.second.Name().empty())
 			Files::LogError("Warning: planet \"" + it.first + "\" is referred to, but never defined.");
 	for(const auto &it : ships)
 		if(it.second.ModelName().empty())

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -227,7 +227,7 @@ void GameData::CheckReferences()
 		if(it.second.Name().empty())
 			Files::LogError("Warning: phrase \"" + it.first + "\" is referred to, but never defined.");
 	for(const auto &it : planets)
-		if(it.second.Name().empty())
+		if(it.second.Name().empty() && !it.second.GetSystem())
 			Files::LogError("Warning: planet \"" + it.first + "\" is referred to, but never defined.");
 	for(const auto &it : ships)
 		if(it.second.ModelName().empty())


### PR DESCRIPTION
 - Wormhole "planets" are given a system, but unless also defined with a `planet` entry, would not pass GameData::CheckReferences until the wormhole was linked to another system

per #404 wormholes with no `planet` definition are not drawn on the map, so until #2601 merges, the link to the pug galaxy will be drawn (if one revisits it, as it will then be marked as visited).
refs #3137 