### PR TITLE
mission-defined string substitutions (phrases in mission text)

### DIFF
--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -232,6 +232,14 @@ string Format::Replace(const string &source, const map<string, string> keys)
 
 
 
+void Format::MergeReplacements(map<string,string> &target, const vector<pair<string, string>> &source)
+{
+	for(const auto &it : source)
+		target["<"+it.first+">"] = Format::Replace(it.second, target);
+}
+
+
+
 void Format::ReplaceAll(string &text, const string &target, const string &replacement)
 {
 	// If the searched string is an empty string, do nothing.

--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -232,7 +232,7 @@ string Format::Replace(const string &source, const map<string, string> keys)
 
 
 
-void Format::MergeReplacements(map<string,string> &target, const vector<pair<string, string>> &source)
+void Format::MergeReplacements(map<string, string> &target, const vector<pair<string, string>> &source)
 {
 	for(const auto &it : source)
 		target["<" + it.first + ">"] = Format::Replace(it.second, target);

--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -235,7 +235,7 @@ string Format::Replace(const string &source, const map<string, string> keys)
 void Format::MergeReplacements(map<string,string> &target, const vector<pair<string, string>> &source)
 {
 	for(const auto &it : source)
-		target["<"+it.first+">"] = Format::Replace(it.second, target);
+		target["<" + it.first + ">"] = Format::Replace(it.second, target);
 }
 
 

--- a/source/Format.h
+++ b/source/Format.h
@@ -41,7 +41,7 @@ public:
 	static std::string Replace(const std::string &source, const std::map<std::string, std::string> keys);
 	// Set variables in a replacement list. The second argument is pairs of the form (varname,string)
 	// The string will be expanded via Replace() to put the value "<varname>" in the target map/
-	static void MergeReplacements(std::map<std::string,std::string> &target, const std::vector<std::pair<std::string, std::string>> &source);
+	static void MergeReplacements(std::map<std::string, std::string> &target, const std::vector<std::pair<std::string, std::string>> &source);
 	// Replace all occurrences of "target" with "replacement" in-place.
 	static void ReplaceAll(std::string &text, const std::string &target, const std::string &replacement);
 	

--- a/source/Format.h
+++ b/source/Format.h
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 
@@ -38,7 +39,10 @@ public:
 	// Replace a set of "keys," which must be strings in the form "<name>", with
 	// a new set of strings, and return the result.
 	static std::string Replace(const std::string &source, const std::map<std::string, std::string> keys);
-	// Replace all occurences of "target" with "replacement" in-place.
+	// Set variables in a replacement list. The second argument is pairs of the form (varname,string)
+	// The string will be expanded via Replace() to put the value "<varname>" in the target map/
+	static void MergeReplacements(std::map<std::string,std::string> &target, const std::vector<std::pair<std::string, std::string>> &source);
+	// Replace all occurrences of "target" with "replacement" in-place.
 	static void ReplaceAll(std::string &text, const std::string &target, const std::string &replacement);
 	
 	// Convert a string to title caps or to lower case.

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -187,6 +187,8 @@ bool GameData::BeginLoad(const char * const *argv)
 		it.second.FinishLoading(true);
 	for(auto &it : persons)
 		it.second.FinishLoading();
+	for(auto &it : missions)
+		it.second.FinishLoading();
 	startConditions.FinishLoading();
 	
 	// Store the current state, to revert back to later.

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -187,8 +187,6 @@ bool GameData::BeginLoad(const char * const *argv)
 		it.second.FinishLoading(true);
 	for(auto &it : persons)
 		it.second.FinishLoading();
-	for(auto &it : missions)
-		it.second.FinishLoading();
 	startConditions.FinishLoading();
 	
 	// Store the current state, to revert back to later.

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -30,7 +30,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <cmath>
 #include <sstream>
-#include <iostream>
 
 using namespace std;
 
@@ -255,18 +254,18 @@ void Mission::Load(const DataNode &node)
 			else
 				child.PrintTrace("Skipping unrecognized attribute:");
 		}
-		else if(child.Token(0) == "subs")
+		else if(child.Token(0) == "text substitutions")
 		{
 			for(const DataNode &grand : child)
 			{
 				if(grand.Size() > 1 && grand.Token(0).find(">") != string::npos)
-					child.PrintTrace("No \">\" allowed in subs keys (\""+grand.Token(0)+"\"):");
+					grand.PrintTrace("Skipping invalid use of angle brackets in substitution key \""+grand.Token(0)+"\":");
 				else if(grand.Size() == 3 && grand.Token(1) == "phrase")
 					missionSubs.emplace_back(grand.Token(0), "phrase:"+grand.Token(2));
 				else if(grand.Size() == 3 && grand.Token(1) == "=")
 					missionSubs.emplace_back(grand.Token(0), "assign:"+grand.Token(2));
 				else
-					child.PrintTrace("Skipping unrecognized subs definition \""+grand.Token(0)+"\":");
+					grand.PrintTrace("Skipping unrecognized text substitutions definition \""+grand.Token(0)+"\":");
 			}
 		}
 		else

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -259,13 +259,13 @@ void Mission::Load(const DataNode &node)
 			for(const DataNode &grand : child)
 			{
 				if(grand.Size() > 1 && grand.Token(0).find(">") != string::npos)
-					grand.PrintTrace("Skipping invalid use of angle brackets in substitution key \""+grand.Token(0)+"\":");
+					grand.PrintTrace("Skipping invalid use of angle brackets in substitution key:");
 				else if(grand.Size() == 3 && grand.Token(1) == "phrase")
-					textSubstitutions.emplace_back(grand.Token(0), "phrase:" + grand.Token(2));
+					textSubstitutions.emplace_back(grand.Token(0), GameData::Phrases().Get(grand.Token(2)), grand.Token(2));
 				else if(grand.Size() == 3 && grand.Token(1) == "=")
-					textSubstitutions.emplace_back(grand.Token(0), "assign:" + grand.Token(2));
+					textSubstitutions.emplace_back(grand.Token(0), nullptr, grand.Token(2));
 				else
-					grand.PrintTrace("Skipping unrecognized text substitutions definition \""+grand.Token(0)+"\":");
+					grand.PrintTrace("Skipping unrecognized text substitutions definition:");
 			}
 		}
 		else
@@ -969,13 +969,10 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	std::vector<std::pair<std::string, std::string>> missionSubs;
 	for(auto &it : textSubstitutions)
 	{
-		if(it.second.substr(0, 7) == "phrase:")
-		{
-			const Phrase *phrase = GameData::Phrases().Get(it.second.substr(7));
-			missionSubs.emplace_back(it.first, phrase ? phrase->Get() : "");
-		}
+		const Phrase *phrase = std::get<1>(it);
+		missionSubs.emplace_back(std::get<0>(it), phrase ? phrase->Get() : std::get<2>(it));
 		else
-			missionSubs.emplace_back(it.first, it.second.substr(7));
+			missionSubs.emplace_back(std::get<0>(it), std::get<2>(it));
 	}
 	
 	// If anything goes wrong below, this mission should not be offered.

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -971,8 +971,6 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	{
 		const Phrase *phrase = std::get<1>(it);
 		missionSubs.emplace_back(std::get<0>(it), phrase ? phrase->Get() : std::get<2>(it));
-		else
-			missionSubs.emplace_back(std::get<0>(it), std::get<2>(it));
 	}
 	
 	// If anything goes wrong below, this mission should not be offered.

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1145,7 +1145,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	subs["<destination>"] = subs["<planet>"] + " in the " + subs["<system>"] + " system";
 	subs["<date>"] = result.deadline.ToString();
 	subs["<day>"] = result.deadline.LongString();
-	Format::MergeReplacements(subs,missionSubs);
+	Format::MergeReplacements(subs, missionSubs);
 	// Stopover and waypoint substitutions: iterate by reference to the
 	// pointers so we can check when we're at the very last one in the set.
 	// Stopovers: "<name> in the <system name> system" with "," and "and".

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -261,9 +261,9 @@ void Mission::Load(const DataNode &node)
 				if(grand.Size() > 1 && grand.Token(0).find(">") != string::npos)
 					grand.PrintTrace("Skipping invalid use of angle brackets in substitution key \""+grand.Token(0)+"\":");
 				else if(grand.Size() == 3 && grand.Token(1) == "phrase")
-					textSubstitutions.emplace_back(grand.Token(0), "phrase:"+grand.Token(2));
+					textSubstitutions.emplace_back(grand.Token(0), "phrase:" + grand.Token(2));
 				else if(grand.Size() == 3 && grand.Token(1) == "=")
-					textSubstitutions.emplace_back(grand.Token(0), "assign:"+grand.Token(2));
+					textSubstitutions.emplace_back(grand.Token(0), "assign:" + grand.Token(2));
 				else
 					grand.PrintTrace("Skipping unrecognized text substitutions definition \""+grand.Token(0)+"\":");
 			}
@@ -969,7 +969,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	std::vector<std::pair<std::string, std::string>> missionSubs;
 	for(auto &it : textSubstitutions)
 	{
-		if(it.second.substr(0,7) == "phrase:")
+		if(it.second.substr(0, 7) == "phrase:")
 		{
 			const Phrase *phrase = GameData::Phrases().Get(it.second.substr(7));
 			missionSubs.emplace_back(it.first, phrase ? phrase->Get() : "");

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -966,7 +966,7 @@ const MissionAction &Mission::GetAction(Trigger trigger) const
 Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &boardingShip) const
 {
 	Mission result;
-	std::vector<std::pair<std::string,std::string>> missionSubs;
+	std::vector<std::pair<std::string, std::string>> missionSubs;
 	for(auto &it : missionSubPhrases)
 	{
 		const Phrase *phrase = GameData::Phrases().Get(it.second);

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -261,9 +261,9 @@ void Mission::Load(const DataNode &node)
 				if(grand.Size() > 1 && grand.Token(0).find(">") != string::npos)
 					grand.PrintTrace("Skipping invalid use of angle brackets in substitution key \""+grand.Token(0)+"\":");
 				else if(grand.Size() == 3 && grand.Token(1) == "phrase")
-					missionSubPhrases.emplace_back(grand.Token(0), grand.Token(2));
+					textSubstitutions.emplace_back(grand.Token(0), "phrase:"+grand.Token(2));
 				else if(grand.Size() == 3 && grand.Token(1) == "=")
-					missionSubText.emplace_back(grand.Token(0), grand.Token(2));
+					textSubstitutions.emplace_back(grand.Token(0), "assign:"+grand.Token(2));
 				else
 					grand.PrintTrace("Skipping unrecognized text substitutions definition \""+grand.Token(0)+"\":");
 			}
@@ -967,12 +967,16 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 {
 	Mission result;
 	std::vector<std::pair<std::string, std::string>> missionSubs;
-	for(auto &it : missionSubPhrases)
+	for(auto &it : textSubstitutions)
 	{
-		const Phrase *phrase = GameData::Phrases().Get(it.second);
-		missionSubs.emplace_back(it.first, phrase ? phrase->Get() : "");
+		if(it.second.substr(0,7) == "phrase:")
+		{
+			const Phrase *phrase = GameData::Phrases().Get(it.second.substr(7));
+			missionSubs.emplace_back(it.first, phrase ? phrase->Get() : "");
+		}
+		else
+			missionSubs.emplace_back(it.first, it.second.substr(7));
 	}
-	missionSubs.insert(missionSubs.end(), missionSubText.begin(), missionSubText.end());
 	
 	// If anything goes wrong below, this mission should not be offered.
 	result.hasFailed = true;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -225,8 +225,8 @@ private:
 	// Track which `on enter` MissionActions have triggered.
 	std::set<const MissionAction *> didEnter;
 	// String substitution requests read in by Load()
-	std::vector<std::pair<std::string,std::string>> missionSubText;
-	std::vector<std::pair<std::string,std::string>> missionSubPhrases;
+	std::vector<std::pair<std::string, std::string>> missionSubText;
+	std::vector<std::pair<std::string, std::string>> missionSubPhrases;
 };
 
 

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -24,7 +24,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <memory>
 #include <set>
 #include <string>
-#include <utility>
+#include <tuple>
 #include <vector>
 
 class DataNode;
@@ -223,7 +223,7 @@ private:
 	// Track which `on enter` MissionActions have triggered.
 	std::set<const MissionAction *> didEnter;
 	// String substitution requests read in by Load()
-	std::vector<std::pair<std::string, std::string>> textSubstitutions;
+	std::vector<std::tuple<std::string, const Phrase *, std::string>> textSubstitutions;
 };
 
 

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -51,8 +51,6 @@ public:
 	
 	// Load a mission, either from the game data or from a saved game.
 	void Load(const DataNode &node);
-	// Expand phrases in subs
-	void FinishLoading();
 	// Save a mission. It is safe to assume that any mission that is being saved
 	// is already "instantiated," so only a subset of the data must be saved.
 	void Save(DataWriter &out, const std::string &tag = "mission") const;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -214,6 +214,8 @@ private:
 	// NPCs:
 	std::list<NPC> npcs;
 	
+	std::vector<std::tuple<std::string, const Phrase *, std::string>> textSubstitutions;
+	
 	// Actions to perform:
 	std::map<Trigger, MissionAction> actions;
 	// "on enter" actions may name a specific system, or rely on matching a
@@ -222,8 +224,6 @@ private:
 	std::list<MissionAction> genericOnEnter;
 	// Track which `on enter` MissionActions have triggered.
 	std::set<const MissionAction *> didEnter;
-	// String substitution requests read in by Load()
-	std::vector<std::tuple<std::string, const Phrase *, std::string>> textSubstitutions;
 };
 
 

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -225,8 +225,7 @@ private:
 	// Track which `on enter` MissionActions have triggered.
 	std::set<const MissionAction *> didEnter;
 	// String substitution requests read in by Load()
-	std::vector<std::pair<std::string, std::string>> missionSubText;
-	std::vector<std::pair<std::string, std::string>> missionSubPhrases;
+	std::vector<std::pair<std::string, std::string>> textSubstitutions;
 };
 
 

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -224,8 +224,9 @@ private:
 	std::list<MissionAction> genericOnEnter;
 	// Track which `on enter` MissionActions have triggered.
 	std::set<const MissionAction *> didEnter;
-	// Mission-specific variables
-	std::vector<std::pair<std::string,std::string>> missionSubs;
+	// String substitution requests read in by Load()
+	std::vector<std::pair<std::string,std::string>> missionSubText;
+	std::vector<std::pair<std::string,std::string>> missionSubPhrases;
 };
 
 

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -24,6 +24,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
+#include <vector>
 
 class DataNode;
 class DataWriter;
@@ -49,6 +51,8 @@ public:
 	
 	// Load a mission, either from the game data or from a saved game.
 	void Load(const DataNode &node);
+	// Expand phrases in subs
+	void FinishLoading();
 	// Save a mission. It is safe to assume that any mission that is being saved
 	// is already "instantiated," so only a subset of the data must be saved.
 	void Save(DataWriter &out, const std::string &tag = "mission") const;
@@ -220,6 +224,8 @@ private:
 	std::list<MissionAction> genericOnEnter;
 	// Track which `on enter` MissionActions have triggered.
 	std::set<const MissionAction *> didEnter;
+	// Mission-specific variables
+	std::vector<std::pair<std::string,std::string>> missionSubs;
 };
 
 

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -478,7 +478,7 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 
 
 
-MissionAction MissionAction::Instantiate(map<string, string> &subs, const System *origin, int jumps, int payload) const
+MissionAction MissionAction::Instantiate(map<string, string> &subs, const vector<pair<string, string>> &missionSubs, const System *origin, int jumps, int payload) const
 {
 	MissionAction result;
 	result.trigger = trigger;
@@ -502,6 +502,7 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 	if(result.payment)
 		subs["<payment>"] = Format::Credits(abs(result.payment))
 			+ (result.payment == 1 ? " credit" : " credits");
+	Format::MergeReplacements(subs, missionSubs);
 	
 	if(!logText.empty())
 		result.logText = Format::Replace(logText, subs);
@@ -528,7 +529,9 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 	// Restore the "<payment>" value from the "on complete" condition, for use
 	// in other parts of this mission.
 	if(result.payment && trigger != "complete")
+	{
 		subs["<payment>"] = previousPayment;
-	
+		Format::MergeReplacements(subs, missionSubs);
+	}
 	return result;
 }

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -23,6 +23,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 class DataNode;
 class DataWriter;
@@ -64,7 +65,7 @@ public:
 	
 	// "Instantiate" this action by filling in the wildcard text for the actual
 	// destination, payment, cargo, etc.
-	MissionAction Instantiate(std::map<std::string, std::string> &subs, const System *origin, int jumps, int payload) const;
+	MissionAction Instantiate(std::map<std::string, std::string> &subs, const std::vector<std::pair<std::string, std::string>> &missionSubs, const System *origin, int jumps, int payload) const;
 	
 	
 private:

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -405,7 +405,7 @@ bool NPC::HasFailed() const
 
 // Create a copy of this NPC but with the fleets replaced by the actual
 // ships they represent, wildcards in the conversation text replaced, etc.
-NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const System *destination) const
+NPC NPC::Instantiate(map<string, string> &subs, const vector<pair<string,string>> &missionSubs, const System *origin, const System *destination) const
 {
 	NPC result;
 	result.government = government;
@@ -468,8 +468,10 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	
 	// String replacement:
 	if(!result.ships.empty())
+	{
 		subs["<npc>"] = result.ships.front()->Name();
-	
+		Format::MergeReplacements(subs,missionSubs);
+	}
 	// Do string replacement on any dialog or conversation.
 	string dialogText = stockDialogPhrase ? stockDialogPhrase->Get()
 		: (!dialogPhrase.Name().empty() ? dialogPhrase.Get()

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -470,7 +470,7 @@ NPC NPC::Instantiate(map<string, string> &subs, const vector<pair<string,string>
 	if(!result.ships.empty())
 	{
 		subs["<npc>"] = result.ships.front()->Name();
-		Format::MergeReplacements(subs,missionSubs);
+		Format::MergeReplacements(subs, missionSubs);
 	}
 	// Do string replacement on any dialog or conversation.
 	string dialogText = stockDialogPhrase ? stockDialogPhrase->Get()

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -405,7 +405,7 @@ bool NPC::HasFailed() const
 
 // Create a copy of this NPC but with the fleets replaced by the actual
 // ships they represent, wildcards in the conversation text replaced, etc.
-NPC NPC::Instantiate(map<string, string> &subs, const vector<pair<string,string>> &missionSubs, const System *origin, const System *destination) const
+NPC NPC::Instantiate(map<string, string> &subs, const vector<pair<string, string>> &missionSubs, const System *origin, const System *destination) const
 {
 	NPC result;
 	result.government = government;

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -23,6 +23,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
+#include <utility>
 
 class DataNode;
 class DataWriter;
@@ -63,7 +65,7 @@ public:
 	
 	// Create a copy of this NPC but with the fleets replaced by the actual
 	// ships they represent, wildcards in the conversation text replaced, etc.
-	NPC Instantiate(std::map<std::string, std::string> &subs, const System *origin, const System *destination) const;
+	NPC Instantiate(std::map<std::string, std::string> &subs, const std::vector<std::pair<std::string, std::string>> &missionSubs, const System *origin, const System *destination) const;
 	
 	
 private:


### PR DESCRIPTION
**Feature:** Allow mission-defined `<substitutions>` which allows (among other things) phrases in mission text.

## Usage Examples
There's a great multitude of uses for this, but I'll give a simple, stupid, example.

```
mission...
  description `Hunt a pirate that said "<rudeness>"`
  name `Hunt a rude pirate.`
  "text substitutions"
    rudeness1 phrase "hostile disabled"
    rudeness2 phrase "hostile disabled"
    rudeness = "<rudeness1> <rudeness2>"
  on offer
    dialog `An angry pilot wants you to find a pirate that said, "<rudeness>"`
  on complete
    dialog `The pilot thanks you for decimating the pirate that said, "<rudeness>"`
    payment 100000
  npc kill
    ...
```

This will bring up a dialog saying something like:

> An angry pilot wants you to find a pirate that said, "Leave me alone, you impertinent milk-livered ratsbane. I can't believe I'm at the mercy of such a qualling spur-galled codpiece."

You'll get a consistent completion message:

> The pilot thanks you for decimating the pirate that said, "Leave me alone, you impertinent milk-livered ratsbane. I can't believe I'm at the mercy of such a qualling spur-galled codpiece."

and a consistent description.

You can reference standard keys too:

```
    "text substitutions"
      key1 = "I want <payment> right now!"
      key2 = "My favorite place is <destination>."
```


## Testing Done

A variety of subs combinations were attempted, including invalid ones. 

Three special cases are tried:

1. A sub key that contains a `>` is discarded with a warning
2. Substitutions are processed in order so each one can see the earlier ones
3. References to invalid phrases result in ""
4. Text substitutions are seen in both dialogs and conversations.

## Performance Impact
I'd expect each mission to take a fraction of a microsecond longer to instantiate
