### PR TITLE
Remnant: License Aquisition Options (and rejection tolerance)

### DIFF
--- a/changelog
+++ b/changelog
@@ -43,6 +43,7 @@ Version 0.9.11:
       * If the player has a jump drive and a hyperdrive installed when going to the Syndicate for a jump drive, they will no longer give you an extra jump drive. (@Amazinite)
       * Should the player have their own jump drive during Free Worlds Reconciliation, the Navy will now provide an extra escort for the unused jump drive. (@AlbertNewton)
       * Removed the Hunted by State missions, as they made playing as a pirate too punishing. (@Amazinite)
+      * The "Remnant: Broken Jump Drive" missions can be done in lieu of the "Remnant: Key Stones" missions in order to obtain a Remnant license. (@Zitchas)
     * Balance:
       * Heliarch and Coalition crew now have altered base crew attack and defense stats. (@Tadrix)
       * Gave the Pelican more engine space to better fit its description of being a fast ship. (@Zitchas)

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -824,6 +824,7 @@ mission "Remnant: Technology Available"
 			has "Remnant: Key Stones: done"
 			has "Remnant: Key Stones (Hai): done"
 			has "Remnant: Key Stones (Pre-Hai) 2: done"
+			has "Remnant: Broken Jump Drive 2: done"
 	on offer
 		payment 2000000
 		set "license: Remnant"


### PR DESCRIPTION
**Bugfix:**
Players getting stuck at the start of the Remnant storyline if they somehow miss the Keystone missions or happen to decline/abort them because they sound like a frivolous money-making scheme instead of a progression-locking mission.

## Fix Details
Adds an alternate route to meeting the requirements for the Remnant basic license. This is done by allowing the completion of the second mission in the Broken Jump Drive mission series to count in place of the Keystone missions. The second mission was chosen because while the first BJD could be triggered by chance, doing it again demonstrates that the pilot is intentionally seeking to help the Remnant. On the flip side, it doesn't force the player to complete the whole BJD set right away. (It is intended to be an optional set that affects timers and dialogues down the road, rather than an obligatory set)

Note: the pilot will still need to complete the Void Sprite and Remnant Defense mission sets. This change only allows the substitution of "Remnant: Broken Jump Drive 2: done" in place of any of the Key Stone missions.