### PR TITLE
"war begins" removes Navy shipyard only

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -121,8 +121,8 @@ event "war begins"
 		description `Until recently, Geminus was home to the Republic Navy Yard, the largest shipyard in human space. Now, there is nothing left of the shipyard but a gaping crater in the ground, from the recent terrorist bombing.`
 		spaceport `Fortunately, the spaceport and residential areas survived the bombing, which was focused only on the Navy yard and happened early in the morning, when very few people were at work.`
 		spaceport `The Navy officers who are in charge here have no time for anyone who is not enlisted in the Navy and participating in the ongoing investigation.`
-		shipyard clear
-		outfitter clear
+		remove shipyard "Navy Advanced"
+		remove shipyard "Navy Basics"
 		"required reputation" 100
 	planet "Martini"
 		description `Martini is a world of exotic beaches and perfect weather. The Republic's central bank and the galactic stock exchange were previously headquartered here, before a terrorist attack destroyed them and a large portion of the capital city as well.`
@@ -2587,15 +2587,8 @@ event "geminus rebuilt"
 		description `	The shattered remnants of the old Navy Yard are still left abandoned and slowly rusting away in the planet's caustic atmosphere, but the Republic has now built a new shipyard to replace the one destroyed in the bombing, and once again Geminus has become a central hub of technology and industry.`
 		spaceport `Like everything else on Geminus, the spaceport is not terribly pretty, but is functional and efficient. Each of the wide hallways is marked out like a road, with space in the center for electric carts carrying cargo, while pedestrians are relegated to the edges. Video cameras and sensors have been placed at every intersection, and access to the shipbuilding facilities is tightly controlled.`
 		spaceport `	The hub of the spaceport is a food court with a ring of shops in the center and seating on the outside, where you can look out of plate glass windows at the lava fields and caldera outside. By night, you can see the volcanic glow all around the horizon.`
-		shipyard "Basic Ships"
 		shipyard "Navy Basics"
 		shipyard "Navy Advanced"
-		shipyard "Betelgeuse Basics"
-		shipyard "Lionheart Basics"
-		outfitter "Common Outfits"
-		outfitter "Ammo North"
-		outfitter "Lovelace Advanced"
-		outfitter "Syndicate Basics"
 
 mission "Geminus Rebuilt"
 	landing


### PR DESCRIPTION
The `"war begins"` event currently removes all outfitters and shipyards from Geminus. However, the description explicitly states only the *Navy* shipyard was targeted and destroyed. This proposal tweaks `"war begins"` to remove the Navy B&A shipyards only; `"geminus rebuilt"` is also changed accordingly.