### PR TITLE
Correct AppStream ID to conform to latest version of the AppStream spec

### DIFF
--- a/endless-sky.appdata.xml
+++ b/endless-sky.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>io.github.EndlessSky.endless-sky</id>
+  <id>io.github.endless_sky.endless_sky</id>
   <launchable type="desktop-id">endless-sky.desktop</launchable>
   <name>Endless Sky</name>
   <name xml:lang="de">Weltraumspiel</name>


### PR DESCRIPTION
The AppStream ID I recommended in https://github.com/endless-sky/endless-sky/pull/3455 reflected an immature understanding of the nuances of how AppStream interacts with DBus and what characters are acceptable. Since then, I was contacted by the AppStream and DBus maintainers who set me right, leading to [a formal change in the spec](https://github.com/ximion/appstream/issues/162).

The bottom line is that hyphens and spaces should always be replaced with underscores, so Endless Sky's optimally-correct Appstream ID should be `io.github.endless_sky.endless_sky`