### PR TITLE
Local Hai space merchants

### DIFF
--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -500,7 +500,7 @@ fleet "Large Northern Merchants"
 		"Headhunter" 3
 
 fleet "Small Human Merchants (Hai)"
-	government "Merchant"
+	government "human Merchant"
 	names "civilian"
 	cargo 3
 	personality
@@ -559,7 +559,7 @@ fleet "Small Human Merchants (Hai)"
 		"Aphid"
 
 fleet "Large Human Merchants (Hai)"
-	government "Merchant"
+	government "human Merchant"
 	names "civilian"
 	cargo 4
 	personality

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -189,6 +189,7 @@ government "human Merchant"
 	"attitude toward"
 		"Pirate" -.2
 		"Korath" -.2
+		"Hai (Unfettered)" -.2
 		"Merchant" .5
 	"bribe" .05
 	"fine" 0

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -78,7 +78,7 @@ government "Hai"
 	"player reputation" 0
 	"attitude toward"
 		"Hai (Unfettered)" -.5
-		"Merchant" .01
+		"human Merchant" .01
 	"bribe" .02
 	"fine" 0
 	"friendly hail" "friendly hai"
@@ -93,7 +93,7 @@ government "Hai (Unfettered)"
 		"Hai" -.01
 		"Wanderer" -.01
 		"Pug" -.01
-		"Merchant" -.01
+		"human Merchant" -.01
 		"Kor Efret" -.01
 	"bribe" .02
 	"fine" 0
@@ -177,10 +177,23 @@ government "Kor Sestor"
 		"Wanderer" -.01
 		"Republic" -.01
 		"Merchant" -.01
+		"human Merchant" -.01
 		"Navy (Oathkeeper)" -.01
 		"Syndicate" -.01
 	
 	"player reputation" -1000
+
+government "human Merchant"
+	swizzle 5
+
+	"attitude toward"
+		"Pirate" -.2
+		"Korath" -.2
+		"Merchant" 1
+	"bribe" .05
+	"fine" 0
+	"friendly hail" "friendly civilian"
+	"hostile hail" "hostile civilian"
 
 government "Merchant"
 	swizzle 5
@@ -189,6 +202,7 @@ government "Merchant"
 	"attitude toward"
 		"Pirate" -.2
 		"Korath" -.2
+		"human Merchant" 1
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly civilian"
@@ -256,6 +270,7 @@ government "Pirate"
 		"Hai" -.01
 		"Korath" -.01
 		"Merchant" -.1
+		"human Merchant" -.1
 		"Syndicate" -.01
 	"bribe" .05
 	"fine" 0

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -189,7 +189,7 @@ government "human Merchant"
 	"attitude toward"
 		"Pirate" -.2
 		"Korath" -.2
-		"Merchant" 1
+		"Merchant" .5
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly civilian"
@@ -202,7 +202,7 @@ government "Merchant"
 	"attitude toward"
 		"Pirate" -.2
 		"Korath" -.2
-		"human Merchant" 1
+		"human Merchant" .5
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly civilian"


### PR DESCRIPTION
This creates a new government ("human Merchants") and merchants in Hai space are given that government. This is so the Hai don't get (directly) mad at you if you pirate Merchants in human space. Hai-space merchants will still get mad at you, and if you attack them that will damage your reputation with the Hai, but with this it's possible (though tricky) to be a pirate in human space and a cargo-hauler in Hai space.