### PR TITLE
Change the government of the ravens in "Deep Archeology 3"

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -561,19 +561,19 @@ mission "Deep Archaeology 3"
 	
 	npc
 		personality waiting
-		government Republic
+		government "Deep Security"
 		ship "Raven (Afterburner)" "D.P.S. Wyrd"
 	
 	npc
 		personality waiting
 		system Aspidiske
-		government Republic
+		government "Deep Security"
 		ship "Raven (Afterburner)" "D.P.S. Skuld"
 	
 	npc
 		personality waiting
 		system Gomeisa
-		government Republic
+		government "Deep Security"
 		ship "Raven (Afterburner)" "D.P.S. Verthandi"
 	
 	on complete


### PR DESCRIPTION
This mission was written back when the deep's security was just the Republic government, so they're labeled as republic ships despite having the D.P.S. title associated with deep ships. This PR updates them to be part of the deep security government. This does not affect the ones that chase you in Deep Archeology 5.