### PR TITLE
Wrap messages when drawing them to prevent overflow

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -401,7 +401,7 @@ interface "hud"
 		to 120 0 bottom left
 	box "messages"
 		from 120 0 bottom left
-		to -80 -200 bottom right
+		to -100 -200 bottom right
 	box "ammo"
 		from -80 460 top right
 		to 0 0 bottom right


### PR DESCRIPTION
Refs #1825 
For this screenshot I set the wrap width to be really short, in order to illustrate the wrapping.
![image](https://user-images.githubusercontent.com/20871346/33349082-49c703b6-d45e-11e7-8ac8-23371e00c81f.png)
