### PR TITLE
Fix: Changing Alpha Combat Values to be better than the Navy's

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -10,8 +10,8 @@
 
 government "Alpha"
 	swizzle 1
-	"crew attack" 8
-	"crew defense" 6
+	"crew attack" 5
+	"crew defense" 4
 	"player reputation" -1000
 	"bribe" 0
 

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -10,8 +10,8 @@
 
 government "Alpha"
 	swizzle 1
-	"crew attack" 1.4
-	"crew defense" 2.2
+	"crew attack" 8
+	"crew defense" 6
 	"player reputation" -1000
 	"bribe" 0
 

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -10,8 +10,8 @@
 
 government "Alpha"
 	swizzle 1
-	"crew attack" 3
-	"crew defense" 3
+	"crew attack" 1.5
+	"crew defense" 2.5
 	"player reputation" -1000
 	"bribe" 0
 

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -10,8 +10,8 @@
 
 government "Alpha"
 	swizzle 1
-	"crew attack" 5
-	"crew defense" 4
+	"crew attack" 3
+	"crew defense" 3
 	"player reputation" -1000
 	"bribe" 0
 


### PR DESCRIPTION
**Bugfix:** This PR addresses the fact that Alpha Hand to Hand combat values are equal to that of a Navy soldier, despite being described as worth several of them.

## Fix Details
Attack from 1.4 up to 3
Defense from 2.2 up to 3

Biologically, Alphas are supposed to be super-soldiers, engineered to be perfect warriors; Most of the description revolves around the physical, but there are hints here and there that it is mental as well.

Socially, the current Alphas are portrayed as veteran survivors who are aggressive guerrilla warfare specialists and stealth operators. They are described in the lore as one Alpha as being worth several Navy soldiers. This implies that they are experienced, well trained, and combat-hardened. It is worth noting that even when the Navy is forwarned and can bring their elite forces to bear, they still expect to need ten soldiers for every one alpha. 

The stats are intended to represent a combination of being biologically a "perfect warrior" as well as considerable combat experience and training. 

The values are arbitrary. They look good enough to be impressive, but not so high as to be insurmountable. They should make capturing Alpha ships significantly harder without making them impossible.

edit: Values changed to 3 for each. This is intended to represent the fact that not all Alpha crew are actually Alpha's. They may have a number of pirates and/or slaves too. (especially for cannon-fodder roles) I personally think it is likely that all the *required* crew is Alphas, and that extra is canon-fodder; but we really have no insight into Alpha society.

On the one hand, if they are super-egotistical then an Alpha wouldn't want to be subordinate to another, and thus they would need to have lots of slaves to fill the roles under a small set of Alphas. 
On the other hand, they were engineered to be perfect soldiers. Perfect soldiers implies being perfect members of an army, which involves a large numbers of people working together for optimum combat effectiveness. If this is the case, then they would see relying on slaves as a weakness, since no slave would be able to perform at the level of an Alpha, and thus would be a detriment to the ship.

## Impact
Giftbringer is going to be harder to capture, as is any other Alpha ships we happen to run into during future stories; but otherwise the impact is minimal. The largest impact will simply be people no longer looking at the combat stats and going "But aren't Alpha's supposed to be *better* than Navy Soldiers?"