### PR TITLE
Explicitly state the hit force of the Hai Tracker as being a feature

### DIFF
--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -231,7 +231,7 @@ outfit "Hai Tracker Pod"
 		"infrared tracking" .4
 		"shield damage" 200
 		"hull damage" 160
-		"hit force" 350
+		"hit force" 200
 		"missile strength" 16
 	description "Trackers are fast, powerful, and accurate homing weapons. Their only weakness is their large turning radius: if a Tracker misses its target, it takes a long time to turn around."
 

--- a/data/hai outfits.txt
+++ b/data/hai outfits.txt
@@ -231,9 +231,9 @@ outfit "Hai Tracker Pod"
 		"infrared tracking" .4
 		"shield damage" 200
 		"hull damage" 160
-		"hit force" 200
+		"hit force" 350
 		"missile strength" 16
-	description "Trackers are fast, powerful, and accurate homing weapons. Their only weakness is their large turning radius: if a Tracker misses its target, it takes a long time to turn around."
+	description "Trackers are fast and accurate homing weapons. Although not as powerful as most human missiles, Trackers boast a significant hit force, helping to prevent the escape of whoever is unfortunate enough to be on the receiving end. Their only weakness is their large turning radius: if a Tracker misses its target, it takes a long time to turn around."
 
 effect "tracker fire"
 	sprite "effect/tracker fire"


### PR DESCRIPTION
Ref: [Feedback](https://steamcommunity.com/app/404410/discussions/0/1653297026046844771/#c1653297026047413327)

Explicitly state that the hit force of the Hai Trackers is a feature that compensates for their relatively low damage compared to human missiles.

<details><summary>Old description</summary>The Hai Tracker applies among the most hit force per shot and per second of the more agile missiles (i.e. Meteor, Sidewinder, Tracker, Piercer, Thunderhead). Given the volume with which Hai ships deploy Trackers, dealing with them can be difficult when they're constantly tossing you around.

This PR greatly reduced the hit force of the Tracker from 350 to 200, bringing its hit force more in line with something like the Meteor Missile, which actually does more damage per shot.</details>