### PR TITLE
Improve the playability and tactical flexibility of human missile weapons

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -650,7 +650,7 @@ outfit "Meteor Missile Launcher"
 		"fire effect" "meteor fire"
 		"die effect" "missile death"
 		"hit effect" "missile hit"
-		"inaccuracy" 10
+		"inaccuracy" 5
 		"velocity" 13
 		"lifetime" 415
 		"reload" 75
@@ -658,7 +658,7 @@ outfit "Meteor Missile Launcher"
 		"firing heat" 20
 		"acceleration" 1
 		"drag" .1
-		"turn" 1.25
+		"turn" 1.3
 		"homing" 3
 		"infrared tracking" .8
 		"shield damage" 220
@@ -823,14 +823,14 @@ outfit "Torpedo Launcher"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 5
+		"velocity" 5.5
 		"lifetime" 720
 		"reload" 150
 		"firing energy" 2
 		"firing heat" 45
 		"acceleration" .15
 		"drag" .025
-		"turn" 1.3
+		"turn" 1.5
 		"homing" 3
 		"optical tracking" .8
 		"shield damage" 650
@@ -885,14 +885,14 @@ outfit "Typhoon Launcher"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 4
-		"lifetime" 750
+		"velocity" 4.5
+		"lifetime" 900
 		"reload" 140
 		"firing energy" 4
 		"firing heat" 50
 		"acceleration" .1
 		"drag" .02
-		"turn" 1.5
+		"turn" 1.8
 		"homing" 4
 		"optical tracking" .9
 		"shield damage" 900

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -824,7 +824,7 @@ outfit "Torpedo Launcher"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
 		"velocity" 5.5
-		"lifetime" 720
+		"lifetime" 920
 		"reload" 150
 		"firing energy" 2
 		"firing heat" 45
@@ -886,7 +886,7 @@ outfit "Typhoon Launcher"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
 		"velocity" 4.5
-		"lifetime" 900
+		"lifetime" 1200
 		"reload" 140
 		"firing energy" 4
 		"firing heat" 50

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -651,18 +651,18 @@ outfit "Meteor Missile Launcher"
 		"die effect" "missile death"
 		"hit effect" "missile hit"
 		"inaccuracy" 10
-		"velocity" 9
-		"lifetime" 600
-		"reload" 48
+		"velocity" 13
+		"lifetime" 415
+		"reload" 75
 		"firing energy" 1
 		"firing heat" 20
-		"acceleration" .9
+		"acceleration" 1
 		"drag" .1
-		"turn" 2
+		"turn" 1.25
 		"homing" 3
 		"infrared tracking" .8
-		"shield damage" 130
-		"hull damage" 80
+		"shield damage" 220
+		"hull damage" 150
 		"hit force" 220
 		"missile strength" 4
 	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. Meteors are quickly destroyed by anti-missile systems, and their infrared tracking systems have trouble homing in on targets with low heat levels. Nevertheless, they can be deadly in large numbers and against poorly-defended targets."
@@ -713,18 +713,18 @@ outfit "Sidewinder Missile Launcher"
 		"die effect" "missile death"
 		"hit effect" "missile hit"
 		"inaccuracy" 4
-		"velocity" 11
-		"lifetime" 600
-		"reload" 40
+		"velocity" 12
+		"lifetime" 550
+		"reload" 60
 		"firing energy" 1
 		"firing heat" 15
-		"acceleration" 1.1
+		"acceleration" 1.2
 		"drag" .1
-		"turn" 3
+		"turn" 5
 		"homing" 4
 		"radar tracking" .9
-		"shield damage" 100
-		"hull damage" 70
+		"shield damage" 165
+		"hull damage"115
 		"hit force" 170
 		"missile strength" 12
 	description "The Sidewinder Missile is designed by Lovelace Labs, which is ironically also the designer of the Anti-Missile Turret. Rumors say that the two engineering teams at Lovelace who make the missiles and the anti-missiles are locked in furious competition with each other: the result has been generation after generation of smarter missiles and then smarter turrets to fend them off."
@@ -777,8 +777,8 @@ outfit "Javelin Pod"
 		"reload" 15
 		"firing energy" .2
 		"firing heat" 12
-		"shield damage" 48
-		"hull damage" 26
+		"shield damage" 55
+		"hull damage" 30
 		"hit force" 50
 		"missile strength" 2
 	description "The Javelin Pod fires a rapid stream of unguided missiles. A Javelin Pod does far more damage than any gun of a comparable size, and has a longer range as well, but once a ship has fired off all its ammunition it must leave combat and find a planet where it can buy more, which makes Javelins less useful in protracted battles. As a result, they are very popular with pirates as a way to quickly disable a small target."
@@ -823,20 +823,20 @@ outfit "Torpedo Launcher"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 6
-		"lifetime" 600
-		"reload" 120
+		"velocity" 5
+		"lifetime" 720
+		"reload" 150
 		"firing energy" 2
 		"firing heat" 45
 		"acceleration" .15
 		"drag" .025
-		"turn" 1.5
+		"turn" 1.3
 		"homing" 3
 		"optical tracking" .8
-		"shield damage" 450
-		"hull damage" 450
+		"shield damage" 650
+		"hull damage" 650
 		"hit force" 300
-		"missile strength" 30
+		"missile strength" 36
 	description "Torpedoes are the most powerful homing weapon, but they move slowly enough that fast ships can simply outrun them, making them most useful against large targets or against small ships at times when they are too distracted to dodge. Torpedo launchers are also much larger than other missile systems, so they are most often found in capital ships."
 
 effect "torpedo fire"
@@ -885,20 +885,20 @@ outfit "Typhoon Launcher"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 5
-		"lifetime" 600
-		"reload" 100
+		"velocity" 4
+		"lifetime" 750
+		"reload" 140
 		"firing energy" 4
 		"firing heat" 50
 		"acceleration" .1
 		"drag" .02
-		"turn" 1.8
+		"turn" 1.5
 		"homing" 4
 		"optical tracking" .9
-		"shield damage" 610
-		"hull damage" 610
+		"shield damage" 900
+		"hull damage" 900
 		"hit force" 450
-		"missile strength" 40
+		"missile strength" 50
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."
 
 effect "typhoon fire"
@@ -946,15 +946,15 @@ outfit "Heavy Rocket Launcher"
 		"inaccuracy" 1
 		"velocity" 8
 		"lifetime" 100
-		"reload" 200
+		"reload" 240
 		"firing energy" 1
 		"firing heat" 250
 		"acceleration" .8
 		"drag" .1
 		"trigger radius" 30
 		"blast radius" 50
-		"shield damage" 700
-		"hull damage" 600
+		"shield damage" 1000
+		"hull damage" 800
 		"hit force" 600
 		"missile strength" 16
 	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -651,21 +651,21 @@ outfit "Meteor Missile Launcher"
 		"die effect" "missile death"
 		"hit effect" "missile hit"
 		"inaccuracy" 5
-		"velocity" 13
-		"lifetime" 415
-		"reload" 75
+		"velocity" 11
+		"lifetime" 490
+		"reload" 80
 		"firing energy" 1
 		"firing heat" 20
 		"acceleration" 1
 		"drag" .1
-		"turn" 1.3
+		"turn" 1.35
 		"homing" 3
 		"infrared tracking" .8
-		"shield damage" 220
-		"hull damage" 150
+		"shield damage" 260
+		"hull damage" 160
 		"hit force" 220
 		"missile strength" 4
-	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. Meteors are quickly destroyed by anti-missile systems, and their infrared tracking systems have trouble homing in on targets with low heat levels. Nevertheless, they can be deadly in large numbers and against poorly-defended targets."
+	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. Meteors are quickly destroyed by anti-missile systems, and their infrared tracking systems have trouble homing in on targets with low heat levels. Nevertheless, their large warheads can spell doom for poorly-defended targets when the missiles are fired in great numbers."
 
 effect "meteor fire"
 	sprite "effect/meteor fire"
@@ -677,7 +677,7 @@ effect "meteor fire"
 
 outfit "Sidewinder Missile"
 	category "Ammunition"
-	cost 800
+	cost 900
 	thumbnail "outfit/sidewinder"
 	"mass" .2
 	"sidewinder capacity" -1
@@ -713,22 +713,22 @@ outfit "Sidewinder Missile Launcher"
 		"die effect" "missile death"
 		"hit effect" "missile hit"
 		"inaccuracy" 4
-		"velocity" 12
-		"lifetime" 550
+		"velocity" 14
+		"lifetime" 470
 		"reload" 60
 		"firing energy" 1
 		"firing heat" 15
 		"acceleration" 1.2
 		"drag" .1
-		"turn" 5
+		"turn" 4
 		"homing" 4
 		"radar tracking" .9
-		"shield damage" 165
-		"hull damage"115
+		"shield damage" 180
+		"hull damage" 125
 		"hit force" 170
 		"missile strength" 12
 	description "The Sidewinder Missile is designed by Lovelace Labs, which is ironically also the designer of the Anti-Missile Turret. Rumors say that the two engineering teams at Lovelace who make the missiles and the anti-missiles are locked in furious competition with each other: the result has been generation after generation of smarter missiles and then smarter turrets to fend them off."
-	description "	Although not as powerful or cheap as the popular Meteor missiles, Sidewinders have several advantages, including their better tracking systems and protective casings that make them much harder for anti-missile systems to destroy."
+	description "	Although not as powerful or cheap as the popular Meteor missiles, Sidewinders have several advantages, including their superior maneuverability, better tracking systems, and protective casings that make them much harder for anti-missile systems to destroy."
 
 effect "sidewinder fire"
 	sprite "effect/sidewinder fire"
@@ -777,8 +777,8 @@ outfit "Javelin Pod"
 		"reload" 15
 		"firing energy" .2
 		"firing heat" 12
-		"shield damage" 55
-		"hull damage" 30
+		"shield damage" 57
+		"hull damage" 36
 		"hit force" 50
 		"missile strength" 2
 	description "The Javelin Pod fires a rapid stream of unguided missiles. A Javelin Pod does far more damage than any gun of a comparable size, and has a longer range as well, but once a ship has fired off all its ammunition it must leave combat and find a planet where it can buy more, which makes Javelins less useful in protracted battles. As a result, they are very popular with pirates as a way to quickly disable a small target."
@@ -823,8 +823,8 @@ outfit "Torpedo Launcher"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 5.5
-		"lifetime" 920
+		"velocity" 6
+		"lifetime" 600
 		"reload" 150
 		"firing energy" 2
 		"firing heat" 45
@@ -833,10 +833,10 @@ outfit "Torpedo Launcher"
 		"turn" 1.5
 		"homing" 3
 		"optical tracking" .8
-		"shield damage" 650
-		"hull damage" 650
+		"shield damage" 680
+		"hull damage" 680
 		"hit force" 300
-		"missile strength" 36
+		"missile strength" 30
 	description "Torpedoes are the most powerful homing weapon, but they move slowly enough that fast ships can simply outrun them, making them most useful against large targets or against small ships at times when they are too distracted to dodge. Torpedo launchers are also much larger than other missile systems, so they are most often found in capital ships."
 
 effect "torpedo fire"
@@ -885,20 +885,20 @@ outfit "Typhoon Launcher"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 4.5
-		"lifetime" 1200
-		"reload" 140
+		"velocity" 5
+		"lifetime" 600
+		"reload" 120
 		"firing energy" 4
 		"firing heat" 50
 		"acceleration" .1
 		"drag" .02
-		"turn" 1.8
+		"turn" 1.5
 		"homing" 4
 		"optical tracking" .9
-		"shield damage" 900
-		"hull damage" 900
+		"shield damage" 880
+		"hull damage" 880
 		"hit force" 450
-		"missile strength" 50
+		"missile strength" 40
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."
 
 effect "typhoon fire"
@@ -944,7 +944,7 @@ outfit "Heavy Rocket Launcher"
 		"hit effect" "heavy rocket hit"
 		"die effect" "small explosion"
 		"inaccuracy" 1
-		"velocity" 8
+		"velocity" 9
 		"lifetime" 100
 		"reload" 240
 		"firing energy" 1
@@ -953,8 +953,8 @@ outfit "Heavy Rocket Launcher"
 		"drag" .1
 		"trigger radius" 30
 		"blast radius" 50
-		"shield damage" 1000
-		"hull damage" 800
+		"shield damage" 850
+		"hull damage" 720
 		"hit force" 600
 		"missile strength" 16
 	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."


### PR DESCRIPTION
Here's version 2 of my attempt to improve human missile playability, this time with more moderation and a lot more playtesting for balance.

All human missiles get +20% DPS to improve their combat usefulness compared to gun weapons. They get large increases in per-missile damage, accompanied (mostly) by significant reductions in missile launcher fire rate. Some missiles get a few additional tweaks to refine their battle roles.

The overall effect of these changes is to differentiate the human missiles from one another in terms of their ideal battle roles  in a way that makes the game world feel more realistic, and to make using them and facing them in battle more fun:
- Since missiles how have much larger per-missile payloads, getting a hit with individual missiles makes a difference: missiles feel powerful, not like little pinpricks.
- High missile damage coupled with low fire rate makes missile combat significantly cheaper and slower to drain missile magazines, which reduces the frustration of running out of ammo and needing to buy more missiles all the time.
- Being both faster and less agile, Meteors are now significantly easier to dodge in a small fast ship which makes the start of the game less frustrating for new players.
- Sidewinders are now much better at shooting down small fast ships, but their higher cost-per-DPS makes them not cost-effective to use against large ships. Against poorly-protected large ships, Meteors are a better option, and against well-defended capital ships, Torpedoes are more appropriate. Where Sidewinders shine is as defensive weapons against small incoming fighter-sized craft, much like modern ship-launched anti-air missiles. They can also be mounted to said fighter-sides craft to shoot down other fighters.
- Javelin pods' very high DPS/ton turns them into a real option. A fighter-sized craft with two Javelin pods is actually threatening.

I played through the early game as all three starting ships, and then most of the Free Worlds campaign in various transports, freighters, and light-to-medium warships. It was substantially easier to avoid being frustratingly killed by Meteor-armed pirates when flying a Shuttle or Sparrow. Major battles went more or less the same way. The Star Barge was very slightly harder without an anti-missile turret, but that was an easy fix: install an anti-missile turret! Overall I had _much_ more fun using missile weapons and nothing felt unbalanced.