### PR TITLE
Make stealing an electron beam more consistent and reasonable

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -1175,6 +1175,7 @@ event "navy using mark ii ships"
 			"Frigate (Mark II)"
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)"
+
 fleet "gunboat only"
 	government "Republic"
 	names "republic small"
@@ -1188,7 +1189,7 @@ event "gunboats in Alnasl"
 	system "Alnasl"
 		fleet "Small Southern Merchants" 1300
 		fleet "Large Southern Merchants" 2500
-		fleet "gunboat only" 3600
+		fleet "gunboat only" 2400
 	system "Wei"
 		remove fleet "Large Republic"
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -1176,29 +1176,23 @@ event "navy using mark ii ships"
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)"
 
-fleet "gunboat only"
-	government "Republic"
-	names "republic small"
-	cargo 0
-	personality
-		heroic
-	variant
-		"Gunboat (Mark II)"
-
 event "gunboats in Alnasl"
-	system Alnasl
+	system "Alnasl"
 		fleet "Small Southern Merchants" 1300
 		fleet "Large Southern Merchants" 2500
-		fleet "gunboat only" 800
+	system "Wei"
+		remove fleet "Large Republic"
 
 event "normal in Alnasl"
-	system Alnasl
+	system "Alnasl"
 		fleet "Small Southern Merchants" 1300
 		fleet "Large Southern Merchants" 2500
 		fleet "Small Southern Pirates" 6000
 		fleet "Small Republic" 900
 		fleet "Large Republic" 1100
 		fleet "Navy Surveillance" 1200
+	system "Wei"
+		add fleet "Large Republic" 700
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -1175,11 +1175,20 @@ event "navy using mark ii ships"
 			"Frigate (Mark II)"
 			"Rainmaker (Mark II)" 2
 			"Gunboat (Mark II)"
+fleet "gunboat only"
+	government "Republic"
+	names "republic small"
+	cargo 0
+	personality
+		heroic
+	variant
+		"Gunboat (Mark II)"
 
 event "gunboats in Alnasl"
 	system "Alnasl"
 		fleet "Small Southern Merchants" 1300
 		fleet "Large Southern Merchants" 2500
+		fleet "gunboat only" 3600
 	system "Wei"
 		remove fleet "Large Republic"
 

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -209,7 +209,14 @@ mission "FW Southern Recon 1B"
 				`	"How can I find a gunboat that's all by itself? They're usually a part of a bigger fleet."`
 			`	She thinks about that for a moment, then says, "The Navy has shifted most of their capital ships to the defecting systems in the south. That means that some of the systems up north will have lighter defenses. You might try Wei or Alnasl. Good luck, Captain."`
 				accept
-	
+	npc
+		government "Republic"
+		system "Alnasl"
+		personality heroic opportunistic staying
+		fleet
+			names "republic small"
+			variant
+				"Gunboat (Mark II)"
 	to complete
 		not "FW Southern Recon 1B (Turret): done"
 	to fail


### PR DESCRIPTION
**Content (Missions)**

## Summary
Ref: #4172
The difficulty of this mission has been of concern for a while now. This change should make stealing an electron beam more consistent and reasonable now.

1. Wei no longer spawns large Republic fleets doing the duration of the mission. Given that the player is only expected to be in a single ship, it's unreasonable to expect the player to be able to either take on a large Republic fleet solo or be capable of always evading a large Republic fleet when jumping to Alnasl.
2. Greatly reduced the spawn rate of Mark II Gunboats in Alnasl, and added an NPC Gunboat spawned by the mission. This means that the player is guaranteed to run into at least one Gunboat in Alnasl upon entering, and is less likely to have to deal with multiple Gunboats at once.