### PR TITLE
Improved blasters

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -109,8 +109,8 @@ outfit "Modified Blaster"
 		"reload" 12
 		"firing energy" 16
 		"firing heat" 32
-		"shield damage" 16
-		"hull damage" 8
+		"shield damage" 14
+		"hull damage" 7
 	description "This is an Energy Blaster that has been tampered with to increase its power and range slightly, at the cost of a significant increase in its energy requirements. Modified Blasters also produce an extreme amount of heat when firing, increasing the risk that your ship will overheat."
 
 outfit "Modified Blaster Turret"
@@ -135,8 +135,8 @@ outfit "Modified Blaster Turret"
 		"reload" 6
 		"firing energy" 16
 		"firing heat" 32
-		"shield damage" 16
-		"hull damage" 8
+		"shield damage" 14
+		"hull damage" 7
 	description "This is a turreted version of the Modified Blaster, which is an Energy Blaster modified for greater power at the cost of higher energy consumption and heat. These turrets are popular with pirates and others who are trying to cram as much firepower into their ships as possible."
 
 

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -21,7 +21,7 @@ outfit "Energy Blaster"
 		sound "blaster"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
-		"velocity" 8
+		"velocity" 8.5
 		"lifetime" 60
 		"reload" 12
 		"firing energy" 10
@@ -47,7 +47,7 @@ outfit "Blaster Turret"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
 		"turret turn" 5
-		"velocity" 8
+		"velocity" 8.5
 		"lifetime" 60
 		"reload" 6
 		"firing energy" 10
@@ -73,7 +73,7 @@ outfit "Quad Blaster Turret"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
 		"turret turn" 3
-		"velocity" 8
+		"velocity" 8.5
 		"lifetime" 60
 		"reload" 3
 		"firing energy" 10
@@ -104,7 +104,7 @@ outfit "Modified Blaster"
 		sound "mod blaster"
 		"hit effect" "blaster impact"
 		"inaccuracy" 4
-		"velocity" 8.5
+		"velocity" 9
 		"lifetime" 60
 		"reload" 12
 		"firing energy" 16
@@ -130,7 +130,7 @@ outfit "Modified Blaster Turret"
 		"hit effect" "blaster impact"
 		"inaccuracy" 4
 		"turret turn" 4
-		"velocity" 8.5
+		"velocity" 9
 		"lifetime" 60
 		"reload" 6
 		"firing energy" 16

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -21,13 +21,13 @@ outfit "Energy Blaster"
 		sound "blaster"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
-		"velocity" 7
+		"velocity" 8
 		"lifetime" 60
 		"reload" 12
 		"firing energy" 10
-		"firing heat" 35
-		"shield damage" 9
-		"hull damage" 6
+		"firing heat" 20
+		"shield damage" 10
+		"hull damage" 5
 	description "Although not the most accurate or damaging of weapons, the Energy Blaster is popular because it is small enough to be installed on even the tiniest of ships. One blaster is not enough to do appreciable damage to anything larger than a fighter, but a ship equipped with several of them becomes a force to be reckoned with."
 
 outfit "Blaster Turret"
@@ -47,13 +47,13 @@ outfit "Blaster Turret"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
 		"turret turn" 5
-		"velocity" 7
+		"velocity" 8
 		"lifetime" 60
 		"reload" 6
 		"firing energy" 10
-		"firing heat" 35
-		"shield damage" 9
-		"hull damage" 6
+		"firing heat" 20
+		"shield damage" 10
+		"hull damage" 5
 	description "A Blaster Turret is a pair of Energy Blasters mounted on a rotating platform, allowing it to fire in any direction. Sophisticated software algorithms allow the turret to correct for a target's motion, making the Blaster Turret effective even against small, quickly moving fighters. Because it needs a special mounting point with a 360 degree field of view, not all ships are capable of being equipped with a turret."
 
 outfit "Quad Blaster Turret"
@@ -73,13 +73,13 @@ outfit "Quad Blaster Turret"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
 		"turret turn" 3
-		"velocity" 7
+		"velocity" 8
 		"lifetime" 60
 		"reload" 3
 		"firing energy" 10
-		"firing heat" 35
-		"shield damage" 9
-		"hull damage" 6
+		"firing heat" 20
+		"shield damage" 10
+		"hull damage" 5
 	description "A Quad Blaster Turret carries four guns on a single turret mount, doubling the firepower of an ordinary Blaster Turret for ships with enough space to install one and energy to drive it."
 
 effect "blaster impact"
@@ -104,12 +104,12 @@ outfit "Modified Blaster"
 		sound "mod blaster"
 		"hit effect" "blaster impact"
 		"inaccuracy" 4
-		"velocity" 7.5
+		"velocity" 8.5
 		"lifetime" 60
 		"reload" 12
 		"firing energy" 16
-		"firing heat" 55
-		"shield damage" 12
+		"firing heat" 32
+		"shield damage" 16
 		"hull damage" 8
 	description "This is an Energy Blaster that has been tampered with to increase its power and range slightly, at the cost of a significant increase in its energy requirements. Modified Blasters also produce an extreme amount of heat when firing, increasing the risk that your ship will overheat."
 
@@ -130,12 +130,12 @@ outfit "Modified Blaster Turret"
 		"hit effect" "blaster impact"
 		"inaccuracy" 4
 		"turret turn" 4
-		"velocity" 7.5
+		"velocity" 8.5
 		"lifetime" 60
 		"reload" 6
 		"firing energy" 16
-		"firing heat" 55
-		"shield damage" 12
+		"firing heat" 32
+		"shield damage" 16
 		"hull damage" 8
 	description "This is a turreted version of the Modified Blaster, which is an Energy Blaster modified for greater power at the cost of higher energy consumption and heat. These turrets are popular with pirates and others who are trying to cram as much firepower into their ships as possible."
 


### PR DESCRIPTION
Yet another counterproposal to make blasters somewhat more attractive. This one does not involve any changes to default or variant ship builds. As suggested in #3393:

> Increasing the Blaster range (maybe by increasing speed rather than lifetime) and decreasing its heat production.

This proposal does that:
* blaster velocity increased from 7 to 8.5, which means a range increase from 420 to 510
  * modified blaster from 7.5 to 9.0, thus range from 450 to 540
* blaster and modified blaster firing heat reduced by 3/7 (to make it twice the firing energy)
* blaster and modified blaster firing energy remains unchanged (i.e. highly inefficient)
* blaster shield + hull damage per second changed from 45+30 to 50+25
  * modified blaster from 60+40 to 70+35

With these changes blasters remain highly inefficient, but might become occasionally useful.

*not implemented* but to be considered, because of modified blaster's 40% higher damage:
  * modified blaster gun size from 6 to 7 (blaster has 5)
  * modified blaster turret size from 18 to 20 (blaster has 15, quad blaster 25); 
  * the "Modified Argosy (Blaster)" seems to be the only ship equipped with modified blasters (maybe replace the ordinary quad blaster turrets with modified blaster turrets to save space and heat?)

Effectively this patch results into:

Blasters:
* poor energy and heat efficiencies
* good credit and mass efficiencies
* mediocre range
* higher shield than hull damage

Lasers:
* great energy and heat efficiencies
* decent credit and mass efficiencies
* low range (especially with #3406)
* higher hull than shield damage
* continuous fire


So yes, lasers remain attractive, but blasters get their own niche.