### PR TITLE
Copy requiredOutfits in MissionAction::Instantiate().

### DIFF
--- a/changelog
+++ b/changelog
@@ -17,6 +17,7 @@ Version 0.9.10:
     * Mission NPCs that have no saved system will not crash the game when the player departs a planet. (@tehhowch)
     * Ship thumbnails are now saved, just like sprites. (@MageKing17)
     * Hostile Mereti ships during the Wanderer Mind missions will no longer return understandable hails. (@Amazinite)
+    * The "require" mission tag is now evaluated in all actions, not just when the mission is offered. (@MageKing17)
   * Game content:
     * Black holes now have a landing message. (@Comnom)
     * Pirate occupation spaceport missions will no longer cause the player to launch if the occupation is in another system. (@ZBok)

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -483,6 +483,7 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 		result.events[it.first] = make_pair(day, day);
 	}
 	result.gifts = gifts;
+	result.requiredOutfits = requiredOutfits;
 	result.payment = payment + (jumps + 1) * payload * paymentMultiplier;
 	// Fill in the payment amount if this is the "complete" action.
 	string previousPayment = subs["<payment>"];


### PR DESCRIPTION
When `requiredOutfits` was implemented, it was included in `MissionAction::Save()` but not `MissionAction::Instantiate()`; since mission( action)s aren't saved until after they've been instantiated, this effectively meant that `requiredOutfits` could never be saved, and also couldn't be checked in any blocks except `on offer`, `on accept`, or `on decline`, all of which would have the same effect: prevent the mission from being offered if the `require` check failed.

This adds a line to copy `requiredOutfits` when instantiating the `MissionAction` object, allowing it to be saved in the save file and used for blocks not checked when the mission is offered.

Fixes #4554 (hopefully).