### PR TITLE
Freshly-instantiated, uninterested NPC flagships should have no parent

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -294,6 +294,8 @@ void Engine::Place()
 					ship->SetParent(npcFlagship);
 				else if(!ship->GetPersonality().IsUninterested())
 					ship->SetParent(flagship);
+				else
+					ship->SetParent(nullptr);
 			}
 		}
 	


### PR DESCRIPTION
For missions which are generated when the player lands, if more than one ship is in an NPC block with `personality uninterested`, multiple NPC flagships would be assigned

1) Since Fleet::Place and Fleet::Enter perform NPC flagship assignments
2) Since Engine::EnterSystem also performs NPC flagship assignments (but exclusively for mission NPCs)

During instantiation, the Fleet method is called, and while the NPC flagship chosen here is the first ship in the group, the ships are added to the **front** of the NPC's ship list. Upon launching after accepting the mission, the mission ships are then placed again, starting with the **front** of the NPC ship list (and this ship will become the NPC flagship).

I opted for this change, rather than altering the `push_front` in Fleet::Enter and Fleet::Place to become `push_back`, as making that change could require re-inspecting every mission NPC fleet in the game to ensure the proper ship is chosen as the NPC flagship.