### PR TITLE
Boarding a faction increases the chance of being targeted by them

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -244,7 +244,10 @@ void AI::UpdateEvents(const list<ShipEvent> &events)
 	for(const ShipEvent &event : events)
 	{
 		if(event.Actor() && event.Target())
+		{
 			actions[event.Actor()][event.Target()] |= event.Type();
+			notoriety[event.Actor()][event.TargetGovernment()] |= event.Type();
+		}
 		if(event.ActorGovernment() && event.Target())
 			governmentActions[event.ActorGovernment()][event.Target()] |= event.Type();
 		if(event.ActorGovernment()->IsPlayer() && event.Target())
@@ -265,6 +268,7 @@ void AI::UpdateEvents(const list<ShipEvent> &events)
 void AI::Clean()
 {
 	actions.clear();
+	notoriety.clear();
 	governmentActions.clear();
 	playerActions.clear();
 	shipStrength.clear();
@@ -943,6 +947,8 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 			}
 			// Prefer to go after armed targets, especially if you're not a pirate.
 			range += 1000. * (!IsArmed(*it) * (1 + !person.Plunders()));
+			// Targets which have plundered this ship's faction earn extra scorn.
+			range -= 1000 * Has(*it, gov, ShipEvent::BOARD);
 			// Focus on nearly dead ships.
 			range += 500. * (it->Shields() + it->Hull());
 			if((isPotentialNemesis && !hasNemesis) || range < closest)
@@ -962,8 +968,9 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 		for(const auto &it : ships)
 			if(it->GetSystem() == system && it->GetGovernment() != gov && it->IsTargetable())
 			{
-				if((cargoScan && !Has(ship.GetGovernment(), it, ShipEvent::SCAN_CARGO))
-						|| (outfitScan && !Has(ship.GetGovernment(), it, ShipEvent::SCAN_OUTFITS)))
+				// Scan friendly ships that are as-yet unscanned by this ship's government.
+				if((cargoScan && !Has(gov, it, ShipEvent::SCAN_CARGO))
+						|| (outfitScan && !Has(gov, it, ShipEvent::SCAN_OUTFITS)))
 				{
 					double range = it->Position().Distance(ship.Position());
 					if(range < closest)
@@ -3089,6 +3096,23 @@ bool AI::Has(const Government *government, const weak_ptr<const Ship> &other, in
 		return false;
 	
 	return (oit->second & type);
+}
+
+
+
+// True if the ship has committed the action against that government. For
+// example, if the player boarded any ship belonging to that government.
+bool AI::Has(const Ship &ship, const Government *government, int type) const
+{
+	auto sit = notoriety.find(ship.shared_from_this());
+	if(sit == notoriety.end())
+		return false;
+	
+	auto git = sit->second.find(government);
+	if(git == sit->second.end())
+		return false;
+	
+	return (git->second & type);
 }
 
 

--- a/source/AI.h
+++ b/source/AI.h
@@ -120,8 +120,12 @@ private:
 	
 	void MovePlayer(Ship &ship, const PlayerInfo &player);
 	
+	// True if the ship performed the indicated event to the other ship.
 	bool Has(const Ship &ship, const std::weak_ptr<const Ship> &other, int type) const;
+	// True if the government performed the indicated event to the other ship.
 	bool Has(const Government *government, const std::weak_ptr<const Ship> &other, int type) const;
+	// True if the ship has performed the indicated event against any member of the government.
+	bool Has(const Ship &ship, const Government *government, int type) const;
 	
 	
 private:
@@ -179,6 +183,7 @@ private:
 	// Records of what various AI ships and factions have done.
 	typedef std::owner_less<std::weak_ptr<const Ship>> Comp;
 	std::map<std::weak_ptr<const Ship>, std::map<std::weak_ptr<const Ship>, int, Comp>, Comp> actions;
+	std::map<std::weak_ptr<const Ship>, std::map<const Government *, int>, Comp> notoriety;
 	std::map<const Government *, std::map<std::weak_ptr<const Ship>, int, Comp>> governmentActions;
 	std::map<std::weak_ptr<const Ship>, int, Comp> playerActions;
 	std::map<const Ship *, std::weak_ptr<Ship>> helperList;


### PR DESCRIPTION
Refs #2256 , 

There were two ways to perform the check in the new `Has()` method:
1) loop every ship in the `actions` map, and check if their government is the same as the ship performing the targeting check, and then if they have been the target of the event in question
2) Add a map which stores this information directly

I went with route 2 as it is logically simpler to understand, and requires no loops in the new method.

The specific value of the prioritization could be tweaked. I wanted it to offset the deprioritization caused by removing all weapons from one's ship, but it's possible this value will result in armed ships that plunder being excessively targeted by other members of the boarded factions. However, IMO this is a warranted side-effect of boarding and (and likely destroying) otherwise harmless entities.
