### PR TITLE
Frigate Mark II given matching visuals.

### DIFF
--- a/data/variants.txt
+++ b/data/variants.txt
@@ -995,22 +995,22 @@ ship "Freighter" "Freighter (Secret Cargo)"
 
 ship "Frigate" "Frigate (Mark II)"
 	outfits
+		"Particle Cannon" 4
+		"Anti-Missile Turret"
+		"Blaster Turret" 2
 		"NT-200 Nucleovoltaic"
+		"Dwarf Core"
 		"LP072a Battery Pack"
+		"Supercapacitor"
+		"D41-HY Shield Generator"
 		"Small Radar Jammer"
+		"Water Coolant System"
+		"Outfits Expansion"
+		"Laser Rifle" 8
+		"Fragmentation Grenades" 8
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
-		"Fragmentation Grenades" 8
 		"Hyperdrive"
-		"Outfits Expansion"
-		"Supercapacitor"
-		"Particle Cannon" 4
-		"Dwarf Core"
-		"Laser Rifle" 8
-		"Anti-Missile Turret"
-		"Water Coolant System"
-		"Blaster Turret" 2
-		"D41-HY Shield Generator"
 	turret "Anti-Missile Turret"
 	turret "Blaster Turret"
 	turret "Blaster Turret"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -995,21 +995,22 @@ ship "Freighter" "Freighter (Secret Cargo)"
 
 ship "Frigate" "Frigate (Mark II)"
 	outfits
-		"Particle Cannon" 4
-		"Anti-Missile Turret"
-		"Blaster Turret" 2
 		"NT-200 Nucleovoltaic"
-		"Dwarf Core"
-		"LP036a Battery Pack"
-		"D41-HY Shield Generator"
+		"LP072a Battery Pack"
 		"Small Radar Jammer"
-		"Water Coolant System"
-		"Outfits Expansion"
-		"Laser Rifle" 8
-		"Fragmentation Grenades" 8
-		"X3700 Ion Thruster"
+		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
+		"Fragmentation Grenades" 8
 		"Hyperdrive"
+		"Outfits Expansion"
+		"Supercapacitor"
+		"Particle Cannon" 4
+		"Dwarf Core"
+		"Laser Rifle" 8
+		"Anti-Missile Turret"
+		"Water Coolant System"
+		"Blaster Turret" 2
+		"D41-HY Shield Generator"
 	turret "Anti-Missile Turret"
 	turret "Blaster Turret"
 	turret "Blaster Turret"


### PR DESCRIPTION
This gives the Frigate (Mark II) a250 atomic thrusters, because it is the only mark II ship that has ion thrusters, which looks out of place in my opinion. This PR gives it matching visuals with the rest of the Mark II ships, without changing the speed too much. It also gives the ship increased energy storage with the excess outfit space.

Suggested by @Arachi-Lover 