### PR TITLE
EMP license

### DIFF
--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -170,6 +170,8 @@ effect "point defense die"
 outfit "EMP Torpedo"
 	plural "EMP Torpedoes"
 	category "Ammunition"
+	licenses
+		Remnant
 	cost 4400
 	thumbnail "outfit/emp torpedo"
 	"mass" 1
@@ -178,6 +180,8 @@ outfit "EMP Torpedo"
 
 outfit "EMP Torpedo Bay"
 	category "Secondary Weapons"
+	licenses
+		Remnant
 	cost 80000
 	thumbnail "outfit/emp torpedo bay"
 	"mass" 9

--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -170,8 +170,6 @@ effect "point defense die"
 outfit "EMP Torpedo"
 	plural "EMP Torpedoes"
 	category "Ammunition"
-	licenses
-		Remnant
 	cost 4400
 	thumbnail "outfit/emp torpedo"
 	"mass" 1


### PR DESCRIPTION
All Remnant weapons and outfits require a Remnant license. The exception is the new EMP Torpedo Bay. My guess is this is not intentional, hence this patch, which applies the Remnant license to this weapon as well.