### PR TITLE
Replace most gov->IsPlayer with ship->IsYours

### DIFF
--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -91,7 +91,8 @@ mission "FWC Attack Kaus Borealis"
 		event "fwc capture kaus borealis"
 	
 	npc
-		personality heroic
+		government "Free Worlds"
+		personality heroic escort
 		fleet
 			names "free worlds capital"
 			fighters "free worlds fighters"
@@ -240,7 +241,8 @@ mission "FWC Cebalrai 1B"
 		event "fwc capture cebalrai"
 	
 	npc
-		personality heroic
+		government "Free Worlds"
+		personality heroic escort
 		fleet
 			names "free worlds capital"
 			variant
@@ -491,7 +493,8 @@ mission "FWC Diplomacy 1B"
 				accept
 	
 	npc accompany save
-		personality timid
+		government "Escort"
+		personality timid escort
 		ship "Argosy" "F.S. Big Brother"
 
 	on visit
@@ -535,7 +538,8 @@ mission "FWC Diplomacy 1C"
 				launch
 	
 	npc
-		personality timid
+		government "Escort"
+		personality timid escort
 		ship "Argosy" "F.S. Big Brother"
 
 	npc
@@ -601,7 +605,8 @@ mission "FWC Checkmate 1"
 				launch
 	
 	npc
-		personality heroic
+		government "Free Worlds"
+		personality heroic escort
 		fleet
 			names "free worlds capital"
 			fighters "free worlds fighters"
@@ -819,7 +824,8 @@ mission "FWC Checkmate 1B"
 		event "fwc capture menkent"
 
 	npc
-		personality heroic
+		government "Free Worlds"
+		personality heroic escort
 		fleet
 			names "free worlds capital"
 			fighters "free worlds fighters"
@@ -930,7 +936,8 @@ mission "FWC Checkmate Escorts"
 		has "FWC Pug 4: done"
 	
 	npc kill
-		personality heroic disables
+		government "Free Worlds"
+		personality heroic escort disables
 		fleet
 			names "free worlds capital"
 			variant
@@ -1488,7 +1495,8 @@ mission "FWC Pug 3B"
 				launch
 	
 	npc
-		personality heroic
+		government "Free Worlds"
+		personality heroic escort
 		fleet
 			names "free worlds capital"
 			fighters "free worlds fighters"
@@ -1636,7 +1644,8 @@ mission "FWC Pug 3D: Reinforcements"
 				"Combat Drone" 6
 				"Gunboat" 2
 	npc kill
-		personality heroic waiting
+		government "Free Worlds"
+		personality heroic escort waiting
 		fleet
 			names "free worlds capital"
 			variant

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -927,7 +927,8 @@ mission "FW Northern 3B"
 				accept
 	
 	npc accompany save
-		personality timid
+		government "Free Worlds"
+		personality timid escort
 		ship Dreadnought "F.S. Bartlett"
 		ship Dreadnought "F.S. Magnolia"
 	
@@ -1498,7 +1499,8 @@ mission "FW Bloodsea 1.2A"
 				accept
 	
 	npc
-		personality heroic
+		government "Free Worlds"
+		personality heroic escort
 		ship "Dreadnought" "F.S. Bombastic"
 		ship "Falcon (Plasma)" "F.S. Equalizer"
 		ship "Falcon (Plasma)" "F.S. Enforcer"
@@ -1947,7 +1949,8 @@ mission "FW Defend New Tibet"
 				"Manta (Mark II)" 3
 				"Quicksilver (Mark II)" 5
 	npc
-		personality heroic disables
+		government "Free Worlds"
+		personality heroic escort disables
 		ship "Dreadnought" "F.S. Holly"
 		ship "Falcon (Plasma)" "F.S. Nebula"
 		ship "Skein" "F.S. Larkspur"
@@ -2069,7 +2072,8 @@ mission "FW Liberate Delta Sagittarii"
 		event "fwc southern liberation"
 	
 	npc
-		personality heroic
+		government "Free Worlds"
+		personality heroic escort
 		fleet
 			names "free worlds capital"
 			variant

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -601,6 +601,7 @@ mission "FW Embassy 1C"
 				accept
 	
 	npc accompany save
+		government "Free Worlds"
 		personality escort heroic
 		ship "Dreadnought" "F.S. Gibraltar"
 	
@@ -1528,6 +1529,7 @@ mission "FW Pug 3B"
 				accept
 	
 	npc accompany save
+		government "Free Worlds"
 		personality escort disables
 		ship "Dreadnought" "F.S. Independence"
 		ship "Dreadnought" "F.S. Freedom"
@@ -1570,6 +1572,7 @@ mission "FW Pug 3C"
 				accept
 	
 	npc accompany save
+		government "Free Worlds"
 		personality escort
 		ship "Dreadnought" "F.S. Independence"
 		ship "Dreadnought" "F.S. Freedom"
@@ -1597,6 +1600,7 @@ mission "FW Pug 4: Escorts"
 		has "FW Pug 6: done"
 	
 	npc kill
+		government "Free Worlds"
 		personality escort heroic disables
 		ship "Dreadnought (Jump)" "F.S. Independence"
 		ship "Dreadnought (Jump)" "F.S. Freedom"

--- a/data/free worlds side plots.txt
+++ b/data/free worlds side plots.txt
@@ -516,6 +516,8 @@ mission "FW Stack Core 1B"
 				accept
 	
 	npc accompany save
+		government "Free Worlds"
+		personality escort disables
 		fleet
 			names "civilian"
 			cargo 3

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -179,7 +179,7 @@ void BoardingPanel::Draw()
 			Round(defenseOdds.DefenderPower(crew)));
 	}
 	int vCrew = victim ? victim->Crew() : 0;
-	if(victim && (victim->IsCapturable() || victim->GetGovernment()->IsPlayer()))
+	if(victim && (victim->IsCapturable() || victim->IsYours()))
 	{
 		info.SetString("enemy crew", to_string(vCrew));
 		info.SetString("enemy attack",
@@ -187,7 +187,7 @@ void BoardingPanel::Draw()
 		info.SetString("enemy defense",
 			Round(attackOdds.DefenderPower(vCrew)));
 	}
-	if(victim && victim->IsCapturable() && !victim->GetGovernment()->IsPlayer())
+	if(victim && victim->IsCapturable() && !victim->IsYours())
 	{
 		// If you haven't initiated capture yet, show the self destruct odds in
 		// the attack odds. It's illogical for you to have access to that info,
@@ -465,9 +465,9 @@ bool BoardingPanel::CanExit() const
 bool BoardingPanel::CanTake() const
 {
 	// If you ship or the other ship has been captured:
-	if(!you->GetGovernment()->IsPlayer())
+	if(!you->IsYours())
 		return false;
-	if(victim->GetGovernment()->IsPlayer())
+	if(victim->IsYours())
 		return false;
 	if(isCapturing || playerDied)
 		return false;
@@ -487,9 +487,9 @@ bool BoardingPanel::CanCapture() const
 		return false;
 	
 	// If your ship or the other ship has been captured:
-	if(!you->GetGovernment()->IsPlayer())
+	if(!you->IsYours())
 		return false;
-	if(victim->GetGovernment()->IsPlayer())
+	if(victim->IsYours())
 		return false;
 	if(!victim->IsCapturable())
 		return false;

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -377,7 +377,6 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			{
 				messages.push_back("You have been killed. Your ship is lost.");
 				you->WasCaptured(victim);
-				you->SetIsYours(false);
 				playerDied = true;
 				isCapturing = false;
 			}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -950,7 +950,7 @@ void PlayerInfo::Land(UI *ui)
 	vector<shared_ptr<Ship>>::iterator it = ships.begin();
 	while(it != ships.end())
 	{
-		if(!*it || (*it)->IsDestroyed() || !(*it)->GetGovernment()->IsPlayer())
+		if((*it)->IsDestroyed() || !(*it)->IsYours())
 		{
 			// If any of your ships are destroyed, your cargo "cost basis" should
 			// be adjusted based on what you lost.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1175,7 +1175,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	else if(requiredCrew && static_cast<int>(Random::Int(requiredCrew)) >= Crew())
 	{
 		pilotError = 30;
-		if(parent.lock() || !government->IsPlayer())
+		if(parent.lock() || !isYours)
 			Messages::Add(name + " is moving erratically because there are not enough crew to pilot it.");
 		else
 			Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it.");
@@ -1336,7 +1336,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 					// Allow the player to get all the way to the end of the
 					// boarding sequence (including locking on to the ship) but
 					// not to actually board, if they are cloaked.
-					if(government->IsPlayer())
+					if(isYours)
 						Messages::Add("You cannot board a ship while cloaked.");
 				}
 				else
@@ -1683,29 +1683,28 @@ int Ship::Scan()
 	}
 	
 	// Play the scanning sound if the actor or the target is the player's ship.
-	if(government->IsPlayer() || (target->GetGovernment()->IsPlayer() && activeScanning))
+	if(isYours || (target->isYours && activeScanning))
 		Audio::Play(Audio::Get("scan"), Position());
 	
-	if(startedScanning && government->IsPlayer())
+	if(startedScanning && isYours)
 	{
 		if(!target->Name().empty())
 			Messages::Add("Attempting to scan the " + target->Noun() + " \"" + target->Name() + "\".", false);
 		else
 			Messages::Add("Attempting to scan the selected " + target->Noun() + ".", false);
 	}
-	else if(startedScanning && target->GetGovernment()->IsPlayer())
+	else if(startedScanning && target->isYours)
 		Messages::Add("The " + government->GetName() + " " + Noun() + " \""
 			+ Name() + "\" is attempting to scan you.", false);
 	
-	if(target->GetGovernment()->IsPlayer() && !government->IsPlayer() && (result & ShipEvent::SCAN_CARGO))
+	if(target->isYours && !isYours)
 	{
-		Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-			+ Name() + "\" completed its scan of your cargo.");
-	}
-	if(target->GetGovernment()->IsPlayer() && !government->IsPlayer() && (result & ShipEvent::SCAN_OUTFITS))
-	{
-		Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-			+ Name() + "\" completed its scan of your outfits.");
+		if(result & ShipEvent::SCAN_CARGO)
+			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
+					+ Name() + "\" completed its scan of your cargo.");
+		if(result & ShipEvent::SCAN_OUTFITS)
+			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
+					+ Name() + "\" completed its scan of your outfits.");
 	}
 	
 	return result;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2067,8 +2067,9 @@ double Ship::TransferFuel(double amount, Ship *to)
 
 void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 {
-	// Repair up to the point where it is just barely not disabled.
+	// Repair up to the point where this ship is just barely not disabled.
 	hull = max(hull, MinimumHull());
+	isDisabled = false;
 	
 	// Set the new government.
 	government = capturer->GetGovernment();
@@ -2085,18 +2086,22 @@ void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 		AddCrew(transfer);
 	}
 	
+	commands.Clear();
 	// Set the capturer as this ship's parent.
 	SetParent(capturer);
+	// Clear this ship's previous targets.
 	SetTargetShip(shared_ptr<Ship>());
 	SetTargetStellar(nullptr);
 	SetTargetSystem(nullptr);
 	shipToAssist.reset();
-	commands.Clear();
-	isDisabled = false;
+	targetAsteroid.reset();
+	targetFlotsam.reset();
 	hyperspaceSystem = nullptr;
 	landingPlanet = nullptr;
 	
+	// This ship behaves like its new parent does.
 	isSpecial = capturer->isSpecial;
+	isYours = capturer->isYours;
 	personality = capturer->personality;
 	
 	// Fighters should flee a disabled ship, but if the player manages to capture
@@ -2111,6 +2116,8 @@ void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 		if(escort)
 			escort->parent.reset();
 	}
+	// This ship should not care about its now-unallied escorts.
+	escorts.clear();
 }
 
 


### PR DESCRIPTION
 - Swaps to using the less-complex yet still-correct check `Ship::IsYours()` rather than `Ship::GetGovernment()->IsPlayer()`
 - Every mission NPC declares its government
 - Swapped a number of unspecified (i.e. Player government) NPCs to using the more-appropriate Free Worlds government