### PR TITLE
Moved done button on map to far right, adjusted button sizes.

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -841,27 +841,27 @@ interface "mission" bottom
 interface "map buttons" bottom right
 	active if "!is shipyards"
 	sprite "ui/wide button"
-		from -450 -50 to -340 0
+		from -464 -50 to -354 0
 	button s "_Shipyards"
-		from -440 -40 to -350 -10
+		from -454 -40 to -364 -10
 	
 	active if "!is outfitters"
 	sprite "ui/wide button"
-		from -350 -50 to -240 0
+		from -364 -50 to -254 0
 	button o "_Outfitters"
-		from -340 -40 to -250 -10
+		from -354 -40 to -264 -10
 	
 	active if "!is missions"
 	sprite "ui/dialog cancel"
-		from -250 -50 to -160 0
+		from -264 -50 to -174 0
 	button i "M_issions"
-		from -240 -40 to -170 -10
+		from -254 -40 to -184 -10
 	
 	active if "!is ports"
 	sprite "ui/dialog cancel"
-		from -170 -50 to -80 0
+		from -184 -50 to -94 0
 	button p "_Ports"
-		from -160 -40 to -90 -10
+		from -174 -40 to -104 -10
 	
 	active
 	sprite "ui/dialog cancel"

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -839,34 +839,35 @@ interface "mission" bottom
 
 
 interface "map buttons" bottom right
-	sprite "ui/dialog cancel"
-		from -450 -50 to -360 0
-	button d "_Done"
-		from -450 -50 to -360 0
-	
 	active if "!is shipyards"
 	sprite "ui/wide button"
-		from -370 -50 to -260 0
+		from -450 -50 to -340 0
 	button s "_Shipyards"
-		from -370 -50 to -260 0
+		from -440 -40 to -350 -10
 	
 	active if "!is outfitters"
 	sprite "ui/wide button"
-		from -270 -50 to -160 0
+		from -350 -50 to -240 0
 	button o "_Outfitters"
-		from -270 -50 to -160 0
+		from -340 -40 to -250 -10
 	
 	active if "!is missions"
 	sprite "ui/dialog cancel"
-		from -170 -50 to -80 0
+		from -250 -50 to -160 0
 	button i "M_issions"
-		from -170 -50 to -80 0
+		from -240 -40 to -170 -10
 	
 	active if "!is ports"
 	sprite "ui/dialog cancel"
-		from -90 -50 to 0 0
+		from -170 -50 to -80 0
 	button p "_Ports"
+		from -160 -40 to -90 -10
+	
+	active
+	sprite "ui/dialog cancel"
 		from -90 -50 to 0 0
+	button d "_Done"
+		from -80 -40 to -10 -10
 	
 	sprite "ui/zoom"
 		from 0 -40 to -90 -90


### PR DESCRIPTION
* Moved done button to far right on map screen to be consistent with other interface elements such as shipyard, outfitters, planet landings, player info screen.
* All click areas for these buttons now match button visible areas.  Previously only the zoom +/- buttons did this.

~~Requires #4401 (removes old button code)~~ (merged)

Current version, 14 extra pixel separation.
![image](https://user-images.githubusercontent.com/51398924/61332629-94574580-a7d9-11e9-902b-1603141e61fe.png)


Initial commit: 
![image](https://user-images.githubusercontent.com/51398924/61193154-8afd9a00-a66e-11e9-8a3f-a73f0efbde17.png)

Original:
![image](https://user-images.githubusercontent.com/51398924/61193213-da43ca80-a66e-11e9-8617-68cd944e87cf.png)

