### PR TITLE
Change "Modified Argosy" class to "Medium Warship"

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1923,7 +1923,7 @@ ship "Modified Argosy"
 	plural "Modified Argosies"
 	sprite "ship/modified argosy"
 	attributes
-		category "Light Warship"
+		category "Medium Warship"
 		"cost" 1960000
 		"shields" 4800
 		"hull" 1900


### PR DESCRIPTION
Converted the "Medium Argosy" into a "Medium Warship", because it's statistically closer to medium warships than it is to light warships.

A comparison of human space heavy warships (and freighters):
```
                   guns + turrets, weapons + engines,   outfits + mass,       hull + shields
Bactrian         :      4 + 6 = 10,  300 + 180 = 480, 740 + 940 = 1680, 8600 + 17500 = 26100
Behemoth         :      2 + 6 = 8,   280 +  90 = 270, 510 + 540 = 1050, 6300 +  7600 = 13900
Bulk Freighter   :      1 + 6 = 7,   180 +  85 = 265, 410 + 870 = 1280, 7600 +  4000 = 11600
Carrier          :      8 + 4 = 12,  370 + 210 = 580, 870 + 910 = 1780, 8300 + 21400 = 29700
Class C Freighter:      0 + 4 = 4,   140 +  85 = 225, 400 + 810 = 1210, 7600 + 13500 = 21100
Cruiser          :      6 + 4 = 10,  320 + 170 = 490, 760 + 680 = 1440, 6400 + 19600 = 26000
Dreadnought      :      4 + 5 = 9,   360 + 190 = 550, 790 + 630 = 1420, 7300 + 18100 = 25400
Falcon           :      4 + 4 = 8,   240 + 150 = 390, 540 + 510 = 1050, 3700 + 12800 = 16500
Leviathan        :      4 + 4 = 8,   240 + 120 = 360, 620 + 480 = 1100, 5000 + 14400 = 19400
*Modified Argosy*:      4 + 2 = 6,   140 +  80 = 220, 340 + 250 =  590, 1900 +  4800 =  6700
Protector        :      2 + 6 = 8,   220 + 100 = 320, 570 + 500 = 1070, 6500 +  9500 = 16000
Vanguard         :      7 + 1 = 8,   220 + 120 = 340, 560 + 500 = 1060, 6000 +  9800 = 15800
```
It is clear that the "Modified Argosy" does not belong here amongst the heavy warships.


A comparison of human space medium warships:
```
                   guns + turrets, weapons + engines,   outfits + mass,      hull + shields
Aerie            :      2 + 3 = 5,   150 +  95 = 245, 390 + 130 =  520, 1900 +  5700 =  7600
Bastion          :      4 + 3 = 7,   180 + 120 = 300, 470 + 580 = 1050, 4200 +  6700 = 10900
Corvette         :      4 + 2 = 6,   150 + 100 = 250, 420 + 150 =  570, 1200 +  6100 =  7300
Firebird         :      4 + 2 = 6,   160 + 100 = 260, 400 + 290 =  690, 2800 +  6400 =  9200
Frigate          :      4 + 3 = 7,   170 + 100 = 270, 410 + 310 =  720, 2500 +  8000 = 10500
Manta            :      6 + 0 = 6,   140 + 100 = 240, 350 + 170 =  520, 1500 +  5900 =  7400
*Modified Argosy*:      4 + 2 = 6,   140 +  80 = 220, 340 + 250 =  590, 1900 +  4800 =  6700
Mule             :      2 + 4 = 6,   210 + 110 = 320, 450 + 320 =  770, 4400 +  5400 =  9800
Nest             :      2 + 4 = 6,   140 +  80 = 220, 400 + 250 =  650, 3700 +  2500 =  6200
Osprey           :      4 + 2 = 6,   180 + 130 = 310, 450 + 270 =  620, 1600 +  7200 =  8800
Roost            :      2 + 4 = 6,   140 +  80 = 220, 450 + 360 =  810, 5200 +  2900 =  8100
Skein            :      2 + 4 = 6,   140 +  80 = 220, 500 + 470 =  970, 6700 +  3300 = 10000
Splinter         :      2 + 3 = 5,   150 + 100 = 250, 400 + 250 =  650, 1700 +  5200 =  6900
```
It is clear that the "Modified Argosy" is statistically similar to all medium warships.


A comparison of human space light warships:
```
                   guns + turrets, weapons + engines,   outfits + mass,       hull + shields
Gunboat          :      2 + 1 = 3,   100 +  90 = 190, 270 + 150 =  410, 1400 +  5800 =  7200
Headhunter       :      2 + 1 = 3,    60 +  80 = 140, 250 + 120 =  370,  700 +  3800 =  4500
*Modified Argosy*:      4 + 2 = 6,   140 +  80 = 220, 340 + 250 =  590, 1900 +  4800 =  6700
Quicksilver      :      2 + 0 = 2,    60 +  70 = 130, 240 + 120 =  360,  800 +  3000 =  3800
Rainmaker        :      6 + 0 = 6,    60 +  50 = 110, 230 + 180 =  410, 1200 +  3500 =  4700
Raven            :      4 + 0 = 4,    90 + 100 = 190, 280 + 130 =  410, 1400 +  4700 =  6100
```
It is clear that the "Modified Argosy" is overall heavier than all other light warships.