### PR TITLE
warn if conversation text has multiple tokens (e.g. incorrectly-indented goto)

### DIFF
--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -180,6 +180,10 @@ void Conversation::Load(const DataNode &node)
 			// so, future nodes can't merge onto this one.
 			if(LoadGotos(child))
 				nodes.back().canMergeOnto = false;
+			
+			// Check for common errors such as indenting a goto incorrectly:
+			if(child.Size() > 1)
+				node.PrintTrace("Conversation text should be a single string. Only the first string in the line (\""+child.Token(0)+"\") will be used:");
 		}
 	}
 	

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -114,11 +114,16 @@ void Conversation::Load(const DataNode &node)
 		{
 			// Create a new node with one or more choices in it.
 			nodes.emplace_back(true);
+			bool foundErrors = false;
 			for(const DataNode &grand : child)
 			{
 				// Check for common errors such as indenting a goto incorrectly:
 				if(grand.Size() > 1)
-					node.PrintTrace("Choice text should be a single string. Only the first string in the line (\""+grand.Token(0)+"\") will be used:");
+				{
+					grand.PrintTrace("Conversation choices should be a single token:");
+					foundErrors = true;
+					continue;
+				}
 				
 				// Store the text of this choice. By default, the choice will
 				// just bring you to the next node in the script.
@@ -129,7 +134,8 @@ void Conversation::Load(const DataNode &node)
 			}
 			if(nodes.back().data.empty())
 			{
-				child.PrintTrace("Conversation contains an empty \"choice\" node:");
+				if(!foundErrors)
+					child.PrintTrace("Conversation contains an empty \"choice\" node:");
 				nodes.pop_back();
 			}
 		}
@@ -167,6 +173,9 @@ void Conversation::Load(const DataNode &node)
 			nodes.back().canMergeOnto = false;
 			nodes.back().conditions.Load(child);
 		}
+		// Check for common errors such as indenting a goto incorrectly:
+		else if(child.Size() > 1)
+			child.PrintTrace("Conversation text should be a single token:");
 		else
 		{
 			// This is just an ordinary text node.
@@ -184,10 +193,6 @@ void Conversation::Load(const DataNode &node)
 			// so, future nodes can't merge onto this one.
 			if(LoadGotos(child))
 				nodes.back().canMergeOnto = false;
-			
-			// Check for common errors such as indenting a goto incorrectly:
-			if(child.Size() > 1)
-				node.PrintTrace("Conversation text should be a single string. Only the first string in the line (\""+child.Token(0)+"\") will be used:");
 		}
 	}
 	

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -116,6 +116,10 @@ void Conversation::Load(const DataNode &node)
 			nodes.emplace_back(true);
 			for(const DataNode &grand : child)
 			{
+				// Check for common errors such as indenting a goto incorrectly:
+				if(grand.Size() > 1)
+					node.PrintTrace("Choice text should be a single string. Only the first string in the line (\""+grand.Token(0)+"\") will be used:");
+				
 				// Store the text of this choice. By default, the choice will
 				// just bring you to the next node in the script.
 				nodes.back().data.emplace_back(grand.Token(0), nodes.size());


### PR DESCRIPTION
This gives a warning that will catch common conversation coding errors like these two:

```
mission whatever
  ...
  on complete
    conversation
      ...
      "this is a regular line of text"
        goto 1
      "this is a regular line of text"
      goto 2
      choice
        "this is a choice"
        goto 3
```

The `goto 2` and `goto 3` are indented incorrectly, so the code treats them as regular text. These changes update Conversation::Load to give errors and ignore those lines:

```
Conversation text should be a single token:
file .../data/whatever.txt
L1:   mission whatever
L6:     on complete
L7:       conversation
L13:        goto 2

Conversation choices should be a single token:
file .../data/whatever.txt
L1:   mission whatever
L6:     on complete
L7:       conversation
L11:        choice
L16:          goto 3
```