### PR TITLE
Changing OK to Okay in Remnant Expanded Horizons Quarg 3

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -1254,7 +1254,7 @@ mission "Remnant: Expanded Horizons Quarg 3"
 	on offer
 		conversation
 			`Back in the spaceport bar you wait around for a couple hours. Just when you were about to go find them, the trio walk in looking like they had spent all day on the move, but otherwise unreadable.`
-			`	"OK, I think we are ready to go. Can you take us to <planet>?"`
+			`	"Okay, I think we are ready to go. Can you take us to <planet>?"`
 				accept
 	on complete
 		payment 150000


### PR DESCRIPTION
In Remnant: Expanded Horizons Quarg 3, one dialogue line starts with `OK` whereas the writing style of ES uses `Okay` instead. So, changing it here. (this is in line 1257)