### PR TITLE
Fix: Tweaking Puffin-Drak conflict

### DIFF
--- a/data/drak/drak.txt
+++ b/data/drak/drak.txt
@@ -53,7 +53,7 @@ outfit "Drak Draining Field"
 		"firing energy" 20
 		"firing heat" 5
 		"firing force" 30
-		"hit force" 50
+		"hit force" 100
 		"shield damage" 50
 		"ion damage" .5
 		"disruption damage" 1
@@ -92,8 +92,8 @@ outfit "Drak Turret"
 		"hit effect" "drak bolt impact"
 		"inaccuracy" 1
 		"turret turn" 4.
-		"velocity" 36
-		"lifetime" 30
+		"velocity" 30
+		"lifetime" 36
 		"reload" 16
 		"firing energy" 160
 		"firing heat" 160

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -771,7 +771,7 @@ ship "Puffin"
 		"hull" 1500
 		"required crew" 1
 		"bunks" 2
-		"mass" 44
+		"mass" 40
 		"drag" 1.27
 		"heat dissipation" 0.9
 		"fuel capacity" 700


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #{{insert number}}

Changes:
- Drak draining field force 50 -> 100
- Drak Turret velocity and lifetime swapped. So same effective range, but a bit slower.
- Puffin mass dropped from 44 to 40.

## Testing Done
Repeatedly running the Nenia puffin dodging mission.

## Results
Things are back to the Puffin getting shoved, although not as dramatically as it was when the force was 500 and working properly. The puffin usually gets hit enough times to build up some graphical indicators, but it is enough to outpace most of the turret shots. I've only tested it a dozen times or so, but it seems to work fairly well at  being exciting and stressful, but not dying. So, this is what I'm aiming for.

## Alternative

Alternatively, we could leave it at force 50, and drop the puffin mass some more. I don't know for sure, but dropping it to somewhere close to 30 would probably work.