### PR TITLE
Add Mark II Oathkeeper fleets at the same time as the rest of the Navy

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -1126,7 +1126,55 @@ event "navy using mark ii ships"
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)"
 
+	fleet "Small Oathkeeper"
+		add variant 6
+			"Rainmaker (Mark II)" 2
+		add variant 5
+			"Gunboat (Mark II)"
+			"Rainmaker (Mark II)"
+		add variant 4
+			"Frigate (Mark II)"
+		add variant 3
+			"Gunboat (Mark II)" 2
+		add variant 1
+			"Rainmaker (Mark II)" 3
+		add variant 6
+			"Gunboat (Mark II)"
 
+	fleet "Large Oathkeeper"
+		add variant 5
+			"Frigate (Mark II)" 2
+			"Rainmaker (Mark II)"
+			"Gunboat (Mark II)"
+		add variant 3
+			"Cruiser (Mark II)"
+			"Combat Drone" 4
+		add variant 3
+			"Cruiser (Mark II)"
+			"Combat Drone" 4
+			"Frigate (Mark II)"
+			"Rainmaker (Mark II)"
+		add variant 2
+			"Carrier (Mark II)"
+			"Lance" 4
+			"Combat Drone" 6
+		add variant 1
+			"Carrier (Mark II)"
+			"Lance" 4
+			"Combat Drone" 6
+			"Cruiser (Mark II)"
+			"Combat Drone" 4
+			"Frigate (Mark II)" 2
+			"Rainmaker (Mark II)" 2
+			"Gunboat (Mark II)" 2
+		add variant 1
+			"Cruiser (Mark II)"
+			"Combat Drone" 4
+			"Frigate (Mark II)" 2
+		add variant 1
+			"Frigate (Mark II)"
+			"Rainmaker (Mark II)" 2
+			"Gunboat (Mark II)"
 
 fleet "gunboat only"
 	government "Republic"

--- a/data/events.txt
+++ b/data/events.txt
@@ -1127,38 +1127,38 @@ event "navy using mark ii ships"
 			"Gunboat (Mark II)"
 
 	fleet "Small Oathkeeper"
-		add variant 6
+		add variant 12
 			"Rainmaker (Mark II)" 2
-		add variant 5
+		add variant 12
 			"Gunboat (Mark II)"
 			"Rainmaker (Mark II)"
-		add variant 4
+		add variant 9
 			"Frigate (Mark II)"
-		add variant 3
-			"Gunboat (Mark II)" 2
-		add variant 1
-			"Rainmaker (Mark II)" 3
 		add variant 6
+			"Gunboat (Mark II)" 2
+		add variant 3
+			"Rainmaker (Mark II)" 3
+		add variant 12
 			"Gunboat (Mark II)"
 
 	fleet "Large Oathkeeper"
-		add variant 5
+		add variant 12
 			"Frigate (Mark II)" 2
 			"Rainmaker (Mark II)"
 			"Gunboat (Mark II)"
-		add variant 3
+		add variant 6
 			"Cruiser (Mark II)"
 			"Combat Drone" 4
-		add variant 3
+		add variant 6
 			"Cruiser (Mark II)"
 			"Combat Drone" 4
 			"Frigate (Mark II)"
 			"Rainmaker (Mark II)"
-		add variant 2
+		add variant 6
 			"Carrier (Mark II)"
 			"Lance" 4
 			"Combat Drone" 6
-		add variant 1
+		add variant 3
 			"Carrier (Mark II)"
 			"Lance" 4
 			"Combat Drone" 6
@@ -1167,11 +1167,11 @@ event "navy using mark ii ships"
 			"Frigate (Mark II)" 2
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)" 2
-		add variant 1
+		add variant 3
 			"Cruiser (Mark II)"
 			"Combat Drone" 4
 			"Frigate (Mark II)" 2
-		add variant 1
+		add variant 3
 			"Frigate (Mark II)"
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)"


### PR DESCRIPTION
This is a minor immersion fix - there are Mark II Oathkeeper ships later in the story, but no randomly spawned fleets. This way the Navy isn't neglecting the fleets responsible for defending the North.

I also considered adding the Oathkeeper variants later, so that they can't be used for the Electron Beam hunting missions. If that's preferable, I'll add them in a separate event sometime between then and the FW Alphas missions.