### PR TITLE
Holding shift toggles the park buttons to only affect in-system ships

### DIFF
--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -93,7 +93,7 @@ void Panel::AddZone(const Rectangle &rect, const function<void()> &fun)
 
 void Panel::AddZone(const Rectangle &rect, SDL_Keycode key)
 {
-	AddZone(rect, [this, key](){ this->KeyDown(key, 0, Command(), true); });
+	AddZone(rect, [this, key](){ this->KeyDown(key, SDL_GetModState(), Command(), true); });
 }
 
 

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -287,7 +287,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		{
 			const Ship &ship = *player.Ships()[i];
 			if(!ship.IsDisabled() && &ship != flagship 
-				&& ((shift && ship.GetSystem() == flagship->GetSystem()) || !shift))
+				&& (!shift || (shift && ship.GetSystem() == flagship->GetSystem())))
 				allParked &= ship.IsParked();
 		}
 		
@@ -295,7 +295,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		{
 			const Ship &ship = *player.Ships()[i];
 			if(!ship.IsDisabled() && &ship != flagship 
-				&& ((shift && ship.GetSystem() == flagship->GetSystem()) || !shift))
+				&& (!shift || (shift && ship.GetSystem() == flagship->GetSystem())))
 				player.ParkShip(&ship, !allParked);
 		}
 	}
@@ -306,12 +306,12 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		const Ship *flagship = player.Flagship();
 		for(const auto &it : player.Ships())
 			if(!it->IsDisabled() && it.get() != flagship 
-				&& ((shift && it->GetSystem() == flagship->GetSystem()) || !shift))
+				&& (!shift || (shift && it->GetSystem() == flagship->GetSystem())))
 				allParked &= it->IsParked();
 		
 		for(const auto &it : player.Ships())
 			if(!it->IsDisabled() && (allParked || it.get() != flagship) 
-				&& ((shift && it->GetSystem() == flagship->GetSystem()) || !shift))
+				&& (!shift || (shift && it->GetSystem() == flagship->GetSystem())))
 				player.ParkShip(it.get(), !allParked);
 	}
 	else if(command.Has(Command::MAP) || key == 'm')

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -286,14 +286,16 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		for(int i : allSelected)
 		{
 			const Ship &ship = *player.Ships()[i];
-			if(!ship.IsDisabled() && &ship != flagship)
+			if(!ship.IsDisabled() && &ship != flagship 
+				&& ((shift && ship.GetSystem() == flagship->GetSystem()) || !shift))
 				allParked &= ship.IsParked();
 		}
 		
 		for(int i : allSelected)
 		{
 			const Ship &ship = *player.Ships()[i];
-			if(!ship.IsDisabled() && &ship != flagship)
+			if(!ship.IsDisabled() && &ship != flagship 
+				&& ((shift && ship.GetSystem() == flagship->GetSystem()) || !shift))
 				player.ParkShip(&ship, !allParked);
 		}
 	}
@@ -303,11 +305,13 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		bool allParked = true;
 		const Ship *flagship = player.Flagship();
 		for(const auto &it : player.Ships())
-			if(!it->IsDisabled() && it.get() != flagship)
+			if(!it->IsDisabled() && it.get() != flagship 
+				&& ((shift && it->GetSystem() == flagship->GetSystem()) || !shift))
 				allParked &= it->IsParked();
 		
 		for(const auto &it : player.Ships())
-			if(!it->IsDisabled() && (allParked || it.get() != flagship))
+			if(!it->IsDisabled() && (allParked || it.get() != flagship) 
+				&& ((shift && it->GetSystem() == flagship->GetSystem()) || !shift))
 				player.ParkShip(it.get(), !allParked);
 	}
 	else if(command.Has(Command::MAP) || key == 'm')


### PR DESCRIPTION
**Feature:** This PR implements the feature request ~~detailed and~~ discussed ~~in issue #{{insert number}}~~ on Discord.

## Feature Details
This PR adds the ability to only toggle the park status of in-system ships by holding the shift key before either clicking the (un)park or (un)park all buttons, or pressing the hotkeys for these buttons (P and A).
This allows easier management of larger fleets if for example you park different fleet compositions on different planets. (E.g. war fleet on one planet, trader fleet on another, backup fighters/drones on another, etc.)

## UI Screenshots
Here's a selection of in ship and out of ship systems. Normally when activating the (un)park command, all these ships would be toggled.
![image](https://user-images.githubusercontent.com/17688683/82123060-41d21700-9765-11ea-886c-ae33df3d539c.png)
With this, holding shift then activating park only toggles the in-system ships.
![image](https://user-images.githubusercontent.com/17688683/82123081-64643000-9765-11ea-92aa-001e05107d19.png)

## Usage Examples
N/A

## Testing Done
I parked a number of ships on various different planets, then proceeded to make different selections of ships and toggle the (un)park and (un)park all keys with and without holding shift. In all instances, the expected behavior occurred. 

## Performance Impact
N/A
