### PR TITLE
Fixed the Albatross engine flare zoom factors

### DIFF
--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -192,8 +192,8 @@ ship "Albatross"
 		"Hyperdrive"
 	
 	engine -28 155 .8
-	engine 28 155 .9
-	engine 0 184 .8
+	engine 28 155 .8
+	engine 0 184 .9
 	gun 0 -190
 	gun -9 -177 "Inhibitor Cannon"
 	gun 9 -177 "Inhibitor Cannon"


### PR DESCRIPTION
I noticed that the right flare was slightly longer than the left flare on my Albatross. Did some digging and it looks like the engine zoom factors were swapped.