### PR TITLE
Revert automatic assertion in FinishLoading that a ship is not disabled

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -438,7 +438,10 @@ void Ship::FinishLoading(bool isNewInstance)
 	if(isNewInstance)
 		Recharge(true);
 	
-	isDisabled = false;
+	// Ships read from a save file may have non-default shields or hull.
+	// Perform a full IsDisabled calculation.
+	isDisabled = true;
+	isDisabled = IsDisabled();
 }
 
 


### PR DESCRIPTION
 - 2633668c9f9c5933cbf8f0a98c855ab7b9345d20 made it so that every ship that FinishLoading is called for considers itself not disabled - even if its current hull and shields value mean it should be disabled.