### PR TITLE
Add “medium freighter” category

### DIFF
--- a/data/coalition ships.txt
+++ b/data/coalition ships.txt
@@ -55,7 +55,7 @@ ship "Arach Courier"
 ship "Arach Freighter"
 	sprite "ship/arach freighter"
 	attributes
-		category "Light Freighter"
+		category "Medium Freighter"
 		licenses
 			Coalition
 		"cost" 4580000
@@ -157,7 +157,7 @@ ship "Arach Hulk"
 ship "Arach Spindle"
 	sprite "ship/arach spindle"
 	attributes
-		category "Heavy Freighter"
+		category "Medium Freighter"
 		licenses
 			Coalition
 		"cost" 6652000
@@ -208,7 +208,7 @@ ship "Arach Spindle"
 ship "Arach Transport"
 	sprite "ship/arach transport"
 	attributes
-		category "Light Freighter"
+		category "Medium Freighter"
 		licenses
 			Coalition
 		"cost" 2772000
@@ -862,7 +862,7 @@ ship "Saryd Sojourner"
 ship "Saryd Traveler"
 	sprite "ship/saryd traveler"
 	attributes
-		category "Heavy Freighter"
+		category "Medium Freighter"
 		licenses
 			Coalition
 		"cost" 3385000

--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -575,7 +575,7 @@ ship "Violin Spider" "Violin Spider (Pulse)"
 ship "Water Bug"
 	sprite "ship/hai water bug"
 	attributes
-		category "Heavy Freighter"
+		category "Medium Freighter"
 		"cost" 6500000
 		"shields" 7900
 		"hull" 4500

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -66,7 +66,7 @@ ship "Argosy"
 	plural "Argosies"
 	sprite "ship/argosy"
 	attributes
-		category "Light Freighter"
+		category "Medium Freighter"
 		"cost" 1960000
 		"shields" 4200
 		"hull" 2600
@@ -317,12 +317,12 @@ ship "Bastion"
 		"hull" 4200
 		"required crew" 32
 		"bunks" 47
-		"mass" 580
+		"mass" 540
 		"drag" 10.3
 		"heat dissipation" .5
 		"fuel capacity" 500
 		"cargo space" 110
-		"outfit space" 470
+		"outfit space" 450
 		"weapon capacity" 180
 		"engine capacity" 120
 		weapon
@@ -1483,7 +1483,7 @@ ship "Gunboat"
 ship "Hauler"
 	sprite "ship/hauler i"
 	attributes
-		category "Light Freighter"
+		category "Medium Freighter"
 		"cost" 1430000
 		"shields" 2500
 		"hull" 3700
@@ -1537,7 +1537,7 @@ ship "Hauler"
 ship "Hauler II"
 	sprite "ship/hauler ii"
 	attributes
-		category "Heavy Freighter"
+		category "Medium Freighter"
 		"cost" 2340000
 		"shields" 2900
 		"hull" 5200
@@ -1591,7 +1591,7 @@ ship "Hauler II"
 ship "Hauler III"
 	sprite "ship/hauler iii"
 	attributes
-		category "Heavy Freighter"
+		category "Medium Freighter"
 		"cost" 3260000
 		"shields" 3300
 		"hull" 6700
@@ -1923,7 +1923,7 @@ ship "Modified Argosy"
 	plural "Modified Argosies"
 	sprite "ship/modified argosy"
 	attributes
-		category "Light Warship"
+		category "Medium Warship"
 		"cost" 1960000
 		"shields" 4800
 		"hull" 1900

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -317,12 +317,12 @@ ship "Bastion"
 		"hull" 4200
 		"required crew" 32
 		"bunks" 47
-		"mass" 540
+		"mass" 580
 		"drag" 10.3
 		"heat dissipation" .5
 		"fuel capacity" 500
 		"cargo space" 110
-		"outfit space" 450
+		"outfit space" 470
 		"weapon capacity" 180
 		"engine capacity" 120
 		weapon
@@ -1923,7 +1923,7 @@ ship "Modified Argosy"
 	plural "Modified Argosies"
 	sprite "ship/modified argosy"
 	attributes
-		category "Medium Warship"
+		category "Light Warship"
 		"cost" 1960000
 		"shields" 4800
 		"hull" 1900

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -45,7 +45,8 @@ namespace {
 
 const vector<string> Ship::CATEGORIES = {
 	"Transport",
-	"Light Freighter",
+	"Light Freighter",	
+	"Medium Freighter",
 	"Heavy Freighter",
 	"Interceptor",
 	"Light Warship",


### PR DESCRIPTION
Warships are subdivided into light, medium, and heavy; the criterion seems to be the empty mass (i.e. hull plus outfit capacity).
```
                    mass
light  warship:     <500
medium warship: 500-1000
heavy  warship:    >1000
```

Freighter categories are currently assigned rather arbitrarily. This pull request changes that to harmonize freighter categories to those of warships.
The Hauler, Hauler II, and Hauler III all fit within the medium category (cf. their warship counterparts Nest, Roost, and Skein), as do a few others. 
