### PR TITLE
Fix overclocked repair module

### DIFF
--- a/data/coalition outfits.txt
+++ b/data/coalition outfits.txt
@@ -157,7 +157,7 @@ outfit "Overclocked Repair Module"
 	"hull energy" 1.3
 	"hull heat" 1.14
 	"heat generation" .6
-	description "These advanced repair modules are issued to Heliarch ships, providing unparalleled hull repair in all of Coalition space. The legions of small repair drones come with the extensive pathways they use to quickly get around a ship, and as such the outfit can interfere with a ship's cooling and heat dissipation systems."
+	description "These advanced repair modules are issued to Heliarch ships, providing hull repair unparalleled in all of Coalition space. The legions of small repair drones come with the extensive pathways they use to quickly get around a ship, and as such the outfit can interfere with a ship's cooling and heat dissipation systems."
 
 outfit "Cooling Module"
 	category "Systems"

--- a/data/coalition outfits.txt
+++ b/data/coalition outfits.txt
@@ -157,7 +157,7 @@ outfit "Overclocked Repair Module"
 	"hull energy" 1.3
 	"hull heat" 1.14
 	"heat generation" .6
-	description "These advanced repair modules are issued to Heliarch ships, providing unparalled hull repair in all of Coalition space. The legions of small repair drones come with the extensive pathways they use to quickly get around a ship, and as such the outfit can interfere with a ship's cooling and heat dissipation systems."
+	description "These advanced repair modules are issued to Heliarch ships, providing unparalleled hull repair in all of Coalition space. The legions of small repair drones come with the extensive pathways they use to quickly get around a ship, and as such the outfit can interfere with a ship's cooling and heat dissipation systems."
 
 outfit "Cooling Module"
 	category "Systems"


### PR DESCRIPTION
**Bugfix:** This PR addresses a spelling mistake in the "Overclocked Repair Module" description

## Fix Details

1. replaces `unparalled` with `unparalleled`
2. changes the sentence structure from: `providing unparalled hull repair in all of Coalition space.` to `providing hull repair unparalleled in all of Coalition space.`

The previous sentence implies that it is an outfit that provides great hull repair that works throughout coalition space. The revised sentence implies that it is an outfit that provides the best hull repair that can be found in coalition space. Basically, the placement of the word 'unparalleled" in the current version makes it sound like the hull repair only works in coalition space.

## Credit
Thanks to Mr. Doom on the Endless Sky Discord for spotting the spelling mistake in "unparalled".
