### PR TITLE
Corrected X5200 description

### DIFF
--- a/data/engines.txt
+++ b/data/engines.txt
@@ -223,7 +223,7 @@ outfit "X5200 Ion Steering"
 	"turn" 2174
 	"turning energy" 3.5
 	"turning heat" 7.3
-	description ""The X5200 is a steering system so large and powerful that only a handful of ships can install it. This means that this steering system is rarely sold due to its limited market."
+	description "The X5200 is a steering system so large and powerful that only a handful of ships can install it. This means that this steering system is rarely sold due to its limited market."
 	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
 
 

--- a/data/engines.txt
+++ b/data/engines.txt
@@ -223,7 +223,7 @@ outfit "X5200 Ion Steering"
 	"turn" 2174
 	"turning energy" 3.5
 	"turning heat" 7.3
-	description "The X5200 is a steering system so powerful that only a handful of ships use it. It is standard equipment for Republic cruisers and carriers, ships so large that they are practically a self-contained city."
+	description "The X5200 is a steering system so powerful and large that only a handful of ships can install it. It is useful for huge capital ships which are practically self-contained cities."
 	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
 
 

--- a/data/engines.txt
+++ b/data/engines.txt
@@ -223,7 +223,7 @@ outfit "X5200 Ion Steering"
 	"turn" 2174
 	"turning energy" 3.5
 	"turning heat" 7.3
-	description "The X5200 is a steering system so powerful and large that only a handful of ships can install it. It is useful for capital ships so large they are practically self-contained cities.
+	description ""The X5200 is a steering system so large and powerful that only a handful of ships can install it. This means that this steering system is rarely sold due to its limited market."
 	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
 
 

--- a/data/engines.txt
+++ b/data/engines.txt
@@ -223,7 +223,7 @@ outfit "X5200 Ion Steering"
 	"turn" 2174
 	"turning energy" 3.5
 	"turning heat" 7.3
-	description "The X5200 is a steering system so powerful and large that only a handful of ships can install it. It is useful for huge capital ships which are practically self-contained cities."
+	description "The X5200 is a steering system so powerful and large that only a handful of ships can install it. It is useful for capital ships so large they are practically self-contained cities.
 	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
 
 


### PR DESCRIPTION
The current description of the "X5200 Ion Steering" describes it as “standard equipment for Republic cruisers and carriers”. However, none of the Republic ships nor any of their variants actually use a X5200, therefore the description is clearly wrong. This patch rewrites the text to something more generic.