### PR TITLE
"Lost" help should not appear while you're in the middle of hyperspacing to another system

### DIFF
--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -100,7 +100,8 @@ void MainPanel::Step()
 		bool canRefuel = player.GetSystem()->HasFuelFor(*flagship);
 		if(isActive && !flagship->IsHyperspacing() && !flagship->JumpsRemaining() && !canRefuel)
 			isActive = !DoHelp("stranded");
-		if(isActive && flagship->Position().Length() > 10000. && player.GetDate() <= GameData::Start().GetDate() + 4)
+		if(isActive && flagship->Position().Length() > 10000. && player.GetDate() <= GameData::Start().GetDate() + 4 
+			&& !flagship->IsHyperspacing())
 		{
 			++lostness;
 			int count = 1 + lostness / 3600;


### PR DESCRIPTION
Because if you've already engaged your hyperdrive, you probably figured out how to jump to another system.