### PR TITLE
Change Bactrian Classification

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -186,7 +186,7 @@ ship "Bactrian"
 	attributes
 		licenses
 			City-Ship
-		category "Heavy Warship"
+		category "Transport"
 		"cost" 17600000
 		"shields" 17500
 		"hull" 8600


### PR DESCRIPTION
This PR is purely cosmetic, and is an effort to redirect the perception and fixation on the Bactrian by making one simple change:

- The Bactrian is reclassified as a Transport.

As @jafdy pointed out in the discussion for PR #4347 , a large part of the problem isn't the stats of the Bactrian, but rather the perception. As such, this PR seeks to rectify that perception in the most basic way: Change the label. After all, the label is the single most easily identifiable way to decide what something is. According to the discussion, the majority involved in the development of the game seems pretty clear that the Bactrian isn't a warship, it is simply a transport that is decent warship. And likewise, everyone seems pretty much in agreement that the Bactrian isn't a great warship when compared with the alternatives. As such, I propose that we pass on this knowledge of the development team to the player base by changing the label on the Bactrian so that first time players can see, right off the bat, that this is NOT a warship, but rather a combat capable transport. In other words, letting new players see what the veterans already know.
