### PR TITLE
fix: CI: Prevent usage of microsoft's ubuntu repos

### DIFF
--- a/.github/workflows/build_parse.yml
+++ b/.github/workflows/build_parse.yml
@@ -50,6 +50,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
+        # Microsoft Repos (for dotnet, azure-cli etc.) frequently cause issues (https://github.com/dotnet/core-setup/issues/7778#issuecomment-523518122), and we don't need them anyways
+        for apt_file in `grep -lr packages.microsoft.com /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
         sudo apt-get update
         sudo apt-get install libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons ccache
     - name: Cache ccache


### PR DESCRIPTION
... As they can cause runs to fail at any time, see
https://github.com/dotnet/core-setup/issues/7778#issuecomment-523518122
https://github.com/endless-sky/endless-sky/pull/4756#issuecomment-578366139

**Bugfix:** This PR addresses an issue raised by [this action run](https://github.com/endless-sky/endless-sky/pull/4411/checks?check_run_id=408031429).

Refs #4757.

## Fix Details
The run failed because `sudo apt-get update` was called, while Microsoft's repository was apparently taking a nap or something. This appears to be a [frequent issue](https://github.com/dotnet/core-setup/issues/7778#issuecomment-523518122), which isn't nice for test runners that should be as reliable as possible.

This PR removes all package lists using `packages.microsoft.com` at runtime. Specifically, those are lists for `dotnet`, `azure-cli` and `microsoft-prod`(??). All reside in the `/etc/apt/sources.list.d/` folder, and are thus deemed "optional" lists, e.g. they don't contain essential ubuntu packages.
