### PR TITLE
Added daily maintenance attributes

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -155,8 +155,8 @@ tip "jump speed:"
 tip "jump fuel:"
 	`How much fuel is consumed when you jump between systems using this drive.`
 
-tip "maintenance cost:"
-	`How many credits per day you need to spend to maintain this outfit.`
+tip "maintenance costs:"
+	`How many credits per day you need to spend to maintain this outfit. Even if a ship is parked, you still need to pay for its maintenance.`
 
 tip "map:"
 	`How many star systems are included in this map.`
@@ -166,6 +166,9 @@ tip "mass with no cargo:"
 
 tip "mass:"
 	`Mass, in tons. A ship's mass determines how fast it turns and accelerates.`
+
+tip "operating costs:"
+	`How many credits per day you need to spend to maintain this outfit while it is in active use.`
 
 tip "outfit scan:"
 	`Lets you scan your target ship's outfits from up to this distance away.`

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -156,7 +156,7 @@ tip "jump fuel:"
 	`How much fuel is consumed when you jump between systems using this drive.`
 
 tip "maintenance costs:"
-	`How many credits per day you need to spend to maintain this outfit. Even if a ship is parked, you still need to pay for its maintenance.`
+	`How many credits per day you need to spend to maintain this outfit. Even if a ship is parked or an outfit is in cargo, you still need to pay for its maintenance.`
 
 tip "map:"
 	`How many star systems are included in this map.`

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -155,6 +155,9 @@ tip "jump speed:"
 tip "jump fuel:"
 	`How much fuel is consumed when you jump between systems using this drive.`
 
+tip "maintenance cost:"
+	`How many credits per day you need to spend to maintain this outfit.`
+
 tip "map:"
 	`How many star systems are included in this map.`
 

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -254,15 +254,13 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 	// include commas, so just handle that separately here.
 	if(typesPaid.size() >= 3)
 	{
-		string output;
 		auto it = typesPaid.begin();
 		for(unsigned int i = 0; i < typesPaid.size() - 1; ++i)
 		{
-			output += creditString(it->second) + " in " + it->first + ", ";
+			out << creditString(it->second) << " in " << it->first << ", ";
 			++it;
 		}
-		output += "and " + creditString(it->second) + " in " + it->first + ".";
-		out << output;
+		out << "and " << creditString(it->second) << " in " << it->first + ".";
 	}
 	else
 	{

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -197,8 +197,7 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 			++it;
 	}
 	
-	// Maintenance costs are dealt with last since missing maintenance costs do
-	// not impact your credit score.
+	// Maintenance costs are dealt with last.
 	int64_t maintenancePaid = maintenanceDue;
 	if(maintenanceDue)
 	{
@@ -209,6 +208,7 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 			credits -= maintenancePaid;
 			if(!missedPayment)
 				out << "You could not pay all your maintenance costs.";
+			missedPayment = true;
 		}
 		else
 		{
@@ -230,7 +230,7 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 	// If you didn't make any payments, no need to continue further.
 	if(!(salariesPaid + mortgagesPaid + maintenancePaid + finesPaid))
 		return out.str();
-	else if(missedPayment || maintenanceDue)
+	else if(missedPayment)
 		out << " ";
 	
 	out << "You paid ";

--- a/source/Account.h
+++ b/source/Account.h
@@ -41,11 +41,14 @@ public:
 	void PayExtra(int mortgage, int64_t amount);
 	
 	// Step forward one day, and return a string summarizing payments made.
-	std::string Step(int64_t assets, int64_t salaries);
+	std::string Step(int64_t assets, int64_t salaries, int64_t maintenance);
 	
 	// Overdue crew salaries:
 	int64_t SalariesOwed() const;
 	void PaySalaries(int64_t amount);
+	// Overdue maintenance costs:
+	int64_t MaintenanceDue() const;
+	void PayMaintenance(int64_t amount);
 	
 	// Liabilities:
 	const std::vector<Mortgage> &Mortgages() const;
@@ -67,8 +70,10 @@ private:
 	
 private:
 	int64_t credits;
-	// If back salaries cannot be paid, they pile up rather than being ignored.
+	// If back salaries and maintenance cannot be paid, they pile up rather 
+	// than being ignored.
 	int64_t salariesOwed;
+	int64_t maintenanceDue;
 	
 	std::vector<Mortgage> mortgages;
 	

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -248,7 +248,7 @@ void BankPanel::Draw()
 	// Draw the "Pay All" button.
 	const Interface *interface = GameData::Interfaces().Get("bank");
 	Information info;
-	if((salariesOwed || maintenanceDue) && player.Accounts().Credits() != 0)
+	if((salariesOwed || maintenanceDue) && player.Accounts().Credits() > 0)
 		info.SetCondition("can pay");
 	else
 		for(const Mortgage &mortgage : player.Accounts().Mortgages())

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -120,7 +120,7 @@ void BankPanel::Draw()
 	int64_t maintenanceDue = player.Accounts().MaintenanceDue();
 	// Figure out how many rows of the display are for mortgages, and also check
 	// whether multiple mortgages have to be combined into the last row.
-	mortgageRows = MAX_ROWS - (salaries != 0) - (maintenance != 0) - (income[0] != 0 || income[1] != 0);
+	mortgageRows = MAX_ROWS - (salaries != 0 || salariesOwed != 0) - (maintenance != 0 || maintenanceDue != 0) - (income[0] != 0 || income[1] != 0);
 	int mortgageCount = player.Accounts().Mortgages().size();
 	mergedMortgages = (mortgageCount > mortgageRows);
 	if(!mergedMortgages)

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -111,9 +111,11 @@ void BankPanel::Draw()
 		for( ; it != player.Conditions().end() && !it->first.compare(0, prefix[i].length(), prefix[i]); ++it)
 			income[i] += it->second;
 	}
+	// Checl if maintenance needs to be drawn.
+	int64_t maintenance = player.Maintenance();
 	// Figure out how many rows of the display are for mortgages, and also check
 	// whether multiple mortgages have to be combined into the last row.
-	mortgageRows = MAX_ROWS - (salaries != 0) - (income[0] != 0 || income[1] != 0);
+	mortgageRows = MAX_ROWS - (salaries != 0) - (maintenance != 0) - (income[0] != 0 || income[1] != 0);
 	int mortgageCount = player.Accounts().Mortgages().size();
 	mergedMortgages = (mortgageCount > mortgageRows);
 	if(!mergedMortgages)
@@ -182,6 +184,23 @@ void BankPanel::Draw()
 		else
 			table.Advance(3);
 		table.Draw(salaries);
+		table.Advance();
+	}
+	// Draw the maintenance costs, if necessary.
+	if(maintenance)
+	{
+		totalPayment += maintenance;
+		
+		table.Draw("Maintenance");
+		if(player.Accounts().MaintenanceDue())
+		{
+			table.Draw(Format::Credits(player.Accounts().MaintenanceDue()));
+			table.Draw("(overdue)");
+			table.Advance(1);
+		}
+		else
+			table.Advance(3);
+		table.Draw(maintenance);
 		table.Advance();
 	}
 	if(income[0] || income[1])

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -112,10 +112,7 @@ void BankPanel::Draw()
 		for( ; it != player.Conditions().end() && !it->first.compare(0, prefix[i].length(), prefix[i]); ++it)
 			income[i] += it->second;
 	}
-	// Check if maintenance needs to be drawn. The player can still have due
-	// maintenance even if they no longer have outfits that require maintenance, 
-	// as to avoid the player being able to dodge payments by selling the outfit,
-	// so also check for any overdue maintenance costs.
+	// Check if maintenance needs to be drawn.
 	int64_t maintenance = player.Maintenance();
 	int64_t maintenanceDue = player.Accounts().MaintenanceDue();
 	// Figure out how many rows of the display are for mortgages, and also check

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -695,12 +695,8 @@ int64_t PlayerInfo::Maintenance() const
 		if(!ship->IsDestroyed())
 		{
 			maintenance += ship->Attributes().Get("maintenance costs");
-			auto outfit = ship->Cargo().Outfits().begin();
-			for(unsigned int i = 0; i < ship->Cargo().Outfits().size(); ++i)
-			{
-				maintenance += outfit->first->Get("maintenance costs") * outfit->second;
-				++outfit;
-			}
+			for(const auto &outfit : ship->Cargo().Outfits())
+				maintenance += outfit.first->Get("maintenance costs") * outfit.second;
 			if(!ship->IsParked())
 				maintenance += ship->Attributes().Get("operating costs");
 		}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -691,24 +691,23 @@ int64_t PlayerInfo::Salaries() const
 int64_t PlayerInfo::Maintenance() const
 {
 	int64_t maintenance = 0;
-	// If the player is landed, then all cargo will be in the player's 
+	// If the player is landed, then cargo will be in the player's 
 	// pooled cargo. Check there so that the bank panel can display the
 	// correct total maintenance costs. When launched all cargo will be
 	// in the player's ships instead of in the pooled cargo, so no outfit 
 	// will be counted twice.
 	for(const auto &outfit : Cargo().Outfits())
-		maintenance += outfit.first->Get("maintenance costs") * outfit.second;
+		maintenance += max(0, outfit.first->Get("maintenance costs")) * outfit.second;
 	for(const shared_ptr<Ship> &ship : ships)
 		if(!ship->IsDestroyed())
 		{
-			maintenance += ship->Attributes().Get("maintenance costs");
+			maintenance += max(0, ship->Attributes().Get("maintenance costs"));
 			for(const auto &outfit : ship->Cargo().Outfits())
-				maintenance += outfit.first->Get("maintenance costs") * outfit.second;
+				maintenance += max(0, outfit.first->Get("maintenance costs")) * outfit.second;
 			if(!ship->IsParked())
-				maintenance += ship->Attributes().Get("operating costs");
+				maintenance += max(0, ship->Attributes().Get("operating costs"));
 		}
-	// Maintenance costs should never be net negative.
-	return max(0, maintenance);
+	return maintenance;
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -693,8 +693,12 @@ int64_t PlayerInfo::Maintenance() const
 {
 	int64_t maintenance = 0;
 	for(const shared_ptr<Ship> &ship : ships)
-		if(!ship->IsParked() && !ship->IsDestroyed())
-			maintenance += ship->Attributes().Get("maintenance cost");
+		if(!ship->IsDestroyed())
+		{
+			maintenance += ship->Attributes().Get("maintenance costs");
+			if(!ship->IsParked())
+				maintenance += ship->Attributes().Get("operating costs");
+		}
 	return maintenance;
 }
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -687,7 +687,6 @@ int64_t PlayerInfo::Salaries() const
 
 
 
-
 // Calculate the daily maintenance cost for all ships and in cargo outfits.
 int64_t PlayerInfo::Maintenance() const
 {

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -691,6 +691,13 @@ int64_t PlayerInfo::Salaries() const
 int64_t PlayerInfo::Maintenance() const
 {
 	int64_t maintenance = 0;
+	// If the player is landed, then all cargo will be in the player's 
+	// pooled cargo. Check there so that the bank panel can display the
+	// correct total maintenance costs. When launched all cargo will be
+	// in the player's ships instead of in the pooled cargo, so no outfit 
+	// will be counted twice.
+	for(const auto &outfit : Cargo().Outfits())
+		maintenance += outfit.first->Get("maintenance costs") * outfit.second;
 	for(const shared_ptr<Ship> &ship : ships)
 		if(!ship->IsDestroyed())
 		{
@@ -700,7 +707,8 @@ int64_t PlayerInfo::Maintenance() const
 			if(!ship->IsParked())
 				maintenance += ship->Attributes().Get("operating costs");
 		}
-	return maintenance;
+	// Maintenance costs should never be net negative.
+	return max(0, maintenance);
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -688,7 +688,7 @@ int64_t PlayerInfo::Salaries() const
 
 
 
-// Calculate the daily maintenance cost for all unparked ships.
+// Calculate the daily maintenance cost for all ships and in cargo outfits.
 int64_t PlayerInfo::Maintenance() const
 {
 	int64_t maintenance = 0;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -696,6 +696,12 @@ int64_t PlayerInfo::Maintenance() const
 		if(!ship->IsDestroyed())
 		{
 			maintenance += ship->Attributes().Get("maintenance costs");
+			auto outfit = ship->Cargo().Outfits().begin();
+			for(unsigned int i = 0; i < ship->Cargo().Outfits().size(); ++i)
+			{
+				maintenance += outfit->first->Get("maintenance costs") * outfit->second;
+				++outfit;
+			}
 			if(!ship->IsParked())
 				maintenance += ship->Attributes().Get("operating costs");
 		}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -570,7 +570,7 @@ void PlayerInfo::IncrementDate()
 	
 	// Have the player pay salaries, mortgages, etc. and print a message that
 	// summarizes the payments that were made.
-	string message = accounts.Step(assets, Salaries());
+	string message = accounts.Step(assets, Salaries(), Maintenance());
 	if(!message.empty())
 		Messages::Add(message);
 	
@@ -683,6 +683,19 @@ int64_t PlayerInfo::Salaries() const
 	
 	// Every crew member except the player receives 100 credits per day.
 	return 100 * (crew - 1);
+}
+
+
+
+
+// Calculate the daily maintenance cost for all unparked ships.
+int64_t PlayerInfo::Maintenance() const
+{
+	int64_t maintenance = 0;
+	for(const shared_ptr<Ship> &ship : ships)
+		if(!ship->IsParked() && !ship->IsDestroyed())
+			maintenance += ship->Attributes().Get("maintenance cost");
+	return maintenance;
 }
 
 
@@ -2229,6 +2242,7 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 	conditions["unpaid mortgages"] = min(limit, accounts.TotalDebt("Mortgage"));
 	conditions["unpaid fines"] = min(limit, accounts.TotalDebt("Fine"));
 	conditions["unpaid salaries"] = min(limit, accounts.SalariesOwed());
+	conditions["unpaid maintenance"] = min(limit, accounts.MaintenanceDue());
 	conditions["credit score"] = accounts.CreditScore();
 	// Serialize the current reputation with other governments.
 	SetReputationConditions();

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -106,7 +106,7 @@ public:
 	Account &Accounts();
 	// Calculate the daily salaries for crew, not counting crew on "parked" ships.
 	int64_t Salaries() const;
-	// Calculate the daily maintenance cost for all unparked ships.
+	// Calculate the daily maintenance cost for all ships and in cargo outfits.
 	int64_t Maintenance() const;
 	
 	// Access the flagship (the first ship in the list). This returns null if

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -106,6 +106,8 @@ public:
 	Account &Accounts();
 	// Calculate the daily salaries for crew, not counting crew on "parked" ships.
 	int64_t Salaries() const;
+	// Calculate the daily maintenance cost for all unparked ships.
+	int64_t Maintenance() const;
 	
 	// Access the flagship (the first ship in the list). This returns null if
 	// the player does not have any ships.


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4284. 
Maintenance costs have also been requested or discussed in #4591, #3659, #2219, and more.

## Feature Details
This mechanic is not intended to be used in vanilla, but seeing as how it has been requested many times, I see this as a worthwhile addition. 

Adds `"maintenance costs"` and `"operating costs"` outfit attributes that work similarly to how crew salaries work. Every day, the total maintenance cost is deducted from the player's credits. `"maintenance costs"` are always active so long as the player owns the outfit/ship while `"operating costs"` only apply to unparked ships. Both will show as `Maintenance` in the bank and with each day that passes.

Overdue maintenance costs have zero effect on the efficiency or sale price of the outfit or ship they are attached to, and having maintenance costs on an outfit or ship in no way effects how it depreciates.

If the player has overdue maintenance costs and sells the outfit or ship that has the maintenance cost, then they will still need to pay the overdue costs, just as they do with overdue crew salaries after firing the crew. This is to make it so that the player can't simply ignore overdue maintenance costs by selling the offending outfit or ship. If the purpose of maintenance costs is like the usage outlined in #4284 where it's a roundabout way to have crew that cost extra, then this makes sense, since you're technically paying overdue crew salaries. But in the case where maintenance costs are actually meant as maintenance costs, one could explain this away as the player paying for the repair of the outfit/ship even after they sold it off because of how overdue maintenance costs don't impact sale price.

This PR also fixes an oversight with crew salaries; overdue crew salaries will continue to be paid even if you fire all of your crew, but if you have 0 crew aside from yourself then the crew line will not appear in the bank panel, meaning you can't tell how much overdue crew salaries you still have to pay, but you could still click on the `Pay All` button, even though it was greyed out, and pay off the overdue salaries. This fixed behavior extends to overdue maintenance costs without any current maintenance costs.

## UI Screenshots
Crew salaries will now display in the bank if you have no crew but have overdue salaries, and the `Pay All` button highlights accordingly.
![image](https://user-images.githubusercontent.com/17688683/66767053-93d45680-ee7d-11e9-94f9-0ee9676fdf01.png)
A display of two types of payments being paid at once.
![image](https://user-images.githubusercontent.com/17688683/66767166-ce3df380-ee7d-11e9-9ccf-a687e204dce1.png)
Three types of payments being paid.
![image](https://user-images.githubusercontent.com/17688683/66767543-aef39600-ee7e-11e9-9038-56b83c39b159.png)
All four payment types being paid. Payment types are displaying in alphabetical order because I guess that's how a `map` stores keys.
![image](https://user-images.githubusercontent.com/17688683/66767593-c92d7400-ee7e-11e9-8a3f-c488477f612b.png)
The bank panel will size the number of mortgages properly depending on if you have crew or maintenance costs.
![image](https://user-images.githubusercontent.com/17688683/66767490-94212180-ee7e-11e9-9987-8a00366ff194.png)
![image](https://user-images.githubusercontent.com/17688683/66767696-fd089980-ee7e-11e9-9a8a-36acdab9537a.png)

## Usage Examples
`"maintenance costs"` and `"operating costs"` are attributes of an outfit or ship, used as follows.
```
outfit "Jump Drive"
	category "Systems"
	cost 1000000
	thumbnail "outfit/jump drive"
	"mass" 20
	"outfit space" -20
	"jump speed" .3
	"jump fuel" 200
	"jump drive" 1
	"maintenance costs" 1000

ship "Kar Ik Vot 349"
	sprite "ship/kar ik vot 349"
	thumbnail "thumbnail/kar ik vot 349"
	attributes
		category "Heavy Warship"
		"cost" 41280000
		"operating costs" 10000
		...
```
