### PR TITLE
Equipped variants with rifles

### DIFF
--- a/data/variants.txt
+++ b/data/variants.txt
@@ -17,6 +17,7 @@ ship "Star Barge" "Star Barge (Armed)"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 3
 
 
 
@@ -31,6 +32,7 @@ ship "Sparrow" "Sparrow (Patrol)"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 2
 
 
 
@@ -43,6 +45,7 @@ ship "Raven" "Raven (Afterburner)"
 		"X3200 Ion Steering"
 		"Hyperdrive"
 		"Afterburner"
+		"Laser Rifle" 13
 
 
 
@@ -55,6 +58,7 @@ ship "Wasp" "Wasp (Proton)"
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
 		"Hyperdrive"
+		"Laser Rifle" 2
 
 
 
@@ -69,6 +73,7 @@ ship "Manta" "Manta (Proton)"
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
+		"Laser Rifle" 10
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Proton Gun"
@@ -88,6 +93,7 @@ ship "Quicksilver" "Quicksilver (Proton)"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 6
 
 
 
@@ -112,6 +118,7 @@ ship "Cruiser" "Cruiser (Heavy)"
 		"A525 Atomic Steering"
 		"X2200 Ion Steering"
 		"Scram Drive"
+		"Laser Rifle" 136
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -140,6 +147,7 @@ ship "Scout" "Scout (Speedy)"
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 12
 
 
 
@@ -155,6 +163,7 @@ ship "Clipper" "Clipper (Heavy)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Scram Drive"
+		"Laser Rifle" 9
 
 
 
@@ -168,6 +177,7 @@ ship "Clipper" "Clipper (Speedy)"
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 9
 
 
 
@@ -183,6 +193,7 @@ ship "Freighter" "Freighter (Fancy)"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Scram Drive"
+		"Laser Rifle" 7
 	turret "Laser Turret"
 	turret "Laser Turret"
 	turret "Heavy Anti-Missile Turret"
@@ -201,6 +212,7 @@ ship "Freighter" "Freighter (Proton)"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Scram Drive"
+		"Laser Rifle" 7
 
 
 
@@ -216,6 +228,7 @@ ship "Argosy" "Argosy (Laser)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 14
 
 
 
@@ -232,6 +245,7 @@ ship "Argosy" "Argosy (Missile)"
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 14
 	turret "Anti-Missile Turret"
 	turret "Heavy Anti-Missile Turret"
 
@@ -248,6 +262,7 @@ ship "Argosy" "Argosy (Proton)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 14
 
 
 
@@ -262,6 +277,7 @@ ship "Argosy" "Argosy (Turret)"
 		"X3700 Ion Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 14
 
 
 
@@ -276,6 +292,7 @@ ship "Argosy" "Argosy (Blaster)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 14
 
 
 
@@ -295,6 +312,7 @@ ship "Behemoth" "Behemoth (Proton)"
 		"A125 Atomic Steering"
 		"A375 Atomic Steering"
 		"Scram Drive"
+		"Laser Rifle" 30
 	turret "Proton Turret"
 	turret "Proton Turret"
 	turret "Proton Turret"
@@ -319,6 +337,7 @@ ship "Behemoth" "Behemoth (Speedy)"
 		"A125 Atomic Steering"
 		"A375 Atomic Steering"
 		"Scram Drive"
+		"Laser Rifle" 30
 
 
 
@@ -336,6 +355,7 @@ ship "Bulk Freighter" "Bulk Freighter (Heavy)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Scram Drive"
+		"Laser Rifle" 18
 	turret "Laser Turret"
 	turret "Laser Turret"
 	turret "Heavy Anti-Missile Turret"
@@ -357,6 +377,7 @@ ship "Bulk Freighter" "Bulk Freighter (Blaster)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Scram Drive"
+		"Laser Rifle" 18
 
 
 
@@ -373,6 +394,7 @@ ship "Bulk Freighter" "Bulk Freighter (Proton)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Scram Drive"
+		"Laser Rifle" 18
 
 
 
@@ -386,6 +408,7 @@ ship "Fury" "Fury (Missile)"
 		"Greyhound Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 3
 
 
 
@@ -399,6 +422,7 @@ ship "Fury" "Fury (Laser)"
 		"Chipmunk Plasma Thruster"
 		"A125 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 3
 
 
 
@@ -411,6 +435,7 @@ ship "Hawk" "Hawk (Speedy)"
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 4
 
 
 
@@ -424,6 +449,7 @@ ship "Hawk" "Hawk (Rocket)"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 4
 
 
 
@@ -439,6 +465,7 @@ ship "Bastion" "Bastion (Heavy)"
 		"X3700 Ion Thruster"
 		"Orca Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 40
 
 
 
@@ -456,6 +483,7 @@ ship "Bastion" "Bastion (Laser)"
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 40
 	turret "Heavy Anti-Missile Turret"
 	turret "Heavy Laser Turret"
 	turret "Heavy Laser Turret"
@@ -474,6 +502,7 @@ ship "Corvette" "Corvette (Speedy)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 32
 
 
 
@@ -492,6 +521,7 @@ ship "Corvette" "Corvette (Missile)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 32
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Torpedo Launcher"
@@ -512,6 +542,7 @@ ship "Firebird" "Firebird (Plasma)"
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 22
 
 
 
@@ -529,6 +560,7 @@ ship "Firebird" "Firebird (Missile)"
 		"Impala Plasma Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 22
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Torpedo Launcher"
@@ -551,6 +583,7 @@ ship "Mule" "Mule (Heavy)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 42
 
 
 
@@ -566,6 +599,7 @@ ship "Osprey" "Osprey (Laser)"
 		"Impala Plasma Thruster"
 		"X4200 Ion Steering"
 		"Hyperdrive"
+		"Laser Rifle" 24
 
 
 
@@ -584,6 +618,7 @@ ship "Osprey" "Osprey (Missile)"
 		"A520 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 24
 	gun "Heavy Rocket Launcher"
 	gun "Heavy Rocket Launcher"
 	gun "Torpedo Launcher"
@@ -604,6 +639,7 @@ ship "Raven" "Raven (Heavy)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 13
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Meteor Missile Launcher"
@@ -623,6 +659,7 @@ ship "Splinter" "Splinter (Laser)"
 		"X3700 Ion Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 21
 	turret "Heavy Laser Turret"
 	turret "Heavy Anti-Missile Turret"
 	turret "Heavy Laser Turret"
@@ -640,6 +677,7 @@ ship "Splinter" "Splinter (Proton)"
 		"X3700 Ion Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 21
 	turret "Proton Turret"
 	turret "Anti-Missile Turret"
 	turret "Proton Turret"
@@ -657,6 +695,7 @@ ship "Falcon" "Falcon (Laser)"
 		"Impala Plasma Thruster"
 		"Orca Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 75
 
 
 
@@ -673,6 +712,7 @@ ship "Falcon" "Falcon (Heavy)"
 		"Orca Plasma Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 75
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
 	gun "Meteor Missile Launcher"
@@ -693,6 +733,7 @@ ship "Leviathan" "Leviathan (Laser)"
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 64
 
 
 
@@ -712,6 +753,7 @@ ship "Leviathan" "Leviathan (Heavy)"
 		"Afterburner"
 		"Scram Drive"
 		"Ramscoop"
+		"Laser Rifle" 64
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Torpedo Launcher"
@@ -731,6 +773,7 @@ ship "Protector" "Protector (Laser)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 69
 	turret "Laser Turret"
 	turret "Laser Turret"
 	turret "Heavy Laser Turret"
@@ -751,6 +794,7 @@ ship "Protector" "Protector (Proton)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 69
 
 
 
@@ -764,6 +808,7 @@ ship "Vanguard" "Vanguard (Particle)"
 		"X3700 Ion Thruster"
 		"X4200 Ion Steering"
 		"Hyperdrive"
+		"Laser Rifle" 45
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -783,6 +828,7 @@ ship "Heavy Shuttle" "Heavy Shuttle (Armed)"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 8
 
 
 
@@ -794,6 +840,7 @@ ship "Flivver" "Flivver (Racing)"
 		"A120 Atomic Thruster"
 		"A125 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 3
 
 
 
@@ -810,6 +857,7 @@ ship "Berserker" "Berserker (Afterburner)"
 		"Greyhound Plasma Steering"
 		"Afterburner"
 		"Hyperdrive"
+		"Laser Rifle" 2
 
 
 
@@ -822,6 +870,7 @@ ship "Headhunter" "Headhunter (Particle)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 4
 
 
 
@@ -836,6 +885,7 @@ ship "Modified Argosy" "Modified Argosy (Heavy)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 12
 
 
 
@@ -851,6 +901,7 @@ ship "Modified Argosy" "Modified Argosy (Blaster)"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
+		"Laser Rifle" 12
 
 
 
@@ -868,6 +919,7 @@ ship "Modified Argosy" "Modified Argosy (Missile)"
 		"X3700 Ion Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 12
 
 
 
@@ -882,6 +934,7 @@ ship "Falcon" "Falcon (Plasma)"
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 75
 
 
 
@@ -895,6 +948,7 @@ ship "Fury" "Fury (Flamethrower)"
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
 		"Hyperdrive"
+		"Laser Rifle" 3
 
 
 
@@ -909,6 +963,7 @@ ship "Rainmaker" "Rainmaker (Mark II)"
 		"A120 Atomic Thruster"
 		"A125 Atomic Steering"
 		"Scram Drive"
+		"Laser Rifle" 14
 	gun
 	gun
 	gun "Sidewinder Missile Launcher"
@@ -930,6 +985,7 @@ ship "Gunboat" "Gunboat (Mark II)"
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 12
 
 
 
@@ -947,6 +1003,7 @@ ship "Frigate" "Frigate (Mark II)"
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 44
 	turret "Anti-Missile Turret"
 	turret "Blaster Turret"
 	turret "Blaster Turret"
@@ -969,6 +1026,7 @@ ship "Cruiser" "Cruiser (Mark II)"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 136
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
@@ -998,6 +1056,7 @@ ship "Carrier" "Carrier (Mark II)"
 		"A860 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 184
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Sidewinder Missile Launcher"
@@ -1030,6 +1089,7 @@ ship "Behemoth" "Behemoth (Heavy)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 30
 	turret "Quad Blaster Turret"
 	turret "Quad Blaster Turret"
 	turret "Plasma Turret"
@@ -1052,6 +1112,7 @@ ship "Splinter" "Splinter (Mark II)"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 		"Ionic Afterburner"
+		"Laser Rifle" 21
 
 
 
@@ -1069,6 +1130,7 @@ ship "Manta" "Manta (Mark II)"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 		"Ionic Afterburner"
+		"Laser Rifle" 10
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -1088,6 +1150,7 @@ ship "Quicksilver" "Quicksilver (Mark II)"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 6
 
 
 
@@ -1103,6 +1166,7 @@ ship "Manta" "Manta (Nuclear)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 10
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -1131,6 +1195,7 @@ ship "Cruiser" "Cruiser (Jump)"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Jump Drive"
+		"Laser Rifle" 136
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Typhoon Launcher"
@@ -1162,6 +1227,7 @@ ship "Carrier" "Carrier (Jump)"
 		"A860 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Jump Drive"
+		"Laser Rifle" 184
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Sidewinder Missile Launcher"
@@ -1190,6 +1256,7 @@ ship "Dreadnought" "Dreadnought (Jump)"
 		"Orca Plasma Thruster"
 		"Orca Plasma Steering"
 		"Jump Drive"
+		"Laser Rifle" 147
 
 
 
@@ -1204,6 +1271,7 @@ ship "Clipper" "Clipper (Nuclear)"
 		"A255 Atomic Steering"
 		"Hyperdrive"
 		"Afterburner"
+		"Laser Rifle" 9
 
 
 
@@ -1220,6 +1288,7 @@ ship "Osprey" "Osprey (Alien Weapons)"
 		`"Bondir" Atomic Thruster`
 		`"Bondir" Atomic Steering`
 		Hyperdrive
+		"Laser Rifle" 24
 
 
 
@@ -1236,6 +1305,7 @@ ship "Nest" "Nest (Sidewinder)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
+		"Laser Rifle" 14
 
 
 
@@ -1252,6 +1322,7 @@ ship "Roost" "Roost (Sidewinder)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
+		"Laser Rifle" 16
 
 
 
@@ -1269,6 +1340,7 @@ ship "Skein" "Skein (Sidewinder)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
+		"Laser Rifle" 18
 
 
 
@@ -1281,6 +1353,7 @@ ship "Lance" "Lance (Gatling)"
 		"D14-RN Shield Generator"
 		"X1700 Ion Thruster"
 		"X1200 Ion Steering"
+		"Laser Rifle" 1
 
 
 
@@ -1293,6 +1366,7 @@ ship "Barb" "Barb (Gatling)"
 		Supercapacitor 3
 		"D14-RN Shield Generator"
 		"X1050 Ion Engines"
+		"Laser Rifle" 2
 
 
 
@@ -1306,6 +1380,7 @@ ship "Fury" "Fury (Gatling)"
 		"X2700 Ion Thruster"
 		"A125 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 3
 
 
 
@@ -1319,6 +1394,7 @@ ship "Sparrow" "Sparrow (Gatling)"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 2
 
 
 
@@ -1330,6 +1406,7 @@ ship "Flivver" "Flivver (Hai)"
 		`"Basrem" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
+		"Laser Rifle" 3
 
 
 
@@ -1345,6 +1422,7 @@ ship "Arrow" "Arrow (Hai)"
 		`"Benga" Atomic Thruster`
 		`"Biroo" Atomic Steering`
 		"Hyperdrive"
+		"Laser Rifle" 5
 
 
 
@@ -1359,6 +1437,7 @@ ship "Bounder" "Bounder (Hai)"
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
+		"Laser Rifle" 17
 
 
 
@@ -1374,6 +1453,7 @@ ship "Star Queen" "Star Queen (Hai)"
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 112
 
 
 
@@ -1390,6 +1470,7 @@ ship "Freighter" "Freighter (Hai)"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
+		"Laser Rifle" 7
 	turret "Pulse Turret"
 	turret "Laser Turret"
 	turret "Bullfrog Anti-Missile"
@@ -1410,6 +1491,7 @@ ship "Hauler" "Hauler (Hai)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 12
 	turret "Quad Blaster Turret"
 	turret "Chameleon Anti-Missile"
 	turret "Chameleon Anti-Missile"
@@ -1431,6 +1513,7 @@ ship "Hauler II" "Hauler II (Hai)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 12
 	turret "Quad Blaster Turret"
 	turret "Chameleon Anti-Missile"
 	turret "Chameleon Anti-Missile"
@@ -1452,6 +1535,7 @@ ship "Hauler III" "Hauler III (Hai)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 12
 	turret "Quad Blaster Turret"
 	turret "Chameleon Anti-Missile"
 	turret "Chameleon Anti-Missile"
@@ -1474,6 +1558,7 @@ ship "Behemoth" "Behemoth (Hai)"
 		`"Biroo" Atomic Steering`
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
+		"Laser Rifle" 30
 
 
 
@@ -1490,6 +1575,7 @@ ship "Bulk Freighter" "Bulk Freighter (Hai)"
 		`"Benga" Atomic Steering`
 		`"Basrem" Atomic Steering`
 		"Scram Drive"
+		"Laser Rifle" 18
 	turret "Pulse Turret"
 	turret "Pulse Turret"
 	turret "Chameleon Anti-Missile"
@@ -1508,6 +1594,7 @@ ship "Headhunter" "Headhunter (Hai)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 4
 
 
 
@@ -1524,6 +1611,7 @@ ship "Corvette" "Corvette (Hai)"
 		`"Biroo" Atomic Thruster`
 		`"Bondir" Atomic Steering`
 		"Hyperdrive"
+		"Laser Rifle" 32
 
 
 
@@ -1540,6 +1628,7 @@ ship "Firebird" "Firebird (Hai Weapons)"
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
+		"Laser Rifle" 22
 
 
 
@@ -1557,6 +1646,7 @@ ship "Firebird" "Firebird (Hai Shields)"
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 32
 
 
 
@@ -1578,6 +1668,7 @@ ship "Mule" "Mule (Hai Engines)"
 		`"Biroo" Atomic Steering`
 		`"Basrem" Atomic Steering`
 		"Hyperdrive"
+		"Laser Rifle" 42
 
 
 
@@ -1595,6 +1686,7 @@ ship "Mule" "Mule (Hai Weapons)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 42
 
 
 
@@ -1610,6 +1702,7 @@ ship "Leviathan" "Leviathan (Hai Engines)"
 		`"Bondir" Atomic Thruster`
 		`"Bondir" Atomic Steering`
 		"Hyperdrive"
+		"Laser Rifle" 64
 
 
 
@@ -1627,6 +1720,7 @@ ship "Leviathan" "Leviathan (Hai Weapons)"
 		"Afterburner"
 		"Scram Drive"
 		"Ramscoop"
+		"Laser Rifle" 64
 
 
 
@@ -1648,6 +1742,7 @@ ship "Bactrian" "Bactrian (Hai Engines)"
 		`"Bufaer" Atomic Thruster`
 		`"Bufaer" Atomic Steering`
 		"Hyperdrive"
+		"Laser Rifle" 245
 
 
 
@@ -1669,6 +1764,7 @@ ship "Bactrian" "Bactrian (Hai Weapons)"
 		"X4700 Ion Thruster"
 		"X5200 Ion Steering"
 		"Hyperdrive"
+		"Laser Rifle" 245
 	gun "Pulse Cannon"
 	gun "Pulse Cannon"
 	gun "Hai Tracker Pod"
@@ -1693,6 +1789,7 @@ ship "Quicksilver" "Quicksilver (Scanner)"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 6
 
 
 
@@ -1711,6 +1808,7 @@ ship "Bastion" "Bastion (Scanner)"
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
+		"Laser Rifle" 40
 
 
 
@@ -1725,6 +1823,7 @@ ship "Freighter" "Freighter (Secret Cargo)"
 		"X2200 Ion Steering"
 		"Scram Drive"
 		"Secret Cargo"
+		"Laser Rifle" 7
 
 
 
@@ -1743,3 +1842,4 @@ ship "Bactrian" "Bactrian (Hired Gun)"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 245

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -373,10 +373,10 @@ ship "Bulk Freighter" "Bulk Freighter (Blaster)"
 		"D94-YV Shield Generator"
 		"Water Coolant System"
 		"Outfits Expansion" 2
+		"Laser Rifle" 17
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 6
 
 
 

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -14,10 +14,10 @@ ship "Star Barge" "Star Barge (Armed)"
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Laser Rifle"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -29,10 +29,10 @@ ship "Sparrow" "Sparrow (Patrol)"
 		"D14-RN Shield Generator"
 		"Cargo Scanner"
 		"Outfit Scanner"
+		"Laser Rifle"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -41,11 +41,11 @@ ship "Raven" "Raven (Afterburner)"
 		"Heavy Laser" 4
 		"NT-200 Nucleovoltaic"
 		"D41-HY Shield Generator"
+		"Laser Rifle" 11
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
 		"Afterburner"
-		"Laser Rifle" 6
 
 
 
@@ -55,10 +55,10 @@ ship "Wasp" "Wasp (Proton)"
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Laser Rifle"
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -70,10 +70,10 @@ ship "Manta" "Manta (Proton)"
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
 		"D14-RN Shield Generator"
+		"Laser Rifle" 3
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 6
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Proton Gun"
@@ -90,10 +90,10 @@ ship "Quicksilver" "Quicksilver (Proton)"
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
 		"Cooling Ducts"
+		"Laser Rifle" 3
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
 
 
 
@@ -113,11 +113,11 @@ ship "Cruiser" "Cruiser (Heavy)"
 		"Liquid Helium Cooler"
 		"Ramscoop"
 		"Outfits Expansion"
+		"Laser Rifle" 128
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"X2200 Ion Steering"
 		"Scram Drive"
-		"Laser Rifle" 81
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -143,10 +143,10 @@ ship "Scout" "Scout (Speedy)"
 		"D23-QP Shield Generator"
 		"Cooling Ducts"
 		"Outfits Expansion"
+		"Laser Rifle" 5
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 2
 
 
 
@@ -159,10 +159,10 @@ ship "Clipper" "Clipper (Heavy)"
 		"RT-I Radiothermal"
 		"Supercapacitor"
 		"D67-TM Shield Generator"
+		"Laser Rifle"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Scram Drive"
-		"Laser Rifle" 3
 
 
 
@@ -173,10 +173,10 @@ ship "Clipper" "Clipper (Speedy)"
 		"Supercapacitor"
 		"D41-HY Shield Generator"
 		"Cooling Ducts"
+		"Laser Rifle" 7
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
 
 
 
@@ -189,10 +189,10 @@ ship "Freighter" "Freighter (Fancy)"
 		"D14-RN Shield Generator"
 		"Ramscoop"
 		"Outfits Expansion"
+		"Laser Rifle" 6
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Scram Drive"
-		"Laser Rifle" 2
 	turret "Laser Turret"
 	turret "Laser Turret"
 	turret "Heavy Anti-Missile Turret"
@@ -208,10 +208,10 @@ ship "Freighter" "Freighter (Proton)"
 		"D14-RN Shield Generator"
 		"Ramscoop"
 		"Outfits Expansion"
+		"Laser Rifle"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Scram Drive"
-		"Laser Rifle" 2
 
 
 
@@ -224,10 +224,10 @@ ship "Argosy" "Argosy (Laser)"
 		"Supercapacitor"
 		"D67-TM Shield Generator"
 		"Outfits Expansion" 2
+		"Laser Rifle" 7
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 4
 
 
 
@@ -241,10 +241,10 @@ ship "Argosy" "Argosy (Missile)"
 		"Supercapacitor"
 		"D41-HY Shield Generator"
 		"Outfits Expansion"
+		"Laser Rifle" 9
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 4
 	turret "Anti-Missile Turret"
 	turret "Heavy Anti-Missile Turret"
 
@@ -258,10 +258,10 @@ ship "Argosy" "Argosy (Proton)"
 		"Supercapacitor"
 		"D67-TM Shield Generator"
 		"Outfits Expansion" 2
+		"Laser Rifle" 3
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 4
 
 
 
@@ -273,10 +273,10 @@ ship "Argosy" "Argosy (Turret)"
 		"D41-HY Shield Generator"
 		"Small Radar Jammer"
 		"Outfits Expansion"
+		"Laser Rifle" 10
 		"X3700 Ion Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 4
 
 
 
@@ -288,10 +288,10 @@ ship "Argosy" "Argosy (Blaster)"
 		"LP072a Battery Pack"
 		"D41-HY Shield Generator"
 		"Outfits Expansion"
+		"Laser Rifle" 3
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 4
 
 
 
@@ -307,11 +307,11 @@ ship "Behemoth" "Behemoth (Proton)"
 		"Large Radar Jammer"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion" 6
+		"Laser Rifle" 3
 		"A250 Atomic Thruster"
 		"A125 Atomic Steering"
 		"A375 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 12
 	turret "Proton Turret"
 	turret "Proton Turret"
 	turret "Proton Turret"
@@ -332,11 +332,11 @@ ship "Behemoth" "Behemoth (Speedy)"
 		"Large Radar Jammer"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion" 6
+		"Laser Rifle" 6
 		"A250 Atomic Thruster"
 		"A125 Atomic Steering"
 		"A375 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 12
 
 
 
@@ -351,10 +351,10 @@ ship "Bulk Freighter" "Bulk Freighter (Heavy)"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
 		"Outfits Expansion"
+		"Laser Rifle"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 6
 	turret "Laser Turret"
 	turret "Laser Turret"
 	turret "Heavy Anti-Missile Turret"
@@ -390,10 +390,10 @@ ship "Bulk Freighter" "Bulk Freighter (Proton)"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
 		"Outfits Expansion"
+		"Laser Rifle" 8
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 6
 
 
 
@@ -404,10 +404,10 @@ ship "Fury" "Fury (Missile)"
 		"nGVF-BB Fuel Cell"
 		"Supercapacitor" 3
 		"D14-RN Shield Generator"
+		"Laser Rifle" 
 		"Greyhound Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -418,10 +418,10 @@ ship "Fury" "Fury (Laser)"
 		"Supercapacitor"
 		"D23-QP Shield Generator"
 		"Cooling Ducts"
+		"Laser Rifle"
 		"Chipmunk Plasma Thruster"
 		"A125 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -431,10 +431,10 @@ ship "Hawk" "Hawk (Speedy)"
 		"S3 Thermionic"
 		"Supercapacitor" 3
 		"D41-HY Shield Generator"
+		"Laser Rifle" 2
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 2
 
 
 
@@ -445,10 +445,10 @@ ship "Hawk" "Hawk (Rocket)"
 		"RT-I Radiothermal"
 		"Supercapacitor" 2
 		"D41-HY Shield Generator"
+		"Laser Rifle"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 2
 
 
 
@@ -461,10 +461,10 @@ ship "Bastion" "Bastion (Heavy)"
 		"D67-TM Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion" 2
+		"Laser Rifle" 24
 		"X3700 Ion Thruster"
 		"Orca Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 17
 
 
 
@@ -479,10 +479,10 @@ ship "Bastion" "Bastion (Laser)"
 		"Small Radar Jammer"
 		"Water Coolant System"
 		"Outfits Expansion"
+		"Laser Rifle" 34
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 17
 	turret "Heavy Anti-Missile Turret"
 	turret "Heavy Laser Turret"
 	turret "Heavy Laser Turret"
@@ -498,10 +498,10 @@ ship "Corvette" "Corvette (Speedy)"
 		"D41-HY Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Cooling Ducts"
+		"Laser Rifle" 31
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 8
 
 
 
@@ -517,10 +517,10 @@ ship "Corvette" "Corvette (Missile)"
 		"D94-YV Shield Generator"
 		"Cooling Ducts"
 		"Cargo Expansion"
+		"Laser Rifle" 8
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 8
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Torpedo Launcher"
@@ -538,10 +538,10 @@ ship "Firebird" "Firebird (Plasma)"
 		"D41-HY Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion"
+		"Laser Rifle" 4
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 7
 
 
 
@@ -556,10 +556,10 @@ ship "Firebird" "Firebird (Missile)"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
 		"Outfits Expansion"
+		"Laser Rifle" 10
 		"Impala Plasma Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 7
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Torpedo Launcher"
@@ -579,10 +579,10 @@ ship "Mule" "Mule (Heavy)"
 		"Water Coolant System"
 		"Outfits Expansion"
 		"Ramscoop"
+		"Laser Rifle" 39
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 6
 
 
 
@@ -595,10 +595,10 @@ ship "Osprey" "Osprey (Laser)"
 		"Supercapacitor" 4
 		"D94-YV Shield Generator"
 		"Water Coolant System"
+		"Laser Rifle" 3
 		"Impala Plasma Thruster"
 		"X4200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 9
 
 
 
@@ -614,10 +614,10 @@ ship "Osprey" "Osprey (Missile)"
 		"Supercapacitor" 3
 		"D41-HY Shield Generator"
 		"Water Coolant System"
+		"Laser Rifle" 19
 		"A520 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 9
 	gun "Heavy Rocket Launcher"
 	gun "Heavy Rocket Launcher"
 	gun "Torpedo Launcher"
@@ -635,10 +635,10 @@ ship "Raven" "Raven (Heavy)"
 		"D23-QP Shield Generator"
 		"Water Coolant System"
 		"Cooling Ducts"
+		"Laser Rifle" 6
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 6
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Meteor Missile Launcher"
@@ -655,10 +655,10 @@ ship "Splinter" "Splinter (Laser)"
 		"Fission Reactor"
 		"LP036a Battery Pack"
 		"D94-YV Shield Generator"
+		"Laser Rifle" 12
 		"X3700 Ion Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 7
 	turret "Heavy Laser Turret"
 	turret "Heavy Anti-Missile Turret"
 	turret "Heavy Laser Turret"
@@ -673,10 +673,10 @@ ship "Splinter" "Splinter (Proton)"
 		"Fission Reactor"
 		"LP036a Battery Pack"
 		"D94-YV Shield Generator"
+		"Laser Rifle" 5
 		"X3700 Ion Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 7
 	turret "Proton Turret"
 	turret "Anti-Missile Turret"
 	turret "Proton Turret"
@@ -691,10 +691,10 @@ ship "Falcon" "Falcon (Laser)"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
 		"Small Radar Jammer"
+		"Laser Rifle" 73
 		"Impala Plasma Thruster"
 		"Orca Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 75
 
 
 
@@ -708,10 +708,10 @@ ship "Falcon" "Falcon (Heavy)"
 		"Fusion Reactor"
 		"D67-TM Shield Generator"
 		"Small Radar Jammer"
+		"Laser Rifle" 68
 		"Orca Plasma Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 52
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
 	gun "Meteor Missile Launcher"
@@ -729,10 +729,10 @@ ship "Leviathan" "Leviathan (Laser)"
 		"D94-YV Shield Generator"
 		"Liquid Helium Cooler"
 		"Ramscoop"
+		"Laser Rifle" 38
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 64
 
 
 
@@ -747,12 +747,12 @@ ship "Leviathan" "Leviathan (Heavy)"
 		"LP036a Battery Pack"
 		"D94-YV Shield Generator" 2
 		"Liquid Nitrogen Cooler"
+		"Laser Rifle" 5
 		"Impala Plasma Thruster"
 		"A375 Atomic Steering"
 		"Afterburner"
 		"Scram Drive"
 		"Ramscoop"
-		"Laser Rifle" 43
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Torpedo Launcher"
@@ -769,10 +769,10 @@ ship "Protector" "Protector (Laser)"
 		"Supercapacitor" 3
 		"D94-YV Shield Generator" 2
 		"Water Coolant System"
+		"Laser Rifle" 66
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 30
 	turret "Laser Turret"
 	turret "Laser Turret"
 	turret "Heavy Laser Turret"
@@ -790,10 +790,10 @@ ship "Protector" "Protector (Proton)"
 		"Supercapacitor" 3
 		"D94-YV Shield Generator" 2
 		"Water Coolant System"
+		"Laser Rifle" 40
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 30
 
 
 
@@ -804,10 +804,10 @@ ship "Vanguard" "Vanguard (Particle)"
 		"LP072a Battery Pack"
 		"D67-TM Shield Generator"
 		"Liquid Nitrogen Cooler"
+		"Laser Rifle" 8
 		"X3700 Ion Thruster"
 		"X4200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 23
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -824,10 +824,10 @@ ship "Heavy Shuttle" "Heavy Shuttle (Armed)"
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Laser Rifle" 6
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -836,10 +836,10 @@ ship "Flivver" "Flivver (Racing)"
 		"RT-I Radiothermal"
 		"D14-RN Shield Generator"
 		"Water Coolant System"
+		"Laser Rifle"
 		"A120 Atomic Thruster"
 		"A125 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -852,11 +852,11 @@ ship "Berserker" "Berserker (Afterburner)"
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
 		"Ramscoop"
+		"Laser Rifle"
 		"Chipmunk Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Afterburner"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -866,10 +866,10 @@ ship "Headhunter" "Headhunter (Particle)"
 		"NT-200 Nucleovoltaic"
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
+		"Laser Rifle" 4
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 2
 
 
 
@@ -881,10 +881,10 @@ ship "Modified Argosy" "Modified Argosy (Heavy)"
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
 		"Water Coolant System"
+		"Laser Rifle" 9
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 5
 
 
 
@@ -897,10 +897,10 @@ ship "Modified Argosy" "Modified Argosy (Blaster)"
 		"D67-TM Shield Generator"
 		"Small Radar Jammer"
 		"Liquid Nitrogen Cooler"
+		"Laser Rifle" 6
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 5
 
 
 
@@ -915,10 +915,10 @@ ship "Modified Argosy" "Modified Argosy (Missile)"
 		"S3 Thermionic"
 		"LP072a Battery Pack"
 		"D41-HY Shield Generator"
+		"Laser Rifle" 4
 		"X3700 Ion Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 5
 
 
 
@@ -930,10 +930,10 @@ ship "Falcon" "Falcon (Plasma)"
 		"D41-HY Shield Generator"
 		"Small Radar Jammer"
 		"Liquid Nitrogen Cooler"
+		"Laser Rifle" 13
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 52
 
 
 
@@ -944,10 +944,10 @@ ship "Fury" "Fury (Flamethrower)"
 		"Supercapacitor"
 		"D14-RN Shield Generator"
 		"Ramscoop"
+		"Laser Rifle"
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -959,10 +959,10 @@ ship "Rainmaker" "Rainmaker (Mark II)"
 		"LP036a Battery Pack"
 		"D67-TM Shield Generator"
 		"Fuel Pod"
+		"Laser Rifle" 9
 		"A120 Atomic Thruster"
 		"A125 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 7
 	gun
 	gun
 	gun "Sidewinder Missile Launcher"
@@ -981,10 +981,10 @@ ship "Gunboat" "Gunboat (Mark II)"
 		"D41-HY Shield Generator"
 		"Water Coolant System"
 		"Outfits Expansion" 2
+		"Laser Rifle" 3
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 7
 
 
 
@@ -999,10 +999,10 @@ ship "Frigate" "Frigate (Mark II)"
 		"D41-HY Shield Generator"
 		"Water Coolant System"
 		"Outfits Expansion"
+		"Laser Rifle" 21
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 21
 	turret "Anti-Missile Turret"
 	turret "Blaster Turret"
 	turret "Blaster Turret"
@@ -1022,10 +1022,10 @@ ship "Cruiser" "Cruiser (Mark II)"
 		"D94-YV Shield Generator"
 		"Liquid Helium Cooler"
 		"Fuel Pod"
+		"Laser Rifle" 116
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 81
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
@@ -1052,10 +1052,10 @@ ship "Carrier" "Carrier (Mark II)"
 		"D94-YV Shield Generator"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 3
+		"Laser Rifle" 34
 		"A860 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 111
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Sidewinder Missile Launcher"
@@ -1082,12 +1082,12 @@ ship "Behemoth" "Behemoth (Heavy)"
 		"Supercapacitor"
 		"D94-YV Shield Generator"
 		"Outfits Expansion" 6
+		"Laser Rifle" 3
 		"Liquid Helium Cooler"
 		"Liquid Nitrogen Cooler"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 12
 	turret "Quad Blaster Turret"
 	turret "Quad Blaster Turret"
 	turret "Plasma Turret"
@@ -1106,11 +1106,11 @@ ship "Splinter" "Splinter (Mark II)"
 		"S-970 Regenerator"
 		"Water Coolant System" 4
 		"Outfits Expansion" 2
+		"Laser Rifle" 13
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 		"Ionic Afterburner"
-		"Laser Rifle" 7
 
 
 
@@ -1124,11 +1124,11 @@ ship "Manta" "Manta (Mark II)"
 		"S-270 Regenerator"
 		"Water Coolant System"
 		"Outfits Expansion"
+		"Laser Rifle" 10
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 		"Ionic Afterburner"
-		"Laser Rifle" 6
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -1145,10 +1145,10 @@ ship "Quicksilver" "Quicksilver (Mark II)"
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
 		"Cooling Ducts"
+		"Laser Rifle" 2
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
 
 
 
@@ -1161,10 +1161,10 @@ ship "Manta" "Manta (Nuclear)"
 		"S-270 Regenerator"
 		"Water Coolant System"
 		"Outfits Expansion"
+		"Laser Rifle" 2
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 6
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -1190,10 +1190,10 @@ ship "Cruiser" "Cruiser (Jump)"
 		"Fuel Pod" 2
 		"Ramscoop"
 		"Outfits Expansion" 2
+		"Laser Rifle" 136
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Jump Drive"
-		"Laser Rifle" 81
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Typhoon Launcher"
@@ -1222,10 +1222,10 @@ ship "Carrier" "Carrier (Jump)"
 		"Water Coolant System"
 		"Fuel Pod"
 		"Outfits Expansion" 4
+		"Laser Rifle" 162
 		"A860 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Jump Drive"
-		"Laser Rifle" 111
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Sidewinder Missile Launcher"
@@ -1251,10 +1251,10 @@ ship "Dreadnought" "Dreadnought (Jump)"
 		"D41-HY Shield Generator"
 		"Small Radar Jammer"
 		"Liquid Helium Cooler"
+		"Laser Rifle" 51
 		"Orca Plasma Thruster"
 		"Orca Plasma Steering"
 		"Jump Drive"
-		"Laser Rifle" 84
 
 
 
@@ -1265,11 +1265,11 @@ ship "Clipper" "Clipper (Nuclear)"
 		"Supercapacitor"
 		"D67-TM Shield Generator"
 		"Catalytic Ramscoop"
+		"Laser Rifle" 3
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
 		"Afterburner"
-		"Laser Rifle" 3
 
 
 
@@ -1283,10 +1283,10 @@ ship "Osprey" "Osprey (Alien Weapons)"
 		"Hai Fissure Batteries"
 		"Hai Corundum Regenerator"
 		"Liquid Nitrogen Cooler"
+		"Laser Rifle" 7
 		`"Bondir" Atomic Thruster`
 		`"Bondir" Atomic Steering`
 		Hyperdrive
-		"Laser Rifle" 9
 
 
 
@@ -1300,10 +1300,10 @@ ship "Nest" "Nest (Sidewinder)"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
 		"Large Radar Jammer"
+		"Laser Rifle" 5
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
-		"Laser Rifle" 5
 
 
 
@@ -1317,10 +1317,10 @@ ship "Roost" "Roost (Sidewinder)"
 		"S3 Thermionic"
 		"D94-YV Shield Generator" 2
 		"Small Radar Jammer"
+		"Laser Rifle" 
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
-		"Laser Rifle" 7
 
 
 
@@ -1335,10 +1335,10 @@ ship "Skein" "Skein (Sidewinder)"
 		"D94-YV Shield Generator" 3
 		"Large Radar Jammer"
 		"Outfits Expansion" 2
+		"Laser Rifle" 13
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
-		"Laser Rifle" 7
 
 
 
@@ -1349,9 +1349,9 @@ ship "Lance" "Lance (Gatling)"
 		Supercapacitor
 		"nGVF-BB Fuel Cell"
 		"D14-RN Shield Generator"
+		"Laser Rifle"
 		"X1700 Ion Thruster"
 		"X1200 Ion Steering"
-		"Laser Rifle"
 
 
 
@@ -1363,8 +1363,8 @@ ship "Barb" "Barb (Gatling)"
 		"nGVF-AA Fuel Cell"
 		Supercapacitor 3
 		"D14-RN Shield Generator"
-		"X1050 Ion Engines"
 		"Laser Rifle"
+		"X1050 Ion Engines"
 
 
 
@@ -1375,10 +1375,10 @@ ship "Fury" "Fury (Gatling)"
 		"nGVF-CC Fuel Cell"
 		"Supercapacitor"
 		"D23-QP Shield Generator"
+		"Laser Rifle"
 		"X2700 Ion Thruster"
 		"A125 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -1389,10 +1389,10 @@ ship "Sparrow" "Sparrow (Gatling)"
 		"nGVF-AA Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Laser Rifle"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -1401,10 +1401,10 @@ ship "Flivver" "Flivver (Hai)"
 		"RT-I Radiothermal"
 		"D14-RN Shield Generator"
 		"Hai Williwaw Cooling"
+		"Laser Rifle"
 		`"Basrem" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -1417,10 +1417,10 @@ ship "Arrow" "Arrow (Hai)"
 		"Supercapacitor" 2
 		"D14-RN Shield Generator"
 		"Small Radar Jammer"
+		"Laser Rifle" 2
 		`"Benga" Atomic Thruster`
 		`"Biroo" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -1432,10 +1432,10 @@ ship "Bounder" "Bounder (Hai)"
 		"Hai Fissure Batteries"
 		"D14-RN Shield Generator"
 		"Hai Williwaw Cooling"
+		"Laser Rifle" 15
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle"
 
 
 
@@ -1448,10 +1448,10 @@ ship "Star Queen" "Star Queen (Hai)"
 		"Hai Fissure Batteries"
 		"D94-YV Shield Generator"
 		"Small Radar Jammer"
+		"Laser Rifle" 51
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 43
 
 
 
@@ -1465,10 +1465,10 @@ ship "Freighter" "Freighter (Hai)"
 		"D14-RN Shield Generator"
 		"Ramscoop"
 		"Outfits Expansion"
+		"Laser Rifle" 7
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 2
 	turret "Pulse Turret"
 	turret "Laser Turret"
 	turret "Bullfrog Anti-Missile"
@@ -1486,10 +1486,10 @@ ship "Hauler" "Hauler (Hai)"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
 		"Small Radar Jammer"
+		"Laser Rifle" 4
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
 	turret "Quad Blaster Turret"
 	turret "Chameleon Anti-Missile"
 	turret "Chameleon Anti-Missile"
@@ -1508,10 +1508,10 @@ ship "Hauler II" "Hauler II (Hai)"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
 		"Small Radar Jammer"
+		"Laser Rifle" 
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
 	turret "Quad Blaster Turret"
 	turret "Chameleon Anti-Missile"
 	turret "Chameleon Anti-Missile"
@@ -1530,10 +1530,10 @@ ship "Hauler III" "Hauler III (Hai)"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
 		"Small Radar Jammer"
+		"Laser Rifle" 5
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
 	turret "Quad Blaster Turret"
 	turret "Chameleon Anti-Missile"
 	turret "Chameleon Anti-Missile"
@@ -1552,11 +1552,11 @@ ship "Behemoth" "Behemoth (Hai)"
 		"Large Radar Jammer"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion" 6
+		"Laser Rifle" 11
 		`"Benga" Atomic Thruster`
 		`"Biroo" Atomic Steering`
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 12
 
 
 
@@ -1569,11 +1569,11 @@ ship "Bulk Freighter" "Bulk Freighter (Hai)"
 		"RT-I Radiothermal"
 		"Hai Ravine Batteries"
 		"D23-QP Shield Generator"
+		"Laser Rifle" 8
 		"X3700 Ion Thruster"
 		`"Benga" Atomic Steering`
 		`"Basrem" Atomic Steering`
 		"Scram Drive"
-		"Laser Rifle" 6
 	turret "Pulse Turret"
 	turret "Pulse Turret"
 	turret "Chameleon Anti-Missile"
@@ -1589,10 +1589,10 @@ ship "Headhunter" "Headhunter (Hai)"
 		"Hai Chasm Batteries"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
+		"Laser Rifle"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 2
 
 
 
@@ -1606,10 +1606,10 @@ ship "Corvette" "Corvette (Hai)"
 		"D94-YV Shield Generator"
 		"Cooling Ducts"
 		"Cargo Expansion"
+		"Laser Rifle" 19
 		`"Biroo" Atomic Thruster`
 		`"Bondir" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 8
 
 
 
@@ -1623,10 +1623,10 @@ ship "Firebird" "Firebird (Hai Weapons)"
 		"Hai Gorge Batteries"
 		"D41-HY Shield Generator"
 		"Hai Williwaw Cooling" 2
+		"Laser Rifle" 18
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 7
 
 
 
@@ -1641,10 +1641,10 @@ ship "Firebird" "Firebird (Hai Shields)"
 		"Liquid Nitrogen Cooler"
 		"Hai Williwaw Cooling"
 		"Outfits Expansion" 2
+		"Laser Rifle" 12
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 7
 
 
 
@@ -1662,11 +1662,11 @@ ship "Mule" "Mule (Hai Engines)"
 		"Cooling Ducts"
 		"Outfits Expansion"
 		"Ramscoop"
+		"Laser Rifle" 42
 		`"Bondir" Atomic Thruster`
 		`"Biroo" Atomic Steering`
 		`"Basrem" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 6
 
 
 
@@ -1681,10 +1681,10 @@ ship "Mule" "Mule (Hai Weapons)"
 		"Water Coolant System"
 		"Outfits Expansion" 3
 		"Ramscoop"
+		"Laser Rifle" 9
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 6
 
 
 
@@ -1697,10 +1697,10 @@ ship "Leviathan" "Leviathan (Hai Engines)"
 		"Hai Ravine Batteries"
 		"D67-TM Shield Generator"
 		"Liquid Helium Cooler"
+		"Laser Rifle" 55
 		`"Bondir" Atomic Thruster`
 		`"Bondir" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 43
 
 
 
@@ -1713,12 +1713,12 @@ ship "Leviathan" "Leviathan (Hai Weapons)"
 		"Hai Ravine Batteries"
 		"Hai Diamond Regenerator"
 		"Liquid Nitrogen Cooler"
+		"Laser Rifle" 29
 		"Impala Plasma Thruster"
 		"A375 Atomic Steering"
 		"Afterburner"
 		"Scram Drive"
 		"Ramscoop"
-		"Laser Rifle" 43
 
 
 
@@ -1737,10 +1737,10 @@ ship "Bactrian" "Bactrian (Hai Engines)"
 		"Hai Williwaw Cooling" 3
 		"Ramscoop"
 		"Outfits Expansion" 2
+		"Laser Rifle" 200
 		`"Bufaer" Atomic Thruster`
 		`"Bufaer" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 70
 
 
 
@@ -1759,10 +1759,10 @@ ship "Bactrian" "Bactrian (Hai Weapons)"
 		"Hai Williwaw Cooling" 2
 		"Ramscoop"
 		"Large Radar Jammer"
+		"Laser Rifle" 189
 		"X4700 Ion Thruster"
 		"X5200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 70
 	gun "Pulse Cannon"
 	gun "Pulse Cannon"
 	gun "Hai Tracker Pod"
@@ -1784,10 +1784,10 @@ ship "Quicksilver" "Quicksilver (Scanner)"
 		"D23-QP Shield Generator"
 		"Cooling Ducts"
 		"Cargo Scanner"
+		"Laser Rifle" 5
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
 
 
 
@@ -1803,10 +1803,10 @@ ship "Bastion" "Bastion (Scanner)"
 		"D67-TM Shield Generator"
 		"Water Coolant System"
 		"Cargo Scanner"
+		"Laser Rifle" 18
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 17
 
 
 
@@ -1817,11 +1817,11 @@ ship "Freighter" "Freighter (Secret Cargo)"
 		"nGVF-EE Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Laser Rifle" 4
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
 		"Scram Drive"
 		"Secret Cargo"
-		"Laser Rifle" 2
 
 
 
@@ -1837,7 +1837,7 @@ ship "Bactrian" "Bactrian (Hired Gun)"
 		"Water Coolant System"
 		"Outfits Expansion" 2
 		"Large Radar Jammer"
+		"Laser Rifle" 169
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 70

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -105,7 +105,6 @@ ship "Cruiser" "Cruiser (Heavy)"
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		"Quad Blaster Turret"
-		"Laser Rifle" 20
 		"Fragmentation Grenades" 20
 		"Armageddon Core"
 		"Dwarf Core"
@@ -1079,7 +1078,6 @@ ship "Behemoth" "Behemoth (Heavy)"
 		"Quad Blaster Turret" 2
 		"Plasma Turret" 2
 		"Heavy Anti-Missile Turret" 2
-		"Laser Rifle" 16
 		"Fusion Reactor"
 		"Supercapacitor"
 		"D94-YV Shield Generator"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -105,7 +105,6 @@ ship "Cruiser" "Cruiser (Heavy)"
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		"Quad Blaster Turret"
-		"Fragmentation Grenades" 20
 		"Armageddon Core"
 		"Dwarf Core"
 		"Supercapacitor"
@@ -113,6 +112,7 @@ ship "Cruiser" "Cruiser (Heavy)"
 		"Liquid Helium Cooler"
 		"Ramscoop"
 		"Outfits Expansion"
+		"Fragmentation Grenades" 20
 		"Laser Rifle" 128
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -1082,9 +1082,9 @@ ship "Behemoth" "Behemoth (Heavy)"
 		"Supercapacitor"
 		"D94-YV Shield Generator"
 		"Outfits Expansion" 6
-		"Laser Rifle" 3
 		"Liquid Helium Cooler"
 		"Liquid Nitrogen Cooler"
+		"Laser Rifle" 3
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -17,7 +17,7 @@ ship "Star Barge" "Star Barge (Armed)"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
+		"Laser Rifle"
 
 
 
@@ -32,7 +32,7 @@ ship "Sparrow" "Sparrow (Patrol)"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 2
+		"Laser Rifle"
 
 
 
@@ -45,7 +45,7 @@ ship "Raven" "Raven (Afterburner)"
 		"X3200 Ion Steering"
 		"Hyperdrive"
 		"Afterburner"
-		"Laser Rifle" 13
+		"Laser Rifle" 6
 
 
 
@@ -58,7 +58,7 @@ ship "Wasp" "Wasp (Proton)"
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 2
+		"Laser Rifle"
 
 
 
@@ -73,7 +73,7 @@ ship "Manta" "Manta (Proton)"
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 10
+		"Laser Rifle" 6
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Proton Gun"
@@ -93,7 +93,7 @@ ship "Quicksilver" "Quicksilver (Proton)"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 6
+		"Laser Rifle" 3
 
 
 
@@ -117,7 +117,7 @@ ship "Cruiser" "Cruiser (Heavy)"
 		"A525 Atomic Steering"
 		"X2200 Ion Steering"
 		"Scram Drive"
-		"Laser Rifle" 136
+		"Laser Rifle" 81
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -146,7 +146,7 @@ ship "Scout" "Scout (Speedy)"
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 12
+		"Laser Rifle" 2
 
 
 
@@ -162,7 +162,7 @@ ship "Clipper" "Clipper (Heavy)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Scram Drive"
-		"Laser Rifle" 9
+		"Laser Rifle" 3
 
 
 
@@ -176,7 +176,7 @@ ship "Clipper" "Clipper (Speedy)"
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 9
+		"Laser Rifle" 3
 
 
 
@@ -192,7 +192,7 @@ ship "Freighter" "Freighter (Fancy)"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Scram Drive"
-		"Laser Rifle" 7
+		"Laser Rifle" 2
 	turret "Laser Turret"
 	turret "Laser Turret"
 	turret "Heavy Anti-Missile Turret"
@@ -211,7 +211,7 @@ ship "Freighter" "Freighter (Proton)"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Scram Drive"
-		"Laser Rifle" 7
+		"Laser Rifle" 2
 
 
 
@@ -227,7 +227,7 @@ ship "Argosy" "Argosy (Laser)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 14
+		"Laser Rifle" 4
 
 
 
@@ -244,7 +244,7 @@ ship "Argosy" "Argosy (Missile)"
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 14
+		"Laser Rifle" 4
 	turret "Anti-Missile Turret"
 	turret "Heavy Anti-Missile Turret"
 
@@ -261,7 +261,7 @@ ship "Argosy" "Argosy (Proton)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 14
+		"Laser Rifle" 4
 
 
 
@@ -276,7 +276,7 @@ ship "Argosy" "Argosy (Turret)"
 		"X3700 Ion Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 14
+		"Laser Rifle" 4
 
 
 
@@ -291,7 +291,7 @@ ship "Argosy" "Argosy (Blaster)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 14
+		"Laser Rifle" 4
 
 
 
@@ -311,7 +311,7 @@ ship "Behemoth" "Behemoth (Proton)"
 		"A125 Atomic Steering"
 		"A375 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 30
+		"Laser Rifle" 12
 	turret "Proton Turret"
 	turret "Proton Turret"
 	turret "Proton Turret"
@@ -336,7 +336,7 @@ ship "Behemoth" "Behemoth (Speedy)"
 		"A125 Atomic Steering"
 		"A375 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 30
+		"Laser Rifle" 12
 
 
 
@@ -354,7 +354,7 @@ ship "Bulk Freighter" "Bulk Freighter (Heavy)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 18
+		"Laser Rifle" 6
 	turret "Laser Turret"
 	turret "Laser Turret"
 	turret "Heavy Anti-Missile Turret"
@@ -376,7 +376,7 @@ ship "Bulk Freighter" "Bulk Freighter (Blaster)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 18
+		"Laser Rifle" 6
 
 
 
@@ -393,7 +393,7 @@ ship "Bulk Freighter" "Bulk Freighter (Proton)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 18
+		"Laser Rifle" 6
 
 
 
@@ -407,7 +407,7 @@ ship "Fury" "Fury (Missile)"
 		"Greyhound Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
+		"Laser Rifle"
 
 
 
@@ -421,7 +421,7 @@ ship "Fury" "Fury (Laser)"
 		"Chipmunk Plasma Thruster"
 		"A125 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
+		"Laser Rifle"
 
 
 
@@ -434,7 +434,7 @@ ship "Hawk" "Hawk (Speedy)"
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 4
+		"Laser Rifle" 2
 
 
 
@@ -448,7 +448,7 @@ ship "Hawk" "Hawk (Rocket)"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 4
+		"Laser Rifle" 2
 
 
 
@@ -464,7 +464,7 @@ ship "Bastion" "Bastion (Heavy)"
 		"X3700 Ion Thruster"
 		"Orca Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 40
+		"Laser Rifle" 17
 
 
 
@@ -482,7 +482,7 @@ ship "Bastion" "Bastion (Laser)"
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 40
+		"Laser Rifle" 17
 	turret "Heavy Anti-Missile Turret"
 	turret "Heavy Laser Turret"
 	turret "Heavy Laser Turret"
@@ -501,7 +501,7 @@ ship "Corvette" "Corvette (Speedy)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 32
+		"Laser Rifle" 8
 
 
 
@@ -520,7 +520,7 @@ ship "Corvette" "Corvette (Missile)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 32
+		"Laser Rifle" 8
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Torpedo Launcher"
@@ -541,7 +541,7 @@ ship "Firebird" "Firebird (Plasma)"
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 22
+		"Laser Rifle" 7
 
 
 
@@ -559,7 +559,7 @@ ship "Firebird" "Firebird (Missile)"
 		"Impala Plasma Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 22
+		"Laser Rifle" 7
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Torpedo Launcher"
@@ -582,7 +582,7 @@ ship "Mule" "Mule (Heavy)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 42
+		"Laser Rifle" 6
 
 
 
@@ -598,7 +598,7 @@ ship "Osprey" "Osprey (Laser)"
 		"Impala Plasma Thruster"
 		"X4200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 24
+		"Laser Rifle" 9
 
 
 
@@ -617,7 +617,7 @@ ship "Osprey" "Osprey (Missile)"
 		"A520 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 24
+		"Laser Rifle" 9
 	gun "Heavy Rocket Launcher"
 	gun "Heavy Rocket Launcher"
 	gun "Torpedo Launcher"
@@ -638,7 +638,7 @@ ship "Raven" "Raven (Heavy)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 13
+		"Laser Rifle" 6
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Meteor Missile Launcher"
@@ -658,7 +658,7 @@ ship "Splinter" "Splinter (Laser)"
 		"X3700 Ion Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 21
+		"Laser Rifle" 7
 	turret "Heavy Laser Turret"
 	turret "Heavy Anti-Missile Turret"
 	turret "Heavy Laser Turret"
@@ -676,7 +676,7 @@ ship "Splinter" "Splinter (Proton)"
 		"X3700 Ion Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 21
+		"Laser Rifle" 7
 	turret "Proton Turret"
 	turret "Anti-Missile Turret"
 	turret "Proton Turret"
@@ -711,7 +711,7 @@ ship "Falcon" "Falcon (Heavy)"
 		"Orca Plasma Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 75
+		"Laser Rifle" 52
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
 	gun "Meteor Missile Launcher"
@@ -752,7 +752,7 @@ ship "Leviathan" "Leviathan (Heavy)"
 		"Afterburner"
 		"Scram Drive"
 		"Ramscoop"
-		"Laser Rifle" 64
+		"Laser Rifle" 43
 	gun "Meteor Missile Launcher"
 	gun "Meteor Missile Launcher"
 	gun "Torpedo Launcher"
@@ -772,7 +772,7 @@ ship "Protector" "Protector (Laser)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 69
+		"Laser Rifle" 30
 	turret "Laser Turret"
 	turret "Laser Turret"
 	turret "Heavy Laser Turret"
@@ -793,7 +793,7 @@ ship "Protector" "Protector (Proton)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 69
+		"Laser Rifle" 30
 
 
 
@@ -807,7 +807,7 @@ ship "Vanguard" "Vanguard (Particle)"
 		"X3700 Ion Thruster"
 		"X4200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 45
+		"Laser Rifle" 23
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -827,7 +827,7 @@ ship "Heavy Shuttle" "Heavy Shuttle (Armed)"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 8
+		"Laser Rifle"
 
 
 
@@ -839,7 +839,7 @@ ship "Flivver" "Flivver (Racing)"
 		"A120 Atomic Thruster"
 		"A125 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
+		"Laser Rifle"
 
 
 
@@ -856,7 +856,7 @@ ship "Berserker" "Berserker (Afterburner)"
 		"Greyhound Plasma Steering"
 		"Afterburner"
 		"Hyperdrive"
-		"Laser Rifle" 2
+		"Laser Rifle"
 
 
 
@@ -869,7 +869,7 @@ ship "Headhunter" "Headhunter (Particle)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 4
+		"Laser Rifle" 2
 
 
 
@@ -884,7 +884,7 @@ ship "Modified Argosy" "Modified Argosy (Heavy)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 12
+		"Laser Rifle" 5
 
 
 
@@ -900,7 +900,7 @@ ship "Modified Argosy" "Modified Argosy (Blaster)"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 12
+		"Laser Rifle" 5
 
 
 
@@ -918,7 +918,7 @@ ship "Modified Argosy" "Modified Argosy (Missile)"
 		"X3700 Ion Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 12
+		"Laser Rifle" 5
 
 
 
@@ -933,7 +933,7 @@ ship "Falcon" "Falcon (Plasma)"
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 75
+		"Laser Rifle" 52
 
 
 
@@ -947,7 +947,7 @@ ship "Fury" "Fury (Flamethrower)"
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
+		"Laser Rifle"
 
 
 
@@ -962,7 +962,7 @@ ship "Rainmaker" "Rainmaker (Mark II)"
 		"A120 Atomic Thruster"
 		"A125 Atomic Steering"
 		"Scram Drive"
-		"Laser Rifle" 14
+		"Laser Rifle" 7
 	gun
 	gun
 	gun "Sidewinder Missile Launcher"
@@ -984,7 +984,7 @@ ship "Gunboat" "Gunboat (Mark II)"
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 12
+		"Laser Rifle" 7
 
 
 
@@ -1002,7 +1002,7 @@ ship "Frigate" "Frigate (Mark II)"
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 44
+		"Laser Rifle" 21
 	turret "Anti-Missile Turret"
 	turret "Blaster Turret"
 	turret "Blaster Turret"
@@ -1025,7 +1025,7 @@ ship "Cruiser" "Cruiser (Mark II)"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 136
+		"Laser Rifle" 81
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
@@ -1055,7 +1055,7 @@ ship "Carrier" "Carrier (Mark II)"
 		"A860 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 184
+		"Laser Rifle" 111
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Sidewinder Missile Launcher"
@@ -1087,7 +1087,7 @@ ship "Behemoth" "Behemoth (Heavy)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 30
+		"Laser Rifle" 12
 	turret "Quad Blaster Turret"
 	turret "Quad Blaster Turret"
 	turret "Plasma Turret"
@@ -1110,7 +1110,7 @@ ship "Splinter" "Splinter (Mark II)"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 		"Ionic Afterburner"
-		"Laser Rifle" 21
+		"Laser Rifle" 7
 
 
 
@@ -1128,7 +1128,7 @@ ship "Manta" "Manta (Mark II)"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 		"Ionic Afterburner"
-		"Laser Rifle" 10
+		"Laser Rifle" 6
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -1148,7 +1148,7 @@ ship "Quicksilver" "Quicksilver (Mark II)"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 6
+		"Laser Rifle" 3
 
 
 
@@ -1164,7 +1164,7 @@ ship "Manta" "Manta (Nuclear)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 10
+		"Laser Rifle" 6
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
@@ -1193,7 +1193,7 @@ ship "Cruiser" "Cruiser (Jump)"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Jump Drive"
-		"Laser Rifle" 136
+		"Laser Rifle" 81
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Typhoon Launcher"
@@ -1225,7 +1225,7 @@ ship "Carrier" "Carrier (Jump)"
 		"A860 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Jump Drive"
-		"Laser Rifle" 184
+		"Laser Rifle" 111
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Sidewinder Missile Launcher"
@@ -1254,7 +1254,7 @@ ship "Dreadnought" "Dreadnought (Jump)"
 		"Orca Plasma Thruster"
 		"Orca Plasma Steering"
 		"Jump Drive"
-		"Laser Rifle" 147
+		"Laser Rifle" 84
 
 
 
@@ -1269,7 +1269,7 @@ ship "Clipper" "Clipper (Nuclear)"
 		"A255 Atomic Steering"
 		"Hyperdrive"
 		"Afterburner"
-		"Laser Rifle" 9
+		"Laser Rifle" 3
 
 
 
@@ -1286,7 +1286,7 @@ ship "Osprey" "Osprey (Alien Weapons)"
 		`"Bondir" Atomic Thruster`
 		`"Bondir" Atomic Steering`
 		Hyperdrive
-		"Laser Rifle" 24
+		"Laser Rifle" 9
 
 
 
@@ -1303,7 +1303,7 @@ ship "Nest" "Nest (Sidewinder)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
-		"Laser Rifle" 14
+		"Laser Rifle" 5
 
 
 
@@ -1320,7 +1320,7 @@ ship "Roost" "Roost (Sidewinder)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
-		"Laser Rifle" 16
+		"Laser Rifle" 7
 
 
 
@@ -1338,7 +1338,7 @@ ship "Skein" "Skein (Sidewinder)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		Hyperdrive
-		"Laser Rifle" 18
+		"Laser Rifle" 7
 
 
 
@@ -1351,7 +1351,7 @@ ship "Lance" "Lance (Gatling)"
 		"D14-RN Shield Generator"
 		"X1700 Ion Thruster"
 		"X1200 Ion Steering"
-		"Laser Rifle" 1
+		"Laser Rifle"
 
 
 
@@ -1364,7 +1364,7 @@ ship "Barb" "Barb (Gatling)"
 		Supercapacitor 3
 		"D14-RN Shield Generator"
 		"X1050 Ion Engines"
-		"Laser Rifle" 2
+		"Laser Rifle"
 
 
 
@@ -1378,7 +1378,7 @@ ship "Fury" "Fury (Gatling)"
 		"X2700 Ion Thruster"
 		"A125 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 3
+		"Laser Rifle"
 
 
 
@@ -1392,7 +1392,7 @@ ship "Sparrow" "Sparrow (Gatling)"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 2
+		"Laser Rifle"
 
 
 
@@ -1404,7 +1404,7 @@ ship "Flivver" "Flivver (Hai)"
 		`"Basrem" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 3
+		"Laser Rifle"
 
 
 
@@ -1420,7 +1420,7 @@ ship "Arrow" "Arrow (Hai)"
 		`"Benga" Atomic Thruster`
 		`"Biroo" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 5
+		"Laser Rifle"
 
 
 
@@ -1435,7 +1435,7 @@ ship "Bounder" "Bounder (Hai)"
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 17
+		"Laser Rifle"
 
 
 
@@ -1451,7 +1451,7 @@ ship "Star Queen" "Star Queen (Hai)"
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 112
+		"Laser Rifle" 43
 
 
 
@@ -1468,7 +1468,7 @@ ship "Freighter" "Freighter (Hai)"
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 7
+		"Laser Rifle" 2
 	turret "Pulse Turret"
 	turret "Laser Turret"
 	turret "Bullfrog Anti-Missile"
@@ -1489,7 +1489,7 @@ ship "Hauler" "Hauler (Hai)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 12
+		"Laser Rifle" 3
 	turret "Quad Blaster Turret"
 	turret "Chameleon Anti-Missile"
 	turret "Chameleon Anti-Missile"
@@ -1511,7 +1511,7 @@ ship "Hauler II" "Hauler II (Hai)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 12
+		"Laser Rifle" 3
 	turret "Quad Blaster Turret"
 	turret "Chameleon Anti-Missile"
 	turret "Chameleon Anti-Missile"
@@ -1533,7 +1533,7 @@ ship "Hauler III" "Hauler III (Hai)"
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 12
+		"Laser Rifle" 3
 	turret "Quad Blaster Turret"
 	turret "Chameleon Anti-Missile"
 	turret "Chameleon Anti-Missile"
@@ -1556,7 +1556,7 @@ ship "Behemoth" "Behemoth (Hai)"
 		`"Biroo" Atomic Steering`
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 30
+		"Laser Rifle" 12
 
 
 
@@ -1573,7 +1573,7 @@ ship "Bulk Freighter" "Bulk Freighter (Hai)"
 		`"Benga" Atomic Steering`
 		`"Basrem" Atomic Steering`
 		"Scram Drive"
-		"Laser Rifle" 18
+		"Laser Rifle" 6
 	turret "Pulse Turret"
 	turret "Pulse Turret"
 	turret "Chameleon Anti-Missile"
@@ -1592,7 +1592,7 @@ ship "Headhunter" "Headhunter (Hai)"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 4
+		"Laser Rifle" 2
 
 
 
@@ -1609,7 +1609,7 @@ ship "Corvette" "Corvette (Hai)"
 		`"Biroo" Atomic Thruster`
 		`"Bondir" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 32
+		"Laser Rifle" 8
 
 
 
@@ -1626,7 +1626,7 @@ ship "Firebird" "Firebird (Hai Weapons)"
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 22
+		"Laser Rifle" 7
 
 
 
@@ -1644,7 +1644,7 @@ ship "Firebird" "Firebird (Hai Shields)"
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 32
+		"Laser Rifle" 7
 
 
 
@@ -1666,7 +1666,7 @@ ship "Mule" "Mule (Hai Engines)"
 		`"Biroo" Atomic Steering`
 		`"Basrem" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 42
+		"Laser Rifle" 6
 
 
 
@@ -1684,7 +1684,7 @@ ship "Mule" "Mule (Hai Weapons)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 42
+		"Laser Rifle" 6
 
 
 
@@ -1700,7 +1700,7 @@ ship "Leviathan" "Leviathan (Hai Engines)"
 		`"Bondir" Atomic Thruster`
 		`"Bondir" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 64
+		"Laser Rifle" 43
 
 
 
@@ -1718,7 +1718,7 @@ ship "Leviathan" "Leviathan (Hai Weapons)"
 		"Afterburner"
 		"Scram Drive"
 		"Ramscoop"
-		"Laser Rifle" 64
+		"Laser Rifle" 43
 
 
 
@@ -1740,7 +1740,7 @@ ship "Bactrian" "Bactrian (Hai Engines)"
 		`"Bufaer" Atomic Thruster`
 		`"Bufaer" Atomic Steering`
 		"Hyperdrive"
-		"Laser Rifle" 245
+		"Laser Rifle" 70
 
 
 
@@ -1762,7 +1762,7 @@ ship "Bactrian" "Bactrian (Hai Weapons)"
 		"X4700 Ion Thruster"
 		"X5200 Ion Steering"
 		"Hyperdrive"
-		"Laser Rifle" 245
+		"Laser Rifle" 70
 	gun "Pulse Cannon"
 	gun "Pulse Cannon"
 	gun "Hai Tracker Pod"
@@ -1787,7 +1787,7 @@ ship "Quicksilver" "Quicksilver (Scanner)"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 6
+		"Laser Rifle" 3
 
 
 
@@ -1806,7 +1806,7 @@ ship "Bastion" "Bastion (Scanner)"
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
 		"Hyperdrive"
-		"Laser Rifle" 40
+		"Laser Rifle" 17
 
 
 
@@ -1821,7 +1821,7 @@ ship "Freighter" "Freighter (Secret Cargo)"
 		"X2200 Ion Steering"
 		"Scram Drive"
 		"Secret Cargo"
-		"Laser Rifle" 7
+		"Laser Rifle" 2
 
 
 
@@ -1840,4 +1840,4 @@ ship "Bactrian" "Bactrian (Hired Gun)"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
-		"Laser Rifle" 245
+		"Laser Rifle" 70


### PR DESCRIPTION
A frequent complaint is that seizing ships is too easy. This patch equips human variant ships with a number of hand-to-hand rifles equal to their total bunks (as is already the case with Marauders). 
Would this make seizing individual ships impossibly hard? Not really. However, the advantage is that variant ships are better able to defend themselves, inflicting larger crew losses on the attacker, thus making it harder to seize many ships in quick succession. 
Because ordinary rifles do not take up outfit capacity, this change does not break any builds.

Furthermore, space is a dangerous place. It always seemed a bit weird ships allow themselves to be plundered only to be blown up afterwards. With rifles they might be more willing to fight for their own lifes.

Why only variants and not default ships? Variant ships are not for sale; the AI does not purchase rifles; human players can choose for themselves whether or not they want any hand-to-hand weapons; adding rifles by default also increases purchase price unnecessarily; this is no issue for variants.

This simple patch has the potential to improve gameplay.