### PR TITLE
Removed common shuttle from luxury shipyard

### DIFF
--- a/data/sales.txt
+++ b/data/sales.txt
@@ -103,7 +103,6 @@ shipyard "Northern Pirates"
 	"Berserker"
 
 shipyard "Luxury Ships"
-	"Shuttle"
 	"Blackbird"
 	"Falcon"
 	"Arrow"


### PR DESCRIPTION
The Luxury Shipyard (at Shroud) already sells three other shuttles, so there is no real need for selling the cheap shuttle as well. Furthermore, the common shuttle is already sold at many other systems, including neighbouring Betelgeuse.