### PR TITLE
adjusted heavy rocket lifetime

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -652,7 +652,7 @@ outfit "Meteor Missile Launcher"
 		"hit effect" "missile hit"
 		"inaccuracy" 5
 		"velocity" 11
-		"lifetime" 490
+		"lifetime" 480
 		"reload" 80
 		"firing energy" 1
 		"firing heat" 20
@@ -714,7 +714,7 @@ outfit "Sidewinder Missile Launcher"
 		"hit effect" "missile hit"
 		"inaccuracy" 4
 		"velocity" 14
-		"lifetime" 470
+		"lifetime" 480
 		"reload" 60
 		"firing energy" 1
 		"firing heat" 15

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -945,7 +945,7 @@ outfit "Heavy Rocket Launcher"
 		"die effect" "small explosion"
 		"inaccuracy" 1
 		"velocity" 9
-		"lifetime" 100
+		"lifetime" 90
 		"reload" 240
 		"firing energy" 1
 		"firing heat" 250


### PR DESCRIPTION
#3866 increased the velocity of the meteor and sidewinder and reduced lifetime to keep range about unchanged. The heavy rocket velocity was also increased, but it was omitted to decrease the lifetime. This proposal adjusts it.
Old: 8×100=800
Current: 9×100=900
Proposed: 9×90=810

(Also rounded meteor and sidewinder lifetime from 490 and 470 respectively to 480, i.e. 8 seconds; the effect on range is hardly noticeable. Meteors and sidewinders are similar weapons and used to have identical lifetime (600). Likewise, torpedoes and typhoons still have the same lifetime (unchanged).)