### PR TITLE
Auto-Aim to Spare the Disabled after closing board panel

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2529,7 +2529,7 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 		currentTarget.reset();
 	
 	// Only fire on disabled targets if you don't want to plunder them.
-	bool spareDisabled = (person.Disables() || (person.Plunders() && ship.Cargo().Free()));
+	bool spareDisabled = (person.Disables() || (person.Plunders() && ship.Cargo().Free()) || ship.IsYours());
 	
 	// Don't use weapons with firing force if you are preparing to jump.
 	bool isWaitingToJump = ship.Commands().Has(Command::JUMP | Command::WAIT);


### PR DESCRIPTION
As noted in #3696, auto aim, upon the closing of the board panel, fires upon the ship that was just boarded, destroying it.

Since most players aren't bloodthirsty hounds that kill for sport or just for the sensation of murder, it can be assumed that the auto-aim shouldn't carelessly wast lives either.

Also, splash damage non-secondary weapons (like Pug Gridfire Turret) firing upon an enemy ship will damage the player as well, making this decision doubly stupid. 

I'm pretty sure that this code will fix this problem, as now, if the ship belongs to the playerGovernment, it won't fire upon disabled ships, like it should.