### PR TITLE
Abort the jump if a ship is disabled mid-jump.

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1168,6 +1168,15 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		// Don't apply external acceleration while jumping.
 		acceleration = Point();
 		
+		// If at some point during the jump process the ship is disabled, abort
+		// the jump sequence.
+		if(isDisabled)
+		{
+			hyperspaceSystem = nullptr;
+			hyperspaceCount = 0;
+			return;
+		}
+
 		// Enter hyperspace.
 		int direction = hyperspaceSystem ? 1 : -1;
 		hyperspaceCount += direction;
@@ -1181,15 +1190,6 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		// or more particles per ship per turn at the peak of the jump.
 		if(isUsingJumpDrive && !forget)
 			CreateSparks(visuals, "jump drive", hyperspaceCount * Width() * Height() * .000006);
-
-		// If at some point during the jump process the ship is disabled, abort
-		// the jump sequence.
-		if (isDisabled)
-		{
-			hyperspaceSystem = nullptr;
-			hyperspaceCount = 0;
-			return;
-		}
 		
 		if(hyperspaceCount == HYPER_C)
 		{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1165,9 +1165,6 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	}
 	else if(hyperspaceSystem || hyperspaceCount)
 	{
-		// Don't apply external acceleration while jumping.
-		acceleration = Point();
-		
 		// If at some point during the jump process the ship is disabled, abort
 		// the jump sequence.
 		if(isDisabled)
@@ -1176,6 +1173,9 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 			hyperspaceCount = 0;
 			return;
 		}
+
+		// Don't apply external acceleration while jumping.
+		acceleration = Point();
 
 		// Enter hyperspace.
 		int direction = hyperspaceSystem ? 1 : -1;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1181,6 +1181,15 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		// or more particles per ship per turn at the peak of the jump.
 		if(isUsingJumpDrive && !forget)
 			CreateSparks(visuals, "jump drive", hyperspaceCount * Width() * Height() * .000006);
+
+		// If at some point during the jump process the ship is disabled, abort
+		// the jump sequence.
+		if (isDisabled)
+		{
+			hyperspaceSystem = nullptr;
+			hyperspaceCount = 0;
+			return;
+		}
 		
 		if(hyperspaceCount == HYPER_C)
 		{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1176,7 +1176,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 
 		// Don't apply external acceleration while jumping.
 		acceleration = Point();
-
+		
 		// Enter hyperspace.
 		int direction = hyperspaceSystem ? 1 : -1;
 		hyperspaceCount += direction;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5058 

## Fix Details

Stop the jump sequence when the ship is disabled while the jump animation is playing. This is mainly done for jump drives, but is also applicable for hyperdrives.

For hyperdrives, this can only happen in the very beginning of the jump, while the ship is accelerating in the origin system. While I haven't tested this for hyperdrives (mainly because of how rare/hard to do it is), the result would be that the ship stops the jump with an increase in velocity.

## Testing Done

Tested this on my main save on Korath raiders. Works as intended, the jump drive animation stops and the Korath raider doesn't jump.