### PR TITLE
Adding a spaceport to Wormhole Alpha and reworking containing systems

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -417,7 +417,6 @@ government "Wanderer"
 
 # A dummy government used to prevent Hai from entering the wormhole in Waypoint/Ultima Thule, but allowing human merchants and other governments to enter.
 government "Wormhole Alpha"
-	color .4 .4 .4
 	"attitude toward"
 		"Hai" -.01
 		"Hai (Unfettered)" -.01

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -419,5 +419,5 @@ government "Wanderer"
 government "Wormhole Alpha"
 	color .4 .4 .4
 	"attitude toward"
-		"Hai" -.3
-		"Hai (Unfettered)" -.3
+		"Hai" -.01
+		"Hai (Unfettered)" -.01

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -90,6 +90,7 @@ government "Hai"
 	
 	"player reputation" 0
 	"attitude toward"
+		" Hai " 1
 		"Hai (Unfettered)" -.1
 		"Merchant" .01
 	"bribe" .02
@@ -104,6 +105,7 @@ government " Hai "
 	
 	"player reputation" 0
 	"attitude toward"
+		"Hai" 1
 		"Hai (Unfettered)" -.1
 		"Merchant" .01
 	"bribe" .02

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -403,4 +403,4 @@ government "Wormhole Alpha"
 	color .4 .4 .4
 	"attitude toward"
 		"Hai" -.3
-		"Hai (Unfettered" -.3
+		"Hai (Unfettered)" -.3

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -98,6 +98,20 @@ government "Hai"
 	"hostile hail" "hostile hai"
 	"hostile disabled hail" "hostile disabled hai"
 
+government " Hai "
+	swizzle 0
+	color .84 .42 .81
+	
+	"player reputation" 0
+	"attitude toward"
+		"Hai (Unfettered)" -.1
+		"Merchant" .01
+	"bribe" .02
+	"friendly hail" "friendly hai"
+	"friendly disabled hail" "friendly disabled hai"
+	"hostile hail" "hostile hai"
+	"hostile disabled hail" "hostile disabled hai"
+
 government "Hai (Unfettered)"
 	swizzle 4
 	color .69 .33 .82

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -399,6 +399,7 @@ government "Wanderer"
 	"hostile hail" "wanderer untranslated"
 	"hostile disabled hail" "wanderer untranslated"
 
+# A dummy government used to prevent Hai from entering the wormhole in Waypoint/Ultima Thule, but allowing human merchants and other governments to enter.
 government "Wormhole Alpha"
 	color .4 .4 .4
 	"attitude toward"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -398,3 +398,9 @@ government "Wanderer"
 	"friendly disabled hail" "wanderer untranslated"
 	"hostile hail" "wanderer untranslated"
 	"hostile disabled hail" "wanderer untranslated"
+
+government "Wormhole Alpha"
+	color .4 .4 .4
+	"attitude toward"
+		"Hai" -.3
+		"Hai (Unfettered" -.3

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -1452,7 +1452,7 @@ mission "Pirate Troubles [4]"
 		"reputation: Hai" += 40
 	
 	npc save accompany
-		government "Hai"
+		government " Hai "
 		personality escort
 		fleet
 			names "hai"

--- a/data/map.txt
+++ b/data/map.txt
@@ -27341,6 +27341,7 @@ planet Winter
 		fleet "Large Militia" 5
 
 planet "Wormhole Alpha"
+	government "Wormhole Alpha"
 	description ""
 	spaceport ""
 

--- a/data/map.txt
+++ b/data/map.txt
@@ -26330,6 +26330,7 @@ planet Relic
 planet "Remnant Wormhole"
 	attributes "requires: quantum keystone"
 	description ""
+	spaceport ""
 
 planet "Remote Blue"
 	attributes kimek urban

--- a/data/map.txt
+++ b/data/map.txt
@@ -26330,7 +26330,6 @@ planet Relic
 planet "Remnant Wormhole"
 	attributes "requires: quantum keystone"
 	description ""
-	spaceport ""
 
 planet "Remote Blue"
 	attributes kimek urban

--- a/data/map.txt
+++ b/data/map.txt
@@ -27343,6 +27343,7 @@ planet Winter
 
 planet "Wormhole Alpha"
 	description ""
+	spaceport ""
 
 planet "Wyvern Station"
 	attributes rim station

--- a/data/map.txt
+++ b/data/map.txt
@@ -23155,8 +23155,7 @@ system Waypoint
 	trade Medical 745
 	trade Metal 478
 	trade Plastic 452
-	fleet "Small Hai" 1200
-	fleet "Large Hai" 2500
+	fleet "Small Hai" 1000
 	fleet "Small Human Merchants (Hai)" 18000
 	fleet "Large Human Merchants (Hai)" 28000
 	object


### PR DESCRIPTION
## Summary
This PR adds a spaceport to Wormhole Alpha. Enabling NPCs and fleets that spawn in Waypoint to land on the wormhole.

Thanks to @Zitchas for suggesting this, as I only thought of doing it for the Remnant wormholes in #4737 