### PR TITLE
Introduce a "no fuel?" warning

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -468,4 +468,4 @@ tip "no hyperdrive?"
 	`This ship has no hyperdrive. If it took off, it would be unable to leave this star system.`
 
 tip "no fuel?"
-	`This ship has not enough fuel capacity to make a hyperspace jump. If it took off, it would be unable to leave this star system.`
+	`This ship has insufficient fuel capacity to make a hyperspace jump. If it took off, it would be unable to leave this star system.`

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -464,8 +464,8 @@ tip "limited turn?"
 tip "solar power?"
 	`This ship is powered entirely by solar energy. If you fly too far from the center of a star system, maneuvering may become difficult because your engines will only have a fraction of the power they require.`
 
-tip "no fuel?"
-	`This ship has no fuel. If it took off, it would be unable to leave this star system.`
-
 tip "no hyperdrive?"
 	`This ship has no hyperdrive. If it took off, it would be unable to leave this star system.`
+
+tip "no fuel?"
+	`This ship has not enough fuel. If it took off, it would be unable to leave this star system.`

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -464,5 +464,8 @@ tip "limited turn?"
 tip "solar power?"
 	`This ship is powered entirely by solar energy. If you fly too far from the center of a star system, maneuvering may become difficult because your engines will only have a fraction of the power they require.`
 
+tip "no fuel?"
+	`This ship has no fuel. If it took off, it would be unable to leave this star system.`
+
 tip "no hyperdrive?"
 	`This ship has no hyperdrive. If it took off, it would be unable to leave this star system.`

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -468,4 +468,4 @@ tip "no hyperdrive?"
 	`This ship has no hyperdrive. If it took off, it would be unable to leave this star system.`
 
 tip "no fuel?"
-	`This ship has not enough fuel. If it took off, it would be unable to leave this star system.`
+	`This ship has not enough fuel capacity to make a hyperspace jump. If it took off, it would be unable to leave this star system.`

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -736,9 +736,9 @@ string Ship::FlightCheck() const
 		return "limited turn?";
 	if(energy - .8 * solar < .2 * (turnEnergy + thrustEnergy))
 		return "solar power?";
-	if(!hyperDrive && !jumpDrive && !canBeCarried)
+	if(!canBeCarried && !hyperDrive && !jumpDrive)
 		return "no hyperdrive?";
-	if(fuel < JumpFuel(hyperspaceSystem) && !canBeCarried)
+	if(!canBeCarried && fuel < JumpFuel(hyperspaceSystem))
 		return "no fuel?";
 	
 	return "";

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -736,10 +736,10 @@ string Ship::FlightCheck() const
 		return "limited turn?";
 	if(energy - .8 * solar < .2 * (turnEnergy + thrustEnergy))
 		return "solar power?";
-	if(fuel <= 0. && !canBeCarried)
-		return "no fuel?";
 	if(!hyperDrive && !jumpDrive && !canBeCarried)
 		return "no hyperdrive?";
+	if(fuel < JumpFuel(hyperspaceSystem) && !canBeCarried)
+		return "no fuel?";
 	
 	return "";
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -703,6 +703,7 @@ string Ship::FlightCheck() const
 	double solar = attributes.Get("solar collection");
 	double battery = attributes.Get("energy capacity");
 	double energy = generation + solar + battery;
+	double fuel = attributes.Get("fuel capacity");
 	double thrust = attributes.Get("thrust");
 	double reverseThrust = attributes.Get("reverse thrust");
 	double afterburner = attributes.Get("afterburner thrust");
@@ -735,6 +736,8 @@ string Ship::FlightCheck() const
 		return "limited turn?";
 	if(energy - .8 * solar < .2 * (turnEnergy + thrustEnergy))
 		return "solar power?";
+	if(fuel <= 0. && !canBeCarried)
+		return "no fuel?";
 	if(!hyperDrive && !jumpDrive && !canBeCarried)
 		return "no hyperdrive?";
 	

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -736,10 +736,13 @@ string Ship::FlightCheck() const
 		return "limited turn?";
 	if(energy - .8 * solar < .2 * (turnEnergy + thrustEnergy))
 		return "solar power?";
-	if(!canBeCarried && !hyperDrive && !jumpDrive)
-		return "no hyperdrive?";
-	if(!canBeCarried && fuel < JumpFuel(hyperspaceSystem))
-		return "no fuel?";
+	if(!canBeCarried)
+	{
+		if(!hyperDrive && !jumpDrive)
+			return "no hyperdrive?";
+		if(fuel < JumpFuel(hyperspaceSystem))
+			return "no fuel?";
+	}
 	
 	return "";
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -740,7 +740,7 @@ string Ship::FlightCheck() const
 	{
 		if(!hyperDrive && !jumpDrive)
 			return "no hyperdrive?";
-		if(fuel < JumpFuel(hyperspaceSystem))
+		if(fuel < JumpFuel())
 			return "no fuel?";
 	}
 	

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -703,7 +703,7 @@ string Ship::FlightCheck() const
 	double solar = attributes.Get("solar collection");
 	double battery = attributes.Get("energy capacity");
 	double energy = generation + solar + battery;
-	double fuel = attributes.Get("fuel capacity");
+	double fuelCapacity = attributes.Get("fuel capacity");
 	double thrust = attributes.Get("thrust");
 	double reverseThrust = attributes.Get("reverse thrust");
 	double afterburner = attributes.Get("afterburner thrust");
@@ -740,7 +740,7 @@ string Ship::FlightCheck() const
 	{
 		if(!hyperDrive && !jumpDrive)
 			return "no hyperdrive?";
-		if(fuel < JumpFuel())
+		if(fuelCapacity < JumpFuel())
 			return "no fuel?";
 	}
 	


### PR DESCRIPTION
Currently all ships have some internal fuel capacity. However, it is not inconceivable ships with 0 fuel might be introduced, or outfits that lower the fuel capacity. (In fact I'm working on a plug-in that changes all ships to have 0 fuel.)
This patch introduces a "no fuel?" warning, analoguous to the "no hyperdrive?" warning (#3635).