### PR TITLE
refactor: Require a new press to exit a conversation or select a choice

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -206,7 +206,7 @@ bool ConversationPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comm
 	if(node < 0)
 	{
 		// If the conversation has ended, the only possible action is to exit.
-		if(key == SDLK_RETURN || key == SDLK_KP_ENTER)
+		if(isNewPress && (key == SDLK_RETURN || key == SDLK_KP_ENTER))
 		{
 			Exit();
 			return true;
@@ -266,7 +266,7 @@ bool ConversationPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comm
 		--choice;
 	else if(key == SDLK_DOWN && choice < conversation.Choices(node) - 1)
 		++choice;
-	else if((key == SDLK_RETURN || key == SDLK_KP_ENTER) && choice < conversation.Choices(node))
+	else if((key == SDLK_RETURN || key == SDLK_KP_ENTER) && isNewPress && choice < conversation.Choices(node))
 		Goto(conversation.NextNode(node, choice), choice);
 	else if(key >= '1' && key < static_cast<SDL_Keycode>('1' + choices.size()))
 		Goto(conversation.NextNode(node, key - '1'), key - '1');


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4718 

## Feature Details
Since conversations are more important than dialogs, don't let the player accidentally skip through them just because they were holding return to close a number of dialogs that appeared.

The easiest way to verify the behavior is to compare the "new pilot" process. Enter your character's name, then hold Enter. On `master`, the post-name panel will close shortly after it is accepted. With this PR, you must release Enter and press it again.