### PR TITLE
Replace timer for "fw syndicate welcoming" with filter-restricted "on enter"

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -1767,14 +1767,13 @@ event "pug invasion 4"
 
 
 event "fw syndicate welcoming"
-	"reputation: Syndicate" = 1
-	government Syndicate
+	government "Syndicate"
 		"attitude toward"
 			"Free Worlds" 0
-			Republic 0
+			"Republic" 0
 			"Navy (Oathkeeper)" 0
 		bribe .08
-	system Algenib
+	system "Algenib"
 		government "Syndicate (Extremist)"
 		fleet "Small Core Pirates" 1500
 		fleet "Large Core Pirates" 2000

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -927,7 +927,8 @@ mission "FW Northern 3B"
 				accept
 	
 	npc accompany save
-		personality timid
+		government "Free Worlds"
+		personality timid escort
 		ship Dreadnought "F.S. Bartlett"
 		ship Dreadnought "F.S. Magnolia"
 	
@@ -1478,8 +1479,8 @@ mission "FW Bloodsea 1.2A"
 	landing
 	name "Capture Bloodsea"
 	description "Take a Free Worlds fleet to invade the <system> system and eliminate any pirate resistance, then land on <planet>."
-	source Dancer
-	destination Bloodsea
+	source "Dancer"
+	destination "Bloodsea"
 	clearance
 	to offer
 		has "FW Bloodsea 1.2: done"
@@ -1498,7 +1499,8 @@ mission "FW Bloodsea 1.2A"
 				accept
 	
 	npc
-		personality heroic
+		government "Free Worlds"
+		personality heroic escort
 		ship "Dreadnought" "F.S. Bombastic"
 		ship "Falcon (Plasma)" "F.S. Equalizer"
 		ship "Falcon (Plasma)" "F.S. Enforcer"
@@ -2069,7 +2071,8 @@ mission "FW Liberate Delta Sagittarii"
 		event "fwc southern liberation"
 	
 	npc
-		personality heroic
+		government "Free Worlds"
+		personality heroic escort
 		fleet
 			names "free worlds capital"
 			variant

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -1030,8 +1030,8 @@ mission "FW Pug 2A"
 	name "Reason with the Syndicate"
 	description "Travel with Alondo to meet with the Syndicate leaders on Foundry, determine their intentions, and convince them not to completely seal themselves off from human space. Hurry, before they cut the last link."
 	autosave
-	source Earth
-	destination Foundry
+	source "Earth"
+	destination "Foundry"
 	clearance
 	passengers 1
 	to offer
@@ -1041,7 +1041,6 @@ mission "FW Pug 2A"
 	
 	on offer
 		log "Agreed to travel to Syndicate space through the one remaining hyperspace path that is still open, through the uninhabited star systems to the north."
-		event "fw syndicate welcoming" 11
 		conversation
 			`A palpable sense of fear and near-panic hangs over the spaceport on Earth. At any minute, this system that serves as the very hub of human government could disappear into the same unknown abyss that has swallowed up its neighbors.`
 			`	Parliament is eager now to meet with you and to receive whatever assistance you may be able to offer. As Alondo stands in front of the chamber asking the members of Parliament for more information, they answer him with respect and deference, far different from how you have been treated here in the past. You learn that although one link remains open to Syndicate space, no one has dared to travel through it. Given the pace at which the other links were cut, they fear that the one remaining link will disappear any day now.`
@@ -1068,8 +1067,11 @@ mission "FW Pug 2A"
 			label yes
 			`	Parliament thanks you for your willingness to serve, and you and Alondo hurry back to your ship. "There's no telling how long the link will remain open," he says. "So, we must hurry to the Syndicate headquarters on <planet> immediately."`
 				accept
-	on complete
-		"reputation: Syndicate" >?= 1
+	on enter
+		system
+			government "Syndicate"
+		"reputation: Syndicate" = 1
+		event "fw syndicate welcoming"
 	
 	npc
 		system "Sol"
@@ -1083,13 +1085,12 @@ mission "FW Pug 2A"
 mission "FW Pug 2A Visit"
 	landing
 	source
-		near Achernar 1 100
-		government Syndicate
+		near "Achernar" 1 100
+		government "Syndicate"
 	to offer
 		has "FW Pug 2A: active"
 	
 	on offer
-		"reputation: Syndicate" >?= 1
 		conversation
 			`Oddly, when you land on <origin> you find that the people here are in as much of a state of confusion and fear as back on Earth. Either no one knows what is going on and why they have been nearly cut off from the rest of human space, or every single person you talk to is united in a conspiracy to feign ignorance. They urge you to continue your journey to meet with the Syndicate executives on Foundry. "Maybe you can talk some sense into them," says one merchant captain. "First the nukes, and now this. The extremist faction within the Syndicate is getting out of hand."`
 				decline
@@ -1101,8 +1102,8 @@ mission "FW Pug 2B"
 	name "Install a Jump Drive"
 	description "Travel to the Syndicate world of Hephaestus, where the Syndicate Systems personnel have been instructed to install a jump drive on your ship, so that you can investigate the systems that the Pug has cut off."
 	autosave
-	source Foundry
-	destination Hephaestus
+	source "Foundry"
+	destination "Hephaestus"
 	to offer
 		has "FW Pug 2A: done"
 	passengers 1


### PR DESCRIPTION
Refs #1360 
 - `"fw syndicate welcoming"` resets the player's rep to 1 (ensuring the player can land on the Syndicate worlds, which are not accepting bribes at that point).
 - If the player had a Jump Drive but did not dominate Syndicate worlds, they would be unable to land until the event triggered.
 - Since `on enter` MissionActions are processed after the player's pending GameEvents are checked, any GameEvent within an `on enter` will not actually occur until the next day (e.g. jump or planetary takeoff), the rep change is moved from the GameEvent into the `on enter` MissionAction. The player does not have any Free Worlds or Republic escorts for this mission, so the `attitude toward` and system fleet adjustments can wait the extra day.


 - Also removes a few uses of the "Escort" government where "Free Worlds" + `personality escort` would suffice