### PR TITLE
Remnant-Fix: Making Plasma Cannons singular

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -702,7 +702,7 @@ mission "Remnant: Tech Retrieval"
 		or
 			has "Remnant: Heavy Laser: done"
 			has "Remnant: Catalytic Ramscoop: done"
-			has "Remnant: Plasma Cannons: done"
+			has "Remnant: Plasma Cannon: done"
 			has "Remnant: Electron Beam: done"
 			has "Remnant: D94-YV Shield Generator: done"
 			has "Remnant: S-970 Regenerator: done"
@@ -1037,7 +1037,7 @@ mission "Remnant: Salvage 1"
 		random < 50
 		or
 			has "Remnant: Catalytic Ramscoop: done"
-			has "Remnant: Plasma Cannons: done"
+			has "Remnant: Plasma Cannon: done"
 			has "Remnant: Heavy Laser: done"
 			has "Remnant: Tech Retrieval: done"
 	on offer


### PR DESCRIPTION
Removing the `s` from Plasma Cannons in the requirements for Remnant: Tech Retrieval and Remnant: Salvage 1 so that they properly match the name of the plasma cannon mission (which, like the other tech retrieval missions, is singular.)

Change:
- line 705 removed the plurral `s` from Cannons
- line 1040 removed the plural `s` from Cannons

Thanks to CaptJosh on the Endless Sky discord for reporting this.