### PR TITLE
Removed "slave food" from pirate slavery jobs

### DIFF
--- a/data/pirate jobs.txt
+++ b/data/pirate jobs.txt
@@ -1378,10 +1378,9 @@ mission "Slave Transport [0]"
 	name "Transfer slaves to <planet>"
 	job
 	repeat
-	description "A pirate on <planet> has bought slaves from a local warlord. Transfer these <bunks> slaves and <cargo> to <destination> for <payment>. Slavery is punishable by death throughout the galaxy, so this may be a dangerous job to take."
+	description "A pirate on <planet> has bought slaves from a local warlord. Transfer these <bunks> slaves to <destination> for <payment>. Slavery is punishable by death throughout the galaxy, so this may be a dangerous job to take."
 	passengers 2 10 .9
-	cargo "slave food" 1
-		illegal -1
+	illegal -1
 	to offer
 		random < 25
 		"reputation: Pirate" > 0
@@ -1399,10 +1398,9 @@ mission "Slave Transport [1]"
 	name "Transfer slaves to <planet>"
 	job
 	repeat
-	description "A pirate on <planet> has bought slaves from a local warlord. Transfer these <bunks> slaves and <cargo> to <destination> for <payment>. Slavery is punishable by death throughout the galaxy, so this may be a dangerous job to take."
+	description "A pirate on <planet> has bought slaves from a local warlord. Transfer these <bunks> slaves to <destination> for <payment>. Slavery is punishable by death throughout the galaxy, so this may be a dangerous job to take."
 	passengers 2 10 .9
-	cargo "slave food" 1
-		illegal -1
+	illegal -1
 	to offer
 		random < 25
 		"reputation: Pirate" > 0
@@ -1420,10 +1418,9 @@ mission "Slave Transport [2]"
 	name "Transfer slaves to <planet>"
 	job
 	repeat
-	description "A pirate on <planet> has bought slaves from a local warlord. Transfer these <bunks> slaves and <cargo> to <destination> for <payment>. Slavery is punishable by death throughout the galaxy, so this may be a dangerous job to take."
+	description "A pirate on <planet> has bought slaves from a local warlord. Transfer these <bunks> slaves to <destination> for <payment>. Slavery is punishable by death throughout the galaxy, so this may be a dangerous job to take."
 	passengers 2 10 .9
-	cargo "slave food" 1
-		illegal -1
+	illegal -1
 	to offer
 		random < 25
 		"reputation: Pirate" > 0
@@ -1443,10 +1440,9 @@ mission "Bulk Slave Transport [0]"
 	name "Transfer slaves to <planet>"
 	job
 	repeat
-	description "A pirate on <planet> has bought slaves from a local warlord. Transfer these <bunks> slaves and <cargo> to <destination> for <payment>. Slavery is punishable by death throughout the galaxy, so this may be a dangerous job to take."
+	description "A pirate on <planet> has bought slaves from a local warlord. Transfer these <bunks> slaves to <destination> for <payment>. Slavery is punishable by death throughout the galaxy, so this may be a dangerous job to take."
 	passengers 10 4 .1
-	cargo "slave food" 1
-		illegal -1
+	illegal -1
 	to offer
 		random < 15
 		"reputation: Pirate" > 0
@@ -1464,10 +1460,9 @@ mission "Bulk Slave Transport [1]"
 	name "Transfer slaves to <planet>"
 	job
 	repeat
-	description "A pirate on <planet> has bought slaves from a local warlord. Transfer these <bunks> slaves and <cargo> to <destination> for <payment>. Slavery is punishable by death throughout the galaxy, so this may be a dangerous job to take."
+	description "A pirate on <planet> has bought slaves from a local warlord. Transfer these <bunks> slaves to <destination> for <payment>. Slavery is punishable by death throughout the galaxy, so this may be a dangerous job to take."
 	passengers 10 4 .1
-	cargo "slave food" 1
-		illegal -1
+	illegal -1
 	to offer
 		random < 15
 		"reputation: Pirate" > 0


### PR DESCRIPTION
Given that illegal cargo is no longer required for a mission to fine the player upon being scanned, I've removed the "slave food" from pirate slavery jobs, since the only point of the slave food was so that the player could be properly punished for carrying slaves.

I'm keeping the extra cargo in the wanted passenger jobs because they have blurbs that pop up upon being scanned that relate to the cargo. (Although, I can see an argument for them being removed in the non-highly wanted passenger missions given the specificity of how the passengers are taken vs the relative commonality of the job, ref: https://github.com/endless-sky/endless-sky/pull/3688#issuecomment-385249464.)