### PR TITLE
Change version in credits.txt

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -1,5 +1,5 @@
 Welcome to Endless Sky!
-version 0.9.9
+version 0.9.9-nightly
 
 Programming
   Michael Zahniser

--- a/credits.txt
+++ b/credits.txt
@@ -1,5 +1,5 @@
 Welcome to Endless Sky!
-version 0.9.8
+version 0.9.9
 
 Programming
   Michael Zahniser


### PR DESCRIPTION
This PR makes it very clear to nightly users that they are using the current nightly (0.9.9), not the current stable version 0.9.8. When I installed my built nightly and saw the version 0.9.8 in the credits, I thought there was a problem in installation and I was still in 0.9.8, so I have to check the map to be sure (and it is really nightly).