### PR TITLE
Armageddon Core Balance

### DIFF
--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -413,7 +413,7 @@ outfit "Boulder Reactor"
 	"mass" 90
 	"outfit space" -90
 	"energy generation" 17.3
-	"heat generation" 38
+	"heat generation" 34
 	description "The Hai designed these miniaturized fusion generators back when their territory was being raided by the Korath. In these relatively peaceful times, they have seen no need to update the design."
 
 outfit "Geode Reactor"

--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -413,7 +413,7 @@ outfit "Boulder Reactor"
 	"mass" 90
 	"outfit space" -90
 	"energy generation" 17.3
-	"heat generation" 34
+	"heat generation" 38
 	description "The Hai designed these miniaturized fusion generators back when their territory was being raided by the Korath. In these relatively peaceful times, they have seen no need to update the design."
 
 outfit "Geode Reactor"

--- a/data/power.txt
+++ b/data/power.txt
@@ -201,7 +201,7 @@ outfit "Fusion Reactor"
 	"mass" 100
 	"outfit space" -100
 	"energy generation" 18.2
-	"heat generation" 44
+	"heat generation" 40
 	description "The invention of practical fusion power near the end of the twenty-first century spurred a new era of prosperity and plenty. Centuries later, the generators have been reduced in size, but are still generally only used in capital warships."
 
 outfit "Armageddon Core"
@@ -211,7 +211,7 @@ outfit "Armageddon Core"
 	"mass" 130
 	"outfit space" -130
 	"energy generation" 24.2
-	"heat generation" 67.5
+	"heat generation" 69
 	description "The Armageddon Core was designed to meet the extreme power needs of the largest warships of the Republic Navy. One of these generators costs more than an entire fleet of smaller ships."
 
 outfit "Stack Core"

--- a/data/power.txt
+++ b/data/power.txt
@@ -210,7 +210,7 @@ outfit "Armageddon Core"
 	thumbnail "outfit/core"
 	"mass" 130
 	"outfit space" -130
-	"energy generation" 25
+	"energy generation" 24.2
 	"heat generation" 67.5
 	description "The Armageddon Core was designed to meet the extreme power needs of the largest warships of the Republic Navy. One of these generators costs more than an entire fleet of smaller ships."
 

--- a/data/power.txt
+++ b/data/power.txt
@@ -211,7 +211,7 @@ outfit "Armageddon Core"
 	"mass" 130
 	"outfit space" -130
 	"energy generation" 24.2
-	"heat generation" 69
+	"heat generation" 70
 	description "The Armageddon Core was designed to meet the extreme power needs of the largest warships of the Republic Navy. One of these generators costs more than an entire fleet of smaller ships."
 
 outfit "Stack Core"

--- a/data/power.txt
+++ b/data/power.txt
@@ -211,7 +211,7 @@ outfit "Armageddon Core"
 	"mass" 130
 	"outfit space" -130
 	"energy generation" 24.2
-	"heat generation" 75
+	"heat generation" 67.5
 	description "The Armageddon Core was designed to meet the extreme power needs of the largest warships of the Republic Navy. One of these generators costs more than an entire fleet of smaller ships."
 
 outfit "Stack Core"

--- a/data/power.txt
+++ b/data/power.txt
@@ -201,7 +201,7 @@ outfit "Fusion Reactor"
 	"mass" 100
 	"outfit space" -100
 	"energy generation" 18.2
-	"heat generation" 40
+	"heat generation" 44
 	description "The invention of practical fusion power near the end of the twenty-first century spurred a new era of prosperity and plenty. Centuries later, the generators have been reduced in size, but are still generally only used in capital warships."
 
 outfit "Armageddon Core"
@@ -210,7 +210,7 @@ outfit "Armageddon Core"
 	thumbnail "outfit/core"
 	"mass" 130
 	"outfit space" -130
-	"energy generation" 24.2
+	"energy generation" 25
 	"heat generation" 67.5
 	description "The Armageddon Core was designed to meet the extreme power needs of the largest warships of the Republic Navy. One of these generators costs more than an entire fleet of smaller ships."
 


### PR DESCRIPTION
So I've long thought that the Armageddon core, far from being the best human reactor, is kinds rubbish. There's almost no reason to use it in favor of two Hai boulder reactors, which out perform-it in pretty much every way. While I understand that Hai tech is supposed to be more efficient and all-around better than their human counterparts, the extent to which the Armageddon is outstripped is a little sad. 

The problem is not its energy-to-weight ration, which IMO is fine. It's the excessive waste heat. I get the impression that it's humanities first attempt to create something like the (IMO overrated) Korath reactors, but to this extend the thing just doesn't have the stats to justify using it. I've decided a good way to make the navy's definitive heavy reactor a more attractive choice (even if just for flavor/making the free worlds campaign just a bit tougher) is to reduce the waste heat by a modest 10%. More would be overkill, less an insignificant difference.