### PR TITLE
Remove ramscoop from Sestor fighter and drone

### DIFF
--- a/data/korath ships.txt
+++ b/data/korath ships.txt
@@ -827,7 +827,6 @@ ship "Far Lek 14"
 	description "At the peak of their recent civil war, the Kor Sestor faction developed these automated attack drones, easy to manufacture and encased in an ultra-dense hull that can absorb a significant amount of damage."
 
 
-
 ship "Far Osk 27"
 	sprite "ship/far osk 27"
 	thumbnail "thumbnail/far osk 27"
@@ -865,6 +864,7 @@ ship "Far Osk 27"
 	explode "tiny explosion" 25
 	explode "small explosion" 15
 	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to carry far more weaponry than any comparable human ship."
+
 
 
 ship "Model 8"

--- a/data/korath ships.txt
+++ b/data/korath ships.txt
@@ -805,7 +805,6 @@ ship "Far Lek 14"
 		"weapon capacity" 11
 		"engine capacity" 24
 		"self destruct" .6
-		"ramscoop" 3
 		weapon
 			"blast radius" 5
 			"shield damage" 50
@@ -845,7 +844,6 @@ ship "Far Osk 27"
 		"weapon capacity" 22
 		"engine capacity" 24
 		"self destruct" .6
-		"ramscoop" 3
 		weapon
 			"blast radius" 12
 			"shield damage" 120


### PR DESCRIPTION
The Kor Sestor "Far Osk 27" fighter and "Far Lek 14" drone somehow have a ramscoop value of 3. They don't have fuel nor a hyperdrive, therefore this is rather useless and should be removed.