### PR TITLE
Missile Overhaul part VII: Exchange launcher and storage capacities

### DIFF
--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -191,9 +191,9 @@ outfit "Tracker Storage Pod"
 	category "Ammunition"
 	cost 28000
 	thumbnail "outfit/hai tracker storage"
-	"mass" 4.4
-	"outfit space" -10
-	"tracker capacity" 28
+	"mass" 8
+	"outfit space" -14
+	"tracker capacity" 30
 	ammo "Hai Tracker"
 	description "The Tracker Storage Pod is used to store extra ammunition for Tracker Pods."
 
@@ -201,11 +201,11 @@ outfit "Hai Tracker Pod"
 	category "Secondary Weapons"
 	cost 150000
 	thumbnail "outfit/hai tracker pod"
-	"mass" 8
-	"outfit space" -19
-	"weapon capacity" -19
+	"mass" 8.8
+	"outfit space" -10
+	"weapon capacity" -10
 	"gun ports" -1
-	"tracker capacity" 56
+	"tracker capacity" 6
 	weapon
 		sprite "projectile/tracker"
 			"frame rate" 10

--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -142,7 +142,7 @@ ship "Lightning Bug"
 ship "Lightning Bug" "Lightning Bug (Pulse)"
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 56
+		"Hai Tracker" 6
 		"Pulse Turret" 2
 		"Geode Reactor"
 		"Hai Gorge Batteries"
@@ -241,7 +241,8 @@ ship "Shield Beetle"
 	outfits
 		"Ion Cannon" 4
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 224
+		"Tracker Storage Pod" 2
+		"Hai Tracker" 84
 		"Chameleon Anti-Missile" 2
 		"Boulder Reactor"
 		"Geode Reactor"
@@ -278,7 +279,8 @@ ship "Shield Beetle"
 ship "Shield Beetle" "Shield Beetle (Tracker)"
 	outfits
 		"Hai Tracker Pod" 8
-		"Hai Tracker" 448
+		"Tracker Storage Pod" 4
+		"Hai Tracker" 168
 		"Pulse Turret" 4
 		"Boulder Reactor"
 		"Geode Reactor"
@@ -316,7 +318,8 @@ ship "Shield Beetle" "Shield Beetle (Jump)"
 	outfits
 		"Ion Cannon" 4
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 224
+		"Tracker Storage Pod" 2
+		"Hai Tracker" 84
 		"Chameleon Anti-Missile" 2
 		"Boulder Reactor" 2
 		"Hai Chasm Batteries" 2
@@ -345,7 +348,8 @@ ship "Shield Beetle" "Shield Beetle (Jump)"
 ship "Shield Beetle" "Shield Beetle (Jump, Tracker)"
 	outfits
 		"Hai Tracker Pod" 8
-		"Hai Tracker" 448
+		"Tracker Storage Pod" 4
+		"Hai Tracker" 168
 		"Pulse Turret" 4
 		"Boulder Reactor" 2
 		"Hai Ravine Batteries"
@@ -385,7 +389,8 @@ ship "Solifuge"
 			"hit force" 3500
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 56
+		"Tracker Storage Pod"
+		"Hai Tracker" 36
 		"Ion Cannon" 4
 		"Pulse Turret" 2
 		"Chameleon Anti-Missile"
@@ -452,7 +457,8 @@ ship "Solifuge" "Solifuge (Pulse)"
 ship "Solifuge" "Solifuge (Tracker)"
 	outfits
 		"Hai Tracker Pod" 5
-		"Hai Tracker" 280
+		"Tracker Storage Pod" 3
+		"Hai Tracker" 150
 		"Pulse Turret" 4
 		"Chameleon Anti-Missile"
 		"Bullfrog Anti-Missile" 2
@@ -469,7 +475,8 @@ ship "Solifuge" "Solifuge (Tracker)"
 ship "Solifuge" "Solifuge (Jump)"
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 56
+		"Tracker Storage Pod"
+		"Hai Tracker" 36
 		"Ion Cannon" 4
 		"Pulse Turret" 2
 		"Chameleon Anti-Missile"
@@ -507,7 +514,8 @@ ship "Solifuge" "Solifuge (Jump, Pulse)"
 ship "Solifuge" "Solifuge (Jump, Tracker)"
 	outfits
 		"Hai Tracker Pod" 5
-		"Hai Tracker" 280
+		"Tracker Storage Pod" 3
+		"Hai Tracker" 150
 		"Pulse Turret" 4
 		"Chameleon Anti-Missile"
 		"Bullfrog Anti-Missile" 2
@@ -545,7 +553,7 @@ ship "Violin Spider"
 			"hit force" 180
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 56
+		"Hai Tracker" 6
 		"Pebble Core"
 		Supercapacitor
 		"Hai Williwaw Cooling"
@@ -596,7 +604,8 @@ ship "Water Bug"
 			"hit force" 1860
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Tracker storage pod"
+		"Hai Tracker" 42
 		"Pulse Turret"
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
@@ -625,7 +634,8 @@ ship "Water Bug"
 ship "Water Bug" "Water Bug (Pulse)"
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Tracker Storage Pod"
+		"Hai Tracker" 42
 		"Pulse Turret" 3
 		"Geode Reactor"
 		"Hai Gorge Batteries"
@@ -639,7 +649,8 @@ ship "Water Bug" "Water Bug (Pulse)"
 ship "Water Bug" "Water Bug (Jump)"
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Tracker Storage Pod"
+		"Hai Tracker" 42
 		"Pulse Turret"
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"

--- a/data/korath ships.txt
+++ b/data/korath ships.txt
@@ -311,7 +311,8 @@ ship "Kar Ik Vot 349"
 	outfits
 		"Korath Detainer" 2
 		"Korath Piercer Launcher" 2
-		"Korath Piercer" 62
+		"Korath Piercer Rack"
+		"Korath Piercer" 50
 		"Korath Warder" 2
 		"Korath Repeater Turret" 6
 		
@@ -351,7 +352,8 @@ ship "Kar Ik Vot 349"
 ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Offense)"
 	outfits
 		"Korath Piercer Launcher" 4
-		"Korath Piercer" 124
+		"Korath Piercer Rack" 2
+		"Korath Piercer" 100
 		"Korath Repeater Turret" 6
 		"Korath Grab-Strike" 2
 		
@@ -380,7 +382,8 @@ ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Offense)"
 ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Defense)"
 	outfits
 		"Korath Piercer Launcher" 4
-		"Korath Piercer" 124
+		"Korath Piercer Rack" 2
+		"Korath Piercer" 100
 		"Korath Warder" 3
 		"Korath Grab-Strike" 3
 		"Korath Banisher" 2
@@ -465,7 +468,8 @@ ship "Tek Far 71 - Lek"
 	outfits
 		"Korath Detainer"
 		"Korath Piercer Launcher" 2
-		"Korath Piercer" 62
+		"Korath Piercer Rack"
+		"Korath Piercer" 50
 		"Korath Banisher"
 		"Korath Warder" 2
 		
@@ -557,7 +561,8 @@ ship "Tek Far 78 - Osk"
 	outfits
 		"Korath Detainer"
 		"Korath Piercer Launcher" 3
-		"Korath Piercer" 93
+		"Korath Piercer Rack"
+		"Korath Piercer" 54
 		"Korath Banisher"
 		"Korath Warder" 2
 		
@@ -648,7 +653,8 @@ ship "Tek Far 109"
 	outfits
 		"Korath Detainer"
 		"Korath Piercer Launcher" 2
-		"Korath Piercer" 62
+		"Korath Piercer Rack"
+		"Korath Piercer" 50
 		"Korath Banisher" 2
 		
 		"Double Plasma Core"
@@ -753,7 +759,8 @@ ship "Met Par Tek 53" "Met Par Tek 53 (Sniper)"
 	outfits
 		"Korath Detainer"
 		"Korath Piercer Launcher" 2
-		"Korath Piercer" 62
+		"Korath Piercer Rack"
+		"Korath Piercer" 50
 		"Korath Grab-Strike"
 		"Korath Warder"
 		

--- a/data/korath weapons.txt
+++ b/data/korath weapons.txt
@@ -226,7 +226,7 @@ outfit "Korath Repeater Turret"
 
 outfit "Korath Piercer"
 	category "Ammunition"
-	cost 3500
+	cost 7000
 	thumbnail "outfit/piercer"
 	"mass" .3
 	"piercer capacity" -1
@@ -236,9 +236,9 @@ outfit "Korath Piercer Rack"
 	category "Ammunition"
 	cost 56000
 	thumbnail "outfit/korath piercer storage"
-	"mass" 2.2
-	"outfit space" -7
-	"piercer capacity" 16
+	"mass" 17.5
+	"outfit space" -25
+	"piercer capacity" 23
 	ammo "Korath Piercer"
 	description "The Korath Piercer Rack is used to store extra ammunition for Korath Piercer Launchers."
 
@@ -246,12 +246,12 @@ outfit "Korath Piercer Launcher"
 	category "Secondary Weapons"
 	cost 593000
 	thumbnail "outfit/piercer launcher"
-	"mass" 18
-	"outfit space" -27
-	"weapon capacity" -27
+	"mass" 12.8
+	"outfit space" -14
+	"weapon capacity" -14
 	"energy capacity" 50
 	"gun ports" -1
-	"piercer capacity" 31
+	"piercer capacity" 4
 	weapon
 		sprite "projectile/piercer"
 			"frame rate" 5

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -88,7 +88,8 @@ ship "Argosy"
 	outfits
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Blaster Turret" 2
 		
 		"RT-I Radiothermal"
@@ -141,7 +142,8 @@ ship "Arrow"
 			"hit force" 360
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Anti-Missile Turret"
 		
 		"Dwarf Core"
@@ -190,7 +192,8 @@ ship "Bactrian"
 			"hit force" 3900
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Torpedo Launcher" 2
 		"Torpedo" 60
 		"Heavy Laser Turret" 4
@@ -333,7 +336,8 @@ ship "Bastion"
 	outfits
 		"Plasma Cannon" 2
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
+		"Heavy Rocket Rack"
+		"Heavy Rocket" 12
 		"Blaster Turret" 3
 		
 		"S3 Thermionic"
@@ -441,7 +445,9 @@ ship "Berserker"
 			"hull damage" 150
 			"hit force" 450
 	outfits
-		"Beam Laser" 4
+		"Beam Laser" 3
+		"Meteor Missile Launcher"
+		"Meteor Missile" 4
 		
 		"nGVF-CC Fuel Cell"
 		"LP072a Battery Pack"
@@ -453,10 +459,10 @@ ship "Berserker"
 		
 	engine -10 45
 	engine 10 45
-	gun -20 12
-	gun 20 12
-	gun -44 10
-	gun 44 10
+	gun -20 12 "Beam Laser"
+	gun 20 12 "Beam Laser"
+	gun -44 10 "Beam Laser"
+	gun 44 10 "Meteor Missile Launcher"
 	explode "tiny explosion" 10
 	explode "small explosion" 15
 	"final explode" "final explosion small"
@@ -614,7 +620,8 @@ ship "Bulk Freighter"
 			"hit force" 1800
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Laser Turret" 3
 		"Heavy Anti-Missile Turret" 2
 		
@@ -672,6 +679,7 @@ ship "Carrier"
 	outfits
 		"Particle Cannon" 4
 		"Meteor Missile Launcher" 4
+		"Meteor Missile Box" 4
 		"Meteor Missile" 140
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
@@ -806,7 +814,8 @@ ship "Clipper"
 	outfits
 		"Beam Laser" 2
 		"Javelin Pod" 2
-		"Javelin" 400
+		"Javelin Storage Crate" 2
+		"Javelin" 200
 		
 		"nGVF-DD Fuel Cell"
 		"LP072a Battery Pack"
@@ -947,6 +956,7 @@ ship "Cruiser"
 	outfits
 		"Particle Cannon" 4
 		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile Rack" 2
 		"Sidewinder Missile" 100
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
@@ -1008,7 +1018,9 @@ ship "Dagger"
 			"hull damage" 60
 			"hit force" 180
 	outfits
-		"Beam Laser" 2
+		"Heavy Laser"
+		"Meteor Missile Launcher"
+		"Meteor Missile" 4
 		
 		"nGVF-BB Fuel Cell"
 		"D14-RN Shield Generator"
@@ -1018,8 +1030,8 @@ ship "Dagger"
 		
 	engine -15 30
 	engine 15 30
-	gun -14 -10 "Beam Laser"
-	gun 14 -10 "Beam Laser"
+	gun -14 -10 "Heavy Laser"
+	gun 14 -10 "Meteor Missile Launcher"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description "The Dagger is a fighter designed by Lionheart Industries, intended to be carried by their Aerie warship, although other ships have been known to carry them, as well. As with many Lionheart ships, its chassis is largely composed of lightweight composite materials, making it considerably faster than other fighters."
@@ -1050,7 +1062,8 @@ ship "Dreadnought"
 			"hit force" 3900
 	outfits
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
+		"Meteor Missile Box" 2
+		"Meteor Missile" 80
 		"Plasma Turret" 5
 		
 		"Breeder Reactor"
@@ -1110,7 +1123,8 @@ ship "Falcon"
 	outfits
 		"Plasma Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo Storage Rack"
+		"Torpedo" 20
 		"Quad Blaster Turret" 4
 		
 		"Breeder Reactor"
@@ -1164,7 +1178,9 @@ ship "Finch"
 			"hull damage" 60
 			"hit force" 180
 	outfits
-		"Beam Laser" 2
+		"Beam Laser"
+		"Heavy Rocket Launcher"
+		"Heavy Rocket"
 		
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
@@ -1176,7 +1192,7 @@ ship "Finch"
 	engine -5 32
 	engine 5 32
 	gun -7 -14 "Beam Laser"
-	gun 7 -14 "Beam Laser"
+	gun 7 -14 "Heavy Rocket Launcher"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description "When the Free Worlds started requesting a Carrier solution from its local shipyards, Tarazed Shipyards quickly saw that a few modifications could make their entry level interceptor into a top tier fighter. Over 85% of the parts that make up the Finch are shared with the Sparrow assembly line, so it's no surprise that even trimmed down to (barely) fit into a fighter bay, the Finch bears strong resemblance to its hyperspace-faring cousin."
@@ -1259,7 +1275,8 @@ ship "Flivver"
 			"hit force" 240
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
@@ -1354,7 +1371,8 @@ ship "Frigate"
 	outfits
 		"Particle Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo Storage Rack"
+		"Torpedo" 20
 		"Blaster Turret" 3
 		
 		"NT-200 Nucleovoltaic"
@@ -1407,7 +1425,11 @@ ship "Fury"
 			"hull damage" 120
 			"hit force" 360
 	outfits
-		"Energy Blaster" 4
+		"Energy Blaster" 2
+		"Meteor Missile Launcher"
+		"Meteor Missile" 4
+		"Heavy Rocket Launcher"
+		"Heavy Rocket" 1
 		
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
@@ -1419,10 +1441,10 @@ ship "Fury"
 		
 	engine -17 35
 	engine 17 35
-	gun -10 -26
-	gun 10 -26
-	gun -16 -20
-	gun 16 -20
+	gun -10 -26 "Meteor Missile Launcher"
+	gun 10 -26 "Energy Blaster"
+	gun -16 -20 "Energy Blaster"
+	gun 16 -20 "Heavy Rocket Launcher"
 	explode "tiny explosion" 10
 	explode "small explosion" 20
 	description "The Fury is Southbound Shipyard's most popular design of escort ship. They have greater firepower than any other interceptor-class vessel, meaning that any pirate flying solo will think twice before attacking a convoy that is accompanied by a Fury. However, Furies are also much less maneuverable than other small ships."
@@ -1504,7 +1526,8 @@ ship "Hauler"
 			"hit force" 900
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1558,7 +1581,8 @@ ship "Hauler II"
 			"hit force" 1200
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1612,7 +1636,8 @@ ship "Hauler III"
 			"hit force" 1500
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1795,7 +1820,9 @@ ship "Lance"
 			"hull damage" 60
 			"hit force" 180
 	outfits
-		"Beam Laser" 2
+		"Beam Laser"
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 4
 		
 		"nGVF-AA Fuel Cell"
 		"LP036a Battery Pack"
@@ -1807,7 +1834,7 @@ ship "Lance"
 	engine -15 30
 	engine 15 30
 	gun -14 -10 "Beam Laser"
-	gun 14 -10 "Beam Laser"
+	gun 14 -10 "Sidewinder Missile Launcher"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description "The Lance is the primary fighter used by the Republic Navy. As with all fighters, it is weak by itself but very effective as part of a larger squadron."
@@ -1893,7 +1920,8 @@ ship "Manta"
 	outfits
 		"Particle Cannon" 4
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
@@ -1996,7 +2024,8 @@ ship "Mule"
 			"hit force" 1500
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
 		
@@ -2051,7 +2080,8 @@ ship "Nest"
 			"hit force" 900
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -2160,7 +2190,8 @@ ship "Protector"
 			"hit force" 2400
 	outfits
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo Storage Rack"
+		"Torpedo" 20
 		"Quad Blaster Turret" 6
 		
 		"Fusion Reactor"
@@ -2264,6 +2295,7 @@ ship "Rainmaker"
 	outfits
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 4
+		"Meteor Missile Box" 4
 		"Meteor Missile" 140
 		
 		"nGVF-CC Fuel Cell"
@@ -2362,7 +2394,8 @@ ship "Roost"
 			"hit force" 1200
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -2515,7 +2548,8 @@ ship "Skein"
 			"hit force" 1500
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -2574,7 +2608,9 @@ ship "Sparrow"
 			"hull damage" 80
 			"hit force" 240
 	outfits
-		"Beam Laser" 2
+		"Beam Laser"
+		"Meteor Missile Launcher"
+		"Meteor Missile" 2
 		
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
@@ -2586,8 +2622,8 @@ ship "Sparrow"
 		
 	engine -5 35
 	engine 5 35
-	gun -7 -10
-	gun 7 -10
+	gun -7 -10 "Beam Laser"
+	gun 7 -10 "Meteor Missile Launcher"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description "Classified as an interceptor rather than a fighter because it has its own hyperdrive instead of needing to be carried inside a larger ship, the Tarazed Sparrow is the smallest and cheapest combat ship available. Because of its limited cargo and passenger space, the primary way for a Sparrow pilot to pay the bills is by hunting pirates... or by becoming one. In either case, it is a perilous way to earn a living."
@@ -2712,7 +2748,8 @@ ship "Star Queen"
 			"hit force" 900
 	outfits
 		"Sidewinder Missile Launcher" 3
-		"Sidewinder Missile" 150
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 60
 		"Heavy Anti-Missile Turret" 2
 		
 		"NT-200 Nucleovoltaic"
@@ -2853,7 +2890,8 @@ ship "Wasp"
 	outfits
 		"Energy Blaster" 2
 		"Javelin Pod"
-		"Javelin" 200
+		"Javelin Storage Crate"
+		"Javelin" 120
 		
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -22,7 +22,9 @@ ship "Star Barge" "Star Barge (Armed)"
 
 ship "Sparrow" "Sparrow (Patrol)"
 	outfits
-		"Beam Laser" 2
+		"Beam Laser"
+		"Meteor Missile Launcher"
+		"Meteor Missile" 3
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
@@ -61,7 +63,8 @@ ship "Wasp" "Wasp (Proton)"
 ship "Manta" "Manta (Proton)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Proton Gun" 4
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
@@ -94,7 +97,8 @@ ship "Quicksilver" "Quicksilver (Proton)"
 ship "Cruiser" "Cruiser (Heavy)"
 	outfits
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
+		"Heavy Rocket Rack" 3
+		"Heavy Rocket" 32
 		"Particle Cannon" 4
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
@@ -130,6 +134,7 @@ ship "Scout" "Scout (Speedy)"
 		"Meteor Missile Launcher"
 		"Meteor Missile" 35
 		"Sidewinder Missile Launcher"
+		"Sidewinder Missile Rack"
 		"Sidewinder Missile" 50
 		"Anti-Missile Turret"
 		"NT-200 Nucleovoltaic"
@@ -146,9 +151,11 @@ ship "Scout" "Scout (Speedy)"
 ship "Clipper" "Clipper (Heavy)"
 	outfits
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
+		"Heavy Rocket Rack"
+		"Heavy Rocket" 12
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"RT-I Radiothermal"
 		"Supercapacitor"
 		"D67-TM Shield Generator"
@@ -207,7 +214,8 @@ ship "Argosy" "Argosy (Laser)"
 ship "Argosy" "Argosy (Missile)"
 	outfits
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
+		"Meteor Missile Box" 2
+		"Meteor Missile" 70
 		"Anti-Missile Turret"
 		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
@@ -253,7 +261,8 @@ ship "Argosy" "Argosy (Blaster)"
 ship "Behemoth" "Behemoth (Speedy)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Heavy Laser Turret" 6
 		"Breeder Reactor"
 		"LP144a Battery Pack"
@@ -274,7 +283,8 @@ ship "Bulk Freighter" "Bulk Freighter (Heavy)"
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
@@ -294,7 +304,8 @@ ship "Bulk Freighter" "Bulk Freighter (Blaster)"
 	outfits
 		"Quad Blaster Turret" 5
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Fusion Reactor"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
@@ -308,8 +319,9 @@ ship "Bulk Freighter" "Bulk Freighter (Blaster)"
 
 ship "Fury" "Fury (Missile)"
 	outfits
-		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
+		"Heavy Laser"
+		"Meteor Missile Launcher" 3
+		"Meteor Missile" 15
 		"nGVF-BB Fuel Cell"
 		"Supercapacitor" 3
 		"D14-RN Shield Generator"
@@ -347,7 +359,8 @@ ship "Hawk" "Hawk (Speedy)"
 ship "Hawk" "Hawk (Rocket)"
 	outfits
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
+		"Heavy Rocket Rack"
+		"Heavy Rocket" 12
 		"RT-I Radiothermal"
 		"Supercapacitor" 2
 		"D41-HY Shield Generator"
@@ -412,7 +425,8 @@ ship "Corvette" "Corvette (Missile)"
 		"Torpedo Launcher" 2
 		"Torpedo" 60
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Heavy Anti-Missile Turret" 2
 		"Fission Reactor"
 		"LP036a Battery Pack"
@@ -448,9 +462,11 @@ ship "Firebird" "Firebird (Plasma)"
 ship "Firebird" "Firebird (Missile)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Torpedo Launcher" 2
-		Torpedo 60
+		"Torpedo Storage Rack"
+		Torpedo 20
 		"Heavy Laser Turret" 2
 		"Fission Reactor"
 		"LP072a Battery Pack"
@@ -470,7 +486,8 @@ ship "Mule" "Mule (Heavy)"
 	outfits
 		"Heavy Laser Turret" 4
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"Supercapacitor" 4
@@ -502,9 +519,11 @@ ship "Osprey" "Osprey (Laser)"
 ship "Osprey" "Osprey (Missile)"
 	outfits
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo Storage Rack"
+		"Torpedo" 20
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
+		"Heavy Rocket Rack"
+		"Heavy Rocket" 12
 		"Heavy Laser Turret" 2
 		"Breeder Reactor"
 		"LP036a Battery Pack"
@@ -525,7 +544,8 @@ ship "Raven" "Raven (Heavy)"
 	outfits
 		"Particle Cannon" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Fission Reactor"
 		"Supercapacitor" 3
 		"D23-QP Shield Generator"
@@ -578,7 +598,8 @@ ship "Falcon" "Falcon (Heavy)"
 		"Torpedo Launcher" 2
 		"Torpedo" 60
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Heavy Laser Turret" 4
 		"Fusion Reactor"
 		"D67-TM Shield Generator"
@@ -612,9 +633,11 @@ ship "Leviathan" "Leviathan (Laser)"
 ship "Leviathan" "Leviathan (Heavy)"
 	outfits
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo Storage Rack"
+		"Torpedo" 20
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Heavy Laser Turret" 4
 		"Breeder Reactor"
 		"LP036a Battery Pack"
@@ -756,7 +779,8 @@ ship "Modified Argosy" "Modified Argosy (Blaster)"
 ship "Modified Argosy" "Modified Argosy (Missile)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Torpedo Launcher" 2
 		"Torpedo" 60
 		"Heavy Laser Turret"
@@ -800,6 +824,7 @@ ship "Fury" "Fury (Flamethrower)"
 ship "Rainmaker" "Rainmaker (Mark II)"
 	outfits
 		"Sidewinder Missile Launcher" 4
+		"Sidewinder Missile Rack" 4
 		"Sidewinder Missile" 200
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
@@ -855,9 +880,11 @@ ship "Frigate" "Frigate (Mark II)"
 ship "Cruiser" "Cruiser (Mark II)"
 	outfits
 		"Typhoon Launcher" 2
-		"Typhoon Torpedo" 60
+		"Typhoon Storage Tube" 2
+		"Typhoon Torpedo" 46
 		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 200
+		"Sidewinder Missile Rack" 3
+		"Sidewinder Missile" 150
 		"Electron Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Armageddon Core"
@@ -885,6 +912,7 @@ ship "Carrier" "Carrier (Mark II)"
 	outfits
 		"Particle Cannon" 4
 		"Sidewinder Missile Launcher" 4
+		"Sidewinder Missile Rack" 4
 		"Sidewinder Missile" 200
 		"Electron Turret" 3
 		"Heavy Anti-Missile Turret"
@@ -958,7 +986,8 @@ ship "Manta" "Manta (Mark II)"
 	outfits
 		"Particle Cannon" 4
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"S-270 Regenerator"
@@ -1014,9 +1043,11 @@ ship "Manta" "Manta (Nuclear)"
 ship "Cruiser" "Cruiser (Jump)"
 	outfits
 		"Typhoon Launcher" 2
-		"Typhoon Torpedo" 60
+		"Typhoon Storage Tube" 2
+		"Typhoon Torpedo" 46
 		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 200
+		"Sidewinder Missile Rack" 3
+		"Sidewinder Missile" 150
 		"Electron Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Armageddon Core"
@@ -1047,7 +1078,8 @@ ship "Carrier" "Carrier (Jump)"
 	outfits
 		"Particle Cannon" 4
 		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 200
+		"Sidewinder Missile Rack" 3
+		"Sidewinder Missile" 150
 		"Electron Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Armageddon Core"
@@ -1079,6 +1111,7 @@ ship "Carrier" "Carrier (Jump)"
 ship "Dreadnought" "Dreadnought (Jump)"
 	outfits
 		"Meteor Missile Launcher" 4
+		"Meteor Missile Box" 4
 		"Meteor Missile" 140
 		"Plasma Turret" 5
 		"Stack Core"
@@ -1125,6 +1158,7 @@ ship "Osprey" "Osprey (Alien Weapons)"
 ship "Nest" "Nest (Sidewinder)"
 	outfits
 		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile Rack" 2
 		"Sidewinder Missile" 100
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -1141,6 +1175,7 @@ ship "Nest" "Nest (Sidewinder)"
 ship "Roost" "Roost (Sidewinder)"
 	outfits
 		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile Rack" 2
 		"Sidewinder Missile" 100
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -1157,6 +1192,7 @@ ship "Roost" "Roost (Sidewinder)"
 ship "Skein" "Skein (Sidewinder)"
 	outfits
 		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile Rack" 2
 		"Sidewinder Missile" 100
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -1235,7 +1271,8 @@ ship "Flivver" "Flivver (Hai)"
 ship "Arrow" "Arrow (Hai)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Bullfrog Anti-Missile"
 		"Pebble Core"
 		"Supercapacitor" 2
@@ -1264,7 +1301,8 @@ ship "Bounder" "Bounder (Hai)"
 ship "Star Queen" "Star Queen (Hai)"
 	outfits
 		"Hai Tracker Pod" 3
-		"Hai Tracker" 168
+		"Tracker Storage Pod" 3
+		"Hai Tracker" 108
 		"Chameleon Anti-Missile" 2
 		"NT-200 Nucleovoltaic"
 		"Hai Fissure Batteries"
@@ -1298,7 +1336,8 @@ ship "Freighter" "Freighter (Hai)"
 ship "Hauler" "Hauler (Hai)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Quad Blaster Turret" 2
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
@@ -1319,7 +1358,8 @@ ship "Hauler" "Hauler (Hai)"
 ship "Hauler II" "Hauler II (Hai)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Quad Blaster Turret" 2
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
@@ -1340,7 +1380,8 @@ ship "Hauler II" "Hauler II (Hai)"
 ship "Hauler III" "Hauler III (Hai)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile Box"
+		"Meteor Missile" 40
 		"Quad Blaster Turret" 2
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
@@ -1361,7 +1402,8 @@ ship "Hauler III" "Hauler III (Hai)"
 ship "Behemoth" "Behemoth (Hai)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Pulse Turret" 6
 		"Boulder Reactor"
 		"Hai Ravine Batteries"
@@ -1379,7 +1421,8 @@ ship "Behemoth" "Behemoth (Hai)"
 ship "Bulk Freighter" "Bulk Freighter (Hai)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Pulse Turret" 2
 		"Chameleon Anti-Missile" 3
 		"RT-I Radiothermal"
@@ -1413,7 +1456,8 @@ ship "Headhunter" "Headhunter (Hai)"
 ship "Corvette" "Corvette (Hai)"
 	outfits
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 224
+		"Tracker Storage Pod" 2
+		"Hai Tracker" 72
 		"Heavy Anti-Missile Turret" 2
 		"Fission Reactor"
 		"LP036a Battery Pack"
@@ -1462,7 +1506,8 @@ ship "Firebird" "Firebird (Hai Shields)"
 ship "Mule" "Mule (Hai Engines)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Heavy Laser Turret" 3
 		"Chameleon Anti-Missile"
 		"Boulder Reactor"
@@ -1515,7 +1560,8 @@ ship "Leviathan" "Leviathan (Hai Engines)"
 ship "Leviathan" "Leviathan (Hai Weapons)"
 	outfits
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 224
+		"Tracker Storage Pod" 2
+		"Hai Tracker" 72
 		"Heavy Laser Turret" 4
 		"Boulder Reactor"
 		"Hai Ravine Batteries"
@@ -1532,9 +1578,11 @@ ship "Leviathan" "Leviathan (Hai Weapons)"
 ship "Bactrian" "Bactrian (Hai Engines)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 50
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo Storage Rack" 2
+		"Torpedo" 40
 		"Heavy Laser Turret" 4
 		"Heavy Anti-Missile Turret" 2
 		"Fusion Reactor"
@@ -1554,7 +1602,8 @@ ship "Bactrian" "Bactrian (Hai Weapons)"
 	outfits
 		"Pulse Cannon" 2
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Tracker Storage Pod"
+		"Hai Tracker" 36
 		"Chameleon Anti-Missile" 2
 		"Pulse Turret" 2
 		"Heavy Laser Turret" 2
@@ -1599,7 +1648,8 @@ ship "Bastion" "Bastion (Scanner)"
 	outfits
 		"Plasma Cannon" 2
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
+		"Heavy Rocket Rack"
+		"Heavy Rocket" 12
 		"Blaster Turret" 3
 		"S3 Thermionic"
 		"LP144a Battery Pack"

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -598,9 +598,9 @@ outfit "Meteor Missile Box"
 	category "Ammunition"
 	cost 9000
 	thumbnail "outfit/meteor storage"
-	"mass" 1.4
-	"outfit space" -5
-	"meteor capacity" 18
+	"mass" 4
+	"outfit space" -10
+	"meteor capacity" 30
 	ammo "Meteor Missile"
 	description "The Meteor Missile Box is used to store extra ammunition for Meteor Missile Launchers."
 
@@ -608,11 +608,11 @@ outfit "Meteor Missile Launcher"
 	category "Secondary Weapons"
 	cost 15000
 	thumbnail "outfit/meteor launcher"
-	"mass" 3
-	"outfit space" -10
-	"weapon capacity" -10
+	"mass" 4
+	"outfit space" -5
+	"weapon capacity" -5
 	"gun ports" -1
-	"meteor capacity" 35
+	"meteor capacity" 5
 	weapon
 		sprite "projectile/meteor"
 			"no repeat"
@@ -660,9 +660,9 @@ outfit "Sidewinder Missile Rack"
 	category "Ammunition"
 	cost 20000
 	thumbnail "outfit/sidewinder storage"
-	"mass" 2
-	"outfit space" -7
-	"sidewinder capacity" 25
+	"mass" 6
+	"outfit space" -15
+	"sidewinder capacity" 45
 	ammo "Sidewinder Missile"
 	description "The Sidewinder Missile Rack is used to store extra ammunition for Sidewinder Missile Launchers."
 
@@ -670,9 +670,9 @@ outfit "Sidewinder Missile Launcher"
 	category "Secondary Weapons"
 	cost 60000
 	thumbnail "outfit/sidewinder launcher"
-	"mass" 4
-	"outfit space" -14
-	"weapon capacity" -14
+	"mass" 6
+	"outfit space" -7
+	"weapon capacity" -7
 	"gun ports" -1
 	"sidewinder capacity" 50
 	weapon
@@ -723,8 +723,8 @@ outfit "Javelin Storage Crate"
 	category "Ammunition"
 	cost 5000
 	thumbnail "outfit/javelin storage"
-	"mass" 2
-	"outfit space" -6
+	"mass" 4
+	"outfit space" -8
 	"javelin capacity" 100
 	ammo "Javelin"
 	description "The Javelin Storage Crate is used to store extra ammunition for Javlein Pods."
@@ -733,11 +733,11 @@ outfit "Javelin Pod"
 	category "Secondary Weapons"
 	cost 20000
 	thumbnail "outfit/javelin pod"
-	"mass" 4
-	"outfit space" -12
-	"weapon capacity" -12
+	"mass" 5.2
+	"outfit space" -6
+	"weapon capacity" -6
 	"gun ports" -1
-	"javelin capacity" 200
+	"javelin capacity" 20
 	weapon
 		sprite "projectile/javelin"
 		sound "javelin"
@@ -770,9 +770,9 @@ outfit "Torpedo Storage Rack"
 	category "Ammunition"
 	cost 21000
 	thumbnail "outfit/torpedo storage"
-	"mass" 3
-	"outfit space" -9
-	"torpedo capacity" 15
+	"mass" 12
+	"outfit space" -20
+	"torpedo capacity" 20
 	ammo "Torpedo"
 	description "The Torpedo Storage Rack is used to store extra ammunition for Torpedo Launchers."
 
@@ -780,11 +780,11 @@ outfit "Torpedo Launcher"
 	category "Secondary Weapons"
 	cost 80000
 	thumbnail "outfit/torpedo launcher"
-	"mass" 13
-	"outfit space" -25
-	"weapon capacity" -25
+	"mass" 13.8
+	"outfit space" -15
+	"weapon capacity" -15
 	"gun ports" -1
-	"torpedo capacity" 30
+	"torpedo capacity" 3
 	weapon
 		sprite "projectile/torpedo"
 			"frame rate" 2
@@ -832,9 +832,9 @@ outfit "Typhoon Storage Tube"
 	category "Ammunition"
 	cost 40500
 	thumbnail "outfit/typhoon storage"
-	"mass" 2.5
-	"outfit space" -10
-	"typhoon capacity" 15
+	"mass" 20
+	"outfit space" -30
+	"typhoon capacity" 20
 	ammo "Typhoon Torpedo"
 	description "The Typhoon Storage Tube is used to store extra ammunition for Typhoon Launchers."
 
@@ -842,11 +842,11 @@ outfit "Typhoon Launcher"
 	category "Secondary Weapons"
 	cost 260000
 	thumbnail "outfit/typhoon launcher"
-	"mass" 20
-	"outfit space" -35
-	"weapon capacity" -35
+	"mass" 28.5
+	"outfit space" -20
+	"weapon capacity" -20
 	"gun ports" -1
-	"typhoon capacity" 30
+	"typhoon capacity" 3
 	weapon
 		sprite "projectile/typhoon"
 			"frame rate" 4
@@ -893,8 +893,8 @@ outfit "Heavy Rocket Rack"
 	category "Ammunition"
 	cost 20000
 	thumbnail "outfit/rocket storage"
-	"mass" 2
-	"outfit space" -7
+	"mass" 11
+	"outfit space" -16
 	"rocket capacity" 10
 	ammo "Heavy Rocket"
 	description "The Heavy Rocket Rack is used to store extra ammunition for Heavy Rocket Launchers."
@@ -903,11 +903,11 @@ outfit "Heavy Rocket Launcher"
 	category "Secondary Weapons"
 	cost 40000
 	thumbnail "outfit/rocket launcher"
-	"mass" 10
-	"outfit space" -20
-	"weapon capacity" -20
+	"mass" 6
+	"outfit space" -12
+	"weapon capacity" -12
 	"gun ports" -1
-	"rocket capacity" 20
+	"rocket capacity" 1
 	weapon
 		sprite "projectile/rocket"
 			"frame rate" 4
@@ -930,7 +930,7 @@ outfit "Heavy Rocket Launcher"
 		"hull damage" 600
 		"hit force" 80
 		"missile strength" 16
-	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
+	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters. Each launcher can only hold a single rocket; additional capacity requires the installation of storage racks."
 
 effect "heavy rocket hit"
 	sprite "effect/explosion/huge"


### PR DESCRIPTION
This patch generally reverses the capacities for missile launchers and their storage outfits: now launchers are smaller and have a very limited internal capacity, and storage boxes/racks/tubes are much larger. This allows fighter-sized craft to be armed with missile weapons without giving them enormous missile-firing capacity that unbalances the game With this change:

- Military capital ships retain their high missile capacity
- Medium-sized ships with missile capacity lose quite a bit of their capacity
- Most fighter and interceptor craft can and do gain a very small amount of missile capacity

New launcher and storage sizes were balanced so that compared to the status quo, two launchers and one storage box/rack/tube are equal in total size, but result in fewer missiles. Regaining lost capacity requires buying more storage, which takes up more space now, and only larger ships will have that space available. No more Furies with 140 Meteor Missiles.

This change enables the creation and use of several new ship loadout options:
- Missile-armed fighters that quickly exhaust their missile supplies and then have to rely on guns
- Torpedo boats that exist entirely to fire torpedoes at capital ships (AI might need tweaking to make this actually work)
- Medium-sized ships that can mount multiple types of missile launchers for maximum flexibility
- Fighter-sized craft that can be armed with Heavy Rockets without turning into lone-capital-ship-destroying unholy terrors

Overall, this makes fighters feel more like real-world fighters, and capital ships like real-world capital ships. The differentiator in missile armament is not whether or not fighter-sized craft can carry missiles, but rather how many. Fighter-sized craft can now carry only a few missiles without sacrificing other armament--just like real-world fighters--while large capital ships maintain their huge missile stores--just like real-world missile cruisers and destroyers.