### PR TITLE
Add a flag to explicitly mark a mission as failed

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -796,7 +796,10 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	else if(trigger == DECLINE)
 		++player.Conditions()[name + ": offered"];
 	else if(trigger == FAIL)
+	{
 		--player.Conditions()[name + ": active"];
+		++player.Conditions()[name + ": failed"];
+	}
 	else if(trigger == COMPLETE)
 	{
 		--player.Conditions()[name + ": active"];


### PR DESCRIPTION
I decided to separate this out from the idea of an `": aborted"` flag because as far as I can tell it works without further intervention and is backward-compatible.

ref: https://github.com/endless-sky/endless-sky/issues/4018#issuecomment-455907094