### PR TITLE
Added additional Remnant: Key Stones missions 

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -398,6 +398,7 @@ mision "Remnant: Key Stones (Pre-Hai) 1"
 	to offer
 		not "Remnant: Key Stones (Hai): offered"
 		not "Remnant: Key Stones: offered"
+		not "First Contact: Hai: offered"
 		or
 			has "event: remnant: void sprite research"
 			has "Remnant: Defense 3: done"

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -317,6 +317,9 @@ event "remnant: surveillance end"
 
 
 conversation "remnant key stones"
+	branch found
+		has "Remnant: Found Keystones: offered"
+	
 	`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. "Greetings, outsider," he says. "I have heard many good things about you and your assistance to our people. Would you be interested in going on a quest for me?"`
 	choice
 		`	"What kind of quest?"`
@@ -342,9 +345,15 @@ conversation "remnant key stones"
 	`	The outfitter manager thanks you. "We'll discuss payment once you return," he says.`
 		accept
 	
+	label found
+	`You find the outfitter manager and tell him that you have good news. "You found another world where the stones can be mined?" he asks.`
+		goto exchange
+	
 	label hai1
 	`	"I've seen that before," you say.`
 	`	He looks at you with surprise. "You found another world where these stones can be mined?"`
+	
+	label exchange
 	choice
 		`	"Yes, in the territory of some aliens far to the north of here."`
 			goto hai2
@@ -418,30 +427,8 @@ mission "Remnant: Key Stones (Pre-Hai) 2"
 	to offer
 		has "Remnant: Key Stones (Pre-Hai) 1: done"
 	on offer
-		conversation
-			`You find the outfitter manager and tell him that you have good news. "You found another world where the stones can be mined?" he asks.`
-			choice
-				`	"Yes, in the territory of some aliens far to the north of here."`
-					goto hai
-				`	"Yes, but I would prefer not to tell you where."`
-			
-			`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
-				goto more
-			
-			label hai
-			`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
-			
-			label more
-			`	"Tell me more," you say.`
-			`	He says, "If you could fetch me a large supply of these stones, say fifty of them, I would purchase them from you for a high enough price that you would earn a tidy profit. What do you say?"`
-			choice
-				`	"Sure, I would be glad to accept that deal."`
-				`	"Sorry, I'm really not interested in doing business with you Remnant folks."`
-					decline
-			
-			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
-				accept
-			
+		conversation "remnant key stones"
+		
 	on visit
 		dialog `You have returned to <planet>, but you don't have 50 "Quantum Keystones" to give to the outfitter. Buy the Keystones from the Hai before returning here.`
 	on complete

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -316,12 +316,12 @@ event "remnant: surveillance end"
 
 
 
-mision "Remnant: Key Stones (Pre-Hai)"
+mision "Remnant: Key Stones (Pre-Hai) 1"
 	name "Key Stones"
 	description "The manager of the outfitter on <planet> is interested in finding alternative sources of Key Stones. The Remnant have explored the entire Ember Waste, so you will need to search elsewhere for these stones."
 	source "Viminal"
 	to offer
-		not "Remnant: Key Stones (Pre-Hai): offered"
+		not "Remnant: Key Stones (Hai): offered"
 		not "Remnant: Key Stones: offered"
 		or
 			has "event: remnant: void sprite research"
@@ -338,7 +338,9 @@ mision "Remnant: Key Stones (Pre-Hai)"
 			`	"Please, I assure you, this quest will be very lucrative for you.`
 			
 			label quest
-			`	"You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them. We have explored all of the Ember Waste, but have been unable to find any large concentrations of these stones."
+			`	"You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them." The manager shows you a Key Stone that he has with him.`
+			scene "outfit/keystone"`
+			`	"We have explored all of the Ember Waste, but have been unable to find any large concentrations of these stones."
 			`	"You seem to be able to easily explore outside of this region. If you manage to discover a source of Key Stones outside of the Ember Waste, would you please inform me of them?"`
 			choice
 				`	"If I find anything, I'll let you know."`
@@ -399,6 +401,15 @@ mission "Remnant: Key Stones (Pre-Hai) 2"
 
 			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
 				accept
+			
+	on visit
+		dialog `You have returned to <planet>, but you don't have 50 "Quantum Keystones" to give to the outfitter. Buy the Keystones from the Hai before returning here.`
+	on complete
+		outfit "Quantum Keystone" -50
+		payment 6000000
+		conversation
+			`You visit the local outfitter and tell the manager that you have brought a shipment of "Quantum Keystones" to sell to him. He is overjoyed, and gladly pays you six million credits for them. You can't help noticing that based on how much the Key Stones sell for here, he will be earning even more profit than you did, even though you did nearly all the work.`
+			`	"You have made a valuable contribution to our people by doing this," he says. "These stones will allow more of our ships to explore the Ember Waste and discover the secrets that it holds."`
 	
 	
 	
@@ -408,7 +419,7 @@ mision "Remnant: Key Stones (Hai)"
 	description "The manager of the outfitter on <planet> has offered to pay you six million credits in exchange for a shipment of fifty Quantum Keystones (which you will have to purchase from the Hai)."
 	source "Viminal"
 	to offer
-		not "Remnant: Key Stones (Pre-Hai): offered"
+		not "Remnant: Key Stones (Pre-Hai) 1: offered"
 		not "Remnant: Key Stones: offered"
 		has "First Contact: Hai: offered"
 		or
@@ -451,6 +462,15 @@ mision "Remnant: Key Stones (Hai)"
 
 			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
 				accept
+			
+	on visit
+		dialog `You have returned to <planet>, but you don't have 50 "Quantum Keystones" to give to the outfitter. Buy the Keystones from the Hai before returning here.`
+	on complete
+		outfit "Quantum Keystone" -50
+		payment 6000000
+		conversation
+			`You visit the local outfitter and tell the manager that you have brought a shipment of "Quantum Keystones" to sell to him. He is overjoyed, and gladly pays you six million credits for them. You can't help noticing that based on how much the Key Stones sell for here, he will be earning even more profit than you did, even though you did nearly all the work.`
+			`	"You have made a valuable contribution to our people by doing this," he says. "These stones will allow more of our ships to explore the Ember Waste and discover the secrets that it holds."`
 		
 
 
@@ -460,7 +480,7 @@ mission "Remnant: Key Stones"
 	source "Viminal"
 	to offer
 		has "remnant blood test pure"
-		not "Remnant: Key Stones (Pre-Hai): offered"
+		not "Remnant: Key Stones (Pre-Hai) 1: offered"
 		not "Remnant: Key Stones (Hai): offered"
 	on offer
 		require "Quantum Keystone"
@@ -704,8 +724,11 @@ mission "Remnant: Technology Available"
 		government "Remnant"
 	to offer
 		has "event: remnant: void sprite research"
-		has "Remnant: Key Stones: done"
 		has "Remnant: Defense 3: done"
+		or
+			has "Remnant: Key Stones: done"
+			has "Remnant: Key Stones (Hai): done"
+			has "Remnant: Key Stones (Pre-Hai) 2: done"
 	on offer
 		payment 2000000
 		set "license: Remnant"

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -316,6 +316,81 @@ event "remnant: surveillance end"
 
 
 
+conversation "remnant key stones"
+	branch normal
+		has "Remnant: Key Stones: offered"
+	
+	branch found
+		has "Remnant: Found Keystones: offered"
+	
+	`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. "Greetings, outsider," he says. "I have heard many good things about you and your assistance to our people. Would you be interested in going on a quest for me?"`
+	choice
+		`	"What kind of quest?"`
+			goto quest
+		`	"Sorry, I'm not interested."`
+
+	`	"Please, I assure you, this quest will be very lucrative for you.`
+
+	label quest
+	`	"You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them." The manager shows you a Key Stone that he has with him.`
+	scene "outfit/keystone"`
+	
+	branch hai
+		has "First Contact: Hai: offered"
+	
+	`	"We have explored all of the Ember Waste, but have been unable to find any large concentrations of these stones."
+	`	"You seem to be able to easily explore outside of this region. If you manage to discover a source of Key Stones outside of the Ember Waste, would you please inform me of them?"`
+	choice
+		`	"If I find anything, I'll let you know."`
+		`	"No thanks. This seems like a wild goose chase to me."`
+			decline
+
+	`	The outfitter manager thanks you. "We'll discuss payment once you return," he says.`
+		accept
+	
+	label found
+	`You find the outfitter manager and tell him that you have good news. "You found another world where the stones can be mined?" he asks.`
+		goto exchange
+	
+	label hai
+	`	"I've seen that before," you say.`
+	`	He looks at you with surprise. "You found another world where these stones can be mined?"`
+		goto exchange
+	
+	label normal
+	`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. He says, "I could not help but notice that you have a Key Stone that looks different from the ones from our mines. You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them. Have you found another world where these stones can be mined?"`
+	
+	label exchange
+	choice
+		`	"Yes, in the territory of some aliens far to the north of here."`
+			goto hai
+		`	"Yes, but I would prefer not to tell you where."`
+
+	`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
+		goto more
+
+	label hai
+	`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
+
+	label more
+	`	"Tell me more," you say.`
+	`	He says, "If you could fetch me a large supply of these stones, say fifty of them, I would purchase them from you for a high enough price that you would earn a tidy profit. What do you say?"`
+	choice
+		`	"Sure, I would be glad to accept that deal."`
+		`	"Sorry, I'm really not interested in doing business with you Remnant folks."`
+			decline
+
+	`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
+		accept
+
+
+
+conversation "remnant key stones done"
+	`You visit the local outfitter and tell the manager that you have brought a shipment of "Quantum Keystones" to sell to him. He is overjoyed, and gladly pays you six million credits for them. You can't help noticing that based on how much the Key Stones sell for here, he will be earning even more profit than you did, even though you did nearly all the work.`
+	`	"You have made a valuable contribution to our people by doing this," he says. "These stones will allow more of our ships to explore the Ember Waste and discover the secrets that it holds."`
+
+
+
 mision "Remnant: Key Stones (Pre-Hai) 1"
 	name "Key Stones"
 	description "The manager of the outfitter on <planet> is interested in finding alternative sources of Key Stones. The Remnant have explored the entire Ember Waste, so you will need to search elsewhere for these stones."
@@ -328,27 +403,7 @@ mision "Remnant: Key Stones (Pre-Hai) 1"
 			has "Remnant: Defense 3: done"
 	on offer
 		require "Quantum Keystone" 0
-		conversation
-			`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. "Greetings, outsider," he says. "I have heard many good things about you and your assistance to our people. Would you be interested in going on a quest for me?"`
-			choice
-				`	"What kind of quest?"`
-					goto quest
-				`	"Sorry, I'm not interested."`
-			
-			`	"Please, I assure you, this quest will be very lucrative for you.`
-			
-			label quest
-			`	"You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them." The manager shows you a Key Stone that he has with him.`
-			scene "outfit/keystone"`
-			`	"We have explored all of the Ember Waste, but have been unable to find any large concentrations of these stones."
-			`	"You seem to be able to easily explore outside of this region. If you manage to discover a source of Key Stones outside of the Ember Waste, would you please inform me of them?"`
-			choice
-				`	"If I find anything, I'll let you know."`
-				`	"No thanks. This seems like a wild goose chase to me."`
-					decline
-			
-			`	The outfitter manager thanks you. "We'll discuss payment once you return," he says.`
-				accept
+		conversation "remnant key stones"
 		
 	to complete
 		has "Remnant: Found Keystones: offered"
@@ -378,38 +433,14 @@ mission "Remnant: Key Stones (Pre-Hai) 2"
 	to offer
 		has "Remnant: Key Stones (Pre-Hai): done"
 	on offer
-		conversation
-			`You find the outfitter manager and tell him that you have good news. "You found another world where these stones can be mined?" he asks.`
-			choice
-				`	"Yes, in the territory of some aliens far to the north of here."`
-					goto hai
-				`	"Yes, but I would prefer not to tell you where."`
-
-			`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
-				goto more
-
-			label hai
-			`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
-
-			label more
-			`	"Tell me more," you say.`
-			`	He says, "If you could fetch me a large supply of these stones, say fifty of them, I would purchase them from you for a high enough price that you would earn a tidy profit. What do you say?"`
-			choice
-				`	"Sure, I would be glad to accept that deal."`
-				`	"Sorry, I'm really not interested in doing business with you Remnant folks."`
-					decline
-
-			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
-				accept
+		conversation "remnant key stones"
 			
 	on visit
 		dialog `You have returned to <planet>, but you don't have 50 "Quantum Keystones" to give to the outfitter. Buy the Keystones from the Hai before returning here.`
 	on complete
 		outfit "Quantum Keystone" -50
 		payment 6000000
-		conversation
-			`You visit the local outfitter and tell the manager that you have brought a shipment of "Quantum Keystones" to sell to him. He is overjoyed, and gladly pays you six million credits for them. You can't help noticing that based on how much the Key Stones sell for here, he will be earning even more profit than you did, even though you did nearly all the work.`
-			`	"You have made a valuable contribution to our people by doing this," he says. "These stones will allow more of our ships to explore the Ember Waste and discover the secrets that it holds."`
+		conversation "remnant key stones done"
 	
 	
 	
@@ -427,50 +458,14 @@ mision "Remnant: Key Stones (Hai)"
 			has "Remnant: Defense 3: done"
 	on offer
 		require "Quantum Keystone" 0
-		conversation
-			`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. "Greetings, outsider," he says. "I have heard many good things about you and your assistance to our people. Would you be interested in going on a quest for me?"`
-			choice
-				`	"What kind of quest?"`
-					goto quest
-				`	"Sorry, I'm not interested."`
-			
-			`	"Please, I assure you, this quest will be very lucrative for you.`
-			
-			label quest
-			`	"You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them." The manager shows you a Key Stone that he has with him.`
-			scene "outfit/keystone"
-			`	"I've seen that before," you say.`
-			`	He looks at you with surprise. "You found another world where these stones can be mined?"`
-			choice
-				`	"Yes, in the territory of some aliens far to the north of here."`
-					goto hai
-				`	"Yes, but I would prefer not to tell you where."`
-
-			`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
-				goto more
-
-			label hai
-			`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
-
-			label more
-			`	"Tell me more," you say.`
-			`	He says, "If you could fetch me a large supply of these stones, say fifty of them, I would purchase them from you for a high enough price that you would earn a tidy profit. What do you say?"`
-			choice
-				`	"Sure, I would be glad to accept that deal."`
-				`	"Sorry, I'm really not interested in doing business with you Remnant folks."`
-					decline
-
-			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
-				accept
+		conversation "remnant key stones"
 			
 	on visit
 		dialog `You have returned to <planet>, but you don't have 50 "Quantum Keystones" to give to the outfitter. Buy the Keystones from the Hai before returning here.`
 	on complete
 		outfit "Quantum Keystone" -50
 		payment 6000000
-		conversation
-			`You visit the local outfitter and tell the manager that you have brought a shipment of "Quantum Keystones" to sell to him. He is overjoyed, and gladly pays you six million credits for them. You can't help noticing that based on how much the Key Stones sell for here, he will be earning even more profit than you did, even though you did nearly all the work.`
-			`	"You have made a valuable contribution to our people by doing this," he says. "These stones will allow more of our ships to explore the Ember Waste and discover the secrets that it holds."`
+		conversation "remnant key stones done"
 		
 
 
@@ -484,38 +479,14 @@ mission "Remnant: Key Stones"
 		not "Remnant: Key Stones (Hai): offered"
 	on offer
 		require "Quantum Keystone"
-		conversation
-			`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. He says, "I could not help but notice that you have a Key Stone that looks different from the ones from our mines. Have you found another world where these stones can be mined?"`
-			choice
-				`	"Yes, in the territory of some aliens far to the north of here."`
-					goto hai
-				`	"Yes, but I would prefer not to tell you where."`
-
-			`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
-				goto more
-
-			label hai
-			`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
-
-			label more
-			`	"Tell me more," you say.`
-			`	He says, "If you could fetch me a large supply of these stones, say fifty of them, I would purchase them from you for a high enough price that you would earn a tidy profit. What do you say?"`
-			choice
-				`	"Sure, I would be glad to accept that deal."`
-				`	"Sorry, I'm really not interested in doing business with you Remnant folks."`
-					decline
-
-			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
-				accept
+		conversation "remnant key stones"
 	
 	on visit
 		dialog `You have returned to <planet>, but you don't have 50 "Quantum Keystones" to give to the outfitter. Buy the Keystones from the Hai before returning here.`
 	on complete
 		outfit "Quantum Keystone" -50
 		payment 6000000
-		conversation
-			`You visit the local outfitter and tell the manager that you have brought a shipment of "Quantum Keystones" to sell to him. He is overjoyed, and gladly pays you six million credits for them. You can't help noticing that based on how much the Key Stones sell for here, he will be earning even more profit than you did, even though you did nearly all the work.`
-			`	"You have made a valuable contribution to our people by doing this," he says. "These stones will allow more of our ships to explore the Ember Waste and discover the secrets that it holds."`
+		conversation "remnant key stones done"
 
 
 

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -316,12 +316,152 @@ event "remnant: surveillance end"
 
 
 
+mision "Remnant: Key Stones (Pre-Hai)"
+	name "Key Stones"
+	description "The manager of the outfitter on <planet> is interested in finding alternative sources of Key Stones. The Remnant have explored the entire Ember Waste, so you will need to search elsewhere for these stones."
+	source "Viminal"
+	to offer
+		not "Remnant: Key Stones (Pre-Hai): offered"
+		not "Remnant: Key Stones: offered"
+		or
+			has "event: remnant: void sprite research"
+			has "Remnant: Defense 3: done"
+	on offer
+		require "Quantum Keystone" 0
+		conversation
+			`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. "Greetings, outsider," he says. "I have heard many good things about you and your assistance to our people. Would you be interested in going on a quest for me?"`
+			choice
+				`	"What kind of quest?"`
+					goto quest
+				`	"Sorry, I'm not interested."`
+			
+			`	"Please, I assure you, this quest will be very lucrative for you.`
+			
+			label quest
+			`	"You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them. We have explored all of the Ember Waste, but have been unable to find any large concentrations of these stones."
+			`	"You seem to be able to easily explore outside of this region. If you manage to discover a source of Key Stones outside of the Ember Waste, would you please inform me of them?"`
+			choice
+				`	"If I find anything, I'll let you know."`
+				`	"No thanks. This seems like a wild goose chase to me."`
+					decline
+			
+			`	The outfitter manager thanks you. "We'll discuss payment once you return," he says.`
+				accept
+		
+	to complete
+		has "Remnant: Found Keystones: offered"
+
+
+
+mission "Remnant: Found Keystones"
+	landing
+	invisible
+	source
+		government "Hai"
+	to offer
+		has "First Contact: Hai: offered"
+	on offer
+		conversation
+			`While exploring the Hai spaceport, you notice something interesting about some of the Hai ships. Many of them appear to be decorated with a stone that looks very similar to the Quantum Key Stones found in the Ember Waste. You ask a nearby Hai what they are, and she tells you that the stones are good luck charms that many Hai use on their ships that can be purchased from any Hai outfitter.`
+			`	You should return to the Remnant outfitter manager to tell him about the stones in Hai space.`
+				decline
+
+
+
+mission "Remnant: Key Stones (Pre-Hai) 2"
+	landing
+	name "Key Stones"
+	description "The manager of the outfitter on <planet> has offered to pay you six million credits in exchange for a shipment of fifty Quantum Keystones (which you will have to purchase from the Hai)."
+	source "Viminal"
+	to offer
+		has "Remnant: Key Stones (Pre-Hai): done"
+	on offer
+		conversation
+			`You find the outfitter manager and tell him that you have good news. "You found another world where these stones can be mined?" he asks.`
+			choice
+				`	"Yes, in the territory of some aliens far to the north of here."`
+					goto hai
+				`	"Yes, but I would prefer not to tell you where."`
+
+			`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
+				goto more
+
+			label hai
+			`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
+
+			label more
+			`	"Tell me more," you say.`
+			`	He says, "If you could fetch me a large supply of these stones, say fifty of them, I would purchase them from you for a high enough price that you would earn a tidy profit. What do you say?"`
+			choice
+				`	"Sure, I would be glad to accept that deal."`
+				`	"Sorry, I'm really not interested in doing business with you Remnant folks."`
+					decline
+
+			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
+				accept
+	
+	
+	
+	
+mision "Remnant: Key Stones (Hai)"
+	name "Keystones"
+	description "The manager of the outfitter on <planet> has offered to pay you six million credits in exchange for a shipment of fifty Quantum Keystones (which you will have to purchase from the Hai)."
+	source "Viminal"
+	to offer
+		not "Remnant: Key Stones (Pre-Hai): offered"
+		not "Remnant: Key Stones: offered"
+		has "First Contact: Hai: offered"
+		or
+			has "event: remnant: void sprite research"
+			has "Remnant: Defense 3: done"
+	on offer
+		require "Quantum Keystone" 0
+		conversation
+			`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. "Greetings, outsider," he says. "I have heard many good things about you and your assistance to our people. Would you be interested in going on a quest for me?"`
+			choice
+				`	"What kind of quest?"`
+					goto quest
+				`	"Sorry, I'm not interested."`
+			
+			`	"Please, I assure you, this quest will be very lucrative for you.`
+			
+			label quest
+			`	"You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them." The manager shows you a Key Stone that he has with him.`
+			scene "outfit/keystone"
+			`	"I've seen that before," you say.`
+			`	He looks at you with surprise. "You found another world where these stones can be mined?"`
+			choice
+				`	"Yes, in the territory of some aliens far to the north of here."`
+					goto hai
+				`	"Yes, but I would prefer not to tell you where."`
+
+			`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
+				goto more
+
+			label hai
+			`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
+
+			label more
+			`	"Tell me more," you say.`
+			`	He says, "If you could fetch me a large supply of these stones, say fifty of them, I would purchase them from you for a high enough price that you would earn a tidy profit. What do you say?"`
+			choice
+				`	"Sure, I would be glad to accept that deal."`
+				`	"Sorry, I'm really not interested in doing business with you Remnant folks."`
+					decline
+
+			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
+				accept
+		
+
+
 mission "Remnant: Key Stones"
 	name "Keystones"
 	description "The manager of the outfitter on <planet> has offered to pay you six million credits in exchange for a shipment of fifty Quantum Keystones (which you will have to purchase from the Hai)."
 	source "Viminal"
 	to offer
 		has "remnant blood test pure"
+		not "Remnant: Key Stones (Pre-Hai): offered"
+		not "Remnant: Key Stones (Hai): offered"
 	on offer
 		require "Quantum Keystone"
 		conversation

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -335,7 +335,7 @@ conversation "remnant key stones"
 	`	"You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them." The manager shows you a Key Stone that he has with him.`
 	scene "outfit/keystone"`
 	
-	branch hai
+	branch hai1
 		has "First Contact: Hai: offered"
 	
 	`	"We have explored all of the Ember Waste, but have been unable to find any large concentrations of these stones."
@@ -352,7 +352,7 @@ conversation "remnant key stones"
 	`You find the outfitter manager and tell him that you have good news. "You found another world where the stones can be mined?" he asks.`
 		goto exchange
 	
-	label hai
+	label hai1
 	`	"I've seen that before," you say.`
 	`	He looks at you with surprise. "You found another world where these stones can be mined?"`
 		goto exchange
@@ -363,13 +363,13 @@ conversation "remnant key stones"
 	label exchange
 	choice
 		`	"Yes, in the territory of some aliens far to the north of here."`
-			goto hai
+			goto hai2
 		`	"Yes, but I would prefer not to tell you where."`
 
 	`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
 		goto more
 
-	label hai
+	label hai2
 	`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
 
 	label more

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -419,6 +419,7 @@ mission "Remnant: Found Keystones"
 	to offer
 		has "First Contact: Hai: offered"
 	on offer
+		"Remnant: Found Keystones: offered" ++
 		conversation
 			`While exploring the Hai spaceport, you notice something interesting about some of the Hai ships. Many of them appear to be decorated with a stone that looks very similar to the Quantum Key Stones found in the Ember Waste. You ask a nearby Hai what they are, and she tells you that the stones are good luck charms that many Hai use on their ships that can be purchased from any Hai outfitter.`
 			`	You should return to the Remnant outfitter manager to tell him about the stones in Hai space.`
@@ -480,6 +481,7 @@ mission "Remnant: Key Stones"
 		not "Remnant: Key Stones (Hai): offered"
 	on offer
 		require "Quantum Keystone"
+		"Remnant: Key Stones: offered" ++
 		conversation "remnant key stones"
 	
 	on visit

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -432,7 +432,7 @@ mission "Remnant: Key Stones (Pre-Hai) 2"
 	description "The manager of the outfitter on <planet> has offered to pay you six million credits in exchange for a shipment of fifty Quantum Keystones (which you will have to purchase from the Hai)."
 	source "Viminal"
 	to offer
-		has "Remnant: Key Stones (Pre-Hai): done"
+		has "Remnant: Key Stones (Pre-Hai) 1: done"
 	on offer
 		conversation "remnant key stones"
 			

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -317,12 +317,6 @@ event "remnant: surveillance end"
 
 
 conversation "remnant key stones"
-	branch normal
-		has "Remnant: Key Stones: offered"
-	
-	branch found
-		has "Remnant: Found Keystones: offered"
-	
 	`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. "Greetings, outsider," he says. "I have heard many good things about you and your assistance to our people. Would you be interested in going on a quest for me?"`
 	choice
 		`	"What kind of quest?"`
@@ -344,34 +338,24 @@ conversation "remnant key stones"
 		`	"If I find anything, I'll let you know."`
 		`	"No thanks. This seems like a wild goose chase to me."`
 			decline
-
+	
 	`	The outfitter manager thanks you. "We'll discuss payment once you return," he says.`
 		accept
-	
-	label found
-	`You find the outfitter manager and tell him that you have good news. "You found another world where the stones can be mined?" he asks.`
-		goto exchange
 	
 	label hai1
 	`	"I've seen that before," you say.`
 	`	He looks at you with surprise. "You found another world where these stones can be mined?"`
-		goto exchange
-	
-	label normal
-	`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. He says, "I could not help but notice that you have a Key Stone that looks different from the ones from our mines. You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them. Have you found another world where these stones can be mined?"`
-	
-	label exchange
 	choice
 		`	"Yes, in the territory of some aliens far to the north of here."`
 			goto hai2
 		`	"Yes, but I would prefer not to tell you where."`
-
+	
 	`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
 		goto more
-
+	
 	label hai2
 	`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
-
+	
 	label more
 	`	"Tell me more," you say.`
 	`	He says, "If you could fetch me a large supply of these stones, say fifty of them, I would purchase them from you for a high enough price that you would earn a tidy profit. What do you say?"`
@@ -379,7 +363,7 @@ conversation "remnant key stones"
 		`	"Sure, I would be glad to accept that deal."`
 		`	"Sorry, I'm really not interested in doing business with you Remnant folks."`
 			decline
-
+	
 	`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
 		accept
 
@@ -419,7 +403,6 @@ mission "Remnant: Found Keystones"
 	to offer
 		has "First Contact: Hai: offered"
 	on offer
-		"Remnant: Found Keystones: offered" ++
 		conversation
 			`While exploring the Hai spaceport, you notice something interesting about some of the Hai ships. Many of them appear to be decorated with a stone that looks very similar to the Quantum Key Stones found in the Ember Waste. You ask a nearby Hai what they are, and she tells you that the stones are good luck charms that many Hai use on their ships that can be purchased from any Hai outfitter.`
 			`	You should return to the Remnant outfitter manager to tell him about the stones in Hai space.`
@@ -435,7 +418,29 @@ mission "Remnant: Key Stones (Pre-Hai) 2"
 	to offer
 		has "Remnant: Key Stones (Pre-Hai) 1: done"
 	on offer
-		conversation "remnant key stones"
+		conversation
+			`You find the outfitter manager and tell him that you have good news. "You found another world where the stones can be mined?" he asks.`
+			choice
+				`	"Yes, in the territory of some aliens far to the north of here."`
+					goto hai
+				`	"Yes, but I would prefer not to tell you where."`
+			
+			`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
+				goto more
+			
+			label hai
+			`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
+			
+			label more
+			`	"Tell me more," you say.`
+			`	He says, "If you could fetch me a large supply of these stones, say fifty of them, I would purchase them from you for a high enough price that you would earn a tidy profit. What do you say?"`
+			choice
+				`	"Sure, I would be glad to accept that deal."`
+				`	"Sorry, I'm really not interested in doing business with you Remnant folks."`
+					decline
+			
+			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
+				accept
 			
 	on visit
 		dialog `You have returned to <planet>, but you don't have 50 "Quantum Keystones" to give to the outfitter. Buy the Keystones from the Hai before returning here.`
@@ -481,8 +486,29 @@ mission "Remnant: Key Stones"
 		not "Remnant: Key Stones (Hai): offered"
 	on offer
 		require "Quantum Keystone"
-		"Remnant: Key Stones: offered" ++
-		conversation "remnant key stones"
+		conversation
+			`As you are walking through the spaceport, a man comes up to you and introduces himself as the manager of the local outfitter. He says, "I could not help but notice that you have a Key Stone that looks different from the ones from our mines. You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them. Have you found another world where these stones can be mined?"`
+			choice
+				`	"Yes, in the territory of some aliens far to the north of here."`
+					goto hai
+				`	"Yes, but I would prefer not to tell you where."`
+			
+			`	"That is understandable," he says. "I am a businessman and I understand how valuable certain trade secrets can be. But perhaps I can interest you in a mutually profitable endeavor?"`
+				goto more
+			
+			label hai
+			`	"Intriguing," he sings. "Are they aware of how valuable these stones are?" You tell him about the Hai, that they are an old species and that to them the Key Stones are just good luck charms. "Perhaps they have forgotten the true use of the Stones," says the man. "This may give us an opportunity for a mutually profitable endeavor."`
+			
+			label more
+			`	"Tell me more," you say.`
+			`	He says, "If you could fetch me a large supply of these stones, say fifty of them, I would purchase them from you for a high enough price that you would earn a tidy profit. What do you say?"`
+			choice
+				`	"Sure, I would be glad to accept that deal."`
+				`	"Sorry, I'm really not interested in doing business with you Remnant folks."`
+					decline
+			
+			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
+				accept
 	
 	on visit
 		dialog `You have returned to <planet>, but you don't have 50 "Quantum Keystones" to give to the outfitter. Buy the Keystones from the Hai before returning here.`

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -333,12 +333,12 @@ conversation "remnant key stones"
 
 	label quest
 	`	"You may have noticed the red anomalies scattered within this region of space. What you may not have known is that these are wormholes, accessible only with the possession of a Quantum Key Stone. My people highly value these Key Stones because of this, but our mines produce very few of them." The manager shows you a Key Stone that he has with him.`
-	scene "outfit/keystone"`
+	scene "outfit/keystone"
 	
 	branch hai1
 		has "First Contact: Hai: offered"
 	
-	`	"We have explored all of the Ember Waste, but have been unable to find any large concentrations of these stones."
+	`	"We have explored all of the Ember Waste, but have been unable to find any large concentrations of these stones."`
 	`	"You seem to be able to easily explore outside of this region. If you manage to discover a source of Key Stones outside of the Ember Waste, would you please inform me of them?"`
 	choice
 		`	"If I find anything, I'll let you know."`
@@ -391,7 +391,7 @@ conversation "remnant key stones done"
 
 
 
-mision "Remnant: Key Stones (Pre-Hai) 1"
+mission "Remnant: Key Stones (Pre-Hai) 1"
 	name "Key Stones"
 	description "The manager of the outfitter on <planet> is interested in finding alternative sources of Key Stones. The Remnant have explored the entire Ember Waste, so you will need to search elsewhere for these stones."
 	source "Viminal"
@@ -446,7 +446,7 @@ mission "Remnant: Key Stones (Pre-Hai) 2"
 	
 	
 	
-mision "Remnant: Key Stones (Hai)"
+mission "Remnant: Key Stones (Hai)"
 	name "Keystones"
 	description "The manager of the outfitter on <planet> has offered to pay you six million credits in exchange for a shipment of fifty Quantum Keystones (which you will have to purchase from the Hai)."
 	source "Viminal"

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -788,20 +788,14 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	if(it != actions.end() && !it->second.CanBeDone(player, boardingShip))
 		return false;
 	
-	if(trigger == OFFER)
+	if(trigger == ACCEPT)
 	{
 		++player.Conditions()[name + ": offered"]; 
-	}
-	else if(trigger == DEFER)
-	{
-		--player.Conditions()[name + ": offered"]; 
-	}
-	else if(trigger == ACCEPT)
-	{
 		++player.Conditions()[name + ": active"];
 	}
 	else if(trigger == DECLINE)
 	{
+		++player.Conditions()[name + ": offered"]; 
 		++player.Conditions()[name + ": declined"];
 	}
 	else if(trigger == FAIL)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -790,12 +790,12 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	
 	if(trigger == ACCEPT)
 	{
-		++player.Conditions()[name + ": offered"]; 
+		++player.Conditions()[name + ": offered"];
 		++player.Conditions()[name + ": active"];
 	}
 	else if(trigger == DECLINE)
 	{
-		++player.Conditions()[name + ": offered"]; 
+		++player.Conditions()[name + ": offered"];
 		++player.Conditions()[name + ": declined"];
 	}
 	else if(trigger == FAIL)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -788,14 +788,20 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	if(it != actions.end() && !it->second.CanBeDone(player, boardingShip))
 		return false;
 	
-	if(trigger == ACCEPT)
+	if(trigger == OFFER)
 	{
-		++player.Conditions()[name + ": offered"];
+		++player.Conditions()[name + ": offered"]; 
+	}
+	else if(trigger == DEFER)
+	{
+		--player.Conditions()[name + ": offered"]; 
+	}
+	else if(trigger == ACCEPT)
+	{
 		++player.Conditions()[name + ": active"];
 	}
 	else if(trigger == DECLINE)
 	{
-		++player.Conditions()[name + ": offered"];
 		++player.Conditions()[name + ": declined"];
 	}
 	else if(trigger == FAIL)


### PR DESCRIPTION
Ref: #4409 #4491
These additional missions account for the player not always reaching the Ember Waste with a Quantum Keystone. These missions also make it explicit to the player that the keystones are used to enter the wormholes in the region.

The possible scenarios are now as follows:
* The player arrives in the Ember Waste with a Hai Keystone and is approached by the outfitter manager. This is currently the only possible way to progress the Remnant story.
* The player arrives in the Ember Waste without a Hai Keystone, but does know about the Hai. After helping the Remnant with one set of missions, the outfitter manager may approach the player asking them to search for alternative sources of Key Stones, to which the player will answer that they know of one such location.
* The player arrives in the Ember Waste without a Hai Keystone, but does NOT know about the Hai. After helping the Remnant with one set of missions, the outfitter manager may approach the player asking them to search for alternative sources of Key Stones. The player will then accept the mission to search for new sources. After finding the Hai, the player may return to the manager and tell them about having found an alternative source.

If the player is offered any of the three missions and declines, they won't be able to be offered the other two missions. 