### PR TITLE
Have the mission to not kill pug defenders use `save` instead of `kill`

### DIFF
--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -2486,12 +2486,12 @@ mission "Wanderers Ap'arak 3: Pug"
 	source "Varu Tev'kei"
 	to offer
 		has "Wanderers Ap'arak 2: done"
-	npc kill
+	npc save
 		personality staying unconstrained uninterested
 		government "Pug"
 		ship "Pug Arfecta" "Hork Ekekek Ptui"
 		ship "Pug Arfecta" "Graak Sput Kchoo"
-	on complete
+	on fail
 		dialog `Shortly after defeating the Pug ships, you receive a message from Sobari Tele'ek: "We are [aware? incredulous?] of reports that you have [exterminated, eradicated] our Keepers in the Ap'arak system. This is unacceptable! From now on, you are no longer welcome in our [territory, space]."`
 		"reputation: Wanderer" <?= -1
 


### PR DESCRIPTION
Right now the Wanderer reaction to killing the pug during "Wanderers Ap'arak 3: Pug" only activates on landing on "Varu Tev'kei". It also allows you to capture one of the Arfectas and continue the Wanderer campaign. This makes it so that the mission is resolved upon landing anywhere, and it fails the Wanderer campaign even if you capture or destroy just one of them.

Thanks to Harryyeo123 on Discord for pointing out this issue.