### PR TITLE
Fighters that are launched should not be marked for removal

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -303,6 +303,14 @@ void Body::MarkForRemoval()
 
 
 
+// Mark this object to not be removed from the game.
+void Body::UnmarkForRemoval()
+{
+	shouldBeRemoved = false;
+}
+
+
+
 // Set the current time step.
 void Body::SetStep(int step, bool isHighDPI) const
 {

--- a/source/Body.h
+++ b/source/Body.h
@@ -94,6 +94,8 @@ protected:
 	void PauseAnimation();
 	// Mark this object to be removed from the game.
 	void MarkForRemoval();
+	// Mark that this object should not be removed (e.g. a launched fighter).
+	void UnmarkForRemoval();
 	
 	
 protected:

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1405,6 +1405,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 			bay.ship->Place(position + angle.Rotate(bay.point), v, launchAngle);
 			bay.ship->SetSystem(currentSystem);
 			bay.ship->SetParent(shared_from_this());
+			bay.ship->UnmarkForRemoval();
 			// Fighters in your ship have the same temperature as your ship
 			// itself, so when they launch they should take their share of heat
 			// with them, so that the fighter and the mothership remain at the


### PR DESCRIPTION
Refs #3183 

Ship::Carry sets the fighter's system to nullptr, clearing the Ship class variable `currentSystem`.
Ship::Move sets ships with no `currentSystem` as needing removal

Thus when a ship first launched, it would not be marked for removal, but once it boarded its parent, it would be.