### PR TITLE
Made Syndicate test dummies disable and gave them confusion

### DIFF
--- a/data/syndicate jobs.txt
+++ b/data/syndicate jobs.txt
@@ -174,7 +174,8 @@ mission "Syndicate target practice [0]"
 		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"
 		government "Test Dummy"
-		personality staying heroic target
+		personality disables staying heroic target
+			confusion 120
 		system destination
 		ship "Berserker Test Dummy" "Syndicate Test Vessel"
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
@@ -207,7 +208,8 @@ mission "Syndicate target practice [1]"
 		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"
 		government "Test Dummy"
-		personality staying heroic target
+		personality disables staying heroic target
+			confusion 120
 		system destination
 		ship "Quicksilver Test Dummy" "Syndicate Test Vessel"
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
@@ -240,7 +242,8 @@ mission "Syndicate target practice [2]"
 		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"
 		government "Test Dummy"
-		personality staying heroic target
+		personality disables staying heroic target
+			confusion 120
 		system destination
 		ship "Splinter Test Dummy" "Syndicate Test Vessel"
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
@@ -272,7 +275,8 @@ mission "Syndicate target practice [3]"
 		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"
 		government "Test Dummy"
-		personality staying heroic target
+		personality disables staying heroic target
+			confusion 120
 		system destination
 		ship "Vanguard Test Dummy" "Syndicate Test Vessel"
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."


### PR DESCRIPTION
Ref: #4115 

Syndicate test dummy ships will now disable instead of killing the player. A happy customer is an alive customer. No use in killing off captains in the Core that could otherwise be spending their money on Syndicate goods.

Also gave Syndicate test dummy ships a confusion value of 120. Confusion isn't used hardly enough in the game. Given that the technology that the Syndicate are working on with these ships is effectively the same thing as the Kor Automata, I thought it fitting to give these test dummies a behavior that makes it very clear that the technology of fully automating large vessels is only in the works for the Syndicate.