### PR TITLE
Capitalization corrections

### DIFF
--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1560,7 +1560,7 @@ mission "FW Escort 3"
 		dialog
 			`	Voigt is immensely relieved to see the <npc> returned safely home. "You have done us a great service today, Captain," he says, as he hands you credit chips for <payment>. "I'll be sure to let the Council know how helpful you have been."`
 		"assisted free worlds" ++
-		log "Helped rescue a Free Worlds freighter that had been disabled by pirates. Earned the gratitude of Tomek Voigt, the Councilor in charge of the supply convoys."
+		log "Helped rescue a Free Worlds freighter that had been disabled by pirates. Earned the gratitude of Tomek Voigt, the Council member in charge of the supply convoys."
 	
 	on fail
 		set "fw intro escort failed"

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1560,7 +1560,7 @@ mission "FW Escort 3"
 		dialog
 			`	Voigt is immensely relieved to see the <npc> returned safely home. "You have done us a great service today, Captain," he says, as he hands you credit chips for <payment>. "I'll be sure to let the Council know how helpful you have been."`
 		"assisted free worlds" ++
-		log "Helped rescue a Free Worlds freighter that had been disabled by pirates. Earned the gratitude of Tomek Voigt, the council member in charge of the supply convoys."
+		log "Helped rescue a Free Worlds freighter that had been disabled by pirates. Earned the gratitude of Tomek Voigt, the Councilor in charge of the supply convoys."
 	
 	on fail
 		set "fw intro escort failed"

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -854,7 +854,7 @@ mission "FW Katya 3"
 			`	Eyes glances at her, sees her expression, and says, "No, Councilor, don't even think of it. That's a horrible idea."`
 			`	"No," she says, "it's brilliant. Captain <last>, are you familiar with the Dereliction and Salvage Act of 2976?"`
 			choice
-				`	"Of course. I read Parliamentary proceedings every night when I'm trying to fall asleep."`
+				`	"Of course. I read parliamentary proceedings every night when I'm trying to fall asleep."`
 					goto yes
 				`	"No, I've never heard of it."`
 					goto no

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -455,7 +455,7 @@ mission "FW Recon 3B"
 	
 	on complete
 		"assisted free worlds" ++
-		dialog `JJ meets you as soon as you land, and you pass off your information and photos to him. He pays you <payment> and says, "I'll be sure to let the Free Worlds council know how helpful you have been."`
+		dialog `JJ meets you as soon as you land, and you pass off your information and photos to him. He pays you <payment> and says, "I'll be sure to let the Free Worlds Council know how helpful you have been."`
 		payment 80000
 		log "Gave the Free Worlds some photos and information on the Navy base on New Wales. Jean-Jacques, the militia contact, was very grateful for the help."
 
@@ -702,7 +702,7 @@ mission "FW Katya Alt 2"
 		has "chosen sides"
 	on offer
 		conversation
-			`As you are walking through the spaceport, someone calls out, "Captain <last>!" A Free Worlds officer is approaching you; you recognize her as the same woman who pulled a gun on you earlier as a way to "test" you. "I apologize for pulling that trick on you before," she says. "My name is Katya Reynolds. I've heard really good things about you from some other members of the Free Worlds council, and I'm hoping you'd reconsider working with me."`
+			`As you are walking through the spaceport, someone calls out, "Captain <last>!" A Free Worlds officer is approaching you; you recognize her as the same woman who pulled a gun on you earlier as a way to "test" you. "I apologize for pulling that trick on you before," she says. "My name is Katya Reynolds. I've heard really good things about you from some other members of the Free Worlds Council, and I'm hoping you'd reconsider working with me."`
 			choice
 				`	"Okay, as long as you don't point any more guns at me."`
 				`	"Sorry, I just really don't like you. Or the Free Worlds."`

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1229,7 +1229,7 @@ mission "FW Katya 7C"
 				`	(Check what my computer says.)`
 			
 			`	You check your computer. "One job opening, for a janitor in the mess hall."`
-			`	She grimaces. "Okay, it's better than nothing. I'll take the job to go undercover and see what I can find out. You take Eyes to <planet>, where he can get in touch with the Free Worlds council. I'll find a way to send you a message once I've found the perpetrators."`
+			`	She grimaces. "Okay, it's better than nothing. I'll take the job to go undercover and see what I can find out. You take Eyes to <planet>, where he can get in touch with the Free Worlds Council. I'll find a way to send you a message once I've found the perpetrators."`
 			`	"Katerina," says Eyes, "this is way too dangerous."`
 			`	"There's no other way," she says. "We have no time to lose. I'm willing to risk it."`
 			`	With deep reservations, you drop her off at the outpost, where she is quickly offered the job. "Not many folks care to work up here," says the foreman, "so your help would be much appreciated." You and Eyes return to your ship and get ready to travel to <planet> with the evidence.`
@@ -1388,7 +1388,7 @@ mission "FW Escort 1B"
 	on complete
 		payment 400000
 		conversation
-			`You are met at the spaceport by Tomek Voigt, one of the members of the Free Worlds council. He thanks you and the other escort captains for your service, and pays you each <payment>. "The convoy is heading out again immediately," he says, "so meet me in the spaceport if you are willing to volunteer for escort duty again."`
+			`You are met at the spaceport by Tomek Voigt, one of the members of the Free Worlds Council. He thanks you and the other escort captains for your service, and pays you each <payment>. "The convoy is heading out again immediately," he says, "so meet me in the spaceport if you are willing to volunteer for escort duty again."`
 	
 	on fail
 		set "fw intro escort failed"
@@ -1586,7 +1586,7 @@ mission "FW Escort Second Chance"
 	
 	on offer
 		conversation
-			`Soon after you exit your ship a man approaches you. "Captain <last>?" he asks. You nod. "My name is Alondo," he says. "I'm a member of the Free Worlds council. Katya speaks so highly of you that I would like to see you join us, even though you messed up that escort mission."`
+			`Soon after you exit your ship a man approaches you. "Captain <last>?" he asks. You nod. "My name is Alondo," he says. "I'm a member of the Free Worlds Council. Katya speaks so highly of you that I would like to see you join us, even though you messed up that escort mission."`
 			choice
 				`	"Yes, I'm very sorry about that."`
 				`	"Sorry, but I decided I don't want to assist the Free Worlds anyway."`
@@ -1789,7 +1789,7 @@ mission "FW Commitment"
 			`Soon after you land, a courier arrives at your ship and hands you a formal looking letter. It reads:`
 			``
 			`Dear Captain <last>,`
-			`	The Free Worlds council would like to thank you for the invaluable assistance you have rendered to us recently. We are prepared to offer you a position as an officer in our militia, remaining in command of your own ship. Your starting salary will be 300 credits per diem. If you want to join us, please report to our headquarters on Bourne at your earliest convenience.`
+			`	The Free Worlds Council would like to thank you for the invaluable assistance you have rendered to us recently. We are prepared to offer you a position as an officer in our militia, remaining in command of your own ship. Your starting salary will be 300 credits per diem. If you want to join us, please report to our headquarters on Bourne at your earliest convenience.`
 			`	Sincerely,`
 			`				Tomek Voigt`
 			`				Jean-Jacques Soleau`
@@ -1858,7 +1858,7 @@ mission "Rescue Katya 1"
 mission "Rescue Katya 2"
 	landing
 	name "Rescue Katya"
-	description "Return to <planet> and report to the Free Worlds council that you were unable to locate Katya."
+	description "Return to <planet> and report to the Free Worlds Council that you were unable to locate Katya."
 	source Clink
 	destination Longjump
 	to offer

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -869,7 +869,7 @@ mission "FW Northern 3"
 				accept
 	
 	on complete
-		log "Agreed to become a member of the Free Worlds council, taking Tomek's spot."
+		log "Agreed to become a member of the Free Worlds Council, taking Tomek's spot."
 		"salary: Free Worlds" = 2500
 		conversation
 			`As you are landing on <planet>, Freya says, "I miss Katya. It's hard being the only woman on the Council."`
@@ -1359,7 +1359,7 @@ mission "FW Bloodsea 1.1"
 				goto attack
 			label attack
 			`	"So, we attack them?" you ask.`
-			`	"You're on the council now," he says. "I'll leave it up to you. Option one is, we bring them the supplies and workers, in merchant ships, but use very heavily armed merchant ships in case they double cross us. Option two is, we go to Dancer and see if JJ can lend us an invasion fleet."`
+			`	"You're on the Council now," he says. "I'll leave it up to you. Option one is, we bring them the supplies and workers, in merchant ships, but use very heavily armed merchant ships in case they double cross us. Option two is, we go to Dancer and see if JJ can lend us an invasion fleet."`
 				accept
 
 

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -1497,7 +1497,7 @@ mission "FW Pug 3A"
 		conversation
 			`Your ship caused quite a stir when it entered the Sol system via jump drive. Fortunately Parliament allowed you to land in one of their private hangars, but even so a few press drones managed to follow your ship into the hangar and have cameras pointed at you from the moment you and Alondo disembark.`
 			`	You report to Parliament that the hyperspace links are being cut not by the Syndicate, but by an alien species, and that the Syndicate has offered to supply jump drives for an attack fleet if the Republic and the Free Worlds will supply the ships. You also report that the aliens' intention is to spread out to occupy more of human space and to demand a fraction of the resource production of all human planets, supposedly in the name of bringing "peace."`
-			`	One of the Senators asks, "Do you think we have any chance of defeating the aliens?"`
+			`	One of the senators asks, "Do you think we have any chance of defeating the aliens?"`
 			choice
 				`	"It's possible. They all live in a single star system, so we outnumber them."`
 					goto questions

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -970,7 +970,7 @@ mission "FW Pug 1 Return"
 	
 	on offer
 		conversation
-			`You receive an urgent message from JJ: "Captain <last>, return to New Tibet at once! We've received word that the Syndicate is somehow severing their hyperspace connections to the rest of human space. We're calling an emergency council meeting, to convene as soon as you arrive here."`
+			`You receive an urgent message from JJ: "Captain <last>, return to New Tibet at once! We've received word that the Syndicate is somehow severing their hyperspace connections to the rest of human space. We're calling an emergency Council meeting, to convene as soon as you arrive here."`
 				decline
 
 

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -1032,7 +1032,7 @@ mission "FW Senate 1B"
 			`	"It's brilliant. And probably totally unsustainable. Each world that joins us negotiates a certain yearly tax amount based on their population and resources. In return they gain access to our defense fleet and other shared resources. Twenty percent of each planet's tax payments are 'unrestricted,' money the Free Worlds can use for whatever we think is most important. But the rest of the taxes can be earmarked for whatever projects that world thinks are most important. Those taxes can also be an in kind donation, such as supplying ships or crews for the common militia..."`
 			`	He continues talking for quite some time. You stop even trying to follow what he is saying. Finally he sees the blank expression on your face and stops babbling. "The point is," he says, "if we can convince enough worlds to pool their money, the Conservatory will become a reality. Our own public university."`
 			choice
-				`	"So you're here to talk to the Senators?"`
+				`	"So you're here to talk to the senators?"`
 				`	"Sounds like that could be a great public relations move for convincing more worlds to join us."`
 			`	"Indeed," he says. "Anyway, I'm off to a meeting, but meet me later in the spaceport if you've got room for some passengers."`
 
@@ -1611,7 +1611,7 @@ mission "FW Pirates 4.1"
 				`	"No, I was led to believe that I was following the Senate's orders."`
 			`	"Interesting," says Arianna. "That's not what Tomek told us. And JJ and Freya both said that you were well aware of the Senate's wishes."`
 			label reason
-			`	One of the other Senators, an older man, asks, "Why did you choose to take part in the attack?"`
+			`	One of the other senators, an older man, asks, "Why did you choose to take part in the attack?"`
 			choice
 				`	"I wanted to do something to end the pirate threat."`
 				`	"I trusted that Tomek would know the best strategy."`

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -1656,7 +1656,7 @@ mission "FW Refinery 1"
 			`	"That's easy to answer," says JJ. "He didn't like the idea of taking orders from the Senate. He thought they should treat him like a hero and go along with whatever he thought best."`
 				goto next
 			label defend
-			`	JJ and Freya are both quiet for a minute, then Freya says, "You know, there are people in the Senate who worry that the Council could become the ruling authority in the Free Worlds, instead of a democratic Senate. It wouldn't be the first time a people's revolution turned into an oligarchy. We of the council have to be careful not to let that happen."`
+			`	JJ and Freya are both quiet for a minute, then Freya says, "You know, there are people in the Senate who worry that the Council could become the ruling authority in the Free Worlds, instead of a democratic Senate. It wouldn't be the first time a people's revolution turned into an oligarchy. We of the Council have to be careful not to let that happen."`
 				goto next
 			label next
 			`	"So, what will happen to Tomek?" you ask.`

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -883,7 +883,7 @@ mission "FW Pirates 1"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
-		log "Tomek, from the Free Worlds council, is trying to decide how to best deal with the threat of the pirates to the south of Free Worlds space."
+		log "Tomek, from the Free Worlds Council, is trying to decide how to best deal with the threat of the pirates to the south of Free Worlds space."
 		conversation
 			`Tomek is sitting at the bar with a galactic map and a tumbler of whiskey. The map has notes written all over it, with lines marking the current Free Worlds and Republic territories. "Good to see you, <first>!" he says. "I hope whatever weapons Barmy Edward had you testing worked well. Most of his inventions are pure genius, but some are just bizarre and useless."`
 			`	You describe to him the impressive performance of the Plasma Turrets, and the challenge of finding a ship with enough size for them. "Excellent!" he says. "That opens up some interesting tactical possibilities. But now it's time to switch gears entirely."`


### PR DESCRIPTION
Titles and the names of specific bodies are capitalized in English, but when using words in a generic sense, they are not, nor are adjectives or adverbs. E.g. 'the US Senate is a senate'; 'Senator X was one of a group of senators who complained about their senatorial staff'. I did a `grep` to check for inconsistencies.
* Conservatory is always capitalized
* Council was usually but not always capitalized; this is corrected
* Councilor [sic] is always capitalized
* Parliament is always capitalized
* Parliamentary is corrected to parliamentary
* Senate is always capitalized
* senator(s) was occassionally capitalized; this is corrected