### PR TITLE
Lose frames instead of slowing down.

### DIFF
--- a/source/FrameTimer.cpp
+++ b/source/FrameTimer.cpp
@@ -41,14 +41,17 @@ FrameTimer::FrameTimer(int fps, int maxLagMsec)
 
 
 // Wait until the next frame should begin.
-void FrameTimer::Wait()
+double FrameTimer::Wait()
 {
+	double lagCount = 0;
 	// Note: in theory this could get interrupted by a signal handler, although
 	// it's unlikely the program will receive any signals that do not terminate
 	// it and that it does not ignore. But, the worst that would happen in that
 	// case is that this particular frame will end too quickly, and then it will
 	// go back to normal for the next one.
 	chrono::steady_clock::time_point now = chrono::steady_clock::now();
+	
+	// are we early?
 	if(now < next)
 	{
 		// This should never happen with a true steady clock, but make sure that
@@ -61,9 +64,14 @@ void FrameTimer::Wait()
 	}
 	// If the lag is too high, don't try to do catch-up.
 	if(now - next > maxLag)
+	{
+		// track how many steps we are behind
+		lagCount =  (1.0 * (now - next)) / step;
 		next = now;
+	}
 	
 	Step();
+	return lagCount;
 }
 
 

--- a/source/FrameTimer.h
+++ b/source/FrameTimer.h
@@ -31,7 +31,8 @@ public:
 	explicit FrameTimer(int fps, int maxLagMsec = 5);
 	
 	// Wait until the next frame should begin.
-	void Wait();
+	// returns how many steps we missed, 0 -> no lag
+	double Wait();
 	// Find out how long it has been since this timer was created, in seconds.
 	double Time() const;
 	

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -178,6 +178,9 @@ void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode)
 	
 	// Limit how quickly full-screen mode can be toggled.
 	int toggleTimeout = 0;
+
+	// keep track of lagging
+	double lagCount = 0;
 	
 	// IsDone becomes true when the game is quit.
 	while(!menuPanels.IsDone())
@@ -277,6 +280,22 @@ void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode)
 			}
 		}
 		
+		// drop the frame if we are (still) lagging behind
+		if(lagCount >= 1)
+		{
+			// we only slow down in flight,
+			// we still slow down in the menu etc for smoother animations
+			if(inFlight)
+			{
+				lagCount = lagCount - 1;
+				continue;
+			}
+			else
+			{
+				lagCount = 0;
+			}
+		}
+		
 		Audio::Step();
 		
 		// Events in this frame may have cleared out the menu, in which case
@@ -287,7 +306,7 @@ void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode)
 		
 		GameWindow::Step();
 
-		timer.Wait();
+		lagCount += timer.Wait();
 	}
 	
 	// If player quit while landed on a planet, save the game if there are changes.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -283,7 +283,7 @@ void GameLoop(PlayerInfo &player, Conversation &conversation, bool &debugMode)
 		// drop the frame if we are (still) lagging behind
 		if(lagCount >= 1)
 		{
-			// we only slow down in flight,
+			// we only drop frames in flight,
 			// we still slow down in the menu etc for smoother animations
 			if(inFlight)
 			{


### PR DESCRIPTION
The following code is not production ready, as it modifies the main code path.
It is meant to test the proposed option.

------

This enables to play the game at normal speed with slow computers
or with software rendering.
There will be lagging instead of a slowed down gameplay.
Maybe this should be an option.

You could use this environment for software rendering with Mesa and llvmpipe:

export LIBGL_ALWAYS_SOFTWARE=1
export MESA_GL_VERSION_OVERRIDE=3.0
export LP_NUM_THREADS=<number of hyperthreads>
