### PR TITLE
Updated pirate occupation missions

### DIFF
--- a/data/south jobs.txt
+++ b/data/south jobs.txt
@@ -115,8 +115,8 @@ conversation "pirate occupation"
 		`	(Don't join the fight.)`
 			decline
 		`	(Join the defense fleet.)`
-	`A few militia pilots have gathered to help repel the pirate attack. You join them, and take off together...`
-		launch
+	`A few militia pilots have gathered to help repel the pirate attack. You join them, and prepare your ship for the upcoming battle...`
+		accept
 
 
 


### PR DESCRIPTION
Removed launch on accept. There is no immediate action in nearby space anyway for these missions, the player has to jump several times to reach the objective, launching on accept seems unnecessary.

Re-worded the dialogue to suit.

Spotted by Kiko.