### PR TITLE
tweaked gatling

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -1059,8 +1059,8 @@ outfit "Bullet Boxes"
 	category "Ammunition"
 	cost 3000
 	thumbnail "outfit/bullet storage"
-	"mass" 2
-	"outfit space" -5
+	"mass" 1
+	"outfit space" -4
 	"gatling round capacity" 1500
 	ammo "Gatling Gun Ammo"
 	description "Bullet Boxes are used to store extra ammunition for Gatling Guns."
@@ -1082,7 +1082,7 @@ outfit "Gatling Gun"
 		icon "icon/gat"
 		"inaccuracy" 2
 		"velocity" 16
-		"lifetime" 1
+		"lifetime" 2
 		"reload" 3
 		"burst count" 180
 		"burst reload" 1
@@ -1102,7 +1102,7 @@ outfit "gbullet"
 		"random velocity" 8
 		"lifetime" 20
 		"random lifetime" 5
-		"shield damage" 3
+		"shield damage" 4
 		"hull damage" 6
 		"hit force" 2
 		"hit effect" "bullet impact"


### PR DESCRIPTION
b59a4ef25dd16c4ebe4fc5b4bb94cdda6c8835aa improved the damage per second of most human missiles by 20%. 
As a consequence the gap between javelin pods (size 12) and gatling guns (size 8) has widened. Yes, gatlings do not suffer from anti-missile systems, but bullets are also sold in fewer outfitters. Therefore I think they deserve some improvement. Currently:
![screenshot from 2018-09-08 19-03-30](https://user-images.githubusercontent.com/21634324/45256783-c454e180-b39b-11e8-82d8-f69ce5e8612d.png)

This proposal:
* increases gatling's shield damage by a third but leaves hull damage untouched;
* slightly tweaks lifetime to get average range between beam (300) and heavy (400) lasers;
* reduces bullet boxes size by one, because ammunition storage is typically half the size of the launcher (meteor 5/10, javelin 6/12, sidewinder 7/14) or less (larger launchers).

As a consequence:
![screenshot from 2018-09-08 19-06-54](https://user-images.githubusercontent.com/21634324/45256848-6ffe3180-b39c-11e8-9422-2d447873ae31.png)

So the javelin pod is 50% larger and now inflicts about +200% shield and +20% hull damage compared to the gatling. (Shield damage per credit is 57/50 for the javelin and 4/4 for the gatling).