### PR TITLE
Revert some .gitignore changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Compiled Binaries and shortcuts
 /endless-sky
-EndlessSky.exe
+*.exe
 *.lnk
 
 # dlls needed to run the binary

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ ipch/
 *.vcxproj*
 *.userosscache
 *.sln.docstates
+*.xcodeproj/**


### PR DESCRIPTION
This reverts a change removing xcode project settings from `.gitignore` in c76aea7294f0f76a823e3009c6e7c96600a9eb98. That commit also changed ignoring `*.exe` to just `EndlessSky.exe` - Do we definitely want to do that?