### PR TITLE
Surveillance Pod has some tactical scan power

### DIFF
--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -234,7 +234,7 @@ outfit "Tactical Scanner"
 
 outfit "Surveillance Pod"
 	category "Systems"
-	cost 42000
+	cost 122500
 	thumbnail "outfit/surveillance pod"
 	"mass" 5
 	"outfit space" -5
@@ -243,6 +243,7 @@ outfit "Surveillance Pod"
 	"cargo scan power" 4
 	"cargo scan speed" 2
 	"atmosphere scan" 100
+	"tactical scan power" 9
 	description "This is Navy technology, a collection of scanners designed to fit perfectly inside one of their surveillance drones. Since the outputs are fairly standard, you could connect it to your own ship's systems if you want. Installing more than one increases the scan range and speed."
 
 


### PR DESCRIPTION
The dedicated Tactical Scanner gives 100 * sqrt(32) range (565),  while this multipurpose outfit gives a tactical range of 300. Increased the price based on the new ability, ~144000 / sqrt(32) * sqrt(9)

I don't see any reason for the Navy to care about what asteroids contain (assuming IED asteroids isn't a thing yet), so I did not feel it necessary to include "asteroid scan power."