### PR TITLE
Kor Efreti spaceport news

### DIFF
--- a/data/korath/korath news.txt
+++ b/data/korath/korath news.txt
@@ -11,6 +11,7 @@
 news "kor efret merchant"
 	location
 		government "Kor Efret"
+		not attributes "station"
 	name
 		word
 			"Korath merchant"
@@ -28,6 +29,7 @@ news "kor efret merchant"
 news "kor efret worker"
 	location
 		government "Kor Efret"
+		not attributes "station"
 	name
 		word
 			"Korath worker"
@@ -42,6 +44,7 @@ news "kor efret worker"
 news "kor efret local"
 	location
 		government "Kor Efret"
+		not attributes "station"
 	name
 		word
 			"Korath local"
@@ -51,15 +54,13 @@ news "kor efret local"
 	message
 		word
 			"A ball chased by a young Korath rolls up to your feet. You pick it up, and the youth pauses and stares at you for a moment before gesturing in thanks and accepting the ball. It runs back to a grown Korath who holds both its hands up with palms toward you."
-			"There's a Korath nearby precariously balancing several boxes above its head. You can't tell if it's a street performer or just transporting the crates."
 			"A local Korath gestures toward a building you've never been inside before. Out of curiousity, you poke your head inside to see the reptilian aliens conversing and sharing drinks: it's a bar. Some things never change, no matter where you are in the galaxy."
-			"A Kor Efret near your ship is speaking with a worker, gradually increasing its volume until it's doing some strange mix of shouting and hissing. Suddenly, it turns and stalks away with its chest puffed out."
-			"You try asking one of the Korath about the abandoned buildings littered throughout the spaceport, but it's no good. You're unable to convey the strange dichotomy the mixture of old and new makes; in fact, it seems to be the norm here."
 			"You pass by one of the abandoned buildings and hear a door open and close rapidly behind you. You turn back and see a Korath dressed in rags quickly walking the other direction."
 
 news "kor efret scientist"
 	location
 		government "Kor Efret"
+		not attributes "station"
 	name
 		word
 			"Korath scientist"
@@ -70,3 +71,19 @@ news "kor efret scientist"
 		word
 			"A Kor Efret pushes a cart filled with strange chemicals and bits of technology past you."
 			"A Korath walks through the spaceport reading numbers off a device and inputting them onto another one. It looks like it's taking samples of the air quality."
+			
+news "kor efret station friendly"		
+	location
+		government "Kor Efret"
+	name
+		word
+			"Korath local"
+			"Kor Efret local"
+			"Korath"
+			"Kor Efret"
+	message
+		word
+			"There's a Korath nearby precariously balancing several boxes above its head. You can't tell if it's a street performer or just transporting the crates."
+			"A Kor Efret near your ship is speaking with a worker, gradually increasing its volume until it's doing some strange mix of shouting and hissing. Suddenly, it turns and stalks away with its chest puffed out."
+			"A Korath is studying you intently from a distance. You guess it's never seen a human face to face before."
+			"A local greets you by holding its hands up with its palms facing toward you."

--- a/data/korath/korath news.txt
+++ b/data/korath/korath news.txt
@@ -55,7 +55,7 @@ news "kor efret local"
 			"A local Korath gestures toward a building you've never been inside before. Out of curiousity, you poke your head inside to see the reptilian aliens conversing and sharing drinks: it's a bar. Some things never change, no matter where you are in the galaxy."
 			"A Kor Efret near your ship is speaking with a worker, gradually increasing its volume until it's doing some strange mix of shouting and hissing. Suddenly, it turns and stalks away with its chest puffed out."
 			"You try asking one of the Korath about the abandoned buildings littered throughout the spaceport, but it's no good. You're unable to convey the strange dichotomy the mixture of old and new makes; in fact, it seems to be the norm here."
-			"You pass by one of the abandoned buildings and hear a door open and close rapidly behind you. You turn back, and a Korath dressed in rags is quickly walking the other direction."
+			"You pass by one of the abandoned buildings and hear a door open and close rapidly behind you. You turn back and see a Korath dressed in rags quickly walking the other direction."
 
 news "kor efret fancy"
 	location

--- a/data/korath/korath news.txt
+++ b/data/korath/korath news.txt
@@ -57,18 +57,6 @@ news "kor efret local"
 			"You try asking one of the Korath about the abandoned buildings littered throughout the spaceport, but it's no good. You're unable to convey the strange dichotomy the mixture of old and new makes; in fact, it seems to be the norm here."
 			"You pass by one of the abandoned buildings and hear a door open and close rapidly behind you. You turn back and see a Korath dressed in rags quickly walking the other direction."
 
-news "kor efret fancy"
-	location
-		government "Kor Efret"
-	name
-		word
-			"Well-dressed Korath"
-			"Well-dressed Kor Efret"
-	message
-		word
-			"One Korath wearing a toga-like outfit walks directly toward you. You barely manage to get out of the way before it bumps into you, and it makes a hissing sound. As you watch it continue through the spaceport, every other Korath gives it plenty of space. You hope you didn't just cause a diplomatic crisis on behalf of your entire species."
-			"Nearby, a Korath with a toga-like robe speaks to a small group of noticably worse-dressed Kor Efreti. You don't know what they're talking about, but it's obvious they're being told what to do."
-
 news "kor efret scientist"
 	location
 		government "Kor Efret"

--- a/data/korath/korath news.txt
+++ b/data/korath/korath news.txt
@@ -81,4 +81,4 @@ news "kor efret scientist"
 	message
 		word
 			"A Kor Efret pushes a cart filled with strange chemicals and bits of technology past you."
-			"A Korath wearing an insignia - probably to designate it as some sort of government official - strides through the spaceport with a strange device. It looks like it's taking samples of the air quality."
+			"A Korath walks through the spaceport reading numbers off a device and inputting them onto another one. It looks like it's taking samples of the air quality."

--- a/data/korath/korath news.txt
+++ b/data/korath/korath news.txt
@@ -1,0 +1,84 @@
+# Copyright (c) 2020 by W1zrad
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+news "kor efret merchant"
+	location
+		government "Kor Efret"
+	name
+		word
+			"Korath merchant"
+			"Kor Efret merchant"
+			"Korath vendor"
+			"Kor Efret vendor"
+	message
+		word
+			"A Korath waves you over to a stand filled with a variety of foods. It wants you to buy something, but nothing looks particularly appetizing."
+			"You spend some time inspecting the wares of a street vendor selling small pieces of... some sort of technology. You have no idea what any of it is."
+			"A merchant cries out in its own language to passerby while gesturing to a strange outfit you've never seen before. Some stop to look, but most ignore it."
+			"One Korath seems to be auctioning off a strange device to a small crowd."
+			"You enter an unusually busy building and are greeted by a Korath who seems to work there. It's filled with monitors displaying natural flora and fauna. The Korath in here are captivated by them."
+
+news "kor efret worker"
+	location
+		government "Kor Efret"
+	name
+		word
+			"Korath worker"
+			"Kor Efret worker"
+	message
+		word
+			"The Korath attaching fuel cables to your ship stops and holds both its hands up with its palms toward you when it notices you watching."
+			"Two of the workers nearby are speaking to each other while gesturing to your ship. It looks like they aren't used to visitors here."
+			"A worker carries a crate containing several tools past you to several other Korath. They seem to be repairing an outfit - or maybe it's an air conditioning unit. You can't really tell."
+			"A Korath emerges from a nearby dilapidated building and begins sealing every possible entrance - windows, doors, large cracks - shut. It moves with such efficiency that you're sure it's done this plenty of times before."
+
+news "kor efret local"
+	location
+		government "Kor Efret"
+	name
+		word
+			"Korath local"
+			"Kor Efret local"
+			"Korath"
+			"Kor Efret"
+	message
+		word
+			"A ball chased by a young Korath rolls up to your feet. You pick it up, and the youth pauses and stares at you for a moment before gesturing in thanks and accepting the ball. It runs back to a grown Korath who holds both its hands up with palms toward you."
+			"There's a Korath nearby precariously balancing several boxes above its head. You can't tell if it's a street performer or just transporting the crates."
+			"A local Korath gestures toward a building you've never been inside before. Out of curiousity, you poke your head inside to see the reptilian aliens conversing and sharing drinks: it's a bar. Some things never change, no matter where you are in the galaxy."
+			"A Kor Efret near your ship is speaking with a worker, gradually increasing its volume until it's doing some strange mix of shouting and hissing. Suddenly, it turns and stalks away with its chest puffed out."
+			"You try asking one of the Korath about the abandoned buildings littered throughout the spaceport, but it's no good. You're unable to convey the strange dichotomy the mixture of old and new makes; in fact, it seems to be the norm here."
+			"You pass by one of the abandoned buildings and hear a door open and close rapidly behind you. You turn back, and a Korath dressed in rags is quickly walking the other direction."
+
+news "kor efret fancy"
+	location
+		government "Kor Efret"
+	name
+		word
+			"Well-dressed Korath"
+			"Well-dressed Kor Efret"
+	message
+		word
+			"One Korath wearing a toga-like outfit walks directly toward you. You barely manage to get out of the way before it bumps into you, and it makes a hissing sound. As you watch it continue through the spaceport, every other Korath gives it plenty of space. You hope you didn't just cause a diplomatic crisis on behalf of your entire species."
+			"Nearby, a Korath with a toga-like robe speaks to a small group of noticably worse-dressed Kor Efreti. You don't know what they're talking about, but it's obvious they're being told what to do."
+
+news "kor efret scientist"
+	location
+		government "Kor Efret"
+	name
+		word
+			"Korath scientist"
+			"Kor Efret scientist"
+			"Korath technologist"
+			"Kor Efret technologist"
+	message
+		word
+			"A Kor Efret pushes a cart filled with strange chemicals and bits of technology past you."
+			"A Korath wearing an insignia - probably to designate it as some sort of government official - strides through the spaceport with a strange device. It looks like it's taking samples of the air quality."


### PR DESCRIPTION
## Summary
Adds 17 spaceport news dialogues for Kor Efret planets/stations (none of which is actual dialogue, as the player does not know Korath language). I tried to elaborate on the existing planet/spaceport descriptions of the dichotomy of market stalls and plazas in the middle of cities. Added a new minor aspect to existing lore:
Cities are partly abandoned/dilapidated due to the civil war: buildings range from brand new to structurally unstable. I thought this was appropriate considering the Korath's role as a declining species.

Below are a couple screenshots of the news.
![korefretinews1](https://user-images.githubusercontent.com/20505367/89332259-13c3eb00-d661-11ea-9d54-0af7f6f4e09f.png)
![korefretinews2](https://user-images.githubusercontent.com/20505367/89332265-16264500-d661-11ea-8eac-12a434e6165a.png)

## Save File
This save file can be used to play through the new mission content:
[Test Pilot~korathnews.txt](https://github.com/endless-sky/endless-sky/files/5023874/Test.Pilot.korathnews.txt)