### PR TITLE
Minimize precision errors of outfit additions.

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -31,6 +31,10 @@ namespace {
 	inline void PreciseAddMul(double &value, double mul, int count)
 	{
 		value = trunc(trunc(value * INV_EPS) + trunc(trunc(mul * INV_EPS) * count)) * EPS;
+		// Remove sign from negative zero.
+		// EPS does not have precision errors so a simple comparison is enough.
+		if(value == -0.)
+			value = 0.;
 	}
 }
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -24,6 +24,14 @@ using namespace std;
 
 namespace {
 	const double EPS = 0.0000000001;
+	const double INV_EPS = 1. / EPS;
+	
+	
+	// Minimize precision errors of "value += mul * count".
+	inline void PreciseAddMul(double &value, double mul, int count)
+	{
+		value = trunc(trunc(value * INV_EPS) + trunc(trunc(mul * INV_EPS) * count)) * EPS;
+	}
 }
 
 const vector<string> Outfit::CATEGORIES = {
@@ -186,13 +194,9 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 void Outfit::Add(const Outfit &other, int count)
 {
 	cost += other.cost * count;
-	mass += other.mass * count;
+	PreciseAddMul(mass, other.mass, count);
 	for(const auto &at : other.attributes)
-	{
-		attributes[at.first] += at.second * count;
-		if(fabs(attributes[at.first]) < EPS)
-			attributes[at.first] = 0.;
-	}
+		PreciseAddMul(attributes[at.first], at.second, count);
 	
 	for(const auto &it : other.flareSprites)
 	{


### PR DESCRIPTION
Selling 50000 Fragmentation Grenades, 50000 Laser Rifle and 50000 Nerve Gas accumulates so many precision errors the you are left with 1 unsellable Nerve Gas.
You can get around the issue by loading the game again.

Precision errors are avoided by truncating to `EPS` precision whenever possible.
Note that it is still possible to get precision errors if `count` is big enough to propagate the `mul` precision error to `.5 * EPS`.

Fixes: #3639 (bulk selling processes 1 outfit at a time, so count is not an issue)

Test file provided by @KiLEdEnNis: [sell_issue.txt](https://github.com/endless-sky/endless-sky/files/1722054/sell_issue.txt)

