### PR TITLE
Remove unused member variable.

### DIFF
--- a/source/ShipInfoPanel.h
+++ b/source/ShipInfoPanel.h
@@ -86,11 +86,10 @@ private:
 	std::vector<ClickZone<int>> zones;
 	std::vector<ClickZone<std::string>> commodityZones;
 	std::vector<ClickZone<const Outfit *>> plunderZones;
-	// Keep track of which item the mouse is hovering over, which item was most
-	// recently selected, and which item is currently being dragged.
+	// Keep track of which item the mouse is hovering over and which item is
+	// currently being dragged.
 	int hoverIndex = -1;
 	int draggingIndex = -1;
-	int selectedIndex = -1;
 	// Track the current mouse location.
 	Point hoverPoint;
 	// You can only make changes to ships when landed on a planet.


### PR DESCRIPTION
Nothing more to add. `ShipInfoPanel::selectedIndex` was unused and clang generated a warning which failed the build due to `-Werror`.