### PR TITLE
Support launch effects for carried ships when departing from their carrier

### DIFF
--- a/data/effects.txt
+++ b/data/effects.txt
@@ -143,6 +143,19 @@ effect "final explosion large"
 	sound "final explosion large"
 
 
+
+effect "basic launch"
+	sprite "effect/smoke"
+		"no repeat"
+		"random start frame"
+		"frame rate" 8
+	"lifetime" 30
+	"random angle" 15
+	"random spin" 360
+	"random velocity" 3
+
+
+
 effect "smoke"
 	sprite "effect/smoke"
 		"no repeat"

--- a/source/Effect.h
+++ b/source/Effect.h
@@ -13,9 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef EFFECT_H_
 #define EFFECT_H_
 
-#include "Angle.h"
 #include "Body.h"
-#include "Point.h"
 
 #include <string>
 
@@ -25,7 +23,7 @@ class Sound;
 
 
 // Class representing the template for a visual effect such as an explosion,
-// which is drawn for effect but  has no impact on any other objects in the
+// which is drawn for effect but has no impact on any other objects in the
 // game. Because this class is more heavyweight than it needs to be, actual
 // visual effects when they are placed use the Visual class, based on the
 // template provided by an Effect.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1394,7 +1394,7 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 		return;
 	
 	// Launch fighters.
-	ship->Launch(newShips);
+	ship->Launch(newShips, newVisuals);
 	
 	// Fire weapons. If this returns true the ship has at least one anti-missile
 	// system ready to fire.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -210,15 +210,29 @@ void Ship::Load(const DataNode &node)
 				hasBays = true;
 			}
 			bays.emplace_back(child.Value(1), child.Value(2), key == "fighter");
+			Bay &bay = bays.back();
 			for(int i = 3; i < child.Size(); ++i)
 			{
 				for(unsigned j = 1; j < BAY_SIDE.size(); ++j)
 					if(child.Token(i) == BAY_SIDE[j])
-						bays.back().side = j;
+						bay.side = j;
 				for(unsigned j = 1; j < BAY_FACING.size(); ++j)
 					if(child.Token(i) == BAY_FACING[j])
-						bays.back().facing = j;
+						bay.facing = j;
 			}
+			if(child.HasChildren())
+				for(const DataNode &grand : child)
+				{
+					// Load in the effect(s) to be displayed when the ship launches.
+					if(grand.Token(0) == "launch effect" && grand.Size() >= 2)
+					{
+						int count = grand.Size() >= 3 ? static_cast<int>(grand.Value(2)) : 1;
+						const Effect *e = GameData::Effects().Get(grand.Token(1));
+						bay.launchEffects.insert(bay.launchEffects.end(), count, e);
+					}
+					else
+						grand.PrintTrace("Child nodes of \"bay\" tokens can only be \"launch effect\":");
+				}
 		}
 		else if(key == "leak" && child.Size() >= 2)
 		{
@@ -603,6 +617,15 @@ void Ship::Save(DataWriter &out) const
 				out.Write(BAY_TYPE[bay.isFighter], x, y, BAY_FACING[bay.facing]);
 			else
 				out.Write(BAY_TYPE[bay.isFighter], x, y);
+			if(!bay.launchEffects.empty())
+			{
+				out.BeginChild();
+				{
+					for(const Effect *effect : bay.launchEffects)
+						out.Write("launch effect", effect->Name());
+				}
+				out.EndChild();
+			}
 		}
 		for(const Leak &leak : leaks)
 			out.Write("leak", leak.effect->Name(), leak.openPeriod, leak.closePeriod);
@@ -1620,7 +1643,7 @@ void Ship::DoGeneration()
 
 
 // Launch any ships that are ready to launch.
-void Ship::Launch(list<shared_ptr<Ship>> &ships)
+void Ship::Launch(list<shared_ptr<Ship>> &ships, vector<Visual> &visuals)
 {
 	// Allow fighters to launch from a disabled ship, but not from a ship that
 	// is landing, jumping, or cloaked.
@@ -1634,12 +1657,16 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 			double maxV = bay.ship->MaxVelocity();
 			Angle launchAngle = angle + BAY_ANGLE[bay.facing];
 			Point v = velocity + (.3 * maxV) * launchAngle.Unit() + (.2 * maxV) * Angle::Random().Unit();
-			bay.ship->Place(position + angle.Rotate(bay.point), v, launchAngle);
+			Point exitPoint = position + angle.Rotate(bay.point);
+			bay.ship->Place(exitPoint, v, launchAngle);
 			bay.ship->SetSystem(currentSystem);
 			bay.ship->SetParent(shared_from_this());
 			bay.ship->UnmarkForRemoval();
 			// Update the cached sum of carried ship masses.
 			carriedMass -= bay.ship->Mass();
+			// Create the desired launch effects.
+			for(const Effect *effect : bay.launchEffects)
+				visuals.emplace_back(*effect, exitPoint, velocity, launchAngle);
 			
 			bay.ship.reset();
 		}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -520,6 +520,11 @@ void Ship::FinishLoading(bool isNewInstance)
 	if(isNewInstance)
 		Recharge(true);
 	
+	// Add a default "launch effect" to any internal bays if this ship is crewed (i.e. pressurized).
+	for(Bay &bay : bays)
+		if(bay.side == Bay::INSIDE && bay.launchEffects.empty() && Crew())
+			bay.launchEffects.emplace_back(GameData::Effects().Get("basic launch"));
+	
 	// Figure out if this ship can be carried.
 	const string &category = attributes.Category();
 	canBeCarried = (category == "Fighter" || category == "Drone");

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -31,6 +31,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 class DataNode;
 class DataWriter;
+class Effect;
 class Flotsam;
 class Government;
 class Minable;
@@ -58,7 +59,7 @@ public:
 	public:
 		Bay(double x, double y, bool isFighter) : point(x * .5, y * .5), isFighter(isFighter) {}
 		// Copying a bay does not copy the ship inside it.
-		Bay(const Bay &b) : point(b.point), isFighter(b.isFighter), side(b.side), facing(b.facing) {}
+		Bay(const Bay &b) : point(b.point), isFighter(b.isFighter), side(b.side), facing(b.facing), launchEffects(b.launchEffects) {}
 		
 		Point point;
 		std::shared_ptr<Ship> ship;
@@ -74,6 +75,9 @@ public:
 		static const uint8_t LEFT = 1;
 		static const uint8_t RIGHT = 2;
 		static const uint8_t BACK = 3;
+		
+		// The launch effect(s) to be simultaneously played when the bay's ship launches.
+		std::vector<const Effect *> launchEffects;
 	};
 	
 	class EnginePoint : public Point {
@@ -168,7 +172,7 @@ public:
 	// Generate energy, heat, etc. (This is called by Move().)
 	void DoGeneration();
 	// Launch any ships that are ready to launch.
-	void Launch(std::list<std::shared_ptr<Ship>> &ships);
+	void Launch(std::list<std::shared_ptr<Ship>> &ships, std::vector<Visual> &visuals);
 	// Check if this ship is boarding another ship. If it is, it either plunders
 	// it or, if this is a player ship, returns the ship it is plundering so a
 	// plunder dialog can be displayed.


### PR DESCRIPTION
Refs #944

Until #957 is supported, supporting "retrieve effect" doesn't make much sense, since the effect location will be in a different place than the carried ship "gets absorbed" by the carrier. With #957 supported, adding support for a "retrieve effect" won't be difficult.

Example bay definition:
```
drone -66 24 over left
    "launch effect" "external launch"
```

Caveat: effects for an "under" bay will be drawn on top of the ship. I don't think this part is easily addressed.

I've also defined a "basic launch" effect that any non-automaton ship will use for internal bays (that do not define their own launch effects), to prevent needing to go through every existing ship definition and add it explicitly.
[Basic launch](https://youtu.be/IQVC30iEi78)
(I'm sure this effect could be greatly improved by an artist :grin: )