### PR TITLE
Remove Navy License from the Auxiliary to bring it in line with other large navy vessels

### DIFF
--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -412,7 +412,7 @@ outfit "Navy License"
 outfit "Navy Auxiliary License"
 	category "Special"
 	thumbnail "outfit/auxiliary license"
-	description "It is a particularly rare occurence for a Navy Auxiliary, of any kind, to be owned for private use."
+	description "It is a particularly rare occurrence for a Navy Auxiliary, of any kind, to be owned for private use."
 
 outfit "Navy Cruiser License"
 	category "Special"

--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -69,6 +69,7 @@ shipyard "Navy Advanced"
 	"Frigate"
 	"Cruiser"
 	"Carrier"
+	"Auxiliary"
 
 shipyard "Megaparsec Basics"
 	"Quicksilver"

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -190,7 +190,6 @@ ship "Auxiliary"
 	attributes
 		category "Transport"
 		licenses
-			Navy
 			Navy Auxiliary
 		"cost" 13720000
 		"shields" 17100

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -190,7 +190,7 @@ ship "Auxiliary"
 	attributes
 		category "Transport"
 		licenses
-			Navy Auxiliary
+			"Navy Auxiliary"
 		"cost" 13720000
 		"shields" 17100
 		"hull" 5900


### PR DESCRIPTION
Navy ships that have their own specialised license don't have a Navy License requirement, but the Auxiliary does.