### PR TITLE
Gave Tactical and Asteroid scanners to some ships

### DIFF
--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -867,15 +867,15 @@ fleet "Human Miners"
 	variant 1
 		"Fury"
 	variant 2
-		"Fury (Laser)"
-	variant 3
+		"Fury (Miner)"
+	variant 1
 		"Hawk"
-	variant 1
-		"Hawk (Speedy)"
 	variant 2
-		"Headhunter"
+		"Hawk (Miner)"
 	variant 1
-		"Headhunter (Particle)"
+		"Headhunter"
+	variant 2
+		"Headhunter (Miner)"
 
 fleet "Small Free Worlds"
 	government "Free Worlds"

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -368,6 +368,7 @@ ship "Bastion"
 		"nGVF-BB Fuel Cell"
 		"D67-TM Shield Generator"
 		"Water Coolant System"
+		"Tactical Scanner"
 		"Laser Rifle" 7
 		
 		"Impala Plasma Thruster"
@@ -742,6 +743,7 @@ ship "Carrier"
 		"Laser Rifle" 40
 		"Fragmentation Grenades" 40
 		"Security Station"
+		"Tactical Scanner"
 		
 		"X5700 Ion Thruster"
 		"X4200 Ion Steering"
@@ -1041,6 +1043,7 @@ ship "Cruiser"
 		"Laser Rifle" 20
 		"Fragmentation Grenades" 20
 		"Security Station"
+		"Tactical Scanner"
 		
 		"X4700 Ion Thruster"
 		"X4200 Ion Steering"
@@ -1155,6 +1158,7 @@ ship "Dreadnought"
 		"D41-HY Shield Generator"
 		"Small Radar Jammer"
 		"Liquid Helium Cooler"
+		"Tactical Scanner"
 		"Laser Rifle" 25
 		
 		"Orca Plasma Thruster"
@@ -1598,6 +1602,7 @@ ship "Gunboat"
 		"Small Radar Jammer"
 		"Cargo Scanner"
 		"Outfit Scanner"
+		"Tactical Scanner"
 		"Brig"
 		
 		"X3700 Ion Thruster"
@@ -2479,6 +2484,7 @@ ship "Rainmaker"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
 		"Large Radar Jammer"
+		"Tactical Scanner"
 		
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
@@ -2588,6 +2594,7 @@ ship "Roost"
 		"LP072a Battery Pack"
 		"D41-HY Shield Generator" 4
 		"Large Radar Jammer"
+		"Tactical Scanner"
 		"Laser Rifle" 2
 		
 		"Greyhound Plasma Thruster"
@@ -2751,6 +2758,7 @@ ship "Skein"
 		"LP072a Battery Pack"
 		"D67-TM Shield Generator" 4
 		"Large Radar Jammer"
+		"Tactical Scanner"
 		"Laser Rifle" 4
 		
 		"Greyhound Plasma Thruster"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -186,6 +186,7 @@ ship "Bastion" "Bastion (Heavy)"
 		"LP072a Battery Pack"
 		"D67-TM Shield Generator"
 		"Liquid Nitrogen Cooler"
+		"Tactical Scanner"
 		"Laser Rifle" 8
 		"Outfits Expansion" 2
 		"X3700 Ion Thruster"
@@ -703,6 +704,7 @@ ship "Cruiser" "Cruiser (Mark II)"
 		"Small Radar Jammer" 2
 		"Liquid Helium Cooler"
 		"Fuel Pod"
+		"Tactical Scanner"
 		"Laser Rifle" 25
 		"Fragmentation Grenades" 25
 		"A520 Atomic Thruster"
@@ -732,6 +734,7 @@ ship "Dreadnought" "Dreadnought (Jump)"
 		"D41-HY Shield Generator"
 		"Small Radar Jammer"
 		"Liquid Helium Cooler"
+		"Tactical Scanner"
 		"Laser Rifle" 25
 		"Orca Plasma Thruster"
 		"Orca Plasma Steering"
@@ -755,6 +758,7 @@ ship "Falcon" "Falcon (Heavy)"
 		"Fusion Reactor"
 		"D67-TM Shield Generator"
 		"Small Radar Jammer"
+		"Tactical Scanner"
 		"Laser Rifle" 20
 		"Orca Plasma Thruster"
 		"A375 Atomic Steering"
@@ -774,6 +778,7 @@ ship "Falcon" "Falcon (Laser)"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
 		"Small Radar Jammer"
+		"Tactical Scanner"
 		"Laser Rifle" 18
 		"Impala Plasma Thruster"
 		"Orca Plasma Steering"
@@ -788,6 +793,7 @@ ship "Falcon" "Falcon (Plasma)"
 		"D41-HY Shield Generator"
 		"Small Radar Jammer"
 		"Liquid Nitrogen Cooler"
+		"Tactical Scanner"
 		"Laser Rifle" 16
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
@@ -1084,6 +1090,18 @@ ship "Fury" "Fury (Missile)"
 		"Hyperdrive"
 
 
+ship "Fury" "Fury (Miner)"
+	outfits
+		"Heavy Laser" 2
+		"nGVF-CC Fuel Cell"
+		"Supercapacitor"
+		"D14-RN Shield Generator"
+		"Asteroid Scanner"
+		"X2700 Ion Thruster"
+		"X2200 Ion Steering"
+		"Hyperdrive"
+
+
 
 ship "Gunboat" "Gunboat (Mark II)"
 	outfits
@@ -1216,6 +1234,18 @@ ship "Hawk" "Hawk (Speedy)"
 		"Hyperdrive"
 
 
+ship "Hawk" "Hawk (Miner)"
+	outfits
+		"Heavy Laser" 2
+		"S3 Thermionic"
+		"LP036a Battery Pack"
+		"D41-HY Shield Generator"
+		"Asteroid Scanner"
+		"A120 Atomic Thruster"
+		"A255 Atomic Steering"
+		"Hyperdrive"
+
+
 
 ship "Headhunter" "Headhunter (Hai)"
 	outfits
@@ -1235,6 +1265,18 @@ ship "Headhunter" "Headhunter (Particle)"
 		"NT-200 Nucleovoltaic"
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
+		"A250 Atomic Thruster"
+		"A375 Atomic Steering"
+		"Hyperdrive"
+
+
+ship "Headhunter" "Headhunter (Miner)"
+	outfits
+		"Particle Cannon" 2
+		"NT-200 Nucleovoltaic"
+		"LP036a Battery Pack"
+		"D14-RN Shield Generator"
+		"Asteroid Scanner"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
@@ -1593,6 +1635,7 @@ ship "Osprey" "Osprey (Laser)"
 		"Supercapacitor" 4
 		"D94-YV Shield Generator"
 		"Water Coolant System"
+		"Tactical Scanner"
 		"Laser Rifle" 3
 		"Impala Plasma Thruster"
 		"X4200 Ion Steering"
@@ -1612,6 +1655,7 @@ ship "Osprey" "Osprey (Missile)"
 		"Supercapacitor" 3
 		"D41-HY Shield Generator"
 		"Water Coolant System"
+		"Tactical Scanner"
 		"Laser Rifle" 3
 		"A520 Atomic Thruster"
 		"A375 Atomic Steering"


### PR DESCRIPTION
The description of the Tactical Scanner says that it has been in use by the Navy for some time, while only recently being used by militia ships. Gave this scanner to Navy ships where it fit and to FW-used heavy and medium warships where it fit.

The Asteroid Scanner is a very useful tool for those looking to make money off of asteroid mining, yet the current human miners don't use them. Created new miner variants of the Hawk, Fury, and Headhunter that use asteroid scanners and appear twice as often as their variants that don't use the scanners. These miner variants are based off of the variants of these ships that use to spawn (e.g. the Headhunter (Miner) is based off of and replaced the Headhunter (Particle) within miner fleets).