### PR TITLE
Certain ships should not auto-assist their disabled parent

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -684,7 +684,7 @@ void AI::Step(const PlayerInfo &player)
 			else
 				MoveEscort(*it, command);
 		}
-		else if(parent->IsDisabled())
+		else if(parent->IsDisabled() && !it->CanBeCarried())
 		{
 			// Your parent is disabled, and is in this system. If you have enemy
 			// targets present, fight them. Otherwise, repair your parent.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -690,8 +690,10 @@ void AI::Step(const PlayerInfo &player)
 			// targets present, fight them. Otherwise, repair your parent.
 			if(target)
 				MoveIndependent(*it, command);
-			else
+			else if(!parent->GetPersonality().IsDerelict())
 				it->SetShipToAssist(parent);
+			else
+				CircleAround(*it, command, *parent);
 		}
 		else if(personality.IsStaying())
 			MoveIndependent(*it, command);


### PR DESCRIPTION
While the parent won't ask its carried escort to help it, that escort would discover it has a disabled parent and attempt to assist it when combat ends, or when its own health is low enough that it has no combat target.

This PR removes that behavior, so that only non-carried ships will consider assisting their disabled parent.