### PR TITLE
Adjust human guided missiles to adjust to jamming and tracking changes

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -678,15 +678,15 @@ outfit "Meteor Missile Launcher"
 		"hit effect" "missile hit"
 		"inaccuracy" 5
 		"velocity" 11
-		"lifetime" 490
+		"lifetime" 350
 		"reload" 80
 		"firing energy" 1
 		"firing heat" 20
 		"acceleration" 1
 		"drag" .1
-		"turn" 1.35
-		"homing" 3
-		"infrared tracking" .8
+		"turn" 1.8
+		"homing" 1
+		"infrared tracking" .65
 		"shield damage" 260
 		"hull damage" 160
 		"hit force" 220
@@ -740,7 +740,7 @@ outfit "Sidewinder Missile Launcher"
 		"hit effect" "missile hit"
 		"inaccuracy" 4
 		"velocity" 14
-		"lifetime" 470
+		"lifetime" 350
 		"reload" 60
 		"firing energy" 1
 		"firing heat" 15
@@ -850,8 +850,8 @@ outfit "Torpedo Launcher"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 6
-		"lifetime" 600
+		"velocity" 7
+		"lifetime" 900
 		"reload" 150
 		"firing energy" 2
 		"firing heat" 45
@@ -912,8 +912,8 @@ outfit "Typhoon Launcher"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 5
-		"lifetime" 600
+		"velocity" 6
+		"lifetime" 1100
 		"reload" 120
 		"firing energy" 4
 		"firing heat" 50
@@ -922,8 +922,8 @@ outfit "Typhoon Launcher"
 		"turn" 1.5
 		"homing" 4
 		"optical tracking" .9
-		"shield damage" 880
-		"hull damage" 880
+		"shield damage" 920
+		"hull damage" 920
 		"hit force" 450
 		"missile strength" 40
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."


### PR DESCRIPTION
With the jamming and tracking changes in https://github.com/endless-sky/endless-sky/pull/4204, I've slightly adjusted the Torpedoes, Sidewinder, and Meteor.

The humble Meteor finally has a useful battle role: it is now a short-range bombardment weapon that is optimally fired from fighters against medium-to-large-sized ships, but can be used against small maneuvering ships when fired by a skillful pilot (i.e. the player).

However, it's still just as forgiving to new players--in fact maybe even more so: By worsening its tracking, it is now easier to dodge in a small ship. Its reduced range means that it won't come from out of nowhere. Reduced homing mean that when it misses, it never comes back around for another attack run.

The sidewinder's range was nearly cut in half. It's now longer-ranged than the meteor, but shorter than the Torpedo. It's essentially just an anti-fighter weapon now, and very effective in this role. However it can be pressed into service against warships in a pinch (it is very expensive to do this, just like when the U.S. Navy uses a 4 million dollar Standard Missile against ships instead of than fighters or other missiles, which are its intended targets).

The Torpedoes are now the go-to long range anti-capital ship weapons. The changes to tracking make them virtually worthless against small maneuvering ships, but they are devastating to capital ships.

I've done a lot of testing and with https://github.com/endless-sky/endless-sky/pull/4204 plus this PR, human guided missiles _finally_ feel good to me.