### PR TITLE
A couple more Bulk Passenger jobs for balance and diversity

### DIFF
--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2215,7 +2215,7 @@ mission "Stranded field trip to <planet>"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 200
-		dialog `The students excitedly rush off your ship into the arms of waiting parents, the adventure was fun but they're very pleased to be safely home after so long. The school deposits <payment> into your account.`
+		dialog `The students excitedly rush off your ship into the arms of their waiting parents, the adventure was fun but they're very pleased to be safely home after so long. The school deposits <payment> into your account.`
 
 mission "Prisoners [0]"
 	name "Prisoner transport to <planet>"

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2209,7 +2209,7 @@ mission "Stranded Field Trip [0]"
 		"passenger space" > 50
 	source
 		attributes "near earth" "deep" "paradise" "tourism"
-
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		distance 4 16
 		attributes "near earth" "deep" "paradise" "urban"

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2197,7 +2197,8 @@ mission "Colonists [1]"
 		payment 10000
 		dialog "The colonists depart your ship after paying you <payment>."
 
-mission "Stranded field trip to <planet>"
+mission "Stranded Field Trip [0]"
+	name "Stranded field trip to <planet>"
 	job
 	repeat
 	description `These <bunks> school students have been stranded on an educational field trip due to the unexpected bankruptcy of their booked transport. They have the supplies to continue their studies but need to be safely returned home at some point. The school & parents have put up a reward of <payment>.`

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2197,12 +2197,12 @@ mission "Colonists [1]"
 		payment 10000
 		dialog "The colonists depart your ship after paying you <payment>."
 
-mission "Stranded Field Trip [0]"
+mission "Stranded Field Trip"
 	name "Stranded field trip to <planet>"
 	job
 	repeat
-	description `These <bunks> school students have been stranded on an educational field trip due to the unexpected bankruptcy of their booked transport. They have <tons> of school supplies with which to continue their studies, but need to be safely returned home to <destination> at some point. The school and parents have put up a reward of <payment>.`
-	passengers 20 100 .6
+	description `These <bunks> school students have been stranded on a field trip due to the unexpected bankruptcy of their booked transport. The school and parents have put up a reward of <payment> for them to be returned home to <destination>.`
+	passengers 20 4 .1
 	cargo "educational supplies" 2 10 .6
 	to offer
 		random < 10
@@ -2213,10 +2213,12 @@ mission "Stranded Field Trip [0]"
 	destination
 		distance 4 16
 		attributes "near earth" "deep" "paradise" "urban"
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 10000 200
+		payment
+		payment 10000
 		dialog `The students excitedly rush off your ship into the arms of their waiting parents. The adventure was fun, but they're very pleased to be safely home after so long. The school deposits <payment> into your account.`
 
 mission "Prisoners [0]"

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2201,7 +2201,7 @@ mission "Stranded Field Trip [0]"
 	name "Stranded field trip to <planet>"
 	job
 	repeat
-	description `These <bunks> school students have been stranded on an educational field trip due to the unexpected bankruptcy of their booked transport. They have the supplies to continue their studies but need to be safely returned home at some point. The school & parents have put up a reward of <payment>.`
+	description `These <bunks> school students have been stranded on an educational field trip due to the unexpected bankruptcy of their booked transport. They have <tons> of school supplies with which to continue their studies, but need to be safely returned home to <destination> at some point. The school and parents have put up a reward of <payment>.`
 	passengers 20 100 .6
 	cargo "educational supplies" 2 10 .6
 	to offer
@@ -2209,6 +2209,7 @@ mission "Stranded Field Trip [0]"
 		"passenger space" > 50
 	source
 		attributes "near earth" "deep" "paradise" "tourism"
+
 	destination
 		distance 4 16
 		attributes "near earth" "deep" "paradise" "urban"

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2216,7 +2216,7 @@ mission "Stranded Field Trip [0]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 200
-		dialog `The students excitedly rush off your ship into the arms of their waiting parents, the adventure was fun but they're very pleased to be safely home after so long. The school deposits <payment> into your account.`
+		dialog `The students excitedly rush off your ship into the arms of their waiting parents. The adventure was fun but they're very pleased to be safely home after so long. The school deposits <payment> into your account.`
 
 mission "Prisoners [0]"
 	name "Prisoner transport to <planet>"

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2197,6 +2197,26 @@ mission "Colonists [1]"
 		payment 10000
 		dialog "The colonists depart your ship after paying you <payment>."
 
+mission "Stranded field trip to <planet>"
+	job
+	repeat
+	description `These <bunks> school students have been stranded on an educational field trip due to the unexpected bankruptcy of their booked transport. They have the supplies to continue their studies but need to be safely returned home at some point. The school & parents have put up a reward of <payment>.`
+	passengers 20 100 .6
+	cargo "educational supplies" 2 10 .6
+	to offer
+		random < 10
+		"passenger space" > 50
+	source
+		attributes "near earth" "deep" "paradise" "tourism"
+	destination
+		distance 4 16
+		attributes "near earth" "deep" "paradise" "urban"
+	on visit
+		dialog phrase "generic passenger on visit"
+	on complete
+		payment 10000 200
+		dialog `The students excitedly rush off your ship into the arms of waiting parents, the adventure was fun but they're very pleased to be safely home after so long. The school deposits <payment> into your account.`
+
 mission "Prisoners [0]"
 	name "Prisoner transport to <planet>"
 	job

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -2217,7 +2217,7 @@ mission "Stranded Field Trip [0]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 200
-		dialog `The students excitedly rush off your ship into the arms of their waiting parents. The adventure was fun but they're very pleased to be safely home after so long. The school deposits <payment> into your account.`
+		dialog `The students excitedly rush off your ship into the arms of their waiting parents. The adventure was fun, but they're very pleased to be safely home after so long. The school deposits <payment> into your account.`
 
 mission "Prisoners [0]"
 	name "Prisoner transport to <planet>"

--- a/data/paradise world jobs.txt
+++ b/data/paradise world jobs.txt
@@ -468,7 +468,7 @@ mission "Paradise Job: Debtors"
 
 
 mission "Paradise Job: Retirees"
-	name "Wealthy retirees to <planet>
+	name "Wealthy retirees to <planet>"
 	job
 	repeat
 	description "This coterie of <bunks> wealthy retirees is willing to pay <payment> to be transported in style to <destination>, along with <tons> of their most treasured possessions."

--- a/data/paradise world jobs.txt
+++ b/data/paradise world jobs.txt
@@ -9,7 +9,8 @@
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 
-mission "Care package to <planet>"
+mission "Paradise Job: Care Package"
+	name "Care package to <planet>"
 	job
 	repeat
 	deadline
@@ -31,7 +32,8 @@ mission "Care package to <planet>"
 		dialog "Still wondering why one university student would possibly need such a large quantity of <commodity>, you deliver the interstellar care package and collect your payment of <payment>."
 
 
-mission "Birthday supplies to <planet>"
+mission "Paradise Job: Birthday Supplies"
+	name "Birthday supplies to <planet>"
 	job
 	repeat
 	deadline
@@ -53,7 +55,8 @@ mission "Birthday supplies to <planet>"
 		dialog "You deliver the cargo to the garden of an imposing mansion in the countryside, wherein some pouty young sprout is throwing a very conspicuous fit at the center of a swarm of guests. The parents sheepishly hand you your payment of <payment>."
 
 
-mission "Art delivery to <planet>"
+mission "Paradise Job: Art Delivery"
+	name "Art delivery to <planet>"
 	job
 	repeat
 	deadline
@@ -75,7 +78,8 @@ mission "Art delivery to <planet>"
 		dialog "Your ship is directed to the rear loading dock of a palatial complex where your cargo of <commodity> is unloaded. You collect your payment of <payment>."
 
 
-mission "Newlyweds to <planet>"
+mission "Paradise Job: Newlyweds"
+	name "Newlyweds to <planet>"
 	job
 	repeat
 	deadline
@@ -99,7 +103,8 @@ mission "Newlyweds to <planet>"
 		dialog "You bid the two lovebirds goodbye on <planet> and collect your payment of <payment>."
 
 
-mission "Theater props to <planet>"
+mission "Paradise Job: Theater Props"
+	name "Theater props to <planet>"
 	job
 	repeat
 	deadline
@@ -121,7 +126,8 @@ mission "Theater props to <planet>"
 		dialog "Your ship is directed to the rear loading dock of a sprawling entertainment complex where your cargo of <commodity> is unloaded. You collect your payment of <payment>."
 
 
-mission "Fine food to <planet>"
+mission "Paradise Job: Fine Food"
+	name "Fine food to <planet>"
 	job
 	repeat
 	deadline
@@ -190,7 +196,8 @@ mission "Transport partiers [2]"
 		payment 5000 190
 		dialog "You bid goodbye to the students, who behaved surprisingly well during the journey - yielding many fascinating conversations on subjects as diverse as philosophy, microfluidics, and intergalactic economics. Their proud parents send you your payment of <payment>."
 
-mission "Food donations to <planet>"
+mission "Paradise Job: Food Donations"
+	name "Food donations to <planet>"
 	job
 	repeat
 	description "The fine citizens of <origin> seek a compassionate captain for a mission of mercy to donate <cargo> to the undernourished souls of <destination>. Payment is <payment>."
@@ -209,7 +216,8 @@ mission "Food donations to <planet>"
 		dialog "You collect your payment of <payment>, but not before noticing the general robustness and ample bellies of the dockworkers unloading the donation of <commodity>."
 
 
-mission "Clothing donations to <planet>"
+mission "Paradise Job: Clothing Donations"
+	name "Clothing donations to <planet>"
 	job
 	repeat
 	description "The fine citizens of <origin> seek a compassionate captain for a mission of mercy to donate <cargo> to the under-dressed and fashion-deprived souls of <destination>. Payment is <payment>."
@@ -228,7 +236,8 @@ mission "Clothing donations to <planet>"
 		dialog "You collect your payment of <payment>, but not before noticing the fine quality of the clothes worn by the dockworkers unloading the donation of <commodity>."
 
 
-mission "Medical aid to <planet>"
+mission "Paradise Job: Medical Aid"
+	name "Medical aid to <planet>"
 	job
 	repeat
 	description "The fine citizens of <origin> seek a compassionate captain for a mission of mercy to donate <cargo> to the suffering souls of <destination>. Payment is <payment>."
@@ -247,7 +256,8 @@ mission "Medical aid to <planet>"
 		dialog "You collect your payment of <payment>, but not before noticing the general health and vigor of the dockworkers unloading the donation of <commodity>."
 
 
-mission "Charity goods to <planet>"
+mission "Paradise Job: Charity"
+	name "Charity goods to <planet>"
 	job
 	repeat
 	description "The fine citizens of <origin> seek a compassionate captain for a mission of mercy to donate <cargo> to the naive and culturally-underexposed souls of <destination>. Payment is <payment>."
@@ -266,7 +276,8 @@ mission "Charity goods to <planet>"
 		dialog "You collect your payment of <payment>, but not before noticing the quality of the clothes, jewelry, and personal electronics carried by the dockworkers unloading the donation of <commodity>."
 
 
-mission "Party goods to <planet>"
+mission "Paradise Job: Party Goods"
+	name "Party goods to <planet>"
 	job
 	repeat
 	deadline
@@ -290,7 +301,8 @@ mission "Party goods to <planet>"
 		dialog "Your ship is directed to land on a makeshift tarmac near a sprawling greenfield where novelty castles are being constructed. Sharply-dressed stewards unload the <commodity> and you collect your payment of <payment>."
 
 
-mission "Estate assets to <planet>"
+mission "Paradise Job: Estate Assets"
+	name "Estate assets to <planet>"
 	job
 	repeat
 	description "Trustees are seeking starship captains willing to deliver individual portions of a recently deceased upstanding citizen's estate - <cargo> - to the upcoming estate sale on <destination>. Payment is <payment>."
@@ -310,7 +322,8 @@ mission "Estate assets to <planet>"
 		dialog "As you watch the dockworkers unload crate after crate, you can't help but wonder what would drive someone to collect such a huge quantity of <commodity>. You collect your payment of <payment>."
 
 
-mission "Contract laborers to <planet>"
+mission "Paradise Jobs: Contract Laborers"
+	name "Contract laborers to <planet>"
 	job
 	repeat
 	description "Return to <destination> after picking up <bunks> contract laborers located on <stopovers> who are eager to experience the luxury of the paradise worlds. Payment is <payment>."
@@ -332,7 +345,8 @@ mission "Contract laborers to <planet>"
 		dialog "The bedraggled contract laborers kept to themselves and didn't say a word to you throughout the entire trip. The scruffy foreman who receives you on <origin> seems pleased, however. He hands you your payment of <payment>."
 
 
-mission "Waste disposal on <planet>"
+mission "Paradise Job: Waste Disposal"
+	name "Waste disposal on <planet>"
 	job
 	repeat
 	description "Urgent waste disposal is needed. Transport <cargo> to <destination> to keep property values from falling. Payment is <payment>."
@@ -405,12 +419,12 @@ mission "Pleasure cruise security"
 		payment 50000
 
 
-# Brig bulk missions
-mission "Non-violent parolees to <planet>"
+mission "Paradise Job: Parolees"
+	name "Parolees to <planet>"
 	job
 	repeat
 	description `These <bunks> non-violent repeat offenders have accepted longer community service sentences that better use their skills in return for serving their time on the paradise world of <destination>. Transport them to their new home to carry out their service. The payment is <payment>.`
-	passengers 20 100 .6
+	passengers 20 4 .1
 	to offer
 		random < 15
 		"passenger space" > 50
@@ -424,15 +438,17 @@ mission "Non-violent parolees to <planet>"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
+		payment
 		payment 10000
 		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of a local security force as they prepare to repay their debts to society. A clerk on <planet> checks their condition as they're led off. He seems mostly pleased and hands you your payment of <payment>."
 
 
-mission "Debtors to <planet>"
+mission "Paradise Job: Debtors"
+	name "Debtors to <planet>"
 	job
 	repeat
-	description `These <bunks> poor souls have bankrupted themselves attempting to live beyond their means on <origin>. Due to their general incompetence, and media scrutiny on the issue, the government will pay you <payment> to assist in deporting them to <destination> which has been identified as somewhere that they can make something useful of themselves.`
-	passengers 20 100 .6
+	description `These <bunks> poor souls have bankrupted themselves attempting to live beyond their means. Due to media scrutiny on the issue, the local government will pay you <payment> to transport them to <destination> where they can "make something useful of themselves."`
+	passengers 20 4 .1
 	to offer
 		random < 15
 		"passenger space" > 50
@@ -446,19 +462,20 @@ mission "Debtors to <planet>"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
+		payment
 		payment 10000
 		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of immigration officials. A grinning job service provider is on hand to pay you the <payment> you are owed."
 
 
-# Luxury Accomodation bulk missions
-mission "Wealthy Retirees to <planet>"
+mission "Paradise Job: Retirees"
+	name "Wealthy retirees to <planet>
 	job
 	repeat
 	description "This coterie of <bunks> wealthy retirees is willing to pay <payment> to be transported in style to <destination>, along with <tons> of their most treasured possessions."
 	passengers 7 12 .6
 	cargo "treasured possessions" 7 12 .2
 	to offer
-		random < 15
+		random < 10
 		"passenger space" > 30
 		"cargo space" > 120
 	on offer
@@ -475,21 +492,22 @@ mission "Wealthy Retirees to <planet>"
 		dialog "You bid goodbye to the retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite and full of highly amusing, though often morally questionable, anecdotes. Once the last of their belongings have been safely unloaded your accounts receive the payment of <payment> from their travel broker."
 
 
-mission "Wilderness Retreat Cohort to <planet>"
+mission "Paradise Job: Wilderness Retreat"
+	name "Wilderness Retreat to <planet>"
 	job
 	repeat
 	description `Bring <bunks> pseudo-celebrities and wealthy tourists to the wild and untamed world of <destination> for a "Wilderness Retreat." Payment is <payment>.`
 	passengers 10 4 .1
 	to offer
-		random < 15
+		random < 10
 		"passenger space" > 30
 	on offer
 		require "Luxury Accommodations"
 	source
 		attributes "urban" "near earth" "core" "paradise"
 	destination
-		attributes "frontier" "rim" "forest" "fishing"
 		distance 6 20
+		attributes "frontier" "rim" "forest" "fishing"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete

--- a/data/paradise world jobs.txt
+++ b/data/paradise world jobs.txt
@@ -404,8 +404,8 @@ mission "Pleasure cruise security"
 		payment
 		payment 50000
 
+
 # Brig bulk missions
-	
 mission "Non-violent parolees to <planet>"
 	job
 	repeat
@@ -424,6 +424,7 @@ mission "Non-violent parolees to <planet>"
 	on complete
 		payment 10000
 		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of a local security force as they prepare to repay their debts to society. A clerk on <origin> checks their condition as they're led off. He seems mostly pleased and hands you your payment of <payment>."
+
 
 mission "Debtors to <planet>"
 	job
@@ -444,8 +445,8 @@ mission "Debtors to <planet>"
 		payment 10000
 		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of immigration officials. A grinning job service provider is on hand to pay you the <payment> you are owed."
 
-# Luxury Accomodation bulk missions
 
+# Luxury Accomodation bulk missions
 mission "Wealthy Retirees to <planet>"
 	job
 	repeat
@@ -469,6 +470,7 @@ mission "Wealthy Retirees to <planet>"
 		payment 10000 200
 		dialog "You bid goodbye to the retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite and full of highly amusing, though often morally questionable, anecdotes. Once the last of their things have been safely unloaded your accounts receive the payment of <payment> from their travel broker."
 
+
 mission "Wilderness Retreat Cohort to <planet>"
 	job
 	repeat
@@ -488,4 +490,5 @@ mission "Wilderness Retreat Cohort to <planet>"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 25000 250
-		dialog "Your passengers are met by an overly enthusiastic greeting service of comically overdressed 'wilderness guides'. You can't help but think these people are either about to end up on a popular relaity show, or be safely fleeced of their money, but they're not the sort of characters who engender much sympathy for such fates. One of the greeters quietly transfers you your payment of <payment>."
+		dialog "Your passengers are met by an overly enthusiastic greeting service of comically overdressed 'wilderness guides'. You can't help but think these people are either about to end up on a popular reality show, or be safely fleeced of their money, but they're not the sort of characters who engender much sympathy for such fates. One of the greeters quietly transfers you your payment of <payment>."
+

--- a/data/paradise world jobs.txt
+++ b/data/paradise world jobs.txt
@@ -409,38 +409,42 @@ mission "Pleasure cruise security"
 mission "Non-violent parolees to <planet>"
 	job
 	repeat
-	description `These <bunks> non-violent repeat offenders have accepted longer community service sentences that better use their skills in return for serving their time on a paradise world. Transport them to their new home to carry out their service. The payment is <payment>.`
+	description `These <bunks> non-violent repeat offenders have accepted longer community service sentences that better use their skills in return for serving their time on the paradise world of <destination>. Transport them to their new home to carry out their service. The payment is <payment>.`
 	passengers 20 100 .6
 	to offer
 		random < 15
 		"passenger space" > 50
+	on offer
+		require "Brig"
 	source
 		attributes "mining" "fishing" "textiles" "factory" "farming" "oil"
 	destination
 		distance 2 18
 		attributes "paradise"
 	on visit
-		dialog phrase "generic missing stopover or passengers"
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000
-		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of a local security force as they prepare to repay their debts to society. A clerk on <origin> checks their condition as they're led off. He seems mostly pleased and hands you your payment of <payment>."
+		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of a local security force as they prepare to repay their debts to society. A clerk on <planet> checks their condition as they're led off. He seems mostly pleased and hands you your payment of <payment>."
 
 
 mission "Debtors to <planet>"
 	job
 	repeat
-	description `These <bunks> poor souls have bankrupted themselves attempting to live beyond their means on <origin>. Due to their general incompetence, and media scrutiny on the issue, the government will pay you <payment> to assist in deporting them to somewhere they can make something useful of themselves.`
+	description `These <bunks> poor souls have bankrupted themselves attempting to live beyond their means on <origin>. Due to their general incompetence, and media scrutiny on the issue, the government will pay you <payment> to assist in deporting them to <destination> which has been identified as somewhere that they can make something useful of themselves.`
 	passengers 20 100 .6
 	to offer
 		random < 15
 		"passenger space" > 50
+	on offer
+		require "Brig"
 	source
 		attributes "paradise"
 	destination
 		distance 2 30
 		attributes "mining" "fishing" "forest" "textiles" "factory" "farming" "oil" "frontier" "dirt belt" "south" "rim"
 	on visit
-		dialog phrase "generic missing stopover or passengers"
+		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000
 		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of immigration officials. A grinning job service provider is on hand to pay you the <payment> you are owed."
@@ -468,7 +472,7 @@ mission "Wealthy Retirees to <planet>"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 200
-		dialog "You bid goodbye to the retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite and full of highly amusing, though often morally questionable, anecdotes. Once the last of their things have been safely unloaded your accounts receive the payment of <payment> from their travel broker."
+		dialog "You bid goodbye to the retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite and full of highly amusing, though often morally questionable, anecdotes. Once the last of their belongings have been safely unloaded your accounts receive the payment of <payment> from their travel broker."
 
 
 mission "Wilderness Retreat Cohort to <planet>"
@@ -490,5 +494,5 @@ mission "Wilderness Retreat Cohort to <planet>"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 25000 250
-		dialog "Your passengers are met by an overly enthusiastic greeting service of comically overdressed 'wilderness guides'. You can't help but think these people are either about to end up on a popular reality show, or be safely fleeced of their money, but they're not the sort of characters who engender much sympathy for such fates. One of the greeters quietly transfers you your payment of <payment>."
+		dialog `Your passengers are met by an overly enthusiastic greeting service of comically overdressed "wilderness guides." You can't help but think these people are either about to end up on a popular reality show, or be safely fleeced of their money, but they're not the sort of characters who engender much sympathy for such fates. One of the greeters quietly transfers to you your payment of <payment>.`
 

--- a/data/paradise world jobs.txt
+++ b/data/paradise world jobs.txt
@@ -403,3 +403,89 @@ mission "Pleasure cruise security"
 		dialog "You bid goodbye to the captain of the <npc> and accept your payment of <payment>."
 		payment
 		payment 50000
+
+# Brig bulk missions
+	
+mission "Non-violent parolees to <planet>"
+	job
+	repeat
+	description `These <bunks> non-violent repeat offenders have accepted longer community service sentences that better use their skills in return for serving their time on a paradise world. Transport them to their new home to carry out their service. The payment is <payment>.`
+	passengers 20 100 .6
+	to offer
+		random < 15
+		"passenger space" > 50
+	source
+		attributes "mining" "fishing" "textiles" "factory" "farming" "oil"
+	destination
+		distance 2 18
+		attributes "paradise"
+	on visit
+		dialog phrase "generic missing stopover or passengers"
+	on complete
+		payment 10000
+		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of a local security force as they prepare to repay their debts to society. A clerk on <origin> checks their condition as they're led off. He seems mostly pleased and hands you your payment of <payment>."
+
+mission "Debtors to <planet>"
+	job
+	repeat
+	description `These <bunks> poor souls have bankrupted themselves attempting to live beyond their means on <origin>. Due to their general incompetence, and media scrutiny on the issue, the government will pay you <payment> to assist in deporting them to somewhere they can make something useful of themselves.`
+	passengers 20 100 .6
+	to offer
+		random < 15
+		"passenger space" > 50
+	source
+		attributes "paradise"
+	destination
+		distance 2 30
+		attributes "mining" "fishing" "forest" "textiles" "factory" "farming" "oil" "frontier" "dirt belt" "south" "rim"
+	on visit
+		dialog phrase "generic missing stopover or passengers"
+	on complete
+		payment 10000
+		dialog "The passengers shuffle unhappily out of the ship under the watchful eye of immigration officials. A grinning job service provider is on hand to pay you the <payment> you are owed."
+
+# Luxury Accomodation bulk missions
+
+mission "Wealthy Retirees to <planet>"
+	job
+	repeat
+	description "This coterie of <bunks> wealthy retirees is willing to pay <payment> to be transported in style to <destination>, along with <tons> of their most treasured possessions."
+	passengers 7 12 .6
+	cargo "treasured possessions" 7 12 .2
+	to offer
+		random < 15
+		"passenger space" > 30
+		"cargo space" > 120
+	on offer
+		require "Luxury Accommodations"
+	source
+		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest" "urban"
+	destination
+		distance 3 16
+		attributes "paradise"
+	on visit
+		dialog phrase "generic passenger on visit"
+	on complete
+		payment 10000 200
+		dialog "You bid goodbye to the retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite and full of highly amusing, though often morally questionable, anecdotes. Once the last of their things have been safely unloaded your accounts receive the payment of <payment> from their travel broker."
+
+mission "Wilderness Retreat Cohort to <planet>"
+	job
+	repeat
+	description "Bring <bunks> pseudo-celebrities and wealthy tourists to the wild and untamed world of <destination> for a 'Wilderness Retreat'. Payment is <payment>."
+	passengers 10 4 .1
+	to offer
+		random < 15
+		"passenger space" > 30
+	on offer
+		require "Luxury Accommodations"
+	source
+		attributes "urban" "near earth" "core" "paradise"
+	destination
+		attributes "frontier" "rim" "forest" "fishing"
+		distance 6 20
+	on visit
+		dialog phrase "generic passenger on visit"
+	on complete
+		payment 25000 250
+		dialog "Your passengers are met by an overly enthusiastic greeting service of comically overdressed 'wilderness guides'. You can't help but think these people are either about to end up on a popular relaity show, or be safely fleeced of their money, but they're not the sort of characters who engender much sympathy for such fates. One of the greeters quietly transfers you your payment of <payment>."

--- a/data/paradise world jobs.txt
+++ b/data/paradise world jobs.txt
@@ -478,7 +478,7 @@ mission "Wealthy Retirees to <planet>"
 mission "Wilderness Retreat Cohort to <planet>"
 	job
 	repeat
-	description "Bring <bunks> pseudo-celebrities and wealthy tourists to the wild and untamed world of <destination> for a 'Wilderness Retreat'. Payment is <payment>."
+	description `Bring <bunks> pseudo-celebrities and wealthy tourists to the wild and untamed world of <destination> for a "Wilderness Retreat." Payment is <payment>.`
 	passengers 10 4 .1
 	to offer
 		random < 15
@@ -495,4 +495,3 @@ mission "Wilderness Retreat Cohort to <planet>"
 	on complete
 		payment 25000 250
 		dialog `Your passengers are met by an overly enthusiastic greeting service of comically overdressed "wilderness guides." You can't help but think these people are either about to end up on a popular reality show, or be safely fleeced of their money, but they're not the sort of characters who engender much sympathy for such fates. One of the greeters quietly transfers to you your payment of <payment>.`
-


### PR DESCRIPTION
These commits add 5 new bulk passenger transport jobs that shouldn't spam things too much.

If you choose the playstyle where you run around with a sizable escort fleet you reach a point where the only jobs you ever take are the ones whose destination is a place you were already planning to stop at - because anything else just isn't cost effective.

The only exceptions to this are Colonist delivery missions, and occasionally strike breakers if you can pick up more than one for an area.

Colonist missions only really flow in one direction also, which makes them not all that common unless that's the direction you're going. This can make doing things in human space a tinsy bit dull if you were otherwise enjoying rolling around doing mission-running amidst your plot and other shenanigans. Additionally, the luxury accommodation and the brig use up outfit space (more for the former) and they have absolutely no equivalent to the colonist mission, which seems counter-intuitive if you're flying with a big powerful escort. Logically you'd be a great candidate for any large groups of wealthy tourists or prisoner scum at that point, but none of their missions hit the cost effective threshold to go out of your way by even a couple of jumps if you're spending 100,000+ on crew fees per day.

These commits make it so that within human space you have a pair of missions for each of default, luxury, or brig that have opposing inwards or outwards directions, and each is a different subset of inwards and outwards so that they're not samey back-and-forth simulators.

Edit: The paradise world jobs still contain replacements in the unique name only because almost all the missions in that file have those. Once these are working maybe I'll review the naming all the way through.