### PR TITLE
Fill the default value in the save and ship rename dialogs

### DIFF
--- a/source/Dialog.h
+++ b/source/Dialog.h
@@ -50,8 +50,7 @@ template <class T>
 	Dialog(T *t, void (T::*fun)(int), const std::string &text, int initialValue);
 	
 template <class T>
-	Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text,
-			const std::string& initialValue = "");
+	Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text, std::string initialValue = "");
 	
 template <class T>
 	Dialog(T *t, void (T::*fun)(), const std::string &text);
@@ -119,12 +118,10 @@ Dialog::Dialog(T *t, void (T::*fun)(int), const std::string &text, int initialVa
 
 
 template <class T>
-Dialog::Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text,
-		const std::string& initialValue)
-	: stringFun(std::bind(fun, t, std::placeholders::_1))
+Dialog::Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text, std::string initialValue)
+	: stringFun(std::bind(fun, t, std::placeholders::_1)), input(initialValue)
 {
 	Init(text);
-	input = initialValue;
 }
 
 

--- a/source/Dialog.h
+++ b/source/Dialog.h
@@ -50,7 +50,8 @@ template <class T>
 	Dialog(T *t, void (T::*fun)(int), const std::string &text, int initialValue);
 	
 template <class T>
-	Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text);
+	Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text,
+			const std::string& initialValue = "");
 	
 template <class T>
 	Dialog(T *t, void (T::*fun)(), const std::string &text);
@@ -118,10 +119,12 @@ Dialog::Dialog(T *t, void (T::*fun)(int), const std::string &text, int initialVa
 
 
 template <class T>
-Dialog::Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text)
+Dialog::Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text,
+		const std::string& initialValue)
 	: stringFun(std::bind(fun, t, std::placeholders::_1))
 {
 	Init(text);
+	input = initialValue;
 }
 
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -198,8 +198,15 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		if(it == files.end() || it->second.empty() || it->second.front().first.size() < 4)
 			return false;
 		
+		const Date &today = player.GetDate();
+		const int year = today.Year(), month = today.Month(), day = today.Day();
+		const string &defaultFilename =
+			to_string(year) + "-" +
+			(month < 10 ? "0" : "") + to_string(month) + "-" +
+			(day < 10 ? "0" : "") + to_string(day);
 		GetUI()->Push(new Dialog(this, &LoadPanel::SnapshotCallback,
-			"Enter a name for this snapshot, or leave the name empty to use the current date:"));
+			"Enter a name for this snapshot, or leave the name empty to use the current date:",
+			defaultFilename));
 	}
 	else if(key == 'R' && !selectedFile.empty())
 	{

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -199,8 +199,10 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 			return false;
 		
 		const Date &today = player.GetDate();
-		const int year = today.Year(), month = today.Month(), day = today.Day();
-		const string &defaultFilename =
+		const int year = today.Year();
+		const int month = today.Month();
+		const int day = today.Day();
+		const string defaultFilename =
 			to_string(year) + "-" +
 			(month < 10 ? "0" : "") + to_string(month) + "-" +
 			(day < 10 ? "0" : "") + to_string(day);

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -138,7 +138,8 @@ bool ShipInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		GetUI()->Push(new PlayerInfoPanel(player));
 	}
 	else if(key == 'R' || (key == 'r' && shift))
-		GetUI()->Push(new Dialog(this, &ShipInfoPanel::Rename, "Change this ship's name?"));
+		GetUI()->Push(new Dialog(this, &ShipInfoPanel::Rename, "Change this ship's name?",
+					(*shipIt)->Name()));
 	else if(canEdit && (key == 'P' || (key == 'p' && shift)))
 	{
 		if(shipIt->get() != player.Flagship() || (*shipIt)->IsParked())

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -138,8 +138,7 @@ bool ShipInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		GetUI()->Push(new PlayerInfoPanel(player));
 	}
 	else if(key == 'R' || (key == 'r' && shift))
-		GetUI()->Push(new Dialog(this, &ShipInfoPanel::Rename, "Change this ship's name?",
-					(*shipIt)->Name()));
+		GetUI()->Push(new Dialog(this, &ShipInfoPanel::Rename, "Change this ship's name?", (*shipIt)->Name()));
 	else if(canEdit && (key == 'P' || (key == 'p' && shift)))
 	{
 		if(shipIt->get() != player.Flagship() || (*shipIt)->IsParked())


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed ~~in issue #{{insert number}}~~ below

## Feature Details
The "rename ship" dialog will start prefilled with the name of the ship, rather than empty.

The save dialog will start prefilled with the date, rather than empty. The behavior is unchanged, I think: currently if the user clicks "OK" in the save dialog when the textbox is empty, the date is used.

## UI Screenshots
The following two dialogs are affected. In master they both start with the textbox empty, the screenshot shows the new value:

![2020-02-16-184741_619x380_scrot](https://user-images.githubusercontent.com/24784687/74610644-e2745480-50ec-11ea-9e9f-f1790e668cf4.png)
![2020-02-16-184728_260x163_scrot](https://user-images.githubusercontent.com/24784687/74610645-e30ceb00-50ec-11ea-8536-3387a89fe829.png)

## Usage Examples
N/A

## Testing Done
I opened the dialogs and verified the textbox starts prefilled with the correct value, even when the day-of-month is single digit.

## Performance Impact
N/A
