### PR TITLE
Reduced the speed of the Centipede

### DIFF
--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -74,8 +74,8 @@ ship "Centipede"
 		"hull" 2400
 		"required crew" 35
 		"bunks" 131
-		"mass" 128
-		"drag" 3
+		"mass" 168
+		"drag" 4
 		"heat dissipation" .75
 		"fuel capacity" 600
 		"cargo space" 38

--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -75,7 +75,7 @@ ship "Centipede"
 		"required crew" 35
 		"bunks" 131
 		"mass" 168
-		"drag" 4
+		"drag" 4.4
 		"heat dissipation" .75
 		"fuel capacity" 600
 		"cargo space" 38

--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -75,7 +75,7 @@ ship "Centipede"
 		"required crew" 35
 		"bunks" 131
 		"mass" 168
-		"drag" 4.4
+		"drag" 4
 		"heat dissipation" .75
 		"fuel capacity" 600
 		"cargo space" 38


### PR DESCRIPTION
Even considering the fact that Hai engines are very good, the Centipede is rather fast for its size. This change brings the Centipede's speed in a bit.

Comparing with a Star Queen fitted with the same engines as the Centipede, as the Centipede was intended as a Hai version of the Star Queen.

Ship | Max Speed | Turn Rate (empty)
----|-----|----
Star Queen (5 spare outfit space) | 452.7 | 140
Centipede (current, 20 spare outfit space) | 830 | 169
Centipede (changed, 20 spare outfit space) | 622.5 | 156