### PR TITLE
Add a supernova system closer to FW/Coalition

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -20648,6 +20648,34 @@ system Salipastart
 			distance 291
 			period 21.2086
 
+system Saquergen
+	pos -482 561
+	government Uninhabited
+	habitable 100
+	belt 1435
+	asteroids "small rock" 3 3.9105
+	asteroids "medium rock" 1 4.3255
+	asteroids "small metal" 2 6.7143
+	minables gold 2 3.04353
+	minables yottrite 4 4.69542
+	trade Clothing 243
+	trade Electronics 599
+	trade Equipment 513
+	trade Food 511
+	trade "Heavy Metals" 1254
+	trade Industrial 623
+	trade "Luxury Goods" 933
+	trade Medical 452
+	trade Metal 276
+	trade Plastic 328
+	object
+		sprite star/nova
+		period 1000
+	object
+		sprite planet/lava2
+		distance 938.342
+		period 531.634
+
 system Sargas
 	pos -542 445
 	government Republic


### PR DESCRIPTION
as suggested by Derpy here https://github.com/endless-sky/endless-sky/pull/4896#issuecomment-661946450
, this adds a supernova system closer to Coalition space. Though as he suggested one only accessible via Coalition space would be ideal to get players to trigger the recently added Coalition Yottrite missions, if it was so easily accessible there wouldn't be a need for you to bring them any since the Heliarchs could just mine a few asteroids with a Jump Drive-equipped Punisher and have all the material they'd need, without needing to go through territory that isn't theirs and then back.

system is positioned just under Shaula, a bit to the left, and can only be jumped to from Shaula and the neighboring FW systems, a bit too far away for one to jump there from the closest Coalition system.