### PR TITLE
Don't try to match the top when scrolling down a big selected item.

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -74,7 +74,7 @@ void ShopPanel::Step()
 		if(selectedBottomY > mainBottomY)
 			DoScroll(max(-30., mainBottomY - selectedBottomY));
 		// Scroll down until the bottoms or the tops match.
-		else if(selectedBottomY < mainBottomY && selectedTopY < mainTopY)
+		else if(selectedBottomY < mainBottomY && (mainBottomY - mainTopY < selectedBottomY - selectedTopY && selectedTopY < mainTopY))
 			DoScroll(min(30., min(mainTopY - selectedTopY, mainBottomY - selectedBottomY)));
 		// Details are in view.
 		else


### PR DESCRIPTION
If the height of the selected item was a bit bigger than the main height, the auto-scroll would go up and down repeatedly and never stop.