### PR TITLE
Listed Flamethrower under Guns

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -524,7 +524,7 @@ effect "plasma explosion"
 
 
 outfit "Flamethrower"
-	category "Secondary Weapons"
+	category "Guns"
 	cost 190000
 	thumbnail "outfit/flamethrower"
 	"mass" 9


### PR DESCRIPTION
The Flamethrower does not require any ammunition (and fires continuously), therefore it would be more suitable to list under Guns instead of under Secondary Weapons. This would also make it easier to compare it with lasers, plasma cannons, Korath fire lances, etc.