### PR TITLE
Add anti-missile defenses to most ships that lacked them

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -89,7 +89,8 @@ ship "Argosy"
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 70
-		"Blaster Turret" 2
+		"Blaster Turret"
+		"Anti-Missile Turret"
 		
 		"RT-I Radiothermal"
 		"LP072a Battery Pack"
@@ -106,7 +107,7 @@ ship "Argosy"
 	gun -23 -37 "Meteor Missile Launcher"
 	gun 23 -37 "Meteor Missile Launcher"
 	turret 0 -12 "Blaster Turret"
-	turret 0 8 "Blaster Turret"
+	turret 0 8 "Anti-Missile Turret"
 	explode "tiny explosion" 10
 	explode "small explosion" 25
 	explode "medium explosion" 25
@@ -334,11 +335,13 @@ ship "Bastion"
 		"Plasma Cannon" 2
 		"Heavy Rocket Launcher" 2
 		"Heavy Rocket" 40
-		"Blaster Turret" 3
+		"Blaster Turret" 2
+		"Anti-Missile Turret"
 		
 		"S3 Thermionic"
 		"LP144a Battery Pack"
 		"nGVF-BB Fuel Cell"
+		"Large Radar Jammer"
 		"D67-TM Shield Generator"
 		"Water Coolant System"
 		
@@ -352,7 +355,7 @@ ship "Bastion"
 	gun 54 -14 "Plasma Cannon"
 	gun -54 -14 "Heavy Rocket Launcher"
 	gun 54 -14 "Heavy Rocket Launcher"
-	turret 0 0 "Blaster Turret"
+	turret 0 0 "Anti-Missile Turret"
 	turret -30 14 "Blaster Turret"
 	turret 30 14 "Blaster Turret"
 	explode "tiny explosion" 5
@@ -487,7 +490,8 @@ ship "Blackbird"
 			"hull damage" 300
 			"hit force" 900
 	outfits
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret"
+		"Heavy Anti-Missile Turret"
 		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
@@ -501,7 +505,7 @@ ship "Blackbird"
 	engine -40 55
 	engine 40 55
 	turret -18 0 "Heavy Laser Turret"
-	turret 18 0 "Heavy Laser Turret"
+	turret 18 0 "Heavy Anti-Missile Turret"
 	explode "tiny explosion" 15
 	explode "small explosion" 34
 	explode "medium explosion" 18
@@ -534,11 +538,13 @@ ship "Bounder"
 			"hull damage" 150
 			"hit force" 450
 	outfits
-		"Blaster Turret" 2
+		"Blaster Turret"
+		"Anti-Missile Turret"
 		
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Small Radar Jammer"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
@@ -547,7 +553,7 @@ ship "Bounder"
 	engine -12 44
 	engine 12 44
 	turret -37 4 "Blaster Turret"
-	turret 37 4 "Blaster Turret"
+	turret 37 4 "Anti-Missile Turret"
 	explode "tiny explosion" 10
 	explode "small explosion" 20
 	explode "medium explosion" 15
@@ -811,6 +817,7 @@ ship "Clipper"
 		"nGVF-DD Fuel Cell"
 		"LP072a Battery Pack"
 		"D23-QP Shield Generator"
+		"Small Radar Jammer"
 		
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
@@ -891,7 +898,8 @@ ship "Corvette"
 			"hit force" 1200
 	outfits
 		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret"
+		"Heavy Anti-Missile Turret"
 		
 		"NT-200 Nucleovoltaic"
 		"LP072a Battery Pack"
@@ -909,7 +917,7 @@ ship "Corvette"
 	gun -14 -60 "Heavy Laser"
 	gun 14 -60 "Heavy Laser"
 	turret 0 -11 "Heavy Laser Turret"
-	turret 0 74 "Heavy Laser Turret"
+	turret 0 74 "Heavy Anti-Missile Turret"
 	explode "tiny explosion" 18
 	explode "small explosion" 36
 	explode "medium explosion" 24
@@ -1051,13 +1059,14 @@ ship "Dreadnought"
 	outfits
 		"Meteor Missile Launcher" 4
 		"Meteor Missile" 140
-		"Plasma Turret" 5
+		"Plasma Turret" 4
+		"Heavy Anti-Missile Turret"
 		
 		"Breeder Reactor"
 		"S3 Thermionic"
 		"LP144a Battery Pack"
 		"D41-HY Shield Generator"
-		"Small Radar Jammer"
+		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		
 		"Orca Plasma Thruster"
@@ -1070,7 +1079,7 @@ ship "Dreadnought"
 	gun 10 -167 "Meteor Missile Launcher"
 	gun -20 -151 "Meteor Missile Launcher"
 	gun 20 -151 "Meteor Missile Launcher"
-	turret 0 -94 "Plasma Turret"
+	turret 0 -94 "Heavy Anti-Missile Turret"
 	turret -38 -56 "Plasma Turret"
 	turret 38 -56 "Plasma Turret"
 	turret -44 118 "Plasma Turret"
@@ -1111,7 +1120,8 @@ ship "Falcon"
 		"Plasma Cannon" 2
 		"Torpedo Launcher" 2
 		"Torpedo" 60
-		"Quad Blaster Turret" 4
+		"Quad Blaster Turret" 3
+		"Heavy Anti-Missile Turret"
 		
 		"Breeder Reactor"
 		"LP144a Battery Pack"
@@ -1132,7 +1142,7 @@ ship "Falcon"
 	turret -16 -24 "Quad Blaster Turret"
 	turret 16 -24 "Quad Blaster Turret"
 	turret -57 40 "Quad Blaster Turret"
-	turret 57 40 "Quad Blaster Turret"
+	turret 57 40 "Heavy Anti-Missile Turret"
 	explode "tiny explosion" 40
 	explode "small explosion" 55
 	explode "medium explosion" 60
@@ -1169,6 +1179,7 @@ ship "Finch"
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Small Radar Jammer"
 		
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
@@ -1207,7 +1218,8 @@ ship "Firebird"
 			"hit force" 1500
 	outfits
 		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret" 1
+		"Heavy Anti-Missile Turret"
 		
 		"RT-I Radiothermal"
 		"nGVF-AA Fuel Cell"
@@ -1225,7 +1237,7 @@ ship "Firebird"
 	gun -39 -13 "Heavy Laser"
 	gun 39 -13 "Heavy Laser"
 	turret -5 3 "Heavy Laser Turret"
-	turret 5 3 "Heavy Laser Turret"
+	turret 5 3 "Heavy Anti-Missile Turret"
 	explode "tiny explosion" 18
 	explode "small explosion" 36
 	explode "medium explosion" 24
@@ -1308,6 +1320,7 @@ ship "Freighter"
 		"nGVF-EE Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Small Radar Jammer"
 		
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
@@ -1355,7 +1368,8 @@ ship "Frigate"
 		"Particle Cannon" 2
 		"Torpedo Launcher" 2
 		"Torpedo" 60
-		"Blaster Turret" 3
+		"Blaster Turret" 2
+		"Anti-Missile Turret"
 		
 		"NT-200 Nucleovoltaic"
 		"LP144a Battery Pack"
@@ -1371,7 +1385,7 @@ ship "Frigate"
 	gun 10 -83 "Particle Cannon"
 	gun -10 -83 "Torpedo Launcher"
 	gun 10 -83 "Torpedo Launcher"
-	turret 0 -37 "Blaster Turret"
+	turret 0 -37 "Anti-Missile Turret"
 	turret -12 -12 "Blaster Turret"
 	turret 12 -12 "Blaster Turret"
 	explode "tiny explosion" 18
@@ -1670,6 +1684,7 @@ ship "Hawk"
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
+		"Small Radar Jammer"
 		
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
@@ -1838,7 +1853,8 @@ ship "Leviathan"
 			"hit force" 1200
 	outfits
 		"Particle Cannon" 4
-		"Quad Blaster Turret" 4
+		"Quad Blaster Turret" 3
+		"Heavy Anti-Missile Turret"
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
@@ -1858,7 +1874,7 @@ ship "Leviathan"
 	turret -15 -50 "Quad Blaster Turret"
 	turret 15 -50 "Quad Blaster Turret"
 	turret -25 10 "Quad Blaster Turret"
-	turret 25 10 "Quad Blaster Turret"
+	turret 25 10 "Heavy Anti-Missile Turret"
 	explode "tiny explosion" 18
 	explode "small explosion" 36
 	explode "medium explosion" 24
@@ -1944,7 +1960,8 @@ ship "Modified Argosy"
 			"hit force" 1200
 	outfits
 		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret"
+		"Heavy Anti-Missile Turret"
 		
 		"NT-200 Nucleovoltaic"
 		"LP072a Battery Pack"
@@ -1962,7 +1979,7 @@ ship "Modified Argosy"
 	gun -23 -37 "Heavy Laser"
 	gun 23 -37 "Heavy Laser"
 	turret 0 -12 "Heavy Laser Turret"
-	turret 0 8 "Heavy Laser Turret"
+	turret 0 8 "Heavy Anti-Missile Turret"
 	explode "tiny explosion" 10
 	explode "small explosion" 25
 	explode "medium explosion" 30
@@ -2107,7 +2124,8 @@ ship "Osprey"
 			"hit force" 1200
 	outfits
 		"Plasma Cannon" 4
-		"Quad Blaster Turret" 2
+		"Quad Blaster Turret"
+		"Heavy Anti-Missile Turret"
 		
 		"Breeder Reactor"
 		"LP072a Battery Pack"
@@ -2126,7 +2144,7 @@ ship "Osprey"
 	gun -26 -53 "Plasma Cannon"
 	gun 26 -53 "Plasma Cannon"
 	turret -16 -16 "Quad Blaster Turret"
-	turret 16 -16 "Quad Blaster Turret"
+	turret 16 -16 "Heavy Anti-Missile Turret"
 	explode "medium explosion" 24
 	explode "large explosion" 16
 	explode "small explosion" 40
@@ -2161,7 +2179,8 @@ ship "Protector"
 	outfits
 		"Torpedo Launcher" 2
 		"Torpedo" 60
-		"Quad Blaster Turret" 6
+		"Quad Blaster Turret" 5
+		"Heavy Anti-Missile Turret"
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
@@ -2178,7 +2197,7 @@ ship "Protector"
 	gun -15 -100 "Torpedo Launcher"
 	gun 15 -100 "Torpedo Launcher"
 	turret -54 -54 "Quad Blaster Turret"
-	turret 54 -54 "Quad Blaster Turret"
+	turret 54 -54 "Heavy Anti-Missile Turret"
 	turret -73 0 "Quad Blaster Turret"
 	turret 73 0 "Quad Blaster Turret"
 	turret -54 54 "Quad Blaster Turret"
@@ -2619,7 +2638,8 @@ ship "Splinter"
 			"hit force" 900
 	outfits
 		"Proton Gun" 2
-		"Blaster Turret" 3
+		"Blaster Turret" 2
+		"Anti-Missile Turret"
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
@@ -2636,7 +2656,7 @@ ship "Splinter"
 	gun -15 -80 "Proton Gun"
 	gun 15 -80 "Proton Gun"
 	turret -17 -28 "Blaster Turret"
-	turret 0 -28 "Blaster Turret"
+	turret 0 -28 "Anti-Missile Turret"
 	turret 17 -28 "Blaster Turret"
 	explode "tiny explosion" 18
 	explode "small explosion" 36

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1412,7 +1412,7 @@ ship "Behemoth" "Behemoth (Hai)"
 	outfits
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 100
-		"Pulse Turret"
+		"Pulse Turret" 5
 		"Bullfrog Anti-Missile"
 		"Boulder Reactor"
 		"Hai Ravine Batteries"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -139,6 +139,7 @@ ship "Scout" "Scout (Speedy)"
 		"Outfits Expansion"
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
+		"Small Radar Jammer"
 		"Hyperdrive"
 
 
@@ -154,6 +155,7 @@ ship "Clipper" "Clipper (Heavy)"
 		"D67-TM Shield Generator"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
+		"Small Radar Jammer"
 		"Scram Drive"
 
 
@@ -183,6 +185,7 @@ ship "Freighter" "Freighter (Fancy)"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Scram Drive"
+		"Small Radar Jammer"
 	turret "Laser Turret"
 	turret "Laser Turret"
 	turret "Heavy Anti-Missile Turret"
@@ -292,7 +295,8 @@ ship "Bulk Freighter" "Bulk Freighter (Heavy)"
 
 ship "Bulk Freighter" "Bulk Freighter (Blaster)"
 	outfits
-		"Quad Blaster Turret" 5
+		"Quad Blaster Turret" 4
+		"Heavy Anti-Missile Turret"
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 70
 		"Fusion Reactor"
@@ -303,6 +307,11 @@ ship "Bulk Freighter" "Bulk Freighter (Blaster)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Scram Drive"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
 
 
 
@@ -340,6 +349,7 @@ ship "Hawk" "Hawk (Speedy)"
 		"D41-HY Shield Generator"
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
+		"Small Radar Jammer"
 		"Hyperdrive"
 
 
@@ -353,6 +363,7 @@ ship "Hawk" "Hawk (Rocket)"
 		"D41-HY Shield Generator"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
+		"Small Radar Jammer"
 		"Hyperdrive"
 
 
@@ -360,7 +371,8 @@ ship "Hawk" "Hawk (Rocket)"
 ship "Bastion" "Bastion (Heavy)"
 	outfits
 		"Plasma Cannon" 4
-		"Quad Blaster Turret" 3
+		"Quad Blaster Turret" 2
+		"Heavy Anti-Missile Turret"
 		"Fusion Reactor"
 		"LP072a Battery Pack"
 		"D67-TM Shield Generator"
@@ -369,6 +381,9 @@ ship "Bastion" "Bastion (Heavy)"
 		"X3700 Ion Thruster"
 		"Orca Plasma Steering"
 		"Hyperdrive"
+	turret "Heavy Anti-Missile Turret"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
 
 
 
@@ -432,7 +447,8 @@ ship "Corvette" "Corvette (Missile)"
 ship "Firebird" "Firebird (Plasma)"
 	outfits
 		"Plasma Cannon" 4
-		"Quad Blaster Turret" 2
+		"Quad Blaster Turret"
+		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
 		"LP072a Battery Pack"
 		"LP036a Battery Pack"
@@ -442,6 +458,8 @@ ship "Firebird" "Firebird (Plasma)"
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+	turret "Quad Blaster Turret"
+	turret "Heavy Anti-Missile Turret"
 
 
 
@@ -451,7 +469,8 @@ ship "Firebird" "Firebird (Missile)"
 		"Meteor Missile" 70
 		"Torpedo Launcher" 2
 		Torpedo 60
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret"
+		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
@@ -505,7 +524,8 @@ ship "Osprey" "Osprey (Missile)"
 		"Torpedo" 60
 		"Heavy Rocket Launcher" 2
 		"Heavy Rocket" 40
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret"
+		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
 		"LP036a Battery Pack"
 		"Supercapacitor" 3
@@ -518,6 +538,8 @@ ship "Osprey" "Osprey (Missile)"
 	gun "Heavy Rocket Launcher"
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
+	turret "Heavy Laser Turret"
+	turret "Heavy Anti-Missile Turret"
 
 
 
@@ -579,7 +601,8 @@ ship "Falcon" "Falcon (Heavy)"
 		"Torpedo" 60
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 70
-		"Heavy Laser Turret" 4
+		"Heavy Laser Turret" 3
+		"Heavy Anti-Missile Turret"
 		"Fusion Reactor"
 		"D67-TM Shield Generator"
 		"Small Radar Jammer"
@@ -590,13 +613,18 @@ ship "Falcon" "Falcon (Heavy)"
 	gun "Torpedo Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Anti-Missile Turret"
 
 
 
 ship "Leviathan" "Leviathan (Laser)"
 	outfits
 		"Heavy Laser" 4
-		"Heavy Laser Turret" 4
+		"Heavy Laser Turret" 3
+		"Heavy Anti-Missile Turret"
 		"Armageddon Core"
 		"LP036a Battery Pack"
 		"Supercapacitor"
@@ -606,6 +634,10 @@ ship "Leviathan" "Leviathan (Laser)"
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Anti-Missile Turret"
 
 
 
@@ -615,7 +647,8 @@ ship "Leviathan" "Leviathan (Heavy)"
 		"Torpedo" 60
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 70
-		"Heavy Laser Turret" 4
+		"Heavy Laser Turret" 3
+		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
 		"LP036a Battery Pack"
 		"D94-YV Shield Generator" 2
@@ -629,12 +662,17 @@ ship "Leviathan" "Leviathan (Heavy)"
 	gun "Meteor Missile Launcher"
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Anti-Missile Turret"
 
 
 
 ship "Protector" "Protector (Laser)"
 	outfits
-		"Laser Turret" 2
+		"Laser Turret"
+		"Anti-Missile Turret"
 		"Heavy Laser Turret" 4
 		"Fusion Reactor"
 		"LP036a Battery Pack"
@@ -645,7 +683,7 @@ ship "Protector" "Protector (Laser)"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 	turret "Laser Turret"
-	turret "Laser Turret"
+	turret "Anti-Missile Turret"
 	turret "Heavy Laser Turret"
 	turret "Heavy Laser Turret"
 	turret "Heavy Laser Turret"
@@ -741,7 +779,8 @@ ship "Modified Argosy" "Modified Argosy (Heavy)"
 ship "Modified Argosy" "Modified Argosy (Blaster)"
 	outfits
 		"Modified Blaster" 4
-		"Quad Blaster Turret" 2
+		"Quad Blaster Turret"
+		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
 		"LP144a Battery Pack"
 		"D67-TM Shield Generator"
@@ -750,6 +789,7 @@ ship "Modified Argosy" "Modified Argosy (Blaster)"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
+
 
 
 
@@ -941,7 +981,8 @@ ship "Behemoth" "Behemoth (Heavy)"
 ship "Splinter" "Splinter (Mark II)"
 	outfits
 		"Particle Cannon" 2
-		"Quad Blaster Turret" 3
+		"Quad Blaster Turret" 2
+		"Heavy Anti-Missile Turret"
 		"Fusion Reactor"
 		"Supercapacitor"
 		"S-970 Regenerator"
@@ -951,6 +992,9 @@ ship "Splinter" "Splinter (Mark II)"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 		"Ionic Afterburner"
+	turret "Quad Blaster Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Quad Blaster Turret"
 
 
 
@@ -1080,7 +1124,8 @@ ship "Dreadnought" "Dreadnought (Jump)"
 	outfits
 		"Meteor Missile Launcher" 4
 		"Meteor Missile" 140
-		"Plasma Turret" 5
+		"Plasma Turret" 4
+		"Heavy Anti-Missile Turret"
 		"Stack Core"
 		"LP144a Battery Pack"
 		"D41-HY Shield Generator"
@@ -1089,6 +1134,11 @@ ship "Dreadnought" "Dreadnought (Jump)"
 		"Orca Plasma Thruster"
 		"Orca Plasma Steering"
 		"Jump Drive"
+	turret "Heavy Anti-Missile Turret"
+	turret "Plasma Turret"
+	turret "Plasma Turret"
+	turret "Plasma Turret"
+	turret "Plasma Turret"
 
 
 
@@ -1362,7 +1412,8 @@ ship "Behemoth" "Behemoth (Hai)"
 	outfits
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 100
-		"Pulse Turret" 6
+		"Pulse Turret"
+		"Bullfrog Anti-Missile"
 		"Boulder Reactor"
 		"Hai Ravine Batteries"
 		"Hai Diamond Regenerator"


### PR DESCRIPTION
This change adds anti-missile turrets to most larger ships and variants that previously lacked them, and tries to cram Radar Jammers into smaller ships. Everything fits (at least the non-variant ships; I didn't check all the variants).

This is necessary if and when https://github.com/endless-sky/endless-sky/pull/3279 goes in. With that change, large ships that already have anti-missile defenses should not be that much more vulnerable to missiles on a DPS basis, but large ships without any anti-missile defenses get devastated. Anti-missile defenses become much more important for large ships.

Even if https://github.com/endless-sky/endless-sky/pull/3279 does not get merged, IMHO it still makes sense because missiles are only very dangerous to larger ships with zero anti-missile ability, so most ship designers and owners would want to build this in. And increasing anti-missile coverage for human ships makes changes to missile effectiveness more possible in the future since it wouldn't have such a disproportionate effect on all the currently-unprotected vessels.