### PR TITLE
Enable any mission conversation to require the player to launch

### DIFF
--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -298,6 +298,10 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination) co
 		ConversationPanel *panel = new ConversationPanel(player, conversation, destination);
 		if(isOffer)
 			panel->SetCallback(&player, &PlayerInfo::MissionCallback);
+		// Use a basic callback to handle forced departure outside of `on offer`
+		// conversations.
+		else
+			panel->SetCallback(&player, &PlayerInfo::BasicCallback);
 		ui->Push(panel);
 	}
 	else if(!dialogText.empty() && ui)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1548,7 +1548,8 @@ void PlayerInfo::MissionCallback(int response)
 	
 	Mission &mission = missionList.front();
 	
-	shouldLaunch |= Conversation::RequiresLaunch(response);
+	// If landed, this conversation may require the player to immediately depart.
+	shouldLaunch |= (GetPlanet() && Conversation::RequiresLaunch(response));
 	if(response == Conversation::ACCEPT || response == Conversation::LAUNCH)
 	{
 		bool shouldAutosave = mission.RecommendsAutosave();
@@ -1580,6 +1581,16 @@ void PlayerInfo::MissionCallback(int response)
 	}
 	else if(response == Conversation::DIE)
 		Die(true);
+}
+
+
+
+// Basic callback, allowing conversations to force the player to depart from a
+// planet without requiring a mission to offer.
+void PlayerInfo::BasicCallback(int response)
+{
+	// If landed, this conversation may require the player to immediately depart.
+	shouldLaunch |= (GetPlanet() && Conversation::RequiresLaunch(response));
 }
 
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -163,6 +163,8 @@ public:
 	void HandleBlockedMissions(Mission::Location location, UI *ui);
 	// Callback for accepting or declining whatever mission has been offered.
 	void MissionCallback(int response);
+	// Basic callback for handling forced departure from a planet.
+	void BasicCallback(int response);
 	// Complete or fail a mission.
 	void RemoveMission(Mission::Trigger trigger, const Mission &mission, UI *ui);
 	// Mark a mission as failed, but do not remove it from the mission list yet.


### PR DESCRIPTION
Refs #3167 

 - Adds a "BasicCallback" to enable conversations that come from non "on offer" conversations to force the player to depart the planet.
 - Guards setting "shouldLaunch" to true while in flight, as a boarding/assisting mission could otherwise set this and cause odd behavior on the next landing.

I didn't extend this callback to the conversation started by completing an NPC since the player is never on a planet when they "complete" an NPC.