### PR TITLE
Make Illegal and Stealth work for passengers, too

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -581,7 +581,7 @@ int CargoHold::IllegalCargoFine() const
 			return fine;
 		worst = max(worst, fine / 2);
 	}
-
+	
 	for(const auto &it : missionCargo)
 	{
 		int fine = it.first->IllegalCargoFine();

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -581,8 +581,16 @@ int CargoHold::IllegalCargoFine() const
 			return fine;
 		worst = max(worst, fine / 2);
 	}
-	
+
 	for(const auto &it : missionCargo)
+	{
+		int fine = it.first->IllegalCargoFine();
+		if(fine < 0)
+			return fine;
+		worst = max(worst, fine);
+	}
+
+	for(const auto &it : passengers)
 	{
 		int fine = it.first->IllegalCargoFine();
 		if(fine < 0)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -123,6 +123,20 @@ void Mission::Load(const DataNode &node)
 				passengerLimit = child.Value(2);
 			if(child.Size() >= 4)
 				passengerProb = child.Value(3);
+			for(const DataNode &grand : child)
+			{
+				if(grand.Token(0) == "illegal" && grand.Size() == 2)
+					illegalCargoFine = grand.Value(1);
+				else if(grand.Token(0) == "illegal" && grand.Size() == 3)
+				{
+					illegalCargoFine = grand.Value(1);
+					illegalCargoMessage = grand.Token(2);
+				}
+				else if(grand.Token(0) == "stealth")
+					failIfDiscovered = true;
+				else
+					grand.PrintTrace("Skipping unrecognized attribute:");
+			}
 		}
 		else if(child.Token(0) == "invisible")
 			isVisible = false;
@@ -260,7 +274,25 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			}
 		}
 		if(passengers)
+		{
 			out.Write("passengers", passengers);
+			if(illegalCargoFine)
+			{
+				out.BeginChild();
+				{
+					out.Write("illegal", illegalCargoFine, illegalCargoMessage);
+				}
+				out.EndChild();
+			}
+			if(failIfDiscovered)
+			{
+				out.BeginChild();
+				{
+					out.Write("stealth");
+				}
+				out.EndChild();
+			}
+		}
 		if(!isVisible)
 			out.Write("invisible");
 		if(hasPriority)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -100,21 +100,7 @@ void Mission::Load(const DataNode &node)
 				cargoLimit = child.Value(3);
 			if(child.Size() >= 5)
 				cargoProb = child.Value(4);
-			
-			for(const DataNode &grand : child)
-			{
-				if(grand.Token(0) == "illegal" && grand.Size() == 2)
-					illegalCargoFine = grand.Value(1);
-				else if(grand.Token(0) == "illegal" && grand.Size() == 3)
-				{
-					illegalCargoFine = grand.Value(1);
-					illegalCargoMessage = grand.Token(2);
-				}
-				else if(grand.Token(0) == "stealth")
-					failIfDiscovered = true;
-				else
-					grand.PrintTrace("Skipping unrecognized attribute:");
-			}
+			HandleContraband(child);
 		}
 		else if(child.Token(0) == "passengers" && child.Size() >= 2)
 		{
@@ -123,20 +109,7 @@ void Mission::Load(const DataNode &node)
 				passengerLimit = child.Value(2);
 			if(child.Size() >= 4)
 				passengerProb = child.Value(3);
-			for(const DataNode &grand : child)
-			{
-				if(grand.Token(0) == "illegal" && grand.Size() == 2)
-					illegalCargoFine = grand.Value(1);
-				else if(grand.Token(0) == "illegal" && grand.Size() == 3)
-				{
-					illegalCargoFine = grand.Value(1);
-					illegalCargoMessage = grand.Token(2);
-				}
-				else if(grand.Token(0) == "stealth")
-					failIfDiscovered = true;
-				else
-					grand.PrintTrace("Skipping unrecognized attribute:");
-			}
+			HandleContraband(child);
 		}
 		else if(child.Token(0) == "invisible")
 			isVisible = false;
@@ -1115,4 +1088,24 @@ const Planet *Mission::PickPlanet(const LocationFilter &filter, const PlayerInfo
 			options.push_back(&it.second);
 	}
 	return options.empty() ? nullptr : options[Random::Int(options.size())];
+}
+
+
+
+void Mission::HandleContraband(const DataNode &child)
+{
+	for(const DataNode &grand : child)
+	{
+		if(grand.Token(0) == "illegal" && grand.Size() == 2)
+			illegalCargoFine = grand.Value(1);
+		else if(grand.Token(0) == "illegal" && grand.Size() == 3)
+		{
+			illegalCargoFine = grand.Value(1);
+			illegalCargoMessage = grand.Token(2);
+		}
+		else if(grand.Token(0) == "stealth")
+			failIfDiscovered = true;
+		else
+			grand.PrintTrace("Skipping unrecognized attribute:");
+	}
 }

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -141,6 +141,7 @@ private:
 	void Enter(const System *system, PlayerInfo &player, UI *ui);
 	const System *PickSystem(const LocationFilter &filter, const PlayerInfo &player) const;
 	const Planet *PickPlanet(const LocationFilter &filter, const PlayerInfo &player) const;
+	void HandleContraband(const DataNode &child);
 	
 	
 private:


### PR DESCRIPTION
Now you can write passenger-only missions where being scanned will get you fined and/or fail the mission, like so:

![it worked](https://user-images.githubusercontent.com/1097249/32695763-9f392c0a-c722-11e7-95ae-ff666aae7d71.png)
