### PR TITLE
Add flagship System and Planet to player conditions

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2332,12 +2332,26 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 		conditions["passenger space"] = flagship->Cargo().BunksFree();
 	}
 	
+	// Clear any existing flagship system: and planet: conditions. (Note: '!' = ' ' + 1.)
+	auto firstS = conditions.lower_bound("flagship system: ");
+	auto lastS = conditions.lower_bound("flagship system:!");
+	if(firstS != lastS)
+		conditions.erase(firstS, lastS);
+	auto firstP = conditions.lower_bound("flagship planet: ");
+	auto lastP = conditions.lower_bound("flagship planet:!");
+	if(firstP != lastP)
+		conditions.erase(firstP, lastP);
+	
 	// Store conditions for flagship current crew, required crew, and bunks.
 	if(flagship)
 	{
 		conditions["flagship crew"] = flagship->Crew();
 		conditions["flagship required crew"] = flagship->RequiredCrew();
 		conditions["flagship bunks"] = flagship->Attributes().Get("bunks");
+		if(flagship->GetSystem())
+			conditions["flagship system: " + flagship->GetSystem()->Name()] = 1;
+		if(flagship->GetPlanet())
+			conditions["flagship planet: " + flagship->GetPlanet()->Name()] = 1;
 	}
 	else
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2308,11 +2308,16 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 	conditions["credit score"] = accounts.CreditScore();
 	// Serialize the current reputation with other governments.
 	SetReputationConditions();
+	// Helper lambda function to clear a range
+	auto clearRange = [](map<string, int64_t> &conditionsMap, string firstStr, string lastStr)
+	{
+		auto first = conditionsMap.lower_bound(firstStr);
+		auto last = conditionsMap.lower_bound(lastStr);
+		if(first != last)
+			conditionsMap.erase(first, last);
+	};
 	// Clear any existing ships: conditions. (Note: '!' = ' ' + 1.)
-	auto first = conditions.lower_bound("ships: ");
-	auto last = conditions.lower_bound("ships:!");
-	if(first != last)
-		conditions.erase(first, last);
+	clearRange(conditions, "ships: ", "ships:!");
 	// Store special conditions for cargo and passenger space.
 	conditions["cargo space"] = 0;
 	conditions["passenger space"] = 0;
@@ -2333,14 +2338,8 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 	}
 	
 	// Clear any existing flagship system: and planet: conditions. (Note: '!' = ' ' + 1.)
-	auto firstS = conditions.lower_bound("flagship system: ");
-	auto lastS = conditions.lower_bound("flagship system:!");
-	if(firstS != lastS)
-		conditions.erase(firstS, lastS);
-	auto firstP = conditions.lower_bound("flagship planet: ");
-	auto lastP = conditions.lower_bound("flagship planet:!");
-	if(firstP != lastP)
-		conditions.erase(firstP, lastP);
+	clearRange(conditions, "flagship system: ", "flagship system:!");
+	clearRange(conditions, "flagship planet: ", "flagship planet:!");
 	
 	// Store conditions for flagship current crew, required crew, and bunks.
 	if(flagship)
@@ -2351,7 +2350,7 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 		if(flagship->GetSystem())
 			conditions["flagship system: " + flagship->GetSystem()->Name()] = 1;
 		if(flagship->GetPlanet())
-			conditions["flagship planet: " + flagship->GetPlanet()->Name()] = 1;
+			conditions["flagship planet: " + flagship->GetPlanet()->TrueName()] = 1;
 	}
 	else
 	{


### PR DESCRIPTION
**Feature:** This PR implements a feature to publish the flagships location (system and planet) in the player conditions.

## Feature Details
This adds two new conditions:
```
"flagship planet: <planet-name>"
"flagship system: <system-name>" 
```
Those conditions can be used during automatic tests to put asserts on the location of the flagship.

## UI Screenshots
N/A

## Usage Examples
To be used during automatic testing as a condition to wait for or to assert on.

## Testing Done
Verified that the conditions get set (on Shangri-La in the Polaris system) and that the conditions get updated/rewritten (on Amazon in the Schedar system).

## Performance Impact
No significant impact expected, those conditions are only calculated on major events like departing or landing.