### PR TITLE
Fixed some undefined behavior at startup.

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -275,7 +275,7 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, bool isVisible)
 	
 	// Certain events only count towards the NPC's status if originated by
 	// the player: scanning, boarding, or assisting.
-	if(!event.ActorGovernment()->IsPlayer())
+	if(event.ActorGovernment() && !event.ActorGovernment()->IsPlayer())
 		type &= ~(ShipEvent::SCAN_CARGO | ShipEvent::SCAN_OUTFITS
 				| ShipEvent::ASSIST | ShipEvent::BOARD);
 	

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2146,7 +2146,8 @@ double Ship::IdleHeat() const
 	// heat * (1 - diss + activeCool / (100 * mass)) = (heatGen - cool)
 	double production = max(0., attributes.Get("heat generation") - cooling);
 	double dissipation = .001 * attributes.Get("heat dissipation") + activeCooling / (100. * Mass());
-	return production / dissipation;
+
+	return dissipation != 0. ? production / dissipation : 0.;
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -31,6 +31,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <limits>
 
 using namespace std;
 
@@ -2147,7 +2148,7 @@ double Ship::IdleHeat() const
 	double production = max(0., attributes.Get("heat generation") - cooling);
 	double dissipation = .001 * attributes.Get("heat dissipation") + activeCooling / (100. * Mass());
 
-	return dissipation != 0. ? production / dissipation : 0.;
+	return dissipation != 0. ? production / dissipation : numeric_limits<double>::infinity();
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2148,7 +2148,9 @@ double Ship::IdleHeat() const
 	double production = max(0., attributes.Get("heat generation") - cooling);
 	double dissipation = .001 * attributes.Get("heat dissipation") + activeCooling / (100. * Mass());
 
-	return dissipation != 0. ? production / dissipation : numeric_limits<double>::infinity();
+	if(dissipation == 0.)
+		return production == 0. ? heat : numeric_limits<double>::infinity();
+	return production / dissipation;
 }
 
 


### PR DESCRIPTION
At the start of the game, `event.ActorGovernment()` is a null pointer, and dereferencing it is UB. Additionally, some ships do not provide active cooling nor heat dissipation or some other cooling properties, which results in a division by zero. Timer Ship suffers from this problem.

I'm not to sure what `Ship::IdleHeat` actually does, but it seems like the correct behavior is to return 0 in that case.