### PR TITLE
Avoid creating a passenger reference when 0 passengers are transferred

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -347,6 +347,9 @@ const map<const Mission *, int> &CargoHold::PassengerList() const
 // Transfer ordinary commodities from one cargo hold to another.
 int CargoHold::Transfer(const string &commodity, int amount, CargoHold &to)
 {
+	if(!amount)
+		return 0;
+	
 	// Remove up to the specified tons of cargo from this cargo hold, adding
 	// them to the given cargo hold if possible. If not possible, add the
 	// remainder back to this cargo hold, even if there is not space for it.
@@ -362,6 +365,9 @@ int CargoHold::Transfer(const string &commodity, int amount, CargoHold &to)
 // Transfer outfits from one cargo hold to another.
 int CargoHold::Transfer(const Outfit *outfit, int amount, CargoHold &to)
 {
+	if(!amount)
+		return 0;
+	
 	// Remove up to the specified number of items from this cargo hold, adding
 	// them to the given cargo hold if possible. If not possible, add the
 	// remainder back to this cargo hold, even if there is not space for it.
@@ -413,9 +419,11 @@ int CargoHold::TransferPassengers(const Mission *mission, int amount, CargoHold 
 	if(to.bunks >= 0)
 		amount = max(0, min(amount, to.BunksFree()));
 	
-	passengers[mission] -= amount;
-	to.passengers[mission] += amount;
-	
+	if(amount)
+	{
+		passengers[mission] -= amount;
+		to.passengers[mission] += amount;
+	}
 	return amount;
 }
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -763,10 +763,12 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 		if(event.Type() & ShipEvent::DESTROY)
 		{
 			// Destroyed ships carrying mission cargo result in failed missions.
+			// Mission cargo may have a quantity of zero (i.e. 0 mass).
 			for(const auto &it : event.Target()->Cargo().MissionCargo())
 				failed |= (it.first == this);
+			// If any mission passengers were present, this mission is failed.
 			for(const auto &it : event.Target()->Cargo().PassengerList())
-				failed |= (it.first == this);
+				failed |= (it.first == this && it.second);
 			if(failed)
 				message += "lost. ";
 		}


### PR DESCRIPTION
Refs #3354 

Commit https://github.com/endless-sky/endless-sky/commit/8e0d8167403de689132a08406b9d7f3211beebf4 ended up generating 0-quantity references to outfits, commodities, and passengers.

This PR adds a check for a non-zero passenger quantity before failing a mission, and also takes steps to prevent creating a 0-quantity entry *at all* for commodities, outfits, and passengers.
See https://github.com/endless-sky/endless-sky/issues/3354#issuecomment-349132704 for a destroyed ship's CargoHold instance, on master and before the named commit above. As of this PR, the original behavior is restored.

Test save located [here](https://gist.github.com/bluss/6587944bf49386a12ba1f4ea70e85ad6) courtesy of   @bluss