### PR TITLE
Remant: Fixing the Gascraft to prevent another avenue of Cloak installation

### DIFF
--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -193,12 +193,18 @@ ship "Gascraft"
 		"energy capacity" 150
 		"ramscoop" 0.5
 		"cargo space" 8
-		"outfit space" 88
+		"outfit space" 54
 		"engine capacity" 34
 		"shield generation" 0.6
 		"shield energy" 0.4
 		"hull repair rate" 1.2
 		"hull energy" 0.9
+		"turn" 448.0
+		"turning energy" 1.32
+		"turning heat" 1.4
+		"thrust" 18.0
+		"thrusting energy" 2.65
+		"thrusting heat" 2.5
 		"gaslining" 1
 		"outfit scan power" 24
 		"outfit scan speed" 1
@@ -209,8 +215,6 @@ ship "Gascraft"
 		"Emergency Ramscoop"
 		"Quantum Key Stone"
 
-		"Crucible-Class Thruster"
-		"Crucible-Class Steering"
 		"Hyperdrive"
 
 	engine 0 30


### PR DESCRIPTION
Added built-in thrust & turn equivalent to a set of crucible engines.

Removed the set of crucible engines & equivalent amount of space.

This change means that the player cannot swap these components out for the Coalition's small thrust module and small steering module, thus ensuring the player can't use those to outfit the gascraft with a cloaking device.

Note that a player could still technically replace the millennium cell with a Small Biochemical Cell and fit the Cloak in, but they would be unable to cloak for any real length of time, especially while maneuvering. I suspect that trying to use the cloak with said cell would probably actually be harder than the normal dodging. Since it is probably actually harder, I'm leaving it in, whereas with the smaller engines, it becomes easier.

Related thread: https://github.com/endless-sky/endless-sky/pull/3535 Wherein Endless-Sky describes how he removed the capacitor to force the player to not use the cloak. 