### PR TITLE
Added a missing source line to Terraforming 7

### DIFF
--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -2361,6 +2361,7 @@ mission "Terraforming 6"
 mission "Terraforming 7"
 	name "Terraforming Research"
 	description "Bring Amy and Nolan to <destination>, where they will research and publish Amy's terraforming methods."
+	source "Earth"
 	destination "Valhalla"
 	passengers 2
 	blocked "You need <capacity> in order to take on the next mission. Return here when you have the required space free."


### PR DESCRIPTION
Currently, it is possible for Terraforming 7 to offer on any world that has a spaceport. According to 6, however, Amy is busy in an Earth spaceport. This pull fixes that.