### PR TITLE
feat: Overhaul jamming and tracking to make them more fun and realistic

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -258,7 +258,7 @@ tip "piercing protection:"
 	`Protection against weapons that pierce shields. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in damage leak, while a total value of 11 only results in a 10 percent reduction.`
 
 tip "radar jamming:"
-	`Reduces the ability of missiles that use radar to track your ship.`
+	`Reduces the ability of radar-guided missiles to track your ship. The more radar jamming is installed, the greater the distance at which missiles can be jammed, and the greater the chance that a jammed missile will fly off in a random direction.`
 
 tip "ramscoop:"
 	`Replenishes fuel by harvesting the stellar wind. Ramscoops are more effective when closer to a star. If you add more than one ramscoop, each additional one is less effective: you need four ramscoops to achieve double the recharge rate that one ramscoop provides.`
@@ -564,13 +564,13 @@ tip "tracking:"
 	`How well this weapon maintains its target lock.`
 
 tip "optical tracking:"
-	`How well this weapon maintains an optical target lock, which depend on the size of the target.`
+	`How well this weapon maintains an optical target lock, which depends on the size of the target.`
 
 tip "infrared tracking:"
-	`How well this weapon maintains an infrared target lock, which depends on the target ship's heat level.`
+	`How well this weapon maintains an infrared target lock, which depends on the target ship's heat level and distance from the missile; IR-guided missiles become more accurate the closer they are to their targets.`
 
 tip "radar tracking:"
-	`How well this weapon maintains a radar target lock, which can be interrupted by a ship with radar jamming installed.`
+	`How well this weapon maintains a radar target lock; negatively affected by the target ship's radar jamming equipment.`
 
 tip "piercing:"
 	`This percentage of this weapon's damage always leaks through to the hull.`


### PR DESCRIPTION
This PR aims to make missile tracking and jamming much more strongly affected by the characteristics of the target ship and the missile's tracking and homing methods, rather than being something that almost always works no matter what. This is more fun, rewards the player for equipping their ship appropriately, and makes missiles a bit more likely to miss their targets on average.

To that effect, it implements the following technical changes to jamming and tracking:
- Double the "resolution" of missile tracking by checking for lock twice as frequently
- When a missile has lost its lock, zero out its base chance to regain it
- Attenuate the effects of radar jamming proportional to the distance between the jammer and the missile; more jamming means that radar-guided missiles can become jammed at longer ranges
- Make jammed radar-guided missiles have a chance to "go haywire", proportional again to the strength of the jamming compared to the strength of the missile's radar tracking modified by the distance to the jammer
- Increase the reliability of infrared tracking when close to the target, mimicking the real-world phenomenon stemming from the wavelengths of infrared light being easier to distinguish with greater distance
- Slightly reduce the ship weight at which optical tracking becomes maximally effective to compensate for tracking being a bit less accurate now

Taken together, these changes mean that running a cool ship actually causes IR missiles to miss a lot of the time, and installing even a Small Radar Jammer is enough to make a fraction of Sidewinders miss against a maneuvering target. Torpedoes miss a little bit more against large ships, and are now almost useless against small maneuvering ships.

This PR also makes the combination of radar and IR tracking in a single missile make sense: radar tracking is used for long-range effectiveness, and the missile switches to IR when it's close to the target. Some of the best real-world missiles do this, too.

closes #1865
closes #3912