### PR TITLE
Bugfix: Add additional status parameter to scan rings emplace_back.

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -737,7 +737,7 @@ void Engine::Step(bool isActive)
 		double width = max(target->Width(), target->Height());
 		Point pos = target->Position() - center;
 		statuses.emplace_back(pos, flagship->OutfitScanFraction(), flagship->CargoScanFraction(),
-			10. + max(20., width * .5), 2, Angle(pos).Degrees() + 180.);
+			0, 10. + max(20., width * .5), 2, Angle(pos).Degrees() + 180.);
 	}
 	// Handle any events that change the selected ships.
 	if(groupSelect >= 0)


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #4729

## Fix Details
PR #4513 adds an additional parameter to the statuses constructor, but the scan rings still needed to be updated. This PR adds the additional parameter also for the scan rings.

## Tests executed
Performed an in-system flight performing a scan (with and without status overlays)
- The overlay rings show up properly.
- The scan rings show up properly.

## Save File
Not provided, but any game with a flagship with cargo and/or outfit scanners can be used to verify.
