### PR TITLE
Update MFirebird Hull

### DIFF
--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -357,7 +357,7 @@ ship "Marauder Firebird"
 		category "Medium Warship"
 		"cost" 4100000
 		"shields" 7000
-		"hull" 3000
+		"hull" 3650
 		"required crew" 10
 		"bunks" 25
 		"mass" 350

--- a/data/marauders.txt
+++ b/data/marauders.txt
@@ -356,8 +356,8 @@ ship "Marauder Firebird"
 	attributes
 		category "Medium Warship"
 		"cost" 4100000
-		"shields" 7000
-		"hull" 3650
+		"shields" 6400
+		"hull" 4000
 		"required crew" 10
 		"bunks" 25
 		"mass" 350


### PR DESCRIPTION
the description of the Marauder Firebird at one point mentions, like in other Marauder ships, how it has more shields and hull:
"With extra ..., hull plating"
but the MFirebird actually has *less* hull than it's normal counterpart, having 3000 for the Marauder version vs the 3400 for the standard.
In the same fashion as for other Medium Warships such as the Splinter and the Manta, and how their Marauder versions have 250 more hull than the Standard ones, this increases the Hull of the MFirebird to 3650.