### PR TITLE
Fixing the lack of Gaslining on the Penguin

### DIFF
--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -541,6 +541,7 @@ ship "Penguin"
 		"shield energy" 0.5
 		"hull repair rate" 2
 		"hull energy" 1.0
+		"gaslining" 1
 		"cloak" .03
 		"cloaking energy" 3
 		"cloaking fuel" .05


### PR DESCRIPTION
**Bugfix:** This PR addresses the fact that the Penguin does not have gaslining.

## Fix Details
adds `"gaslining" 1` to the Penguin

Thanks to BeccaBunny for spotting this. I have no idea how I missed it, considering how much I like using the Penguin.