### PR TITLE
CD: Don't break with some special characters in commit messages

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -20,7 +20,8 @@ jobs:
       - name: Adjust version strings
         run: |
           perl -p -i -e 's/(Endless Sky) [\d.]+/$1 ${{ github.sha }}/ig' source/main.cpp
-          perl -p -i -e "s/version [\d.]+/$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s)/ig" credits.txt
+          CREDIT_STRING=$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \' \")
+          perl -p -i -e "s|version [\d.]+|$CREDIT_STRING|" credits.txt
         shell: bash
       - name: Build Application
         run: scons -j $(nproc)
@@ -48,7 +49,8 @@ jobs:
       - name: Adjust version strings
         run: |
           perl -p -i -e 's/(Endless Sky) [\d.]+/$1 ${{ github.sha }}/ig' source/main.cpp
-          perl -p -i -e "s/version [\d.]+/$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s)/ig" credits.txt
+          CREDIT_STRING=$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \' \")
+          perl -p -i -e "s|version [\d.]+|$CREDIT_STRING|" credits.txt
         shell: bash
       - name: Build Application
         run: |
@@ -83,7 +85,8 @@ jobs:
       - name: Adjust version strings
         run: |
           perl -p -i -e 's/(Endless Sky) [\d.]+/$1 ${{ github.sha }}/ig' source/main.cpp
-          perl -p -i -e "s/version [\d.]+/$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s)/ig" credits.txt
+          CREDIT_STRING=$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \' \")
+          perl -p -i -e "s|version [\d.]+|$CREDIT_STRING|" credits.txt
           perl -0777 -p -i -e 's/(CFBundleShortVersionString.*?)[\d.]+/$1sha256.${{ github.sha }}/igs' XCode/EndlessSky-Info.plist
         shell: bash
       - name: Build Application

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Adjust version strings
         run: |
           perl -p -i -e 's/(Endless Sky) [\d.]+/$1 ${{ github.sha }}/ig' source/main.cpp
-          CREDIT_STRING=$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \' \")
+          CREDIT_STRING=$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \" \')
           perl -p -i -e "s|version [\d.]+|$CREDIT_STRING|" credits.txt
         shell: bash
       - name: Build Application
@@ -49,7 +49,7 @@ jobs:
       - name: Adjust version strings
         run: |
           perl -p -i -e 's/(Endless Sky) [\d.]+/$1 ${{ github.sha }}/ig' source/main.cpp
-          CREDIT_STRING=$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \' \")
+          CREDIT_STRING=$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \" \')
           perl -p -i -e "s|version [\d.]+|$CREDIT_STRING|" credits.txt
         shell: bash
       - name: Build Application
@@ -85,7 +85,7 @@ jobs:
       - name: Adjust version strings
         run: |
           perl -p -i -e 's/(Endless Sky) [\d.]+/$1 ${{ github.sha }}/ig' source/main.cpp
-          CREDIT_STRING=$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \' \")
+          CREDIT_STRING=$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \" \')
           perl -p -i -e "s|version [\d.]+|$CREDIT_STRING|" credits.txt
           perl -0777 -p -i -e 's/(CFBundleShortVersionString.*?)[\d.]+/$1sha256.${{ github.sha }}/igs' XCode/EndlessSky-Info.plist
         shell: bash


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue that arose in [this run](https://github.com/endless-sky/endless-sky/runs/495166301)

## Fix Details
Continuous Builds always build a "version string" from the current commit message, which then gets put in credits.txt. The regex that did this could break when this version string contained a `/` and (potenially, untested) something like a `$1`. 
With this PR, the regex delimiter is now the lesser-used `|` symbol. In case a `|` or `$` still appears, it is replaced by a `_`. Since there is now bash string substitution for the sake of clarity, `"` is also being replaced by `'`.
This should make the regex resilient enough to build every time - probably not resilient enough for straight up sabotage, but enough for unexpected side effects.

## Testing Done
Tested locally, since the credits.txt is not used anywhere else, and perl- & bash- implementations do not differ between platforms.
