### PR TITLE
Always select the first available mission when clicking a new system.

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -327,6 +327,13 @@ bool MissionPanel::Click(int x, int y, int clicks)
 		}
 	if(system)
 	{
+		// Always go to the first available mission when clicking a new system.
+		if(selectedSystem && selectedSystem != system)
+		{
+			availableIt == available.end();
+			acceptedIt == accepted.end();
+		}
+
 		Select(system);
 		int options = available.size() + accepted.size();
 		// If you just aborted your last mission, it is possible that neither


### PR DESCRIPTION
Without this change, it's unintuitive and feels inconsistent whether clicking a new system selects an available mission or an active mission. The way it works internally, the game holds the selected mission as an iterator (availableIt + acceptedIt basically acting as a single iterator). Clicking the same system again simply iterates, and that's fine. But when you click a new system, it finds the NEXT mission in the list that involves the new system - whether or not it's in the available list or accepted list. This makes what mission is selected when clicking a new system depend on the order of the mission list. That feels unintuitive. So, to make it consistent, the iterators are simply reset when selecting a new system.

For example: Say you have a long list of available and active missions for the new system, and you're selecting some mission for another system.
* If the previously selected mission is higher in the available list, it will go down the list and find a new available mission for the new system.
* If the previously selected mission is at the end of the available list, it will switch to the active mission list and find an existing active mission for the new system.

(Fair warning: I didn't compile this, couldn't get a project set up, but it seems to be a super simple change.)