### PR TITLE
Fix: James's intro mission - A: Give the Shuttle an Energy Blaster

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2718,6 +2718,7 @@ ship "Shuttle"
 			"hull damage" 60
 			"hit force" 180
 	outfits
+		"Energy Blaster"
 		"nGVF-AA Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
@@ -2728,12 +2729,12 @@ ship "Shuttle"
 		
 	engine -6 30
 	engine 6 30
-	gun 0 -31
+	gun 0 -31 "Energy Blaster"
 	leak "leak" 60 50
 	explode "tiny explosion" 10
 	explode "small explosion" 5
 	description "Although Betelgeuse Shipyards produces other ship models as well, the majority of their profits come from sales of the Shuttle. This versatile ship serves equally well as a passenger transport or a cargo courier. It also happens to be the cheapest ship you can buy which is capable of hyperspace travel."
-	description `	Shuttles are not designed to withstand combat of any sort, but they are fast and maneuverable enough to get out of harm's way if attacked by a larger, slower ship. Although they are typically unarmed, they have enough space for one weapon, which is the origin of the popular phrase, "as useless as a blaster cannon on a shuttlecraft."`
+	description `	Shuttles are not designed to withstand combat of any sort, but they are fast and maneuverable enough to get out of harm's way if attacked by a larger, slower ship. Although they are typically armed, they have enough space for only one weapon, which is the origin of the popular phrase, "as useless as a blaster cannon on a shuttlecraft."`
 
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #4707 

## Fix Details
Jame's transport intro mission includes James giving the player instructions that "if they want to be safer, they should sell their gun." There are three options for resolving this:
A) give the shuttle a blaster
B) change Jame's dialogue to specify that the player should *avoid* buying a gun, rather than telling them to sell the one they have.
C) remove that section of dialogue entirely.

This PR is option A.

Note: Only one of option A or B should be implemented. When one is merged, the other should be closed. Option [B can be found here.](https://github.com/endless-sky/endless-sky/pull/4709)