### PR TITLE
Random lifetime for effects

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -96,7 +96,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: brew install libpng libjpeg-turbo libmad sdl2 p7zip
+        run: |
+          brew update
+          brew install libpng libjpeg-turbo libmad sdl2 p7zip
       - name: Adjust library paths
         run: |
           install_name_tool -id "@rpath/libpng16.16.dylib" /usr/local/lib/libpng16.16.dylib

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -54,7 +54,7 @@ phrase "deep mystery cube dropoff station payment"
 	word
 		`leave the mystery cube in the second supplies cabinet you come across.`
 		`leave the mystery cube in an unscrewed air vent.`
-		`hand the cube to the thrid tourist couple you see on the station. They accept it without a word.`
+		`hand the cube to the third tourist couple you see on the station. They accept it without a word.`
 		`drop the cube into a copper trash can in the spaceport.`
 		`drop the cube into a laundry chute.`
 	word

--- a/data/human/free worlds middle.txt
+++ b/data/human/free worlds middle.txt
@@ -2026,7 +2026,7 @@ mission "FW Defend New Tibet"
 		has "FW Rand 1B: done"
 	
 	on offer
-		log "As a member of the Council, must make the deciding vote on a difficult decision. A defector from the Syndicate is claiming to have proof that the Syndicate was behind the bombings of Martini and Gemini. If that is true, the Republic may agree to make peace with the Free Worlds. But, refusing to return the defector to the Syndicate would certainly earn their enmity."
+		log "As a member of the Council, must make the deciding vote on a difficult decision. A defector from the Syndicate is claiming to have proof that the Syndicate was behind the bombings of Martini and Geminus. If that is true, the Republic may agree to make peace with the Free Worlds. But, refusing to return the defector to the Syndicate would certainly earn their enmity."
 		conversation
 			`The fleet in orbit around Wayfarer is pitifully small, surely not enough to take on more than a couple of Navy capital ships. JJ orders one of their communication officers to try to establish a secure link to Bourne or to any Free Worlds post on the other side of the Navy blockade. After about ten minutes, the officer returns and says, "Sir, we're receiving communications from New Tibet. You need to talk to them."`
 			`	"Our fleet is there?" asks JJ.`

--- a/data/map.txt
+++ b/data/map.txt
@@ -27529,7 +27529,7 @@ planet "Rekat Moraski"
 planet Relic
 	attributes "near earth"
 	landscape land/valley4
-	description `Relic was colonized over seven hundred years ago, back when the construction of the first hyperdrive was still in living memory. At this point, most starships had a very limited range, so the stars adjacent to earth where the only viable opinion for any colonization attempts. Because of this, Relic seemed like it was going to become a major colony, despite it's low gravity, harsh environment, and limited resources.`
+	description `Relic was colonized over seven hundred years ago, back when the construction of the first hyperdrive was still in living memory. At this point, most starships had a very limited range, so the stars adjacent to Earth were the only viable options for any colonization attempts. Because of this, Relic seemed like it was going to become a major colony, despite it's low gravity, harsh environment, and limited resources.`
 	description `	However, this would not last. In less than fifty years, the colonies had spread to much more favorable planets, and Relic was left behind by most human development.`
 	spaceport `The spaceport here is located in the only recognized city on Relic, and it's only designed to handle the occasional merchant or Navy ship on its way to or from Earth. It doesn't even use standard landing pads used on most other planets. Instead, the natives seem to have set up some concrete slabs next to some gas pumps and gone back to their lives. Despite this, the small portion of Earth's traffic means a few ships land at the spaceport every day. This results in a running joke among the locals that the chief industry of Relic is the gas station.`
 	outfitter "Ammo North"

--- a/source/Effect.cpp
+++ b/source/Effect.cpp
@@ -39,6 +39,8 @@ void Effect::Load(const DataNode &node)
 			sound = Audio::Get(child.Token(1));
 		else if(child.Token(0) == "lifetime" && child.Size() >= 2)
 			lifetime = child.Value(1);
+		else if(child.Token(0) == "random lifetime" && child.Size() >= 2)
+			randomLifetime = child.Value(1);
 		else if(child.Token(0) == "velocity scale" && child.Size() >= 2)
 			velocityScale = child.Value(1);
 		else if(child.Token(0) == "random velocity" && child.Size() >= 2)

--- a/source/Effect.h
+++ b/source/Effect.h
@@ -58,6 +58,7 @@ private:
 	double randomFrameRate = 0.;
 	
 	int lifetime = 0;
+	int randomLifetime = 0;
 	
 	// Allow the Visual class to access all these private members.
 	friend class Visual;

--- a/source/Visual.cpp
+++ b/source/Visual.cpp
@@ -24,6 +24,9 @@ using namespace std;
 Visual::Visual(const Effect &effect, Point pos, Point vel, Angle facing, Point hitVelocity)
 	: Body(effect, pos, vel, facing), lifetime(effect.lifetime)
 {
+	if(effect.randomLifetime > 0)
+		lifetime += Random::Int(effect.randomLifetime);
+	
 	angle += Angle::Random(effect.randomAngle) - Angle::Random(effect.randomAngle);
 	spin = Angle::Random(effect.randomSpin) - Angle::Random(effect.randomSpin);
 	

--- a/source/Visual.cpp
+++ b/source/Visual.cpp
@@ -25,7 +25,7 @@ Visual::Visual(const Effect &effect, Point pos, Point vel, Angle facing, Point h
 	: Body(effect, pos, vel, facing), lifetime(effect.lifetime)
 {
 	if(effect.randomLifetime > 0)
-		lifetime += Random::Int(effect.randomLifetime);
+		lifetime += Random::Int(effect.randomLifetime + 1);
 	
 	angle += Angle::Random(effect.randomAngle) - Angle::Random(effect.randomAngle);
 	spin = Angle::Random(effect.randomSpin) - Angle::Random(effect.randomSpin);


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed ~~in issue #{{insert number}}~~ no where.

## Feature Details
Allows effects to have a random lifetime akin to the random lifetime on projectiles, and to match the fact that they already have random velocity. 

## UI Screenshots
N/A

## Usage Examples
```
effect "jump drive"
	sprite "effect/jump drive"
		"no repeat"
		"frame rate" 12
	"lifetime" 10
+	"random lifetime" 200
	"random angle" 180
	"velocity scale" 0.
```

## Testing Done
Give a random lifetime to the jump drive effect, causing the jump drive particles to decay at random intervals. 
The jump drive effect after moving away from where I just jumped in. A high random lifetime leaves many particles remaining from where I just was.
![image](https://user-images.githubusercontent.com/17688683/81507934-a6f1bc80-92ce-11ea-9cdb-cbe64f92a2ca.png)
A short time later, only a few particles are left.
![image](https://user-images.githubusercontent.com/17688683/81507927-99d4cd80-92ce-11ea-8104-2e4a128add6a.png)

## Performance Impact
N/A
