### PR TITLE
tweaked Surveillance Pod

### DIFF
--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -246,11 +246,12 @@ outfit "Surveillance Pod"
 	thumbnail "outfit/surveillance pod"
 	"mass" 5
 	"outfit space" -5
-	"outfit scan power" 16
-	"outfit scan speed" 2
-	"cargo scan power" 4
-	"cargo scan speed" 2
+	"asteroid scan power" 9
 	"atmosphere scan" 100
+	"cargo scan power" 9
+	"cargo scan speed" 2
+	"outfit scan power" 9
+	"outfit scan speed" 2
 	"tactical scan power" 9
 	description "This is Navy technology, a collection of scanners designed to fit perfectly inside one of their surveillance drones. Since the outputs are fairly standard, you could connect it to your own ship's systems if you want. Installing more than one increases the scan range and speed."
 


### PR DESCRIPTION
Currently the Navy Surveillance Pod has three different ranges (CS 200, OS 400, TS 300), but because it's a single device, it would make more sense to have only a single range. This proposal:
* standardizes scan powers to 9 (i.e. 300 range)
* adds an asteroid scan power (because the Surveillance Pod was introduced years before the Asteroid Scanner)
* alphabetizes scan attributes