### PR TITLE
Fixed Mission.cpp default init for EMPTY

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -958,7 +958,7 @@ const string &Mission::Identifier() const
 const MissionAction &Mission::GetAction(Trigger trigger) const
 {
 	auto ait = actions.find(trigger);
-	static const MissionAction EMPTY;
+	static const MissionAction EMPTY{};
 	if(ait != actions.end())
 		return ait->second;
 	else


### PR DESCRIPTION
**Build fix:** This PR addresses inability to successfully build master/continuous for macOS (10.11 using Xcode 8.2.1)

## File Name(s) / Line Number(s)
Mission.cpp - Line 961

## Error Encountered:
Default initialization of an object of const type "const MissionAction" without a user-provided default constructor.

## Fix Details
Add empty object initializer {} - this is the recommended fix by Xcode.

## Testing Done
Builds successfully and game operates normally.