### PR TITLE
tweaked javelin

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -774,11 +774,13 @@ outfit "Javelin Pod"
 		"inaccuracy" 1
 		"velocity" 10
 		"lifetime" 60
-		"reload" 15
+		"reload" 12
+		"burst count" 5
+		"burst reload" 3
 		"firing energy" .2
 		"firing heat" 12
-		"shield damage" 57
-		"hull damage" 36
+		"shield damage" 48
+		"hull damage" 26
 		"hit force" 50
 		"missile strength" 2
 	description "The Javelin Pod fires a rapid stream of unguided missiles. A Javelin Pod does far more damage than any gun of a comparable size, and has a longer range as well, but once a ship has expended all of its ammunition it must leave combat and find a planet where it can buy more, which makes Javelins less useful in protracted battles."

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -774,7 +774,7 @@ outfit "Javelin Pod"
 		"inaccuracy" 1
 		"velocity" 10
 		"lifetime" 60
-		"reload" 12
+		"reload" 15
 		"burst count" 5
 		"burst reload" 3
 		"firing energy" .2


### PR DESCRIPTION
Currently javelins are rather useless against ships with anti-missile systems, because even a single basic anti-missile turret (size 16) can take out two javelin pods (size 2×12=24). This proposal:
* fires javelins in bursts of five: all five hit within 0.25 s (15 frames), after which no javelins are fired for 1.0 s (75-15=60 frames)
* <s>changes it from four shots per second to five, which means it'll empty in 40 seconds instead of 50</s>
* reduces per shot shield and hull damage to the old values prior to #3866

As a result, individual javelins inflict less damage per second against players without AM turrets, but more javelins could hit ships that have AM turrets

Before:
![screenshot from 2019-01-30 18-02-37](https://user-images.githubusercontent.com/21634324/51998908-dc97db00-24b9-11e9-8a84-4b5399e393ca.png)

First proposal:
![screenshot from 2019-01-30 18-01-41](https://user-images.githubusercontent.com/21634324/51998919-e4577f80-24b9-11e9-8182-8bca63366daa.png)

Current proposal:
![screenshot from 2019-02-01 11-43-57](https://user-images.githubusercontent.com/21634324/52118682-4d083e80-2617-11e9-8256-905ef566703a.png)

See also #4149 
