### PR TITLE
fw epilogue edit

### DIFF
--- a/data/free worlds epilogue.txt
+++ b/data/free worlds epilogue.txt
@@ -9,6 +9,7 @@
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 mission "FW Epilogue: Ijs and Katya"
+	minor
 	landing
 	source "Winter"
 	to offer
@@ -53,6 +54,7 @@ mission "FW Epilogue: Ijs and Katya"
 
 
 mission "FW Epilogue: Alondo"
+	minor
 	landing
 	source "Bourne"
 	to offer
@@ -90,6 +92,7 @@ mission "FW Epilogue: Alondo"
 
 
 mission "FW Epilogue: Freya"
+	minor
 	landing
 	source "Pugglemug"
 	to offer
@@ -141,6 +144,7 @@ mission "FW Epilogue: Freya"
 
 
 mission "FW Epilogue: Danforth"
+	minor
 	landing
 	source "Farpoint"
 	to offer

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -2849,14 +2849,6 @@ mission "Paradise Fortune 4"
 			`While in flight, Diana tells you the stories that she heard of the war. In the Paradise Planets region, they were told that declaring independence and bombing Geminus and Martini was the Free Worlds' first step in overthrowing the Republic.`
 			`	"We should talk to Alondo," Diana says. "He'll be able to handle this situation."`
 			
-			branch epilogue
-				has "FW Epilogue: Alondo: offered"
-			`	As you're coming in for a landing on Bourne, you receive a message from Alondo. "<first>!" he says. "I just heard that you were in system. Want to meet up for a drink and talk about old times?"`
-			choice
-				`	"I'd be glad to any other time, but I need your help at the moment."`
-					goto conversation
-			
-			label epilogue
 			`	As you're coming in for a landing, you contact Alondo, who is luckily on Bourne. "What have you gotten yourself into?" he responds after you mention that you need his help.`
 			choice
 				`	"I'll explain the situation when we meet."`

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -2849,6 +2849,14 @@ mission "Paradise Fortune 4"
 			`While in flight, Diana tells you the stories that she heard of the war. In the Paradise Planets region, they were told that declaring independence and bombing Geminus and Martini was the Free Worlds' first step in overthrowing the Republic.`
 			`	"We should talk to Alondo," Diana says. "He'll be able to handle this situation."`
 			
+			branch epilogue
+				has "FW Epilogue: Alondo: offered"
+			`	As you're coming in for a landing on Bourne, you receive a message from Alondo. "<first>!" he says. "I just heard that you were in system. Want to meet up for a drink and talk about old times?"`
+			choice
+				`	"I'd be glad to any other time, but I need your help at the moment."`
+					goto conversation
+			
+			label epilogue
 			`	As you're coming in for a landing, you contact Alondo, who is luckily on Bourne. "What have you gotten yourself into?" he responds after you mention that you need his help.`
 			choice
 				`	"I'll explain the situation when we meet."`


### PR DESCRIPTION
When testing the Paradise Fortune mission chain, FW Epilogue: Alondo offered, leading to a situation where I sat down and had a beer with Alondo while the Republic was hot on my heels.

The mission Paradise Fortune 4 has a branch that I assume was intended to handle this, but it does nothing to stop the mission from being offered (since it cant), only changes the beginning dialog.

This PR handles this oddity by removing the ineffective branch from Paradise Fortune 4, and marks the all the epilogue missions minor to avoid the need for any special dialog for this case or any other.