### PR TITLE
Set security to 0 for the Tefkar Ret station

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -26838,6 +26838,7 @@ planet "Tefkar Ret"
 	attributes korath station
 	landscape land/station0
 	description `This station is run down and completely abandoned, emptied of atmosphere so that air pressure will not put ongoing stress on the station's structure. Each section is sealed off from the others by heavy blast doors, leaving most of the station inaccessible.`
+	security 0
 
 planet "Third Umber"
 	attributes kimek factory research


### PR DESCRIPTION
 This Efreti station in the Kashikt system is said to be completely abandoned, but you can get fined for being there with Nerve Gas, so I set the security there to 0 since it didn't make sense.