### PR TITLE
Combine multiple on visit dialogs into a single dialog to avoid being spammed

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -913,10 +913,17 @@ const string &Mission::Identifier() const
 
 
 
-// Get the mission actions for this mission.
-map<Mission::Trigger, MissionAction> Mission::GetActions() const
+// Get a specific mission action from this mission.
+// If a mission action is not found for the given trigger, returns an empty 
+// mission action.
+const MissionAction &Mission::GetAction(Trigger trigger) const
 {
-	return actions;
+	auto ait = actions.find(trigger);
+	static const MissionAction EMPTY;
+	if(ait != actions.end())
+		return ait->second;
+	else
+		return EMPTY;
 }
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -818,7 +818,7 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	// if this is a non-job mission that just got offered and if so,
 	// automatically accept it.
 	if(it != actions.end())
-		it->second.Do(player, ui, destination ? destination->GetSystem() : nullptr, boardingShip);
+		it->second.Do(player, ui, destination ? destination->GetSystem() : nullptr, boardingShip, IsUnique());
 	else if(trigger == OFFER && location != JOB)
 		player.MissionCallback(Conversation::ACCEPT);
 	

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -913,6 +913,14 @@ const string &Mission::Identifier() const
 
 
 
+// Get the mission actions for this mission.
+map<Mission::Trigger, MissionAction> Mission::GetActions() const
+{
+	return actions;
+}
+
+
+
 // "Instantiate" a mission by replacing randomly selected values and places
 // with a single choice, and then replacing any wildcard text as well.
 Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &boardingShip) const

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -142,8 +142,10 @@ public:
 	// never modified by string substitution, so it can be used in condition
 	// variables, etc.
 	const std::string &Identifier() const;
-	// Get the mission actions for this mission.
-	std::map<Trigger, MissionAction> GetActions() const; 
+	// Get a specific mission action from this mission.
+	// If the mission action is not found for the given trigger, returns an empty 
+	// mission action.
+	const MissionAction &GetAction(Trigger trigger) const; 
 	
 	// "Instantiate" a mission by replacing randomly selected values and places
 	// with a single choice, and then replacing any wildcard text as well.

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -142,6 +142,8 @@ public:
 	// never modified by string substitution, so it can be used in condition
 	// variables, etc.
 	const std::string &Identifier() const;
+	// Get the mission actions for this mission.
+	std::map<Trigger, MissionAction> GetActions() const; 
 	
 	// "Instantiate" a mission by replacing randomly selected values and places
 	// with a single choice, and then replacing any wildcard text as well.

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -327,6 +327,13 @@ int MissionAction::Payment() const
 
 
 
+string MissionAction::DialogText() const
+{
+	return dialogText;
+}
+
+
+
 // Check if this action can be completed right now. It cannot be completed
 // if it takes away money or outfits that the player does not have.
 bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &boardingShip) const
@@ -419,9 +426,13 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 			subs["<ship>"] = player.Flagship()->Name();
 		string text = Format::Replace(dialogText, subs);
 		
+		// Don't push the dialog text if this is a visit action; on visit dialogs 
+		// are handled by PlayerInfo as to avoid the player being spammed by 
+		// dialogs if they have multiple missions active with the same destination
+		// (e.g. in the case of stacking bounty jobs).
 		if(isOffer)
 			ui->Push(new Dialog(text, player, destination));
-		else
+		else if(trigger != "visit")
 			ui->Push(new Dialog(text));
 	}
 	else if(isOffer && ui)

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -327,7 +327,7 @@ int MissionAction::Payment() const
 
 
 
-string MissionAction::DialogText() const
+const string &MissionAction::DialogText() const
 {
 	return dialogText;
 }
@@ -433,7 +433,7 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 		// stacking bounty jobs).
 		if(isOffer)
 			ui->Push(new Dialog(text, player, destination));
-		else if(!(trigger == "visit" && !isUnique))
+		else if(isUnique || trigger != "visit")
 			ui->Push(new Dialog(text));
 	}
 	else if(isOffer && ui)

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -401,7 +401,7 @@ bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &
 
 
 
-void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, const shared_ptr<Ship> &ship) const
+void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, const shared_ptr<Ship> &ship, const bool isUnique) const
 {
 	bool isOffer = (trigger == "offer");
 	if(!conversation.IsEmpty() && ui)
@@ -426,13 +426,14 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 			subs["<ship>"] = player.Flagship()->Name();
 		string text = Format::Replace(dialogText, subs);
 		
-		// Don't push the dialog text if this is a visit action; on visit dialogs 
-		// are handled by PlayerInfo as to avoid the player being spammed by 
-		// dialogs if they have multiple missions active with the same destination
-		// (e.g. in the case of stacking bounty jobs).
+		// Don't push the dialog text if this is a visit action on a nonunique
+		// mission; on visit, nonunique dialogs are handled by PlayerInfo as to
+		// avoid the player being spammed by dialogs if they have multiple
+		// missions active with the same destination (e.g. in the case of
+		// stacking bounty jobs).
 		if(isOffer)
 			ui->Push(new Dialog(text, player, destination));
-		else if(trigger != "visit")
+		else if(!(trigger == "visit" && !isUnique))
 			ui->Push(new Dialog(text));
 	}
 	else if(isOffer && ui)

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -52,6 +52,8 @@ public:
 	
 	int Payment() const;
 	
+	std::string DialogText() const;
+	
 	// Check if this action can be completed right now. It cannot be completed
 	// if it takes away money or outfits that the player does not have, or should
 	// take place in a system that does not match the specified LocationFilter.

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -52,7 +52,7 @@ public:
 	
 	int Payment() const;
 	
-	std::string DialogText() const;
+	const std::string &DialogText() const;
 	
 	// Check if this action can be completed right now. It cannot be completed
 	// if it takes away money or outfits that the player does not have, or should

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -60,7 +60,7 @@ public:
 	bool CanBeDone(const PlayerInfo &player, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
 	// Perform this action. If a conversation is shown, the given destination
 	// will be highlighted in the map if you bring it up.
-	void Do(PlayerInfo &player, UI *ui = nullptr, const System *destination = nullptr, const std::shared_ptr<Ship> &ship = nullptr) const;
+	void Do(PlayerInfo &player, UI *ui = nullptr, const System *destination = nullptr, const std::shared_ptr<Ship> &ship = nullptr, const bool isUnqiue = true) const;
 	
 	// "Instantiate" this action by filling in the wildcard text for the actual
 	// destination, payment, cargo, etc.

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -60,7 +60,7 @@ public:
 	bool CanBeDone(const PlayerInfo &player, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
 	// Perform this action. If a conversation is shown, the given destination
 	// will be highlighted in the map if you bring it up.
-	void Do(PlayerInfo &player, UI *ui = nullptr, const System *destination = nullptr, const std::shared_ptr<Ship> &ship = nullptr, const bool isUnqiue = true) const;
+	void Do(PlayerInfo &player, UI *ui = nullptr, const System *destination = nullptr, const std::shared_ptr<Ship> &ship = nullptr, const bool isUnique = true) const;
 	
 	// "Instantiate" this action by filling in the wildcard text for the actual
 	// destination, payment, cargo, etc.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2372,7 +2372,11 @@ void PlayerInfo::StepMissions(UI *ui)
 			// getting spammed by on visit dialogs if they are stacking jobs
 			// from the same destination.
 			if(visitText.empty())
-				visitText = Format::Replace(mission.GetAction(Mission::VISIT).DialogText(), substitutions);
+			{
+				const auto &text = mission.GetAction(Mission::VISIT).DialogText();
+				if(!text.empty())
+					visitText = Format::Replace(text, substitutions);
+			}
 			++missionVisits;
 		}
 	}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2342,7 +2342,6 @@ void PlayerInfo::StepMissions(UI *ui)
 	
 	string visitText;
 	int missionVisits = 0;
-	int deadlineMissions = 0;
 	auto substitutions = map<string, string>{
 		{"<first>", firstName},
 		{"<last>", lastName}
@@ -2366,31 +2365,21 @@ void PlayerInfo::StepMissions(UI *ui)
 		else if(mission.Destination() == GetPlanet() && !freshlyLoaded)
 		{
 			mission.Do(Mission::VISIT, *this, ui);
-			if(mission.IsUnique())
+			if(mission.IsUnique() || !mission.IsVisible())
 				continue;
 			
 			// On visit dialogs are handled separately as to avoid a player
 			// getting spammed by on visit dialogs if they are stacking jobs
 			// from the same destination.
-			auto action = mission.GetAction(Mission::VISIT);
-			if(!action.DialogText().empty() && visitText.empty())
-				visitText = Format::Replace(action.DialogText(), substitutions);
+			if(visitText.empty()
+				visitText = Format::Replace(mission.GetAction(Mission::VISIT).DialogText(), substitutions);
 			++missionVisits;
-			if(mission.Deadline())
-				++deadlineMissions;
 		}
 	}
-	if(!visitText.empty())
+	if(!visitText.empty() && missionVisits > 1)
 	{
-		visitText += "\n\tYou have " + Format::Number(missionVisits) + " unfinished " 
-			+ ((missionVisits > 1) ? "missions" : "mission") + " at this location";
-		if(deadlineMissions)
-		{
-			visitText += "(" + Format::Number(deadlineMissions) + " of which "
-					+ ((deadlineMissions > 1) ? "have approaching deadlines" : "has an approaching deadline)");
-		}
-		visitText += ".";
-		
+		visitText += "\n\t(You have " + Format::Number(missionVisits - 1) + " other unfinished " 
+			+ ((missionVisits > 2) ? "missions" : "mission") + " at this location.)";
 		ui->Push(new Dialog(visitText));
 	}
 	// One mission's actions may influence another mission, so loop through one

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2341,7 +2341,7 @@ void PlayerInfo::StepMissions(UI *ui)
 					mission.Do(ShipEvent(nullptr, ship, ShipEvent::DESTROY), *this, ui);
 	
 	string visitText;
-	int extraVisitDialogs = 0;
+	int missionVisits = 0;
 	int deadlineMissions = 0;
 	auto substitutions = map<string, string>{
 		{"<first>", firstName},
@@ -2373,23 +2373,19 @@ void PlayerInfo::StepMissions(UI *ui)
 			// getting spammed by on visit dialogs if they are stacking jobs
 			// from the same destination.
 			auto action = mission.GetAction(Mission::VISIT);
-			if(!action.DialogText().empty())
-			{
-				if(visitText.empty())
-					visitText = Format::Replace(action.DialogText(), substitutions);
-				else
-					++extraVisitDialogs;
-				if(mission.Deadline())
-					++deadlineMissions;
-			}
+			if(!action.DialogText().empty() && visitText.empty())
+				visitText = Format::Replace(action.DialogText(), substitutions);
+			++missionVisits;
+			if(mission.Deadline())
+				++deadlineMissions;
 		}
 	}
 	if(!visitText.empty())
 	{
-		if(extraVisitDialogs)
+		if(missionVisits)
 		{
-			visitText += "\n\tYou have " + Format::Number(extraVisitDialogs) + " other unfinished " 
-				+ ((extraVisitDialogs > 1) ? "missions" : "mission") + " at this location";
+			visitText += "\n\tYou have " + Format::Number(missionVisits) + " other unfinished " 
+				+ ((missionVisits > 1) ? "missions" : "mission") + " at this location";
 			if(deadlineMissions)
 			{
 				visitText += "(" + Format::Number(deadlineMissions) + " of which "

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2382,17 +2382,15 @@ void PlayerInfo::StepMissions(UI *ui)
 	}
 	if(!visitText.empty())
 	{
-		if(missionVisits)
+		visitText += "\n\tYou have " + Format::Number(missionVisits) + " unfinished " 
+			+ ((missionVisits > 1) ? "missions" : "mission") + " at this location";
+		if(deadlineMissions)
 		{
-			visitText += "\n\tYou have " + Format::Number(missionVisits) + " other unfinished " 
-				+ ((missionVisits > 1) ? "missions" : "mission") + " at this location";
-			if(deadlineMissions)
-			{
-				visitText += "(" + Format::Number(deadlineMissions) + " of which "
+			visitText += "(" + Format::Number(deadlineMissions) + " of which "
 					+ ((deadlineMissions > 1) ? "have approaching deadlines" : "has an approaching deadline)");
-			}
-			visitText += ".";
 		}
+		visitText += ".";
+		
 		ui->Push(new Dialog(visitText));
 	}
 	// One mission's actions may influence another mission, so loop through one

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2371,7 +2371,7 @@ void PlayerInfo::StepMissions(UI *ui)
 			// On visit dialogs are handled separately as to avoid a player
 			// getting spammed by on visit dialogs if they are stacking jobs
 			// from the same destination.
-			if(visitText.empty()
+			if(visitText.empty())
 				visitText = Format::Replace(mission.GetAction(Mission::VISIT).DialogText(), substitutions);
 			++missionVisits;
 		}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2343,6 +2343,12 @@ void PlayerInfo::StepMissions(UI *ui)
 	string visitText;
 	int extraVisitDialogs = 0;
 	int deadlineMissions = 0;
+	map<string, string> subs;
+	subs["<first>"] = firstName;
+	subs["<last>"] = lastName;
+	if(Flagship())
+		subs["<ship>"] = Flagship()->Name();
+	
 	auto mit = missions.begin();
 	while(mit != missions.end())
 	{
@@ -2359,30 +2365,21 @@ void PlayerInfo::StepMissions(UI *ui)
 		else if(mission.Destination() == GetPlanet() && !freshlyLoaded)
 		{
 			mission.Do(Mission::VISIT, *this, ui);
+			if(mission.IsUnique())
+				continue;
 			
 			// On visit dialogs are handled separately as to avoid a player
 			// getting spammed by on visit dialogs if they are stacking jobs
 			// from the same destination.
-			map<Mission::Trigger, MissionAction> actions = mission.GetActions();
-			auto ait = actions.find(Mission::VISIT);
-			if(ait != actions.end())
+			auto ait = mission.GetAction(Mission::VISIT);
+			if(!ait.DialogText().empty())
 			{
-				if(!mission.IsUnique())
-				{
-					if(visitText.empty())
-					{
-						map<string, string> subs;
-						subs["<first>"] = firstName;
-						subs["<last>"] = lastName;
-						if(Flagship())
-							subs["<ship>"] = Flagship()->Name();
-						visitText = Format::Replace(ait->second.DialogText(), subs);
-					}
-					else
-						++extraVisitDialogs;
-					if(mission.Deadline())
-						++deadlineMissions;
-				}
+				if(visitText.empty())
+					visitText = Format::Replace(ait.DialogText(), subs);
+				else
+					++extraVisitDialogs;
+				if(mission.Deadline())
+					++deadlineMissions;
 			}
 		}
 	}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2341,7 +2341,8 @@ void PlayerInfo::StepMissions(UI *ui)
 					mission.Do(ShipEvent(nullptr, ship, ShipEvent::DESTROY), *this, ui);
 	
 	string visitText;
-	int visitDialogs = 0;
+	int extraVisitDialogs = 0;
+	int deadlineMissions = 0;
 	auto mit = missions.begin();
 	while(mit != missions.end())
 	{
@@ -2366,24 +2367,35 @@ void PlayerInfo::StepMissions(UI *ui)
 			auto ait = actions.find(Mission::VISIT);
 			if(ait != actions.end())
 			{
-				if(visitText.empty())
+				if(!mission.IsUnique())
 				{
-					map<string, string> subs;
-					subs["<first>"] = firstName;
-					subs["<last>"] = lastName;
-					if(Flagship())
-						subs["<ship>"] = Flagship()->Name();
-					visitText = Format::Replace(ait->second.DialogText(), subs);
+					if(visitText.empty())
+					{
+						map<string, string> subs;
+						subs["<first>"] = firstName;
+						subs["<last>"] = lastName;
+						if(Flagship())
+							subs["<ship>"] = Flagship()->Name();
+						visitText = Format::Replace(ait->second.DialogText(), subs);
+					}
+					else
+						++extraVisitDialogs;
+					if(mission.Deadline())
+						++deadlineMissions;
 				}
-				else
-					++visitDialogs;
 			}
 		}
 	}
 	if(!visitText.empty())
 	{
-		if(visitDialogs)
-			visitText += "\n\tYou have " + Format::Number(visitDialogs) + " other incomplete " + ((visitDialogs > 1) ? "missions" : "mission") + " at this location.";
+		if(extraVisitDialogs)
+		{
+			visitText += "\n\tYou have " + Format::Number(extraVisitDialogs) + " other unfinished " + ((extraVisitDialogs > 1) ? "missions" : "mission") + " at this location.";
+			if(deadlineMissions)
+			{
+				visitText += "\n\t" + Format::Number(deadlineMissions) + " of your unfinished missions here " + ((deadlineMissions > 1) ? "have approaching deadlines." : "has an approaching deadline.");
+			}
+		}
 		ui->Push(new Dialog(visitText));
 	}
 	// One mission's actions may influence another mission, so loop through one

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2376,7 +2376,7 @@ void PlayerInfo::StepMissions(UI *ui)
 			if(!action.DialogText().empty())
 			{
 				if(visitText.empty())
-					visitText = Format::Replace(ait.DialogText(), substitutions);
+					visitText = Format::Replace(action.DialogText(), substitutions);
 				else
 					++extraVisitDialogs;
 				if(mission.Deadline())
@@ -2395,7 +2395,7 @@ void PlayerInfo::StepMissions(UI *ui)
 				visitText += "(" + Format::Number(deadlineMissions) + " of which "
 					+ ((deadlineMissions > 1) ? "have approaching deadlines" : "has an approaching deadline)");
 			}
-			visitTest += ".";
+			visitText += ".";
 		}
 		ui->Push(new Dialog(visitText));
 	}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2380,10 +2380,11 @@ void PlayerInfo::StepMissions(UI *ui)
 			++missionVisits;
 		}
 	}
-	if(!visitText.empty() && missionVisits > 1)
+	if(!visitText.empty())
 	{
-		visitText += "\n\t(You have " + Format::Number(missionVisits - 1) + " other unfinished " 
-			+ ((missionVisits > 2) ? "missions" : "mission") + " at this location.)";
+		if(missionVisits > 1)
+			visitText += "\n\t(You have " + Format::Number(missionVisits - 1) + " other unfinished " 
+				+ ((missionVisits > 2) ? "missions" : "mission") + " at this location.)";
 		ui->Push(new Dialog(visitText));
 	}
 	// One mission's actions may influence another mission, so loop through one

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2343,11 +2343,11 @@ void PlayerInfo::StepMissions(UI *ui)
 	string visitText;
 	int extraVisitDialogs = 0;
 	int deadlineMissions = 0;
-	map<string, string> subs;
-	subs["<first>"] = firstName;
-	subs["<last>"] = lastName;
+	map<string, string> substitutions;
+	substitutions["<first>"] = firstName;
+	substitutions["<last>"] = lastName;
 	if(Flagship())
-		subs["<ship>"] = Flagship()->Name();
+		substitutions["<ship>"] = Flagship()->Name();
 	
 	auto mit = missions.begin();
 	while(mit != missions.end())
@@ -2371,11 +2371,11 @@ void PlayerInfo::StepMissions(UI *ui)
 			// On visit dialogs are handled separately as to avoid a player
 			// getting spammed by on visit dialogs if they are stacking jobs
 			// from the same destination.
-			auto ait = mission.GetAction(Mission::VISIT);
-			if(!ait.DialogText().empty())
+			auto action = mission.GetAction(Mission::VISIT);
+			if(!action.DialogText().empty())
 			{
 				if(visitText.empty())
-					visitText = Format::Replace(ait.DialogText(), subs);
+					visitText = Format::Replace(ait.DialogText(), substitutions);
 				else
 					++extraVisitDialogs;
 				if(mission.Deadline())
@@ -2387,10 +2387,12 @@ void PlayerInfo::StepMissions(UI *ui)
 	{
 		if(extraVisitDialogs)
 		{
-			visitText += "\n\tYou have " + Format::Number(extraVisitDialogs) + " other unfinished " + ((extraVisitDialogs > 1) ? "missions" : "mission") + " at this location.";
+			visitText += "\n\tYou have " + Format::Number(extraVisitDialogs) + " other unfinished " 
+				+ ((extraVisitDialogs > 1) ? "missions" : "mission") + " at this location.";
 			if(deadlineMissions)
 			{
-				visitText += "\n\t" + Format::Number(deadlineMissions) + " of your unfinished missions here " + ((deadlineMissions > 1) ? "have approaching deadlines." : "has an approaching deadline.");
+				visitText += "\n\tOf your unfinished missions here " + Format::Number(deadlineMissions) 
+					+ ((deadlineMissions > 1) ? " have approaching deadlines." : " has an approaching deadline.");
 			}
 		}
 		ui->Push(new Dialog(visitText));

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2343,7 +2343,7 @@ void PlayerInfo::StepMissions(UI *ui)
 	string visitText;
 	int extraVisitDialogs = 0;
 	int deadlineMissions = 0;
-	auto subs = map<string, string>{
+	auto substitutions = map<string, string>{
 		{"<first>", firstName},
 		{"<last>", lastName}
 	};

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2343,9 +2343,10 @@ void PlayerInfo::StepMissions(UI *ui)
 	string visitText;
 	int extraVisitDialogs = 0;
 	int deadlineMissions = 0;
-	map<string, string> substitutions;
-	substitutions["<first>"] = firstName;
-	substitutions["<last>"] = lastName;
+	auto subs = map<string, string>{
+		{"<first>", firstName},
+		{"<last>", lastName}
+	};
 	if(Flagship())
 		substitutions["<ship>"] = Flagship()->Name();
 	
@@ -2388,12 +2389,13 @@ void PlayerInfo::StepMissions(UI *ui)
 		if(extraVisitDialogs)
 		{
 			visitText += "\n\tYou have " + Format::Number(extraVisitDialogs) + " other unfinished " 
-				+ ((extraVisitDialogs > 1) ? "missions" : "mission") + " at this location.";
+				+ ((extraVisitDialogs > 1) ? "missions" : "mission") + " at this location";
 			if(deadlineMissions)
 			{
-				visitText += "\n\tOf your unfinished missions here " + Format::Number(deadlineMissions) 
-					+ ((deadlineMissions > 1) ? " have approaching deadlines." : " has an approaching deadline.");
+				visitText += "(" + Format::Number(deadlineMissions) + " of which "
+					+ ((deadlineMissions > 1) ? "have approaching deadlines" : "has an approaching deadline)");
 			}
+			visitTest += ".";
 		}
 		ui->Push(new Dialog(visitText));
 	}


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4565.

## Feature Details
Implements a similar system as #4526 for on visit dialogs by telling the player how many other incomplete missions they have at this location instead of spamming them with a new dialog for each mission. The on visit dialog that gets shown is currently simply from the first mission in the list. Unique missions (i.e. one time missions) will show their dialogs separately from non-unique (i.e. repeatable) missions. If you have multiple non-unique on visits and any of them have deadlines, then you will be reminded of that.

## UI Screenshots
![image](https://user-images.githubusercontent.com/17688683/66696161-8e1d1c00-ec97-11e9-9471-588c965d3846.png)
![image](https://user-images.githubusercontent.com/17688683/66696168-983f1a80-ec97-11e9-8bf5-5ec045973e5f.png)
![image](https://user-images.githubusercontent.com/17688683/66705193-b9345980-ecf1-11e9-9818-787737496b82.png)
See https://github.com/endless-sky/endless-sky/pull/4592#discussion_r334246030 for more screenshots of various cases.