### PR TITLE
Connect the Coalition language with the Heliarch registration mission

### DIFF
--- a/data/coalition missions.txt
+++ b/data/coalition missions.txt
@@ -43,6 +43,7 @@ mission "Coalition: First Contact"
 		"reputation: Coalition" += 10
 		"reputation: Heliarch" += 10
 		set "known to the heliarchs"
+		set "language: Coalition"
 		log "Factions" "Heliarchs" `The Heliarchs are the rulers of Coalition space: apparently not elected, but instead selected by merit from among the citizens of the Coalition in such a way as to ensure that all three species are equally represented. Thousands of years ago, the Heliarchs led their three species to band together and drive the Quarg out of Coalition space. The Heliarch centers of government are the three Quarg ringworlds that they captured in that war. They are the only ones in Coalition space who are allowed to have weapons on their starships, and they act as a sort of police force, maintaining peace between the Coalition species.`
 		conversation
 			`Your first view of the landing area confirms beyond a doubt that this is a Quarg ringworld, not just an imitation of one. The interior architecture is unmistakable. But no Quarg are present here, only the three species of the Coalition. Soon after you land, a delegation approaches your ship: again, one of each species, but these are wearing golden circlets around their heads. The circlets are not merely decorative, but seem to contain some electronics as well.`

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -112,6 +112,7 @@ government "Hai (Unfettered)"
 government "Heliarch"
 	swizzle 0
 	color 1 .8 .5
+	language "Coalition"
 	"player reputation" 1
 	"friendly hail" "friendly heliarch"
 	"hostile hail" "hostile heliarch"


### PR DESCRIPTION
This fixes seeing the unrecognized language hail when trying to land on restricted Coalition worlds after registering with the Heliarchs.

Question: This makes Ablub's Invention and any other restricted Coalition planets bribable - if this is incorrect, which if any are specifically meant to be restricted (like the ringworlds are)?