### PR TITLE
Update AI::DoScatter to ignore out-of-system ships

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -362,7 +362,7 @@ void AI::Step(const PlayerInfo &player)
 		double health = .5 * it->Shields() + it->Hull();
 		bool isPresent = (it->GetSystem() == player.GetSystem());
 		bool isStranded = IsStranded(*it);
-		bool thisIsLaunching = (isLaunching && it->GetSystem() == player.GetSystem());
+		bool thisIsLaunching = (isLaunching && isPresent);
 		if(isStranded || it->IsDisabled())
 		{
 			// Derelicts never ask for help, to make sure that only the player
@@ -2115,9 +2115,12 @@ void AI::DoScatter(Ship &ship, Command &command)
 	
 	double turnRate = ship.TurnRate();
 	double acceleration = ship.Acceleration();
+	// TODO: If there are many ships, use CollisionSet::Circle or another
+	// suitable method to limit which ships are checked.
 	for(const shared_ptr<Ship> &other : ships)
 	{
-		if(other.get() == &ship)
+		// Do not scatter away from yourself, or ships in other systems.
+		if(other.get() == &ship || other->GetSystem() != ship.GetSystem())
 			continue;
 		
 		// Check for any ships that have nearly the same movement profile as


### PR DESCRIPTION
If there are a significant number of ships in-game (either due to the player accepting many NPC-creating missions, such as bounty hunting, or simply having a massive fleet https://github.com/endless-sky/endless-sky/pull/2788#issuecomment-352947338), AI::DoScatter can become a bottleneck as it currently checks against every ship to determine if there is a similar movement profile.

This PR flags the check for a future refinement, while also adding a simple preliminary check that the two ships are in the same system.