### PR TITLE
Fix "Wanderers Evacuation" to occur in order

### DIFF
--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -1986,7 +1986,7 @@ mission "Wanderers Evacuation 1C"
 	source "Vara K'chrai"
 	destination "Vara Ke'sok"
 	to offer
-		has "Wanderers Evacuation 1: done"
+		has "Wanderers Evacuation 1B: done"
 	on offer
 		conversation
 			`The transports offload the refugees, and one of the captains tells you that they are wanted back on <planet>. But now that you know that Iktat Rek may be dying, perhaps you should visit him while you are here.`


### PR DESCRIPTION
If you land on Vara K'chrai ahead of the transports in `Wanderers Evacuation 1B`, you get the message to wait for the transports and then `Wanderers Evacuation 1C` starts anyway. I think this prevents that, while still preserving the illusion of a single multi-stop mission.

Unfortunately, when trying to test it, I screwed up juggling my snapshots and now have no save from the correct part of the plot.