### PR TITLE
WIP: Allow missions to specify random outfits & random outfit quantities

### DIFF
--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -183,7 +183,7 @@ void Minable::TakeDamage(const Projectile &projectile)
 }
 
 
-	
+
 // Determine what flotsam this asteroid will create.
 const map<const Outfit *, int> &Minable::Payload() const
 {

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1052,14 +1052,15 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	for(const NPC &npc : npcs)
 		result.npcs.push_back(npc.Instantiate(subs, player.GetSystem(), result.destination->GetSystem()));
 	
-	// Instantiate the actions. The "complete" action is always first so that
-	// the "<payment>" substitution can be filled in.
+	// Instantiate the actions. The "complete" action is always first so that the "<payment>"
+	// substitution can be filled in. This will also instantiate any randomly chosen gifts or
+	// gift quantities.
 	for(const auto &it : actions)
-		result.actions[it.first] = it.second.Instantiate(subs, player.GetSystem(), jumps, payload);
+		result.actions[it.first] = it.second.Instantiate(subs, player.GetSystem(), jumps, payload, result.destination);
 	for(const auto &it : onEnter)
-		result.onEnter[it.first] = it.second.Instantiate(subs, player.GetSystem(), jumps, payload);
+		result.onEnter[it.first] = it.second.Instantiate(subs, player.GetSystem(), jumps, payload, result.destination);
 	for(const MissionAction &action : genericOnEnter)
-		result.genericOnEnter.emplace_back(action.Instantiate(subs, player.GetSystem(), jumps, payload));
+		result.genericOnEnter.emplace_back(action.Instantiate(subs, player.GetSystem(), jumps, payload, result.destination));
 	
 	// Perform substitution in the name and description.
 	result.displayName = Format::Replace(displayName, subs);

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -465,6 +465,58 @@ const map<const Outfit *, int> MissionAction::Gifts() const
 
 
 
+// Return a map of the outfits that the player is given.
+const map<const Outfit *, int> MissionAction::OutfitsReceived() const
+{
+	map<const Outfit *, int> giftsReceived;
+	for(const auto &gift : gifts)
+		if(gift.second > 0)
+			giftsReceived.emplace(gift);
+	
+	return giftsReceived;
+}
+
+
+
+// Return a map of the outfits that the player must have and give.
+const map<const Outfit *, int> MissionAction::OutfitsTaken() const
+{
+	map<const Outfit *, int> giftsTaken;
+	for(const auto &gift : gifts)
+		if(gift.second < 0)
+			giftsTaken.emplace(gift);
+	
+	return giftsTaken;
+}
+
+
+
+// Return a map of the outfits the player must have (but gets to keep).
+const map<const Outfit *, int> MissionAction::OutfitsRequired() const
+{
+	map<const Outfit *, int> giftsRequired;
+	for(const auto &list : {gifts, requiredOutfits})
+		for(const auto &gift : list)
+			if(gift.second > 0)
+				giftsRequired.emplace(gift);
+	
+	return giftsRequired;
+}
+
+
+
+// Return a map of the outfits the player must not have.
+const map<const Outfit *, int> MissionAction::OutfitsForbidden() const
+{
+	map<const Outfit *, int> forbidden;
+	for(const auto &gift : requiredOutfits)
+		if(!gift.second)
+			forbidden.emplace(gift);
+	
+	return forbidden;
+}
+
+
 // Return the space needed to store these gifts in cargo, without regard to the
 // gifting direction.
 double MissionAction::MaxGiftSize() const
@@ -474,6 +526,19 @@ double MissionAction::MaxGiftSize() const
 		total += abs(gift.second) * gift.first->Get("mass");
 	
 	return total;
+}
+
+
+
+// Return the net cost of the gifts incurred by the player. If positive,
+// the player would lose "net worth" by completing this action.
+int64_t MissionAction::NetGiftValue(double depreciation) const
+{
+	int64_t total = 0.;
+	for(const pair<const Outfit *, int> &gift : gifts)
+		total -= gift.second * gift.first->Cost();
+	
+	return depreciation * total;
 }
 
 

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -780,6 +780,13 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 			}
 		}
 	}
+	// If the player is delivering gifts in this MissionAction, the player
+	// is compensated for the necessary cargo space upon completion.
+	map<const Outfit *, int> taken = result.OutfitsTaken();
+	if(!taken.empty())
+		for(const auto &transfer : taken)
+			payload += abs(transfer.second * transfer.first->Get("mass"));
+	
 	result.payment = payment + (jumps + 1) * payload * paymentMultiplier;
 	// Fill in the payment amount if this is the "complete" action.
 	string previousPayment = subs["<payment>"];

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -50,6 +50,10 @@ public:
 	
 	int Payment() const;
 	
+	// Determine how many (and which) gifts are needed to complete this action.
+	const std::map<const Outfit *, int> Gifts() const;
+	// The total cargo space needed to hold this action's gifts.
+	double MaxGiftSize() const;
 	// Check if this action can be completed right now. It cannot be completed
 	// if it takes away money or outfits that the player does not have, or should
 	// take place in a system that does not match the specified LocationFilter.

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -26,6 +26,7 @@ class DataNode;
 class DataWriter;
 class GameEvent;
 class Outfit;
+class Planet;
 class PlayerInfo;
 class System;
 class UI;
@@ -58,8 +59,8 @@ public:
 	void Do(PlayerInfo &player, UI *ui = nullptr, const System *destination = nullptr) const;
 	
 	// "Instantiate" this action by filling in the wildcard text for the actual
-	// destination, payment, cargo, etc.
-	MissionAction Instantiate(std::map<std::string, std::string> &subs, const System *origin, int jumps, int payload) const;
+	// destination, payment, cargo, etc., and picking any needed random outfits.
+	MissionAction Instantiate(std::map<std::string, std::string> &subs, const System *origin, int jumps, int payload, const Planet *destination) const;
 	
 	
 private:
@@ -81,6 +82,11 @@ private:
 	std::map<const Outfit *, int> gifts;
 	std::map<const Outfit *, int> giftLimit;
 	std::map<const Outfit *, double> giftProb;
+	// Randomly selected outfits are chosen during instantiation and
+	// then merged with any existing, specifically-identified outfits.
+	std::map<const std::string, int> randomGifts;
+	std::map<const std::string, int> randomGiftsLimit;
+	std::map<const std::string, double> randomGiftsProb;
 	
 	int64_t payment = 0;
 	int64_t paymentMultiplier = 0;

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -39,6 +39,12 @@ class UI;
 // special item, modifying condition flags, or queueing an event to occur.
 class MissionAction {
 public:
+	// These are the allowed requests for a random outfit to be gifted, and
+	// match a given text string to a given Outfit::CATEGORIES value.
+	static const std::map<const std::string, const int> OUTFIT_REQUESTS;
+
+	
+public:
 	MissionAction() = default;
 	// Construct and Load() at the same time.
 	MissionAction(const DataNode &node, const std::string &missionName);

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -76,8 +76,12 @@ private:
 	Conversation conversation;
 	
 	std::map<const GameEvent *, std::pair<int, int>> events;
-	std::map<const Outfit *, int> gifts;
+	
 	std::map<const Outfit *, int> requiredOutfits;
+	std::map<const Outfit *, int> gifts;
+	std::map<const Outfit *, int> giftLimit;
+	std::map<const Outfit *, double> giftProb;
+	
 	int64_t payment = 0;
 	int64_t paymentMultiplier = 0;
 	

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -58,8 +58,14 @@ public:
 	
 	// Determine how many (and which) gifts are needed to complete this action.
 	const std::map<const Outfit *, int> Gifts() const;
+	const std::map<const Outfit *, int> OutfitsReceived() const;
+	const std::map<const Outfit *, int> OutfitsTaken() const;
+	const std::map<const Outfit *, int> OutfitsRequired() const;
+	const std::map<const Outfit *, int> OutfitsForbidden() const;
 	// The total cargo space needed to hold this action's gifts.
 	double MaxGiftSize() const;
+	// The value of this action's gifts at the desired depreciation level.
+	int64_t NetGiftValue(double depreciation = 1.) const;
 	// Check if this action can be completed right now. It cannot be completed
 	// if it takes away money or outfits that the player does not have, or should
 	// take place in a system that does not match the specified LocationFilter.

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -591,6 +591,20 @@ const vector<System::Asteroid> &System::Asteroids() const
 
 
 
+// Get the number of asteroids containing a given minable outfit in the system.
+const int System::MinableCount(const Outfit *plunder) const
+{
+	int count = 0;
+	// Each minable asteroid can contain multiple minable outfits.
+	for(const System::Asteroid &asteroid : asteroids)
+		if(asteroid.Type())
+			count += asteroid.Type()->Payload().count(plunder) * asteroid.Count();
+
+	return count;
+}
+
+
+
 // Get the background haze sprite for this system.
 const Sprite *System::Haze() const
 {

--- a/source/System.h
+++ b/source/System.h
@@ -26,6 +26,7 @@ class Date;
 class Fleet;
 class Government;
 class Minable;
+class Outfit;
 class Planet;
 class Ship;
 class Sprite;
@@ -124,6 +125,8 @@ public:
 	
 	// Get the specification of how many asteroids of each type there are.
 	const std::vector<Asteroid> &Asteroids() const;
+	// Get the number of asteroids containing the given outfit as plunder.
+	const int MinableCount(const Outfit *plunder) const;
 	// Get the background haze sprite for this system.
 	const Sprite *Haze() const;
 	


### PR DESCRIPTION
Refs #3082 
This PR extends support for random outfit picking, and random outfit quantity picking, in missions / jobs, to replicate the available features for mission cargo.

Also added to support the above
 - Category restrictions for the randomly selected outfit:
   - "random outfit" (e.g. purchased or looted from a ship)
   - "random minable" (located within a minable asteroid)
   - Use of an Outfit category, e.g. Power: "random power outfit", "random power minable"
 - Missions involving delivery of outfits to a destination (whether or not the outfits are given to the player) compensates the player for the used cargo space, just as though the outfits were "mission cargo"
 - Text substitutions in the form of `<trigger: _____>` where trigger is any of `offer`, `complete`, `accept`, etc.
   - These substitutions allow the mission writer to relay the requested outfits, cargo size, etc to the player in the appropriate place, e.g. tell the player about a stopover transfer in the stopover dialog and mention only the gifts transferred during the stopover, or tell the player on accepting which outfits will be picked up at the stopover and which outfits will be removed at the destination, without requiring them to be the same outfits.

A usage example:
```
on complete
    outfit "random power outfit" -1 -5
    payment 16000 150
    dialog `The store manager pays you <payment> and thanks you for delivering <complete: gifts given> to address the equipment shortage.`
```

TODO
 - [ ] Implement an optional value-based payment (#3082 ) that has the player either pay or be paid for gifted outfits
 - [ ] Check over random weights to ensure they introduce sensible bias for randomly picked outfits/minables
 - [ ] Perhaps implement space-checks to prevent jobs that are too large for the player to complete from being offered (non-jobs should probably be offered even if too large)
       - Always offering is a possibility because the player can upgrade their fleet in order to accommodate the requested job size
 - [ ] Clean up implementation (removing unused added functions / includes / development commentary)
 - [ ] Address community issues & feedback