### PR TITLE
Update the Pilot's License description

### DIFF
--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -402,7 +402,7 @@ outfit "Pilot's License"
 	category "Special"
 	cost 50000
 	thumbnail "outfit/license"
-	description "Decades ago, starship pilots used to be able to fly through the sky without needing to worry about getting any sort of license. However, recent Republic legislation led to the creation of pilot's licenses, which still let you have all the freedoms captains had previously... if you can cough up the money for it. Needless to say, this system is not terribly popular with freelance merchant captains."
+	description "Decades ago, starship pilots used to be able to fly without any sort of license. However, recent Republic legislation has led to the creation of pilot's licenses, which still permit all the freedoms captains had previously... if you can cough up the money for it. Needless to say, this system is not terribly popular with freelance merchant captains."
 
 outfit "Navy License"
 	category "Special"

--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -402,7 +402,7 @@ outfit "Pilot's License"
 	category "Special"
 	cost 50000
 	thumbnail "outfit/license"
-	description "Decades ago, starship pilots used to be able to fly through the sky without needing to worry about getting any sort of license. However, recent Republic legislation led to the creation of pilot's licenses, which still let you have all the freedoms captains had previously... if you can pay for it. Needless to say, this system is not terribly popular with freelance merchant captains."
+	description "Decades ago, starship pilots used to be able to fly through the sky without needing to worry about getting any sort of license. However, recent Republic legislation led to the creation of pilot's licenses, which still let you have all the freedoms captains had previously... if you can cough up the money for it. Needless to say, this system is not terribly popular with freelance merchant captains."
 
 outfit "Navy License"
 	category "Special"

--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -402,7 +402,7 @@ outfit "Pilot's License"
 	category "Special"
 	cost 50000
 	thumbnail "outfit/license"
-	description "Without a pilot's license, you cannot purchase a ship on a Republic planet. And if you buy an unlicensed ship on another planet and then bring it into Republic space, you can be fined until you cough up the money for a license. Needless to say, this policy is not terribly popular with freelance merchant captains."
+	description "Decades ago, starship pilots used to be able to fly through the sky without needing to worry about getting any sort of license. However, recent Republic legislation led to the creation of pilot's licenses, which still let you have all the freedoms captains had previously... if you can pay for it. Needless to say, this system is not terribly popular with freelance merchant captains."
 
 outfit "Navy License"
 	category "Special"

--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -402,7 +402,7 @@ outfit "Pilot's License"
 	category "Special"
 	cost 50000
 	thumbnail "outfit/license"
-	description "Decades ago, starship pilots used to be able to fly without any sort of license. However, recent Republic legislation has led to the creation of pilot's licenses, which still permit all the freedoms captains had previously... if you can cough up the money for it. Needless to say, this system is not terribly popular with freelance merchant captains."
+	description "For much of the Republic's nearly three century long history, being able to pilot your own starship was limited only by your ability to purchase one. But at the turn of the millennium in an attempt to increase tax revenue, the Republic Parliament passed a law requiring that all ship captains purchase a pilot's license, and for no small fee at that. Needless to say, this policy is not terribly popular with freelance merchant captains."
 
 outfit "Navy License"
 	category "Special"


### PR DESCRIPTION
This PR removes the references to needing to license ships and fines incurring to ships you don't have a license for, and replaces it with a description of how Parliament is restricting the freedoms of pilots.