### PR TITLE
Change aim to be explicitly signed

### DIFF
--- a/source/Command.h
+++ b/source/Command.h
@@ -134,7 +134,7 @@ private:
 	// Turning amount is stored as a separate double to allow fractional values.
 	double turn = 0.;
 	// Turret turn rates, reduced to 8 bits to save space.
-	char aim[32] = {};
+	signed char aim[32] = {};
 };
 
 


### PR DESCRIPTION
This fixes #4456 where, on architectures that default to unsigned
chars (ppc), turrets would only rotate in one direction.  The logic
in Aim and SetAim depend on the aim array to be able to represent
negative numbers.