### PR TITLE
Hostile escorts consider parent position before using "follow" behavior

### DIFF
--- a/source/AI.h
+++ b/source/AI.h
@@ -68,6 +68,9 @@ template <class Type>
 	
 	
 private:
+	// Check if a ship can pursue its target (i.e. beyond the "fence").
+	bool CanPursue(const Ship &ship, const Ship &target) const;
+	// Disabled or stranded ships coordinate with other ships to get assistance.
 	void AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship);
 	static bool CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel);
 	bool HasHelper(const Ship &ship, const bool needsFuel);


### PR DESCRIPTION
Refs #3507 , #2234

Extends the check prior to entering "follow the parent" behavior to consider if the parent is beyond the fence and the if the ship cares about that sort of thing.

I didn't tweak the behavior in MoveIndependent regarding out-of-range ships as it isn't entirely clear what the goal is:
https://github.com/endless-sky/endless-sky/blob/cb8d456b44dafc2695611540a6d65ecd674aea90/source/AI.cpp#L1127-L1137
My interpretation is
 - Keep targeting this ship, even though it is out of your bounds
 - if it is faster than you going outward, give up chasing and start returning to the center before it crosses the actual boundary
 - if it is slower than you going outward, chase it for a bit even after it crosses the actual boundary
 - When you give up the chase, execute a "wide turn" by thrusting so long as you are moving toward the boundary (if the target ship is targeting you, e.g. a missile-boat AI, this can increase the range to the point that it turns around and comes back)