### PR TITLE
fix: Account for the depreciation grace period in the max age of an outfit or ship

### DIFF
--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -29,8 +29,8 @@ namespace {
 	// Depreciation parameters.
 	double FULL_DEPRECIATION = 0.25;
 	double DAILY_DEPRECIATION = 0.997;
-	int MAX_AGE = 1000;
 	int GRACE_PERIOD = 7;
+	int MAX_AGE = 1000 + GRACE_PERIOD;
 }
 
 
@@ -334,11 +334,11 @@ double Depreciation::Depreciate(int age) const
 {
 	if(age <= GRACE_PERIOD)
 		return 1.;
-	if(age >= MAX_AGE + GRACE_PERIOD)
+	if(age >= MAX_AGE)
 		return FULL_DEPRECIATION;
 	
 	double daily = pow(DAILY_DEPRECIATION, age - GRACE_PERIOD);
-	double linear = static_cast<double>(MAX_AGE - (age - GRACE_PERIOD)) / MAX_AGE;
+	double linear = static_cast<double>(MAX_AGE - age) / MAX_AGE;
 	return FULL_DEPRECIATION + (1. - FULL_DEPRECIATION) * daily * linear;
 }
 

--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -27,10 +27,10 @@ namespace {
 	// Names for the two kinds of depreciation records.
 	string NAME[2] = {"fleet depreciation", "stock depreciation"};
 	// Depreciation parameters.
-	double FULL_DEPRECIATION = 0.25;
-	double DAILY_DEPRECIATION = 0.997;
-	int GRACE_PERIOD = 7;
-	int MAX_AGE = 1000 + GRACE_PERIOD;
+	constexpr double FULL_DEPRECIATION = 0.25;
+	constexpr double DAILY_DEPRECIATION = 0.997;
+	constexpr int GRACE_PERIOD = 7;
+	constexpr int MAX_AGE = 1000 + GRACE_PERIOD;
 }
 
 

--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -338,7 +338,7 @@ double Depreciation::Depreciate(int age) const
 		return FULL_DEPRECIATION;
 	
 	double daily = pow(DAILY_DEPRECIATION, age - GRACE_PERIOD);
-	double linear = static_cast<double>(MAX_AGE - age) / MAX_AGE;
+	double linear = static_cast<double>(MAX_AGE - age) / (MAX_AGE - GRACE_PERIOD);
 	return FULL_DEPRECIATION + (1. - FULL_DEPRECIATION) * daily * linear;
 }
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #4912.

## Fix Details
MAX_AGE is now 1000 + GRACE_PERIOD (i.e. 1007). 
This makes it so that Depreciation::Save and Depreciation::Buy will use 1007 as the age for fully depreciated items instead of 1000 as is used currently, which meant that you'd actually gain back 7 days of depreciation (as seen in #4912).
Simplified the linear equation in Depreciation::Depreciate as a result of this change. The outcome of the Depreciate function has remained unchanged, though.
