### PR TITLE
Add text substitution for <waypoints> in missions

### DIFF
--- a/data/coalition jobs.txt
+++ b/data/coalition jobs.txt
@@ -371,9 +371,9 @@ mission "Coalition: Saryd Interspecies 1"
 		has "known to the heliarchs"
 		random < 70
 	source
-		attributes saryd
+		attributes "saryd"
 	destination
-		attributes kimek arach
+		attributes "kimek" "arach"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -390,9 +390,9 @@ mission "Coalition: Saryd Interspecies 2"
 		has "known to the heliarchs"
 		random < 30
 	source
-		attributes saryd
+		attributes "saryd"
 	destination
-		attributes kimek arach
+		attributes "kimek" "arach"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -409,9 +409,9 @@ mission "Coalition: Kimek Interspecies 1"
 		has "known to the heliarchs"
 		random < 70
 	source
-		attributes kimek
+		attributes "kimek"
 	destination
-		attributes saryd arach
+		attributes "saryd" "arach"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -428,9 +428,9 @@ mission "Coalition: Kimek Interspecies 2"
 		has "known to the heliarchs"
 		random < 30
 	source
-		attributes kimek
+		attributes "kimek"
 	destination
-		attributes saryd arach
+		attributes "saryd" "arach"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -447,9 +447,9 @@ mission "Coalition: Arach Interspecies 1"
 		has "known to the heliarchs"
 		random < 70
 	source
-		attributes arach
+		attributes "arach"
 	destination
-		attributes saryd kimek
+		attributes "saryd" "kimek"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -466,9 +466,9 @@ mission "Coalition: Arach Interspecies 2"
 		has "known to the heliarchs"
 		random < 30
 	source
-		attributes arach
+		attributes "arach"
 	destination
-		attributes saryd kimek
+		attributes "saryd" "kimek"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -489,7 +489,7 @@ mission "Coalition: Transfer 1"
 		government "Coalition"
 	destination
 		government "Coalition"
-		attributes mining farming factory oil
+		attributes "mining" "farming" "factory" "oil"
 		distance 2 20
 	on complete
 		"coalition jobs" ++
@@ -510,7 +510,7 @@ mission "Coalition: Transfer 2"
 		government "Coalition"
 	destination
 		government "Coalition"
-		attributes mining farming factory oil
+		attributes "mining" "farming" "factory" "oil"
 		distance 2 20
 	on complete
 		"coalition jobs" ++
@@ -531,7 +531,7 @@ mission "Coalition: Transfer 3"
 		government "Coalition"
 	destination
 		government "Coalition"
-		attributes mining farming factory oil
+		attributes "mining" "farming" "factory" "oil"
 		distance 2 20
 	on complete
 		"coalition jobs" ++
@@ -554,7 +554,7 @@ mission "Coalition: Tourists Out 1"
 		government "Coalition"
 	destination
 		government "Coalition"
-		attributes tourism
+		attributes "tourism"
 		distance 5 20
 	on complete
 		"coalition jobs" ++
@@ -576,7 +576,7 @@ mission "Coalition: Tourists Out 2"
 		government "Coalition"
 	destination
 		government "Coalition"
-		attributes tourism
+		attributes "tourism"
 		distance 5 20
 	on complete
 		"coalition jobs" ++
@@ -598,7 +598,7 @@ mission "Coalition: Tourists Out 3"
 		government "Coalition"
 	destination
 		government "Coalition"
-		attributes tourism
+		attributes "tourism"
 		distance 5 20
 	on complete
 		"coalition jobs" ++
@@ -619,7 +619,7 @@ mission "Coalition: Tourists Home 1"
 		random < 40
 	source
 		government "Coalition"
-		attributes tourism
+		attributes "tourism"
 	destination
 		government "Coalition"
 		distance 5 20
@@ -641,7 +641,7 @@ mission "Coalition: Tourists Home 2"
 		random < 30
 	source
 		government "Coalition"
-		attributes tourism
+		attributes "tourism"
 	destination
 		government "Coalition"
 		distance 5 20
@@ -663,7 +663,7 @@ mission "Coalition: Tourists Home 3"
 		random < 20
 	source
 		government "Coalition"
-		attributes tourism
+		attributes "tourism"
 	destination
 		government "Coalition"
 		distance 5 20

--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -11,7 +11,7 @@
 mission "FWC Scouting 1"
 	landing
 	name "Scout Kaus Borealis"
-	description "Travel through the Kaus Borealis system to determine how strong the Navy presence is there, while JJ works to gather a fleet to attack it."
+	description "Travel through the <waypoints> system to determine how strong the Navy presence is there, while JJ works to gather a fleet to attack it."
 	autosave
 	source "New Portland"
 	waypoint "Kaus Borealis"
@@ -155,7 +155,7 @@ mission "FWC Attack Kaus Borealis"
 mission "FWC Cebalrai 1"
 	landing
 	name "Scout out Cebalrai"
-	description "Scout out the Navy presence in the Cebalrai system, then report back to Tomek on <planet>."
+	description "Scout out the Navy presence in the <waypoints> system, then report back to Tomek on <planet>."
 	autosave
 	source "New Iceland"
 	waypoint "Cebalrai"
@@ -196,7 +196,7 @@ mission "FWC Cebalrai 1"
 			`	"Well," he says, "if we can take Cebalrai, our entire territory will be behind just two choke points, which will allow us to defend ourselves against the Navy without spreading the fleet too thin. So next, I'd like you to go scout out the Cebalrai system and report on the Navy's position there."`
 				accept
 	
-	on enter Cebalrai
+	on enter "Cebalrai"
 		dialog
 			`There are a few Navy ships here, but nowhere near as many as were in the Kaus Borealis system before your last attack. Perhaps the Navy has decided to pull back their forces.`
 	

--- a/data/free worlds epilogue.txt
+++ b/data/free worlds epilogue.txt
@@ -10,7 +10,7 @@
 
 mission "FW Epilogue: Ijs and Katya"
 	landing
-	source Winter
+	source "Winter"
 	to offer
 		has "free worlds plot completed"
 	
@@ -54,7 +54,7 @@ mission "FW Epilogue: Ijs and Katya"
 
 mission "FW Epilogue: Alondo"
 	landing
-	source Bourne
+	source "Bourne"
 	to offer
 		has "free worlds plot completed"
 	
@@ -91,7 +91,7 @@ mission "FW Epilogue: Alondo"
 
 mission "FW Epilogue: Freya"
 	landing
-	source Pugglemug
+	source "Pugglemug"
 	to offer
 		has "free worlds plot completed"
 	
@@ -142,7 +142,7 @@ mission "FW Epilogue: Freya"
 
 mission "FW Epilogue: Danforth"
 	landing
-	source Farpoint
+	source "Farpoint"
 	to offer
 		has "free worlds plot completed"
 		not "Wanderers: Alpha Surveillance E: offered"

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -10,14 +10,14 @@
 
 mission "Pact Recon 0"
 	name "Pirate Reconnaissance"
-	description "Fly through the Alniyat, Han, Atria, and Lesath systems, then report to <destination> so the Southern Defense Pact can analyze your logs of pirate activity (if any)."
+	description "Fly through the <waypoints> systems, then report to <destination> so the Southern Defense Pact can analyze your logs of pirate activity (if any)."
 	waypoint "Alniyat"
 	waypoint "Han"
 	waypoint "Atria"
 	waypoint "Lesath"
 	source
-		attributes south
-	destination Glaze
+		attributes "south"
+	destination "Glaze"
 	to offer
 		random < 60
 		not "event: war begins"
@@ -70,14 +70,14 @@ mission "Pact Recon 0"
 mission "Pact Recon 1"
 	landing
 	name "Pirate Reconnaissance"
-	description "Fly through the Wei, Alnasl, Eber, and Alpha Arae systems, then report to <destination> so the Southern Defense Pact can analyze your logs of pirate activity (if any)."
+	description "Fly through the <waypoints> systems, then report to <destination> so the Southern Defense Pact can analyze your logs of pirate activity (if any)."
 	waypoint "Wei"
 	waypoint "Alnasl"
 	waypoint "Eber"
 	waypoint "Alpha Arae"
 	source
-		attributes south "dirt belt" rim "near earth"
-	destination Glaze
+		attributes "south" "dirt belt" "rim" "near earth"
+	destination "Glaze"
 	to offer
 		random < 40
 		not "event: war begins"
@@ -97,14 +97,14 @@ mission "Pact Recon 1"
 mission "Pact Recon 2"
 	landing
 	name "Pirate Reconnaissance"
-	description "Fly through the Men, Antares, Shaula, and Nunki systems, then report to <destination> so the Southern Defense Pact can analyze your logs of pirate activity (if any)."
+	description "Fly through the <waypoints> systems, then report to <destination> so the Southern Defense Pact can analyze your logs of pirate activity (if any)."
 	waypoint "Men"
 	waypoint "Antares"
 	waypoint "Shaula"
 	waypoint "Nunki"
 	source
-		attributes south "dirt belt" rim "near earth"
-	destination Glaze
+		attributes "south" "dirt belt" "rim" "near earth"
+	destination "Glaze"
 	to offer
 		random < 40
 		not "event: war begins"
@@ -124,14 +124,14 @@ mission "Pact Recon 2"
 mission "Pact Recon 3"
 	landing
 	name "Pirate Reconnaissance"
-	description "Fly through the Orvala, Hintar, Naper, and Boral systems, searching for a gathering pirate fleet. Report to the Pact on <destination> when you are done."
+	description "Fly through the <waypoints> systems, searching for a gathering pirate fleet. Report to the Pact on <destination> when you are done."
 	waypoint "Orvala"
 	waypoint "Hintar"
 	waypoint "Naper"
 	waypoint "Boral"
 	source
-		attributes south "dirt belt" rim "near earth"
-	destination Glaze
+		attributes "south" "dirt belt" "rim" "near earth"
+	destination "Glaze"
 	to offer
 		random < 40
 		not "event: war begins"
@@ -142,9 +142,9 @@ mission "Pact Recon 3"
 			`Once again, you receive a message from Freya Winters. "We have another mission for you," she says, "this one a bit more dangerous. We've heard rumors of a pirate fleet massing in one of the seldom-visited systems in the Dirt Belt, and we need to know where they are. Interested in helping to track them down? As before, you don't need to fight them, just observe them."`
 	
 	npc
-		government Pirate
+		government "Pirate"
 		personality staying plunders disables
-		system Naper
+		system "Naper"
 		fleet "Small Southern Pirates" 3
 		fleet "Large Northern Pirates"
 	
@@ -157,8 +157,8 @@ mission "Pact Recon 3"
 
 mission "Pact Questioning"
 	source
-		attributes "near earth" paradise
-		government Republic
+		attributes "near earth" "paradise"
+		government "Republic"
 	to offer
 		not "chosen sides"
 		has "Pact Recon 1: done"
@@ -341,20 +341,20 @@ mission "FW Recon 1"
 
 mission "FW Recon 2"
 	name "Free Worlds Reconnaissance"
-	description "Scan any ships in the Menkent system that are equipped like the combat-ready cruiser you scanned previously, then return to <destination>."
+	description "Scan any ships in the <waypoints> system that are equipped like the combat-ready cruiser you scanned previously, then return to <destination>."
 	source
-		planet Glaze
+		planet "Glaze"
 	to offer
 		has "FW Recon 1: done"
 	to fail
 		has "chosen sides"
-	waypoint Menkent
+	waypoint "Menkent"
 	
 	on offer
 		conversation
 			`You meet up with the militia officer in the spaceport bar. "Glad you showed up," he says, "I'm Jean-Jacques, by the way, but you can call me JJ."`
 			`	You introduce yourself in return, and he continues. "Here's the deal. I'm the commander of the militia on Glaze. So far, we and the Navy are not shooting at each other, because no one wants to fire the first shot. But if they're getting ready to change that, they'll start refitting their cruisers with heavy weaponry instead of surveillance equipment. So, I need to know how many more of their ships are equipped like the one you just scanned."`
-			`	He continues, "I'd like you to go to Menkent, where they're building some sort of secret base. Scan any ships you think match the one we just saw, then bring your scanner logs back here for me to look at."`
+			`	He continues, "I'd like you to go to <waypoints>, where they're building some sort of secret base. Scan any ships you think match the one we just saw, then bring your scanner logs back here for me to look at."`
 			choice
 				`	"Sure, I'd be glad to do that."`
 					accept
@@ -362,9 +362,9 @@ mission "FW Recon 2"
 					decline
 	
 	npc "scan outfits"
-		government Republic
+		government "Republic"
 		personality staying uninterested
-		system Menkent
+		system "Menkent"
 		fleet
 			names "republic capital"
 			fighters "republic fighter"
@@ -1529,24 +1529,24 @@ mission "FW Escort 2B"
 
 mission "FW Escort 3"
 	name "Stranded Freighter"
-	description "Repair the <npc>, which is stranded in the Lesath system, and escort it safely back to <destination>."
+	description "Repair the <npc>, which is stranded in the <waypoints> system, and escort it safely back to <destination>."
 	autosave
-	source Longjump
-	waypoint Lesath
+	source "Longjump"
+	waypoint "Lesath"
 	to offer
 		has "FW Escort 2B: done"
 	to fail
 		has "chosen sides"
 	
 	npc accompany save
-		system Lesath
+		system "Lesath"
 		personality escort derelict timid
 		government "Merchant"
 		ship "Freighter" "F.S. Shackleton"
 	
 	on offer
 		conversation
-			`When you walk into the bar, Voigt looks very glad to see you. "Here's the deal," he says. "One of our freighters, the <npc>, was just disabled in the Lesath system. We need you to fly there immediately, repair it, and bring it back here before it can be captured by the pirates. Do you think you're up to the task?"`
+			`When you walk into the bar, Voigt looks very glad to see you. "Here's the deal," he says. "One of our freighters, the <npc>, was just disabled in the <waypoints> system. We need you to fly there immediately, repair it, and bring it back here before it can be captured by the pirates. Do you think you're up to the task?"`
 			choice
 				`	"Sure!"`
 				`	"Sorry, I'm just a merchant captain. The Free Worlds shouldn't be asking me to do combat missions."`

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -13,8 +13,8 @@ mission "FW Diplomacy 1"
 	name "Free Worlds Diplomacy"
 	description "Travel to <planet> to meet up with Alondo, who will explain more."
 	source
-		near Sabik 1 100
-	destination Longjump
+		near "Sabik" 1 100
+	destination "Longjump"
 	to offer
 		has "event: navy occupying the south"
 	on fail
@@ -38,8 +38,8 @@ mission "FW Diplomacy 1B"
 	name "Free Worlds Diplomacy"
 	description "Bring Alondo to <planet> to meet with Parliament. Your guarantee of safe passage will expire on <day>."
 	autosave
-	source Longjump
-	destination Earth
+	source "Longjump"
+	destination "Earth"
 	deadline 24
 	to offer
 		has "FW Diplomacy 1: done"
@@ -90,7 +90,7 @@ mission "FW Diplomacy 1C"
 	landing
 	name "Free Worlds Diplomacy"
 	description "Bring Alondo to <planet> to meet with the senior Navy officers. Take as direct a route as possible, because your safe passage expires soon."
-	source Earth
+	source "Earth"
 	destination "New Wales"
 	clearance
 	to offer
@@ -153,13 +153,13 @@ mission "FW Diplomacy 1D"
 
 mission "FW Southern Recon 1"
 	name "Reconnaissance"
-	description "Fly through Rastaban, Delta Sagittarii, and Albaldah to get a sense of the Navy's strength in those systems, then report to <destination>."
+	description "Fly through <waypoints> to get a sense of the Navy's strength in those systems, then report to <destination>."
 	autosave
-	source Longjump
-	waypoint Rastaban
+	source "Longjump"
+	waypoint "Rastaban"
 	waypoint "Delta Sagittarii"
-	waypoint Albaldah
-	destination Trinket
+	waypoint "Albaldah"
+	destination "Trinket"
 	to offer
 		has "FW Diplomacy 1D: done"
 	on fail
@@ -179,8 +179,8 @@ mission "FW Southern Recon 1B"
 	name "Electron Beam"
 	description "Steal an Electron Beam from a Navy gunboat and return it to <planet> for Freya to look at. She thought your best bet for finding lone gunboats might be the Wei or Alnasl systems."
 	autosave
-	source Trinket
-	destination Trinket
+	source "Trinket"
+	destination "Trinket"
 	to offer
 		has "FW Southern Recon 1: done"
 	
@@ -439,7 +439,7 @@ mission "FW Southern Battle 3"
 	name "Sweep for Navy Ships"
 	description "Travel through the systems near Rastaban and make sure that the remainder of the Navy occupation fleet is retreating. (If they are fleeing, let them flee.)"
 	autosave
-	source Dancer
+	source "Dancer"
 	to offer
 		has "FW Southern Battle 2: done"
 	waypoint Girtab
@@ -469,17 +469,17 @@ mission "FW Southern Battle 3"
 				accept
 	
 	npc
-		government Republic
+		government "Republic"
 		personality fleeing uninterested
 		system "Delta Sagittarii"
 		fleet "Large Republic" 2
 	npc
-		government Republic
+		government "Republic"
 		personality fleeing uninterested
 		system "Girtab"
 		fleet "Large Republic" 2
 	npc
-		government Republic
+		government "Republic"
 		personality fleeing uninterested
 		system "Albaldah"
 		fleet "Large Republic" 2
@@ -666,12 +666,12 @@ mission "FW Southern Break Ends"
 mission "FW Northern 1"
 	landing
 	name "Northern Expansion"
-	description "Take a fleet to <destination> (visiting Alphecca and Seginus along the way), securing those systems to allow them to defect to the Free Worlds."
+	description "Take a fleet to <destination> (visiting <waypoints> along the way), securing those systems to allow them to defect to the Free Worlds."
 	autosave
-	source Dancer
+	source "Dancer"
 	destination "New Tibet"
-	waypoint Alphecca
-	waypoint Seginus
+	waypoint "Alphecca"
+	waypoint "Seginus"
 	clearance
 	to offer
 		has "event: fw occupying the north"
@@ -685,7 +685,7 @@ mission "FW Northern 1"
 		conversation
 			`When you land on Dancer, the Free Worlds fleet appears to be preparing for another battle: missiles and torpedoes are being loaded onto ships and crew members are running around. You eventually find Freya and Alondo, and ask them what is going on.`
 			`	"Another three worlds have secretly told us they are ready to defect," says Alondo, "and this time around we want to get there before the Navy does."`
-			`	Freya says, "We need you to take Alondo, along with the ships that we've been able to muster, and fly through the Seginus and Alphecca systems, then land on <destination>. If all goes well, you will get through to <planet> before the Republic can muster reinforcements. Drive off any Republic ships you encounter along the way."`
+			`	Freya says, "We need you to take Alondo, along with the ships that we've been able to muster, and fly through the <waypoints> systems, then land on <destination>. If all goes well, you will get through to <planet> before the Republic can muster reinforcements. Drive off any Republic ships you encounter along the way."`
 				accept
 	
 	npc
@@ -693,17 +693,17 @@ mission "FW Northern 1"
 		personality heroic escort
 		fleet "Large Free Worlds" 3
 	npc
-		government Republic
+		government "Republic"
 		personality fleeing uninterested
 		system "Wei"
 		fleet "Large Republic" 2
 	npc
-		government Republic
+		government "Republic"
 		personality fleeing uninterested
 		system "Seginus"
 		fleet "Large Republic" 2
 	npc
-		government Republic
+		government "Republic"
 		personality fleeing uninterested
 		system "Alphecca"
 		fleet "Large Republic" 2

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -920,10 +920,10 @@ mission "FW Pug 1"
 			`	"Our fleet is still scattered throughout this quadrant," he says, "and I'll need Katya to command a part of it. Right now I just need you to travel to Rand, if possible, and find out what's going on. It could just be a communications malfunction, but I seriously doubt it. Meanwhile, Katya and Ijs can help me with organizing the fleet."`
 				accept
 	
-	on enter Cebalrai
+	on enter "Cebalrai"
 		dialog
 			`Based on your previous maps of this sector, there should be a hyperspace link from here to the Rasalhague system. But your sensors show nothing. Something has severed the link.`
-	on enter Ascella
+	on enter "Ascella"
 		dialog
 			`The Ascella system used to be linked to Rasalhague and Delta Capricorni, but no longer. Either the Syndicate has discovered the ability to alter hyperspace links, and is using it to block the Free Worlds from interfering with them, or you have a much stranger problem on your hands...`
 
@@ -931,7 +931,7 @@ mission "FW Pug 1"
 
 mission "FW Pug 1 Tundra"
 	landing
-	source Tundra
+	source "Tundra"
 	to offer
 		has "FW Pug 1: active"
 	

--- a/data/free worlds side plots.txt
+++ b/data/free worlds side plots.txt
@@ -158,7 +158,7 @@ mission "FW Wolf Pack 1"
 	description "Travel to <planet> in the Deep, where Free Worlds sympathizers will share details of a new ramscoop technology. (You may have to bribe planets along the way to get permission to refuel.)"
 	source
 		government "Free Worlds"
-	destination Memory
+	destination "Memory"
 	clearance
 	minor
 	to offer
@@ -198,7 +198,7 @@ mission "FW Wolf Pack 1B"
 	landing
 	name "Ramscoop Technology"
 	description "Return to Free space with the plans for a new, more efficient ramscoop, and deliver them to Delta V Corporation on <destination>."
-	destination Solace
+	destination "Solace"
 	to offer
 		has "FW Wolf Pack 1: done"
 		not "event: fw armistice"
@@ -234,7 +234,7 @@ mission "FW Wolf Pack 2"
 	description `A group identifying themselves as the "Free Worlds Wolf Pack" has asked you to visit them on <planet> if you want to aid their work against the Republic.`
 	source
 		government "Free Worlds"
-	destination Solace
+	destination "Solace"
 	to offer
 		has "FW Wolf Pack 1B: done"
 		has "event: fw gets catalytic ramscoop"
@@ -259,9 +259,9 @@ mission "FW Wolf Pack 2"
 mission "FW Wolf Pack 2A"
 	landing
 	name "Attack Food Convoy"
-	description "Destroy three Republic freighters in the Sarin system that are carrying food, then report back to <planet> for payment."
-	source Solace
-	waypoint Sarin
+	description "Destroy three Republic freighters in the <waypoints> system that are carrying food, then report back to <planet> for payment."
+	source "Solace"
+	waypoint "Sarin"
 	to offer
 		has "FW Wolf Pack 2: done"
 		not "event: fw armistice"
@@ -300,8 +300,8 @@ mission "FW Wolf Pack 2A"
 				accept
 	
 	npc kill
-		government Republic
-		system Sarin
+		government "Republic"
+		system "Sarin"
 		personality timid staying target
 		ship "Freighter" "Horn of Plenty"
 		ship "Freighter" "Autumn Twilight"
@@ -309,8 +309,8 @@ mission "FW Wolf Pack 2A"
 		dialog "You have destroyed all the target freighters. Time to report back to the Wolf Pack on Solace."
 	
 	npc
-		government Republic
-		system Sarin
+		government "Republic"
+		system "Sarin"
 		personality heroic staying
 		ship "Gunboat (Mark II)" "R.N.S. Atherstone"
 		ship "Gunboat (Mark II)" "R.N.S. Tyndale"
@@ -328,7 +328,7 @@ mission "FW Wolf Pack 2A"
 event "wolf pack 3 ready"
 
 event "wolf pack gacrux start"
-	system Gacrux
+	system "Gacrux"
 		fleet "Small Southern Merchants" 2000
 		fleet "Large Southern Merchants" 5000
 		fleet "Small Southern Pirates" 2000
@@ -336,7 +336,7 @@ event "wolf pack gacrux start"
 		fleet "Small Republic" 8000
 
 event "wolf pack gacrux end"
-	system Gacrux
+	system "Gacrux"
 		fleet "Small Southern Merchants" 2000
 		fleet "Large Southern Merchants" 5000
 		fleet "Small Southern Pirates" 2000
@@ -353,8 +353,8 @@ mission "FW Wolf Pack 3"
 	description "Destroy two Republic bulk freighters in the Gacrux system that are carrying food, then report back to <planet> for payment."
 	source
 		government "Free Worlds"
-	destination Solace
-	waypoint Gacrux
+	destination "Solace"
+	waypoint "Gacrux"
 	to offer
 		has "FW Wolf Pack 2A: done"
 		has "event: wolf pack 3 ready"
@@ -373,16 +373,16 @@ mission "FW Wolf Pack 3"
 		event "wolf pack gacrux end"
 
 	npc kill
-		government Republic
-		system Gacrux
+		government "Republic"
+		system "Gacrux"
 		personality timid staying target
 		ship "Bulk Freighter" "Dew of the Morning"
 		ship "Bulk Freighter" "Heaven's Blessing"
 		dialog "The food convoy has been destroyed. You can now return to Solace."
 	
 	npc
-		government Republic
-		system Gacrux
+		government "Republic"
+		system "Gacrux"
 		personality heroic staying
 		ship "Protector (Laser)" "R.N.S. Bulwark"
 		ship "Protector" "R.N.S. Citadel"
@@ -402,14 +402,14 @@ mission "FW Wolf Pack 3"
 event "wolf pack 4 ready"
 
 event "wolf pack mizar start"
-	system Mizar
+	system "Mizar"
 		fleet "Small Southern Merchants" 1400
 		fleet "Large Southern Merchants" 4500
 		fleet "Small Republic" 5000
 		fleet "Small Southern Pirates" 9000
 
 event "wolf pack mizar end"
-	system Mizar
+	system "Mizar"
 		fleet "Small Southern Merchants" 1400
 		fleet "Large Southern Merchants" 4500
 		fleet "Small Republic" 1000
@@ -422,11 +422,11 @@ event "wolf pack mizar end"
 mission "FW Wolf Pack 4"
 	landing
 	name "Attack Food Convoy"
-	description "Destroy a Republic Bactrian freighter in the Mizar system that is carrying food, then report back to <planet> for payment."
+	description "Destroy a Republic Bactrian freighter in the <waypoints> system that is carrying food, then report back to <planet> for payment."
 	source
 		government "Free Worlds"
-	destination Solace
-	waypoint Mizar
+	destination "Solace"
+	waypoint "Mizar"
 	to offer
 		has "FW Wolf Pack 3: done"
 		has "event: wolf pack 4 ready"
@@ -436,7 +436,7 @@ mission "FW Wolf Pack 4"
 	
 	on offer
 		dialog
-			`You receive another message from the Wolf Pack: "Hello Captain. If nothing else, we've certainly succeeded in getting some of the Navy's ships diverted from the front, to serve as escorts! Your next target, if you're willing to help us again, will be a bit tougher: a Bactrian freighter, probably with Navy escorts. The freighter is passing through the Mizar system. Interested?`
+			`You receive another message from the Wolf Pack: "Hello Captain. If nothing else, we've certainly succeeded in getting some of the Navy's ships diverted from the front, to serve as escorts! Your next target, if you're willing to help us again, will be a bit tougher: a Bactrian freighter, probably with Navy escorts. The freighter is passing through the <waypoints> system. Interested?`
 	
 	on accept
 		event "wolf pack mizar start"
@@ -444,15 +444,15 @@ mission "FW Wolf Pack 4"
 		event "wolf pack mizar end"
 
 	npc kill
-		government Republic
-		system Mizar
+		government "Republic"
+		system "Mizar"
 		personality timid staying target
 		ship "Bactrian" "Golden Fleece"
 		dialog "You have eliminated the Bactrian that was carrying food to the Republic. Time to report back to the Wolf Pack and receive your reward."
 	
 	npc
-		government Republic
-		system Mizar
+		government "Republic"
+		system "Mizar"
 		personality heroic staying
 		fleet
 			names "republic capital"
@@ -477,7 +477,7 @@ mission "FW Stack Core 1"
 	name "Escort convoy from Rand"
 	description "Freya asked you to stop by Rand if you are able, to help escort a freighter convoy carrying vital supplies for building some exciting new equipment."
 	landing
-	destination Rand
+	destination "Rand"
 	to offer
 		has "FW Reconciliation Break: offered"
 	
@@ -492,7 +492,7 @@ mission "FWC Stack Core 1"
 	name "Escort convoy from Rand"
 	description "Freya asked you to stop by Rand if you are able, to help escort a freighter convoy carrying vital supplies for building some exciting new equipment."
 	landing
-	destination Rand
+	destination "Rand"
 	to offer
 		has "FW Liberate Delta Sagittarii: done"
 	
@@ -505,8 +505,8 @@ mission "FW Stack Core 1B"
 	landing
 	name "Escort convoy from Rand"
 	description "Freya asked you to escort this convoy carrying vital supplies for building some exciting new equipment, to <destination>."
-	source Rand
-	destination Solace
+	source "Rand"
+	destination "Solace"
 	to offer
 		has "FW Stack Core 1: done"
 	
@@ -527,7 +527,7 @@ mission "FW Stack Core 1B"
 	
 	npc
 		government "Republic"
-		system Menkent
+		system "Menkent"
 		personality surveillance
 		fleet
 			names "republic capital"
@@ -547,7 +547,7 @@ mission "FW Stack Core 1C"
 	landing
 	minor
 	source
-		near Pherkad 100
+		near "Pherkad" 100
 	to offer
 		has "event: stack core for sale"
 	

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -397,7 +397,7 @@ mission "FW Syndicate Diplomacy 1C"
 	to offer
 		has "FW Syndicate Diplomacy 1B: done"
 	clearance "Alondo has a brief chat with the spaceport controller and manages to get you permission to land."
-		attributes "dirt belt" south
+		attributes "dirt belt" "south"
 	passengers 1
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
@@ -666,12 +666,12 @@ mission "FW Plasma Testing 1"
 mission "FW Plasma Testing 1B"
 	landing
 	name "Weapons Testing"
-	description "As a test for the new Plasma Turret, assist the Walloping Window-Blind in destroying the Red Nile, a pirate ship that is probably in the Ildaria system. Then return to <planet>."
+	description "As a test for the new Plasma Turret, assist the Walloping Window-Blind in destroying the Red Nile, a pirate ship that is probably in the <waypoints> system. Then return to <planet>."
 	autosave
-	source Rust
+	source "Rust"
 	to offer
 		has "FW Plasma Testing 1: done"
-	waypoint Ildaria
+	waypoint "Ildaria"
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
@@ -682,7 +682,7 @@ mission "FW Plasma Testing 1B"
 	npc kill
 		government "Pirate"
 		personality plunders staying target
-		system Ildaria
+		system "Ildaria"
 		ship "Leviathan (Heavy)" "Red Nile"
 		dialog `The <npc> has been eliminated. Time to return to <destination> and report to Barmy Edward.`
 	
@@ -737,8 +737,8 @@ mission "FW Plasma Testing 1B"
 			
 			label plan
 			`	"So, where do I come in?" you ask.`
-			`	"Well, the Council says no testing against the Navy yet. No point in provoking a fight just to try out an untested weapon. So I asked them what other target they could suggest, and they mentioned this pirate ship by the name of Red Nile, that's been haunting the Ildaria system, sniping on merchants that take a wrong turn and end up there."`
-			`	With a grand gesture, he indicates an aging Tarazed Falcon parked in the far corner of the hangar. It's a little rusty, and the paint is flaking, but a Falcon is an impressive ship under any circumstances. "We packed four of our prototypes into our department's very own test ship, the Walloping Window-Blind. We can't let you fly her, of course," he says, "on account of she's dearer to us than our own children. So the plan is, the Window-Blind will accompany you to Ildaria, and you fight the pirates together, taking careful note of how the guns perform. Sound like fun?`
+			`	"Well, the Council says no testing against the Navy yet. No point in provoking a fight just to try out an untested weapon. So I asked them what other target they could suggest, and they mentioned this pirate ship by the name of Red Nile, that's been haunting the <waypoints> system, sniping on merchants that take a wrong turn and end up there."`
+			`	With a grand gesture, he indicates an aging Tarazed Falcon parked in the far corner of the hangar. It's a little rusty, and the paint is flaking, but a Falcon is an impressive ship under any circumstances. "We packed four of our prototypes into our department's very own test ship, the Walloping Window-Blind. We can't let you fly her, of course," he says, "on account of she's dearer to us than our own children. So the plan is, the Window-Blind will accompany you to <waypoints>, and you fight the pirates together, taking careful note of how the guns perform. Sound like fun?`
 			choice
 				`	"You bet!"`
 					accept
@@ -795,7 +795,7 @@ mission "FW Plasma Testing 1B"
 mission "plasma turret available"
 	landing
 	source
-		near Kraz 100
+		near "Kraz" 100
 	to offer
 		has "event: plasma turret available"
 	on offer
@@ -873,10 +873,10 @@ mission "FW Pirates 1"
 	name "Pirate Reconnaissance"
 	description "Scout out all the pirate systems on the southern fringe of human space, then report back to Tomek on <planet>"
 	source Longjump
-	waypoint Men
-	waypoint Antares
-	waypoint Shaula
-	waypoint Nunki
+	waypoint "Men"
+	waypoint "Antares"
+	waypoint "Shaula"
+	waypoint "Nunki"
 	to offer
 		has "FW Supply Convoy 1: done"
 	on fail
@@ -912,7 +912,7 @@ mission "FW Pirates 1"
 
 mission "FW Pirates 1A"
 	landing
-	source Harmony
+	source "Harmony"
 	to offer
 		has "FW Pirates 1: active"
 	
@@ -965,8 +965,8 @@ mission "FW Pirates 1A"
 mission "FW Senate 1"
 	name "Senator Huygens"
 	description "Meet Senator Arianna Huygens on <planet>, and transport her to the new Free Worlds Senate building on Bourne."
-	source Longjump
-	destination Mere
+	source "Longjump"
+	destination "Mere"
 	to offer
 		has "FW Pirates 1: done"
 	on fail
@@ -1136,7 +1136,7 @@ mission "FW Pirates 2"
 	name "Southern Patrol"
 	description "Lead a patrol through the Free Worlds systems on the southern rim, driving off any pirates you encounter, then meet up with Tomek on <destination>."
 	autosave
-	source Bourne
+	source "Bourne"
 	waypoint "Yed Prior"
 	waypoint "Beta Lupi"
 	waypoint "Kappa Centauri"
@@ -1145,7 +1145,7 @@ mission "FW Pirates 2"
 	waypoint "Dschubba"
 	waypoint "Han"
 	waypoint "Atria"
-	destination Longjump
+	destination "Longjump"
 	to offer
 		has "FW Senate 1B: done"
 	on fail

--- a/data/hai jobs.txt
+++ b/data/hai jobs.txt
@@ -354,7 +354,7 @@ mission "Delivery to Human Space [0]"
 		government "Hai"
 		near "Heia Due" 2
 	destination
-		attributes north
+		attributes "north"
 	on complete
 		payment 80000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
@@ -371,7 +371,7 @@ mission "Delivery to Human Space [1]"
 		government "Hai"
 		near "Heia Due" 2
 	destination
-		attributes north
+		attributes "north"
 	on complete
 		payment 80000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
@@ -388,7 +388,7 @@ mission "Delivery to Human Space [2]"
 		government "Hai"
 		near "Heia Due" 2
 	destination
-		attributes north
+		attributes "north"
 	on complete
 		payment 80000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
@@ -408,25 +408,25 @@ mission "Escort to Human Space (Small)"
 		government "Hai"
 		near "Heia Due" 2
 	destination
-		attributes north
+		attributes "north"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis waiting harvests plunders
-		system Rajak
+		system "Rajak"
 		fleet "Small Northern Pirates"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis waiting harvests plunders
 		system destination
 		fleet "Small Northern Pirates"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis staying harvests plunders
 		system destination
 		fleet "Small Northern Pirates"
 	
 	npc accompany save
-		government Merchant
+		government "Merchant"
 		personality escort timid
 		fleet
 			names "civilian"
@@ -451,30 +451,30 @@ mission "Escort to Human Space (Medium)"
 		government "Hai"
 		near "Heia Due" 2
 	destination
-		attributes north
+		attributes "north"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis waiting harvests plunders
-		system Cardax
+		system "Cardax"
 		fleet "Small Northern Pirates"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis waiting harvests plunders
-		system Rigel
+		system "Rigel"
 		fleet "Small Northern Pirates"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis waiting harvests plunders
-		system Rajak
+		system "Rajak"
 		fleet "Small Northern Pirates"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis staying harvests plunders
 		system destination
 		fleet "Small Northern Pirates" 2
 	
 	npc accompany save
-		government Merchant
+		government "Merchant"
 		personality escort timid
 		fleet
 			names "civilian"
@@ -499,25 +499,25 @@ mission "Escort to Human Space (Large)"
 		government "Hai"
 		near "Heia Due" 2
 	destination
-		attributes north
+		attributes "north"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis waiting harvests plunders
-		system Rajak
+		system "Rajak"
 		fleet "Large Northern Pirates"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis waiting harvests plunders
 		system destination
 		fleet "Small Northern Pirates"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis staying harvests plunders
 		system destination
 		fleet "Large Northern Pirates"
 	
 	npc accompany save
-		government Merchant
+		government "Merchant"
 		personality escort timid
 		fleet
 			names "civilian"
@@ -542,31 +542,31 @@ mission "Escort to Human Space (Extra Large)"
 		government "Hai"
 		near "Heia Due" 2
 	destination
-		attributes north
+		attributes "north"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis waiting harvests plunders
-		system Rigel
+		system "Rigel"
 		fleet "Small Northern Pirates"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis waiting harvests plunders
-		system Cardax
+		system "Cardax"
 		fleet "Large Northern Pirates"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis waiting harvests plunders
-		system Rajak
+		system "Rajak"
 		fleet "Large Northern Pirates"
 	npc
-		government Pirate
+		government "Pirate"
 		personality nemesis staying harvests plunders
 		system destination
 		fleet "Small Northern Pirates"
 		fleet "Large Northern Pirates"
 	
 	npc accompany save
-		government Merchant
+		government "Merchant"
 		personality escort timid
 		fleet
 			names "civilian"
@@ -786,7 +786,7 @@ mission "Hai Cargo [2]"
 	to offer
 		random < 60
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
 	destination
 		distance 2 7
@@ -804,7 +804,7 @@ mission "Hai Cargo [3]"
 	to offer
 		random < 50
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
 	destination
 		distance 3 7
@@ -823,7 +823,7 @@ mission "Hai Cargo [4]"
 	to offer
 		random < 40
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
 	destination
 		distance 4 7
@@ -877,7 +877,7 @@ mission "Hai Bulk Delivery [2]"
 	to offer
 		random < 50
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
 	destination
 		distance 4 7
@@ -935,7 +935,7 @@ mission "Hai Large Bulk Delivery [2]"
 		random < 40
 		"cargo space" > 160
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
 	destination
 		distance 4 7
@@ -993,7 +993,7 @@ mission "Hai Rush Delivery [2]"
 	to offer
 		random < 50
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
 	destination
 		distance 5 7
@@ -1013,7 +1013,7 @@ mission "Hai Rush Delivery [3]"
 	to offer
 		random < 40
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
 	destination
 		distance 6 7
@@ -1074,7 +1074,7 @@ mission "Hai Large Rush Delivery [2]"
 		random < 40
 		"cargo space" > 80
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
 	destination
 		distance 5 7
@@ -1095,7 +1095,7 @@ mission "Hai Large Rush Delivery [3]"
 		random < 30
 		"cargo space" > 80
 	source
-		attributes mining textiles factory farming fishing oil
+		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
 	destination
 		distance 6 7

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -391,8 +391,8 @@ mission "Unfettered returning home"
 	description "This Hai has asked you to smuggle him out of Unfettered space and bring him to <destination>."
 	minor
 	source
-		attributes unfettered
-	destination Hai-home
+		attributes "unfettered"
+	destination "Hai-home"
 	clearance
 	passengers 1
 	to offer

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -10,9 +10,9 @@
 
 mission "Kestrel Testing"
 	name "Warship Testing"
-	description "Travel to the Umbral system to fight and disable a prototype warship that Tarazed Corporation is testing. Do not destroy the ship, or you will lose your payment and your opportunity to buy one."
-	source Wayfarer
-	waypoint Umbral
+	description "Travel to the <waypoints> system to fight and disable a prototype warship that Tarazed Corporation is testing. Do not destroy the ship, or you will lose your payment and your opportunity to buy one."
+	source "Wayfarer"
+	waypoint "Umbral"
 	to offer
 		"combat rating" > 8000
 	
@@ -46,13 +46,13 @@ mission "Kestrel Testing"
 				`	"No problem. Where will I battle this ship?"`
 				`	"Sorry, I don't think I can agree to that."`
 					decline
-			`	"We do most of our starship testing in the Umbral system," he says. "The test ship is unmistakable. Journey there, disable it without destroying it, then return here and we'll ask you about any weaknesses you found or improvements you would make. And if you destroy the ship or steal it, naturally you will forfeit your payment."`
+			`	"We do most of our starship testing in the <waypoints> system," he says. "The test ship is unmistakable. Journey there, disable it without destroying it, then return here and we'll ask you about any weaknesses you found or improvements you would make. And if you destroy the ship or steal it, naturally you will forfeit your payment."`
 				accept
 	
 	npc disable save
 		government "Test Dummy"
 		personality staying nemesis heroic
-		system Umbral
+		system "Umbral"
 		ship "Unknown Ship Type" "Tarazed Prototype"
 	
 	on complete
@@ -185,10 +185,10 @@ mission "Kestrel: More Shields"
 mission "Kestrel Available"
 	landing
 	source
-		near Tarazed 100
+		near "Tarazed" 100
 	to offer
 		has "kestrel available"
-	destination Wayfarer
+	destination "Wayfarer"
 	on offer
 		conversation
 			scene ship/kestrel

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -192,13 +192,13 @@ mission "Remnant: Bounty"
 mission "Remnant: Defense 3"
 	landing
 	name "Remnant surveillance"
-	description "Travel to the Parca system, destroy any Korath ships you find there, then deploy a Remnant surveillance satellite to give them advance warning of Korath raids in the future. Return to <planet> when you are done."
+	description "Travel to the <waypoints> system, destroy any Korath ships you find there, then deploy a Remnant surveillance satellite to give them advance warning of Korath raids in the future. Return to <planet> when you are done."
 	source
 		government "Remnant"
 	to offer
 		"Remnant: Bounty: done" >= 3
 	cargo "surveillance equipment" 13
-	waypoint Parca
+	waypoint "Parca"
 	on offer
 		conversation
 			`A man approaches your ship soon after you collect your latest bounty, and sings, "You have been most helpful in fighting the Korath. Would you be willing to assist us in another way?"`
@@ -213,9 +213,9 @@ mission "Remnant: Defense 3"
 	on accept
 		event "remnant: surveillance begin"
 	npc kill
-		government Korath
+		government "Korath"
 		personality heroic nemesis staying
-		system Parca
+		system "Parca"
 		fleet "Korath Raid" 2
 		dialog "Now that you are alone, you are able to deploy the Remnant surveillance satellite unobserved. Time to report back to <planet>."
 	on complete
@@ -231,11 +231,11 @@ mission "Remnant: Defense 3"
 			`	He grins, very slightly. "That is not my decision alone to make," he says, "but I will put in a word for you and see what I can do."`
 
 event "remnant: surveillance begin"
-	system Parca
+	system "Parca"
 		remove fleet "Korath Raid"
 
 event "remnant: surveillance end"
-	system Parca
+	system "Parca"
 		add fleet "Korath Raid" 10000
 
 
@@ -243,7 +243,7 @@ event "remnant: surveillance end"
 mission "Remnant: Key Stones"
 	name "Keystones"
 	description "The manager of the outfitter on <planet>, a Remnant world, has offered to pay you six million credits in exchange for a shipment of fifty Quantum Keystones (which you will have to purchase from the Hai)."
-	source Viminal
+	source "Viminal"
 	to offer
 		has "First Contact: Remnant: offered"
 	on offer
@@ -283,9 +283,9 @@ mission "Remnant: Key Stones"
 
 mission "Remnant: Void Sprites 1"
 	name "Space creatures"
-	description "A man on the Remnant homeworld of <planet> asked you to collect data on some strange space creatures in the Nenia system, in another part of the Ember Waste."
-	source Aventine
-	waypoint Nenia
+	description "A man on the Remnant homeworld of <planet> asked you to collect data on some strange space creatures in the <waypoints> system, in another part of the Ember Waste."
+	source "Aventine"
+	waypoint "Nenia"
 	cargo "scanning equipment" 8
 	to offer
 		has "First Contact: Remnant: offered"
@@ -331,13 +331,13 @@ mission "Remnant: Void Sprites 1"
 	npc
 		government "Indigenous Lifeform"
 		personality timid mining harvests staying mute
-		system Nenia
+		system "Nenia"
 		fleet
 			cargo 0
 			variant
 				"Void Sprite"
 				"Void Sprite (Infant)" 3
-	on enter Nenia
+	on enter "Nenia"
 		dialog `There are indeed some strange space-faring life forms in this system. You collect measurements with the special sensors, and then prepare to return to <planet>.`
 
 
@@ -345,9 +345,9 @@ mission "Remnant: Void Sprites 1"
 mission "Remnant: Void Sprites 2"
 	landing
 	name "Scan the void sprites"
-	description "Return to the Nenia system, and use an outfit scanner on one of each of the types of void sprites to see if you can tell how their propulsion works."
-	source Aventine
-	waypoint Nenia
+	description "Return to the <waypoints> system, and use an outfit scanner on one of each of the types of void sprites to see if you can tell how their propulsion works."
+	source "Aventine"
+	waypoint "Nenia"
 	to offer
 		has "Remnant: Void Sprites 1: done"
 	on offer
@@ -373,7 +373,7 @@ mission "Remnant: Void Sprites 2"
 	npc "scan outfits"
 		government "Indigenous Lifeform"
 		personality timid mining harvests staying mute
-		system Nenia
+		system "Nenia"
 		fleet
 			cargo 0
 			variant
@@ -385,11 +385,11 @@ mission "Remnant: Void Sprites 2"
 		event "remnant: nenia restored"
 
 event "remnant: nenia empty"
-	system Nenia
+	system "Nenia"
 		remove fleet "Void Sprites"
 
 event "remnant: nenia restored"
-	system Nenia
+	system "Nenia"
 		add fleet "Void Sprites" 500
 
 
@@ -398,10 +398,10 @@ mission "Remnant: Void Sprites 3"
 	landing
 	name "Visit void sprite planets"
 	description `Purchase a "gascraft" ship from the Remnant world of Viminal, and use it to explore the two gas giants where the void sprites live. Then, return to <planet>.`
-	source Aventine
-	stopover Viminal
-	stopover Nasqueron
-	stopover Slylandro
+	source "Aventine"
+	stopover "Viminal"
+	stopover "Nasqueron"
+	stopover "Slylandro"
 	cargo "scanning equipment" 8
 	blocked "The Remnant researcher has another job for you, but you're going to have to free up some cargo space in order to take it on."
 	to offer
@@ -434,7 +434,7 @@ mission "Remnant: Void Sprites 3"
 		event "remnant: gascraft"
 	npc
 		government " Drak "
-		system Nenia
+		system "Nenia"
 		personality staying heroic nemesis uninterested
 		ship "Archon (Cloaked)" "Lifted Lorax"
 	on stopover
@@ -463,7 +463,7 @@ mission "Remnant: Void Sprites 3"
 			`	You thank him for the information and tell him that you will look forward to reading the results of his study (and, getting paid for your help) once it is complete.`
 
 event "remnant: gascraft"
-	planet Viminal
+	planet "Viminal"
 		add shipyard "Remnant Gascraft"
 
 government " Drak "

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -17,8 +17,8 @@ mission "Immigrant Workers"
 		random < 50
 	source "New Iceland"
 	destination
-		attributes core
-		attributes factory textile
+		attributes "core"
+		attributes "factory" "textile"
 	on complete
 		payment
 		payment 10000
@@ -416,23 +416,23 @@ mission "Transport Workers C"
 
 mission "WR Star 1"
 	name "Star Research"
-	description "Fly through the Ildaria system with this team of scientists, then return them to <destination>."
+	description "Fly through the <waypoints> system with this team of scientists, then return them to <destination>."
 	minor
 	source
-		attributes deep
-		attributes urban research
-	waypoint Ildaria
+		attributes "deep"
+		attributes "urban" "research"
+	waypoint "Ildaria"
 	to offer
 		random < 20
 	passengers 3
 	cargo "sensors" 2
 	
 	on offer
-		dialog `A group of scientists approaches you and asks if you will be headed to the Rim any time soon. "We're doing research on Wolf-Rayet stars," they explain, "and we're hoping to find a captain who can do a fly-by of Ildaria." Scientific research in the Deep is notoriously well-funded, so they will probably pay you quite well.`
+		dialog `A group of scientists approaches you and asks if you will be headed to the Rim any time soon. "We're doing research on Wolf-Rayet stars," they explain, "and we're hoping to find a captain who can do a fly-by of <waypoints>." Scientific research in the Deep is notoriously well-funded, so they will probably pay you quite well.`
 	
 	on complete
 		payment 250000
-		dialog `The team of scientists thanks you for bringing them to Ildaria and back, and pays you <payment>. They seem eager to get back to their lab and start analyzing their measurements.`
+		dialog `The team of scientists thanks you for bringing them to <waypoints> and back, and pays you <payment>. They seem eager to get back to their lab and start analyzing their measurements.`
 
 
 
@@ -441,7 +441,7 @@ mission "Deep Archaeology 1"
 	description "Drop this archaeologist off on <destination>, before making a trip to Midgard in the Deep to collect some samples."
 	minor
 	source
-		attributes paradise north "near earth"
+		attributes "paradise" "north" "near earth"
 		near Miaplacidus 1 20
 	destination Vinci
 	to offer
@@ -1225,7 +1225,7 @@ mission "Rim Archaeology 5B"
 
 event "rim archaeology results"
 	planet Zug
-		attributes rim farming factory tourism
+		add attributes "tourism"
 		description `Zug is a pleasant world of rolling hills, fertile fields, and a few small oceans. Hundreds of millions of people live here, with more immigrants arriving every day, almost faster than the construction industry can keep up with them. In addition to the larger cities, many people live in smaller farming villages, making this one of the few worlds in the region that is truly self-sufficient both in industry and in agriculture.`
 		description `	The largest industry on Zug is Southbound Shipyards. However, in the wake of some extraordinary archaeological discoveries of a lost civilization, Zug has suddenly also become a popular destination for tourists.`
 
@@ -1235,7 +1235,7 @@ mission "Rim Archaeology 6"
 	landing
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Independent" "Neutral"
-		near Sol 100
+		near "Sol" 100
 		attributes spaceport
 	to offer
 		has "event: rim archaeology results"
@@ -1258,7 +1258,7 @@ mission "Drug Running 1"
 	source
 		attributes "near earth" "dirt belt" "north"
 	destination
-		attributes paradise
+		attributes "paradise"
 		distance 1 100
 	cargo "illegal drugs" 5 2 .1
 		illegal 40000
@@ -1289,7 +1289,7 @@ mission "Drug Running 2"
 	source
 		attributes "near earth" "dirt belt" "north"
 	destination
-		attributes rich
+		attributes "rich"
 		distance 1 100
 	cargo "illegal drugs" 5 2 .1
 		illegal 50000
@@ -1315,7 +1315,7 @@ mission "Drug Running 3"
 	source
 		attributes "near earth" "dirt belt" "north"
 	destination
-		attributes urban
+		attributes "urban"
 		distance 1 100
 	cargo "illegal drugs" 5 2 .1
 		illegal 70000
@@ -1417,11 +1417,11 @@ mission "Rescue Miners 1"
 	name "Rescue Miners"
 	minor
 	source
-		attributes core
-		attributes urban
+		attributes "core"
+		attributes "urban"
 	destination
-		attributes core
-		attributes mining
+		attributes "core"
+		attributes "mining"
 		distance 1 100
 	passengers 15
 	cargo "emergency supplies" 15
@@ -1439,8 +1439,8 @@ mission "Rescue Miners 2"
 	name "Rescue Miners"
 	minor
 	destination
-		attributes core
-		attributes urban
+		attributes "core"
+		attributes "urban"
 		distance 2 10
 	passengers 15
 	to offer
@@ -1535,7 +1535,7 @@ mission "Courier 4"
 	destination
 		distance 7 14
 		government "Republic" "Free Worlds" "Syndicate" "Quarg" "Neutral"
-		attributes rich
+		attributes "rich"
 	on offer
 		conversation
 			`A man wearing a very complicated hat waves to you from the other side of a landing pad. "Yoo-hoo, Captain!" he says. "I have a courier mission for you if you're interested."`
@@ -1896,9 +1896,9 @@ mission "A wolf, a goat, and a cabbage"
 
 mission "Terminus exploration"
 	name "Missing drone"
-	description "Travel to the Terminus system to see if you can find any sign of a probe drone that had been launched by a team of scientists before they were attacked by pirates and forced to flee."
-	source Bounty
-	waypoint Terminus
+	description "Travel to the <waypoints> system to see if you can find any sign of a probe drone that had been launched by a team of scientists before they were attacked by pirates and forced to flee."
+	source "Bounty"
+	waypoint "Terminus"
 	to offer
 		"combat rating" > 20
 	on offer
@@ -1919,14 +1919,14 @@ mission "Terminus exploration"
 			`	"Thank you so much!" he says. "All I need you to do is board the drone and download its database. Unless the pirates have already stripped out the computer, of course. The drone is in the Terminus system, a few jumps away from here."`
 				accept
 	npc assist
-		system Terminus
-		government Uninhabited
+		system "Terminus"
+		government "Uninhabited"
 		personality derelict target
 		ship "Science Drone" "Beagle"
 		dialog `You board the science drone and discover that the pirates have stripped just about everything of value from it: the engines, the sensors, and the fuel cell that powered it. But the computer system is either too deeply integrated into the drone, or too specialized, to be of any value to the pirates. You transfer enough power to the drone's batteries to reactivate it, and are able to retrieve the data that the scientist was looking for. But it's clear that this drone, or what's left of it, is not going anywhere. You'll have to leave it behind.`
 	npc
-		system Terminus
-		government Pirate
+		system "Terminus"
+		government "Pirate"
 		personality staying
 		fleet "Small Southern Pirates" 2
 	on complete

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -682,7 +682,7 @@ event "wanderers: kashikt battle begins"
 
 event "wanderers: kashikt battle ends"
 	system "Kashikt"
-		fleet Quarg 1000
+		fleet "Quarg" 1000
 		fleet "Large Quarg" 2000
 		fleet "Kor Efret Home" 1000
 
@@ -1789,7 +1789,7 @@ mission "Wanderers: Sestor Search: Human Spaceport"
 	invisible
 	source
 		government Republic "Free Worlds" Syndicate Neutral
-		attributes north
+		attributes "north"
 	to offer
 		has "Wanderers: Sestor Search: active"
 	on offer
@@ -2614,7 +2614,7 @@ mission "Wanderers: Sestor: Kill Southern Remnant"
 
 mission "Wanderers: Sestor: Remnant Visit"
 	landing
-	source Farpoint
+	source "Farpoint"
 	to offer
 		has "Wanderers: Sestor: Kill Southern Remnant: active"
 		not "Wanderers: Sestor: Scattered Remnant: done"
@@ -3246,7 +3246,7 @@ event "wanderers: sabira eseskrai colony"
 	system "Furmeliki"
 		add fleet "Kor Efret Home" 800
 	planet "Sabira Eseskrai"
-		add attributes wanderer
+		add attributes "wanderer"
 		description `Long ago, this planet was home to several Korath oil mining settlements, but now all that remains visible are the tops of a few dozen of the tallest buildings. Everything else has been buried by sandstorms.`
 		description `	Due to a recent shift in climate the deserts have begun shrinking once more, with local vegetation growing to cover more and more land each year. The Wanderers, working together with the Kor Efreti, have founded a settlement here and begun working to accelerate the process of rejuvenating the wastelands.`
 		spaceport `This small settlement is populated by a roughly equal number of Korath and Wanderer settlers. Since most of them do not speak each other's language, the two groups do not mingle much, and communicate mostly via gestures and drawings. It's not much, but it's at least a start for the two species to begin learning from each other.`

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -1068,7 +1068,7 @@ mission "Wanderers: Alpha Surveillance D"
 
 mission "Wanderers: Alpha Surveillance D (Avalon)"
 	landing
-	source Avalon
+	source "Avalon"
 	to offer
 		has "Wanderers: Alpha Surveillance D: active"
 	on offer
@@ -1548,7 +1548,7 @@ event "capture of ik'kara'ka"
 		fleet "Small Unfettered" 600
 		fleet "Large Unfettered" 400
 	planet "Varu Mer'ek"
-		attributes unfettered factory
+		attributes "unfettered" "factory"
 		description `This Wanderer factory world was recently captured by the Unfettered Hai, who are now busy trying to repurpose the Wanderer factories and equipment that were left behind, to build more ships for their war fleets. The Wanderers did not have time to demolish any of their equipment or to carry it off-world before the planet was lost. As a result, they have given the Unfettered a significant technological advantage here.`
 		spaceport `The Unfettered seem to be quite at home in the tree house dwellings that the Wanderers left behind, and the Unfettered youth living here scramble up trunks and leap from tree to tree with reckless abandon, exulting in this new world they have captured and trying to outdo each other with their daredevil escapades.`
 		shipyard clear
@@ -2059,7 +2059,7 @@ event "battle for sich'ka'ara ends"
 		fleet "Large Unfettered" 600
 		fleet "Small Unfettered" 600
 	planet "Kort Vek'kri"
-		attributes unfettered
+		attributes "unfettered"
 		spaceport `The Unfettered clearly do not know quite what to make of the Wanderer research station here that they have recently captured. Animals that were once part of various experiments are now wandering loose, and the Unfettered are making only sporadic efforts to keep them well-fed. Every once in a while one of them, driven by sheer hunger, tries to smash its way into one of the crates of military rations that the Unfettered have stacked up in the shade near the main landing pad.`
 	fleet "Large Unfettered"
 		add variant 3

--- a/data/wanderers.txt
+++ b/data/wanderers.txt
@@ -670,7 +670,7 @@ event "wanderers: unfettered invasion starts"
 		"attitude toward"
 			"Wanderer" -.01
 	planet "Varu K'est"
-		attributes unfettered
+		attributes "unfettered"
 		description `Varu K'est is a spare, ancient planet of arid plateaus and deep, meandering canyons, with too little rainfall to support any but the hardiest of shrubs. Before the Unfettered invaded, the only Wanderer settlements remaining here were the military bases they had set up to defend their frontier. Now, it is home to an ever-growing number of Unfettered settlements, including many civilians who have come here just for the chance to live on a world that is not overcrowded and polluted.`
 		spaceport `The Unfettered are using the few jump drives they have to ferry more and more of their people into Wanderer space. When each wave of ships arrives here in the spaceport, technicians carefully remove the jump drives from all but a few of them. A few well guarded jump-capable ships then carry those spare jump drives back to Unfettered space, where they are used to bring more ships and people.`
 		shipyard clear
@@ -737,19 +737,19 @@ event "wanderers: more systems lost"
 		fleet "Small Unfettered" 400
 		fleet "Wanderer Defense" 600
 	planet "Vara Ke'stai"
-		attributes unfettered farming
+		attributes "unfettered" "farming"
 		description `The Wanderers worked for years to make this desert world bloom: planting hardy shrubs and cacti that eventually transform the sand into a soil that can hold moisture. In some regions, especially closer to the poles, the deserts have given way to dense forests, but near the equator there are still large stretches of dry and barren sand, broken by the occasional belt of green where a narrow river winds between the dunes.`
 		description `	Now that the Unfettered have taken over control of the planet, it may be only a matter of time before the deserts dominate it once again.`
 		spaceport `The spaceport is in a forest village near the planet's north pole. The landing pads are massive stone monoliths laid on the ground in a nearby clearing. But aside from a few large warehouses at ground level, the village itself is entirely made of tree-houses. Although they are very different from Hai architecture, the Unfettered seem to be quite at home living in the tree-houses, and have not built many of their own structures yet.`
 		outfitter clear
 	planet "Var' Kar'i'i"
-		attributes unfettered urban farming
+		attributes "unfettered" "urban" "farming"
 		description `Of all the worlds that the Unfettered have captured, this is surely the one that the Wanderers will miss the most: a heavily forested planet that was once home to countless small villages and even a few cities. The Unfettered are clearly doing their best to tend the farms here, but they operate on a permaculture system that relies heavily on maintaining a delicate ecological balance, rather than on machines and pesticides.`
 		spaceport `A large number of Unfettered settlers have already arrived here and begun setting up a spaceport village, complete with markets, taverns, and military barracks. To the Unfettered, who have lived their whole lives on worlds where the local ecology is in shambles, this planet must seem like a paradise.`
 		shipyard clear
 		outfitter clear
 	planet "Vara Ke'sok"
-		attributes unfettered fishing
+		attributes "unfettered" "fishing"
 		description `The surface of this world is almost entirely ocean. The Wanderer settlements were built on massive floating algae mats, some of them the size of a small city. Engines are attached to some of these floating villages, allowing them to be slowly propelled from one part of the planet's surface to another, and the only native industries are fishing and seaweed farming.`
 		spaceport `The raft of algae that supports the spaceport is probably at least a dozen meters thick, but flexible enough that it bends as the ocean swells pass underneath, causing individual buildings to rise up or tilt slightly relative to their neighbors. Now that this world has been captured by the Unfettered, nearly all the buildings are empty; it appears that the Hai are not too fond of the idea of inhabiting a water world, so they are using it mostly as a military base.`
 
@@ -869,7 +869,7 @@ event "wanderers: spera anatrusk colony"
 	system Kaliptari
 		government "Wanderer"
 	planet "Spera Anatrusk"
-		attributes wanderer
+		attributes "wanderer"
 		add description `	Hidden deep in a canyon, the Wanderers have begun establishing a military base here.`
 		spaceport `The Wanderers have hollowed out hangars and caves in the soft sandstone walls of this canyon and have begun to build a military base where they can store supplies and repair their ships while trying to decide how best to deal with the new challenges that face them in Korath space.`
 		spaceport `	Oddly enough, they have also found enough time to plant a large garden on a terrace near the base of the canyon, where they are experimenting to find out which plant species will best grow in this arid environment. The Wanderer drive to understand and transform the local ecology is strong, indeed.`
@@ -903,7 +903,7 @@ event "wanderers: desi seledrak"
 	system "Solifar"
 		government "Wanderer"
 	planet "Desi Seledrak"
-		attributes wanderer
+		attributes "wanderer"
 		description `Plumes of soot and ash rise from a cluster of several dozen volcanoes on this planet's main continent, shrouding the planet in a thick layer of clouds and choking out the sunlight. The ruins of several Korath cities and the geometric grids of cleared land surrounding them show that this was once a farming world, but now few plants are able to survive and kilometer-high glaciers have begun creeping down from the poles.`
 		description `	With some help from the Mereti drones, the Wanderers have set up factories here that are pumping out carbon dioxide and methane to warm the atmosphere. In a few decades, the glaciers may start to recede.`
 		spaceport `This odd settlement was built half by the Wanderers and half by the Mereti drones. The layout of the streets is completely chaotic, and they have planted rows of trees and bushes everywhere: some inside greenhouses, and some hardier species out in the open air. The settlement is near the equator, but it is still not particularly warm.`

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -988,13 +988,14 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	subs["<destination>"] = subs["<planet>"] + " in the " + subs["<system>"] + " system";
 	subs["<date>"] = result.deadline.ToString();
 	subs["<day>"] = result.deadline.LongString();
+	// Stopover and waypoint substitutions: iterate by reference to the
+	// pointers so we can check when we're at the very last one in the set.
+	// Stopovers: "<name> in the <system name> system" with "," and "and".
 	if(!result.stopovers.empty())
 	{
 		string planets;
 		const Planet * const *last = &*--result.stopovers.end();
 		int count = 0;
-		// Iterate by reference to the pointers so we can check when we're at
-		// the very last one in the set.
 		for(const Planet * const &planet : result.stopovers)
 		{
 			if(count++)
@@ -1002,6 +1003,20 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 			planets += planet->Name() + " in the " + planet->GetSystem()->Name() + " system";
 		}
 		subs["<stopovers>"] = planets;
+	}
+	// Waypoints: "<system name>" with "," and "and".
+	if(!result.waypoints.empty())
+	{
+		string systems;
+		const System * const *last = &*--result.waypoints.end();
+		int count = 0;
+		for(const System * const &system : result.waypoints)
+		{
+			if(count++)
+				systems += (&system != last) ? ", " : (count > 2 ? ", and " : " and ");
+			systems += system->Name();
+		}
+		subs["<waypoints>"] = systems;
 	}
 	
 	// Instantiate the NPCs. This also fills in the "<npc>" substitution.


### PR DESCRIPTION
Kept it simple so that any desired phrasing can be used:
For a mission with waypoints in Kornephoros and Wei, this substitution would yield:
`"Scout the <waypoints> systems."` - > `"Scout the Kornephoros and Wei systems."`
`"Scout <waypoints>."` -> `"Scout Kornephoros and Wei."`