### PR TITLE
Equip Firebird with particle cannons

### DIFF
--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -446,6 +446,9 @@ fleet "Large Northern Merchants"
 		"Berserker (Afterburner)" 2
 	variant 10
 		"Freighter" 2
+		"Firebird (Laser)"
+	variant 10
+		"Freighter" 2
 		"Firebird (Plasma)"
 	variant 10
 		"Freighter" 2
@@ -453,6 +456,9 @@ fleet "Large Northern Merchants"
 	variant 10
 		"Freighter" 3
 		"Firebird"
+	variant 2
+		"Freighter" 3
+		"Firebird (Laser)"
 	variant 2
 		"Freighter" 3
 		"Firebird (Plasma)"
@@ -574,6 +580,9 @@ fleet "Large Northern Merchants"
 	variant 1
 		"Star Queen"
 		"Firebird" 2
+	variant 1
+		"Star Queen"
+		"Firebird (Laser)" 2
 	variant 1
 		"Star Queen"
 		"Firebird (Plasma)" 2
@@ -1797,6 +1806,8 @@ fleet "Large Core Pirates"
 	variant 2
 		"Firebird"
 	variant 1
+		"Firebird (Laser)"
+	variant 1
 		"Firebird (Plasma)"
 	variant 1
 		"Firebird (Missile)"
@@ -1850,11 +1861,16 @@ fleet "Large Northern Pirates"
 	variant 4
 		"Firebird"
 	variant 2
+		"Firebird (Laser)"
+	variant 2
 		"Firebird (Missile)"
 	variant 2
 		"Firebird (Plasma)"
 	variant 3
 		"Firebird"
+		"Corvette"
+	variant 1
+		"Firebird (Laser)"
 		"Corvette"
 	variant 1
 		"Firebird (Plasma)"
@@ -1890,7 +1906,7 @@ fleet "Large Northern Pirates"
 		"Firebird"
 	variant 2
 		"Leviathan (Laser)"
-		"Firebird"
+		"Firebird (Laser)"
 	variant 2
 		"Leviathan (Heavy)"
 		"Firebird (Plasma)"
@@ -1994,12 +2010,12 @@ fleet "pirate raid"
 		"Splinter (Laser)" 2
 	variant 1
 		"Splinter (Proton)" 2
-	variant 2
-		"Firebird"
-	variant 1
-		"Firebird (Plasma)"
 	variant 4
 		"Firebird"
+	variant 2
+		"Firebird (Laser)"
+	variant 2
+		"Firebird (Missile)"
 	variant 2
 		"Firebird (Plasma)"
 	variant 3

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1279,8 +1279,8 @@ ship "Firebird"
 			"hull damage" 500
 			"hit force" 1500
 	outfits
-		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
+		"Particle Cannon" 4
+		"Blaster Turret" 2
 		
 		"RT-I Radiothermal"
 		"nGVF-AA Fuel Cell"
@@ -1293,12 +1293,12 @@ ship "Firebird"
 		
 	engine -33 65
 	engine 33 65
-	gun -28 -27 "Heavy Laser"
-	gun 28 -27 "Heavy Laser"
-	gun -39 -13 "Heavy Laser"
-	gun 39 -13 "Heavy Laser"
-	turret -5 3 "Heavy Laser Turret"
-	turret 5 3 "Heavy Laser Turret"
+	gun -28 -27 "Particle Cannon"
+	gun 28 -27 "Particle Cannon"
+	gun -39 -13 "Particle Cannon"
+	gun 39 -13 "Particle Cannon"
+	turret -5 3 "Blaster Turret"
+	turret 5 3 "Blaster Turret"
 	leak "leak" 50 50
 	leak "flame" 30 80
 	explode "tiny explosion" 18

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -771,6 +771,19 @@ ship "Firebird" "Firebird (Missile)"
 	gun "Torpedo Launcher"
 
 
+ship "Firebird" "Firebird (Laser)"
+	outfits
+		"Heavy Laser" 4
+		"Heavy Laser Turret" 2
+		"RT-I Radiothermal"
+		"nGVF-AA Fuel Cell"
+		"LP144a Battery Pack"
+		"D41-HY Shield Generator"
+		"X3700 Ion Thruster"
+		"X3200 Ion Steering"
+		"Hyperdrive"
+
+
 ship "Firebird" "Firebird (Plasma)"
 	outfits
 		"Plasma Cannon" 4


### PR DESCRIPTION
This patch equips the default Firebird with particle cannons, because:
* this makes the Firebird somewhat more effective
* Lovelace is quite close to Betelgeuse, whereas Deep Sky is much farther away
* the Firebird is basically a small Leviathan, which also has particle cannons (and quad blaster turrets)
* differentiates the Betelgeuse's Firebird from Lionheart's Corvette, which has four heavy laser cannons and two heavy laser turrets (cf. #3411)