### PR TITLE
Stop Mystery Cube Jobs from going to stations

### DIFF
--- a/data/deep jobs.txt
+++ b/data/deep jobs.txt
@@ -60,6 +60,7 @@ mission "Deep Mystery Cube [0]"
 	destination
 		distance 7 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
+		not attributes "station"
 	on accept
 		dialog phrase "deep mystery cube pickup"
 	on visit
@@ -90,6 +91,7 @@ mission "Deep Mystery Cube [1]"
 	destination
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
+		not attributes "station"
 	on accept
 		dialog phrase "deep mystery cube pickup"
 	on visit
@@ -120,6 +122,7 @@ mission "Deep Mystery Cube [2]"
 	destination
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
+		not attributes "station"
 	on accept
 		dialog phrase "deep mystery cube pickup"
 	on visit
@@ -179,6 +182,7 @@ mission "Mystery retrieval"
 	stopover
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
+		not attributes "station"
 	on stopover
 		dialog phrase "deep mystery cube pickup"
 	on visit

--- a/data/deep jobs.txt
+++ b/data/deep jobs.txt
@@ -195,7 +195,7 @@ mission "Deep Mystery Cube Station"
 	description "Deliver a package to <destination>. Payment is <payment>."
 	cargo "mystery package" 1
 	to offer
-		random < 5
+		random < 7
 		"combat rating" > 35
 	source
 		attributes "deep"

--- a/data/deep jobs.txt
+++ b/data/deep jobs.txt
@@ -46,25 +46,6 @@ phrase "deep mystery cube dropoff payment"
 	word
 		`Your bank account immediately notifies you that the agreed-upon payment of <payment> has been deposited. You wonder how they knew.`
 
-phrase "deep mystery cube dropoff station payment"
-	word
-		`As instructed, you`
-	word
-		` `
-	word
-		`leave the mystery cube in the second supplies cabinet you come across.`
-		`leave the mystery cube in an unscrewed air vent.`
-		`hand the cube to the thrid tourist couple you see on the station. They accept it without a word.`
-		`drop the cube into a copper trash can in the spaceport.`
-		`drop the cube into a laundry chute.`
-	word
-		``
-		` "This has to be legal, or they couldn't post it to the job board," you remind yourself.`
-	word
-		` `
-	word
-		`Your bank account immediately notifies you that the agreed-upon payment of <payment> has been deposited. You wonder how they knew.`
-
 mission "Deep Mystery Cube [0]"
 	name "Mystery delivery to <planet>"
 	job
@@ -180,37 +161,6 @@ mission "Deep Mystery Cube [3]"
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
-	npc
-		government "Bounty Hunter"
-		personality nemesis disables waiting plunders
-		system
-			distance 6 9
-		fleet "Bounty Hunters"
-
-
-mission "Deep Mystery Cube Station"
-	name "Mystery delivery to <planet>"
-	job
-	repeat
-	description "Deliver a package to <destination>. Payment is <payment>."
-	cargo "mystery package" 1
-	to offer
-		random < 7
-		"combat rating" > 35
-	source
-		attributes "deep"
-	destination
-		distance 9 20
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
-		attributes "station"
-	on accept
-		dialog phrase "deep mystery cube pickup"
-	on visit
-		dialog phrase "generic cargo on visit"
-	on complete
-		"mystery cube" ++
-		payment 5000 1000
-		dialog phrase "deep mystery cube dropoff station payment"
 	npc
 		government "Bounty Hunter"
 		personality nemesis disables waiting plunders

--- a/data/deep jobs.txt
+++ b/data/deep jobs.txt
@@ -46,6 +46,25 @@ phrase "deep mystery cube dropoff payment"
 	word
 		`Your bank account immediately notifies you that the agreed-upon payment of <payment> has been deposited. You wonder how they knew.`
 
+phrase "deep mystery cube dropoff station payment"
+	word
+		`As instructed, you`
+	word
+		` `
+	word
+		`leave the mystery cube in the second supplies cabinet you come across.`
+		`leave the mystery cube in an unscrewed air vent.`
+		`hand the cube to the thrid tourist couple you see on the station. They accept it without a word.`
+		`drop the cube into a copper trash can in the spaceport.`
+		`drop the cube into a laundry chute.`
+	word
+		``
+		` "This has to be legal, or they couldn't post it to the job board," you remind yourself.`
+	word
+		` `
+	word
+		`Your bank account immediately notifies you that the agreed-upon payment of <payment> has been deposited. You wonder how they knew.`
+
 mission "Deep Mystery Cube [0]"
 	name "Mystery delivery to <planet>"
 	job
@@ -161,6 +180,37 @@ mission "Deep Mystery Cube [3]"
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
+	npc
+		government "Bounty Hunter"
+		personality nemesis disables waiting plunders
+		system
+			distance 6 9
+		fleet "Bounty Hunters"
+
+
+mission "Deep Mystery Cube Station"
+	name "Mystery delivery to <planet>"
+	job
+	repeat
+	description "Deliver a package to <destination>. Payment is <payment>."
+	cargo "mystery package" 1
+	to offer
+		random < 5
+		"combat rating" > 35
+	source
+		attributes "deep"
+	destination
+		distance 9 20
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
+		attributes "station"
+	on accept
+		dialog phrase "deep mystery cube pickup"
+	on visit
+		dialog phrase "generic cargo on visit"
+	on complete
+		"mystery cube" ++
+		payment 5000 1000
+		dialog phrase "deep mystery cube dropoff station payment"
 	npc
 		government "Bounty Hunter"
 		personality nemesis disables waiting plunders


### PR DESCRIPTION
**Bugfix:**

## Fix Details
The wording used in the phrase "deep mystery cube dropoff payment", which is in the on complete dialog of Deep Mystery Cube jobs, assumes features specific to a planet. However, Deep Mystery Cube jobs can still have a destination of a space station, making the phrase seem out of place. This fix stops the main mystery cube jobs from choosing stations as a destination. This pr is a variant of #4827 without the replacement jobs.