### PR TITLE
The bank is now accessible without a flagship

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -103,12 +103,15 @@ void PlanetPanel::Draw()
 	
 	if(planet.CanUseServices())
 	{
-		if(flagship && planet.IsInhabited())
+		if(planet.IsInhabited())
 		{
-			info.SetCondition("is inhabited");
 			info.SetCondition("has bank");
-			if(system.HasTrade())
-				info.SetCondition("has trade");
+			if(flagship)
+			{
+				info.SetCondition("is inhabited");
+				if(system.HasTrade())
+					info.SetCondition("has trade");
+			}
 		}
 		
 		if(flagship && planet.HasSpaceport())


### PR DESCRIPTION
Ref: #4508

https://github.com/endless-sky/endless-sky/commit/1df09fcf23afbe81d2729e17be163d9d4c2c83f8 made it so that the bank shows up if the planet is inhabited and if the player has a flagship. This change makes the bank accessible only if the planet is inhabited.

![image](https://user-images.githubusercontent.com/17688683/64132430-d9413680-cd9d-11e9-9105-e37d4dd44a34.png)
