### PR TITLE
Improve UX for PlayerInfo / ShipInfo panels

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -176,7 +176,9 @@ void PlayerInfoPanel::Draw()
 
 bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 {
-	if(key == 'd' || key == SDLK_ESCAPE || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI)))
+	bool control = (mod & (KMOD_CTRL | KMOD_GUI));
+	bool shift = (mod & KMOD_SHIFT);
+	if(key == 'd' || key == SDLK_ESCAPE || (key == 'w' && control)
 			|| key == 'i' || command.Has(Command::INFO))
 		GetUI()->Pop(this);
 	else if(key == 's' || key == SDLK_RETURN || key == SDLK_KP_ENTER)
@@ -212,7 +214,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		}
 		// Holding both Ctrl & Shift keys and using the arrows moves the
 		// selected ship group up or down one row.
-		else if(!allSelected.empty() && (mod & KMOD_CTRL) && (mod & KMOD_SHIFT))
+		else if(!allSelected.empty() && control && shift)
 		{
 			// Move based on the position of the first selected ship. An upward
 			// movement is a shift of one, while a downward move shifts 1 and
@@ -276,7 +278,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		if(selectedIndex >= 0)
 			allSelected.insert(selectedIndex);
 	}
-	else if(canEdit && !allSelected.empty() && (key == 'P' || (key == 'p' && (mod & KMOD_SHIFT))))
+	else if(canEdit && (key == 'P' || (key == 'p' && shift)) && !allSelected.empty())
 	{
 		// Toggle the parked status for all selected ships.
 		bool allParked = true;
@@ -295,7 +297,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 				player.ParkShip(&ship, !allParked);
 		}
 	}
-	else if(canEdit && player.Ships().size() > 1 && (key == 'A' || (key == 'a' && (mod & KMOD_SHIFT))))
+	else if(canEdit && (key == 'A' || (key == 'a' && shift)) && player.Ships().size() > 1)
 	{
 		// Toggle the parked status for all ships except the flagship.
 		bool allParked = true;
@@ -315,7 +317,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 	else if(key >= '0' && key <= '9')
 	{
 		int group = key - '0';
-		if(mod & (KMOD_CTRL | KMOD_GUI))
+		if(control)
 		{
 			// Convert from indices into ship pointers.
 			set<Ship *> selected;
@@ -334,7 +336,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 			
 			// If the shift key is not down, replace the current set of selected
 			// ships with the group with the given index.
-			if(!(mod & KMOD_SHIFT))
+			if(!shift)
 				allSelected = added;
 			else
 			{

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -276,7 +276,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		if(selectedIndex >= 0)
 			allSelected.insert(selectedIndex);
 	}
-	else if(canEdit && key == 'P' && !allSelected.empty())
+	else if(canEdit && !allSelected.empty() && (key == 'P' || (key == 'p' && (mod & KMOD_SHIFT))))
 	{
 		// Toggle the parked status for all selected ships.
 		bool allParked = true;
@@ -295,7 +295,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 				player.ParkShip(&ship, !allParked);
 		}
 	}
-	else if(canEdit && key == 'A' && player.Ships().size() > 1)
+	else if(canEdit && player.Ships().size() > 1 && (key == 'A' || (key == 'a' && (mod & KMOD_SHIFT))))
 	{
 		// Toggle the parked status for all ships except the flagship.
 		bool allParked = true;

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -176,7 +176,8 @@ void PlayerInfoPanel::Draw()
 
 bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 {
-	if(key == 'd' || key == SDLK_ESCAPE || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI))))
+	if(key == 'd' || key == SDLK_ESCAPE || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI)))
+			|| key == 'i' || command.Has(Command::INFO))
 		GetUI()->Pop(this);
 	else if(key == 's' || key == SDLK_RETURN || key == SDLK_KP_ENTER)
 	{
@@ -307,7 +308,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 			if(!it->IsDisabled() && (allParked || it.get() != flagship))
 				player.ParkShip(it.get(), !allParked);
 	}
-	else if(command.Has(Command::INFO | Command::MAP) || key == 'm')
+	else if(command.Has(Command::MAP) || key == 'm')
 		GetUI()->Push(new MissionPanel(player));
 	else if(key == 'l' && player.HasLogs())
 		GetUI()->Push(new LogbookPanel(player));

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -131,7 +131,7 @@ bool ShipInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			shipIt = player.Ships().begin();
 		UpdateInfo();
 	}
-	else if(key == 'i')
+	else if(key == 'i' || command.Has(Command::INFO))
 	{
 		GetUI()->Pop(this);
 		GetUI()->Push(new PlayerInfoPanel(player));
@@ -192,7 +192,7 @@ bool ShipInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 			}
 		}
 	}
-	else if(command.Has(Command::INFO | Command::MAP) || key == 'm')
+	else if(command.Has(Command::MAP) || key == 'm')
 		GetUI()->Push(new MissionPanel(player));
 	else if(key == 'l' && player.HasLogs())
 		GetUI()->Push(new LogbookPanel(player));

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -115,10 +115,10 @@ void ShipInfoPanel::Draw()
 
 bool ShipInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 {
-	bool hasShift = mod & KMOD_SHIFT;
+	bool shift = (mod & KMOD_SHIFT);
 	if(key == 'd' || key == SDLK_ESCAPE || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI))))
 		GetUI()->Pop(this);
-	else if(!player.Ships().empty() && ((key == 'p' && !hasShift) || key == SDLK_LEFT || key == SDLK_UP))
+	else if(!player.Ships().empty() && ((key == 'p' && !shift) || key == SDLK_LEFT || key == SDLK_UP))
 	{
 		if(shipIt == player.Ships().begin())
 			shipIt = player.Ships().end();
@@ -137,9 +137,9 @@ bool ShipInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 		GetUI()->Pop(this);
 		GetUI()->Push(new PlayerInfoPanel(player));
 	}
-	else if(key == 'R' || (key == 'r' && hasShift))
+	else if(key == 'R' || (key == 'r' && shift))
 		GetUI()->Push(new Dialog(this, &ShipInfoPanel::Rename, "Change this ship's name?"));
-	else if(canEdit && (key == 'P' || (key == 'p' && hasShift)))
+	else if(canEdit && (key == 'P' || (key == 'p' && shift)))
 	{
 		if(shipIt->get() != player.Flagship() || (*shipIt)->IsParked())
 			player.ParkShip(shipIt->get(), !(*shipIt)->IsParked());


### PR DESCRIPTION
Closes #3703 

Fixes a bug / UX detriment where the Player Info panel could not be toggled with `i` - instead, `i` would open the mission panel. This stems from `i` being the default key associated with the INFO command.

This PR regularizes the use of `Command::INFO` to always do what the ticker says:
https://github.com/endless-sky/endless-sky/blob/d2e19f154a37c267562192847a720fd4a36e3c1b/keys.txt#L20

Additionally, for certain buttons associated with the Player/Ship info panels, (rename, park/unpark, park/unpark all), allows the use of the Shift key to perform the action. (The game ships an interface definition which makes the buttons emit the uppercase key, which keyboards generally can't do.)
I skipped including the Caps Lock key in this, since it is fairly probable that someone will have it pressed without intending to emit "uppercase" keys.

Since `ShipInfoPanel::CanDump` requires `canEdit` (i.e, if the player is on a planet, they can edit their fleet composition) to be false (no littering!), I removed the check. The binding to uppercase `P` stems from [`519c5cd58`](https://github.com/endless-sky/endless-sky/commit/519c5cd580bc9862bd69c42964c98a89f7a78e6e#diff-573158c16b111d76168129cf5c0f29a2R213), and even then `P` appears to be associated with parking and unparking ships. Since `P` is otherwise handled already, it being here isn't doing anything but make us wonder why it's there.