### PR TITLE
Always track a target, even if out-of-range

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2437,7 +2437,7 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
 			// Loop through each ship this hardpoint could shoot at. Find the
 			// one that is the "best" in terms of how many frames it will take
 			// to aim at it and for a projectile to hit it.
-			double bestScore = 1000.;
+			double bestScore = numeric_limits<double>::infinity();
 			double bestAngle = 0.;
 			for(const Body *target : enemies)
 			{

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1623,7 +1623,7 @@ void AI::Swarm(Ship &ship, Command &command, const Ship &target)
 	Point direction = target.Position() - ship.Position();
 	double maxSpeed = ship.MaxVelocity();
 	double rendezvousTime = RendezvousTime(direction, target.Velocity(), maxSpeed);
-	if(isnan(rendezvousTime) || rendezvousTime > 600.)
+	if(std::isnan(rendezvousTime) || rendezvousTime > 600.)
 		rendezvousTime = 600.;
 	direction += rendezvousTime * target.Velocity();
 	MoveTo(ship, command, target.Position() + direction, .5 * maxSpeed * direction.Unit(), 50., 2.);
@@ -1660,7 +1660,7 @@ void AI::KeepStation(Ship &ship, Command &command, const Ship &target)
 	
 	// Time it will take (roughly) to move to the target ship:
 	double positionTime = RendezvousTime(positionDelta, target.Velocity(), maxV);
-	if(isnan(positionTime) || positionTime > MAX_TIME)
+	if(std::isnan(positionTime) || positionTime > MAX_TIME)
 		positionTime = MAX_TIME;
 	Point rendezvous = positionDelta + target.Velocity() * positionTime;
 	double positionAngle = Angle(rendezvous).Degrees();
@@ -1822,7 +1822,7 @@ void AI::PickUp(Ship &ship, Command &command, const Body &target)
 	
 	// Estimate where the target will be by the time we reach it.
 	double time = RendezvousTime(p, v, vMax);
-	if(isnan(time))
+	if(std::isnan(time))
 		time = p.Length() / vMax;
 	double degreesToTurn = TO_DEG * acos(min(1., max(-1., p.Unit().Dot(ship.Facing().Unit()))));
 	time += degreesToTurn / ship.TurnRate();
@@ -2112,7 +2112,7 @@ bool AI::DoHarvesting(Ship &ship, Command &command)
 			Point v = it->Velocity() - ship.Velocity();
 			double vMax = ship.MaxVelocity();
 			double time = RendezvousTime(p, v, vMax);
-			if(isnan(time))
+			if(std::isnan(time))
 				continue;
 			
 			double degreesToTurn = TO_DEG * acos(min(1., max(-1., p.Unit().Dot(ship.Facing().Unit()))));
@@ -2330,7 +2330,7 @@ Point AI::TargetAim(const Ship &ship, const Body &target)
 		Point p = target.Position() - start + ship.GetPersonality().Confusion();
 		Point v = target.Velocity() - ship.Velocity();
 		double steps = RendezvousTime(p, v, weapon->Velocity() + .5 * weapon->RandomVelocity());
-		if(isnan(steps))
+		if(std::isnan(steps))
 			continue;
 		
 		steps = min(steps, weapon->TotalLifetime());
@@ -2455,7 +2455,7 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
 				double rendezvousTime = RendezvousTime(p, v, vp);
 				// If there is no intersection (i.e. the turret is not facing the target),
 				// consider this target "out-of-range" but still targetable.
-				if(isnan(rendezvousTime))
+				if(std::isnan(rendezvousTime))
 					rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
 				
 				// Determine where the target will be at that point.
@@ -2630,7 +2630,7 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 			
 			// Calculate how long it will take the projectile to reach its target.
 			double steps = RendezvousTime(p, v, vp);
-			if(!isnan(steps) && steps <= lifetime)
+			if(!std::isnan(steps) && steps <= lifetime)
 			{
 				command.SetFire(index);
 				continue;


### PR DESCRIPTION
Refs #3149 

 - Ensure that at least one target will always be aimed at, by increasing the starting score to +Inf
 - Handle NaN returns from RendezvousTime