### PR TITLE
Bugfix: Terraforming 6 should not offer in Sol

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -2171,6 +2171,7 @@ mission "Terraforming 6"
 	source
 		government "Republic"
 		not attributes "deep"
+		not system "Sol"
 	destination "Earth"
 	deadline
 	to offer


### PR DESCRIPTION
If the source for Terraforming 6 is in Sol, the deadline becomes 0 making it impossible to complete.

Reported by Kiko the Exile on discord.