### PR TITLE
Tweaked some small human ships

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2936,7 +2936,7 @@ ship "Surveillance Drone"
 	engine -5 29
 	engine 5 29
 	explode "tiny explosion" 15
-	description "Surveillance drones are unarmed drones used by the Republic navy to scan ships and planets in a star system."
+	description "Surveillance Drones are unarmed drones used by the Republic navy to scan ships and planets in a star system."
 
 
 

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -558,7 +558,7 @@ ship "Bounder"
 		"fuel capacity" 900
 		"cargo space" 40
 		"outfit space" 220
-		"weapon capacity" 50
+		"weapon capacity" 45
 		"engine capacity" 110
 		weapon
 			"blast radius" 30

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -559,7 +559,7 @@ ship "Bounder"
 		"cargo space" 40
 		"outfit space" 220
 		"weapon capacity" 45
-		"engine capacity" 90
+		"engine capacity" 110
 		weapon
 			"blast radius" 30
 			"shield damage" 300

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1805,7 +1805,7 @@ ship "Headhunter"
 		"fuel capacity" 400
 		"cargo space" 50
 		"outfit space" 250
-		"weapon capacity" 60
+		"weapon capacity" 70
 		"engine capacity" 80
 		weapon
 			"blast radius" 44

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -135,7 +135,7 @@ ship "Arrow"
 		"required crew" 1
 		"bunks" 5
 		"mass" 130
-		"drag" 2.7
+		"drag" 2.2
 		"heat dissipation" .85
 		"fuel capacity" 400
 		"cargo space" 10

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -915,7 +915,7 @@ ship "Combat Drone"
 	engine 9 29
 	gun 0 -29 "Beam Laser"
 	explode "tiny explosion" 15
-	description "Combat Drones are pilotless attack ships used primarily by the Republic Navy. Although very weak and easy to destroy, they can be very effective in large numbers. Because drones do not need a cockpit, they can be filled entirely with equipment and solid metal, which makes their hulls stronger than other small ships."
+	description "Combat drones are pilotless attack ships used primarily by the Republic Navy. Although very weak and easy to destroy, they can be very effective in large numbers. Because drones do not need a cockpit, they can be filled entirely with equipment and solid metal, which makes their hulls stronger than other small ships."
 
 
 
@@ -1565,7 +1565,7 @@ ship "Gunboat"
 	explode "small explosion" 20
 	explode "medium explosion" 15
 	"final explode" "final explosion small"
-	description "The Navy Gunboat is designed for engaging targets at short range, and also serves as the Navy's mobile sensor platform, scanning ships for illegal equipment or cargo."
+	description "The Navy gunboat is designed for engaging targets at short range, and also serves as the Navy's mobile sensor platform, scanning ships for illegal equipment or cargo."
 
 
 
@@ -2936,7 +2936,7 @@ ship "Surveillance Drone"
 	engine -5 29
 	engine 5 29
 	explode "tiny explosion" 15
-	description "Surveillance Drones are unarmed drones used by the Republic navy to scan ships and planets in a star system."
+	description "Surveillance drones are unarmed drones used by the Republic navy to scan ships and planets in a star system."
 
 
 
@@ -3041,4 +3041,4 @@ ship "Wasp"
 	leak "leak" 60 50
 	explode "tiny explosion" 20
 	explode "small explosion" 10
-	description "The Wasp is a medium-strength interceptor, designed by Syndicated Shipyards to serve as an escort for cargo vessels. Like most Syndicate ships, it is not particularly pretty, but it at least serves the purpose it was made for."
+	description "The wasp is a medium-strength interceptor, designed by Syndicated Shipyards to serve as an escort for cargo vessels. Like most Syndicate ships, it is not particularly pretty, but it at least serves the purpose it was made for."

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1757,7 +1757,7 @@ ship "Hawk"
 		"drag" 2.1
 		"heat dissipation" .8
 		"fuel capacity" 300
-		"cargo space" 30
+		"cargo space" 20
 		"outfit space" 200
 		"weapon capacity" 50
 		"engine capacity" 70

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1565,7 +1565,7 @@ ship "Gunboat"
 	explode "small explosion" 20
 	explode "medium explosion" 15
 	"final explode" "final explosion small"
-	description "The Navy gunboat is designed for engaging targets at short range, and also serves as the Navy's mobile sensor platform, scanning ships for illegal equipment or cargo."
+	description "The Navy Gunboat is designed for engaging targets at short range, and also serves as the Navy's mobile sensor platform, scanning ships for illegal equipment or cargo."
 
 
 

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -258,7 +258,7 @@ ship "Barb"
 		"heat dissipation" .78
 		"outfit space" 85
 		"weapon capacity" 24
-		"engine capacity" 22
+		"engine capacity" 20
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -300,7 +300,7 @@ ship "Barb" "Barb (Proton)"
 		"heat dissipation" .78
 		"outfit space" 85
 		"weapon capacity" 28
-		"engine capacity" 22
+		"engine capacity" 20
 		weapon
 			"blast radius" 12
 			"shield damage" 120

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1845,7 +1845,7 @@ ship "Heavy Shuttle"
 	attributes
 		category "Transport"
 		"cost" 320000
-		"shields" 700
+		"shields" 800
 		"hull" 700
 		"required crew" 1
 		"bunks" 8

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2602,8 +2602,8 @@ ship "Shuttle"
 	attributes
 		category "Transport"
 		"cost" 180000
-		"shields" 500
-		"hull" 600
+		"shields" 600
+		"hull" 500
 		"required crew" 1
 		"bunks" 6
 		"mass" 70

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -3041,4 +3041,4 @@ ship "Wasp"
 	leak "leak" 60 50
 	explode "tiny explosion" 20
 	explode "small explosion" 10
-	description "The wasp is a medium-strength interceptor, designed by Syndicated Shipyards to serve as an escort for cargo vessels. Like most Syndicate ships, it is not particularly pretty, but it at least serves the purpose it was made for."
+	description "The Wasp is a medium-strength interceptor, designed by Syndicated Shipyards to serve as an escort for cargo vessels. Like most Syndicate ships, it is not particularly pretty, but it at least serves the purpose it was made for."

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -915,7 +915,7 @@ ship "Combat Drone"
 	engine 9 29
 	gun 0 -29 "Beam Laser"
 	explode "tiny explosion" 15
-	description "Combat drones are pilotless attack ships used primarily by the Republic Navy. Although very weak and easy to destroy, they can be very effective in large numbers. Because drones do not need a cockpit, they can be filled entirely with equipment and solid metal, which makes their hulls stronger than other small ships."
+	description "Combat Drones are pilotless attack ships used primarily by the Republic Navy. Although very weak and easy to destroy, they can be very effective in large numbers. Because drones do not need a cockpit, they can be filled entirely with equipment and solid metal, which makes their hulls stronger than other small ships."
 
 
 

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1759,7 +1759,7 @@ ship "Hawk"
 		"fuel capacity" 300
 		"cargo space" 30
 		"outfit space" 200
-		"weapon capacity" 45
+		"weapon capacity" 50
 		"engine capacity" 70
 		weapon
 			"blast radius" 30

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1314,7 +1314,7 @@ ship "Flivver"
 	sprite "ship/flivver"
 	thumbnail "thumbnail/flivver"
 	attributes
-		category "Interceptor"
+		category "Transport"
 		"cost" 180000
 		"shields" 1400
 		"hull" 200

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1803,7 +1803,7 @@ ship "Headhunter"
 		"drag" 2.6
 		"heat dissipation" .8
 		"fuel capacity" 400
-		"cargo space" 50
+		"cargo space" 40
 		"outfit space" 250
 		"weapon capacity" 70
 		"engine capacity" 80

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -559,7 +559,7 @@ ship "Bounder"
 		"cargo space" 40
 		"outfit space" 220
 		"weapon capacity" 45
-		"engine capacity" 110
+		"engine capacity" 90
 		weapon
 			"blast radius" 30
 			"shield damage" 300

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1314,7 +1314,7 @@ ship "Flivver"
 	sprite "ship/flivver"
 	thumbnail "thumbnail/flivver"
 	attributes
-		category "Transport"
+		category "Interceptor"
 		"cost" 180000
 		"shields" 1400
 		"hull" 200
@@ -1759,7 +1759,7 @@ ship "Hawk"
 		"fuel capacity" 300
 		"cargo space" 30
 		"outfit space" 200
-		"weapon capacity" 40
+		"weapon capacity" 45
 		"engine capacity" 70
 		weapon
 			"blast radius" 30
@@ -3013,7 +3013,7 @@ ship "Wasp"
 		"fuel capacity" 400
 		"cargo space" 10
 		"outfit space" 150
-		"weapon capacity" 28
+		"weapon capacity" 30
 		"engine capacity" 60
 		weapon
 			"blast radius" 20


### PR DESCRIPTION
Summary:
* Hawk  +10 weapon capacity, –10 cargo space
* Wasp +2 weapon capacity
* Bounder –5 weapon capacity
* Headhunter  +10 weapon capacity, –10 cargo space
* Barb and Barb (Proton) –2 engine capacity
* Heavy Shuttle +100 shields
* Shuttle +100 shields, –100 hull
* Arrow –0.5 drag

Currently the Fury and the Hawk both have a weapon capacity of 40, allowing them to be equipped with two heavy rocket launchers or one typhoon launcher. However, the Hawk is a clearly larger ship and it's desciption states it's "much more heavily armed". Therefore I think it deserves more weapon capacity; this proposal increases it to <s>45</s> 50, which allows the Hawk to use two plasma cannons or torpedo launchers.
Furthermore, most interceptors have a cargo space of 10, the Fury has 15, but the Hawk has 30, equal to the Raven, a much larger ship. Therefore I propose to reduce the Hawk's from 30 to 20, which seems more reasonable (and is still enough to steal a jump drive).

The Wasp's weapon capacity is increased from 28 to 30, making it more versatile and less useless, and allowing it to compete with the Berserker (35), so both can equip three meteor launchers. This would put the Wasp, "a medium-strength interceptor", in between the Sparrow (can equip two meteors) and Fury (can equip four meteors).

The Bounder, explicitly "designed not for battle", currently has a weapon capacity of 50. This is reduced to 45, more than enough for its default build (30) or its variant (44).
<s>Furthermore, its current engine capacity (110) is very close to much larger ships, such as the Leviathan (120) or Star Queen (100), and far more than its default and variant builds need (81). The engine capacity is reduced to 90, still higher than e.g. the Arrow (60) or Heavy Shuttle (60).</s>

The Headhunter currently has a weapon capacity of 60, the same as the Quicksilver, which has no turret mount; by increasing it to 70, the Headhunter could equip a heavy laser turret and two heavy lasers, or an anti-missile turret and two torpedo launchers. Besides, it would fit nicely in between the Scout (40) and Hawk (50) on the one hand, Raven (90) and Gunboat (100) on the other.
Furthermore, reduced the Headhunter's cargo space from 50 to 40, for the same reasons as the Hawk's.

The Barb's description states it's "featuring newly-developed miniaturized ion engines", i.e. the `X1050 Ion Engines`, the description of which starts with "When designing the Barb". However, the X1050's size is 20, therefore the Barb doesn't need 22 engine capacity.

According to its description, the Arrow is "able to outrun nearly every other ship in the sky." Although its maximum speed (c. 600 per second) is above average, it is not really exceptional. Besides, it can't be sped up by installing more powerful engines, because it already has the largest atomic engines its capacity allows. By reducing its drag, its maximum speed is increased by c. 20%, allowing it to at least outrun most default human ship builds.

<s>Also changed Flivver category to "Interceptor", because its cargo size and bunks are very low.</s> 