### PR TITLE
Colour profit / price column in Trading Screen green / yellow / red.

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -100,6 +100,12 @@ color "map travel ok none" .55 .1 0. 0.
 color "map used wormhole" .5 .2 .9 1.
 color "map unused wormhole" .165 .066 .3 .333
 
+# Colors used for drawing the trade good prices (green - yellow - red)
+color "trade level very low" 0.01 0.8 0.02 0.
+color "trade level low" 0.4 0.8 0.03 0.
+color "trade level medium" 0.8 0.75 0.01 0.
+color "trade level high" 0.8 0.4 0.02 0.
+color "trade level very high" 0.8 0.02 0.01 0.
 
 
 interface "menu background"

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -153,6 +153,13 @@ void TradingPanel::Draw()
 	int i = 0;
 	bool canSell = false;
 	bool canBuy = false;
+	const Color TRADE_LEVEL_COLORS[5] = {
+		*GameData::Colors().Get("trade level very low"),
+		*GameData::Colors().Get("trade level low"),
+		*GameData::Colors().Get("trade level medium"),
+		*GameData::Colors().Get("trade level high"),
+		*GameData::Colors().Get("trade level very high")
+	};
 	for(const Trade::Commodity &commodity : GameData::Commodities())
 	{
 		y += 20;
@@ -172,7 +179,10 @@ void TradingPanel::Draw()
 			if(basis && basis != price && hold)
 			{
 				string profit = "(profit: " + to_string(price - basis) + ")";
-				font.Draw(profit, Point(LEVEL_X, y), color);
+				// show (profit XXX) in green (> 0) or orange (< 0)
+				int profitColorIndex = (price - basis) < 0 ? 3 : 1;
+				Color profitColor = TRADE_LEVEL_COLORS[profitColorIndex];
+				font.Draw(profit, Point(LEVEL_X, y), profitColor);
 			}
 			else
 			{
@@ -183,7 +193,8 @@ void TradingPanel::Draw()
 					level = 4;
 				else
 					level = (5 * level) / (commodity.high - commodity.low);
-				font.Draw(TRADE_LEVEL[level], Point(LEVEL_X, y), color);
+				Color tradeLevelColor = TRADE_LEVEL_COLORS[level];
+				font.Draw(TRADE_LEVEL[level], Point(LEVEL_X, y), tradeLevelColor);
 			}
 		
 			font.Draw("[buy]", Point(BUY_X, y), color);


### PR DESCRIPTION
To make it simpler to see how good prices are, colour the words "(very low)" etc.
![maim](https://user-images.githubusercontent.com/215510/47026117-032d4280-d165-11e8-9f46-a2b6d3e234b5.png)
Also colour the profit (in the same column) green (if > 0) or orange (if < 0).