### PR TITLE
Delay launch of pure noncombatant fighters & drones

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -131,7 +131,7 @@ namespace {
 	// Determine if the ship has sensors.
 	bool CanScan(const Ship &ship)
 	{
-		if ( ship.Attributes().Get("cargo scan power") + ship.Attributes().Get("outfit scan power") + ship.Attributes().Get("atmosphere scan") + ship.Attributes().Get("asteroid scan power") > 0 )
+		if ( ship.Attributes().Get("cargo scan power") + ship.Attributes().Get("outfit scan power") + ship.Attributes().Get("atmosphere scan") + ship.Attributes().Get("asteroid scan power") + ship.Attributes().Get("tactical scan power") > 0 )
 			return true;
 		return false;
 	}
@@ -140,7 +140,7 @@ namespace {
 	void Deploy(const Ship &ship, bool includingDamaged)
 	{
 		for(const Ship::Bay &bay : ship.Bays())
-			if(bay.ship && (includingDamaged || ( bay.ship->Health() > .75 && ( IsArmed(*bay.ship) || CanAntimissile(*bay.ship) || CanScan(*bay.ship) || ship.Health() < 0.375 ))))
+			if(bay.ship && (includingDamaged || ( bay.ship->Health() > .75 && ( IsArmed(*bay.ship) || CanAntimissile(*bay.ship) || CanScan(*bay.ship) || (ship.Shields() + ship.Hull() < 1 )))))
 				bay.ship->SetCommands(Command::DEPLOY);
 	}
 	
@@ -1651,7 +1651,8 @@ bool AI::ShouldDock(const Ship &ship, const Ship &parent, bool playerShipsLaunch
 			maxRange = max(maxRange, weapon->Range());
 		}
 	}
-	if(!maxRange && ( ship.Health() <= parent.Health() || parent.Health() > 0.5))
+	double canScan = ( ship.Attributes().Get("cargo scan power") + ship.Attributes().Get("outfit scan power") + ship.Attributes().Get("atmosphere scan") + ship.Attributes().Get("asteroid scan power") + ship.Attributes().Get("tactical scan power") > 0 );
+	if(!maxRange && !canScan && ( ship.Health() <= parent.Health() || (parent.Hull() + parent.Shields() > 1 )))
 		return true;
 	
 	// If a fighter has fuel capacity but is very low, it should return if

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -140,7 +140,7 @@ namespace {
 	void Deploy(const Ship &ship, bool includingDamaged)
 	{
 		for(const Ship::Bay &bay : ship.Bays())
-			if(bay.ship && (includingDamaged || ( bay.ship->Health() > .75 && ( IsArmed(*bay.ship) || CanAntimissile(*bay.ship) || CanScan(*bay.ship) || (ship.Shields() + ship.Hull() < 1 )))))
+			if(bay.ship && (includingDamaged || ( bay.ship->Health() > .75 && ( IsArmed(*bay.ship) || CanAntimissile(*bay.ship) || CanScan(*bay.ship) || (ship.Shields() + ship.Hull() < 0.75 )))))
 				bay.ship->SetCommands(Command::DEPLOY);
 	}
 	


### PR DESCRIPTION
<!--**Enhancement / Mechanics**?-->

## Summary
This PR adds some logic to Command::DEPLOY and AI::ShouldDock in AI.cpp for unarmed carried ships.  If a fighter or drone has no usable weapons, no anti-missile turrets, and no scanners (e.g., a Boxwing or a Faes'mar), it will now refrain from launching when the Deploy command is issued until its parent ship is below 3/8 health (from full with no disruption, 75% hull).

Once launched, said unarmed ships - and pure missile fighters that have run out of ammo - will attempt to return to their parent if either the parent is above 50% health, or they are at lower health than their parent.

This will allow a carrier with a mix of cargo drones and combat fighters to safely launch its fighters without worrying about losing its cargo drones, unless the carrier itself is in danger and wishes to shed the weight of and shield itself with its cargo drones.

The exemption from this behaviour for fighters/drones with scanners preserves the behaviour of Navy Surveillance Cruisers. It has a side effect of allowing the player to specify they want a particular fighter to always launch by placing a cargo scanner on it.

The object of this PR was to open up possibilities for more noncombatant carried ships without them acting silly, and to open up possibilities for practical mixed boxwing-fighter or missile fighter use.

## Save File
This save file has a player with five Tek Far 71 Lek's, five Skeins, and a diverse complement of fighters and drones to test.  The player is in the Tarazed system where fighters and carriers may be purchased, and has been around long enough for the FW carriers to start appearing.  It was created with the All-Content plugin, which is not necessary to have installed.

[Smart Boxwings.txt](https://github.com/endless-sky/endless-sky/files/4500619/Smart.Boxwings.txt)

<!--## PR Checklist
 - [ ] I  decline to claim copyright of any assets produced or modified
 - [ ] I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}
 - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}
 
-----------------------
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
{{add details}}-->

## Testing Done
Flying around with the above save, fighting and watching how my ships react, firing on my own ships to verify launch behaviour, spawning in AI-controlled ships with Boxwings to see how they react, observing Navy Surveillance cruisers to make sure they're unaffected.

Compiled & tested on a Debian 8 machine.

<!-- ## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}} -->

-----------------------
<!--**Feature:** This PR implements the feature request detailed and discussed in issue #{{insert number}}

## Feature Details
{{add details about the feature you implemented}} -->

## UI Screenshots

Showing fleet after a Deploy command issued, note the Faes'mar have not launched:

![no-launched-boxwings](https://user-images.githubusercontent.com/31712538/79704345-aeccbc80-824c-11ea-86e2-b42270a9a1e5.png)

After some combat, a Seli'maar equipped with Sidewinders has run out of ammo and returned to its mothership, while another that still has ammo remains in space.

![out-of-ammo](https://user-images.githubusercontent.com/31712538/79704364-d0c63f00-824c-11ea-923a-19914546ae22.png)

While firing on this escort, it launches its Faes'maars having lost sheilds.

![launched-boxwings1](https://user-images.githubusercontent.com/31712538/79704389-f4898500-824c-11ea-8aae-2a118aaf3d5a.png)

<!-- ## Usage Examples
{{if this feature is used in the data files, provide examples!}}

## Testing Done
{{describe how you tested the new feature}} -->

## Performance Impact
Possible negative impact as it is adding complexity to the AI code.