### PR TITLE
Don't auto-launch after accepting Project Hawking mission

### DIFF
--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -1079,7 +1079,7 @@ mission "Deep: Project Hawking"
 			`	"Thank you, Captain. The planets that we need to go to are..." Garrison turns to the other three scientists. "<stopovers>," Hannah says.`
 			`	"... Thanks. After we've gathered all the supplies, we'll need to be dropped off on <destination>."`
 			`	You bring the scientists to your ship where they quickly make themselves comfy in the bunk rooms. As you walk to the bridge, you overhear Pierre quietly communicating with what you assume to be the spaceport authorities, "...<last> agreed. I expect 'Project Hawking' to proceed on schedule. We will arrive before <day>." As you prepare for launch, you wonder what you've just signed up for.`
-			accept
+				accept
 	
 	on visit
 		dialog `You have arrived on <planet>, but you do not have all the supplies needed for "Project Hawking". Return to <stopovers> to collect all of the required cargo.`

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -1079,6 +1079,7 @@ mission "Deep: Project Hawking"
 			`	"Thank you, Captain. The planets that we need to go to are..." Garrison turns to the other three scientists. "<stopovers>," Hannah says.`
 			`	"... Thanks. After we've gathered all the supplies, we'll need to be dropped off on <destination>."`
 			`	You bring the scientists to your ship where they quickly make themselves comfy in the bunk rooms. As you walk to the bridge, you overhear Pierre quietly communicating with what you assume to be the spaceport authorities, "...<last> agreed. I expect 'Project Hawking' to proceed on schedule. We will arrive before <day>." As you prepare for launch, you wonder what you've just signed up for.`
+			accept
 	
 	on visit
 		dialog `You have arrived on <planet>, but you do not have all the supplies needed for "Project Hawking". Return to <stopovers> to collect all of the required cargo.`

--- a/data/deep missions.txt
+++ b/data/deep missions.txt
@@ -1079,7 +1079,6 @@ mission "Deep: Project Hawking"
 			`	"Thank you, Captain. The planets that we need to go to are..." Garrison turns to the other three scientists. "<stopovers>," Hannah says.`
 			`	"... Thanks. After we've gathered all the supplies, we'll need to be dropped off on <destination>."`
 			`	You bring the scientists to your ship where they quickly make themselves comfy in the bunk rooms. As you walk to the bridge, you overhear Pierre quietly communicating with what you assume to be the spaceport authorities, "...<last> agreed. I expect 'Project Hawking' to proceed on schedule. We will arrive before <day>." As you prepare for launch, you wonder what you've just signed up for.`
-				launch
 	
 	on visit
 		dialog `You have arrived on <planet>, but you do not have all the supplies needed for "Project Hawking". Return to <stopovers> to collect all of the required cargo.`


### PR DESCRIPTION
**Content ( Missions )**

## Summary
Simple remove auto launch line from this one mission. There's no urgency in the text, and I wanted to buy commodities before I left the planet.

## Save File
This is an old change so I don't have any save files

## PR Checklist
 - [ x ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
 - [ N/A ] I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}
 - [ N/A ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}