### PR TITLE
Hawk +10 weapon capacity, –10 cargo space

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1757,9 +1757,9 @@ ship "Hawk"
 		"drag" 2.1
 		"heat dissipation" .8
 		"fuel capacity" 300
-		"cargo space" 30
+		"cargo space" 20
 		"outfit space" 200
-		"weapon capacity" 40
+		"weapon capacity" 50
 		"engine capacity" 70
 		weapon
 			"blast radius" 30


### PR DESCRIPTION
This differentiates the Hawk from the Fury and allows equipping e.g. two plasma cannons or torpedo launchers.