### PR TITLE
Center the turret on Pointedstick's Vanguard

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -333,7 +333,7 @@ person "Captain Nate"
 		gun -31 -45 "Heavy Rocket Launcher"
 		gun 31 -45 "Heavy Rocket Launcher"
 		gun 31 -45 "Heavy Rocket Launcher"
-		turret 0 40 "Anti-Missile Turret"
+		turret -1 44 "Anti-Missile Turret"
 		explode "tiny explosion" 18
 		explode "small explosion" 36
 		explode "medium explosion" 24


### PR DESCRIPTION
While messing around with the hull config for Pointedstick's Vanguard for a ship in my mod, it was brought to my attention that the turret was off-center. Upon checking the actual ship, I found this was the case. This change should _hopefully_ center the turret.