### PR TITLE
Remove compiler warnings on OSX build

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -608,7 +608,7 @@ void Engine::Step(bool isActive)
 		targetAsteroid = flagship->GetTargetAsteroid();
 		// Record that the player knows this type of asteroid is available here.
 		if(targetAsteroid)
-			for(const pair<const Outfit *, int> &it : targetAsteroid->Payload())
+			for(const auto &it : targetAsteroid->Payload())
 				player.Harvest(it.first);
 	}
 	if(!target)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -544,16 +544,16 @@ void Ship::Save(DataWriter &out) const
 			out.Write("category", baseAttributes.Category());
 			out.Write("cost", baseAttributes.Cost());
 			out.Write("mass", baseAttributes.Mass());
-			for(const pair<Body, int> &it : baseAttributes.FlareSprites())
+			for(const auto &it : baseAttributes.FlareSprites())
 				for(int i = 0; i < it.second; ++i)
 					it.first.SaveSprite(out, "flare sprite");
-			for(const pair<const Sound *, int> &it : baseAttributes.FlareSounds())
+			for(const auto &it : baseAttributes.FlareSounds())
 				for(int i = 0; i < it.second; ++i)
 					out.Write("flare sound", it.first->Name());
-			for(const pair<const Effect *, int> &it : baseAttributes.AfterburnerEffects())
+			for(const auto &it : baseAttributes.AfterburnerEffects())
 				for(int i = 0; i < it.second; ++i)
 					out.Write("afterburner effect", it.first->Name());
-			for(const pair<const char *, double> &it : baseAttributes.Attributes())
+			for(const auto &it : baseAttributes.Attributes())
 				if(it.second)
 					out.Write(it.first, it.second);
 		}


### PR DESCRIPTION
With OSX 10.13.3 17D102, XCode 9.4.1, and clang-902.0.39.2, building for `x86_64-apple-darwin17.4.0` generates loop-analysis warnings about copies:

<details><summary>Click to expand</summary>


```
=== BUILD TARGET EndlessSky OF PROJECT EndlessSky WITH CONFIGURATION Release ===
/Users/travis/build/tehhowch/endless-sky/source/Ship.cpp:550:40: warning: 
loop variable 'it' has type 'const pair<const Sound *, int> &' but is initialized with type
 'const std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<const Sound *, int>, std::__1::__tree_node<std::__1::__value_type<const Sound *, int>, void *> *, long> >::value_type'
 (aka 'const pair<const Sound *const, int>') resulting in a copy [-Wrange-loop-analysis]
                        for(const pair<const Sound *, int> &it : baseAttributes.FlareSounds())
                                                            ^
/Users/travis/build/tehhowch/endless-sky/source/Ship.cpp:550:8: note: 
use non-reference type 'pair<const Sound *, int>' to keep the copy or type
 'const std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<const Sound *, int>, std::__1::__tree_node<std::__1::__value_type<const Sound *, int>, void *> *, long> >::value_type &' 
 (aka 'const pair<const Sound *const, int> &') to prevent copying
                        for(const pair<const Sound *, int> &it : baseAttributes.FlareSounds())
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
							
/Users/travis/build/tehhowch/endless-sky/source/Ship.cpp:553:41: warning: 
loop variable 'it' has type 'const pair<const Effect *, int> &' but is initialized with type
 'const std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<const Effect *, int>, std::__1::__tree_node<std::__1::__value_type<const Effect *, int>, void *> *, long> >::value_type'
 (aka 'const pair<const Effect *const, int>') resulting in a copy [-Wrange-loop-analysis]
                        for(const pair<const Effect *, int> &it : baseAttributes.AfterburnerEffects())
                                                             ^
/Users/travis/build/tehhowch/endless-sky/source/Ship.cpp:553:8: note: 
use non-reference type 'pair<const Effect *, int>' to keep the copy or type
 'const std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<const Effect *, int>, std::__1::__tree_node<std::__1::__value_type<const Effect *, int>, void *> *, long> >::value_type &'
 (aka 'const pair<const Effect *const, int> &') to prevent copying
                        for(const pair<const Effect *, int> &it : baseAttributes.AfterburnerEffects())
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
							
/Users/travis/build/tehhowch/endless-sky/source/Engine.cpp:611:41: warning: 
loop variable 'it' has type 'const pair<const Outfit *, int> &' but is initialized with type
 'const std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<const Outfit *, int>, std::__1::__tree_node<std::__1::__value_type<const Outfit *, int>, void *> *, long> >::value_type'
 (aka 'const pair<const Outfit *const, int>') resulting in a copy [-Wrange-loop-analysis]
                        for(const pair<const Outfit *, int> &it : targetAsteroid->Payload())
                                                             ^
/Users/travis/build/tehhowch/endless-sky/source/Engine.cpp:611:8: note: 
use non-reference type 'pair<const Outfit *, int>' to keep the copy or type
 'const std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<const Outfit *, int>, std::__1::__tree_node<std::__1::__value_type<const Outfit *, int>, void *> *, long> >::value_type &'
 (aka 'const pair<const Outfit *const, int> &') to prevent copying
                        for(const pair<const Outfit *, int> &it : targetAsteroid->Payload())
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
</details>

Rather than replace with `const T *const`, I've opted for the use of `auto` to let the compiler handle the type declarations (consistent with the ES style guide re: auto for small-scope variables with long or possibly confusing type names).