### PR TITLE
Always put a digit to left of the decimal separator.

### DIFF
--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -74,7 +74,7 @@ string Format::Number(double value)
 	if(left > 3)
 		delimiterIndex = left - 3;
 	
-	while(rounded || right)
+	do
 	{
 		int digit = rounded % 10;
 		if(nonzero || digit)
@@ -90,7 +90,11 @@ string Format::Number(double value)
 			if(!right)
 			{
 				if(nonzero)
+				{
 					result += '.';
+					if(!rounded)
+						result += '0';
+				}
 				nonzero = true;
 			}
 		}
@@ -101,6 +105,7 @@ string Format::Number(double value)
 				result += ',';
 		}
 	}
+	while(rounded || right);
 	
 	// Add the negative sign if needed.
 	if(isNegative)

--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -74,8 +74,7 @@ string Format::Number(double value)
 	if(left > 3)
 		delimiterIndex = left - 3;
 	
-	do
-	{
+	do {
 		int digit = rounded % 10;
 		if(nonzero || digit)
 		{
@@ -104,8 +103,7 @@ string Format::Number(double value)
 			if(left == delimiterIndex && rounded)
 				result += ',';
 		}
-	}
-	while(rounded || right);
+	} while(rounded || right);
 	
 	// Add the negative sign if needed.
 	if(isNegative)


### PR DESCRIPTION
Show 0.7 instead of .7.
Natural languages always have at least 1 digit to the left
of the decimal separator; unlike some computer languages like C/C++.
Fix issue #3611