### PR TITLE
Refactor MapPanel's Draw___ methods

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -64,6 +64,15 @@ color "radar blink" 1. 1. 1. 0.
 color "error back" .25 .1 .1 1.
 color "warning back" .21 .18 .08 1.
 
+color "map link" .6, .6, .6, .6
+color "map name" .6, .6, .6, .6
+color "map travel ok fleet" .2, .5, 0., 0.
+color "map travel ok flagship" .5, .4, 0., 0.
+color "map travel ok none" .55, .1, 0., 0.
+color "map used wormhole" .5, .2, .9, 1.
+color "map unused wormhole" .165, .066, .3, .333
+
+
 
 
 interface "menu background"
@@ -261,6 +270,12 @@ interface "preferences"
 
 
 
+interface "mini-map" top
+	point "origin"
+		center 0 100
+
+
+
 interface "hud"
 	# Player status.
 	anchor top right
@@ -316,7 +331,7 @@ interface "hud"
 	sprite "ui/radar"
 		from 0 0
 		align top left
-	point radar
+	point "radar"
 		center 128 128
 	value "radar radius" 110
 	value "radar pointer radius" 130
@@ -336,7 +351,7 @@ interface "hud"
 	sprite "ui/target"
 		from 0 240
 		align top left
-	point target
+	point "target"
 		center 75 315
 		dimensions 140 140
 	value "target radius" 70

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -270,12 +270,6 @@ interface "preferences"
 
 
 
-interface "mini-map" top
-	point "origin"
-		center 0 100
-
-
-
 interface "hud"
 	# Player status.
 	anchor top right
@@ -420,6 +414,10 @@ interface "hud"
 	box "ammo"
 		from -110 450 top right
 		to 0 0 bottom right
+	anchor top
+	point "mini-map"
+		center 0 150
+
 
 
 

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -523,7 +523,8 @@ void MapDetailPanel::DrawInfo()
 		uiPoint.Y() += 20.;
 	}
 	
-	if(selectedPlanet && !selectedPlanet->Description().empty() && player.HasVisited(selectedPlanet))
+	if(selectedPlanet && !selectedPlanet->Description().empty()
+			&& player.HasVisited(selectedPlanet) && !selectedPlanet->IsWormhole())
 	{
 		static const int X_OFFSET = 240;
 		static const int WIDTH = 500;

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -142,7 +142,7 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, double alpha, const System 
 	const Font &font = FontSet::Get(14);
 	Color lineColor(alpha, 0.);
 	Point center = .5 * (jump[0]->Position() + jump[1]->Position());
-	const Point &drawPos = GameData::Interfaces().Get("mini-map")->GetPoint("origin");
+	const Point &drawPos = GameData::Interfaces().Get("hud")->GetPoint("mini-map");
 	set<const System *> drawnSystems = { jump[0], jump[1] };
 	bool isLink = jump[0]->Links().count(jump[1]);
 	

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -51,6 +51,9 @@ using namespace std;
 
 const double MapPanel::OUTER = 6.;
 const double MapPanel::INNER = 3.5;
+const double MapPanel::LINK_WIDTH = 1.2;
+// Draw links only outside the system ring, which has radius MapPanel::OUTER.
+const double MapPanel::LINK_OFFSET = 7.;
 
 
 
@@ -83,8 +86,6 @@ void MapPanel::Draw()
 	if(Preferences::Has("Hide unexplored map regions"))
 		FogShader::Draw(center, Zoom(), player);
 	
-	DrawTravelPlan();
-	
 	// Draw the "visible range" circle around your current location.
 	Color dimColor(.1, 0.);
 	RingShader::Draw(Zoom() * (playerSystem ? playerSystem->Position() + center : center),
@@ -93,7 +94,9 @@ void MapPanel::Draw()
 	RingShader::Draw(Zoom() * (selectedSystem ? selectedSystem->Position() + center : center),
 		11., 9., brightColor);
 	
+	++step;
 	DrawWormholes();
+	DrawTravelPlan();
 	DrawLinks();
 	DrawSystems();
 	DrawNames();
@@ -139,54 +142,59 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, double alpha, const System 
 	const Font &font = FontSet::Get(14);
 	Color lineColor(alpha, 0.);
 	Point center = .5 * (jump[0]->Position() + jump[1]->Position());
-	Point drawPos(0., Screen::Top() + 100.);
-	set<const System *> seen;
-	bool isLink = false;
-
-	const Set<Color> &colors = GameData::Colors();
-	Color currentColor = colors.Get("active mission")->Additive(alpha * 2.);
-	Color blockedColor = colors.Get("blocked mission")->Additive(alpha * 2.);
-	Color waypointColor = colors.Get("waypoint")->Additive(alpha * 2.);
+	const Point &drawPos = GameData::Interfaces().Get("mini-map")->GetPoint("origin");
+	set<const System *> drawnSystems = { jump[0], jump[1] };
+	bool isLink = jump[0]->Links().count(jump[1]);
 	
+	const Set<Color> &colors = GameData::Colors();
+	const Color &currentColor = colors.Get("active mission")->Additive(alpha * 2.);
+	const Color &blockedColor = colors.Get("blocked mission")->Additive(alpha * 2.);
+	const Color &waypointColor = colors.Get("waypoint")->Additive(alpha * 2.);
+	
+	const Ship *flagship = player.Flagship();
 	for(int i = 0; i < 2; ++i)
 	{
+		static const string UNKNOWN_SYSTEM = "Unexplored System";
 		const System *system = jump[i];
 		const Government *gov = system->GetGovernment();
-		bool isKnown = player.KnowsName(system);
 		Point from = system->Position() - center + drawPos;
-		string name = isKnown ? system->Name() : "Unexplored System";
-		font.Draw(name, from + Point(6., -.5 * font.Height()), lineColor);
+		const string &name = player.KnowsName(system) ? system->Name() : UNKNOWN_SYSTEM;
+		font.Draw(name, from + Point(OUTER, -.5 * font.Height()), lineColor);
 		
+		// Draw the origin and destination systems, since they
+		// might not be linked via hyperspace.
 		Color color = Color(.5 * alpha, 0.);
-		if(player.HasVisited(system) && system->IsInhabited(player.Flagship()) && gov)
+		if(player.HasVisited(system) && system->IsInhabited(flagship) && gov)
 			color = Color(
 				alpha * gov->GetColor().Get()[0],
 				alpha * gov->GetColor().Get()[1],
 				alpha * gov->GetColor().Get()[2], 0.);
-		RingShader::Draw(from, 6., 3.5, color);
+		RingShader::Draw(from, OUTER, INNER, color);
 		
 		for(const System *link : system->Links())
 		{
+			// Only draw systems known to be attached to the jump systems.
 			if(!player.HasVisited(system) && !player.HasVisited(link))
 				continue;
 			
+			// Draw the system link. This will double-draw the jump
+			// path if it is via hyperlink, to increase brightness.
 			Point to = link->Position() - center + drawPos;
-			Point unit = (from - to).Unit() * 7.;
-			LineShader::Draw(from - unit, to + unit, 1.2, lineColor);
+			Point unit = (from - to).Unit() * LINK_OFFSET;
+			LineShader::Draw(from - unit, to + unit, LINK_WIDTH, lineColor);
 			
-			isLink |= (link == jump[!i]);
-			if(seen.count(link) || link == jump[!i])
+			if(drawnSystems.count(link))
 				continue;
-			seen.insert(link);
+			drawnSystems.insert(link);
 			
 			gov = link->GetGovernment();
 			Color color = Color(.5 * alpha, 0.);
-			if(player.HasVisited(link) && link->IsInhabited(player.Flagship()) && gov)
+			if(player.HasVisited(link) && link->IsInhabited(flagship) && gov)
 				color = Color(
 					alpha * gov->GetColor().Get()[0],
 					alpha * gov->GetColor().Get()[1],
 					alpha * gov->GetColor().Get()[2], 0.);
-			RingShader::Draw(to, 6., 3.5, color);
+			RingShader::Draw(to, OUTER, INNER, color);
 		}
 		
 		Angle angle;
@@ -220,12 +228,15 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, double alpha, const System 
 		}
 	}
 	
+	// Draw the rest of the directional arrow. If this is a normal jump,
+	// the stem was already drawn above.
 	Point from = jump[0]->Position() - center + drawPos;
 	Point to = jump[1]->Position() - center + drawPos;
 	Point unit = (to - from).Unit();
-	from += 7. * unit;
-	to -= 7. * unit;
+	from += LINK_OFFSET * unit;
+	to -= LINK_OFFSET * unit;
 	Color bright(2. * alpha, 0.);
+	// Non-hyperspace jumps are drawn with a dashed directional arrow.
 	if(!isLink)
 	{
 		double length = (to - from).Length();
@@ -234,10 +245,10 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, double alpha, const System 
 			LineShader::Draw(
 				from + unit * ((i * length) / segments + 2.),
 				from + unit * (((i + 1) * length) / segments - 2.),
-				1.2, bright);
+				LINK_WIDTH, bright);
 	}
-	LineShader::Draw(to, to + Angle(-30.).Rotate(unit) * -10., 1.2, bright);
-	LineShader::Draw(to, to + Angle(30.).Rotate(unit) * -10., 1.2, bright);
+	LineShader::Draw(to, to + Angle(-30.).Rotate(unit) * -10., LINK_WIDTH, bright);
+	LineShader::Draw(to, to + Angle(30.).Rotate(unit) * -10., LINK_WIDTH, bright);
 }
 
 
@@ -416,18 +427,19 @@ void MapPanel::Select(const System *system)
 		return;
 	selectedSystem = system;
 	vector<const System *> &plan = player.TravelPlan();
-	if(!player.Flagship() || (!plan.empty() && system == plan.front()))
+	Ship *flagship = player.Flagship();
+	if(!flagship || (!plan.empty() && system == plan.front()))
 		return;
 	
-	bool isJumping = player.Flagship()->IsEnteringHyperspace();
-	const System *source = isJumping ? player.Flagship()->GetTargetSystem() : player.GetSystem();
+	bool isJumping = flagship->IsEnteringHyperspace();
+	const System *source = isJumping ? flagship->GetTargetSystem() : playerSystem;
 	
 	bool shift = (SDL_GetModState() & KMOD_SHIFT) && !plan.empty();
 	if(system == source && !shift)
 	{
 		plan.clear();
 		if(!isJumping)
-			player.Flagship()->SetTargetSystem(nullptr);
+			flagship->SetTargetSystem(nullptr);
 		else
 			plan.push_back(source);
 	}
@@ -448,7 +460,7 @@ void MapPanel::Select(const System *system)
 	{
 		plan.clear();
 		if(!isJumping)
-			player.Flagship()->SetTargetSystem(nullptr);
+			flagship->SetTargetSystem(nullptr);
 		
 		while(system != source)
 		{
@@ -538,16 +550,18 @@ void MapPanel::DrawTravelPlan()
 	if(!playerSystem)
 		return;
 	
-	Color defaultColor(.5, .4, 0., 0.);
-	Color outOfFlagshipFuelRangeColor(.55, .1, .0, 0.);
-	Color withinFleetFuelRangeColor(.2, .5, .0, 0.);
-	Color wormholeColor(0.5, 0.2, 0.9, 1.);
+	const Set<Color> &colors = GameData::Colors();
+	const Color &defaultColor = *colors.Get("map travel ok flagship");
+	const Color &outOfFlagshipFuelRangeColor = *colors.Get("map travel ok none");
+	const Color &withinFleetFuelRangeColor = *colors.Get("map travel ok fleet");
+	const Color &wormholeColor = *colors.Get("map used wormhole");
 	
-	// At each point in the path, we'll keep track of how many ships in the
+	// At each point in the path, keep track of how many ships in the
 	// fleet are able to make it this far.
-	Ship *flagship = player.Flagship();
+	const Ship *flagship = player.Flagship();
 	if(!flagship)
 		return;
+	
 	bool stranded = false;
 	bool hasEscort = false;
 	map<const Ship *, double> fuel;
@@ -581,7 +595,7 @@ void MapPanel::DrawTravelPlan()
 		if(!isHyper && !isJump && !isWormhole)
 			break;
 		
-		// Wormholes cost nothing to grow through. If this is not a wormhole,
+		// Wormholes cost nothing to go through. If this is not a wormhole,
 		// check how much fuel every ship will expend to go through it.
 		if(!isWormhole)
 			for(auto &it : fuel)
@@ -609,7 +623,7 @@ void MapPanel::DrawTravelPlan()
 		
 		Point from = Zoom() * (next->Position() + center);
 		Point to = Zoom() * (previous->Position() + center);
-		Point unit = (from - to).Unit() * 7.;
+		Point unit = (from - to).Unit() * LINK_OFFSET;
 		LineShader::Draw(from - unit, to + unit, 3., drawColor);
 		
 		previous = next;
@@ -620,49 +634,89 @@ void MapPanel::DrawTravelPlan()
 
 void MapPanel::DrawWormholes()
 {
-	Color wormholeColor(0.5, 0.2, 0.9, 1.);
-	Color wormholeDimColor(0.5 / 3., 0.2 / 3., 0.9 / 3., 1.);
-	const double wormholeWidth = 1.2;
-	const double wormholeLength = 4.;
-	const double wormholeArrowHeadRatio = .3;
-	
-	map<const System *, const System *> drawn;
-	for(const auto &it : GameData::Systems())
+	// Drawlist of links, in "from -> to" order. Track whether the arrow is on one or both ends.
+	map<pair<const System *, const System *>, bool> toDraw;
+	// Avoid iterating each StellarObject in every system by iterating over planets instead. A
+	// system can host more than one set of wormholes (e.g. Cardea), and some wormholes may even
+	// share a link vector. If a wormhole's planet has no description, no link will be drawn.
+	for(const auto &it : GameData::Planets())
 	{
-		const System *previous = &it.second;
-		for(const StellarObject &object : previous->Objects())
-			if(object.GetPlanet() && object.GetPlanet()->IsWormhole() && player.HasVisited(object.GetPlanet()))
+		if(!it.second.IsWormhole() || !player.HasVisited(&it.second) || it.second.Description().empty())
+			continue;
+		
+		const vector<const System *> &waypoints = it.second.WormholeSystems();
+		for(auto it = waypoints.begin(); it != waypoints.end(); )
+		{
+			const System *from = *it++;
+			if(!player.HasVisited(from))
+				continue;
+			
+			const System *to = it != waypoints.end() ? *it
+					: (waypoints.size() > 2 ? waypoints.front() : nullptr);
+			if(to)
 			{
-				// Wormholes with no description should not be drawn.
-				if(object.GetPlanet()->Description().empty())
-					continue;
-				
-				const System *next = object.GetPlanet()->WormholeDestination(previous);
-				// Only draw a wormhole if both systems have been visited.
-				if(!player.HasVisited(previous) || !player.HasVisited(next))
-					continue;
-				
-				drawn[previous] = next;
-				Point from = Zoom() * (previous->Position() + center);
-				Point to = Zoom() * (next->Position() + center);
-				Point unit = (from - to).Unit() * 7.;
-				from -= unit;
-				to += unit;
-				
-				Angle left(45.);
-				Angle right(-45.);
-				
-				Point wormholeUnit = Zoom() * wormholeLength * unit;
-				Point arrowLeft = left.Rotate(wormholeUnit * wormholeArrowHeadRatio);
-				Point arrowRight = right.Rotate(wormholeUnit * wormholeArrowHeadRatio);
-				
-				// Don't double-draw the links.
-				if(drawn[next] != previous)
-					LineShader::Draw(from, to, wormholeWidth, wormholeDimColor);
-				LineShader::Draw(from - wormholeUnit + arrowLeft, from - wormholeUnit, wormholeWidth, wormholeColor);
-				LineShader::Draw(from - wormholeUnit + arrowRight, from - wormholeUnit, wormholeWidth, wormholeColor);
-				LineShader::Draw(from, from - (wormholeUnit + Zoom() * 0.1 * unit), wormholeWidth, wormholeColor);
+				// This link is any part of a one-way wormhole, or the outgoing leg of a
+				// two-way wormhole. It may also be the reverse of an existing, separate
+				// wormhole, in which case that one should be drawn bidirectional.
+				if(player.HasVisited(to))
+				{
+					const pair<const System *, const System *> link = make_pair(to, from);
+					const auto &it = toDraw.find(link);
+					if(it == toDraw.end())
+						toDraw.emplace(make_pair(from, to), false);
+					else
+						it->second = true;
+				}
 			}
+			else
+			{
+				// This is the return leg of a two-way wormhole.
+				// Find and flag the first leg as bidirectional.
+				const pair<const System *, const System *> link = make_pair(waypoints.front(), from);
+				const auto &it = toDraw.find(link);
+				if(it != toDraw.end())
+					it->second = true;
+			}
+		}
+	}
+	
+	const Color &wormholeDim = *GameData::Colors().Get("map unused wormhole");
+	const Color &arrowColor = *GameData::Colors().Get("map used wormhole");
+	static const double ARROW_LENGTH = 4.;
+	static const double ARROW_RATIO = .3;
+	static const Angle LEFT(30.);
+	static const Angle RIGHT(-30.);
+	const double zoom = Zoom();
+	
+	for(const auto &link : toDraw)
+	{
+		// Compute the start and end positions of the wormhole link.
+		Point from = zoom * (link.first.first->Position() + center);
+		Point to = zoom * (link.first.second->Position() + center);
+		Point offset = (from - to).Unit() * LINK_OFFSET;
+		from -= offset;
+		to += offset;
+		
+		// Compute the start and end positions of the arrow edges.
+		Point arrowStem = zoom * ARROW_LENGTH * offset;
+		Point arrowLeft = arrowStem - ARROW_RATIO * LEFT.Rotate(arrowStem);
+		Point arrowRight = arrowStem - ARROW_RATIO * RIGHT.Rotate(arrowStem);
+		
+		// Draw the link.
+		LineShader::Draw(from, to, LINK_WIDTH, wormholeDim);
+		// Draw the from->to arrowhead.
+		Point fromTip = from - arrowStem;
+		LineShader::Draw(from, fromTip, LINK_WIDTH, arrowColor);
+		LineShader::Draw(from - arrowLeft, fromTip, LINK_WIDTH, arrowColor);
+		LineShader::Draw(from - arrowRight, fromTip, LINK_WIDTH, arrowColor);
+		if(link.second)
+		{
+			// Draw the to->from arrowhead.
+			Point toTip = to + arrowStem;
+			LineShader::Draw(to, toTip, LINK_WIDTH, arrowColor);
+			LineShader::Draw(to + arrowLeft, toTip, LINK_WIDTH, arrowColor);
+			LineShader::Draw(to + arrowRight, toTip, LINK_WIDTH, arrowColor);
+		}
 	}
 }
 
@@ -671,8 +725,8 @@ void MapPanel::DrawWormholes()
 void MapPanel::DrawLinks()
 {
 	// Draw the links between the systems.
-	Color closeColor(.6, .6);
-	Color farColor(.3, .3);
+	const Color &closeColor = *GameData::Colors().Get("map link");
+	const Color &farColor = closeColor.Transparent(.5);
 	for(const auto &it : GameData::Systems())
 	{
 		const System *system = &it.second;
@@ -690,12 +744,12 @@ void MapPanel::DrawLinks()
 				
 				Point from = Zoom() * (system->Position() + center);
 				Point to = Zoom() * (link->Position() + center);
-				Point unit = (from - to).Unit() * 7.;
+				Point unit = (from - to).Unit() * LINK_OFFSET;
 				from -= unit;
 				to += unit;
 				
 				bool isClose = (system == playerSystem || link == playerSystem);
-				LineShader::Draw(from, to, 1.2, isClose ? closeColor : farColor);
+				LineShader::Draw(from, to, LINK_WIDTH, isClose ? closeColor : farColor);
 			}
 	}
 }
@@ -834,8 +888,8 @@ void MapPanel::DrawNames()
 	
 	// Draw names for all systems you have visited.
 	const Font &font = FontSet::Get((Zoom() > 2.0) ? 18 : 14);
-	Color closeColor(.6, .6);
-	Color farColor(.3, .3);
+	const Color &closeColor = *GameData::Colors().Get("map name");
+	const Color &farColor = closeColor.Transparent(.5);
 	Point offset((Zoom() > 2.0) ? 8. : 6., -.5 * font.Height());
 	for(const auto &it : GameData::Systems())
 	{
@@ -854,8 +908,8 @@ void MapPanel::DrawMissions()
 {
 	// Draw a pointer for each active or available mission.
 	map<const System *, Angle> angle;
-	Color black(0., 1.);
-	Color white(1., 1.);
+	static const Color black(0., 1.);
+	static const Color white(1., 1.);
 	
 	const Set<Color> &colors = GameData::Colors();
 	const Color &availableColor = *colors.Get("available job");
@@ -868,7 +922,6 @@ void MapPanel::DrawMissions()
 		const System *system = mission.Destination()->GetSystem();
 		DrawPointer(system, angle[system], mission.HasSpace(player) ? availableColor : unavailableColor);
 	}
-	++step;
 	for(const Mission &mission : player.Missions())
 	{
 		if(!mission.IsVisible())

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -47,6 +47,8 @@ public:
 	
 	static const double OUTER;
 	static const double INNER;
+	static const double LINK_WIDTH;
+	static const double LINK_OFFSET;
 	
 	
 public:

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -425,6 +425,13 @@ const System *Planet::WormholeDestination(const System *from) const
 
 
 
+const vector<const System *> &Planet::WormholeSystems() const
+{
+	return systems;
+}
+
+
+
 // Check if the given ship has all the attributes necessary to allow it to
 // land on this planet.
 bool Planet::IsAccessible(const Ship *ship) const

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -103,6 +103,7 @@ public:
 	bool IsWormhole() const;
 	const System *WormholeSource(const System *to) const;
 	const System *WormholeDestination(const System *from) const;
+	const std::vector<const System *> &WormholeSystems() const;
 	
 	// Check if the given ship has all the attributes necessary to allow it to
 	// land on this planet.


### PR DESCRIPTION
Splitting the MapPanel refactoring out of #2601 so that #2601 can deal only with adding functionality re: invalid travel plans and not also rewrite a good chunk of `MapPanel`
 
- Improve mod coloring support via expanded use of interfaces.txt:
   - Switch the minimap from a hardcoded position to an `Interface`
   - Use travel plan colors from interfaces.txt
   - Use System name, link colors from interfaces.txt
 - Move the increment of `step` from the `DrawMissions` method to the base `Draw` method
 - Add comments to `DrawMiniMap`, `DrawTravelPlan`, and `DrawWormholes`
 - Used and updated `MapPanel` constants
 - Draw the Travel Plan after wormholes, since wormholes by default have non-zero alpha.
   - This removes the small, dark purple centerline from drawn travel plan routes that use wormholes
 - Adds function to `Planet` to export all systems in which it can be found
 - Do not show the "planet description" box if the player selects a wormhole planet (since drawn wormholes have non-empty descriptions)
 - Change `DrawWormholes` iteration scheme from "every `StellarObject` in every `System`" to "check only `planets`"
   - Fixes bug in `DrawWormholes` caused when two wormholes reference the same system (i.e. Cardea), which cause the wormhole link to be drawn over a previous directional arrow

images from #2601:

|`master` | 993e617 |
|:-----:|:-----:|
|![image](https://user-images.githubusercontent.com/20871346/31474332-a31816ae-aebf-11e7-9c90-ce3d84338f22.png) | ![image](https://user-images.githubusercontent.com/20871346/31474426-4d8299d4-aec0-11e7-973b-086dbd13855c.png)|

