### PR TITLE
Changed the Quicksilver (Mark II)'s outfits

### DIFF
--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1727,12 +1727,12 @@ ship "Protector" "Protector (Proton)"
 ship "Quicksilver" "Quicksilver (Mark II)"
 	outfits
 		"Particle Cannon" 2
-		"RT-I Radiothermal"
+		"Fission Reactor"
 		"LP036a Battery Pack"
-		"D23-QP Shield Generator"
-		"Cooling Ducts"
-		"Greyhound Plasma Thruster"
-		"Greyhound Plasma Steering"
+		"S-270 Regenerator"
+		"Water Coolant System"
+		"A250 Atomic Thruster"
+		"A255 Atomic Steering"
 		"Hyperdrive"
 
 


### PR DESCRIPTION
As of right now, the Quicksilver and Quicksilver (Mark II) have the *exact* same outfits. This PR changes the Mark II's outfits, upgrading it in the same way that the other Syndicate Mark II ships are upgraded (new shield gennies, better cooling, better power generation, atomic engines), excluding the addition of an Ionic Afterburner.

Error caught by @Kryes-Omega.