### PR TITLE
Support data files encoded by UTF-8.

### DIFF
--- a/EndlessSky.cbp
+++ b/EndlessSky.cbp
@@ -323,6 +323,8 @@
 		<Unit filename="source/TradingPanel.h" />
 		<Unit filename="source/UI.cpp" />
 		<Unit filename="source/UI.h" />
+		<Unit filename="source/Utf8.cpp" />
+		<Unit filename="source/Utf8.h" />
 		<Unit filename="source/Visual.cpp" />
 		<Unit filename="source/Visual.h" />
 		<Unit filename="source/Weapon.cpp" />

--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		A9C70E101C0E5B51000B3D14 /* File.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9C70E0E1C0E5B51000B3D14 /* File.cpp */; };
 		A9CC526D1950C9F6004E4E22 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9CC526C1950C9F6004E4E22 /* Cocoa.framework */; };
 		A9D40D1A195DFAA60086EE52 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9D40D19195DFAA60086EE52 /* OpenGL.framework */; };
+		B590161321ED4A0F00799178 /* Utf8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B590161121ED4A0E00799178 /* Utf8.cpp */; };
 		B55C239D2303CE8B005C1A14 /* GameWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B55C239B2303CE8A005C1A14 /* GameWindow.cpp */; };
 		B5DDA6942001B7F600DBA76A /* News.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5DDA6922001B7F600DBA76A /* News.cpp */; };
 		DF8D57E11FC25842001525DA /* Dictionary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57DF1FC25842001525DA /* Dictionary.cpp */; };
@@ -431,6 +432,8 @@
 		A9CC52701950C9F6004E4E22 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		A9CC52711950C9F6004E4E22 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		A9D40D19195DFAA60086EE52 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		B590161121ED4A0E00799178 /* Utf8.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Utf8.cpp; path = source/Utf8.cpp; sourceTree = "<group>"; };
+		B590161221ED4A0F00799178 /* Utf8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Utf8.h; path = source/Utf8.h; sourceTree = "<group>"; };
 		B55C239B2303CE8A005C1A14 /* GameWindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameWindow.cpp; path = source/GameWindow.cpp; sourceTree = "<group>"; };
 		B55C239C2303CE8A005C1A14 /* GameWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameWindow.h; path = source/GameWindow.h; sourceTree = "<group>"; };
 		B5DDA6922001B7F600DBA76A /* News.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = News.cpp; path = source/News.cpp; sourceTree = "<group>"; };
@@ -717,6 +720,8 @@
 				A96863991AE6FD0D004FE1FE /* TradingPanel.h */,
 				A968639A1AE6FD0D004FE1FE /* UI.cpp */,
 				A968639B1AE6FD0D004FE1FE /* UI.h */,
+				B590161121ED4A0E00799178 /* Utf8.cpp */,
+				B590161221ED4A0F00799178 /* Utf8.h */,
 				DF8D57E21FC25889001525DA /* Visual.cpp */,
 				DF8D57E31FC25889001525DA /* Visual.h */,
 				A968639C1AE6FD0D004FE1FE /* Weapon.cpp */,
@@ -881,6 +886,7 @@
 				A96863E01AE6FD0E004FE1FE /* Panel.cpp in Sources */,
 				A96863D21AE6FD0E004FE1FE /* MapDetailPanel.cpp in Sources */,
 				DFAAE2AA1FD4A27B0072C0A8 /* ImageSet.cpp in Sources */,
+				B590161321ED4A0F00799178 /* Utf8.cpp in Sources */,
 				A96863D41AE6FD0E004FE1FE /* Mask.cpp in Sources */,
 				A96863E61AE6FD0E004FE1FE /* Point.cpp in Sources */,
 				A96863DE1AE6FD0E004FE1FE /* OutfitterPanel.cpp in Sources */,

--- a/copyright
+++ b/copyright
@@ -814,10 +814,6 @@ Copyright: Tommaso Becca
 License: CC-BY-SA-4.0
 Comment: Derived from works by ESA/Hubble & NASA (under the same license)
 
-Files: source/Utf8.*
-Copyright: 2017, 2018 by Flávio J. Saraiva
-License: GPL-3+
-
 License: GPL-3+
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/copyright
+++ b/copyright
@@ -814,6 +814,10 @@ Copyright: Tommaso Becca
 License: CC-BY-SA-4.0
 Comment: Derived from works by ESA/Hubble & NASA (under the same license)
 
+Files: source/Utf8.*
+Copyright: 2017, 2018 by Flávio J. Saraiva
+License: GPL-3+
+
 License: GPL-3+
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/source/DataFile.cpp
+++ b/source/DataFile.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataFile.h"
 
 #include "Files.h"
+#include "Utf8.h"
 
 using namespace std;
 
@@ -49,7 +50,7 @@ void DataFile::Load(const string &path)
 	root.tokens.push_back("file");
 	root.tokens.push_back(path);
 	
-	Load(&*data.begin(), &*data.end());
+	LoadData(data);
 }
 
 
@@ -57,7 +58,7 @@ void DataFile::Load(const string &path)
 // Constructor, taking an istream. This can be cin or a file.
 void DataFile::Load(istream &in)
 {
-	vector<char> data;
+	string data;
 	
 	static const size_t BLOCK = 4096;
 	while(in)
@@ -68,10 +69,10 @@ void DataFile::Load(istream &in)
 		data.resize(currentSize + in.gcount());
 	}
 	// As a sentinel, make sure the file always ends in a newline.
-	if(data.back() != '\n')
+	if(data.empty() || data.back() != '\n')
 		data.push_back('\n');
 	
-	Load(&*data.begin(), &*data.end());
+	LoadData(data);
 }
 
 
@@ -93,7 +94,7 @@ list<DataNode>::const_iterator DataFile::end() const
 
 
 // Parse the given text.
-void DataFile::Load(const char *it, const char *end)
+void DataFile::LoadData(const string &data)
 {
 	// Keep track of the current stack of indentation levels and the most recent
 	// node at each level - that is, the node that will be the "parent" of any
@@ -104,16 +105,19 @@ void DataFile::Load(const char *it, const char *end)
 	bool warned = false;
 	size_t lineNumber = 0;
 	
-	for( ; it != end; ++it)
+	size_t end = data.length();
+	for(size_t pos = 0; pos < end; pos = Utf8::NextCodePoint(data, pos))
 	{
 		++lineNumber;
+		char32_t c = Utf8::DecodeCodePoint(data, pos);
+		
 		// Find the first non-white character in this line.
 		bool isSpaces = false;
 		int white = 0;
-		for( ; *it <= ' ' && *it != '\n'; ++it)
+		while(c <= ' ' && c != '\n')
 		{
 			// Warn about mixed indentations when parsing files.
-			if(!isSpaces && *it == ' ')
+			if(!isSpaces && c == ' ')
 			{
 				// If we've parsed whitespace that wasn't a space, issue a warning.
 				if(white)
@@ -123,23 +127,28 @@ void DataFile::Load(const char *it, const char *end)
 				
 				isSpaces = true;
 			}
-			else if(fileIsSpaces && !warned && *it != ' ')
+			else if(fileIsSpaces && !warned && c != ' ')
 			{
 				warned = true;
 				stack.back()->PrintTrace("Mixed whitespace usage in file");
 			}
 			
 			++white;
+			pos = Utf8::NextCodePoint(data, pos);
+			c = Utf8::DecodeCodePoint(data, pos);
 		}
 		
 		// If the line is a comment, skip to the end of the line.
-		if(*it == '#')
+		if(c == '#')
 		{
-			while(*it != '\n')
-				++it;
+			while(c != '\n')
+			{
+				pos = Utf8::NextCodePoint(data, pos);
+				c = Utf8::DecodeCodePoint(data, pos);
+			}
 		}
 		// Skip empty lines (including comment lines).
-		if(*it == '\n')
+		if(c == '\n')
 			continue;
 		
 		// Determine where in the node tree we are inserting this node, based on
@@ -161,45 +170,62 @@ void DataFile::Load(const char *it, const char *end)
 		whiteStack.push_back(white);
 		
 		// Tokenize the line. Skip comments and empty lines.
-		while(*it != '\n')
+		while(c != '\n')
 		{
 			// Check if this token begins with a quotation mark. If so, it will
 			// include everything up to the next instance of that mark.
-			char endQuote = *it;
+			char32_t endQuote = c;
 			bool isQuoted = (endQuote == '"' || endQuote == '`');
-			it += isQuoted;
+			if(isQuoted)
+			{
+				pos = Utf8::NextCodePoint(data, pos);
+				c = Utf8::DecodeCodePoint(data, pos);
+			}
 			
-			const char *start = it;
+			const size_t start = pos;
 			
 			// Find the end of this token.
-			while(*it != '\n' && (isQuoted ? (*it != endQuote) : (*it > ' ')))
-				++it;
+			while(c != '\n' && (isQuoted ? (c != endQuote) : (c > ' ')))
+			{
+				pos = Utf8::NextCodePoint(data, pos);
+				c = Utf8::DecodeCodePoint(data, pos);
+			}
 			
 			// It ought to be legal to construct a string from an empty iterator
 			// range, but it appears that some libraries do not handle that case
 			// correctly. So:
-			if(start == it)
+			if(start == pos)
 				node.tokens.emplace_back();
 			else
-				node.tokens.emplace_back(start, it);
+				node.tokens.emplace_back(data, start, pos - start);
 			// This is not a fatal error, but it may indicate a format mistake:
-			if(isQuoted && *it == '\n')
+			if(isQuoted && c == '\n')
 				node.PrintTrace("Closing quotation mark is missing:");
 			
-			if(*it != '\n')
+			if(c != '\n')
 			{
 				// If we've not yet reached the end of the line of text, search
 				// forward for the next non-whitespace character.
-				it += isQuoted;
-				while(*it != '\n' && *it <= ' ' && *it != '#')
-					++it;
+				if(isQuoted)
+				{
+					pos = Utf8::NextCodePoint(data, pos);
+					c = Utf8::DecodeCodePoint(data, pos);
+				}
+				while(c != '\n' && c <= ' ' && c != '#')
+				{
+					pos = Utf8::NextCodePoint(data, pos);
+					c = Utf8::DecodeCodePoint(data, pos);
+				}
 				
 				// If a comment is encountered outside of a token, skip the rest
 				// of this line of the file.
-				if(*it == '#')
+				if(c == '#')
 				{
-					while(*it != '\n')
-						++it;
+					while(c != '\n')
+					{
+						pos = Utf8::NextCodePoint(data, pos);
+						c = Utf8::DecodeCodePoint(data, pos);
+					}
 				}
 			}
 		}

--- a/source/DataFile.h
+++ b/source/DataFile.h
@@ -43,7 +43,7 @@ public:
 	
 	
 private:
-	void Load(const char *it, const char *end);
+	void LoadData(const std::string &data);
 	
 	
 private:

--- a/source/DataNode.cpp
+++ b/source/DataNode.cpp
@@ -71,6 +71,7 @@ const vector<string> &DataNode::Tokens() const
 
 
 // Get the token with the given index. No bounds checking is done.
+// DataFile loading guarantees index 0 always exists.
 const string &DataNode::Token(int index) const
 {
 	return tokens[index];

--- a/source/DataNode.h
+++ b/source/DataNode.h
@@ -40,6 +40,7 @@ public:
 	// Get all the tokens in this node as an iterable vector.
 	const std::vector<std::string> &Tokens() const;
 	// Get the token at the given index. No bounds checking is done internally.
+	// DataFile loading guarantees index 0 always exists.
 	const std::string &Token(int index) const;
 	// Convert the token at the given index to a number. This returns 0 if the
 	// index is out of range or the token cannot be interpreted as a number.

--- a/source/DataWriter.cpp
+++ b/source/DataWriter.cpp
@@ -105,7 +105,7 @@ void DataWriter::WriteToken(const char *a)
 	bool hasQuote = false;
 	for(const char *it = a; *it; ++it)
 	{
-		hasSpace |= (*it <= ' ');
+		hasSpace |= (*it <= ' ' && *it >= 0);
 		hasQuote |= (*it == '"');
 	}
 	

--- a/source/Utf8.cpp
+++ b/source/Utf8.cpp
@@ -1,0 +1,105 @@
+/* Utf8.cpp
+Copyright (c) 2017, 2018 by Flavio J. Saraiva
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "Utf8.h"
+
+using namespace std;
+
+namespace Utf8 {
+	size_t NextCodePoint(const string &str, size_t pos)
+	{
+		if(pos >= str.length())
+			return str.length();
+		
+		for(++pos; pos < str.length(); ++pos)
+			if((str[pos] & 0x80) == 0 || (str[pos] & 0xc0) == 0xc0)
+				break;
+		return pos;
+	}
+	
+	
+	
+	// Returns the start of the unicode code point at pos in utf8.
+	size_t CodePointStart(const string &str, size_t pos)
+	{
+		// 0xxxxxxx and 11?????? start a code point
+		while(pos > 0 && (str[pos] & 0x80) != 0x00 && (str[pos] & 0xc0) != 0xc0)
+			--pos;
+		return pos;
+	}
+	
+	
+	
+	// Determines the number of bytes used by the unicode code point in utf8.
+	int CodePointBytes(const char *str)
+	{
+		// end - 00000000
+		if(!str || !*str)
+			return 0;
+		
+		// 1 byte - 0xxxxxxx
+		if((*str & 0x80) == 0)
+			return 1;
+		
+		// invalid - 10?????? or 11?????? invalid
+		if((*str & 0x40) == 0 || (*(str + 1) & 0xc0) != 0x80)
+			return -1;
+		
+		// 2 bytes - 110xxxxx 10xxxxxx
+		if((*str & 0x20) == 0)
+			return 2;
+		
+		// invalid - 111????? 10?????? invalid
+		if((*(str + 2) & 0xc0) != 0x80)
+			return -1;
+		
+		// 3 bytes - 1110xxxx 10xxxxxx 10xxxxxx
+		if((*str & 0x10) == 0)
+			return 3;
+		
+		// invalid - 1111???? 10?????? 10?????? invalid
+		if((*(str + 3) & 0xc0) != 0x80)
+			return -1;
+		
+		// 4 bytes - 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+		if((*str & 0x8) == 0)
+			return 4;
+		
+		// not unicode - 11111??? 10?????? 10?????? 10??????
+		return -1;
+	}
+	
+	
+	
+	// Decodes a unicode code point in utf8.
+	// Invalid codepoints are converted to 0xFFFFFFFF.
+	char32_t DecodeCodePoint(const string &str, size_t pos)
+	{
+		if(pos >= str.length())
+			return 0;
+		
+		// invalid (-1) or end (0)
+		int bytes = CodePointBytes(str.c_str() + pos);
+		if(bytes < 1)
+			return bytes;
+		
+		// 1 byte
+		if(bytes == 1)
+			return (str[pos] & 0x7f);
+		
+		// 2-4 bytes
+		char32_t c = (str[pos] & ((1 << (7 - bytes)) - 1));
+		for(int i = 1; i < bytes; ++i)
+			c = (c << 6) + (str[pos + i] & 0x3f);
+		return c;
+	}
+}

--- a/source/Utf8.cpp
+++ b/source/Utf8.cpp
@@ -18,7 +18,7 @@ namespace Utf8 {
 	size_t NextCodePoint(const string &str, size_t pos)
 	{
 		if(pos >= str.length())
-			return str.length();
+			return string::npos;
 		
 		for(++pos; pos < str.length(); ++pos)
 			if((str[pos] & 0x80) == 0 || (str[pos] & 0xc0) == 0xc0)
@@ -82,24 +82,30 @@ namespace Utf8 {
 	
 	// Decodes a unicode code point in utf8.
 	// Invalid codepoints are converted to 0xFFFFFFFF.
-	char32_t DecodeCodePoint(const string &str, size_t pos)
+	char32_t DecodeCodePoint(const string &str, size_t &pos)
 	{
 		if(pos >= str.length())
+		{
+			pos = string::npos;
 			return 0;
+		}
 		
 		// invalid (-1) or end (0)
 		int bytes = CodePointBytes(str.c_str() + pos);
 		if(bytes < 1)
+		{
+			++pos;
 			return bytes;
+		}
 		
 		// 1 byte
 		if(bytes == 1)
-			return (str[pos] & 0x7f);
+			return (str[pos++] & 0x7f);
 		
 		// 2-4 bytes
-		char32_t c = (str[pos] & ((1 << (7 - bytes)) - 1));
+		char32_t c = (str[pos++] & ((1 << (7 - bytes)) - 1));
 		for(int i = 1; i < bytes; ++i)
-			c = (c << 6) + (str[pos + i] & 0x3f);
+			c = (c << 6) + (str[pos++] & 0x3f);
 		return c;
 	}
 }

--- a/source/Utf8.h
+++ b/source/Utf8.h
@@ -18,7 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 namespace Utf8 {
 	// Skip to the next unicode code point after pos in utf8.
-	// Return the string length when there are no more code points.
+	// Return string::npos when there are no more code points.
 	std::size_t NextCodePoint(const std::string &str, std::size_t pos);
 	
 	// Returns the start of the unicode code point at pos in utf8.
@@ -26,7 +26,9 @@ namespace Utf8 {
 	
 	// Decodes a unicode code point in utf8.
 	// Invalid codepoints are converted to 0xFFFFFFFF.
-	char32_t DecodeCodePoint(const std::string &str, std::size_t pos);
+	// pos skips to the next unicode code point after pos in utf8,
+	// or is set string::npos when there are no more code points.
+	char32_t DecodeCodePoint(const std::string &str, std::size_t &pos);
 }
 
 #endif

--- a/source/Utf8.h
+++ b/source/Utf8.h
@@ -1,0 +1,32 @@
+/* Utf8.h
+Copyright (c) 2017, 2018 by Flavio J. Saraiva
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef UTF8_H_
+#define UTF8_H_
+
+#include <cstddef>
+#include <string>
+
+namespace Utf8 {
+	// Skip to the next unicode code point after pos in utf8.
+	// Return the string length when there are no more code points.
+	std::size_t NextCodePoint(const std::string &str, std::size_t pos);
+	
+	// Returns the start of the unicode code point at pos in utf8.
+	std::size_t CodePointStart(const std::string &str, std::size_t pos);
+	
+	// Decodes a unicode code point in utf8.
+	// Invalid codepoints are converted to 0xFFFFFFFF.
+	char32_t DecodeCodePoint(const std::string &str, std::size_t pos);
+}
+
+#endif


### PR DESCRIPTION
**Feature:** This is a part of #4123 (for now) and needs no extra libraries.

## Feature Details
This PR allows Endless Sky to read a data file contains a character encoded by UTF-8.

The code originates from #3312 and it is written by flaviojs.

## UI Screenshots
N/A

## Usage Examples
[test-data.zip](https://github.com/endless-sky/endless-sky/files/5217965/test-data.zip)
This plugin introduces the government β that has the display name "Beta."

```
government β
	"display name" "Beta"
```

## Testing Done
The current master detects this when reading the plugin:

```
Skipping unrecognized root object:
file ${HOME}/.local/share/endless-sky/plugins/test-for-datafile-encoded-utf-8/data/governments.txt
L11:   government
```

This PR version raises no error.

## Performance Impact
N/A