### PR TITLE
Hotkey improvements for PlayerInfoPanel, ShipInfoPanel, TradingPanel

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -883,7 +883,7 @@ interface "info panel"
 		from 250 -290 to 500 280
 	
 	visible if "ship tab"
-	button R
+	button r
 		center -375 -270
 		dimensions 250 30
 	sprite "ui/ship tab"

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -934,7 +934,7 @@ interface "info panel"
 	active if "can park"
 	sprite "ui/dialog cancel"
 		center -55 305
-	button P "Park"
+	button p "_Park"
 		center -55 305
 		dimensions 70 30
 	active
@@ -942,7 +942,7 @@ interface "info panel"
 	visible if "show unpark"
 	sprite "ui/dialog cancel"
 		center -55 305
-	button P "Unpark"
+	button p "Un_park"
 		center -55 305
 		dimensions 70 30
 	
@@ -965,13 +965,13 @@ interface "info panel"
 	visible if "show park all"
 	sprite "ui/wide button"
 		center 145 305
-	button A "Park All"
+	button a "Park _All"
 		center 145 305
 		dimensions 90 30
 	visible if "show unpark all"
 	sprite "ui/wide button"
 		center 145 305
-	button A "Unpark All"
+	button a "Unpark _All"
 		center 145 305
 		dimensions 90 30
 

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -175,7 +175,7 @@ void PlayerInfoPanel::Draw()
 
 bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 {
-	if(key == 'd' || key == SDLK_ESCAPE || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI))))
+	if(key == 'd' || key == 'i' || key == SDLK_ESCAPE || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI))))
 		GetUI()->Pop(this);
 	else if(key == 's' || key == SDLK_RETURN || key == SDLK_KP_ENTER)
 	{
@@ -274,7 +274,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		if(selectedIndex >= 0)
 			allSelected.insert(selectedIndex);
 	}
-	else if(canEdit && key == 'P' && !allSelected.empty())
+	else if(canEdit && key == 'p' && !allSelected.empty())
 	{
 		// Toggle the parked status for all selected ships.
 		bool allParked = true;
@@ -293,7 +293,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 				player.ParkShip(&ship, !allParked);
 		}
 	}
-	else if(canEdit && key == 'A' && player.Ships().size() > 1)
+	else if(canEdit && key == 'a' && player.Ships().size() > 1)
 	{
 		// Toggle the parked status for all ships except the flagship.
 		bool allParked = true;

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -136,7 +136,7 @@ bool ShipInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		GetUI()->Pop(this);
 		GetUI()->Push(new PlayerInfoPanel(player));
 	}
-	else if(key == 'R')
+	else if(key == 'r')
 		GetUI()->Push(new Dialog(this, &ShipInfoPanel::Rename, "Change this ship's name?"));
 	else if(canEdit && key == 'P')
 	{

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -223,13 +223,13 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		player.SetMapColoring(max(0, player.MapColoring() - 1));
 	else if(key == SDLK_DOWN)
 		player.SetMapColoring(max(0, min(COMMODITY_COUNT - 1, player.MapColoring() + 1)));
-	else if(key == '=' || key == SDLK_RETURN || key == SDLK_SPACE)
+	else if(key == '=' || key == SDLK_LEFT || key == SDLK_SPACE)
 		Buy(1);
-	else if(key == '-' || key == SDLK_BACKSPACE || key == SDLK_DELETE)
+	else if(key == '-' || key == SDLK_RIGHT || key == SDLK_DELETE)
 		Buy(-1);
-	else if(key == 'B' || (key == 'b' && (mod & KMOD_SHIFT)))
+	else if(key == 'B' || key == SDLK_RETURN)
 		Buy(1000000000);
-	else if(key == 'S' || (key == 's' && (mod & KMOD_SHIFT)))
+	else if(key == 'S' || key == SDLK_BACKSPACE)
 	{
 		for(const auto &it : GameData::Commodities())
 		{

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -223,13 +223,13 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		player.SetMapColoring(max(0, player.MapColoring() - 1));
 	else if(key == SDLK_DOWN)
 		player.SetMapColoring(max(0, min(COMMODITY_COUNT - 1, player.MapColoring() + 1)));
-	else if(key == '=' || key == SDLK_LEFT || key == SDLK_SPACE)
+	else if(key == '=' || key == SDLK_RETURN || key == SDLK_SPACE)
 		Buy(1);
-	else if(key == '-' || key == SDLK_RIGHT || key == SDLK_DELETE)
+	else if(key == '-' || key == SDLK_BACKSPACE || key == SDLK_DELETE)
 		Buy(-1);
-	else if(key == 'B' || key == SDLK_RETURN)
+	else if(key == 'B' || (key == 'b' && (mod & KMOD_SHIFT)))
 		Buy(1000000000);
-	else if(key == 'S' || key == SDLK_BACKSPACE)
+	else if(key == 'S' || (key == 's' && (mod & KMOD_SHIFT)))
 	{
 		for(const auto &it : GameData::Commodities())
 		{


### PR DESCRIPTION
**PlayerInfoPanel:**
- added key **i** to close the panel; it can now be toggled with **i**, analogous to the map with **m**  (before it opened the map)
- added key **p** to toggle park/unpark selected ships
- added key **a** to toggle park all/unpark all  
   (is there a reason these were not activated in the first place?)

**ShipInfoPanel:**
- added key **r** to rename the ship

**TradingPanel:**
- changed _Buy One_ to **Left-Arrow** from **Return**  (there's also **Space**)
- changed _Sell One_ to **Right-Arrow** from **Backspace**  (there's also **Delete**)
   (you could already scroll through the commodities with **Up** and **Down**)
- changed _Buy All_ to **Return** from **Shift-b**  (since **Shift** is already used as x5 modifier and **b** for Bank)
- changed _Sell All_ to **Backspace** from **Shift-s**  (... **s** used for Spaceport)
