### PR TITLE
Added a government specifier to a set of ships that did not have one

### DIFF
--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1701,8 +1701,8 @@ mission "FW Rand 1"
 	name "Occupy Zeta Aquilae"
 	description "Take a Free Worlds fleet to Zeta Aquilae, drive away whatever Navy ships are there, and then land on Rand, which has decided to join the Free Worlds."
 	autosave
-	source Dancer
-	destination Rand
+	source "Dancer"
+	destination "Rand"
 	clearance
 	passengers 2
 	blocked "You need a bunk free for Freya (in addition to JJ) to continue this mission."
@@ -1732,7 +1732,8 @@ mission "FW Rand 1"
 				accept
 	
 	npc
-		personality heroic disables
+		government "Free Worlds"
+		personality heroic disables escort
 		ship "Dreadnought" "F.S. Elder"
 		ship "Falcon (Plasma)" "F.S. Reliant"
 		ship "Falcon (Heavy)" "F.S. Bismark"
@@ -1746,14 +1747,14 @@ mission "FW Rand 1"
 		ship "Hawk (Rocket)" "F.S. Echo"
 		ship "Hawk" "F.S. Shadow"
 	npc
-		personality heroic disables
 		government "Free Worlds"
+		personality heroic disables
 		system "Kochab"
 		ship "Dreadnought" "F.S. Linden"
 	
 	npc evade
+		government "Republic"
 		system "Zeta Aquilae"
-		government Republic
 		personality staying heroic
 		fleet 2
 			names "republic capital"


### PR DESCRIPTION
Rather than let these NPCs use the player government, they properly belong to the Free Worlds and have the `escort` personality tag so they are still shown as your "convoy."

Spotted this automatic use of the player government when looking over the mission referred to in #3354 
I highly doubt this PR would resolve any underlying issue there.