### PR TITLE
AI improvements for afterburners and reverse thrusters.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1755,8 +1755,15 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition, const
 	
 	bool shouldReverse = false;
 	dp = targetPosition - StoppingPoint(ship, targetVelocity, shouldReverse);
+	if(dp.Length() < radius && shouldReverse)
+	{
+		// We can directly use the reverse thrusters to stop at the target.
+		command |= Command::BACK;
+		return false;
+	}
+
 	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .8);
-	if(!isClose || (!isFacing && !shouldReverse))
+	if(!isClose || !isFacing)
 		command.SetTurn(TurnToward(ship, dp));
 	if(isFacing)
 		command |= Command::FORWARD;
@@ -1891,8 +1898,16 @@ void AI::CircleAround(Ship &ship, Command &command, const Body &target)
 {
 	Point direction = target.Position() - ship.Position();
 	command.SetTurn(TurnToward(ship, direction));
-	if(ship.Facing().Unit().Dot(direction) >= 0. && direction.Length() > 200.)
+
+	double length = direction.Length();
+	if(ship.Facing().Unit().Dot(direction) >= 0. && length > 200.)
+	{
 		command |= Command::FORWARD;
+
+		// If the ship is far away enough the ship should use the afterburner.
+		if(length > 750. && ShouldUseAfterburner(ship))
+			command |= Command::AFTERBURNER;
+	}
 }
 
 
@@ -2090,8 +2105,12 @@ void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 	double circumference = stepsInFullTurn * ship.Velocity().Length();
 	double diameter = max(200., circumference / PI);
 	
+	// If the ship has reverse thrusters and the target is behind it, we can
+	// use them to reach the target more quickly.
+	if(ship.Facing().Unit().Dot(d.Unit()) < -.75 && ship.Attributes().Get("reverse thrust"))
+		command |= Command::BACK;
 	// This isn't perfect, but it works well enough.
-	if((ship.Facing().Unit().Dot(d) >= 0. && d.Length() > diameter)
+	else if((ship.Facing().Unit().Dot(d) >= 0. && d.Length() > diameter)
 			|| (ship.Velocity().Dot(d) < 0. && ship.Facing().Unit().Dot(d.Unit()) >= .9))
 		command |= Command::FORWARD;
 	

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1755,7 +1755,7 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition, const
 	
 	bool shouldReverse = false;
 	dp = targetPosition - StoppingPoint(ship, targetVelocity, shouldReverse);
-	if(dp.Length() < radius && shouldReverse)
+	if(shouldReverse && dp.Length() < radius)
 	{
 		// We can directly use the reverse thrusters to stop at the target.
 		command |= Command::BACK;
@@ -1900,7 +1900,7 @@ void AI::CircleAround(Ship &ship, Command &command, const Body &target)
 	command.SetTurn(TurnToward(ship, direction));
 
 	double length = direction.Length();
-	if(ship.Facing().Unit().Dot(direction) >= 0. && length > 200.)
+	if(length > 200. && ship.Facing().Unit().Dot(direction) >= 0.)
 	{
 		command |= Command::FORWARD;
 


### PR DESCRIPTION
This PR improves the AI a bit when the ship has afterburners or reverse thrusters.

1. `CircleAround` now uses the afterburner for speed - basically PR #4655 which the author has abandoned with the review incorporated.

2. `MoveTo` now better uses the reverse thruster if possible. For example, when landing on a planet while flying straight to it will now use the reverse thruster to stop instead of turning around<sup>1</sup>.

3. `MoveToAttack` uses reverse thrusters to reach the enemy quicker.

More details:

`CircleAround` will, if the ship is 750 away from the target fire its afterburners. This gives it enough time to gather without shooting past the target.

`MoveToAttack` circles the enemy, but if the enemy flies through the ship then currently the ship turns around. But if it has reverse thrusters it can reverse to reach the enemy, all while still turning to face it. The enemy has a tiny bit of a harder time evading.

<sup>1</sup> (`MoveTo`) The ship will only use the reverse thrusters if doing Shift+Down in that frame results in the ship being on the target. But keep in mind that if turning + stopping is faster than the reverse thruster then the reverse thruster won't be used.

## Testing Done

I tested each feature; here are the save files. [1](https://gist.github.com/Rakete1111/5cb0a9627dff7c9295cc31ffcdf72843) [2](https://gist.github.com/Rakete1111/1d86e4a82b92ea0be30a53ed25e60de5) [3](https://gist.github.com/Rakete1111/2fd6dfd93db408b90e4f5a1264d209e4)

## Performance Impact
N/A