### PR TITLE
Customizable jump drive and hyperdrive sounds and effects

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1263,7 +1263,26 @@ void Engine::CalculateStep()
 		MoveShip(it);
 	// If the flagship just began jumping, play the appropriate sound.
 	if(!wasHyperspacing && flagship && flagship->IsEnteringHyperspace())
-		Audio::Play(Audio::Get(flagship->IsUsingJumpDrive() ? "jump drive" : "hyperdrive"));
+	{
+		if(flagship->IsUsingJumpDrive())
+		{
+			const map<const Sound *, int> jumpSounds = flagship->Attributes().JumpSounds();
+			if(jumpSounds.empty())
+				Audio::Play(Audio::Get("jump drive"));
+			else
+				for(const auto &sound : jumpSounds)
+					Audio::Play(sound.first);
+		}
+		else
+		{
+			const map<const Sound *, int> hyperSounds = flagship->Attributes().HyperSounds();
+			if(hyperSounds.empty())
+				Audio::Play(Audio::Get("hyperdrive"));
+			else
+				for(const auto &sound : hyperSounds)
+					Audio::Play(sound.first);
+		}
+	}
 	// Check if the flagship just entered a new system.
 	if(flagship && playerSystem != flagship->GetSystem())
 	{
@@ -1473,17 +1492,53 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 	// the system. Make no sound if it entered via wormhole.
 	if(ship.get() != flagship && ship->Zoom() == 1.)
 	{
+		// The position from where sounds will be played.
+		Point position = ship->Position();
 		// Did this ship just begin hyperspacing?
 		if(wasHere && !wasHyperspacing && ship->IsHyperspacing())
-			Audio::Play(
-				Audio::Get(isJump ? "jump out" : "hyperdrive out"),
-				ship->Position());
+		{
+			if(isJump)
+			{
+				const map<const Sound *, int> jumpSounds = ship->Attributes().JumpOutSounds();
+				if(jumpSounds.empty())
+					Audio::Play(Audio::Get("jump out"), position);
+				else
+					for(const auto &sound : jumpSounds)
+						Audio::Play(sound.first, position);
+			}
+			else
+			{
+				const map<const Sound *, int> hyperSounds = ship->Attributes().HyperOutSounds();
+				if(hyperSounds.empty())
+					Audio::Play(Audio::Get("hyperdrive out"), position);
+				else
+					for(const auto &sound : hyperSounds)
+						Audio::Play(sound.first, position);
+			}
+		}
 		
 		// Did this ship just jump into the player's system?
 		if(!wasHere && flagship && ship->GetSystem() == flagship->GetSystem())
-			Audio::Play(
-				Audio::Get(isJump ? "jump in" : "hyperdrive in"),
-				ship->Position());
+		{
+			if(isJump)
+			{
+				const map<const Sound *, int> jumpSounds = ship->Attributes().JumpInSounds();
+				if(jumpSounds.empty())
+					Audio::Play(Audio::Get("jump in"), position);
+				else
+					for(const auto &sound : jumpSounds)
+						Audio::Play(sound.first, position);
+			}
+			else
+			{
+				const map<const Sound *, int> hyperSounds = ship->Attributes().HyperInSounds();
+				if(hyperSounds.empty())
+					Audio::Play(Audio::Get("hyperdrive in"), position);
+				else
+					for(const auto &sound : hyperSounds)
+						Audio::Play(sound.first, position);
+			}
+		}
 	}
 	
 	// Boarding:

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1266,7 +1266,7 @@ void Engine::CalculateStep()
 	{
 		if(flagship->IsUsingJumpDrive())
 		{
-			const map<const Sound *, int> jumpSounds = flagship->Attributes().JumpSounds();
+			const map<const Sound *, int> &jumpSounds = flagship->Attributes().JumpSounds();
 			if(jumpSounds.empty())
 				Audio::Play(Audio::Get("jump drive"));
 			else
@@ -1275,7 +1275,7 @@ void Engine::CalculateStep()
 		}
 		else
 		{
-			const map<const Sound *, int> hyperSounds = flagship->Attributes().HyperSounds();
+			const map<const Sound *, int> &hyperSounds = flagship->Attributes().HyperSounds();
 			if(hyperSounds.empty())
 				Audio::Play(Audio::Get("hyperdrive"));
 			else
@@ -1399,20 +1399,17 @@ void Engine::CalculateStep()
 				if(ship->IsThrusting() && !ship->EnginePoints().empty())
 				{
 					for(const auto &it : ship->Attributes().FlareSounds())
-						if(it.second > 0)
-							Audio::Play(it.first, ship->Position());
+						Audio::Play(it.first, ship->Position());
 				}
 				else if(ship->IsReversing() && !ship->ReverseEnginePoints().empty())
 				{
 					for(const auto &it : ship->Attributes().ReverseFlareSounds())
-						if(it.second > 0)
-							Audio::Play(it.first, ship->Position());
+						Audio::Play(it.first, ship->Position());
 				}
 				if(ship->IsSteering() && !ship->SteeringEnginePoints().empty())
 				{
 					for(const auto &it : ship->Attributes().SteeringFlareSounds())
-						if(it.second > 0)
-							Audio::Play(it.first, ship->Position());
+						Audio::Play(it.first, ship->Position());
 				}
 			}
 			else
@@ -1425,20 +1422,17 @@ void Engine::CalculateStep()
 		if(flagship->IsThrusting() && !flagship->EnginePoints().empty())
 		{
 			for(const auto &it : flagship->Attributes().FlareSounds())
-				if(it.second > 0)
-					Audio::Play(it.first);
+				Audio::Play(it.first);
 		}
 		else if(flagship->IsReversing() && !flagship->ReverseEnginePoints().empty())
 		{
 			for(const auto &it : flagship->Attributes().ReverseFlareSounds())
-				if(it.second > 0)
-					Audio::Play(it.first);
+				Audio::Play(it.first);
 		}
 		if(flagship->IsSteering() && !flagship->SteeringEnginePoints().empty())
 		{
 			for(const auto &it : flagship->Attributes().SteeringFlareSounds())
-				if(it.second > 0)
-					Audio::Play(it.first);
+				Audio::Play(it.first);
 		}
 	}
 	// Draw the projectiles.
@@ -1499,7 +1493,7 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 		{
 			if(isJump)
 			{
-				const map<const Sound *, int> jumpSounds = ship->Attributes().JumpOutSounds();
+				const map<const Sound *, int> &jumpSounds = ship->Attributes().JumpOutSounds();
 				if(jumpSounds.empty())
 					Audio::Play(Audio::Get("jump out"), position);
 				else
@@ -1508,7 +1502,7 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 			}
 			else
 			{
-				const map<const Sound *, int> hyperSounds = ship->Attributes().HyperOutSounds();
+				const map<const Sound *, int> &hyperSounds = ship->Attributes().HyperOutSounds();
 				if(hyperSounds.empty())
 					Audio::Play(Audio::Get("hyperdrive out"), position);
 				else
@@ -1522,7 +1516,7 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 		{
 			if(isJump)
 			{
-				const map<const Sound *, int> jumpSounds = ship->Attributes().JumpInSounds();
+				const map<const Sound *, int> &jumpSounds = ship->Attributes().JumpInSounds();
 				if(jumpSounds.empty())
 					Audio::Play(Audio::Get("jump in"), position);
 				else
@@ -1531,7 +1525,7 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 			}
 			else
 			{
-				const map<const Sound *, int> hyperSounds = ship->Attributes().HyperInSounds();
+				const map<const Sound *, int> &hyperSounds = ship->Attributes().HyperInSounds();
 				if(hyperSounds.empty())
 					Audio::Play(Audio::Get("hyperdrive in"), position);
 				else

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1264,24 +1264,13 @@ void Engine::CalculateStep()
 	// If the flagship just began jumping, play the appropriate sound.
 	if(!wasHyperspacing && flagship && flagship->IsEnteringHyperspace())
 	{
-		if(flagship->IsUsingJumpDrive())
-		{
-			const map<const Sound *, int> &jumpSounds = flagship->Attributes().JumpSounds();
-			if(jumpSounds.empty())
-				Audio::Play(Audio::Get("jump drive"));
-			else
-				for(const auto &sound : jumpSounds)
-					Audio::Play(sound.first);
-		}
+		bool isJumping = flagship->IsUsingJumpDrive();
+		const map<const Sound *, int> &jumpSounds = isJumping ? flagship->Attributes().JumpSounds() : flagship->Attributes().HyperSounds();
+		if(jumpSounds.empty())
+			Audio::Play(Audio::Get(isJumping ? "jump drive" : "hyperdrive"));
 		else
-		{
-			const map<const Sound *, int> &hyperSounds = flagship->Attributes().HyperSounds();
-			if(hyperSounds.empty())
-				Audio::Play(Audio::Get("hyperdrive"));
-			else
-				for(const auto &sound : hyperSounds)
-					Audio::Play(sound.first);
-		}
+			for(const auto &sound : jumpSounds)
+				Audio::Play(sound.first);
 	}
 	// Check if the flagship just entered a new system.
 	if(flagship && playerSystem != flagship->GetSystem())
@@ -1491,47 +1480,23 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 		// Did this ship just begin hyperspacing?
 		if(wasHere && !wasHyperspacing && ship->IsHyperspacing())
 		{
-			if(isJump)
-			{
-				const map<const Sound *, int> &jumpSounds = ship->Attributes().JumpOutSounds();
-				if(jumpSounds.empty())
-					Audio::Play(Audio::Get("jump out"), position);
-				else
-					for(const auto &sound : jumpSounds)
-						Audio::Play(sound.first, position);
-			}
+			const map<const Sound *, int> &jumpSounds = isJump ? ship->Attributes().JumpOutSounds() : ship->Attributes().HyperOutSounds();
+			if(jumpSounds.empty())
+				Audio::Play(Audio::Get(isJump ? "jump out" : "hyperdrive out"), position);
 			else
-			{
-				const map<const Sound *, int> &hyperSounds = ship->Attributes().HyperOutSounds();
-				if(hyperSounds.empty())
-					Audio::Play(Audio::Get("hyperdrive out"), position);
-				else
-					for(const auto &sound : hyperSounds)
-						Audio::Play(sound.first, position);
-			}
+				for(const auto &sound : jumpSounds)
+					Audio::Play(sound.first, position);
 		}
 		
 		// Did this ship just jump into the player's system?
 		if(!wasHere && flagship && ship->GetSystem() == flagship->GetSystem())
 		{
-			if(isJump)
-			{
-				const map<const Sound *, int> &jumpSounds = ship->Attributes().JumpInSounds();
-				if(jumpSounds.empty())
-					Audio::Play(Audio::Get("jump in"), position);
-				else
-					for(const auto &sound : jumpSounds)
-						Audio::Play(sound.first, position);
-			}
+			const map<const Sound *, int> &jumpSounds = isJump ? ship->Attributes().JumpInSounds() : ship->Attributes().HyperInSounds();
+			if(jumpSounds.empty())
+				Audio::Play(Audio::Get(isJump ? "jump in" : "hyperdrive in"), position);
 			else
-			{
-				const map<const Sound *, int> &hyperSounds = ship->Attributes().HyperInSounds();
-				if(hyperSounds.empty())
-					Audio::Play(Audio::Get("hyperdrive in"), position);
-				else
-					for(const auto &sound : hyperSounds)
-						Audio::Play(sound.first, position);
-			}
+				for(const auto &sound : jumpSounds)
+					Audio::Play(sound.first, position);
 		}
 	}
 	

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -127,6 +127,20 @@ void Outfit::Load(const DataNode &node)
 			++steeringFlareSounds[Audio::Get(child.Token(1))];
 		else if(child.Token(0) == "afterburner effect" && child.Size() >= 2)
 			++afterburnerEffects[GameData::Effects().Get(child.Token(1))];
+		else if(child.Token(0) == "jump effect" && child.Size() >= 2)
+			++jumpEffects[GameData::Effects().Get(child.Token(1))];
+		else if(child.Token(0) == "hyperdrive sound" && child.Size() >= 2)
+			++hyperSounds[Audio::Get(child.Token(1))];
+		else if(child.Token(0) == "hyperdrive in sound" && child.Size() >= 2)
+			++hyperInSounds[Audio::Get(child.Token(1))];
+		else if(child.Token(0) == "hyperdrive out sound" && child.Size() >= 2)
+			++hyperOutSounds[Audio::Get(child.Token(1))];
+		else if(child.Token(0) == "jump sound" && child.Size() >= 2)
+			++jumpSounds[Audio::Get(child.Token(1))];
+		else if(child.Token(0) == "jump in sound" && child.Size() >= 2)
+			++jumpInSounds[Audio::Get(child.Token(1))];
+		else if(child.Token(0) == "jump out sound" && child.Size() >= 2)
+			++jumpOutSounds[Audio::Get(child.Token(1))];
 		else if(child.Token(0) == "flotsam sprite" && child.Size() >= 2)
 			flotsamSprite = SpriteSet::Get(child.Token(1));
 		else if(child.Token(0) == "thumbnail" && child.Size() >= 2)
@@ -314,6 +328,20 @@ void Outfit::Add(const Outfit &other, int count)
 		steeringFlareSounds[it.first] += count * it.second;
 	for(const auto &it : other.afterburnerEffects)
 		afterburnerEffects[it.first] += count * it.second;
+	for(const auto &it : other.jumpEffects)
+		jumpEffects[it.first] += count * it.second;
+	for(const auto &it : other.hyperSounds)
+		hyperSounds[it.first] += count * it.second;
+	for(const auto &it : other.hyperInSounds)
+		hyperInSounds[it.first] += count * it.second;
+	for(const auto &it : other.hyperOutSounds)
+		hyperOutSounds[it.first] += count * it.second;
+	for(const auto &it : other.jumpSounds)
+		jumpSounds[it.first] += count * it.second;
+	for(const auto &it : other.jumpInSounds)
+		jumpInSounds[it.first] += count * it.second;
+	for(const auto &it : other.jumpOutSounds)
+		jumpOutSounds[it.first] += count * it.second;
 }
 
 
@@ -373,6 +401,56 @@ const map<const Sound *, int> &Outfit::SteeringFlareSounds() const
 const map<const Effect *, int> &Outfit::AfterburnerEffects() const
 {
 	return afterburnerEffects;
+}
+
+
+
+// Get this oufit's jump effects and sounds, if any.
+const map<const Effect *, int> &Outfit::JumpEffects() const
+{
+	return jumpEffects;
+}
+
+
+
+const map<const Sound *, int> &Outfit::HyperSounds() const
+{
+	return hyperSounds;
+}
+
+
+
+const map<const Sound *, int> &Outfit::HyperInSounds() const
+{
+	return hyperInSounds;
+}
+
+
+
+const map<const Sound *, int> &Outfit::HyperOutSounds() const
+{
+	return hyperOutSounds;
+}
+
+
+
+const map<const Sound *, int> &Outfit::JumpSounds() const
+{
+	return jumpSounds;
+}
+
+
+
+const map<const Sound *, int> &Outfit::JumpInSounds() const
+{
+	return jumpInSounds;
+}
+
+
+
+const map<const Sound *, int> &Outfit::JumpOutSounds() const
+{
+	return jumpOutSounds;
 }
 
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -74,6 +74,19 @@ namespace {
 		else
 			oit->second += count * it.second;
 	}
+	
+	// Used to add the contents of one outfit's map to another, while also
+	// erasing any key with a value of zero.
+	template <class T>
+	void MergeMaps(map<const T *, int> thisMap, map<const T *, int> otherMap, int count)
+	{
+		for(const auto &it : otherMap)
+		{
+			thisMap[it.first] += count * it.second;
+			if(thisMap[it.first] == 0)
+				thisMap.erase(it.first);
+		}
+	}
 }
 
 const vector<string> Outfit::CATEGORIES = {
@@ -320,72 +333,17 @@ void Outfit::Add(const Outfit &other, int count)
 		AddFlareSprites(reverseFlareSprites, it, count);
 	for(const auto &it : other.steeringFlareSprites)
 		AddFlareSprites(steeringFlareSprites, it, count);
-	for(const auto &it : other.flareSounds)
-	{
-		flareSounds[it.first] += count * it.second;
-		if(flareSounds[it.first] == 0)
-			flareSounds.erase(it.first);
-	}
-	for(const auto &it : other.reverseFlareSounds)
-	{
-		reverseFlareSounds[it.first] += count * it.second;
-		if(reverseFlareSounds[it.first] == 0)
-			reverseFlareSounds.erase(it.first);
-	}
-	for(const auto &it : other.steeringFlareSounds)
-	{
-		steeringFlareSounds[it.first] += count * it.second;
-		if(steeringFlareSounds[it.first] == 0)
-			steeringFlareSounds.erase(it.first);
-	}
-	for(const auto &it : other.afterburnerEffects)
-	{
-		afterburnerEffects[it.first] += count * it.second;
-		if(afterburnerEffects[it.first] == 0)
-			afterburnerEffects.erase(it.first);
-	}
-	for(const auto &it : other.jumpEffects)
-	{
-		jumpEffects[it.first] += count * it.second;
-		if(jumpEffects[it.first] == 0)
-			jumpEffects.erase(it.first);
-	}
-	for(const auto &it : other.hyperSounds)
-	{
-		hyperSounds[it.first] += count * it.second;
-		if(hyperSounds[it.first] == 0)
-			hyperSounds.erase(it.first);
-	}
-	for(const auto &it : other.hyperInSounds)
-	{
-		hyperInSounds[it.first] += count * it.second;
-		if(hyperInSounds[it.first] == 0)
-			hyperInSounds.erase(it.first);
-	}
-	for(const auto &it : other.hyperOutSounds)
-	{
-		hyperOutSounds[it.first] += count * it.second;
-		if(hyperOutSounds[it.first] == 0)
-			hyperOutSounds.erase(it.first);
-	}
-	for(const auto &it : other.jumpSounds)
-	{
-		jumpSounds[it.first] += count * it.second;
-		if(jumpSounds[it.first] == 0)
-			jumpSounds.erase(it.first);
-	}
-	for(const auto &it : other.jumpInSounds)
-	{
-		jumpInSounds[it.first] += count * it.second;
-		if(jumpInSounds[it.first] == 0)
-			jumpInSounds.erase(it.first);
-	}
-	for(const auto &it : other.jumpOutSounds)
-	{
-		jumpOutSounds[it.first] += count * it.second;
-		if(jumpOutSounds[it.first] == 0)
-			jumpOutSounds.erase(it.first);
-	}
+	MergeMaps(flareSounds, other.flareSounds, count);
+	MergeMaps(reverseFlareSounds, other.reverseFlareSounds, count);
+	MergeMaps(steeringFlareSounds, other.steeringFlareSounds, count);
+	MergeMaps(afterburnerEffects, other.afterburnerEffects, count);
+	MergeMaps(jumpEffects, other.jumpEffects, count);
+	MergeMaps(hyperSounds, other.hyperSounds, count);
+	MergeMaps(hyperInSounds, other.hyperInSounds, count);
+	MergeMaps(hyperOutSounds, other.hyperOutSounds, count);
+	MergeMaps(jumpSounds, other.jumpSounds, count);
+	MergeMaps(jumpInSounds, other.jumpInSounds, count);
+	MergeMaps(jumpOutSounds, other.jumpOutSounds, count);
 }
 
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -78,7 +78,7 @@ namespace {
 	// Used to add the contents of one outfit's map to another, while also
 	// erasing any key with a value of zero.
 	template <class T>
-	void MergeMaps(map<const T *, int> thisMap, map<const T *, int> otherMap, int count)
+	void MergeMaps(map<const T *, int> &thisMap, const map<const T *, int> &otherMap, int count)
 	{
 		for(const auto &it : otherMap)
 		{

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -321,27 +321,71 @@ void Outfit::Add(const Outfit &other, int count)
 	for(const auto &it : other.steeringFlareSprites)
 		AddFlareSprites(steeringFlareSprites, it, count);
 	for(const auto &it : other.flareSounds)
+	{
 		flareSounds[it.first] += count * it.second;
+		if(flareSounds[it.first] == 0)
+			flareSounds.erase(it.first);
+	}
 	for(const auto &it : other.reverseFlareSounds)
+	{
 		reverseFlareSounds[it.first] += count * it.second;
+		if(reverseFlareSounds[it.first] == 0)
+			reverseFlareSounds.erase(it.first);
+	}
 	for(const auto &it : other.steeringFlareSounds)
+	{
 		steeringFlareSounds[it.first] += count * it.second;
+		if(steeringFlareSounds[it.first] == 0)
+			steeringFlareSounds.erase(it.first);
+	}
 	for(const auto &it : other.afterburnerEffects)
+	{
 		afterburnerEffects[it.first] += count * it.second;
+		if(afterburnerEffects[it.first] == 0)
+			afterburnerEffects.erase(it.first);
+	}
 	for(const auto &it : other.jumpEffects)
+	{
 		jumpEffects[it.first] += count * it.second;
+		if(jumpEffects[it.first] == 0)
+			jumpEffects.erase(it.first);
+	}
 	for(const auto &it : other.hyperSounds)
+	{
 		hyperSounds[it.first] += count * it.second;
+		if(hyperSounds[it.first] == 0)
+			hyperSounds.erase(it.first);
+	}
 	for(const auto &it : other.hyperInSounds)
+	{
 		hyperInSounds[it.first] += count * it.second;
+		if(hyperInSounds[it.first] == 0)
+			hyperInSounds.erase(it.first);
+	}
 	for(const auto &it : other.hyperOutSounds)
+	{
 		hyperOutSounds[it.first] += count * it.second;
+		if(hyperOutSounds[it.first] == 0)
+			hyperOutSounds.erase(it.first);
+	}
 	for(const auto &it : other.jumpSounds)
+	{
 		jumpSounds[it.first] += count * it.second;
+		if(jumpSounds[it.first] == 0)
+			jumpSounds.erase(it.first);
+	}
 	for(const auto &it : other.jumpInSounds)
+	{
 		jumpInSounds[it.first] += count * it.second;
+		if(jumpInSounds[it.first] == 0)
+			jumpInSounds.erase(it.first);
+	}
 	for(const auto &it : other.jumpOutSounds)
+	{
 		jumpOutSounds[it.first] += count * it.second;
+		if(jumpOutSounds[it.first] == 0)
+			jumpOutSounds.erase(it.first);
+	}
 }
 
 

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -106,6 +106,8 @@ private:
 	
 	Dictionary attributes;
 	
+	// The integers in these pairs/maps indicate the number of
+	// sprites/effects/sounds to be placed/played.
 	std::vector<std::pair<Body, int>> flareSprites;
 	std::vector<std::pair<Body, int>> reverseFlareSprites;
 	std::vector<std::pair<Body, int>> steeringFlareSprites;

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -81,6 +81,14 @@ public:
 	const std::map<const Sound *, int> &SteeringFlareSounds() const;
 	// Get the afterburner effect, if any.
 	const std::map<const Effect *, int> &AfterburnerEffects() const;
+	// Get this oufit's jump effects and sounds, if any.
+	const std::map<const Effect *, int> &JumpEffects() const;
+	const std::map<const Sound *, int> &HyperSounds() const;
+	const std::map<const Sound *, int> &HyperInSounds() const;
+	const std::map<const Sound *, int> &HyperOutSounds() const;
+	const std::map<const Sound *, int> &JumpSounds() const;
+	const std::map<const Sound *, int> &JumpInSounds() const;
+	const std::map<const Sound *, int> &JumpOutSounds() const;
 	// Get the sprite this outfit uses when dumped into space.
 	const Sprite *FlotsamSprite() const;
 	
@@ -105,6 +113,13 @@ private:
 	std::map<const Sound *, int> reverseFlareSounds;
 	std::map<const Sound *, int> steeringFlareSounds;
 	std::map<const Effect *, int> afterburnerEffects;
+	std::map<const Effect *, int> jumpEffects;
+	std::map<const Sound *, int> hyperSounds;
+	std::map<const Sound *, int> hyperInSounds;
+	std::map<const Sound *, int> hyperOutSounds;
+	std::map<const Sound *, int> jumpSounds;
+	std::map<const Sound *, int> jumpInSounds;
+	std::map<const Sound *, int> jumpOutSounds;
 	const Sprite *flotsamSprite = nullptr;
 };
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1245,7 +1245,19 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		// Create the particle effects for the jump drive. This may create 100
 		// or more particles per ship per turn at the peak of the jump.
 		if(isUsingJumpDrive && !forget)
-			CreateSparks(visuals, "jump drive", hyperspaceCount * Width() * Height() * .000006);
+		{
+			double sparkAmount = hyperspaceCount * Width() * Height() * .000006;
+			const map<const Effect *, int> jumpEffects = attributes.JumpEffects();
+			if(jumpEffects.empty())
+				CreateSparks(visuals, "jump drive", sparkAmount);
+			else
+			{
+				// Spread the amount of particle effects created among all jump effects.
+				sparkAmount /= jumpEffects.size();
+				for(const auto &effect : jumpEffects)
+					CreateSparks(visuals, effect.first, sparkAmount);
+			}
+		}
 		
 		if(hyperspaceCount == HYPER_C)
 		{
@@ -3338,13 +3350,19 @@ void Ship::CreateExplosion(vector<Visual> &visuals, bool spread)
 // Place a "spark" effect, like ionization or disruption.
 void Ship::CreateSparks(vector<Visual> &visuals, const string &name, double amount)
 {
+	CreateSparks(visuals, GameData::Effects().Get(name), amount);
+}
+
+
+
+void Ship::CreateSparks(vector<Visual> &visuals, const Effect *effect, double amount)
+{
 	if(forget)
 		return;
 	
 	// Limit the number of sparks, depending on the size of the sprite.
 	amount = min(amount, Width() * Height() * .0006);
 	
-	const Effect *effect = GameData::Effects().Get(name);
 	while(true)
 	{
 		amount -= Random::Real();

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1247,7 +1247,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		if(isUsingJumpDrive && !forget)
 		{
 			double sparkAmount = hyperspaceCount * Width() * Height() * .000006;
-			const map<const Effect *, int> jumpEffects = attributes.JumpEffects();
+			const map<const Effect *, int> &jumpEffects = attributes.JumpEffects();
 			if(jumpEffects.empty())
 				CreateSparks(visuals, "jump drive", sparkAmount);
 			else

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -406,6 +406,7 @@ private:
 	void CreateExplosion(std::vector<Visual> &visuals, bool spread = false);
 	// Place a "spark" effect, like ionization or disruption.
 	void CreateSparks(std::vector<Visual> &visuals, const std::string &name, double amount);
+	void CreateSparks(std::vector<Visual> &visuals, const Effect *effect, double amount);
 	
 	
 private:


### PR DESCRIPTION
**Feature:** This PR implements a feature request discussed on Discord in reference to #5042

## Feature Details
Adds the ability to customize the sound and effect that a jump drive or hyperdrive has, instead of all jump drives and hyperdrive needing to use the same sounds and effect.

Adds the following new attributes:
* `"jump effect" <effect name>`: The effect that is created over a ship when it is jumping. This is an effect, not simply a sprite, so the effect must be defined elsewhere.
* `"jump sound" <sound name>`: The sound made when the player's flagship jumps. 
* `"jump in sound" <sound name>`: The sound made when other ships jump into the player's system.
* `"jump out sound" <sound name>`: The sound made when other ships jump out of the player's system.
* `"hyperdrive sound" <sound name>`: The sound made when the player's flagship hyperjumps. 
* `"hyperdrive in sound" <sound name>`: The sound made when other ships hyperjump into the player's system.
* `"hyperdrive out sound" <sound name>`: The sound made when other ships hyperjump out of the player's system.

If none of the above attributes are defined, the game reverts to the default sounds and effect. (This is why the jump drive, hyperdrive, and scram drive are unchanged in this PR. Although come to think of it, the scram drive could use a unique sound.)
If multiple drives are installed, each with their own custom sounds or effect, then the sounds and effects of each drive are created. 

## UI Screenshots
N/A

## Usage Examples
The following could be an example of the syntax for the jump drive in #5042.
```
outfit "Scram Jump Drive"
	"jump speed" 1
	"jump fuel" 200
	"jump drive" 1
	"jump effect" "scram jump drive"
	"jump sound" "scram jump drive"
	"jump in sound" "scram jump drive in"
	"jump out sound" "scram jump drive out"
```

## Testing Done
The following video depicts three Albatrosses, one with a normal JD, one with a "scram JD" using the sounds and effects from #5042, and one with both.
https://drive.google.com/open?id=1X-dBfNPUeZNFO6nBi5WrTLF31qq5YWg1

## Performance Impact
Each ship when jumping now needs to check if they have any custom sounds to be played or effects to be created. If not, revert to the default, as opposed to previously where it was a simple check of if the jump or hyperdrive sound should be used.
Given that ships are not jumping constantly though, I expect no noticeable impact on performance from these extra computations.
The amount of particle effects created when you have multiple jump drive effects is the same as if you were to only have one, as the amount of each effect produced is divided by the number of effects. This means that having multiple jump drive effects shouldn't cause extra stress on the game when compared to only one jump effect.