### PR TITLE
Added Wanderer Mission that leads to Wanderers: Defend Vara Ke'sok

### DIFF
--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -408,7 +408,7 @@ mission "Wanderers: Defend Vara Ke'sok Hint"
 				`	"We only do those jobs to get paid."`
 					goto jerk
 			label war
-			`	"Ambassador Sayari mentioned you are great [hero, explorer] in Human space, and solved many [issues, disasters]. Or are we mistaken?"`
+			`	"Ambassador Sayari mentioned you are great [hero, explorer] in human space, and solved many [issues, disasters]. Or are we mistaken?"`
 				goto choice2
 			label hai
 			`	"Ambassador Sayari mentioned you are great [hero, explorer], even in Hai space, and solved many [issues, disasters]. Or are we mistaken?"`

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -378,9 +378,9 @@ mission "Tell Wanderers about the Pug"
 
 mission "Wanderers: Defend Vara Ke'sok Hint"
 	name "Wanderer supplies to <planet>"
-	description "Transport <cargo> to <system>, where repairs are needed from Unfettered attacks."
+	description "Transport <cargo> to <destination>, where repairs are needed from Unfettered attacks."
 	passengers 1
-	cargo "building supplies" 20
+	cargo "building supplies" 10
 	source 
 		near "Sich'ka'ara" 1 100
 	destination "Vara Ke'sok"
@@ -393,15 +393,38 @@ mission "Wanderers: Defend Vara Ke'sok Hint"
 			`Walking around the spaceport, you are approached by two Wanderers. One of them begins speaking in the Hai language, which your translator picks up. "Greetings, [stranger, curiosity]. We heard you perform [charitable, heroic] acts. Is this correct?"`
 			choice
 				`	"Yes it is. What do you need?"`
-				`	"That sounds like me."`
-				`	"How much are you willing to pay?"`
+					goto proposal
+				`	"Depends on how much you are willing to pay."`
 					goto jerk
-			`	The speaking Wanderer nods in approval.`
-				goto proposal
+				`	"Where did you hear that from?"`
+			branch hai
+				"reputation: Hai" > 100
+			branch war
+				has "main plot completed"
+			`	"Ambassador Sayari mentioned humans do many [jobs, hobbies] in their space. Or are we mistaken?"`
+			choice
+				`	"Humans aren't too altruistic, but I'd be happy to help."`
+					goto proposal
+				`	"We only do those jobs to get paid."`
+					goto jerk
+			label war
+			`	"Ambassador Sayari mentioned you are great [hero, explorer] in Human space, and solved many [issues, disasters]. Or are we mistaken?"`
+				goto choice2
+			label hai
+			`	"Ambassador Sayari mentioned you are great [hero, explorer], even in Hai space, and solved many [issues, disasters]. Or are we mistaken?"`
+				goto choice2
+			label choice2
+			choice
+				`	"I guess I could be considered a hero."
+					goto proposal
+				`	"Calling me a great hero would be an understatement."`
+					goto proposal
+				`	"That's me, but I would prefer some payment as well."`
+					goto jerk
 			label jerk
 			`	The speaking Wanderer looks at you with a blank expression, and simply says, "There can be [compensation, arrangements] of <payment> for the work.`
 			label proposal
-			`	"At the [body, planet] named Vara Ke'sok, there are [raids, plundering] by Unfettered that take place. During these, various structures get [damaged, hurt]. We wish you to help [fix, mend] these by carrying <tons> of [supplies, materials]."`
+			`	"At the [body, planet] named Vara Ke'sok, there are [raids, conquests] by Unfettered that take place. During these, various structures get [damaged, hurt]. We wish you to help [fix, mend] these by carrying <tons> of [supplies, materials]."`
 			choice
 				`	"I'd be happy to do that."`
 				`	"Sorry, but I have more important matters to attend to."`
@@ -413,7 +436,6 @@ mission "Wanderers: Defend Vara Ke'sok Hint"
 	on complete
 		payment 10000 20
 		conversation
-			`Touching down onto the planet, several Wanderers gather around your ship and prepare to carry the cargo out of your ship. Before the Wanderer you transported to <planet> can say a word, a shrill bird cry fills the air..."`
 
 
 mission "Wanderers: Defend Vara Ke'sok"
@@ -425,12 +447,15 @@ mission "Wanderers: Defend Vara Ke'sok"
 		or
 			random < 50
 			has "Wanderers: Defend Vara Ke'sok Hint: done"
+			and
+				not "Wanderers: Defend Vara Ke'sok Hint: active"
 	on offer
 		conversation
 			branch hint
 				has "Wanderers: Defend Vara Ke'sok Hint: done"
 			`Soon after you land in the spaceport, there is a flurry of activity as many of the Wanderers fly to their ships, which begin to take off from the planet. In the sky, you see bright flashes that may be distant weapons fire or explosions.`
 			`	You are buffeted by wind as one of the Wanderers lands next to your ship and says, in the Hai language, "Unfettered [raider, pirate] fleet comes. We have put food on freighter, hope they take [offering, gift] and leave. If not [appeased, satisfied] you help convince them to leave. Yes?"`
+			label choice
 			choice
 				`	"Yes, I will help drive the Unfettered away."`
 					goto yes
@@ -441,10 +466,10 @@ mission "Wanderers: Defend Vara Ke'sok"
 			`	The Wanderer leaves to join one of the ships that is taking off, and you quickly ready your own ship to follow...`
 				launch
 			label hint
-			`Looking around, you suddenly see a flurry of activity as many of the Wanderers fly to their ships, which begin to take off from the planet. In the sky, you see bright flashes that may be distant weapons fire or explosions.`
-			`	The Wanderer that tasked you to carry the construction materials speaks up. "Unfettered [raider, pirate] fleet comes. We will put food on freighter, hope they take [offering, gift] and leave. If not [appeased, satisfied] you help convince them to leave."`
-			`	The Wanderer leaves to gather food for the freighter, and you quickly ready your own ship for take-off...`
-				launch
+			`Touching down onto the planet, several Wanderers gather around your ship and prepare to carry the cargo out of your ship. Before the Wanderer you transported to <planet> can say a word, a shrill bird cry fills the air."`
+			`	Looking around, you suddenly see a flurry of activity as many of the Wanderers fly to their ships, which begin to take off from the planet. In the sky, you see bright flashes that may be distant weapons fire or explosions.`
+			`	The Wanderer that tasked you to carry the construction materials speaks up. "Unfettered [raider, pirate] fleet comes. We will put food on freighter, hope they take [offering, gift] and leave. If not [appeased, satisfied] you help convince them to leave. Yes?"`
+				goto choice
 	on accept
 		"reputation: Hai (Unfettered)" <?= -1
 		event "Sich'ka'ara empty"

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -417,7 +417,7 @@ mission "Wanderers: Defend Vara Ke'sok Hint"
 			choice
 				`	"I guess I could be considered a hero."`
 					goto proposal
-				`	"Calling me a great hero would be an understatement."`
+				`	"Calling me a 'great' hero would be an understatement."`
 					goto proposal
 				`	"That's me, but I would prefer some payment as well."`
 					goto jerk

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -415,7 +415,7 @@ mission "Wanderers: Defend Vara Ke'sok Hint"
 				goto choice2
 			label choice2
 			choice
-				`	"I guess I could be considered a hero."
+				`	"I guess I could be considered a hero."`
 					goto proposal
 				`	"Calling me a great hero would be an understatement."`
 					goto proposal

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -403,7 +403,7 @@ mission "Wanderers: Defend Vara Ke'sok Hint"
 				has "main plot completed"
 			`	"Ambassador Sayari mentioned humans do many [jobs, hobbies] in their space. Or are we mistaken?"`
 			choice
-				`	"Humans aren't too altruistic, but I'd be happy to help."`
+				`	"Indeed we do."`
 					goto proposal
 				`	"We only do those jobs to get paid."`
 					goto jerk
@@ -453,6 +453,11 @@ mission "Wanderers: Defend Vara Ke'sok"
 				has "Wanderers: Defend Vara Ke'sok Hint: done"
 			`Soon after you land in the spaceport, there is a flurry of activity as many of the Wanderers fly to their ships, which begin to take off from the planet. In the sky, you see bright flashes that may be distant weapons fire or explosions.`
 			`	You are buffeted by wind as one of the Wanderers lands next to your ship and says, in the Hai language, "Unfettered [raider, pirate] fleet comes. We have put food on freighter, hope they take [offering, gift] and leave. If not [appeased, satisfied] you help convince them to leave. Yes?"`
+				goto choice
+			label hint
+			`Touching down onto the planet, several Wanderers gather around your ship and prepare to carry the cargo out of your ship. Before the Wanderer you transported to <planet> can say a word, a shrill bird cry fills the air."`
+			`	Looking around, you suddenly see a flurry of activity as many of the Wanderers fly to their ships, which begin to take off from the planet. In the sky, you see bright flashes that may be distant weapons fire or explosions.`
+			`	The Wanderer that tasked you to carry the construction materials speaks up. "Unfettered [raider, pirate] fleet comes. We will put food on freighter, hope they take [offering, gift] and leave. If not [appeased, satisfied] you help convince them to leave. Yes?"`
 			label choice
 			choice
 				`	"Yes, I will help drive the Unfettered away."`
@@ -463,11 +468,6 @@ mission "Wanderers: Defend Vara Ke'sok"
 			label yes
 			`	The Wanderer leaves to join one of the ships that is taking off, and you quickly ready your own ship to follow...`
 				launch
-			label hint
-			`Touching down onto the planet, several Wanderers gather around your ship and prepare to carry the cargo out of your ship. Before the Wanderer you transported to <planet> can say a word, a shrill bird cry fills the air."`
-			`	Looking around, you suddenly see a flurry of activity as many of the Wanderers fly to their ships, which begin to take off from the planet. In the sky, you see bright flashes that may be distant weapons fire or explosions.`
-			`	The Wanderer that tasked you to carry the construction materials speaks up. "Unfettered [raider, pirate] fleet comes. We will put food on freighter, hope they take [offering, gift] and leave. If not [appeased, satisfied] you help convince them to leave. Yes?"`
-				goto choice
 	on accept
 		"reputation: Hai (Unfettered)" <?= -1
 		event "Sich'ka'ara empty"

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -376,6 +376,45 @@ mission "Tell Wanderers about the Pug"
 				decline
 
 
+mission "Wanderers: Defend Vara Ke'sok Hint"
+	name "Wanderer supplies to <planet>"
+	description "Transport <cargo> to <system>, where repairs are needed from Unfettered attacks."
+	passengers 1
+	cargo "building supplies" 20
+	source 
+		near "Sich'ka'ara" 1 100
+	destination "Vara Ke'sok"
+	to offer
+		random < 60
+		has "Wanderers Conversation: offered"
+		not "Wanderers: Defend Vara Ke'sok: done"
+	on offer
+		conversation
+			`Walking around the spaceport, you are approached by two Wanderers. One of them begins speaking in the Hai language, which your translator picks up. "Greetings, [stranger, curiosity]. We heard you perform [charitable, heroic] acts. Is this correct?"`
+			choice
+				`	"Yes it is. What do you need?"`
+				`	"That sounds like me."`
+				`	"How much are you willing to pay?"`
+					goto jerk
+			`	The speaking Wanderer nods in approval.`
+				goto proposal
+			label jerk
+			`	The speaking Wanderer looks at you with a blank expression, and simply says, "There can be [compensation, arrangements] of <payment> for the work.`
+			label proposal
+			`	"At the [body, planet] named Vara Ke'sok, there are [raids, plundering] by Unfettered that take place. During these, various structures get [damaged, hurt]. We wish you to help [fix, mend] these by carrying <tons> of [supplies, materials]."`
+			choice
+				`	"I'd be happy to do that."`
+				`	"Sorry, but I have more important matters to attend to."`
+					defer
+			`	When the Wanderer hears your translated response, they chatter to their friend, who nods in glee and runs off towards a nearby warehouse. "We will load the cargo into the ship soon. I will [join, accompany] you to <planet> to direct the [healing, repairs]."`
+				accept
+	on visit
+		dialog phrase "generic cargo and passenger on visit"
+	on complete
+		payment 10000 20
+		conversation
+			`Touching down onto the planet, several Wanderers gather around your ship and prepare to carry the cargo out of your ship. Before the Wanderer you transported to <planet> can say a word, a shrill bird cry fills the air..."`
+
 
 mission "Wanderers: Defend Vara Ke'sok"
 	description "Defend <planet> from an Unfettered attack by driving off or destroying the Hai ships."
@@ -383,9 +422,13 @@ mission "Wanderers: Defend Vara Ke'sok"
 	source "Vara Ke'sok"
 	to offer
 		has "Wanderers Conversation: offered"
-		random < 50
+		or
+			random < 50
+			has "Wanderers: Defend Vara Ke'sok Hint: done"
 	on offer
 		conversation
+			branch hint
+				has "Wanderers: Defend Vara Ke'sok Hint: done"
 			`Soon after you land in the spaceport, there is a flurry of activity as many of the Wanderers fly to their ships, which begin to take off from the planet. In the sky, you see bright flashes that may be distant weapons fire or explosions.`
 			`	You are buffeted by wind as one of the Wanderers lands next to your ship and says, in the Hai language, "Unfettered [raider, pirate] fleet comes. We have put food on freighter, hope they take [offering, gift] and leave. If not [appeased, satisfied] you help convince them to leave. Yes?"`
 			choice
@@ -396,6 +439,11 @@ mission "Wanderers: Defend Vara Ke'sok"
 				defer
 			label yes
 			`	The Wanderer leaves to join one of the ships that is taking off, and you quickly ready your own ship to follow...`
+				launch
+			label hint
+			`Looking around, you suddenly see a flurry of activity as many of the Wanderers fly to their ships, which begin to take off from the planet. In the sky, you see bright flashes that may be distant weapons fire or explosions.`
+			`	The Wanderer that tasked you to carry the construction materials speaks up. "Unfettered [raider, pirate] fleet comes. We will put food on freighter, hope they take [offering, gift] and leave. If not [appeased, satisfied] you help convince them to leave."`
+			`	The Wanderer leaves to gather food for the freighter, and you quickly ready your own ship for take-off...`
 				launch
 	on accept
 		"reputation: Hai (Unfettered)" <?= -1

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -415,7 +415,7 @@ mission "Wanderers: Defend Vara Ke'sok Hint"
 				goto choice2
 			label choice2
 			choice
-				`	"I guess I could be considered a hero."`
+				`	"I guess I could be considered a hero." `
 					goto proposal
 				`	"Calling me a 'great' hero would be an understatement."`
 					goto proposal

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -443,11 +443,10 @@ mission "Wanderers: Defend Vara Ke'sok"
 	source "Vara Ke'sok"
 	to offer
 		has "Wanderers Conversation: offered"
+		not "Wanderers: Defend Vara Ke'sok Hint: active"
 		or
 			random < 50
 			has "Wanderers: Defend Vara Ke'sok Hint: done"
-			and
-				not "Wanderers: Defend Vara Ke'sok Hint: active"
 	on offer
 		conversation
 			branch hint

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -435,7 +435,6 @@ mission "Wanderers: Defend Vara Ke'sok Hint"
 		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 10000 20
-		conversation
 
 
 mission "Wanderers: Defend Vara Ke'sok"

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -415,7 +415,7 @@ mission "Wanderers: Defend Vara Ke'sok Hint"
 				goto choice2
 			label choice2
 			choice
-				`	"I guess I could be considered a hero." `
+				`	"I guess I could be considered a hero."`
 					goto proposal
 				`	"Calling me a 'great' hero would be an understatement."`
 					goto proposal


### PR DESCRIPTION
**Content (Jobs)**

## Summary
Adds a new Wanderer mission between Wanderers Conversation and Wanderers: Defend Vara Ke'sok, to direct the player towards Wanderers: Defend Vara Ke'sok.

## Save File
This save file can be used to play through the new mission content:
[test 6.txt](https://github.com/endless-sky/endless-sky/files/4113305/test.6.txt)
Simply take off, land, and check the spaceport until you get offered the mission.