### PR TITLE
Wasp +2 weapon capacity

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -3013,7 +3013,7 @@ ship "Wasp"
 		"fuel capacity" 400
 		"cargo space" 10
 		"outfit space" 150
-		"weapon capacity" 28
+		"weapon capacity" 30
 		"engine capacity" 60
 		weapon
 			"blast radius" 20


### PR DESCRIPTION
This puts the Wasp, a "medium strength interceptor", nicely in between the Sparrow's 20 and the Fury's 40; at 30 the Wasp could equip e.g. one particle cannon or three meteors.