### PR TITLE
balance change to "Wanderers Defend Sich'ka'ara"

### DIFF
--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -2002,7 +2002,7 @@ mission "Wanderers Defend Sich'ka'ara"
 			names "hai"
 			variant
 				"Shield Beetle" 2
-				"Shield Beetle (Tracker)" 1
+				"Shield Beetle (Tracker)"
 				"Shield Beetle (Pulse)" 2
 				"Water Bug" 3
 				"Water Bug (Pulse)" 4
@@ -2012,7 +2012,7 @@ mission "Wanderers Defend Sich'ka'ara"
 		fleet
 			names "hai"
 			variant
-				"Shield Beetle" 1
+				"Shield Beetle"
 				"Shield Beetle (Tracker)" 3
 				"Shield Beetle (Pulse)" 2
 				"Water Bug" 7
@@ -2023,9 +2023,10 @@ mission "Wanderers Defend Sich'ka'ara"
 		fleet
 			names "wanderer"
 			variant
+				"Tempest"
 				"Tempest (Missile)" 2
 				"Autumn Leaf" 3
-				"Summer Leaf" 1
+				"Summer Leaf"
 	npc
 		personality heroic staying
 		government "Wanderer"
@@ -2034,7 +2035,7 @@ mission "Wanderers Defend Sich'ka'ara"
 			variant
 				"Tempest (Heavy)"
 				"Tempest"
-				"Strong Wind" 1
+				"Strong Wind"
 				"Autumn Leaf" 2
 				"Summer Leaf" 3
 	on complete


### PR DESCRIPTION
so, due to the new turret turning angles we knew the combat missions would require some rebalancing, and I said I'd test them in my new playthrough (playing in 1 ship for fun & a challenge so might as well)

I've done this mission nearly 10 times in the old (current) state, and it was basically undoable in my Albatross (yes, the mission is balanced on having a Tempest, but apart from lower durability they're surprisingly even), so I tried adding a Tempest in to make it a little bit easier

the Albatross loadout I tested it in:
![albatross loadout 2](https://user-images.githubusercontent.com/10348657/33948603-95fe25be-e027-11e7-9362-d80c760ce8fa.png)

I tried the mission a handful of times AFTER adding this Tempest, and cloaked the full battle to see how the fleets would do without the player; around half the Hai ships make it through

then I tried it a handful of times by focusing the same ships the Wanderers focused (teamwork), and maybe 2 Tempests and 1-2 Summer/Autumn leaves make it through at most, I was quite surprised how much of an impact the player has when using a proper strategy

I also considered maybe adding 1 or 2 Summer Leaves in for good measure, what do ya all think?