### PR TITLE
Save ship outfits in alphabetic order to savegame.

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -715,13 +715,13 @@ void Ship::Save(DataWriter &out) const
 			for(const auto &it : outfits)
 				if(it.first && it.second)
 					orderedOutfits[it.first->Name()] = it.second;
-			for(const auto &ito : orderedOutfits)
-				{
-					if(ito.second == 1)
-						out.Write(ito.first);
-					else
-						out.Write(ito.first, ito.second);
-				}
+			for(const auto &it : orderedOutfits)
+			{
+				if(it.second == 1)
+					out.Write(it.first);
+				else
+					out.Write(it.first, it.second);
+			}
 		}
 		out.EndChild();
 		

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -704,13 +704,23 @@ void Ship::Save(DataWriter &out) const
 		out.Write("outfits");
 		out.BeginChild();
 		{
+			// Using a temporary map with the outfit names as keys so that
+			// outfits are written to the savefile in named alphabetical
+			// order.
+			// The game-engine doesn't care in which order outfits are
+			// saved or loaded, the sorting here is done as a service for
+			// content creators that use savegames for working on their
+			// new content.
+			map<string, int> orderedOutfits;
 			for(const auto &it : outfits)
 				if(it.first && it.second)
+					orderedOutfits[it.first->Name()] = it.second;
+			for(const auto &ito : orderedOutfits)
 				{
-					if(it.second == 1)
-						out.Write(it.first->Name());
+					if(ito.second == 1)
+						out.Write(ito.first);
 					else
-						out.Write(it.first->Name(), it.second);
+						out.Write(ito.first, ito.second);
 				}
 		}
 		out.EndChild();


### PR DESCRIPTION
**Feature:** This PR implements part of the feature request detailed and discussed in issue #5171

## Feature Details
This PR adds a temporary map in the function that saves the ship-outfits to a save-game file to ensure that the outfits are saved in alphabetical order.

## UI Screenshots
N/A

## Usage Examples
N/A, the game automatically applies the ordering when saving.

## Testing Done
I started the game with an existing save-game, pressed depart and then closed the game. The outfits in the save-game before and after starting where the same (but the outfits after starting the game were sorted in alphabetical order).

## Performance Impact
The effect of this change is that the function that saves the game takes a little bit longer time and temporary uses a little bit more memory (since it needs to build up the temporary map). But ships have small lists of outfits, so the impact should be very minimal.
Saving the game is not performance critical code.