### PR TITLE
Ships with non-safe blast radius weaponry do not follow the projectile

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1704,14 +1704,21 @@ void AI::Attack(Ship &ship, Command &command, const Ship &target)
 	double shortestRange = 4000.;
 	bool isArmed = false;
 	bool hasAmmo = false;
+	double minSafeDistance = 0.;
 	for(const Hardpoint &weapon : ship.Weapons())
 	{
 		const Outfit *outfit = weapon.GetOutfit();
 		if(outfit && !weapon.IsAntiMissile())
 		{
 			isArmed = true;
-			if(!outfit->Ammo() || ship.OutfitCount(outfit->Ammo()))
-				hasAmmo = true;
+			bool hasThisAmmo = (!outfit->Ammo() || ship.OutfitCount(outfit->Ammo()));
+			hasAmmo |= hasThisAmmo;
+			
+			// Exploding weaponry that can damage this ship requires special
+			// consideration (while we have the ammo to use the weapon).
+			if(hasThisAmmo && outfit->BlastRadius() && !outfit->IsSafe())
+				minSafeDistance = max(outfit->BlastRadius() + outfit->TriggerRadius(), minSafeDistance);
+			
 			// The missile boat AI should be applied at 1000 pixels range if
 			// all weapons are homing or turrets, and at 2000 if not.
 			double multiplier = (weapon.IsHoming() || weapon.IsTurret()) ? 1. : .5;
@@ -1728,10 +1735,12 @@ void AI::Attack(Ship &ship, Command &command, const Ship &target)
 	// Deploy any fighters you are carrying.
 	if(!ship.IsYours())
 		command |= Command::DEPLOY;
-	// If this ship only has long-range weapons, it should keep its distance
-	// instead of trying to close with the target ship.
-	Point d = target.Position() - ship.Position();
-	if(shortestRange > 1000. && d.Length() < .5 * shortestRange)
+	
+	// If this ship has only long-range weapons, or some weapons have a
+	// blast radius, it should keep some distance instead of closing in.
+	Point d = (target.Position() + target.Velocity()) - (ship.Position() + ship.Velocity());
+	if((minSafeDistance > 0. || shortestRange > 1000.)
+			&& d.Length() < max(1.25 * minSafeDistance, .5 * shortestRange))
 	{
 		// If this ship can use reverse thrusters, consider doing so.
 		double reverseSpeed = ship.MaxReverseVelocity();
@@ -1741,15 +1750,14 @@ void AI::Attack(Ship &ship, Command &command, const Ship &target)
 			command.SetTurn(TurnToward(ship, d));
 			if(ship.Facing().Unit().Dot(d) >= 0.)
 				command |= Command::BACK;
-			return;
 		}
 		else
 		{
 			command.SetTurn(TurnToward(ship, -d));
 			if(ship.Facing().Unit().Dot(d) <= 0.)
 				command |= Command::FORWARD;
-			return;
 		}
+		return;
 	}
 	
 	MoveToAttack(ship, command, target);


### PR DESCRIPTION
 Instead, they attempt to keep the minimum safe distance (blast radius + trigger radius) between them and their target ship. 
The behavior switch (close towards target vs start distancing) occurs at a point larger than the safe distance since the ship requires some time to turn away. I opted for 125%, which is (50 + 30) * 1.25 = 100px for Heavy Rockets, and (150 + 30) * 1.25 = 225 for Nuclear Missiles.

This PR (even without coupling with #3300 ) should greatly improve the AI behavior for the "Hawk (Rocket)" and Captain Nate NPCs, along with other NPCs using non-safe, exploding weaponry.