### PR TITLE
Referenced the Hauler IV in the "Hauler VI cargo prototype" missions

### DIFF
--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3472,7 +3472,7 @@ mission "Inheritance Redirection"
 
 
 
-mission "Hauler VI cargo prototype 1"
+mission "Hauler IV cargo prototype 1"
 	name "Escort Hauler prototype to formal dinner"
 	description "Escort the <npc> to <destination> to deliver sushi for a formal dinner."
 	minor
@@ -3494,7 +3494,7 @@ mission "Hauler VI cargo prototype 1"
 					defer
 			`	She smiles and replies, "Well, I actually don't know you, but I just read your name on one of the cargo manifests. And my experience is that this greeting works best if you need something from a spaceship captain."`
 			label "hello too"
-			`	She says, "My name is Veronica Oxygenpocket, and I'm the lead for a team that's designing the new Hauler VI transport ship series at Southbound Shipyards."`
+			`	She says, "My name is Veronica Oxygenpocket, and I'm the lead for a team that's designing the new Hauler IV transport ship series at Southbound Shipyards."`
 			choice
 				`	"'Oxygenpocket' is an uncommon name."`
 				`	"And what help do you need from me?"`
@@ -3502,7 +3502,7 @@ mission "Hauler VI cargo prototype 1"
 			`	Veronica responds, "Well, it might sound uncommon to people from a planet with a breathable atmosphere, but it is actually similar to Vanderberg, which means 'from the mountain,' or Langley, which means 'woodland.'`
 			`	"Oxygenpockets were as much a feature on my home-planet as mountains and woodlands are on more habitable planets."`
 			label "help request"
-			`	Veronica pauses for a moment and then continues, "We're testing the VI's cargo refrigeration system using the Testament, a modified Hauler III. This system is one of our biggest achievements. To show how well it works, we plan to throw a formal dinner on <destination> with fresh sushi transported from here. I'm sure everyone at the dinner will be amazed by how well the food has been preserved despite the travel time. I'd like you to escort the ship and its cargo to <planet>."`
+			`	Veronica pauses for a moment and then continues, "We're testing the IV's cargo refrigeration system using the Testament, a modified Hauler III. This system is one of our biggest achievements. To show how well it works, we plan to throw a formal dinner on <destination> with fresh sushi transported from here. I'm sure everyone at the dinner will be amazed by how well the food has been preserved despite the travel time. I'd like you to escort the ship and its cargo to <planet>."`
 			choice
 				`	"Isn't it a bit risky to transport food using a refrigeration system that hasn't been tested yet?"`
 				`	"Am I also invited for the dinner?"`
@@ -3531,14 +3531,14 @@ mission "Hauler VI cargo prototype 1"
 		dialog
 			`You wait for the Testament to land, but it remains in orbit. There is no response to your hails. Maybe you should take off and investigate.`
 
-mission "Hauler VI cargo prototype 2"
+mission "Hauler IV cargo prototype 2"
 	name "Escort Hauler prototype to <planet>"
 	description "Escort the <npc> to <destination> to deliver cooked fish dishes to a streetfood festival."
 	source "Skymoot"
 	destination "Zug"
 	landing
 	to offer
-		has "Hauler VI cargo prototype 1: done"	
+		has "Hauler IV cargo prototype 1: done"	
 	npc accompany
 		government "Merchant"
 		personality escort timid
@@ -3553,13 +3553,13 @@ mission "Hauler VI cargo prototype 2"
 		dialog
 			`This time the Testament appears to be landing right behind you, but the ship flies away at full thrust just before touching the landing pad. You receive another message: "The Sushi completely burned. We cannot be seen near the festival or near the shipyard with this burned sushi! Our new destination is the waste processing plant at Longjump."`
 
-mission "Hauler VI cargo prototype 3"
+mission "Hauler IV cargo prototype 3"
 	name "Escort Hauler prototype to waste plant"
 	description "Escort the <npc> to <destination> to deliver charred food waste to a waste-processing plant."
 	destination "Longjump"
 	landing
 	to offer
-		has "Hauler VI cargo prototype 2: done"
+		has "Hauler IV cargo prototype 2: done"
 	npc accompany
 		government "Merchant"
 		personality escort timid

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3519,7 +3519,7 @@ mission "Hauler VI cargo prototype 1"
 				`	"Am I also invited for the dinner?"`
 					goto invited
 				`	"Why do you need me to escort the ship?"`
-					goto internal`
+					goto internal
 			label "refrigerate"
 			`	"Risky, why? I don't see what can go wrong. The system is quite well designed. I'm so proud of my team."`
 			choice

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3472,7 +3472,7 @@ mission "Inheritance Redirection"
 
 
 
-mission "Hauler IV cargo prototype 1"
+mission "Hauler VI cargo prototype 1"
 	name "Escort Hauler prototype to formal dinner"
 	description "Escort the <npc> to <destination> to deliver sushi for a formal dinner."
 	minor
@@ -3494,7 +3494,7 @@ mission "Hauler IV cargo prototype 1"
 					defer
 			`	She smiles and replies, "Well, I actually don't know you, but I just read your name on one of the cargo manifests. And my experience is that this greeting works best if you need something from a spaceship captain."`
 			label "hello too"
-			`	She says, "My name is Veronica Oxygenpocket, and I'm the lead for a team that's designing the new Hauler IV transport ship series at Southbound Shipyards."`
+			`	She says, "My name is Veronica Oxygenpocket, and I'm the lead for a team that's designing the new Hauler VI transport ship series at Southbound Shipyards."`
 			choice
 				`	"'Oxygenpocket' is an uncommon name."`
 				`	"And what help do you need from me?"`
@@ -3502,15 +3502,25 @@ mission "Hauler IV cargo prototype 1"
 			`	Veronica responds, "Well, it might sound uncommon to people from a planet with a breathable atmosphere, but it is actually similar to Vanderberg, which means 'from the mountain,' or Langley, which means 'woodland.'`
 			`	"Oxygenpockets were as much a feature on my home-planet as mountains and woodlands are on more habitable planets."`
 			label "help request"
-			`	Veronica pauses for a moment and then continues, "We're testing the IV's cargo refrigeration system using the Testament, a modified Hauler III. This system is one of our biggest achievements. To show how well it works, we plan to throw a formal dinner on <destination> with fresh sushi transported from here. I'm sure everyone at the dinner will be amazed by how well the food has been preserved despite the travel time. I'd like you to escort the ship and its cargo to <planet>."`
+			`	Veronica pauses for a moment and then continues, "We're testing the VI's cargo refrigeration system using the Testament, a modified Hauler III. This system is one of our biggest achievements. To show how well it works, we plan to throw a formal dinner on <destination> with fresh sushi transported from here. I'm sure everyone at the dinner will be amazed by how well the food has been preserved despite the travel time. I'd like you to escort the ship and its cargo to <planet>."`
+			choice
+				`	"Isn't it a bit risky to transport food using a refrigeration system that hasn't been tested yet?"`
+					goto refrigerate
+				`	"Am I also invited for the dinner?"`
+					goto invited
+				`	"Why do you need me to escort the ship?"`
+					goto internal
+				`	"Shouldn't you be making the Hauler IV first?"`
+				`	"Sure, I'll help you."`
+					accept
+			`	Veronica softly chuckles. "That would be the obvious choice, wouldn't it be? But this isn't just a case of slapping another cargo pod between the cockpit and engines, we've modified the design to have the optimal amount of cargo pods without comprimising the integrity of the vessel. And besides, our marketing department says that the people who are willing to by a Hauler IV are just as willing to buy larger Haulers."`
 			choice
 				`	"Isn't it a bit risky to transport food using a refrigeration system that hasn't been tested yet?"`
 				`	"Am I also invited for the dinner?"`
 					goto invited
 				`	"Why do you need me to escort the ship?"`
-					goto internal
-				`	"Sure, I'll help you."`
-					accept
+					goto internal`
+			label refrigerate
 			`	"Risky, why? I don't see what can go wrong. The system is quite well designed. I'm so proud of my team."`
 			choice
 				`	"Am I also invited for the dinner?"`
@@ -3531,14 +3541,14 @@ mission "Hauler IV cargo prototype 1"
 		dialog
 			`You wait for the Testament to land, but it remains in orbit. There is no response to your hails. Maybe you should take off and investigate.`
 
-mission "Hauler IV cargo prototype 2"
+mission "Hauler VI cargo prototype 2"
 	name "Escort Hauler prototype to <planet>"
 	description "Escort the <npc> to <destination> to deliver cooked fish dishes to a streetfood festival."
 	source "Skymoot"
 	destination "Zug"
 	landing
 	to offer
-		has "Hauler IV cargo prototype 1: done"	
+		has "Hauler VI cargo prototype 1: done"	
 	npc accompany
 		government "Merchant"
 		personality escort timid
@@ -3553,13 +3563,13 @@ mission "Hauler IV cargo prototype 2"
 		dialog
 			`This time the Testament appears to be landing right behind you, but the ship flies away at full thrust just before touching the landing pad. You receive another message: "The Sushi completely burned. We cannot be seen near the festival or near the shipyard with this burned sushi! Our new destination is the waste processing plant at Longjump."`
 
-mission "Hauler IV cargo prototype 3"
+mission "Hauler VI cargo prototype 3"
 	name "Escort Hauler prototype to waste plant"
 	description "Escort the <npc> to <destination> to deliver charred food waste to a waste-processing plant."
 	destination "Longjump"
 	landing
 	to offer
-		has "Hauler IV cargo prototype 2: done"
+		has "Hauler VI cargo prototype 2: done"
 	npc accompany
 		government "Merchant"
 		personality escort timid

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3513,7 +3513,7 @@ mission "Hauler VI cargo prototype 1"
 				`	"Shouldn't you be making the Hauler IV first?"`
 				`	"Sure, I'll help you."`
 					accept
-			`	Veronica softly chuckles. "That would be the obvious choice, wouldn't it be? But this isn't just a case of slapping another cargo pod between the cockpit and engines, we've modified the design to have the optimal amount of cargo pods without comprimising the integrity of the vessel. And besides, our marketing department says that the people who are willing to by a Hauler IV are just as willing to buy larger Haulers."`
+			`	Veronica softly chuckles. "That would be the obvious choice, wouldn't it be? But this isn't just a case of slapping another cargo pod between the cockpit and engines. We've modified the design to have the optimal amount of cargo pods without compromising the integrity of the vessel, or making it difficult to build in our existing shipyards. And besides, our marketing department has found that captains willing to buy a Hauler IV are just as willing to buy larger Haulers."`
 			choice
 				`	"Isn't it a bit risky to transport food using a refrigeration system that hasn't been tested yet?"`
 				`	"Am I also invited for the dinner?"`

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3520,7 +3520,7 @@ mission "Hauler VI cargo prototype 1"
 					goto invited
 				`	"Why do you need me to escort the ship?"`
 					goto internal`
-			label refrigerate
+			label "refrigerate"
 			`	"Risky, why? I don't see what can go wrong. The system is quite well designed. I'm so proud of my team."`
 			choice
 				`	"Am I also invited for the dinner?"`


### PR DESCRIPTION
## Fix Details
~~In the "Hauler VI cargo prototype" missions, the Hauler VI is referred to. This is an odd choice in my opinion, as VI means 6, not 4, and the Hauler IV (4) would be the logical step up. This PR changes all mentions of "Hauler VI" to "Hauler IV". An alternative solution could be to keep it as the Hauler VI, but add a bit of dialogue referring to this oddity ("Why VI and not IV?").~~

In response to the feedback from Zitchas, Derpy and petervdmeer, I've changed the PR to add a new choice that covers the apparent oddness of moving from the Hauler III straight to the Hauler VI.
