### PR TITLE
CI/CD: Update action versions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - actions-update
   pull_request:
     types: 
       - synchronize # New commit has been pushed

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Package Application
         run: tar -czf ${{ env.OUTPUT }} sounds images/ data/ license.txt keys.txt icon.png endless-sky credits.txt copyright changelog
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
@@ -52,7 +52,7 @@ jobs:
       - name: Build AppImage
         run: ./utils/build_appimage.sh
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
@@ -84,7 +84,7 @@ jobs:
       - name: Package Application
         run: 7z a ${{ env.OUTPUT }} .\sounds\ .\images\ .\data\ *.dll license.txt keys.txt icon.png EndlessSky.exe credits.txt copyright changelog
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
@@ -115,7 +115,7 @@ jobs:
           cd build/Release
           7z a ${{ github.workspace }}/${{ env.OUTPUT }} Endless\ Sky.app
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
@@ -168,52 +168,36 @@ jobs:
               --description "$DESCRIPTION" \
               --pre-release
           fi
-      - name: Download ${{ env.OUTPUT_UBUNTU }}
-        uses: actions/download-artifact@v1
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
         with:
-          name: ${{ env.OUTPUT_UBUNTU }}
-          path: ${{ github.workspace }}
+          path: ${{ github.workspace }} # This will download all files to e.g `./EndlessSky-win64.zip/EndlessSky-win64.zip`
       - name: Add ${{ env.OUTPUT_UBUNTU }} to release tag
         run: |
           github-release upload \
             --tag continuous \
             --replace \
             --name ${{ env.OUTPUT_UBUNTU }} \
-            --file ${{ env.OUTPUT_UBUNTU }}
-      - name: Download ${{ env.OUTPUT_APPIMAGE }}
-        uses: actions/download-artifact@v1
-        with:
-          name: ${{ env.OUTPUT_APPIMAGE }}
-          path: ${{ github.workspace }}
+            --file ${{ env.OUTPUT_UBUNTU }}/${{ env.OUTPUT_UBUNTU }}
       - name: Add ${{ env.OUTPUT_APPIMAGE }} to release tag
         run: |
           github-release upload \
             --tag continuous \
             --replace \
             --name ${{ env.OUTPUT_APPIMAGE }} \
-            --file ${{ env.OUTPUT_APPIMAGE }}
-      - name: Download ${{ env.OUTPUT_WINDOWS }}
-        uses: actions/download-artifact@v1
-        with:
-          name: ${{ env.OUTPUT_WINDOWS }}
-          path: ${{ github.workspace }}
+            --file ${{ env.OUTPUT_APPIMAGE }}/${{ env.OUTPUT_APPIMAGE }}
       - name: Add ${{ env.OUTPUT_WINDOWS }} to release tag
         run: |
           github-release upload \
             --tag continuous \
             --replace \
             --name ${{ env.OUTPUT_WINDOWS }} \
-            --file ${{ env.OUTPUT_WINDOWS }}
-      - name: Download ${{ env.OUTPUT_MACOS }}
-        uses: actions/download-artifact@v1
-        with:
-          name: ${{ env.OUTPUT_MACOS }}
-          path: ${{ github.workspace }}
+            --file ${{ env.OUTPUT_WINDOWS }}/${{ env.OUTPUT_WINDOWS }}
       - name: Add ${{ env.OUTPUT_MACOS }} to release tag
         run: |
           github-release upload \
             --tag continuous \
             --replace \
             --name ${{ env.OUTPUT_MACOS }} \
-            --file ${{ env.OUTPUT_MACOS }}
+            --file ${{ env.OUTPUT_MACOS }}/${{ env.OUTPUT_MACOS }}
     

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - actions-update
   pull_request:
     types: 
       - synchronize # New commit has been pushed

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Build AppImage
         run: ./utils/build_appimage.sh
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: Build & Parse
 
 # TODO:
 # - Reduce duplicate code (Blocking: https://github.community/t5/GitHub-Actions/Support-for-YAML-anchors/td-p/30336)
-# - Cache artifact files directly instead of directories (Workaround for https://github.com/actions/upload-artifact/issues/3)
-# - Don't tar the macOS app before uploading (Workaround for https://github.com/actions/upload-artifact/issues/36)
 # - Investigate using scoop as package manager on windows
 # - Cache build files on all systems (Looking at you OSX)
 # - Cache development libraries on windows
@@ -55,13 +53,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Restore cached artifact
       id: cache-artifact
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v2
       with: 
-        path: artifact
-        key: ${{ matrix.os }}-artifacts-${{ hashFiles('.github/workflows/**') }}-${{ hashFiles('source/**') }}-${{ hashFiles('SConstruct') }} # Any of these files will trigger a rebuild
-    - name: Move restored artifact
-      if: steps.cache-artifact.outputs.cache-hit == 'true'
-      run: mv artifact/${{ env.ARTIFACT }} .
+        path: ${{ env.ARTIFACT }}
+        key: ${{ matrix.os }}-artifact-${{ hashFiles('.github/workflows/**') }}-${{ hashFiles('source/**') }}-${{ hashFiles('SConstruct') }} # Any of these files will trigger a rebuild
     - name: Install dependencies
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
@@ -70,7 +65,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons ccache
     - name: Cache ccache
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v2
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ${{ matrix.os }}-ccache-${{ github.repository }}-${{ github.ref }}-${{ github.sha }}
@@ -82,15 +77,10 @@ jobs:
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: scons -j $(nproc);
     - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v2
       with:
         name: binary-${{ matrix.os }} 
         path: ${{ env.ARTIFACT }}
-    - name: Move artifact for caching
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        mkdir artifact
-        mv ${{ env.ARTIFACT }} artifact/
 
 
   build_windows:
@@ -108,13 +98,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Restore cached artifact
       id: cache-artifact
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v2
       with:
-        path: artifact
+        path: ${{ env.ARTIFACT }}
         key: ${{ matrix.os }}-artifacts-${{ hashFiles('.github/workflows/**') }}-${{ hashFiles('source/**') }}-${{ hashFiles('.winmake') }} # Any of these files will trigger a rebuild
-    - name: Move restored artifact
-      if: steps.cache-artifact.outputs.cache-hit == 'true'
-      run: mv artifact/${{ env.ARTIFACT }} .
     - name: Install dependencies
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: choco install sccache
@@ -126,7 +113,7 @@ jobs:
         Remove-Item win64-dev.zip
     - name: Cache sccache
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v2
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: ${{ matrix.os }}-sccache-${{ github.repository }}-${{ github.ref }}-${{ github.sha }}
@@ -144,15 +131,10 @@ jobs:
         COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libstdc++-6.dll .
         COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libwinpthread-1.dll .
     - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v2
       with:
         name: binary-${{ matrix.os }}
         path: ${{ env.ARTIFACT }}
-    - name: Move artifact for caching
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        MD artifact
-        MOVE ${{ env.ARTIFACT }} artifact/
 
 
   build_macos:
@@ -161,18 +143,15 @@ jobs:
       matrix:
         os: [macos-latest]
     env:
-      ARTIFACT: EndlessSky.app.tar
+      ARTIFACT: /tmp/EndlessSky.dst/Applications/
     steps:
     - uses: actions/checkout@v2
     - name: Restore cached artifact
       id: cache-artifact
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v2
       with: 
-        path: artifact
+        path: ${{ env.ARTIFACT }}
         key: ${{ matrix.os }}-artifacts-${{ hashFiles('.github/workflows/**') }}-${{ hashFiles('source/**') }}-${{ hashFiles('EndlessSky.xcodeproj/**') }} # Any of these files will trigger a rebuild
-    - name: Move restored artifact
-      if: steps.cache-artifact.outputs.cache-hit == 'true'
-      run: mv artifact/${{ env.ARTIFACT }} .
     - name: Install dependencies
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
@@ -181,21 +160,11 @@ jobs:
     - name: Compile
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: xcodebuild -configuration "Release" -jobs $(sysctl -n hw.logicalcpu) -quiet install
-    - name: Archive artifact
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd /tmp/EndlessSky.dst/Applications/
-        tar -cf $GITHUB_WORKSPACE/${{ env.ARTIFACT }} "Endless Sky.app"
     - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v2
       with:
         name: app-${{ matrix.os }}
         path: ${{ env.ARTIFACT }}
-    - name: Move artifact for caching
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        mkdir artifact
-        mv ${{ env.ARTIFACT }} artifact/
 
 
   test_ubuntu:
@@ -212,10 +181,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev scons ccache
     - name: Download artifact
-      uses: actions/download-artifact@v1.0.0
+      uses: actions/download-artifact@v2
       with:
         name: binary-${{ matrix.os }}
-        path: .
     - name: Execute test_parse
       run: |
         chmod +x endless-sky
@@ -239,10 +207,9 @@ jobs:
         COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libstdc++-6.dll .
         COPY C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libwinpthread-1.dll .
     - name: Download artifact
-      uses: actions/download-artifact@v1.0.0
+      uses: actions/download-artifact@v2
       with:
         name: binary-${{ matrix.os }}
-        path: .
     - name: Execute test_parse
       run: .\tests\test_parse.ps1 EndlessSky.exe
 
@@ -260,12 +227,9 @@ jobs:
         brew update
         brew install libmad libpng jpeg-turbo sdl2
     - name: Download artifact
-      uses: actions/download-artifact@v1.0.0
+      uses: actions/download-artifact@v2
       with:
         name: app-${{ matrix.os }}
-        path: .
-    - name: Extract artifact
-      run: tar -xf EndlessSky.app.tar
     - name: Execute test_parse
       run: |
         chmod +x "./Endless Sky.app/Contents/MacOS/Endless Sky"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Build & Parse
 # TODO:
 # - Reduce duplicate code (Blocking: https://github.community/t5/GitHub-Actions/Support-for-YAML-anchors/td-p/30336)
 # - Investigate using scoop as package manager on windows
+# - MacOS artifact uploads are still slow (https://github.com/actions/upload-artifact/issues/69)
 # - Cache build files on all systems (Looking at you OSX)
 # - Cache development libraries on windows
 # - Run windows builds as matrix with different mingw versions

--- a/.github/workflows/xcode_check.yml
+++ b/.github/workflows/xcode_check.yml
@@ -31,7 +31,7 @@ jobs:
         ./tests/check_xcode.sh
     - name: Upload XCode patch
       if: failure()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: xcode-project.patch
         path: xcode-project.patch


### PR DESCRIPTION
**Chore:** This PR bumps the versions of the actions used in the CD/CD.

## Details
- upload-artifact v2
	- Removed some `path: .` that are default anyways
	- Bite the bullet and upload all 3k MacOS files without `tar`ing the beforehand. MacOS is already slow as hell, so 3m more won't matter much. Refs https://github.com/actions/upload-artifact/issues/69
- download-artifact v2
	- Can download *all* artifacts, which we use in `cd.yml`
- cache v2
	- Can now cache single files, no more moving around artifacts in `ci.yml`

## Testing Done
All changed parts of the workflows ran at least once, see
https://github.com/MCOfficer/endless-sky/actions
https://github.com/MCOfficer/endless-sky/releases/tag/test-actions-update
https://github.com/MCOfficer/endless-sky/releases/tag/continuous

## Save File
N/A

