### PR TITLE
Fixing problematic changes to the Petrel and Tern

### DIFF
--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -592,7 +592,7 @@ ship "Petrel"
 		"required crew" 2
 		"bunks" 3
 		"mass" 50
-		"drag" 1.8
+		"drag" 1.3
 		"heat dissipation" .8
 		"outfit space" 133
 		"weapon capacity" 33
@@ -612,18 +612,17 @@ ship "Petrel"
 			"hull damage" 200
 			"hit force" 350
 	outfits
-		"Inhibitor Cannon"
+		"Inhibitor Cannon" 2
 		
 		"Millennium Cell" 2
 		"Crystal Capacitor"
 		"Thermoelectric Cooler"
 		
-		"Crucible-Class Thruster"
-		"Crucible-Class Steering"
+		"Anvil-Class Engine"
 		
-	gun 0 -38.5 "Inhibitor Cannon"
-	gun -10.5 -24 
-	gun 10.5 -24
+	gun 0 -38.5
+	gun -10.5 -24 "Inhibitor Cannon" 
+	gun 10.5 -24 "Inhibitor Cannon" 
 	turret 0 2.5
 	engine 0 41.5
 	explode "tiny explosion" 30

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -592,7 +592,7 @@ ship "Petrel"
 		"required crew" 2
 		"bunks" 3
 		"mass" 50
-		"drag" 1.3
+		"drag" 1.4
 		"heat dissipation" .8
 		"outfit space" 133
 		"weapon capacity" 33

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -586,13 +586,13 @@ ship "Petrel"
 		"cost" 1141000
 		"shields" 1000
 		"hull" 2300
-		"cargo space" 19
+		"cargo space" 15
 		"fuel capacity" 50
 		"ramscoop" 0.5
 		"required crew" 2
 		"bunks" 3
 		"mass" 50
-		"drag" 1.4
+		"drag" 1.44
 		"heat dissipation" .8
 		"outfit space" 133
 		"weapon capacity" 33

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -587,19 +587,24 @@ ship "Petrel"
 		"shields" 1000
 		"hull" 2300
 		"cargo space" 19
+		"fuel capacity" 50
+		"ramscoop" 0.5
 		"required crew" 2
 		"bunks" 3
 		"mass" 50
 		"drag" 1.8
 		"heat dissipation" .8
-		"outfit space" 133
+		"outfit space" 140
 		"weapon capacity" 33
-		"engine capacity" 26
+		"engine capacity" 34
 		"shield generation" 0.36
 		"shield energy" 0.24
 		"hull repair rate" 0.82
 		"hull energy" 0.54
 		"gaslining" 1
+		"outfit scan power" 10
+		"outfit scan speed" 1
+		"tactical scan power" 20
 		"asteroid scan power" 30
 		weapon
 			"blast radius" 15
@@ -607,24 +612,24 @@ ship "Petrel"
 			"hull damage" 200
 			"hit force" 350
 	outfits
-		"Thrasher Cannon" 2
+		"Inhibitor Cannon" 2
 		
 		"Millennium Cell" 2
 		"Crystal Capacitor"
 		"Thermoelectric Cooler"
-		"Fuel Pod"
-		"Emergency Ramscoop"
 		
-		"Anvil-Class Engine"
+		"Crucible-Class Thruster"
+		"Crucible-Class Steering"
 		
 	gun 0 -38.5
-	gun -10.5 -24 "Thrasher Cannon"
-	gun 10.5 -24 "Thrasher Cannon"
+	gun -10.5 -24 "Inhibitor Cannon"
+	gun 10.5 -24 "Inhibitor Cannon"
 	turret 0 2.5
 	engine 0 41.5
 	explode "tiny explosion" 30
 	explode "small explosion" 20
 	description "The Petrel is a multi-role mining/wing leader fightercraft designed to provide support for flights of lighter Terns in high-risk environments. The ship's design originated as an an urban mobile gun platform that flitted around structures and natural terrain, but proved easy to adapt into a spacecraft."
+	description "	The Remnant are loath to sacrifice pilots and crew from the comparatively small pool they are drawn from. As such, their fighters are equipped with medium-range weaponry designed to strike enemies from afar."
 
 
 

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -621,8 +621,8 @@ ship "Petrel"
 		"Anvil-Class Engine"
 		
 	gun 0 -38.5
-	gun -10.5 -24 "Inhibitor Cannon" 
-	gun 10.5 -24 "Inhibitor Cannon" 
+	gun -10.5 -24 "Inhibitor Cannon"
+	gun 10.5 -24 "Inhibitor Cannon"
 	turret 0 2.5
 	engine 0 41.5
 	explode "tiny explosion" 30

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -806,6 +806,9 @@ ship "Tern"
 		"hull repair rate" 0.55
 		"hull energy" 0.37
 		"gaslining" 1
+		"outfit scan power" 10
+		"outfit scan speed" 1
+		"tactical scan power" 20
 		"atmosphere scan" 100
 		"asteroid scan power" 30
 		weapon

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -594,7 +594,7 @@ ship "Petrel"
 		"mass" 50
 		"drag" 1.8
 		"heat dissipation" .8
-		"outfit space" 140
+		"outfit space" 133
 		"weapon capacity" 33
 		"engine capacity" 34
 		"shield generation" 0.36
@@ -612,7 +612,7 @@ ship "Petrel"
 			"hull damage" 200
 			"hit force" 350
 	outfits
-		"Inhibitor Cannon" 2
+		"Inhibitor Cannon"
 		
 		"Millennium Cell" 2
 		"Crystal Capacitor"
@@ -621,9 +621,9 @@ ship "Petrel"
 		"Crucible-Class Thruster"
 		"Crucible-Class Steering"
 		
-	gun 0 -38.5
-	gun -10.5 -24 "Inhibitor Cannon"
-	gun 10.5 -24 "Inhibitor Cannon"
+	gun 0 -38.5 "Inhibitor Cannon"
+	gun -10.5 -24 
+	gun 10.5 -24
 	turret 0 2.5
 	engine 0 41.5
 	explode "tiny explosion" 30

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -585,14 +585,14 @@ ship "Petrel"
 			Remnant
 		"cost" 1141000
 		"shields" 1000
-		"hull" 2300
+		"hull" 2500
 		"cargo space" 15
-		"fuel capacity" 50
+		"fuel capacity" 100
 		"ramscoop" 0.5
 		"required crew" 2
 		"bunks" 3
 		"mass" 50
-		"drag" 1.44
+		"drag" 1.55
 		"heat dissipation" .8
 		"outfit space" 133
 		"weapon capacity" 33


### PR DESCRIPTION
## Fix Details:
The Petrels were erroneously converted into being close-quarter fighters. This fixes that change.

## Changes:
*Petrel:*
- restores their fuel capacity to 50, instead of the 100 it was pre-Derp
- ramscoop restored to 0.5, instead of the 1 it was before.
- engine capacity back up to 34, exactly the same as before (and the minimum to fit the crucible engines)
- scanning restored (10 from 12, and 20 from 26. So both ranges are shorter than they were)
- 1 inhibitor cannons again instead of thrashers (they originally had inhibitors. This is a long-range support fighter, NOT close quarters. Remnant aren't suicidal)
- restored the description that explains how the Remnant use these fighters.
*Tern:*
- scanning restored (10 from 12, and 20 from 26. So both ranges are shorter than they were)