### PR TITLE
Add missing reputation serialization to conversation ConditionSets

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -317,7 +317,10 @@ void ConversationPanel::Goto(int index, int choice)
 		{
 			// Apply nodes alter the player's condition variables but do not
 			// display any conversation text of their own.
+			player.SetReputationConditions();
 			conversation.Conditions(node).Apply(player.Conditions());
+			// Update any altered government reputations.
+			player.CheckReputationConditions();
 		}
 		else
 		{

--- a/source/GameEvent.cpp
+++ b/source/GameEvent.cpp
@@ -124,22 +124,18 @@ void GameEvent::SetDate(const Date &date)
 
 void GameEvent::Apply(PlayerInfo &player)
 {
-	for(const auto &it : GameData::Governments())
-	{
-		int rep = it.second.Reputation();
-		player.Conditions()["reputation: " + it.first] = rep;
-	}
+	// Serialize the current reputation with other governments.
+	player.SetReputationConditions();
 	
+	// Apply this event's ConditionSet to the player's conditions.
 	conditionsToApply.Apply(player.Conditions());
+	// Apply (and store a record of applying) this event's other general
+	// changes (e.g. updating an outfitter's inventory).
 	player.AddChanges(changes);
 	
-	for(const auto &it : GameData::Governments())
-	{
-		int rep = it.second.Reputation();
-		int newRep = player.Conditions()["reputation: " + it.first];
-		if(rep != newRep)
-			it.second.AddReputation(newRep - rep);
-	}
+	// Update the current reputation with other governments (e.g. this
+	// event's ConditionSet may have altered some reputations).
+	player.CheckReputationConditions();
 	
 	for(const System *system : systemsToUnvisit)
 		player.Unvisit(system);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1590,8 +1590,8 @@ const map<string, int> &PlayerInfo::Conditions() const
 
 
 
-// Set and check the reputation conditions, which missions can use to modify
-// the player's reputation.
+// Set and check the reputation conditions, which missions and events can use to
+// modify the player's reputation with other governments.
 void PlayerInfo::SetReputationConditions()
 {
 	for(const auto &it : GameData::Governments())
@@ -2177,6 +2177,7 @@ void PlayerInfo::UpdateAutoConditions()
 	conditions["unpaid fines"] = min(limit, accounts.TotalDebt("Fine"));
 	conditions["unpaid salaries"] = min(limit, accounts.SalariesOwed());
 	conditions["credit score"] = accounts.CreditScore();
+	// Serialize the current reputation with other governments.
 	SetReputationConditions();
 	// Clear any existing ships: conditions. (Note: '!' = ' ' + 1.)
 	auto first = conditions.lower_bound("ships: ");

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -174,8 +174,8 @@ public:
 	int GetCondition(const std::string &name) const;
 	std::map<std::string, int> &Conditions();
 	const std::map<std::string, int> &Conditions() const;
-	// Set and check the reputation conditions, which missions can use to modify
-	// the player's reputation.
+	// Set and check the reputation conditions, which missions and events
+	// can use to modify the player's reputation with other governments.
 	void SetReputationConditions();
 	void CheckReputationConditions();
 	
@@ -184,6 +184,7 @@ public:
 	bool HasVisited(const System *system) const;
 	bool HasVisited(const Planet *planet) const;
 	bool KnowsName(const System *system) const;
+	// Marking a system as visited also "sees" its neighbors.
 	void Visit(const System *system);
 	void Visit(const Planet *planet);
 	// Mark a system and its planets as unvisited, even if visited previously.


### PR DESCRIPTION
Refs #3196 , https://groups.google.com/d/msg/endless-sky/_XAgbcSP6Is/t-jKZSazBQAJ, 
 - Fixes issue where changes to the stored government reputations were not reflected in the current political landscape when the changes were performed via conversation `apply` node.