### PR TITLE
allow missions to fine the player or give a mortgage

### DIFF
--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -333,10 +333,19 @@ void Account::AddMortgage(int64_t principal)
 
 
 
-// Add a "fine" with a high, fixed interest rate and a short term.
-void Account::AddFine(int64_t amount)
+// Add a "fine" with a high, fixed interest rate
+void Account::AddFine(int64_t amount, int term)
 {
-	mortgages.emplace_back(amount, 0, 60);
+	mortgages.emplace_back(amount, 0, term);
+}
+
+
+
+// Add a "fine" with a high, fixed interest rate and a short term.
+void Account::AddFine(int64_t amount, double interest, int term)
+{
+	double creditScore = 2*(600-interest/.00001);
+	mortgages.emplace_back(amount, int(creditScore), term);
 }
 
 

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -344,8 +344,8 @@ void Account::AddFine(int64_t amount, int term)
 // Add a "fine" with a high, fixed interest rate and a short term.
 void Account::AddFine(int64_t amount, double interest, int term)
 {
-	double creditScore = 2*(600-interest/.00001);
-	mortgages.emplace_back(amount, int(creditScore), term);
+	double creditScore = 2 * (600 - interest * 100000);
+	mortgages.emplace_back(amount, creditScore, term);
 }
 
 

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -333,19 +333,30 @@ void Account::AddMortgage(int64_t principal)
 
 
 
-// Add a "fine" with a high, fixed interest rate
-void Account::AddFine(int64_t amount, int term)
+// Add a "fine" with a high, fixed interest rate and a short term.
+void Account::AddFine(int64_t amount)
 {
-	mortgages.emplace_back(amount, 0, term);
+       mortgages.emplace_back(amount, 0, 60);
 }
 
-
-
-// Add a "fine" with a high, fixed interest rate and a short term.
-void Account::AddFine(int64_t amount, double interest, int term)
+// General debt addition, specifying all parameters
+void Account::AddDebt(int64_t amount, int term, double interest, const string &type)
 {
-	double creditScore = 2 * (600 - interest * 100000);
-	mortgages.emplace_back(amount, creditScore, term);
+	double localCreditScore = creditScore;
+	if(term<=0)
+	{
+		if(type == "Mortgage")
+			term = 365;
+		else if(type == "Fine")
+			term = 60;
+		else
+			term = localCreditScore <= 0 ? 60 : 365;
+	}
+	if(interest > 0)
+		localCreditScore = 2 * (600 - interest * 100000);
+	else if(type != "Mortgage")
+		localCreditScore = 0;
+	mortgages.emplace_back(amount, localCreditScore, term, type);
 }
 
 

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -336,14 +336,14 @@ void Account::AddMortgage(int64_t principal)
 // Add a "fine" with a high, fixed interest rate and a short term.
 void Account::AddFine(int64_t amount)
 {
-       mortgages.emplace_back(amount, 0, 60);
+	mortgages.emplace_back(amount, 0, 60);
 }
 
 // General debt addition, specifying all parameters
 void Account::AddDebt(int64_t amount, int term, double interest, const string &type)
 {
 	double localCreditScore = creditScore;
-	if(term<=0)
+	if(term <= 0)
 	{
 		if(type == "Mortgage")
 			term = 365;

--- a/source/Account.h
+++ b/source/Account.h
@@ -53,8 +53,8 @@ public:
 	// Liabilities:
 	const std::vector<Mortgage> &Mortgages() const;
 	void AddMortgage(int64_t principal);
-	void AddFine(int64_t amount,int term=60);
-	void AddFine(int64_t amount,double interest,int term);
+	void AddFine(int64_t amount);
+	void AddDebt(int64_t amount,int term=-1,double interest=-1,const std::string &type="");
 	int64_t Prequalify() const;
 	// Assets:
 	int64_t NetWorth() const;

--- a/source/Account.h
+++ b/source/Account.h
@@ -54,7 +54,7 @@ public:
 	const std::vector<Mortgage> &Mortgages() const;
 	void AddMortgage(int64_t principal);
 	void AddFine(int64_t amount);
-	void AddDebt(int64_t amount,int term,double interest,const std::string &type);
+	void AddDebt(int64_t amount, int term, double interest, const std::string &type);
 	int64_t Prequalify() const;
 	// Assets:
 	int64_t NetWorth() const;

--- a/source/Account.h
+++ b/source/Account.h
@@ -53,7 +53,8 @@ public:
 	// Liabilities:
 	const std::vector<Mortgage> &Mortgages() const;
 	void AddMortgage(int64_t principal);
-	void AddFine(int64_t amount);
+	void AddFine(int64_t amount,int term=60);
+	void AddFine(int64_t amount,double interest,int term);
 	int64_t Prequalify() const;
 	// Assets:
 	int64_t NetWorth() const;

--- a/source/Account.h
+++ b/source/Account.h
@@ -54,7 +54,7 @@ public:
 	const std::vector<Mortgage> &Mortgages() const;
 	void AddMortgage(int64_t principal);
 	void AddFine(int64_t amount);
-	void AddDebt(int64_t amount,int term=-1,double interest=-1,const std::string &type="");
+	void AddDebt(int64_t amount,int term,double interest,const std::string &type);
 	int64_t Prequalify() const;
 	// Assets:
 	int64_t NetWorth() const;

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -223,6 +223,42 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 				swap(minDays, maxDays);
 			events[GameData::Events().Get(child.Token(1))] = make_pair(minDays, maxDays);
 		}
+		else if(key == "fine")
+		{
+			if(child.Size() < 2)
+			{
+				child.PrintTrace("Invalid fine block; must have 1 to 3 arguments.");
+				continue;
+			}
+			fine = child.Value(1);
+			fineTerm = -1;
+			fineInterest = -1;
+			if(fine < 0)
+			{
+				child.PrintTrace("Fines must be larger than 0.");
+				continue;
+			}
+			if(child.Size() > 2)
+			{
+				fineTerm = child.Value(2);
+				if(fineTerm < 1)
+				{
+					child.PrintTrace("Fine terms must be 1 or more days");
+					continue;
+				}
+			}
+			if(child.Size() > 3)
+			{
+				fineInterest = child.Value(3)/100.0;
+				if(fineInterest < 0)
+				{
+					child.PrintTrace("Fine interest must be 0 or higher.");
+					continue;
+				}
+			}
+			if(child.Size() > 4)
+				child.PrintTrace("Invalid fine block; must have 1 to 3 arguments.");
+		}
 		else if(key == "fail")
 		{
 			string toFail = child.Size() >= 2 ? child.Token(1) : missionName;
@@ -457,6 +493,15 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 	if(payment)
 		player.Accounts().AddCredits(payment);
 	
+	if(fine > 0)
+	{
+		if(fineInterest >= 0)
+			player.Accounts().AddFine(fine,fineInterest,fineTerm);
+		else if(fineTerm > 0)
+			player.Accounts().AddFine(fine,fineTerm);
+		else
+			player.Accounts().AddFine(fine);
+	}
 	for(const auto &it : events)
 		player.AddEvent(*it.first, player.GetDate() + it.second.first);
 	
@@ -497,6 +542,14 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 	result.gifts = gifts;
 	result.requiredOutfits = requiredOutfits;
 	result.payment = payment + (jumps + 1) * payload * paymentMultiplier;
+	if(fine)
+	{
+		result.fine = fine;
+		subs["<fine>"] = Format::Number(abs(result.fine))
+			+ (result.fine == 1 ? " credit" : " credits");
+		result.fineTerm = fineTerm;
+		result.fineInterest = fineInterest;
+	}
 	// Fill in the payment amount if this is the "complete" action.
 	string previousPayment = subs["<payment>"];
 	if(result.payment)

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -240,11 +240,11 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			{
 				if(grand.Size() < 2)
 				{
-					grand.PrintTrace("Skipping incomplete debt attribute \""+grand.Token(0)+"\":");
+					grand.PrintTrace("Skipping incomplete debt attribute:");
 					continue;
 				}
 				if(grand.Size() > 2)
-					grand.PrintTrace("Debt attributes must have 1 value (\""+grand.Token(0)+"\"):");
+					grand.PrintTrace("Debt attributes must have 1 value:");
 				if(grand.Token(0) == "interest rate")
 				{
 					debtInterest = grand.Value(1) / 100.0;
@@ -270,10 +270,10 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 					else if(grand.Token(1) == "fine")
 						debtType = "fine";
 					else
-						grand.PrintTrace("Skipping unrecognized debt type \""+grand.Token(1)+"\":");
+						grand.PrintTrace("Skipping unrecognized debt type:");
 				}
 				else
-					grand.PrintTrace("Skipping unrecognized debt attribute \""+grand.Token(0)+"\":");
+					grand.PrintTrace("Skipping unrecognized debt attribute:");
 			}
 		}
 		else if(key == "fail")

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -247,7 +247,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 					grand.PrintTrace("Debt attributes must have 1 value (\""+grand.Token(0)+"\"):");
 				if(grand.Token(0) == "interest rate")
 				{
-					debtInterest = grand.Value(1)/100.0;
+					debtInterest = grand.Value(1) / 100.0;
 					if(debtInterest < 0)
 					{
 						grand.PrintTrace("Debt interest must be 0% or higher.");
@@ -511,7 +511,7 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 		player.Accounts().AddCredits(payment);
 	
 	if(debt > 0)
-		player.Accounts().AddDebt(debt,debtTerm,debtInterest,debtType);
+		player.Accounts().AddDebt(debt, debtTerm, debtInterest, debtType);
 	for(const auto &it : events)
 		player.AddEvent(*it.first, player.GetDate() + it.second.first);
 	

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -227,7 +227,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 		{
 			if(child.Size() < 2)
 			{
-				child.PrintTrace("Invalid fine block; must have 1 to 3 arguments.");
+				child.PrintTrace("Skipping invalid \"fine\": must have 1 to 3 arguments:");
 				continue;
 			}
 			fine = child.Value(1);
@@ -542,10 +542,10 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 	result.gifts = gifts;
 	result.requiredOutfits = requiredOutfits;
 	result.payment = payment + (jumps + 1) * payload * paymentMultiplier;
-	if(fine)
+	if(fine > 0)
 	{
 		result.fine = fine;
-		subs["<fine>"] = Format::Number(abs(result.fine))
+		subs["<fine>"] = Format::Credits(result.fine)
 			+ (result.fine == 1 ? " credit" : " credits");
 		result.fineTerm = fineTerm;
 		result.fineInterest = fineInterest;

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -88,9 +88,10 @@ private:
 	int64_t payment = 0;
 	int64_t paymentMultiplier = 0;
 	
-	int64_t fine = 0;
-	int64_t fineTerm = -1;
-	double fineInterest = -1;
+	int64_t debt = 0;
+	int64_t debtTerm = -1;
+	double debtInterest = -1;
+	std::string debtType;
 	
 	// When this action is performed, the missions with these names fail.
 	std::set<std::string> fail;

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -88,6 +88,10 @@ private:
 	int64_t payment = 0;
 	int64_t paymentMultiplier = 0;
 	
+	int64_t fine = 0;
+	int64_t fineTerm = -1;
+	double fineInterest = -1;
+	
 	// When this action is performed, the missions with these names fail.
 	std::set<std::string> fail;
 	

--- a/source/Mortgage.cpp
+++ b/source/Mortgage.cpp
@@ -42,12 +42,11 @@ int64_t Mortgage::Maximum(int64_t annualRevenue, int creditScore, int64_t curren
 
 // Create a new mortgage of the given amount.
 Mortgage::Mortgage(int64_t principal, int creditScore, int term, const string &requestedType)
-	:type(requestedType),
+	: type(requestedType),
 	principal(principal),
 	interest((600 - creditScore / 2) / 100000.),
 	term(term)
 {
-	
 	if(type.empty())
 		type = creditScore <= 0 ? "Fine" : "Mortgage";
 	

--- a/source/Mortgage.cpp
+++ b/source/Mortgage.cpp
@@ -46,11 +46,11 @@ Mortgage::Mortgage(int64_t principal, int creditScore, int term)
 	interest((600 - creditScore / 2) * .00001),
 	term(term)
 {
-	int thousanths = 600 - creditScore / 2;
-	if(thousanths < 1000)
-		interestString = "0." + to_string(thousanths) + "%";
+	int thousandths = 600 - creditScore / 2;
+	if(thousandths < 1000)
+		interestString = "0." + to_string(thousandths) + "%";
 	else
-		interestString = to_string(thousanths/1000) + "." + to_string(thousanths%1000) + "%";
+		interestString = to_string(thousandths / 1000) + "." + to_string(thousandths % 1000) + "%";
 }
 
 

--- a/source/Mortgage.cpp
+++ b/source/Mortgage.cpp
@@ -44,9 +44,13 @@ Mortgage::Mortgage(int64_t principal, int creditScore, int term)
 	: type(creditScore <= 0 ? "Fine" : "Mortgage"),
 	principal(principal),
 	interest((600 - creditScore / 2) * .00001),
-	interestString("0." + to_string(600 - creditScore / 2) + "%"),
 	term(term)
 {
+	int thousanths = 600 - creditScore / 2;
+	if(thousanths < 1000)
+		interestString = "0." + to_string(thousanths) + "%";
+	else
+		interestString = to_string(thousanths/1000) + "." + to_string(thousanths%1000) + "%";
 }
 
 

--- a/source/Mortgage.h
+++ b/source/Mortgage.h
@@ -36,7 +36,7 @@ public:
 	Mortgage() = default;
 	// Create a new mortgage of the given amount. If this is a fine, set the
 	// credit score to zero for a higher interest rate.
-	Mortgage(int64_t principal, int creditScore, int term = 365);
+	Mortgage(int64_t principal, int creditScore, int term = 365, const std::string &type="");
 	// Construct and Load() at the same time.
 	Mortgage(const DataNode &node);
 	


### PR DESCRIPTION
Adds a new "debt" action to give a fine or mortgage. This resolves issue #1216 using the solution suggested by @endless-sky 

```
mission ...
  ...
  on ...
    debt 100000
      "interest rate" .3
      type fine
      term 300
```

Syntax. Defaults are the same as the game internals:

- `debt 100000` = amount of the fine or mortgage
- `"interest rate" .3` = 0.3% interest rate; default is based on credit rating, with a credit rating of 0 for fines
- `type fine` = fine or mortgage. Default is mortgage if an interest rate is specified, otherwise the default is fine.
- `term 300` = term to calculate daily payments. Default is 60 for fines and 365 for mortgages.

You can put `<debt>` in the description, name, etc. to get the fine amount followed by "credit" or "credits" just like `<payment>`.

The code in Mortgage.cpp that makes the string for the interest rate is updated to handle interest of 1% and higher correctly.