### PR TITLE
Tweaked gatling gun ammo price.

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -1021,7 +1021,7 @@ effect "nuke residue slow"
 outfit "Gatling Gun Ammo"
 	plural "Gatling Gun Ammo"
 	category "Ammunition"
-	cost 2
+	cost 4
 	thumbnail "outfit/bullet"
 	"mass" .002
 	"gatling round capacity" -1


### PR DESCRIPTION
Changed "Gatling Gun Ammo" value to 4 each, because 25% of 4 is 1 (and 25% of 2 is 0).