### PR TITLE
NPC "completion" / MissionAction conversations can kill the player and/or NPC

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -69,7 +69,7 @@ BoardingPanel::BoardingPanel(PlayerInfo &player, const shared_ptr<Ship> &victim)
 	
 	// You cannot plunder hand to hand weapons, because they are kept in the
 	// crew's quarters, not mounted on the exterior of the ship. Certain other
-	// outfits are also unplunderable, like mass expansions.
+	// outfits are also unplunderable, like outfits expansions.
 	auto sit = victim->Outfits().begin();
 	auto cit = victim->Cargo().Outfits().begin();
 	while(sit != victim->Outfits().end() || cit != victim->Cargo().Outfits().end())

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -226,7 +226,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 	{
 		// When closing the panel, mark the player dead if their ship was captured.
 		if(playerDied)
-			player.Die(true);
+			player.Die();
 		GetUI()->Pop(this);
 	}
 	else if(playerDied)

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -29,7 +29,8 @@ namespace {
 		{"launch", Conversation::LAUNCH},
 		{"flee", Conversation::FLEE},
 		{"depart", Conversation::DEPART},
-		{"die", Conversation::DIE}
+		{"die", Conversation::DIE},
+		{"explode", Conversation::EXPLODE}
 	};
 	
 	// Get the index of the given special string. 0 means it is "goto", a number
@@ -72,6 +73,7 @@ const int Conversation::LAUNCH;
 const int Conversation::FLEE;
 const int Conversation::DEPART;
 const int Conversation::DIE;
+const int Conversation::EXPLODE;
 
 
 

--- a/source/Conversation.h
+++ b/source/Conversation.h
@@ -37,10 +37,16 @@ public:
 	static const int ACCEPT = -1;
 	static const int DECLINE = -2;
 	static const int DEFER = -3;
-	static const int LAUNCH = -4; // Accept + leave immediately.
-	static const int FLEE = -5; // Decline + leave immediately. 
-	static const int DEPART = -6; // Defer + leave immediately. 
+	// These 3 options force the player to TakeOff (if landed), or cause
+	// the boarded NPCs to explode, in addition to respectively duplicating
+	// the above mission outcomes.
+	static const int LAUNCH = -4;
+	static const int FLEE = -5;
+	static const int DEPART = -6;
+	// The player may simply die (if landed on a planet or captured while
+	// in space), or the flagship might also explode.
 	static const int DIE = -7;
+	static const int EXPLODE = -8;
 	
 	// Check whether the given conversation outcome is one that forces the
 	// player to immediately depart.

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -48,8 +48,8 @@ namespace {
 
 
 // Constructor.
-ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &conversation, const System *system, const Ship *ship)
-	: player(player), conversation(conversation), scroll(0.), system(system)
+ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &conversation, const System *system, const shared_ptr<Ship> ship)
+	: player(player), conversation(conversation), scroll(0.), system(system), ship(ship)
 {
 	// These substitutions need to be applied on the fly as each paragraph of
 	// text is prepared for display.
@@ -346,18 +346,19 @@ void ConversationPanel::Goto(int index, int choice)
 void ConversationPanel::Exit()
 {
 	GetUI()->Pop(this);
-	// If this is a conversation offered from boarding or assisting an NPC,
-	// being forced to leave via LAUNCH, FLEE, or DEPART destroys it. If it
-	// is a hostile NPC and not destroyed, and its mission (e.g. "leave me
-	// alone, here's X as payment") was not accepted, open a BoardingPanel
-	// to allow plundering it - unless you're dead.
-	if(node != Conversation::DIE && player.BoardingShip())
+	// If this is a conversation offered from an NPC, ending it via LAUNCH,
+	// FLEE, or DEPART destroys the NPC. For hostile NPCs that are boarded
+	// and not being destroyed, show the BoardingPanel unless the player is
+	// being killed or the conversation is exiting via ACCEPT.
+	if(node != Conversation::DIE && ship)
 	{
 		if(Conversation::RequiresLaunch(node))
-			player.BoardingShip()->Destroy();
-		else if(player.BoardingShip()->GetGovernment()->IsEnemy()
+			ship->Destroy();
+		// Check that this ship is the player's boarding target, as NPC
+		// completion conversations can result from non-boarding events.
+		else if(ship == player.BoardingShip() && ship->GetGovernment()->IsEnemy()
 				&& node != Conversation::ACCEPT)
-			GetUI()->Push(new BoardingPanel(player, player.BoardingShip()));
+			GetUI()->Push(new BoardingPanel(player, ship));
 	}
 	// Call the exit response (e.g. ACCEPT, DIE) handler, which is usually
 	// PlayerInfo::MissionCallback.

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -355,18 +355,17 @@ void ConversationPanel::Exit()
 	{
 		// A forced-launch ending (LAUNCH, FLEE, or DEPART) destroys any NPC.
 		if(Conversation::RequiresLaunch(node))
-			// TODO: This may need a ShipEvent, but not all instances
-			// are necessarily caused by the player.
 			ship->Destroy();
 		// Only show the BoardingPanel for a hostile NPC that is being boarded.
 		// (NPC completion conversations can result from non-boarding events.)
-		else if(ship->Position().Distance(player.Flagship()->Position()) <= 1.
-				&& ship->GetGovernment()->IsEnemy()
-				&& node != Conversation::ACCEPT)
+		// TODO: Is there a better / more robust boarding check than relative position?
+		else if(node != Conversation::ACCEPT && ship->GetGovernment()->IsEnemy()
+				&& !ship->IsDestroyed() && ship->IsDisabled()
+				&& ship->Position().Distance(player.Flagship()->Position()) <= 1.)
 			GetUI()->Push(new BoardingPanel(player, ship));
 	}
-	// Call the exit response handler (PlayerInfo::MissionCallback)
-	// to manage the conversation's effect on the player's missions.
+	// Call the exit response handler to manage the conversation's effect
+	// on the player's missions, or force takeoff from a planet.
 	if(callback)
 		callback(node);
 }

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -350,7 +350,7 @@ void ConversationPanel::Exit()
 	// FLEE, or DEPART destroys the NPC. For hostile NPCs that are boarded
 	// and not being destroyed, show the BoardingPanel unless the player is
 	// being killed or the conversation is exiting via ACCEPT.
-	if(node != Conversation::DIE && ship)
+	if(node != Conversation::DIE && node != Conversation::EXPLODE && ship)
 	{
 		if(Conversation::RequiresLaunch(node))
 			ship->Destroy();
@@ -361,7 +361,7 @@ void ConversationPanel::Exit()
 			GetUI()->Push(new BoardingPanel(player, ship));
 	}
 	// Call the exit response (e.g. ACCEPT, DIE) handler, which is usually
-	// PlayerInfo::MissionCallback.
+	// PlayerInfo::MissionCallback, but may be PlayerInfo::BasicCallback.
 	if(callback)
 		callback(node);
 }

--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -39,7 +39,7 @@ class System;
 // the panel closes, to report the outcome of the conversation.
 class ConversationPanel : public Panel {
 public:
-	ConversationPanel(PlayerInfo &player, const Conversation &conversation, const System *system = nullptr, const std::shared_ptr<Ship> ship = nullptr);
+	ConversationPanel(PlayerInfo &player, const Conversation &conversation, const System *system = nullptr, const std::shared_ptr<Ship> &ship = nullptr);
 	
 template <class T>
 	void SetCallback(T *t, void (T::*fun)(int));

--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -20,6 +20,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <functional>
 #include <list>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,7 @@ class System;
 // the panel closes, to report the outcome of the conversation.
 class ConversationPanel : public Panel {
 public:
-	ConversationPanel(PlayerInfo &player, const Conversation &conversation, const System *system = nullptr, const Ship *ship = nullptr);
+	ConversationPanel(PlayerInfo &player, const Conversation &conversation, const System *system = nullptr, const std::shared_ptr<Ship> ship = nullptr);
 	
 template <class T>
 	void SetCallback(T *t, void (T::*fun)(int));
@@ -124,6 +125,10 @@ private:
 	// If specified, this is a star system to display with a special big pointer
 	// when the player brings up the map. (Typically a mission destination.)
 	const System *system;
+	// If specified, this is a pointer to the ship that this conversation
+	// acts upon (e.g. the ship failing a "flight check", or the NPC you
+	// have boarded).
+	std::shared_ptr<Ship> ship;
 };
 
 

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -478,7 +478,16 @@ void MainPanel::StepEvents(bool &isActive)
 			// Determine if a Dialog or ConversationPanel is being drawn next frame.
 			isActive = (GetUI()->Top().get() == this);
 			
-			if(isActive && (event.Type() == ShipEvent::BOARD) && !event.Target()->IsDestroyed())
+			// Confirm that this event's target is not destroyed and still an
+			// enemy before showing the BoardingPanel (as a mission NPC's
+			// completion conversation may have allowed it to be destroyed or
+			// captured).
+			// TODO: This BoardingPanel should not be displayed if a mission NPC
+			// completion conversation creates a BoardingPanel for it, or if the
+			// NPC completion conversation ends via `accept,` even if the ship is
+			// still hostile.
+			if(isActive && (event.Type() == ShipEvent::BOARD) && !event.Target()->IsDestroyed()
+					&& event.Target()->GetGovernment()->IsEnemy())
 			{
 				// Either no mission activated, or the one that did was "silent."
 				GetUI()->Push(new BoardingPanel(player, event.Target()));

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -532,14 +532,14 @@ bool Mission::HasFullClearance() const
 
 
 // Check if it's possible to offer or complete this mission right now.
-bool Mission::CanOffer(const PlayerInfo &player) const
+bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardingShip) const
 {
 	if(location == BOARDING || location == ASSISTING)
 	{
-		if(!player.BoardingShip())
+		if(!boardingShip)
 			return false;
 		
-		if(!sourceFilter.Matches(*player.BoardingShip()))
+		if(!sourceFilter.Matches(*boardingShip))
 			return false;
 	}
 	else
@@ -718,7 +718,7 @@ bool Mission::IsUnique() const
 // When the state of this mission changes, it may make changes to the player
 // information or show new UI panels. PlayerInfo::MissionCallback() will be
 // used as the callback for any UI panel that returns a value.
-bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui)
+bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<Ship> &boardingShip)
 {
 	if(trigger == STOPOVER)
 	{
@@ -769,7 +769,7 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui)
 	// if this is a non-job mission that just got offered and if so,
 	// automatically accept it.
 	if(it != actions.end())
-		it->second.Do(player, ui, destination ? destination->GetSystem() : nullptr);
+		it->second.Do(player, ui, destination ? destination->GetSystem() : nullptr, boardingShip);
 	else if(trigger == OFFER && location != JOB)
 		player.MissionCallback(Conversation::ACCEPT);
 	
@@ -854,7 +854,7 @@ const string &Mission::Identifier() const
 
 // "Instantiate" a mission by replacing randomly selected values and places
 // with a single choice, and then replacing any wildcard text as well.
-Mission Mission::Instantiate(const PlayerInfo &player) const
+Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &boardingShip) const
 {
 	Mission result;
 	// If anything goes wrong below, this mission should not be offered.
@@ -1020,8 +1020,8 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	subs["<fare>"] = (result.passengers == 1) ? "a passenger" : (subs["<bunks>"] + " passengers");
 	if(player.GetPlanet())
 		subs["<origin>"] = player.GetPlanet()->Name();
-	else if(player.BoardingShip())
-		subs["<origin>"] = player.BoardingShip()->Name();
+	else if(boardingShip)
+		subs["<origin>"] = boardingShip->Name();
 	subs["<planet>"] = result.destination ? result.destination->Name() : "";
 	subs["<system>"] = result.destination ? result.destination->GetSystem()->Name() : "";
 	subs["<destination>"] = subs["<planet>"] + " in the " + subs["<system>"] + " system";

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -21,6 +21,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 
@@ -99,7 +100,7 @@ public:
 	// check for whether you can offer a mission does not take available space
 	// into account, so before actually offering a mission you should also check
 	// if the player has enough space.
-	bool CanOffer(const PlayerInfo &player) const;
+	bool CanOffer(const PlayerInfo &player, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
 	bool HasSpace(const PlayerInfo &player) const;
 	bool CanComplete(const PlayerInfo &player) const;
 	bool IsSatisfied(const PlayerInfo &player) const;
@@ -121,10 +122,10 @@ public:
 	
 	// When the state of this mission changes, it may make changes to the player
 	// information or show new UI panels. PlayerInfo::MissionCallback() will be
-	// used as the callback for any UI panel that returns a value. If it is not
-	// possible for this change to happen, this function returns false.
+	// used as the callback for an `on offer` conversation, to handle its response.
+	// If it is not possible for this change to happen, this function returns false.
 	enum Trigger {COMPLETE, OFFER, ACCEPT, DECLINE, FAIL, DEFER, VISIT, STOPOVER};
-	bool Do(Trigger trigger, PlayerInfo &player, UI *ui = nullptr);
+	bool Do(Trigger trigger, PlayerInfo &player, UI *ui = nullptr, const std::shared_ptr<Ship> &boardingShip = nullptr);
 	
 	// Get a list of NPCs associated with this mission. Every time the player
 	// takes off from a planet, they should be added to the active ships.
@@ -140,7 +141,7 @@ public:
 	
 	// "Instantiate" a mission by replacing randomly selected values and places
 	// with a single choice, and then replacing any wildcard text as well.
-	Mission Instantiate(const PlayerInfo &player) const;
+	Mission Instantiate(const PlayerInfo &player, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
 	
 	
 private:

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -345,7 +345,9 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination) co
 	bool isOffer = (trigger == "offer");
 	if(!conversation.IsEmpty() && ui)
 	{
-		ConversationPanel *panel = new ConversationPanel(player, conversation, destination);
+		// If the player is boarding a ship, reference that ship (so it may offer
+		// substitutions and possibly even be destroyed by the player's actions).
+		ConversationPanel *panel = new ConversationPanel(player, conversation, destination, player.BoardingShip());
 		if(isOffer)
 			panel->SetCallback(&player, &PlayerInfo::MissionCallback);
 		// Use a basic callback to handle forced departure outside of `on offer`

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -340,18 +340,18 @@ bool MissionAction::CanBeDone(const PlayerInfo &player) const
 
 
 
-void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination) const
+void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, const shared_ptr<Ship> &ship) const
 {
 	bool isOffer = (trigger == "offer");
 	if(!conversation.IsEmpty() && ui)
 	{
-		// If the player is boarding a ship, reference that ship (so it may offer
-		// substitutions and possibly even be destroyed by the player's actions).
-		ConversationPanel *panel = new ConversationPanel(player, conversation, destination, player.BoardingShip());
+		// Conversations offered while boarding or assisting reference a ship,
+		// which may be destroyed depending on the player's choices.
+		ConversationPanel *panel = new ConversationPanel(player, conversation, destination, ship);
 		if(isOffer)
 			panel->SetCallback(&player, &PlayerInfo::MissionCallback);
 		// Use a basic callback to handle forced departure outside of `on offer`
-		// conversations, and allow this MissionAction the ability to kill the player.
+		// conversations.
 		else
 			panel->SetCallback(&player, &PlayerInfo::BasicCallback);
 		ui->Push(panel);

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -351,7 +351,7 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination) co
 		if(isOffer)
 			panel->SetCallback(&player, &PlayerInfo::MissionCallback);
 		// Use a basic callback to handle forced departure outside of `on offer`
-		// conversations.
+		// conversations, and allow this MissionAction the ability to kill the player.
 		else
 			panel->SetCallback(&player, &PlayerInfo::BasicCallback);
 		ui->Push(panel);

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "LocationFilter.h"
 
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <utility>
@@ -27,6 +28,7 @@ class DataWriter;
 class GameEvent;
 class Outfit;
 class PlayerInfo;
+class Ship;
 class System;
 class UI;
 
@@ -55,7 +57,7 @@ public:
 	bool CanBeDone(const PlayerInfo &player) const;
 	// Perform this action. If a conversation is shown, the given destination
 	// will be highlighted in the map if you bring it up.
-	void Do(PlayerInfo &player, UI *ui = nullptr, const System *destination = nullptr) const;
+	void Do(PlayerInfo &player, UI *ui = nullptr, const System *destination = nullptr, const std::shared_ptr<Ship> &ship = nullptr) const;
 	
 	// "Instantiate" this action by filling in the wildcard text for the actual
 	// destination, payment, cargo, etc.

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -296,8 +296,12 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, bool isVisible)
 		Messages::Add("Mission failed.");
 	else if(ui && HasSucceeded(player.GetSystem()) && !hasSucceeded)
 	{
+		// If completing this NPC displays a conversation, reference it.
+		// This allows the target of `npc board` to be destroyed before
+		// the player can plunder it. (A BoardingPanel will not be shown
+		// unless the player is truly boarding the referenced NPC.)
 		if(!conversation.IsEmpty())
-			ui->Push(new ConversationPanel(player, conversation));
+			ui->Push(new ConversationPanel(player, conversation, nullptr, ship));
 		else if(!dialogText.empty())
 			ui->Push(new Dialog(dialogText));
 	}

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -301,7 +301,15 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, bool isVisible)
 		// the player can plunder it. (A BoardingPanel will not be shown
 		// unless the player is truly boarding the referenced NPC.)
 		if(!conversation.IsEmpty())
-			ui->Push(new ConversationPanel(player, conversation, nullptr, ship));
+		{
+			if((type & (ShipEvent::BOARD | ShipEvent::ASSIST))
+					&& event.Actor().get() == player.Flagship())
+				player.SetBoardingShip(ship);
+			
+			ConversationPanel *panel = new ConversationPanel(player, conversation, nullptr, ship);
+			panel->SetCallback(&player, &PlayerInfo::BasicCallback);
+			ui->Push(panel);
+		}
 		else if(!dialogText.empty())
 			ui->Push(new Dialog(dialogText));
 	}

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -296,20 +296,10 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, bool isVisible)
 		Messages::Add("Mission failed.");
 	else if(ui && HasSucceeded(player.GetSystem()) && !hasSucceeded)
 	{
-		// If completing this NPC displays a conversation, reference it.
-		// This allows the target of `npc board` to be destroyed before
-		// the player can plunder it. (A BoardingPanel will not be shown
-		// unless the player is truly boarding the referenced NPC.)
+		// If "completing" this NPC displays a conversation, reference
+		// it, to allow the completing event's target to be destroyed.
 		if(!conversation.IsEmpty())
-		{
-			if((type & (ShipEvent::BOARD | ShipEvent::ASSIST))
-					&& event.Actor().get() == player.Flagship())
-				player.SetBoardingShip(ship);
-			
-			ConversationPanel *panel = new ConversationPanel(player, conversation, nullptr, ship);
-			panel->SetCallback(&player, &PlayerInfo::BasicCallback);
-			ui->Push(panel);
-		}
+			ui->Push(new ConversationPanel(player, conversation, nullptr, ship));
 		else if(!dialogText.empty())
 			ui->Push(new Dialog(dialogText));
 	}

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -246,7 +246,7 @@ void PlanetPanel::TakeOffIfReady()
 		if(!check.empty() && check.back() == '!')
 		{
 			GetUI()->Push(new ConversationPanel(player,
-				*GameData::Conversations().Get("flight check: " + check), nullptr, ship.get()));
+				*GameData::Conversations().Get("flight check: " + check), nullptr, ship));
 			return;
 		}
 	}

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -75,7 +75,7 @@ public:
 	void AddEvent(const GameEvent &event, const Date &date);
 	
 	// Mark the player as dead, or check if they have died.
-	void Die(bool allShipsDie = false);
+	void Die(int response = 0);
 	bool IsDead() const;
 	
 	// Get or set the player's name.
@@ -264,7 +264,6 @@ private:
 	
 	// Check that this player's current state can be saved.
 	bool CanBeSaved() const;
-	void Die(int response);
 	
 	
 private:

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -156,6 +156,7 @@ public:
 	Mission *MissionToOffer(Mission::Location location);
 	Mission *BoardingMission(const std::shared_ptr<Ship> &ship);
 	const std::shared_ptr<Ship> &BoardingShip() const;
+	void SetBoardingShip(const std::shared_ptr<Ship> &ship);
 	// If one of your missions cannot be offered because you do not have enough
 	// space for it, and it specifies a message to be shown in that situation,
 	// show that message.
@@ -263,6 +264,7 @@ private:
 	
 	// Check that this player's current state can be saved.
 	bool CanBeSaved() const;
+	void Die(int response);
 	
 	
 private:

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -75,7 +75,7 @@ public:
 	void AddEvent(const GameEvent &event, const Date &date);
 	
 	// Mark the player as dead, or check if they have died.
-	void Die(int response = 0);
+	void Die(int response = 0, const std::shared_ptr<Ship> &capturer = nullptr);
 	bool IsDead() const;
 	
 	// Get or set the player's name.
@@ -155,8 +155,6 @@ public:
 	// Check to see if there is any mission to offer in the spaceport right now.
 	Mission *MissionToOffer(Mission::Location location);
 	Mission *BoardingMission(const std::shared_ptr<Ship> &ship);
-	const std::shared_ptr<Ship> &BoardingShip() const;
-	void SetBoardingShip(const std::shared_ptr<Ship> &ship);
 	// If one of your missions cannot be offered because you do not have enough
 	// space for it, and it specifies a message to be shown in that situation,
 	// show that message.
@@ -250,7 +248,7 @@ private:
 	void ApplyChanges();
 	
 	// New missions are generated each time you land on a planet.
-	void UpdateAutoConditions();
+	void UpdateAutoConditions(bool isBoarding = false);
 	void CreateMissions();
 	void StepMissions(UI *ui);
 	void Autosave() const;
@@ -296,7 +294,6 @@ private:
 	std::list<Mission> availableJobs;
 	std::list<Mission> availableMissions;
 	std::list<Mission> boardingMissions;
-	std::shared_ptr<Ship> boardingShip;
 	std::list<Mission> doneMissions;
 	
 	std::map<std::string, int> conditions;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2102,6 +2102,8 @@ double Ship::TransferFuel(double amount, Ship *to)
 
 
 
+// Convert this ship from one government to another, as a result of boarding
+// actions (if the player is capturing) or player death (poor decision-making).
 void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 {
 	// Repair up to the point where this ship is just barely not disabled.
@@ -2114,11 +2116,11 @@ void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 	// Transfer some crew over. Only transfer the bare minimum unless even that
 	// is not possible, in which case, share evenly.
 	int totalRequired = capturer->RequiredCrew() + RequiredCrew();
-	int transfer = RequiredCrew();
-	if(transfer)
+	int transfer = RequiredCrew() - crew;
+	if(transfer > 0)
 	{
-		if(totalRequired > capturer->Crew())
-			transfer = max(1, (capturer->Crew() * RequiredCrew()) / totalRequired);
+		if(totalRequired > capturer->Crew() + crew)
+			transfer = max(crew ? 0 : 1, (capturer->Crew() * transfer) / totalRequired);
 		capturer->AddCrew(-transfer);
 		AddCrew(transfer);
 	}


### PR DESCRIPTION
Refs #3206 , #3129, #3228 

 - Adds a new player-death keyword, `explode`, to resolve the ambiguity over how the player dies while in space
   - If the player's ship should be destroyed, use `explode`. The flagship will explode.
   - If the player's ship should be captured, use `die`. The player dies, and his ship is taken over by the ship it was boarding. (If `die` is used and there is no boarding ship, the flagship changes government, simulating a mutiny.)
 - If you're dying as a result of a conversation, you aren't going to be shown the BoardingPanel
 - `launch`, `depart`, and `flee` kill the NPC associated with a conversation, even if not boarded (say, if your outfit scan activated some embedded explosives' trigger mechanism...), unless you're dying too.