### PR TITLE
Randomly generate the offer dialouge for Courier 2

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1839,7 +1839,7 @@ phrase "generic human package offer"
 	word
 		` `
 	word
-		`appears from seemingly nowhere to say`
+		`appears from seemingly nowhere to ask,`
 		`approaches you and says,`
 		`flags you down and asks,`
 		`walks up to you and asks,`
@@ -1850,7 +1850,7 @@ phrase "generic human package offer"
 		`"Excuse me, Captain.`
 		`"Hello, Captain.`
 		`"Hello.`
-		`"Sorry to inturrupt, but`
+		`"Sorry to interrupt, but`
 	word
 		` `
 	word

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1828,6 +1828,50 @@ mission "Courier 1"
 		dialog phrase "generic cargo delivery payment"
 
 
+phrase "generic human package offer"
+	word
+		`A local`
+		`A man`
+		`A resident of <source>`
+		`A stranger`
+		`A woman`
+		`One of the spaceport's dock workers`
+	word
+		` `
+	word
+		`appears from seemingly nowhere to say`
+		`approaches you and says,`
+		`flags you down and asks,`
+		`walks up to you and asks,`
+	word
+		` `
+	word
+		`"Captain,`
+		`"Excuse me, Captain.`
+		`"Hello, Captain.`
+		`"Hello.`
+		`"Sorry to inturrupt, but`
+	word
+		` `
+	word
+		`I have a small package that needs to get to <planet> by <day>.`
+		`I'm trying to get a package to a relative on <planet> by <day>.`
+		`one of my clients on <planet> needs this package by <day>.`
+		`I'm trying to get this package to <planet> before <day>.`
+	word
+		` `
+	word
+		`Are you able to carry it for me?`
+		`Can you carry it for me?`
+		`Could you take it there?`
+		`Can you help me out with this?`
+	word
+		``
+		` I'll give you <payment> for the effort.`
+		` I'm willing to pay you <payment>.`
+		` I can afford to give you <payment> for it.`
+	word
+		`"`
 
 mission "Courier 2"
 	name "Package to <planet>"
@@ -1844,9 +1888,7 @@ mission "Courier 2"
 		distance 7 14
 		government "Republic" "Free Worlds" "Syndicate" "Quarg" "Neutral"
 	on offer
-		dialog `A woman in the spaceport flags you down and asks, "Excuse me, Captain. I have small package that needs to get to <planet> by <day>. Can you carry it for me?"`
-	on visit
-		dialog phrase "generic cargo on visit"
+		dialog phrase "generic package offer"
 	on complete
 		payment
 		payment 50000

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1889,6 +1889,8 @@ mission "Courier 2"
 		government "Republic" "Free Worlds" "Syndicate" "Quarg" "Neutral"
 	on offer
 		dialog phrase "generic package offer"
+	on visit
+		dialog phrase "generic cargo on visit"
 	on complete
 		payment
 		payment 50000

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1835,7 +1835,6 @@ phrase "generic human package offer"
 		`A resident of <source>`
 		`A stranger`
 		`A woman`
-		`One of the spaceport's dock workers`
 	word
 		` `
 	word
@@ -1843,20 +1842,20 @@ phrase "generic human package offer"
 		`approaches you and says,`
 		`flags you down and asks,`
 		`walks up to you and asks,`
+		`stops you and asks,`
 	word
-		` `
+		` "`
 	word
-		`"Captain,`
-		`"Excuse me, Captain.`
-		`"Hello, Captain.`
-		`"Hello.`
-		`"Sorry to interrupt, but`
+		`Captain,`
+		`Excuse me, Captain.`
+		`Sorry to interrupt, but`
+		`Hey there, Captain.`
 	word
 		` `
 	word
 		`I have a small package that needs to get to <planet> by <day>.`
 		`I'm trying to get a package to a relative on <planet> by <day>.`
-		`one of my clients on <planet> needs this package by <day>.`
+		`I need to get this package to one of my clients on <planet> by <day>.`
 		`I'm trying to get this package to <planet> before <day>.`
 	word
 		` `
@@ -1866,7 +1865,6 @@ phrase "generic human package offer"
 		`Could you take it there?`
 		`Can you help me out with this?`
 	word
-		``
 		` I'll give you <payment> for the effort.`
 		` I'm willing to pay you <payment>.`
 		` I can afford to give you <payment> for it.`

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1886,7 +1886,7 @@ mission "Courier 2"
 		distance 7 14
 		government "Republic" "Free Worlds" "Syndicate" "Quarg" "Neutral"
 	on offer
-		dialog phrase "generic package offer"
+		dialog phrase "generic human package offer"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete


### PR DESCRIPTION
I'm not sure about the formatting, since I don't know of any examples of this in the current game.

This makes Courier 2 (the small package mission) have several different offer dialogues, which are generated in the same way as the hail dialogue. For an example of what this can generate: `A resident of Earth approaches you and says, "Sorry to interrupt, but I have a small package that needs to get to New Boston by April 32nd, 3012. I'm willing to pay you 2 credits for it."`. I also made it so that it tells you how much you'll get paid for it 3 out of 4 times. (The current offer never states payment.) The longest possible combination is 237 characters long, which is 43 characters shorter than Courier 3's offer.