### PR TITLE
feat(government): Allow customization of the government's displayed name

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -113,6 +113,7 @@ government "Hai"
 	"hostile disabled hail" "hostile disabled hai"
 
 government " Hai "
+	"display name" "Hai"
 	swizzle 0
 	color .84 .42 .81
 	
@@ -202,6 +203,7 @@ government "Ka'het"
 	"player reputation" -1
 
 government " Ka'het "
+	"display name" "Ka'het"
 	swizzle 0
 	language "Ka'het"
 

--- a/data/hai missions.txt
+++ b/data/hai missions.txt
@@ -1288,6 +1288,7 @@ government "Scar's Legion"
 	"hostile hail" "hostile pirate"
 
 government " Scar's Legion "
+	"display name" "Scar's Legion"
 	swizzle 6
 	color .78 0 0
 	"player reputation" -1000

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -802,6 +802,7 @@ event "remnant: gascraft"
 		add shipyard "Remnant Gascraft"
 
 government " Drak "
+	"display name" "Drak"
 	swizzle 5
 	"player reputation" -1000
 	"attitude toward"

--- a/data/wanderers middle.txt
+++ b/data/wanderers middle.txt
@@ -1053,6 +1053,7 @@ mission "Wanderers: Mind 5"
 
 
 government " Kor Mereti "
+	"display name" "Kor Mereti"
 	swizzle 5
 	language "Korath"
 	"attitude toward"

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -251,7 +251,7 @@ void GameData::CheckReferences()
 		if(!it.second.GetGovernment() && !deferred["fleet"].count(it.first))
 			Files::LogError("Warning: fleet \"" + it.first + "\" is referred to, but never defined.");
 	for(const auto &it : governments)
-		if(it.second.GetName().empty() && !deferred["government"].count(it.first))
+		if(it.second.GetTrueName().empty() && !deferred["government"].count(it.first))
 			Files::LogError("Warning: government \"" + it.first + "\" is referred to, but never defined.");
 	for(const auto &it : minables)
 		if(it.second.Name().empty())
@@ -269,7 +269,7 @@ void GameData::CheckReferences()
 		if(it.second.Name().empty())
 			Files::LogError("Warning: phrase \"" + it.first + "\" is referred to, but never defined.");
 	for(const auto &it : planets)
-		if(it.second.Name().empty() && !deferred["planet"].count(it.first))
+		if(it.second.TrueName().empty() && !deferred["planet"].count(it.first))
 			Files::LogError("Warning: planet \"" + it.first + "\" is referred to, but never defined.");
 	for(const auto &it : ships)
 		if(it.second.ModelName().empty())

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -50,11 +50,17 @@ Government::Government()
 void Government::Load(const DataNode &node)
 {
 	if(node.Size() >= 2)
+	{
 		name = node.Token(1);
+		if(displayName.empty())
+			displayName = name;
+	}
 	
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "swizzle" && child.Size() >= 2)
+		if(child.Token(0) == "display name" && child.Size() >= 2)
+			displayName = child.Token(1);
+		else if(child.Token(0) == "swizzle" && child.Size() >= 2)
 			swizzle = child.Value(1);
 		else if(child.Token(0) == "color" && child.Size() >= 4)
 			color = Color(child.Value(1), child.Value(2), child.Value(3));
@@ -134,8 +140,16 @@ void Government::Load(const DataNode &node)
 
 
 
-// Get the name of this government.
+// Get the display name of this government.
 const string &Government::GetName() const
+{
+	return displayName;
+}
+
+
+
+// Get the name used for this government in the data files.
+const string &Government::GetTrueName() const
 {
 	return name;
 }

--- a/source/Government.h
+++ b/source/Government.h
@@ -45,8 +45,10 @@ public:
 	// Load a government's definition from a file.
 	void Load(const DataNode &node);
 	
-	// Get the name of this government.
+	// Get the display name of this government.
 	const std::string &GetName() const;
+	// Get the name used for this government in the data files.
+	const std::string &GetTrueName() const;
 	// Get the color swizzle to use for ships of this government.
 	int GetSwizzle() const;
 	// Get the color to use for displaying this government on the map.
@@ -117,6 +119,7 @@ public:
 private:
 	unsigned id;
 	std::string name;
+	std::string displayName;
 	int swizzle = 0;
 	Color color;
 	

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -181,7 +181,7 @@ void LocationFilter::Save(DataWriter &out) const
 			out.BeginChild();
 			{
 				for(const Government *government : governments)
-					out.Write(government->GetName());
+					out.Write(government->GetTrueName());
 			}
 			out.EndChild();
 		}

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -204,7 +204,7 @@ void NPC::Save(DataWriter &out) const
 			out.Write("accompany");
 		
 		if(government)
-			out.Write("government", government->GetName());
+			out.Write("government", government->GetTrueName());
 		personality.Save(out);
 		
 		if(!dialogText.empty())


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4767 

## Feature Details
 - Adds a government keyword `"display name"`
 - Defaults the display name to the name used in the data files
 - Updates `Government::GetName()` to return the display name
 - Adds `Government::GetTrueName()` for places where the datafile token is required.
 - Updates the current governments that use spaces to have the targeted display name