### PR TITLE
Remnant: Dialog explaining "buy to cargo" in Remnant: Key Stones

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -614,22 +614,21 @@ mission "Remnant: Key Stones"
 					decline
 			
 			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
-			`	"We look forward to receiving this shipment" he sings. "Just so we are clear, however: You do not need to install them on your ship - delivering them in your cargo hold will work just fine."`
+			`	"We look forward to receiving this shipment" he sings. "Just so we are clear, however: you do not need to install them on your ship - delivering them in your cargo hold will work just fine."`
 			choice
 				`	"I can purchase outfits into my cargo bay?"`
 				`	"Why would you even need to specify that?"`
 					goto whymention
-				`	"OK"`
-					goto noquestion
+				`	"Okay."`
+					accept
 			`	"Of course. There are several different methods available for doing so." He switches to a chant as he begins listing methods.`
 			`	"Firstly, our outfitter interface has a small toggle labeled 'in-cargo' that - when checked - will instruct the dockworkers to load any outfits you purchase into your cargo bay instead of installing it.`
 			`	"Secondly, if you do not have any ships selected in the outfitter control panel when you make a purchase, our logistics system will assign it for delivery to your cargo hold instead of scheduling an installation.`
 			`	"Lastly, if you have an outfit installed, just tap the 'U' key on the outfitter to request that the selected outfit be uninstalled. After removal they will be left in your cargo hold."`
-			`	He glances at his commlink and starts tapping at something. "We look forward to your return." He trills, before striding away still looking at his display.`
-				goto noquestion
+			`	He glances at his commlink and starts tapping at something. "We look forward to your return," he trills, before striding away still looking at his display.`
+				accept
 			label whymention
 			`	"What seems straightforward to you and I is not always so simple for others. I have met more than a few pilots who thought that outfits could only be transported installed on their hull." He smiles briefly at the thought before turning and heading away.`
-			label noquestion
 				accept
 	
 	on visit

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -489,7 +489,7 @@ conversation "remnant key stones"
 	`	"Secondly, if you do not have any ships selected in the outfitter control panel when you make a purchase, our logistics system will assign it for delivery to your cargo hold instead of scheduling an installation.`
 	`	"Lastly, if you have an outfit installed, just tap the 'U' key on the outfitter to request that the selected outfit be uninstalled. After removal they will be left in your cargo hold."`
 	`	He glances at his commlink and starts tapping at something. "We look forward to your return," he trills, before striding away still looking at his display.`
-		goto noquestion
+		accept
 	label whymention
 	`	"What seems straightforward to you and I is not always so simple for others. I have met more than a few pilots who thought that outfits could only be transported installed on their hull." He smiles briefly at the thought before turning and heading away.`
 		accept

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -488,7 +488,7 @@ conversation "remnant key stones"
 	`	"Firstly, our outfitter interface has a small toggle labeled 'in-cargo' that - when checked - will instruct the dockworkers to load any outfits you purchase into your cargo bay instead of installing it.`
 	`	"Secondly, if you do not have any ships selected in the outfitter control panel when you make a purchase, our logistics system will assign it for delivery to your cargo hold instead of scheduling an installation.`
 	`	"Lastly, if you have an outfit installed, just tap the 'U' key on the outfitter to request that the selected outfit be uninstalled. After removal they will be left in your cargo hold."`
-	`	He glances at his commlink and starts tapping at something. "We look forward to your return." He trills, before striding away still looking at his display.`
+	`	He glances at his commlink and starts tapping at something. "We look forward to your return," he trills, before striding away still looking at his display.`
 		goto noquestion
 	label whymention
 	`	"What seems straightforward to you and I is not always so simple for others. I have met more than a few pilots who thought that outfits could only be transported installed on their hull." He smiles briefly at the thought before turning and heading away.`

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -492,7 +492,6 @@ conversation "remnant key stones"
 		goto noquestion
 	label whymention
 	`	"What seems straightforward to you and I is not always so simple for others. I have met more than a few pilots who thought that outfits could only be transported installed on their hull." He smiles briefly at the thought before turning and heading away.`
-	label noquestion
 		accept
 
 

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -482,7 +482,7 @@ conversation "remnant key stones"
 		`	"I can purchase outfits into my cargo bay?"`
 		`	"Why would you even need to specify that?"`
 			goto whymention
-		`	"OK"`
+		`	"Okay."`
 			accept
 	`	"Of course. There are several different methods available for doing so." He switches to a chant as he begins listing methods.`
 	`	"Firstly, our outfitter interface has a small toggle labeled 'in-cargo' that - when checked - will instruct the dockworkers to load any outfits you purchase into your cargo bay instead of installing it.`

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -477,7 +477,7 @@ conversation "remnant key stones"
 			decline
 	
 	`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
-	`	"We look forward to receiving this shipment" he sings. "Just so we are clear, however: You do not need to install them on your ship - delivering them in your cargo hold will work just fine."`
+	`	"We look forward to receiving this shipment" he sings. "Just so we are clear, however: you do not need to install them on your ship - delivering them in your cargo hold will work just fine."`
 	choice
 		`	"I can purchase outfits into my cargo bay?"`
 		`	"Why would you even need to specify that?"`

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -483,7 +483,7 @@ conversation "remnant key stones"
 		`	"Why would you even need to specify that?"`
 			goto whymention
 		`	"OK"`
-			goto noquestion
+			accept
 	`	"Of course. There are several different methods available for doing so." He switches to a chant as he begins listing methods.`
 	`	"Firstly, our outfitter interface has a small toggle labeled 'in-cargo' that - when checked - will instruct the dockworkers to load any outfits you purchase into your cargo bay instead of installing it.`
 	`	"Secondly, if you do not have any ships selected in the outfitter control panel when you make a purchase, our logistics system will assign it for delivery to your cargo hold instead of scheduling an installation.`

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -477,6 +477,22 @@ conversation "remnant key stones"
 			decline
 	
 	`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
+	`	"We look forward to receiving this shipment" he sings. "Just so we are clear, however: You do not need to install them on your ship - delivering them in your cargo hold will work just fine."`
+	choice
+		`	"I can purchase outfits into my cargo bay?"`
+		`	"Why would you even need to specify that?"`
+			goto whymention
+		`	"OK"`
+			goto noquestion
+	`	"Of course. There are several different methods available for doing so." He switches to a chant as he begins listing methods.`
+	`	"Firstly, our outfitter interface has a small toggle labeled 'in-cargo' that - when checked - will instruct the dockworkers to load any outfits you purchase into your cargo bay instead of installing it.`
+	`	"Secondly, if you do not have any ships selected in the outfitter control panel when you make a purchase, our logistics system will assign it for delivery to your cargo hold instead of scheduling an installation.`
+	`	"Lastly, if you have an outfit installed, just tap the 'U' key on the outfitter to request that the selected outfit be uninstalled. After removal they will be left in your cargo hold."`
+	`	He glances at his commlink and starts tapping at something. "We look forward to your return." He trills, before striding away still looking at his display.`
+		goto noquestion
+	label whymention
+	`	"What seems straightforward to you and I is not always so simple for others. I have met more than a few pilots who thought that outfits could only be transported installed on their hull." He smiles briefly at the thought before turning and heading away.`
+	label noquestion
 		accept
 
 
@@ -599,6 +615,22 @@ mission "Remnant: Key Stones"
 					decline
 			
 			`	After a bit of haggling, he agrees to pay you six million credits in exchange for a cargo of fifty Hai "Keystones." Given how cheap they are to purchase in Hai space, you will be earning a very tidy profit on the deal.`
+			`	"We look forward to receiving this shipment" he sings. "Just so we are clear, however: You do not need to install them on your ship - delivering them in your cargo hold will work just fine."`
+			choice
+				`	"I can purchase outfits into my cargo bay?"`
+				`	"Why would you even need to specify that?"`
+					goto whymention
+				`	"OK"`
+					goto noquestion
+			`	"Of course. There are several different methods available for doing so." He switches to a chant as he begins listing methods.`
+			`	"Firstly, our outfitter interface has a small toggle labeled 'in-cargo' that - when checked - will instruct the dockworkers to load any outfits you purchase into your cargo bay instead of installing it.`
+			`	"Secondly, if you do not have any ships selected in the outfitter control panel when you make a purchase, our logistics system will assign it for delivery to your cargo hold instead of scheduling an installation.`
+			`	"Lastly, if you have an outfit installed, just tap the 'U' key on the outfitter to request that the selected outfit be uninstalled. After removal they will be left in your cargo hold."`
+			`	He glances at his commlink and starts tapping at something. "We look forward to your return." He trills, before striding away still looking at his display.`
+				goto noquestion
+			label whymention
+			`	"What seems straightforward to you and I is not always so simple for others. I have met more than a few pilots who thought that outfits could only be transported installed on their hull." He smiles briefly at the thought before turning and heading away.`
+			label noquestion
 				accept
 	
 	on visit


### PR DESCRIPTION
**Content (Missions dialog addition)**

## Summary
Depending on playthrough style, the Remnant: Key Stones mission may well be the first mission requiring the player to buy large amounts of an outfit for a delivery. As such, it is entirely possible that the player doesn't know that they can buy outfits into the outfitter instead of having to install them. This provides a dialogue opportunity for the player to ask for and get an explanation of how to do so in an in-character manner.

## Details
This PR adds text to the `Remnant: Key Stones` mission wherein the remnant giving the mission reminds <first> that they can just deliver the keystones in their cargo hold and don't need to install them on their hull, which then gives the player a choice.
1) Ask for an explanation, where the Remnant explains the three ways of getting an outfit into the cargo hold.
2) Ask why they would feel the need to mention that, wherein the outfitter comments about having met pilots in the past who don't know about it.
3) Just accept the statement, as they already know about that.

## Save File
This save file can be used to play through the new mission content (player starts in a Falcon with several Falcon escorts just outside the Ember Waste Threshold wormhole, ready to explore the Ember Waste. No Remnant missions have been completed at this point):
[RemTest~Ember Waste Brink.txt](https://github.com/endless-sky/endless-sky/files/4798877/RemTest.Ember.Waste.Brink.txt)


## PR Checklist
 - ~~[X] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
 - ~~[X] I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}~~
 - ~~[X] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~
  
