### PR TITLE
Allow the "fancy" sobel filters in ShopPanels to be replaced with "fast" sprite images

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -57,6 +57,7 @@ void Preferences::Load()
 	settings["Draw starfield"] = true;
 	settings["Hide unexplored map regions"] = true;
 	settings["Turrets focus fire"] = true;
+	settings["Ship outlines in shops"] = true;
 	
 	DataFile prefs(Files::Config() + "preferences.txt");
 	for(const DataNode &node : prefs)

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -52,6 +52,7 @@ namespace {
 	const string REACTIVATE_HELP = "Reactivate first-time help";
 	const string SCROLL_SPEED = "Scroll speed";
 	const string FIGHTER_REPAIR = "Repair fighters in";
+	const string SHIP_OUTLINES = "Ship outlines in shops";
 }
 
 
@@ -440,6 +441,7 @@ void PreferencesPanel::DrawSettings()
 		"Draw background haze",
 		"Draw starfield",
 		"Show hyperspace flash",
+		SHIP_OUTLINES,
 		"",
 		"Other",
 		"Clickable radar display",
@@ -501,6 +503,11 @@ void PreferencesPanel::DrawSettings()
 		{
 			isOn = true;
 			text = Preferences::Has(FIGHTER_REPAIR) ? "parallel" : "series";
+		}
+		else if(setting == SHIP_OUTLINES)
+		{
+			isOn = true;
+			text = Preferences::Has(SHIP_OUTLINES) ? "fancy" : "fast";
 		}
 		else if(setting == REACTIVATE_HELP)
 		{

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -41,6 +41,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
+	const string SHIP_OUTLINES = "Ship outlines in shops";
+	
 	constexpr int ICON_TILE = 62;
 	constexpr int ICON_COLS = 4;
 	constexpr float ICON_SIZE = ICON_TILE - 8;
@@ -132,11 +134,19 @@ void ShopPanel::Draw()
 	
 	if(dragShip && dragShip->GetSprite())
 	{
-		static const Color selected(.8f, 1.f);
 		const Sprite *sprite = dragShip->GetSprite();
 		float scale = ICON_SIZE / max(sprite->Width(), sprite->Height());
-		Point size(sprite->Width() * scale, sprite->Height() * scale);
-		OutlineShader::Draw(sprite, dragPoint, size, selected);
+		if(Preferences::Has(SHIP_OUTLINES))
+		{
+			static const Color selected(.8f, 1.f);
+			Point size(sprite->Width() * scale, sprite->Height() * scale);
+			OutlineShader::Draw(sprite, dragPoint, size, selected);
+		}
+		else
+		{
+			int swizzle = dragShip->CustomSwizzle() >= 0 ? dragShip->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
+			SpriteShader::Draw(sprite, dragPoint, scale, swizzle);
+		}
 	}
 
 	if(sameSelectedTopY)
@@ -221,8 +231,16 @@ void ShopPanel::DrawSidebar()
 		if(sprite)
 		{
 			float scale = ICON_SIZE / max(sprite->Width(), sprite->Height());
-			Point size(sprite->Width() * scale, sprite->Height() * scale);
-			OutlineShader::Draw(sprite, point, size, isSelected ? selected : unselected);
+			if(Preferences::Has(SHIP_OUTLINES))
+			{
+				Point size(sprite->Width() * scale, sprite->Height() * scale);
+				OutlineShader::Draw(sprite, point, size, isSelected ? selected : unselected);
+			}
+			else
+			{
+				int swizzle = ship->CustomSwizzle() >= 0 ? ship->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
+				SpriteShader::Draw(sprite, point, scale, swizzle);
+			}
 		}
 		
 		zones.emplace_back(point, Point(ICON_TILE, ICON_TILE), ship.get());


### PR DESCRIPTION
**Feature:** This PR implements a feature to fix the issue #2442.

## Feature Details
Adds a new preference that toggles the behavior of the ship outlines in the ShopPanel. When set to "fancy," the game renders the sobel filters of the ship sprites, as it does now. When set to "fast," the game instead uses the top-down sprite of the ship instead of applying the shader to it.

NOTE: This preference ONLY affects the ShopPanel. The sobel filter shader is still used for the flight UI, the main menu, and for the ShipInfoPanel. In each of these cases you only have one or two ships that need the shader rendered, and therefore I saw the need to change these cases unnecessary, as the issue was with a large number of ships rendering this shader at once, which is only found in the ShopPanel.

## UI Screenshots
The location of this setting in preferences.
![image](https://user-images.githubusercontent.com/17688683/88495659-96291c80-cf88-11ea-88ed-a780f4af853c.png)

A side-by-side of the two settings, fancy on the left and fast on the right.
![unknown](https://user-images.githubusercontent.com/17688683/88495751-e607e380-cf88-11ea-9b54-97eaa97f1183.png)


## Usage Examples
N/A

## Testing Done
Tested that the preferences itself properly toggles the outlines in the ShopPanel.
Tested that the preference saves when the game is closed.
Tested GPU usage with 50 Shuttles on fast vs fancy.
* On the main landing screen (our control): ~19% GPU usage
* In the shipyard (fancy): ~50% GPU usage
* In the shipyard (fast): ~19% GPU usage (basically the same as the control)

## Performance Impact
Given that this is allowing for a less GPU intensive option, switching to the "fast" outlines option should improve performance in ShopPanels for those with large fleets.
