### PR TITLE
Add option for built-in guns and turrets

### DIFF
--- a/data/drak.txt
+++ b/data/drak.txt
@@ -202,12 +202,6 @@ ship "Archon"
 			"hull damage" 10000
 			"hit force" 30000
 	outfits
-		"Drak Antimatter Cannon"
-		"Drak Anti-Missile Field" 2
-		"Drak Draining Field"
-		"Drak Distancer" 2
-		"Drak Turret" 3
-		
 		"Medium Graviton Thruster"
 		"Medium Graviton Steering"
 		"Hyperdrive"
@@ -215,15 +209,15 @@ ship "Archon"
 	
 	engine -17 92
 	engine 17 92
-	gun 0 -74 "Drak Antimatter Cannon"
-	turret 0 -10 "Drak Anti-Missile Field"
-	turret 0 -10 "Drak Anti-Missile Field"
-	turret 0 -10 "Drak Draining Field"
-	turret -40 -13 "Drak Turret"
-	turret 40 -13 "Drak Turret"
-	turret 0 81 "Drak Turret"
-	turret -55 16 "Drak Distancer"
-	turret 55 16 "Drak Distancer"
+	gun 0 -74 "Drak Antimatter Cannon" built-in
+	turret 0 -10 "Drak Anti-Missile Field" built-in
+	turret 0 -10 "Drak Anti-Missile Field" built-in
+	turret 0 -10 "Drak Draining Field" built-in
+	turret -40 -13 "Drak Turret" built-in
+	turret 40 -13 "Drak Turret" built-in
+	turret 0 81 "Drak Turret" built-in
+	turret -55 16 "Drak Distancer" built-in
+	turret 55 16 "Drak Distancer" built-in
 	explode "nuke explosion" 3
 	"final explode" "final explosion large"
 
@@ -231,11 +225,12 @@ ship "Archon" "Archon (Cloaked)"
 	"never disabled"
 	add attributes
 		"cloak" .04
-	turret "Drak Anti-Missile Field"
-	turret "Drak Anti-Missile Field"
-	turret "Drak Draining Field"
-	turret "Drak Turret"
-	turret "Drak Turret"
-	turret "Drak Turret"
-	turret "Drak Distancer"
-	turret "Drak Distancer"
+	gun "Drak Antimatter Cannon" built-in
+	turret "Drak Anti-Missile Field" built-in
+	turret "Drak Anti-Missile Field" built-in
+	turret "Drak Draining Field" built-in
+	turret "Drak Turret" built-in
+	turret "Drak Turret" built-in
+	turret "Drak Turret" built-in
+	turret "Drak Distancer" built-in
+	turret "Drak Distancer" built-in

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -238,7 +238,13 @@ void Armament::Step(const Ship &ship)
 	
 	for(auto &it : streamReload)
 	{
-		int count = ship.OutfitCount(it.first);
+		// Count how many we have from each outfit. We count using the
+		// hardpoints to make sure we also reach built-in weapons.
+		int count = 0;
+		for (Hardpoint &hardpoint : hardpoints)
+			if (hardpoint.GetOutfit() == it.first)
+				count++;
+
 		it.second -= count;
 		// Always reload to the quickest firing interval.
 		it.second = max(it.second, 1 - count);

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -26,17 +26,17 @@ using namespace std;
 
 
 // Add a gun hardpoint (fixed-direction weapon).
-void Armament::AddGunPort(const Point &point, const Outfit *outfit)
+void Armament::AddGunPort(const Point &point, const Outfit *outfit, bool builtIn)
 {
-	hardpoints.emplace_back(point, false, outfit);
+	hardpoints.emplace_back(point, false, outfit, builtIn);
 }
 
 
 
 // Add a turret hardpoint (omnidirectional weapon).
-void Armament::AddTurret(const Point &point, const Outfit *outfit)
+void Armament::AddTurret(const Point &point, const Outfit *outfit, bool builtIn)
 {
-	hardpoints.emplace_back(point, true, outfit);
+	hardpoints.emplace_back(point, true, outfit, builtIn);
 }
 
 
@@ -70,7 +70,7 @@ void Armament::Add(const Outfit *outfit, int count)
 			// If this slot has the given outfit in it and we need to uninstall
 			// some of them, uninstall it. Otherwise, remember the fact that one
 			// of these outfits is installed.
-			if(count < 0)
+			if((count < 0) && (!hardpoint.IsBuiltIn()))
 			{
 				hardpoint.Uninstall();
 				++count;
@@ -149,6 +149,8 @@ void Armament::Swap(int first, int second)
 	if(static_cast<unsigned>(second) >= hardpoints.size())
 		return;
 	if(hardpoints[first].IsTurret() != hardpoints[second].IsTurret())
+		return;
+	if(hardpoints[first].IsBuiltIn() || hardpoints[second].IsBuiltIn())
 		return;
 	
 	// Swap the weapons in the two hardpoints.

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -39,8 +39,8 @@ class Visual;
 class Armament {
 public:
 	// Add a gun or turret hard-point.
-	void AddGunPort(const Point &point, const Outfit *outfit = nullptr);
-	void AddTurret(const Point &point, const Outfit *outfit = nullptr);
+	void AddGunPort(const Point &point, const Outfit *outfit = nullptr, bool builtIn = false);
+	void AddTurret(const Point &point, const Outfit *outfit = nullptr, bool builtIn = false);
 	// This must be called after all the outfit data is loaded. If you add more
 	// of a given weapon than there are slots for it, the extras will not fire.
 	// But, the "gun ports" attribute should keep that from happening. To

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -39,8 +39,8 @@ namespace {
 
 
 // Constructor.
-Hardpoint::Hardpoint(const Point &point, bool isTurret, const Outfit *outfit)
-	: outfit(outfit), point(point * .5), isTurret(isTurret)
+Hardpoint::Hardpoint(const Point &point, bool isTurret, const Outfit *outfit, bool builtIn)
+	: outfit(outfit), point(point * .5), isTurret(isTurret), isBuiltIn(builtIn)
 {
 }
 
@@ -84,6 +84,13 @@ Angle Hardpoint::HarmonizedAngle() const
 	// Projectiles with a range of zero should fire straight forward. A
 	// special check is needed to avoid divide by zero errors.
 	return Angle(d <= 0. ? 0. : -asin(point.X() / d) * TO_DEG);
+}
+
+
+
+bool Hardpoint::IsBuiltIn() const
+{
+	return isBuiltIn;
 }
 
 

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -30,7 +30,7 @@ class Visual;
 class Hardpoint {
 public:
 	// Constructor. Hardpoints may or may not specify what weapon is in them.
-	Hardpoint(const Point &point, bool isTurret, const Outfit *outfit = nullptr);
+	Hardpoint(const Point &point, bool isTurret, const Outfit *outfit = nullptr, bool builtIn = false);
 	
 	// Get the weapon installed in this hardpoint (or null if there is none).
 	const Outfit *GetOutfit() const;
@@ -43,6 +43,7 @@ public:
 	// Get the angle this weapon ought to point at for ideal gun harmonization.
 	Angle HarmonizedAngle() const;
 	// Shortcuts for querying weapon characteristics.
+	bool IsBuiltIn() const;
 	bool IsTurret() const;
 	bool IsHoming() const;
 	bool IsAntiMissile() const;
@@ -95,6 +96,9 @@ private:
 	bool isTurret = false;
 	bool isFiring = false;
 	bool wasFiring = false;
+	// Indicates if this weapon is built-in. Meaning that it cannot be swapped or removed
+	// from the ship and also cannot be plundered.
+	bool isBuiltIn = false;
 };
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -462,6 +462,12 @@ private:
 	// (That is, they were specified as linked to a given gun or turret point.)
 	std::map<const Outfit *, int> equipped;
 	
+	// Also keep track how many built-in outfits we have. They will not
+	// show up as explicit outfits, but they do take up space like weapon-
+	// space and gun or turret points.
+	//TODO: make those builtIn weapons part of the hull value (they are now silently ignored).
+	std::map<const Outfit *, int> builtIn;
+
 	// Various energy levels:
 	double shields = 0.;
 	double hull = 0.;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -458,15 +458,6 @@ private:
 	
 	std::vector<EnginePoint> enginePoints;
 	Armament armament;
-	// While loading, keep track of which outfits already have been equipped.
-	// (That is, they were specified as linked to a given gun or turret point.)
-	std::map<const Outfit *, int> equipped;
-	
-	// Also keep track how many built-in outfits we have. They will not
-	// show up as explicit outfits, but they do take up space like weapon-
-	// space and gun or turret points.
-	//TODO: make those builtIn weapons part of the hull value (they are now silently ignored).
-	std::map<const Outfit *, int> builtIn;
 
 	// Various energy levels:
 	double shields = 0.;


### PR DESCRIPTION
Hyperdrives, hull-generation, cloaking and many other options can already be built-in into ship hulls. This change adds an option for guns and turrets to be built-in into the hull of the spaceship it is installed in.

Built-in weapons cannot be removed from the ship they are installed in.
And selling the ship that has built-in weapons does not put the built-in weapon in stock.