### PR TITLE
Increase Quarg attitude towards Kor Efret

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -426,7 +426,7 @@ government "Quarg"
 	"player reputation" 1
 	"attitude toward"
 		"Merchant" .01
-		"Kor Efret" .01
+		"Kor Efret" .25
 		"Kor Mereti" -.01
 		"Kor Sestor" -.01
 		"Hai" .01


### PR DESCRIPTION
The Quarg claim to protect the Kor Efret, but presently the penalty for attacking the Kor Efret is quite low. This updates the Quarg attitude to 0.25, so they really will protect the Kor Efret.
