### PR TITLE
Move PickSystem and PickPlanet from Mission to LocationFilter

### DIFF
--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "GameData.h"
 #include "Government.h"
 #include "Planet.h"
+#include "Random.h"
 #include "Ship.h"
 #include "System.h"
 
@@ -274,6 +275,45 @@ LocationFilter LocationFilter::SetOrigin(const System *origin) const
 	return result;
 }
 
+
+
+// Pick a random system that matches this filter, based on the given origin.
+const System *LocationFilter::PickSystem(const System *origin) const
+{
+	// Find a planet that satisfies the filter.
+	vector<const System *> options;
+	for(const auto &it : GameData::Systems())
+	{
+		// Skip entries with incomplete data.
+		if(it.second.Name().empty())
+			continue;
+		if(Matches(&it.second, origin))
+			options.push_back(&it.second);
+	}
+	return options.empty() ? nullptr : options[Random::Int(options.size())];
+}
+
+
+
+// Pick a random planet that matches this filter, based on the given origin.
+const Planet *LocationFilter::PickPlanet(const System *origin, bool hasClearance) const
+{
+	// Find a planet that satisfies the filter.
+	vector<const Planet *> options;
+	for(const auto &it : GameData::Planets())
+	{
+		const Planet &planet = it.second;
+		// Skip entries with incomplete data.
+		if(planet.Name().empty() || !planet.GetSystem())
+			continue;
+		// Skip planets that do not offer jobs or missions.
+		if(planet.IsWormhole() || !planet.HasSpaceport() || (!hasClearance && !planet.CanLand()))
+			continue;
+		if(Matches(&planet, origin))
+			options.push_back(&planet);
+	}
+	return options.empty() ? nullptr : options[Random::Int(options.size())];
+}
 
 
 

--- a/source/LocationFilter.h
+++ b/source/LocationFilter.h
@@ -53,6 +53,10 @@ public:
 	// Return a new LocationFilter with any "distance" conditions converted
 	// into "near" references, relative to the given system.
 	LocationFilter SetOrigin(const System *origin) const;
+	// Generic find system / find planet methods, based on the given origin
+	// system (e.g. the player's current system) and ability to land.
+	const System *PickSystem(const System *origin) const;
+	const Planet *PickPlanet(const System *origin, bool hasClearance = false) const;
 	
 	
 private:

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -856,18 +856,19 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	result.name = name;
 	result.waypoints = waypoints;
 	// Handle waypoint systems that are chosen randomly.
+	const System * const source = player.GetSystem();
 	for(const LocationFilter &filter : waypointFilters)
 	{
-		const System *system = PickSystem(filter, player);
+		const System *system = filter.PickSystem(source);
 		if(!system)
 			return result;
 		result.waypoints.insert(system);
 	}
 	// If one of the waypoints is the current system, it is already visited.
-	if(result.waypoints.count(player.GetSystem()))
+	if(result.waypoints.count(source))
 	{
-		result.waypoints.erase(player.GetSystem());
-		result.visitedWaypoints.insert(player.GetSystem());
+		result.waypoints.erase(source);
+		result.visitedWaypoints.insert(source);
 	}
 	
 	// Copy the stopover planet list, and populate the list based on the filters
@@ -883,7 +884,7 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	}
 	for(const LocationFilter &filter : stopoverFilters)
 	{
-		const Planet *planet = PickPlanet(filter, player);
+		const Planet *planet = filter.PickPlanet(source, !clearance.empty());
 		if(!planet)
 			return result;
 		result.stopovers.insert(planet);
@@ -896,7 +897,7 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	result.destination = destination;
 	if(!result.destination && !destinationFilter.IsEmpty())
 	{
-		result.destination = PickPlanet(destinationFilter, player);
+		result.destination = destinationFilter.PickPlanet(source, !clearance.empty());
 		if(!result.destination)
 			return result;
 	}
@@ -916,7 +917,7 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	{
 		const Trade::Commodity *commodity = nullptr;
 		if(cargo == "random")
-			commodity = PickCommodity(*player.GetSystem(), *result.destination->GetSystem());
+			commodity = PickCommodity(*source, *result.destination->GetSystem());
 		else
 		{
 			for(const Trade::Commodity &option : GameData::Commodities())
@@ -964,7 +965,7 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	// Estimate how far the player will have to travel to visit all the waypoints
 	// and stopovers and then to land on the destination planet. Rather than a
 	// full traveling salesman path, just calculate a greedy approximation.
-	const System *source = player.GetSystem();
+	const System *path = source;
 	list<const System *> destinations;
 	for(const System *system : result.waypoints)
 		destinations.push_back(system);
@@ -975,18 +976,18 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	while(!destinations.empty())
 	{
 		// Find the closest destination to this location.
-		DistanceMap distance(source);
+		DistanceMap distance(path);
 		auto it = destinations.begin();
 		auto bestIt = it;
 		for(++it; it != destinations.end(); ++it)
 			if(distance.Days(*it) < distance.Days(*bestIt))
 				bestIt = it;
 		
-		source = *bestIt;
+		path = *bestIt;
 		jumps += distance.Days(*bestIt);
 		destinations.erase(bestIt);
 	}
-	DistanceMap distance(source);
+	DistanceMap distance(path);
 	jumps += distance.Days(result.destination->GetSystem());
 	int payload = result.cargoSize + 10 * result.passengers;
 	
@@ -1050,16 +1051,16 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	
 	// Instantiate the NPCs. This also fills in the "<npc>" substitution.
 	for(const NPC &npc : npcs)
-		result.npcs.push_back(npc.Instantiate(subs, player.GetSystem(), result.destination->GetSystem()));
+		result.npcs.push_back(npc.Instantiate(subs, source, result.destination->GetSystem()));
 	
 	// Instantiate the actions. The "complete" action is always first so that
 	// the "<payment>" substitution can be filled in.
 	for(const auto &it : actions)
-		result.actions[it.first] = it.second.Instantiate(subs, player.GetSystem(), jumps, payload);
+		result.actions[it.first] = it.second.Instantiate(subs, source, jumps, payload);
 	for(const auto &it : onEnter)
-		result.onEnter[it.first] = it.second.Instantiate(subs, player.GetSystem(), jumps, payload);
+		result.onEnter[it.first] = it.second.Instantiate(subs, source, jumps, payload);
 	for(const MissionAction &action : genericOnEnter)
-		result.genericOnEnter.emplace_back(action.Instantiate(subs, player.GetSystem(), jumps, payload));
+		result.genericOnEnter.emplace_back(action.Instantiate(subs, source, jumps, payload));
 	
 	// Perform substitution in the name and description.
 	result.displayName = Format::Replace(displayName, subs);
@@ -1094,42 +1095,6 @@ void Mission::Enter(const System *system, PlayerInfo &player, UI *ui)
 				didEnter.insert(&action);
 				break;
 			}
-}
-
-
-
-const System *Mission::PickSystem(const LocationFilter &filter, const PlayerInfo &player) const
-{
-	// Find a planet that satisfies the filter.
-	vector<const System *> options;
-	for(const auto &it : GameData::Systems())
-	{
-		// Skip entries with incomplete data.
-		if(it.second.Name().empty())
-			continue;
-		if(filter.Matches(&it.second, player.GetSystem()))
-			options.push_back(&it.second);
-	}
-	return options.empty() ? nullptr : options[Random::Int(options.size())];
-}
-
-
-
-const Planet *Mission::PickPlanet(const LocationFilter &filter, const PlayerInfo &player) const
-{
-	// Find a planet that satisfies the filter.
-	vector<const Planet *> options;
-	for(const auto &it : GameData::Planets())
-	{
-		// Skip entries with incomplete data.
-		if(it.second.Name().empty() || (clearance.empty() && !it.second.CanLand()))
-			continue;
-		if(it.second.IsWormhole() || !it.second.HasSpaceport() || !it.second.GetSystem())
-			continue;
-		if(filter.Matches(&it.second, player.GetSystem()))
-			options.push_back(&it.second);
-	}
-	return options.empty() ? nullptr : options[Random::Int(options.size())];
 }
 
 

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -143,8 +143,6 @@ public:
 	
 private:
 	void Enter(const System *system, PlayerInfo &player, UI *ui);
-	const System *PickSystem(const LocationFilter &filter, const PlayerInfo &player) const;
-	const Planet *PickPlanet(const LocationFilter &filter, const PlayerInfo &player) const;
 	// For legacy code, contraband definitions can be placed in two different
 	// locations, so move that parsing out to a helper function.
 	bool ParseContraband(const DataNode &node);

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -403,20 +403,7 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	// Pick the system for this NPC to start out in.
 	result.system = system;
 	if(!result.system && !location.IsEmpty())
-	{
-		// Find a destination that satisfies the filter.
-		vector<const System *> options;
-		for(const auto &it : GameData::Systems())
-		{
-			// Skip entries with incomplete data.
-			if(it.second.Name().empty())
-				continue;
-			if(location.Matches(&it.second, origin))
-				options.push_back(&it.second);
-		}
-		if(!options.empty())
-			result.system = options[Random::Int(options.size())];
-	}
+		result.system = location.PickSystem(origin);
 	if(!result.system)
 		result.system = (isAtDestination && destination) ? destination : origin;
 	


### PR DESCRIPTION
 - Support choosing a random system or planet from a given location filter outside of just mission instantiation
 - Remove duplication (albeit there isn't much yet)

(This will be useful for #2990 or another PR that adds travel instructions to mission NPCs.)