### PR TITLE
Improve likelihood that "plunders" fleets can plunder

### DIFF
--- a/data/hai.txt
+++ b/data/hai.txt
@@ -107,7 +107,7 @@ fleet "Large Hai"
 fleet "Small Unfettered"
 	government "Hai (Unfettered)"
 	names "hai"
-	cargo 3
+	cargo 1
 	personality
 		disables
 		plunders
@@ -123,7 +123,7 @@ fleet "Small Unfettered"
 fleet "Large Unfettered"
 	government "Hai (Unfettered)"
 	names "hai"
-	cargo 3
+	cargo 1
 	personality
 		disables
 		plunders
@@ -169,6 +169,7 @@ fleet "Large Unfettered"
 fleet "Unfettered Raid"
 	government "Hai (Unfettered)"
 	names "hai"
+	cargo 1
 	personality
 		disables
 		plunders

--- a/data/korath.txt
+++ b/data/korath.txt
@@ -194,9 +194,9 @@ fleet "Korath Raid"
 	government "Korath"
 	names "korath"
 	fighters "korath"
-	cargo 3
+	cargo 1
 	personality
-		disables plunders opportunistic
+		disables plunders opportunistic harvests
 	variant
 		"Korath Raider"
 		"Korath Chaser" 2

--- a/data/remnant.txt
+++ b/data/remnant.txt
@@ -11,6 +11,7 @@
 fleet "Small Remnant"
 	government "Remnant"
 	names "remnant"
+	cargo 2
 	personality
 		heroic disables plunders appeasing
 	variant 8
@@ -37,6 +38,7 @@ fleet "Small Remnant"
 fleet "Large Remnant"
 	government "Remnant"
 	names "remnant"
+	cargo 2
 	personality
 		heroic disables plunders appeasing
 	variant 6


### PR DESCRIPTION
 - Default fleet cargo tries is 3, which results in mostly-filled cargo holds (and therefore an inability to plunder)
 - Added `harvests` to the Korath Raid fleet so that it will care about the jettisoned cargo from injured Remnant and Merchant fleets