### PR TITLE
Add a mission on assisting Navy ships

### DIFF
--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -43,7 +43,7 @@ mission "Navy emergency"
 	repeat
 	deadline
 	passengers 1 3
-	description "Deliver <fare> to <destination> by <date>: the military hospital is waiting for you."
+	description "Deliver <fare> to <destination> by <date>; the military hospital is waiting for you."
 	to offer
 		"reputation: Navy (Oathkeeper)" > 100
 		"passenger space" > <bunks>
@@ -55,7 +55,7 @@ mission "Navy emergency"
 		planet Farpoint
 	on offer
 		conversation
-			`When you repear the <origin>, the captain thanks you but add: "We had injuries during the battle. Could you bring them to Farpoint hospital in emergency? It would only be <bunks> <passengers>."`
+			`When you repair the <origin>, the captain thanks you, but adds, "We had injuries during the battle. Could you bring the injured to the military hospital on Farpoint? It would only be <bunks> <passengers>."`
 			choice
 				`"Sure, I'll do it."`
 					accept
@@ -64,4 +64,4 @@ mission "Navy emergency"
 	on complete
 		"reputation: Navy (Oathkeeper)" += 2
 		payment 32000 100
-		dialog "The Navy's nurses take care of the wounded and transport them from the spaceport to the military hospital. An officier thanks you with a payment of <payment>."
+		dialog "The Navy's nurses take care of the wounded and transport them from the spaceport to the military hospital. An officer thanks you with a payment of <payment>."

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -37,3 +37,31 @@ mission "Assisting Hai"
 			`Knowing you risked your life to save the <origin>, the captain gives you <payment>.`
 				decline
 	destination Hai-home
+
+mission "Navy emergency"
+	assisting
+	repeat
+	deadline
+	passengers 1 3
+	description "Deliver <fare> to <destination> by <date>: the military hospital is waiting for you."
+	to offer
+		"reputation: Navy (Oathkeeper)" > 100
+		"passenger space" > <bunks>
+		random < 15
+	source
+		government "Navy (Oathkeeper)"
+		system "Arneb" "Hatysa" "Alnilam" "Unagi" "Almaaz" "Mintaka" "Gorvi" "Tortor" "Fah Root" "Rigel" "Hassaleh" "Danoa" "Rajak" "Sumar" "Ultima Thule" "Cardax" "Volax" "Moktar"
+	destination
+		planet Farpoint
+	on offer
+		conversation
+			`When you repear the <origin>, the captain thanks you but add: "We had injuries during the battle. Could you bring them to Farpoint hospital in emergency? It would only be <bunks> <passengers>."`
+			choice
+				`"Sure, I'll do it."`
+					accept
+				`"Sorry, it's not on my way."`
+					decline
+	on complete
+		"reputation: Navy (Oathkeeper)" += 2
+		payment 32000 100
+		dialog "The Navy's nurses take care of the wounded and transport them from the spaceport to the military hospital. An officier thanks you with a payment of <payment>."

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -46,16 +46,14 @@ mission "Navy emergency"
 	description "Deliver <fare> to <destination> by <date>; the military hospital is waiting for you."
 	to offer
 		"reputation: Navy (Oathkeeper)" > 100
-		"passenger space" > <bunks>
 		random < 15
 	source
 		government "Navy (Oathkeeper)"
 		system "Arneb" "Hatysa" "Alnilam" "Unagi" "Almaaz" "Mintaka" "Gorvi" "Tortor" "Fah Root" "Rigel" "Hassaleh" "Danoa" "Rajak" "Sumar" "Ultima Thule" "Cardax" "Volax" "Moktar"
-	destination
-		planet Farpoint
+	destination "Farpoint"
 	on offer
 		conversation
-			`When you repair the <origin>, the captain thanks you, but adds, "We had injuries during the battle. Could you bring the injured to the military hospital on Farpoint? It would only be <bunks> <passengers>."`
+			`When you repair the <origin>, the captain thanks you, but adds, "We had injuries during the battle. Could you bring the injured to the military hospital on <destination>? It would only be <bunks> <passengers>."`
 			choice
 				`"Sure, I'll do it."`
 					accept


### PR DESCRIPTION
Add a mission on assisting Navy ships where the captain ask you to bring wounded to Farpoint hospital.

Feel free to correct the wordings, english is not my mother-tongue.
Maybe it should also be rebalanced.

Know issue: this occurs also on drones, which have no passengers, because AFAIK I have no way to add conditions on ship model or on ship crew. But if you could find a workaround...