### PR TITLE
Consider target's heat level when picking targets

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -343,6 +343,11 @@ interface "hud"
 		dimensions 0 -192
 		color "heat"
 		size 2
+	bar "overheat"
+		from -13.5 403
+		dimensions 0 -192
+		color "medium"
+		size 2
 
 	# Targets.
 	anchor top left

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -984,6 +984,9 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 			range -= 1000 * Has(*it, gov, ShipEvent::BOARD);
 			// Focus on nearly dead ships.
 			range += 500. * (it->Shields() + it->Hull());
+			// If a target is extremely overheated, focus on ships that can attack back.
+			if(it->IsOverheated())
+				range += 3000. * (it->Heat() - .9);
 			if((isPotentialNemesis && !hasNemesis) || range < closest)
 			{
 				closest = range;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -551,7 +551,7 @@ void Engine::Step(bool isActive)
 		info.SetBar("fuel", flagship->Fuel(),
 			flagship->Attributes().Get("fuel capacity") * .01);
 		info.SetBar("energy", flagship->Energy());
-		info.SetBar("heat", flagship->Heat());
+		info.SetBar("heat", min(1., flagship->Heat()));
 		info.SetBar("shields", flagship->Shields());
 		info.SetBar("hull", flagship->Hull(), 20.);
 	}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -551,7 +551,16 @@ void Engine::Step(bool isActive)
 		info.SetBar("fuel", flagship->Fuel(),
 			flagship->Attributes().Get("fuel capacity") * .01);
 		info.SetBar("energy", flagship->Energy());
-		info.SetBar("heat", min(1., flagship->Heat()));
+		double heat = flagship->Heat();
+		info.SetBar("heat", min(1., heat));
+		// Use a segmented "overheat" bar to indicate any excess heat
+		// that must be shed before the ship is no longer overheated.
+		if(flagship->IsOverheated())
+		{
+			double excess = heat - .9;
+			double segments = ceil(excess);
+			info.SetBar("overheat", excess / segments, segments);
+		}
 		info.SetBar("shields", flagship->Shields());
 		info.SetBar("hull", flagship->Hull(), 20.);
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2176,6 +2176,14 @@ double Ship::Hull() const
 
 
 
+double Ship::Fuel() const
+{
+	double maximum = attributes.Get("fuel capacity");
+	return maximum ? min(1., fuel / maximum) : 0.;
+}
+
+
+
 double Ship::Energy() const
 {
 	double maximum = attributes.Get("energy capacity");
@@ -2184,18 +2192,12 @@ double Ship::Energy() const
 
 
 
+// Allow returning a heat value greater than 1 (i.e. conveying how overheated
+// this ship has become).
 double Ship::Heat() const
 {
 	double maximum = MaximumHeat();
-	return maximum ? min(1., heat / maximum) : 1.;
-}
-
-
-
-double Ship::Fuel() const
-{
-	double maximum = attributes.Get("fuel capacity");
-	return maximum ? min(1., fuel / maximum) : 0.;
+	return maximum ? heat / maximum : 1.;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -240,9 +240,11 @@ public:
 	// Get characteristics of this ship, as a fraction between 0 and 1.
 	double Shields() const;
 	double Hull() const;
-	double Energy() const;
-	double Heat() const;
 	double Fuel() const;
+	double Energy() const;
+	// A ship's heat is generally between 0 and 1, but if it receives
+	// heat damage the value can increase above 1.
+	double Heat() const;
 	// Get the ship's "health," where <=0 is disabled and 1 means full health.
 	double Health() const;
 	// Get the number of jumps this ship can make before running out of fuel.


### PR DESCRIPTION
1. If a target is extremely overheated, there are probably other ships around that are not overheated that can attack the ship - those targets should be attacked more preferably than a ship which is incapacitated for a significant period of time.

2. ~~Adds a visual conveyance of the degree ( :grinning: ) to which the player has been overheated, by segmenting the HUD's `heat` bar.~~ Adds a second overlay bar with the ship's excess heat (the heat which needs to be dissipated before the ship is no longer overheated). This information is not currently available, so if the player is extremely overheated but otherwise not disabled, they can get visual feedback of how long they have to wait before their ship will begin responding again.

<details><summary>After provoking 20 Doombats:</summary>

This image is pre-overlay bar:
![image](https://user-images.githubusercontent.com/20871346/34584083-ed328afc-f15f-11e7-9bdf-b828a2f897e7.png)
</details>
  