### PR TITLE
Update developer instructions for deb-based distros.

### DIFF
--- a/readme-developer.txt
+++ b/readme-developer.txt
@@ -10,8 +10,8 @@ DEB-based distros:
    g++ \
    scons \
    libsdl2-dev \
-   libpng12-dev \
-   libjpeg-turbo8-dev \
+   libpng-dev \
+   libjpeg-dev \
    libgl1-mesa-dev \
    libglew-dev \
    libopenal-dev \


### PR DESCRIPTION
Debian stable doesn't have libpng12-dev or libjpeg-turbo8-dev.