### PR TITLE
Make "Southbound Shipyard's" plural in Fury description.

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1572,7 +1572,7 @@ ship "Fury"
 	leak "flame" 50 80
 	explode "tiny explosion" 10
 	explode "small explosion" 20
-	description "The Fury is Southbound Shipyard's most popular design of escort ship. They have greater firepower than any other interceptor-class vessel, meaning that any pirate flying solo will think twice before attacking a convoy that is accompanied by a Fury. However, Furies are also much less maneuverable than other small ships."
+	description "The Fury is Southbound Shipyards' most popular design of escort ship. They have greater firepower than any other interceptor-class vessel, meaning that any pirate flying solo will think twice before attacking a convoy that is accompanied by a Fury. However, Furies are also much less maneuverable than other small ships."
 
 
 


### PR DESCRIPTION
According to every other ship description, "Southbound Shipyards" is the correct name, and this was probably a transposition typo.