### PR TITLE
feat(mechanics): Support 'G' for billions.

### DIFF
--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -180,7 +180,7 @@ double Format::Parse(const string &str)
 			value *= 1e3;
 		else if(*it == 'm' || *it == 'M')
 			value *= 1e6;
-		else if(*it == 'b' || *it == 'B')
+		else if(*it == 'b' || *it == 'B' || *it == 'g' || *it == 'G')
 			value *= 1e9;
 		else if(*it == 't' || *it == 'T')
 			value *= 1e12;


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed ~in issue #{{insert number}}~ in this issue

## Feature Details
In the loan take/pay extra dialogs, allow specifying an amount in billions with `G`. (Format::Parse isn't used by anything else)

`G` denotes billions both in computers (e.g., GB of RAM) and in [SI prefixes](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes), and doesn't have any conflicting meaning.

## UI Screenshots
![2020-09-06-004135_255x129_scrot](https://user-images.githubusercontent.com/24784687/92315729-bf05ee00-efd9-11ea-994e-8aa2ab468647.png)

## Usage Examples
N/A

## Testing Done
Took a loan of `0.002G`, paid back `0.001G`.

## Performance Impact
N/A
