### PR TITLE
tweaked javelin reload time

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -774,7 +774,7 @@ outfit "Javelin Pod"
 		"inaccuracy" 1
 		"velocity" 10
 		"lifetime" 60
-		"reload" 20
+		"reload" 15
 		"firing energy" .2
 		"firing heat" 12
 		"shield damage" 48


### PR DESCRIPTION
Currently the javelin pod (size 12) only has a better capacity than the meteor missile launcher (size 10), but in all other respects is significantly worse. This patch reduces the javelin's reload time from 20 to 15, which, although still not great, makes it at least a viable choice.

Before:
![screenshot from 2018-07-14 13-37-44](https://user-images.githubusercontent.com/21634324/42724108-9ad4e5d6-876c-11e8-8295-e68484039968.png)

After:
![screenshot from 2018-07-14 13-39-14](https://user-images.githubusercontent.com/21634324/42724113-9f18db66-876c-11e8-8dc1-4c69b5a8ec8b.png)
