### PR TITLE
Remove commas from color specifications

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -89,13 +89,13 @@ color "warning back" .21 .18 .08 1.
 
 # Colors used when drawing the map (system names, links, and the player's desired route).
 # (The color of the ring that represents a given system is context-sensitive.)
-color "map link" .6, .6, .6, .6
-color "map name" .6, .6, .6, .6
-color "map travel ok fleet" .2, .5, 0., 0.
-color "map travel ok flagship" .5, .4, 0., 0.
-color "map travel ok none" .55, .1, 0., 0.
-color "map used wormhole" .5, .2, .9, 1.
-color "map unused wormhole" .165, .066, .3, .333
+color "map link" .6 .6 .6 .6
+color "map name" .6 .6 .6 .6
+color "map travel ok fleet" .2 .5 0. 0.
+color "map travel ok flagship" .5 .4 0. 0.
+color "map travel ok none" .55 .1 0. 0.
+color "map used wormhole" .5 .2 .9 1.
+color "map unused wormhole" .165 .066 .3 .333
 
 
 


### PR DESCRIPTION
I accidentally included commas when I moved these to user colors.