### PR TITLE
Parrot and Author governments no longer give fines.

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -18,6 +18,7 @@ government "Alpha"
 government "Author"
 	"player reputation" 1
 	"bribe" 0
+	fine 0
 
 government "Builder"
 	# While when you attack the drones they will try to defend themselves, when you come back 
@@ -373,6 +374,7 @@ government "Parrot"
 	swizzle 2
 	"player reputation" 1
 	"bribe" 0
+	fine 0
 
 government "Pirate"
 	swizzle 6


### PR DESCRIPTION
## Fix Details
The "Parrot" and "Author" governments could give fines.  "Cap'n Pester" often shows up and scans the user.  Normally this is fine, but if the player has any outfits with the "atrocity" property set, then suddenly they're being attacked by a Quarg Wardragon that just sorta shows up out of nowhere.  That's a bit much even for such a terrible outfit.

This just makes the author vehicles not shoot players for being terrible people.

## Testing Done
Very small change.  The game still starts and nothing else is different.

## Save File
Nothing in the default content uses the "atrocity" property, so a save game testing it is not possible without a plugin.
