### PR TITLE
consider completion conditions when coloring missions in map panel

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -636,10 +636,11 @@ bool Mission::CanComplete(const PlayerInfo &player) const
 // bright or dim text colors.
 bool Mission::IsSatisfied(const PlayerInfo &player) const
 {
-	if(!toComplete.Test(player.Conditions()))
+	if(!waypoints.empty() || !stopovers.empty())
 		return false;
 	
-	if(!waypoints.empty() || !stopovers.empty())
+	// Test the completion conditions for this mission.
+	if(!toComplete.Test(player.Conditions()))
 		return false;
 	
 	// Determine if any fines or outfits that must be transferred, can.

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -627,9 +627,6 @@ bool Mission::CanComplete(const PlayerInfo &player) const
 	if(player.GetPlanet() != destination)
 		return false;
 	
-	if(!toComplete.Test(player.Conditions()))
-		return false;
-	
 	return IsSatisfied(player);
 }
 
@@ -639,6 +636,9 @@ bool Mission::CanComplete(const PlayerInfo &player) const
 // bright or dim text colors.
 bool Mission::IsSatisfied(const PlayerInfo &player) const
 {
+	if(!toComplete.Test(player.Conditions()))
+		return false;
+	
 	if(!waypoints.empty() || !stopovers.empty())
 		return false;
 	


### PR DESCRIPTION
As described in #4765, the map panel only runs basic checks in `Mission::IsSatisfied` and never checks the actual completion conditions. That causes some missions to be displayed as being able to complete, even though they can't.

This fix moves the test of completion conditions from `Mission::CanComplete` into `Mission::IsSatisfied` (which is called by `Mission::CanComplete`).  

A consequence of this is that we cannot lie to the player about the completion conditions quite so easily.