### PR TITLE
Increase crew attack and defense for Coalition species

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -35,7 +35,7 @@ government "Bounty Hunter"
 government "Coalition"
 	swizzle 5
 	color 1 .6 .7
-	"crew attack" 2
+	"crew attack" .6
 	"crew defense" 3
 	language "Coalition"
 	"player reputation" 1

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -35,6 +35,8 @@ government "Bounty Hunter"
 government "Coalition"
 	swizzle 5
 	color 1 .6 .7
+	"crew attack" 2
+	"crew defense" 3
 	language "Coalition"
 	"player reputation" 1
 	"attitude toward"
@@ -112,6 +114,8 @@ government "Hai (Unfettered)"
 government "Heliarch"
 	swizzle 0
 	color 1 .8 .5
+	"crew attack" 3
+	"crew defense" 4
 	"player reputation" 1
 	"friendly hail" "friendly heliarch"
 	"hostile hail" "hostile heliarch"


### PR DESCRIPTION
The Coalition is made up of species with increased affinity for close-quarters combat. They all move fast. Arachnids and beetles (animals the Arach and the Kimek are based upon) are carnivorous by design and have the benefit of their sturdy carapaces (natural armour) and natural weapons. Even Saryds would benefit from thick hides and strong kicks.

This proposed change reflects that.

Coalition civilians aren't taught to fight well, so they would have to rely on their natural instincts, There's also a possibility that a ship might be crewed by an all-Saryd crew (and they wouldn't be the ideal troops for fighting inside ships). Heliarch crews, however, are always mixed and are trained well to work in concert for their advantage.