### PR TITLE
Fix a bug for NPC carriers to get lost.

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -316,12 +316,12 @@ void Engine::Place(const list<NPC> &npcs, shared_ptr<Ship> flagship)
 			if(ship->IsDestroyed() || ship->IsDisabled())
 				continue;
 			
+			// Redo the loading up of fighters.
+			ship->UnloadBays();
 			if(ship->BaysFree(false))
 				droneCarriers[&*ship] = ship->BaysFree(false);
 			if(ship->BaysFree(true))
 				fighterCarriers[&*ship] = ship->BaysFree(true);
-			// Redo the loading up of fighters.
-			ship->UnloadBays();
 		}
 		
 		shared_ptr<Ship> npcFlagship;


### PR DESCRIPTION
This PR prevents NPC fighter/drone carriers to get lost.

Current version of Engine::Place(npcs, flagship) counts the number of bay's free before unloading bays, so fighters/drones may be launched from the carrier.
A fighter/drone outside a bay can become a NPC flagship and a carrier will be able to load the fighter/drone, therefor a child ship of the fighter/drone gets lost.