### PR TITLE
Display a map tooltip for escorts in a given system

### DIFF
--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -22,6 +22,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 class Angle;
@@ -113,7 +114,7 @@ protected:
 	// for use in determining which governments are in the legend.
 	std::map<const Government *, double> closeGovernments;
 	// Systems in which your escorts are located.
-	std::map<const System *, bool> escortSystems;
+	std::map<const System *, std::pair<int, int>> escortSystems;
 	// Center the view on the given system (may actually be slightly offset
 	// to account for panels on the screen).
 	void CenterOnSystem(const System *system);

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Color.h"
 #include "DistanceMap.h"
 #include "Point.h"
+#include "WrappedText.h"
 
 #include <map>
 #include <string>
@@ -65,6 +66,7 @@ protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command) override;
 	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Hover(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Scroll(double dx, double dy) override;
 	
@@ -119,6 +121,13 @@ protected:
 	// Cache the map layout, so it doesn't have to be re-calculated every frame.
 	// The cache must be updated when the coloring mode changes.
 	void UpdateCache();
+	
+	// For tooltips:
+	int hoverCount = 0;
+	bool hasHover = false;
+	const System *hoverSystem = nullptr;
+	std::string tooltip;
+	WrappedText hoverText;
 	
 	
 private:

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -125,7 +125,6 @@ protected:
 	
 	// For tooltips:
 	int hoverCount = 0;
-	bool hasHover = false;
 	const System *hoverSystem = nullptr;
 	std::string tooltip;
 	WrappedText hoverText;

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -140,6 +140,7 @@ private:
 	void DrawSystems();
 	void DrawNames();
 	void DrawMissions();
+	void DrawTooltips();
 	void DrawPointer(const System *system, Angle &angle, const Color &color, bool bigger = false);
 	static void DrawPointer(Point position, Angle &angle, const Color &color, bool drawBack = true, bool bigger = false);
 	

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -157,11 +157,12 @@ bool MapSalesPanel::Click(int x, int y, int clicks)
 
 
 
+// Check to see if the mouse is over the scrolling pane.
 bool MapSalesPanel::Hover(int x, int y)
 {
 	isDragging = (x < Screen::Left() + WIDTH);
 	
-	return true;
+	return isDragging ? true : MapPanel::Hover(x, y);
 }
 
 

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -403,6 +403,7 @@ bool MissionPanel::Drag(double dx, double dy)
 
 
 
+// Check to see if the mouse is over either of the mission lists.
 bool MissionPanel::Hover(int x, int y)
 {
 	dragSide = 0;
@@ -417,7 +418,7 @@ bool MissionPanel::Hover(int x, int y)
 		if(static_cast<int>(index) < AcceptedVisible())
 			dragSide = 1;
 	}
-	return true;
+	return dragSide ? true : MapPanel::Hover(x, y);
 }
 
 


### PR DESCRIPTION
Refs https://github.com/endless-sky/endless-sky/pull/3576#issuecomment-358497939

Current UI:
<details><summary>Active and parked</summary>


![image](https://user-images.githubusercontent.com/20871346/35171223-9c3d1b92-fd28-11e7-84b0-55e6a98dd0f7.png)
</details>
<details><summary>Flagship only</summary>


![image](https://user-images.githubusercontent.com/20871346/35171236-aca792c8-fd28-11e7-86ab-3329c10111c0.png)
</details><details><summary>Active only</summary>


![image](https://user-images.githubusercontent.com/20871346/35171337-1902e972-fd29-11e7-8204-e2bb007d591a.png)
</details><details><summary>Parked only</summary>


![image](https://user-images.githubusercontent.com/20871346/35171403-5210a7d6-fd29-11e7-8bd2-5da107ba91cb.png)
</details>


~~To-do~~ Done
 - [x] Change escortSystems to track count and type, not just type (e.g. `pair<int, int>` instead of `bool`)
 - [x] Extended info tooltips per refernence
 - [x] Smarter fillshader / tooltip position (shifting near edge)
 - [x] Support "passive" hovering rather than only active hovering.
 - [x] Obey preference for pip display (no pips -> no pip tooltips)