### PR TITLE
Move ship and outfit categories to data files

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -1,0 +1,31 @@
+# Copyright (c) 2016 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+categories "ship"
+	"Fighter"
+	"Drone"
+	"Interceptor"
+	"Transport"
+	"Light Freighter"
+	"Heavy Freighter"
+	"Light Warship"
+	"Medium Warship"
+	"Heavy Warship"
+	
+categories "outfit"
+	"Guns"
+	"Turrets"
+	"Secondary Weapons"
+	"Ammunition"
+	"Systems"
+	"Power"
+	"Engines"
+	"Hand to Hand"
+	"Special"

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -217,7 +217,6 @@ bool GameData::BeginLoad(const char * const *argv)
 // Check for objects that are referred to but never defined.
 void GameData::CheckReferences()
 {
-	
 	set<string> knownOutfitCategories(categories["outfit"].begin(), categories["outfit"].end());
 	set<string> knownShipCategories(categories["ship"].begin(), categories["ship"].end());
 	for(const string &carried : {"Fighter", "Drone"})

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -127,6 +127,7 @@ public:
 	
 	// Strings for combat rating levels, etc.
 	static const std::string &Rating(const std::string &type, int level);
+	static const std::vector<std::string> &Categories(const std::string &type);
 	
 	static const StarField &Background();
 	static void SetHaze(const Sprite *sprite);

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -470,7 +470,7 @@ void LocationFilter::LoadChild(const DataNode &child)
 	else if(key == "category" && child.Size() >= 2 + isNot)
 	{
 		// Ship categories cannot be combined in an "and" condition.
-		static const set<string> allowed(Ship::CATEGORIES.begin(), Ship::CATEGORIES.end());
+		static const set<string> allowed(GameData::Categories("ship").begin(), GameData::Categories("ship").end());
 		for(int i = 1 + isNot; i < child.Size(); ++i)
 		{
 			const string &value = child.Token(i);

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -47,7 +47,7 @@ const int MapSalesPanel::WIDTH = 270;
 
 MapSalesPanel::MapSalesPanel(PlayerInfo &player, bool isOutfitters)
 	: MapPanel(player, SHOW_SPECIAL),
-	categories(isOutfitters ? Outfit::CATEGORIES : Ship::CATEGORIES),
+	categories(GameData::Categories(isOutfitters ? "outfit" : "ship")),
 	isOutfitters(isOutfitters),
 	collapsed(player.Collapsed(isOutfitters ? "outfitter map" : "shipyard map"))
 {
@@ -59,7 +59,7 @@ MapSalesPanel::MapSalesPanel(PlayerInfo &player, bool isOutfitters)
 
 MapSalesPanel::MapSalesPanel(const MapPanel &panel, bool isOutfitters)
 	: MapPanel(panel),
-	categories(isOutfitters ? Outfit::CATEGORIES : Ship::CATEGORIES),
+	categories(GameData::Categories(isOutfitters ? "outfit" : "ship")),
 	isOutfitters(isOutfitters),
 	collapsed(player.Collapsed(isOutfitters ? "outfitter map" : "shipyard map"))
 {

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -27,18 +27,6 @@ namespace {
 	const double EPS = 0.0000000001;
 }
 
-const vector<string> Outfit::CATEGORIES = {
-	"Guns",
-	"Turrets",
-	"Secondary Weapons",
-	"Ammunition",
-	"Systems",
-	"Power",
-	"Engines",
-	"Hand to Hand",
-	"Special"
-};
-
 
 
 void Outfit::Load(const DataNode &node)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -83,20 +83,6 @@ namespace {
 	}
 }
 
-const vector<string> Ship::CATEGORIES = {
-	"Transport",
-	"Light Freighter",
-	"Heavy Freighter",
-	"Interceptor",
-	"Light Warship",
-	"Medium Warship",
-	"Heavy Warship",
-	"Fighter",
-	"Drone"
-};
-
-
-
 // Construct and Load() at the same time.
 Ship::Ship(const DataNode &node)
 {

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -325,7 +325,7 @@ void ShipInfoPanel::DrawOutfits(const Rectangle &bounds, Rectangle &cargoBounds)
 	table.DrawAt(start);
 	
 	// Draw the outfits in the same order used in the outfitter.
-	for(const string &category : Outfit::CATEGORIES)
+	for(const string &category : GameData::Categories("outfit"))
 	{
 		auto it = outfits.find(category);
 		if(it == outfits.end())

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -49,7 +49,7 @@ namespace {
 ShopPanel::ShopPanel(PlayerInfo &player, bool isOutfitter)
 	: player(player), day(player.GetDate().DaysSinceEpoch()),
 	planet(player.GetPlanet()), playerShip(player.Flagship()),
-	categories(isOutfitter ? Outfit::CATEGORIES : Ship::CATEGORIES),
+	categories(GameData::Categories(isOutfitter ? "outfit" : "ship")),
 	collapsed(player.Collapsed(isOutfitter ? "outfitter" : "shipyard"))
 {
 	if(playerShip)


### PR DESCRIPTION
This PR will allow modders to rename, add or remove categories of ships or outfits.

It also allows the categories to be rearranged in any order (However, the "Fighter" and "Drone" categories will always be present: if they aren't defined, they will be added to the bottom of the list)

Edit: Yeah, I kinda reset this branch to the master so my old PR closed out. RIP