### PR TITLE
Do not translate game title

### DIFF
--- a/endless-sky.appdata.xml
+++ b/endless-sky.appdata.xml
@@ -3,8 +3,6 @@
   <id>io.github.endless_sky.endless_sky</id>
   <launchable type="desktop-id">endless-sky.desktop</launchable>
   <name>Endless Sky</name>
-  <name xml:lang="de">Weltraumspiel</name>
-  <name xml:lang="fr">Jeu spatial</name>
   <summary>Space exploration and combat game</summary>
   <summary xml:lang="de">Weltraumhandels und Kampfsimulator</summary>
   <summary xml:lang="fr">Jeu d'exploration et de combat dans l'espace</summary>


### PR DESCRIPTION
The game title is a proper name and should not be translated. Also the previous German and French translation were a little off… 🙄 (see issue)

Fixes https://github.com/endless-sky/endless-sky/issues/4453