### PR TITLE
Fix: Restores Tinker's tribute after Pug War

### DIFF
--- a/data/human/events.txt
+++ b/data/human/events.txt
@@ -2142,6 +2142,7 @@ event "pug territory liberated"
 	"tribute: Furnace" *= 1200
 	"tribute: Reunion" *= 2900
 	"tribute: Kraken Station" *= 500
+	"tribute: Tinker" *= 1100
 	system Deneb
 		government Neutral
 		fleet "Small Core Merchants" 400


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5149 

## Fix Details
In the event "pug territory liberated", Tinker's tribute is not restored - unlike all the other planets and stations in the affected territories.

Thanks to Pete-2004 for spotting this bug.

