### PR TITLE
Buffing Coalition civilian modules

### DIFF
--- a/data/coalition outfits.txt
+++ b/data/coalition outfits.txt
@@ -18,7 +18,7 @@ outfit "Small Collector Module"
 	"outfit space" -8
 	"solar collection" .8
 	"heat generation" .4
-	"ionization resistance" 1
+	"ion resistance" 1
 	description "Solar power is the mainstay of the Coalition's merchant marine. The design of these panels has been refined over the millennia, growing ever more efficient. Because of the distributed nature of the panels, they are harder to disrupt than other power systems."
 
 outfit "Large Collector Module"
@@ -31,7 +31,7 @@ outfit "Large Collector Module"
 	"outfit space" -28
 	"solar collection" 3.3
 	"heat generation" 1.5
-	"ionization resistance" 3
+	"ion resistance" 3
 	description "One of these solar panels is enough to meet the energy needs of a medium-sized Coalition civilian ship, especially given the energy efficiency of their engines and the fact that under their laws only Heliarch ships are allowed to have weapons. Because of the distributed nature of the panels, they are more resilient against weapons that target power systems."
 
 outfit "Small Reactor Module"

--- a/data/coalition outfits.txt
+++ b/data/coalition outfits.txt
@@ -18,7 +18,8 @@ outfit "Small Collector Module"
 	"outfit space" -8
 	"solar collection" .8
 	"heat generation" .4
-	description "Solar power is the mainstay of the Coalition's merchant marine. The design of these panels has been refined over the millennia, growing ever more efficient."
+	"ionization resistance" 1
+	description "Solar power is the mainstay of the Coalition's merchant marine. The design of these panels has been refined over the millennia, growing ever more efficient. Because of the distributed nature of the panels, they are harder to disrupt than other power systems."
 
 outfit "Large Collector Module"
 	category "Power"
@@ -30,7 +31,8 @@ outfit "Large Collector Module"
 	"outfit space" -28
 	"solar collection" 3.3
 	"heat generation" 1.5
-	description "One of these solar panels is enough to meet the energy needs of a medium-sized Coalition civilian ship, especially given the energy efficiency of their engines and the fact that under their laws only Heliarch ships are allowed to have weapons."
+	"ionization resistance" 3
+	description "One of these solar panels is enough to meet the energy needs of a medium-sized Coalition civilian ship, especially given the energy efficiency of their engines and the fact that under their laws only Heliarch ships are allowed to have weapons. Because of the distributed nature of the panels, they are more resilient against weapons that target power systems."
 
 outfit "Small Reactor Module"
 	category "Power"
@@ -90,7 +92,8 @@ outfit "Small Shield Module"
 	"shield generation" .28
 	"shield energy" .28
 	"shield heat" .1
-	description "Although combat is almost unheard of in Coalition space, almost all of their ships are able to recharge their shields when necessary."
+	"shields" 560
+	description "Although combat is almost unheard of in Coalition space, almost all of their ships are able to recharge their shields when necessary. Coalition shield rechargers make their shields more resilient to damage."
 
 outfit "Large Shield Module"
 	category "Systems"
@@ -103,7 +106,8 @@ outfit "Large Shield Module"
 	"shield generation" 1.3
 	"shield energy" 1.3
 	"shield heat" .5
-	description "The Coalition manufactures heavy shield generators for their ships in case they ever face aggression from the Quarg or another species."
+	"shields" 2200
+	description "The Coalition manufactures heavy shield generators for their ships in case they ever face aggression from the Quarg or another species. Coalition shield rechargers make their shields more resilient to damage."
 
 outfit "Small Repair Module"
 	category "Systems"
@@ -116,6 +120,7 @@ outfit "Small Repair Module"
 	"hull repair rate" .12
 	"hull energy" .12
 	"hull heat" .1
+	"hull" 300
 	description "Arachi ships, which rely more on strong hull than on energy shields, often carry one of these repair modules to allow damaged hull plating to be patched back together on the fly."
 
 outfit "Large Repair Module"
@@ -129,6 +134,7 @@ outfit "Large Repair Module"
 	"hull repair rate" .57
 	"hull energy" .57
 	"hull heat" .5
+	"hull" 1200
 	description "This hub houses a small fleet of repair robots that can climb around on a ship's hull and repair damage to it, even in the middle of combat."
 
 outfit "Cooling Module"


### PR DESCRIPTION
Moving coalition civilian from mostly tier 0.75 to proper tier 1.5 with unique offerings: shield modules buff shield HP, repair modules buff hull HP, solar panels offer small ion resistance.