### PR TITLE
Revert use of aggressive scanning check for non-surveillance ships

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -984,8 +984,8 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 			for(const auto &it : ships)
 				if(it->GetSystem() == system && it->GetGovernment() != gov && it->IsTargetable())
 				{
-					if((!cargoScan || Has(ship, it, ShipEvent::SCAN_CARGO))
-							&& (!outfitScan || Has(ship, it, ShipEvent::SCAN_OUTFITS)))
+					if((!cargoScan || Has(gov, it, ShipEvent::SCAN_CARGO))
+							&& (!outfitScan || Has(gov, it, ShipEvent::SCAN_OUTFITS)))
 						continue;
 					
 					double range = it->Position().Distance(ship.Position());


### PR DESCRIPTION
#3531 used the wrong "Should I scan this target?" check in FindTarget

This PR restores the "relaxed" scanning behavior to non-surveillance ships, wherein only any ship of that government can satisfy the urge to scan. Surveillance ships retain their penchant for nosiness, requiring a personal inspection.