### PR TITLE
Add a "launching" personality, to complement "waiting"

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -324,10 +324,11 @@ void Engine::Place()
 		bool isHere = (ship->GetSystem() == player.GetSystem());
 		if(isHere)
 			pos = planetPos;
-		// Check whether this ship should take off with you.
-		if(isHere && !ship->IsDisabled()
-				&& (player.GetPlanet()->CanLand(*ship) || ship->IsYours())
-				&& !(ship->GetPersonality().IsStaying() || ship->GetPersonality().IsWaiting()))
+		// Check whether this ship should take off with you. "Launching" ships can always take
+		// off, otherwise they must be able to land and also not be flagged to stay in space.
+		if(isHere && !ship->IsDisabled() && (ship->GetPersonality().IsLaunching()
+				|| ((player.GetPlanet()->CanLand(*ship) || ship->IsYours())
+				&& !(ship->GetPersonality().IsStaying() || ship->GetPersonality().IsWaiting()))))
 		{
 			if(player.GetPlanet())
 				ship->SetPlanet(player.GetPlanet());

--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -48,6 +48,7 @@ namespace {
 	const int OPPORTUNISTIC = (1 << 24);
 	const int TARGET = (1 << 25);
 	const int MARKED = (1 << 26);
+	const int LAUNCHING = (1 << 27);
 	
 	const map<string, int> TOKEN = {
 		{"pacifist", PACIFIST},
@@ -76,7 +77,8 @@ namespace {
 		{"mute", MUTE},
 		{"opportunistic", OPPORTUNISTIC},
 		{"target", TARGET},
-		{"marked", MARKED}
+		{"marked", MARKED},
+		{"launching", LAUNCHING}
 	};
 	
 	const double DEFAULT_CONFUSION = 10.;
@@ -245,6 +247,13 @@ bool Personality::IsEntering() const
 bool Personality::IsWaiting() const
 {
 	return flags & WAITING;
+}
+
+
+
+bool Personality::IsLaunching() const
+{
+	return flags & LAUNCHING;
 }
 
 

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -53,6 +53,7 @@ public:
 	bool IsStaying() const;
 	bool IsEntering() const;
 	bool IsWaiting() const;
+	bool IsLaunching() const;
 	bool IsFleeing() const;
 	bool IsDerelict() const;
 	bool IsUninterested() const;


### PR DESCRIPTION
Refs #1567

 - Mission NPCs with the "launching" personality will always take off with the player, even if their government (or other attributes) would normally prevent them from landing.