### PR TITLE
Arfecta has fuel generation to allow cloaking

### DIFF
--- a/data/pug.txt
+++ b/data/pug.txt
@@ -490,12 +490,12 @@ ship "Pug Arfecta"
 		"engine capacity" 220
 		"energy capacity" 10000
 		"energy generation" 200
+		"fuel generation" .2
 		"heat generation" 10
 		"shield generation" 32
 		"shield energy" 32
 		"hull repair rate" 5
 		"hull energy" 5
-		"cloaking fuel" -.2
 		"reverse thrust" 66
 		"reverse thrusting energy" 4.9
 		"reverse thrusting heat" 6.9


### PR DESCRIPTION
Give the Arfecta fuel generation (introduced in #3870) instead of negative cloaking fuel. This means the Arfecta can still cloak indefinitely without spending any fuel and when it's not cloaked, it's fuel increases automatically; furthermore, players can safely remove the cloaking device from captured Arfectas.