### PR TITLE
Fix minor typo in infant void sprite description

### DIFF
--- a/data/drak/indigenous.txt
+++ b/data/drak/indigenous.txt
@@ -128,7 +128,7 @@ ship "Void Sprite" "Void Sprite (Infant)"
 	leak "blood" 60 50
 	explode "blood" 25
 	"final explode" "void sprite infant death"
-	description "This is the immature form of the void sprite. While they typically rely on their tendrils and natural boyancy to fly within atmospheres, they have demonstrated the unusual ability to manipulate gravitational fields to propel themselves off-world."
+	description "This is the immature form of the void sprite. While they typically rely on their tendrils and natural buoyancy to fly within atmospheres, they have demonstrated the unusual ability to manipulate gravitational fields to propel themselves off-world."
 
 effect "void sprite infant death"
 	sprite "effect/void sprite infant death"


### PR DESCRIPTION
Referenced in https://discordapp.com/channels/251118043411775489/536900466655887360/746482315663900692 on the ES discord

-----------------------
**Bugfix:** This PR addresses issue  https://discordapp.com/channels/251118043411775489/536900466655887360/746482315663900692

## Fix Details
Fixed the typo. That's all really

## Testing Done
Compiled and verified that the change took place
