### PR TITLE
Pilot's License Implementation

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -13,6 +13,8 @@ ship "Aerie"
 	thumbnail "thumbnail/aerie"
 	attributes
 		category "Medium Warship"
+		licenses
+			Pilot's
 		"cost" 3500000
 		"shields" 5700
 		"hull" 1900
@@ -72,6 +74,8 @@ ship "Argosy"
 	thumbnail "thumbnail/argosy"
 	attributes
 		category "Light Freighter"
+		licenses
+			Pilot's
 		"cost" 1960000
 		"shields" 4200
 		"hull" 2600
@@ -129,6 +133,8 @@ ship "Arrow"
 	thumbnail "thumbnail/arrow"
 	attributes
 		category "Transport"
+		licenses
+			Pilot's
 		"cost" 1200000
 		"shields" 2000
 		"hull" 400
@@ -180,6 +186,8 @@ ship "Bactrian"
 	thumbnail "thumbnail/bactrian"
 	attributes
 		category "Heavy Warship"
+		licenses
+			Pilot's
 		"cost" 17600000
 		"shields" 17500
 		"hull" 8600
@@ -248,6 +256,8 @@ ship "Barb"
 	thumbnail "thumbnail/barb"
 	attributes
 		category "Fighter"
+		licenses
+			Pilot's
 		"cost" 50000
 		"shields" 800
 		"hull" 200
@@ -290,6 +300,8 @@ ship "Barb" "Barb (Proton)"
 	thumbnail "thumbnail/barbp"
 	attributes
 		category "Fighter"
+		licenses
+			Pilot's
 		"cost" 50000
 		"shields" 800
 		"hull" 200
@@ -330,6 +342,8 @@ ship "Bastion"
 	thumbnail "thumbnail/bastion"
 	attributes
 		category "Medium Warship"
+		licenses
+			Pilot's
 		"cost" 3560000
 		"shields" 6700
 		"hull" 4200
@@ -390,6 +404,8 @@ ship "Behemoth"
 	thumbnail "thumbnail/behemoth"
 	attributes
 		category "Heavy Freighter"
+		licenses
+			Pilot's
 		"cost" 10800000
 		"shields" 7600
 		"hull" 6300
@@ -448,6 +464,8 @@ ship "Berserker"
 	thumbnail "thumbnail/berserker"
 	attributes
 		category "Interceptor"
+		licenses
+			Pilot's
 		"cost" 520000
 		"shields" 2200
 		"hull" 500
@@ -497,6 +515,8 @@ ship "Blackbird"
 	thumbnail "thumbnail/blackbird"
 	attributes
 		category "Transport"
+		licenses
+			Pilot's
 		"cost" 2230000
 		"shields" 4400
 		"hull" 900
@@ -547,6 +567,8 @@ ship "Bounder"
 	thumbnail "thumbnail/bounder"
 	attributes
 		category "Transport"
+		licenses
+			Pilot's
 		"cost" 1140000
 		"shields" 2200
 		"hull" 700
@@ -594,6 +616,8 @@ ship "Boxwing"
 	thumbnail "thumbnail/boxwing"
 	attributes
 		category "Fighter"
+		licenses
+			Pilot's
 		cost 369000
 		"shields" 400
 		"hull" 800
@@ -631,6 +655,8 @@ ship "Bulk Freighter"
 	thumbnail "thumbnail/bulk freighter"
 	attributes
 		category "Heavy Freighter"
+		licenses
+			Pilot's
 		"cost" 9400000
 		"shields" 4000
 		"hull" 7600
@@ -769,6 +795,8 @@ ship "Class C Freighter"
 	thumbnail "thumbnail/bulk freighter"
 	attributes
 		category "Heavy Warship"
+		licenses
+			Pilot's
 		"cost" 11400000
 		"shields" 13500
 		"hull" 7600
@@ -834,6 +862,8 @@ ship "Clipper"
 	thumbnail "thumbnail/clipper"
 	attributes
 		category "Light Freighter"
+		licenses
+			Pilot's
 		"cost" 900000
 		"shields" 2700
 		"hull" 800
@@ -924,6 +954,8 @@ ship "Corvette"
 	thumbnail "thumbnail/corvette"
 	attributes
 		category "Medium Warship"
+		licenses
+			Pilot's
 		"cost" 4400000
 		"shields" 6100
 		"hull" 1200
@@ -1052,6 +1084,8 @@ ship "Dagger"
 	thumbnail "thumbnail/dagger"
 	attributes
 		category "Fighter"
+		licenses
+			Pilot's
 		"cost" 129000
 		"shields" 1000
 		"hull" 300
@@ -1093,6 +1127,8 @@ ship "Dreadnought"
 	thumbnail "thumbnail/dreadnought"
 	attributes
 		category "Heavy Warship"
+		licenses
+			Pilot's
 		"cost" 11900000
 		"shields" 18100
 		"hull" 7300
@@ -1156,6 +1192,8 @@ ship "Falcon"
 	thumbnail "thumbnail/falcon"
 	attributes
 		category "Heavy Warship"
+		licenses
+			Pilot's
 		"cost" 10900000
 		"shields" 12800
 		"hull" 3700
@@ -1218,6 +1256,8 @@ ship "Finch"
 	thumbnail "thumbnail/finch"
 	attributes
 		category "Fighter"
+		licenses
+			Pilot's
 		"cost" 126000
 		"shields" 1100
 		"hull" 200
@@ -1260,6 +1300,8 @@ ship "Firebird"
 	thumbnail "thumbnail/firebird"
 	attributes
 		category "Medium Warship"
+		licenses
+			Pilot's
 		"cost" 3700000
 		"shields" 6400
 		"hull" 2800
@@ -1315,6 +1357,8 @@ ship "Flivver"
 	thumbnail "thumbnail/flivver"
 	attributes
 		category "Transport"
+		licenses
+			Pilot's
 		"cost" 180000
 		"shields" 1400
 		"hull" 200
@@ -1361,6 +1405,8 @@ ship "Freighter"
 	thumbnail "thumbnail/freighter"
 	attributes
 		category "Light Freighter"
+		licenses
+			Pilot's
 		"cost" 730000
 		"shields" 2000
 		"hull" 2000
@@ -1473,6 +1519,8 @@ ship "Fury"
 	thumbnail "thumbnail/fury"
 	attributes
 		category "Interceptor"
+		licenses
+			Pilot's
 		"cost" 490000
 		"shields" 2000
 		"hull" 400
@@ -1574,6 +1622,8 @@ ship "Hauler"
 	thumbnail "thumbnail/hauler i"
 	attributes
 		category "Light Freighter"
+		licenses
+			Pilot's
 		"cost" 1430000
 		"shields" 2500
 		"hull" 3700
@@ -1632,6 +1682,8 @@ ship "Hauler II"
 	thumbnail "thumbnail/hauler ii"
 	attributes
 		category "Heavy Freighter"
+		licenses
+			Pilot's
 		"cost" 2340000
 		"shields" 2900
 		"hull" 5200
@@ -1690,6 +1742,8 @@ ship "Hauler III"
 	thumbnail "thumbnail/hauler iii"
 	attributes
 		category "Heavy Freighter"
+		licenses
+			Pilot's
 		"cost" 3260000
 		"shields" 3300
 		"hull" 6700
@@ -1748,6 +1802,8 @@ ship "Hawk"
 	thumbnail "thumbnail/hawk"
 	attributes
 		category "Interceptor"
+		licenses
+			Pilot's
 		"cost" 670000
 		"shields" 2500
 		"hull" 500
@@ -1794,6 +1850,8 @@ ship "Headhunter"
 	thumbnail "thumbnail/headhunter"
 	attributes
 		category "Light Warship"
+		licenses
+			Pilot's
 		"cost" 1850000
 		"shields" 3800
 		"hull" 700
@@ -1844,6 +1902,8 @@ ship "Heavy Shuttle"
 	thumbnail "thumbnail/heavy shuttle"
 	attributes
 		category "Transport"
+		licenses
+			Pilot's
 		"cost" 320000
 		"shields" 700
 		"hull" 700
@@ -1887,6 +1947,8 @@ ship "Lance"
 	thumbnail "thumbnail/lance"
 	attributes
 		category "Fighter"
+		licenses
+			Pilot's
 		"cost" 93000
 		"shields" 800
 		"hull" 400
@@ -1928,6 +1990,8 @@ ship "Leviathan"
 	thumbnail "thumbnail/leviathan"
 	attributes
 		category "Heavy Warship"
+		licenses
+			Pilot's
 		"cost" 9800000
 		"shields" 14400
 		"hull" 5000
@@ -1986,6 +2050,8 @@ ship "Manta"
 	thumbnail "thumbnail/manta"
 	attributes
 		category "Medium Warship"
+		licenses
+			Pilot's
 		"cost" 3400000
 		"shields" 5900
 		"hull" 1500
@@ -2041,6 +2107,8 @@ ship "Modified Argosy"
 	thumbnail "thumbnail/modified argosy"
 	attributes
 		category "Light Warship"
+		licenses
+			Pilot's
 		"cost" 1960000
 		"shields" 4800
 		"hull" 1900
@@ -2096,6 +2164,8 @@ ship "Mule"
 	thumbnail "thumbnail/mule"
 	attributes
 		category "Medium Warship"
+		licenses
+			Pilot's
 		"cost" 4580000
 		"shields" 5400
 		"hull" 4400
@@ -2155,6 +2225,8 @@ ship "Nest"
 	thumbnail "thumbnail/nest"
 	attributes
 		category "Medium Warship"
+		licenses
+			Pilot's
 		"cost" 2500000
 		"shields" 2500
 		"hull" 3700
@@ -2215,6 +2287,8 @@ ship "Osprey"
 	thumbnail "thumbnail/osprey"
 	attributes
 		category "Medium Warship"
+		licenses
+			Pilot's
 		"cost" 4400000
 		"shields" 7200
 		"hull" 1600
@@ -2272,6 +2346,8 @@ ship "Protector"
 	thumbnail "thumbnail/protector"
 	attributes
 		category "Heavy Warship"
+		licenses
+			Pilot's
 		"cost" 5500000
 		"shields" 9500
 		"hull" 6500
@@ -2331,6 +2407,8 @@ ship "Quicksilver"
 	thumbnail "thumbnail/quicksilver"
 	attributes
 		category "Light Warship"
+		licenses
+			Pilot's
 		"cost" 1090000
 		"shields" 3000
 		"hull" 800
@@ -2433,6 +2511,8 @@ ship "Raven"
 	thumbnail "thumbnail/raven"
 	attributes
 		category "Light Warship"
+		licenses
+			Pilot's
 		"cost" 1800000
 		"shields" 4700
 		"hull" 1400
@@ -2484,6 +2564,8 @@ ship "Roost"
 	thumbnail "thumbnail/roost"
 	attributes
 		category "Medium Warship"
+		licenses
+			Pilot's
 		"cost" 3000000
 		"shields" 2900
 		"hull" 5200
@@ -2546,6 +2628,8 @@ ship "Scout"
 	thumbnail "thumbnail/scout"
 	attributes
 		category "Transport"
+		licenses
+			Pilot's
 		"cost" 850000
 		"shields" 1200
 		"hull" 400
@@ -2601,6 +2685,8 @@ ship "Shuttle"
 	thumbnail "thumbnail/shuttle"
 	attributes
 		category "Transport"
+		licenses
+			Pilot's
 		"cost" 180000
 		"shields" 500
 		"hull" 600
@@ -2710,6 +2796,8 @@ ship "Sparrow"
 	thumbnail "thumbnail/sparrow"
 	attributes
 		category "Interceptor"
+		licenses
+			Pilot's
 		"cost" 225000
 		"shields" 1200
 		"hull" 300
@@ -2756,6 +2844,8 @@ ship "Splinter"
 	thumbnail "thumbnail/splinter"
 	attributes
 		category "Medium Warship"
+		licenses
+			Pilot's
 		"cost" 3100000
 		"shields" 5200
 		"hull" 1700
@@ -2812,6 +2902,8 @@ ship "Star Barge"
 	thumbnail "thumbnail/star barge"
 	attributes
 		category "Light Freighter"
+		licenses
+			Pilot's
 		"cost" 210000
 		"shields" 600
 		"hull" 1000
@@ -2855,6 +2947,8 @@ ship "Star Queen"
 	thumbnail "thumbnail/star queen"
 	attributes
 		category "Transport"
+		licenses
+			Pilot's
 		"cost" 5500000
 		"shields" 4100
 		"hull" 2200
@@ -2945,6 +3039,8 @@ ship "Vanguard"
 	thumbnail "thumbnail/vanguard"
 	attributes
 		category "Heavy Warship"
+		licenses
+			Pilot's
 		"cost" 7200000
 		"shields" 9800
 		"hull" 6000
@@ -3002,6 +3098,8 @@ ship "Wasp"
 	thumbnail "thumbnail/wasp"
 	attributes
 		category "Interceptor"
+		licenses
+			Pilot's
 		"cost" 400000
 		"shields" 1500
 		"hull" 500


### PR DESCRIPTION
The outfit "Pilot's License" states: "Without a pilot's license, you cannot purchase a ship on a Republic planet." This pull request implements that lore requirement in the game by adding "Pilot's License" as a license requirement to all ships that did not have some other license already applied to it.

The shipyard will now show that the Pilot's License is required for purchase.

The outfit "Pilot's License" also states: "And if you buy an unlicensed ship on another planet and then bring it into Republic space, you can be fined until you cough up the money for a license." This lore function could be implemented by creating a unique fleet of pirate ships that are only available through pirate shipyards which then have no license assigned to them. It doesn't make sense to have pirate shipyards require a republic license. The game could fine players for using these pirate ships.