### PR TITLE
Adds Beta-version text to Main Menu

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -144,8 +144,8 @@ interface "main menu"
 		center -420 155
 		dimensions 120 30
 
-	# For Beta Only
-	label "THIS IS THE BETA VERSION"
+	# For Unstable Only
+	label "THIS IS THE UNSTABLE VERSION"
 		center 0 100
 	label "PLEASE REPORT ALL ISSUES TO"
 		center 0 120

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -144,6 +144,18 @@ interface "main menu"
 		center -420 155
 		dimensions 120 30
 
+	# For Beta Only
+	label "THIS IS THE BETA VERSION"
+		center 0 100
+	label "PLEASE REPORT ALL ISSUES TO"
+		center 0 120
+	label "US ON GITHUB, STEAM FORUMS,"
+		center 0 140
+	label "OR DISCORD (/ZeuASSx)"
+		center 0 160
+	label "Thanks for playing!"
+		center 0 180
+
 
 
 interface "menu player info"


### PR DESCRIPTION
Adds a block of text on the main menu, just below the compass rose, mentioning that the version being played is a Beta version, and to submit issues to the community on the GitHub, Steam Forums, or Discord (including the Discord ending link, in case people need it).

I feel that this can help direct people playing the beta into reporting their issues so that we can fix them quickly for the Stable release.