### PR TITLE
Restrict reparenting of mission-affiliated carried ships to the same missison

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -711,7 +711,7 @@ void AI::Step(const PlayerInfo &player)
 				
 				auto parentChoices = vector<shared_ptr<Ship>>{};
 				parentChoices.reserve(ships.size() * .1);
-				auto reparentWith = [&](const list<shared_ptr<Ship>> otherShips) -> bool
+				auto reparentWith = [&it, &gov, &parent, &parentChoices](const list<shared_ptr<Ship>> otherShips) -> bool
 				{
 					for(const auto &other : otherShips)
 						if(other->GetGovernment() == gov && other->GetSystem() == it->GetSystem() && !other->CanBeCarried())
@@ -729,23 +729,16 @@ void AI::Step(const PlayerInfo &player)
 				};
 				// Mission ships should only pick ships from the same mission.
 				auto missionIt = it->IsSpecial() && !it->IsYours()
-					? find_if(player.Missions().begin(), player.Missions().end(), [&it](const Mission &m)
-					{
-						auto nend = m.NPCs().end();
-						return nend != find_if(m.NPCs().begin(), nend, [&it](const NPC &n)
+					? find_if(player.Missions().begin(), player.Missions().end(),
+						[&it](const Mission &m) -> bool
 						{
-							auto send = n.Ships().end();
-							return send != find_if(n.Ships().begin(), send, [&it](const shared_ptr<Ship> &s)
-							{
-								return s.get() == it.get();
-							});
-						});
-					})
+							return m.HasShip(it);
+						})
 					: player.Missions().end();
 				if(missionIt != player.Missions().end())
 				{
-					auto npcs = missionIt->NPCs();
-					for(const auto npc : npcs)
+					auto &npcs = missionIt->NPCs();
+					for(const auto &npc : npcs)
 						if(reparentWith(npc.Ships()))
 							break;
 				}

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -702,29 +702,59 @@ void AI::Step(const PlayerInfo &player)
 			// A fighter must belong to the same government as its parent to dock with it.
 			bool hasParent = parent && parent->GetGovernment() == gov;
 			bool hasSpace = hasParent && parent->BaysFree(isFighter);
-			if(!hasParent || (!hasSpace && !Random::Int(600)) || parent->IsDestroyed()
+			if(!hasParent || (!hasSpace && !Random::Int(1200)) || parent->IsDestroyed()
 					|| parent->GetSystem() != it->GetSystem())
 			{
 				// Find a parent for orphaned fighters and drones.
 				parent.reset();
 				it->SetParent(parent);
-				vector<shared_ptr<Ship>> parentChoices;
+				
+				auto parentChoices = vector<shared_ptr<Ship>>{};
 				parentChoices.reserve(ships.size() * .1);
-				for(const auto &other : ships)
-					if(other->GetGovernment() == gov && other->GetSystem() == it->GetSystem() && !other->CanBeCarried())
-					{
-						if(!other->IsDisabled() && other->CanCarry(*it.get()))
+				auto reparentWith = [&](const list<shared_ptr<Ship>> otherShips) -> bool
+				{
+					for(const auto &other : otherShips)
+						if(other->GetGovernment() == gov && other->GetSystem() == it->GetSystem() && !other->CanBeCarried())
 						{
-							parent = other;
-							it->SetParent(other);
-							break;
+							if(!other->IsDisabled() && other->CanCarry(*it.get()))
+							{
+								parent = other;
+								it->SetParent(other);
+								return true;
+							}
+							else
+								parentChoices.emplace_back(other);
 						}
-						else
-							parentChoices.emplace_back(other);
-					}
+					return false;
+				};
+				// Mission ships should only pick ships from the same mission.
+				auto missionIt = it->IsSpecial() && !it->IsYours()
+					? find_if(player.Missions().begin(), player.Missions().end(), [&it](const Mission &m)
+					{
+						auto nend = m.NPCs().end();
+						return nend != find_if(m.NPCs().begin(), nend, [&it](const NPC &n)
+						{
+							auto send = n.Ships().end();
+							return send != find_if(n.Ships().begin(), send, [&it](const shared_ptr<Ship> &s)
+							{
+								return s.get() == it.get();
+							});
+						});
+					})
+					: player.Missions().end();
+				if(missionIt != player.Missions().end())
+				{
+					auto npcs = missionIt->NPCs();
+					for(const auto npc : npcs)
+						if(reparentWith(npc.Ships()))
+							break;
+				}
+				else
+					reparentWith(ships);
 				
 				if(!parent && !parentChoices.empty())
 				{
+					// No suitable candidate can carry this ship, but this ship can still act as an escort.
 					parent = parentChoices[Random::Int(parentChoices.size())];
 					it->SetParent(parent);
 				}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Audio.h"
 #include "Effect.h"
+#include "Files.h"
 #include "FillShader.h"
 #include "Fleet.h"
 #include "Flotsam.h"
@@ -284,7 +285,11 @@ void Engine::Place()
 		// If a special ship somehow was saved without a system reference, place it into the
 		// player's system to avoid a nullptr deference.
 		else if(!ship->GetSystem())
+		{
+			// Log this error.
+			Files::LogError("Engine::Place: Set fallback system for the NPC \"" + ship->Name() + "\" as it had no system");
 			ship->SetSystem(player.GetSystem());
+		}
 		
 		// If the position is still (0, 0), the special ship is in a different
 		// system, disabled, or otherwise unable to land on viable planets in

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -255,7 +255,8 @@ void Engine::Place()
 		planetRadius = object->Radius();
 	}
 	
-	// Give each special ship we just added a random heading and position.
+	// Give each non-carried, special ship we just added a random heading and position.
+	// (While carried by a parent, ships will not be present in `Engine::ships`.)
 	for(const shared_ptr<Ship> &ship : ships)
 	{
 		Point pos;
@@ -280,6 +281,11 @@ void Engine::Place()
 			else if(hasOwnPlanet)
 				pos = object->Position() + angle.Unit() * Random::Real() * object->Radius();
 		}
+		// If a special ship somehow was saved without a system reference, place it into the
+		// player's system to avoid a nullptr deference.
+		else if(!ship->GetSystem())
+			ship->SetSystem(player.GetSystem());
+		
 		// If the position is still (0, 0), the special ship is in a different
 		// system, disabled, or otherwise unable to land on viable planets in
 		// the player's system: place it "in flight".

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -836,6 +836,18 @@ const list<NPC> &Mission::NPCs() const
 
 
 
+// Checks if the given ship belongs to one of the mission's NPCs.
+bool Mission::HasShip(const shared_ptr<Ship> &ship) const
+{
+	for(const auto &npc : npcs)
+		for(const auto &npcShip : npc.Ships())
+			if(npcShip == ship)
+				return true;
+	return false;
+}
+
+
+
 // If any event occurs between two ships, check to see if this mission cares
 // about it. This may affect the mission status or display a message.
 void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -132,6 +132,8 @@ public:
 	// Get a list of NPCs associated with this mission. Every time the player
 	// takes off from a planet, they should be added to the active ships.
 	const std::list<NPC> &NPCs() const;
+	// Checks if the given ship belongs to one of the mission's NPCs.
+	bool HasShip(const std::shared_ptr<Ship> &ship) const;
 	// If any event occurs between two ships, check to see if this mission cares
 	// about it. This may affect the mission status or display a message.
 	void Do(const ShipEvent &event, PlayerInfo &player, UI *ui);


### PR DESCRIPTION
Refs #4307 

Also reduces the frequency with which carried ships that are escorts of a ship that cannot carry them seek different parents.