### PR TITLE
Save thumbnails, just as we save sprites.

### DIFF
--- a/changelog
+++ b/changelog
@@ -15,6 +15,7 @@ Version 0.9.10:
     * The "Unwanted Cargo" mission now correctly identifies when you have the translator. (@Amazinite)
     * Paradise Fortune 1's on visit dialog no longer refers to Diana by name. (@petervdmeer)
     * Mission NPCs that have no saved system will not crash the game when the player departs a planet. (@tehhowch)
+    * Ship thumbnails are now saved, just like sprites. (@MageKing17)
   * Game content:
     * Black holes now have a landing message. (@Comnom)
     * Pirate occupation spaceport missions will no longer cause the player to launch if the occupation is in another system. (@ZBok)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -32,6 +32,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "ShipEvent.h"
 #include "Sound.h"
 #include "SpriteSet.h"
+#include "Sprite.h"
 #include "StellarObject.h"
 #include "System.h"
 #include "Visual.h"
@@ -578,6 +579,8 @@ void Ship::Save(DataWriter &out) const
 		if(!noun.empty())
 			out.Write("noun", noun);
 		SaveSprite(out);
+		if(thumbnail)
+			out.Write("thumbnail", thumbnail->Name());
 		
 		if(neverDisabled)
 			out.Write("never disabled");


### PR DESCRIPTION
This will allow variants with different thumbnails to have their thumbnails be preserved through a save/load cycle. Fixes #4503.