### PR TITLE
Extended the ammo attribute to specify how much ammo is used per shot

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -348,7 +348,10 @@ tip "Special:"
 
 # Weapon attributes:
 tip "ammo:"
-	`When this weapon fires it consumes one outfit of this type.`
+	`When this weapon fires it consumes outfits of this type.`
+
+tip "ammo usage:"
+	`The number of units of ammo that this weapon consumes when fired.`
 
 tip "range:"
 	`Total range of this weapon.`

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -71,7 +71,7 @@ void Outfit::Load(const DataNode &node)
 		else if(child.Token(0) == "weapon")
 			LoadWeapon(child);
 		else if(child.Token(0) == "ammo" && child.Size() >= 2)
-			ammo = GameData::Outfits().Get(child.Token(1));
+			ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)),0);
 		else if(child.Token(0) == "description" && child.Size() >= 2)
 		{
 			description += child.Token(1);

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -71,7 +71,12 @@ void Outfit::Load(const DataNode &node)
 		else if(child.Token(0) == "weapon")
 			LoadWeapon(child);
 		else if(child.Token(0) == "ammo" && child.Size() >= 2)
+		{
+			// Non-weapon outfits can have ammo so that storage outfits
+			// properly remove excess ammo when the storage is sold, instead
+			// of blocking the sale of the outfit until the ammo is sold first.
 			ammo = make_pair(GameData::Outfits().Get(child.Token(1)), 0);
+		}
 		else if(child.Token(0) == "description" && child.Size() >= 2)
 		{
 			description += child.Token(1);

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -71,7 +71,7 @@ void Outfit::Load(const DataNode &node)
 		else if(child.Token(0) == "weapon")
 			LoadWeapon(child);
 		else if(child.Token(0) == "ammo" && child.Size() >= 2)
-			ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)),0);
+			ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)), 0);
 		else if(child.Token(0) == "description" && child.Size() >= 2)
 		{
 			description += child.Token(1);

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -71,7 +71,7 @@ void Outfit::Load(const DataNode &node)
 		else if(child.Token(0) == "weapon")
 			LoadWeapon(child);
 		else if(child.Token(0) == "ammo" && child.Size() >= 2)
-			ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)), 0);
+			ammo = make_pair(GameData::Outfits().Get(child.Token(1)), 0);
 		else if(child.Token(0) == "description" && child.Size() >= 2)
 		{
 			description += child.Token(1);

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -239,6 +239,12 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		attributeLabels.emplace_back("ammo:");
 		attributeValues.emplace_back(outfit.Ammo()->Name());
 		attributesHeight += 20;
+		if(outfit.IsWeapon() && outfit.AmmoUsage() > 1)
+		{
+			attributeLabels.emplace_back("ammo usage:");
+			attributeValues.emplace_back(Format::Number(outfit.AmmoUsage()));
+			attributesHeight += 20;
+		}
 	}
 	
 	attributeLabels.emplace_back("range:");

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -239,7 +239,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		attributeLabels.emplace_back("ammo:");
 		attributeValues.emplace_back(outfit.Ammo()->Name());
 		attributesHeight += 20;
-		if(outfit.IsWeapon() && outfit.AmmoUsage() > 1)
+		if(outfit.AmmoUsage() > 1)
 		{
 			attributeLabels.emplace_back("ammo usage:");
 			attributeValues.emplace_back(Format::Number(outfit.AmmoUsage()));

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -239,7 +239,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		attributeLabels.emplace_back("ammo:");
 		attributeValues.emplace_back(outfit.Ammo()->Name());
 		attributesHeight += 20;
-		if(outfit.AmmoUsage() > 1)
+		if(outfit.AmmoUsage() != 1)
 		{
 			attributeLabels.emplace_back("ammo usage:");
 			attributeValues.emplace_back(Format::Number(outfit.AmmoUsage()));

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2951,7 +2951,7 @@ bool Ship::CanFire(const Weapon *weapon) const
 	if(weapon->Ammo())
 	{
 		auto it = outfits.find(weapon->Ammo());
-		if(it == outfits.end() || it->second <= 0)
+		if(it == outfits.end() || it->second < weapon->AmmoUsage())
 			return false;
 	}
 	
@@ -2976,7 +2976,7 @@ void Ship::ExpendAmmo(const Weapon *weapon)
 	if(!weapon)
 		return;
 	if(weapon->Ammo())
-		AddOutfit(weapon->Ammo(), -1);
+		AddOutfit(weapon->Ammo(), -weapon->AmmoUsage());
 	
 	energy -= weapon->FiringEnergy();
 	fuel -= weapon->FiringFuel();

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -56,10 +56,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			sound = Audio::Get(child.Token(1));
 		else if(key == "ammo")
 		{
-			if(child.Size() <= 2)
-				ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)), 1);
-			else
-				ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)), max(1, static_cast<int>(child.Value(2))));
+			int usage = (child.Size() >= 3) ? child.Value(2) : 1;
+			ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)), max(1, usage));
 		}
 		else if(key == "icon")
 			icon = SpriteSet::Get(child.Token(1));

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -55,7 +55,12 @@ void Weapon::LoadWeapon(const DataNode &node)
 		else if(key == "sound")
 			sound = Audio::Get(child.Token(1));
 		else if(key == "ammo")
-			ammo = GameData::Outfits().Get(child.Token(1));
+		{
+			if(child.Size() <= 2)
+				ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)),1);
+			else
+				ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)),max(1,static_cast<int>(child.Value(2))));
+		}
 		else if(key == "icon")
 			icon = SpriteSet::Get(child.Token(1));
 		else if(key == "fire effect")
@@ -90,8 +95,6 @@ void Weapon::LoadWeapon(const DataNode &node)
 				lifetime = max(0., value);
 			else if(key == "random lifetime")
 				randomLifetime = max(0., value);
-			else if(key == "ammo usage")
-				ammoUsage = max(1.,value);
 			else if(key == "reload")
 				reload = max(1., value);
 			else if(key == "burst reload")
@@ -241,9 +244,13 @@ const Sound *Weapon::WeaponSound() const
 
 const Outfit *Weapon::Ammo() const
 {
-	return ammo;
+	return ammoPair.first;
 }
 
+int Weapon::AmmoUsage() const
+{
+	return ammoPair.second;
+}
 
 
 const Sprite *Weapon::Icon() const

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -90,6 +90,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 				lifetime = max(0., value);
 			else if(key == "random lifetime")
 				randomLifetime = max(0., value);
+			else if(key == "ammo usage")
+				ammoUsage = max(1.,value);
 			else if(key == "reload")
 				reload = max(1., value);
 			else if(key == "burst reload")

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -247,10 +247,13 @@ const Outfit *Weapon::Ammo() const
 	return ammoPair.first;
 }
 
+
+
 int Weapon::AmmoUsage() const
 {
 	return ammoPair.second;
 }
+
 
 
 const Sprite *Weapon::Icon() const

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -57,7 +57,7 @@ void Weapon::LoadWeapon(const DataNode &node)
 		else if(key == "ammo")
 		{
 			int usage = (child.Size() >= 3) ? child.Value(2) : 1;
-			ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)), max(1, usage));
+			ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)), max(0, usage));
 		}
 		else if(key == "icon")
 			icon = SpriteSet::Get(child.Token(1));

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -57,7 +57,7 @@ void Weapon::LoadWeapon(const DataNode &node)
 		else if(key == "ammo")
 		{
 			int usage = (child.Size() >= 3) ? child.Value(2) : 1;
-			ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)), max(0, usage));
+			ammo = make_pair(GameData::Outfits().Get(child.Token(1)), max(0, usage));
 		}
 		else if(key == "icon")
 			icon = SpriteSet::Get(child.Token(1));
@@ -242,14 +242,14 @@ const Sound *Weapon::WeaponSound() const
 
 const Outfit *Weapon::Ammo() const
 {
-	return ammoPair.first;
+	return ammo.first;
 }
 
 
 
 int Weapon::AmmoUsage() const
 {
-	return ammoPair.second;
+	return ammo.second;
 }
 
 

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -57,9 +57,9 @@ void Weapon::LoadWeapon(const DataNode &node)
 		else if(key == "ammo")
 		{
 			if(child.Size() <= 2)
-				ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)),1);
+				ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)), 1);
 			else
-				ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)),max(1,static_cast<int>(child.Value(2))));
+				ammoPair = make_pair(GameData::Outfits().Get(child.Token(1)), max(1, static_cast<int>(child.Value(2))));
 		}
 		else if(key == "icon")
 			icon = SpriteSet::Get(child.Token(1));

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Point.h"
 
 #include <map>
+#include <utility>
 
 class DataNode;
 class Effect;

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -59,6 +59,8 @@ public:
 	int BurstCount() const;
 	int Homing() const;
 	
+	int AmmoUsage() const;
+	
 	int MissileStrength() const;
 	int AntiMissile() const;
 	// Weapons of the same type will alternate firing (streaming) rather than
@@ -159,6 +161,8 @@ private:
 	int burstCount = 1;
 	int homing = 0;
 	
+	int ammoUsage = 1;
+	
 	int missileStrength = 0;
 	int antiMissile = 0;
 	
@@ -214,6 +218,8 @@ inline double Weapon::Reload() const { return reload; }
 inline double Weapon::BurstReload() const { return burstReload; }
 inline int Weapon::BurstCount() const { return burstCount; }
 inline int Weapon::Homing() const { return homing; }
+
+inline int Weapon::AmmoUsage() const { return ammoUsage; }
 
 inline int Weapon::MissileStrength() const { return missileStrength; }
 inline int Weapon::AntiMissile() const { return antiMissile; }

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -125,7 +125,9 @@ protected:
 	// default turnrate.
 	void SetTurretTurn(double rate);
 	
-	std::pair<const Outfit*, int> ammoPair;
+	// A pair representing the outfit that is consumed as ammo and the number
+	// of that outfit consumed upon fire.
+	std::pair<const Outfit*, int> ammo;
 	
 	
 private:

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -125,7 +125,7 @@ protected:
 	// default turnrate.
 	void SetTurretTurn(double rate);
 	
-	const Outfit *ammo = nullptr;
+	std::pair<const Outfit*,int> ammoPair;
 	
 	
 private:
@@ -160,8 +160,6 @@ private:
 	double burstReload = 1.;
 	int burstCount = 1;
 	int homing = 0;
-	
-	int ammoUsage = 1;
 	
 	int missileStrength = 0;
 	int antiMissile = 0;
@@ -218,8 +216,6 @@ inline double Weapon::Reload() const { return reload; }
 inline double Weapon::BurstReload() const { return burstReload; }
 inline int Weapon::BurstCount() const { return burstCount; }
 inline int Weapon::Homing() const { return homing; }
-
-inline int Weapon::AmmoUsage() const { return ammoUsage; }
 
 inline int Weapon::MissileStrength() const { return missileStrength; }
 inline int Weapon::AntiMissile() const { return antiMissile; }

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -125,7 +125,7 @@ protected:
 	// default turnrate.
 	void SetTurretTurn(double rate);
 	
-	std::pair<const Outfit*,int> ammoPair;
+	std::pair<const Outfit*, int> ammoPair;
 	
 	
 private:


### PR DESCRIPTION
Ref: #4223

Using the syntax from #4223: `ammo <outfit name> <number of outfits consumed>`. Putting no number is the same thing as putting one. 0 ammo usage is allowed, but the ammo outfit must be installed in order to fire.

This displays in game as a new line underneath ammo called "ammo usage". Ammo usage will only appear on weapons that consume something other than 1 ammo per shot.
![image](https://user-images.githubusercontent.com/17688683/64397568-bded5a00-d02f-11e9-9bf6-b9efc54a33a2.png)

