### PR TITLE
Faster blaster bolts

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -130,8 +130,8 @@ outfit "Modified Blaster Turret"
 		"hit effect" "blaster impact"
 		"inaccuracy" 4
 		"turret turn" 4
-		"velocity" 15
-		"lifetime" 30
+		"velocity" 11.25
+		"lifetime" 40
 		"reload" 6
 		"firing energy" 16
 		"firing heat" 55

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -21,8 +21,8 @@ outfit "Energy Blaster"
 		sound "blaster"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
-		"velocity" 7
-		"lifetime" 60
+		"velocity" 10.5
+		"lifetime" 40
 		"reload" 12
 		"firing energy" 10
 		"firing heat" 35
@@ -47,8 +47,8 @@ outfit "Blaster Turret"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
 		"turret turn" 5
-		"velocity" 7
-		"lifetime" 60
+		"velocity" 10.5
+		"lifetime" 40
 		"reload" 6
 		"firing energy" 10
 		"firing heat" 35
@@ -73,8 +73,8 @@ outfit "Quad Blaster Turret"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
 		"turret turn" 3
-		"velocity" 7
-		"lifetime" 60
+		"velocity" 10.5
+		"lifetime" 40
 		"reload" 3
 		"firing energy" 10
 		"firing heat" 35
@@ -104,8 +104,8 @@ outfit "Modified Blaster"
 		sound "mod blaster"
 		"hit effect" "blaster impact"
 		"inaccuracy" 4
-		"velocity" 7.5
-		"lifetime" 60
+		"velocity" 11.25
+		"lifetime" 40
 		"reload" 12
 		"firing energy" 16
 		"firing heat" 55
@@ -130,8 +130,8 @@ outfit "Modified Blaster Turret"
 		"hit effect" "blaster impact"
 		"inaccuracy" 4
 		"turret turn" 4
-		"velocity" 7.5
-		"lifetime" 60
+		"velocity" 15
+		"lifetime" 30
 		"reload" 6
 		"firing energy" 16
 		"firing heat" 55


### PR DESCRIPTION
Something that makes Blaster weapons feel unimpressive is the slow speed at which their projectiles travel. They feel more like blaster _blobs_ than blaster _bolts_.

This change increases blaster bolt speed by 50%, keeping the overall range the same. Now the bolts look much more impressive and dangerous (especially when combined with https://github.com/endless-sky/endless-sky/pull/3306). This also helps Blaster turrets get a few more hits in against small fast-moving targets, which should improve their viability compared to Laser turrets.