### PR TITLE
Draw a pointer to the targeted asteroid

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2695,11 +2695,6 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 	}
 	wasHyperspacing = ship.IsEnteringHyperspace();
 	
-	// If the player's targeted asteroid leaves the scannable range, it is no longer targeted.
-	if(ship.GetTargetAsteroid() && ((ship.GetTargetAsteroid()->Position() - ship.Position()).Length()
-			> (100. * sqrt(ship.Attributes().Get("asteroid scan power")))))
-		ship.SetTargetAsteroid(nullptr);
-	
 	if(keyDown.Has(Command::NEAREST))
 	{
 		double closest = numeric_limits<double>::infinity();

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2695,6 +2695,11 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 	}
 	wasHyperspacing = ship.IsEnteringHyperspace();
 	
+	// If the player's targeted asteroid leaves the scannable range, it is no longer targeted.
+	if(ship.GetTargetAsteroid() && ((ship.GetTargetAsteroid()->Position() - ship.Position()).Length()
+			> (100. * sqrt(ship.Attributes().Get("asteroid scan power")))))
+		ship.SetTargetAsteroid(nullptr);
+	
 	if(keyDown.Has(Command::NEAREST))
 	{
 		double closest = numeric_limits<double>::infinity();

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -568,6 +568,14 @@ void Engine::Step(bool isActive)
 			targetAsteroid->GetFrame(step));
 		info.SetString("target name", Format::Capitalize(targetAsteroid->Name()) + " Asteroid");
 		
+		// Don't show the angle to the asteroid if it is very close.
+		targetAngle = targetAsteroid->Position() - center;
+		double length = targetAngle.Length();
+		if(length > 20.)
+			targetAngle /= length;
+		else
+			targetAngle = Point();
+		
 		if(flagship->Attributes().Get("tactical scan power"))
 		{
 			info.SetCondition("range display");


### PR DESCRIPTION
~~Once an asteroid is no longer in range of the flagship's asteroid scanners, it should no longer be targeted (as it is no longer drawn with the targeting reticles).~~

While in range, a pointer is shown in the direction of the asteroid, as is done for ships. 