### PR TITLE
Fail mission when ship flees with unfulfilled actions

### DIFF
--- a/data/syndicate world jobs.txt
+++ b/data/syndicate world jobs.txt
@@ -74,6 +74,8 @@ mission "Corporate espionage"
 	on complete
 		dialog `You transmit your scans and receive a hearty congratulations, as well as <payment>. "This will save us months!" you hear someone say in the background as you close the audio link.`
 		payment 50000
+	on fail
+		dialog "You failed to make the requested scans of the <npc>'s cargo."
 
 
 mission "Document delivery to <planet>"

--- a/data/syndicate world jobs.txt
+++ b/data/syndicate world jobs.txt
@@ -75,7 +75,7 @@ mission "Corporate espionage"
 		dialog `You transmit your scans and receive a hearty congratulations, as well as <payment>. "This will save us months!" you hear someone say in the background as you close the audio link.`
 		payment 50000
 	on fail
-		dialog "You failed to make the requested scans of the <npc>'s cargo."
+		dialog "You failed to make the requested scans of the <npc>'s cargo before it could deliver them."
 
 
 mission "Document delivery to <planet>"

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1255,6 +1255,9 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 		// self-destruct.
 		if(ship->IsDestroyed())
 			eventQueue.emplace_back(nullptr, ship, ShipEvent::DESTROY);
+		// Record that the ship was able to flee (by landing).
+		else
+			eventQueue.emplace_back(nullptr, ship, ShipEvent::FLEE);
 		return;
 	}
 	

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1256,9 +1256,14 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 		// self-destruct.
 		if(ship->IsDestroyed())
 			eventQueue.emplace_back(nullptr, ship, ShipEvent::DESTROY);
-		// Record that the ship was able to flee (by landing).
-		else
+		// The ship was able to flee. Carried ships only flee with the parent.
+		else if(!ship->CanBeCarried() || !ship->GetParent() || ship->GetParent()->ShouldBeRemoved())
+		{
 			eventQueue.emplace_back(nullptr, ship, ShipEvent::FLEE);
+			for(auto &bay : ship->Bays())
+				if(bay.ship)
+					eventQueue.emplace_back(nullptr, bay.ship, ShipEvent::FLEE);
+		}
 		return;
 	}
 	

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1248,6 +1248,10 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 	// Bail out if the ship just died.
 	if(ship->ShouldBeRemoved())
 	{
+		// Regular ships are silent about being removed.
+		if(!ship->IsSpecial())
+			return;
+		
 		// Make sure this ship's destruction was recorded, even if it died from
 		// self-destruct.
 		if(ship->IsDestroyed())

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -352,6 +352,9 @@ void Engine::Step(bool isActive)
 		else if(jumpCount > 0)
 			--jumpCount;
 	}
+	// Player mission npcs can react to events.
+	for(const ShipEvent &event : events)
+		player.HandleEvent(event, nullptr);
 	ai.UpdateEvents(events);
 	ai.UpdateKeys(player, clickCommands, isActive && wasActive);
 	wasActive = isActive;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -352,9 +352,6 @@ void Engine::Step(bool isActive)
 		else if(jumpCount > 0)
 			--jumpCount;
 	}
-	// Player mission npcs can react to events.
-	for(const ShipEvent &event : events)
-		player.HandleEvent(event, nullptr);
 	ai.UpdateEvents(events);
 	ai.UpdateKeys(player, clickCommands, isActive && wasActive);
 	wasActive = isActive;

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -368,8 +368,8 @@ bool NPC::HasFailed() const
 			return true;
 	
 		// If we still need to perform an action on this NPC, then that ship
-		// being destroyed should cause the mission to fail.
-		if((~it.second & succeedIf) && (it.second & ShipEvent::DESTROY))
+		// fleeing or being destroyed should cause the mission to fail.
+		if((~it.second & succeedIf) && (it.second & (ShipEvent::FLEE | ShipEvent::DESTROY)))
 			return true;
 	}
 

--- a/source/ShipEvent.h
+++ b/source/ShipEvent.h
@@ -62,7 +62,9 @@ public:
 		// you had with the given government, first.
 		ATROCITY = (1 << 8),
 		// This ship just jumped into a different system.
-		JUMP = (1 << 9)
+		JUMP = (1 << 9),
+		// The given ship landed on a planet and is being removed.
+		FLEE = (1 << 10)
 	};
 	
 	


### PR DESCRIPTION
Reference: option 3 of #3179

~~The event introduced in f5091982de0c9c882a7280295de05fd27851a240 was never used. It's was probably meant to reach the player mission npcs so I made sure all events of the event queue reach them, which includes the new event `ShipEvent::FLEE`.~~