### PR TITLE
Measure scanner distances from the ship's outline rather than its center

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2731,7 +2731,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		{
 			for(const shared_ptr<Minable> &asteroid : minables)
 			{
-				double range = ship.Position().Distance(asteroid->Position());
+				double range = ship.GetMask().Range(asteroid->Position() - ship.Position(), ship.Facing());
 				if(range < asteroidRange)
 				{
 					ship.SetTargetAsteroid(asteroid);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -571,7 +571,7 @@ void Engine::Step(bool isActive)
 		if(flagship->Attributes().Get("tactical scan power"))
 		{
 			info.SetCondition("range display");
-			int targetRange = round(targetAsteroid->Position().Distance(flagship->Position()));
+			int targetRange = round(flagship->GetMask(step).Range(targetAsteroid->Position() - center, flagship->Facing()));
 			info.SetString("target range", to_string(targetRange));
 		}
 	}
@@ -615,9 +615,10 @@ void Engine::Step(bool isActive)
 			else
 				targetAngle = Point();
 			
-			// Check if the target is close enough to show tactical information.
+			// Check if the target is close enough to show tactical information,
+			// measuring from the outside of the flagship rather than its center.
 			double tacticalRange = 100. * sqrt(flagship->Attributes().Get("tactical scan power"));
-			double targetRange = target->Position().Distance(flagship->Position());
+			double targetRange = flagship->GetMask(step).Range(target->Position() - center, flagship->Facing());
 			if(tacticalRange)
 			{
 				info.SetCondition("range display");
@@ -700,7 +701,7 @@ void Engine::Step(bool isActive)
 		for(const shared_ptr<Minable> &minable : asteroids.Minables())
 		{
 			Point offset = minable->Position() - center;
-			if(offset.Length() > scanRange)
+			if(!flagship->GetMask(step).WithinRange(offset, flagship->Facing(), scanRange))
 				continue;
 			
 			targets.push_back({
@@ -1570,7 +1571,7 @@ void Engine::HandleMouseClicks()
 		for(const shared_ptr<Minable> &minable : asteroids.Minables())
 		{
 			Point position = minable->Position() - flagship->Position();
-			if(position.Length() > scanRange)
+			if(!flagship->GetMask(step).WithinRange(position, flagship->Facing(), scanRange))
 				continue;
 			
 			double range = clickPoint.Distance(position) - minable->Radius();

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1526,7 +1526,7 @@ int Ship::Scan()
 		outfitSpeed = 1.;
 	
 	// Check how close this ship is to the target it is trying to scan.
-	double distance = (target->position - position).Length();
+	double distance = GetMask().Range(target->position - position, angle);
 	
 	// Check if either scanner has finished scanning.
 	bool startedScanning = false;


### PR DESCRIPTION
Refs #3302 
 `Mask-to-center` distance:
 - Better agreement between displayed range and known weapon ranges than if measuring distances `center-to-center`.
 - Range to target is 0 if overlapping the target's center
 - Target "knowledge" requires measuring more than just its edge (i.e., `mask-to-center` range is more logical than `mask-to-mask` range.