### PR TITLE
remove extra call to glUniform1i in Font.cpp

### DIFF
--- a/source/Font.cpp
+++ b/source/Font.cpp
@@ -475,9 +475,6 @@ void Font::SetUpShader(float glyphW, float glyphH)
 	screenWidth = 0;
 	screenHeight = 0;
 	
-	// The texture always comes from texture unit 0.
-	glUniform1i(shader.Uniform("tex"), 0);
-
 	colorI = shader.Uniform("color");
 	scaleI = shader.Uniform("scale");
 	glyphI = shader.Uniform("glyph");


### PR DESCRIPTION
https://github.com/endless-sky/endless-sky/commit/406c34e2baf6f88246d45a7ac70b8751c2c9092e#diff-38b37fd2bcdee403e42b45bbde753a3e moved the call to `glUniform1i(shader.Uniform("tex"), 0);` in `Font::SetUpShader()` up top without removing the old one. 

The second call logs `glUniform1i has failed because the operation requires a currently active program object (GL_INVALID_OPERATION)` if gl context debugging is enabled.