### PR TITLE
Do not trigger the remembrance day or war begins missions on uninhabited planets

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -17,6 +17,7 @@ mission "remembrance day"
 	landing
 	source
 		government "Republic"
+		not attributes uninhabited
 	to offer
 		has "event: remembrance day"
 	on offer

--- a/data/events.txt
+++ b/data/events.txt
@@ -17,7 +17,7 @@ mission "remembrance day"
 	landing
 	source
 		government "Republic"
-		not attributes uninhabited
+		not attributes "uninhabited"
 	to offer
 		has "event: remembrance day"
 	on offer

--- a/data/events.txt
+++ b/data/events.txt
@@ -17,7 +17,7 @@ mission "remembrance day"
 	landing
 	source
 		government "Republic"
-		not attributes "uninhabited"
+		attributes "spaceport"
 	to offer
 		has "event: remembrance day"
 	on offer
@@ -137,7 +137,7 @@ mission "event: war begins"
 	landing
 	source
 		government "Republic" "Syndicate" "Free Worlds"
-		not attributes "uninhabited"
+		attributes "spaceport"
 	to offer
 		has "event: war begins"
 	on offer

--- a/data/events.txt
+++ b/data/events.txt
@@ -137,6 +137,7 @@ mission "event: war begins"
 	landing
 	source
 		government "Republic" "Syndicate" "Free Worlds"
+		not attributes "uninhabited"
 	to offer
 		has "event: war begins"
 	on offer


### PR DESCRIPTION
This excludes all `uninhabited` just to be sure.

Fixes #4104 
