### PR TITLE
Fixed map search centering at non-default zoom.

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -97,7 +97,7 @@ MapPanel::MapPanel(PlayerInfo &player, int commodity, const System *special)
 	TallyEscorts(player.Ships(), escortSystems);
 	
 	if(selectedSystem)
-		center = Point(0., 0.) - selectedSystem->Position();
+		CenterOnSystem(selectedSystem);
 }
 
 
@@ -510,7 +510,7 @@ void MapPanel::Find(const string &name)
 			{
 				bestIndex = index;
 				selectedSystem = &it.second;
-				center = -selectedSystem->Position();
+				CenterOnSystem(selectedSystem);
 				if(!index)
 				{
 					selectedPlanet = nullptr;
@@ -526,7 +526,7 @@ void MapPanel::Find(const string &name)
 			{
 				bestIndex = index;
 				selectedSystem = it.second.GetSystem();
-				center = -selectedSystem->Position();
+				CenterOnSystem(selectedSystem);
 				if(!index)
 				{
 					selectedPlanet = &it.second;
@@ -566,6 +566,13 @@ int MapPanel::Search(const string &str, const string &sub)
 	auto it = search(str.begin(), str.end(), sub.begin(), sub.end(),
 		[](char a, char b) { return toupper(a) == toupper(b); });
 	return (it == str.end() ? -1 : it - str.begin());
+}
+
+
+
+void MapPanel::CenterOnSystem(const System *system)
+{
+	center = Point(0., -80.) / Zoom() - system->Position();
 }
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -510,7 +510,7 @@ void MapPanel::Find(const string &name)
 			{
 				bestIndex = index;
 				selectedSystem = &it.second;
-				center = Zoom() * (Point() - selectedSystem->Position());
+				center = -selectedSystem->Position();
 				if(!index)
 				{
 					selectedPlanet = nullptr;
@@ -526,7 +526,7 @@ void MapPanel::Find(const string &name)
 			{
 				bestIndex = index;
 				selectedSystem = it.second.GetSystem();
-				center = Zoom() * (Point() - selectedSystem->Position());
+				center = -selectedSystem->Position();
 				if(!index)
 				{
 					selectedPlanet = &it.second;

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -111,6 +111,9 @@ protected:
 	std::map<const Government *, double> closeGovernments;
 	// Systems in which your escorts are located.
 	std::map<const System *, bool> escortSystems;
+	// Center the view on the given system (may actually be slightly offset
+	// to account for panels on the screen).
+	void CenterOnSystem(const System *system);
 	
 	
 private:

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -99,7 +99,7 @@ MissionPanel::MissionPanel(PlayerInfo &player)
 
 	// Center the system slightly above the center of the screen because the
 	// lower panel is taking up more space than the upper one.
-	center = Point(0., -80.) - selectedSystem->Position();
+	CenterOnSystem(selectedSystem);
 }
 
 
@@ -266,7 +266,7 @@ bool MissionPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 	else if(acceptedIt != accepted.end())
 		selectedSystem = acceptedIt->Destination()->GetSystem();
 	if(selectedSystem)
-		center = Point(0., -80.) - selectedSystem->Position();
+		CenterOnSystem(selectedSystem);
 	
 	return true;
 }
@@ -291,7 +291,7 @@ bool MissionPanel::Click(int x, int y, int clicks)
 			acceptedIt = accepted.end();
 			dragSide = -1;
 			selectedSystem = availableIt->Destination()->GetSystem();
-			center = Point(0., -80.) - selectedSystem->Position();
+			CenterOnSystem(selectedSystem);
 			return true;
 		}
 	}
@@ -309,7 +309,7 @@ bool MissionPanel::Click(int x, int y, int clicks)
 			availableIt = available.end();
 			dragSide = 1;
 			selectedSystem = acceptedIt->Destination()->GetSystem();
-			center = Point(0., -80.) - selectedSystem->Position();
+			CenterOnSystem(selectedSystem);
 			return true;
 		}
 	}


### PR DESCRIPTION
The result of a search in the map is currently centered incorrectly when the zoom is not at the default level.

Results of searching for "Sol" at +1 zoom before and after the change:
![2018-04-17-02-13-11 307659972](https://user-images.githubusercontent.com/596106/38860988-56eab826-41e6-11e8-9727-b4ad222e6ed9.png)
![2018-04-17-02-13-34 280366556](https://user-images.githubusercontent.com/596106/38860989-571923fa-41e6-11e8-8a79-cdb313e4c12b.png)
