### PR TITLE
Fast boolean options

### DIFF
--- a/EndlessSky.cbp
+++ b/EndlessSky.cbp
@@ -172,6 +172,8 @@
 		<Unit filename="source/HailPanel.h" />
 		<Unit filename="source/Hardpoint.cpp" />
 		<Unit filename="source/Hardpoint.h" />
+		<Unit filename="source/Help.cpp" />
+		<Unit filename="source/Help.h" />
 		<Unit filename="source/HiringPanel.cpp" />
 		<Unit filename="source/HiringPanel.h" />
 		<Unit filename="source/ImageBuffer.cpp" />

--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5155CD731DBB9FF900EF090B /* Depreciation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5155CD711DBB9FF900EF090B /* Depreciation.cpp */; };
 		6245F8251D301C7400A7A094 /* Body.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6245F8231D301C7400A7A094 /* Body.cpp */; };
 		6245F8281D301C9000A7A094 /* Hardpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6245F8261D301C9000A7A094 /* Hardpoint.cpp */; };
+		6245F8281D301CA000A7A094 /* Help.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6245F8261D301CA000A7A094 /* Help.cpp */; };
 		628BDAEF1CC5DC950062BCD2 /* PlanetLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 628BDAED1CC5DC950062BCD2 /* PlanetLabel.cpp */; };
 		62A405BA1D47DA4D0054F6A0 /* FogShader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62A405B81D47DA4D0054F6A0 /* FogShader.cpp */; };
 		62C3111A1CE172D000409D91 /* Flotsam.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62C311181CE172D000409D91 /* Flotsam.cpp */; };
@@ -176,6 +177,8 @@
 		6245F8241D301C7400A7A094 /* Body.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Body.h; path = source/Body.h; sourceTree = "<group>"; };
 		6245F8261D301C9000A7A094 /* Hardpoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Hardpoint.cpp; path = source/Hardpoint.cpp; sourceTree = "<group>"; };
 		6245F8271D301C9000A7A094 /* Hardpoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Hardpoint.h; path = source/Hardpoint.h; sourceTree = "<group>"; };
+		6245F8261D301CA000A7A094 /* Help.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Help.cpp; path = source/Help.cpp; sourceTree = "<group>"; };
+		6245F8271D301CA000A7A094 /* Help.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Help.h; path = source/Help.h; sourceTree = "<group>"; };
 		628BDAED1CC5DC950062BCD2 /* PlanetLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PlanetLabel.cpp; path = source/PlanetLabel.cpp; sourceTree = "<group>"; };
 		628BDAEE1CC5DC950062BCD2 /* PlanetLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlanetLabel.h; path = source/PlanetLabel.h; sourceTree = "<group>"; };
 		62A405B81D47DA4D0054F6A0 /* FogShader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FogShader.cpp; path = source/FogShader.cpp; sourceTree = "<group>"; };
@@ -561,6 +564,8 @@
 				A968631E1AE6FD0B004FE1FE /* HailPanel.h */,
 				6245F8261D301C9000A7A094 /* Hardpoint.cpp */,
 				6245F8271D301C9000A7A094 /* Hardpoint.h */,
+				6245F8261D301CA000A7A094 /* Help.cpp */,
+				6245F8271D301CA000A7A094 /* Help.h */,
 				A968631F1AE6FD0B004FE1FE /* HiringPanel.cpp */,
 				A96863201AE6FD0B004FE1FE /* HiringPanel.h */,
 				A96863211AE6FD0B004FE1FE /* ImageBuffer.cpp */,
@@ -927,6 +932,7 @@
 				A96863E21AE6FD0E004FE1FE /* Phrase.cpp in Sources */,
 				628BDAEF1CC5DC950062BCD2 /* PlanetLabel.cpp in Sources */,
 				6245F8281D301C9000A7A094 /* Hardpoint.cpp in Sources */,
+				6245F8281D301CA000A7A094 /* Help.cpp in Sources */,
 				A96863C01AE6FD0E004FE1FE /* FontSet.cpp in Sources */,
 				A96863D61AE6FD0E004FE1FE /* Messages.cpp in Sources */,
 				A97C24ED1B17BE3C007DDFA1 /* MapShipyardPanel.cpp in Sources */,

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -170,8 +170,8 @@ void AI::IssueMoveTarget(const PlayerInfo &player, const Point &target, const Sy
 void AI::UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive)
 {
 	shift = (SDL_GetModState() & KMOD_SHIFT);
-	escortsUseAmmo = Preferences::Has("Escorts expend ammo");
-	escortsAreFrugal = Preferences::Has("Escorts use ammo frugally");
+	escortsUseAmmo = preferences.escortsExpendAmmo;
+	escortsAreFrugal = preferences.frugalEscorts;
 	
 	Command oldHeld = keyHeld;
 	keyHeld.ReadKeyboard();
@@ -333,8 +333,8 @@ void AI::Step(const PlayerInfo &player)
 	int targetTurn = 0;
 	int minerCount = 0;
 	const int maxMinerCount = minables.empty() ? 0 : 9;
-	bool opportunisticEscorts = !Preferences::Has("Turrets focus fire");
-	bool fightersRetreat = Preferences::Has("Damaged fighters retreat");
+	bool opportunisticEscorts = !preferences.turretsFocusFire;
+	bool fightersRetreat = preferences.damagedFightersRetreat;
 	for(const auto &it : ships)
 	{
 		// Skip any carried fighters or drones that are somehow in the list.
@@ -3097,8 +3097,8 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 		command |= Command::SCAN;
 	
 	const shared_ptr<const Ship> target = ship.GetTargetShip();
-	AimTurrets(ship, command, !Preferences::Has("Turrets focus fire"));
-	if(Preferences::Has("Automatic firing") && !ship.IsBoarding()
+	AimTurrets(ship, command, !preferences.turretsFocusFire);
+	if(preferences.automaticFiring && !ship.IsBoarding()
 			&& !(keyStuck | keyHeld).Has(Command::LAND | Command::JUMP | Command::BOARD)
 			&& (!target || target->GetGovernment()->IsEnemy()))
 		AutoFire(ship, command, false);
@@ -3143,8 +3143,8 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 			keyStuck = keyHeld;
 	}
 	bool shouldAutoAim = false;
-	if(Preferences::Has("Automatic aiming") && !command.Turn() && !ship.IsBoarding()
-			&& (Preferences::Has("Automatic firing") || keyHeld.Has(Command::PRIMARY))
+	if(preferences.automaticAiming && !command.Turn() && !ship.IsBoarding()
+			&& (preferences.automaticFiring || keyHeld.Has(Command::PRIMARY))
 			&& ((target && target->GetSystem() == ship.GetSystem() && target->IsTargetable())
 				|| ship.GetTargetAsteroid())
 			&& !keyStuck.Has(Command::LAND | Command::JUMP | Command::BOARD))
@@ -3238,7 +3238,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 	if(ship.HasBays() && isLaunching)
 	{
 		command |= Command::DEPLOY;
-		Deploy(ship, !Preferences::Has("Damaged fighters retreat"));
+		Deploy(ship, !preferences.damagedFightersRetreat);
 	}
 	if(isCloaking)
 		command |= Command::CLOAK;

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -61,7 +61,7 @@ BankPanel::BankPanel(PlayerInfo &player)
 // This is called each frame when the bank is active.
 void BankPanel::Step()
 {
-	DoHelp("bank");
+	DoHelp(Help::BANK);
 }
 
 

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -447,7 +447,7 @@ bool BoardingPanel::Drag(double dx, double dy)
 // The scroll wheel can be used to scroll the plunder list.
 bool BoardingPanel::Scroll(double dx, double dy)
 {
-	return Drag(0., dy * Preferences::ScrollSpeed());
+	return Drag(0., dy * preferences.scrollSpeed);
 }
 
 

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -276,7 +276,7 @@ bool ConversationPanel::Drag(double dx, double dy)
 // Handle the scroll wheel.
 bool ConversationPanel::Scroll(double dx, double dy)
 {
-	return Drag(0., dy * Preferences::ScrollSpeed());
+	return Drag(0., dy * preferences.scrollSpeed);
 }
 
 

--- a/source/DrawList.cpp
+++ b/source/DrawList.cpp
@@ -115,7 +115,7 @@ void DrawList::Draw() const
 {
 	SpriteShader::Bind();
 	
-	bool withBlur = Preferences::Has("Render motion blur");
+	bool withBlur = preferences.renderMotionBlur;
 	for(const SpriteShader::Item &item : items)
 		SpriteShader::Add(item, withBlur);
 	

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -156,7 +156,7 @@ Engine::Engine(PlayerInfo &player)
 	: player(player), ai(ships, asteroids.Minables(), flotsam),
 	shipCollisions(256, 32)
 {
-	zoom = Preferences::ViewZoom();
+	zoom = preferences.ViewZoom();
 	
 	// Start the thread for doing calculations.
 	calcThread = thread(&Engine::ThreadEntryPoint, this);
@@ -404,7 +404,7 @@ void Engine::Step(bool isActive)
 	// Smoothly zoom in and out.
 	if(isActive)
 	{
-		double zoomTarget = Preferences::ViewZoom();
+		double zoomTarget = preferences.ViewZoom();
 		if(zoom < zoomTarget)
 			zoom = min(zoomTarget, zoom * 1.03);
 		else if(zoom > zoomTarget)
@@ -412,7 +412,7 @@ void Engine::Step(bool isActive)
 	}
 		
 	// Draw a highlight to distinguish the flagship from other ships.
-	if(flagship && !flagship->IsDestroyed() && Preferences::Has("Highlight player's flagship"))
+	if(flagship && !flagship->IsDestroyed() && preferences.highlightPlayersFlagship)
 	{
 		highlightSprite = flagship->GetSprite();
 		highlightUnit = flagship->Unit() * zoom;
@@ -492,7 +492,7 @@ void Engine::Step(bool isActive)
 	
 	// Create the status overlays.
 	statuses.clear();
-	if(isActive && Preferences::Has("Show status overlays"))
+	if(isActive && preferences.showStatusOverlays)
 		for(const auto &it : ships)
 		{
 			if(!it->GetGovernment() || it->GetSystem() != currentSystem || it->Cloaking() == 1.)
@@ -512,7 +512,7 @@ void Engine::Step(bool isActive)
 	
 	// Create the planet labels.
 	labels.clear();
-	if(currentSystem && Preferences::Has("Show planet labels"))
+	if(currentSystem && preferences.showPlanetLabels)
 	{
 		for(const StellarObject &object : currentSystem->Objects())
 		{
@@ -533,7 +533,7 @@ void Engine::Step(bool isActive)
 	if(flagship && flagship->Hull())
 	{
 		Point shipFacingUnit(0., -1.);
-		if(Preferences::Has("Rotate flagship in HUD"))
+		if(preferences.rotateFlagshipInHud)
 			shipFacingUnit = flagship->Facing().Unit();
 		
 		info.SetSprite("player sprite", flagship->GetSprite(), shipFacingUnit, flagship->GetFrame(step));
@@ -884,7 +884,7 @@ void Engine::Draw() const
 		for(int i = 0; i < 2; ++i)
 			SpriteShader::Draw(mark[i], center + Point(dx[i], 0.), 1., targetSwizzle);
 	}
-	if(jumpCount && Preferences::Has("Show mini-map"))
+	if(jumpCount && preferences.showMinimap)
 		MapPanel::DrawMiniMap(player, .5 * min(1., jumpCount / 30.), jumpInProgress, step);
 	
 	// Draw ammo status.
@@ -932,7 +932,7 @@ void Engine::Draw() const
 	// filling the entire backlog of sprites before landing on a planet.
 	GameData::Progress();
 	
-	if(Preferences::Has("Show CPU / GPU load"))
+	if(preferences.showCpuGpuLoad)
 	{
 		string loadString = to_string(lround(load * 100.)) + "% CPU";
 		Color color = *colors.Get("medium");
@@ -955,7 +955,7 @@ void Engine::Click(const Point &from, const Point &to, bool hasShift)
 	const Interface *interface = GameData::Interfaces().Get("hud");
 	Point radarCenter = interface->GetPoint("radar");
 	double radarRadius = interface->GetValue("radar radius");
-	if(Preferences::Has("Clickable radar display") && (from - radarCenter).Length() <= radarRadius)
+	if(preferences.clickableRadarDisplay && (from - radarCenter).Length() <= radarRadius)
 		isRadarClick = true;
 	else
 		isRadarClick = false;
@@ -981,7 +981,7 @@ void Engine::RClick(const Point &point)
 	const Interface *interface = GameData::Interfaces().Get("hud");
 	Point radarCenter = interface->GetPoint("radar");
 	double radarRadius = interface->GetValue("radar radius");
-	if(Preferences::Has("Clickable radar display") && (point - radarCenter).Length() <= radarRadius)
+	if(preferences.clickableRadarDisplay && (point - radarCenter).Length() <= radarRadius)
 		clickPoint = (point - radarCenter) / RADAR_SCALE;
 	else
 		clickPoint = point / zoom;
@@ -1184,7 +1184,7 @@ void Engine::CalculateStep()
 						it.GetPlanet()->WormholeDestination(playerSystem) == flagship->GetSystem())
 					player.Visit(it.GetPlanet());
 		
-		doFlash = Preferences::Has("Show hyperspace flash");
+		doFlash = preferences.showHyperspaceFlash;
 		playerSystem = flagship->GetSystem();
 		player.SetSystem(playerSystem);
 		EnterSystem();
@@ -1861,7 +1861,7 @@ void Engine::FillRadar()
 		--alarmTime;
 	else if(hasHostiles && !hadHostiles)
 	{
-		if(Preferences::Has("Warning siren"))
+		if(preferences.warningSiren)
 			Audio::Play(Audio::Get("alarm"));
 		alarmTime = 180;
 		hadHostiles = true;

--- a/source/Help.cpp
+++ b/source/Help.cpp
@@ -1,0 +1,64 @@
+/* Help.cpp
+Copyright (c) 2014 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "Help.h"
+
+#include "Preferences.h"
+#include "GameData.h"
+
+using namespace std;
+
+namespace {
+	static const char *TopicNames[Help::MAX] =
+	{
+		"bank",
+		"basics 1",
+		"basics 2",
+		"dead",
+		"disabled",
+		"hiring",
+		"jobs",
+		"lost 1",
+		"lost 2",
+		"lost 3",
+		"lost 4",
+		"lost 5",
+		"lost 6",
+		"lost 7",
+		"map",
+		"multiple ships",
+		"navigation",
+		"outfitter",
+		"stranded",
+		"trading",
+	};
+}
+
+bool Help::ShouldShow(Topic topic)
+{
+	string preference = string("help: ") + TopicNames[topic];
+	if(Preferences::Has(preference))
+		return false;
+
+	Preferences::Set(preference);
+	return true;
+}
+
+const char *Help::TopicName(Topic topic)
+{
+	return TopicNames[topic];
+}
+
+std::string Help::HelpMessage(Topic topic)
+{
+	return GameData::HelpMessage(TopicName(topic));
+}

--- a/source/Help.cpp
+++ b/source/Help.cpp
@@ -45,17 +45,25 @@ namespace {
 
 bool Help::ShouldShow(Topic topic)
 {
-	string preference = string("help: ") + TopicNames[topic];
-	if(Preferences::Has(preference))
+	bool& seen = preferences.Get(string("help: ") + TopicNames[topic]);
+	if(seen)
 		return false;
 
-	Preferences::Set(preference);
+	seen = true;
 	return true;
 }
 
 const char *Help::TopicName(Topic topic)
 {
 	return TopicNames[topic];
+}
+
+Help::Topic Help::FindTopic(string name)
+{
+	for(int t=0; t<MAX; t++)
+		if(name == TopicNames[t])
+			return (Topic)t;
+	return (Topic)-1;
 }
 
 std::string Help::HelpMessage(Topic topic)

--- a/source/Help.h
+++ b/source/Help.h
@@ -1,0 +1,61 @@
+/* Help.h
+Copyright (c) 2014 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef HELP_H_
+#define HELP_H_
+
+#include <string>
+
+// Class for context help messages.
+class Help {
+public:
+	enum Topic {
+		BANK,
+		BASICS_1,
+		BASICS_2,
+		DEAD,
+		DISABLED,
+		HIRING,
+		JOBS,
+		LOST_1,
+		LOST_2,
+		LOST_3,
+		LOST_4,
+		LOST_5,
+		LOST_6,
+		LOST_7,
+		MAP,
+		MULTIPLE_SHIPS,
+		NAVIGATION,
+		OUTFITTER,
+		STRANDED,
+		TRADING,
+
+		MAX
+	};
+
+	// This returns true for the first time it invoked with a topic.
+	// The next invocation with the same topic will return false.
+	static bool ShouldShow(Topic);
+
+	// Get the help message for this topic.
+	static std::string HelpMessage(Topic);
+
+private:
+	// Get the topic label for data and save files.
+	static const char* TopicName(Topic);
+
+};
+
+
+
+#endif

--- a/source/Help.h
+++ b/source/Help.h
@@ -54,6 +54,10 @@ private:
 	// Get the topic label for data and save files.
 	static const char* TopicName(Topic);
 
+	// Get the topic from its label.
+	static Topic FindTopic(std::string);
+
+	friend class Preferences;
 };
 
 

--- a/source/HiringPanel.cpp
+++ b/source/HiringPanel.cpp
@@ -34,7 +34,7 @@ HiringPanel::HiringPanel(PlayerInfo &player)
 
 void HiringPanel::Step()
 {
-	DoHelp("hiring");
+	DoHelp(Help::HIRING);
 }
 
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -359,7 +359,7 @@ bool LoadPanel::Drag(double dx, double dy)
 
 bool LoadPanel::Scroll(double dx, double dy)
 {
-	return Drag(0., dy * Preferences::ScrollSpeed());
+	return Drag(0., dy * preferences.scrollSpeed);
 }
 
 

--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -250,7 +250,7 @@ bool LogbookPanel::Drag(double dx, double dy)
 
 bool LogbookPanel::Scroll(double dx, double dy)
 {
-	return Drag(0., dy * Preferences::ScrollSpeed());
+	return Drag(0., dy * preferences.scrollSpeed);
 }
 
 

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -94,14 +94,14 @@ void MainPanel::Step()
 	{
 		// Check if any help messages should be shown.
 		if(isActive && flagship->IsTargetable())
-			isActive = !DoHelp("navigation");
+			isActive = !DoHelp(Help::NAVIGATION);
 		if(isActive && flagship->IsDestroyed())
-			isActive = !DoHelp("dead");
+			isActive = !DoHelp(Help::DEAD);
 		if(isActive && flagship->IsDisabled())
-			isActive = !DoHelp("disabled");
+			isActive = !DoHelp(Help::DISABLED);
 		bool canRefuel = player.GetSystem()->HasFuelFor(*flagship);
 		if(isActive && !flagship->IsHyperspacing() && !flagship->JumpsRemaining() && !canRefuel)
-			isActive = !DoHelp("stranded");
+			isActive = !DoHelp(Help::STRANDED);
 		if(isActive && flagship->Position().Length() > 10000. && player.GetDate() <= GameData::Start().GetDate() + 4 
 			&& !flagship->IsHyperspacing())
 		{
@@ -109,11 +109,10 @@ void MainPanel::Step()
 			int count = 1 + lostness / 3600;
 			if(count > lostCount && count <= 7)
 			{
-				string message = "lost 1";
-				message.back() += lostCount;
+				Help::Topic topic = (Help::Topic)((int)Help::LOST_1 + lostCount);
 				++lostCount;
 				
-				GetUI()->Push(new Dialog(GameData::HelpMessage(message)));
+				GetUI()->Push(new Dialog(Help::HelpMessage(topic)));
 			}
 		}
 	}

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -156,7 +156,7 @@ void MainPanel::Draw()
 			isDragging = false;
 	}
 	
-	if(Preferences::Has("Show CPU / GPU load"))
+	if(preferences.showCpuGpuLoad)
 	{
 		string loadString = to_string(lround(load * 100.)) + "% GPU";
 		const Color &color = *GameData::Colors().Get("medium");
@@ -196,13 +196,13 @@ bool MainPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		show = command;
 	else if(command.Has(Command::AMMO))
 	{
-		Preferences::ToggleAmmoUsage();
-		Messages::Add("Your escorts will now expend ammo: " + Preferences::AmmoUsage() + ".");
+		preferences.ToggleAmmoUsage();
+		Messages::Add("Your escorts will now expend ammo: " + preferences.AmmoUsage() + ".");
 	}
 	else if(key == '-' && !command)
-		Preferences::ZoomViewOut();
+		preferences.ZoomViewOut();
 	else if(key == '=' && !command)
-		Preferences::ZoomViewIn();
+		preferences.ZoomViewIn();
 	else if(key >= '0' && key <= '9' && !command)
 		engine.SelectGroup(key - '0', mod & KMOD_SHIFT, mod & (KMOD_CTRL | KMOD_GUI));
 	else
@@ -274,9 +274,9 @@ bool MainPanel::Release(int x, int y)
 bool MainPanel::Scroll(double dx, double dy)
 {
 	if(dy < 0)
-		Preferences::ZoomViewOut();
+		preferences.ZoomViewOut();
 	else if(dy > 0)
-		Preferences::ZoomViewIn();
+		preferences.ZoomViewIn();
 	else
 		return false;
 	

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -93,7 +93,7 @@ MapDetailPanel::MapDetailPanel(const MapPanel &panel)
 void MapDetailPanel::Step()
 {
 	if(!player.GetPlanet())
-		DoHelp("map");
+		DoHelp(Help::MAP);
 }
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -109,7 +109,7 @@ void MapPanel::Draw()
 	for(const auto &it : GameData::Galaxies())
 		SpriteShader::Draw(it.second.GetSprite(), Zoom() * (center + it.second.Position()), Zoom());
 	
-	if(Preferences::Has("Hide unexplored map regions"))
+	if(preferences.hideUnexploredMapRegions)
 		FogShader::Draw(center, Zoom(), player);
 	
 	// Draw the "visible range" circle around your current location.
@@ -660,7 +660,7 @@ void MapPanel::DrawTravelPlan()
 // Communicate the location of non-destroyed, player-owned ships.
 void MapPanel::DrawEscorts()
 {
-	if(!Preferences::Has("Show escort systems on map"))
+	if(!preferences.showEscortSystemsOnMap)
 		return;
 	
 	// Fill in the center of any system containing the player's ships, if the

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -181,7 +181,7 @@ bool MapSalesPanel::Drag(double dx, double dy)
 bool MapSalesPanel::Scroll(double dx, double dy)
 {
 	if(isDragging)
-		scroll = min(0., max(-maxScroll, scroll + dy * 2.5 * Preferences::ScrollSpeed()));
+		scroll = min(0., max(-maxScroll, scroll + dy * 2.5 * preferences.scrollSpeed));
 	else
 		return MapPanel::Scroll(dx, dy);
 	

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -139,7 +139,7 @@ MissionPanel::MissionPanel(const MapPanel &panel)
 
 void MissionPanel::Step()
 {
-	DoHelp("jobs");
+	DoHelp(Help::JOBS);
 }
 
 

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -424,7 +424,7 @@ bool MissionPanel::Hover(int x, int y)
 bool MissionPanel::Scroll(double dx, double dy)
 {
 	if(dragSide)
-		return Drag(0., dy * Preferences::ScrollSpeed());
+		return Drag(0., dy * preferences.scrollSpeed);
 	
 	return MapPanel::Scroll(dx, dy);
 }

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -73,7 +73,7 @@ OutfitterPanel::OutfitterPanel(PlayerInfo &player)
 void OutfitterPanel::Step()
 {
 	CheckRefill();
-	DoHelp("outfitter");
+	DoHelp(Help::OUTFITTER);
 	ShopPanel::Step();
 }
 

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Dialog.h"
 #include "FillShader.h"
 #include "GameData.h"
+#include "Help.h"
 #include "Preferences.h"
 #include "Screen.h"
 #include "UI.h"
@@ -239,19 +240,16 @@ int Panel::Modifier()
 
 // Display the given help message if it has not yet been shown. Return true
 // if the message was displayed.
-bool Panel::DoHelp(const string &name) const
+bool Panel::DoHelp(Help::Topic topic) const
 {
-	string preference = "help: " + name;
-	if(Preferences::Has(preference))
+	if(!Help::ShouldShow(topic))
 		return false;
-	
-	const string &message = GameData::HelpMessage(name);
+
+	const string &message = Help::HelpMessage(topic);
 	if(message.empty())
 		return false;
-	
-	Preferences::Set(preference);
+
 	ui->Push(new Dialog(message));
-	
 	return true;
 }
 

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef PANEL_H_
 #define PANEL_H_
 
+#include "Help.h"
 #include "Rectangle.h"
 
 #include <functional>
@@ -93,7 +94,7 @@ protected:
 	static int Modifier();
 	// Display the given help message if it has not yet been shown. Return true
 	// if the message was displayed.
-	bool DoHelp(const std::string &name) const;
+	bool DoHelp(Help::Topic topic) const;
 	
 	
 private:

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1009,7 +1009,7 @@ void PlayerInfo::Land(UI *ui)
 	
 	// Hire extra crew back if any were lost in-flight (i.e. boarding) or
 	// some bunks were freed up upon landing (i.e. completed missions).
-	if(Preferences::Has("Rehire extra crew when lost") && hasSpaceport && flagship)
+	if(preferences.rehireExtraCrewWhenLost && hasSpaceport && flagship)
 	{
 		int added = desiredCrew - flagship->Crew();
 		if(added > 0)

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -108,7 +108,7 @@ void PlayerInfoPanel::Step()
 	// If the player has acquired a second ship for the first time, explain to
 	// them how to reorder the ships in their fleet.
 	if(player.Ships().size() > 1)
-		DoHelp("multiple ships");
+		DoHelp(Help::MULTIPLE_SHIPS);
 }
 
 

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -452,7 +452,7 @@ bool PlayerInfoPanel::Release(int x, int y)
 
 bool PlayerInfoPanel::Scroll(double dx, double dy)
 {
-	return Scroll(dy * -.1 * Preferences::ScrollSpeed());
+	return Scroll(dy * -.1 * preferences.scrollSpeed);
 }
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -13,33 +13,69 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef PREFERENCES_H_
 #define PREFERENCES_H_
 
-#include <string>
+#include "Help.h"
 
+#include <string>
 
 
 class Preferences {
 public:
-	static void Load();
-	static void Save();
-	
-	static bool Has(const std::string &name);
-	static void Set(const std::string &name, bool on = true);
-	
+	void Load();
+	void Save();
+
+	bool& Get(std::string);
+
 	// Toogle the ammo usage preferences, cycling between "never," "frugally,"
 	// and "always."
-	static void ToggleAmmoUsage();
-	static std::string AmmoUsage();
-	
-	// Scroll speed preference.
-	static int ScrollSpeed();
-	static void SetScrollSpeed(int speed);
+	void ToggleAmmoUsage();
+	std::string AmmoUsage();
 	
 	// View zoom.
-	static double ViewZoom();
-	static bool ZoomViewIn();
-	static bool ZoomViewOut();
+	double ViewZoom();
+	bool ZoomViewIn();
+	bool ZoomViewOut();
+
+	// Preference values
+
+	// Display
+	int zoomIndex;
+	bool showStatusOverlays;
+	bool highlightPlayersFlagship;
+	bool rotateFlagshipInHud;
+	bool showPlanetLabels;
+	bool showMinimap;
+	bool fullscreen; // Implicit
+	bool maximized; // Implicit
+
+	// AI
+	bool automaticAiming;
+	bool automaticFiring;
+	bool escortsExpendAmmo;
+	bool frugalEscorts;
+	bool turretsFocusFire;
+	bool damagedFightersRetreat; // Hidden
+
+	// Performance
+	bool showCpuGpuLoad;
+	bool renderMotionBlur;
+	bool reduceLargeGraphics;
+	bool drawBackgroundHaze;
+	bool showHyperspaceFlash;
+
+	// Other
+	bool clickableRadarDisplay;
+	bool hideUnexploredMapRegions;
+	bool seenHelp[Help::MAX];
+	bool rehireExtraCrewWhenLost;
+	int scrollSpeed;
+	bool showEscortSystemsOnMap;
+	bool warningSiren;
+
+private:
+	bool* Find(std::string);
 };
 
 
+extern Preferences preferences;
 
 #endif

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -64,7 +64,7 @@ void ShopPanel::Step()
 	// If the player has acquired a second ship for the first time, explain to
 	// them how to reorder the ships in their fleet.
 	if(player.Ships().size() > 1)
-		DoHelp("multiple ships");
+		DoHelp(Help::MULTIPLE_SHIPS);
 	// Perform autoscroll to bring item details into view.
 	if(scrollDetailsIntoView && mainDetailHeight > 0)
 	{

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -799,7 +799,7 @@ bool ShopPanel::Release(int x, int y)
 bool ShopPanel::Scroll(double dx, double dy)
 {
 	scrollDetailsIntoView = false;
-	return DoScroll(dy * 2.5 * Preferences::ScrollSpeed());
+	return DoScroll(dy * 2.5 * preferences.scrollSpeed);
 }
 
 

--- a/source/Sprite.cpp
+++ b/source/Sprite.cpp
@@ -55,7 +55,7 @@ void Sprite::AddFrames(ImageBuffer &buffer, bool is2x)
 	}
 	
 	// Check whether this sprite is large enough to require size reduction.
-	if(Preferences::Has("Reduce large graphics") && buffer.Width() * buffer.Height() >= 1000000)
+	if(preferences.reduceLargeGraphics && buffer.Width() * buffer.Height() >= 1000000)
 		buffer.ShrinkToHalfSize();
 	
 	// Upload the images as a single array texture.

--- a/source/StarField.cpp
+++ b/source/StarField.cpp
@@ -142,7 +142,7 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom) const
 	glUseProgram(0);
 	
 	// Draw the background haze unless it is disabled in the preferences.
-	if(!Preferences::Has("Draw background haze"))
+	if(!preferences.drawBackgroundHaze)
 		return;
 	
 	DrawList drawList;

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -85,7 +85,7 @@ TradingPanel::~TradingPanel()
 	
 void TradingPanel::Step()
 {
-	DoHelp("trading");
+	DoHelp(Help::TRADING);
 }
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -103,12 +103,12 @@ int main(int argc, char *argv[])
 		if(SDL_GetCurrentDisplayMode(0, &mode))
 			return DoError("Unable to query monitor resolution!");
 		
-		Preferences::Load();
+		preferences.Load();
 		Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
-		bool isFullscreen = Preferences::Has("fullscreen");
+		bool isFullscreen = preferences.fullscreen;
 		if(isFullscreen)
 			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
-		else if(Preferences::Has("maximized"))
+		else if(preferences.maximized)
 			flags |= SDL_WINDOW_MAXIMIZED;
 		
 		// Make the window just slightly smaller than the monitor resolution.
@@ -348,13 +348,12 @@ int main(int argc, char *argv[])
 			player.Save();
 		
 		// Remember the window state.
-		bool isMaximized = (SDL_GetWindowFlags(window) & SDL_WINDOW_MAXIMIZED);
-		Preferences::Set("maximized", isMaximized);		
-		Preferences::Set("fullscreen", isFullscreen);
+		preferences.maximized = (SDL_GetWindowFlags(window) & SDL_WINDOW_MAXIMIZED);
+		preferences.fullscreen = isFullscreen;
 		// The Preferences class reads the screen dimensions, so update them to
 		// match the actual window size.
 		Screen::SetRaw(windowWidth, windowHeight);
-		Preferences::Save();
+		preferences.Save();
 		
 		Cleanup(window, context);
 	}


### PR DESCRIPTION
This PR optimizes help and setting code to use enums and static class fields instead of string lookups, thus cutting down on a LOT of unnecessary string comparisons.

This change makes follow-up PRs which introduce preferences that would be accessed many times per frame more palatable.

Please see the commits' individual commit messages for extended details.

An alternative version of the second commit, which uses an enum of all settings, is available here:
https://github.com/CyberShadow/endless-sky/commits/fast-boolean-options-v1
It has the benefit of deduplicating up the preferences panel and preferences class string literals, but the code is overall uglier.