### PR TITLE
feat: Allow some weapons to be parallel / non-converged.

### DIFF
--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -77,6 +77,10 @@ Angle Hardpoint::HarmonizedAngle() const
 	if(!outfit)
 		return Angle();
 	
+	// Weapons that fire in parallel beams don't get a harmonized angle.
+	if(outfit->IsParallel())
+		return Angle();
+	
 	// Find the point of convergence of shots fired from this gun. That is,
 	// find the angle where the projectile's X offset will be zero when it
 	// reaches the very end of its range.

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -46,6 +46,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			isPhasing = true;
 		else if(key == "no damage scaling")
 			isDamageScaled = false;
+		else if(key == "parallel")
+			isParallel = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")
@@ -214,6 +216,13 @@ void Weapon::LoadWeapon(const DataNode &node)
 bool Weapon::IsWeapon() const
 {
 	return isWeapon;
+}
+
+
+
+bool Weapon::IsParallel() const
+{
+	return isParallel;
 }
 
 

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -37,6 +37,7 @@ public:
 	// Load from a "weapon" node, either in an outfit or in a ship (explosion).
 	void LoadWeapon(const DataNode &node);
 	bool IsWeapon() const;
+	bool IsParallel() const;
 	
 	// Get assets used by this weapon.
 	const Body &WeaponSprite() const;
@@ -155,6 +156,7 @@ private:
 	bool isSafe = false;
 	bool isPhasing = false;
 	bool isDamageScaled = true;
+	bool isParallel = false;
 	
 	// Attributes.
 	int lifetime = 0;


### PR DESCRIPTION
**Feature:** This PR implements a feature to allow weapons to be parallel, non-converged

## Feature Details
This PR adds a new keyword `parallel` that can be used in outfit weapon definitions to indicate that the weapon should not get a converged focus aiming point.

The `parallel` keyword is also used for gunport angles in https://github.com/endless-sky/endless-sky/pull/4801. Intended combination of those features is that guns fire non-converged when the outfit weapon itself has the `parallel` keyword or when the port has the `parallel` keyword (or when both have the keyword).

## UI Screenshots
(The definition of the weapon used is attached)
This is a Kestrel firing a short-range weapon without parallel enabled:
![converged_short_range](https://user-images.githubusercontent.com/35403542/74561430-d495c680-4f68-11ea-848e-5f880b38aecf.png)

This is the same Kestrel firing the same short-range weapon with parallel in its definition:
![parallel_short_range](https://user-images.githubusercontent.com/35403542/74561434-d95a7a80-4f68-11ea-94ac-460e28205bf3.png)

## Usage Examples
This feature/keyword can be useful for weapons with a relatively short range and for homing missile type weapons (which don't need to converge, but which seek out their targets by themselves). See above for the short range example.

## Testing Done
Screenshots above are from two short tests of this feature. Here is the weapons data-file used for testing:
[welder_weapon.txt](https://github.com/endless-sky/endless-sky/files/4206435/welder_weapon.txt)

## Performance Impact
None expected, the angle calculation for weapons is done when a weapon is installed. Not when a weapon is fired.