### PR TITLE
Adding Return the Samples 2 reverse compatibility

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -1320,8 +1320,8 @@ event "remnant: return the samples timer"
 
 
 
-# Compatibility patch for those who made completed Return the Samples 2 before 0.9.11, where it did not have the timer.
-mission "Remnant Return the Samples Compatability Patch"
+# Compatibility patch for those who completed Return the Samples 2 before 0.9.11, where it did not have the timer.
+mission "Remnant Return the Samples Compatibility Patch"
 	landing
 	invisible
 	to offer

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -1320,7 +1320,7 @@ event "remnant: return the samples timer"
 
 
 
-# Compatibility patch for those who made completed Void Sprite 2 before 0.9.11, where it did not have the timer.
+# Compatibility patch for those who made completed Return the Samples 2 before 0.9.11, where it did not have the timer.
 mission "Remnant Return the Samples Compatability Patch"
 	landing
 	invisible

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -1320,6 +1320,19 @@ event "remnant: return the samples timer"
 
 
 
+# Compatibility patch for those who made completed Void Sprite 2 before 0.9.11, where it did not have the timer.
+mission "Remnant Return the Samples Compatability Patch"
+	landing
+	invisible
+	to offer
+		has "Remnant: Return the Samples 2: Done"
+		not "event: remnant: return the samples timer"
+	on offer
+		event "remnant: return the samples timer" 2
+		fail
+
+
+
 mission "Remnant: Salvage 1"
 	name "Remnant History Updates"
 	description `The Remnant are interested in learning about what has happened in human space since they left. Find a copy of human history on <destination>.`


### PR DESCRIPTION
**Bugfix:** This PR addresses the issue where players using a pilot file from before the addition of the "Return the Samples 2 timer" are unable to trigger the Face to Maw missions.

## Fix Details
This adds a small reverse compatibility mission to fix pilot files for players who completed Return the Samples 2 before it had the timer.
