### PR TITLE
Overheated/Hyperspacing ships don't need to decide on actions

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -362,24 +362,17 @@ void AI::Step(const PlayerInfo &player)
 		bool isPresent = (it->GetSystem() == player.GetSystem());
 		bool isStranded = IsStranded(*it);
 		bool thisIsLaunching = (isLaunching && it->GetSystem() == player.GetSystem());
-		if(isStranded || it->IsDisabled() || it->IsOverheated())
+		if(isStranded || it->IsDisabled())
 		{
 			// Derelicts never ask for help, to make sure that only the player
 			// will repair them.
 			if(it->IsDestroyed() || it->GetPersonality().IsDerelict())
 				continue;
 			
-			bool isDisabled = it->IsDisabled();
-			// An overheated ship should only ask for help if it is
-			// also disabled, or in need of fuel. If it's just too
-			// hot, there's nothing for it to do this turn.
-			if(!isStranded && !isDisabled && it->IsOverheated())
-				continue;
-			
 			// Attempt to find a friendly ship to render assistance.
 			AskForHelp(*it, isStranded, flagship);
 			
-			if(isDisabled)
+			if(it->IsDisabled())
 			{
 				// Ships other than escorts should deploy fighters if disabled.
 				if(!it->IsYours() || thisIsLaunching)
@@ -390,6 +383,9 @@ void AI::Step(const PlayerInfo &player)
 				continue;
 			}
 		}
+		if(it->IsOverheated())
+			continue;
+		
 		// Special case: if the player's flagship tries to board a ship to
 		// refuel it, that escort should hold position for boarding.
 		isStranded |= (flagship && it == flagship->GetTargetShip() && CanBoard(*flagship, *it)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -365,14 +365,21 @@ void AI::Step(const PlayerInfo &player)
 		if(isStranded || it->IsDisabled() || it->IsOverheated())
 		{
 			// Derelicts never ask for help, to make sure that only the player
-			// will repair them. Destroyed / overheated ships cannot be helped.
-			if(it->IsDestroyed() || it->GetPersonality().IsDerelict() || it->IsOverheated())
+			// will repair them.
+			if(it->IsDestroyed() || it->GetPersonality().IsDerelict())
+				continue;
+			
+			bool isDisabled = it->IsDisabled();
+			// An overheated ship should only ask for help if it is
+			// also disabled, or in need of fuel. If it's just too
+			// hot, there's nothing for it to do this turn.
+			if(!isStranded && !isDisabled && it->IsOverheated())
 				continue;
 			
 			// Attempt to find a friendly ship to render assistance.
 			AskForHelp(*it, isStranded, flagship);
 			
-			if(it->IsDisabled())
+			if(isDisabled)
 			{
 				// Ships other than escorts should deploy fighters if disabled.
 				if(!it->IsYours() || thisIsLaunching)


### PR DESCRIPTION
 - Hyperspacing ships can still (de)cloak and autofire weapons, but have no ability to change their movement strategies.
 - Overheated ships are effectively disabled, but IsDisabled explicitly does not return true for a ship which is solely overheated (so the radar can blink their pointer properly)
 - Stranded/Disabled ships shouldn't ask overheated or hyperspacing ships for help since that help may be a long time coming.


This should cut down on a bunch of repeated-yet-unnecessary movement routing checks (e.g. a ship picked a destination and is already jumping to it - no need to keep checking if it should refuel, if it can get there, etc.).