### PR TITLE
Only rehire extra crew when the player has a flagship.

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1076,7 +1076,7 @@ void PlayerInfo::Land(UI *ui)
 	
 	// Hire extra crew back if any were lost in-flight (i.e. boarding) or
 	// some bunks were freed up upon landing (i.e. completed missions).
-	if(Preferences::Has("Rehire extra crew when lost") && hasSpaceport)
+	if(Preferences::Has("Rehire extra crew when lost") && hasSpaceport && flagship)
 	{
 		int added = desiredCrew - flagship->Crew();
 		if(added > 0)


### PR DESCRIPTION
Fixes crash when you create a new player with the preference "Rehire extra crew when lost" enabled.

References: #3086 #3089