### PR TITLE
Better differentiate various human medium warships and knock the Mule down a peg

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2231,7 +2231,7 @@ ship "Mule"
 	explode "small explosion" 30
 	explode "medium explosion" 20
 	"final explode" "final explosion medium"
-	description "The Mule is as much of a hodgepodge as its looks suggest. The Lionheart ship designers combined a good deal of cargo space with a decent amount of weaponry and even a fighter bay, and ended up with a ship that is mostly used as a freighter but must be classified as a warship because of its heavy armament and shields. This hodgepodge nature has its downside, though, namely its high crew requirement and the fact that any dedicated ship of the same cost will do better in a specific role than the Mule will."
+	description "The Mule is as much of a hodgepodge as its looks suggest. The Lionheart ship designers combined a good deal of cargo space with a decent amount of weaponry and even a fighter bay, and ended up with a ship that is mostly used as a freighter but must be classified as a warship because of its heavy armament and shields. This hodgepodge nature has its downside, though, namely its high crew requirement and the fact that any dedicated ship of the same cost will do better in a specialized role than the Mule will."
 
 
 

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2301,13 +2301,13 @@ ship "Osprey"
 	thumbnail "thumbnail/osprey"
 	attributes
 		category "Medium Warship"
-		"cost" 4400000
+		"cost" 3900000
 		"shields" 7200
 		"hull" 1600
 		"required crew" 9
 		"bunks" 24
 		"mass" 270
-		"drag" 6.1
+		"drag" 5.9
 		"heat dissipation" .8
 		"fuel capacity" 600
 		"cargo space" 40

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -341,7 +341,7 @@ ship "Bastion"
 	thumbnail "thumbnail/bastion"
 	attributes
 		category "Medium Warship"
-		"cost" 4060000
+		"cost" 3860000
 		"shields" 7500
 		"hull" 4700
 		"required crew" 17
@@ -2179,7 +2179,7 @@ ship "Mule"
 	thumbnail "thumbnail/mule"
 	attributes
 		category "Medium Warship"
-		"cost" 4580000
+		"cost" 4080000
 		"shields" 5400
 		"hull" 4400
 		"required crew" 22
@@ -2301,7 +2301,7 @@ ship "Osprey"
 	thumbnail "thumbnail/osprey"
 	attributes
 		category "Medium Warship"
-		"cost" 3900000
+		"cost" 4200000
 		"shields" 7200
 		"hull" 1600
 		"required crew" 9

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -341,9 +341,9 @@ ship "Bastion"
 	thumbnail "thumbnail/bastion"
 	attributes
 		category "Medium Warship"
-		"cost" 3560000
-		"shields" 6700
-		"hull" 4200
+		"cost" 4060000
+		"shields" 7500
+		"hull" 4700
 		"required crew" 17
 		"bunks" 40
 		"mass" 580
@@ -352,7 +352,7 @@ ship "Bastion"
 		"fuel capacity" 500
 		"cargo space" 110
 		"outfit space" 470
-		"weapon capacity" 180
+		"weapon capacity" 190
 		"engine capacity" 120
 		weapon
 			"blast radius" 120

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2188,9 +2188,9 @@ ship "Mule"
 		"drag" 5.7
 		"heat dissipation" .5
 		"fuel capacity" 600
-		"cargo space" 200
+		"cargo space" 170
 		"outfit space" 440
-		"weapon capacity" 180
+		"weapon capacity" 170
 		"engine capacity" 110
 		weapon
 			"blast radius" 100

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2182,15 +2182,15 @@ ship "Mule"
 		"cost" 4580000
 		"shields" 5400
 		"hull" 4400
-		"required crew" 6
+		"required crew" 22
 		"bunks" 43
 		"mass" 320
 		"drag" 5.7
 		"heat dissipation" .5
 		"fuel capacity" 600
-		"cargo space" 270
-		"outfit space" 450
-		"weapon capacity" 210
+		"cargo space" 200
+		"outfit space" 440
+		"weapon capacity" 180
 		"engine capacity" 110
 		weapon
 			"blast radius" 100
@@ -2231,7 +2231,7 @@ ship "Mule"
 	explode "small explosion" 30
 	explode "medium explosion" 20
 	"final explode" "final explosion medium"
-	description "The Mule is as much of a hodgepodge as its looks suggest. The Lionheart ship designers combined a good deal of cargo space with a decent amount of weaponry and even a fighter bay, and ended up with a ship that is mostly used as a freighter but must be classified as a warship because of its heavy armament and shields."
+	description "The Mule is as much of a hodgepodge as its looks suggest. The Lionheart ship designers combined a good deal of cargo space with a decent amount of weaponry and even a fighter bay, and ended up with a ship that is mostly used as a freighter but must be classified as a warship because of its heavy armament and shields. This hodgepodge nature has its downside, though, namely its high crew requirement and the fact that any dedicated ship of the same cost will do better in a specific role than the Mule will."
 
 
 

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -344,7 +344,7 @@ ship "Bastion"
 		"cost" 3860000
 		"shields" 7500
 		"hull" 4700
-		"required crew" 17
+		"required crew" 14
 		"bunks" 40
 		"mass" 580
 		"drag" 10.3
@@ -2182,7 +2182,7 @@ ship "Mule"
 		"cost" 4080000
 		"shields" 5400
 		"hull" 4400
-		"required crew" 22
+		"required crew" 17
 		"bunks" 43
 		"mass" 320
 		"drag" 5.7

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -344,7 +344,7 @@ ship "Bastion"
 		"cost" 3860000
 		"shields" 7500
 		"hull" 4700
-		"required crew" 14
+		"required crew" 17
 		"bunks" 40
 		"mass" 580
 		"drag" 10.3
@@ -2182,7 +2182,7 @@ ship "Mule"
 		"cost" 4080000
 		"shields" 5400
 		"hull" 4400
-		"required crew" 17
+		"required crew" 14
 		"bunks" 43
 		"mass" 320
 		"drag" 5.7

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1566,7 +1566,8 @@ ship "Mule" "Mule (Hai Engines)"
 ship "Mule" "Mule (Hai Weapons)"
 	outfits
 		"Ion Cannon"
-		"Pulse Turret" 4
+		"Pulse Turret" 3
+		"Chameleon Anti-Missile"
 		"Geode Reactor"
 		"Hai Ravine Batteries"
 		"Hai Fissure Batteries"
@@ -1582,9 +1583,10 @@ ship "Mule" "Mule (Hai Weapons)"
 
 ship "Mule" "Mule (Heavy)"
 	outfits
-		"Heavy Laser Turret" 4
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 90
+		"Heavy Laser Turret" 3
+		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"Supercapacitor" 4

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1584,10 +1584,11 @@ ship "Mule" "Mule (Heavy)"
 	outfits
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 90
-		"Heavy Laser Turret" 4
+		"Heavy Laser Turret" 3
+		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
 		"LP072a Battery Pack"
-		"Supercapacitor" 3
+		"Supercapacitor" 4
 		"D67-TM Shield Generator"
 		"Water Coolant System"
 		"Outfits Expansion"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1559,7 +1559,6 @@ ship "Mule" "Mule (Hai Engines)"
 		"Pulse Rifle"
 		`"Bondir" Atomic Thruster`
 		`"Biroo" Atomic Steering`
-		`"Basrem" Atomic Steering`
 		"Hyperdrive"
 
 
@@ -1585,11 +1584,10 @@ ship "Mule" "Mule (Heavy)"
 	outfits
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 90
-		"Heavy Laser Turret" 3
-		"Heavy Anti-Missile Turret"
+		"Heavy Laser Turret" 4
 		"Fission Reactor"
 		"LP072a Battery Pack"
-		"Supercapacitor" 4
+		"Supercapacitor" 3
 		"D67-TM Shield Generator"
 		"Water Coolant System"
 		"Outfits Expansion"


### PR DESCRIPTION
## Summary
The Mule has been a topic of discussion for some time, as well as the balance between the various human medium warships. (Ref: #4579,  #1598/https://github.com/endless-sky/endless-sky/commit/ece73dc9cab663bf02f15d048b7252469cc65672, #1626, #1627, #3411, #2076) This PR seeks to knock the Mule down a bit, but in lowering the effectiveness of the Mule, I felt that I was making it too similar to some of the other human medium warships, so I made some slight tweaks to other medium warships as well. These tweaks also help to differentiate the various roles that the medium warships are suppose to fulfill. 

These are the roles that I see each medium warship filling:
* **Cheap but Effective**: Splinter, Manta
* **Dedicated Carrier**: Nest, Roost, Skein
* **Combat Carrier**: Aerie
* **Jack of All Trades**: Mule
* **Tank**: Bastion
* **General Combat**: Firebird
* **Speedy Combat**: Osprey
* **Speed Demon**: Corvette
* **Best in Combat**: Frigate

For the most part, these ships fit their roles well. But, the Mule was notably a master of all trades more than a jack of all trades. As such, it has received the bulk of the changes.
<details><summary>Mule changes</summary>

The Mule has...
* the most weapon space among all medium warships (210 vs 180 Bastion and Osprey next closest).
* the most cargo among all medium warships by more than double the next closest (270 vs 120 Skein).
* a greater cargo space than all light freighters (270 vs 150 Freighter) and more cargo than the Hauler II, a heavy freighter (270 vs 260).
* the second highest outfit space (450 tied with Osprey vs 470 Bastion in first place).
* the highest spare bunk space (37 tied with Frigate vs 24 Corvette next closest).
* the second lowest crew requirement (6 tied with Roost vs 5 Nest at the lowest).
* the second highest HP when ignoring licensed ships (9,800 vs 10,900 Bastion in first).
* the only real downside is its lower speed.

With all this in mind, I wanted to make changes to make the Mule less of a master of all trades, but I wanted to be less drastic than #2076.
* Left the engine space and drag as is as the speed isn't something of note.
* Decreased the weapon space from 210 to ~~180~~ 170 so that the Mule still has a high weapon space, but not the most by a substantial amount. 
   * The single fighter bay can partially be seen as +20 weapon space, so the previous 210 weapon space plus the single fighter made the Mule a no brainer in terms of combat for medium warships.
* Decreased the cargo space from 270 to ~~200~~ 170, meaning that the Mule's cargo is now at a midpoint between light and heavy freighters instead of being within the range of heavy freighter cargo space.
* Decreased the cost by 500k since the previous cost increase was done in part due to the similar cargo space to the Hauler II.
* Decreased the outfit space from 450 to 440 to differentiate it from the Osprey. Nothing an outfits expansion can't fix.
* Increased the required crew count from an astonishingly low 6 to ~~22~~ (edit) ~~17~~ 14.
* Added a sentence to the end of the description noting that the required crew is a downside for the ship, and that it's only a jack of all trades and not a master of all.

</details>

Moving on to the Bastion, I had the feeling that it was just a worse version of the Osprey. Same weapon space, similar outfit and engine space, similar gun and turret numbers, but about 24% more health at the cost of about half the speed. The only real positives of the Bastion over the Osprey are being cheaper and having more cargo. As such, I decided to make some changes to push the Bastion a little more into its tank role.

<details><summary>Bastion changes</summary>

* Increased the shields from 6700 to 7500.
* Increased the hull from 4200 to 4700.
  * These changes push the Bastion further into its tank role by giving it a significantly higher health pool than the next closest ship (1700 point difference compared to the previous 400 point difference with the Frigate), and it now has about 39% more health than the Osprey instead of about 24%.
* Increased the weapon space from 180 to 190 to differentiate its weapon space from the Osprey and Mule, as well as push it a little further into a tank role with space for the biggest guns among medium warships.
* Increased the cost slightly to compensate for the increased combat effectiveness.
* Made no changes to the engine space and drag since it's already a very slow ship.
* (edit) ~~Reduced the required crew from a comparatively high 17 to 14, only 4 more than the Osprey's 10.~~ Left the Bastion's crew requirement as is, as the Bastion is now the closest thing to a heavy warship without being one.
</details>

The Osprey is an interesting ship that fits its role well, but I decided to make some slight changes to it still.

<details><summary>Osprey changes</summary>

* Reduced the cost slightly to make it a more appealing choice. The sale cost of the Osprey is still the greatest among the medium warships by quite a bit, but it's just ever slightly less expensive.
* Reduced the drag slightly given that despite the description as an agile ship, I got the sense that the drag was a little high.

</details>

Beyond these three ships, I think that everything else in the medium warship category is largely fine, save for perhaps the Splinter. 
* The Nest, Roost, and Skein are fine as is, given they excel at their dedicated carrier role.
* The Firebird and Corvette already received some changes in #3411, and I think that they're great as is.
* The Manta with its 6 gun ports works amazingly as a missile platform now, so it needs no changes.
* The Aerie works amazingly as a combat carrier; a ship designed to carry a small number of fighters but also get involved in the combat on its own. As a side note, the fact that we're missing this archetype of ship at higher tiers is a little saddening. (Although the Pond Strider and [Ibis](https://github.com/endless-sky/endless-sky/pull/4546/files) look to fill this role.)
* The Frigate already fits well within the Navy fleets, and fits its combat role well; it has the second highest HP among medium warships paired with a balanced speed and weapon space.

## PR Checklist: questions that need answered
 - [x] Make changes to the Splinter? VERDICT: It's fine as-is.
The Splinter is personally my least used medium warship, and I don't hear good things from others either. The Splinter is still an interesting ship, though, being the cheapest and second fastest medium warship. It's essentially a downgraded version of the Corvette, which may mean that it's fine as is.
 - [x] Lower Bastion required crew? VERDICT: No. The Bastion is now the closest MW to a HW, so it should have the highest crew requirement.
I think that the crew requirement on the Bastion was rather unjustifiable before, which is partially why I looked to increase the effectiveness of the Bastion slightly. The Bastion now fills the same role for medium warships that the Modified Argosy does for light warships; that is, it get very close to the edge of the next category up, but isn't quite there. But, is the required crew still too high, or do these changes make the required crew fine now?
 - [x] Lower Mule required crew from the increased value? VERDICT: Lowered from 22 to 14.
An increase from 6 (which was admittedly way too low before) to 22 might be a bit much. Should the required crew be brought down a bit from here? For reference, the Vanguard has the lowest crew requirement among the heavy warships at 23.

## Additional Notes

Further justification for each change can be found in the description of each of the commits where the change was made.

Despite my mention of #2076, I have no intention to make any changes to the Bactrian. I feel that #2184 and #3120 were all that was necessary for balancing the Bactrian.

Given that @Pointedstick mentioned that #1598 wasn't actually addressed when it was closed, and since he's opened many of the issues that I mentioned about the differentiation between the medium warships, I'd like to see what he thinks about the changes here.

Given that @Zitchas has opened a PR in the past with regards to the categorization of the Mule, I'd like to see what he thinks about the Mule's place now.

Changes have been made in the past to various interceptors and light warships, and the heavy warships have always been pretty distinct from one another, so I don't see a need to do any similar balance passes on the other categories of human combat ships. The only change I can think about needing done is swapping the crew requirements of the Quicksilver and Headhunter.