### PR TITLE
pirate fleets corrections

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -190,8 +190,8 @@ event "initial deployment 1"
 		fleet "Large Northern Merchants" 3500
 		fleet "Small Republic" 600
 		fleet "Large Republic" 400
-		fleet "Small Northern Pirates" 4000
-		fleet "Large Northern Pirates" 8000
+		fleet "Small Southern Pirates" 4000
+		fleet "Large Southern Pirates" 8000
 		fleet "Navy Surveillance" 2000
 	system "Phecda"
 		fleet "Small Northern Merchants" 900

--- a/data/events.txt
+++ b/data/events.txt
@@ -186,8 +186,8 @@ event "initial deployment 1"
 		description `Ingot is a volcanic moon, totally unsuitable for life but rich in metal. The miners who work here must spend all their time inside pressurized buildings. Because Ingot has almost no atmosphere to slow them down, meteorites are a constant danger to the colonists. The shells of the buildings have multiple layers, designed to be self-sealing in any but the largest of impacts. Most of the mining is done remotely by robotic vehicles, but someone still needs to be present to control them and to make repairs when something goes wrong.`
 		description `Ingot is also now home to a burgeoning Navy base, although since the planet is so unlivable most of the troops are just living in ships in orbit.`
 	system "Fala"
-		fleet "Small Northern Merchants" 1900
-		fleet "Large Northern Merchants" 3500
+		fleet "Small Southern Merchants" 1900
+		fleet "Large Southern Merchants" 3500
 		fleet "Small Republic" 600
 		fleet "Large Republic" 400
 		fleet "Small Southern Pirates" 4000
@@ -361,7 +361,7 @@ event "initial deployment 2"
 		fleet "Navy Surveillance" 1600
 	system "Alioth"
 		fleet "Small Southern Merchants" 400
-		fleet "Large Northern Merchants" 600
+		fleet "Large Southern Merchants" 600
 		fleet "Small Southern Pirates" 1200
 		fleet "Large Southern Pirates" 2400
 		fleet "Small Republic" 3000
@@ -390,14 +390,14 @@ event "initial deployment 2"
 		fleet "Navy Surveillance" 1600
 	system "Alphecca"
 		fleet "Small Southern Merchants" 2000
-		fleet "Large Northern Merchants" 3500
+		fleet "Large Southern Merchants" 3500
 		fleet "Small Southern Pirates" 3000
 		fleet "Small Republic" 3000
 		fleet "Large Republic" 4000
 		fleet "Navy Surveillance" 1600
 	system "Boral"
 		fleet "Small Southern Merchants" 3000
-		fleet "Large Northern Merchants" 8000
+		fleet "Large Southern Merchants" 8000
 		fleet "Small Southern Pirates" 1500
 		fleet "Small Republic" 7000
 		fleet "Large Republic" 12000

--- a/data/map.txt
+++ b/data/map.txt
@@ -9262,8 +9262,8 @@ system Fala
 	fleet "Small Northern Merchants" 1600
 	fleet "Large Northern Merchants" 3000
 	fleet "Small Republic" 4000
-	fleet "Small Northern Pirates" 2000
-	fleet "Large Northern Pirates" 4000
+	fleet "Small Southern Pirates" 2000
+	fleet "Large Southern Pirates" 4000
 	fleet "Human Miners" 2000
 	object
 		sprite star/g5-old
@@ -14178,8 +14178,8 @@ system Lolami
 	fleet "Small Northern Merchants" 2000
 	fleet "Large Northern Merchants" 3000
 	fleet "Small Republic" 5000
-	fleet "Small Northern Pirates" 2000
-	fleet "Large Northern Pirates" 4000
+	fleet "Small Southern Pirates" 2000
+	fleet "Large Southern Pirates" 4000
 	fleet "Human Miners" 3000
 	object
 		sprite star/g0
@@ -21855,8 +21855,8 @@ system "Tania Australis"
 	fleet "Small Northern Merchants" 1000
 	fleet "Large Northern Merchants" 2000
 	fleet "Small Republic" 3000
-	fleet "Small Northern Pirates" 4000
-	fleet "Large Northern Pirates" 9000
+	fleet "Small Southern Pirates" 4000
+	fleet "Large Southern Pirates" 9000
 	object
 		sprite star/g0-old
 		period 10

--- a/data/map.txt
+++ b/data/map.txt
@@ -16599,7 +16599,6 @@ system Nocte
 	fleet "Large Northern Merchants" 5000
 	fleet "Small Republic" 3000
 	fleet "Large Republic" 7000
-	fleet "Small Northern Pirates" 2500
 	fleet "Human Miners" 1600
 	object
 		sprite star/m4

--- a/data/map.txt
+++ b/data/map.txt
@@ -17845,6 +17845,7 @@ system Polaris
 	fleet "Large Core Merchants" 700
 	fleet "Small Syndicate" 1000
 	fleet "Large Syndicate" 2000
+	fleet "Small Core Pirates" 1500
 	fleet "Korath Raid" 50000
 	object
 		sprite star/k5

--- a/data/map.txt
+++ b/data/map.txt
@@ -17845,7 +17845,6 @@ system Polaris
 	fleet "Large Core Merchants" 700
 	fleet "Small Syndicate" 1000
 	fleet "Large Syndicate" 2000
-	fleet "Small Core Pirates" 1500
 	fleet "Korath Raid" 50000
 	object
 		sprite star/k5

--- a/data/map.txt
+++ b/data/map.txt
@@ -18790,8 +18790,6 @@ system Regulus
 	trade Plastic 318
 	fleet "Small Southern Merchants" 6000
 	fleet "Small Northern Merchants" 6000
-	fleet "Small Southern Pirates" 2000
-	fleet "Large Southern Pirates" 8000
 	fleet "Small Republic" 10000
 	fleet "Human Miners" 3000
 	object

--- a/data/map.txt
+++ b/data/map.txt
@@ -14170,8 +14170,6 @@ system Lolami
 	trade Plastic 316
 	fleet "Small Northern Merchants" 2000
 	fleet "Small Republic" 5000
-	fleet "Small Southern Pirates" 2000
-	fleet "Large Southern Pirates" 4000
 	fleet "Human Miners" 3000
 	object
 		sprite star/g0

--- a/data/map.txt
+++ b/data/map.txt
@@ -9885,7 +9885,6 @@ system Fingol
 	fleet "Large Northern Merchants" 3000
 	fleet "Small Republic" 2000
 	fleet "Large Republic" 3000
-	fleet "Small Northern Pirates" 2000
 	fleet "Human Miners" 3000
 	object
 		sprite star/m4

--- a/data/map.txt
+++ b/data/map.txt
@@ -13814,8 +13814,6 @@ system Kugel
 	fleet "Small Core Merchants" 4000
 	fleet "Small Republic" 6000
 	fleet "Small Syndicate" 8000
-	fleet "Large Core Pirates" 4000
-	fleet "Small Core Pirates" 4000
 	object
 		sprite star/g5
 		period 10

--- a/data/map.txt
+++ b/data/map.txt
@@ -9075,7 +9075,6 @@ system Eteron
 	fleet "Large Northern Merchants" 1500
 	fleet "Small Republic" 2000
 	fleet "Large Republic" 4000
-	fleet "Small Northern Pirates" 1000
 	fleet "Human Miners" 2000
 	object
 		sprite star/m4


### PR DESCRIPTION
Removed pirates from five systems (Kugel, Eteron, Fingol, Nocte, Regulus), because they are uninhabited and each one's only neighbour has no pirate fleets at all, so it's weird they appear here out of nowhere. Cf. #4038. 

[EDIT]: Also changed the pirate fleets in Fala and Tania Australis from Northern to Southern, because:
* there are no pirate fleets in Algieba or Phecda
* Delta Velorum and Mora have Southern fleets
* the only inhabited object in these three systems is a Republic dirt belt planet
* `event "initial deployment 1"` removes all pirates from Tania Australis
  * because this isolates the uninhabited system of Lolami, pirates are removed from there as well.
* these systems are closer to Shaula than to Almaaz
  
In other words, Northern pirates make little sense here, Southern do.


This basically results in the following:
* Core Pirates in the Core
* Northern Pirates in the Deep and the North
* Southern Pirates in the Dirt Belt and the South