### PR TITLE
Added a mission that helps the player if they become stuck in the Ember Waste

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -142,6 +142,8 @@ mission "Remnant Blood Test Patch"
 mission "lost in ember waste"
 	landing
 	invisible
+	source
+		governmant "Remnant"
 	to offer
 		has "remnant blood test pure"
 		not "license: Remnant"
@@ -158,6 +160,8 @@ event "lost in ember waste"
 mission "Remnant: Lost in Ember Waste"
 	landing
 	invisible
+	source
+		governmant "Remnant"
 	to offer
 		has "event: lost in ember waste"
 		outfit "Quantum Key Stone" 1

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -224,7 +224,7 @@ mission "Remnant: Lost in Ember Waste"
 			`	"Well I got lost when I was 17 and returned when I was 64, so perhaps some 130 years ago now that I returned." She chuckles at the surprised look on your face as you realize that she is nearly 200 years old. "Uncovering ancient alien technology is quite the blessing.`
 				goto end
 			
-			label daughtesr
+			label daughters
 			`	"Oh, I made sure to tell them I was returning home. They know where to find me if they ever need me, and I have made trips to see them every decade or so. I'm nearing the end of my days, though, so I may only have one more trip left in me.`
 			
 			label end

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -199,7 +199,7 @@ mission "Remnant: Lost in Ember Waste"
 				decline
 			
 			label republic
-			`	"I was an adventurous spirit in my youth," she says. "One day I found my way out of the Ember Waste and back to what I learned was the rest of humanity. For years my people had hidden here believing the Alphas had killed everyone else, but I now knew that we had little to fear.
+			`	"I was an adventurous spirit in my youth," she says. "One day I found my way out of the Ember Waste and back to what I learned was the rest of humanity. For years my people had hidden here believing the Alphas had killed everyone else, but I discovered that we had little to fear.
 			`	"I explored the Republic for many months, learning what had happened since the Alpha Wars, but when I attempted to return to the Ember Waste to tell my people, I found that my key stone had been stolen at some point during my journey. I had no way to return."`
 			`	She lets out a long sigh. "I don't want to bore you with all the details, but I resigned myself to my new life. I met a man, had two daughters, but never lost hope of returning to my true home. One day, after my daughters had grown and my husband had passed in an accident, I decided to go on another adventure. I dusted off my old ship, and soon discovered Hai space."`
 			branch hai

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -201,7 +201,7 @@ mission "Remnant: Lost in Ember Waste"
 			label republic
 			`	"I was an adventurous spirit in my youth," she says. "One day I found my way out of the Ember Waste and back to what I learned was the rest of humanity. For years my people had hidden here believing the Alphas had killed everyone else, but I discovered that we had little to fear.`
 			`	"I explored the Republic for many months, learning what had happened since the Alpha Wars, but when I attempted to return to the Ember Waste to tell my people, I found that my key stone had been stolen at some point during my journey. I had no way to return."`
-			`	She lets out a long sigh. "I don't want to bore you with all the details, but I resigned myself to my new life. I met a man, had two daughters, but never lost hope of returning to my true home. One day, after my daughters had grown and my husband had passed in an accident, I decided to go on another adventure. I dusted off my old ship, and soon discovered Hai space."`
+			`	She lets out a long sigh. "I don't want to bore you with all the details, but I resigned myself to my new life. I met a man, had two daughters, but never lost hope of returning to my true home. One day, after my daughters had grown and my husband had passed in an accident, I decided to go on another adventure. I dusted off my old ship, and soon discovered the Hai."`
 			branch hai
 				has "First Contact: Hai"
 			choice
@@ -225,7 +225,7 @@ mission "Remnant: Lost in Ember Waste"
 				goto end
 			
 			label daughters
-			`	"Oh, I made sure to tell them I was returning home. They know where to find me if they ever need me, and I have made trips to see them every decade or so. I'm nearing the end of my days, though, so I may only have one more trip left in me.`
+			`	"Oh, I only told them about deciding to travel the galaxy. Never told them about returning home. I made trips to see them every so often, but they both passed many decades ago now. It seems like the Republic can't quite get anyone to live past 130 years.`
 			
 			label end
 			`	"I really must get going, now," she says. The woman gets up to leave, but before walking away she turns to you and sings, "Safe travels, Captain," with a big grin on her face. You say goodbye to her in return and part ways.`

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -164,6 +164,7 @@ mission "Remnant: Lost in Ember Waste"
 		governmant "Remnant"
 	to offer
 		has "event: lost in ember waste"
+	on offer
 		outfit "Quantum Key Stone" 1
 		log `Became stuck in the Ember Waste, but was given a quantum key stone by an old woman who claims to have once been stuck in Republic space under similar circumstances.`
 		conversation

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -161,6 +161,7 @@ mission "Remnant: Lost in Ember Waste"
 	to offer
 		has "event: lost in ember waste"
 		outfit "Quantum Key Stone" 1
+		log `Became stuck in the Ember Waste, but was given a quantum key stone by an old woman who claims to have once been stuck in Republic space under similar circumstances.`
 		conversation
 			`You wander the <origin> spaceport feeling very lost in this strange region of space. Having flown around for a few weeks with no idea of how to get out, you wonder if you'll be stuck here forever.`
 			`	You sit down on a bench and think about how you're going to get out of this situation. While you think, an old woman approaches you and signs something.`
@@ -214,7 +215,7 @@ mission "Remnant: Lost in Ember Waste"
 			`	"Well of course. How else would I have been able to return home?`
 			
 			label next
-			`	"To my surprise, the Hai had a large number of quantum key stones. I was so thrilled that I didn't even ask any questions about how they had them. I bought one and flew as fast as I could back to the Ember Waste, and I've been here ever since."`
+			`	"To my surprise, the Hai had a large number of quantum key stones." She pauses for a moment. "Might be a good idea for you to bring some of those Hai key stones here. Anyways, I was so thrilled that I didn't even ask any questions about how they had them. I bought one and flew as fast as I could back to the Ember Waste, and I've been here ever since."`
 			choice
 				`	"How long ago was that?"`
 				`	"What about your daughters?"`
@@ -224,7 +225,7 @@ mission "Remnant: Lost in Ember Waste"
 				goto end
 			
 			label daughtesr
-			`	"Oh, I made sure to tell them I was returning home. They know where to find me if they ever need me, and I have made trips to see them every decade or so.`
+			`	"Oh, I made sure to tell them I was returning home. They know where to find me if they ever need me, and I have made trips to see them every decade or so. I'm nearing the end of my days, though, so I may only have one more trip left in me.`
 			
 			label end
 			`	"I really must get going, now," she says. The woman gets up to leave, but before walking away she turns to you and sings, "Safe travels, Captain," with a big grin on her face. You say goodbye to her in return and part ways.`

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -215,7 +215,7 @@ mission "Remnant: Lost in Ember Waste"
 			`	"Well of course. How else would I have been able to return home?`
 			
 			label next
-			`	"To my surprise, the Hai had a large number of quantum key stones." She pauses for a moment. "Might be a good idea for you to bring some of those Hai key stones here. Anyways, I was so thrilled that I didn't even ask any questions about how they had them. I bought one and flew as fast as I could back to the Ember Waste, and I've been here ever since."`
+			`	"To my surprise, the Hai had a large number of quantum key stones." She pauses for a moment. "Might be a good idea for you to bring some of those Hai key stones here. Anyway, I was so thrilled that I didn't even ask any questions about how they had them. I bought one and flew as fast as I could back to the Ember Waste, and I've been here ever since."`
 			choice
 				`	"How long ago was that?"`
 				`	"What about your daughters?"`
@@ -1642,7 +1642,7 @@ mission "Remnant: Broken Jump Drive 2"
 				`	"Great! I will find more."`
 					goto end
 				`	"What are you studying?"`
-			`	"Our previous research into jump drives determined that these drives are unsurprisingly multi-part systems. We know the outer part that we can see and handle is mostly the machinery for generating some kind of containment field or pocket. As to how it works or why it is needed..." his chant trails off and he makes a gesture you suspect may be the equivalent of a shrug. "Anyways, our team is focused on the nature of this outer system. It is our hope that, damaged as it is, its continued existence might allow us to look a little farther inside its inner workings to figure out exactly what that field does and how it is used.`
+			`	"Our previous research into jump drives determined that these drives are unsurprisingly multi-part systems. We know the outer part that we can see and handle is mostly the machinery for generating some kind of containment field or pocket. As to how it works or why it is needed..." his chant trails off and he makes a gesture you suspect may be the equivalent of a shrug. "Anyway, our team is focused on the nature of this outer system. It is our hope that, damaged as it is, its continued existence might allow us to look a little farther inside its inner workings to figure out exactly what that field does and how it is used.`
 			label end
 			`	"Well, my compatriots finished unloading rather quickly, so I should be off. For all our sakes, I hope you find more of these for us."`
 

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -139,6 +139,98 @@ mission "Remnant Blood Test Patch"
 
 
 
+mission "lost in ember waste"
+	landing
+	invisible
+	to offer
+		has "remnant blood test pure"
+		not "license: Remnant"
+	on offer
+		attribute "quantum keystone" 0
+		require "Jump Drive" 0
+		event "lost in ember waste" 14
+		fail
+
+event "lost in ember waste"
+
+
+
+mission "Remnant: Lost in Ember Waste"
+	landing
+	invisible
+	to offer
+		has "event: lost in ember waste"
+		outfit "Quantum Key Stone" 1
+		conversation
+			`You wander the <origin> spaceport feeling very lost in this strange region of space. Having flown around for a few weeks with no idea of how to get out, you wonder if you'll be stuck here forever.`
+			`	You sit down on a bench and think about how you're going to get out of this situation. While you think, an old woman approaches you and signs something.`
+			choice
+				`	"Sorry, I don't understand."`
+			`	The old woman chuckles to herself. "You seem lost." She says. You nod. To your surprise, she doesn't sing everything she says like the other Remnant.
+			`	"I'm guessing you don't know about the wormholes."`
+			choice
+				`	"The what?"`
+				`	"I do, I just can't get through them."`
+					goto know
+			
+			`	"There are red wormholes scattered around this region of space. You can only access them if you have a key stone on your ship, though. Don't ask me how it works, but that's how it is."`
+				goto keystone
+			
+			label know
+			`	"Get scammed out of your key stone?" she asks with another chuckle. "Or maybe your jump drive, and now you're stuck here? No problem."`
+			
+			label keystone
+			`	The woman reaches into a bag that she has with her and hands you a quantum key stone. "Just put this on your ship and you can be on your way out of here."`
+			choice
+				`	"You're just giving this to me?"`
+					goto thanks
+				`	"What's the catch?"`
+			`	She chuckles again. "No catch."`
+			
+			label thanks
+			`	The woman sits down on the bench next to you. "I was once lost in Republic space for many years after losing my key stone. I know what it can be like to be away from your people for that long, so I'd rather not see you share the same fate."`
+			choice
+				`	"Thanks for the help. I'll go fit this on my ship."`
+				`	"How'd you get to Republic space."`
+					goto republic
+			
+			`	You say goodbye to the woman and begin walking to your ship. "Safe travels, Captain," she sings with a big grin on her face as you walk away.`
+				decline
+			
+			label republic
+			`	"I was an adventurous spirit in my youth," she says. "One day I found my way out of the Ember Waste and back to what I learned was the rest of humanity. For years my people had hidden here believing the Alphas had killed everyone else, but I now knew that we had little to fear.
+			`	"I explored the Republic for many months, learning what had happened since the Alpha Wars, but when I attempted to return to the Ember Waste to tell my people, I found that my key stone had been stolen at some point during my journey. I had no way to return."`
+			`	She lets out a long sigh. "I don't want to bore you with all the details, but I resigned myself to my new life. I met a man, had two daughters, but never lost hope of returning to my true home. One day, after my daughters had grown and my husband had passed in an accident, I decided to go on another adventure. I dusted off my old ship, and soon discovered Hai space."`
+			branch hai
+				has "First Contact: Hai"
+			choice
+				`	"The who?"`
+			`	"How you've discovered and become lost here without having discovered the Hai first is beyond me." She chuckles. "The Hai are a peaceful alien people north of humanity. Go looking for a purple wormhole in the uninhabited systems of the Far North. You may find your way there.`
+				goto next
+			
+			label hai
+			choice
+				`	"You've met the Hai?"`
+			`	"Well of course. How else would I have been able to return home?`
+			
+			label next
+			`	"To my surprise, the Hai had a large number of quantum key stones. I was so thrilled that I didn't even ask any questions about how they had them. I bought one and flew as fast as I could back to the Ember Waste, and I've been here ever since."`
+			choice
+				`	"How long ago was that?"`
+				`	"What about your daughters?"`
+					goto daughters
+			
+			`	"Well I got lost when I was 17 and returned when I was 64, so perhaps some 130 years ago now that I returned." She chuckles at the surprised look on your face as you realize that she is nearly 200 years old. "Uncovering ancient alien technology is quite the blessing.`
+				goto end
+			
+			label daughtesr
+			`	"Oh, I made sure to tell them I was returning home. They know where to find me if they ever need me, and I have made trips to see them every decade or so.`
+			
+			label end
+			`	"I really must get going, now," she says. The woman gets up to leave, but before walking away she turns to you and sings, "Safe travels, Captain," with a big grin on her face. You say goodbye to her in return and part ways.`
+				decline
+
+
 
 mission "Remnant: Defense 1"
 	name "Defend <planet>"

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -148,7 +148,8 @@ mission "lost in ember waste"
 		has "remnant blood test pure"
 		not "license: Remnant"
 	on offer
-		attribute "quantum keystone" 0
+		require "Quantum Keystone" 0
+		require "Quantum Key Stone" 0
 		require "Jump Drive" 0
 		event "lost in ember waste" 14
 		fail

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -143,7 +143,7 @@ mission "lost in ember waste"
 	landing
 	invisible
 	source
-		governmant "Remnant"
+		government "Remnant"
 	to offer
 		has "remnant blood test pure"
 		not "license: Remnant"
@@ -162,7 +162,7 @@ mission "Remnant: Lost in Ember Waste"
 	landing
 	invisible
 	source
-		governmant "Remnant"
+		government "Remnant"
 	to offer
 		has "event: lost in ember waste"
 	on offer
@@ -173,7 +173,7 @@ mission "Remnant: Lost in Ember Waste"
 			`	You sit down on a bench and think about how you're going to get out of this situation. While you think, an old woman approaches you and signs something.`
 			choice
 				`	"Sorry, I don't understand."`
-			`	The old woman chuckles to herself. "You seem lost," she says. You nod. To your surprise, she doesn't sing everything she says like the other Remnant.
+			`	The old woman chuckles to herself. "You seem lost," she says. You nod. To your surprise, she doesn't sing everything she says like the other Remnant.`
 			`	"I'm guessing you don't know about the wormholes."`
 			choice
 				`	"The what?"`

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -167,7 +167,7 @@ mission "Remnant: Lost in Ember Waste"
 			`	You sit down on a bench and think about how you're going to get out of this situation. While you think, an old woman approaches you and signs something.`
 			choice
 				`	"Sorry, I don't understand."`
-			`	The old woman chuckles to herself. "You seem lost." She says. You nod. To your surprise, she doesn't sing everything she says like the other Remnant.
+			`	The old woman chuckles to herself. "You seem lost," she says. You nod. To your surprise, she doesn't sing everything she says like the other Remnant.
 			`	"I'm guessing you don't know about the wormholes."`
 			choice
 				`	"The what?"`
@@ -192,21 +192,21 @@ mission "Remnant: Lost in Ember Waste"
 			`	The woman sits down on the bench next to you. "I was once lost in Republic space for many years after losing my key stone. I know what it can be like to be away from your people for that long, so I'd rather not see you share the same fate."`
 			choice
 				`	"Thanks for the help. I'll go fit this on my ship."`
-				`	"How'd you get to Republic space."`
+				`	"How'd you get to Republic space?"`
 					goto republic
 			
 			`	You say goodbye to the woman and begin walking to your ship. "Safe travels, Captain," she sings with a big grin on her face as you walk away.`
 				decline
 			
 			label republic
-			`	"I was an adventurous spirit in my youth," she says. "One day I found my way out of the Ember Waste and back to what I learned was the rest of humanity. For years my people had hidden here believing the Alphas had killed everyone else, but I discovered that we had little to fear.
+			`	"I was an adventurous spirit in my youth," she says. "One day I found my way out of the Ember Waste and back to what I learned was the rest of humanity. For years my people had hidden here believing the Alphas had killed everyone else, but I discovered that we had little to fear.`
 			`	"I explored the Republic for many months, learning what had happened since the Alpha Wars, but when I attempted to return to the Ember Waste to tell my people, I found that my key stone had been stolen at some point during my journey. I had no way to return."`
 			`	She lets out a long sigh. "I don't want to bore you with all the details, but I resigned myself to my new life. I met a man, had two daughters, but never lost hope of returning to my true home. One day, after my daughters had grown and my husband had passed in an accident, I decided to go on another adventure. I dusted off my old ship, and soon discovered Hai space."`
 			branch hai
 				has "First Contact: Hai"
 			choice
 				`	"The who?"`
-			`	"How you've discovered and become lost here without having discovered the Hai first is beyond me." She chuckles. "The Hai are a peaceful alien people north of humanity. Go looking for a purple wormhole in the uninhabited systems of the Far North. You may find your way there.`
+			`	"How you've become lost here without having discovered the Hai first is beyond me." She chuckles. "The Hai are a peaceful alien people north of humanity. Go looking for a purple wormhole in the uninhabited systems of the Far North. You may find your way there.`
 				goto next
 			
 			label hai

--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -334,6 +334,8 @@ outfit "Emergency Ramscoop"
 
 outfit "Quantum Key Stone"
 	category "Systems"
+	licenses
+		Remnant
 	cost 240000
 	thumbnail "outfit/keystone"
 	"mass" 1


### PR DESCRIPTION
Ref: #4491, #4493

This PR adds a mission that accounts for the scenario where the player enters the Ember Waste but loses their jump drive and/or quantum keystone for whatever reason and becomes stuck. The mission will only offer if the player doesn't have a quantum keystone/key stone and doesn't have a jump drive. Once the player is in this situation, they will trigger and event on a 14 day delay that triggers the mission. This delay is so that the player gets a sense of being stuck before help shows up. I just thought it'd be more interesting that way. 

This change reverts #4491 since that change will no longer be necessary to get the player out of this scenario.

Also, felt like pinning down the Caelian description with some story. Let it be known that the Remnant found out that the Alpha Wars had ended in the 2880s.