### PR TITLE
Add Hai jobs to bring commodities back from human space

### DIFF
--- a/data/hai jobs.txt
+++ b/data/hai jobs.txt
@@ -350,7 +350,7 @@ mission "Delivery to Human Space [0]"
 	job
 	repeat
 	description "This human wishes for <cargo> to be delivered to <destination> in human space. Payment is <payment>."
-	cargo random 2 10
+	cargo random 5 10
 	to offer
 		random < 30
 	source
@@ -359,7 +359,7 @@ mission "Delivery to Human Space [0]"
 	destination
 		attributes "north"
 	on complete
-		payment 80000
+		payment 60000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
 
 mission "Delivery to Human Space [1]"
@@ -367,7 +367,7 @@ mission "Delivery to Human Space [1]"
 	job
 	repeat
 	description "This Hai wishes for <cargo> to be delivered to <destination> in human space. Payment is <payment>."
-	cargo random 2 10
+	cargo random 5 10
 	to offer
 		random < 25
 	source
@@ -376,7 +376,7 @@ mission "Delivery to Human Space [1]"
 	destination
 		attributes "north"
 	on complete
-		payment 80000
+		payment 60000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
 
 mission "Delivery to Human Space [2]"
@@ -384,7 +384,7 @@ mission "Delivery to Human Space [2]"
 	job
 	repeat
 	description "This human wishes for <cargo> to be delivered to <destination> in human space. Payment is <payment>."
-	cargo random 2 10
+	cargo random 5 10
 	to offer
 		random < 20
 	source
@@ -393,7 +393,7 @@ mission "Delivery to Human Space [2]"
 	destination
 		attributes "north"
 	on complete
-		payment 80000
+		payment 60000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
 
 mission "Hai Retrieve Human Luxury Goods"

--- a/data/hai jobs.txt
+++ b/data/hai jobs.txt
@@ -400,8 +400,9 @@ mission "Hai Retrieve Human Luxury Goods"
 	name "Special order to <planet>"
 	job
 	repeat
-	description "A Hai socialite on <planet> wants to show off their knowledge of human culture to their peers. They will pay <payment> for <cargo> from <stopovers>."
-	cargo "Luxury Goods" 1 5
+	description "A Hai socialite on <planet> wants to show off their knowledge of human culture to their peers. They want <cargo> from <stopovers> by <date>. Payment is <payment>."
+	cargo "Luxury Goods" 5 10
+	deadline 24
 	to offer
 		random < 15
 	source
@@ -412,15 +413,16 @@ mission "Hai Retrieve Human Luxury Goods"
 	on stopover
 		dialog "You gather the requested <commodity> and load them on your ship for return to <planet>."
 	on complete
-		payment 160000
+		payment 120000
 		dialog "Your payment of <payment> is waiting when you touch down, along with delivery instructions. You send the <commodity> by dedicated courier."
 
 mission "Hai Retrieve Human Food"
 	name "Special order to <planet>"
 	job
 	repeat
-	description "A Hai gourmet on <planet> is bored with local fare and wants to try food they heard about from human tourists. They will pay <payment> for <cargo> from <stopovers>."
-	cargo "Food" 1 5
+	description "A Hai gourmet on <planet> is bored with local fare and wants to try food they heard about from human tourists. They want <cargo> from <stopovers> by <date>. Payment is <payment>."
+	cargo "Food" 5 10
+	deadline 24
 	to offer
 		random < 15
 	source
@@ -431,15 +433,16 @@ mission "Hai Retrieve Human Food"
 	on stopover
 		dialog "You gather the requested <commodity> and load them on your ship for return to <planet>."
 	on complete
-		payment 160000
+		payment 120000
 		dialog "As soon as you touch down you receive a message from the Hai gourmet with thanks and your payment of <payment>."
 
 mission "Hai Retrieve Human Electronics"
 	name "Special order to <planet>"
 	job
 	repeat
-	description "A Hai tinkerer on <planet> wants to experiment with human technology. They will pay <payment> for <cargo> from <stopovers>."
-	cargo "Electronics" 1 5
+	description "A Hai tinkerer on <planet> wants to experiment with human technology. They want <cargo> from <stopovers> by <date>. Payment is <payment>."
+	cargo "Electronics" 5 10
+	deadline 24
 	to offer
 		random < 15
 	source
@@ -450,7 +453,7 @@ mission "Hai Retrieve Human Electronics"
 	on stopover
 		dialog "You gather the requested <commodity> and load them on your ship for return to <planet>."
 	on complete
-		payment 160000
+		payment 120000
 		dialog "The Hai tinkerer is waiting for you when you arrive. They pay you <payment> and then run after the cargo pallets as though they plan to open them right there in the spaceport."
 
 

--- a/data/hai jobs.txt
+++ b/data/hai jobs.txt
@@ -396,6 +396,63 @@ mission "Delivery to Human Space [2]"
 		payment 80000
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
 
+mission "Hai Retrieve Human Luxury Goods"
+	name "Special order to <planet>"
+	job
+	repeat
+	description "A Hai socialite on <destination> wants to show off their knowledge of human culture to their peers. They will pay <payment> for <cargo> from <stopovers>."
+	cargo "Luxury Goods" 1 5
+	to offer
+		random < 15
+	source
+		government "Hai"
+		near "Heia Due" 2
+	stopover
+		attributes "north"
+	on stopover
+		dialog "You gather the requested <commodity> and load them on your ship for return to <planet>."
+	on complete
+		payment 160000
+		dialog "Your payment of <payment> is waiting when you touch down, along with delivery instructions. You send the <commodity> by dedicated courier."
+
+mission "Hai Retrieve Human Food"
+	name "Special order to <planet>"
+	job
+	repeat
+	description "A Hai gourmet on <destination> is bored with local fare and wants to try food they heard about from human tourists. They will pay <payment> for <cargo> from <stopovers>."
+	cargo "Food" 1 5
+	to offer
+		random < 15
+	source
+		government "Hai"
+		near "Heia Due" 2
+	stopover
+		attributes "north"
+	on stopover
+		dialog "You gather the requested <commodity> and load them on your ship for return to <planet>."
+	on complete
+		payment 160000
+		dialog "As soon as you touch down you receive a message from the Hai gourmet with thanks and your payment of <payment>."
+
+mission "Hai Retrieve Human Electronics"
+	name "Special order to <planet>"
+	job
+	repeat
+	description "A Hai tinkerer on <destination> wants to experiment with human technology. They will pay <payment> for <cargo> from <stopovers>."
+	cargo "Electronics" 1 5
+	to offer
+		random < 15
+	source
+		government "Hai"
+		near "Heia Due" 2
+	stopover
+		attributes "north"
+	on stopover
+		dialog "You gather the requested <commodity> and load them on your ship for return to <planet>."
+	on complete
+		payment 160000
+		dialog "The Hai tinkerer is waiting for you when you arrive. They pay you <payment> and then run after the cargo pallets as though they plan to open them right there in the spaceport."
+
 
 
 mission "Escort to Human Space (Small)"

--- a/data/hai jobs.txt
+++ b/data/hai jobs.txt
@@ -400,7 +400,7 @@ mission "Hai Retrieve Human Luxury Goods"
 	name "Special order to <planet>"
 	job
 	repeat
-	description "A Hai socialite on <destination> wants to show off their knowledge of human culture to their peers. They will pay <payment> for <cargo> from <stopovers>."
+	description "A Hai socialite on <planet> wants to show off their knowledge of human culture to their peers. They will pay <payment> for <cargo> from <stopovers>."
 	cargo "Luxury Goods" 1 5
 	to offer
 		random < 15
@@ -419,7 +419,7 @@ mission "Hai Retrieve Human Food"
 	name "Special order to <planet>"
 	job
 	repeat
-	description "A Hai gourmet on <destination> is bored with local fare and wants to try food they heard about from human tourists. They will pay <payment> for <cargo> from <stopovers>."
+	description "A Hai gourmet on <planet> is bored with local fare and wants to try food they heard about from human tourists. They will pay <payment> for <cargo> from <stopovers>."
 	cargo "Food" 1 5
 	to offer
 		random < 15
@@ -438,7 +438,7 @@ mission "Hai Retrieve Human Electronics"
 	name "Special order to <planet>"
 	job
 	repeat
-	description "A Hai tinkerer on <destination> wants to experiment with human technology. They will pay <payment> for <cargo> from <stopovers>."
+	description "A Hai tinkerer on <planet> wants to experiment with human technology. They will pay <payment> for <cargo> from <stopovers>."
 	cargo "Electronics" 1 5
 	to offer
 		random < 15


### PR DESCRIPTION
This adds some two-way transport missions for Hai space. They pay twice as much as the one-way delivery jobs, but have deadlines. This also nerfs the existing delivery jobs.