### PR TITLE
Ctrl-Shift-Arrow key moves selected ships on PlayerInfoPanel

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -822,6 +822,10 @@ int PlayerInfo::ReorderShips(const set<int> &fromIndices, int toIndex)
 	if(fromIndices.empty() || static_cast<unsigned>(toIndex) >= ships.size())
 		return -1;
 	
+	// When shifting ships up in the list, move to the desired index. If
+	// moving down, move after the selected index.
+	int direction = (*fromIndices.begin() < toIndex) ? 1 : 0;
+	
 	// Remove the ships from last to first, so that each removal leaves all the
 	// remaining indices in the set still valid.
 	vector<shared_ptr<Ship>> removed;
@@ -842,10 +846,12 @@ int PlayerInfo::ReorderShips(const set<int> &fromIndices, int toIndex)
 		if(*it < toIndex)
 			--toIndex;
 	}
-	ships.insert(ships.begin() + toIndex, removed.begin(), removed.end());
+	vector<shared_ptr<Ship>>::const_iterator insertPos = ships.begin() + toIndex + direction;
+	ships.insert(insertPos > ships.end() ? ships.end() : insertPos,
+			removed.begin(), removed.end());
 	flagship.reset();
 	
-	return toIndex;
+	return toIndex + direction;
 }
 
 

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -229,13 +229,11 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 					++toIndex;
 					++next;
 				}
-				// Shift 1 extra for the first ship in the selection.
-				++toIndex;
 			}
 			
 			// Clamp the destination index to the end of the ships list.
 			size_t moved = allSelected.size();
-			toIndex = min(player.Ships().size() - moved + 1, static_cast<size_t>(toIndex));
+			toIndex = min(player.Ships().size() - moved, static_cast<size_t>(toIndex));
 			selectedIndex = player.ReorderShips(allSelected, toIndex);
 			// If the move accessed invalid indices, no moves are done
 			// but the selectedIndex is set to -1.

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -208,6 +208,54 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 				Scroll(-player.Ships().size());
 			}
 		}
+		// Holding both Ctrl & Shift keys and using the arrows moves the
+		// selected ship group up or down one row.
+		else if(!allSelected.empty() && (mod & KMOD_CTRL) && (mod & KMOD_SHIFT))
+		{
+			// Move based on the position of the first selected ship. An upward
+			// movement is a shift of one, while a downward move shifts 1 and
+			// then 1 for each ship in the contiguous selection.
+			size_t toIndex = *allSelected.begin();
+			if(key == SDLK_UP && toIndex > 0)
+				--toIndex;
+			else if(key == SDLK_DOWN)
+			{
+				int next = ++toIndex;
+				for(set<int>::const_iterator sel = allSelected.begin(); ++sel != allSelected.end(); )
+				{
+					if(*sel != next)
+						break;
+					
+					++toIndex;
+					++next;
+				}
+				// Shift 1 extra for the first ship in the selection.
+				++toIndex;
+			}
+			
+			// Clamp the destination index to the end of the ships list.
+			size_t moved = allSelected.size();
+			toIndex = min(player.Ships().size() - moved + 1, static_cast<size_t>(toIndex));
+			selectedIndex = player.ReorderShips(allSelected, toIndex);
+			// If the move accessed invalid indices, no moves are done
+			// but the selectedIndex is set to -1.
+			if(selectedIndex < 0)
+				selectedIndex = *allSelected.begin();
+			else
+			{
+				// Update the selected indices so they still refer
+				// to the block of ships that just got moved.
+				int lastIndex = selectedIndex + moved;
+				allSelected.clear();
+				for(int i = selectedIndex; i < lastIndex; ++i)
+					allSelected.insert(i);
+			}
+			// Update the scroll if necessary to keep the selected ship on screen.
+			int scrollDirection = ((selectedIndex >= scroll + LINES_PER_PAGE) - (selectedIndex < scroll));
+			if(selectedIndex >= 0 && Scroll((LINES_PER_PAGE - 2) * scrollDirection))
+				hoverIndex = -1;
+			return true;
+		}
 		else
 		{
 			// Move the selection up or down one space.


### PR DESCRIPTION
Refs #3202 
Ctrl+Shift+Up -> move the selected ships up one space
Ctrl+Shift+Down -> move the selected ships down one space.

Tweaked the position selection for PlayerInfo::ReorderShips so that the direction of movement indicates which side of the position is moved to:
 - If moving up the list, current behavior (first selected ship moves to the targeted index)
 - If moving down the list, move one more (the ship at the targeted index is moved ahead of the first ship.

This altered behavior means that the selected ship can be dragged (or arrow-keyed) to the end of the list, and not just the position before it.

As with drag-moving non-adjacent ships, they are all grouped after the movement.