### PR TITLE
made Ember Wormhole require quantum keystone

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -24719,6 +24719,7 @@ planet "Ember Threshold"
 	description ""
 
 planet "Ember Wormhole"
+	attributes "requires: quantum keystone"
 	description ""
 
 planet "Esayaku Fen"


### PR DESCRIPTION
Because it improves consistency:
* other wormholes in the Ember Waste also require quantum keystones
* the "Ember Wormhole" is currently the only wormhole with a red sprite that doesn't require a quantum keystone; other reds do, purples don't