### PR TITLE
Missile changes

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -614,7 +614,7 @@ effect "flamethrower hit"
 
 outfit "Meteor Missile"
 	category "Ammunition"
-	cost 500
+	cost 250
 	thumbnail "outfit/meteor"
 	"mass" .2
 	"meteor capacity" -1
@@ -627,7 +627,7 @@ outfit "Meteor Missile Box"
 	thumbnail "outfit/meteor storage"
 	"mass" 2
 	"outfit space" -5
-	"meteor capacity" 15
+	"meteor capacity" 30
 	ammo "Meteor Missile"
 	description "The Meteor Missile Box is used to store extra ammunition for Meteor Missile Launchers."
 
@@ -677,7 +677,7 @@ effect "meteor fire"
 
 outfit "Sidewinder Missile"
 	category "Ammunition"
-	cost 900
+	cost 450
 	thumbnail "outfit/sidewinder"
 	"mass" .2
 	"sidewinder capacity" -1
@@ -689,7 +689,7 @@ outfit "Sidewinder Missile Rack"
 	thumbnail "outfit/sidewinder storage"
 	"mass" 2.4
 	"outfit space" -7
-	"sidewinder capacity" 23
+	"sidewinder capacity" 46
 	ammo "Sidewinder Missile"
 	description "The Sidewinder Missile Rack is used to store extra ammunition for Sidewinder Missile Launchers."
 
@@ -740,7 +740,7 @@ effect "sidewinder fire"
 
 outfit "Javelin"
 	category "Ammunition"
-	cost 50
+	cost 25
 	thumbnail "outfit/javelin"
 	"mass" .04
 	"javelin capacity" -1
@@ -752,7 +752,7 @@ outfit "Javelin Storage Crate"
 	thumbnail "outfit/javelin storage"
 	"mass" 2
 	"outfit space" -6
-	"javelin capacity" 100
+	"javelin capacity" 200
 	ammo "Javelin"
 	description "The Javelin Storage Crate is used to store extra ammunition for Javelin Pods."
 
@@ -800,7 +800,7 @@ outfit "Torpedo Storage Rack"
 	thumbnail "outfit/torpedo storage"
 	"mass" 3
 	"outfit space" -9
-	"torpedo capacity" 15
+	"torpedo capacity" 30
 	ammo "Torpedo"
 	description "The Torpedo Storage Rack is used to store extra ammunition for Torpedo Launchers."
 
@@ -862,7 +862,7 @@ outfit "Typhoon Storage Tube"
 	thumbnail "outfit/typhoon storage"
 	"mass" 2.5
 	"outfit space" -10
-	"typhoon capacity" 15
+	"typhoon capacity" 30
 	ammo "Typhoon Torpedo"
 	description "The Typhoon Storage Tube is used to store extra ammunition for Typhoon Launchers."
 
@@ -896,10 +896,10 @@ outfit "Typhoon Launcher"
 		"turn" 1.5
 		"homing" 4
 		"optical tracking" .9
-		"shield damage" 880
-		"hull damage" 880
+		"shield damage" 920
+		"hull damage" 920
 		"hit force" 450
-		"missile strength" 40
+		"missile strength" 60
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."
 
 effect "typhoon fire"
@@ -911,7 +911,7 @@ effect "typhoon fire"
 
 outfit "Heavy Rocket"
 	category "Ammunition"
-	cost 2000
+	cost 1000
 	thumbnail "outfit/rocket"
 	"mass" .5
 	"rocket capacity" -1
@@ -923,7 +923,7 @@ outfit "Heavy Rocket Rack"
 	thumbnail "outfit/rocket storage"
 	"mass" 2
 	"outfit space" -7
-	"rocket capacity" 10
+	"rocket capacity" 20
 	ammo "Heavy Rocket"
 	description "The Heavy Rocket Rack is used to store extra ammunition for Heavy Rocket Launchers."
 
@@ -955,10 +955,10 @@ outfit "Heavy Rocket Launcher"
 		"trigger radius" 20
 		"blast radius" 50
 		"shield damage" 850
-		"hull damage" 720
+		"hull damage" 460
 		"hit force" 600
 		"missile strength" 16
-	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
+	description "Heavy Rockets are one of the most powerful missile weapons available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
 
 effect "heavy rocket hit"
 	sprite "effect/explosion/huge"
@@ -1049,7 +1049,7 @@ effect "nuke residue slow"
 outfit "Gatling Gun Ammo"
 	plural "Gatling Gun Ammo"
 	category "Ammunition"
-	cost 4
+	cost 2
 	thumbnail "outfit/bullet"
 	"mass" .002
 	"gatling round capacity" -1
@@ -1062,7 +1062,7 @@ outfit "Bullet Boxes"
 	thumbnail "outfit/bullet storage"
 	"mass" 2
 	"outfit space" -5
-	"gatling round capacity" 1500
+	"gatling round capacity" 3000
 	ammo "Gatling Gun Ammo"
 	description "Bullet Boxes are used to store extra ammunition for Gatling Guns."
 


### PR DESCRIPTION
This is a tweaking of how both early game and late game missiles work, making early game missiles more practical, and giving underperforming late game missiles boosts where they need them.

Changes:

All missile racks and box given double storage capacity. (I'm counting Gatling gun as a missile launcher.)
All human missiles, barring the typhoon and the torpedo, have 1/2 price.
Typhoon damage increased from 880 to 920 and missile strength increased form 40 to 60.
Heavy rocket hull damage reduced from 720 to 460 and description tweaked.
Minelayer capacity increased from 17 to 18, piercer capacity increased from 31 to 32.
Korath piercers piercing upgraded form 0.2 to 0.6.
Korath mines given a slow value of 2.
Thunderhead missiles missile strength greatly increased (12-40) before the casing breaks off.
Korath missiles available at Korath outfitters.