### PR TITLE
Support selecting systems without planning route

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -547,7 +547,8 @@ void MapPanel::Select(const System *system)
 	
 	bool shift = (SDL_GetModState() & KMOD_SHIFT) && !plan.empty();
 	bool ctrl = (SDL_GetModState() & KMOD_CTRL);
-	if (ctrl) {
+	if (ctrl) 
+	{
 		return;
 	}
 	else if(system == source && !shift)

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -546,8 +546,10 @@ void MapPanel::Select(const System *system)
 	const System *source = isJumping ? flagship->GetTargetSystem() : playerSystem;
 	
 	auto mod = SDL_GetModState();
-	bool ctrl = (SDL_GetModState() & KMOD_CTRL);
-	if (ctrl) 
+	// TODO: Whoever called Select should tell us what to do with this system vis-a-vis the travel plan, rather than
+	// possibly manipulating it both here and there. Or, we entirely separate Select from travel plan modifications.
+	bool shift = (mod & KMOD_SHIFT) && !plan.empty();
+	if(mod & KMOD_CTRL)
 		return;
 	else if(system == source && !shift)
 	{

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -545,7 +545,7 @@ void MapPanel::Select(const System *system)
 	bool isJumping = flagship->IsEnteringHyperspace();
 	const System *source = isJumping ? flagship->GetTargetSystem() : playerSystem;
 	
-	bool shift = (SDL_GetModState() & KMOD_SHIFT) && !plan.empty();
+	auto mod = SDL_GetModState();
 	bool ctrl = (SDL_GetModState() & KMOD_CTRL);
 	if (ctrl) 
 		return;

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -548,9 +548,7 @@ void MapPanel::Select(const System *system)
 	bool shift = (SDL_GetModState() & KMOD_SHIFT) && !plan.empty();
 	bool ctrl = (SDL_GetModState() & KMOD_CTRL);
 	if (ctrl) 
-	{
 		return;
-	}
 	else if(system == source && !shift)
 	{
 		plan.clear();

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -546,7 +546,11 @@ void MapPanel::Select(const System *system)
 	const System *source = isJumping ? flagship->GetTargetSystem() : playerSystem;
 	
 	bool shift = (SDL_GetModState() & KMOD_SHIFT) && !plan.empty();
-	if(system == source && !shift)
+	bool ctrl = (SDL_GetModState() & KMOD_CTRL);
+	if (ctrl) {
+		return;
+	}
+	else if(system == source && !shift)
 	{
 		plan.clear();
 		if(!isJumping)


### PR DESCRIPTION
## Feature Details
This feature lets you use a modify key (control in this case) to prevent automatic route planning on the map panel. While routes are very easy to plan in Endless Sky, having a trip with 3-4 stops make re-planning it tedious. With this change, holding down control lets you directly select a system, cycling you through available missions on the Missions tab, or letting you preview commodity prices for a stop on the way on the Ports tab.

Future development could allow for an option to enable/disable automatic route planning, where this modifier would be the inverse of that (plot route if enabled, directly select if disabled), but in the meantime, this is a quality-of-life change that benefits players who take on many jobs at once.

## Testing Done
Tested for clicking on a variety of explored/unexplored systems, and using multiple modifiers. Control will overwrite shift's behavior due to the conditional block, and it's not planning a route in the first place.