### PR TITLE
Add dialogue phrases for missing waypoints

### DIFF
--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -64,6 +64,15 @@ phrase "generic missing stopover or cargo"
 phrase "generic missing stopover or escort"
 	word
 		`You have reached <planet>, but you're missing something! Either you haven't visited <stopovers>, or you left the <npc> behind.`
+phrase "generic missing waypoint or cargo and passengers"
+	word
+		`You have reached <planet>, but you're missing something! Either you haven't passed through <waypoints>, or not all the cargo and passengers are in the system.`
+phrase "generic missing waypoint or passengers"
+	word
+		`You have reached <planet>, but you're missing something! Either you haven't passed through <waypoints>, or not all the passengers are in the system.`
+phrase "generic missing waypoint or cargo"
+	word
+		`You have reached <planet>, but you're missing something! Either you haven't passed through <waypoints>, or not all the cargo is in the system.`		
 
 phrase "generic stopover on visit"
 	word

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -460,7 +460,7 @@ mission "WR Star 1"
 		dialog `A group of scientists approaches you and asks if you will be headed to the Rim any time soon. "We're doing research on Wolf-Rayet stars," they explain, "and we're hoping to find a captain who can do a fly-by of <waypoints>." Scientific research in the Deep is notoriously well-funded, so they will probably pay you quite well.`
 	
 	on visit
-		dialog `You land on <planet>, but the scientists tell you they're not finished yet. Either you forgot to fly through <waypoints>, or some of the scientists and their equipment are on an escort that hasn't entered the system yet. Better leave the planet and figure it all out.`
+		dialog phrase "generic missing waypoint or cargo and passengers"
 	on complete
 		payment 250000
 		dialog `The team of scientists thanks you for bringing them to <waypoints> and back, and pays you <payment>. They seem eager to get back to their lab and start analyzing their measurements.`

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -460,7 +460,7 @@ mission "WR Star 1"
 		dialog `A group of scientists approaches you and asks if you will be headed to the Rim any time soon. "We're doing research on Wolf-Rayet stars," they explain, "and we're hoping to find a captain who can do a fly-by of <waypoints>." Scientific research in the Deep is notoriously well-funded, so they will probably pay you quite well.`
 	
 	on visit
-		dialog `You land on <planet>, but realize that the scientists and their equipment were on one of your escorts who hasn't entered the system yet. Better depart and wait for them.`
+		dialog `You land on <planet>, but the scientists tell you they're not finished yet. Either you forgot to fly through <waypoints>, or some of the scientists and their equipment are on an escort that hasn't entered the system yet. Better leave the planet and figure it all out.`
 	on complete
 		payment 250000
 		dialog `The team of scientists thanks you for bringing them to <waypoints> and back, and pays you <payment>. They seem eager to get back to their lab and start analyzing their measurements.`


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5195.

## Fix Details
Adds three new `on visit` dialogue phrases that can be used for future missions and the mission issue #5195 references: 
1) Missing waypoint or cargo
2) Missing waypoint or passengers
3) Missing waypoint, cargo, or passengers
Replaces `on visit` for `mission "WR Star 1"` with the new missing waypoint, cargo, or passengers phrase.

## Testing Done
Using the provided save file, the phrase for missing waypoint, cargo, or passengers appears correctly.

## Save File
This save file can be used to verify the bugfix.
[WaypointDialogTest.txt](https://github.com/endless-sky/endless-sky/files/5012386/WaypointDialogTest.txt)
The mission is already assigned. Simply leave the planet and land again to view the new dialogue.