### PR TITLE
Missile Tweaks

### DIFF
--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -193,7 +193,7 @@ outfit "Tracker Storage Pod"
 	thumbnail "outfit/hai tracker storage"
 	"mass" 4.4
 	"outfit space" -10
-	"tracker capacity" 28
+	"tracker capacity" 56
 	ammo "Hai Tracker"
 	description "The Tracker Storage Pod is used to store extra ammunition for Tracker Pods."
 

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -614,7 +614,7 @@ effect "flamethrower hit"
 
 outfit "Meteor Missile"
 	category "Ammunition"
-	cost 500
+	cost 250
 	thumbnail "outfit/meteor"
 	"mass" .2
 	"meteor capacity" -1
@@ -627,7 +627,7 @@ outfit "Meteor Missile Box"
 	thumbnail "outfit/meteor storage"
 	"mass" 2
 	"outfit space" -5
-	"meteor capacity" 15
+	"meteor capacity" 30
 	ammo "Meteor Missile"
 	description "The Meteor Missile Box is used to store extra ammunition for Meteor Missile Launchers."
 
@@ -677,7 +677,7 @@ effect "meteor fire"
 
 outfit "Sidewinder Missile"
 	category "Ammunition"
-	cost 900
+	cost 450
 	thumbnail "outfit/sidewinder"
 	"mass" .2
 	"sidewinder capacity" -1
@@ -689,7 +689,7 @@ outfit "Sidewinder Missile Rack"
 	thumbnail "outfit/sidewinder storage"
 	"mass" 2.4
 	"outfit space" -7
-	"sidewinder capacity" 23
+	"sidewinder capacity" 46
 	ammo "Sidewinder Missile"
 	description "The Sidewinder Missile Rack is used to store extra ammunition for Sidewinder Missile Launchers."
 
@@ -740,7 +740,7 @@ effect "sidewinder fire"
 
 outfit "Javelin"
 	category "Ammunition"
-	cost 50
+	cost 25
 	thumbnail "outfit/javelin"
 	"mass" .04
 	"javelin capacity" -1
@@ -752,7 +752,7 @@ outfit "Javelin Storage Crate"
 	thumbnail "outfit/javelin storage"
 	"mass" 2
 	"outfit space" -6
-	"javelin capacity" 100
+	"javelin capacity" 200
 	ammo "Javelin"
 	description "The Javelin Storage Crate is used to store extra ammunition for Javelin Pods."
 
@@ -800,7 +800,7 @@ outfit "Torpedo Storage Rack"
 	thumbnail "outfit/torpedo storage"
 	"mass" 3
 	"outfit space" -9
-	"torpedo capacity" 15
+	"torpedo capacity" 30
 	ammo "Torpedo"
 	description "The Torpedo Storage Rack is used to store extra ammunition for Torpedo Launchers."
 
@@ -862,7 +862,7 @@ outfit "Typhoon Storage Tube"
 	thumbnail "outfit/typhoon storage"
 	"mass" 2.5
 	"outfit space" -10
-	"typhoon capacity" 15
+	"typhoon capacity" 30
 	ammo "Typhoon Torpedo"
 	description "The Typhoon Storage Tube is used to store extra ammunition for Typhoon Launchers."
 
@@ -896,10 +896,10 @@ outfit "Typhoon Launcher"
 		"turn" 1.5
 		"homing" 4
 		"optical tracking" .9
-		"shield damage" 880
-		"hull damage" 880
+		"shield damage" 920
+		"hull damage" 920
 		"hit force" 450
-		"missile strength" 40
+		"missile strength" 60
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."
 
 effect "typhoon fire"
@@ -911,7 +911,7 @@ effect "typhoon fire"
 
 outfit "Heavy Rocket"
 	category "Ammunition"
-	cost 2000
+	cost 1000
 	thumbnail "outfit/rocket"
 	"mass" .5
 	"rocket capacity" -1
@@ -923,7 +923,7 @@ outfit "Heavy Rocket Rack"
 	thumbnail "outfit/rocket storage"
 	"mass" 2
 	"outfit space" -7
-	"rocket capacity" 10
+	"rocket capacity" 20
 	ammo "Heavy Rocket"
 	description "The Heavy Rocket Rack is used to store extra ammunition for Heavy Rocket Launchers."
 
@@ -955,10 +955,10 @@ outfit "Heavy Rocket Launcher"
 		"trigger radius" 20
 		"blast radius" 50
 		"shield damage" 850
-		"hull damage" 720
+		"hull damage" 460
 		"hit force" 600
 		"missile strength" 16
-	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
+	description "Heavy Rockets are one of the most powerful missile weapons available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
 
 effect "heavy rocket hit"
 	sprite "effect/explosion/huge"
@@ -1049,7 +1049,7 @@ effect "nuke residue slow"
 outfit "Gatling Gun Ammo"
 	plural "Gatling Gun Ammo"
 	category "Ammunition"
-	cost 4
+	cost 2
 	thumbnail "outfit/bullet"
 	"mass" .002
 	"gatling round capacity" -1
@@ -1062,7 +1062,7 @@ outfit "Bullet Boxes"
 	thumbnail "outfit/bullet storage"
 	"mass" 2
 	"outfit space" -5
-	"gatling round capacity" 1500
+	"gatling round capacity" 3000
 	ammo "Gatling Gun Ammo"
 	description "Bullet Boxes are used to store extra ammunition for Gatling Guns."
 

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -238,7 +238,7 @@ outfit "Korath Piercer Rack"
 	thumbnail "outfit/korath piercer storage"
 	"mass" 2.2
 	"outfit space" -7
-	"piercer capacity" 16
+	"piercer capacity" 32
 	ammo "Korath Piercer"
 	description "The Korath Piercer Rack is used to store extra ammunition for Korath Piercer Launchers."
 
@@ -251,7 +251,7 @@ outfit "Korath Piercer Launcher"
 	"weapon capacity" -27
 	"energy capacity" 50
 	"gun ports" -1
-	"piercer capacity" 31
+	"piercer capacity" 32
 	weapon
 		sprite "projectile/piercer"
 			"frame rate" 5
@@ -276,7 +276,7 @@ outfit "Korath Piercer Launcher"
 		"infrared tracking" .9
 		"shield damage" 290
 		"hull damage" 440
-		"piercing" .2
+		"piercing" .6
 		"hit force" 300
 		"missile strength" 73
 		"stream"
@@ -390,7 +390,7 @@ outfit "Korath Mine Rack"
 	thumbnail "outfit/korath mine storage"
 	"mass" 2.7
 	"outfit space" -9
-	"minelayer capacity" 9
+	"minelayer capacity" 18
 	ammo "Korath Mine"
 	description "The Korath Mine Rack is used to store extra ammunition for Korath Minelayers."
 
@@ -403,7 +403,7 @@ outfit "Korath Minelayer"
 	"weapon capacity" -48
 	"energy capacity" 50
 	"gun ports" -1
-	"minelayer capacity" 17
+	"minelayer capacity" 18
 	weapon
 		sprite "projectile/korath minelayer"
 			"frame rate" .6
@@ -449,6 +449,7 @@ outfit "Korath Mine Submunition"
 		"drag" .05
 		"shield damage" 350
 		"hull damage" 280
+		"slowing damage" 2
 		"hit force" 200
 		"missile strength" 22
 

--- a/data/korath/korath.txt
+++ b/data/korath/korath.txt
@@ -582,6 +582,8 @@ fleet "Kor Mereti Miners"
 
 
 outfitter "Korath Basics"
+	"Korath Piercer"
+	"Korath Mine"
 	"Korath Piercer Rack"
 	"Korath Mine Rack"
 	"Command Center"

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -249,7 +249,7 @@ outfit "Thunderhead Launcher"
 		"homing" 4
 		"infrared tracking" .9
 		"radar tracking" .6
-		"missile strength" 12
+		"missile strength" 40
 	description "A prime example of Wanderer ingenuity, Thunderhead missiles each carry five submunitions that are capable of independent tracking. Even if the target is able to shoot down or evade a few of them, the remaining missile fragments will still find their mark."
 
 outfit "Thunderhead Missile"
@@ -289,7 +289,7 @@ outfit "Thunderhead Storage Array"
 	thumbnail "outfit/thunderhead storage"
 	"mass" 2
 	"outfit space" -8
-	"thunderhead capacity" 20
+	"thunderhead capacity" 40
 	ammo "Thunderhead Missile"
 	description "The Thunderhead Storage Array is used to store extra ammunition for Thunderhead Launchers."
 


### PR DESCRIPTION
This is a tweaking of how both early game and late game missiles work, making early game missiles more practical, and giving underperforming late game missiles boosts where they need them. 

Changes:

All missile racks and box given double storage capacity. (I'm counting gatling gun as a missile launcher.)
All human missiles, barring the typhoon and the torpedo, have 1/2 price.
Typhoon damage increased from 880 to 920 and missile strength increased form 40 to 60.
Heavy rocket hull damage reduced from 720 to 460 and description tweaked.
Korath piercers piercing upgraded form 0.2 to 0.6.
Korath mines given a slow value of 2.
Thunderhead missiles missile strength greatly increased (12-40) before the casing breaks off.
Korath missiles available at Korath outfitters.
