### PR TITLE
fix: Typo in Kaeyin description (@Mr. Doom)

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -26603,7 +26603,7 @@ planet "Into White"
 planet "Kaeyin"
 	attributes uninhabited
 	landscape land/myrabella5
-	description `The world of Kaeyin now seems to be complately uninhabited, but it hasn't always been like that. Large, empty cities with towers of indescribable design encompass a portion of one single continent. The rest of the land remains almost untouched by anything not native to this planet, as if the buildings were simply lowered down onto the land rather than built up over time.`
+	description `The world of Kaeyin now seems to be completely uninhabited, but it hasn't always been like that. Large, empty cities with towers of indescribable design encompass a portion of one single continent. The rest of the land remains almost untouched by anything not native to this planet, as if the buildings were simply lowered down onto the land rather than built up over time.`
 	spaceport `The only word you can think of to describe the spaceport is "impressive." It is on the top of the largest tower, placed in the exact center of a gargantuan city. With a base almost as big as a sizable village, very quickly getting thinner as it raises into the city's skyline.`
 	spaceport `	Tiny, four-legged robots walk on the walls of every room, cleaning them in a matter of seconds. You can see more on the road below, and you presume they are everywhere in this city; this makes it impossible to estimate how long the planet has been abandoned, since everything here is perfect and clean.`
 


### PR DESCRIPTION
**Bugfix:** This PR addresses a typo in the description of Kaeyin.

## Fix Details
![image](https://user-images.githubusercontent.com/22377202/78051239-b00d7680-737d-11ea-826b-a819f50bce6c.png)
