### PR TITLE
feat(interface): add hire-max and fire-max hotkeys

### DIFF
--- a/source/HiringPanel.cpp
+++ b/source/HiringPanel.cpp
@@ -117,6 +117,16 @@ bool HiringPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 		player.Flagship()->AddCrew(-min(maxFire, Modifier()));
 		player.UpdateCargoCapacities();
 	}
+	else if(key == 'H')
+	{
+		player.Flagship()->AddCrew(maxHire);
+		player.UpdateCargoCapacities();
+	}
+	else if(key == 'F')
+	{
+		player.Flagship()->AddCrew(-maxFire);
+		player.UpdateCargoCapacities();
+	}
 	
 	return false;
 }


### PR DESCRIPTION
NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!) 

-----------------------
**Feature:** This PR implements the feature with no related issue.

## Feature Details
Add two hotkeys to the hiring panel. 'H' for hire max and 'F' for fire max.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
N/A

## Performance Impact
N/A
