### PR TITLE
Make torpedoes worse at tracking fighters and fast ships

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -796,14 +796,14 @@ outfit "Torpedo Launcher"
 		"hit effect" "large explosion"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 7
+		"velocity" 3.5
 		"lifetime" 600
 		"reload" 120
 		"firing energy" 2
 		"firing heat" 45
-		"acceleration" .7
+		"acceleration" .6
 		"drag" .1
-		"turn" 4
+		"turn" 1
 		"homing" 3
 		"optical tracking" .8
 		"shield damage" 450
@@ -858,14 +858,14 @@ outfit "Typhoon Launcher"
 		"hit effect" "large explosion"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 5
+		"velocity" 3
 		"lifetime" 600
 		"reload" 100
 		"firing energy" 4
 		"firing heat" 50
-		"acceleration" .5
+		"acceleration" .4
 		"drag" .1
-		"turn" 6
+		"turn" 1
 		"homing" 4
 		"optical tracking" .9
 		"shield damage" 610

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -809,7 +809,7 @@ outfit "Torpedo Launcher"
 		"shield damage" 450
 		"hull damage" 450
 		"hit force" 40
-		"missile strength" 20
+		"missile strength" 40
 	description "Torpedoes are the most powerful homing weapon, but they move slowly enough that fast ships can simply outrun them, making them most useful against large targets or against small ships at times when they are too distracted to dodge. Torpedo launchers are also much larger than other missile systems, so they are most often found in capital ships."
 
 effect "torpedo fire"
@@ -871,7 +871,7 @@ outfit "Typhoon Launcher"
 		"shield damage" 610
 		"hull damage" 610
 		"hit force" 70
-		"missile strength" 30
+		"missile strength" 60
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."
 
 effect "typhoon fire"

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -865,7 +865,7 @@ outfit "Typhoon Launcher"
 		"firing heat" 50
 		"acceleration" .4
 		"drag" .1
-		"turn" 1
+		"turn" 1.2
 		"homing" 4
 		"optical tracking" .9
 		"shield damage" 610


### PR DESCRIPTION
Torpedoes are now much slower, but with twice as much missile strength to compensate for the fact that they'll be receiving anti-missile fire for much longer. With this change, it becomes practically impossible to hit small fighters and interceptors with torpedo weapons, which is as it should be given their battle role and description. Large ships are still pretty easy to hit just because of their size, even if they're fast.

This should also have the side effect of making life easier for starting players--any pirate ship armed with torpedoes wont't be able to insta-kill the types of ships that the player starts with.