### PR TITLE
FW campaign changes

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -1594,6 +1594,16 @@ event "fw tarazed joins"
 
 
 
+event "fw tarazed republic"
+	system "Tarazed"
+		government "Republic"
+	system "Dabih"
+		government "Republic"
+	system "Albireo"
+		government "Republic"
+
+
+
 event "deep sky tech available"
 	outfitter "Deep Sky Basics"
 		"Catalytic Ramscoop"
@@ -2291,12 +2301,6 @@ event "fwc capture kaus borealis"
 		fleet "Small Free Worlds" 400
 		fleet "Large Free Worlds" 400
 		fleet "Large Republic" 2000
-	system "Tarazed"
-		government "Republic"
-	system "Dabih"
-		government "Republic"
-	system "Albireo"
-		government "Republic"
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -1510,8 +1510,8 @@ event "fw at war with Syndicate"
 	government Syndicate
 		"attitude toward"
 			"Free Worlds" -.3
-			"Pirate" -.4
-			"Korath" -.5
+			"Pirate" -.01
+			"Korath" -.01
 		bribe 0
 	system Rutilicus
 		fleet "Small Southern Merchants" 600
@@ -1888,6 +1888,8 @@ event "fw syndicate welcoming"
 			"Free Worlds" 0
 			"Republic" 0
 			"Navy (Oathkeeper)" 0
+			"Pirate" -.4
+			"Korath" -.5
 		bribe .08
 	system "Algenib"
 		government "Syndicate (Extremist)"

--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -1455,7 +1455,7 @@ mission "FWC Pug 3A"
 			label introductions
 			`	Standing next to Danforth is someone you think might be his bodyguard: a dark-skinned woman dressed entirely in black. Even the whites of her eyes are black: when she gets closer, you can see that it is actually a scleric tattoo, an intricate Celtic knotwork pattern inked into the whites of her eyes. Surprisingly, Katya recognizes her. "Raven!" says Katya. You aren't sure if Katya sounds happy to see her, or scared.`
 			`	"Hello Councilor," says the woman.`
-			`	Danforth says, "We hear you have come from the disconnected territory, and that you bring word of a potential alien invasion. Come with us, please." He ushers you into one of the Navy cruisers that are parked nearby, and into a room you assume is his private office; the guards check you and Katya for weapons and then leave you alone with Danforth and Raven. "Now," says Danforth, "you will answer our questions."`
+			`	Danforth says, "We hear you have come from the disconnected territory, and that you bring word of a potential alien invasion. Come with us, please." He ushers you into one of the Navy Cruisers that are parked nearby, and into a room you assume is his private office; the guards check you and Katya for weapons and then leave you alone with Danforth and Raven. "Now," says Danforth, "you will answer our questions."`
 			`	He gestures to Raven, who walks up to you and holds out her hands. "Take my hands, please, Captain," she says.`
 			choice
 				`	(Take her hands.)`
@@ -2033,7 +2033,7 @@ mission "FWC Pug 5"
 			choice
 				`	"That does sound like a good strategic choice."`
 				`	"How will your fleet get to Vega without traveling through the Pug home system? That system is swarming with their ships."`
-			`	Danforth says, "During the battle, we managed to salvage jump drives from a few of the Pug ships. We've installed them in three of our carriers. Hopefully, with your help, that will be enough to overcome any resistance in the Vega system. Then Miss Winters can work her magic with the hyperlinks again, and we'll be able to bring a massive reinforcement fleet from Sol."`
+			`	Danforth says, "During the battle, we managed to salvage jump drives from a few of the Pug ships. We've installed them in three of our Carriers. Hopefully, with your help, that will be enough to overcome any resistance in the Vega system. Then Miss Winters can work her magic with the hyperlinks again, and we'll be able to bring a massive reinforcement fleet from Sol."`
 			`	"Sounds good to me," says Freya. "I wish more of our own ships had jump drives, so we could assist you."`
 			`	"Indeed," says Danforth. "That's why it's so important for Captain <last>'s ship to be part of this battle. When it's all over, I want to be able to tell Parliament that this war was won by the Free Worlds and the Navy fighting side by side every step of the way. And I hope you will be able to tell your Senate the same thing, so that they will be more amenable to a compromise between us."`
 			choice

--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -1158,12 +1158,12 @@ mission "FWC Pug 2"
 	on offer
 		log "Found out that the aliens who attacked the Wolf Pack fleet call themselves the Pug. After destroying that fleet, the aliens have not attacked anyone else except a few merchants who tried to resist them. They came from a nearby star system that did not previously have any hyperspace connections to human space, and seem intent on controlling and perhaps enslaving the local human population."
 		conversation
-			`When you land at the spaceport on <origin>, you find no evidence of violent struggle; merchant captains are walking around freely, haggling for commodities, and conversing with each other just like in any other spaceport you have visited. However, the spaceport is also being patrolled by small groups of slender, bipedal, pale-skinned aliens who you assume are the Pug. Each one is holding a metal staff that looks like some sort of weapon, but none of them move to attack you.`
-			`	Soon after you land, you spot a man making his way towards your ship, ducking behind other ships and crates every time a group of Pug look in his direction. If he is some sort of fugitive from them, it might be unwise to throw your lot in with him. On the other hand, he could have valuable information for you.`
+			`When you land at the spaceport on <origin>, you find no evidence of violent struggle; merchant captains are walking around freely, haggling for commodities, and conversing with each other just like in any other spaceport you have visited. However, the spaceport is also being patrolled by small groups of slender, bipedal, pale-skinned aliens. Each one is holding a metal staff that looks like some sort of weapon, but none of them move to attack you.`
+			`	Soon after you land, you spot a man making his way towards your ship, ducking behind other ships and crates every time a group of aliens looks in his direction. If he is some sort of fugitive from them, it might be unwise to throw your lot in with him. On the other hand, he could have valuable information for you.`
 			choice
 				`	(Stay around and talk to him.)`
 					goto board
-				`	(Take off before I draw the Pug's attention.)`
+				`	(Take off before I draw the aliens' attention.)`
 			
 			`	You start to get ready to take off, but he gestures urgently to you. Reluctantly, you decide to wait and hear what he has to say.`
 			label board

--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -236,6 +236,7 @@ mission "FWC Cebalrai 1B"
 	
 	on offer
 		event "fwc attack cebalrai"
+		event "fw tarazed republic"
 		conversation
 			`You meet up with Tomek and Alondo and tell them that the defenses in the Cebalrai system did not seem particularly strong. "They must've seen the writing on the wall and pulled back the rest of their fleet," says Alondo.`
 			`	"Either that," says Tomek, "or they're wary of engaging us again now that they know we're willing to use nukes. Which I'm still not happy about, by the way. It's only a matter of time until they respond in kind. But in any case, our next move is clear: bring a fleet to Cebalrai and capture the system. <first>, you'll be in charge of that fleet. Alondo can travel with you to handle the diplomatic aftermath."`

--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -2368,6 +2368,7 @@ mission "FWC End"
 		event "syndicate tech available"
 		set "main plot completed"
 		set "free worlds plot completed"
+		set "free worlds checkmate"
 		conversation
 			`You arrive in the Parliament building just as Alondo and Katya have finished meeting with them. "Good news," says Katya. "We're all officially pardoned. And you, Captain <last>, have become something of a hero."`
 			`	"Better yet," says Alondo, "the war with the Republic is over. We agreed to limiting our territory to its current size, and to a very minor tax to cover the cost of Navy protection if the aliens attack again or some other major catastrophe strikes. In return, the Free Worlds have been granted autonomy from the Republic."`

--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -2369,6 +2369,7 @@ mission "FWC End"
 		set "main plot completed"
 		set "free worlds plot completed"
 		set "free worlds checkmate"
+		event "stack core for sale"
 		conversation
 			`You arrive in the Parliament building just as Alondo and Katya have finished meeting with them. "Good news," says Katya. "We're all officially pardoned. And you, Captain <last>, have become something of a hero."`
 			`	"Better yet," says Alondo, "the war with the Republic is over. We agreed to limiting our territory to its current size, and to a very minor tax to cover the cost of Navy protection if the aliens attack again or some other major catastrophe strikes. In return, the Free Worlds have been granted autonomy from the Republic."`

--- a/data/free worlds epilogue.txt
+++ b/data/free worlds epilogue.txt
@@ -148,7 +148,6 @@ mission "FW Epilogue: Danforth"
 	landing
 	source "Farpoint"
 	to offer
-		has "free worlds reconciliation"
 		not "Wanderers: Alpha Surveillance E: offered"
 	
 	on offer
@@ -159,7 +158,13 @@ mission "FW Epilogue: Danforth"
 				`	(Not right now.)`
 					defer
 			
+			branch checkmate1
+				has "free worlds checkmate"
 			`	Danforth is quite excited to see you. "Captain <last>!" he says. "So good to see you back up here in my neck of the woods again. It's funny, you'd think that with the war over they'd just dissolve the Oathkeepers, since the whole Republic is at peace with the Free Worlds and there's no longer any oath left for us to keep. But, the Oathkeepers became so well known for our role against the Pug and the Syndicate that now everyone wants to join our division."`
+				goto choice
+			label checkmate1
+			`	Danforth is quite excited to see you. "Captain <last>!" he says. "So good to see you back up here in my neck of the woods again. It's funny, you'd think that with the war over they'd just dissolve the Oathkeepers, since the whole Republic is at peace with the Free Worlds and there's no longer any oath left for us to keep. But, the Oathkeepers became so well known for our role against the Pug and the terrorists that now everyone wants to join our division."`
+			label choice
 			choice
 				`	"Glad to see you're still in the thick of things, sir!"`
 					goto thick
@@ -177,6 +182,12 @@ mission "FW Epilogue: Danforth"
 			label end
 			`	"Are the pirates giving you any trouble?" you ask.`
 			`	"A bit," he says. "We still have far too many pirates in this sector, in part due to the Free Worlds driving them out of the south. The pirates grew stronger and more bold as the war dragged on, when all our fleets were busy elsewhere, but now we're beginning to get them under control again."`
+			choice checkmate2
+				has "free worlds checkmate"
 			`	Then he leans forward and says, more quietly, "Of course, you and I both know the pirates aren't the main threat. Raven is off infiltrating Syndicate worlds even as we speak, and several of my other best intelligence officers, too. The Syndicate wants us to believe that they've weeded out all the rotten apples from their ranks, but we're keeping an eye on them, all the same."`
+				goto end
+			label checkmate2
+			`	Then he leans forward and says, more quietly, "Just a heads up that the Navy has their eye on the Free Worlds still. Just because a peace treaty was made doesn't mean you can keep your nukes forever. We destroyed all the means of making nukes for the terrorists on Buccaneer Bay for a reason."`
+			label end
 			`	After you talk for a while longer, Danforth wishes you luck and sends you on your way. "I'll be in touch if we ever need your assistance in the future," he says.`
 				decline

--- a/data/free worlds epilogue.txt
+++ b/data/free worlds epilogue.txt
@@ -183,7 +183,7 @@ mission "FW Epilogue: Danforth"
 			label end
 			`	"Are the pirates giving you any trouble?" you ask.`
 			`	"A bit," he says. "We still have far too many pirates in this sector, in part due to the Free Worlds driving them out of the south. The pirates grew stronger and more bold as the war dragged on, when all our fleets were busy elsewhere, but now we're beginning to get them under control again."`
-			choice checkmate2
+			branch checkmate2
 				has "free worlds checkmate"
 			`	Then he leans forward and says, more quietly, "Of course, you and I both know the pirates aren't the main threat. Raven is off infiltrating Syndicate worlds even as we speak, and several of my other best intelligence officers, too. The Syndicate wants us to believe that they've weeded out all the rotten apples from their ranks, but we're keeping an eye on them, all the same."`
 				goto end

--- a/data/free worlds epilogue.txt
+++ b/data/free worlds epilogue.txt
@@ -164,7 +164,7 @@ mission "FW Epilogue: Danforth"
 			`	Danforth is quite excited to see you. "Captain <last>!" he says. "So good to see you back up here in my neck of the woods again. It's funny, you'd think that with the war over they'd just dissolve the Oathkeepers, since the whole Republic is at peace with the Free Worlds and there's no longer any oath left for us to keep. But, the Oathkeepers became so well known for our role against the Pug and the Syndicate that now everyone wants to join our division."`
 				goto choice
 			label checkmate1
-			`	Danforth is quite excited to see you. "Captain <last>!" he says. "So good to see you back up here in my neck of the woods again. It's funny, you'd think that with the war over they'd just dissolve the Oathkeepers, since the whole Republic is at peace with the Free Worlds and there's no longer any oath left for us to keep. But, the Oathkeepers became so well known for our role against the Pug and the terrorists that now everyone wants to join our division."`
+			`	Danforth is quite excited to see you. "Captain <last>!" he says. "So good to see you back up here in my neck of the woods again. It's funny, you'd think that with the war over they'd just dissolve the Oathkeepers, since the whole Republic is at peace with the Free Worlds and there's no longer any oath left for us to keep. But, the Oathkeepers became so well known for our role against the Pug that now everyone wants to join our division."`
 			label choice
 			choice
 				`	"Glad to see you're still in the thick of things, sir!"`

--- a/data/free worlds epilogue.txt
+++ b/data/free worlds epilogue.txt
@@ -163,8 +163,10 @@ mission "FW Epilogue: Danforth"
 				has "free worlds checkmate"
 			`	Danforth is quite excited to see you. "Captain <last>!" he says. "So good to see you back up here in my neck of the woods again. It's funny, you'd think that with the war over they'd just dissolve the Oathkeepers, since the whole Republic is at peace with the Free Worlds and there's no longer any oath left for us to keep. But, the Oathkeepers became so well known for our role against the Pug and the Syndicate that now everyone wants to join our division."`
 				goto choice
+			
 			label checkmate1
 			`	Danforth is quite excited to see you. "Captain <last>!" he says. "So good to see you back up here in my neck of the woods again. It's funny, you'd think that with the war over they'd just dissolve the Oathkeepers, since the whole Republic is at peace with the Free Worlds and there's no longer any oath left for us to keep. But, the Oathkeepers became so well known for our role against the Pug that now everyone wants to join our division."`
+			
 			label choice
 			choice
 				`	"Glad to see you're still in the thick of things, sir!"`
@@ -174,21 +176,24 @@ mission "FW Epilogue: Danforth"
 			
 			label thick
 			`	"Oh, you bet I am," he says. "I'll never retire from the Navy, you know. I plan to still be serving on the day I die."`
-				goto end
+				goto next
 			
 			label work
 			`	"Just the sort of work we all signed up for in the first place," he says. "Defending the defenseless, keeping the peace, helping silly novice pilots who run out of fuel."`
-				goto end
+				goto next
 			
-			label end
+			label next
 			`	"Are the pirates giving you any trouble?" you ask.`
 			`	"A bit," he says. "We still have far too many pirates in this sector, in part due to the Free Worlds driving them out of the south. The pirates grew stronger and more bold as the war dragged on, when all our fleets were busy elsewhere, but now we're beginning to get them under control again."`
+			
 			branch checkmate2
 				has "free worlds checkmate"
 			`	Then he leans forward and says, more quietly, "Of course, you and I both know the pirates aren't the main threat. Raven is off infiltrating Syndicate worlds even as we speak, and several of my other best intelligence officers, too. The Syndicate wants us to believe that they've weeded out all the rotten apples from their ranks, but we're keeping an eye on them, all the same."`
 				goto end
+			
 			label checkmate2
 			`	Then he leans forward and says, more quietly, "Just a heads up that the Navy has their eye on the Free Worlds still. Just because a peace treaty was made doesn't mean you can keep your nukes forever. We destroyed all the means of making nukes for the terrorists on Buccaneer Bay for a reason."`
+			
 			label end
 			`	After you talk for a while longer, Danforth wishes you luck and sends you on your way. "I'll be in touch if we ever need your assistance in the future," he says.`
 				decline

--- a/data/free worlds epilogue.txt
+++ b/data/free worlds epilogue.txt
@@ -148,6 +148,7 @@ mission "FW Epilogue: Danforth"
 	landing
 	source "Farpoint"
 	to offer
+		has "free worlds plot completed"
 		not "Wanderers: Alpha Surveillance E: offered"
 	
 	on offer

--- a/data/free worlds epilogue.txt
+++ b/data/free worlds epilogue.txt
@@ -148,7 +148,7 @@ mission "FW Epilogue: Danforth"
 	landing
 	source "Farpoint"
 	to offer
-		has "free worlds plot completed"
+		has "free worlds reconciliation"
 		not "Wanderers: Alpha Surveillance E: offered"
 	
 	on offer

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -284,7 +284,7 @@ mission "FW Recon 0"
 
 mission "FW Recon 1"
 	name "Free Worlds Reconnaissance"
-	description "Perform an outfit scan on the cruiser <npc>, then report to a Free Worlds officer on <destination>."
+	description "Perform an outfit scan on the Cruiser <npc>, then report to a Free Worlds officer on <destination>."
 	source
 		planet "Glaze"
 	to offer
@@ -344,7 +344,7 @@ mission "FW Recon 1"
 
 mission "FW Recon 2"
 	name "Free Worlds Reconnaissance"
-	description "Scan any ships in the <waypoints> system that are equipped like the combat-ready cruiser you scanned previously, then return to <destination>."
+	description "Scan any ships in the <waypoints> system that are equipped like the combat-ready Cruiser you scanned previously, then return to <destination>."
 	source
 		planet "Glaze"
 	to offer
@@ -356,7 +356,7 @@ mission "FW Recon 2"
 	on offer
 		conversation
 			`You meet up with the militia officer in the spaceport bar. "Glad you showed up," he says, "I'm Jean-Jacques, by the way, but you can call me JJ."`
-			`	You introduce yourself in return, and he continues. "Here's the deal. I'm the commander of the militia on Glaze. So far, we and the Navy are not shooting at each other, because no one wants to fire the first shot. But if they're getting ready to change that, they'll start refitting their cruisers with heavy weaponry instead of surveillance equipment. So, I need to know how many more of their ships are equipped like the one you just scanned."`
+			`	You introduce yourself in return, and he continues. "Here's the deal. I'm the commander of the militia on Glaze. So far, we and the Navy are not shooting at each other, because no one wants to fire the first shot. But if they're getting ready to change that, they'll start refitting their Cruisers with heavy weaponry instead of surveillance equipment. So, I need to know how many more of their ships are equipped like the one you just scanned."`
 			`	He continues, "I'd like you to go to <waypoints>, where they're building some sort of secret base. Scan any ships you think match the one we just saw, then bring your scanner logs back here for me to look at."`
 			choice
 				`	"Sure, I'd be glad to do that."`
@@ -429,7 +429,7 @@ mission "FW Recon 3B"
 	
 	on offer
 		conversation
-			`You walk through the new section of the spaceport that the Navy is building, trying to look inconspicuous. When it seems that no one is watching, you snap a few photographs. You count seven hangars large enough to house a carrier, and workers are clearing and blasting level surfaces for many more. An entire new village of identical prefabricated houses has sprung up nearby. And every few minutes, a warship flies overhead with a roar that shakes the entire mountain. It is an intimidating sight.`
+			`You walk through the new section of the spaceport that the Navy is building, trying to look inconspicuous. When it seems that no one is watching, you snap a few photographs. You count seven hangars large enough to house a Carrier, and workers are clearing and blasting level surfaces for many more. An entire new village of identical prefabricated houses has sprung up nearby. And every few minutes, a warship flies overhead with a roar that shakes the entire mountain. It is an intimidating sight.`
 			`	As you are heading back to your ship after taking note of everything you think JJ would be interested in, two officers walk past you and you overhear one saying to the other, "Secret message from fleet command."`
 			`	You stop to tie your shoe and try to listen in. "What's the message?" asks the other.`
 			`	"I can't tell you here," says the first, and they duck behind one of the storage sheds.`
@@ -456,7 +456,7 @@ mission "FW Recon 3B"
 				"Gunboat"
 	
 	on visit
-		dialog `A minute after you land, a Republic gunboat, the <npc>, lands directly next to you. JJ does not approach you. You notice from your ship's logs that this gunboat has been following you ever since you left <origin>; before you can hand over the information, you will need to escape its pursuit.`
+		dialog `A minute after you land, a Republic Gunboat, the <npc>, lands directly next to you. JJ does not approach you. You notice from your ship's logs that this Gunboat has been following you ever since you left <origin>; before you can hand over the information, you will need to escape its pursuit.`
 	
 	on complete
 		"assisted free worlds" ++
@@ -834,7 +834,7 @@ mission "FW Katya 2C"
 
 mission "FW Katya 3"
 	name "Drone Hunting"
-	description `Disable a surveillance drone (ideally when no cruisers are watching), board it, "salvage" its surveillance equipment, and return to <destination>. (Until you leave the system where you disabled the drone, other Republic ships may attack you.)`
+	description `Disable a surveillance drone (ideally when no Cruisers are watching), board it, "salvage" its surveillance equipment, and return to <destination>. (Until you leave the system where you disabled the drone, other Republic ships may attack you.)`
 	source Rand
 	to offer
 		has "FW Katya 2C: done"
@@ -842,7 +842,7 @@ mission "FW Katya 3"
 		has "chosen sides"
 	on offer
 		conversation
-			`You find Eyes and Katya sitting in the shade of one of the few trees in the port, drinking some sort of frozen milkshakes while they stare out at the desert and talk in hushed voices. When you join them, Katya says, "I was just filling Eyes in on the Navy's recent fleet mobilization. Half the Dirt Belt is swarming with cruisers and surveillance drones right now. It's hard to believe that we can find the attackers before they do, unless they're somewhere the Navy hasn't thought to look."`
+			`You find Eyes and Katya sitting in the shade of one of the few trees in the port, drinking some sort of frozen milkshakes while they stare out at the desert and talk in hushed voices. When you join them, Katya says, "I was just filling Eyes in on the Navy's recent fleet mobilization. Half the Dirt Belt is swarming with Cruisers and surveillance drones right now. It's hard to believe that we can find the attackers before they do, unless they're somewhere the Navy hasn't thought to look."`
 			`	"Agreed," says Eyes, "and to make matters worse, their sensors are probably much better than mine."`
 			`	Katya appears to be struck by a sudden idea. "The sensors on their drones," she says, "their unmanned drones..."`
 			`	Eyes glances at her, sees her expression, and says, "No, Councilor, don't even think of it. That's a horrible idea."`

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -2072,6 +2072,7 @@ mission "FW Defend New Tibet"
 	on complete
 		"reputation: Republic" = 1
 		event "fw armistice"
+		event "fw tarazed republic"
 		event "end battle of alioth"
 		conversation
 			`It doesn't take long to find the monastery that contacted you earlier, but nothing is left of it but burnt-out shells of buildings. You land and look around for survivors. You find several corpses dressed in maroon robes, some of them badly burnt, but no sign of the defector or the monk you spoke with earlier.`

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -23,7 +23,14 @@ mission "FW Diplomacy 1"
 	on offer
 		conversation
 			`As you are landing, you receive a message from JJ, on behalf of the Council. The message reads:`
+			branch suspended
+				has "FW Pirates 4.1: offered"
 			`	Captain <last>, sorry that we have been out of contact. We need your help once again, to assist in a diplomatic mission. Please meet up with Alondo on <planet> as soon as possible. He will give you more information.`
+				goto end
+			
+			label suspended
+			`	Captain <last>. Your suspension from the Free Worlds has just ended. The Senate is still not happy with what you did, and has therefore not reinstated your pay, but they have allowed you to continue working for us. Don't cause any more issues and you'll regain your pay. Please meet up with Alondo on <planet> as soon as possible. He will give you more information.`
+			label end
 			`			Sincerely,`
 			`				Jean-Jacques and Freya`
 				accept
@@ -654,14 +661,23 @@ mission "FW Southern Break"
 	on offer
 		log "Once again there is no immediate work to be done for the Free Worlds. This would be a good time to earn some money for an upgraded ship, if possible."
 		event "fw occupying the north" 50
+		"salary: Free Worlds" >?= 800
 		conversation
 			`You land on Dancer and report to Alondo and Freya that the prisoner transfer is complete. "What do we do now?" you ask.`
 			`	Freya says, "Well, I hope we're done with fighting for a while, now. We'll stay here to hold this system against any Navy retaliation. And, we'll keep hoping that Parliament might come to their senses and agree to a diplomatic end to this conflict. In the meantime I suggest you spend some time doing whatever it is you do to earn money on the side - carrying passengers or freight or hunting pirates. We'll contact you when things begin to move forward again."`
 			choice
 				`	"Sounds good. I'll hope to hear from you soon."`
-					decline
+					goto salary
 				`	"You're sure there's nothing else I can do to help the Free Worlds right now?"`
-			`	Alondo says, "You might hear from some other folks who could use your assistance, but as for the Council, I think it's a waiting game for us right now. Please don't think we aren't grateful for your help, Captain. All we're saying is that hopefully, for a few months at least, we'll all be able to take a break from fighting and go back to actually living our lives. And don't worry, we'll contact you as soon as things get interesting again."`
+			`	Alondo says, "You might hear from some other folks who could use your assistance, but as for the Council, I think it's a waiting game for us right now. Please don't think we aren't grateful for your help, Captain. All we're saying is that hopefully, for a few months at least, we'll all be able to take a break from fighting and go back to actually living our lives."`
+			
+			label salary
+			branch end
+				not "FW Pirates 4.1: offered"
+			`	"Before you leave, Captain," Freya says. "The Senate has decided to reinstate your pay after these recent events. You should now have a salary of 800 credits, just like before."`
+			
+			label end
+			`	Alondo gives you a nod. "We'll contact you as soon as things get interesting again."`
 				decline
 
 

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -306,10 +306,17 @@ mission "FW Southern Battle 1B"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
+		event "flamethrower available" 10
 		conversation
 			`When you land on <origin>, a Southbound Shipyards executive leads you to a hangar. The hangar is huge, but it clearly was not meant to hold a ship as large as the one it now contains. There is barely enough space for the cranes and catwalks being used by the construction crews. He says, "The Dreadnought is a new design, the largest ship we've ever built. Only three of them have been completed so far." You can't help but be impressed at the size of the Dreadnought: as bulky as a Cruiser, it looks like a cross between a Bastion and an Argosy freighter.`
 			`	He then leads you out to a section of the spaceport where three Dreadnoughts are parked. Next to them, and looking tiny by comparison, are five Furies. You ask, "Are those Furies part of the battle fleet, too?"`
-			`	"Yes," he says, "equipped with some fancy new weapons from Barmy Edward up at Kraz Cybernetics. I haven't seen them in action yet, but he's convinced they'll be useful against the Navy."`
+			branch untested
+				not "FW Flamethrower 2: done"
+			`	"Yes," he says, "equipped with some fancy new weapons from Barmy Edward up at Kraz Cybernetics that he said you helped test. I haven't seen them in action yet, but he's convinced they'll be useful against the Navy."`
+				goto end
+			label untested
+			`	"Yes," he says, "equipped with some fancy new weapons from Barmy Edward up at Kraz Cybernetics that he recently finished working on. He said they should be entering mass production soon. Flamethrowers, the crazy bastard. I haven't seen them in action yet, but he's convinced they'll be useful against the Navy."`
+			label end
 			`	You thank him for his time, and meet up with the captains of the battle fleet, arranging for them to follow you back to Trinket.`
 				accept
 	

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1620,8 +1620,8 @@ mission "FW Albatross 1"
 	name "Freya to <planet>"
 	description "Bring Freya to <planet> to meet up with JJ and make plans for convincing Albatross to give up piracy and join the Free Worlds."
 	autosave
-	source Zug
-	destination Dancer
+	source "Zug"
+	destination "Dancer"
 	to offer
 		has "FW Dreadnoughts Ready: done"
 	passengers 1
@@ -1658,7 +1658,9 @@ mission "FW Albatross 1"
 			`	"Yes," she says. "Yes, it does. Now, let's go meet up with JJ."`
 				accept
 			label metoo
-			`	Freya raises an eyebrow. "I hadn't heard. We don't have time to find someone else for this mission, so try not to say that so loudly when you're on Albatross."`
+			apply
+				set "gay"
+			`	Freya raises an eyebrow. "I hadn't heard. We don't have time to find someone else for this mission, so you'll need to be the one to transport JJ. Stay safe."`
 				accept
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
@@ -1700,8 +1702,8 @@ mission "FW Albatross 2A"
 	name "Hunt Ryk Bartlett"
 	description "Hunt down the pirate warlord Ryk Bartlett, who has been plundering merchant convoys in the vicinity of Zeta Aquilae. (Only his personal ship, the Dread, must be destroyed.) Then, return to Albatross."
 	autosave
-	source Albatross
-	destination Albatross
+	source "Albatross"
+	destination "Albatross"
 	clearance
 	to offer
 		has "FW Albatross 2: done"
@@ -1711,6 +1713,16 @@ mission "FW Albatross 2A"
 	
 	on offer
 		conversation
+			branch meeting
+				not "gay"
+			apply
+				clear "gay"
+			`JJ puts a hand on your shoulder before leaving the ship. "Freya let me know. For safety reasons only, of course. You can stay here if you aren't comfortable."`
+			choice
+				`	"No, I'll come with you."`
+				`	"Thank you. I'll stay."`
+					goto alt
+			label meeting
 			`Your meeting with the elders of Albatross happens in secret, by night. They are afraid that if their current pirate overlord, Ryk Bartlett, finds out that they have met with you, they will face retribution. JJ begins by describing the Free Worlds' offer: all the benefits of the mutual defense pact, in exchange for an agreement to uphold human rights and the rule of law, plus offering financial support for the Free Worlds.`
 			`	"Begging your pardon," says one of the elders, "but what makes you different from any pirate organization that comes in here, demanding our money in return for 'protection'?"`
 			choice
@@ -1725,6 +1737,11 @@ mission "FW Albatross 2A"
 			`	The elder who spoke seems unconvinced. "Seems to me that you 'Council' folks are the real rulers, and your 'Senate' is a figurehead," he says. "So I don't call that true democracy."`
 			`	"Maybe," says another of the elders, "but they're still better than Bartlett. I say, if the Free Worlds can free us from him, we'll at least give their new government a try." A few of the others nod in agreement.`
 			`	They explain that to the best of their knowledge, Bartlett is spending most of his time near the Zeta Aquilae system, plundering merchant convoys of heavy metals coming out of Rand and Oblivion. If you can destroy Bartlett and his flagship, the Dread, his followers will probably disperse.`
+				accept
+			label alt
+			`	The meeting with the elders of Albatross happens in secret, by night. They are afraid that if their current pirate overlord, Ryk Bartlett, finds out that they have met with you, they will face retribution. You wait in your ship while JJ attempts to convince the elders that they should join the Free Worlds. After some hours, JJ returns.`
+			`	"They're interested," JJ says to you, "but they want the current warlord dead."`
+			`	They explained that to the best of their knowledge, Bartlett is spending most of his time near the Zeta Aquilae system, plundering merchant convoys of heavy metals coming out of Rand and Oblivion. If you can destroy Bartlett and his flagship, the Dread, his followers will probably disperse.`
 				accept
 	on visit
 		dialog phrase "generic bounty hunting on visit"

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -192,7 +192,7 @@ mission "FW Southern Recon 1"
 mission "FW Southern Recon 1B"
 	landing
 	name "Electron Beam"
-	description "Steal an Electron Beam from a Navy gunboat and return it to <planet> for Freya to look at. She thought your best bet for finding lone gunboats might be the Wei or Alnasl systems."
+	description "Steal an Electron Beam from a Navy Gunboat and return it to <planet> for Freya to look at. She thought your best bet for finding lone Gunboats might be the Wei or Alnasl systems."
 	autosave
 	source "Trinket"
 	destination "Trinket"
@@ -211,9 +211,9 @@ mission "FW Southern Recon 1B"
 			`	"Well," she says, "the plasma turrets weren't the only ace up our sleeve, but still, it's frustrating that the Navy still has such an advantage over us technologically."`
 			`	"What should we do?" you ask.`
 			label attack
-			`	"We're going to have to fight them eventually, but first we need as much information as we can get on their new weapon systems. I'd like you to find one of their gunboats that has the new electron beams installed, steal one of them, and bring it back here. I imagine one of them can't be much bigger than twenty or thirty tons, so you ought to be able to find space for it. Think you can do that?"`
+			`	"We're going to have to fight them eventually, but first we need as much information as we can get on their new weapon systems. I'd like you to find one of their Gunboats that has the new electron beams installed, steal one of them, and bring it back here. I imagine one of them can't be much bigger than twenty or thirty tons, so you ought to be able to find space for it. Think you can do that?"`
 			choice
-				`	"How can I find a gunboat that's all by itself? They're usually a part of a bigger fleet."`
+				`	"How can I find a Gunboat that's all by itself? They're usually a part of a bigger fleet."`
 			`	She thinks about that for a moment, then says, "The Navy has shifted most of their capital ships to the defecting systems in the south. That means that some of the systems up north will have lighter defenses. You might try Wei or Alnasl. Good luck, Captain."`
 				accept
 	npc
@@ -1127,11 +1127,11 @@ mission "FW Alphas 1.1"
 			choice
 				`	"It must be a trick. There can't still be Alphas around. Maybe the pirates dyed their skin green to make people fear them."`
 				`	"How is it possible that some of the Alphas are still alive?"`
-			`	Alondo says, "This may be a trick, but we can't afford to take that risk. The Alphas were the greatest threat humanity has ever faced. And before they contacted us for help, Poisonwood reached out to the Navy." As he is speaking, a shadow passes overhead. You look up and see the unmistakable silhouette of a Navy cruiser, coming in for a landing.`
+			`	Alondo says, "This may be a trick, but we can't afford to take that risk. The Alphas were the greatest threat humanity has ever faced. And before they contacted us for help, Poisonwood reached out to the Navy." As he is speaking, a shadow passes overhead. You look up and see the unmistakable silhouette of a Navy Cruiser, coming in for a landing.`
 			choice
 				`	"Are you insane? You're letting the Navy come here?"`
 				`	"We're going to work side by side with the Navy right after that awful battle?"`
-			`	Alondo explains, "It's only one cruiser, an 'Oathkeeper' ship, sworn to take no part in our war. The Free Worlds have almost no troops trained for ground combat, so without the Navy's help we would be unlikely to be able to eliminate the Alphas."`
+			`	Alondo explains, "It's only one Cruiser, an 'Oathkeeper' ship, sworn to take no part in our war. The Free Worlds have almost no troops trained for ground combat, so without the Navy's help we would be unlikely to be able to eliminate the Alphas."`
 			`	The Navy ship lands, and a man steps off who you recognize immediately: Admiral William Danforth, who is something of a folk hero throughout human space, and who you have heard is the commander of the entire Oathkeepers regiment. With him is a man who he introduces as Commander Aaron Nguyen of the Navy Humanitarian Corps. As Nguyen shakes your hand, you are struck by the fact that although he is your enemy, you see no trace of hostility in his eyes - in fact, his expression is surprisingly warm and affectionate.`
 			`	"We have no room for error," says Danforth. "These Alphas must be eliminated, and they must not be allowed to escape. On that, at least, we can all agree."`
 			`	Freya says, "Captain <last> will lead the attack." She beckons to two of the Free Worlds captains. "Marco, Emily, you will join them with your Falcons. Destroy any pirate ships in orbit, then land and secure the facility. Understood?" You nod, and prepare to take off for the <system> system.`
@@ -1800,7 +1800,7 @@ mission "FW Rand 1"
 				`	"Are you saying we shouldn't let them join, even though they want to?"`
 				`	"Well, I say, if they want to join us, we should let them. Who knows if they'll be this enthusiastic about the Free Worlds later if we let them down now."`
 			`	JJ thinks about that for a moment, then says, "Well, I guess we should let them join. It will mean we may need to launch an assault to drive the Navy off New Iceland. But if we do that, our tactical position shifts from one that's worse than what we have now, to something much better. Freya, did they say if there's any sign that the Navy has gotten word of this?"`
-			`	"A few carriers are in orbit around Rand," she says, "so they must suspect something. But the bulk of the Navy fleet is still to the north and east of here."`
+			`	"A few Carriers are in orbit around Rand," she says, "so they must suspect something. But the bulk of the Navy fleet is still to the north and east of here."`
 			`	JJ says, "Okay Captain, here's what I propose. We'll leave the bulk of our fleet here to defend Dancer and New Portland, but take a few of our best ships to Zeta Aquilae and drive out the Navy. Freya and I will travel with you so that if we need to make any decisions, we'll have most of the Council there in person. How does that sound?"`
 			choice
 				`	"It sounds like a good plan. Let's do it!"`

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -937,6 +937,7 @@ mission "FW Pug 1"
 		event "pug invasion 2" 6
 		event "pug invasion 3" 10
 		event "pug invasion 4" 14
+		"reputation: Pug" >?= 1
 		conversation
 			`As soon as you land on <origin>, JJ comes running up to your ship. "<first>," he says, "we have serious trouble. A few minutes ago I received a distress call from Rand, then their transmission was cut off. I'm afraid the Syndicate may be expanding into our space."`
 			choice

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -2454,3 +2454,15 @@ mission "FW Syndicate Extremists 1C"
 			`	You discover that Parliament has made a treaty with the Free Worlds, agreeing that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, your war against the Republic is officially over.`
 			`	Your meeting with Parliament is long and grueling, as they press you and Freya for every detail you can give them about the enigmatic Pug and their apparent motivation in invading human space. The questions about the Syndicate are equally hard to answer. But at the end of the session, one of the members of Parliament informs you that they have authorized an official commendation for you, along with a reward of five million credits "to cover any of your expenses from fighting the aliens, and to help you integrate back into civilian life."`
 			`	The war is over; your work for the Free Worlds is at an end. What you do next is up to you...`
+
+
+
+mission "FW Navy Out Of Rastaban (Bad Karma)"
+	landing
+	invisible
+	to offer
+		has "FW Syndicate Extremists 1C: done"
+		not "event: navy out of rastaban"
+	on offer
+		event "navy out of rastaban" 30
+		fail

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -275,6 +275,19 @@ mission "FW Navy Out Of Rastaban"
 
 
 
+mission "fw tarazed joins"
+	landing
+	invisible
+	to offer
+		has "FW Reconciliation 2: done"
+		not "FW Reconciliation 2A: done"
+		karma > 0
+	on offer
+		event "fw tarazed joins"
+		fail
+
+
+
 mission "FW Reconciliation 2A"
 	name "Oathkeepers on Farpoint"
 	description "Travel to <destination> to meet with the Navy Oathkeepers. Raven's ship will continue to travel with you."
@@ -291,7 +304,6 @@ mission "FW Reconciliation 2A"
 	
 	on offer
 		log `The governor of Valhalla, in the Deep, has proposed a "police action" to arrest one or more of the Syndicate leaders and bring them to justice. It will be a secret joint operation between the Free Worlds, the Deep, and the Oathkeepers.`
-		event "fw tarazed joins"
 		conversation
 			`When you land on Valhalla, a man shows up at your ship and introduces himself as Edrick Flint, the governor of Valhalla. He invites all of you to join him for dinner at his home, which turns out to be an apartment on the twenty-third floor of one of the downtown skyscrapers. There, he introduces you to several other regional governors and authorities.`
 			`	"You may be aware," Edrick says, "that the Deep was self-governing before the formation of the Republic. Indeed, during some of the darkest centuries of the space age, the Deep stood out as a beacon of civilization, a place where piracy was not tolerated and all travelers were safe. When we joined the Republic, we retained the authority to police our own territory, and that authority includes the right to track down fugitives who have fled beyond our usual jurisdiction."`
@@ -312,7 +324,14 @@ mission "FW Reconciliation 2A"
 			`	"That's why the fleet will be composed of ships from three different organizations," says Edrick. "You will find a reason to travel to Earth with perhaps one of your fancy new Dreadnoughts as an escort. When you arrive, there will just happen to be an Oathkeeper patrol passing through the same system. And a merchant convoy from the Deep. With its own set of escorts, of course."`
 			`	"We'd need to know exactly where and on what planet our target lives, prior to entering Syndicate space," says Katya. "And, if you want to have a court trial immediately prior to the arrest, it sounds like Sawyer will need to stay here."`
 			`	"Indeed," says Edrick, "but I assure you, he is safer from the Syndicate here than anywhere else in human space, your own territory included. As for locating a target, that's why the Oathkeepers have requested that you visit them on Farpoint."`
+			branch tarazed
+				karma > 0
+			`	The rest of the evening is a more casual time for conversation, with plenty of good food and wine.`
+				goto end
+			
+			label tarazed
 			`	The rest of the evening is a more casual time for conversation, with plenty of good food and wine. Alondo sends you a message to inform you that Tarazed has decided to officially join the Free Worlds after having received word of the Parliament hearing, news that brings joy to Katya and Ijs.`
+			label end
 			`	At one point, Edrick pulls you aside and says, "I've requested that you be granted access to some of the new technology that was developed here during the course of the war. In particular, please find space on your ship for a ramscoop; you will need it for your next mission. And also, here." He hands you a data card. "This is a copy of Sawyer's evidence, in case something happens here. Keep it very, very safe."`
 				accept
 	

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -2448,6 +2448,7 @@ mission "FW Syndicate Extremists 1C"
 	on complete
 		log "Received an official commendation from Parliament and a promise that the war with the Free Worlds is officially over. Humanity is at peace once more, but new challenges may await in the star systems out beyond human space that are accessible only by jump drive."
 		payment 5000000
+		event "stack core for sale"
 		set "main plot completed"
 		set "free worlds plot completed"
 		set "free worlds reconciliation"

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -2473,7 +2473,16 @@ mission "FW Syndicate Extremists 1C"
 		set "free worlds reconciliation"
 		conversation
 			`On Earth, you return to something of a hero's welcome, far different from the first time you were here on a diplomatic mission. A crowd of locals gathers in the spaceport to watch your ship land. With the Free Worlds having been instrumental in defeating the aliens, and absolved of any guilt in the terrorist attacks, it seems that most people here are ready to see you as a hero rather than a criminal.`
+			
+			branch good
+				not "event: navy out of rastaban"
+			`	You discover that Parliament has made a treaty with the Free Worlds, agreeing that the Navy will begin pulling out of any occupied systems, and that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, your war against the Republic is officially over.`
+				goto end
+			
+			label good
 			`	You discover that Parliament has made a treaty with the Free Worlds, agreeing that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, your war against the Republic is officially over.`
+			
+			label end
 			`	Your meeting with Parliament is long and grueling, as they press you and Freya for every detail you can give them about the enigmatic Pug and their apparent motivation in invading human space. The questions about the Syndicate are equally hard to answer. But at the end of the session, one of the members of Parliament informs you that they have authorized an official commendation for you, along with a reward of five million credits "to cover any of your expenses from fighting the aliens, and to help you integrate back into civilian life."`
 			`	The war is over; your work for the Free Worlds is at an end. What you do next is up to you...`
 

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -2450,6 +2450,7 @@ mission "FW Syndicate Extremists 1C"
 		payment 5000000
 		set "main plot completed"
 		set "free worlds plot completed"
+		set "free worlds reconciliation"
 		conversation
 			`On Earth, you return to something of a hero's welcome, far different from the first time you were here on a diplomatic mission. A crowd of locals gathers in the spaceport to watch your ship land. With the Free Worlds having been instrumental in defeating the aliens, and absolved of any guilt in the terrorist attacks, it seems that most people here are ready to see you as a hero rather than a criminal.`
 			`	You discover that Parliament has made a treaty with the Free Worlds, agreeing that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, your war against the Republic is officially over.`

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -175,7 +175,7 @@ mission "FW Reconciliation 1C"
 			`	Sawyer directs you to the site where the secret development took place. Nothing is left but a wide and slightly overgrown clearing. After checking your radar and seeing no incoming ships, you risk landing. Sawyer says that there were buildings here a few years ago, but now not even their foundations remain, and a sensor sweep for metallic objects turns up nothing, not even as small as a single nail.`
 			`	However, Ijs points out a few subtle signs of human habitation. "A clearing like this would normally form in a fire," he says, "but notice, no fire scars on the trees on the edges of the clearing."`
 			`	Raven says, "And our geophysical radar is picking up structures underground. Several deep shafts, and rock that's been stressed and fractured by a large explosion. They did a good job of hiding everything else, but if you scar a planet that badly, it doesn't go away. The stones speak."`
-			`	As you continue inspecting the site, suddenly Raven's copilot shouts out the door of her gunboat at you. "Syndicate ships have entered the system! We need to get back to Earth with the evidence, quickly!"`
+			`	As you continue inspecting the site, suddenly Raven's copilot shouts out the door of her Gunboat at you. "Syndicate ships have entered the system! We need to get back to Earth with the evidence, quickly!"`
 				launch
 	
 	npc accompany save
@@ -678,7 +678,7 @@ mission "FW Syndicate Capture 1"
 	on offer
 		log "Preparing to invade Syndicate space with a joint strike force made up of Free Worlds, Deep security, and Oathkeeper ships. The plan is to capture one of the Syndicate executives and bring him to trial."
 		conversation
-			`You land on Earth and make a show of being very busy ensuring that the Free Worlds ambassadors are comfortable and well cared for, until finally you receive a secure message from Edrick. He tells you that the convoy from the Deep is landing on Mars right now, and an Oathkeeper cruiser is visiting the shipyard on Luna. As soon as you are ready, you can take off, and travel together into the heart of Syndicate space.`
+			`You land on Earth and make a show of being very busy ensuring that the Free Worlds ambassadors are comfortable and well cared for, until finally you receive a secure message from Edrick. He tells you that the convoy from the Deep is landing on Mars right now, and an Oathkeeper Cruiser is visiting the shipyard on Luna. As soon as you are ready, you can take off, and travel together into the heart of Syndicate space.`
 			`	You make an excuse to depart, and return to your ship. "Well," says Ijs, "this is it. If we're lucky, they won't see us coming, but no matter what, getting back out of Syndicate space will be a nightmare. Good luck, all."`
 				accept
 	on visit
@@ -2275,7 +2275,7 @@ mission "FW Syndicate Extremists 1A"
 	on offer
 		log "With the Pug defeated, it is finally time to deal with the Syndicate extremists and the Alphas that they allied with. The extremists are armed with nuclear missiles, but the Syndicate CEO has agreed to provide a cloaking device that will make it possible to dodge the missiles."
 		conversation
-			`The presence of a Navy cruiser in orbit seldom goes unnoticed, especially a cruiser captained by someone as famous as William Danforth. As soon as you land, a Syndicate employee meets you and escorts you, Freya, and Danforth to the office of Alastair Korban, the CEO. He does not seem very happy to see you. "I only just got word that the aliens were defeated a few days ago," he says. "I'm surprised you're back here already."`
+			`The presence of a Navy Cruiser in orbit seldom goes unnoticed, especially a Cruiser captained by someone as famous as William Danforth. As soon as you land, a Syndicate employee meets you and escorts you, Freya, and Danforth to the office of Alastair Korban, the CEO. He does not seem very happy to see you. "I only just got word that the aliens were defeated a few days ago," he says. "I'm surprised you're back here already."`
 			`	Danforth says, "I've got a whole Navy fleet just a few jumps away from here who are itching to destroy something. So here's the deal. You name me some targets: the men who were responsible for the terrorist attack. Then I will do you a favor and take them off your hands. Fair enough?"`
 			`	Korban sighs, and then opens his desk and pulls out a sheet of paper. "This is my resignation letter," he says. "I've been working on it since my first meeting with Captain <last>. I've failed in my leadership of this company. But you have no idea how deep that failure goes."`
 			choice
@@ -2430,7 +2430,7 @@ mission "FW Syndicate Extremists 1C"
 		event "navy occupies algenib"
 		event "navy done with algenib" 50
 		conversation
-			`Soon after you land, more Navy ships begin pouring into the system, including Admiral Danforth's own cruiser. Navy soldiers and ships are scouring the whole surface of the planet; there is very little chance that any of the Alphas who remain here will be able to escape their detection. Admiral Danforth meets with you and Freya and thanks you for providing the decoy that kept his own ships from bearing the brunt of the Alphas' nuclear arsenal.`
+			`Soon after you land, more Navy ships begin pouring into the system, including Admiral Danforth's own Cruiser. Navy soldiers and ships are scouring the whole surface of the planet; there is very little chance that any of the Alphas who remain here will be able to escape their detection. Admiral Danforth meets with you and Freya and thanks you for providing the decoy that kept his own ships from bearing the brunt of the Alphas' nuclear arsenal.`
 			`	"Do you need us to do anything more here?" asks Freya.`
 			`	"No," he says, "and I hear that Parliament wants to speak with you, Captain <last>. Something about an official commendation for your part in the battle against the Pug, I think. Meanwhile, this may not be the end of our trouble with the Syndicate, but at least it's a good start. It's been an honor to fight alongside you."`
 			choice

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -2475,7 +2475,7 @@ mission "FW Syndicate Extremists 1C"
 			`On Earth, you return to something of a hero's welcome, far different from the first time you were here on a diplomatic mission. A crowd of locals gathers in the spaceport to watch your ship land. With the Free Worlds having been instrumental in defeating the aliens, and absolved of any guilt in the terrorist attacks, it seems that most people here are ready to see you as a hero rather than a criminal.`
 			
 			branch good
-				not "event: navy out of rastaban"
+				has "event: navy out of rastaban"
 			`	You discover that Parliament has made a treaty with the Free Worlds, agreeing that the Navy will begin pulling out of any occupied systems, and that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, your war against the Republic is officially over.`
 				goto end
 			

--- a/data/free worlds side plots.txt
+++ b/data/free worlds side plots.txt
@@ -559,6 +559,7 @@ mission "FW Stack Core 1C"
 	source
 		near "Pherkad" 100
 	to offer
+		not "main plot completed"
 		has "event: stack core for sale"
 	
 	on offer

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -25,7 +25,7 @@ mission "Liberate Kornephoros"
 			`	You find Tomek walking among the fleet, conversing with captains and assessing the damage they have suffered. When he sees you he says, "Captain <last>! How is your '<ship>' holding together?"`
 			choice
 				`	"She took a bit of a pounding, but I've patched her up."`
-				`	"Just fine. It'd take more than a few cruisers to destroy the <ship>."`
+				`	"Just fine. It'd take more than a few Cruisers to destroy the <ship>."`
 			
 			`	"Glad to hear it," he says. "Listen, we need to press our advantage before the Republic has time to call for reinforcements. If we strike quickly, we could be able to retake Kornephoros from them. It's important to break the blockade on that system just for the sake of trade with the rest of the galaxy, and on top of that, of course, Katya needs to be rescued."`
 			`	"Indeed," you say.`
@@ -578,9 +578,9 @@ mission "FW Hope Recon 1C"
 			
 			apply
 				set "fw caught navy planting sensors"
-			`	You approach the location, flying low to avoid detection, and come upon a Navy gunboat, landed on the planet. Some distance away from the ship, several figures in thick snowsuits are setting up some sort of equipment with lots of antennae. It seems that the Navy had the same idea as Freya, of using this world as a listening post. Your sensors show that the gunboat is powered down.`
-			`	The moment your ship comes over the horizon, they start running back toward the gunboat. You destroy their equipment with a few well-placed shots, then train your guns on the crew members, who are still some distance from their ship. When they realize they cannot get back to it before being shot, they raise their hands in surrender.`
-			`	You count seven crew members in the group, which is the typical crew complement of a gunboat. That may mean the gunboat is uncrewed, and you could kill the crew and steal it. On the other hand, if there are more crew aboard the ship it would be better to destroy it first, then finish off the landing crew.`
+			`	You approach the location, flying low to avoid detection, and come upon a Navy Gunboat, landed on the planet. Some distance away from the ship, several figures in thick snowsuits are setting up some sort of equipment with lots of antennae. It seems that the Navy had the same idea as Freya, of using this world as a listening post. Your sensors show that the Gunboat is powered down.`
+			`	The moment your ship comes over the horizon, they start running back toward the Gunboat. You destroy their equipment with a few well-placed shots, then train your guns on the crew members, who are still some distance from their ship. When they realize they cannot get back to it before being shot, they raise their hands in surrender.`
+			`	You count seven crew members in the group, which is the typical crew complement of a Gunboat. That may mean the Gunboat is uncrewed, and you could kill the crew and steal it. On the other hand, if there are more crew aboard the ship it would be better to destroy it first, then finish off the landing crew.`
 			choice
 				`	(Destroy the ship, then finish off the crew.)`
 					goto destroy
@@ -590,7 +590,7 @@ mission "FW Hope Recon 1C"
 					goto spare
 			
 			label destroy
-			`	It turns out you made the right choice: someone is indeed onboard the gunboat still, because the moment you open fire it raises shields and starts powering up its engines and weapons. But, your initial shots must have damaged some critical systems, because it only manages to fire a few shots at you and to lift off about thirty meters into the air before crashing back down onto the ice and exploding. You quickly pick off the landing crew as well; they have no place to hide on the broad, flat glacial expanse.`
+			`	It turns out you made the right choice: someone is indeed onboard the Gunboat still, because the moment you open fire it raises shields and starts powering up its engines and weapons. But, your initial shots must have damaged some critical systems, because it only manages to fire a few shots at you and to lift off about thirty meters into the air before crashing back down onto the ice and exploding. You quickly pick off the landing crew as well; they have no place to hide on the broad, flat glacial expanse.`
 			`	Your own mission is complete, so it's time to return to <planet> and report to Freya.`
 				decline
 			
@@ -790,7 +790,7 @@ mission "FW Plasma Testing 1B"
 				goto next
 			
 			label fighters
-			`	"I guess we'll need to test it to find out," he says, "but our main goal was to have a weapon that could do serious damage to a cruiser. Right now the Navy's heaviest ships have ours severely outgunned."`
+			`	"I guess we'll need to test it to find out," he says, "but our main goal was to have a weapon that could do serious damage to a Cruiser. Right now the Navy's heaviest ships have ours severely outgunned."`
 				goto next
 			
 			label next

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1629,7 +1629,7 @@ ship "Gunboat"
 	explode "small explosion" 20
 	explode "medium explosion" 15
 	"final explode" "final explosion small"
-	description "The Navy gunboat is designed for engaging targets at short range, and also serves as the Navy's mobile sensor platform, scanning ships for illegal equipment or cargo."
+	description "The Navy Gunboat is designed for engaging targets at short range, and also serves as the Navy's mobile sensor platform, scanning ships for illegal equipment or cargo."
 
 
 

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -2795,7 +2795,7 @@ mission "Wanderers: Sestor Alt: Alnilam 1"
 mission "Wanderers: Sestor Alt: Alnilam 2"
 	landing
 	name "Attack Alpha base"
-	description "Travel to the <system> system with these Oathkeeper cruisers to eliminate the Alpha base on <planet>."
+	description "Travel to the <system> system with these Oathkeeper Cruisers to eliminate the Alpha base on <planet>."
 	source "Farpoint"
 	destination "Zenith"
 	clearance
@@ -2831,7 +2831,7 @@ mission "Wanderers: Sestor Alt: Alnilam 2"
 mission "Wanderers: Sestor Alt: Alnilam 3"
 	landing
 	name "Return to <planet>"
-	description "Escort the Oathkeeper cruisers back to <destination>."
+	description "Escort the Oathkeeper Cruisers back to <destination>."
 	source "Zenith"
 	destination "Farpoint"
 	to offer

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -1024,7 +1024,7 @@ mission "Wanderers: Alpha Surveillance D"
 		conversation
 			`You are met in the spaceport by a bearded, middle-aged human man and a Quarg with exceptionally wrinkly skin. The Quarg says, "I hear that you need help against the Alphas. My friend Elias here has lived among us for a long time, and has told me much about the Alphas, their wars and their depredations."`
 			`	The human shakes hands with you and introduces himself as Elias Hanover. He says, "The Quarg are very hesitant to take sides in what they view as an internal human conflict. And they are equally hesitant to entrust their technology to a stranger like you. But if the Alphas are gathering strength and amassing alien technology, they must be stopped."`
-			`	The Quarg says, "Elias is a trusted friend of ours. We have given him a device for tracking a ship traveling by jump drive, and programmed it with the parameters of a human carrier ship. Do not try to take the device from him. He will lead you to find your quarry, and then you must return the device to us immediately."`
+			`	The Quarg says, "Elias is a trusted friend of ours. We have given him a device for tracking a ship traveling by jump drive, and programmed it with the parameters of a human Carrier. Do not try to take the device from him. He will lead you to find your quarry, and then you must return the device to us immediately."`
 			`	Elias asks, "If we find them, are you prepared to take on a Carrier by yourself?"`
 			choice
 				`	"Yes, my ship is stronger than anything in human space."`
@@ -1048,7 +1048,7 @@ mission "Wanderers: Alpha Surveillance D"
 	on enter "Makferuti"
 		dialog `Elias frowns as he looks at the tracker's readout. "I think we've taken a wrong turn. No sign of jump drives being used in this system," he says.`
 	on enter "Host"
-		dialog `When you enter this system, your sensors pick up a Navy Carrier in orbit around an Earth-like planet. It appears that you have found the Alpha base. "That's them," says Hanover. "I hope you're strong enough to destroy them." The carrier starts to launch fighters: Korath ones, not human ships. This might be a difficult fight...`
+		dialog `When you enter this system, your sensors pick up a Navy Carrier in orbit around an Earth-like planet. It appears that you have found the Alpha base. "That's them," says Hanover. "I hope you're strong enough to destroy them." The Carrier starts to launch fighters: Korath ones, not human ships. This might be a difficult fight...`
 	
 	npc
 		government "Kor Sestor"
@@ -1084,7 +1084,7 @@ mission "Wanderers: Alpha Surveillance D"
 	on visit
 		dialog `You've returned to <planet>, but you have a feeling that your job isn't done. Either find where the Alphas are hiding, or return to where they are hiding and finish what you started.`
 	on complete
-		log "Defeated a Navy Carrier, presumably being operated by the Alphas, that was equipped with Korath fighters and drones. Presumably there is an Alpha base hidden somewhere on the earth-like planet that the carrier was guarding."
+		log "Defeated a Navy Carrier, presumably being operated by the Alphas, that was equipped with Korath fighters and drones. Presumably there is an Alpha base hidden somewhere on the earth-like planet that the Carrier was guarding."
 		conversation
 			`When you land back on <planet>, Elias says that he should go and immediately return the tracking device to his Quarg friend. "After that," he says, "we'll need to figure out who can help us to locate and bust open the Alpha base. Meet me in the spaceport when you're ready."`
 
@@ -1144,7 +1144,7 @@ mission "Wanderers: Alpha Surveillance F"
 		has "Wanderers: Alpha Surveillance E: done"
 	
 	on offer
-		log "Admiral Danforth agreed to bring his cruiser to the planet in Korath space where the Alphas seem to be hiding, with enough troops and equipment to launch an assault on the base."
+		log "Admiral Danforth agreed to bring his Cruiser to the planet in Korath space where the Alphas seem to be hiding, with enough troops and equipment to launch an assault on the base."
 		log "Factions" "Oathkeepers" `However, the true reason that the powerful Oathkeeper fleet is positioned in the North is not just to keep the pirates at bay, but also to stand as a last defense in case the Hai decide to invade human space. Apparently the Navy has known about the Hai and the wormhole linking their space to human space for some time, but chooses not to make that knowledge public.`
 		conversation
 			`Danforth welcomes you into his private office and uses a device to sweep the room for bugs. "Please forgive my caution," he says when he is done. "Now, show me where this planet is."`
@@ -1187,7 +1187,7 @@ mission "Wanderers: Alpha Surveillance G"
 		log "The Alphas have fled from the base on Avalon. The Oathkeepers destroyed what is left of the base, which will hopefully set the Alphas back quite a bit."
 		conversation
 			`It does not take long for Danforth's team to locate the Alpha base, buried deep underground in a network of limestone caves. You and Danforth hover your ships above the site to catch anyone who tries to take off and escape. Danforth keeps you updated on the progress of the troops. "Breached the perimeter. Dealing with some booby traps. Explosives, poison gas. Nasty stuff. No sign of inhabitants, but they were here recently. Place looks cleaned out. Extensive base. Hangars, labs, supply rooms. Probably took them a century to build."`
-			`	His troops spend a while exploring the base and eventually conclude that the Alphas packed up and left soon after you destroyed the carrier. Once the place has been thoroughly explored and they are sure there are no more clues to be found, Danforth tells them, "Okay, blow the place. No sense in leaving them a base to return to."`
+			`	His troops spend a while exploring the base and eventually conclude that the Alphas packed up and left soon after you destroyed the Carrier. Once the place has been thoroughly explored and they are sure there are no more clues to be found, Danforth tells them, "Okay, blow the place. No sense in leaving them a base to return to."`
 			choice
 				`	"So this was all for nothing?"`
 				`	"I wish we had been able to catch them."`


### PR DESCRIPTION
## Summary
Addressing a number of small issues pertaining to the FW Campaign all at once.

## Todo
- [x] In FWC, the player now doesn't magically know the name of the Pug before being told what they are (#2693).
- [x] In FW Middle, characters will now react if the player was suspended from the FW at the end of FW Start (#2687).
- [x] Rastaban and the surrounding systems now revert to FW ownership for bad karma Reconciliation runs, just much later than during good karma (#2696).
- [x] Flamethrowers now unlock for FW runs regardless of whether you helped test them or not.
- [x] Fixed some minor reputation issues that could occur in FWR (#2695).
- [x] Normalized capitalization of Navy ships (#2698).
- [x] Epilogue for Danforth changes based off of the branch (#2663).
- [x] Stacks Cores now unlock for FW runs regardless of whether you helped escort the freighters or not. 
- [x] Allow the player to decline going to the meeting on Albatross if they say they're gay (mentioned in #3705).
- [x] Because I removed Rastaban and the surrounding systems from being completely tied to karma in FWR, I've made it so that Tarazed and the surrounding systems now join the FW based off of karma. 
- Normalize Ijs vs Eyes, at least within the same mission (#2585)? **Doesn't seem necessary.**
- Epilogue for Tomek (mentioned in #2663). **Will change in or post #4672.**