### PR TITLE
Escorts refuel more reasonably when they have both a hyperdrive and a jumpdrive.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1437,6 +1437,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 	const Planet *parentPlanet = (parent.GetTargetStellar() ? parent.GetTargetStellar()->GetPlanet() : nullptr);
 	bool planetIsHere = (parentPlanet && parentPlanet->IsInSystem(parent.GetSystem()));
 	bool systemHasFuel = hasFuelCapacity && ship.GetSystem()->HasFuelFor(ship);
+	// Non-staying escorts should route to their parent ship's system if not already in it.
 	if(!parentIsHere && !isStaying)
 	{
 		if(ship.GetTargetStellar())
@@ -1478,6 +1479,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 			// This ship has no route to the parent's system, so park at the system's center.
 			MoveTo(ship, command, Point(), Point(), 40., 0.1);
 	}
+	// If the parent is in-system and planning to jump, non-staying escorts should follow suit.
 	else if(parent.Commands().Has(Command::JUMP) && parent.GetTargetSystem() && !isStaying)
 	{
 		DistanceMap distance(ship, parent.GetTargetSystem());
@@ -1489,6 +1491,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 		else if(ShouldRefuel(ship, dest))
 			Refuel(ship, command);
 		else if(!ship.JumpsRemaining())
+			// Return to the system center to maximize solar collection rate.
 			MoveTo(ship, command, Point(), Point(), 40., 0.1);
 		else
 		{


### PR DESCRIPTION
This PR fixes #1238.

Escorts make a refuel plan which is based on the target system of the parent ship or the travel plan to the final destination.