### PR TITLE
Made pirates hostile to Pug

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -265,6 +265,7 @@ government "Pirate"
 		"Hai" -.01
 		"Korath" -.01
 		"Merchant" -.1
+		"Pug" -.01
 		"Syndicate" -.01
 	"bribe" .05
 	"fine" 0


### PR DESCRIPTION
While doing my own solo Quicksilver challenge, I made the Pug jump to Orvala where the pirate ship "Dread" lurks. I expected that the pirates will attack the Pug, but it didn't happened. It seems it is no longer the case in master, unlike in 0.9.8. That doesn't make sense. This PR makes the pirates hostile to the Pug, while not affecting either faction's reputation.