### PR TITLE
Make Korath Command center unplunderable

### DIFF
--- a/data/korath outfits.txt
+++ b/data/korath outfits.txt
@@ -158,6 +158,7 @@ outfit "Command Center"
 	"bunks" 1
 	"required crew" 1
 	"automaton" -1
+	unplunderable 1
 	description "In response to occasional raids by the robotic war machines left behind after their recent conflict, the Kor Efret have developed this minimal, spartan command center that can be installed in a captured robotic ship to allow a pilot to override the AI and interface with the ship's controls. The command center only provides a single bunk for the captain, so more may be necessary if the ship has turrets or other systems that require crew."
 
 outfit "Reasoning Node"


### PR DESCRIPTION
Even though it will never spawn in vanilla gameplay. The command center should be unplunderable, like bunk rooms or outfit expansions.