### PR TITLE
Guard positions for escorts around lead ships

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1830,9 +1830,18 @@ void AI::KeepStation(Ship &ship, Command &command, const Ship &target)
 	double mass = ship.Mass();
 	Point unit = ship.Facing().Unit();
 	double currentAngle = ship.Facing().Degrees();
+
+	// Target position, either the target-ship, or a relative position compared to
+	// the target ship if such a relative position is set
+	Point targetPosition = target.Position();
+	Point targetVelocity = target.Velocity();
+	Point guardPosition = ship.GetGuardPosition();
+	if (guardPosition)
+		targetPosition += (Angle(targetVelocity)).Rotate(guardPosition);
+
 	// This is where we want to be relative to where we are now:
-	Point velocityDelta = target.Velocity() - ship.Velocity();
-	Point positionDelta = target.Position() + LEAD_TIME * velocityDelta - ship.Position();
+	Point velocityDelta = targetVelocity - ship.Velocity();
+	Point positionDelta = targetPosition + LEAD_TIME * velocityDelta - ship.Position();
 	double positionSize = positionDelta.Length();
 	double positionWeight = positionSize / (positionSize + POSITION_DEADBAND);
 	// This is how fast we want to be going relative to how fast we're going now:

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -325,6 +325,13 @@ void Ship::Load(const DataNode &node)
 			description += child.Token(1);
 			description += '\n';
 		}
+		else if(key == "guard")
+		{
+			if(child.HasChildren())
+				for(const DataNode &grand : child)
+					if(grand.Token(0) == "position" && grand.Size() >= 3)
+						guardPosition = Point(grand.Value(1), grand.Value(2));
+		}
 		else if(key != "actions")
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
@@ -684,6 +691,15 @@ void Ship::Save(DataWriter &out) const
 			out.Write("destination system", targetSystem->Name());
 		if(isParked)
 			out.Write("parked");
+		if(guardPosition)
+		{
+			out.Write("guard");
+			out.BeginChild();
+			{
+				out.Write("position", guardPosition.X(), guardPosition.Y());
+			}
+			out.EndChild();
+		}
 	}
 	out.EndChild();
 }
@@ -3103,6 +3119,14 @@ shared_ptr<Ship> Ship::GetParent() const
 const vector<weak_ptr<Ship>> &Ship::GetEscorts() const
 {
 	return escorts;
+}
+
+
+
+// Positions relative to parents or tracked objects
+const Point Ship::GetGuardPosition() const
+{
+	return guardPosition;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -376,7 +376,10 @@ public:
 	std::shared_ptr<Ship> GetParent() const;
 	const std::vector<std::weak_ptr<Ship>> &GetEscorts() const;
 	
-	
+	// Positions relative to parents or tracked objects
+	const Point GetGuardPosition() const;
+
+
 private:
 	// Add or remove a ship from this ship's list of escorts.
 	void AddEscort(Ship &ship);
@@ -523,8 +526,9 @@ private:
 	// Links between escorts and parents.
 	std::vector<std::weak_ptr<Ship>> escorts;
 	std::weak_ptr<Ship> parent;
+
+	// References and offsets for idle/stationkeeping positions
+	Point guardPosition;
 };
-
-
 
 #endif


### PR DESCRIPTION
Add guard (position) functionality to allow escort ships to do stationkeeping on a relative offset to their lead ship.

Here is a screenshot of 4 escorts on "guard positions":
0, 500
0, -500
-500, 0
500,0

![guard_positions](https://user-images.githubusercontent.com/35403542/60759040-1481ec00-a01f-11e9-9c59-384411b7dfc2.png)
