### PR TITLE
Implemented the Riptide into the Wanderer campaign

### DIFF
--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -909,4 +909,4 @@ ship "Riptide"
 	explode "medium explosion" 40
 	explode "large explosion" 20
 	"final explode" "final explosion medium"
-	description "As with many Wanderer ships the Riptide is an old design, brought back to help move civilians in response to the Unfettered invasion."
+	description "The Riptide is a dedicated transport ship meant to replace the temporary Deep River freighters that were converted into transport ships for refugee evacuation. Although not as durable as the Deep River, the Riptide is far more nimble of a ship while at the same time being able to carry more passengers."

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -1271,12 +1271,12 @@ mission "Wanderers: Mentors 2"
 		conversation
 			`A team of Wanderer terraforming experts has been assembled on <origin>. They have requisitioned a transport and filled it with an overwhelming variety of sensors, bioreactors, chemical filters, and other scientific devices. But, it's clear that none of them quite understand what is going on with the Kor Mereti. The team's manager says, "We are to meet with [sentient? awakened?] robots? They are interested in [foliage, plants]? There are worlds to be [repaired, healed]?"`
 			`	You do your best to answer their questions, but this is clearly not a situation that any of them had anticipated. Perhaps not even a situation that their species has ever had to deal with before, given that usually they are working in regions of space that have long since been abandoned by their former inhabitants.`
-			`	The freighter gets ready to follow you back to <planet>, where hopefully more of their questions will be answered.`
+			`	The transport gets ready to follow you back to <planet>, where hopefully more of their questions will be answered.`
 				accept
 	npc accompany save
 		government "Wanderer"
 		personality escort
-		ship "Deep River Transport" "Green Talon"
+		ship "Riptide" "Green Talon"
 
 
 

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -1426,7 +1426,7 @@ mission "Wanderers Invaded 1"
 			choice
 				`	"Okay, I'll help you to evacuate."`
 			label end
-			`	"Thank you," he says. "We have assembled a fleet of freighters, refitted to carry [refugees, evacuees]. Please escort the fleet to <planet>. You will receive further [orders, directions] when you land."`
+			`	"Thank you," he says. "We have assembled a fleet of freighters, refitted to carry [refugees, evacuees]. These ships are not ideal, but they will suffice for now until we can produce dedicated [transportation, evacuation] ships. Please escort the fleet to <planet>. You will receive further [orders, directions] when you land."`
 				accept
 	npc accompany save
 		government "Wanderer"
@@ -1926,7 +1926,7 @@ mission "Wanderers Evacuation 1"
 			has "Wanderers Pond Strider Recon 2: done"
 	on offer
 		conversation
-			`Four Wanderer transports - perhaps, in fact, the same four you escorted before - are parked here. One of the captains approaches you and says, "We are evacuating the worlds that will be [isolated, trapped] if the Unfettered gain more territory. Will you escort us to <planet>, and from there to the capital?"`
+			`Four Wanderer ships that you've never seen before are parked here. These must be the dedicated transport ships that Iktat Rek mentioned. One of the captains approaches you and says, "We are evacuating the worlds that will be [isolated, trapped] if the Unfettered gain more territory. Will you escort us to <planet>, and from there to the capital?"`
 			choice
 				`	"I would be glad to."`
 					accept
@@ -1935,17 +1935,28 @@ mission "Wanderers Evacuation 1"
 	npc accompany save
 		government "Wanderer"
 		personality timid escort
-		ship "Deep River Transport" "Espret Si'yakar"
-		ship "Deep River Transport" "Fel'tar Kor'meti'i"
-		ship "Deep River Transport" "Tok'tobar'tek La'a"
-		ship "Deep River Transport" "Eka'ta Turuk'ta"
+		ship "Riptide" "Vek'sek Kach'ik"
+		ship "Riptide" "Fel'tar Kri'esei"
+		ship "Riptide" "Vori'yek'tek La'a"
+		ship "Riptide" "Iyik'ta Rei'ta"
 	npc
 		government "Hai (Unfettered)"
 		personality heroic staying
 		fleet "Large Unfettered" 2
 	on visit
-		dialog
-			`You have reached <planet>, but the Wanderer transports have not all arrived yet. You should take off and wait for them to catch up with you.`
+		dialog `You've landed on <planet>, but not all of the Riptide transports carrying the refugees are in the system. Better depart and wait for them all to arrive.`
+
+
+
+# The Riptide was added after these missions, so it is triggered separately for backward compatibility.
+mission "Wanderers Riptide Patch"
+	invisible
+	landing
+	to offer
+		has "Wanderers Evacuation 1: offered"
+	on offer
+		event "wanderers: riptide mass production"
+		fail
 
 
 
@@ -1965,17 +1976,17 @@ mission "Wanderers Evacuation 1B"
 	npc accompany save
 		government "Wanderer"
 		personality timid escort
-		ship "Deep River Transport" "Espret Si'yakar"
-		ship "Deep River Transport" "Fel'tar Kor'meti'i"
-		ship "Deep River Transport" "Tok'tobar'tek La'a"
-		ship "Deep River Transport" "Eka'ta Turuk'ta"
+		ship "Riptide" "Vek'sek Kach'ik"
+		ship "Riptide" "Fel'tar Kri'esei"
+		ship "Riptide" "Vori'yek'tek La'a"
+		ship "Riptide" "Iyik'ta Rei'ta"
 	npc
 		government "Hai (Unfettered)"
 		personality heroic staying
 		system "Sich'ka'ara"
 		fleet "Large Unfettered" 3
 	on visit
-		dialog `You've landed on <planet>, but not all of the Deep River transports carrying the refugees are in the system. Better depart and wait for them all to arrive.`
+		dialog `You've landed on <planet>, but not all of the Riptide transports carrying the refugees are in the system. Better depart and wait for them all to arrive.`
 
 
 
@@ -2003,17 +2014,17 @@ mission "Wanderers Evacuation 1C"
 	npc accompany save
 		government "Wanderer"
 		personality timid escort
-		ship "Deep River Transport" "Espret Si'yakar"
-		ship "Deep River Transport" "Fel'tar Kor'meti'i"
-		ship "Deep River Transport" "Tok'tobar'tek La'a"
-		ship "Deep River Transport" "Eka'ta Turuk'ta"
+		ship "Riptide" "Vek'sek Kach'ik"
+		ship "Riptide" "Fel'tar Kri'esei"
+		ship "Riptide" "Vori'yek'tek La'a"
+		ship "Riptide" "Iyik'ta Rei'ta"
 	npc
 		government "Hai (Unfettered)"
 		personality heroic staying
 		system "Sich'ka'ara"
 		fleet "Large Unfettered" 4
 	on visit
-		dialog `You've landed on <planet>, but not all of the Deep River transports carrying the refugees are in the system. Better depart and wait for them all to arrive.`
+		dialog `You've landed on <planet>, but not all of the Riptide transports carrying the refugees are in the system. Better depart and wait for them all to arrive.`
 
 
 

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -1955,7 +1955,7 @@ mission "Wanderers Riptide Patch"
 	to offer
 		has "Wanderers Evacuation 1: offered"
 	on offer
-		event "wanderers: riptide mass production"
+		event "wanderers: riptide mass production" 30
 		fail
 
 

--- a/data/wanderers.txt
+++ b/data/wanderers.txt
@@ -760,6 +760,23 @@ event "wanderers: unfettered invasion starts"
 		shipyard clear
 		outfitter clear
 
+event "wanderers: riptide mass production"
+	fleet "Wanderer Freight"
+		add variant 3
+			"Riptide"
+		add variant
+			"Riptide"
+			"Tempest"
+		add variant
+			"Riptide"
+			"Strong Wind"
+			"Autumn Leaf"
+		add variant
+			"Riptide"
+			"Summer Leaf" 2
+	shipyard "Wanderer Advanced"
+		"Riptide"
+
 event "wanderers: tempest mass production"
 	fleet "Wanderer Defense"
 		add variant 6


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Implements the Riptide (#4102) into the Wanderer campaign by replacing the last set of Deep River transports with Riptides instead, and foreshadows the existence of the Riptide during the first time you see Deep River transports. The first time you see Riptides, they become available to buy and can be seen in Wanderer freight fleets after 30 days.