### PR TITLE
Correct certain references to Iktat Rek after name change

### DIFF
--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -309,7 +309,7 @@ mission "Wanderers: Rek To Kor Efret"
 	to offer
 		has "Wanderers: First Mereti Attack: done"
 	on offer
-		log `Iktat Rek has survived the Molt, but in a completely new form. Rek is now female, and is only the size of a Wanderer child, and has chosen the name "Ektasi Rek" for herself, meaning something like "communicator" or "bridge-builder."`
+		log `Rek has survived the Molt, but in a completely new form. Rek is now female, and is only the size of a Wanderer child, and has chosen the name "Ektasi Rek" for herself, meaning something like "communicator" or "bridge-builder."`
 		log "People" "Iktat Rek" `Rek underwent the Molt, a mysterious process in which the body of a Wanderer who is exposed to novel stimuli transforms into a completely new species while still maintaining that individual's memories and personality. The new Rek is a female and goes by the name "Ektasi Rek."`
 		log "People" "Ektasi Rek" `Ektasi Rek is the first Wanderer in millennia to undergo the Molt, changing into a completely different species with new capabilities. As more Wanderers go through the Molt, the Wanderers as a whole will have to decide which of these mutations represents the best way for their species to survive and flourish in Korath space.`
 		conversation

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -2227,7 +2227,7 @@ mission "Wanderers Rek 1"
 	to offer
 		has "Wanderers Rek 0: done"
 	on offer
-		log "Brought Iktat Rek to a Wanderer hospital facility. His illness, or molt, is progressing, and he has grown much weaker. But his mind is still as sharp as ever, and in fact he has somehow managed to pick up human language just by listening to the words of the translation machine."
+		log "Brought Rek to a Wanderer hospital facility. His illness, or molt, is progressing, and he has grown much weaker. But his mind is still as sharp as ever, and in fact he has somehow managed to pick up human language just by listening to the words of the translation machine."
 		conversation
 			`A Wanderer hospital is not too different from a human one. You stand in a corner trying not to get in the way as they transfer Rek to a bed and connect him to various tubes and wires. Without his feathers he looks unbelievably fragile, almost skeletal, but the Wanderer nurses and doctors are handling him as gently as possible.`
 			`	Eventually you are left alone with him. For a while he seems to just be gazing off into the distance, his eyes unfocused. Then he seems to realize that you are here and his eyes take on a new depth and alertness as he turns to look at you. Again speaking in your own language, he says, "Go visit the Sko'karak system and tell me what you find there." Then he shuts his eyes and falls asleep.`
@@ -2250,7 +2250,7 @@ mission "Wanderers Rek 2"
 		event "wanderers: more systems lost"
 		conversation
 			`When you arrive, you can tell that the locals are agitated about something. Finally one of them switches into the Hai language and explains to you what is going on. "We have just heard that the Unfettered have [stolen, captured] three more of our worlds," he says, "but do not tell Rek the news."`
-			`	You visit Iktat Rek and tell him that you found nothing out of the ordinary in the Sko'karak system. He barely even opens his eyes as you speak to him. "Go back and look again," he says.`
+			`	You visit Rek and tell him that you found nothing out of the ordinary in the Sko'karak system. He barely even opens his eyes as you speak to him. "Go back and look again," he says.`
 			choice
 				`	"Okay, I'll go and look again."`
 					accept
@@ -2300,7 +2300,7 @@ mission "Wanderers Ap'arak 1"
 	to offer
 		has "Wanderers Rek 3: done"
 	on offer
-		log "Iktat Rek has been placed in protective quarantine in a germ-free room, where he will receive drugs that will suppress his immune system and allow the genetic change that is taking place in his body to be completed. Even if he survives the process, it may change him beyond recognition."
+		log "Rek has been placed in protective quarantine in a germ-free room, where he will receive drugs that will suppress his immune system and allow the genetic change that is taking place in his body to be completed. Even if he survives the process, it may change him beyond recognition."
 		conversation
 			`You hurry into the hospital room. Rek's skin is now almost entirely bare aside from the withered, stringy black feathers that have grown in place of the once rich plumage. Rek's eyes spring open when you enter the room. "You have news," Rek says. "I can see it in your expression. What did you see?" Given how hard it is to read alien facial expressions, it would be quite remarkable if Rek could actually tell anything from looking at your face, but it would not be polite to say so.`
 			choice


### PR DESCRIPTION
I changed only references to actions or facts about Rek after the name change. There are a few later references to actions by Iktat Rek before the name change which I left in place.

The name change happens here: https://github.com/endless-sky/endless-sky/pull/3464/files#diff-2760ec72ad2076e6a39f862d3c509af5L2202 so the intent is to avoid referring to Rek with "Iktat" after that takes place.