### PR TITLE
Update the line width for the final word in a wrapped text string

### DIFF
--- a/source/WrappedText.cpp
+++ b/source/WrappedText.cpp
@@ -231,12 +231,12 @@ void WrappedText::Wrap()
 			int width = font->Width(text.c_str() + word.index);
 			if(word.x + width > wrapWidth)
 			{
-				// If we just overflowed the length of the line, this word will
-				// be the first on the next line, and the current line needs to
-				// be adjusted for alignment.
+				// If adding this word would overflow the length of the line, this
+				// word will be the first on the next line.
 				word.y += lineHeight;
 				word.x = 0;
 				
+				// Adjust the spacing of words in the now-complete line.
 				AdjustLine(lineBegin, lineWidth, false);
 			}
 			// Store this word, then advance the x position to the end of it.
@@ -251,9 +251,11 @@ void WrappedText::Wrap()
 		// If that whitespace was a newline, we must handle that, too.
 		if(c == '\n')
 		{
+			// The next word will begin on a new line.
 			word.y += lineHeight + paragraphBreak;
 			word.x = 0;
 			
+			// Adjust the word spacings on the now-completed line.
 			AdjustLine(lineBegin, lineWidth, true);
 		}
 		// Otherwise, whitespace just adds to the x position.
@@ -272,17 +274,22 @@ void WrappedText::Wrap()
 		int width = font->Width(text.c_str() + word.index);
 		if(word.x + width > wrapWidth)
 		{
-			// If we just overflowed the length of the line, this word will
-			// be the first on the next line, and the current line needs to
-			// be adjusted for alignment.
+			// If adding this word would overflow the length of the line, this
+			// final word will be the first (and only) on the next line.
 			word.y += lineHeight;
 			word.x = 0;
 			
+			// Adjust the spacing of words in the now-complete line.
 			AdjustLine(lineBegin, lineWidth, false);
 		}
+		// Add this final word to the existing words.
 		words.push_back(word);
 		word.y += lineHeight + paragraphBreak;
+		// Keep track of how wide this line is now that this word is added.
+		word.x += width;
+		lineWidth = word.x;
 	}
+	// Adjust the spacing of words in the final line of text.
 	AdjustLine(lineBegin, lineWidth, true);
 	
 	height = word.y;


### PR DESCRIPTION
Refs #3588 
 - If `CENTER` or `RIGHT` aligning, the width of the last word is needed. With adding it, `extraSpace` erroneously included the width of the final word, resulting in the addition of too much space when adjusting word positions.
 - Since `JUSTIFIED` is historically the only alignment used, and no justification of the final line is done (it's always left-aligned), this escaped detection for quite a while :)
 