### PR TITLE
Specify an initial planet for mission NPCs

### DIFF
--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -676,11 +676,13 @@ mission "FW Syndicate Capture 1"
 		government "Free Worlds"
 	
 	npc accompany save
+		planet "Luna"
 		personality escort heroic waiting
 		government "Navy (Oathkeeper)"
 		ship "Cruiser (Mark II)" "N.S. Hand of Justice"
 	
 	npc accompany save
+		planet "Mars"
 		personality escort heroic waiting
 		government "Deep Security"
 		ship "Bactrian" "Unbreakable"

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -20,6 +20,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "GameData.h"
 #include "Government.h"
 #include "Messages.h"
+#include "Planet.h"
 #include "PlayerInfo.h"
 #include "Random.h"
 #include "Ship.h"
@@ -84,6 +85,8 @@ void NPC::Load(const DataNode &node)
 			else
 				location.Load(child);
 		}
+		else if(child.Token(0) == "planet" && child.Size() >= 2)
+			planet = GameData::Planets().Get(child.Token(1));
 		else if(child.Token(0) == "succeed" && child.Size() >= 2)
 			succeedIf = child.Value(1);
 		else if(child.Token(0) == "fail" && child.Size() >= 2)
@@ -408,6 +411,9 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 		result.system = location.PickSystem(origin);
 	if(!result.system)
 		result.system = (isAtDestination && destination) ? destination : origin;
+	// If a planet was specified in the template, it must be in this system.
+	if(planet && result.system->FindStellar(planet))
+		result.planet = planet;
 	
 	// Convert fleets into instances of ships.
 	for(const shared_ptr<Ship> &ship : ships)
@@ -438,6 +444,12 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 		
 		if(personality.IsEntering())
 			Fleet::Enter(*result.system, *ship);
+		else if(result.planet)
+		{
+			// A valid planet was specified in the template, so these NPCs start out landed.
+			ship->SetSystem(result.system);
+			ship->SetPlanet(result.planet);
+		}
 		else
 			Fleet::Place(*result.system, *ship);
 	}

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -26,6 +26,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 class DataNode;
 class DataWriter;
 class Government;
+class Planet;
 class PlayerInfo;
 class Ship;
 class ShipEvent;
@@ -73,6 +74,8 @@ private:
 	LocationFilter location;
 	const System *system = nullptr;
 	bool isAtDestination = false;
+	// Start out landed on this planet.
+	const Planet *planet = nullptr;
 	
 	// Dialog or conversation to show when all requirements for this NPC are met:
 	std::string dialogText;


### PR DESCRIPTION
This PR would allow content creators to build off #4111 , and enable a mission's NPC to start out landed on a specific planet. If the specified planet is not in the instantiated NPC's system, then the planet specification is ignored.

e.g.
```
npc
    system "Sol"
    planet "Luna"
    government "Korath"
    fleet "Korath Raid"
```

will result in a Korath raid fleet taking off from Luna when the player next takes off, while
```
npc
    planet "Hevru Hai"
    government "Quarg"
    fleet "Large Quarg"
```
will only result in a large Quarg fleet departing from Hevru Hai if the mission is being offered from Hevru Hai (as the default system when unspecified is the mission's origin system).

The requirement to specify the proper system in addition to the planet ensures that the NPCs will be in the proper system even if the referenced planet is a wormhole (which has multiple systems). If we are ok with being unable to specify the appropriate wormhole planet properly, this requirement can be dropped and the PR amended to allow specifying just `planet` or both `system` and `planet`. 


Refs #2375 

----

test binary available from AppVeyor here: https://ci.appveyor.com/project/tehhowch/endless-sky/builds/22152377/artifacts
test missions: 
[depart-test-mission.txt](https://github.com/endless-sky/endless-sky/files/2834176/depart-test-mission.txt)
