### PR TITLE
Generic jobs can now offer from independent worlds

### DIFF
--- a/data/frontier jobs.txt
+++ b/data/frontier jobs.txt
@@ -19,9 +19,10 @@ mission "Frontier delivery [0]"
 	to offer
 		random < 30
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		not attributes "frontier"
 	destination
+		not government "Pirate"
 		distance 2 10
 		attributes "frontier"
 	npc
@@ -50,9 +51,10 @@ mission "Frontier delivery [1]"
 	to offer
 		random < 25
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		not attributes "frontier"
 	destination
+		not government "Pirate"
 		distance 2 10
 		attributes "frontier"
 	npc
@@ -81,9 +83,10 @@ mission "Frontier delivery [2]"
 	to offer
 		random < 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		not attributes "frontier"
 	destination
+		not government "Pirate"
 		distance 2 10
 		attributes "frontier"
 	npc
@@ -111,11 +114,12 @@ mission "Frontier Emigration [0]"
 	to offer
 		random < 30
 	source
+		not government "Pirate"
 		attributes "frontier"
 		not planet "Shangri-La"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		not attributes "frontier"
 	on complete
 		payment 3000 140
@@ -131,11 +135,12 @@ mission "Frontier Emigration [1]"
 	to offer
 		random < 25
 	source
+		not government "Pirate"
 		attributes "frontier"
 		not planet "Shangri-La"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		not attributes "frontier"
 	on complete
 		payment 3000 140
@@ -151,11 +156,12 @@ mission "Frontier Emigration [2]"
 	to offer
 		random < 20
 	source
+		not government "Pirate"
 		attributes "frontier"
 		not planet "Shangri-La"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		not attributes "frontier"
 	on complete
 		payment 3000 140
@@ -172,9 +178,10 @@ mission "Disaster Relief"
 	to offer
 		random < 10
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		not attributes "frontier"
 	destination
+		not government "Pirate"
 		distance 2 10
 		attributes "frontier"
 		not planet "Shangri-La"
@@ -194,6 +201,7 @@ mission "Instruct Novice Pilot"
 		government "Republic" "Free Worlds" "Neutral" "Independent"
 		attributes "frontier" "dirt belt" "rim" "north" "south" "mining" "farming"
 	stopover
+		not government "Pirate"
 		attributes "frontier" "outfitter"
 		distance 3 7
 	on stopover
@@ -234,7 +242,7 @@ mission "Small Pirate gambling"
 		"combat rating" < 200
 		credits > 14357
 	source
-		attributes "dirt belt" "south" "rim" "pirate"
+		attributes "dirt belt" "south" "rim" "pirate" "frontier"
 	on offer
 		conversation
 			`You're having a drink in a dimly lit spaceport bar when you notice a group of young men in crimson leather outfits gambling in a dark corner. The barman eyes them warily. One of them raises his drink and waves you over, beckoning to join their game.`

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -28,10 +28,10 @@ mission "Escort (Tiny, Northern, Dangerous Destination)"
 			"combat rating" > 0
 			has "ships: Interceptor"
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "deep" "paradise" "near earth"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "north"
 		distance 2 4
 	npc
@@ -89,10 +89,10 @@ mission "Escort (Tiny, Northern, Dangerous Origin)"
 			"combat rating" > 0
 			has "ships: Interceptor"
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "north"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "deep" "paradise" "near earth" "core"
 		distance 2 4
 	npc
@@ -147,10 +147,10 @@ mission "Escort (Small, Northern, Dangerous Destination)"
 		random < 70
 		"combat rating" > 5
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "deep" "paradise" "near earth"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "north"
 		distance 3 4
 	npc
@@ -195,10 +195,10 @@ mission "Escort (Small, Northern, Dangerous Origin)"
 		random < 40
 		"combat rating" > 5
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "north"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "deep" "paradise" "near earth" "core"
 		distance 3 4
 	npc
@@ -244,10 +244,10 @@ mission "Escort (Medium, Northern, Dangerous Destination)"
 		random < 40
 		"combat rating" > 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "deep" "paradise" "near earth"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "north"
 		distance 3 4
 	npc
@@ -298,10 +298,10 @@ mission "Escort (Medium, Northern, Dangerous Origin)"
 		random < 40
 		"combat rating" > 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "north"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "deep" "paradise" "near earth" "core"
 		distance 3 4
 	npc
@@ -352,10 +352,10 @@ mission "Escort (Large, Northern, Dangerous Destination)"
 		random < 30
 		"combat rating" > 60
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "deep" "paradise" "near earth"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "north"
 		distance 3 4
 	npc
@@ -397,10 +397,10 @@ mission "Escort (Large, Northern, Dangerous Origin)"
 		random < 30
 		"combat rating" > 60
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "north"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "deep" "paradise" "near earth" "core"
 		distance 3 4
 	npc
@@ -443,10 +443,10 @@ mission "Escort (Extra Large, Northern, Dangerous Destination)"
 		random < 15
 		"combat rating" > 100
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "deep" "paradise" "near earth"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "north"
 		distance 3 4
 	npc
@@ -490,10 +490,10 @@ mission "Escort (Extra Large, Northern, Dangerous Origin)"
 		random < 15
 		"combat rating" > 100
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "north"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "deep" "paradise" "near earth" "core"
 		distance 3 4
 	npc
@@ -546,10 +546,10 @@ mission "Escort (Tiny, Core, Dangerous Destination)"
 			"combat rating" > 0
 			has "ships: Interceptor"
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "near earth"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "north" "frontier" "dirt belt"
 		distance 2 4
 	npc
@@ -607,10 +607,10 @@ mission "Escort (Tiny, Core, Dangerous Origin)"
 			"combat rating" > 0
 			has "ships: Interceptor"
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "north" "frontier"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise" "near earth"
 		distance 2 5
 	npc
@@ -665,10 +665,10 @@ mission "Escort (Small, Core, Dangerous Destination)"
 		random < 70
 		"combat rating" > 5
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise" "near earth"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "north" "frontier" "dirt belt"
 		distance 3 4
 	npc
@@ -713,10 +713,10 @@ mission "Escort (Small, Core, Dangerous Origin)"
 		random < 70
 		"combat rating" > 5
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "north" "frontier"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise" "near earth"
 		distance 3 5
 	npc
@@ -762,10 +762,10 @@ mission "Escort (Medium, Core, Dangerous Destination)"
 		random < 40
 		"combat rating" > 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise" "near earth"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "north" "frontier" "dirt belt"
 		distance 3 4
 	npc
@@ -810,10 +810,10 @@ mission "Escort (Medium, Core, Dangerous Origin)"
 		random < 40
 		"combat rating" > 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "north" "frontier"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise" "near earth"
 		distance 3 5
 	npc
@@ -866,10 +866,10 @@ mission "Escort (Large, Core, Dangerous Destination)"
 		random < 50
 		"combat rating" > 60
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise" "near earth"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "north" "frontier" "dirt belt"
 		distance 3 4
 	npc
@@ -911,10 +911,10 @@ mission "Escort (Large, Core, Dangerous Origin)"
 		random < 50
 		"combat rating" > 60
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "north" "frontier"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise" "near earth"
 		distance 3 5
 	npc
@@ -957,10 +957,10 @@ mission "Escort (Extra Large, Core, Dangerous Destination)"
 		random < 20
 		"combat rating" > 100
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise" "near earth"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "north" "frontier" "dirt belt"
 		distance 3 4
 	npc
@@ -1004,10 +1004,10 @@ mission "Escort (Extra Large, Core, Dangerous Origin)"
 		random < 20
 		"combat rating" > 100
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "core" "north" "frontier"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise" "near earth"
 		distance 3 5
 	npc
@@ -1061,10 +1061,10 @@ mission "Escort (Tiny, Southern, Dangerous Origin or Destination)"
 			"combat rating" > 0
 			has "ships: Interceptor"
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "south" "rim" "dirt belt"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "south" "rim" "dirt belt"
 		distance 2 4
 	npc
@@ -1118,10 +1118,10 @@ mission "Escort (Small, Southern, Dangerous Origin or Destination)"
 		random < 70
 		"combat rating" > 5
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "south" "rim" "dirt belt"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "south" "rim" "dirt belt"
 		distance 3 4
 	npc
@@ -1159,10 +1159,10 @@ mission "Escort (Medium, Southern, Dangerous Origin or Destination)"
 		random < 40
 		"combat rating" > 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "south" "rim" "dirt belt"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "south" "rim" "dirt belt"
 		distance 3 4
 	npc
@@ -1200,10 +1200,10 @@ mission "Escort (Large, Southern, Dangerous Origin or Destination)"
 		random < 50
 		"combat rating" > 60
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "south" "rim" "dirt belt"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "south" "rim" "dirt belt"
 		distance 3 4
 	npc
@@ -1239,10 +1239,10 @@ mission "Escort (Extra Large, Southern, Dangerous Origin or Destination)"
 		random < 20
 		"combat rating" > 100
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "south" "rim" "dirt belt"
 	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "south" "rim" "dirt belt"
 		distance 3 4
 	npc
@@ -1297,8 +1297,9 @@ mission "Southern Pirate Attack"
 		"combat rating" > 100
 		random < 10
 	source
+		not government "Pirate"
 		attributes "frontier"
-		attributes rim south "dirt belt"
+		attributes "rim" "south" "dirt belt"
 	npc evade
 		government "Pirate"
 		personality heroic staying target harvests plunders
@@ -1330,8 +1331,9 @@ mission "Northern Pirate Attack"
 		"combat rating" > 100
 		random < 10
 	source
+		not government "Pirate"
 		attributes "frontier"
-		attributes north paradise deep
+		attributes "north" "paradise" "deep"
 	npc evade
 		government "Pirate"
 		personality heroic staying target harvests plunders
@@ -1363,6 +1365,7 @@ mission "Core Pirate Attack"
 		"combat rating" > 100
 		random < 10
 	source
+		not government "Pirate"
 		attributes "frontier"
 		attributes "core" "near earth"
 	npc evade
@@ -1469,10 +1472,10 @@ mission "Cargo [0]"
 	description "Deliver <cargo> to <destination>. Payment is <payment>."
 	cargo random 5 2 .1
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 8
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -1486,10 +1489,10 @@ mission "Cargo [1]"
 	to offer
 		random < 90
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -1504,10 +1507,10 @@ mission "Cargo [2]"
 		random < 80
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -1522,10 +1525,10 @@ mission "Cargo [3]"
 		random < 70
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 3 14
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 2000
@@ -1541,10 +1544,10 @@ mission "Cargo [4]"
 		random < 60
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 4 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 4000
@@ -1559,10 +1562,10 @@ mission "Bulk Delivery [0]"
 	to offer
 		random < 70
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 8
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -1576,10 +1579,10 @@ mission "Bulk Delivery [1]"
 	to offer
 		random < 60
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 2000
@@ -1595,10 +1598,10 @@ mission "Bulk Delivery [2]"
 		random < 50
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 4 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 4000
@@ -1614,10 +1617,10 @@ mission "Rush Delivery [0]"
 	to offer
 		random < 90
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 4 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 16000
@@ -1633,10 +1636,10 @@ mission "Rush Delivery [1]"
 	to offer
 		random < 80
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 5 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 18000
@@ -1653,10 +1656,10 @@ mission "Rush Delivery [2]"
 		random < 70
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 6 14
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 20000
@@ -1673,10 +1676,10 @@ mission "Rush Delivery [3]"
 		random < 60
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 7 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 22000
@@ -1696,10 +1699,10 @@ mission "Passengers [0]"
 	description "Bring <fare> to <destination>. Payment is <payment>."
 	passengers 1 10 .9
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 2000
@@ -1714,10 +1717,10 @@ mission "Passengers [1]"
 	to offer
 		random < 75
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		dialog phrase "generic passenger dropoff payment"
@@ -1731,10 +1734,10 @@ mission "Passengers [2]"
 	to offer
 		random < 50
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		dialog phrase "generic passenger dropoff payment"
@@ -1748,10 +1751,10 @@ mission "Passengers [3]"
 	to offer
 		random < 25
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		dialog phrase "generic passenger dropoff payment"
@@ -1766,10 +1769,10 @@ mission "Passengers [4]"
 		random < 50
 	source
 		attributes "urban"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 2000
@@ -1783,11 +1786,11 @@ mission "Transport miners to <planet>"
 	to offer
 		random < 50
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "mining"
 		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 2000
@@ -1801,11 +1804,11 @@ mission "Transport farmers to <planet>"
 	to offer
 		random < 50
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "farming"
 		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 2000
@@ -1819,11 +1822,11 @@ mission "Transport mill workers to <planet>"
 	to offer
 		random < 50
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "textiles"
 		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 2000
@@ -1837,11 +1840,11 @@ mission "Transport workers to <planet>"
 	to offer
 		random < 80
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "factory"
 		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 2000
@@ -1856,11 +1859,11 @@ mission "Tourists out [0]"
 	to offer
 		random < 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "tourism"
 		distance 6 35
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 6000
@@ -1875,11 +1878,11 @@ mission "Tourists out [1]"
 	to offer
 		random < 50
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "tourism"
 		distance 2 25
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 4000
@@ -1897,11 +1900,11 @@ mission "Wealthy tourists out"
 		require "Luxury Accommodations"
 	source
 		attributes "rich" "urban"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "tourism"
 		distance 4 30
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment 10000 200
 		dialog phrase "generic passenger dropoff payment"
@@ -1915,11 +1918,11 @@ mission "Tourists back [0]"
 	to offer
 		random < 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "tourism"
 	destination
 		distance 6 35
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 6000
@@ -1934,11 +1937,11 @@ mission "Tourists back [1]"
 	to offer
 		random < 50
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "tourism"
 	destination
 		distance 2 25
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 4000
@@ -1956,11 +1959,11 @@ mission "Wealthy tourists back"
 		require "Luxury Accommodations"
 	source
 		attributes "tourism"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "rich" "urban"
 		distance 4 30
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment 10000 200
 		dialog phrase "generic passenger dropoff payment"
@@ -1975,10 +1978,10 @@ mission "Family [0]"
 		random < 60
 		"passenger space" > 10
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 4 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 4000
@@ -1994,10 +1997,10 @@ mission "Family [1]"
 		random < 50
 		"passenger space" > 10
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 5 20
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 6000
@@ -2013,10 +2016,10 @@ mission "Family [2]"
 		random < 40
 		"passenger space" > 10
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 6 24
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 8000
@@ -2032,10 +2035,10 @@ mission "Family [3]"
 		random < 30
 		"passenger space" > 10
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 8 32
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 10000
@@ -2051,11 +2054,11 @@ mission "Strike Breakers [mining]"
 		random < 10
 		"passenger space" > 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "mining"
 		distance 2 20
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 10000
@@ -2071,11 +2074,11 @@ mission "Strike Breakers [textile]"
 		random < 10
 		"passenger space" > 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "textiles"
 		distance 2 20
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 10000
@@ -2091,11 +2094,11 @@ mission "Strike Breakers [factory]"
 		random < 10
 		"passenger space" > 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "factory"
 		distance 2 20
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 10000
@@ -2112,11 +2115,11 @@ mission "Colonists [0]"
 		"passenger space" > 30
 	source
 		attributes "urban" "near earth" "core" "factory"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest"
 		distance 2 20
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 8000
@@ -2133,11 +2136,11 @@ mission "Colonists [1]"
 		"passenger space" > 30
 	source
 		attributes "urban" "near earth" "core" "factory"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest"
 		distance 4 30
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 10000
@@ -2150,10 +2153,10 @@ mission "Prisoners [0]"
 	description "Bring <bunks> petty criminals to <destination>, where they will serve their sentences as mine laborers. Payment is <payment>."
 	passengers 2 10 .9
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "mining"
 		attributes "north" "south" "rim" "frontier" "core"
 	to offer
@@ -2175,10 +2178,10 @@ mission "Prisoners [1]"
 	on offer
 		require "Brig"
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "factory"
 		attributes "north" "south" "rim" "frontier" "core"
 	on complete
@@ -2196,10 +2199,10 @@ mission "Prisoners [2]"
 	on offer
 		require "Brig"
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise"
 	on complete
 		payment 5000 165
@@ -2216,10 +2219,10 @@ mission "Prisoners [3]"
 	on offer
 		require "Brig"
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "moon" "military"
 	on complete
 		payment 5000 165
@@ -2237,10 +2240,10 @@ mission "Prisoners [4]"
 	on offer
 		require "Brig"
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "moon" "military"
 	on complete
 		payment 25000 175
@@ -2259,12 +2262,12 @@ mission "Released Prisoners [0]"
 	description "Transport <bunks> prisoners home after completing their sentences of hard labor. Payment is <payment>."
 	passengers 2 10 .9
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "mining" "factory"
 		attributes "north" "south" "rim" "frontier" "core"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	to offer
 		random < 15
 	on complete
@@ -2278,11 +2281,11 @@ mission "Released Prisoners [1]"
 	description "Transport <bunks> prisoners home after completing their sentences as domestic servants. Payment is <payment>."
 	passengers 2 10 .9
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "paradise"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	to offer
 		random < 15
 	on complete
@@ -2296,11 +2299,11 @@ mission "Released Prisoners [2]"
 	description "Transport <bunks> prisoners home after completing their sentences in a penal colony. Payment is <payment>."
 	passengers 2 10 .9
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "frontier" "moon" "military"
 	destination
 		distance 2 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	to offer
 		random < 15
 	on complete
@@ -2317,10 +2320,10 @@ mission "Large Bulk Delivery [0]"
 		random < 70
 		"cargo space" > 160
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 2 8
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 4000
@@ -2336,10 +2339,10 @@ mission "Large Bulk Delivery [1]"
 		random < 60
 		"cargo space" > 160
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 3 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 6000
@@ -2356,10 +2359,10 @@ mission "Large Bulk Delivery [2]"
 		"cargo space" > 160
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 4 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 8000
@@ -2376,10 +2379,10 @@ mission "Large Rush Delivery [0]"
 		random < 90
 		"cargo space" > 80
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 4 10
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 36000
@@ -2396,10 +2399,10 @@ mission "Large Rush Delivery [1]"
 		random < 80
 		"cargo space" > 80
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 5 12
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 38000
@@ -2417,10 +2420,10 @@ mission "Large Rush Delivery [2]"
 		"cargo space" > 80
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 6 14
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 40000
@@ -2438,10 +2441,10 @@ mission "Large Rush Delivery [3]"
 		"cargo space" > 80
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 7 16
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on complete
 		payment
 		payment 42000
@@ -2685,7 +2688,7 @@ mission "Bounty Hunting (Marauder I)"
 				"combat rating" < 1200
 				random < 35
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
 		government "Bounty"
@@ -2711,7 +2714,7 @@ mission "Bounty Hunting (Marauder II)"
 				"combat rating" < 1800
 				random < 30
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
 		government "Bounty"
@@ -2737,7 +2740,7 @@ mission "Bounty Hunting (Marauder III)"
 				"combat rating" < 2200
 				random < 25
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
 		government "Bounty"
@@ -2763,7 +2766,7 @@ mission "Bounty Hunting (Marauder IV)"
 				"combat rating" < 2700
 				random < 30
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
 		government "Bounty"
@@ -2789,7 +2792,7 @@ mission "Bounty Hunting (Marauder V)"
 				"combat rating" < 3500
 				random < 25
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
 		government "Bounty"
@@ -2816,7 +2819,7 @@ mission "Bounty Hunting (Marauder VI)"
 				"combat rating" < 5000
 				random < 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
 		government "Bounty"
@@ -2838,7 +2841,7 @@ mission "Bounty Hunting (Marauder VII)"
 		"combat rating" > 2980
 		random < 20
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
 		government "Bounty"
@@ -2860,7 +2863,7 @@ mission "Bounty Hunting (Marauder VIII)"
 		"combat rating" > 4000
 		random < 15
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
 		government "Bounty"
@@ -2882,7 +2885,7 @@ mission "Bounty Hunting (Marauder IX)"
 		"combat rating" > 6000
 		random < 10
 	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
 	npc kill
 		government "Bounty"

--- a/data/map.txt
+++ b/data/map.txt
@@ -23977,7 +23977,7 @@ planet Ahr
 	outfitter "Coalition Advanced"
 
 planet Albatross
-	attributes pirate "south pirate"
+	attributes pirate "south pirate" south frontier
 	landscape land/snow6
 	description `Albatross is a cold ocean world orbiting a small, cold sun. The first settlers on Albatross were anarchists who believed that in a society free from unnatural laws and constraints, everyone would happily and freely work for the common good. The next settlers were pirates who believed that a planet free from laws and constraints would be a great base of operations.`
 	description `	The anarchist farming communes, each operating independently but trading with outsiders to gain necessary supplies, are clustered in the barely temperate climate near the equator. The pirate bases, having a much more ready source of supplies, are located wherever there are flat landing areas close to craggy, defensible mountains.`
@@ -24270,7 +24270,7 @@ planet "Bright Echo"
 	outfitter "Coalition Basics"
 
 planet "Buccaneer Bay"
-	attributes pirate "core pirate"
+	attributes pirate "core pirate" core frontier
 	landscape land/beach0
 	description `Pirates who have struck it rich dream of retiring on Buccaneer Bay. It is a warm ocean planet, with many places reminiscent of the islands in the ancient Caribbean where humanity's first pirate fleets sailed.`
 	description `	Many of the inhabitants are in fact not pirates, but their descendants, and these children and grand-children of anarchist outlaws have built a system of regional government that oversees hospitals, schools, and other public services, all created without funding from the Republic or taxes paid to it. The planet even sports its own shipyard, although many of the ships built here are, not surprisingly, based on designs pirated from the Syndicate and Republic shipyards.`
@@ -24478,7 +24478,7 @@ planet "Corral of Meblumem"
 	"required reputation" 15
 
 planet Covert
-	attributes pirate mining "core pirate"
+	attributes pirate mining "core pirate" core frontier
 	landscape land/badlands2
 	description `Covert is home to a powerful mining cartel, operating outside the control of Republic law or any other external authority. It is rumored to be one of the few planets in human space where weapons-grade uranium and plutonium is mined and enriched. Any goods for sale here were most likely produced by slave labor, often by survivors of ships that have been captured by pirates. A massive pirate fleet is docked on the outskirts of the spaceport, a warning to any private pilot who might think of cheating or opposing the cartel.`
 	spaceport `From the moment you landed, you have been followed by a pair of security guards with earpieces and laser guns. The spaceport is one enormous building, with square, straight hallways and featureless walls, and nearly every door you pass is locked. Cameras at each hallway intersection pivot to watch as you approach. This is simultaneously one of the most secure spaceports you have visited, and one of the most dangerous, although if you do not do anything to provoke the animosity of the cartel, you will probably be able to leave in peace.`
@@ -24552,7 +24552,7 @@ planet Darkwaste
 	description `This planet seems to have all the conditions necessary for a vibrant, Earth-like ecology. The gravity and temperature are moderate, and there is a fair amount of surface water, although the oceans are quite small. However, aside from a few stunted plants and lichen, there is almost no native life here. Given how skilled the Hai appear to be at terraforming other worlds, it is strange that this one has been left barren.`
 
 planet "Deadman's Cove"
-	attributes pirate "core pirate"
+	attributes pirate "core pirate" core frontier
 	landscape land/sea1
 	description `Deadman's Cove is an ocean planet; the continents take up only a tenth of its surface area. Legends tell of massive sea creatures hiding in the deeps: serpents hundreds of meters long; colossal sea turtles; strange tentacled monsters and exotic fish.`
 	description `	One island archipelago is home to the spaceport, the only part of the planet where it is safe to land uninvited. The other islands - even some that seem from a distance to be uninhabited - are often used as staging bases for pirate fleets, who guard their secrets closely.`
@@ -24958,7 +24958,7 @@ planet "Fourth Shadow"
 	spaceport `The spaceport is crowded with travelers, about equally divided between those who are freshly arriving, drawn by the promise of plentiful work and a cheap cost of living, and those who are preparing to leave and attempt to build a better life somewhere else. Most Kimek choose to specialize as workers rather than raising families, so the vast majority of the travelers are alone or traveling only with a loosely knit group of friends.`
 
 planet Freedom
-	attributes pirate farming "north pirate"
+	attributes pirate farming "north pirate" north frontier
 	landscape land/bwerner7
 	description `Freedom is home to the oldest and largest anarchist colonies in human history. The original settlers arrived in the first century after the invention of the hyperdrive, coming with the goal of simply getting as far away from civilization as possible. The colony has reinvented itself countless times since then as different leaders have taken control, and in fact at present it is split into two separate towns, East Mesa and West Mesa.`
 	description `	The environment is a mix of deserts and brackish oceans, with a fair amount of native wildlife and good potential for farming. Anywhere else in human space, this planet would have become densely settled, but out here it has remained mostly empty.`
@@ -25114,7 +25114,7 @@ planet Greenbloom
 	spaceport `The spaceport is a massive floating island built by the Hai - a network of hexagonal platforms, each roughly half a kilometer in diameter, linked by bridges that can bend to accommodate the platforms rising and falling in rough weather. You are not sure what sort of alloy the platforms are built from, but judging by the fact that some of them have coral colonies growing on their edges, they can probably last for centuries without requiring any maintenance.`
 
 planet Greenrock
-	attributes pirate "south pirate"
+	attributes pirate "south pirate" south frontier
 	landscape land/sky0
 	description `Greenrock is the closest thing that the pirates in southern human space have to a center of government, but taking the form of large, powerful corporations rather than elected officials. When rival pirate bands seek to negotiate on neutral territory, this is where they meet. Nearly everything is for sale here: illegal weapons, ships customized for pirating, and even slaves.`
 	spaceport `You have heard enough about this port's reputation that you are not surprised to see the slave markets, heavily guarded in case any visitors happen to find themselves in possession of a conscience. Nor are you shocked by the shady establishments catering to all manner of prurient interests. This is, after all, a pirate port, and everything is for sale here.`
@@ -25177,7 +25177,7 @@ planet Harmony
 	security 0
 
 planet Haven
-	attributes pirate mining "north pirate"
+	attributes pirate mining "north pirate" north frontier
 	landscape land/dune1
 	description `Haven was founded by highly successful "privateers" nearly two centuries ago. Since then, as rival bands of pirates have fought over it, it has changed hands fourteen times, but has never been successfully invaded by the Republic. Numerous small manufacturing shops sell outfits that cannot be bought legally, and there is even a small shipyard where customized ships are sold.`
 	description `	Much of the planet is desert, but with enough moisture to grow enough crops to feed the entire population. Strip mining has turned other parts of the planet into barren wastelands, and has polluted many of the rivers.`
@@ -26669,7 +26669,7 @@ planet Slylandro
 	security 0
 
 planet "Smuggler's Den"
-	attributes pirate station "south pirate"
+	attributes pirate station "south pirate" south frontier
 	landscape land/loc1
 	description `Smuggler's Den was formerly known as Grendel Station, back when it was an operating refinery. But, it has since been taken over by pirates, who turned it into a haven for all manner of smugglers and privateers. The repair shops here can make a variety of legal and illegal modifications to your ship, and in the shipyard you can buy refurbished starships... if it does not trouble your conscience to think about the likely fates of their previous owners.`
 	spaceport `It is a strange but indisputable fact that pirates smell worse than ordinary human beings. In this day and age, where even the cheapest shuttlecraft at least has a sonic shower, there is no logical explanation for it, except that anarchist tendencies must somehow go hand in hand with a tendency to reject society's norms around hygiene. Here in a space station, with nothing but recycled air to breathe, the effect is overpowering.`
@@ -26762,7 +26762,7 @@ planet Stonebreak
 	outfitter "Hai Intermediate"
 
 planet Stormhold
-	attributes pirate "core pirate"
+	attributes pirate "core pirate" core frontier
 	landscape land/fog3
 	description `A cold planet, with dense, foggy atmosphere. As with many pirate outposts, Stormhold is home to an unknown number of villages and hidden outposts, each controlled by a different pirate faction. It is also said that some of the most dangerous fugitives in the galaxy live deep in the forests of this planet, escaping detection by living underground or by avoiding the use of electronic devices.`
 	spaceport `The spaceport is a large town, with a population of roughly thirty thousand. People of all races and cultures mingle freely, while keeping a wary eye open for off-worlders who may be Republic agents in disguise.`
@@ -26863,7 +26863,7 @@ planet Thrall
 		fleet "Large Republic" 8
 
 planet Thule
-	attributes pirate "south pirate"
+	attributes pirate "south pirate" south frontier
 	landscape land/dmottl2
 	description `Thule is a mountainous world with a population of nearly a billion, settled in the early days of space exploration. When the colony was first established, the Earth government did not yet have the strength to control any system but its own, and when the Republic was formed, Thule did not join, and has repulsed all efforts to force them to do so. It is well-known that the planet sponsors pirate fleets which bring it cheap materials to bolster its economy, but the planet is so far from the center of Republic space that fighting a war here would be prohibitively expensive, and so they remain unopposed.`
 	spaceport `The inhabitants of Thule are notoriously suspicious of strangers. They all seem to immediately recognize you as an off-worlder, perhaps by your clothing or your accent. The food sold in the shops is like nothing you have seen elsewhere, and the natives' accents are so strong that they almost seem to be speaking a different language. You feel as if you are visiting an alien world; centuries of separation has created a culture here that is very different from your own.`
@@ -27294,7 +27294,7 @@ planet "Wyvern Station"
 		fleet "Large Militia" 6
 
 planet Zenith
-	attributes pirate "north pirate"
+	attributes pirate "north pirate" north frontier
 	landscape land/water4
 	description `Zenith is a cold and unpleasant world, where the fog seldom lifts and the sun is rarely seen, where much of the lowlands are flooded each day by the tide, and storms are unpredictable and fierce. It has, however, one major advantage as a place to settle: it is far enough away that the Republic makes no attempt to control it.`
 	description `	Several villages have been founded near the equator, and in addition there are an unknown number of private holdings, ranging from underground bunkers to enormous cement fortresses. Because the land is owned by no government and anyone can build a dwelling without permission or paperwork as long as they are willing to fight off any other claimants, the total population of Zenith is unknown.`

--- a/data/rim jobs.txt
+++ b/data/rim jobs.txt
@@ -17,6 +17,7 @@ mission "Southbound Shipment [0]"
 	to offer
 		random < 10
 	source
+		not government "Pirate"
 		near "Zubeneschamali" 2 10
 		attributes "rim" "south"
 	destination "Zug"
@@ -37,6 +38,7 @@ mission "Southbound Shipment [1]"
 	to offer
 		random < 10
 	source
+		not government "Pirate"
 		near "Zubeneschamali" 2 10
 		attributes "rim" "south"
 	destination "Zug"
@@ -58,6 +60,7 @@ mission "Kraz Shipment"
 	to offer
 		random < 10
 	source
+		not government "Pirate"
 		near "Kraz" 2 10
 		attributes "rim" "south"
 	destination "Rust"

--- a/data/south jobs.txt
+++ b/data/south jobs.txt
@@ -17,8 +17,10 @@ mission "Pirate Occupation [0]"
 		random < 5
 		"combat rating" > 100
 	source
+		not government "Pirate"
 		attributes "south" "rim"
 	destination
+		not government "Pirate"
 		distance 2 3
 		attributes "south"
 	npc
@@ -50,8 +52,10 @@ mission "Pirate Occupation [1]"
 		random < 5
 		"combat rating" > 200
 	source
+		not government "Pirate"
 		attributes "south" "rim"
 	destination
+		not government "Pirate"
 		distance 2 3
 		attributes "south"
 	npc
@@ -84,8 +88,10 @@ mission "Pirate Occupation [2]"
 		random < 5
 		"combat rating" > 300
 	source
+		not government "Pirate"
 		attributes "south" "rim"
 	destination
+		not government "Pirate"
 		distance 2 3
 		attributes "south"
 	npc


### PR DESCRIPTION
Ref: #4243

I gave all pirate worlds the frontier attribute and a regional attribute. In order to avoid any strange job sources or destinations, I then went through some regional jobs to ensure that they wouldn't offer or have a destination on pirate planets. I then went into the jobs files and just replaced `government "Republic" "Free Worlds" "Syndicate" "Neutral"` with `government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"`. We can trim some fat from here if we want, though. (e.g. how Jana suggested not having passenger or rush delivery jobs to/from these former pirate worlds.)

The reason I added Independent to all the generic jobs, even some of the regional ones, is because of how future storylines may use the Independent government differently or on different worlds.