### PR TITLE
Korathi → Korath

### DIFF
--- a/data/quarg missions.txt
+++ b/data/quarg missions.txt
@@ -76,7 +76,7 @@ mission "First Contact: Kuwaru Efreti"
 	on offer
 		conversation
 			`In your past experience, you've never seen the Quarg move with anything approaching haste or excitement, but when you land on this station a group of them run up to you, moving faster than you thought they were able to. For a minute or two they just gawk at you and talk amongst themselves in their own language; you think you recognize the word "Humani," and perhaps, "Eartha."`
-			`	Finally a Quarg appears who speaks your language, or at least is willing to try. It says, "Salutations, astonishing sojourner. Whither came you, and wherefore visit you us here in the unquiet graveyard of the Korathi?"`
+			`	Finally a Quarg appears who speaks your language, or at least is willing to try. It says, "Salutations, astonishing sojourner. Whither came you, and wherefore visit you us here in the unquiet graveyard of the Korath?"`
 			choice
 				`	"I'm just here to explore. Can you tell me more about the Korath?"`
 				`	"I came here to learn what happened to the Korath."`
@@ -100,7 +100,7 @@ mission "First Contact: Kuwaru Efreti"
 			label korath
 			`	You are interrupted as one of the Korath who inhabit this ringworld walks by, and the Quarg says, "Friend Korath, meet the human."`
 			`	"<first> <last>," you say, holding out a hand automatically. The Korath does not shake your hand, but instead greets you by holding up both hands, palms toward you. It says something in its own language, then hurries away.`
-			`	The Quarg says to you, "One faction among the Korathi sought peace. 'Korath Efreti,' they name themselves, which means 'Korath Friends.' They are under our protection and intend you no harm. But, they have not your language; here humans are rare. Another question have you?"`
+			`	The Quarg says to you, "One faction among the Korath sought peace. 'Korath Efreti,' they name themselves, which means 'Korath Friends.' They are under our protection and intend you no harm. But, they have not your language; here humans are rare. Another question have you?"`
 			choice
 				`	"Will the friendly Korath let me purchase their technology?"`
 				`	"Why don't you destroy the robots, if they're such a threat?"`

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -418,14 +418,14 @@ mission "Wanderers: Quarg Assistance 2"
 				`	"The Wanderers may be able to help you deal with the hostile automata."`
 					goto automata
 
-			`	"Are they able also to make the Korathi worthy to inhabit those worlds again? Are they able to make wise enough the Korathi to not ruin their homes once more? Or do the abilities of these extragalactic interlopers not extend so far?"`
+			`	"Are they able also to make the Korath worthy to inhabit those worlds again? Are they able to make wise enough the Korath to not ruin their homes once more? Or do the abilities of these extragalactic interlopers not extend so far?"`
 				goto next
 
 			label automata
 			`	"Are their vessels and arms mightier than ours?" asks the Quarg. "Have they a wisdom vaster than our own? Or are they more numerous than we? For we are trillions. What could these extragalactic interlopers achieve, that long before your emergence attempted have we not?"`
 
 			label next
-			`	When you don't respond, the Quarg continues, "These Wanderers are not indigenous to our galaxy, and thus have not we an obligation to avert their extinction. The Korathi are our charge and our responsibility. So implore I you to tell me, why a good thing for the Korathi it is that their shattered territory these aliens invade."`
+			`	When you don't respond, the Quarg continues, "These Wanderers are not indigenous to our galaxy, and thus have not we an obligation to avert their extinction. The Korath are our charge and our responsibility. So implore I you to tell me, why a good thing for the Korath it is that their shattered territory these aliens invade."`
 			choice
 				`	"The Wanderers could help the Korath by teaching them to take care of their worlds better."`
 				`	"The Wanderers don't want to stay here forever; they will move on once the worlds are repaired."`

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -709,7 +709,7 @@ mission "Unfettered: Jump Drive Source"
 				`	"If I want to find more jump drives to give you, where should I look?"`
 				`	"You said that 'other humans' have been selling you jump drives as well?"`
 					goto others
-			`	He says, "The unfettered humans will not tell us their source, but we suspect they steal from our old foe, the Korathi invaders. The unfettered human leader told a story I did not understand, that Prometheus was punished for stealing from the gods, but no one is punished for stealing from Prometheus. Was Prometheus a human hero?"`
+			`	He says, "The unfettered humans will not tell us their source, but we suspect they steal from our old foe, the Korath invaders. The unfettered human leader told a story I did not understand, that Prometheus was punished for stealing from the gods, but no one is punished for stealing from Prometheus. Was Prometheus a human hero?"`
 				goto prometheus
 			label others
 			`	"Yes," he says, "the unfettered humans. They sell us many jump drives. They say it is their calling to help us. The unfettered human leader told a story I did not understand, that Prometheus was punished for stealing from the gods, but no one is punished for stealing from Prometheus. Was Prometheus a human hero?"`


### PR DESCRIPTION
Changed seven instances of Korathi into Korath, because it seems everywhere else Korath can be both singular, plural, and adjective; cf. Hai, Pug, Quarg, or Remnant.