### PR TITLE
Allow negative repair costs

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -72,9 +72,9 @@ namespace {
 			return;
 		
 		// Energy and fuel costs are the energy or fuel required per unit repaired.
-		if(energyCost)
+		if(energyCost > 0)
 			available = min(available, energy / energyCost);
-		if(fuelCost)
+		if(fuelCost > 0)
 			available = min(available, fuel / fuelCost);
 		
 		double transfer = min(available, maximum - stat);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -72,9 +72,9 @@ namespace {
 			return;
 		
 		// Energy and fuel costs are the energy or fuel required per unit repaired.
-		if(energyCost > 0)
+		if(energyCost > 0.)
 			available = min(available, energy / energyCost);
-		if(fuelCost > 0)
+		if(fuelCost > 0.)
 			available = min(available, fuel / fuelCost);
 		
 		double transfer = min(available, maximum - stat);


### PR DESCRIPTION
**Feature:** This PR implements ~~the feature request detailed and discussed in issue #{{insert number}}~~ a feature I thought of while updating #4520.

## Feature Details
Right now, if an outfit that repairs your hull or regens your shields has a negative energy or fuel cost, that blocks your hull or shields from being repaired/regenerated. This simple change makes it so that negative `energyCost` or `fuelCost` values no longer block repairs by causing the `available` repairs to become negative.

Note that this will still run into the issue of negative attributes being blocked on install, ref: #4682.

## UI Screenshots
N/A

## Usage Examples
The following shield generator would produce energy when in use (after you've forced it onto the ship):

```
outfit "Ion Converter"
	...
	"shield generation" 1
	"shield energy" -1
	...
```

## Testing Done
None.

## Performance Impact
N/A
