### PR TITLE
Use a preference to control fighter repair strategy

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -45,8 +45,8 @@ void Preferences::Load()
 	// values for settings that are off by default.
 	settings["Automatic aiming"] = true;
 	settings["Render motion blur"] = true;
-	settings["Escorts use ammo frugally"] = true;
-	settings["Escorts expend ammo"] = true;
+	settings[FRUGAL_ESCORTS] = true;
+	settings[EXPEND_AMMO] = true;
 	settings["Damaged fighters retreat"] = true;
 	settings["Warning siren"] = true;
 	settings["Show escort systems on map"] = true;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -51,6 +51,7 @@ namespace {
 	const string FRUGAL_ESCORTS = "Escorts use ammo frugally";
 	const string REACTIVATE_HELP = "Reactivate first-time help";
 	const string SCROLL_SPEED = "Scroll speed";
+	const string FIGHTER_REPAIR = "Repair fighters in";
 }
 
 
@@ -430,15 +431,16 @@ void PreferencesPanel::DrawSettings()
 		"Automatic aiming",
 		"Automatic firing",
 		EXPEND_AMMO,
+		FIGHTER_REPAIR,
 		TURRET_TRACKING,
-		"",
+		"\n",
 		"Performance",
 		"Show CPU / GPU load",
 		"Render motion blur",
 		"Reduce large graphics",
 		"Draw background haze",
 		"Show hyperspace flash",
-		"\n",
+		"",
 		"Other",
 		"Clickable radar display",
 		"Hide unexplored map regions",
@@ -474,7 +476,8 @@ void PreferencesPanel::DrawSettings()
 		// Record where this setting is displayed, so the user can click on it.
 		prefZones.emplace_back(table.GetCenterPoint(), table.GetRowSize(), setting);
 		
-		// Get the "on / off" text for this setting.
+		// Get the "on / off" text for this setting. Setting "isOn"
+		// draws the setting "bright" (i.e. the setting is active).
 		bool isOn = Preferences::Has(setting);
 		string text;
 		if(setting == ZOOM_FACTOR)
@@ -493,6 +496,11 @@ void PreferencesPanel::DrawSettings()
 		{
 			isOn = true;
 			text = Preferences::Has(FOCUS_PREFERENCE) ? "focused" : "opportunistic";
+		}
+		else if(setting == FIGHTER_REPAIR)
+		{
+			isOn = true;
+			text = Preferences::Has(FIGHTER_REPAIR) ? "parallel" : "series";
 		}
 		else if(setting == REACTIVATE_HELP)
 		{


### PR DESCRIPTION
The player can choose between "least need" (series) and "most need" (parallel). Maintains the default strategy of "least need" for AI ships and players who have not set the preference, while allowing player-specific control.

Refs #3182, https://github.com/endless-sky/endless-sky/issues/2333#issuecomment-291005200