### PR TITLE
Made Kor Sestor attack Bounty Hunters after Zenith is bombed

### DIFF
--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -2454,6 +2454,7 @@ event "bombed zenith"
 	government "Kor Sestor"
 		"attitude toward"
 			"Pirate" -.01
+			"Bounty Hunter" -.01
 	planet "Zenith"
 		description `Zenith is a cold and unpleasant world, where the fog seldom lifts and the sun is rarely seen, where much of the lowlands are flooded each day by the tide, and storms are unpredictable and fierce. It has, however, one major advantage as a place to settle: it is far enough away that the Republic makes no attempt to control it.`
 		description `	The settlements here were never more than tenuous villages operating on the brink of starvation as they sought to make a living in this icy wilderness. Now, many of them have collapsed due to massive earthquakes that came after the Oathkeepers had the planet bombed to destroy an Alpha base.`


### PR DESCRIPTION
After Zenith is bombed, the lore says literally says they `are attacking Navy and civilian ships indiscriminately.`, so it makes sense then that the Sestor drones would attack bounty hunters as well after that event