### PR TITLE
Make Independent hostile to pirates

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -123,6 +123,8 @@ government "Independent"
 	color .78 .36 .36
 	
 	"player reputation" 10
+	"attitude toward"
+		"Pirate" -.3
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly civilian"

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1105,7 +1105,7 @@ mission "Rim Archaeology 3B"
 				accept
 	
 	npc evade
-		government Independent
+		government " Independent "
 		personality waiting
 		ship "Marauder Falcon (Engines)" "Oxyrhynchus"
 	
@@ -1116,7 +1116,8 @@ mission "Rim Archaeology 3B"
 	on complete
 		payment 300000
 
-
+government " Independent "
+	"player reputation" 0
 
 mission "Rim Archaeology 4A"
 	landing


### PR DESCRIPTION
This PR will make Independent ships (those in the Men system) hostile towards pirates, as a promise to the Free Worlds to denounce piracy in exchange for their independence. There is however a mission where a ship (Oxyrhynchus) whose government is "Independent" is following you. If somehow your reputation with the Independent is negative (because you dominated Men for example), currently this will make the ship hostile to you. It is supposed to just follow you. So this PR also creates an " Independent " for that ship, unaffected of whatever you did to Thule or Smuggler's Den. Another benefit, this also allows the player to increase their reputation with the Independent.