### PR TITLE
Updating Protector Description

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2412,7 +2412,7 @@ ship "Protector"
 	explode "medium explosion" 24
 	explode "large explosion" 8
 	"final explode" "final explosion large"
-	description `Voted the "ugliest ship in the sky" by Stars and Starships Magazine, the Protector is a typical example of brutally efficient Syndicate engineering. It is basically nothing more than six blaster turrets attached to a set of engines and crew's quarters, designed as a defense platform that can accompany merchant convoys.`
+	description `Voted the "ugliest ship in the sky" by Stars and Starships Magazine, the Protector is a typical example of brutally efficient Syndicate engineering. It is basically nothing more than six turrets attached to a set of engines and crew's quarters, designed as a defense platform that can accompany merchant convoys.`
 
 
 


### PR DESCRIPTION
Removing the word "blaster" to reflect the fact that the Protector now carries two anti-missile turrets in addition to the blaster turrets.

Thanks to Hyugat on the ES Discord for pointing out this discrepancy. 