### PR TITLE
Lowered Star Queen minimum crew

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2695,7 +2695,7 @@ ship "Star Queen"
 		"cost" 5500000
 		"shields" 4100
 		"hull" 2200
-		"required crew" 43
+		"required crew" 27
 		"bunks" 112
 		"mass" 230
 		"drag" 5.5


### PR DESCRIPTION
The Star Queen currently is not only the least efficient passenger transport, it's actually worse than almost all cargo freighters. Let's have a look at passenger to crew ratios (higher values are better):

```
Bounder       :  17/1  - 1 =  16    : 1
Blackbird     :  28/3  - 1 =   8.33 : 1
Heavy Shuttle :   8/1  - 1 =   7    : 1
Mule          :  43/6  - 1 =   6.2  : 1
Scout         :  12/2  - 1 =   5    : 1
Shuttle       :   6/1  - 1 =   5    : 1
Arrow         :   5/1  - 1 =   4    : 1
Hauler        :  12/3  - 1 =   3    : 1
Hauler II     :  12/3  - 1 =   3    : 1
Hauler III    :  12/3  - 1 =   3    : 1
Argosy        :  14/4  - 1 =   2.5  : 1
Bactrian      : 245/70 - 1 =   2.5  : 1
Freighter     :   7/2  - 1 =   2.5  : 1
Flivver       :   3/1  - 1 =   2    : 1
Clipper       :   9/3  - 1 =   2    : 1
Star Barge    :   3/1  - 1 =   2    : 1
Bulk Freighter:  18/6  - 1 =   2    : 1
*Star Queen*  : 112/43 - 1 =   1.6  : 1
Behemoth      :  30/12 - 1 =   1.5  : 1
```
As you can see currently only the Behemoth is worse than the Star Queen. By lowering the minimum crew to 27, the Star Queen becomes twice as efficient, with a ratio of 3.14:1, putting it at least above the freighters, although it remains the worst of all passenger transports.