### PR TITLE
Weapon blast strength decreases with distance from blast

### DIFF
--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -199,7 +199,7 @@ namespace {
 	
 	
 	// Find the radius of the object.
-	double Radius(const vector<Point> &outline)
+	double ComputeRadius(const vector<Point> &outline)
 	{
 		double radius = 0.;
 		for(const Point &p : outline)
@@ -229,7 +229,7 @@ void Mask::Create(const ImageBuffer &image, int frame)
 	
 	Simplify(raw, &outline);
 	
-	radius = Radius(outline);
+	radius = ComputeRadius(outline);
 }
 
 
@@ -323,6 +323,13 @@ double Mask::Range(Point point, Angle facing) const
 		range = min(range, p.Distance(point));
 	
 	return range;
+}
+
+
+
+double Mask::Radius() const
+{
+	return radius;
 }
 
 

--- a/source/Mask.h
+++ b/source/Mask.h
@@ -54,6 +54,8 @@ public:
 	
 	// Find out how close the given point is to the mask.
 	double Range(Point point, Angle facing) const;
+	// Get the maximum distance from the center of this mask.
+	double Radius() const;
 	
 	
 private:

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2364,7 +2364,9 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 		double blastRadius = max(1., weapon.BlastRadius());
 		double radiusRatio = weapon.TriggerRadius() / blastRadius;
 		double k = !radiusRatio ? 1. : (1. + .25 * radiusRatio * radiusRatio);
-		double d = GetMask().Range(projectile.Position() - position, angle);
+		// Rather than exactly compute the distance between the explosion and
+		// the closest point on the ship, estimate it using the mask's Radius.
+		double d = max(0., (projectile.Position() - position).Length() - GetMask().Radius());
 		double rSquared = d * d / (blastRadius * blastRadius);
 		damageScaling *= k / ((1. + rSquared * rSquared) * (1. + rSquared * rSquared));
 	}

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -276,6 +276,7 @@ public:
 	// type, which may be a combination of PROVOKED, DISABLED, and DESTROYED.
 	// If isBlast, this ship was caught in the blast radius of a weapon but was
 	// not necessarily its primary target.
+	// Blast damage is dependent on the distance to the damage source.
 	int TakeDamage(const Projectile &projectile, bool isBlast = false);
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -44,6 +44,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			isSafe = true;
 		else if(key == "phasing")
 			isPhasing = true;
+		else if(key == "no damage scaling")
+			isDamageScaled = false;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -95,6 +95,9 @@ public:
 	// everything else, including asteroids.
 	bool IsSafe() const;
 	bool IsPhasing() const;
+	// Blast radius weapons will scale damage and hit force based on distance,
+	// unless the "no damage scaling" keyphrase is used in the weapon definition.
+	bool IsDamageScaled() const;
 	
 	// These values include all submunitions:
 	double ShieldDamage() const;
@@ -145,6 +148,7 @@ private:
 	bool isStreamed = false;
 	bool isSafe = false;
 	bool isPhasing = false;
+	bool isDamageScaled = true;
 	
 	// Attributes.
 	int lifetime = 0;
@@ -243,6 +247,7 @@ inline double Weapon::HitForce() const { return hitForce; }
 
 inline bool Weapon::IsSafe() const { return isSafe; }
 inline bool Weapon::IsPhasing() const { return isPhasing; }
+inline bool Weapon::IsDamageScaled() const { return isDamageScaled; }
 
 inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); }
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }


### PR DESCRIPTION
 - To mitigate the damage falloff for weapons with a trigger radius, a multiplier based on the ratio of trigger and blast radius is used.
 - For a weapon with 0 trigger radius, the damage will range from 100% at the center, to 25% at the edge of the blast radius.
 - "advanced" weaponry can define if it is not damage-scaled.

Refs #1630, #2529, #3275 

As of d400956, the denominator is chosen to vary with distance such that it does not immediately plummet, but rather gently plateaus before decreasing after ~40% of the blast radius:
![image](https://user-images.githubusercontent.com/20871346/33228582-6f9a59bc-d184-11e7-8aee-6d658782e1fd.png)

This can be changed to a more aggressive profile (see discussion in #2529 ).

This change is best combined with an "Avoid" behavior in the AI that would seek away from danger (be it an exceptionally strong ship, or a potent explosive), but they are separate issues and should not be combined in a single PR. This PR would help balance some of the increased damage associated with #3275  (though only for Heavy Rocket and Nuclear Missile, as all other "missiles" are simply projectiles (just like the Beam Laser) that have no blast radius).