### PR TITLE
Added landing clearance for "Ambassadors from Earth"

### DIFF
--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -460,6 +460,7 @@ mission "FW Embassy 1"
 	landing
 	source Farpoint
 	destination Earth
+	clearance
 	passengers 2
 	to offer
 		has "FW Defend Farpoint: done"


### PR DESCRIPTION
If the player didn't disabled some pirate ships before "Ambassadors from Earth", they will have to bribe the spaceport authorities, which doesn't make sense, because you're going to Earth to escort their ambassadors. This PR gives landing clearance.

[Here's my save file that the above scenario can happen](https://github.com/endless-sky/endless-sky/files/2158627/Marcelo.Pilar.txt)
