### PR TITLE
Re-name Sestor vessels to follow prime number naming scheme

### DIFF
--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -646,9 +646,9 @@ ship "Tek Far 71 - Lek" "Tek Far 71 - Lek (Close Quarters)"
 	turret "Korath Repeater Turret"
 
 
-ship "Tek Far 78 - Osk"
-	sprite "ship/tek far 78 osk"
-	thumbnail "thumbnail/tek far 78 osk"
+ship "Tek Far 79 - Osk"
+	sprite "ship/tek far 79 osk"
+	thumbnail "thumbnail/tek far 79 osk"
 	attributes
 		category "Medium Warship"
 		"cost" 25630000
@@ -715,7 +715,7 @@ ship "Tek Far 78 - Osk"
 	"final explode" "final explosion large"
 	description "This carrier is equipped with docking clamps for up to nine fighters. When loaded with a full complement of the powerful Kor Sestor robotic fighters, it is a formidable opponent."
 
-ship "Tek Far 78 - Osk" "Tek Far 78 - Osk (Close Quarters)"
+ship "Tek Far 79 - Osk" "Tek Far 79 - Osk (Close Quarters)"
 	outfits
 		"Korath Detainer"
 		"Korath Warder" 2
@@ -898,9 +898,9 @@ ship "Met Par Tek 53" "Met Par Tek 53 (Sniper)"
 	turret
 
 
-ship "Far Lek 14"
-	sprite "ship/far lek 14"
-	thumbnail "thumbnail/far lek 14"
+ship "Far Lek 13"
+	sprite "ship/far lek 13"
+	thumbnail "thumbnail/far lek 13"
 	attributes
 		category "Drone"
 		"cost" 573000
@@ -936,9 +936,9 @@ ship "Far Lek 14"
 	description "At the peak of their recent civil war, the Kor Sestor faction developed these automated attack drones, easy to manufacture and encased in an ultra-dense hull that can absorb a significant amount of damage."
 
 
-ship "Far Osk 27"
-	sprite "ship/far osk 27"
-	thumbnail "thumbnail/far osk 27"
+ship "Far Osk 29"
+	sprite "ship/far osk 29"
+	thumbnail "thumbnail/far osk 29"
 	attributes
 		category "Fighter"
 		"cost" 761000
@@ -972,7 +972,7 @@ ship "Far Osk 27"
 	gun 13 -8
 	explode "tiny explosion" 25
 	explode "small explosion" 15
-	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to carry far more weaponry than any comparable human ship."
+	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS29 fighter is able to carry far more weaponry than any comparable human ship."
 
 
 

--- a/data/korath/korath.txt
+++ b/data/korath/korath.txt
@@ -259,46 +259,46 @@ fleet "Small Kor Sestor"
 		"Met Par Tek 53 (Sniper)" 3
 	variant 8
 		"Tek Far 71 - Lek"
-		"Far Lek 14" 10
+		"Far Lek 13" 10
 	variant 5
 		"Tek Far 71 - Lek (Close Quarters)"
-		"Far Lek 14" 10
+		"Far Lek 13" 10
 	variant
 		"Tek Far 71 - Lek"
-		"Far Lek 14" 6
+		"Far Lek 13" 6
 	variant
 		"Tek Far 71 - Lek (Close Quarters)"
-		"Far Lek 14" 4
+		"Far Lek 13" 4
 	variant
 		"Tek Far 71 - Lek (Close Quarters)"
-		"Far Lek 14" 2
+		"Far Lek 13" 2
 	variant 6
-		"Tek Far 78 - Osk"
-		"Far Osk 27" 9
+		"Tek Far 79 - Osk"
+		"Far Osk 29" 9
 	variant 4
-		"Tek Far 78 - Osk (Close Quarters)"
-		"Far Osk 27" 9
+		"Tek Far 79 - Osk (Close Quarters)"
+		"Far Osk 29" 9
 	variant
-		"Tek Far 78 - Osk"
-		"Far Osk 27" 7
+		"Tek Far 79 - Osk"
+		"Far Osk 29" 7
 	variant
-		"Tek Far 78 - Osk (Close Quarters)"
-		"Far Osk 27" 5
+		"Tek Far 79 - Osk (Close Quarters)"
+		"Far Osk 29" 5
 	variant
-		"Tek Far 78 - Osk"
-		"Far Osk 27" 2
+		"Tek Far 79 - Osk"
+		"Far Osk 29" 2
 	variant 3
 		"Tek Far 109"
-		"Far Lek 14" 9
-		"Far Osk 27" 7
+		"Far Lek 13" 9
+		"Far Osk 29" 7
 	variant
 		"Tek Far 109"
-		"Far Lek 14" 6
-		"Far Osk 27" 3
+		"Far Lek 13" 6
+		"Far Osk 29" 3
 	variant
 		"Tek Far 109"
-		"Far Lek 14" 3
-		"Far Osk 27" 2
+		"Far Lek 13" 3
+		"Far Osk 29" 2
 
 fleet "Large Kor Sestor"
 	government "Kor Sestor"
@@ -308,69 +308,69 @@ fleet "Large Kor Sestor"
 	variant 8
 		"Kar Ik Vot 349"
 		"Tek Far 71 - Lek"
-		"Far Lek 14" 10
+		"Far Lek 13" 10
 		"Met Par Tek 53" 2
 	variant 4
 		"Kar Ik Vot 349 (Defense)"
 		"Tek Far 71 - Lek (Close Quarters)"
-		"Far Lek 14" 8
+		"Far Lek 13" 8
 		"Met Par Tek 53 (Sniper)" 2
 	variant 4
 		"Kar Ik Vot 349 (Offense)"
 		"Tek Far 71 - Lek"
-		"Far Lek 14" 9
+		"Far Lek 13" 9
 		"Met Par Tek 53"
 		"Met Par Tek 53 (Sniper)"
 	variant 4
 		"Kar Ik Vot 349 (Trapper)"
 		"Tek Far 71 - Lek (Close Quarters)"
-		"Far Lek 14" 7
+		"Far Lek 13" 7
 		"Met Par Tek 53"
 		"Met Par Tek 53 (Sniper)"
 	variant 8
 		"Kar Ik Vot 349"
-		"Tek Far 78 - Osk"
-		"Far Osk 27" 9
+		"Tek Far 79 - Osk"
+		"Far Osk 29" 9
 		"Met Par Tek 53"
 	variant 4
 		"Kar Ik Vot 349 (Defense)"
-		"Tek Far 78 - Osk (Close Quarters)"
-		"Far Osk 27" 7
+		"Tek Far 79 - Osk (Close Quarters)"
+		"Far Osk 29" 7
 		"Met Par Tek 53"
 	variant 4
 		"Kar Ik Vot 349 (Offense)"
-		"Tek Far 78 - Osk"
-		"Far Osk 27" 8
+		"Tek Far 79 - Osk"
+		"Far Osk 29" 8
 		"Met Par Tek 53 (Sniper)"
 	variant 4
 		"Kar Ik Vot 349 (Trapper)"
-		"Tek Far 78 - Osk (Close Quarters)"
-		"Far Osk 27" 6
+		"Tek Far 79 - Osk (Close Quarters)"
+		"Far Osk 29" 6
 		"Met Par Tek 53 (Sniper)"
 	variant 4
 		"Kar Ik Vot 349"
 		"Tek Far 71 - Lek"
-		"Far Lek 14" 10
-		"Tek Far 78 - Osk"
-		"Far Osk 27" 9
+		"Far Lek 13" 10
+		"Tek Far 79 - Osk"
+		"Far Osk 29" 9
 	variant 2
 		"Kar Ik Vot 349 (Defense)"
 		"Tek Far 71 - Lek (Close Quarters)"
-		"Far Lek 14" 8
-		"Tek Far 78 - Osk"
-		"Far Osk 27" 8
+		"Far Lek 13" 8
+		"Tek Far 79 - Osk"
+		"Far Osk 29" 8
 	variant 2
 		"Kar Ik Vot 349 (Offense)"
 		"Tek Far 71 - Lek"
-		"Far Lek 14" 9
-		"Tek Far 78 - Osk (Close Quarters)"
-		"Far Osk 27" 7
+		"Far Lek 13" 9
+		"Tek Far 79 - Osk (Close Quarters)"
+		"Far Osk 29" 7
 	variant 2
 		"Kar Ik Vot 349 (Trapper)"
 		"Tek Far 71 - Lek (Close Quarters)"
-		"Far Lek 14" 7
-		"Tek Far 78 - Osk (Close Quarters)"
-		"Far Osk 27" 6
+		"Far Lek 13" 7
+		"Tek Far 79 - Osk (Close Quarters)"
+		"Far Osk 29" 6
 	variant 2
 		"Kar Ik Vot 349"
 	variant 1
@@ -395,21 +395,21 @@ fleet "Large Kor Sestor"
 		"Met Par Tek 53 (Sniper)" 3
 	variant 5
 		"Tek Far 109" 3
-		"Far Lek 14" 27
-		"Far Osk 27" 21
+		"Far Lek 13" 27
+		"Far Osk 29" 21
 	variant 3
 		"Tek Far 109"
 		"Tek Far 71 - Lek"
-		"Tek Far 78 - Osk"
-		"Far Lek 14" 17
-		"Far Osk 27" 13
+		"Tek Far 79 - Osk"
+		"Far Lek 13" 17
+		"Far Osk 29" 13
 		"Met Par Tek 53 (Sniper)" 2
 	variant 3
 		"Tek Far 109"
 		"Tek Far 71 - Lek (Close Quarters)"
-		"Tek Far 78 - Osk (Close Quarters)"
-		"Far Lek 14" 17
-		"Far Osk 27" 13
+		"Tek Far 79 - Osk (Close Quarters)"
+		"Far Lek 13" 17
+		"Far Osk 29" 13
 		"Met Par Tek 53" 2
 
 

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -1622,7 +1622,7 @@ mission "Wanderers: Sestor Attack"
 			variant
 				"Kar Ik Vot 349 (Trapper)"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Far Lek 14" 7
+				"Far Lek 13" 7
 				"Met Par Tek 53"
 				"Met Par Tek 53 (Sniper)"
 		fleet
@@ -1630,8 +1630,8 @@ mission "Wanderers: Sestor Attack"
 			fighters "kor sestor fighter"
 			variant
 				"Kar Ik Vot 349 (Defense)"
-				"Tek Far 78 - Osk (Close Quarters)"
-				"Far Osk 27" 7
+				"Tek Far 79 - Osk (Close Quarters)"
+				"Far Osk 29" 7
 				"Met Par Tek 53"
 	npc evade
 		government "Kor Sestor"
@@ -1642,26 +1642,26 @@ mission "Wanderers: Sestor Attack"
 			variant
 				"Tek Far 109"
 				"Tek Far 71 - Lek"
-				"Tek Far 78 - Osk"
-				"Far Lek 14" 17
-				"Far Osk 27" 13
+				"Tek Far 79 - Osk"
+				"Far Lek 13" 17
+				"Far Osk 29" 13
 				"Met Par Tek 53 (Sniper)" 2
 		fleet
 			names "kor sestor"
 			fighters "kor sestor fighter"
 			variant
 				"Tek Far 109" 3
-				"Far Lek 14" 27
-				"Far Osk 27" 21
+				"Far Lek 13" 27
+				"Far Osk 29" 21
 		fleet
 			names "kor sestor"
 			fighters "kor sestor fighter"
 			variant
 				"Kar Ik Vot 349 (Trapper)"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Far Lek 14" 7
-				"Tek Far 78 - Osk (Close Quarters)"
-				"Far Osk 27" 6
+				"Far Lek 13" 7
+				"Tek Far 79 - Osk (Close Quarters)"
+				"Far Osk 29" 6
 	npc
 		government "Wanderer"
 		personality staying heroic
@@ -1875,7 +1875,7 @@ mission "Wanderers: Sestor Search: Human Spaceport"
 				`	"You should be glad you're still in one piece."`
 					goto glad1
 					
-			`	"Well," the pilot says, "we had hired a beefy Leviathan escort to Farpoint. When we were going in for landing, two of these hostile ships jumped in from the northwest, the direction of all the anarchist colonies in this area. The ships weren't big, but they were tough: our four heavy laser turrets weren't enough to produce even a dent in their shields. They made short work of the Leviathan, and nearly disabled our ship, too. It was lucky I decided that jumping would be faster than landing. We warped out of the system while in atmosphere, saving the ship, but now I'm in debt to all my crew because I couldn't meet a rush delivery deadline. Still had to deliver the goods, but lost a pretty substantial bonus."`
+			`	"Well," the pilot says, "we had hired a beefy Leviathan escort to Farpoint in the Alnitak system. When we were going in for landing, two of these hostile ships jumped in from the northwest, the direction of all the anarchist colonies in this area. The ships weren't big, but they were tough: our four heavy laser turrets weren't enough to produce even a dent in their shields. They made short work of the Leviathan, and nearly disabled our ship, too. It was lucky I decided that jumping would be faster than landing. We warped out of the system while in atmosphere, saving the ship, but now I'm in debt to all my crew because I couldn't meet a rush delivery deadline."`
 			choice
 				`	"You're lucky as hell to be here today."`
 					goto glad
@@ -1883,7 +1883,7 @@ mission "Wanderers: Sestor Search: Human Spaceport"
 					goto thanks
 					
 			label where
-			`	"Well," the pilot says, "we were on a deadline to do a large cargo run to Farpoint, when two of these hostile ships jumped in from the northwest, the direction of all the anarchist colonies in this area. I had to jump the ship in atmosphere to stop us from getting shredded by their strange melting weaponry. I immediately reported the attack to a desk clerk at the Navy base in the neighboring system Saiph, but their servers show no logs of any unidentified ships beyond Farpoint, so I guess they turned around after scouting out the Alnitak system. Just my luck to be in the system the moment those things entered, too, because I missed the delivery deadline. Still had to deliver the goods, but lost a pretty substantial bonus."`
+			`	"Well," the pilot says, "we were doing a large cargo run to Farpoint in the Alnitak system, when two of these hostile ships jumped in from the northwest, the direction of all the anarchist colonies in this area. I had to jump the ship in atmosphere to stop us from getting shredded by their strange melting weaponry. I immediately reported the attack to a desk clerk at the Navy base in the neighboring system Saiph, but their servers show no logs of any unidentified ships beyond Farpoint, so I guess they turned around after scouting out the Alnitak system."`
 			choice
 				`	"You're lucky as hell to be here today."`
 					goto glad
@@ -1891,7 +1891,7 @@ mission "Wanderers: Sestor Search: Human Spaceport"
 					goto thanks
 			
 			label glad1
-			`	"I am! The attacking ships weren't big, but they were tough: our four heavy laser turrets couldn't even produce a dent in their shields," the captain says. "We even hired a beefy Leviathan to protect us from the pirate raids as we traveled to Farpoint, but when these hostile ships jumped in from the northwest, they made short work of our escort and nearly disabled our ship, too. I had to jump out of the system while in atmosphere to save the ship, but now I'm in debt to all my crew because I didn't meet a rush delivery deadline. Still had to deliver the goods, but lost a pretty substantial bonus."`
+			`	"I am! The attacking ships weren't big, but they were tough: our four heavy laser turrets couldn't even produce a dent in their shields," the captain says. "We even hired a beefy Leviathan to protect us from the pirate raids as we traveled to Farpoint, but when these hostile ships jumped in from the northwest, they made short work of our escort and nearly disabled our ship, too. I had to jump out of the system while in atmosphere to save the ship, but now I'm in debt to all my crew because I didn't meet a rush delivery deadline."`
 			choice
 				`	"You really are lucky as hell to be here today."`
 					goto glad
@@ -1993,15 +1993,15 @@ mission "Wanderers: Sestor: Farpoint Attack 1"
 			variant
 				"Kar Ik Vot 349"
 				"Tek Far 71 - Lek"
-				"Far Lek 14" 10
+				"Far Lek 13" 10
 				"Met Par Tek 53" 2
 		fleet
 			names "kor sestor"
 			fighters "kor sestor fighter"
 			variant
 				"Kar Ik Vot 349 (Offense)"
-				"Tek Far 78 - Osk"
-				"Far Osk 27" 8
+				"Tek Far 79 - Osk"
+				"Far Osk 29" 8
 				"Met Par Tek 53 (Sniper)"
 		fleet
 			names "kor sestor"
@@ -2134,7 +2134,7 @@ mission "Wanderers: Sestor: Alnilam Fleet 2"
 			variant
 				"Kar Ik Vot 349 (Defense)"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Far Lek 14" 10
+				"Far Lek 13" 10
 
 
 
@@ -2255,7 +2255,7 @@ mission "Wanderers: Sestor: Farpoint Attack 2"
 			variant
 				"Kar Ik Vot 349"
 				"Tek Far 71 - Lek"
-				"Far Lek 14" 10
+				"Far Lek 13" 10
 				"Met Par Tek 53" 2
 		fleet
 			names "kor sestor"
@@ -2263,23 +2263,23 @@ mission "Wanderers: Sestor: Farpoint Attack 2"
 			variant
 				"Kar Ik Vot 349 (Defense)"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Far Lek 14" 8
+				"Far Lek 13" 8
 				"Met Par Tek 53 (Sniper)" 2
 		fleet
 			names "kor sestor"
 			fighters "kor sestor fighter"
 			variant
 				"Kar Ik Vot 349 (Offense)"
-				"Tek Far 78 - Osk"
-				"Far Osk 27" 8
+				"Tek Far 79 - Osk"
+				"Far Osk 29" 8
 				"Met Par Tek 53 (Sniper)"
 		fleet
 			names "kor sestor"
 			fighters "kor sestor fighter"
 			variant
 				"Kar Ik Vot 349 (Trapper)"
-				"Tek Far 78 - Osk (Close Quarters)"
-				"Far Osk 27" 6
+				"Tek Far 79 - Osk (Close Quarters)"
+				"Far Osk 29" 6
 				"Met Par Tek 53 (Sniper)"
 		fleet
 			names "kor sestor"
@@ -2287,27 +2287,27 @@ mission "Wanderers: Sestor: Farpoint Attack 2"
 			variant
 				"Kar Ik Vot 349 (Defense)"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Far Lek 14" 8
-				"Tek Far 78 - Osk"
-				"Far Osk 27" 8
+				"Far Lek 13" 8
+				"Tek Far 79 - Osk"
+				"Far Osk 29" 8
 		fleet
 			names "kor sestor"
 			fighters "kor sestor fighter"
 			variant
 				"Kar Ik Vot 349 (Offense)"
 				"Tek Far 71 - Lek"
-				"Far Lek 14" 9
-				"Tek Far 78 - Osk (Close Quarters)"
-				"Far Osk 27" 7
+				"Far Lek 13" 9
+				"Tek Far 79 - Osk (Close Quarters)"
+				"Far Osk 29" 7
 		fleet
 			names "kor sestor"
 			fighters "kor sestor fighter"
 			variant
 				"Kar Ik Vot 349 (Trapper)"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Far Lek 14" 7
-				"Tek Far 78 - Osk (Close Quarters)"
-				"Far Osk 27" 6
+				"Far Lek 13" 7
+				"Tek Far 79 - Osk (Close Quarters)"
+				"Far Osk 29" 6
 		fleet
 			names "kor sestor"
 			fighters "kor sestor fighter"
@@ -2334,9 +2334,9 @@ mission "Wanderers: Sestor: Farpoint Attack 2"
 			variant
 				"Tek Far 109"
 				"Tek Far 71 - Lek"
-				"Tek Far 78 - Osk"
-				"Far Lek 14" 17
-				"Far Osk 27" 13
+				"Tek Far 79 - Osk"
+				"Far Lek 13" 17
+				"Far Osk 29" 13
 				"Met Par Tek 53 (Sniper)" 2
 		fleet
 			names "kor sestor"
@@ -2344,9 +2344,9 @@ mission "Wanderers: Sestor: Farpoint Attack 2"
 			variant
 				"Tek Far 109"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Tek Far 78 - Osk (Close Quarters)"
-				"Far Lek 14" 17
-				"Far Osk 27" 13
+				"Tek Far 79 - Osk (Close Quarters)"
+				"Far Lek 13" 17
+				"Far Osk 29" 13
 				"Met Par Tek 53" 2
 		dialog `Against all odds, all the Kor Sestor ships attacking the Oathkeepers have been destroyed. Maybe you won't have to use Danforth's bomb after all.`
 
@@ -2369,7 +2369,7 @@ mission "Wanderers: Sestor: Scattered Remnant"
 			variant
 				"Kar Ik Vot 349"
 				"Tek Far 71 - Lek"
-				"Far Lek 14" 10
+				"Far Lek 13" 10
 				"Met Par Tek 53" 2
 		dialog `All of the Kor Sestor ships in this system have been eliminated.`
 	npc kill
@@ -2382,7 +2382,7 @@ mission "Wanderers: Sestor: Scattered Remnant"
 			variant
 				"Kar Ik Vot 349 (Defense)"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Far Lek 14" 8
+				"Far Lek 13" 8
 				"Met Par Tek 53 (Sniper)" 2
 		dialog `All of the Kor Sestor ships in this system have been eliminated.`
 	npc kill
@@ -2394,16 +2394,16 @@ mission "Wanderers: Sestor: Scattered Remnant"
 			fighters "kor sestor fighter"
 			variant
 				"Kar Ik Vot 349 (Offense)"
-				"Tek Far 78 - Osk"
-				"Far Osk 27" 8
+				"Tek Far 79 - Osk"
+				"Far Osk 29" 8
 				"Met Par Tek 53 (Sniper)"
 		fleet
 			names "kor sestor"
 			fighters "kor sestor fighter"
 			variant
 				"Kar Ik Vot 349 (Trapper)"
-				"Tek Far 78 - Osk (Close Quarters)"
-				"Far Osk 27" 6
+				"Tek Far 79 - Osk (Close Quarters)"
+				"Far Osk 29" 6
 				"Met Par Tek 53 (Sniper)"
 		dialog `All of the Kor Sestor ships in this system have been eliminated.`
 	npc kill
@@ -2416,9 +2416,9 @@ mission "Wanderers: Sestor: Scattered Remnant"
 			variant
 				"Kar Ik Vot 349 (Defense)"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Far Lek 14" 8
-				"Tek Far 78 - Osk"
-				"Far Osk 27" 8
+				"Far Lek 13" 8
+				"Tek Far 79 - Osk"
+				"Far Osk 29" 8
 		dialog `All of the Kor Sestor ships in this system have been eliminated.`
 	npc kill
 		system "Mebsuta"
@@ -2430,9 +2430,9 @@ mission "Wanderers: Sestor: Scattered Remnant"
 			variant
 				"Kar Ik Vot 349 (Offense)"
 				"Tek Far 71 - Lek"
-				"Far Lek 14" 9
-				"Tek Far 78 - Osk (Close Quarters)"
-				"Far Osk 27" 7
+				"Far Lek 13" 9
+				"Tek Far 79 - Osk (Close Quarters)"
+				"Far Osk 29" 7
 		dialog `All of the Kor Sestor ships in this system have been eliminated.`
 	npc kill
 		system "Rigel"
@@ -2444,9 +2444,9 @@ mission "Wanderers: Sestor: Scattered Remnant"
 			variant
 				"Kar Ik Vot 349 (Trapper)"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Far Lek 14" 7
-				"Tek Far 78 - Osk (Close Quarters)"
-				"Far Osk 27" 6
+				"Far Lek 13" 7
+				"Tek Far 79 - Osk (Close Quarters)"
+				"Far Osk 29" 6
 		dialog `All of the Kor Sestor ships in this system have been eliminated.`
 	npc kill
 		system "Castor"
@@ -2493,9 +2493,9 @@ mission "Wanderers: Sestor: Scattered Remnant"
 			variant
 				"Tek Far 109"
 				"Tek Far 71 - Lek"
-				"Tek Far 78 - Osk"
-				"Far Lek 14" 17
-				"Far Osk 27" 13
+				"Tek Far 79 - Osk"
+				"Far Lek 13" 17
+				"Far Osk 29" 13
 				"Met Par Tek 53 (Sniper)" 2
 		dialog `All of the Kor Sestor ships in this system have been eliminated.`
 	npc kill
@@ -2508,9 +2508,9 @@ mission "Wanderers: Sestor: Scattered Remnant"
 			variant
 				"Tek Far 109"
 				"Tek Far 71 - Lek (Close Quarters)"
-				"Tek Far 78 - Osk (Close Quarters)"
-				"Far Lek 14" 17
-				"Far Osk 27" 13
+				"Tek Far 79 - Osk (Close Quarters)"
+				"Far Lek 13" 17
+				"Far Osk 29" 13
 				"Met Par Tek 53" 2
 		dialog `All of the Kor Sestor ships in this system have been eliminated.`
 		
@@ -2938,7 +2938,7 @@ mission "Wanderers: Sestor: Scan Drones"
 		government "Kor Sestor"
 		personality heroic staying
 		ship "Kar Ik Vot 349" "07-134.2"
-		ship "Tek Far 78 - Osk" "07-894.0"
+		ship "Tek Far 79 - Osk" "07-894.0"
 		ship "Tek Far 71 - Lek" "07-554.3"
 		ship "Met Par Tek 53" "07-983.2"
 		ship "Met Par Tek 53" "07-992.1"
@@ -3179,15 +3179,15 @@ mission "Wanderers: Sestor: Factory 2"
 			variant
 				"Kar Ik Vot 349"
 				"Tek Far 71 - Lek"
-				"Far Lek 14" 10
+				"Far Lek 13" 10
 				"Met Par Tek 53" 2
 		fleet
 			names "kor sestor"
 			fighters "kor sestor fighter"
 			variant
 				"Kar Ik Vot 349 (Offense)"
-				"Tek Far 78 - Osk"
-				"Far Osk 27" 8
+				"Tek Far 79 - Osk"
+				"Far Osk 29" 8
 				"Met Par Tek 53 (Sniper)" 2
 		fleet
 			names "kor sestor"
@@ -3195,9 +3195,9 @@ mission "Wanderers: Sestor: Factory 2"
 			variant
 				"Tek Far 109"
 				"Tek Far 71 - Lek"
-				"Tek Far 78 - Osk"
-				"Far Lek 14" 17
-				"Far Osk 27" 13
+				"Tek Far 79 - Osk"
+				"Far Lek 13" 17
+				"Far Osk 29" 13
 
 
 
@@ -3268,20 +3268,20 @@ event "wanderers: exiles have drones"
 	fleet "Korath Home"
 		add variant 2
 			"Tek Far 71 - Lek"
-			"Far Lek 14" 6
+			"Far Lek 13" 6
 		add variant 2
 			"Tek Far 71 - Lek (Close Quarters)"
-			"Far Lek 14" 4
+			"Far Lek 13" 4
 		add variant 2
-			"Tek Far 78 - Osk (Close Quarters)"
-			"Far Osk 27" 5
+			"Tek Far 79 - Osk (Close Quarters)"
+			"Far Osk 29" 5
 		add variant 2
-			"Tek Far 78 - Osk"
-			"Far Osk 27" 2
+			"Tek Far 79 - Osk"
+			"Far Osk 29" 2
 		add variant 3
 			"Tek Far 109"
-			"Far Lek 14" 9
-			"Far Osk 27" 7
+			"Far Lek 13" 9
+			"Far Osk 29" 7
 		add variant 3
 			"Met Par Tek 53" 3
 		add variant 2
@@ -3386,7 +3386,7 @@ mission "Wanderers: Sestor: Final"
 			variant
 				"Model 32"
 				"Model 16" 3
-				"Tek Far 78 - Osk"
+				"Tek Far 79 - Osk"
 				"Met Par Tek 53 (Sniper)" 2
 	on visit
 		dialog phrase "generic waypoint on visit"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -769,7 +769,7 @@ mission "Wanderers: Jump Drive Source"
 	to complete
 		has "Unfettered: Jump Drive Source: offered"
 	on visit
-		dialog `You have not yet tried to sell the Unfettered Hai a jump drive. Return here after doing so.`
+		dialog `You have not yet tried to sell the Unfettered Hai a Jump Drive. Return here after doing so.`
 	on complete
 		conversation
 			`You report to Iktat Rek. "Most [intriguing, disturbing]," he says. "If what you say of these Alpha humans is [correct, unbiased], they are a dangerous foe. And in exchange for so many jump drives, no doubt the Unfettered have [supplied, furnished] them with many weapons." He pauses to think for a minute, then says, "You must track them. There is a Wanderer [device, technology] that can help you. But I must ask our [elders, government] for permission before giving you access to it. I will meet you back in the spaceport soon."`
@@ -1145,16 +1145,16 @@ mission "Wanderers: Alpha Surveillance D"
 		government "Alpha"
 		system "Host"
 		personality heroic nemesis staying vindictive
-		ship "Far Osk 27" "Dasher"
-		ship "Far Osk 27" "Dancer"
-		ship "Far Osk 27" "Prancer"
-		ship "Far Osk 27" "Vixen"
-		ship "Far Lek 14" "Cupid"
-		ship "Far Lek 14" "Comet"
-		ship "Far Lek 14" "Donner"
-		ship "Far Lek 14" "Blitzen"
-		ship "Far Lek 14" "Rudolph"
-		ship "Far Lek 14" "Ralph"
+		ship "Far Osk 29" "Dasher"
+		ship "Far Osk 29" "Dancer"
+		ship "Far Osk 29" "Prancer"
+		ship "Far Osk 29" "Vixen"
+		ship "Far Lek 13" "Cupid"
+		ship "Far Lek 13" "Comet"
+		ship "Far Lek 13" "Donner"
+		ship "Far Lek 13" "Blitzen"
+		ship "Far Lek 13" "Rudolph"
+		ship "Far Lek 13" "Ralph"
 	
 	on visit
 		dialog `You've returned to <planet>, but you have a feeling that your job isn't done. Either find where the Alphas are hiding, or return to where they are hiding and finish what you started.`
@@ -2635,7 +2635,7 @@ mission "Wanderers Ap'arak 3"
 		has "Wanderers Ap'arak 2: done"
 	on offer
 		log `The Wanderers have begun producing even larger warships, and have succeeded in driving off yet another Unfettered assault. Afterwards the Pug, whom the Wanderers refer to as the "Keepers," finally sent assistance... in the form of two ships, which they claim are powerful enough to keep the entire Unfettered fleet at bay.`
-		log "Factions" "Unfettered Hai" `After obtaining a sufficient number of jump drives, the Unfettered expanded into Wanderer space and managed to conquer six worlds from the Wanderers before their advance was stopped due to Pug interference.`
+		log "Factions" "Unfettered Hai" `After obtaining a sufficient number of Jump Drives, the Unfettered expanded into Wanderer space and managed to conquer six worlds from the Wanderers before their advance was stopped due to Pug interference.`
 		conversation
 			`The Wanderers here seem incredulous that they managed to drive off such a powerful Unfettered attack force. As you walk through the spaceport, many of them stop to thank you for your assistance in defending their home.`
 			`	Just as you reach the pavilion where the military leaders are gathering, a shadow falls over you, and you look up to see two ships approaching with the unmistakable horned silhouettes of Pug warships. Throughout the spaceport you hear Wanderer voices raised in excitement, and hundreds of them leap into the air to accompany the Pug ships to the landing pad. Sobari Tele'ek says to you, "It is a [visitation, appearance] of the Keepers! In our hour of [need, desperation] they make themselves known at last." A small delegation of Pug disembarks from the ships and approaches the pavilion on foot.`


### PR DESCRIPTION
## Feature Details
Kor Sestor vessels, for the most part, follow a naming pattern of ship models being assigned a prime number. This brings outliers in line to follow that pattern.

Changed names are:
"Far Lek 14" -> "Far Lek 13"
"Far Osk 27" -> "Far Osk 29"
"Tek Far 78 - Osk" -> "Tek Far 79 - Osk"

## Testing Done
The changes work fine on new pilots, but the altered ship names lead to conflicts on older saves which have had new fleets added in by events prior to this proposed update. While this can be remedied through some "find and replace" save editing, I'll admit it's a bit of a pain.

## Performance Impact
N/A
