### PR TITLE
Add flagship crew info to conditions. Partially implements #4286

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2256,6 +2256,11 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 		conditions["passenger space"] = flagship->Cargo().BunksFree();
 	}
 	
+	// Store conditions for flagship current crew, required crew, and bunks.
+	conditions["crew"] = flagship->Crew();
+	conditions["required crew"] = flagship->RequiredCrew();
+	conditions["bunks"] = flagship->Attributes().Get("bunks");
+	
 	// Conditions for your fleet's attractiveness to pirates:
 	pair<double, double> factors = RaidFleetFactors();
 	conditions["cargo attractiveness"] = factors.first;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2257,9 +2257,9 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 	}
 	
 	// Store conditions for flagship current crew, required crew, and bunks.
-	conditions["crew"] = flagship->Crew();
-	conditions["required crew"] = flagship->RequiredCrew();
-	conditions["bunks"] = flagship->Attributes().Get("bunks");
+	conditions["flagship crew"] = flagship->Crew();
+	conditions["flagship required crew"] = flagship->RequiredCrew();
+	conditions["flagship bunks"] = flagship->Attributes().Get("bunks");
 	
 	// Conditions for your fleet's attractiveness to pirates:
 	pair<double, double> factors = RaidFleetFactors();


### PR DESCRIPTION
This allows checking crew-related conditions of the player flagship. Attached is a file to test.

This allows directly checking for `"crew"`, `"required crew"`, and `"bunks"` in the same way that `"cargo space"` and '"passenger space"` work now.

[test flagship conditions.txt](https://github.com/endless-sky/endless-sky/files/3220562/test.flagship.conditions.txt)

Note: recommend not merging until after the next stable release.