### PR TITLE
Add more swizzle choices

### DIFF
--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -36,34 +36,34 @@ namespace {
 	GLuint vbo;
 
 	const vector<vector<GLint>> SWIZZLE = {
-		{GL_RED, GL_GREEN, GL_BLUE, GL_ALPHA},		 // red + yellow markings (republic)
-		{GL_RED, GL_BLUE, GL_GREEN, GL_ALPHA},		 // red + magenta markings
-		{GL_GREEN, GL_RED, GL_BLUE, GL_ALPHA},		 // green + yellow (freeholders)
-		{GL_BLUE, GL_RED, GL_GREEN, GL_ALPHA},		 // green + cyan
-		{GL_GREEN, GL_BLUE, GL_RED, GL_ALPHA},		 // blue + magenta (syndicate)
-		{GL_BLUE, GL_GREEN, GL_RED, GL_ALPHA},		 // blue + cyan (merchant)
-		{GL_GREEN, GL_BLUE, GL_BLUE, GL_ALPHA},		 // red and black (pirate)
-		{GL_BLUE, GL_ZERO, GL_ZERO, GL_ALPHA}, 		 // red only (cloaked)
-		{GL_ZERO, GL_ZERO, GL_ZERO, GL_ALPHA}, 		 // black only (outline)
-		{GL_RED, GL_RED, GL_GREEN, GL_ALPHA},		// 9 faded yellow
-		{GL_RED, GL_RED, GL_BLUE, GL_ALPHA},		// 10 yellow
-		{GL_RED, GL_GREEN, GL_RED, GL_ALPHA},		// 11 faded magenta
-		{GL_RED, GL_GREEN, GL_GREEN, GL_ALPHA},		// 12 faded red
-		{GL_RED, GL_BLUE, GL_RED, GL_ALPHA},		// 13 magenta
-		{GL_RED, GL_BLUE, GL_BLUE, GL_ALPHA},		// 14 red
-		{GL_GREEN, GL_RED, GL_RED, GL_ALPHA},		// 15 faded cyan
-		{GL_GREEN, GL_RED, GL_GREEN, GL_ALPHA},		// 16 faded green
-		{GL_GREEN, GL_GREEN, GL_RED, GL_ALPHA},		// 17 faded blue
-		{GL_GREEN, GL_GREEN, GL_GREEN, GL_ALPHA},	 // 18 silver / monochrome
-		{GL_GREEN, GL_GREEN, GL_BLUE, GL_ALPHA},	// 19 ochre
-		{GL_GREEN, GL_BLUE, GL_GREEN, GL_ALPHA},	// 20 purple
-		{GL_BLUE, GL_RED, GL_RED, GL_ALPHA},		// 21 cyan
-		{GL_BLUE, GL_RED, GL_BLUE, GL_ALPHA},		// 22 green
-		{GL_BLUE, GL_GREEN, GL_GREEN, GL_ALPHA},	// 23 dark blue
-		{GL_BLUE, GL_GREEN, GL_BLUE, GL_ALPHA},		// 24 dark green
-		{GL_BLUE, GL_BLUE, GL_RED, GL_ALPHA},		// 25 deep blue
-		{GL_BLUE, GL_BLUE, GL_GREEN, GL_ALPHA},		// 26 navy blue
-		{GL_BLUE, GL_BLUE, GL_BLUE, GL_ALPHA},		// 27 black
+		{GL_RED, GL_GREEN, GL_BLUE, GL_ALPHA},		// 0 red + yellow markings (republic)
+		{GL_RED, GL_BLUE, GL_GREEN, GL_ALPHA},		// 1 red + magenta markings
+		{GL_GREEN, GL_RED, GL_BLUE, GL_ALPHA},		// 2 green + yellow (freeholders)
+		{GL_BLUE, GL_RED, GL_GREEN, GL_ALPHA},		// 3 green + cyan
+		{GL_GREEN, GL_BLUE, GL_RED, GL_ALPHA},		// 4 blue + magenta (syndicate)
+		{GL_BLUE, GL_GREEN, GL_RED, GL_ALPHA},		// 5 blue + cyan (merchant)
+		{GL_GREEN, GL_BLUE, GL_BLUE, GL_ALPHA},		// 6 red and black (pirate)
+		{GL_BLUE, GL_ZERO, GL_ZERO, GL_ALPHA}, 		// 7 red only (cloaked)
+		{GL_ZERO, GL_ZERO, GL_ZERO, GL_ALPHA}, 		// 8 black only (outline)
+		{GL_RED, GL_GREEN, GL_GREEN, GL_ALPHA},		// 9 faded red
+		{GL_RED, GL_BLUE, GL_BLUE, GL_ALPHA},		// 10 red
+		{GL_RED, GL_RED, GL_GREEN, GL_ALPHA},		// 11 faded yellow
+		{GL_GREEN, GL_GREEN, GL_BLUE, GL_ALPHA},	// 12 ochre
+		{GL_RED, GL_RED, GL_BLUE, GL_ALPHA},		// 13 yellow
+		{GL_GREEN, GL_RED, GL_GREEN, GL_ALPHA},		// 14 faded green
+		{GL_BLUE, GL_RED, GL_BLUE, GL_ALPHA},		// 15 green
+		{GL_BLUE, GL_GREEN, GL_BLUE, GL_ALPHA},		// 16 dark green
+		{GL_GREEN, GL_RED, GL_RED, GL_ALPHA},		// 17 faded cyan
+		{GL_BLUE, GL_RED, GL_RED, GL_ALPHA},		// 18 cyan
+		{GL_GREEN, GL_GREEN, GL_RED, GL_ALPHA},		// 19 faded blue
+		{GL_BLUE, GL_BLUE, GL_GREEN, GL_ALPHA},		// 20 navy blue
+		{GL_BLUE, GL_BLUE, GL_RED, GL_ALPHA},		// 21 deep blue
+		{GL_BLUE, GL_GREEN, GL_GREEN, GL_ALPHA},	// 22 dark blue
+		{GL_GREEN, GL_BLUE, GL_GREEN, GL_ALPHA},	// 23 purple
+		{GL_RED, GL_GREEN, GL_RED, GL_ALPHA},		// 24 faded magenta
+		{GL_RED, GL_BLUE, GL_RED, GL_ALPHA},		// 25 magenta
+		{GL_BLUE, GL_BLUE, GL_BLUE, GL_ALPHA},		// 26 black
+		{GL_GREEN, GL_GREEN, GL_GREEN, GL_ALPHA},	// 27 silver / monochrome
 	};
 }
 

--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -36,35 +36,35 @@ namespace {
 	GLuint vbo;
 
 	const vector<vector<GLint>> SWIZZLE = {
-		{GL_RED, GL_GREEN, GL_BLUE, GL_ALPHA}, // red + yellow markings (republic)
-		{GL_RED, GL_BLUE, GL_GREEN, GL_ALPHA}, // red + magenta markings
-		{GL_GREEN, GL_RED, GL_BLUE, GL_ALPHA}, // green + yellow (freeholders)
-		{GL_BLUE, GL_RED, GL_GREEN, GL_ALPHA}, // green + cyan
-		{GL_GREEN, GL_BLUE, GL_RED, GL_ALPHA}, // blue + magenta (syndicate)
-		{GL_BLUE, GL_GREEN, GL_RED, GL_ALPHA}, // blue + cyan (merchant)
-		{GL_GREEN, GL_BLUE, GL_BLUE, GL_ALPHA}, // red and black (pirate)
-		{GL_BLUE, GL_ZERO, GL_ZERO, GL_ALPHA},  // red only (cloaked)
-		{GL_ZERO, GL_ZERO, GL_ZERO, GL_ALPHA},  // black only (outline)
-		{GL_RED, GL_RED, GL_GREEN, GL_ALPHA},			// 9 faded yellow
-		{GL_RED, GL_RED, GL_BLUE, GL_ALPHA},			// 10 yellow
-		{GL_RED, GL_GREEN, GL_RED, GL_ALPHA},			// 11 faded magenta
+		{GL_RED, GL_GREEN, GL_BLUE, GL_ALPHA},		 // red + yellow markings (republic)
+		{GL_RED, GL_BLUE, GL_GREEN, GL_ALPHA},		 // red + magenta markings
+		{GL_GREEN, GL_RED, GL_BLUE, GL_ALPHA},		 // green + yellow (freeholders)
+		{GL_BLUE, GL_RED, GL_GREEN, GL_ALPHA},		 // green + cyan
+		{GL_GREEN, GL_BLUE, GL_RED, GL_ALPHA},		 // blue + magenta (syndicate)
+		{GL_BLUE, GL_GREEN, GL_RED, GL_ALPHA},		 // blue + cyan (merchant)
+		{GL_GREEN, GL_BLUE, GL_BLUE, GL_ALPHA},		 // red and black (pirate)
+		{GL_BLUE, GL_ZERO, GL_ZERO, GL_ALPHA}, 		 // red only (cloaked)
+		{GL_ZERO, GL_ZERO, GL_ZERO, GL_ALPHA}, 		 // black only (outline)
+		{GL_RED, GL_RED, GL_GREEN, GL_ALPHA},		// 9 faded yellow
+		{GL_RED, GL_RED, GL_BLUE, GL_ALPHA},		// 10 yellow
+		{GL_RED, GL_GREEN, GL_RED, GL_ALPHA},		// 11 faded magenta
 		{GL_RED, GL_GREEN, GL_GREEN, GL_ALPHA},		// 12 faded red
-		{GL_RED, GL_BLUE, GL_RED, GL_ALPHA},			// 13 magenta
-		{GL_RED, GL_BLUE, GL_BLUE, GL_ALPHA},			// 14 red
-		{GL_GREEN, GL_RED, GL_RED, GL_ALPHA},			// 15 faded cyan
+		{GL_RED, GL_BLUE, GL_RED, GL_ALPHA},		// 13 magenta
+		{GL_RED, GL_BLUE, GL_BLUE, GL_ALPHA},		// 14 red
+		{GL_GREEN, GL_RED, GL_RED, GL_ALPHA},		// 15 faded cyan
 		{GL_GREEN, GL_RED, GL_GREEN, GL_ALPHA},		// 16 faded green
 		{GL_GREEN, GL_GREEN, GL_RED, GL_ALPHA},		// 17 faded blue
-		{GL_GREEN, GL_GREEN, GL_GREEN, GL_ALPHA}, // 18 silver / monochrome
+		{GL_GREEN, GL_GREEN, GL_GREEN, GL_ALPHA},	 // 18 silver / monochrome
 		{GL_GREEN, GL_GREEN, GL_BLUE, GL_ALPHA},	// 19 ochre
 		{GL_GREEN, GL_BLUE, GL_GREEN, GL_ALPHA},	// 20 purple
-		{GL_BLUE, GL_RED, GL_RED, GL_ALPHA},			// 21 cyan
-		{GL_BLUE, GL_RED, GL_BLUE, GL_ALPHA},			// 22 green
+		{GL_BLUE, GL_RED, GL_RED, GL_ALPHA},		// 21 cyan
+		{GL_BLUE, GL_RED, GL_BLUE, GL_ALPHA},		// 22 green
 		{GL_BLUE, GL_GREEN, GL_GREEN, GL_ALPHA},	// 23 dark blue
 		{GL_BLUE, GL_GREEN, GL_BLUE, GL_ALPHA},		// 24 dark green
-		{GL_BLUE, GL_BLUE, GL_RED, GL_ALPHA},			// 25 deep blue
+		{GL_BLUE, GL_BLUE, GL_RED, GL_ALPHA},		// 25 deep blue
 		{GL_BLUE, GL_BLUE, GL_GREEN, GL_ALPHA},		// 26 navy blue
 		{GL_BLUE, GL_BLUE, GL_BLUE, GL_ALPHA},		// 27 black
-		{GL_RED, GL_RED, GL_ALPHA, GL_ALPHA},			// 28 blue (overlay)
+		{GL_RED, GL_RED, GL_ALPHA, GL_ALPHA},		// 28 blue (overlay)
 		{GL_ALPHA, GL_RED, GL_ALPHA, GL_ALPHA},		// 29 magenta (overlay)
 		{GL_ALPHA, GL_ALPHA, GL_ALPHA, GL_ALPHA},	// 30 white only (outline)
 		{GL_BLUE, GL_BLUE, GL_ALPHA, GL_ALPHA}		// 31 navy blue (overlay)

--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -31,7 +31,7 @@ namespace {
 	GLint blurI;
 	GLint clipI;
 	GLint alphaI;
-
+	
 	GLuint vao;
 	GLuint vbo;
 
@@ -82,17 +82,17 @@ void SpriteShader::Init()
 		"uniform mat2 transform;\n"
 		"uniform vec2 blur;\n"
 		"uniform float clip;\n"
-
+		
 		"in vec2 vert;\n"
 		"out vec2 fragTexCoord;\n"
-
+		
 		"void main() {\n"
 		"  vec2 blurOff = 2 * vec2(vert.x * abs(blur.x), vert.y * abs(blur.y));\n"
 		"  gl_Position = vec4((transform * (vert + blurOff) + position) * scale, 0, 1);\n"
 		"  vec2 texCoord = vert + vec2(.5, .5);\n"
 		"  fragTexCoord = vec2(texCoord.x, max(clip, texCoord.y)) + blurOff;\n"
 		"}\n";
-
+	
 	static const char *fragmentCode =
 		"uniform sampler2DArray tex;\n"
 		"uniform float frame;\n"
@@ -100,11 +100,11 @@ void SpriteShader::Init()
 		"uniform vec2 blur;\n"
 		"uniform float alpha;\n"
 		"const int range = 5;\n"
-
+		
 		"in vec2 fragTexCoord;\n"
-
+		
 		"out vec4 finalColor;\n"
-
+		
 		"void main() {\n"
 		"  float first = floor(frame);\n"
 		"  float second = mod(ceil(frame), frameCount);\n"
@@ -137,7 +137,7 @@ void SpriteShader::Init()
 		"  }\n"
 		"  finalColor = color * alpha;\n"
 		"}\n";
-
+	
 	shader = Shader(vertexCode, fragmentCode);
 	scaleI = shader.Uniform("scale");
 	frameI = shader.Uniform("frame");
@@ -147,15 +147,15 @@ void SpriteShader::Init()
 	blurI = shader.Uniform("blur");
 	clipI = shader.Uniform("clip");
 	alphaI = shader.Uniform("alpha");
-
+	
 	glUseProgram(shader.Object());
 	glUniform1i(shader.Uniform("tex"), 0);
 	glUseProgram(0);
-
+	
 	// Generate the vertex data for drawing sprites.
 	glGenVertexArrays(1, &vao);
 	glBindVertexArray(vao);
-
+	
 	glGenBuffers(1, &vbo);
 	glBindBuffer(GL_ARRAY_BUFFER, vbo);
 
@@ -166,10 +166,10 @@ void SpriteShader::Init()
 		 .5f,  .5f
 	};
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertexData), vertexData, GL_STATIC_DRAW);
-
+	
 	glEnableVertexAttribArray(shader.Attrib("vert"));
 	glVertexAttribPointer(shader.Attrib("vert"), 2, GL_FLOAT, GL_FALSE, 2 * sizeof(GLfloat), nullptr);
-
+	
 	// unbind the VBO and VAO
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindVertexArray(0);
@@ -181,7 +181,7 @@ void SpriteShader::Draw(const Sprite *sprite, const Point &position, float zoom,
 {
 	if(!sprite)
 		return;
-
+	
 	Item item;
 	item.texture = sprite->Texture();
 	item.frame = frame;
@@ -194,7 +194,7 @@ void SpriteShader::Draw(const Sprite *sprite, const Point &position, float zoom,
 	item.transform[3] = sprite->Height() * zoom;
 	// Swizzle.
 	item.swizzle = swizzle;
-
+	
 	Bind();
 	Add(item);
 	Unbind();
@@ -206,7 +206,7 @@ void SpriteShader::Bind()
 {
 	glUseProgram(shader.Object());
 	glBindVertexArray(vao);
-
+	
 	GLfloat scale[2] = {2.f / Screen::Width(), -2.f / Screen::Height()};
 	glUniform2fv(scaleI, 1, scale);
 }
@@ -227,12 +227,12 @@ void SpriteShader::Add(const Item &item, bool withBlur)
 	// Clipping has the oppostie sense in the shader.
 	glUniform1f(clipI, 1.f - item.clip);
 	glUniform1f(alphaI, item.alpha);
-
+	
 	// Bounds check for the swizzle value:
 	int swizzle = (static_cast<size_t>(item.swizzle) >= SWIZZLE.size() ? 0 : item.swizzle);
 	// Set the color swizzle.
 	glTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_SWIZZLE_RGBA, SWIZZLE[swizzle].data());
-
+	
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
 
@@ -242,7 +242,7 @@ void SpriteShader::Unbind()
 {
 	glBindVertexArray(0);
 	glUseProgram(0);
-
+	
 	// Reset the swizzle.
 	glTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_SWIZZLE_RGBA, SWIZZLE[0].data());
 }

--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -64,10 +64,6 @@ namespace {
 		{GL_BLUE, GL_BLUE, GL_RED, GL_ALPHA},		// 25 deep blue
 		{GL_BLUE, GL_BLUE, GL_GREEN, GL_ALPHA},		// 26 navy blue
 		{GL_BLUE, GL_BLUE, GL_BLUE, GL_ALPHA},		// 27 black
-		{GL_RED, GL_RED, GL_ALPHA, GL_ALPHA},		// 28 blue (overlay)
-		{GL_ALPHA, GL_RED, GL_ALPHA, GL_ALPHA},		// 29 magenta (overlay)
-		{GL_ALPHA, GL_ALPHA, GL_ALPHA, GL_ALPHA},	// 30 white only (outline)
-		{GL_BLUE, GL_BLUE, GL_ALPHA, GL_ALPHA}		// 31 navy blue (overlay)
 	};
 }
 

--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -158,7 +158,7 @@ void SpriteShader::Init()
 	
 	glGenBuffers(1, &vbo);
 	glBindBuffer(GL_ARRAY_BUFFER, vbo);
-
+	
 	GLfloat vertexData[] = {
 		-.5f, -.5f,
 		-.5f,  .5f,


### PR DESCRIPTION
Based on #1779 and #2009, this PR adds 18 new swizzle options.
 
`swizzle 27`
![image](https://user-images.githubusercontent.com/8760485/35177380-29319d9c-fd7f-11e7-97ff-bb8ff1b87931.png)

`swizzle 20`
![image](https://user-images.githubusercontent.com/8760485/35177384-37dbc606-fd7f-11e7-8ed7-eec9fd2c6b24.png)