### PR TITLE
Missile Overhaul part IV: Increase missile damage and durability, double reload times and price

### DIFF
--- a/data/coalition weapons.txt
+++ b/data/coalition weapons.txt
@@ -102,7 +102,7 @@ outfit "Finisher Pod"
 		"inaccuracy" 5
 		"velocity" 10
 		"lifetime" 60
-		"reload" 80
+		"reload" 160
 		"firing energy" 120
 		"firing heat" 20
 		"acceleration" .8
@@ -130,14 +130,14 @@ outfit "Active Finisher"
 		"radar tracking" .8
 		"optical tracking" .5
 		"missile strength" 50
-		"shield damage" 1500
-		"hull damage" 1900
-		"hit force" 240
+		"shield damage" 6000
+		"hull damage" 7600
+		"hit force" 960
 
 outfit "Finisher Torpedo"
 	plural "Finisher Torpedoes"
 	category "Ammunition"
-	cost 32000
+	cost 64000
 	thumbnail "outfit/finisher"
 	"mass" .5
 	"finisher capacity" -1

--- a/data/coalition weapons.txt
+++ b/data/coalition weapons.txt
@@ -110,7 +110,7 @@ outfit "Finisher Pod"
 		"turn" 0.1
 		"homing" 2
 		"radar tracking" .8
-		"missile strength" 50
+		"missile strength" 75
 		"submunition" "Active Finisher" 1
 	description `Finisher Torpedoes are one of the Heliarchs' most dreaded weapons. In fact, in one way or another most of their other weapons merely exist to hold a ship in place for long enough for a barrage of Finishers to destroy it.`
 

--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -181,7 +181,7 @@ effect "rail sparks"
 
 outfit "Hai Tracker"
 	category "Ammunition"
-	cost 1000
+	cost 2000
 	thumbnail "outfit/hai tracker"
 	"mass" .2
 	"tracker capacity" -1
@@ -220,7 +220,7 @@ outfit "Hai Tracker Pod"
 		"inaccuracy" 20
 		"velocity" 14
 		"lifetime" 600
-		"reload" 60
+		"reload" 120
 		"firing energy" 45
 		"firing heat" 5
 		"acceleration" .7
@@ -229,9 +229,9 @@ outfit "Hai Tracker Pod"
 		"homing" 4
 		"optical tracking" .8
 		"infrared tracking" .4
-		"shield damage" 200
-		"hull damage" 160
-		"hit force" 50
+		"shield damage" 800
+		"hull damage" 640
+		"hit force" 200
 		"missile strength" 16
 	description "Trackers are fast, powerful, and accurate homing weapons. Their only weakness is their large turning radius: if a Tracker misses its target, it takes a long time to turn around."
 

--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -232,7 +232,7 @@ outfit "Hai Tracker Pod"
 		"shield damage" 800
 		"hull damage" 640
 		"hit force" 200
-		"missile strength" 16
+		"missile strength" 24
 	description "Trackers are fast, powerful, and accurate homing weapons. Their only weakness is their large turning radius: if a Tracker misses its target, it takes a long time to turn around."
 
 effect "tracker fire"

--- a/data/korath weapons.txt
+++ b/data/korath weapons.txt
@@ -226,7 +226,7 @@ outfit "Korath Repeater Turret"
 
 outfit "Korath Piercer"
 	category "Ammunition"
-	cost 3500
+	cost 7000
 	thumbnail "outfit/piercer"
 	"mass" .3
 	"piercer capacity" -1
@@ -266,7 +266,7 @@ outfit "Korath Piercer Launcher"
 		"inaccuracy" 3
 		"velocity" 18
 		"lifetime" 200
-		"reload" 72
+		"reload" 144
 		"firing energy" 29
 		"firing heat" 144
 		"acceleration" .54
@@ -274,10 +274,10 @@ outfit "Korath Piercer Launcher"
 		"turn" 1.6
 		"homing" 4
 		"infrared tracking" .9
-		"shield damage" 290
-		"hull damage" 440
+		"shield damage" 1160
+		"hull damage" 1760
 		"piercing" .2
-		"hit force" 30
+		"hit force" 120
 		"missile strength" 73
 		"stream"
 	description "Korath Piercer missiles carry a pair of warheads. The first, a smaller one in the very tip of the missile, explodes on impact to blast a hole in the ship's shields to allow some of the subsequent, larger explosion to pierce through."

--- a/data/korath weapons.txt
+++ b/data/korath weapons.txt
@@ -278,7 +278,7 @@ outfit "Korath Piercer Launcher"
 		"hull damage" 1760
 		"piercing" .2
 		"hit force" 120
-		"missile strength" 73
+		"missile strength" 110
 		"stream"
 	description "Korath Piercer missiles carry a pair of warheads. The first, a smaller one in the very tip of the missile, explodes on impact to blast a hole in the ship's shields to allow some of the subsequent, larger explosion to pierce through."
 

--- a/data/wanderer outfits.txt
+++ b/data/wanderer outfits.txt
@@ -240,7 +240,7 @@ outfit "Thunderhead Launcher"
 		"inaccuracy" 10
 		"velocity" 4
 		"lifetime" 400
-		"reload" 75
+		"reload" 150
 		"firing energy" 18
 		"firing heat" 36
 		"acceleration" 1.1
@@ -254,7 +254,7 @@ outfit "Thunderhead Launcher"
 
 outfit "Thunderhead Missile"
 	category "Ammunition"
-	cost 1800
+	cost 3600
 	thumbnail "outfit/thunderhead"
 	mass .3
 	"thunderhead capacity" -1
@@ -276,9 +276,9 @@ outfit "Thunderhead"
 		"homing" 4
 		"optical tracking" .9
 		"radar tracking" .6
-		"shield damage" 110
-		"hull damage" 80
-		"hit force" 20
+		"shield damage" 440
+		"hull damage" 320
+		"hit force" 80
 		"missile strength" 3
 
 outfit "Thunderhead Storage Array"

--- a/data/wanderer outfits.txt
+++ b/data/wanderer outfits.txt
@@ -249,7 +249,7 @@ outfit "Thunderhead Launcher"
 		"homing" 4
 		"infrared tracking" .9
 		"radar tracking" .6
-		"missile strength" 12
+		"missile strength" 18
 	description "A prime example of Wanderer ingenuity, Thunderhead missiles each carry five submunitions that are capable of independent tracking. Even if the target is able to shoot down or evade a few of them, the remaining missile fragments will still find their mark."
 
 outfit "Thunderhead Missile"

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -587,7 +587,7 @@ effect "flamethrower hit"
 
 outfit "Meteor Missile"
 	category "Ammunition"
-	cost 500
+	cost 1000
 	thumbnail "outfit/meteor"
 	"mass" .2
 	"meteor capacity" -1
@@ -626,7 +626,7 @@ outfit "Meteor Missile Launcher"
 		"inaccuracy" 10
 		"velocity" 9
 		"lifetime" 600
-		"reload" 48
+		"reload" 96
 		"firing energy" 1
 		"firing heat" 20
 		"acceleration" .9
@@ -634,9 +634,9 @@ outfit "Meteor Missile Launcher"
 		"turn" 2
 		"homing" 3
 		"infrared tracking" .8
-		"shield damage" 130
-		"hull damage" 80
-		"hit force" 30
+		"shield damage" 520
+		"hull damage" 320
+		"hit force" 120
 		"missile strength" 4
 	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. The tracking system on these missiles is notoriously unreliable, and they are easily destroyed by anti-missile systems, but in large numbers or when fired at a slow-moving target they can be deadly."
 
@@ -650,7 +650,7 @@ effect "meteor fire"
 
 outfit "Sidewinder Missile"
 	category "Ammunition"
-	cost 800
+	cost 1600
 	thumbnail "outfit/sidewinder"
 	"mass" .2
 	"sidewinder capacity" -1
@@ -688,7 +688,7 @@ outfit "Sidewinder Missile Launcher"
 		"inaccuracy" 4
 		"velocity" 11
 		"lifetime" 600
-		"reload" 40
+		"reload" 80
 		"firing energy" 1
 		"firing heat" 15
 		"acceleration" 1.1
@@ -696,9 +696,9 @@ outfit "Sidewinder Missile Launcher"
 		"turn" 3
 		"homing" 4
 		"radar tracking" .9
-		"shield damage" 100
-		"hull damage" 70
-		"hit force" 25
+		"shield damage" 400
+		"hull damage" 280
+		"hit force" 100
 		"missile strength" 12
 	description "The Sidewinder Missile is designed by Lovelace Labs, which is ironically also the designer of the Anti-Missile Turret. Rumors say that the two engineering teams at Lovelace who make the missiles and the anti-missiles are locked in furious competition with each other: the result has been generation after generation of smarter missiles and then smarter turrets to fend them off."
 	description "	Although not as powerful or cheap as the popular Meteor missiles, Sidewinders have several advantages, including their better tracking systems and protective casings that make them much harder for anti-missile systems to destroy."
@@ -713,7 +713,7 @@ effect "sidewinder fire"
 
 outfit "Javelin"
 	category "Ammunition"
-	cost 50
+	cost 100
 	thumbnail "outfit/javelin"
 	"mass" .04
 	"javelin capacity" -1
@@ -742,17 +742,18 @@ outfit "Javelin Pod"
 		sprite "projectile/javelin"
 		sound "javelin"
 		ammo "Javelin"
+		stream
 		icon "icon/javelin"
 		"hit effect" "tiny explosion"
 		"inaccuracy" 1
 		"velocity" 10
 		"lifetime" 60
-		"reload" 20
+		"reload" 40
 		"firing energy" .2
 		"firing heat" 12
-		"shield damage" 48
-		"hull damage" 26
-		"hit force" 5
+		"shield damage" 192
+		"hull damage" 104
+		"hit force" 20
 		"missile strength" 2
 	description "The Javelin Pod fires a rapid stream of unguided missiles. A Javelin Pod does far more damage than any gun of a comparable size, and has a longer range as well, but once a ship has fired off all its ammunition it must leave combat and find a planet where it can buy more, which makes Javelins less useful in protracted battles. As a result, they are very popular with pirates as a way to quickly disable a small target."
 
@@ -760,7 +761,7 @@ outfit "Javelin Pod"
 outfit "Torpedo"
 	plural "Torpedoes"
 	category "Ammunition"
-	cost 1400
+	cost 2800
 	thumbnail "outfit/torpedo"
 	"mass" .4
 	"torpedo capacity" -1
@@ -798,7 +799,7 @@ outfit "Torpedo Launcher"
 		"inaccuracy" 5
 		"velocity" 7
 		"lifetime" 600
-		"reload" 120
+		"reload" 240
 		"firing energy" 2
 		"firing heat" 45
 		"acceleration" .7
@@ -806,9 +807,9 @@ outfit "Torpedo Launcher"
 		"turn" 4
 		"homing" 3
 		"optical tracking" .8
-		"shield damage" 450
-		"hull damage" 450
-		"hit force" 40
+		"shield damage" 1800
+		"hull damage" 1800
+		"hit force" 160
 		"missile strength" 20
 	description "Torpedoes are the most powerful homing weapon, but they move slowly enough that fast ships can simply outrun them, making them most useful against large targets or against small ships at times when they are too distracted to dodge. Torpedo launchers are also much larger than other missile systems, so they are most often found in capital ships."
 
@@ -822,7 +823,7 @@ effect "torpedo fire"
 outfit "Typhoon Torpedo"
 	plural "Typhoon Torpedoes"
 	category "Ammunition"
-	cost 2700
+	cost 5400
 	thumbnail "outfit/typhoon"
 	"mass" .5
 	"typhoon capacity" -1
@@ -860,7 +861,7 @@ outfit "Typhoon Launcher"
 		"inaccuracy" 5
 		"velocity" 5
 		"lifetime" 600
-		"reload" 100
+		"reload" 200
 		"firing energy" 4
 		"firing heat" 50
 		"acceleration" .5
@@ -868,9 +869,9 @@ outfit "Typhoon Launcher"
 		"turn" 6
 		"homing" 4
 		"optical tracking" .9
-		"shield damage" 610
-		"hull damage" 610
-		"hit force" 70
+		"shield damage" 2440
+		"hull damage" 2440
+		"hit force" 280
 		"missile strength" 30
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."
 
@@ -883,7 +884,7 @@ effect "typhoon fire"
 
 outfit "Heavy Rocket"
 	category "Ammunition"
-	cost 2000
+	cost 4000
 	thumbnail "outfit/rocket"
 	"mass" .5
 	"rocket capacity" -1
@@ -913,22 +914,23 @@ outfit "Heavy Rocket Launcher"
 			"frame rate" 4
 		sound "rocket"
 		ammo "Heavy Rocket"
+		stream
 		icon "icon/rocket"
 		"hit effect" "heavy rocket hit"
 		"die effect" "small explosion"
 		"inaccuracy" 1
 		"velocity" 8
 		"lifetime" 100
-		"reload" 200
+		"reload" 400
 		"firing energy" 1
 		"firing heat" 250
 		"acceleration" .8
 		"drag" .1
 		"trigger radius" 30
 		"blast radius" 50
-		"shield damage" 700
-		"hull damage" 600
-		"hit force" 80
+		"shield damage" 2800
+		"hull damage" 2400
+		"hit force" 320
 		"missile strength" 16
 	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
 
@@ -947,7 +949,7 @@ effect "heavy rocket hit"
 
 outfit "Nuclear Missile"
 	category "Secondary Weapons"
-	cost 1000000
+	cost 2000000
 	thumbnail "outfit/nuke"
 	"mass" 10
 	"outfit space" -10
@@ -966,12 +968,12 @@ outfit "Nuclear Missile"
 		"hit effect" "nuke residue slow" 10
 		"die effect" "missile death"
 		"inaccuracy" 1
-		"velocity" 6
+		"velocity" 3
 		"lifetime" 800
 		"reload" 400
 		"firing energy" 10
 		"firing heat" 400
-		"acceleration" .8
+		"acceleration" .4
 		"drag" .1
 		"turn" 4
 		"homing" 4
@@ -979,8 +981,8 @@ outfit "Nuclear Missile"
 		"optical tracking" 1
 		"trigger radius" 30
 		"blast radius" 150
-		"shield damage" 9000
-		"hull damage" 7000
+		"shield damage" 18000
+		"hull damage" 14000
 		"hit force" 4000
 		"missile strength" 200
 	description "It has been centuries since the last nuclear war was fought, and until very recently, most people in the galaxy assumed that that era of chaos and destruction was forever behind us..."

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -637,7 +637,7 @@ outfit "Meteor Missile Launcher"
 		"shield damage" 520
 		"hull damage" 320
 		"hit force" 120
-		"missile strength" 4
+		"missile strength" 6
 	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. The tracking system on these missiles is notoriously unreliable, and they are easily destroyed by anti-missile systems, but in large numbers or when fired at a slow-moving target they can be deadly."
 
 effect "meteor fire"
@@ -699,7 +699,7 @@ outfit "Sidewinder Missile Launcher"
 		"shield damage" 400
 		"hull damage" 280
 		"hit force" 100
-		"missile strength" 12
+		"missile strength" 18
 	description "The Sidewinder Missile is designed by Lovelace Labs, which is ironically also the designer of the Anti-Missile Turret. Rumors say that the two engineering teams at Lovelace who make the missiles and the anti-missiles are locked in furious competition with each other: the result has been generation after generation of smarter missiles and then smarter turrets to fend them off."
 	description "	Although not as powerful or cheap as the popular Meteor missiles, Sidewinders have several advantages, including their better tracking systems and protective casings that make them much harder for anti-missile systems to destroy."
 
@@ -754,7 +754,7 @@ outfit "Javelin Pod"
 		"shield damage" 192
 		"hull damage" 104
 		"hit force" 20
-		"missile strength" 2
+		"missile strength" 3
 	description "The Javelin Pod fires a rapid stream of unguided missiles. A Javelin Pod does far more damage than any gun of a comparable size, and has a longer range as well, but once a ship has fired off all its ammunition it must leave combat and find a planet where it can buy more, which makes Javelins less useful in protracted battles. As a result, they are very popular with pirates as a way to quickly disable a small target."
 
 
@@ -810,7 +810,7 @@ outfit "Torpedo Launcher"
 		"shield damage" 1800
 		"hull damage" 1800
 		"hit force" 160
-		"missile strength" 20
+		"missile strength" 30
 	description "Torpedoes are the most powerful homing weapon, but they move slowly enough that fast ships can simply outrun them, making them most useful against large targets or against small ships at times when they are too distracted to dodge. Torpedo launchers are also much larger than other missile systems, so they are most often found in capital ships."
 
 effect "torpedo fire"
@@ -872,7 +872,7 @@ outfit "Typhoon Launcher"
 		"shield damage" 2440
 		"hull damage" 2440
 		"hit force" 280
-		"missile strength" 30
+		"missile strength" 40
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."
 
 effect "typhoon fire"
@@ -931,7 +931,7 @@ outfit "Heavy Rocket Launcher"
 		"shield damage" 2800
 		"hull damage" 2400
 		"hit force" 320
-		"missile strength" 16
+		"missile strength" 24
 	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
 
 effect "heavy rocket hit"


### PR DESCRIPTION
With this change, Missile launchers fire half as fast, but their missiles cost double, inflict quadruple the damage, and are 50% stronger, to allow at least a few through light anti-missile defenses (which are now more dangerous with the missiles' reduced fire rates) Much more damage per missile impact feels both more realistic and more fun, and increases the utility of anti-missile preparations in player ship design.

Additional changes/exceptions:
- Heavy Rockets and Javelins now use the Stream mode, which makes them more vulnerable to anti-missile fire to compensate for their greatly increased effectiveness
- Nuclear missile damage values doubled, not quadrupled (that seemed a little excessive, and would let them one-shot all human ships). Even so, I halved their speed.
- Korath Mines received no changes. They seemed fine as-is.