### PR TITLE
Add support for Eclipse to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 /obj/Release/
 /obj/Win32/
 /bin/
-
+.cproject
+.project


### PR DESCRIPTION
This commit makes git ignore the project files automatically created by
Eclipse.