### PR TITLE
Update Marauding Max

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -196,6 +196,15 @@ government "Kor Sestor"
 	
 	"player reputation" -1000
 
+government "Marauder"
+	swizzle 6
+	color .78 .36 .36
+	"player reputation" 1
+	"bribe" .1
+	"fine" 0
+	"hostile hail" "hostile pirate"
+	raid "Marauder fleet X"
+
 government "Merchant"
 	swizzle 5
 	

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -198,12 +198,10 @@ government "Kor Sestor"
 
 government "Marauder"
 	swizzle 6
-	color .78 .36 .36
 	"player reputation" 1
 	"bribe" .1
 	"fine" 0
 	"hostile hail" "hostile pirate"
-	raid "Marauder fleet X"
 
 government "Merchant"
 	swizzle 5

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -107,14 +107,29 @@ person "Cap'n Pester"
 
 
 
-person "Marauding Max K"
-	government "Author"
-	frequency 300
+person "Marauding Max"
+	government "Indigenous Lifeform"
+	frequency 400
 	personality
-		surveillance
+		surveillance unconstrained harvests
 	phrase
-		phrase
-			"friendly author"
+		word
+			"Do you think you "
+			"Ever wondered if you "
+			"Think you'll also need some luck if you think you "
+		word
+			"got what it takes to "
+			"got the gumption to "
+			"could "
+			"are capable of "
+			"have the cojones to "
+			"are good enough to "
+		word
+			"capture "
+			"collect "
+			"gather "
+		woed
+			"all 28 Marauder models?"
 	phrase
 		word
 			"Have you "
@@ -144,10 +159,10 @@ person "Marauding Max K"
 			"lately?"
 			"recently?"
 			"in the past couple of days?"
-	# Not sure about implying there is a shop that people can have this done to their ships, but it's fun banter...(there is no shop).
+	# Not sure about implying there is a shop that people can have this done to their ships, but it's fun banter that encourages the player to explore...(there is no shop).
 	phrase
 		word
-			"If you can find me or my crew within the community, we'll help you turning that "
+			"If you can find my crew, we'll help you turn that "
 		word
 			"trash heap "
 			"rust bucket "
@@ -194,15 +209,14 @@ ship "Marauder Fury"
 		"Meteor Missile Launcher" 4
 		"Hai Tracker" 112
 		"Meteor Missile" 140
-		
-		"Pebble Core"
-		"Small Biochemical Cell"
-		"Hai Williwaw Cooling"
-		"Hai Corundum Regenerator"
+
+		"Systems Core (Small)"
+		"Red Sun Reactor"
 		"Intrusion Countermeasures" 3
-		
+		"Nerve Gas"
+
 		`"Biroo" Atomic Thruster`
-		"A255 Atomic Steering"
+		`"Benga" Atomic Steering`
 		"Hyperdrive"
 		
 	engine -21 42

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -108,7 +108,7 @@ person "Cap'n Pester"
 
 
 person "Marauding Max"
-	government "Indigenous Lifeform"
+	government "Marauder"
 	frequency 400
 	personality
 		surveillance unconstrained harvests
@@ -116,13 +116,13 @@ person "Marauding Max"
 		word
 			"Do you think you "
 			"Ever wondered if you "
-			"Think you'll also need some luck if you think you "
+			"Think you'll also need some luck if you "
 		word
 			"got what it takes to "
 			"got the gumption to "
 			"could "
 			"are capable of "
-			"have the cojones to "
+			"have the guramba to "
 			"are good enough to "
 		word
 			"capture "
@@ -219,9 +219,9 @@ ship "Marauder Fury"
 		`"Benga" Atomic Steering`
 		"Hyperdrive"
 		
-	engine -21 42
+	engine -21 42 .9
 	engine 0 48
-	engine 21 42
+	engine 21 42 .9
 	gun -12 -33 "Meteor Missile Launcher"
 	gun 12 -33 "Meteor Missile Launcher"
 	gun -20 -25 "Meteor Missile Launcher"


### PR DESCRIPTION
*The original Marauder model artist wished to be somewhat dissociated from the person/character.
*Acquiring the Mad Quest no longer incurs "Author" wrath.
*Appears more often, and promotes the side-game of collecting the Marauder ships (as well as player exploration).
*Updated his loadout to more modern outfits - including Nerve Gas, likely causing a fine (upon capture) - to help offset the increase in ship value.