### PR TITLE
Admiral Danforth now only helps liberate Poisonwood if your reputation is positive with Oathkeepers

### DIFF
--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -968,6 +968,7 @@ mission "FW Northern 4.1A"
 		has "FW Northern 4: done"
 		not "FW Northern 4.2A: offered"
 		karma >= 2
+		"reputation: Navy (Oathkeeper)" >= 0
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
@@ -1006,7 +1007,9 @@ mission "FW Northern 4.2A"
 	to offer
 		has "FW Northern 4: done"
 		not "FW Northern 4.1A: offered"
-		karma < 2
+		or
+			karma < 2
+			"reputation: Navy (Oathkeeper)" < 0
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	


### PR DESCRIPTION
Ref: #3678 and the various related issues.

It doesn't make sense for Admiral Danforth to agree to help to liberate Poisonwood if he's also going to try and blow you up or get blown up by your escorts.