### PR TITLE
Add the ability for plugins to override builtin missions

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -92,15 +92,11 @@ void Mission::Load(const DataNode &node)
 		node.PrintTrace("No name specified for mission:");
 		return;
 	}
-	// If a mission object is "loaded" twice, that is most likely an error (e.g.
+	// If a mission object is "loaded" twice, override the current mission (e.g.
 	// due to a plugin containing a mission with the same name as the base game
-	// or another plugin). This class is not designed to allow merging or
-	// overriding of mission data from two different definitions.
+	// or another plugin).
 	if(!name.empty())
-	{
-		node.PrintTrace("Duplicate definition of mission:");
-		return;
-	}
+		*this = Mission();
 	name = node.Token(1);
 	
 	for(const DataNode &child : node)


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4487

## Feature Details

This adds the ability for missions to be overridden by plugins for example.

It works by basically copy constructing a new empty object into the mission to be overridden and then load the new mission normally.

As far as I can understand, `GameData` is responsible for loading any missions in the game. That is also the only point where missions are loaded (where their `Load` function is called). The builtin missions are loaded first, so any plugin that provides a mission with the same name will have the builtin plugin correctly overridden by this PR.

## Testing Done

Using the example mission provided in the issue. Works.

## Performance Impact

N/A