### PR TITLE
Clear ghost commands from when the engine was not active

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -433,10 +433,15 @@ void Engine::Step(bool isActive)
 			--jumpCount;
 	}
 	ai.UpdateEvents(events);
-	if(isActive && wasActive)
+	if(isActive)
 	{
 		HandleKeyboardInputs();
-		ai.UpdateKeys(player, activeCommands);
+		// If the engine wasn't active the last frame, then clear any commands that were
+		// picked up as ghost commands from the previous non-engine screen.
+		if(wasActive)
+			ai.UpdateKeys(player, activeCommands);
+		else
+			activeCommands.Clear();
 	}
 	wasActive = isActive;
 	Audio::Update(center);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -436,12 +436,12 @@ void Engine::Step(bool isActive)
 	if(isActive)
 	{
 		HandleKeyboardInputs();
-		// If the engine wasn't active the last frame, then clear any commands that were
-		// picked up as ghost commands from the previous non-engine screen.
-		if(wasActive)
-			ai.UpdateKeys(player, activeCommands);
-		else
+		// Ignore any inputs given when first becoming active, since those inputs
+		// were issued when some other panel (e.g. planet, hail) was displayed.
+		if(!wasActive)
 			activeCommands.Clear();
+		else
+			ai.UpdateKeys(player, activeCommands);
 	}
 	wasActive = isActive;
 	Audio::Update(center);


### PR DESCRIPTION
**Bugfix:** This PR addresses a command ghosting issue reported on steam

## Origin of bug-report
https://steamcommunity.com/app/404410/discussions/1/1750149787514366978/

## Fix Details
The engine is only reading commands while it is active, but any key that
was pressed before the engine became active (and that is still pressed
when activating the engine) should not be seen as a new keypress.

This commit fixes that by discarding the very first commands read when
the engine becomes active.

## Testing Done
Tested departing using 'd' with a ship with fighters (with and without this change). Without the change the fighters were deployed on launch, with this change the fighters were not deployed on launch.

## Save File
None provided. Any ship with fighters or drones would be fine.
