### PR TITLE
feat: CD: Also build AppImage

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,8 +2,8 @@ name: CD
 
 on:
   push:
-    branches:
-      - master
+#    branches:
+#      - master
 
 jobs:
   ubuntu_x86_64:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,8 +2,8 @@ name: CD
 
 on:
   push:
-#    branches:
-#      - master
+    branches:
+      - master
 
 jobs:
   ubuntu_x86_64:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -36,7 +36,7 @@ jobs:
   appimage_x86_64:
     runs-on: ubuntu-latest
     env:
-      OUTPUT: endless-sky-x86_64-${{ github.event.tag_name }}.AppImage
+      OUTPUT: endless-sky-x86_64-${{ github.sha }}.AppImage
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -36,6 +36,7 @@ jobs:
   appimage_x86_64:
     runs-on: ubuntu-latest
     env:
+      ARCH: x86_64
       OUTPUT: endless-sky-x86_64-${{ github.sha }}.AppImage
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +46,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons
       - name: Build AppImage
-        run: ./build_appimage.sh
+        run: ./utils/build_appimage.sh
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,7 +9,7 @@ jobs:
   ubuntu_x86_64:
     runs-on: ubuntu-latest
     env:
-      OUTPUT: endless-sky-amd64-${{ github.sha }}.tar.gz
+      OUTPUT: endless-sky-x86_64-${{ github.sha }}.tar.gz
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -27,6 +27,25 @@ jobs:
         run: scons -j $(nproc)
       - name: Package Application
         run: tar -czf ${{ env.OUTPUT }} sounds images/ data/ license.txt keys.txt icon.png endless-sky credits.txt copyright changelog
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ env.OUTPUT }}
+          path: ${{ env.OUTPUT }}
+
+  appimage_x86_64:
+    runs-on: ubuntu-latest
+    env:
+      OUTPUT: endless-sky-x86_64-${{ github.event.tag_name }}.AppImage
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons
+      - name: Build AppImage
+        run: ./build_appimage.sh
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -9,6 +9,7 @@ jobs:
   appimage_amd64:
     runs-on: ubuntu-latest
     env:
+      ARCH: x86_64
       OUTPUT: endless-sky-amd64-${{ github.event.release.tag_name }}.AppImage
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -19,7 +20,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons
       - name: Build AppImage
-        run: ./build_appimage.sh
+        run: ./utils/build_appimage.sh
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -9,7 +9,6 @@ jobs:
   appimage_amd64:
     runs-on: ubuntu-latest
     env:
-      ARCH: x86_64
       OUTPUT: endless-sky-amd64-${{ github.event.tag_name }}.AppImage
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -19,17 +18,8 @@ jobs:
           sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons
-      - name: Build Application
-        run: |
-          cp icons/icon_512x512.png endless-sky.png # We need an icon file with this name
-          scons -j $(nproc) install DESTDIR=AppDir 
-          # Inside an AppImage, the executable is a link called "AppRun" at the root of AppDir/.
-          # Keeping the data files next to the executable is perfectly valid, so we just move them to AppDir/ to avoid errors.
-          mv AppDir/usr/local/share/games/endless-sky/* AppDir/
       - name: Build AppImage
-        run: |
-          curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o linuxdeploy && chmod +x linuxdeploy
-          ./linuxdeploy --appdir AppDir -e endless-sky -d endless-sky.desktop -i endless-sky.png --output appimage
+        run: ./build_appimage.sh
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -9,7 +9,7 @@ jobs:
   appimage_amd64:
     runs-on: ubuntu-latest
     env:
-      OUTPUT: endless-sky-amd64-${{ github.event.tag_name }}.AppImage
+      OUTPUT: endless-sky-amd64-${{ github.event.release.tag_name }}.AppImage
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -1,0 +1,19 @@
+# Builds Endless Sky and packages it as AppImage
+# Control the output filename with the OUTPUT environment variable
+
+# We need an icon file with a name matching the executable
+cp icons/icon_512x512.png endless-sky.png
+
+# Build
+scons -j $(nproc) install DESTDIR=AppDir 
+
+# Inside an AppImage, the executable is a link called "AppRun" at the root of AppDir/.
+# Keeping the data files next to the executable is perfectly valid, so we just move them to AppDir/ to avoid errors.
+mv AppDir/usr/local/share/games/endless-sky/* AppDir/
+
+# Now build the actual AppImage
+curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o linuxdeploy && chmod +x linuxdeploy
+./linuxdeploy --appdir AppDir -e endless-sky -d endless-sky.desktop -i endless-sky.png --output appimage
+
+# Clean up
+rm -rf AppDir linuxdeploy endless-sky.png

--- a/utils/build_appimage.sh
+++ b/utils/build_appimage.sh
@@ -1,5 +1,8 @@
+#!/bin/bash
+
 # Builds Endless Sky and packages it as AppImage
 # Control the output filename with the OUTPUT environment variable
+# You may have to set the ARCH environment variable to e.g. x86_64.
 
 # We need an icon file with a name matching the executable
 cp icons/icon_512x512.png endless-sky.png


### PR DESCRIPTION
**Feature:** This PR adds an AppImage to the CD.

## Feature Details
Thus far AppImages were only build for releases. Since tarballs can link against libraries that the target system doesn't have, AppImages are a better choice for distributing portable linux packages.
This PR extracts the build steps into a script `build_appimage.sh`, which both the CD and Release CD use. It also fixes an issue with the Release CD's version number.

Please advise on where to put `build_appimage.sh`. Do we want a folder specifically for CI/CD scripts, similar to `test`?

## Testing Done
https://github.com/MCOfficer/endless-sky/releases/tag/appimage-test-2
https://github.com/MCOfficer/endless-sky/actions/runs/55112999