### PR TITLE
Add script that checks if the Xcode project is complete.

### DIFF
--- a/.github/workflows/build_parse.yml
+++ b/.github/workflows/build_parse.yml
@@ -120,6 +120,9 @@ jobs:
       run: |
         brew update
         brew install libmad libpng jpeg-turbo sdl2
+    - name: Try fixing XCode entries if required
+      run: |
+        ./tests/try_xcode_fix.sh
     - name: Compile
       run: xcodebuild -configuration "Release" -jobs $(sysctl -n hw.logicalcpu) install
     - name: Execute test_parse

--- a/tests/try_xcode_fix.sh
+++ b/tests/try_xcode_fix.sh
@@ -36,10 +36,19 @@ do
 				exit 1
 			fi
 		fi
+		# Run XcodeProjAdder and print exit-code.
+		./Xcode-Proj-Adder/bin/XcodeProjAdder \
+			-XCP ${ESTOP}/EndlessSky.xcodeproj/project.pbxproj \
+			-SCSV "../source/${FILE}"
+		echo "XcodeProjAdder ran with result $0"
+		# Check if the requested file was added
+		cat EndlessSky.xcodeproj/project.pbxproj | grep "$FILE" > /dev/null
+		if [ $? -eq 0 ]
+		then
+			echo "Error: file ${FILE} not added to XCode project"
+			exit 1
+		fi
 		NUM_ADDED=$(( NUM_ADDED + 1 ))
-		#./Xcode-Proj-Adder/bin/XcodeProjAdder \
-		#	-XCP ${ESTOP}/EndlessSky.xcodeproj/project.pbxproj \
-		#	-SSCV "../source/${FILE}"
 	fi
 done
 

--- a/tests/try_xcode_fix.sh
+++ b/tests/try_xcode_fix.sh
@@ -21,7 +21,7 @@ for FILE in $(ls -1 source)
 do
 	echo "Checking ${FILE}"
 	# Check if the file is already in the XCode project
-	cat EndlessSky.xcodeproj/project.pbxproj | grep --silent "$FILE"
+	cat EndlessSky.xcodeproj/project.pbxproj | grep "$FILE"
 	if [ $? -ne 0 ] && [ "$FILE" != "WinApp.rc" ]
 	then
 		echo "File $FILE is missing from XCode-project"

--- a/tests/try_xcode_fix.sh
+++ b/tests/try_xcode_fix.sh
@@ -12,10 +12,6 @@ ESTOP=$(pwd)
 echo "script-dir: ${HERE}"
 echo "es-top-dir: ${ESTOP}"
 
-
-# Checkout helper script for adding Xcode/project files if they are missing
-#git clone https://github.com/zackslash/Xcode-Proj-Adder.git
-
 NUM_ADDED=0
 for FILE in $(ls -1 source)
 do
@@ -25,6 +21,21 @@ do
 	if [ $? -ne 0 ] && [ "$FILE" != "WinApp.rc" ]
 	then
 		echo "File $FILE is missing from XCode-project"
+		if [ ! -d Xcode-Proj-Adder ]
+		then
+			echo "Cloning Xcode-Proj-Adder project"
+			git clone https://github.com/zackslash/Xcode-Proj-Adder.git
+			if [ $? -ne 0 ]
+			then
+				echo "Error: Cloning failed"
+				exit 1
+			fi
+			if [ ! -f ./Xcode-Proj-Adder/bin/XcodeProjAdder ]
+			then
+				echo "Error: Xcode-adder missing"
+				exit 1
+			fi
+		fi
 		NUM_ADDED=$(( NUM_ADDED + 1 ))
 		#./Xcode-Proj-Adder/bin/XcodeProjAdder \
 		#	-XCP ${ESTOP}/EndlessSky.xcodeproj/project.pbxproj \
@@ -35,7 +46,7 @@ done
 if [ ${NUM_ADDED} -gt 0 ]
 then
 	echo "You should add ${NUM_ADDED} files"
-	echo "The Xcode project file now contains:"
+	echo "An example of the project file after adding the missing files:"
 	echo ""
 	cat EndlessSky.xcodeproj/project.pbxproj
 	echo ""

--- a/tests/try_xcode_fix.sh
+++ b/tests/try_xcode_fix.sh
@@ -46,7 +46,7 @@ do
 		if [ $? -ne 0 ]
 		then
 			echo "Error: file ${FILE} not added to XCode project"
-			exit 1
+			#exit 1
 		fi
 		NUM_ADDED=$(( NUM_ADDED + 1 ))
 	fi

--- a/tests/try_xcode_fix.sh
+++ b/tests/try_xcode_fix.sh
@@ -21,7 +21,7 @@ for FILE in $(ls -1 source)
 do
 	echo "Checking ${FILE}"
 	# Check if the file is already in the XCode project
-	cat EndlessSky.xcodeproj/project.pbxproj | grep "$FILE"
+	cat EndlessSky.xcodeproj/project.pbxproj | grep "$FILE" > /dev/null
 	if [ $? -ne 0 ] && [ "$FILE" != "WinApp.rc" ]
 	then
 		echo "File $FILE is missing from XCode-project"

--- a/tests/try_xcode_fix.sh
+++ b/tests/try_xcode_fix.sh
@@ -9,12 +9,17 @@ cd ..
 
 ESTOP=$(pwd)
 
+echo "script-dir: ${HERE}"
+echo "es-top-dir: ${ESTOP}"
+
+
 # Checkout helper script for adding Xcode/project files if they are missing
 #git clone https://github.com/zackslash/Xcode-Proj-Adder.git
 
 NUM_ADDED=0
 for FILE in $(ls -1 source)
 do
+	echo "Checking ${FILE}"
 	# Check if the file is already in the XCode project
 	cat EndlessSky.xcodeproj/project.pbxproj | grep --silent "$FILE"
 	if [ $? -ne 0 ] && [ "$FILE" != "WinApp.rc" ]

--- a/tests/try_xcode_fix.sh
+++ b/tests/try_xcode_fix.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Determine path of the current script
+HERE=$(cd `dirname $0` && pwd)
+
+# Go to toplevel ES directory
+cd ${HERE}
+cd ..
+
+ESTOP=$(pwd)
+
+# Checkout helper script for adding Xcode/project files if they are missing
+#git clone https://github.com/zackslash/Xcode-Proj-Adder.git
+
+NUM_ADDED=0
+for FILE in $(ls -1 source)
+do
+	# Check if the file is already in the XCode project
+	cat EndlessSky.xcodeproj/project.pbxproj | grep --silent "$FILE"
+	if [ $? -ne 0 ] && [ "$FILE" != "WinApp.rc" ]
+	then
+		echo "File $FILE is missing from XCode-project"
+		NUM_ADDED=$(( NUM_ADDED + 1 ))
+		#./Xcode-Proj-Adder/bin/XcodeProjAdder \
+		#	-XCP ${ESTOP}/EndlessSky.xcodeproj/project.pbxproj \
+		#	-SSCV "../source/${FILE}"
+	fi
+done
+
+if [ ${NUM_ADDED} -gt 0 ]
+then
+	echo "You should add ${NUM_ADDED} files"
+	echo "The Xcode project file now contains:"
+	echo ""
+	cat EndlessSky.xcodeproj/project.pbxproj
+	echo ""
+fi

--- a/tests/try_xcode_fix.sh
+++ b/tests/try_xcode_fix.sh
@@ -38,12 +38,12 @@ do
 		fi
 		# Run XcodeProjAdder and print exit-code.
 		./Xcode-Proj-Adder/bin/XcodeProjAdder \
-			-XCP ${ESTOP}/EndlessSky.xcodeproj/project.pbxproj \
+			-XCP ${ESTOP}/EndlessSky.xcodeproj \
 			-SCSV "../source/${FILE}"
-		echo "XcodeProjAdder ran with result $0"
+		echo "XcodeProjAdder ran with result $?"
 		# Check if the requested file was added
 		cat EndlessSky.xcodeproj/project.pbxproj | grep "$FILE" > /dev/null
-		if [ $? -eq 0 ]
+		if [ $? -ne 0 ]
 		then
 			echo "Error: file ${FILE} not added to XCode project"
 			exit 1

--- a/tests/try_xcode_fix.sh
+++ b/tests/try_xcode_fix.sh
@@ -46,6 +46,8 @@ do
 		if [ $? -ne 0 ]
 		then
 			echo "Error: file ${FILE} not added to XCode project"
+			echo "Files and directories present:"
+			ls
 			#exit 1
 		fi
 		NUM_ADDED=$(( NUM_ADDED + 1 ))


### PR DESCRIPTION
**Feature:** This PR adds some scripting to help deal with missing source-files in the XCode-project.

## Feature Details
Intended usage is that if the MacOS compilation fails, then the script as provided in this PR would run to add the missing XCode files and print the fix in the output-logs for the PR owner to apply.

## UI Screenshots
N/A

## Usage Examples
Add some source-code files, then notice them missing for MacOS and copy the entries as printed in the MacOS Github actions to the proper sections in the XCode project to make sure the code also compiles for MacOS.
