### PR TITLE
Added wartime jobs for the Free Worlds

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -131,18 +131,6 @@ event "war begins"
 	planet "Bourne"
 		description `Bourne is a well-developed industrial world that was first settled four centuries ago. Its cities are home to some of the richest individuals in this section of the galaxy, but also home to tens of thousands of homeless people, and many others whose factory jobs are barely providing enough to make ends meet.`
 		description `Bourne is also the seat of government for the newly formed Coalition of Free Worlds.`
-	planet "Deep"
-		add attributes "frontline"
-	planet "Glaze"
-		add attributes "frontline"
-	planet "Longjump"
-		add attributes "frontline"
-	planet "Lichen"
-		add attributes "frontline"
-	planet "Trinket"
-		add attributes "frontline"
-	planet "Sundrinker"
-		add attributes "frontline"
 
 mission "event: war begins"
 	landing
@@ -1232,16 +1220,6 @@ event "fw southern expansion"
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
 		description `	In the wake of their defeat in the south, the Navy has begun to set up a massive new base here on New Iceland, in order to allow them to continue to have a strong presence in this sector.`
-	planet "Dancer"
-		add attributes "frontline"
-	planet "New Portland"
-		add attributes "frontline"
-	planet "New India"
-		add attributes "frontline"
-	planet "Sundrinker"
-		remove attributes "frontline"
-	planet "Lichen"
-		remove attributes "frontline"
 
 
 
@@ -1293,20 +1271,6 @@ event "fw northern expansion"
 		government "Free Worlds"
 	system Wei
 		government "Free Worlds"
-	planet "New Tibet"
-		add attributes "frontline"
-	planet "New Holland"
-		add attributes "frontline"
-	planet "Clark"
-		add attributes "frontline"
-	planet "Deep"
-		remove attributes "frontline"
-	planet "Longjump"
-		remove attributes "frontline"
-	planet "Glaze"
-		remove attributes "frontline"
-	planet "Trinket"
-		remove attributes "frontline"
 
 
 
@@ -1492,14 +1456,6 @@ event "fw expanded and cut"
 		fleet "Small Republic" 800
 		fleet "Large Republic" 1000
 		fleet "Large Free Worlds" 3000
-	planet "Oblivion"
-		add attributes "frontline"
-	planet "Rand"
-		add attributes "frontline"
-	planet "Arabia"
-		add attributes "frontline"
-	planet "New India"
-		remove attributes "frontline"
 
 
 
@@ -1574,22 +1530,6 @@ event "fw armistice"
 		fleet "Small Republic" 2000
 		fleet "Large Republic" 3000
 		fleet "Navy Surveillance" 1600
-	planet "New Tibet"
-		remove attributes "frontline"
-	planet "New Holland"
-		remove attributes "frontline"
-	planet "Clark"
-		remove attributes "frontline"
-	planet "Oblivion"
-		remove attributes "frontline"
-	planet "Rand"
-		remove attributes "frontline"
-	planet "Arabia"
-		remove attributes "frontline"
-	planet "New Portland"
-		remove attributes "frontline"
-	planet "Dancer"
-		remove attributes "frontline"
 
 
 
@@ -2195,8 +2135,6 @@ event "fwc capture kaus borealis"
 		fleet "Large Republic" 2000
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
-	planet "New Iceland"
-		add attributes "frontline"
 
 
 
@@ -2221,16 +2159,6 @@ event "fwc capture cebalrai"
 		fleet "Large Southern Merchants" 4000
 		fleet "Small Free Worlds" 600
 		fleet "Large Free Worlds" 700
-	planet "Tundra"
-		add attributes "frontline"
-	planet "Dancer"
-		remove attributes "frontline"
-	planet "New Portland"
-		remove attributes "frontline"
-	planet "Rand"
-		remove attributes "frontline"
-	planet "Arabia"
-		remove attributes "frontline"
 
 
 
@@ -2503,18 +2431,6 @@ event "fwc peace with the navy"
 		fleet "Small Pug" 800
 		fleet "Large Pug" 1200
 		fleet "Human Miners" 5000
-	planet "Tundra"
-		remove attributes "frontline"
-	planet "New Iceland"
-		remove attributes "frontline"
-	planet "Oblivion"
-		remove attributes "frontline"
-	planet "New Tibet"
-		remove attributes "frontline"
-	planet "New Holland"
-		remove attributes "frontline"
-	planet "Clark"
-		remove attributes "frontline"
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -131,6 +131,18 @@ event "war begins"
 	planet "Bourne"
 		description `Bourne is a well-developed industrial world that was first settled four centuries ago. Its cities are home to some of the richest individuals in this section of the galaxy, but also home to tens of thousands of homeless people, and many others whose factory jobs are barely providing enough to make ends meet.`
 		description `Bourne is also the seat of government for the newly formed Coalition of Free Worlds.`
+	planet "Deep"
+		add attributes "frontline"
+	planet "Glaze"
+		add attributes "frontline"
+	planet "Longjump"
+		add attributes "frontline"
+	planet "Lichen"
+		add attributes "frontline"
+	planet "Trinket"
+		add attributes "frontline"
+	planet "Sundrinker"
+		add attributes "frontline"
 
 mission "event: war begins"
 	landing
@@ -1220,6 +1232,16 @@ event "fw southern expansion"
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
 		description `	In the wake of their defeat in the south, the Navy has begun to set up a massive new base here on New Iceland, in order to allow them to continue to have a strong presence in this sector.`
+	planet "Dancer"
+		add attributes "frontline"
+	planet "New Portland"
+		add attributes "frontline"
+	planet "New India"
+		add attributes "frontline"
+	planet "Sundrinker"
+		remove attributes "frontline"
+	planet "Lichen"
+		remove attributes "frontline"
 
 
 
@@ -1271,6 +1293,20 @@ event "fw northern expansion"
 		government "Free Worlds"
 	system Wei
 		government "Free Worlds"
+	planet "New Tibet"
+		add attributes "frontline"
+	planet "New Holland"
+		add attributes "frontline"
+	planet "Clark"
+		add attributes "frontline"
+	planet "Deep"
+		remove attributes "frontline"
+	planet "Longjump"
+		remove attributes "frontline"
+	planet "Glaze"
+		remove attributes "frontline"
+	planet "Trinket"
+		remove attributes "frontline"
 
 
 
@@ -1456,6 +1492,14 @@ event "fw expanded and cut"
 		fleet "Small Republic" 800
 		fleet "Large Republic" 1000
 		fleet "Large Free Worlds" 3000
+	planet "Oblivion"
+		add attributes "frontline"
+	planet "Rand"
+		add attributes "frontline"
+	planet "Arabia"
+		add attributes "frontline"
+	planet "New India"
+		remove attributes "frontline"
 
 
 
@@ -1530,6 +1574,22 @@ event "fw armistice"
 		fleet "Small Republic" 2000
 		fleet "Large Republic" 3000
 		fleet "Navy Surveillance" 1600
+	planet "New Tibet"
+		remove attributes "frontline"
+	planet "New Holland"
+		remove attributes "frontline"
+	planet "Clark"
+		remove attributes "frontline"
+	planet "Oblivion"
+		remove attributes "frontline"
+	planet "Rand"
+		remove attributes "frontline"
+	planet "Arabia"
+		remove attributes "frontline"
+	planet "New Portland"
+		remove attributes "frontline"
+	planet "Dancer"
+		remove attributes "frontline"
 
 
 
@@ -2135,6 +2195,8 @@ event "fwc capture kaus borealis"
 		fleet "Large Republic" 2000
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
+	planet "New Iceland"
+		add attributes "frontline"
 
 
 
@@ -2159,6 +2221,16 @@ event "fwc capture cebalrai"
 		fleet "Large Southern Merchants" 4000
 		fleet "Small Free Worlds" 600
 		fleet "Large Free Worlds" 700
+	planet "Tundra"
+		add attributes "frontline"
+	planet "Dancer"
+		remove attributes "frontline"
+	planet "New Portland"
+		remove attributes "frontline"
+	planet "Rand"
+		remove attributes "frontline"
+	planet "Arabia"
+		remove attributes "frontline"
 
 
 
@@ -2431,6 +2503,18 @@ event "fwc peace with the navy"
 		fleet "Small Pug" 800
 		fleet "Large Pug" 1200
 		fleet "Human Miners" 5000
+	planet "Tundra"
+		remove attributes "frontline"
+	planet "New Iceland"
+		remove attributes "frontline"
+	planet "Oblivion"
+		remove attributes "frontline"
+	planet "New Tibet"
+		remove attributes "frontline"
+	planet "New Holland"
+		remove attributes "frontline"
+	planet "Clark"
+		remove attributes "frontline"
 
 
 

--- a/data/free worlds war jobs.txt
+++ b/data/free worlds war jobs.txt
@@ -20,6 +20,7 @@ mission "FW Scout Run [0]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
+		attributes "frontline"
 	waypoint
 		distance 1 2
 		government "Republic"
@@ -41,6 +42,7 @@ mission "FW Scout Run [1]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
+		attributes "frontline"
 	waypoint
 		distance 2 3
 		government "Republic"
@@ -65,6 +67,7 @@ mission "FW Scout Run [2]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
+		attributes "frontline"
 	waypoint
 		distance 2 3
 		government "Republic"
@@ -317,7 +320,7 @@ mission "FW Outfitter Resupply [0]"
 	job
 	repeat
 	name `Resupply <planet>`
-	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	description `The outfitter on <planet> is running low on supplies and needs to be restocked immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
 	deadline 1 1
 	cargo random 5 2 .1
 	to offer
@@ -338,7 +341,7 @@ mission "FW Outfitter Resupply [1]"
 	job
 	repeat
 	name `Resupply <planet>`
-	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	description `The outfitter on <planet> is running low on supplies and needs to be restocked immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
 	deadline 1 1
 	cargo random 5 2 .1
 	to offer
@@ -359,7 +362,7 @@ mission "FW Outfitter Resupply [2]"
 	job
 	repeat
 	name `Resupply <planet>`
-	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	description `The outfitter on <planet> is running low on supplies and needs to be restocked immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
 	deadline 1 1
 	cargo random 5 2 .1
 	to offer
@@ -380,7 +383,7 @@ mission "FW Bulk Outfitter Resupply [0]"
 	job
 	repeat
 	name `Resupply <planet>`
-	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	description `The outfitter on <planet> is running low on supplies and needs to be restocked immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
 	deadline 1 1
 	cargo random 25 2 .05
 	to offer
@@ -401,7 +404,7 @@ mission "FW Bulk Outfitter Resupply [1]"
 	job
 	repeat
 	name `Resupply <planet>`
-	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	description `The outfitter on <planet> is running low on supplies and needs to be restocked immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
 	deadline 1 1
 	cargo random 25 2 .05
 	to offer
@@ -422,7 +425,7 @@ mission "FW Bulk Outfitter Resupply [2]"
 	job
 	repeat
 	name `Resupply <planet>`
-	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	description `The outfitter on <planet> is running low on supplies and needs to be restocked immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
 	deadline 1 1
 	cargo random 25 2 .05
 	to offer
@@ -456,7 +459,7 @@ mission "FW Frontline Resupply [0]"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		ttributes "frontline"
+		attributes "frontline"
 	on complete
 		payment 2000 180
 		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
@@ -478,7 +481,7 @@ mission "FW Frontline Resupply [1]"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		ttributes "frontline"
+		attributes "frontline"
 	on complete
 		payment 2000 180
 		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
@@ -500,7 +503,7 @@ mission "FW Frontline Resupply [2]"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		ttributes "frontline"
+		attributes "frontline"
 	on complete
 		payment 2000 180
 		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
@@ -522,7 +525,7 @@ mission "FW Bulk Frontline Resupply [0]"
 	destination
 		distance 3 12
 		government "Free Worlds"
-		ttributes "frontline"
+		attributes "frontline"
 	on complete
 		payment 5000 180
 		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
@@ -544,7 +547,7 @@ mission "FW Bulk Frontline Resupply [1]"
 	destination
 		distance 3 12
 		government "Free Worlds"
-		ttributes "frontline"
+		attributes "frontline"
 	on complete
 		payment 5000 180
 		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`

--- a/data/free worlds war jobs.txt
+++ b/data/free worlds war jobs.txt
@@ -1,0 +1,722 @@
+# Copyright (c) 2018 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+mission "FW Scout Run [0]"
+	job
+	repeat
+	name `Scouting Run`
+	description `Fly through the designated Republic system and scout it out for Navy activity. Then return to <destination> by <date> where your ship's scanner logs will be analyzed. Payment is <payment>.`
+	deadline
+	to offer
+		random < 30
+		has "salary: Free Worlds"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+	waypoint
+		distance 1 2
+		government "Republic"
+	on complete
+		payment 10000 180
+		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>. `
+	on visit
+		dialog `You have landed on <planet>, but you have yet to scout out all the marked systems. Visit all the systems marked on your map before returning.`
+
+mission "FW Scout Run [1]"
+	job
+	repeat
+	name `Scouting Run`
+	description `Fly through the designated Republic systems and scout them out for Navy activity. Then return to <destination> by <date> where your ship's scanner logs will be analyzed. Payment is <payment>.`
+	deadline
+	to offer
+		random < 25
+		has "salary: Free Worlds"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+	waypoint
+		distance 2 3
+		government "Republic"
+	waypoint
+		distance 2 3
+		government "Republic"
+	on complete
+		payment 20000 180
+		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>. `
+	on visit
+		dialog `You have landed on <planet>, but you have yet to scout out all the marked systems. Visit all the systems marked on your map before returning.`
+
+mission "FW Scout Run [2]"
+	job
+	repeat
+	name `Scouting Run`
+	description `Fly through the designated Republic systems and scout them out for Navy activity. Then return to <destination> by <date> where your ship's scanner logs will be analyzed. Payment is <payment>.`
+	deadline
+	to offer
+		random < 20
+		has "salary: Free Worlds"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+	waypoint
+		distance 2 3
+		government "Republic"
+	waypoint
+		distance 3 4
+		government "Republic"
+	on complete
+		payment 30000 180
+		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>. `
+	on visit
+		dialog `You have landed on <planet>, but you have yet to scout out all the marked systems. Visit all the systems marked on your map before returning.`
+
+
+
+mission "FW Convoy Defense [0]"
+	job
+	repeat
+	name `Convoy to <planet>`
+	description `The shipyard on <planet> is in need of more supplies for building warships. Immediately escort a convoy of ships to <destination> by <date>. Payment is <payment>.`
+	deadline 0 1
+	to offer
+		random < 30
+		has "salary: Free Worlds"
+		not "main plot completed"
+	source
+		government "Free Worlds"
+		attributes "mining" "factory"
+		not attributes shipyard
+	destination
+		government "Free Worlds"
+		attributes shipyard
+		distance 2 6
+	npc
+		government "Pirate"
+		personality nemesis staying harvests plunders
+		system destination
+		fleet "Large Southern Pirates"
+		fleet "Small Southern Pirates"
+	npc
+		government "Pirate"
+		personality nemesis harvests plunders
+		system destination
+		fleet "Large Southern Pirates"
+		fleet "Small Southern Pirates"
+	npc
+		government "Pirate"
+		personality nemesis harvests plunders
+		fleet "Large Southern Pirates"
+	npc accompany save
+		government "Merchant"
+		personality escort timid
+		fleet
+			names "civilian"
+			variant
+				"Freighter" 2
+				"Bastion"
+			variant
+				"Behemoth"
+				"Clipper" 2
+			variant
+				"Behemoth" 2
+			variant
+				"Hauler III"
+				"Bastion" 2
+			variant
+				"Hauler II" 2
+				"Osprey"
+			variant
+				"Argosy" 2
+				"Osprey"
+	on complete
+		payment 270000
+		dialog `The captain of the <npc> thanks you for escorting them safely, and the shipyard pays you <payment> for helping to deliver the supplies.`
+	on visit
+		dialog `You have reached <planet>, but you left part or all of the convoy behind! Better depart and wait for them to arrive in this star system.`
+
+mission "FW Convoy Defense [1]"
+	job
+	repeat
+	name `Convoy to <planet>`
+	description `The shipyard on <planet> is in need of more supplies for building warships. Immediately escort a convoy of ships to <destination> by <date>. Payment is <payment>.`
+	deadline 0 1
+	to offer
+		random < 20
+		has "salary: Free Worlds"
+		not "main plot completed"
+	source
+		government "Free Worlds"
+		attributes "mining" "factory"
+		not attributes shipyard
+	destination
+		government "Free Worlds"
+		attributes shipyard
+		distance 2 6
+	npc
+		government "Pirate"
+		personality nemesis staying harvests plunders
+		system destination
+		fleet "Large Southern Pirates"
+		fleet "Small Southern Pirates"
+	npc
+		government "Pirate"
+		personality nemesis harvests plunders
+		system destination
+		fleet "Large Southern Pirates"
+		fleet "Small Southern Pirates"
+	npc
+		government "Pirate"
+		personality nemesis harvests plunders
+		fleet "Large Southern Pirates"
+	npc accompany save
+		government "Merchant"
+		personality escort timid
+		fleet
+			names "civilian"
+			variant
+				"Freighter" 2
+				"Bastion"
+			variant
+				"Behemoth"
+				"Clipper" 2
+			variant
+				"Behemoth" 2
+			variant
+				"Hauler III"
+				"Bastion" 2
+			variant
+				"Hauler II" 2
+				"Osprey"
+			variant
+				"Argosy" 2
+				"Osprey"
+	on complete
+		payment 270000
+		dialog `The captain of the <npc> thanks you for escorting them safely, and the shipyard pays you <payment> for helping to deliver the supplies.`
+	on visit
+		dialog `You have reached <planet>, but you left part or all of the convoy behind! Better depart and wait for them to arrive in this star system.`
+
+mission "FW Convoy Defense [2]"
+	job
+	repeat
+	name `Convoy to <planet>`
+	description `The shipyard on <planet> is in need of more supplies for building warships. Immediately escort a convoy of ships to <destination> by <date>. Payment is <payment>.`
+	deadline 0 1
+	to offer
+		random < 10
+		has "salary: Free Worlds"
+		not "main plot completed"
+	source
+		government "Free Worlds"
+		attributes "mining" "factory"
+		not attributes shipyard
+	destination
+		government "Free Worlds"
+		attributes shipyard
+		distance 2 6
+	npc
+		government "Pirate"
+		personality nemesis staying harvests plunders
+		system destination
+		fleet "Large Southern Pirates"
+		fleet "Small Southern Pirates"
+	npc
+		government "Pirate"
+		personality nemesis harvests plunders
+		system destination
+		fleet "Large Southern Pirates"
+		fleet "Small Southern Pirates"
+	npc
+		government "Pirate"
+		personality nemesis harvests plunders
+		fleet "Large Southern Pirates"
+	npc accompany save
+		government "Merchant"
+		personality escort timid
+		fleet
+			names "civilian"
+			variant
+				"Freighter" 2
+				"Bastion"
+			variant
+				"Behemoth"
+				"Clipper" 2
+			variant
+				"Behemoth" 2
+			variant
+				"Hauler III"
+				"Bastion" 2
+			variant
+				"Hauler II" 2
+				"Osprey"
+			variant
+				"Argosy" 2
+				"Osprey"
+	on complete
+		payment 270000
+		dialog `The captain of the <npc> thanks you for escorting them safely, and the shipyard pays you <payment> for helping to deliver the supplies.`
+	on visit
+		dialog `You have reached <planet>, but you left part or all of the convoy behind! Better depart and wait for them to arrive in this star system.`
+
+
+
+mission "FW Reinforcements [0]"
+	job
+	repeat
+	name `Reinforcements to <planet>`
+	description `These <bunks> Free Worlds soldiers require immediate transport to <destination> by <date> in order to reinforce the frontlines. Payment is <payment>.`
+	deadline 1 1
+	passengers 5 5 .2
+	to offer
+		random < 20
+		has "salary: Free Worlds"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		not attributes "frontline"
+	destination
+		distance 2 10
+		government "Free Worlds"
+		attributes "frontline"
+	on complete
+		payment 10000 180
+		dialog `You unload the Free Worlds soldiers into the busy spaceport of <planet>, and collect your payment of <payment>.`
+
+mission "FW Reinforcements [1]"
+	job
+	repeat
+	name `Reinforcements to <planet>`
+	description `These <bunks> Free Worlds soldiers require immediate transport to <destination> by <date> in order to reinforce the frontlines. Payment is <payment>.`
+	deadline 1 1
+	passengers 5 5 .2
+	to offer
+		random < 10
+		has "salary: Free Worlds"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		not attributes "frontline"
+	destination
+		distance 2 10
+		government "Free Worlds"
+		attributes "frontline"
+	on complete
+		payment 10000 180
+		dialog `You unload the Free Worlds soldiers into the busy spaceport of <planet>, and collect your payment of <payment>.`
+
+
+
+mission "FW Outfitter Resupply [0]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo random 5 2 .1
+	to offer
+		random < 50
+		has "salary: Free Worlds"
+		not "main plot completed"
+	source
+		government "Free Worlds"
+	destination
+		distance 4 8
+		government "Free Worlds"
+		attributes outfitter
+	on complete
+		payment 2000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+
+mission "FW Outfitter Resupply [1]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo random 5 2 .1
+	to offer
+		random < 40
+		has "salary: Free Worlds"
+		not "main plot completed"
+	source
+		government "Free Worlds"
+	destination
+		distance 5 10
+		government "Free Worlds"
+		attributes outfitter
+	on complete
+		payment 2000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+
+mission "FW Outfitter Resupply [2]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo random 5 2 .1
+	to offer
+		random < 30
+		has "salary: Free Worlds"
+		not "main plot completed"
+	source
+		government "Free Worlds"
+	destination
+		distance 6 12
+		government "Free Worlds"
+		attributes outfitter
+	on complete
+		payment 2000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+
+mission "FW Bulk Outfitter Resupply [0]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo random 25 2 .05
+	to offer
+		random < 30
+		has "salary: Free Worlds"
+		not "main plot completed"
+	source
+		government "Free Worlds"
+	destination
+		distance 4 8
+		government "Free Worlds"
+		attributes outfitter
+	on complete
+		payment 5000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+
+mission "FW Bulk Outfitter Resupply [1]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo random 25 2 .05
+	to offer
+		random < 25
+		has "salary: Free Worlds"
+		not "main plot completed"
+	source
+		government "Free Worlds"
+	destination
+		distance 5 10
+		government "Free Worlds"
+		attributes outfitter
+	on complete
+		payment 5000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+
+mission "FW Bulk Outfitter Resupply [2]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The outfitter on <planet> is running low on supplies and needs resupplied immediately. Deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo random 25 2 .05
+	to offer
+		random < 20
+		has "salary: Free Worlds"
+		not "main plot completed"
+	source
+		government "Free Worlds"
+	destination
+		distance 6 12
+		government "Free Worlds"
+		attributes outfitter
+	on complete
+		payment 5000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+
+mission "FW Frontline Resupply [0]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The frontlines of the war are in need of a resupply. Immediately deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo "food" 5 2 .1
+	to offer
+		random < 40
+		has "salary: Free Worlds"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		not attributes "frontline"
+	destination
+		distance 2 10
+		government "Free Worlds"
+		ttributes "frontline"
+	on complete
+		payment 2000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
+
+mission "FW Frontline Resupply [1]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The frontlines of the war are in need of a resupply. Immediately deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo "medical" 5 2 .1
+	to offer
+		random < 30
+		has "salary: Free Worlds"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		not attributes "frontline"
+	destination
+		distance 2 10
+		government "Free Worlds"
+		ttributes "frontline"
+	on complete
+		payment 2000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
+
+mission "FW Frontline Resupply [2]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The frontlines of the war are in need of a resupply. Immediately deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo "heavy metals" 5 2 .1
+	to offer
+		random < 20
+		has "salary: Free Worlds"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		not attributes "frontline"
+	destination
+		distance 2 10
+		government "Free Worlds"
+		ttributes "frontline"
+	on complete
+		payment 2000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
+
+mission "FW Bulk Frontline Resupply [0]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The frontlines of the war are in need of a resupply. Immediately deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo "food" 25 2 .95
+	to offer
+		random < 30
+		has "salary: Free Worlds"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		not attributes "frontline"
+	destination
+		distance 3 12
+		government "Free Worlds"
+		ttributes "frontline"
+	on complete
+		payment 5000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
+
+mission "FW Bulk Frontline Resupply [1]"
+	job
+	repeat
+	name `Resupply <planet>`
+	description `The frontlines of the war are in need of a resupply. Immediately deliver <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	cargo "medical" 25 2 .95
+	to offer
+		random < 15
+		has "salary: Free Worlds"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		not attributes "frontline"
+	destination
+		distance 3 12
+		government "Free Worlds"
+		ttributes "frontline"
+	on complete
+		payment 5000 180
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
+
+
+
+mission "FW Care Package to Republic [0]"
+	job
+	repeat
+	name `Care package to <planet>`
+	description `A citizen of the Free Worlds is worried about family members in the Republic. Immediately deliver a care package of <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 0 1
+	cargo random 1 3
+	to offer
+		random < 30
+		has "chosen sides"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+	destination
+		government "Republic"
+		distance 2 5
+	on complete
+		payment 1000 180
+		dialog `You deliver the care package of <commodity> to the specified address and explain to the people where the care package came from. They thank you for delivering it, and you collect your payment of <payment>.`
+
+mission "FW Care Package to Republic [1]"
+	job
+	repeat
+	name `Care package to <planet>`
+	description `A citizen of the Free Worlds is worried about family members in the Republic. Immediately deliver a care package of <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 0 1
+	cargo random 1 3
+	to offer
+		random < 30
+		has "chosen sides"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+	destination
+		government "Republic"
+		distance 2 5
+	on complete
+		payment 1000 180
+		dialog `You deliver the care package of <commodity> to the specified address and explain to the people where the care package came from. They thank you for delivering it, and you collect your payment of <payment>.`
+
+mission "FW Care Package from Republic [0]"
+	job
+	repeat
+	name `Care package to <planet>`
+	description `A citizen of the Republic is worried about family members in the Free Worlds. Immediately deliver a care package of <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 0 1
+	cargo random 1 3
+	to offer
+		random < 30
+		has "chosen sides"
+		not "event: fw armistice"
+	source
+		government "Republic"
+	destination
+		government "Free Worlds"
+		distance 2 5
+	on complete
+		payment 1000 180
+		dialog `You deliver the care package of <commodity> to the specified address and explain to the people where the care package came from. They thank you for delivering it, and you collect your payment of <payment>.`
+
+mission "FW Care Package from Republic [1]"
+	job
+	repeat
+	name `Care package to <planet>`
+	description `A citizen of the Republic is worried about family members in the Free Worlds. Immediately deliver a care package of <cargo> to <destination> by <date>. Payment is <payment>.`
+	deadline 0 1
+	cargo random 1 3
+	to offer
+		random < 30
+		has "chosen sides"
+		not "event: fw armistice"
+	source
+		government "Republic"
+	destination
+		government "Free Worlds"
+		distance 2 5
+	on complete
+		payment 1000 180
+		dialog `You deliver the care package of <commodity> to the specified address and explain to the people where the care package came from. They thank you for delivering it, and you collect your payment of <payment>.`
+
+
+
+mission "FW Refugees [0]"
+	job
+	repeat
+	name `Refugees to <planet>`
+	description `These <bunks> passengers would like to escape the frontlines of the war and immediately settle on <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	passengers 2 10 .9
+	to offer
+		random < 60
+		has "chosen sides"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		attributes "frontline"
+	destination
+		distance 2 10
+		government "Free Worlds"
+		not attributes "frontline"
+	on complete
+		payment 2000 180
+		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
+
+mission "FW Refugees [1]"
+	job
+	repeat
+	name `Refugees to <planet>`
+	description `These <bunks> passengers would like to escape the frontlines of the war and immediately settle on <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	passengers 2 10 .9
+	to offer
+		random < 40
+		has "chosen sides"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		attributes "frontline"
+	destination
+		distance 2 10
+		government "Free Worlds"
+		not attributes "frontline"
+	on complete
+		payment 2000 180
+		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
+
+mission "FW Refugees [2]"
+	job
+	repeat
+	name `Refugees to <planet>`
+	description `These <bunks> passengers would like to escape the frontlines of the war and immediately settle on <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	passengers 2 10 .9
+	to offer
+		random < 20
+		has "chosen sides"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		attributes "frontline"
+	destination
+		distance 2 10
+		government "Free Worlds"
+		not attributes "frontline"
+	on complete
+		payment 2000 180
+		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
+
+mission "FW Bulk Refugees [0]"
+	job
+	repeat
+	name `Refugees to <planet>`
+	description `These <bunks> passengers would like to escape the frontlines of the war and immediately settle on <destination> by <date>. Payment is <payment>.`
+	deadline 1 1
+	passengers 5 5 .5
+	to offer
+		random < 20
+		has "chosen sides"
+		not "event: fw armistice"
+	source
+		government "Free Worlds"
+		attributes "frontline"
+	destination
+		distance 2 10
+		government "Free Worlds"
+		not attributes "frontline"
+	on complete
+		payment 5000 180
+		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`

--- a/data/free worlds war jobs.txt
+++ b/data/free worlds war jobs.txt
@@ -286,9 +286,11 @@ mission "FW Reinforcements [0]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
@@ -311,9 +313,11 @@ mission "FW Reinforcements [1]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
@@ -464,9 +468,11 @@ mission "FW Frontline Resupply [0]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
@@ -489,9 +495,11 @@ mission "FW Frontline Resupply [1]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
@@ -514,9 +522,11 @@ mission "FW Frontline Resupply [2]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
@@ -539,9 +549,11 @@ mission "FW Bulk Frontline Resupply [0]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	destination
 		distance 3 12
 		government "Free Worlds"
@@ -564,9 +576,11 @@ mission "FW Bulk Frontline Resupply [1]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	destination
 		distance 3 12
 		government "Free Worlds"
@@ -678,9 +692,11 @@ mission "FW Refugees [0]"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	on complete
 		payment 2000 180
 		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
@@ -703,9 +719,11 @@ mission "FW Refugees [1]"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	on complete
 		payment 2000 180
 		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
@@ -728,9 +746,11 @@ mission "FW Refugees [2]"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	on complete
 		payment 2000 180
 		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
@@ -753,9 +773,11 @@ mission "FW Bulk Refugees [0]"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		not neighbor government "Republic"
-		not neighbor
+		not
 			neighbor government "Republic"
+		not
+			neighbor
+				neighbor government "Republic"
 	on complete
 		payment 5000 180
 		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`

--- a/data/free worlds war jobs.txt
+++ b/data/free worlds war jobs.txt
@@ -20,7 +20,8 @@ mission "FW Scout Run [0]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	waypoint
 		distance 1 2
 		government "Republic"
@@ -42,7 +43,8 @@ mission "FW Scout Run [1]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	waypoint
 		distance 2 3
 		government "Republic"
@@ -67,7 +69,8 @@ mission "FW Scout Run [2]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	waypoint
 		distance 2 3
 		government "Republic"
@@ -283,11 +286,14 @@ mission "FW Reinforcements [0]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	on complete
 		payment 10000 180
 		dialog `You unload the Free Worlds soldiers into the busy spaceport of <planet>, and collect your payment of <payment>.`
@@ -305,11 +311,14 @@ mission "FW Reinforcements [1]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	on complete
 		payment 10000 180
 		dialog `You unload the Free Worlds soldiers into the busy spaceport of <planet>, and collect your payment of <payment>.`
@@ -455,11 +464,14 @@ mission "FW Frontline Resupply [0]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	on complete
 		payment 2000 180
 		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
@@ -477,11 +489,14 @@ mission "FW Frontline Resupply [1]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	on complete
 		payment 2000 180
 		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
@@ -499,11 +514,14 @@ mission "FW Frontline Resupply [2]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	on complete
 		payment 2000 180
 		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
@@ -521,11 +539,14 @@ mission "FW Bulk Frontline Resupply [0]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	destination
 		distance 3 12
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	on complete
 		payment 5000 180
 		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
@@ -543,11 +564,14 @@ mission "FW Bulk Frontline Resupply [1]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	destination
 		distance 3 12
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	on complete
 		payment 5000 180
 		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
@@ -649,11 +673,14 @@ mission "FW Refugees [0]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	on complete
 		payment 2000 180
 		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
@@ -671,11 +698,14 @@ mission "FW Refugees [1]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	on complete
 		payment 2000 180
 		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
@@ -693,11 +723,14 @@ mission "FW Refugees [2]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	on complete
 		payment 2000 180
 		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
@@ -715,11 +748,14 @@ mission "FW Bulk Refugees [0]"
 		not "event: fw armistice"
 	source
 		government "Free Worlds"
-		attributes "frontline"
+		neighbor
+			neighbor government "Republic"
 	destination
 		distance 2 10
 		government "Free Worlds"
-		not attributes "frontline"
+		not neighbor government "Republic"
+		not neighbor
+			neighbor government "Republic"
 	on complete
 		payment 5000 180
 		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`

--- a/data/free worlds war jobs.txt
+++ b/data/free worlds war jobs.txt
@@ -12,7 +12,7 @@ mission "FW Scout Run [0]"
 	job
 	repeat
 	name `Scouting Run`
-	description `Fly through the designated Republic system and scout it out for Navy activity. Then return to <destination> by <date> where your ship's scanner logs will be analyzed. Payment is <payment>.`
+	description `Fly through the <waypoints> system and scout it out for Navy activity. Then return to <destination> by <date> where your ship's scanner logs will be analyzed. Payment is <payment>.`
 	deadline
 	to offer
 		random < 30
@@ -34,7 +34,7 @@ mission "FW Scout Run [1]"
 	job
 	repeat
 	name `Scouting Run`
-	description `Fly through the designated Republic systems and scout them out for Navy activity. Then return to <destination> by <date> where your ship's scanner logs will be analyzed. Payment is <payment>.`
+	description `Fly through the <waypoints> systems and scout them out for Navy activity. Then return to <destination> by <date> where your ship's scanner logs will be analyzed. Payment is <payment>.`
 	deadline
 	to offer
 		random < 25
@@ -59,7 +59,7 @@ mission "FW Scout Run [2]"
 	job
 	repeat
 	name `Scouting Run`
-	description `Fly through the designated Republic systems and scout them out for Navy activity. Then return to <destination> by <date> where your ship's scanner logs will be analyzed. Payment is <payment>.`
+	description `Fly through the <waypoints> systems and scout them out for Navy activity. Then return to <destination> by <date> where your ship's scanner logs will be analyzed. Payment is <payment>.`
 	deadline
 	to offer
 		random < 20

--- a/data/free worlds war jobs.txt
+++ b/data/free worlds war jobs.txt
@@ -27,7 +27,7 @@ mission "FW Scout Run [0]"
 		government "Republic"
 	on complete
 		payment 10000 180
-		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>. `
+		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>.`
 	on visit
 		dialog `You have landed on <planet>, but you have yet to scout out all the marked systems. Visit all the systems marked on your map before returning.`
 
@@ -53,7 +53,7 @@ mission "FW Scout Run [1]"
 		government "Republic"
 	on complete
 		payment 20000 180
-		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>. `
+		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>.`
 	on visit
 		dialog `You have landed on <planet>, but you have yet to scout out all the marked systems. Visit all the systems marked on your map before returning.`
 
@@ -79,7 +79,7 @@ mission "FW Scout Run [2]"
 		government "Republic"
 	on complete
 		payment 30000 180
-		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>. `
+		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>.`
 	on visit
 		dialog `You have landed on <planet>, but you have yet to scout out all the marked systems. Visit all the systems marked on your map before returning.`
 
@@ -348,7 +348,7 @@ mission "FW Outfitter Resupply [0]"
 		attributes outfitter
 	on complete
 		payment 2000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
 
 mission "FW Outfitter Resupply [1]"
 	job
@@ -369,7 +369,7 @@ mission "FW Outfitter Resupply [1]"
 		attributes outfitter
 	on complete
 		payment 2000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
 
 mission "FW Outfitter Resupply [2]"
 	job
@@ -390,7 +390,7 @@ mission "FW Outfitter Resupply [2]"
 		attributes outfitter
 	on complete
 		payment 2000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
 
 mission "FW Bulk Outfitter Resupply [0]"
 	job
@@ -411,7 +411,7 @@ mission "FW Bulk Outfitter Resupply [0]"
 		attributes outfitter
 	on complete
 		payment 5000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
 
 mission "FW Bulk Outfitter Resupply [1]"
 	job
@@ -432,7 +432,7 @@ mission "FW Bulk Outfitter Resupply [1]"
 		attributes outfitter
 	on complete
 		payment 5000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
 
 mission "FW Bulk Outfitter Resupply [2]"
 	job
@@ -453,7 +453,7 @@ mission "FW Bulk Outfitter Resupply [2]"
 		attributes outfitter
 	on complete
 		payment 5000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free World captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
 
 mission "FW Frontline Resupply [0]"
 	job


### PR DESCRIPTION
Added a number of jobs that only occur during the war and mostly only offer when the player is receiving a salary from the Free Worlds.

The jobs:
* **Scout Run**: travel into Republic territory and scout out the Navy activity for the Free Worlds to use.
* **Convoy Defense**: War requires a lot of resources, especially if the shipyards are trying to pump out ships for the war effort. Escort multiple freighters and possibly a few warships filled with supplies for making new ships.
* **Reinforcements**: Bring Free Worlds soldiers to the frontline worlds of the war in order to reinforce the planets.
* **Outfitter Resupply:** Resupply the many outfitters of the Free Worlds as they become low on supplies.
* **Frontline Resupply:** Resupply the frontline planets with food, medical supplies, or heavy metals for fortifications. 
* **Care Package Delivery:** If you find yourself able to travel into Republic space, you may find a few concerned citizens in the Free Worlds asking you to deliver care packages to family members in the Republic, or vice versa.
* **Refugees:** Transport Free Worlds civilians who would like to stay away from the frontlines to worlds deeper into Free Worlds territory.

<hr/>
These jobs all have multipliers of 180, which is 20% better than the normal multiplier of 150. This may remedy #1848 by giving the player an additional way to gain income while at war, as the current generic jobs are not very sufficient in providing the player with enough funds to reliably purchase new warships when needed. This will also resolve #1753, as most of the jobs have deadlines that only provide the player with 1 or even 0 opportunities to refuel; things have to be done fast during war, as a battle could break out any second.
