### PR TITLE
Show location of player escorts on the map

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -657,6 +657,9 @@ void MapPanel::DrawTravelPlan()
 // Communicate the location of non-destroyed, player-owned ships.
 void MapPanel::DrawEscorts()
 {
+	if(!Preferences::Has("Show escort systems on map"))
+		return;
+	
 	// Fill in the center of any (non-flagship) escort system.
 	const Color &presence = *GameData::Colors().Get("map link");
 	double zoom = Zoom();

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -110,7 +110,7 @@ protected:
 	// for use in determining which governments are in the legend.
 	std::map<const Government *, double> closeGovernments;
 	// Systems in which your escorts are located.
-	std::map<const System *, int> escortSystems;
+	std::map<const System *, bool> escortSystems;
 	
 	
 private:

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -97,21 +97,29 @@ protected:
 	
 	const System *playerSystem;
 	const System *selectedSystem;
-	const System *specialSystem;
 	const Planet *selectedPlanet = nullptr;
+	// A system associated with a dialog or conversation.
+	const System *specialSystem;
 	
 	Point center;
 	int commodity;
 	int step = 0;
 	std::string buttonCondition;
 	
+	// Distance from the screen center to the nearest owned system,
+	// for use in determining which governments are in the legend.
 	std::map<const Government *, double> closeGovernments;
+	// Systems in which your escorts are located.
+	std::map<const System *, int> escortSystems;
 	
 	
 private:
 	void DrawTravelPlan();
+	// Indicate which other systems have player escorts.
+	void DrawEscorts();
 	void DrawWormholes();
 	void DrawLinks();
+	// Draw systems in accordance to the set commodity color scheme.
 	void DrawSystems();
 	void DrawNames();
 	void DrawMissions();

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -48,6 +48,7 @@ void Preferences::Load()
 	settings["Escorts expend ammo"] = true;
 	settings["Damaged fighters retreat"] = true;
 	settings["Warning siren"] = true;
+	settings["Show escort systems on map"] = true;
 	settings["Show mini-map"] = true;
 	settings["Show planet labels"] = true;
 	settings["Show hyperspace flash"] = true;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -441,11 +441,12 @@ void PreferencesPanel::DrawSettings()
 		"\n",
 		"Other",
 		"Clickable radar display",
+		"Hide unexplored map regions",
 		REACTIVATE_HELP,
 		"Rehire extra crew when lost",
 		SCROLL_SPEED,
-		"Warning siren",
-		"Hide unexplored map regions"
+		"Show escort systems on map",
+		"Warning siren"
 	};
 	bool isCategory = true;
 	for(const string &setting : SETTINGS)


### PR DESCRIPTION
Another part of #3070 (and #2678 ) was that the player should have a way to know where their escorts are. This has also come up in other issues, where players have trouble locating systems (to go get stranded escorts, etc).

Rather than add a pointer or a thin ring around escort systems (which are generally used for missions), I've opted to fill in the central ring of a system with a small pip if it has at least one player ship. If the only escorts are parked, the pip will be dimmer than if there are unparked ships there.
This is an opt-out preference.

<details><summary>Preference panel</summary>


![image](https://user-images.githubusercontent.com/20871346/35057767-94cc06e2-fb7b-11e7-87a4-d52499e3ecc6.png)
</details>
<details><summary>Escorts in Pherkad, Shaula, and Lesath</summary>

![image](https://user-images.githubusercontent.com/20871346/35058049-5b22206a-fb7c-11e7-922e-560bc6b41b67.png)
</details>

Possible alterations:
 - ~~Differentiate between systems with only parked escorts, and those with at least one unparked escort~~ Done
 - ~~Show the pip even for the player's system~~ Done
 - Choose a better preference name
 - ~~Make it opt-out or not optional~~ Done
 - Future Work: Tooltips

Feedback requested