### PR TITLE
Remnant keystone no longer requries license

### DIFF
--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -334,8 +334,6 @@ outfit "Emergency Ramscoop"
 
 outfit "Quantum Key Stone"
 	category "Systems"
-	licenses
-		Remnant
 	cost 240000
 	thumbnail "outfit/keystone"
 	"mass" 1


### PR DESCRIPTION
There has been at least one player who's had a save broken due to losing all keystones in remnant space before obtaining the license (https://steamcommunity.com/app/404410/discussions/0/1639794651173778949/), and therefore being trapped* in it. Although this PR doesn't prevent it from happening, it does make it much easier to escape remnant space. It also makes life easier for players who are outfitting in remnant space and don't want to go all the way up to hai territory.

Admittedly, it's a bit inconsistent with the lore, since the remnant probably wouldn't sell stones to an outsider, but I don't think anyone's going to uninstall the game over that.
*This is technically escapable by two methods, but neither are very intuitive.