### PR TITLE
Typo fix for the planet Babiali

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -25853,7 +25853,7 @@ planet Aventine
 planet Babiali
 	attributes "ice giant" uninhabited
 	landscape land/canyon12
-	description `Babiali surface is a bona fide example of cataclysm. Ice and rock extends from horizon to horizon, with vast networks of cracks and fissures suggesting it was subject to some kind of sudden force fairly recently in its geological history.`
+	description `Babiali's surface is a bona fide example of cataclysm. Ice and rock extends from horizon to horizon, with vast networks of cracks and fissures suggesting it was subject to some kind of sudden force fairly recently in its geological history.`
 	description `	At present, Babiali has a regular stream of mining and research craft systematically flying over the crust looking for rare metals or anything else of value. Despite the activity, no one has bothered to set up anything resembling a spaceport.`
 	security 0
 	government Uninhabited


### PR DESCRIPTION
**Feature:** Typo fix

## Feature Details
Added a missing apostrophe-s to Babiali's planet description.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Made the same changes to my map.txt and tested it in-game. All works properly.

## Performance Impact
N/A
