### PR TITLE
feat: Solar heat mechanic for increased heat generation the closer you are to the system center

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -242,6 +242,9 @@ tip "slowing resistance:"
 tip "solar collection:"
 	`Produces a variable amount of energy depending on how far this ship is from the star at the center of the system.`
 
+tip "solar heat:"
+	`Produces a variable amount of heat depending on how far this ship is from the star at the center of the system.`
+
 tip "tactical scan power:"
 	`Tactical scanners allow you to view your current target's crew complement, fuel, heat, and energy levels when it is within range. The range is proportional to the square root of this value.`
 

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -66,6 +66,7 @@ namespace {
 		{"shield fuel", 0},
 		{"shield heat", 0},
 		{"solar collection", 0},
+		{"solar heat", 0},
 		{"thrusting energy", 0},
 		{"thrusting heat", 0},
 		{"turn", 0},

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1674,9 +1674,10 @@ void Ship::DoGeneration()
 		{
 			double scale = .2 + 1.8 / (.001 * position.Length() + 1);
 			fuel += currentSystem->SolarWind() * .03 * scale * (sqrt(attributes.Get("ramscoop")) + .05 * scale);
-		
-			energy += currentSystem->SolarPower() * scale * attributes.Get("solar collection");
-			heat += currentSystem->SolarPower() * scale * attributes.Get("solar heat");
+			
+			double solarScaling = currentSystem->SolarPower() * scale;
+			energy += solarScaling * attributes.Get("solar collection");
+			heat += solarScaling * attributes.Get("solar heat");
 		}
 		
 		double coolingEfficiency = CoolingEfficiency();
@@ -2505,8 +2506,7 @@ double Ship::IdleHeat() const
 	// heat = heat * diss + heatGen - cool - activeCool * heat / (100 * mass)
 	// heat = heat * (diss - activeCool / (100 * mass)) + (heatGen - cool)
 	// heat * (1 - diss + activeCool / (100 * mass)) = (heatGen - cool)
-	double production = max(0., attributes.Get("heat generation") 
-		+ attributes.Get("solar heat") - cooling);
+	double production = max(0., attributes.Get("heat generation") - cooling);
 	double dissipation = HeatDissipation() + activeCooling / MaximumHeat();
 	return production / dissipation;
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1676,6 +1676,7 @@ void Ship::DoGeneration()
 			fuel += currentSystem->SolarWind() * .03 * scale * (sqrt(attributes.Get("ramscoop")) + .05 * scale);
 		
 			energy += currentSystem->SolarPower() * scale * attributes.Get("solar collection");
+			heat += currentSystem->SolarPower() * scale * attributes.Get("solar heat");
 		}
 		
 		double coolingEfficiency = CoolingEfficiency();
@@ -2504,7 +2505,8 @@ double Ship::IdleHeat() const
 	// heat = heat * diss + heatGen - cool - activeCool * heat / (100 * mass)
 	// heat = heat * (diss - activeCool / (100 * mass)) + (heatGen - cool)
 	// heat * (1 - diss + activeCool / (100 * mass)) = (heatGen - cool)
-	double production = max(0., attributes.Get("heat generation") - cooling);
+	double production = max(0., attributes.Get("heat generation") 
+		+ attributes.Get("solar heat") - cooling);
 	double dissipation = HeatDissipation() + activeCooling / MaximumHeat();
 	return production / dissipation;
 }

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -269,6 +269,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	double efficiency = ship.CoolingEfficiency();
 	heatTable.push_back(Format::Number(
 		60. * (attributes.Get("heat generation") 
+			+ attributes.Get("solar heat")
 			+ attributes.Get("fuel heat")
 			- efficiency * (attributes.Get("cooling") + attributes.Get("active cooling")))));
 	attributesHeight += 20;


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #2508. Also, turns out #2618 existed, so this is really just that PR redone.

## Feature Details
Adds an attribute `"solar heat"` that would allow an outfit/ship to produce heat given its distance to the system center. Meant as a counter to solar collection's energy production given the distance to the center.
This PR does not add this attribute to any outfit, only implementing the mechanic to be used.

I'll note that I didn't use the same `"solar heat generation"` name as #2618; solar collection isn't `"solar energy generation"`, after all. 

## Usage Examples
```
outfit "Small Collector Module"
	...
	"solar collection" .8
	"solar heat" .4
```

## Testing Done
It builds and the CI tests pass. That's about all the testing I've done.

## Performance Impact
N/A
