### PR TITLE
Prevent messing up the FW storyline

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -791,7 +791,6 @@ event "start of hostilities"
 	government "Republic"
 		"attitude toward"
 			"Free Worlds" -.2
-			"Korath" -.01
 			"Merchant" .01
 			"Pirate" -.01
 	government "Free Worlds"
@@ -1482,7 +1481,6 @@ event "fw armistice"
 	government Republic
 		"attitude toward"
 			"Free Worlds" 0
-			"Korath" -.3
 			"Merchant" .25
 			"Pirate" -.3
 	government "Free Worlds"
@@ -2395,7 +2393,6 @@ event "fwc peace with the navy"
 	government "Republic"
 		"attitude toward"
 			"Free Worlds" 0
-			"Korath" -.3
 			"Merchant" .25
 			"Pirate" -.3
 	government "Free Worlds"

--- a/data/events.txt
+++ b/data/events.txt
@@ -791,10 +791,13 @@ event "start of hostilities"
 	government "Republic"
 		"attitude toward"
 			"Free Worlds" -.2
+			"Korath" -.1
+			"Merchant" .1
+			"Pirate" -.1
 	government "Free Worlds"
 		"attitude toward"
 			"Republic" -.2
-	"reputation: Republic" <?= -100000
+	"reputation: Republic" <?= -10
 
 
 
@@ -1072,7 +1075,7 @@ event "fw safe passage starts"
 
 
 event "fw safe passage ends"
-	"reputation: Republic" <?= -101000
+	"reputation: Republic" <?= -1000
 
 
 
@@ -1479,6 +1482,9 @@ event "fw armistice"
 	government Republic
 		"attitude toward"
 			"Free Worlds" 0
+			"Korath" -.3
+			"Merchant" .25
+			"Pirate" -.3
 	government "Free Worlds"
 		"attitude toward"
 			Republic 0
@@ -2389,6 +2395,9 @@ event "fwc peace with the navy"
 	government "Republic"
 		"attitude toward"
 			"Free Worlds" 0
+			"Korath" -.3
+			"Merchant" .25
+			"Pirate" -.3
 	government "Free Worlds"
 		"attitude toward"
 			"Republic" 0

--- a/data/events.txt
+++ b/data/events.txt
@@ -791,9 +791,9 @@ event "start of hostilities"
 	government "Republic"
 		"attitude toward"
 			"Free Worlds" -.2
-			"Korath" -.1
-			"Merchant" .1
-			"Pirate" -.1
+			"Korath" -.01
+			"Merchant" .01
+			"Pirate" -.01
 	government "Free Worlds"
 		"attitude toward"
 			"Republic" -.2

--- a/data/events.txt
+++ b/data/events.txt
@@ -794,7 +794,7 @@ event "start of hostilities"
 	government "Free Worlds"
 		"attitude toward"
 			"Republic" -.2
-	"reputation: Republic" <?= -10
+	"reputation: Republic" <?= -100000
 
 
 
@@ -1072,7 +1072,7 @@ event "fw safe passage starts"
 
 
 event "fw safe passage ends"
-	"reputation: Republic" <?= -1000
+	"reputation: Republic" <?= -101000
 
 
 

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -312,6 +312,7 @@ government "Republic"
 	"player reputation" 2
 	"attitude toward"
 		"Alpha" -.3
+		"Korath" -.3
 		"Merchant" .25
 		"Militia" .1
 		"Pirate" -.3

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -312,7 +312,6 @@ government "Republic"
 	"player reputation" 2
 	"attitude toward"
 		"Alpha" -.3
-		"Korath" -.3
 		"Merchant" .25
 		"Militia" .1
 		"Pirate" -.3


### PR DESCRIPTION
This PR will make it very difficult to make the Republic friendly to the player after they have joined the Free Worlds (except when it is ceasefire time and when the war is over). This means killing pirates is not a viable option. Plus, because it is very difficult to make the Republic friendly again, this PR will also make the Republic hostile to the Korath exiles again.