### PR TITLE
Remnant-Fix: A missing quotation mark

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -684,7 +684,7 @@ mission "Remnant: Tech Retrieval"
 			choice
 				`	"Okay, I will see what I can find."`
 					goto find
-				`	"Could you elaborate on 'how fast they can travel in deep space?"`
+				`	"Could you elaborate on 'how fast they can travel in deep space?'"`
 				`	"No, I don't want to get involved in this."`
 					goto nothelp
 			`	She considers her thoughts briefly, then chants, "How fast a ship can move through an area of deep space basically depends on how fast they can collect fuel. Ramscoops were common at the time of the exodus, and if humanity has developed better ramscoops or other means of generating fuel, these would significantly improve their speed at exploring or crossing large volumes of space."`

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -684,7 +684,7 @@ mission "Remnant: Tech Retrieval"
 			choice
 				`	"Okay, I will see what I can find."`
 					goto find
-				`	"Could you elaborate on 'how fast they can travel in deep space?'"`
+				`	"Could you elaborate on 'how fast they can travel in deep space'?"`
 				`	"No, I don't want to get involved in this."`
 					goto nothelp
 			`	She considers her thoughts briefly, then chants, "How fast a ship can move through an area of deep space basically depends on how fast they can collect fuel. Ramscoops were common at the time of the exodus, and if humanity has developed better ramscoops or other means of generating fuel, these would significantly improve their speed at exploring or crossing large volumes of space."`


### PR DESCRIPTION
Adds a missing `'` to line 687 in the remnant missions.txt file.

Thanks to @jostephd for spotting this and reporting it in issue #4357 

Thanks to the Writing Commune led by Moonbeam for the advice on correcting it.