### PR TITLE
Made the cloaking device unplunderable.

### DIFF
--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -255,6 +255,7 @@ outfit "Cloaking Device"
 	"cloak" .01
 	"cloaking energy" 1
 	"cloaking fuel" .2
+	unplunderable 1
 	description "You're sure the cloaking device is here somewhere, but you can't see it."
 
 


### PR DESCRIPTION
This patches a particular exploit where the player is able to plunder the Cloaking Device from Pug Arfectas (yes, it can be done, I've tested it), even though they cannot uninstall it from within an outfitter without selling the ship. (This is [intentional](
https://github.com/endless-sky/endless-sky/issues/1344#issuecomment-234128902).)

- It doesn't seem logical to me that you would be able to plunder the cloaking device with on-ship tools, yet not be able to uninstall it with a full outfitter.
- Note that this patch would still allow a cloaking device in cargo to be plundered, according to [BoardingPanel.cpp#L88](https://github.com/endless-sky/endless-sky/blob/1fd6336f3194f5a2d2fc148f48cad8790a5e327b/source/BoardingPanel.cpp#L88). The cloaking device, as far as can be known to the player, has only ever been left completely deactivated and [therefore visible](https://github.com/endless-sky/endless-sky/blob/master/data/outfits.txt#L258) and removable (within reasonable ability) once [in a certain Korath ship's cargo hold](https://github.com/endless-sky/endless-sky/blob/master/data/free%20worlds%20reconciliation.txt#L2243).