### PR TITLE
Added an extra mission so the player has one active after the Sestor Remnant

### DIFF
--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -2632,11 +2632,27 @@ mission "Wanderers: Sestor: Remnant Visit"
 
 
 
+mission "Wanderers: Sestor: Drones in Alnilam Waypoint"
+	landing
+	source
+	name "Drones in Alnilam"
+	description "Eliminate the remaining Kor Sestor fleet in the Alnilam system."
+	waypoint "Alnilam"
+	to offer
+		has "Wanderers: Sestor: Scattered Remnant: done"
+		or
+			not "Wanderers: Sestor: Alnilam Fleet 1: done"
+			not "Wanderers: Sestor: Alnilam Fleet 2: done"
+	to complete
+		has "Wanderers: Sestor: Alnilam Fleet 1: done"
+		has "Wanderers: Sestor: Alnilam Fleet 2: done"
+
+
+
 mission "Wanderers: Sestor: Drones in Alnilam"
 	landing
+	invisible
 	source "Farpoint"
-	name "Drones in Alnilam"
-	description "With the help of the Oathkeepers, eliminate the Kor Sestor fleet in the Alnilam system."
 	to offer
 		has "Wanderers: Sestor: Scattered Remnant: done"
 		or


### PR DESCRIPTION
Currently, after the player has destroyed the Sestor ships plaguing human space, it is possible for the player to be completely without a visible active mission despite the fact that there is still something to do. This occurs when the player still has to destroy the Sestor fleets in Alnilam, but doesn't ask for help from Danforth.

This PR adds an additional mission so that the player will always have one active during this part of the Wanderer campaign. As a result, the mission where the player asks for escorts is now invisible, as otherwise it would look like the player has two of the same mission.