### PR TITLE
Made Korath hostile towards Bounty Hunters

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -148,7 +148,7 @@ government "Korath"
 	
 	"attitude toward"
 		"Kor Sestor" -.01
-		"Bounty Hunter" -0.01
+		"Bounty Hunter" -.01
 	
 	"player reputation" -10
 

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -148,6 +148,7 @@ government "Korath"
 	
 	"attitude toward"
 		"Kor Sestor" -.01
+		"Bounty Hunter" -0.01
 	
 	"player reputation" -10
 


### PR DESCRIPTION
Considering Korath raiders will attack everyone else, it makes sense that they'd also attack bounty hunters; because why leave them out of the fun.