### PR TITLE
correct jump speed displayed

### DIFF
--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -43,6 +43,7 @@ namespace {
 		{"hull repair rate", 60.},
 		{"hull energy", 60.},
 		{"hull heat", 60.},
+		{"jump speed", 60.},
 		{"reverse thrusting energy", 60.},
 		{"reverse thrusting heat", 60.},
 		{"shield generation", 60.},


### PR DESCRIPTION
Jump speed is a velocity and should thus be displayed in its per second value, as is done for similar stats.