### PR TITLE
Refactor PlayerInfo::Land

### DIFF
--- a/source/Mission.h
+++ b/source/Mission.h
@@ -191,6 +191,8 @@ private:
 	std::set<const System *> didEnter;
 	std::set<const Planet *> stopovers;
 	std::list<LocationFilter> stopoverFilters;
+	std::set<const Planet *> visitedStopovers;
+	std::set<const System *> visitedWaypoints;
 	
 	// NPCs:
 	std::list<NPC> npcs;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -160,7 +160,6 @@ void PlayerInfo::Load(const string &path)
 			ships.push_back(shared_ptr<Ship>(new Ship()));
 			ships.back()->Load(child);
 			ships.back()->SetIsSpecial();
-			ships.back()->SetGovernment(GameData::PlayerGovernment());
 			ships.back()->FinishLoading(false);
 			ships.back()->SetIsYours();
 		}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2557,7 +2557,8 @@ void PlayerInfo::Fine(UI *ui)
 					" Your days of traveling the stars have come to an end.";
 				ui->Push(new Dialog(message));
 			}
-			Die();
+			// All ships belonging to the player should be removed.
+			Die(true);
 		}
 		else
 			ui->Push(new Dialog(message));

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -250,8 +250,12 @@ private:
 	// New missions are generated each time you land on a planet.
 	void UpdateAutoConditions();
 	void CreateMissions();
+	void StepMissions(UI *ui);
 	void Autosave() const;
 	void Save(const std::string &path) const;
+	
+	// Check for and apply any punitive actions from planetary security.
+	void Fine(UI *ui);
 	
 	// Helper function to update the ship selection.
 	void SelectShip(const std::shared_ptr<Ship> &ship, bool *first);


### PR DESCRIPTION
 - Use StepMissions() to handle changes to active missions - recording NPC self-destructs, completions, failures, etc.
 - Planets for which mission clearance has been given (or if infiltrating) will not fine the player ( Refs #1452 )