### PR TITLE
fix: Ships hit by blast damage while targeted will be provoked

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1833,7 +1833,7 @@ void Engine::DoCollisions(Projectile &projectile)
 				if(isSafe && projectile.Target() != ship && !gov->IsEnemy(ship->GetGovernment()))
 					continue;
 				
-				int eventType = ship->TakeDamage(projectile, ship != hit.get());
+				int eventType = ship->TakeDamage(projectile, ship != hit.get(), player.Flagship());
 				if(eventType)
 					eventQueue.emplace_back(gov, ship->shared_from_this(), eventType);
 			}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2614,8 +2614,10 @@ double Ship::MaxReverseVelocity() const
 
 // This ship just got hit by the given projectile. Take damage according to
 // what sort of weapon the projectile it.
-int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
+int Ship::TakeDamage(const Projectile &projectile, bool isBlast, Ship *playerFlagship)
 {
+	// assert(!isBlast || playerFlagship);
+
 	int type = 0;
 	
 	double damageScaling = 1.;
@@ -2682,7 +2684,8 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 		type |= ShipEvent::DESTROY;
 	// If this ship was hit directly and did not consider itself an enemy of the
 	// ship that hit it, it is now "provoked" against that government.
-	if(!isBlast && projectile.GetGovernment() && !projectile.GetGovernment()->IsEnemy(government)
+	bool directHit = !isBlast || (this == &*playerFlagship->GetTargetShip());
+	if(directHit && projectile.GetGovernment() && !projectile.GetGovernment()->IsEnemy(government)
 			&& (Shields() < .9 || Hull() < .9 || !personality.IsForbearing())
 			&& !personality.IsPacifist() && weapon.DoesDamage())
 		type |= ShipEvent::PROVOKE;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -294,9 +294,10 @@ public:
 	// what sort of weapon the projectile it. The return value is a ShipEvent
 	// type, which may be a combination of PROVOKED, DISABLED, and DESTROYED.
 	// If isBlast, this ship was caught in the blast radius of a weapon but was
-	// not necessarily its primary target.
+	// not necessarily its primary target. In this case, playerFlagship should be
+	// set.
 	// Blast damage is dependent on the distance to the damage source.
-	int TakeDamage(const Projectile &projectile, bool isBlast = false);
+	int TakeDamage(const Projectile &projectile, bool isBlast = false, Ship *playerFlagship = nullptr);
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.
 	void ApplyForce(const Point &force);


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #4836 

## Fix Details
Ignore the `!isBlast` check when the ship being damaged is targeted

Should I uncomment the assert? I don't see any other asserts in the code (only `static_assert`) so I wasn't sure.

## Testing Done
I shot heavy rockets at an asteroid that a merchant ship was passing next to. The merchant exploded but didn't become hostile (as expected, see #1341 #821).

Then I selected a merchant, hit it directly with heavy rockets, and merchants became hostile.