### PR TITLE
feat(mechanics): Save ship explosion effects in alphabetic order to savegame.

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -92,7 +92,7 @@ namespace {
 	
 	// Helper function to write out a map that have keys as pointers and
 	// integer values as counters to a datawriter in alphabetical order of
-	// the items pointed to by the keys.
+	// the names of the items pointed to by the keys.
 	// Entries with null-pointers and zero counters are not written out.
 	template <class T, typename F, typename G>
 	void WriteSorted(const map<const T*, int> &container, F nameFn, G writeFn)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -98,11 +98,11 @@ namespace {
 	void WriteSorted(const map<const T*, int> &container, F nameFn, G writeFn)
 	{
 		map<string, int> sorted;
-		for_each(container.cbegin(), container.cend(), [&](const pair<const T*, int> &element) {
+		for_each(container.cbegin(), container.cend(), [&](const pair<const T*, int> &element){
 			if(element.first && element.second)
 				sorted.emplace(nameFn(element), element.second);
 		});
-		for_each(sorted.cbegin(), sorted.cend(), [&](const pair<const string, int> &element) {
+		for_each(sorted.cbegin(), sorted.cend(), [&](const pair<const string, int> &element){
 			writeFn(element);
 		});
 	}
@@ -824,9 +824,9 @@ void Ship::Save(DataWriter &out) const
 		// Sort the explosion and final explosion effects by name before
 		// writing them out. This is done as a service for content
 		// creators that use savefiles for creating new content.
-		auto sortFn = [&](const pair<const Effect*, int> it) -> string { return it.first->Name(); };
-		auto writeFn = [&](const pair<const string, int> it) { out.Write("explode", it.first, it.second); };
-		auto writeFnFinal = [&](const pair<const string, int> it) { out.Write("final explode", it.first, it.second); };
+		auto sortFn = [&](const pair<const Effect*, int> it)->string{return it.first->Name();};
+		auto writeFn = [&](const pair<const string, int> it){out.Write("explode", it.first, it.second);};
+		auto writeFnFinal = [&](const pair<const string, int> it){out.Write("final explode", it.first, it.second);};
 		WriteSorted(explosionEffects, sortFn, writeFn);
 		WriteSorted(finalExplosions, sortFn, writeFnFinal);
 		

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -805,12 +805,22 @@ void Ship::Save(DataWriter &out) const
 		}
 		for(const Leak &leak : leaks)
 			out.Write("leak", leak.effect->Name(), leak.openPeriod, leak.closePeriod);
+		
+		// Sort the explosion and final explosion effects by name before
+		// writing them out. This is done as a service for content
+		// creators that use savefiles for creating new content.
+		map<string, int> explosionEffectsSorted;
 		for(const auto &it : explosionEffects)
 			if(it.first && it.second)
-				out.Write("explode", it.first->Name(), it.second);
+				explosionEffectsSorted[it.first->Name()] = it.second;
+		for(const auto &it : explosionEffectsSorted)
+			out.Write("explode", it.first, it.second);
+		explosionEffectsSorted.clear();
 		for(const auto &it : finalExplosions)
 			if(it.first && it.second)
-				out.Write("final explode", it.first->Name(), it.second);
+				explosionEffectsSorted[it.first->Name()] = it.second;
+		for(const auto &it : explosionEffectsSorted)
+			out.Write("final explode", it.first, it.second);
 		
 		if(currentSystem)
 			out.Write("system", currentSystem->Name());

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -90,14 +90,19 @@ namespace {
 		}
 	}
 	
-	template <class T>
-	void WriteSorted(const map<const T*, int> &container, function<string (const pair<const T*, int>)> nameFn, function<void (const pair<const T*, int>)> writeFn)
+	// Helper function to write out a map that have keys as pointers and
+	// integer values as counters to a datawriter in alphabetical order of
+	// the items pointed to by the keys.
+	// Entries with null-pointers and zero counters are not written out.
+	template <class T, typename F, typename G>
+	void WriteSorted(const map<const T*, int> &container, F nameFn, G writeFn)
 	{
 		map<string, int> sorted;
-		for_each(container.cbegin(), container.cend(), [&](const pair<T*,int> &element) {
-			sorted.emplace(nameFn(element), element.second);
+		for_each(container.cbegin(), container.cend(), [&](const pair<const T*, int> &element) {
+			if(element.first && element.second)
+				sorted.emplace(nameFn(element), element.second);
 		});
-		for_each(sorted.cbegin(), sorted.cend(), [&](const pair<T*, int> &element) {
+		for_each(sorted.cbegin(), sorted.cend(), [&](const pair<const string, int> &element) {
 			writeFn(element);
 		});
 	}
@@ -724,7 +729,7 @@ void Ship::Save(DataWriter &out) const
 			// content creators that use savegames for working on their
 			// new content.
 			auto sortFn = [&](const pair<const Outfit*, int> it) -> string { return it.first->Name(); };
-			auto writeFn = [&](const pair<const Outfit*, int> it)
+			auto writeFn = [&](const pair<const string, int> it)
 			{
 				if(it.second == 1)
 					out.Write(it.first);
@@ -820,8 +825,8 @@ void Ship::Save(DataWriter &out) const
 		// writing them out. This is done as a service for content
 		// creators that use savefiles for creating new content.
 		auto sortFn = [&](const pair<const Effect*, int> it) -> string { return it.first->Name(); };
-		auto writeFn = [&](const pair<const Effect*, int> it) { out.Write("explode", it.first, it.second); };
-		auto writeFnFinal = [&](const pair<const Effect*, int> it) { out.Write("final explode", it.first, it.second); };
+		auto writeFn = [&](const pair<const string, int> it) { out.Write("explode", it.first, it.second); };
+		auto writeFnFinal = [&](const pair<const string, int> it) { out.Write("final explode", it.first, it.second); };
 		WriteSorted(explosionEffects, sortFn, writeFn);
 		WriteSorted(finalExplosions, sortFn, writeFnFinal);
 		


### PR DESCRIPTION
**Feature:** This PR implements part of the feature request detailed and discussed in issue #5171

## Feature Details
This PR adds a temporary map in the function that saves the ship-explosion-effects to a save-game file to ensure that the explosion-effectss are saved in alphabetical order.

## UI Screenshots
N/A

## Usage Examples
N/A, the game automatically applies the ordering when saving.

## Testing Done
I started the game with an existing save-game, pressed depart and then closed the game. The explosion effects in the save-game before and after starting where the same (but the effects after starting were sorted in alphabetical order).

## Performance Impact
The function that saves the game will take a little bit more time and temporary uses a little bit more memory (since it needs to build up the temporary maps). But ships have small lists of explosion effects, so the impact should be very minimal.
Saving the game is not performance critical code.