### PR TITLE
reworked energy and heat balance table in ShipInfoDisplay

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -299,9 +299,6 @@ tip "sum:"
 tip "capacity:"
 	`Energy and heat storage capacity. Energy capacity allows a ship to temporarily draw more energy than it produces. The heat capacity is the heat a ship can build up before overheating.`
 
-tip "buffer time:"
-	`Time until the energy storage is depleted or the ship overheats when all systems are running.`
-
 
 
 # Outfit categories:

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -293,8 +293,14 @@ tip "repairing hull:"
 tip "charging shields:"
 	`Energy consumed and heat generated when this ship is recharging its shields. This is in addition to the "idle" amount.`
 
-tip "max:"
-	`Energy storage capacity and maximum safe level for heat generation. Energy capacity allows a ship to temporarily draw more energy than it produces. The heat maximum is the highest your heat generation can be without eventually causing your ship to overheat.`
+tip "sum:"
+	`Energy and heat balance with all the ships systems running. With a negative energy balance having some energy storage capacity is advised. A positive heat balance can eventually cause the ship to overheat.`
+
+tip "capacity:"
+	`Energy and heat storage capacity. Energy capacity allows a ship to temporarily draw more energy than it produces. The heat capacity is the heat a ship can build up before overheating.`
+
+tip "buffer time:"
+	`Time until the energy storage is depleted or the ship overheats when all systems are running.`
 
 
 

--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -124,7 +124,10 @@ string Format::Decimal(double value, int places)
 	double integer;
 	double fraction = fabs(modf(value, &integer));
 	
-	string result = to_string(static_cast<int>(integer)) + ".";
+	string result = to_string(static_cast<int>(integer));
+	if(places)
+		result += ".";
+	
 	while(places--)
 	{
 		fraction = modf(fraction * 10., &integer);

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -293,33 +293,33 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	double sumHeat = idleHeat + movingHeat + firingHeat + (shieldHeat + hullHeat);
 	
 	tableLabels.push_back("idle:");
-	energyTable.push_back(Format::Number(60. * idleEnergy));
-	heatTable.push_back(Format::Number(60. * idleHeat));
+	energyTable.push_back(Format::Decimal(60. * idleEnergy, 0));
+	heatTable.push_back(Format::Decimal(60. * idleHeat, 0));
 	attributesHeight += 20;
 	tableLabels.push_back("moving:");
-	energyTable.push_back(Format::Number(-60. * movingEnergy));
-	heatTable.push_back(Format::Number(60. * movingHeat));
+	energyTable.push_back(Format::Decimal(-60. * movingEnergy, 0));
+	heatTable.push_back(Format::Decimal(60. * movingHeat,0 ));
 	attributesHeight += 20;
 	tableLabels.push_back("firing:");
-	energyTable.push_back(Format::Number(-60. * firingEnergy));
-	heatTable.push_back(Format::Number(60. * firingHeat));
+	energyTable.push_back(Format::Decimal(-60. * firingEnergy, 0));
+	heatTable.push_back(Format::Decimal(60. * firingHeat, 0));
 	attributesHeight += 20;
 	tableLabels.push_back((shieldEnergy && hullEnergy) ? "shields / hull:" :
 		hullEnergy ? "repairing hull:" : "charging shields:");
-	energyTable.push_back(Format::Number(-60. * (shieldEnergy + hullEnergy)));
-	heatTable.push_back(Format::Number(60. * (shieldHeat + hullHeat)));
+	energyTable.push_back(Format::Decimal(-60. * (shieldEnergy + hullEnergy), 0));
+	heatTable.push_back(Format::Decimal(60. * (shieldHeat + hullHeat), 0));
 	attributesHeight += 20;
 	tableLabels.push_back("sum:");
-	energyTable.push_back(Format::Number(60. * sumEnergy));
-	heatTable.push_back(Format::Number(60. * sumHeat));
+	energyTable.push_back(Format::Decimal(60. * sumEnergy, 0));
+	heatTable.push_back(Format::Decimal(60. * sumHeat, 0));
 	attributesHeight += 20;
 	tableLabels.push_back("capacity:");
-	energyTable.push_back(Format::Number(attributes.Get("energy capacity")));
-	heatTable.push_back(Format::Number(max(emptyMass * 100 - ship.IdleHeat(), 0.)));
+	energyTable.push_back(Format::Decimal(attributes.Get("energy capacity"), 0));
+	heatTable.push_back(Format::Decimal(max(emptyMass * 100 - ship.IdleHeat(), 0.), 0));
 	attributesHeight += 20;
 	tableLabels.push_back("buffer time:");
-	energyTable.push_back((sumEnergy < 0) ? Format::Number((int)(attributes.Get("energy capacity") / (-60 * sumEnergy))) : "-");
-	heatTable.push_back((sumHeat > 0) ? Format::Number((int)((max(emptyMass * 100 - ship.IdleHeat(), 0.)) / (60 * sumHeat))) : "-");
+	energyTable.push_back((sumEnergy < 0) ? Format::Decimal(attributes.Get("energy capacity") / (-60 * sumEnergy), 0) : "-");
+	heatTable.push_back((sumHeat > 0) ? Format::Decimal(max(emptyMass * 100 - ship.IdleHeat(), 0.) / (60 * sumHeat), 0) : "-");
 	// Pad by 10 pixels on the top and bottom.
 	attributesHeight += 30;
 }

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -316,10 +316,6 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	tableLabels.push_back("capacity:");
 	energyTable.push_back(Format::Decimal(attributes.Get("energy capacity"), 0));
 	heatTable.push_back(Format::Decimal(max(emptyMass * 100. - ship.IdleHeat(), 0.), 0));
-	attributesHeight += 20;
-	tableLabels.push_back("buffer time:");
-	energyTable.push_back((sumEnergy < 0) ? Format::Decimal(attributes.Get("energy capacity") / (-60. * sumEnergy), 0) : "-");
-	heatTable.push_back((sumHeat > 0) ? Format::Decimal(max(emptyMass * 100. - ship.IdleHeat(), 0.) / (60. * sumHeat), 0) : "-");
 	// Pad by 10 pixels on the top and bottom.
 	attributesHeight += 30;
 }

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -315,11 +315,11 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	attributesHeight += 20;
 	tableLabels.push_back("capacity:");
 	energyTable.push_back(Format::Decimal(attributes.Get("energy capacity"), 0));
-	heatTable.push_back(Format::Decimal(max(emptyMass * 100 - ship.IdleHeat(), 0.), 0));
+	heatTable.push_back(Format::Decimal(max(emptyMass * 100. - ship.IdleHeat(), 0.), 0));
 	attributesHeight += 20;
 	tableLabels.push_back("buffer time:");
-	energyTable.push_back((sumEnergy < 0) ? Format::Decimal(attributes.Get("energy capacity") / (-60 * sumEnergy), 0) : "-");
-	heatTable.push_back((sumHeat > 0) ? Format::Decimal(max(emptyMass * 100 - ship.IdleHeat(), 0.) / (60 * sumHeat), 0) : "-");
+	energyTable.push_back((sumEnergy < 0) ? Format::Decimal(attributes.Get("energy capacity") / (-60. * sumEnergy), 0) : "-");
+	heatTable.push_back((sumHeat > 0) ? Format::Decimal(max(emptyMass * 100. - ship.IdleHeat(), 0.) / (60. * sumHeat), 0) : "-");
 	// Pad by 10 pixels on the top and bottom.
 	attributesHeight += 30;
 }


### PR DESCRIPTION
The energy and heat balance in the outfitter's info panel is a bit inconsistent and hard to make use of without a calculator. And even then it is missing an important information: The heat capacity.

Lets take a look at the default Firebird.

**What we have now:**
![old-balance](https://user-images.githubusercontent.com/34216542/38772745-74456d3e-403e-11e8-8d9a-897db4ca2c5a.png)
- _max_ lists two different quantities, a capacity for the energy and a dissipation rate for the heat
- What we really want to know is how long the energy lasts
   So we have to calculate 4800 / (336-180-594-30) = 10s, and do this every time we change the outfit
- for the heat we have the max rate so we calculate (1194 + 312 + 1920) - 2289 = 1137
   We produce more heat than we dissipate, so we'd like to know how long we have before we overheat
   Unfortunately there is no way of knowing without the formula for the heat capacity and looking into the ship definition for the dissipation factor


**This PR does the following changes:**
![new-balance](https://user-images.githubusercontent.com/34216542/38772851-b43fe1ec-4040-11e8-9c48-4a51b77af56a.png)
- displays the heat dissipation as negative _idle_ heat rate
- adds a _sum_ row
- displays the _heat capacity_ (remaining after idle heat level) next to the _energy capacity_
- calculates the _time_ until the capacity is drained/reached under full load (in case of negative balance)


**Explanations in the tooltips:**
- sum: `Energy and heat balance with all the ships systems running. With a negative energy balance having some energy storage capacity is advised. A positive heat balance can eventually cause the ship to overheat.`

- capacity: `Energy and heat storage capacity. Energy capacity allows a ship to temporarily draw more energy than it produces. The heat capacity is the heat a ship can build up before overheating.`

- buffer time: `Time until the energy storage is depleted or the ship overheats when all systems are running.`

