### PR TITLE
Hyperspace code cleanup and minimum entry distances

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -322,11 +322,16 @@ void AI::Step(const PlayerInfo &player)
 			++it;
 	}
 	for(const auto &it : ships)
-		if(it->Position().Length() >= MAX_DISTANCE_FROM_CENTER)
+    {
+	    double border = 0;
+	    if(it->GetSystem())
+            border = it->GetSystem()->Border();
+		if(it->Position().Length() >= MAX_DISTANCE_FROM_CENTER+border)
 		{
 			int &value = fenceCount[&*it];
 			value = min(FENCE_MAX, value + FENCE_DECAY + 1);
 		}
+    }
 	
 	const Ship *flagship = player.Flagship();
 	step = (step + 1) & 31;
@@ -1097,7 +1102,7 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 	if(target && !ship.IsYours() && !ship.GetPersonality().IsUnconstrained())
 	{
 		Point extrapolated = target->Position() + 120. * (target->Velocity() - ship.Velocity());
-		if(extrapolated.Length() >= MAX_DISTANCE_FROM_CENTER)
+		if(extrapolated.Length() >= MAX_DISTANCE_FROM_CENTER+ship.GetSystem()->Border())
 		{
 			MoveTo(ship, command, Point(), Point(), 40., .8);
 			if(ship.Velocity().Dot(ship.Position()) > 0.)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -322,16 +322,16 @@ void AI::Step(const PlayerInfo &player)
 			++it;
 	}
 	for(const auto &it : ships)
-    {
-	    double border = 0;
-	    if(it->GetSystem())
-            border = it->GetSystem()->Border();
+	{
+		double border = 0;
+		if(it->GetSystem())
+			border = it->GetSystem()->Border();
 		if(it->Position().Length() >= MAX_DISTANCE_FROM_CENTER+border)
 		{
 			int &value = fenceCount[&*it];
 			value = min(FENCE_MAX, value + FENCE_DECAY + 1);
 		}
-    }
+	}
 	
 	const Ship *flagship = player.Flagship();
 	step = (step + 1) & 31;
@@ -2730,11 +2730,11 @@ double AI::RendezvousTime(const Point &p, const Point &v, double vp)
 	// to intersect the target?
 	// (p.x + v.x*t)^2 + (p.y + v.y*t)^2 = vp^2*t^2
 	// p.x^2 + 2*p.x*v.x*t + v.x^2*t^2
-	//    + p.y^2 + 2*p.y*v.y*t + v.y^2t^2
-	//    - vp^2*t^2 = 0
+	//	+ p.y^2 + 2*p.y*v.y*t + v.y^2t^2
+	//	- vp^2*t^2 = 0
 	// (v.x^2 + v.y^2 - vp^2) * t^2
-	//    + (2 * (p.x * v.x + p.y * v.y)) * t
-	//    + (p.x^2 + p.y^2) = 0
+	//	+ (2 * (p.x * v.x + p.y * v.y)) * t
+	//	+ (p.x^2 + p.y^2) = 0
 	double a = v.Dot(v) - vp * vp;
 	double b = 2. * p.Dot(v);
 	double c = p.Dot(p);

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -342,7 +342,7 @@ const System *Fleet::Enter(const System &system, Ship &ship, const System *sourc
 void Fleet::Place(const System &system, Ship &ship)
 {
 	// Move out a random distance from that object, facing toward it or away.
-	Point pos = ChooseCenter(system) + Angle::Random().Unit() * Random::Real() * 400.;
+	Point pos = ChooseCenter(system) + Angle::Random().Unit() * Random::Real() * system.Border();
 	
 	double velocity = Random::Real() * ship.MaxVelocity();
 	

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1271,7 +1271,7 @@ void Ship::IterateHyperspace(vector<Visual> &visuals)
 	acceleration = Point();
 	
 	// Initial segment
-	if (hyperCount == 0 && hyperspaceSystem)
+	if(hyperCount == 0 && hyperspaceSystem)
 	{
 		hyperSteps = 100;
 		hyperAcceleration = 2.;
@@ -1315,21 +1315,22 @@ void Ship::IterateHyperspace(vector<Visual> &visuals)
 	if(hyperspaceSystem)
 		fuel -= hyperspaceFuelCost / hyperSteps;
 	
-	if(GetParent() && GetParent()->currentSystem == currentSystem)
+	if(GetParent() && GetParent()->currentSystem == currentSystem && hyperspaceSystem)
 	{
 		hyperOffset = position+velocity - GetParent()->position; // Allows formation to be held through hyperspace
 		double length = hyperOffset.Length();
 		if(length > fleetRadius) // Condense fleet around leader
 		{
-			Point offsetFromDesired = hyperOffset-hyperOffset*(fleetRadius/length);
-			position -= offsetFromDesired*((0.05+0.05*hyperCount)/hyperSteps); // This calculation is arbitrary, and chosen to look good in-game
+			Point offsetFromDesired = hyperOffset-hyperOffset * (fleetRadius/length);
+			hyperOffset = hyperOffset * (fleetRadius/length);
+			position -= offsetFromDesired.Unit()*5 + offsetFromDesired * 0.1*((double)hyperCount / hyperSteps); // This calculation is arbitrary, and chosen to look good in-game
 		}
 	}
 	
 	//Hyper Drive Repeat
 	if(!isUsingJumpDrive)
 	{
-		if (hyperCount <= hyperSteps){ // If false, the ship is a cruising stage of hyperspace travel
+		if(hyperCount <= hyperSteps){ // If false, the ship is a cruising stage of hyperspace travel
 			velocity += (hyperAcceleration * hyperspaceRate) * angle.Unit();
 		}
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -472,12 +472,12 @@ private:
 	const Planet *landingPlanet = nullptr;
 	
 	int hyperSteps;
-    double hyperAcceleration;
-    double fleetRadius;
+	double hyperAcceleration;
+	double fleetRadius;
 	double hyperspaceFuelCost = 0.;
 	bool isUsingJumpDrive = false;
 	const System *hyperspaceSystem = nullptr;
-    Point hyperTarget;
+	Point hyperTarget;
 	int hyperCount = 0;
 	Point hyperOffset;
 	

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -376,6 +376,8 @@ private:
 	void CreateExplosion(std::vector<Visual> &visuals, bool spread = false);
 	// Place a "spark" effect, like ionization or disruption.
 	void CreateSparks(std::vector<Visual> &visuals, const std::string &name, double amount);
+	// Performs one step of the hyperspace animation. (This is called by Move().)
+	void IterateHyperspace(std::vector<Visual> &visuals);
 	
 	
 private:
@@ -469,11 +471,15 @@ private:
 	// hyperspacing, and exploding. Each one must track some special counters:
 	const Planet *landingPlanet = nullptr;
 	
-	int hyperspaceCount = 0;
-	const System *hyperspaceSystem = nullptr;
-	bool isUsingJumpDrive = false;
+	int hyperSteps;
+    double hyperAcceleration;
+    double fleetRadius;
 	double hyperspaceFuelCost = 0.;
-	Point hyperspaceOffset;
+	bool isUsingJumpDrive = false;
+	const System *hyperspaceSystem = nullptr;
+    Point hyperTarget;
+	int hyperCount = 0;
+	Point hyperOffset;
 	
 	std::map<const Effect *, int> explosionEffects;
 	unsigned explosionRate = 0;

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -261,6 +261,8 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			habitable = child.Value(valueIndex);
 		else if(key == "belt")
 			asteroidBelt = child.Value(valueIndex);
+		else if(key == "border")
+			border = child.Value(valueIndex);
 		else if(key == "haze")
 			haze = SpriteSet::Get(value);
 		else if(key == "trade" && child.Size() >= 3)
@@ -502,6 +504,14 @@ double System::HabitableZone() const
 double System::AsteroidBelt() const
 {
 	return asteroidBelt;
+}
+
+
+
+// Get the radius of the system border.
+double System::Border() const
+{
+	return border;
 }
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -110,6 +110,8 @@ public:
 	double HabitableZone() const;
 	// Get the radius of the asteroid belt.
 	double AsteroidBelt() const;
+    // Get the radius of the system border.
+    double Border() const;
 	// Get the rate of solar collection and ramscoop refueling.
 	double SolarPower() const;
 	double SolarWind() const;
@@ -181,6 +183,7 @@ private:
 	std::vector<FleetProbability> fleets;
 	double habitable = 1000.;
 	double asteroidBelt = 1500.;
+	double border = 1000.;
 	double solarPower = 0.;
 	double solarWind = 0.;
 	


### PR DESCRIPTION
Attempt 2: Electric Boogaloo
Now it should be much cleaner.

**Code cleanup**
The hyperspace code was moved out of the Move() function, structured to better reflect the sequence of events (separated into intial, repeated, and transitional hyperspace events), and worded to be less vague.

**Functionality changes**
New features:
"border" attribute for systems, representing a region that a ship entering with hyperspace travel is unable to pass through. Hyperspace travel ends before this border is reached, and jumping ships are placed outside the border.
This border also affects the distribution of pre-existing fleets in a system, and adds to the maximum distance an AI can venture from the system centre.
To address numerous complaints of users entering a system only to immediately be in the firing range of more powerful ships, the border is set to 1000 by default, as most systems have occasional enemy ships and thus require a decent-sized border.

Alterations:
Hyperdrive travel ends when a ship is travelling below maximum speed, and slow enough that it could stop before reaching the target from its current location. This replaces the system where hyperspace travel would end when the ship was travelling slow enough to stop within 1000 units.
Jump Drive no longer scatters ships randomly: Positions in a fleet are retained, and a fleet will attempt to jump directly to a target, though the target will likely be within the border and thus the entry point will be moved.

Bugfixes:
Ships that are more than 1000 units away from yours in a hyperspace jump will no longer teleport closer, and instead smoothly glide closer. This effect might be a bit strong at long separation distances, feel free to tweak this part.

New issues:
As a "cruise" stage of hyperspace travel was necessary allow borders to affect each ship in a fleet individualy while still placing the entire fleet in one location, ships spend longer travelling at maximum hyperspace speed, which causes a framerate drop in asteroid-heavy systems (this was already an issue, now it's worse).

**Purpose of change**
The purpose of the code cleanup is to improve the understandability and moddability of hyperspace code by making it follow a predictable structure instead of a random structure that breaks when changed.

The purpose of the border is to improve gameplay quality by adding a new parameter to systems.
A smaller border (like the game is now) makes non-combat gameplay better, by keeping everything in a convenient distance of the ship.
A larger border makes combat better by having new ships not arrive within attack range of already present ships, thus adding more emphasis to ship traits other than health and damage.
As such, the size of a border should reflect how significant a role combat plays in that system.