### PR TITLE
Creating the copyright entry for Ravenshining's work

### DIFF
--- a/copyright
+++ b/copyright
@@ -704,6 +704,22 @@ Copyright: Benjamin Jackson (gods.benyamin@outlook.com)
 License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license)
 
+Files
+ images/planet/browndwarf-l-rouge*
+ images/planet/browndwarf-l*
+ images/planet/browndwarf-y-rouge*
+ images/planet/browndwarf-y*
+Copyright: Lia Gerty (https://github.com/ravenshining)
+License: CC-BY-SA-4.0
+Comment: Derived from works by Michael Zahniser (under the same license)
+
+Files
+ images/planet/browndwarf-t-rouge*
+ images/planet/browndwarf-t*
+Copyright: Lia Gerty (https://github.com/ravenshining)
+License: CC-BY-SA-4.0
+Comment: Derived from works by NASA (public domain)
+ 
 
 License: GPL-3+
  This program is free software: you can redistribute it and/or modify

--- a/copyright
+++ b/copyright
@@ -711,7 +711,6 @@ Files
  images/planet/browndwarf-y*
 Copyright: Lia Gerty (https://github.com/ravenshining)
 License: CC-BY-SA-4.0
-Comment: Derived from works by Michael Zahniser (under the same license)
 
 Files
  images/planet/browndwarf-t-rouge*

--- a/credits.txt
+++ b/credits.txt
@@ -73,6 +73,7 @@ Artwork
   Frederick Goy IV (CC-BY-SA 4.0)
   Zachary Siple (CC-BY-SA 4.0)
   Darcy Manoel (CC-BY-SA 4.0)
+  Lia Gerty (CC-BY-SA 4.0) 
 
 Photos from Wikimedia Commons
   Berthold Werner (CC-BY-SA 3.0)


### PR DESCRIPTION
This simply adds proper credit for Ravenshining's images. Four are their own works, and two are derivative of NASA's public domain images.