### PR TITLE
Feat: Realtime hailing

### DIFF
--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -309,6 +309,13 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 
 
 
+bool HailPanel::IsModal() const
+{
+	return true;
+}
+
+
+
 void HailPanel::SetBribe(double scale)
 {
 	// Find the total value of your fleet.

--- a/source/HailPanel.h
+++ b/source/HailPanel.h
@@ -40,6 +40,9 @@ public:
 	
 	virtual void Draw() override;
 	
+	// The hailpanel on the stack doesn't pause the game.
+	virtual bool IsModal() const override;
+	
 	
 protected:
 	// Only override the ones you need; the default action is to return false.

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -64,7 +64,12 @@ void MainPanel::Step()
 	
 	// Depending on what UI element is on top, the game is "paused." This
 	// checks only already-drawn panels.
-	bool isActive = GetUI()->IsTop(this);
+	bool isActive = false;
+	{
+		shared_ptr<Panel> topPanel = GetUI()->Top();
+		if(topPanel)
+			isActive = topPanel->IsModal();
+	}
 	
 	// Display any requested panels.
 	if(show.Has(Command::MAP))
@@ -191,6 +196,13 @@ void MainPanel::OnCallback()
 	// Start the next step of the simulation because Step() above still
 	// thinks the planet panel is up and therefore will not start it.
 	engine.Go();
+}
+
+
+
+bool MainPanel::IsModal() const
+{
+	return true;
 }
 
 

--- a/source/MainPanel.h
+++ b/source/MainPanel.h
@@ -42,6 +42,9 @@ public:
 	// Send a command to the engine (on behalf of the player).
 	void GiveCommand(const Command &command);
 
+	// The mainpanel on the stack doesn't pause the game.
+	virtual bool IsModal() const override;
+
 	// The main panel allows fast-forward.
 	virtual bool AllowFastForward() const override;
 	

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -65,6 +65,16 @@ bool Panel::TrapAllEvents()
 
 
 
+// Check if this panel is modal, which means that the gameloop in the main
+// engine would continue running if this panel is active. Panels are by
+// default not modal.
+bool Panel::IsModal() const
+{
+	return false;
+}
+
+
+
 // Check if this panel can be "interrupted" to return to the main menu.
 bool Panel::IsInterruptible() const
 {

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -49,6 +49,10 @@ public:
 	// Return true if, when this panel is on the stack, no events should be
 	// passed to any panel under it. By default, all panels do this.
 	bool TrapAllEvents();
+	// Check if this panel is modal, which means that the gameloop in the main
+	// engine would continue running if this panel is active. Panels are by
+	// default not modal.
+	virtual bool IsModal() const;
 	// Check if this panel can be "interrupted" to return to the main menu.
 	bool IsInterruptible() const;
 	


### PR DESCRIPTION
**Feature:** This PR implements a first step towards the feature discussed in issue #871

## Feature Details
This is the first step towards allowing the game-engine to continue running when certain panels are active. The panels get an IsModal function which will ensure that the game-engine is not paused when the function returns true.

The first panel that I'm testing this with is the HailPanel. With this PR the game-engine keeps running while the HailPanel is open. (And the planetary defence force launches while the panel still is open if you demand tribute. Note to self: don't ask tribute when being too close to the hailed planet.)

If this works well, then one of the next steps would be to update the BoardingPanel to run in real-time as well (which is the feature requested in #871).

The IsModal functionname was inspired by Tehhowchs remark in #2978.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
I need to review the HailPanel code a bit more and some more testing is required before this can be merged.

The main reviewing/testing that still is required is to check if the panel uses cached/static game-data, for example what happens if a ship gets hailed that then flies away, or if the player dies while the panel is open? Is the code in the HailPanel able to handle such situations?

The HailPanel is now also active while the event-loop is active. I also need to check if this gives undesirable interactions between those pieces of code.

## Performance Impact
No performance impact expected.