### PR TITLE
add the "south pirate" attribute to Bloodsea

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -24175,7 +24175,7 @@ planet Bivrost
 		fleet "Large Deep Security" 35
 
 planet Bloodsea
-	attributes pirate
+	attributes pirate "south pirate"
 	landscape land/beach5
 	description `Bloodsea is nearly uninhabited, except for a few pirate outposts. Its name comes from the planet's oceans, which are blood-red due to rhodophyte algae. Although the climate is temperate and there are many white sand beaches, no one comes here hoping to go swimming.`
 	description `	The pirates have no industry of their own, but instead make a living by reselling stolen cargo from raids on merchant fleets.`

--- a/data/map.txt
+++ b/data/map.txt
@@ -24175,7 +24175,7 @@ planet Bivrost
 		fleet "Large Deep Security" 35
 
 planet Bloodsea
-	attributes pirate "south pirate"
+	attributes pirate "south pirate" south frontier
 	landscape land/beach5
 	description `Bloodsea is nearly uninhabited, except for a few pirate outposts. Its name comes from the planet's oceans, which are blood-red due to rhodophyte algae. Although the climate is temperate and there are many white sand beaches, no one comes here hoping to go swimming.`
 	description `	The pirates have no industry of their own, but instead make a living by reselling stolen cargo from raids on merchant fleets.`


### PR DESCRIPTION
Working on missions involving specific regions, turns out Bloodsea is the only southern pirate world without the `"south pirate"` attribute for some reason. Now it is not. Small fix.