### PR TITLE
Adding the "Marked" Personality to the target of the 2nd Remnant Bounty job

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -1143,7 +1143,7 @@ mission "Remnant: Bounty 2"
 		random < 60
 	npc kill
 		government "Korath"
-		personality heroic vindictive target uninterested waiting
+		personality heroic vindictive target uninterested waiting marked
 		system
 			distance 1 2
 		fleet


### PR DESCRIPTION
Adding the "Marked" personality to the target ship for the second Remnant Bounty mission so that the Remnant will leave it alone. Otherwise it is too easy for the player (not to mention harder to salvage from). And most importantly, so it works as intended.