### PR TITLE
Update Ship::Health calculation

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2200,15 +2200,19 @@ double Ship::Fuel() const
 
 
 
-// Get the ship's "health," where 0 is disabled and 1 means full health.
+// Get the ship's "health," where <=0 is disabled and 1 means full health.
 double Ship::Health() const
 {
 	double minimumHull = MinimumHull();
-	double divisor = attributes.Get("shields") + attributes.Get("hull") - minimumHull;
-	if(divisor <= 0)
+	double hullDivisor = attributes.Get("hull") - minimumHull;
+	double divisor = attributes.Get("shields") + hullDivisor;
+	// This should not happen, but just in case.
+	if(divisor <= 0. || hullDivisor <= 0.)
 		return 0.;
 	
-	return (shields + hull - minimumHull) / divisor;
+	double spareHull = hull - minimumHull;
+	// Consider hull-only and pooled health, compensating for any reductions by disruption damage.
+	return min(spareHull / hullDivisor, (spareHull + shields / (1. + disruption * .01)) / divisor);
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -243,7 +243,7 @@ public:
 	double Energy() const;
 	double Heat() const;
 	double Fuel() const;
-	// Get the ship's "health," where 0 is disabled and 1 means full health.
+	// Get the ship's "health," where <=0 is disabled and 1 means full health.
 	double Health() const;
 	// Get the number of jumps this ship can make before running out of fuel.
 	// This depends on how much fuel it has and what sort of hyperdrive it uses.


### PR DESCRIPTION
 - Updated comments to reflect that this function can return negative values (e.g. hull damaged beyond minimum hull).
 - Considers both "pooled" health (hull + shields) and hull-only health (per https://github.com/endless-sky/endless-sky/issues/3092#issuecomment-335036347 )
 - Added consideration of disruption damage when adding shields in the pooled health part.


We could enforce the "return of 0 means it is disabled" by adding `|| isDisabled` in the check for a `<=0` divisor.