### PR TITLE
allow fast-forward to be toggled in boarding and hail panels

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -404,6 +404,8 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 	}
 	else if(command.Has(Command::INFO))
 		GetUI()->Push(new ShipInfoPanel(player));
+	else if(command.Has(Command::FASTFORWARD))
+		return false;
 	
 	// Trim the list of status messages.
 	while(messages.size() > 5)

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -303,7 +303,9 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		else
 			message = "I do not want your money.";
 	}
-	
+	else if(command.Has(Command::FASTFORWARD))
+		return false;
+
 	return true;
 }
 

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -305,7 +305,7 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	}
 	else if(command.Has(Command::FASTFORWARD))
 		return false;
-
+	
 	return true;
 }
 


### PR DESCRIPTION
A recent UI change blocked fast-forward in panels that handled the keypress. This PR explicitly allows the fast-forward key in boarding and hail panels, unless the key is mapped to one specific to that panel (like "a").

The bug was introduced by #4882 to fix issue #4880 which reported that you cannot type the fast-forward key in text fields. The fix #4882 blocked fast-forward everywhere, except when the UI didn't handle the keystroke. For some reason, the boarding and hailing panels block all keystrokes by default, including fast-forward.

Issue #5038 reported the bug in which fast-forward breaks in boarding and hailing panels. @tehhowch's explanation is:

> It is indeed intentional that you cannot toggle FF state when not in active flight.

which is definitely false. You can toggle it everywhere except boarding panels, hailing panels, and text fields.

It is dangerous to block the fast-forward key outside active flight since you may need to quickly react to something than happened, like capturing a valuable ship.

The fix is to have the BoardingPanel and HailPanel ignore the fast-forward key, unless it mapped to a key needed by that panel (like "c").