### PR TITLE
Tweaked Raven base cost

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1825,7 +1825,7 @@ ship "Headhunter"
 	thumbnail "thumbnail/headhunter"
 	attributes
 		category "Light Warship"
-		"cost" 1800000
+		"cost" 1850000
 		"shields" 3800
 		"hull" 700
 		"required crew" 2

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1825,7 +1825,7 @@ ship "Headhunter"
 	thumbnail "thumbnail/headhunter"
 	attributes
 		category "Light Warship"
-		"cost" 1850000
+		"cost" 1800000
 		"shields" 3800
 		"hull" 700
 		"required crew" 2
@@ -2476,7 +2476,7 @@ ship "Raven"
 	thumbnail "thumbnail/raven"
 	attributes
 		category "Light Warship"
-		"cost" 1800000
+		"cost" 2600000
 		"shields" 4700
 		"hull" 1400
 		"required crew" 6


### PR DESCRIPTION
The Raven currently has a base cost (1.8 M) just below the Headhunter's (1.85 M). However, the Raven is a clearly more powerful ship (100 weapon capacity instead of 60), therefore it would make sense to make it more expensive. This proposal increases it by 0.8 M. For comparison the base costs of Lionheart ships:
* 0.129 M: Dagger
* 0.18 M: Flivver
* 0.85 M: Scout
* 1.8 M: current Raven
* 1.85 M: Headhunter
* 2.6 M proposed Raven
* 3.5 M: Aerie
* 4.4 M: Corvette
* 4.58 M: Mule
* 17.6 M: Bactrian