### PR TITLE
Thrust multiplier

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -879,7 +879,7 @@ vector<string> Ship::FlightCheck() const
 	double afterburner = (attributes.Get("afterburner thrust") * (1. + attributes.Get("thrust multiplier")));
 	double thrustEnergy = (attributes.Get("thrusting energy") * (1. + attributes.Get("thrusting energy multiplier")));
 	double turn = (attributes.Get("turn") * (1. + attributes.Get("turn multiplier")));
-	double turnEnergy = (attributes.Get("turning energy") * (1. + attributes.Get("turning energy multiplier")));
+	double turnEnergy = (attributes.Get("turning energy") * (1. + attributes.Get("thrust energy multiplier")));
 	double hyperDrive = attributes.Get("hyperdrive");
 	double jumpDrive = attributes.Get("jump drive");
 	

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -875,11 +875,11 @@ vector<string> Ship::FlightCheck() const
 	double fuelCapacity = attributes.Get("fuel capacity");
 	double fuel = fuelCapacity + fuelChange;
 	double thrust = (attributes.Get("thrust") * (1. + attributes.Get("thrust multiplier")));
-	double reverseThrust = attributes.Get("reverse thrust");
-	double afterburner = attributes.Get("afterburner thrust");
-	double thrustEnergy = attributes.Get("thrusting energy");
-	double turn = attributes.Get("turn");
-	double turnEnergy = attributes.Get("turning energy");
+	double reverseThrust = (attributes.Get("reverse thrust") * (1. + attributes.Get("thrust multiplier")));
+	double afterburner = (attributes.Get("afterburner thrust") * (1. + attributes.Get("thrust multiplier")));
+	double thrustEnergy = (attributes.Get("thrusting energy") * (1. + attributes.Get("thrusting energy multiplier")));
+	double turn = (attributes.Get("turn") * (1. + attributes.Get("turn multiplier")));
+	double turnEnergy = (attributes.Get("turning energy") * (1. + attributes.Get("turning energy multiplier")));
 	double hyperDrive = attributes.Get("hyperdrive");
 	double jumpDrive = attributes.Get("jump drive");
 	

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -874,7 +874,7 @@ vector<string> Ship::FlightCheck() const
 	double fuelChange = attributes.Get("fuel generation") - attributes.Get("fuel consumption");
 	double fuelCapacity = attributes.Get("fuel capacity");
 	double fuel = fuelCapacity + fuelChange;
-	double thrust = attributes.Get("thrust");
+	double thrust = (attributes.Get("thrust") * (1. + attributes.Get("thrust multiplier")));
 	double reverseThrust = attributes.Get("reverse thrust");
 	double afterburner = attributes.Get("afterburner thrust");
 	double thrustEnergy = attributes.Get("thrusting energy");


### PR DESCRIPTION
-----------------------
**Feature:** Thrust multipliers

## Summary
I've edited the game's thrust mechanics to have multipliers analogous to the "shield generation multiplier" and "shield energy multiplier". The new attributes are:
"thrust multiplier"
"turn multiplier"
"thrusting energy multiplier"

## Save File
[Plugin file hosted on Discord. There's a new outfit for sale in Tarazed called the "Park and Preen" that uses these new mechanics.](https://cdn.discordapp.com/attachments/375355335369687054/750056207816851576/Shipmod.7z)

## Usage Examples
Intended to be used with "ship mod" outfits - limited-installation outfits that provide upgrades or tweaks to the ship's overall performance.

## Testing Done
Testing will be done in a few minutes.
