### PR TITLE
feat: Move swizzling into shader

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -302,7 +302,7 @@ void GameData::CheckReferences()
 
 
 
-void GameData::LoadShaders()
+void GameData::LoadShaders(bool useShaderSwizzle)
 {
 	FontSet::Add(Files::Images() + "font/ubuntu14r.png", 14);
 	FontSet::Add(Files::Images() + "font/ubuntu18r.png", 18);
@@ -317,7 +317,7 @@ void GameData::LoadShaders()
 	OutlineShader::Init();
 	PointerShader::Init();
 	RingShader::Init();
-	SpriteShader::Init();
+	SpriteShader::Init(useShaderSwizzle);
 	BatchShader::Init();
 	
 	background.Init(16384, 4096);

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -64,7 +64,7 @@ public:
 	static bool BeginLoad(const char * const *argv);
 	// Check for objects that are referred to but never defined.
 	static void CheckReferences();
-	static void LoadShaders();
+	static void LoadShaders(bool useShaderSwizzle);
 	// TODO: make Progress() a simple accessor.
 	static double Progress();
 	// Whether initial game loading is complete (sprites and audio are loaded).

--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -82,7 +82,7 @@ void SpriteShader::Init(bool useShaderSwizzle)
 		"uniform float frame;\n"
 		"uniform float frameCount;\n"
 		"uniform vec2 blur;\n";
-	if (useShaderSwizzle) fragmentCodeStream <<
+	if(useShaderSwizzle) fragmentCodeStream <<
 		"uniform int swizzler;\n";
 	fragmentCodeStream <<
 		"uniform float alpha;\n"
@@ -124,7 +124,8 @@ void SpriteShader::Init(bool useShaderSwizzle)
 		"  }\n";
 	
 	// Only included when hardware swizzle not supported, GL <3.3 and GLES
-	if (useShaderSwizzle) {
+	if(useShaderSwizzle)
+	{
 		fragmentCodeStream <<
 		"  switch (swizzler) {\n"
 		"    case 0:\n"
@@ -172,7 +173,7 @@ void SpriteShader::Init(bool useShaderSwizzle)
 	blurI = shader.Uniform("blur");
 	clipI = shader.Uniform("clip");
 	alphaI = shader.Uniform("alpha");
-	if (useShaderSwizzle)
+	if(useShaderSwizzle)
 		swizzlerI = shader.Uniform("swizzler");
 	
 	glUseProgram(shader.Object());
@@ -258,7 +259,7 @@ void SpriteShader::Add(const Item &item, bool withBlur)
 	// Bounds check for the swizzle value:
 	int swizzle = (static_cast<size_t>(item.swizzle) >= SWIZZLE.size() ? 0 : item.swizzle);
 	// Set the color swizzle.
-	if (SpriteShader::useShaderSwizzle)
+	if(SpriteShader::useShaderSwizzle)
 		glUniform1i(swizzlerI, swizzle);
 	else
 		glTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_SWIZZLE_RGBA, SWIZZLE[swizzle].data());
@@ -274,7 +275,7 @@ void SpriteShader::Unbind()
 	glUseProgram(0);
 	
 	// Reset the swizzle.
-	if (SpriteShader::useShaderSwizzle)
+	if(SpriteShader::useShaderSwizzle)
 		glUniform1i(swizzlerI, 0);
 	else
 		glTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_SWIZZLE_RGBA, SWIZZLE[0].data());

--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Sprite.h"
 
 #include <vector>
+#include <sstream>
 
 using namespace std;
 
@@ -31,6 +32,7 @@ namespace {
 	GLint blurI;
 	GLint clipI;
 	GLint alphaI;
+	GLint swizzlerI;
 	
 	GLuint vao;
 	GLuint vbo;
@@ -48,11 +50,13 @@ namespace {
 	};
 }
 
-
+bool SpriteShader::useShaderSwizzle = false;
 
 // Initialize the shaders.
-void SpriteShader::Init()
+void SpriteShader::Init(bool useShaderSwizzle)
 {
+	SpriteShader::useShaderSwizzle = useShaderSwizzle;
+	
 	static const char *vertexCode =
 		"// vertex sprite shader\n"
 		"uniform vec2 scale;\n"
@@ -71,12 +75,16 @@ void SpriteShader::Init()
 		"  fragTexCoord = vec2(texCoord.x, max(clip, texCoord.y)) + blurOff;\n"
 		"}\n";
 	
-	static const char *fragmentCode =
+	ostringstream fragmentCodeStream;
+	fragmentCodeStream <<
 		"// fragment sprite shader\n"
 		"uniform sampler2DArray tex;\n"
 		"uniform float frame;\n"
 		"uniform float frameCount;\n"
-		"uniform vec2 blur;\n"
+		"uniform vec2 blur;\n";
+	if (useShaderSwizzle) fragmentCodeStream <<
+		"uniform int swizzler;\n";
+	fragmentCodeStream <<
 		"uniform float alpha;\n"
 		"const int range = 5;\n"
 		
@@ -113,9 +121,47 @@ void SpriteShader::Init()
 		"      else\n"
 		"        color += scale * texture(tex, vec3(coord, first));\n"
 		"    }\n"
-		"  }\n"
+		"  }\n";
+	
+	// Only included when hardware swizzle not supported, GL <3.3 and GLES
+	if (useShaderSwizzle) {
+		fragmentCodeStream <<
+		"  switch (swizzler) {\n"
+		"    case 0:\n"
+		"      color = color.rgba;\n"
+		"      break;\n"
+		"    case 1:\n"
+		"      color = color.rbga;\n"
+		"      break;\n"
+		"    case 2:\n"
+		"      color = color.grba;\n"
+		"      break;\n"
+		"    case 3:\n"
+		"      color = color.brga;\n"
+		"      break;\n"
+		"    case 4:\n"
+		"      color = color.gbra;\n"
+		"      break;\n"
+		"    case 5:\n"
+		"      color = color.bgra;\n"
+		"      break;\n"
+		"    case 6:\n"
+		"      color = color.gbba;\n"
+		"      break;\n"
+		"    case 7:\n"
+		"      color = vec4(color.b, 0.f, 0.f, color.a);\n"
+		"      break;\n"
+		"    case 8:\n"
+		"      color = vec4(0.f, 0.f, 0.f, color.a);\n"
+		"      break;\n"
+		"  }\n";
+	}
+	fragmentCodeStream <<
 		"  finalColor = color * alpha;\n"
 		"}\n";
+	
+	static const string fragmentCodeString = fragmentCodeStream.str();
+	static const char *fragmentCode = fragmentCodeString.c_str();
 	
 	shader = Shader(vertexCode, fragmentCode);
 	scaleI = shader.Uniform("scale");
@@ -126,6 +172,8 @@ void SpriteShader::Init()
 	blurI = shader.Uniform("blur");
 	clipI = shader.Uniform("clip");
 	alphaI = shader.Uniform("alpha");
+	if (useShaderSwizzle)
+		swizzlerI = shader.Uniform("swizzler");
 	
 	glUseProgram(shader.Object());
 	glUniform1i(shader.Uniform("tex"), 0);
@@ -210,7 +258,10 @@ void SpriteShader::Add(const Item &item, bool withBlur)
 	// Bounds check for the swizzle value:
 	int swizzle = (static_cast<size_t>(item.swizzle) >= SWIZZLE.size() ? 0 : item.swizzle);
 	// Set the color swizzle.
-	glTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_SWIZZLE_RGBA, SWIZZLE[swizzle].data());
+	if (SpriteShader::useShaderSwizzle)
+		glUniform1i(swizzlerI, swizzle);
+	else
+		glTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_SWIZZLE_RGBA, SWIZZLE[swizzle].data());
 	
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
@@ -223,5 +274,8 @@ void SpriteShader::Unbind()
 	glUseProgram(0);
 	
 	// Reset the swizzle.
-	glTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_SWIZZLE_RGBA, SWIZZLE[0].data());
+	if (SpriteShader::useShaderSwizzle)
+		glUniform1i(swizzlerI, 0);
+	else
+		glTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_SWIZZLE_RGBA, SWIZZLE[0].data());
 }

--- a/source/SpriteShader.h
+++ b/source/SpriteShader.h
@@ -51,7 +51,8 @@ public:
 	static void Bind();
 	static void Add(const Item &item, bool withBlur = false);
 	static void Unbind();
-
+	
+	
 private:
 	static bool useShaderSwizzle;
 };

--- a/source/SpriteShader.h
+++ b/source/SpriteShader.h
@@ -43,7 +43,7 @@ public:
 	
 public:
 	// Initialize the shaders.
-	static void Init();
+	static void Init(bool useShaderSwizzle);
 	
 	// Draw a sprite.
 	static void Draw(const Sprite *sprite, const Point &position, float zoom = 1.f, int swizzle = 0, float frame = 0.f);
@@ -51,6 +51,9 @@ public:
 	static void Bind();
 	static void Add(const Item &item, bool withBlur = false);
 	static void Unbind();
+
+private:
+	static bool useShaderSwizzle;
 };
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
 		if(!GameWindow::Init())
 			return 1;
 		
-		GameData::LoadShaders();
+		GameData::LoadShaders(!GameWindow::HasSwizzle());
 		
 		// Show something other than a blank window.
 		GameWindow::Step();
@@ -171,13 +171,6 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 	menuPanels.Push(new MenuPanel(player, gamePanels));
 	if(!conversation.IsEmpty())
 		menuPanels.Push(new ConversationPanel(player, conversation));
-	
-	if(!GameWindow::HasSwizzle())
-		menuPanels.Push(new Dialog(
-			"Note: your computer does not support the \"texture swizzling\" OpenGL feature, "
-			"which Endless Sky uses to draw ships in different colors depending on which "
-			"government they belong to. So, all human ships will be the same color, which "
-			"may be confusing. Consider upgrading your graphics driver (or your OS)."));
 	
 	bool showCursor = true;
 	int cursorTime = 0;


### PR DESCRIPTION
## Summary
Use swizzling in shader instead of extension. This is effectively the same but removes the requirement for extension.

## Testing Done
I forced swizzle to a constant value at compile time and verified the images look the same before and after my change.