### PR TITLE
Fixed grammer usage of parole

### DIFF
--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -149,7 +149,7 @@ mission "Liberate Kornephoros"
 			
 			label speech
 			`	Tomek climbs up onto the hull of a nearby ship and addresses the prisoners. "Hello," he says. A few of the Navy officers respond, warily. "My name is Tomek Voigt," he says. "Our militia is very loosely organized, but I'm the one in charge of organizing it." That gets a few laughs from the Free Worlds guards. "As such, I am responsible for deciding your fate."`
-			`	At that, a hush falls over the crowd. "The Council has decided," he continues, "that any of you who gives us your parole, swearing to take no further part in fighting the Free Worlds, will be returned to Republic space. You will give us your word of honor that you will either seek reassignment in another part of the galaxy, or resign your commission."`
+			`	At that, a hush falls over the crowd. "The Council has decided," he continues, "that any of you who gives us your word, swearing to take no further part in fighting the Free Worlds, will receive parole and be returned to Republic space. You will give us your word of honor that you will either seek reassignment in another part of the galaxy, or resign your commission."`
 			`	A few of the Free Worlds guards shout, "What?" But only a surprising few. The rest are nodding, seemingly pleased with the Council's choice. Tomek climbs down from the hull and approaches the prisoners, and you notice Alondo and Freya have joined him.`
 			`	One of the Navy officers stands up. "I'll take that oath," he says, "if you'll honor your part of it."`
 			`	Tomek takes the man's hands, looks him in the eyes, and asks, "Do you swear before God and these witnesses to take no further part in military actions against the Free Worlds?"`


### PR DESCRIPTION
Parole was being used in the wrong direction asking the navy to provide it instead of requiring them to accept the conditions to receive it.