### PR TITLE
Add override to AllowFastForward() where appropriate.

### DIFF
--- a/source/MainPanel.h
+++ b/source/MainPanel.h
@@ -40,7 +40,7 @@ public:
 	void OnCallback();
 	
 	// The main panel allows fast-forward.
-	virtual bool AllowFastForward() const;
+	virtual bool AllowFastForward() const override;
 	
 	
 protected:

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -64,7 +64,7 @@ public:
 	static void DrawMiniMap(const PlayerInfo &player, float alpha, const System *const jump[2], int step);
 	
 	// Map panels allow fast-forward to stay active.
-	virtual bool AllowFastForward() const;
+	virtual bool AllowFastForward() const override;
 	
 	
 protected:

--- a/source/PlayerInfoPanel.h
+++ b/source/PlayerInfoPanel.h
@@ -37,7 +37,7 @@ public:
 	virtual void Draw() override;
 	
 	// The player info panel allow fast-forward to stay active.
-	virtual bool AllowFastForward() const;
+	virtual bool AllowFastForward() const override;
 	
 	
 protected:


### PR DESCRIPTION
**Bugfix:** This PR addresses a compiler warning that was introduced in #5148

## Fix Details
The override keyword was missing for AllowFastForward(). C++ allows this, but it is more appropriate if the keyword is given so that the compiler can check for overrides that were done incorrectly.
Added the keyword.

## Testing Done
Compiled the game after adding the keyword to allow the compiler to verify that overriding was done correctly.

## Save File
N/A
