### PR TITLE
FW license

### DIFF
--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -2020,11 +2020,21 @@ mission "Defend Sabik"
 	on complete
 		dialog `The Navy has been driven off, but at a great cost. You should probably visit the spaceport and see if Tomek is there, or someone else who can tell you what to do next.`
 
-mission "FWCarrier License"
+mission "FW License"
 	invisible
 	landing
 	to offer
 		has "event: joined the free worlds"
 	on offer
-		set "license: Militia Carrier"
+		set "license: Militia"
+		fail
+
+mission "FW License Fix"
+	invisible
+	landing
+	to offer
+		has "license: Militia Carrier"
+	on offer
+		set "license: Militia"
+		clear "license: Militia Carrier"
 		fail

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1901,6 +1901,9 @@ mission "Defend Sabik"
 	
 	on offer
 		set "license: Militia"
+		"salary: Free Worlds" = 300
+		event "start of hostilities"
+		event "joined the free worlds"
 		conversation
 			`When you land on <planet>, you discover that Tomek has already found transportation here; he meets you almost as soon as your ship lands. When you step out of the hatch alone, without Katya, he turns away in grief. "I'm sorry," you say, "I couldn't locate her. The whole place is under guard."`
 			`	"Very well," he says, "we'll have to hope that she's still hidden there somewhere. In the meantime, we need to make your allegiance official so that you can fight alongside us if it comes to that."`
@@ -1918,11 +1921,6 @@ mission "Defend Sabik"
 			`	An hour later you are in the bar celebrating your new employment when emergency sirens start blaring. Someone runs into the bar and says, "The Navy has entered the system. What do we do?"`
 			`	Tomek says, "We can't let them take this system, or they'll have us completely bottled up. This is where it begins. We need to fight. Get to your ships, quickly! But if you can, disable their ships instead of destroying them. These are Navy ships after all, and most of them don't want war any more than we do." You hurry to join all the other ships taking off to defend the system.`
 				launch
-		
-		"salary: Free Worlds" = 300
-		event "start of hostilities"
-		event "joined the free worlds"
-	
 	on accept
 		log "Officially joined the Free Worlds. Helping to defend Sabik, which is now under attack by the Navy. This Free Worlds work may mean getting involved in a lot more battles like this one."
 	

--- a/data/free worlds intro.txt
+++ b/data/free worlds intro.txt
@@ -1900,6 +1900,7 @@ mission "Defend Sabik"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
+		set "license: Militia"
 		conversation
 			`When you land on <planet>, you discover that Tomek has already found transportation here; he meets you almost as soon as your ship lands. When you step out of the hatch alone, without Katya, he turns away in grief. "I'm sorry," you say, "I couldn't locate her. The whole place is under guard."`
 			`	"Very well," he says, "we'll have to hope that she's still hidden there somewhere. In the meantime, we need to make your allegiance official so that you can fight alongside us if it comes to that."`
@@ -2019,15 +2020,6 @@ mission "Defend Sabik"
 		dialog `You've landed on <planet>, but there are still Navy ships circling overhead. You should take off and help finish them off.`
 	on complete
 		dialog `The Navy has been driven off, but at a great cost. You should probably visit the spaceport and see if Tomek is there, or someone else who can tell you what to do next.`
-
-mission "FW License"
-	invisible
-	landing
-	to offer
-		has "event: joined the free worlds"
-	on offer
-		set "license: Militia"
-		fail
 
 mission "FW License Fix"
 	invisible

--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -419,10 +419,10 @@ outfit "Carrier License"
 	thumbnail "outfit/carrier license"
 	description "Only a handful of people in the past century have been given permission to purchase a Navy Carrier, even a decommissioned one, for private use."
 
-outfit "Militia Carrier License"
+outfit "Militia License"
 	category "Special"
 	thumbnail "outfit/militia license"
-	description "Officially joined the Free Worlds. Received permission to purchase their Militia-only carriers."
+	description "Officially joined the Free Worlds. Received permission to purchase their Militia-only ships."
 
 outfit "City-Ship License"
 	category "Special"

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1135,6 +1135,8 @@ ship "Dreadnought"
 	thumbnail "thumbnail/dreadnought"
 	attributes
 		category "Heavy Warship"
+		licenses
+			"Militia"
 		"cost" 11900000
 		"shields" 18100
 		"hull" 7300
@@ -2743,7 +2745,7 @@ ship "Skein"
 	attributes
 		category "Medium Warship"
 		licenses
-			"Militia Carrier"
+			"Militia"
 		"cost" 3500000
 		"shields" 3300
 		"hull" 6700


### PR DESCRIPTION
despite being their strongest ship, the Dreadnought isn't restricted by the Free Worlds' current Militia Carrier license. When new storylines roll in, I'd imagine you'd have the Dreadnought be like a Cruiser or Carrier right now, not buyable unless you did the storyline of it's faction.

this changes the Militia Carrier License to just Militia License, adjusting the description, the mission that gives it, the licenses required for both the Skein and the Dreadnought, and also adding a mission to replace the Militia Carrier License in old saves with the new one. 