### PR TITLE
Show government name of a planet when different from system's government

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -450,7 +450,10 @@ void MapDetailPanel::DrawInfo()
 				SpriteShader::Draw(planetSprite, uiPoint);
 				planetY[planet] = uiPoint.Y() - 60;
 			
-				font.Draw(object.Name(),
+				string name = object.Name();
+				if(planet->GetGovernment() != selectedSystem->GetGovernment())
+					name += " (" + planet->GetGovernment()->GetName() + ")";
+				font.Draw(name,
 					uiPoint + Point(-70., -52.),
 					planet == selectedPlanet ? medium : dim);
 				

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -452,7 +452,7 @@ void MapDetailPanel::DrawInfo()
 			
 				string name = object.Name();
 				if(planet->GetGovernment() != selectedSystem->GetGovernment())
-					name += " (" + planet->GetGovernment()->GetName() + ")";
+					name += " (" + planet->GetGovernment()->GetName() + " outpost)";
 				font.Draw(name,
 					uiPoint + Point(-70., -52.),
 					planet == selectedPlanet ? medium : dim);


### PR DESCRIPTION
When you select Tarazed in the map, the list of Planets will say "Echo (Quarg)" rather than "Echo".