### PR TITLE
Make fast-forward key configurable

### DIFF
--- a/keys.txt
+++ b/keys.txt
@@ -19,6 +19,7 @@
 "View star map" 109
 "View player info" 105
 "Toggle fullscreen" 1073741892
+"Toggle fast-forward" 1073741881
 "Fleet: Fight my target" 102
 "Fleet: Gather around me" 103
 "Fleet: Hold position" 104

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -61,12 +61,13 @@ const Command Command::CLOAK(1uL << 17, "Toggle cloaking device");
 const Command Command::MAP(1uL << 18, "View star map");
 const Command Command::INFO(1uL << 19, "View player info");
 const Command Command::FULLSCREEN(1uL << 20, "Toggle fullscreen");
-const Command Command::FIGHT(1uL << 21, "Fleet: Fight my target");
-const Command Command::GATHER(1uL << 22, "Fleet: Gather around me");
-const Command Command::HOLD(1uL << 23, "Fleet: Hold position");
-const Command Command::AMMO(1uL << 24, "Fleet: Toggle ammo usage");
-const Command Command::WAIT(1uL << 25, "");
-const Command Command::STOP(1ul << 26, "");
+const Command Command::FASTFORWARD(1uL << 21, "Toggle fast-forward");
+const Command Command::FIGHT(1uL << 22, "Fleet: Fight my target");
+const Command Command::GATHER(1uL << 23, "Fleet: Gather around me");
+const Command Command::HOLD(1uL << 24, "Fleet: Hold position");
+const Command Command::AMMO(1uL << 25, "Fleet: Toggle ammo usage");
+const Command Command::WAIT(1uL << 26, "");
+const Command Command::STOP(1ul << 27, "");
 
 
 

--- a/source/Command.h
+++ b/source/Command.h
@@ -50,6 +50,7 @@ public:
 	static const Command MAP;
 	static const Command INFO;
 	static const Command FULLSCREEN;
+	static const Command FASTFORWARD;
 	// Escort commands:
 	static const Command FIGHT;
 	static const Command GATHER;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -298,7 +298,7 @@ void PreferencesPanel::DrawControls()
 		"Navigation",
 		"Weapons",
 		"Targeting",
-		"Menus",
+		"Interface",
 		"Fleet"
 	};
 	const string *category = CATEGORIES;
@@ -361,7 +361,7 @@ void PreferencesPanel::DrawControls()
 			bool isEditing = (index == editing);
 			if(isConflicted || isEditing)
 			{
-				table.SetHighlight(66, 120);
+				table.SetHighlight(56, 120);
 				table.DrawHighlight(isEditing ? dim: red);
 			}
 			
@@ -369,7 +369,7 @@ void PreferencesPanel::DrawControls()
 			bool isHovering = (index == hover && !isEditing);
 			if(!isHovering && index == selected)
 			{
-				table.SetHighlight(-120, 64);
+				table.SetHighlight(-120, 54);
 				table.DrawHighlight(back);
 			}
 			

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -327,6 +327,7 @@ void PreferencesPanel::DrawControls()
 		Command::MAP,
 		Command::INFO,
 		Command::FULLSCREEN,
+		Command::FASTFORWARD,
 		Command::NONE,
 		Command::DEPLOY,
 		Command::FIGHT,

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -314,7 +314,7 @@ int main(int argc, char *argv[])
 					else
 						SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
 				}
-				else if(event.type == SDL_KEYDOWN
+				else if(event.type == SDL_KEYDOWN && !event.key.repeat
 					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))
 				{
 					isFastForward = !isFastForward;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -124,6 +124,7 @@ int main(int argc, char *argv[])
 		Preferences::Load();
 		Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
 		bool isFullscreen = Preferences::Has("fullscreen");
+		bool isFastForward = false;
 		if(isFullscreen)
 			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 		else if(Preferences::Has("maximized"))
@@ -313,6 +314,11 @@ int main(int argc, char *argv[])
 					else
 						SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
 				}
+				else if(event.type == SDL_KEYDOWN
+					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))
+				{
+					isFastForward = !isFastForward;
+				}
 				else if(activeUI.Handle(event))
 				{
 					// No need to do anything more!
@@ -335,38 +341,37 @@ int main(int argc, char *argv[])
 			// Tell all the panels to step forward, then draw them.
 			((!isPaused && menuPanels.IsEmpty()) ? gamePanels : menuPanels).StepAll();
 			
-			// Caps lock slows the frame rate in debug mode, but raises it in
-			// normal mode. Slowing eases in and out over a couple of frames.
-			bool fastForward = false;
-			if((mod & KMOD_CAPS) && inFlight)
+			// Caps lock slows the frame rate in debug mode.
+			// Slowing eases in and out over a couple of frames.
+			if((mod & KMOD_CAPS) && inFlight && debugMode)
 			{
-				if(debugMode)
+				if(frameRate > 10)
 				{
-					if(frameRate > 10)
-					{
-						frameRate = max(frameRate - 5, 10);
-						timer.SetFrameRate(frameRate);
-					}
+					frameRate = max(frameRate - 5, 10);
+					timer.SetFrameRate(frameRate);
 				}
-				else
+			}
+			else
+			{
+				if(frameRate < 60)
 				{
-					fastForward = true;
+					frameRate = min(frameRate + 5, 60);
+					timer.SetFrameRate(frameRate);
+				}
+				
+				if(isFastForward && inFlight)
+				{
 					skipFrame = (skipFrame + 1) % 3;
 					if(skipFrame)
 						continue;
 				}
-			}
-			else if(frameRate < 60)
-			{
-				frameRate = min(frameRate + 5, 60);
-				timer.SetFrameRate(frameRate);
 			}
 			
 			Audio::Step();
 			// Events in this frame may have cleared out the menu, in which case
 			// we should draw the game panels instead:
 			(menuPanels.IsEmpty() ? gamePanels : menuPanels).DrawAll();
-			if(fastForward)
+			if(isFastForward)
 				SpriteShader::Draw(SpriteSet::Get("ui/fast forward"), Screen::TopLeft() + Point(10., 10.));
 			
 			SDL_GL_SwapWindow(window);


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #2738

## Feature Details
This PR makes the fast-forward key configurable. It does not make using Caps Lock for low framerate in debug mode configurable, however.

This would be helpful for people using Caps Lock as a compose, layout switch, or second escape key.
It also makes the fast-forward feature easier to discover.

The fact that Caps Lock still toggles low framerate in debug mode means that one can use fast-forward in conjunction with it, for example to reproduce a bug which occurs only after some time.

(Note: It would be nice if the keybinding is listed in [the manual](https://github.com/endless-sky/endless-sky/wiki/PlayersManual#key-bindings-and-shortcuts), even if this PR is not merged)

## UI Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/5276727/72220562-7c7b3700-355a-11ea-8e51-fe37a5687d4e.png) | ![image](https://user-images.githubusercontent.com/5276727/72220592-c3692c80-355a-11ea-9b39-2149b6bcd29d.png) |

(Setting below "Toggle Fullscreen")

## Usage Examples
N/A