### PR TITLE
feat(cd): Display build time on the releases page

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -151,7 +151,7 @@ jobs:
           git push --tags --force
       - name: Setup continuous release
         run: |
-          DESCRIPTION="Triggered on $(date -u '+%Y-%m-%d %H:%M') by commit ${{ github.sha }} (@${{ github.actor }})
+          DESCRIPTION="Triggered on $(date -u '+%Y/%m/%d, %H:%M') UTC by commit ${{ github.sha }} (@${{ github.actor }})
           \n
           \nThis is an automated build of the latest source. It may be unstable or even crash, corrupt your save or eat your kitten. Use with caution!
           \n

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,8 +2,8 @@ name: CD
 
 on:
   push:
-    branches:
-      - master
+#    branches:
+#      - master
   pull_request:
     types: 
       - synchronize # New commit has been pushed

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,8 +2,8 @@ name: CD
 
 on:
   push:
-#    branches:
-#      - master
+    branches:
+      - master
   pull_request:
     types: 
       - synchronize # New commit has been pushed

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -152,10 +152,10 @@ jobs:
       - name: Setup continuous release
         run: |
           DESCRIPTION="Triggered on $(date -u '+%Y/%m/%d, %H:%M') UTC by commit ${{ github.sha }} (@${{ github.actor }})
-          \n
-          \nThis is an automated build of the latest source. It may be unstable or even crash, corrupt your save or eat your kitten. Use with caution!
-          \n
-          \nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          
+          This is an automated build of the latest source. It may be unstable or even crash, corrupt your save or eat your kitten. Use with caution!
+          
+          https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if ! github-release info -t continuous > /dev/null 2>&1; then
             github-release release \
               --tag continuous \

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -151,10 +151,11 @@ jobs:
           git push --tags --force
       - name: Setup continuous release
         run: |
-          DESCRIPTION=$'This is an automated build of the latest source. It may be unstable or even crash, corrupt your save or eat your kitten. Use with caution!
+          DESCRIPTION="Triggered on $(date -u '+%Y-%m-%d %H:%M') by commit ${{ github.sha }} (@${{ github.actor }})
           \n
-          \nTriggered on commit ${{ github.sha }} by @${{ github.actor }}
-          \nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          \nThis is an automated build of the latest source. It may be unstable or even crash, corrupt your save or eat your kitten. Use with caution!
+          \n
+          \nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if ! github-release info -t continuous > /dev/null 2>&1; then
             github-release release \
               --tag continuous \


### PR DESCRIPTION
**Feature**

## Feature Details
The build time (actually the time of uploading) is now displayed along the commit hash and author. The formatting has been altered slightly.

Before:
![image](https://user-images.githubusercontent.com/22377202/82424885-13ff1200-9a86-11ea-8b65-c70052bab305.png)

After:
![image](https://user-images.githubusercontent.com/22377202/82424857-0cd80400-9a86-11ea-9dde-d4156b0c6b8d.png)

## Testing Done
https://github.com/MCOfficer/endless-sky/releases/tag/continuous
