### PR TITLE
Tweaked Kestrel

### DIFF
--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -210,6 +210,7 @@ event "kestrel available: more shields"
 	shipyard "Tarazed Advanced"
 		"Kestrel (More Shields)"
 
+
 ship "Unknown Ship Type"
 	sprite "ship/kestrel"
 	attributes
@@ -217,15 +218,15 @@ ship "Unknown Ship Type"
 		"cost" 10300000
 		"shields" 17400
 		"hull" 6200
-		"required crew" 72
+		"required crew" 64
 		"bunks" 128
 		"mass" 740
-		"drag" 12.5
-		"heat dissipation" .45
+		"drag" 9.8
+		"heat dissipation" .6
 		"fuel capacity" 500
 		"cargo space" 120
 		"outfit space" 810
-		"weapon capacity" 380
+		"weapon capacity" 390
 		"engine capacity" 210
 		weapon
 			"blast radius" 260
@@ -233,16 +234,16 @@ ship "Unknown Ship Type"
 			"hull damage" 1300
 			"hit force" 3900
 	outfits
-		"Particle Cannon" 4
-		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Particle Cannon" 6
 		"Heavy Laser Turret" 4
+		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
 		"Liquid Nitrogen Cooler"
+		
 		"Orca Plasma Thruster"
-		"X5200 Ion Steering"
+		"Orca Plasma Steering"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
@@ -250,8 +251,8 @@ ship "Unknown Ship Type"
 	gun 31 66 "Particle Cannon"
 	gun -53 61 "Particle Cannon"
 	gun 53 61 "Particle Cannon"
-	gun -75 57 "Torpedo Launcher"
-	gun 75 57 "Torpedo Launcher"
+	gun -75 57 "Particle Cannon"
+	gun 75 57 "Particle Cannon"
 	turret -7 -4 "Heavy Laser Turret"
 	turret 7 -4 "Heavy Laser Turret"
 	turret -23 14 "Heavy Laser Turret"
@@ -262,6 +263,7 @@ ship "Unknown Ship Type"
 	explode "huge explosion" 30
 	"final explode" "final explosion large"
 
+
 ship "Kestrel"
 	sprite "ship/kestrel"
 	thumbnail "thumbnail/kestrel"
@@ -270,15 +272,15 @@ ship "Kestrel"
 		"cost" 10300000
 		"shields" 17400
 		"hull" 6200
-		"required crew" 72
+		"required crew" 64
 		"bunks" 128
 		"mass" 740
-		"drag" 12.5
-		"heat dissipation" .45
+		"drag" 9.8
+		"heat dissipation" .6
 		"fuel capacity" 500
 		"cargo space" 120
 		"outfit space" 810
-		"weapon capacity" 380
+		"weapon capacity" 390
 		"engine capacity" 210
 		weapon
 			"blast radius" 260
@@ -286,16 +288,16 @@ ship "Kestrel"
 			"hull damage" 1300
 			"hit force" 3900
 	outfits
-		"Particle Cannon" 4
-		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Particle Cannon" 6
 		"Heavy Laser Turret" 4
+		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
 		"Liquid Nitrogen Cooler"
+		
 		"Orca Plasma Thruster"
-		"X5200 Ion Steering"
+		"Orca Plasma Steering"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
@@ -303,8 +305,8 @@ ship "Kestrel"
 	gun 31 66 "Particle Cannon"
 	gun -53 61 "Particle Cannon"
 	gun 53 61 "Particle Cannon"
-	gun -75 57 "Torpedo Launcher"
-	gun 75 57 "Torpedo Launcher"
+	gun -75 57 "Particle Cannon"
+	gun 75 57 "Particle Cannon"
 	turret -7 -4 "Heavy Laser Turret"
 	turret 7 -4 "Heavy Laser Turret"
 	turret -23 14 "Heavy Laser Turret"
@@ -317,16 +319,15 @@ ship "Kestrel"
 	description "Several years ago, while visiting a sweat lodge in search of spiritual renewal, Tarazed's chief ship designer fell into a trance and journeyed to a reality separate from our own. There he saw visions of a strange and elegant starship. Returning to his work with renewed purpose, he spent the next seven years making the Kestrel a reality."
 
 
-
-ship "Kestrel" "Kestrel (More Weapons)"
-	add attributes
-		"weapon capacity" 20
-
 ship "Kestrel" "Kestrel (More Engines)"
 	add attributes
-		"engine capacity" 20
+		"engine capacity" 30
 
 ship "Kestrel" "Kestrel (More Shields)"
 	add attributes
-		"shields" 2700
-		"hull" 1300
+		"shields" 3000
+		"hull" 1500
+
+ship "Kestrel" "Kestrel (More Weapons)"
+	add attributes
+		"weapon capacity" 40

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -216,7 +216,7 @@ ship "Unknown Ship Type"
 	attributes
 		category "Heavy Warship"
 		"cost" 10300000
-		"shields" 18400
+		"shields" 19400
 		"hull" 7200
 		"required crew" 64
 		"bunks" 128
@@ -270,7 +270,7 @@ ship "Kestrel"
 	attributes
 		category "Heavy Warship"
 		"cost" 10300000
-		"shields" 18400
+		"shields" 19400
 		"hull" 7200
 		"required crew" 64
 		"bunks" 128

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -221,7 +221,7 @@ ship "Unknown Ship Type"
 		"required crew" 64
 		"bunks" 128
 		"mass" 740
-		"drag" 10.8
+		"drag" 11
 		"heat dissipation" .6
 		"fuel capacity" 500
 		"cargo space" 120
@@ -277,7 +277,7 @@ ship "Kestrel"
 		"required crew" 64
 		"bunks" 128
 		"mass" 740
-		"drag" 10.8
+		"drag" 11
 		"heat dissipation" .6
 		"fuel capacity" 500
 		"cargo space" 120
@@ -325,6 +325,7 @@ ship "Kestrel"
 
 ship "Kestrel" "Kestrel (More Engines)"
 	add attributes
+		"drag" -1.0
 		"fuel capacity" 100
 		"engine capacity" 30
 

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -249,18 +249,18 @@ ship "Unknown Ship Type"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
-	gun -31 65 "Particle Cannon"
-	gun 31 65 "Particle Cannon"
-	gun -42 63
-	gun 42 63
-	gun -53 61 "Particle Cannon"
-	gun 53 61 "Particle Cannon"
-	gun -64 59
-	gun 64 59
-	gun -75 57 "Torpedo Launcher"
-	gun 75 57 "Torpedo Launcher"
 	gun -86 55
 	gun 86 55
+	gun -75 57 "Torpedo Launcher"
+	gun 75 57 "Torpedo Launcher"
+	gun -64 59
+	gun 64 59
+	gun -53 61 "Particle Cannon"
+	gun 53 61 "Particle Cannon"
+	gun -42 63
+	gun 42 63
+	gun -31 65 "Particle Cannon"
+	gun 31 65 "Particle Cannon"
 	turret -7 -4 "Heavy Laser Turret"
 	turret 7 -4 "Heavy Laser Turret"
 	turret -23 14 "Heavy Laser Turret"
@@ -311,18 +311,18 @@ ship "Kestrel"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
-	gun -31 65 "Particle Cannon"
-	gun 31 65 "Particle Cannon"
-	gun -42 63
-	gun 42 63
-	gun -53 61 "Particle Cannon"
-	gun 53 61 "Particle Cannon"
-	gun -64 59
-	gun 64 59
-	gun -75 57 "Torpedo Launcher"
-	gun 75 57 "Torpedo Launcher"
 	gun -86 55
 	gun 86 55
+	gun -75 57 "Torpedo Launcher"
+	gun 75 57 "Torpedo Launcher"
+	gun -64 59
+	gun 64 59
+	gun -53 61 "Particle Cannon"
+	gun 53 61 "Particle Cannon"
+	gun -42 63
+	gun 42 63
+	gun -31 65 "Particle Cannon"
+	gun 31 65 "Particle Cannon"
 	turret -7 -4 "Heavy Laser Turret"
 	turret 7 -4 "Heavy Laser Turret"
 	turret -23 14 "Heavy Laser Turret"

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -216,8 +216,8 @@ ship "Unknown Ship Type"
 	attributes
 		category "Heavy Warship"
 		"cost" 10300000
-		"shields" 17400
-		"hull" 6200
+		"shields" 18400
+		"hull" 7200
 		"required crew" 64
 		"bunks" 128
 		"mass" 740
@@ -270,8 +270,8 @@ ship "Kestrel"
 	attributes
 		category "Heavy Warship"
 		"cost" 10300000
-		"shields" 17400
-		"hull" 6200
+		"shields" 18400
+		"hull" 7200
 		"required crew" 64
 		"bunks" 128
 		"mass" 740

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -249,16 +249,10 @@ ship "Unknown Ship Type"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
-	gun -86 55
-	gun 86 55
 	gun -75 57 "Torpedo Launcher"
 	gun 75 57 "Torpedo Launcher"
-	gun -64 59
-	gun 64 59
 	gun -53 61 "Particle Cannon"
 	gun 53 61 "Particle Cannon"
-	gun -42 63
-	gun 42 63
 	gun -31 65 "Particle Cannon"
 	gun 31 65 "Particle Cannon"
 	turret -7 -4 "Heavy Laser Turret"
@@ -311,16 +305,10 @@ ship "Kestrel"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
-	gun -86 55
-	gun 86 55
 	gun -75 57 "Torpedo Launcher"
 	gun 75 57 "Torpedo Launcher"
-	gun -64 59
-	gun 64 59
 	gun -53 61 "Particle Cannon"
 	gun 53 61 "Particle Cannon"
-	gun -42 63
-	gun 42 63
 	gun -31 65 "Particle Cannon"
 	gun 31 65 "Particle Cannon"
 	turret -7 -4 "Heavy Laser Turret"
@@ -337,6 +325,7 @@ ship "Kestrel"
 
 ship "Kestrel" "Kestrel (More Engines)"
 	add attributes
+		"fuel capacity" 100
 		"engine capacity" 30
 
 ship "Kestrel" "Kestrel (More Shields)"
@@ -347,3 +336,21 @@ ship "Kestrel" "Kestrel (More Shields)"
 ship "Kestrel" "Kestrel (More Weapons)"
 	add attributes
 		"weapon capacity" 40
+	gun -75 57 "Torpedo Launcher"
+	gun 75 57 "Torpedo Launcher"
+	gun -75 57
+	gun 75 57
+	gun -75 57
+	gun 75 57
+	gun -53 61 "Particle Cannon"
+	gun 53 61 "Particle Cannon"
+	gun -53 61
+	gun 53 61
+	gun -53 61
+	gun 53 61
+	gun -31 65 "Particle Cannon"
+	gun 31 65 "Particle Cannon"
+	gun -31 65
+	gun 31 65
+	gun -31 65
+	gun 31 65

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -253,8 +253,8 @@ ship "Unknown Ship Type"
 	gun 75 57 "Torpedo Launcher"
 	gun -53 61 "Particle Cannon"
 	gun 53 61 "Particle Cannon"
-	gun -31 65 "Particle Cannon"
-	gun 31 65 "Particle Cannon"
+	gun -31 66 "Particle Cannon"
+	gun 31 66 "Particle Cannon"
 	turret -7 -4 "Heavy Laser Turret"
 	turret 7 -4 "Heavy Laser Turret"
 	turret -23 14 "Heavy Laser Turret"
@@ -309,8 +309,8 @@ ship "Kestrel"
 	gun 75 57 "Torpedo Launcher"
 	gun -53 61 "Particle Cannon"
 	gun 53 61 "Particle Cannon"
-	gun -31 65 "Particle Cannon"
-	gun 31 65 "Particle Cannon"
+	gun -31 66 "Particle Cannon"
+	gun 31 66 "Particle Cannon"
 	turret -7 -4 "Heavy Laser Turret"
 	turret 7 -4 "Heavy Laser Turret"
 	turret -23 14 "Heavy Laser Turret"
@@ -348,9 +348,9 @@ ship "Kestrel" "Kestrel (More Weapons)"
 	gun 53 61
 	gun -53 61
 	gun 53 61
-	gun -31 65 "Particle Cannon"
-	gun 31 65 "Particle Cannon"
-	gun -31 65
-	gun 31 65
-	gun -31 65
-	gun 31 65
+	gun -31 66 "Particle Cannon"
+	gun 31 66 "Particle Cannon"
+	gun -31 66
+	gun 31 66
+	gun -31 66
+	gun 31 66

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -337,21 +337,25 @@ ship "Kestrel" "Kestrel (More Shields)"
 ship "Kestrel" "Kestrel (More Weapons)"
 	add attributes
 		"weapon capacity" 40
-	gun -75 57 "Torpedo Launcher"
-	gun 75 57 "Torpedo Launcher"
-	gun -75 57
-	gun 75 57
-	gun -75 57
-	gun 75 57
-	gun -53 61 "Particle Cannon"
-	gun 53 61 "Particle Cannon"
-	gun -53 61
-	gun 53 61
-	gun -53 61
-	gun 53 61
 	gun -31 66 "Particle Cannon"
 	gun 31 66 "Particle Cannon"
 	gun -31 66
 	gun 31 66
 	gun -31 66
 	gun 31 66
+	gun -53 61 "Particle Cannon"
+	gun 53 61 "Particle Cannon"
+	gun -53 61
+	gun 53 61
+	gun -53 61
+	gun 53 61
+	gun -75 57 "Torpedo Launcher"
+	gun 75 57 "Torpedo Launcher"
+	gun -75 57
+	gun 75 57
+	gun -75 57
+	gun 75 57
+	turret -7 -4 "Heavy Laser Turret"
+	turret 7 -4 "Heavy Laser Turret"
+	turret -23 14 "Heavy Laser Turret"
+	turret 23 14 "Heavy Laser Turret"

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -234,7 +234,7 @@ ship "Unknown Ship Type"
 			"hull damage" 1300
 			"hit force" 3900
 	outfits
-		"Particle Cannon" 6
+		"Heavy Laser" 12
 		"Heavy Laser Turret" 4
 		
 		"Fusion Reactor"
@@ -247,12 +247,18 @@ ship "Unknown Ship Type"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
-	gun -31 66 "Particle Cannon"
-	gun 31 66 "Particle Cannon"
-	gun -53 61 "Particle Cannon"
-	gun 53 61 "Particle Cannon"
-	gun -75 57 "Particle Cannon"
-	gun 75 57 "Particle Cannon"
+	gun -31 66 "Heavy Laser"
+	gun 31 66 "Heavy Laser"
+	gun -42 63 "Heavy Laser"
+	gun 42 63 "Heavy Laser"
+	gun -53 61 "Heavy Laser"
+	gun 53 61 "Heavy Laser"
+	gun -64 59 "Heavy Laser"
+	gun 64 59 "Heavy Laser"
+	gun -75 57 "Heavy Laser"
+	gun 75 57 "Heavy Laser"
+	gun -86 55 "Heavy Laser"
+	gun 86 55 "Heavy Laser"
 	turret -7 -4 "Heavy Laser Turret"
 	turret 7 -4 "Heavy Laser Turret"
 	turret -23 14 "Heavy Laser Turret"
@@ -288,7 +294,7 @@ ship "Kestrel"
 			"hull damage" 1300
 			"hit force" 3900
 	outfits
-		"Particle Cannon" 6
+		"Heavy Laser" 12
 		"Heavy Laser Turret" 4
 		
 		"Fusion Reactor"
@@ -301,12 +307,18 @@ ship "Kestrel"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
-	gun -31 66 "Particle Cannon"
-	gun 31 66 "Particle Cannon"
-	gun -53 61 "Particle Cannon"
-	gun 53 61 "Particle Cannon"
-	gun -75 57 "Particle Cannon"
-	gun 75 57 "Particle Cannon"
+	gun -31 66 "Heavy Laser"
+	gun 31 66 "Heavy Laser"
+	gun -42 63 "Heavy Laser"
+	gun 42 63 "Heavy Laser"
+	gun -53 61 "Heavy Laser"
+	gun 53 61 "Heavy Laser"
+	gun -64 59 "Heavy Laser"
+	gun 64 59 "Heavy Laser"
+	gun -75 57 "Heavy Laser"
+	gun 75 57 "Heavy Laser"
+	gun -86 55 "Heavy Laser"
+	gun 86 55 "Heavy Laser"
 	turret -7 -4 "Heavy Laser Turret"
 	turret 7 -4 "Heavy Laser Turret"
 	turret -23 14 "Heavy Laser Turret"

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -221,7 +221,7 @@ ship "Unknown Ship Type"
 		"required crew" 64
 		"bunks" 128
 		"mass" 740
-		"drag" 9.8
+		"drag" 10.8
 		"heat dissipation" .6
 		"fuel capacity" 500
 		"cargo space" 120
@@ -275,7 +275,7 @@ ship "Kestrel"
 		"required crew" 64
 		"bunks" 128
 		"mass" 740
-		"drag" 9.8
+		"drag" 10.8
 		"heat dissipation" .6
 		"fuel capacity" 500
 		"cargo space" 120

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -243,6 +243,7 @@ ship "Unknown Ship Type"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
 		"Liquid Nitrogen Cooler"
+		"Tactical Scanner" 2
 		
 		"Orca Plasma Thruster"
 		"Orca Plasma Steering"
@@ -299,6 +300,7 @@ ship "Kestrel"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
 		"Liquid Nitrogen Cooler"
+		"Tactical Scanner" 2
 		
 		"Orca Plasma Thruster"
 		"Orca Plasma Steering"

--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -234,7 +234,9 @@ ship "Unknown Ship Type"
 			"hull damage" 1300
 			"hit force" 3900
 	outfits
-		"Heavy Laser" 12
+		"Particle Cannon" 4
+		"Torpedo Launcher" 2
+		"Torpedo" 60
 		"Heavy Laser Turret" 4
 		
 		"Fusion Reactor"
@@ -247,18 +249,18 @@ ship "Unknown Ship Type"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
-	gun -31 66 "Heavy Laser"
-	gun 31 66 "Heavy Laser"
-	gun -42 63 "Heavy Laser"
-	gun 42 63 "Heavy Laser"
-	gun -53 61 "Heavy Laser"
-	gun 53 61 "Heavy Laser"
-	gun -64 59 "Heavy Laser"
-	gun 64 59 "Heavy Laser"
-	gun -75 57 "Heavy Laser"
-	gun 75 57 "Heavy Laser"
-	gun -86 55 "Heavy Laser"
-	gun 86 55 "Heavy Laser"
+	gun -31 65 "Particle Cannon"
+	gun 31 65 "Particle Cannon"
+	gun -42 63
+	gun 42 63
+	gun -53 61 "Particle Cannon"
+	gun 53 61 "Particle Cannon"
+	gun -64 59
+	gun 64 59
+	gun -75 57 "Torpedo Launcher"
+	gun 75 57 "Torpedo Launcher"
+	gun -86 55
+	gun 86 55
 	turret -7 -4 "Heavy Laser Turret"
 	turret 7 -4 "Heavy Laser Turret"
 	turret -23 14 "Heavy Laser Turret"
@@ -294,7 +296,9 @@ ship "Kestrel"
 			"hull damage" 1300
 			"hit force" 3900
 	outfits
-		"Heavy Laser" 12
+		"Particle Cannon" 4
+		"Torpedo Launcher" 2
+		"Torpedo" 60
 		"Heavy Laser Turret" 4
 		
 		"Fusion Reactor"
@@ -307,18 +311,18 @@ ship "Kestrel"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
-	gun -31 66 "Heavy Laser"
-	gun 31 66 "Heavy Laser"
-	gun -42 63 "Heavy Laser"
-	gun 42 63 "Heavy Laser"
-	gun -53 61 "Heavy Laser"
-	gun 53 61 "Heavy Laser"
-	gun -64 59 "Heavy Laser"
-	gun 64 59 "Heavy Laser"
-	gun -75 57 "Heavy Laser"
-	gun 75 57 "Heavy Laser"
-	gun -86 55 "Heavy Laser"
-	gun 86 55 "Heavy Laser"
+	gun -31 65 "Particle Cannon"
+	gun 31 65 "Particle Cannon"
+	gun -42 63
+	gun 42 63
+	gun -53 61 "Particle Cannon"
+	gun 53 61 "Particle Cannon"
+	gun -64 59
+	gun 64 59
+	gun -75 57 "Torpedo Launcher"
+	gun 75 57 "Torpedo Launcher"
+	gun -86 55
+	gun 86 55
 	turret -7 -4 "Heavy Laser Turret"
 	turret 7 -4 "Heavy Laser Turret"
 	turret -23 14 "Heavy Laser Turret"


### PR DESCRIPTION
The Kestrel is supposed to be a superb, modern, state-of-the-art warship of alien design. In practice, it's hardly better than a Bactrian, Carrier, or Dreadnought, its nearest human competitors. This patch intends to improve the Kestrel's desirability by tweaking various stats:

* +2000 shields, +1000 hull, putting it in the same range as the Carrier
* reduced required crew to 64, putting its daily upkeep slightly below the Bactrian's 70
* lowered drag to 11, because the Kestrel is a highly streamlined design, therefore it is odd it is currently relatively slow; for comparison, Cruiser is at 10.1, Dreadnought at 10.1, and Falcon at 6.7 (maximum velocity = thrust / drag)
* improved heat dissipation to .6; for comparison, Dreadnought has .65 and Falcon .7
* +10 weapon capacity, to allow six plasma cannons plus four plasma turrets
* <s>increased the number of gun ports from six to twelve; for comparison, the Carrier and Shield Beetle have eight, the Vanguard and Albatross seven</s>

variants:
* (More Engines):
  * −1 drag, making it c. 10% faster with the same engines
  * +100 fuel capacity, useful if it has an afterburner
  * +30 engine capacity (instead of +20), to allow X5700 thruster plus X5200 steering, or A860 thruster plus A865 steering plus afterburner
* (More Shields):
  *  +3000 shields and +1500 hull (instead of +2700 and +1300)
* (More Weapons):
  * +40 weapon capacity (instead of +20), to allow six typhoon launchers plus four electron turrets
  * 3×6=18 gun ports instead of the ordinary 6
