### PR TITLE
improved Remnant ramscoop

### DIFF
--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -238,11 +238,11 @@ outfit "Emergency Ramscoop"
 	category "Systems"
 	licenses
 		Remnant
-	cost 72000
+	cost 144000
 	thumbnail "outfit/emergency ramscoop"
 	"mass" 4
 	"outfit space" -4
-	"ramscoop" 0.5
+	"ramscoop" 0.75
 	description "The Ember Waste is the sort of place where only a very foolish captain would travel without some sort of device for replenishing hyperspace fuel. This ramscoop is not particularly powerful, but it allows a ship to explore without fear of getting stranded."
 
 

--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -238,11 +238,11 @@ outfit "Emergency Ramscoop"
 	category "Systems"
 	licenses
 		Remnant
-	cost 144000
+	cost 72000
 	thumbnail "outfit/emergency ramscoop"
 	"mass" 4
 	"outfit space" -4
-	"ramscoop" 0.75
+	"ramscoop" 0.8
 	description "The Ember Waste is the sort of place where only a very foolish captain would travel without some sort of device for replenishing hyperspace fuel. This ramscoop is not particularly powerful, but it allows a ship to explore without fear of getting stranded."
 
 


### PR DESCRIPTION
This proposal improves the Remnant's ramscoop by 60% <s>50% and increases its cost by 100%</s>. It deserves an improvement because currently it's hardly better than the ordinary ramscoop. Besides, in #3557 it was claimed it's easy to unlock Wanderer outfits long before getting a Remnant licence. In comparison:

``` 
                              credits, mass, ramscoop, efficiency
ordinary Ramscoop           : 0.060m ,  10 ,    1.0  , 0.1000
current Emergency Ramscoop  : 0.072m ,   4 ,    0.5  , 0.1250
proposed Emergency Ramscoop : 0.072m ,   4 ,    0.8  , 0.2000
campaign Catalytic Ramscoop : 0.320m ,  16 ,    7.0  , 0.4375
Wanderer Ramscoop           : 0.460m ,   7 ,    4.0  , 0.5714
```