### PR TITLE
feat: Allow the scram drive attribute to be applied to Jump Drives

### DIFF
--- a/source/Ship.h
+++ b/source/Ship.h
@@ -360,6 +360,8 @@ public:
 	int OutfitCount(const Outfit *outfit) const;
 	// Add or remove outfits. (To remove, pass a negative number.)
 	void AddOutfit(const Outfit *outfit, int count);
+	// Determine if the ship has an outfit with the specified type and optionally subtype
+	bool HasOutfit(const std::string &type, const std::string &subtype) const;
 	
 	// Get the list of weapons.
 	Armament &GetArmament();


### PR DESCRIPTION
Enables a scram-enabled jump drive outfit.

**Feature:** This PR implements the feature request detailed and discussed in issue #5204 

## Feature Details

Allows the "scram drive" attribute to be applied to both hyperdrives (which makes a scram drive) and jump drives (which makes a scram-enabled jump drive). When applied to a jump drive, it makes the ship align to the target system (like a scram drive) but jump like a jump drive. The changes have zero impact on existing drives, Hyperdrives, Scram Drives, and Jump Drives (and ships with those bulit-in) all behave the same way the did before the code change. The code changes only enable new behavior if you apply the "scram drive" attribute to a jump drive outfit (or apply both attributes to a ship to have a built-in scram-enabled jump capability).

## UI Screenshots

N/A

## Usage Examples

It is not currently used in the data files. I plan on adding a new outfit, the Slip Drive (Quantum Slipstream Drive) which is a scram-enabled jump drive to plugins. Here's the outfit I used for testing:

```
outfit "Slip Drive"
	category "Systems"
	cost 5000000
	thumbnail "outfit/slip drive"
	"mass" 20
	"outfit space" -20
	"jump fuel" 175
	"scram drive" 0.2
	"jump drive" 1
	description `The Quantum Slipstream Drive, nicknamed the "Slip Drive", allows ships to travel between systems without a hyperlink connection. A slipstream is a narrowly focused, directed field that is initiated by manipulating the fabric of the space-time continuum at the quantum level. This creates a subspace tunnel, which is projected ahead of the vessel. Once a ship has entered the slipstream, the forces inside propel it at incredible speed. Like a Scram Drive, ships must be oriented towards the destination system before jumping and can be in motion during the jump. A sequence of jumps with a Slip Drive takes more time than a Jump Drive and the ships are vulnerable to attack between jumps because ships must reorient towards the next target system before each jump.`
```

## Testing Done

Tested setting targets on the map, and jumping across multiple systems (mixed hyperspace and jump), with multiple drive configurations, including ships with multiple drives and fleets of ships with mixed drive configurations, including all 16 possible combinations:
* Ship with no drives
* Hyperdrive
* Scram Drive
* Jump Drive
* HyperDrive + Scram Drive
* HyperDrive + Jump Drive
* Scram Drive + Jump Drive
* HyperDrive + Scram Drive + Jump Drive
* Slip Drive
* Hyperdrive + Slip Drive
* Scram Drive + Slip Drive
* Jump Drive + Slip Drive
* HyperDrive + Scram Drive + Slip Drive
* HyperDrive + Jump Drive + Slip Drive
* Scram Drive + Jump Drive + Slip Drive
* HyperDrive + Scram Drive + Jump Drive + Slip Drive

## Performance Impact

There are a few places in the code where the CPU will have to search the outfits list of a ship instead of grabbing the "scram drive" attribute right off the ship's composite attribute list, but the outfits lists are fairly small and bounded so iterating the list is pretty quick, and the PrepForJump, IsReadyForJump, and JumpFuel calculations are only done when plotting courses and actually jumping.
