### PR TITLE
Heat as weapon resource

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2756,6 +2756,8 @@ bool Ship::CanFire(const Weapon *weapon) const
 	
 	if(energy < weapon->FiringEnergy())
 		return false;
+	if(heat < -(weapon->FiringHeat()))
+		return false;
 	if(fuel < weapon->FiringFuel())
 		return false;
 	


### PR DESCRIPTION
Simply prevents a weapon from firing if it would reduce your heat below 0.
To make use of this, create weapons with negative heat costs.

Isolated from other changes as recommended in #3800.