### PR TITLE
Typo fixes

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -142,7 +142,7 @@ mission "Smuggler's Den, Part 1"
 			
 			label search
 			`	As you are conversing a bearded man and a rough-looking teenage boy enter the bar and begin looking around the room. "That's our captain," she says. "Please, you have to help us. There's a service tunnel that connects to the back entrance of the bar. We can escape through there."`
-			`	You've heard of these service passageways: the most dangerous part of this lawless station, dimly lit and seldom travelled, except by drug addicts and prostitutes. This whole thing might just be a ruse to lure you into one, where they can attack you without anyone interfering. "No," says the boy, "if we head for the service tunnel, they'll be sure to notice us. Let's just stay at the table until they go away."`
+			`	You've heard of these service passageways: the most dangerous part of this lawless station, dimly lit and seldom traveled, except by drug addicts and prostitutes. This whole thing might just be a ruse to lure you into one, where they can attack you without anyone interfering. "No," says the boy, "if we head for the service tunnel, they'll be sure to notice us. Let's just stay at the table until they go away."`
 			`	The baby begins to cry, softly, and she bounces it gently, trying desperately to quiet it. "Shh. Shh." For the moment, it falls silent.`
 			choice
 				`	(Try the service tunnel.)`

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -1831,7 +1831,7 @@ mission "Wanderers: Sestor Search: Human Spaceport"
 					goto thanks
 			
 			label glad1
-			`	"I am! The attacking ships weren't big, but they were tough: our four heavy laser turrets couldn't even produce a dent in their shields," the captain says. "We even hired a beefy Leviathan to protect us from the pirate raids as we travelled to Farpoint, but when these hostile ships jumped in from the northwest, they made short work of our escort and nearly disabled our ship, too. I had to jump out of the system while in atmosphere to save the ship, but now I'm in debt to all my crew because I didn't meet a rush delivery deadline."`
+			`	"I am! The attacking ships weren't big, but they were tough: our four heavy laser turrets couldn't even produce a dent in their shields," the captain says. "We even hired a beefy Leviathan to protect us from the pirate raids as we traveled to Farpoint, but when these hostile ships jumped in from the northwest, they made short work of our escort and nearly disabled our ship, too. I had to jump out of the system while in atmosphere to save the ship, but now I'm in debt to all my crew because I didn't meet a rush delivery deadline."`
 			choice
 				`	"You really are lucky as hell to be here today."`
 					goto glad

--- a/data/wanderers.txt
+++ b/data/wanderers.txt
@@ -357,7 +357,7 @@ phrase "friendly wanderer"
 		"a welcome "
 		"an honored "
 	word
-		"[visitor, traveller] "
+		"[visitor, traveler] "
 		"guest "
 	word
 		"to "


### PR DESCRIPTION
Changed any instances of `Travel(er/ed/ing)` being spelled with two `L`s to one `L` to match the rest of the uses of the word in game.

Reference: https://github.com/endless-sky/endless-sky/pull/3298#discussion_r158734115