### PR TITLE
Fix: Remnant: Cognizance 4 - Changing sings to signs

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -2904,11 +2904,11 @@ mission "Remnant: Cognizance 4"
 			branch chilia
 				"remnant chilia" > 1
 			`The <ship> has barely come to a rest on its designated pad when your panel is blinking with a request for permission to come aboard. A glance at the viewscreen shows a fit young man with a military bearing standing at your airlock. You quickly check with the starport control and confirm that the prefect in charge of Remnant military activities is indeed waiting to board your ship. You hit the unlock button and watch as Prefect Chilia strides onboard.`
-			`	"Greetings, Captain <first>," he sings. "I am Prefect Chilia. I have the nominal responsibility for the overall defense of Remnant space and military operations." He smiles deprecatingly. "I say 'nominal' as virtually all our activities are military in some way, but usually fall under the purview of those who better understand them.`
+			`	"Greetings, Captain <first>," he signs. "I am Prefect Chilia. I have the nominal responsibility for the overall defense of Remnant space and military operations." He smiles deprecatingly. "I say 'nominal' as virtually all our activities are military in some way, but usually fall under the purview of those who better understand them.`
 				goto main
 			label chilia
 			`The <ship> has barely come to a rest on its designated pad when your panel is blinking with a request for permission to come aboard. A quick glance at the viewscreen shows Prefect Chilia standing at your airlock. You quickly hit the unlock button and watch as he strides onboard.`
-			`	"Greetings, Captain <first>," he sings. "You seem to have a knack for finding things of importance to us. I am glad, however, that you and Plume discovered this."`
+			`	"Greetings, Captain <first>," he signs. "You seem to have a knack for finding things of importance to us. I am glad, however, that you and Plume discovered this."`
 			label main
 			branch voidrifle
 				has "Remnant: Face to Maw 2B: done"


### PR DESCRIPTION
**Bugfix:**

## Fix Details
In Cognizance 4, Prefect Chilia exclusively signs. Note that there is no transition between this section and the later section describing how his gestures change with the topic of conversation. This is in contrast to his possible earlier introduction during Face-to-Maw where he sings.

Thanks to Ririshi on Discord for asking about this and bringing it to my attention.
