### PR TITLE
Enabling the player to demand tribute from the Remnant

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -24130,6 +24130,9 @@ planet Aventine
 	bribe 0
 	shipyard Remnant
 	outfitter Remnant
+	tribute 4000
+		threshold 7500
+		fleet "Large Remnant" 60
 
 planet "Bank of Blugtad"
 	attributes arach wealthy urban
@@ -24306,6 +24309,9 @@ planet Caelian
 	bribe 0
 	shipyard Remnant
 	outfitter Remnant
+	tribute 3000
+		threshold 7500
+		fleet "Large Remnant" 40
 
 planet Calda
 	attributes paradise tourism rich
@@ -27187,6 +27193,9 @@ planet Viminal
 	bribe 0
 	shipyard Remnant
 	outfitter Remnant
+	tribute 3000
+		threshold 7500
+		fleet "Large Remnant" 40
 
 planet Vinci
 	attributes paradise factory

--- a/data/map.txt
+++ b/data/map.txt
@@ -24131,8 +24131,8 @@ planet Aventine
 	shipyard Remnant
 	outfitter Remnant
 	tribute 4000
-		threshold 7500
-		fleet "Large Remnant" 60
+		threshold 8500
+		fleet "Large Remnant" 80
 
 planet "Bank of Blugtad"
 	attributes arach wealthy urban
@@ -24310,8 +24310,8 @@ planet Caelian
 	shipyard Remnant
 	outfitter Remnant
 	tribute 3000
-		threshold 7500
-		fleet "Large Remnant" 40
+		threshold 8000
+		fleet "Large Remnant" 60
 
 planet Calda
 	attributes paradise tourism rich
@@ -27194,8 +27194,8 @@ planet Viminal
 	shipyard Remnant
 	outfitter Remnant
 	tribute 3000
-		threshold 7500
-		fleet "Large Remnant" 40
+		threshold 8000
+		fleet "Large Remnant" 60
 
 planet Vinci
 	attributes paradise factory


### PR DESCRIPTION
This PR adds tribute amounts, thresholds, and fleets to the planet definitions for Aventine, Viminal, and Caelian.

All three use the "Large Remnant" fleet, 60 in the case of Viminal and Caelian, and 80 for Aventine. The tribute given is correspondingly 3000 for the former two, and 4000 for the latter.

The logic behind these values is thus: 
- The Remnant have no external trade routes, nor significant economy of any kind, thus it seems unreasonable to expect that they would have large amounts of cash flow.
- The Remnant are strongly oriented towards "survival at all costs" against perceived existential threats.
- They are routinely attacked by a strong alien faction that they are capable of meeting on sufficiently equal terms that they can afford to "manage" the battle to encourage the aliens to get enough loot to want to come back, while destroying enough to have valuable salvage.

As a result, this sounds like a situation where demanding tribute from them should be a fairly high risk/low reward situation. (admittedly, 3k and 4k per day is still significant, but the ratio of potential profit compared to the forces one has to overcome is significantly lower)