### PR TITLE
Fix: Adding missing Key Stones to Remnant Ships

### DIFF
--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -129,6 +129,7 @@ ship "Albatross" "Albatross (Turret)"
 		"Millennium Cell"
 		"Crystal Capacitor"
 		"Thermoelectric Cooler"
+		"Quantum Key Stone"
 		"Outfits Expansion" 2
 		"Tuning Rifle" 49
 
@@ -153,6 +154,7 @@ ship "Albatross" "Albatross (Heavy)"
 		"Millennium Cell"
 		"Crystal Capacitor" 2
 		"Thermoelectric Cooler" 2
+		"Quantum Key Stone"
 		"Outfits Expansion" 4
 		"Tuning Rifle" 65
 
@@ -183,6 +185,7 @@ ship "Albatross" "Albatross (Shield)"
 		"Aeon Cell"
 		"Millennium Cell"
 		"Thermoelectric Cooler" 1
+		"Quantum Key Stone"
 		"Outfits Expansion" 6
 		"Systems Core (Large)" 3
 		"Small Heat Shunt" 1
@@ -278,6 +281,7 @@ ship "Gull" "Gull (Sniper)"
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
+		"Quantum Key Stone"
 		"Salvage Scanner" 2
 		"Outfits Expansion"
 		"Tuning Rifle" 4
@@ -296,6 +300,7 @@ ship "Gull" "Gull (Support)"
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
+		"Quantum Key Stone"
 		"Salvage Scanner" 2
 		"Outfits Expansion"
 		"Tuning Rifle" 3
@@ -310,6 +315,7 @@ ship "Gull" "Gull (Cargo)"
 
 		"Epoch Cell"
 		"Crystal Capacitor"
+		"Quantum Key Stone"
 		"Salvage Scanner"
 		"Tuning Rifle" 3
 
@@ -323,6 +329,7 @@ ship "Gull" "Gull (Bunks)"
 
 		"Epoch Cell"
 		"Crystal Capacitor"
+		"Quantum Key Stone"
 		"Salvage Scanner"
 		"Tuning Rifle" 3
 


### PR DESCRIPTION
**Fix:** This PR addresses the fact that Remnant ships that either need to or will need to use Ember Waste wormholes do not  have a Quantum Keystone.

## Fix Details
- Adds Quantum Keystones to a range of ships so that they are properly equipped for the missions they will be used in.
