### PR TITLE
Give FW Pug 2C: Jump Drive priority so that you aren't given an extra JD

### DIFF
--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -1229,8 +1229,7 @@ mission "FW Pug 2C: Scram Drive"
 
 
 
-mission "FW Pug 2C: Jump Drive"
-	priority
+mission "FW Pug 2C: A Jump Drive"
 	landing
 	name "Investigate the Pug"
 	description "Travel to the Deneb system to investigate the Pug; if possible, make contact with them and determine what their goals and desires are."

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -1193,6 +1193,7 @@ mission "FW Pug 2C: Hyperdrive"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
+		require "Jump Drive" 0
 		outfit "Hyperdrive" -1
 		conversation
 			`You are directed to land in a hangar some distance away from the spaceport, in a cluster of buildings owned by Syndicated Systems. A team of engineers meets you and quickly and efficiently removes your Hyperdrive and replaces it with a strange, alien-looking device that you assume must be a Jump Drive. "Now, be careful with your fuel gauge," one of them tells you. "This thing guzzles twice as much fuel per jump as an ordinary hyperdrive, and you don't want to become stranded while outside human space."`
@@ -1218,6 +1219,7 @@ mission "FW Pug 2C: Scram Drive"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
+		require "Jump Drive" 0
 		outfit "Scram Drive" -1
 		conversation
 			`You are directed to land in a hangar some distance away from the spaceport, in a cluster of buildings owned by Syndicated Systems. A team of engineers meets you and quickly and efficiently removes your Scram Drive and replaces it with a strange, alien-looking device that you assume must be a Jump Drive. "Now, be careful with your fuel gauge," one of them tells you. "This thing guzzles twice as much fuel per jump as an ordinary hyperdrive, and you don't want to become stranded while outside human space."`

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -1193,7 +1193,6 @@ mission "FW Pug 2C: Hyperdrive"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
-		require "Jump Drive" 0
 		outfit "Hyperdrive" -1
 		conversation
 			`You are directed to land in a hangar some distance away from the spaceport, in a cluster of buildings owned by Syndicated Systems. A team of engineers meets you and quickly and efficiently removes your Hyperdrive and replaces it with a strange, alien-looking device that you assume must be a Jump Drive. "Now, be careful with your fuel gauge," one of them tells you. "This thing guzzles twice as much fuel per jump as an ordinary hyperdrive, and you don't want to become stranded while outside human space."`
@@ -1219,7 +1218,6 @@ mission "FW Pug 2C: Scram Drive"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
-		require "Jump Drive" 0
 		outfit "Scram Drive" -1
 		conversation
 			`You are directed to land in a hangar some distance away from the spaceport, in a cluster of buildings owned by Syndicated Systems. A team of engineers meets you and quickly and efficiently removes your Scram Drive and replaces it with a strange, alien-looking device that you assume must be a Jump Drive. "Now, be careful with your fuel gauge," one of them tells you. "This thing guzzles twice as much fuel per jump as an ordinary hyperdrive, and you don't want to become stranded while outside human space."`
@@ -1232,6 +1230,7 @@ mission "FW Pug 2C: Scram Drive"
 
 
 mission "FW Pug 2C: Jump Drive"
+	priority
 	landing
 	name "Investigate the Pug"
 	description "Travel to the Deneb system to investigate the Pug; if possible, make contact with them and determine what their goals and desires are."


### PR DESCRIPTION
For the FW Pug 2C missions where the player is given a Jump Drive by the Syndicate, having both a Hyperdrive and Jump Drive installed will result in the Syndicate removing your HD and giving you a second JD. 

Giving FW Pug 2C: Jump Drive priority means that this mission will prevent the Hyperdrive and Scram Drive versions of the mission from offering if the player has a jump drive already.

<details><summary>Old description</summary>This PR makes it so that the Hyperdrive and Scram Drive versions of this mission now check to make sure that the player doesn't have a JD already.

Note: This change will make it so that the player's entire fleet is checked for a JD, even though the mission states that only the flagship is being checked. Will need to extend the behavior of `require` to be able to only check the flagship as mentioned in #4002 in order to avoid that.</details>