### PR TITLE
Hyperdrive and Jump Disruption damage types

### DIFF
--- a/data/drak.txt
+++ b/data/drak.txt
@@ -145,6 +145,7 @@ outfit "Drak Antimatter Fragment"
 		"hit force" 1000
 		"shield damage" 5610
 		"hull damage" 5610
+		"cloak disruption" 150
 		"blast radius" 100
 
 effect "antimatter spark"

--- a/data/effects.txt
+++ b/data/effects.txt
@@ -43,6 +43,15 @@ effect "slowing spark"
 	"random spin" 30
 	"random velocity" .1
 
+# TODO: Use a unique effect and sprite
+effect "cloak disruption spark"
+	sprite "effect/nano spark"
+		"random start frame"
+		"frame rate" 16
+	"lifetime" 1
+	"random angle" 360
+	"random spin" 4
+
 
 effect "flame"
 	sprite "effect/flame"

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -40,6 +40,9 @@ color "heat" .70 .43 .43 .75
 color "overheat" .70 .61 .43 .75
 color "energy" .6 .6 .6 .75
 color "fuel" .70 .62 .43 .75
+color "hyper disrupted" .5 .0 .0 .75
+color "jump disrupted" .0 .0 .5 .75
+color "double disrupted" .35 .0 .35 .75
 
 color "flagship highlight" .5 .8 .2 0.
 
@@ -340,6 +343,21 @@ interface "hud"
 		from -53.5 425
 		dimensions 0 -192
 		color "fuel"
+		size 2
+	bar "hyper disrupted"
+		from -53.5 425
+		dimensions 0 -192
+		color "hyper disrupted"
+		size 2
+	bar "jump disrupted"
+		from -53.5 425
+		dimensions 0 -192
+		color "jump disrupted"
+		size 2
+	bar "double disrupted"
+		from -53.5 425
+		dimensions 0 -192
+		color "double disrupted"
 		size 2
 	bar "energy"
 		from -33.5 415

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -374,6 +374,12 @@ tip "slowing damage / second:"
 tip "disruption damage / second:"
 	`Disrupts the target's shields, allowing weapon damage to "leak through" to the hull even if shields are up. Shield disruption wears off over time.`
 
+tip "drive disruption / second:"
+	`Disrupts the target's hyperdrive, preventing them from using it. Hyperdrive disruption wears off over time.`
+
+tip "jump disruption / second:"
+	`Disrupts the target's jump drive, preventing them from using it. Jump disruption wears off over time.`
+
 tip "firing energy / second:"
 	`Energy consumed by this weapon per second when firing.`
 
@@ -427,6 +433,12 @@ tip "slowing damage / shot:"
 
 tip "disruption damage / shot:"
 	`Disrupts the target's shields, allowing weapon damage to "leak through" to the hull even if shields are up. Shield disruption wears off over time.`
+
+tip "drive disruption / shot:"
+	`Disrupts the target's hyperdrive, preventing them from using it. Hyperdrive disruption wears off over time.`
+
+tip "jump disruption / shot:"
+	`Disrupts the target's jump drive, preventing them from using it. Jump disruption wears off over time.`
 
 tip "firing energy / shot:"
 	`Each shot requires this much energy. A weapon will not fire if the ship's batteries do not have at least this amount of energy stored.`

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3444,6 +3444,13 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player)
 			if(isNewPress)
 				Audio::Play(Audio::Get("fail"));
 		}
+		else if(ship.IsDisrupted())
+		{
+			Messages::Add("Your drive is being disrupted!");
+			keyStuck.Clear();
+			if(isNewPress)
+				Audio::Play(Audio::Get("fail"));
+		}
 		else if(!ship.JumpFuel(ship.GetTargetSystem()))
 		{
 			Messages::Add("You cannot jump to the selected system.");

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -589,8 +589,20 @@ void Engine::Step(bool isActive)
 	info.SetString("date", player.GetDate().ToString());
 	if(flagship)
 	{
-		info.SetBar("fuel", flagship->Fuel(),
-			flagship->Attributes().Get("fuel capacity") * .01);
+		double fuel = flagship->Fuel();
+		double fuelCap = flagship->Attributes().Get("fuel capacity") * .01;
+		bool hyperDisrupted = flagship->HyperDisrupted();
+		bool jumpDisrupted = flagship->JumpDisrupted();
+		info.SetBar("fuel", fuel, fuelCap);
+		if((step / 20) % 2)
+		{
+			if(jumpDisrupted && hyperDisrupted)
+				info.SetBar("double disrupted", fuel, fuelCap);
+			else if(hyperDisrupted)
+				info.SetBar("hyper disrupted", fuel, fuelCap);
+			else if(jumpDisrupted)
+				info.SetBar("jump disrupted", fuel, fuelCap);
+		}
 		info.SetBar("energy", flagship->Energy());
 		double heat = flagship->Heat();
 		info.SetBar("heat", min(1., heat));

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -831,7 +831,7 @@ void MapPanel::DrawTravelPlan()
 	for(const shared_ptr<Ship> &it : player.Ships())
 		if(!it->IsParked() && !it->CanBeCarried() && it->GetSystem() == flagship->GetSystem())
 		{
-			if(it->IsDisabled())
+			if(it->IsDisabled() || it->IsDisrupted())
 			{
 				stranded = true;
 				continue;
@@ -881,7 +881,7 @@ void MapPanel::DrawTravelPlan()
 			drawColor = wormholeColor;
 		else if(!stranded)
 			drawColor = withinFleetFuelRangeColor;
-		else if(fuel[flagship] >= 0.)
+		else if(fuel[flagship] >= 0. && !flagship->IsDisrupted())
 			drawColor = defaultColor;
 		
 		Point from = Zoom() * (next->Position() + center);

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -831,7 +831,7 @@ void MapPanel::DrawTravelPlan()
 	for(const shared_ptr<Ship> &it : player.Ships())
 		if(!it->IsParked() && !it->CanBeCarried() && it->GetSystem() == flagship->GetSystem())
 		{
-			if(it->IsDisabled() || it->IsDisrupted())
+			if(it->IsDisabled())
 			{
 				stranded = true;
 				continue;
@@ -865,7 +865,7 @@ void MapPanel::DrawTravelPlan()
 				if(it.second >= 0.)
 				{
 					double cost = isJump ? it.first->JumpDriveFuel() : it.first->HyperdriveFuel();
-					if(!cost || cost > it.second)
+					if(!cost || cost > it.second || it.first->IsDisrupted(previous, next))
 					{
 						it.second = -1.;
 						stranded = true;
@@ -881,7 +881,7 @@ void MapPanel::DrawTravelPlan()
 			drawColor = wormholeColor;
 		else if(!stranded)
 			drawColor = withinFleetFuelRangeColor;
-		else if(fuel[flagship] >= 0. && !flagship->IsDisrupted())
+		else if(fuel[flagship] >= 0. && !flagship->IsDisrupted(previous, next))
 			drawColor = defaultColor;
 		
 		Point from = Zoom() * (next->Position() + center);

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -262,6 +262,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		"ion damage",
 		"slowing damage",
 		"disruption damage",
+		"drive disruption",
+		"jump disruption",
 		"firing energy",
 		"firing heat",
 		"firing fuel"
@@ -275,6 +277,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		outfit.IonDamage() * 100.,
 		outfit.SlowingDamage() * 100.,
 		outfit.DisruptionDamage() * 100.,
+		outfit.HyperDisruptionDamage() / 60.,
+		outfit.JumpDisruptionDamage() / 60.,
 		outfit.FiringEnergy(),
 		outfit.FiringHeat(),
 		outfit.FiringFuel()

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -96,42 +96,44 @@ namespace {
 		tie(minMass,maxMass,deviation) = effect;
 		
 		// If this weapon doesn't have an effect range, max damage is always dealt
-		if(minMass == 0. && maxMass == 0) {}
-		else if(deviation == 0.)
+		if(minMass != 0. && maxMass != 0.)
 		{
-			// For deviation values of 0, any ship outside the mass range takes 
-			// no disruption damage.
-			if(currentMass < minMass || currentMass > maxMass)
-				damage = 0.;
-		}
-		else if(deviation < 0.)
-		{
-			// For deviation values less than 0, any ship inside the mass range
-			// takes no damage, and ships outside the range take more damage 
-			// the farther from the range that they are.
-			if(currentMass >= minMass && currentMass <= maxMass)
-				damage = 0.;
-			else if(currentMass < minMass)
+			if(deviation == 0.)
 			{
-				damage *= 1 - exp(-pow(currentMass - minMass, 2) / (2 * pow(deviation, 2)));
+				// For deviation values of 0, any ship outside the mass range takes 
+				// no disruption damage.
+				if(currentMass < minMass || currentMass > maxMass)
+					damage = 0.;
 			}
-			else if(currentMass > maxMass)
+			else if(deviation < 0.)
 			{
-				damage *= 1 - exp(-pow(currentMass - maxMass, 2) / (2 * pow(deviation, 2)));
+				// For deviation values less than 0, any ship inside the mass range
+				// takes no damage, and ships outside the range take more damage 
+				// the farther from the range that they are.
+				if(currentMass >= minMass && currentMass <= maxMass)
+					damage = 0.;
+				else if(currentMass < minMass)
+				{
+					damage *= 1. - exp(-pow(currentMass - minMass, 2.) / (2. * pow(deviation, 2.)));
+				}
+				else if(currentMass > maxMass)
+				{
+					damage *= 1. - exp(-pow(currentMass - maxMass, 2.) / (2. * pow(deviation, 2.)));
+				}
 			}
-		}
-		else if(deviation > 0.)
-		{
-			// For deviation vales greater than 0, any ship inside the mass range
-			// takes max damage, and ships outide the range take less damage
-			// the farther from the range that they are.
-			if(currentMass < minMass)
+			else if(deviation > 0.)
 			{
-				damage *= exp(-pow(currentMass - minMass, 2) / (2 * pow(deviation, 2)));
-			}
-			else if(currentMass > maxMass)
-			{
-				damage *= exp(-pow(currentMass - maxMass, 2) / (2 * pow(deviation, 2)));
+				// For deviation vales greater than 0, any ship inside the mass range
+				// takes max damage, and ships outide the range take less damage
+				// the farther from the range that they are.
+				if(currentMass < minMass)
+				{
+					damage *= exp(-pow(currentMass - minMass, 2.) / (2. * pow(deviation, 2.)));
+				}
+				else if(currentMass > maxMass)
+				{
+					damage *= exp(-pow(currentMass - maxMass, 2.) / (2. * pow(deviation, 2.)));
+				}
 			}
 		}
 		

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2560,9 +2560,16 @@ double Ship::JumpFuelMissing() const
 
 
 
-bool Ship::IsDisrupted() const
+bool Ship::IsDisrupted(const System *start, const System *destination) const
 {
-	return (!IsReadyToJump() && (HyperDisrupted() || JumpDisrupted()));
+	if(!start || !destination)
+	{
+		start = currentSystem;
+		destination = targetSystem;
+	}
+	
+	bool isJump = attributes.Get("jump drive") && (!attributes.Get("hyperdrive") || (attributes.Get("hyperdrive") && hyperDisruption) || !start->Links().count(destination));
+	return ((isJump && jumpDisruption) || (!isJump && hyperDisruption));
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1128,7 +1128,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		const double DEFAULT_HYPERSPEED = 0.2;
 		// Hyperdrive disruption is lost by a rate of at least one per frame,
 		// but each additional hyperdrive will increase the loss rate by 1.
-		hyperDisruption = max(0., hyperDisruption - (1. + attributes.Get("jump speed") / DEFAULT_HYPERSPEED));
+		hyperDisruption = max(0., hyperDisruption - (1. + (attributes.Get("jump speed") + attributes.Get("scram drive"))/ DEFAULT_HYPERSPEED));
 	}
 	if(jumpDisruption)
 	{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -124,7 +124,7 @@ namespace {
 		{
 			// For deviation vales greater than 0, any ship inside the mass range
 			// takes max damage, and ships outide the range take less damage
-			// the farther form the range that they are.
+			// the farther from the range that they are.
 			if(currentMass < minMass)
 			{
 				damage *= exp(-pow(currentMass - minMass, 2) / (2 * pow(deviation, 2)));
@@ -1406,7 +1406,8 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	else if(commands.Has(Command::JUMP) && IsReadyToJump())
 	{
 		hyperspaceSystem = GetTargetSystem();
-		isUsingJumpDrive = !attributes.Get("hyperdrive") || !currentSystem->Links().count(hyperspaceSystem);
+		isUsingJumpDrive = attributes.Get("jump drive") && !jumpDisruption && 
+			(!attributes.Get("hyperdrive") || (attributes.Get("hyperdrive") && hyperDisruption) || !currentSystem->Links().count(hyperspaceSystem));
 		hyperspaceFuelCost = JumpFuel(hyperspaceSystem);
 	}
 	
@@ -2203,7 +2204,9 @@ bool Ship::IsReadyToJump(bool waitingIsReady) const
 		return false;
 	
 	Point direction = targetSystem->Position() - currentSystem->Position();
-	bool isJump = !attributes.Get("hyperdrive") || !currentSystem->Links().count(targetSystem);
+	bool isJump = attributes.Get("jump drive") && (!attributes.Get("hyperdrive") || (attributes.Get("hyperdrive") && hyperDisruption) || !currentSystem->Links().count(targetSystem));
+	if((isJump && jumpDisruption) || (!isJump && hyperDisruption))
+		return false;
 	double scramThreshold = attributes.Get("scram drive");
 	
 	// The ship can only enter hyperspace if it is traveling slowly enough

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2558,6 +2558,27 @@ double Ship::JumpFuelMissing() const
 
 
 
+bool Ship::IsDisrupted() const
+{
+	return (!IsReadyToJump() && (HyperDisrupted() || JumpDisrupted()));
+}
+
+
+
+bool Ship::HyperDisrupted() const
+{
+	return (hyperDisruption > 0.);
+}
+
+
+
+bool Ship::JumpDisrupted() const
+{
+	return (jumpDisruption > 0.);
+}
+
+
+
 // Get the heat level at idle.
 double Ship::IdleHeat() const
 {

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -431,6 +431,8 @@ private:
 	int customSwizzle = -1;
 	double cloak = 0.;
 	double cloakDisruption = 0.;
+	double hyperDisruption = 0.;
+	double jumpDisruption = 0.;
 	// Cached values for figuring out when anti-missile is in range.
 	double antiMissileRange = 0.;
 	double weaponRadius = 0.;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -268,7 +268,7 @@ public:
 	double JumpFuelMissing() const;
 	// Get if this ship can't leave the system because its hyperdrive or jump
 	// drive is being disrupted.
-	bool IsDisrupted() const;
+	bool IsDisrupted(const System *start = nullptr, const System *destination = nullptr) const;
 	bool HyperDisrupted() const;
 	bool JumpDisrupted() const;
 	// Get the heat level at idle.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -266,6 +266,11 @@ public:
 	double JumpDriveFuel() const;
 	// Get the amount of fuel missing for the next jump (smart refuelling)
 	double JumpFuelMissing() const;
+	// Get if this ship can't leave the system because its hyperdrive or jump
+	// drive is being disrupted.
+	bool IsDisrupted() const;
+	bool HyperDisrupted() const;
+	bool JumpDisrupted() const;
 	// Get the heat level at idle.
 	double IdleHeat() const;
 	// Get the heat dissipation, in heat units per heat unit per frame.

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -83,6 +83,20 @@ void Weapon::LoadWeapon(const DataNode &node)
 			int count = (child.Size() >= 3) ? child.Value(2) : 1;
 			submunitions[GameData::Outfits().Get(child.Token(1))] += count;
 		}
+		else if(key == "hyperdrive disruption effect")
+		{
+			double minMass = max(0., child.Value(1));
+			double maxMass = (child.Size() >= 3) ? max(minMass, (child.Value(2))) : max(0., minMass);
+			double deviation = (child.Size() >= 4) ? child.Value(3) : 0.;
+			hyperDisruptEffect = make_tuple(minMass, maxMass, deviation);
+		}
+		else if(key == "jump disruption effect")
+		{
+			double minMass = max(0., child.Value(1));
+			double maxMass = (child.Size() >= 3) ? max(minMass, (child.Value(2))) : max(0., minMass);
+			double deviation = (child.Size() >= 4) ? child.Value(3) : 0.;
+			jumpDisruptEffect = make_tuple(minMass, maxMass, deviation);
+		}
 		else
 		{
 			double value = child.Value(1);
@@ -167,6 +181,10 @@ void Weapon::LoadWeapon(const DataNode &node)
 				damage[SLOWING_DAMAGE] = value;
 			else if(key == "cloak disruption")
 				damage[ANTICLOAK_DAMAGE] = value;
+			else if(key == "hyperdrive disruption")
+				damage[ANTIHYPER_DAMAGE] = value;
+			else if(key == "jump disruption")
+				damage[ANTIJUMP_DAMAGE] = value;
 			else if(key == "hit force")
 				damage[HIT_FORCE] = value;
 			else if(key == "piercing")

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -165,6 +165,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 				damage[DISRUPTION_DAMAGE] = value;
 			else if(key == "slowing damage")
 				damage[SLOWING_DAMAGE] = value;
+			else if(key == "cloak disruption")
+				damage[ANTICLOAK_DAMAGE] = value;
 			else if(key == "hit force")
 				damage[HIT_FORCE] = value;
 			else if(key == "piercing")

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Point.h"
 
 #include <map>
+#include <tuple>
 
 class DataNode;
 class Effect;
@@ -109,6 +110,12 @@ public:
 	double DisruptionDamage() const;
 	double SlowingDamage() const;
 	double CloakDisruptionDamage() const;
+	double HyperDisruptionDamage() const;
+	double JumpDisruptionDamage() const;
+	// Values dictating how ship is affected by this weapon's hyper and jump
+	// disruption given the ship's mass.
+	std::tuple<double,double,double> HyperDisruptionEffect() const;
+	std::tuple<double,double,double> JumpDisruptionEffect() const;
 	// Check if this weapon does damage. If not, attacking a ship with this
 	// weapon is not a provocation (even if you push or pull it).
 	bool DoesDamage() const;
@@ -187,7 +194,7 @@ private:
 	double triggerRadius = 0.;
 	double blastRadius = 0.;
 	
-	static const int DAMAGE_TYPES = 9;
+	static const int DAMAGE_TYPES = 11;
 	static const int SHIELD_DAMAGE = 0;
 	static const int HULL_DAMAGE = 1;
 	static const int FUEL_DAMAGE = 2;
@@ -197,7 +204,12 @@ private:
 	static const int SLOWING_DAMAGE = 6;
 	static const int HIT_FORCE = 7;
 	static const int ANTICLOAK_DAMAGE = 8;
+	static const int ANTIHYPER_DAMAGE = 9;
+	static const int ANTIJUMP_DAMAGE = 10;
 	mutable double damage[DAMAGE_TYPES] = {};
+	
+	std::tuple<double,double,double> hyperDisruptEffect;
+	std::tuple<double,double,double> jumpDisruptEffect;
 	
 	double piercing = 0.;
 	
@@ -260,6 +272,11 @@ inline double Weapon::IonDamage() const { return TotalDamage(ION_DAMAGE); }
 inline double Weapon::DisruptionDamage() const { return TotalDamage(DISRUPTION_DAMAGE); }
 inline double Weapon::SlowingDamage() const { return TotalDamage(SLOWING_DAMAGE); }
 inline double Weapon::CloakDisruptionDamage() const { return TotalDamage(ANTICLOAK_DAMAGE); }
+inline double Weapon::HyperDisruptionDamage() const { return TotalDamage(ANTIHYPER_DAMAGE); }
+inline double Weapon::JumpDisruptionDamage() const { return TotalDamage(ANTIJUMP_DAMAGE); }
+
+inline std::tuple<double,double,double> Weapon::HyperDisruptionEffect() const { return hyperDisruptEffect; }
+inline std::tuple<double,double,double> Weapon::JumpDisruptionEffect() const { return jumpDisruptEffect; }
 
 inline bool Weapon::DoesDamage() const { if(!calculatedDamage) TotalDamage(0); return doesDamage; }
 

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -108,6 +108,7 @@ public:
 	double IonDamage() const;
 	double DisruptionDamage() const;
 	double SlowingDamage() const;
+	double CloakDisruptionDamage() const;
 	// Check if this weapon does damage. If not, attacking a ship with this
 	// weapon is not a provocation (even if you push or pull it).
 	bool DoesDamage() const;
@@ -186,7 +187,7 @@ private:
 	double triggerRadius = 0.;
 	double blastRadius = 0.;
 	
-	static const int DAMAGE_TYPES = 8;
+	static const int DAMAGE_TYPES = 9;
 	static const int SHIELD_DAMAGE = 0;
 	static const int HULL_DAMAGE = 1;
 	static const int FUEL_DAMAGE = 2;
@@ -195,7 +196,8 @@ private:
 	static const int DISRUPTION_DAMAGE = 5;
 	static const int SLOWING_DAMAGE = 6;
 	static const int HIT_FORCE = 7;
-	mutable double damage[DAMAGE_TYPES] = {0., 0., 0., 0., 0., 0., 0., 0.};
+	static const int ANTICLOAK_DAMAGE = 8;
+	mutable double damage[DAMAGE_TYPES] = {};
 	
 	double piercing = 0.;
 	
@@ -257,6 +259,7 @@ inline double Weapon::HeatDamage() const { return TotalDamage(HEAT_DAMAGE); }
 inline double Weapon::IonDamage() const { return TotalDamage(ION_DAMAGE); }
 inline double Weapon::DisruptionDamage() const { return TotalDamage(DISRUPTION_DAMAGE); }
 inline double Weapon::SlowingDamage() const { return TotalDamage(SLOWING_DAMAGE); }
+inline double Weapon::CloakDisruptionDamage() const { return TotalDamage(ANTICLOAK_DAMAGE); }
 
 inline bool Weapon::DoesDamage() const { if(!calculatedDamage) TotalDamage(0); return doesDamage; }
 


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4598. 
I merged #3599 into this branch to build off of since both that PR and this one are adding new damage types, and #3599 made some cleaning changes: basically just avoiding conflicts. I'd expect #3599 to be merged before this, though. Just mind those changes in this PR.

## Feature Details
Adds warp jamming attributes as weapon damage types. As with cloaking disruption's effect on cloaking (see #3599), having hyperdrive/jump disruption on your ship means that you can not jump until the disruption has completely dissipated. I designed this to have the highest degree of flexibility given the questions laid out in #4598.

If one of a ship's drives are disabled, then it will still be able to use the other drive. But, if an escort's hyperdrive is disabled and you use a jump drive to get to another system, the escort won't use its hyperdrive to reach you and will instead wait for its jump drive to reactivate and then follow you. This wasn't intentional, but I'd say is preferable, as otherwise the escort could potentially begin following you by HD, then have its JD reactivate and need to backtrack, wasting fuel.

Disruption is bled at a rate of `1 + jump speed / default jump speed` per frame, where default jump speed = 0.2 for hyperdrive disruption and 0.3 for jump drive disruption. This means that for each additional hyperdrive and/or jump drive that a ship has installed, the disruption will dissipate quicker. The default expected bleed value of most ships then is 2. Should these attributes become prevalent in a certain region of space, I'd suggest looking into reviving hyperdrive boosters (#1664) as an outfit to counter drive disruption.

The four new attributes are as follows.
`"hyperdrive disruption" <x>`
`"hyperdrive disruption effect" <min> <max> <deviation>`
`"jump disruption" <x>`
`"jump disruption effect" <min> <max> <deviation>`

The disruption attributes determine the base value of disruption that is applied to the impacted ship. The disruption effect attributes are used to modify the base value based off of the mass of the ship being impacted. The purpose of this is to allow for warp inhibitors that may only impact ships of certain sizes, or may simply impact some ships better than others. 
The min value is the minimum mass and the max value is the maximum mass, while the deviation impacts how ships outside of the min-max range are affected. The disruption effect does not need to be specified, which results in the default behavior of affecting all ships to the same degree, but if it is, the max and deviation values are optional. Not providing a max value could be used to create a disruptor that only impacts a specific mass (and therefore perhaps a specific mission ship), and not providing a deviation value means that only those ships inside the given range are affected. If a deviation value is given, then ships outside of the min-max range are able to be affected, but to a lesser degree. Negative deviation values are allowed, and this flips the effect such that those ships inside the range will now not be impacted, while those ships outside the range are to a greater degree the further from the range that they are.
[This](https://www.desmos.com/calculator/c2yag7wolv) Desmos graph shows how the deviation affects the disruption for ships outside the given mass range. The equation itself is based off of a normal curve, with the deviation simply being the standard deviation of the curve.

## UI Screenshots
Instead of the usual effect created around the ship like for ionization and similar, I decided to go for a UI effect that tells you when your drive is disabled. This doesn't tell you when other ships are disabled though, so a visual effect on the ship may still be in order.

If only your hyperdrive is disrupted, your fuel gauge blinks red.
If only your jump drive is disrupted, your fuel gauge blinks blue.
If both drives are disabled, your fuel gauge blinks purple.
These colors are subject to change (and probably should in some way, as the blue and purple can look similar for certain types of color blindness).
![fuel gauges](https://user-images.githubusercontent.com/17688683/66917973-5f32dd00-efec-11e9-9f7a-0c4c0e97104c.png)


## Usage Examples
```
# This weapon would disrupt both drives for ships between 400 and 800 tons.
outfit "Warp Inhibitor"
	...
	weapon
		...
		"hyperdrive disruption" 10
		"hyperdrive disruption effect" 400 800
		"jump disruption" 10
		"jump disruption effect" 400 800

# This weapon would disrupt hyperdrives on all ships, but ships between 400 and 800 
# would be hit the most.
outfit "Hyperdrive Disruptor"
	...
	weapon
		...
		"hyperdrive disruption" 10
		"hyperdrive disruption effect" 400 800 10

# This weapon would disrupt all jump drives.
outfit "Jump Jammer"
	...
	weapon
		...
		"jump disruption" 10

# This weapon would disrupt jump drives on all ships outside 
# of 1000 to 2000 tons, but ships closer to the range are less affected
outfit "Mosquito Catcher"
	...
	weapon
		...
		"jump disruption" 10
		"jump disruption effect" 1000 2000 -50
```

## Questions

* Should these disruption effects create visual effects on ships?
* Does anyone have a better name suggestion for the `disruption effect` attributes?
* Currently the disruption effect attributes don't display anywhere in the outfitter. I have no idea how one would show that information. Should these attributes just be left out of the outfitter with the description of the weapon describing what it is that the weapon affects?
* Currently these disruption effects aren't impacted by leakage (i.e. having the shields up doesn't decrease the incoming disruption). Should this be changed? I'd personally argue against this, as unlike the other attributes, jump disruption could effectively leave you completely stuck for a fair amount of time if the disruption you took was high, and the difference between shields up and shields down is rather drastic and could therefore lead to difficult to balance jump disruption.
* Given that a ship without a hyperdrive or jump drive doesn't need to bleed that disruption type, should the additional +1 be removed from the disruption bleed per frame? This would mean that the expected bleed value of most ships would be 1. The only thing this would really change is the value that drive disruption weapons would have.
* Should there be a maximum possible disruption on a ship as to avoid a scenario where the player is forced to stick around an uninhabited system for a while because they got hit with high amounts of disruption? Say 60 seconds.