### PR TITLE
Update Pirate planetary defense missions

### DIFF
--- a/data/conversations.txt
+++ b/data/conversations.txt
@@ -19,6 +19,9 @@ conversation "intro"
 	`	The elevator is so well-tuned that you do not even realize it is moving until it has deposited you back in the lobby. But as you leave the bank, you are smiling. This crazy adventure suddenly feels real to you. You are going to do it. You are finally going to get off this planet.`
 	`	Compared to the bank, you feel much more at home in the shipyard, walking among the rusted out hulks and newer ships that gleam in the sunlight. You smell grease and dirt and rocket fuel; wonderful smells. There are three ship models within your price range. Which one you choose will determine your future...`
 
+
+
+# Conversations shown when launching from a planet with insufficiently equipped ships.
 conversation "flight check: no energy!"
 	scene "scene/engine2"
 	`You've heard enough horror stories about the sort of accidents that happen when starship systems malfunction to be completely convinced of the necessity of a pre-flight safety check. As you listen to the complex symphony of hums, rattles, and clicks of "<ship>" warming up, you run through a mental checklist. Computers: check. Life support: check.`
@@ -38,3 +41,33 @@ conversation "flight check: overheating!"
 	scene "scene/engine"
 	`You've heard enough horror stories about the sort of accidents that happen when starship systems malfunction to be completely convinced of the necessity of a pre-flight safety check. As you listen to the complex symphony of hums, rattles, and clicks of "<ship>" warming up, you run through a mental checklist. Computers: check. Life support: check.`
 	`	By the time you reach the end of the checklist, it has grown uncomfortably warm. The air smells like ozone and hot metal, and your cameras are showing a plume of steam or smoke escaping from the hull near the engines. If your systems are running this hot while still in the atmosphere, they're likely to overheat the moment you hit hard vacuum. You are going to have to either install cooling systems, or trade out some components for lower-heat alternatives.`
+
+
+
+# Planetary defense mission conversations.
+conversation "northern pirate defense"
+	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the Navy! We need every combat-worthy ship to join in the defenses!" This could also be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
+	choice
+		"	(Stay here until the fight is over.)"
+			decline
+		"	(Join the defense fleet.)"
+	"Local pirate forces are preparing to repel the Navy attack. You join them, and take off together..."
+		launch
+
+conversation "core pirate defense"
+	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the Syndicate! We need every combat-worthy ship to join in the defenses!" This could also be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
+	choice
+		"	(Stay here until the fight is over.)"
+			decline
+		"	(Join the defense fleet.)"
+	"Local pirate forces are preparing to repel the Syndicate attack. You join them, and take off together..."
+		launch
+
+conversation "southern pirate defense"
+	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the militia! We need every combat-worthy ship to join in the defenses!" This could also be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
+	choice
+		"	(Stay here until the fight is over.)"
+			decline
+		"	(Join the defense fleet.)"
+	"Local pirate forces are preparing to repel the militia attack. You join them, and take off together..."
+		launch

--- a/data/conversations.txt
+++ b/data/conversations.txt
@@ -41,33 +41,3 @@ conversation "flight check: overheating!"
 	scene "scene/engine"
 	`You've heard enough horror stories about the sort of accidents that happen when starship systems malfunction to be completely convinced of the necessity of a pre-flight safety check. As you listen to the complex symphony of hums, rattles, and clicks of "<ship>" warming up, you run through a mental checklist. Computers: check. Life support: check.`
 	`	By the time you reach the end of the checklist, it has grown uncomfortably warm. The air smells like ozone and hot metal, and your cameras are showing a plume of steam or smoke escaping from the hull near the engines. If your systems are running this hot while still in the atmosphere, they're likely to overheat the moment you hit hard vacuum. You are going to have to either install cooling systems, or trade out some components for lower-heat alternatives.`
-
-
-
-# Planetary defense mission conversations.
-conversation "northern pirate defense"
-	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the Navy! We need every combat-worthy ship to join in the defenses!" This could also be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
-	choice
-		"	(Stay here until the fight is over.)"
-			decline
-		"	(Join the defense fleet.)"
-	"Local pirate forces are preparing to repel the Navy attack. You join them, and take off together..."
-		launch
-
-conversation "core pirate defense"
-	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the Syndicate! We need every combat-worthy ship to join in the defenses!" This could also be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
-	choice
-		"	(Stay here until the fight is over.)"
-			decline
-		"	(Join the defense fleet.)"
-	"Local pirate forces are preparing to repel the Syndicate attack. You join them, and take off together..."
-		launch
-
-conversation "southern pirate defense"
-	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the militia! We need every combat-worthy ship to join in the defenses!" This could also be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
-	choice
-		"	(Stay here until the fight is over.)"
-			decline
-		"	(Join the defense fleet.)"
-	"Local pirate forces are preparing to repel the militia attack. You join them, and take off together..."
-		launch

--- a/data/pirate jobs.txt
+++ b/data/pirate jobs.txt
@@ -91,6 +91,8 @@ mission "Cargo Smuggling [3]"
 		payment 6000 200
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
 
+
+
 mission "Drug Running [0]"
 	name "Drug run to <planet>"
 	job
@@ -175,6 +177,8 @@ mission "Drug Running [3]"
 		payment 9000 250
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
 
+
+
 mission "Bulk Cargo Smuggling [0]"
 	name "Bulk smuggling to <planet>"
 	job
@@ -238,6 +242,8 @@ mission "Bulk Cargo Smuggling [2]"
 		payment 15000 200
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
 
+
+
 mission "Bulk Drug Running [0]"
 	name "Bulk drug run to <planet>"
 	job
@@ -300,6 +306,8 @@ mission "Bulk Drug Running [2]"
 	on complete
 		payment 20000 250
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
+
+
 
 mission "Stealth Cargo Smuggling (North) [0]"
 	name "Highly illegal cargo to <planet>"
@@ -664,6 +672,8 @@ mission "Stealth Cargo Smuggling (South) [1]"
 		payment 75000 300
 		dialog "You find the contact outside of the main city. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
 
+
+
 mission "Stealth Drug Running (North) [0]"
 	name "Highly illegal drugs to <planet>"
 	job
@@ -1027,6 +1037,8 @@ mission "Stealth Drug Running (South) [1]"
 		payment 100000 375
 		dialog "You find the contact outside of the main city. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
 
+
+
 mission "Wanted Passenger [0]"
 	name "Wanted individual to <planet>"
 	job
@@ -1114,6 +1126,8 @@ mission "Wanted Passengers [3]"
 	on complete
 		payment 20000 300
 		dialog "Your <passengers> insist that you land on the edge of the spaceport to avoid being seen. After you land, they pay you <payment> before quickly grabbing their things and leaving your ship."
+
+
 
 mission "Highly Wanted Passenger (North)"
 	name "Galactic criminal to <planet>"
@@ -1358,6 +1372,8 @@ mission "Highly Wanted Passenger (South)"
 		payment 200000 1000
 		dialog "You land outside of the main city to avoid any chances of your passenger being seen. They grab their things and make their way off of your ship after paying you <payment>."
 
+
+
 mission "Slave Transport [0]"
 	name "Transfer slaves to <planet>"
 	job
@@ -1421,6 +1437,8 @@ mission "Slave Transport [2]"
 		payment 75000 400
 		dialog "After landing on <planet>, the pirates move the <bunks> slaves from your ship and pay you <payment>."
 
+
+
 mission "Bulk Slave Transport [0]"
 	name "Transfer slaves to <planet>"
 	job
@@ -1462,6 +1480,8 @@ mission "Bulk Slave Transport [1]"
 	on complete
 		payment 100000 400
 		dialog "After landing on <planet>, the pirates move the <bunks> slaves from your ship and pay you <payment>."
+
+
 
 mission "Mercenary Job (Medium, North, Dangerous Origin)"
 	name "Protection to <planet>"
@@ -1898,6 +1918,8 @@ mission "Escort Stolen Vessel (Extra Large, South, Dangerous Path)"
 	on visit
 		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
 
+
+
 mission "Eliminating Law Enforcement (North, Small)"
 	name "Navy near <system>"
 	repeat
@@ -2032,6 +2054,8 @@ mission "Eliminating Law Enforcement (South, Large)"
 	on complete
 		payment 400000
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the militia fleet."
+
+
 
 mission "Eliminating Competition (North, Small)"
 	name "Competition near <system>"
@@ -2168,6 +2192,8 @@ mission "Eliminating Competition (South, Large)"
 		payment 750000
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the rival gang."
 
+
+
 mission "Raid on Merchants (North)"
 	name "Merchants near <system>"
 	repeat
@@ -2271,7 +2297,7 @@ mission "Northern Pirate Defense"
 		government "Republic"
 		personality heroic staying waiting
 		fleet "Large Republic" 2
-		dialog "The Navy fleets have been eliminated. Return to <destination>."
+		dialog `The Navy fleets have been defeated. Return to <destination>.`
 	npc
 		government "Pirate"
 		personality plunders staying
@@ -2299,7 +2325,7 @@ mission "Northern Pirate Defense [Unpaid]"
 		personality heroic staying waiting
 		fleet "Large Republic"
 		fleet "Small Republic"
-		dialog "The Navy fleets have been eliminated. Return to <destination>."
+		dialog `The Navy fleets have been defeated. Return to <destination>.`
 	npc
 		government "Pirate"
 		personality plunders staying
@@ -2309,6 +2335,15 @@ mission "Northern Pirate Defense [Unpaid]"
 		conversation "northern pirate defense"
 	on complete
 		dialog `Many locals of <planet> thank you for helping to drive off the Navy.`
+
+conversation "northern pirate defense"
+	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the Navy! We need every combat-worthy ship to join the defenses!" This could be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
+	choice
+		`	(Stay here until the fight is over.)`
+			decline
+		`	(Join the defense fleet.)`
+	`	Local pirate forces are preparing to repel the Navy attack. You join them, and take off together...`
+		launch
 
 
 mission "Core Pirate Defense"
@@ -2327,7 +2362,7 @@ mission "Core Pirate Defense"
 		personality heroic staying waiting
 		fleet "Small Syndicate"
 		fleet "Large Syndicate" 2
-		dialog "The Syndicate fleets have been eliminated. Return to <destination>."
+		dialog `The Syndicate fleets have been defeated. Return to <destination>.`
 	npc
 		government "Pirate"
 		personality plunders staying
@@ -2354,7 +2389,7 @@ mission "Core Pirate Defense [Unpaid]"
 		personality heroic staying waiting
 		fleet "Small Syndicate" 2
 		fleet "Large Syndicate"
-		dialog "The Syndicate fleets have been eliminated. Return to <destination>."
+		dialog `The Syndicate fleets have been defeated. Return to <destination>.`
 	npc
 		government "Pirate"
 		personality plunders staying
@@ -2362,7 +2397,16 @@ mission "Core Pirate Defense [Unpaid]"
 	on offer
 		conversation "core pirate defense"
 	on complete
-		dialog `Many locals of <planet> thank you for helping to drive off the <government: npc>.`
+		dialog `Many locals of <planet> thank you for helping to drive off the Syndicate.`
+
+conversation "core pirate defense"
+	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the Syndicate! We need every combat-worthy ship to join the defenses!" This could be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
+	choice
+		`	(Stay here until the fight is over.)`
+			decline
+		`	(Join the defense fleet.)`
+	`	Local pirate forces are preparing to repel the Syndicate attack. You join them, and take off together...`
+		launch
 
 
 mission "Southern Pirate Defense"
@@ -2381,7 +2425,7 @@ mission "Southern Pirate Defense"
 		personality heroic staying waiting
 		fleet "Small Militia"
 		fleet "Large Militia" 2
-		dialog "The militia fleets have been eliminated. Return to <destination>."
+		dialog `The militia fleets have been defeated. Return to <destination>.`
 	npc
 		government "Pirate"
 		personality plunders staying
@@ -2408,7 +2452,7 @@ mission "Southern Pirate Defense [Unpaid]"
 		personality heroic staying waiting
 		fleet "Small Militia" 2
 		fleet "Large Militia"
-		dialog "The militia fleets have been eliminated. Return to <destination>."
+		dialog `The militia fleets have been defeated. Return to <destination>.`
 	npc
 		government "Pirate"
 		personality plunders staying
@@ -2417,6 +2461,15 @@ mission "Southern Pirate Defense [Unpaid]"
 		conversation "southern pirate defense"
 	on complete
 		dialog `Many locals of <planet> thank you for helping to drive off the militia forces.`
+
+conversation "southern pirate defense"
+	`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the militia! We need every combat-worthy ship to join the defenses!" This could be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
+	choice
+		`	(Stay here until the fight is over.)`
+			decline
+		`	(Join the defense fleet.)`
+	`	Local pirate forces are preparing to repel the militia attack. You join them, and take off together...`
+		launch
 
 
 
@@ -2528,6 +2581,8 @@ mission "Cargo Theft (South)"
 		outfit "Secret Cargo" -1
 		payment 1500000
 		dialog "The pirates of <planet> take the secret cargo from your cargo hold and pay you <payment>."
+
+
 
 # Must destroy hunters and land to fail
 mission "Hunted by State [0]"

--- a/data/pirate jobs.txt
+++ b/data/pirate jobs.txt
@@ -2254,13 +2254,15 @@ mission "Raid on Merchants (South)"
 		payment 150000
 		dialog "After counting up the loot from the destroyed merchant fleet, you are given your cut. <payment>"
 
+
+
 mission "Northern Pirate Defense"
 	name "Defend <planet>"
 	repeat
 	minor
 	description "Local Navy forces are attacking <destination>! Defeat them to defend anarchy!"
 	to offer
-		random < 20
+		random < 15
 		"reputation: Pirate" >= 0
 	source
 		government "Pirate"
@@ -2276,17 +2278,38 @@ mission "Northern Pirate Defense"
 		fleet "Large Northern Pirates"
 		fleet "Small Northern Pirates"
 	on offer
-		conversation
-			`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the militia! We need every combat-worthy ship to join in the defenses!" This could also be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
-			choice
-				"	(Stay here until the fight is over.)"
-					decline
-				"	(Join the defense fleet.)"
-			"Local pirate forces are preparing to repel the militia attack. You join them, and take off together..."
-				launch
+		conversation "northern pirate defense"
 	on complete
 		payment 200000
-		dialog "Many locals of <planet> thank you and collectively pay you <payment> for helping to drive off the Navy."
+		dialog `Many locals of <planet> thank you and collectively pay you <payment> for helping to drive off the Navy.`
+
+mission "Northern Pirate Defense [Unpaid]"
+	name "Defend <planet>"
+	repeat
+	minor
+	description "Local Navy forces are attacking <destination>! Defeat them to defend anarchy!"
+	to offer
+		random < 5
+		"reputation: Pirate" >= 0
+	source
+		government "Pirate"
+		attributes "north pirate"
+	npc evade
+		government "Republic"
+		personality heroic staying waiting
+		fleet "Large Republic"
+		fleet "Small Republic"
+		dialog "The Navy fleets have been eliminated. Return to <destination>."
+	npc
+		government "Pirate"
+		personality plunders staying
+		fleet "Large Northern Pirates"
+		fleet "Small Northern Pirates"
+	on offer
+		conversation "northern pirate defense"
+	on complete
+		dialog `Many locals of <planet> thank you for helping to drive off the Navy.`
+
 
 mission "Core Pirate Defense"
 	name "Defend <planet>"
@@ -2294,7 +2317,7 @@ mission "Core Pirate Defense"
 	minor
 	description "Local Syndicate forces are attacking <destination>! Defeat them to defend anarchy!"
 	to offer
-		random < 20
+		random < 15
 		"reputation: Pirate" >= 0
 	source
 		government "Pirate"
@@ -2310,17 +2333,37 @@ mission "Core Pirate Defense"
 		personality plunders staying
 		fleet "Small Core Pirates" 2
 	on offer
-		conversation
-			`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the Syndicate! We need every combat-worthy ship to join in the defenses!" This could also be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
-			choice
-				"	(Stay here until the fight is over.)"
-					decline
-				"	(Join the defense fleet.)"
-			"Local pirate forces are preparing to repel the Syndicate attack. You join them, and take off together..."
-				launch
+		conversation "core pirate defense"
 	on complete
 		payment 200000
-		dialog "Many locals of <planet> thank you and collectively pay you <payment> for helping to drive off the Navy."
+		dialog `Many locals of <planet> thank you and collectively pay you <payment> for helping to drive off the Syndicate.`
+
+mission "Core Pirate Defense [Unpaid]"
+	name "Defend <planet>"
+	repeat
+	minor
+	description "Local Syndicate forces are attacking <destination>! Defeat them to defend anarchy!"
+	to offer
+		random < 5
+		"reputation: Pirate" >= 0
+	source
+		government "Pirate"
+		attributes "core pirate"
+	npc evade
+		government "Syndicate"
+		personality heroic staying waiting
+		fleet "Small Syndicate" 2
+		fleet "Large Syndicate"
+		dialog "The Syndicate fleets have been eliminated. Return to <destination>."
+	npc
+		government "Pirate"
+		personality plunders staying
+		fleet "Small Core Pirates" 2
+	on offer
+		conversation "core pirate defense"
+	on complete
+		dialog `Many locals of <planet> thank you for helping to drive off the <government: npc>.`
+
 
 mission "Southern Pirate Defense"
 	name "Defend <planet>"
@@ -2328,7 +2371,7 @@ mission "Southern Pirate Defense"
 	minor
 	description "Local militia forces are attacking <destination>! Defeat them to defend anarchy!"
 	to offer
-		random < 20
+		random < 15
 		"reputation: Pirate" >= 0
 	source
 		government "Pirate"
@@ -2344,17 +2387,38 @@ mission "Southern Pirate Defense"
 		personality plunders staying
 		fleet "Small Southern Pirates" 2
 	on offer
-		conversation
-			`Suddenly you hear raised voices and shouting outside: "We are under attack! <planet> is under attack by the militia! We need every combat-worthy ship to join in the defenses!" This could also be an easy way to get yourself killed, and you can't even guarantee that you will be paid for your work.`
-			choice
-				"	(Stay here until the fight is over.)"
-					decline
-				"	(Join the defense fleet.)"
-			"Local pirate forces are preparing to repel the militia attack. You join them, and take off together..."
-				launch
+		conversation "southern pirate defense"
 	on complete
 		payment 200000
-		dialog "Many locals of <planet> thank you and collectively pay you <payment> for helping to drive off the Navy."
+		dialog `Many locals of <planet> thank you and collectively pay you <payment> for helping to drive off the militia forces.`
+
+mission "Southern Pirate Defense [Unpaid]"
+	name "Defend <planet>"
+	repeat
+	minor
+	description "Local militia forces are attacking <destination>! Defeat them to defend anarchy!"
+	to offer
+		random < 5
+		"reputation: Pirate" >= 0
+	source
+		government "Pirate"
+		attributes "south pirate"
+	npc evade
+		government "Militia"
+		personality heroic staying waiting
+		fleet "Small Militia" 2
+		fleet "Large Militia"
+		dialog "The militia fleets have been eliminated. Return to <destination>."
+	npc
+		government "Pirate"
+		personality plunders staying
+		fleet "Small Southern Pirates" 2
+	on offer
+		conversation "southern pirate defense"
+	on complete
+		dialog `Many locals of <planet> thank you for helping to drive off the militia forces.`
+
+
 
 outfit "Secret Cargo"
 	category "Special"

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -214,6 +214,9 @@ void GameData::BeginLoad(const char * const *argv)
 // Check for objects that are referred to but never defined.
 void GameData::CheckReferences()
 {
+	for(const auto &it : conversations)
+		if(it.second.IsEmpty())
+			Files::LogError("Warning: conversation \"" + it.first + "\" is referred to, but never defined.");
 	for(const auto &it : effects)
 		if(it.second.Name().empty())
 			Files::LogError("Warning: effect \"" + it.first + "\" is referred to, but never defined.");


### PR DESCRIPTION
 - Fix incorrect references to opposing forces (e.g. "militia" used where it should be "Navy")
 - Add unpaid variants of the defense missions
 - Use stock conversations to hold the `on offer`
 - Add reference checking for stock conversations