### PR TITLE
Update AppStream file to standardize ID and add version, release date, and changelog information

### DIFF
--- a/endless-sky.appdata.xml
+++ b/endless-sky.appdata.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>io.github.EndlessSky.endless-sky</id>
+  <launchable type="desktop-id">endless-sky.desktop</launchable>
   <name>Endless Sky</name>
   <name xml:lang="de">Weltraumspiel</name>
   <name xml:lang="fr">Jeu spatial</name>

--- a/endless-sky.appdata.xml
+++ b/endless-sky.appdata.xml
@@ -18,7 +18,7 @@
   <p>
    Endless Sky is a sandbox-style space exploration game similar to Elite, Escape Velocity, or Star Control. You start out as the captain of a tiny space ship and can choose what to do from there. The game includes a major plot line and many minor missions, but you can choose whether you want to play through the plot or strike out on your own as a merchant or bounty hunter or explorer.
   </p>
-</description>
+  </description>
   <url type="bugtracker">https://github.com/endless-sky/endless-sky/issues</url>
   <url type="help">https://github.com/endless-sky/endless-sky/wiki/PlayersManual</url>
   <url type="homepage">https://endless-sky.github.io/</url>
@@ -33,4 +33,78 @@
       <image>https://endless-sky.github.io/screenshots/beams.jpg</image>
     </screenshot>
   </screenshots>
+  <releases>
+    <release version="0.9.8" date="2017-08-14">
+      <description>
+        <p>Bug fixes:</p>
+        <ul>
+            <li>Typo fixes. (@Amazinite, @Bladewood, @Hadron1776, @MessyMix, @tehhowch)</li>
+            <li>You no longer ever transfer crew to automata when capturing them. (@tehhowch)</li>
+            <li>Fixed ships not fully decloaking after cloaking to repair themselves. (@tehhowch)</li>
+            <li>Shift-selecting a range of ships in a shop no longer includes disabled ships. (@tehhowch)</li>
+            <li>Fixed an error in how the travel plan is drawn when you have no flagship. (@tehhowch)</li>
+            <li>Fixed flashing ships repeatedly triggering the warning siren. (@Hadron1776)</li>
+            <li>Fixed a bug that kept you from landing on planets that aren't on your travel plan. (@tehhowch)</li>
+            <li>Adding a stellar object that is linked to a planet definition now works properly.</li>
+            <li>Map labels now reset to their default state when loading a new game.</li>
+            <li>Fixed a crash that could happen when disowning ships.</li>
+            <li>Fixed a crash that could occur when your flagship is captured.</li>
+            <li>Daily weapon reloads (e.g. when you jump) no longer reset turret angles.</li>
+            <li>Fixed the messages list not resetting if creating a new pilot from the main menu.</li>
+        <ul>
+        <p>Game content:</p>
+        <ul>
+            <li>Fixed a Remnant mission that could be offered on non-Remnant worlds. (@tehhowch)</li>
+            <li>Fixed the turret assignments on the cloaked Archon. (@tehhowch)</li>
+            <li>The uninhabited "Far Monad" world will no longer fine the player. (@Amazinite)</li>
+            <li>Fixed some issues with the Wanderer / Kor Sestor missions. (@tehhowch)</li>
+            <li>Reordering some ship hardpoints for consistency. (@warp-core)</li>
+            <li>Added a different faction log entry for the Remnant if you don't befriend them. (@tehhowch)</li>
+            <li>Added descriptions for the Remnant ships and thumbnail images for their outfits.</li>
+            <li>Made the Remnant's Point Defense Turret far more effective, to justify its price.</li>
+            <li>Made the Remnant generators a bit better, and made the Crystal Capacitor draw power.</li>
+            <li>Made the Starling and Albatross ships a bit faster, and gave the Starling more fuel.</li>
+            <li>Added another wormhole link connecting the rest of the Ember Waste.</li>
+            <li>Wanderer jobs now become less frequent after the Hai invade them.</li>
+            <li>The prison on Clink now "closes" once the war is over.</li>
+            <li>If you bomb Zenith in the Wanderer story, its planet sprite now changes to show the crater.</li>
+            <li>Some Hai ships now have "Quantum Keystones" installed, to match the lore about them.</li>
+            <li>Hai outfitters now sell fuel pods.</li>
+            <li>The mission NPC void sprites are now "mute," like all the others.</li>
+        </ul>
+        <p>Game mechanics:</p>
+        <ul>
+            <li>Fixed some inefficiencies and glitches with ships assisting each other. (@tehhowch)</li>
+            <li>Fixed some bugs with escort pathfinding and spurious refuelling. (@tehhowch)</li>
+            <li>Demanding tribute from a planet now always makes its government and allies hostile.</li>
+            <li>Enemies will no longer hang out just waiting for a player who is beyond the "invisible fence."</li>
+            <li>Missions can now specify a random range of time delays for events.</li>
+            <li>If your ship has no forward-facing guns, auto-aim will no longer activate.</li>
+            <li>The <payment> substitution in missions now shows payment for that action clause, if any.</li>
+            <li>Once a "derelict" NPC has been boarded, it can now repair when landing like an ordinary ship.</li>
+        </ul>
+        <p>User interface:</p>
+        <ul>
+            <li>In the radar, the "blink" color for mission targets is now customizable. (@Hadron1776)</li>
+            <li>Restricted planets are now a different color than hostile planets. (@Hadron1776)</li>
+            <li>If a plugin overrides the start date, new player messages still work correctly. (@Hadron1776)</li>
+            <li>Fixed a missing newline in the scan dialog for harvested materials in cargo. (@tehhowch)</li>
+            <li>In fullscreen mode, the cursor now disappears if you don't move the mouse for 10 seconds.</li>
+            <li>Sped up the main view zoom animation so it's easier to set it to a specific zoom level.</li>
+            <li>Made it so you can sell outfits in cargo without switching to the cargo view.</li>
+            <li>Fixed a case where your flagship could end up included in the escort selection.</li>
+            <li>In the map, systems with "inhabited" worlds but no spaceports now show up as uninhabited.</li>
+            <li>Made it possible to click a planet in the map to set it as your landing target.</li>
+            <li>You can now double-click a snapshot in the Load / Save panel to load it.</li>
+            <li>Planet labels now always use the government color (instead of being red for hostile planets).</li>
+        </ul>
+        <p>Under the hood:</p>
+        <ul>
+            <li>Refactored the assistance-seeking AI to use less CPU time. (@tehhowch)</li>
+            <li>Fixed some missing #includes that messed up compilation in Visual Studio.</li>
+            <li>Fixed some potential issues and dead code found by Clang's static analyzer.</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
 </component>

--- a/endless-sky.appdata.xml
+++ b/endless-sky.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>endless-sky.desktop</id>
+  <id>io.github.EndlessSky.endless-sky</id>
   <name>Endless Sky</name>
   <name xml:lang="de">Weltraumspiel</name>
   <name xml:lang="fr">Jeu spatial</name>


### PR DESCRIPTION
Resolves #3453
Resolves #3461

I've opted to not to rename the desktop file and instead add the `<launchable>` tag to associate the AppStream data with the desktop file. An alternative approach is to remove/not add the `<launchable>` tag, and instead rename the desktop file to match the AppStream ID (i.e. `io.github.EndlessSky.endless-sky.desktop`).

Relevant part of the AppStream spec: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html