### PR TITLE
Added and removed `minor` tags from certain missions

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -371,7 +371,6 @@ event "deep: warlord detected"
 
 
 mission "Deep: Mystery Cubes 1"
-	minor
 	landing
 	name `Travel to <planet>`
 	description `Travel to <destination> to learn more about the situation with the warlord Beelzebub.`
@@ -1823,7 +1822,6 @@ mission "Deep: Remnant Surveillance - Aventine"
 
 
 mission "Deep: Scientist Rescue Timer"
-	minor
 	landing
 	invisible
 	to offer

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3408,6 +3408,7 @@ mission "Capture Smuggler"
 
 mission "Inheritance Redirection"
 	description "Travel to <destination> to act as heir for the late warlord Limping Pappa."
+	minor
 	source
 		attributes "frontier"
 	destination
@@ -3474,6 +3475,7 @@ mission "Inheritance Redirection"
 mission "Hauler VI cargo prototype 1"
 	name "Escort Hauler prototype to formal dinner"
 	description "Escort the <npc> to <destination> to deliver sushi for a formal dinner."
+	minor
 	source
 		planet "Deep"
 	destination "Skymoot"


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #4965
## Fix Details
Added the `minor` tag to "Inheritance Redirection" and "Hauler VI cargo prototype 1", and removed the tag from "Deep: Mystery Cubes 1" and "Deep: Scientist Rescue Timer".
