### PR TITLE
Reducing the Outfit Size of Solar

### DIFF
--- a/data/coalition outfits.txt
+++ b/data/coalition outfits.txt
@@ -15,7 +15,7 @@ outfit "Small Collector Module"
 	cost 60000
 	thumbnail "outfit/small collector module"
 	"mass" 8
-	"outfit space" -8
+	"outfit space" -4
 	"solar collection" .8
 	"heat generation" .4
 	description "Solar power is the mainstay of the Coalition's merchant marine. The design of these panels has been refined over the millennia, growing ever more efficient."
@@ -27,7 +27,7 @@ outfit "Large Collector Module"
 	cost 300000
 	thumbnail "outfit/large collector module"
 	"mass" 28
-	"outfit space" -28
+	"outfit space" -14
 	"solar collection" 3.3
 	"heat generation" 1.5
 	description "One of these solar panels is enough to meet the energy needs of a medium-sized Coalition civilian ship, especially given the energy efficiency of their engines and the fact that under their laws only Heliarch ships are allowed to have weapons."

--- a/data/power.txt
+++ b/data/power.txt
@@ -68,7 +68,7 @@ outfit "KP-6 Photovoltaic Panel"
 	cost 10000
 	thumbnail "outfit/tiny photovoltaic"
 	"mass" 3
-	"outfit space" -3
+	"outfit space" -1
 	"solar collection" .1
 	description "This early commercial photovoltaic system was the driving force behind humanity's first interplanetary trade network. Rugged and modular, it can be bolted to the hull of any ship and has seen even the most remote parts of human space."
 
@@ -77,7 +77,7 @@ outfit "KP-6 Photovoltaic Array"
 	cost 90000
 	thumbnail "outfit/small photovoltaic"
 	"mass" 24
-	"outfit space" -24
+	"outfit space" -8
 	"solar collection" 1.1
 	description "The compact modularity of the KP-6 lent itself well to the creation of larger solar collection arrays. This original Korunak Photovoltaics model is equipped with a solar tracker, allowing it to make better use of available light."
 


### PR DESCRIPTION
**Balance Fix:** This PR addresses issue #4885 

## Fix Details
- Size of KP-6 panel reduce to 1 ton (from 3), but mass is left at 3.
- Size of KP 6 array reduced to 8 ton (from 24), but mass is left at 24.
- Size of small collector module reduced to 4 (from 8), but mass is left at 8.
- Size of large collector module reduced to 14 (from 28), but mass is left at 28.

The description and functionality of solar panels is specifically something that can be bolted to the outside of a ship. As such, the amount of space it takes up in our outfitter should be minimal. However, just because it doesn't take up space internally, doesn't mean that it doesn't add mass to the ship. 

This presents an interesting trade off: 
- For people who value energy per unit of outfit space (for instance, merchants who don't care about speed and just want the most space possible), then these outfits will be a little bit more useful. 
- For those who care about energy per unit of mass added to their ship (people who care about speed and mobility, or have high power demands), then these outfits will be just useless as they always have been. 

This, I feel, elevates solar panels from the realm of "completely useless except for maxed out cargo/bunk builds" to "a poor merchant might actually consider using these." Which I think makes them a more interesting part of the game.

That being said, I would like to hear from those who are focusing on Coalition space, like @Arachi-Lover . How does this change affect the balance over there? Is it too much? Not enough?

Also, I am aware of MZ's general dislike of 1 ton outfits, because "no one would have any reason to *not* put one on their ship to fill the last bit of space." Firstly, having a tiny backup solar panel as an extremely common outfit on a spaceship makes a huge amount of sense, so it actually sounds like a really good lore thing. Secondly, it's 6 energy. That's tiny. That's 1/8th the power output of the next smallest power generator, and an even tinier fraction of the power output of anything used for combat purposes. And thirdly, it is solar. Which means that it has to be near a star to give full power. So even as a "thing to fill that last ton of space" sort of outfit, it's a rather pathetic value. I suspect that for most people, the extra 3 tons of mass is a bigger detriment than the small energy gain.