### PR TITLE
Give Meteors and Sidewinders distinct battle roles

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -624,14 +624,14 @@ outfit "Meteor Missile Launcher"
 		"die effect" "missile death"
 		"hit effect" "medium explosion"
 		"inaccuracy" 10
-		"velocity" 9
-		"lifetime" 480
+		"velocity" 0.1
+		"lifetime" 150
 		"reload" 48
 		"firing energy" 1
 		"firing heat" 20
-		"acceleration" .9
+		"acceleration" 3
 		"drag" .1
-		"turn" 4
+		"turn" 2
 		"homing" 2
 		"infrared tracking" .7
 		"shield damage" 130
@@ -693,7 +693,7 @@ outfit "Sidewinder Missile Launcher"
 		"firing heat" 15
 		"acceleration" 1.1
 		"drag" .1
-		"turn" 6
+		"turn" 5
 		"homing" 4
 		"radar tracking" .9
 		"shield damage" 100

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -625,15 +625,15 @@ outfit "Meteor Missile Launcher"
 		"hit effect" "medium explosion"
 		"inaccuracy" 10
 		"velocity" 9
-		"lifetime" 600
+		"lifetime" 480
 		"reload" 48
 		"firing energy" 1
 		"firing heat" 20
 		"acceleration" .9
 		"drag" .1
-		"turn" 2
-		"homing" 3
-		"infrared tracking" .8
+		"turn" 4
+		"homing" 2
+		"infrared tracking" .7
 		"shield damage" 130
 		"hull damage" 80
 		"hit force" 30
@@ -693,7 +693,7 @@ outfit "Sidewinder Missile Launcher"
 		"firing heat" 15
 		"acceleration" 1.1
 		"drag" .1
-		"turn" 3
+		"turn" 6
 		"homing" 4
 		"radar tracking" .9
 		"shield damage" 100


### PR DESCRIPTION
With this change, Meteor missiles are launched at a low speed but accelerate very quickly, have a shorter lifespan to compensate, and turn and track much worse (to match the in-game description). The net effect is to make them more useful against large ships--using high speed to bypass anti-missile defenses--but less useful against small fast ships. This should also have the side effect of making life easier for starting players, since most pirates in the Dirt Belt and galactic South are armed with Meteors which are now much worse against the types of ships that the player starts with.

Sidewinder missiles are now basically air-to-air missiles: they are slower than Meteors, but can maneuver to hit small fighters without 80% of them missing on the first pass and needing to turn around. This increases the importance and usefulness of radar jammers, which right now are pretty under-utilized.