### PR TITLE
Increase maximum volume back to 100%

### DIFF
--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -78,8 +78,7 @@ namespace {
 	ALCdevice *device = nullptr;
 	ALCcontext *context = nullptr;
 	bool isInitialized = false;
-	double volume = .5;
-	static const double VOLUME_SCALE = .25;
+	double volume = .125;
 	
 	// This queue keeps track of sounds that have been requested to play. Each
 	// added sound is "deferred" until the next audio position update to make
@@ -136,7 +135,7 @@ void Audio::Init(const vector<string> &sources)
 	ALfloat zero[3] = {0., 0., 0.};
 	ALfloat	orientation[6] = {0., 0., -1., 0., 1., 0.};
 	
-	alListenerf(AL_GAIN, volume * VOLUME_SCALE);
+	alListenerf(AL_GAIN, volume);
 	alListenerfv(AL_POSITION, zero);
 	alListenerfv(AL_VELOCITY, zero);
 	alListenerfv(AL_ORIENTATION, orientation);
@@ -210,7 +209,7 @@ void Audio::SetVolume(double level)
 {
 	volume = min(1., max(0., level));
 	if(isInitialized)
-		alListenerf(AL_GAIN, volume * VOLUME_SCALE);
+		alListenerf(AL_GAIN, volume);
 }
 
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -34,6 +34,7 @@ namespace {
 	
 	const vector<double> ZOOMS = {.25, .35, .50, .70, 1.00, 1.40, 2.00};
 	int zoomIndex = 4;
+	const double VOLUME_SCALE = .25;
 }
 
 
@@ -64,7 +65,7 @@ void Preferences::Load()
 		else if(node.Token(0) == "zoom" && node.Size() >= 2)
 			Screen::SetZoom(node.Value(1));
 		else if(node.Token(0) == "volume" && node.Size() >= 2)
-			Audio::SetVolume(node.Value(1));
+			Audio::SetVolume(node.Value(1) * VOLUME_SCALE);
 		else if(node.Token(0) == "scroll speed" && node.Size() >= 2)
 			scrollSpeed = node.Value(1);
 		else if(node.Token(0) == "view zoom")
@@ -80,7 +81,7 @@ void Preferences::Save()
 {
 	DataWriter out(Files::Config() + "preferences.txt");
 	
-	out.Write("volume", Audio::Volume());
+	out.Write("volume", Audio::Volume() / VOLUME_SCALE);
 	out.Write("window size", Screen::RawWidth(), Screen::RawHeight());
 	out.Write("zoom", Screen::Zoom());
 	out.Write("scroll speed", scrollSpeed);


### PR DESCRIPTION
This increases the upper limit on what the volume can be set to back to 100% (as before 006238e85b7c9647e011c1d6bebcee40216c81ee).

The default volume remains unchanged (now 12.5% of maximum).

Volume in existing configurations remains unchanged. In the configuration file, the volume value now has the range from 0 to 4 (instead of 0 to 1).

Fixes #3725.