### PR TITLE
corrected chaser description

### DIFF
--- a/data/korath ships.txt
+++ b/data/korath ships.txt
@@ -127,7 +127,7 @@ ship "Korath Chaser"
 	engine 7 23
 	gun 0 -28 "Korath Fire-Lance"
 	explode "tiny explosion" 20
-	description "The Korath Chaser is a fighter carried by most of their capital ships."
+	description "The Korath Chaser is a fighter carried by their raiding ships."
 
 
 

--- a/data/korath ships.txt
+++ b/data/korath ships.txt
@@ -127,7 +127,7 @@ ship "Korath Chaser"
 	engine 7 23
 	gun 0 -28 "Korath Fire-Lance"
 	explode "tiny explosion" 20
-	description "The Korath Chaser is a fighter carried by their raiding ships."
+	description "The Korath Chaser is a fighter carried by many of their ships."
 
 
 


### PR DESCRIPTION
Capital ships are the largest ships a fleet could possibly have. In the case of the Korath, the World-Ship. However, world-ships do not carry any chasers, raiders do.