### PR TITLE
More Shields Kestrel +10% heat dissipation

### DIFF
--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -336,6 +336,7 @@ ship "Kestrel" "Kestrel (More Shields)"
 	add attributes
 		"shields" 3000
 		"hull" 1500
+		"heat dissipation" .06
 
 ship "Kestrel" "Kestrel (More Weapons)"
 	add attributes


### PR DESCRIPTION
Prior to #3976, the More Shields Kestrel was by far the most popular option. <s>According to #4906, it is now by far the least chosen. That means it deserves a little extra (though nothing too major).</s>
This patch gives the More Shields Kestrel +10% heat dissipation, making it somewhat less vulnerable to heat damage weapons, consistent with it being the defensive variant.