### PR TITLE
Prevent matching LocationFilters to planets that have no system

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1077,7 +1077,7 @@ const Planet *Mission::PickPlanet(const LocationFilter &filter, const PlayerInfo
 		// Skip entries with incomplete data.
 		if(it.second.Name().empty() || (clearance.empty() && !it.second.CanLand()))
 			continue;
-		if(it.second.IsWormhole() || !it.second.HasSpaceport())
+		if(it.second.IsWormhole() || !it.second.HasSpaceport() || !it.second.GetSystem())
 			continue;
 		if(filter.Matches(&it.second, player.GetSystem()))
 			options.push_back(&it.second);


### PR DESCRIPTION
 For planets which are only fully defined after certain GameEvents (The Eye), it is possible that the game attempts to obtain the government of their system. Since these planets are not in a system yet, this would generate a segfault due to an unhandled nullptr use.

Since Planet.cpp has several existing uses of `GetSystem` without checking for nullptr, I opted to perform this bugfix for #3155 in the function call that only occurs when the player lands, and only if missions that use destination or stopover LocationFilters are picked to offer, rather than in the function that is called in-flight by countless NPCs.