### PR TITLE
Buff Ion Rain Gun

### DIFF
--- a/data/coalition weapons.txt
+++ b/data/coalition weapons.txt
@@ -291,7 +291,7 @@ outfit "Ion Rain Gun"
 		"random lifetime" 5
 		"reload" 4
 		"firing energy" 12
-		"firing heat" 4.4
+		"firing heat" 4
 		"shield damage" 12
 		"hull damage" 5
 		"ion damage" .32

--- a/data/coalition weapons.txt
+++ b/data/coalition weapons.txt
@@ -291,10 +291,10 @@ outfit "Ion Rain Gun"
 		"random lifetime" 5
 		"reload" 4
 		"firing energy" 12
-		"firing heat" 4
+		"firing heat" 4.4
 		"shield damage" 12
-		"hull damage" 2
-		"ion damage" .2
+		"hull damage" 5
+		"ion damage" .32
 	description "Heliarch ships primarily serve as a police force. This weapon is designed to neutralize a target's offensive capabilities until more Heliarch ships can join the fray."
 
 effect "ion rain impact"


### PR DESCRIPTION
despite being a Tier above the Hai, and focusing heavily on military actions, the Heliarch's Ion Rain Gun is at best a very sad sidegrade of the Hai Ion Cannon, losing half the range and having over 4 times the firing energy for an extra 12 shield damage per second, *30 less hull damage per second*, and 200 *less* ion damage per second.
 Now of course the Ion Rain Gun is considerably smaller than the Ion Cannon, but if we analyze the two based on attributes/s (per space), we have the following:

Ion Cannon= 3.5 shield damage/s, 1.2 hull d./s, 10.6 ion d./s | 2.5 firing energy/s, 3.1 f. heat/s
Ion Rain Gun= 10.5 shield damage/s, 1.7 hull d./s, 17.6 ion d./s | 10.5 firing energy/s, 3.5 f. heat/s

 So, 3 times the shield damage, a .5 increase to hull damage, and not even double the ion damage, for over 4 times the firing energy and a bit more firing heat. and the range drop. being a tier above and heavily militarized.
 This PR is an attempt to make the IRG's situation a bit better, by buffing hull damage and ion damage (from 2 to 5, and from .2 to .32, respectively).

 The new stats would give the IRG actually more hull damage than the Ion Cannon (IRG 75 vs IC 60, as opposed to the previous IRG 30 vs IC 60), and also increase its ion damage from 300 to 480.
 Analyzing by space again, the new stats would net us this:

Ion Cannon= 3.5 sd/s, 1.2 hd/s, 10.6 id/s | 2.5 fe/s, 3.1 fh/s
Ion Rain Gun= 10.5 sd/s, 4.4 hd/s, 28.2 id/s | 10.5 fe/s, 3.5 fh/s