### PR TITLE
Integrated Gascraft supercapacitor

### DIFF
--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -292,13 +292,14 @@ ship "Gascraft"
 		"hull" 1500
 		"required crew" 1
 		"bunks" 1
-		"mass" 70
+		"mass" 80
 		"drag" 1.7
 		"heat dissipation" 0.9
 		"fuel capacity" 700
 		"cargo space" 8
-		"outfit space" 100
+		"outfit space" 90
 		"engine capacity" 34
+		"energy capacity" 170
 		"shield generation" 0.6
 		"shield energy" 0.4
 		"hull repair rate" 1.2
@@ -306,7 +307,6 @@ ship "Gascraft"
 		"gaslining" 1
 	outfits
 		"Millennium Cell"
-		"Crystal Capacitor"
 		"Emergency Ramscoop"
 		"Quantum Key Stone"
 		

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -292,14 +292,14 @@ ship "Gascraft"
 		"hull" 1500
 		"required crew" 1
 		"bunks" 1
-		"mass" 80
+		"mass" 82
 		"drag" 1.7
 		"heat dissipation" 0.9
 		"fuel capacity" 700
 		"cargo space" 8
-		"outfit space" 90
+		"outfit space" 88
 		"engine capacity" 34
-		"energy capacity" 170
+		"energy capacity" 150
 		"shield generation" 0.6
 		"shield energy" 0.4
 		"hull repair rate" 1.2

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -292,12 +292,12 @@ ship "Gascraft"
 		"hull" 1500
 		"required crew" 1
 		"bunks" 1
-		"mass" 80
+		"mass" 70
 		"drag" 1.7
 		"heat dissipation" 0.9
 		"fuel capacity" 700
 		"cargo space" 8
-		"outfit space" 90
+		"outfit space" 100
 		"engine capacity" 34
 		"shield generation" 0.6
 		"shield energy" 0.4
@@ -306,7 +306,7 @@ ship "Gascraft"
 		"gaslining" 1
 	outfits
 		"Millennium Cell"
-		"Supercapacitor"
+		"Crystal Capacitor"
 		"Emergency Ramscoop"
 		"Quantum Key Stone"
 		


### PR DESCRIPTION
Currently the Gascraft is equipped with a Supercapacitor, which is weird, because:
* The Remnant outfitters do not sell supercapacitors, nor do any other Remnant ships have them
* Supercacitors are only produced and sold in human and Hai space, and the Remnant have lived in splendid isolation from human space for centuries

<s>This proposal equips the Gascraft with a Remnant Crystal Capacitor instead; outfit capacity is changed accordingly, total mass remains unchanged.</s>
This proposal internalizes the Gascraft's energy capacitor and removed the now obsolete human supercapacitor.