### PR TITLE
Issue deprecation warnings & simplify some code

### DIFF
--- a/data/drak.txt
+++ b/data/drak.txt
@@ -18,6 +18,7 @@ outfit "Drak Distancer"
 	"turret mounts" -1
 	weapon
 		"fire effect" "distancer flare"
+		"turret turn" 4.
 		"velocity" 2000
 		"lifetime" 1
 		"reload" 1
@@ -41,6 +42,7 @@ outfit "Drak Draining Field"
 	"weapon capacity" -84
 	"turret mounts" -1
 	weapon
+		"turret turn" 4.
 		"velocity" 400
 		"lifetime" 1
 		"reload" 1
@@ -83,6 +85,7 @@ outfit "Drak Turret"
 			"random start frame"
 		"hit effect" "drak bolt impact"
 		"inaccuracy" 1
+		"turret turn" 4.
 		"velocity" 36
 		"lifetime" 30
 		"reload" 16

--- a/data/quarg outfits.txt
+++ b/data/quarg outfits.txt
@@ -42,6 +42,7 @@ outfit "Quarg Skylance"
 		sound "skylance"
 		"hit effect" "skylance impact"
 		"inaccuracy" .4
+		"turret turn" 4.
 		"velocity" 500
 		"lifetime" 1
 		"reload" 1

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1377,6 +1377,7 @@ outfit "Imaginary Weapon"
 		"drag" .1
 		"turn" 3
 		"homing" 4
+		"tracking" 1.
 
 ship "Hallucination"
 	sprite "ship/hallucination"

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1119,8 +1119,8 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	// AI ships without an in-range hostile target consider scanning other ships.
 	if(!isYours && !target)
 	{
-		bool cargoScan = ship.Attributes().Get("cargo scan") || ship.Attributes().Get("cargo scan power");
-		bool outfitScan = ship.Attributes().Get("outfit scan") || ship.Attributes().Get("outfit scan power");
+		bool cargoScan = ship.Attributes().Get("cargo scan power");
+		bool outfitScan = ship.Attributes().Get("outfit scan power");
 		if(cargoScan || outfitScan)
 		{
 			closest = numeric_limits<double>::infinity();
@@ -1281,8 +1281,8 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 	}
 	else if(target)
 	{
-		bool cargoScan = ship.Attributes().Get("cargo scan") || ship.Attributes().Get("cargo scan power");
-		bool outfitScan = ship.Attributes().Get("outfit scan") || ship.Attributes().Get("outfit scan power");
+		bool cargoScan = ship.Attributes().Get("cargo scan power");
+		bool outfitScan = ship.Attributes().Get("outfit scan power");
 		if((!cargoScan || Has(gov, target, ShipEvent::SCAN_CARGO))
 				&& (!outfitScan || Has(gov, target, ShipEvent::SCAN_OUTFITS)))
 			target.reset();
@@ -2075,8 +2075,8 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 	else if(target)
 	{
 		// Approach and scan the targeted, friendly ship's cargo or outfits.
-		bool cargoScan = ship.Attributes().Get("cargo scan") || ship.Attributes().Get("cargo scan power");
-		bool outfitScan = ship.Attributes().Get("outfit scan") || ship.Attributes().Get("outfit scan power");
+		bool cargoScan = ship.Attributes().Get("cargo scan power");
+		bool outfitScan = ship.Attributes().Get("outfit scan power");
 		// If the pointer to the target ship exists, it is targetable and in-system.
 		bool mustScanCargo = cargoScan && !Has(ship, target, ShipEvent::SCAN_CARGO);
 		bool mustScanOutfits = outfitScan && !Has(ship, target, ShipEvent::SCAN_OUTFITS);
@@ -2095,8 +2095,8 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 		
 		// Consider scanning any ship in this system that you haven't yet personally scanned.
 		vector<shared_ptr<Ship>> targetShips;
-		bool cargoScan = ship.Attributes().Get("cargo scan") || ship.Attributes().Get("cargo scan power");
-		bool outfitScan = ship.Attributes().Get("outfit scan") || ship.Attributes().Get("outfit scan power");
+		bool cargoScan = ship.Attributes().Get("cargo scan power");
+		bool outfitScan = ship.Attributes().Get("outfit scan power");
 		if(cargoScan || outfitScan)
 			for(const auto &it : ships)
 				if(it->GetGovernment() != gov && it->GetSystem() == system && it->IsTargetable())

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -94,7 +94,10 @@ void Outfit::Load(const DataNode &node)
 	
 	// Legacy support for turrets that don't specify a turn rate:
 	if(IsWeapon() && attributes.Get("turret mounts") && !TurretTurn() && !AntiMissile())
+	{
 		SetTurretTurn(4.);
+		node.PrintTrace("Warning: Deprecated use of a turret without specified \"turret turn\":");
+	}
 }
 
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -98,6 +98,28 @@ void Outfit::Load(const DataNode &node)
 		SetTurretTurn(4.);
 		node.PrintTrace("Warning: Deprecated use of a turret without specified \"turret turn\":");
 	}
+	// Convert any legacy cargo / outfit scan definitions into power & speed,
+	// so no runtime code has to check for both.
+	auto convertScan = [&](string &&kind) -> void
+	{
+		const string label = kind + " scan";
+		double initial = attributes.Get(label);
+		if(initial)
+		{
+			attributes[label] = 0.;
+			node.PrintTrace("Warning: Deprecated use of \"" + label + "\" instead of \""
+					+ label + " power\" and \"" + label + " speed\":");
+			
+			// A scan value of 300 is equivalent to a scan power of 9.
+			attributes[label + " power"] += initial * initial * .0001;
+			// The default scan speed of 1 is unrelated to the magnitude of the scan value.
+			// It may have been already specified, and if so, should not be increased.
+			if(!attributes.Get(label + " speed"))
+				attributes[label + " speed"] = 1.;
+		}
+	};
+	convertScan("outfit");
+	convertScan("cargo");
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1733,10 +1733,8 @@ int Ship::Scan()
 		return 0;
 	
 	// The range of a scanner is proportional to the square root of its power.
-	double cargoPower = attributes.Get("cargo scan power");
-	double cargoDistance = cargoPower ? 100. * sqrt(cargoPower) : attributes.Get("cargo scan");
-	double outfitPower = attributes.Get("outfit scan power");
-	double outfitDistance = outfitPower ? 100. * sqrt(outfitPower) : attributes.Get("outfit scan");
+	double cargoDistance = 100. * sqrt(attributes.Get("cargo scan power"));
+	double outfitDistance = 100. * sqrt(attributes.Get("outfit scan power"));
 	
 	// Bail out if this ship has no scanners.
 	if(!cargoDistance && !outfitDistance)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1756,30 +1756,20 @@ int Ship::Scan()
 	bool startedScanning = false;
 	bool activeScanning = false;
 	int result = 0;
-	if(cargoScan < SCAN_TIME)
+	auto doScan = [&](double &elapsed, const double speed, const double scannerRange, const int event) -> void
 	{
-		if(distance < cargoDistance)
+		if(elapsed < SCAN_TIME && distance < scannerRange)
 		{
-			startedScanning |= !cargoScan;
+			startedScanning |= !elapsed;
 			activeScanning = true;
 			// To make up for the scan decay above:
-			cargoScan += cargoSpeed + 1.;
-			if(cargoScan >= SCAN_TIME)
-				result |= ShipEvent::SCAN_CARGO;
+			elapsed += speed + 1.;
+			if(elapsed >= SCAN_TIME)
+				result |= event;
 		}
-	}
-	if(outfitScan < SCAN_TIME)
-	{
-		if(distance < outfitDistance)
-		{
-			startedScanning |= !outfitScan;
-			activeScanning = true;
-			// To make up for the scan decay above:
-			outfitScan += outfitSpeed + 1.;
-			if(outfitScan >= SCAN_TIME)
-				result |= ShipEvent::SCAN_OUTFITS;
-		}
-	}
+	};
+	doScan(cargoScan, cargoSpeed, cargoDistance, ShipEvent::SCAN_CARGO);
+	doScan(outfitScan, outfitSpeed, outfitDistance, ShipEvent::SCAN_OUTFITS);
 	
 	// Play the scanning sound if the actor or the target is the player's ship.
 	if(isYours || (target->isYours && activeScanning))

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -269,7 +269,7 @@ void Ship::Load(const DataNode &node)
 				if(count > 0)
 					outfits[GameData::Outfits().Get(grand.Token(0))] += count;
 				else
-					grand.PrintTrace("Skipping invalid outfit count of " + count);
+					grand.PrintTrace("Skipping invalid outfit count:");
 			}
 		}
 		else if(key == "cargo")

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -135,11 +135,11 @@ void Weapon::LoadWeapon(const DataNode &node)
 			else if(key == "firing heat")
 				firingHeat = value;
 			else if(key == "split range")
-				splitRange = value;
+				splitRange = max(0., value);
 			else if(key == "trigger radius")
-				triggerRadius = value;
+				triggerRadius = max(0., value);
 			else if(key == "blast radius")
-				blastRadius = value;
+				blastRadius = max(0., value);
 			else if(key == "shield damage")
 				damage[SHIELD_DAMAGE] = value;
 			else if(key == "hull damage")

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -174,7 +174,10 @@ void Weapon::LoadWeapon(const DataNode &node)
 	
 	// Support legacy missiles with no tracking type defined:
 	if(homing && !tracking && !opticalTracking && !infraredTracking && !radarTracking)
+	{
 		tracking = 1.;
+		node.PrintTrace("Warning: Deprecated use of \"homing\" without use of \"[optical|infrared|radar] tracking.\"");
+	}
 	
 	// Convert the "live effect" counts from occurrences per projectile lifetime
 	// into chance of occurring per frame.


### PR DESCRIPTION
 - "Outfit scan" and "cargo scan" have been deprecated a long time. Previously this has been "handled" by treating them like they aren't deprecated at all - runtime code had to check for both the old and new attributes. No more: these old attributes are converted during game load into the proper types.
 - Converted the implicit default values of tracking `1.` and turret turn `4.` into explicit values, and added warning for failure to specify those attributes.
 - bounds-check that split range, blast radius, and trigger radius are `>= 0.`