### PR TITLE
Lower "Kestrel Testing" requirements

### DIFF
--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -14,7 +14,7 @@ mission "Kestrel Testing"
 	source "Wayfarer"
 	waypoint "Umbral"
 	to offer
-		"combat rating" > 8000
+		"combat rating" > 2980
 	
 	on offer
 		conversation


### PR DESCRIPTION
… from `(9) force to be reckoned with` to `(8) respected foe` in order to prevent the *Kestrel* from being already outdated when it is unlocked.