### PR TITLE
Add heliarch patrols that watch armed players

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -109,6 +109,8 @@ mission "Heliarch Watchers"
 		not "Heliarch Watchers: active"
 	to fail
 		"armament deterrence" == 0
+	to complete
+		never
 	npc
 		personality heroic opportunistic
 		government "Heliarch"

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -98,8 +98,22 @@ event "label coalition space"
 	galaxy "label arachi"
 		sprite "label/arachi"
 
-
-
+mission "Heliarch Watchers"
+	repeat
+	landing
+	invisible
+	source
+		government "Coalition"
+	to offer
+		"armament deterrence" > 0
+		not "Heliarch Watchers: active"
+	to fail
+		"armament deterrence" == 0
+	npc
+		personality heroic opportunistic
+		government "Heliarch"
+		fleet "Heliarch" 2
+	
 mission "Coalition: Contributor"
 	landing
 	name "Return to the <planet>"


### PR DESCRIPTION
## Summary
The Heliarchs state that they do not trust civilians with weapons, but currently they do not act on this when a player carries weapons.
This PR adds Heliarch patrols that follow and monitor the activity of any player travelling around Coalition space with weapons.
This was briefly discussed on the discord server, so I have opened this PR to allow further discussion.