### PR TITLE
Reclass the Bactrian as a Heavy Freighter

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -188,7 +188,7 @@ ship "Bactrian"
 	attributes
 		licenses
 			City-Ship
-		category "Transport"
+		category "Heavy Freighter"
 		"cost" 17600000
 		"shields" 17500
 		"hull" 8600


### PR DESCRIPTION
in line with how endless-sky classed the Korath WS (the Baccy T2 basically). Ships that perform well as both freighters and transports usually are classed as freighters in this game, and having the Bactrian as a transport would be too misleading for mission conditions (as a rule, frighters can be decently armed, but transports usually aren't) that would underestimate player fleet's capabilities.