### PR TITLE
Conditional spaceport news

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -793,13 +793,13 @@ double GameData::SolarWind(const Sprite *sprite)
 
 
 
-// Pick a random news object that applies to the given planet. If there is
-// no applicable news, this returns null.
-const News *GameData::PickNews(const Planet *planet)
+// Pick a random news object that applies to the player's planets and conditions.
+// If there is no applicable news, this returns null.
+const News *GameData::PickNews(const Planet *planet, const PlayerInfo &player)
 {
 	vector<const News *> matches;
 	for(const auto &it : news)
-		if(!it.second.IsEmpty() && it.second.Matches(planet))
+		if(!it.second.IsEmpty() && it.second.Matches(planet, player))
 			matches.push_back(&it.second);
 	
 	return matches.empty() ? nullptr : matches[Random::Int(matches.size())];

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -667,6 +667,13 @@ const Set<Mission> &GameData::Missions()
 
 
 
+const Set<News> &GameData::SpaceportNews()
+{
+	return news;
+}
+
+
+
 const Set<Outfit> &GameData::Outfits()
 {
 	return outfits;
@@ -789,20 +796,6 @@ double GameData::SolarWind(const Sprite *sprite)
 {
 	auto it = solarWind.find(sprite);
 	return (it == solarWind.end() ? 0. : it->second);
-}
-
-
-
-// Pick a random news object that applies to the player's planets and conditions.
-// If there is no applicable news, this returns null.
-const News *GameData::PickNews(const Planet *planet, const PlayerInfo &player)
-{
-	vector<const News *> matches;
-	for(const auto &it : news)
-		if(!it.second.IsEmpty() && it.second.Matches(planet, player))
-			matches.push_back(&it.second);
-	
-	return matches.empty() ? nullptr : matches[Random::Int(matches.size())];
 }
 
 

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -13,7 +13,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef GAME_DATA_H_
 #define GAME_DATA_H_
 
-#include "PlayerInfo.h"
 #include "Sale.h"
 #include "Set.h"
 #include "Trade.h"
@@ -105,6 +104,7 @@ public:
 	static const Set<Interface> &Interfaces();
 	static const Set<Minable> &Minables();
 	static const Set<Mission> &Missions();
+	static const Set<News> &SpaceportNews();
 	static const Set<Outfit> &Outfits();
 	static const Set<Sale<Outfit>> &Outfitters();
 	static const Set<Person> &Persons();
@@ -127,10 +127,6 @@ public:
 	// Get the solar power and wind output of the given stellar object sprite.
 	static double SolarPower(const Sprite *sprite);
 	static double SolarWind(const Sprite *sprite);
-	
-	// Pick a random news object that applies to the player's planets and conditions.
-	// If there is no applicable news, this returns null.
-	static const News *PickNews(const Planet *planet, const PlayerInfo &player);
 	
 	// Strings for combat rating levels, etc.
 	static const std::string &Rating(const std::string &type, int level);

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef GAME_DATA_H_
 #define GAME_DATA_H_
 
+#include "PlayerInfo.h"
 #include "Sale.h"
 #include "Set.h"
 #include "Trade.h"
@@ -127,9 +128,9 @@ public:
 	static double SolarPower(const Sprite *sprite);
 	static double SolarWind(const Sprite *sprite);
 	
-	// Pick a random news object that applies to the given planet. If there is
-	// no applicable news, this returns null.
-	static const News *PickNews(const Planet *planet);
+	// Pick a random news object that applies to the player's planets and conditions.
+	// If there is no applicable news, this returns null.
+	static const News *PickNews(const Planet *planet, const PlayerInfo &player);
 	
 	// Strings for combat rating levels, etc.
 	static const std::string &Rating(const std::string &type, int level);

--- a/source/News.cpp
+++ b/source/News.cpp
@@ -13,7 +13,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "News.h"
 
 #include "DataNode.h"
-#include "PlayerInfo.h"
 #include "Random.h"
 #include "SpriteSet.h"
 
@@ -86,7 +85,7 @@ void News::Load(const DataNode &node)
 				messages.Load(child);
 		}
 		else if(tag == "to" && hasValue)
-		{		
+		{
 			if(child.Token(valueIndex) == "show")
 			{
 				if(remove)

--- a/source/News.cpp
+++ b/source/News.cpp
@@ -84,6 +84,19 @@ void News::Load(const DataNode &node)
 			else
 				messages.Load(child);
 		}
+		// Handle the attributes which cannot be "removed" or "added."
+		else if(add || remove)
+		{
+			child.PrintTrace("Cannot \"add\" or \"remove\" a specific value from the given key:");
+			continue;
+		}
+		else if(tag == "to" && hasValue)
+		{
+			if(child.Token(valueIndex) == "show")
+				toShow.Load(child);
+			else
+				child.PrintTrace("Unrecognized news attribute:");
+		}
 		else
 			child.PrintTrace("Unrecognized news attribute:");
 	}
@@ -98,14 +111,14 @@ bool News::IsEmpty() const
 
 
 
-// Check if this news item is available on the given planet.
-bool News::Matches(const Planet *planet) const
+// Check if this news item is available given the player's planet and conditions.
+bool News::Matches(const Planet *planet, const PlayerInfo &player) const
 {
 	// If no location filter is specified, it should never match. This can be
 	// used to create news items that are never shown until an event "activates"
 	// them by specifying their location.
 	// Similarly, by updating a news item with "remove location", it can be deactivated.
-	return location.IsEmpty() ? false : location.Matches(planet);
+	return location.IsEmpty() ? false : (location.Matches(planet) && toShow.Test(player.Conditions()));
 }
 
 

--- a/source/News.cpp
+++ b/source/News.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "News.h"
 
 #include "DataNode.h"
+#include "PlayerInfo.h"
 #include "Random.h"
 #include "SpriteSet.h"
 
@@ -112,13 +113,13 @@ bool News::IsEmpty() const
 
 
 // Check if this news item is available given the player's planet and conditions.
-bool News::Matches(const Planet *planet, const PlayerInfo &player) const
+bool News::Matches(const PlayerInfo &player) const
 {
 	// If no location filter is specified, it should never match. This can be
 	// used to create news items that are never shown until an event "activates"
 	// them by specifying their location.
 	// Similarly, by updating a news item with "remove location", it can be deactivated.
-	return location.IsEmpty() ? false : (location.Matches(planet) && toShow.Test(player.Conditions()));
+	return location.IsEmpty() ? false : (location.Matches(player.GetPlanet()) && toShow.Test(player.Conditions()));
 }
 
 

--- a/source/News.cpp
+++ b/source/News.cpp
@@ -85,16 +85,15 @@ void News::Load(const DataNode &node)
 			else
 				messages.Load(child);
 		}
-		// Handle the attributes which cannot be "removed" or "added."
-		else if(add || remove)
-		{
-			child.PrintTrace("Cannot \"add\" or \"remove\" a specific value from the given key:");
-			continue;
-		}
 		else if(tag == "to" && hasValue)
-		{
+		{		
 			if(child.Token(valueIndex) == "show")
-				toShow.Load(child);
+			{
+				if(remove)
+					toShow = ConditionSet{};
+				else
+					toShow.Load(child);
+			}
 			else
 				child.PrintTrace("Unrecognized news attribute:");
 		}
@@ -113,13 +112,13 @@ bool News::IsEmpty() const
 
 
 // Check if this news item is available given the player's planet and conditions.
-bool News::Matches(const PlayerInfo &player) const
+bool News::Matches(const Planet *planet, const map<string, int64_t> &conditions) const
 {
 	// If no location filter is specified, it should never match. This can be
 	// used to create news items that are never shown until an event "activates"
 	// them by specifying their location.
 	// Similarly, by updating a news item with "remove location", it can be deactivated.
-	return location.IsEmpty() ? false : (location.Matches(player.GetPlanet()) && toShow.Test(player.Conditions()));
+	return location.IsEmpty() ? false : (location.Matches(planet) && toShow.Test(conditions));
 }
 
 

--- a/source/News.h
+++ b/source/News.h
@@ -22,7 +22,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 class DataNode;
 class Planet;
-class PlayerInfo;
 class Sprite;
 
 

--- a/source/News.h
+++ b/source/News.h
@@ -36,7 +36,7 @@ public:
 	// Check whether this news item has anything to say.
 	bool IsEmpty() const;
 	// Check if this news item is available given the player's planet and conditions.
-	bool Matches(const PlayerInfo &player) const;
+	bool Matches(const Planet *planet, const std::map<std::string, std::int64_t> &conditions) const;
 	
 	// Get the speaker's name.
 	std::string Name() const;

--- a/source/News.h
+++ b/source/News.h
@@ -16,13 +16,13 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "ConditionSet.h"
 #include "LocationFilter.h"
 #include "Phrase.h"
-#include "PlayerInfo.h"
 
 #include <string>
 #include <vector>
 
 class DataNode;
 class Planet;
+class PlayerInfo;
 class Sprite;
 
 
@@ -36,7 +36,7 @@ public:
 	// Check whether this news item has anything to say.
 	bool IsEmpty() const;
 	// Check if this news item is available given the player's planet and conditions.
-	bool Matches(const Planet *planet, const PlayerInfo &player) const;
+	bool Matches(const PlayerInfo &player) const;
 	
 	// Get the speaker's name.
 	std::string Name() const;

--- a/source/News.h
+++ b/source/News.h
@@ -13,8 +13,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef NEWS_H_
 #define NEWS_H_
 
+#include "ConditionSet.h"
 #include "LocationFilter.h"
 #include "Phrase.h"
+#include "PlayerInfo.h"
 
 #include <string>
 #include <vector>
@@ -33,8 +35,8 @@ public:
 	
 	// Check whether this news item has anything to say.
 	bool IsEmpty() const;
-	// Check if this news item is available on the given planet.
-	bool Matches(const Planet *planet) const;
+	// Check if this news item is available given the player's planet and conditions.
+	bool Matches(const Planet *planet, const PlayerInfo &player) const;
 	
 	// Get the speaker's name.
 	std::string Name() const;
@@ -46,6 +48,7 @@ public:
 	
 private:
 	LocationFilter location;
+	ConditionSet toShow;
 	
 	Phrase names;
 	std::vector<const Sprite *> portraits;

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -48,7 +48,7 @@ SpaceportPanel::SpaceportPanel(PlayerInfo &player)
 
 void SpaceportPanel::UpdateNews()
 {
-	const News *news = GameData::PickNews(player.GetPlanet());
+	const News *news = GameData::PickNews(player.GetPlanet(), player);
 	if(!news)
 		return;
 	hasNews = true;

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -20,6 +20,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "Point.h"
+#include "Random.h"
 #include "UI.h"
 
 using namespace std;
@@ -48,7 +49,7 @@ SpaceportPanel::SpaceportPanel(PlayerInfo &player)
 
 void SpaceportPanel::UpdateNews()
 {
-	const News *news = GameData::PickNews(player.GetPlanet(), player);
+	const News *news = PickNews();
 	if(!news)
 		return;
 	hasNews = true;
@@ -100,4 +101,18 @@ void SpaceportPanel::Draw()
 		newsMessage.Draw(interface->GetBox(hasPortrait ? "message portrait" : "message").TopLeft(),
 			*GameData::Colors().Get("medium"));
 	}
+}
+
+
+
+// Pick a random news object that applies to the player's planets and conditions.
+// If there is no applicable news, this returns null.
+const News *SpaceportPanel::PickNews() const
+{
+	vector<const News *> matches;
+	for(const auto &it : GameData::SpaceportNews())
+		if(!it.second.IsEmpty() && it.second.Matches(player))
+			matches.push_back(&it.second);
+	
+	return matches.empty() ? nullptr : matches[Random::Int(matches.size())];
 }

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -110,8 +110,10 @@ void SpaceportPanel::Draw()
 const News *SpaceportPanel::PickNews() const
 {
 	vector<const News *> matches;
+	const Planet *planet = player.GetPlanet();
+	const map<string, int64_t> &conditions = player.Conditions();
 	for(const auto &it : GameData::SpaceportNews())
-		if(!it.second.IsEmpty() && it.second.Matches(player))
+		if(!it.second.IsEmpty() && it.second.Matches(planet, conditions))
 			matches.push_back(&it.second);
 	
 	return matches.empty() ? nullptr : matches[Random::Int(matches.size())];

--- a/source/SpaceportPanel.h
+++ b/source/SpaceportPanel.h
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Information.h"
 #include "WrappedText.h"
 
+class News;
 class PlayerInfo;
 
 
@@ -32,6 +33,10 @@ public:
 	
 	virtual void Step() override;
 	virtual void Draw() override;
+	
+	
+private:
+	const News *PickNews() const;
 	
 	
 private:


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4945.

## Feature Details
Adds a new node to news, `to show`. This is a condition set like `to offer` that must be passed in order for the news item to show, in addition to the location filter matching.

## UI Screenshots
N/A

## Usage Examples
```
news "reminiscing about the war"
	...
	to show
		has "main plot completed"
	...
```

## Testing Done
Created three news entries. One had no show conditions. The second was set to only show before the main plot was completed. The third was set to only show after the main plot was completed. All three news entries showed under the proper conditions.

## Performance Impact
N/A
