### PR TITLE
Teach scons to compile in msys2 with mingw-w64. (windows)

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -59,6 +59,7 @@ Conversation LoadConversation();
 
 
 
+extern "C"
 int main(int argc, char *argv[])
 {
 	Conversation conversation;


### PR DESCRIPTION
Based on the codeblocks project but also copies dlls. 
Changed the linkage of `main` to match what SDL2main expects.
Did not teach scons how to package the result.

How to build:
1) install MSYS2
2) update MSYS2
3) enter MSYS2 shell
4) install what you need:
 `pacman -S  python2  git  base-devel`
 (optional) for 32-bit build: `pacman -S  mingw-w64-i686-toolchain  mingw-w64-i686-SDL2  mingw-w64-i686-openal  mingw-w64-i686-glew  mingw-w64-i686-libpng  mingw-w64-i686-libjpeg-turbo  mingw-w64-i686-libmad`
 (optional) for 64-bit build: `pacman -S  mingw-w64-x86_64-toolchain  mingw-w64-x86_64-SDL2  mingw-w64-x86_64-openal  mingw-w64-x86_64-glew  mingw-w64-x86_64-libpng  mingw-w64-x86_64-libjpeg-turbo  mingw-w64-x86_64-libmad`
5) get source:
 `git clone https://github.com/endless-sky/endless-sky.git`
6) build:
 (optional) set up 32-bit build: `export MSYSTEM=MINGW32 ; source /etc/profile`
 (optional) set up 64-bit build: `export MSYSTEM=MINGW64 ; source /etc/profile`
 `cd endless-sky`
 `scons`