### PR TITLE
Allow a minimum zoom of 50%

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -40,7 +40,7 @@ using namespace std;
 namespace {
 	// Settings that require special handling.
 	const string ZOOM_FACTOR = "Main zoom factor";
-	const int ZOOM_FACTOR_MIN = 100;
+	const int ZOOM_FACTOR_MIN = 50;
 	const int ZOOM_FACTOR_MAX = 200;
 	const int ZOOM_FACTOR_INCREMENT = 10;
 	const string VIEW_ZOOM_FACTOR = "View zoom factor";

--- a/source/Screen.cpp
+++ b/source/Screen.cpp
@@ -45,7 +45,7 @@ int Screen::Zoom()
 
 void Screen::SetZoom(int percent)
 {
-	ZOOM = max(100, min(200, percent));
+	ZOOM = max(50, min(200, percent));
 	WIDTH = RAW_WIDTH * 100 / ZOOM;
 	HEIGHT = RAW_HEIGHT * 100 / ZOOM;
 }


### PR DESCRIPTION
Currently the minimum allowed main zoom factor is 100%; this patch allows to reduce it down to 50%, for better support of low resolution screens.

E.g. a 3840×2160 screen at 150% zoom is equivalent to 1280×720 at 50% zoom. At this setting outfitter and shipyard icons are already unnecessarily large. 1280×720 at 100% zoom would be equivalent to 3840×2160 screen at 300% zoom, which seems ridiculous.