### PR TITLE
Update erase usage

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -95,9 +95,8 @@ void Fleet::Load(const DataNode &node)
 		{
 			// If given a full ship definition of one of this fleet's variant members, remove the variant.
 			bool didRemove = false;
+			Variant toRemove(child);
 			for(auto it = variants.begin(); it != variants.end(); ++it)
-			{
-				Variant toRemove = Variant(child);
 				if(toRemove.ships.size() == it->ships.size() &&
 					is_permutation(it->ships.begin(), it->ships.end(), toRemove.ships.begin()))
 				{
@@ -106,7 +105,7 @@ void Fleet::Load(const DataNode &node)
 					didRemove = true;
 					break;
 				}
-			}
+			
 			if(!didRemove)
 				child.PrintTrace("Did not find matching variant for specified operation:");
 		}

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -815,11 +815,9 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 	{
 		const System *system = event.Actor()->GetSystem();
 		// If this was a waypoint, clear it.
-		if(waypoints.count(system))
-		{
-			waypoints.erase(system);
+		if(waypoints.erase(system))
 			visitedWaypoints.insert(system);
-		}
+		
 		// Perform an "on enter" action for this system, if possible.
 		Enter(system, player, ui);
 	}
@@ -865,11 +863,8 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 		result.waypoints.insert(system);
 	}
 	// If one of the waypoints is the current system, it is already visited.
-	if(result.waypoints.count(source))
-	{
-		result.waypoints.erase(source);
+	if(result.waypoints.erase(source));
 		result.visitedWaypoints.insert(source);
-	}
 	
 	// Copy the stopover planet list, and populate the list based on the filters
 	// that were given.

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -369,25 +369,15 @@ void System::Link(System *other)
 
 void System::Unlink(System *other)
 {
-	auto it = find(links.begin(), links.end(), other);
-	if(it != links.end())
-		links.erase(it);
-	
-	it = find(other->links.begin(), other->links.end(), this);
-	if(it != other->links.end())
-		other->links.erase(it);
+	links.erase(other);
+	other->links.erase(this);
 	
 	// If the only reason these systems are neighbors is because of a hyperspace
 	// link, they are no longer neighbors.
 	if(position.Distance(other->position) > NEIGHBOR_DISTANCE)
 	{
-		it = find(neighbors.begin(), neighbors.end(), other);
-		if(it != neighbors.end())
-			neighbors.erase(it);
-		
-		it = find(other->neighbors.begin(), other->neighbors.end(), this);
-		if(it != other->neighbors.end())
-			other->neighbors.erase(it);
+		neighbors.erase(other);
+		other->neighbors.erase(this);
 	}
 }
 


### PR DESCRIPTION
 - Variant toRemove only needs to be initialized once
 - set.erase first performs a count, and erase(<key>) returns 1 if <key> was erased
 - System.links & System.neighbor used to be vectors, but were made sets in 4fa19f67a4f4e559f08b769bf7596ff52005eff2, and set supports erase(<key>)