### PR TITLE
Republic now hostile to Korath exiles

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -312,6 +312,7 @@ government "Republic"
 	"player reputation" 2
 	"attitude toward"
 		"Alpha" -.3
+		"Korath" -.3
 		"Merchant" .25
 		"Militia" .1
 		"Pirate" -.3

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -123,8 +123,6 @@ government "Independent"
 	color .78 .36 .36
 	
 	"player reputation" 10
-	"attitude toward"
-		"Pirate" -.3
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly civilian"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -123,6 +123,8 @@ government "Independent"
 	color .78 .36 .36
 	
 	"player reputation" 10
+	"attitude toward"
+		"Pirate" -.3
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly civilian"


### PR DESCRIPTION
Separated from #3749. Same as the unrelated governments.txt commit on that PR: this will make the Republic hostile again to the Korath exiles.

(and ignore the may commits)