### PR TITLE
Added missing copyright entries

### DIFF
--- a/copyright
+++ b/copyright
@@ -575,6 +575,27 @@ Files:
  images/ship/leviathan*
  images/ship/shuttle*
  images/ship/star?queen*
+ images/thumbnail/argosy*
+ images/thumbnail/clipper*
+ images/thumbnail/dreadnought*
+ images/thumbnail/fury*
+ images/thumbnail/hauler?i*
+ images/thumbnail/hauler?ii*
+ images/thumbnail/hauler?iii*
+ images/thumbnail/modified argosy*
+ images/thumbnail/bastion*
+ images/thumbnail/behemoth*
+ images/thumbnail/heavy?shuttle*
+ images/thumbnail/firebird*
+ images/thumbnail/leviathan*
+ images/thumbnail/shuttle*
+ images/thumbnail/star?queen*
+ images/thumbnail/boxwing*
+ images/thumbnail/nest*
+ images/thumbnail/roost*
+ images/thumbnail/skein*
+ images/thumbnail/mfirebird*
+ images/thumbnail/mleviathan*
  images/ship/localworldship*
 Copyright: Michael Zahniser <mzahniser@gmail.com>
 License: CC-BY-SA-4.0

--- a/copyright
+++ b/copyright
@@ -550,11 +550,16 @@ Files:
  images/ship/nest*
  images/ship/roost*
  images/ship/skein*
+ images/thumbnail/nest*
+ images/thumbnail/roost*
+ images/thumbnail/skein*
 Copyright: Iaz Poolar
 License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license) and detailed by Becca Tommaso (tommasobecca03@gmail.com).
 
-Files: images/ship/boxwing*
+Files:
+ images/ship/boxwing*
+ images/thumbnail/boxwing*
 Copyright: Iaz Poolar
 License: CC-BY-SA-4.0
 Comment: Detailed by Becca Tommaso (tommasobecca03@gmail.com).
@@ -590,12 +595,6 @@ Files:
  images/thumbnail/leviathan*
  images/thumbnail/shuttle*
  images/thumbnail/star?queen*
- images/thumbnail/boxwing*
- images/thumbnail/nest*
- images/thumbnail/roost*
- images/thumbnail/skein*
- images/thumbnail/mfirebird*
- images/thumbnail/mleviathan*
  images/ship/localworldship*
 Copyright: Michael Zahniser <mzahniser@gmail.com>
 License: CC-BY-SA-4.0
@@ -604,6 +603,8 @@ Comment: Detailed by Becca Tommaso (tommasobecca03@gmail.com).
 Files:
  images/ship/mfirebird*
  images/ship/mleviathan*
+ images/thumbnail/mfirebird*
+ images/thumbnail/mleviathan*
 Copyright: Maximilian Korber
 License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license) and detailed by Becca Tommaso (tommasobecca03@gmail.com).


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Apparently I forgot to properly list the thumbnail entries of the Betelgeuse and Southbound redesigns. This PR adds them, under the relative sections