### PR TITLE
Change CircleAround, Swarm and KeepStation to use Body target

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1832,7 +1832,7 @@ void AI::PrepareForHyperspace(Ship &ship, Command &command)
 
 
 	
-void AI::CircleAround(Ship &ship, Command &command, const Ship &target)
+void AI::CircleAround(Ship &ship, Command &command, const Body &target)
 {
 	Point direction = target.Position() - ship.Position();
 	command.SetTurn(TurnToward(ship, direction));
@@ -1842,7 +1842,7 @@ void AI::CircleAround(Ship &ship, Command &command, const Ship &target)
 
 
 
-void AI::Swarm(Ship &ship, Command &command, const Ship &target)
+void AI::Swarm(Ship &ship, Command &command, const Body &target)
 {
 	Point direction = target.Position() - ship.Position();
 	double maxSpeed = ship.MaxVelocity();
@@ -1855,7 +1855,7 @@ void AI::Swarm(Ship &ship, Command &command, const Ship &target)
 
 
 
-void AI::KeepStation(Ship &ship, Command &command, const Ship &target)
+void AI::KeepStation(Ship &ship, Command &command, const Body &target)
 {
 	// Constants:
 	static const double MAX_TIME = 600.;

--- a/source/AI.h
+++ b/source/AI.h
@@ -97,9 +97,9 @@ private:
 	static bool MoveTo(Ship &ship, Command &command, const Point &targetPosition, const Point &targetVelocity, double radius, double slow);
 	static bool Stop(Ship &ship, Command &command, double maxSpeed = 0., const Point direction = Point());
 	static void PrepareForHyperspace(Ship &ship, Command &command);
-	static void CircleAround(Ship &ship, Command &command, const Ship &target);
-	static void Swarm(Ship &ship, Command &command, const Ship &target);
-	static void KeepStation(Ship &ship, Command &command, const Ship &target);
+	static void CircleAround(Ship &ship, Command &command, const Body &target);
+	static void Swarm(Ship &ship, Command &command, const Body &target);
+	static void KeepStation(Ship &ship, Command &command, const Body &target);
 	static void Attack(Ship &ship, Command &command, const Ship &target);
 	static void MoveToAttack(Ship &ship, Command &command, const Body &target);
 	static void PickUp(Ship &ship, Command &command, const Body &target);


### PR DESCRIPTION
**Feature:** This PR changes the target in CircleAround, Swarm and KeepStation from Ship to the more generic Body class

## Feature Details
This change will make those 3 functions also available for future changes that might want to use those functions with targets like asteroids, formation-positions or planets.
The 3 functions only use properties which are already available in the Body base-class; so there was no need to use the more specific Ship parameter.

## UI Screenshots
N/A

## Usage Examples
This can be relevant if we want to use KeepStation (with different internal parameters) for formation position keeping in #4471 .

## Testing Done
Compiled (it compiles) and started the game. Function parameters are normally checked at compile time, so just checking compilation this should be okay as long as ES doesn't generate new function calls at runtime.

## Performance Impact
None expected.