### PR TITLE
fix(cd): Compile AppImages on xenial rather than bionic

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,12 +2,12 @@ name: CD
 
 on:
   push:
-#    branches:
-#      - master
+    branches:
+      - master
 
 jobs:
   ubuntu_x86_64:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     env:
       OUTPUT: endless-sky-x86_64-${{ github.sha }}.tar.gz
     steps:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,12 +2,12 @@ name: CD
 
 on:
   push:
-    branches:
-      - master
+#    branches:
+#      - master
 
 jobs:
   ubuntu_x86_64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     env:
       OUTPUT: endless-sky-x86_64-${{ github.sha }}.tar.gz
     steps:
@@ -34,7 +34,7 @@ jobs:
           path: ${{ env.OUTPUT }}
 
   appimage_x86_64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     env:
       ARCH: x86_64
       OUTPUT: endless-sky-x86_64-${{ github.sha }}.AppImage

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   appimage_amd64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     env:
       ARCH: x86_64
       OUTPUT: endless-sky-amd64-${{ github.event.release.tag_name }}.AppImage


### PR DESCRIPTION
**Bugfix:** This PR potentially addresses issue #4923

## Fix Details
We shouldn't be linking against the newer version of glibc shipped with Bionic when Xenial is still LTS. With this PR, AppImages are built on Xenial.

## Testing Done
Tested in a clean Xenial VM. There are opposing results in #4923, however, so this is just a low-hanging-fruit fix.