### PR TITLE
Make Hai not hostile to the Unfettered by default

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -86,7 +86,6 @@ government "Hai"
 	
 	"player reputation" 0
 	"attitude toward"
-		"Hai (Unfettered)" -.5
 		"Merchant" .01
 	"bribe" .02
 	"fine" 0


### PR DESCRIPTION
In this PR, the regular Hai will only be hostile to the Unfettered when the latter attacks them. The Hai should only attack for self-defense. If the Hai attack the Unfettered before the latter do, then it is contradicting their claim that they are a peaceful race. And I don't think that the regular Hai would like to kill each other.