### PR TITLE
Skip capacity check on Uninstall

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -458,13 +458,13 @@ void CargoHold::TransferAll(CargoHold &to, bool transferPassengers)
 
 
 // Add the given amount of the given commodity.
-int CargoHold::Add(const string &commodity, int amount)
+int CargoHold::Add(const string &commodity, int amount, bool force)
 {
 	if(amount < 0)
 		return -Remove(commodity, -amount);
 	
-	// If this cargo hold has a size limit, apply it.
-	if(size >= 0)
+	// If this cargo hold has a size limit, apply it (unless forced).
+	if(!force && size >= 0)
 		amount = max(0, min(amount, Free()));
 	commodities[commodity] += amount;
 	return amount;
@@ -473,14 +473,14 @@ int CargoHold::Add(const string &commodity, int amount)
 
 
 // Add the given number of copies of the given outfit.
-int CargoHold::Add(const Outfit *outfit, int amount)
+int CargoHold::Add(const Outfit *outfit, int amount, bool force)
 {
 	if(amount < 0)
 		return -Remove(outfit, -amount);
 	
-	// If the outfit has mass and this cargo hold has a size limit, apply it.
+	// If the outfit has mass and this cargo hold has a size limit, apply it (unless forced).
 	double mass = outfit->Mass();
-	if(size >= 0 && mass > 0.)
+	if(!force && size >= 0 && mass > 0.)
 		amount = max(0, min(amount, static_cast<int>(Free() / mass)));
 	outfits[outfit] += amount;
 	return amount;

--- a/source/CargoHold.h
+++ b/source/CargoHold.h
@@ -86,8 +86,8 @@ public:
 	
 	// These functions do the same thing as Transfer() with no destination
 	// specified, but they have clearer names to make the code more readable.
-	int Add(const std::string &commodity, int amount = 1);
-	int Add(const Outfit *outfit, int amount = 1);
+	int Add(const std::string &commodity, int amount = 1, bool force = false);
+	int Add(const Outfit *outfit, int amount = 1, bool force = false);
 	int Remove(const std::string &commodity, int amount = 1);
 	int Remove(const Outfit *outfit, int amount = 1);
 	

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -582,9 +582,10 @@ void OutfitterPanel::Sell(bool toCargo)
 			if(selectedOutfit->Get("required crew"))
 				ship->AddCrew(-selectedOutfit->Get("required crew"));
 			ship->Recharge();
-			if(toCargo && player.Cargo().Add(selectedOutfit))
+			if(toCargo)
 			{
-				// Transfer to cargo completed.
+				// Transfer to cargo even if it would exceed the capacity
+				player.Cargo().Add(selectedOutfit, 1, true)
 			}
 			else
 			{

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -585,7 +585,7 @@ void OutfitterPanel::Sell(bool toCargo)
 			if(toCargo)
 			{
 				// Transfer to cargo even if it would exceed the capacity
-				player.Cargo().Add(selectedOutfit, 1, true)
+				player.Cargo().Add(selectedOutfit, 1, true);
 			}
 			else
 			{


### PR DESCRIPTION
**Feature:** This PR implements a trivial quality-of-life feature

## Feature Details
Having 'u' sometimes uninstall the outfits and sometimes sell them is very confusing.
Always place uninstalled outfits into the cargo hold, even if it exceeds its capacity.
This change will make swapping active and inactive outfits much more comfortable.

## UI Screenshots
N/A

## Testing Done
None, sorry.
If it passes CI, it should be good to go.

## Performance Impact
N/A

Thank you!