### PR TITLE
Fix "Ringworld Debris" completion to stop it from prematurely completing

### DIFF
--- a/data/ka'het/ka'het missions.txt
+++ b/data/ka'het/ka'het missions.txt
@@ -103,10 +103,9 @@ mission "Ringworld Debris"
 			scene "scene/ringworld debris"
 			`	In one particular corner you see that there is a small, barely recognizable tube, badly damaged but with a few intact wires creeping out. After tinkering a bit with the wires you manage to connect the debris to your ship's secondary power systems. It barely uses any energy at all, but you can feel the air around it starting to get slightly colder.`
 			`	You unplug it and store the debris in a separate part of your ship. Maybe some alien species could tell you about it, if you were to bring it to them.`
+		fail
 	to complete
 		never
-	to fail
-		has "ringworld debris"
 
 mission "Ringworld Debris: Remnant"
 	invisible

--- a/data/ka'het/ka'het missions.txt
+++ b/data/ka'het/ka'het missions.txt
@@ -95,6 +95,7 @@ mission "First Contact: Ka'het: Remnant 1B"
 mission "Ringworld Debris"
 	invisible
 	landing
+	waypoint "Queri"
 	on enter "Queri"
 		set "ringworld debris"
 		conversation

--- a/data/ka'het/ka'het missions.txt
+++ b/data/ka'het/ka'het missions.txt
@@ -95,7 +95,6 @@ mission "First Contact: Ka'het: Remnant 1B"
 mission "Ringworld Debris"
 	invisible
 	landing
-	waypoint "Queri"
 	on enter "Queri"
 		set "ringworld debris"
 		conversation
@@ -104,6 +103,10 @@ mission "Ringworld Debris"
 			scene "scene/ringworld debris"
 			`	In one particular corner you see that there is a small, barely recognizable tube, badly damaged but with a few intact wires creeping out. After tinkering a bit with the wires you manage to connect the debris to your ship's secondary power systems. It barely uses any energy at all, but you can feel the air around it starting to get slightly colder.`
 			`	You unplug it and store the debris in a separate part of your ship. Maybe some alien species could tell you about it, if you were to bring it to them.`
+	to complete
+		never
+	to fail
+		has "ringworld debris"
 
 mission "Ringworld Debris: Remnant"
 	invisible


### PR DESCRIPTION
**Bugfix**

## Fix Details
This bug fix prevents Ringworld Debris from being prematurely completed by landing on the first planet you took off from after the mission was added, likely New Boston for new pilots. Additionally, this PR makes entering Queri fail the mission, to clear it out of the save file after it has been used.

## Testing Done
I've tested that the mission offers properly, that you can't prematurely complete it, that the conversation still triggers and that the mission goes away after collecting the debris.

