### PR TITLE
HUD interface improvements

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -346,6 +346,7 @@ interface "hud"
 		dimensions 100 100
 		color "hit"
 		size 3
+		mode "alpha"
 	bar "fuel"
 		from -53.5 425
 		dimensions 0 -192
@@ -425,6 +426,7 @@ interface "hud"
 		dimensions 100 100
 		color "hit"
 		size 3
+		mode "alpha"
 	
 	visible if "range display"
 	sprite "ui/range"

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -40,6 +40,7 @@ color "heat" .70 .43 .43 .75
 color "overheat" .70 .61 .43 .75
 color "energy" .6 .6 .6 .75
 color "fuel" .70 .62 .43 .75
+color "hit" 5. .2 .2 1.
 
 color "flagship highlight" .5 .8 .2 0.
 
@@ -318,6 +319,10 @@ interface "hud"
 		color "medium"
 		align right
 	
+	point "player target"
+		center -75 155
+		dimensions 140 140
+	value "player target radius" 70
 	outline "player sprite"
 		center -75 155
 		dimensions 70 70
@@ -336,6 +341,11 @@ interface "hud"
 		dimensions 110 110
 		color "disabled hull"
 		size 1.5
+	ring "hit"
+		center -75 155
+		dimensions 100 100
+		color "hit"
+		size 3
 	bar "fuel"
 		from -53.5 425
 		dimensions 0 -192
@@ -410,6 +420,11 @@ interface "hud"
 		dimensions 110 110
 		color "disabled hull"
 		size 1.5
+	ring "target hit"
+		center 75 315
+		dimensions 100 100
+		color "hit"
+		size 3
 	
 	visible if "range display"
 	sprite "ui/range"

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -58,8 +58,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <cmath>
 #include <string>
 
-#include <iostream>
-
 using namespace std;
 
 namespace {

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2146,13 +2146,14 @@ double Engine::HitDetection::Pop(std::shared_ptr<const Ship> ship)
 	}
 	else
 	{
+		repetitiveDamage += repetitiveFrameDamages[step];
+
 		// Damage on current frame?
 		if(currentHealth < health)
 		{
 			damage = (health - currentHealth
 					+ (min(repetitiveFrameDamages[step] * 60, repetitiveDamage) - repetitiveFrameDamages[step]))
 							/ health * DAMAGE_SCALE;
-
 			// Keep the last damage for 200 milliseconds!
 			retention = 60 / 5;
 		}
@@ -2176,6 +2177,5 @@ double Engine::HitDetection::Pop(std::shared_ptr<const Ship> ship)
 
 void Engine::HitDetection::OnRepetitiveHit(double damage)
 {
-	repetitiveDamage += damage;
 	repetitiveFrameDamages[step] += damage;
 }

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -568,7 +568,7 @@ void Engine::Step(bool isActive)
 	if(flagship && flagship->Hull())
 	{
 		Point shipFacingUnit(0., -1.);
-		if(Preferences::Has("Rotate flagship in HUD") || zoom < 1)
+		if(Preferences::Has("Rotate flagship in HUD"))
 			shipFacingUnit = flagship->Facing().Unit();
 		
 		info.SetSprite("player sprite", flagship->GetSprite(), shipFacingUnit, flagship->GetFrame(step));

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -174,6 +174,10 @@ private:
 	Point targetVector;
 	Point targetUnit;
 	int targetSwizzle = -1;
+
+	int flagshipHit;
+	int targetHit;
+
 	EscortDisplay escorts;
 	std::vector<Status> statuses;
 	std::vector<PlanetLabel> labels;

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -132,6 +132,39 @@ private:
 		int type;
 		double angle;
 	};
+
+	// Gathers ship damage information.
+	//
+	// Single projectiles (missiles) are associated to their respective event
+	// frame, while repetitive projectiles (beams, blasters,...) are cumulated
+	// over the last second to better represent their effect (otherwise, due to
+	// their low intensity, they would pass undetected at event-frame level).
+	class HitDetection {
+	public:
+		// Returns the overall damage on current frame and moves to next frame.
+		double Pop(std::shared_ptr<const Ship> ship);
+		// Adds the given repetitive damage to current frame detection.
+		// @param damage Frame-specific damage.
+		void OnRepetitiveHit(double damage);
+
+	private:
+		std::shared_ptr<const Ship> ship;
+
+		// Overall damage (both instantaneous damage (by missiles) and cumulative,
+		// repetitive damage (by non-missile weapons, like beams, blasters,...))
+		// on current frame.
+		double damage;
+		// Initial ship health on current frame.
+		double health;
+
+		// Cumulative non-missile damage.
+		double repetitiveDamage;
+		// Non-missile damage by frame on last second.
+		double repetitiveFrameDamages[60];
+
+		int retention;
+		int step = 0;
+	};
 	
 	
 private:
@@ -175,8 +208,8 @@ private:
 	Point targetUnit;
 	int targetSwizzle = -1;
 
-	int flagshipHit;
-	int targetHit;
+	HitDetection flagshipHitDetection;
+	HitDetection targetHitDetection;
 
 	EscortDisplay escorts;
 	std::vector<Status> statuses;

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -606,6 +606,13 @@ bool Interface::BarElement::ParseLine(const DataNode &node)
 		color = GameData::Colors().Get(node.Token(1));
 	else if(node.Token(0) == "size" && node.Size() >= 2)
 		width = node.Value(1);
+	else if(node.Token(0) == "mode" && node.Size() >= 2)
+		if(node.Token(1) == "alpha")
+			mode = ALPHA;
+		else if(node.Token(1) == "length")
+			mode = LENGTH;
+		else
+			node.PrintTrace("Unrecognized interface element attribute value:");
 	else
 		return false;
 	
@@ -632,7 +639,18 @@ void Interface::BarElement::Draw(const Rectangle &rect, const Information &info,
 		if(!rect.Width() || !rect.Height())
 			return;
 		
-		RingShader::Draw(rect.Center(), .5 * rect.Width(), width, value, *color, segments > 1. ? segments : 0.);
+		Color drawColor;
+		switch(mode) {
+		case ALPHA:
+			drawColor = color->Transparent(value);
+			value = 1;
+			break;
+		case LENGTH:
+		default:
+			drawColor = *color;
+			break;
+		}
+		RingShader::Draw(rect.Center(), .5 * rect.Width(), width, value, drawColor, segments);
 	}
 	else
 	{

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -174,6 +174,11 @@ private:
 	// This class handles "bar" and "ring" elements.
 	class BarElement : public Element {
 	public:
+		enum Mode {
+			LENGTH,
+			ALPHA
+		};
+	public:
 		BarElement(const DataNode &node, const Point &globalAnchor);
 		
 	protected:
@@ -188,6 +193,7 @@ private:
 		const Color *color = nullptr;
 		float width = 2.f;
 		bool isRing = false;
+		Mode mode = LENGTH;
 	};
 	
 	


### PR DESCRIPTION
This PR  aims to enhance the visual feedback of the HUD interface:

- target display:
  - [ADD] **target hit detector** (ring "target hit"): _highlights whenever the target takes damage_ (rendered as a reddish thick inner ring for 200 milliseconds).
&nbsp;
![endless-sky_feat_hud-refine_target](https://user-images.githubusercontent.com/10812966/63933527-b3dcc180-ca59-11e9-9006-1fc40286c3a4.jpg)

- flagship display:
  - [ADD] **flagship hit detector** (ring "hit"): _highlights whenever the flagship takes damage_ (rendered as a reddish thick inner ring for 200 milliseconds).
  - [ADD] **target bearing** (point "player target"): backs up the bearing currently on target display for convenience (_this way, the user can easily collimate the flagship direction with the target location_).
&nbsp;
![endless-sky_feat_hud-refine_flagship](https://user-images.githubusercontent.com/10812966/63933624-e8e91400-ca59-11e9-91d7-fd5673a62600.jpg)
