### PR TITLE
Add per-ton summary of outfit stats to the tooltip shown for outfit mass

### DIFF
--- a/source/ItemInfoDisplay.cpp
+++ b/source/ItemInfoDisplay.cpp
@@ -207,7 +207,12 @@ void ItemInfoDisplay::CheckHover(const Table &table, const string &label) const
 		if(hoverCount >= HOVER_TIME)
 		{
 			hoverCount = HOVER_TIME;
-			hoverText.Wrap(GameData::Tooltip(label));
+			hoverText.Wrap(getTooltipText(label));
 		}
 	}
+}
+
+const std::string& ItemInfoDisplay::getTooltipText(const std::string &label) const
+{
+	return GameData::Tooltip(label);
 }

--- a/source/ItemInfoDisplay.h
+++ b/source/ItemInfoDisplay.h
@@ -51,7 +51,7 @@ protected:
 	void UpdateDescription(const std::string &text, const std::vector<std::string> &licenses, bool isShip);
 	Point Draw(Point point, const std::vector<std::string> &labels, const std::vector<std::string> &values) const;
 	void CheckHover(const Table &table, const std::string &label) const;
-	
+	virtual const std::string& getTooltipText(const std::string &label) const;
 	
 protected:
 	static const int WIDTH = 250;

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -185,6 +185,8 @@ void OutfitInfoDisplay::UpdateRequirements(const Outfit &outfit, const PlayerInf
 
 void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 {
+	tooltipStats.clear();
+	
 	attributeLabels.clear();
 	attributeValues.clear();
 	attributesHeight = 20;
@@ -213,6 +215,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 			attributeLabels.emplace_back(static_cast<string>(it.first) + ":");
 			attributeValues.emplace_back(Format::Number(it.second * scale));
 			attributesHeight += 20;
+			
+			tooltipStats += static_cast<string>(it.first) + ": " + Format::Number((it.second * scale) / outfit.Mass()) + "\n";
 		}
 		hasNormalAttributes = true;
 	}
@@ -276,6 +280,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 				attributeLabels.emplace_back(VALUE_NAMES[i] + PER_SECOND);
 				attributeValues.emplace_back(Format::Number(60. * values[i] / reload));
 				attributesHeight += 20;
+				
+				tooltipStats += VALUE_NAMES[i] + ": " + (Format::Number((60. * values[i] / reload) / outfit.Mass())) + "\n";
 			}
 	}
 	
@@ -370,4 +376,19 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 			attributeValues.emplace_back(Format::Number(otherValues[i]));
 			attributesHeight += 20;
 		}
+}
+
+const std::string& OutfitInfoDisplay::getTooltipText(const std::string &label) const
+{
+	tooltipText.clear();
+	if (label == "mass:") {
+		tooltipText.append(ItemInfoDisplay::getTooltipText(label));
+		tooltipText.append("\n- Stats per ton -\n");
+		tooltipText.append(tooltipStats);
+		
+		return tooltipText;
+	}
+	else {
+		return ItemInfoDisplay::getTooltipText(label);
+	}
 }

--- a/source/OutfitInfoDisplay.h
+++ b/source/OutfitInfoDisplay.h
@@ -47,6 +47,8 @@ public:
 	// void DrawAttributes(const Point &topLeft) const;
 	void DrawRequirements(const Point &topLeft) const;
 	
+protected:
+	virtual const std::string& getTooltipText(const std::string &label) const;
 	
 private:
 	void UpdateRequirements(const Outfit &outfit, const PlayerInfo &player, bool canSell);
@@ -56,6 +58,8 @@ private:
 private:
 	std::vector<std::string> requirementLabels;
 	std::vector<std::string> requirementValues;
+	mutable std::string tooltipText;
+	std::string tooltipStats;
 	int requirementsHeight = 0;
 };
 


### PR DESCRIPTION
related issue: #4106