### PR TITLE
Make AppStream file use valid XML, pass `appstreamcli validate`, and add screenshots

### DIFF
--- a/endless-sky.appdata.xml
+++ b/endless-sky.appdata.xml
@@ -26,16 +26,16 @@
     <screenshot type="default">
       <image>https://endless-sky.github.io/images/screenshots/battle.jpg</image>
     </screenshot>
-	<screenshot>
+    <screenshot>
       <image>https://endless-sky.github.io/screenshots/beams.jpg</image>
     </screenshot>
-	<screenshot>
+    <screenshot>
       <image>https://camo.githubusercontent.com/647979e73d2121a1a982a96b0561e0e435598fd4/68747470733a2f2f656e646c6573732d736b792e6769746875622e696f2f73637265656e73686f74732f736d616c6c382e6a7067</image>
     </screenshot>
     <screenshot>
       <image>https://endless-sky.github.io/images/screenshots/outfitter.jpg</image>
     </screenshot>
-	<screenshot>
+    <screenshot>
       <image>https://endless-sky.github.io/images/screenshots/shipyard.jpg</image>
     </screenshot>
   </screenshots>

--- a/endless-sky.appdata.xml
+++ b/endless-sky.appdata.xml
@@ -9,7 +9,7 @@
   <summary xml:lang="de">Weltraumhandels und Kampfsimulator</summary>
   <summary xml:lang="fr">Jeu d'exploration et de combat dans l'espace</summary>
   <developer_name>Michael Zahniser</developer_name>
-  <license>GPL-3.0 and CC-BY-SA-4.0 and CC-BY-SA-3.0 and CC-BY-3.0</license>
+  <project_license>GPL-3.0 AND CC-BY-SA-4.0 AND CC-BY-SA-3.0 AND CC-BY-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <description>
   <p>
@@ -24,13 +24,19 @@
   <url type="homepage">https://endless-sky.github.io/</url>
   <screenshots>
     <screenshot type="default">
-      <image>https://endless-sky.github.io/screenshots/fight.jpg</image>
+      <image>https://endless-sky.github.io/images/screenshots/battle.jpg</image>
     </screenshot>
-    <screenshot>
-      <image>https://endless-sky.github.io/screenshots/hyperspace.jpg</image>
-    </screenshot>
-    <screenshot>
+	<screenshot>
       <image>https://endless-sky.github.io/screenshots/beams.jpg</image>
+    </screenshot>
+	<screenshot>
+      <image>https://camo.githubusercontent.com/647979e73d2121a1a982a96b0561e0e435598fd4/68747470733a2f2f656e646c6573732d736b792e6769746875622e696f2f73637265656e73686f74732f736d616c6c382e6a7067</image>
+    </screenshot>
+    <screenshot>
+      <image>https://endless-sky.github.io/images/screenshots/outfitter.jpg</image>
+    </screenshot>
+	<screenshot>
+      <image>https://endless-sky.github.io/images/screenshots/shipyard.jpg</image>
     </screenshot>
   </screenshots>
   <releases>
@@ -51,7 +57,7 @@
             <li>Fixed a crash that could occur when your flagship is captured.</li>
             <li>Daily weapon reloads (e.g. when you jump) no longer reset turret angles.</li>
             <li>Fixed the messages list not resetting if creating a new pilot from the main menu.</li>
-        <ul>
+        </ul>
         <p>Game content:</p>
         <ul>
             <li>Fixed a Remnant mission that could be offered on non-Remnant worlds. (@tehhowch)</li>
@@ -80,7 +86,7 @@
             <li>Enemies will no longer hang out just waiting for a player who is beyond the "invisible fence."</li>
             <li>Missions can now specify a random range of time delays for events.</li>
             <li>If your ship has no forward-facing guns, auto-aim will no longer activate.</li>
-            <li>The <payment> substitution in missions now shows payment for that action clause, if any.</li>
+            <li>The &lt;payment&gt; substitution in missions now shows payment for that action clause, if any.</li>
             <li>Once a "derelict" NPC has been boarded, it can now repair when landing like an ordinary ship.</li>
         </ul>
         <p>User interface:</p>


### PR DESCRIPTION
This change makes the AppStream file pass both XML and AppStream validation (`appstreamcli validate <file>`).

Also, I added some more screenshots. Regarding screenshots, it would be fantastic if you could provide the following:
- A larger, 16:9 widescreen version of https://endless-sky.github.io/screenshots/beams.jpg or something like it
- A larger, 16:9 widescreen version of https://camo.githubusercontent.com/647979e73d2121a1a982a96b0561e0e435598fd4/68747470733a2f2f656e646c6573732d736b792e6769746875622e696f2f73637265656e73686f74732f736d616c6c382e6a7067 or something like it, and display it at https://endless-sky.github.io/screenshots.html

The better Endless Sky's AppStream metadata is, the more I can advertise Endless Sky as a good example when I blog about [KDE Discover](https://userbase.kde.org/Discover), KDE's software center that I help develop. E.g https://pointieststick.wordpress.com/2018/01/23/discover-makes-your-app-look-gooooood/ Check out the screenshots close to the bottom of the post. :)

These kinds of changes will also help Endless Sky look better in other Software Centers too, like GNOME Software and ElementaryOS's AppCenter.