### PR TITLE
Update Pirate occupation missions to exclude Quarg Planets and systems

### DIFF
--- a/data/south jobs.txt
+++ b/data/south jobs.txt
@@ -20,7 +20,7 @@ mission "Pirate Occupation [0]"
 		not government "Pirate"
 		attributes "south" "rim"
 	destination
-		not government "Pirate"
+		not government "Pirate" "Quarg"
 		distance 2 3
 		attributes "south"
 	npc
@@ -57,7 +57,7 @@ mission "Pirate Occupation [1]"
 		not government "Pirate"
 		attributes "south" "rim"
 	destination
-		not government "Pirate"
+		not government "Pirate" "Quarg"
 		distance 2 3
 		attributes "south"
 	npc
@@ -95,7 +95,7 @@ mission "Pirate Occupation [2]"
 		not government "Pirate"
 		attributes "south" "rim"
 	destination
-		not government "Pirate"
+		not government "Pirate" "Quarg"
 		distance 2 3
 		attributes "south"
 	npc


### PR DESCRIPTION
Pirate occupation missions spawn on Quarg worlds, they shouldn't due to Quarg not being involved with human factions/they are much more powerful than any pirate in-game.