### PR TITLE
Hai spaceport missions

### DIFF
--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -435,3 +435,224 @@ mission "Unfettered returning home"
 		dialog
 			`You need not have worried about the reception the Unfettered youth would receive here on Hai-home. Scarcely minutes after you hesitantly contact the Hai government, a happy crowd has gathered around your ship. When he steps out of the hatchway, he looks stunned at being welcomed so warmly. One of the Hai governors thanks you for transporting him, and pays you <payment>.`
 		"reputation: Hai" += 10
+
+
+
+mission "Returning Home"
+	description "Bring Elliot home to his family on <destination>."
+	minor
+	source
+		government "Hai"
+	destination
+		attributes "dirt belt"
+		attributes "farming"
+	passengers 1
+	to offer
+		random < 40
+	on offer
+		conversation
+			`You are stopped by a human in the <origin> marketplace. He takes off his hat and asks, "You're from the outside, aren't you?"`
+			choice
+				`	"Yes, I am."`
+					goto outsider
+				`	"What do you mean 'the outside?'"`
+			
+			`	"Outside of Hai space. Your ship looks newer than most of the ships that humans fly around here."`
+			choice
+				`Oh, yes. I do come from outside.`
+			
+			label outsider
+			`	"Good. My name is Elliot." You introduce yourself to Elliot and shake hands.`
+			`	"Can you take me to <destination>?" Elliot asks.`
+			`	"That's all the way in the Dirt Belt," you say. "Why do you want to go that far?"`
+			`	Elliot looks down at the ground for a second and takes a deep breath while gripping his hat in his hands. "You see, I haven't lived here all my life. I was born on <planet> to a poor farming family. Most of my days were spent working on the farm, which I hated with a passion. One day I just got fed up with things and I ran away.`
+			`	"I ran away from home to the spaceport city and snuck my way into the cargo hold of a freighter. The captain didn't open the cargo hold for three weeks while I stayed in it. Lucky for me the freighter was transporting food, so I had plenty to eat.`
+			`	"When the cargo hold doors finally opened, I ran out as fast as I could, only to run back in at the sight of a group of Hai. I had no idea where I was at the time, but I've been living here ever since. That was when I was sixteen, nearly six years ago now."`
+			`	Elliot looks down at the ground again and wipes a tear from the corner of his eye.`
+			choice
+				`	"Alright, I'll take you to <planet>"`
+					goto accept
+				`	"And you finally want to go back home?"`
+				`	"Sorry, but I'm not able to take you that far."`
+					goto decline
+			
+			`	"Yes. I've thought a lot about it lately. I want to see my family again."`
+			choice
+				`	"Alright, I'll take you to <planet>"`
+					goto accept
+				`	"Sorry, but I'm not able to take you that far."`
+			
+			label decline
+			`	"I understand," Elliot says. "I'll just try and find someone else to help me. Goodbye, <first>."`
+				decline
+			
+			label accept
+			`	You lead Elliot to your ship and show him to a bunk room. After leaving Elliot there, you wonder if his family is still even on <planet> anymore.`
+				accept
+			
+	on complete
+		payment 45000
+		conversation
+			`Elliot thanks your for bringing him to <planet> and hands you <payment>. He flags down a taxi just outside the spaceport, but before getting in to the taxi he turns back to you.`
+			`	"Do you want to come with me? I'd love for you to meet my family. They'll want to meet you when I tell them how I got back."`
+			choice
+				`	"Sorry, I have other places to be. Good luck."`
+				`	"Sure. I've come with you this far."`
+					goto sure
+			
+			`	"I understand. Thanks again, <first>. I'll always owe you."`
+			`	Elliot gets into the taxi, which drives off toward the seemingly endless farmlands outside of the spaceport city.`
+				decline
+			
+			label sure
+			`	The view for nearly the entire three hour drive is of hills and farmland with the occasional building or wild animal. Elliot shakes as the taxi approaches the house from the driveway. "I'm wondering if they still even live here," he says nervously.`
+			`	No one comes out of the house when the taxi stops. You walk up to the front door with Elliot and a middle aged woman answers the door with a ug of coffee and a bewildered look on her face.`
+			`	"Can I help you?" the woman asks.`
+			`	Eliiot looks over at you with a big smile on his face. "Yes you can, mom," he says to her. The woman's face lights up with joy and she begins jumping up and down, spilling coffee from her mug.`
+			`	"Oh Elliot, I can't believe it!" Elliot's mom puts down her mug and leaps out the door to hug him. "Jackson! Sarah! Abby! Sean! Victor! Elliot is here!" Elliot's entire family comes out from the house and greets him, asking dozens of questions about where and how he's been and why he left.`
+			`	Elliot introduces you to his family, who thank you for bringing Elliot home. Victor, who was only seven years old when Elliot left and is now twelve, asks you question after question about being a pilot, sometimes asking new questions before you can even answer the old one.`
+			`	"Are you going back to the spaceport, <first>?" the taxi driver yells from the driveway. "I need to get back to the city as soon as I can."
+			`	You say goodbye to Elliot and to his family. "Thanks again, <first>," Elliot says to you. "I'll always owe you."`
+
+
+
+mission "Unwanted Cargo Trigger"
+	invisible
+	landing
+	source
+		government "Hai"
+	to offer
+		random < 10
+		"cargo space" > 0
+	on offer
+		event "hai in cargo" 14
+		fail
+
+event "hai in cargo"
+
+mission "Unwanted Cargo"
+	landing
+	description "Bring the Hai child who hid in your cargo hold back to <destination>."
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	destination "Allhome"
+	to offer
+		has "event: hai in cargo"
+	on offer
+		conversation
+			`The check cargo light for your ship begins blinking when you land, meaning that a cargo crate may have come loose in flight. You shut off the ship's engines and walk to the cargo hold.`
+			`	You check every cargo crate in the hold, but can't find anything wrong. Right as you decide to leave, one of the smaller crates begins rocking back and forth.`
+			branch translator
+				has "Human Cultural Archives: done"
+				
+			`	You hear a voice come from the crate, but it is not a language you understand. The voice continues to speak, and you recognize it as the Hai language.`
+			choice
+				`	(Open the crate)`
+			`	You open the crate and are met eye to eye with a Hai child. You aren't sure how old it is, but it looks to be about the height of a one year old human child. It tries to communicate with you, but begins to cry when it sees the confused look on your face.`
+			choice
+				`	"Don't cry, little guy."`
+					goto cry
+				`	(Pick up the Hai.)`
+				
+			`	The child waves its hands around when you try to pick it up, making it impossible to grab on to. After waiting for a few minutes, the child finally calms down, eventually going to sleep in the crate.`
+				goto end
+			
+			label cry
+			`	The child begins to cry even louder as you try to calm it down. After waiting for a few minutes, the child finally calms down, eventually going to sleep in the crate.`
+				goto end
+			
+			label translator
+			`	You hear a voice come from the crate, and surprisingly your Hai translator begins speaking. "Let me out! I want to go home!"`
+			choice
+				`	(Open the crate)`
+			`	You open the crate and are met eye to eye with a Hai child. You aren't sure how old it is, but it looks to be about the height of a one year old human child. "I want my mommy!" it says as its eyes begin to tear up.`
+			choice
+				`	"Where's your mommy?"`
+				`	"Don't cry, little guy."`
+			`	The child looks surprised when your translation device speaks to it in Hai. "Take me home!" it yells back at you. You attempt to find out where the child's home is, but it continues to cry for its mother without giving any important information.`
+			
+			label end
+			`	This child must have somehow gotten into your cargo hold while you were in Hai space. Leaving a Hai child on a human world would be an extremely bad idea. Perhaps someone on <destination> will be able to bring the child back to its family.`
+				accept
+			
+	on complete
+		payment 50000
+		dialog `You contact the spaceport authorities of <planet> and ask them if they are looking for a lost Hai child. It turns out that the family was so worried that they put up a <payment> reward for finding their son. A Hai spaceport worker takes the child from your ship and thanks you for finding him for the family.`
+
+
+
+mission "Hiding in Plain Sight"
+	description "Arthur and his Hai friend, Kiru, to <destination> for a gaming convention."
+	minor
+	source
+		government "Hai"
+	destination "Vinci"
+	passengers 2
+	to offer
+		random < 30
+	on offer
+		conversation
+			`While eating in a spaceport cafeteria that serves both Hai and human cuisine, you are approached by a teenaged human and Hai. "Hello. Do you know how to get to <destination>?" the Hai asks you.`
+			choice
+				`	"I do. Why do you want to go there?"`
+				`	"I don't. You'll have to ask someone else."`
+					decline
+			`	The human responds, "There's a massive convention on <planet> for a game called 'Boundless Frontiers.' The convention has a huge cosplaying scene, and I think Kiru would fit right in."`
+			`	"Arthur and I have <payment> to give you if you bring us to the <planet>," Kiru says. "We can find our own way back to the Hai space, as well."`
+			choice
+				`	"Alright, I can take you there."`
+					accept
+				`	"Sorry, you'll have to find someone else to bring you,"`
+					decline
+					
+	on complete
+		payment 75000
+		dialog `Arthur and Kiru pay you <payment> before running off to the convention center. As they run away, you notice that Kiru is drawing a number of eyes from the crowd, but no one seems to suspect that he is an actual alien.`
+
+
+
+mission "Hai Honeymoon"
+	description "Bring Anaya and Touhar to <destination> for their honeymoon."
+	minor
+	source "Skyfarm"
+	destination "Featherweight"
+	passengers 2
+	to offer
+		random < 60
+	on offer
+		conversation
+			`You hop around the spaceport of <origin>, trying to get adjusted to the low gravity of this moon, when you are approached by a toweringly tall human woman and an equally tall Hai male who are clearly adjusted to <origin>'s gravity.`
+			`	"You look like you need help there, Captain," the woman says with a chuckle.`
+			choice
+				`	"Don't worry. I almost have the hang of it."`
+				`	"Maybe a little bit."`
+			`	"It's always fun watching captains when they step off the comfort of their ship," the Hai says.`
+			`	"At least he's trying, Touhar," the woman says.`
+			choice
+				`	"Can I help you two with something?"`
+				`	"Is there something I can help you with, or are you just going to watch me?"`
+			`	"Actually, there is something," the woman says. "My name is Anaya, and this is my husband, Touhar. And you are?"`
+			choice
+				`	"My name is <first> <last>."`
+				`	"Wait, your husband?"`
+					goto husband
+			
+			`	"Very nice to meet you, Captain <last>," Touhar says to you.`
+				goto next
+			
+			label husband
+			`	"What, you've never seen an interspecies couple before?" Touhar asks with a hint of sarcasm in his voice.`
+			
+			label next
+			`	"We got married last week, and we were hoping to travel to <destination> for our honeymoon. I know it's risky to bring Touhar into human space, but Featherweight is a sparcely inhabited world, and I have a friend who owns a house in the mountains far from anyone who could see Touhar."`
+			`	"Said friend will be able to arrange for our return to <origin> as well," Touhar adds. "Will you take us?"`
+			choice
+				`	"Sure."`
+					accept
+				`	"Sorry, I can't travel that far from here."`
+					decline
+					
+	on complete
+		payment 100000
+		dialog `Instead of landing in the spaceport where they can be seen, you drop Anaya and Touhar off as close as you can to Anaya's friend's house where they will be staying. The house is a few kilometers away, but they assure you that they can make it on their own. They pay you <payment> and thank you for bringing them this far.`
+

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -439,7 +439,7 @@ mission "Unfettered returning home"
 
 
 mission "Returning Home"
-	description "Bring Elliot home to his family on <destination>, who he hasn't seen in almost six years."
+	description "Bring Elliot home to his family on <destination>. Elliot ran away from his family as a teenager and hasn't seen them in almost six years."
 	minor
 	source
 		government "Hai"
@@ -564,7 +564,7 @@ mission "Unwanted Cargo"
 			label translator
 			`	You hear a voice come from the crate, and surprisingly your Hai translator begins speaking. "Let me out! I want to go home!"`
 			choice
-				`	(Open the crate)`
+				`	(Open the crate.)`
 			`	You open the crate and are met eye to eye with a Hai child. You aren't sure how old it is, but it looks to be about the height of a one year old human child. "I want my mommy!" it says as its eyes begin to tear up.`
 			choice
 				`	"Where's your mommy?"`
@@ -583,7 +583,7 @@ mission "Unwanted Cargo"
 
 mission "Expanding Business [1]"
 	name "An Interesting Proposition"
-	description "Travel with businessman David Turner to <destination> "
+	description "Travel with businessman David Turner to <destination> where a convoy of freighters are awaiting escort."
 	minor
 	source "Greenwater"
 	destination "Allhome"
@@ -621,7 +621,7 @@ mission "Expanding Business [1]"
 			
 			label opportunity
 			`	"Allow me to explain. The journey to the Hai can be a dangerous one, and you know that. I heard many stories during the war of merchants trying to reach the Hai, but thanks to the Navy being distracted, those merchants fell victim to pirates patrolling the systems of the Far North. Now that many merchants are here, they're trapped. They expended most of if not all of their ammunition trying to get here, and now they have none to defend them on their way back. Human ammunition has become a scarce commodity among human captains in this region of space, leaving open a market that's just waiting to be cornered.`
-			`	"I'd like you, Captain <last>, bero of humanity, to help me set up an outfitter here on <origin>, an outfitter that would supply these desperate merchants with relief by supplying them with the ammunition they need, along with outfits they might want to buy for their old ships. WIth a name like yours backing up this business, the profits are sure to be phenominal, profits that you would be sharing in by being a founding member of this outfitter."`
+			`	"I'd like you, Captain <last>, hero of humanity, to help me set up an outfitter here on <origin>, an outfitter that would supply these desperate merchants with relief by supplying them with the ammunition they need, along with outfits they might want to buy for their old ships. I've already received approval from the Hai government for the construction of an outfitter, and with a name like yours backing up this business, the profits are sure to be phenomenal, profits that you would be sharing in by being a founding member of this outfitter."`
 			choice
 				`	"This sounds like a good idea to me. What do you need me to do?"`
 					goto interested
@@ -630,10 +630,10 @@ mission "Expanding Business [1]"
 			`	"Nonsense, Captain! All you'd need to do is help escort a few freighters from <planet> to Follower and back to here, and for so simple a job you could be receiving enough money to not work another day in your life, or perhaps even support a massive fleet."`
 			choice
 				`	"Again, I'm not interested. Goodbye."`
-				`	"Alright, you have me interested"`
+				`	"Alright, you have me interested."`
 					goto interested
 			
-			`	"Well, I tried, Captain. I'll just have to travel back to the Paradise Worlds and make my money in other areas of business, then." Turner hands you another business card and winks. "Goodbye, <last>. You should know where to find me if you need me."`
+			`	"Well, I tried, Captain," Turner says with a smirk. "I'll just have to travel back to the Paradise Worlds and make my money in other areas of business, then." He hands you another business card and winks. "Goodbye, Captain <last>. You should know where to find me if you need me."`
 				decline
 			
 			label interested
@@ -642,8 +642,286 @@ mission "Expanding Business [1]"
 				
 	npc save
 		personality escort
-		government "Republic"
-		ship "Star Queen (Hai)" "Rex Auri"
+		government "Merchant"
+		ship "Star Queen (Hai)" "Chryso Vasilia"
+	
+	on complete
+		dialog `The freighters are ready to launch by the time you get to <planet>. "Now we just need to escort these freighter to Follower in the Alphard system and back in one piece," Turner exclaims, hopping back on to his Star Queen.`
+
+mission "Expanding Business [2]"
+	landing
+	name "An Interesting Proposition"
+	description "Escort the freighters to <destination> where they will be picking up supplies for the Greenwater outfitter."
+	destination "Follower"
+	to offer
+		has "Expanding Business [1]: done"
+	
+	npc save
+		personality escort
+		government "Merchant"
+		ship "Star Queen (Hai)" "Chryso Vasilia"
+	npc save
+		personality escort
+		government "Merchant"
+		fleet
+			names "civilian"
+			variant
+				"Bulk Freighter (Hai)" 3
+	
+	npc
+		personality staying
+		government "Pirate"
+		system "Ultima Thule"
+		fleet "Small Northern Pirate"
+	npc
+		personality staying
+		government "Pirate"
+		system "Rajak"
+		fleet "Large Northern Pirate"
+	npc
+		personality staying
+		government "Pirate"
+		system destination
+		fleet "Large Northern Pirate"
+
+mission "Expanding Business [3]"
+	landing
+	name "An Interesting Proposition"
+	description "Escort Turner's ship to <destination> so that he can speak with an old friend."
+	destination "Rust"
+	to offer
+		has "Expanding Business [2]: done"
+	on offer
+		conversation
+			`Turner jumps off of his Star Queen before the boarding ramp fully reaches the ground, clearly eager to get moving with this project.`
+			`	Turner swears under his breath when he walks up to you. "Low life pirates giving us trouble on the way here. That's the kind of trouble I'm talking about that an outfitter in Hai space would help with. There's no telling what would have happened had my Bulk Freighters not had their missiles. Or if you were not there to protect them, of course."`
+			`	Turner has a talk with the spaceport authorities, and within a short amount of time the necessary cargo is loaded on to the freighters. When the freighters are fully loaded, they take off without even giving you time to get to your ship.`
+			`	"They can get back to Greenwater on their own," Turner says from behind you as you watch the freighters fly off. "I told them to leave as soon as they could. As for you and me, I need escort to <destination>. I received a message from an old friend there who would like to have a chat with me ASAP."`
+				accept
+				
+	npc save
+		personality escort
+		government "Merchant"
+		ship "Star Queen (Hai)" "Chryso Vasilia"
+
+mission "Expanding Business [4]"
+	landing
+	name "An Interesting Proposition"
+	description "Escort Turner back to <destination> to oversee the construction of the outfitter."
+	destination "Greenwater"
+	to offer
+		has "Expanding Business [3]: done"
+	on offer
+		conversation
+			`Turner lands his ship outside of the Kraz Cybernetics building. "Wait here while I have a talk with my friend, Edward. This should only take a few minutes."`
+			`	A few hours later, Turner returns carrying a black suitcase. "Sorry, that took longer than I expected. Now, let's get back to <destination>."`
+				accept
+			
+	on complete
+		event "outfitter on greenwater" 95
+		conversation
+			`By the time you finally reach <planet>, construction on the outfitter is already underway. The construction workers have laid the foundation of the outfitter close to the spaceport, taking up a good portion of a park.`
+			`	"I had to pay a pretty penny to get the outfitter this close to the spaceport," Turner says to you, "but it'll all be worth it in the end."`
+			`	"The outfitter should be done in three months or so. You'll know it's done once you find an extra five thousand credits in your pocket every day." Turner pats you on the back. "Have fun until then, Captain <last>. Keep yourself busy saving the galaxy."`
+
+event "outfitter on greenwater"
+	planet "Greenwater"
+		outfitter "Basic Outfits"
+		outfitter "Ammo North"
+		outfitter "Ammo South"
+
+mission "Expanding Business: outfitter complete"
+	landing
+	invisible
+	to offer
+		has "event: outfitter on greenwater"
+	on offer
+		"salary: Turner Incorporated" = 5000
+		event "request for a shipyard" 270
+		fail
+
+event "request for a shipyard"
+
+mission "Expanding Business [5]"
+	landing
+	name "A New Proposition"
+	description "Meet with David Turner on <destination> to talk about a new proposition."
+	source
+		government "Hai"
+	destination "Greenwater"
+	to offer
+		has "event: request for a shipyard"
+	on offer
+		dialog `You receive a message from David Turner when you land. "Hello, Captain. I hope you've been enjoying your share in the outfitter. I have a new proposition for you, as I've bought out the rest of the park around the outfitter. Meet me on <destination> if you'd like to hear about it."`
+
+mission "Expanding Business [6]"
+	landing
+	name "A New Proposition"
+	description "Escort the freighters to <destination> in order to pick up the supplies for the shipyard."
+	destination "Sunracer"
+	to offer
+		has "Expanding Business [5]: done"
+	on offer
+		conversation
+			`Turner meets you in a high-end human-owned restaurant in the richer part of the city, very much reminiscent of something you would find on a Paradise Planet.`
+			`	"It's been quite some time since we last spoke, Captain <last>. Over a year now. Have you been enjoying the extra cash in your pocket every day, Captain <last>?"`
+			choice
+				`	"Yes. It's been a huge help paying crew salaries."`
+					goto salaries
+				`	"Five thousand credits each day isn't much for me."`
+			
+			`	"I suppose just under two million credits every year wouldn't be much to a hero such as yourself. Spaceships are expensive, after all. How does five million credits every year sound to you?"`
+				goto choice
+			
+			label salaries
+			`	"I'm glad to hear that, Captain <last>. I spent my early years as a captain myself, and I didn't much enjoy having to worry about crew salaries every day. Perhaps nearly tripling that amount will help even more."`
+			
+			label choice
+			choice
+				`	"Am I getting a raise?"`
+				`	"Is this part of your new proposition?"`
+					goto proposition
+			
+			`	"You could call it that," Turner says after sipping from his glass of wine.`
+			
+			label proposition
+			`	"Building a outfitter selling human goods here on <origin> has had to be the best idea I've ever had, Captain <last>, but recently I thought of an even better idea. You see, most of the humans you see flying around in Hai space are flying decades old ships. Hai ships are prohibitively expensive for humans. The Aphid is nearly three million credits! This means that demand for ships is extremely high among humans, Captain <last>. Do you see where I'm going with this?"`
+			choice
+				`	"You need me to help you escort freighters again?"`
+				`	"Do you want to build a shipyard selling human ships?"`
+			
+			`	"Yes, Captain. Right now, the only realistic way that a human born here can get a ship is if they know a captain willing to retire. Even then, prices for a human ship can be more than twice what they are across the wormhole. It's preposterous, Captain <last>!`
+			`	"I've already made arrangements with the local Hai government. The rest of the park next to the outfitter is now my property, and I intend to use it to build the shipyard. I've also contacted Megaparsec and bought a license to build their ships and some of the outfits they sell on <planet>. My freighters are at the ready in the spaceport right now. All I need you to do is escort them to <destination> and back, and in six to seven month's time when the shipyard is done, you'll reap the rewards. What do you say, Captain <last>? Do you want to be a hero to millions once again?"`
+			choice
+				`	"Sure, this sounds like a great idea."`
+					goto accept
+				`	"I'm not interested in working with you anymore, Turner."`
+			
+			`	Turner smirks at your response. "Understood, Captain <last>. I'll just save myself five thousand credits a day from now on. I'll be seeing myself out now."`
+				decline
+			
+			label accept
+			`	"Excellent decision, Captain <last>. I'll meet you outside to send the ships off."`
+				accept
+			
+	on decline
+		clear "salary: Turner Incorporated"
+	
+	npc save
+		personality escort
+		government "Merchant"
+		ship "Star Queen (Hai)" "Chryso Vasilia"
+	npc save
+		personality escort
+		government "Merchant"
+		fleet
+			names "civilian"
+			variant
+				"Bulk Freighter (Hai)" 3
+	
+	npc
+		personality staying
+		government "Pirate"
+		system "Ultima Thule"
+		fleet "Small Northern Pirate"
+	npc
+		personality staying
+		government "Pirate"
+		system "Rajak"
+		fleet "Large Northern Pirate"
+	npc
+		personality staying
+		government "Pirate"
+		system destination
+		fleet "Large Northern Pirate"
+		
+	on complete
+		dialog `The Bulk Freighters are loaded with supplies without any problem. When one of the spaceport workers asks Turner where the supplies are going, he replies, "These are just to expand a business venture of mine on, uh, Glory."`
+
+mission "Expanding Business [7]"
+	landing
+	name "A New Proposition"
+	description "Escort the freighters back to <destination> to begin construction on the shipyard."
+	destination "Greenwater"
+	to offer
+		has "Expanding Business [6]: done"
+	
+	npc
+		personality staying
+		government "Pirate"
+		system "Cardax"
+		fleet "Small Northern Pirate"
+	npc
+		personality staying
+		government "Pirate"
+		system "Rajak"
+		fleet "Large Northern Pirate"
+		
+	on complete
+		event "shipyard on greenwater" 180
+		conversation
+			`	Construction on the shipyard begins almost immediately after the supplies are unloaded from the freighters, starting with the demolition of the rest of the park. A downtrodden looking crowd gathers to watch the demolition, but Turner ensures to you that there are plenty of other parks in the city for them to go to.`
+			`	"Something big is going to come of this, Captain <last>," Turner says. "Just know that you were all part of it. You'll know the shipyard is done when you find an extra nine thousand credits in your pocket each day. Goodbye until then, Captain <last>."`
+
+event "shipyard on greenwater"
+	planet "Greenwater"
+		shipyard "Basic Ships"
+		shipyard "Syndicate Basics"
+		shipyard "Megaparsec Basics"
+		shipyard "Megaparsec Advanced"
+		outfitter "Common Outfits"
+		outfitter "Syndicate Advanced"
+		outfitter "Lovelace Basics"
+	fleet "Small Human Merchants (Hai)"
+		add variant 20
+			"Sparrow"
+		add variant 20
+			"Star Barge"
+		add variant 20
+			"Shuttle"
+		add variant 5
+			"Freighter"
+			"Wasp" 2
+		add variant 10
+			"Freighter"
+			"Shuttle" 2
+			"Quicksilver"
+		add variant 15
+			"Bounder"
+			"Wasp" 2
+		add variant 5
+			"Manta"
+		add variant 5
+			"Freighter" 2
+			"Manta"
+	fleet "Large Human Merchants (Hai)"
+		add variant 6
+			"Freighter (Proton)" 2
+			"Quicksilver" 2
+		add variant 6
+			"Freighter" 4
+			"Quicksilver" 2
+			"Splinter" 1
+		add variant 3
+			"Freighter" 4
+			"Quicksilver" 2
+			"Splinter (Laser)" 1
+		add variant 3
+			"Freighter" 4
+			"Quicksilver" 2
+			"Splinter (Proton)" 1
+
+mission "Expanding Business: shipyard complete"
+	landing
+	invisible
+	to offer
+		has "event: shipyard on greenwater"
+	on offer
+		"salary: Turner Incorporated" = 14000
+		fail
+
+
+
 
 
 

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -439,7 +439,7 @@ mission "Unfettered returning home"
 
 
 mission "Returning Home"
-	description "Bring Elliot home to his family on <destination>."
+	description "Bring Elliot home to his family on <destination>, who he hasn't seen in almost six years."
 	minor
 	source
 		government "Hai"
@@ -459,7 +459,7 @@ mission "Returning Home"
 			
 			`	"Outside of Hai space. Your ship looks newer than most of the ships that humans fly around here."`
 			choice
-				`Oh, yes. I do come from outside.`
+				`	"Oh, yes. I do come from outside."`
 			
 			label outsider
 			`	"Good. My name is Elliot." You introduce yourself to Elliot and shake hands.`
@@ -470,7 +470,7 @@ mission "Returning Home"
 			`	"When the cargo hold doors finally opened, I ran out as fast as I could, only to run back in at the sight of a group of Hai. I had no idea where I was at the time, but I've been living here ever since. That was when I was sixteen, nearly six years ago now."`
 			`	Elliot looks down at the ground again and wipes a tear from the corner of his eye.`
 			choice
-				`	"Alright, I'll take you to <planet>"`
+				`	"Alright, I'll take you to <planet>."`
 					goto accept
 				`	"And you finally want to go back home?"`
 				`	"Sorry, but I'm not able to take you that far."`
@@ -493,7 +493,7 @@ mission "Returning Home"
 	on complete
 		payment 45000
 		conversation
-			`Elliot thanks your for bringing him to <planet> and hands you <payment>. He flags down a taxi just outside the spaceport, but before getting in to the taxi he turns back to you.`
+			`Elliot thanks your for bringing him to <planet> and hands you <payment>. He flags down a taxi just outside the spaceport, but before entering the taxi he turns back to you.`
 			`	"Do you want to come with me? I'd love for you to meet my family. They'll want to meet you when I tell them how I got back."`
 			choice
 				`	"Sorry, I have other places to be. Good luck."`
@@ -506,13 +506,13 @@ mission "Returning Home"
 			
 			label sure
 			`	The view for nearly the entire three hour drive is of hills and farmland with the occasional building or wild animal. Elliot shakes as the taxi approaches the house from the driveway. "I'm wondering if they still even live here," he says nervously.`
-			`	No one comes out of the house when the taxi stops. You walk up to the front door with Elliot and a middle aged woman answers the door with a ug of coffee and a bewildered look on her face.`
+			`	No one comes out of the house when the taxi stops. You walk up to the front door with Elliot and a middle aged woman answers the door with a mug of coffee and a bewildered look on her face.`
 			`	"Can I help you?" the woman asks.`
 			`	Eliiot looks over at you with a big smile on his face. "Yes you can, mom," he says to her. The woman's face lights up with joy and she begins jumping up and down, spilling coffee from her mug.`
 			`	"Oh Elliot, I can't believe it!" Elliot's mom puts down her mug and leaps out the door to hug him. "Jackson! Sarah! Abby! Sean! Victor! Elliot is here!" Elliot's entire family comes out from the house and greets him, asking dozens of questions about where and how he's been and why he left.`
 			`	Elliot introduces you to his family, who thank you for bringing Elliot home. Victor, who was only seven years old when Elliot left and is now twelve, asks you question after question about being a pilot, sometimes asking new questions before you can even answer the old one.`
 			`	"Are you going back to the spaceport, <first>?" the taxi driver yells from the driveway. "I need to get back to the city as soon as I can."
-			`	You say goodbye to Elliot and to his family. "Thanks again, <first>," Elliot says to you. "I'll always owe you."`
+			`	You say goodbye to Elliot and to his family. "Thanks again, <first>," Elliot says. "I'll always owe you."`
 
 
 
@@ -532,7 +532,7 @@ event "hai in cargo"
 
 mission "Unwanted Cargo"
 	landing
-	description "Bring the Hai child who hid in your cargo hold back to <destination>."
+	description "Bring a Hai child who hid in your cargo hold back to <destination>."
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	destination "Allhome"
@@ -547,7 +547,7 @@ mission "Unwanted Cargo"
 				
 			`	You hear a voice come from the crate, but it is not a language you understand. The voice continues to speak, and you recognize it as the Hai language.`
 			choice
-				`	(Open the crate)`
+				`	(Open the crate.)`
 			`	You open the crate and are met eye to eye with a Hai child. You aren't sure how old it is, but it looks to be about the height of a one year old human child. It tries to communicate with you, but begins to cry when it sees the confused look on your face.`
 			choice
 				`	"Don't cry, little guy."`
@@ -558,7 +558,7 @@ mission "Unwanted Cargo"
 				goto end
 			
 			label cry
-			`	The child begins to cry even louder as you try to calm it down. After waiting for a few minutes, the child finally calms down, eventually going to sleep in the crate.`
+			`	The child begins to cry even louder than before. After waiting for a few minutes, the child finally calms down, eventually going to sleep in the crate.`
 				goto end
 			
 			label translator
@@ -581,8 +581,74 @@ mission "Unwanted Cargo"
 
 
 
+mission "Expanding Business [1]"
+	name "An Interesting Proposition"
+	description "Travel with businessman David Turner to <destination> "
+	minor
+	source "Greenwater"
+	destination "Allhome"
+	to offer
+		has "main plot completed"
+	on offer
+		conversation
+			`Walking through the <origin> spaceport, you notice that almost half of the people you see are humans, unlike other Hai worlds where the Hai outnumber humans by a sizable degree. A human dressed in a business suit shouts your name from across the street and approaches you.`
+			`	"Captain <last>, one of the many heros of humanity! I noticed you right away when I laid my eyes upon you. I'd like to personally thank you for what you've done."`
+			choice
+				`	"Glad to get some recognition for all the hard work I've done."`
+					goto boast
+				`	"Don't mention it. I just did what I could to help."`
+					goto downplay
+				`	"Can I help you, sir?"`
+			
+			`	"I'm the one who should be using formal titles to address you, so please, Captain, don't call me sir. The name's David Joseph Turner, venture capitalist, entrepreneur, and famous Paradise Worlds businessman." Turner grabs a business card from the pocket and hands it to you. The card contains his contact information, an address on Martini, and makes sure to boast in golden letters his net worth of more than three billion credits.`
+				goto proposition
+			
+			label boast
+			`	"A personality as big as yourself should be receiving praise and recognition wherever you go! People must really have no respect these days. The name's David Joseph Turner, venture capitalist, entrepreneur, and famous Paradise Worlds businessman." Turner grabs a business card from the pocket and hands it to you. The card contains his contact information, an address on Martini, and makes sure to boast in golden letters his net worth of more than three billion credits.`
+				goto proposition
+			
+			label downplay
+			`	"No need to downplay yourself, Captain! You've done God's work in saving humanity from that alien scourge. The name's David Joseph Turner, venture capitalist, entrepreneur, and famous Paradise Worlds businessman." Turner grabs a business card from the pocket and hands it to you. The card contains his contact information, an address on Martini, and makes sure to boast in golden letters his net worth of more than three billion credits.`
+			
+			label proposition
+			`	"You may not have heard of me, but I've sure as hell heard of you, and I'd like to make a proposition to you." Turner turns around and waves his arm across the crowd of people in the spaceport. "You see all the humans here? About one out of every four of these people only arrived here after war broke out through the wormhole. Captains who knew of the Hai came flocking here in droves after the Navy entered Kornephoros, hoping to avoid any troubles that the war would bring. Some captains returned after the war end, but most stayed, and I see a massive market opportunity in that."`
+			choice
+				`	"What kind of market opportunity?"`
+					goto opportunity
+				`	"Sorry, but I don't have the time to talk about this."`
+				
+			`	You try to walk away, but Turner stops you by grabbing your arm and continues to talk.`
+			
+			label opportunity
+			`	"Allow me to explain. The journey to the Hai can be a dangerous one, and you know that. I heard many stories during the war of merchants trying to reach the Hai, but thanks to the Navy being distracted, those merchants fell victim to pirates patrolling the systems of the Far North. Now that many merchants are here, they're trapped. They expended most of if not all of their ammunition trying to get here, and now they have none to defend them on their way back. Human ammunition has become a scarce commodity among human captains in this region of space, leaving open a market that's just waiting to be cornered.`
+			`	"I'd like you, Captain <last>, bero of humanity, to help me set up an outfitter here on <origin>, an outfitter that would supply these desperate merchants with relief by supplying them with the ammunition they need, along with outfits they might want to buy for their old ships. WIth a name like yours backing up this business, the profits are sure to be phenominal, profits that you would be sharing in by being a founding member of this outfitter."`
+			choice
+				`	"This sounds like a good idea to me. What do you need me to do?"`
+					goto interested
+				`	"Sorry, but I'm not interested in your proposition."`
+			
+			`	"Nonsense, Captain! All you'd need to do is help escort a few freighters from <planet> to Follower and back to here, and for so simple a job you could be receiving enough money to not work another day in your life, or perhaps even support a massive fleet."`
+			choice
+				`	"Again, I'm not interested. Goodbye."`
+				`	"Alright, you have me interested"`
+					goto interested
+			
+			`	"Well, I tried, Captain. I'll just have to travel back to the Paradise Worlds and make my money in other areas of business, then." Turner hands you another business card and winks. "Goodbye, <last>. You should know where to find me if you need me."`
+				decline
+			
+			label interested
+			`	"Excellent, Captain! I'll be making myself comfy on my own ship. A convoy of freighters is waiting for us on <destination>. From there, we're off to Follower to pick up supplies."`
+				accept
+				
+	npc save
+		personality escort
+		government "Republic"
+		ship "Star Queen (Hai)" "Rex Auri"
+
+
+
 mission "Hiding in Plain Sight"
-	description "Arthur and his Hai friend, Kiru, to <destination> for a gaming convention."
+	description "Bring Arthur and his Hai friend, Kiru, to <destination> for a gaming convention."
 	minor
 	source
 		government "Hai"
@@ -592,7 +658,7 @@ mission "Hiding in Plain Sight"
 		random < 30
 	on offer
 		conversation
-			`While eating in a spaceport cafeteria that serves both Hai and human cuisine, you are approached by a teenaged human and Hai. "Hello. Do you know how to get to <destination>?" the Hai asks you.`
+			`While eating in a spaceport cafeteria that serves both Hai and human cuisine, you are approached by a teenage human and Hai. "Hello. Do you know how to get to <destination>?" the Hai asks.`
 			choice
 				`	"I do. Why do you want to go there?"`
 				`	"I don't. You'll have to ask someone else."`
@@ -602,7 +668,7 @@ mission "Hiding in Plain Sight"
 			choice
 				`	"Alright, I can take you there."`
 					accept
-				`	"Sorry, you'll have to find someone else to bring you,"`
+				`	"Sorry, you'll have to find someone else to bring you."`
 					decline
 					
 	on complete
@@ -621,7 +687,7 @@ mission "Hai Honeymoon"
 		random < 60
 	on offer
 		conversation
-			`You hop around the spaceport of <origin>, trying to get adjusted to the low gravity of this moon, when you are approached by a toweringly tall human woman and an equally tall Hai male who are clearly adjusted to <origin>'s gravity.`
+			`You hop around the spaceport of <origin>, trying to adjusted to the low gravity of this moon, when you are approached by a toweringly tall human woman and an equally tall Hai male who are clearly having no trouble with <origin>'s gravity.`
 			`	"You look like you need help there, Captain," the woman says with a chuckle.`
 			choice
 				`	"Don't worry. I almost have the hang of it."`
@@ -644,7 +710,7 @@ mission "Hai Honeymoon"
 			`	"What, you've never seen an interspecies couple before?" Touhar asks with a hint of sarcasm in his voice.`
 			
 			label next
-			`	"We got married last week, and we were hoping to travel to <destination> for our honeymoon. I know it's risky to bring Touhar into human space, but Featherweight is a sparcely inhabited world, and I have a friend who owns a house in the mountains far from anyone who could see Touhar."`
+			`	"We got married last week, and we were hoping to travel to <destination> for our honeymoon. I know it's risky to bring Touhar into human space, but <planet> is a sparsely inhabited world, and I have a friend who owns a house in the mountains far from anyone who could see Touhar."`
 			`	"Said friend will be able to arrange for our return to <origin> as well," Touhar adds. "Will you take us?"`
 			choice
 				`	"Sure."`
@@ -654,5 +720,5 @@ mission "Hai Honeymoon"
 					
 	on complete
 		payment 100000
-		dialog `Instead of landing in the spaceport where they can be seen, you drop Anaya and Touhar off as close as you can to Anaya's friend's house where they will be staying. The house is a few kilometers away, but they assure you that they can make it on their own. They pay you <payment> and thank you for bringing them this far.`
+		dialog `Instead of landing in the spaceport where they can be seen, you drop Anaya and Touhar off as close as you can to where they will be staying. The house is a few kilometers away, but they assure you that they can make it on their own. They pay you <payment> and thank you for bringing them this far.`
 

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -922,9 +922,6 @@ mission "Expanding Business: shipyard complete"
 
 
 
-
-
-
 mission "Hiding in Plain Sight"
 	description "Bring Arthur and his Hai friend, Kiru, to <destination> for a gaming convention."
 	minor

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -540,7 +540,7 @@ mission "Unwanted Cargo"
 		has "event: hai in cargo"
 	on offer
 		conversation
-			`The check cargo light for your ship begins blinking when you land, meaning that a cargo crate may have come loose in flight. You shut off the ship's engines and walk to the cargo hold.`
+			`The "Check Cargo" light for your ship begins blinking when you land, meaning that a cargo crate may have come loose in flight. You shut off the ship's engines and walk to the cargo hold.`
 			`	You check every cargo crate in the hold, but can't find anything wrong. Right as you decide to leave, one of the smaller crates begins rocking back and forth.`
 			branch translator
 				has "Human Cultural Archives: done"
@@ -613,11 +613,27 @@ mission "Expanding Business [1]"
 			
 			label proposition
 			`	"You may not have heard of me, but I've sure as hell heard of you, and I'd like to make a proposition to you." Turner turns around and waves his arm across the crowd of people in the spaceport. "You see all the humans here? About one out of every four of these people only arrived here after war broke out through the wormhole. Captains who knew of the Hai came flocking here in droves after the Navy entered Kornephoros, hoping to avoid any troubles that the war would bring. Some captains returned after the war end, but most stayed, and I see a massive market opportunity in that."`
+			branch rich
+				"net worth" >= 4000000000
+			
 			choice
 				`	"What kind of market opportunity?"`
 					goto opportunity
 				`	"Sorry, but I don't have the time to talk about this."`
-				
+					goto walk
+			
+			label rich
+			choice
+				`	"What kind of market opportunity?"`
+					goto opportunity
+				`	"You're only three billion credits? Why shouldn't I pursue your opportunity on my own?"`
+				`	"Sorry, but I don't have the time to talk about this."`
+					goto walk
+			
+			`	"Of course you're worth more than me, Captain <last>, but you are no business owner. I have the connections and skills, but a name like yours will always help.`
+				goto opportunity
+			
+			label walk
 			`	You try to walk away, but Turner stops you by grabbing your arm and continues to talk.`
 			
 			label opportunity
@@ -797,8 +813,11 @@ mission "Expanding Business [6]"
 					goto accept
 				`	"I'm not interested in working with you anymore, Turner."`
 			
-			`	Turner smirks at your response. "Understood, Captain <last>. I'll just save myself five thousand credits a day from now on. I'll be seeing myself out now."`
-				decline
+			`	Turner smirks at your response. "Understood, Captain <last>. I'll just save myself five thousand credits a day from now on by rescinding your salary. I'll be seeing myself out now."`
+			choice
+				`	"Goodbye."`
+					decline
+				`	"Wait! I changed my mind. I'll help you."`
 			
 			label accept
 			`	"Excellent decision, Captain <last>. I'll meet you outside to send the ships off."`

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -548,7 +548,7 @@ mission "Unwanted Cargo"
 			`	You hear a voice come from the crate, but it is not a language you understand. The voice continues to speak, and you recognize it as the Hai language.`
 			choice
 				`	(Open the crate.)`
-			`	You open the crate and are met eye to eye with a Hai child. You aren't sure how old it is, but it looks to be about the height of a one year old human child. It tries to communicate with you, but begins to cry when it sees the confused look on your face.`
+			`	You open the crate and are met face to face with a Hai child. You aren't sure how old it is, but it looks to be about the height of a one year old human child. It tries to communicate with you, but begins to cry when it sees the confused look on your face.`
 			choice
 				`	"Don't cry, little guy."`
 					goto cry
@@ -588,11 +588,12 @@ mission "Expanding Business [1]"
 	source "Greenwater"
 	destination "Allhome"
 	to offer
+		has "First Contact: Hai: offered"
 		has "main plot completed"
 	on offer
 		conversation
 			`Walking through the <origin> spaceport, you notice that almost half of the people you see are humans, unlike other Hai worlds where the Hai outnumber humans by a sizable degree. A human dressed in a business suit shouts your name from across the street and approaches you.`
-			`	"Captain <last>, one of the many heros of humanity! I noticed you right away when I laid my eyes upon you. I'd like to personally thank you for what you've done."`
+			`	"Captain <last>, one of the many heroes of humanity! I noticed you right away when I laid my eyes upon you. I'd like to personally thank you for what you've done."`
 			choice
 				`	"Glad to get some recognition for all the hard work I've done."`
 					goto boast
@@ -630,7 +631,7 @@ mission "Expanding Business [1]"
 			`	"Nonsense, Captain! All you'd need to do is help escort a few freighters from <planet> to Follower and back to here, and for so simple a job you could be receiving enough money to not work another day in your life, or perhaps even support a massive fleet."`
 			choice
 				`	"Again, I'm not interested. Goodbye."`
-				`	"Alright, you have me interested."`
+				`	"Alright, you have my attention."`
 					goto interested
 			
 			`	"Well, I tried, Captain," Turner says with a smirk. "I'll just have to travel back to the Paradise Worlds and make my money in other areas of business, then." He hands you another business card and winks. "Goodbye, Captain <last>. You should know where to find me if you need me."`
@@ -646,12 +647,12 @@ mission "Expanding Business [1]"
 		ship "Star Queen (Hai)" "Chryso Vasilia"
 	
 	on complete
-		dialog `The freighters are ready to launch by the time you get to <planet>. "Now we just need to escort these freighter to Follower in the Alphard system and back in one piece," Turner exclaims, hopping back on to his Star Queen.`
+		dialog `The freighters are ready to launch by the time you get to <planet>. "Now we just need to escort these freighters to Follower in the Alphard system and back in one piece," Turner exclaims, hopping back on to his Star Queen.`
 
 mission "Expanding Business [2]"
 	landing
 	name "An Interesting Proposition"
-	description "Escort the freighters to <destination> where they will be picking up supplies for the Greenwater outfitter."
+	description "Escort the freighters to <destination> where they will pick up supplies for the Greenwater outfitter."
 	destination "Follower"
 	to offer
 		has "Expanding Business [1]: done"
@@ -763,8 +764,7 @@ mission "Expanding Business [6]"
 		has "Expanding Business [5]: done"
 	on offer
 		conversation
-			`Turner meets you in a high-end human-owned restaurant in the richer part of the city, very much reminiscent of something you would find on a Paradise Planet.`
-			`	"It's been quite some time since we last spoke, Captain <last>. Over a year now. Have you been enjoying the extra cash in your pocket every day, Captain <last>?"`
+			`Turner meets you in a high-end human-owned restaurant in the richer part of the city, very much reminiscent of something you would find on a Paradise Planet. "It's been quite some time since we last spoke, Captain <last>. Over a year now," he says. "Have you been enjoying the extra cash in your pocket every day, Captain <last>?"`
 			choice
 				`	"Yes. It's been a huge help paying crew salaries."`
 					goto salaries
@@ -785,13 +785,13 @@ mission "Expanding Business [6]"
 			`	"You could call it that," Turner says after sipping from his glass of wine.`
 			
 			label proposition
-			`	"Building a outfitter selling human goods here on <origin> has had to be the best idea I've ever had, Captain <last>, but recently I thought of an even better idea. You see, most of the humans you see flying around in Hai space are flying decades old ships. Hai ships are prohibitively expensive for humans. The Aphid is nearly three million credits! This means that demand for ships is extremely high among humans, Captain <last>. Do you see where I'm going with this?"`
+			`	"Building a outfitter selling human goods here on <origin> has had to be the best idea I've ever had, Captain <last>, but recently I thought of an even better idea. You see, most of the humans you see flying around in Hai space are flying decades-old ships. Hai ships are prohibitively expensive for humans. The Aphid is nearly three million credits! This means that demand for ships is extremely high among humans, Captain <last>. Do you see where I'm going with this?"`
 			choice
 				`	"You need me to help you escort freighters again?"`
 				`	"Do you want to build a shipyard selling human ships?"`
 			
 			`	"Yes, Captain. Right now, the only realistic way that a human born here can get a ship is if they know a captain willing to retire. Even then, prices for a human ship can be more than twice what they are across the wormhole. It's preposterous, Captain <last>!`
-			`	"I've already made arrangements with the local Hai government. The rest of the park next to the outfitter is now my property, and I intend to use it to build the shipyard. I've also contacted Megaparsec and bought a license to build their ships and some of the outfits they sell on <planet>. My freighters are at the ready in the spaceport right now. All I need you to do is escort them to <destination> and back, and in six to seven month's time when the shipyard is done, you'll reap the rewards. What do you say, Captain <last>? Do you want to be a hero to millions once again?"`
+			`	"I've already made arrangements with the local Hai government. The rest of the park next to the outfitter is now my property, and I intend to use it to build the shipyard. I've also contacted Megaparsec and bought a license to build their ships and some of the outfits they sell on <planet>. My freighters are at the ready in the spaceport right now. All I need you to do is escort them to <destination> and back, and in six to seven months' time when the shipyard is done, you'll reap the rewards. What do you say, Captain <last>? Do you want to be a hero to millions once again?"`
 			choice
 				`	"Sure, this sounds like a great idea."`
 					goto accept
@@ -934,6 +934,7 @@ mission "Hiding in Plain Sight"
 	passengers 2
 	to offer
 		random < 30
+		has "First Contact: Hai: offered"
 	on offer
 		conversation
 			`While eating in a spaceport cafeteria that serves both Hai and human cuisine, you are approached by a teenage human and Hai. "Hello. Do you know how to get to <destination>?" the Hai asks.`
@@ -963,6 +964,7 @@ mission "Hai Honeymoon"
 	passengers 2
 	to offer
 		random < 60
+		has "First Contact: Hai: offered"
 	on offer
 		conversation
 			`You hop around the spaceport of <origin>, trying to adjusted to the low gravity of this moon, when you are approached by a toweringly tall human woman and an equally tall Hai male who are clearly having no trouble with <origin>'s gravity.`
@@ -999,4 +1001,3 @@ mission "Hai Honeymoon"
 	on complete
 		payment 100000
 		dialog `Instead of landing in the spaceport where they can be seen, you drop Anaya and Touhar off as close as you can to where they will be staying. The house is a few kilometers away, but they assure you that they can make it on their own. They pay you <payment> and thank you for bringing them this far.`
-

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -511,7 +511,7 @@ mission "Returning Home"
 			`	Eliiot looks over at you with a big smile on his face. "Yes you can, mom," he says to her. The woman's face lights up with joy and she begins jumping up and down, spilling coffee from her mug.`
 			`	"Oh Elliot, I can't believe it!" Elliot's mom puts down her mug and leaps out the door to hug him. "Jackson! Sarah! Abby! Sean! Victor! Elliot is here!" Elliot's entire family comes out from the house and greets him, asking dozens of questions about where and how he's been and why he left.`
 			`	Elliot introduces you to his family, who thank you for bringing Elliot home. Victor, who was only seven years old when Elliot left and is now twelve, asks you question after question about being a pilot, sometimes asking new questions before you can even answer the old one.`
-			`	"Are you going back to the spaceport, <first>?" the taxi driver yells from the driveway. "I need to get back to the city as soon as I can."
+			`	"Are you going back to the spaceport, <first>?" the taxi driver yells from the driveway. "I need to get back to the city as soon as I can."`
 			`	You say goodbye to Elliot and to his family. "Thanks again, <first>," Elliot says. "I'll always owe you."`
 
 

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -467,7 +467,7 @@ mission "Returning Home"
 			`	"That's all the way in the Dirt Belt," you say. "Why do you want to go that far?"`
 			`	Elliot looks down at the ground for a second and takes a deep breath while gripping his hat in his hands. "You see, I haven't lived here all my life. I was born on <planet> to a poor farming family. Most of my days were spent working on the farm, which I hated with a passion. One day I just got fed up with things and I ran away.`
 			`	"I ran away from home to the spaceport city and snuck my way into the cargo hold of a freighter. The captain didn't open the cargo hold for three weeks while I stayed in it. Lucky for me the freighter was transporting food, so I had plenty to eat.`
-			`	"When the cargo hold doors finally opened, I ran out as fast as I could, only to run back in at the sight of a group of Hai. I had no idea where I was at the time, but I've been living here ever since. That was when I was sixteen, nearly six years ago now."`
+			`	"When the cargo hold doors finally opened, I ran out as fast as I could, only to run back in at the sight of a group of Hai. I had no idea where I was at the time, but I've been living here ever since. That was when I was thirteen, nearly five years ago now."`
 			`	Elliot looks down at the ground again and wipes a tear from the corner of his eye.`
 			choice
 				`	"Alright, I'll take you to <planet>."`
@@ -565,7 +565,7 @@ mission "Unwanted Cargo"
 			`	You hear a voice come from the crate, and surprisingly your Hai translator begins speaking. "Let me out! I want to go home!"`
 			choice
 				`	(Open the crate.)`
-			`	You open the crate and are met eye to eye with a Hai child. You aren't sure how old it is, but it looks to be about the height of a one year old human child. "I want my mommy!" it says as its eyes begin to tear up.`
+			`	You open the crate and are met eye to eye with a Hai child. You aren't sure how old it is, but it looks to be about the size of a one year old human child. "I want my mommy!" it says as its eyes begin to tear up.`
 			choice
 				`	"Where's your mommy?"`
 				`	"Don't cry, little guy."`
@@ -739,7 +739,7 @@ mission "Expanding Business [4]"
 		conversation
 			`By the time you finally reach <planet>, construction on the outfitter is already underway. The construction workers have laid the foundation of the outfitter close to the spaceport, taking up a good portion of a park.`
 			`	"I had to pay a pretty penny to get the outfitter this close to the spaceport," Turner says to you, "but it'll all be worth it in the end."`
-			`	"The outfitter should be done in three months or so. You'll know it's done once you find an extra five thousand credits in your pocket every day." Turner pats you on the back. "Have fun until then, Captain <last>. Keep yourself busy saving the galaxy."`
+			`	"The outfitter should be done in three months or so. You'll know it's done once you find an extra two thousand credits in your pocket every day." Turner pats you on the back. "Have fun until then, Captain <last>. Keep yourself busy saving the galaxy."`
 
 event "outfitter on greenwater"
 	planet "Greenwater"
@@ -753,7 +753,7 @@ mission "Expanding Business: outfitter complete"
 	to offer
 		has "event: outfitter on greenwater"
 	on offer
-		"salary: Turner Incorporated" = 5000
+		"salary: Turner Incorporated" = 2000
 		event "request for a shipyard" 270
 		fail
 
@@ -784,13 +784,13 @@ mission "Expanding Business [6]"
 			choice
 				`	"Yes. It's been a huge help paying crew salaries."`
 					goto salaries
-				`	"Five thousand credits each day isn't much for me."`
+				`	"Two thousand credits each day isn't much for me."`
 			
-			`	"I suppose just under two million credits every year wouldn't be much to a hero such as yourself. Spaceships are expensive, after all. How does five million credits every year sound to you?"`
+			`	"I suppose two thousand credits every day wouldn't be much to a hero such as yourself. Spaceships are expensive, after all. How does four thousand credits every day sound to you?"`
 				goto choice
 			
 			label salaries
-			`	"I'm glad to hear that, Captain <last>. I spent my early years as a captain myself, and I didn't much enjoy having to worry about crew salaries every day. Perhaps nearly tripling that amount will help even more."`
+			`	"I'm glad to hear that, Captain <last>. I spent my early years as a captain myself, and I didn't much enjoy having to worry about crew salaries every day. Perhaps doubling that amount will help even more."`
 			
 			label choice
 			choice
@@ -813,7 +813,7 @@ mission "Expanding Business [6]"
 					goto accept
 				`	"I'm not interested in working with you anymore, Turner."`
 			
-			`	Turner smirks at your response. "Understood, Captain <last>. I'll just save myself five thousand credits a day from now on by rescinding your salary. I'll be seeing myself out now."`
+			`	Turner smirks at your response. "Understood, Captain <last>. I'll just save myself two thousand credits a day from now on by rescinding your salary. I'll be seeing myself out now."`
 			choice
 				`	"Goodbye."`
 					decline
@@ -936,7 +936,7 @@ mission "Expanding Business: shipyard complete"
 	to offer
 		has "event: shipyard on greenwater"
 	on offer
-		"salary: Turner Incorporated" = 14000
+		"salary: Turner Incorporated" = 4000
 		fail
 
 
@@ -983,7 +983,7 @@ mission "Hai Honeymoon"
 		has "First Contact: Hai: offered"
 	on offer
 		conversation
-			`You hop around the spaceport of <origin>, trying to adjusted to the low gravity of this moon, when you are approached by a toweringly tall human woman and an equally tall Hai male who are clearly having no trouble with <origin>'s gravity.`
+			`You hop around the spaceport of <origin>, trying to adjust to the low gravity of this moon, when you are approached by a toweringly tall human woman and an equally tall Hai male who are clearly having no trouble with <origin>'s gravity.`
 			`	"You look like you need help there, Captain," the woman says with a chuckle.`
 			choice
 				`	"Don't worry. I almost have the hang of it."`
@@ -1006,7 +1006,7 @@ mission "Hai Honeymoon"
 			`	"What, you've never seen an interspecies couple before?" Touhar asks with a hint of sarcasm in his voice.`
 			
 			label next
-			`	"We got married last week, and we were hoping to travel to <destination> for our honeymoon. I know it's risky to bring Touhar into human space, but <planet> is a sparsely inhabited world, and I have a friend who owns a house in the mountains far from anyone who could see Touhar."`
+			`	"We got married last week, and we were hoping to travel to <destination> for our honeymoon. I know it's risky to bring Touhar into human space, but <planet> is a sparsely inhabited world, and I have a friend who owns a house in the mountains far from anyone who could see him."`
 			`	"Said friend will be able to arrange for our return to <origin> as well," Touhar adds. "Will you take us?"`
 			choice
 				`	"Sure."`

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -612,7 +612,7 @@ mission "Expanding Business [1]"
 			`	"No need to downplay yourself, Captain! You've done God's work in saving humanity from that alien scourge. The name's David Joseph Turner, venture capitalist, entrepreneur, and famous Paradise Worlds businessman." Turner grabs a business card from the pocket and hands it to you. The card contains his contact information, an address on Martini, and makes sure to boast in golden letters his net worth of more than three billion credits.`
 			
 			label proposition
-			`	"You may not have heard of me, but I've sure as hell heard of you, and I'd like to make a proposition to you." Turner turns around and waves his arm across the crowd of people in the spaceport. "You see all the humans here? About one out of every four of these people only arrived here after war broke out through the wormhole. Captains who knew of the Hai came flocking here in droves after the Navy entered Kornephoros, hoping to avoid any troubles that the war would bring. Some captains returned after the war end, but most stayed, and I see a massive market opportunity in that."`
+			`	"You may not have heard of me, but I've sure as hell heard of you, and I'd like to make a proposition to you." Turner turns around and waves his arm across the crowd of people in the spaceport. "You see all the humans here? About one out of every four of these people only arrived here after war broke out through the wormhole. Captains who knew of the Hai came flocking here in droves after the Navy entered Kornephoros, hoping to avoid any troubles that the war would bring. Some captains returned after the war ended, but most stayed, and I see a massive market opportunity in that."`
 			branch rich
 				"net worth" >= 4000000000
 			
@@ -626,7 +626,7 @@ mission "Expanding Business [1]"
 			choice
 				`	"What kind of market opportunity?"`
 					goto opportunity
-				`	"You're only three billion credits? Why shouldn't I pursue your opportunity on my own?"`
+				`	"You're only worth three billion credits? Why shouldn't I pursue your opportunity on my own?"`
 				`	"Sorry, but I don't have the time to talk about this."`
 					goto walk
 			
@@ -650,7 +650,7 @@ mission "Expanding Business [1]"
 				`	"Alright, you have my attention."`
 					goto interested
 			
-			`	"Well, I tried, Captain," Turner says with a smirk. "I'll just have to travel back to the Paradise Worlds and make my money in other areas of business, then." He hands you another business card and winks. "Goodbye, Captain <last>. You should know where to find me if you need me."`
+			`	"Well, I tried, Captain," Turner says with a smirk. "I'll just have to travel back to the Paradise Worlds and make my money in other areas of business, then." He hands you another business card and winks. "Goodbye, Captain <last>. You should know where to find me if you need me. Perhaps we can pursue this venture together in the future."`
 				decline
 			
 			label interested


### PR DESCRIPTION
Hai space is rather underused mission wise. While there are the few introduction missions to the Hai and a few Wanderer missions that deal with the Hai, this region of space doesn't actually have anything else in it.

This PR adds five new sets of missions to Hai space. 

* **Returning Home**: Elliot ran away from home when he was a teenager and found his way to Hai space. He would now like to return home to his family in the Dirt Belt.
* **Unwanted Cargo**: While in Hai space, a Hai child crawls its way into your cargo hold. You don't realize this until you make it back to human space, though! Return the lost child to its family.
* **Expanding Business**: Available after the main plot is completed, a Paradise World businessman would like to use your name to set up a outfitter in Hai space. Earn royalties for helping to set up this outfitter.  Later set up a shipyard that provides humans of Hai space with cheap alternatives to the expensive Hai ships.
* **Hiding in Plain Sight**: Bring a human and his Hai friend to a convention in the Paradise Worlds. Don't worry, the Hai should fit right in with the cosplayers.
* **Hai Honeymoon**: Bring a human and her Hai husband to the woman's home planet in the Far North where they hope to honeymoon together in the woods.