### PR TITLE
Enable System Attributes and their use in LocationFilters

### DIFF
--- a/data/stars.txt
+++ b/data/stars.txt
@@ -77,3 +77,13 @@ star "star/nova"
 star "star/wr"
 	power 0.4
 	wind 4
+
+
+
+# Sprites which classify as "galactic phenomena" - any system in which
+# these can be found will have the attribute "galactic phenomena".
+phenomena
+	"star/nova"
+	"star/wr"
+	"planet/wormhole"
+	"planet/wormhole-red"

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -58,11 +58,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <algorithm>
 #include <iostream>
-#include <map>
 #include <utility>
-#include <vector>
 
-class Sprite;
 
 using namespace std;
 
@@ -101,6 +98,7 @@ namespace {
 	Trade trade;
 	map<const System *, map<string, int>> purchases;
 	
+	set<const Sprite *> galacticPhenomena;
 	map<const Sprite *, string> landingMessages;
 	map<const Sprite *, double> solarPower;
 	map<const Sprite *, double> solarWind;
@@ -729,6 +727,13 @@ double GameData::SolarWind(const Sprite *sprite)
 
 
 
+bool GameData::IsGalacticPhenomenon(const Sprite *sprite)
+{
+	return galacticPhenomena.count(sprite);
+}
+
+
+
 // Pick a random news object that applies to the given planet. If there is
 // no applicable news, this returns null.
 const News *GameData::PickNews(const Planet *planet)
@@ -933,6 +938,12 @@ void GameData::LoadFile(const string &path, bool debugMode)
 				else
 					child.PrintTrace("Unrecognized star attribute:");
 			}
+		}
+		else if(key == "phenomena" && node.HasChildren())
+		{
+			galacticPhenomena.clear();
+			for(const DataNode &child : node)
+				galacticPhenomena.emplace(SpriteSet::Get(child.Token(0)));
 		}
 		else if(key == "news" && node.Size() >= 2)
 			news.Get(node.Token(1))->Load(node);

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -120,6 +120,9 @@ public:
 	// Get the solar power and wind output of the given stellar object sprite.
 	static double SolarPower(const Sprite *sprite);
 	static double SolarWind(const Sprite *sprite);
+	// Check if this sprite is associated with being a "galactic phenomenon",
+	// e.g. a wormhole or elaborate star.
+	static bool IsGalacticPhenomenon(const Sprite *sprite);
 	
 	// Pick a random news object that applies to the given planet. If there is
 	// no applicable news, this returns null.

--- a/source/LocationFilter.h
+++ b/source/LocationFilter.h
@@ -50,10 +50,10 @@ public:
 private:
 	// Load one particular line of conditions.
 	void LoadChild(const DataNode &child);
-	// Check if the filter matches the given system. If it did not, return true
-	// only if the filter wasn't looking for planet characteristics or if the
-	// didPlanet argument is set (meaning we already checked those).
-	bool Matches(const System *system, const System *origin, bool didPlanet) const;
+	// Check if the filter matches the given system. If so, returns true if
+	// a planet in the system already matched, if the system's attributes,
+	// match, or if the filter wasn't looking for attributes or planets.
+	bool Matches(const System *system, const System *origin, bool hasMatch) const;
 	
 	
 private:

--- a/source/System.h
+++ b/source/System.h
@@ -138,9 +138,15 @@ public:
 	// Check how dangerous this system is (credits worth of enemy ships jumping
 	// in per frame).
 	double Danger() const;
+	const std::set<std::string> &Attributes() const;
+	const std::set<std::string> PlanetAttributes(const Ship *ship = nullptr) const;
 	
 	
 private:
+	// After the system's objects are updated via Load(), update system-specific
+	// automatic attributes such as "binary star".
+	void UpdateAutoAttributes();
+	void UpdateLandingMessages();
 	void LoadObject(const DataNode &node, Set<Planet> &planets, int parent = -1);
 	
 	
@@ -183,6 +189,11 @@ private:
 	
 	// Commodity prices.
 	std::map<std::string, Price> trade;
+	// Automatic attributes characteristic of this system and its
+	// StellarObjects. Does not include attributes of planets, e.g. "urban".
+	std::set<std::string> attributes;
+	// User-specified attributes from events or map definitions.
+	std::set<std::string> baseAttributes;
 };
 
 


### PR DESCRIPTION
Refs #3143 #526 

LocationFilter will now union a planet and its system, and a system and its planets, while checking for matches to a particular set of attributes.
A system's attributes are comprised of those specified via file, with the `attributes` node:
```
system "Sol Arach"
    attributes "nexus"
```
and those that are automatically generated from its StellarObjects and links.  The above "nexus" attribute would be unnecessary, as Sol Arach has 7 systems linked to it, and the "nexus" attribute is automatically assigned for those systems that have 6 or more linked systems.

Current automatic system attributes ( #3143 )
 - nexus
 - crossroads
 - galactic phenomena
 - ternary star
 - binary star
 - no star
 - high solar wind
 - high luminosity
 - high minable density
 - high asteroid density
 - many moons
 - wormhole (when unioned with `PlanetAttributes()` in LocationFilter::Matches, if the wormhole is accessible)
 - inhabited (when unioned with `PlanetAttributes()` in LocationFilter::Matches, if the inhabited planets are accessible)
 - uninhabited

The import of attributes from a system's accessible planets means the system will import any geographic or civilization based attributes (e.g. `pirate`, `north`, `dirt belt`, etc). It also means "contradictory" attributes can exist - for example, peacekeeping forces might need an escort to a system that is `urban rich poor` (note that because an individual planet won't have both attributes, contradictory attributes won't match if `and`ed in a source, destination, or stopover filter (but will work in a waypoint or NPC system filter).

An alternative (or perhaps complementary) approach would be to specify another embedded LocationFilter that is applied only during system match-checking.

