### PR TITLE
Add a "battery too small to fire weapon" flight check warning

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -494,5 +494,5 @@ tip "no hyperdrive?"
 tip "no fuel?"
 	`This ship has insufficient fuel capacity to make a hyperspace jump. If it took off, it would be unable to leave this star system.`
 
-tip "less battery than firing cost?"
+tip "insufficient energy to fire?"
 	`This ship has insufficient energy storage to fire an installed weapon.`

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -493,3 +493,6 @@ tip "no hyperdrive?"
 
 tip "no fuel?"
 	`This ship has insufficient fuel capacity to make a hyperspace jump. If it took off, it would be unable to leave this star system.`
+
+tip "less battery than firing cost?"
+	`This ship has insufficient energy storage to fire an installed weapon.`

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -760,7 +760,7 @@ double Ship::MaxFiringEnergy() const
 	for(const auto &it : outfits)
 	{
 		if (it.first->IsWeapon() && it.first->Reload() > 1) {
-			maxFiringEnergy = std::max(maxFiringEnergy, it.first->FiringEnergy());
+			maxFiringEnergy = max(maxFiringEnergy, it.first->FiringEnergy());
 		}
 	}
 	return maxFiringEnergy;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -810,7 +810,7 @@ string Ship::FlightCheck() const
 	for(const auto &it : outfits)
 		if(it.first->IsWeapon() && it.first->FiringEnergy() > energy)
 			return "insufficient energy to fire?";
-
+	
 	return "";
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -95,7 +95,7 @@ namespace {
 		double maxFiringEnergy = 0.0;
 		for(const auto &it : outfits)
 			{
-				if (it.first->IsWeapon() && it.first->Reload() > 1) {
+				if (it.first->IsWeapon()) {
 					maxFiringEnergy = max(maxFiringEnergy, it.first->FiringEnergy());
 				}
 			}
@@ -824,7 +824,7 @@ string Ship::FlightCheck() const
 		if(fuelCapacity < JumpFuel())
 			return "no fuel?";
 	}
-	if(battery < maxWeaponEnergy)
+	if((generation + battery + solar) < maxWeaponEnergy)
 		return "insufficient energy to fire?";
 
 	return "";

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -85,6 +85,22 @@ namespace {
 			fuel -= transfer * fuelCost;
 		}
 	}
+
+	
+
+	// Get the maximum firing energy among all installed weapons that
+	// don't fire continuously (like beams do).
+	double MaxWeaponEnergy(const map<const Outfit *, int> &outfits)
+	{
+		double maxFiringEnergy = 0.0;
+		for(const auto &it : outfits)
+			{
+				if (it.first->IsWeapon() && it.first->Reload() > 1) {
+					maxFiringEnergy = max(maxFiringEnergy, it.first->FiringEnergy());
+				}
+			}
+		return maxFiringEnergy;
+	}
 }
 
 const vector<string> Ship::CATEGORIES = {
@@ -752,22 +768,6 @@ int64_t Ship::ChassisCost() const
 
 
 
-// Get the maximum firing energy among all installed weapons that
-// don't fire continuously (like beams do).
-double Ship::MaxFiringEnergy() const
-{
-	double maxFiringEnergy = 0.0;
-	for(const auto &it : outfits)
-	{
-		if (it.first->IsWeapon() && it.first->Reload() > 1) {
-			maxFiringEnergy = max(maxFiringEnergy, it.first->FiringEnergy());
-		}
-	}
-	return maxFiringEnergy;
-}
-
-
-
 // Check if this ship is configured in such a way that it would be difficult
 // or impossible to fly.
 string Ship::FlightCheck() const
@@ -788,7 +788,7 @@ string Ship::FlightCheck() const
 	double turnEnergy = attributes.Get("turning energy");
 	double hyperDrive = attributes.Get("hyperdrive");
 	double jumpDrive = attributes.Get("jump drive");
-	double maxFiringEnergy = MaxFiringEnergy();
+	double maxWeaponEnergy = MaxWeaponEnergy(outfits);
 	
 	// Error conditions:
 	if(IdleHeat() >= MaximumHeat())
@@ -824,7 +824,7 @@ string Ship::FlightCheck() const
 		if(fuelCapacity < JumpFuel())
 			return "no fuel?";
 	}
-	if(battery < maxFiringEnergy)
+	if(battery < maxWeaponEnergy)
 		return "insufficient energy to fire?";
 
 	return "";

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -825,7 +825,7 @@ string Ship::FlightCheck() const
 			return "no fuel?";
 	}
 	if(battery < maxFiringEnergy)
-		return "less battery than firing cost?";
+		return "insufficient energy to fire?";
 
 	return "";
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -85,22 +85,6 @@ namespace {
 			fuel -= transfer * fuelCost;
 		}
 	}
-
-	
-
-	// Get the maximum firing energy among all installed weapons that
-	// don't fire continuously (like beams do).
-	double MaxWeaponEnergy(const map<const Outfit *, int> &outfits)
-	{
-		double maxFiringEnergy = 0.0;
-		for(const auto &it : outfits)
-			{
-				if (it.first->IsWeapon()) {
-					maxFiringEnergy = max(maxFiringEnergy, it.first->FiringEnergy());
-				}
-			}
-		return maxFiringEnergy;
-	}
 }
 
 const vector<string> Ship::CATEGORIES = {
@@ -788,7 +772,6 @@ string Ship::FlightCheck() const
 	double turnEnergy = attributes.Get("turning energy");
 	double hyperDrive = attributes.Get("hyperdrive");
 	double jumpDrive = attributes.Get("jump drive");
-	double maxWeaponEnergy = MaxWeaponEnergy(outfits);
 	
 	// Error conditions:
 	if(IdleHeat() >= MaximumHeat())
@@ -824,8 +807,9 @@ string Ship::FlightCheck() const
 		if(fuelCapacity < JumpFuel())
 			return "no fuel?";
 	}
-	if((generation + battery + solar) < maxWeaponEnergy)
-		return "insufficient energy to fire?";
+	for(const auto &it : outfits)
+		if(it.first->IsWeapon() && it.first->FiringEnergy() > energy)
+			return "insufficient energy to fire?";
 
 	return "";
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -752,6 +752,22 @@ int64_t Ship::ChassisCost() const
 
 
 
+// Get the maximum firing energy among all installed weapons that
+// don't fire continuously (like beams do).
+double Ship::MaxFiringEnergy() const
+{
+	double maxFiringEnergy = 0.0;
+	for(const auto &it : outfits)
+	{
+		if (it.first->IsWeapon() && it.first->Reload() > 1) {
+			maxFiringEnergy = std::max(maxFiringEnergy, it.first->FiringEnergy());
+		}
+	}
+	return maxFiringEnergy;
+}
+
+
+
 // Check if this ship is configured in such a way that it would be difficult
 // or impossible to fly.
 string Ship::FlightCheck() const
@@ -772,6 +788,7 @@ string Ship::FlightCheck() const
 	double turnEnergy = attributes.Get("turning energy");
 	double hyperDrive = attributes.Get("hyperdrive");
 	double jumpDrive = attributes.Get("jump drive");
+	double maxFiringEnergy = MaxFiringEnergy();
 	
 	// Error conditions:
 	if(IdleHeat() >= MaximumHeat())
@@ -807,7 +824,9 @@ string Ship::FlightCheck() const
 		if(fuelCapacity < JumpFuel())
 			return "no fuel?";
 	}
-	
+	if(battery < maxFiringEnergy)
+		return "less battery than firing cost?";
+
 	return "";
 }
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -135,9 +135,6 @@ public:
 	int64_t Cost() const;
 	int64_t ChassisCost() const;
 
-	// Get the maximum firing energy among all installed weapons that
-	// don't fire continuously (like beams do).
-	double MaxFiringEnergy() const;
 	// Check if this ship is configured in such a way that it would be difficult
 	// or impossible to fly.
 	std::string FlightCheck() const;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -134,6 +134,10 @@ public:
 	// Get this ship's cost.
 	int64_t Cost() const;
 	int64_t ChassisCost() const;
+
+	// Get the maximum firing energy among all installed weapons that
+	// don't fire continuously (like beams do).
+	double MaxFiringEnergy() const;
 	// Check if this ship is configured in such a way that it would be difficult
 	// or impossible to fly.
 	std::string FlightCheck() const;


### PR DESCRIPTION
New players may be confused if their projectile weapons don't fire even though their energy bar is full. This PR adds a flight check warning that warns the player if a ship has a non-continuously-firing weapon installed that requires more energy than the ship has energy storage.

Here's an example shuttle with no energy storage that has an energy blaster installed:
<img width="1280" alt="screen shot 2019-02-05 at 12 57 42 am" src="https://user-images.githubusercontent.com/1474501/52255789-f4b89180-28e1-11e9-83ec-ee04ef97bc66.png">

Here's the same shuttle with a beam laser, which produces no warning since it fires continuously:
<img width="1280" alt="screen shot 2019-02-05 at 12 57 20 am" src="https://user-images.githubusercontent.com/1474501/52255809-11ed6000-28e2-11e9-8a0e-8b01cd7269c4.png">




