### PR TITLE
Improvements to the Cloaking AI

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2159,6 +2159,17 @@ bool AI::DoCloak(Ship &ship, Command &command)
 			if(fuel < ship.JumpFuel())
 				return false;
 		}
+		
+		// If your parent has chosen to cloak, cloak and rendezvous with them.
+		const shared_ptr<const Ship> &parent = ship.GetParent();
+		if(parent && parent->Commands().Has(Command::CLOAK) && parent->GetSystem() == ship.GetSystem()
+				&& !parent->GetGovernment()->IsEnemy(ship.GetGovernment()))
+		{
+			command |= Command::CLOAK;
+			KeepStation(ship, command, *parent);
+			return true;
+		}
+		
 		// Otherwise, always cloak if you are in imminent danger.
 		static const double MAX_RANGE = 10000.;
 		double range = MAX_RANGE;

--- a/source/AI.h
+++ b/source/AI.h
@@ -100,7 +100,7 @@ private:
 	void DoSurveillance(Ship &ship, Command &command, std::shared_ptr<Ship> &target) const;
 	void DoMining(Ship &ship, Command &command);
 	bool DoHarvesting(Ship &ship, Command &command);
-	void DoCloak(Ship &ship, Command &command);
+	bool DoCloak(Ship &ship, Command &command);
 	// Prevent ships from stacking on each other when many are moving in sync.
 	void DoScatter(Ship &ship, Command &command);
 	


### PR DESCRIPTION
 - Cloaked ships can decloak to repair their disabled / stranded allies (and be asked to do so by ships of their own government)
 - Extended the "don't cloak if you'll be stranded" check to ensure that the ship can actually even achieve cloak
 - Switched from absolute shield/hull health to using the "health until disabled" metric, using the same threshold as retreating fighters.
 - Cloaking for repairs does not occur unless you can actually repair
 - Added a rudimentary "retreat" behavior, so that ships that choose to cloak to repair will actually increase the distance from their target (rather than continue to move as though they are not cloaked)
 - Cloaked AI escorts will cloak when their friendly parent cloaks, and then rendezvous with them (thus making it more likely that they focus on the same hostile target when they decloak).