### PR TITLE
bugfix: Allied mission NPCs should prepare to jump with the player if player is holding J

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1779,10 +1779,11 @@ bool Ship::IsUsingJumpDrive() const
 
 
 // Check if this ship is currently able to enter hyperspace to it target.
-bool Ship::IsReadyToJump() const
+bool Ship::IsReadyToJump(bool checkWait) const
 {
 	// You can't jump if you're waiting for someone else or are already jumping.
-	if(IsDisabled() || commands.Has(Command::WAIT) || hyperspaceCount || !targetSystem)
+	if(IsDisabled() || hyperspaceCount || !targetSystem
+			|| (checkWait && commands.Has(Command::WAIT)))
 		return false;
 	
 	// Check if the target system is valid and there is enough fuel to jump.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -202,8 +202,8 @@ public:
 	bool IsHyperspacing() const;
 	// Check if this ship is hyperspacing, specifically via a jump drive.
 	bool IsUsingJumpDrive() const;
-	// Check if this ship is currently able to enter hyperspace to it target.
-	bool IsReadyToJump() const;
+	// Check if this ship is currently able to enter hyperspace to its target.
+	bool IsReadyToJump(bool checkWait = true) const;
 	// Get this ship's custom swizzle.
 	int CustomSwizzle() const;
 	


### PR DESCRIPTION
Refs #3243 , #3065 , #3052 

"Grandparent" knowledge is needed in AI::Step else the NPC's escorts will continually turn towards a hostile target and then back to the jump direction.