### PR TITLE
Stationary turret for missile hardpoint

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -92,8 +92,13 @@ void Outfit::Load(const DataNode &node)
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
 	
+	// Stationary turret for missile hardpoint
+	if (IsWeapon() && attributes.Get("turret mounts") && attributes.Get("turret noturn"))
+	{
+		SetTurretTurn(0.);
+	}
 	// Legacy support for turrets that don't specify a turn rate:
-	if(IsWeapon() && attributes.Get("turret mounts") && !TurretTurn() && !AntiMissile())
+	else if(IsWeapon() && attributes.Get("turret mounts") && !TurretTurn() && !AntiMissile())
 	{
 		SetTurretTurn(4.);
 		node.PrintTrace("Warning: Deprecated use of a turret without specified \"turret turn\":");

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -76,7 +76,8 @@ namespace {
 		{"unplunderable", "This outfit cannot be plundered."},
 		{"installable", "This is not an installable item."},
 		{"hyperdrive", "Allows you to make hyperjumps."},
-		{"jump drive", "Lets you jump to any nearby system."}
+		{"jump drive", "Lets you jump to any nearby system."},
+		{"turret noturn", "Stationary hardpoint."}
 	};
 }
 


### PR DESCRIPTION
With excelent tracking missiles it produces a nice curve shooting effect that was broken for me by the default turn rate. So I fixed it. :)
Add "turret notrurn" 1 to outfit attributes to make the turret stationary. (It overrides the specified or default turnrate!)