### PR TITLE
Always show tactical information if targeting a player-owned ship

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -660,7 +660,8 @@ void Engine::Step(bool isActive)
 			}
 			// Actual tactical information requires a scrutable
 			// target that is within the tactical scanner range.
-			if(targetRange <= tacticalRange && !target->Attributes().Get("inscrutable"))
+			if((targetRange <= tacticalRange && !target->Attributes().Get("inscrutable"))
+					|| (tacticalRange && target->IsYours()))
 			{
 				info.SetCondition("tactical display");
 				info.SetString("target crew", to_string(target->Crew()));


### PR DESCRIPTION
Seems a bit odd that we can't visualize the realtime data from our player-owned ships just because they're out of range.