### PR TITLE
Moved M. Fury to persons

### DIFF
--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -454,62 +454,6 @@ ship "Marauder Firebird" "Marauder Firebird (Weapons)"
 
 
 
-ship "Marauder Fury"
-	plural "Marauder Furies"
-	sprite "ship/mfury"
-	attributes
-		category "Interceptor"
-		"cost" 750000
-		"shields" 3000
-		"hull" 600
-		"required crew" 1
-		"bunks" 3
-		"mass" 100
-		"drag" 1.9
-		"heat dissipation" .85
-		"fuel capacity" 500
-		"cargo space" 15
-		"outfit space" 240
-		"weapon capacity" 80
-		"engine capacity" 100
-		"ramscoop" 2
-		weapon
-			"blast radius" 36
-			"shield damage" 360
-			"hull damage" 180
-			"hit force" 520
-	outfits
-		"Hai Tracker Pod" 2
-		"Meteor Missile Launcher" 4
-		"Hai Tracker" 112
-		"Meteor Missile" 140
-		
-		"Pebble Core"
-		"Small Biochemical Cell"
-		"Hai Williwaw Cooling"
-		"Hai Corundum Regenerator"
-		"Laser Rifle" 3
-		
-		`"Biroo" Atomic Thruster`
-		"A255 Atomic Steering"
-		"Hyperdrive"
-		
-	engine -21 42
-	engine 0 48
-	engine 21 42
-	gun -12 -33 "Meteor Missile Launcher"
-	gun 12 -33 "Meteor Missile Launcher"
-	gun -20 -25 "Meteor Missile Launcher"
-	gun 20 -25 "Meteor Missile Launcher"
-	gun -43.5 2 "Hai Tracker Pod"
-	gun 43.5 2 "Hai Tracker Pod"
-	explode "tiny explosion" 10
-	explode "small explosion" 20
-	"final explode" "final explosion small"
-	description "You're sure there's a Southbound Fury under all the extra modifications. This ship appears to be one man's insane quest to make the most powerful single pilot warship ever. Upon closer inspection, you're inclined to believe he may have succeeded."
-
-
-
 ship "Marauder Leviathan"
 	sprite "ship/mleviathans"
 	attributes

--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -488,7 +488,7 @@ ship "Marauder Fury"
 		"Small Biochemical Cell"
 		"Hai Williwaw Cooling"
 		"Hai Corundum Regenerator"
-		"Intrusion Countermeasures" 3
+		"Laser Rifle" 3
 		
 		`"Biroo" Atomic Thruster`
 		"A255 Atomic Steering"

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -538,3 +538,57 @@ ship "Modified Osprey"
 	explode "small explosion" 40
 	explode "tiny explosion" 28
 	"final explode" "final explosion large" 1
+
+ship "Marauder Fury"
+	plural "Marauder Furies"
+	sprite "ship/mfury"
+	attributes
+		category "Interceptor"
+		"cost" 750000
+		"shields" 3000
+		"hull" 600
+		"required crew" 1
+		"bunks" 3
+		"mass" 100
+		"drag" 1.9
+		"heat dissipation" .85
+		"fuel capacity" 500
+		"cargo space" 15
+		"outfit space" 240
+		"weapon capacity" 80
+		"engine capacity" 100
+		"ramscoop" 2
+		weapon
+			"blast radius" 36
+			"shield damage" 360
+			"hull damage" 180
+			"hit force" 520
+	outfits
+		"Hai Tracker Pod" 2
+		"Meteor Missile Launcher" 4
+		"Hai Tracker" 112
+		"Meteor Missile" 140
+		
+		"Pebble Core"
+		"Small Biochemical Cell"
+		"Hai Williwaw Cooling"
+		"Hai Corundum Regenerator"
+		"Intrusion Countermeasures" 3
+		
+		`"Biroo" Atomic Thruster`
+		"A255 Atomic Steering"
+		"Hyperdrive"
+		
+	engine -21 42
+	engine 0 48
+	engine 21 42
+	gun -12 -33 "Meteor Missile Launcher"
+	gun 12 -33 "Meteor Missile Launcher"
+	gun -20 -25 "Meteor Missile Launcher"
+	gun 20 -25 "Meteor Missile Launcher"
+	gun -43.5 2 "Hai Tracker Pod"
+	gun 43.5 2 "Hai Tracker Pod"
+	explode "tiny explosion" 10
+	explode "small explosion" 20
+	"final explode" "final explosion small"
+	description "You're sure there's a Southbound Fury under all the extra modifications. This ship appears to be one man's insane quest to make the most powerful single pilot warship ever. Upon closer inspection, you're inclined to believe he may have succeeded."

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -162,6 +162,60 @@ person "Marauding Max K"
 			"into a REAL marauding warship!"
 	ship "Marauder Fury" "Mad Quest"
 
+ship "Marauder Fury"
+	plural "Marauder Furies"
+	sprite "ship/mfury"
+	attributes
+		category "Interceptor"
+		"cost" 750000
+		"shields" 3000
+		"hull" 600
+		"required crew" 1
+		"bunks" 3
+		"mass" 100
+		"drag" 1.9
+		"heat dissipation" .85
+		"fuel capacity" 500
+		"cargo space" 15
+		"outfit space" 240
+		"weapon capacity" 80
+		"engine capacity" 100
+		"ramscoop" 2
+		weapon
+			"blast radius" 36
+			"shield damage" 360
+			"hull damage" 180
+			"hit force" 520
+	outfits
+		"Hai Tracker Pod" 2
+		"Meteor Missile Launcher" 4
+		"Hai Tracker" 112
+		"Meteor Missile" 140
+		
+		"Pebble Core"
+		"Small Biochemical Cell"
+		"Hai Williwaw Cooling"
+		"Hai Corundum Regenerator"
+		"Intrusion Countermeasures" 3
+		
+		`"Biroo" Atomic Thruster`
+		"A255 Atomic Steering"
+		"Hyperdrive"
+		
+	engine -21 42
+	engine 0 48
+	engine 21 42
+	gun -12 -33 "Meteor Missile Launcher"
+	gun 12 -33 "Meteor Missile Launcher"
+	gun -20 -25 "Meteor Missile Launcher"
+	gun 20 -25 "Meteor Missile Launcher"
+	gun -43.5 2 "Hai Tracker Pod"
+	gun 43.5 2 "Hai Tracker Pod"
+	explode "tiny explosion" 10
+	explode "small explosion" 20
+	"final explode" "final explosion small"
+	description "You're sure there's a Southbound Fury under all the extra modifications. This ship appears to be one man's insane quest to make the most powerful single pilot warship ever. Upon closer inspection, you're inclined to believe he may have succeeded."
+
 
 
 person "Captain Nate"
@@ -538,57 +592,3 @@ ship "Modified Osprey"
 	explode "small explosion" 40
 	explode "tiny explosion" 28
 	"final explode" "final explosion large" 1
-
-ship "Marauder Fury"
-	plural "Marauder Furies"
-	sprite "ship/mfury"
-	attributes
-		category "Interceptor"
-		"cost" 750000
-		"shields" 3000
-		"hull" 600
-		"required crew" 1
-		"bunks" 3
-		"mass" 100
-		"drag" 1.9
-		"heat dissipation" .85
-		"fuel capacity" 500
-		"cargo space" 15
-		"outfit space" 240
-		"weapon capacity" 80
-		"engine capacity" 100
-		"ramscoop" 2
-		weapon
-			"blast radius" 36
-			"shield damage" 360
-			"hull damage" 180
-			"hit force" 520
-	outfits
-		"Hai Tracker Pod" 2
-		"Meteor Missile Launcher" 4
-		"Hai Tracker" 112
-		"Meteor Missile" 140
-		
-		"Pebble Core"
-		"Small Biochemical Cell"
-		"Hai Williwaw Cooling"
-		"Hai Corundum Regenerator"
-		"Intrusion Countermeasures" 3
-		
-		`"Biroo" Atomic Thruster`
-		"A255 Atomic Steering"
-		"Hyperdrive"
-		
-	engine -21 42
-	engine 0 48
-	engine 21 42
-	gun -12 -33 "Meteor Missile Launcher"
-	gun 12 -33 "Meteor Missile Launcher"
-	gun -20 -25 "Meteor Missile Launcher"
-	gun 20 -25 "Meteor Missile Launcher"
-	gun -43.5 2 "Hai Tracker Pod"
-	gun 43.5 2 "Hai Tracker Pod"
-	explode "tiny explosion" 10
-	explode "small explosion" 20
-	"final explode" "final explosion small"
-	description "You're sure there's a Southbound Fury under all the extra modifications. This ship appears to be one man's insane quest to make the most powerful single pilot warship ever. Upon closer inspection, you're inclined to believe he may have succeeded."


### PR DESCRIPTION
<s>Although I understand the Marauder Fury's need to defend itself, I think having it equipped with three Quarg Intrusion Countermeasures is hard to explain, lore-wise. This proposal replaces them with ordinary human laser rifles. There is no space (0/240) for security stations.</s>

Because it's a unique person ship, this proposal moves the M. Fury from the `marauders.txt` file to the `persons.txt` file to avoid unnecessary confusion.