### PR TITLE
Remove deprecated bribe action

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2188,8 +2188,6 @@ void PlayerInfo::ApplyChanges()
 			for(const Planet *planet : mission.Stopovers())
 				planet->Bribe(mission.HasFullClearance());
 		}
-	if(system)
-		GameData::GetPolitics().Bribe(system->GetGovernment());
 	
 	// It is sometimes possible for the player to be landed on a planet where
 	// they do not have access to any services. So, this flag is used to specify


### PR DESCRIPTION
 - Check was added in 03a9a089df3e9440e784604de0c80e8365a447be, when the fine action did not check if the player was freshly loaded.
 - Check was deprecated by 2866bcf1c65abd90db07ffb7e470c2f73bf9485f

I originally made this commit on #3070 but I'm not sure how soon that will be merged.
Relevant comment:
>When I was developing this (and ships were shown while landed), I couldn't figure out how IsEnemy was returning false for "known" hostiles (which led to using both "IsEnemy()" and "rep < 0" checks). While swapping to use System::Danger in the map coloring scheme, I noticed this issue on a massive scale - all because I'm landed on Greenrock, which resulted in auto-bribing the Pirate government upon game load.
