### PR TITLE
Teach AI ships to afterburner during CircleAround

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1829,6 +1829,10 @@ void AI::CircleAround(Ship &ship, Command &command, const Ship &target)
 	command.SetTurn(TurnToward(ship, direction));
 	if(ship.Facing().Unit().Dot(direction) >= 0. && direction.Length() > 200.)
 		command |= Command::FORWARD;
+
+	// Use an equipped afterburner if possible
+	if (command.Has(Command::FORWARD) && direction.Length() > 600 && ShouldUseAfterburner(ship))
+		command |= Command::AFTERBURNER;
 }
 
 


### PR DESCRIPTION
## Feature Details

I've noticed that escorts use their afterburners when attacking, but not
when escaping from danger.

This commit adds an afterburner condition to the `AI::CircleAround`
routine. As a reminder, `AI::CircleAround` is used in these scenarios:

- An escort has been told to gather around the flagship
- An AI ship has reason to pursue a particular target (eg. cargo scan)

In these situations, the ship will use its afterburner (if it has one)
to approach its target more quickly. To prevent wasteful usage, the ship
will only fire its afterburner if its target is further away than 600.

## UI Screenshots

<img width="832" alt="image" src="https://user-images.githubusercontent.com/468136/68536765-dd508c80-03bc-11ea-9c2e-4bb2cf9b790c.png">


## Usage Examples

- Afterburners can now help escorts escape from dangerous situations
- Government ships can now use afterburners to pursue ships for scanning
