### PR TITLE
Fixed pathing through undefined systems.

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -553,8 +553,12 @@ void GameData::Change(const DataNode &node)
 // that a change creates or moves a system.
 void GameData::UpdateNeighbors()
 {
-	for(auto &it : systems)
+	for(auto &it : systems) {
+		// Skip systems that have no name.
+		if(it.first.empty() || it.second.Name().empty())
+			continue;
 		it.second.UpdateNeighbors(systems);
+	}
 }
 
 

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -553,7 +553,8 @@ void GameData::Change(const DataNode &node)
 // that a change creates or moves a system.
 void GameData::UpdateNeighbors()
 {
-	for(auto &it : systems) {
+	for(auto &it : systems)
+	{
 		// Skip systems that have no name.
 		if(it.first.empty() || it.second.Name().empty())
 			continue;

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -333,7 +333,8 @@ void System::UpdateNeighbors(const Set<System> &systems)
 	
 	// Any other star system that is within the neighbor distance is also a
 	// neighbor. This will include any nearby linked systems.
-	for(const auto &it : systems) {
+	for(const auto &it : systems)
+	{
 		// Skip systems that have no name.
 		if(it.first.empty() || it.second.Name().empty())
 			continue;

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -333,9 +333,14 @@ void System::UpdateNeighbors(const Set<System> &systems)
 	
 	// Any other star system that is within the neighbor distance is also a
 	// neighbor. This will include any nearby linked systems.
-	for(const auto &it : systems)
+	for(const auto &it : systems) {
+		// Skip systems that have no name.
+		if(it.first.empty() || it.second.Name().empty())
+			continue;
+
 		if(&it.second != this && it.second.Position().Distance(position) <= NEIGHBOR_DISTANCE)
 			neighbors.insert(&it.second);
+	}
 	
 	// Calculate the solar power and solar wind.
 	solarPower = 0.;


### PR DESCRIPTION
## Fix Details
The pathfinder could still choose to path through a system that has not
yet been defined (for example, when it is created by a mission).  The
rest of the game ignores these systems with similar checks to these.

## Testing Done
I played a fair bit of the game with these fixes applied.  Testing that it actually fixes the bug was achieved by playing with PR 4871 applied, which triggers it.  The bug causes a hidden system at 0,0 (near Kor Men) to be pathable, but not visible.  This just takes it out of the pathfinder as well.

## Save File
Bug only occurs with plugins or PR 4871 applied.