### PR TITLE
Make the Kuwaru Efreti Quarg more consistent with their language

### DIFF
--- a/data/quarg missions.txt
+++ b/data/quarg missions.txt
@@ -76,7 +76,7 @@ mission "First Contact: Kuwaru Efreti"
 	on offer
 		conversation
 			`In your past experience, you've never seen the Quarg move with anything approaching haste or excitement, but when you land on this station a group of them run up to you, moving faster than you thought they were able to. For a minute or two they just gawk at you and talk amongst themselves in their own language; you think you recognize the word "Humani," and perhaps, "Eartha."`
-			`	Finally a Quarg appears who speaks your language, or at least is willing to try. It says, "Welcome, astonishing sojourner. Whither came you, and wherefore visit you us here in the unquiet graveyard of the Korathi?"`
+			`	Finally a Quarg appears who speaks your language, or at least is willing to try. It says, "Welcome, astonishing sojourner. Whither came ye, and wherefore visit ye us here in the unquiet graveyard of the Korathi?"`
 			choice
 				`	"I'm just here to explore. Can you tell me more about the Korath?"`
 				`	"I came here to learn what happened to the Korath."`
@@ -85,31 +85,31 @@ mission "First Contact: Kuwaru Efreti"
 				`	"What crimes did they commit?"`
 					goto crimes
 				`	"What do you mean, 'thinking war machines'?"`
-			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being they yet reproduce and wage senseless war against each other. Ware their ships if you wander north and east of here. They wield diverse weapons and strange, and we can bring you no succor within the bourne of their space."`
+			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being reproduce yet and wage senseless war against each other they. Ware their ships should ye wander north and east of here. Wield they diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
 			choice
 				`	"You mentioned 'crimes.' What crimes did they commit?"`
-			`	"Of that we will not speak, lest we awaken in you the desire to follow in their footsteps. But you may observe the wreckage of their abominations and take warning."`
+			`	"Of that we shall not speak, lest awaken in you we the desire to in their footsteps follow. But observe may ye the wreckage of their abominations and take warning."`
 				goto korath
 			
 			label crimes
-			`	"Of that we will not speak, lest we awaken in you the desire to follow in their footsteps. But you may observe the wreckage of their abominations and take warning."`
+			`	"Of that we shall not speak, lest awaken in you we the desire to in their footsteps follow. But observe may ye the wreckage of their abominations and take warning."`
 			choice
 				`	"You mentioned 'thinking war machines.' What are those?"`
-			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being they yet reproduce and wage senseless war against each other. Ware their ships if you wander north and east of here. They wield diverse weapons and strange, and we can bring you no succor within the bourne of their space."`
+			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being reproduce yet and wage against each other senseless war they. Ware their ships should ye wander north and east of here. Wield they diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
 			
 			label korath
 			`	You are interrupted as one of the Korath who inhabit this ringworld walks by, and the Quarg says, "Friend Korath, meet the human."`
 			`	"<first> <last>," you say, holding out a hand automatically. The Korath does not shake your hand, but instead greets you by holding up both hands, palms toward you. It says something in its own language, then hurries away.`
-			`	The Quarg says to you, "One faction among the Korath desired peace. Korath Efreti, they name themselves, which means Korath Friends. They are under our protection and intend you no harm. But, they have not your language; here humans are rare. Have you another question?"`
+			`	The Quarg says to you, "Desired peace one faction among the Korathi. Korath Efreti, name they themselves, which meaneth 'Korath Friends.' Under our protection are and intend no harm you they. But, have not they your language; here humans are rare. Another question have ye?"`
 			choice
 				`	"Will the friendly Korath let me purchase their technology?"`
 				`	"Why don't you destroy the robots, if they're such a threat?"`
 					goto destroy
 				`	"No, but I'm glad to meet you."`
 					decline
-			`	"Visit their worlds," says the Quarg. "Though they learn not your words, you are clever and may speak as one without words does, by pointing at things." You thank it for its time, and the crowd of Quarg that has been gawking at you slowly disperses.`
+			`	"Visit their worlds," says the Quarg. "Though learn not they your words, clever are ye and may speak as doth one without words, by pointing at things." You thank it for its time, and the crowd of Quarg that has been gawking at you slowly disperses.`
 				decline
 			
 			label destroy
-			`	It clicks its teeth together, which might be the Quarg equivalent of laughter. "It was hoped that one faction of robots would destroy the other, and leave less work for us to do, but they are sadly too evenly matched. We instead merely restrain them from expanding, as one isolates a fire one cannot extinguish and waits for it to burn out." You thank it for its time, and the crowd of Quarg that has been gawking at you slowly disperses.`
+			`	It clicks its teeth together, which might be the Quarg equivalent of laughter. "Hoped was it that one faction of robots would destroy the other, and leave for us less work to do, but sadly too evenly matched are they. Instead restrain merely we them from expanding, as one isolateth a fire one cannot extinguish and for it to burn out waiteth." You thank it for its time, and the crowd of Quarg that has been gawking at you slowly disperses.`
 				decline

--- a/data/quarg missions.txt
+++ b/data/quarg missions.txt
@@ -76,7 +76,7 @@ mission "First Contact: Kuwaru Efreti"
 	on offer
 		conversation
 			`In your past experience, you've never seen the Quarg move with anything approaching haste or excitement, but when you land on this station a group of them run up to you, moving faster than you thought they were able to. For a minute or two they just gawk at you and talk amongst themselves in their own language; you think you recognize the word "Humani," and perhaps, "Eartha."`
-			`	Finally a Quarg appears who speaks your language, or at least is willing to try. It says, "Welcome, astonishing sojourner. Whither came ye, and wherefore visit ye us here in the unquiet graveyard of the Korathi?"`
+			`	Finally a Quarg appears who speaks your language, or at least is willing to try. It says, "Salutations, astonishing sojourner. Whither came you, and wherefore visit you us here in the unquiet graveyard of the Korathi?"`
 			choice
 				`	"I'm just here to explore. Can you tell me more about the Korath?"`
 				`	"I came here to learn what happened to the Korath."`
@@ -85,31 +85,31 @@ mission "First Contact: Kuwaru Efreti"
 				`	"What crimes did they commit?"`
 					goto crimes
 				`	"What do you mean, 'thinking war machines'?"`
-			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being, they reproduce yet and wage against each other senseless war. Ware their ships should ye wander north and east of here, for wield they diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
+			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being, they yet reproduce and wage against each other senseless war. Ware their ships should you wander north and east of here, for they wield diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
 			choice
 				`	"You mentioned 'crimes.' What crimes did they commit?"`
-			`	"Of that we shall not speak, lest awaken in you we the desire to in their footsteps follow. But observe may ye the wreckage of their abominations and take warning."`
+			`	"Of that we shall not speak, lest awaken in you we the desire to in their footsteps follow. But you may observe the wreckage of their abominations and take warning."`
 				goto korath
 			
 			label crimes
-			`	"Of that we shall not speak, lest awaken in you we the desire to in their footsteps follow. But observe may ye the wreckage of their abominations and take warning."`
+			`	"Of that we shall not speak, lest awaken in you we the desire to in their footsteps follow. But you may observe the wreckage of their abominations and take warning."`
 			choice
 				`	"You mentioned 'thinking war machines.' What are those?"`
-			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being, they reproduce yet and wage against each other senseless war. Ware their ships should ye wander north and east of here, for wield they diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
+			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being, they yet reproduce and wage against each other senseless war. Ware their ships should you wander north and east of here, for they wield diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
 			
 			label korath
 			`	You are interrupted as one of the Korath who inhabit this ringworld walks by, and the Quarg says, "Friend Korath, meet the human."`
 			`	"<first> <last>," you say, holding out a hand automatically. The Korath does not shake your hand, but instead greets you by holding up both hands, palms toward you. It says something in its own language, then hurries away.`
-			`	The Quarg says to you, "Desired peace one faction among the Korathi. 'Korath Efreti,' name they themselves, which meaneth 'Korath Friends.' They are under our protection and intend you no harm. But, have not they your language; here humans are rare. Another question have ye?"`
+			`	The Quarg says to you, "One faction among the Korathi sought peace. 'Korath Efreti,' they name themselves, which means 'Korath Friends.' They are under our protection and intend you no harm. But, they have not your language; here humans are rare. Another question have you?"`
 			choice
 				`	"Will the friendly Korath let me purchase their technology?"`
 				`	"Why don't you destroy the robots, if they're such a threat?"`
 					goto destroy
 				`	"No, but I'm glad to meet you."`
 					decline
-			`	"Visit their worlds," says the Quarg. "Though learn not they your words, clever are ye and may speak as doth one without words, by pointing at things." You thank it for its time, and the crowd of Quarg that has been gawking at you slowly disperses.`
+			`	"Visit their worlds," says the Quarg. "Though they learn not your words, you are clever and may speak as does one without words, by pointing at things." You thank it for its time, and the crowd of Quarg that has been gawking at you slowly disperses.`
 				decline
 			
 			label destroy
-			`	It clicks its teeth together, which might be the Quarg equivalent of laughter. "Hoped was it that one faction of robots would destroy the other, and leave for us less work to do, but they are sadly too evenly matched. Instead restrain merely we them from expanding, as one isolateth a fire one cannot extinguish and for it to burn out waiteth." You thank it for its time, and the crowd of Quarg that has been gawking at you slowly disperses.`
+			`	It clicks its teeth together, which might be the Quarg equivalent of laughter. "It was hoped that one faction of robots would destroy the other, and leave for us less work to do, but they are sadly too evenly matched. Instead we merely restrain them from expanding, as one isolates a fire one cannot extinguish and for it to burn out waits." You thank it for its time, and the crowd of Quarg that has been gawking at you slowly disperses.`
 				decline

--- a/data/quarg missions.txt
+++ b/data/quarg missions.txt
@@ -80,12 +80,12 @@ mission "First Contact: Kuwaru Efreti"
 			choice
 				`	"I'm just here to explore. Can you tell me more about the Korath?"`
 				`	"I came here to learn what happened to the Korath."`
-			`	"Ah, the unwise Korath," it says. "Once a mighty empire, now sadly splintered and diminished. Their own thinking war machines, now breeding with abandon and inimical to all, hunt the survivors. And some of them, too, were exiled for their great crimes."`
+			`	"Ah, the unwise Korath," it says. "Once a mighty empire, now sadly splintered and diminished. Their own thinking war machines, now breeding with abandon and inimical to all, hunt the survivors. And of them some, too, were exiled for their great crimes."`
 			choice
 				`	"What crimes did they commit?"`
 					goto crimes
 				`	"What do you mean, 'thinking war machines'?"`
-			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being reproduce yet and wage senseless war against each other they. Ware their ships should ye wander north and east of here. Wield they diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
+			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being, they reproduce yet and wage against each other senseless war. Ware their ships should ye wander north and east of here, for wield they diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
 			choice
 				`	"You mentioned 'crimes.' What crimes did they commit?"`
 			`	"Of that we shall not speak, lest awaken in you we the desire to in their footsteps follow. But observe may ye the wreckage of their abominations and take warning."`
@@ -95,12 +95,12 @@ mission "First Contact: Kuwaru Efreti"
 			`	"Of that we shall not speak, lest awaken in you we the desire to in their footsteps follow. But observe may ye the wreckage of their abominations and take warning."`
 			choice
 				`	"You mentioned 'thinking war machines.' What are those?"`
-			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being reproduce yet and wage against each other senseless war they. Ware their ships should ye wander north and east of here. Wield they diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
+			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being, they reproduce yet and wage against each other senseless war. Ware their ships should ye wander north and east of here, for wield they diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
 			
 			label korath
 			`	You are interrupted as one of the Korath who inhabit this ringworld walks by, and the Quarg says, "Friend Korath, meet the human."`
 			`	"<first> <last>," you say, holding out a hand automatically. The Korath does not shake your hand, but instead greets you by holding up both hands, palms toward you. It says something in its own language, then hurries away.`
-			`	The Quarg says to you, "Desired peace one faction among the Korathi. Korath Efreti, name they themselves, which meaneth 'Korath Friends.' Under our protection are and intend no harm you they. But, have not they your language; here humans are rare. Another question have ye?"`
+			`	The Quarg says to you, "Desired peace one faction among the Korathi. 'Korath Efreti,' name they themselves, which meaneth 'Korath Friends.' They are under our protection and intend you no harm. But, have not they your language; here humans are rare. Another question have ye?"`
 			choice
 				`	"Will the friendly Korath let me purchase their technology?"`
 				`	"Why don't you destroy the robots, if they're such a threat?"`
@@ -111,5 +111,5 @@ mission "First Contact: Kuwaru Efreti"
 				decline
 			
 			label destroy
-			`	It clicks its teeth together, which might be the Quarg equivalent of laughter. "Hoped was it that one faction of robots would destroy the other, and leave for us less work to do, but sadly too evenly matched are they. Instead restrain merely we them from expanding, as one isolateth a fire one cannot extinguish and for it to burn out waiteth." You thank it for its time, and the crowd of Quarg that has been gawking at you slowly disperses.`
+			`	It clicks its teeth together, which might be the Quarg equivalent of laughter. "Hoped was it that one faction of robots would destroy the other, and leave for us less work to do, but they are sadly too evenly matched. Instead restrain merely we them from expanding, as one isolateth a fire one cannot extinguish and for it to burn out waiteth." You thank it for its time, and the crowd of Quarg that has been gawking at you slowly disperses.`
 				decline

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -410,27 +410,27 @@ mission "Wanderers: Quarg Assistance 2"
 		log "The Quarg (or possibly, a faction within the Quarg, or even just a group of Quarg acting on their own) have agreed to send three of their warships to help defend the Wanderer settlement in Korath space. (Or maybe they are sending the ships because they view the Wanderers as invaders and want to keep an eye on them. It is not easy to determine their true intentions.)"
 		log "Factions" "Wanderers" `According to the Quarg, the Wanderers are not native to this galaxy, but were brought here from somewhere else (presumably by the Pug).`
 		conversation
-			`The Quarg do not generally share any information on how their leadership hierarchy works, if such a hierarchy even exists, so your best bet to find help for the Wanderers is just to ask around until you find the right person. You flag down the first Quarg who passes you in the hallway. "So," it says, "us the Quarg the human sojourner hath come to visit. Of assistance how may I be?"`
+			`The Quarg do not generally share any information on how their leadership hierarchy works, if such a hierarchy even exists, so your best bet to find help for the Wanderers is just to ask around until you find the right person. You flag down the first Quarg who passes you in the hallway. "So," it says, "us the Quarg the human sojourner has come to visit. Of assistance how may I be?"`
 			`	"Well," you say, "I'm here on behalf of a species that has recently settled on one of the abandoned Korath worlds. I'm hoping you can help protect them."`
-			`	It says, "Yes, aware are we that befriended have ye the eternally drifting Wanderers, who are friends of the insufferable Pug. But for what reason aid them should we?"`
+			`	It says, "Yes, aware are we that befriended have you the eternally drifting Wanderers, who are friends of the insufferable Pug. But wherefore aid them should we?"`
 			choice
 				`	"The Wanderers know how to repair planetary ecosystems. They could make the Korath worlds livable again."`
 				`	"The Wanderers may be able to help you deal with the hostile automata."`
 					goto automata
 
-			`	"Able also to make worthy to inhabit those worlds again the Korathi are they? Able to make wise enough to not ruin their homes once more the Korathi are they? Or extend not so far the abilities of these extragalactic interlopers?"`
+			`	"Are they able also to make the Korathi worthy to inhabit those worlds again? Are they able to make wise enough the Korathi to not ruin their homes once more? Or do the abilities of these extragalactic interlopers not extend so far?"`
 				goto next
 
 			label automata
-			`	"Mightier than our ships are theirs?" asks the Quarg. "Greater wisdom than we have they? Or more numerous than we are they? For we are trillions. What could these extragalactic interlopers achieve, that long before the emergence of you attempted have we not?"`
+			`	"Are their vessels and arms mightier than ours?" asks the Quarg. "Have they a wisdom vaster than our own? Or are they more numerous than we? For we are trillions. What could these extragalactic interlopers achieve, that long before your emergence attempted have we not?"`
 
 			label next
-			`	When you don't respond, the Quarg continues, "Indigenous are not these Wanderers to our galaxy, and thus have not we an obligation to avert their extinction. The Korathi are our charge and our responsibility. So implore I you to tell me, why a good thing for the Korathi it is that their shattered territory these aliens invade."`
+			`	When you don't respond, the Quarg continues, "These Wanderers are not indigenous to our galaxy, and thus have not we an obligation to avert their extinction. The Korathi are our charge and our responsibility. So implore I you to tell me, why a good thing for the Korathi it is that their shattered territory these aliens invade."`
 			choice
 				`	"The Wanderers could help the Korath by teaching them to take care of their worlds better."`
 				`	"The Wanderers don't want to stay here forever; they will move on once the worlds are repaired."`
 
-			`	The Quarg blinks slowly, with its strange eyelids moving from side to side rather than top to bottom. Then it says, "Grant you shall we three warships to with you travel back to the settlement of these friends of the loathsome Pug. Help keep will they the death-bringing robots at bay. And oversee will they the Wanderers, and judge if as benevolent as ye say are they."`
+			`	The Quarg blinks slowly, with its strange eyelids moving from side to side rather than top to bottom. Then it says, "Grant you shall we three warships to with you travel back to the settlement of these friends of the loathsome Pug. They will help to keep the death-bringing robots at bay. And oversee will they the Wanderers, and judge if as benevolent as you say are they."`
 			`	It is extremely strange that the first random Quarg you accosted in the hallway happened to be one with the authority to launch a fleet of warships, but it would be impolite to question such a generous, if extremely verbose offer. You thank the Quarg and return to your ship. Hopefully the Wanderers will be glad for the protection and will not object to having a Quarg fleet overhead scrutinizing their actions.`
 				accept
 	npc accompany save

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -410,28 +410,28 @@ mission "Wanderers: Quarg Assistance 2"
 		log "The Quarg (or possibly, a faction within the Quarg, or even just a group of Quarg acting on their own) have agreed to send three of their warships to help defend the Wanderer settlement in Korath space. (Or maybe they are sending the ships because they view the Wanderers as invaders and want to keep an eye on them. It is not easy to determine their true intentions.)"
 		log "Factions" "Wanderers" `According to the Quarg, the Wanderers are not native to this galaxy, but were brought here from somewhere else (presumably by the Pug).`
 		conversation
-			`The Quarg do not generally share any information on how their leadership hierarchy works, if such a hierarchy even exists, so your best bet to find help for the Wanderers is just to ask around until you find the right person. You flag down the first Quarg who passes you in the hallway. "How can I help you, human?" it asks.`
+			`The Quarg do not generally share any information on how their leadership hierarchy works, if such a hierarchy even exists, so your best bet to find help for the Wanderers is just to ask around until you find the right person. You flag down the first Quarg who passes you in the hallway. "So," it says, "us the Quarg the human sojourner hath come to visit. Of assistance how may I be?"`
 			`	"Well," you say, "I'm here on behalf of a species that has recently settled on one of the abandoned Korath worlds. I'm hoping you can help protect them."`
-			`	It says, "Yes, we are aware that you are a friend of the Wanderers, who are friends of the insufferable Pug. But why should we assist them?"`
+			`	It says, "Yes, aware are we that befriended have ye the eternally drifting Wanderers, who are friends of the insufferable Pug. But for what reason aid them should we?"`
 			choice
 				`	"The Wanderers know how to repair planetary ecosystems. They could make the Korath worlds livable again."`
 				`	"The Wanderers may be able to help you deal with the hostile automata."`
 					goto automata
 
-			`	"Are they also able to make the Korath worthy of inhabiting those worlds again? Are they able to make the Korath wise enough to not ruin their homes once more? Or do the abilities of these extragalactic interlopers not extend so far?"`
+			`	"Able also to make worthy to inhabit those worlds again the Korathi are they? Able to make wise enough to not ruin their homes once more the Korathi are they? Or extend not so far the abilities of these extragalactic interlopers?"`
 				goto next
 
 			label automata
-			`	"Are their ships more powerful than ours?" asks the Quarg. "Do they have greater wisdom than we do? Or are they more numerous than we? For we are trillions. What could these extragalactic interlopers do, that we have not already attempted?"`
+			`	"Mightier than our ships are theirs?" asks the Quarg. "Greater wisdom than we have they? Or more numerous than we are they? For we are trillions. What could these extragalactic interlopers achieve, that long before the emergence of you attempted have we not?"`
 
 			label next
-			`	When you don't respond, the Quarg continues, "These Wanderers are not indigenous to our galaxy, and thus we have no obligation to prevent their extinction. The Korath are our charge and our responsibility. So tell me, why it is a good thing for the Korath that these aliens are invading their territory."`
+			`	When you don't respond, the Quarg continues, "Indigenous are not these Wanderers to our galaxy, and thus have not we an obligation to avert their extinction. The Korathi are our charge and our responsibility. So implore I you to tell me, why a good thing for the Korathi it is that their shattered territory these aliens invade."`
 			choice
 				`	"The Wanderers could help the Korath by teaching them to take care of their worlds better."`
 				`	"The Wanderers don't want to stay here forever; they will move on once the worlds are repaired."`
 
-			`	The Quarg blinks slowly, with its strange eyelids moving from side to side rather than top to bottom. Then it says, "We will give you three warships to travel with you back to the settlement of these friends of the loathsome Pug. They will help keep the drones at bay. And they will keep watch on the Wanderers, and judge if they are as benevolent as you say."`
-			`	It is extremely strange that the first random Quarg you accosted in the hallway happened to be one with the authority to launch a fleet of warships, but it would be impolite to question such a generous offer. You thank the Quarg and return to your ship. Hopefully the Wanderers will be glad for the protection and will not object to having a Quarg fleet overhead scrutinizing their actions.`
+			`	The Quarg blinks slowly, with its strange eyelids moving from side to side rather than top to bottom. Then it says, "Grant you shall we three warships to with you travel back to the settlement of these friends of the loathsome Pug. Help keep will they the death-bringing robots at bay. And oversee will they the Wanderers, and judge if as benevolent as ye say are they."`
+			`	It is extremely strange that the first random Quarg you accosted in the hallway happened to be one with the authority to launch a fleet of warships, but it would be impolite to question such a generous, if extremely verbose offer. You thank the Quarg and return to your ship. Hopefully the Wanderers will be glad for the protection and will not object to having a Quarg fleet overhead scrutinizing their actions.`
 				accept
 	npc accompany save
 		government "Quarg"


### PR DESCRIPTION
My main issue is specifically in the Wanderer mission when you are ordered to ask the Quarg for help, because the Quarg then have a very good handling of the modern English language, when in a previous encounter (if any) they clearly... had problems. I propose that we change that.