### PR TITLE
bug fix to: spaceport news mixing up roles and messages

### DIFF
--- a/source/News.cpp
+++ b/source/News.cpp
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "SpriteSet.h"
 
 #include <algorithm>
+#include <iostream>
 
 using namespace std;
 
@@ -112,9 +113,17 @@ string News::Name() const
 
 
 // Pick a portrait at random out of the possible options.
-const Sprite *News::Portrait() const
+const Sprite *News::Portrait(const std::set<const Sprite *> &forbidden) const
 {
-	return portraits.empty() ? nullptr : portraits[Random::Int(portraits.size())];
+	if(forbidden.empty())
+		return portraits.empty() ? nullptr : portraits[Random::Int(portraits.size())];
+
+	std::vector<const Sprite *> allowed;
+	for(const auto &it : portraits)
+		if(forbidden.find(it) == forbidden.end())
+			allowed.push_back(it);
+			
+	return allowed.empty() ? nullptr : allowed[Random::Int(allowed.size())];
 }
 
 

--- a/source/News.cpp
+++ b/source/News.cpp
@@ -17,7 +17,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "SpriteSet.h"
 
 #include <algorithm>
-#include <iostream>
 
 using namespace std;
 

--- a/source/News.h
+++ b/source/News.h
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <string>
 #include <vector>
+#include <set>
 
 class DataNode;
 class Planet;
@@ -37,7 +38,7 @@ public:
 	// Get the speaker's name.
 	std::string Name() const;
 	// Pick a portrait at random out of the possible options.
-	const Sprite *Portrait() const;
+	const Sprite *Portrait(const std::set<const Sprite *> &forbidden) const;
 	// Get the speaker's message, chosen randomly.
 	std::string Message() const;
 	

--- a/source/SpaceportPanel.h
+++ b/source/SpaceportPanel.h
@@ -14,11 +14,13 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #define SPACEPORT_PANEL_H_
 
 #include "Panel.h"
+#include "News.h"
 
 #include "Information.h"
 #include "WrappedText.h"
 
 #include <map>
+#include <set>
 
 class PlayerInfo;
 class Sprite;
@@ -48,6 +50,7 @@ private:
 	// After displaying a portrait for a particular profession,
 	// only show it for that same profession.
 	std::map<const Sprite *, std::string> displayedProfessions;
+	std::map<const News *, std::set<const Sprite *> > professionsByNews;
 };
 
 


### PR DESCRIPTION
Fixes  #4463

This update ensures a news story will always use a portrait+name combination that is valid for that news story, while avoiding duplicate occupations if possible. The new logic for picking is:

1. Pick a random portrait and use it if it hasn't been used. Record the news, portrait, and name.
2. Reuse a portrait+name, chosen at random, from the possibilities already used by that news.
3. Pick a random portrait and name that are correct for that news, allowing somebody to have multiple occupations.

Thus far, in my tests, the fallback option 3 has never been used. However, there is nothing wrong with somebody having two professions. That is common in real life, and there is no reason why, for example, a biologist can't be a tourist or a photographer can't be a merchant. Still, for the sake of variety, that should be avoided if possible, and this PR still avoids that if possible.