### PR TITLE
bugfix: Allow calling PlayerInfo::SetTravelDestination with nullptr planet

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1927,7 +1927,7 @@ const Planet *PlayerInfo::TravelDestination() const
 void PlayerInfo::SetTravelDestination(const Planet *planet)
 {
 	travelDestination = planet;
-	if(planet->IsInSystem(system) && Flagship())
+	if(planet && planet->IsInSystem(system) && Flagship())
 		Flagship()->SetTargetStellar(system->FindStellar(planet));
 }
 


### PR DESCRIPTION
**Bugfix:** This PR addresses a null-pointer issue found during the development of #4370

## Fix Details
Calling PlayerInfo::SetTravelDestination with a nullpointer as planet causes a null-pointer-derefence. This PR addresses the null-pointer-dereference by first checking if the pointer is not null.

## Testing Done
Tested during #4370.
The game keeps planet-travel-destinations until a new planet-travel destination gets set. A follow-up PR might be desirable to make sure that the travel-destination gets cleared when the player switches navigation to a new system (this larger fix is not included in this PR).

## Save File
N/A (An older version of #4370 is required to trigger the issue seen here)
