### PR TITLE
Normalized spelling of gases

### DIFF
--- a/data/commodities.txt
+++ b/data/commodities.txt
@@ -563,7 +563,7 @@ trade
 		"thermoset polymer waste"
 		"trash"
 		"used syringes"
-		"volatile gasses"
+		"volatile gases"
 	commodity "Construction"
 		"box girders"
 		"carbon steel"


### PR DESCRIPTION
Gas is pluralized as "gases" in the description of New Wales and Winter, but this one commodity has it pluralized as "gasses."