### PR TITLE
fix: Fully ignore the BACK command if FORWARD is also pressed.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3357,9 +3357,9 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 			command |= Command::FORWARD;
 		if(activeCommands.Has(Command::RIGHT | Command::LEFT))
 			command.SetTurn(activeCommands.Has(Command::RIGHT) - activeCommands.Has(Command::LEFT));
-		if(activeCommands.Has(Command::BACK))
+		if(activeCommands.Has(Command::BACK) && !activeCommands.Has(Command::FORWARD))
 		{
-			if(!activeCommands.Has(Command::FORWARD) && ship.Attributes().Get("reverse thrust"))
+			if(ship.Attributes().Get("reverse thrust"))
 				command |= Command::BACK;
 			else if(!activeCommands.Has(Command::RIGHT | Command::LEFT))
 				command.SetTurn(TurnBackward(ship));


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue regarding BACK with reverse thrusters and FORWARD behaving strangely.

## Fix Details
Zogdigi reported on Discord that the behaviour was confusing.
Behavior after this change is quite predictable: pressing FORWARD and BACK at the same time causes BACK to be completely ignored.
And just BACK with reverse thrusters causes reverse thrusters to fire.
While just BACK without reverse thrusters causes the ship to turn against its movement direction.

Discord is currently down for my location, so I cannot respond on the Discordapp.

## Testing Done
Briefly tested FORWARD+BACK, FORWARD-only and BACK-only with ships with and without reverse thrusters. The ships appeared to behave as expected.

## Save File
No save-file provided. But buying reverse thrusters on any ship allows testing of this feature.
I could create a save-file if desired.