### PR TITLE
moved variants from mission to ship files

### DIFF
--- a/data/variants.txt
+++ b/data/variants.txt
@@ -411,6 +411,39 @@ ship "Bulk Freighter" "Bulk Freighter (Proton)"
 
 
 
+ship "Carrier" "Carrier (Alpha)"
+	outfits
+		"Ion Cannon" 2
+		"Hai Tracker Pod" 4
+		"Hai Tracker" 224
+		"Korath Disruptor" 2
+		"Korath Slicer Turret" 2
+		
+		"Triple Plasma Core"
+		"Systems Core (Large)"
+		"Large Heat Shunt" 3
+		"Small Heat Shunt"
+		"Wanderer Ramscoop"
+		"Outfits Expansion" 4
+		"Laser Rifle" 120
+		
+		`"Bondir" Atomic Thruster`
+		"Steering (Stellar Class)"
+		"Jump Drive"
+	
+	gun "Hai Tracker Pod"
+	gun "Hai Tracker Pod"
+	gun "Ion Cannon"
+	gun "Ion Cannon"
+	gun "Hai Tracker Pod"
+	gun "Hai Tracker Pod"
+	gun
+	gun
+	turret "Korath Disruptor"
+	turret "Korath Slicer Turret"
+	turret "Korath Disruptor"
+	turret "Korath Slicer Turret"
+	
 ship "Carrier" "Carrier (Jump)"
 	outfits
 		"Particle Cannon" 4

--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -771,6 +771,15 @@ ship "Deep River"
 	"final explode" "final explosion large"
 	description "The Deep River is a bulk freighter, designed to carry cargo in detachable pods."
 
+ship "Deep River" "Deep River (Jump, Unarmed)"
+	outfits
+		"White Sun Reactor"
+		"Dark Storm Shielding" 3
+		"Fuel Pod"
+		"Type 2 Radiant Thruster"
+		"Type 4 Radiant Steering"
+		"Jump Drive"
+
 ship "Deep River" "Deep River 0"
 	sprite "ship/deep river 0"
 	add attributes

--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -776,6 +776,7 @@ ship "Deep River" "Deep River (Jump, Unarmed)"
 		"White Sun Reactor"
 		"Dark Storm Shielding" 3
 		"Fuel Pod"
+		
 		"Type 2 Radiant Thruster"
 		"Type 4 Radiant Steering"
 		"Jump Drive"

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -492,15 +492,6 @@ mission "Wanderers: Unfettered Diplomacy 1"
 	on accept
 		log `Volunteered to help bring a shipment of food to the Unfettered, as "tribute" from the Wanderers, in the hope that it will placate the Unfettered into making peace.`
 
-ship "Deep River" "Deep River (Jump, Unarmed)"
-	outfits
-		"White Sun Reactor"
-		"Dark Storm Shielding" 3
-		"Fuel Pod"
-		"Type 2 Radiant Thruster"
-		"Type 4 Radiant Steering"
-		"Jump Drive"
-
 
 
 mission "Wanderers: Unfettered Diplomacy 1A"
@@ -949,39 +940,6 @@ mission "Wanderers: Alpha Surveillance C (Pug)"
 				decline
 
 
-
-ship "Carrier" "Carrier (Alpha)"
-	outfits
-		"Ion Cannon" 2
-		"Hai Tracker Pod" 4
-		"Hai Tracker" 224
-		"Korath Disruptor" 2
-		"Korath Slicer Turret" 2
-		
-		"Triple Plasma Core"
-		"Systems Core (Large)"
-		"Large Heat Shunt" 3
-		"Small Heat Shunt"
-		"Wanderer Ramscoop"
-		"Outfits Expansion" 4
-		"Laser Rifle" 120
-		
-		`"Bondir" Atomic Thruster`
-		"Steering (Stellar Class)"
-		"Jump Drive"
-	
-	gun "Hai Tracker Pod"
-	gun "Hai Tracker Pod"
-	gun "Ion Cannon"
-	gun "Ion Cannon"
-	gun "Hai Tracker Pod"
-	gun "Hai Tracker Pod"
-	gun
-	gun
-	turret "Korath Disruptor"
-	turret "Korath Slicer Turret"
-	turret "Korath Disruptor"
-	turret "Korath Slicer Turret"
 
 mission "Wanderers: Alpha Surveillance D"
 	name "Find the Alphas"


### PR DESCRIPTION
Human ship variants are typically listed together in the `variants.txt` file; non-human ship variants are listed directly after the default ship in the same ship file. This is a sensible approach that helps preventing variants from being overlooked. 
However, the `wanderers start.txt` file defined two variants (Deep River (Jump, Unarmed) and Carrier (Alpha)), even though other campaign specific variants (e.g. Carrier (Jump), Deep River 0, Shield Beetle (Jump)) are defined elsewhere. This patch moves those two exceptions to the appropiate files.