### PR TITLE
Increase missile hit force to make them feel more powerful

### DIFF
--- a/data/coalition weapons.txt
+++ b/data/coalition weapons.txt
@@ -132,7 +132,7 @@ outfit "Active Finisher"
 		"missile strength" 50
 		"shield damage" 1500
 		"hull damage" 1900
-		"hit force" 240
+		"hit force" 3600
 
 outfit "Finisher Torpedo"
 	plural "Finisher Torpedoes"

--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -231,7 +231,7 @@ outfit "Hai Tracker Pod"
 		"infrared tracking" .4
 		"shield damage" 200
 		"hull damage" 160
-		"hit force" 50
+		"hit force" 750
 		"missile strength" 16
 	description "Trackers are fast, powerful, and accurate homing weapons. Their only weakness is their large turning radius: if a Tracker misses its target, it takes a long time to turn around."
 

--- a/data/korath weapons.txt
+++ b/data/korath weapons.txt
@@ -277,7 +277,7 @@ outfit "Korath Piercer Launcher"
 		"shield damage" 290
 		"hull damage" 440
 		"piercing" .2
-		"hit force" 30
+		"hit force" 450
 		"missile strength" 73
 		"stream"
 	description "Korath Piercer missiles carry a pair of warheads. The first, a smaller one in the very tip of the missile, explodes on impact to blast a hole in the ship's shields to allow some of the subsequent, larger explosion to pierce through."
@@ -449,7 +449,7 @@ outfit "Korath Mine Submunition"
 		"drag" .05
 		"shield damage" 350
 		"hull damage" 280
-		"hit force" 50
+		"hit force" 750
 		"missile strength" 22
 
 effect "minelayer fire"

--- a/data/wanderer outfits.txt
+++ b/data/wanderer outfits.txt
@@ -278,7 +278,7 @@ outfit "Thunderhead"
 		"radar tracking" .6
 		"shield damage" 110
 		"hull damage" 80
-		"hit force" 20
+		"hit force" 300
 		"missile strength" 3
 
 outfit "Thunderhead Storage Array"

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -636,7 +636,7 @@ outfit "Meteor Missile Launcher"
 		"infrared tracking" .8
 		"shield damage" 130
 		"hull damage" 80
-		"hit force" 30
+		"hit force" 450
 		"missile strength" 4
 	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. The tracking system on these missiles is notoriously unreliable, and they are easily destroyed by anti-missile systems, but in large numbers or when fired at a slow-moving target they can be deadly."
 
@@ -698,7 +698,7 @@ outfit "Sidewinder Missile Launcher"
 		"radar tracking" .9
 		"shield damage" 100
 		"hull damage" 70
-		"hit force" 25
+		"hit force" 375
 		"missile strength" 12
 	description "The Sidewinder Missile is designed by Lovelace Labs, which is ironically also the designer of the Anti-Missile Turret. Rumors say that the two engineering teams at Lovelace who make the missiles and the anti-missiles are locked in furious competition with each other: the result has been generation after generation of smarter missiles and then smarter turrets to fend them off."
 	description "	Although not as powerful or cheap as the popular Meteor missiles, Sidewinders have several advantages, including their better tracking systems and protective casings that make them much harder for anti-missile systems to destroy."
@@ -752,7 +752,7 @@ outfit "Javelin Pod"
 		"firing heat" 12
 		"shield damage" 48
 		"hull damage" 26
-		"hit force" 5
+		"hit force" 75
 		"missile strength" 2
 	description "The Javelin Pod fires a rapid stream of unguided missiles. A Javelin Pod does far more damage than any gun of a comparable size, and has a longer range as well, but once a ship has fired off all its ammunition it must leave combat and find a planet where it can buy more, which makes Javelins less useful in protracted battles. As a result, they are very popular with pirates as a way to quickly disable a small target."
 
@@ -808,7 +808,7 @@ outfit "Torpedo Launcher"
 		"optical tracking" .8
 		"shield damage" 450
 		"hull damage" 450
-		"hit force" 40
+		"hit force" 600
 		"missile strength" 20
 	description "Torpedoes are the most powerful homing weapon, but they move slowly enough that fast ships can simply outrun them, making them most useful against large targets or against small ships at times when they are too distracted to dodge. Torpedo launchers are also much larger than other missile systems, so they are most often found in capital ships."
 
@@ -870,7 +870,7 @@ outfit "Typhoon Launcher"
 		"optical tracking" .9
 		"shield damage" 610
 		"hull damage" 610
-		"hit force" 70
+		"hit force" 1050
 		"missile strength" 30
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."
 
@@ -928,7 +928,7 @@ outfit "Heavy Rocket Launcher"
 		"blast radius" 50
 		"shield damage" 700
 		"hull damage" 600
-		"hit force" 80
+		"hit force" 1200
 		"missile strength" 16
 	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
 


### PR DESCRIPTION
This multiplies missiles' `hit force` by 15 to make them seem like they're actually doing something on impact. That seems like a very high number, but it's really not--the net effect is simply to make missiles visibly impact small light ships and push them back a little bit. It's a small but dramatic change and makes missiles _feel_ more dangerous without actually changing any of their actual danger-related game mechanics.

This change combines really well with https://github.com/endless-sky/endless-sky/pull/3274