### PR TITLE
(Urgent) fix for New Pilot crash

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2283,9 +2283,15 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 	}
 	
 	// Store conditions for flagship current crew, required crew, and bunks.
-	conditions["flagship crew"] = flagship->Crew();
-	conditions["flagship required crew"] = flagship->RequiredCrew();
-	conditions["flagship bunks"] = flagship->Attributes().Get("bunks");
+	if(flagship) {
+	  conditions["flagship crew"] = flagship->Crew();
+	  conditions["flagship required crew"] = flagship->RequiredCrew();
+	  conditions["flagship bunks"] = flagship->Attributes().Get("bunks");
+	} else {
+	  conditions["flagship crew"] = 0;
+	  conditions["flagship required crew"] = 0;
+	  conditions["flagship bunks"] = 0;
+	}
 	
 	// Conditions for your fleet's attractiveness to pirates:
 	pair<double, double> factors = RaidFleetFactors();


### PR DESCRIPTION
**Urgent Bugfix**: Fixes issue  #4750.  The game crashes on new pilot creation due to dereferencing a null pointer to the flagship.  The fix sets the flagship bunks, crew, and required crew to 0 when no flagship exists.

This is an ***urgent*** fix.  It is presently impossible to create a new pilot.