### PR TITLE
reorder Carrier's HAM turret

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -745,8 +745,8 @@ ship "Carrier"
 	gun 25 -166 "Meteor Missile Launcher"
 	turret 0 -114 "Heavy Laser Turret"
 	turret 0 15 "Heavy Anti-Missile Turret"
-	turret 0 103 "Heavy Anti-Missile Turret"
-	turret 0 157 "Heavy Laser Turret"
+	turret 0 103 "Heavy Laser Turret"
+	turret 0 157 "Heavy Anti-Missile Turret"
 	fighter -37 -65
 	fighter 37 -65
 	fighter -46 40

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -743,10 +743,10 @@ ship "Carrier"
 	gun 25 -166 "Particle Cannon"
 	gun -25 -166 "Meteor Missile Launcher"
 	gun 25 -166 "Meteor Missile Launcher"
-	turret 0 -114 "Heavy Laser Turret"
-	turret 0 15 "Heavy Anti-Missile Turret"
-	turret 0 103 "Heavy Laser Turret"
-	turret 0 157 "Heavy Anti-Missile Turret"
+	turret 0 -114 "Heavy Anti-Missile Turret"
+	turret 0 15 "Heavy Laser Turret"
+	turret 0 103 "Heavy Anti-Missile Turret"
+	turret 0 157 "Heavy Laser Turret"
 	fighter -37 -65
 	fighter 37 -65
 	fighter -46 40

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -458,10 +458,10 @@ ship "Carrier" "Carrier (Jump)"
 	gun "Particle Cannon"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
-	turret "Electron Turret"
 	turret "Heavy Anti-Missile Turret"
 	turret "Electron Turret"
 	turret "Heavy Anti-Missile Turret"
+	turret "Electron Turret"
 
 
 ship "Carrier" "Carrier (Mark II)"
@@ -489,10 +489,10 @@ ship "Carrier" "Carrier (Mark II)"
 	gun "Particle Cannon"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
-	turret "Electron Turret"
 	turret "Heavy Anti-Missile Turret"
 	turret "Electron Turret"
 	turret "Heavy Anti-Missile Turret"
+	turret "Electron Turret"
 
 
 

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -460,8 +460,8 @@ ship "Carrier" "Carrier (Jump)"
 	gun "Sidewinder Missile Launcher"
 	turret "Electron Turret"
 	turret "Heavy Anti-Missile Turret"
-	turret "Heavy Anti-Missile Turret"
 	turret "Electron Turret"
+	turret "Heavy Anti-Missile Turret"
 
 
 ship "Carrier" "Carrier (Mark II)"
@@ -491,8 +491,8 @@ ship "Carrier" "Carrier (Mark II)"
 	gun "Sidewinder Missile Launcher"
 	turret "Electron Turret"
 	turret "Heavy Anti-Missile Turret"
-	turret "Heavy Anti-Missile Turret"
 	turret "Electron Turret"
+	turret "Heavy Anti-Missile Turret"
 
 
 


### PR DESCRIPTION
Placed the Carrier's first Heavy Anti-Missile turret on the first mount, to cover a greater area and protect it from full frontal missiles.