### PR TITLE
Fix stale map cache when changing ship/outfit selection

### DIFF
--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -102,6 +102,7 @@ void MapOutfitterPanel::Select(int index)
 		selected = list[index];
 		selectedInfo.Update(*selected, player);
 	}
+	UpdateCache();
 }
 
 

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -116,6 +116,10 @@ protected:
 	// to account for panels on the screen).
 	void CenterOnSystem(const System *system);
 	
+	// Cache the map layout, so it doesn't have to be re-calculated every frame.
+	// The cache must be updated when the coloring mode changes.
+	void UpdateCache();
+	
 	
 private:
 	void DrawTravelPlan();
@@ -129,10 +133,6 @@ private:
 	void DrawMissions();
 	void DrawPointer(const System *system, Angle &angle, const Color &color, bool bigger = false);
 	static void DrawPointer(Point position, Angle &angle, const Color &color, bool drawBack = true, bool bigger = false);
-	
-	// Cache the map layout, so it doesn't have to be re-calculated every frame.
-	// The cache must be updated when the coloring mode changes.
-	void UpdateCache();
 	
 	
 private:

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -97,6 +97,7 @@ void MapShipyardPanel::Select(int index)
 		selected = list[index];
 		selectedInfo.Update(*selected, player.StockDepreciation(), player.GetDate().DaysSinceEpoch());
 	}
+	UpdateCache();
 }
 
 


### PR DESCRIPTION
Fixes the map not being updated when another ship or outfit is selected in the shipyards/outfitters map modes.

Bug introduced in commit 7d74467288d2e92df1aa48fe4678d7f19ea9acb6.

Fixes issue #3733. An alternative way to fix it would be to translate the selection index (as seen in the `MapSalesPanel::Select(int index)` parameter to a fake commodity index, so that the map cache staleness check picks up the change automatically.