### PR TITLE
enable "start of hostilities" to trigger Republic rep penalty

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -798,7 +798,7 @@ event "start of hostilities"
 	government "Free Worlds"
 		"attitude toward"
 			"Republic" -.2
-	"reputation: Republic" = -10
+	"reputation: Republic" <?= -10
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -798,6 +798,7 @@ event "start of hostilities"
 	government "Free Worlds"
 		"attitude toward"
 			"Republic" -.2
+	"reputation: Republic" = -10
 
 
 

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1940,7 +1940,6 @@ mission "Defend Sabik"
 			`	Tomek says, "We can't let them take this system, or they'll have us completely bottled up. This is where it begins. We need to fight. Get to your ships, quickly! But if you can, disable their ships instead of destroying them. These are Navy ships after all, and most of them don't want war any more than we do." You hurry to join all the other ships taking off to defend the system.`
 				launch
 		
-		"reputation: Republic" = -10
 		"salary: Free Worlds" = 300
 		event "start of hostilities"
 		event "joined the free worlds"

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -243,7 +243,7 @@ mission "FW Prisoner Parole 2"
 			
 			label next
 			`	"The Navy has had two crushing defeats," he says. "They will be hesitant to attack again until their numbers are much stronger. That gives us some time for diplomacy, to strengthen our position and look for allies, or at least for sympathizers. Which is where you come in. I'm going to ask you to carry a diplomatic mission to the Syndicate. Meet us in the spaceport when you are ready."`
-		"reputation: Republic" = -1000
+		"reputation: Republic" <?= -1000
 		event "oathkeepers founded" 50
 
 

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -198,7 +198,7 @@ mission "FW Prisoner Parole"
 				accept
 		"reputation: Republic" = 1
 		event "temporary ceasefire"
-		event "start of hostilities" 7
+		event "start of hostilities" 8
 	
 	on complete
 		dialog `You drop off the Navy prisoners on <planet>. Now, it's time to get back to Deep with your fleet before the ceasefire ends.`


### PR DESCRIPTION
This is a resolution to #3317 , as an alternate solution to #3318 

This change causes the player to become hostile with the Republic after "FW Prisoner Parole" is completed and while "FW Prisoner Parole 2" is still active.

The event timer in "FW Prisoner Parole" is extended to 8 days, as the mission can still be successful by the end of the 7th day (on the deadline) but the hostility event was triggering at the start of that day.

The -10 reputation setting in mission "Defend Sabik" is removed, as it is now redundant with the -10 setting in the event its self.

The -1000 reputation setting in mission "FW Prisoner Parole 2" still exists as it happens after and supersedes the event.