### PR TITLE
System attributes for the Ember Waste and select systems

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -2062,7 +2062,7 @@ system Adhara
 system Aescolanus
 	pos -15 340
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "The Ember Waste" "Wormhole"
 	habitable 233.28
 	belt 1323
 	haze _menu/haze-red
@@ -6220,7 +6220,7 @@ system Cardax
 system Cardea
 	pos -89.1297 417.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "The Ember Waste" "Wormhole"
 	habitable 851.84
 	belt 1725
 	haze _menu/haze-red
@@ -6836,7 +6836,7 @@ system Cinxia
 system Coluber
 	pos 149.504 197.389
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "The Ember Waste" "Wormhole"
 	habitable 659.2
 	belt 1590
 	haze _menu/haze-red
@@ -8444,7 +8444,7 @@ system Eblumab
 system Edusa
 	pos 273.87 347.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "The Ember Waste" "Wormhole"
 	habitable 2372.76
 	belt 1167
 	haze _menu/haze-red
@@ -9273,7 +9273,7 @@ system Eshkoshtar
 system Esix
 	pos 142 532
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "The Ember Waste" "The Graveyard" "Wormhole"
 	haze _menu/haze-red
 	habitable 8640
 	link Gerenus
@@ -9944,7 +9944,7 @@ system Fasitopfar
 system Fearis
 	pos -16 643
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "The Ember Waste" "The Graveyard" "Wormhole"
 	haze _menu/haze-red
 	habitable 486.68
 	link Feraticus
@@ -12587,7 +12587,7 @@ system "Imo Dep"
 system Insitor
 	pos -28.1296 400.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "The Ember Waste" "Wormhole"
 	habitable 553.28
 	belt 1170
 	haze _menu/haze-red
@@ -17657,7 +17657,7 @@ system Orvala
 system Ossipago
 	pos 6.87033 429.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "The Ember Waste" "Wormhole"
 	habitable 1948.28
 	belt 1803
 	haze _menu/haze-red
@@ -17723,7 +17723,7 @@ system Ossipago
 system Paeli
 	pos 129 497
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "The Ember Waste" "The Graveyard" "Wormhole"
 	haze _menu/haze-red
 	habitable 425.92
 	link Esix
@@ -19778,7 +19778,7 @@ system Regulus
 system Relifer
 	pos 19 603
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "The Ember Waste" "The Graveyard" "Wormhole"
 	haze _menu/haze-red
 	habitable 625
 	link Feraticus
@@ -19992,7 +19992,7 @@ system Rigel
 system Ritilas
 	pos 11 523
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "The Ember Waste" "The Graveyard" "Wormhole"
 	haze _menu/haze-red
 	habitable 135
 	link Queri
@@ -20892,7 +20892,7 @@ system Schedar
 system Segesta
 	pos 111.87 294.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "The Ember Waste" "Wormhole"
 	habitable 425.92
 	belt 1120
 	haze _menu/haze-red
@@ -22582,7 +22582,7 @@ system "Steep Roof"
 system Stercutus
 	pos 140.87 320.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "The Ember Waste" "Wormhole"
 	habitable 945
 	belt 1492
 	haze _menu/haze-red
@@ -23220,6 +23220,7 @@ system Tejat
 system Terminus
 	pos -727.99 -23.2491
 	government Republic
+	attributes "Wormhole"
 	habitable 425.92
 	belt 1221
 	link Limen
@@ -23542,6 +23543,7 @@ system "Ula Mon"
 system "Ultima Thule"
 	pos -336 -211
 	government Republic
+	attributes "Wormhole"
 	habitable 2560
 	belt 1635
 	link Rajak
@@ -24217,6 +24219,7 @@ system "Wah Yoot"
 system Waypoint
 	pos -184 -515
 	government Hai
+	attributes "Wormhole"
 	habitable 78.125
 	belt 1610
 	link "Heia Due"

--- a/data/map.txt
+++ b/data/map.txt
@@ -9899,6 +9899,7 @@ system Faronektu
 system Fasitopfar
 	pos 92.4305 -105.812
 	government Uninhabited
+	attributes "Archon"
 	habitable 100
 	belt 1670
 	asteroids "small rock" 24 7.722
@@ -13278,6 +13279,7 @@ system Kashikt
 system Kasikfar
 	pos 10.4305 -127.812
 	government Uninhabited
+	attributes "Archon"
 	habitable 100
 	belt 1539
 	asteroids "small rock" 4 3.8019
@@ -17128,7 +17130,7 @@ system Naper
 system Nenia
 	pos -39.1297 467.242
 	government Uninhabited
-	attributes "The Ember Waste" "Void Sprites"
+	attributes "The Ember Waste" "Void Sprites" "Archon"
 	habitable 2340
 	belt 1343
 	haze _menu/haze-red
@@ -18128,6 +18130,7 @@ system Peragenor
 system Peresedersi
 	pos 81.4305 -154.812
 	government Uninhabited
+	attributes "Archon"
 	habitable 100
 	belt 1065
 	asteroids "small rock" 49 1.403
@@ -20711,6 +20714,7 @@ system Sarin
 system Sayaiban
 	pos 250.431 -274.812
 	government Drak
+	attributes "Archon"
 	habitable 2035
 	belt 1803
 	asteroids "small rock" 13 2.106

--- a/data/map.txt
+++ b/data/map.txt
@@ -17130,7 +17130,7 @@ system Naper
 system Nenia
 	pos -39.1297 467.242
 	government Uninhabited
-	attributes "ember waste" "Void Sprites" "archon"
+	attributes "ember waste" "void sprites" "archon"
 	habitable 2340
 	belt 1343
 	haze _menu/haze-red

--- a/data/map.txt
+++ b/data/map.txt
@@ -2062,7 +2062,7 @@ system Adhara
 system Aescolanus
 	pos -15 340
 	government Uninhabited
-	attributes "The Ember Waste" "Wormhole"
+	attributes "ember waste" "wormhole"
 	habitable 233.28
 	belt 1323
 	haze _menu/haze-red
@@ -2103,7 +2103,7 @@ system Aescolanus
 system "Aki'il"
 	pos -83 722
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	habitable 1505.92
 	asteroids "large metal" 47 5
 	asteroids "large rock" 2 10
@@ -4249,7 +4249,7 @@ system Antares
 system Antevorta
 	pos -36.1297 446.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 320
 	belt 1994
 	haze _menu/haze-red
@@ -4430,7 +4430,7 @@ system Arcturus
 system Arculus
 	pos 308.87 393.242
 	government Remnant
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 625
 	belt 1536
 	haze _menu/haze-red
@@ -5913,7 +5913,7 @@ system "Broken Bowl"
 system Caeculus
 	pos 162.87 343.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 320
 	belt 1797
 	haze _menu/haze-red
@@ -6220,7 +6220,7 @@ system Cardax
 system Cardea
 	pos -89.1297 417.242
 	government Uninhabited
-	attributes "The Ember Waste" "Wormhole"
+	attributes "ember waste" "wormhole"
 	habitable 851.84
 	belt 1725
 	haze _menu/haze-red
@@ -6782,7 +6782,7 @@ system Chy'chra
 system Cinxia
 	pos 265.87 415.242
 	government Remnant
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 425.92
 	belt 1713
 	haze _menu/haze-red
@@ -6836,7 +6836,7 @@ system Cinxia
 system Coluber
 	pos 149.504 197.389
 	government Uninhabited
-	attributes "The Ember Waste" "Wormhole"
+	attributes "ember waste" "wormhole"
 	habitable 659.2
 	belt 1590
 	haze _menu/haze-red
@@ -6953,7 +6953,7 @@ system Companion
 system Convector
 	pos -14.1297 379.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 4131.68
 	belt 1961
 	haze _menu/haze-red
@@ -7447,7 +7447,7 @@ system Debrugt
 system Delia
 	pos -41 757
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	habitable 486.68
 	link Dixere
@@ -7883,7 +7883,7 @@ system Diphda
 system Dixere
 	pos 33 708
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	habitable 851.84
 	link Delia
@@ -8444,7 +8444,7 @@ system Eblumab
 system Edusa
 	pos 273.87 347.242
 	government Uninhabited
-	attributes "The Ember Waste" "Wormhole"
+	attributes "ember waste" "wormhole"
 	habitable 2372.76
 	belt 1167
 	haze _menu/haze-red
@@ -9273,7 +9273,7 @@ system Eshkoshtar
 system Esix
 	pos 142 532
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard" "Wormhole"
+	attributes "ember waste" "graveyard" "wormhole"
 	haze _menu/haze-red
 	habitable 8640
 	link Gerenus
@@ -9762,7 +9762,7 @@ system Farbutero
 system Farinus
 	pos 202.87 440.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 745.92
 	belt 1149
 	haze _menu/haze-red
@@ -9899,7 +9899,7 @@ system Faronektu
 system Fasitopfar
 	pos 92.4305 -105.812
 	government Uninhabited
-	attributes "Archon"
+	attributes "archon"
 	habitable 100
 	belt 1670
 	asteroids "small rock" 24 7.722
@@ -9944,7 +9944,7 @@ system Fasitopfar
 system Fearis
 	pos -16 643
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard" "Wormhole"
+	attributes "ember waste" "graveyard" "wormhole"
 	haze _menu/haze-red
 	habitable 486.68
 	link Feraticus
@@ -10080,7 +10080,7 @@ system "Fell Omen"
 system Feraticus
 	pos 58 630
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	habitable 320
 	link Dixere
@@ -10142,7 +10142,7 @@ system Feraticus
 system Fereti
 	pos -39 600
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	habitable 486.68
 	link Lire
@@ -10888,7 +10888,7 @@ system "Gamma Corvi"
 system Gerenus
 	pos 197 514
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	habitable 9065.92
 	link Esix
@@ -11008,7 +11008,7 @@ system Gienah
 system Giribea
 	pos -6 674
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	habitable 1705
 	link Delia
@@ -12587,7 +12587,7 @@ system "Imo Dep"
 system Insitor
 	pos -28.1296 400.242
 	government Uninhabited
-	attributes "The Ember Waste" "Wormhole"
+	attributes "ember waste" "wormhole"
 	habitable 553.28
 	belt 1170
 	haze _menu/haze-red
@@ -13279,7 +13279,7 @@ system Kashikt
 system Kasikfar
 	pos 10.4305 -127.812
 	government Uninhabited
-	attributes "Archon"
+	attributes "archon"
 	habitable 100
 	belt 1539
 	asteroids "small rock" 4 3.8019
@@ -14676,7 +14676,7 @@ system Lesath
 system Levana
 	pos 203.504 247.389
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 2798.68
 	belt 1202
 	haze _menu/haze-red
@@ -14795,7 +14795,7 @@ system Limen
 system Lire
 	pos -59 676
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	habitable 1080
 	link Fearis
@@ -15044,7 +15044,7 @@ system "Lone Cloud"
 system Lucina
 	pos 175.504 176.389
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 320
 	belt 1466
 	haze _menu/haze-red
@@ -17130,7 +17130,7 @@ system Naper
 system Nenia
 	pos -39.1297 467.242
 	government Uninhabited
-	attributes "The Ember Waste" "Void Sprites" "Archon"
+	attributes "ember waste" "Void Sprites" "archon"
 	habitable 2340
 	belt 1343
 	haze _menu/haze-red
@@ -17345,7 +17345,7 @@ system Nocte
 system Nona
 	pos 166 558
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	habitable 1080
 	link Esix
@@ -17657,7 +17657,7 @@ system Orvala
 system Ossipago
 	pos 6.87033 429.242
 	government Uninhabited
-	attributes "The Ember Waste" "Wormhole"
+	attributes "ember waste" "wormhole"
 	habitable 1948.28
 	belt 1803
 	haze _menu/haze-red
@@ -17723,7 +17723,7 @@ system Ossipago
 system Paeli
 	pos 129 497
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard" "Wormhole"
+	attributes "ember waste" "graveyard" "wormhole"
 	haze _menu/haze-red
 	habitable 425.92
 	link Esix
@@ -17788,7 +17788,7 @@ system Paeli
 system Pantica
 	pos 303.87 445.242
 	government Remnant
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 486.68
 	belt 1203
 	haze _menu/haze-red
@@ -17843,7 +17843,7 @@ system Pantica
 system Parca
 	pos 150.504 151.389
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 760
 	belt 1315
 	haze _menu/haze-red
@@ -18068,7 +18068,7 @@ system Pelubta
 system Peragenor
 	pos 86.8703 356.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 1080
 	belt 1920
 	haze _menu/haze-red
@@ -18130,7 +18130,7 @@ system Peragenor
 system Peresedersi
 	pos 81.4305 -154.812
 	government Uninhabited
-	attributes "Archon"
+	attributes "archon"
 	habitable 100
 	belt 1065
 	asteroids "small rock" 49 1.403
@@ -18172,7 +18172,7 @@ system Peresedersi
 system Perfica
 	pos 185.87 419.242
 	government Uninhabited
-	attributes "The Ember Waste"
+	attributes "ember waste"
 	habitable 1080
 	belt 1160
 	haze _menu/haze-red
@@ -18724,7 +18724,7 @@ system Polaris
 system Polerius
 	pos 88 482
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	habitable 1505.92
 	link Paeli
@@ -19387,7 +19387,7 @@ system Quaru
 system Queri
 	pos 69 518
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard"
+	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	habitable 135
 	link Esix
@@ -19778,7 +19778,7 @@ system Regulus
 system Relifer
 	pos 19 603
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard" "Wormhole"
+	attributes "ember waste" "graveyard" "wormhole"
 	haze _menu/haze-red
 	habitable 625
 	link Feraticus
@@ -19992,7 +19992,7 @@ system Rigel
 system Ritilas
 	pos 11 523
 	government Uninhabited
-	attributes "The Ember Waste" "The Graveyard" "Wormhole"
+	attributes "ember waste" "graveyard" "wormhole"
 	haze _menu/haze-red
 	habitable 135
 	link Queri
@@ -20714,7 +20714,7 @@ system Sarin
 system Sayaiban
 	pos 250.431 -274.812
 	government Drak
-	attributes "Archon"
+	attributes "archon"
 	habitable 2035
 	belt 1803
 	asteroids "small rock" 13 2.106
@@ -20892,7 +20892,7 @@ system Schedar
 system Segesta
 	pos 111.87 294.242
 	government Uninhabited
-	attributes "The Ember Waste" "Wormhole"
+	attributes "ember waste" "wormhole"
 	habitable 425.92
 	belt 1120
 	haze _menu/haze-red
@@ -22582,7 +22582,7 @@ system "Steep Roof"
 system Stercutus
 	pos 140.87 320.242
 	government Uninhabited
-	attributes "The Ember Waste" "Wormhole"
+	attributes "ember waste" "wormhole"
 	habitable 945
 	belt 1492
 	haze _menu/haze-red
@@ -23220,7 +23220,7 @@ system Tejat
 system Terminus
 	pos -727.99 -23.2491
 	government Republic
-	attributes "Wormhole"
+	attributes "wormhole"
 	habitable 425.92
 	belt 1221
 	link Limen
@@ -23543,7 +23543,7 @@ system "Ula Mon"
 system "Ultima Thule"
 	pos -336 -211
 	government Republic
-	attributes "Wormhole"
+	attributes "wormhole"
 	habitable 2560
 	belt 1635
 	link Rajak
@@ -24219,7 +24219,7 @@ system "Wah Yoot"
 system Waypoint
 	pos -184 -515
 	government Hai
-	attributes "Wormhole"
+	attributes "wormhole"
 	habitable 78.125
 	belt 1610
 	link "Heia Due"

--- a/data/map.txt
+++ b/data/map.txt
@@ -2062,6 +2062,7 @@ system Adhara
 system Aescolanus
 	pos -15 340
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 233.28
 	belt 1323
 	haze _menu/haze-red
@@ -2102,6 +2103,7 @@ system Aescolanus
 system "Aki'il"
 	pos -83 722
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	habitable 1505.92
 	asteroids "large metal" 47 5
 	asteroids "large rock" 2 10
@@ -4247,6 +4249,7 @@ system Antares
 system Antevorta
 	pos -36.1297 446.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 320
 	belt 1994
 	haze _menu/haze-red
@@ -4427,6 +4430,7 @@ system Arcturus
 system Arculus
 	pos 308.87 393.242
 	government Remnant
+	attributes "The Ember Waste"
 	habitable 625
 	belt 1536
 	haze _menu/haze-red
@@ -5909,6 +5913,7 @@ system "Broken Bowl"
 system Caeculus
 	pos 162.87 343.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 320
 	belt 1797
 	haze _menu/haze-red
@@ -6215,6 +6220,7 @@ system Cardax
 system Cardea
 	pos -89.1297 417.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 851.84
 	belt 1725
 	haze _menu/haze-red
@@ -6776,6 +6782,7 @@ system Chy'chra
 system Cinxia
 	pos 265.87 415.242
 	government Remnant
+	attributes "The Ember Waste"
 	habitable 425.92
 	belt 1713
 	haze _menu/haze-red
@@ -6829,6 +6836,7 @@ system Cinxia
 system Coluber
 	pos 149.504 197.389
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 659.2
 	belt 1590
 	haze _menu/haze-red
@@ -6945,6 +6953,7 @@ system Companion
 system Convector
 	pos -14.1297 379.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 4131.68
 	belt 1961
 	haze _menu/haze-red
@@ -7438,6 +7447,7 @@ system Debrugt
 system Delia
 	pos -41 757
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 486.68
 	link Dixere
@@ -7873,6 +7883,7 @@ system Diphda
 system Dixere
 	pos 33 708
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 851.84
 	link Delia
@@ -8433,6 +8444,7 @@ system Eblumab
 system Edusa
 	pos 273.87 347.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 2372.76
 	belt 1167
 	haze _menu/haze-red
@@ -9261,6 +9273,7 @@ system Eshkoshtar
 system Esix
 	pos 142 532
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 8640
 	link Gerenus
@@ -9749,6 +9762,7 @@ system Farbutero
 system Farinus
 	pos 202.87 440.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 745.92
 	belt 1149
 	haze _menu/haze-red
@@ -9929,6 +9943,7 @@ system Fasitopfar
 system Fearis
 	pos -16 643
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 486.68
 	link Feraticus
@@ -10064,6 +10079,7 @@ system "Fell Omen"
 system Feraticus
 	pos 58 630
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 320
 	link Dixere
@@ -10125,6 +10141,7 @@ system Feraticus
 system Fereti
 	pos -39 600
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 486.68
 	link Lire
@@ -10870,6 +10887,7 @@ system "Gamma Corvi"
 system Gerenus
 	pos 197 514
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 9065.92
 	link Esix
@@ -10989,6 +11007,7 @@ system Gienah
 system Giribea
 	pos -6 674
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 1705
 	link Delia
@@ -12567,6 +12586,7 @@ system "Imo Dep"
 system Insitor
 	pos -28.1296 400.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 553.28
 	belt 1170
 	haze _menu/haze-red
@@ -14654,6 +14674,7 @@ system Lesath
 system Levana
 	pos 203.504 247.389
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 2798.68
 	belt 1202
 	haze _menu/haze-red
@@ -14772,6 +14793,7 @@ system Limen
 system Lire
 	pos -59 676
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 1080
 	link Fearis
@@ -15020,6 +15042,7 @@ system "Lone Cloud"
 system Lucina
 	pos 175.504 176.389
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 320
 	belt 1466
 	haze _menu/haze-red
@@ -17105,6 +17128,7 @@ system Naper
 system Nenia
 	pos -39.1297 467.242
 	government Uninhabited
+	attributes "The Ember Waste" "Void Sprites"
 	habitable 2340
 	belt 1343
 	haze _menu/haze-red
@@ -17319,6 +17343,7 @@ system Nocte
 system Nona
 	pos 166 558
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 1080
 	link Esix
@@ -17630,6 +17655,7 @@ system Orvala
 system Ossipago
 	pos 6.87033 429.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 1948.28
 	belt 1803
 	haze _menu/haze-red
@@ -17695,6 +17721,7 @@ system Ossipago
 system Paeli
 	pos 129 497
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 425.92
 	link Esix
@@ -17759,6 +17786,7 @@ system Paeli
 system Pantica
 	pos 303.87 445.242
 	government Remnant
+	attributes "The Ember Waste"
 	habitable 486.68
 	belt 1203
 	haze _menu/haze-red
@@ -17813,6 +17841,7 @@ system Pantica
 system Parca
 	pos 150.504 151.389
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 760
 	belt 1315
 	haze _menu/haze-red
@@ -18037,6 +18066,7 @@ system Pelubta
 system Peragenor
 	pos 86.8703 356.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 1080
 	belt 1920
 	haze _menu/haze-red
@@ -18139,6 +18169,7 @@ system Peresedersi
 system Perfica
 	pos 185.87 419.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 1080
 	belt 1160
 	haze _menu/haze-red
@@ -18690,6 +18721,7 @@ system Polaris
 system Polerius
 	pos 88 482
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 1505.92
 	link Paeli
@@ -19352,6 +19384,7 @@ system Quaru
 system Queri
 	pos 69 518
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 135
 	link Esix
@@ -19742,6 +19775,7 @@ system Regulus
 system Relifer
 	pos 19 603
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 625
 	link Feraticus
@@ -19955,6 +19989,7 @@ system Rigel
 system Ritilas
 	pos 11 523
 	government Uninhabited
+	attributes "The Ember Waste" "The Graveyard"
 	haze _menu/haze-red
 	habitable 135
 	link Queri
@@ -20853,6 +20888,7 @@ system Schedar
 system Segesta
 	pos 111.87 294.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 425.92
 	belt 1120
 	haze _menu/haze-red
@@ -22542,6 +22578,7 @@ system "Steep Roof"
 system Stercutus
 	pos 140.87 320.242
 	government Uninhabited
+	attributes "The Ember Waste"
 	habitable 945
 	belt 1492
 	haze _menu/haze-red


### PR DESCRIPTION
**Content (Map Data)**

## Summary
This PR adds attributes to a variety of systems in order to label a few key features, as per the specification included in the [MapData ](https://github.com/endless-sky/endless-sky/wiki/MapData) wiki page. 

## Details
The attributes that it adds are:
- "ember waste" (applied to all systems in the Ember Waste)
- "graveyard" (applied to all systems in the Graveyard)
- "void sprites" (applied to Nenia)
- "archon" (applied to all systems that have resident Archons.)
- "wormhole" (applied to all systems that have wormholes)

## Reason
I am planning a variety of generic jobs for the Remnant because, well, they don't really have anything other than the Korath Bounties. In order to target these jobs properly, they need to be able to have identifiers that allow the game to randomly pick from sets. For instance, picking a random system that has a wormhole. Or a random system in the Ember Waste, etc. 

## Importance
I would just like to note that a number of small upcoming mission sets that give the player some alternative repeating opportunities (that is to say, jobs) depend directly on this PR. And by "small mission sets," I mean "1 mission to introduce the idea, and then 1-3 different repeatable jobs based around the idea" sorts of things. As such, I would like to see it merged for 0.9.13, and consider it a higher priority for merging as it simply provides foundational data for other missions and jobs to be built on.

## Future development possibilities (not intended for this PR)
- Adding an attribute tag that specifies its region to all systems.
- Adding a region item to the system properties. (this would be tidier than using an attribute, but would require an engine change)

