### PR TITLE
Feat: Give ship

### DIFF
--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -39,7 +39,7 @@ namespace {
 			return;
 		
 		player.BuyShip(model, name, true);
-		Messages::Add("The " + model->ModelName() + " \"" + name + ",\" was added to your fleet.");
+		Messages::Add("The " + model->ModelName() + " \"" + name + "\" was added to your fleet.");
 	}
 	
 	void DoGift(PlayerInfo &player, const Outfit *outfit, int count, UI *ui)
@@ -200,7 +200,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			if(child.Token(1) == "ship" && child.Size() >= 3)
 				giftShips[GameData::Ships().Get(child.Token(2))] = child.Size() >= 4 ? child.Token(3) : "";
 			else
-				child.PrintTrace("Skipping unsupported give syntax:");
+				child.PrintTrace("Skipping unsupported \"give\" syntax:");
 		}
 		else if(key == "outfit" && hasValue)
 		{

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -39,8 +39,15 @@ namespace {
 			return;
 		
 		player.BuyShip(model, name, true);
+		
+		string noun = model->Noun();
+		string message;
+		char c = tolower(noun.front());
+		bool isVowel = (c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u');
+		message = (isVowel ? "An " : "A ");
+		message += noun;
 		if(ui)
-			ui->Push(new Dialog("The " + name + " was added to your fleet!"));
+			ui->Push(new Dialog(message + ", the " + model->ModelName() + " \"" + name + ",\" was added to your fleet!"));
 	}
 	
 	void DoGift(PlayerInfo &player, const Outfit *outfit, int count, UI *ui)

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -39,14 +39,7 @@ namespace {
 			return;
 		
 		player.BuyShip(model, name, true);
-		
-		string noun = model->Noun();
-		string message;
-		char c = tolower(noun.front());
-		bool isVowel = (c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u');
-		message = (isVowel ? "An " : "A ");
-		message += noun;
-		Messages::Add(message + ", the " + model->ModelName() + " \"" + name + ",\" was added to your fleet.");
+		Messages::Add("The " + model->ModelName() + " \"" + name + ",\" was added to your fleet.");
 	}
 	
 	void DoGift(PlayerInfo &player, const Outfit *outfit, int count, UI *ui)

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -196,7 +196,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			conversation.Load(child);
 		else if(key == "conversation" && hasValue)
 			stockConversation = GameData::Conversations().Get(child.Token(1));
-		else if(key ==  "ship" && hasValue)
+		else if(key == "ship" && hasValue)
 			giftShips[GameData::Ships().Get(child.Token(1))] = child.Size() >= 3 ? child.Token(2) : "";
 		else if(key == "outfit" && hasValue)
 		{

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -46,8 +46,7 @@ namespace {
 		bool isVowel = (c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u');
 		message = (isVowel ? "An " : "A ");
 		message += noun;
-		if(ui)
-			ui->Push(new Dialog(message + ", the " + model->ModelName() + " \"" + name + ",\" was added to your fleet!"));
+		Messages::Add(message + ", the " + model->ModelName() + " \"" + name + ",\" was added to your fleet.");
 	}
 	
 	void DoGift(PlayerInfo &player, const Outfit *outfit, int count, UI *ui)

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -33,14 +33,17 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
-	void DoGiftShip(PlayerInfo &player, const Ship *model, const string &name, UI *ui)
+	void DoGift(PlayerInfo &player, const Ship *model, const string &name, UI *ui)
 	{
+		if(model->ModelName().empty())
+			return;
+		
 		player.BuyShip(model, name, true);
 		if(ui)
 			ui->Push(new Dialog("The " + name + " was added to your fleet!"));
 	}
 	
-	void DoGiftOutfit(PlayerInfo &player, const Outfit *outfit, int count, UI *ui)
+	void DoGift(PlayerInfo &player, const Outfit *outfit, int count, UI *ui)
 	{
 		Ship *flagship = player.Flagship();
 		bool isSingle = (abs(count) == 1);
@@ -307,7 +310,7 @@ void MissionAction::Save(DataWriter &out) const
 			conversation.Save(out);
 		
 		for(const auto &it : giftShips)
-			out.Write("ship", it.first->Name(), it.second);
+			out.Write("ship", it.first->ModelName(), it.second);
 		for(const auto &it : giftOutfits)
 			out.Write("outfit", it.first->Name(), it.second);
 		for(const auto &it : requiredOutfits)
@@ -457,15 +460,15 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 			player.AddSpecialLog(it.first, eit.first, eit.second);
 	
 	for(const auto &it : giftShips)
-		DoGiftShip(player, it.first, it.second, ui);
+		DoGift(player, it.first, it.second, ui);
 	// If multiple outfits are being transferred, first remove them before
 	// adding any new ones.
 	for(const auto &it : giftOutfits)
 		if(it.second < 0)
-			DoGiftOutfit(player, it.first, it.second, ui);
+			DoGift(player, it.first, it.second, ui);
 	for(const auto &it : giftOutfits)
 		if(it.second > 0)
-			DoGiftOutfit(player, it.first, it.second, ui);
+			DoGift(player, it.first, it.second, ui);
 	
 	if(payment)
 		player.Accounts().AddCredits(payment);

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -35,7 +35,7 @@ using namespace std;
 namespace {
 	void DoGiftShip(PlayerInfo &player, const Ship *model, const std::string &name, UI *ui)
 	{
-		player.GiftShip(model, name);
+		player.BuyShip(model, name, true);
 		
 		if(ui)
 			ui->Push(new Dialog("The " + name + " was added to your fleet!"));

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -36,7 +36,6 @@ namespace {
 	void DoGiftShip(PlayerInfo &player, const Ship *model, const std::string &name, UI *ui)
 	{
 		player.BuyShip(model, name, true);
-		
 		if(ui)
 			ui->Push(new Dialog("The " + name + " was added to your fleet!"));
 	}
@@ -306,6 +305,7 @@ void MissionAction::Save(DataWriter &out) const
 		}
 		if(!conversation.IsEmpty())
 			conversation.Save(out);
+		
 		for(const auto &it : giftShips)
 			out.Write("ship", it.first->Name(), it.second);
 		for(const auto &it : giftOutfits)
@@ -507,7 +507,6 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 		int day = it.second.first + Random::Int(it.second.second - it.second.first + 1);
 		result.events[it.first] = make_pair(day, day);
 	}
-	
 	for(const auto &it : giftShips)
 		result.giftShips[it.first] = !it.second.empty() ? it.second : GameData::Phrases().Get("civilian")->Get();
 	result.giftOutfits = giftOutfits;

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -33,7 +33,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
-	void DoGiftShip(PlayerInfo &player, const Ship *modelName, const std::string &name, UI *ui)
+	void DoGiftShip(PlayerInfo &player, const Ship *model, const std::string &name, UI *ui)
 	{
 		player.GiftShip(modelName, name);
 		

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -33,7 +33,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
-	void DoGiftShip(PlayerInfo &player, const Ship *model, const std::string &name, UI *ui)
+	void DoGiftShip(PlayerInfo &player, const Ship *model, const string &name, UI *ui)
 	{
 		player.BuyShip(model, name, true);
 		if(ui)

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -195,7 +195,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 		else if(key == "conversation" && hasValue)
 			stockConversation = GameData::Conversations().Get(child.Token(1));
 		else if(key ==  "ship" && hasValue)
-			giftShips[GameData::Ships().Get(child.Token(1))] = (child.Size() > 2 ? child.Token(2) : "");
+			giftShips[GameData::Ships().Get(child.Token(1))] = child.Size() >= 3 ? child.Token(2) : "";
 		else if(key == "outfit" && hasValue)
 		{
 			int count = (child.Size() < 3 ? 1 : static_cast<int>(child.Value(2)));

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -196,8 +196,13 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			conversation.Load(child);
 		else if(key == "conversation" && hasValue)
 			stockConversation = GameData::Conversations().Get(child.Token(1));
-		else if(key == "ship" && hasValue)
-			giftShips[GameData::Ships().Get(child.Token(1))] = child.Size() >= 3 ? child.Token(2) : "";
+		else if(key == "give" && hasValue)
+		{
+			if(child.Token(1) == "ship" && child.Size() >= 3)
+				giftShips[GameData::Ships().Get(child.Token(2))] = child.Size() >= 4 ? child.Token(3) : "";
+			else
+				child.PrintTrace("Skipping unsupported give syntax:")
+		}
 		else if(key == "outfit" && hasValue)
 		{
 			int count = (child.Size() < 3 ? 1 : static_cast<int>(child.Value(2)));

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -201,7 +201,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			if(child.Token(1) == "ship" && child.Size() >= 3)
 				giftShips[GameData::Ships().Get(child.Token(2))] = child.Size() >= 4 ? child.Token(3) : "";
 			else
-				child.PrintTrace("Skipping unsupported give syntax:")
+				child.PrintTrace("Skipping unsupported give syntax:");
 		}
 		else if(key == "outfit" && hasValue)
 		{

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -35,7 +35,7 @@ using namespace std;
 namespace {
 	void DoGiftShip(PlayerInfo &player, const Ship *model, const std::string &name, UI *ui)
 	{
-		player.GiftShip(modelName, name);
+		player.GiftShip(model, name);
 		
 		if(ui)
 			ui->Push(new Dialog("The " + name + " was added to your fleet!"));

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -33,7 +33,15 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
-	void DoGift(PlayerInfo &player, const Outfit *outfit, int count, UI *ui)
+	void DoGiftShip(PlayerInfo &player, const Ship *modelName, const std::string &name, UI *ui)
+	{
+		player.GiftShip(modelName, name);
+		
+		if(ui)
+			ui->Push(new Dialog("The " + name + " was added to your fleet!"));
+	}
+	
+	void DoGiftOutfit(PlayerInfo &player, const Outfit *outfit, int count, UI *ui)
 	{
 		Ship *flagship = player.Flagship();
 		bool isSingle = (abs(count) == 1);
@@ -186,11 +194,13 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			conversation.Load(child);
 		else if(key == "conversation" && hasValue)
 			stockConversation = GameData::Conversations().Get(child.Token(1));
+		else if(key ==  "ship" && hasValue)
+			giftShips[GameData::Ships().Get(child.Token(1))] = (child.Size() > 2 ? child.Token(2) : "");
 		else if(key == "outfit" && hasValue)
 		{
 			int count = (child.Size() < 3 ? 1 : static_cast<int>(child.Value(2)));
 			if(count)
-				gifts[GameData::Outfits().Get(child.Token(1))] = count;
+				giftOutfits[GameData::Outfits().Get(child.Token(1))] = count;
 			else
 			{
 				// outfit <outfit> 0 means the player must have this outfit.
@@ -296,8 +306,9 @@ void MissionAction::Save(DataWriter &out) const
 		}
 		if(!conversation.IsEmpty())
 			conversation.Save(out);
-		
-		for(const auto &it : gifts)
+		for(const auto &it : giftShips)
+			out.Write("ship", it.first->Name(), it.second);
+		for(const auto &it : giftOutfits)
 			out.Write("outfit", it.first->Name(), it.second);
 		for(const auto &it : requiredOutfits)
 			out.Write("require", it.first->Name(), it.second);
@@ -342,7 +353,7 @@ bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &
 		return false;
 	
 	const Ship *flagship = player.Flagship();
-	for(const auto &it : gifts)
+	for(const auto &it : giftOutfits)
 	{
 		// If this outfit is being given, the player doesn't need to have it.
 		if(it.second > 0)
@@ -445,14 +456,16 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 		for(const auto &eit : it.second)
 			player.AddSpecialLog(it.first, eit.first, eit.second);
 	
+	for(const auto &it : giftShips)
+		DoGiftShip(player, it.first, it.second, ui);
 	// If multiple outfits are being transferred, first remove them before
 	// adding any new ones.
-	for(const auto &it : gifts)
+	for(const auto &it : giftOutfits)
 		if(it.second < 0)
-			DoGift(player, it.first, it.second, ui);
-	for(const auto &it : gifts)
+			DoGiftOutfit(player, it.first, it.second, ui);
+	for(const auto &it : giftOutfits)
 		if(it.second > 0)
-			DoGift(player, it.first, it.second, ui);
+			DoGiftOutfit(player, it.first, it.second, ui);
 	
 	if(payment)
 		player.Accounts().AddCredits(payment);
@@ -494,7 +507,10 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 		int day = it.second.first + Random::Int(it.second.second - it.second.first + 1);
 		result.events[it.first] = make_pair(day, day);
 	}
-	result.gifts = gifts;
+	
+	for(const auto &it : giftShips)
+		result.giftShips[it.first] = !it.second.empty() ? it.second : GameData::Phrases().Get("civilian")->Get();
+	result.giftOutfits = giftOutfits;
 	result.requiredOutfits = requiredOutfits;
 	result.payment = payment + (jumps + 1) * payload * paymentMultiplier;
 	// Fill in the payment amount if this is the "complete" action.

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -83,7 +83,8 @@ private:
 	Conversation conversation;
 	
 	std::map<const GameEvent *, std::pair<int, int>> events;
-	std::map<const Outfit *, int> gifts;
+	std::map<const Ship *, std::string> giftShips;
+	std::map<const Outfit *, int> giftOutfits;
 	std::map<const Outfit *, int> requiredOutfits;
 	int64_t payment = 0;
 	int64_t paymentMultiplier = 0;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -842,29 +842,21 @@ void PlayerInfo::AddShip(const shared_ptr<Ship> &ship)
 
 
 // Buy a ship of the given model, and give it the given name.
-void PlayerInfo::BuyShip(const Ship *model, const string &name)
+void PlayerInfo::BuyShip(const Ship *model, const string &name, bool isGift)
 {
-	ReceiveShip(model, name, false);
-}
-
-
-
-// Receive a ship of the given model with the given name as a gift.
-void PlayerInfo::GiftShip(const Ship *model, const std::string &name)
-{
-	ReceiveShip(model, name, true);
+	ReceiveShip(model, name, isGift);
 }
 
 
 
 // Adds a ship of the given model with the given name to the player's fleet. If this ship is being gifted, it costs nothing and starts fully depreciated.
-void PlayerInfo::ReceiveShip(const Ship *model, const string &name, bool gifting)
+void PlayerInfo::ReceiveShip(const Ship *model, const string &name, bool isGift)
 {
 	if(!model)
 		return;
 	
 	int day = date.DaysSinceEpoch();
-	int64_t cost = gifting ? 0 : stockDepreciation.Value(*model, day);
+	int64_t cost = isGift ? 0 : stockDepreciation.Value(*model, day);
 	if(accounts.Credits() >= cost)
 	{
 		ships.push_back(shared_ptr<Ship>(new Ship(*model)));
@@ -879,7 +871,7 @@ void PlayerInfo::ReceiveShip(const Ship *model, const string &name, bool gifting
 		flagship.reset();
 		
 		// Record the transfer of this ship in the depreciation and stock info.
-		if(!gifting)
+		if(!isGift)
 		{
 			depreciation.Buy(*model, day, &stockDepreciation);
 			for(const auto &it : model->Outfits())

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -841,16 +841,9 @@ void PlayerInfo::AddShip(const shared_ptr<Ship> &ship)
 
 
 
-// Buy a ship of the given model, and give it the given name.
+// Adds a ship of the given model with the given name to the player's fleet.
+// If this ship is being gifted, it costs nothing and starts fully depreciated.
 void PlayerInfo::BuyShip(const Ship *model, const string &name, bool isGift)
-{
-	ReceiveShip(model, name, isGift);
-}
-
-
-
-// Adds a ship of the given model with the given name to the player's fleet. If this ship is being gifted, it costs nothing and starts fully depreciated.
-void PlayerInfo::ReceiveShip(const Ship *model, const string &name, bool isGift)
 {
 	if(!model)
 		return;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -841,8 +841,8 @@ void PlayerInfo::AddShip(const shared_ptr<Ship> &ship)
 
 
 
-// Charge the player the cost of a ship and give it the specified name:
-void PlayerInfo::BuyShip(const Ship *model, const std::string &name)
+// Buy a ship of the given model, and give it the given name.
+void PlayerInfo::BuyShip(const Ship *model, const string &name)
 {
 	ReceiveShip(model, name, false);
 }
@@ -857,7 +857,7 @@ void PlayerInfo::GiftShip(const Ship *model, const std::string &name)
 
 
 
-// Purchase or receive a gift of a ship of the given model and name
+// Adds a ship of the given model with the given name to the player's fleet. If this ship is being gifted, it costs nothing and starts fully depreciated.
 void PlayerInfo::ReceiveShip(const Ship *model, const string &name, bool gifting)
 {
 	if(!model)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -849,7 +849,7 @@ void PlayerInfo::BuyShip(const Ship *model, const string &name)
 
 
 
-// Receive a ship as a gift
+// Receive a ship of the given model with the given name as a gift.
 void PlayerInfo::GiftShip(const Ship *model, const std::string &name)
 {
 	ReceiveShip(model, name, true);

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -270,8 +270,8 @@ private:
 	
 	// Check that this player's current state can be saved.
 	bool CanBeSaved() const;
-
-
+	
+	
 private:
 	std::string firstName;
 	std::string lastName;

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -121,8 +121,8 @@ public:
 	std::map<const std::shared_ptr<Ship>, std::vector<std::string>> FlightCheck() const;
 	// Add a captured ship to your fleet.
 	void AddShip(const std::shared_ptr<Ship> &ship);
-	// Buy a ship, receive a gifted ship, or sell a ship.
-	void BuyShip(const Ship *model, const std::string &name, bool isGift);
+	// Buy a ship or sell a ship.
+	void BuyShip(const Ship *model, const std::string &name, bool isGift = false);
 	void SellShip(const Ship *selected);
 	void DisownShip(const Ship *selected);
 	void ParkShip(const Ship *selected, bool isParked);
@@ -267,9 +267,6 @@ private:
 	
 	// Helper function to update the ship selection.
 	void SelectShip(const std::shared_ptr<Ship> &ship, bool *first);
-
-	// Adds a ship of the given model with the given name to the player's fleet. If this ship is being gifted, it costs nothing and starts fully depreciated.
-	void ReceiveShip(const Ship *model, const std::string &name, bool isGift);
 	
 	// Check that this player's current state can be saved.
 	bool CanBeSaved() const;

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -121,8 +121,9 @@ public:
 	std::map<const std::shared_ptr<Ship>, std::vector<std::string>> FlightCheck() const;
 	// Add a captured ship to your fleet.
 	void AddShip(const std::shared_ptr<Ship> &ship);
-	// Buy or sell a ship.
+	// Buy a ship, receive a gifted ship, or sell a ship.
 	void BuyShip(const Ship *model, const std::string &name);
+	void GiftShip(const Ship *model, const std::string &name);
 	void SellShip(const Ship *selected);
 	void DisownShip(const Ship *selected);
 	void ParkShip(const Ship *selected, bool isParked);
@@ -247,6 +248,9 @@ public:
 	
 	
 private:
+	// Internal implementation of BuyShip and GiftShip
+	void ReceiveShip(const Ship *model, const std::string &name, bool gifting);
+	
 	// Don't allow anyone else to copy this class, because pointers won't get
 	// transferred properly.
 	PlayerInfo(const PlayerInfo &) = default;
@@ -270,8 +274,8 @@ private:
 	
 	// Check that this player's current state can be saved.
 	bool CanBeSaved() const;
-	
-	
+
+
 private:
 	std::string firstName;
 	std::string lastName;

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -121,7 +121,7 @@ public:
 	std::map<const std::shared_ptr<Ship>, std::vector<std::string>> FlightCheck() const;
 	// Add a captured ship to your fleet.
 	void AddShip(const std::shared_ptr<Ship> &ship);
-	// Buy a ship or sell a ship.
+	// Buy or sell a ship.
 	void BuyShip(const Ship *model, const std::string &name, bool isGift = false);
 	void SellShip(const Ship *selected);
 	void DisownShip(const Ship *selected);

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -121,8 +121,6 @@ public:
 	std::map<const std::shared_ptr<Ship>, std::vector<std::string>> FlightCheck() const;
 	// Add a captured ship to your fleet.
 	void AddShip(const std::shared_ptr<Ship> &ship);
-	
-	bool isGift = false;
 	// Buy a ship, receive a gifted ship, or sell a ship.
 	void BuyShip(const Ship *model, const std::string &name, bool isGift);
 	void SellShip(const Ship *selected);

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -121,7 +121,7 @@ public:
 	std::map<const std::shared_ptr<Ship>, std::vector<std::string>> FlightCheck() const;
 	// Add a captured ship to your fleet.
 	void AddShip(const std::shared_ptr<Ship> &ship);
-	// Buy a ship, receive a gifted ship, or sell a ship.
+	// Buy a ship, receive a ship, or sell a ship.
 	void BuyShip(const Ship *model, const std::string &name);
 	void GiftShip(const Ship *model, const std::string &name);
 	void SellShip(const Ship *selected);

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -121,9 +121,10 @@ public:
 	std::map<const std::shared_ptr<Ship>, std::vector<std::string>> FlightCheck() const;
 	// Add a captured ship to your fleet.
 	void AddShip(const std::shared_ptr<Ship> &ship);
-	// Buy a ship, receive a ship, or sell a ship.
-	void BuyShip(const Ship *model, const std::string &name);
-	void GiftShip(const Ship *model, const std::string &name);
+	
+	bool isGift = false;
+	// Buy a ship, receive a gifted ship, or sell a ship.
+	void BuyShip(const Ship *model, const std::string &name, bool isGift);
 	void SellShip(const Ship *selected);
 	void DisownShip(const Ship *selected);
 	void ParkShip(const Ship *selected, bool isParked);
@@ -248,9 +249,6 @@ public:
 	
 	
 private:
-	// Internal implementation of BuyShip and GiftShip
-	void ReceiveShip(const Ship *model, const std::string &name, bool gifting);
-	
 	// Don't allow anyone else to copy this class, because pointers won't get
 	// transferred properly.
 	PlayerInfo(const PlayerInfo &) = default;
@@ -271,6 +269,9 @@ private:
 	
 	// Helper function to update the ship selection.
 	void SelectShip(const std::shared_ptr<Ship> &ship, bool *first);
+
+	// Adds a ship of the given model with the given name to the player's fleet. If this ship is being gifted, it costs nothing and starts fully depreciated.
+	void ReceiveShip(const Ship *model, const std::string &name, bool isGift);
 	
 	// Check that this player's current state can be saved.
 	bool CanBeSaved() const;

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -313,7 +313,7 @@ void ShipyardPanel::BuyShip(const string &name)
 		else if(modifier > 1)
 			shipName += " " + to_string(i);
 		
-		player.BuyShip(selectedShip, shipName, false);
+		player.BuyShip(selectedShip, shipName);
 	}
 	
 	playerShip = &*player.Ships().back();

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -313,7 +313,7 @@ void ShipyardPanel::BuyShip(const string &name)
 		else if(modifier > 1)
 			shipName += " " + to_string(i);
 		
-		player.BuyShip(selectedShip, shipName);
+		player.BuyShip(selectedShip, shipName, false);
 	}
 	
 	playerShip = &*player.Ships().back();


### PR DESCRIPTION
## Summary
Gives creators the ability to give ships to the player through missions

-----------------------

## Feature Details
This is a partial implementation of  #4399 it allows the giving of ships through missions.

## Usage Examples
It can be used in a mission under `on offer`, `on accept`, etc.. 
```
on <action>
    give ship <ship model> [<name>]
```
If the second name is left out, a civilian ship name will be generated for the gifted ship.
e.g.
```
mission "some mission"
    ...
    on complete
        give ship Sparrow "Mote of Might"
        give ship "Star Barge"
```
indicates that completing the mission will result in the player being given a Sparrow that is named "Mote of Might," and being given a Star Barge with a randomly picked civilian name

## Testing Done
Using the example mission gives two ships, one with a name, and one without a predetermined name, it gets generated later.
#### Example mission
[test.txt](https://github.com/endless-sky/endless-sky/files/5188133/testing.txt)

## Performance Impact
n/a