### PR TITLE
Fix binding of sampler tex.

### DIFF
--- a/source/Font.cpp
+++ b/source/Font.cpp
@@ -468,7 +468,7 @@ void Font::SetUpShader(float glyphW, float glyphH)
 	screenHeight = 0;
 	
 	// The texture always comes from texture unit 0.
-	glUniform1ui(shader.Uniform("tex"), 0);
+	glUniform1i(shader.Uniform("tex"), 0);
 
 	colorI = shader.Uniform("color");
 	scaleI = shader.Uniform("scale");

--- a/source/OutlineShader.cpp
+++ b/source/OutlineShader.cpp
@@ -117,7 +117,7 @@ void OutlineShader::Init()
 	colorI = shader.Uniform("color");
 	
 	glUseProgram(shader.Object());
-	glUniform1ui(shader.Uniform("tex"), 0);
+	glUniform1i(shader.Uniform("tex"), 0);
 	glUseProgram(0);
 	
 	// Generate the vertex data for drawing sprites.


### PR DESCRIPTION
For samplers, Mesa3D expects the argument to be int.
It was being sent as uint.

Reference: #3292