### PR TITLE
Largest Korath drones get more large heat shunts

### DIFF
--- a/data/korath ships.txt
+++ b/data/korath ships.txt
@@ -319,8 +319,7 @@ ship "Kar Ik Vot 349"
 		"Triple Plasma Core"
 		"Plasma Core"
 		"Systems Core (Large)"
-		"Large Heat Shunt" 4
-		"Small Heat Shunt" 2
+		"Large Heat Shunt" 5
 		"Control Transceiver"
 		
 		"Thruster (Planetary Class)"
@@ -1150,7 +1149,7 @@ ship "Model 256"
 		
 		"Triple Plasma Core"
 		"Systems Core (Large)"
-		"Large Heat Shunt"
+		"Large Heat Shunt" 2
 		"Reasoning Node" 3
 		
 		"Thruster (Planetary Class)"
@@ -1208,7 +1207,7 @@ ship "Model 512"
 		"Triple Plasma Core"
 		"Plasma Core"
 		"Systems Core (Large)"
-		"Large Heat Shunt"
+		"Large Heat Shunt" 2
 		"Small Heat Shunt" 2
 		"Reasoning Node" 3
 		


### PR DESCRIPTION
The Kar Ik Vot 349, Model 256, and Model 512 produce a lot of heat but also have some unused outfit capacity. This proposal gives them one more large heat shunt (size 24) to make them less likely to be overheated by heat-producing weapons. There is enough room for this, therefore mass and outfit size can be left unchanged.

The Kor Mereti Model 256 and Model 512 before:
![screenshot from 2018-01-19 18-34-32](https://user-images.githubusercontent.com/21634324/35163770-2a09b038-fd48-11e7-8465-15838b1a347e.png)

The Kor Mereti Model 256 and Model 512 after:
![screenshot from 2018-01-19 18-43-42](https://user-images.githubusercontent.com/21634324/35163988-d65add12-fd48-11e7-90e6-c65e32a583dd.png)


The Kor Sestor Kar Ik Vot 349 currently has 4 large + 2 small heat shunts, resulting into:
![screenshot from 2018-01-19 18-30-40](https://user-images.githubusercontent.com/21634324/35163910-85a5bc66-fd48-11e7-9e44-73d1251254b4.png)

This proposal replaces those with 5 large + 0 small heat shunts, resulting into:
![screenshot from 2018-01-19 18-31-55](https://user-images.githubusercontent.com/21634324/35163923-905e48d0-fd48-11e7-8456-16a51d40689b.png)
