### PR TITLE
Fix: Adds a description for Archons

### DIFF
--- a/data/drak/drak.txt
+++ b/data/drak/drak.txt
@@ -234,8 +234,8 @@ ship "Archon"
 	turret 55 16 "Drak Distancer"
 	explode "nuke explosion" 3
 	"final explode" "final explosion large"
-	description "Very little is know about Archons other than that they significantly exceed the spacefaring prowess of any known species. From external observation, they appear to be a mix of organic and cybernetic elements. They are known to guard noteworthy locations and seem focused on guarding sapient species or the remains thereof."
-	description "It is unknown whether Archons are grown, created, or raised. Likewise, while they are identified as 'Drak' by most IFF systems, it is unknown whether or not they are Drak, are merely servants or agents of the Drak, or if the labeling is completely erroneous."
+	description "Very little is know about Archons other than that they significantly exceed the spacefaring prowess of any known species. From external observation, they appear to be a mix of organic and cybernetic elements. They are known to guard noteworthy locations and sapient species or the remains thereof."
+	description "It is unknown whether Archons are grown, created, or raised. Likewise, while they are identified as 'Drak' by most IFF systems, it is unknown whether or not they are Drak, servants or agents of the Drak, or another thing entirely."
 
 ship "Archon" "Archon B"
 	"never disabled"

--- a/data/drak/drak.txt
+++ b/data/drak/drak.txt
@@ -234,6 +234,8 @@ ship "Archon"
 	turret 55 16 "Drak Distancer"
 	explode "nuke explosion" 3
 	"final explode" "final explosion large"
+	description "Very little is know about Archons other than that they significantly exceed the spacefaring prowess of any known species. From external observation, they appear to be a mix of organic and cybernetic elements. They are known to guard noteworthy locations and seem focused on guarding sapient species or the remains thereof."
+	description "It is unknown whether Archons are grown, created, or raised. Likewise, while they are identified as 'Drak' by most IFF systems, it is unknown whether or not they are Drak, are merely servants or agents of the Drak, or if the labeling is completely erroneous."
 
 ship "Archon" "Archon B"
 	"never disabled"

--- a/data/drak/drak.txt
+++ b/data/drak/drak.txt
@@ -234,8 +234,7 @@ ship "Archon"
 	turret 55 16 "Drak Distancer"
 	explode "nuke explosion" 3
 	"final explode" "final explosion large"
-	description "Very little is known about Archons other than that they significantly exceed the spacefaring prowess of any known species. From external observation, they appear to be a mix of organic and cybernetic elements. They are known to guard noteworthy locations and sapient species - or the remains thereof."
-	description "	It is unknown whether Archons are grown, created, or raised. Likewise, while they are identified as 'Drak' by most ships' identification systems, it is unknown whether or not they are Drak, servants or agents of the Drak, or another thing entirely."
+	description `The Archon's presence is chilling. The "ship" has an almost organic appearance, but your ship's scanners give you no discernible information on its construction. What exactly it is you do not know, but you can feel that it is powerful.`
 
 ship "Archon" "Archon B"
 	"never disabled"

--- a/data/drak/drak.txt
+++ b/data/drak/drak.txt
@@ -235,7 +235,7 @@ ship "Archon"
 	explode "nuke explosion" 3
 	"final explode" "final explosion large"
 	description "Very little is know about Archons other than that they significantly exceed the spacefaring prowess of any known species. From external observation, they appear to be a mix of organic and cybernetic elements. They are known to guard noteworthy locations and sapient species or the remains thereof."
-	description "It is unknown whether Archons are grown, created, or raised. Likewise, while they are identified as 'Drak' by most IFF systems, it is unknown whether or not they are Drak, servants or agents of the Drak, or another thing entirely."
+	description "	It is unknown whether Archons are grown, created, or raised. Likewise, while they are identified as 'Drak' by most IFF systems, it is unknown whether or not they are Drak, servants or agents of the Drak, or another thing entirely."
 
 ship "Archon" "Archon B"
 	"never disabled"

--- a/data/drak/drak.txt
+++ b/data/drak/drak.txt
@@ -234,8 +234,8 @@ ship "Archon"
 	turret 55 16 "Drak Distancer"
 	explode "nuke explosion" 3
 	"final explode" "final explosion large"
-	description "Very little is know about Archons other than that they significantly exceed the spacefaring prowess of any known species. From external observation, they appear to be a mix of organic and cybernetic elements. They are known to guard noteworthy locations and sapient species or the remains thereof."
-	description "	It is unknown whether Archons are grown, created, or raised. Likewise, while they are identified as 'Drak' by most IFF systems, it is unknown whether or not they are Drak, servants or agents of the Drak, or another thing entirely."
+	description "Very little is known about Archons other than that they significantly exceed the spacefaring prowess of any known species. From external observation, they appear to be a mix of organic and cybernetic elements. They are known to guard noteworthy locations and sapient species - or the remains thereof."
+	description "	It is unknown whether Archons are grown, created, or raised. Likewise, while they are identified as 'Drak' by most ships' identification systems, it is unknown whether or not they are Drak, servants or agents of the Drak, or another thing entirely."
 
 ship "Archon" "Archon B"
 	"never disabled"


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5273 

## Fix Details
This adds a description to Archons.

This fixes #5273 

Thanks to McloughlinGuy for reporting it.

## Lore Implications
- This PR does not attempt to resolve any of the debate/questions surrounding the Archons and the Drak, instead codifying it so that it is clear that this isn't just players being confused - their pilot (and humanity in general) is equally confused as to what exactly the Archons are.