### PR TITLE
Updated fuel attribute line to include fuel gain.  Updated associated tooltips.

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -95,11 +95,17 @@ tip "    engine capacity:"
 tip "fighter bays:"
 	`The number of ships from the "Fighter" category that this ship can carry.`
 
-tip "fuel:"
-	`This ship's current fuel amount. An ordinary hyperdrive jump consumes 100 fuel.`
+tip "fuel gain / capacity:"
+	`This ship's average fuel gain per second and total fuel capacity. An ordinary hyperdrive consumes 100 fuel per jump. Fuel gain is the sum of fuel generation, consumption and the performance of any ramscoops installed while near an average star.`
 
 tip "fuel capacity:"
-	`An ordinary hyperdrive jump consumes 100 fuel. Fuel is replenished for free when you land on an inhabited planet.`
+	`This ship's total fuel capacity. An ordinary hyperdrive consumes 100 fuel per jump.`
+
+tip "fuel / gain / max:"
+	`This ship's current fuel level, average fuel gain per second, and total fuel capacity. An ordinary hyperdrive jump consumes 100 fuel per jump. Fuel gain is the sum of fuel generation, consumption and the performance of any ramscoops installed while near an average star.`
+
+tip "fuel / capacity:"
+	`This ship's current fuel level and total fuel capacity. An ordinary hyperdrive jump consumes 100 fuel per jump.`
 
 tip "fuel consumption:"
 	`Fuel consumed per second while in flight (can generate energy or heat).`


### PR DESCRIPTION
This updates adds fuel gain to the fuel attribute display line defined in ShipInfoDisplay.cpp and is used in the shop side panel and player info panel to describe the current fuel status.  #3487

The primary difficulty of this is simply getting the wording right and ensuring it fits all on one line as it would be inappropriate to use two lines for this.  The best I came up with is as follows.  Any better wording suggestions would be appreciated.

landed ships:
`"fuel gain / capacity:"`
`"fuel capacity:"` (not currently shown)
in flight:
`"fuel / gain / max:"`
`"fuel / capacity:"` (not currently shown)

"fuel" has a double use as the overall line description, and while in flight the individual fuel level.
"capacity" is preferred over "max" as it's more descriptive, but is substituted with "max" for the in flight version due to space constraints.

The fuel gain line exposes the player to the fact that every ship in the game has a default 0.4 fuel gain per second if they're close to a star.  Hence the (not currently shown) above.

![image](https://user-images.githubusercontent.com/51398924/60764946-7eae8700-a047-11e9-96d4-7f7c18dec495.png)

Updated all 4 possible tooltips and defined fuel gain in them.  Notably this includes the new attributes `fuel generation` and `fuel consumption`.

`Fuel gain is the sum of fuel generation, consumption and the performance of any ramscoops installed while near an average star.`

![image](https://user-images.githubusercontent.com/51398924/60765046-c08bfd00-a048-11e9-8511-28adca73e503.png)
![image](https://user-images.githubusercontent.com/51398924/60765053-cc77bf00-a048-11e9-873f-a1d0f87b4ae8.png)
