### PR TITLE
Updating Ember Waste Wormholes so they will be used by fleets

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -24767,7 +24767,6 @@ planet "Ember Reaches"
 planet "Ember Threshold"
 	attributes "requires: quantum keystone"
 	description ""
-	spaceport ""
 
 planet "Ember Wormhole"
 	attributes "requires: quantum keystone"

--- a/data/map.txt
+++ b/data/map.txt
@@ -26330,6 +26330,7 @@ planet Relic
 planet "Remnant Wormhole"
 	attributes "requires: quantum keystone"
 	description ""
+	spaceport ""
 
 planet "Remote Blue"
 	attributes kimek urban

--- a/data/map.txt
+++ b/data/map.txt
@@ -24762,14 +24762,17 @@ planet "Elek Kartanu"
 planet "Ember Reaches"
 	attributes "requires: quantum keystone"
 	description ""
+	spaceport ""
 
 planet "Ember Threshold"
 	attributes "requires: quantum keystone"
 	description ""
+	spaceport ""
 
 planet "Ember Wormhole"
 	attributes "requires: quantum keystone"
 	description ""
+	spaceport ""
 
 planet "Esayaku Fen"
 	attributes korath


### PR DESCRIPTION
**Content**

## Summary
This change adds `spaceport ""` to the attributes for all the internal Ember Waste and Remnant wormholes. As such, NPCs and Fleets that have the appropriate Key Stones should at least occasionally use the wormholes to exit the system instead of simply jumping back wherever they came from. 

Thanks to RightHand on the ES Discord for noticing this.

edit: This has been modified so that it only applies to those wormholes *within* the Ember Waste. It does not change the Ember Threshold, so NPCs should still ignore it.