### PR TITLE
Made Hai-home unbribeable and increased the required reputation

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -93,7 +93,6 @@ government "Hai"
 		"Hai (Unfettered)" -.1
 		"Merchant" .01
 	"bribe" .02
-	"fine" 0
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"
 	"hostile hail" "hostile hai"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -90,7 +90,7 @@ government "Hai"
 	
 	"player reputation" 0
 	"attitude toward"
-		"Hai (Unfettered)" -.5
+		"Hai (Unfettered)" -.1
 		"Merchant" .01
 	"bribe" .02
 	"fine" 0

--- a/data/map.txt
+++ b/data/map.txt
@@ -25171,7 +25171,8 @@ planet Hai-home
 	spaceport `The spaceport in the capital city of Haimat is massive, with towers well over a kilometer high and hangars large enough to park an entire fleet of capital ships in. Although the port is bustling, with ships taking off and landing almost every minute, nearly three quarters of the landing pads and hangars are empty, and whole sections of the spaceport appear to be unused. Clearly, this port was designed to handle far more traffic than this.`
 	shipyard "Hai Advanced"
 	outfitter "Hai Advanced"
-	"required reputation" 10
+	"required reputation" 100
+	bribe 0
 
 planet "Hammer of Debrugt"
 	attributes arach mining shipping urban

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -106,7 +106,7 @@ mission "Wanderers: Hai Diplomat"
 			`	You manage to contact the local governor's office, but when you speak with the governor he says, "First contact? Human, this is not a task for just any Hai. You must go to our home world, where an official ambassador can join you. I will contact them and tell them to expect you."`
 				accept
 	on accept
-		"reputation: Hai" >?= 20
+		"reputation: Hai" >?= 50
 
 
 
@@ -758,6 +758,7 @@ mission "Wanderers: Alpha Surveillance A"
 	autosave
 	source "Vara K'chrai"
 	destination "Hai-home"
+	clearance
 	to offer
 		has "Wanderers: Jump Drive Source: done"
 	

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -106,7 +106,8 @@ mission "Wanderers: Hai Diplomat"
 			`	You manage to contact the local governor's office, but when you speak with the governor he says, "First contact? Human, this is not a task for just any Hai. You must go to our home world, where an official ambassador can join you. I will contact them and tell them to expect you."`
 				accept
 	on accept
-		"reputation: Hai" >?= 50
+		"reputation: Hai" >?= 20
+		"reputation: Hai" += 30
 
 
 


### PR DESCRIPTION
**Content**
## Background
Ref: #4646
Now that the Bactrian has been locked behind a license, there's been some discussion of whether the Shield Beetle should be license locked, since it is now the most powerful non-license locked heavy warship. This is actually a question I've been contemplating since as far back as [late February 2018](https://trello.com/c/Ayg35ZeX/71-shield-beetle-unlock#action-5a94fa4f85224b44022f657f). 
Part of my rationale for locking the Bactrian behind a license was that the next best heavy warships below it are the Falcon and Leviathan, which are both rather weak in comparison, while all similar ships (Cruiser, Carrier, Dreadnought, Kestrel), require a license (or some story) to obtain. The same thing is now true for the Shield Beetle; all comparable ships (Bactrian, Cruiser, Carrier, Dreadnought, Solifuge, Albatross, Kestrel) are currently locked behind some requirement. 

## Summary
The only requirement for obtaining the Shield Beetle is currently discovering the Hai and paying a small bribe to land on Hai-home if you haven't already reached the required reputation to land. This change makes it so that Hai-home can now no longer be bribed, and the player must gain a larger reputation to land on Hai-home, while the reputation gained for disabling/killing/capturing Unfettered has been reduced. The Shield Beetle and Geocoris are both unique to Hai-home, so both these ships now effectively have a reputation barrier to purchase.

The player can still gain clearance to Hai-home through various missions, meaning the Shield Beetle and Geocoris can be purchased with a lower than usual reputation. Given that the player typically only has clearance to Hai-home during the Wanderer campaign, at which point the player would want a Shield Beetle, I believe this to be fine. I've changed an instance in Wanderer start where the player's reputation with the Hai is increased to 20 to have it be increased to 50, meaning that doing the very start of the Wanderer campaign not only gives the player one-time clearance to Hai-home for a chance to purchase the Shield Beetle, but it also gets them half way to having the reputation to purchase a Shield Beetle if they aren't already that far.

Edit: Spaceport news in Hai space seems to suggest that the Hai don't take kindly to H2H weapons, so it would be expected that they really don't like nerve gas, so there's little reason why the Hai wouldn't also fine you for nerve gas. Removed `"fine" 0` from the Hai government so that Hai planets will now fine you for illegal outfits and cargo. All Hai planets still have the default security of 25%.

## Why this and not that?
I think that having the Shield Beetle (and Geocoris) be effectively locked by a reputation barrier is more interesting than a simple license lock that's unlocked by doing some missions. For starters, this would be a novel way to lock a ship, as all other locked ships are locked behind missions and/or licenses. It seems to me that it would be rather repetitive to have yet another ship locked by yet another license. This approach also allows the player more flexibility to obtaining a Shield Beetle; do I actively hunt down Unfettered to increase my reputation, or do I just sit around and assist Hai ships when I can (which will now comparatively be more helpful than attacking Unfettered)? Or do I go do some missions to increase my reputation, such as starting the Wanderer campaign? (The missions from #4646 could easily be repurposed to simply give the player a decent reputation boost (say 10 to 20) instead of outright unlocking the Shield Beetle.) Or maybe I just get clearance from a single mission and buy one Shield Beetle then leave.