### PR TITLE
Fix: Adding two missing spaces in Remnant Friendly phrases

### DIFF
--- a/data/remnant/remnant.txt
+++ b/data/remnant/remnant.txt
@@ -376,8 +376,8 @@ phrase "friendly remnant"
 		"last month"
 		"last year"
 	word
-		"."
-		"!"
+		". "
+		"! "
 	word
 		"Luckily"
 		"Fortunately"


### PR DESCRIPTION
**Bugfix:** 

## Fix Details
Adding two missing spaces.
