### PR TITLE
Support multiple fleet types in planet tributes

### DIFF
--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -364,7 +364,7 @@ void Personality::UpdateConfusion(bool isFiring)
 Personality Personality::Defender()
 {
 	Personality defender;
-	defender.flags = STAYING | NEMESIS | HEROIC;
+	defender.flags = STAYING | MARKED | HEROIC | UNCONSTRAINED | TARGET;
 	return defender;
 }
 

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -164,17 +164,31 @@ void Planet::Load(const DataNode &node, const Set<Sale<Ship>> &ships, const Set<
 		else if(key == "tribute")
 		{
 			tribute = child.Value(valueIndex);
+			bool resetFleets = !defenseFleets.empty();
 			for(const DataNode &grand : child)
 			{
 				if(grand.Token(0) == "threshold" && grand.Size() >= 2)
 					defenseThreshold = grand.Value(1);
-				else if(grand.Token(0) == "fleet" && grand.Size() >= 3)
+				else if(grand.Token(0) == "fleet")
 				{
-					defenseCount = (grand.Size() >= 3 ? grand.Value(2) : 1);
-					defenseFleet = GameData::Fleets().Get(grand.Token(1));
+					if(grand.Size() >= 2 && !grand.HasChildren())
+					{
+						// Allow only one "tribute" node to define the tribute fleets.
+						if(resetFleets)
+						{
+							defenseFleets.clear();
+							resetFleets = false;
+						}
+						defenseFleets.insert(defenseFleets.end(),
+								grand.Size() >= 3 ? grand.Value(2) : 1,
+								GameData::Fleets().Get(grand.Token(1))
+						);
+					}
+					else
+						grand.PrintTrace("Skipping unsupported tribute fleet definition:");
 				}
 				else
-					grand.PrintTrace("Skipping unrecognized attribute:");
+					grand.PrintTrace("Skipping unrecognized tribute attribute:");
 			}
 		}
 		else
@@ -191,7 +205,7 @@ void Planet::Load(const DataNode &node, const Set<Sale<Ship>> &ships, const Set<
 			attributes.erase(AUTO_ATTRIBUTES[i]);
 	}
 
-	inhabited = (HasSpaceport() || requiredReputation || defenseFleet) && !attributes.count("uninhabited");
+	inhabited = (HasSpaceport() || requiredReputation || !defenseFleets.empty()) && !attributes.count("uninhabited");
 }
 
 
@@ -502,22 +516,28 @@ string Planet::DemandTribute(PlayerInfo &player) const
 {
 	if(player.GetCondition("tribute: " + name))
 		return "We are already paying you as much as we can afford.";
-	if(!tribute || !defenseFleet || !defenseCount || player.GetCondition("combat rating") < defenseThreshold)
+	if(!tribute || defenseFleets.empty())
 		return "Please don't joke about that sort of thing.";
+	if(player.GetCondition("combat rating") < defenseThreshold)
+		return "You're not worthy of our time.";
 	
 	// The player is scary enough for this planet to take notice. Check whether
 	// this is the first demand for tribute, or not.
 	if(!isDefending)
 	{
 		isDefending = true;
-		GameData::GetPolitics().Offend(defenseFleet->GetGovernment(), ShipEvent::PROVOKE);
-		GameData::GetPolitics().Offend(GetGovernment(), ShipEvent::ATROCITY);
+		set<const Government *> toProvoke;
+		for(const auto &fleet : defenseFleets)
+			toProvoke.insert(fleet->GetGovernment());
+		for(const auto &gov : toProvoke)
+			gov->Offend(ShipEvent::PROVOKE);
+		// Terrorizing a planet is not taken lightly by it or its allies.
+		GetGovernment()->Offend(ShipEvent::ATROCITY);
 		return "Our defense fleet will make short work of you.";
 	}
 	
-	// The player has already demanded tribute. Have they killed off the entire
-	// defense fleet?
-	bool isDefeated = (defenseDeployed == defenseCount);
+	// The player has already demanded tribute. Have they defeated the entire defense fleet?
+	bool isDefeated = (defenseDeployed == defenseFleets.size());
 	for(const shared_ptr<Ship> &ship : defenders)
 		if(!ship->IsDisabled() && !ship->IsYours())
 		{
@@ -535,17 +555,17 @@ string Planet::DemandTribute(PlayerInfo &player) const
 
 
 
+// While being tributed, attempt to spawn the next specified defense fleet.
 void Planet::DeployDefense(list<shared_ptr<Ship>> &ships) const
 {
-	if(!isDefending || Random::Int(60) || defenseDeployed == defenseCount)
+	if(!isDefending || Random::Int(60) || defenseDeployed == defenseFleets.size())
 		return;
 	
-	// Have another defense fleet take off from the planet.
 	auto end = defenders.begin();
-	defenseFleet->Enter(*GetSystem(), defenders, this);
+	defenseFleets[defenseDeployed]->Enter(*GetSystem(), defenders, this);
 	ships.insert(ships.begin(), defenders.begin(), end);
 	
-	// All defenders get a special personality.
+	// All defenders use a special personality.
 	Personality defenderPersonality = Personality::Defender();
 	for(auto it = defenders.begin(); it != end; ++it)
 		(**it).SetPersonality(defenderPersonality);

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -144,12 +144,16 @@ private:
 	double security = .25;
 	bool inhabited;
 	
+	// The salary to be paid if this planet is dominated.
 	int tribute = 0;
-	const Fleet *defenseFleet = nullptr;
-	int defenseCount = 0;
-	mutable int defenseDeployed = 0;
+	// The minimum combat rating needed to dominate this planet.
 	int defenseThreshold = 4000;
 	mutable bool isDefending = false;
+	// The defense fleets that should be spawned (in order of specification).
+	std::vector<const Fleet *> defenseFleets;
+	// How many fleets have been spawned, and the index of the next to be spawned.
+	mutable size_t defenseDeployed = 0;
+	// Ships that have been created by instantiating its defense fleets.
 	mutable std::list<std::shared_ptr<Ship>> defenders;
 	
 	std::vector<const System *> systems;


### PR DESCRIPTION
Refs #2524 , #2318, 

 - Use an vector of stock fleet definitions to allow customized tribute battles
 - Increase difficulty of all tributes by changing the personality from `staying heroic nemesis` to `staying heroic marked unconstrained`
   - Tribute fleets will now only target the player's ships, and will be ignored by all other ships even if they would be "natural" enemies.
 - Increase visibility of tribute fleets in busy systems by applying the "target" personality
 - Correct a bug in the bounds check for tribute fleet definition
   - `fleet "Small Republic"` is currently skipped while `fleet "Small Republic" 1` is accepted. Both are valid and acceptable with this PR.
 - Print a warning if there is a custom fleet definition (i.e. child nodes to a node that starts with `fleet`)
 - If multiple mods alter a given planet's defense fleets, only the last modification is kept. This reproduces the behavior w.r.t. the tribute value / `master`, as only the last value is kept. If a mod only changes the amount / threshold, the standard fleet definition is kept.

With this PR, a tribute definition could then look like this:
```
planet "Gauntlet of Doom"
    tribute 1e6
        threshold 1e7
        fleet "Paradise Merchants" 2
        fleet "Navy Surveillance" 5
        fleet "Large Republic" 6
        fleet "Large Syndicate" 7
        fleet "Large Free Worlds" 8
        fleet "Large Pug" 9
        fleet "Large Quarg" 100
```
which would require the player to defeat fleets with the Merchant, Republic, Syndicate, Free Worlds, Pug, and Quarg governments (137 instantiated fleets in total in this example). These fleets would spawn in the order defined - first the Merchants, then the navy surveillance, then Republic, Syndicate, ... Quarg.