### PR TITLE
Remnant Fix: Adding Remnant license requirement to EMP torpedoes

### DIFF
--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -172,6 +172,8 @@ effect "point defense die"
 outfit "EMP Torpedo"
 	plural "EMP Torpedoes"
 	category "Ammunition"
+	licenses
+		Remnant
 	cost 4400
 	thumbnail "outfit/emp torpedo"
 	"mass" 1


### PR DESCRIPTION
Fixing the lack of a license requirement for the EMP torpedo.

This issue is mentioned in: https://github.com/endless-sky/endless-sky/pull/3805
And: https://github.com/endless-sky/endless-sky/pull/3818

This PR simply adds the requirement to have the Remnant license in order to purchase the EMP Torpedoes.

The Remnant are a reclusive, relatively tight knit society that is so paranoid about security that they force newcomers to take a blood test before having any dealings with them (and attack anyone that refuses). They are *not* going to sell advanced weaponry to someone without security clearances.

In reference to the PRs mentioned, there is no statement explaining if this is intentional or simply an oversight. Even the PR that would (from the title) deal with this specifically (PR #3818 ) is actually only a PR about adding the outfits to the outfitter, and doesn't deal with licenses at all.

Upon further reflection, it seems that the main logic behind not restricting the EMP torpedo is that the thunderheads and finishers don't require them either. While I can't speak for the thunderheads, it seems to me that the Coalition/Heliarchs are setup for a future plot line involving a rebellion, which could conceivably give the player access to outfitters that would be willing to supply the player with heliarch weaponry without caring about licenses. 

This does not apply to the Remnant. As mentioned above, they are a tight knit and very security conscious society that doesn't (and is very unlikely to have anywhere in the story as far as I can see) any kind of rebellion storyline, and thus no potential for having access to outfitters selling EMPs who aren't concerned about the lack of a license. 