### PR TITLE
FW Middle: (better) explain why attacking Bloodsea is fine now when it wasn't before

### DIFF
--- a/data/free worlds checkmate.txt
+++ b/data/free worlds checkmate.txt
@@ -170,7 +170,7 @@ mission "FWC Cebalrai 1"
 	on offer
 		log "Captured the Kaus Borealis system from the Navy, even though the locals are still loyal to the Republic. Also, learned that the Wolf Pack ships have been using nuclear missiles, and that is why they were so effective in decimating the Navy fleet."
 		conversation
-			`As you bring your ship in for a landing, it occurs to you that this is the first time that you have fought a battle for a star system that had not voluntarily decided to join the Free Worlds, and you are not sure what to do next. Fortunately, soon more Free Worlds ships begin arriving, and one of them is carrying Alondo. Tomek is with him. "Hi there, <first>," says Tomek. "Bet you didn't expect to see me again, huh?"`
+			`As you bring your ship in for a landing, it occurs to you that this is the first time that you have fought a battle for a Republic star system that had not voluntarily decided to join the Free Worlds, and you are not sure what to do next. Fortunately, soon more Free Worlds ships begin arriving, and one of them is carrying Alondo. Tomek is with him. "Hi there, <first>," says Tomek. "Bet you didn't expect to see me again, huh?"`
 			`	Alondo says, "<first>, I'll leave you and Tomek to catch up. I should go talk to the governor immediately. There's no way the locals will have failed to notice the nuclear explosions happening in space right over their heads."`
 			choice
 				`	"What? We weren't using nukes, just conventional weapons."`

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1413,18 +1413,16 @@ mission "FW Bloodsea 1.1"
 				`	"Well, building a spaceport is probably cheaper than fighting a major battle."`
 					goto port
 				`	"They're asking a lot. Why don't we just invade them?"`
-					goto attack
+					goto invade
 			label port
 			`	"Yes," he says, "except that I can almost guarantee that when we show up on their doorstep with everything they asked for, some local warlord will attack our ships, steal our supplies, enslave our workers, and build himself a nice cozy island fortress."`
 			`	"So, we attack them?" you ask.`
-			label attack
+			label invade
 			branch hostile
 				not "event: fw suppressed Bloodsea"
 			`	"They didn't seem very happy about you doing that the first time. But..." Alondo pauses for a moment.`
 			label hostile
-			`	"That's certainly the simpler option," he says, "especially because I can almost guarantee that when we show up on their doorstep with everything they asked for, some local warlord will attack our ships, steal our supplies, enslave our workers, and build himself a nice cozy island fortress.`
-			label invade
-			`	"Tomek may have been punished for disobeying the Senate's orders, but we're in a different situation now. Our numbers have swelled because of our victories and new territory, and we now have the Dreadnoughts at our disposal, so occupying Bloodsea is now a viable option.`
+			`	"That's certainly the simpler option," he says. "Tomek may have been punished for disobeying the Senate's orders, but we're in a different situation now. Our numbers have swelled because of our victories and new territory, and we now have the Dreadnoughts at our disposal, so occupying Bloodsea is now a viable option.`
 			`	"You're on the Council now," he says. "I'll leave it up to you. Option one is, we bring them the supplies and workers, in merchant ships, but use very heavily armed merchant ships in case they double cross us. Option two is, we go to Dancer and see if JJ can lend us an invasion fleet while I convince the Senate that attacking Bloodsea is the better decision."`
 				accept
 	on visit

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1413,16 +1413,18 @@ mission "FW Bloodsea 1.1"
 				`	"Well, building a spaceport is probably cheaper than fighting a major battle."`
 					goto port
 				`	"They're asking a lot. Why don't we just invade them?"`
-					goto invade
+					goto attack
 			label port
 			`	"Yes," he says, "except that I can almost guarantee that when we show up on their doorstep with everything they asked for, some local warlord will attack our ships, steal our supplies, enslave our workers, and build himself a nice cozy island fortress."`
 			`	"So, we attack them?" you ask.`
-			label invade
+			label attack
 			branch hostile
 				not "event: fw suppressed Bloodsea"
 			`	"They didn't seem very happy about you doing that the first time. But..." Alondo pauses for a moment.`
 			label hostile
-			`	"That's certainly the simpler option," he says, "especially because I can almost guarantee that when we show up on their doorstep with everything they asked for, some local warlord will attack our ships, steal our supplies, enslave our workers, and build himself a nice cozy island fortress. Tomek may have been punished for disobeying the Senate's orders, but we're in a different situation now. Our numbers have swelled because of our victories and new territory, and we now have the Dreadnoughts at our disposal, so occupying Bloodsea is now a viable option."`
+			`	"That's certainly the simpler option," he says, "especially because I can almost guarantee that when we show up on their doorstep with everything they asked for, some local warlord will attack our ships, steal our supplies, enslave our workers, and build himself a nice cozy island fortress.`
+			label invade
+			`	"Tomek may have been punished for disobeying the Senate's orders, but we're in a different situation now. Our numbers have swelled because of our victories and new territory, and we now have the Dreadnoughts at our disposal, so occupying Bloodsea is now a viable option.`
 			`	"You're on the Council now," he says. "I'll leave it up to you. Option one is, we bring them the supplies and workers, in merchant ships, but use very heavily armed merchant ships in case they double cross us. Option two is, we go to Dancer and see if JJ can lend us an invasion fleet while I convince the Senate that attacking Bloodsea is the better decision."`
 				accept
 	on visit

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1564,8 +1564,9 @@ mission "FW Bloodsea 1.2A"
 			choice
 				`	"Alondo convinced me that the Bloodsea natives were just planning to betray us."`
 				`	"I don't think the pirates will understand any language except overwhelming force."`
+			`	"You're starting to sound a lot like Tomek," JJ remarks.`
 			`	"I also contacted the Senate on the way here," Alondo says, "and they approved the invasion. We're much more powerful now than before, making invasion a viable option."`
-			`	"Perhaps," says JJ. "I need to keep most of my fleet here, to defend against the Navy, but I'll select a few of the strongest ships to accompany you to Bloodsea. Make sure they make it home safe, though. We'll need every ship we can get for when the Navy attacks. Good luck, Captain."`
+			`	"Perhaps," says JJ. "I'll provide you with some ships, but I'm not happy about this. I need to keep most of my fleet here, to defend against the Navy, but I'll select a few of the strongest ships to accompany you to Bloodsea. Make sure they make it home safe, though. We'll need every ship we can get for when the Navy attacks. Good luck, Captain."`
 				accept
 	
 	npc

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1403,7 +1403,7 @@ mission "FW Bloodsea 1.1"
 			`The local leaders are unwilling to meet aboard your ship, and Alondo is afraid you will be ambushed if you venture too far away from it, so eventually they agree to set up a tent on the landing pad next to yours and meet there. Outside, a storm is raging, the rain mixing with salt spray from the blood-red ocean nearby.`
 			branch peaceful
 				not "event: fw suppressed Bloodsea"
-			`	Most of the leaders grimace at the sight of you. "What is the invader doing here?" one of them asks to Alondo.
+			`	Most of the leaders grimace at the sight of you. "What is the invader doing here?" one of them asks to Alondo.`
 			`	"Captain <last> was only following orders, but the officer responsible for giving those orders has been justly punished," Alondo says. "We come in peace this time." The leaders don't seem convinced with that answer, but they agree to continue.`
 			label peaceful
 			`	As you talk, it becomes clear that the inhabitants of Bloodsea are ashamed of how destitute and undeveloped their world is. Several of them have visited the island spaceport on Deep, and after dancing around the issue for a while, they make a request: if the Free Worlds builds them a real, modern island spaceport, they will join the Free Worlds.`

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1401,6 +1401,11 @@ mission "FW Bloodsea 1.1"
 		log "The local leaders on the lawless world of Bloodsea have said that they will join the Free Worlds, and stop supporting piracy, in exchange for the equipment to build a more modern spaceport. However, they may just be trying to steal the construction materials; it might be simpler to just attack and conquer them."
 		conversation
 			`The local leaders are unwilling to meet aboard your ship, and Alondo is afraid you will be ambushed if you venture too far away from it, so eventually they agree to set up a tent on the landing pad next to yours and meet there. Outside, a storm is raging, the rain mixing with salt spray from the blood-red ocean nearby.`
+			branch peaceful
+				not "event: fw suppressed Bloodsea"
+			`	Most of the leaders grimace at the sight of you. "What is the invader doing here?" one of them asks to Alondo.
+			`	"Captain <last> was only following orders, but the officer responsible for giving those orders has been justly punished," Alondo says. "We come in peace this time." The leaders don't seem convinced with that answer, but they agree to continue.`
+			label peaceful
 			`	As you talk, it becomes clear that the inhabitants of Bloodsea are ashamed of how destitute and undeveloped their world is. Several of them have visited the island spaceport on Deep, and after dancing around the issue for a while, they make a request: if the Free Worlds builds them a real, modern island spaceport, they will join the Free Worlds.`
 			`	One of them lays out a detailed list of amenities the port must have: concrete seawalls, raised landing pads, floating docks, sturdy hangars and warehouses, and various defense systems "for when the others learn that we've decided to join you." Also, the deal is off if you show up in orbit with a fleet that "looks like an invasion fleet rather than a construction fleet."`
 			`	You thank them and return to your ship. Alondo asks, "What do you think?"`
@@ -1411,13 +1416,14 @@ mission "FW Bloodsea 1.1"
 					goto invade
 			label port
 			`	"Yes," he says, "except that I can almost guarantee that when we show up on their doorstep with everything they asked for, some local warlord will attack our ships, steal our supplies, enslave our workers, and build himself a nice cozy island fortress."`
-				goto attack
-			label invade
-			`	"That's certainly the simpler option," he says, "especially because I can almost guarantee that when we show up on their doorstep with everything they asked for, some local warlord will attack our ships, steal our supplies, enslave our workers, and build himself a nice cozy island fortress."`
-				goto attack
-			label attack
 			`	"So, we attack them?" you ask.`
-			`	"You're on the Council now," he says. "I'll leave it up to you. Option one is, we bring them the supplies and workers, in merchant ships, but use very heavily armed merchant ships in case they double cross us. Option two is, we go to Dancer and see if JJ can lend us an invasion fleet."`
+			label invade
+			branch hostile
+				not "event: fw suppressed Bloodsea"
+			`	"They didn't seem very happy about you doing that the first time. But..." Alondo pauses for a moment.`
+			label hostile
+			`	"That's certainly the simpler option," he says, "especially because I can almost guarantee that when we show up on their doorstep with everything they asked for, some local warlord will attack our ships, steal our supplies, enslave our workers, and build himself a nice cozy island fortress. Tomek may have been punished for disobeying the Senate's orders, but we're in a different situation now. Our numbers have swelled because of our victories and new territory, and we now have the Dreadnoughts at our disposal, so occupying Bloodsea is now a viable option."`
+			`	"You're on the Council now," he says. "I'll leave it up to you. Option one is, we bring them the supplies and workers, in merchant ships, but use very heavily armed merchant ships in case they double cross us. Option two is, we go to Dancer and see if JJ can lend us an invasion fleet while I convince the Senate that attacking Bloodsea is the better decision."`
 				accept
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
@@ -1554,11 +1560,12 @@ mission "FW Bloodsea 1.2A"
 		event "battle for bloodsea"
 		karma --
 		conversation
-			`When you meet up with JJ, he says, "So, it's going to be battle rather than diplomacy? I suppose that may be for the best; I'm sure the pirates were planning some sort of double-cross. But still, it's too bad we couldn't find a peaceful solution."`
+			`When you meet up with JJ, Alondo explains that you're in need of an invasion fleet for Bloodsea. JJ looks confused at the request. "What? Whatever happened to diplomacy? I only heard that the Senate approved a diplomatic mission. Didn't Tomek get punished for this exact stunt?"`
 			choice
 				`	"Alondo convinced me that the Bloodsea natives were just planning to betray us."`
 				`	"I don't think the pirates will understand any language except overwhelming force."`
-			`	"Perhaps," says JJ. "At any rate, we'll never know, now. I need to keep most of my fleet here, to defend against the Navy, but I've selected a few of the strongest ships to accompany you to Bloodsea. Good luck, Captain."`
+			`	"I also contacted the Senate on the way here," Alondo says, "and they approved the invasion. We're much more powerful now than before, making invasion a viable option."`
+			`	"Perhaps," says JJ. "I need to keep most of my fleet here, to defend against the Navy, but I'll select a few of the strongest ships to accompany you to Bloodsea. Make sure they make it home safe, though. We'll need every ship we can get for when the Navy attacks. Good luck, Captain."`
 				accept
 	
 	npc


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Ref: #4671 (Forgot about this issue for the first PR.), #3772, #4672
A plot hole that I've seen brought up before concerns how the player gets punished in FW start for invading Bloodsea, but is given the option to invade Bloodsea in FW middle without consequences. This is brought up in #3772, where I highlighted how it is somewhat addressed after a single choice, but I feel that it isn't explained well enough currently, especially given that it's only explained by a single line that you only see if you choose the correct dialog.

* The leaders of Bloodsea now recognize you if you invaded them previously.
* Alondo now references the Tomek situation and explains why it's different now.
* Should you choose to invade, Alondo contacts the Senate for permission, which is granted.
* JJ is now confused about you deciding to invade, instead of immediately giving into the idea. This plays into his character trait expressed during the FW end choice, where he wants to take the defector for diplomacy instead of continuing to fight the Navy. (JJ seems to be more of a reluctant warrior, but currently it doesn't seem like that in these missions.)
* Changed a sentence in FWC that is wrong if the player attack Bloodsea or Greenrock previously, qualifying the claim that the FW hadn't invaded any unwilling system prior by saying that it's only an unwilling Republic system that they hadn't invaded.