### PR TITLE
Tweaks to some human transport ship stats to make them more viable choices

### DIFF
--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -75,7 +75,7 @@ ship "Centipede"
 		"required crew" 35
 		"bunks" 131
 		"mass" 187
-		"drag" 4
+		"drag" 3.9
 		"heat dissipation" .75
 		"fuel capacity" 600
 		"cargo space" 38

--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -74,7 +74,7 @@ ship "Centipede"
 		"hull" 2400
 		"required crew" 35
 		"bunks" 131
-		"mass" 168
+		"mass" 187
 		"drag" 4
 		"heat dissipation" .75
 		"fuel capacity" 600

--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -19,9 +19,9 @@ ship "Marauder Arrow"
 		"required crew" 2
 		"bunks" 5
 		"mass" 145
-		"drag" 2.5
+		"drag" 2.0
 		"heat dissipation" .85
-		"fuel capacity" 400
+		"fuel capacity" 600
 		"cargo space" 5
 		"outfit space" 210
 		"weapon capacity" 55

--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -19,13 +19,13 @@ ship "Marauder Arrow"
 		"required crew" 2
 		"bunks" 5
 		"mass" 145
-		"drag" 2.7
+		"drag" 2.5
 		"heat dissipation" .85
 		"fuel capacity" 400
 		"cargo space" 5
 		"outfit space" 210
 		"weapon capacity" 55
-		"engine capacity" 80
+		"engine capacity" 95
 		"self destruct" .25
 		weapon
 			"blast radius" 27

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2965,7 +2965,7 @@ ship "Star Queen"
 		"required crew" 41
 		"bunks" 112
 		"mass" 230
-		"drag" 5.5
+		"drag" 4.5
 		"heat dissipation" .65
 		"fuel capacity" 700
 		"cargo space" 60

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -141,13 +141,13 @@ ship "Arrow"
 		"required crew" 1
 		"bunks" 5
 		"mass" 130
-		"drag" 2.6
+		"drag" 2.5
 		"heat dissipation" .85
 		"fuel capacity" 400
 		"cargo space" 10
 		"outfit space" 180
 		"weapon capacity" 50
-		"engine capacity" 74
+		"engine capacity" 75
 		weapon
 			"blast radius" 24
 			"shield damage" 240

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -141,13 +141,13 @@ ship "Arrow"
 		"required crew" 1
 		"bunks" 5
 		"mass" 130
-		"drag" 2.7
+		"drag" 2.6
 		"heat dissipation" .85
 		"fuel capacity" 400
 		"cargo space" 10
 		"outfit space" 180
 		"weapon capacity" 50
-		"engine capacity" 60
+		"engine capacity" 74
 		weapon
 			"blast radius" 24
 			"shield damage" 240

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -141,9 +141,9 @@ ship "Arrow"
 		"required crew" 1
 		"bunks" 5
 		"mass" 130
-		"drag" 2.5
+		"drag" 2.0
 		"heat dissipation" .85
-		"fuel capacity" 400
+		"fuel capacity" 600
 		"cargo space" 10
 		"outfit space" 180
 		"weapon capacity" 50
@@ -2967,7 +2967,7 @@ ship "Star Queen"
 		"mass" 230
 		"drag" 5.5
 		"heat dissipation" .65
-		"fuel capacity" 500
+		"fuel capacity" 700
 		"cargo space" 60
 		"outfit space" 360
 		"weapon capacity" 120


### PR DESCRIPTION
In response to Issue #4567 "Making the Arrow Actually Fast", a proposed solution. 

<details><summary>Old PR description.</summary>Note: I'm not saying that this is definitely needed, but issue #4567 requested this change, so I'm PRing this as a possible solution that people can try out. This is probably a "minimal change" version that doesn't come anywhere near allowing the sorts of permanent speed boosts requested in that issue, but it would definitely make the Arrow a bit faster and give it better outfitting potential to be very zippy.

This PR changes:
- the Arrow's drag from 2.7 to 2.6 (increases base max speed from 606 to 630)
- the Arrow's engine space from 60 to 74 (which would give it the space to install an afterburner)

In stock configuration, this has a slight change, most notably it increases its speed to just barely be faster than a combat drone, and only slightly slower than a stock sparrow; thus improving its "run away" chances.

It does open things up for people interested in making a ship that relies on running away by allowing a little more flexibility in installing alternate engine configurations or adding an afterburner.</details>

<hr/>

@Amazinite here, editing the OP to explain the changes since Zitchas implemented stuff that I asked.

* Arrow and Star Queen fuel increases: A sign of a good transport ship should be its ability to travel long distances without needing to refuel. These two ships were on the lower side in terms of fuel capacity when compared to the other human transport ships, so they've had their fuel capacity increased.
* Arrow drag reduction: Despite the claim in the ship's description that it's one of the fastest ships around, the potential for the Arrow to go fast was actually very low. Reducing the drag makes the Arrow a truly fast ship, with its base max speed going from 607 to 819, as compared to the Flivver's base max of 924,
* Arrow engine space increase: One of the key attributes of stock ships is that they leave room to upgrade. The Arrow though already comes with atomic engines, so there's really no upgrade room. Increasing the engine space gives the Arrow some upgrade room, and allows it to reach even greater speeds.
* Star Queen drag reduction: The Star Queen has been a ship that many have considered useless; a transport ship with a high required crew that cuts into your profits. The ship isn't helped by its low speed either, although would could argue that it's intentionally low since the only people who use the ship are in a pirate free region of space. Still, the ship's drag has been reduced by a decent amount to make it more appealing.
* Centipede drag and mass changes: This ship's drag was reduced slightly to compensate for the Star Queen's drop in drag, as the Centipede was intentionally designed as an upgrade to the Star Queen. The mass was changed because when I was creating the Centipede, my spreadsheet had a typo for the Star Queen mass that resulted in my making the Centipede's mass lower than it should have been.