### PR TITLE
Set Deneb government to "None" when Pug leave

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -1956,7 +1956,7 @@ event "pug territory liberated"
 	system Caph
 		government Syndicate
 	system Deneb
-		government Uninhabited
+		government None
 		fleet "Small Core Merchants" 400
 		fleet "Large Core Merchants" 600
 		fleet "Small Northern Merchants" 1000
@@ -2523,7 +2523,7 @@ event "fwc pug defeated"
 	system Alderamin
 		government Syndicate
 	system Deneb
-		government Uninhabited
+		government None
 		fleet "Small Core Merchants" 400
 		fleet "Large Core Merchants" 600
 		fleet "Small Northern Merchants" 1000

--- a/data/events.txt
+++ b/data/events.txt
@@ -1956,7 +1956,7 @@ event "pug territory liberated"
 	system Caph
 		government Syndicate
 	system Deneb
-		government Neutral
+		government Uninhabited
 		fleet "Small Core Merchants" 400
 		fleet "Large Core Merchants" 600
 		fleet "Small Northern Merchants" 1000
@@ -1965,6 +1965,10 @@ event "pug territory liberated"
 		fleet "Large Republic" 900 
 		fleet "Small Syndicate" 1200
 		fleet "Large Syndicate" 2000
+	planet "Pugglemug"
+		"required reputation" 0
+	planet "Pugglequat"
+		"required reputation" 0
 	planet "Rand"
 		security 0.05
 	planet "Oblivion"
@@ -2519,7 +2523,7 @@ event "fwc pug defeated"
 	system Alderamin
 		government Syndicate
 	system Deneb
-		government Neutral
+		government Uninhabited
 		fleet "Small Core Merchants" 400
 		fleet "Large Core Merchants" 600
 		fleet "Small Northern Merchants" 1000
@@ -2530,6 +2534,10 @@ event "fwc pug defeated"
 		fleet "Large Syndicate" 2000
 	system Nocte
 		government Republic
+	planet "Pugglemug"
+		"required reputation" 0
+	planet "Pugglequat"
+		"required reputation" 0
 	planet "Rand"
 		security 0.05
 	planet "Oblivion"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -272,6 +272,9 @@ government "Pirate"
 	"hostile hail" "hostile pirate"
 	raid "pirate raid"
 
+government "None"
+	color .6 .6 .6
+
 government "Pug"
 	swizzle 0
 	color .99 .89 .70


### PR DESCRIPTION
When the Pug flee or are defeated in the Free Worlds campaign, Deneb joins Tarazed's Neutral government. This is problematic:
* gameplay: if you demand(ed) tribute from any or all Neutral (i.e. Tarazed) planets, you can no longer land in Deneb
* lore: no <s>humans live</s> human government controls Pugglemug or Pugglequat

<s>This patch changes the government to "Uninhabited" instead (cf. Kor Sestor planets), thus always allowing any player to land in Deneb.</s>
This patch assigns Deneb to a newly introduced "None" government, which is unrelated to other governments and unaffected by reputations. 