### PR TITLE
Give more luxury ships Luxury Accomodations

### DIFF
--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -181,8 +181,6 @@ fleet "Small Core Merchants"
 		"Freighter"
 		"Shuttle" 2
 		"Quicksilver"
-	variant 20
-		"Arrow (Luxury)"
 	variant 50
 		"Bounder"
 	variant 30
@@ -435,8 +433,6 @@ fleet "Small Northern Merchants"
 	variant 10
 		"Freighter" 3
 		"Sparrow" 1
-	variant 10
-		"Arrow (Luxury)"
 	variant 10
 		"Blackbird"
 	variant 3

--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -95,6 +95,7 @@ ship "Centipede"
 		"Hai Corundum Regenerator"
 		"Hai Ravine Batteries"
 		"Hai Williwaw Cooling" 3
+		"Luxury Accommodations"
 		"Quantum Keystone"
 		`"Biroo" Atomic Thruster`
 		`"Biroo" Atomic Steering`
@@ -123,9 +124,11 @@ ship "Centipede" "Centipede (Pulse)"
 		"Pulse Cannon" 2
 		"Bullfrog Anti-Missile" 3
 		"Boulder Reactor"
-		"Hai Gorge Batteries"
+		"Hai Fissure Batteries"
+		"Hai Chasm Batteries"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 5
+		"Luxury Accommodations"
 		"Quantum Keystone"
 		"Pulse Rifle" 24
 		`"Biroo" Atomic Thruster`

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -150,14 +150,15 @@ ship "Arrow"
 			"hull damage" 120
 			"hit force" 360
 	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 50
 		"Anti-Missile Turret"
 		
 		"Dwarf Core"
 		"Supercapacitor"
 		"D14-RN Shield Generator"
 		"Small Radar Jammer"
+		"Luxury Accommodations"
 		
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -87,24 +87,9 @@ ship "Arrow" "Arrow (Hai)"
 		"Pebble Core"
 		"Supercapacitor" 2
 		"D14-RN Shield Generator"
-		"Small Radar Jammer"
+		"Luxury Accommodations"
 		`"Benga" Atomic Thruster`
 		`"Biroo" Atomic Steering`
-		"Hyperdrive"
-
-
-ship "Arrow" "Arrow (Luxury)"
-	outfits
-		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 100
-		"Anti-Missile Turret"
-		"Dwarf Core"
-		"Supercapacitor"
-		"D14-RN Shield Generator"
-		"Small Radar Jammer"
-		"Luxury Accommodations"
-		"A250 Atomic Thruster"
-		"A255 Atomic Steering"
 		"Hyperdrive"
 
 


### PR DESCRIPTION
This PR adds Luxury accommodations to the Hai Centipede and Human Arrow, both of which are mentioned as specifically existing for the purpose of transporting wealthy people. Loadouts are adjusted a bit where needed to keep from becoming negative, as Luxury Accommodations add weigh 10 tons.