### PR TITLE
Adjust Marauder Splinter required crew value

### DIFF
--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -909,7 +909,7 @@ ship "Marauder Splinter"
 		"cost" 3400000
 		"shields" 5700
 		"hull" 1950
-		"required crew" 14
+		"required crew" 8
 		"bunks" 22
 		"mass" 275
 		"drag" 4.0


### PR DESCRIPTION
All Marauder ships except Marauder Splinter and Marauder Falcon follow the same formula - the increase in amount of required crew equals the increase in amount of total bunks. E.g. other Medium Warships:
* Marauder Firebird has +3 required crew and +3 total bunks compared to regular Firebird.
* Marauder Manta has +1 required crew and +1 total bunks compared to regular Manta.

Marauder Splinter currently has +7 required crew and +1 total bunks compared to regular Splinter which greatly reduces the usability of Marauder versions of the ship compared to regular Splinter for both boarding and transport missions, including storyline ones, without any good reason, and looks odd compared to other Marauder ships. 

I propose to adjust required crew of Maradeur Splinter to +1 compared to regular Splinter, to address this issue.