### PR TITLE
tweaked javelin hull damage

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -778,8 +778,8 @@ outfit "Javelin Pod"
 		"firing energy" .2
 		"firing heat" 12
 		"shield damage" 48
-		"hull damage" 26
-		"hit force" 50
+		"hull damage" 36
+		"hit force" 48
 		"missile strength" 2
 	description "The Javelin Pod fires a rapid stream of unguided missiles. A Javelin Pod does far more damage than any gun of a comparable size, and has a longer range as well, but once a ship has fired off all its ammunition it must leave combat and find a planet where it can buy more, which makes Javelins less useful in protracted battles. As a result, they are very popular with pirates as a way to quickly disable a small target."
 


### PR DESCRIPTION
#3845 tweaked javelin reload time. This patch increases the javelin's hull damage by about a third, reduces hit force by 4%, and keeps the shield damage and other stats unchanged. This makes the javelin more useful for disabling or blowing up enemy ships. Although still not great, it becomes a somewhat more interesting choice. 