### PR TITLE
Fixes map not recoloring bug when switching between shipyard and outfitter views.

### DIFF
--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -45,6 +45,7 @@ MapOutfitterPanel::MapOutfitterPanel(const MapPanel &panel, bool onlyHere)
 {
 	Init();
 	onlyShowSoldHere = onlyHere;
+	UpdateCache();
 }
 
 

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -44,6 +44,7 @@ MapShipyardPanel::MapShipyardPanel(const MapPanel &panel, bool onlyHere)
 {
 	Init();
 	onlyShowSoldHere = onlyHere;
+	UpdateCache();
 }
 
 


### PR DESCRIPTION
MapShipyardPanel and MapOutfitterPanel now update the map coloring when switching between them.

From discord:
> 5:27 AM] Blaank: [bug][0.9.9]  When looking at the map, and selecting shipyards, the icons shown for has shipyard and does not have shipyard are incorrect.  They are identical to the has outfitter selection.  If you select a system, the upper left will correctly highlight if it has or does not have a shipyard but the colored circles are the wrong color.

The map coloring is only updated by DrawSystems() when MapPanel::commodity is changed, however the MapShipyardPanel and MapOutfitterPanel use commodity == SHOW_SPECIAL which draws whether a system has an outfitter/shipyard or not as opposed to ports view where it shows how many outfits/ships are available there.

Added UpdateCache() to the constructors of each panel to update the system coloring on switch.