### PR TITLE
Disallow buying license restricted outfits into cargo.

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -822,9 +822,9 @@ bool ShopPanel::Scroll(double dx, double dy)
 
 int64_t ShopPanel::LicenseCost(const Outfit *outfit) const
 {
-	// Don't require a license for an outfit that you have in cargo or that you
-	// just sold to the outfitter. (Otherwise, there would be no way to transfer
-	// a restricted plundered outfit between ships or from cargo to a ship.)
+	// If the player is attempting to install an outfit from cargo or that they just
+	// sold to the shop, then ignore its license requirement, if any. (Otherwise there
+	// would be no way to use or transfer license-restricted outfits between ships.)
 	if((player.Cargo().Get(outfit) && playerShip) || player.Stock(outfit) > 0)
 		return 0;
 	

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -825,7 +825,7 @@ int64_t ShopPanel::LicenseCost(const Outfit *outfit) const
 	// Don't require a license for an outfit that you have in cargo or that you
 	// just sold to the outfitter. (Otherwise, there would be no way to transfer
 	// a restricted plundered outfit between ships or from cargo to a ship.)
-	if(player.Cargo().Get(outfit) || player.Stock(outfit) > 0)
+	if((player.Cargo().Get(outfit) && playerShip) || player.Stock(outfit) > 0)
 		return 0;
 	
 	const Sale<Outfit> &available = player.GetPlanet()->Outfitter();


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #4883 

## Fix Details

The problem was that if you have an outfit in cargo, then you could buy additional outfits into cargo even if you didn't have the required license.

This fixes the issue by only allowing the player to install license restricted outfits from cargo (install = buying + ship selected).

## Testing Done

Tried various combinations of selling/buying into stock/cargo to try to buy additional license restricted Crystal Capacitors, which with the patch doesn't work.

## Save File

The save file from the linked issue, https://gist.github.com/shnwnd/ea07dfcf3ad6d32f2013505d698b64d6.