### PR TITLE
Use add attributes

### DIFF
--- a/data/drak.txt
+++ b/data/drak.txt
@@ -164,7 +164,7 @@ effect "antimatter dust"
 	"random spin" 50
 
 
-ship Archon
+ship "Archon"
 	noun "entity"
 	sprite ship/archon
 		"frame rate" 0.87
@@ -223,31 +223,9 @@ ship Archon
 	explode "nuke explosion" 3
 	"final explode" "final explosion large"
 
-ship Archon "Archon (Cloaked)"
+ship "Archon" "Archon (Cloaked)"
 	"never disabled"
-	attributes
-		category "Heavy Warship"
-		"cost" 1000000000
-		"shields" 4000000
-		"hull" 1000000
-		"required crew" 1
-		"bunks" 1
-		"mass" 1000
-		"drag" 27
-		"heat dissipation" 40
-		"fuel capacity" 800
-		"cargo space" 0
-		"outfit space" 800
-		"weapon capacity" 600
-		"engine capacity" 200
-		"energy capacity" 10000
-		"energy generation" 500
-		"shield generation" 100
-		"shield energy" 100
-		"hull repair rate" 100
-		"hull energy" 100
-		"heat generation" 17
-		"ramscoop" 100
+	add attributes
 		"cloak" .04
 	turret "Drak Anti-Missile Field"
 	turret "Drak Anti-Missile Field"

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -212,7 +212,6 @@ event "kestrel available: more shields"
 
 ship "Unknown Ship Type"
 	sprite ship/kestrel
-	plural "Kestrels"
 	attributes
 		category "Heavy Warship"
 		"cost" 10300000
@@ -263,7 +262,57 @@ ship "Unknown Ship Type"
 	explode "huge explosion" 30
 	"final explode" "final explosion large"
 
-ship "Unknown Ship Type" "Kestrel"
+ship "Kestrel"
+	sprite ship/kestrel
+	attributes
+		category "Heavy Warship"
+		"cost" 10300000
+		"shields" 17400
+		"hull" 6200
+		"required crew" 72
+		"bunks" 128
+		"mass" 740
+		"drag" 12.5
+		"heat dissipation" .45
+		"fuel capacity" 500
+		"cargo space" 120
+		"outfit space" 810
+		"weapon capacity" 380
+		"engine capacity" 210
+		weapon
+			"blast radius" 260
+			"shield damage" 2600
+			"hull damage" 1300
+			"hit force" 3900
+	outfits
+		"Particle Cannon" 4
+		"Torpedo Launcher" 2
+		"Torpedo" 60
+		"Heavy Laser Turret" 4
+		"Fusion Reactor"
+		"LP144a Battery Pack"
+		"D94-YV Shield Generator"
+		"Liquid Nitrogen Cooler"
+		"Orca Plasma Thruster"
+		"X5200 Ion Steering"
+		"Hyperdrive"
+	engine -14 177
+	engine 14 177
+	gun -31 66 "Particle Cannon"
+	gun 31 66 "Particle Cannon"
+	gun -53 61 "Particle Cannon"
+	gun 53 61 "Particle Cannon"
+	gun -75 57 "Torpedo Launcher"
+	gun 75 57 "Torpedo Launcher"
+	turret -7 -4 "Heavy Laser Turret"
+	turret 7 -4 "Heavy Laser Turret"
+	turret -23 14 "Heavy Laser Turret"
+	turret 23 14 "Heavy Laser Turret"
+	explode "small explosion" 25
+	explode "medium explosion" 35
+	explode "large explosion" 45
+	explode "huge explosion" 30
+	"final explode" "final explosion large"
 	description "Several years ago, while visiting a sweat lodge in search of spiritual renewal, Tarazed's chief ship designer fell into a trance and journeyed to a reality separate from our own. There he saw visions of a strange and elegant starship. Returning to his work with renewed purpose, he spent the next seven years making the Kestrel a reality."
 
 

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -212,6 +212,7 @@ event "kestrel available: more shields"
 
 ship "Unknown Ship Type"
 	sprite ship/kestrel
+	plural "Kestrels"
 	attributes
 		category "Heavy Warship"
 		"cost" 10300000
@@ -262,112 +263,20 @@ ship "Unknown Ship Type"
 	explode "huge explosion" 30
 	"final explode" "final explosion large"
 
-ship "Kestrel"
-	sprite ship/kestrel
-	attributes
-		category "Heavy Warship"
-		"cost" 10300000
-		"shields" 17400
-		"hull" 6200
-		"required crew" 72
-		"bunks" 128
-		"mass" 740
-		"drag" 12.5
-		"heat dissipation" .45
-		"fuel capacity" 500
-		"cargo space" 120
-		"outfit space" 810
-		"weapon capacity" 380
-		"engine capacity" 210
-		weapon
-			"blast radius" 260
-			"shield damage" 2600
-			"hull damage" 1300
-			"hit force" 3900
-	outfits
-		"Particle Cannon" 4
-		"Torpedo Launcher" 2
-		"Torpedo" 60
-		"Heavy Laser Turret" 4
-		"Fusion Reactor"
-		"LP144a Battery Pack"
-		"D94-YV Shield Generator"
-		"Liquid Nitrogen Cooler"
-		"Orca Plasma Thruster"
-		"X5200 Ion Steering"
-		"Hyperdrive"
-	engine -14 177
-	engine 14 177
-	gun -31 66 "Particle Cannon"
-	gun 31 66 "Particle Cannon"
-	gun -53 61 "Particle Cannon"
-	gun 53 61 "Particle Cannon"
-	gun -75 57 "Torpedo Launcher"
-	gun 75 57 "Torpedo Launcher"
-	turret -7 -4 "Heavy Laser Turret"
-	turret 7 -4 "Heavy Laser Turret"
-	turret -23 14 "Heavy Laser Turret"
-	turret 23 14 "Heavy Laser Turret"
-	explode "small explosion" 25
-	explode "medium explosion" 35
-	explode "large explosion" 45
-	explode "huge explosion" 30
-	"final explode" "final explosion large"
+ship "Unknown Ship Type" "Kestrel"
 	description "Several years ago, while visiting a sweat lodge in search of spiritual renewal, Tarazed's chief ship designer fell into a trance and journeyed to a reality separate from our own. There he saw visions of a strange and elegant starship. Returning to his work with renewed purpose, he spent the next seven years making the Kestrel a reality."
 
 
 
 ship "Kestrel" "Kestrel (More Weapons)"
-	attributes
-		category "Heavy Warship"
-		"cost" 10300000
-		"shields" 17400
-		"hull" 6200
-		"required crew" 72
-		"bunks" 128
-		"mass" 740
-		"drag" 12.5
-		"heat dissipation" .45
-		"fuel capacity" 500
-		"cargo space" 120
-		"outfit space" 810
-		"weapon capacity" 400
-		"engine capacity" 210
-
-
+	add attributes
+		"weapon capacity" 20
 
 ship "Kestrel" "Kestrel (More Engines)"
-	attributes
-		category "Heavy Warship"
-		"cost" 10300000
-		"shields" 17400
-		"hull" 6200
-		"required crew" 72
-		"bunks" 128
-		"mass" 740
-		"drag" 12.5
-		"heat dissipation" .45
-		"fuel capacity" 500
-		"cargo space" 120
-		"outfit space" 810
-		"weapon capacity" 380
-		"engine capacity" 230
-
-
+	add attributes
+		"engine capacity" 20
 
 ship "Kestrel" "Kestrel (More Shields)"
-	attributes
-		category "Heavy Warship"
-		"cost" 10300000
-		"shields" 20100
-		"hull" 7500
-		"required crew" 72
-		"bunks" 128
-		"mass" 760
-		"drag" 12.5
-		"heat dissipation" .45
-		"fuel capacity" 500
-		"cargo space" 120
-		"outfit space" 810
-		"weapon capacity" 380
-		"engine capacity" 210
+	add attributes
+		"shields" 2700
+		"hull" 1300

--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -57,25 +57,10 @@ ship "Marauder Arrow"
 	description "This Arrow has had numerous modifications to its hull and internal systems to make more room for outfits - mostly with combat in mind. More shields, weapons, engines, outfit space, and a turret mount nearly push this ship into the Light Warship category, and definitely make it one of the heaviest Interceptors you're likely to find."
 
 
-
 ship "Marauder Arrow" "Marauder Arrow (Engines)"
 	sprite "ship/marrowe"
-	attributes
-		category "Interceptor"
-		"cost" 1320000
-		"shields" 2300
-		"hull" 500
-		"required crew" 2
-		"bunks" 5
-		"mass" 145
-		"drag" 2.7
-		"heat dissipation" .85
-		"fuel capacity" 400
-		"cargo space" 5
-		"outfit space" 210
-		"weapon capacity" 55
-		"engine capacity" 100
-		"self destruct" .25
+	add attributes
+		"engine capacity" 20
 	outfits
 		"Heavy Laser" 2
 		"Anti-Missile Turret"
@@ -91,35 +76,13 @@ ship "Marauder Arrow" "Marauder Arrow (Engines)"
 		
 	engine -10 57
 	engine 10 57
-	gun -6 -36 "Heavy Laser"
-	gun 6 -36 "Heavy Laser"
-	turret 0 15 "Anti-Missile Turret"
-	explode "tiny explosion" 12
-	explode "small explosion" 18
-	explode "medium explosion" 6
-	"final explode" "final explosion small"
 	description "With a third engine mount, you remark that this Arrow seems more like a missile. The beefed-up engines, a little extra outfit capacity, extra shield emitters, and thicker hull plating make this vessel a very competent Interceptor."
-
 
 
 ship "Marauder Arrow" "Marauder Arrow (Weapons)"
 	sprite "ship/marroww"
-	attributes
-		category "Interceptor"
-		"cost" 1320000
-		"shields" 2300
-		"hull" 500
-		"required crew" 2
-		"bunks" 5
-		"mass" 145
-		"drag" 2.7
-		"heat dissipation" .85
-		"fuel capacity" 400
-		"cargo space" 5
-		"outfit space" 210
-		"weapon capacity" 60
-		"engine capacity" 80
-		"self destruct" .25
+	add attributes
+		"weapon capacity" 5
 	outfits
 		"Energy Blaster" 4
 		"Heavy Laser Turret"
@@ -134,17 +97,11 @@ ship "Marauder Arrow" "Marauder Arrow (Weapons)"
 		"A255 Atomic Steering"
 		"Hyperdrive"
 		
-	engine -8 57
-	engine 8 57
 	gun -6 -36 "Energy Blaster"
 	gun 6 -36 "Energy Blaster"
 	gun -7 -34 "Energy Blaster"
 	gun 7 -34 "Energy Blaster"
-	turret 0 15
-	explode "tiny explosion" 12
-	explode "small explosion" 18
-	explode "medium explosion" 6
-	"final explode" "final explosion small"
+	turret 0 15 "Heavy Laser Turret"
 	description "The weapons systems on this Arrow have been enhanced almost to the point of competing with Lionheart's Headhunter. The ship can still outrun all but the fastest ships, if things get a little too hairy."
 
 
@@ -201,25 +158,10 @@ ship "Marauder Bounder"
 	description "This Megaparsec Bounder has been modified from a courier-scout into a heavy escort Interceptor - currently the largest in the class. A little extra outfit space, reinforced turret mounts, a new gun port in front of the pilot, and additional shield emitters bring this former Transport into combat with fearsome speed and armament."
 
 
-
 ship "Marauder Bounder" "Marauder Bounder (Engines)"
 	sprite "ship/mboundere"
-	attributes
-		category "Interceptor"
-		"cost" 1250000
-		"shields" 2500
-		"hull" 700
-		"required crew" 2
-		"bunks" 18
-		"mass" 145
-		"drag" 3.7
-		"heat dissipation" .8
-		"fuel capacity" 900
-		"cargo space" 20
-		"outfit space" 240
-		"weapon capacity" 80
-		"engine capacity" 130
-		"self destruct" .25
+	add attributes
+		"engine capacity" 15
 	outfits
 		"Heavy Laser"
 		"Quad Blaster Turret" 2
@@ -238,35 +180,13 @@ ship "Marauder Bounder" "Marauder Bounder (Engines)"
 	engine -12 58 .7
 	engine 0 51
 	engine 12 58 .7
-	gun 0 -85 "Heavy Laser"
-	turret -38 7 "Quad Blaster Turret"
-	turret 38 7 "Quad Blaster Turret"
-	explode "tiny explosion" 10
-	explode "small explosion" 20
-	explode "medium explosion" 15
-	"final explode" "final explosion small"
 	description "The previous owner of this Bounder has modified an already fast courier-scout into an even faster heavy escort Interceptor with some truly enormous engines, making it incredibly fast for its size."
-
 
 
 ship "Marauder Bounder" "Marauder Bounder (Weapons)"
 	sprite "ship/mbounderw"
-	attributes
-		category "Interceptor"
-		"cost" 1250000
-		"shields" 2500
-		"hull" 700
-		"required crew" 2
-		"bunks" 18
-		"mass" 145
-		"drag" 3.7
-		"heat dissipation" .8
-		"fuel capacity" 900
-		"cargo space" 20
-		"outfit space" 240
-		"weapon capacity" 100
-		"engine capacity" 115
-		"self destruct" .25
+	add attributes
+		"weapon capacity" 20
 	outfits
 		"Modified Blaster" 2
 		"Heavy Laser Turret" 2
@@ -289,10 +209,6 @@ ship "Marauder Bounder" "Marauder Bounder (Weapons)"
 	gun 7 -77 "Modified Blaster"
 	turret -37 4 "Heavy Laser Turret"
 	turret 37 4 "Heavy Laser Turret"
-	explode "tiny explosion" 10
-	explode "small explosion" 20
-	explode "medium explosion" 15
-	"final explode" "final explosion small"
 	description "Simultaneously the deadliest and most graceful Interceptor in the galaxy, this once Bounder courier-scout has been equipped with incredibly powerful weapons for a ship of its size."
 
 
@@ -354,25 +270,10 @@ ship "Marauder Falcon"
 	description "This Tarazed Falcon has been heavily modified by some very dedicated craftsmen. The hull is riddled with extra shield emitters and expanded equipment bays, adding bulk and definitely voiding the warranty."
 
 
-
 ship "Marauder Falcon" "Marauder Falcon (Engines)"
 	sprite "ship/mfalcone"
-	attributes
-		category "Heavy Warship"
-		"cost" 13900000
-		"shields" 14100
-		"hull" 4100
-		"required crew" 43
-		"bunks" 80
-		"mass" 560
-		"drag" 6.7
-		"heat dissipation" .8
-		"fuel capacity" 600
-		"cargo space" 60
-		"outfit space" 580
-		"weapon capacity" 265
-		"engine capacity" 220
-		"self destruct" .1
+	add attributes
+		"engine capacity" 55
 	outfits
 		"Electron Beam" 4
 		"Blaster Turret" 2
@@ -401,34 +302,13 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 	turret 16 -24 "Modified Blaster Turret"
 	turret -57 32.5 "Blaster Turret"
 	turret 57 32.5 "Blaster Turret"
-	explode "tiny explosion" 40
-	explode "small explosion" 55
-	explode "medium explosion" 60
-	explode "large explosion" 40
-	"final explode" "final explosion large"
 	description "Whoever modified this Falcon clearly valued speed above all else. Major sections of the hull have been reconfigured to accommodate the largest possible engines. If hot-rodding across the galaxy in a 1000 ton warship that handles like a Flivver is your dream, look no further."
-
-
 
 
 ship "Marauder Falcon" "Marauder Falcon (Weapons)"
 	sprite "ship/mfalconw"
-	attributes
-		category "Heavy Warship"
-		"cost" 13900000
-		"shields" 14100
-		"hull" 4100
-		"required crew" 43
-		"bunks" 80
-		"mass" 560
-		"drag" 6.7
-		"heat dissipation" .8
-		"fuel capacity" 600
-		"cargo space" 60
-		"outfit space" 580
-		"weapon capacity" 300
-		"engine capacity" 165
-		"self destruct" .1
+	add attributes
+		"weapon capacity" 35
 	outfits
 		"Plasma Cannon" 6
 		"Quad Blaster Turret" 4
@@ -457,11 +337,6 @@ ship "Marauder Falcon" "Marauder Falcon (Weapons)"
 	turret 16 -25 "Quad Blaster Turret"
 	turret -57 32.5 "Quad Blaster Turret"
 	turret 57 32.5 "Quad Blaster Turret"
-	explode "tiny explosion" 40
-	explode "small explosion" 55
-	explode "medium explosion" 60
-	explode "large explosion" 40
-	"final explode" "final explosion large"
 	description "Whoever modified this Falcon clearly believed that firepower was everything. Two additional gun ports have been integrated into the hull, and the ship's interior space has been reconfigured to accommodate nearly any set of weapons you can imagine."
 
 
@@ -521,25 +396,10 @@ ship "Marauder Firebird"
 	description "By the looks of the modification that have taken place, you suspect that this ship contains no original parts. With extra shield emitters, hull plating, and outfit space, this half-millennium young ship is finding new life with its heavy modification."
 
 
-
 ship "Marauder Firebird" "Marauder Firebird (Engines)"
 	sprite "ship/mfirebirde"
-	attributes
-		category "Medium Warship"
-		"cost" 4100000
-		"shields" 7000
-		"hull" 3000
-		"required crew" 10
-		"bunks" 25
-		"mass" 350
-		"drag" 4.5
-		"heat dissipation" .6
-		"fuel capacity" 400
-		"cargo space" 20
-		"outfit space" 450
-		"weapon capacity" 175
-		"engine capacity" 130
-		"self destruct" .15
+	add attributes
+		"engine capacity" 20
 	outfits
 		"Plasma Cannon" 4
 		"Quad Blaster Turret"
@@ -567,33 +427,13 @@ ship "Marauder Firebird" "Marauder Firebird (Engines)"
 	gun 38 -18 "Plasma Cannon"
 	turret -5 3 "Quad Blaster Turret"
 	turret 5 3 "Anti-Missile Turret"
-	explode "tiny explosion" 18
-	explode "small explosion" 36
-	explode "medium explosion" 24
-	explode "large explosion" 8
-	"final explode" "final explosion medium"
 	description "One of the biggest complaints about Betelgeuse's venerable classic from younger pilots is that it's heavy and slow. A previous owner of this ship also believed so, and has fitted another engine port, in addition to setting aside more space for outfits and giving the old ship some new hull plating and shield emitters."
-
 
 
 ship "Marauder Firebird" "Marauder Firebird (Weapons)"
 	sprite "ship/mfirebirdw"
-	attributes
-		category "Medium Warship"
-		"cost" 4100000
-		"shields" 7000
-		"hull" 3000
-		"required crew" 10
-		"bunks" 25
-		"mass" 350
-		"drag" 4.5
-		"heat dissipation" .6
-		"fuel capacity" 400
-		"cargo space" 20
-		"outfit space" 450
-		"weapon capacity" 210
-		"engine capacity" 110
-		"self destruct" .15
+	add attributes
+		"weapon capacity" 35
 	outfits
 		"Particle Cannon" 4
 		"Quad Blaster Turret" 2
@@ -610,19 +450,6 @@ ship "Marauder Firebird" "Marauder Firebird (Weapons)"
 		"A525 Atomic Steering"
 		"Hyperdrive"
 	
-	engine -32 62
-	engine 32 62
-	gun -27 -32 "Particle Cannon"
-	gun 27 -32 "Particle Cannon"
-	gun -38 -18 "Particle Cannon"
-	gun 38 -18 "Particle Cannon"
-	turret -5 3 "Quad Blaster Turret"
-	turret 5 3 "Quad Blaster Turret"
-	explode "tiny explosion" 18
-	explode "small explosion" 36
-	explode "medium explosion" 24
-	explode "large explosion" 8
-	"final explode" "final explosion medium"
 	description "This Medium Warship with one of the heaviest armaments possible just got heavier. With more outfit space, giant gun ports, extra hull plating, and more shield emitters - this blast from the past will make its targets history."
 
 
@@ -742,25 +569,10 @@ ship "Marauder Leviathan"
 	description "The Betelgeuse Shipyards Leviathan has been in service for a long time, and captains have had some very interesting ideas about how to modify them for optimum performance. This one has had the hull surface completely stripped off and replaced with a surface containing more shield projectors per square meter."
 
 
-
 ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 	sprite "ship/mleviathane"
-	attributes
-		category "Heavy Warship"
-		"cost" 10800000
-		"shields" 16000
-		"hull" 5500
-		"required crew" 47
-		"bunks" 68
-		"mass" 640
-		"drag" 7.6
-		"heat dissipation" .5
-		"fuel capacity" 500
-		"cargo space" 40
-		"outfit space" 680
-		"weapon capacity" 265
-		"engine capacity" 220
-		"self destruct" .1
+	add attributes
+		"engine capacity" 80
 	outfits
 		"Electron Beam" 4
 		"Quad Blaster Turret" 4
@@ -780,41 +592,13 @@ ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 	
 	engine -25 125
 	engine 25 125
-	gun -38 -34 "Electron Beam"
-	gun 38 -34 "Electron Beam"
-	gun -50 -23 "Electron Beam"
-	gun 50 -23 "Electron Beam"
-	turret -15 -50 "Quad Blaster Turret"
-	turret 15 -50 "Quad Blaster Turret"
-	turret -25 10 "Quad Blaster Turret"
-	turret 25 10 "Quad Blaster Turret"
-	explode "tiny explosion" 18
-	explode "small explosion" 36
-	explode "medium explosion" 24
-	explode "large explosion" 8
-	"final explode" "final explosion large"
 	description "As if the Leviathan isn't a terrifying enough ship already, this one has been heavily modified with special attention paid to the engine capacity, enabling it to bring its guns to bear even faster."
-
 
 
 ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
 	sprite "ship/mleviathanw"
-	attributes
-		category "Heavy Warship"
-		"cost" 10800000
-		"shields" 16000
-		"hull" 5500
-		"required crew" 47
-		"bunks" 68
-		"mass" 640
-		"drag" 7.6
-		"heat dissipation" .5
-		"fuel capacity" 500
-		"cargo space" 40
-		"outfit space" 680
-		"weapon capacity" 300
-		"engine capacity" 140
-		"self destruct" .1
+	add attributes
+		"weapon capacity" 35
 	outfits
 		"Particle Cannon" 4
 		"Heavy Laser Turret" 4
@@ -832,8 +616,6 @@ ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
 		"Ionic Afterburner"
 		"Hyperdrive"
 	
-	engine -25 120
-	engine 25 120
 	gun -38 -55 "Particle Cannon"
 	gun 38 -55 "Particle Cannon"
 	gun -50 -44 "Particle Cannon"
@@ -842,11 +624,6 @@ ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
 	turret 15 -50 "Heavy Laser Turret"
 	turret -25 10 "Heavy Laser Turret"
 	turret 25 10 "Heavy Laser Turret"
-	explode "tiny explosion" 18
-	explode "small explosion" 36
-	explode "medium explosion" 24
-	explode "large explosion" 8
-	"final explode" "final explosion large"
 	description "This Leviathan once belonged to an infamous pirate captain whose name has been lost to the ages. It's had so much custom work done to it that can hardly even be considered the same ship. The weapons capacity, in particular has been massively increased."
 
 
@@ -908,25 +685,10 @@ ship "Marauder Manta"
 	description `After the Syndicate released their Vanguard Heavy Warship, the Manta fell somewhat out of favor, lacking the ability to mount any anti-missile systems. The owner of this Manta rectified that, added some extra armor plating and shield emitters, and rearranged some of the internals to yield a little more outfit space. Dry tonnage alone keeps it in the Medium Warship category.`
 
 
-
 ship "Marauder Manta" "Marauder Manta (Engines)"
 	sprite "ship/mmantae"
-	attributes
-		category "Medium Warship"
-		"cost" 3740000
-		"shields" 6500
-		"hull" 1750
-		"required crew" 7
-		"bunks" 11
-		"mass" 195
-		"drag" 4.7
-		"heat dissipation" .8
-		"fuel capacity" 400
-		"cargo space" 10
-		"outfit space" 390
-		"weapon capacity" 155
-		"engine capacity" 130
-		"self destruct" .15
+	add attributes
+		"engine capacity" 20
 	outfits
 		"Plasma Cannon" 4
 		"Meteor Missile Launcher" 2
@@ -946,39 +708,20 @@ ship "Marauder Manta" "Marauder Manta (Engines)"
 	engine -33.5 38
 	engine 0 76
 	engine 33.5 38
-	gun -66 -30 "Meteor Missile Launcher"
-	gun 66 -30 "Meteor Missile Launcher"
-	gun -27 -30 "Plasma Cannon"
-	gun 27 -30 "Plasma Cannon"
-	gun -20 -30 "Plasma Cannon"
-	gun 20 -30 "Plasma Cannon"
-	turret 0 -29 "Quad Blaster Turret"
-	explode "tiny explosion" 10
-	explode "small explosion" 20
-	explode "medium explosion" 15
-	"final explode" "final explosion medium"
+	gun "Meteor Missile Launcher"
+	gun "Meteor Missile Launcher"
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	turret "Quad Blaster Turret"
 	description `A previous owner of this Manta has gone to great lengths to make sure they could bring all six gun ports to bear in a hurry and chase down smaller warships. Style was not lost on that captain, and a forked tail yielded a little more space for shield projectors in an area that would have been destabilized by engine exhaust. It almost makes it to "Heavy Warship," but dry tonnage keeps it in the Medium Warship category.`
-
 
 
 ship "Marauder Manta" "Marauder Manta (Weapons)"
 	sprite "ship/mmantaw"
-	attributes
-		category "Medium Warship"
-		"cost" 3740000
-		"shields" 6500
-		"hull" 1750
-		"required crew" 7
-		"bunks" 11
-		"mass" 195
-		"drag" 4.7
-		"heat dissipation" .8
-		"fuel capacity" 400
-		"cargo space" 10
-		"outfit space" 390
-		"weapon capacity" 175
-		"engine capacity" 110
-		"self destruct" .15
+	add attributes
+		"weapon capacity" 20
 	outfits
 		"Particle Cannon" 2
 		"Proton Gun" 2
@@ -1007,10 +750,6 @@ ship "Marauder Manta" "Marauder Manta (Weapons)"
 	gun -20 -35 "Particle Cannon"
 	gun 20 -35 "Particle Cannon"
 	turret 0 -29 "Heavy Anti-Missile Turret"
-	explode "tiny explosion" 10
-	explode "small explosion" 20
-	explode "medium explosion" 15
-	"final explode" "final explosion medium"
 	description `This Manta has undergone extensive modification, featuring extra gun ports, hull plating, and shield emitters. You wonder where the modifier intended the power systems to go, but you're sure you'll find space for them somewhere. It almost makes it to "Heavy Warship," but dry tonnage keeps it in the Medium Warship category.`
 
 
@@ -1064,25 +803,10 @@ ship "Marauder Quicksilver"
 	description "This Megaparsec Quicksilver is a bit of a Hotrod, being a little faster, with extra shield projectors, hull plating, and an extra bunk. This aftermarket model also features a turret mount, perhaps in an answer to Lionheart's Headhunter. The shop that built this ship is sure to see more customers."
 
 
-
 ship "Marauder Quicksilver" "Marauder Quicksilver (Engines)"
 	sprite "ship/mquicksilvere"
-	attributes
-		category "Light Warship"
-		"cost" 1200000
-		"shields" 3500
-		"hull" 900
-		"required crew" 4
-		"bunks" 7
-		"mass" 140
-		"drag" 2.7
-		"heat dissipation" .8
-		"fuel capacity" 400
-		"cargo space" 5
-		"outfit space" 265
-		"weapon capacity" 65
-		"engine capacity" 115
-		"self destruct" .15
+	add attributes
+		"engine capacity" 40
 	outfits
 		"Pulse Cannon" 2
 		"Anti-Missile Turret"
@@ -1101,34 +825,13 @@ ship "Marauder Quicksilver" "Marauder Quicksilver (Engines)"
 	engine -16 52
 	engine 0 52
 	engine 16 52
-	gun -7 -39 "Pulse Cannon"
-	gun 7 -39 "Pulse Cannon"
-	turret 0 15 "Anti-Missile Turret"
-	explode "tiny explosion" 12
-	explode "small explosion" 16
-	"final explode" "final explosion small"
 	description "This Quicksilver has even more space available for engine use - and even another thruster port! It's also got a few extra shield projectors, more hull plating and another bunk. This aftermarket model also features a turret mount, perhaps in response to Lionheart's Headhunter. Whoever modified this ship wanted to chase their prey down with vicious speed."
-
 
 
 ship "Marauder Quicksilver" "Marauder Quicksilver (Weapons)"
 	sprite "ship/mquicksilverw"
-	attributes
-		category "Light Warship"
-		"cost" 1200000
-		"shields" 3500
-		"hull" 900
-		"required crew" 4
-		"bunks" 7
-		"mass" 140
-		"drag" 2.7
-		"heat dissipation" .8
-		"fuel capacity" 400
-		"cargo space" 5
-		"outfit space" 265
-		"weapon capacity" 80
-		"engine capacity" 75
-		"self destruct" .15
+	add attributes
+		"weapon capacity" 15
 	outfits
 		"Heavy Laser" 2
 		"Heavy Laser Turret"
@@ -1146,13 +849,6 @@ ship "Marauder Quicksilver" "Marauder Quicksilver (Weapons)"
 	
 	engine -17 54
 	engine 17 54
-	turret 0 15
-	gun -7 -39 "Heavy Laser"
-	gun 7 -39 "Heavy Laser"
-	turret 0 15 "Heavy Laser Turret"
-	explode "tiny explosion" 12
-	explode "small explosion" 16
-	"final explode" "final explosion small"
 	description "This Quicksilver has even bigger gun ports. It's also got a few extra shield emitters, more hull plating, and an extra bunk. Outfitted right, this aftermarket model could be even faster than a stock model, bringing a couple of extra cannons and a turret to the fight, to mimic Lionheart's Headhunter perhaps a little more menacingly."
 
 
@@ -1210,25 +906,10 @@ ship "Marauder Raven"
 	description "The modifier of this Raven has given more heft to an agile and elegant vessel. They've added a turret and some apparently flimsy bulkheads over extra shield emitters and outfit space. If it weren't for the wingtips, you would barely recognize Lionheart's ship under the patchwork that you expect has made an already deadly warship even more so."
 
 
-
 ship "Marauder Raven" "Marauder Raven (Engines)"
 	sprite "ship/mravene"
-	attributes
-		category "Light Warship"
-		"cost" 2250000
-		"shields" 5200
-		"hull" 1600
-		"required crew" 7
-		"bunks" 14
-		"mass" 145
-		"drag" 3.7
-		"heat dissipation" .8
-		"fuel capacity" 500
-		"cargo space" 20
-		"outfit space" 310
-		"weapon capacity" 105
-		"engine capacity" 130
-		"self destruct" .15
+	add attributes
+		"engine capacity" 20
 	outfits
 		"Heavy Laser" 4
 		"Heavy Laser Turret"
@@ -1246,38 +927,13 @@ ship "Marauder Raven" "Marauder Raven (Engines)"
 	engine -12 45 .7
 	engine 0 43
 	engine 12 45 .7
-	gun -10 -33 "Heavy Laser"
-	gun 10 -33 "Heavy Laser"
-	gun -16 -28 "Heavy Laser"
-	gun 16 -28 "Heavy Laser"
-	turret 0 -19 "Heavy Laser Turret"
-	explode "medium explosion" 24
-	explode "large explosion" 16
-	explode "tiny explosion" 28
-	explode "small explosion" 40
-	"final explode" "final explosion small"
 	description "Lionheart's elegant Raven has gained popularity with pirates because of its agility. This one appears to have been modified for even more of the latter, at the expense of the former, and You only recognize it as a Raven by the wingtips. A third engine bay, more outfit space, additional shield emitters, and a turret make this already deadly warship appear even more frightening."
-
 
 
 ship "Marauder Raven" "Marauder Raven (Weapons)"
 	sprite "ship/mravenw"
-	attributes
-		category "Light Warship"
-		"cost" 2250000
-		"shields" 5200
-		"hull" 1600
-		"required crew" 7
-		"bunks" 14
-		"mass" 145
-		"drag" 3.7
-		"heat dissipation" .8
-		"fuel capacity" 500
-		"cargo space" 20
-		"outfit space" 310
-		"weapon capacity" 135
-		"engine capacity" 110
-		"self destruct" .15
+	add attributes
+		"weapon capacity" 30
 	outfits
 		"Plasma Cannon" 2
 		"Pulse Cannon" 2
@@ -1293,18 +949,11 @@ ship "Marauder Raven" "Marauder Raven (Weapons)"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 	
-	engine -12 45
-	engine 12 45
 	gun -11 -33 "Plasma Cannon"
 	gun 11 -33 "Plasma Cannon"
 	gun -17 -28 "Pulse Cannon"
 	gun 17 -28 "Pulse Cannon"
 	turret 0 -19 "Heavy Laser Turret"
-	explode "medium explosion" 24
-	explode "large explosion" 16
-	explode "tiny explosion" 28
-	explode "small explosion" 40
-	"final explode" "final explosion small"
 	description "A former owner of this ship apparently didn't like the lithe Raven, and has added so much more weapons, shield, and outfit capacity to it that you only recognize it by the wingtips. Besides adding a turret, this ship has enormous gun ports, making you wonder how much more deadly you could make a Light Warship."
 
 
@@ -1362,25 +1011,10 @@ ship "Marauder Splinter"
 	description "The Splinter is the largest warship produced by Megaparsec. Apparently someone wanted a bit more out of it, and has covered large sections of the hull with extra shield emitters and hull plating. Much of the stock cargo space has been converted to outfit, weapons and engines space, coupled with streamlining of existing internal systems make this light Medium Warship an agile and flexible war machine."
 
 
-
 ship "Marauder Splinter" "Marauder Splinter (Engines)"
 	sprite "ship/msplintere"
-	attributes
-		category "Medium Warship"
-		"cost" 3400000
-		"shields" 5700
-		"hull" 1950
-		"required crew" 14
-		"bunks" 22
-		"mass" 275
-		"drag" 4.0
-		"heat dissipation" .7
-		"fuel capacity" 600
-		"cargo space" 40
-		"outfit space" 450
-		"weapon capacity" 165
-		"engine capacity" 130
-		"self destruct" .15
+	add attributes
+		"engine capacity" 20
 	outfits
 		"Plasma Cannon" 2
 		"Quad Blaster Turret" 2
@@ -1401,38 +1035,16 @@ ship "Marauder Splinter" "Marauder Splinter (Engines)"
 	engine -15 114 .7
 	engine 0 118
 	engine 15 114 .7
-	gun -15 -82 "Plasma Cannon"
-	gun 15 -82 "Plasma Cannon"
-	turret -17 -28 "Quad Blaster Turret"
-	turret 0 -28 "Heavy Anti-Missile Turret"
-	turret 17 -28 "Quad Blaster Turret"
-	explode "tiny explosion" 18
-	explode "small explosion" 36
-	explode "medium explosion" 24
-	explode "large explosion" 8
-	"final explode" "final explosion medium"
+	turret "Quad Blaster Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Quad Blaster Turret"
 	description "In a sub-kiloton warship, you're not likely to find one faster or more deadly than this one. Large sections of the hull have been covered with extra hull plating and shield emitters. Much of the cargo space has been converted to outfit space, a great deal of which is at the rear of the ship, which features a new engine port."
-
 
 
 ship "Marauder Splinter" "Marauder Splinter (Weapons)"
 	sprite "ship/msplinterw"
-	attributes
-		category "Medium Warship"
-		"cost" 3400000
-		"shields" 5700
-		"hull" 1950
-		"required crew" 14
-		"bunks" 22
-		"mass" 275
-		"drag" 4.0
-		"heat dissipation" .7
-		"fuel capacity" 600
-		"cargo space" 40
-		"outfit space" 450
-		"weapon capacity" 180
-		"engine capacity" 110
-		"self destruct" .15
+	add attributes
+		"weapon capacity" 15
 	outfits
 		"Plasma Cannon" 4
 		"Quad Blaster Turret" 2
@@ -1449,8 +1061,6 @@ ship "Marauder Splinter" "Marauder Splinter (Weapons)"
 		"A525 Atomic Steering"
 		"Hyperdrive"
 	
-	engine -14 112
-	engine 14 112
 	gun -7.5 -98 "Plasma Cannon"
 	gun 7.5 -98 "Plasma Cannon"
 	gun -15 -82 "Plasma Cannon"
@@ -1458,9 +1068,4 @@ ship "Marauder Splinter" "Marauder Splinter (Weapons)"
 	turret -17 -28 "Quad Blaster Turret"
 	turret 0 -28 "Heavy Anti-Missile Turret"
 	turret 17 -28 "Quad Blaster Turret"
-	explode "tiny explosion" 18
-	explode "small explosion" 36
-	explode "medium explosion" 24
-	explode "large explosion" 8
-	"final explode" "final explosion medium"
 	description "This Splinter has had extensive modification to its weapons space, with two new forward hard points on either side of the bridge. Large sections of the hull are covered with extra shield emitters and hull plating. Much of the stock cargo space has been converted to space for outfits, weapons and engines, coupled with streamlining of existing internal systems make the prospect of meeting this flexible war machine in an uninhabited system seem pretty unappealing."

--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -762,93 +762,38 @@ ship "Deep River"
 
 ship "Deep River" "Deep River 0"
 	sprite "ship/deep river 0"
-	attributes
-		category "Heavy Freighter"
-		"cost" 18300000
-		"shields" 17600
-		"hull" 47500
-		"required crew" 13
-		"bunks" 22
-		"mass" 350
-		"drag" 7.4
-		"heat dissipation" .6
-		"fuel capacity" 500
-		"cargo space" 0
-		"outfit space" 363
-		"weapon capacity" 177
-		"engine capacity" 83
+	add attributes
+		"mass" -400
+		"drag" -2
+		"cargo space" -1140
 
 ship "Deep River" "Deep River 1"
 	sprite "ship/deep river 1"
-	attributes
-		category "Heavy Freighter"
-		"cost" 18300000
-		"shields" 17600
-		"hull" 47500
-		"required crew" 13
-		"bunks" 22
-		"mass" 430
-		"drag" 7.8
-		"heat dissipation" .6
-		"fuel capacity" 500
-		"cargo space" 228
-		"outfit space" 363
-		"weapon capacity" 177
-		"engine capacity" 83
+	add attributes
+		"mass" -320
+		"drag" -1.6
+		"cargo space" -912
 
 ship "Deep River" "Deep River 2"
 	sprite "ship/deep river 2"
-	attributes
-		category "Heavy Freighter"
-		"cost" 18300000
-		"shields" 17600
-		"hull" 47500
-		"required crew" 13
-		"bunks" 22
-		"mass" 510
-		"drag" 8.2
-		"heat dissipation" .6
-		"fuel capacity" 500
-		"cargo space" 456
-		"outfit space" 363
-		"weapon capacity" 177
-		"engine capacity" 83
+	add attributes
+		"mass" -240
+		"drag" -1.2
+		"cargo space" -684
 
 ship "Deep River" "Deep River 3"
 	sprite "ship/deep river 3"
-	attributes
-		category "Heavy Freighter"
-		"cost" 18300000
-		"shields" 17600
-		"hull" 47500
-		"required crew" 13
-		"bunks" 22
-		"mass" 590
-		"drag" 8.6
-		"heat dissipation" .6
-		"fuel capacity" 500
-		"cargo space" 684
-		"outfit space" 363
-		"weapon capacity" 177
-		"engine capacity" 83
+	add attributes
+		"mass" -160
+		"drag" -.8
+		"cargo space" -456
 
 ship "Deep River" "Deep River 4"
 	sprite "ship/deep river 4"
-	attributes
-		category "Heavy Freighter"
-		"cost" 18300000
-		"shields" 17600
-		"hull" 47500
-		"required crew" 13
-		"bunks" 22
-		"mass" 670
-		"drag" 9.0
-		"heat dissipation" .6
-		"fuel capacity" 500
-		"cargo space" 912
-		"outfit space" 363
-		"weapon capacity" 177
-		"engine capacity" 83
+	add attributes
+		"mass" -80
+		"drag" -.4
+		"cargo space" -228
 
 ship "Deep River Transport"
 	sprite "ship/deep river"


### PR DESCRIPTION
 - Simplify definition of the Kestrel and its variants
 - Simplify definitions of Marauder variants
 - Simplify definition of the cloaking Archon
 - Simplify definition of the Deep River variants

With these changes, plus the Doombat change from earlier, proper usage of `add attributes` is conveyed to any content creators that prefer to learn from existing examples, and not just from reading the wiki (where `add attributes` should get an entry, in the Variants header: https://github.com/endless-sky/endless-sky/wiki/CreatingShips#variants).