### PR TITLE
Slightly buffed the Proton Gun

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -443,10 +443,10 @@ outfit "Proton Fragment"
 			"frame rate" 2
 		"hit effect" "proton impact"
 		"inaccuracy" 2
-		"lifetime" 20
+		"lifetime" 24
 		"hit force" 6
-		"shield damage" 8
-		"hull damage" 6.6
+		"shield damage" 8.4
+		"hull damage" 7
 
 effect "proton impact"
 	sprite "effect/proton impact"


### PR DESCRIPTION
Reference: #3287 

* Submunition lifetime: 20 -> 24
  * Range: 528 -> 624 (96 pixel / 18% increase)
  * This makes the Proton Gun's range about 83% that of the Particle Cannon instead of the previous 70%.
* Submunition shield damage: 8 -> 8.4 (5% increase)
  * Shield DPS: 180 -> 189
* Submunition hull damage: 6.6 -> 7 (6% increase)
  * Hull DPS: 148.5 -> 157.5

An overall 5.5% increase in damage.

The increased range and slightly increased damage to the Proton Gun makes it a more viable alternative to the Plasma Cannon and its powerful heat damage or the Particle Cannon and it's massive range and substantial hit force, and the inaccuracy of the submunitions makes it an interesting weapon to use at range but a very powerful weapon up close.