### PR TITLE
Fix two missing indents in "Remnant: Face to Maw2/2B."

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -1803,7 +1803,7 @@ mission "Remnant: Face to Maw 2"
 					accept
 				`	"I would rather not."`
 			`	Plume stoically accepts that with a nod. "That is your choice. I will arrange for another ship to transport it."`
-			decline
+				decline
 	on accept
 		event "remnant: penguin"
 	on complete
@@ -1861,7 +1861,7 @@ mission "Remnant: Face to Maw 2B"
 					accept
 				`	"I would rather not."`
 			`	The technician looks disappointed. "Oh well, enjoy your trophy."`
-			decline
+				decline
 	on complete
 		log "People" "Chilia" `As a military prefect, Chilia is responsible for the defense of Remnant space. He can usually be found on the front lines of combat unless required to work on tactics for the Remnant as a whole.`
 		payment 250000


### PR DESCRIPTION
**Bugfix:** This PR addresses issues in mission "Remnant: Face to Maw2" and "... 2B."

Current version shows "decline" in the conversation:
![missing_indent](https://user-images.githubusercontent.com/22392249/68118112-7eb18b80-ff42-11e9-9fd3-c6048f7bc4e8.jpg)

It should add a indent to be a special tag.