### PR TITLE
Implement heat transfer between motherships and drones/fighters

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1544,11 +1544,13 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 void Ship::DoGeneration()
 {
 	// Transfer heat to or from ships in bays before they can do their own generation.
-	if (!bays.empty()) {
+	if (!bays.empty())
+	{
 		const double area = Width() * Height();
 		const double heatDensity = heat / area;
 		for(Bay &bay : bays)
-			if(bay.ship) {
+			if(bay.ship)
+			{
 				const double bayArea = bay.ship->Width() * bay.ship->Height();
 				const double bayHeatDensity = bay.ship->heat / bayArea;
 				// The amount of heat transferred is proportional to the difference in heat per unit

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -50,7 +50,7 @@ namespace {
 	const vector<Angle> BAY_ANGLE = {Angle(0.), Angle(-90.), Angle(90.), Angle(180.)};
 	
 	const double MAXIMUM_TEMPERATURE = 100.;
-	// The portion of the different in heat per unit area which is transferred per game tick:
+	// The portion of the different in heat per unit mass which is transferred per game tick:
 	const double HEAT_TRANSFER_COEFFICIENT = 0.04;
 	
 	const double SCAN_TIME = 60.;
@@ -1554,18 +1554,16 @@ void Ship::DoGeneration()
 	// Transfer heat to or from ships in bays before they can do their own generation.
 	if (!bays.empty())
 	{
-		const double area = Width() * Height();
-		const double heatDensity = heat / area;
+		const double heatDensity = heat / Mass();
 		for(Bay &bay : bays)
 			if(bay.ship)
 			{
-				const double bayArea = bay.ship->Width() * bay.ship->Height();
-				const double bayHeatDensity = bay.ship->heat / bayArea;
+				const double bayHeatDensity = bay.ship->heat / bay.ship->Mass();
 				// The amount of heat transferred is proportional to the difference in heat per unit
-				// area (the 2D heat density) and to the area through which the heat is transferred,
-				// which is the area of the ship in this bay.
+				// mass and to the mass through which the heat conducts, which is the mass of the ship
+				// in this bay.
 				const double transfer =
-					(heatDensity - bayHeatDensity) * HEAT_TRANSFER_COEFFICIENT * bayArea;
+					(heatDensity - bayHeatDensity) * HEAT_TRANSFER_COEFFICIENT * bay.ship->Mass();
 				heat -= transfer;
 				bay.ship->heat += transfer;
 				// The ships in bays must also be simulated alone.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -826,11 +826,12 @@ void Ship::SetPosition(Point position)
 
 
 // Instantiate a newly-created ship in-flight.
-void Ship::Place(Point position, Point velocity, Angle angle)
+void Ship::Place(Point position, Point velocity, Angle angle, double heat)
 {
 	this->position = position;
 	this->velocity = velocity;
 	this->angle = angle;
+	this->heat = heat;
 	
 	// If landed, place the ship right above the planet.
 	// Escorts should take off a bit behind their flagships.
@@ -842,7 +843,6 @@ void Ship::Place(Point position, Point velocity, Angle angle)
 	else
 		zoom = 1.;
 	// Make sure various special status values are reset.
-	heat = IdleHeat();
 	ionization = 0.;
 	disruption = 0.;
 	slowness = 0.;
@@ -854,6 +854,14 @@ void Ship::Place(Point position, Point velocity, Angle angle)
 	shipToAssist.reset();
 	if(government)
 		SetSwizzle(customSwizzle >= 0 ? customSwizzle : government->GetSwizzle());
+}
+
+
+
+// Version of Place with default IdleHeat
+void Ship::Place(Point position, Point velocity, Angle angle)
+{
+	Place(position, velocity, angle, IdleHeat());
 }
 
 
@@ -1779,7 +1787,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships, vector<Visual> &visuals)
 			// When ejected, ships depart haphazardly.
 			Angle launchAngle = ejecting ? Angle(exitPoint - position) : angle + BAY_ANGLE[bay.facing];
 			Point v = velocity + (.3 * maxV) * launchAngle.Unit() + (.2 * maxV) * Angle::Random().Unit();
-			bay.ship->Place(exitPoint, v, launchAngle);
+			bay.ship->Place(exitPoint, v, launchAngle, bay.ship->heat);
 			bay.ship->SetSystem(currentSystem);
 			bay.ship->SetParent(shared_from_this());
 			bay.ship->UnmarkForRemoval();

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -142,6 +142,7 @@ public:
 	void SetPosition(Point position);
 	// When creating a new ship, you must set the following:
 	void Place(Point position = Point(), Point velocity = Point(), Angle angle = Angle());
+	void Place(Point position, Point velocity, Angle angle, double heat);
 	void SetName(const std::string &name);
 	void SetSystem(const System *system);
 	void SetPlanet(const Planet *planet);


### PR DESCRIPTION
I just implemented this because I saw the `TODO` comment, but I don't know if it is appropriate to implement. I haven't done very much testing with this feature, but drone carriers still appear to work fine.

The rate of heat transfer is proportional to the difference in heat per unit area between the mother ship and the drone and to the area of the drone (i.e. the area across which heat can flow.) There is also the proportionality constant `HEAT_TRANSFER_COEFFICIENT`, which is at the moment 0.04. The higher the constant, the faster the heat transfer rate.

I think that this feature adds an interesting mechanic to the game. If your drone carrier has very good cooling but your drones do not, then the carrier could act as a heat sink to keep the drones cool.