### PR TITLE
Add "ion protection" to Heliarch ships

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -274,6 +274,7 @@ ship "Heliarch Interdictor"
 		"mass" 520
 		"drag" 7.4
 		"heat dissipation" .70
+		"ion protection" .2
 		"fuel capacity" 800
 		"cargo space" 79
 		"outfit space" 544
@@ -396,6 +397,7 @@ ship "Heliarch Neutralizer"
 		"mass" 270
 		"drag" 4.1
 		"heat dissipation" .75
+		"ion protection" .1
 		"fuel capacity" 1000
 		"cargo space" 36
 		"outfit space" 367
@@ -515,6 +517,7 @@ ship "Heliarch Punisher"
 		"mass" 780
 		"drag" 12.2
 		"heat dissipation" .60
+		"ion protection" .3
 		"fuel capacity" 600
 		"cargo space" 94
 		"outfit space" 885


### PR DESCRIPTION
I've had this in mind for a while but keep forgetting about it so opening this draft for discussion.

Adds ion protection to the 3 Heliarch ships, the value getting higher as the ships go from Light to Medium to Heavy warships.
Reasoning being that, being built to fight the Quarg, who have Ion Damage on their skylances, and the Heliarchs themselves having developped ion weaponry, they should know a thing or two about how to minimize the effects of ion damage on their ships.
Along with the 5032 buffs to the Reactor Modules, should make Heliarch ships (especially the Punisher) much less prone to getting affected by the ion damage of Skylances while they're still well above the disabled threshold

If my math is correct, these current values should reduce the ion damage the Neutralizer takes to 90% of the total value, the ion damage the Interdictor to ~83% of the total value, and the Punisher should take ~77% of the total ion damage.

Values aren't definitive obviously and will probably change.