### PR TITLE
feat: CI: Run windows builds in a matrix of MinGW versions

### DIFF
--- a/.github/workflows/build_parse.yml
+++ b/.github/workflows/build_parse.yml
@@ -18,142 +18,142 @@ name: Build & Parse
 on:
   push:
     paths:
-    - 'source/**'
-    - 'data/**'
-    - 'tests/**'
-    - 'EndlessSky.xcodeproj/**'
-    - 'XCode/**'
-    - '.github/workflows/**'
-    - keys.txt
-    - SConstruct
-    - .winmake
+      - "source/**"
+      - "data/**"
+      - "tests/**"
+      - "EndlessSky.xcodeproj/**"
+      - "XCode/**"
+      - ".github/workflows/**"
+      - keys.txt
+      - SConstruct
+      - .winmake
   pull_request:
     paths:
-    - 'source/**'
-    - 'data/**'
-    - 'tests/**'
-    - 'EndlessSky.xcodeproj/**'
-    - 'XCode/**'
-    - '.github/workflows/**'
-    - keys.txt
-    - SConstruct
-    - .winmake
-
+      - "source/**"
+      - "data/**"
+      - "tests/**"
+      - "EndlessSky.xcodeproj/**"
+      - "XCode/**"
+      - ".github/workflows/**"
+      - keys.txt
+      - SConstruct
+      - .winmake
 
 jobs:
-
   build_ubuntu:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-16.04]
     env:
-        CCACHE_DIR: ./ccache/
-        CXX: ccache g++
-        ARTIFACT: endless-sky
+      CCACHE_DIR: ./ccache/
+      CXX: ccache g++
+      ARTIFACT: endless-sky
     steps:
-    - uses: actions/checkout@v2
-    - name: Restore cached artifact
-      id: cache-artifact
-      uses: actions/cache@v1.1.0
-      with: 
-        path: artifact
-        key: ${{ matrix.os }}-artifacts-${{ hashFiles('.github/workflows/**') }}-${{ hashFiles('source/**') }}-${{ hashFiles('SConstruct') }} # Any of these files will trigger a rebuild
-    - name: Move restored artifact
-      if: steps.cache-artifact.outputs.cache-hit == 'true'
-      run: mv artifact/${{ env.ARTIFACT }} .
-    - name: Install dependencies
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons ccache
-    - name: Cache ccache
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/cache@v1.1.0
-      with:
-        path: ${{ env.CCACHE_DIR }}
-        key: ${{ matrix.os }}-ccache-${{ github.repository }}-${{ github.ref }}-${{ github.sha }}
-        restore-keys: | 
-          ${{ matrix.os }}-ccache-${{ github.repository }}-${{ github.ref }}-
-          ${{ matrix.os }}-ccache-${{ github.repository }}-
-          ${{ matrix.os }}-ccache-
-    - name: Compile
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: scons -j $(nproc);
-    - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: binary-${{ matrix.os }} 
-        path: ${{ env.ARTIFACT }}
-    - name: Move artifact for caching
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        mkdir artifact
-        mv ${{ env.ARTIFACT }} artifact/
-
+      - uses: actions/checkout@v2
+      - name: Restore cached artifact
+        id: cache-artifact
+        uses: actions/cache@v1.1.0
+        with:
+          path: artifact
+          key: ${{ matrix.os }}-artifacts-${{ hashFiles('.github/workflows/**') }}-${{ hashFiles('source/**') }}-${{ hashFiles('SConstruct') }} # Any of these files will trigger a rebuild
+      - name: Move restored artifact
+        if: steps.cache-artifact.outputs.cache-hit == 'true'
+        run: mv artifact/${{ env.ARTIFACT }} .
+      - name: Install dependencies
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: |
+          sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons ccache
+      - name: Cache ccache
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        uses: actions/cache@v1.1.0
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ matrix.os }}-ccache-${{ github.repository }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.os }}-ccache-${{ github.repository }}-${{ github.ref }}-
+            ${{ matrix.os }}-ccache-${{ github.repository }}-
+            ${{ matrix.os }}-ccache-
+      - name: Compile
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: scons -j $(nproc);
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: binary-${{ matrix.os }}
+          path: ${{ env.ARTIFACT }}
+      - name: Move artifact for caching
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: |
+          mkdir artifact
+          mv ${{ env.ARTIFACT }} artifact/
 
   build_windows:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-latest]
+        mingw: [4.8.5, 8.1.0]
     env:
-        SCCACHE_DIR: ./sccache/
-        DIR_MINGW64: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32
-        DIR_ESLIB: .\dev64
-        CXX: sccache g++
-        ARTIFACT: EndlessSky.exe 
+      SCCACHE_DIR: ./sccache/
+      DIR_MINGW64: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32
+      DIR_ESLIB: .\dev64
+      CXX: sccache g++
+      ARTIFACT: EndlessSky.exe
     steps:
-    - uses: actions/checkout@v2
-    - name: Restore cached artifact
-      id: cache-artifact
-      uses: actions/cache@v1.1.0
-      with:
-        path: artifact
-        key: ${{ matrix.os }}-artifacts-${{ hashFiles('.github/workflows/**') }}-${{ hashFiles('source/**') }}-${{ hashFiles('.winmake') }} # Any of these files will trigger a rebuild
-    - name: Move restored artifact
-      if: steps.cache-artifact.outputs.cache-hit == 'true'
-      run: mv artifact/${{ env.ARTIFACT }} .
-    - name: Install dependencies
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: choco install sccache
-    - name: Fetch development libraries
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        Invoke-WebRequest https://endless-sky.github.io/win64-dev.zip -OutFile win64-dev.zip
-        Expand-Archive win64-dev.zip -DestinationPath . -Force
-        Remove-Item win64-dev.zip
-    - name: Cache sccache
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/cache@v1.1.0
-      with:
-        path: ${{ env.SCCACHE_DIR }}
-        key: ${{ matrix.os }}-sccache-${{ github.repository }}-${{ github.ref }}-${{ github.sha }}
-        restore-keys: |
-          ${{ matrix.os }}-sccache-${{ github.repository }}-${{ github.ref }}-
-          ${{ matrix.os }}-sccache-${{ github.repository }}-
-          ${{ matrix.os }}-sccache
-    - name: Compile
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        make -e -f .winmake -j ($(Get-CIMInstance -Class 'CIM_Processor').NumberOfLogicalProcessors)
-        COPY .\bin\pkgd\EndlessSky.exe EndlessSky.exe
-        COPY ".\dev64\bin\*.dll" .
-        COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libgcc_s_seh-1.dll .
-        COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libstdc++-6.dll .
-        COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libwinpthread-1.dll .
-    - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: binary-${{ matrix.os }}
-        path: ${{ env.ARTIFACT }}
-    - name: Move artifact for caching
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        MD artifact
-        MOVE ${{ env.ARTIFACT }} artifact/
-
+      - uses: actions/checkout@v2
+      - name: Restore cached artifact
+        id: cache-artifact
+        uses: actions/cache@v1.1.0
+        with:
+          path: artifact
+          key: ${{ matrix.os }}-mingw${{ matrix.mingw }}-artifacts-${{ hashFiles('.github/workflows/**') }}-${{ hashFiles('source/**') }}-${{ hashFiles('.winmake') }} # Any of these files will trigger a rebuild
+      - name: Move restored artifact
+        if: steps.cache-artifact.outputs.cache-hit == 'true'
+        run: mv artifact/${{ env.ARTIFACT }} .
+      - name: Install sccache
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: choco install sccache
+      - name: Install MinGW
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: choco install -y --no-progress --allow-downgrade mingw --version=${{ matrix.mingw }}
+      - name: Fetch development libraries
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: |
+          Invoke-WebRequest https://endless-sky.github.io/win64-dev.zip -OutFile win64-dev.zip
+          Expand-Archive win64-dev.zip -DestinationPath . -Force
+          Remove-Item win64-dev.zip
+      - name: Cache sccache
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        uses: actions/cache@v1.1.0
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ matrix.os }}-mingw${{ matrix.mingw }}-sccache-${{ github.repository }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.os }}-mingw${{ matrix.mingw }}-sccache-${{ github.repository }}-${{ github.ref }}-
+            ${{ matrix.os }}-mingw${{ matrix.mingw }}-sccache-${{ github.repository }}-
+            ${{ matrix.os }}-mingw${{ matrix.mingw }}-sccache
+      - name: Compile
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: |
+          make -e -f .winmake -j ($(Get-CIMInstance -Class 'CIM_Processor').NumberOfLogicalProcessors)
+          COPY .\bin\pkgd\EndlessSky.exe EndlessSky.exe
+          COPY ".\dev64\bin\*.dll" .
+          COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libgcc_s_seh-1.dll .
+          COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libstdc++-6.dll .
+          COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libwinpthread-1.dll .
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: binary-${{ matrix.os }}-mingw${{ matrix.mingw }}
+          path: ${{ env.ARTIFACT }}
+      - name: Move artifact for caching
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: |
+          MD artifact
+          MOVE ${{ env.ARTIFACT }} artifact/
 
   build_macos:
     runs-on: ${{ matrix.os }}
@@ -163,40 +163,39 @@ jobs:
     env:
       ARTIFACT: EndlessSky.app.tar
     steps:
-    - uses: actions/checkout@v2
-    - name: Restore cached artifact
-      id: cache-artifact
-      uses: actions/cache@v1.1.0
-      with: 
-        path: artifact
-        key: ${{ matrix.os }}-artifacts-${{ hashFiles('.github/workflows/**') }}-${{ hashFiles('source/**') }}-${{ hashFiles('EndlessSky.xcodeproj/**') }} # Any of these files will trigger a rebuild
-    - name: Move restored artifact
-      if: steps.cache-artifact.outputs.cache-hit == 'true'
-      run: mv artifact/${{ env.ARTIFACT }} .
-    - name: Install dependencies
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        brew update
-        brew install libmad libpng jpeg-turbo sdl2
-    - name: Compile
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: xcodebuild -configuration "Release" -jobs $(sysctl -n hw.logicalcpu) -quiet install
-    - name: Archive artifact
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd /tmp/EndlessSky.dst/Applications/
-        tar -cf $GITHUB_WORKSPACE/${{ env.ARTIFACT }} "Endless Sky.app"
-    - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: app-${{ matrix.os }}
-        path: ${{ env.ARTIFACT }}
-    - name: Move artifact for caching
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        mkdir artifact
-        mv ${{ env.ARTIFACT }} artifact/
-
+      - uses: actions/checkout@v2
+      - name: Restore cached artifact
+        id: cache-artifact
+        uses: actions/cache@v1.1.0
+        with:
+          path: artifact
+          key: ${{ matrix.os }}-artifacts-${{ hashFiles('.github/workflows/**') }}-${{ hashFiles('source/**') }}-${{ hashFiles('EndlessSky.xcodeproj/**') }} # Any of these files will trigger a rebuild
+      - name: Move restored artifact
+        if: steps.cache-artifact.outputs.cache-hit == 'true'
+        run: mv artifact/${{ env.ARTIFACT }} .
+      - name: Install dependencies
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: |
+          brew update
+          brew install libmad libpng jpeg-turbo sdl2
+      - name: Compile
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: xcodebuild -configuration "Release" -jobs $(sysctl -n hw.logicalcpu) -quiet install
+      - name: Archive artifact
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: |
+          cd /tmp/EndlessSky.dst/Applications/
+          tar -cf $GITHUB_WORKSPACE/${{ env.ARTIFACT }} "Endless Sky.app"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: app-${{ matrix.os }}
+          path: ${{ env.ARTIFACT }}
+      - name: Move artifact for caching
+        if: steps.cache-artifact.outputs.cache-hit != 'true'
+        run: |
+          mkdir artifact
+          mv ${{ env.ARTIFACT }} artifact/
 
   test_ubuntu:
     runs-on: ${{ matrix.os }}
@@ -205,47 +204,49 @@ jobs:
         os: [ubuntu-latest, ubuntu-16.04]
     needs: build_ubuntu
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons ccache
-    - name: Download artifact
-      uses: actions/download-artifact@v1.0.0
-      with:
-        name: binary-${{ matrix.os }}
-        path: .
-    - name: Execute test_parse
-      run: |
-        chmod +x endless-sky
-        ./tests/test_parse.sh ./endless-sky
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons ccache
+      - name: Download artifact
+        uses: actions/download-artifact@v1.0.0
+        with:
+          name: binary-${{ matrix.os }}
+          path: .
+      - name: Execute test_parse
+        run: |
+          chmod +x endless-sky
+          ./tests/test_parse.sh ./endless-sky
 
   test_windows:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-latest]
+        mingw: [4.8.5, 8.1.0]
     needs: build_windows
     steps:
-    - uses: actions/checkout@v2
-    - name: Fetch development libraries
-      run: |
-        Invoke-WebRequest https://endless-sky.github.io/win64-dev.zip -OutFile win64-dev.zip
-        Expand-Archive win64-dev.zip -DestinationPath . -Force
-        Remove-Item win64-dev.zip
-        COPY ".\dev64\bin\*.dll" .
-        COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libgcc_s_seh-1.dll .
-        COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libstdc++-6.dll .
-        COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libwinpthread-1.dll .
-    - name: Download artifact
-      uses: actions/download-artifact@v1.0.0
-      with:
-        name: binary-${{ matrix.os }}
-        path: .
-    - name: Execute test_parse
-      run: .\tests\test_parse.ps1 EndlessSky.exe
-
+      - uses: actions/checkout@v2
+      - name: Install MinGW
+        run: choco install -y --no-progress --allow-downgrade mingw --version=${{ matrix.mingw }}
+      - name: Fetch development libraries
+        run: |
+          Invoke-WebRequest https://endless-sky.github.io/win64-dev.zip -OutFile win64-dev.zip
+          Expand-Archive win64-dev.zip -DestinationPath . -Force
+          Remove-Item win64-dev.zip
+          COPY ".\dev64\bin\*.dll" .
+          COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libgcc_s_seh-1.dll .
+          COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libstdc++-6.dll .
+          COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libwinpthread-1.dll .
+      - name: Download artifact
+        uses: actions/download-artifact@v1.0.0
+        with:
+          name: binary-${{ matrix.os }}-mingw${{ matrix.mingw }}
+          path: .
+      - name: Execute test_parse
+        run: .\tests\test_parse.ps1 EndlessSky.exe
 
   test_macos:
     runs-on: ${{ matrix.os }}
@@ -254,19 +255,19 @@ jobs:
         os: [macos-latest]
     needs: build_macos
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        brew update
-        brew install libmad libpng jpeg-turbo sdl2
-    - name: Download artifact
-      uses: actions/download-artifact@v1.0.0
-      with:
-        name: app-${{ matrix.os }}
-        path: .
-    - name: Extract artifact
-      run: tar -xf EndlessSky.app.tar
-    - name: Execute test_parse
-      run: |
-        chmod +x "./Endless Sky.app/Contents/MacOS/Endless Sky"
-        ./tests/test_parse.sh "./Endless Sky.app/Contents/MacOS/Endless Sky"
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install libmad libpng jpeg-turbo sdl2
+      - name: Download artifact
+        uses: actions/download-artifact@v1.0.0
+        with:
+          name: app-${{ matrix.os }}
+          path: .
+      - name: Extract artifact
+        run: tar -xf EndlessSky.app.tar
+      - name: Execute test_parse
+        run: |
+          chmod +x "./Endless Sky.app/Contents/MacOS/Endless Sky"
+          ./tests/test_parse.sh "./Endless Sky.app/Contents/MacOS/Endless Sky"


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in discord:
> Mco, thoughts on having the windows builds also matrixed out over the various g++ versions, going back to the first with support for c++11? Seems like something we would want to do, but maybe not for every commit. Mostly because these various versions of MinGW also mean various versions of the c++ libs

## Feature Details
With this PR, instead of one Windows build, there are now 2, for MingW latest and v4.8.5 (as found on [chocolatey](https://chocolatey.org/packages/mingw)).

It also reformts the YAML file to align with - what appears to be - the YAML "standard", e.g. most formatters will produce this or something very similar.