### PR TITLE
feat: Also build CD on PRs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types: 
+      - synchronize # New commit has been pushed
+      - opened
 
 jobs:
 
@@ -114,7 +118,8 @@ jobs:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
 
-  process_artifacts:
+  upload_artifacts_to_release:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - ubuntu_x86_64
@@ -209,4 +214,4 @@ jobs:
             --replace \
             --name ${{ env.OUTPUT_MACOS }} \
             --file ${{ env.OUTPUT_MACOS }}
-      
+    

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
 
-  ubuntu_x86_64:
+  cd_ubuntu_x86_64:
     runs-on: ubuntu-latest
     env:
       OUTPUT: endless-sky-x86_64-continuous.tar.gz
@@ -35,7 +35,7 @@ jobs:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
 
-  appimage_x86_64:
+  cd_appimage_x86_64:
     runs-on: ubuntu-16.04
     env:
       ARCH: x86_64
@@ -57,7 +57,7 @@ jobs:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
 
-  windows_win64:
+  cd_windows_win64:
     runs-on: windows-latest
     env:
       DIR_MINGW64: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32
@@ -89,10 +89,10 @@ jobs:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
 
-  macos_x86_64:
+  cd_macos_x86_64:
     runs-on: macos-latest
     env:
-      OUTPUT: EndlessSky-macOS-continuous.zip
+      OUTPUT: EndlessSky-macOS10.15-continuous.zip
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -118,20 +118,20 @@ jobs:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
 
-  upload_artifacts_to_release:
+  cd_upload_artifacts_to_release:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
-      - ubuntu_x86_64
-      - appimage_x86_64
-      - windows_win64
-      - macos_x86_64
+      - cd_ubuntu_x86_64
+      - cd_appimage_x86_64
+      - cd_windows_win64
+      - cd_macos_x86_64
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OUTPUT_UBUNTU: endless-sky-x86_64-continuous.tar.gz
       OUTPUT_APPIMAGE: endless-sky-x86_64-continuous.AppImage
       OUTPUT_WINDOWS: EndlessSky-win64-continuous.zip
-      OUTPUT_MACOS: EndlessSky-macOS-continuous.zip
+      OUTPUT_MACOS: EndlessSky-macOS10.15-continuous.zip
     steps:
       - uses: actions/checkout@v2
       - name: Install gothub


### PR DESCRIPTION
**Feature:** This PR implements enables CD builds on Pull Requests, so people can download and playtest PRs without having to compile.

## Feature Details
With this change, the CD workflow will run,
1. when a new commit is pushed to the master branch
2. when a PR is opened
3. when new commit are added to a PR

In the case of 1), artifacts will be published to the `continuous` release. For PRs, artifacts can be downloaded from the "Checks" tab:
https://gfycat.com/annualtintedcopepod

The download is still only available for logged-in users: https://github.com/actions/upload-artifact/issues/51

## Testing Done
Tested on a multitude of PRs. As far as i can tell, this change needs to be in the head branch, so this will not work for old PRs until they merge master.

## Follow-up features:
Post a comment on the PR with links to the assets. Unfortunately, Github's Actions API is still somewhat immature, so this would require querying and parsing the Github API. There is a nice action for "Sticky" comments, though: https://github.com/marocchino/sticky-pull-request-comment