### PR TITLE
+Makefile

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,10 +1,10 @@
-######Building Endless Sky
+###### Building Endless Sky
 _NOTE: If you have strayed here by accident and are inexperienced with building
 software and the command line, it may be a better idea to grab the program from
 your package manager, the releases section in GitHub, or Steam, rather than
 fruitlessly wasting your time_
 
-###Linux
+### Linux
 You must install both headers and runtimes of the following libraries:
 - sdl2
 - libpng
@@ -36,7 +36,7 @@ dependencies using the following command, requiring root privileges:
 
     # apt install build-essential lib{sdl2,png12,jpeg62-turbo,glew,openal,mad0}-dev
 
-###Mac OS X
+### Mac OS X
 You must install [Homebrew](https://brew.sh), then you must install the
 following packages using `brew install`:
 
@@ -82,5 +82,5 @@ After sufficient cursing at Apple, you may proceed to build and run:
     $ make
     $ ./endless-sky
 
-###Windows
+### Windows
 TODO

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,86 @@
+######Building Endless Sky
+_NOTE: If you have strayed here by accident and are inexperienced with building
+software and the command line, it may be a better idea to grab the program from
+your package manager, the releases section in GitHub, or Steam, rather than
+fruitlessly wasting your time_
+
+###Linux
+You must install both headers and runtimes of the following libraries:
+- sdl2
+- libpng
+- libjpeg-turbo
+- glew
+- openal
+- mad
+
+The following tools are necessary to proceed:
+- C++ compiler that supports C++11 (GCC 4.8.1+, clang 3.3+)
+- GNU make
+- pkg-config
+
+You then run the following commands in the same directory as the `Makefile`:
+
+    $ make
+    $ ./endless-sky
+
+`-j9` may be passed to `make` to make the build go faster at the expense of
+memory and CPU time. Setting an environment variable `OPTFLAGS` will alter the
+default optimisation flags, while `CXXFLAGS` and `LDFLAGS` will let you change
+the compiler and linker flags respectively, if any changes are necessary.
+
+The program will infer the location of the `data` and `images` directories
+according to the rules outlined in the man page `endless-sky.6`.
+
+Debian-based distributions will probably want to install all necessary
+dependencies using the following command, requiring root privileges:
+
+    # apt install build-essential lib{sdl2,png12,jpeg62-turbo,glew,openal,mad0}-dev
+
+###Mac OS X
+You must install [Homebrew](https://brew.sh), then you must install the
+following packages using `brew install`:
+
+    $ brew install pkg-config sdl2 openal-soft jpeg-turbo lib{png,mad}
+
+You must also either set `PKG_CONFIG_PATH` or follow the instructions according
+to the output of homebrew after you install any of those packages in order for
+`pkg-config` to be able to find its library definition files necessary to
+proceed.
+
+Example output:
+    This formula is keg-only, which means it was not symlinked into /usr/local,
+    because macOS provides OpenAL.framework.
+
+    If you need to have this software first in your PATH run:
+    echo 'export PATH="/usr/local/opt/openal-soft/bin:$PATH"' >> ~/.bash_profile
+
+    For compilers to find this software you may need to set:
+        LDFLAGS:  -L/usr/local/opt/openal-soft/lib
+    	CPPFLAGS: -I/usr/local/opt/openal-soft/include
+    For pkg-config to find this software you may need to set:
+    	PKG_CONFIG_PATH: /usr/local/opt/openal-soft/lib/pkgconfig
+
+Unfortunately, Mac OS X does not seem to provide any `gl.pc`. You can work
+around this by either manually editing the Makefile to allow you to compile by
+passing special CXXFLAGS and LDFLAGS environment variables, or you can use this
+file, taken from [here](https://stackoverflow.com/questions/29457534/cmake-on-osx-yosemite-10-10-3-glew-package-gl-not-found):
+
+    PACKAGE=GL
+
+    Name: OpenGL
+    Description: OpenGL
+    Version: 11.1.1
+    Cflags: -framework OpenGL -framework AGL
+    Libs: -Wl,-framework,OpenGL,-framework,AGL
+
+Simply create a plain text file named `gl.pc` with a plain text editor, place
+the above contents with no leading whitespace inside said file, then place that
+file in `/usr/lib/pkgconfig`.
+
+After sufficient cursing at Apple, you may proceed to build and run:
+
+    $ make
+    $ ./endless-sky
+
+###Windows
+TODO

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,6 +48,7 @@ to the output of homebrew after you install any of those packages in order for
 proceed.
 
 Example output:
+
     This formula is keg-only, which means it was not symlinked into /usr/local,
     because macOS provides OpenAL.framework.
 

--- a/Makefile
+++ b/Makefile
@@ -31,29 +31,26 @@ $(shell mkdir -p $(DIR_RELEASE) $(DIR_DEBUG) $(DIR_PROF))
 $(DIR_RELEASE)/%.o: $(DIR_SRC)/%.cpp
 	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $@ -c -MMD $<
 
-$(DIR_RELEASE)/$(PROG): $(OBJS)
-	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $(DIR_RELEASE)/$(PROG) $^ $(LDFLAGS)
+$(PROG): $(OBJS)
+	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $(PROG) $^ $(LDFLAGS)
 
-release: $(DIR_RELEASE)/$(PROG)
-	cp $(DIR_RELEASE)/$(PROG) .
+release: $(PROG)
 
 $(DIR_DEBUG)/%.o: $(DIR_SRC)/%.cpp
 	$(CXX) $(CXXFLAGS) -g -o $@ -c -MMD $<
 
-$(DIR_DEBUG)/$(PROG_DEBUG): $(OBJS_DEBUG)
-	$(CXX) $(CXXFLAGS) -g -o $(DIR_DEBUG)/$(PROG_DEBUG) $^ $(LDFLAGS)
+$(PROG_DEBUG): $(OBJS_DEBUG)
+	$(CXX) $(CXXFLAGS) -g -o $(PROG_DEBUG) $^ $(LDFLAGS)
 
-debug: $(DIR_DEBUG)/$(PROG_DEBUG)
-	cp $(DIR_DEBUG)/$(PROG_DEBUG) .
+debug: $(PROG_DEBUG)
 
 $(DIR_PROF)/%.o: $(DIR_SRC)/%.cpp
 	$(CXX) $(CXXFLAGS) -pg -o $@ -c -MMD $<
 
-$(DIR_PROF)/$(PROG_PROF): $(OBJS_PROF)
-	$(CXX) $(CXXFLAGS) -pg -o $(DIR_PROF)/$(PROG_PROF) $^ $(LDFLAGS)
+$(PROG_PROF): $(OBJS_PROF)
+	$(CXX) $(CXXFLAGS) -pg -o $(PROG_PROF) $^ $(LDFLAGS)
 
-profile: $(DIR_PROF)/$(PROG_PROF)
-	cp $(DIR_PROF)/$(PROG_PROF) .
+profile: $(PROG_PROF)
 
 .DEFAULT: all
 all: release

--- a/Makefile
+++ b/Makefile
@@ -31,20 +31,29 @@ $(shell mkdir -p $(DIR_RELEASE) $(DIR_DEBUG) $(DIR_PROF))
 $(DIR_RELEASE)/%.o: $(DIR_SRC)/%.cpp
 	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $@ -c -MMD $<
 
-release: $(OBJS)
-	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $(PROG) $^ $(LDFLAGS)
+$(DIR_RELEASE)/$(PROG): $(OBJS)
+	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $(DIR_RELEASE)/$(PROG) $^ $(LDFLAGS)
+
+release: $(DIR_RELEASE)/$(PROG)
+	cp $(DIR_RELEASE)/$(PROG) .
 
 $(DIR_DEBUG)/%.o: $(DIR_SRC)/%.cpp
 	$(CXX) $(CXXFLAGS) -g -o $@ -c -MMD $<
 
-debug: $(OBJS_DEBUG)
-	$(CXX) $(CXXFLAGS) -g -o $(PROG_DEBUG) $^ $(LDFLAGS)
+$(DIR_DEBUG)/$(PROG_DEBUG): $(OBJS_DEBUG)
+	$(CXX) $(CXXFLAGS) -g -o $(DIR_DEBUG)/$(PROG_DEBUG) $^ $(LDFLAGS)
+
+debug: $(DIR_DEBUG)/$(PROG_DEBUG)
+	cp $(DIR_DEBUG)/$(PROG_DEBUG) .
 
 $(DIR_PROF)/%.o: $(DIR_SRC)/%.cpp
 	$(CXX) $(CXXFLAGS) -pg -o $@ -c -MMD $<
 
-profile: $(OBJS_PROF)
-	$(CXX) $(CXXFLAGS) -pg -o $(PROG_PROF) $^ $(LDFLAGS)
+$(DIR_PROF)/$(PROG_PROF): $(OBJS_PROF)
+	$(CXX) $(CXXFLAGS) -pg -o $(DIR_PROF)/$(PROG_PROF) $^ $(LDFLAGS)
+
+profile: $(DIR_PROF)/$(PROG_PROF)
+	cp $(DIR_PROF)/$(PROG_PROF) .
 
 .DEFAULT: all
 all: release

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ PROG_DEBUG = $(PROG)-debug
 PROG_PROF = $(PROG)-profile
 DIR_SRC = source
 DIR_BUILD = build
-DIR_RELEASE = $(addsuffix release,$(DIR_BUILD)/)
-DIR_DEBUG = $(addsuffix debug,$(DIR_BUILD)/)
-DIR_PROF = $(addsuffix profile,$(DIR_BUILD)/)
+DIR_RELEASE = $(DIR_BUILD)/release
+DIR_DEBUG = $(DIR_BUILD)/debug
+DIR_PROF = $(DIR_BUILD)/profile
 
 SRCS = $(wildcard $(DIR_SRC)/*.cpp)
 OBJS = $(patsubst $(DIR_SRC)/%.cpp,$(DIR_RELEASE)/%.o,$(SRCS))

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,74 @@
+PREFIX ?= /usr/local
+
+.PHONY: release debug profile all clean install
+OPTLEVEL ?= -O3
+
+LIBS += sdl2 libpng libjpeg gl glew openal mad
+CXXFLAGS += -std=c++11 -Wall
+CXXFLAGS += $(shell pkg-config $(LIBS) --cflags)
+LDFLAGS += $(shell pkg-config $(LIBS) --libs) -lpthread
+
+PROG = endless-sky
+PROG_DEBUG = $(PROG)-debug
+PROG_PROF = $(PROG)-profile
+DIR_SRC = source
+DIR_BUILD = build
+DIR_RELEASE = $(addsuffix release,$(DIR_BUILD)/)
+DIR_DEBUG = $(addsuffix debug,$(DIR_BUILD)/)
+DIR_PROF = $(addsuffix profile,$(DIR_BUILD)/)
+
+SRCS = $(wildcard $(DIR_SRC)/*.cpp)
+OBJS = $(patsubst $(DIR_SRC)/%.cpp,$(DIR_RELEASE)/%.o,$(SRCS))
+OBJS_DEBUG = $(patsubst $(DIR_SRC)/%.cpp,$(DIR_DEBUG)/%.o,$(SRCS))
+OBJS_PROF = $(patsubst $(DIR_SRC)/%.cpp,$(DIR_PROF)/%.o,$(SRCS))
+
+$(info mkdir -p $(DIR_RELEASE) $(DIR_DEBUG) $(DIR_PROF))
+$(shell mkdir -p $(DIR_RELEASE) $(DIR_DEBUG) $(DIR_PROF))
+
+$(DIR_RELEASE)/%.o: $(DIR_SRC)/%.cpp
+	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $@ -c $<
+
+release: $(OBJS)
+	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $(PROG) $^ $(LDFLAGS)
+
+$(DIR_DEBUG)/%.o: $(DIR_SRC)/%.cpp
+	$(CXX) $(CXXFLAGS) -g -o $@ -c $<
+
+debug: $(OBJS_DEBUG)
+	$(CXX) $(CXXFLAGS) -g -o $(PROG_DEBUG) $^ $(LDFLAGS)
+
+$(DIR_PROF)/%.o: $(DIR_SRC)/%.cpp
+	$(CXX) $(CXXFLAGS) -pg -o $@ -c $<
+
+profile: $(OBJS_PROF)
+	$(CXX) $(CXXFLAGS) -pg -o $(PROG_PROF) $^ $(LDFLAGS)
+
+.DEFAULT: all
+all: release
+
+DESTINATION = $(DESTDIR)$(PREFIX)
+PREFIX_DATA = $(DESTINATION)/share/games/$(PROG)
+PREFIX_BIN = $(DESTINATION)/bin
+ICON = icons/icon_
+ICONS = 16x16 22x22 24x24 32x32 48x48 256x256
+
+install: release
+	mkdir -p $(PREFIX_BIN)
+	install -m 0755 $(PROG) $(PREFIX_BIN)
+	mkdir -p $(PREFIX_DATA)
+	cp -R --no-preserve=ownership data $(PREFIX_DATA)
+	cp -R --no-preserve=ownership images $(PREFIX_DATA)
+	cp -R --no-preserve=ownership sounds $(PREFIX_DATA)
+	cp --no-preserve=ownership credits.txt $(PREFIX_DATA)
+	cp --no-preserve=ownership keys.txt $(PREFIX_DATA)
+	mkdir -p $(DESTINATION)/share/man/man6/
+	gzip -c $(PROG).6 > $(DESTINATION)/share/man/man6/$(PROG).6.gz
+	for icon in $(ICONS); do \
+		mkdir -p $(DESTINATION)/share/icons/hicolor/$$icon/apps; \
+		cp --no-preserve=ownership $(ICON)$$icon.png $(DESTINATION)/share/icons/hicolor/$$icon/apps/$(PROG).png; \
+	done
+
+clean:
+	$(RM) $(PROG) $(PROG_DEBUG) $(PROG_PROF)
+	$(RM) -r $(DIR_RELEASE) $(DIR_DEBUG) $(DIR_PROF)
+

--- a/Makefile
+++ b/Makefile
@@ -19,26 +19,29 @@ DIR_PROF = $(DIR_BUILD)/profile
 
 SRCS = $(wildcard $(DIR_SRC)/*.cpp)
 OBJS = $(patsubst $(DIR_SRC)/%.cpp,$(DIR_RELEASE)/%.o,$(SRCS))
+DEPS = $(patsubst $(DIR_SRC)/%.cpp,$(DIR_RELEASE)/%.d,$(SRCS))
 OBJS_DEBUG = $(patsubst $(DIR_SRC)/%.cpp,$(DIR_DEBUG)/%.o,$(SRCS))
+DEPS_DEBUG = $(patsubst $(DIR_SRC)/%.cpp,$(DIR_DEBUG)/%.d,$(SRCS))
 OBJS_PROF = $(patsubst $(DIR_SRC)/%.cpp,$(DIR_PROF)/%.o,$(SRCS))
+DEPS_PROF = $(patsubst $(DIR_SRC)/%.cpp,$(DIR_PROF)/%.d,$(SRCS))
 
 $(info mkdir -p $(DIR_RELEASE) $(DIR_DEBUG) $(DIR_PROF))
 $(shell mkdir -p $(DIR_RELEASE) $(DIR_DEBUG) $(DIR_PROF))
 
 $(DIR_RELEASE)/%.o: $(DIR_SRC)/%.cpp
-	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $@ -c $<
+	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $@ -c -MMD $<
 
 release: $(OBJS)
 	$(CXX) $(OPTLEVEL) $(CXXFLAGS) -o $(PROG) $^ $(LDFLAGS)
 
 $(DIR_DEBUG)/%.o: $(DIR_SRC)/%.cpp
-	$(CXX) $(CXXFLAGS) -g -o $@ -c $<
+	$(CXX) $(CXXFLAGS) -g -o $@ -c -MMD $<
 
 debug: $(OBJS_DEBUG)
 	$(CXX) $(CXXFLAGS) -g -o $(PROG_DEBUG) $^ $(LDFLAGS)
 
 $(DIR_PROF)/%.o: $(DIR_SRC)/%.cpp
-	$(CXX) $(CXXFLAGS) -pg -o $@ -c $<
+	$(CXX) $(CXXFLAGS) -pg -o $@ -c -MMD $<
 
 profile: $(OBJS_PROF)
 	$(CXX) $(CXXFLAGS) -pg -o $(PROG_PROF) $^ $(LDFLAGS)
@@ -72,3 +75,6 @@ clean:
 	$(RM) $(PROG) $(PROG_DEBUG) $(PROG_PROF)
 	$(RM) -r $(DIR_RELEASE) $(DIR_DEBUG) $(DIR_PROF)
 
+-include $(DEPS)
+-include $(DEPS_DEBUG)
+-include $(DEPS_PROF)


### PR DESCRIPTION
Scons is so evil, it has its own plane of existence in the deepest recesses of hell, where it tortures chained, naked and afraid distribution maintainers with implements of destruction and despair better known as `Python 2` and `doing everything that make does, but worse`. It has also been seen stealing cake from your fridge.

This adds a Makefile that is tested to work on _one_ GNU/Linux machine under GNU make. Changes are requested, if any are necessary to make it work under more systems.

I've just seen that Steam still doesn't ship libmad with its steam runtime boogaloo, so the static linkage shenanigans should be added later. There is also the matter of extending the developer readme or replacing it with a more pragmatic- and intimidating-sounding *INSTALL* file.

#1882 

Disclaimer: This PR has nothing to do with the date it is posted on.