### PR TITLE
NEW CLASS: GameWindow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ ipch/
 *.userosscache
 *.sln.docstates
 *.xcodeproj/**
+EndlessSky.cscope_file_list

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,3 @@ ipch/
 *.userosscache
 *.sln.docstates
 *.xcodeproj/**
-EndlessSky.cscope_file_list

--- a/EndlessSky.cbp
+++ b/EndlessSky.cbp
@@ -166,6 +166,8 @@
 		<Unit filename="source/GameData.h" />
 		<Unit filename="source/GameEvent.cpp" />
 		<Unit filename="source/GameEvent.h" />
+		<Unit filename="source/GameWindow.cpp" />
+		<Unit filename="source/GameWindow.h" />
 		<Unit filename="source/Government.cpp" />
 		<Unit filename="source/Government.h" />
 		<Unit filename="source/HailPanel.cpp" />

--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		A9C70E101C0E5B51000B3D14 /* File.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9C70E0E1C0E5B51000B3D14 /* File.cpp */; };
 		A9CC526D1950C9F6004E4E22 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9CC526C1950C9F6004E4E22 /* Cocoa.framework */; };
 		A9D40D1A195DFAA60086EE52 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9D40D19195DFAA60086EE52 /* OpenGL.framework */; };
+		B55C239D2303CE8B005C1A14 /* GameWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B55C239B2303CE8A005C1A14 /* GameWindow.cpp */; };
 		B5DDA6942001B7F600DBA76A /* News.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5DDA6922001B7F600DBA76A /* News.cpp */; };
 		DF8D57E11FC25842001525DA /* Dictionary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57DF1FC25842001525DA /* Dictionary.cpp */; };
 		DF8D57E51FC25889001525DA /* Visual.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57E21FC25889001525DA /* Visual.cpp */; };
@@ -430,6 +431,8 @@
 		A9CC52701950C9F6004E4E22 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		A9CC52711950C9F6004E4E22 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		A9D40D19195DFAA60086EE52 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		B55C239B2303CE8A005C1A14 /* GameWindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameWindow.cpp; path = source/GameWindow.cpp; sourceTree = "<group>"; };
+		B55C239C2303CE8A005C1A14 /* GameWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameWindow.h; path = source/GameWindow.h; sourceTree = "<group>"; };
 		B5DDA6922001B7F600DBA76A /* News.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = News.cpp; path = source/News.cpp; sourceTree = "<group>"; };
 		B5DDA6932001B7F600DBA76A /* News.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = News.h; path = source/News.h; sourceTree = "<group>"; };
 		DF8D57DF1FC25842001525DA /* Dictionary.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Dictionary.cpp; path = source/Dictionary.cpp; sourceTree = "<group>"; };
@@ -554,6 +557,8 @@
 				A96863171AE6FD0B004FE1FE /* GameData.h */,
 				A96863181AE6FD0B004FE1FE /* GameEvent.cpp */,
 				A96863191AE6FD0B004FE1FE /* GameEvent.h */,
+				B55C239B2303CE8A005C1A14 /* GameWindow.cpp */,
+				B55C239C2303CE8A005C1A14 /* GameWindow.h */,
 				A968631A1AE6FD0B004FE1FE /* gl_header.h */,
 				A968631B1AE6FD0B004FE1FE /* Government.cpp */,
 				A968631C1AE6FD0B004FE1FE /* Government.h */,
@@ -880,6 +885,7 @@
 				A96863E61AE6FD0E004FE1FE /* Point.cpp in Sources */,
 				A96863DE1AE6FD0E004FE1FE /* OutfitterPanel.cpp in Sources */,
 				62C3111A1CE172D000409D91 /* Flotsam.cpp in Sources */,
+				B55C239D2303CE8B005C1A14 /* GameWindow.cpp in Sources */,
 				A96863B91AE6FD0E004FE1FE /* Effect.cpp in Sources */,
 				A96863AE1AE6FD0E004FE1FE /* ConditionSet.cpp in Sources */,
 				A96863DC1AE6FD0E004FE1FE /* Outfit.cpp in Sources */,

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -1,0 +1,357 @@
+/* GameWindow.cpp
+Copyright (c) 2014 by Michael Zahniser
+
+Provides the ability to create window objects. Like the main game window.
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "Files.h"
+#include "GameWindow.h"
+#include "gl_header.h"
+#include "ImageBuffer.h"
+#include "Preferences.h"
+#include "Screen.h"
+
+#include <cstring>
+#include <SDL2/SDL.h>
+#include <string>
+#include <sstream>
+
+using namespace std;
+
+namespace {
+	SDL_GLContext context;
+	int minWidth = 640;
+	int minHeight = 480;
+	int width;
+	int height;
+	int monitorHz;
+	bool hasSwizzle;
+	SDL_Window *mainWindow;
+	
+	// Logs SDL errors and returns 1 if found
+	int checkSDLerror()
+	{
+		const char *sdlMessage = SDL_GetError();
+		if(sdlMessage && sdlMessage[0])
+		{
+			string message;
+			message = " (SDL message: \"";
+			message += sdlMessage;
+			message += "\")";			
+			Files::LogError(message);
+			
+			return 1;
+		}
+		
+		return 0;
+	}
+}
+
+
+
+int GameWindow::Width()
+{
+	return width;
+}
+
+
+
+int GameWindow::Height()
+{
+	return height;
+}
+
+
+
+int GameWindow::MonitorHz()
+{
+	return monitorHz;
+}
+
+
+
+bool GameWindow::IsFullscreen()
+{
+	return (SDL_GetWindowFlags(mainWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP);
+}
+
+
+
+bool GameWindow::IsMaximized()
+{
+	return (SDL_GetWindowFlags(mainWindow) & SDL_WINDOW_MAXIMIZED);
+}
+
+
+
+bool GameWindow::HasSwizzle()
+{
+	return hasSwizzle;
+}
+
+
+
+int GameWindow::Init()
+{
+	if (SDL_Init(SDL_INIT_VIDEO) != 0) 
+		return 1;
+	
+	// Start with a clear the error state
+	SDL_GetError();
+	
+	// Check how big the window can be.
+	SDL_DisplayMode mode;
+	if(SDL_GetCurrentDisplayMode(0, &mode))
+		return DoError("Unable to query monitor resolution!");
+	
+	monitorHz = mode.refresh_rate;
+	
+	Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
+
+	if(Preferences::Has("fullscreen"))
+		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+	else if(Preferences::Has("maximized"))
+		flags |= SDL_WINDOW_MAXIMIZED;
+	
+	// Make the window just slightly smaller than the monitor resolution.
+	int maxWidth = mode.w;
+	int maxHeight = mode.h;
+	if(maxWidth < minWidth || maxHeight < minHeight)
+		return DoError("Monitor resolution is too small!");
+	
+	int windowWidth = maxWidth - 100;
+	int windowHeight = maxHeight - 100;
+						
+	// Decide how big the window should be.
+	if(Screen::RawWidth() && Screen::RawHeight())
+	{
+		// Load the previously saved window dimensions.
+		windowWidth = min(windowWidth, Screen::RawWidth());
+		windowHeight = min(windowHeight, Screen::RawHeight());
+	}
+	
+	// Create the window.
+	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+#ifdef _WIN32
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+#endif
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+	
+	mainWindow = SDL_CreateWindow("Endless Sky", SDL_WINDOWPOS_UNDEFINED, 
+		SDL_WINDOWPOS_UNDEFINED, windowWidth, windowHeight, flags);
+		
+	if(!mainWindow)
+		return DoError("Unable to create window!");
+	
+	context = SDL_GL_CreateContext(mainWindow);
+	if(!context)
+		return DoError("Unable to create OpenGL context! Check if your system supports OpenGL 3.0.");
+	
+	if(SDL_GL_MakeCurrent(mainWindow, context))
+		return DoError("Unable to set the current OpenGL context!");
+			
+	// Initialize GLEW.
+#ifndef __APPLE__
+	glewExperimental = GL_TRUE;
+	if(glewInit() != GLEW_OK)
+		return DoError("Unable to initialize GLEW!");
+#endif
+	
+	// Check that the OpenGL version is high enough.
+	const char *glVersion = reinterpret_cast<const char *>(glGetString(GL_VERSION));
+	if(!glVersion || !*glVersion)
+		return DoError("Unable to query the OpenGL version!");
+	
+	const char *glslVersion = reinterpret_cast<const char *>(glGetString(GL_SHADING_LANGUAGE_VERSION));
+	if(!glslVersion || !*glslVersion)
+	{
+		ostringstream out;
+		out << "Unable to query the GLSL version. OpenGL version is " << glVersion << ".";
+		return DoError(out.str());
+	}
+	
+	if(*glVersion < '3')
+	{
+		ostringstream out;
+		out << "Endless Sky requires OpenGL version 3.0 or higher." << endl;
+		out << "Your OpenGL version is " << glVersion << ", GLSL version " << glslVersion << "." << endl;
+		out << "Please update your graphics drivers.";
+		return DoError(out.str());
+	}
+	
+	checkSDLerror();
+	
+	// OpenGL settings
+	glClearColor(0.f, 0.f, 0.0f, 1.f);
+	glEnable(GL_BLEND);
+	glDisable(GL_DEPTH_TEST);
+	glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+	
+	// Set Adaptive VSync or fail to normal VSync
+	if(SDL_GL_SetSwapInterval(-1) == -1)
+	{
+		checkSDLerror();	
+		SDL_GL_SetSwapInterval(1);
+	}
+	
+	// Make sure the screen size and view-port are set correctly.
+	AdjustViewport();
+	
+#ifndef __APPLE__
+	// On OS X, setting the window icon will cause that same icon to be used
+	// in the dock and the application switcher. That's not something we
+	// want, because the ".icns" icon that is used automatically is prettier.
+	SetIcon();
+#endif
+
+string swizzleName = "_texture_swizzle";		
+#ifndef __APPLE__
+	const char *extensions = reinterpret_cast<const char *>(glGetString(GL_EXTENSIONS));
+	hasSwizzle = strstr(extensions, swizzleName.c_str());
+#else
+	bool swizzled = false;
+	GLint extensionCount;
+	glGetIntegerv(GL_NUM_EXTENSIONS, &extensionCount);
+	for(GLint i = 0; i < extensionCount && !swizzled; ++i)
+	{
+		const char *extension = reinterpret_cast<const char *>(glGetStringi(GL_EXTENSIONS, i));
+		swizzled = (extension && strstr(extension, swizzleName.c_str()));
+	}
+	hasSwizzle = swizzled;
+#endif
+
+	return 0;
+}
+
+
+
+void GameWindow::SetIcon()
+{
+	if(!mainWindow)
+		return;
+		
+	// Load the icon file.
+	ImageBuffer buffer;
+	if(!buffer.Read(Files::Resources() + "icon.png"))
+		return;
+	if(!buffer.Pixels() || !buffer.Width() || !buffer.Height())
+		return;
+	
+	// Convert the icon to an SDL surface.
+	SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(buffer.Pixels(), buffer.Width(), buffer.Height(),
+		32, 4 * buffer.Width(), 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000);
+	if(surface)
+	{
+		SDL_SetWindowIcon(mainWindow, surface);
+		SDL_FreeSurface(surface);
+	}
+}
+
+
+
+void GameWindow::AdjustViewport()
+{
+	if(!mainWindow)
+		return;
+		
+	// Get the window's size in screen coordinates.
+	SDL_GetWindowSize(mainWindow, &width, &height);
+	
+	// Round the window size up to a multiple of 2, even if this
+	// means one pixel of the display will be clipped.
+	int roundWidth = (width + 1) & ~1;
+	int roundHeight = (height + 1) & ~1;
+	Screen::SetRaw(roundWidth, roundHeight);
+	
+	// Find out the drawable dimensions. If this is a high- DPI display, this
+	// may be larger than the window.
+	int drawWidth, drawHeight;
+	SDL_GL_GetDrawableSize(mainWindow, &drawWidth, &drawHeight);
+	Screen::SetHighDPI(drawWidth > width || drawHeight > height);	
+	
+	// Set the viewport to go off the edge of the window, if necessary, to get
+	// everything pixel-aligned.
+	drawWidth = (drawWidth * roundWidth) / width;
+	drawHeight = (drawHeight * roundHeight) / height;
+	glViewport(0, 0, drawWidth, drawHeight);
+}
+
+
+
+void GameWindow::ToggleFullscreen()
+{
+	// This will generate a window size change event, 
+	// no need to adjust the viewport here.		
+	if(IsFullscreen())
+	{ 
+		SDL_SetWindowFullscreen(mainWindow, 0);
+		SDL_SetWindowSize(mainWindow, width, height);
+	}
+	else
+		SDL_SetWindowFullscreen(mainWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
+}
+
+
+
+void GameWindow::Step()
+{
+	SDL_GL_SwapWindow(mainWindow);
+}
+
+	
+
+void GameWindow::Quit()
+{
+	// Make sure the cursor is visible.
+	SDL_ShowCursor(true);
+	
+	// Clean up in the reverse order that everything is launched.
+#ifndef _WIN32
+	// Under windows, this cleanup code causes intermittent crashes.
+	if(context)
+		SDL_GL_DeleteContext(context);
+#endif
+	if(mainWindow)
+		SDL_DestroyWindow(mainWindow);
+	SDL_Quit();
+}	
+
+
+
+int GameWindow::DoError(const string& message)
+{
+	GameWindow::Quit();			
+	
+	// Print the error message in the terminal and the error file.
+	Files::LogError(message);		
+	checkSDLerror();
+	
+	// Show the error message both in a message box and in the terminal.
+	SDL_MessageBoxData box;
+	box.flags = SDL_MESSAGEBOX_ERROR;
+	box.window = nullptr;
+	box.title = "Endless Sky: Error";
+	box.message = message.c_str();
+	box.colorScheme = nullptr;
+	
+	SDL_MessageBoxButtonData button;
+	button.flags = SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT;
+	button.buttonid = 0;
+	button.text = "OK";
+	box.numbuttons = 1;
+	box.buttons = &button;
+	
+	int result = 0;
+	SDL_ShowMessageBox(&box, &result);
+	
+	return 1;
+}

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -29,11 +29,9 @@ using namespace std;
 namespace {
 	SDL_Window *mainWindow;
 	SDL_GLContext context;
-	int minWidth = 640;
-	int minHeight = 480;
-	int width;
-	int height;
-	int monitorHz;
+	int width = 0;
+	int height = 0;
+	//int monitorHz;
 	bool hasSwizzle;
 		
 	// Logs SDL errors and returns 1 if found
@@ -71,10 +69,10 @@ int GameWindow::Height()
 
 
 
-int GameWindow::MonitorHz()
-{
-	return monitorHz;
-}
+//int GameWindow::MonitorHz()
+//{
+//	return monitorHz;
+//}
 
 
 
@@ -105,7 +103,7 @@ int GameWindow::Init()
 	if (SDL_Init(SDL_INIT_VIDEO) != 0) 
 		return 1;
 	
-	// Start with a clear the error state
+	// Start with a clear error state
 	SDL_GetError();
 	
 	// Get details about the current display.
@@ -114,6 +112,8 @@ int GameWindow::Init()
 		return DoError("Unable to query monitor resolution!");
 		
 	// Make the window just slightly smaller than the monitor resolution.
+	int minWidth = 640;
+	int minHeight = 480;
 	int maxWidth = mode.w;
 	int maxHeight = mode.h;
 	if(maxWidth < minWidth || maxHeight < minHeight)
@@ -130,7 +130,7 @@ int GameWindow::Init()
 		windowHeight = min(windowHeight, Screen::RawHeight());
 	}
 	
-	monitorHz = mode.refresh_rate;
+	//monitorHz = mode.refresh_rate;
 	
 	// Settings that must be declared before the window creation.
 	Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -279,25 +279,33 @@ void GameWindow::AdjustViewport()
 	if(!mainWindow)
 		return;
 		
-	// Keep track of the actual size of the window when it is resized.
-	SDL_GetWindowSize(mainWindow, &width, &height);
+	// Get the window's size in screen coordinates.
+	int windowWidth, windowHeight;
+	SDL_GetWindowSize(mainWindow, &windowWidth, &windowHeight);
+	
+	// Only save the window size when not in fullscreen mode.
+	if(!GameWindow::IsFullscreen())
+	{
+		width = windowWidth;
+		height = windowHeight;
+	}
 	
 	// Round the window size up to a multiple of 2, even if this
 	// means one pixel of the display will be clipped.
-	int roundWidth = (width + 1) & ~1;
-	int roundHeight = (height + 1) & ~1;
+	int roundWidth = (windowWidth + 1) & ~1;
+	int roundHeight = (windowHeight + 1) & ~1;
 	Screen::SetRaw(roundWidth, roundHeight);
 	
 	// Find out the drawable dimensions. If this is a high- DPI display, this
 	// may be larger than the window.
 	int drawWidth, drawHeight;
 	SDL_GL_GetDrawableSize(mainWindow, &drawWidth, &drawHeight);
-	Screen::SetHighDPI(drawWidth > width || drawHeight > height);	
+	Screen::SetHighDPI(drawWidth > windowWidth || drawHeight > windowHeight);	
 	
 	// Set the viewport to go off the edge of the window, if necessary, to get
 	// everything pixel-aligned.
-	drawWidth = (drawWidth * roundWidth) / width;
-	drawHeight = (drawHeight * roundHeight) / height;
+	drawWidth = (drawWidth * roundWidth) / windowWidth;
+	drawHeight = (drawHeight * roundHeight) / windowHeight;
 	glViewport(0, 0, drawWidth, drawHeight);
 }
 

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -34,14 +34,14 @@ namespace {
 	//int monitorHz;
 	bool hasSwizzle;
 		
-	// Logs SDL errors and returns 1 if found
-	bool checkSDLerror(const string &context)
+	// Logs SDL errors and returns true if found
+	bool checkSDLerror()
 	{
 		string message = SDL_GetError();
 		if(!message.empty())
 		{
 			Files::LogError("(SDL message: \"" + message + "\")");
-			SDL_ClearError
+			SDL_ClearError();
 			return true;
 		}
 		
@@ -97,7 +97,7 @@ bool GameWindow::Init()
 {
 	// This needs to be called before any other SDL commands.
 	if (SDL_Init(SDL_INIT_VIDEO) != 0) {
-		checkSDLerror;
+		checkSDLerror();
 		return false;
 	}
 	

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -31,7 +31,6 @@ namespace {
 	SDL_GLContext context;
 	int width = 0;
 	int height = 0;
-	//int monitorHz;
 	bool hasSwizzle;
 		
 	// Logs SDL errors and returns true if found
@@ -62,13 +61,6 @@ int GameWindow::Height()
 {
 	return height;
 }
-
-
-
-//int GameWindow::MonitorHz()
-//{
-//	return monitorHz;
-//}
 
 
 
@@ -129,8 +121,6 @@ bool GameWindow::Init()
 		windowHeight = min(windowHeight, Screen::RawHeight());
 	}
 	
-	//monitorHz = mode.refresh_rate;
-	
 	// Settings that must be declared before the window creation.
 	Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
 
@@ -156,10 +146,6 @@ bool GameWindow::Init()
 #endif
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);	
 	SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
-	
-	// FSAA?
-	//SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
-	//SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 2);
 		
 	context = SDL_GL_CreateContext(mainWindow);
 	if(!context){

--- a/source/GameWindow.h
+++ b/source/GameWindow.h
@@ -1,0 +1,67 @@
+/* GameWindow.h
+Copyright (c) 2014 by Michael Zahniser
+
+Provides the ability to create window objects. Like the main game window.
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef GAMEWINDOW_H_
+#define GAMEWINDOW_H_
+
+#include <string>
+
+// This class is a collection of global functions for handling SDL_Windows.
+class GameWindow
+{
+public:
+	// Last known window width from windowed mode
+	static int Width();
+	
+	// Last known height width from windowed mode
+	static int Height();
+	
+	// The refresh rate of the current display
+	static int MonitorHz();
+
+	// Returns true if the main window is in full screen mode
+	static bool IsFullscreen();
+	
+	// Returns true if the main window is maximized
+	static bool IsMaximized();
+	
+	// Returns true if the system supports OpenGL texture_swizzle
+	static bool HasSwizzle();
+
+	// Initialize the main window
+	static int Init();
+	
+	// Paint the next frame in the main window
+	static void Step();
+	
+	// Ensure the proper icon is set on the main window
+	static void SetIcon();
+	
+	// Handles resize events of the main window
+	static void AdjustViewport();
+
+	// Toggle full screen mode for the main window
+	static void ToggleFullscreen();
+	
+	// Destroys all window system objects (because we're about to quit). 
+	static void Quit();
+	
+	// Print the error message in the terminal, error file, and message box.
+	// Checks for video system errors and records those as well.
+	static int DoError(const std::string& message);
+};
+
+
+
+#endif

--- a/source/GameWindow.h
+++ b/source/GameWindow.h
@@ -40,7 +40,7 @@ public:
 	static bool HasSwizzle();
 
 	// Initialize the main window
-	static int Init();
+	static bool Init();
 	
 	// Paint the next frame in the main window
 	static void Step();
@@ -59,7 +59,7 @@ public:
 	
 	// Print the error message in the terminal, error file, and message box.
 	// Checks for video system errors and records those as well.
-	static int DoError(const std::string& message);
+	static void DoError(const std::string& message);
 };
 
 #endif

--- a/source/GameWindow.h
+++ b/source/GameWindow.h
@@ -1,8 +1,6 @@
 /* GameWindow.h
 Copyright (c) 2014 by Michael Zahniser
 
-Provides the ability to create window objects. Like the main game window.
-
 Endless Sky is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
 Foundation, either version 3 of the License, or (at your option) any later version.
@@ -21,42 +19,34 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 class GameWindow
 {
 public:
-	// Last known window width from windowed mode
-	static int Width();
-	
-	// Last known height width from windowed mode
-	static int Height();
-	
-	// Returns true if the main window is in full screen mode
-	static bool IsFullscreen();
-	
-	// Returns true if the main window is maximized
-	static bool IsMaximized();
-	
-	// Returns true if the system supports OpenGL texture_swizzle
-	static bool HasSwizzle();
-
-	// Initialize the main window
 	static bool Init();
+	static void Quit();
 	
-	// Paint the next frame in the main window
+	// Paint the next frame in the main window.
 	static void Step();
 	
-	// Ensure the proper icon is set on the main window
+	// Ensure the proper icon is set on the main window.
 	static void SetIcon();
 	
-	// Handles resize events of the main window
+	// Handle resize events of the main window.
 	static void AdjustViewport();
-
-	// Toggle full screen mode for the main window
-	static void ToggleFullscreen();
 	
-	// Destroys all window system objects (because we're about to quit). 
-	static void Quit();
+	// Last known windowed-mode width & height.
+	static int Width();
+	static int Height();
+	// 
+	static bool IsMaximized();
+	static bool IsFullscreen();
+	static void ToggleFullscreen();	
+	
+	// Check if the initialized window system supports OpenGL texture_swizzle.
+	static bool HasSwizzle();
 	
 	// Print the error message in the terminal, error file, and message box.
 	// Checks for video system errors and records those as well.
-	static void DoError(const std::string& message);
+	static void ExitWithError(const std::string& message);
 };
+
+
 
 #endif

--- a/source/GameWindow.h
+++ b/source/GameWindow.h
@@ -28,7 +28,7 @@ public:
 	static int Height();
 	
 	// The refresh rate of the current display
-	static int MonitorHz();
+	//static int MonitorHz();
 
 	// Returns true if the main window is in full screen mode
 	static bool IsFullscreen();
@@ -61,7 +61,5 @@ public:
 	// Checks for video system errors and records those as well.
 	static int DoError(const std::string& message);
 };
-
-
 
 #endif

--- a/source/GameWindow.h
+++ b/source/GameWindow.h
@@ -27,9 +27,6 @@ public:
 	// Last known height width from windowed mode
 	static int Height();
 	
-	// The refresh rate of the current display
-	//static int MonitorHz();
-
 	// Returns true if the main window is in full screen mode
 	static bool IsFullscreen();
 	

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
 	}
 	catch(const runtime_error &error)
 	{
-		GameWindow::DoError(error.what());
+		GameWindow::ExitWithError(error.what());
 		return 1;
 	}
 		

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -19,11 +19,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataFile.h"
 #include "DataNode.h"
 #include "Dialog.h"
-#include "Files.h"
 #include "Font.h"
 #include "FrameTimer.h"
 #include "GameData.h"
-#include "ImageBuffer.h"
+#include "GameWindow.h"
 #include "MenuPanel.h"
 #include "Panel.h"
 #include "PlayerInfo.h"
@@ -33,13 +32,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "SpriteShader.h"
 #include "UI.h"
 
-#include "gl_header.h"
-#include <SDL2/SDL.h>
-
-#include <cstring>
 #include <iostream>
 #include <map>
-#include <sstream>
+
 #include <stdexcept>
 #include <string>
 
@@ -51,10 +46,7 @@ using namespace std;
 
 void PrintHelp();
 void PrintVersion();
-void SetIcon(SDL_Window *window);
-void AdjustViewport(SDL_Window *window);
-int DoError(string message, SDL_Window *window = nullptr, SDL_GLContext context = nullptr);
-void Cleanup(SDL_Window *window, SDL_GLContext context);
+void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode);
 Conversation LoadConversation();
 #ifdef _WIN32
 void InitConsole();
@@ -62,8 +54,10 @@ void InitConsole();
 
 
 
+// Entry point for the executable "EndlessSky.exe"
 int main(int argc, char *argv[])
 {
+	// Handle command-line arguments
 #ifdef _WIN32
 	if(argc > 1)
 		InitConsole();
@@ -91,259 +85,164 @@ int main(int argc, char *argv[])
 		else if(arg == "-p" || arg == "--parse-save")
 			loadOnly = true;
 	}
-	PlayerInfo player;
 	
-	try {
-		// Begin loading the game data. Exit early if we are not using the UI.
-		if(!GameData::BeginLoad(argv))
-			return 0;
-		
-		// Load player data, including reference-checking.
-		player.LoadRecent();
-		if(loadOnly)
-		{
-			cout << "Parse completed." << endl;
-			return 0;
-		}
-		
-		SDL_Init(SDL_INIT_VIDEO);
-		
-		Audio::Init(GameData::Sources());
-		
-		// On Windows, make sure that the sleep timer has at least 1 ms resolution
-		// to avoid irregular frame rates.
+	// Begin loading the game data. Exit early if we are not using the UI.
+	if(!GameData::BeginLoad(argv))
+		return 0;
+	
+	// Load player data, including reference-checking.
+	PlayerInfo player;
+	player.LoadRecent();
+	if(loadOnly)
+	{
+		cout << "Parse completed." << endl;
+		return 0;
+	}
+	
+	// On Windows, make sure that the sleep timer has at least 1 ms resolution
+	// to avoid irregular frame rates.
 #ifdef _WIN32
-		timeBeginPeriod(1);
+	timeBeginPeriod(1);
 #endif
+	
+	Preferences::Load();
+	
+	if(GameWindow::Init() != 0)
+		return 1;
+	
+	GameData::LoadShaders();
+	
+	// Show something other than a blank window while we get going.
+	GameWindow::Step();
+	
+	Audio::Init(GameData::Sources());
+	
+	// This is the main loop where all the action begins.
+	try { 
+		GameLoop(player, conversation, debugMode);
+	}
+	catch(const runtime_error &error)
+	{
+		return GameWindow::DoError(error.what());
+	}
 		
-		// Check how big the window can be.
-		SDL_DisplayMode mode;
-		if(SDL_GetCurrentDisplayMode(0, &mode))
-			return DoError("Unable to query monitor resolution!");
-		
-		Preferences::Load();
-		Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
-		bool isFullscreen = Preferences::Has("fullscreen");
-		bool isFastForward = false;
-		if(isFullscreen)
-			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
-		else if(Preferences::Has("maximized"))
-			flags |= SDL_WINDOW_MAXIMIZED;
-		
-		// Make the window just slightly smaller than the monitor resolution.
-		int maxWidth = mode.w;
-		int maxHeight = mode.h;
-		if(maxWidth < 640 || maxHeight < 480)
-			return DoError("Monitor resolution is too small!");
-		
-		// Decide how big the window should be.
-		int windowWidth = (maxWidth - 100);
-		int windowHeight = (maxHeight - 100);
-		if(Screen::RawWidth() && Screen::RawHeight())
+	// Remember the window state.
+	Preferences::Set("maximized", GameWindow::IsMaximized());		
+	Preferences::Set("fullscreen", GameWindow::IsFullscreen());
+	Screen::SetRaw(GameWindow::Width(), GameWindow::Height());
+	Preferences::Save();
+
+	GameWindow::Quit();
+	Audio::Quit();
+	
+	return 0;
+}
+
+void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode)
+{
+	// gamePanels is used for the main panel where you fly your spaceship. 
+	// All other game content related dialogs are placed on top of the gamePanels.
+	// If there are both menuPanels and gamePanels, then the menuPanels take
+	// priority over the gamePanels. The gamePanels will not be shown until
+	// the stack of menuPanels is empty.
+	
+	UI gamePanels;
+	// MenuPanels is used for the panels related to pilot creation, preferences,
+	// game loading and game saving.
+	UI menuPanels;
+	menuPanels.Push(new MenuPanel(player, gamePanels));
+	if(!conversation.IsEmpty())
+		menuPanels.Push(new ConversationPanel(player, conversation));
+
+	if(!GameWindow::HasSwizzle())
+		menuPanels.Push(new Dialog(
+			"Note: your computer does not support the \"texture swizzling\" OpenGL feature, "
+			"which Endless Sky uses to draw ships in different colors depending on which "
+			"government they belong to. So, all human ships will be the same color, which "
+			"may be confusing. Consider upgrading your graphics driver (or your OS)."));
+			
+	bool showCursor = true;
+	int cursorTime = 0;
+	int frameRate = 60; // GameWindow::MonitorHz; // You could match the rate here.
+	FrameTimer timer(frameRate);
+	bool isPaused = false;
+	// If fast forwarding, keep track of whether the current frame should be drawn.
+	int skipFrame = 0;
+	// Limit how quickly full-screen mode can be toggled.
+	int toggleTimeout = 0;
+	while(!menuPanels.IsDone())
+	{
+		if(toggleTimeout)
+			--toggleTimeout;
+		// Handle any events that occurred in this frame.
+		SDL_Event event;
+		while(SDL_PollEvent(&event))
 		{
-			// Load the previously saved window dimensions.
-			windowWidth = min(windowWidth, Screen::RawWidth());
-			windowHeight = min(windowHeight, Screen::RawHeight());
-		}
-		
-		// Create the window.
-		SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-#ifdef _WIN32
-		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
-#endif
-		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-		
-		SDL_Window *window = SDL_CreateWindow("Endless Sky",
-			SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-			windowWidth, windowHeight, flags);
-		if(!window)
-			return DoError("Unable to create window!");
-		
-		SDL_GLContext context = SDL_GL_CreateContext(window);
-		if(!context)
-			return DoError("Unable to create OpenGL context! Check if your system supports OpenGL 3.0.", window);
-		
-		if(SDL_GL_MakeCurrent(window, context))
-			return DoError("Unable to set the current OpenGL context!", window, context);
-		
-		SDL_GL_SetSwapInterval(1);
-		
-		// Initialize GLEW.
-#ifndef __APPLE__
-		glewExperimental = GL_TRUE;
-		if(glewInit() != GLEW_OK)
-			return DoError("Unable to initialize GLEW!", window, context);
-#endif
-		
-		// Check that the OpenGL version is high enough.
-		const char *glVersion = reinterpret_cast<const char *>(glGetString(GL_VERSION));
-		if(!glVersion || !*glVersion)
-			return DoError("Unable to query the OpenGL version!", window, context);
-		
-		const char *glslVersion = reinterpret_cast<const char *>(glGetString(GL_SHADING_LANGUAGE_VERSION));
-		if(!glslVersion || !*glslVersion)
-		{
-			ostringstream out;
-			out << "Unable to query the GLSL version. OpenGL version is " << glVersion << ".";
-			return DoError(out.str(), window, context);
-		}
-		
-		if(*glVersion < '3')
-		{
-			ostringstream out;
-			out << "Endless Sky requires OpenGL version 3.0 or higher." << endl;
-			out << "Your OpenGL version is " << glVersion << ", GLSL version " << glslVersion << "." << endl;
-			out << "Please update your graphics drivers.";
-			return DoError(out.str(), window, context);
-		}
-		
-		glClearColor(0.f, 0.f, 0.0f, 1.f);
-		glEnable(GL_BLEND);
-		glDisable(GL_DEPTH_TEST);
-		glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-		
-		GameData::LoadShaders();
-		// Make sure the screen size and viewport are set correctly.
-		AdjustViewport(window);
-#ifndef __APPLE__
-		// On OS X, setting the window icon will cause that same icon to be used
-		// in the dock and the application switcher. That's not something we
-		// want, because the .icns icon that is used automatically is prettier.
-		SetIcon(window);
-#endif
-		if(!isFullscreen)
-			SDL_GetWindowSize(window, &windowWidth, &windowHeight);
-		
-		// GamePanels is used for the main-panel (flying your spaceship). The planet
-		// dialog and all other game-content related dialogs are placed on top of the
-		// main-panel.
-		// If there are both menuPanels and gamePanels, then the menuPanels take
-		// priority over the gamePanels. The gamePanels will then not be shown until
-		// the stack of menuPanels is empty.
-		UI gamePanels;
-		// MenuPanels is used for the panels related to pilot creation, preferences,
-		// game loading and game saving.
-		UI menuPanels;
-		menuPanels.Push(new MenuPanel(player, gamePanels));
-		if(!conversation.IsEmpty())
-			menuPanels.Push(new ConversationPanel(player, conversation));
-		
-		string swizzleName = "_texture_swizzle";
-#ifndef __APPLE__
-		const char *extensions = reinterpret_cast<const char *>(glGetString(GL_EXTENSIONS));
-		if(!strstr(extensions, swizzleName.c_str()))
-#else
-		bool hasSwizzle = false;
-		GLint extensionCount;
-		glGetIntegerv(GL_NUM_EXTENSIONS, &extensionCount);
-		for(GLint i = 0; i < extensionCount && !hasSwizzle; ++i)
-		{
-			const char *extension = reinterpret_cast<const char *>(glGetStringi(GL_EXTENSIONS, i));
-			hasSwizzle = (extension && strstr(extension, swizzleName.c_str()));
-		}
-		if(!hasSwizzle)
-#endif
-			menuPanels.Push(new Dialog(
-				"Note: your computer does not support the \"texture swizzling\" OpenGL feature, "
-				"which Endless Sky uses to draw ships in different colors depending on which "
-				"government they belong to. So, all human ships will be the same color, which "
-				"may be confusing. Consider upgrading your graphics driver (or your OS)."));
-		
-		bool showCursor = true;
-		int cursorTime = 0;
-		int frameRate = 60;
-		FrameTimer timer(frameRate);
-		bool isPaused = false;
-		// If fast forwarding, keep track of whether the current frame should be drawn.
-		int skipFrame = 0;
-		// Limit how quickly fullscreen mode can be toggled.
-		int toggleTimeout = 0;
-		while(!menuPanels.IsDone())
-		{
-			if(toggleTimeout)
-				--toggleTimeout;
-			// Handle any events that occurred in this frame.
-			SDL_Event event;
-			while(SDL_PollEvent(&event))
+			UI &activeUI = (menuPanels.IsEmpty() ? gamePanels : menuPanels);
+			
+			// If the mouse moves, reset the cursor movement timeout.
+			if(event.type == SDL_MOUSEMOTION)
+				cursorTime = 0;
+			
+			// The caps lock key slows the game down (to make it easier to
+			// see and debug things that are happening quickly).
+			if(debugMode && event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_BACKQUOTE)
 			{
-				UI &activeUI = (menuPanels.IsEmpty() ? gamePanels : menuPanels);
-				
-				// If the mouse moves, reset the cursor movement timeout.
-				if(event.type == SDL_MOUSEMOTION)
-					cursorTime = 0;
-				
-				// The caps lock key slows the game down (to make it easier to
-				// see and debug things that are happening quickly).
-				if(debugMode && event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_BACKQUOTE)
-				{
-					isPaused = !isPaused;
-				}
-				else if(event.type == SDL_KEYDOWN && menuPanels.IsEmpty()
-						&& Command(event.key.keysym.sym).Has(Command::MENU)
-						&& !gamePanels.IsEmpty() && gamePanels.Top()->IsInterruptible())
-				{
-					menuPanels.Push(shared_ptr<Panel>(
-						new MenuPanel(player, gamePanels)));
-				}
-				else if(event.type == SDL_QUIT)
-				{
-					menuPanels.Quit();
-				}
-				else if(event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
-				{
-					// The window has been resized. Adjust the raw screen size
-					// and the OpenGL viewport to match.
-					AdjustViewport(window);
-					if(!isFullscreen)
-						SDL_GetWindowSize(window, &windowWidth, &windowHeight);
-				}
-				else if(event.type == SDL_KEYDOWN && !toggleTimeout
-						&& (Command(event.key.keysym.sym).Has(Command::FULLSCREEN)
-						|| (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT))))
-				{
-					// Toggle full-screen mode. This will generate a window size
-					// change event, so no need to adjust the viewport here.
-					isFullscreen = !isFullscreen;
-					toggleTimeout = 30;
-					if(!isFullscreen)
-					{
-						SDL_SetWindowFullscreen(window, 0);
-						SDL_SetWindowSize(window, windowWidth, windowHeight);
-					}
-					else
-						SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-				}
-				else if(event.type == SDL_KEYDOWN && !event.key.repeat
-					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))
-				{
-					isFastForward = !isFastForward;
-				}
-				else if(activeUI.Handle(event))
-				{
-					// No need to do anything more!
-				}
+				isPaused = !isPaused;
 			}
-			SDL_Keymod mod = SDL_GetModState();
-			Font::ShowUnderlines(mod & KMOD_ALT);
-			
-			// In fullscreen mode, hide the cursor if inactive for ten seconds,
-			// but only if the player is flying around in the main view.
-			bool inFlight = (menuPanels.IsEmpty() && gamePanels.Root() == gamePanels.Top());
-			++cursorTime;
-			bool shouldShowCursor = (!isFullscreen || cursorTime < 600 || !inFlight);
-			if(shouldShowCursor != showCursor)
+			// User pressed the Menu key
+			else if(event.type == SDL_KEYDOWN && menuPanels.IsEmpty()
+					&& Command(event.key.keysym.sym).Has(Command::MENU)
+					&& !gamePanels.IsEmpty() && gamePanels.Top()->IsInterruptible())
 			{
-				showCursor = shouldShowCursor;
-				SDL_ShowCursor(showCursor);
+				menuPanels.Push(shared_ptr<Panel>(
+					new MenuPanel(player, gamePanels)));
 			}
-			
-			// Tell all the panels to step forward, then draw them.
-			((!isPaused && menuPanels.IsEmpty()) ? gamePanels : menuPanels).StepAll();
-			
-			// Caps lock slows the frame rate in debug mode.
-			// Slowing eases in and out over a couple of frames.
-			if((mod & KMOD_CAPS) && inFlight && debugMode)
+			else if(event.type == SDL_QUIT)
+			{
+				menuPanels.Quit();
+			}
+			else if(event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+			{
+				// The window has been resized. Adjust the raw screen size
+				// and the OpenGL viewport to match.
+				GameWindow::AdjustViewport();
+			}
+			else if(event.type == SDL_KEYDOWN && !toggleTimeout
+					&& (Command(event.key.keysym.sym).Has(Command::FULLSCREEN)
+					|| (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT))))
+			{
+				toggleTimeout = 30;
+				GameWindow::ToggleFullscreen();
+			}
+			else if(activeUI.Handle(event))
+			{
+				// The UI handled the event.
+			}
+		}
+		SDL_Keymod mod = SDL_GetModState();
+		Font::ShowUnderlines(mod & KMOD_ALT);
+		
+		// In full-screen mode, hide the cursor if inactive for ten seconds,
+		// but only if the player is flying around in the main view.
+		bool inFlight = (menuPanels.IsEmpty() && gamePanels.Root() == gamePanels.Top());
+		++cursorTime;
+		bool shouldShowCursor = (GameWindow::IsFullscreen() || cursorTime < 600 || !inFlight);
+		if(shouldShowCursor != showCursor)
+		{
+			showCursor = shouldShowCursor;
+			SDL_ShowCursor(showCursor);
+		}
+		
+		// Tell all the panels to step forward, then draw them.
+		((!isPaused && menuPanels.IsEmpty()) ? gamePanels : menuPanels).StepAll();
+		
+		// Caps lock slows the frame rate in debug mode, but raises it in
+		// normal mode. Slowing eases in and out over a couple of frames.
+		bool fastForward = false;
+		if((mod & KMOD_CAPS) && inFlight)
+		{
+			if(debugMode)
 			{
 				if(frameRate > 10)
 				{
@@ -353,54 +252,35 @@ int main(int argc, char *argv[])
 			}
 			else
 			{
-				if(frameRate < 60)
-				{
-					frameRate = min(frameRate + 5, 60);
-					timer.SetFrameRate(frameRate);
-				}
-				
-				if(isFastForward && inFlight)
-				{
-					skipFrame = (skipFrame + 1) % 3;
-					if(skipFrame)
-						continue;
-				}
+				fastForward = true;
+				skipFrame = (skipFrame + 1) % 3;
+				if(skipFrame)
+					continue;
 			}
-			
-			Audio::Step();
-			// Events in this frame may have cleared out the menu, in which case
-			// we should draw the game panels instead:
-			(menuPanels.IsEmpty() ? gamePanels : menuPanels).DrawAll();
-			if(isFastForward)
-				SpriteShader::Draw(SpriteSet::Get("ui/fast forward"), Screen::TopLeft() + Point(10., 10.));
-			
-			SDL_GL_SwapWindow(window);
-			timer.Wait();
+		}
+		else if(frameRate < 60)
+		{
+			frameRate = min(frameRate + 5, 60);
+			timer.SetFrameRate(frameRate);
 		}
 		
-		// If you quit while landed on a planet, save the game - if you did anything.
-		if(player.GetPlanet() && gamePanels.CanSave())
-			player.Save();
+		Audio::Step();
 		
-		// Remember the window state.
-		bool isMaximized = (SDL_GetWindowFlags(window) & SDL_WINDOW_MAXIMIZED);
-		Preferences::Set("maximized", isMaximized);		
-		Preferences::Set("fullscreen", isFullscreen);
-		// The Preferences class reads the screen dimensions, so update them to
-		// match the actual window size.
-		Screen::SetRaw(windowWidth, windowHeight);
-		Preferences::Save();
+		// Events in this frame may have cleared out the menu, in which case
+		// we should draw the game panels instead:
+		(menuPanels.IsEmpty() ? gamePanels : menuPanels).DrawAll();
+		if(fastForward)
+			SpriteShader::Draw(SpriteSet::Get("ui/fast forward"), Screen::TopLeft() + Point(10., 10.));
 		
-		Cleanup(window, context);
-	}
-	catch(const runtime_error &error)
-	{
-		DoError(error.what());
+		GameWindow::Step();
+
+		timer.Wait();
 	}
 	
-	return 0;
+	// If player quit while landed on a planet, save the game if there are changes.
+	if(player.GetPlanet() && gamePanels.CanSave())
+		player.Save();
 }
-
 
 
 void PrintHelp()
@@ -432,112 +312,6 @@ void PrintVersion()
 	cerr << "This is free software: you are free to change and redistribute it." << endl;
 	cerr << "There is NO WARRANTY, to the extent permitted by law." << endl;
 	cerr << endl;
-}
-
-
-
-void SetIcon(SDL_Window *window)
-{
-	// Load the icon file.
-	ImageBuffer buffer;
-	if(!buffer.Read(Files::Resources() + "icon.png"))
-		return;
-	if(!buffer.Pixels() || !buffer.Width() || !buffer.Height())
-		return;
-	
-	// Convert the icon to an SDL surface.
-	SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(buffer.Pixels(), buffer.Width(), buffer.Height(),
-		32, 4 * buffer.Width(), 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000);
-	if(surface)
-	{
-		SDL_SetWindowIcon(window, surface);
-		SDL_FreeSurface(surface);
-	}
-}
-
-
-
-void AdjustViewport(SDL_Window *window)
-{
-	// Get the window's size in screen coordinates.
-	int width, height;
-	SDL_GetWindowSize(window, &width, &height);
-	
-	// Round the window size up to a multiple of 2, even if this
-	// means one pixel of the display will be clipped.
-	int roundWidth = (width + 1) & ~1;
-	int roundHeight = (height + 1) & ~1;
-	Screen::SetRaw(roundWidth, roundHeight);
-	
-	// Find out the drawable dimensions. If this is a high- DPI display, this
-	// may be larger than the window.
-	int drawWidth, drawHeight;
-	SDL_GL_GetDrawableSize(window, &drawWidth, &drawHeight);
-	Screen::SetHighDPI(drawWidth > width || drawHeight > height);	
-	
-	// Set the viewport to go off the edge of the window, if necessary, to get
-	// everything pixel-aligned.
-	drawWidth = (drawWidth * roundWidth) / width;
-	drawHeight = (drawHeight * roundHeight) / height;
-	glViewport(0, 0, drawWidth, drawHeight);
-}
-
-
-
-int DoError(string message, SDL_Window *window, SDL_GLContext context)
-{
-	Cleanup(window, context);
-	
-	// Check if SDL has more details.
-	const char *sdlMessage = SDL_GetError();
-	if(sdlMessage && sdlMessage[0])
-	{
-		message += " (SDL message: \"";
-		message += sdlMessage;
-		message += "\")";
-	}
-	
-	// Print the error message in the terminal and the error file.
-	Files::LogError(message);
-	
-	// Show the error message both in a message box and in the terminal.
-	SDL_MessageBoxData box;
-	box.flags = SDL_MESSAGEBOX_ERROR;
-	box.window = nullptr;
-	box.title = "Endless Sky: Error";
-	box.message = message.c_str();
-	box.colorScheme = nullptr;
-	
-	SDL_MessageBoxButtonData button;
-	button.flags = SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT;
-	button.buttonid = 0;
-	button.text = "OK";
-	box.numbuttons = 1;
-	box.buttons = &button;
-	
-	int result = 0;
-	SDL_ShowMessageBox(&box, &result);
-	
-	return 1;
-}
-
-
-
-void Cleanup(SDL_Window *window, SDL_GLContext context)
-{
-	// Make sure the cursor is visible.
-	SDL_ShowCursor(true);
-	
-	// Clean up in the reverse order that everything is launched.
-#ifndef _WIN32
-	// Under windows, this cleanup code causes intermittent crashes.
-	if(context)
-		SDL_GL_DeleteContext(context);
-#endif
-	if(window)
-		SDL_DestroyWindow(window);
-	Audio::Quit();
-	SDL_Quit();
 }
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -191,8 +191,6 @@ void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode)
 			if(event.type == SDL_MOUSEMOTION)
 				cursorTime = 0;
 			
-			// The caps lock key slows the game down (to make it easier to
-			// see and debug things that are happening quickly).
 			if(debugMode && event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_BACKQUOTE)
 			{
 				isPaused = !isPaused;
@@ -200,7 +198,8 @@ void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode)
 			else if(event.type == SDL_KEYDOWN && menuPanels.IsEmpty()
 					&& Command(event.key.keysym.sym).Has(Command::MENU)
 					&& !gamePanels.IsEmpty() && gamePanels.Top()->IsInterruptible())
-			{   // User pressed the Menu key
+			{   
+				// User pressed the Menu key.
 				menuPanels.Push(shared_ptr<Panel>(
 					new MenuPanel(player, gamePanels)));
 			}
@@ -287,6 +286,7 @@ void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode)
 	if(player.GetPlanet() && gamePanels.CanSave())
 		player.Save();
 }
+
 
 
 void PrintHelp()

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
 	
 	Preferences::Load();
 	
-	if(GameWindow::Init() != 0)
+	if(!GameWindow::Init())
 		return 1;
 	
 	GameData::LoadShaders();
@@ -123,7 +123,8 @@ int main(int argc, char *argv[])
 	}
 	catch(const runtime_error &error)
 	{
-		return GameWindow::DoError(error.what());
+		GameWindow::DoError(error.what());
+		return 1;
 	}
 		
 	// Remember the window state.


### PR DESCRIPTION
**NEW:** GameWindow Class. Contains all SDL window code that was in main.cpp
This resulted in changes to the order of operations to untangle SDL window code from other initialization tasks. The Window appears earlier in the loading process but otherwise appears the same to the user.

I modeled the class after the Audio class. Similar naming and use. One benefit is that initialization cruft that used to be in main has a smaller scope and can die when it's done, leaving only properties that we need to use later. 

_Curly's Law: Do One Thing_
To keep main short and sweet it initializes everything and then calls GameLoop, where the main loop lives. Reading main is now just reading a list of things. This makes 100% of real work done in modular bits. 

**CHANGE LOG:**
WAS: Normal VSYNC on.
NEW: Try to set "Adaptive VSync" and fail to normal VSync.

REMOVED: Manual tracking of fullscreen and maximize.
NEW: Return actual window state from SDL.

REMOVED: SDL_WINDOW_SHOWN flag 
BECAUSE: "SDL_WINDOW_SHOWN is ignored by SDL_CreateWindow(). The SDL_Window is implicitly shown if SDL_WINDOW_HIDDEN is not set. "

NEW: Explicitly ask for hardware acceleration. If it fails it will just use the software renderer.

DISABLED: Win32 exception for SDL_GL_DeleteContext. Everything suggests that this call needs to be left in. Let's see if this crash on quit has been resolved. I'm a Windows developer and I haven't seen the crash yet.
