### PR TITLE
Revamped the Hunted mission to improve the mechanic of bounty hunters

### DIFF
--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -3032,7 +3032,7 @@ mission "Bounty Hunting (Marauder X)"
 		random < 5
 	npc kill
 		government "Bounty"
-		personality heroic unconstrained waiting nemesis plunders harvests
+		personality heroic unconstrained staying nemesis target
 		system
 			distance 1 3
 		fleet "Marauder fleet X"
@@ -3042,3 +3042,146 @@ mission "Bounty Hunting (Marauder X)"
 	on complete
 		payment 750000
 		dialog phrase "generic fleet bounty hunting payment dialog"
+
+
+
+mission "Hunted Warning"
+	invisible
+	landing
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
+	to offer
+		"combat rating" > 8103
+		or
+			not "chosen sides"
+			has "main plot completed"
+	on offer
+		log `Got noticed at a spaceport bar as a "famous warrior." Was warned to watch for pirates looking to make a name for themselves or bounty hunters looking to claim a bounty.`
+		conversation
+			`You walk into a bar in the spaceport looking for something to eat when a man sitting at a table in the corner looks up and takes notice of you. "It's Captain <last>, the famous warrior! Barkeep, give <first> a drink on my tab."`
+			choice
+				`	"Glad to get some recognition. I work hard out here."`
+					goto recognition
+				`	"Famous warrior?"`
+			`	"Of course! Word travels fast in the galaxy, and word on the hyperspace lanes is that you're quite the fighter."`
+			
+			branch recognition
+				"reputation: Republic" >= 0
+				"reputation: Free Worlds" >= 0
+				"reputation: Syndicate" >= 0
+			
+			`	"It doesn't help that you've pissed off the law, either," someone says, not sounding too happy.`
+			label recognition
+			`	More of the patrons of the bar begin to notice that you've entered and begin chattering amongst themselves. "Quite the force to be reckoned with, I've heard," you overhear one of them mumble.`
+			`	"You might want to watch your back," another says to you. "Plenty of pirates looking to make a name for themselves taking out such a famous captain, and plenty of bounty hunters out for a bounty you might have on your head without even knowing about it."`
+			choice
+				`	"I'll be fine. My ship is strong enough to stand against anything."`
+				`	"Maybe I should go into hiding for a while."`
+					goto hide
+			`	"Oh, I'm sure it is. You wouldn't have gotten this notorious if you weren't able to hold your all."`
+				goto end
+			label hide
+			`	"You'd need to hide for more than just a while, but laying low in a small ship might help to stay off the radar of any bounty hunters."`
+			label end
+			`	After a few more minutes of mumbling, the bar returns to like it was before you entered. The food you ordered arrives and you dig in.`
+				decline
+
+mission "Hunted"
+	invisible
+	landing
+	deadline 30
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
+	to offer
+		"combat rating" > 8103
+		# Below 1000 DPS.
+		# A single stock T1 interceptor deals about 300 to 750 DPS.
+		"armament detterence" >= 2
+		random < 3
+		or
+			not "chosen sides"
+			has "main plot completed"
+	npc save
+		# Somewhere between 1000 and 1500 DPS.
+		# A single stock T1 light warship deals about 500 to 1.5k DPS.
+		to despawn
+			or
+				"armament deterrence" < 2
+				"armament deterrance" >= 3
+		government "Bounty Hunter"
+		personality heroic unconstrained waiting nemesis plunders harvests
+		system
+			distance 5 5
+		# Some interceptors, maybe one light or medium warship.
+		fleet "Bounty Hunters"
+	npc save
+		# Somewhere between 1500 and 2000 DPS.
+		# A single stock T1 medium warship deals about 1.5k to 2k DPS.
+		to despawn
+			or
+				"armament deterrence" < 3
+				"armament deterrance" >= 4
+		government "Bounty Hunter"
+		personality heroic unconstrained waiting nemesis plunders harvests
+		system
+			distance 5 5
+		# Typically a Marauder LW + 2 Marauder Interceptors.
+		fleet "Marauder fleet I"
+	npc save
+		# Somewhere between 2000 and 4000 DPS.
+		# A single stock T1 heavy warship deals about 2k to 4k DPS.
+		to despawn
+			or
+				"armament deterrence" < 4
+				"armament deterrance" >= 8
+		government "Bounty Hunter"
+		personality heroic unconstrained waiting nemesis plunders harvests
+		system
+			distance 5 5
+		# Typically a Marauder MW + 2 Marauder LWs.
+		fleet "Marauder fleet IV"
+	npc save
+		# Somewhere between 4000 and 8000 DPS.
+		# A single stock T2 heavy warship deals about 5k to 6k DPS.
+		to despawn
+			or
+				"armament deterrence" < 8
+				"armament deterrance" >= 16
+		government "Bounty Hunter"
+		personality heroic unconstrained waiting nemesis plunders harvests
+		system
+			distance 5 5
+		# A Marauder HW + 3 MWs.
+		fleet "Marauder fleet VII"
+	npc save
+		# Greater than 8000 DPS.
+		# A single stock Heliarch Punisher deals almost 10k DPS.
+		# A single Quarg ship or Pug Arfecta deals almost 11k DPS.
+		to despawn
+			"armament deterrence" < 16
+		government "Bounty Hunter"
+		personality heroic unconstrained waiting nemesis plunders harvests
+		system
+			distance 5 5
+		# A fleet of Marauder vessels.
+		fleet "Marauder fleet X"
+	npc save
+		# Greater than 16000 DPS.
+		to despawn
+			"armament deterrence" < 32
+		government "Bounty Hunter"
+		personality heroic unconstrained waiting nemesis plunders harvests
+		system
+			distance 5 5
+		fleet "Marauder fleet X"
+	npc save
+		# Greater than 32000 DPS.
+		to despawn
+			"armament deterrence" < 64
+		government "Bounty Hunter"
+		personality heroic unconstrained waiting nemesis plunders harvests
+		system
+			distance 5 5
+		fleet "Marauder fleet X"

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -3100,6 +3100,7 @@ mission "Hunted"
 		# A single stock T1 interceptor deals about 300 to 750 DPS.
 		"armament detterence" >= 2
 		random < 3
+		not "Hunted: active"
 		or
 			not "chosen sides"
 			has "main plot completed"
@@ -3160,14 +3161,16 @@ mission "Hunted"
 		# A single stock Heliarch Punisher deals almost 10k DPS.
 		# A single Quarg ship or Pug Arfecta deals almost 11k DPS.
 		to despawn
-			"armament deterrence" < 16
+			or
+				"armament deterrence" < 16
+				"armament deterrence" >= 64
 		government "Bounty Hunter"
 		personality heroic unconstrained waiting nemesis plunders harvests
 		system
 			distance 5 5
 		# A fleet of Marauder vessels.
 		fleet "Marauder fleet X"
-	npc save
+	npc kill
 		# Greater than 16000 DPS.
 		to despawn
 			"armament deterrence" < 32
@@ -3176,7 +3179,7 @@ mission "Hunted"
 		system
 			distance 5 5
 		fleet "Marauder fleet X"
-	npc save
+	npc kill
 		# Greater than 32000 DPS.
 		to despawn
 			"armament deterrence" < 64
@@ -3184,4 +3187,4 @@ mission "Hunted"
 		personality heroic unconstrained waiting nemesis plunders harvests
 		system
 			distance 5 5
-		fleet "Marauder fleet X"
+		fleet "Marauder fleet X" 2

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -3105,7 +3105,7 @@ mission "Hunted"
 			not "chosen sides"
 			has "main plot completed"
 	npc save
-		# Somewhere between 1000 and 1500 DPS.
+		# Between 1000 and 1500 DPS.
 		# A single stock T1 light warship deals about 500 to 1.5k DPS.
 		to despawn
 			or
@@ -3118,7 +3118,7 @@ mission "Hunted"
 		# Some interceptors, maybe one light or medium warship.
 		fleet "Bounty Hunters"
 	npc save
-		# Somewhere between 1500 and 2000 DPS.
+		# Between 1500 and 2000 DPS.
 		# A single stock T1 medium warship deals about 1.5k to 2k DPS.
 		to despawn
 			or
@@ -3131,7 +3131,7 @@ mission "Hunted"
 		# Typically a Marauder LW + 2 Marauder Interceptors.
 		fleet "Marauder fleet I"
 	npc save
-		# Somewhere between 2000 and 4000 DPS.
+		# Between 2000 and 4000 DPS.
 		# A single stock T1 heavy warship deals about 2k to 4k DPS.
 		to despawn
 			or
@@ -3144,7 +3144,7 @@ mission "Hunted"
 		# Typically a Marauder MW + 2 Marauder LWs.
 		fleet "Marauder fleet IV"
 	npc save
-		# Somewhere between 4000 and 8000 DPS.
+		# Between 4000 and 8000 DPS.
 		# A single stock T2 heavy warship deals about 5k to 6k DPS.
 		to despawn
 			or
@@ -3157,13 +3157,13 @@ mission "Hunted"
 		# A Marauder HW + 3 MWs.
 		fleet "Marauder fleet VII"
 	npc save
-		# Greater than 8000 DPS.
+		# Between than 8000 and 16000 DPS.
 		# A single stock Heliarch Punisher deals almost 10k DPS.
 		# A single Quarg ship or Pug Arfecta deals almost 11k DPS.
 		to despawn
 			or
 				"armament deterrence" < 16
-				"armament deterrence" >= 64
+				"armament deterrence" >= 32
 		government "Bounty Hunter"
 		personality heroic unconstrained waiting nemesis plunders harvests
 		system
@@ -3178,7 +3178,7 @@ mission "Hunted"
 		personality heroic unconstrained waiting nemesis plunders harvests
 		system
 			distance 5 5
-		fleet "Marauder fleet X"
+		fleet "Marauder fleet X" 2
 	npc kill
 		# Greater than 32000 DPS.
 		to despawn
@@ -3187,4 +3187,4 @@ mission "Hunted"
 		personality heroic unconstrained waiting nemesis plunders harvests
 		system
 			distance 5 5
-		fleet "Marauder fleet X" 2
+		fleet "Marauder fleet X"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This PR readds bounty hunters that track the player down should their combat rating be high enough, but with some important differences. Below is a table comparing raid fleets (which I think are a well done mechanic) with the hunted fleets new and old. The things mentioned about raid fleets are things that I think make raid fleets a good mechanic, while the things mentioned about the old hunted fleets are why I think they were bad. Although not all of these aspects have changed for the new hunted fleets, I think that the most important ones have been touched on and improved, namely the fact that hunted fleets were never introduced, did not scale with the player, and were unavoidable.

Raid Fleets | Hunted Fleets (Old) | Hunted Fleets (New)
----|----|----
Balances snowballing freighter fleets. | Balances against nothing. | Balances against nothing.
You're told of their existence during the (Star Barge) intro. | You're never told of their existence. | You're told of their existence upon being able to trigger them.
Can be avoided by reducing your cargo space or increasing your DPS (or becoming friendly with pirates). | Can not be avoided, only confronted. | Can be avoided by changing your DPS out of the range of the NPC spawns, or by fleeing them for 30 days.
Uses the Pirate government, meaning you can get help from nearby NPCs. | Uses the bounty hunter government, meaning only the player can combat them. | Uses the bounty hunter government.
Scale with the player by spawning more fleets according to how attractive your fleet is. | Do not scale with the player. | Scale with the player by spawning stronger fleets according to your fleet DPS.
The player info screen tells you how likely you are to spawn a raid fleet. | Raid fleets always have a 3% chance to spawn on landing in human space, unknown to the player. | 3% chance on landing, unknown to the player.
There is an indication when they spawn (a message at the bottom left upon entering the system). | No indication of when they spawn (aside from getting shot at). | No indication of when they spawn.

## Save File
Just have a combat rating of 9 or above and land anywhere while the main campaign is not active and you should get the conversation warning you about bounty hunters.

## PR Checklist
 - ~~I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
 - ~~I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}~~
 - ~~I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~