### PR TITLE
Fix Outfitter Attribute display bug

### DIFF
--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -242,10 +242,9 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		outfit.FiringFuel()
 	};
 	
-	// Add any per-second values to the table. If the outfit reload is 60,
-	// do not print per-second values since they are the per-shot values.
+	// Add any per-second values to the table.
 	double reload = outfit.Reload();
-	if(reload && reload != 60.)
+	if(reload)
 	{
 		static const string PER_SECOND = " / second:";
 		for(unsigned i = 0; i < values.size(); ++i)

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -153,8 +153,8 @@ void OutfitInfoDisplay::UpdateRequirements(const Outfit &outfit, const PlayerInf
 	for(unsigned i = 0; i + 1 < NAMES.size(); i += 2)
 		if(outfit.Get(NAMES[i + 1]))
 		{
-			requirementLabels.push_back(string());
-			requirementValues.push_back(string());
+			requirementLabels.emplace_back();
+			requirementValues.emplace_back();
 			requirementsHeight += 10;
 		
 			requirementLabels.push_back(NAMES[i]);
@@ -171,29 +171,28 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	attributeValues.clear();
 	attributesHeight = 20;
 	
-	map<string, map<string, int>> listing;
-	for(const auto &it : outfit.Attributes())
+	for(const pair<string, double> &it : outfit.Attributes())
 	{
-		static set<string> SKIP = {
-			"outfit space", "weapon capacity", "engine capacity", "gun ports", "turret mounts"};
+		static const set<string> SKIP = {
+			"outfit space", "weapon capacity", "engine capacity", "gun ports", "turret mounts"
+		};
 		if(SKIP.count(it.first))
 			continue;
 		
-		string value;
 		auto sit = SCALE.find(it.first);
 		double scale = (sit == SCALE.end() ? 1. : sit->second);
 		
 		auto bit = BOOLEAN_ATTRIBUTES.find(it.first);
 		if(bit != BOOLEAN_ATTRIBUTES.end()) 
 		{
-			attributeLabels.push_back(bit->second);
-			attributeValues.push_back(" ");
+			attributeLabels.emplace_back(bit->second);
+			attributeValues.emplace_back(" ");
 			attributesHeight += 20;
 		}
 		else
 		{
-			attributeLabels.push_back(it.first + ':');
-			attributeValues.push_back(Format::Number(it.second * scale));
+			attributeLabels.emplace_back(it.first + ":");
+			attributeValues.emplace_back(Format::Number(it.second * scale));
 			attributesHeight += 20;
 		}
 	}
@@ -201,117 +200,89 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	if(!outfit.IsWeapon())
 		return;
 	
-	attributeLabels.push_back(string());
-	attributeValues.push_back(string());
+	// Pad the table.
+	attributeLabels.emplace_back();
+	attributeValues.emplace_back();
 	attributesHeight += 10;
 	
 	if(outfit.Ammo())
 	{
-		attributeLabels.push_back("ammo:");
-		attributeValues.push_back(outfit.Ammo()->Name());
+		attributeLabels.emplace_back("ammo:");
+		attributeValues.emplace_back(outfit.Ammo()->Name());
 		attributesHeight += 20;
 	}
 	
-	attributeLabels.push_back("range:");
-	attributeValues.push_back(Format::Number(outfit.Range()));
+	attributeLabels.emplace_back("range:");
+	attributeValues.emplace_back(Format::Number(outfit.Range()));
 	attributesHeight += 20;
 	
-	if(outfit.ShieldDamage() && outfit.Reload())
+	static const vector<string> VALUE_NAMES = {
+		"shield damage",
+		"hull damage",
+		"fuel damage",
+		"heat damage",
+		"ion damage",
+		"slowing damage",
+		"disruption damage",
+		"firing energy",
+		"firing heat",
+		"firing fuel"
+	};
+	
+	vector<double> values = {
+		outfit.ShieldDamage(),
+		outfit.HullDamage(),
+		outfit.FuelDamage(),
+		outfit.HeatDamage(),
+		outfit.IonDamage() * 100.,
+		outfit.SlowingDamage() * 100.,
+		outfit.DisruptionDamage() * 100.,
+		outfit.FiringEnergy(),
+		outfit.FiringHeat(),
+		outfit.FiringFuel()
+	};
+	
+	// Add any per-second values to the table. If the outfit reload is 60,
+	// do not print per-second values since they are the per-shot values.
+	double reload = outfit.Reload();
+	if(reload && reload != 60.)
 	{
-		attributeLabels.push_back("shield damage / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.ShieldDamage() / outfit.Reload()));
-		attributesHeight += 20;
+		static const string PER_SECOND = " / second:";
+		for(unsigned i = 0; i < values.size(); ++i)
+			if(values[i])
+			{
+				attributeLabels.emplace_back(VALUE_NAMES[i] + PER_SECOND);
+				attributeValues.emplace_back(Format::Number(60. * values[i] / reload));
+				attributesHeight += 20;
+			}
 	}
 	
-	if(outfit.HullDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("hull damage / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.HullDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.FuelDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("fuel damage / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.FuelDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.HeatDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("heat damage / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.HeatDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.IonDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("ion damage / second:");
-		attributeValues.push_back(Format::Number(6000. * outfit.IonDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.SlowingDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("slowing damage / second:");
-		attributeValues.push_back(Format::Number(6000. * outfit.SlowingDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.DisruptionDamage() && outfit.Reload())
-	{
-		attributeLabels.push_back("disruption damage / second:");
-		attributeValues.push_back(Format::Number(6000. * outfit.DisruptionDamage() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.FiringEnergy() && outfit.Reload())
-	{
-		attributeLabels.push_back("firing energy / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.FiringEnergy() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.FiringHeat() && outfit.Reload())
-	{
-		attributeLabels.push_back("firing heat / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.FiringHeat() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	if(outfit.FiringFuel() && outfit.Reload())
-	{
-		attributeLabels.push_back("firing fuel / second:");
-		attributeValues.push_back(Format::Number(60. * outfit.FiringFuel() / outfit.Reload()));
-		attributesHeight += 20;
-	}
-	
-	bool isContinuous = (outfit.Reload() <= 1);
-	attributeLabels.push_back("shots / second:");
+	bool isContinuous = (reload <= 1);
+	attributeLabels.emplace_back("shots / second:");
 	if(isContinuous)
-		attributeValues.push_back("continuous");
+		attributeValues.emplace_back("continuous");
 	else
-		attributeValues.push_back(Format::Number(60. / outfit.Reload()));
+		attributeValues.emplace_back(Format::Number(60. / reload));
 	attributesHeight += 20;
 	
 	double turretTurn = outfit.TurretTurn() * 60.;
 	if(turretTurn)
 	{
-		attributeLabels.push_back("turret turn rate:");
-		attributeValues.push_back(Format::Number(turretTurn));
+		attributeLabels.emplace_back("turret turn rate:");
+		attributeValues.emplace_back(Format::Number(turretTurn));
 		attributesHeight += 20;
 	}
 	int homing = outfit.Homing();
 	if(homing)
 	{
 		static const string skill[] = {
-			"no",
+			"none",
 			"poor",
 			"fair",
 			"good",
 			"excellent"
 		};
-		attributeLabels.push_back("homing:");
+		attributeLabels.emplace_back("homing:");
 		attributeValues.push_back(skill[max(0, min(4, homing))]);
 		attributesHeight += 20;
 	}
@@ -338,47 +309,43 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 			attributesHeight += 20;
 		}
 	
-	attributeLabels.push_back(string());
-	attributeValues.push_back(string());
+	// Pad the table.
+	attributeLabels.emplace_back();
+	attributeValues.emplace_back();
 	attributesHeight += 10;
 	
+	// Add per-shot values to the table. If the weapon fires continuously,
+	// the values have already been added.
+	if(!isContinuous)
+	{
+		static const string PER_SHOT = " / shot:";
+		for(unsigned i = 0; i < VALUE_NAMES.size(); ++i)
+			if(values[i])
+			{
+				attributeLabels.emplace_back(VALUE_NAMES[i] + PER_SHOT);
+				attributeValues.emplace_back(Format::Number(values[i]));
+				attributesHeight += 20;
+			}
+	}
+	
 	static const vector<string> OTHER_NAMES = {
-		"shield damage / shot:",
-		"hull damage / shot:",
-		"fuel damage / shot:",
-		"heat damage / shot:",
-		"ion damage / shot:",
-		"slowing damage / shot:",
-		"disruption damage / shot:",
-		"firing energy / shot:",
-		"firing heat / shot:",
-		"firing fuel / shot:",
 		"inaccuracy:",
 		"blast radius:",
 		"missile strength:",
-		"anti-missile:",
+		"anti-missile:"
 	};
-	vector<double> values = {
-		outfit.ShieldDamage(),
-		outfit.HullDamage(),
-		outfit.FuelDamage(),
-		outfit.HeatDamage(),
-		outfit.IonDamage() * 100.,
-		outfit.SlowingDamage() * 100.,
-		outfit.DisruptionDamage() * 100.,
-		outfit.FiringEnergy(),
-		outfit.FiringHeat(),
-		outfit.FiringFuel(),
+	vector<double> otherValues = {
 		outfit.Inaccuracy(),
 		outfit.BlastRadius(),
 		static_cast<double>(outfit.MissileStrength()),
 		static_cast<double>(outfit.AntiMissile())
 	};
-	for(unsigned i = (isContinuous ? 9 : 0); i < OTHER_NAMES.size(); ++i)
-		if(values[i])
+	
+	for(unsigned i = 0; i < OTHER_NAMES.size(); ++i)
+		if(otherValues[i])
 		{
-			attributeLabels.push_back(OTHER_NAMES[i]);
-			attributeValues.push_back(Format::Number(values[i]));
+			attributeLabels.emplace_back(OTHER_NAMES[i]);
+			attributeValues.emplace_back(Format::Number(otherValues[i]));
 			attributesHeight += 20;
 		}
 }

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -171,7 +171,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	attributeValues.clear();
 	attributesHeight = 20;
 	
-	for(const pair<string, double> &it : outfit.Attributes())
+	for(const pair<const char *, double> &it : outfit.Attributes())
 	{
 		static const set<string> SKIP = {
 			"outfit space", "weapon capacity", "engine capacity", "gun ports", "turret mounts"
@@ -191,7 +191,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		}
 		else
 		{
-			attributeLabels.emplace_back(it.first + ":");
+			attributeLabels.emplace_back(static_cast<string>(it.first) + ":");
 			attributeValues.emplace_back(Format::Number(it.second * scale));
 			attributesHeight += 20;
 		}

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -519,7 +519,7 @@ void OutfitterPanel::Sell(bool toCargo)
 			{
 				// Determine how many of this ammo I must sell to also sell the launcher.
 				int mustSell = 0;
-				for(const pair<string, double> &it : ship->Attributes().Attributes())
+				for(const pair<const char *, double> &it : ship->Attributes().Attributes())
 					if(it.second < 0.)
 						mustSell = max<int>(mustSell, it.second / ammo->Get(it.first));
 				
@@ -565,7 +565,7 @@ void OutfitterPanel::FailSell(bool toCargo) const
 		else
 		{
 			for(const Ship *ship : playerShips)
-				for(const pair<string, double> &it : selectedOutfit->Attributes())
+				for(const pair<const char *, double> &it : selectedOutfit->Attributes())
 					if(ship->Attributes().Get(it.first) < it.second)
 					{
 						for(const auto &sit : ship->Outfits())

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -519,7 +519,7 @@ void OutfitterPanel::Sell(bool toCargo)
 			{
 				// Determine how many of this ammo I must sell to also sell the launcher.
 				int mustSell = 0;
-				for(const auto &it : ship->Attributes().Attributes())
+				for(const pair<string, double> &it : ship->Attributes().Attributes())
 					if(it.second < 0.)
 						mustSell = max<int>(mustSell, it.second / ammo->Get(it.first));
 				
@@ -565,7 +565,7 @@ void OutfitterPanel::FailSell(bool toCargo) const
 		else
 		{
 			for(const Ship *ship : playerShips)
-				for(const auto &it : selectedOutfit->Attributes())
+				for(const pair<string, double> &it : selectedOutfit->Attributes())
 					if(ship->Attributes().Get(it.first) < it.second)
 					{
 						for(const auto &sit : ship->Outfits())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -430,7 +430,7 @@ void Ship::Save(DataWriter &out) const
 		{
 			out.Write("category", baseAttributes.Category());
 			out.Write("cost", baseAttributes.Cost());
-			for(const auto &it : baseAttributes.Attributes())
+			for(const pair<string, double> &it : baseAttributes.Attributes())
 				if(it.second)
 					out.Write(it.first, it.second);
 		}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -430,7 +430,7 @@ void Ship::Save(DataWriter &out) const
 		{
 			out.Write("category", baseAttributes.Category());
 			out.Write("cost", baseAttributes.Cost());
-			for(const pair<string, double> &it : baseAttributes.Attributes())
+			for(const pair<const char *, double> &it : baseAttributes.Attributes())
 				if(it.second)
 					out.Write(it.first, it.second);
 		}


### PR DESCRIPTION
Refs #3147 

The fix is to not combine the `const char *` value `it.first` and `':'`. Previously, `it.first` was a `std::string`, but after 595d2e8557489ae4549e42e3eb42a5ac7eecd04d it became `const char *`. Due to use of `auto` for the iterator `it`, the pointer to char was kept, rather than converting to a string for display / use.

Summary:
 - Change `auto` to the type `pair<string, double>` when `it.first` is to be used as a string
 - `push_back` to `emplace_back`
 - Simplify display of per-second values
 - Omit per-second values if reload = 60 (i.e. per second == per shot)
 - Separate non per shot / per second values from values which should be printed as per shot / per second
    - Addition of new damage types no longer requires updating the `isContinuous` offset