### PR TITLE
Add hand-to-hand weapons to Republic Navy ships

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -725,8 +725,6 @@ ship "Carrier"
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret" 2
 
-		"Laser Rifle" 40
-		"Fragmentation Grenades" 40
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
@@ -734,6 +732,8 @@ ship "Carrier"
 		"Large Radar Jammer" 2
 		"Water Coolant System"
 		"Brig"
+		"Laser Rifle" 40
+		"Fragmentation Grenades" 40
 		
 		"X5700 Ion Thruster"
 		"X4200 Ion Steering"
@@ -1022,15 +1022,14 @@ ship "Cruiser"
 		"Sidewinder Missile" 100
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret" 2
-		
-		"Laser Rifle" 20
-		"Fragmentation Grenades" 20
 
 		"Fusion Reactor"
 		"LP288a Battery Pack"
 		"D67-TM Shield Generator"
 		"Large Radar Jammer" 2
 		"Liquid Nitrogen Cooler"
+		"Laser Rifle" 20
+		"Fragmentation Grenades" 20
 		
 		"X4700 Ion Thruster"
 		"X4200 Ion Steering"
@@ -1468,13 +1467,12 @@ ship "Frigate"
 		"Blaster Turret" 2
 		"Anti-Missile Turret"
 
-		"Laser Rifle" 5
-		"Fragmentation Grenades" 5
-
 		"NT-200 Nucleovoltaic"
 		"LP144a Battery Pack"
 		"D41-HY Shield Generator"
 		"Large Radar Jammer"
+		"Laser Rifle" 5
+		"Fragmentation Grenades" 5
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -733,6 +733,7 @@ ship "Carrier"
 		"Brig"
 		"Laser Rifle" 40
 		"Fragmentation Grenades" 40
+		"Security Station"
 		
 		"X5700 Ion Thruster"
 		"X4200 Ion Steering"
@@ -1029,6 +1030,7 @@ ship "Cruiser"
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 20
 		"Fragmentation Grenades" 20
+		"Security Station"
 		
 		"X4700 Ion Thruster"
 		"X4200 Ion Steering"
@@ -1472,6 +1474,7 @@ ship "Frigate"
 		"Large Radar Jammer"
 		"Laser Rifle" 5
 		"Fragmentation Grenades" 5
+		"Security Station"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -725,7 +725,6 @@ ship "Carrier"
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret" 2
 
-		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
 		"D94-YV Shield Generator"

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -724,6 +724,9 @@ ship "Carrier"
 		"Meteor Missile" 140
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret" 2
+
+		"Laser Rifle" 40
+		"Fragmentation Grenades" 40
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
@@ -1020,6 +1023,9 @@ ship "Cruiser"
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
+		"Laser Rifle" 20
+		"Fragmentation Grenades" 20
+
 		"Fusion Reactor"
 		"LP288a Battery Pack"
 		"D67-TM Shield Generator"
@@ -1461,7 +1467,10 @@ ship "Frigate"
 		"Torpedo" 60
 		"Blaster Turret" 2
 		"Anti-Missile Turret"
-		
+
+		"Laser Rifle" 5
+		"Fragmentation Grenades" 5
+
 		"NT-200 Nucleovoltaic"
 		"LP144a Battery Pack"
 		"D41-HY Shield Generator"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -483,6 +483,8 @@ ship "Carrier" "Carrier (Mark II)"
 		"Sidewinder Missile" 200
 		"Electron Turret" 2
 		"Heavy Anti-Missile Turret" 2
+		"Laser Rifle" 40
+		"Fragmentation Grenades" 40
 		"Armageddon Core"
 		"Dwarf Core"
 		"LP036a Battery Pack"
@@ -676,6 +678,8 @@ ship "Cruiser" "Cruiser (Mark II)"
 		"Sidewinder Missile" 200
 		"Electron Turret" 2
 		"Heavy Anti-Missile Turret" 2
+		"Laser Rifle" 20
+		"Fragmentation Grenades" 20
 		"Armageddon Core"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
@@ -957,6 +961,8 @@ ship "Frigate" "Frigate (Mark II)"
 		"Particle Cannon" 4
 		"Anti-Missile Turret"
 		"Blaster Turret" 2
+		"Laser Rifle" 5
+		"Fragmentation Grenades" 5
 		"NT-200 Nucleovoltaic"
 		"Dwarf Core"
 		"LP036a Battery Pack"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -449,6 +449,8 @@ ship "Carrier" "Carrier (Jump)"
 		"Sidewinder Missile" 200
 		"Electron Turret" 2
 		"Heavy Anti-Missile Turret" 2
+		"Laser Rifle" 40
+		"Fragmentation Grenades" 40
 		"Armageddon Core"
 		"Dwarf Core"
 		"LP072a Battery Pack"
@@ -646,6 +648,8 @@ ship "Cruiser" "Cruiser (Jump)"
 		"Sidewinder Missile" 200
 		"Electron Turret" 3
 		"Heavy Anti-Missile Turret"
+		"Laser Rifle" 20
+		"Fragmentation Grenades" 20
 		"Armageddon Core"
 		"LP144a Battery Pack"
 		"LP036a Battery Pack"


### PR DESCRIPTION
This adds 40 Laser Rifles and Frag grenades to all Carrier variants, 20 of same to all Cruisers, and 5 of same to all Frigates.

The effect of this will be making it harder for the player to capture what are nominally the toughest ships in human space. It also adds immersion - apparently right now Navy Marines are so badass they can defend against boarding parties with their bare hands.

I will do a separate PR to do similar for Dreadnoughts and maybe other Militia/FW ships, and a third to update Oathkeeper fleets with Mark II variants at the appropriate time.