### PR TITLE
Bounder –5 weapon capacity

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -558,7 +558,7 @@ ship "Bounder"
 		"fuel capacity" 900
 		"cargo space" 40
 		"outfit space" 220
-		"weapon capacity" 50
+		"weapon capacity" 45
 		"engine capacity" 110
 		weapon
 			"blast radius" 30


### PR DESCRIPTION
The Bounder is not designed for combat; a weapon capacity at 45 differentiates it from the Arrow's 50 and the Scout's 40; it is large enough for the Bounder to equip two chameleon anti-missile or two laser turrets.