### PR TITLE
Removing obsolete fourth-wall dialog text

### DIFF
--- a/data/free worlds epilogue.txt
+++ b/data/free worlds epilogue.txt
@@ -30,8 +30,6 @@ mission "FW Epilogue: Ijs and Katya"
 					goto excitement
 				`	"It's kind of hard to adjust to civilian life."`
 					goto adjust
-				`	"I want to explore the rest of the galaxy, but apparently that part of the game hasn't been implemented yet."`
-					goto game
 			
 			label excitement
 			`	"I understand that feeling," says Katya. "But, just remind yourself, this is what we fought for. For peace. For a world where no one has to fear for their lives.`
@@ -39,11 +37,6 @@ mission "FW Epilogue: Ijs and Katya"
 			
 			label adjust
 			`	"Tell me about it," laughs Katya. "I can hardly believe I'm now a professor. Or at least, acting as one. But after so much fighting, and so much time alone and imprisoned, for me it feels good to finally be able to relax, to let go of the idea that the galaxy will fall apart without me."`
-				goto end
-			
-			label game
-			`	"Whoops," says Ijs, "now you've done it, there goes the fourth wall."`
-			`	Katya laughs. "If you're so eager to explore the rest of the galaxy, <first>, maybe you should volunteer to help out with creating the stories to populate it. This is an open source game after all, and it would be a sad thing for it to remain the product of only one person's imagination."`
 				goto end
 			
 			label end


### PR DESCRIPTION
It seems to me that the dialog option"I want to explore the rest of the galaxy, but apparently that part of the game hasn't been implemented yet" is probably obsolete dialog, since I am doing that in my game.

(I didn't check when this was added, don't know if there are huge plans for more exploring, didn't verify it works, but I'm pretty sure the format is still okay)