### PR TITLE
Make Fast forward and Fullscreen keys not override UI inputs

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -216,6 +216,10 @@ void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode)
 				// and the OpenGL viewport to match.
 				GameWindow::AdjustViewport();
 			}
+			else if(activeUI.Handle(event))
+			{
+				// The UI handled the event.
+			}
 			else if(event.type == SDL_KEYDOWN && !toggleTimeout
 					&& (Command(event.key.keysym.sym).Has(Command::FULLSCREEN)
 					|| (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT))))
@@ -226,11 +230,7 @@ void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode)
 			else if(event.type == SDL_KEYDOWN && !event.key.repeat
 					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))
 			{
-					isFastForward = !isFastForward;
-			}
-			else if(activeUI.Handle(event))
-			{
-				// The UI handled the event.
+				isFastForward = !isFastForward;
 			}
 		}
 		SDL_Keymod mod = SDL_GetModState();


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #4880
## Fix Details
Changing the order so that UI takes priority makes it so that fullscreen and fast-forward toggles are only activated if there is no active dialog taking input instead. You can think of it as making main() the root panel in the stack.

## Testing Done
Tested with some parts of the game, things seem to not break in unexpected ways. 

## Save File
Not applicable, can easily be verified with a new or existing save using the instructions in #4880.

