### PR TITLE
Enabled text replacements in ship hails (#3716).

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1503,7 +1503,7 @@ void Engine::SendHails()
 		return;
 	
 	// Generate a random hail message.
-	SendMessage(source, source->GetHail());
+	SendMessage(source, source->GetHail(player));
 }
 
 

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -113,7 +113,7 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 	}
 	
 	if(message.empty())
-		message = ship->GetHail();
+		message = ship->GetHail(player);
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -848,8 +848,8 @@ string Ship::GetHail(const PlayerInfo &player) const
 	subs["<date>"] = player.GetDate().ToString();
 	subs["<day>"] = player.GetDate().LongString();
 	
-	string hail_str = hail ? hail->Get() : government ? government->GetHail(isDisabled) : "";
-	return Format::Replace(hail_str, subs);
+	string hailStr = hail ? hail->Get() : government ? government->GetHail(isDisabled) : "";
+	return Format::Replace(hailStr, subs);
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -16,12 +16,14 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataNode.h"
 #include "DataWriter.h"
 #include "Effect.h"
+#include "Format.h"
 #include "GameData.h"
 #include "Government.h"
 #include "Mask.h"
 #include "Messages.h"
 #include "Phrase.h"
 #include "Planet.h"
+#include "PlayerInfo.h"
 #include "Projectile.h"
 #include "Random.h"
 #include "ShipEvent.h"
@@ -832,9 +834,22 @@ void Ship::SetHail(const Phrase &phrase)
 
 
 
-string Ship::GetHail() const
+string Ship::GetHail(const PlayerInfo &player) const
 {
-	return hail ? hail->Get() : government ? government->GetHail(isDisabled) : "";
+	map<string, string> subs;
+	
+	subs["<first>"] = player.FirstName();
+	subs["<last>"] = player.LastName();
+	if(player.Flagship())
+		subs["<ship>"] = player.Flagship()->Name();
+	
+	subs["<npc>"] = Name();
+	subs["<system>"] = player.GetSystem()->Name();
+	subs["<date>"] = player.GetDate().ToString();
+	subs["<day>"] = player.GetDate().LongString();
+	
+	string hail_str = hail ? hail->Get() : government ? government->GetHail(isDisabled) : "";
+	return Format::Replace(hail_str, subs);
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -36,6 +36,7 @@ class Government;
 class Minable;
 class Phrase;
 class Planet;
+class PlayerInfo;
 class Projectile;
 class StellarObject;
 class System;
@@ -152,7 +153,7 @@ public:
 	// Get a random hail message, or set the object used to generate them. If no
 	// object is given the government's default will be used.
 	void SetHail(const Phrase &phrase);
-	std::string GetHail() const;
+	std::string GetHail(const PlayerInfo &player) const;
 	
 	// Set the commands for this ship to follow this timestep.
 	void SetCommands(const Command &command);


### PR DESCRIPTION
#3716 seemed like a neat little addition, so here you go. This change allows these text replacements to be used in ship hail strings (suggestions for additions/changes welcome, of course):
- `<first>`, `<last>` (captain's name)
- `<ship>` (flagship's name)
- `<system>` (current system's name)
- `<npc>` (hailing ship's name)
- `<date>`, `<day>` (current date)

Contrived example (this PR does not include any actual new hails):
![hails](https://user-images.githubusercontent.com/596106/39446282-d6896302-4c72-11e8-82fd-ed4813ed9580.png)