### PR TITLE
Added missing hails to alien governments

### DIFF
--- a/data/coalition.txt
+++ b/data/coalition.txt
@@ -756,15 +756,15 @@ phrase "friendly heliarch"
 
 phrase "friendly disabled heliarch"
 	word
-		"Repairs, we do need."
-		"Disabled, our ship has become."
-		"Disabled, our ship is. "
+		"Repairs, we do need"
+		"Disabled, our ship has become"
+		"Disabled, our ship is"
 	word
-		" "
+		". "
 	word
 		"Board our ship, you must"
 		"Help, you must"
-		"Appreciated, assistance would be."
+		"Appreciated, assistance would be"
 	word
 		"."
 
@@ -959,6 +959,8 @@ phrase "hostile disabled heliarch"
 		"A "
 	phrase
 		"shakespearean insults"
+	word
+		" "
 	word
 		", you are"
 		"at the mercy of, I can not believe I am"

--- a/data/coalition.txt
+++ b/data/coalition.txt
@@ -754,6 +754,20 @@ phrase "friendly heliarch"
 	word
 		"."
 
+phrase "friendly disabled heliarch"
+	word
+		"Repairs, we do need."
+		"Disabled, our ship has become."
+		"Disabled, our ship is. "
+	word
+		" "
+	word
+		"Board our ship, you must"
+		"Help, you must"
+		"Appreciated, assistance would be."
+	word
+		"."
+
 phrase "hostile heliarch phrase 1 (the+our)"
 	word
 		"the"
@@ -922,3 +936,46 @@ phrase "hostile heliarch"
 		"not be extinct"
 	word
 		"!"
+
+phrase "hostile disabled heliarch"
+	word
+		"You"
+		"Alone, you must leave me, you"
+		"Meet me again, you'd better hope never happen, you"
+		"Cross me, you'd better not, you"
+		"Avenge me, my friends will, you"
+		"Away from me, you must stay, you"
+		"Board me, I dare the"
+	word
+		" "
+	phrase
+		"shakespearean insults"
+	word
+		"."
+		"!"
+
+phrase "hostile disabled heliarch"
+	word
+		"A "
+	phrase
+		"shakespearean insults"
+	word
+		", you are"
+		"at the mercy of, I can not believe I am"
+	word
+		"."
+		"!"
+
+phrase "hostile disabled heliarch"
+	word
+		"("
+	word
+		"The Heliarch ship hails you, speaking in a language you do not understand."
+		"The Heliarch yell at you in an alien language."
+	word
+		" "
+	word
+		"Their translation device must be broken"
+		"You can only wonder what they're saying
+	word
+		".)"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -93,7 +93,9 @@ government "Hai"
 	"bribe" .02
 	"fine" 0
 	"friendly hail" "friendly hai"
+	"friendly disabled hail" "friendly disabled hai"
 	"hostile hail" "hostile hai"
+	"hostile disabled hail" "hostile disabled hai"
 
 government "Hai (Unfettered)"
 	swizzle 4
@@ -109,14 +111,18 @@ government "Hai (Unfettered)"
 	"bribe" .02
 	"fine" 0
 	"friendly hail" "friendly unfettered"
+	"friendly disabled hail" "friendly disabled unfettered"
 	"hostile hail" "hostile unfettered"
+	"hostile disabled hail" "hostile disabled unfettered"
 
 government "Heliarch"
 	swizzle 0
 	color 1 .8 .5
 	"player reputation" 1
 	"friendly hail" "friendly heliarch"
+	"friendly disabled hail" "friendly disabled heliarch"
 	"hostile hail" "hostile heliarch"
+	"hostile disabled hail" "hostile disabled heliarch"
 	"attitude toward"
 		"Quarg" -.01
 		"Coalition" 1
@@ -297,7 +303,9 @@ government "Pug"
 		"Drak" -.01
 		"Quarg" -.01
 	"friendly hail" "friendly pug"
+	"friendly disabled hail" "friendly disabled pug"
 	"hostile hail" "hostile pug"
+	"hostile disabled hail" "hostile pug"
 
 government "Quarg"
 	swizzle 0
@@ -312,6 +320,7 @@ government "Quarg"
 		"Hai" .01
 		"Pirate" -.01
 	"hostile hail" "hostile quarg"
+	"hostile disabled hail" "hostile quarg"
 
 government "Remnant"
 	swizzle 0
@@ -383,5 +392,6 @@ government "Wanderer"
 	"player reputation" 1
 	language "Wanderer"
 	"friendly hail" "wanderer untranslated"
+	"friendly disabled hail" "wanderer untranslated"
 	"hostile hail" "wanderer untranslated"
 	"hostile disabled hail" "wanderer untranslated"

--- a/data/hai.txt
+++ b/data/hai.txt
@@ -197,50 +197,6 @@ fleet "Large Hai"
 		"Water Bug"
 		"Grasshopper (Tracker)"
 
-fleet "Hai Defense"
-	government "Hai"
-	names "hai"
-	personality
-		opportunistic
-	variant 2
-		"Shield Beetle"
-		"Lightning Bug (Pulse)" 2
-	variant 2
-		"Shield Beetle (Tracker)"
-		"Lightning Bug" 2
-	variant 1
-		"Shield Beetle"
-		"Lightning Bug (Pulse)"
-	variant 1
-		"Shield Beetle (Tracker)"
-		"Lightning Bug"
-	variant 3
-		"Shield Beetle (Tracker)"
-		"Shield Beetle"
-	variant 1
-		"Shield Beetle (Tracker)" 2
-	variant 1
-		"Shield Beetle" 2
-	variant 1
-		"Lightning Bug" 5
-	variant 3
-		"Shield Beetle (Pulse)"
-		"Lightning Bug (Pulse)" 2
-	variant 2
-		"Shield Beetle (Pulse)"
-		"Shield Beetle"
-	variant 2
-		"Shield Beetle (Pulse)"
-		"Shield Beetle (Tracker)"
-	variant
-		"Shield Beetle (Pulse)"
-		"Shield Beetle"
-		"Lightning Bug (Pulse)" 2
-	variant
-		"Shield Beetle (Pulse)"
-		"Shield Beetle (Tracker)"
-		"Lightning Bug" 2
-
 fleet "Small Unfettered"
 	government "Hai (Unfettered)"
 	names "hai"

--- a/data/hai.txt
+++ b/data/hai.txt
@@ -197,6 +197,50 @@ fleet "Large Hai"
 		"Water Bug"
 		"Grasshopper (Tracker)"
 
+fleet "Hai Defense"
+	government "Hai"
+	names "hai"
+	personality
+		opportunistic
+	variant 2
+		"Shield Beetle"
+		"Lightning Bug (Pulse)" 2
+	variant 2
+		"Shield Beetle (Tracker)"
+		"Lightning Bug" 2
+	variant 1
+		"Shield Beetle"
+		"Lightning Bug (Pulse)"
+	variant 1
+		"Shield Beetle (Tracker)"
+		"Lightning Bug"
+	variant 3
+		"Shield Beetle (Tracker)"
+		"Shield Beetle"
+	variant 1
+		"Shield Beetle (Tracker)" 2
+	variant 1
+		"Shield Beetle" 2
+	variant 1
+		"Lightning Bug" 5
+	variant 3
+		"Shield Beetle (Pulse)"
+		"Lightning Bug (Pulse)" 2
+	variant 2
+		"Shield Beetle (Pulse)"
+		"Shield Beetle"
+	variant 2
+		"Shield Beetle (Pulse)"
+		"Shield Beetle (Tracker)"
+	variant
+		"Shield Beetle (Pulse)"
+		"Shield Beetle"
+		"Lightning Bug (Pulse)" 2
+	variant
+		"Shield Beetle (Pulse)"
+		"Shield Beetle (Tracker)"
+		"Lightning Bug" 2
+
 fleet "Small Unfettered"
 	government "Hai (Unfettered)"
 	names "hai"
@@ -519,7 +563,22 @@ phrase "friendly hai"
 		"harmony."
 		"concord."
 		"cooperation."
-		
+
+phrase "friendly disabled hai"
+	word
+		"Fellow peacekeeper"
+		"Human visitor"
+		"Friend"
+	word
+		", "
+	word
+		"please provide assistance to us"
+		"our ship has been disabled and needs repaired"
+		"please spare a moment to rescue us"
+	word
+		"."
+		"!"
+
 phrase "hostile hai"
 	word
 		"You "
@@ -577,7 +636,40 @@ phrase "hostile hai"
 		"space."
 		"territory."
 		"worlds."
-	
+
+phrase "hostile disabled hai"
+	word
+		"You "
+	word
+		"impure"
+		"unclean"
+		"tainted"
+		"foul"
+		"shameful"
+		"violent"
+		"greedy"
+		"immoral"
+		"belligerent"
+		"brutal"
+		"cruel"
+		"heartless"
+	word
+		" "
+	word
+		"human"
+		"creature"
+		"thing"
+		"being"
+	word
+		". "
+		"! "
+	word
+		" We provided you sanctuary and you betrayed us."
+		" We were nothing but peaceful to you but you did not reciprocate."
+		" We live only in peace yet you come bringing war."
+		" Have you no soul?"
+		
+
 phrase "friendly unfettered"
 	word
 		"We "
@@ -625,6 +717,43 @@ phrase "friendly unfettered"
 		"unaltered"
 	word
 		" Hai."
+
+phrase "friendly disabled unfettered"
+	word
+		"Strong"
+		"True"
+		"Ambitious"
+		"Worthy"
+	word
+		" "
+	word
+		"warrior"
+		"human"
+		"ally"
+	word
+		"! "
+		". "
+	word
+		"These weaklings"
+		"Our enemies"
+		"They"
+	word
+		" have "
+	word
+		"disabled us"
+		"gotten the better of us"
+		"defeated us"
+	word
+		"! "
+		". "
+	word
+		"Assist us in our fight"
+		"Repair us so that we may continue in glorious battle"
+		"Fix our ship so that we may fight"
+		"Destroy our enemies before they destroy us"
+	word
+		"!"
+		"."
 		
 phrase "hostile unfettered"
 	word
@@ -662,3 +791,23 @@ phrase "hostile unfettered"
 		"unaltered"
 	word
 		" Hai!"
+
+phrase "hostile disabled unfettered"
+	word
+		"You coward"
+		"You weakling"
+		"You monkey"
+		"You pathetic nut"
+	word
+		"! "
+		". "
+	word
+		"Finish what you have started"
+		"My brothers and sisters will avenge me"
+		"My brothers and sisters will make short work of you after this"
+		"I challenge you to a duel! Board me"
+		"I dare you to board me"
+		"Let's finish this face to face"
+	word
+		"!"
+		"."

--- a/data/hai.txt
+++ b/data/hai.txt
@@ -529,7 +529,7 @@ phrase "friendly disabled hai"
 		", "
 	word
 		"please provide assistance to us"
-		"our ship has been disabled and needs repaired"
+		"our ship has been disabled and needs repair"
 		"please spare a moment to rescue us"
 	word
 		"."

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -2189,6 +2189,8 @@ phrase "hostile disabled"
 		"You'd better not cross me, you"
 		"My friends will avenge me, you"
 		"Stay away from me, you"
+	word
+		" "
 	phrase
 		"shakespearean insults"
 	word

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -1523,7 +1523,7 @@ phrase "friendly disabled pug"
 	word
 		"We are only a part of a larger whole"
 		"Our time has come"
-		"We are defeated, but the casue continues"
+		"We are defeated, but the cause continues"
 	word
 		"; "
 	word

--- a/data/hails.txt
+++ b/data/hails.txt
@@ -1519,6 +1519,20 @@ phrase "friendly pug"
 		" through-out the universe."
 		" among all sentient beings."
 
+phrase "friendly disabled pug"
+	word
+		"We are only a part of a larger whole"
+		"Our time has come"
+		"We are defeated, but the casue continues"
+	word
+		"; "
+	word
+		"leave us be to perish"
+		"continue fighting without us"
+		"worry not about us"
+	word
+		"."
+
 phrase "friendly pirate"
 	word
 		"We're"
@@ -2175,8 +2189,13 @@ phrase "hostile disabled"
 		"You'd better not cross me, you"
 		"My friends will avenge me, you"
 		"Stay away from me, you"
+	phrase
+		"shakespearean insults"
 	word
-		" "
+		"."
+		"!"
+
+phrase "shakespearean insults"
 	word
 		"artless"
 		"bawdy"
@@ -2334,9 +2353,6 @@ phrase "hostile disabled"
 		"vassal"
 		"whey-face"
 		"wagtail"
-	word
-		"."
-		"!"
 
 phrase "hostile civilian"
 	word
@@ -3121,7 +3137,7 @@ phrase "hostile pug"
 		"misdeed"
 	word
 		"."
-		
+
 phrase "hostile syndicate"
 	word
 		"We defend the Syndicate"

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -273,6 +273,7 @@ mission "Visit Wanderers Again"
 event "wanderer technology available" #Name unchanged for compatibility
 	government "Wanderer"
 		"friendly hail" "friendly wanderer"
+		"friendly disabled hail" "friendly disabled wanderer"
 		"hostile hail" "hostile wanderer"
 		"hostile disabled hail" "hostile disabled wanderer"
 

--- a/data/wanderers.txt
+++ b/data/wanderers.txt
@@ -481,8 +481,34 @@ phrase "friendly wanderer"
 		"[cure, remedy]"
 	word
 		" them."
-		
-		
+
+phrase "friendly disabled wanderer"
+	word
+		"[Visitor, Traveler]"
+		"Guest"
+	word
+		", "
+	word
+		"our work is in [danger, peril]"
+		"we have been [assaulted, attacked]"
+		"we have become [disabled, incapacitated]"
+	word
+		". "
+		"! "
+	word
+		"We need to be [repaired, fixed]"
+		"Assist us"
+		"Fight for us"
+	word
+		", please"
+		", we beg you"
+		""
+		""
+		""
+	word
+		"."
+		"!"
+
 phrase "hostile wanderer"
 	word
 		"We do not wish to "


### PR DESCRIPTION
Ref: #2526, #4549

This PR adds hails to alien governments where they were missing, aside from the Remnant which I think @Zitchas should handle.

These hails aren't meant to be comprehensive, as you may notice that some yield a low number of combinations. I expect @Pointedstick to be able to take what's done here and run pretty far with it so that we have hail diversity in areas that aren't just human space. This PR is mainly for just filling in some holes in alien hails, but this should be expanded upon.

In some instances (Pug, Quarg), the hostile hails and hostile disabled hails are the same. I did this because I felt that the hostile hails fit good enough to also be hostile disabled hails.