### PR TITLE
fix Railgun Slugs amount for Flea and Pondstrider

### DIFF
--- a/data/hai ships.txt
+++ b/data/hai ships.txt
@@ -160,7 +160,7 @@ ship "Flea"
 			"hit force" 80
 	outfits
 		"Railgun"
-		"Railgun Slug" 160
+		"Railgun Slug" 150
 		"Sand Cell"
 		"Hai Chasm Batteries"
 		`"Baellie" Atomic Engines`
@@ -397,7 +397,7 @@ ship "Pond Strider"
 			"hit force" 1750
 	outfits
 		"Railgun" 2
-		"Railgun Slug" 320
+		"Railgun Slug" 300
 		"Pulse Cannon"
 		"Pulse Turret" 2
 		"Bullfrog Anti-Missile" 


### PR DESCRIPTION
Railgun has a railgun slug capacity of 150, but the Flea (which has 1 Railgun) has 160 slugs by default, and the Pond Strider (which has 2 Railguns) has 320 slugs by default.

this just changes those to 150 and 300 respectively, to have it follow the slug capacity set by the weapon.