### PR TITLE
Harmony and New Tibet can pay tribute

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -25152,6 +25152,9 @@ planet Harmony
 	spaceport `The spaceport is on the outskirts of one of the larger cities, with a few medium-sized skyscrapers and many tall smokestacks for factories and oil refineries. The starship hangars here are shaped like oversized barns, and close to the hangars, grain is stored in silos. The spaceport police are on horseback.`
 	spaceport `	Inside the building at the center of the port is a large cafeteria, with food of the simple "meat and potatoes" variety. You notice a few children and teenagers in rough, homemade clothing staring out the windows at the ships taking off and landing.`
 	security 0
+	tribute 700
+		threshold 3000
+		fleet "Large Militia" 12
 
 planet Haven
 	attributes pirate mining "north pirate"
@@ -25984,6 +25987,9 @@ planet "New Tibet"
 	description `	In the lowlands, large farms support sprawling cities full of factories, a striking contrast to the simplicity and isolation of the mountain villages.`
 	spaceport `The spaceport is in a hilly region, just outside of the largest city, with a view of a valley full of farms that stretch for tens of kilometers, all the way down to the ocean. The port is much less modern than the city nearby; it was built by the early settlers and has not been significantly updated since then, because the focus has been on improving life for the locals, not for their occasional visitors.`
 	security 0.1
+	tribute 600
+		threshold 3000
+		fleet "Large Militia" 10
 
 planet "New Wales"
 	attributes "dirt belt" mining

--- a/data/map.txt
+++ b/data/map.txt
@@ -25152,9 +25152,9 @@ planet Harmony
 	spaceport `The spaceport is on the outskirts of one of the larger cities, with a few medium-sized skyscrapers and many tall smokestacks for factories and oil refineries. The starship hangars here are shaped like oversized barns, and close to the hangars, grain is stored in silos. The spaceport police are on horseback.`
 	spaceport `	Inside the building at the center of the port is a large cafeteria, with food of the simple "meat and potatoes" variety. You notice a few children and teenagers in rough, homemade clothing staring out the windows at the ships taking off and landing.`
 	security 0
-	tribute 700
-		threshold 3000
-		fleet "Large Militia" 12
+	tribute 400
+		threshold 2500
+		fleet "Small Militia" 30
 
 planet Haven
 	attributes pirate mining "north pirate"


### PR DESCRIPTION
Currently Harmony and New Tibet are the only two inhabited planets in human space unable to pay tribute. This patch assigns a tribute of 400 to Harmony, which has "millions of people", and a tribute of 600 to New Tibet, which has "sprawling cities"; both are given an appropiate large militia defence fleet, allowing a player who behaves as 'a galactic terrorist' to dominate and land here as well.

For comparison the tribute of a few nearby planets:

New Portland (200): "only a handful of towns"
Hopper (300): "only a few small settlements"
Sinter (400): "the population of the entire planet is only a few thousand people"
Lichen (500): "Planetary government, or indeed any government above the village level, is virtually nonexistent."
New Argentina (1000): "The spaceport is on the outskirts of one of New Argentina's largest towns... which has a population of barely ten thousand people."