### PR TITLE
Swapped two FW NPCs to Free Worlds instead of Escort

### DIFF
--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -177,7 +177,7 @@ mission "FW Prisoner Parole"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	npc accompany save
-		government "Escort"
+		government "Free Worlds"
 		personality timid escort
 		ship "Falcon (Heavy)" "F.S. Starry Warrior"
 		ship "Blackbird" "Flight of Fancy"
@@ -217,7 +217,7 @@ mission "FW Prisoner Parole 2"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	npc accompany save
-		government "Escort"
+		government "Free Worlds"
 		personality timid escort
 		ship "Falcon (Heavy)" "F.S. Starry Warrior"
 		ship "Blackbird" "Flight of Fancy"


### PR DESCRIPTION
Due to the temporary ceasefire event applying to all FW-Republic conflict, these escorts can properly belong to the Free Worlds government rather than the player's government, without negatively impacting mission completions.