### PR TITLE
Fix disabled ship state

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1559,7 +1559,7 @@ void Ship::DoGeneration()
 	double maxHull = attributes.Get("hull");
 	hull = min(hull, maxHull);
 	
-	isDisabled = isOverheated || hull < MinimumHull() || (!crew && RequiredCrew());
+	isDisabled = isOverheated || (abs(hull - MinimumHull()) >= 1 && hull < MinimumHull()) || (!crew && RequiredCrew());
 	
 	// Whenever not actively scanning, the amount of scan information the ship
 	// has "decays" over time. For a scanner with a speed of 1, one second of
@@ -1922,7 +1922,7 @@ bool Ship::IsDisabled() const
 	
 	double minimumHull = MinimumHull();
 	bool needsCrew = RequiredCrew() != 0;
-	return (hull < minimumHull || (!crew && needsCrew));
+	return ((abs(hull - minimumHull) >= 1 && hull < minimumHull) || (!crew && needsCrew));
 }
 
 


### PR DESCRIPTION
When a ship is disabled and recovered by boarding it will become re-disabled when the player lands on a planet without repair capabilities and reloads game.

To duplicate:
1. Go out into a system with a de-populated planet with a escort
2. Set a escort's hull to the calculated minimum hull value up to 8 digits
3. Recover escort by boarding
4. Land to save game
5. Reload
6. Escort should be disabled again

I'm pretty sure that using the `sqrt` function is creating trailing decimals that are causing the `MinimumHull` to always exceed the value stored in the save file for a disabled ship.

Using a `Model 8` as a example:
Value in save file: `576.19441`
Return value of call to `MinimumHull`: `max(.15, min(.45, 10. / sqrt(3320))) = 576.19441163...`

**Relevant files**
https://github.com/endless-sky/endless-sky/blob/f63e258e03287f38908e889a659e991fd2ba51f4/source/Ship.cpp#L3001-L3008

https://github.com/endless-sky/endless-sky/blob/f63e258e03287f38908e889a659e991fd2ba51f4/source/DataWriter.cpp#L29-L33