### PR TITLE
Headhunter +10 weapon capacity

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1803,7 +1803,7 @@ ship "Headhunter"
 		"drag" 2.6
 		"heat dissipation" .8
 		"fuel capacity" 400
-		"cargo space" 40
+		"cargo space" 50
 		"outfit space" 250
 		"weapon capacity" 70
 		"engine capacity" 80

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1803,9 +1803,9 @@ ship "Headhunter"
 		"drag" 2.6
 		"heat dissipation" .8
 		"fuel capacity" 400
-		"cargo space" 50
+		"cargo space" 40
 		"outfit space" 250
-		"weapon capacity" 60
+		"weapon capacity" 70
 		"engine capacity" 80
 		weapon
 			"blast radius" 44


### PR DESCRIPTION
This differentiates the Headhunter from the Quicksilver's 60 and allows equipping e.g. two heavy laser cannons plus one heavy laser turret, or two typhoons and no turret.