### PR TITLE
Draft a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
+(You can open a PR to add or improve a section, if you find them lacking!) 
+
+----------------------
+**Content**
+
+## Summary
+{{summarize your content! Include links to related issues}}
+
+## Save File
+This save file can be used to play through the new content:
+{{attach a save file that allows people to easily test your added content}}
+
+## PR Checklist
+ - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
+ - [ ] I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}
+  
+  
+-----------------------
+**Bugfix:** This PR addresses issue #{{insert number}}
+
+## Fix Details
+{{add details}}
+
+## Save File
+This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
+{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}
+
+
+-----------------------
+**Feature:** This PR implements the feature request detailed and discussed in issue #{{insert number}}
+
+## Feature Details
+{{add details about the feature you implemented}}
+
+## UI Screenshots
+{{attach before + after screenshots of any changes to UI, or replace this line with "N/A"}}
+
+## Usage Examples
+{{if this feature is used in the data files, provide examples!}}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,18 +2,19 @@ NOTICE: Delete the sections that do not apply to your PR, and fill out the secti
 (You can open a PR to add or improve a section, if you find them lacking!) 
 
 ----------------------
-**Content**
+**Content (Artwork / Missions / Jobs)**
 
 ## Summary
-{{summarize your content! Include links to related issues}}
+{{summarize your content! Include links to related issues, in-game screenshots, etc.}}
 
 ## Save File
-This save file can be used to play through the new content:
-{{attach a save file that allows people to easily test your added content}}
+This save file can be used to play through the new mission content:
+{{attach a save file that allows people to easily test your added mission content or see your new in-game art}}
 
 ## PR Checklist
  - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
  - [ ] I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}
+ - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}
   
   
 -----------------------


### PR DESCRIPTION
Current GitHub support for multiple PR templates is lacking (url parameters only!) so people will just need to remove the bits that don't apply.

https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template
A UI for picking the template when there are multiple templates is apparently "in the works" for more than a year.

**Link to the rendered markdown: [is here](https://github.com/endless-sky/endless-sky/blob/contrib/pr-template/.github/pull_request_template.md)**