### PR TITLE
Fix: Correcting " Drak " swizzle

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -551,7 +551,10 @@ event "remnant: gascraft"
 		add shipyard "Remnant Gascraft"
 
 government " Drak "
+	swizzle 5
 	"player reputation" -1000
+	"attitude toward"
+		"Indigenous Lifeform" 1
 
 event "remnant: void sprite research"
 


### PR DESCRIPTION
This gives " Drak " the same swizzle as the normal Drak, and gives it a favourable attitude toward the indigenous lifeforms to ensure that it continues its protective behaviours.

Thanks to Spookext for reporting the swizzle changing bug.

Change:
 - Adds: 
        `swizzle 5`
 - Adds :
```
"attitude toward"
		"Indigenous Lifeform" 1
```