### PR TITLE
Basic editing pass on Marauder ship descriptions.

### DIFF
--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -55,7 +55,7 @@ ship "Marauder Arrow"
 	explode "small explosion" 18
 	explode "medium explosion" 6
 	"final explode" "final explosion small"
-	description "This Arrow has had numerous modifications to its hull and internal systems to make more room for outfits - mostly with combat in mind. More shields, weapons, engines, outfit space, and a turret mount nearly push this ship into the Light Warship category, and definitely make it one of the heaviest Interceptors you're likely to find."
+	description "This Arrow has had numerous modifications to its hull and internal systems to make more room for outfits - mostly with combat in mind. More shields, weapons, engines, outfit space, and a turret mount nearly push this ship into classification as a light warship, and definitely make it one of the heaviest interceptors you're likely to find."
 
 
 ship "Marauder Arrow" "Marauder Arrow (Engines)"
@@ -78,7 +78,7 @@ ship "Marauder Arrow" "Marauder Arrow (Engines)"
 		
 	engine -10 57
 	engine 10 57
-	description "With a third engine mount, you remark that this Arrow seems more like a missile. The beefed-up engines, a little extra outfit capacity, extra shield emitters, and thicker hull plating make this vessel a very competent Interceptor."
+	description "With a third engine mount, this Arrow seems more like an oversized missile than a ship. The beefed-up engines, a little extra outfit capacity, extra shield emitters, and thicker hull plating make this vessel a very competent interceptor."
 
 
 ship "Marauder Arrow" "Marauder Arrow (Weapons)"
@@ -105,7 +105,7 @@ ship "Marauder Arrow" "Marauder Arrow (Weapons)"
 	gun -7 -34 "Energy Blaster"
 	gun 7 -34 "Energy Blaster"
 	turret 0 15 "Heavy Laser Turret"
-	description "The weapons systems on this Arrow have been enhanced almost to the point of competing with Lionheart's Headhunter. The ship can still outrun all but the fastest ships, if things get a little too hairy."
+	description "The weapons systems on this Arrow have been enhanced to the point of competing with Lionheart's Headhunter, although it can still outrun all but the fastest ships, if things get a little too hairy."
 
 
 
@@ -159,7 +159,7 @@ ship "Marauder Bounder"
 	explode "small explosion" 20
 	explode "medium explosion" 15
 	"final explode" "final explosion small"
-	description "This Megaparsec Bounder has been modified from a courier-scout into a heavy escort Interceptor - currently the largest in the class. A little extra outfit space, reinforced turret mounts, a new gun port in front of the pilot, and additional shield emitters bring this former Transport into combat with fearsome speed and armament."
+	description "This Megaparsec Bounder has been modified from a courier-scout into a heavy escort interceptor - currently the largest in the class. A little extra outfit space, reinforced turret mounts, a new gun port in front of the pilot, and additional shield emitters grant this former transport both fearsome speed and armament."
 
 
 ship "Marauder Bounder" "Marauder Bounder (Engines)"
@@ -185,7 +185,7 @@ ship "Marauder Bounder" "Marauder Bounder (Engines)"
 	engine -12 58 .7
 	engine 0 51
 	engine 12 58 .7
-	description "The previous owner of this Bounder has modified an already fast courier-scout into an even faster heavy escort Interceptor with some truly enormous engines, making it incredibly fast for its size."
+	description "The previous owner of this Bounder has modified an already fast courier-scout into an even faster heavy escort interceptor with some truly enormous engines, giving it incredible maneuverability for its size."
 
 
 ship "Marauder Bounder" "Marauder Bounder (Weapons)"
@@ -215,7 +215,7 @@ ship "Marauder Bounder" "Marauder Bounder (Weapons)"
 	gun 7 -77 "Modified Blaster"
 	turret -37 4 "Heavy Laser Turret"
 	turret 37 4 "Heavy Laser Turret"
-	description "Simultaneously the deadliest and most graceful Interceptor in the galaxy, this once Bounder courier-scout has been equipped with incredibly powerful weapons for a ship of its size."
+	description "Simultaneously the deadliest and most graceful interceptor in the galaxy, this former Bounder courier-scout has been equipped with incredibly powerful weapons for a ship of its size."
 
 
 
@@ -310,7 +310,7 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 	turret 16 -24 "Modified Blaster Turret"
 	turret -57 32.5 "Blaster Turret"
 	turret 57 32.5 "Blaster Turret"
-	description "Whoever modified this Falcon clearly valued speed above all else. Major sections of the hull have been reconfigured to accommodate the largest possible engines. If hot-rodding across the galaxy in a 1000 ton warship that handles like a Flivver is your dream, look no further."
+	description "Whoever modified this Falcon clearly valued speed above all else. Major sections of the hull have been reconfigured to accommodate the largest possible engines. If hot-rodding across the galaxy in a 1000-ton warship that handles like a Flivver is your dream, look no further."
 
 
 ship "Marauder Falcon" "Marauder Falcon (Weapons)"
@@ -403,7 +403,7 @@ ship "Marauder Firebird"
 	explode "medium explosion" 24
 	explode "large explosion" 8
 	"final explode" "final explosion medium"
-	description "By the looks of the modification that have taken place, you suspect that this ship contains no original parts. With extra shield emitters, hull plating, and outfit space, this half-millennium young ship is finding new life with its heavy modification."
+	description "By the looks of the modification that have taken place, you suspect that this ship contains no original parts. With extra shield emitters, hull plating, and outfit space, this half-millennium-old design is finding new life with its heavy modification."
 
 
 ship "Marauder Firebird" "Marauder Firebird (Engines)"
@@ -462,7 +462,7 @@ ship "Marauder Firebird" "Marauder Firebird (Weapons)"
 	gun 38.5 -18.5 "Particle Cannon"
 	turret 0 -44 "Quad Blaster Turret"
 	turret 0 -2.5 "Quad Blaster Turret"
-	description "This Medium Warship with one of the heaviest armaments possible just got heavier. With more outfit space, giant gun ports, extra hull plating, and more shield emitters - this blast from the past will make its targets history."
+	description "The Firebird is known to have one of the heaviest armaments possible for a warship of its size, and this modified version makes it even heavier. With more outfit space, giant gun ports, extra hull plating, and more shield emitters, this blast from the past will make its targets history."
 
 
 
@@ -523,7 +523,7 @@ ship "Marauder Leviathan"
 	explode "medium explosion" 24
 	explode "large explosion" 8
 	"final explode" "final explosion large"
-	description "The Betelgeuse Shipyards Leviathan has been in service for a long time, and captains have had some very interesting ideas about how to modify them for optimum performance. This one has had the hull surface completely stripped off and replaced with a surface containing more shield projectors per square meter."
+	description "The Betelgeuse Shipyards Leviathan has been in service for a long time, and captains have had some very interesting ideas about how to modify them for optimum performance. This one has had the hull surface completely stripped and replaced, with the new layout containing more shield projectors per square meter."
 
 
 ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
@@ -552,7 +552,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 	engine 41 118.5 0.6
 	engine -21 126.5 0.8
 	engine 21 126.5 0.8
-	description "As if the Leviathan isn't a terrifying enough ship already, this one has been heavily modified with special attention paid to the engine capacity, enabling it to bring its guns to bear even faster."
+	description "As if the Leviathan wasn't a terrifying enough ship already, this one has been heavily modified with special attention paid to the engine capacity, enabling it to bring its guns to bear even faster."
 
 
 ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
@@ -585,7 +585,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
 	turret 14.5 -11.5 "Heavy Laser Turret"
 	turret -26 11.5 "Heavy Laser Turret"
 	turret 26 11.5 "Heavy Laser Turret"
-	description "This Leviathan once belonged to an infamous pirate captain whose name has been lost to the ages. It's had so much custom work done to it that can hardly even be considered the same ship. The weapons capacity, in particular has been massively increased."
+	description "This Leviathan once belonged to an infamous pirate captain whose name has been lost to the ages. It's had so much custom work done to it that can hardly even be considered the same ship; the weapons capacity, in particular, has been massively increased."
 
 
 
@@ -644,7 +644,7 @@ ship "Marauder Manta"
 	explode "small explosion" 20
 	explode "medium explosion" 15
 	"final explode" "final explosion medium"
-	description `After the Syndicate released their Vanguard Heavy Warship, the Manta fell somewhat out of favor, lacking the ability to mount any anti-missile systems. The owner of this Manta rectified that, added some extra armor plating and shield emitters, and rearranged some of the internals to yield a little more outfit space. Dry tonnage alone keeps it in the Medium Warship category.`
+	description `After the Syndicate released their Vanguard Heavy Warship, the Manta fell somewhat out of favor due to its lack of ability to mount any anti-missile turrets. The owner of this Manta rectified that, added some extra armor plating and shield emitters, and rearranged some of the internals to yield a little more outfit space. Dry tonnage alone keeps it from being classified as a heavy warship.`
 
 
 ship "Marauder Manta" "Marauder Manta (Engines)"
@@ -678,7 +678,7 @@ ship "Marauder Manta" "Marauder Manta (Engines)"
 	gun "Plasma Cannon"
 	gun "Plasma Cannon"
 	turret "Quad Blaster Turret"
-	description `A previous owner of this Manta has gone to great lengths to make sure they could bring all six gun ports to bear in a hurry and chase down smaller warships. Style was not lost on that captain, and a forked tail yielded a little more space for shield projectors in an area that would have been destabilized by engine exhaust. It almost makes it to "Heavy Warship," but dry tonnage keeps it in the Medium Warship category.`
+	description `A previous owner of this Manta has gone to great lengths to make sure they could bring all six gun ports to bear in a hurry, and chase down smaller warships. Style was not lost on that captain, and a forked tail yielded a little more space for shield projectors in an area that would have been destabilized by engine exhaust. If its dry tonnage were any higher, it would be classified as a heavy warship.`
 
 
 ship "Marauder Manta" "Marauder Manta (Weapons)"
@@ -714,7 +714,7 @@ ship "Marauder Manta" "Marauder Manta (Weapons)"
 	gun -20 -35 "Particle Cannon"
 	gun 20 -35 "Particle Cannon"
 	turret 0 -29 "Heavy Anti-Missile Turret"
-	description `This Manta has undergone extensive modification, featuring extra gun ports, hull plating, and shield emitters. You wonder where the modifier intended the power systems to go, but you're sure you'll find space for them somewhere. It almost makes it to "Heavy Warship," but dry tonnage keeps it in the Medium Warship category.`
+	description `This Manta has undergone extensive modification, featuring extra gun ports, hull plating, and shield emitters. Whoever modified it seems to have forgotten to include dedicated space for the power systems, as they're crammed in and around everything else like an afterthought. If its dry tonnage were any higher, it would be classified as a heavy warship.`
 
 
 
@@ -765,7 +765,7 @@ ship "Marauder Quicksilver"
 	explode "tiny explosion" 12
 	explode "small explosion" 16
 	"final explode" "final explosion small"
-	description "This Megaparsec Quicksilver is a bit of a Hotrod, being a little faster, with extra shield projectors, hull plating, and an extra bunk. This aftermarket model also features a turret mount, perhaps in an answer to Lionheart's Headhunter. The shop that built this ship is sure to see more customers."
+	description "This Megaparsec Quicksilver is a bit of a hotrod, being a little faster, with extra shield projectors, hull plating, and an extra bunk. This aftermarket model also features a turret mount, perhaps in an answer to Lionheart's Headhunter. The shop that built this ship is sure to see more customers."
 
 
 ship "Marauder Quicksilver" "Marauder Quicksilver (Engines)"
@@ -791,7 +791,7 @@ ship "Marauder Quicksilver" "Marauder Quicksilver (Engines)"
 	engine -16 52
 	engine 0 52
 	engine 16 52
-	description "This Quicksilver has even more space available for engine use - and even another thruster port! It's also got a few extra shield projectors, more hull plating and another bunk. This aftermarket model also features a turret mount, perhaps in response to Lionheart's Headhunter. Whoever modified this ship wanted to chase their prey down with vicious speed."
+	description "This Quicksilver has even more space available for engine use - and even another thruster port! It's also got a few extra shield projectors, more hull plating, and another bunk. This aftermarket model also features a turret mount, perhaps in response to Lionheart's Headhunter. Whoever modified this ship wanted to chase their prey down with vicious speed."
 
 
 ship "Marauder Quicksilver" "Marauder Quicksilver (Weapons)"
@@ -816,7 +816,7 @@ ship "Marauder Quicksilver" "Marauder Quicksilver (Weapons)"
 	
 	engine -17 54
 	engine 17 54
-	description "This Quicksilver has even bigger gun ports. It's also got a few extra shield emitters, more hull plating, and an extra bunk. Outfitted right, this aftermarket model could be even faster than a stock model, bringing a couple of extra cannons and a turret to the fight, to mimic Lionheart's Headhunter perhaps a little more menacingly."
+	description "This Quicksilver has even bigger gun ports. It's also got a few extra shield emitters, more hull plating, and an extra bunk. Outfitted right, this aftermarket model could be even faster than a stock model, bringing a couple of extra cannons and a turret to a fight in more menacing mimicry of Lionheart's Headhunter."
 
 
 
@@ -871,7 +871,7 @@ ship "Marauder Raven"
 	explode "tiny explosion" 28
 	explode "small explosion" 40
 	"final explode" "final explosion small"
-	description "The modifier of this Raven has given more heft to an agile and elegant vessel. They've added a turret and some apparently flimsy bulkheads over extra shield emitters and outfit space. If it weren't for the wingtips, you would barely recognize Lionheart's ship under the patchwork that you expect has made an already deadly warship even more so."
+	description "Whoever modified this Raven has given more heft to an agile and elegant vessel. They've added a turret and some apparently-flimsy bulkheads over extra shield emitters and outfit space. If it weren't for the wings, the central hull would barely be recognizeable as Lionheart's original under the patchwork that you expect has made an already deadly warship even more so."
 
 
 ship "Marauder Raven" "Marauder Raven (Engines)"
@@ -896,7 +896,7 @@ ship "Marauder Raven" "Marauder Raven (Engines)"
 	engine -12 45 .7
 	engine 0 43
 	engine 12 45 .7
-	description "Lionheart's elegant Raven has gained popularity with pirates because of its agility. This one appears to have been modified for even more of the latter, at the expense of the former, and You only recognize it as a Raven by the wingtips. A third engine bay, more outfit space, additional shield emitters, and a turret make this already deadly warship appear even more frightening."
+	description "Lionheart's elegant Raven has gained popularity with pirates because of its agility. This one appears to have been modified for even more of the latter at the expense of the former, and the central hull can only be recognized as a Raven because of the wings. A third engine bay, more outfit space, additional shield emitters, and a turret make this already deadly warship appear even more frightening."
 
 
 ship "Marauder Raven" "Marauder Raven (Weapons)"
@@ -924,7 +924,7 @@ ship "Marauder Raven" "Marauder Raven (Weapons)"
 	gun -17 -28 "Pulse Cannon"
 	gun 17 -28 "Pulse Cannon"
 	turret 0 -19 "Heavy Laser Turret"
-	description "A former owner of this ship apparently didn't like the lithe Raven, and has added so much more weapons, shield, and outfit capacity to it that you only recognize it by the wingtips. Besides adding a turret, this ship has enormous gun ports, making you wonder how much more deadly you could make a Light Warship."
+	description "A former owner of this ship apparently didn't like the lithe Raven, and has added so much more to it - more weapons, more shields, and more outfit capacity - that the central hull can only be recognized because of the wings. Besides adding a turret, this ship has enormous gun ports, making you wonder how much more deadly you could possibly make a warship this small."
 
 
 
@@ -979,7 +979,7 @@ ship "Marauder Splinter"
 	explode "medium explosion" 24
 	explode "large explosion" 8
 	"final explode" "final explosion medium"
-	description "The Splinter is the largest warship produced by Megaparsec. Apparently someone wanted a bit more out of it, and has covered large sections of the hull with extra shield emitters and hull plating. Much of the stock cargo space has been converted to outfit, weapons and engines space, coupled with streamlining of existing internal systems make this light Medium Warship an agile and flexible war machine."
+	description "The Splinter is the largest warship produced by Megaparsec. Apparently someone wanted a bit more out of it, and has covered large sections of the hull with extra shield emitters and hull plating. Much of the stock cargo space has been converted to outfit, weapons, and engines space; coupled with a streamlining of existing internal systems, it makes this warship an agile and flexible war machine."
 
 
 ship "Marauder Splinter" "Marauder Splinter (Engines)"
@@ -1010,7 +1010,7 @@ ship "Marauder Splinter" "Marauder Splinter (Engines)"
 	turret "Quad Blaster Turret"
 	turret "Heavy Anti-Missile Turret"
 	turret "Quad Blaster Turret"
-	description "In a sub-kiloton warship, you're not likely to find one faster or more deadly than this one. Large sections of the hull have been covered with extra hull plating and shield emitters. Much of the cargo space has been converted to outfit space, a great deal of which is at the rear of the ship, which features a new engine port."
+	description "You're not likely to find a sub-kiloton warship faster or more deadly than this one. Large sections of the hull have been covered with extra hull plating and shield emitters. Much of the cargo space has been converted to outfit space, a great deal of which is at the rear of the ship, which features a new engine port."
 
 
 ship "Marauder Splinter" "Marauder Splinter (Weapons)"
@@ -1041,4 +1041,4 @@ ship "Marauder Splinter" "Marauder Splinter (Weapons)"
 	turret -17 -28 "Quad Blaster Turret"
 	turret 0 -28 "Heavy Anti-Missile Turret"
 	turret 17 -28 "Quad Blaster Turret"
-	description "This Splinter has had extensive modification to its weapons space, with two new forward hard points on either side of the bridge. Large sections of the hull are covered with extra shield emitters and hull plating. Much of the stock cargo space has been converted to space for outfits, weapons and engines, coupled with streamlining of existing internal systems make the prospect of meeting this flexible war machine in an uninhabited system seem pretty unappealing."
+	description "This Splinter has had extensive modification to its weapons space, with two new forward hard points on either side of the bridge. Large sections of the hull are covered with extra shield emitters and hull plating. Much of the stock cargo space has been converted to space for outfits, weapons, and engines; coupled with a streamlining of existing internal systems, it makes the prospect of meeting this flexible war machine in an uninhabited system seem pretty unappealing."

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -231,7 +231,7 @@ ship "Marauder Fury"
 	explode "tiny explosion" 10
 	explode "small explosion" 20
 	"final explode" "final explosion small"
-	description "You're sure there's a Southbound Fury under all the extra modifications. This ship appears to be one man's insane quest to make the most powerful single pilot warship ever. Upon closer inspection, you're inclined to believe he may have succeeded."
+	description "You're sure there's a Southbound Shipyards Fury under all the extra modifications. This ship appears to be one man's insane quest to make the most powerful single-pilot warship ever; after close inspection, you're inclined to believe he may have succeeded."
 
 
 


### PR DESCRIPTION
While the descriptions are currently not visible anywhere without plugins, they're still full of awkward phrasings and poor grammar; I particularly disliked the constant usage of in-game ship classifications like Medium Warship, which no stock ship description does. While I didn't feel confident enough to completely rewrite them at this time, I figured giving them at least an editing pass would be an improvement.

Mostly the result of @Cat-Lady complaining about them on Discord. I actually did most of this work days ago and then got busy with other things, but I dusted it off, finished the Marauder Splinter, and finally pushed it. I also did most of the work while tired, so let me know if I missed something obvious.