### PR TITLE
Fix: Adds license requirement to the Penguin

### DIFF
--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -519,6 +519,8 @@ ship "Penguin"
 	thumbnail "thumbnail/penguin"
 	attributes
 		category "Transport"
+		licenses
+			Remnant
 		cost 2530000
 		"shields" 3000
 		"hull" 1500


### PR DESCRIPTION
**Bugfix:** 
This PR addresses the discrepancy that the penguin does not have a listed license requirement. 

It fixes it by adding the basic Remnant license as a requirement to the Penguin.
