### PR TITLE
Allow plugins to explicitly override already-defined missions and outfits

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -107,7 +107,8 @@ void Mission::Load(const DataNode &node)
 		}
 		else
 		{
-			node.PrintTrace("Duplicate definition of mission:");
+			node.PrintTrace("Duplicate definition of mission "
+					"(add \"override\" if intentional):");
 			return;
 		}
 	}

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -92,14 +92,29 @@ void Mission::Load(const DataNode &node)
 		node.PrintTrace("No name specified for mission:");
 		return;
 	}
-	// If a mission object is "loaded" twice, that is most likely an error (e.g.
-	// due to a plugin containing a mission with the same name as the base game
-	// or another plugin). This class is not designed to allow merging or
-	// overriding of mission data from two different definitions.
+	bool isOverride = (node.Size() >= 3 && node.Token(2) == "override");
+	// If a mission object is "loaded" twice, that is most likely an error
+	// (e.g. due to a plugin containing a mission with the same name as the
+	// base game or another plugin). However, sometimes it's useful to
+	// intentionally override a specific mission from a plugin.
 	if(!name.empty())
 	{
-		node.PrintTrace("Duplicate definition of mission:");
-		return;
+		if(isOverride)
+		{
+			// If explicitly requested, start from a blank slate,
+			// so that all data is replaced.
+			*this = Mission();
+		}
+		else
+		{
+			node.PrintTrace("Duplicate definition of mission:");
+			return;
+		}
+	}
+	else if(isOverride)
+	{
+		node.PrintTrace("Warning: overriding a non-existent mission:");
+		// Proceed to load the mission as if override were not given.
 	}
 	name = node.Token(1);
 	

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -46,26 +46,10 @@ void Outfit::Load(const DataNode &node)
 	// Note: an outfit with no name wouldn't be global and therefore
 	// overriding wouldn't make sense (?).
 	bool isOverride = (node.Size() >= 3 && node.Token(2) == "override");
-	if(!name.empty())
-	{
-		if(isOverride)
-		{
-			// If explicitly requested, start from a blank slate,
-			// so that all data is replaced.
-			*this = Outfit();
-		}
-		else
-		{
-			node.PrintTrace("Duplicate definition of outfit "
-					"(add \"override\" if intentional):");
-			return;
-		}
-	}
+	if(!name.empty() && isOverride)
+		*this = Outfit();
 	else if(isOverride)
-	{
 		node.PrintTrace("Warning: overriding a non-existent outfit:");
-		// Proceed to load the outfit as if override were not given.
-	}
 	
 	if(node.Size() >= 2)
 	{

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -43,12 +43,36 @@ const vector<string> Outfit::CATEGORIES = {
 
 void Outfit::Load(const DataNode &node)
 {
+	// Note: an outfit with no name wouldn't be global and therefore
+	// overriding wouldn't make sense (?).
+	bool isOverride = (node.Size() >= 3 && node.Token(2) == "override");
+	if(!name.empty())
+	{
+		if(isOverride)
+		{
+			// If explicitly requested, start from a blank slate,
+			// so that all data is replaced.
+			*this = Outfit();
+		}
+		else
+		{
+			node.PrintTrace("Duplicate definition of outfit "
+					"(add \"override\" if intentional):");
+			return;
+		}
+	}
+	else if(isOverride)
+	{
+		node.PrintTrace("Warning: overriding a non-existent outfit:");
+		// Proceed to load the outfit as if override were not given.
+	}
+	
 	if(node.Size() >= 2)
 	{
 		name = node.Token(1);
 		pluralName = name + 's';
 	}
-	
+
 	for(const DataNode &child : node)
 	{
 		if(child.Token(0) == "category" && child.Size() >= 2)

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -56,7 +56,7 @@ void Outfit::Load(const DataNode &node)
 		name = node.Token(1);
 		pluralName = name + 's';
 	}
-
+	
 	for(const DataNode &child : node)
 	{
 		if(child.Token(0) == "category" && child.Size() >= 2)


### PR DESCRIPTION
Related to #3996 and #4487.

I wanted to make a plugin that made a minor change to the way the stock "Hunt Down \<npc>" missions worked, but found that there was no way either to prevent the stock missions from appearing or to override any aspect of their behavior. Disabling the stock missions (e.g. with #3996) and making my own copies with unique names would be a workable solution, but would result in separate counts for e.g. `"Bounty Hunting (Small): offered"` and `"Fancy Plugin Name Bounty Hunting (Small): offered"`; in this particular case there would be no real harm, but I can easily imagine use cases where that would be bad. Manual and tedious condition-massaging would fix it, but this solution is far simpler...

Current behavior is that when a mission is loaded with the same name as an existing mission, the new data is completely ignored. This PR makes it so that a mission can explicitly tag itself as an `override`, in which case it will entirely replace any existing mission with the same name. The onus for dealing with the consequences is on the plugin developer, as expected when tampering with stock data.

Example:

```
mission "Bounty Hunting (Small)" override
    (mission data goes here)
```

Existing behavior in the absence of `override` tag is not changed. If a mission with an `override` tag does not share the same name as an existing mission, a warning is printed and the mission is loaded anyway.