### PR TITLE
reduced short term value depreciation

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -1048,7 +1048,7 @@ effect "nuke residue slow"
 outfit "Gatling Gun Ammo"
 	plural "Gatling Gun Ammo"
 	category "Ammunition"
-	cost 4
+	cost 5
 	thumbnail "outfit/bullet"
 	"mass" .002
 	"gatling round capacity" -1

--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -27,8 +27,8 @@ namespace {
 	// Names for the two kinds of depreciation records.
 	string NAME[2] = {"fleet depreciation", "stock depreciation"};
 	// Depreciation parameters.
-	double FULL_DEPRECIATION = 0.25;
-	double DAILY_DEPRECIATION = 0.99;
+	double FULL_DEPRECIATION = 0.2;
+	double DAILY_DEPRECIATION = 0.995;
 	int MAX_AGE = 1000;
 }
 


### PR DESCRIPTION
Currently `FULL_DEPRECIATION = 0.25` (i.e. minimum value is 25%) and `DAILY_DEPRECIATION = 0.99`; this proposal changes these value to 0.2 and 0.995 respectively. The resulting values (see lines 331 to 343) are:

```
            current          proposed
one day   : 0.992  (-0.8%) ; 0.995  (-0.5%)
one week  : 0.944  (-5.6%) ; 0.967  (-3.3%)
one month : 0.788 (-21.2%) ; 0.868 (-13.2%)
one year  : 0.262 (-73.8%) ; 0.281 (-71.9%)
two years : 0.250 (-75.0%) ; 0.206 (-79.4%)
```

Effectively this proposal has the following effects:
* short term value loss is lessened, to make it less punitive to try out new things and to travel around to purchase outfits in other areas of space
* the difference after a year is hardly noticeable
* seizing ships is somewhat less profitable, because minimum value is lowered

PS To keep the minimum value of gatling gun bullets at 1, its cost is also increased.
(`5 * 0.2 = 4 * 0.25`)