### PR TITLE
Add 'not attributes "station"' to "Deep Mystery Cube [3]" 

### DIFF
--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -172,6 +172,7 @@ mission "Deep Mystery Cube [3]"
 	destination
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
+		not attributes "station"
 	on accept
 		dialog phrase "deep mystery cube pickup"
 	on visit


### PR DESCRIPTION
**Bugfix** 

## Fix Details
Adds 'not attributes "station"' to "Deep Mystery Cube [3]", just like all the other DMC non-station jobs.
