### PR TITLE
Removed unnecessary Barb and X1050

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -248,10 +248,6 @@ event "initial deployment 1"
 	planet "New Austria"
 		description `New Austria is a rugged mountain world, full of snow-capped peaks and valleys so deep and so steep that they rarely see sunlight. The few settlements that have been built here were developed for mining sapphires and rubies; the sapphires found in New Austria range from blue to yellow to black to clear in color, and are used both for industrial abrasives and for jewelry.`
 		description `The Navy has recently requisitioned one of the abandoned mining towns and begun refurbishing it for a secure military base, with the mining tunnels used as deep underground bunkers.`
-	shipyard "Syndicate Basics"
-		"Barb"
-	outfitter "Syndicate Basics"
-		"X1050 Ion Engines"
 
 event "initial deployment 2"
 	date 14 8 3014


### PR DESCRIPTION
Currently:
* `event "initial deployment 1"` (lines 150--254) adds Barb to Syndicate Basics shipyard and X1050 to Syndicate Basics outfitter
* `event "southern carriers 1"` (lines 516--529) adds Barb to Syndicate Basics shipyard and X1050 to Syndicate Advanced outfitter
* `event "southern carriers 2"` (lines 531--559) adds Barb(Proton) to Syndicate Basics shipyard and X1050 to Syndicate Basics outfitter

In other words, the Barb and X1050 are currently added twice. This proposal removes them from the first event, because their occurence there is probably a leftover which ought to have been removed; it doesn't make sense to add the X1050 to the Basics outfitter long before it's added to the Advanced outfitter.