### PR TITLE
Added new assisting/boarding missions

### DIFF
--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -108,6 +108,7 @@ mission "Assisting Free Worlds"
 		random < 5
 	source
 		government "Free Worlds"
+		not category "Fighter" "Drone"
 	destination
 		government "Free Worlds"
 		distance 2 4
@@ -139,6 +140,7 @@ mission "Assisting Republic"
 		random < 5
 	source
 		government "Republic"
+		not category "Fighter" "Drone"
 	destination
 		government "Republic"
 		distance 2 4
@@ -170,6 +172,7 @@ mission "Assisting Deep Security"
 		random < 5
 	source
 		government "Deep Security"
+		not category "Fighter" "Drone"
 	destination
 		attributes "deep"
 		distance 2 4
@@ -201,6 +204,7 @@ mission "Assisting Syndicate"
 		random < 5
 	source
 		government "Syndicate"
+		not category "Fighter" "Drone"
 	destination
 		government "Syndicate"
 		distance 2 4

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -8,21 +8,320 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-mission "Assisting Merchant"
+conversation "assisting merchant"
+	`When you repair the <origin>, the captain thanks you for your assistance and pays you <payment>.`
+		decline
+
+mission "Assisting Merchant (Small)"
 	assisting
 	repeat
+	minor
+	to offer
+		random < 20
+	source
+		government "Merchant"
+		category "Interceptor" "Light Warship" "Transport" "Light Freighter"
+	on offer
+		payment 10000
+		conversation "assisting merchant"
+	# A mission with no destination will not be offered, so give it one.
+	# What the destination is doesn't matter, because you always 'decline' this.
+	destination "Earth"
+
+mission "Assisting Merchant (Medium)"
+	assisting
+	repeat
+	minor
+	to offer
+		random < 15
+	source
+		government "Merchant"
+		category "Medium Warship" "Heavy Freighter"
+	on offer
+		payment 20000
+		conversation "assisting merchant"
+	destination "Earth"
+
+mission "Assisting Merchant (Large)"
+	assisting
+	repeat
+	minor
 	to offer
 		random < 10
 	source
-		government Merchant
+		government "Merchant"
+		category "Heavy Warship"
 	on offer
-		payment 10000
+		payment 30000
+		conversation "assisting merchant"
+	destination "Earth"
+
+
+
+mission "Dangerous Journey"
+	assisting
+	minor
+	name "Delivery to <planet>"
+	description "Deliver <cargo> to <destination>. Payment is <payment>."
+	to offer
+		random < 10
+	source
+		government "Merchant"
+		category "Light Freighter" "Heavy Freighter"
+	destination
+		government "Republic" "Syndicate" "Free Worlds"
+		attributes "frontier"
+		distance 2 3
+	cargo random 5 2 .1
+	on offer
 		conversation
-			`When you repair the <origin>, the captain thanks you for your assistance and pays you <payment>.`
-				decline
-	# A mission with no destination will not be offered, so give it one.
-	# What the destination is doesn't matter, because you always 'decline' this.
-	destination Earth
+			`When you repair the <origin>, the captain hails you. "This is the second time I've nearly died in the past week doing this job! Here, take this <cargo> to <destination> and finish this job for me. They said the payment is <payment>."`
+			choice
+				`	(Take the cargo.)`
+					accept
+				`	(Don't take the cargo.)`
+			`	The captain begins swearing you out, so you cut the feed. Hopefully they make it to their destination in one piece.`
+					decline
+	on complete
+		payment 7500
+		dialog `You drop off your cargo of <commodity>, explain how the original merchant who took the job quit and handed off the cargo to you, and collect your payment of <payment>.`
+
+
+
+conversation "assisting law enforcement"
+	`The captain of the <origin> thanks you for repairing them, but informs you that the pirates that disabled them are only a smaller part of a fleet attacking <destination>.`
+	`	The authorities of <planet> will probably pay you quite well if you assist them, but this could also be an easy way to get yourself killed.`
+	choice
+		`	(Don't join the fight.)`
+			decline
+		`	(Join the defense fleet.)`
+			accept
+
+mission "Assisting Free Worlds"
+	assisting
+	repeat
+	minor
+	name "Defend <planet>"
+	description "Defeat a pirate raid on <destination>."
+	to offer
+		"combat rating" > 100
+		random < 5
+	source
+		government "Free Worlds"
+	destination
+		government "Free Worlds"
+		distance 2 4
+	on offer
+		conversation "assisting law enforcement"
+	npc kill
+		government "Pirate"
+		personality heroic staying target harvests plunders
+		system destination
+		fleet "Large Southern Pirates" 2
+		fleet "Small Southern Pirates"
+	npc
+		government "Free Worlds"
+		personality heroic staying
+		system destination
+		fleet "Large Free Worlds"
+	on complete
+		payment 150000
+		dialog phrase "generic pirate attack payment dialog"
+
+mission "Assisting Republic"
+	assisting
+	repeat
+	minor
+	name "Defend <planet>"
+	description "Defeat a pirate raid on <destination>."
+	to offer
+		"combat rating" > 100
+		random < 5
+	source
+		government "Republic"
+	destination
+		government "Republic"
+		distance 2 4
+	on offer
+		conversation "assisting law enforcement"
+	npc kill
+		government "Pirate"
+		personality heroic staying target harvests plunders
+		system destination
+		fleet "Large Northern Pirates" 2
+		fleet "Small Northern Pirates"
+	npc
+		government "Republic"
+		personality heroic staying
+		system destination
+		fleet "Small Republic" 2
+	on complete
+		payment 150000
+		dialog phrase "generic pirate attack payment dialog"
+
+mission "Assisting Deep Security"
+	assisting
+	repeat
+	minor
+	name "Defend <planet>"
+	description "Defeat a pirate raid on <destination>."
+	to offer
+		"combat rating" > 100
+		random < 5
+	source
+		government "Deep Security"
+	destination
+		attributes "deep"
+		distance 2 4
+	on offer
+		conversation "assisting law enforcement"
+	npc kill
+		government "Pirate"
+		personality heroic staying target harvests plunders
+		system destination
+		fleet "Large Northern Pirates" 2
+		fleet "Small Northern Pirates"
+	npc
+		government "Deep Security"
+		personality heroic staying
+		system destination
+		fleet "Large Deep Security"
+	on complete
+		payment 150000
+		dialog phrase "generic pirate attack payment dialog"
+
+mission "Assisting Syndicate"
+	assisting
+	repeat
+	minor
+	name "Defend <planet>"
+	description "Defeat a pirate raid on <destination>."
+	to offer
+		"combat rating" > 100
+		random < 5
+	source
+		government "Syndicate"
+	destination
+		government "Syndicate"
+		distance 2 4
+	on offer
+		conversation "assisting law enforcement"
+	npc kill
+		government "Pirate"
+		personality heroic staying target harvests plunders
+		system destination
+		fleet "Large Core Pirates" 2
+		fleet "Small Core Pirates"
+	npc
+		government "Syndicate"
+		personality heroic staying
+		system destination
+		fleet "Large Syndicate"
+	on complete
+		payment 150000
+		dialog phrase "generic pirate attack payment dialog"
+
+
+
+conversation "boarding pirate"
+	`You make short-range scans of the <origin>'s outfits and cargo. Among the cargo, you find a crate full of credit chips worth <payment>. It looks like you've struck gold.`
+		decline
+
+mission "Boarding Pirate (Small)"
+	boarding
+	repeat
+	minor
+	to offer
+		random < 7
+	source
+		government "Pirate"
+		category "Interceptor" "Light Warship" "Transport" "Light Freighter"
+	on offer
+		payment 50000
+		conversation "boarding pirate"
+	destination "Earth"
+
+mission "Boarding Pirate (Medium)"
+	boarding
+	repeat
+	minor
+	to offer
+		random < 5
+	source
+		government "Pirate"
+		category "Medium Warship" "Heavy Freighter"
+	on offer
+		payment 100000
+		conversation "boarding pirate"
+	destination "Earth"
+
+mission "Boarding Pirate (Large)"
+	boarding
+	repeat
+	minor
+	to offer
+		random < 3
+	source
+		government "Pirate"
+		category "Heavy Warship"
+	on offer
+		payment 150000
+		conversation "boarding pirate"
+	destination "Earth"
+
+
+
+mission "Pirate Ambush"
+	invisible
+	boarding
+	repeat
+	minor
+	deadline 1
+	to offer
+		"combat rating" > 100
+		random < 5
+	source
+		government "Pirate"
+		category "Interceptor" "Light Warship" "Transport" "Light Freighter"
+	on offer
+		conversation
+			`You board the <origin>, but find no crew aboard. When you reach the cockpit of the ship, you look out into space to see an escape pod floating away. The <origin> is emitting a distress signal to nearby pirates, and a self destruct sequence has been activated. It looks like you're about to have company.`
+				launch
+	
+	npc kill
+		government "Pirate"
+		personality nemisis harvests plunders entering
+		fleet "pirate raid" 2
+
+
+
+mission "Pirate Mutiny"
+	boarding
+	minor
+	description "Bring <bunks> ex-pirate crew members to <destination>."
+	to offer
+		random < 10
+	source
+		government "Pirate"
+		category "Medium Warship" "Heavy Warship"
+	destination
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		distance 2 4
+	passengers 10 20
+	on offer
+		conversation
+			`When you board the <origin>, you find most of the crew already dead. One of the surviving crew members, who looks like a teenaged boy no older than 16, approaches you with his hands in the air. He explains that after the ship was disabled, a section of the crew decided to overthrow the tyrannous captain. He continues, saying how most pirate crew members are forced into servitude on pirate ships. The surviving <bunks> crew members beg you to bring them to <destination> so that they can escape from their lives of piracy.`
+			`	The fight seems to have damaged the ship beyond repair. This ship may not last much longer in the vacuum of space if you leave the pirates here.`
+			choice
+				`	(Help the pirate crew.)`
+					launch
+				`	(Leave the pirate crew.)`
+					flee
+	on complete
+		payment 25000
+		dialog `The pirate crew members thank you for bringing them to <planet>. One of them hands you a small payment of <payment>. You wish them all the best of luck with their new lives and part ways.`
+
+
 
 mission "Assisting Hai"
 	assisting
@@ -30,10 +329,10 @@ mission "Assisting Hai"
 	to offer
 		random < 27
 	source
-		government Hai
+		government "Hai"
 	on offer
 		payment 30000
 		conversation
 			`Knowing you risked your life to save the <origin>, the captain gives you <payment>.`
 				decline
-	destination Hai-home
+	destination "Hai-home"

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -80,7 +80,7 @@ mission "Dangerous Journey"
 				`	(Take the cargo.)`
 					accept
 				`	(Don't take the cargo.)`
-			`	The captain begins swearing you out, so you cut the feed. Hopefully they make it to their destination in one piece.`
+			`	The captain begins cussing you out, so you cut the feed. Hopefully they make it to their destination in one piece.`
 					decline
 	on complete
 		payment 7500

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -294,7 +294,7 @@ mission "Pirate Ambush"
 	
 	npc kill
 		government "Pirate"
-		personality nemisis harvests plunders entering
+		personality nemesis harvests plunders entering
 		fleet "pirate raid" 2
 
 

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -228,7 +228,7 @@ mission "Assisting Syndicate"
 
 
 conversation "boarding pirate"
-	`You make short-range scans of the <origin>'s outfits and cargo. Among the cargo, you find a crate full of credit chips worth <payment>. It looks like you've struck gold.`
+	`You make short-range scans of the <origin>'s outfits and cargo. Among the cargo, you find a crate full of credit chips worth <payment>. You drag the crate onto your ship before deciding to make your next move.`
 		decline
 
 mission "Boarding Pirate (Small)"
@@ -289,7 +289,7 @@ mission "Pirate Ambush"
 		category "Interceptor" "Light Warship" "Transport" "Light Freighter"
 	on offer
 		conversation
-			`You board the <origin>, but find no crew aboard. When you reach the cockpit of the ship, you look out into space to see an escape pod floating away. The <origin> is emitting a distress signal to nearby pirates, and a self destruct sequence has been activated. It looks like you're about to have company.`
+			`You board the <origin>, but find no crew aboard. When you reach the cockpit of the ship, you look out into space to see an escape pod floating away. The <origin> is emitting a distress signal to nearby pirates, and a self destruct sequence has been activated. You run back to your ship and get ready to fight.`
 				launch
 	destination "Earth"
 	npc kill

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -291,7 +291,7 @@ mission "Pirate Ambush"
 		conversation
 			`You board the <origin>, but find no crew aboard. When you reach the cockpit of the ship, you look out into space to see an escape pod floating away. The <origin> is emitting a distress signal to nearby pirates, and a self destruct sequence has been activated. It looks like you're about to have company.`
 				launch
-	
+	destination "Earth"
 	npc kill
 		government "Pirate"
 		personality nemesis harvests plunders entering

--- a/data/boarding missions.txt
+++ b/data/boarding missions.txt
@@ -75,12 +75,12 @@ mission "Dangerous Journey"
 	cargo random 5 2 .1
 	on offer
 		conversation
-			`When you repair the <origin>, the captain hails you. "This is the second time I've nearly died in the past week doing this job! Here, take this <cargo> to <destination> and finish this job for me. They said the payment is <payment>."`
+			`When you repair the <origin>, the captain hails you. "This is the fourth time I've nearly died in the past week doing this job! Here, take this <cargo> to <destination> and finish this job for me. They said the payment is <payment>."`
 			choice
 				`	(Take the cargo.)`
 					accept
 				`	(Don't take the cargo.)`
-			`	The captain begins cussing you out, so you cut the feed. Hopefully they make it to their destination in one piece.`
+			`	The captain begins loudly swearing, so you cut the feed. Hopefully they make it to their destination in one piece.`
 					decline
 	on complete
 		payment 7500
@@ -228,7 +228,7 @@ mission "Assisting Syndicate"
 
 
 conversation "boarding pirate"
-	`You make short-range scans of the <origin>'s outfits and cargo. Among the cargo, you find a crate full of credit chips worth <payment>. You drag the crate onto your ship before deciding to make your next move.`
+	`You make short-range scans of the <origin>'s outfits and cargo. Among the cargo, you find a crate full of credit chips worth <payment>. You drag the crate onto your ship before considering your next move.`
 		decline
 
 mission "Boarding Pirate (Small)"
@@ -289,7 +289,7 @@ mission "Pirate Ambush"
 		category "Interceptor" "Light Warship" "Transport" "Light Freighter"
 	on offer
 		conversation
-			`You board the <origin>, but find no crew aboard. When you reach the cockpit of the ship, you look out into space to see an escape pod floating away. The <origin> is emitting a distress signal to nearby pirates, and a self destruct sequence has been activated. You run back to your ship and get ready to fight.`
+			`You board the <origin>, but find no crew aboard. When you reach the cockpit of the ship, you look out into space to see an escape pod floating away. The <origin> is emitting a distress signal to nearby pirates, and a self destruct sequence has been activated! You run back to your ship and get ready to fight.`
 				launch
 	destination "Earth"
 	npc kill
@@ -314,8 +314,8 @@ mission "Pirate Mutiny"
 	passengers 10 20
 	on offer
 		conversation
-			`When you board the <origin>, you find most of the crew already dead. One of the surviving crew members, who looks like a teenaged boy no older than 16, approaches you with his hands in the air. He explains that after the ship was disabled, a section of the crew decided to overthrow the tyrannous captain. He continues, saying how most pirate crew members are forced into servitude on pirate ships. The surviving <bunks> crew members beg you to bring them to <destination> so that they can escape from their lives of piracy.`
-			`	The fight seems to have damaged the ship beyond repair. This ship may not last much longer in the vacuum of space if you leave the pirates here.`
+			`When you board the <origin>, you find most of the crew already dead. One of the surviving crew members, who looks like a teenaged boy no older than 16, approaches you with his hands in the air. He explains that after the ship was disabled, a section of the crew decided to overthrow the tyrannical captain. He continues, saying how most pirate crew members are forced into servitude on pirate ships. The surviving <bunks> crew members beg you to bring them to <destination> so that they can escape from pirate slavery.`
+			`	The fight seems to have damaged the ship beyond repair. It may not last much longer in the vacuum of space if you leave the pirates here.`
 			choice
 				`	(Help the pirate crew.)`
 					launch

--- a/data/south jobs.txt
+++ b/data/south jobs.txt
@@ -14,7 +14,7 @@ mission "Pirate Occupation [0]"
 	repeat
 	description `A small band of pirates have been occupying <system>, and the local government has asked for help. Defeat the pirates in the system and land on <planet> when done. Payment is <payment>.`
 	to offer
-		random < 15
+		random < 5
 		"combat rating" > 100
 	source
 		attributes "south" "rim"
@@ -47,7 +47,7 @@ mission "Pirate Occupation [1]"
 	repeat
 	description `A gang of pirates have been occupying <system>, and the local government has asked for help. Defeat the pirates in the system and land on <planet> when done. Payment is <payment>.`
 	to offer
-		random < 10
+		random < 5
 		"combat rating" > 200
 	source
 		attributes "south" "rim"


### PR DESCRIPTION
Ref: https://github.com/endless-sky/endless-sky/pull/4139#issuecomment-457804708

Added assisting/boarding missions using the new mechanics added by #3140 and #3005.

New missions:
* Dangerous journey: Offered by assisting merchant freighters. Finish a basic cargo delivery job for a merchant captain who has been disabled twice in the past week trying to delivery the cargo to a frontier world. 
* Assisting law enforcement: Basically a planetary defense job, only offered upon assisting law enforcement ships that are not fighters or drones.
* Boarding pirate: A different take on the assisting merchant jobs. Upon boarding a pirate ship, have a small chance to find a treasure crate of credits. Credit size dependent on the ship category.
* Pirate ambush: After you've achieved a low combat rating, small pirate ships have a chance to trigger ambushes upon being boarded. Spawns two pirate raid fleets that enter the system.
* Pirate mutiny: Upon boarding a pirate ship, find that part of the crew has killed the captain and any crew loyal to him. Bring them to a safe place on a lawful planet, or leave them to die in space as the ship explodes from the damage caused by the internal struggle.
  * Note: Offered on medium and heavy warships, and has a passenger size of 10 to 20. The Manta is the only ship that it wouldn't make sense to have this offer from, as that ship only has up to 10 bunks. I don't think that's too much of an issue, though.
  * I wrote this mission in a very general way, but I am totally open to this mission being replaced in the future to be more like the Smugglers Den missions.

Other changes:
* Expanded the assisting merchant missions to have various sizes based off of the category of the source ship.
* Reduced the offer rate of pirate occupation missions in the South, as they seemed a little too common, which would only be made worse by having Free Worlds ships also offer such missions when you repair them.