### PR TITLE
Changed the names and descriptions of bounty missions

### DIFF
--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2554,8 +2554,8 @@ mission "Recycle garbage"
 
 
 mission "Bounty Hunting (Small)"
-	name "Wanted ship near <system>"
-	description "A pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	name "Wanted privateer near <system>"
+	description "A low-end pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2597,8 +2597,8 @@ mission "Bounty Hunting (Small)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Medium)"
-	name "Large pirate near <system>"
-	description "A heavily armed pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	name "Pirate near <system>"
+	description "A medium pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2634,8 +2634,8 @@ mission "Bounty Hunting (Medium)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Big)"
-	name "Huge pirate near <system>"
-	description "A heavy pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	name "Pirate warlord spotted near <system>"
+	description "A heavy warship known as the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2676,7 +2676,7 @@ mission "Bounty Hunting (Big)"
 
 mission "Bounty Hunting (Small, Boarding, Entering)"
 	name "Stolen ship near <system>"
-	description "A wanted criminal is fleeing in a stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminal to <destination> to stand trial on <date>. Reward for capture: <payment>."
+	description "A wanted criminal is fleeing in a stolen ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminal to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 1
 	deadline 14
 	repeat
@@ -2715,7 +2715,7 @@ mission "Bounty Hunting (Small, Boarding, Entering)"
 
 mission "Bounty Hunting (Medium, Boarding, Entering)"
 	name "Stolen warship near <system>"
-	description "A wanted criminal and several accomplices are fleeing in a large stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminals to <destination> to stand trial on <date>. Reward for capture: <payment>."
+	description "A wanted criminal and several accomplices are fleeing in a stolen warship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminals to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 4
 	deadline 14
 	repeat

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2554,7 +2554,7 @@ mission "Recycle garbage"
 
 
 mission "Bounty Hunting (Small)"
-	name "Wanted privateer near <system>"
+	name "Wanted bandit near <system>"
 	description "A low-end pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2634,7 +2634,7 @@ mission "Bounty Hunting (Medium)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Big)"
-	name "Wanted pirate warlord spotted near <system>"
+	name "Wanted warlord near <system>"
 	description "A heavy warship known as the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2714,7 +2714,7 @@ mission "Bounty Hunting (Small, Boarding, Entering)"
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal."
 
 mission "Bounty Hunting (Medium, Boarding, Entering)"
-	name "Large stolen ship near <system>"
+	name "Stolen warship near <system>"
 	description "A wanted criminal and several accomplices are fleeing in a large stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminals to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 4
 	deadline 14

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2598,7 +2598,7 @@ mission "Bounty Hunting (Small)"
 
 mission "Bounty Hunting (Medium)"
 	name "Hunt down the <npc>"
-	description "A medium pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2840,7 +2840,7 @@ mission "Bounty Hunting (Marauder III)"
 
 mission "Bounty Hunting (Marauder IV)"
 	name "Hunt down the <npc>"
-	description "A fleet of medium Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2868,7 +2868,7 @@ mission "Bounty Hunting (Marauder IV)"
 
 mission "Bounty Hunting (Marauder V)"
 	name "Hunt down the <npc>"
-	description "A fleet of medium Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2897,7 +2897,7 @@ mission "Bounty Hunting (Marauder V)"
 
 mission "Bounty Hunting (Marauder VI)"
 	name "Hunt down the <npc>"
-	description "A fleet of medium Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2597,7 +2597,7 @@ mission "Bounty Hunting (Small)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Medium)"
-	name "Pirate near <system>"
+	name "Wanted pirate near <system>"
 	description "A medium pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2634,7 +2634,7 @@ mission "Bounty Hunting (Medium)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Big)"
-	name "Pirate warlord spotted near <system>"
+	name "Wanted pirate warlord spotted near <system>"
 	description "A heavy warship known as the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2555,7 +2555,7 @@ mission "Recycle garbage"
 
 mission "Bounty Hunting (Small)"
 	name "Hunt down the <npc>"
-	description "A pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A small pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2598,7 +2598,7 @@ mission "Bounty Hunting (Small)"
 
 mission "Bounty Hunting (Medium)"
 	name "Hunt down the <npc>"
-	description "A pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A medium pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2635,7 +2635,7 @@ mission "Bounty Hunting (Medium)"
 
 mission "Bounty Hunting (Big)"
 	name "Hunt down the <npc>"
-	description "A pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A large pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2676,7 +2676,7 @@ mission "Bounty Hunting (Big)"
 
 mission "Bounty Hunting (Small, Boarding, Entering)"
 	name "Board the <npc>"
-	description "A wanted criminal is fleeing in a stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminal to <destination> to stand trial on <date>. Reward for capture: <payment>."
+	description "A wanted criminal is fleeing in a small stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminal to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 1
 	deadline 14
 	repeat
@@ -2715,7 +2715,7 @@ mission "Bounty Hunting (Small, Boarding, Entering)"
 
 mission "Bounty Hunting (Medium, Boarding, Entering)"
 	name "Board the <npc>"
-	description "A wanted criminal and several accomplices are fleeing in a stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminals to <destination> to stand trial on <date>. Reward for capture: <payment>."
+	description "A wanted criminal and several accomplices are fleeing in a large stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminals to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 4
 	deadline 14
 	repeat
@@ -2756,7 +2756,7 @@ mission "Bounty Hunting (Medium, Boarding, Entering)"
 
 mission "Bounty Hunting (Marauder I)"
 	name "Hunt down the <npc>"
-	description "A Marauder vessel named the <npc>, leading a small fleet, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2784,7 +2784,7 @@ mission "Bounty Hunting (Marauder I)"
 
 mission "Bounty Hunting (Marauder II)"
 	name "Hunt down the <npc>"
-	description "A Marauder vessel named the <npc>, leading a small fleet, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2812,7 +2812,7 @@ mission "Bounty Hunting (Marauder II)"
 
 mission "Bounty Hunting (Marauder III)"
 	name "Hunt down the <npc>"
-	description "A Marauder vessel named the <npc>, leading a small fleet, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2840,7 +2840,7 @@ mission "Bounty Hunting (Marauder III)"
 
 mission "Bounty Hunting (Marauder IV)"
 	name "Hunt down the <npc>"
-	description "A Marauder vessel named the <npc>, leading a small fleet, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of medium Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2868,7 +2868,7 @@ mission "Bounty Hunting (Marauder IV)"
 
 mission "Bounty Hunting (Marauder V)"
 	name "Hunt down the <npc>"
-	description "A Marauder vessel named the <npc>, leading a small fleet, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of medium Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2897,7 +2897,7 @@ mission "Bounty Hunting (Marauder V)"
 
 mission "Bounty Hunting (Marauder VI)"
 	name "Hunt down the <npc>"
-	description "A Marauder vessel named the <npc>, leading a small fleet, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of medium Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2925,7 +2925,7 @@ mission "Bounty Hunting (Marauder VI)"
 
 mission "Bounty Hunting (Marauder VII)"
 	name "Hunt down the <npc>"
-	description "A Marauder vessel named the <npc>, leading a small fleet, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2949,7 +2949,7 @@ mission "Bounty Hunting (Marauder VII)"
 
 mission "Bounty Hunting (Marauder VIII)"
 	name "Hunt down the <npc>"
-	description "A Marauder vessel named the <npc>, leading a small fleet, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2973,7 +2973,7 @@ mission "Bounty Hunting (Marauder VIII)"
 
 mission "Bounty Hunting (Marauder IX)"
 	name "Hunt down the <npc>"
-	description "A Marauder vessel named the <npc>, leading a small fleet, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2554,8 +2554,8 @@ mission "Recycle garbage"
 
 
 mission "Bounty Hunting (Small)"
-	name "Hunt down the <npc>"
-	description "A small pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	name "Wanted ship near <source>"
+	description "A pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2597,8 +2597,8 @@ mission "Bounty Hunting (Small)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Medium)"
-	name "Hunt down the <npc>"
-	description "A pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	name "Large wanted ship near <source>"
+	description "A large pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2634,8 +2634,8 @@ mission "Bounty Hunting (Medium)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Big)"
-	name "Hunt down the <npc>"
-	description "A large pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	name "Very large wanted ship near <source>"
+	description "A very large pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2675,8 +2675,8 @@ mission "Bounty Hunting (Big)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Small, Boarding, Entering)"
-	name "Board the <npc>"
-	description "A wanted criminal is fleeing in a small stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminal to <destination> to stand trial on <date>. Reward for capture: <payment>."
+	name "Stolen ship near <source>"
+	description "A wanted criminal is fleeing in a stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminal to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 1
 	deadline 14
 	repeat
@@ -2714,7 +2714,7 @@ mission "Bounty Hunting (Small, Boarding, Entering)"
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal."
 
 mission "Bounty Hunting (Medium, Boarding, Entering)"
-	name "Board the <npc>"
+	name "Large stolen ship near <source>"
 	description "A wanted criminal and several accomplices are fleeing in a large stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminals to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 4
 	deadline 14
@@ -2755,7 +2755,7 @@ mission "Bounty Hunting (Medium, Boarding, Entering)"
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal gang."
 
 mission "Bounty Hunting (Marauder I)"
-	name "Hunt down the <npc>"
+	name "Small Marauders near <source>"
 	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2783,7 +2783,7 @@ mission "Bounty Hunting (Marauder I)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder II)"
-	name "Hunt down the <npc>"
+	name "Small Marauders near <source>"
 	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2811,7 +2811,7 @@ mission "Bounty Hunting (Marauder II)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder III)"
-	name "Hunt down the <npc>"
+	name "Small Marauders near <source>"
 	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2839,7 +2839,7 @@ mission "Bounty Hunting (Marauder III)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder IV)"
-	name "Hunt down the <npc>"
+	name "Marauders near <source>"
 	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2867,7 +2867,7 @@ mission "Bounty Hunting (Marauder IV)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder V)"
-	name "Hunt down the <npc>"
+	name "Marauders near <source>"
 	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2896,7 +2896,7 @@ mission "Bounty Hunting (Marauder V)"
 
 
 mission "Bounty Hunting (Marauder VI)"
-	name "Hunt down the <npc>"
+	name "Marauders near <source>"
 	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2924,7 +2924,7 @@ mission "Bounty Hunting (Marauder VI)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder VII)"
-	name "Hunt down the <npc>"
+	name "Large Marauders near <source>"
 	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2948,7 +2948,7 @@ mission "Bounty Hunting (Marauder VII)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder VIII)"
-	name "Hunt down the <npc>"
+	name "Large Marauders near <source>"
 	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2972,7 +2972,7 @@ mission "Bounty Hunting (Marauder VIII)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder IX)"
-	name "Hunt down the <npc>"
+	name "Large Marauders near <source>"
 	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2554,7 +2554,7 @@ mission "Recycle garbage"
 
 
 mission "Bounty Hunting (Small)"
-	name "Wanted ship near <origin>"
+	name "Wanted ship near <system>"
 	description "A pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2597,8 +2597,8 @@ mission "Bounty Hunting (Small)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Medium)"
-	name "Large wanted ship near <origin>"
-	description "A large pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	name "Large pirate near <system>"
+	description "A heavily armed pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2634,8 +2634,8 @@ mission "Bounty Hunting (Medium)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Big)"
-	name "Very large wanted ship near <origin>"
-	description "A very large pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	name "Huge pirate near <system>"
+	description "A heavy pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
 	to offer
@@ -2675,7 +2675,7 @@ mission "Bounty Hunting (Big)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Small, Boarding, Entering)"
-	name "Stolen ship near <origin>"
+	name "Stolen ship near <system>"
 	description "A wanted criminal is fleeing in a stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminal to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 1
 	deadline 14
@@ -2714,7 +2714,7 @@ mission "Bounty Hunting (Small, Boarding, Entering)"
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal."
 
 mission "Bounty Hunting (Medium, Boarding, Entering)"
-	name "Large stolen ship near <origin>"
+	name "Large stolen ship near <system>"
 	description "A wanted criminal and several accomplices are fleeing in a large stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminals to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 4
 	deadline 14
@@ -2755,7 +2755,7 @@ mission "Bounty Hunting (Medium, Boarding, Entering)"
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal gang."
 
 mission "Bounty Hunting (Marauder I)"
-	name "Small Marauders near <origin>"
+	name "Small Marauders near <system>"
 	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2783,7 +2783,7 @@ mission "Bounty Hunting (Marauder I)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder II)"
-	name "Small Marauders near <origin>"
+	name "Small Marauders near <system>"
 	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2811,7 +2811,7 @@ mission "Bounty Hunting (Marauder II)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder III)"
-	name "Small Marauders near <origin>"
+	name "Small Marauders near <system>"
 	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2839,7 +2839,7 @@ mission "Bounty Hunting (Marauder III)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder IV)"
-	name "Marauders near <origin>"
+	name "Marauders near <system>"
 	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2867,7 +2867,7 @@ mission "Bounty Hunting (Marauder IV)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder V)"
-	name "Marauders near <origin>"
+	name "Marauders near <system>"
 	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2896,7 +2896,7 @@ mission "Bounty Hunting (Marauder V)"
 
 
 mission "Bounty Hunting (Marauder VI)"
-	name "Marauders near <origin>"
+	name "Marauders near <system>"
 	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2924,7 +2924,7 @@ mission "Bounty Hunting (Marauder VI)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder VII)"
-	name "Large Marauders near <origin>"
+	name "Large Marauders near <system>"
 	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2948,7 +2948,7 @@ mission "Bounty Hunting (Marauder VII)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder VIII)"
-	name "Large Marauders near <origin>"
+	name "Large Marauders near <system>"
 	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2972,7 +2972,7 @@ mission "Bounty Hunting (Marauder VIII)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder IX)"
-	name "Large Marauders near <origin>"
+	name "Large Marauders near <system>"
 	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2554,7 +2554,7 @@ mission "Recycle garbage"
 
 
 mission "Bounty Hunting (Small)"
-	name "Wanted ship near <source>"
+	name "Wanted ship near <origin>"
 	description "A pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2597,7 +2597,7 @@ mission "Bounty Hunting (Small)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Medium)"
-	name "Large wanted ship near <source>"
+	name "Large wanted ship near <origin>"
 	description "A large pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2634,7 +2634,7 @@ mission "Bounty Hunting (Medium)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Big)"
-	name "Very large wanted ship near <source>"
+	name "Very large wanted ship near <origin>"
 	description "A very large pirate vessel named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2675,7 +2675,7 @@ mission "Bounty Hunting (Big)"
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Small, Boarding, Entering)"
-	name "Stolen ship near <source>"
+	name "Stolen ship near <origin>"
 	description "A wanted criminal is fleeing in a stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminal to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 1
 	deadline 14
@@ -2714,7 +2714,7 @@ mission "Bounty Hunting (Small, Boarding, Entering)"
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal."
 
 mission "Bounty Hunting (Medium, Boarding, Entering)"
-	name "Large stolen ship near <source>"
+	name "Large stolen ship near <origin>"
 	description "A wanted criminal and several accomplices are fleeing in a large stolen hot rod ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminals to <destination> to stand trial on <date>. Reward for capture: <payment>."
 	passengers 4
 	deadline 14
@@ -2755,7 +2755,7 @@ mission "Bounty Hunting (Medium, Boarding, Entering)"
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal gang."
 
 mission "Bounty Hunting (Marauder I)"
-	name "Small Marauders near <source>"
+	name "Small Marauders near <origin>"
 	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2783,7 +2783,7 @@ mission "Bounty Hunting (Marauder I)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder II)"
-	name "Small Marauders near <source>"
+	name "Small Marauders near <origin>"
 	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2811,7 +2811,7 @@ mission "Bounty Hunting (Marauder II)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder III)"
-	name "Small Marauders near <source>"
+	name "Small Marauders near <origin>"
 	description "A fleet of small Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2839,7 +2839,7 @@ mission "Bounty Hunting (Marauder III)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder IV)"
-	name "Marauders near <source>"
+	name "Marauders near <origin>"
 	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2867,7 +2867,7 @@ mission "Bounty Hunting (Marauder IV)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder V)"
-	name "Marauders near <source>"
+	name "Marauders near <origin>"
 	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2896,7 +2896,7 @@ mission "Bounty Hunting (Marauder V)"
 
 
 mission "Bounty Hunting (Marauder VI)"
-	name "Marauders near <source>"
+	name "Marauders near <origin>"
 	description "A fleet of Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2924,7 +2924,7 @@ mission "Bounty Hunting (Marauder VI)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder VII)"
-	name "Large Marauders near <source>"
+	name "Large Marauders near <origin>"
 	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2948,7 +2948,7 @@ mission "Bounty Hunting (Marauder VII)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder VIII)"
-	name "Large Marauders near <source>"
+	name "Large Marauders near <origin>"
 	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job
@@ -2972,7 +2972,7 @@ mission "Bounty Hunting (Marauder VIII)"
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder IX)"
-	name "Large Marauders near <source>"
+	name "Large Marauders near <origin>"
 	description "A fleet of large Marauder ships, lead by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
 	repeat
 	job


### PR DESCRIPTION
Something that's always annoyed me about the bounty hunting missions is that one that requires you to hunt down a leviathan and one that requires you to fight a firebird have the exact same name and descriptions, so the only way you can figure out which ones you should take early on is by looking at nothing but the payment.

This changes the descriptions of all bounty hunting jobs so they give you a rough description of what you're going to be fighting.