### PR TITLE
Reparent jump-capable carried ships to out-of-system flagship

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -707,9 +707,19 @@ void AI::Step(const PlayerInfo &player)
 			bool hasParent = parent && parent->GetGovernment() == gov;
 			bool hasSpace = hasParent && parent->BaysFree(it->Attributes().Category() == "Fighter");
 			bool inParentSystem = hasParent && parent->GetSystem() == it->GetSystem();
-			if(!hasParent || parent->IsDestroyed() || (!hasSpace && !Random::Int(1200))
+			bool canJump = it->JumpFuel();
+			// If the flagship is in a different system, then set it as parent for orphaned jump-capable
+			// carried ships to ensure that the orphaned ships jump towards the flagship.
+			if(it->IsYours() && canJump && !hasParent && flagship && flagship->GetSystem() != it->GetSystem())
+			{
+				// Set flagship as parent for orphaned fighters and drones.
+				parent.reset();
+				parent = player.FlagshipPtrReadOnly();
+				it->SetParent(parent);
+			}
+			else if(!hasParent || parent->IsDestroyed() || (!hasSpace && !Random::Int(1200))
 					// Any carried ship that cannot jump should reparent if not in its parent's system.
-					|| (!inParentSystem && !it->JumpFuel()))
+					|| (!inParentSystem && !canJump))
 			{
 				// Find a parent for orphaned fighters and drones.
 				parent.reset();

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -730,6 +730,7 @@ Ship *PlayerInfo::Flagship()
 
 
 
+// Determine which ship is the flagship and return the shared pointer to it.
 const shared_ptr<Ship> &PlayerInfo::FlagshipPtr()
 {
 	if(!flagship)
@@ -742,6 +743,15 @@ const shared_ptr<Ship> &PlayerInfo::FlagshipPtr()
 			}
 	}
 	
+	return FlagshipPtrReadOnly();
+}
+
+
+
+// Get the shared pointer to the flagship, but don't lookup which ship is
+// the flagship if it is unknown.
+const shared_ptr<Ship> &PlayerInfo::FlagshipPtrReadOnly() const
+{
 	static const shared_ptr<Ship> empty;
 	return (flagship && flagship->IsYours()) ? flagship : empty;
 }

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -114,6 +114,7 @@ public:
 	const Ship *Flagship() const;
 	Ship *Flagship();
 	const std::shared_ptr<Ship> &FlagshipPtr();
+	const std::shared_ptr<Ship> &FlagshipPtrReadOnly() const;
 	// Get the full list of ships the player owns.
 	const std::vector<std::shared_ptr<Ship>> &Ships() const;
 	// Add a captured ship to your fleet.


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue where jump-capable carried ships were not jumping to the flagship

## Fix Details
This fix sets the flagship as parent for player-owned jump-capable carried ships without a parent.
[Bobby Bugfix.txt](https://github.com/endless-sky/endless-sky/files/3848557/Bobby.Bugfix.txt)


I believe the loss of the parent can happen if the flagship is in a different system and has no or insufficient bays and when this condition in AI.cpp "(!hasSpace && !Random::Int(1200))" is true.

## Save File
This save file [Jumping Bug.txt](https://github.com/endless-sky/endless-sky/files/3848561/Jumping.Bug.txt) can be used to verify the bugfix. The bug will occur when using 7558528209a338fcdd1d1a254fa835ef15bdbc03, and will not occur when using this branch's build.