### PR TITLE
Allow mission NPCs to spawn or despawn based off of ConditionSets

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -261,6 +261,9 @@ void Engine::Place()
 	// Add NPCs to the list of ships. Fighters have to be assigned to carriers,
 	// and all but "uninterested" ships should follow the player.
 	shared_ptr<Ship> flagship = player.FlagshipPtr();
+	
+	// Update the active NPCs for missions based on the player's conditions.
+	player.UpdateMissionNPCs();
 	for(const Mission &mission : player.Missions())
 		Place(mission.NPCs(), flagship);
 	
@@ -338,6 +341,11 @@ void Engine::Place(const list<NPC> &npcs, shared_ptr<Ship> flagship)
 {
 	for(const NPC &npc : npcs)
 	{
+		// If this NPC has failed its spawn conditions or passed its despawn
+		// conditions, don't place it.
+		if(!npc.PassedSpawn() || npc.PassedDespawn())
+			continue;
+		
 		map<string, map<Ship *, int>> carriers;
 		for(const shared_ptr<Ship> &ship : npc.Ships())
 		{

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -354,7 +354,8 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			out.Write("stopover", planet->Name(), "visited");
 		
 		for(const NPC &npc : npcs)
-			npc.Save(out);
+			if(npc.PassedSpawn() && !npc.PassedDespawn())
+				npc.Save(out);
 		
 		// Save all the actions, because this might be an "available mission" that
 		// has not been received yet but must still be included in the saved game.
@@ -811,6 +812,9 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	{
 		++player.Conditions()[name + ": offered"];
 		++player.Conditions()[name + ": active"];
+		// Any potential on offer conversation has been finished, so update
+		// the active NPCs for the first time.
+		UpdateNPCs(player);
 	}
 	else if(trigger == DECLINE)
 	{
@@ -851,6 +855,18 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 const list<NPC> &Mission::NPCs() const
 {
 	return npcs;
+}
+
+
+
+// Update which NPCs are active based on their spawn and despawn conditions.
+void Mission::UpdateNPCs(const PlayerInfo &player)
+{
+	for(auto &npc : npcs)
+	{
+		npc.CanSpawn(player);
+		npc.CanDespawn(player);
+	}
 }
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -353,7 +353,9 @@ void Mission::Save(DataWriter &out, const string &tag) const
 		for(const Planet *planet : visitedStopovers)
 			out.Write("stopover", planet->Name(), "visited");
 		
-		// Save all NPCs, except those that have despawned.
+		// Save all NPCs, except those that have despawned. This is so that despawned
+		// NPCs will not reappear should the player quit the game and return, and the
+		// NPCs no lonager pass the despawn conditions.
 		for(const NPC &npc : npcs)
 			if(!npc.PassedDespawn())
 				npc.Save(out);
@@ -864,10 +866,7 @@ const list<NPC> &Mission::NPCs() const
 void Mission::UpdateNPCs(const PlayerInfo &player)
 {
 	for(auto &npc : npcs)
-	{
-		npc.CanSpawn(player);
-		npc.CanDespawn(player);
-	}
+		npc.UpdateSpawning(player);
 }
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -353,8 +353,9 @@ void Mission::Save(DataWriter &out, const string &tag) const
 		for(const Planet *planet : visitedStopovers)
 			out.Write("stopover", planet->Name(), "visited");
 		
+		// Save all NPCs, except those that have despawned.
 		for(const NPC &npc : npcs)
-			if(npc.PassedSpawn() && !npc.PassedDespawn())
+			if(!npc.PassedDespawn())
 				npc.Save(out);
 		
 		// Save all the actions, because this might be an "available mission" that

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -931,6 +931,10 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 		
 		// Perform an "on enter" action for this system, if possible.
 		Enter(system, player, ui);
+		
+		// Update any potential NPCs for this mission, as an "on enter" action may have
+		// changed the player's conditions.
+		UpdateNPCs(player);
 	}
 	
 	for(NPC &npc : npcs)

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -133,6 +133,8 @@ public:
 	// Get a list of NPCs associated with this mission. Every time the player
 	// takes off from a planet, they should be added to the active ships.
 	const std::list<NPC> &NPCs() const;
+	// Update which NPCs are active based on their spawn and despawn conditions.
+	void UpdateNPCs(const PlayerInfo &player);
 	// Checks if the given ship belongs to one of the mission's NPCs.
 	bool HasShip(const std::shared_ptr<Ship> &ship) const;
 	// If any event occurs between two ships, check to see if this mission cares

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -276,14 +276,14 @@ void NPC::Save(DataWriter &out) const
 // Update spawning and despawning for this NPC.
 void NPC::UpdateSpawning(const PlayerInfo &player)
 {
-	// The spawn and despawn conditions are tested every time this function is called
-	// until they pass. This is so that a change in a player's conditions don't cause
-	// an NPC to "un-spawn" or "un-despawn."
+	// The conditions are tested every time this function is called until
+	// they pass. This is so that a change in a player's conditions don't
+	// cause an NPC to "un-spawn" or "un-despawn." Despawn conditions are
+	// only checked after the spawn conditions have passed so that an NPC
+	// doesn't "despawn" before spawning in the first place.
 	if(!passedSpawnConditions)
 		passedSpawnConditions = toSpawn.Test(player.Conditions());
-	
-	// Only test despawn conditions if the spawn conditions have passed.
-	if(passedSpawnConditions && !toDespawn.IsEmpty() && !passedDespawnConditions)
+	else if(!toDespawn.IsEmpty() && !passedDespawnConditions)
 		passedDespawnConditions = toDespawn.Test(player.Conditions());
 }
 

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -126,6 +126,15 @@ void NPC::Load(const DataNode &node)
 			conversation.Load(child);
 		else if(child.Token(0) == "conversation" && child.Size() > 1)
 			stockConversation = GameData::Conversations().Get(child.Token(1));
+		else if(child.Token(0) == "to" && child.Size() >= 2)
+		{
+			if(child.Token(1) == "spawn")
+				toSpawn.Load(child);
+			else if(child.Token(1) == "despawn")
+				toDespawn.Load(child);
+			else
+				child.PrintTrace("Skipping unrecognized attribute:");
+		}
 		else if(child.Token(0) == "ship")
 		{
 			if(child.HasChildren() && child.Size() == 2)
@@ -203,6 +212,25 @@ void NPC::Save(DataWriter &out) const
 		if(mustAccompany)
 			out.Write("accompany");
 		
+		if(!toSpawn.IsEmpty())
+		{
+			out.Write("to", "spawn");
+			out.BeginChild();
+			{
+				toSpawn.Save(out);
+			}
+			out.EndChild();
+		}
+		if(!toDespawn.IsEmpty())
+		{
+			out.Write("to", "despawn");
+			out.BeginChild();
+			{
+				toDespawn.Save(out);
+			}
+			out.EndChild();
+		}
+		
 		if(government)
 			out.Write("government", government->GetTrueName());
 		personality.Save(out);
@@ -237,6 +265,45 @@ void NPC::Save(DataWriter &out) const
 		}
 	}
 	out.EndChild();
+}
+
+
+
+// Update to spawn conditions for if this NPC can be placed.
+void NPC::CanSpawn(const PlayerInfo &player)
+{
+	// Only check the toSpawn conditions the first time this function is called.
+	if(!toSpawn.IsEmpty() && !checkedSpawnConditions)
+	{
+		checkedSpawnConditions = true;
+		passedSpawnConditions = toSpawn.Test(player.Conditions());
+	}
+}
+
+
+
+// Return if spawned conditions have passed, without updating.
+bool NPC::PassedSpawn() const
+{
+	return passedSpawnConditions;
+}
+
+
+
+// Update the to despawn conditions for if this NPC should be removed.
+void NPC::CanDespawn(const PlayerInfo &player)
+{
+	// Check the toDepsawn conditions each time this function is called until they pass.
+	if(!toDespawn.IsEmpty() && !passedDespawnConditions)
+		passedDespawnConditions = toDespawn.Test(player.Conditions());
+}
+
+
+
+// Return if despawned conditions have passed, without updating.
+bool NPC::PassedDespawn() const
+{
+	return passedDespawnConditions;
 }
 
 
@@ -319,6 +386,11 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, bool isVisible)
 
 bool NPC::HasSucceeded(const System *playerSystem) const
 {
+	// If this NPC has been despawned or was never spawned in the first place
+	// then ignore its objectives.
+	if(!passedSpawnConditions || passedDespawnConditions)
+		return true;
+	
 	if(HasFailed())
 		return false;
 	
@@ -386,7 +458,12 @@ bool NPC::IsLeftBehind(const System *playerSystem) const
 
 
 bool NPC::HasFailed() const
-{					
+{
+	// If this NPC has been despawned or was never spawned in the first place
+	// then ignore its objectives.
+	if(!passedSpawnConditions || passedDespawnConditions)
+		return false;
+	
 	for(const auto &it : actions)
 	{
 		if(it.second & failIf)
@@ -416,6 +493,12 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	result.failIf = failIf;
 	result.mustEvade = mustEvade;
 	result.mustAccompany = mustAccompany;
+	
+	result.checkedSpawnConditions = checkedSpawnConditions;
+	result.passedSpawnConditions = passedSpawnConditions;
+	result.passedDespawnConditions = passedDespawnConditions;
+	result.toSpawn = toSpawn;
+	result.toDespawn = toDespawn;
 	
 	// Pick the system for this NPC to start out in.
 	result.system = system;

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -273,12 +273,18 @@ void NPC::Save(DataWriter &out) const
 
 
 
-// Update to spawn conditions for if this NPC can be placed.
-void NPC::CanSpawn(const PlayerInfo &player)
+// Update spawning and despawning for this NPC.
+void NPC::UpdateSpawning(const PlayerInfo &player)
 {
-	// Check the toSpawn conditions each time this function is called until they pass.
+	// The spawn and despawn conditions are tested every time this function is called
+	// until they pass. This is so that a change in a player's conditions don't cause
+	// an NPC to "un-spawn" or "un-despawn."
 	if(!passedSpawnConditions)
 		passedSpawnConditions = toSpawn.Test(player.Conditions());
+	
+	// Only test despawn conditions if the spawn conditions have passed.
+	if(passedSpawnConditions && !toDespawn.IsEmpty() && !passedDespawnConditions)
+		passedDespawnConditions = toDespawn.Test(player.Conditions());
 }
 
 
@@ -287,16 +293,6 @@ void NPC::CanSpawn(const PlayerInfo &player)
 bool NPC::PassedSpawn() const
 {
 	return passedSpawnConditions;
-}
-
-
-
-// Update the to despawn conditions for if this NPC should be removed.
-void NPC::CanDespawn(const PlayerInfo &player)
-{
-	// Check the toDepsawn conditions each time this function is called until they pass.
-	if(!toDespawn.IsEmpty() && !passedDespawnConditions)
-		passedDespawnConditions = toDespawn.Test(player.Conditions());
 }
 
 

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -212,7 +212,11 @@ void NPC::Save(DataWriter &out) const
 		if(mustAccompany)
 			out.Write("accompany");
 		
-		if(!toSpawn.IsEmpty())
+		// Only save out spawn conditions if they have yet to be evaluated.
+		// This is so that if a player quits the game and returns, NPCs that
+		// were spawned do not then become despawned because they no longer
+		// pass the spawn conditions.
+		if(!toSpawn.IsEmpty() && !checkedSpawnConditions)
 		{
 			out.Write("to", "spawn");
 			out.BeginChild();

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -212,11 +212,11 @@ void NPC::Save(DataWriter &out) const
 		if(mustAccompany)
 			out.Write("accompany");
 		
-		// Only save out spawn conditions if they have yet to be evaluated.
+		// Only save out spawn conditions if they have yet to be met.
 		// This is so that if a player quits the game and returns, NPCs that
 		// were spawned do not then become despawned because they no longer
 		// pass the spawn conditions.
-		if(!toSpawn.IsEmpty() && !checkedSpawnConditions)
+		if(!toSpawn.IsEmpty() && !passedSpawnConditions)
 		{
 			out.Write("to", "spawn");
 			out.BeginChild();
@@ -276,12 +276,9 @@ void NPC::Save(DataWriter &out) const
 // Update to spawn conditions for if this NPC can be placed.
 void NPC::CanSpawn(const PlayerInfo &player)
 {
-	// Only check the toSpawn conditions the first time this function is called.
-	if(!toSpawn.IsEmpty() && !checkedSpawnConditions)
-	{
-		checkedSpawnConditions = true;
+	// Check the toSpawn conditions each time this function is called until they pass.
+	if(!passedSpawnConditions)
 		passedSpawnConditions = toSpawn.Test(player.Conditions());
-	}
 }
 
 
@@ -498,7 +495,6 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	result.mustEvade = mustEvade;
 	result.mustAccompany = mustAccompany;
 	
-	result.checkedSpawnConditions = checkedSpawnConditions;
 	result.passedSpawnConditions = passedSpawnConditions;
 	result.passedDespawnConditions = passedDespawnConditions;
 	result.toSpawn = toSpawn;

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -283,7 +283,8 @@ void NPC::UpdateSpawning(const PlayerInfo &player)
 	// doesn't "despawn" before spawning in the first place.
 	if(!passedSpawnConditions)
 		passedSpawnConditions = toSpawn.Test(player.Conditions());
-	else if(!toDespawn.IsEmpty() && !passedDespawnConditions)
+	
+	if(passedSpawnConditions && !toDespawn.IsEmpty() && !passedDespawnConditions)
 		passedDespawnConditions = toDespawn.Test(player.Conditions());
 }
 

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -51,11 +51,9 @@ public:
 	// a template, so fleets will be replaced by individual ships already.
 	void Save(DataWriter &out) const;
 	
-	// Update and check the to spawn conditions for if this NPC can be placed.
-	void CanSpawn(const PlayerInfo &player);
+	// Update or check spawning and despawning for this NPC.
+	void UpdateSpawning(const PlayerInfo &player);
 	bool PassedSpawn() const;
-	// Update and check the to despawn conditions for if this NPC should be removed.
-	void CanDespawn(const PlayerInfo &player);
 	bool PassedDespawn() const;
 	
 	// Get the ships associated with this set of NPCs.

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -51,6 +51,13 @@ public:
 	// a template, so fleets will be replaced by individual ships already.
 	void Save(DataWriter &out) const;
 	
+	// Update and check the to spawn conditions for if this NPC can be placed.
+	void CanSpawn(const PlayerInfo &player);
+	bool PassedSpawn() const;
+	// Update and check the to despawn conditions for if this NPC should be removed.
+	void CanDespawn(const PlayerInfo &player);
+	bool PassedDespawn() const;
+	
 	// Get the ships associated with this set of NPCs.
 	const std::list<std::shared_ptr<Ship>> Ships() const;
 	
@@ -85,6 +92,13 @@ private:
 	
 	Conversation conversation;
 	const Conversation *stockConversation = nullptr;
+	
+	// Conditions that must be met in order for this NPC to be placed or despawned:
+	bool checkedSpawnConditions = false;
+	bool passedSpawnConditions = true;
+	bool passedDespawnConditions = false;
+	ConditionSet toSpawn;
+	ConditionSet toDespawn;
 	
 	// The ships may be listed individually or referred to as a fleet, and may
 	// be customized or just refer to stock objects:

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -94,8 +94,7 @@ private:
 	const Conversation *stockConversation = nullptr;
 	
 	// Conditions that must be met in order for this NPC to be placed or despawned:
-	bool checkedSpawnConditions = false;
-	bool passedSpawnConditions = true;
+	bool passedSpawnConditions = false;
 	bool passedDespawnConditions = false;
 	ConditionSet toSpawn;
 	ConditionSet toDespawn;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1477,6 +1477,15 @@ const Mission *PlayerInfo::ActiveBoardingMission() const
 
 
 
+// Update mission NPCs with the player's current conditions.
+void PlayerInfo::UpdateMissionNPCs()
+{
+	for(Mission &mission : missions)
+		mission.UpdateNPCs(*this);
+}
+
+
+
 // Accept the given job.
 void PlayerInfo::AcceptJob(const Mission &mission, UI *ui)
 {

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1134,6 +1134,7 @@ void PlayerInfo::Land(UI *ui)
 	UpdateAutoConditions();
 	
 	// Update missions that are completed, or should be failed.
+	UpdateMissionNPCs();
 	StepMissions(ui);
 	UpdateCargoCapacities();
 	

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -157,6 +157,7 @@ public:
 	const std::list<Mission> &Missions() const;
 	const std::list<Mission> &AvailableJobs() const;
 	const Mission *ActiveBoardingMission() const;
+	void UpdateMissionNPCs();
 	void AcceptJob(const Mission &mission, UI *ui);
 	// Check to see if there is any mission to offer right now.
 	Mission *MissionToOffer(Mission::Location location);


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #5159. Related to #1564.

## Feature Details
This PR adds the ability to spawn or despawn `npc`s based off of the player's conditions. 
The `to spawn` conditions are first evaluated after the player has accepted the mission, meaning that conditions changed during an `on offer` conversation can trigger whether `npc`s spawn. Should the `to spawn` conditions fail on accept, then they are reevaluated on every landing, departure, and jump until succeeding. If the conditions succeed, the `npc` will spawn on the next departure.
The `to despawn` conditions are evaluated at the same times as the `to spawn` conditions (on accept and after every landing, departure, or jump until succeeding), but only if the `to spawn` conditions have succeeded. (That is, if the NPC hasn't even spawned yet, it won't test its `to despawn` conditions.) If the conditions succeed, the `npc` will despawn on the next landing.

If an `npc` block either isn't spawned or has been despawned, then the objective of the `npc` is ignored. This means that you can create alternative objectives for a mission. E.g. you may have an `npc` that must be directly killed in order to complete the mission, or you may be able to do something that triggers the despawn conditions on the `npc`, therefore ignoring the kill objective and allowing you to complete the mission. (Or you can create additional objectives by having an `npc` with a specific objective spawn in the middle of the mission.)

The syntax for spawn and despawn conditions is as follows:
```
npc
	...
	to spawn
		<conditions>
	to despawn
		<conditions>
	...
```

## UI Screenshots
N/A

## Usage Examples
The following `npc` block would only spawn its ships if you have the "angered warlord" condition, perhaps gained by making a wrong choice during a conversation. Then should the player obtain the "appeased warlord" condition, these pirates will despawn on the next landing.
```
npc kill
	to spawn
		has "angered warlord"
	to despawn
		has "appeased warlord"
	government "Pirate"
	fleet "Large Southern Pirates" 2
```

## Testing Done
<details><summary>Test mission.</summary>

```
mission "NPC Conditions Test"
	repeat
	source "Shiver"
	destination "Earth"
	on offer
		conversation
			`Do you want to spawn an NPC?`
			choice
				`	Yes.`
					goto yes
				`	No.`
			`	Okay, there will be no NPC. If you enter Fomalhaut and land, the NPC should spawn.`
					accept
			
			label yes
			apply
				set "spawn NPCs"
			`	Okay, spawning the NPC. If you enter Vega and land, the NPC should despawn.`
				accept
	
	on enter "Vega"
		set "despawn NPCs"

	on enter "Fomalhaut"
		set "spawn NPCs"
	
	npc kill
		to spawn
			has "spawn NPCs"
		to despawn
			has "despawn NPCs"
		government "Drak"
		ship "Archon" "Shoulders of Giants"
	
	on fail
		clear "spawn NPCs"
		clear "despawn NPCs"
	on complete
		clear "spawn NPCs"
		clear "despawn NPCs"
		dialog "Did it work?"
```
</details>

## Performance Impact
N/A
