### PR TITLE
Certain panels block game saves if still displayed

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -58,6 +58,9 @@ namespace {
 ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &conversation, const System *system, const shared_ptr<Ship> &ship)
 	: player(player), conversation(conversation), scroll(0.), system(system), ship(ship)
 {
+	// All conversation panels prevent saving the game while displayed.
+	preventsSaving = true;
+	
 #if defined _WIN32
 	PATH_LENGTH = Files::Saves().size();
 #endif

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -91,11 +91,13 @@ Dialog::Dialog(const string &text)
 
 
 
-// Mission accept / decline dialog.
+// Mission accept / decline dialog. The game should not be
+// saved while this particular Dialog is being shown.
 Dialog::Dialog(const string &text, PlayerInfo &player, const System *system)
 	: intFun(bind(&PlayerInfo::MissionCallback, &player, placeholders::_1)),
 	system(system), player(&player)
 {
+	preventsSaving = true;
 	Init(text, true, true);
 }
 

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -166,7 +166,7 @@ bool Panel::Release(int x, int y)
 }
 
 
-	
+
 void Panel::SetIsFullScreen(bool set)
 {
 	isFullScreen = set;
@@ -187,7 +187,7 @@ void Panel::SetInterruptible(bool set)
 }
 
 
-	
+
 // Dim the background of this panel.
 void Panel::DrawBackdrop() const
 {

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -97,6 +97,10 @@ protected:
 	bool DoHelp(const std::string &name) const;
 	
 	
+protected:
+	bool preventsSaving = false;
+	
+	
 private:
 	class Zone : public Rectangle {
 	public:

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -217,8 +217,22 @@ void UI::CanSave(bool canSave)
 
 
 
+// The game can be saved if the save file was loaded, and none of the
+// known panels inhibits saving--like an "on offer" dialog or conversation.
 bool UI::CanSave() const
 {
+	if(canSave)
+	{
+		auto BlocksSaving = [](const vector<shared_ptr<Panel>> &container)
+		{
+			for(const auto &panel : container)
+				if(panel->preventsSaving)
+					return true;
+			return false;
+		};
+		if(BlocksSaving(stack) || BlocksSaving(toPush))
+			return false;
+	}
 	return canSave;
 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -359,7 +359,9 @@ int main(int argc, char *argv[])
 			timer.Wait();
 		}
 		
-		// If you quit while landed on a planet, save the game - if you did anything.
+		// If you quit while landed on a planet, save the game - if you did anything. If
+		// you're currently in a conversation, (e.g. a mission is offering or completing)
+		// you cannot save either, else the MissionAction will execute multiple times.
 		if(player.GetPlanet() && gamePanels.CanSave())
 			player.Save();
 		


### PR DESCRIPTION
Refs https://github.com/endless-sky/endless-sky/issues/3746

This needs to be playtested a fair bit before merging, to make sure there aren't unintended "why didn't it save there" situations. This change should only influence cases where the program is closed (x'd out, Alt-F4) or quit (menu -> quit), and not "normal" (auto)saving such as the pre-takeoff save.