### PR TITLE
feat: Use RGBA tetxures instead of BGRA for better portability

### DIFF
--- a/source/Font.cpp
+++ b/source/Font.cpp
@@ -370,7 +370,7 @@ void Font::LoadTexture(ImageBuffer &image)
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, image.Width(), image.Height(), 0,
-		GL_BGRA, GL_UNSIGNED_BYTE, image.Pixels());
+		GL_RGBA, GL_UNSIGNED_BYTE, image.Pixels());
 }
 
 

--- a/source/Sprite.cpp
+++ b/source/Sprite.cpp
@@ -71,7 +71,7 @@ void Sprite::AddFrames(ImageBuffer &buffer, bool is2x)
 	// Upload the image data.
 	glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_RGBA8, // target, mipmap level, internal format,
 		buffer.Width(), buffer.Height(), buffer.Frames(), // width, height, depth,
-		0, GL_BGRA, GL_UNSIGNED_BYTE, buffer.Pixels()); // border, input format, data type, data.
+		0, GL_RGBA, GL_UNSIGNED_BYTE, buffer.Pixels()); // border, input format, data type, data.
 	
 	// Unbind the texture.
 	glBindTexture(GL_TEXTURE_2D_ARRAY, 0);


### PR DESCRIPTION
This is https://github.com/endless-sky/endless-sky/pull/5153 with whitespace changes removed.

## Summary
Use RGBA texures instead of BGRA for better portability, as only some variants of libjpeg support BGRA, use the more common variant.

## Testing Done
Visually checked if the textures look the same before and after my change