### PR TITLE
Rename Defend to Retreat in boarding panel

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -645,7 +645,7 @@ interface "boarding"
 		from 330 -22
 		align right
 	
-	label "survival odds (defending):"
+	label "survival odds (retreating):"
 		from 50 8
 		align left
 	string "defense odds"
@@ -679,7 +679,7 @@ interface "boarding"
 		dimensions 80 30
 	
 	active if "can defend"
-	button d "_Defend"
+	button d "_Retreat"
 		center 210 185
 		dimensions 80 30
 

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -304,7 +304,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		}
 		isCapturing = true;
 		messages.push_back("The airlock blasts open. Combat has begun!");
-		messages.push_back("(It will end if you both choose to \"defend.\")");
+		messages.push_back("(It will end if you kill their crew, or retreat.)");
 	}
 	else if((key == 'a' || key == 'd') && CanAttack())
 	{
@@ -324,7 +324,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		// If neither side attacks, combat ends.
 		if(!youAttack && !enemyAttacks)
 		{
-			messages.push_back("You retreat to your ships. Combat ends.");
+			messages.push_back("You successfully retreat. Combat ends.");
 			isCapturing = false;
 		}
 		else
@@ -332,7 +332,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 			if(youAttack)
 				messages.push_back("You attack. ");
 			else if(enemyAttacks)
-				messages.push_back("You defend. ");
+				messages.push_back("Retreat failed! ");
 			
 			// To speed things up, have multiple rounds of combat each time you
 			// click the button, if you started with a lot of crew.


### PR DESCRIPTION
## Feature Details
This PR renames Defend and associated labels, to Retreat for the boarding. After dozens of hours for my first playthrough, I never once clicked the "Defend" button when boarding ships, and the name perplexed me. It gave the impression that boarding was more of a symmetrical mini game, and that, somehow, this panel might appear if an enemy boards me. However, "Defending" is only something done when you are very in over your head, or are familiar with the game and are trying to get lucky. Normal players are given the odds, and would rarely attempt an attack where a retreat would be unsuccessful, as a situation where defending/retreating is unlikely would have attacking be very unlikely.

Renaming it to "Retreat" would make it much more in-line with the experience of most players, and make it less confusing. If also accepted, I'd be willing to update variable/function/comment names, but for now, I just went with the player-side text.

## UI Screenshots
![retreat](https://user-images.githubusercontent.com/4471575/90581970-32ae9b00-e192-11ea-9baa-4c378badc7f5.png)
