### PR TITLE
Various Deep missions now check to make sure that the war is not ongoing

### DIFF
--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -28,6 +28,9 @@ mission "Deep: Syndicate Convoy"
 			and
 				"deep convoy" == 2
 				random < 40
+		or
+			not "chosen sides"
+			has "main plot completed"
 				
 	on offer
 		conversation
@@ -119,6 +122,9 @@ mission "Deep: Tarazed Convoy"
 			and
 				"deep convoy" == 2
 				random < 40
+		or
+			not "chosen sides"
+			has "main plot completed"
 	
 	on offer
 		conversation
@@ -213,6 +219,9 @@ mission "Deep: Kraz Convoy"
 			and
 				"deep convoy" == 2
 				random < 40
+		or
+			not "chosen sides"
+			has "main plot completed"
 	
 	on offer
 		conversation
@@ -309,6 +318,9 @@ mission "Deep: Mystery Cubes 0"
 			and
 				"deep convoy" == 3
 				random < 90
+		or
+			not "chosen sides"
+			has "main plot completed"
 	
 	on offer
 		conversation
@@ -394,6 +406,9 @@ mission "Deep: Mystery Cubes 1"
 	destination "Luna"
 	to offer
 		has "event: deep: warlord detected"
+		or
+			not "chosen sides"
+			has "main plot completed"
 	
 	on offer
 		dialog `You receive a message from Lieutenant Paris. "Greetings, Captain. The situation involving Beelzebub has gone slightly sour, and the Navy is involved now. I have been asked to gather the merchants who assisted the Deep previously in placing the cubes. If you are interested, please come to <destination>."`
@@ -668,6 +683,9 @@ mission "Deep: TMBR 0"
 		has "There Might Be Riots part 3B: done"
 		not "Deep: Remnant 0: offered"
 		not "Deep: Project Hawking: offered"
+		or
+			not "chosen sides"
+			has "main plot completed"
 	
 	on offer
 		conversation
@@ -1021,6 +1039,9 @@ mission "Deep: Project Hawking"
 	to offer
 		random < 40
 		has "Deep: Mystery Cubes 4: done"
+		or
+			not "chosen sides"
+			has "main plot completed"
 		
 	on offer
 		conversation
@@ -1274,6 +1295,9 @@ mission "Deep: Remnant 0"
 		has "Deep: Mystery Cubes 4: done"
 		has "Terminus exploration: done"
 		has "First Contact: Hai: offered"
+		or
+			not "chosen sides"
+			has "main plot completed"
 	
 	on offer
 		conversation
@@ -1346,6 +1370,9 @@ mission "Deep: Remnant: Keystone Research"
 	destination "Valhalla"
 	to offer
 		has "event: deep: keystone research"
+		or
+			not "chosen sides"
+			has "main plot completed"
 	
 	on offer
 		dialog
@@ -1828,6 +1855,9 @@ mission "Deep: Scientist Rescue 0"
 	waypoint "Betelgeuse"
 	to offer
 		has "event: deep: scientist rescue timer"
+		or
+			not "chosen sides"
+			has "main plot completed"
 	
 	on offer
 		conversation


### PR DESCRIPTION
Any Deep mission which is the beginning of a string or which triggers after a delay now checks to see if the war is currently happening before being able to offer. This is to avoid the situation where the player may be in the middle of a truce period with the Republic, start a mission in Republic space or with Republic escorts, then have that truce period end. Plot-wise, this also means the Deep won't appear to be off doing its own thing (especially for the Navy and Syndicate campaigns) when it should be helping the Republic.