### PR TITLE
Only handle Engine keyboard inputs when the game is not paused

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -276,7 +276,7 @@ void AI::IssueMoveTarget(const PlayerInfo &player, const Point &target, const Sy
 
 
 // Commands issued via the keyboard (mostly, to the flagship).
-void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands, bool isActive)
+void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 {
 	shift = (SDL_GetModState() & KMOD_SHIFT);
 	escortsUseAmmo = Preferences::Has("Escorts expend ammo");
@@ -294,7 +294,7 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands, bool isActive)
 	}
 	const Ship *flagship = player.Flagship();
 	
-	if(!isActive || !flagship || flagship->IsDestroyed())
+	if(!flagship || flagship->IsDestroyed())
 		return;
 	
 	// Only toggle the "cloak" command if one of your ships has a cloaking device.

--- a/source/AI.h
+++ b/source/AI.h
@@ -54,7 +54,7 @@ template <class Type>
 	void IssueShipTarget(const PlayerInfo &player, const std::shared_ptr<Ship> &target);
 	void IssueMoveTarget(const PlayerInfo &player, const Point &target, const System *moveToSystem);
 	// Commands issued via the keyboard (mostly, to the flagship).
-	void UpdateKeys(PlayerInfo &player, Command &clickCommands, bool isActive);
+	void UpdateKeys(PlayerInfo &player, Command &clickCommands);
 	
 	// Allow the AI to track any events it is interested in.
 	void UpdateEvents(const std::list<ShipEvent> &events);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -433,10 +433,10 @@ void Engine::Step(bool isActive)
 			--jumpCount;
 	}
 	ai.UpdateEvents(events);
-	if(isActive)
+	if(isActive && wasActive)
 	{
 		HandleKeyboardInputs();
-		ai.UpdateKeys(player, activeCommands, isActive && wasActive);
+		ai.UpdateKeys(player, activeCommands);
 	}
 	wasActive = isActive;
 	Audio::Update(center);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -433,8 +433,11 @@ void Engine::Step(bool isActive)
 			--jumpCount;
 	}
 	ai.UpdateEvents(events);
-	HandleKeyboardInputs();
-	ai.UpdateKeys(player, activeCommands, isActive && wasActive);
+	if(isActive)
+	{
+		HandleKeyboardInputs();
+		ai.UpdateKeys(player, activeCommands, isActive && wasActive);
+	}
 	wasActive = isActive;
 	Audio::Update(center);
 	


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue regarding Engine keyboard input reading while the game is paused (as reported on Discord)

## Fix Details
The engine is continuously running (at 60 fps), even when the game is paused, to ensure that functions like drawing of the main flight screen are continuously active.

Some functions like movement of ships, movement of projectiles and player commands to his/her flagship and fleet should however be suspended when the engine is not active.

This PR changes the reading of keyboard inputs to only register those inputs when the game is not paused.

## Testing
I didn't have time yet to extensively test this PR; it needs some more testing before we can merge this.