### PR TITLE
Fix overflow in Angle.

### DIFF
--- a/source/Angle.cpp
+++ b/source/Angle.cpp
@@ -62,10 +62,14 @@ Angle::Angle()
 
 
 
-// Convert an angle in degrees into an Angle object.
+// Construct an Angle from the given angle in degrees.
 Angle::Angle(double degrees)
-	: angle(lround(degrees * DEG_TO_STEP) & MASK)
+	: angle(llround(degrees * DEG_TO_STEP) & MASK)
 {
+	// Make sure llround does not overflow with the values of System::SetDate.
+	// "now" has 32 bit integer precision. "speed" and "offset" have floating
+	// point precision and should be in the range from -360 to 360.
+	static_assert(sizeof(long long) >= 8, "llround can overflow");
 }
 
 


### PR DESCRIPTION
When long is 32-bit, lround overflows with the values produced in System::SetDate, returning an implementation dependent number.
Using llround is enough to avoid overflowing with the expected values.

Since: 1c6e6a6f8cb77bc0447952a84d86bf66b492071b
Fixes: #3640