### PR TITLE
Fix starting condition for Remnant: Expanded Horizons Quarg 1

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -1168,7 +1168,7 @@ mission "Remnant: Expanded Horizons Quarg 1"
 	destination "Wayfarer"
 	to offer
 		has "Remnant: Learn Sign Follow Up: offered"
-		has "Remnant: Salvage 1: done"
+		has "Remnant: Salvage 2: done"
 		has "First Contact: Quarg: offered"
 		random < 40
 	on offer


### PR DESCRIPTION
Fixing a mission start error where Dawn aproaches the player after they've been off to retrieve the historical data but before the player has actually turned in the data.

Changes the "to offer" tie-in between the two strings for Expanded Horizons Quarg 1 from Salvage 1 done to Salvage 2 done.