### PR TITLE
Player will now receive on visit dialog for cargo and passenger jobs

### DIFF
--- a/data/coalition jobs.txt
+++ b/data/coalition jobs.txt
@@ -25,6 +25,8 @@ mission "Coalition: Ringworld Workers 1"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -44,6 +46,8 @@ mission "Coalition: Ringworld Workers 2"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -63,6 +67,8 @@ mission "Coalition: Ringworld Workers 3"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -87,6 +93,8 @@ mission "Coalition: Ringworld Volunteers 1"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -106,6 +114,8 @@ mission "Coalition: Ringworld Volunteers 2"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -125,6 +135,8 @@ mission "Coalition: Ringworld Volunteers 3"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -150,6 +162,8 @@ mission "Coalition: Ringworld Materials 1"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -170,6 +184,8 @@ mission "Coalition: Ringworld Materials 2"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -190,6 +206,8 @@ mission "Coalition: Ringworld Materials 3"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -214,6 +232,8 @@ mission "Coalition: Ringworld Supplies 1"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -233,6 +253,8 @@ mission "Coalition: Ringworld Supplies 2"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -252,6 +274,8 @@ mission "Coalition: Ringworld Supplies 3"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -273,6 +297,8 @@ mission "Coalition: Heliarch Candidate"
 		government "Coalition"
 	destination
 		government "Heliarch"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -297,6 +323,8 @@ mission "Coalition: Interpreters 1"
 		government "Heliarch"
 	destination
 		government "Coalition"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -316,6 +344,8 @@ mission "Coalition: Interpreters 2"
 		government "Heliarch"
 	destination
 		government "Coalition"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -335,6 +365,8 @@ mission "Coalition: Interpreters 3"
 		government "Heliarch"
 	destination
 		government "Coalition"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -359,6 +391,8 @@ mission "Coalition: Peacekeepers 1"
 		government "Heliarch"
 	destination
 		government "Coalition"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -378,6 +412,8 @@ mission "Coalition: Peacekeepers 2"
 		government "Heliarch"
 	destination
 		government "Coalition"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -402,6 +438,8 @@ mission "Coalition: Saryd Interspecies 1"
 		attributes "saryd"
 	destination
 		attributes "kimek" "arach"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -421,6 +459,8 @@ mission "Coalition: Saryd Interspecies 2"
 		attributes "saryd"
 	destination
 		attributes "kimek" "arach"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -440,6 +480,8 @@ mission "Coalition: Kimek Interspecies 1"
 		attributes "kimek"
 	destination
 		attributes "saryd" "arach"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -459,6 +501,8 @@ mission "Coalition: Kimek Interspecies 2"
 		attributes "kimek"
 	destination
 		attributes "saryd" "arach"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -478,6 +522,8 @@ mission "Coalition: Arach Interspecies 1"
 		attributes "arach"
 	destination
 		attributes "saryd" "kimek"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -497,6 +543,8 @@ mission "Coalition: Arach Interspecies 2"
 		attributes "arach"
 	destination
 		attributes "saryd" "kimek"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -523,6 +571,8 @@ mission "Coalition: Transfer 1"
 		government "Coalition"
 		attributes "mining" "farming" "factory" "oil"
 		distance 2 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -544,6 +594,8 @@ mission "Coalition: Transfer 2"
 		government "Coalition"
 		attributes "mining" "farming" "factory" "oil"
 		distance 2 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -565,6 +617,8 @@ mission "Coalition: Transfer 3"
 		government "Coalition"
 		attributes "mining" "farming" "factory" "oil"
 		distance 2 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -594,6 +648,8 @@ mission "Coalition: Tourists Out 1"
 		government "Coalition"
 		attributes "tourism"
 		distance 5 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment 22000 200
@@ -617,6 +673,8 @@ mission "Coalition: Tourists Out 2"
 		government "Coalition"
 		attributes "tourism"
 		distance 5 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment 32000 200
@@ -640,6 +698,8 @@ mission "Coalition: Tourists Out 3"
 		government "Coalition"
 		attributes "tourism"
 		distance 5 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment 42000 200
@@ -668,6 +728,8 @@ mission "Coalition: Tourists Home 1"
 	destination
 		government "Coalition"
 		distance 5 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment 22000 200
@@ -691,6 +753,8 @@ mission "Coalition: Tourists Home 2"
 	destination
 		government "Coalition"
 		distance 5 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment 32000 200
@@ -714,6 +778,8 @@ mission "Coalition: Tourists Home 3"
 	destination
 		government "Coalition"
 		distance 5 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment 42000 200
@@ -739,6 +805,8 @@ mission "Coalition: Fast Courier 1"
 	destination
 		government "Coalition"
 		distance 6 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -760,6 +828,8 @@ mission "Coalition: Fast Courier 2"
 	destination
 		government "Coalition"
 		distance 6 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -781,6 +851,8 @@ mission "Coalition: Fast Courier 3"
 	destination
 		government "Coalition"
 		distance 6 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -806,6 +878,8 @@ mission "Coalition: Cargo 1"
 	destination
 		government "Coalition"
 		distance 2 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -826,6 +900,8 @@ mission "Coalition: Cargo 2"
 	destination
 		government "Coalition"
 		distance 2 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -846,6 +922,8 @@ mission "Coalition: Cargo 3"
 	destination
 		government "Coalition"
 		distance 2 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -866,6 +944,8 @@ mission "Coalition: Cargo 4"
 	destination
 		government "Coalition"
 		distance 2 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -887,6 +967,8 @@ mission "Coalition: Bulk 1"
 	destination
 		government "Coalition"
 		distance 3 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -907,6 +989,8 @@ mission "Coalition: Bulk 2"
 	destination
 		government "Coalition"
 		distance 3 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -927,6 +1011,8 @@ mission "Coalition: Bulk 3"
 	destination
 		government "Coalition"
 		distance 3 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -947,6 +1033,8 @@ mission "Coalition: Bulk 4"
 	destination
 		government "Coalition"
 		distance 3 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -969,6 +1057,8 @@ mission "Coalition: Rush 1"
 	destination
 		government "Coalition"
 		distance 4 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -990,6 +1080,8 @@ mission "Coalition: Rush 2"
 	destination
 		government "Coalition"
 		distance 4 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -1011,6 +1103,8 @@ mission "Coalition: Rush 3"
 	destination
 		government "Coalition"
 		distance 4 20
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -1033,6 +1127,8 @@ mission "Coalition: Doctors"
 	destination
 		government "Coalition"
 		distance 4 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -1057,6 +1153,8 @@ mission "Coalition: Cadets 1"
 		near "Belug" 1 20
 		government "Coalition"
 	destination "Belug's Plunge"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -1076,6 +1174,8 @@ mission "Coalition: Cadets 2"
 		near "Belug" 2 20
 		government "Coalition"
 	destination "Belug's Plunge"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -1102,6 +1202,8 @@ mission "Coalition: To Games 1"
 		near "Homeward" 2 20
 		government "Coalition"
 	destination "Far Home"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment 10000 200
@@ -1122,6 +1224,8 @@ mission "Coalition: To Games 2"
 		near "Homeward" 2 20
 		government "Coalition"
 	destination "Far Home"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment 15000 200
@@ -1142,6 +1246,8 @@ mission "Coalition: To Games 3"
 		near "Homeward" 2 20
 		government "Coalition"
 	destination "Far Home"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment 25000 200
@@ -1163,6 +1269,8 @@ mission "Coalition: From Games 1"
 	destination
 		government "Coalition"
 		distance 2 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -1184,6 +1292,8 @@ mission "Coalition: From Games 2"
 	destination
 		government "Coalition"
 		distance 2 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment
@@ -1205,6 +1315,8 @@ mission "Coalition: From Games 3"
 	destination
 		government "Coalition"
 		distance 2 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"coalition jobs" ++
 		payment

--- a/data/deep jobs.txt
+++ b/data/deep jobs.txt
@@ -62,6 +62,8 @@ mission "Deep Mystery Cube [0]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 	on accept
 		dialog phrase "deep mystery cube pickup"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"mystery cube" ++
 		payment 5000 1000
@@ -90,6 +92,8 @@ mission "Deep Mystery Cube [1]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 	on accept
 		dialog phrase "deep mystery cube pickup"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"mystery cube" ++
 		payment 5000 1000
@@ -118,6 +122,8 @@ mission "Deep Mystery Cube [2]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 	on accept
 		dialog phrase "deep mystery cube pickup"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"mystery cube" ++
 		payment 5000 1000
@@ -146,6 +152,8 @@ mission "Deep Mystery Cube [3]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 	on accept
 		dialog phrase "deep mystery cube pickup"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		"mystery cube" ++
 		payment 5000 1000
@@ -200,6 +208,8 @@ mission "Transport scientists"
 		distance 2 50
 	on stopover
 		dialog "The scientists have been giddily discussing the results of their research during the entire trip. You're happy for a bit of peace and quiet as they make tracks for a prominent research lab to have the results analyzed. You prepare for the return journey to <planet>."
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		dialog "You bid goodbye to the scientists and accept your payment of <payment>."
 		payment
@@ -269,6 +279,8 @@ mission "Record academic conference"
 	destination
 		attributes "research" "quarg" "rich" "paradise"
 		distance 4 10
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		dialog phrase "academic conference recording payment"
 		payment 5000 1000

--- a/data/dirt belt jobs.txt
+++ b/data/dirt belt jobs.txt
@@ -24,6 +24,8 @@ mission "Drought Relief"
 		distance 3 10
 		attributes "dirt belt"
 		attributes "farming"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 10000 160
 		dialog "You drop off your cargo of <commodity> and collect your payment of <payment>. A group of <planet> citizens thank you and bid you farewell."
@@ -56,6 +58,8 @@ mission "To Remembrance Day celebration [0]"
 	destination
 		distance 3 15
 		attributes "dirt belt"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 1000 180
 		dialog "You wish your <passengers> the best of luck on <planet>. The children run off your ship in green face paint, and the parents pay you <payment>."
@@ -88,6 +92,8 @@ mission "To Remembrance Day celebration [1]"
 	destination
 		distance 3 15
 		attributes "dirt belt"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 180
 		dialog `Spaceport workers already festively dressed for Remembrance Day remove the cargo of <commodity> from your ship and hand you your payment of <payment>.`
@@ -119,6 +125,8 @@ mission "To Remembrance Day celebration [2]"
 	destination
 		distance 3 15
 		attributes "dirt belt"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 180
 		dialog `Spaceport workers already festively dressed for Remembrance Day remove the cargo of <commodity> from your ship and hand you your payment of <payment>.`
@@ -148,6 +156,8 @@ mission "From Remembrance Day celebration [0]"
 	destination
 		distance 3 15
 		attributes "dirt belt"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 1000
@@ -178,6 +188,8 @@ mission "From Remembrance Day celebration [1]"
 	destination
 		distance 3 15
 		attributes "dirt belt"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 1000

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1461,6 +1461,9 @@ mission "Raider Attack 2"
 phrase "generic cargo delivery payment"
 	word
 		`You drop off your cargo of <commodity> and collect your payment of <payment>.`
+phrase "generic cargo on visit"
+	word
+		`You have reached <planet>, but not all of the cargo is in the system! Better depart and wait for your escorts to arrive in this star system.`
 
 mission "Cargo [0]"
 	name "Delivery to <planet>"
@@ -1473,6 +1476,8 @@ mission "Cargo [0]"
 	destination
 		distance 2 8
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -1490,6 +1495,8 @@ mission "Cargo [1]"
 	destination
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -1508,6 +1515,8 @@ mission "Cargo [2]"
 	destination
 		distance 2 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -1526,6 +1535,8 @@ mission "Cargo [3]"
 	destination
 		distance 3 14
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 2000
@@ -1545,6 +1556,8 @@ mission "Cargo [4]"
 	destination
 		distance 4 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 4000
@@ -1563,6 +1576,8 @@ mission "Bulk Delivery [0]"
 	destination
 		distance 2 8
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -1580,6 +1595,8 @@ mission "Bulk Delivery [1]"
 	destination
 		distance 3 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 2000
@@ -1599,6 +1616,8 @@ mission "Bulk Delivery [2]"
 	destination
 		distance 4 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 4000
@@ -1618,6 +1637,8 @@ mission "Rush Delivery [0]"
 	destination
 		distance 4 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 16000
@@ -1637,6 +1658,8 @@ mission "Rush Delivery [1]"
 	destination
 		distance 5 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 18000
@@ -1657,6 +1680,8 @@ mission "Rush Delivery [2]"
 	destination
 		distance 6 14
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 20000
@@ -1677,6 +1702,8 @@ mission "Rush Delivery [3]"
 	destination
 		distance 7 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 22000
@@ -1688,6 +1715,9 @@ phrase "generic passenger dropoff payment"
 	word
 		`You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>.`
 		`You say farewell to your <passengers> on <planet>, and collect your payment of <payment>.`
+phrase "generic passenger on visit"
+	word
+		`You have reached <planet>, but not all of the passengers are in the system! Better depart and wait for your escorts to arrive in this star system.`
 
 mission "Passengers [0]"
 	name "Passenger transport to <planet>"
@@ -1700,6 +1730,8 @@ mission "Passengers [0]"
 	destination
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 2000
@@ -1718,6 +1750,8 @@ mission "Passengers [1]"
 	destination
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		dialog phrase "generic passenger dropoff payment"
@@ -1735,6 +1769,8 @@ mission "Passengers [2]"
 	destination
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		dialog phrase "generic passenger dropoff payment"
@@ -1752,6 +1788,8 @@ mission "Passengers [3]"
 	destination
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		dialog phrase "generic passenger dropoff payment"
@@ -1770,6 +1808,8 @@ mission "Passengers [4]"
 	destination
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 2000
@@ -1788,6 +1828,8 @@ mission "Transport miners to <planet>"
 		attributes "mining"
 		distance 3 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 2000
@@ -1806,6 +1848,8 @@ mission "Transport farmers to <planet>"
 		attributes "farming"
 		distance 3 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 2000
@@ -1824,6 +1868,8 @@ mission "Transport mill workers to <planet>"
 		attributes "textiles"
 		distance 3 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 2000
@@ -1842,6 +1888,8 @@ mission "Transport workers to <planet>"
 		attributes "factory"
 		distance 3 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 2000
@@ -1861,6 +1909,8 @@ mission "Tourists out [0]"
 		attributes "tourism"
 		distance 6 35
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 6000
@@ -1880,6 +1930,8 @@ mission "Tourists out [1]"
 		attributes "tourism"
 		distance 2 25
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 4000
@@ -1902,6 +1954,8 @@ mission "Wealthy tourists out"
 		attributes "tourism"
 		distance 4 30
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 200
 		dialog phrase "generic passenger dropoff payment"
@@ -1920,6 +1974,8 @@ mission "Tourists back [0]"
 	destination
 		distance 6 35
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 6000
@@ -1939,6 +1995,8 @@ mission "Tourists back [1]"
 	destination
 		distance 2 25
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 4000
@@ -1961,6 +2019,8 @@ mission "Wealthy tourists back"
 		attributes "rich" "urban"
 		distance 4 30
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 200
 		dialog phrase "generic passenger dropoff payment"
@@ -1979,6 +2039,8 @@ mission "Family [0]"
 	destination
 		distance 4 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 4000
@@ -1998,6 +2060,8 @@ mission "Family [1]"
 	destination
 		distance 5 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 6000
@@ -2017,6 +2081,8 @@ mission "Family [2]"
 	destination
 		distance 6 24
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 8000
@@ -2036,6 +2102,8 @@ mission "Family [3]"
 	destination
 		distance 8 32
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -2056,6 +2124,8 @@ mission "Strike Breakers [mining]"
 		attributes "mining"
 		distance 2 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -2076,6 +2146,8 @@ mission "Strike Breakers [textile]"
 		attributes "textiles"
 		distance 2 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -2096,6 +2168,8 @@ mission "Strike Breakers [factory]"
 		attributes "factory"
 		distance 2 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -2117,6 +2191,8 @@ mission "Colonists [0]"
 		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest"
 		distance 2 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 8000
@@ -2138,6 +2214,8 @@ mission "Colonists [1]"
 		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest"
 		distance 4 30
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -2160,6 +2238,8 @@ mission "Prisoners [0]"
 		random < 15
 	on offer
 		require "Brig"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 165
 		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of several well-armed guards as they prepare to repay their debts to society as forced laborers in <planet>'s mines. You collect your payment of <payment>."
@@ -2181,6 +2261,8 @@ mission "Prisoners [1]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "factory"
 		attributes "north" "south" "rim" "frontier" "core"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 165
 		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of several well-armed guards as they prepare to repay their debts to society as forced laborers in <planet>'s factories. You collect your payment of <payment>."
@@ -2201,6 +2283,8 @@ mission "Prisoners [2]"
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "paradise"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 165
 		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of several well-armed guards as they prepare to repay their debts to society as domestic servants for <planet>'s wealthy elite. You collect your payment of <payment>."
@@ -2221,6 +2305,8 @@ mission "Prisoners [3]"
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "frontier" "moon" "military"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 165
 		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of several well-armed guards as they prepare to repay their debts to society in a penal colony on this remote world. You collect your payment of <payment>."
@@ -2242,6 +2328,8 @@ mission "Prisoners [4]"
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "frontier" "moon" "military"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 25000 175
 		dialog "Your shackled passengers offer bitter curses as burly and well-armed guards practically beat them out of your ship, driving them in the direction of a penal colony on this remote world. You collect your payment of <payment>."
@@ -2267,6 +2355,8 @@ mission "Released Prisoners [0]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	to offer
 		random < 15
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 3000 150
 		dialog "The released prisoners walk out into the spaceport with nothing but their meager belongings and discharge paperwork. You collect your payment of <payment>."
@@ -2285,6 +2375,8 @@ mission "Released Prisoners [1]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	to offer
 		random < 15
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 3000 150
 		dialog "The released prisoners walk out into the spaceport with nothing but their meager belongings and discharge paperwork. You collect your payment of <payment>."
@@ -2303,6 +2395,8 @@ mission "Released Prisoners [2]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	to offer
 		random < 15
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 3000 150
 		dialog "The released prisoners walk into the spaceport with nothing but discharge paperwork and the clothes on their backs. You collect your payment of <payment>."
@@ -2321,6 +2415,8 @@ mission "Large Bulk Delivery [0]"
 	destination
 		distance 2 8
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 4000
@@ -2340,6 +2436,8 @@ mission "Large Bulk Delivery [1]"
 	destination
 		distance 3 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 6000
@@ -2360,6 +2458,8 @@ mission "Large Bulk Delivery [2]"
 	destination
 		distance 4 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 8000
@@ -2380,6 +2480,8 @@ mission "Large Rush Delivery [0]"
 	destination
 		distance 4 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 36000
@@ -2400,6 +2502,8 @@ mission "Large Rush Delivery [1]"
 	destination
 		distance 5 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 38000
@@ -2421,6 +2525,8 @@ mission "Large Rush Delivery [2]"
 	destination
 		distance 6 14
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 40000
@@ -2442,6 +2548,8 @@ mission "Large Rush Delivery [3]"
 	destination
 		distance 7 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 42000
@@ -2460,6 +2568,8 @@ mission "Recycle garbage"
 	destination
 		attributes "factory" "mining" "dirt belt"
 		distance 9 12
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		dialog "You drop off the <commodity> at an especially smelly solid waste recycler and collect your payment of <payment>."
 		payment

--- a/data/near earth jobs.txt
+++ b/data/near earth jobs.txt
@@ -21,6 +21,8 @@ mission "Historical field trip to <planet>"
 	destination
 		distance 4 12
 		attributes "near earth"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -54,6 +56,8 @@ mission "To Earth Day celebration [0]"
 		near "Sol" 1 15
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	destination "Earth"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 1000 180
 		dialog "You wish your <passengers> the best of luck on <planet>. After collecting your payment of <payment>, your <passengers> put on their Earth Day hats and leave with their belongings."
@@ -86,6 +90,8 @@ mission "To Earth Day celebration [1]"
 		near "Sol" 1 15
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 	destination "Earth"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 180
 		dialog `Spaceport workers already festively dressed for Earth Day remove the cargo of <commodity> from your ship and hand you your payment of <payment>.`
@@ -114,6 +120,8 @@ mission "From Earth Day celebration [0]"
 	destination
 		distance 1 15
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 1000
@@ -143,6 +151,8 @@ mission "From Earth Day celebration [1]"
 	destination
 		distance 1 15
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 1000

--- a/data/paradise world jobs.txt
+++ b/data/paradise world jobs.txt
@@ -23,6 +23,8 @@ mission "Care package to <planet>"
 		distance 2 5
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "paradise" "research" "rich"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 5000
@@ -43,6 +45,8 @@ mission "Birthday supplies to <planet>"
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "paradise" "rich" "core" "near earth"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 5000
@@ -63,6 +67,8 @@ mission "Art delivery to <planet>"
 	destination
 		distance 2 5
 		attributes "paradise"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 5000
@@ -86,6 +92,8 @@ mission "Newlyweds to <planet>"
 		distance 2 15
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Quarg"
 		attributes "paradise" "rich" "core" "near earth"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 250
 		dialog "You bid the two lovebirds goodbye on <planet> and collect your payment of <payment>."
@@ -105,6 +113,8 @@ mission "Theater props to <planet>"
 	destination
 		distance 2 8
 		attributes "paradise"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 8000
@@ -125,6 +135,8 @@ mission "Fine food to <planet>"
 	destination
 		distance 2 10
 		attributes "paradise"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 8000
@@ -149,6 +161,8 @@ mission "Transport partiers [1]"
 	destination
 		distance 4 12
 		attributes "tourism"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 200
 		dialog "You're not sorry to say goodbye to the rowdy and uncouth troublemakers you've been transporting. Their parents send you your payment of <payment> with not a word of acknowledgement."
@@ -170,6 +184,8 @@ mission "Transport partiers [2]"
 	destination
 		distance 4 12
 		attributes "tourism"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 190
 		dialog "You bid goodbye to the students, who behaved surprisingly well during the journey - yielding many fascinating conversations on subjects as diverse as philosophy, microfluidics, and intergalactic economics. Their proud parents send you your payment of <payment>."
@@ -186,6 +202,8 @@ mission "Food donations to <planet>"
 	destination
 		distance 2 16
 		attributes "rim" "south" "dirt belt" "frontier" "military"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 90
 		dialog "You collect your payment of <payment>, but not before noticing the general robustness and ample bellies of the dockworkers unloading the donation of <commodity>."
@@ -203,6 +221,8 @@ mission "Clothing donations to <planet>"
 	destination
 		distance 2 16
 		attributes "rim" "south" "dirt belt" "frontier" "military"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 100
 		dialog "You collect your payment of <payment>, but not before noticing the fine quality of the clothes worn by the dockworkers unloading the donation of <commodity>."
@@ -220,6 +240,8 @@ mission "Medical aid to <planet>"
 	destination
 		distance 2 16
 		attributes "rim" "south" "dirt belt" "frontier" "military"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 100
 		dialog "You collect your payment of <payment>, but not before noticing the general health and vigor of the dockworkers unloading the donation of <commodity>."
@@ -237,6 +259,8 @@ mission "Charity goods to <planet>"
 	destination
 		distance 2 16
 		attributes "rim" "south" "dirt belt" "frontier" "military"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 100
 		dialog "You collect your payment of <payment>, but not before noticing the quality of the clothes, jewelry, and personal electronics carried by the dockworkers unloading the donation of <commodity>."
@@ -278,6 +302,8 @@ mission "Estate assets to <planet>"
 	destination
 		distance 3 12
 		attributes "rich"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 10000
@@ -316,6 +342,8 @@ mission "Waste disposal on <planet>"
 	destination
 		distance 2 20
 		attributes "dirt belt"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		dialog "You drop off the exceptionally foul shipment of <commodity> on <planet>, already looking forward to the chemical bath your cargo hold is going to receive. You collect your payment of <payment> and hope that somebody around here knows what to do with the unpleasant mess you dropped off."
@@ -335,6 +363,8 @@ mission "Transport high-class tourists"
 	destination
 		attributes "religious" "quarg" "pirate" "volcanic" "frontier"
 		distance 8 20
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		dialog "Your passengers begin to wander off, some of them sporting puzzled looks as the memories of glossy photos in the brochures give way to reality. You collect your payment of <payment>."
 		payment 25000 250

--- a/data/pirate jobs.txt
+++ b/data/pirate jobs.txt
@@ -24,6 +24,8 @@ mission "Cargo Smuggling [0]"
 	destination
 		distance 3 6
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 4000 200
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -45,6 +47,8 @@ mission "Cargo Smuggling [1]"
 	destination
 		distance 3 8
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 4000 200
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -66,6 +70,8 @@ mission "Cargo Smuggling [2]"
 	destination
 		distance 4 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 200
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -87,6 +93,8 @@ mission "Cargo Smuggling [3]"
 	destination
 		distance 5 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 6000 200
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -110,6 +118,8 @@ mission "Drug Running [0]"
 	destination
 		distance 3 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 250
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -131,6 +141,8 @@ mission "Drug Running [1]"
 	destination
 		distance 4 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 250
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -152,6 +164,8 @@ mission "Drug Running [2]"
 	destination
 		distance 5 14
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 7000 250
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -173,6 +187,8 @@ mission "Drug Running [3]"
 	destination
 		distance 6 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 9000 250
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -196,6 +212,8 @@ mission "Bulk Cargo Smuggling [0]"
 	destination
 		distance 3 8
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 7000 200
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -217,6 +235,8 @@ mission "Bulk Cargo Smuggling [1]"
 	destination
 		distance 3 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 10000 200
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -238,6 +258,8 @@ mission "Bulk Cargo Smuggling [2]"
 	destination
 		distance 4 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 15000 200
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -261,6 +283,8 @@ mission "Bulk Drug Running [0]"
 	destination
 		distance 4 12
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 10000 250
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -282,6 +306,8 @@ mission "Bulk Drug Running [1]"
 	destination
 		distance 5 14
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 15000 250
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -303,6 +329,8 @@ mission "Bulk Drug Running [2]"
 	destination
 		distance 6 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Pirate"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 20000 250
 		dialog "You find the contact at the edge of the spaceport. Your cargo of <commodity> is removed from your ship and you collect your payment of <payment>."
@@ -356,6 +384,8 @@ mission "Stealth Cargo Smuggling (North) [0]"
 	on fail
 		"reputation: Republic" -= 5
 		"reputation: Navy (Oathkeeper)" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 50000 300
 		"reputation: Pirate" += 5
@@ -431,6 +461,8 @@ mission "Stealth Cargo Smuggling (North) [1]"
 	on fail
 		"reputation: Republic" -= 5
 		"reputation: Navy (Oathkeeper)" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 75000 300
 		"reputation: Pirate" += 5
@@ -482,6 +514,8 @@ mission "Stealth Cargo Smuggling (Core) [0]"
 				"Quicksilver (Scanner)"
 	on fail
 		"reputation: Syndicate" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 50000 300
 		"reputation: Pirate" += 5
@@ -559,6 +593,8 @@ mission "Stealth Cargo Smuggling (Core) [1]"
 				"Quicksilver (Scanner)" 2
 	on fail
 		"reputation: Syndicate" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 75000 300
 		"reputation: Pirate" += 5
@@ -611,6 +647,8 @@ mission "Stealth Cargo Smuggling (South) [0]"
 	on fail
 		"reputation: Free Worlds" -= 5
 		"reputation: Militia" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 50000 300
 		"reputation: Pirate" += 5
@@ -689,6 +727,8 @@ mission "Stealth Cargo Smuggling (South) [1]"
 	on fail
 		"reputation: Free Worlds" -= 5
 		"reputation: Militia" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 75000 300
 		"reputation: Pirate" += 5
@@ -743,6 +783,8 @@ mission "Stealth Drug Running (North) [0]"
 	on fail
 		"reputation: Republic" -= 5
 		"reputation: Navy (Oathkeeper)" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 75000 375
 		"reputation: Pirate" += 5
@@ -818,6 +860,8 @@ mission "Stealth Drug Running (North) [1]"
 	on fail
 		"reputation: Republic" -= 5
 		"reputation: Navy (Oathkeeper)" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 100000 375
 		"reputation: Pirate" += 5
@@ -869,6 +913,8 @@ mission "Stealth Drug Running (Core) [0]"
 				"Quicksilver (Scanner)"
 	on fail
 		"reputation: Syndicate" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 75000 375
 		"reputation: Pirate" += 5
@@ -946,6 +992,8 @@ mission "Stealth Drug Running (Core) [1]"
 				"Quicksilver (Scanner)" 2
 	on fail
 		"reputation: Syndicate" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 100000 375
 		"reputation: Pirate" += 5
@@ -998,6 +1046,8 @@ mission "Stealth Drug Running (South) [0]"
 	on fail
 		"reputation: Free Worlds" -= 5
 		"reputation: Militia" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 75000 375
 		"reputation: Pirate" += 5
@@ -1076,6 +1126,8 @@ mission "Stealth Drug Running (South) [1]"
 	on fail
 		"reputation: Free Worlds" -= 5
 		"reputation: Militia" -= 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 100000 375
 		"reputation: Pirate" += 5
@@ -1101,6 +1153,8 @@ mission "Wanted Passenger [0]"
 	destination
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 30000 300
 		dialog "Your <passengers> insists that you land on the edge of the spaceport to avoid being seen. After you land, they pay you <payment> before quickly grabbing their things and leaving your ship."
@@ -1123,6 +1177,8 @@ mission "Wanted Passengers [1]"
 	destination
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 20000 300
 		dialog "Your <passengers> insist that you land on the edge of the spaceport to avoid being seen. After you land, they pay you <payment> before quickly grabbing their things and leaving your ship."
@@ -1145,6 +1201,8 @@ mission "Wanted Passengers [2]"
 	destination
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 20000 300
 		dialog "Your <passengers> insist that you land on the edge of the spaceport to avoid being seen. After you land, they pay you <payment> before quickly grabbing their things and leaving your ship."
@@ -1167,6 +1225,8 @@ mission "Wanted Passengers [3]"
 	destination
 		distance 2 10
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 20000 300
 		dialog "Your <passengers> insist that you land on the edge of the spaceport to avoid being seen. After you land, they pay you <payment> before quickly grabbing their things and leaving your ship."
@@ -1251,6 +1311,8 @@ mission "Highly Wanted Passenger (North)"
 	on fail
 		"reputation: Republic" -= 5
 		"reputation: Navy (Oathkeeper)" -= 5
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 200000 1000
 		"reputation: Pirate" += 5
@@ -1336,6 +1398,8 @@ mission "Highly Wanted Passenger (Core)"
 				"Quicksilver (Scanner)" 2
 	on fail
 		"reputation: Syndicate" -= 5
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 200000 1000
 		"reputation: Pirate" += 5
@@ -1422,6 +1486,8 @@ mission "Highly Wanted Passenger (South)"
 	on fail
 		"reputation: Free Worlds" -= 5
 		"reputation: Militia" -= 5
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 200000 1000
 		"reputation: Pirate" += 5
@@ -1447,6 +1513,8 @@ mission "Slave Transport [0]"
 	destination
 		distance 3 30
 		government "Pirate"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 75000 400
 		dialog "After landing on <planet>, the pirates move the <bunks> slaves from your ship and pay you <payment>."
@@ -1469,6 +1537,8 @@ mission "Slave Transport [1]"
 	destination
 		distance 3 30
 		government "Pirate"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 75000 400
 		dialog "After landing on <planet>, the pirates move the <bunks> slaves from your ship and pay you <payment>."
@@ -1491,6 +1561,8 @@ mission "Slave Transport [2]"
 	destination
 		distance 3 30
 		government "Pirate"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 75000 400
 		dialog "After landing on <planet>, the pirates move the <bunks> slaves from your ship and pay you <payment>."
@@ -1515,6 +1587,8 @@ mission "Bulk Slave Transport [0]"
 	destination
 		distance 3 30
 		government "Pirate"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 100000 400
 		dialog "After landing on <planet>, the pirates move the <bunks> slaves from your ship and pay you <payment>."
@@ -1537,6 +1611,8 @@ mission "Bulk Slave Transport [1]"
 	destination
 		distance 3 30
 		government "Pirate"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 100000 400
 		dialog "After landing on <planet>, the pirates move the <bunks> slaves from your ship and pay you <payment>."

--- a/data/rim jobs.txt
+++ b/data/rim jobs.txt
@@ -24,6 +24,8 @@ mission "Southbound Shipment [0]"
 		government "Pirate"
 		personality heroic harvests plunders
 		fleet "Small Southern Pirates"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 0 160
 		dialog phrase "generic cargo delivery payment"
@@ -44,6 +46,8 @@ mission "Southbound Shipment [1]"
 		government "Pirate"
 		personality heroic harvests plunders
 		fleet "Small Southern Pirates"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 0 160
 		dialog phrase "generic cargo delivery payment"
@@ -65,6 +69,8 @@ mission "Kraz Shipment"
 		government "Pirate"
 		personality heroic harvests plunders
 		fleet "Small Southern Pirates"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 0 160
 		dialog phrase "generic cargo delivery payment"

--- a/data/south jobs.txt
+++ b/data/south jobs.txt
@@ -135,6 +135,8 @@ mission "Sketchy Cargo [0]"
 		attributes "south"
 	on accept
 		dialog `You follow the directions specified in the job to an abandoned-looking warehouse and find your cargo in unlabeled crates. As you load it onto your ship, you get the feeling that you are being watched.`
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 0 160
 		dialog "You drop off the unlabeled cargo in a warehouse not too dissimilar to the one you picked it up in. A man dressed in a cloak hands you <payment> after the last crate is removed from your ship."
@@ -154,6 +156,8 @@ mission "Sketchy Cargo [1]"
 		attributes "south"
 	on accept
 		dialog `You follow the directions specified in the job to an abandoned-looking warehouse and find your cargo in unlabeled crates. As you load it onto your ship, you get the feeling that you are being watched.`
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 0 160
 		dialog "You drop off the unlabeled cargo in a warehouse not too dissimilar to the one you picked it up in. A man dressed in a cloak hands you <payment> after the last crate is removed from your ship."
@@ -175,6 +179,8 @@ mission "Sketchy Passenger [0]"
 		attributes "south"
 	on accept
 		dialog `You have some difficulty finding your passengers, but after almost an hour of searching you finally find them. As they follow you back to your ship, you hear them whispering to each other, but you can't make out what they're saying.`
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 2000 160
 		dialog "Your passengers ask that you land away from the busy spaceport center. They hand you <payment> and rush out of your ship and away from the spaceport with considerable speed."
@@ -194,6 +200,8 @@ mission "Sketchy Passenger [1]"
 		attributes "south"
 	on accept
 		dialog `You have some difficulty finding your passengers, but after almost an hour of searching you finally find them. As they follow you back to your ship, you hear them whispering to each other, but you can't make out what they're saying.`
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 2000 160
 		dialog "Your passengers ask that you land away from the busy spaceport center. They hand you <payment> and rush out of your ship and away from the spaceport with considerable speed."

--- a/data/syndicate jobs.txt
+++ b/data/syndicate jobs.txt
@@ -25,6 +25,8 @@ mission "Transport executive to <planet>"
 		distance 3 15
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent" "Quarg"
 		attributes "paradise" "rich" "core" "near earth"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 250
 		dialog "The executive rushes off your ship without even a goodbye, fancy briefcase in hand. You collect your payment of <payment>."
@@ -93,6 +95,8 @@ mission "Document delivery to <planet>"
 		distance 3 20
 		government Republic "Free Worlds" Syndicate Neutral
 		attributes factory mining "dirt belt"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 170
 		dialog "Almost as soon as you open the cargo hatch, several silent and surprisingly well-dressed men feed the crates of documents onto a conveyor belt right next to your landing site that you hadn't noticed, where to your surprise they soon disappear into the flames of an industrial incinerator. You collect your payment of <payment>."
@@ -110,6 +114,8 @@ mission "Waste recycling on <planet>"
 	destination
 		distance 3 10
 		government Syndicate
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 2000
@@ -131,6 +137,8 @@ mission "Rush fuel Delivery"
 	destination
 		distance 3 10
 		government Syndicate
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 20000
@@ -151,6 +159,8 @@ mission "Rush equipment Delivery"
 	destination
 		distance 3 10
 		government Syndicate
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 9000
@@ -311,6 +321,9 @@ ship "Vanguard" "Vanguard Test Dummy"
 		"automaton" 1
 		"self destruct" 1
 
+phrase "generic cargo and passenger on visit"
+	word
+		`You have reached <planet>, but not all of the cargo and passengers are in the system! Better depart and wait for your escorts to arrive in this star system.`
 
 mission "Syndicate Prisoner Transport [0]"
 	name "Transport executive to house arrest"
@@ -331,6 +344,8 @@ mission "Syndicate Prisoner Transport [0]"
 		random < 5
 	on offer
 		require "Luxury Accommodations"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 10000 200
 		dialog "The executive strolls off your ship with a sunny smile on his face. One of the lawyers hands you your payment of <payment> with muttered threats about libel lawsuits if you say anything about what you may or may not have overheard on your ship."
@@ -353,6 +368,8 @@ mission "Syndicate Prisoner Transport [1]"
 		random < 15
 	on offer
 		require "Brig"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 200
 		dialog "A group of guards carry the prisoner off your ship more roughly than is strictly necessary. You receive your payment of <payment>."
@@ -375,6 +392,8 @@ mission "Syndicate Prisoner Transport [2]"
 		random < 15
 	on offer
 		require "Brig"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 15000 175
 		dialog "A group of guards lead the prisoners off your ship, chained together at the ankles. You receive your payment of <payment>."
@@ -398,6 +417,8 @@ mission "Syndicate Prisoner Transport [3]"
 		random < 15
 	on offer
 		require "Brig"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 150
 		dialog "The prisoners are still wearing their civilian clothes, and you can see bruises from when they were arrested as the guards lead them inside. You receive your payment of <payment>."
@@ -421,6 +442,8 @@ mission "Syndicate Prisoner Transport [4]"
 		random < 10
 	on offer
 		require "Brig"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 15000 200
 		dialog `The union organizers are defiant as the guards drag them inside, and one of the organizers yells about "class traitors." You receive your payment of <payment>.`
@@ -445,6 +468,8 @@ mission "Return Syndicate Prisoners [0]"
 		random < 5
 	on offer
 		require "Luxury Accommodations"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 20000 200
 		dialog "The executive strides toward the express customs entrance with a smug grin. A paperwork-laden lawyer gives you your payment of <payment>."
@@ -466,6 +491,8 @@ mission "Return Syndicate Prisoners [1]"
 		not attributes "military"
 	to offer
 		random < 15
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 100
 		dialog "The protesters look around the spaceport nervously before disembarking. You receive your payment of <payment>."
@@ -487,6 +514,8 @@ mission "Return Syndicate Prisoners [2]"
 		not attributes "military"
 	to offer
 		random < 10
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 100
 		dialog "The labor organizers are almost skeletally thin from their imprisonment. One of them raises his face to the sky as though showering in sunlight. You receive your payment of <payment>."

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -24,6 +24,8 @@ mission "Wanderer Workers [0]"
 		distance 2 8
 		attributes "factory" "urban"
 		government "Wanderer"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -44,6 +46,8 @@ mission "Wanderer Workers [1]"
 		distance 2 8
 		attributes "factory" "urban"
 		government "Wanderer"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 15000
@@ -65,6 +69,8 @@ mission "Wanderer Farmers [0]"
 		distance 2 8
 		attributes "farming"
 		government "Wanderer"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -86,6 +92,8 @@ mission "Wanderer Farmers [1]"
 		distance 2 8
 		attributes "farming"
 		government "Wanderer"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 15000
@@ -106,6 +114,8 @@ mission "Wanderer Younglings [0]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -126,6 +136,8 @@ mission "Wanderer Younglings [1]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -149,6 +161,8 @@ mission "Wanderer Scientists (Pollution) [0]"
 		distance 2 8
 		attributes "mining" "oil" "factory"
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 15000 180
 		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment of <payment>."
@@ -171,6 +185,8 @@ mission "Wanderer Scientists (Pollution) [1]"
 		distance 2 8
 		attributes "mining" "oil" "factory"
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 20000 180
 		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment of <payment>."
@@ -192,6 +208,8 @@ mission "Wanderer Scientists (Phenomenon) [0]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 15000 180
 		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment of <payment>."
@@ -213,6 +231,8 @@ mission "Wanderer Scientists (Phenomenon) [1]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 20000 180
 		dialog "You wish the scientists the best of luck on <planet> as they carry their scientific equipment off of your ship and hand you your payment of <payment>."
@@ -233,6 +253,8 @@ mission "Wanderer Biologists [0]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment
 		payment 15000
@@ -253,6 +275,8 @@ mission "Wanderer Biologists [1]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment
 		payment 20000
@@ -274,6 +298,8 @@ mission "Wanderer Botanists [0]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment
 		payment 15000
@@ -294,6 +320,8 @@ mission "Wanderer Botanists [1]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment
 		payment 20000
@@ -315,6 +343,8 @@ mission "Wanderer Harvest [0]"
 		distance 2 8
 		attributes "farming"
 		government "Wanderer"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 15000
@@ -336,6 +366,8 @@ mission "Wanderer Harvest [1]"
 		distance 2 8
 		attributes "farming"
 		government "Wanderer"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 20000
@@ -408,6 +440,8 @@ mission "Wanderer Cargo [0]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 2000
@@ -428,6 +462,8 @@ mission "Wanderer Cargo [1]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 4000
@@ -448,6 +484,8 @@ mission "Wanderer Cargo [2]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 6000
@@ -467,6 +505,8 @@ mission "Wanderer Cargo [3]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 8000
@@ -486,6 +526,8 @@ mission "Wanderer Cargo [4]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 10000
@@ -508,6 +550,8 @@ mission "Wanderer Rush Delivery [0]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 32000
@@ -529,6 +573,8 @@ mission "Wanderer Rush Delivery [1]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 40000
@@ -549,6 +595,8 @@ mission "Wanderer Rush Delivery [2]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 44000
@@ -569,6 +617,8 @@ mission "Wanderer Rush Delivery [3]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 50000
@@ -590,6 +640,8 @@ mission "Wanderer Bulk Delivery [0]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 10000
@@ -610,6 +662,8 @@ mission "Wanderer Bulk Delivery [1]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 14000
@@ -629,6 +683,8 @@ mission "Wanderer Bulk Delivery [2]"
 	destination
 		distance 2 8
 		government "Wanderer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 20000


### PR DESCRIPTION
Currently, the player will only receive an `on visit` dialog in certain missions, mainly escort missions where they have left the escort behind, or those missions where an objective must be completed first like killing/evading/disabling the enemy. There are other situations though where a player may get to the destination but need an `on visit` dialog to tell them why it isn't complete, such as cargo or passenger missions where the player may have escorts lagging behind.

This PR adds generic `on visit` dialogs to all jobs that have cargo or passengers. This PR does not touch any spaceport missions. I also skipped over certain jobs that weren't strictly "take this cargo/these passengers here," such as a few jobs that had stopovers, like the Wanderer Invasive Species jobs or a job I spotted in the Paradise Worlds file.

Should we merge this, I'll go through the actual missions and give less generic `on visit` messages for them.