### PR TITLE
Improved Gunnery Algorithm for Projectiles with Drag

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2472,8 +2472,8 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                         }
                         else
                         {
-                            //Calculate how much drift turret velocity will in that time.
-                            offset = ship.Velocity() * -2. * M_PI * expm1(-rendezvousTime * M_1_PI * 0.5);
+                            //Calculate how much drift turret velocity will cause in that time.
+                            offset = ship.Velocity() * -expm1(-rendezvousTime * weapon->Drag()) / weapon->Drag();
                         }
                         
                         iterations --;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2456,12 +2456,13 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                 double rendezvousTime = 0.;
                 if(weapon->Acceleration())
                 {
-                    Point offset = Point(0.,0.); //the effect of ship.Velocity() on final position of projectile
+                    //Uses iterative approxamation to find out how long it would take for the projectile
+                    //to reach the target, accounting for the 'offset' caused by 'ship.Velocity()'.
+                    Point offset = Point(0.,0.);
                     short int iterations = 3;
                     while (iterations > 0)
                     {
-                        // Find out how long it would take for this projectile to reach the target
-                        //compensating for any calculated offset.
+                        // Find out how long it would take for this projectile to reach the target.
                         rendezvousTime = RendezvousTime(p - offset, v, vp);
                         
                         if(std::isnan(rendezvousTime))

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2442,39 +2442,75 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
 			double bestAngle = 0.;
 			for(const Body *target : enemies)
 			{
-				Point p = target->Position() - start;
-				Point v = target->Velocity();
-				// Only take the ship's velocity into account if this weapon
-				// does not have its own acceleration.
-				if(!weapon->Acceleration())
-					v -= ship.Velocity();
-				// By the time this action is performed, the ships will have moved
-				// forward one time step.
-				p += v;
-				
-				// Find out how long it would take for this projectile to reach the target.
-				double rendezvousTime = RendezvousTime(p, v, vp);
-				// If there is no intersection (i.e. the turret is not facing the target),
-				// consider this target "out-of-range" but still targetable.
-				if(std::isnan(rendezvousTime))
-					rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
-				
-				// Determine where the target will be at that point.
-				p += v * rendezvousTime;
-				
-				// Determine how much the turret must turn to face that vector.
-				double degrees = (Angle(p) - aim).Degrees();
-				double turnTime = fabs(degrees) / weapon->TurretTurn();
-				// All ships that are within weapons range have the same basic
-				// weight. Outside that range, give them lower priority.
-				rendezvousTime = max(0., rendezvousTime - weapon->TotalLifetime());
-				// Always prefer ships that you are able to hit.
-				double score = turnTime + (180. / weapon->TurretTurn()) * rendezvousTime;
-				if(score < bestScore)
-				{
-					bestScore = score;
-					bestAngle = degrees;
-				}
+                Point p = target->Position() - start;
+                Point v = target->Velocity();
+                // Only take the ship's velocity into account if this weapon
+                // does not have its own acceleration.
+                if(!weapon->Acceleration())
+                    v -= ship.Velocity();
+                // By the time this action is performed, the ships will have moved
+                // forward one time step.
+                p += v;
+                
+                // Find out how long it would take for this projectile to reach the target.
+                double rendezvousTime = 0;
+                if(weapon->Acceleration())
+                {
+                    Point offset = Point(0,0); //the effect of ship.Velocity() on final position of projectile
+                    int iterations = 3;
+                    while (iterations > 0)
+                    {
+                        // Find out how long it would take for this projectile to reach the target compensating for any calculated offset.
+                        rendezvousTime = RendezvousTime(p - offset, v, vp);
+                        
+                        // If there is no intersection (i.e. the turret is not facing the target),
+                        // consider this target "out-of-range" but still targetable.
+                        if(std::isnan(rendezvousTime))
+                            rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
+                        
+                        //Calculate how much drift turret velocity will in that time.
+                        offset = ship.Velocity() * -2.0 * M_PI * expm1(-rendezvousTime * M_1_PI * 0.5);
+                        
+                        iterations --;
+                    }
+                    
+                    // Determine where the target will be at that point.
+                    p += v * rendezvousTime - offset;
+                }
+                else
+                {
+                    // Find out how long it would take for this projectile to reach the target.
+                    rendezvousTime = RendezvousTime(p, v, vp);
+                    
+                    // If there is no intersection (i.e. the turret is not facing the target),
+                    // consider this target "out-of-range" but still targetable.
+                    if(std::isnan(rendezvousTime))
+                        rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
+                    
+                    // Determine where the target will be at that point.
+                    p += v * rendezvousTime;
+                }
+                // If there is no intersection (i.e. the turret is not facing the target),
+                // consider this target "out-of-range" but still targetable.
+                if(std::isnan(rendezvousTime))
+                    rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
+                
+                // Determine where the target will be at that point.
+                p += v * rendezvousTime;
+                
+                // Determine how much the turret must turn to face that vector.
+                double degrees = (Angle(p) - aim).Degrees();
+                double turnTime = fabs(degrees) / weapon->TurretTurn();
+                // All ships that are within weapons range have the same basic
+                // weight. Outside that range, give them lower priority.
+                rendezvousTime = max(0., rendezvousTime - weapon->TotalLifetime());
+                // Always prefer ships that you are able to hit.
+                double score = turnTime + (180. / weapon->TurretTurn()) * rendezvousTime;
+                if(score < bestScore)
+                {
+                    bestScore = score;
+                    bestAngle = degrees;
+                }
 			}
 			if(bestAngle)
 			{

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2442,60 +2442,60 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
 			double bestAngle = 0.;
 			for(const Body *target : enemies)
 			{
-                Point p = target->Position() - start;
-                Point v = target->Velocity();
-                // Only take the ship's velocity into account if this weapon
-                // does not have its own acceleration.
-                if(!weapon->Acceleration())
-                    v -= ship.Velocity();
-                // By the time this action is performed, the ships will have moved
-                // forward one time step.
-                p += v;
-                
-                // Find out how long it would take for this projectile to reach the target.
-                double rendezvousTime = 0.;
-                if(weapon->Acceleration())
-                {
-                    // For projectiles with drag, use iterative approximation.
-                    Point offset = Point(0.,0.);
-                    short int iterations = 3;
-                    while (iterations > 0)
-                    {
-                        rendezvousTime = RendezvousTime(p - offset, v, vp);
-                        
-                        if(std::isnan(rendezvousTime))
-                            iterations = 0;
-                        else
-                            // Calculate how much drift turret velocity will cause in that time.
-                            offset = ship.Velocity() * -expm1(-rendezvousTime * weapon->Drag()) / weapon->Drag();
-                        
-                        iterations --;
-                    }
-                }
-                else
-                    rendezvousTime = RendezvousTime(p, v, vp);
-                
-                // If there is no intersection (i.e. the turret is not facing the target),
-                // consider this target "out-of-range" but still targetable.
-                if(std::isnan(rendezvousTime))
-                    rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
-                
-                // Determine where the target will be at that point.
-                p += v * rendezvousTime;
-                
-                // Determine how much the turret must turn to face that vector.
-                double degrees = (Angle(p) - aim).Degrees();
-                double turnTime = fabs(degrees) / weapon->TurretTurn();
-                // All ships that are within weapons range have the same basic
-                // weight. Outside that range, give them lower priority.
-                rendezvousTime = max(0., rendezvousTime - weapon->TotalLifetime());
-                // Always prefer ships that you are able to hit.
-                double score = turnTime + (180. / weapon->TurretTurn()) * rendezvousTime;
-                if(score < bestScore)
-                {
-                    bestScore = score;
-                    bestAngle = degrees;
-                }
+				Point p = target->Position() - start;
+				Point v = target->Velocity();
+				// Only take the ship's velocity into account if this weapon
+				// does not have its own acceleration.
+				if(!weapon->Acceleration())
+					v -= ship.Velocity();
+				// By the time this action is performed, the ships will have moved
+				// forward one time step.
+				p += v;
+				
+				// Find out how long it would take for this projectile to reach the target.
+				double rendezvousTime = 0.;
+				if(weapon->Acceleration())
+				{
+					// For projectiles with drag, use iterative approximation.
+					Point offset = Point(0.,0.);
+					short int iterations = 3;
+					while (iterations > 0)
+					{
+						rendezvousTime = RendezvousTime(p - offset, v, vp);
+						
+						if(std::isnan(rendezvousTime))
+							iterations = 0;
+						else
+							// Calculate how much drift turret velocity will cause in that time.
+							offset = ship.Velocity() * -expm1(-rendezvousTime * weapon->Drag()) / weapon->Drag();
+						
+						iterations --;
+					}
+				}
+				else
+					rendezvousTime = RendezvousTime(p, v, vp);
+				
+				// If there is no intersection (i.e. the turret is not facing the target),
+				// consider this target "out-of-range" but still targetable.
+				if(std::isnan(rendezvousTime))
+					rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
+				
+				// Determine where the target will be at that point.
+				p += v * rendezvousTime;
+				
+				// Determine how much the turret must turn to face that vector.
+				double degrees = (Angle(p) - aim).Degrees();
+				double turnTime = fabs(degrees) / weapon->TurretTurn();
+				// All ships that are within weapons range have the same basic
+				// weight. Outside that range, give them lower priority.
+				rendezvousTime = max(0., rendezvousTime - weapon->TotalLifetime());
+				// Always prefer ships that you are able to hit.
+				double score = turnTime + (180. / weapon->TurretTurn()) * rendezvousTime;
+				if(score < bestScore)
+				{
+					bestScore = score;
+					bestAngle = degrees;
+				}
 			}
 			if(bestAngle)
 			{

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2453,10 +2453,10 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                 p += v;
                 
                 // Find out how long it would take for this projectile to reach the target.
-                double rendezvousTime = 0;
+                double rendezvousTime = 0.;
                 if(weapon->Acceleration())
                 {
-                    Point offset = Point(0,0); //the effect of ship.Velocity() on final position of projectile
+                    Point offset = Point(0.,0.); //the effect of ship.Velocity() on final position of projectile
                     int iterations = 3;
                     while (iterations > 0)
                     {
@@ -2466,16 +2466,18 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                         // If there is no intersection (i.e. the turret is not facing the target),
                         // consider this target "out-of-range" but still targetable.
                         if(std::isnan(rendezvousTime))
+                        {
                             rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
-                        
-                        //Calculate how much drift turret velocity will in that time.
-                        offset = ship.Velocity() * -2.0 * M_PI * expm1(-rendezvousTime * M_1_PI * 0.5);
+                            iterations = 0;
+                        }
+                        else
+                        {
+                            //Calculate how much drift turret velocity will in that time.
+                            offset = ship.Velocity() * -2. * M_PI * expm1(-rendezvousTime * M_1_PI * 0.5);
+                        }
                         
                         iterations --;
                     }
-                    
-                    // Determine where the target will be at that point.
-                    p += v * rendezvousTime - offset;
                 }
                 else
                 {
@@ -2486,14 +2488,7 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                     // consider this target "out-of-range" but still targetable.
                     if(std::isnan(rendezvousTime))
                         rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
-                    
-                    // Determine where the target will be at that point.
-                    p += v * rendezvousTime;
                 }
-                // If there is no intersection (i.e. the turret is not facing the target),
-                // consider this target "out-of-range" but still targetable.
-                if(std::isnan(rendezvousTime))
-                    rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
                 
                 // Determine where the target will be at that point.
                 p += v * rendezvousTime;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2456,7 +2456,7 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                 double rendezvousTime = 0.;
                 if(weapon->Acceleration())
                 {
-                    // For projectiles with drag, use iterative approxamation.
+                    // For projectiles with drag, use iterative approximation.
                     Point offset = Point(0.,0.);
                     short int iterations = 3;
                     while (iterations > 0)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2456,13 +2456,11 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                 double rendezvousTime = 0.;
                 if(weapon->Acceleration())
                 {
-                    //Uses iterative approxamation to find out how long it would take for the projectile
-                    //to reach the target, accounting for the 'offset' caused by 'ship.Velocity()'.
+                    //Uses iterative approxamation for projectiles with drag.
                     Point offset = Point(0.,0.);
                     short int iterations = 3;
                     while (iterations > 0)
                     {
-                        // Find out how long it would take for this projectile to reach the target.
                         rendezvousTime = RendezvousTime(p - offset, v, vp);
                         
                         if(std::isnan(rendezvousTime))
@@ -2475,7 +2473,6 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                     }
                 }
                 else
-                    // Find out how long it would take for this projectile to reach the target.
                     rendezvousTime = RendezvousTime(p, v, vp);
                 
                 // If there is no intersection (i.e. the turret is not facing the target),

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2468,19 +2468,15 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                         if(std::isnan(rendezvousTime))
                             iterations = 0;
                         else
-                        {
                             //Calculate how much drift turret velocity will cause in that time.
                             offset = ship.Velocity() * -expm1(-rendezvousTime * weapon->Drag()) / weapon->Drag();
-                        }
                         
                         iterations --;
                     }
                 }
                 else
-                {
                     // Find out how long it would take for this projectile to reach the target.
                     rendezvousTime = RendezvousTime(p, v, vp);
-                }
                 
                 // If there is no intersection (i.e. the turret is not facing the target),
                 // consider this target "out-of-range" but still targetable.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2456,7 +2456,7 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                 double rendezvousTime = 0.;
                 if(weapon->Acceleration())
                 {
-                    //Uses iterative approxamation for projectiles with drag.
+                    // For projectiles with drag, use iterative approxamation.
                     Point offset = Point(0.,0.);
                     short int iterations = 3;
                     while (iterations > 0)
@@ -2466,7 +2466,7 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                         if(std::isnan(rendezvousTime))
                             iterations = 0;
                         else
-                            //Calculate how much drift turret velocity will cause in that time.
+                            // Calculate how much drift turret velocity will cause in that time.
                             offset = ship.Velocity() * -expm1(-rendezvousTime * weapon->Drag()) / weapon->Drag();
                         
                         iterations --;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2457,19 +2457,15 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                 if(weapon->Acceleration())
                 {
                     Point offset = Point(0.,0.); //the effect of ship.Velocity() on final position of projectile
-                    int iterations = 3;
+                    short int iterations = 3;
                     while (iterations > 0)
                     {
-                        // Find out how long it would take for this projectile to reach the target compensating for any calculated offset.
+                        // Find out how long it would take for this projectile to reach the target
+                        //compensating for any calculated offset.
                         rendezvousTime = RendezvousTime(p - offset, v, vp);
                         
-                        // If there is no intersection (i.e. the turret is not facing the target),
-                        // consider this target "out-of-range" but still targetable.
                         if(std::isnan(rendezvousTime))
-                        {
-                            rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
                             iterations = 0;
-                        }
                         else
                         {
                             //Calculate how much drift turret velocity will cause in that time.
@@ -2483,12 +2479,12 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
                 {
                     // Find out how long it would take for this projectile to reach the target.
                     rendezvousTime = RendezvousTime(p, v, vp);
-                    
-                    // If there is no intersection (i.e. the turret is not facing the target),
-                    // consider this target "out-of-range" but still targetable.
-                    if(std::isnan(rendezvousTime))
-                        rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
                 }
+                
+                // If there is no intersection (i.e. the turret is not facing the target),
+                // consider this target "out-of-range" but still targetable.
+                if(std::isnan(rendezvousTime))
+                    rendezvousTime = max(p.Length() / (vp ? vp : 1.), 2 * weapon->TotalLifetime());
                 
                 // Determine where the target will be at that point.
                 p += v * rendezvousTime;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2458,7 +2458,7 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
 				{
 					// For projectiles with drag, use iterative approximation.
 					Point offset = Point(0.,0.);
-					short int iterations = 3;
+					short int iterations = 1;
 					while (iterations > 0)
 					{
 						rendezvousTime = RendezvousTime(p - offset, v, vp);


### PR DESCRIPTION
In response to issue #3686.
This causes turrets to correctly compensate for turret's velocity. It does so by finding the amount of drift caused by the velocity for the calculated rendezvous time. Since the correct rendezvous time is also dependent on offset of the turret velocity, they are calculated recursively with a small number of repetitions.
The math is explained [in this video](https://youtu.be/pOFl0BhUkDI?t=6m49s).
Balance compensation for the Korath Grab-Strike may be worth consideration.
The amount of repetitions can be changed by changing the initial value of 'iterations'.