### PR TITLE
Fix: Changing electron beam to S-970 Regenerators

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -906,7 +906,7 @@ mission "Remnant: D94-YV Shield Generator"
 
 mission "Remnant: S-970 Regenerator"
 	name "Retrieve S-970 Regenerators"
-	description "A Remnant engineer has offered you <payment> for delivering two electron beams to a testing range on <planet>."
+	description "A Remnant engineer has offered you <payment> for delivering two S-970 Regenerators to an impact testing facility on <planet>."
 	minor
 	source "Viminal"
 	destination


### PR DESCRIPTION
Fixing an erroneously labeled outfit in the description on line 909. Thanks to Kiko for finding it.