### PR TITLE
Create short Hai mission string to unlock the Shield Beetle

### DIFF
--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -1069,16 +1069,16 @@ mission "Enlisted by Hai [1]"
 	description "Defeat a pirate raid on <destination>."
 	to offer
 		"combat rating" > 400
-		"random" < 35
+		"random" < 25
 	source "Allhome"
 	npc
 		government "Hai"
-		personality "heroic" staying"
+		personality heroic staying
 		fleet "Large Hai" 2
 		fleet "Large Militia"
 	npc evade
 		government "Pirate"
-		personality "heroic" "staying"
+		personality coward waiting
 		fleet "Large Northern Pirates" 10
 	on offer
 		conversation
@@ -1096,7 +1096,7 @@ mission "Enlisted by Hai [1]"
 
 mission "Enlisted by Hai [2]"
 	name "Enlist with the Hai"
-	description "You have been recommended for your attentiveness for keeping the peace throughout Hai space. Hai officials would like to consult you about possible enlistment."
+	description "You have been recommended following your demonstration of peacekeeping. Hai officials would like to consult you about possible enlistment."
 	priority
 	to offer
 		has "Enlisted by Hai [1]: done"
@@ -1109,11 +1109,11 @@ mission "Enlisted by Hai [2]"
 	destination "Hai-home"
 	on offer
 		conversation
-			`As soon as you depart your ship you discover an envoy of sorts awaiting you. "Few human visitors demonstrate care for the lasting peace we have established so long ago," the Hai begins hastily. "You are a prominent example of your kind, and we request audience on <destination>. The unfettered humans have revealed a tentativeness to prey on those who follow a path unlike their own."`
+			`As soon as you depart your ship you discover an envoy of sorts awaiting you. "Not all human visitors demonstrate care for the lasting peace we have established so long ago," the Hai begins hastily. "You are a prominent example of your kind, and we request audience on <destination>. The unfettered humans have revealed a tentativeness to prey on those who follow a path unlike their own."`
 			choice
 				`	"I suppose I can hear you out."`
 				`	"I would prefer to not get caught up in any trouble."`
-					defer
+					decline
 			`	"That is most pleasing," it says. "the consuls will be notified of this news and will be expecting attendance."`
 				accept
 
@@ -1124,11 +1124,11 @@ mission "Enlisted by Hai [3]"
 	to offer
 		has "Enlisted by Hai [2]: offered"
 	source "Hai-home"
-	npc "kill"
+	npc kill
 		government "Pirate"
 		dialog
 			`You have eliminated the pirate leader's ships. Hopefully this sends a warning to any other pirate warlords who meddles in the affairs of the Hai.`
-		personality "disables" "heroic" "nemesis" "plunders" "staying" "target"
+		personality disables heroic nemesis plunders staying target
 		system "Oblate"
 		ship "Falcon (Heavy)" "Gash"
 		ship "Splinter (Laser)" "Gnar"

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -1067,19 +1067,10 @@ mission "Hai Honeymoon"
 mission "Enlisted by Hai [1]"
 	name "Defend <planet>"
 	description "Defeat a pirate raid on <destination>."
+	source "Allhome"
 	to offer
 		"combat rating" > 400
 		"random" < 25
-	source "Allhome"
-	npc
-		government "Hai"
-		personality heroic staying
-		fleet "Large Hai" 2
-		fleet "Large Militia"
-	npc evade
-		government "Pirate"
-		personality coward waiting
-		fleet "Large Northern Pirates" 10
 	on offer
 		conversation
 			`Suddenly you notice a massive rush in the spaceport: "We are under attack! <planet> is under attack by the unfettered humans! We need every combat-worthy ship to join in the defenses!" The authorities will probably be very gracious, but this could also be an easy way to get yourself killed.`
@@ -1089,24 +1080,28 @@ mission "Enlisted by Hai [1]"
 					defer
 			`A mix of Hai and Human pilots have amassed to help repel the unfettered attack. You join them, and take off together...`
 				launch
+	npc
+		government "Hai"
+		personality heroic staying
+		fleet "Large Hai" 2
+		fleet "Large Militia"
+	npc evade
+		government "Pirate"
+		personality coward waiting
+		fleet "Large Northern Pirates" 10
 	on complete
-		dialog
-			`The government of <planet> pays you <payment> for helping to drive off the attack.`
 		payment 280000
+		dialog `The government of <planet> pays you <payment> for helping to drive off the attack.`
 
 mission "Enlisted by Hai [2]"
+	priority
 	name "Enlist with the Hai"
 	description "You have been recommended following your demonstration of peacekeeping. Hai officials would like to consult you about possible enlistment."
-	priority
-	to offer
-		has "Enlisted by Hai [1]: done"
-	to complete
-		never
-	to fail
-		has "enlisted"
 	source
 		government "Hai"
 	destination "Hai-home"
+	to offer
+		has "Enlisted by Hai [1]: done"
 	on offer
 		conversation
 			`As soon as you depart your ship you discover an envoy of sorts awaiting you. "Not all human visitors demonstrate care for the lasting peace we have established so long ago," the Hai begins hastily. "You are a prominent example of your kind, and we request audience on <destination>. The unfettered humans have revealed a tentativeness to prey on those who follow a path unlike their own."`
@@ -1116,23 +1111,20 @@ mission "Enlisted by Hai [2]"
 					decline
 			`	"That is most pleasing," it says. "the consuls will be notified of this news and will be expecting attendance."`
 				accept
+	to complete
+		never
+	to fail
+		has "enlisted"
 
 mission "Enlisted by Hai [3]"
+	landing
 	name "Hai Bounty"
 	description "Eliminate the coordinator of the attacks on Hai space."
-	landing
+	source "Hai-home"
 	to offer
 		has "Enlisted by Hai [2]: offered"
-	source "Hai-home"
-	npc kill
-		government "Pirate"
-		dialog
-			`You have eliminated the pirate leader's ships. Hopefully this sends a warning to any other pirate warlords who meddles in the affairs of the Hai.`
-		personality disables heroic nemesis plunders staying target
-		system "Oblate"
-		ship "Falcon (Heavy)" "Gash"
-		ship "Splinter (Laser)" "Gnar"
 	on offer
+		set "enlisted"
 		conversation 
 			`Stepping off onto the landing pads you are again greeted by a Hai envoy. "We are glad you could be present for this appointment with the elders," it says, "please follow me."`
 			choice
@@ -1145,9 +1137,15 @@ mission "Enlisted by Hai [3]"
 			`	Being lead through a series of hallways and around several bends, you have trouble visualizing the exact way you and the Hai arrived here. Stopping at a large doorway you are told that beyond this door is the chamber of the elders.`
 			`	Entering the chamber you are greeted with a larger audience than you were expecting. "We have heard of your efforts defending the planet of Allhome and we are honored," says a rather elderly Hai, "but as we have business to discuss I will skip the formalities." Saying somewhat resigned, as though discussing hostilities causes them great distress, "Recently we have learned of the source of these attacks, joint warlords that go by Gnar and Gash, they control the unfettered planet of Stormhold," now with even more resignation in its' voice, "Usually we deal with our situations internally, however human space is outside of our jurisdiction, and I'm afraid several of our largest warships would stir up quite a panic. We regret to send you alone to deal with our matters given the risk, but we will compensate you greatly for your efforts."`
 				accept
-		set "enlisted"
+	npc kill
+		government "Pirate"
+		personality disables heroic nemesis plunders staying target
+		system "Oblate"
+		ship "Falcon (Heavy)" "Gash"
+		ship "Splinter (Laser)" "Gnar"
+		dialog `You have eliminated the pirate leader's ships. Hopefully this sends a warning to any other pirate warlords who meddles in the affairs of the Hai.`
 	on complete
-		conversation
-			`	"We already see the fruits of your labor, the attacks are slowing" the elderly Hai again says, "We thank you for your assistance, we may call on you again should we require your assistance."`
 		payment "2800000"
 		set "license: Hai Trust"
+		conversation
+			`"We already see the fruits of your labor, the attacks are slowing" the elderly Hai again says, "We thank you for your assistance, we may call on you again should we require your assistance."`

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -1061,3 +1061,93 @@ mission "Hai Honeymoon"
 	on complete
 		payment 100000
 		dialog `Instead of landing in the spaceport where they can be seen, you drop Anaya and Touhar off as close as you can to where they will be staying. The house is a few kilometers away, but they assure you that they can make it on their own. They pay you <payment> and thank you for bringing them this far.`
+
+
+
+mission "Enlisted by Hai [1]"
+	name "Defend <planet>"
+	description "Defeat a pirate raid on <destination>."
+	to offer
+		"combat rating" > 400
+		"random" < 35
+	source "Allhome"
+	npc
+		government "Hai"
+		personality "heroic" staying"
+		fleet "Large Hai" 2
+		fleet "Large Militia"
+	npc evade
+		government "Pirate"
+		personality "heroic" "staying"
+		fleet "Large Northern Pirates" 10
+	on offer
+		conversation
+			`Suddenly you notice a massive rush in the spaceport: "We are under attack! <planet> is under attack by the unfettered humans! We need every combat-worthy ship to join in the defenses!" The authorities will probably be very gracious, but this could also be an easy way to get yourself killed.`
+			choice
+				`	(Join the defense fleet.)`
+				`	(Stay here until the fight is over.)`
+					defer
+			`A mix of Hai and Human pilots have amassed to help repel the unfettered attack. You join them, and take off together...`
+				launch
+	on complete
+		dialog
+			`The government of <planet> pays you <payment> for helping to drive off the attack.`
+		payment 280000
+
+mission "Enlisted by Hai [2]"
+	name "Enlist with the Hai"
+	description "You have been recommended for your attentiveness for keeping the peace throughout Hai space. Hai officials would like to consult you about possible enlistment."
+	priority
+	to offer
+		has "Enlisted by Hai [1]: done"
+	to complete
+		never
+	to fail
+		has "enlisted"
+	source
+		government "Hai"
+	destination "Hai-home"
+	on offer
+		conversation
+			`As soon as you depart your ship you discover an envoy of sorts awaiting you. "Few human visitors demonstrate care for the lasting peace we have established so long ago," the Hai begins hastily. "You are a prominent example of your kind, and we request audience on <destination>. The unfettered humans have revealed a tentativeness to prey on those who follow a path unlike their own."`
+			choice
+				`	"I suppose I can hear you out."`
+				`	"I would prefer to not get caught up in any trouble."`
+					defer
+			`	"That is most pleasing," it says. "the consuls will be notified of this news and will be expecting attendance."`
+				accept
+
+mission "Enlisted by Hai [3]"
+	name "Hai Bounty"
+	description "Eliminate the coordinator of the attacks on Hai space."
+	landing
+	to offer
+		has "Enlisted by Hai [2]: offered"
+	source "Hai-home"
+	npc "kill"
+		government "Pirate"
+		dialog
+			`You have eliminated the pirate leader's ships. Hopefully this sends a warning to any other pirate warlords who meddles in the affairs of the Hai.`
+		personality "disables" "heroic" "nemesis" "plunders" "staying" "target"
+		system "Oblate"
+		ship "Falcon (Heavy)" "Gash"
+		ship "Splinter (Laser)" "Gnar"
+	on offer
+		conversation 
+			`Stepping off onto the landing pads you are again greeted by a Hai envoy. "We are glad you could be present for this appointment with the elders," it says, "please follow me."`
+			choice
+				`	(Follow.)`
+					goto continue
+				`	"Actually, I came to formally decline."`
+			`	"I see, well I'll inform my superiors of your decision. I do wish to see you again protecting our peaceful way of life."`
+				decline
+			label continue
+			`	Being lead through a series of hallways and around several bends, you have trouble visualizing the exact way you and the Hai arrived here. Stopping at a large doorway you are told that beyond this door is the chamber of the elders.`
+			`	Entering the chamber you are greeted with a larger audience than you were expecting. "We have heard of your efforts defending the planet of Allhome and we are honored," says a rather elderly Hai, "but as we have business to discuss I will skip the formalities." Saying somewhat resigned, as though discussing hostilities causes them great distress, "Recently we have learned of the source of these attacks, joint warlords that go by Gnar and Gash, they control the unfettered planet of Stormhold," now with even more resignation in its' voice, "Usually we deal with our situations internally, however human space is outside of our jurisdiction, and I'm afraid several of our largest warships would stir up quite a panic. We regret to send you alone to deal with our matters given the risk, but we will compensate you greatly for your efforts."`
+				accept
+		set "enlisted"
+	on complete
+		conversation
+			`	"We already see the fruits of your labor, the attacks are slowing" the elderly Hai again says, "We thank you for your assistance, we may call on you again should we require your assistance."`
+		payment "2800000"
+		set "license: Hai Trust"

--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -444,6 +444,8 @@ ship "Shield Beetle"
 	thumbnail "thumbnail/hai shield beetle"
 	attributes
 		category "Heavy Warship"
+		licenses
+			"Hai Trust"
 		"cost" 17900000
 		"shields" 32000
 		"hull" 9800


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**
1 Hai planetary defense mission
2 follow-up missions on dealing with the pirate threat

## Summary
This PR addresses the blatant issue of the Shield Beetle, an immensely strong early/mid-game heavy warship, being available so early and so easily to players. The changes address the issue by locking the Shield Beetle behind a license and creating a short mission string that leads the player to being provided with the license, thus allowing the player to purchase the ship.
![image](https://user-images.githubusercontent.com/32188044/68271250-e20cfc00-00af-11ea-8ea8-210a5613130c.png)


## Plugin File
This plugin file can be used to play through the new mission content:
[Hai Enlisted Missions.zip](https://github.com/endless-sky/endless-sky/files/3812723/Hai.Enlisted.Missions.zip)


## PR Checklist
 - [x] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
#### Irrelevant:
 - ~~[ ] I uploaded the necessary image, blend, and texture assets here:~~
 - ~~[ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets:~~