### PR TITLE
feat: Use RGBA texures instead of BGRA for better portability

### DIFF
--- a/source/ImageBuffer.cpp
+++ b/source/ImageBuffer.cpp
@@ -316,7 +316,7 @@ namespace {
 		
 		jpeg_finish_decompress(&cinfo);
 		jpeg_destroy_decompress(&cinfo);
-
+		
 		// Expand RGB to RGBA
 		for (unsigned int y = 0; y < cinfo.image_height; y++)
 		{
@@ -329,7 +329,7 @@ namespace {
 				pptr[idx * 4 + 3] = static_cast<unsigned char>(0xFF);
 			}
 		}
-
+		
 		return true;
 	}
 	

--- a/source/ImageBuffer.cpp
+++ b/source/ImageBuffer.cpp
@@ -248,8 +248,6 @@ namespace {
 			png_set_expand_gray_1_2_4_to_8(png);
 		if(colorType == PNG_COLOR_TYPE_GRAY || colorType == PNG_COLOR_TYPE_GRAY_ALPHA)
 			png_set_gray_to_rgb(png);
-		if(colorType & PNG_COLOR_MASK_COLOR)
-			png_set_bgr(png);
 		// Let libpng handle any interlaced image decoding.
 		png_set_interlace_handling(png);
 		png_read_update_info(png, info);
@@ -285,7 +283,7 @@ namespace {
 		
 		jpeg_stdio_src(&cinfo, file);
 		jpeg_read_header(&cinfo, true);
-		cinfo.out_color_space = JCS_EXT_BGRA;
+		cinfo.out_color_space = JCS_RGB;
 		
 		// MAYBE: Reading in lots of images in a 32-bit process gets really hairy using the standard approach due to
 		// contiguous memory layout requirements. Investigate using an iterative loading scheme for large images.
@@ -318,7 +316,20 @@ namespace {
 		
 		jpeg_finish_decompress(&cinfo);
 		jpeg_destroy_decompress(&cinfo);
-		
+
+		// Expand RGB to RGBA
+		for (unsigned int y = 0; y < cinfo.image_height; y++)
+		{
+			auto pptr = reinterpret_cast<uint8_t*>(buffer.Begin(y, frame));
+			for(int idx = width - 1; idx >= 0; --idx)
+			{
+				pptr[idx * 4 + 0] = pptr[idx * 3 + 0];
+				pptr[idx * 4 + 1] = pptr[idx * 3 + 1];
+				pptr[idx * 4 + 2] = pptr[idx * 3 + 2];
+				pptr[idx * 4 + 3] = static_cast<unsigned char>(0xFF);
+			}
+		}
+
 		return true;
 	}
 	

--- a/source/Sprite.cpp
+++ b/source/Sprite.cpp
@@ -71,7 +71,7 @@ void Sprite::AddFrames(ImageBuffer &buffer, bool is2x)
 	// Upload the image data.
 	glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_RGBA8, // target, mipmap level, internal format,
 		buffer.Width(), buffer.Height(), buffer.Frames(), // width, height, depth,
-		0, GL_BGRA, GL_UNSIGNED_BYTE, buffer.Pixels()); // border, input format, data type, data.
+		0, GL_RGBA, GL_UNSIGNED_BYTE, buffer.Pixels()); // border, input format, data type, data.
 	
 	// Unbind the texture.
 	glBindTexture(GL_TEXTURE_2D_ARRAY, 0);

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -261,7 +261,7 @@ void Font::LoadTexture(ImageBuffer &image)
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, image.Width(), image.Height(), 0,
-		GL_BGRA, GL_UNSIGNED_BYTE, image.Pixels());
+		GL_RGBA, GL_UNSIGNED_BYTE, image.Pixels());
 }
 
 


### PR DESCRIPTION
## Summary
Use RGBA texures instead of BGRA for better portability, as only some variants of libjpeg support BGRA, use the more common variant.

## Testing Done
Visually checked if the textures look the same before and after my change