### PR TITLE
Add phrase expansion and replacement functions to the phrase node.

### DIFF
--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -232,35 +232,6 @@ string Format::Replace(const string &source, const map<string, string> keys)
 
 
 
-string Format::Replace(const string &source, const function<string (const string&)> &subst)
-{
-	string result;
-	result.reserve(source.length());
-	
-	size_t start = 0;
-	while(start < source.length())
-	{
-		size_t left = source.find("${", start);
-		if(left == string::npos)
-			break;
-		
-		size_t right = source.find('}', left);
-		if(right == string::npos)
-			break;
-		
-		++right;
-		size_t length = right - left;
-		result.append(source, start, left - start);
-		result.append(subst(string(source, left + 2, length - 3)));
-		start = right;
-	}
-	
-	result.append(source, start, source.length() - start);
-	return result;
-}
-
-
-
 string Format::Capitalize(const string &str)
 {
 	string result = str;

--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -232,6 +232,35 @@ string Format::Replace(const string &source, const map<string, string> keys)
 
 
 
+string Format::Replace(const string &source, const function<string (const string&)> &subst)
+{
+	string result;
+	result.reserve(source.length());
+	
+	size_t start = 0;
+	while(start < source.length())
+	{
+		size_t left = source.find("${", start);
+		if(left == string::npos)
+			break;
+		
+		size_t right = source.find('}', left);
+		if(right == string::npos)
+			break;
+		
+		++right;
+		size_t length = right - left;
+		result.append(source, start, left - start);
+		result.append(subst(string(source, left + 2, length - 3)));
+		start = right;
+	}
+	
+	result.append(source, start, source.length() - start);
+	return result;
+}
+
+
+
 string Format::Capitalize(const string &str)
 {
 	string result = str;

--- a/source/Format.h
+++ b/source/Format.h
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef FORMAT_H_
 #define FORMAT_H_
 
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -38,6 +39,9 @@ public:
 	// Replace a set of "keys," which must be strings in the form "<name>", with
 	// a new set of strings, and return the result.
 	static std::string Replace(const std::string &source, const std::map<std::string, std::string> keys);
+	// Replace a sub-string "${name}" with a result of subst("name").
+	static std::string Replace(const std::string &source,
+		const std::function<std::string (const std::string&)> &subst);
 	
 	// Convert a string to title caps or to lower case.
 	static std::string Capitalize(const std::string &str);

--- a/source/Format.h
+++ b/source/Format.h
@@ -13,7 +13,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef FORMAT_H_
 #define FORMAT_H_
 
-#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -39,9 +38,6 @@ public:
 	// Replace a set of "keys," which must be strings in the form "<name>", with
 	// a new set of strings, and return the result.
 	static std::string Replace(const std::string &source, const std::map<std::string, std::string> keys);
-	// Replace a sub-string "${name}" with a result of subst("name").
-	static std::string Replace(const std::string &source,
-		const std::function<std::string (const std::string&)> &subst);
 	
 	// Convert a string to title caps or to lower case.
 	static std::string Capitalize(const std::string &str);

--- a/source/Phrase.cpp
+++ b/source/Phrase.cpp
@@ -139,7 +139,7 @@ Phrase::Choice::Choice(const DataNode &node, bool isPhraseName)
 	}
 	// Add the remaining text to the sequence.
 	if(entry.length() - start > 0)
-		emplace_back(string(entry, start, entry.length() - start), nullptr);
+		emplace_back(string{entry, start, entry.length() - start}, nullptr);
 }
 
 

--- a/source/Phrase.cpp
+++ b/source/Phrase.cpp
@@ -13,10 +13,30 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Phrase.h"
 
 #include "DataNode.h"
+#include "Format.h"
 #include "GameData.h"
 #include "Random.h"
 
 using namespace std;
+
+namespace {
+	// Replace oldStr with newStr in target.
+	string Replace(const string &target, const string &oldStr, const string &newStr)
+	{
+		const size_t oldSize = oldStr.size();
+		const size_t newSize = newStr.size();
+		string result(target);
+		for(size_t pos = 0;;)
+		{
+			pos = result.find(oldStr, pos);
+			if(pos == string::npos)
+				break;
+			result.replace(pos, oldSize, newStr);
+			pos += newSize;
+		}
+		return result;
+	}
+}
 
 
 
@@ -34,7 +54,22 @@ void Phrase::Load(const DataNode &node)
 		if(child.Token(0) == "word")
 		{
 			for(const DataNode &grand : child)
-				part.words.push_back(grand.Token(0));
+			{
+				const string &word = grand.Token(0);
+				bool error = false;
+				Format::Replace(word, [&](const string &s) -> string
+					{
+						const Phrase *subphrase = GameData::Phrases().Get(s);
+						if(subphrase->ReferencesPhrase(this))
+						{
+							child.PrintTrace("Found recursive phrase reference:");
+							error = true;
+						}
+						return "";
+					});
+				if(!error)
+					part.words.push_back(word);
+			}
 		}
 		else if(child.Token(0) == "phrase")
 		{
@@ -47,11 +82,21 @@ void Phrase::Load(const DataNode &node)
 					part.phrases.push_back(subphrase);
 			}
 		}
+		else if(child.Token(0) == "replace")
+		{
+			for(const DataNode &grand : child)
+			{
+				const string o(grand.Token(0));
+				const string n(grand.Size() >= 2 ? grand.Token(1) : "");
+				auto f = [o, n](const string &s) -> string { return Replace(s, o, n); };
+				part.replaceRules.emplace_back(f);
+			}
+		}
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 		
-		// If no words or phrases were given, discard this part of the phrase.
-		if(part.words.empty() && part.phrases.empty())
+		// If no words, phrases, or replaces were given, discard this part of the phrase.
+		if(part.words.empty() && part.phrases.empty() && part.replaceRules.empty())
 			parts.back().pop_back();
 	}
 }
@@ -76,7 +121,18 @@ string Phrase::Get() const
 		if(!part.phrases.empty())
 			result += part.phrases[Random::Int(part.phrases.size())]->Get();
 		else if(!part.words.empty())
-			result += part.words[Random::Int(part.words.size())];
+		{
+			string word = part.words[Random::Int(part.words.size())];
+			word = Format::Replace(word, [&](const string &s) -> string
+				{
+					const Phrase *subphrase = GameData::Phrases().Get(s);
+					return subphrase->Get();
+				});
+			result += word;
+		}
+		else if(!part.replaceRules.empty())
+			for(auto f : part.replaceRules)
+				result = f(result);
 	}
 	
 	return result;

--- a/source/Phrase.h
+++ b/source/Phrase.h
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef PHRASE_H_
 #define PHRASE_H_
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,7 @@ private:
 	public:
 		std::vector<std::string> words;
 		std::vector<const Phrase *> phrases;
+		std::vector<std::function<std::string(const std::string&)>> replaceRules;
 	};
 	
 	

--- a/source/Phrase.h
+++ b/source/Phrase.h
@@ -32,20 +32,36 @@ public:
 	
 	
 private:
+	friend class Sentense;
 	bool ReferencesPhrase(const Phrase *phrase) const;
 	
 	
+public:
+	// Option represents a child node in a "word" or "phrase" node.
+	using Option = std::vector<std::pair<std::string, const Phrase*>>;
+	
+	
 private:
+	// Part represents a "word", "phrase", or "replace" in a phrase node.
 	class Part {
 	public:
-		std::vector<std::vector<std::pair<std::string, const Phrase*>>> words;
+		std::vector<Option> options;
 		std::vector<std::function<std::string(const std::string&)>> replaceRules;
+	};
+	
+	// Sentense represents a phrase node.
+	class Sentense {
+	public:
+		void Load(const DataNode &node, const Phrase* parent);
+		
+		std::vector<Part> parts;
 	};
 	
 	
 private:
 	std::string name;
-	std::vector<std::vector<Part>> parts;
+	// Each time this phrase is defined, a new sentence is created.
+	std::vector<Sentense> sentenses;
 };
 
 

--- a/source/Phrase.h
+++ b/source/Phrase.h
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 class DataNode;
@@ -37,8 +38,7 @@ private:
 private:
 	class Part {
 	public:
-		std::vector<std::string> words;
-		std::vector<const Phrase *> phrases;
+		std::vector<std::vector<std::pair<std::string, const Phrase*>>> words;
 		std::vector<std::function<std::string(const std::string&)>> replaceRules;
 	};
 	


### PR DESCRIPTION
This PR adds 2 functions to the phrase node in order to avoid combinatorial explosion.
ref. #4533 and [this comment](https://github.com/endless-sky/endless-sky/issues/558#issuecomment-487903300).

(1) phrase expansion
A word in the phrase node can include phrase expansions:
```
phrase "buy and sell"
    word
        "buy ${contraband} from"
        "sell ${contraband} to"
```
"contraband" is a phrase name.

(2) child node "replace"
The "replace" node specifies the way of replacement some strings.

```
phrase "test phrase"
	word
		"I suspect that"
	word
		" "
	word
		"the CEO of the Syndicate%"
		"the leaders of the Syndicate"
	word
		" "
	word
		"don't have our best interests at heart."
		"are keeping secrets from the rest of the galaxy."
		"try to do right by people."
	replace
		"% do" " does"
		"% are" " is"
		"% try" " tries"
		"%" ""
```
I plan to create a translation support that needs these functions.