### PR TITLE
Display effective scan ranges and interference

### DIFF
--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -22,6 +22,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Table.h"
 
 #include <algorithm>
+#include <cmath>
 #include <map>
 #include <sstream>
 

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -257,32 +257,31 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	if(attributes.Get("scan interference"))
 	{
 		attributeLabels.push_back("chance to block scan:");
-		attributeValues.push_back(Format::Number(100.	
-			- 100. / (1. + attributes.Get("scan interference"))) + "%");
+		attributeValues.push_back(Format::Number(100. - 100. / (1. + attributes.Get("scan interference"))) + "%");
 		attributesHeight += 20;
 	}
 	if(attributes.Get("asteroid scan power"))
 	{
 		attributeLabels.push_back("asteroid scan range:");
-		attributeValues.push_back(Format::Round(100. * sqrt(attributes.Get("asteroid scan power"))));
+		attributeValues.push_back(Format::Number(100. * sqrt(attributes.Get("asteroid scan power"))));
 		attributesHeight += 20;
 	}
 	if(attributes.Get("cargo scan power"))
 	{
 		attributeLabels.push_back("cargo scan range:");
-		attributeValues.push_back(Format::Round(100. * sqrt(attributes.Get("cargo scan power"))));
+		attributeValues.push_back(Format::Number(100. * sqrt(attributes.Get("cargo scan power"))));
 		attributesHeight += 20;
 	}
 	if(attributes.Get("outfit scan power"))
 	{
 		attributeLabels.push_back("outfit scan range:");
-		attributeValues.push_back(Format::Round(100. * sqrt(attributes.Get("outfit scan power"))));
+		attributeValues.push_back(Format::Number(100. * sqrt(attributes.Get("outfit scan power"))));
 		attributesHeight += 20;
 	}
 	if(attributes.Get("tactical scan power"))
 	{
 		attributeLabels.push_back("tactical scan range:");
-		attributeValues.push_back(Format::Round(100. * sqrt(attributes.Get("tactical scan power"))));
+		attributeValues.push_back(Format::Number(100. * sqrt(attributes.Get("tactical scan power"))));
 		attributesHeight += 20;
 	}
 	

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -253,6 +253,39 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributesHeight += 20;
 	}
 	
+	// Miscellaneous stats
+	if(attributes.Get("scan interference"))
+	{
+		attributeLabels.push_back("chance to block scan:");
+		attributeValues.push_back(Format::Number(100.	
+			- 100. / (1. + attributes.Get("scan interference"))) + "%");
+		attributesHeight += 20;
+	}
+	if(attributes.Get("asteroid scan power"))
+	{
+		attributeLabels.push_back("asteroid scan range:");
+		attributeValues.push_back(Format::Round(100. * sqrt(attributes.Get("asteroid scan power"))));
+		attributesHeight += 20;
+	}
+	if(attributes.Get("cargo scan power"))
+	{
+		attributeLabels.push_back("cargo scan range:");
+		attributeValues.push_back(Format::Round(100. * sqrt(attributes.Get("cargo scan power"))));
+		attributesHeight += 20;
+	}
+	if(attributes.Get("outfit scan power"))
+	{
+		attributeLabels.push_back("outfit scan range:");
+		attributeValues.push_back(Format::Round(100. * sqrt(attributes.Get("outfit scan power"))));
+		attributesHeight += 20;
+	}
+	if(attributes.Get("tactical scan power"))
+	{
+		attributeLabels.push_back("tactical scan range:");
+		attributeValues.push_back(Format::Round(100. * sqrt(attributes.Get("tactical scan power"))));
+		attributesHeight += 20;
+	}
+	
 	tableLabels.clear();
 	energyTable.clear();
 	heatTable.clear();


### PR DESCRIPTION
Effective scan range is 100×sqrt(scan power) and the chance to fail a scan is 1/(1+scan interference). I don't know about you, but I'm too lazy to calculate the result every time I'm considering installing scanners, so I'd prefer it if the result was displayed somewhere. That's what this proposal does.

If your ship has 1 interference plating (interference 0.5), 1 asteroid (power 40), 1 cargo (power 9), 1 cargo (power 25), and 1 tactical (power 32) scanner equipped, you'll see in outfit and shipyard just above the ship's energy and heat table:
![screenshot from 2018-11-14 21-54-57](https://user-images.githubusercontent.com/21634324/48512084-e2860480-e858-11e8-9962-26b05607782f.png)
If you have no scanners, none of the above will be displayed, and if you only have tactical scanners, you'll only see the last line.

This also makes it possible (e.g. plug-in) for (alien?) ships to have integrated scanners (e.g. Albatross 4 scan interference, Skylark 100 asteroid scan power, and Wardragon 100 tactical scan power) and the player to be made aware of it.