### PR TITLE
Listed Turrets above Guns

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -27,8 +27,8 @@ namespace {
 }
 
 const vector<string> Outfit::CATEGORIES = {
-	"Guns",
 	"Turrets",
+	"Guns",
 	"Secondary Weapons",
 	"Ammunition",
 	"Systems",


### PR DESCRIPTION
Because Secondary Weapons occupy gun slots as well, it would make sense to list them directly after Guns, which also makes an easier comparison, therefore Turrets are now listed before Guns.
An alternative, listing Turrets after Ammunition, seems worse.