### PR TITLE
Allow phrase-based randomized dialog

### DIFF
--- a/data/coalition jobs.txt
+++ b/data/coalition jobs.txt
@@ -8,6 +8,10 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
+phrase "coalition ringworld workers"
+	word
+		`You drop off the workers on the <planet>. A few minutes later you receive a transfer of <payment>.`
+
 mission "Coalition: Ringworld Workers 1"
 	job
 	repeat
@@ -25,7 +29,7 @@ mission "Coalition: Ringworld Workers 1"
 		"coalition jobs" ++
 		payment
 		payment 10000
-		dialog `You drop off the volunteers on the <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition ringworld workers"
 
 mission "Coalition: Ringworld Workers 2"
 	job
@@ -44,7 +48,7 @@ mission "Coalition: Ringworld Workers 2"
 		"coalition jobs" ++
 		payment
 		payment 15000
-		dialog `You drop off the volunteers on the <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition ringworld workers"
 
 mission "Coalition: Ringworld Workers 3"
 	job
@@ -63,8 +67,12 @@ mission "Coalition: Ringworld Workers 3"
 		"coalition jobs" ++
 		payment
 		payment 20000
-		dialog `You drop off the volunteers on the <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition ringworld workers"
 
+
+phrase "coalition ringworld volunteers"
+	word
+		`You drop off the volunteers on the <planet>, where they are met by a Heliarch agent. A few minutes later you receive a transfer of <payment>.`
 
 mission "Coalition: Ringworld Volunteers 1"
 	job
@@ -83,7 +91,7 @@ mission "Coalition: Ringworld Volunteers 1"
 		"coalition jobs" ++
 		payment
 		payment 4000
-		dialog `You drop off the volunteers on the <planet>, where they are met by a Heliarch agent. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition ringworld volunteers"
 
 mission "Coalition: Ringworld Volunteers 2"
 	job
@@ -102,7 +110,7 @@ mission "Coalition: Ringworld Volunteers 2"
 		"coalition jobs" ++
 		payment
 		payment 8000
-		dialog `You drop off the volunteers on the <planet>, where they are met by a Heliarch agent. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition ringworld volunteers"
 
 mission "Coalition: Ringworld Volunteers 3"
 	job
@@ -121,8 +129,12 @@ mission "Coalition: Ringworld Volunteers 3"
 		"coalition jobs" ++
 		payment
 		payment 12000
-		dialog `You drop off the volunteers on the <planet>, where they are met by a Heliarch agent. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition ringworld volunteers"
 
+
+phrase "coalition ringworld materials"
+	word
+		`You drop off the construction materials and receive <payment> in payment.`
 
 mission "Coalition: Ringworld Materials 1"
 	job
@@ -142,7 +154,7 @@ mission "Coalition: Ringworld Materials 1"
 		"coalition jobs" ++
 		payment
 		payment 30000
-		dialog `You drop off the construction materials and receive <payment> in payment.`
+		dialog phrase "coalition ringworld materials"
 
 mission "Coalition: Ringworld Materials 2"
 	job
@@ -162,7 +174,7 @@ mission "Coalition: Ringworld Materials 2"
 		"coalition jobs" ++
 		payment
 		payment 40000
-		dialog `You drop off the construction materials and receive <payment> in payment.`
+		dialog phrase "coalition ringworld materials"
 
 mission "Coalition: Ringworld Materials 3"
 	job
@@ -182,8 +194,12 @@ mission "Coalition: Ringworld Materials 3"
 		"coalition jobs" ++
 		payment
 		payment 50000
-		dialog `You drop off the construction materials and receive <payment> in payment.`
+		dialog phrase "coalition ringworld materials"
 
+
+phrase "coalition ringworld supplies"
+	word
+		`You drop off the donation of <commodity> and receive <payment> in payment.`
 
 mission "Coalition: Ringworld Supplies 1"
 	job
@@ -202,7 +218,7 @@ mission "Coalition: Ringworld Supplies 1"
 		"coalition jobs" ++
 		payment
 		payment 2000
-		dialog `You drop off the donation of <commodity> and receive <payment> in payment.`
+		dialog phrase "coalition ringworld supplies"
 
 mission "Coalition: Ringworld Supplies 2"
 	job
@@ -221,7 +237,7 @@ mission "Coalition: Ringworld Supplies 2"
 		"coalition jobs" ++
 		payment
 		payment 4000
-		dialog `You drop off the donation of <commodity> and receive <payment> in payment.`
+		dialog phrase "coalition ringworld supplies"
 
 mission "Coalition: Ringworld Supplies 3"
 	job
@@ -240,7 +256,7 @@ mission "Coalition: Ringworld Supplies 3"
 		"coalition jobs" ++
 		payment
 		payment 6000
-		dialog `You drop off the donation of <commodity> and receive <payment> in payment.`
+		dialog phrase "coalition ringworld supplies"
 
 
 mission "Coalition: Heliarch Candidate"
@@ -264,6 +280,10 @@ mission "Coalition: Heliarch Candidate"
 		dialog `Heliarch agents meet your ship as soon as it docks and receive the candidate whom you have been transporting, in a small ceremony. A few minutes later you receive a transfer of <payment>.`
 
 
+phrase "coalition interpreters dialog"
+	word
+		`You drop off the interpreters on <planet>. A few minutes later you receive a transfer of <payment>.`
+
 mission "Coalition: Interpreters 1"
 	job
 	repeat
@@ -281,7 +301,7 @@ mission "Coalition: Interpreters 1"
 		"coalition jobs" ++
 		payment
 		payment 5000
-		dialog `You drop off the interpreters on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition interpreters dialog"
 
 mission "Coalition: Interpreters 2"
 	job
@@ -300,7 +320,7 @@ mission "Coalition: Interpreters 2"
 		"coalition jobs" ++
 		payment
 		payment 10000
-		dialog `You drop off the interpreters on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition interpreters dialog"
 
 mission "Coalition: Interpreters 3"
 	job
@@ -319,8 +339,12 @@ mission "Coalition: Interpreters 3"
 		"coalition jobs" ++
 		payment
 		payment 10000
-		dialog `You drop off the interpreters on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition interpreters dialog"
 
+
+phrase "coalition peacekeepers dialog"
+	word
+		`You drop off the peacekeepers on <planet>. A few minutes later you receive a transfer of <payment>.`
 
 mission "Coalition: Peacekeepers 1"
 	job
@@ -339,7 +363,7 @@ mission "Coalition: Peacekeepers 1"
 		"coalition jobs" ++
 		payment
 		payment 20000
-		dialog `You drop off the peacekeepers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition peacekeepers dialog"
 
 mission "Coalition: Peacekeepers 2"
 	job
@@ -358,8 +382,12 @@ mission "Coalition: Peacekeepers 2"
 		"coalition jobs" ++
 		payment
 		payment 30000
-		dialog `You drop off the peacekeepers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition peacekeepers dialog"
 
+
+phrase "coalition interspecies settlers"
+	word
+		`You drop off the settlers on <planet>. A few minutes later you receive a transfer of <payment>.`
 
 mission "Coalition: Saryd Interspecies 1"
 	job
@@ -378,7 +406,7 @@ mission "Coalition: Saryd Interspecies 1"
 		"coalition jobs" ++
 		payment
 		payment 10000
-		dialog `You drop off the settlers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition interspecies settlers"
 
 mission "Coalition: Saryd Interspecies 2"
 	job
@@ -397,7 +425,7 @@ mission "Coalition: Saryd Interspecies 2"
 		"coalition jobs" ++
 		payment
 		payment 15000
-		dialog `You drop off the settlers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition interspecies settlers"
 
 mission "Coalition: Kimek Interspecies 1"
 	job
@@ -416,7 +444,7 @@ mission "Coalition: Kimek Interspecies 1"
 		"coalition jobs" ++
 		payment
 		payment 10000
-		dialog `You drop off the settlers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition interspecies settlers"
 
 mission "Coalition: Kimek Interspecies 2"
 	job
@@ -435,7 +463,7 @@ mission "Coalition: Kimek Interspecies 2"
 		"coalition jobs" ++
 		payment
 		payment 15000
-		dialog `You drop off the settlers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition interspecies settlers"
 
 mission "Coalition: Arach Interspecies 1"
 	job
@@ -454,7 +482,7 @@ mission "Coalition: Arach Interspecies 1"
 		"coalition jobs" ++
 		payment
 		payment 10000
-		dialog `You drop off the settlers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition interspecies settlers"
 
 mission "Coalition: Arach Interspecies 2"
 	job
@@ -473,8 +501,12 @@ mission "Coalition: Arach Interspecies 2"
 		"coalition jobs" ++
 		payment
 		payment 15000
-		dialog `You drop off the settlers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition interspecies settlers"
 
+
+phrase "coalition transfer dialog"
+	word
+		`You drop off the workers on <planet>. A few minutes later you receive a transfer of <payment>.`
 
 mission "Coalition: Transfer 1"
 	job
@@ -495,7 +527,7 @@ mission "Coalition: Transfer 1"
 		"coalition jobs" ++
 		payment
 		payment 5000
-		dialog `You drop off the workers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition transfer dialog"
 
 mission "Coalition: Transfer 2"
 	job
@@ -516,7 +548,7 @@ mission "Coalition: Transfer 2"
 		"coalition jobs" ++
 		payment
 		payment 10000
-		dialog `You drop off the workers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition transfer dialog"
 
 mission "Coalition: Transfer 3"
 	job
@@ -537,8 +569,12 @@ mission "Coalition: Transfer 3"
 		"coalition jobs" ++
 		payment
 		payment 15000
-		dialog `You drop off the workers on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition transfer dialog"
 
+
+phrase "coalition tourists outbound"
+	word
+		`The tourists thank you for bringing them to <planet> and pay you <payment>.`
 
 mission "Coalition: Tourists Out 1"
 	job
@@ -561,7 +597,7 @@ mission "Coalition: Tourists Out 1"
 	on complete
 		"coalition jobs" ++
 		payment 22000 200
-		dialog `The tourists thank you for bringing them to <planet> and pay you <payment>.`
+		dialog phrase "coalition tourists outbound"
 
 mission "Coalition: Tourists Out 2"
 	job
@@ -584,7 +620,7 @@ mission "Coalition: Tourists Out 2"
 	on complete
 		"coalition jobs" ++
 		payment 32000 200
-		dialog `The tourists thank you for bringing them to <planet> and pay you <payment>.`
+		dialog phrase "coalition tourists outbound"
 
 mission "Coalition: Tourists Out 3"
 	job
@@ -607,8 +643,12 @@ mission "Coalition: Tourists Out 3"
 	on complete
 		"coalition jobs" ++
 		payment 42000 200
-		dialog `The tourists thank you for bringing them to <planet> and pay you <payment>.`
+		dialog phrase "coalition tourists outbound"
 
+
+phrase "coalition tourists homebound"
+	word
+		`The tourists thank you for bringing them home and pay you <payment>.`
 
 mission "Coalition: Tourists Home 1"
 	job
@@ -631,7 +671,7 @@ mission "Coalition: Tourists Home 1"
 	on complete
 		"coalition jobs" ++
 		payment 22000 200
-		dialog `The tourists thank you for bringing them home and pay you <payment>.`
+		dialog phrase "coalition tourists homebound"
 
 mission "Coalition: Tourists Home 2"
 	job
@@ -654,7 +694,7 @@ mission "Coalition: Tourists Home 2"
 	on complete
 		"coalition jobs" ++
 		payment 32000 200
-		dialog `The tourists thank you for bringing them home and pay you <payment>.`
+		dialog phrase "coalition tourists homebound"
 
 mission "Coalition: Tourists Home 3"
 	job
@@ -677,8 +717,12 @@ mission "Coalition: Tourists Home 3"
 	on complete
 		"coalition jobs" ++
 		payment 42000 200
-		dialog `The tourists thank you for bringing them home and pay you <payment>.`
+		dialog phrase "coalition tourists homebound"
 
+
+phrase "coalition fast courier"
+	word
+		`The recipient thanks you for bringing the <commodity> here so quickly, and pays you <payment>.`
 
 mission "Coalition: Fast Courier 1"
 	job
@@ -699,7 +743,7 @@ mission "Coalition: Fast Courier 1"
 		"coalition jobs" ++
 		payment
 		payment 30000
-		dialog `The recipient thanks you for bringing the <commodity> here so quickly, and pays you <payment>.`
+		dialog phrase "coalition fast courier"
 
 mission "Coalition: Fast Courier 2"
 	job
@@ -720,7 +764,7 @@ mission "Coalition: Fast Courier 2"
 		"coalition jobs" ++
 		payment
 		payment 40000
-		dialog `The recipient thanks you for bringing the <commodity> here so quickly, and pays you <payment>.`
+		dialog phrase "coalition fast courier"
 
 mission "Coalition: Fast Courier 3"
 	job
@@ -741,8 +785,12 @@ mission "Coalition: Fast Courier 3"
 		"coalition jobs" ++
 		payment
 		payment 50000
-		dialog `The recipient thanks you for bringing the <commodity> here so quickly, and pays you <payment>.`
+		dialog phrase "coalition fast courier"
 
+
+phrase "coalition commodity delivery"
+	word
+		`You drop off the <commodity> on <planet>, and receive <payment> in payment.`
 
 mission "Coalition: Cargo 1"
 	job
@@ -762,7 +810,7 @@ mission "Coalition: Cargo 1"
 		"coalition jobs" ++
 		payment
 		payment 2000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 mission "Coalition: Cargo 2"
 	job
@@ -782,7 +830,7 @@ mission "Coalition: Cargo 2"
 		"coalition jobs" ++
 		payment
 		payment 4000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 mission "Coalition: Cargo 3"
 	job
@@ -802,7 +850,7 @@ mission "Coalition: Cargo 3"
 		"coalition jobs" ++
 		payment
 		payment 6000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 mission "Coalition: Cargo 4"
 	job
@@ -822,7 +870,7 @@ mission "Coalition: Cargo 4"
 		"coalition jobs" ++
 		payment
 		payment 8000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 
 mission "Coalition: Bulk 1"
@@ -843,7 +891,7 @@ mission "Coalition: Bulk 1"
 		"coalition jobs" ++
 		payment
 		payment 10000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 mission "Coalition: Bulk 2"
 	job
@@ -863,7 +911,7 @@ mission "Coalition: Bulk 2"
 		"coalition jobs" ++
 		payment
 		payment 14000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 mission "Coalition: Bulk 3"
 	job
@@ -883,7 +931,7 @@ mission "Coalition: Bulk 3"
 		"coalition jobs" ++
 		payment
 		payment 20000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 mission "Coalition: Bulk 4"
 	job
@@ -903,7 +951,7 @@ mission "Coalition: Bulk 4"
 		"coalition jobs" ++
 		payment
 		payment 30000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 
 mission "Coalition: Rush 1"
@@ -925,7 +973,7 @@ mission "Coalition: Rush 1"
 		"coalition jobs" ++
 		payment
 		payment 32000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 mission "Coalition: Rush 2"
 	job
@@ -946,7 +994,7 @@ mission "Coalition: Rush 2"
 		"coalition jobs" ++
 		payment
 		payment 40000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 mission "Coalition: Rush 3"
 	job
@@ -967,7 +1015,7 @@ mission "Coalition: Rush 3"
 		"coalition jobs" ++
 		payment
 		payment 50000
-		dialog `You drop off the <commodity> on <planet>, and receive <payment> in payment.`
+		dialog phrase "coalition commodity delivery"
 
 
 mission "Coalition: Doctors"
@@ -992,6 +1040,10 @@ mission "Coalition: Doctors"
 		dialog `The doctors methodically pack up their equipment and leave your ship. From their lack of urgency, it appears that this is a routine event, not a crisis. A few minutes later you receive a transfer of <payment>.`
 
 
+phrase "coalition cadets dialog"
+	word
+		`You drop off the cadets on <planet>. A few minutes later you receive a transfer of <payment>.`
+
 mission "Coalition: Cadets 1"
 	job
 	repeat
@@ -1009,7 +1061,7 @@ mission "Coalition: Cadets 1"
 		"coalition jobs" ++
 		payment
 		payment 10000
-		dialog `You drop off the cadets on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition cadets dialog"
 
 mission "Coalition: Cadets 2"
 	job
@@ -1028,8 +1080,12 @@ mission "Coalition: Cadets 2"
 		"coalition jobs" ++
 		payment
 		payment 12000
-		dialog `You drop off the cadets on <planet>. A few minutes later you receive a transfer of <payment>.`
+		dialog phrase "coalition cadets dialog"
 
+
+phrase "coalition games dialog"
+	word
+		`The passengers thank you for bringing them to <planet> and pay you <payment>.`
 
 mission "Coalition: To Games 1"
 	job
@@ -1049,7 +1105,7 @@ mission "Coalition: To Games 1"
 	on complete
 		"coalition jobs" ++
 		payment 10000 200
-		dialog `The passengers thank you for bringing them to <planet> and pay you <payment>.`
+		dialog phrase "coalition games dialog"
 
 mission "Coalition: To Games 2"
 	job
@@ -1069,7 +1125,7 @@ mission "Coalition: To Games 2"
 	on complete
 		"coalition jobs" ++
 		payment 15000 200
-		dialog `The passengers thank you for bringing them to <planet> and pay you <payment>.`
+		dialog phrase "coalition games dialog"
 
 mission "Coalition: To Games 3"
 	job
@@ -1089,7 +1145,7 @@ mission "Coalition: To Games 3"
 	on complete
 		"coalition jobs" ++
 		payment 25000 200
-		dialog `The passengers thank you for bringing them to <planet> and pay you <payment>.`
+		dialog phrase "coalition games dialog"
 
 
 mission "Coalition: From Games 1"
@@ -1111,7 +1167,7 @@ mission "Coalition: From Games 1"
 		"coalition jobs" ++
 		payment
 		payment 10000
-		dialog `The passengers thank you for bringing them to <planet> and pay you <payment>.`
+		dialog phrase "coalition games dialog"
 
 mission "Coalition: From Games 2"
 	job
@@ -1132,7 +1188,7 @@ mission "Coalition: From Games 2"
 		"coalition jobs" ++
 		payment
 		payment 15000
-		dialog `The passengers thank you for bringing them to <planet> and pay you <payment>.`
+		dialog phrase "coalition games dialog"
 
 mission "Coalition: From Games 3"
 	job
@@ -1153,4 +1209,4 @@ mission "Coalition: From Games 3"
 		"coalition jobs" ++
 		payment
 		payment 25000
-		dialog `The passengers thank you for bringing them to <planet> and pay you <payment>.`
+		dialog phrase "coalition games dialog"

--- a/data/deep jobs.txt
+++ b/data/deep jobs.txt
@@ -39,7 +39,7 @@ phrase "deep mystery cube dropoff payment"
 		`hand the cube to the first beggar woman you see planetside. She accepts it without a word, and leaves.`
 		`drop the cube at a warehouse. Nobody comes around to collect it.`
 	word
-		` `
+		``
 		` "This has to be legal, or they couldn't post it to the job board," you remind yourself.`
 	word
 		` `

--- a/data/deep jobs.txt
+++ b/data/deep jobs.txt
@@ -8,6 +8,43 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
+phrase "deep mystery cube pickup"
+	word
+		`As instructed, you`
+		`You`
+	word
+		` `
+	word
+		`open an deposit box`
+		`open a storage locker`
+	word
+		` `
+	word
+		`in an unmarked and uninhabited warehouse`
+		`near your landing site`
+	word
+		` `
+	word
+		`and pick up the mystery package. It is a small black cube, about two centimeters to a side, surprisingly heavy for its size, with no markings of any kind. Odd.`
+
+phrase "deep mystery cube dropoff payment"
+	word
+		`As instructed, you`
+	word
+		` `
+	word
+		`leave the mystery cube by the side of the road a few miles away from the spaceport.`
+		`leave the mystery cube behind a rickety-looking wooden tower.`
+		`bury the cube out in the middle of nowhere before landing in the spaceport.`
+		`hand the cube to the first beggar woman you see planetside. She accepts it without a word, and leaves.`
+		`drop the cube at a warehouse. Nobody comes around to collect it.`
+	word
+		` `
+		` "This has to be legal, or they couldn't post it to the job board," you remind yourself.`
+	word
+		` `
+	word
+		`Your bank account immediately notifies you that the agreed-upon payment of <payment> has been deposited. You wonder how they knew.`
 
 mission "Deep Mystery Cube [0]"
 	name "Mystery delivery to <planet>"
@@ -24,11 +61,11 @@ mission "Deep Mystery Cube [0]"
 		distance 7 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 	on accept
-		dialog "You pick up the mystery package in an unmarked and uninhabited warehouse. It is a small black cube about two centimeters to a side, surprisingly heavy for its size, with no markings of any kind. Odd."
+		dialog phrase "deep mystery cube pickup"
 	on complete
 		"mystery cube" ++
 		payment 5000 1000
-		dialog `As instructed, you leave the mystery cube by the side of the road a few miles away from the spaceport. "This has to be legal, or they couldn't post it to the job board," you remind yourself as you collect the payment of <payment>.`
+		dialog phrase "deep mystery cube dropoff payment"
 	npc
 		government "Bounty Hunter"
 		personality nemesis disables waiting plunders
@@ -52,11 +89,11 @@ mission "Deep Mystery Cube [1]"
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 	on accept
-		dialog "You pick up the mystery package in an unmarked and uninhabited warehouse. It is a small black cube about two centimeters to a side, surprisingly heavy for its size, with no markings of any kind. Odd."
+		dialog phrase "deep mystery cube pickup"
 	on complete
 		"mystery cube" ++
 		payment 5000 1000
-		dialog `As instructed, you leave the mystery cube behind a rickety-looking wooden tower. "This has to be legal, or they couldn't post it to the job board," you remind yourself as you collect the payment of <payment>.`
+		dialog phrase "deep mystery cube dropoff payment"
 	npc
 		government "Bounty Hunter"
 		personality nemesis disables waiting plunders
@@ -80,11 +117,11 @@ mission "Deep Mystery Cube [2]"
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 	on accept
-		dialog "You pick up the mystery package in an unmarked and uninhabited warehouse. It is a small black cube about two centimeters to a side, surprisingly heavy for its size, with no markings of any kind. Odd."
+		dialog phrase "deep mystery cube pickup"
 	on complete
 		"mystery cube" ++
 		payment 5000 1000
-		dialog `As instructed, you bury the cube out in the middle of nowhere before landing in the spaceport. "This has to be legal, or they couldn't post it to the job board," you remind yourself as you collect the payment of <payment>.`
+		dialog phrase "deep mystery cube dropoff payment"
 	npc
 		government "Bounty Hunter"
 		personality nemesis disables waiting plunders
@@ -108,11 +145,11 @@ mission "Deep Mystery Cube [3]"
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 	on accept
-		dialog "You pick up the mystery package in an unmarked and uninhabited warehouse. It is a small black cube about two centimeters to a side, surprisingly heavy for its size, with no markings of any kind. Odd."
+		dialog phrase "deep mystery cube pickup"
 	on complete
 		"mystery cube" ++
 		payment 5000 1000
-		dialog `As instructed, you hand the cube to the first beggar woman you see planetside. She accepts it without a word. "This has to be legal, or they couldn't post it to the job board," you remind yourself as you collect the payment of <payment>.`
+		dialog phrase "deep mystery cube dropoff payment"
 	npc
 		government "Bounty Hunter"
 		personality nemesis disables waiting plunders
@@ -135,11 +172,11 @@ mission "Mystery retrieval"
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 	on stopover
-		dialog "As instructed, you open a storage locker near your landing site and pick up the mystery package: a small black cube about two centimeters to a side, surprisingly heavy for its size, with no markings of any kind. Odd."
+		dialog phrase "deep mystery cube pickup"
 	on complete
 		"mystery cube" ++
 		payment 5000 1000
-		dialog `You drop off the cube at a warehouse, as instructed. Nobody comes around to collect it, but nonetheless your bank account immediately notifies you that the agreed-upon payment of <payment> has been deposited. You wonder how they knew.`
+		dialog phrase "deep mystery cube dropoff payment"
 	npc
 		government "Bounty Hunter"
 		personality nemesis disables waiting plunders
@@ -208,6 +245,17 @@ mission "Escort science vessel"
 		payment
 		payment 60000
 
+phrase "academic conference recording payment"
+	word
+		`You touch down on <planet> and make your way to the conference hall at a grand university. The provided credentials gain you access and you set up the recording equipment at the back of the room.`
+	word
+		` `
+	word
+		`The panelists are electrifying, speaking eloquently on a variety of cutting-edge topics in the sciences and humanities. The experience leaves you feeling remarkably optimistic about the future of humanity here in the stars.`
+	word
+		` `
+	word
+		`You transmit the video to your contact on <origin> and receive your payment of <payment>.`
 
 mission "Record academic conference"
 	job
@@ -222,5 +270,5 @@ mission "Record academic conference"
 		attributes "research" "quarg" "rich" "paradise"
 		distance 4 10
 	on complete
-		dialog "You touch down and make your way to the conference hall at a grand university. The provided credentials gain you access and you set up the recording equipment at the back of the room. The panelists are electrifying, speaking eloquently on a variety of cutting-edge topics in the sciences and humanities. The experience leaves you feeling remarkably optimistic about the future of humanity here in the stars. You transmit the video to your contact on <origin> and receive your payment of <payment>."
+		dialog phrase "academic conference recording payment"
 		payment 5000 1000

--- a/data/deep jobs.txt
+++ b/data/deep jobs.txt
@@ -15,7 +15,7 @@ phrase "deep mystery cube pickup"
 	word
 		` `
 	word
-		`open an deposit box`
+		`open a deposit box`
 		`open a storage locker`
 	word
 		` `

--- a/data/dirt belt jobs.txt
+++ b/data/dirt belt jobs.txt
@@ -234,7 +234,7 @@ mission "Food Convoy [0]"
 		payment 100000
 		dialog "The captain of the <npc> thanks you for escorting their ships safely, and pays you <payment>."
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 
 mission "Food Convoy [1]"
@@ -279,7 +279,7 @@ mission "Food Convoy [1]"
 		payment 160000
 		dialog "The captain of the <npc> thanks you for escorting their ships safely, and pays you <payment>."
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 
 mission "Food Convoy [2]"
@@ -325,4 +325,4 @@ mission "Food Convoy [2]"
 		payment 220000
 		dialog "The captain of the <npc> thanks you for escorting their ships safely, and pays you <payment>."
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1714,7 +1714,7 @@ mission "FW Bounty 2"
 		system
 			near "Delta Sagittarii" 1 2
 		ship "Behemoth (Speedy)" "Moonless Night"
-		dialog `The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>.`
+		dialog phrase "generic hunted bounty eliminated dialog"
 	
 	on complete
 		payment 200000
@@ -1758,7 +1758,7 @@ mission "FW Bounty 3"
 		government Bounty
 		system "Shaula"
 		ship "Osprey (Alien Weapons)" "Silverhawk"
-		dialog `The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>.`
+		dialog phrase "generic hunted bounty eliminated dialog"
 	
 	on complete
 		"assisted free worlds" ++

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1213,7 +1213,7 @@ mission "FW Alphas 1.1A"
 		ship "Cruiser (Mark II)" "N.S. Peacemaker"
 	
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 	
 	on offer
 		log "With the help of the Oathkeepers, liberated Poisonwood from the Alpha invaders."

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -509,7 +509,7 @@ mission "FW Embassy 1B"
 		ship "Star Queen" "Lady of the Lake"
 	
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 
 
@@ -2201,7 +2201,7 @@ mission "FW Syndicate Extremists 1"
 		ship "Cruiser (Mark II)" "N.S. Peacemaker"
 	
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 
 
@@ -2267,7 +2267,7 @@ mission "FW Syndicate Extremists 1A"
 		ship "Cruiser (Mark II)" "N.S. Peacemaker"
 	
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 
 

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -1228,7 +1228,7 @@ mission "FW Pirates 3"
 		log "Given orders by the Free Worlds Senate to escort a diplomatic mission to the anarchist planet Thule. Tomek is not happy about bargaining with the pirates instead of fighting them."
 	
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 	
 	on complete
 		karma ++
@@ -1520,7 +1520,7 @@ mission "FW Pirates 4B"
 		ship "Falcon" "F.S. Terebinth"
 	
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 	
 	on offer
 		log "The elders on Thule do not want to join the Free Worlds, but they have agreed to crack down on pirate activity in their system and to welcome Free Worlds visitors to their planet."

--- a/data/free worlds war jobs.txt
+++ b/data/free worlds war jobs.txt
@@ -8,6 +8,10 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
+phrase "free worlds scanner payment"
+	word
+		`A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>.`
+
 mission "FW Scout Run [0]"
 	job
 	repeat
@@ -27,7 +31,7 @@ mission "FW Scout Run [0]"
 		government "Republic"
 	on complete
 		payment 10000 180
-		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>.`
+		dialog phrase "free worlds scanner payment"
 	on visit
 		dialog `You have landed on <planet>, but you have yet to scout out all the marked systems. Visit all the systems marked on your map before returning.`
 
@@ -53,7 +57,7 @@ mission "FW Scout Run [1]"
 		government "Republic"
 	on complete
 		payment 20000 180
-		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>.`
+		dialog phrase "free worlds scanner payment"
 	on visit
 		dialog `You have landed on <planet>, but you have yet to scout out all the marked systems. Visit all the systems marked on your map before returning.`
 
@@ -79,11 +83,15 @@ mission "FW Scout Run [2]"
 		government "Republic"
 	on complete
 		payment 30000 180
-		dialog `A Free Worlds captain is waiting for you when you land and takes a copy of your scanner logs, and you collect your payment of <payment>.`
+		dialog phrase "free worlds scanner payment"
 	on visit
 		dialog `You have landed on <planet>, but you have yet to scout out all the marked systems. Visit all the systems marked on your map before returning.`
 
 
+
+phrase "free worlds convoy supplies payment"
+	word
+		`The captain of the <npc> thanks you for escorting them safely, and the shipyard pays you <payment> for helping to deliver the supplies.`
 
 mission "FW Convoy Defense [0]"
 	job
@@ -143,7 +151,7 @@ mission "FW Convoy Defense [0]"
 				"Osprey"
 	on complete
 		payment 270000
-		dialog `The captain of the <npc> thanks you for escorting them safely, and the shipyard pays you <payment> for helping to deliver the supplies.`
+		dialog phrase "free worlds convoy supplies payment"
 	on visit
 		dialog `You have reached <planet>, but you left part or all of the convoy behind! Better depart and wait for them to arrive in this star system.`
 
@@ -205,7 +213,7 @@ mission "FW Convoy Defense [1]"
 				"Osprey"
 	on complete
 		payment 270000
-		dialog `The captain of the <npc> thanks you for escorting them safely, and the shipyard pays you <payment> for helping to deliver the supplies.`
+		dialog phrase "free worlds convoy supplies payment"
 	on visit
 		dialog `You have reached <planet>, but you left part or all of the convoy behind! Better depart and wait for them to arrive in this star system.`
 
@@ -267,7 +275,7 @@ mission "FW Convoy Defense [2]"
 				"Osprey"
 	on complete
 		payment 270000
-		dialog `The captain of the <npc> thanks you for escorting them safely, and the shipyard pays you <payment> for helping to deliver the supplies.`
+		dialog phrase "free worlds convoy supplies payment"
 	on visit
 		dialog `You have reached <planet>, but you left part or all of the convoy behind! Better depart and wait for them to arrive in this star system.`
 
@@ -328,6 +336,14 @@ mission "FW Reinforcements [1]"
 		dialog `You unload the Free Worlds soldiers into the busy spaceport of <planet>, and collect your payment of <payment>.`
 
 
+phrase "free worlds thanked resupply payment"
+	phrase
+		"generic cargo delivery payment"
+	word
+		` `
+	word
+		`A Free Worlds captain stationed on <planet> thanks you for delivering the much-needed supplies.`
+		`The Free Worlds captains stationed on <planet> thank you for delivering the much-needed supplies.`
 
 mission "FW Outfitter Resupply [0]"
 	job
@@ -348,7 +364,7 @@ mission "FW Outfitter Resupply [0]"
 		attributes outfitter
 	on complete
 		payment 2000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 mission "FW Outfitter Resupply [1]"
 	job
@@ -369,7 +385,7 @@ mission "FW Outfitter Resupply [1]"
 		attributes outfitter
 	on complete
 		payment 2000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 mission "FW Outfitter Resupply [2]"
 	job
@@ -390,7 +406,7 @@ mission "FW Outfitter Resupply [2]"
 		attributes outfitter
 	on complete
 		payment 2000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 mission "FW Bulk Outfitter Resupply [0]"
 	job
@@ -411,7 +427,7 @@ mission "FW Bulk Outfitter Resupply [0]"
 		attributes outfitter
 	on complete
 		payment 5000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 mission "FW Bulk Outfitter Resupply [1]"
 	job
@@ -432,7 +448,7 @@ mission "FW Bulk Outfitter Resupply [1]"
 		attributes outfitter
 	on complete
 		payment 5000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 mission "FW Bulk Outfitter Resupply [2]"
 	job
@@ -453,7 +469,7 @@ mission "FW Bulk Outfitter Resupply [2]"
 		attributes outfitter
 	on complete
 		payment 5000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. A Free Worlds captain stationed on <planet> thanks you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 mission "FW Frontline Resupply [0]"
 	job
@@ -480,7 +496,7 @@ mission "FW Frontline Resupply [0]"
 			neighbor government "Republic"
 	on complete
 		payment 2000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 mission "FW Frontline Resupply [1]"
 	job
@@ -507,7 +523,7 @@ mission "FW Frontline Resupply [1]"
 			neighbor government "Republic"
 	on complete
 		payment 2000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 mission "FW Frontline Resupply [2]"
 	job
@@ -534,7 +550,7 @@ mission "FW Frontline Resupply [2]"
 			neighbor government "Republic"
 	on complete
 		payment 2000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 mission "FW Bulk Frontline Resupply [0]"
 	job
@@ -561,7 +577,7 @@ mission "FW Bulk Frontline Resupply [0]"
 			neighbor government "Republic"
 	on complete
 		payment 5000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 mission "FW Bulk Frontline Resupply [1]"
 	job
@@ -588,9 +604,13 @@ mission "FW Bulk Frontline Resupply [1]"
 			neighbor government "Republic"
 	on complete
 		payment 5000 180
-		dialog `You drop off your cargo of <commodity> and collect your payment of <payment>. The Free Worlds captains stationed on <planet> thank you for delivering the much needed supplies.`
+		dialog phrase "free worlds thanked resupply payment"
 
 
+
+phrase "free worlds thanked care package"
+	word
+		`You deliver the care package of <commodity> to the specified address and explain to the people where the care package came from. They thank you for delivering it, and you collect your payment of <payment>.`
 
 mission "FW Care Package to Republic [0]"
 	job
@@ -610,7 +630,7 @@ mission "FW Care Package to Republic [0]"
 		distance 2 5
 	on complete
 		payment 1000 180
-		dialog `You deliver the care package of <commodity> to the specified address and explain to the people where the care package came from. They thank you for delivering it, and you collect your payment of <payment>.`
+		dialog phrase "free worlds thanked care package"
 
 mission "FW Care Package to Republic [1]"
 	job
@@ -630,7 +650,7 @@ mission "FW Care Package to Republic [1]"
 		distance 2 5
 	on complete
 		payment 1000 180
-		dialog `You deliver the care package of <commodity> to the specified address and explain to the people where the care package came from. They thank you for delivering it, and you collect your payment of <payment>.`
+		dialog phrase "free worlds thanked care package"
 
 mission "FW Care Package from Republic [0]"
 	job
@@ -650,7 +670,7 @@ mission "FW Care Package from Republic [0]"
 		distance 2 5
 	on complete
 		payment 1000 180
-		dialog `You deliver the care package of <commodity> to the specified address and explain to the people where the care package came from. They thank you for delivering it, and you collect your payment of <payment>.`
+		dialog phrase "free worlds thanked care package"
 
 mission "FW Care Package from Republic [1]"
 	job
@@ -670,9 +690,13 @@ mission "FW Care Package from Republic [1]"
 		distance 2 5
 	on complete
 		payment 1000 180
-		dialog `You deliver the care package of <commodity> to the specified address and explain to the people where the care package came from. They thank you for delivering it, and you collect your payment of <payment>.`
+		dialog phrase "free worlds thanked care package"
 
 
+
+phrase "free worlds thanked refugee transport"
+	word
+		`Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
 
 mission "FW Refugees [0]"
 	job
@@ -699,7 +723,7 @@ mission "FW Refugees [0]"
 				neighbor government "Republic"
 	on complete
 		payment 2000 180
-		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
+		dialog phrase "free worlds thanked refugee transport"
 
 mission "FW Refugees [1]"
 	job
@@ -726,7 +750,7 @@ mission "FW Refugees [1]"
 				neighbor government "Republic"
 	on complete
 		payment 2000 180
-		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
+		dialog phrase "free worlds thanked refugee transport"
 
 mission "FW Refugees [2]"
 	job
@@ -753,7 +777,7 @@ mission "FW Refugees [2]"
 				neighbor government "Republic"
 	on complete
 		payment 2000 180
-		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
+		dialog phrase "free worlds thanked refugee transport"
 
 mission "FW Bulk Refugees [0]"
 	job
@@ -780,4 +804,4 @@ mission "FW Bulk Refugees [0]"
 				neighbor government "Republic"
 	on complete
 		payment 5000 180
-		dialog `Your passengers thank you graciously for taking them away from the dangerous frontlines of the war. You wish them the best of luck on <planet>, and collect your payment of <payment>.`
+		dialog phrase "free worlds thanked refugee transport"

--- a/data/frontier jobs.txt
+++ b/data/frontier jobs.txt
@@ -38,7 +38,7 @@ mission "Frontier delivery [0]"
 		fleet "Small Northern Pirates" 2
 	on complete
 		payment 4000 180
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 
 mission "Frontier delivery [1]"
@@ -69,7 +69,7 @@ mission "Frontier delivery [1]"
 		fleet "Small Northern Pirates" 3
 	on complete
 		payment 4000 180
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 
 mission "Frontier delivery [2]"
@@ -99,7 +99,7 @@ mission "Frontier delivery [2]"
 		fleet "Large Northern Pirates"
 	on complete
 		payment 4000 180
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 
 mission "Frontier Emigration [0]"
@@ -119,7 +119,7 @@ mission "Frontier Emigration [0]"
 		not attributes "frontier"
 	on complete
 		payment 3000 140
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 
 mission "Frontier Emigration [1]"
@@ -139,7 +139,7 @@ mission "Frontier Emigration [1]"
 		not attributes "frontier"
 	on complete
 		payment 3000 140
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 
 mission "Frontier Emigration [2]"
@@ -159,7 +159,7 @@ mission "Frontier Emigration [2]"
 		not attributes "frontier"
 	on complete
 		payment 3000 140
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 
 mission "Disaster Relief"

--- a/data/hai jobs.txt
+++ b/data/hai jobs.txt
@@ -23,7 +23,7 @@ mission "Human Vacation [1]"
 		attributes "human tourism"
 	on complete
 		payment 8000 150
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Human Vacation [2]"
 	name "Human vacationers to <planet>"
@@ -40,7 +40,7 @@ mission "Human Vacation [2]"
 		attributes "human tourism"
 	on complete
 		payment 5000 150
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [1]"
 	name "Hai vacationer to <planet>"
@@ -57,7 +57,7 @@ mission "Hai Vacation [1]"
 		attributes "hai tourism"
 	on complete
 		payment 6000 150
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [2]"
 	name "Hai vacationers to <planet>"
@@ -74,7 +74,7 @@ mission "Hai Vacation [2]"
 		attributes "hai tourism"
 	on complete
 		payment 4000 150
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [3]"
 	name "Hai vacationers to <planet>"
@@ -91,7 +91,7 @@ mission "Hai Vacation [3]"
 		attributes "hai tourism"
 	on complete
 		payment 4000 150
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [4]"
 	name "Hai vacationers to <planet>"
@@ -109,7 +109,7 @@ mission "Hai Vacation [4]"
 	on complete
 		payment
 		payment 6000
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 
 mission "Wealthy Hai [1]"
@@ -131,7 +131,7 @@ mission "Wealthy Hai [1]"
 		distance 4 8
 	on complete
 		payment 15000 300
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Wealthy Hai [2]"
 	name "Wealthy Hai to <planet>"
@@ -152,8 +152,12 @@ mission "Wealthy Hai [2]"
 		distance 4 8
 	on complete
 		payment 15000 300
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
+
+phrase "hai festival payment dialog"
+	word
+		`Luckily your <passengers> didn't cause too much trouble on the trip. After collecting their things, they pay you <payment> and make their way to the festival.`
 
 mission "Hai Festival [1]"
 	name "Festival at <planet>"
@@ -172,7 +176,7 @@ mission "Hai Festival [1]"
 		government "Hai"
 	on complete
 		payment 10000 200
-		dialog "Luckily your <passengers> didn't cause too much trouble on the trip. After collecting their things, they pay you <payment> and make their way to the festival."
+		dialog phrase "hai festival payment dialog"
 
 mission "Hai Festival [2]"
 	name "Festival at <planet>"
@@ -191,7 +195,7 @@ mission "Hai Festival [2]"
 		government "Hai"
 	on complete
 		payment 10000 200
-		dialog "Luckily your <passengers> didn't cause too much trouble on the trip. After collecting their things, they pay you <payment> and make their way to the festival."
+		dialog phrase "hai festival payment dialog"
 
 mission "Hai Festival [3]"
 	name "Festival at <planet>"
@@ -210,9 +214,23 @@ mission "Hai Festival [3]"
 		government "Hai"
 	on complete
 		payment 10000 200
-		dialog "Luckily your <passengers> didn't cause too much trouble on the trip. After collecting their things, they pay you <payment> and make their way to the festival."
+		dialog phrase "hai festival payment dialog"
 
 
+
+phrase "unfettered aid payment dialog"
+	word
+		`You drop off the aid (or as they like to refer to it, "tribute") for the Unfettered, and receive <payment> from your contact on <origin>.`
+
+phrase "unfettered aid pickup dialog"
+	word
+		`The Hai dockworkers load the food for the Unfettered onto your ship. One of them says to you,`
+		`As the Hai load the food onto your ship, one of them says,`
+	word
+		` `
+	word
+		`"Thank you. This is far better than watching our kinfolk starve."`
+		`"Tell our brothers and sisters that if they will only repent, they will be welcome to come home."`
 
 mission "Unfettered Aid [0]"
 	name "Aid shipment to Unfettered"
@@ -231,10 +249,10 @@ mission "Unfettered Aid [0]"
 		distance 3 4
 		attributes "unfettered"
 	on accept
-		dialog `The Hai dockworkers load the food for the Unfettered onto your ship. One of them says to you, "Thank you. This is far better than watching our kinfolk starve."`
+		dialog phrase "unfettered aid pickup dialog"
 	on complete
 		payment 5000 1600
-		dialog `You drop off the aid (or as they like to refer to it, "tribute") for the Unfettered, and they pay you <payment>.`
+		dialog phrase "unfettered aid payment dialog"
 
 mission "Unfettered Aid [1]"
 	name "Aid shipment to Unfettered"
@@ -253,10 +271,10 @@ mission "Unfettered Aid [1]"
 		distance 4 5
 		attributes "unfettered"
 	on accept
-		dialog `As the Hai load the food onto your ship, one of them says, "Tell our brothers and sisters that if they will only repent, they will be welcome to come home."`
+		dialog phrase "unfettered aid pickup dialog"
 	on complete
 		payment 6000 1800
-		dialog `You drop off the aid (or as they like to refer to it, "tribute") for the Unfettered, and they pay you <payment>.`
+		dialog phrase "unfettered aid payment dialog"
 
 mission "Unfettered Aid [2]"
 	name "Aid shipment to Unfettered"
@@ -275,10 +293,20 @@ mission "Unfettered Aid [2]"
 		distance 5 6
 		attributes "unfettered"
 	on accept
-		dialog `The Hai dockworkers load the food for the Unfettered onto your ship. One of them says to you, "Tell our brothers and sisters that if they will only repent, they will be welcome to come home."`
+		dialog "unfettered aid pickup dialog"
 	on complete
 		payment 7000 2000
-		dialog `You drop off the aid (or as they like to refer to it, "tribute") for the Unfettered, and they pay you <payment>.`
+		dialog phrase "unfettered aid payment dialog"
+
+phrase "unfettered tribute payment dialog"
+	word
+		`You drop off the tribute to the Unfettered, and they pay you <payment>.`
+
+phrase "unfettered tribute pickup dialog"
+	word
+		`When you inform the Hai that you are here to receive a tribute payment for the Unfettered, they load the cargo onto your ship with a rather surprising swiftness and cheerfulness.`
+		`The Hai dockworkers load the tribute for the Unfettered onto your ship. One of them says to you, "Thank you. This is far better than watching our kinfolk starve."`
+		`As the Hai load the tribute onto your ship, one of them says, "Tell our brothers and sisters that if they will only repent, they will be welcome to come home."`
 
 mission "Unfettered Tribute 1"
 	name "Hai Tribute to <planet>"
@@ -291,15 +319,14 @@ mission "Unfettered Tribute 1"
 	cargo "food (tribute)" 25 2 .05
 	on complete
 		payment 5000 1600
-		dialog "You drop off the tribute to the Unfettered, and they pay you <payment>."
+		dialog phrase "unfettered tribute payment dialog"
 	source
 		attributes "unfettered"
 	stopover
 		distance 3 4
 		attributes "hai"
 	on stopover
-		dialog
-			`When you inform the Hai that you are here to receive a tribute payment for the Unfettered, they load the cargo onto your ship with a rather surprising swiftness and cheerfulness.`
+		dialog phrase "unfettered tribute pickup dialog"
 
 mission "Unfettered Tribute 2"
 	name "Hai Tribute to <planet>"
@@ -312,15 +339,14 @@ mission "Unfettered Tribute 2"
 	cargo "food (tribute)" 35 2 .05
 	on complete
 		payment 7000 2000
-		dialog "You drop off the tribute to the Unfettered, and they pay you <payment>."
+		dialog phrase "unfettered tribute payment dialog"
 	source
 		attributes "unfettered"
 	stopover
 		distance 4 5
 		attributes "hai"
 	on stopover
-		dialog
-			`The Hai dockworkers load the tribute for the Unfettered onto your ship. One of them says to you, "Thank you. This is far better than watching our kinfolk starve."`
+		dialog phrase "unfettered tribute pickup dialog"
 
 mission "Unfettered Tribute 3"
 	name "Hai Tribute to <planet>"
@@ -333,15 +359,14 @@ mission "Unfettered Tribute 3"
 	cargo "food (tribute)" 45 2 .05
 	on complete
 		payment 9000 2400
-		dialog "You drop off the tribute to the Unfettered, and they pay you <payment>."
+		dialog phrase "unfettered tribute payment dialog"
 	source
 		attributes "unfettered"
 	stopover
 		distance 5 6
 		attributes "hai"
 	on stopover
-		dialog
-			`As the Hai load the tribute onto your ship, one of them says, "Tell our brothers and sisters that if they will only repent, they will be welcome to come home."`
+		dialog phrase "unfettered tribute pickup dialog"
 
 
 
@@ -360,7 +385,7 @@ mission "Delivery to Human Space [0]"
 		attributes "north"
 	on complete
 		payment 60000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Delivery to Human Space [1]"
 	name "Special Delivery to <planet>"
@@ -377,7 +402,7 @@ mission "Delivery to Human Space [1]"
 		attributes "north"
 	on complete
 		payment 60000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Delivery to Human Space [2]"
 	name "Special Delivery to <planet>"
@@ -394,7 +419,7 @@ mission "Delivery to Human Space [2]"
 		attributes "north"
 	on complete
 		payment 60000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Retrieve Human Luxury Goods"
 	name "Special order to <planet>"
@@ -497,9 +522,9 @@ mission "Escort to Human Space (Small)"
 				"Freighter (Hai)"
 	on complete
 		payment 120000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort to Human Space (Medium)"
 	name "Special Escort to <planet>"
@@ -545,9 +570,9 @@ mission "Escort to Human Space (Medium)"
 				"Freighter (Hai)"
 	on complete
 		payment 180000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort to Human Space (Large)"
 	name "Special Escort to <planet>"
@@ -588,9 +613,9 @@ mission "Escort to Human Space (Large)"
 				"Behemoth (Hai)"
 	on complete
 		payment 240000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort to Human Space (Extra Large)"
 	name "Special Escort to <planet>"
@@ -637,9 +662,9 @@ mission "Escort to Human Space (Extra Large)"
 				"Behemoth (Hai)"
 	on complete
 		payment 300000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 
 
@@ -658,7 +683,7 @@ mission "Hai Passengers [1]"
 		government "Hai"
 	on complete
 		payment
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Passengers [2]"
 	name "Passenger transport to <planet>"
@@ -675,7 +700,7 @@ mission "Hai Passengers [2]"
 		government "Hai"
 	on complete
 		payment
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Passengers [3]"
 	name "Passenger transport to <planet>"
@@ -692,7 +717,7 @@ mission "Hai Passengers [3]"
 		government "Hai"
 	on complete
 		payment
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Family [0]"
 	name "Transport family to <planet>"
@@ -821,7 +846,7 @@ mission "Hai Cargo [0]"
 		government "Hai"
 	on complete
 		payment
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [1]"
 	name "Delivery to <planet>"
@@ -838,7 +863,7 @@ mission "Hai Cargo [1]"
 		government "Hai"
 	on complete
 		payment
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [2]"
 	name "Delivery to <planet>"
@@ -856,7 +881,7 @@ mission "Hai Cargo [2]"
 		government "Hai"
 	on complete
 		payment
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [3]"
 	name "Delivery to <planet>"
@@ -875,7 +900,7 @@ mission "Hai Cargo [3]"
 	on complete
 		payment
 		payment 2000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [4]"
 	name "Delivery to <planet>"
@@ -894,7 +919,7 @@ mission "Hai Cargo [4]"
 	on complete
 		payment
 		payment 4000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Bulk Delivery [0]"
 	name "Bulk delivery to <planet>"
@@ -911,7 +936,7 @@ mission "Hai Bulk Delivery [0]"
 		government "Hai"
 	on complete
 		payment
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Bulk Delivery [1]"
 	name "Bulk delivery to <planet>"
@@ -929,7 +954,7 @@ mission "Hai Bulk Delivery [1]"
 	on complete
 		payment
 		payment 2000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Bulk Delivery [2]"
 	name "Bulk delivery to <planet>"
@@ -948,7 +973,7 @@ mission "Hai Bulk Delivery [2]"
 	on complete
 		payment
 		payment 4000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Bulk Delivery [0]"
 	name "Large bulk delivery to <planet>"
@@ -967,7 +992,7 @@ mission "Hai Large Bulk Delivery [0]"
 	on complete
 		payment
 		payment 4000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Bulk Delivery [1]"
 	name "Large bulk delivery to <planet>"
@@ -986,7 +1011,7 @@ mission "Hai Large Bulk Delivery [1]"
 	on complete
 		payment
 		payment 6000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Bulk Delivery [2]"
 	name "Large bulk delivery to <planet>"
@@ -1006,7 +1031,7 @@ mission "Hai Large Bulk Delivery [2]"
 	on complete
 		payment
 		payment 8000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Rush Delivery [0]"
 	name "Rush delivery to <planet>"
@@ -1025,7 +1050,7 @@ mission "Hai Rush Delivery [0]"
 	on complete
 		payment
 		payment 16000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Rush Delivery [1]"
 	name "Rush delivery to <planet>"
@@ -1044,7 +1069,7 @@ mission "Hai Rush Delivery [1]"
 	on complete
 		payment
 		payment 18000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Rush Delivery [2]"
 	name "Rush delivery to <planet>"
@@ -1064,7 +1089,7 @@ mission "Hai Rush Delivery [2]"
 	on complete
 		payment
 		payment 20000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Rush Delivery [3]"
 	name "Rush delivery to <planet>"
@@ -1084,7 +1109,7 @@ mission "Hai Rush Delivery [3]"
 	on complete
 		payment
 		payment 22000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Rush Delivery [0]"
 	name "Large rush delivery to <planet>"
@@ -1104,7 +1129,7 @@ mission "Hai Large Rush Delivery [0]"
 	on complete
 		payment
 		payment 36000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Rush Delivery [1]"
 	name "Large rush delivery to <planet>"
@@ -1124,7 +1149,7 @@ mission "Hai Large Rush Delivery [1]"
 	on complete
 		payment
 		payment 38000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Rush Delivery [2]"
 	name "Large rush delivery to <planet>"
@@ -1145,7 +1170,7 @@ mission "Hai Large Rush Delivery [2]"
 	on complete
 		payment
 		payment 40000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Rush Delivery [3]"
 	name "Large rush delivery to <planet>"
@@ -1166,7 +1191,7 @@ mission "Hai Large Rush Delivery [3]"
 	on complete
 		payment
 		payment 42000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 
 

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -8,6 +8,13 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
+phrase "generic arrived-without-npc dialog"
+	word
+		`You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system.`
+phrase "generic safe escort completion dialog"
+	word
+		`The captain of the <npc> thanks you for escorting them safely, and pays you <payment>.`
+
 mission "Escort (Tiny, Northern, Dangerous Destination)"
 	name "Escort to <planet>"
 	description "Despite your relative inexperience, the captain of the <npc> is willing to pay you <payment> for an escort into a dangerous region of space to reach <destination> by <date>."
@@ -65,9 +72,9 @@ mission "Escort (Tiny, Northern, Dangerous Destination)"
 				"Star Barge"
 	on complete
 		payment 15000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Tiny, Northern, Dangerous Origin)"
 	name "Escort to <planet>"
@@ -126,9 +133,9 @@ mission "Escort (Tiny, Northern, Dangerous Origin)"
 				"Star Barge"
 	on complete
 		payment 15000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Small, Northern, Dangerous Destination)"
 	name "Escort to <planet>"
@@ -174,9 +181,9 @@ mission "Escort (Small, Northern, Dangerous Destination)"
 				"Freighter"
 	on complete
 		payment 60000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Small, Northern, Dangerous Origin)"
 	name "Escort to <planet>"
@@ -223,9 +230,9 @@ mission "Escort (Small, Northern, Dangerous Origin)"
 				"Freighter"
 	on complete
 		payment 60000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Medium, Northern, Dangerous Destination)"
 	name "Escort to <planet>"
@@ -277,9 +284,9 @@ mission "Escort (Medium, Northern, Dangerous Destination)"
 				"Freighter"
 	on complete
 		payment 90000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Medium, Northern, Dangerous Origin)"
 	name "Escort to <planet>"
@@ -331,9 +338,9 @@ mission "Escort (Medium, Northern, Dangerous Origin)"
 				"Freighter"
 	on complete
 		payment 90000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Large, Northern, Dangerous Destination)"
 	name "Escort to <planet>"
@@ -376,9 +383,9 @@ mission "Escort (Large, Northern, Dangerous Destination)"
 				"Behemoth"
 	on complete
 		payment 120000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Large, Northern, Dangerous Origin)"
 	name "Escort to <planet>"
@@ -422,9 +429,9 @@ mission "Escort (Large, Northern, Dangerous Origin)"
 				"Behemoth"
 	on complete
 		payment 120000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Extra Large, Northern, Dangerous Destination)"
 	name "Escort to <planet>"
@@ -469,9 +476,9 @@ mission "Escort (Extra Large, Northern, Dangerous Destination)"
 				"Behemoth"
 	on complete
 		payment 150000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Extra Large, Northern, Dangerous Origin)"
 	name "Escort to <planet>"
@@ -521,9 +528,9 @@ mission "Escort (Extra Large, Northern, Dangerous Origin)"
 				"Behemoth"
 	on complete
 		payment 150000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 
 mission "Escort (Tiny, Core, Dangerous Destination)"
@@ -583,9 +590,9 @@ mission "Escort (Tiny, Core, Dangerous Destination)"
 				"Star Barge"
 	on complete
 		payment 20000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Tiny, Core, Dangerous Origin)"
 	name "Escort to <planet>"
@@ -644,9 +651,9 @@ mission "Escort (Tiny, Core, Dangerous Origin)"
 				"Star Barge"
 	on complete
 		payment 20000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Small, Core, Dangerous Destination)"
 	name "Escort to <planet>"
@@ -692,9 +699,9 @@ mission "Escort (Small, Core, Dangerous Destination)"
 				"Freighter"
 	on complete
 		payment 60000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Small, Core, Dangerous Origin)"
 	name "Escort to <planet>"
@@ -741,9 +748,9 @@ mission "Escort (Small, Core, Dangerous Origin)"
 				"Freighter"
 	on complete
 		payment 60000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Medium, Core, Dangerous Destination)"
 	name "Escort to <planet>"
@@ -789,9 +796,9 @@ mission "Escort (Medium, Core, Dangerous Destination)"
 				"Freighter"
 	on complete
 		payment 90000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Medium, Core, Dangerous Origin)"
 	name "Escort to <planet>"
@@ -845,9 +852,9 @@ mission "Escort (Medium, Core, Dangerous Origin)"
 				"Freighter"
 	on complete
 		payment 90000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Large, Core, Dangerous Destination)"
 	name "Escort to <planet>"
@@ -890,9 +897,9 @@ mission "Escort (Large, Core, Dangerous Destination)"
 				"Bulk Freighter"
 	on complete
 		payment 120000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Large, Core, Dangerous Origin)"
 	name "Escort to <planet>"
@@ -936,9 +943,9 @@ mission "Escort (Large, Core, Dangerous Origin)"
 				"Bulk Freighter"
 	on complete
 		payment 120000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Extra Large, Core, Dangerous Destination)"
 	name "Escort to <planet>"
@@ -983,9 +990,9 @@ mission "Escort (Extra Large, Core, Dangerous Destination)"
 				"Bulk Freighter"
 	on complete
 		payment 150000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Extra Large, Core, Dangerous Origin)"
 	name "Escort to <planet>"
@@ -1036,9 +1043,9 @@ mission "Escort (Extra Large, Core, Dangerous Origin)"
 				"Bulk Freighter"
 	on complete
 		payment 150000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 
 mission "Escort (Tiny, Southern, Dangerous Origin or Destination)"
@@ -1097,9 +1104,9 @@ mission "Escort (Tiny, Southern, Dangerous Origin or Destination)"
 				"Star Barge"
 	on complete
 		payment 15000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Small, Southern, Dangerous Origin or Destination)"
 	name "Escort to <planet>"
@@ -1138,9 +1145,9 @@ mission "Escort (Small, Southern, Dangerous Origin or Destination)"
 				"Freighter"
 	on complete
 		payment 60000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Medium, Southern, Dangerous Origin or Destination)"
 	name "Escort to <planet>"
@@ -1179,9 +1186,9 @@ mission "Escort (Medium, Southern, Dangerous Origin or Destination)"
 				"Freighter"
 	on complete
 		payment 90000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Large, Southern, Dangerous Origin or Destination)"
 	name "Escort to <planet>"
@@ -1218,9 +1225,9 @@ mission "Escort (Large, Southern, Dangerous Origin or Destination)"
 				"Bulk Freighter"
 	on complete
 		payment 120000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort (Extra Large, Southern, Dangerous Origin or Destination)"
 	name "Escort to <planet>"
@@ -1259,9 +1266,27 @@ mission "Escort (Extra Large, Southern, Dangerous Origin or Destination)"
 				"Behemoth"
 	on complete
 		payment 150000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
+
+phrase "generic pirate attack payment dialog"
+	word
+		`The government of <planet>`
+	word
+		` `
+		` gratefully `
+	word
+		`pays you <payment> for helping to`
+	word
+		` drive off `
+		` defeat `
+	word
+		`the `
+	word
+		`pirates.`
+		`raiders.`
+		`attackers.`
 
 mission "Southern Pirate Attack"
 	name "Defend <planet>"
@@ -1294,7 +1319,7 @@ mission "Southern Pirate Attack"
 				launch
 	on complete
 		payment 150000
-		dialog "The government of <planet> pays you <payment> for helping to drive off the pirates."
+		dialog phrase "generic pirate attack payment dialog"
 
 mission "Northern Pirate Attack"
 	name "Defend <planet>"
@@ -1327,7 +1352,7 @@ mission "Northern Pirate Attack"
 				launch
 	on complete
 		payment 250000
-		dialog "The government of <planet> pays you <payment> for helping to drive off the pirates."
+		dialog phrase "generic pirate attack payment dialog"
 
 mission "Core Pirate Attack"
 	name "Defend <planet>"
@@ -1360,8 +1385,8 @@ mission "Core Pirate Attack"
 				launch
 	on complete
 		payment 200000
-		dialog "The government of <planet> pays you <payment> for helping to drive off the pirates."
-		
+		dialog phrase "generic pirate attack payment dialog"
+
 mission "Raider Attack 1"
 	name "Defend <planet>"
 	description "Defeat an alien raid on <destination>."
@@ -1396,7 +1421,7 @@ mission "Raider Attack 1"
 	on complete
 		payment 550000
 		dialog `The government of <planet> pays you <payment> for helping to drive off the raiders.`
-		
+
 mission "Raider Attack 2"
 	name "Defend <planet>"
 	description "Defeat an alien raid on <destination>."
@@ -1432,6 +1457,11 @@ mission "Raider Attack 2"
 		payment 750000
 		dialog `The government of <planet> pays you <payment> for helping to drive off the raiders.`
 
+
+phrase "generic cargo delivery payment"
+	word
+		`You drop off your cargo of <commodity> and collect your payment of <payment>.`
+
 mission "Cargo [0]"
 	name "Delivery to <planet>"
 	job
@@ -1445,7 +1475,7 @@ mission "Cargo [0]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	on complete
 		payment
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Cargo [1]"
 	name "Delivery to <planet>"
@@ -1462,7 +1492,7 @@ mission "Cargo [1]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	on complete
 		payment
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Cargo [2]"
 	name "Delivery to <planet>"
@@ -1480,7 +1510,7 @@ mission "Cargo [2]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	on complete
 		payment
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Cargo [3]"
 	name "Delivery to <planet>"
@@ -1499,7 +1529,7 @@ mission "Cargo [3]"
 	on complete
 		payment
 		payment 2000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Cargo [4]"
 	name "Delivery to <planet>"
@@ -1518,7 +1548,7 @@ mission "Cargo [4]"
 	on complete
 		payment
 		payment 4000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Bulk Delivery [0]"
 	name "Bulk delivery to <planet>"
@@ -1535,7 +1565,7 @@ mission "Bulk Delivery [0]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	on complete
 		payment
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Bulk Delivery [1]"
 	name "Bulk delivery to <planet>"
@@ -1553,7 +1583,7 @@ mission "Bulk Delivery [1]"
 	on complete
 		payment
 		payment 2000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Bulk Delivery [2]"
 	name "Bulk delivery to <planet>"
@@ -1572,7 +1602,7 @@ mission "Bulk Delivery [2]"
 	on complete
 		payment
 		payment 4000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Rush Delivery [0]"
 	name "Rush delivery to <planet>"
@@ -1591,7 +1621,7 @@ mission "Rush Delivery [0]"
 	on complete
 		payment
 		payment 16000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Rush Delivery [1]"
 	name "Rush delivery to <planet>"
@@ -1610,7 +1640,7 @@ mission "Rush Delivery [1]"
 	on complete
 		payment
 		payment 18000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Rush Delivery [2]"
 	name "Rush delivery to <planet>"
@@ -1630,7 +1660,7 @@ mission "Rush Delivery [2]"
 	on complete
 		payment
 		payment 20000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Rush Delivery [3]"
 	name "Rush delivery to <planet>"
@@ -1650,9 +1680,14 @@ mission "Rush Delivery [3]"
 	on complete
 		payment
 		payment 22000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 
+
+phrase "generic passenger dropoff payment"
+	word
+		`You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>.`
+		`You say farewell to your <passengers> on <planet>, and collect your payment of <payment>.`
 
 mission "Passengers [0]"
 	name "Passenger transport to <planet>"
@@ -1668,7 +1703,7 @@ mission "Passengers [0]"
 	on complete
 		payment
 		payment 2000
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Passengers [1]"
 	name "Passenger transport to <planet>"
@@ -1685,7 +1720,7 @@ mission "Passengers [1]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	on complete
 		payment
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Passengers [2]"
 	name "Passenger transport to <planet>"
@@ -1702,7 +1737,7 @@ mission "Passengers [2]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	on complete
 		payment
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Passengers [3]"
 	name "Passenger transport to <planet>"
@@ -1719,7 +1754,7 @@ mission "Passengers [3]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	on complete
 		payment
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Passengers [4]"
 	name "Passenger transport to <planet>"
@@ -1738,7 +1773,7 @@ mission "Passengers [4]"
 	on complete
 		payment
 		payment 2000
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Transport miners to <planet>"
 	job
@@ -1829,7 +1864,7 @@ mission "Tourists out [0]"
 	on complete
 		payment
 		payment 6000
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Tourists out [1]"
 	name "Bring tourists to <planet>"
@@ -1848,7 +1883,7 @@ mission "Tourists out [1]"
 	on complete
 		payment
 		payment 4000
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Wealthy tourists out"
 	name "Bring wealthy tourists to <planet>"
@@ -1869,7 +1904,7 @@ mission "Wealthy tourists out"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	on complete
 		payment 10000 200
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Tourists back [0]"
 	name "Bring a tourist home to <planet>"
@@ -1888,7 +1923,7 @@ mission "Tourists back [0]"
 	on complete
 		payment
 		payment 6000
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Tourists back [1]"
 	name "Bring tourists home to <planet>"
@@ -1907,7 +1942,7 @@ mission "Tourists back [1]"
 	on complete
 		payment
 		payment 4000
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Wealthy tourists back"
 	name "Bring wealthy tourists home to <planet>"
@@ -1928,7 +1963,7 @@ mission "Wealthy tourists back"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	on complete
 		payment 10000 200
-		dialog "You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Family [0]"
 	name "Transport family to <planet>"
@@ -2289,7 +2324,7 @@ mission "Large Bulk Delivery [0]"
 	on complete
 		payment
 		payment 4000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Large Bulk Delivery [1]"
 	name "Large bulk delivery to <planet>"
@@ -2308,7 +2343,7 @@ mission "Large Bulk Delivery [1]"
 	on complete
 		payment
 		payment 6000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Large Bulk Delivery [2]"
 	name "Large bulk delivery to <planet>"
@@ -2328,7 +2363,7 @@ mission "Large Bulk Delivery [2]"
 	on complete
 		payment
 		payment 8000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Large Rush Delivery [0]"
 	name "Large rush delivery to <planet>"
@@ -2348,7 +2383,7 @@ mission "Large Rush Delivery [0]"
 	on complete
 		payment
 		payment 36000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Large Rush Delivery [1]"
 	name "Large rush delivery to <planet>"
@@ -2368,7 +2403,7 @@ mission "Large Rush Delivery [1]"
 	on complete
 		payment
 		payment 38000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Large Rush Delivery [2]"
 	name "Large rush delivery to <planet>"
@@ -2389,7 +2424,7 @@ mission "Large Rush Delivery [2]"
 	on complete
 		payment
 		payment 40000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Large Rush Delivery [3]"
 	name "Large rush delivery to <planet>"
@@ -2410,7 +2445,7 @@ mission "Large Rush Delivery [3]"
 	on complete
 		payment
 		payment 42000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Recycle garbage"
 	name "Recycle garbage"
@@ -2429,6 +2464,14 @@ mission "Recycle garbage"
 		dialog "You drop off the <commodity> at an especially smelly solid waste recycler and collect your payment of <payment>."
 		payment
 		payment 20000
+
+phrase "generic hunted bounty eliminated dialog"
+	word
+		`The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>.`
+
+phrase "generic bounty hunting payment dialog"
+	word
+		`The government of <planet> gratefully pays you <payment> for eliminating the <npc>.`
 
 mission "Bounty Hunting (Small)"
 	name "Hunt down <npc>"
@@ -2466,10 +2509,10 @@ mission "Bounty Hunting (Small)"
 				"Manta"
 			variant
 				"Manta (Proton)"
-		dialog "The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty eliminated dialog"
 	on complete
 		payment 150000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc>."
+		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Medium)"
 	name "Hunt down <npc>"
@@ -2501,10 +2544,10 @@ mission "Bounty Hunting (Medium)"
 				"Bastion (Laser)"
 			variant
 				"Firebird (Plasma)"
-		dialog "The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty eliminated dialog"
 	on complete
 		payment 200000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc>."
+		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Big)"
 	name "Hunt down <npc>"
@@ -2540,10 +2583,10 @@ mission "Bounty Hunting (Big)"
 				"Vanguard"
 			variant
 				"Vanguard (Particle)"
-		dialog "The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty eliminated dialog"
 	on complete
 		payment 250000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc>."
+		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Small, Boarding, Entering)"
 	name "Board <npc>"
@@ -2621,6 +2664,14 @@ mission "Bounty Hunting (Medium, Boarding, Entering)"
 		payment 350000
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal gang."
 
+phrase "generic hunted bounty fleet eliminated dialog"
+	word
+		`The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>.`
+
+phrase "generic fleet bounty hunting payment dialog"
+	word
+		`The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet.`
+
 mission "Bounty Hunting (Marauder I)"
 	name "Hunt down <npc>"
 	description "A Marauder vessel named <npc>, leading a small fleet, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
@@ -2642,10 +2693,10 @@ mission "Bounty Hunting (Marauder I)"
 		system
 			distance 1 3
 		fleet "Marauder fleet I"
-		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on complete
 		payment 300000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder II)"
 	name "Hunt down <npc>"
@@ -2668,10 +2719,10 @@ mission "Bounty Hunting (Marauder II)"
 		system
 			distance 1 3
 		fleet "Marauder fleet II"
-		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on complete
 		payment 350000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder III)"
 	name "Hunt down <npc>"
@@ -2694,10 +2745,10 @@ mission "Bounty Hunting (Marauder III)"
 		system
 			distance 1 3
 		fleet "Marauder fleet III"
-		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on complete
 		payment 400000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder IV)"
 	name "Hunt down <npc>"
@@ -2720,10 +2771,10 @@ mission "Bounty Hunting (Marauder IV)"
 		system
 			distance 1 3
 		fleet "Marauder fleet IV"
-		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on complete
 		payment 425000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder V)"
 	name "Hunt down <npc>"
@@ -2746,10 +2797,10 @@ mission "Bounty Hunting (Marauder V)"
 		system
 			distance 1 3
 		fleet "Marauder fleet V"
-		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on complete
 		payment 450000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog phrase "generic fleet bounty hunting payment dialog"
 
 
 mission "Bounty Hunting (Marauder VI)"
@@ -2773,10 +2824,10 @@ mission "Bounty Hunting (Marauder VI)"
 		system
 			distance 1 3
 		fleet "Marauder fleet VI"
-		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on complete
 		payment 475000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder VII)"
 	name "Hunt down <npc>"
@@ -2795,10 +2846,10 @@ mission "Bounty Hunting (Marauder VII)"
 		system
 			distance 1 3
 		fleet "Marauder fleet VII"
-		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on complete
 		payment 500000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder VIII)"
 	name "Hunt down <npc>"
@@ -2817,10 +2868,10 @@ mission "Bounty Hunting (Marauder VIII)"
 		system
 			distance 1 3
 		fleet "Marauder fleet VIII"
-		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on complete
 		payment 550000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder IX)"
 	name "Hunt down <npc>"
@@ -2839,10 +2890,10 @@ mission "Bounty Hunting (Marauder IX)"
 		system
 			distance 1 3
 		fleet "Marauder fleet IX"
-		dialog "The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>."
+		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on complete
 		payment 600000
-		dialog "The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet."
+		dialog phrase "generic fleet bounty hunting payment dialog"
 
 # Must destroy hunters and land to fail
 mission "Marauder Hunted"
@@ -2863,4 +2914,3 @@ mission "Marauder Hunted"
 		system
 			distance 5 5
 		fleet "Marauder fleet X"
-

--- a/data/pirate jobs.txt
+++ b/data/pirate jobs.txt
@@ -1536,9 +1536,9 @@ mission "Mercenary Job (Medium, North, Dangerous Origin)"
 				"Corvette (Speedy)"
 	on complete
 		payment 180000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort Illegal Cargo (Large, North, Dangerous Path)"
 	name "Protect cargo to <planet>"
@@ -1584,9 +1584,9 @@ mission "Escort Illegal Cargo (Large, North, Dangerous Path)"
 				"Leviathan"
 	on complete
 		payment 240000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort Stolen Vessel (Extra Large, North, Dangerous Path)"
 	name "Protect ship to <planet>"
@@ -1631,9 +1631,9 @@ mission "Escort Stolen Vessel (Extra Large, North, Dangerous Path)"
 				"Shuttle"
 	on complete
 		payment 375000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Mercenary Job (Medium, Core, Dangerous Origin)"
 	name "Protection to <planet>"
@@ -1677,9 +1677,9 @@ mission "Mercenary Job (Medium, Core, Dangerous Origin)"
 				"Quicksilver (Proton)"
 	on complete
 		payment 180000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort Illegal Cargo (Large, Core, Dangerous Path)"
 	name "Protect cargo to <planet>"
@@ -1721,9 +1721,9 @@ mission "Escort Illegal Cargo (Large, Core, Dangerous Path)"
 				"Splinter (Laser)" 2
 	on complete
 		payment 240000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort Stolen Vessel (Extra Large, Core, Dangerous Path)"
 	name "Protect ship to <planet>"
@@ -1774,9 +1774,9 @@ mission "Escort Stolen Vessel (Extra Large, Core, Dangerous Path)"
 				"Heavy Shuttle"
 	on complete
 		payment 375000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Mercenary Job (Medium, South, Dangerous Origin)"
 	name "Protection to <planet>"
@@ -1820,9 +1820,9 @@ mission "Mercenary Job (Medium, South, Dangerous Origin)"
 				"Modified Argosy"
 	on complete
 		payment 180000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort Illegal Cargo (Large, South, Dangerous Path)"
 	name "Protect cargo to <planet>"
@@ -1866,9 +1866,9 @@ mission "Escort Illegal Cargo (Large, South, Dangerous Path)"
 				"Bastion (Heavy)"
 	on complete
 		payment 240000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 mission "Escort Stolen Vessel (Extra Large, South, Dangerous Path)"
 	name "Protect ship to <planet>"
@@ -1919,9 +1919,9 @@ mission "Escort Stolen Vessel (Extra Large, South, Dangerous Path)"
 				"Heavy Shuttle"
 	on complete
 		payment 375000
-		dialog "The captain of the <npc> thanks you for escorting them safely, and pays you <payment>."
+		dialog phrase "generic safe escort completion dialog"
 	on visit
-		dialog "You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system."
+		dialog phrase "generic arrived-without-npc dialog"
 
 
 

--- a/data/rim jobs.txt
+++ b/data/rim jobs.txt
@@ -26,7 +26,7 @@ mission "Southbound Shipment [0]"
 		fleet "Small Southern Pirates"
 	on complete
 		payment 0 160
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Southbound Shipment [1]"
 	name "Shipment to <planet>"
@@ -46,7 +46,7 @@ mission "Southbound Shipment [1]"
 		fleet "Small Southern Pirates"
 	on complete
 		payment 0 160
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 
 mission "Kraz Shipment"
@@ -67,7 +67,7 @@ mission "Kraz Shipment"
 		fleet "Small Southern Pirates"
 	on complete
 		payment 0 160
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 mission "Han Sizer Month [0]"
 	name `Han Sizer celebration`

--- a/data/south jobs.txt
+++ b/data/south jobs.txt
@@ -39,8 +39,7 @@ mission "Pirate Occupation [0]"
 		conversation "pirate occupation"
 	on complete
 		payment 100000
-		dialog `The government of <planet> thanks you for defeating the pirates and pays you <payment>.`
-
+		dialog phrase "generic pirate attack payment dialog"
 
 mission "Pirate Occupation [1]"
 	name `Pirates occupying <system>`
@@ -74,8 +73,7 @@ mission "Pirate Occupation [1]"
 		conversation "pirate occupation"
 	on complete
 		payment 150000
-		dialog `The government of <planet> thanks you for defeating the pirates and pays you <payment>.`
-
+		dialog phrase "generic pirate attack payment dialog"
 
 mission "Pirate Occupation [2]"
 	name `Pirates occupying <system>`
@@ -109,7 +107,7 @@ mission "Pirate Occupation [2]"
 		conversation "pirate occupation"
 	on complete
 		payment 200000
-		dialog `The government of <planet> thanks you for defeating the pirates and pays you <payment>.`
+		dialog phrase "generic pirate attack payment dialog"
 
 conversation "pirate occupation"
 	`Suddenly you hear raised voices and shouting outside as pilots run for their ships: "<destination> is being occupied by a pirate fleet! They are requesting help from any combat-worthy ship in the region to join the defenses!" The authorities of <planet> will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
@@ -119,6 +117,7 @@ conversation "pirate occupation"
 		`	(Join the defense fleet.)`
 	`A few militia pilots have gathered to help repel the pirate attack. You join them, and take off together...`
 		launch
+
 
 
 mission "Sketchy Cargo [0]"
@@ -140,7 +139,6 @@ mission "Sketchy Cargo [0]"
 		payment 0 160
 		dialog "You drop off the unlabeled cargo in a warehouse not too dissimilar to the one you picked it up in. A man dressed in a cloak hands you <payment> after the last crate is removed from your ship."
 
-
 mission "Sketchy Cargo [1]"
 	name "Delivery to <planet>"
 	job
@@ -161,6 +159,7 @@ mission "Sketchy Cargo [1]"
 		dialog "You drop off the unlabeled cargo in a warehouse not too dissimilar to the one you picked it up in. A man dressed in a cloak hands you <payment> after the last crate is removed from your ship."
 
 
+
 mission "Sketchy Passenger [0]"
 	name "Passenger transport to <planet>"
 	job
@@ -179,7 +178,6 @@ mission "Sketchy Passenger [0]"
 	on complete
 		payment 2000 160
 		dialog "Your passengers ask that you land away from the busy spaceport center. They hand you <payment> and rush out of your ship and away from the spaceport with considerable speed."
-
 
 mission "Sketchy Passenger [1]"
 	name "Passenger transport to <planet>"

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1755,7 +1755,7 @@ mission "Courier 1"
 	on complete
 		payment
 		payment 30000
-		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>."
+		dialog phrase "generic cargo delivery payment"
 
 
 

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -27,7 +27,7 @@ mission "Wanderer Workers [0]"
 	on complete
 		payment
 		payment 10000
-		dialog "You say farewell to your <passengers> on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Wanderer Workers [1]"
 	name "Wanderer workers to <planet>"
@@ -47,7 +47,7 @@ mission "Wanderer Workers [1]"
 	on complete
 		payment
 		payment 15000
-		dialog "You say farewell to your <passengers> on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Wanderer Farmers [0]"
 	name "Wanderer farmers to <planet>"
@@ -68,7 +68,7 @@ mission "Wanderer Farmers [0]"
 	on complete
 		payment
 		payment 10000
-		dialog "You say farewell to your <passengers> on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Wanderer Farmers [1]"
 	name "Wanderer farmers to <planet>"
@@ -89,7 +89,7 @@ mission "Wanderer Farmers [1]"
 	on complete
 		payment
 		payment 15000
-		dialog "You say farewell to your <passengers> on <planet>, and collect your payment of <payment>."
+		dialog phrase "generic passenger dropoff payment"
 
 mission "Wanderer Younglings [0]"
 	name "Wanderer younglings to <planet>"
@@ -387,6 +387,12 @@ mission "Wanderer Invasive Species [1]"
 		payment 30000 200
 		dialog `After handing the plants off to other Wanderers to plant elsewhere, the <bunks> Wanderers each thank you for assisting them in keeping the plants on <planet> and hand you <payment>.`
 
+
+
+phrase "wanderer cargo delivery payment"
+	word
+		`You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>.`
+
 mission "Wanderer Cargo [0]"
 	name "Delivery to <planet>"
 	job
@@ -405,7 +411,7 @@ mission "Wanderer Cargo [0]"
 	on complete
 		payment
 		payment 2000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
 
 mission "Wanderer Cargo [1]"
 	name "Delivery to <planet>"
@@ -425,7 +431,7 @@ mission "Wanderer Cargo [1]"
 	on complete
 		payment
 		payment 4000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
 
 mission "Wanderer Cargo [2]"
 	name "Delivery to <planet>"
@@ -445,7 +451,7 @@ mission "Wanderer Cargo [2]"
 	on complete
 		payment
 		payment 6000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
 
 mission "Wanderer Cargo [3]"
 	name "Delivery to <planet>"
@@ -464,7 +470,7 @@ mission "Wanderer Cargo [3]"
 	on complete
 		payment
 		payment 8000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
 
 mission "Wanderer Cargo [4]"
 	name "Delivery to <planet>"
@@ -483,7 +489,8 @@ mission "Wanderer Cargo [4]"
 	on complete
 		payment
 		payment 10000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
+
 
 mission "Wanderer Rush Delivery [0]"
 	name "Rush delivery to <planet>"
@@ -504,7 +511,7 @@ mission "Wanderer Rush Delivery [0]"
 	on complete
 		payment
 		payment 32000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
 
 mission "Wanderer Rush Delivery [1]"
 	name "Rush delivery to <planet>"
@@ -525,7 +532,7 @@ mission "Wanderer Rush Delivery [1]"
 	on complete
 		payment
 		payment 40000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
 
 mission "Wanderer Rush Delivery [2]"
 	name "Rush delivery to <planet>"
@@ -545,7 +552,7 @@ mission "Wanderer Rush Delivery [2]"
 	on complete
 		payment
 		payment 44000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
 
 mission "Wanderer Rush Delivery [3]"
 	name "Rush delivery to <planet>"
@@ -565,7 +572,8 @@ mission "Wanderer Rush Delivery [3]"
 	on complete
 		payment
 		payment 50000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
+
 
 mission "Wanderer Bulk Delivery [0]"
 	name "Bulk delivery to <planet>"
@@ -585,7 +593,7 @@ mission "Wanderer Bulk Delivery [0]"
 	on complete
 		payment
 		payment 10000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
 
 mission "Wanderer Bulk Delivery [1]"
 	name "Bulk delivery to <planet>"
@@ -605,7 +613,7 @@ mission "Wanderer Bulk Delivery [1]"
 	on complete
 		payment
 		payment 14000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"
 
 mission "Wanderer Bulk Delivery [2]"
 	name "Bulk delivery to <planet>"
@@ -624,4 +632,4 @@ mission "Wanderer Bulk Delivery [2]"
 	on complete
 		payment
 		payment 20000
-		dialog "You drop off your cargo of <commodity>. The Wanderers thank you and you collect your payment of <payment>."
+		dialog phrase "wanderer cargo delivery payment"

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Color.h"
 #include "Command.h"
 #include "Conversation.h"
+#include "DataNode.h"
 #include "FillShader.h"
 #include "Font.h"
 #include "FontSet.h"
@@ -173,6 +174,26 @@ void Dialog::Draw()
 		Point barPos(stringPos.X() + font.Width(truncated) + 2., inputPos.Y());
 		FillShader::Fill(barPos, Point(1., 16.), dim);
 	}
+}
+
+
+
+// Format and add the text from the given node to the given string.
+void Dialog::ParseTextNode(const DataNode &node, size_t startingIndex, string &text)
+{
+	for(int i = startingIndex; i < node.Size(); ++i)
+	{
+		if(!text.empty())
+			text += "\n\t";
+		text += node.Token(i);
+	}
+	for(const DataNode &child : node)
+		for(int i = 0; i < child.Size(); ++i)
+		{
+			if(!text.empty())
+				text += "\n\t";
+			text += child.Token(i);
+		}
 }
 
 

--- a/source/Dialog.h
+++ b/source/Dialog.h
@@ -21,6 +21,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <functional>
 #include <string>
 
+class DataNode;
 class PlayerInfo;
 class System;
 
@@ -56,6 +57,9 @@ template <class T>
 	
 	// Draw this panel.
 	virtual void Draw() override;
+	
+	// Static method used to convert a DataNode into formatted Dialog text.
+	static void ParseTextNode(const DataNode &node, size_t startingIndex, std::string &text);
 	
 	
 protected:

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -129,24 +129,6 @@ namespace {
 		}
 		return available;
 	}
-	
-	// Parse the given node's text for a log or simple dialog.
-	void ParseSimpleText(string &text, bool isSpecial, const DataNode &node)
-	{
-		for(int i = isSpecial ? 3 : 1; i < node.Size(); ++i)
-		{
-			if(!text.empty())
-				text += "\n\t";
-			text += node.Token(i);
-		}
-		for(const DataNode &child : node)
-			for(int i = 0; i < child.Size(); ++i)
-			{
-				if(!text.empty())
-					text += "\n\t";
-				text += child.Token(i);
-			}
-	}
 }
 
 
@@ -176,7 +158,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			bool isSpecial = (child.Size() >= 3);
 			string &text = (isSpecial ?
 				specialLogText[child.Token(1)][child.Token(2)] : logText);
-			ParseSimpleText(text, isSpecial, child);
+			Dialog::ParseTextNode(child, isSpecial ? 3 : 1, text);
 		}
 		else if(key == "dialog")
 		{
@@ -198,7 +180,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 					firstGrand.PrintTrace("Skipping unsupported dialog phrase syntax:");
 			}
 			else
-				ParseSimpleText(dialogText, false, child);
+				Dialog::ParseTextNode(child, 1, dialogText);
 		}
 		else if(key == "conversation" && child.HasChildren())
 			conversation.Load(child);

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -129,6 +129,24 @@ namespace {
 		}
 		return available;
 	}
+	
+	// Parse the given node's text for a log or simple dialog.
+	void ParseSimpleText(string &text, bool isSpecial, const DataNode &node)
+	{
+		for(int i = isSpecial ? 3 : 1; i < node.Size(); ++i)
+		{
+			if(!text.empty())
+				text += "\n\t";
+			text += node.Token(i);
+		}
+		for(const DataNode &child : node)
+			for(int i = 0; i < child.Size(); ++i)
+			{
+				if(!text.empty())
+					text += "\n\t";
+				text += child.Token(i);
+			}
+	}
 }
 
 
@@ -153,24 +171,34 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 		const string &key = child.Token(0);
 		bool hasValue = (child.Size() >= 2);
 		
-		if(key == "log" || key == "dialog")
+		if(key == "log")
 		{
-			bool isSpecial = (key == "log" && child.Size() >= 3);
-			string &text = (key == "dialog" ? dialogText :
-				isSpecial ? specialLogText[child.Token(1)][child.Token(2)] : logText);
-			for(int i = isSpecial ? 3 : 1; i < child.Size(); ++i)
+			bool isSpecial = (child.Size() >= 3);
+			string &text = (isSpecial ?
+				specialLogText[child.Token(1)][child.Token(2)] : logText);
+			ParseSimpleText(text, isSpecial, child);
+		}
+		else if(key == "dialog")
+		{
+			// Dialog text may be supplied from a stock named phrase, a
+			// private unnamed phrase, or directly specified.
+			if(hasValue && child.Token(1) == "phrase")
 			{
-				if(!text.empty())
-					text += "\n\t";
-				text += child.Token(i);
+				if(!child.HasChildren() && child.Size() == 3)
+					stockDialogPhrase = GameData::Phrases().Get(child.Token(2));
+				else
+					child.PrintTrace("Skipping unsupported dialog phrase syntax:");
 			}
-			for(const DataNode &grand : child)
-				for(int i = 0; i < grand.Size(); ++i)
-				{
-					if(!text.empty())
-						text += "\n\t";
-					text += grand.Token(i);
-				}
+			else if(!hasValue && child.HasChildren() && (*child.begin()).Token(0) == "phrase")
+			{
+				const DataNode &firstGrand = (*child.begin());
+				if(firstGrand.Size() == 1 && firstGrand.HasChildren())
+					dialogPhrase.Load(firstGrand);
+				else
+					firstGrand.PrintTrace("Skipping unsupported dialog phrase syntax:");
+			}
+			else
+				ParseSimpleText(dialogText, false, child);
 		}
 		else if(key == "conversation" && child.HasChildren())
 			conversation.Load(child);
@@ -486,6 +514,10 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 		for(const auto &eit : it.second)
 			result.specialLogText[it.first][eit.first] = Format::Replace(eit.second, subs);
 	
+	// Create any associated dialog text from phrases, or use the directly specified text.
+	string dialogText = stockDialogPhrase ? stockDialogPhrase->Get()
+		: (!dialogPhrase.Name().empty() ? dialogPhrase.Get()
+		: this->dialogText);
 	if(!dialogText.empty())
 		result.dialogText = Format::Replace(dialogText, subs);
 	

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -16,6 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "ConditionSet.h"
 #include "Conversation.h"
 #include "LocationFilter.h"
+#include "Phrase.h"
 
 #include <map>
 #include <memory>
@@ -73,6 +74,8 @@ private:
 	std::map<std::string, std::map<std::string, std::string>> specialLogText;
 	
 	std::string dialogText;
+	const Phrase *stockDialogPhrase = nullptr;
+	Phrase dialogPhrase;
 	
 	const Conversation *stockConversation = nullptr;
 	Conversation conversation;

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -97,21 +97,7 @@ void NPC::Load(const DataNode &node)
 		else if(child.Token(0) == "personality")
 			personality.Load(child);
 		else if(child.Token(0) == "dialog")
-		{
-			for(int i = 1; i < child.Size(); ++i)
-			{
-				if(!dialogText.empty())
-					dialogText += "\n\t";
-				dialogText += child.Token(i);
-			}
-			for(const DataNode &grand : child)
-				for(int i = 0; i < grand.Size(); ++i)
-				{
-					if(!dialogText.empty())
-						dialogText += "\n\t";
-					dialogText += grand.Token(i);
-				}
-		}
+			Dialog::ParseTextNode(child, 1, dialogText);
 		else if(child.Token(0) == "conversation" && child.HasChildren())
 			conversation.Load(child);
 		else if(child.Token(0) == "conversation" && child.Size() > 1)

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Fleet.h"
 #include "LocationFilter.h"
 #include "Personality.h"
+#include "Phrase.h"
 
 #include <string>
 #include <list>
@@ -76,6 +77,9 @@ private:
 	
 	// Dialog or conversation to show when all requirements for this NPC are met:
 	std::string dialogText;
+	const Phrase *stockDialogPhrase = nullptr;
+	Phrase dialogPhrase;
+	
 	Conversation conversation;
 	const Conversation *stockConversation = nullptr;
 	

--- a/source/Phrase.h
+++ b/source/Phrase.h
@@ -20,7 +20,7 @@ class DataNode;
 
 
 
-// Class representing a set of rules for generating random ship names.
+// Class representing a set of rules for generating text strings from words.
 class Phrase {
 public:
 	void Load(const DataNode &node);


### PR DESCRIPTION
Refs #1856 

This PR introduces reserved syntax for the combination of the `dialog` tag and the `phrase` tag when defining text for dialog pop-ups shown in missions' `on ____` actions and in NPCs' "completion".

Includes some examples in the existing datafiles, and otherwise generally extracts repeated text to a single location (so that it can be more easily diversified by future pulls).

Preferred syntax:
```
dialog phrase <stock phrase name>
```
a "stock phrase" is any phrase defined as a root level `DataNode`--i.e. the first thing on a new line:
```
phrase "hostile disabled"
    word
        ...
```
(see `hails.txt` and `names.txt` for lots more examples of root-level `Phrase`s and complex phrase construction.

Also supported: nested phrase specification
```
dialog
    phrase
        word
            ...
        word
            ...
```

**Any other usage of `phrase` with `dialog` is unsupported, including mixing regular directly-specified text and phrase-generated lines.** If you wish to do that, do it all in a custom phrase. You can define phrase parts as stock, in order to use them as such:
```
phrase "post-noun thanking"
    word
        ` `
        ` graciously `
        ` profusely `
    word
        `thanks you for your time.`

mission "do the thing with Jim-Bob"
    on complete
        dialog
            phrase
                word
                    `Jim Bob`
                phrase
                    `post-noun thanking`
```

Affected existing data: Any existing missions where the keyword `dialog` is followed by the word `phrase` possibly quoted (but not part of a larger token like "phrase you've heard before"), or where the `dialog` keyword is the end of its current line and the only token on the following indented child line is the possibly quoted word `phrase`, will be interpreted differently.

