### PR TITLE
fix: CI: Don't run apt update on ubuntu runners

### DIFF
--- a/.github/workflows/build_parse.yml
+++ b/.github/workflows/build_parse.yml
@@ -49,9 +49,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons ccache
+      run: sudo apt-get install libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons ccache
     - name: Cache ccache
       uses: actions/cache@v1.1.0
       with:


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue raised by [this action run](https://github.com/endless-sky/endless-sky/pull/4411/checks?check_run_id=408031429).

## Fix Details
Specifically, the run failed because `sudo apt-get update` was called, while Microsoft's repository was apparently taking a nap or something. This appears to be a [frequent issue](https://github.com/dotnet/core-setup/issues/7778#issuecomment-523518122), which isn't nice for test runners that should be as reliable as possible.

Subsequently, @petervdmeer rightfully questioned running `apt update` in the first place:
> I also wonder why you would need to run apt-get update inside the job. At the size that Github is operating I would expect images to be automatically generated daily or hourly with an up-to-date apt-cache.

Can't argue with that. Here's to more stable Ubuntu builds.