### PR TITLE
feat(mechanics): Save collections in order by element name

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -773,10 +773,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 				// Mission ships should only pick amongst ships from the same mission.
 				auto missionIt = it->IsSpecial() && !it->IsYours()
 					? find_if(player.Missions().begin(), player.Missions().end(),
-						[&it](const Mission &m) -> bool
-						{
-							return m.HasShip(it);
-						})
+						[&it](const Mission &m) { return m.HasShip(it); })
 					: player.Missions().end();
 				
 				shared_ptr<Ship> newParent;

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -35,7 +35,7 @@ namespace {
 			sortedOutfits.emplace_back(it.first);
 		
 		sort(sortedOutfits.begin(), sortedOutfits.end(),
-			[] (const Outfit *lhs, const Outfit *rhs)
+			[](const Outfit *lhs, const Outfit *rhs)
 			{
 				return lhs->Mass() > rhs->Mass();
 			}

--- a/source/DataWriter.h
+++ b/source/DataWriter.h
@@ -111,8 +111,9 @@ void DataWriter::WriteToken(const A &a)
 
 // Encapsulate the logic for writing the contents of a collection in a sorted manner. The caller
 // should provide a sorting method; it will be called with pointers to the type of the container.
+// The provided write method will be called for each element of the container.
 template <class T, template<class, class...> class C, class... Args, typename A, typename B>
-void WriteSorted(DataWriter &out, const C<T, Args...> &container, A sortFn, B writeFn)
+void WriteSorted(const C<T, Args...> &container, A sortFn, B writeFn)
 {
 	std::vector<const T *> sorted;
 	sorted.reserve(container.size());
@@ -121,10 +122,10 @@ void WriteSorted(DataWriter &out, const C<T, Args...> &container, A sortFn, B wr
 	std::sort(sorted.begin(), sorted.end(), sortFn);
 	
 	for(const auto &sit : sorted)
-		writeFn(out, *sit);
+		writeFn(*sit);
 }
 template <class K, class V, class... Args, typename A, typename B>
-void WriteSorted(DataWriter &out, const std::map<const K *, V, Args...> &container, A sortFn, B writeFn)
+void WriteSorted(const std::map<const K *, V, Args...> &container, A sortFn, B writeFn)
 {
 	std::vector<const std::pair<const K *const, V> *> sorted;
 	sorted.reserve(container.size());
@@ -133,7 +134,7 @@ void WriteSorted(DataWriter &out, const std::map<const K *, V, Args...> &contain
 	std::sort(sorted.begin(), sorted.end(), sortFn);
 	
 	for(const auto &sit : sorted)
-		writeFn(out, *sit);
+		writeFn(*sit);
 }
 
 

--- a/source/DataWriter.h
+++ b/source/DataWriter.h
@@ -13,8 +13,11 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef DATA_WRITER_H_
 #define DATA_WRITER_H_
 
+#include <algorithm>
+#include <map>
 #include <sstream>
 #include <string>
+#include <vector>
 
 class DataNode;
 
@@ -29,6 +32,10 @@ class DataWriter {
 public:
 	// Constructor, specifying the file to write.
 	explicit DataWriter(const std::string &path);
+	DataWriter(const DataWriter &) = delete;
+	DataWriter(DataWriter &&) = delete;
+	DataWriter &operator=(const DataWriter &) = delete;
+	DataWriter operator=(DataWriter &&) = delete;
 	// The file is not actually saved until the destructor is called. This makes
 	// it possible to write the whole file in a single chunk.
 	~DataWriter();
@@ -98,6 +105,35 @@ void DataWriter::WriteToken(const A &a)
 	
 	out << *before << a;
 	before = &space;
+}
+
+
+
+// Encapsulate the logic for writing the contents of a collection in a sorted manner. The caller
+// should provide a sorting method; it will be called with pointers to the type of the container.
+template <class T, template<class, class...> class C, class... Args, typename A, typename B>
+void WriteSorted(DataWriter &out, const C<T, Args...> &container, A sortFn, B writeFn)
+{
+	std::vector<const T *> sorted;
+	sorted.reserve(container.size());
+	for(const auto &it : container)
+		sorted.emplace_back(&it);
+	std::sort(sorted.begin(), sorted.end(), sortFn);
+	
+	for(const auto &sit : sorted)
+		writeFn(out, *sit);
+}
+template <class K, class V, class... Args, typename A, typename B>
+void WriteSorted(DataWriter &out, const std::map<const K *, V, Args...> &container, A sortFn, B writeFn)
+{
+	std::vector<const std::pair<const K *const, V> *> sorted;
+	sorted.reserve(container.size());
+	for(const auto &it : container)
+		sorted.emplace_back(&it);
+	std::sort(sorted.begin(), sorted.end(), sortFn);
+	
+	for(const auto &sit : sorted)
+		writeFn(out, *sit);
 }
 
 

--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -79,7 +79,8 @@ void Depreciation::Save(DataWriter &out, int day) const
 	{
 		using ShipElement = pair<const Ship *const, map<int, int>>;
 		WriteSorted(ships,
-			[](const ShipElement *lhs, const ShipElement *rhs) { return lhs->first->ModelName() < rhs->first->ModelName(); },
+			[](const ShipElement *lhs, const ShipElement *rhs)
+				{ return lhs->first->ModelName() < rhs->first->ModelName(); },
 			[=, &out](const ShipElement &sit)
 			{
 				out.Write("ship", sit.first->ModelName());
@@ -97,7 +98,8 @@ void Depreciation::Save(DataWriter &out, int day) const
 			});
 		using OutfitElement = pair<const Outfit *const, map<int, int>>;
 		WriteSorted(outfits,
-			[](const OutfitElement *lhs, const OutfitElement *rhs) { return lhs->first->Name() < rhs->first->Name(); },
+			[](const OutfitElement *lhs, const OutfitElement *rhs)
+				{ return lhs->first->Name() < rhs->first->Name(); },
 			[=, &out](const OutfitElement &oit)
 			{
 				out.Write("outfit", oit.first->Name());

--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -77,32 +77,38 @@ void Depreciation::Save(DataWriter &out, int day) const
 	out.Write(NAME[isStock]);
 	out.BeginChild();
 	{
-		for(const auto &sit : ships)
-		{
-			out.Write("ship", sit.first->ModelName());
-			out.BeginChild();
+		using ShipElement = pair<const Ship *const, map<int, int>>;
+		WriteSorted(out, ships,
+			[](const ShipElement *lhs, const ShipElement *rhs) { return lhs->first->ModelName() < rhs->first->ModelName(); },
+			[=](DataWriter &dw, const ShipElement &sit)
 			{
-				// If this is a planet's stock, remember how many outfits in
-				// stock are fully depreciated. If it's the player's stock,
-				// anything not recorded is considered fully depreciated, so
-				// there is no reason to save records for those items.
-				for(const auto &it : sit.second)
-					if(isStock || (it.second && it.first > day - MAX_AGE))
-						out.Write(it.first, it.second);
-			}
-			out.EndChild();
-		}
-		for(const auto &oit : outfits)
-		{
-			out.Write("outfit", oit.first->Name());
-			out.BeginChild();
+				dw.Write("ship", sit.first->ModelName());
+				dw.BeginChild();
+				{
+					// If this is a planet's stock, remember how many outfits in
+					// stock are fully depreciated. If it's the player's stock,
+					// anything not recorded is considered fully depreciated, so
+					// there is no reason to save records for those items.
+					for(const auto &it : sit.second)
+						if(isStock || (it.second && it.first > day - MAX_AGE))
+							dw.Write(it.first, it.second);
+				}
+				dw.EndChild();
+			});
+		using OutfitElement = pair<const Outfit *const, map<int, int>>;
+		WriteSorted(out, outfits,
+			[](const OutfitElement *lhs, const OutfitElement *rhs) { return lhs->first->Name() < rhs->first->Name(); },
+			[=](DataWriter &dw, const OutfitElement &oit)
 			{
-				for(const auto &it : oit.second)
-					if(isStock || (it.second && it.first > day - MAX_AGE))
-						out.Write(it.first, it.second);
-			}
-			out.EndChild();
-		}
+				dw.Write("outfit", oit.first->Name());
+				dw.BeginChild();
+				{
+					for(const auto &it : oit.second)
+						if(isStock || (it.second && it.first > day - MAX_AGE))
+							dw.Write(it.first, it.second);
+				}
+				dw.EndChild();
+			});
 	}
 	out.EndChild();
 }

--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -78,12 +78,12 @@ void Depreciation::Save(DataWriter &out, int day) const
 	out.BeginChild();
 	{
 		using ShipElement = pair<const Ship *const, map<int, int>>;
-		WriteSorted(out, ships,
+		WriteSorted(ships,
 			[](const ShipElement *lhs, const ShipElement *rhs) { return lhs->first->ModelName() < rhs->first->ModelName(); },
-			[=](DataWriter &dw, const ShipElement &sit)
+			[=, &out](const ShipElement &sit)
 			{
-				dw.Write("ship", sit.first->ModelName());
-				dw.BeginChild();
+				out.Write("ship", sit.first->ModelName());
+				out.BeginChild();
 				{
 					// If this is a planet's stock, remember how many outfits in
 					// stock are fully depreciated. If it's the player's stock,
@@ -91,23 +91,23 @@ void Depreciation::Save(DataWriter &out, int day) const
 					// there is no reason to save records for those items.
 					for(const auto &it : sit.second)
 						if(isStock || (it.second && it.first > day - MAX_AGE))
-							dw.Write(it.first, it.second);
+							out.Write(it.first, it.second);
 				}
-				dw.EndChild();
+				out.EndChild();
 			});
 		using OutfitElement = pair<const Outfit *const, map<int, int>>;
-		WriteSorted(out, outfits,
+		WriteSorted(outfits,
 			[](const OutfitElement *lhs, const OutfitElement *rhs) { return lhs->first->Name() < rhs->first->Name(); },
-			[=](DataWriter &dw, const OutfitElement &oit)
+			[=, &out](const OutfitElement &oit)
 			{
-				dw.Write("outfit", oit.first->Name());
-				dw.BeginChild();
+				out.Write("outfit", oit.first->Name());
+				out.BeginChild();
 				{
 					for(const auto &it : oit.second)
 						if(isStock || (it.second && it.first > day - MAX_AGE))
-							dw.Write(it.first, it.second);
+							out.Write(it.first, it.second);
 				}
-				dw.EndChild();
+				out.EndChild();
 			});
 	}
 	out.EndChild();

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -101,7 +101,8 @@ namespace {
 		}
 		// Sort this list of choices ascending by mass, so it can be easily trimmed to just
 		// the outfits that fit as the ship's free space decreases.
-		sort(outfits.begin(), outfits.end(), [](const Outfit *a, const Outfit *b){ return a->Mass() < b->Mass(); });
+		sort(outfits.begin(), outfits.end(), [](const Outfit *a, const Outfit *b)
+			{ return a->Mass() < b->Mass(); });
 		return outfits;
 	}
 	

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -458,9 +458,14 @@ void GameData::WriteEconomy(DataWriter &out)
 		{
 			out.Write("purchases");
 			out.BeginChild();
-			for(const auto &pit : purchases)
-				for(const auto &cit : pit.second)
-					out.Write(pit.first->Name(), cit.first, cit.second);
+			using Purchase = pair<const System * const, map<string, int>>;
+			WriteSorted(out, purchases,
+				[](const Purchase *lhs, const Purchase *rhs) { return lhs->first->Name() < rhs->first->Name();},
+				[](DataWriter &dw, const Purchase &pit)
+				{
+					for(const auto &cit : pit.second)
+						dw.Write(pit.first->Name(), cit.first, cit.second);
+				});
 			out.EndChild();
 		}
 		out.WriteToken("system");

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -459,12 +459,12 @@ void GameData::WriteEconomy(DataWriter &out)
 			out.Write("purchases");
 			out.BeginChild();
 			using Purchase = pair<const System * const, map<string, int>>;
-			WriteSorted(out, purchases,
+			WriteSorted(purchases,
 				[](const Purchase *lhs, const Purchase *rhs) { return lhs->first->Name() < rhs->first->Name();},
-				[](DataWriter &dw, const Purchase &pit)
+				[&out](const Purchase &pit)
 				{
 					for(const auto &cit : pit.second)
-						dw.Write(pit.first->Name(), cit.first, cit.second);
+						out.Write(pit.first->Name(), cit.first, cit.second);
 				});
 			out.EndChild();
 		}

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -458,9 +458,10 @@ void GameData::WriteEconomy(DataWriter &out)
 		{
 			out.Write("purchases");
 			out.BeginChild();
-			using Purchase = pair<const System * const, map<string, int>>;
+			using Purchase = pair<const System *const, map<string, int>>;
 			WriteSorted(purchases,
-				[](const Purchase *lhs, const Purchase *rhs) { return lhs->first->Name() < rhs->first->Name();},
+				[](const Purchase *lhs, const Purchase *rhs)
+					{ return lhs->first->Name() < rhs->first->Name(); },
 				[&out](const Purchase &pit)
 				{
 					for(const auto &cit : pit.second)

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -247,5 +247,5 @@ void MapOutfitterPanel::Init()
 	
 	for(auto &it : catalog)
 		sort(it.second.begin(), it.second.end(),
-			[](const Outfit *a, const Outfit *b) {return a->Name() < b->Name();});
+			[](const Outfit *a, const Outfit *b) { return a->Name() < b->Name(); });
 }

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -218,5 +218,5 @@ void MapShipyardPanel::Init()
 	
 	for(auto &it : catalog)
 		sort(it.second.begin(), it.second.end(),
-			[](const Ship *a, const Ship *b) {return a->ModelName() < b->ModelName();});
+			[](const Ship *a, const Ship *b) { return a->ModelName() < b->ModelName(); });
 }

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -596,9 +596,7 @@ void MissionPanel::DrawMissionSystem(const Mission &mission, const Color &color)
 	
 	double zoom = Zoom();
 	auto drawRing = [&](const System *system, const Color &drawColor)
-	{
-		RingShader::Add(zoom * (system->Position() + center), 22.f, 20.5f, drawColor);
-	};
+		{ RingShader::Add(zoom * (system->Position() + center), 22.f, 20.5f, drawColor); };
 	
 	RingShader::Bind();
 	{

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -63,11 +63,12 @@ namespace {
 	
 	void AddFlareSprites(vector<pair<Body, int>> &thisFlares, const pair<Body, int> &it, int count)
 	{
-		auto oit = find_if(thisFlares.begin(), thisFlares.end(), 
-			[&it](pair<Body, int> flare)
+		auto oit = find_if(thisFlares.begin(), thisFlares.end(),
+			[&it](const pair<Body, int> &flare)
 			{
 				return it.first.GetSprite() == flare.first.GetSprite();
-			});
+			}
+		);
 		
 		if(oit == thisFlares.end())
 			thisFlares.emplace_back(it.first, count * it.second);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2643,7 +2643,8 @@ void PlayerInfo::Save(const string &path) const
 		{
 			using StockElement = pair<const Outfit *const, int>;
 			WriteSorted(stock,
-				[](const StockElement *lhs, const StockElement *rhs){ return lhs->first->Name() < rhs->first->Name(); },
+				[](const StockElement *lhs, const StockElement *rhs)
+					{ return lhs->first->Name() < rhs->first->Name(); },
 				[&out](const StockElement &it)
 				{
 					if(it.second)
@@ -2713,7 +2714,8 @@ void PlayerInfo::Save(const string &path) const
 	
 	// Save a list of systems the player has visited.
 	WriteSorted(visitedSystems,
-		[](const System *const *lhs, const System *const *rhs){ return (*lhs)->Name() < (*rhs)->Name(); },
+		[](const System *const *lhs, const System *const *rhs)
+			{ return (*lhs)->Name() < (*rhs)->Name(); },
 		[&out](const System *system)
 		{
 			if(!system->Name().empty())
@@ -2722,7 +2724,8 @@ void PlayerInfo::Save(const string &path) const
 	
 	// Save a list of planets the player has visited.
 	WriteSorted(visitedPlanets,
-		[](const Planet *const *lhs, const Planet *const *rhs){ return (*lhs)->TrueName() < (*rhs)->TrueName(); },
+		[](const Planet *const *lhs, const Planet *const *rhs)
+			{ return (*lhs)->TrueName() < (*rhs)->TrueName(); },
 		[&out](const Planet *planet)
 		{
 			if(!planet->TrueName().empty())

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2641,13 +2641,13 @@ void PlayerInfo::Save(const string &path) const
 		out.Write("stock");
 		out.BeginChild();
 		{
-			WriteSorted(out, stock,
-				[](const pair<const Outfit *const, int> *lhs, const pair<const Outfit *const, int> *rhs)
-					{ return lhs->first->Name() < rhs->first->Name(); },
-				[](DataWriter &dw, const pair<const Outfit *const, int> &it)
+			using StockElement = pair<const Outfit *const, int>;
+			WriteSorted(stock,
+				[](const StockElement *lhs, const StockElement *rhs){ return lhs->first->Name() < rhs->first->Name(); },
+				[&out](const StockElement &it)
 				{
 					if(it.second)
-						dw.Write(it.first->Name(), it.second);
+						out.Write(it.first->Name(), it.second);
 				});
 		}
 		out.EndChild();
@@ -2712,21 +2712,21 @@ void PlayerInfo::Save(const string &path) const
 	out.WriteComment("What you know:");
 	
 	// Save a list of systems the player has visited.
-	WriteSorted(out, visitedSystems,
+	WriteSorted(visitedSystems,
 		[](const System *const *lhs, const System *const *rhs){ return (*lhs)->Name() < (*rhs)->Name(); },
-		[](DataWriter &dw, const System *system)
+		[&out](const System *system)
 		{
 			if(!system->Name().empty())
-				dw.Write("visited", system->Name());
+				out.Write("visited", system->Name());
 		});
 	
 	// Save a list of planets the player has visited.
-	WriteSorted(out, visitedPlanets,
+	WriteSorted(visitedPlanets,
 		[](const Planet *const *lhs, const Planet *const *rhs){ return (*lhs)->TrueName() < (*rhs)->TrueName(); },
-		[](DataWriter &dw, const Planet *planet)
+		[&out](const Planet *planet)
 		{
 			if(!planet->TrueName().empty())
-				dw.Write("visited planet", planet->TrueName());
+				out.Write("visited planet", planet->TrueName());
 		});
 	
 	if(!harvested.empty())
@@ -2734,8 +2734,9 @@ void PlayerInfo::Save(const string &path) const
 		out.Write("harvested");
 		out.BeginChild();
 		{
-			WriteSorted(out, harvested,
-				[](const pair<const System *, const Outfit *> *lhs, const pair<const System *, const Outfit *> *rhs) -> bool
+			using HarvestLog = pair<const System *, const Outfit *>;
+			WriteSorted(harvested,
+				[](const HarvestLog *lhs, const HarvestLog *rhs) -> bool
 				{
 					if(!lhs->first || !rhs->first)
 						return lhs->first;
@@ -2748,10 +2749,10 @@ void PlayerInfo::Save(const string &path) const
 					else
 						return lhs->second->Name() < rhs->second->Name();
 				},
-				[](DataWriter &dw, const pair<const System *, const Outfit *> &it)
+				[&out](const HarvestLog &it)
 				{
 					if(it.first && it.second)
-						dw.Write(it.first->Name(), it.second->Name());
+						out.Write(it.first->Name(), it.second->Name());
 				});
 		}
 		out.EndChild();

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -704,13 +704,14 @@ void Ship::Save(DataWriter &out) const
 		out.Write("outfits");
 		out.BeginChild();
 		{
-			WriteSorted(out, outfits,
-				[](const pair<const Outfit *const, int> *lhs, const pair<const Outfit *const, int> *rhs){ return lhs->first->Name() < rhs->first->Name(); },
-				[](DataWriter &dw, const pair<const Outfit *, int> &it){
+			using OutfitElement = pair<const Outfit *const, int>;
+			WriteSorted(outfits,
+				[](const OutfitElement *lhs, const OutfitElement *rhs){ return lhs->first->Name() < rhs->first->Name(); },
+				[&out](const pair<const Outfit *, int> &it){
 					if(it.second == 1)
-						dw.Write(it.first->Name());
+						out.Write(it.first->Name());
 					else
-						dw.Write(it.first->Name(), it.second);
+						out.Write(it.first->Name(), it.second);
 				});
 		}
 		out.EndChild();
@@ -795,16 +796,21 @@ void Ship::Save(DataWriter &out) const
 		}
 		for(const Leak &leak : leaks)
 			out.Write("leak", leak.effect->Name(), leak.openPeriod, leak.closePeriod);
-		auto effectSort = [](const pair<const Effect *const, int> *lhs, const pair<const Effect *const, int> *rhs){
+		
+		using EffectElement = pair<const Effect *const, int>;
+		auto effectSort = [](const EffectElement *lhs, const EffectElement *rhs)
+		{
 			return lhs->first->Name() < rhs->first->Name();
 		};
-		WriteSorted(out, explosionEffects, effectSort, [](DataWriter &dw, const pair<const Effect *const, int> &it){
+		WriteSorted(explosionEffects, effectSort, [&out](const EffectElement &it)
+		{
 			if(it.first && it.second)
-				dw.Write("explode", it.first->Name(), it.second);
+				out.Write("explode", it.first->Name(), it.second);
 		});
-		WriteSorted(out, finalExplosions, effectSort, [](DataWriter &dw, const pair<const Effect *const, int> &it){
+		WriteSorted(finalExplosions, effectSort, [&out](const EffectElement &it)
+		{
 			if(it.first && it.second)
-				dw.Write("final explode", it.first->Name(), it.second);
+				out.Write("final explode", it.first->Name(), it.second);
 		});
 		
 		if(currentSystem)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -706,8 +706,9 @@ void Ship::Save(DataWriter &out) const
 		{
 			using OutfitElement = pair<const Outfit *const, int>;
 			WriteSorted(outfits,
-				[](const OutfitElement *lhs, const OutfitElement *rhs){ return lhs->first->Name() < rhs->first->Name(); },
-				[&out](const pair<const Outfit *, int> &it){
+				[](const OutfitElement *lhs, const OutfitElement *rhs)
+					{ return lhs->first->Name() < rhs->first->Name(); },
+				[&out](const OutfitElement &it){
 					if(it.second == 1)
 						out.Write(it.first->Name());
 					else
@@ -799,17 +800,15 @@ void Ship::Save(DataWriter &out) const
 		
 		using EffectElement = pair<const Effect *const, int>;
 		auto effectSort = [](const EffectElement *lhs, const EffectElement *rhs)
-		{
-			return lhs->first->Name() < rhs->first->Name();
-		};
+			{ return lhs->first->Name() < rhs->first->Name(); };
 		WriteSorted(explosionEffects, effectSort, [&out](const EffectElement &it)
 		{
-			if(it.first && it.second)
+			if(it.second)
 				out.Write("explode", it.first->Name(), it.second);
 		});
 		WriteSorted(finalExplosions, effectSort, [&out](const EffectElement &it)
 		{
-			if(it.first && it.second)
+			if(it.second)
 				out.Write("final explode", it.first->Name(), it.second);
 		});
 		
@@ -1770,15 +1769,11 @@ void Ship::DoGeneration()
 			sort(carried.begin(), carried.end(), (isYours && Preferences::Has(FIGHTER_REPAIR))
 				// Players may use a parallel strategy, to launch fighters in waves.
 				? [] (const pair<double, Ship *> &lhs, const pair<double, Ship *> &rhs)
-				{
-					return lhs.first > rhs.first;
-				}
+					{ return lhs.first > rhs.first; }
 				// The default strategy is to prioritize the healthiest ship first, in
 				// order to get fighters back out into the battle as soon as possible.
 				: [] (const pair<double, Ship *> &lhs, const pair<double, Ship *> &rhs)
-				{
-					return lhs.first < rhs.first;
-				}
+					{ return lhs.first < rhs.first; }
 			);
 			
 			// Apply shield and hull repair to carried fighters.


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #5171 
closes #5324 

## Feature Details
Where parts of the player's save were not deterministically ordered, they now are. A template method, and a specialization for uses of std::map for a pointer type key, are used to create a vector of pointers to the collection elements, which is then sorted and iterated.

To avoid future code from manipulating DataWriters incorrectly, deletes the copy & move constructors / operators for it.

## UI Screenshots
n/a''

## Usage Examples
n/a

## Testing Done
Saved & loaded & saved again a couple times

## Performance Impact
n/a