### PR TITLE
resume jump/board/land autopilot when movement keys are released

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1608,7 +1608,7 @@ void Engine::HandleKeyboardInputs()
 	++landKeyInterval;
 	if(oldHeld.Has(Command::LAND))
 		landKeyInterval = 0;
-
+	
 	// If maneuvering keys were released, and none are still held, reinstate autopilot
 	// commands if any are still requested:
 	if(!keyHeld.Has(manueveringCommands) && oldHeld.Has(manueveringCommands))

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1604,20 +1604,20 @@ void Engine::HandleKeyboardInputs()
 		Command::FORWARD | Command::LEFT | Command::RIGHT | Command::BACK | Command::AFTERBURNER);
 
 	// Are any movement keys held?
-	bool movementCommands=keyHeld.Has(Command::AFTERBURNER | Command::BACK | Command::FORWARD |
+	bool movementKeys=keyHeld.Has(Command::AFTERBURNER | Command::BACK | Command::FORWARD |
 			Command::LEFT | Command::RIGHT);
 
 	// Were any movement keys held in the previous step?
-	bool oldMovementCommands=oldHeld.Has(Command::AFTERBURNER | Command::BACK | Command::FORWARD |
+	bool oldMovementKeys=oldHeld.Has(Command::AFTERBURNER | Command::BACK | Command::FORWARD |
 			Command::LEFT | Command::RIGHT);
 
-	if(!movementCommands && oldMovementCommands)
+	if(!movementKeys && oldMovementKeys)
 	{
 		// Player has released all movement keys since the last step, so
 		// reinstate autopilot commands.
 		activeCommands |= keyHeld.And(Command::JUMP | Command::BOARD | Command::LAND);
 
-		// Make sure we do not switching landing targets:
+		// Make sure we do not switch landing targets:
 		landKeyInterval = 9999;
 	}
 	else if(oldHeld.Has(Command::LAND))


### PR DESCRIPTION
Resolves #4755.
Conflicts with #4745; awareness of full stop must be added to this change.

Implements this behavior:

1. Press J, B, or L to begin an autopilot action. (Or whatever you've assigned jump, board, and land.)
2. Hold down the button; do not release
3. Use movement keys. This cancels autopilot, as expected.
4. Stop using movement keys.
5. Autopilot resumes its action because J, B, or L are still pressed.

Previously, in step 5, the button was ignored.

