### PR TITLE
Pre rendered rotation for Escape Velocity Nova total conversion

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -201,7 +201,7 @@ void Body::LoadSprite(const DataNode &node)
 			frameOffset += static_cast<float>(child.Value(1));
 			startAtZero = true;
 		}
-		else if(child.Token(0) == "pre rendered rotation" && child.Size() >= 2)
+		else if(child.Token(0) == "pre-rendered rotation" && child.Size() >= 2)
 		{
 			preRenderedRotation = static_cast<int>(child.Value(1));
 		}
@@ -241,7 +241,7 @@ void Body::SaveSprite(DataWriter &out, const string &tag) const
 		if(rewind)
 			out.Write("rewind");
 		if(preRenderedRotation);
-			out.Write("pre rendered rotation", preRenderedRotation);
+			out.Write("pre-rendered rotation", preRenderedRotation);
 	}
 	out.EndChild();
 }
@@ -314,14 +314,14 @@ void Body::SetStep(int step) const
 	// If the animation is paused, reduce the step by however many frames it has
 	// been paused for.
 	step -= pause;
-
+	
 	// If the step is negative or there is no sprite, do nothing. This updates
 	// and caches the mask and the frame so that if further queries are made at
 	// this same time step, we don't need to redo the calculations.
 	if(step == currentStep || step < 0 || !sprite || !sprite->Frames())
 		return;
 	currentStep = step;
-
+	
 	// If the sprite only has one frame, no need to animate anything.
 	float frames = sprite->Frames();
 	if(frames <= 1.f)
@@ -330,12 +330,12 @@ void Body::SetStep(int step) const
 		return;
 	}
 
+	// If pre-rendered rotation, determine the frame from current angle 
+	// and total pre-rendered frames count.
 	if(preRenderedRotation) {
 		int curAngle = (int)(angle.Degrees() + 360.0) % 360;
 		frame = (curAngle / 360.f) * preRenderedRotation;
 	} else {
-
-
 		float lastFrame = frames - 1.f;
 		// This is the number of frames per full cycle. If rewinding, a full cycle
 		// includes the first and last frames once and every other frame twice.

--- a/source/Body.h
+++ b/source/Body.h
@@ -72,6 +72,8 @@ public:
 	void SetSprite(const Sprite *sprite);
 	// Set the color swizzle.
 	void SetSwizzle(int swizzle);
+
+	int GetPreRenderedRotation() const;
 	
 	
 protected:
@@ -120,6 +122,8 @@ private:
 	bool rewind = false;
 	int pause = 0;
 	
+	int preRenderedRotation = 0;
+
 	// Record when this object is marked for removal from the game.
 	bool shouldBeRemoved = false;
 	

--- a/source/DrawList.cpp
+++ b/source/DrawList.cpp
@@ -146,7 +146,6 @@ bool DrawList::Cull(const Body &body, const Point &position, const Point &blur) 
 }
 
 
-
 void DrawList::Push(const Body &body, Point pos, Point blur, double cloak, double clip, int swizzle)
 {
 	SpriteShader::Item item;
@@ -173,14 +172,22 @@ void DrawList::Push(const Body &body, Point pos, Point blur, double cloak, doubl
 	item.position[0] = static_cast<float>(pos.X() * zoom);
 	item.position[1] = static_cast<float>(pos.Y() * zoom);
 	
-	// (0, -1) means a zero-degree rotation (since negative Y is up).
-	uw *= zoom;
-	uh *= zoom;
-	item.transform[0] = -uw.Y();
-	item.transform[1] = uw.X();
-	item.transform[2] = -uh.X();
-	item.transform[3] = -uh.Y();
-	
+	if(body.GetPreRenderedRotation()) {
+		// Rotation (none) and scale.
+		item.transform[0] = width * zoom;
+		item.transform[1] = 0.f;
+		item.transform[2] = -1.f;
+		item.transform[3] = height * zoom;
+	} else {
+		// (0, -1) means a zero-degree rotation (since negative Y is up).
+		uw *= zoom;
+		uh *= zoom;
+		item.transform[0] = -uw.Y();
+		item.transform[1] = uw.X();
+		item.transform[2] = -uh.X();
+		item.transform[3] = -uh.Y();
+	}
+
 	// Calculate the blur vector, in texture coordinates.
 	blur *= zoom;
 	item.blur[0] = unit.Cross(blur) / (width * 4.);

--- a/source/DrawList.cpp
+++ b/source/DrawList.cpp
@@ -146,6 +146,7 @@ bool DrawList::Cull(const Body &body, const Point &position, const Point &blur) 
 }
 
 
+
 void DrawList::Push(const Body &body, Point pos, Point blur, double cloak, double clip, int swizzle)
 {
 	SpriteShader::Item item;


### PR DESCRIPTION
Hi,

It is a small patch to be able to render isometric sprites from original Escape Velocity Nova data with the total conversion script I'm working on.

The related total conversion script is available and working without this patch and it is playable even if some functionalities are still missing : https://github.com/julbouln/evn2es

Regards