### PR TITLE
Added missile storage outfits to ship missile variants and ships that largely use missiles

### DIFF
--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -465,7 +465,8 @@ ship "Shield Beetle"
 	outfits
 		"Ion Cannon" 4
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 224
+		"Hai Tracker" 280
+		"Tracker Storage Pod" 2
 		"Chameleon Anti-Missile" 2
 		"Boulder Reactor"
 		"Geode Reactor"
@@ -575,7 +576,8 @@ ship "Shield Beetle" "Shield Beetle (Pulse)"
 ship "Shield Beetle" "Shield Beetle (Tracker)"
 	outfits
 		"Hai Tracker Pod" 8
-		"Hai Tracker" 448
+		"Hai Tracker" 476
+		"Tracker Storage Pod"
 		"Pulse Turret" 4
 		"Boulder Reactor"
 		"Geode Reactor"
@@ -841,7 +843,8 @@ ship "Water Bug"
 			"hit force" 1860
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Hai Tracker" 168
+		"Tracker Storage Pod" 2
 		"Pulse Turret"
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"

--- a/data/korath ships.txt
+++ b/data/korath ships.txt
@@ -421,7 +421,8 @@ ship "Kar Ik Vot 349"
 	outfits
 		"Korath Detainer" 2
 		"Korath Piercer Launcher" 2
-		"Korath Piercer" 62
+		"Korath Piercer" 94
+		"Korath Piercer Rack" 2
 		"Korath Warder" 2
 		"Korath Repeater Turret" 6
 		
@@ -490,7 +491,8 @@ ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Offense)"
 ship "Kar Ik Vot 349" "Kar Ik Vot 349 (Defense)"
 	outfits
 		"Korath Piercer Launcher" 4
-		"Korath Piercer" 124
+		"Korath Piercer" 140
+		"Korath Piercer Rack"
 		"Korath Warder" 3
 		"Korath Grab-Strike" 3
 		"Korath Banisher" 2
@@ -1151,7 +1153,8 @@ ship "Model 64"
 			"hit force" 6000
 	outfits
 		"Korath Minelayer"
-		"Korath Mine" 17
+		"Korath Mine" 35
+		"Korath Mine Rack" 2
 		"Korath Disruptor" 2
 		"Korath Slicer Turret" 2
 		
@@ -1263,7 +1266,8 @@ ship "Model 256"
 			"hit force" 7800
 	outfits
 		"Korath Minelayer" 2
-		"Korath Mine" 34
+		"Korath Mine" 61
+		"Korath Mine Rack" 3
 		"Korath Disruptor" 3
 		"Korath Slicer Turret" 3
 		
@@ -1321,7 +1325,8 @@ ship "Model 512"
 			"hit force" 8400
 	outfits
 		"Korath Minelayer" 2
-		"Korath Mine" 34
+		"Korath Mine" 52
+		"Korath Mine Rack" 2
 		"Korath Disruptor" 3
 		"Korath Slicer Turret" 4
 		

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -33,7 +33,8 @@ ship "Aerie"
 			"hit force" 1200
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 136
+		"Sidewinder Missile Rack" 2
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		
@@ -359,7 +360,8 @@ ship "Bastion"
 	outfits
 		"Plasma Cannon" 2
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
+		"Heavy Rocket" 60
+		"Heavy Rocket Rack" 2
 		"Blaster Turret" 2
 		"Anti-Missile Turret"
 		
@@ -730,7 +732,8 @@ ship "Carrier"
 	outfits
 		"Particle Cannon" 4
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 120
+		"Meteor Missile" 150
+		"Meteor Missile Box" 2
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -2072,7 +2075,8 @@ ship "Manta"
 	outfits
 		"Particle Cannon" 4
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 75
+		"Meteor Missile Box"
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
@@ -2187,7 +2191,8 @@ ship "Mule"
 			"hit force" 1500
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 136
+		"Sidewinder Missile Rack" 2
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
 		
@@ -2478,7 +2483,8 @@ ship "Rainmaker"
 	outfits
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 120
+		"Meteor Missile" 180
+		"Meteor Missile Box" 4
 		
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -38,13 +38,14 @@ ship "Argosy" "Argosy (Laser)"
 ship "Argosy" "Argosy (Missile)"
 	outfits
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 120
+		"Meteor Missile" 165
+		"Meteor Missile Box" 3
 		"Anti-Missile Turret"
 		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
 		"Supercapacitor"
 		"D41-HY Shield Generator"
-		"Outfits Expansion"
+		"Outfits Expansion" 2
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
@@ -587,11 +588,12 @@ ship "Corvette" "Corvette (Missile)"
 		"Torpedo Launcher" 2
 		"Torpedo" 60
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 159
+		"Sidewinder Missile Rack" 3
 		"Heavy Anti-Missile Turret" 2
 		"Fission Reactor"
 		"LP036a Battery Pack"
-		"D94-YV Shield Generator"
+		"D67-TM Shield Generator"
 		"Cooling Ducts"
 		"Cargo Expansion"
 		"Laser Rifle" 4
@@ -851,13 +853,15 @@ ship "Firebird" "Firebird (Laser)"
 ship "Firebird" "Firebird (Missile)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 90
+		"Meteor Missile Box" 2
 		"Torpedo Launcher" 2
-		Torpedo 60
+		"Torpedo" 75
+		"Torpedo Storage Rack"
 		"Heavy Laser Turret" 2
 		"Fission Reactor"
 		"LP072a Battery Pack"
-		"D94-YV Shield Generator"
+		"D67-TM Shield Generator"
 		"Outfits Expansion"
 		"Laser Rifle" 2
 		"Impala Plasma Thruster"
@@ -1081,7 +1085,8 @@ ship "Fury" "Fury (Missile)"
 		"Javelin Pod"
 		"Javelin" 200
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 75
+		"Meteor Missile Box"
 		"nGVF-BB Fuel Cell"
 		"Supercapacitor" 3
 		"D14-RN Shield Generator"
@@ -1504,7 +1509,8 @@ ship "Modified Argosy" "Modified Argosy (Heavy)"
 ship "Modified Argosy" "Modified Argosy (Missile)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 105
+		"Meteor Missile Box" 3
 		"Torpedo Launcher" 2
 		"Torpedo" 60
 		"Heavy Laser Turret"
@@ -1513,6 +1519,7 @@ ship "Modified Argosy" "Modified Argosy (Missile)"
 		"LP072a Battery Pack"
 		"D41-HY Shield Generator"
 		"Brig"
+		"Outfits Expansion"
 		"Laser Rifle"
 		"X3700 Ion Thruster"
 		"Greyhound Plasma Steering"
@@ -1645,9 +1652,11 @@ ship "Osprey" "Osprey (Laser)"
 ship "Osprey" "Osprey (Missile)"
 	outfits
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 75
+		"Torpedo Storage Rack"
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 40
+		"Heavy Rocket" 60
+		"Heavy Rocker Rack" 2
 		"Heavy Laser Turret"
 		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
@@ -1656,6 +1665,7 @@ ship "Osprey" "Osprey (Missile)"
 		"D41-HY Shield Generator"
 		"Water Coolant System"
 		"Tactical Scanner"
+		"Outfits Expansion"
 		"Laser Rifle" 3
 		"A520 Atomic Thruster"
 		"A375 Atomic Steering"
@@ -1968,13 +1978,16 @@ ship "Star Queen" "Star Queen (Hai)"
 ship "Vanguard" "Vanguard (Missile)"
 	outfits
 		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 180
+		"Sidewinder Missile" 295
+		"Sidewinder Missile Rack" 5
 		"Torpedo Launcher" 3
-		"Torpedo" 90
+		"Torpedo" 120
+		"Torpedo Storage Rack" 2
 		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
 		"Supercapacitor"
-		"D94-YV Shield Generator" 2
+		"D94-YV Shield Generator"
+		"D67-TM Shield Generator"
 		"Large Radar Jammer" 2
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 2

--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -224,7 +224,8 @@ ship "Strong Wind"
 	outfits
 		"Sunbeam" 4
 		"Thunderhead Launcher" 2
-		"Thunderhead Missile" 80
+		"Thunderhead Missile" 120
+		"Thunderhead Storage Array" 2
 		
 		"White Sun Reactor"
 		"Dark Storm Shielding"
@@ -329,13 +330,15 @@ ship "Tempest" "Tempest (Heavy)"
 ship "Tempest" "Tempest (Missile)"
 	outfits
 		"Thunderhead Launcher" 4
-		"Thunderhead Missile" 160
+		"Thunderhead Missile" 220
+		"Thunderhead Storage Array" 3
 		"Dual Sunbeam Turret" 2
 		
 		"White Sun Reactor"
 		"Small Biochemical Cell"
 		"Dark Storm Shielding"
 		"Wanderer Ramscoop"
+		"Outfits Expansion"
 		
 		"Type 4 Radiant Thruster"
 		"Type 4 Radiant Steering"
@@ -745,7 +748,8 @@ ship "Deep River"
 			"hit force" 4200
 	outfits
 		"Thunderhead Launcher" 6
-		"Thunderhead Missile" 240
+		"Thunderhead Missile" 320
+		"Thunderhead Storage Array" 4
 		
 		"Large Biochemical Cell"
 		"Bright Cloud Shielding"


### PR DESCRIPTION
Added missile storage outfits to a select number of ships. These ships included those that had a large number of missile launchers to begin with or relied on missile launchers, and those ships that were marked as being missile variants. If the ship was marked as a missile variant, then I may have changed the loadout of the ship in order to make room for storage outfits. Otherwise, I kept the loadouts of the ships the same and only added storage outfits if there was space.

There are some ships that I looked at to add storage outfits to, but they didn't have enough space for them, and I didn't want to have to drastically change the loadouts of ships just to fit the storage outfits; the benefit of more ammunition often wouldn't outweigh the detriment of losing speed, shields, cooling, etc.

Ref: #2271, #2269