### PR TITLE
Adds the Salvage Scanner to the Remnant Outfitter

### DIFF
--- a/data/remnant.txt
+++ b/data/remnant.txt
@@ -239,6 +239,7 @@ outfitter "Remnant"
 	"Cargo Scanner"
 	"Outfit Scanner"
 	"Tuning Rifle"
+	"Salvage Scanner"
 
 outfitter "Remnant Salvage"
 	"Generator (Furnace Class)"


### PR DESCRIPTION
This PR simply adds the Salvage Scanner to the Remnant Outfitter. That's it.

Sorry this was missed.