### PR TITLE
Change the Militia license to be more in line with the other Human licenses

### DIFF
--- a/data/human/free worlds intro.txt
+++ b/data/human/free worlds intro.txt
@@ -1917,7 +1917,8 @@ mission "Defend Sabik"
 			
 			label paint
 			`	You take the paintbrush, climb on top of your ship, and begin painting it in the green and gold of the Free Worlds. Suddenly you hear a cheer from one of the other ships parked nearby; someone has seen what you are doing and is shouting, "For freedom! Another ship for freedom!" Soon several other people see you, and before long it seems like everyone in the port has picked up the cheer.`
-			`	Tomek stands by, silently, until you finish, and then approaches you, holding out a license. He says, "Thanks, Captain. I'm sure your assistance will be invaluable to our cause," as you accept the Militia license. After a brief silence, he continues. "Now let's hit the bar. I need a drink."`
+			`	Tomek stands by, silently, until you finish, and then approaches you with an outstretched arm holding onto a license. "Here. You're going to need this.`
+			`	"I'm sure your assistance will be invaluable to our cause," he says as you accept the militia license. After a brief silence, he continues. "Now let's hit the bar. I need a drink."`
 			`	An hour later you are in the bar celebrating your new employment when emergency sirens start blaring. Someone runs into the bar and says, "The Navy has entered the system. What do we do?"`
 			`	Tomek says, "We can't let them take this system, or they'll have us completely bottled up. This is where it begins. We need to fight. Get to your ships, quickly! But if you can, disable their ships instead of destroying them. These are Navy ships after all, and most of them don't want war any more than we do." You hurry to join all the other ships taking off to defend the system.`
 				launch

--- a/data/human/free worlds intro.txt
+++ b/data/human/free worlds intro.txt
@@ -1917,7 +1917,7 @@ mission "Defend Sabik"
 			
 			label paint
 			`	You take the paintbrush, climb on top of your ship, and begin painting it in the green and gold of the Free Worlds. Suddenly you hear a cheer from one of the other ships parked nearby; someone has seen what you are doing and is shouting, "For freedom! Another ship for freedom!" Soon several other people see you, and before long it seems like everyone in the port has picked up the cheer.`
-			`	Tomek stands by, silently, until you finish, and then says, "Let's hit the bar. I need a drink."`
+			`	Tomek stands by, silently, until you finish, and then approaches you, holding out a license. He says, "Thanks, Captain. I'm sure your assistance will be invaluable to our cause," as you accept the Militia license. After a brief silence, he continues. "Now let's hit the bar. I need a drink."`
 			`	An hour later you are in the bar celebrating your new employment when emergency sirens start blaring. Someone runs into the bar and says, "The Navy has entered the system. What do we do?"`
 			`	Tomek says, "We can't let them take this system, or they'll have us completely bottled up. This is where it begins. We need to fight. Get to your ships, quickly! But if you can, disable their ships instead of destroying them. These are Navy ships after all, and most of them don't want war any more than we do." You hurry to join all the other ships taking off to defend the system.`
 				launch

--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -427,7 +427,7 @@ outfit "Navy Carrier License"
 outfit "Militia License"
 	category "Special"
 	thumbnail "outfit/militia license"
-	description "This is the standard issue license for all pilots that have enlisted to the Free Worlds. It allows said pilots to fly the colors of the Free Worlds and fight for it, and purchase certain ships."
+	description "This is the standard issue license for all pilots that have enlisted in a local militia, but with the formation of the Free Worlds it has also become a license given to all those that fight for the Free Worlds cause, allowing pilots to fly the colors of the Free Worlds and purchase unique ships that the fledgling government has developed."
 
 outfit "City-Ship License"
 	category "Special"

--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -427,7 +427,7 @@ outfit "Navy Carrier License"
 outfit "Militia License"
 	category "Special"
 	thumbnail "outfit/militia license"
-	description "Officially joined the Free Worlds. Received permission to purchase their Militia-only ships."
+	description "This is the standard issue license for all pilots that have enlisted to the Free Worlds. It allows said pilots to fly the colors of the Free Worlds and fight for it, and purchase certain ships."
 
 outfit "City-Ship License"
 	category "Special"


### PR DESCRIPTION
Right now, the Militia license's description sticks out like a sore thumb amongst the other human licenses, reading more like a logbook entry. This PR changes it to be more in line with the other human licenses, and also adds a small part where you receive the license, like in the Deep missions.