### PR TITLE
Assign UUIDs to ships, missions, and npcs

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -574,6 +574,7 @@ vector<shared_ptr<Ship>> Fleet::Instantiate(const Variant &variant) const
 			ship->SetName(phrase->Get());
 		ship->SetGovernment(government);
 		ship->SetPersonality(personality);
+		ship->NewUUID();
 		
 		placed.push_back(ship);
 	}

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -432,7 +432,7 @@ bool Mission::IsMinor() const
 
 void Mission::EnsureUUID()
 {
-	if(uuid.size() < 1)
+	if(uuid.empty())
 		uuid = Random::UUID();
 }
 
@@ -1130,7 +1130,6 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	
 	// Generate the substitutions map.
 	map<string, string> subs;
-	subs["<uuid>"] = result.uuid;
 	subs["<commodity>"] = result.cargo;
 	subs["<tons>"] = to_string(result.cargoSize) + (result.cargoSize == 1 ? " ton" : " tons");
 	subs["<cargo>"] = subs["<tons>"] + " of " + subs["<commodity>"];

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -54,6 +54,7 @@ public:
 	void Save(DataWriter &out, const std::string &tag = "mission") const;
 	
 	// Basic mission information.
+	const std::string &UUID() const;
 	const std::string &Name() const;
 	const std::string &Description() const;
 	// Check if this mission should be shown in your mission list. If not, the
@@ -66,6 +67,9 @@ public:
 	// Check if this mission is a "minor" mission. Minor missions will only be
 	// offered if no other missions (minor or otherwise) are being offered.
 	bool IsMinor() const;
+	
+	// For backward-compatibility to old saves, generate a UUID if none is present
+	void EnsureUUID();
 	
 	// Find out where this mission is offered.
 	enum Location {SPACEPORT, LANDING, JOB, ASSISTING, BOARDING};
@@ -166,6 +170,8 @@ private:
 	std::string description;
 	std::string blocked;
 	Location location = SPACEPORT;
+	
+	std::string uuid;
 	
 	bool hasFailed = false;
 	bool isVisible = true;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -68,7 +68,7 @@ public:
 	// offered if no other missions (minor or otherwise) are being offered.
 	bool IsMinor() const;
 	
-	// For backward-compatibility to old saves, generate a UUID if none is present
+	// For backward-compatibility to old saves, generate a UUID if none is present.
 	void EnsureUUID();
 	
 	// Find out where this mission is offered.

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -85,6 +85,8 @@ void NPC::Load(const DataNode &node)
 			else
 				location.Load(child);
 		}
+		else if(child.Token(0) == "uuid" && child.Size() >= 2)
+			uuid = child.Token(1);
 		else if(child.Token(0) == "planet" && child.Size() >= 2)
 			planet = GameData::Planets().Get(child.Token(1));
 		else if(child.Token(0) == "succeed" && child.Size() >= 2)
@@ -194,6 +196,8 @@ void NPC::Save(DataWriter &out) const
 	out.Write("npc");
 	out.BeginChild();
 	{
+		if(!uuid.empty())
+			out.Write("uuid", uuid);
 		if(succeedIf)
 			out.Write("succeed", succeedIf);
 		if(failIf)
@@ -237,6 +241,28 @@ void NPC::Save(DataWriter &out) const
 		}
 	}
 	out.EndChild();
+}
+
+
+
+const string &NPC::UUID() const
+{
+	return uuid;
+}
+
+
+
+void NPC::EnsureUUID()
+{
+	if(uuid.empty())
+		uuid = Random::UUID();
+}
+
+
+
+void NPC::NewUUID()
+{
+	uuid = Random::UUID();
 }
 
 
@@ -411,6 +437,7 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	result.government = government;
 	if(!result.government)
 		result.government = GameData::PlayerGovernment();
+	result.uuid = Random::UUID();
 	result.personality = personality;
 	result.succeedIf = succeedIf;
 	result.failIf = failIf;
@@ -441,6 +468,8 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 		result.ships.push_back(make_shared<Ship>(**shipIt));
 		result.ships.back()->SetName(*nameIt);
 	}
+	for(auto resultShipIt : result.ships)
+		resultShipIt->NewUUID();
 	for(const Fleet &fleet : fleets)
 		fleet.Place(*result.system, result.ships, false);
 	for(const Fleet *fleet : stockFleets)

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -51,6 +51,10 @@ public:
 	// a template, so fleets will be replaced by individual ships already.
 	void Save(DataWriter &out) const;
 	
+	const std::string &UUID() const;
+	void EnsureUUID();
+	void NewUUID();
+	
 	// Get the ships associated with this set of NPCs.
 	const std::list<std::shared_ptr<Ship>> Ships() const;
 	
@@ -70,6 +74,8 @@ private:
 	// The government of the ships in this NPC:
 	const Government *government = nullptr;
 	Personality personality;
+	
+	std::string uuid;
 	
 	// Start out in a location matching this filter, or in a particular system:
 	LocationFilter location;

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -38,6 +38,7 @@ void Person::Load(const DataNode &node)
 			ships.emplace_back(new Ship(child));
 			if(setName)
 				ships.back()->SetName(child.Token(2));
+			ships.back()->NewUUID();
 		}
 		else if(child.Token(0) == "government" && child.Size() >= 2)
 			government = GameData::Governments().Get(child.Token(1));

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -84,6 +84,7 @@ void PlayerInfo::New()
 		ships.back()->SetIsSpecial();
 		ships.back()->SetIsYours();
 		ships.back()->SetGovernment(GameData::PlayerGovernment());
+		ships.back()->NewUUID();
 	}
 	// Load starting conditions from a "start" item in the data files. If no
 	// such item exists, StartConditions defines default values.
@@ -172,6 +173,7 @@ void PlayerInfo::Load(const string &path)
 			ships.back()->SetIsSpecial();
 			ships.back()->FinishLoading(false);
 			ships.back()->SetIsYours();
+			ships.back()->EnsureUUID();
 		}
 		else if(child.Token(0) == "groups" && child.Size() >= 2 && !ships.empty())
 			groups[ships.back().get()] = child.Value(1);
@@ -200,12 +202,19 @@ void PlayerInfo::Load(const string &path)
 		else if(child.Token(0) == "mission")
 		{
 			missions.emplace_back(child);
+			missions.back().EnsureUUID();
 			cargo.AddMissionCargo(&missions.back());
 		}
 		else if(child.Token(0) == "available job")
+		{
 			availableJobs.emplace_back(child);
+			availableJobs.back().EnsureUUID();
+		}
 		else if(child.Token(0) == "available mission")
+		{
 			availableMissions.emplace_back(child);
+			availableMissions.back().EnsureUUID();
+		}
 		else if(child.Token(0) == "conditions")
 		{
 			for(const DataNode &grand : child)
@@ -861,6 +870,7 @@ void PlayerInfo::BuyShip(const Ship *model, const string &name)
 		ships.back()->SetIsSpecial();
 		ships.back()->SetIsYours();
 		ships.back()->SetGovernment(GameData::PlayerGovernment());
+		ships.back()->NewUUID();
 		
 		accounts.AddCredits(-cost);
 		flagship.reset();

--- a/source/Random.cpp
+++ b/source/Random.cpp
@@ -27,10 +27,14 @@ namespace {
 	mt19937_64 gen;
 	uniform_int_distribution<uint32_t> uniform;
 	uniform_real_distribution<double> real;
+	uniform_real_distribution<> zeroToFifteen(0, 15);
+	uniform_real_distribution<> eightToEleven(8, 11);
 #else
 	thread_local mt19937_64 gen;
 	thread_local uniform_int_distribution<uint32_t> uniform;
 	thread_local uniform_real_distribution<double> real;
+	thread_local uniform_real_distribution<> zeroToFifteen(0, 15);
+	thread_local uniform_real_distribution<> eightToEleven(8, 11);
 #endif
 }
 
@@ -111,4 +115,37 @@ double Random::Normal()
 	lock_guard<mutex> lock(workaroundMutex);
 #endif
 	return normal(gen);
+}
+
+
+
+// Get a random UUID
+std::string Random::UUID()
+{
+#ifndef __linux__
+	lock_guard<mutex> lock(workaroundMutex);
+#endif
+	char uuid[37];
+	static const char * const hex="0123456789abcdef";
+	int i=0;
+	
+	for(int j = 0; j < 8; j++)
+		uuid[i++] = hex[static_cast<int>(zeroToFifteen(gen))];
+	uuid[i++] = '-';
+	for(int j = 0; j < 4; j++)
+		uuid[i++] = hex[static_cast<int>(zeroToFifteen(gen))];
+	uuid[i++] = '-';
+	uuid[i++] = '4';
+	for(int j = 0; j < 3; j++)
+		uuid[i++] = hex[static_cast<int>(zeroToFifteen(gen))];
+	uuid[i++] = '-';
+	uuid[i++] = hex[static_cast<int>(eightToEleven(gen))];
+	for(int j = 0; j < 3; j++)
+		uuid[i++] = hex[static_cast<int>(zeroToFifteen(gen))];
+	uuid[i++] = '-';
+	for(int j = 0; j < 12; j++)
+		uuid[i++] = hex[static_cast<int>(zeroToFifteen(gen))];
+	uuid[i++] = '\0';
+	
+	return uuid;
 }

--- a/source/Random.cpp
+++ b/source/Random.cpp
@@ -122,7 +122,7 @@ double Random::Normal()
 // Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122)
 // which are hexidecimal strings like "2c8ab67c-e7cc-471a-a415-08a63ba52527"
 // and contain 121 bits of random data.
-std::string Random::UUID()
+string Random::UUID()
 {
 #ifndef __linux__
 	lock_guard<mutex> lock(workaroundMutex);

--- a/source/Random.cpp
+++ b/source/Random.cpp
@@ -119,7 +119,9 @@ double Random::Normal()
 
 
 
-// Get a random UUID
+// Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122)
+// which are hexidecimal strings like "2c8ab67c-e7cc-471a-a415-08a63ba52527"
+// and contain 121 bits of random data.
 std::string Random::UUID()
 {
 #ifndef __linux__

--- a/source/Random.h
+++ b/source/Random.h
@@ -42,7 +42,10 @@ public:
 	static uint32_t Binomial(uint32_t t, double p = .5);
 	// Get a normally distributed number (mean = 0, sigma= 1).
 	static double Normal();
-	// Get a random UUID
+	
+	// Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122)
+	// which are hexidecimal strings like "2c8ab67c-e7cc-471a-a415-08a63ba52527"
+	// and contain 121 bits of random data.
 	static std::string UUID();
 };
 

--- a/source/Random.h
+++ b/source/Random.h
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #define RANDOM_H_
 
 #include <cstdint>
+#include <string>
 
 
 
@@ -41,6 +42,8 @@ public:
 	static uint32_t Binomial(uint32_t t, double p = .5);
 	// Get a normally distributed number (mean = 0, sigma= 1).
 	static double Normal();
+	// Get a random UUID
+	static std::string UUID();
 };
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -148,6 +148,8 @@ void Ship::Load(const DataNode &node)
 		}
 		if(key == "sprite")
 			LoadSprite(child);
+		else if(key == "uuid" && child.Size() >= 2)
+			uuid = child.Token(1);
 		else if(child.Token(0) == "thumbnail" && child.Size() >= 2)
 			thumbnail = SpriteSet::Get(child.Token(1));
 		else if(key == "name" && child.Size() >= 2)
@@ -624,6 +626,9 @@ void Ship::Save(DataWriter &out) const
 		if(customSwizzle >= 0)
 			out.Write("swizzle", customSwizzle);
 		
+		if(!uuid.empty())
+			out.Write("uuid", uuid);
+		
 		out.Write("attributes");
 		out.BeginChild();
 		{
@@ -758,6 +763,28 @@ void Ship::Save(DataWriter &out) const
 const string &Ship::Name() const
 {
 	return name;
+}
+
+
+
+const string &Ship::UUID() const
+{
+	return uuid;
+}
+
+
+
+void Ship::EnsureUUID()
+{
+	if(uuid.empty())
+		uuid = Random::UUID();
+}
+
+
+
+void Ship::NewUUID()
+{
+	uuid = Random::UUID();
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -127,6 +127,10 @@ public:
 	// Save a full description of this ship, as currently configured.
 	void Save(DataWriter &out) const;
 	
+	const std::string &UUID() const;
+	void EnsureUUID();
+	void NewUUID();
+	
 	// Get the name of this particular ship.
 	const std::string &Name() const;
 	
@@ -417,6 +421,8 @@ private:
 	int swizzle;
 	const Government *government;
 	*/
+	
+	std::string uuid;
 	
 	// Characteristics of the chassis:
 	const Ship *base = nullptr;


### PR DESCRIPTION
**Feature:** Adds a unique identifier to ships, missions, and NPCs. Also adds a Random::UUID() function to generate random UUIDs. This aids in recreating pointers to missions, ships, and npcs after loading a game.

## Feature Details

UUIDs are these: https://en.wikipedia.org/wiki/Universally_unique_identifier
Standard definition: https://tools.ietf.org/html/rfc4122

In your save files, you should see:

```
ship
  ...
  uuid 2c8ab67c-e7cc-471a-a415-08a63ba52527

mission
  ...
  uuid 27ecb32b-e8a2-4350-aa5b-6b4b773520c7
  ...
  npc
    ...
    uuid b45551e8-324c-4b35-96ba-cb02357694e2
```

## Usage Examples

In and of itself, this PR is useless, but it will be needed by other PRs that have to uniquely identify ships, missions, or NPCs when loading data back from a file. This allows pointers to ships, NPCs, and missions to be restored.

Used by #5070 to load pointers to mission cargo and mission passengers, and #5082 to load the mission whose conversation was being displayed.

## Testing Done

1. Load a game with no UUIDs. Save it. Make sure all ships, missions, available missions, available jobs, and NPCs have UUIDs.

2. Buy a ship. Save. Make sure it has a UUID.

3. Go to a planet with available jobs and available missions. Save. Make sure they have UUIDs.

4. Go to a planet with a job or mission that has an NPC. Save. Make sure the NPC and its ships have UUIDs.

5. Run with this branch. Save. Load mission from earlier version of the code. It should load correctly; the uuids should be discarded.

## Performance Impact

It'll take a fraction of a microsecond longer to instantiate a mission or make a ship.

