### PR TITLE
Create a few <government: ___> substitutions for mission text

### DIFF
--- a/data/conversations.txt
+++ b/data/conversations.txt
@@ -41,3 +41,12 @@ conversation "flight check: overheating!"
 	scene "scene/engine"
 	`You've heard enough horror stories about the sort of accidents that happen when starship systems malfunction to be completely convinced of the necessity of a pre-flight safety check. As you listen to the complex symphony of hums, rattles, and clicks of "<ship>" warming up, you run through a mental checklist. Computers: check. Life support: check.`
 	`	By the time you reach the end of the checklist, it has grown uncomfortably warm. The air smells like ozone and hot metal, and your cameras are showing a plume of steam or smoke escaping from the hull near the engines. If your systems are running this hot while still in the atmosphere, they're likely to overheat the moment you hit hard vacuum. You are going to have to either install cooling systems, or trade out some components for lower-heat alternatives.`
+
+conversation "pirate attack"
+	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by pirates! We need every combat-worthy ship to join in the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
+	choice
+		`	(Stay here until the fight is over.)`
+			decline
+		`	(Join the defense fleet.)`
+	`	A few <government: npc> pilots have gathered to repel the pirate attack. You join them, and take off together...`
+		launch

--- a/data/conversations.txt
+++ b/data/conversations.txt
@@ -42,6 +42,9 @@ conversation "flight check: overheating!"
 	`You've heard enough horror stories about the sort of accidents that happen when starship systems malfunction to be completely convinced of the necessity of a pre-flight safety check. As you listen to the complex symphony of hums, rattles, and clicks of "<ship>" warming up, you run through a mental checklist. Computers: check. Life support: check.`
 	`	By the time you reach the end of the checklist, it has grown uncomfortably warm. The air smells like ozone and hot metal, and your cameras are showing a plume of steam or smoke escaping from the hull near the engines. If your systems are running this hot while still in the atmosphere, they're likely to overheat the moment you hit hard vacuum. You are going to have to either install cooling systems, or trade out some components for lower-heat alternatives.`
 
+
+
+# Planetary defense mission conversations.
 conversation "pirate attack"
 	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by pirates! We need every combat-worthy ship to join in the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
 	choice
@@ -49,4 +52,13 @@ conversation "pirate attack"
 			decline
 		`	(Join the defense fleet.)`
 	`	A few <government: npc> pilots have gathered to repel the pirate attack. You join them, and take off together...`
+		launch
+
+conversation "alien attack"
+	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by alien raiders! We need every combat-worthy ship to join in the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
+	choice
+		`    (Stay here until the fight is over.)`
+			decline
+		`    (Join the defense fleet.)`
+	`The local <government: origin> defense forces are preparing to repel the alien attack. You join them, and take off together...`
 		launch

--- a/data/conversations.txt
+++ b/data/conversations.txt
@@ -41,24 +41,3 @@ conversation "flight check: overheating!"
 	scene "scene/engine"
 	`You've heard enough horror stories about the sort of accidents that happen when starship systems malfunction to be completely convinced of the necessity of a pre-flight safety check. As you listen to the complex symphony of hums, rattles, and clicks of "<ship>" warming up, you run through a mental checklist. Computers: check. Life support: check.`
 	`	By the time you reach the end of the checklist, it has grown uncomfortably warm. The air smells like ozone and hot metal, and your cameras are showing a plume of steam or smoke escaping from the hull near the engines. If your systems are running this hot while still in the atmosphere, they're likely to overheat the moment you hit hard vacuum. You are going to have to either install cooling systems, or trade out some components for lower-heat alternatives.`
-
-
-
-# Planetary defense mission conversations.
-conversation "pirate attack"
-	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by pirates! We need every combat-worthy ship to join in the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
-	choice
-		`	(Stay here until the fight is over.)`
-			decline
-		`	(Join the defense fleet.)`
-	`	A few <government: npc> pilots have gathered to repel the pirate attack. You join them, and take off together...`
-		launch
-
-conversation "alien attack"
-	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by alien raiders! We need every combat-worthy ship to join in the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
-	choice
-		`    (Stay here until the fight is over.)`
-			decline
-		`    (Join the defense fleet.)`
-	`The local <government: origin> defense forces are preparing to repel the alien attack. You join them, and take off together...`
-		launch

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1379,6 +1379,7 @@ mission "Bounty Hunting (Small)"
 		payment 150000
 		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc>.`
 
+
 mission "Southern Pirate Attack"
 	name "Defend <planet>"
 	description "Defeat a pirate raid on <destination>."
@@ -1457,6 +1458,16 @@ mission "Core Pirate Attack"
 		payment 200000
 		dialog `A <government: destination> official pays you <payment> for helping to drive off the pirates.`
 
+conversation "pirate attack"
+	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by pirates! We need every combat-worthy ship to join the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
+	choice
+		`	(Stay here until the fight is over.)`
+			decline
+		`	(Join the defense fleet.)`
+	`	A few <government: npc> pilots have gathered to repel the pirate attack. You join them, and take off together...`
+		launch
+
+
 mission "Raider Attack 1"
 	name "Defend <planet>"
 	description "Defeat an alien raid on <destination>."
@@ -1511,6 +1522,16 @@ mission "Raider Attack 2"
 	on complete
 		payment 750000
 		dialog `A <government: destination> official pays you <payment> for helping to drive off the raiders.`
+
+conversation "alien attack"
+	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by alien raiders! We need every combat-worthy ship to join the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
+	choice
+		`    (Stay here until the fight is over.)`
+			decline
+		`    (Join the defense fleet.)`
+	`The local <government: origin> defense forces are preparing to repel the alien attack. You join them, and take off together...`
+		launch
+
 
 mission "Cargo [0]"
 	name "Delivery to <planet>"

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1273,10 +1273,10 @@ mission "Bounty Hunting (Big)"
 		"combat rating" > 500
 		random < 20
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 2
@@ -1301,7 +1301,7 @@ mission "Bounty Hunting (Big)"
 		dialog "The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 250000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc>."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc>."
 
 mission "Bounty Hunting (Medium)"
 	name "Hunt down <npc>"
@@ -1312,10 +1312,10 @@ mission "Bounty Hunting (Medium)"
 		"combat rating" > 400
 		random < 20
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 2
@@ -1336,7 +1336,7 @@ mission "Bounty Hunting (Medium)"
 		dialog "The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 200000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc>."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc>."
 
 mission "Bounty Hunting (Small)"
 	name "Hunt down <npc>"
@@ -1347,10 +1347,10 @@ mission "Bounty Hunting (Small)"
 		"combat rating" > 300
 		random < 40
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 2
@@ -1377,7 +1377,7 @@ mission "Bounty Hunting (Small)"
 		dialog "The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 150000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc>."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc>."
 
 mission "Southern Pirate Attack"
 	name "Defend <planet>"
@@ -1388,29 +1388,22 @@ mission "Southern Pirate Attack"
 		"combat rating" > 100
 		random < 10
 	source
-		attributes frontier
-		attributes rim south "dirt belt"
+		attributes "frontier"
+		attributes "rim" "south" "dirt belt"
+	npc
+		government "Militia"
+		personality heroic staying
+		fleet "Small Militia" 2
 	npc evade
-		government Pirate
+		government "Pirate"
 		personality heroic staying target harvests plunders
 		fleet "Small Southern Pirates"
 		fleet "Large Southern Pirates" 2
-	npc
-		government Militia
-		personality heroic staying
-		fleet "Small Militia" 2
 	on offer
-		conversation
-			`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by pirates! We need every combat-worthy ship to join the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
-			choice
-				`	(Stay here until the fight is over.)`
-					decline
-				`	(Join the defense fleet.)`
-			`A few militia pilots have gathered to help repel the pirate attack. You join them, and take off together...`
-				launch
+		conversation "pirate attack"
 	on complete
 		payment 150000
-		dialog "The government of <planet> pays you <payment> for helping to drive off the pirates."
+		dialog `A <government: destination> official pays you <payment> for helping to drive off the pirates.`
 
 mission "Northern Pirate Attack"
 	name "Defend <planet>"
@@ -1421,29 +1414,22 @@ mission "Northern Pirate Attack"
 		"combat rating" > 100
 		random < 10
 	source
-		attributes frontier
-		attributes north paradise deep
+		attributes "frontier"
+		attributes "north" "paradise" "deep"
+	npc
+		government "Republic"
+		personality heroic staying
+		fleet "Small Republic" 2
 	npc evade
-		government Pirate
+		government "Pirate"
 		personality heroic staying target harvests plunders
 		fleet "Small Northern Pirates"
 		fleet "Large Northern Pirates" 2
-	npc
-		government Republic
-		personality heroic staying
-		fleet "Small Republic" 2
 	on offer
-		conversation
-			`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by pirates! We need every combat-worthy ship to join the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
-			choice
-				`	(Stay here until the fight is over.)`
-					decline
-				`	(Join the defense fleet.)`
-			`The local Navy garrison is preparing to repel the pirate attack. You join them, and take off together...`
-				launch
+		conversation "pirate attack"
 	on complete
 		payment 250000
-		dialog "The government of <planet> pays you <payment> for helping to drive off the pirates."
+		dialog `A <government: destination> official pays you <payment> for helping to drive off the pirates.`
 
 mission "Core Pirate Attack"
 	name "Defend <planet>"
@@ -1454,30 +1440,23 @@ mission "Core Pirate Attack"
 		"combat rating" > 100
 		random < 10
 	source
-		attributes frontier
-		attributes core "near earth"
+		attributes "frontier"
+		attributes "core" "near earth"
+	npc
+		government "Syndicate"
+		personality heroic staying
+		fleet "Small Syndicate" 2
 	npc evade
-		government Pirate
+		government "Pirate"
 		personality heroic staying target harvests plunders
 		fleet "Small Core Pirates"
 		fleet "Large Core Pirates" 2
-	npc
-		government Syndicate
-		personality heroic staying
-		fleet "Small Syndicate" 2
 	on offer
-		conversation
-			`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by pirates! We need every combat-worthy ship to join the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
-			choice
-				`	(Stay here until the fight is over.)`
-					decline
-				`	(Join the defense fleet.)`
-			`The local Syndicate defense forces are preparing to repel the pirate attack. You join them, and take off together...`
-				launch
+		conversation "pirate attack"
 	on complete
 		payment 200000
-		dialog "The government of <planet> pays you <payment> for helping to drive off the pirates."
-		
+		dialog `A <government: destination> official pays you <payment> for helping to drive off the pirates.`
+
 mission "Raider Attack 1"
 	name "Defend <planet>"
 	description "Defeat an alien raid on <destination>."
@@ -2393,10 +2372,10 @@ mission "Bounty Hunting (Marauder I)"
 				"combat rating" < 1200
 				random < 35
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 3
@@ -2404,7 +2383,7 @@ mission "Bounty Hunting (Marauder I)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 300000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
 
 mission "Bounty Hunting (Marauder II)"
 	name "Hunt down <npc>"
@@ -2419,10 +2398,10 @@ mission "Bounty Hunting (Marauder II)"
 				"combat rating" < 1800
 				random < 30
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 3
@@ -2430,7 +2409,7 @@ mission "Bounty Hunting (Marauder II)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 350000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
 
 mission "Bounty Hunting (Marauder III)"
 	name "Hunt down <npc>"
@@ -2445,10 +2424,10 @@ mission "Bounty Hunting (Marauder III)"
 				"combat rating" < 2200
 				random < 25
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 3
@@ -2456,7 +2435,7 @@ mission "Bounty Hunting (Marauder III)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 400000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
 
 mission "Bounty Hunting (Marauder IV)"
 	name "Hunt down <npc>"
@@ -2471,10 +2450,10 @@ mission "Bounty Hunting (Marauder IV)"
 				"combat rating" < 2700
 				random < 30
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 3
@@ -2482,7 +2461,7 @@ mission "Bounty Hunting (Marauder IV)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 425000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
 
 mission "Bounty Hunting (Marauder V)"
 	name "Hunt down <npc>"
@@ -2497,10 +2476,10 @@ mission "Bounty Hunting (Marauder V)"
 				"combat rating" < 3500
 				random < 25
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 3
@@ -2508,7 +2487,7 @@ mission "Bounty Hunting (Marauder V)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 450000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
 
 
 mission "Bounty Hunting (Marauder VI)"
@@ -2524,10 +2503,10 @@ mission "Bounty Hunting (Marauder VI)"
 				"combat rating" < 5000
 				random < 20
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 3
@@ -2535,7 +2514,7 @@ mission "Bounty Hunting (Marauder VI)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 475000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
 
 mission "Bounty Hunting (Marauder VII)"
 	name "Hunt down <npc>"
@@ -2546,10 +2525,10 @@ mission "Bounty Hunting (Marauder VII)"
 		"combat rating" > 2980
 		random < 20
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 3
@@ -2557,7 +2536,7 @@ mission "Bounty Hunting (Marauder VII)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 500000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
 
 mission "Bounty Hunting (Marauder VIII)"
 	name "Hunt down <npc>"
@@ -2568,10 +2547,10 @@ mission "Bounty Hunting (Marauder VIII)"
 		"combat rating" > 4000
 		random < 15
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic staying nemesis target
 		system
 			distance 1 3
@@ -2579,7 +2558,7 @@ mission "Bounty Hunting (Marauder VIII)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 550000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
 
 mission "Bounty Hunting (Marauder IX)"
 	name "Hunt down <npc>"
@@ -2590,10 +2569,10 @@ mission "Bounty Hunting (Marauder IX)"
 		"combat rating" > 6000
 		random < 10
 	source
-		government Republic "Free Worlds" Syndicate Neutral
-		attributes rim south north "dirt belt" core frontier
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
-		government Bounty
+		government "Bounty"
 		personality heroic unconstrained staying nemesis target
 		system
 			distance 1 3
@@ -2601,14 +2580,14 @@ mission "Bounty Hunting (Marauder IX)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 600000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
 
 # Must destroy hunters and land to fail
 mission "Marauder Hunted"
 	invisible
 	landing
 	repeat
-	destination Earth
+	destination "Earth"
 	source
 		government "Republic" "Syndicate" "Free Worlds" "Neutral"
 	to offer

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1301,7 +1301,7 @@ mission "Bounty Hunting (Big)"
 		dialog "The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 250000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc>."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc>.`
 
 mission "Bounty Hunting (Medium)"
 	name "Hunt down <npc>"
@@ -1336,7 +1336,7 @@ mission "Bounty Hunting (Medium)"
 		dialog "The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 200000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc>."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc>.`
 
 mission "Bounty Hunting (Small)"
 	name "Hunt down <npc>"
@@ -1377,7 +1377,7 @@ mission "Bounty Hunting (Small)"
 		dialog "The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 150000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc>."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc>.`
 
 mission "Southern Pirate Attack"
 	name "Defend <planet>"
@@ -1470,28 +1470,21 @@ mission "Raider Attack 1"
 		planet "Sundive"
 		planet "Shangri-La"
 		planet "Nimbus"
-	npc evade
-		government "Korath"
-		personality target timid unconstrained uninterested harvests plunders
-		fleet "Korath Raid" 2
 	npc
 		government "Syndicate"
 		personality heroic staying vindictive
 		fleet "Large Syndicate"
 		fleet "Small Syndicate"
+	npc evade
+		government "Korath"
+		personality target timid unconstrained uninterested harvests plunders
+		fleet "Korath Raid" 2
 	on offer
-		conversation
-			`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by alien raiders! We need every combat-worthy ship to join the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
-			choice
-				`	(Stay here until the fight is over.)`
-					decline
-				`	(Join the defense fleet.)`
-			`The local Syndicate defense forces are preparing to repel the alien attack. You join them, and take off together...`
-				launch
+		conversation "alien attack"
 	on complete
 		payment 550000
-		dialog `The government of <planet> pays you <payment> for helping to drive off the raiders.`
-		
+		dialog `A <government: destination> official pays you <payment> for helping to drive off the raiders.`
+
 mission "Raider Attack 2"
 	name "Defend <planet>"
 	description "Defeat an alien raid on <destination>."
@@ -1505,27 +1498,19 @@ mission "Raider Attack 2"
 		planet "Sundive"
 		planet "Shangri-La"
 		planet "Nimbus"
-	npc evade
-		government "Korath"
-		personality target timid unconstrained uninterested harvests plunders
-		fleet "Korath Raid" 3
-		
 	npc
 		government "Syndicate"
 		personality heroic staying vindictive
 		fleet "Large Syndicate" 2
+	npc evade
+		government "Korath"
+		personality target timid unconstrained uninterested harvests plunders
+		fleet "Korath Raid" 3
 	on offer
-		conversation
-			`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by alien raiders! We need every combat-worthy ship to join the defenses!" The authorities will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
-			choice
-				`	(Stay here until the fight is over.)`
-					decline
-				`	(Join the defense fleet.)`
-			`The local Syndicate defense forces are preparing to repel the alien attack. You join them, and take off together...`
-				launch
+		conversation "alien attack"
 	on complete
 		payment 750000
-		dialog `The government of <planet> pays you <payment> for helping to drive off the raiders.`
+		dialog `A <government: destination> official pays you <payment> for helping to drive off the raiders.`
 
 mission "Cargo [0]"
 	name "Delivery to <planet>"
@@ -2383,7 +2368,7 @@ mission "Bounty Hunting (Marauder I)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 300000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet.`
 
 mission "Bounty Hunting (Marauder II)"
 	name "Hunt down <npc>"
@@ -2409,7 +2394,7 @@ mission "Bounty Hunting (Marauder II)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 350000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet.`
 
 mission "Bounty Hunting (Marauder III)"
 	name "Hunt down <npc>"
@@ -2435,7 +2420,7 @@ mission "Bounty Hunting (Marauder III)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 400000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet.`
 
 mission "Bounty Hunting (Marauder IV)"
 	name "Hunt down <npc>"
@@ -2461,7 +2446,7 @@ mission "Bounty Hunting (Marauder IV)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 425000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet.`
 
 mission "Bounty Hunting (Marauder V)"
 	name "Hunt down <npc>"
@@ -2487,7 +2472,7 @@ mission "Bounty Hunting (Marauder V)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 450000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet.`
 
 
 mission "Bounty Hunting (Marauder VI)"
@@ -2514,7 +2499,7 @@ mission "Bounty Hunting (Marauder VI)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 475000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet.`
 
 mission "Bounty Hunting (Marauder VII)"
 	name "Hunt down <npc>"
@@ -2536,7 +2521,7 @@ mission "Bounty Hunting (Marauder VII)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 500000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet.`
 
 mission "Bounty Hunting (Marauder VIII)"
 	name "Hunt down <npc>"
@@ -2558,7 +2543,7 @@ mission "Bounty Hunting (Marauder VIII)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 550000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet.`
 
 mission "Bounty Hunting (Marauder IX)"
 	name "Hunt down <npc>"
@@ -2580,7 +2565,7 @@ mission "Bounty Hunting (Marauder IX)"
 		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
 		payment 600000
-		dialog "A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog `A local <government: destination> official gratefully pays you <payment> for eliminating the <npc> and their fleet.`
 
 # Must destroy hunters and land to fail
 mission "Marauder Hunted"


### PR DESCRIPTION
Refs #2456, though I chose to use a more flexible / descriptive naming scheme than `originGov`

 - `<government: origin>`: The name of the government of where this mission was offered (e.g. the ship's government or the planet's government).
 - `<government: destination>`: The name of the government of the destination planet.
 - `<government: waypoints>`: The name(s) of the government(s) of all systems which are waypoints
   e.g. "Free Worlds and Republic"
 - `<government: stopovers>`: The name(s) of the government(s) of all planets which are stopovers
   e.g. "Free Worlds, Republic, and Syndicate"
 - `<government: npc>`: The name of the government of the first NPC in the mission's definiton.
 - `<government: npcs>`: The name(s) of all this mission's NPC's government(s).