### PR TITLE
Switching the order of Artwork/photos

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -59,6 +59,21 @@ Editors & Proofreaders
   temtemy
   Zearth Goh aka TheMarksman
 
+Artwork
+  Michael Zahniser (CC-BY-SA 4.0)
+  Maximilian Korber (CC-BY-SA 4.0)
+  Iaz Poolar (CC-BY-SA 4.0)
+  Matthew Smestad (CC-BY-SA 4.0)
+  Jonathan Steck (CC-BY-SA 4.0)
+  Nate Graham (CC-BY-SA 4.0)
+  Evan Fluharty (CC-BY-SA 4.0)
+  Nick Barry (CC-BY-SA 3.0)
+  ESO / L. Calcada (CC-BY-4.0)
+  Becca Tommaso (CC-BY-SA 4.0)
+  Frederick Goy IV (CC-BY-SA 4.0)
+  Zachary Siple (CC-BY-SA 4.0)
+  Darcy Manoel (CC-BY-SA 4.0)
+
 Photos from Wikimedia Commons
   Berthold Werner (CC-BY-SA 3.0)
   Dmitry A. Mottl (CC-BY-SA 3.0)
@@ -77,21 +92,6 @@ and from public domain sources
   US Army
   morguefile.com
   unsplash.com
-
-Other Artwork
-  Michael Zahniser (CC-BY-SA 4.0)
-  Maximilian Korber (CC-BY-SA 4.0)
-  Iaz Poolar (CC-BY-SA 4.0)
-  Matthew Smestad (CC-BY-SA 4.0)
-  Jonathan Steck (CC-BY-SA 4.0)
-  Nate Graham (CC-BY-SA 4.0)
-  Evan Fluharty (CC-BY-SA 4.0)
-  Nick Barry (CC-BY-SA 3.0)
-  ESO / L. Calcada (CC-BY-4.0)
-  Becca Tommaso (CC-BY-SA 4.0)
-  Frederick Goy IV (CC-BY-SA 4.0)
-  Zachary Siple (CC-BY-SA 4.0)
-  Darcy Manoel (CC-BY-SA 4.0)
 
 Sounds from public domain sources
   freesound.org


### PR DESCRIPTION
Moving the Artwork section up to be in front of the photos section, because I think the artwork section (which represents original artwork and derivations by community members, and are thus created for this project) should appear in the list alongside the other sections dedicated to stuff created for this project (programmers, writers, and editors), instead of being tacked on *after* the section crediting photographs that are neither original to this project nor created for it.

Basically, switching the "artwork" section with the "photos" section.
One last tweak to the order that I didn't quite get done before the Credits got merged in #4962 .