### PR TITLE
Drak turret updates to shut down super-heavies

### DIFF
--- a/data/drak/drak.txt
+++ b/data/drak/drak.txt
@@ -94,6 +94,10 @@ outfit "Drak Turret"
 		"shield damage" 256
 		"hull damage" 256
 		"hit force" 120
+		# Updates to shut down super-heavies that can handle
+		# the Drak's damage output:
+		"ion damage" 20000
+		"heat damage" 40000
 	description "This is a turret based cannon with significant range and accuracy."
 
 effect "drak bolt impact"

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -768,7 +768,9 @@ mission "Remnant: Void Sprites 3"
 	npc
 		government " Drak "
 		system "Nenia"
-		personality staying heroic nemesis uninterested
+		personality
+			staying heroic nemesis uninterested
+			confusion 30
 		ship "Archon (Cloaked)" "Lifted Lorax"
 	on stopover
 		conversation
@@ -1256,7 +1258,9 @@ mission "Remnant: Return the Samples"
 	npc
 		government " Drak "
 		system "Nenia"
-		personality staying heroic nemesis uninterested
+		personality
+			staying heroic nemesis uninterested
+			confusion 30
 		ship "Archon (Cloaked)" "Lifted Lorax"
 	on accept
 		log "People" "Plume" `A Remnant researcher specializing in xenobiology, Plume is at the forefront of recent efforts to restart research on the void sprites and a leading expert in non-carbon based lifeforms.`
@@ -1297,7 +1301,9 @@ mission "Remnant: Return the Samples 2"
 	npc
 		government "Drak"
 		system "Nenia"
-		personality staying heroic nemesis uninterested
+		personality
+			staying heroic nemesis uninterested
+			confusion 30
 		ship "Archon" "Lifted Lorax"
 	on stopover
 		conversation


### PR DESCRIPTION
The Drak Archon is unable to handle ships whose damage output and repair are equal to its own. As Tier 2 and 3 super-heavies are added, this makes the Archon vulnerable, especially if one mixes outfits from many races. 

This update adds ion and heat damage to the Drak Turret sufficient to shut down super-heavies with Korath cooling, Quarg batteries, Quarg generators, and enough thrust to outrun the Archon. It was tested with three min-maxed Korath Havens who, as a result of these changes, could no longer get in range.

Unfortunately, this makes the turret essentially instant death to the Gascraft since that ship is shut down for a few seconds after one hit. This update also adds 30 confusion to the Nenia Drak during the gascraft missions, sufficient to dodge the shots with good reliability.
