### PR TITLE
Remove portrait images from spaceport news

### DIFF
--- a/data/hai/hai news.txt
+++ b/data/hai/hai news.txt
@@ -9,7 +9,6 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-# Visual suggestion: a bit quirky or weird; expression is content, confident, or stoic
 news "food in Hai space"
 	location
 		government "Hai"
@@ -19,11 +18,6 @@ news "food in Hai space"
 			"Food connoisseur"
 			"Tourist"
 			"Tour guide"
-	portrait
-		portrait/human26
-		portrait/human31
-		portrait/human57
-		portrait/human68
 	message
 		word
 			"This may sound odd, but the acorn cookies they sell here are the best cookies I've ever eaten."
@@ -34,31 +28,12 @@ news "food in Hai space"
 			"Back home, my favorite snack was pickled walnuts. Here, the pickled acorns are amazing!"
 
 
-# Visual suggestion: glasses, clean-cut attire, possibly scientific accoutrements
 news "trading in Hai space"
 	location
 		government "Hai"
 	name
 		word
 			"Merchant captain"
-	portrait
-		portrait/human02
-		portrait/human04
-		portrait/human06
-		portrait/human10
-		portrait/human15
-		portrait/human17
-		portrait/human31
-		portrait/human58
-		portrait/human63
-		portrait/human72
-		portrait/human73
-		portrait/human76
-		portrait/human79
-		portrait/human98
-		portrait/human108
-		portrait/human112
-		portrait/human125
 	message
 		word
 			"Hai Tech is incredible compared to ours. Every time I add a ship to my fleet, I always make a trip up here to stock up on Hai tech."
@@ -71,7 +46,6 @@ news "trading in Hai space"
 			"Some Hai were protesting the work week. They want to work only 32 hours a week instead of 40. I used to work 70 hours a week for the Syndicate!"
 
 
-# Visual suggestion: glasses, clean-cut attire, possibly scientific accoutrements
 news "science in Hai space"
 	location
 		government "Hai"
@@ -79,13 +53,6 @@ news "science in Hai space"
 		word
 			"Scientist"
 			"Engineer"
-	portrait
-		portrait/human13
-		portrait/human37
-		portrait/human43
-		portrait/human64
-		portrait/human71
-		portrait/human83
 	message
 		word
 			"A while back, my Hai research partner was nearing a breakthrough, and then she vanished. I wonder where she went?"
@@ -97,27 +64,12 @@ news "science in Hai space"
 			"The Hai have an amazing grasp of quantum chromodynamics. It's why their shield generators are so effective."
 			"The alloys Hai use in their ships are way beyond our technology. They're twice as strong with half the weight. No wonder their ships are so fast."
 
-# Visual suggestion: young, normal-looking, more female than male
-# or people with animals
 news "cute story in Hai space"
 	location
 		government "Hai"
 	name
 		word
 			"Tourist"
-	portrait
-		portrait/human00
-		portrait/human01
-		portrait/human11
-		portrait/human18
-		portrait/human35
-		portrait/human55
-		portrait/human66
-		portrait/human69
-		portrait/human107
-		portrait/human114
-		portrait/human123
-		portrait/human128
 	message
 		word
 			"My little daughter loved her stuffed bear back in human space, but now she wants to hug every Hai she sees instead."
@@ -126,31 +78,12 @@ news "cute story in Hai space"
 			"I saw a Hai wearing the cutest bonnet the other day. When I get back to human space, I'm definitely getting a pet squirrel."
 			"Do you see that Hai woman carrying her baby? Doesn't it look like a long-tailed teddy-bear? The Hai are so cute."
 
-# Visual suggestion: a bit quirky or weird; expression is content, confident, or stoic
 news "concerned merchant in Hai space"
 	location
 		government "Hai"
 	name
 		word
 			"Merchant captain"
-	portrait
-		portrait/human02
-		portrait/human04
-		portrait/human06
-		portrait/human10
-		portrait/human15
-		portrait/human17
-		portrait/human31
-		portrait/human58
-		portrait/human63
-		portrait/human72
-		portrait/human73
-		portrait/human76
-		portrait/human79
-		portrait/human98
-		portrait/human108
-		portrait/human112
-		portrait/human125
 	message
 		word
 			"Don't go too far north up here. The Hai have their own pirates, and they're much more powerful than anything we're used to in human space."
@@ -161,31 +94,12 @@ news "concerned merchant in Hai space"
 			"I hope nobody is smuggling Hai technology out of here. I don't want to think about what would happen if the pirates got their hands on this stuff."
 			"The Hai will pay you to rush cargo to human space and back. Don't die trying."
 
-# Visual suggestion: a bit quirky or weird; expression is content, confident, or stoic
 news "human citizen in Hai space"
 	location
 		government "Hai"
 	name
 		word
 			"Human citizen"
-	portrait
-		portrait/human02
-		portrait/human04
-		portrait/human06
-		portrait/human10
-		portrait/human15
-		portrait/human17
-		portrait/human31
-		portrait/human58
-		portrait/human63
-		portrait/human72
-		portrait/human73
-		portrait/human76
-		portrait/human79
-		portrait/human98
-		portrait/human108
-		portrait/human112
-		portrait/human125
 	message
 		word
 			"Don't go too far north up here. The Hai have their own pirates, and they're much more powerful than anything we're used to in human space."
@@ -195,34 +109,12 @@ news "human citizen in Hai space"
 			"Hai scientists that live near me chartered a flight to Allhome, but it got lost and ended up all the way on Canyon. Some people have the worst sense of direction."
 
 
-# Visual suggestions: scruffy and disgruntled; religious and relaxed; sharply-dressed and clean-shaven
 news "reformed pirate in Hai space"
 	location
 		government "Hai"
 	name
 		word
 			"Reformed pirate"
-	portrait
-		portrait/human01
-		portrait/human09
-		portrait/human23
-		portrait/human24
-		portrait/human32
-		portrait/human34
-		portrait/human41
-		portrait/human45
-		portrait/human51
-		portrait/human54
-		portrait/human57
-		portrait/human67
-		portrait/human77
-		portrait/human80
-		portrait/human92
-		portrait/human95
-		portrait/human115
-		portrait/human121
-		portrait/human124
-		portrait/human126
 	message
 		word
 			"I used to rob people for a living, and I'd be in jail now if I stayed in human space. Here, they've given me a job, and I've been sober for six weeks. This has really turned my life around."

--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -17,22 +17,6 @@ news "human merchant anywhere"
 	name
 		word
 			"Merchant captain"
-	portrait
-		portrait/human02
-		portrait/human04
-		portrait/human06
-		portrait/human10
-		portrait/human15
-		portrait/human17
-		portrait/human31
-		portrait/human58
-		portrait/human63
-		portrait/human72
-		portrait/human73
-		portrait/human76
-		portrait/human79
-		portrait/human98
-		portrait/human112
 	message
 		word
 			"Can you believe how little they pay for used ships and outfits these days? It's just a scandal!"
@@ -53,24 +37,6 @@ news "human merchant in human space"
 	name
 		word
 			"Merchant captain"
-	portrait
-		portrait/human02
-		portrait/human04
-		portrait/human06
-		portrait/human10
-		portrait/human15
-		portrait/human17
-		portrait/human31
-		portrait/human58
-		portrait/human63
-		portrait/human72
-		portrait/human73
-		portrait/human76
-		portrait/human79
-		portrait/human98
-		portrait/human108
-		portrait/human112
-		portrait/human125
 	message
 		word
 			"Pirate attacks keep getting more and more frequent, even in star systems that used to be perfectly safe. Why isn't the Navy doing something about it?"
@@ -96,23 +62,6 @@ news "human farming"
 	name
 		word
 			"Farmer"
-	portrait
-		portrait/human03
-		portrait/human05
-		portrait/human08
-		portrait/human09
-		portrait/human20
-		portrait/human21
-		portrait/human22
-		portrait/human52
-		portrait/human53
-		portrait/human78
-		portrait/human113
-		portrait/human116
-		portrait/human119
-		portrait/human120
-		portrait/human121
-		portrait/human126
 	message
 		word
 			"My neighbor is using some sort of newfangled pesticides. The wind carried their residue onto my fields and destroyed half my crops."
@@ -140,18 +89,6 @@ news "human textiles"
 	name
 		word
 			"Textile worker"
-	portrait
-		portrait/human00
-		portrait/human01
-		portrait/human11
-		portrait/human18
-		portrait/human35
-		portrait/human55
-		portrait/human66
-		portrait/human69
-		portrait/human114
-		portrait/human123
-		portrait/human128
 	message
 		word
 			"Two days ago I ran over my finger with an industrial sewing machine. Put a hole straight through my thumb. But at least they paid my medical bill and gave me a week of sick leave."
@@ -171,20 +108,6 @@ news "human mining"
 	name
 		word
 			"Miner"
-	portrait
-		portrait/human07
-		portrait/human36
-		portrait/human41
-		portrait/human42
-		portrait/human50
-		portrait/human54
-		portrait/human60
-		portrait/human70
-		portrait/human77
-		portrait/human82
-		portrait/human102
-		portrait/human115
-		portrait/human117
 	message
 		word
 			"Mining's the best opportunity on this whole planet, but I worry about my health. I've started to cough up blood when I get sick. It's a good thing the company pays for our medical bills."
@@ -202,13 +125,6 @@ news "human factory"
 	name
 		word
 			"Factory worker"
-	portrait
-		portrait/human23
-		portrait/human75
-		portrait/human92
-		portrait/human94
-		portrait/human97
-		portrait/human111
 	message
 		word
 			"Everybody I know wound up working in the plant, so I guess I was gonna go, too. It was inevitable or something, right?"
@@ -229,11 +145,6 @@ news "street vendor"
 		word
 			"Street vendor"
 			"Food stall operator"
-	portrait
-		portrait/human26
-		portrait/human31
-		portrait/human57
-		portrait/human68
 	message
 		word
 			"With the right marinade, rat meat can be delicious. Of course, they don't let us sell the ones that were already dead when we collected them."
@@ -248,12 +159,6 @@ news "company psychologist"
 	name
 		word
 			"Company psychologist"
-	portrait
-		portrait/human12
-		portrait/human28
-		portrait/human47
-		portrait/human93
-		portrait/human103
 	message
 		word
 			"Studies have shown that ultimate fulfillment in life comes from doing valuable work. My calling is to help all our workers achieve that sort of self-actualization by being as productive as possible."
@@ -271,11 +176,6 @@ news "genetic counselor"
 		word
 			"Genetic counselor"
 			"Personal geneticist"
-	portrait
-		portrait/human43
-		portrait/human71
-		portrait/human72
-		portrait/human90
 	message
 		word
 			"Of course the technology to manipulate genes is tightly controlled. But just reading a person's genome, and advising them based on the results, is perfectly legal."
@@ -292,12 +192,6 @@ news "unemployed youth"
 	name
 		word
 			"Unemployed youth"
-	portrait
-		portrait/human27
-		portrait/human34
-		portrait/human39
-		portrait/human98
-		portrait/human109
 	message
 		word
 			"I may be living on the street, but at least I haven't let myself get trapped in debt slavery like the workers on Syndicate worlds."
@@ -312,11 +206,6 @@ news "union organizer"
 	name
 		word
 			"Union organizer"
-	portrait
-		portrait/human08
-		portrait/human33
-		portrait/human38
-		portrait/human56
 	message
 		word
 			"Capitalism is the best system ever invented for driving a productive economy. But without organized labor, the fruits of that productivity will not be shared with the workers."
@@ -333,11 +222,6 @@ news "dock worker"
 	name
 		word
 			"Dock worker"
-	portrait
-		portrait/human03
-		portrait/human45
-		portrait/human69
-		portrait/human92
 	message
 		word
 			"It seems crazy to me that people on other planets would be willing to pay money for the sort of junk that we're loading into starships here."
@@ -354,11 +238,6 @@ news "housekeeper"
 		word
 			"Housekeeper"
 			"Domestic worker"
-	portrait
-		portrait/human18
-		portrait/human23
-		portrait/human65
-		portrait/human75
 	message
 		word
 			"How is it possible that a man who manages a billion-credit corporation can still be so incompetent or so careless that he routinely misses the toilet bowl when he takes a piss?"
@@ -375,11 +254,6 @@ news "groundskeeper"
 		word
 			"Groundskeeper"
 			"Gardener"
-	portrait
-		portrait/human05
-		portrait/human22
-		portrait/human26
-		portrait/human63
 	message
 		word
 			"The family I work for has an odd fascination with carnivorous plants. I have to keep rotting piles of refuse around just to produce enough flies to feed them all."
@@ -395,11 +269,6 @@ news "hair stylist"
 	name
 		word
 			"Hair stylist"
-	portrait
-		portrait/human17
-		portrait/human40
-		portrait/human67
-		portrait/human79
 	message
 		word
 			"For too long, the creativity of trend-setting stylists like myself has been held in check by the limited height of the doorways in most houses."
@@ -415,11 +284,6 @@ news "tour guide"
 	name
 		word
 			"Tour guide"
-	portrait
-		portrait/human15
-		portrait/human25
-		portrait/human52
-		portrait/human77
 	message
 		word
 			"I've delivered the same speech so many times now that the whole thing runs on continuous repeat in my head when I'm trying to sleep."
@@ -435,12 +299,6 @@ news "human resources worker"
 	name
 		word
 			"Human resources worker"
-	portrait
-		portrait/human04
-		portrait/human11
-		portrait/human33
-		portrait/human72
-		portrait/human125
 	message
 		word
 			"We always put our employees first. But sometimes they do things that are bad for their careers. Like, accusing a high-ranking manager of harassment."
@@ -456,11 +314,6 @@ news "loan officer"
 		word
 			"Loan officer"
 			"Mortgage broker"
-	portrait
-		portrait/human02
-		portrait/human29
-		portrait/human83
-		portrait/human86
 	message
 		word
 			"You probably think the interest rates we charge are exorbitant, but with all the ships getting blown up by pirates these days, we barely break even."
@@ -476,11 +329,6 @@ news "hyperspace relay engineer"
 	name
 		word
 			"Hyperspace relay engineer"
-	portrait
-		portrait/human13
-		portrait/human42
-		portrait/human76
-		portrait/human96
 	message
 		word
 			"All of human space is linked into a single communications network by relay beacons. It's something that most people just take for granted."
@@ -496,11 +344,6 @@ news "geological engineer"
 	name
 		word
 			"Geological engineer"
-	portrait
-		portrait/human07
-		portrait/human35
-		portrait/human50
-		portrait/human75
 	message
 		word
 			"With the right equipment, you can see inside a planet as easily as if it were... um... a tomato held up in front of an arc lamp. Sorry, I'm awful at similes."
@@ -517,11 +360,6 @@ news "agricultural scientist"
 	name
 		word
 			"Agricultural scientist"
-	portrait
-		portrait/human39
-		portrait/human53
-		portrait/human95
-		portrait/human97
 	message
 		word
 			"I hope you checked your shoes for invasive species before setting foot on my planet. The last thing we want is for our crops to get infected with the Arcturan Blight."
@@ -537,12 +375,6 @@ news "epidemiologist"
 	name
 		word
 			"Epidemiologist"
-	portrait
-		portrait/human01
-		portrait/human10
-		portrait/human37
-		portrait/human79
-		portrait/human110
 	message
 		word
 			"People always worry about extra-terrestrial viruses and bacteria, but the deadliest diseases are very often caused by microbes we brought with us to the stars from good old Mother Earth."
@@ -558,12 +390,6 @@ news "economist"
 	name
 		word
 			"Economist"
-	portrait
-		portrait/human20
-		portrait/human49
-		portrait/human83
-		portrait/human91
-		portrait/human104
 	message
 		word
 			"We're actually required by local law to predict that the economy will continue to do well, because the government thinks that any dire predictions will be a self-fulfilling prophecy."
@@ -579,11 +405,6 @@ news "nuclear technician"
 	name
 		word
 			"Nuclear technician"
-	portrait
-		portrait/human15
-		portrait/human41
-		portrait/human51
-		portrait/human75
 	message
 		word
 			"Last year all the hair on the left hand side of my face turned white and fell out. The company swears it was just a weird illness and had nothing to do with my work."
@@ -601,11 +422,6 @@ news "substance abuse counselor"
 	name
 		word
 			"Substance abuse counselor"
-	portrait
-		portrait/human37
-		portrait/human61
-		portrait/human64
-		portrait/human93
 	message
 		word
 			"I know some folks try to talk captains like you into carrying drugs on the side. I wish all of you could see the real human cost of that industry."
@@ -621,11 +437,6 @@ news "reporter"
 	name
 		word
 			"Reporter"
-	portrait
-		portrait/human00
-		portrait/human14
-		portrait/human68
-		portrait/human80
 	message
 		word
 			"I'm doing a human interest story about a llama that stowed away in a ship's cargo hold. Llamas are so cute, people will watch anything that involves them."
@@ -643,11 +454,6 @@ news "museum curator"
 	name
 		word
 			"Museum curator"
-	portrait
-		portrait/human36
-		portrait/human66
-		portrait/human73
-		portrait/human92
 	message
 		word
 			"You would not believe the sorts of things that the inhabitants of ancient Earth did for entertainment back before interstellar travel was a reality."
@@ -665,12 +471,6 @@ news "actor"
 	name
 		word
 			"Actor"
-	portrait
-		portrait/human02
-		portrait/human06
-		portrait/human51
-		portrait/human84
-		portrait/human105
 	message
 		word
 			"We're doing a production of the Scottish Play where the three witches are made up to look like Quarg. I know it sounds weird, but it works in our context."
@@ -687,11 +487,6 @@ news "technical writer"
 	name
 		word
 			"Technical writer"
-	portrait
-		portrait/human27
-		portrait/human52
-		portrait/human64
-		portrait/human94
 	message
 		word
 			"Do you have a few minutes to listen to my thoughts on the importance of the serial comma?"
@@ -708,11 +503,6 @@ news "dietitian"
 	name
 		word
 			"Dietitian"
-	portrait
-		portrait/human04
-		portrait/human37
-		portrait/human57
-		portrait/human66
 	message
 		word
 			"I actually have several recipes that can make processed algae delicious. Or at least, visually appealing. Quite edible. I mean, it's not that hard to mask the taste."
@@ -729,11 +519,6 @@ news "chef"
 	name
 		word
 			"Chef"
-	portrait
-		portrait/human00
-		portrait/human18
-		portrait/human31
-		portrait/human48
 	message
 		word
 			"For a recent corporate gala, I constructed a fire pit large enough to roast an entire Antarean thunder-lizard. The fat was perfectly rendered. It was amazing."
@@ -750,12 +535,6 @@ news "insurance agent"
 	name
 		word
 			"Insurance agent"
-	portrait
-		portrait/human43
-		portrait/human49
-		portrait/human78
-		portrait/human97
-		portrait/human127
 	message
 		word
 			"No, we don't sell insurance policies on private starships in this day and age. We also don't insure buildings in flood plains and houses inhabited by convicted serial arsonists."
@@ -773,11 +552,6 @@ news "excavation specialist"
 		word
 			"Excavation specialist"
 			"Explosives worker"
-	portrait
-		portrait/human24
-		portrait/human41
-		portrait/human42
-		portrait/human75
 	message
 		word
 			"Those newfangled mining lasers are pretty cool, but there's nothing like good old-fashioned dynamite for shifting a lot of rock in a hurry."
@@ -795,11 +569,6 @@ news "chauffeur"
 	name
 		word
 			"Chauffeur"
-	portrait
-		portrait/human07
-		portrait/human41
-		portrait/human67
-		portrait/human83
 	message
 		word
 			"I fly the missus to her appointments in a private shuttlecraft, because she hates being stuck in traffic."
@@ -817,11 +586,6 @@ news "human retiree"
 	name
 		word
 			"Retiree"
-	portrait
-		portrait/human26
-		portrait/human29
-		portrait/human30
-		portrait/human38
 	message
 		word
 			"Retiring is the best thing I ever did. They should make it mandatory!"
@@ -841,14 +605,6 @@ news "human financial analyst"
 	name
 		word
 			"Financial analyst"
-	portrait
-		portrait/human14
-		portrait/human16
-		portrait/human32
-		portrait/human39
-		portrait/human49
-		portrait/human56
-		portrait/human65
 	message
 		word
 			"You must be a very brave captain, if you have traveled to some of the... less civilized parts of human space."
@@ -871,12 +627,6 @@ news "human syndicate manager"
 	name
 		word
 			"Syndicate manager"
-	portrait
-		portrait/human12
-		portrait/human33
-		portrait/human67
-		portrait/human68
-		portrait/human91
 	message
 		word
 			"We've had to ask everyone to work sixty-hour weeks just to meet this month's quotas. The workers complain to me, but I tell them I'm in the same boat as they are."
@@ -898,13 +648,6 @@ news "human scientist"
 	name
 		word
 			"Scientist"
-	portrait
-		portrait/human13
-		portrait/human37
-		portrait/human43
-		portrait/human64
-		portrait/human71
-		portrait/human83
 	message
 		word
 			"It's so exciting being on the cutting edge of human knowledge, but I wish it were easier to secure funding. A lot of my equipment is more than 40 years old."
@@ -924,12 +667,6 @@ news "human student"
 	name
 		word
 			"Student"
-	portrait
-		portrait/human28
-		portrait/human90
-		portrait/human93
-		portrait/human96
-		portrait/human107
 	message
 		word
 			"I'm going to be a teacher some day!"
@@ -954,12 +691,6 @@ news "human religious"
 	name
 		word
 			"Mystic"
-	portrait
-		portrait/human45
-		portrait/human57
-		portrait/human61
-		portrait/human124
-		portrait/human126
 	message
 		word
 			"May God be with you!"
@@ -985,15 +716,6 @@ news "human tourism"
 	name
 		word
 			"Tourist"
-	portrait
-		portrait/human40
-		portrait/human46
-		portrait/human47
-		portrait/human48
-		portrait/human84
-		portrait/human86
-		portrait/human95
-		portrait/human122
 	message
 		word
 			"This place is so romantic. I wish I could stay forever."
@@ -1015,9 +737,6 @@ news "human mercenary"
 	name
 		word
 			"Mercenary"
-	portrait
-		portrait/human88
-		portrait/human89
 	message
 		word
 			"I've tracked fugitives halfway across the galaxy, and they have me on... guard duty. These guys must really be desperate given the kind of money they waved in my face."
@@ -1035,13 +754,6 @@ news "human republic soldier"
 	name
 		word
 			"Republic Soldier"
-	portrait
-		portrait/human80
-		portrait/human81
-		portrait/human85
-		portrait/human100
-		portrait/human101
-		portrait/human118
 	message
 		word
 			"I bet you think that starship of yours is hot stuff, huh? Try tooling around in a cruiser with Atomic Engines sometime. You can run circles around interceptors."
@@ -1063,9 +775,6 @@ news "human syndicate soldier"
 	name
 		word
 			"Syndicate Soldier"
-	portrait
-		portrait/human87
-		portrait/human99
 	message
 		word
 			"What a terrible posting. I thought I'd filed my transfer paperwork right, but it turned out my commander's seal had to be a certified original and not a copy, so now I'm stuck here for another two years."
@@ -1084,16 +793,6 @@ news "human pirate"
 	name
 		word
 			"Pirate"
-	portrait
-		portrait/human19
-		portrait/human24
-		portrait/human25
-		portrait/human27
-		portrait/human34
-		portrait/human44
-		portrait/human51
-		portrait/human59
-		portrait/human62
 	message
 		word
 			"Next time we meet up, maybe I'll be plundering your ship."

--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -10,7 +10,6 @@
 
 
 
-# Visual suggestion: a bit quirky or weird; expression is content, confident, or stoic
 news "human merchant anywhere"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent" "Hai"
@@ -30,7 +29,6 @@ news "human merchant anywhere"
 
 
 
-# Visual suggestion: a bit quirky or weird; expression is content, confident, or stoic
 news "human merchant in human space"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -54,7 +52,6 @@ news "human merchant in human space"
 			"My first ship was a Shuttle. I kind of miss that glorified tour bus."
 			"I love doing Syndicate jobs. Easy money for not much work. I guess they're all so rich that they can afford to pay for the best."
 
-# Visual suggestion: hard-bitten, tough, often dark-skinned and/or wearing a hat
 news "human farming"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -81,7 +78,6 @@ news "human farming"
 
 
 
-# Visual suggestion: young, normal-looking, more female than male
 news "human textiles"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -100,7 +96,6 @@ news "human textiles"
 
 
 
-# Visual suggestion: unhappy-looking, predominately male, usually wearing a beanie or a hard hat
 news "human mining"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -117,7 +112,6 @@ news "human mining"
 
 
 
-# Visual suggestion: worn-down-looking, often older
 news "human factory"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -579,7 +573,6 @@ news "chauffeur"
 
 
 
-# Visual suggestion: old
 news "human retiree"
 	location
 		attributes "paradise"
@@ -598,7 +591,6 @@ news "human retiree"
 
 
 
-# Visual suggestion: middle-aged people wearing professional attire
 news "human financial analyst"
 	location
 		attributes "paradise" "near earth"
@@ -620,7 +612,6 @@ news "human financial analyst"
 
 
 
-# Visual suggestion: well-dressed young men, often looking kind of cocky
 news "human syndicate manager"
 	location
 		government "Syndicate"
@@ -640,7 +631,6 @@ news "human syndicate manager"
 
 
 
-# Visual suggestion: glasses, clean-cut attire, possibly scientific accoutrements
 news "human scientist"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -659,7 +649,6 @@ news "human scientist"
 
 
 
-# Visual suggestion: young and optimistic
 news "human student"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -683,7 +672,6 @@ news "human student"
 
 
 
-# Visual suggestion: relaxed, happy, possibly wearing traditional religious dress
 news "human religious"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -707,7 +695,6 @@ news "human religious"
 
 
 
-# Visual suggestion: attractive or sexy, looking either happy or bored
 news "human tourism"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -729,7 +716,6 @@ news "human tourism"
 
 
 
-# Visual suggestion: determined, tough, irregular-looking military/warrior accoutrements
 news "human mercenary"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -746,7 +732,6 @@ news "human mercenary"
 
 
 
-# Visual suggestion: military beret, soldier's clothing, not too fancy
 news "human republic soldier"
 	location
 		government "Republic"
@@ -767,7 +752,6 @@ news "human republic soldier"
 
 
 
-# Visual suggestion: expensive-looking tactical gear
 news "human syndicate soldier"
 	location
 		government "Syndicate"
@@ -786,7 +770,6 @@ news "human syndicate soldier"
 
 
 
-# Visual suggestion: dangerous mofos, lunatics, reavers
 news "human pirate"
 	location
 		government "Pirate"

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -562,18 +562,14 @@ interface "news"
 	sprite "ui/news"
 		center -160 -45
 	image "portrait"
-		center -340 -40
-	string "name portrait"
-		from -270 -100
-		align center left
-		color "bright"
-	box "message portrait"
-		from -270 -80
-		to 80 10
+		center 20 -40
 	string "name"
 		from -400 -100
 		align center left
 		color "bright"
+	box "message portrait"
+		from -400 -80
+		to -50 10
 	box "message"
 		from -400 -80
 		to 80 10

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -563,12 +563,19 @@ interface "news"
 		center -160 -45
 	image "portrait"
 		center -340 -40
-	string "name"
+	string "name portrait"
 		from -270 -100
 		align center left
 		color "bright"
-	box "message"
+	box "message portrait"
 		from -270 -80
+		to 80 10
+	string "name"
+		from -400 -100
+		align center left
+		color "bright"
+	box "message"
+		from -400 -80
 		to 80 10
 
 

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -112,9 +112,7 @@ void SpaceportPanel::Draw()
 		interface->Draw(newsInfo);
 		// Depending on if the news has a portrait, the interface message that
 		// gets filled in changes.
-		string message = "message";
-		if(hasPortrait)
-			message += " portrait";
-		newsMessage.Draw(interface->GetBox(message).TopLeft(), *GameData::Colors().Get("medium"));
+		newsMessage.Draw(interface->GetBox(hasPortrait ? "message portrait" : "message").TopLeft(),
+			*GameData::Colors().Get("medium"));
 	}
 }

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -110,7 +110,7 @@ void SpaceportPanel::Draw()
 	{
 		const Interface *interface = GameData::Interfaces().Get("news");
 		interface->Draw(newsInfo);
-		// Depending on if the news has a portrait, the interface message that
+		// Depending on if the news has a portrait, the interface box that
 		// gets filled in changes.
 		newsMessage.Draw(interface->GetBox(hasPortrait ? "message portrait" : "message").TopLeft(),
 			*GameData::Colors().Get("medium"));

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -36,6 +36,11 @@ SpaceportPanel::SpaceportPanel(PlayerInfo &player)
 	text.SetWrapWidth(480);
 	text.Wrap(player.GetPlanet()->SpaceportDescription());
 	
+	// Query the news interface to find out the wrap width.
+	// TODO: Allow Interface to handle wrapped text directly.
+	const Interface *interface = GameData::Interfaces().Get("news");
+	portraitWidth = interface->GetBox("message portrait").Width();
+	normalWidth = interface->GetBox("message").Width();
 	newsMessage.SetFont(FontSet::Get(14));
 }
 
@@ -54,10 +59,6 @@ void SpaceportPanel::UpdateNews()
 	newsInfo.SetString("name", "");
 	newsInfo.SetSprite("portrait", nullptr);
 	
-	// Query the news interface to find out the wrap width.
-	// TODO: Allow Interface to handle wrapped text directly.
-	const Interface *interface = GameData::Interfaces().Get("news");
-	
 	// Randomly pick which portrait, if any, is to be shown. Depending on if
 	// this news has a portrait, different interface information gets filled in. 
 	auto portrait = news->Portrait();
@@ -67,12 +68,12 @@ void SpaceportPanel::UpdateNews()
 		hasPortrait = true;
 		newsInfo.SetString("name portrait", news->Name() + ':');
 		newsInfo.SetSprite("portrait", portrait);
-		newsMessage.SetWrapWidth(interface->GetBox("message portrait").Width());
+		newsMessage.SetWrapWidth(portraitWidth);
 	}
 	else
 	{
 		newsInfo.SetString("name", news->Name() + ':');
-		newsMessage.SetWrapWidth(interface->GetBox("message").Width());
+		newsMessage.SetWrapWidth(normalWidth);
 	}
 	
 	newsMessage.Wrap('"' + news->Message() + '"');

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -51,31 +51,16 @@ void SpaceportPanel::UpdateNews()
 	const News *news = GameData::PickNews(player.GetPlanet());
 	if(!news)
 		return;
-	
-	// Clear any previously cached information.
 	hasNews = true;
-	hasPortrait = false;
-	newsInfo.SetString("name portrait", "");
-	newsInfo.SetString("name", "");
-	newsInfo.SetSprite("portrait", nullptr);
 	
 	// Randomly pick which portrait, if any, is to be shown. Depending on if
 	// this news has a portrait, different interface information gets filled in. 
 	auto portrait = news->Portrait();
 	// Cache the randomly picked results until the next update is requested.
-	if(portrait)
-	{
-		hasPortrait = true;
-		newsInfo.SetString("name portrait", news->Name() + ':');
-		newsInfo.SetSprite("portrait", portrait);
-		newsMessage.SetWrapWidth(portraitWidth);
-	}
-	else
-	{
-		newsInfo.SetString("name", news->Name() + ':');
-		newsMessage.SetWrapWidth(normalWidth);
-	}
-	
+	hasPortrait = portrait;
+	newsInfo.SetSprite("portrait", portrait);
+	newsInfo.SetString("name", news->Name() + ':');
+	newsMessage.SetWrapWidth(hasPortrait ? portraitWidth : normalWidth);
 	newsMessage.Wrap('"' + news->Message() + '"');
 }
 

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -47,40 +47,31 @@ void SpaceportPanel::UpdateNews()
 	if(!news)
 		return;
 	
+	// Clear any previously cached information.
 	hasNews = true;
-	// Randomly pick which portrait is to be shown.
-	auto portrait = news->Portrait();
-	
-	// Ensure we only display one name for a given portrait.
-	const auto it = displayedProfessions.find(portrait);
-	auto name = string{};
-	if(it == displayedProfessions.end())
-	{
-		name = news->Name();
-		displayedProfessions.emplace(portrait, name);
-	}
-	else
-		name = it->second;
-	
-	// Clear any previous information
 	hasPortrait = false;
 	newsInfo.SetString("name portrait", "");
 	newsInfo.SetString("name", "");
 	newsInfo.SetSprite("portrait", nullptr);
+	
 	// Query the news interface to find out the wrap width.
 	// TODO: Allow Interface to handle wrapped text directly.
 	const Interface *interface = GameData::Interfaces().Get("news");
+	
+	// Randomly pick which portrait, if any, is to be shown. Depending on if
+	// this news has a portrait, different interface information gets filled in. 
+	auto portrait = news->Portrait();
 	// Cache the randomly picked results until the next update is requested.
 	if(portrait)
 	{
 		hasPortrait = true;
-		newsInfo.SetString("name portrait", name + ':');
+		newsInfo.SetString("name portrait", news->Name() + ':');
 		newsInfo.SetSprite("portrait", portrait);
 		newsMessage.SetWrapWidth(interface->GetBox("message portrait").Width());
 	}
 	else
 	{
-		newsInfo.SetString("name", name + ':');
+		newsInfo.SetString("name", news->Name() + ':');
 		newsMessage.SetWrapWidth(interface->GetBox("message").Width());
 	}
 	

--- a/source/SpaceportPanel.h
+++ b/source/SpaceportPanel.h
@@ -41,6 +41,8 @@ private:
 	// Current news item (if any):
 	bool hasNews = false;
 	bool hasPortrait = false;
+	int portraitWidth;
+	int normalWidth;
 	Information newsInfo;
 	WrappedText newsMessage;
 };

--- a/source/SpaceportPanel.h
+++ b/source/SpaceportPanel.h
@@ -18,10 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Information.h"
 #include "WrappedText.h"
 
-#include <map>
-
 class PlayerInfo;
-class Sprite;
 
 
 // GUI panel to be shown when you are in a spaceport. This just draws the port
@@ -46,9 +43,6 @@ private:
 	bool hasPortrait = false;
 	Information newsInfo;
 	WrappedText newsMessage;
-	// After displaying a portrait for a particular profession,
-	// only show it for that same profession.
-	std::map<const Sprite *, std::string> displayedProfessions;
 };
 
 

--- a/source/SpaceportPanel.h
+++ b/source/SpaceportPanel.h
@@ -43,6 +43,7 @@ private:
 	
 	// Current news item (if any):
 	bool hasNews = false;
+	bool hasPortrait = false;
 	Information newsInfo;
 	WrappedText newsMessage;
 	// After displaying a portrait for a particular profession,


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This PR addresses #4325 and removes all portraits from news. This PR does *not* remove the functionality of portraits, only removing the current portrait images from being used. This PR also does *not* remove the portrait images from the game, as plugins may be using them. (If it's decided though that we should also remove the images from the game, we can easily do so.)

This PR also updates the interface so that the name and message move locations depending on if the news does have a portrait or not. Given that the heart of #4165 was the repetition of portrait images, and this PR removes said images from the base game, I've reverted dea4cf7 as well. This also fixes #4463 by removing the portraits and the commit that caused the issue when portraits are present (so if a plugin decides to use portraits, #4463 won't be an issue, and #4165 should really be solved by smart use of which news gets which portraits, and by having a greater variety of portraits).

## Screenshots

Simply removing `portrait` from every news entry resulted in the following image, hence the code changes:
![image](https://user-images.githubusercontent.com/17688683/88819566-2ab09c00-d18e-11ea-9340-3f1608b34d96.png)

Now the spaceport news will look like the following with no portrait:
![image](https://user-images.githubusercontent.com/17688683/88819652-474cd400-d18e-11ea-87d3-947c238e0c69.png)

Or like this with a portrait:
![image](https://user-images.githubusercontent.com/17688683/88823411-0c996a80-d193-11ea-9bd1-083e8da214c3.png)
Portraits now appear on the right side of the UI so that the name and start of the message are always in the same spot regardless of the presence of a portrait.

## Save File
N/A

## PR Checklist
N/A
 - [x] ~~I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
 - [x] ~~I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}~~
 - [x] ~~I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~
