### PR TITLE
Suspend the boarding approach when too far away or too fast.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3000,12 +3000,10 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		keyStuck.Clear(Command::LAND);
 	if(keyStuck.Has(Command::JUMP) && !(ship.GetTargetSystem() || isWormhole))
 		keyStuck.Clear(Command::JUMP);
-	if(keyStuck.Has(Command::BOARD) && !ship.GetTargetShip())
+	if(keyStuck.Has(Command::BOARD) && !(ship.GetTargetShip() && CanBoard(ship, *ship.GetTargetShip())))
 		keyStuck.Clear(Command::BOARD);
 	
-	if(ship.IsBoarding())
-		keyStuck.Clear();
-	else if(keyStuck.Has(Command::LAND) || (keyStuck.Has(Command::JUMP) && isWormhole))
+	if(keyStuck.Has(Command::LAND) || (keyStuck.Has(Command::JUMP) && isWormhole))
 	{
 		if(ship.GetPlanet())
 			keyStuck.Clear();

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1282,8 +1282,6 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	}
 	
 	// Boarding:
-	if(isBoarding && (commands.Has(Command::FORWARD | Command::BACK) || commands.Turn()))
-		isBoarding = false;
 	shared_ptr<const Ship> target = GetTargetShip();
 	// If this is a fighter or drone and it is not assisting someone at the
 	// moment, its boarding target should be its parent ship.
@@ -1295,7 +1293,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		double distance = dp.Length();
 		Point dv = (target->velocity - velocity);
 		double speed = dv.Length();
-		isBoarding |= (distance < 50. && speed < 1. && commands.Has(Command::BOARD));
+		isBoarding = (distance < 50. && speed < 1. && commands.Has(Command::BOARD));
 		if(isBoarding && !CanBeCarried())
 		{
 			if(!target->IsDisabled() && government->IsEnemy(target->government))


### PR DESCRIPTION
The boarding approach changes the ship angle, velocity, and position artificially (no engines). It is activated when you are close enough and slow enough.

After activating it, you can become too far away by selecting another target and you can become too fast by getting hit. With this commit the boarding approach will be temporarily suspended until you get close enough and slow enough again.