### PR TITLE
Increased the cost of the Raven

### DIFF
--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -801,7 +801,7 @@ ship "Marauder Raven"
 	sprite "ship/mravens"
 	attributes
 		category "Light Warship"
-		"cost" 2250000
+		"cost" 2750000
 		"shields" 5200
 		"hull" 1600
 		"required crew" 7

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2487,7 +2487,7 @@ ship "Raven"
 	thumbnail "thumbnail/raven"
 	attributes
 		category "Light Warship"
-		"cost" 1800000
+		"cost" 2200000
 		"shields" 4700
 		"hull" 1400
 		"required crew" 6


### PR DESCRIPTION
Ref: #4051 

Increased the Raven's cost by 400k. Also increased the Marauder Raven costs accordingly.

Even without a change like #4014, the Raven and Headhunter cost are surprisingly close to one another. This PR bumps the cost of the Raven up to be more in line with the cost of other light warships, placing the cost more between the Headhunter, which is statistically weaker than the Raven, and the Modified Argosy, a bigger ship.

Table showing cost of various ships around the progression of the Raven:

Ship | Category | Sale cost
----|----|---
Hawk | Interceptor | 1.028 M
Quicksilver | Light Warship | 1.964 M
Headhunter | Light Warship | 2.540 M
Raven | Light Warship | was 2.672 M, now 3.072 M
Modified Argosy | Light Warship | 3.324 M
Manta | Medium Warship | 4.789 M