### PR TITLE
Consider both trigger and blast radius when firing all weapon types

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2482,8 +2482,9 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 			p += v;
 			
 			// If this weapon has a blast radius, don't fire it if the target is
-			// so close that you'll be hit by the blast.
-			if(!outfit->IsSafe() && p.Length() < outfit->BlastRadius())
+			// so close that you'll be hit by the blast. Weapons using proximity
+			// triggers will explode sooner, so a larger separation is needed.
+			if(!outfit->IsSafe() && p.Length() <= (outfit->BlastRadius() + outfit->TriggerRadius()))
 				continue;
 			
 			// Calculate how long it will take the projectile to reach its target.
@@ -2512,6 +2513,11 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 			// By the time this action is performed, the ships will have moved
 			// forward one time step.
 			p += v;
+			
+			// Non-homing weapons may have a blast radius or proximity trigger.
+			// Do not fire this weapon if we will be caught in the blast.
+			if(!outfit->IsSafe() && p.Length() <= (outfit->BlastRadius() + outfit->TriggerRadius()))
+				continue;
 			
 			// Get the vector the weapon will travel along.
 			v = (ship.Facing() + weapon.GetAngle()).Unit() * vp - v;


### PR DESCRIPTION
 - Previous behaviors did not consider blast radius for non-homing weapons (such as Heavy Rockets), or trigger radius at all.

This PR should help any NPC that uses Nuclear Missiles or Heavy Rockets, or any plugin weapon that has a blast radius and a trigger radius.

As with the existing check, this is a **simple** check that assumes
1) The target does not approach the firing ship
2) The firing ship does not follow the projectile to the target

These assumptions do not currently hold for Heavy Rockets, and are in general dependent on the other weaponry installed (e.g. NM's + Meteors will result in these being valid, but NM's & Heavy Lasers will not). This firing check is basically verifying that the projectile will not immediately explode and harm this ship.
A different PR that alters movement behavior for a ship using non-safe weaponry with a blast radius would be beneficial.