### PR TITLE
Allow non-player ships to emit ShipEvent::ASSIST when repairing ships

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -269,19 +269,21 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, bool isVisible)
 	bool hasSucceeded = HasSucceeded(player.GetSystem());
 	bool hasFailed = HasFailed();
 	
-	// Scan events only count if originated by the player.
+	// If this event was "ASSIST", the ship is now known as not disabled.
+	if(type == ShipEvent::ASSIST)
+		actions[ship.get()] &= ~(ShipEvent::DISABLE);
+	
+	// Certain events only count towards the NPC's status if originated by
+	// the player: scanning, boarding, or assisting.
 	if(!event.ActorGovernment()->IsPlayer())
-		type &= ~(ShipEvent::SCAN_CARGO | ShipEvent::SCAN_OUTFITS);
+		type &= ~(ShipEvent::SCAN_CARGO | ShipEvent::SCAN_OUTFITS
+				| ShipEvent::ASSIST | ShipEvent::BOARD);
 	
 	// Apply this event to the ship and any ships it is carrying.
 	actions[ship.get()] |= type;
 	for(const Ship::Bay &bay : ship->Bays())
 		if(bay.ship)
 			actions[bay.ship.get()] |= type;
-	
-	// If this event was "ASSIST", the ship is now known as not disabled.
-	if(type == ShipEvent::ASSIST)
-		actions[ship.get()] &= ~(ShipEvent::DISABLE);
 	
 	// Check if the success status has changed. If so, display a message.
 	if(HasFailed() && !hasFailed && isVisible)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1451,10 +1451,11 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder)
 		return shared_ptr<Ship>();
 	}
 	
-	// Board a ship of your own government to repair/refuel it.
+	// Board a friendly ship, to repair or refuel it.
 	if(!government->IsEnemy(victim->GetGovernment()))
 	{
 		SetShipToAssist(shared_ptr<Ship>());
+		SetTargetShip(shared_ptr<Ship>());
 		bool helped = victim->isDisabled;
 		victim->hull = max(victim->hull, victim->MinimumHull());
 		victim->isDisabled = false;
@@ -1469,7 +1470,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder)
 			pilotError = 120;
 			victim->pilotError = 120;
 		}
-		return autoPlunder ? shared_ptr<Ship>() : victim;
+		return victim;
 	}
 	if(!victim->IsDisabled())
 		return shared_ptr<Ship>();


### PR DESCRIPTION
Refs #3349 

In addition to making sure that random NPCs emit ShipEvent::ASSIST (they already emitted ShipEvent::BOARD), adds ShipEvent::BOARD and ShipEvent::ASSIST to the list of ShipEvents that only count toward NPC completion when performed by the player.

Previously, the player could have a mission that required boarding an NPC, and it would be completed if any ship completed the task (e.g. a pirate job to take some cargo from a Merchant, and a random pirate boarded the ship before the player could).


