### PR TITLE
Deep mission fixes

### DIFF
--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -1971,6 +1971,8 @@ mission "Deep: Scientist Rescue 1"
 	description "Escort the <npc> to <destination> to retrieve the Star Queen. Escorts will be waiting for you on Memory in the Zosma system and Farpoint in the Alnitak system."
 	destination "Haven"
 	clearance
+	stopover "Memory"
+	stopover "Farpoint"
 	to offer
 		has "Deep: Scientist Rescue 0: done"
 	
@@ -2045,25 +2047,12 @@ mission "Deep: Scientist Rescue 1: Pirates"
 
 
 
-mission "Deep: Scientist Rescue 1: Recruit Escorts"
-	landing
-	name "Deep Security escorts on <planet>"
-	description "Lieutenant Paris mentioned an escort squadron of Deep Security ships was preparing to join you on your mission. Meet up with them on <destination>, if you want to."
-	source "Valhalla"
-	destination "Memory"
-	to offer
-		has "Deep: Scientist Rescue 0: done"
-	to fail
-		has "Deep: Scientist Rescue 1: done"
-
-
-
 mission "Deep: Scientist Rescue 1: Escorts"
 	invisible
 	landing
 	source "Memory"
 	to offer
-		has "Deep: Scientist Rescue 1: Recruit Escorts: done"
+		has "Deep: Scientist Rescue 1: active"
 	to fail
 		or
 			has "Deep: Scientist Rescue 3A: offered"
@@ -2085,25 +2074,12 @@ mission "Deep: Scientist Rescue 1: Escorts"
 
 
 
-mission "Deep: Scientist Rescue 1: Recruit Reinforcements"
-	landing
-	name "Republic Navy escorts on <planet>"
-	description "Lieutenant Paris mentioned that some Navy officers were interested in avenging the loss of their comrades. Meet up with them on <destination>, if you want to."
-	source "Valhalla"
-	destination "Farpoint"
-	to offer
-		has "Deep: Scientist Rescue 0: done"
-	to fail
-		has "Deep: Scientist Rescue 1: done"
-
-
-
 mission "Deep: Scientist Rescue 1: Reinforcements"
 	invisible
 	landing
 	source "Farpoint"
 	to offer
-		has "Deep: Scientist Rescue 1: Recruit Reinforcements: done"
+		has "Deep: Scientist Rescue 1: active"
 	to fail
 		or
 			has "Deep: Scientist Rescue 3A: offered"

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -1288,7 +1288,7 @@ mission "Deep: Remnant 0"
 		or
 			"deep convoy" >= 2
 			has "Deep: Project Hawking: done"
-			has "Deep: TMBR 2: done"
+			has "Deep: TMBR 1: done"
 	
 	on offer
 		conversation

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -2204,7 +2204,7 @@ mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 		government "Pirate"
 		personality staying nemesis
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
-		dialog 
+		dialog
 			`After the Bactrian explodes, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
 			`The transmission cuts out as abruptly as it had started.`
@@ -2265,8 +2265,8 @@ mission "Deep: Scientist Rescue 3A"
 		personality staying nemesis
 		system "Arneb"
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
-		dialog 
-			`After the Bactrian explodes, you receive a transmission from an unknown source. It suddenly opens on its own andou receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
+		dialog
+			`After the Bactrian explodes, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
 			`The transmission cuts out as abruptly as it had started.`
 	on decline

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -2198,6 +2198,8 @@ mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 	destination "Valhalla"
 	to offer
 		has "Deep: Scientist Rescue 1: done"
+	to fail
+		has "Deep: Scientist Rescue 2: done"
 	npc kill
 		government "Pirate"
 		personality staying nemesis
@@ -2239,7 +2241,6 @@ mission "Deep: Scientist Rescue 3A"
 	
 	on offer
 		payment 2000000
-		fail "Deep: Scientist Rescue 2: Pirate Bactrian"
 		log `Escorted the rescued Star Queen back to the Deep. Some of the crew didn't make it. The pirates still have a Bactrian, and the Deep wants it destroyed.`
 		conversation
 			`As you land near the Star Queen, you can see its passengers being escorted off. Rayna and Hannah come running off the ship in tears over to Garrison, who must have arrived as soon as he heard the news. A medical team is examining each passenger while a Deep Security officer asks questions and jots down the responses. Sadly, you also notice a number of body bags next to the ship, likely from scientists or crew that were found dead on the ship.`

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -2173,7 +2173,7 @@ mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 		personality staying nemesis
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
 		dialog 
-			`After the Bactrian explodes, you receive a transmission from an unknown source. It suddenly opens on its own andou receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
+			`After the Bactrian explodes, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
 			`The transmission cuts out as abruptly as it had started.`
 

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -1971,8 +1971,6 @@ mission "Deep: Scientist Rescue 1"
 	description "Escort the <npc> to <destination> to retrieve the Star Queen. Escorts will be waiting for you on Memory in the Zosma system and Farpoint in the Alnitak system."
 	destination "Haven"
 	clearance
-	stopover "Memory"
-	stopover "Farpoint"
 	to offer
 		has "Deep: Scientist Rescue 0: done"
 	

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -2054,9 +2054,7 @@ mission "Deep: Scientist Rescue 1: Escorts"
 	to offer
 		has "Deep: Scientist Rescue 1: active"
 	to fail
-		or
-			has "Deep: Scientist Rescue 3A: offered"
-			has "Deep: Scientist Rescue 3B: offered"
+		has "Deep: Scientist Rescue 2: done"
 	
 	on offer
 		conversation
@@ -2081,9 +2079,7 @@ mission "Deep: Scientist Rescue 1: Reinforcements"
 	to offer
 		has "Deep: Scientist Rescue 1: active"
 	to fail
-		or
-			has "Deep: Scientist Rescue 3A: offered"
-			has "Deep: Scientist Rescue 3B: offered"
+		has "Deep: Scientist Rescue 2: done"
 	
 	on offer
 		conversation
@@ -2170,13 +2166,15 @@ ship "Bactrian" "Bactrian (Cosmic Devil)"
 mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 	landing
 	invisible
-	destination "Valhalla"
 	to offer
 		has "Deep: Scientist Rescue 1: done"
-	npc kill
+	to complete
+		never
+	npc save
 		government "Pirate"
 		personality staying nemesis
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
+	on fail
 		dialog 
 			`After the Bactrian explodes, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
@@ -2209,7 +2207,7 @@ mission "Deep: Scientist Rescue 3A"
 	waypoint "Arneb"
 	to offer
 		has "Deep: Scientist Rescue 2: done"
-		not "Deep: Scientist Rescue 2: Pirate Bactrian: done"
+		not "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
 		not "Deep: Scientist Rescue 3B: offered"
 	
 	on offer
@@ -2240,7 +2238,7 @@ mission "Deep: Scientist Rescue 3A"
 	on fail
 		event "battle in arneb end"
 	to complete
-		has "Deep: Scientist Rescue 2: Pirate Bactrian: done"
+		has "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
 	on complete
 		set "license: City-Ship"
 		event "battle in arneb end"
@@ -2262,7 +2260,7 @@ mission "Deep: Scientist Rescue 3B"
 	invisible
 	to offer
 		has "Deep: Scientist Rescue 2: done"
-		has "Deep: Scientist Rescue 2: Pirate Bactrian: done"
+		has "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
 		not "Deep: Scientist Rescue 3A: offered"
 	
 	on offer

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -2046,12 +2046,27 @@ mission "Deep: Scientist Rescue 1: Pirates"
 
 
 
+mission "Deep: Scientist Rescue 1: Recruit Escorts"
+	landing
+	name "Deep Security escorts on <planet>"
+	description "Lieutenant Paris mentioned an escort squadron of Deep Security ships was preparing to join you on your mission. Meet up with them on <destination>, if you want to."
+	source "Valhalla"
+	destination "Memory"
+	to offer
+		has "Deep: Scientist Rescue 0: done"
+	to fail
+		or
+			has "Deep: Scientist Rescue 1: declined"
+			has "Deep: Scientist Rescue 1: done"
+
+
+
 mission "Deep: Scientist Rescue 1: Escorts"
 	invisible
 	landing
 	source "Memory"
 	to offer
-		has "Deep: Scientist Rescue 1: active"
+		has "Deep: Scientist Rescue 1: Recruit Escorts: done"
 	to fail
 		has "Deep: Scientist Rescue 2: done"
 	
@@ -2071,12 +2086,27 @@ mission "Deep: Scientist Rescue 1: Escorts"
 
 
 
+mission "Deep: Scientist Rescue 1: Recruit Reinforcements"
+	landing
+	name "Republic Navy escorts on <planet>"
+	description "Lieutenant Paris mentioned that some Navy officers were interested in avenging the loss of their comrades. Meet up with them on <destination>, if you want to."
+	source "Valhalla"
+	destination "Farpoint"
+	to offer
+		has "Deep: Scientist Rescue 0: done"
+	to fail
+		or
+			has "Deep: Scientist Rescue 1: declined"
+			has "Deep: Scientist Rescue 1: done"
+
+
+
 mission "Deep: Scientist Rescue 1: Reinforcements"
 	invisible
 	landing
 	source "Farpoint"
 	to offer
-		has "Deep: Scientist Rescue 1: active"
+		has "Deep: Scientist Rescue 1: Recruit Reinforcements: done"
 	to fail
 		has "Deep: Scientist Rescue 2: done"
 	

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -1922,7 +1922,9 @@ mission "Deep: Scientist Rescue 0: Pirates"
 	to offer
 		has "Deep: Scientist Rescue 0: active"
 	to fail
-		has "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
+		or
+			has "Deep: Scientist Rescue 3A: done"
+			has "Deep: Scientist Rescue 3B: offered"
 	npc kill
 		government "Pirate"
 		personality nemesis staying
@@ -2030,7 +2032,9 @@ mission "Deep: Scientist Rescue 1: Pirates"
 	to offer
 		has "Deep: Scientist Rescue 0: done"
 	to fail
-		has "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
+		or
+			has "Deep: Scientist Rescue 3A: done"
+			has "Deep: Scientist Rescue 3B: offered"
 	npc kill
 		government "Pirate"
 		personality nemesis staying
@@ -2161,17 +2165,15 @@ ship "Bactrian" "Bactrian (Cosmic Devil)"
 mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 	landing
 	invisible
+	destination "Valhalla"
 	to offer
 		has "Deep: Scientist Rescue 1: done"
-	to complete
-		never
-	npc save
+	npc kill
 		government "Pirate"
 		personality staying nemesis
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
-	on fail
 		dialog 
-			`You receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
+			`After the Bactrian explodes, you receive a transmission from an unknown source. It suddenly opens on its own andou receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
 			`The transmission cuts out as abruptly as it had started.`
 
@@ -2183,7 +2185,9 @@ mission "Deep: Scientist Rescue 2: More Pirates"
 	to offer
 		has "Deep: Scientist Rescue 1: done"
 	to fail
-		has "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
+		or
+			has "Deep: Scientist Rescue 3A: done"
+			has "Deep: Scientist Rescue 3B: offered"
 	npc kill
 		government "Pirate"
 		personality staying nemesis
@@ -2200,11 +2204,12 @@ mission "Deep: Scientist Rescue 3A"
 	waypoint "Arneb"
 	to offer
 		has "Deep: Scientist Rescue 2: done"
-		not "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
+		not "Deep: Scientist Rescue 2: Pirate Bactrian: done"
 		not "Deep: Scientist Rescue 3B: offered"
 	
 	on offer
 		payment 2000000
+		fail "Deep: Scientist Rescue 2: Pirate Bactrian"
 		log `Escorted the rescued Star Queen back to the Deep. Some of the crew didn't make it. The pirates still have a Bactrian, and the Deep wants it destroyed.`
 		conversation
 			`As you land near the Star Queen, you can see its passengers being escorted off. Rayna and Hannah come running off the ship in tears over to Garrison, who must have arrived as soon as he heard the news. A medical team is examining each passenger while a Deep Security officer asks questions and jots down the responses. Sadly, you also notice a number of body bags next to the ship, likely from scientists or crew that were found dead on the ship.`
@@ -2224,14 +2229,21 @@ mission "Deep: Scientist Rescue 3A"
 			`	"Thank you, <first>." Lieutenant Paris starts walking over to the Star Queen, leaving you alone next to your ship.`
 				accept
 	
+	npc kill
+		government "Pirate"
+		personality staying nemesis
+		system "Arneb"
+		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
+		dialog 
+			`After the Bactrian explodes, you receive a transmission from an unknown source. It suddenly opens on its own andou receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
+			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
+			`The transmission cuts out as abruptly as it had started.`
 	on decline
 		event "battle in arneb end"
 	on visit
 		dialog "You landed on Valhalla, but you didn't kill the Bactrian! Return to Arneb and make sure that the Bactrian is destroyed and forever out of pirate hands."
 	on fail
 		event "battle in arneb end"
-	to complete
-		has "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
 	on complete
 		set "license: City-Ship"
 		event "battle in arneb end"
@@ -2253,7 +2265,7 @@ mission "Deep: Scientist Rescue 3B"
 	invisible
 	to offer
 		has "Deep: Scientist Rescue 2: done"
-		has "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
+		has "Deep: Scientist Rescue 2: Pirate Bactrian: done"
 		not "Deep: Scientist Rescue 3A: offered"
 	
 	on offer

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -1922,9 +1922,7 @@ mission "Deep: Scientist Rescue 0: Pirates"
 	to offer
 		has "Deep: Scientist Rescue 0: active"
 	to fail
-		or
-			has "Deep: Scientist Rescue 3A: done"
-			has "Deep: Scientist Rescue 3B: offered"
+		has "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
 	npc kill
 		government "Pirate"
 		personality nemesis staying
@@ -1949,6 +1947,7 @@ mission "Deep: Scientist Rescue 0: Haven"
 
 mission "Deep: Scientist Rescue 0: Haven Pirates Backup"
 	landing
+	invisible
 	source "Haven"
 	destination "Valhalla"
 	to offer
@@ -2031,9 +2030,7 @@ mission "Deep: Scientist Rescue 1: Pirates"
 	to offer
 		has "Deep: Scientist Rescue 0: done"
 	to fail
-		or
-			has "Deep: Scientist Rescue 3A: done"
-			has "Deep: Scientist Rescue 3B: offered"
+		has "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
 	npc kill
 		government "Pirate"
 		personality nemesis staying
@@ -2174,7 +2171,7 @@ mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
 	on fail
 		dialog 
-			`After the Bactrian explodes, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
+			`You receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
 			`The transmission cuts out as abruptly as it had started.`
 
@@ -2186,9 +2183,7 @@ mission "Deep: Scientist Rescue 2: More Pirates"
 	to offer
 		has "Deep: Scientist Rescue 1: done"
 	to fail
-		or
-			has "Deep: Scientist Rescue 3A: done"
-			has "Deep: Scientist Rescue 3B: offered"
+		has "Deep: Scientist Rescue 2: Pirate Bactrian: failed"
 	npc kill
 		government "Pirate"
 		personality staying nemesis


### PR DESCRIPTION
Some of this was spotted by @oo13 

* Fixed the `to offer` of `Deep: Remnant 0` to refer to the proper mission name of `Deep: TMBR 1` and not 2.
* Used the new `declined` condition to make sure that the recruit escort/reinforcement missions during `Deep: Scientist Rescue 1` did not accept if the player declined `Deep: Scientist Rescue 1`.
* Simplified conditions and missions in order to ensure that missions offer or complete in the proper order and fail at the right times.
* Fixed an instance of a mission not being invisible when it should be.