### PR TITLE
Show visited mission systems

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -409,16 +409,30 @@ const Planet *Mission::Destination() const
 
 
 
-set<const System *> Mission::Waypoints() const
+const set<const System *> &Mission::Waypoints() const
 {
 	return waypoints;
 }
 
 
 
-set<const Planet *> Mission::Stopovers() const
+const set<const System *> &Mission::VisitedWaypoints() const
+{
+	return visitedWaypoints;
+}
+
+
+
+const set<const Planet *> &Mission::Stopovers() const
 {
 	return stopovers;
+}
+
+
+
+const set<const Planet *> &Mission::VisitedStopovers() const
+{
+	return visitedStopovers;
 }
 
 

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -71,8 +71,10 @@ public:
 	
 	// Information about what you are doing.
 	const Planet *Destination() const;
-	std::set<const System *> Waypoints() const;
-	std::set<const Planet *> Stopovers() const;
+	const std::set<const System *> &Waypoints() const;
+	const std::set<const System *> &VisitedWaypoints() const;
+	const std::set<const Planet *> &Stopovers() const;
+	const std::set<const Planet *> &VisitedStopovers() const;
 	const std::string &Cargo() const;
 	int CargoSize() const;
 	int IllegalCargoFine() const;

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -436,24 +436,25 @@ void MissionPanel::DrawKey() const
 	const Sprite *back = SpriteSet::Get("ui/mission key");
 	SpriteShader::Draw(back, Screen::BottomLeft() + .5 * Point(back->Width(), -back->Height()));
 	
-	Color bright(.6, .6);
-	Color dim(.3, .3);
 	const Font &font = FontSet::Get(14);
 	Point angle = Point(1., 1.).Unit();
 	
-	Point pos(Screen::Left() + 10., Screen::Bottom() - 5. * 20. + 5.);
+	const int ROWS = 5;
+	Point pos(Screen::Left() + 10., Screen::Bottom() - ROWS * 20. + 5.);
 	Point pointerOff(5., 5.);
 	Point textOff(8., -.5 * font.Height());
 
 	const Set<Color> &colors = GameData::Colors();
-	const Color COLOR[5] = {
+	const Color &bright = *colors.Get("bright");
+	const Color &dim = *colors.Get("dim");
+	const Color COLOR[ROWS] = {
 		*colors.Get("available job"),
 		*colors.Get("unavailable job"),
 		*colors.Get("active mission"),
 		*colors.Get("blocked mission"),
 		*colors.Get("waypoint")
 	};
-	static const string LABEL[5] = {
+	static const string LABEL[ROWS] = {
 		"Available job; can accept",
 		"Too little space to accept",
 		"Active job; go here to complete",
@@ -466,7 +467,7 @@ void MissionPanel::DrawKey() const
 	if(acceptedIt != accepted.end() && acceptedIt->Destination())
 		selected = 2 + !IsSatisfied(*acceptedIt);
 	
-	for(int i = 0; i < 5; ++i)
+	for(int i = 0; i < ROWS; ++i)
 	{
 		PointerShader::Draw(pos + pointerOff, angle, 10., 18., 0., COLOR[i]);
 		font.Draw(LABEL[i], pos + textOff, i == selected ? bright : dim);
@@ -476,6 +477,7 @@ void MissionPanel::DrawKey() const
 
 
 
+// Fill in the top-middle header bar that names the selected system, and indicates its distance.
 void MissionPanel::DrawSelectedSystem() const
 {
 	const Sprite *sprite = SpriteSet::Get("ui/selected system");
@@ -509,23 +511,36 @@ void MissionPanel::DrawSelectedSystem() const
 
 
 
+// Highlight the systems associated with the given mission (i.e. destination and
+// waypoints) by drawing colored rings around them.
 void MissionPanel::DrawMissionSystem(const Mission &mission, const Color &color) const
 {
-	const Color &waypointColor = *GameData::Colors().Get("waypoint back");
+	const Color &waypoint = *GameData::Colors().Get("waypoint back");
+	const Color &visited = *GameData::Colors().Get("faint");
 	
-	Point pos = Zoom() * (mission.Destination()->GetSystem()->Position() + center);
+	double zoom = Zoom();
+	// Draw a colored ring around the destination system.
+	Point pos = zoom * (mission.Destination()->GetSystem()->Position() + center);
 	RingShader::Draw(pos, 22., 20.5, color);
+	
+	// Draw bright rings around systems that still need to be visited.
 	for(const System *system : mission.Waypoints())
-		RingShader::Draw(Zoom() * (system->Position() + center), 22., 20.5, waypointColor);
+		RingShader::Draw(zoom * (system->Position() + center), 22., 20.5, waypoint);
 	for(const Planet *planet : mission.Stopovers())
-		RingShader::Draw(Zoom() * (planet->GetSystem()->Position() + center), 22., 20.5, waypointColor);
+		RingShader::Draw(zoom * (planet->GetSystem()->Position() + center), 22., 20.5, waypoint);
+	
+	// Draw faint rings around systems already visited for this mission.
+	for(const System *system : mission.VisitedWaypoints())
+		RingShader::Draw(zoom * (system->Position() + center), 22., 20.5, visited);
+	for(const Planet *planet : mission.VisitedStopovers())
+		RingShader::Draw(zoom * (planet->GetSystem()->Position() + center), 22., 20.5, visited);
 }
 
 
 
+// Draw the background for the lists of available and accepted missions (based on pos).
 Point MissionPanel::DrawPanel(Point pos, const string &label, int entries) const
 {
-	const Font &font = FontSet::Get(14);
 	const Color &back = *GameData::Colors().Get("map side panel background");
 	const Color &unselected = *GameData::Colors().Get("medium");
 	const Color &selected = *GameData::Colors().Get("bright");
@@ -553,6 +568,7 @@ Point MissionPanel::DrawPanel(Point pos, const string &label, int entries) const
 		edgePos.Y() -= dy;
 	}
 	
+	const Font &font = FontSet::Get(14);
 	pos += Point(10., 10. + (20. - font.Height()) * .5);
 	font.Draw(label, pos, selected);
 	FillShader::Fill(

--- a/source/MissionPanel.h
+++ b/source/MissionPanel.h
@@ -47,9 +47,13 @@ protected:
 	
 	
 private:
+	// Display and explain the various pointers that may appear on the map.
 	void DrawKey() const;
+	// Display the name of and distance to the selected system.
 	void DrawSelectedSystem() const;
+	// Draw rings around systems that need to be visited for the given mission.
 	void DrawMissionSystem(const Mission &mission, const Color &color) const;
+	// Draw the backgrounds for the "available jobs" and accepted missions/jobs lists.
 	Point DrawPanel(Point pos, const std::string &label, int entries) const;
 	Point DrawList(const std::list<Mission> &list, Point pos) const;
 	void DrawMissionInfo();


### PR DESCRIPTION
If a mission defines a waypoint, this waypoint is no longer visible once it has been visited, even if a task in said waypoint is incomplete (e.g. "destroy the Sestor drones"). Missions began tracking visited waypoints / stopovers in #3208, but they were not used outside of granting clearance to land without being fined.

This PR creates a faint ring around any visited waypoint of an active mission, when that mission is selected. In this screenshot I am in a waypoint system, and have the mission selected, which highlights the missions waypoints (both visited and unvisited).
![image](https://user-images.githubusercontent.com/20871346/35027050-0aae6fac-fb14-11e7-8874-8f780b5fca2c.png)
