### PR TITLE
Refactor some AI functions

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -352,8 +352,7 @@ void AI::Step(const PlayerInfo &player)
 		bool thisIsLaunching = (isLaunching && isPresent);
 		if(isStranded || it->IsDisabled())
 		{
-			// Derelicts never ask for help, to make sure that only the player
-			// will repair them.
+			// Derelicts never ask for help (only the player should repair them).
 			if(it->IsDestroyed() || it->GetPersonality().IsDerelict())
 				continue;
 			
@@ -445,7 +444,7 @@ void AI::Step(const PlayerInfo &player)
 		
 		// Pick a target and automatically fire weapons.
 		shared_ptr<Ship> target = it->GetTargetShip();
-		if(isPresent)
+		if(isPresent && !personality.IsSwarming())
 		{
 			// Each ship only switches targets twice a second, so that it can
 			// focus on damaging one particular ship.
@@ -501,7 +500,7 @@ void AI::Step(const PlayerInfo &player)
 		// Behave in accordance with personality traits.
 		if(isPresent && personality.IsSwarming() && !isStranded)
 		{
-			// Swarming ships should not wait for or be waited for by any ship.
+			// Swarming ships should not wait for (or be waited for by) any ship.
 			if(parent)
 			{
 				parent.reset();

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1920,6 +1920,7 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 		target.reset();
 		ship.SetTargetShip(target);
 	}
+	// If you have a hostile target, pursuing and destroying it has priority.
 	if(target && ship.GetGovernment()->IsEnemy(target->GetGovernment()))
 	{
 		// Automatic aiming and firing already occurred.
@@ -1968,13 +1969,6 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 	}
 	else
 	{
-		shared_ptr<Ship> newTarget = FindTarget(ship);
-		if(newTarget && ship.GetGovernment()->IsEnemy(newTarget->GetGovernment()))
-		{
-			ship.SetTargetShip(newTarget);
-			return;
-		}
-		
 		vector<shared_ptr<Ship>> targetShips;
 		vector<const StellarObject *> targetPlanets;
 		vector<const System *> targetSystems;

--- a/source/AI.h
+++ b/source/AI.h
@@ -27,11 +27,11 @@ class Body;
 class Flotsam;
 class Government;
 class Minable;
+class PlayerInfo;
 class Ship;
 class ShipEvent;
 class StellarObject;
 class System;
-class PlayerInfo;
 
 
 
@@ -126,6 +126,9 @@ private:
 	bool Has(const Government *government, const std::weak_ptr<const Ship> &other, int type) const;
 	// True if the ship has performed the indicated event against any member of the government.
 	bool Has(const Ship &ship, const Government *government, int type) const;
+	
+	// Functions to classify ships based on government and system.
+	void UpdateStrengths(std::map<const Government *, int64_t> &strength, const System *playerSystem);
 	
 	
 private:

--- a/source/AI.h
+++ b/source/AI.h
@@ -80,6 +80,7 @@ private:
 	static void Refuel(Ship &ship, Command &command);
 	static bool CanRefuel(const Ship &ship, const StellarObject *target);
 	
+	// Methods of moving from the current position to a desired position / orientation.
 	static double TurnBackward(const Ship &ship);
 	static double TurnToward(const Ship &ship, const Point &vector);
 	static bool MoveToPlanet(Ship &ship, Command &command);
@@ -92,16 +93,20 @@ private:
 	static void Attack(Ship &ship, Command &command, const Ship &target);
 	static void MoveToAttack(Ship &ship, Command &command, const Body &target);
 	static void PickUp(Ship &ship, Command &command, const Body &target);
+	// Special decisions a ship might make.
 	static bool ShouldUseAfterburner(Ship &ship);
-	void DoSurveillance(Ship &ship, Command &command) const;
+	// Special personality behaviors.
+	void DoSwarming(Ship &ship, Command &command, std::shared_ptr<Ship> &target);
+	void DoSurveillance(Ship &ship, Command &command, std::shared_ptr<Ship> &target) const;
 	void DoMining(Ship &ship, Command &command);
 	bool DoHarvesting(Ship &ship, Command &command);
 	void DoCloak(Ship &ship, Command &command);
+	// Prevent ships from stacking on each other when many are moving in sync.
 	void DoScatter(Ship &ship, Command &command);
 	
 	static Point StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &shouldReverse);
 	// Get a vector giving the direction this ship should aim in in order to do
-	// maximum damaged to a target at the given position with its non-turret,
+	// maximum damage to a target at the given position with its non-turret,
 	// non-homing weapons. If the ship has no non-homing weapons, this just
 	// returns the direction to the target.
 	static Point TargetAim(const Ship &ship);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -495,6 +495,10 @@ void Ship::FinishLoading(bool isNewInstance)
 	if(isNewInstance)
 		Recharge(true);
 	
+	// Figure out if this ship can be carried.
+	const string &category = attributes.Category();
+	isCarried = (category == "Fighter" || category == "Drone");
+	
 	// Ships read from a save file may have non-default shields or hull.
 	// Perform a full IsDisabled calculation.
 	isDisabled = true;
@@ -2492,9 +2496,10 @@ int Ship::BaysFree(bool isFighter) const
 // not reserved for one of its existing escorts.
 bool Ship::CanCarry(const Ship &ship) const
 {
-	bool isFighter = (ship.attributes.Category() == "Fighter");
-	if(!isFighter && ship.attributes.Category() != "Drone")
+	if(!ship.isCarried)
 		return false;
+	// This carried ship is either a fighter or a drone.
+	bool isFighter = (ship.attributes.Category() == "Fighter");
 	
 	int free = BaysFree(isFighter);
 	if(!free)
@@ -2513,21 +2518,18 @@ bool Ship::CanCarry(const Ship &ship) const
 
 bool Ship::CanBeCarried() const
 {
-	const string &category = attributes.Category();
-	return (category == "Fighter" || category == "Drone");
+	return isCarried;
 }
 
 
 
 bool Ship::Carry(const shared_ptr<Ship> &ship)
 {
-	if(!ship)
+	if(!ship || !ship->isCarried)
 		return false;
 	
+	// This carried ship is either a fighter or a drone.
 	bool isFighter = ship->attributes.Category() == "Fighter";
-	bool isDrone = ship->attributes.Category() == "Drone";
-	if(!(isFighter || isDrone))
-		return false;
 	
 	for(Bay &bay : bays)
 		if((bay.isFighter == isFighter) && !bay.ship)

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -396,6 +396,7 @@ private:
 	std::string description;
 	// Characteristics of this particular ship:
 	std::string name;
+	bool isCarried = false;
 	
 	int forget = 0;
 	bool isInSystem = true;


### PR DESCRIPTION
Summary
 - Bugfix to `personality swarming`
   - 55ec12b46883cb2540e5b2148b7edda46e5cc601 / #2828 moved calls for target seeking and automatic firing above personality behaviors (so that ships performing those behaviors would still fire at hostiles if the hostiles were near, even if not being actively attacked)
   - AI::FindTarget would change the target of `swarming` ships without decrementing the associated `swarmCount` value, resulting in a rapid maxing of any ship which lingers in a system. Basically, every `swarming` ship thought that the other ships in-system were already being protected, and would therefore land immediately
   - Fixed by guarding the call to FindTarget by a personality check. Prior to #2828, swarming ships were effectively pacifist (did not target enemies or autofire upon them), so this PR explicitly identifies this behavior. To make `swarming` ships not effectively pacifist will require changing the `swarming` implementation to not use `swarmCount` (or add the relevant decrement code to FindTarget for swarming ships)
 - `swarming` ships will keep moving relative to their swarmed target 
 - Hyperspacing ships no longer 1) queue jettisoning cargo or 2) attempt to autofire at hostile ships
   - Ship::Fire requires the ship to not be hyperspacing in order to fire its weapons, so there is no point picking a target if the ship cannot fire at one
   - A ship is allowed to aim its turrets while hyperspacing
 - Cached the "CanBeCarried" calculation in Ship::FinishLoading since it gets called for every placed ship multiple times per frame.
   - Precursor to offering support for custom "is carried" categories in mods
 - Split out and sped up the strength computation ( #2788 will take this further)
    - profile comparisons between master, UpdateStrengths, US with the roster, and branch tip: 
       - 500 friendly NPC aphids, 1 jump & then fleet-jump back, repeated 3x: https://imgur.com/a/EomEF
       - 500 friendly, 500 hostile NPC aphids, in-system battle, repeated 2x: https://imgur.com/a/DMpfu
 - Rescoped a number of `attribute get` calls so they are only done if needed (mostly in DoSurveillance).

<details><summary>gprof .txt profiles</summary>

[stress1_master.txt](https://github.com/endless-sky/endless-sky/files/1624101/stress1_master.txt)
[stress1_d35c1a1.txt](https://github.com/endless-sky/endless-sky/files/1624104/stress1_d35c1a1.txt)
[stress1_78a03ea.txt](https://github.com/endless-sky/endless-sky/files/1624106/stress1_78a03ea.txt)
[stress1_c32bf6c.txt](https://github.com/endless-sky/endless-sky/files/1624109/stress1_c32bf6c.txt)
[stress2_master.txt](https://github.com/endless-sky/endless-sky/files/1624110/stress2_master.txt)
[stress2_d35c1a1.txt](https://github.com/endless-sky/endless-sky/files/1624111/stress2_d35c1a1.txt)
[stress2_78a03ea.txt](https://github.com/endless-sky/endless-sky/files/1624112/stress2_78a03ea.txt)
[stress2_c32bf6c.txt](https://github.com/endless-sky/endless-sky/files/1624113/stress2_c32bf6c.txt)
</details>