### PR TITLE
fix Unable to initialize GLEW on wayland

### DIFF
--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -126,7 +126,7 @@ bool GameWindow::Init()
 	// Initialize GLEW.
 #ifndef __APPLE__
 	glewExperimental = GL_TRUE;
-	if(glewInit() != GLEW_OK){
+	if(GLenum err = glewInit(); GLEW_OK != err && err != GLEW_ERROR_NO_GLX_DISPLAY){
 		ExitWithError("Unable to initialize GLEW!");
 		return false;
 	}


### PR DESCRIPTION
-----------------------
**Bugfix:** This PR addresses issue flathub/io.github.endless_sky.endless_sky#1
## Fix Details
Glew fails to initialize on wayland because there is no GLX on wayland and distro-provided GLEW is build to forse use of GLX over EGL. This is upsteram GLEW issue nigels-com/glew#172. This PR ignores the GLEW_ERROR_NO_GLX_DISPLAY error. This is the temporary fix until this is fixed by GLEW upstream. @Pointedstick asked me to open PR here.

## Testing Done
Tried playing game on my linux laptop with sway. No crashes or other problems. 

## Save File
No need for save file, bug occurs just when you try to start the game on wayland. It occurs on both v0.9.12 which is in the flatpak and on v0.9.6 which is in my distro repository (Gentoo), and does not occur when using this branch's build.