### PR TITLE
Installing multiple only installs those that come from cargo

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -159,7 +159,7 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point, int scroll
 			string label = "installed: " + to_string(minCount);
 			if(maxCount > minCount)
 				label += " - " + to_string(maxCount);
-		
+			
 			Point labelPos = point + Point(-OUTFIT_SIZE / 2 + 20, OUTFIT_SIZE / 2 - 38);
 			font.Draw(label, labelPos, bright);
 		}
@@ -323,13 +323,15 @@ void OutfitterPanel::Buy()
 		{
 			if(!CanBuy())
 				return;
-		
+			
+			// First, remove this outfit from cargo and add it to the selected ships.
 			if(player.Cargo().Get(selectedOutfit))
 				player.Cargo().Remove(selectedOutfit);
-			else if(!(player.Stock(selectedOutfit) > 0 || outfitter.Has(selectedOutfit)))
+			else if(withoutBuying || !(player.Stock(selectedOutfit) > 0 || outfitter.Has(selectedOutfit)))
 				break;
 			else
 			{
+				// Buy the outfit from the outfitter (possibly at reduced price).
 				int64_t price = player.StockDepreciation().Value(selectedOutfit, day);
 				player.Accounts().AddCredits(-price);
 				player.AddStock(selectedOutfit, -1);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -537,8 +537,10 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			FailBuy();
 		else
 		{
+			withoutBuying = (key == 'i');
 			Buy();
 			player.UpdateCargoCapacities();
+			withoutBuying = false;
 		}
 	}
 	else if(key == 's' || toCargo)

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -115,6 +115,8 @@ protected:
 	std::set<Ship *> playerShips;
 	const Ship *selectedShip = nullptr;
 	const Outfit *selectedOutfit = nullptr;
+	// If the outfit should come only from cargo, this flag is set.
+	bool withoutBuying = false;
 	
 	double mainScroll = 0.;
 	double sideScroll = 0.;


### PR DESCRIPTION
Refs #3544 

If using the shortcut key `i` to install from cargo in conjunction with a modifier key to "move things along," only the number present in cargo will be added to ships (rather than buying the remaining), in accordance with the use of `install` rather than `buy`
