### PR TITLE
Add thumbnail definition to the "Unknown Ship Type"

### DIFF
--- a/data/kestrel.txt
+++ b/data/kestrel.txt
@@ -213,6 +213,7 @@ event "kestrel available: more shields"
 
 ship "Unknown Ship Type"
 	sprite "ship/kestrel"
+	thumbnail "thumbnail/kestrel"
 	attributes
 		category "Heavy Warship"
 		"cost" 10300000


### PR DESCRIPTION
So that the player sees the (already existing) thumbnail in shipyard and outfitter screens. Will also fix it for the all-content-plugin.
![sidebyside](https://user-images.githubusercontent.com/17566547/49321372-e2476380-f4fe-11e8-9464-b4dec5c50a6a.png)