### PR TITLE
fix: Typo in events.txt (@ ESSC)

### DIFF
--- a/data/human/events.txt
+++ b/data/human/events.txt
@@ -1615,7 +1615,7 @@ event "fw armistice"
 		fleet "Small Republic" 2000
 		fleet "Large Republic" 3000
 		fleet "Navy Surveillance" 1600
-	system "Kaus Broealis"
+	system "Kaus Borealis"
 		remove fleet "Republic Logistics"
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses a typo spotted on discord
![image](https://user-images.githubusercontent.com/22377202/85983845-800b5900-b9e8-11ea-932a-73db8b7e0cbf.png)

Related:
#5108 (introduced it)
#5136, #5137 (Other fixes)