### PR TITLE
Random lifetime for effects

### DIFF
--- a/source/Effect.cpp
+++ b/source/Effect.cpp
@@ -39,6 +39,8 @@ void Effect::Load(const DataNode &node)
 			sound = Audio::Get(child.Token(1));
 		else if(child.Token(0) == "lifetime" && child.Size() >= 2)
 			lifetime = child.Value(1);
+		else if(child.Token(0) == "random lifetime" && child.Size() >= 2)
+			randomLifetime = child.Value(1);
 		else if(child.Token(0) == "velocity scale" && child.Size() >= 2)
 			velocityScale = child.Value(1);
 		else if(child.Token(0) == "random velocity" && child.Size() >= 2)

--- a/source/Effect.h
+++ b/source/Effect.h
@@ -58,6 +58,7 @@ private:
 	double randomFrameRate = 0.;
 	
 	int lifetime = 0;
+	int randomLifetime = 0;
 	
 	// Allow the Visual class to access all these private members.
 	friend class Visual;

--- a/source/Visual.cpp
+++ b/source/Visual.cpp
@@ -24,6 +24,9 @@ using namespace std;
 Visual::Visual(const Effect &effect, Point pos, Point vel, Angle facing, Point hitVelocity)
 	: Body(effect, pos, vel, facing), lifetime(effect.lifetime)
 {
+	if(effect.randomLifetime > 0)
+		lifetime += Random::Int(effect.randomLifetime + 1);
+	
 	angle += Angle::Random(effect.randomAngle) - Angle::Random(effect.randomAngle);
 	spin = Angle::Random(effect.randomSpin) - Angle::Random(effect.randomSpin);
 	


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed ~~in issue #{{insert number}}~~ no where.

## Feature Details
Allows effects to have a random lifetime akin to the random lifetime on projectiles, and to match the fact that they already have random velocity. 

## UI Screenshots
N/A

## Usage Examples
```
effect "jump drive"
	sprite "effect/jump drive"
		"no repeat"
		"frame rate" 12
	"lifetime" 10
+	"random lifetime" 200
	"random angle" 180
	"velocity scale" 0.
```

## Testing Done
Give a random lifetime to the jump drive effect, causing the jump drive particles to decay at random intervals. 
The jump drive effect after moving away from where I just jumped in. A high random lifetime leaves many particles remaining from where I just was.
![image](https://user-images.githubusercontent.com/17688683/81507934-a6f1bc80-92ce-11ea-9cdb-cbe64f92a2ca.png)
A short time later, only a few particles are left.
![image](https://user-images.githubusercontent.com/17688683/81507927-99d4cd80-92ce-11ea-8104-2e4a128add6a.png)

## Performance Impact
-1 sanity.