### PR TITLE
Added on visit dialogs for nearly all missions that can trigger them

### DIFF
--- a/data/deep jobs.txt
+++ b/data/deep jobs.txt
@@ -181,6 +181,8 @@ mission "Mystery retrieval"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 	on stopover
 		dialog phrase "deep mystery cube pickup"
+	on visit
+		dialog phrase "generic missing stopover or cargo"
 	on complete
 		"mystery cube" ++
 		payment 5000 1000
@@ -209,7 +211,7 @@ mission "Transport scientists"
 	on stopover
 		dialog "The scientists have been giddily discussing the results of their research during the entire trip. You're happy for a bit of peace and quiet as they make tracks for a prominent research lab to have the results analyzed. You prepare for the return journey to <planet>."
 	on visit
-		dialog phrase "generic passenger on visit"
+		dialog phrase "generic missing stopover or passengers"
 	on complete
 		dialog "You bid goodbye to the scientists and accept your payment of <payment>."
 		payment

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -94,6 +94,8 @@ mission "Deep: Syndicate Convoy"
 	
 	on stopover
 		dialog `You arrive at the pickup location on the night side of Hephaestus. The Syndicate employees who load the freighters do not allow you to see what is inside the cargo, and advise you to leave quickly once the cargo is loaded.`
+	on visit
+		dialog `You have reached <planet>, but you're missing something! Either you haven't visited <stopovers>, or you left part of the convoy behind.`
 	on complete
 		"deep convoy" ++
 		payment 500000
@@ -191,6 +193,8 @@ mission "Deep: Tarazed Convoy"
 	
 	on stopover
 		dialog `You and the freighters are directed to park in a private hangar owned by the Tarazed Corporation. While watching the cargo crates get loaded on to the freighters, you notice that the crates have labels on them which read "To be opened by addressee only" in large red letters.`
+	on visit
+		dialog `You have reached <planet>, but you're missing something! Either you haven't visited <stopovers>, or you left part of the convoy behind.`
 	on complete
 		"deep convoy" ++
 		payment 650000
@@ -279,6 +283,8 @@ mission "Deep: Kraz Convoy"
 	
 	on stopover
 		dialog `When you arrive, Kraz Cybernetics already has the cargo waiting by the spaceport. After a few hours of loading the massive freighters, the spaceport crew gives you the 'all clear' signal, and the Behemoth captains get ready to depart.`
+	on visit
+		dialog `You have reached <planet>, but you're missing something! Either you haven't visited <stopovers>, or you left part of the convoy behind.`
 	on complete
 		"deep convoy" ++
 		payment 800000
@@ -304,7 +310,6 @@ mission "Deep: Mystery Cubes 0"
 	stopover "New Switzerland"
 	stopover "Tundra"
 	stopover "Arabia"
-	cargo "mystery cubes" 1
 	to offer
 		"mystery cube" >= 3
 		"combat rating" > 100
@@ -781,6 +786,8 @@ mission "Deep: TMBR 1"
 			`	Ulrich gathers up the rest of the band and they pack up their supplies. You chart a course for <destination> as the band load their musical equipment on your ship and get ready for the long ride back to human space.`
 				accept
 	
+	on visit
+		dialog `You arrive on <planet>, but realize that your escort carrying the band and their supplies has not arrived yet. Better depart and wait for your escorts to enter the system.`
 	on complete
 		payment 250000
 		log `Brought "There Might Be Riots" back to human space from their vacation in Hai space to play a concert for a team of scientists in the Deep.`
@@ -1080,6 +1087,8 @@ mission "Deep: Project Hawking"
 		system "Naos"
 		ship "Marauder Quicksilver (Engines)" "Gusoyn"
 	
+	on visit
+		dialog `You arrive on <planet>, but realize that your escort carrying the scientists and their supplies has not arrived yet. Better depart and wait for your escorts to enter the system.`
 	on complete
 		payment 1500000
 		log `Helped gather materials for "Project Hawking," an energy and weapons research project being conducted by scientists of the Deep. A pirate Quicksilver attacked the building where the supplies were being placed and crashlanded into the ground, triggering an earthquake.`
@@ -1436,6 +1445,8 @@ mission "Deep: Remnant 2A"
 				"Starling"
 		dialog `You have finished scanning the Remnant ships in the system. You may now return to <destination> with the scanner logs.`
 	
+	on visit
+		dialog `You show your scanner logs to Ivan, but he shakes his head. "This isn't enough. There should be more ships for you to scan in <stopovers>. Make sure you're using an outfit scanner as well."`
 	on complete
 		event "deep: scan log research" 15 32
 		log `Scanned Remnant ships beyond the wormhole in Terminus and handed the scan logs over to Ivan and his team.`
@@ -1469,6 +1480,8 @@ mission "Deep: Remnant 1B"
 				"Starling"
 		dialog `You have finished scanning the Remnant ships in the system. You may now return to <destination> with the scanner logs.`
 	
+	on visit
+		dialog `You show your scanner logs to Ivan, but he shakes his head. "This isn't enough. There should be more ships for you to scan in <stopovers>. Make sure you're using an outfit scanner as well."`
 	on complete
 		event "deep: scan log research" 15 32
 		log `Scanned Remnant ships beyond the wormhole in Terminus and handed the scan logs over to Ivan and his team.`
@@ -1504,6 +1517,8 @@ mission "Deep: Remnant 1C"
 				"Starling"
 		dialog `You have finished scanning the Remnant ships in the system. You may now return to <destination> with the scanner logs.`
 	
+	on visit
+		dialog `You show your scanner logs to Ivan, but he shakes his head. "This isn't enough. There should be more ships for you to scan in <stopovers>. Make sure you're using an outfit scanner as well."`
 	on complete
 		event "deep: scan log research" 15 32
 		log `Scanned Remnant ships beyond the wormhole in Terminus and handed the scan logs over to Ivan and his team.`

--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -67,7 +67,11 @@ phrase "generic missing stopover or escort"
 
 phrase "generic stopover on visit"
 	word
-		`You have reached <planet>, but you haven't visited all the stopovers yet! Better depart and make sure you visit <stopovers>.`
+		`You have reached <planet>, but you haven't visited all the planets yet! Better depart and make sure you visit <stopovers>.`
+phrase "generic waypoint on visit"
+	word
+		`You have reached <planet>, but you haven't visited all the systems yet! Better depart and make sure you visit <waypoints>.`
+
 
 phrase "generic hunted bounty eliminated dialog"
 	word

--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -1,0 +1,84 @@
+# Copyright (c) 2019 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+phrase "generic arrived-without-npc dialog"
+	word
+		`You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system.`
+phrase "generic safe escort completion dialog"
+	word
+		`The captain of the <npc> thanks you for escorting them safely, and pays you <payment>.`
+
+phrase "generic pirate attack payment dialog"
+	word
+		`The government of <planet>`
+	word
+		` `
+		` gratefully `
+	word
+		`pays you <payment> for helping to`
+	word
+		` drive off `
+		` defeat `
+	word
+		`the `
+	word
+		`pirates.`
+		`raiders.`
+		`attackers.`
+
+phrase "generic cargo delivery payment"
+	word
+		`You drop off your cargo of <commodity> and collect your payment of <payment>.`
+phrase "generic cargo on visit"
+	word
+		`You have reached <planet>, but not all of the cargo is in the system! Better depart and wait for your escorts to arrive in this star system.`
+
+phrase "generic passenger dropoff payment"
+	word
+		`You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>.`
+		`You say farewell to your <passengers> on <planet>, and collect your payment of <payment>.`
+phrase "generic passenger on visit"
+	word
+		`You have reached <planet>, but not all of the passengers are in the system! Better depart and wait for your escorts to arrive in this star system.`
+
+phrase "generic cargo and passenger on visit"
+	word
+		`You have reached <planet>, but not all of the cargo and passengers are in the system! Better depart and wait for your escorts to arrive in this star system.`
+
+phrase "generic missing stopover or cargo and passengers"
+	word
+		`You have reached <planet>, but you're missing something! Either you haven't visited <stopovers>, or not all the cargo and passengers are in the system.`
+phrase "generic missing stopover or passengers"
+	word
+		`You have reached <planet>, but you're missing something! Either you haven't visited <stopovers>, or not all the passengers are in the system.`
+phrase "generic missing stopover or cargo"
+	word
+		`You have reached <planet>, but you're missing something! Either you haven't visited <stopovers>, or not all the cargo is in the system.`
+phrase "generic missing stopover or escort"
+	word
+		`You have reached <planet>, but you're missing something! Either you haven't visited <stopovers>, or you left the <npc> behind.`
+
+phrase "generic stopover on visit"
+	word
+		`You have reached <planet>, but you haven't visited all the stopovers yet! Better depart and make sure you visit <stopovers>.`
+
+phrase "generic hunted bounty eliminated dialog"
+	word
+		`The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>.`
+phrase "generic bounty hunting payment dialog"
+	word
+		`The government of <planet> gratefully pays you <payment> for eliminating the <npc>.`
+
+phrase "generic hunted bounty fleet eliminated dialog"
+	word
+		`The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>.`
+phrase "generic fleet bounty hunting payment dialog"
+	word
+		`The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet.`

--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -79,6 +79,9 @@ phrase "generic hunted bounty eliminated dialog"
 phrase "generic bounty hunting payment dialog"
 	word
 		`The government of <planet> gratefully pays you <payment> for eliminating the <npc>.`
+phrase "generic bounty hunting on visit"
+	word
+		`You've landed on <planet>, but the <npc> has not been eliminated yet. Hunt it down and destroy it before returning.`
 
 phrase "generic hunted bounty fleet eliminated dialog"
 	word
@@ -86,3 +89,10 @@ phrase "generic hunted bounty fleet eliminated dialog"
 phrase "generic fleet bounty hunting payment dialog"
 	word
 		`The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet.`
+phrase "generic fleet bounty hunting on visit"
+	word
+		`You've landed on <planet>, but the <npc> and its fleet has not been eliminated yet. Hunt it down and destroy it before returning.`
+
+phrase "generic pirate fleet battle on visit"
+	word
+		`You've landed on <planet>, but there are still pirates circling overhead. You should take off and help finish them off.`

--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -82,6 +82,9 @@ phrase "generic bounty hunting payment dialog"
 phrase "generic bounty hunting on visit"
 	word
 		`You've landed on <planet>, but the <npc> has not been eliminated yet. Hunt it down and destroy it before returning.`
+phrase "generic bounty hunting boarding on visit"
+	word
+		`You've landed on <planet>, but you have not boarded the <npc> yet. Hunt it down and board it before returning.`
 
 phrase "generic hunted bounty fleet eliminated dialog"
 	word

--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -87,6 +87,8 @@ mission "FWC Attack Kaus Borealis"
 			`	"That's right," he says. "Once again, the Wolf Pack will go in first and soften them up, then you and your ships will clean up. I've already given the Wolf Pack orders to attack, so please head straight to Kaus Borealis so you can join the fray before they have time to recover."`
 				accept
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Navy ships circling overhead. You should take off and help finish them off.`
 	on complete
 		event "fwc capture kaus borealis"
 	
@@ -196,6 +198,8 @@ mission "FWC Cebalrai 1"
 			label end
 			`	"Well," he says, "if we can take Cebalrai, our entire territory will be behind just two choke points, which will allow us to defend ourselves against the Navy without spreading the fleet too thin. So next, I'd like you to go scout out the Cebalrai system and report on the Navy's position there."`
 				accept
+	on visit
+		dialog phrase "generic waypoint on visit"
 	
 	on enter "Cebalrai"
 		dialog
@@ -239,6 +243,8 @@ mission "FWC Cebalrai 1B"
 			`	Tomek looks rather somber before saying, "Bold move for a system we have completely surrounded. They're none of our concern right now. Let's make our way to Cebalrai."`
 				accept
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Navy ships circling overhead. You should take off and help finish them off.`
 	on complete
 		event "fwc capture cebalrai"
 	
@@ -411,6 +417,8 @@ mission "FWC Nuke Supply 1C"
 		conversation
 			`You land at one of the many private fortresses on Greenrock owned by various competing warlords. Some workers unload the cargo from the Blue Yonder, and load it up with some lead-lined, well-padded crates that must contain nuclear warheads. You're not sure you like being a part of this, but it may be true that this is the only way you will stand a chance against the Navy.`
 				accept
+	on visit
+		dialog phrase "generic arrived-without-npc dialog"
 	
 	npc accompany save
 		personality escort timid
@@ -538,6 +546,8 @@ mission "FWC Diplomacy 1C"
 			`	Alondo says, "That's right. Tungsten, to be exact. Aerodynamic tungsten rods, each the size of a tree trunk, with a simple guidance system on one end. Our ship is in low earth orbit, traveling at a velocity of roughly eight kilometers per second." As he speaks, the Parliament chamber gradually grows very quiet. "So we will be returning to our ship," says Alondo, "with Miss Reynolds. If the ship in orbit does not hear from me every two minutes, it will jettison its cargo, and there will be nothing left of this building but a crater." He points to the watch he is wearing, and you realize that it must be some sort of communicator.`
 			`	After a brief whispered consultation with a few of the other members of Parliament, Xao says, "You will lose this war, and you will pay dearly for it. Guards, let them return to their ship." You hurry back to your ship and take off immediately, aware that as soon as you are out of range of Earth, the Navy will probably be more than willing to attack you.`
 				launch
+	on visit
+		dialog `You land on <planet>, but you realize that Alondo and Katya are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	
 	npc
 		government "Escort"
@@ -755,6 +765,8 @@ mission "FWC Checkmate 1"
 				"Dreadnought"
 				"Osprey (Missile)"
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Navy ships circling overhead. You should take off and help finish them off.`
 	on complete
 		log "Defended Tundra against a major Navy counter-offensive. From here, the only recourse available to the Free Worlds seems to be to push deep into Republic territory and capture the Sol system, forcing the Navy to surrender. Nuclear weapons are now for sale on Solace to aid in the final assault."
 		event "fwc defended cebalrai"
@@ -822,6 +834,8 @@ mission "FWC Checkmate 1B"
 			`	Tomek tells the Wolf Pack captain, "Okay, we're ready to go. Launch immediately, and Captain <last> will follow behind you. <first>, Katya has asked to travel with you; she wants to get back into the action, and I thought she might have the best chance of anyone at dealing with the folks on the ground on <planet>. Once again, you'll need to drive off any Navy ships before landing there. Good luck."`
 				accept
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Navy ships circling overhead. You should take off and help finish them off.`
 	on complete
 		event "fwc capture menkent"
 
@@ -921,6 +935,8 @@ mission "FWC Checkmate 1C"
 			`[Take good care of this fleet, because it will have to last you for the rest of this campaign: if ships are disabled, board them to "repair" them once the battle is over. And, when jumping into battle, remember that you can hold down the jump key to get all your ships ready to jump simultaneously, so no single ship enters the system first and bears the brunt of the enemy fire.]`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but you realize that Katya is on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		log "The Free Worlds have captured the Vega system, only one hyperjump away from Earth. Nuclear-armed Wolf Pack ships will be arriving shortly to spearhead the assault, but the Navy fleet defending Earth will be massive. Casualties on both sides are likely to be extremely high."
 		conversation
@@ -1014,6 +1030,8 @@ mission "FWC Pug 1"
 			label end
 			`	You and hurry to your ship and fire it up for a hasty launch...`
 				launch
+	on visit
+		dialog `You've landed on <planet>, but there are still alien ships circling overhead. You should take off and help finish them off.`
 	
 	npc
 		personality waiting heroic
@@ -1235,6 +1253,8 @@ mission "FWC Pug 2B"
 			label end
 			`	Katya boards your ship, and you get ready for a diplomatic visit to the alien homeworld.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1307,6 +1327,8 @@ mission "FWC Pug 2C"
 			label end
 			`	"I don't like this at all," says Katya. "Let's head to <planet> and see if any of our equipment is left there from back when it was part of the front in the war against the Republic. Maybe we can find something useful there."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1340,6 +1362,8 @@ mission "FWC Pug 2D"
 			
 			`	"I don't think we have any other choice," she says. "Our friends out there need to know what is happening here. And maybe this, at last, will give the Navy a reason to stop fighting us and to begin working together for peace." Reluctantly, you agree.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya hasn't entered the system yet. Better depart and wait for it to arrive. (If your escorts don't have jump drives, try parking them so that Katya will be on your flagship.)`
 
 
 
@@ -1401,6 +1425,8 @@ mission "FWC Pug 3"
 			`	You and Katya return to your ship and prepare to make a visit to <planet>. Hopefully Freya will still be there, and the Navy will let you talk to her.`
 				accept
 
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 mission "FWC Pug 3A"
@@ -1461,6 +1487,8 @@ mission "FWC Pug 3A"
 			label end
 			`	You return to your ship with Freya, who is carrying a large collection of sensors and equipment. "Let's try <planet> first," she says, "and see if there's any alien technology there that we can use. I hope you still have some ships left in your battle fleet to help defend us."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1495,6 +1523,8 @@ mission "FWC Pug 3B"
 			label alone
 			`	The resistance fighters tell you their own fleet will be launching shortly. You return to your ship and fire up the engines, wishing that you had managed to keep some of the ships from your attack fleet alive, and hoping you will be able to hold off the Pug until Freya finishes her work down here...`
 				launch
+	on visit
+		dialog `You've landed on <planet>, but there are still Pug ships circling overhead. You should take off and help finish them off.`
 	
 	npc
 		government "Free Worlds"
@@ -1558,6 +1588,8 @@ mission "FWC Pug 3C"
 				`	"Do you actually have any idea what you're doing?"`
 			`	"None whatsoever," she says. "I'm just making this up as I go along, based on what I know of hyperspace physics. And for all I know the Pug ships carry the same hyperspace disruption capabilities as this facility, and this is all for nought. But let's give it a try, okay?"`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya and the graviton reflector hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1582,6 +1614,8 @@ mission "FWC Pug 3D"
 			`	You try to establish a communications link to the resistance fighters, and brief snatches of conversation come through, interspersed with static. After a few minutes the static begins to die down, and you can hear their voices more clearly. "It's working!" says Freya.`
 			`	Meanwhile, Navy and Free Worlds ships have begun pouring into the system. You suspect that the battle ahead will be a fierce one, but with a Navy war fleet on your side, it no longer feels like a hopeless cause. "The link should be strong enough for us to travel through it soon," says Freya. "Time to get back to <system>."`
 				accept
+	on visit
+		dialog `You've landed on <planet>, but there are still Pug ships circling overhead. You should take off and help finish them off.`
 	
 	npc evade
 		personality disables heroic staying
@@ -1689,6 +1723,8 @@ mission "FWC Pug 4"
 			`Your fleet lands on <planet>, and to your surprise the locals say that soon before your fleet arrived, all the Pug who were present on the planet departed; clearly they expected your arrival and had no desire to become your prisoners. You only have a few hours to take stock of the situation before the Navy informs you that they have detected another Pug fleet incoming...`
 				launch
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Pug ships circling overhead. You should take off and help finish them off.`
 	on complete
 		event "fwc liberation of rasalhague"
 	
@@ -1802,6 +1838,8 @@ mission "FWC Pug 4A"
 			label attack
 			`	"'Such a big fleet'?" he says. "This is not even a twentieth of the Navy's current fighting power. And I think we'll need many more ships before we're ready to take on the alien homeworld. But don't worry, reinforcements are arriving here constantly. You go do your part, and we'll see to ours."`
 				accept
+	on visit
+		dialog `You land on <planet>, but you realize that Freya is on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1840,6 +1878,8 @@ mission "FWC Pug 4B"
 			`	"Trust me," she says, "it's worth it, if we can get some real answers."`
 			`	"Straight answers from the Quarg?" you say. "Not likely, but it can't hurt to try."`
 				accept
+	on visit
+		dialog `You land on <planet>, but you realize that Freya and the graviton reflector are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1918,6 +1958,8 @@ mission "FWC Pug 4C"
 			`You help Freya to unload and set up the reflector equipment, then contact the Navy on Oblivion and instruct them to point the transmitter in your direction. A few minutes later Admiral Danforth contacts you. "This link appears to be returning too," he says. "So, let's move on. We're going to make an attack on the <system> system, now, and we would welcome your assistance in this battle." You leave the equipment on <origin> and return to your ship with Freya.`
 				accept
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Pug ships circling overhead. You should take off and help finish them off.`
 	on complete
 		log "Succeeded in restoring a few more hyperspace connections, and in driving back the Pug (with the help of the Navy). But, Freya thinks it is way too coincidental that the aliens have left behind the exact technology needed to fix the hyperspace disruptions; it feels like the Pug are playing a game rather than fighting a serious war."
 		event "fwc reconnect zeta aquilae"
@@ -2006,6 +2048,8 @@ mission "FWC Pug 5"
 			`	"Captain," he says, "the point isn't who deserves more credit. The point is, how do we tell this story in a way that makes people on my side and on yours more willing to make peace with each other? That's all I care about." He wishes you the best of luck in your attack on Vega, and says to contact him as soon as the link is restored and the reinforcements are ready.`
 				accept
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Pug ships circling overhead. You should take off and help finish them off.`
 	on complete
 		event "fwc liberation of vega"
 	
@@ -2067,6 +2111,8 @@ mission "FWC Pug 5B"
 			label next
 			`	You load the equipment onto your ship, and Freya says, "Let's set it up on <planet>, rather than Earth. I don't think the graviton radiation is harmful to human beings, but there's no point in placing it on such a densely populated planet."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya and the graviton reflector hasn't entered the system yet. Better depart and wait for it to arrive.`
 	
 	npc
 		government Republic
@@ -2107,6 +2153,8 @@ mission "FWC Pug 5C"
 			`	"Excellent," he says. "Please contact your Council and arrange for your fleet to strike from the south at the same time as the fleet from Vega jumps in from the north."`
 			`	You contact Tomek and tell him the Navy is ready for a final assault, and he agrees to send as many ships as he can spare to join you. Now it's time to return to <planet> and await the attack signal.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 	
 	npc
 		government Republic
@@ -2226,6 +2274,8 @@ mission "FWC Pug 6"
 				"Osprey (Laser)"
 				"Argosy (Turret)"
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		log `The Pug have fled, apparently traveling through an artificial wormhole back to whatever galaxy they came from. And, it turns out that many of their cities on "Pugglemug" were only for show: buildings with no inhabitants, and with holograms creating the appearance of a heavily populated world. They left no advanced technology behind, and no sign of what their true intentions were, but it turns out that the fake cities here were designed for human habitation. They must have been planning this departure for a very long time.`
 		log `Now that the Pug are gone, the Navy will be able to use the "graviton reflectors" to repair the broken hyperspace links and to reconnect all of human space.`

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -282,7 +282,8 @@ mission "FW Recon 0"
 				`	"No problem. But I'm afraid I don't have space for you right now."`
 					defer
 	
-	on visit`You land on <planet>, but you realize that the militia officer is on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
+	on visit
+		dialog `You land on <planet>, but you realize that the militia officer is on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		payment
 		dialog

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -60,6 +60,8 @@ mission "Pact Recon 0"
 	on accept
 		log "Volunteered to help the Southern Mutual Defense Pact keep tabs on pirate activity in their region of space. Pirate attacks seem to be getting worse because the Navy doesn't bother to patrol down here anymore."
 	
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		payment 25000
 		dialog
@@ -87,6 +89,8 @@ mission "Pact Recon 1"
 		dialog
 			`You receive a message from Freya, the militia officer in charge of tracking pirate activity. "We need some more eyes on the empty systems in the middle of the Dirt Belt," she says. "Pay would be a bit better than last time. Interested?"`
 	
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		payment 35000
 		dialog
@@ -114,6 +118,8 @@ mission "Pact Recon 2"
 		dialog
 			`You receive another message from Freya: "Hello Captain! I've got a more challenging and lucrative mission for you. We need someone to do a flyby of all four pirate systems here in the south, to gauge their strength. Again, no fighting is required. What do you say?"`
 	
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		payment 60000
 		dialog
@@ -148,6 +154,8 @@ mission "Pact Recon 3"
 		fleet "Small Southern Pirates" 3
 		fleet "Large Northern Pirates"
 	
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		payment 80000
 		dialog
@@ -274,6 +282,7 @@ mission "FW Recon 0"
 				`	"No problem. But I'm afraid I don't have space for you right now."`
 					defer
 	
+	on visit`You land on <planet>, but you realize that the militia officer is on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		payment
 		dialog
@@ -310,7 +319,7 @@ mission "FW Recon 1"
 	
 	npc "scan outfits"
 		government Republic
-		personality staying uninterested
+		personality staying uninterested target
 		fleet
 			names "republic capital"
 			fighters "republic fighter"
@@ -333,6 +342,8 @@ mission "FW Recon 1"
 			label close
 			`	You cut the commlink and breathe a sigh of relief that the conversation is over.`
 	
+	on visit
+		dialog `You land on <planet>, but you haven't yet scanned the Navy Cruiser patrolling the system. Depart and scan the Cruiser's outfits before returning.`
 	on complete
 		dialog `Soon after you land, the militia officer comes to your ship and pays you <payment> in exchange for your sensor logs regarding the <npc>. He says, "If you would be interested in continuing to work for us, meet me in the spaceport bar in an hour."`
 		payment 10000
@@ -363,7 +374,7 @@ mission "FW Recon 2"
 	
 	npc "scan outfits"
 		government "Republic"
-		personality staying uninterested
+		personality staying uninterested target
 		system "Menkent"
 		fleet
 			names "republic capital"
@@ -372,6 +383,8 @@ mission "FW Recon 2"
 				"Cruiser (Heavy)" 4
 		dialog "You've scanned all the ships you can find here that seem to be upgraded for combat. Time to return to <planet> to collect your payment."
 	
+	on visit
+		dialog `You land on <planet>, but you haven't yet scanned the Navy Cruisers patrolling Menkent. Depart and scan the Cruisers' outfits before returning.`
 	on complete
 		dialog `JJ meets you as soon as you land, and you hand over the scanner data. "Thank you again," he says. "If you're willing to take on one more recon mission, meet me in the bar." He hands you <payment>.`
 		payment 50000
@@ -580,6 +593,8 @@ mission "FW Katya 1B"
 			`	Much later that night, as planned, three shadowy figures load a set of unmarked crates into your cargo bay. Katya assured you that the contents are harmless, just intended to distract the Republic security officers, but you can't help feeling like you're getting involved in something shady.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Marty, Sarah, and the medical supplies hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		payment 100000
 		conversation
@@ -685,7 +700,6 @@ mission "FW Katya Alt 2"
 	source
 		government "Free Worlds"
 	destination Foundry
-	blocked "You have reached <origin>, but you have no bunks free for Mr. Eyes. Return here when you have a bunk available, or abort one of your other missions to make room for this one."
 	passengers 1
 	to offer
 		has "event: FW Katya Alt 2: ready"
@@ -715,6 +729,8 @@ mission "FW Katya Alt 2"
 				`	"Sorry, this sounds a bit too shady to me."`
 					decline
 	
+	on visit
+		dialog `You land on <planet>, but your escort with room for Mr. Eyes hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		set "FW Katya 2: done"
 
@@ -740,6 +756,8 @@ mission "FW Katya 2"
 			
 			`	"Great!" she says. "His name is Mr. Eyes, and he'll meet you on <destination>. For his safety, I'd rather not tell you anything about his work, but I assure you he's an upstanding citizen. A little unpopular with big corporations and certain corrupt local governments, though."`
 				accept
+	on visit
+		dialog `You land on <planet>, but your escort with room for Mr. Eyes hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -809,6 +827,8 @@ mission "FW Katya 2B"
 			`	"First," he says, "we need to go to Geminus, where the attack happened. I can explain more when we get there. In the meantime, I should also warn you that I seem to have terrible luck with pirates showing up wherever I go. It's almost like someone has put a price on my head." He grins.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but you realize that Mr. Eyes is on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on accept
 		log `Met up with a friend of Katya's named Mr. Eyes, who calls himself a "vigilante nuclear power plant inspector." He thinks he can help hunt down the people who bombed Geminus and Martini, to prove that the Free Worlds were not behind it.`
 
@@ -830,6 +850,8 @@ mission "FW Katya 2C"
 			`It turns out that the suitcase Mr. Eyes is carrying is full of portable sensors. He fires them up while explaining to you what he is doing. "Each world, and even each mine, has a slightly different mix of isotopes in their fissionable elements," he explains. "So what I'm doing right now is almost like taking a fingerprint. Once we've got it, we can try to find a match on another planet. I'd be willing to bet the material just came from a civilian reactor core, so tracking it back to the mine wouldn't necessarily incriminate anyone. But developing nukes is tricky, so they probably did tests. And if we can find the test site, that may lead us to the perpetrators."`
 			`	A few minutes later, his measurements are done. "Got it," he says. "Time to start hunting. Katya said to meet up with her on <planet>. It's not our best bet, but it's on the list of suspects."`
 				accept
+	on visit
+		dialog `You land on <planet>, but you realize that Mr. Eyes is on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		payment 100000
 		conversation
@@ -891,6 +913,8 @@ mission "FW Katya 3"
 	on accept
 		log "Katya's plan for hunting down the nuclear terrorists involves stealing the sensor equipment from a Navy surveillance drone. Supposedly taking equipment from a drone counts as a salvage operation as long as none of its owners are present, due to a legal loophole in an old act of Parliament."
 	
+	on visit
+		dialog `You land on <planet>, but you don't have a Surveillance Pod. You must disable a Navy surveillance drone and plunder the outfit from it before returning.`
 	on complete
 		outfit "Surveillance Pod" -1
 		conversation
@@ -932,6 +956,8 @@ mission "FW Katya 4"
 			`	"I'd hate to be rich," says Katya. "So much to fear."`
 			`	You finish your meal (Katya pays the tab), and agree to take off for <planet> first thing in the morning.`
 				accept
+	on visit
+		dialog `You land on <planet>, but you realize that Katya and Mr. Eyes are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -988,6 +1014,8 @@ mission "FW Katya 5"
 					accept
 				`	"Sorry, but I think I'm done with helping the Free Worlds. I'd rather strike out on my own."`
 					decline
+	on visit
+		dialog `You land on <planet>, but you realize that Katya and Mr. Eyes are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1046,6 +1074,8 @@ mission "FW Katya 5B"
 			label morning
 			`	At breakfast in the monastery, Mr. Eyes tells you, "I'm going to be staying here until you get back. Greenrock is no place for a man with a price on his head. But Katya will be going with you." You bring Katya and Greg back to your ship and get ready to take off.`
 				accept
+	on visit
+		dialog `You land on <planet>, but you realize that Katya and Brother Greg are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1070,6 +1100,8 @@ mission "FW Katya 5C"
 			`	"Well, let's head back to <planet> and see what Eyes thinks," says Katya, "but I can't imagine the Navy would have such an arsenal. Searching on mining planets sounds like our best bet for now."`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but you realize that Katya and Brother Greg are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		payment 100000
 		conversation
@@ -1101,6 +1133,8 @@ mission "FW Katya 6"
 			
 			`	"Great!" says Katya. "We'll stop on <planet> first, then swing by Hopper and on to New Iceland. If we still haven't found anything by that point, we'll start working our way up the Rim."`
 				accept
+	on visit
+		dialog `You land on <planet>, but you realize that Katya and Mr. Eyes are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1118,8 +1152,10 @@ mission "FW Katya 6B"
 	on offer
 		conversation
 			`Mr. Eyes fires up his instruments and looks at the results for a few minutes. "Nothing," he says. "Even underground testing would've thrown up a debris plume large enough to measure traces of it. But I'm picking up nothing."`
-			`	"No problem," says Katya, "let's continue to <planet>."`
+			`	"No problem," says Katya. "Let's continue to <planet>."`
 				accept
+	on visit
+		dialog `You land on <planet>, but you realize that Katya and Mr. Eyes are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1138,6 +1174,8 @@ mission "FW Katya 6C"
 		conversation
 			`Again, Eyes runs his tests, and again, nothing shows up. "One more planet to go," he says. "Time to try <planet>." You can tell that they are both starting to feel a bit discouraged, and you are overwhelmed by the thought of how many planets in this sector you may need to search unless you get a lucky break soon.`
 				accept
+	on visit
+		dialog `You land on <planet>, but you realize that Katya and Mr. Eyes are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1162,6 +1200,8 @@ mission "FW Katya 7"
 					accept
 				`	"Sorry, I've got some other missions I need to run instead of continuing this wild goose chase."`
 					decline
+	on visit
+		dialog `You land on <planet>, but you realize that Katya and Mr. Eyes are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1204,6 +1244,8 @@ mission "FW Katya 7B"
 					accept
 				`	"Sorry, 'one more world' is what you said two planets ago. I'm done with this."`
 					decline
+	on visit
+		dialog `You land on <planet>, but you realize that Katya and Mr. Eyes are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1236,6 +1278,8 @@ mission "FW Katya 7C"
 			`	With deep reservations, you drop her off at the outpost, where she is quickly offered the job. "Not many folks care to work up here," says the foreman, "so your help would be much appreciated." You and Eyes return to your ship and get ready to travel to <planet> with the evidence.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but you realize that Mr. Eyes is on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		"assisted free worlds" ++
 		payment 250000
@@ -1671,6 +1715,8 @@ mission "FW Bounty 1"
 		ship "Sparrow" "Rat"
 		dialog `The "Rat Pack" has been eliminated. You can claim the bounty payment by returning to <destination>.`
 	
+	on visit
+		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
 		payment 200000
 		dialog `The militia officer who asked you to hunt down the "Rat Pack" arrives at your ship soon after you land and thanks you profusely. "Now we won't have to worry about them bothering ships in this sector anymore." She pays you <payment> and says she'll tell other militia leaders how helpful you were.`
@@ -1716,6 +1762,8 @@ mission "FW Bounty 2"
 		ship "Behemoth (Speedy)" "Moonless Night"
 		dialog phrase "generic hunted bounty eliminated dialog"
 	
+	on visit
+		dialog phrase "generic bounty hunting on visit"
 	on complete
 		payment 200000
 		dialog `The militia officer who asked you to hunt down the <npc> meets you in the spaceport and pays you <payment>. "Once again, thank you for assisting us," he says.`
@@ -1760,6 +1808,8 @@ mission "FW Bounty 3"
 		ship "Osprey (Alien Weapons)" "Silverhawk"
 		dialog phrase "generic hunted bounty eliminated dialog"
 	
+	on visit
+		dialog phrase "generic bounty hunting on visit"
 	on complete
 		"assisted free worlds" ++
 		payment 300000
@@ -2038,6 +2088,8 @@ mission "Defend Sabik"
 				"Hawk" 2
 				"Sparrow" 1
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Navy ships circling overhead. You should take off and help finish them off.`
 	on complete
 		dialog `The Navy has been driven off, but at a great cost. You should probably visit the spaceport and see if Tomek is there, or someone else who can tell you what to do next.`
 

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -83,6 +83,8 @@ mission "FW Diplomacy 1B"
 	on accept
 		event "fw safe passage starts"
 		event "fw safe passage ends" 24
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -122,6 +124,8 @@ mission "FW Diplomacy 1C"
 				`	"Are you insane? Flying straight into the largest Navy base in the sector?"`
 			`	"Don't worry," he says. "The Navy takes honor very seriously. If they promise our safety, we'll be safe. At least until that grant of safe passage expires, that is." You have serious doubts, but you have no choice but to obey him.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -145,6 +149,8 @@ mission "FW Diplomacy 1D"
 			`	Alondo thanks them for their time and their honesty, and you return to your ship. "Well, it was worth a try. Now we just have to get home safely," he says.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		dialog `You are still finding it hard to believe that you made it to Earth and back in one piece. Alondo thanks you for transporting him and says, "Now I just have to break the bad news to the Senate. JJ and I will meet you in the spaceport bar in a few hours, once we've decided what our next steps will be."`
 		event "navy using mark ii ships"
@@ -171,6 +177,8 @@ mission "FW Southern Recon 1"
 			`Alondo and JJ are in a somber mood when you meet up with them in the bar. You can't help remembering that Tomek always used to be a part of these gatherings, before he turned against the Senate. And now it looks like your next major battle will be fought without Tomek's expert guidance.`
 			`	JJ says, "We've done all we can. Sooner or later we will have to fight the Navy for those star systems. So to start with, <first>, we'd like you to scout them out and report back to us on the Navy's presence there. Freya is on Trinket, gathering a fleet. Report to her there when you're done."`
 				accept
+	on visit
+		dialog phrase "generic waypoint on visit"
 
 
 
@@ -206,6 +214,8 @@ mission "FW Southern Recon 1B"
 		not "FW Southern Recon 1B (Turret): done"
 	to fail
 		has "FW Southern Recon 1B (Turret): done"
+	on visit
+		dialog `You've returned to <planet>, but you don't have an Electron Beam. Try finding lone Navy ships in Wei or Alnasl to disable and plunder from.`
 	on complete
 		fail "FW Southern Recon 1B (Turret)"
 		outfit "Electron Beam" -1
@@ -429,6 +439,8 @@ mission "FW Southern Battle 2"
 			variant
 				"Gunboat (Mark II)" 2
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Navy ships circling overhead. You should take off and help finish them off.`
 	on complete
 		event "fw southern expansion"
 
@@ -484,6 +496,8 @@ mission "FW Southern Battle 3"
 		system "Albaldah"
 		fleet "Large Republic" 2
 	
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		dialog `You've finished patrolling the nearby systems. Now you can meet up with Freya in the spaceport, and hopefully she will have good news about Katya.`
 
@@ -708,6 +722,8 @@ mission "FW Northern 1"
 		system "Alphecca"
 		fleet "Large Republic" 2
 	
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		event "fw northern expansion"
 		dialog
@@ -762,6 +778,8 @@ mission "FW Northern 2A"
 		conversation
 			`As soon as you land, Freya shows up at your ship with a small suitcase full of clothes. "No time to waste," she says. "Let's get going. Our first target will be <planet>, since we know for a fact that they were installing something there."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -782,6 +800,8 @@ mission "FW Northern 2B"
 			`As you approach the planet, Freya sits down at your ship's sensor console and begins fiddling with some settings that you didn't even know existed. She seems entirely focused, and clearly knows what she is doing. You recall being told that she is an engineer, not a politician or a military commander, which makes the fact that she has been able to step up as such a strong leader in the Council very impressive.`
 			`	"Yup, eight different stations," she says finally, "including this one that I nearly overlooked, buried twenty feet under the ice, that is acting as a relay for them." She points out each station on your map, and you fly by each one and destroy it. "Now," she says, "that was what had me most worried, but for the sake of completeness we should sweep the other new worlds, too. Let's go to <planet> next."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -813,6 +833,8 @@ mission "FW Northern 2C"
 			label destroy
 			`	Warily, you approach the sensor installation, kicking down the door to an old abandoned warehouse. Freya is right - it's not guarded. She shuts down the transmitter, then asks for your help bringing some of the sensors and other equipment back to your ship. "I always love having a chance to look at Navy technology," she says. "Now, let's head to <planet>."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -832,6 +854,8 @@ mission "FW Northern 2D"
 		conversation
 			`You spend quite a while flying back and forth above the surface of <origin>, but Freya is unable to locate any Navy signals originating from the surface. Finally she gives up. "It's an out-of-the-way planet," she says. "Any fleet coming here would pass through Alioth or Seginus first. So I guess they didn't bother to put anything here. Time to head to New Tibet and meet up with Alondo!"`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -868,6 +892,8 @@ mission "FW Northern 3"
 			`	"I'm fine," says Alondo, "and JJ is on Rastaban now, guarding our other flank. So you can take a break from being on the front." He heads back outside, and you and Freya get ready to visit the shipyards on <planet>.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		log "Agreed to become a member of the Free Worlds Council, taking Tomek's spot."
 		"salary: Free Worlds" = 2500
@@ -1323,6 +1349,8 @@ mission "FW Bloodsea 1"
 				`	"Wait, didn't things go south rather quickly the last time we attempted this?"`
 			`	Alondo grins. "Yes, but the Free Worlds is in a much stronger position now, and the pirate worlds know it's only a matter of time before they are forced to become civilized. And, the incident on Poisonwood proved that we can't afford to fight a war on two fronts. We need to eliminate the pirate threat, and a diplomatic solution with them is the only sort that will last. So, let's get going!"`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1361,6 +1389,8 @@ mission "FW Bloodsea 1.1"
 			`	"So, we attack them?" you ask.`
 			`	"You're on the Council now," he says. "I'll leave it up to you. Option one is, we bring them the supplies and workers, in merchant ships, but use very heavily armed merchant ships in case they double cross us. Option two is, we go to Dancer and see if JJ can lend us an invasion fleet."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1524,6 +1554,8 @@ mission "FW Bloodsea 1.2A"
 		ship "Manta" "Lucifer"
 		ship "Bastion (Heavy)" "Punisher"
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still pirates defending the system. All pirates in the system must be eliminated before <planet> can be taken.`
 	on complete
 		log "Conquered Bloodsea in the name of the Free Worlds. With enough militia ships patrolling their star system, they ought to think twice before returning to piracy."
 		set "fw bloodsea done"
@@ -1556,7 +1588,7 @@ mission "FW Dreadnoughts Ready"
 mission "FW Albatross 1"
 	landing
 	name "Freya to <planet>"
-	description "Bring Freya to <planet>, to meet up with JJ and make plans for convincing Albatross to give up piracy and join the Free Worlds."
+	description "Bring Freya to <planet> to meet up with JJ and make plans for convincing Albatross to give up piracy and join the Free Worlds."
 	autosave
 	source Zug
 	destination Dancer
@@ -1598,6 +1630,8 @@ mission "FW Albatross 1"
 			label metoo
 			`	Freya raises an eyebrow. "I hadn't heard. We don't have time to find someone else for this mission, so try not to say that so loudly when you're on Albatross."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 mission "FW Albatross 2"
@@ -1620,6 +1654,8 @@ mission "FW Albatross 2"
 			`	You talk for a while and agree that despite the threat from the Navy, dealing with the pirates is important. JJ explains that Albatross started out as a sort of farming commune: independent, but not associated with any illegal activity. But they were dominated by pirates, and since then, one pirate overlord after another has held sway over the planet. So in principle at least, the locals ought to welcome the idea of Free Worlds protection.`
 			`	While you are traveling with JJ, Freya agrees to stay here and work on a better surveillance network, to give Dancer advance warning if the Navy decides to invade.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying JJ hasn't entered the system yet. Better depart and wait for it to arrive.`
 	
 	npc
 		system Nunki
@@ -1660,6 +1696,8 @@ mission "FW Albatross 2A"
 			`	"Maybe," says another of the elders, "but they're still better than Bartlett. I say, if the Free Worlds can free us from him, we'll at least give their new government a try." A few of the others nod in agreement.`
 			`	They explain that to the best of their knowledge, Bartlett is spending most of his time near the Zeta Aquilae system, plundering merchant convoys of heavy metals coming out of Rand and Oblivion. If you can destroy Bartlett and his flagship, the Dread, his followers will probably disperse.`
 				accept
+	on visit
+		dialog phrase "generic bounty hunting on visit"
 	
 	npc kill
 		personality staying plunders disables heroic nemesis target
@@ -1697,6 +1735,8 @@ mission "FW Albatross 2B"
 			`When the elders on Albatross learn that you have destroyed Ryk Bartlett and freed them from his rule, they grudgingly agree to join the Free Worlds, "at least on a trial basis." You hope that you will be able to live up to the promises you have given them.`
 			`	After you return to your ship, JJ says, "So far Freya says there have been no hints of a Navy attack against Dancer, and she has a new set of surveillance satellites up and running in Alpha Arae to monitor fleet activity. So, let's go meet up with her and decide what our next steps should be."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying JJ hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1774,6 +1814,8 @@ mission "FW Rand 1"
 				"Combat Drone" 6
 				"Gunboat (Mark II)"
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Navy ships circling overhead. You should take off and help finish them off.`
 	on complete
 		event "fw expanded and cut"
 
@@ -1810,6 +1852,8 @@ mission "FW Rand 1B"
 				`	"What if the Navy follows the fleet to Wayfarer? We're three of the four Council members. Shouldn't we avoid a situation where we could all be killed?"`
 			`	From JJ's expression, it's clear that he doesn't even want to dignify that question with a response. "If we die, the Free Worlds will live on," he says, "and there's no way we're abandoning a whole section of the fleet just to save our own skins. So, let's go to Wayfarer."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying JJ and Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 	
 	npc
 		government "Free Worlds"
@@ -1976,6 +2020,8 @@ mission "FW Defend New Tibet"
 		ship "Finch" "Echo 6-9"
 		ship "Argosy" "F.S. Nightingale"
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Syndicate ships circling overhead. You should take off and help finish them off.`
 	on complete
 		"reputation: Republic" = 1
 		event "fw armistice"
@@ -2075,6 +2121,8 @@ mission "FW Liberate Delta Sagittarii"
 			`	"Don't worry," says JJ, "it will be. They've been itching to get into the fray for months now. Captain <last>, we'd like you to fly along with the fleet and help to mop up whatever the Wolf Pack leaves behind in the Delta Sagittarii system. Then we'll land on New Portland and figure out what our next steps are. Freya and I will ride on your ship."`
 				accept
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Navy ships circling overhead. You should take off and help finish them off.`
 	on complete
 		event "fwc southern liberation"
 	

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -87,6 +87,8 @@ mission "FW Reconciliation 1"
 			`	You tell her that the last you heard, Ijs was helping to found a new university on <planet>. She says, "We should bring him with us. Raven, will you be traveling with us too?"`
 			`	"Yes," she says. "I'll tell my ship and crew to get ready."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya and Sawyer hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -353,6 +355,8 @@ mission "FW Reconciliation 2B"
 			`	"Indeed," says Danforth. "Southeast of here is a region of uninhabited star systems, a sort of back entrance into Syndicate space. Few ships travel through there, because there is nowhere to refuel, but with a ramscoop or enough fuel capacity, travel is possible. One of the first inhabited worlds on the other side is the lawless world of Stormhold. There, you can surely find a contact who knows enough about the inner workings of the Syndicate to tell you the home of at least a few of our targets... for a price." He hands Katya a large stack of credit chips.`
 			`	Raven says, "I'm going to stay here with the Oathkeepers. Captain <last>, it's been a pleasure working with you. We're counting on you to fetch us this information and return here as quickly as possible."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya and Mr. Eyes hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -377,6 +381,8 @@ mission "FW Reconciliation 2C"
 			`	Katya shows him Sawyer's list of names. "So, these are the bad boys, huh?" he says. Clearly the news of Sawyer's revelations has spread even to this remote world. He looks through the list, and is able to tell you where three of the five men live. "I'd love to see all these bastards taken down," he says.`
 			`	You give him the rest of Danforth's money and thank him for helping you - and ask that he keep your visit secret. "No problem," he says. As you are leaving, he adds, "Also, Mister Springborn... you're my hero, man. Glad you're still finding ways to pester the Syndicate." Ijs seems pleasantly surprised to be recognized.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya and Mr. Eyes hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -450,6 +456,8 @@ mission "FW Defend Farpoint"
 				"Manta" 2
 				"Quicksilver" 5
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Syndicate ships circling overhead. You should take off and help finish them off.`
 	on complete
 		payment 1000000
 
@@ -482,6 +490,8 @@ mission "FW Embassy 1"
 			label next
 			`	"Don't mention it," he says, with a wink. "And now, I think it's best that you head to Earth and pick up those ambassadors. From what I hear, now that Raven is not traveling with you, people are beginning to ask questions about what this Free Worlds captain is doing flying all around Republic space unescorted."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya and Mr. Eyes hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -557,6 +567,8 @@ mission "FW Reconciliation Break"
 			`	You tell him you would be glad to, and you all get ready for yet another journey together.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya and Mr. Eyes hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		conversation
 			`You drop Ijs and Katya off on Skymoot, and wish them well. They both seem eager for a chance to relax, enjoy one another's company, and forget about matters of galactic importance for a while. "We'll see you soon, <first>," says Katya. "Just be sure your ship is in good fighting shape when the time comes to bring the Syndicate to justice."`
@@ -669,6 +681,8 @@ mission "FW Syndicate Capture 1"
 			`You land on Earth and make a show of being very busy ensuring that the Free Worlds ambassadors are comfortable and well cared for, until finally you receive a secure message from Edrick. He tells you that the convoy from the Deep is landing on Mars right now, and an Oathkeeper cruiser is visiting the shipyard on Luna. As soon as you are ready, you can take off, and travel together into the heart of Syndicate space.`
 			`	You make an excuse to depart, and return to your ship. "Well," says Ijs, "this is it. If we're lucky, they won't see us coming, but no matter what, getting back out of Syndicate space will be a nightmare. Good luck, all."`
 				accept
+	on visit
+		dialog `You have reached <planet>, but you left one of your escorts! Better depart and wait for them to arrive in this star system.`
 	
 	npc accompany save
 		personality escort heroic
@@ -723,6 +737,8 @@ mission "FW Syndicate Capture 1B"
 			`	The officers soon radio you that they have found Soylent, and they bring him aboard your ship. Amid all the confusion, you notice a figure in diving gear who jumps off the rear of the yacht and disappears beneath the waves - one of Soylent's men, trying to escape. But since his leader is now in your custody, and your mission is accomplished, you see no reason to chase after him.`
 			`	The Oathkeeper captain sends you a brief message: "Your first priority is to reach the Deep with the prisoner. Our crew is prepared to serve as a rearguard, staying behind if necessary to ensure that you survive. Good luck, Captain."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya and Mr. Eyes hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		event "fw end syndicate capture"
 	
@@ -897,6 +913,8 @@ mission "FW Syndicate Capture 1C"
 			label katya
 			`	Katya says, "It sounds like if the Free Worlds enters Sol, we'll be the spark that sets off an explosion. So, we'll have to trust the Deep, or the Navy, or someone else to try to defuse the situation. Meanwhile, I suggest we return to Free space and muster our entire fleet, to assist the Navy against the Syndicate if it comes to that. JJ ought to be on <planet>; we can meet up with him there."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Katya and Mr. Eyes hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -926,6 +944,8 @@ mission "FW Pug 1"
 				`	"What should we do?"`
 			`	"Our fleet is still scattered throughout this quadrant," he says, "and I'll need Katya to command a part of it. Right now I just need you to travel to Rand, if possible, and find out what's going on. It could just be a communications malfunction, but I seriously doubt it. Meanwhile, Katya and Ijs can help me with organizing the fleet."`
 				accept
+	on visit
+		dialog phrase "generic waypoint on visit"
 	
 	on enter "Cebalrai"
 		dialog
@@ -1023,6 +1043,8 @@ mission "FW Pug 2"
 			
 			`	"We don't," says JJ, "but this all certainly plays out very well for them; their section of the galaxy has suddenly become a very defensible enclave. And the timing of that fleet leaving, and then the link closing - it's too much to be a coincidence. But we can't learn anything for sure by staying here talking; you must go to Earth."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 	
 	npc
 		system "Sol"
@@ -1080,6 +1102,8 @@ mission "FW Pug 2A"
 			government "Syndicate"
 		"reputation: Syndicate" = 1
 		event "fw syndicate welcoming"
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 	
 	npc
 		system "Sol"
@@ -1176,6 +1200,8 @@ mission "FW Pug 2B"
 			`	"Hold on," says Alondo, "I have one condition to add. You will give us one of your jump drives immediately. We will install it in our ship and verify that you are telling the truth about the Pug. If you are, we will work together until this threat is dealt with... and once it is dealt with, we will return our attention to bringing every member of the Syndicate who had a hand in those terrorist attacks to justice. That is our best and final offer." You nod in agreement.`
 			`	It's clear that Alastair is none too happy about that deal, but he accepts it. "The jump drives are all being kept on Hephaestus," he says. "Our Systems division was trying to discover the secret behind them, with little success. If you travel there, I'll tell them to install one of the drives in your ship."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1201,6 +1227,8 @@ mission "FW Pug 2C: Hyperdrive"
 	on accept
 		outfit "Jump Drive" 1
 		set "fw given jump drive"
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1226,6 +1254,8 @@ mission "FW Pug 2C: Scram Drive"
 	on accept
 		outfit "Jump Drive" 1
 		set "fw given jump drive"
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1252,6 +1282,8 @@ mission "FW Pug 2C: Jump Drive"
 	on accept
 		outfit "Jump Drive" 1
 		set "fw given jump drive"
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1385,6 +1417,8 @@ mission "FW Pug 3"
 			`	"We mean bringing an end to your war and your divisions," the alien says. "Those of your worlds and your people who have shown themselves unable to live peacefully, we must govern, to teach them peace. Any who attack us, we must destroy, because we are the bringers of peace, and whoever attacks us is not on the side of peace. And so we will send you back to your people now, to tell them that they have nothing to fear, and that they should await our peace and our protection."`
 			`	The aliens appear to think the conversation is over; they walk away and leave you puzzling over what they said. "We should report back to Earth," says Alondo. "This situation is far beyond what we can handle alone."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1511,6 +1545,8 @@ mission "FW Pug 3A"
 			`	They have many other questions after that; you answer them as best you can, and leave them with full copies of your sensor logs of the alien ships and planets. Parliament agrees that the next step is for you to convince the Free Worlds to contribute two Dreadnoughts to the attack fleet. "Also," one of the members of Parliament says, "maybe you could talk to those aliens who live down in your part of space, see if they can help us out in any way. It sure would be handy if the Pug turn out to be an enemy of theirs."`
 			`	During the hearing, you refrained from mentioning that the Pug claimed to have assisted the Deep in the past, but once you are back in your ship Alondo says, "Maybe we should also visit Valhalla and see if Governor Flint has any information for us."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1691,6 +1727,8 @@ mission "FW Pug 4"
 				"Pug Enfolta"
 				"Pug Zibruka" 2
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still Pug ships circling overhead. You should take off and help finish them off.`
 	on complete
 		event "battle for delta capricorni"
 
@@ -1723,6 +1761,8 @@ mission "FW Pug 4A"
 			`	Freya directs you to fly over the planet and survey the buildings and equipment that the Pug left behind, and after searching for a while you discover an alien building that vaguely resembles a radio transmitter. You land nearby, and as you approach the building on foot, you feel as if the ground beneath you is heaving and rolling like the deck of a ship on choppy seas. "Graviton distortions," she says. "This may be it, the equipment they used to disrupt the hyperspace links. It will take me a while to figure out how it works, though."`
 			`	You agree that she will stay here to try to figure out the alien technology, while you do your best to defend the planet and to keep the Pug from retaking it.`
 				accept
+	on visit
+		dialog `You've landed on <planet>, but there are still Pug ships circling overhead. You should take off and help finish them off.`
 	
 	npc
 		system Deneb
@@ -1794,6 +1834,8 @@ mission "FW Pug 4B"
 			label load
 			`	You load the reflector onto your ship, and get ready to travel to Hephaestus. You suspect that the Pug are going to try to stop you, once they realize what is happening...`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying the graviton reflector hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1895,6 +1937,8 @@ mission "FW Pug 5"
 			label next
 			`	Freya leads you to a warehouse in the spaceport where another one of the "graviton reflectors" is stored. "This should work the same as the one you brought to Hephaestus," she says. "If there's a transmitter on Shiver, we can bring the reflector to Sol and open a link back to the very heart of human space. And at that point, we may even have the Pug outgunned. But first, we need to drive them away from that star system for long enough for me to work the transmitter."`
 				accept
+	on visit
+		dialog `You've landed on <planet>, but there are still Pug ships circling overhead. You should take off and help finish them off.`
 	
 	npc evade
 		personality staying disables
@@ -1957,6 +2001,8 @@ mission "FW Pug 5A"
 				`	"I'm worried that you won't survive if I leave this system undefended."`
 			`	"Don't worry about us here," she says. "We have a fair number of ships here on the ground, if it comes to that. But the most important thing is that you rendezvous with the Navy reinforcements in the <system> system, and if you can draw the Pug fleet to pursue you, all the better. Good luck, <first>."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying the graviton reflector hasn't entered the system yet. Better depart and wait for it to arrive.`
 	
 	npc
 		government Republic
@@ -1999,6 +2045,8 @@ mission "FW Pug 5B"
 			`You help some Navy engineers on Earth to set up the graviton reflector according to Freya's instructions. As before, soon after the reflector is operational the ground seems to tilt and roll as Freya's beam hones in on the reflector and sets up a harmonic oscillation between the two. "The link is reopening!" says one of the engineers. "We're beginning to receive hyperspace communications from Altair again, and from the Syndicate too."`
 			`	A second later your own communicator beeps. It's Freya. "Get back here quickly," she says. "Bring whatever reinforcements you can. A massive Pug fleet just appeared in orbit."`
 				accept
+	on visit
+		dialog `You've landed on <planet>, but there are still Pug ships circling overhead. You should take off and help finish them off.`
 	
 	npc
 		government Republic
@@ -2114,6 +2162,8 @@ mission "FW Pug 6"
 			variant
 				"Protector" 2
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		log `The Pug have fled, apparently traveling through an artificial wormhole back to whatever galaxy they came from. And, it turns out that many of their cities on "Pugglemug" were only for show: buildings with no inhabitants, and with holograms creating the appearance of a heavily populated world. They left no advanced technology behind, and no sign of what their true intentions were, but it turns out that the fake cities here were designed for human habitation. They must have been planning this departure for a very long time.`
 		log `Now that the Pug are gone, the Navy will be able to use the "graviton reflectors" to repair the broken hyperspace links and to reconnect all of human space.`
@@ -2294,6 +2344,8 @@ mission "FW Syndicate Extremists 1B"
 			`You land in the same private hangar that you visited previously to have the jump drive installed, and you think these engineers are the same crew that met you back then. "This thing is almost as bizarre as the jump drive itself," one of them says. "We have no clue how it works, and we weren't done studying it when Korban ordered us to give it to you, so please don't get yourself blown up. Okay?"`
 			`	Meanwhile, Danforth is on his way back to Deneb to rally the Oathkeepers. You should head directly for the <system> system, so that you arrive there far enough in advance of the Oathkeeper fleet.`
 				accept
+	on visit
+		dialog `You've landed on <planet>, but there are still Syndicate ships circling overhead. You should take off and help finish them off.`
 	
 	npc evade
 		government "Syndicate (Extremist)"
@@ -2389,6 +2441,8 @@ mission "FW Syndicate Extremists 1C"
 			`	You return to your ship, and prepare for the journey back to Earth, hopeful that at last Parliament will be willing to negotiate a permanent peace with the Free Worlds.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		log "Received an official commendation from Parliament and a promise that the war with the Free Worlds is officially over. Humanity is at peace once more, but new challenges may await in the star systems out beyond human space that are accessible only by jump drive."
 		payment 5000000

--- a/data/free worlds side plots.txt
+++ b/data/free worlds side plots.txt
@@ -49,6 +49,8 @@ mission "FW Conservatory 1"
 				`	"Sorry, I'm just not interested."`
 					decline
 	
+	on visit
+		dialog `You land on <planet>, but you realize that Mr. Eyes and the Andersons are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		payment 50000
 		dialog `Ijs thanks you for the lift and gives you a credit chip for <payment>. He says, "Next we need to pick up some equipment from Tarazed Corporation. Meet me in the spaceport if you're willing to help out as an escort."`
@@ -315,6 +317,8 @@ mission "FW Wolf Pack 2A"
 		ship "Gunboat (Mark II)" "R.N.S. Atherstone"
 		ship "Gunboat (Mark II)" "R.N.S. Tyndale"
 	
+	on visit
+		dialog `You've landed on <planet>, but the freighters have not been eliminated yet. Hunt them down in the Sarin system and destroy them before returning.`
 	on complete
 		event "wolf pack 3 ready" 10
 		karma --
@@ -388,6 +392,8 @@ mission "FW Wolf Pack 3"
 		ship "Protector" "R.N.S. Citadel"
 		ship "Protector" "R.N.S. Rampart"
 	
+	on visit
+		dialog `You've landed on <planet>, but the freighters have not been eliminated yet. Hunt them down in the Gacrux system and destroy them before returning.`
 	on complete
 		event "wolf pack gacrux end"
 		event "wolf pack 4 ready" 20
@@ -463,6 +469,8 @@ mission "FW Wolf Pack 4"
 				"Lance" 4
 				"Combat Drone" 6
 	
+	on visit
+		dialog `You've landed on <planet>, but the freighter has not been eliminated yet. Hunt it down in the Mizar system and destroy it before returning.`
 	on complete
 		event "wolf pack mizar end"
 		karma --

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -319,6 +319,8 @@ mission "FW Syndicate Diplomacy 1"
 			choice
 				`	"Okay. Let's get going!"`
 					accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -385,6 +387,8 @@ mission "FW Syndicate Diplomacy 1B"
 			label katya
 			`	"We'll have to talk that over with the Council when we get back. But if she is a prisoner of the Intelligence bureau, there is no way we can rescue her. Her only hope is that they will recognize her innocence. For now, we must continue with our mission, and head to Tarazed."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -418,6 +422,8 @@ mission "FW Syndicate Diplomacy 1C"
 			`	"Now," says Alondo, "I'd like to make one more diplomatic visit. The planet Poisonwood has insisted on remaining loyal to the Republic, even though they are deep inside our space. I'd like to meet with their leaders and see if they will reconsider joining us."`
 				accept
 		event "Tarazed neutrality"
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 	
 	
 	
@@ -495,6 +501,8 @@ mission "FW Syndicate Diplomacy 1D"
 			`	You and Alondo return to your ship with one more thing for the fledgling Free Worlds to worry about. "I guess now we should return to <planet> and report to the Council," he says.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		payment 200000
 		conversation
@@ -514,7 +522,7 @@ mission "FW Hope Recon 1"
 	destination Hope
 	to offer
 		has "FW Syndicate Diplomacy 1D: done"
-	cargo sensors 10
+	cargo "sensors" 10
 	blocked `Freya contacts you and says, "<first>, you're going to need ten tons of cargo space for this next mission." You should return here after freeing up <capacity>.`
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
@@ -527,6 +535,8 @@ mission "FW Hope Recon 1"
 			choice
 				`	"No, sounds good."`
 					accept
+	on visit
+		dialog phrase "generic cargo on visit"
 
 
 
@@ -904,6 +914,8 @@ mission "FW Pirates 1"
 	on accept
 		"salary: Free Worlds" = 800
 	
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		dialog
 			`You have scouted out all four pirate systems that Tomek asked you to visit. Time to head back to the spaceport bar and see if he is waiting for you.`
@@ -1011,6 +1023,8 @@ mission "FW Senate 1B"
 			`	"The correct answer," she says, "was, 'nothing whatsoever; they are entirely different disciplines.' Now, hurry up, I hope to be on Bourne a week from now." You consider explaining to her that it's impossible to get there that fast, but decide against it.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Senator Huygens hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		conversation
 			`You drop off Senator Huygens, who says nothing by way of acknowledging your help except, "It's about time we got here." She hurries off.`
@@ -1088,6 +1102,8 @@ mission "FW Flamethrower 2"
 		government "Test Dummy"
 		ship "Doombat" "Doombat"
 	
+	on visit
+		dialog `You've landed on <planet>, but you have not disabled the <npc> yet. Disable it and before returning.`
 	on complete
 		event "flamethrower available" 30
 		log "Assisted Barmy Edward with another weapon test: this time, a flamethrower weapon that works by overheating and disabling its target rather than dealing lots of damage to it. It may or may not be useful in actual combat."
@@ -1203,6 +1219,8 @@ mission "FW Pirates 2"
 		fleet "Small Free Worlds" 2
 		fleet "Large Free Worlds"
 	
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		dialog "Your patrol fleet is still busy finding landing spots, but your work is done. Time to head to the spaceport bar and see if Tomek is there."
 
@@ -1296,6 +1314,8 @@ mission "FW Pirates 3.1"
 			`	"Never mind," he says, "I guess you're as weak-willed as the rest of them." He walks back into the bar and leaves you alone.`
 				accept
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still pirates defending the system. All pirates in the system must be eliminated before <planet> can be taken.`
 	on complete
 		set "fw pirates: disobeyed senate"
 		set "fw pirates: victory"
@@ -1386,6 +1406,8 @@ mission "FW Pirates 3.2A"
 		fleet "Small Northern Pirates"
 		fleet "Large Northern Pirates" 4
 	
+	on visit
+		dialog `You've landed on <planet>, but there are still pirates defending the system. All pirates in the system must be eliminated before <planet> can be taken.`
 	on complete
 		event "fw suppressed Greenrock"
 		event "fw abandoned Greenrock" 40
@@ -1493,6 +1515,8 @@ mission "FW Pirates 4"
 	
 	on accept
 		event "battle for Thule"
+	on visit
+		dialog phrase "generic pirate fleet battle on visit"
 
 
 
@@ -1705,6 +1729,8 @@ mission "FW Refinery 1A"
 			`Your landing site is an abandoned settlement a thousand kilometers from Tundra's main spaceport. It's an old oil field that ran dry decades ago, and only a few of the landing pads are still usable. The Syndicate employees quickly load the cargo onto your ship, and say, "Now, take off quickly, before the Navy sees us doing business with a ship flying Free Worlds colors."`
 				launch
 	
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		log "Brought supplies to Smuggler's Den to help upgrade the station into a working deuterium refinery. No further orders from the Free Worlds, so this might be a good time to find ways to earn more money on the side."
 		dialog

--- a/data/free worlds war jobs.txt
+++ b/data/free worlds war jobs.txt
@@ -29,6 +29,8 @@ mission "FW Scout Run [0]"
 	waypoint
 		distance 1 2
 		government "Republic"
+	on visit
+		dialog phrase "generic stopover on visit"
 	on complete
 		payment 10000 180
 		dialog phrase "free worlds scanner payment"
@@ -55,6 +57,8 @@ mission "FW Scout Run [1]"
 	waypoint
 		distance 2 3
 		government "Republic"
+	on visit
+		dialog phrase "generic stopover on visit"
 	on complete
 		payment 20000 180
 		dialog phrase "free worlds scanner payment"
@@ -81,6 +85,8 @@ mission "FW Scout Run [2]"
 	waypoint
 		distance 3 4
 		government "Republic"
+	on visit
+		dialog phrase "generic stopover on visit"
 	on complete
 		payment 30000 180
 		dialog phrase "free worlds scanner payment"
@@ -304,6 +310,8 @@ mission "FW Reinforcements [0]"
 		government "Free Worlds"
 		neighbor
 			neighbor government "Republic"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 180
 		dialog `You unload the Free Worlds soldiers into the busy spaceport of <planet>, and collect your payment of <payment>.`
@@ -331,6 +339,8 @@ mission "FW Reinforcements [1]"
 		government "Free Worlds"
 		neighbor
 			neighbor government "Republic"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 180
 		dialog `You unload the Free Worlds soldiers into the busy spaceport of <planet>, and collect your payment of <payment>.`
@@ -362,6 +372,8 @@ mission "FW Outfitter Resupply [0]"
 		distance 4 8
 		government "Free Worlds"
 		attributes outfitter
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 2000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -383,6 +395,8 @@ mission "FW Outfitter Resupply [1]"
 		distance 5 10
 		government "Free Worlds"
 		attributes outfitter
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 2000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -404,6 +418,8 @@ mission "FW Outfitter Resupply [2]"
 		distance 6 12
 		government "Free Worlds"
 		attributes outfitter
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 2000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -425,6 +441,8 @@ mission "FW Bulk Outfitter Resupply [0]"
 		distance 4 8
 		government "Free Worlds"
 		attributes outfitter
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -446,6 +464,8 @@ mission "FW Bulk Outfitter Resupply [1]"
 		distance 5 10
 		government "Free Worlds"
 		attributes outfitter
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -467,6 +487,8 @@ mission "FW Bulk Outfitter Resupply [2]"
 		distance 6 12
 		government "Free Worlds"
 		attributes outfitter
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -494,6 +516,8 @@ mission "FW Frontline Resupply [0]"
 		government "Free Worlds"
 		neighbor
 			neighbor government "Republic"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 2000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -521,6 +545,8 @@ mission "FW Frontline Resupply [1]"
 		government "Free Worlds"
 		neighbor
 			neighbor government "Republic"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 2000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -548,6 +574,8 @@ mission "FW Frontline Resupply [2]"
 		government "Free Worlds"
 		neighbor
 			neighbor government "Republic"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 2000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -575,6 +603,8 @@ mission "FW Bulk Frontline Resupply [0]"
 		government "Free Worlds"
 		neighbor
 			neighbor government "Republic"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -602,6 +632,8 @@ mission "FW Bulk Frontline Resupply [1]"
 		government "Free Worlds"
 		neighbor
 			neighbor government "Republic"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 180
 		dialog phrase "free worlds thanked resupply payment"
@@ -628,6 +660,8 @@ mission "FW Care Package to Republic [0]"
 	destination
 		government "Republic"
 		distance 2 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 180
 		dialog phrase "free worlds thanked care package"
@@ -648,6 +682,8 @@ mission "FW Care Package to Republic [1]"
 	destination
 		government "Republic"
 		distance 2 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 180
 		dialog phrase "free worlds thanked care package"
@@ -668,6 +704,8 @@ mission "FW Care Package from Republic [0]"
 	destination
 		government "Free Worlds"
 		distance 2 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 180
 		dialog phrase "free worlds thanked care package"
@@ -688,6 +726,8 @@ mission "FW Care Package from Republic [1]"
 	destination
 		government "Free Worlds"
 		distance 2 5
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 1000 180
 		dialog phrase "free worlds thanked care package"
@@ -721,6 +761,8 @@ mission "FW Refugees [0]"
 		not
 			neighbor
 				neighbor government "Republic"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 2000 180
 		dialog phrase "free worlds thanked refugee transport"
@@ -748,6 +790,8 @@ mission "FW Refugees [1]"
 		not
 			neighbor
 				neighbor government "Republic"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 2000 180
 		dialog phrase "free worlds thanked refugee transport"
@@ -775,6 +819,8 @@ mission "FW Refugees [2]"
 		not
 			neighbor
 				neighbor government "Republic"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 2000 180
 		dialog phrase "free worlds thanked refugee transport"
@@ -802,6 +848,8 @@ mission "FW Bulk Refugees [0]"
 		not
 			neighbor
 				neighbor government "Republic"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 180
 		dialog phrase "free worlds thanked refugee transport"

--- a/data/free worlds war jobs.txt
+++ b/data/free worlds war jobs.txt
@@ -30,7 +30,7 @@ mission "FW Scout Run [0]"
 		distance 1 2
 		government "Republic"
 	on visit
-		dialog phrase "generic stopover on visit"
+		dialog phrase "generic waypoint on visit"
 	on complete
 		payment 10000 180
 		dialog phrase "free worlds scanner payment"
@@ -58,7 +58,7 @@ mission "FW Scout Run [1]"
 		distance 2 3
 		government "Republic"
 	on visit
-		dialog phrase "generic stopover on visit"
+		dialog phrase "generic waypoint on visit"
 	on complete
 		payment 20000 180
 		dialog phrase "free worlds scanner payment"
@@ -86,7 +86,7 @@ mission "FW Scout Run [2]"
 		distance 3 4
 		government "Republic"
 	on visit
-		dialog phrase "generic stopover on visit"
+		dialog phrase "generic waypoint on visit"
 	on complete
 		payment 30000 180
 		dialog phrase "free worlds scanner payment"

--- a/data/hai jobs.txt
+++ b/data/hai jobs.txt
@@ -21,6 +21,8 @@ mission "Human Vacation [1]"
 	destination
 		distance 2 7
 		attributes "human tourism"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 8000 150
 		dialog phrase "generic passenger dropoff payment"
@@ -38,6 +40,8 @@ mission "Human Vacation [2]"
 	destination
 		distance 2 7
 		attributes "human tourism"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 150
 		dialog phrase "generic passenger dropoff payment"
@@ -55,6 +59,8 @@ mission "Hai Vacation [1]"
 	destination
 		distance 2 7
 		attributes "hai tourism"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 6000 150
 		dialog phrase "generic passenger dropoff payment"
@@ -72,6 +78,8 @@ mission "Hai Vacation [2]"
 	destination
 		distance 2 7
 		attributes "hai tourism"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 4000 150
 		dialog phrase "generic passenger dropoff payment"
@@ -89,6 +97,8 @@ mission "Hai Vacation [3]"
 	destination
 		distance 2 7
 		attributes "hai tourism"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 4000 150
 		dialog phrase "generic passenger dropoff payment"
@@ -106,6 +116,8 @@ mission "Hai Vacation [4]"
 	destination
 		distance 2 7
 		attributes "hai tourism"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 6000
@@ -129,6 +141,8 @@ mission "Wealthy Hai [1]"
 	destination
 		government "Hai"
 		distance 4 8
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 15000 300
 		dialog phrase "generic passenger dropoff payment"
@@ -150,6 +164,8 @@ mission "Wealthy Hai [2]"
 	destination
 		government "Hai"
 		distance 4 8
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 15000 300
 		dialog phrase "generic passenger dropoff payment"
@@ -174,6 +190,8 @@ mission "Hai Festival [1]"
 	destination
 		distance 2 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 10000 200
 		dialog phrase "hai festival payment dialog"
@@ -193,6 +211,8 @@ mission "Hai Festival [2]"
 	destination
 		distance 2 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 10000 200
 		dialog phrase "hai festival payment dialog"
@@ -212,6 +232,8 @@ mission "Hai Festival [3]"
 	destination
 		distance 2 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 10000 200
 		dialog phrase "hai festival payment dialog"
@@ -250,6 +272,8 @@ mission "Unfettered Aid [0]"
 		attributes "unfettered"
 	on accept
 		dialog phrase "unfettered aid pickup dialog"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 1600
 		dialog phrase "unfettered aid payment dialog"
@@ -272,6 +296,8 @@ mission "Unfettered Aid [1]"
 		attributes "unfettered"
 	on accept
 		dialog phrase "unfettered aid pickup dialog"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 6000 1800
 		dialog phrase "unfettered aid payment dialog"
@@ -294,6 +320,8 @@ mission "Unfettered Aid [2]"
 		attributes "unfettered"
 	on accept
 		dialog phrase "unfettered aid pickup dialog"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 7000 2000
 		dialog phrase "unfettered aid payment dialog"
@@ -325,6 +353,8 @@ mission "Unfettered Tribute 1"
 	stopover
 		distance 3 4
 		attributes "hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 
@@ -345,6 +375,8 @@ mission "Unfettered Tribute 2"
 	stopover
 		distance 4 5
 		attributes "hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 
@@ -365,6 +397,8 @@ mission "Unfettered Tribute 3"
 	stopover
 		distance 5 6
 		attributes "hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 
@@ -383,6 +417,8 @@ mission "Delivery to Human Space [0]"
 		near "Heia Due" 2
 	destination
 		attributes "north"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 60000
 		dialog phrase "generic cargo delivery payment"
@@ -400,6 +436,8 @@ mission "Delivery to Human Space [1]"
 		near "Heia Due" 2
 	destination
 		attributes "north"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 60000
 		dialog phrase "generic cargo delivery payment"
@@ -417,6 +455,8 @@ mission "Delivery to Human Space [2]"
 		near "Heia Due" 2
 	destination
 		attributes "north"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 60000
 		dialog phrase "generic cargo delivery payment"
@@ -437,6 +477,8 @@ mission "Hai Retrieve Human Luxury Goods"
 		attributes "north"
 	on stopover
 		dialog "You gather the requested <commodity> and load them on your ship for return to <planet>."
+	on visit
+		dialog phrase "generic missing stopover or cargo"
 	on complete
 		payment 120000
 		dialog "Your payment of <payment> is waiting when you touch down, along with delivery instructions. You send the <commodity> by dedicated courier."
@@ -457,6 +499,8 @@ mission "Hai Retrieve Human Food"
 		attributes "north"
 	on stopover
 		dialog "You gather the requested <commodity> and load them on your ship for return to <planet>."
+	on visit
+		dialog phrase "generic missing stopover or cargo"
 	on complete
 		payment 120000
 		dialog "As soon as you touch down you receive a message from the Hai gourmet with thanks and your payment of <payment>."
@@ -477,6 +521,8 @@ mission "Hai Retrieve Human Electronics"
 		attributes "north"
 	on stopover
 		dialog "You gather the requested <commodity> and load them on your ship for return to <planet>."
+	on visit
+		dialog phrase "generic missing stopover or cargo"
 	on complete
 		payment 120000
 		dialog "The Hai tinkerer is waiting for you when you arrive. They pay you <payment> and then run after the cargo pallets as though they plan to open them right there in the spaceport."
@@ -681,6 +727,8 @@ mission "Hai Passengers [1]"
 	destination
 		distance 2 7
 		government "Hai"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		dialog phrase "generic passenger dropoff payment"
@@ -698,6 +746,8 @@ mission "Hai Passengers [2]"
 	destination
 		distance 2 7
 		government "Hai"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		dialog phrase "generic passenger dropoff payment"
@@ -715,6 +765,8 @@ mission "Hai Passengers [3]"
 	destination
 		distance 2 7
 		government "Hai"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		dialog phrase "generic passenger dropoff payment"
@@ -733,6 +785,8 @@ mission "Hai Family [0]"
 	destination
 		distance 4 16
 		government "Hai"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 4000
@@ -752,6 +806,8 @@ mission "Hai Family [1]"
 	destination
 		distance 5 20
 		government "Hai"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 6000
@@ -770,6 +826,8 @@ mission "Transport Hai miners to <planet>"
 		attributes "mining"
 		distance 3 12
 		government "Hai"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 2000
@@ -788,6 +846,8 @@ mission "Transport Hai farmers to <planet>"
 		attributes "farming"
 		distance 3 12
 		government "Hai"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 2000
@@ -806,6 +866,8 @@ mission "Transport Hai mill workers to <planet>"
 		attributes "textiles"
 		distance 3 12
 		government "Hai"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 2000
@@ -824,6 +886,8 @@ mission "Transport Hai workers to <planet>"
 		attributes "factory"
 		distance 3 12
 		government "Hai"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment
 		payment 2000
@@ -844,6 +908,8 @@ mission "Hai Cargo [0]"
 	destination
 		distance 2 8
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -861,6 +927,8 @@ mission "Hai Cargo [1]"
 	destination
 		distance 2 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -879,6 +947,8 @@ mission "Hai Cargo [2]"
 	destination
 		distance 2 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -897,6 +967,8 @@ mission "Hai Cargo [3]"
 	destination
 		distance 3 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 2000
@@ -916,6 +988,8 @@ mission "Hai Cargo [4]"
 	destination
 		distance 4 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 4000
@@ -934,6 +1008,8 @@ mission "Hai Bulk Delivery [0]"
 	destination
 		distance 2 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		dialog phrase "generic cargo delivery payment"
@@ -951,6 +1027,8 @@ mission "Hai Bulk Delivery [1]"
 	destination
 		distance 3 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 2000
@@ -970,6 +1048,8 @@ mission "Hai Bulk Delivery [2]"
 	destination
 		distance 4 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 4000
@@ -989,6 +1069,8 @@ mission "Hai Large Bulk Delivery [0]"
 	destination
 		distance 2 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 4000
@@ -1008,6 +1090,8 @@ mission "Hai Large Bulk Delivery [1]"
 	destination
 		distance 3 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 6000
@@ -1028,6 +1112,8 @@ mission "Hai Large Bulk Delivery [2]"
 	destination
 		distance 4 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 8000
@@ -1047,6 +1133,8 @@ mission "Hai Rush Delivery [0]"
 	destination
 		distance 3 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 16000
@@ -1066,6 +1154,8 @@ mission "Hai Rush Delivery [1]"
 	destination
 		distance 4 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 18000
@@ -1086,6 +1176,8 @@ mission "Hai Rush Delivery [2]"
 	destination
 		distance 5 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 20000
@@ -1106,6 +1198,8 @@ mission "Hai Rush Delivery [3]"
 	destination
 		distance 6 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 22000
@@ -1126,6 +1220,8 @@ mission "Hai Large Rush Delivery [0]"
 	destination
 		distance 3 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 36000
@@ -1146,6 +1242,8 @@ mission "Hai Large Rush Delivery [1]"
 	destination
 		distance 4 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 38000
@@ -1167,6 +1265,8 @@ mission "Hai Large Rush Delivery [2]"
 	destination
 		distance 5 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 40000
@@ -1188,6 +1288,8 @@ mission "Hai Large Rush Delivery [3]"
 	destination
 		distance 6 7
 		government "Hai"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 42000
@@ -1210,6 +1312,8 @@ mission "Hai Prisoner Roleplay"
 		government "Hai"
 	on offer
 		require "Brig"
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 15000 150
 		dialog "The Hai depart your ship chittering in excitement. One of them hands you your payment of <payment> before running to catch up with their friends."

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -430,6 +430,8 @@ mission "Unfettered returning home"
 			`	You show the youth to one of your bunk rooms, and tell him to stay hidden there until you reach Hai-home.`
 				accept
 	
+	on visit
+		dialog `You look for the young Hai, but realize that he took a ride on one of your escorts! Better depart and wait for your escorts to arrive in this star system.`
 	on complete
 		payment 100000
 		dialog
@@ -490,6 +492,8 @@ mission "Returning Home"
 			`	You lead Elliot to your ship and show him to a bunk room. After leaving Elliot there, you wonder if his family is still even on <planet> anymore.`
 				accept
 			
+	on visit
+		dialog `You look for Elliot, but realize that he took a ride on one of your escorts! Better depart and wait for your escorts to arrive in this star system.`
 	on complete
 		payment 45000
 		conversation
@@ -1002,6 +1006,8 @@ mission "Hiding in Plain Sight"
 				`	"Sorry, you'll have to find someone else to bring you."`
 					decline
 					
+	on visit
+		dialog `You look for Arthur and Kiru, but realize that they took a ride on one of your escorts! Better depart and wait for your escorts to arrive in this star system.`
 	on complete
 		payment 75000
 		dialog `Arthur and Kiru pay you <payment> before running off to the convention center. As they run away, you notice that Kiru is drawing a number of eyes from the crowd, but no one seems to suspect that he is an actual alien.`
@@ -1050,6 +1056,8 @@ mission "Hai Honeymoon"
 				`	"Sorry, I can't travel that far from here."`
 					decline
 					
+	on visit
+		dialog `You look for Anaya and Touhar, but realize that they took a ride on one of your escorts! Better depart and wait for your escorts to arrive in this star system.`
 	on complete
 		payment 100000
 		dialog `Instead of landing in the spaceport where they can be seen, you drop Anaya and Touhar off as close as you can to where they will be staying. The house is a few kilometers away, but they assure you that they can make it on their own. They pay you <payment> and thank you for bringing them this far.`

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1294,6 +1294,8 @@ mission "Southern Pirate Attack"
 				`	(Join the defense fleet.)`
 			`A few militia pilots have gathered to help repel the pirate attack. You join them, and take off together...`
 				launch
+	on visit
+		dialog phrase "generic pirate fleet battle on visit"
 	on complete
 		payment 150000
 		dialog phrase "generic pirate attack payment dialog"
@@ -1327,6 +1329,8 @@ mission "Northern Pirate Attack"
 				`	(Join the defense fleet.)`
 			`The local Navy garrison is preparing to repel the pirate attack. You join them, and take off together...`
 				launch
+	on visit
+		dialog phrase "generic pirate fleet battle on visit"
 	on complete
 		payment 250000
 		dialog phrase "generic pirate attack payment dialog"
@@ -1360,6 +1364,8 @@ mission "Core Pirate Attack"
 				`	(Join the defense fleet.)`
 			`The local Syndicate defense forces are preparing to repel the pirate attack. You join them, and take off together...`
 				launch
+	on visit
+		dialog phrase "generic pirate fleet battle on visit"
 	on complete
 		payment 200000
 		dialog phrase "generic pirate attack payment dialog"
@@ -1395,6 +1401,8 @@ mission "Raider Attack 1"
 				`	(Join the defense fleet.)`
 			`The local Syndicate defense forces are preparing to repel the alien attack. You join them, and take off together...`
 				launch
+	on visit
+		dialog `You've landed on <planet>, but there are still Korath circling overhead. You should take off and help finish them off.`
 	on complete
 		payment 550000
 		dialog `The government of <planet> pays you <payment> for helping to drive off the raiders.`
@@ -1430,6 +1438,8 @@ mission "Raider Attack 2"
 				`	(Join the defense fleet.)`
 			`The local Syndicate defense forces are preparing to repel the alien attack. You join them, and take off together...`
 				launch
+	on visit
+		dialog `You've landed on <planet>, but there are still Korath circling overhead. You should take off and help finish them off.`
 	on complete
 		payment 750000
 		dialog `The government of <planet> pays you <payment> for helping to drive off the raiders.`
@@ -2577,6 +2587,8 @@ mission "Bounty Hunting (Small)"
 			variant
 				"Manta (Proton)"
 		dialog phrase "generic hunted bounty eliminated dialog"
+	on visit
+		dialog phrase "generic bounty hunting on visit"
 	on complete
 		payment 150000
 		dialog phrase "generic bounty hunting payment dialog"
@@ -2612,6 +2624,8 @@ mission "Bounty Hunting (Medium)"
 			variant
 				"Firebird (Plasma)"
 		dialog phrase "generic hunted bounty eliminated dialog"
+	on visit
+		dialog phrase "generic bounty hunting on visit"
 	on complete
 		payment 200000
 		dialog phrase "generic bounty hunting payment dialog"
@@ -2651,6 +2665,8 @@ mission "Bounty Hunting (Big)"
 			variant
 				"Vanguard (Particle)"
 		dialog phrase "generic hunted bounty eliminated dialog"
+	on visit
+		dialog phrase "generic bounty hunting on visit"
 	on complete
 		payment 250000
 		dialog phrase "generic bounty hunting payment dialog"
@@ -2688,6 +2704,8 @@ mission "Bounty Hunting (Small, Boarding, Entering)"
 			variant
 				"Clipper (Speedy)"
 		dialog "You blast your way onto the ship and confine the fleeing criminal to your ship's brig. Time to deliver them to <planet>."
+	on visit
+		dialog phrase "generic bounty hunting boarding on visit"
 	on complete
 		payment 175000
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal."
@@ -2727,6 +2745,8 @@ mission "Bounty Hunting (Medium, Boarding, Entering)"
 			variant
 				"Raven (Heavy)"
 		dialog "You blast your way onto the ship, subdue the fleeing criminals, and confine them to your ship's brig. Time to deliver them to <planet>."
+	on visit
+		dialog phrase "generic bounty hunting boarding on visit"
 	on complete
 		payment 350000
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal gang."
@@ -2753,6 +2773,8 @@ mission "Bounty Hunting (Marauder I)"
 			distance 1 3
 		fleet "Marauder fleet I"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
+	on visit
+		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
 		payment 300000
 		dialog phrase "generic fleet bounty hunting payment dialog"
@@ -2779,6 +2801,8 @@ mission "Bounty Hunting (Marauder II)"
 			distance 1 3
 		fleet "Marauder fleet II"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
+	on visit
+		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
 		payment 350000
 		dialog phrase "generic fleet bounty hunting payment dialog"
@@ -2805,6 +2829,8 @@ mission "Bounty Hunting (Marauder III)"
 			distance 1 3
 		fleet "Marauder fleet III"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
+	on visit
+		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
 		payment 400000
 		dialog phrase "generic fleet bounty hunting payment dialog"
@@ -2831,6 +2857,8 @@ mission "Bounty Hunting (Marauder IV)"
 			distance 1 3
 		fleet "Marauder fleet IV"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
+	on visit
+		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
 		payment 425000
 		dialog phrase "generic fleet bounty hunting payment dialog"
@@ -2857,6 +2885,8 @@ mission "Bounty Hunting (Marauder V)"
 			distance 1 3
 		fleet "Marauder fleet V"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
+	on visit
+		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
 		payment 450000
 		dialog phrase "generic fleet bounty hunting payment dialog"
@@ -2884,6 +2914,8 @@ mission "Bounty Hunting (Marauder VI)"
 			distance 1 3
 		fleet "Marauder fleet VI"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
+	on visit
+		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
 		payment 475000
 		dialog phrase "generic fleet bounty hunting payment dialog"
@@ -2906,6 +2938,8 @@ mission "Bounty Hunting (Marauder VII)"
 			distance 1 3
 		fleet "Marauder fleet VII"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
+	on visit
+		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
 		payment 500000
 		dialog phrase "generic fleet bounty hunting payment dialog"
@@ -2928,6 +2962,8 @@ mission "Bounty Hunting (Marauder VIII)"
 			distance 1 3
 		fleet "Marauder fleet VIII"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
+	on visit
+		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
 		payment 550000
 		dialog phrase "generic fleet bounty hunting payment dialog"
@@ -2950,6 +2986,8 @@ mission "Bounty Hunting (Marauder IX)"
 			distance 1 3
 		fleet "Marauder fleet IX"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
+	on visit
+		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
 		payment 600000
 		dialog phrase "generic fleet bounty hunting payment dialog"

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -8,13 +8,6 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-phrase "generic arrived-without-npc dialog"
-	word
-		`You have reached <planet>, but you left the <npc> behind! Better depart and wait for them to arrive in this star system.`
-phrase "generic safe escort completion dialog"
-	word
-		`The captain of the <npc> thanks you for escorting them safely, and pays you <payment>.`
-
 mission "Escort (Tiny, Northern, Dangerous Destination)"
 	name "Escort to <planet>"
 	description "Despite your relative inexperience, the captain of the <npc> is willing to pay you <payment> for an escort into a dangerous region of space to reach <destination> by <date>."
@@ -1270,23 +1263,7 @@ mission "Escort (Extra Large, Southern, Dangerous Origin or Destination)"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
 
-phrase "generic pirate attack payment dialog"
-	word
-		`The government of <planet>`
-	word
-		` `
-		` gratefully `
-	word
-		`pays you <payment> for helping to`
-	word
-		` drive off `
-		` defeat `
-	word
-		`the `
-	word
-		`pirates.`
-		`raiders.`
-		`attackers.`
+
 
 mission "Southern Pirate Attack"
 	name "Defend <planet>"
@@ -1458,12 +1435,6 @@ mission "Raider Attack 2"
 		dialog `The government of <planet> pays you <payment> for helping to drive off the raiders.`
 
 
-phrase "generic cargo delivery payment"
-	word
-		`You drop off your cargo of <commodity> and collect your payment of <payment>.`
-phrase "generic cargo on visit"
-	word
-		`You have reached <planet>, but not all of the cargo is in the system! Better depart and wait for your escorts to arrive in this star system.`
 
 mission "Cargo [0]"
 	name "Delivery to <planet>"
@@ -1710,14 +1681,6 @@ mission "Rush Delivery [3]"
 		dialog phrase "generic cargo delivery payment"
 
 
-
-phrase "generic passenger dropoff payment"
-	word
-		`You wish your <passengers> the best of luck on <planet>, and collect your payment of <payment>.`
-		`You say farewell to your <passengers> on <planet>, and collect your payment of <payment>.`
-phrase "generic passenger on visit"
-	word
-		`You have reached <planet>, but not all of the passengers are in the system! Better depart and wait for your escorts to arrive in this star system.`
 
 mission "Passengers [0]"
 	name "Passenger transport to <planet>"
@@ -2575,13 +2538,7 @@ mission "Recycle garbage"
 		payment
 		payment 20000
 
-phrase "generic hunted bounty eliminated dialog"
-	word
-		`The <npc> has been eliminated. You can claim the bounty payment by returning to <destination>.`
 
-phrase "generic bounty hunting payment dialog"
-	word
-		`The government of <planet> gratefully pays you <payment> for eliminating the <npc>.`
 
 mission "Bounty Hunting (Small)"
 	name "Hunt down the <npc>"
@@ -2773,14 +2730,6 @@ mission "Bounty Hunting (Medium, Boarding, Entering)"
 	on complete
 		payment 350000
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal gang."
-
-phrase "generic hunted bounty fleet eliminated dialog"
-	word
-		`The <npc> and their fleet have been eliminated. You can claim the bounty payment by returning to <destination>.`
-
-phrase "generic fleet bounty hunting payment dialog"
-	word
-		`The government of <planet> gratefully pays you <payment> for eliminating the <npc> and their fleet.`
 
 mission "Bounty Hunting (Marauder I)"
 	name "Hunt down the <npc>"

--- a/data/paradise world jobs.txt
+++ b/data/paradise world jobs.txt
@@ -325,6 +325,7 @@ mission "Contract laborers to <planet>"
 		attributes "mining" "fishing" "textiles" "factory" "farming" "oil"
 	on stopover
 		dialog "The shabbily-dressed young men and women in the group don't look nearly as happy to be boarding your ship as you expected, given the new opportunity that awaits them. They shuffle wearily up the ramp for the return trip to <planet>."
+	on visit
 	on complete
 		payment 10000 50
 		dialog "The bedraggled contract laborers kept to themselves and didn't say a word to you throughout the entire trip. The scruffy foreman who receives you on <origin> seems pleased, however. He hands you your payment of <payment>."
@@ -342,7 +343,6 @@ mission "Waste disposal on <planet>"
 	destination
 		distance 2 20
 		attributes "dirt belt"
-	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment

--- a/data/paradise world jobs.txt
+++ b/data/paradise world jobs.txt
@@ -326,6 +326,7 @@ mission "Contract laborers to <planet>"
 	on stopover
 		dialog "The shabbily-dressed young men and women in the group don't look nearly as happy to be boarding your ship as you expected, given the new opportunity that awaits them. They shuffle wearily up the ramp for the return trip to <planet>."
 	on visit
+		dialog phrase "generic missing stopover or passengers"
 	on complete
 		payment 10000 50
 		dialog "The bedraggled contract laborers kept to themselves and didn't say a word to you throughout the entire trip. The scruffy foreman who receives you on <origin> seems pleased, however. He hands you your payment of <payment>."
@@ -343,6 +344,7 @@ mission "Waste disposal on <planet>"
 	destination
 		distance 2 20
 		attributes "dirt belt"
+	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -220,6 +220,8 @@ mission "Remnant: Defense 2"
 			variant
 				"Korath World-Ship B (Crippled)"
 		dialog "You have destroyed the Korath ship that was left over from the raid on <planet>. You can now return there to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
 	on complete
 		payment 500000
 		dialog `The same woman meets you when you land on <planet>. "Again, thank you," she says. "I will suggest to others that they might offer you similar bounty hunting jobs in the future." She pays you <payment>.`
@@ -248,6 +250,8 @@ mission "Remnant: Bounty"
 			variant
 				"Korath Raider (Crippled)"
 		dialog "You have destroyed the Korath ship. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
 	on complete
 		payment 300000
 		dialog "A Remnant military leader thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>."
@@ -288,6 +292,8 @@ mission "Remnant: Defense 3"
 				"Korath Raider (Crippled)"
 				"Korath Chaser" 2
 		dialog "Now that you are alone, you are able to deploy the Remnant surveillance satellite unobserved. Time to report back to <planet>."
+	on visit
+		dialog `You have returned to <planet>, but you haven't deployed the surveillance satellite yet. Return to <waypoints> and make sure that all of the Korath there have been eliminated.`
 	on complete
 		event "remnant: surveillance end"
 		payment 500000
@@ -342,6 +348,8 @@ mission "Remnant: Key Stones"
 			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
 				accept
 	
+	on visit
+		dialog `You have returned to <planet>, but you don't have 50 "Quantum Keystones" to give to the outfitter. Buy the Keystones from the Hai before returning here.`
 	on complete
 		outfit "Quantum Keystone" -50
 		payment 6000000
@@ -409,6 +417,8 @@ mission "Remnant: Void Sprites 1"
 				"Void Sprite (Infant)" 3
 	on enter "Nenia"
 		dialog `There are indeed some strange space-faring life forms in this system. You collect measurements with the special sensors, and then prepare to return to <planet>.`
+	on visit
+		dialog `You have returned to <planet>, but you're missing something! Either you haven't visited <waypoints> to scan the void sprites, or your escort carrying the scanning equipment has not arrived in the system.`
 
 
 
@@ -451,6 +461,8 @@ mission "Remnant: Void Sprites 2"
 				"Void Sprite (Infant)"
 	on accept
 		event "remnant: nenia empty"
+	on visit
+		dialog `You land on <planet>, but you haven't scanned the void sprites in <waypoints>. Make sure you scan all the void sprites using an outfit scanner.`
 	on complete
 		event "remnant: nenia restored"
 
@@ -512,6 +524,8 @@ mission "Remnant: Void Sprites 3"
 			`You have dodged the Archon and landed on the second of the two gas giants where the void sprites live. The hull of your tiny ship creaks and groans under the high atmospheric pressure, but seems to be holding together. Its sensors pick up flocks of void sprites floating between the planet's cloud layers, presumably feeding on airborne creatures too small to detect from this range.`
 			`	You also observe some void sprites leaving the planet, soaring upward on thermal updrafts. As they rise, their bodies swell to several times their original size, like an aerostat balloon gaining altitude. But clearly they have another form of propulsion as well, something akin to the antigravity repulsors that human ships use to travel from a planet's surface into orbit.`
 			`	After collecting some atmospheric samples for good measure, you prepare to return to <planet>. Hopefully the Archon will calm down once it sees that you have not attacked or disturbed the Sprites on either of these planets.`
+	on visit
+		dialog phrase "generic stopover on visit"
 	on complete
 		event "remnant: void sprite research" 20
 		log "Factions" "Void Sprites" `The "void sprites" are space-dwelling lifeforms. They are apparently not sentient. They evolved in the atmosphere of a gas giant, but have some biological mechanism for altering or reflecting gravity that allows them to fly into outer space, in the same way that human ships use antigravity to escape a planet's gravity well. The void sprites are not particularly powerful or dangerous creatures, but they are guarded by a Drak Archon.`
@@ -736,6 +750,8 @@ mission "Remnant: Heavy Laser"
 			label next
 			`	You lead her back to your ship, where you show her the heavy laser. "A laser cannon?" she asks. "Our records indicate that humanity had primitive laser technology at the time of the Exodus, but nothing that would be considered useful as weapons." She pauses to look down at her scanner. "And yet my scans indicate that they are capable of significant power output." She pauses for a moment before continuing, "These could be quite useful to examine more thoroughly. Please deliver two of these heavy lasers to a research team on <planet>."`
 				accept
+	on visit
+		dialog `You have returned to <planet>, but you don't have the two heavy lasers that Taely requested. Go buy two heavy lasers before returning.`
 	on complete
 		outfit "Heavy Laser" -2
 		payment 870000
@@ -773,6 +789,8 @@ mission "Remnant: Plasma Cannon"
 			label next
 			`	You lead her back to your ship, where you show her the plasma cannon. "I have never seen weapons designed to handle such a high heat output! Is this some kind of plasma based weapon?" she asks, gesturing at a cannon. You nod, and she continues, "Intriguing. We have noticed that the Korath ships seem to run particularly hot, and have speculated that overheating them might be an effective means of disabling them. I would enjoy researching these a bit more. If you could deliver two to <planet> for us you would be well compensated."`
 				accept
+	on visit
+		dialog `You have returned to <planet>, but you don't have the two plasma cannons that Taely requested. Go buy two plasma cannons before returning.`
 	on complete
 		outfit "Plasma Cannon" -2
 		payment 1130000
@@ -818,6 +836,8 @@ mission "Remnant: Catalytic Ramscoop"
 			label next
 			`	You lead her back to your ship, where you show her the catalytic ramscoop. "Interesting. This is a new design?" She asks, gesturing at the ramscoop. You nod, and she continues, "Even if it does not perform well, new perspectives on the problem could be valuable. There is a research team on <planet> that is currently working on new ramscoop designs. If you could deliver two catalytic ramscoops to them we could offer you <payment>."`
 				accept
+	on visit
+		dialog `You have returned to <planet>, but you don't have the two catalytic ramscoops that Taely requested. Go buy two catalytic ramscoops before returning.`
 	on complete
 		outfit "Catalytic Ramscoop" -2
 		payment 1390000
@@ -854,6 +874,8 @@ mission "Remnant: Electron Beam"
 			label next
 			`	You accompany her back to your ship, where she examines the electron beam. "This could be useful. Focusing energy into continuous beams has been a popular idea for centuries. It is very useful to know that they have finally managed to make it into an effective weapon.`
 				accept
+	on visit
+		dialog `You have returned to <planet>, but you don't have the two electron beams that Taely requested. Go buy two electron beams before returning.`
 	on complete
 		outfit "Electron Beam" -2
 		payment 1090000
@@ -890,6 +912,8 @@ mission "Remnant: D94-YV Shield Generator"
 			label next
 			`	You nod in the affirmative and lead her back to your ship, where she examines the D94-YV Shield Generator. "It certainly looks impressive," she chants as she paces around the massive piece of equipment. "It will be valuable to see what our enemies might be shielded with, and maybe something we can learn from it too." She comes to a stop in front of you. "If you could deliver two of these to a lab on <planet> we could compensate you with <payment>.`
 				accept
+	on visit
+		dialog `You have returned to <planet>, but you don't have the two D94-YV Shield Generators that Taely requested. Go buy the two shield generators before returning.`
 	on complete
 		outfit "D94-YV Shield Generator" -2
 		payment 1150000
@@ -926,6 +950,8 @@ mission "Remnant: S-970 Regenerator"
 			label next
 			`	You nod in the agreement and lead her back to your ship, where she does a cursory scan of the S-970 Regenerator. "Hmm," she murmurs as she peers at the readings on her instrument as she waves it up and down the regenerator. "This looks like they may have found a few techniques that would be beneficial for us to study. If you could deliver two of these to a lab on <planet> we could compensate you with <payment>.`
 				accept
+	on visit
+		dialog `You have returned to <planet>, but you don't have the two S-970 Regenerator that Taely requested. Go buy the two shield regenerators before returning.`
 	on complete
 		outfit "S-970 Regenerator" -2
 		payment 2350000
@@ -981,6 +1007,8 @@ mission "Remnant: Return the Samples"
 			`	As the <ship> sinks through the cloud layers, you gently activate the repulsors to slow your descent to avoid startling the void sprites. A few nearby sprites descend with you, seeming to match your velocity. You slow down as you reach the altitude listed in the log of where the eggs are to be released.`
 			`	Setting the ship on auto-pilot, you walk to the back and struggle into the pressure suit. Readying the eggs in the cargo hold, you equalize pressure in the main cargo hold to the swirling clouds outside, and open the bay doors. As predicted, at this pressure level, the eggs are almost weightless, and are fairly easy to carry to the door of the ship and release.`	
 			`	By the time you finish releasing the eggs back into the clouds, several void sprites have converged on your ship and appear to be herding the eggs away from you with gentle buffets of their wings. You take a moment to appreciate the alien beauty of these creatures before closing the hatch and purging the ship with fresh air.`
+	on visit
+		dialog phrase "generic stopover on visit"
 	on complete
 		conversation
 			`Back on the ground, you report on how the release went. The researcher is pleased to hear that the void sprites responded to their presence. "We will give them a few weeks, then try sending another ship to monitor them. Hopefully the Archon will be pacified by this. Meet me in the alien environments lab just off the spaceport if you are interested in pursuing this."`
@@ -1019,6 +1047,8 @@ mission "Remnant: Return the Samples 2"
 			`	Setting the ship on auto-pilot, you head back and suit-up in the bulky pressure suit once again. Readying the eggs in the cargo hold, you equalize pressure and open the bay doors. As before, the eggs are already floating as you open the cocoons and gently carry them to the door.`
 			`	Almost as soon as you release the first egg, a void sprite is there, brushing against the ship to scoop the egg away into the swirling mists. By the time you return with the next one, another sprite is already waiting at the door, undulating in the eerie light. By the time the last egg is released you can see dozens of the strange creatures swarming around the collection of eggs. It occurs to you that very few humans would ever have the chance to see anything like this.`
 			`	After taking a moment to enjoy the view, you shut the door as gently as you can, purge the ship with fresh air, and begin the journey back to Aventine.`
+	on visit
+		dialog phrase "generic stopover on visit"
 	on complete
 		"reputation: Drak" += 1
 		conversation
@@ -1147,6 +1177,8 @@ mission "Remnant: Salvage 3"
 		dialog
 			`The injured crew made for an eerily quiet jaunt from Viminal to Aventine. They didn't sing, and rarely signed. Some spent the trip mellowed out on powerful painkillers, while the few that left their rooms seem to be mostly intent on doing prescribed stretches and movements to help damaged muscles heal. A few are interested in visiting with someone from outside the Ember Waste, but they lacked the energy to do so for long.`
 			`	On Aventine there are ambulances and medical staff waiting to transport the injured to longer-term medical facilities. As they depart, a fresh crew arrives to take their places.`
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 100000
 		set "license: Remnant Capital"
@@ -1225,6 +1257,8 @@ mission "Remnant: Salvage 5"
 			`	Taely quickly helps load the cargo onboard your ship. It doesn't appear to be actual whole items anymore, but rather pieces thereof. "They will be expecting you, but you might have to pry them out of their lab to get some help unloading. They can be a bit single-minded when they have something interesting to work on."`
 				accept
 	
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 150000
 		dialog `On Caelian, you are able to find the appropriate research warehouse just off the main landing pad. After a few minutes, a lab technician disentangles herself from a project and brings a wagon and camel team out to the ship to unload the salvage. It strikes you as a bit incongruous that a lab technician is using a graviton repulsion lifter to load cargo from your ship into a wagon pulled by a camel. "If you can, I should have some things to send back to Taely if you could meet me in the cafeteria this afternoon."`
@@ -1248,6 +1282,8 @@ mission "Remnant: Salvage 6"
 			`	Outside you find a camel pulling a wagon filled with ship parts to be loaded on board the <ship>.`
 				accept
 		
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 150000
 		conversation 
@@ -1299,6 +1335,8 @@ mission "Remnant: Bounty 2"
 			variant
 				"Korath Raider (Hyperdrive)"
 		dialog "You have destroyed the Korath ship. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
 	on complete
 		payment 400000
 		dialog "A Remnant military leader thanks you for hunting down the Korath ship <npc>, and gives you the agreed-upon payment of <payment>."
@@ -1330,6 +1368,8 @@ mission "Remnant: Expanded Horizons Quarg 1"
 					decline
 			`	 You offer to take her and a couple of her colleagues to see the Quarg. She eagerly accepts, although she expresses a preference for landing on the human world, so they can observe the Quarg ships from a distance, as they would rather not draw any attention to themselves. She runs out of the cafeteria after telling you they will meet you at your ship in half an hour.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that you left Dawn and her colleagues on one of you escorts that hasn't entered the system. Better depart and wait for it to arrive.`
 	on complete
 		log "People" "Dawn" `Dawn is a young Remnant researcher with a strong interest in engineering. She has yet to pick a specialty, but appears to have a talent for exo-engineering.`
 		conversation
@@ -1369,6 +1409,8 @@ mission "Remnant: Expanded Horizons Quarg 2"
 		dialog
 			`Dawn and her compatriots eagerly pore over the readouts as they come in, then ask if you could land again to compare their scans to ones taken on the ground.`
 
+	on visit
+		dialog `You've landed on <planet>, but you haven't yet scanned the <npc>'s. Depart and use an outfit scanner to scan the ship.`
 	on complete
 		conversation
 			`The Remnant researcher's attention to detail is impressive. They carefully quantify every aspect of the scans, including notes about the ship's behaviors. By the time you are on the ground again, they have amassed quite a collection of data crystals filled with analysis. You note that they are careful to ensure everything they collect is backed up in multiple places, including what appears to be a small lead lined box.`
@@ -1391,6 +1433,8 @@ mission "Remnant: Expanded Horizons Quarg 3"
 			`Back in the spaceport bar you wait around for a couple hours. Just when you were about to go find them, the trio walk in looking like they had spent all day on the move, but otherwise unreadable.`
 			`	"Okay, I think we are ready to go. Can you take us to <planet>?"`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that you left Dawn and her colleagues on one of you escorts that hasn't entered the system. Better depart and wait for it to arrive.`
 	on complete
 		payment 150000
 		conversation
@@ -1400,6 +1444,10 @@ mission "Remnant: Expanded Horizons Quarg 3"
 			`	Upon arriving at <planet> they quickly thank you, hand you <payment>, and run back to their offices to finish prepping their material to publish and distribute.`
 
 
+
+phrase "broken jump drive on visit"
+	word
+		`You've landed on <planet>, but you don't have a broken jump drive to give to the Remnant. You may need to steal one from Korath Raiders found through Remnant jobs, or depart and wait for an escort carrying one to enter the system.`
 
 mission "Remnant: Broken Jump Drive 1"
 	name "Broken Jump Drive Delivery"
@@ -1444,6 +1492,8 @@ mission "Remnant: Broken Jump Drive 1"
 			label refuse
 			`	He considers this, and sings, "If you wish. Our offer stands, whenever you choose to return."`
 				decline
+	on visit
+		dialog phrase "broken jump drive on visit"
 	on complete
 		outfit "Jump Drive (Broken)" -1
 		"remnant: broken jump drive count" ++
@@ -1485,6 +1535,8 @@ mission "Remnant: Broken Jump Drive 2"
 			`	You nod.`
 			`	"They will definitely appreciate new material to research. The team is located on <planet>. I will send a notification ahead so they will be expecting you."`
 				accept
+	on visit
+		dialog phrase "broken jump drive on visit"
 	on complete
 		outfit "Jump Drive (Broken)" -1
 		"remnant: broken jump drive count" ++
@@ -1526,6 +1578,8 @@ mission "Remnant: Broken Jump Drive 3"
 			`	"I can," you respond.`
 			`	"Excellent. The recent discovery of these broken drives has spurred discussion and excitement in various quarters. We have had teams researching jump drives for at least a century now without a lot of success. I'm told they are rather intricate, but your finds are opening new avenues of investigation. That being said, I'll notify the team on <planet> to expect you."`
 				accept
+	on visit
+		dialog phrase "broken jump drive on visit"
 	on complete
 		outfit "Jump Drive (Broken)" -1
 		"remnant: broken jump drive count" ++
@@ -1568,6 +1622,8 @@ mission "Remnant: Broken Jump Drive 4"
 			`	You nod in response.`
 			`	"Thank you. We are looking forward to seeing what comes from this."`
 				accept
+	on visit
+		dialog phrase "broken jump drive on visit"
 	on complete
 		outfit "Jump Drive (Broken)" -1
 		"remnant: broken jump drive count" ++
@@ -1608,6 +1664,8 @@ mission "Remnant: Broken Jump Drive 5"
 			`	"Sure," you respond.`
 			`	"Much appreciated. The sooner they get it, the sooner they can start on their project. That being said, I have spoken with the other directors, and we have decided that we are getting so many requests that we will put these into the job board for you. Any time the landing scans detect one of these broken jump drives, the system will display a message on the job board listing where the next one needs to be delivered."`
 				accept
+	on visit
+		dialog phrase "broken jump drive on visit"
 	on complete
 		outfit "Jump Drive (Broken)" -1
 		"remnant: broken jump drive count" ++
@@ -1644,6 +1702,8 @@ mission "Remnant: Broken Jump Drive job"
 		government "Remnant"
 		attributes outfitter
 		not distance 0
+	on visit
+		dialog phrase "broken jump drive on visit"
 	on complete
 		outfit "Jump Drive (Broken)" -1
 		"remnant: broken jump drive count" ++

--- a/data/south jobs.txt
+++ b/data/south jobs.txt
@@ -37,6 +37,8 @@ mission "Pirate Occupation [0]"
 		fleet "Small Southern Pirates" 3
 	on offer
 		conversation "pirate occupation"
+	on visit
+		dialog phrase "generic pirate fleet battle on visit"
 	on complete
 		payment 100000
 		dialog phrase "generic pirate attack payment dialog"
@@ -71,6 +73,8 @@ mission "Pirate Occupation [1]"
 		fleet "Large Southern Pirates"
 	on offer
 		conversation "pirate occupation"
+	on visit
+		dialog phrase "generic pirate fleet battle on visit"
 	on complete
 		payment 150000
 		dialog phrase "generic pirate attack payment dialog"
@@ -105,6 +109,8 @@ mission "Pirate Occupation [2]"
 		fleet "Large Southern Pirates" 3
 	on offer
 		conversation "pirate occupation"
+	on visit
+		dialog phrase "generic pirate fleet battle on visit"
 	on complete
 		payment 200000
 		dialog phrase "generic pirate attack payment dialog"

--- a/data/syndicate jobs.txt
+++ b/data/syndicate jobs.txt
@@ -321,9 +321,6 @@ ship "Vanguard" "Vanguard Test Dummy"
 		"automaton" 1
 		"self destruct" 1
 
-phrase "generic cargo and passenger on visit"
-	word
-		`You have reached <planet>, but not all of the cargo and passengers are in the system! Better depart and wait for your escorts to arrive in this star system.`
 
 mission "Syndicate Prisoner Transport [0]"
 	name "Transport executive to house arrest"

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -37,6 +37,8 @@ mission "Immigrant Workers"
 					decline
 			"	They thank you for your assistance, and you give them a hand pushing the heavy cart into your cargo bay."
 				accept
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 
 
 
@@ -60,6 +62,8 @@ mission "Pookie, Part 1"
 					decline
 			"	You tell her that you would be glad to assist, and that you can personally assure her that no harm will come to Pookie while on board your ship. She thanks you, and gives you contact information for her aunt in the <system> system."
 				accept
+	on visit
+		dialog `You have reached <planet>, but your escort with the space reserved for Pookie has not arrived! Better depart and and wait for your escorts to arrive in this star sytem.`
 
 
 
@@ -96,6 +100,8 @@ mission "Pookie, Part 2"
 			`	As she continues rattling off instructions, you ask, "Wait, Pookie is the dog?"`
 			`	"Short for 'Pocahontas,"' she explains. "Good luck, and I hope my sister pays you well." She walks away. There's nothing else you can do but bring Pookie back to your ship, where she immediately lifts her leg against the landing strut.`
 				accept
+	on visit
+		dialog `You have reached <planet>, but your escort carrying Pookie has not arrived! Better depart and and wait for your escorts to arrive in this star sytem.`
 	on complete
 		payment 80000
 		dialog "In the past few days, Pookie has barked incessantly and thrown up several times despite being fed perfectly on schedule, and the room you've been keeping her in will likely smell like dog urine for months. You are all too happy to return her to her owner, who pays you <payment>."
@@ -172,6 +178,8 @@ mission "Smuggler's Den, Part 1"
 			`	You quickly make your way back to your ship. As soon as the door has closed behind you, all three of you breathe a sigh of relief. A second later, the baby begins to wail, loudly. As you show them to their bunks, they introduce themselves as Joe and Maria; the baby's name is Jesse. "I don't know how to thank you," says Maria.`
 			`	"Please don't take too long leaving the station," adds Joe. "But, I think we'll be safe here until you're ready to leave. There's no way they can search all the ships at the dock."`
 				accept
+	on visit
+		dialog `You land on <planet> and look for Joe and Maria, but you realize that they were in one of your escorts that has not yet entered the system. Better depart and wait for them.`
 
 
 
@@ -196,6 +204,8 @@ mission "Smuggler's Den, Part 2"
 			`	Despite his shock and grief, Joe is quite grateful. "You know we can't pay you, right?"`
 			`	"Don't worry about it," you say. You return to your ship and tell the bad news to Maria.`
 				accept
+	on visit
+		dialog `You land on <planet> and look for Joe and Maria, but you realize that they were in one of your escorts that has not yet entered the system. Better depart and wait for them.`
 	on complete
 		event "smuggler's den: payment" 365
 		log `Helped two teens named Joe and Maria and their daughter Jesse to escape their pirate captain. Dropped them off on Millrace where they'll start a new life.`
@@ -278,6 +288,8 @@ mission "Expedition to Hope 1"
 			`	"Thank you," he says. You help them to load their meteorological equipment onto your ship.`
 				accept
 	
+	on visit
+		dialog `You enter the atmosphere of <planet>, but realize that the scientists and their equipment were on one of your escorts who hasn't entered the system yet. Better depart and wait for them.`
 	on complete
 		payment 40000
 
@@ -301,6 +313,8 @@ mission "Expedition to Hope 2"
 			`	The lead scientist hands you forty thousand credits, and says, "Here's the first part of your payment. Now we need to get home to <planet>. I'll pay you the rest once we get there."`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that the scientists and their equipment were on one of your escorts who hasn't entered the system yet. Better depart and wait for them.`
 	on complete
 		payment 40000
 		dialog `You drop the team of scientists off on <planet>. They thank you for helping them out, and pay you <payment>.`
@@ -324,6 +338,8 @@ mission "Transport Workers A"
 	on offer
 		dialog `In one of the corners of the spaceport, you meet a family with two kids, and a pile of trunks and boxes spread out next to them. They tell you that they are trying to book passage to <planet>. "Work has gotten way too hard to come by here," explains the father. "I've had seven different jobs in the past year, and none of them lasted more than a month. So we thought we'd try our luck on a Syndicate world."`
 	
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment
 		payment 20000
@@ -376,6 +392,8 @@ mission "Transport Workers B"
 			`	"Thank you, Captain," he says, shaking your hand. You bring him aboard your ship and show him to one of the empty bunks.`
 				accept
 	
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -412,6 +430,8 @@ mission "Transport Workers C"
 				`	"Sorry, that's way too far from here."`
 					decline
 	
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment
 		payment 10000
@@ -435,6 +455,8 @@ mission "WR Star 1"
 	on offer
 		dialog `A group of scientists approaches you and asks if you will be headed to the Rim any time soon. "We're doing research on Wolf-Rayet stars," they explain, "and we're hoping to find a captain who can do a fly-by of <waypoints>." Scientific research in the Deep is notoriously well-funded, so they will probably pay you quite well.`
 	
+	on visit
+		dialog `You land on <planet>, but realize that the scientists and their equipment were on one of your escorts who hasn't entered the system yet. Better depart and wait for them.`
 	on complete
 		payment 250000
 		dialog `The team of scientists thanks you for bringing them to <waypoints> and back, and pays you <payment>. They seem eager to get back to their lab and start analyzing their measurements.`
@@ -486,6 +508,8 @@ mission "Deep Archaeology 1"
 			label yes
 			`	"Thank you," he says. "Trust me, this could give us some very important information. I'll need you to drop me off on Vinci first, to meet with some scientists. We can then meet up back on Vinci once you have the samples."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying the archaeologist hasn't entered the system yet. Better depart and wait for it.`
 
 
 
@@ -590,6 +614,8 @@ mission "Deep Archaeology 4"
 					decline
 			`	"Excellent," says Albert. "We just need to do a flyover of <planet>, and see what our radar turns up."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Albert, John, and the mapping equipment hasn't entered the system yet. Better depart and wait for it.`
 
 
 
@@ -632,6 +658,8 @@ mission "Deep Archaeology 5"
 		ship "Raven (Afterburner)" "D.P.S. Skuld"
 		ship "Raven (Afterburner)" "D.P.S. Verthandi"
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Albert, John, and the mapping equipment hasn't entered the system yet. Better depart and wait for it.`
 	on complete
 		payment 300000
 		log `Returned to Midgard with Albert Foster, the archaeologist, to map the area around the church. The instruments discovered what looked like an artificial singularity. Got chased away by Deep ships before being able to look closer.`
@@ -687,6 +715,8 @@ mission "There Might Be Riots 1"
 			`	Eventually, the spaceport police arrive and disperse the crowd, and the band settles in for their trip to <destination>.`
 				accept
 	
+	on visit
+		dialog `You arrive on <planet>, but realize that your escort carrying the band and their supplies has not arrived yet. Better depart and wait for your escorts to enter the system.`
 	on complete
 		payment
 		payment 100000
@@ -751,6 +781,8 @@ mission "There Might Be Riots part 2"
 			`	"Then I suggest you do your job and transport them. Immediately." The guards leave. As soon as the band is packed up, you leave the planet...`
 				launch
 	
+	on visit
+		dialog `You arrive on <planet>, but realize that your escort carrying the band and their supplies has not arrived yet. Better depart and wait for your escorts to enter the system.`
 	on complete
 		payment
 		payment 200000
@@ -831,6 +863,8 @@ mission "There Might Be Riots part 3A"
 			`	"Excellent," he says. "We go thumb our noses at the military industrial complex, then you take us to stay with the peaceful squirrel people where the government won't bother us."`
 			`	Once more, they begin loading their stuff onto your ship, while you chart a course to <destination>.`
 				accept
+	on visit
+		dialog `You arrive on <planet>, but realize that your escort carrying the band and their supplies has not arrived yet. Better depart and wait for your escorts to enter the system.`
 
 
 
@@ -896,6 +930,8 @@ mission "There Might Be Riots part 3B"
 			variant
 				"Combat Drone" 35
 	
+	on visit
+		dialog `You arrive on <planet>, but realize that your escort carrying the band and their supplies has not arrived yet. Better depart and wait for your escorts to enter the system.`
 	on complete
 		payment 500000
 		log `Brought "There Might Be Riots" to the Hai world of Allhome after escaping a swarm of combat drones that disrupted their performance on Pilot. Ulrich spoke of a cloudy star in the Rim where he heard a voice in his head after parking his ship.`
@@ -1017,6 +1053,8 @@ mission "Rim Archaeology 1"
 			`	Foster makes a few phone calls to cancel his upcoming plans, and then shows up at your ship with a large collection of geological surveying tools. "Let's go check it out," he says.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Albert hasn't entered the system yet. Better depart and wait for it.`
 	on complete
 		log `Found the archaeologist Albert Foster and told him about the vision of the dragon-people on Zug. Foster suggested that the vision was the doing of an Archon. He discovered a buried city under the lava flows on Zug; perhaps the vision was a real view of the past.`
 		conversation
@@ -1073,6 +1111,8 @@ mission "Rim Archaeology 2B"
 			`When you arrive on <origin>, the excavation machines requested by Albert Foster are already waiting for you at the spaceport. They are some of the largest terrestrial vehicles you have ever seen: a truck with enormous toothed grinding wheels for cutting through stone, and a front-end loader for carrying the loose stone away. You are barely able to fit them through the entrance of your cargo bay.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying the excavation equipment hasn't entered the system yet. Better depart and wait for it.`
 	on complete
 		payment 300000
 
@@ -1172,6 +1212,8 @@ mission "Rim Archaeology 4B"
 		system Dabih
 		ship "Marauder Arrow (Engines)" "Naukratis"
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Amelia and Yarthis hasn't entered the system yet. Better depart and wait for it.`
 	on complete
 		payment 200000
 
@@ -1295,6 +1337,8 @@ mission "Drug Running 1"
 	on decline
 		"said no to drugs" ++
 	
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 80000
@@ -1323,6 +1367,8 @@ mission "Drug Running 2"
 	on offer
 		dialog `When you walk into the local bar, a man sitting in the corner waves you over and says in a hushed voice, "Captain, we've got a shipment of the good stuff that needs to get to <planet>. I promise you this will be a very lucrative operation. What do you say?"`
 	
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 100000
@@ -1351,6 +1397,8 @@ mission "Drug Running 3"
 	on offer
 		dialog `A well-dressed woman approaches you as you are walking through the spaceport and asks quietly if you would be willing to help facilitate the transport of some "naughty substances" to a certain individual on <planet>.`
 	
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 120000
@@ -1469,6 +1517,8 @@ mission "Shady passenger transport 1"
 	on decline
 		"rejected illegal jobs" ++
 
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"getaway driver" ++
 		payment 50000
@@ -1506,6 +1556,8 @@ mission "Shady passenger transport 2"
 	on decline
 		"rejected illegal jobs" ++
 
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		"getaway driver" ++
 		payment 100000
@@ -1550,6 +1602,8 @@ mission "Shady passenger transport 3"
 	on decline
 		"rejected illegal jobs" ++
 
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 350000
 		dialog `During the voyage, you've come to understand that your passengers are mercenaries whose latest exploits put them on the wrong side of the law. They pay you the agreed-upon sum of <payment> and disappear into a crowd, no doubt off to cause chaos and mayhem for some unsuspecting victims. Oh well, not your problem...`
@@ -1659,6 +1713,8 @@ mission "Shady passenger transport 3 - double cross"
 			`	Your first shot finds its mark, and the gang leader crumples to the floor. The other thugs shriek in alarm and begin to spray gunfire in all directions, but it's ineffective panic fire. Taking cover behind the armored captain's chair, you dispatch two more with well-aimed shots.`
 			`	The remaining goons attempt to flee, but your fingers find the button controlling the bridge door and it slams down before they can escape. They throw down their weapons and surrender. You toss them into the brig and decide that it might be a hoot to take them to their original destination as prisoners instead of passengers, and see if you can get a bounty for bringing them in.`
 
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		dialog `You hand off your prisoners to the planetary authorities who gratefully take them into custody. It turns out that they were wanted, and there's a substantial bounty. You find yourself richer to the tune of <payment>.`
 		payment 250000
@@ -1719,6 +1775,8 @@ mission "Rescue Miners 1"
 	
 	on offer
 		dialog `You've just sat down in the spaceport bar and ordered a drink when someone in uniform runs into the room and shouts, "There's been a mine explosion on <planet>! We need all available ships to carry relief workers and supplies and to evacuate the injured to a world where there are better medical facilities." Do you volunteer?`
+	on visit
+		dialog phrase "generic cargo passenger on visit"
 
 
 
@@ -1738,6 +1796,8 @@ mission "Rescue Miners 2"
 	on offer
 		dialog `You drop off the medical personnel on <origin>. There are nearly a hundred injured miners waiting for medical evacuation to <planet>. Do you volunteer to carry some of them?`
 	
+	on visit
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 80000
 		dialog `You drop off the injured miners at one of the medical facilities on <planet> that has agreed to care for the survivors. It's a somewhat chaotic process, but eventually someone thanks you for your help and pays you <payment>.`
@@ -1760,6 +1820,8 @@ mission "Courier 1"
 		government "Republic" "Free Worlds" "Syndicate" "Quarg" "Neutral"
 	on offer
 		dialog `As you are walking through the spaceport, a man approaches you and says, "Excuse me, Captain. I took on a rush delivery to <planet>, but my ship needs repairs and there's no way I can make it there before <day>. Can you take this job for me?"`
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 30000
@@ -1783,6 +1845,8 @@ mission "Courier 2"
 		government "Republic" "Free Worlds" "Syndicate" "Quarg" "Neutral"
 	on offer
 		dialog `A woman in the spaceport flags you down and asks, "Excuse me, Captain. I have small package that needs to get to <planet> by <day>. Can you carry it for me?"`
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 50000
@@ -1805,6 +1869,8 @@ mission "Courier 3"
 		government "Republic" "Free Worlds" "Syndicate" "Quarg" "Neutral"
 	on offer
 		dialog `A woman in a suit walks up to you and says, "Pardon me, Captain. I represent a recently deceased client here on <origin> whose legal papers need to be delivered to his next of kin on <destination>. Would you be willing to do some courier work? The papers must be delivered by <day>."`
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment 100000
 		dialog "You drop off the legal papers and collect your payment of <payment>."
@@ -1840,6 +1906,8 @@ mission "Courier 4"
 			`	"Excellent!" he says. "Come, let me introduce you to your cargo." He leads you to a supply shed where an enormous lizard, taller than you and probably weighing several tons, is being held in a cage that looks far too flimsy for it. "I'll have my men load her aboard your ship at once," says the man, "along with some meat for her to eat on the journey. Watch out for your fingers when you feed her, by the way. Thank you!"`
 				accept
 	
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 100000
@@ -1874,6 +1942,8 @@ mission "Migrant Workers 1"
 				`	"No, sorry, I'm not headed in that direction."`
 					decline
 	
+	on visit
+		dialog phrase "generic passengers on visit"
 	on complete
 		payment
 		payment 20000
@@ -1911,6 +1981,8 @@ mission "Humanitarian 1"
 			`	"Thank you," she says. "Your contact on <planet> will be a man named 'Raven Hunter.' Don't let anyone but him trick you into giving them the supplies."`
 				accept
 	
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 50000
@@ -1949,6 +2021,8 @@ mission "Humanitarian 2"
 			`	"Thank you," he says. "We'll load the food into your cargo hold immediately. The sooner you can drop it off on <planet>, the better."`
 				accept
 	
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 50000
@@ -1984,6 +2058,8 @@ mission "Terraforming 1"
 					accept
 				`	"Sorry, that's way too far away for me to travel right now."`
 					decline
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying the managers hasn't entered the system yet. Better depart and wait for it.`
 
 
 
@@ -2016,6 +2092,8 @@ mission "Terraforming 2"
 			`	An hour later, you meet up with Amy, and arrange for her to join you on your ship before it takes off. Eric and Alaric are very excited, but you are a bit worried about the wisdom of entrusting their planet's future to someone so young and inexperienced.`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Eric, Alaric, and Amy hasn't entered the system yet. Better depart and wait for it.`
 	on complete
 		payment 140000
 		dialog `On the entire return journey, Eric and Alaric have been busy showing Amy geological survey maps of Rand and asking her for ideas. The moment you land, they hurry out of the ship. "I'm going to show Amy around," says Eric, "but meet us in the spaceport bar later if you want to help out with whatever we do next." Alaric hands you <payment> as payment for your services, and then follows after them.`
@@ -2089,6 +2167,8 @@ mission "Terraforming 3"
 		personality derelict fleeing uninterested waiting pacifist mute
 		ship "Asteroid" "Target Asteroid"
 	
+	on visit
+		dialog `You return to the spaceport to the confused looks of Eric, Alaric, and Amy. "You didn't put the thrusters on the asteroid," Amy says. "Just board the asteroid to attach the thrusters." Amy begins pushing you back to your ship, clearly eager to see the results of this experiment.`
 	on complete
 		payment 20000
 		log `Agreed with Amy's idea to steer an asteroid into Rand's polar ice cap in order to change the planet's climate. Hopefully this ends well.`
@@ -2117,6 +2197,8 @@ mission "Terraforming 4"
 				`	"Sorry, I need to move on to some other work now."`
 					decline
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Amy hasn't entered the system yet. Better depart and wait for it.`
 	on complete
 		dialog `As soon as you land, Amy heads off to meet with some local biologists who she contacted during the trip over here. "We'll be back in the spaceport in two hours," she says. "Be sure to have ten tons of cargo space free."`
 
@@ -2152,6 +2234,8 @@ mission "Terraforming 5"
 			`	"For a century or so, yes," she says. "But that's a whole lot more economical than vaporizing the ice caps using traditional terraforming equipment. Come on, let's get back to <planet>."`
 				accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Amy and the seeds hasn't entered the system yet. Better depart and wait for it.`
 	on complete
 		payment 60000
 		event "terraforming timer" 4 8
@@ -2260,6 +2344,8 @@ mission "Terraforming 7"
 				`	"Sorry, I have other places to be."`
 					decline
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Amy and Nolan hasn't entered the system yet. Better depart and wait for it.`
 	on complete
 		payment 50000
 		event "terraforming research" 120 180
@@ -2305,6 +2391,8 @@ mission "Terraforming 9"
 			`	"Once you're ready, Captain, please bring us to <destination>. Tundra was a tropical world millions of years ago, but became cold after a cataclysmic event of some sort. There's a good chance that we may be able to nudge the planet back toward a warmer climate if we do this right."`
 					accept
 	
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying the scientists and their equipment hasn't entered the system yet. Better depart and wait for it.`
 	on complete
 		dialog 
 			`The journey to Tundra was spent by your passengers discussing the possible methods of terraforming the planet. The Republic representative was none too pleased when Nolan, perhaps jokingly, suggested crashing an asteroid into it.`
@@ -2348,6 +2436,8 @@ mission "Terraforming 10"
 			
 			`	The representative leaves the bar. "We'll wait here," Amy says to you. "I'll speak with the Tundra government about evacuating the area around where the impact site will be so that we can start when you get back."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying the representative hasn't entered the system yet. Better depart and wait for it.`
 
 
 
@@ -2369,6 +2459,8 @@ mission "Terraforming 11"
 		dialog
 			`Your ship is targeted by pirate fleets when you enter the system. Before you engage, you receive a message from Amy.`
 			`"Captain, these pirate ships have been occupying the system for days. You must take them out if we are to safely crash an asteroid into Tundra."`
+	on visit
+		dialog `You return to <planet>, but not all of the pirates have been fought off. They don't look like they're leaving any time soon either. Better depart and finish them off for good.`
 	npc evade
 		government "Pirate"
 		personality nemesis staying target
@@ -2405,6 +2497,8 @@ mission "Terraforming 12"
 		personality derelict fleeing uninterested waiting pacifist mute
 		ship "Asteroid" "Target Asteroid"
 	
+	on visit
+		dialog `You return to the spaceport to the confused looks of Amy and the rest of the scientists. "You didn't put the thrusters on the asteroid," Amy says. "Just board the asteroid to attach the thrusters." Amy begins pushing you back to your ship, clearly eager to see the results of this experiment.`
 	on complete
 		payment 200000
 		event "terraforming timer 2" 730 912
@@ -2537,6 +2631,8 @@ mission "Terminus exploration"
 		government "Pirate"
 		personality staying
 		fleet "Small Southern Pirates" 2
+	on visit
+		dialog `You've returned to <planet>, but you don't have the drone's data. Go to Terminus and board the science drone to retrieve the data.`
 	on complete
 		payment 90000
 		log `Recovered data from a derelict science drone for a team of scientists, who were studying a strange red anomaly in the Terminus system. They suggest that it may be a partially collapsed wormhole.`
@@ -2629,6 +2725,8 @@ mission "Lost Boy 2"
 			`	"Oh yeah, that bugger! That little rebel was causin' me trouble so I sold him off soon as I could. If ya looking for him, then you're gonna need to look for a ship by the name of <npc>. They bought your boy Tod 'bout four days ago. Might be hangin' around a system nearby."`
 			`	You thank Cygnet, who has been surprisingly polite for a slave trader, for the information. "If ya ever need a slave, just come talk to me," he remarks as you walk back to your ship. "I've got the cheapest slaves this side of Sol."`
 				accept
+	on visit
+		dialog `You've landed on <planet>, but you haven't yet found Tod. Keep looking for the <npc> and then board the ship; it can't be far from Deadman's Cove.`
 	
 	npc board
 		personality staying nemesis target plunders
@@ -2660,6 +2758,8 @@ mission "Lost Boy 3"
 	name `Bring Tod to <planet>`
 	description `Now that Tod's mother knows he is safe, bring him to <destination> so that he may start his mining job to support him and his mother.`
 	destination "Placer"
+	passengers 1
+	blocked "This mission requires that you have at least one free bunk. Return once you have the space."
 	to offer
 		has "Lost Boy 2: done"
 	
@@ -2696,6 +2796,8 @@ mission "Lost Boy 3"
 		system "Al Dhanab"
 		ship "Falcon (Heavy)" "Cygnet's Slaver"
 	
+	on visit
+		dialog `You land on <planet>, but remember that Tod is in one of your escorts that has yet to enter the system. Better depart and wait for it to arrive.`
 	on complete
 		dialog `You wish Tod the best of luck on <planet>. "Thank you, Captain. Hopefully I can repay you one day. As cliche as it sounds, I owe you my life."`
 
@@ -2731,6 +2833,8 @@ mission "Paradise Fortune 1"
 			`	You open the hatch to your ship and yell "Get on!" as the girl approaches. "Thank you, Captain," she says while getting closer, to much protest from the approaching security guards.`
 			`	As she enters your ship, she grabs your arm and pulls you in with her before closing the hatch. "Launch and go to <destination>, now! I'll explain when we get there."`
 				launch
+	on visit
+		dialog `You land on <planet>, but realize that Diana is in one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -2782,6 +2886,8 @@ mission "Paradise Fortune 2"
 			
 	on decline
 		payment 150000
+	on visit
+		dialog `You land on <planet>, but realize that Diana is in one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -2838,6 +2944,9 @@ mission "Paradise Fortune 3"
 	
 	on decline
 		payment 500000
+	
+	on visit
+		dialog `You land on <planet>, but realize that Diana is in one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	
 	npc evade
 		government "Republic"
@@ -2971,6 +3080,8 @@ mission "Northern Blockade"
 		fleet "Large Northern Pirates"
 		fleet "Small Northern Pirates" 3
 	
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 7500
@@ -3049,6 +3160,8 @@ mission "Southern Blockade"
 		fleet "Large Free Worlds"
 	on stopover
 		dialog `The last of the defenses are quickly unloaded from your ship, put into place, and activated. A pirate ship attacking the system attempts to follow you down to the surface, but the fire coming from the newly installed spaceport turrets forces the pirate to turn away and flee for orbit. Time to return to <destination>.`
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 5000
@@ -3090,6 +3203,8 @@ mission "Core Blockade"
 		fleet "Large Core Pirates"
 		fleet "Small Core Pirates" 3
 	
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 10000
@@ -3168,6 +3283,8 @@ mission "Pirate Blockade"
 		personality nemesis staying harvests plunders
 		fleet "Large Core Pirates"
 	
+	on visit
+		dialog `You land on <planet> and begin looking around for the man you are suppose to meet, but then you realize that not all of the escaped slaves are here. Better depart and wait for your escorts holding the rest to arrive.`
 	on complete
 		payment
 		payment 1000

--- a/data/wanderer jobs.txt
+++ b/data/wanderer jobs.txt
@@ -392,6 +392,8 @@ mission "Wanderer Invasive Species [0]"
 		government "Wanderer"
 	on stopover
 		dialog `The Wanderers quickly make their way out of your ship with their equipment to contain the invasive animals. After roughly an hour, they return to your ship with cages that they place into your cargo hold. Now return to <origin> for payment.`
+	on visit
+		dialog phrase "generic missing stopover or cargo and passengers"
 	on complete
 		payment 25000 200
 		dialog `After releasing the animals, the <bunks> Wanderers each thank you for assisting them in returning the animals to <planet> and hand you <payment>.`
@@ -415,6 +417,8 @@ mission "Wanderer Invasive Species [1]"
 		government "Wanderer"
 	on stopover
 		dialog `The Wanderers quickly make their way out of your ship with their equipment to contain the invasive plant. After roughly an hour, they return to your ship with plants in containers of some sort that they place into your cargo hold. Now return to <origin> for payment.`
+	on visit
+		dialog phrase "generic missing stopover or cargo and passengers"
 	on complete
 		payment 30000 200
 		dialog `After handing the plants off to other Wanderers to plant elsewhere, the <bunks> Wanderers each thank you for assisting them in keeping the plants on <planet> and hand you <payment>.`

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -61,6 +61,8 @@ mission "Wanderers: Surveying 1"
 			label end
 			`	The Wanderers load a large amount of scientific equipment onto your ship and explain how to use it. They also indicate several planets that their long-range sensors have detected that they would like you to investigate further.`
 				accept
+	on visit
+		dialog phrase "generic stopover on visit"
 
 
 
@@ -121,6 +123,8 @@ mission "Wanderers: Surveying 2"
 			`	You leave the meeting with a long list of tasks to perform for the Wanderers. You hope they appreciate all the assistance you are giving them.`
 				accept
 	
+	on visit
+		dialog phrase "generic stopover on visit"
 	on complete
 		conversation
 			`You present your planetary measurements to Tema'a Iriket, the terraforming director. She is very excited about the data. "So many worlds," she says, "each with their own [personality? idiosyncrasies?]. We will learn more about each one, and discover how we can [partner, collaborate] with them to help them [recover, be reborn]."`
@@ -147,6 +151,8 @@ mission "Wanderers: Nova Remnants"
 			"You fire up your ship's sensors and collect the data that the Wanderers asked for on this system's sun."
 	to offer
 		has "Wanderers: Surveying 1: done"
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		log "Factions" "Archons" `Archons are partly biological, partly technological, and partly something that human language has no words for. They are extremely powerful. The Archons are somehow affiliated with the Drak, yet separate from them.`
 		conversation
@@ -184,6 +190,8 @@ mission "Wanderers: Mereti Controller"
 	source "Spera Anatrusk"
 	to offer
 		has "Wanderers: Surveying 1: done"
+	on visit
+		dialog `You have returned to <planet>, but you don't yet have a the component that is controlling the Kor Mereti drones. Depart and attempt to board one of the drones to plunder one.`
 	on complete
 		log `Discovered that the "Kor Mereti" drone ships are controlled by some sort of collective and decentralized artificial intelligence, with no obvious weaknesses.`
 		outfit "Reasoning Node" -1
@@ -210,6 +218,8 @@ mission "Wanderers: Sestor Controller"
 	source "Spera Anatrusk"
 	to offer
 		has "Wanderers: Surveying 1: done"
+	on visit
+		dialog `You have returned to <planet>, but you don't yet have a the component that is controlling the Kor Sestor drones. Depart and attempt to board one of the drones to plunder one.`
 	on complete
 		log `The "Kor Sestor" drones turn out to all be controlled remotely, presumably by either an artificial intelligence or by Korath leaders in hiding on one of their worlds. If the control center could be found, it would be possible to gain control of the entire Kor Sestor fleet.`
 		outfit "Control Transceiver" -1
@@ -362,6 +372,8 @@ mission "Wanderers: Rek To Kor Efret"
 			label end
 			`	Rek has no trouble finding the bunk rooms, and cheerfully settles in while you prepare for the journey to <planet>.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Rek hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -433,6 +445,8 @@ mission "Wanderers: Quarg Assistance 2"
 			`	The Quarg blinks slowly, with its strange eyelids moving from side to side rather than top to bottom. Then it says, "Grant you shall we three warships to with you travel back to the settlement of these friends of the loathsome Pug. They will help to keep the death-bringing robots at bay. And oversee will they the Wanderers, and judge if as benevolent as you say are they."`
 			`	It is extremely strange that the first random Quarg you accosted in the hallway happened to be one with the authority to launch a fleet of warships, but it would be impolite to question such a generous, if extremely verbose offer. You thank the Quarg and return to your ship. Hopefully the Wanderers will be glad for the protection and will not object to having a Quarg fleet overhead scrutinizing their actions.`
 				accept
+	on visit
+		dialog `You've reached <planet>, but you left one of the Quarg ships behind. Better depart and wait for it to arrive.`
 	npc accompany save
 		government "Quarg"
 		personality escort
@@ -620,6 +634,8 @@ mission "Wanderers: Mereti Observation"
 				"Model 64"
 				"Model 32" 2
 				"Model 16" 5
+	on visit
+		dialog `You've returned to <planet>, but you don't have enough data for the Wanderers. Return to Mesuket and wait until the device notifies you that it has enough data.`
 
 
 
@@ -673,6 +689,8 @@ mission "Wanderers: Kor Efret 2"
 			`	Rek does her best to explain your suggestion to the Korath. One of them responds, and she translates, "She said that there is a team of Korath engineers on <planet> who have been working for fifty years to find a way to destroy the automata. She says perhaps they can assist us."`
 			`	You agree to travel with Rek to <planet> and see what the engineers can tell you.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Rek hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -805,6 +823,8 @@ mission "Wanderers: Kor Efret 4"
 			label end
 			`	Rek tells you that she wants to return to <planet> to continue her work with the Korath community there. You agree to take her there before returning to report to Tele'ek.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Rek hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -850,6 +870,8 @@ mission "Wanderers: Kor Mereti Hacking"
 			label end
 			`	You aren't sure what you can say that would be helpful to him, so you return to your ship and prepare to travel to the Mekislepti system to test out the Kor Mereti hacking program.`
 				accept
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on enter "Mekislepti"
 		dialog
 			`When you enter the Mekislepti system, an entire fleet of drones moves to intercept you. Hardly daring to hope, you press the button that activates the Wanderer program. For a fraction of a second, the drones' engines stop firing and they drift as if out of control. Then, with renewed purpose, they move to attack you.`
@@ -930,6 +952,8 @@ mission "Wanderers: Mind 2"
 			label end
 			`	The "artificial Mind" turns out to be a computer not much larger than a typical cargo crate. Pa'aret walks beside it with one wing draped around it like an overprotective parent while Wanderer workers load it onto your ship. Clearly this particular piece of technology is very valuable to the Wanderers.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Meto Pa'aret and the Mind hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1010,6 +1034,8 @@ mission "Wanderers: Mind 5"
 			label end
 			`	A team of Wanderer engineers boards your ship, and you prepare to deliver them, along with the artificial Mind, to the Kor Mereti space station in the <system> system.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Wanderer engineers and the Mind hasn't entered the system yet. Better depart and wait for it to arrive.`
 	npc
 		government "Kor Mereti"
 		personality staying heroic
@@ -1088,6 +1114,8 @@ mission "Wanderers: Mind 6"
 				"Model 64" 3
 				"Model 32" 5
 				"Model 16" 8
+	on visit
+		dialog `You've landed on <planet>, but there are still hostile Kor Mereti drones in the Chimitarp system. Better depart and make sure they've been taken care of.`
 
 
 
@@ -1191,6 +1219,8 @@ mission "Wanderers: Mind 8"
 			`	The drone says, "We gave it water. But maybe the dirt was [poisoned, unhealthy]. Or the light is too bright. A human cannot fix it, but our [parents? ancestors?] would know how. Will you bring it to them?"`
 			`	They seem too distraught about the dead plant to be willing to give you more information about themselves. Despite the absurdity of the situation, you agree to take the plant back to the Wanderers and see if they can do anything for it.`
 				accept
+	on visit
+		dialog `You've reached <planet>, but your escort who is carrying the dead plant hasn't arrived in the system yet. Better depart and wait for it.`
 
 
 
@@ -1515,6 +1545,8 @@ mission "Wanderers: Sestor Scanning"
 			`	Iriket says, "I can supply Captain <last> with [surveying?] scanners and [ground-penetrating radar?] from the terraforming team. Such a [facility, installation] might well be deep underground."`
 			`	The Wanderers begin loading the scanning equipment onto your ship, and ask you to land on each of the planets in Kor Sestor space to collect measurements. "Bring the [data, results] back to us to be analyzed," says Iriket.`
 				accept
+	on visit
+		dialog phrase "generic stopover on visit"
 	on stopover
 		dialog `That was the last of the Kor Sestor planets that the Wanderers asked you to scan. Time to return to <planet> with the data.`
 
@@ -1699,6 +1731,8 @@ mission "Wanderers: Sestor Search"
 			`You return to the planet expecting the Wanderers to be celebrating their victory, but the leaders have grim news. "The drones we fought were only the [rearguard? remnant?] of the fleet," says Tele'ek. "Dozens of [capital ships?] passed through this system and continued on. With this [heading, destination]." On the holographic projector, he brings up a star map, and points to the system where the Eye is. The wormhole leading back to Wanderer space.`
 			`	Tele'ek says, "Every ship we can spare must [pursue, follow] the Sestor drones through the Eye, and hope that we [locate, track down] the drones before they can cause [harm, destruction] to our people." You should probably join them.`
 				accept
+	on visit
+		dialog `You've returned to <planet>, but you haven't yet found out where the Sestor fleet has gone. Keep searching for it; it's dangerous letting such a powerful hostile fleet roam free.`
 	to fail
 		has "wanderers: found the sestor fleet"
 	on enter "Aya'k'k"
@@ -1922,6 +1956,8 @@ mission "Wanderers: Sestor: Farpoint Attack 1"
 			`	You tell him about the underground bunker that the Wanderers discovered, and the signs that someone either recently departed from it, or recently infiltrated it from the surface. He says, "We already know that a group of Alphas was active in that region of space. You and I fought them there just recently, and failed to capture them. I bet that after they fled, they somehow gained access to the Kor Sestor bunker and took over control of the drone fleets."`
 			`	It is not particularly surprising when, a few seconds after he says that, an alarm siren begins to sound...`
 				launch
+	on visit
+		dialog `There are still Sestor warships overhead. You should take off again and assist in the fight.`
 	npc evade
 		government "Kor Sestor"
 		personality heroic staying
@@ -2051,6 +2087,8 @@ mission "Wanderers: Sestor: Quarg Help 2"
 		personality heroic staying
 		system "Alnitak"
 		fleet "Large Kor Sestor" 2
+	on visit
+		dialog `You've reached <planet>, but you've either left one of the Quarg warships behind, or your escort carrying the medical supplies from Elias hasn't entered the system yet. Better depart and wait for it.`
 
 
 
@@ -2112,6 +2150,8 @@ mission "Wanderers: Sestor: Bomb Zenith 1"
 		dialog
 			`Danforth wasn't joking when he said that the device may be your only chance. There are almost a dozen Sestor capital ships in the system, and countless smaller craft tearing the Navy to shreds.`
 			`Even the Quarg warships are having trouble with an opposing fleet this size. Perhaps a more powerful fleet could defeat the automata, but it would be a difficult battle.`
+	on visit
+		dialog `You go to push the device out of the airlock, but realize that you left it on one of your escorts. Better depart and wait for it to enter the system.`
 	on complete
 		fail "Wanderers: Sestor: Farpoint Attack 2"
 	to fail
@@ -2125,6 +2165,8 @@ mission "Wanderers: Sestor: Farpoint Attack 2"
 	source "Farpoint"
 	to offer
 		has "Wanderers: Sestor: Quarg Help 2: done"
+	on visit
+		dialog `Danforth notices your ship land as the sky lights up with the explosions of Navy ships. "Did you use the bomb?" he asks. The stress in his voice is palpable. You shake your head. "Then what the hell are you doing here? Get up there and drop the bomb already!"`
 	npc
 		government "Quarg"
 		personality heroic staying
@@ -2655,6 +2697,8 @@ mission "Wanderers: Sestor: Drones in Alnilam"
 				`	"Are any of your ships repaired yet? I could use some assistance."`
 			`	He agrees to send some Oathkeeper ships with you to destroy the remaining drones, but it is clear that it pains him to risk the last few ships he has that are still spaceworthy.`
 				accept
+	on visit
+		dialog `You've returned to <planet>, but not all of the Sestor ships in Alnilam have been defeated yet. Return to the system and make sure they are all destroyed.`
 	npc
 		government "Navy (Oathkeeper)"
 		personality heroic escort
@@ -2762,6 +2806,8 @@ mission "Wanderers: Sestor Alt: Alnilam 2"
 		ship "Cruiser (Mark II)" "R.N.S. Dauntless"
 		ship "Cruiser (Mark II)" "R.N.S. Forthright"
 		ship "Cruiser (Mark II)" "R.N.S. Virtue"
+	on visit
+		dialog `You've reached <planet>, but not all of the Navy Cruisers have entered the system yet. Better depart and wait for them to arrive, because there's no way you're going to assault the Alpha base without them.`
 
 
 
@@ -2785,6 +2831,8 @@ mission "Wanderers: Sestor Alt: Alnilam 3"
 		ship "Cruiser (Mark II)" "R.N.S. Dauntless"
 		ship "Cruiser (Mark II)" "R.N.S. Forthright"
 		ship "Cruiser (Mark II)" "R.N.S. Virtue"
+	on visit
+		dialog `You've reached <planet>, but not all of the Navy Cruisers have entered the system yet. Better depart and wait for them to arrive.`
 
 
 
@@ -2843,6 +2891,8 @@ mission "Wanderers: Sestor: Scan Drones"
 			label data
 			`	Tele'ek introduces you to the team of scientists who will tackle the problem of shutting down the Kor Sestor factories. They explain to you that they are looking for any identifying information on the drones, including the alloy composition of their hulls and prevalence of blast marks or other signs of age. That will allow them to estimate how quickly the drones are being produced.`
 				accept
+	on visit
+		dialog phrase "generic waypoint on visit"
 	npc
 		system "Silikatakfar"
 		government "Kor Sestor"
@@ -2920,6 +2970,8 @@ mission "Wanderers: Sestor: Exiles 2"
 			label end
 			`	Rek makes herself comfortable in one of your bunk rooms, and you prepare for a visit to the territory of the Korath exiles. "We must somehow earn their trust," she says, "so do not fire on any of their ships. Instead we must find a way to communicate with them or a place where they will meet with us peacefully."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Rek hasn't entered the system yet. Better depart and wait for it to arrive.`
 	npc save
 		government "Korath"
 		system "Kor Fel'tar"
@@ -2997,6 +3049,8 @@ mission "Wanderers: Sestor: Exiles 3"
 		ship "Korath World-Ship A (Jump)" "Seskerat Pratka"
 		ship "Korath World-Ship B (Jump)" "Eskretakfakta"
 		ship "Korath World-Ship C (Jump)" "Prekaprat Skata"
+	on visit
+		dialog `You have reached <planet>, but you're missing something! Either you've left one of the Korath ships behind, or your escort carrying Rek hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -3029,6 +3083,8 @@ mission "Wanderers: Sestor: Factory 1"
 		ship "Korath World-Ship A (Jump)" "Seskerat Pratka"
 		ship "Korath World-Ship B (Jump)" "Eskretakfakta"
 		ship "Korath World-Ship C (Jump)" "Prekaprat Skata"
+	on visit
+		dialog `You have reached <planet>, but you're missing something! Either you've left one of the Korath ships behind, or your escort carrying Rek hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -3160,6 +3216,8 @@ mission "Wanderers: Sestor: Factory 3"
 			label end
 			`	With nothing else to do here, you get ready to return to <planet> and report to the Wanderer leaders.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Rek hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -3290,6 +3348,8 @@ mission "Wanderers: Sestor: Final"
 				"Model 16" 3
 				"Tek Far 78 - Osk"
 				"Met Par Tek 53 (Sniper)" 2
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		log "Discovered that when the Korath exiles shut down the Kor Sestor factory, they also took enough technology from the factory to be able to begin producing war drones of their own. It is possible that the exiles have just become a whole lot more dangerous than they used to be."
 		event "wanderers: exiles have drones" 20

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -65,6 +65,8 @@ mission "First Contact: Wanderer"
 				`	"Are there any Hai here?"`
 			`	The same alien speaks again, pantomiming your ship flying into the sky and then returning, and then points to your airlock and mimics your rodent-ear gesture for the Hai. You think it is telling you to go find one of the Hai who can serve as an interpreter, and bring them back here.`
 				accept
+	on visit
+		dialog `Your ship is surrounded by the birdlike aliens. When you step onto the planet, one of the aliens seems to recognize you. "Ka'hai?" it seems to ask, once again mimicking the rodent-like ears of the Hai with its feathered limbs. You shake your head, for you have returned without a Hai to act as an interpreter. Maybe it would be wise to actually go to the Hai before returning to see if one will come with you.`
 
 
 
@@ -139,6 +141,8 @@ mission "Wanderers: Diplomacy"
 	
 	on accept
 		fail "First Contact: Wanderer"
+	on visit
+		dialog `Your ship is surrounded by the birdlike aliens. When you step onto the planet, one of the aliens seems to recognize you. "Ka'hai?" it seems to ask, once again mimicking the rodent-like ears of the Hai with its feathered limbs. You attempt to gesture to Sayari, but become embarrassed when you realize that you left her on one of your escorts that hasn't yet entered the system. Better depart and wait for it to arrive.`
 
 
 
@@ -394,6 +398,8 @@ mission "Wanderers: Defend Vara Ke'sok"
 	on accept
 		"reputation: Hai (Unfettered)" <?= -1
 		event "Sich'ka'ara empty"
+	on visit
+		dialog "There are still Unfettered warships overhead. You should take off again and assist in the fight."
 	on complete
 		event "Sich'ka'ara restored"
 	
@@ -492,6 +498,8 @@ mission "Wanderers: Unfettered Diplomacy 1"
 					decline
 	on accept
 		log `Volunteered to help bring a shipment of food to the Unfettered, as "tribute" from the Wanderers, in the hope that it will placate the Unfettered into making peace.`
+	on visit
+		dialog `When you land on <planet>, you ask one of the Wanderers where the food shipment is. They only tilt their head and respond to you in the Wanderer language. You look around for Iktat Rek to translate, but you realize that you left him on one of your escorts that hasn't yet entered the system. Better depart and wait for it to arrive.`
 
 ship "Deep River" "Deep River (Jump, Unarmed)"
 	outfits
@@ -523,6 +531,8 @@ mission "Wanderers: Unfettered Diplomacy 1A"
 			`	"I would prefer that you avoid combat," he says. "The Unfettered are said to be [greedy, eager] for bribes, if you are willing to spend money to buy peace. Or simply avoid returning fire; the freighter is well shielded."`
 			`	It takes several hours for the massive Wanderer freighter to be loaded. Rek explains that they have kept track of which kinds of food the Unfettered prefer to steal, so they know what will be edible for them. He says, "Our destination is called <planet>. Sayari tells me that all Hai share a [custom, taboo] concerning guests, so once we land on their planet we will be able to [speak, parley] with them in safety."`
 				accept
+	on visit
+		dialog `You've landed on <planet>, but you're missing something! Either the <npc> hasn't entered the system yet, or Iktat Rek is on one of your escorts that hasn't enetered the system yet. Better depart and wait for it.`
 	npc accompany save
 		government "Wanderer"
 		personality timid escort
@@ -555,6 +565,8 @@ mission "Wanderers: Unfettered Diplomacy 1B"
 				accept
 	on accept
 		event "wanderer / unfettered peace"
+	on visit
+		dialog `You've landed on <planet>, but you're missing something! Either the <npc> hasn't entered the system yet, or Iktat Rek is on one of your escorts that hasn't enetered the system yet. Better depart and wait for it.`
 	npc accompany save
 		government "Wanderer"
 		personality timid escort
@@ -597,6 +609,8 @@ mission "Wanderers: Unfettered Diplomacy 1C"
 		conversation
 			`You drop the freighter off safely on <origin>. Iktat Rek says, "Now I must return to our home, to [discuss, plan] with our elders. We cannot trust the Unfettered with a world in our space; they would build a [garrison, war fleet] there and attack us. But perhaps this [agreement, settlement] will give us peace for long enough to find a better solution."`
 				accept
+	on visit
+		dialog `When you return to <planet>, you're approached by Sayari and a few of the Wanderer elders. "Where is Iktat Rek?" Sayari asks. You realize that you left him on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		"reputation: Wanderer" >?= 20
 		set "license: Wanderer"
@@ -772,6 +786,8 @@ mission "Wanderers: Alpha Surveillance A"
 			`	You split the devices up into three piles, one for each of the Unfettered systems, and keep one of them for yourself, well hidden in a safe place on your ship.`
 				accept
 	
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		log "Planted some surveillance devices, designed by the Wanderers, in Unfettered Hai space. A month from now, they will be done collecting data on ship movements in the area, and may provide a hint of where the Alphas who are selling jump drives to the Unfettered are coming from."
 		event "wanderers: alpha surveillance done" 30
@@ -822,6 +838,8 @@ mission "Wanderers: Alpha Surveillance B"
 			`	Hopefully you will be able to collect the data without the Unfettered intercepting the transmissions and realizing they have been spied on.`
 				accept
 	
+	on visit
+		dialog phrase "generic waypoint on visit"
 	on complete
 		conversation
 			`When you arrive at the spaceport, you contact Iktat Rek and send him a copy of the encrypted recordings. You also mention to him that the Unfettered attacked you after you sent out the data retrieval signal. "That is [unfortunate, regrettable]," says Rek. "I hope they will [cool off, calm down] in time. I suspect you could buy their [friendship, favor] back with another jump drive, or just ignore their [attacks, antagonism] for now."`
@@ -1060,6 +1078,8 @@ mission "Wanderers: Alpha Surveillance D"
 		ship "Far Lek 14" "Rudolph"
 		ship "Far Lek 14" "Ralph"
 	
+	on visit
+		dialog `You've returned to <planet>, but you have a feeling that your job isn't done. Either find where the Alphas are hiding, or return to where they are hiding and finish what you started.`
 	on complete
 		log "Defeated a Navy Carrier, presumably being operated by the Alphas, that was equipped with Korath fighters and drones. Presumably there is an Alpha base hidden somewhere on the earth-like planet that the carrier was guarding."
 		conversation
@@ -1102,6 +1122,8 @@ mission "Wanderers: Alpha Surveillance E"
 			`	He comes back aboard your ship, and you prepare to travel to Danforth's base on <destination>.`
 				accept
 	
+	on visit
+		dialog `You've landed on <planet>, but you realize that Elias is on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive before meeting with Admiral Danforth.`
 	on complete
 		conversation
 			`Admiral Danforth is very pleased to see you, but his expression turns grim when you explain why you have come. When you mention the Alphas, he hushes you. "Let's not speak of that, out here in the open," he says. "Not that I do not trust my people, but it is best to be safe. I will gather troops who I know are able to operate discreetly and have them be ready to join us on an expedition. Meet me in my private office at the spaceport when you're ready."`
@@ -1311,6 +1333,8 @@ mission "Wanderers: Alpha Surveillance I"
 			label leave
 			`	You agree that you will take Elias back to Alta Hai. Whatever Elias is, whoever might wish him harm, you can only hope that a Quarg ringworld is the safest place for him right now.`
 				accept
+	on visit
+		dialog `You've landed on <planet>, but you realize that Elias is on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1619,6 +1643,8 @@ mission "Wanderers Invaded 3B"
 					decline
 			`	"Thank you," she says. "We should go there quickly, so that we can decide our next [gambit, strategy] before the Hai attack us again."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Isai hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1651,6 +1677,8 @@ mission "Wanderers Invaded 3C"
 				accept
 	on accept
 		"reputation: Pug" >?= 1
+	on visit
+		dialog `You return to <planet> without any more information on who or what controls the Eye. Perhaps the answer is closer than you think.`
 	on complete
 		dialog
 			`You have collected some useful information on the nature of the "Eye." You should probably head to the spaceport and meet up with Iktat Rek.`
@@ -1736,6 +1764,8 @@ mission "Wanderers Hai Assistance 1"
 			`	Sayari says, "I have offered to speak to the Hai governors, to see if they can do anything to restrain the Unfettered from making further incursions into Wanderer space. Would you be willing to transport me to <planet>?"`
 			`	"Of course," you say. She leaves to gather some traveling gear and to meet you at your ship.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Sayari hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1769,6 +1799,8 @@ mission "Wanderers Hai Assistance 2"
 			`	"Perhaps it would be enough merely to threaten them," says another of the elders. "We could gather a massive war fleet above Cloudfire. The Unfettered would need to muster a matching fleet above Darkcloak. It would draw many of their warships away from the alien territory."`
 			`	After well over an hour of further discussion, they reach consensus that that is their best option. As you leave the meeting, Sayari says, "And now, I would like to visit the Unfettered themselves. Perhaps we can talk sense into them."`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Sayari hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 mission "Wanderers Hai Assistance Fleet"
 	landing
@@ -1802,6 +1834,8 @@ mission "Wanderers Hai Assistance 3"
 			`	"Better to die asserting our strength than to live with our hands outstretched to beg," says another of the chiefs.`
 			`	You are unable to convince them to change their plans, and as soon as the conversation ends they insist that you leave their planet. "Our warriors in orbit are eager to test this human's strength," says one of the chiefs, laughing.`
 				launch
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Sayari hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -1871,6 +1905,8 @@ mission "Wanderers Solifuge Recon 2"
 				"Violin Spider" 6
 				"Violin Spider (Pulse)" 6
 		dialog "That was the last of the new Unfettered ships. You can now report back to Tele'ek on <planet>."
+	on visit
+		dialog `Tele'ek approaches you when you land. "I have [reports, word] that the Unfettered ships are still [present, alive] within Prakacha'a. Please destroy them all before returning."`
 	on complete
 		conversation
 			`Tele'ek listens carefully as you outline the strengths and weaknesses of the new Unfettered carriers. "I am not greatly [concerned, frightened] by tiny fighters," he says. "The weapon that has done us most harm is their ion cannons, which no ship so small can [wield, carry]. But thank you for your assistance. Alas, we have no other [fights, brawls] for you to take part in right now, but if you visit the spaceport, you will find another evacuation fleet that needs an [escort, protector]."`
@@ -1937,6 +1973,8 @@ mission "Wanderers Evacuation 1B"
 		personality heroic staying
 		system "Sich'ka'ara"
 		fleet "Large Unfettered" 3
+	on visit
+		dialog `You've landed on <planet>, but not all of the Deep River transports carrying the refugees are in the system. Better depart and wait for them all to arrive.`
 
 
 
@@ -1973,6 +2011,8 @@ mission "Wanderers Evacuation 1C"
 		personality heroic staying
 		system "Sich'ka'ara"
 		fleet "Large Unfettered" 4
+	on visit
+		dialog `You've landed on <planet>, but not all of the Deep River transports carrying the refugees are in the system. Better depart and wait for them all to arrive.`
 
 
 
@@ -2216,6 +2256,8 @@ mission "Wanderers Rek 0"
 			`	He makes a sound halfway between a laugh and a cough, and says, "Even as my body decays, my mind has grown sharper. The more I listened to your box speaking to you, the more its words began to make sense to me."`
 			`	He seems too tired to answer any more questions. You make sure Rek is comfortable in one of your bunk rooms, then prepare to travel to <planet>.`
 				accept
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Iktat Rek hasn't entered the system yet. Better depart and wait for it to arrive.`
 
 
 
@@ -2236,6 +2278,8 @@ mission "Wanderers Rek 1"
 	on enter "Sko'karak"
 		dialog
 			`You enter this system with high hopes that Rek, despite his weakened state, has sensed something significant happening here and sent you to discover it. But, your sensors pick up nothing out of the ordinary.`
+	on visit
+		dialog `You've returned to <planet>, but you haven't yet entered the Sko'karak system to investigate. Better depart and make sure you visit it before returning.`
 
 
 
@@ -2261,6 +2305,8 @@ mission "Wanderers Rek 2"
 	on enter "Sko'karak"
 		dialog
 			`You enter the system again, and do an even more detailed sensor sweep in case you missed something the first time. You find nothing.`
+	on visit
+		dialog `You've returned to <planet>, but you haven't yet entered the Sko'karak system to investigate. Better depart and make sure you visit it before returning.`
 
 
 
@@ -2288,6 +2334,8 @@ mission "Wanderers Rek 3"
 	on enter "Sko'karak"
 		dialog
 			`This time when you enter the system, your sensors pick up some strange astronomical phenomenon out beyond the orbit of the farthest planet, a wisp of light like a gathering raincloud. It's not a wormhole, but it is a change. Perhaps it will be enough to give Rek hope.`
+	on visit
+		dialog `You've returned to <planet>, but you haven't yet entered the Sko'karak system to investigate. Better depart and make sure you visit it before returning.`
 
 
 


### PR DESCRIPTION
Ref: #4315 

On visit dialogs for all remaining missions in the game. I split up the PRs to distinguish between jobs only using generic dialogs and proper missions with unique ones.

I've also made a new file named `dialog phrases.txt` used to store the generic dialogs used in various files.

This is taking longer than #4315 given that it isn't 100% copying and pasting `dialog phrase "generic..."` over and over again. Decided to PR what I have done so far.

- [x] Jobs missed in #4315 
- [x] Hai missions
- [x] Deep missions
- [x] Transport missions
- [x] Remnant missions
- [x] Wanderer missions
- [x] Free Worlds missions

Going forward, it should be standard to give a mission an on visit dialog if the mission can trigger it.
<hr/>

### Notes

I haven't added dialogs to a select few missions where it didn't seem like it would make sense, such as the April Fools job or @Pointedstick's shady passenger double cross mission; the passengers had to be in the player's flagship for the mission to make sense, but an on visit dialog would suggest that the passengers were in a different ship the entire time.

In instances where the on visit dialog could be triggered by multiple things and mentioning all the possible triggers didn't make sense, I went with that I considered to be the most likely cause of triggering it. For example, during the mission where you have to find the Alpha base, the on visit dialog could be triggered either due to Elias not being in the system, or the Alpha ship not being killed. I decided to have the on visit mention the Alpha ship not having been destroyed, as I'd find it more likely that the player would run back to Alta Hai after finding the Alpha base instead of the player not having Elias in the system.