### PR TITLE
Write "cargo" keyword at the same level as it is read

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -97,11 +97,9 @@ void CargoHold::Save(DataWriter &out) const
 	for(const auto &it : commodities)
 		if(it.second)
 		{
-			// Only write a "cargo" block if it is not going to be empty.
+			// Only write a "commodities" block if it is not going to be empty.
 			if(first)
 			{
-				out.Write("cargo");
-				out.BeginChild();
 				out.Write("commodities");
 				out.BeginChild();
 			}
@@ -117,15 +115,6 @@ void CargoHold::Save(DataWriter &out) const
 	for(const auto &it : outfits)
 		if(it.second && !it.first->Name().empty())
 		{
-			// It is possible this cargo hold contained no commodities, meaning
-			// we must print the opening tag now.
-			if(first)
-			{
-				out.Write("cargo");
-				out.BeginChild();
-			}
-			first = false;
-			
 			// If this is the first outfit to be written, print the opening tag.
 			if(firstOutfit)
 			{
@@ -136,11 +125,8 @@ void CargoHold::Save(DataWriter &out) const
 			
 			out.Write(it.first->Name(), it.second);
 		}
-	// Back out any indentation blocks that are set, depending on what sorts of
-	// cargo were written to the file.
+	// We only need to EndChild() if at least one line was written above.
 	if(!firstOutfit)
-		out.EndChild();
-	if(!first)
 		out.EndChild();
 	
 	// Mission cargo is not saved because it is repopulated when the missions

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2470,7 +2470,15 @@ void PlayerInfo::Save(const string &path) const
 	
 	// Save accounting information, cargo, and cargo cost bases.
 	accounts.Save(out);
-	cargo.Save(out);
+	if (!cargo.IsEmpty())
+	{
+		out.Write("cargo");
+		out.BeginChild();
+		{
+			cargo.Save(out);
+		}
+		out.EndChild();
+	}
 	if(!costBasis.empty())
 	{
 		out.Write("basis");

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -621,7 +621,15 @@ void Ship::Save(DataWriter &out) const
 		}
 		out.EndChild();
 		
-		cargo.Save(out);
+		if (!cargo.IsEmpty())
+		{
+			out.Write("cargo");
+			out.BeginChild();
+			{
+				cargo.Save(out);
+			}
+			out.EndChild();
+		}
 		out.Write("crew", crew);
 		out.Write("fuel", fuel);
 		out.Write("shields", shields);


### PR DESCRIPTION
The "cargo" keyword was written by CargoHold, but the keyword was read by PlayerInfo and by Ship.

This change moves the writing of the keyword one level up to PlayerInfo and Ship to allow reuse of the CargoHold for other things with other keywords (like planetary storage).