### PR TITLE
Remnant: Allow gain of reputation

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -413,7 +413,7 @@ government "Remnant"
 	"player reputation" 1
 	"bribe" 0
 	"attitude toward"
-		"Indigenous Lifeform" 0.01
+		"Indigenous Lifeform" 0.05
 		"Korath" -.05
 	"penalty for"
 		assist -0.25

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -413,7 +413,12 @@ government "Remnant"
 	"player reputation" 1
 	"bribe" 0
 	"attitude toward"
-		"Korath" -.01
+		"Indigenous Lifeform" 0.01
+		"Korath" -.05
+	"penalty for"
+		assist -0.25
+		capture 5
+		destroy 5
 
 government "Republic"
 	swizzle 0

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -417,8 +417,8 @@ government "Remnant"
 		"Korath" -.05
 	"penalty for"
 		assist -0.25
-		capture 5
-		destroy 5
+		capture 10
+		destroy 10
 
 government "Republic"
 	swizzle 0

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -415,6 +415,7 @@ government "Remnant"
 	"attitude toward"
 		"Indigenous Lifeform" 0.05
 		"Korath" -.05
+		"Alpha" -.05
 	"penalty for"
 		assist -0.25
 		capture 10


### PR DESCRIPTION
Changes:
- Indigenous Lifeform added at 0.05
- Korath reduced to -0.05
- penalty for assisting increased to -0.25
- penalty for capturing or destroying increased to 10

Purpose: To allow people to gain reputation from killing the Korath (which the Remnant appreciates), and to have a positive opinion of the Indigenous Lifeforms (because the Remnant don't want the Archons to hate them any more, and they also consider indigenous lifeforms to be valuable. Thus, they will be upset when the lifeforms are killed.

Likewise, the Remnant are few in number and place a high value on survival and life. Thus a larger-than-average appreciation for their ships being repaired, and a much stronger than average hatred for their ships being captured or destroyed (both of which results in the entire crew being killed).

This does allow the Remnant to be farmed, but it is very time consuming. (by my calculations, the player would need to repair 40 disabled Albatrosses in order to balance out the negative of capturing a single Albatross. ) So I'm not very worried about it.

Compared to almost every other government, the Remnant are extremely small and focused. To them, the act of saving one ship (or destroying one enemy) is much more significant than the same would be for, say, the Republic, or the Heliarchs. These changes reflect the value that the Remnant put on their lives and the lives of their people; and allow the player to build up a reputation with the Remnant if they should happen to decide to help them.