### PR TITLE
Reduced damage and increased firing energy and heat of human lasers

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -157,8 +157,8 @@ outfit "Beam Laser"
 		"velocity" 300
 		"lifetime" 1
 		"reload" 1
-		"firing energy" .6
-		"firing heat" 1.45
+		"firing energy" .5
+		"firing heat" 1.2
 		"shield damage" 0.9
 		"hull damage" 1.15
 	description "In the early part of the space era, the settlements in the region of space known as the Deep developed in relative isolation from the rest of human space. One result of that isolation is that their weapons technology mostly uses beam weapons, instead of the energy projectile weapons that are more common elsewhere. A Beam Laser has a slightly shorter range than an Energy Blaster, but is also much more energy-efficient and does a comparable amount of damage."
@@ -184,8 +184,8 @@ outfit "Laser Turret"
 		"velocity" 300
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1.2
-		"firing heat" 2.9
+		"firing energy" 1
+		"firing heat" 2.4
 		"shield damage" 1.8
 		"hull damage" 2.3
 	description "Laser Turrets are hated by fighter pilots because it is nearly impossible to dodge them once you are within their reach. This turret carries a pair of lasers and can swivel almost instantly to fire on new targets as they approach. Laser Turrets are especially useful when mounted on slow-moving freighters to fend off packs of small pirate vessels."
@@ -217,8 +217,8 @@ outfit "Heavy Laser"
 		"velocity" 400
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1.2
-		"firing heat" 2.65
+		"firing energy" 1
+		"firing heat" 2.2
 		"shield damage" 1.6
 		"hull damage" 2.2
 	description "The Heavy Laser is an upgraded Beam Laser with a significantly longer range and higher power. It is mostly intended for larger ships, where energy and space are plentiful, but some pilots consider a single Heavy Laser to be a worthwhile alternative to a pair of Beam Lasers, because the longer range makes up for the fact that it does not quite deal twice as much damage."
@@ -244,8 +244,8 @@ outfit "Heavy Laser Turret"
 		"velocity" 400
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 2.4
-		"firing heat" 5.3
+		"firing energy" 2
+		"firing heat" 4.4
 		"shield damage" 3.2
 		"hull damage" 4.4
 	description "For ships with enough space to install one, the Heavy Laser Turret is a powerful weapon, equally useful for driving off fighters and for bombarding larger targets with continuous fire without having to worry about pointing your ship in the right direction."
@@ -278,8 +278,8 @@ outfit "Electron Beam"
 		"velocity" 450
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1.8
-		"firing heat" 3.1
+		"firing energy" 1.5
+		"firing heat" 2.6
 		"shield damage" 2.6
 		"hull damage" 3.5
 	description "The Electron Beam is a recent development by the Deep Sky labs, a more powerful weapon with a design similar to their perennially popular laser guns."
@@ -305,8 +305,8 @@ outfit "Electron Turret"
 		"velocity" 450
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 3.6
-		"firing heat" 6.2
+		"firing energy" 3
+		"firing heat" 5.2
 		"shield damage" 5.2
 		"hull damage" 7
 	description "This turret places two of Deep Sky's recently developed electron beam weapons onto a rotating turret, providing unsurpassed accuracy and power for shooting down fast-moving targets."

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -157,10 +157,10 @@ outfit "Beam Laser"
 		"velocity" 300
 		"lifetime" 1
 		"reload" 1
-		"firing energy" .5
-		"firing heat" 1.2
-		"shield damage" 1
-		"hull damage" 1.3
+		"firing energy" .6
+		"firing heat" 1.45
+		"shield damage" 0.9
+		"hull damage" 1.15
 	description "In the early part of the space era, the settlements in the region of space known as the Deep developed in relative isolation from the rest of human space. One result of that isolation is that their weapons technology mostly uses beam weapons, instead of the energy projectile weapons that are more common elsewhere. A Beam Laser has a slightly shorter range than an Energy Blaster, but is also much more energy-efficient and does a comparable amount of damage."
 
 outfit "Laser Turret"
@@ -184,10 +184,10 @@ outfit "Laser Turret"
 		"velocity" 300
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1
-		"firing heat" 2.4
-		"shield damage" 2
-		"hull damage" 2.6
+		"firing energy" 1.2
+		"firing heat" 2.9
+		"shield damage" 1.8
+		"hull damage" 2.3
 	description "Laser Turrets are hated by fighter pilots because it is nearly impossible to dodge them once you are within their reach. This turret carries a pair of lasers and can swivel almost instantly to fire on new targets as they approach. Laser Turrets are especially useful when mounted on slow-moving freighters to fend off packs of small pirate vessels."
 
 effect "beam laser impact"
@@ -217,10 +217,10 @@ outfit "Heavy Laser"
 		"velocity" 400
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1
-		"firing heat" 2.2
-		"shield damage" 1.8
-		"hull damage" 2.4
+		"firing energy" 1.2
+		"firing heat" 2.65
+		"shield damage" 1.6
+		"hull damage" 2.2
 	description "The Heavy Laser is an upgraded Beam Laser with a significantly longer range and higher power. It is mostly intended for larger ships, where energy and space are plentiful, but some pilots consider a single Heavy Laser to be a worthwhile alternative to a pair of Beam Lasers, because the longer range makes up for the fact that it does not quite deal twice as much damage."
 
 outfit "Heavy Laser Turret"
@@ -244,10 +244,10 @@ outfit "Heavy Laser Turret"
 		"velocity" 400
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 2
-		"firing heat" 4.4
-		"shield damage" 3.6
-		"hull damage" 4.8
+		"firing energy" 2.4
+		"firing heat" 5.3
+		"shield damage" 3.2
+		"hull damage" 4.4
 	description "For ships with enough space to install one, the Heavy Laser Turret is a powerful weapon, equally useful for driving off fighters and for bombarding larger targets with continuous fire without having to worry about pointing your ship in the right direction."
 
 effect "heavy laser impact"
@@ -278,10 +278,10 @@ outfit "Electron Beam"
 		"velocity" 450
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1.5
-		"firing heat" 2.6
-		"shield damage" 2.9
-		"hull damage" 3.9
+		"firing energy" 1.8
+		"firing heat" 3.1
+		"shield damage" 2.6
+		"hull damage" 3.5
 	description "The Electron Beam is a recent development by the Deep Sky labs, a more powerful weapon with a design similar to their perennially popular laser guns."
 
 outfit "Electron Turret"
@@ -305,10 +305,10 @@ outfit "Electron Turret"
 		"velocity" 450
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 3.0
-		"firing heat" 5.2
-		"shield damage" 5.8
-		"hull damage" 7.8
+		"firing energy" 3.6
+		"firing heat" 6.2
+		"shield damage" 5.2
+		"hull damage" 7
 	description "This turret places two of Deep Sky's recently developed electron beam weapons onto a rotating turret, providing unsurpassed accuracy and power for shooting down fast-moving targets."
 
 effect "electron impact"


### PR DESCRIPTION
Reference: https://github.com/endless-sky/endless-sky/pull/3307#issuecomment-348807522

To note ahead of time, I have only changed lasers in this PR. I have not (yet) altered any ships or variants that use lasers in order to avoid any issues during the story. I plan to do that before considering this merge worthy, but I'm PRing now in order to get feedback on the changes and outline the effects that this PR has on ships.

Changes:
* All human lasers have seen... 
  * a roughly 10% decrease in damage
  * a roughly 20% increase in both firing energy and heat

Goal: make cannons and blasters more competitive with human lasers by reducing how efficient human lasers are.

I spreadsheeted out all 73 human ships (stock and variant) that use lasers, showing their firing energy/heat before and after the change and their time to run out of energy or overheat before and after the change assuming that all systems are firing (i.e. shooting weapons, thrusting, steering, and regenerating shields). That spreadsheet can be found [here](https://docs.google.com/spreadsheets/d/13JEoF8XAzcX2nZMB9cdZQKgFeLQdZOv1R-E7VUWDi5Y/edit?usp=sharing). All times are in seconds. Ships are not always running all their systems at once, I am simply looking at the worst case scenario change that would occur because of this PR. I expect that normal combat wouldn't be affected too much, only prolonged combat.

Notable results of this change:
* Ships that run out of energy with ALL systems firing constantly that didn't before
  * Clipper
  * Fury (Laser)
  * Marauder Raven
  * Falcon (Heavy)
  * Leviathan (Laser)
  * Mule (Hai Engines)
* Ships that will now overheat with ALL systems firing constantly that didn't before
  * Behemoth
  * Gunboat
  * Aerie
  * Mule
  * Leviathan (Laser)
  * Marauder Leviathan
* Ships that ran out of energy before now run out on average 26.6% faster
* Ships that overheat before now overheat on average 35.28% faster
* Notable ships/variants that changed (looking at ships that play a role in the campaign):
  * Gunboats now run out of energy roughly 26% faster, and Mark IIs run out roughly 41% faster.
  * All Navy Carriers now run out of energy roughly 20% faster. The stock Carrier overheats about 29% faster, but the Mark II and Jump variants overheat roughly 10% faster.
  * Mark II Cruisers now run out of energy roughly 83% faster, and normal Cruisers roughly 30% faster. No Cruisers that see combat (i.e. not the Cruiser (Heavy)) will overheat.
  * The Falcon (Heavy), without any batteries, may now struggle during combat.
  * The Leviathan (Heavy) now runs out of energy roughly 30% faster.

I strongly suggest merging #3350 alongside this, as there are a number of ships that use both lasers and blasters, and with the blaster change and despite the increased difficulty of using lasers, those ships actually end up overheating slower and running out of energy slower or even not at all due to how drastic the change is to blasters (or said differently, how drastically high firing energy and heat of blasters are).
