### PR TITLE
Make "Wanderers Ap'arak 3: Pug" complete on any Wanderer planet

### DIFF
--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -2484,6 +2484,8 @@ mission "Wanderers Ap'arak 3: Pug"
 	landing
 	invisible
 	source "Varu Tev'kei"
+	destination
+		government "Wanderer"
 	to offer
 		has "Wanderers Ap'arak 2: done"
 	npc kill


### PR DESCRIPTION
Right now "Wanderers Ap'arak 3: Pug" only completes if you land on "Varu Tev'kei". This allows you to avoid the Wanderer repuation loss from destroying both Arfectas for some time by avoiding landing there.

With this change the mission "success" and repuation loss apply on any Wanderer planet, which cuts off progress in the story much quicker.

Thanks to Harryyeo123 on Discord for pointing out this issue.

See #4396 for alternate solution.