### PR TITLE
Add auto-hire check box to Hiring Panel

### DIFF
--- a/source/HiringPanel.h
+++ b/source/HiringPanel.h
@@ -36,6 +36,9 @@ protected:
 	
 	
 private:
+	void ToggleAutoHire();
+
+private:
 	PlayerInfo &player;
 	
 	int maxHire;

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -237,7 +237,9 @@ public:
 	void SetMapZoom(int level);
 	// Get the set of collapsed categories for the named panel.
 	std::set<std::string> &Collapsed(const std::string &name);
-	
+	// Set to automatically hire to max crew amount upon landing.
+	void ToggleAutoHire();
+	bool IsAutoHire() const;
 	
 private:
 	// Don't anyone else to copy this class, because pointers won't get
@@ -330,6 +332,7 @@ private:
 	
 	bool freshlyLoaded = true;
 	int desiredCrew = 0;
+	bool autoHire = false;
 };
 
 


### PR DESCRIPTION
When checked, immediately maxes your crew and then will automatically max your crew every time you land, so long as it stays checked.

Because I always, always forget :)

I borrowed the check box code from the outfitter check boxes. Perhaps it should be abstracted out somewhere so that it doesn't have to be copy-pasted in this way?