### PR TITLE
Hope Recon 1C changes

### DIFF
--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -553,6 +553,24 @@ mission "FW Hope Recon 1B"
 
 
 
+ship "Gunboat" "Gunboat (Bunks)"
+	outfits
+		"Heavy Laser" 2
+		"Heavy Laser Turret"
+		
+		"Bunk Room"
+		"RT-I Radiothermal"
+		"LP36a Battery Pack"
+		"LP72a Battery Pack"
+		"D14-RN Shield Generator"
+		"Small Radar Jammer"
+		
+		"X3700 Ion Thruster"
+		"X2200 Ion Steering"
+		"Hyperdrive"
+
+
+
 mission "FW Hope Recon 1C"
 	landing
 	invisible
@@ -565,7 +583,7 @@ mission "FW Hope Recon 1C"
 	npc
 		personality fleeing uninterested timid
 		government Republic
-		ship "Gunboat" "R.N.S. Susquehanna"
+		ship "Gunboat (Bunks)" "R.N.S. Susquehanna"
 	
 	on offer
 		log "Planted some sensors on the abandoned world of Hope, as an early warning system for Navy raids on Free Worlds space. The Navy appears to be doing something on this world, as well."
@@ -580,7 +598,7 @@ mission "FW Hope Recon 1C"
 				set "fw caught navy planting sensors"
 			`	You approach the location, flying low to avoid detection, and come upon a Navy Gunboat, landed on the planet. Some distance away from the ship, several figures in thick snowsuits are setting up some sort of equipment with lots of antennae. It seems that the Navy had the same idea as Freya, of using this world as a listening post. Your sensors show that the Gunboat is powered down.`
 			`	The moment your ship comes over the horizon, they start running back toward the Gunboat. You destroy their equipment with a few well-placed shots, then train your guns on the crew members, who are still some distance from their ship. When they realize they cannot get back to it before being shot, they raise their hands in surrender.`
-			`	You count seven crew members in the group, which is the typical crew complement of a Gunboat. That may mean the Gunboat is uncrewed, and you could kill the crew and steal it. On the other hand, if there are more crew aboard the ship it would be better to destroy it first, then finish off the landing crew.`
+			`	You count eight crew members in the group, which is the typical crew complement of a Gunboat. That may mean the Gunboat is uncrewed, and you could kill the crew and steal it. On the other hand, if there are more crew aboard the ship it would be better to destroy it first, then finish off the landing crew.`
 			choice
 				`	(Destroy the ship, then finish off the crew.)`
 					goto destroy

--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -560,8 +560,8 @@ ship "Gunboat" "Gunboat (Bunks)"
 		
 		"Bunk Room"
 		"RT-I Radiothermal"
-		"LP36a Battery Pack"
-		"LP72a Battery Pack"
+		"LP036a Battery Pack"
+		"LP072a Battery Pack"
 		"D14-RN Shield Generator"
 		"Small Radar Jammer"
 		


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Ref. https://github.com/endless-sky/endless-sky/issues/2785
Currently, the mission FW Hope Recon 1C states 7 crew members as the normal complement of a gunboat, but due to the turret present in every gunboat they are actually at least 8. The bunks of a normal gunboat are also not enough to fly it after 8 crew members have been killed, which is what happens in the mission. This PR fixes the required crew stated in the mission and adds a gunboat variant with the scanners and the brig removed and a downgraded battery in favour of a bunk room, which could mean the Navy needed to bring specialized technicians to install the surveillance station.
In https://github.com/endless-sky/endless-sky/issues/2785 MZ says that the issue doesn't seem worth fixing, but given that the change and the impact is so minor, it was worth a try.