### PR TITLE
Boosting the Strong Wind

### DIFF
--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -213,7 +213,7 @@ ship "Strong Wind"
 		"heat dissipation" .7
 		"fuel capacity" 600
 		"cargo space" 68
-		"outfit space" 496
+		"outfit space" 493
 		"weapon capacity" 198
 		"engine capacity" 114
 		"asteroid scan power" 100
@@ -227,8 +227,8 @@ ship "Strong Wind"
 	outfits
 		"Sunbeam" 4
 		"Thunderhead Launcher" 2
-		"Thunderhead Missile" 120
-		"Thunderhead Storage Array" 2
+		"Thunderhead Missile" 100
+		"Thunderhead Storage Array"
 		
 		"White Sun Reactor"
 		"Dark Storm Shielding"

--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -216,6 +216,9 @@ ship "Strong Wind"
 		"outfit space" 493
 		"weapon capacity" 198
 		"engine capacity" 114
+		"asteroid scan power" 100
+		"atmosphere scan" 100
+		"tactical scan power" 25
 		weapon
 			"blast radius" 200
 			"shield damage" 2000

--- a/data/wanderer ships.txt
+++ b/data/wanderer ships.txt
@@ -211,9 +211,9 @@ ship "Strong Wind"
 		"mass" 260
 		"drag" 4.7
 		"heat dissipation" .7
-		"fuel capacity" 400
+		"fuel capacity" 600
 		"cargo space" 68
-		"outfit space" 493
+		"outfit space" 496
 		"weapon capacity" 198
 		"engine capacity" 114
 		"asteroid scan power" 100
@@ -232,7 +232,7 @@ ship "Strong Wind"
 		
 		"White Sun Reactor"
 		"Dark Storm Shielding"
-		"Wanderer Ramscoop"
+		"Wanderer Ramscoop" 2
 		
 		"Type 3 Radiant Thruster"
 		"Type 4 Radiant Steering"


### PR DESCRIPTION
The Strong Wind is described as a science vessel that has been retrofitted for combat. Given the Wanderer's focus on terraforming activities, it makes sense to me that their science vessel would have very powerful sensors related to that.

This PR adds the following to the Strong Wind:
- "asteroid scan power" 100
- "atmosphere scan" 100
- "tactical scan power" 20

This could result in the Strong Wind being an interesting candidate for a late-game mining ship for players so inclined. This change shouldn't have much impact on combat, but will help the Strong Wind feel a bit more unique than "just another warship."

