### PR TITLE
Fix: Spelling of Gemini->Geminus

### DIFF
--- a/data/human/free worlds middle.txt
+++ b/data/human/free worlds middle.txt
@@ -2032,7 +2032,7 @@ mission "FW Defend New Tibet"
 			`	"Our fleet is there?" asks JJ.`
 			`	"No sir, the Syndicate. They're under attack by the Syndicate."`
 			`	"What?" says JJ. He rushes into the communication room, and you and Freya follow. On the video screen is a Buddhist monk in a maroon robe; behind him, you see other monks rushing about with none of the serenity you would usually expect of them. "What's going on there?" asks JJ.`
-			`	The monk explains, "Yesterday a Syndicate ship landed near our monastery, and the pilot sought refuge with us. He brings evidence that the Syndicate, or some faction within the Syndicate, was behind the attacks on Geminus and Martini."`
+			`	The monk explains, "Yesterday a Syndicate ship landed near our monastery, and the pilot sought refuge with us. He brings evidence that the Syndicate, or some faction within the Syndicate, was behind the attacks on Gemini and Martini."`
 			choice
 				`	"Why would the Syndicate do that?"`
 				`	"What sort of evidence?"`

--- a/data/human/free worlds middle.txt
+++ b/data/human/free worlds middle.txt
@@ -2026,13 +2026,13 @@ mission "FW Defend New Tibet"
 		has "FW Rand 1B: done"
 	
 	on offer
-		log "As a member of the Council, must make the deciding vote on a difficult decision. A defector from the Syndicate is claiming to have proof that the Syndicate was behind the bombings of Martini and Gemini. If that is true, the Republic may agree to make peace with the Free Worlds. But, refusing to return the defector to the Syndicate would certainly earn their enmity."
+		log "As a member of the Council, must make the deciding vote on a difficult decision. A defector from the Syndicate is claiming to have proof that the Syndicate was behind the bombings of Martini and Geminus. If that is true, the Republic may agree to make peace with the Free Worlds. But, refusing to return the defector to the Syndicate would certainly earn their enmity."
 		conversation
 			`The fleet in orbit around Wayfarer is pitifully small, surely not enough to take on more than a couple of Navy capital ships. JJ orders one of their communication officers to try to establish a secure link to Bourne or to any Free Worlds post on the other side of the Navy blockade. After about ten minutes, the officer returns and says, "Sir, we're receiving communications from New Tibet. You need to talk to them."`
 			`	"Our fleet is there?" asks JJ.`
 			`	"No sir, the Syndicate. They're under attack by the Syndicate."`
 			`	"What?" says JJ. He rushes into the communication room, and you and Freya follow. On the video screen is a Buddhist monk in a maroon robe; behind him, you see other monks rushing about with none of the serenity you would usually expect of them. "What's going on there?" asks JJ.`
-			`	The monk explains, "Yesterday a Syndicate ship landed near our monastery, and the pilot sought refuge with us. He brings evidence that the Syndicate, or some faction within the Syndicate, was behind the attacks on Gemini and Martini."`
+			`	The monk explains, "Yesterday a Syndicate ship landed near our monastery, and the pilot sought refuge with us. He brings evidence that the Syndicate, or some faction within the Syndicate, was behind the attacks on Geminus and Martini."`
 			choice
 				`	"Why would the Syndicate do that?"`
 				`	"What sort of evidence?"`


### PR DESCRIPTION
##Summary
Spelling fix. Mission text in `free worlds middle.txt` on line 2035 says "Gemini and Martini." where it should be "Geminus and Martini."

Thanks to ESSpellChecker on Discord for pointing this out.

Note: This is based on usage in the game. Lots of places refer to Geminus, but this is the only instance of "Gemini." So this is bringing this single instance into line with general use everywhere else.