### PR TITLE
Stop crashing when using weapons with infinite submunition

### DIFF
--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -20,7 +20,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "SpriteSet.h"
 
 #include <algorithm>
-#include <array>
 
 using namespace std;
 
@@ -332,29 +331,13 @@ double Weapon::TotalDamage(int index) const
 {
 	if(!calculatedDamage)
 	{
-		// To make infinite submunitions work, we need to break
-		// the infinite recursion. Do this by remembering up to
-		// 10 submunition instances, which should be enough for now.
-		static array<const Weapon *, 10> instancesSeen;
-		static size_t currentIndex;
-
-		instancesSeen[currentIndex++] = this;
-
+		calculatedDamage = true;
 		for(int i = 0; i < DAMAGE_TYPES; ++i)
 		{
 			for(const auto &it : submunitions)
-			{
-				if(find(instancesSeen.begin(), instancesSeen.end(), it.first)
-						!= instancesSeen.end())
-					break;
 				damage[i] += it.first->TotalDamage(i) * it.second;
-			}
 			doesDamage |= (damage[i] > 0.);
 		}
-		
-		calculatedDamage = true;
-		instancesSeen.fill(nullptr);
-		currentIndex = 0;
 	}
 	return damage[index];
 }

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -20,6 +20,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "SpriteSet.h"
 
 #include <algorithm>
+#include <array>
 
 using namespace std;
 
@@ -331,14 +332,29 @@ double Weapon::TotalDamage(int index) const
 {
 	if(!calculatedDamage)
 	{
+		// To make infinite submunitions work, we need to break
+		// the infinite recursion. Do this by remembering up to
+		// 10 submunition instances, which should be enough for now.
+		static array<const Weapon *, 10> instancesSeen;
+		static size_t currentIndex;
+
+		instancesSeen[currentIndex++] = this;
+
 		for(int i = 0; i < DAMAGE_TYPES; ++i)
 		{
 			for(const auto &it : submunitions)
+			{
+				if(find(instancesSeen.begin(), instancesSeen.end(), it.first)
+						!= instancesSeen.end())
+					break;
 				damage[i] += it.first->TotalDamage(i) * it.second;
+			}
 			doesDamage |= (damage[i] > 0.);
 		}
 		
 		calculatedDamage = true;
+		instancesSeen.fill(nullptr);
+		currentIndex = 0;
 	}
 	return damage[index];
 }


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5022

## Fix Details

When calculating the total damage of a weapon with infinite submunition, the game crashes with a stack overflow due to infinite recursion. <del>The fix I'm introducing is to remember up to 10 submunitions and see if they are seen again. This means that the total damage of a weapon with infinite submunition is the total damage up to the point where the loop happens.

<del>This enables any infinite submunition whose repeating munition is at most 10. Should be enough for most.</del>

We can reuse the "calculated" flag to prevent the infinite recursion by setting it to `true` as soon as we start the calculation.

The issue also describes an error that the max velocity is 450000. I haven't seen this issue, even when I increase the velocity of the projectiles to exceed this velocity (although the game starts to lag a bit). So that part of the issue is not addressed in this PR.

## Testing Done

Tested this with the weapon provided in the linked issue. The weapon works perfectly.

## Save File

You need the outfit file from the issue modified as described there (create the loop from B to A) and [this save file](https://gist.githubusercontent.com/Rakete1111/a4a746b3c5cfdab3f4eb6acc21efc251/raw/af215070a2a6ab55970bf614c2a985d6a5a22963/gistfile1.txt).