### PR TITLE
Add the tooltip text for 'movement:'.

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -245,6 +245,9 @@ tip "max speed:"
 tip "acceleration:"
 	`How quickly this ship gains speed. The higher a ship's mass (including the mass of any cargo or fighters it is carrying), the slower it accelerates.`
 
+tip "movement:"
+	`How quickly this ship can accelerate and turn.`
+
 tip "movement, full / no cargo:"
 	`How quickly this ship can accelerate and turn when its cargo hold is full versus when it is empty.`
 


### PR DESCRIPTION
**Bugfix:** This PR fixes a bug that an attribute 'movement:' of no-cargo ships has no tooltip.

## Fix Details
This PR adds the tooltip text for 'movement:'.

## UI Screenshots
![add_tips_movement_UI](https://user-images.githubusercontent.com/22392249/67487301-a5510600-f6a8-11e9-88d9-1ccf9d50caf6.jpg)
