### PR TITLE
Increase Reactor Modules Energy Generation

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -40,7 +40,7 @@ outfit "Small Reactor Module"
 	thumbnail "outfit/small reactor module"
 	"mass" 42
 	"outfit space" -42
-	"energy generation" 8.8
+	"energy generation" 9.8
 	"heat generation" 19
 	description "Solar power is sufficient for commerce, but excessive thriftiness is seldom a winning strategy in warfare. So for ships that must have a reliable energy source to power weapons, the Heliarchs use nuclear reactors."
 
@@ -52,7 +52,7 @@ outfit "Large Reactor Module"
 	thumbnail "outfit/large reactor module"
 	"mass" 98
 	"outfit space" -98
-	"energy generation" 22.3
+	"energy generation" 24.2
 	"heat generation" 45
 	description "This reactor was designed for the most powerful Heliarch warships. Its design has not changed significantly in the millennia since the first battle with the Quarg, but each generation of reactors is made slightly more efficient than the previous ones."
 


### PR DESCRIPTION
despite being half a tier above the Wanderers and Korath, and having been improving their reactors to be more efficient with each generation, the Heliarch's Reactor Modules aren't much more than sidegrades to the Triple Plasma Core and the Blue Sun.
A stock Punisher has 2 Large Reactor Modules, 196 outfit space. If you replace that with a Triple Plasma Core, a Large Heat Shunt, and a Small Heat Shunt, you lose just 60 energy generation, 4 more outfit space, but it also produces about 200 less heat.
Below I've compared the energy/space, heat/space, and energy/heat efficiencies of various reactors

`Boulder= 11.53 e/s, 22.66 h/s | 0.508 e/h`
`Aeon= 8.21 e/s, 11.81 h/s | 0.695 e/h`
`Armaggedon= 11.16 e/s, 32.30 h/s | 0.345 e/h`
`PC= 13.22 e/s, 40 h/s | 0.33 e/h`
`DPC= 14.19 e/s, 46,45 | 0.305 3/h`
`TPC= 15.47 e/s, 54.67 h/s | 0.283 e/h`
`WSun= 11.71 e/s, 15.11 h/s | 0.775 e/h`
`BSun= 12.35 e/s, 15.39 h/s | 0.8 e/h`
`SRM= 12.57 e/s, 27.14 h/s | 0.463 e/h`
`LRM= 13.65 e/s, 27.55 h/s | 0.495 e/h`

 As you can see, though they are more efficient heat-wise than the Korath Cores, they still lose energy-wise, comparing the energy for the space. If we compare them to the Wanderer Reactors, they have an edge in energy efficiency but are worse in heat. if we compare the energy/heat efficiency, both Heliarch cores are behind even the Hai Boulder.
 With the addition of the Overcharged Shield Modules, which lower energy produced with each one installed, Heliarch ships have suffered more with the relatively low energy generated, in particular the Punisher seems to be very prone to giving out when fighting a Wardragon, often running out of energy before shields even go down.
 
Heliarch Reactors definetly shouldn't be something outrageous like the Quarg's own power generators, but as it stands the Reactors are oddballs that don't have a clear advantage over Wanderer or Korath equipment that shows they are a half-tier above (unlike turrets, as the Bombardments boast consistent damage with longer range, or secondaries, as the Finishers deal a great deal of damage and have a good fire rate, or shield/hull regen, as Heliarch Light/Medium/Heavy Warships boast more than the respective classes of Wanderer and Korath warships, or batteries, as the Coalition shows some of the most efficient batteries in the game).
 All in all, the purpose of this is to stir discussion (or rather more discussion, as I've already been talking about this for some days on the discord) on whether the Reactor Modules should indeed be buffed, for example, with the new stats proposed by this PR, which would increase the efficiencies of both modules as such:

`SRM= 14 e/s | 0.515 e/h`
`LRM= 14.81 e/s | 0.537 e/h`
