### PR TITLE
Extend LocationFilter for ship sources

### DIFF
--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -46,6 +46,23 @@ namespace {
 		}
 		return false;
 	}
+	bool SetsIntersect(const set<const Outfit *> &a, const set<const Outfit *> &b)
+	{
+		auto ait = a.begin();
+		auto bit = b.begin();
+		// The stored values are pointers to the same GameData array:
+		// directly compare them.
+		while(ait != a.end() && bit != b.end())
+		{
+			if(*ait == *bit)
+				return true;
+			else if(*ait < *bit)
+				++ait;
+			else
+				++bit;
+		}
+		return false;
+	}
 	
 	// Check if the given system is within the given distance of the center.
 	int Distance(const System *center, const System *system, int maximum)
@@ -178,6 +195,27 @@ void LocationFilter::Save(DataWriter &out) const
 			}
 			out.EndChild();
 		}
+		for(const auto &it : outfits)
+		{
+			out.Write("outfits");
+			out.BeginChild();
+			{
+				for(const Outfit *outfit : it)
+					if(!outfit->Name().empty())
+						out.Write(outfit->Name());
+			}
+			out.EndChild();
+		}
+		if(!shipCategory.empty())
+		{
+			out.Write("category");
+			out.BeginChild();
+			{
+				for(const string &category : shipCategory)
+					out.Write(category);
+			}
+			out.EndChild();
+		}
 		if(center)
 			out.Write("near", center->Name(), centerMinDistance, centerMaxDistance);
 	}
@@ -190,7 +228,8 @@ void LocationFilter::Save(DataWriter &out) const
 bool LocationFilter::IsEmpty() const
 {
 	return planets.empty() && attributes.empty() && systems.empty() && governments.empty()
-		&& !center && originMaxDistance < 0 && notFilters.empty() && neighborFilters.empty();
+		&& !center && originMaxDistance < 0 && notFilters.empty() && neighborFilters.empty()
+		&& outfits.empty() && shipCategory.empty();
 }
 
 
@@ -199,6 +238,10 @@ bool LocationFilter::IsEmpty() const
 bool LocationFilter::Matches(const Planet *planet, const System *origin) const
 {
 	if(!planet || !planet->GetSystem())
+		return false;
+	
+	// If a ship class was given, do not match planets.
+	if(!shipCategory.empty())
 		return false;
 	
 	if(!governments.empty() && !governments.count(planet->GetGovernment()))
@@ -214,6 +257,11 @@ bool LocationFilter::Matches(const Planet *planet, const System *origin) const
 		if(filter.Matches(planet, origin))
 			return false;
 	
+	// If outfits are specified, make sure they can be bought here.
+	for(const set<const Outfit *> &outfitList : outfits)
+		if(!SetsIntersect(outfitList, planet->Outfitter()))
+			return false;
+	
 	return Matches(planet->GetSystem(), origin, true);
 }
 
@@ -221,11 +269,17 @@ bool LocationFilter::Matches(const Planet *planet, const System *origin) const
 
 bool LocationFilter::Matches(const System *system, const System *origin) const
 {
+	// If a ship class was given, do not match systems.
+	if(!shipCategory.empty())
+		return false;
+	
 	return Matches(system, origin, false);
 }
 
 
 
+// Check for matches with the ship's system, government, category,
+// outfits (installed and carried), and attributes.
 bool LocationFilter::Matches(const Ship &ship) const
 {
 	const System *origin = ship.GetSystem();
@@ -233,6 +287,36 @@ bool LocationFilter::Matches(const Ship &ship) const
 		return false;
 	if(!governments.empty() && !governments.count(ship.GetGovernment()))
 		return false;
+	
+	if(!shipCategory.empty() && !shipCategory.count(ship.Attributes().Category()))
+		return false;
+	
+	if(!attributes.empty())
+	{
+		// Create a set from the positive-valued attributes of this ship.
+		set<string> shipAttributes;
+		for(const pair<string, int> &attr : ship.Attributes().Attributes())
+			if(attr.second > 0)
+				shipAttributes.insert(shipAttributes.end(), attr.first);
+		for(const set<string> &attr : attributes)
+			if(!SetsIntersect(attr, shipAttributes))
+				return false;
+	}
+	
+	if(!outfits.empty())
+	{
+		// Create a set from all installed and carried outfits.
+		set<const Outfit *> shipOutfits;
+		for(const auto &oit : ship.Outfits())
+			if(oit.second > 0)
+				shipOutfits.insert(shipOutfits.end(), oit.first);
+		for(const auto &cit : ship.Cargo().Outfits())
+			if(cit.second > 0)
+				shipOutfits.insert(cit.first);
+		for(const auto &outfitSet : outfits)
+			if(!SetsIntersect(outfitSet, shipOutfits))
+				return false;
+	}
 	
 	for(const LocationFilter &filter : notFilters)
 		if(filter.Matches(ship))
@@ -382,6 +466,40 @@ void LocationFilter::LoadChild(const DataNode &child)
 			originMinDistance = child.Value(valueIndex);
 			originMaxDistance = child.Value(1 + valueIndex);
 		}
+	}
+	else if(key == "category" && child.Size() >= 2 + isNot)
+	{
+		// Ship categories cannot be combined in an "and" condition.
+		static const set<string> allowed(Ship::CATEGORIES.begin(), Ship::CATEGORIES.end());
+		for(int i = 1 + isNot; i < child.Size(); ++i)
+		{
+			const string &value = child.Token(i);
+			if(allowed.count(value))
+				shipCategory.insert(value);
+			else
+				child.PrintTrace("Invalid ship category: \"" + value + "\":");
+		}
+		for(const DataNode &grand : child)
+			for(int i = 0; i < grand.Size(); ++i)
+			{
+				const string &value = grand.Token(i);
+				if(allowed.count(value))
+					shipCategory.insert(value);
+				else
+					child.PrintTrace("Invalid ship category: \"" + value + "\":");
+			}
+	}
+	else if(key == "outfits" && child.Size() >= 2 + isNot)
+	{
+		outfits.push_back(set<const Outfit *>());
+		for(int i = 1 + isNot; i < child.Size(); ++i)
+			outfits.back().insert(GameData::Outfits().Get(child.Token(i)));
+		for(const DataNode &grand : child)
+			for(int i = 0; i < grand.Size(); ++i)
+				outfits.back().insert(GameData::Outfits().Get(grand.Token(i)));
+		// Don't allow empty outfit sets; that's probably a typo.
+		if(outfits.back().empty())
+			outfits.pop_back();
 	}
 	else
 		child.PrintTrace("Unrecognized location filter:");

--- a/source/LocationFilter.h
+++ b/source/LocationFilter.h
@@ -20,16 +20,17 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 class DataNode;
 class DataWriter;
 class Government;
+class Outfit;
 class Planet;
 class Ship;
 class System;
 
 
 
-// This class represents a set of constraints on a randomly chosen planet or
-// system. For example, it can require that the planet used for a mission have
-// a certain attribute or be owned by a certain government, or be a certain
-// distance away from the current system.
+// This class represents a set of constraints on a randomly chosen ship, planet,
+// or system. For example, it can require that the planet used for a mission
+// have a certain attribute or be owned by a certain government, or be a
+// certain distance away from the current system.
 class LocationFilter {
 public:
 	LocationFilter() = default;
@@ -48,6 +49,8 @@ public:
 	// If the player is in the given system, does this filter match?
 	bool Matches(const Planet *planet, const System *origin = nullptr) const;
 	bool Matches(const System *system, const System *origin = nullptr) const;
+	// Ships are chosen based on system/"near" filters, government, category
+	// of ship, outfits installed/carried, and their total attributes.
 	bool Matches(const Ship &ship) const;
 	
 	// Return a new LocationFilter with any "distance" conditions converted
@@ -85,7 +88,13 @@ private:
 	int originMinDistance = 0;
 	int originMaxDistance = -1;
 	
-	// These filters store all the things the planet or system must not be.
+	// At least one of the outfits from each set must be available
+	// (to purchase or plunder):
+	std::list<std::set<const Outfit *>> outfits;
+	// A ship must belong to one of these categories:
+	std::set<std::string> shipCategory;
+	
+	// These filters store all the things the planet, system, or ship must not be.
 	std::list<LocationFilter> notFilters;
 	// These filters store all the things the planet or system must border.
 	std::list<LocationFilter> neighborFilters;


### PR DESCRIPTION
Refs #3139 
Missions that trigger on boarding or assisting can now reference the ship's
  - category (e.g. "Heavy Warship")
  - outfits (e.g. "Electron Beam")
  - attributes (e.g. "cloaking fuel")

  Outfit and attribute references return true if the ship has a positive value for the provided token - a ship with a negative or zero-valued attribute/outfit count will not match that attribute or outfit.

  Outfits can also be used for planets to restrict by the items available in its outfitter.

These values are usable in the `source` (all), and  `destination` (outfits only) LocationFilters. A ship is not currently a supported mission destination, so specifying a ship attribute in the attributes node of a  `destination` filter will not work well (unless some planet in map.txt has that attribute).

Example:
```
assisting
source
    not category "Heavy Freighter"
    outfits "Heavy Laser" "Beam Laser"
    government "Merchant"
    attributes "scram drive"
destination
    outfits "Heavy Laser Turret"
on offer
    conversation
        `Please go find Joe on <planet> and inspect their supply of heavy laser turrets`
            accept
```
will match any merchant ship that is equipped or carrying at least one Heavy Laser or Beam Laser (gun versions), is not a Heavy Freighter, and has some outfit that provides a "scram drive" value (in base game, only the Scram Drive).
And will set the mission destination to be a random planet that sells Heavy Laser Turrets.