### PR TITLE
Changes to missions related to earning the Bactrian

### DIFF
--- a/data/deep jobs.txt
+++ b/data/deep jobs.txt
@@ -53,7 +53,7 @@ mission "Deep Mystery Cube [0]"
 	description "Deliver a package to <destination>. Payment is <payment>."
 	cargo "mystery package" 1
 	to offer
-		random < 10
+		random < 25
 		"combat rating" > 35
 	source
 		attributes "deep"

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -1274,10 +1274,6 @@ mission "Deep: Remnant 0"
 		has "Deep: Mystery Cubes 4: done"
 		has "Terminus exploration: done"
 		has "First Contact: Hai: offered"
-		or
-			"deep convoy" >= 2
-			has "Deep: Project Hawking: done"
-			has "Deep: TMBR 1: done"
 	
 	on offer
 		conversation

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -1020,18 +1020,7 @@ mission "Deep: Project Hawking"
 	deadline 10
 	to offer
 		random < 40
-		or
-			has "Deep: Questions: done"
-			has "deep: helped before archaeology"
-			and
-				has "Deep: Mystery Cubes 4: done"
-				has "Deep Archaeology 1: offered"
-				not "Deep Archaeology 1: active"
-				not "Deep Archaeology 2: active"
-				not "Deep Archaeology 3: active"
-				not "Deep Archaeology 4: active"
-				not "Deep Archaeology 5: active"
-				not "Deep Archaeology 5: done"
+		has "Deep: Mystery Cubes 4: done"
 		
 	on offer
 		conversation

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -2491,8 +2491,10 @@ mission "A wolf, a goat, and a cabbage"
 mission "Terminus exploration"
 	name "Missing drone"
 	description "Travel to the <waypoints> system to see if you can find any sign of a probe drone that had been launched by a team of scientists before they were attacked by pirates and forced to flee."
-	source "Bounty"
+	source 
+		planet "Memory" "Haze" "Nifel"
 	waypoint "Terminus"
+	destination "Bounty"
 	to offer
 		"combat rating" > 20
 	on offer
@@ -2510,7 +2512,7 @@ mission "Terminus exploration"
 				`	"Sorry, I don't want to help with this."`
 					decline
 			label end
-			`	"Thank you so much!" he says. "All I need you to do is board the drone and download its database. Unless the pirates have already stripped out the computer, of course. The drone is in the Terminus system, a few jumps away from here."`
+			`	"Thank you so much!" he says. "All I need you to do is board the drone and download its database. Unless the pirates have already stripped out the computer, of course. The drone is in the Terminus system, a few jumps away from here. We'll be waiting on <destination> for your return."`
 				accept
 	npc assist
 		system "Terminus"


### PR DESCRIPTION
These changes make it easier to get all of the missions done to get the Bactrian license by making them offer sooner, more often, or in a better location, in response to feedback I've received by people playing MCO's nightly build. The only outside requirement to the Bactrian missions now is to have discovered the Hai for the purposes of receiving the Deep: Remnant missions.

* The Terminus Scientists mission now offers in the Deep and ends on Bounty, instead of starting and ending on Bounty. This means that the player doesn't need to look outside of the Deep for missions.
* Made one of the mystery cube jobs offer more often, as to avoid having the player struggle to find any such jobs to progress the story with.
* Deep: Project Hawking no longer requires the player to have interacted with the Deep Archaeology missions, for the same reason as to why the Terminus Scientist mission offers in the Deep.
* Cut out one of the conditions from Deep: Remnant's to offer so its more in line with Deep: Project Hawking.