### PR TITLE
Implement a ShipEvent queue to allow delayed ShipEvent handling

### DIFF
--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -58,7 +58,9 @@ private:
 	// Go to the given conversation node. If a choice index is given, include
 	// the text of that choice in the conversation history.
 	void Goto(int index, int choice = -1);
-	// Exit this panel and do whatever needs to happen next.
+	// Exit this panel and do whatever needs to happen next, which includes
+	// possibly activating a callback function and, if docked with an NPC,
+	// destroying it or showing the BoardingPanel (if it is hostile).
 	void Exit();
 	// Handle  mouse click on the "ok," "done," or a conversation choice.
 	void ClickName(int side);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -319,7 +319,7 @@ void Engine::Wait()
 
 
 // Begin the next step of calculations.
-void Engine::Step(bool isActive)
+void Engine::Step(const bool isActive)
 {
 	events.swap(eventQueue);
 	eventQueue.clear();
@@ -724,7 +724,9 @@ void Engine::Go()
 
 
 
-const list<ShipEvent> &Engine::Events() const
+// Pass the list of game events to MainPanel for handling by the player, and any
+// UI element generation.
+list<ShipEvent> &Engine::Events()
 {
 	return events;
 }

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -62,12 +62,13 @@ public:
 	void Wait();
 	// Perform all the work that can only be done while the calculation thread
 	// is paused (for thread safety reasons).
-	void Step(bool isActive);
+	void Step(const bool isActive);
 	// Begin the next step of calculations.
 	void Go();
 	
 	// Get any special events that happened in this step.
-	const std::list<ShipEvent> &Events() const;
+	// MainPanel::Step will clear this list.
+	std::list<ShipEvent> &Events();
 	
 	// Draw a frame.
 	void Draw() const;

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -57,7 +57,8 @@ void MainPanel::Step()
 {
 	engine.Wait();
 	
-	// Depending on what UI element is on top, the game is "paused."
+	// Depending on what UI element is on top, the game is "paused." This
+	// checks only already-drawn panels.
 	bool isActive = GetUI()->IsTop(this);
 	
 	// Display any requested panels.
@@ -422,7 +423,7 @@ void MainPanel::StepEvents(bool &isActive)
 		if(!handledFront)
 			player.HandleEvent(event, GetUI());
 		handledFront = true;
-		isActive = GetUI()->IsTop(this);
+		isActive = (GetUI()->Top().get() == this);
 		
 		// If we can't safely display a new UI element (i.e. an active
 		// mission created a UI element), then stop processing events
@@ -452,7 +453,7 @@ void MainPanel::StepEvents(bool &isActive)
 				player.HandleBlockedMissions((event.Type() & ShipEvent::BOARD)
 						? Mission::BOARDING : Mission::ASSISTING, GetUI());
 			// Determine if a Dialog or ConversationPanel is being drawn next frame.
-			isActive = GetUI()->IsTop(this);
+			isActive = (GetUI()->Top().get() == this);
 			
 			if(isActive && (event.Type() == ShipEvent::BOARD) && !event.Target()->IsDestroyed())
 			{

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -57,8 +57,10 @@ void MainPanel::Step()
 {
 	engine.Wait();
 	
+	// Depending on what UI element is on top, the game is "paused."
 	bool isActive = GetUI()->IsTop(this);
 	
+	// Display any requested panels.
 	if(show.Has(Command::MAP))
 	{
 		GetUI()->Push(new MapDetailPanel(player));
@@ -71,7 +73,6 @@ void MainPanel::Step()
 	}
 	else if(show.Has(Command::HAIL))
 		isActive = !ShowHailPanel();
-	
 	show = Command::NONE;
 	
 	// If the player just landed, pop up the planet panel. When it closes, it
@@ -82,6 +83,8 @@ void MainPanel::Step()
 		player.Land(GetUI());
 		isActive = false;
 	}
+	
+	// Display any relevant help/tutorial messages.
 	const Ship *flagship = player.Flagship();
 	if(flagship)
 	{
@@ -99,39 +102,12 @@ void MainPanel::Step()
 	
 	engine.Step(isActive);
 	
-	for(const ShipEvent &event : engine.Events())
-	{
-		const Government *actor = event.ActorGovernment();
-		
-		player.HandleEvent(event, GetUI());
-		if((event.Type() & (ShipEvent::BOARD | ShipEvent::ASSIST)) && isActive && actor->IsPlayer()
-				&& event.Actor().get() == player.Flagship())
-		{
-			// Boarding events are only triggered by your flagship.
-			Mission *mission = player.BoardingMission(event.Target());
-			if(mission)
-				mission->Do(Mission::OFFER, player, GetUI());
-			else if(event.Type() == ShipEvent::BOARD)
-			{
-				GetUI()->Push(new BoardingPanel(player, event.Target()));
-				isActive = false;
-			}
-		}
-		if(event.Type() & (ShipEvent::SCAN_CARGO | ShipEvent::SCAN_OUTFITS))
-		{
-			if(actor->IsPlayer() && isActive)
-				ShowScanDialog(event);
-			else if(event.TargetGovernment()->IsPlayer())
-			{
-				string message = actor->Fine(player, event.Type(), &*event.Target());
-				if(!message.empty())
-				{
-					GetUI()->Push(new Dialog(message));
-					isActive = false;
-				}
-			}
-		}
-	}
+	// Splice new events onto the eventQueue for (eventual) handling. No
+	// other classes use Engine::Events() after Engine::Step() completes.
+	eventQueue.splice(eventQueue.end(), engine.Events());
+	// Handle as many ShipEvents as possible (stopping if no longer active
+	// and updating the isActive flag).
+	StepEvents(isActive);
 	
 	if(isActive)
 		engine.Go();
@@ -189,8 +165,8 @@ void MainPanel::OnCallback()
 	engine.Go();
 	engine.Wait();
 	engine.Step(true);
-	// Start the next step of the simulatip because Step() above still thinks
-	// the planet panel is up and therefore will not start it.
+	// Start the next step of the simulation because Step() above still
+	// thinks the planet panel is up and therefore will not start it.
 	engine.Go();
 }
 
@@ -427,4 +403,86 @@ bool MainPanel::ShowHailPanel()
 		Messages::Add("Unable to send hail: no target selected.");
 	
 	return false;
+}
+
+
+
+// Handle ShipEvents from this and previous Engine::Step calls. Start with the
+// oldest and then process events until any create a new UI element.
+void MainPanel::StepEvents(bool &isActive)
+{
+	while(isActive && !eventQueue.empty())
+	{
+		const ShipEvent &event = eventQueue.front();
+		const Government *actor = event.ActorGovernment();
+		
+		// Pass this event to the player, to update conditions and make
+		// any new UI elements (e.g. an "on enter" dialog) from their
+		// active missions.
+		if(!handledFront)
+			player.HandleEvent(event, GetUI());
+		handledFront = true;
+		isActive = GetUI()->IsTop(this);
+		
+		// If we can't safely display a new UI element (i.e. an active
+		// mission created a UI element), then stop processing events
+		// until the current Conversation or Dialog is resolved. This
+		// will keep the current event in the queue, so we can still
+		// check it for various special cases involving the player.
+		if(!isActive)
+			break;
+		
+		// Handle boarding events.
+		// 1. Boarding an NPC may "complete" it (i.e. "npc board"). Any UI element that
+		// completion created has now closed, possibly destroying the event target.
+		// 2. Boarding an NPC may create a mission (e.g. it thanks you for the repair/refuel,
+		// asks you to complete a quest, bribes you into leaving it alone, or silently spawns
+		// hostile ships). If boarding creates a mission with an "on offer" conversation, the
+		// ConversationPanel will only let the player plunder a hostile NPC if the mission is
+		// declined or deferred - an "accept" is assumed to have bought the NPC its life.
+		// 3. Boarding a hostile NPC that does not display a mission UI element will display
+		// the BoardingPanel, allowing the player to plunder it.
+		if((event.Type() & (ShipEvent::BOARD | ShipEvent::ASSIST)) && actor->IsPlayer()
+				&& !event.Target()->IsDestroyed() && event.Actor().get() == player.Flagship())
+		{
+			Mission *mission = player.BoardingMission(event.Target());
+			if(mission && mission->HasSpace(player))
+				mission->Do(Mission::OFFER, player, GetUI());
+			else if(mission)
+				player.HandleBlockedMissions((event.Type() & ShipEvent::BOARD)
+						? Mission::BOARDING : Mission::ASSISTING, GetUI());
+			// Determine if a Dialog or ConversationPanel is being drawn next frame.
+			isActive = GetUI()->IsTop(this);
+			
+			if(isActive && (event.Type() == ShipEvent::BOARD) && !event.Target()->IsDestroyed())
+			{
+				// Either no mission activated, or the one that did was "silent."
+				GetUI()->Push(new BoardingPanel(player, event.Target()));
+				isActive = false;
+			}
+		}
+		
+		// Handle scan events of or by the player.
+		if(event.Type() & (ShipEvent::SCAN_CARGO | ShipEvent::SCAN_OUTFITS))
+		{
+			if(actor->IsPlayer())
+			{
+				ShowScanDialog(event);
+				isActive = false;
+			}
+			else if(event.TargetGovernment()->IsPlayer())
+			{
+				string message = actor->Fine(player, event.Type(), &*event.Target());
+				if(!message.empty())
+				{
+					GetUI()->Push(new Dialog(message));
+					isActive = false;
+				}
+			}
+		}
+		
+		// Remove the fully-handled event.
+		eventQueue.pop_front();
+		handledFront = false;
+	}
 }

--- a/source/MainPanel.h
+++ b/source/MainPanel.h
@@ -17,6 +17,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Command.h"
 #include "Engine.h"
+#include "ShipEvent.h"
+
+#include <list>
 
 class PlayerInfo;
 class ShipEvent;
@@ -51,12 +54,17 @@ protected:
 private:
 	void ShowScanDialog(const ShipEvent &event);
 	bool ShowHailPanel();
+	void StepEvents(bool &isActive);
 	
 	
 private:
 	PlayerInfo &player;
 	
 	Engine engine;
+	
+	// These are the pending ShipEvents that have yet to be processed.
+	std::list<ShipEvent> eventQueue;
+	bool handledFront = false;
 	
 	Command show;
 	

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -157,7 +157,9 @@ void UI::Pop(const Panel *panel)
 
 
 
-// Check whether the given panel is on top, i.e. is the active one.
+// Check whether the given panel is on top of the existing panels, i.e. is the
+// active one, on this Step. Any panels that have been pushed this Step are not
+// considered.
 bool UI::IsTop(const Panel *panel) const
 {
 	return (!stack.empty() && stack.back().get() == panel);
@@ -165,7 +167,8 @@ bool UI::IsTop(const Panel *panel) const
 
 
 
-// Get the top panel.
+// Get the absolute top panel, even if it is not yet drawn (i.e. was pushed on
+// this Step).
 shared_ptr<Panel> UI::Top() const
 {
 	if(!toPush.empty())

--- a/source/UI.h
+++ b/source/UI.h
@@ -51,9 +51,10 @@ public:
 	// a panel to Pop() itself.
 	void Pop(const Panel *panel);
 	
-	// Check whether the given panel is on top, i.e. is the active one.
+	// Check whether the given panel is on top, i.e. is the active one, out of
+	// all panels that are already drawn on this step.
 	bool IsTop(const Panel *panel) const;
-	// Get the top panel.
+	// Get the top panel, out of all possible panels, including ones not yet drawn.
 	std::shared_ptr<Panel> Top() const;
 	
 	// Delete all the panels and clear the "done" flag.


### PR DESCRIPTION
Refs #3005 ,  #3129 
 - Handling ShipEvents can result in new UI elements.
 - Only one UI element should be created and displayed to the player at a time (i.e. do not display a dialog and the BoardingPanel simultaneously).
 - Callbacks from one UI element from a given ShipEvent may result in status changes that should influence other UI elements created from the same ShipEvent (e.g. if a mission conversation offered upon boarding an NPC results in that NPC's destruction, the player should not be able to plunder said NPC).

This PR does not attempt to fully address the existing issues with boarding missions (as that is done in #3005 ). It does add one tiny bit of #3005, to check that the player has space for a mission offered in space.
This PR does not implement the needed callbacks to the NPC completion step to enable player or NPC death (out of scope). This PR does, however, enable such a callback's effects to be properly handled by the UI: if the NPC dies, the BoardingPanel won't be shown.
