### PR TITLE
Add regional/noteworthy features attributes to systems

### DIFF
--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -1192,5 +1192,7 @@ news "graffiti on spaceport wall"
 			"Haikus are easy, / but sometimes they don't make sense. / Refrigerator."
 			"Haikus are easy. / I can't think of a good line. / It's snowing on Mount Fuji."
 			"A long time ago / I was respected by all, / but now I sit here."
+			"A handsome young cyborg named Ace / Wooed women at every base / But once ladies glanced at / His special enhancement / They vanished with nary a trace"
+			"Mary had a little lamb / Little lamb little lamb / Mary had a little lamb / Whose fleece was white as snow"
 		word
 			`"`

--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -1174,8 +1174,6 @@ news "graffiti on spaceport wall"
 			"Graffiti painted on a wall"
 	message
 		word
-			`"`
-		word
 			"A lone, soulless husk. / Appointed immortal king. / To sulk forever. - fgnt"
 			"The galaxy's child / Cursed with madness of time / Behind bloody chains - fgnt"
 			"Too proud for farming / Too poor to buy Paradise / I'll hoist the black flag - Lake"
@@ -1194,5 +1192,3 @@ news "graffiti on spaceport wall"
 			"A long time ago / I was respected by all, / but now I sit here."
 			"A handsome young cyborg named Ace / Wooed women at every base / But once ladies glanced at / His special enhancement / They vanished with nary a trace"
 			"Mary had a little lamb / Little lamb little lamb / Mary had a little lamb / Whose fleece was white as snow"
-		word
-			`"`

--- a/data/map.txt
+++ b/data/map.txt
@@ -1829,7 +1829,7 @@ system Ablub
 system Acamar
 	pos -284 -3
 	government Syndicate
-	attributes "!human" "!syndicate" "!core"
+	attributes "!human" "!core"
 	habitable 1080
 	belt 1013
 	link Diphda
@@ -1888,7 +1888,7 @@ system Acamar
 system Achernar
 	pos -93 154
 	government Syndicate
-	attributes "!human" "!syndicate" "!core"
+	attributes "!human" "!core"
 	habitable 625
 	belt 1963
 	haze _menu/haze-133
@@ -1960,7 +1960,7 @@ system Achernar
 system Acrux
 	pos -808 192
 	government Republic
-	attributes "!human" "!free worlds" "!rim"
+	attributes "!human" "!rim"
 	habitable 590.625
 	belt 1407
 	haze _menu/haze-67
@@ -2040,7 +2040,7 @@ system Acrux
 system Adhara
 	pos -669 -200
 	government Republic
-	attributes "!human" "!republic" "!deep"
+	attributes "!human" "!deep"
 	habitable 670
 	belt 1014
 	link "Epsilon Leonis"
@@ -2202,7 +2202,7 @@ system "Aki'il"
 system "Al Dhanab"
 	pos -177 207
 	government Syndicate
-	attributes "!human" "!syndicate" "!core"
+	attributes "!human" "!core"
 	habitable 1080
 	belt 1432
 	haze _menu/haze-133
@@ -2272,7 +2272,7 @@ system "Al Dhanab"
 system Albaldah
 	pos -350 484
 	government Republic
-	attributes "!human" "!free worlds" "!south"
+	attributes "!human" "!south"
 	habitable 534.375
 	belt 1622
 	haze _menu/haze-133
@@ -2347,7 +2347,7 @@ system Albaldah
 system Albireo
 	pos -270 503
 	government Republic
-	attributes "!human" "!free worlds" "!south"
+	attributes "!human" "!south"
 	habitable 760
 	belt 1030
 	link Tarazed
@@ -2472,7 +2472,7 @@ system Alcyone
 system Aldebaran
 	pos -356 -26
 	government Republic
-	attributes "!human" "!republic" "!paradise"
+	attributes "!human" "!paradise"
 	habitable 625
 	belt 1296
 	link Capella
@@ -2518,7 +2518,7 @@ system Aldebaran
 system Alderamin
 	pos -272 258
 	government Syndicate
-	attributes "!human" "!syndicate" "!core"
+	attributes "!human" "!core"
 	habitable 1705
 	belt 1908
 	haze _menu/haze-133
@@ -2583,7 +2583,7 @@ system Alderamin
 system Aldhibain
 	pos -659 451
 	government Republic
-	attributes "!human" "!free worlds" "!south"
+	attributes "!human" "!south"
 	habitable 455.625
 	belt 1840
 	link Kornephoros
@@ -2698,7 +2698,7 @@ system Algenib
 			period 42.6838
 
 system Algieba
-	attributes "!human" "!republic" "!deep"
+	attributes "!human" "!deep"
 	pos -691 -52
 	government Republic
 	habitable 2695
@@ -2770,7 +2770,7 @@ system Algieba
 system Algol
 	pos -210 17
 	government Syndicate
-	attributes "!human" "!syndicate" "!core"
+	attributes "!human" "!core"
 	habitable 534.375
 	belt 1839
 	haze _menu/haze-133
@@ -2832,7 +2832,7 @@ system Algol
 system Algorel
 	pos -631 145
 	government Republic
-	attributes "!human" "!republic" "!dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1993
 	haze _menu/haze-67
@@ -2897,7 +2897,7 @@ system Algorel
 system Alheka
 	pos -350 -271
 	government Republic
-	attributes "!human" "!republic" "!north"
+	attributes "!human" "!north"
 	habitable 1080
 	belt 1380
 	haze _menu/haze-67
@@ -2956,7 +2956,7 @@ system Alheka
 system Alhena
 	pos -430 -80
 	government Republic
-	attributes "!human" "!republic" "!paradise"
+	attributes "!human" "!paradise"
 	habitable 945
 	belt 1078
 	haze _menu/haze-67
@@ -3026,7 +3026,7 @@ system Alhena
 system Alioth
 	pos -620 315
 	government Republic
-	attributes "!human" "!republic" "!dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 455.625
 	belt 1889
 	link Wei
@@ -3079,7 +3079,7 @@ system Alioth
 system Alkaid
 	pos -825 318
 	government Republic
-	attributes "!human" "!republic" "!rim"
+	attributes "!human" "!rim"
 	habitable 1080
 	belt 1142
 	haze _menu/haze-67
@@ -3257,7 +3257,7 @@ system Almach
 system Alnair
 	pos -272 314
 	government Syndicate
-	attributes "!human" "!syndicate" "!core"
+	attributes "!human" "!core"
 	habitable 135
 	belt 1969
 	haze _menu/haze-133
@@ -3326,7 +3326,7 @@ system Alnair
 system Alnasl
 	pos -553 380
 	government Republic
-	attributes "!human" "!republic" "!dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 640
 	belt 1412
 	haze _menu/haze-133
@@ -3467,6 +3467,7 @@ system Alnilam
 system Alnitak
 	pos -331 -412
 	government Republic
+	attributes "!human" "!north"
 	habitable 349.375
 	belt 1907
 	haze _menu/haze-67
@@ -3523,6 +3524,7 @@ system Alnitak
 system Alniyat
 	pos -691 501
 	government Republic
+	attributes "!human" "!south"
 	habitable 534.375
 	belt 1760
 	link Pherkad
@@ -3595,6 +3597,7 @@ system Alniyat
 system "Alpha Arae"
 	pos -481 394
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 945
 	belt 1405
 	link "Delta Sagittarii"
@@ -3665,6 +3668,7 @@ system "Alpha Arae"
 system "Alpha Centauri"
 	pos -429 125
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 320
 	belt 1116
 	haze _menu/haze-67
@@ -3727,6 +3731,7 @@ system "Alpha Centauri"
 system "Alpha Hydri"
 	pos -97 98
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 1400
 	belt 1839
 	haze _menu/haze-133
@@ -3780,6 +3785,7 @@ system "Alpha Hydri"
 system Alphard
 	pos -588 -47
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 1080.62
 	belt 1101
 	link Algieba
@@ -3846,6 +3852,7 @@ system Alphard
 system Alphecca
 	pos -546 308
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1400
 	belt 1101
 	link Alioth
@@ -3895,6 +3902,7 @@ system Alphecca
 system Alpheratz
 	pos -176 125
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 1080.62
 	belt 1645
 	haze _menu/haze-133
@@ -3962,6 +3970,7 @@ system Alpheratz
 system Altair
 	pos -357 161
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 945
 	belt 1830
 	link Vega
@@ -4024,6 +4033,7 @@ system Altair
 system Aludra
 	pos -606 -374
 	government Republic
+	attributes "!human" "!deep"
 	habitable 455.625
 	belt 1511
 	haze _menu/haze-33
@@ -4087,6 +4097,7 @@ system Aludra
 system "Ancient Hope"
 	pos -1159.59 702.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 455
 	belt 1439
 	haze _menu/haze-67
@@ -4156,6 +4167,7 @@ system "Ancient Hope"
 system Ankaa
 	pos -230 100
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 625
 	belt 1003
 	haze _menu/haze-133
@@ -4210,6 +4222,7 @@ system Ankaa
 system Answer
 	pos -1086.59 631.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 425.92
 	belt 1636
 	haze _menu/haze-none
@@ -4274,6 +4287,7 @@ system Answer
 system Antares
 	pos -711 541
 	government Pirate
+	attributes "!human" "!south"
 	habitable 455.625
 	belt 1778
 	haze _menu/haze-67
@@ -4399,6 +4413,7 @@ system Antevorta
 system Ap'arak
 	pos -164.62 -781.858
 	government Wanderer
+	attributes "!wanderer"
 	habitable 1080
 	belt 1385
 	haze _menu/haze-none
@@ -4454,6 +4469,7 @@ system Ap'arak
 system Arcturus
 	pos -589 226
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1422
 	link Mizar
@@ -4588,6 +4604,7 @@ system Arculus
 system Arneb
 	pos -523 -580
 	government Pirate
+	attributes "!human" "!north"
 	habitable 1715
 	belt 1947
 	haze _menu/haze-none
@@ -4636,6 +4653,7 @@ system Arneb
 system Ascella
 	pos -376 328
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 640
 	belt 1971
 	haze _menu/haze-133
@@ -4701,6 +4719,7 @@ system Ascella
 system Asikafarnut
 	pos 253.431 -584.812
 	government "Kor Sestor"
+	attributes "!korath" "!automata"
 	habitable 320
 	belt 1342
 	link Silikatakfar
@@ -4765,6 +4784,7 @@ system Asikafarnut
 system Aspidiske
 	pos -690 -282
 	government Republic
+	attributes "!human" "!deep"
 	habitable 135
 	belt 1885
 	link Avior
@@ -4821,6 +4841,7 @@ system Aspidiske
 system Atria
 	pos -551 532
 	government Republic
+	attributes "!human" "!south"
 	habitable 214.375
 	belt 1340
 	link Han
@@ -4886,6 +4907,7 @@ system Atria
 system Avior
 	pos -658 -317
 	government Republic
+	attributes "!human" "!deep"
 	habitable 1215
 	belt 1097
 	link Aspidiske
@@ -4955,6 +4977,7 @@ system Avior
 system Aya'k'k
 	pos -434.245 -616.57
 	government Wanderer
+	attributes "!wanderer"
 	habitable 486.68
 	belt 1586
 	haze _menu/haze-67
@@ -5014,6 +5037,7 @@ system Aya'k'k
 system Beginning
 	pos -912.587 694.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 425.92
 	belt 1833
 	link Belonging
@@ -5076,6 +5100,7 @@ system Beginning
 system Bellatrix
 	pos -225 -82
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 670
 	belt 1564
 	link Menkar
@@ -5135,6 +5160,7 @@ system Bellatrix
 system Belonging
 	pos -1007.59 658.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 625
 	belt 1407
 	link "Bright Void"
@@ -5194,6 +5220,7 @@ system Belonging
 system Belug
 	pos -1024.59 388.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 486.68
 	belt 1170
 	link Ekuarik
@@ -5263,6 +5290,7 @@ system Belug
 system Belugt
 	pos -838.587 668.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 486.68
 	belt 1517
 	link Gupta
@@ -5337,6 +5365,7 @@ system Belugt
 system "Beta Lupi"
 	pos -851 417
 	government Republic
+	attributes "!human" "!south"
 	habitable 625
 	belt 1261
 	haze _menu/haze-33
@@ -5395,6 +5424,7 @@ system "Beta Lupi"
 system Betelgeuse
 	pos -384 -322
 	government Republic
+	attributes "!human" "!north"
 	habitable 1080
 	belt 1641
 	haze _menu/haze-67
@@ -5469,6 +5499,7 @@ system Betelgeuse
 system Bloptab
 	pos -813.587 727.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 1080
 	belt 1061
 	link Blugtad
@@ -5529,6 +5560,7 @@ system Bloptab
 system Blubipad
 	pos -650.587 594.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 1080
 	belt 1567
 	haze _menu/haze-133
@@ -5585,6 +5617,7 @@ system Blubipad
 system Blugtad
 	pos -771.587 680.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 625
 	belt 1841
 	haze _menu/haze-133
@@ -5657,6 +5690,7 @@ system Blugtad
 system Boral
 	pos -502 331
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 214.375
 	belt 1867
 	link Alphecca
@@ -5721,6 +5755,7 @@ system Boral
 system "Bore Fah"
 	pos 71.7761 -592.536
 	government Hai
+	attributes "hai"
 	habitable 625
 	belt 1823
 	link "Wah Ki"
@@ -5780,6 +5815,7 @@ system "Bore Fah"
 system "Bote Asu"
 	pos 8.87418 -572.768
 	government Hai
+	attributes "hai"
 	habitable 2859.44
 	belt 1613
 	link "Wah Ki"
@@ -5870,6 +5906,7 @@ system "Bote Asu"
 system "Bright Void"
 	pos -1059.59 605.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 2795
 	belt 1385
 	haze _menu/haze-67
@@ -5950,6 +5987,7 @@ system "Bright Void"
 system "Broken Bowl"
 	pos -956.587 566.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 1080
 	belt 1648
 	haze _menu/haze-67
@@ -6077,6 +6115,7 @@ system Caeculus
 system Canopus
 	pos -421 -225
 	government Republic
+	attributes "!human" "!north"
 	habitable 214.375
 	belt 1530
 	haze _menu/haze-67
@@ -6123,6 +6162,7 @@ system Canopus
 system Capella
 	pos -378 -13
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 455.625
 	belt 1722
 	haze _menu/haze-67
@@ -6193,6 +6233,7 @@ system Capella
 system Caph
 	pos -295 77
 	government Syndicate
+	attributes "!human" "!near earth"
 	habitable 670
 	belt 1173
 	link Sol
@@ -6256,6 +6297,7 @@ system Caph
 system Cardax
 	pos -211 -215
 	government Republic
+	attributes "!human" "!north"
 	habitable 1705
 	belt 1228
 	link Moktar
@@ -6383,6 +6425,7 @@ system Cardea
 system Castor
 	pos -452 -17
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 1715
 	belt 1675
 	haze _menu/haze-67
@@ -6467,6 +6510,7 @@ system Castor
 system Cebalrai
 	pos -461 282
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 625
 	belt 1955
 	link Rutilicus
@@ -6527,6 +6571,7 @@ system Cebalrai
 system Celeborim
 	pos 181.431 -633.812
 	government "Kor Sestor"
+	attributes "!korath" "!automata"
 	habitable 320
 	belt 1296
 	link Asikafarnut
@@ -6585,6 +6630,7 @@ system Celeborim
 system Chikatip
 	pos -77.5695 -307.812
 	government Uninhabited
+	attributes "!korath"
 	habitable 425.92
 	belt 1929
 	link Furmeliki
@@ -6640,6 +6686,7 @@ system Chikatip
 system Chimitarp
 	pos 150.431 -287.812
 	government "Kor Mereti"
+	attributes "!korath" "!automata"
 	habitable 912.6
 	belt 1932
 	haze _menu/haze-133
@@ -6712,6 +6759,7 @@ system Chimitarp
 system Chirr'ay'akai
 	pos -102.761 -749.614
 	government Wanderer
+	attributes "!wanderer"
 	habitable 486.68
 	belt 1425
 	haze _menu/haze-33
@@ -6761,6 +6809,7 @@ system Chirr'ay'akai
 system Chornifath
 	pos 40.4305 -214.812
 	government Uninhabited
+	attributes "!korath" "!fringe"
 	habitable 486.68
 	belt 1434
 	haze _menu/haze-133
@@ -6821,6 +6870,7 @@ system Chornifath
 system Chy'chra
 	pos 85.5308 -829.667
 	government Wanderer
+	attributes "!wanderer"
 	habitable 625
 	belt 1120
 	haze _menu/haze-33
@@ -25487,6 +25537,7 @@ system Zosma
 system "Zuba Zub"
 	pos -48.2661 -647.926
 	government Hai
+	attributes "!hai"
 	habitable 425.92
 	belt 1911
 	haze _menu/haze-67
@@ -25552,6 +25603,7 @@ system "Zuba Zub"
 system Zubenelgenubi
 	pos -710 353
 	government Republic
+	attributes "!human" "!rim"
 	habitable 945
 	belt 1475
 	link Zubeneschamali

--- a/data/map.txt
+++ b/data/map.txt
@@ -75,7 +75,7 @@ galaxy "label graveyard"
 system "1 Axis"
 	pos -1274.63 267.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 745.92
 	belt 1112
 	link "Sol Kimek"
@@ -153,7 +153,7 @@ system "1 Axis"
 system "10 Pole"
 	pos -1356.63 19.2137
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 486.68
 	belt 1765
 	haze _menu/haze-67
@@ -225,7 +225,7 @@ system "10 Pole"
 system "11 Autumn Above"
 	pos -1278.63 148.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 1566.68
 	belt 1099
 	haze _menu/haze-133
@@ -307,7 +307,7 @@ system "11 Autumn Above"
 system "11 Spring Below"
 	pos -1272.63 380.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 912.6
 	belt 1932
 	link "4 Spring Rising"
@@ -387,7 +387,7 @@ system "11 Spring Below"
 system "12 Autumn Above"
 	pos -1276.63 -19.7863
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 1050.92
 	belt 1283
 	link "14 Pole"
@@ -481,7 +481,7 @@ system "12 Autumn Above"
 system "14 Pole"
 	pos -1343.63 -119.786
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 625
 	belt 1881
 	haze _menu/haze-67
@@ -542,7 +542,7 @@ system "14 Pole"
 system "14 Summer Above"
 	pos -1436.63 182.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 1400
 	belt 1093
 	haze _menu/haze-67
@@ -608,7 +608,7 @@ system "14 Summer Above"
 system "14 Winter Below"
 	pos -1143.63 341.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 1111.68
 	belt 1173
 	link "8 Winter Below"
@@ -684,7 +684,7 @@ system "14 Winter Below"
 system "16 Autumn Rising"
 	pos -1305.63 74.2137
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 1715
 	belt 1424
 	link "12 Autumn Above"
@@ -754,7 +754,7 @@ system "16 Autumn Rising"
 system "3 Axis"
 	pos -1235.63 299.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 2372.76
 	belt 1202
 	link "1 Axis"
@@ -822,7 +822,7 @@ system "3 Axis"
 system "3 Pole"
 	pos -1344.63 162.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 625
 	belt 1617
 	link "16 Autumn Rising"
@@ -882,7 +882,7 @@ system "3 Pole"
 system "3 Spring Rising"
 	pos -1414.63 356.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 1080
 	belt 1613
 	haze _menu/haze-33
@@ -955,7 +955,7 @@ system "3 Spring Rising"
 system "4 Axis"
 	pos -1169.63 365.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 425.92
 	belt 1838
 	link "14 Winter Below"
@@ -1018,7 +1018,7 @@ system "4 Axis"
 system "4 Spring Rising"
 	pos -1309.63 321.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 320
 	belt 1801
 	link "1 Axis"
@@ -1083,7 +1083,7 @@ system "4 Spring Rising"
 system "4 Summer Rising"
 	pos -1377.63 207.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 320
 	belt 1860
 	link "3 Pole"
@@ -1143,7 +1143,7 @@ system "4 Summer Rising"
 system "4 Winter Rising"
 	pos -1259.63 248.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 135
 	belt 1345
 	link "Sol Kimek"
@@ -1218,7 +1218,7 @@ system "4 Winter Rising"
 system "5 Axis"
 	pos -1142.63 394.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 233.28
 	belt 1775
 	link "4 Axis"
@@ -1291,7 +1291,7 @@ system "5 Axis"
 system "5 Spring Below"
 	pos -1213.63 415.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 1313.28
 	belt 1104
 	link "4 Axis"
@@ -1363,7 +1363,7 @@ system "5 Spring Below"
 system "5 Summer Above"
 	pos -1387.63 118.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 425.92
 	belt 1133
 	haze _menu/haze-133
@@ -1430,7 +1430,7 @@ system "5 Summer Above"
 system "5 Winter Above"
 	pos -1216.63 208.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 320
 	belt 1414
 	link "4 Winter Rising"
@@ -1494,7 +1494,7 @@ system "5 Winter Above"
 system "7 Autumn Rising"
 	pos -1235.63 177.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 425.92
 	belt 1289
 	link "11 Autumn Above"
@@ -1560,7 +1560,7 @@ system "7 Autumn Rising"
 system "8 Winter Below"
 	pos -1179.63 284.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 486.68
 	belt 1285
 	link "3 Axis"
@@ -1625,7 +1625,7 @@ system "8 Winter Below"
 system "9 Spring Above"
 	pos -1377.63 281.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek space"
 	habitable 1050.92
 	belt 1397
 	haze _menu/haze-67
@@ -1700,7 +1700,7 @@ system "9 Spring Above"
 system Ablodab
 	pos -854.587 592.051
 	government Coalition
-	attributes "!arach" "!coalition"
+	attributes "arachi space"
 	habitable 425.92
 	belt 1368
 	link Debrugt
@@ -1775,7 +1775,7 @@ system Ablodab
 system Ablub
 	pos -581.587 637.051
 	government Coalition
-	attributes "!arach" "!coalition"
+	attributes "arachi space"
 	habitable 233.28
 	belt 1641
 	haze _menu/haze-133
@@ -1829,7 +1829,7 @@ system Ablub
 system Acamar
 	pos -284 -3
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 1080
 	belt 1013
 	link Diphda
@@ -1888,7 +1888,7 @@ system Acamar
 system Achernar
 	pos -93 154
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 625
 	belt 1963
 	haze _menu/haze-133
@@ -1960,7 +1960,7 @@ system Achernar
 system Acrux
 	pos -808 192
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 590.625
 	belt 1407
 	haze _menu/haze-67
@@ -2040,7 +2040,7 @@ system Acrux
 system Adhara
 	pos -669 -200
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 670
 	belt 1014
 	link "Epsilon Leonis"
@@ -2146,7 +2146,7 @@ system Aescolanus
 system "Aki'il"
 	pos -83 722
 	government Uninhabited
-	attributes "ember waste" "graveyard" "!isolated"
+	attributes "ember waste" "graveyard" "isolated"
 	habitable 1505.92
 	asteroids "large metal" 47 5
 	asteroids "large rock" 2 10
@@ -2202,7 +2202,7 @@ system "Aki'il"
 system "Al Dhanab"
 	pos -177 207
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 1080
 	belt 1432
 	haze _menu/haze-133
@@ -2272,7 +2272,7 @@ system "Al Dhanab"
 system Albaldah
 	pos -350 484
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 534.375
 	belt 1622
 	haze _menu/haze-133
@@ -2347,7 +2347,7 @@ system Albaldah
 system Albireo
 	pos -270 503
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 760
 	belt 1030
 	link Tarazed
@@ -2405,7 +2405,7 @@ system Albireo
 system Alcyone
 	pos -80 -144
 	government Pirate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 270
 	belt 1438
 	haze _menu/haze-133
@@ -2472,7 +2472,7 @@ system Alcyone
 system Aldebaran
 	pos -356 -26
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 625
 	belt 1296
 	link Capella
@@ -2518,7 +2518,7 @@ system Aldebaran
 system Alderamin
 	pos -272 258
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 1705
 	belt 1908
 	haze _menu/haze-133
@@ -2583,7 +2583,7 @@ system Alderamin
 system Aldhibain
 	pos -659 451
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 455.625
 	belt 1840
 	link Kornephoros
@@ -2641,7 +2641,7 @@ system Aldhibain
 			period 13.622
 
 system Algenib
-	attributes "!human" "!core" "!fringe"
+	attributes "human space" "the core" "fringe"
 	pos -118 341
 	government Pirate
 	habitable 455.625
@@ -2698,7 +2698,7 @@ system Algenib
 			period 42.6838
 
 system Algieba
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	pos -691 -52
 	government Republic
 	habitable 2695
@@ -2770,7 +2770,7 @@ system Algieba
 system Algol
 	pos -210 17
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 534.375
 	belt 1839
 	haze _menu/haze-133
@@ -2832,7 +2832,7 @@ system Algol
 system Algorel
 	pos -631 145
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 320
 	belt 1993
 	haze _menu/haze-67
@@ -2897,7 +2897,7 @@ system Algorel
 system Alheka
 	pos -350 -271
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 1080
 	belt 1380
 	haze _menu/haze-67
@@ -2956,7 +2956,7 @@ system Alheka
 system Alhena
 	pos -430 -80
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 945
 	belt 1078
 	haze _menu/haze-67
@@ -3026,7 +3026,7 @@ system Alhena
 system Alioth
 	pos -620 315
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 455.625
 	belt 1889
 	link Wei
@@ -3079,7 +3079,7 @@ system Alioth
 system Alkaid
 	pos -825 318
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 1080
 	belt 1142
 	haze _menu/haze-67
@@ -3147,7 +3147,7 @@ system Alkaid
 system Almaaz
 	pos -349 -538
 	government Pirate
-	attributes "!human" "!north" "!fringe"
+	attributes "human space" "far north" "fringe"
 	habitable 1080
 	belt 1873
 	haze _menu/haze-33
@@ -3194,7 +3194,7 @@ system Almaaz
 system Almach
 	pos -7 232
 	government Pirate
-	attributes "!human" "!core" "!fringe"
+	attributes "human space" "the core" "fringe"
 	habitable 320
 	belt 1914
 	haze _menu/haze-133
@@ -3257,7 +3257,7 @@ system Almach
 system Alnair
 	pos -272 314
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 135
 	belt 1969
 	haze _menu/haze-133
@@ -3326,7 +3326,7 @@ system Alnair
 system Alnasl
 	pos -553 380
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 640
 	belt 1412
 	haze _menu/haze-133
@@ -3389,7 +3389,7 @@ system Alnasl
 system Alnilam
 	pos -487 -513
 	government Pirate
-	attributes "!human" "!north" "!fringe"
+	attributes "human space" "far north" "fringe"
 	habitable 1715
 	belt 1099
 	haze _menu/haze-33
@@ -3467,7 +3467,7 @@ system Alnilam
 system Alnitak
 	pos -331 -412
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 349.375
 	belt 1907
 	haze _menu/haze-67
@@ -3524,7 +3524,7 @@ system Alnitak
 system Alniyat
 	pos -691 501
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 534.375
 	belt 1760
 	link Pherkad
@@ -3597,7 +3597,7 @@ system Alniyat
 system "Alpha Arae"
 	pos -481 394
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 945
 	belt 1405
 	link "Delta Sagittarii"
@@ -3668,7 +3668,7 @@ system "Alpha Arae"
 system "Alpha Centauri"
 	pos -429 125
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 320
 	belt 1116
 	haze _menu/haze-67
@@ -3731,7 +3731,7 @@ system "Alpha Centauri"
 system "Alpha Hydri"
 	pos -97 98
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 1400
 	belt 1839
 	haze _menu/haze-133
@@ -3785,7 +3785,7 @@ system "Alpha Hydri"
 system Alphard
 	pos -588 -47
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 1080.62
 	belt 1101
 	link Algieba
@@ -3852,7 +3852,7 @@ system Alphard
 system Alphecca
 	pos -546 308
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 1400
 	belt 1101
 	link Alioth
@@ -3902,7 +3902,7 @@ system Alphecca
 system Alpheratz
 	pos -176 125
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 1080.62
 	belt 1645
 	haze _menu/haze-133
@@ -3970,7 +3970,7 @@ system Alpheratz
 system Altair
 	pos -357 161
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 945
 	belt 1830
 	link Vega
@@ -4033,7 +4033,7 @@ system Altair
 system Aludra
 	pos -606 -374
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 455.625
 	belt 1511
 	haze _menu/haze-33
@@ -4097,7 +4097,7 @@ system Aludra
 system "Ancient Hope"
 	pos -1159.59 702.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 455
 	belt 1439
 	haze _menu/haze-67
@@ -4167,7 +4167,7 @@ system "Ancient Hope"
 system Ankaa
 	pos -230 100
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 625
 	belt 1003
 	haze _menu/haze-133
@@ -4222,7 +4222,7 @@ system Ankaa
 system Answer
 	pos -1086.59 631.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 425.92
 	belt 1636
 	haze _menu/haze-none
@@ -4287,7 +4287,7 @@ system Answer
 system Antares
 	pos -711 541
 	government Pirate
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 455.625
 	belt 1778
 	haze _menu/haze-67
@@ -4413,7 +4413,7 @@ system Antevorta
 system Ap'arak
 	pos -164.62 -781.858
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 1080
 	belt 1385
 	haze _menu/haze-none
@@ -4469,7 +4469,7 @@ system Ap'arak
 system Arcturus
 	pos -589 226
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 320
 	belt 1422
 	link Mizar
@@ -4604,7 +4604,7 @@ system Arculus
 system Arneb
 	pos -523 -580
 	government Pirate
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 1715
 	belt 1947
 	haze _menu/haze-none
@@ -4653,7 +4653,7 @@ system Arneb
 system Ascella
 	pos -376 328
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 640
 	belt 1971
 	haze _menu/haze-133
@@ -4719,7 +4719,7 @@ system Ascella
 system Asikafarnut
 	pos 253.431 -584.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 320
 	belt 1342
 	link Silikatakfar
@@ -4784,7 +4784,7 @@ system Asikafarnut
 system Aspidiske
 	pos -690 -282
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 135
 	belt 1885
 	link Avior
@@ -4841,7 +4841,7 @@ system Aspidiske
 system Atria
 	pos -551 532
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 214.375
 	belt 1340
 	link Han
@@ -4907,7 +4907,7 @@ system Atria
 system Avior
 	pos -658 -317
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 1215
 	belt 1097
 	link Aspidiske
@@ -4977,7 +4977,7 @@ system Avior
 system Aya'k'k
 	pos -434.245 -616.57
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 486.68
 	belt 1586
 	haze _menu/haze-67
@@ -5037,7 +5037,7 @@ system Aya'k'k
 system Beginning
 	pos -912.587 694.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 425.92
 	belt 1833
 	link Belonging
@@ -5100,7 +5100,7 @@ system Beginning
 system Bellatrix
 	pos -225 -82
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 670
 	belt 1564
 	link Menkar
@@ -5160,7 +5160,7 @@ system Bellatrix
 system Belonging
 	pos -1007.59 658.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 625
 	belt 1407
 	link "Bright Void"
@@ -5220,7 +5220,7 @@ system Belonging
 system Belug
 	pos -1024.59 388.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 486.68
 	belt 1170
 	link Ekuarik
@@ -5290,7 +5290,7 @@ system Belug
 system Belugt
 	pos -838.587 668.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 486.68
 	belt 1517
 	link Gupta
@@ -5365,7 +5365,7 @@ system Belugt
 system "Beta Lupi"
 	pos -851 417
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 625
 	belt 1261
 	haze _menu/haze-33
@@ -5424,7 +5424,7 @@ system "Beta Lupi"
 system Betelgeuse
 	pos -384 -322
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 1080
 	belt 1641
 	haze _menu/haze-67
@@ -5499,7 +5499,7 @@ system Betelgeuse
 system Bloptab
 	pos -813.587 727.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 1080
 	belt 1061
 	link Blugtad
@@ -5560,7 +5560,7 @@ system Bloptab
 system Blubipad
 	pos -650.587 594.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 1080
 	belt 1567
 	haze _menu/haze-133
@@ -5617,7 +5617,7 @@ system Blubipad
 system Blugtad
 	pos -771.587 680.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 625
 	belt 1841
 	haze _menu/haze-133
@@ -5690,7 +5690,7 @@ system Blugtad
 system Boral
 	pos -502 331
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "human space" "dirt belt" "fringe"
 	habitable 214.375
 	belt 1867
 	link Alphecca
@@ -5906,7 +5906,7 @@ system "Bote Asu"
 system "Bright Void"
 	pos -1059.59 605.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 2795
 	belt 1385
 	haze _menu/haze-67
@@ -5987,7 +5987,7 @@ system "Bright Void"
 system "Broken Bowl"
 	pos -956.587 566.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 1080
 	belt 1648
 	haze _menu/haze-67
@@ -6115,7 +6115,7 @@ system Caeculus
 system Canopus
 	pos -421 -225
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 214.375
 	belt 1530
 	haze _menu/haze-67
@@ -6162,7 +6162,7 @@ system Canopus
 system Capella
 	pos -378 -13
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 455.625
 	belt 1722
 	haze _menu/haze-67
@@ -6233,7 +6233,7 @@ system Capella
 system Caph
 	pos -295 77
 	government Syndicate
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 670
 	belt 1173
 	link Sol
@@ -6297,7 +6297,7 @@ system Caph
 system Cardax
 	pos -211 -215
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 1705
 	belt 1228
 	link Moktar
@@ -6425,7 +6425,7 @@ system Cardea
 system Castor
 	pos -452 -17
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 1715
 	belt 1675
 	haze _menu/haze-67
@@ -6510,7 +6510,7 @@ system Castor
 system Cebalrai
 	pos -461 282
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 625
 	belt 1955
 	link Rutilicus
@@ -6571,7 +6571,7 @@ system Cebalrai
 system Celeborim
 	pos 181.431 -633.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata" "!fringe"
+	attributes "korath space" "fringe"
 	habitable 320
 	belt 1296
 	link Asikafarnut
@@ -6630,7 +6630,7 @@ system Celeborim
 system Chikatip
 	pos -77.5695 -307.812
 	government Uninhabited
-	attributes "!korath" "!fringe"
+	attributes "korath space" "fringe"
 	habitable 425.92
 	belt 1929
 	link Furmeliki
@@ -6686,7 +6686,7 @@ system Chikatip
 system Chimitarp
 	pos 150.431 -287.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 912.6
 	belt 1932
 	haze _menu/haze-133
@@ -6759,7 +6759,7 @@ system Chimitarp
 system Chirr'ay'akai
 	pos -102.761 -749.614
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 486.68
 	belt 1425
 	haze _menu/haze-33
@@ -6809,7 +6809,7 @@ system Chirr'ay'akai
 system Chornifath
 	pos 40.4305 -214.812
 	government Uninhabited
-	attributes "!korath" "!fringe"
+	attributes "korath space" "fringe"
 	habitable 486.68
 	belt 1434
 	haze _menu/haze-133
@@ -6870,7 +6870,7 @@ system Chornifath
 system Chy'chra
 	pos 85.5308 -829.667
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 625
 	belt 1120
 	haze _menu/haze-33
@@ -7169,7 +7169,7 @@ system Convector
 system "Cor Caroli"
 	pos -682 201
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 1080
 	belt 1474
 	link Vindemiatrix
@@ -7228,7 +7228,7 @@ system "Cor Caroli"
 system "Da Ent"
 	pos -6.22391 -462.536
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 233.28
 	belt 1161
 	link "Ya Hai"
@@ -7289,7 +7289,7 @@ system "Da Ent"
 system "Da Lest"
 	pos -23.2239 -413.536
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 320
 	belt 1108
 	link "Lom Tahr"
@@ -7344,7 +7344,7 @@ system "Da Lest"
 system Dabih
 	pos -253 427
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 670
 	belt 1088
 	haze _menu/haze-133
@@ -7404,7 +7404,7 @@ system Dabih
 system Danoa
 	pos -239 -321
 	government Republic
-	attributes "!human" "!north" "!fringe"
+	attributes "human space" "far north" "fringe"
 	habitable 135
 	belt 1689
 	haze _menu/haze-67
@@ -7473,7 +7473,7 @@ system Danoa
 system "Dark Hills"
 	pos -926.587 619.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 1080
 	belt 1367
 	link Beginning
@@ -7540,7 +7540,7 @@ system "Dark Hills"
 system Debrugt
 	pos -869.587 513.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 640
 	belt 1224
 	link Torbab
@@ -7689,7 +7689,7 @@ system Delia
 system "Delta Capricorni"
 	pos -285 202
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 839.375
 	belt 1329
 	haze _menu/haze-133
@@ -7752,7 +7752,7 @@ system "Delta Capricorni"
 system "Delta Sagittarii"
 	pos -414 416
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 320
 	belt 1414
 	haze _menu/haze-133
@@ -7819,7 +7819,7 @@ system "Delta Sagittarii"
 system "Delta Velorum"
 	pos -740 90
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 1080
 	belt 1221
 	haze _menu/haze-67
@@ -7878,7 +7878,7 @@ system "Delta Velorum"
 system Deneb
 	pos -348 225
 	government Pug
-	attributes "!human" "!isolated"
+	attributes "human space" "isolated"
 	habitable 625
 	belt 1890
 	haze _menu/haze-133
@@ -7934,7 +7934,7 @@ system Deneb
 system Denebola
 	pos -478 70
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 534.375
 	belt 1050
 	haze _menu/haze-67
@@ -8035,7 +8035,7 @@ system Diespiter
 system Diphda
 	pos -262 61
 	government Syndicate
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 590.625
 	belt 1559
 	haze _menu/haze-133
@@ -8168,7 +8168,7 @@ system Dixere
 system Dokdobaru
 	pos -21.5695 -241.812
 	government Quarg
-	attributes "!korath" "!efreti" "!ringworld"
+	attributes "korath space" "ringworld"
 	habitable 700
 	belt 1935
 	haze _menu/haze-133
@@ -8273,7 +8273,7 @@ system Dokdobaru
 system Dschubba
 	pos -598 501
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 398.125
 	belt 1429
 	link Atria
@@ -8347,7 +8347,7 @@ system Dschubba
 system Dubhe
 	pos -577 -103
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 349.375
 	belt 1120
 	link Zosma
@@ -8404,7 +8404,7 @@ system Dubhe
 system "Due Yoot"
 	pos -167.547 -426.683
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 233.28
 	belt 1854
 	link "Wah Oh"
@@ -8469,7 +8469,7 @@ system "Due Yoot"
 system Durax
 	pos -59 -90
 	government Pirate
-	attributes "!human" "!core" "!fringe"
+	attributes "human space" "the core" "fringe"
 	habitable 1080
 	belt 1287
 	haze _menu/haze-133
@@ -8534,7 +8534,7 @@ system Durax
 system Eber
 	pos -532 406
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 320
 	belt 1199
 	link Alnasl
@@ -8598,7 +8598,7 @@ system Eber
 system Eblumab
 	pos -767.587 703.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 425.92
 	belt 1804
 	haze _menu/haze-133
@@ -8751,7 +8751,7 @@ system Egeria
 system "Ehma Ti"
 	pos 39.1085 -749.244
 	government "Hai (Unfettered)"
-	attributes "!hai"
+	attributes
 	habitable 486.68
 	belt 1094
 	link "Wah Yoot"
@@ -8819,7 +8819,7 @@ system "Ehma Ti"
 system Ek'kek'ru
 	pos -287.517 -727.738
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 320
 	belt 1517
 	haze _menu/haze-none
@@ -8879,7 +8879,7 @@ system Ek'kek'ru
 system Ekuarik
 	pos -1029.63 426.214
 	government Heliarch
-	attributes "!coalition"
+	attributes
 	habitable 700
 	belt 1711
 	link "Ki War Ek"
@@ -9062,7 +9062,7 @@ system Ekuarik
 system Elnath
 	pos -288 -77
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 1715
 	belt 1462
 	link Acamar
@@ -9127,7 +9127,7 @@ system Elnath
 system Eltanin
 	pos -328 433
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 455.625
 	belt 1859
 	haze _menu/haze-133
@@ -9187,7 +9187,7 @@ system Eltanin
 system Eneremprukt
 	pos 311.431 -448.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 486.68
 	belt 1421
 	link Silikatakfar
@@ -9243,7 +9243,7 @@ system Eneremprukt
 system Enif
 	pos -177 498
 	government Quarg
-	attributes "!human" "!south" "!ringworld"
+	attributes "human space" "the south" "ringworld"
 	habitable 700
 	belt 1974
 	link Sadalmelik
@@ -9332,7 +9332,7 @@ system Enif
 system "Epsilon Leonis"
 	pos -619 -229
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 1400
 	belt 1527
 	link Gomeisa
@@ -9407,7 +9407,7 @@ system "Epsilon Leonis"
 system Es'sprak'ai
 	pos -469.044 -733.375
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 486.68
 	belt 1928
 	haze _menu/haze-none
@@ -9468,7 +9468,7 @@ system Es'sprak'ai
 system Eshkoshtar
 	pos 156.431 -381.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 806.68
 	belt 1105
 	link Mekislepti
@@ -9602,7 +9602,7 @@ system Esix
 system Eteron
 	pos -330 33
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 135
 	belt 1479
 	link Sirius
@@ -9667,7 +9667,7 @@ system Eteron
 system "Fah Root"
 	pos -264.065 -400.135
 	government Hai
-	attributes "!hai" "!fringe"
+	attributes "fringe"
 	habitable 486.68
 	belt 1057
 	haze _menu/haze-67
@@ -9736,7 +9736,7 @@ system "Fah Root"
 system "Fah Soom"
 	pos -179.891 -335.011
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 425.92
 	belt 1185
 	haze _menu/haze-67
@@ -9797,7 +9797,7 @@ system "Fah Soom"
 system Fala
 	pos -690 64
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 625
 	belt 1264
 	link "Tania Australis"
@@ -9858,7 +9858,7 @@ system Fala
 system "Fallen Leaf"
 	pos -903.587 717.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 320
 	belt 1327
 	link Beginning
@@ -9911,7 +9911,7 @@ system "Fallen Leaf"
 system "Far Horizon"
 	pos -1108.59 726.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 320
 	belt 1242
 	haze _menu/haze-67
@@ -9967,7 +9967,7 @@ system "Far Horizon"
 system Farbutero
 	pos 93.4305 -251.812
 	government Uninhabited
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 625
 	belt 1175
 	haze _menu/haze-133
@@ -10113,7 +10113,7 @@ system Farinus
 system Faronektu
 	pos 292.431 -309.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 1080
 	belt 1630
 	haze _menu/haze-133
@@ -10181,7 +10181,7 @@ system Faronektu
 system Fasitopfar
 	pos 92.4305 -105.812
 	government Uninhabited
-	attributes "archon" "!korath" "!isolated" "!nova"
+	attributes "archon" "korath space" "isolated" "!nova"
 	habitable 100
 	belt 1670
 	haze _menu/haze-blackbody
@@ -10289,7 +10289,7 @@ system Fearis
 system "Fell Omen"
 	pos -1156.59 475.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 425.92
 	belt 1240
 	link "Last Word"
@@ -10480,7 +10480,7 @@ system Fereti
 system Feroteri
 	pos 149.431 -205.812
 	government Uninhabited
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 5425.92
 	belt 1419
 	haze _menu/haze-blackbody
@@ -10564,7 +10564,7 @@ system Feroteri
 system Ferukistek
 	pos 307.431 -515.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 486.68
 	belt 1520
 	link Eneremprukt
@@ -10618,7 +10618,7 @@ system Ferukistek
 system Fingol
 	pos -482 113
 	government Republic
-	attributes "!human" "!near earth" "!fringe"
+	attributes "human space" "near earth" "fringe"
 	habitable 135
 	belt 1976
 	haze _menu/haze-none
@@ -10676,7 +10676,7 @@ system Fingol
 system Flugbu
 	pos -903.587 534.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 425.92
 	belt 1843
 	link Torbab
@@ -10741,7 +10741,7 @@ system Flugbu
 system Fomalhaut
 	pos -314 124
 	government Syndicate
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 455.625
 	belt 1854
 	link Altair
@@ -10804,7 +10804,7 @@ system Fomalhaut
 system Fornarep
 	pos 79.4305 -309.812
 	government Uninhabited
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 320
 	belt 1922
 	haze _menu/haze-133
@@ -10871,7 +10871,7 @@ system Fornarep
 system "Four Pillars"
 	pos -1210.59 772.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 486.68
 	belt 1061
 	link "Far Horizon"
@@ -10933,7 +10933,7 @@ system "Four Pillars"
 system Furmeliki
 	pos -35.5695 -281.812
 	government Uninhabited
-	attributes "!korath" "!efreti"
+	attributes "korath space"
 	habitable 486.68
 	belt 1577
 	link Dokdobaru
@@ -10995,7 +10995,7 @@ system Furmeliki
 system Gacrux
 	pos -713 184
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 534.375
 	belt 1188
 	link "Cor Caroli"
@@ -11063,7 +11063,7 @@ system Gacrux
 system "Gamma Cassiopeiae"
 	pos -116 293
 	government Syndicate
-	attributes "!human" "!core" "!fringe"
+	attributes "human space" "the core" "fringe"
 	habitable 455.625
 	belt 1779
 	haze _menu/haze-133
@@ -11122,7 +11122,7 @@ system "Gamma Cassiopeiae"
 system "Gamma Corvi"
 	pos -906 64
 	government Republic
-	attributes "!coalition" "!rim"
+	attributes "the rim"
 	habitable 1535.62
 	belt 1556
 	haze _menu/haze-none
@@ -11245,7 +11245,7 @@ system Gerenus
 system Gienah
 	pos -176 354
 	government Pirate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 534.375
 	belt 1939
 	link Persian
@@ -11380,7 +11380,7 @@ system Giribea
 system Girtab
 	pos -430 481
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 1080
 	belt 1387
 	link Lesath
@@ -11445,7 +11445,7 @@ system Girtab
 system Glubatub
 	pos -650.587 693.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 233.28
 	belt 1093
 	link "Sol Arach"
@@ -11523,7 +11523,7 @@ system Glubatub
 system Gomeisa
 	pos -600 -161
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 911.25
 	belt 1616
 	link Zosma
@@ -11593,7 +11593,7 @@ system Gomeisa
 system "Good Omen"
 	pos -941.587 746.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 1715
 	belt 1598
 	haze _menu/haze-67
@@ -11655,7 +11655,7 @@ system "Good Omen"
 system Gorvi
 	pos -250 -483
 	government Republic
-	attributes "!human" "!north" "!fringe"
+	attributes "human space" "far north" "fringe"
 	habitable 670
 	belt 1345
 	haze _menu/haze-133
@@ -11713,7 +11713,7 @@ system Gorvi
 system Graffias
 	pos -784 517
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 911.25
 	belt 1977
 	link Alniyat
@@ -11777,7 +11777,7 @@ system Graffias
 system Gupta
 	pos -808.587 625.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 912.6
 	belt 1771
 	link Ablodab
@@ -11838,7 +11838,7 @@ system Gupta
 system Hadar
 	pos -788 283
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 455.625
 	belt 1520
 	link "Zeta Centauri"
@@ -11898,7 +11898,7 @@ system Hadar
 system Hamal
 	pos -129 24
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 1080
 	belt 1241
 	haze _menu/haze-133
@@ -11953,7 +11953,7 @@ system Hamal
 system Han
 	pos -610 561
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 1080.62
 	belt 1517
 	link Alniyat
@@ -12012,7 +12012,7 @@ system Han
 system Hassaleh
 	pos -291 -287
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 670
 	belt 1924
 	haze _menu/haze-67
@@ -12073,7 +12073,7 @@ system Hassaleh
 system Hatysa
 	pos -474 -542
 	government Pirate
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 533.75
 	belt 1163
 	haze _menu/haze-33
@@ -12134,7 +12134,7 @@ system Hatysa
 system "Heia Due"
 	pos -146.177 -481.694
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 1215
 	belt 1079
 	haze _menu/haze-67
@@ -12206,7 +12206,7 @@ system "Heia Due"
 system Hesselpost
 	pos -30.5695 -187.812
 	government Uninhabited
-	attributes "!korath" "!efreti" "!fringe"
+	attributes "korath space" "fringe"
 	habitable 486.68
 	belt 1327
 	haze _menu/haze-133
@@ -12277,7 +12277,7 @@ system Hesselpost
 system "Hevru Hai"
 	pos -189 -310
 	government Quarg
-	attributes "!hai" "!ringworld"
+	attributes "ringworld"
 	habitable 700
 	belt 1245
 	link "Fah Soom"
@@ -12392,7 +12392,7 @@ system "Hevru Hai"
 system "Hi Yahr"
 	pos 82.3672 -641.6
 	government "Hai (Unfettered)"
-	attributes "!hai"
+	attributes
 	habitable 625
 	belt 1655
 	link "Wah Yoot"
@@ -12450,7 +12450,7 @@ system "Hi Yahr"
 system Hintar
 	pos -422 311
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "human space" "dirt belt" "fringe"
 	habitable 625
 	belt 1725
 	haze _menu/haze-133
@@ -12510,7 +12510,7 @@ system Hintar
 system Holeb
 	pos -590 287
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 1715
 	belt 1181
 	link Alioth
@@ -12558,7 +12558,7 @@ system Holeb
 system Homeward
 	pos -1045.59 477.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 425.92
 	belt 1499
 	link "Silver Bell"
@@ -12624,7 +12624,7 @@ system Homeward
 system Host
 	pos 384.431 -543.812
 	government Uninhabited
-	attributes "!isolated"
+	attributes "isolated"
 	habitable 486.68
 	belt 1669
 	asteroids "large metal" 1 0.732
@@ -12673,7 +12673,7 @@ system Host
 system Hunter
 	pos -968.587 590.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 425.92
 	belt 1498
 	link "Bright Void"
@@ -12735,7 +12735,7 @@ system Hunter
 system Ik'kara'ka
 	pos 56.2159 -888.296
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 625
 	belt 1497
 	haze _menu/haze-none
@@ -12797,7 +12797,7 @@ system Ik'kara'ka
 system Ildaria
 	pos -702 317
 	government Republic
-	attributes "!human" "!rim" "!wolf-rayet" "!fringe"
+	attributes "human space" "the rim" "!wolf-rayet" "fringe"
 	habitable 625
 	belt 1132
 	haze _menu/haze-133
@@ -12851,7 +12851,7 @@ system Ildaria
 system "Imo Dep"
 	pos -56.2764 -600.1
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 1715
 	belt 1416
 	haze _menu/haze-67
@@ -12976,7 +12976,7 @@ system Insitor
 system "Io Lowe"
 	pos -94.7566 -527.728
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 135
 	belt 1552
 	haze _menu/haze-67
@@ -13038,7 +13038,7 @@ system "Io Lowe"
 system "Io Mann"
 	pos -192.955 -447.669
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 973.36
 	belt 1132
 	haze _menu/haze-67
@@ -13113,7 +13113,7 @@ system "Io Mann"
 system Ipsing
 	pos -549 160
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "human space" "dirt belt" "fringe"
 	habitable 1400
 	belt 1107
 	haze _menu/haze-67
@@ -13180,7 +13180,7 @@ system Ipsing
 system Iyech'yek
 	pos -277.37 -693.913
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 320
 	belt 1613
 	haze _menu/haze-33
@@ -13234,7 +13234,7 @@ system Iyech'yek
 system Izar
 	pos -784 231
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 1294.38
 	belt 1449
 	haze _menu/haze-67
@@ -13299,7 +13299,7 @@ system Izar
 system Ka'ch'chrai
 	pos -240.163 -822.448
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 425.92
 	belt 1745
 	haze _menu/haze-none
@@ -13357,7 +13357,7 @@ system Ka'ch'chrai
 system Ka'pru
 	pos -76.6756 -994.955
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 1505.92
 	belt 1808
 	haze _menu/haze-33
@@ -13428,7 +13428,7 @@ system Ka'pru
 system Kaliptari
 	pos 85.4305 -402.812
 	government Uninhabited
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 320
 	belt 1089
 	link Skeruto
@@ -13503,7 +13503,7 @@ system Kaliptari
 system "Kappa Centauri"
 	pos -867 480
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 1215
 	belt 1508
 	link Pherkad
@@ -13564,7 +13564,7 @@ system "Kappa Centauri"
 system Kashikt
 	pos -73.5695 -219.812
 	government "Kor Efret"
-	attributes "!korath" "!efreti"
+	attributes "korath space"
 	habitable 1715
 	belt 1013
 	link Dokdobaru
@@ -13632,7 +13632,7 @@ system Kashikt
 system Kasikfar
 	pos 10.4305 -127.812
 	government Uninhabited
-	attributes "archon" "!isolated" "!korath" "!nova"
+	attributes "archon" "isolated" "korath space" "!nova"
 	habitable 100
 	belt 1539
 	haze _menu/haze-blackbody
@@ -13673,7 +13673,7 @@ system Kasikfar
 system "Kaus Australis"
 	pos -284 395
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 320
 	belt 1281
 	haze _menu/haze-133
@@ -13725,7 +13725,7 @@ system "Kaus Australis"
 system "Kaus Borealis"
 	pos -456 350
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 590.625
 	belt 1074
 	haze _menu/haze-133
@@ -13788,7 +13788,7 @@ system "Kaus Borealis"
 system "Ki War Ek"
 	pos -1106.63 368.214
 	government Heliarch
-	attributes "!coalition" "!ringworld"
+	attributes "ringworld"
 	habitable 700
 	belt 1777
 	haze _menu/haze-133
@@ -14007,7 +14007,7 @@ system "Ki War Ek"
 system Kiro'ku
 	pos -131.923 -884.46
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 1111.68
 	belt 1308
 	haze _menu/haze-none
@@ -14084,7 +14084,7 @@ system Kiro'ku
 system Kiru'kichi
 	pos -195.063 -662.343
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 2795
 	belt 1465
 	haze _menu/haze-33
@@ -14144,7 +14144,7 @@ system Kiru'kichi
 system Kochab
 	pos -731 279
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 320
 	belt 1912
 	haze _menu/haze-67
@@ -14188,7 +14188,7 @@ system Kochab
 system "Kor Ak'Mari"
 	pos 43 42
 	government Korath
-	attributes "!korath" "!exiles" "!isolated" "!wolf-rayet"
+	attributes "korath space" "isolated"
 	habitable 625
 	belt 1606
 	haze _menu/haze-full
@@ -14239,7 +14239,7 @@ system "Kor Ak'Mari"
 system "Kor En'lakfar"
 	pos -31 -33
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath space" "!exiles"
 	habitable 1080
 	belt 1115
 	haze _menu/haze-133
@@ -14301,7 +14301,7 @@ system "Kor En'lakfar"
 system "Kor Fel'tar"
 	pos 29 -66
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath space" "!exiles"
 	habitable 455.625
 	belt 1444
 	haze _menu/haze-blackbody
@@ -14367,7 +14367,7 @@ system "Kor Fel'tar"
 system "Kor Men"
 	pos 6 -5
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath space" "!exiles"
 	habitable 2340
 	belt 1260
 	haze _menu/haze-blackbody
@@ -14430,7 +14430,7 @@ system "Kor Men"
 system "Kor Nor'peli"
 	pos 52 160
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath space" "!exiles"
 	habitable 590.625
 	belt 1213
 	haze _menu/haze-blackbody
@@ -14495,7 +14495,7 @@ system "Kor Nor'peli"
 system "Kor Tar'bei"
 	pos 57 106
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath space" "!exiles"
 	habitable 214.375
 	belt 1614
 	haze _menu/haze-blackbody
@@ -14552,7 +14552,7 @@ system "Kor Tar'bei"
 system "Kor Zena'i"
 	pos -2 83
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath space" "!exiles"
 	habitable 703.125
 	belt 1866
 	haze _menu/haze-blackbody
@@ -14605,7 +14605,7 @@ system "Kor Zena'i"
 system Kornephoros
 	pos -612 424
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 911.25
 	belt 1168
 	link Sabik
@@ -14686,7 +14686,7 @@ system Kornephoros
 system Korsmanath
 	pos 97.4305 -185.812
 	government Uninhabited
-	attributes "!korath" "!automata" "!fringe"
+	attributes "korath space" "fringe"
 	habitable 486.68
 	belt 1775
 	link Feroteri
@@ -14746,7 +14746,7 @@ system Korsmanath
 system Kraz
 	pos -876 204
 	government Republic
-	attributes "!human" "!rim" 
+	attributes "human space" "the rim" 
 	habitable 1080
 	belt 1056
 	haze _menu/haze-67
@@ -14813,7 +14813,7 @@ system Kraz
 system Kugel
 	pos -230 -26
 	government Syndicate
-	attributes "!human" "!core" "!fringe"
+	attributes "human space" "the core" "fringe"
 	habitable 625
 	belt 1051
 	link Acamar
@@ -14882,7 +14882,7 @@ system Kugel
 system Kursa
 	pos -366 -105
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 455
 	belt 1624
 	haze _menu/haze-67
@@ -14999,7 +14999,7 @@ system "Last Word"
 system Lesath
 	pos -516 485
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 1715
 	belt 1865
 	link Atria
@@ -15132,7 +15132,7 @@ system Levana
 system Limen
 	pos -791.99 -12.2491
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "human space" "dirt belt" "fringe"
 	habitable 1715
 	belt 1463
 	haze _menu/haze-33
@@ -15246,7 +15246,7 @@ system Lire
 system Lolami
 	pos -628 -10
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "human space" "dirt belt" "fringe"
 	habitable 1215
 	belt 1072
 	link "Tania Australis"
@@ -15310,7 +15310,7 @@ system Lolami
 system "Lom Tahr"
 	pos -94.0437 -446.586
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 2372.76
 	belt 1445
 	link "Ya Hai"
@@ -15386,7 +15386,7 @@ system "Lom Tahr"
 system "Lone Cloud"
 	pos -1239.59 747.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 233.28
 	belt 1730
 	link "Four Pillars"
@@ -15437,7 +15437,7 @@ system "Lone Cloud"
 system Lucina
 	pos 175.504 176.389
 	government Uninhabited
-	attributes "ember waste" "!fringe"
+	attributes "ember waste" "fringe"
 	habitable 320
 	belt 1466
 	haze _menu/haze-red
@@ -15493,7 +15493,7 @@ system Lucina
 system Lurata
 	pos -279 463
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 455.625
 	belt 1151
 	haze _menu/haze-133
@@ -15556,7 +15556,7 @@ system Lurata
 system Makferuti
 	pos 288.431 -628.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 621.68
 	belt 1782
 	link Asikafarnut
@@ -15632,7 +15632,7 @@ system Makferuti
 system Markab
 	pos -241 168
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 625
 	belt 1411
 	haze _menu/haze-133
@@ -15715,7 +15715,7 @@ system Markab
 system Markeb
 	pos -602 -305
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 455.625
 	belt 1556
 	haze _menu/haze-33
@@ -15780,7 +15780,7 @@ system Markeb
 system Matar
 	pos -218 272
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 455.625
 	belt 1308
 	haze _menu/haze-133
@@ -15838,7 +15838,7 @@ system Matar
 system Mebla
 	pos -814.587 555.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 486.68
 	belt 1114
 	link Debrugt
@@ -15896,7 +15896,7 @@ system Mebla
 system Mebsuta
 	pos -482 -394
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 670
 	belt 1740
 	haze _menu/haze-33
@@ -15972,7 +15972,7 @@ system Mebsuta
 system Meftarkata
 	pos 52.4305 -276.812
 	government Uninhabited
-	attributes "!korath"
+	attributes "korath space"
 	habitable 2201.68
 	belt 1232
 	haze _menu/haze-133
@@ -16034,7 +16034,7 @@ system Meftarkata
 system "Mei Yohn"
 	pos -106.757 -581.698
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 425.92
 	belt 1075
 	haze _menu/haze-67
@@ -16100,7 +16100,7 @@ system "Mei Yohn"
 system Mekislepti
 	pos 137.431 -335.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 1705
 	belt 1673
 	haze _menu/haze-133
@@ -16164,7 +16164,7 @@ system Mekislepti
 system Meblumem
 	pos -722.587 616.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 2201.68
 	belt 1794
 	link "Sol Arach"
@@ -16229,7 +16229,7 @@ system Meblumem
 system Men
 	pos -888 361
 	government Pirate
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 320
 	belt 1531
 	haze _menu/haze-33
@@ -16295,7 +16295,7 @@ system Men
 system Menkalinan
 	pos -400 -61
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 3430
 	belt 1424
 	haze _menu/haze-67
@@ -16363,7 +16363,7 @@ system Menkalinan
 system Menkar
 	pos -183 -52
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 455.625
 	belt 1634
 	haze _menu/haze-133
@@ -16426,7 +16426,7 @@ system Menkar
 system Menkent
 	pos -495 218
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 2340
 	belt 1728
 	link Vega
@@ -16497,7 +16497,7 @@ system Menkent
 system Merak
 	pos -553 60
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 1080.62
 	belt 1769
 	haze _menu/haze-67
@@ -16562,7 +16562,7 @@ system Merak
 system Mesuket
 	pos 220.431 -409.812
 	government Uninhabited
-	attributes "!korath" "!automata" "!warzone"
+	attributes "korath space"  "warzone"
 	habitable 425.92
 	belt 1189
 	link Eshkoshtar
@@ -16629,7 +16629,7 @@ system Mesuket
 system Miaplacidus
 	pos -524 -69
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 455.625
 	belt 1236
 	link Tejat
@@ -16704,7 +16704,7 @@ system Miaplacidus
 system Miblulub
 	pos -630.587 670.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 1080
 	belt 1757
 	haze _menu/haze-133
@@ -16786,7 +16786,7 @@ system Miblulub
 system Mimosa
 	pos -895 168
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 320
 	belt 1484
 	haze _menu/haze-67
@@ -16837,7 +16837,7 @@ system Mimosa
 system Minkar
 	pos -823 138
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 670
 	belt 1354
 	haze _menu/haze-67
@@ -16903,7 +16903,7 @@ system Minkar
 system Mintaka
 	pos -304 -462
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 775.625
 	belt 1753
 	haze _menu/haze-67
@@ -16967,7 +16967,7 @@ system Mintaka
 system Mirach
 	pos -166 250
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 292.5
 	belt 1980
 	haze _menu/haze-133
@@ -17036,7 +17036,7 @@ system Mirach
 system Mirfak
 	pos -187 -128
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 320
 	belt 1887
 	link Menkar
@@ -17092,7 +17092,7 @@ system Mirfak
 system Mirzam
 	pos -498 -301
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 1080
 	belt 1025
 	haze _menu/haze-67
@@ -17154,7 +17154,7 @@ system Mirzam
 system Mizar
 	pos -579 184
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 1080
 	belt 1876
 	haze _menu/haze-67
@@ -17207,7 +17207,7 @@ system Mizar
 system Moktar
 	pos -169 -170
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 455
 	belt 1888
 	link Oblate
@@ -17275,7 +17275,7 @@ system Moktar
 system Mora
 	pos -755 23
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 320
 	belt 1176
 	haze _menu/haze-67
@@ -17336,7 +17336,7 @@ system Mora
 system Muhlifain
 	pos -702 242
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 455.625
 	belt 1265
 	haze _menu/haze-67
@@ -17383,7 +17383,7 @@ system Muhlifain
 system Muphrid
 	pos -495 152
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 839.375
 	belt 1759
 	link Menkent
@@ -17441,7 +17441,7 @@ system Muphrid
 system Naos
 	pos -653 -396
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 625
 	belt 1045
 	haze _menu/haze-67
@@ -17515,7 +17515,7 @@ system Naos
 system Naper
 	pos -416 369
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 1715
 	belt 1445
 	link Ascella
@@ -17654,7 +17654,7 @@ system Nenia
 system Nihal
 	pos -262 -121
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 534.375
 	belt 1329
 	link Elnath
@@ -17727,7 +17727,7 @@ system Nihal
 system Nocte
 	pos -467 172
 	government Republic
-	attributes "!human" "!near earth" "!fringe"
+	attributes "human space" "near earth" "fringe"
 	habitable 135
 	belt 1304
 	link Vega
@@ -17846,7 +17846,7 @@ system Nona
 system Nunki
 	pos -393 537
 	government Pirate
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 214.375
 	belt 1930
 	link Albaldah
@@ -17916,7 +17916,7 @@ system Nunki
 system Oblate
 	pos -124 -119
 	government Pirate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 12000
 	belt 1704
 	haze _menu/haze-133
@@ -17975,7 +17975,7 @@ system Oblate
 system Orbona
 	pos -735.99 -97.2491
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "human space" "dirt belt" "fringe"
 	habitable 2859.44
 	belt 1507
 	haze _menu/haze-67
@@ -18047,7 +18047,7 @@ system Orbona
 system Orvala
 	pos -334 303
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 533.75
 	belt 1431
 	link "Zeta Aquilae"
@@ -18404,7 +18404,7 @@ system Parca
 system Peacock
 	pos -307 350
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 214.375
 	belt 1870
 	haze _menu/haze-133
@@ -18479,7 +18479,7 @@ system Peacock
 system Pelubta
 	pos -757.587 575.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 9265
 	belt 1709
 	link Meblumem
@@ -18621,7 +18621,7 @@ system Peragenor
 system Peresedersi
 	pos 81.4305 -154.812
 	government Uninhabited
-	attributes "archon" "!korath" "!isolated" "!nova"
+	attributes "archon" "korath space" "isolated" "!nova"
 	habitable 100
 	belt 1065
 	haze _menu/haze-blackbody
@@ -18716,7 +18716,7 @@ system Perfica
 system Persian
 	pos -203 331
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 2170.62
 	belt 1308
 	haze _menu/haze-133
@@ -18784,7 +18784,7 @@ system Persian
 system Persitar
 	pos 297.431 -395.812
 	government Uninhabited
-	attributes "!korath" "!isolated" "!nova"
+	attributes "korath space" "isolated" "!nova"
 	habitable 100
 	belt 1948
 	haze _menu/haze-blackbody
@@ -18821,7 +18821,7 @@ system Persitar
 system Phact
 	pos -375 -191
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 1080.62
 	belt 1704
 	haze _menu/haze-67
@@ -18894,7 +18894,7 @@ system Phact
 system Phecda
 	pos -607 88
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 320
 	belt 1375
 	link Algorel
@@ -18952,7 +18952,7 @@ system Phecda
 system Pherkad
 	pos -798 451
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 135
 	belt 1924
 	haze _menu/haze-67
@@ -19008,7 +19008,7 @@ system Pherkad
 system Phurad
 	pos -494 -153
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 1080
 	belt 1881
 	link Tejat
@@ -19068,7 +19068,7 @@ system Phurad
 system Pik'ro'iyak
 	pos -378.845 -677.001
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 233.28
 	belt 1279
 	haze _menu/haze-none
@@ -19117,7 +19117,7 @@ system Pik'ro'iyak
 system Plort
 	pos -708.587 723.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 320
 	belt 1490
 	link "Sol Arach"
@@ -19295,7 +19295,7 @@ system Polerius
 system Pollux
 	pos -465 4
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 1080
 	belt 1161
 	haze _menu/haze-67
@@ -19350,7 +19350,7 @@ system Pollux
 system Porrima
 	pos -556 123
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 760
 	belt 1636
 	haze _menu/haze-67
@@ -19451,7 +19451,7 @@ system Postverta
 system Prakacha'a
 	pos -35.1114 -802.607
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 1505.92
 	belt 1637
 	haze _menu/haze-33
@@ -19530,7 +19530,7 @@ system Prakacha'a
 system Procyon
 	pos -411 23
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 455.625
 	belt 1763
 	haze _menu/haze-67
@@ -19629,7 +19629,7 @@ system Prosa
 system "Pug Iyik"
 	pos -361.149 -883.233
 	government "Pug (Wanderer)"
-	attributes "!wanderer" "!isolated"
+	attributes "isolated"
 	habitable 625
 	belt 1286
 	haze _menu/haze-blackbody
@@ -19687,7 +19687,7 @@ system "Pug Iyik"
 system Quaru
 	pos -1080.63 448.214
 	government Heliarch
-	attributes "!coalition" "!ringworld"
+	attributes "ringworld"
 	habitable 700
 	belt 1440
 	haze _menu/haze-133
@@ -20003,7 +20003,7 @@ system Queri
 system Rajak
 	pos -270 -236
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 78.125
 	belt 1410
 	haze _menu/haze-67
@@ -20071,7 +20071,7 @@ system Rajak
 system Rasalhague
 	pos -413 246
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 455.625
 	belt 1282
 	haze _menu/haze-133
@@ -20132,7 +20132,7 @@ system Rasalhague
 system Rastaban
 	pos -463 446
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 1080
 	belt 1041
 	haze _menu/haze-133
@@ -20193,7 +20193,7 @@ system Rastaban
 system "Rati Cal"
 	pos -116.765 -391.123
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 425.92
 	belt 1538
 	link "Due Yoot"
@@ -20247,7 +20247,7 @@ system "Rati Cal"
 system Regor
 	pos -702 -335
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 455.625
 	belt 1305
 	haze _menu/haze-67
@@ -20310,7 +20310,7 @@ system Regor
 system Regulus
 	pos -544 25
 	government Republic
-	attributes "!human" "!near earth" "!fringe"
+	attributes "human space" "near earth" "fringe"
 	habitable 8640
 	belt 1605
 	haze _menu/haze-67
@@ -20463,7 +20463,7 @@ system Relifer
 system Remembrance
 	pos -884.587 641.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 486.68
 	belt 1536
 	link Beginning
@@ -20520,7 +20520,7 @@ system Remembrance
 system Rigel
 	pos -324 -363
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 1080
 	belt 1782
 	link Saiph
@@ -20670,7 +20670,7 @@ system Ritilas
 system Ruchbah
 	pos -174 69
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 2560
 	belt 1598
 	haze _menu/haze-133
@@ -20742,7 +20742,7 @@ system Ruchbah
 system Rutilicus
 	pos -535 273
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 625
 	belt 1771
 	link Arcturus
@@ -20811,7 +20811,7 @@ system Rutilicus
 system Sabik
 	pos -675 379
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 625
 	belt 1609
 	link Unukalhai
@@ -20863,7 +20863,7 @@ system Sabik
 system Sabriset
 	pos 151.724 -426.518
 	government Uninhabited
-	attributes "!korath" "!fringe"
+	attributes "korath space" "fringe"
 	habitable 1566.68
 	belt 1025
 	link Sepriaptu
@@ -20917,7 +20917,7 @@ system Sabriset
 system Sadalmelik
 	pos -145 472
 	government Quarg
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 1715
 	belt 1273
 	link Enif
@@ -20973,7 +20973,7 @@ system Sadalmelik
 system Sadalsuud
 	pos -134 508
 	government Quarg
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 1400
 	belt 1859
 	link Enif
@@ -21035,7 +21035,7 @@ system Sadalsuud
 system Sadr
 	pos -287 543
 	government Republic
-	attributes "!human" "!south" "!fringe"
+	attributes "human space" "the south" "fringe"
 	habitable 3859.38
 	belt 1388
 	link Albireo
@@ -21100,7 +21100,7 @@ system Sadr
 system "Sagittarius A*"
 	pos 112 22
 	government Uninhabited
-	attributes "!black hole" "!isolated"
+	attributes "isolated"
 	habitable 10000
 	haze _menu/haze-full
 	object
@@ -21113,7 +21113,7 @@ system "Sagittarius A*"
 system Saiph
 	pos -375 -390
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 320
 	belt 1690
 	haze _menu/haze-33
@@ -21167,7 +21167,7 @@ system Saiph
 system Salipastart
 	pos 250.431 -370.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata" "!warzone"
+	attributes "korath space"  "warzone"
 	habitable 486.68
 	belt 1056
 	haze _menu/haze-133
@@ -21234,7 +21234,7 @@ system Salipastart
 system Saquergen
 	pos -482 561
 	government Uninhabited
-	attributes "!isolated" "!nova"
+	attributes "isolated" "!nova"
 	habitable 100
 	belt 1435
 	asteroids "small rock" 3 3.9105
@@ -21263,7 +21263,7 @@ system Saquergen
 system Sargas
 	pos -542 445
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 911.25
 	belt 1642
 	link Kornephoros
@@ -21314,7 +21314,7 @@ system Sargas
 system Sarin
 	pos -670 293
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 1080
 	belt 1752
 	link Vindemiatrix
@@ -21364,7 +21364,7 @@ system Sarin
 system Sayaiban
 	pos 250.431 -274.812
 	government Drak
-	attributes "archon" "!korath" "!hazard" "!isolated"
+	attributes "archon" "korath space" "isolated"
 	habitable 2035
 	belt 1803
 	asteroids "small rock" 13 2.106
@@ -21419,7 +21419,7 @@ system Sayaiban
 system Scheat
 	pos -205 233
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 625
 	belt 1536
 	haze _menu/haze-133
@@ -21477,7 +21477,7 @@ system Scheat
 system Schedar
 	pos -93 229
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 1080
 	belt 1903
 	haze _menu/haze-133
@@ -21612,7 +21612,7 @@ system Segesta
 system Seginus
 	pos -557 356
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 135
 	belt 1906
 	link Alnasl
@@ -21678,7 +21678,7 @@ system Seginus
 system Seketra
 	pos -24.5695 -356.812
 	government Uninhabited
-	attributes "!korath" "!fringe"
+	attributes "korath space" "fringe"
 	habitable 425.92
 	belt 1465
 	link Skeruto
@@ -21730,7 +21730,7 @@ system Seketra
 system Sepetrosk
 	pos 192.431 -243.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 486.68
 	belt 1286
 	link Chimitarp
@@ -21791,7 +21791,7 @@ system Sepetrosk
 system Sepriaptu
 	pos 139.431 -448.812
 	government Uninhabited
-	attributes "!korath" "!fringe"
+	attributes "korath space" "fringe"
 	habitable 2035
 	belt 1120
 	link Kaliptari
@@ -21843,7 +21843,7 @@ system Sepriaptu
 system Sevrelect
 	pos -114.569 -239.812
 	government "Kor Efret"
-	attributes "!korath" "!efreti"
+	attributes "korath space"
 	habitable 320
 	belt 1763
 	haze _menu/haze-67
@@ -21894,7 +21894,7 @@ system Sevrelect
 system Shaula
 	pos -460 527
 	government Pirate
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 625
 	belt 1814
 	link Lesath
@@ -21962,7 +21962,7 @@ system Shaula
 system Sheratan
 	pos -40 45
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 2035
 	belt 1183
 	haze _menu/haze-133
@@ -22022,7 +22022,7 @@ system Sheratan
 system Si'yak'ku
 	pos -329.235 -760.435
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 1313.28
 	belt 1985
 	haze _menu/haze-none
@@ -22103,7 +22103,7 @@ system Si'yak'ku
 system Sich'ka'ara
 	pos -97.1237 -831.921
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 1715
 	belt 1744
 	haze _menu/haze-none
@@ -22156,7 +22156,7 @@ system Sich'ka'ara
 system Silikatakfar
 	pos 248.431 -481.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 425.92
 	belt 1641
 	link Mesuket
@@ -22210,7 +22210,7 @@ system Silikatakfar
 system "Silver Bell"
 	pos -1045.59 541.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 1080
 	belt 1406
 	link "Bright Void"
@@ -22278,7 +22278,7 @@ system "Silver Bell"
 system "Silver String"
 	pos -1022.59 517.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 1080
 	belt 1986
 	link "Silver Bell"
@@ -22343,7 +22343,7 @@ system "Silver String"
 system Similisti
 	pos 210.431 -313.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 1080
 	belt 1349
 	haze _menu/haze-133
@@ -22411,7 +22411,7 @@ system Similisti
 system Sirius
 	pos -378 44
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 1800
 	belt 1407
 	link Sol
@@ -22475,7 +22475,7 @@ system Sirius
 system Skeruto
 	pos 28.4305 -339.812
 	government Uninhabited
-	attributes "!korath"
+	attributes "korath space"
 	habitable 320
 	belt 1198
 	link Furmeliki
@@ -22526,7 +22526,7 @@ system Skeruto
 system Sko'karak
 	pos -304.43 -930.688
 	government Wanderer
-	attributes "!wanderer"
+	attributes
 	habitable 320
 	belt 1805
 	haze _menu/haze-none
@@ -22579,7 +22579,7 @@ system Sko'karak
 system Sobarati
 	pos 277.431 -557.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 3780
 	belt 1314
 	link Asikafarnut
@@ -22641,7 +22641,7 @@ system Sobarati
 system Sol
 	pos -400 100
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 1080
 	belt 1529
 	haze _menu/haze-67
@@ -22721,7 +22721,7 @@ system Sol
 system "Sol Arach"
 	pos -711.587 649.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 486.68
 	belt 1147
 	haze _menu/haze-133
@@ -22793,7 +22793,7 @@ system "Sol Arach"
 system "Sol Kimek"
 	pos -1310.63 227.214
 	government Coalition
-	attributes "!coalition" "!kimek"
+	attributes "kimek space"
 	habitable 425.92
 	belt 1490
 	link "3 Pole"
@@ -22868,7 +22868,7 @@ system "Sol Kimek"
 system "Sol Saryd"
 	pos -1037.59 675.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 1313.28
 	belt 1720
 	link Belonging
@@ -22951,7 +22951,7 @@ system "Sol Saryd"
 system Solifar
 	pos 47.4305 -435.812
 	government Uninhabited
-	attributes "!korath"
+	attributes "korath space"
 	habitable 320
 	belt 1517
 	haze _menu/haze-67
@@ -23007,7 +23007,7 @@ system Solifar
 system Sospi
 	pos -317 -161
 	government Republic
-	attributes "!human" "!north" "!fringe"
+	attributes "human space" "far north" "fringe"
 	habitable 1715
 	belt 1715
 	haze _menu/haze-133
@@ -23073,7 +23073,7 @@ system Sospi
 system Speloog
 	pos -967.587 445.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 625
 	belt 1159
 	link Belug
@@ -23140,7 +23140,7 @@ system Speloog
 system Spica
 	pos -906 120
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 625
 	belt 1940
 	haze _menu/haze-33
@@ -23243,7 +23243,7 @@ system Statina
 system "Steep Roof"
 	pos -1113.59 570.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd space"
 	habitable 1080
 	belt 1100
 	haze _menu/haze-67
@@ -23379,7 +23379,7 @@ system Stercutus
 system Suhail
 	pos -774 -338
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 1715
 	belt 1715
 	haze _menu/haze-33
@@ -23440,7 +23440,7 @@ system Suhail
 system Sumar
 	pos -236 -273
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 2560
 	belt 1778
 	link Cardax
@@ -23500,7 +23500,7 @@ system Sumar
 system Sumprast
 	pos -101.569 -262.812
 	government "Kor Efret"
-	attributes "!korath" "!automata"
+	attributes "korath space"
 	habitable 486.68
 	belt 1958
 	haze _menu/haze-67
@@ -23566,7 +23566,7 @@ system Sumprast
 system Tais
 	pos -346 381
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 3645
 	belt 1379
 	haze _menu/haze-133
@@ -23624,7 +23624,7 @@ system Tais
 system Talita
 	pos -519 -26
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 1705
 	belt 1403
 	link Miaplacidus
@@ -23690,7 +23690,7 @@ system Talita
 system "Tania Australis"
 	pos -671 7
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 1080
 	belt 1738
 	link Phecda
@@ -23763,7 +23763,7 @@ system "Tania Australis"
 system Tarazed
 	pos -194 448
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 1215
 	belt 1169
 	link Enif
@@ -23826,7 +23826,7 @@ system Tarazed
 system Tebuteb
 	pos -615.587 710.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 553.28
 	belt 1855
 	link Miblulub
@@ -23888,7 +23888,7 @@ system Tebuteb
 system Tejat
 	pos -489 -107
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 1158.12
 	belt 1447
 	link Phurad
@@ -23966,7 +23966,7 @@ system Tejat
 system Terminus
 	pos -727.99 -23.2491
 	government Republic
-	attributes "wormhole" "!human" "!dirt belt" "!fringe"
+	attributes "wormhole" "human space" "dirt belt" "fringe"
 	habitable 425.92
 	belt 1221
 	haze _menu/haze-67
@@ -24019,7 +24019,7 @@ system Terminus
 system "Terra Incognita"
 	pos 9921.5 7086.5
 	government Uninhabited
-	attributes "!pleiades"
+	attributes
 	link "Over the Rainbow"
 	habitable 455.625
 	haze _menu/haze-blackbody
@@ -24064,7 +24064,7 @@ system "Terra Incognita"
 system Torbab
 	pos -949.587 490.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi space"
 	habitable 1505.92
 	belt 1702
 	link Speloog
@@ -24141,7 +24141,7 @@ system Torbab
 system Tortor
 	pos -255 -424
 	government Republic
-	attributes "!human" "!north" "!fringe"
+	attributes "human space" "far north" "fringe"
 	habitable 455.625
 	belt 1243
 	haze _menu/haze-67
@@ -24208,7 +24208,7 @@ system Tortor
 system Turais
 	pos -691 134
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 320
 	belt 1471
 	link Gacrux
@@ -24265,7 +24265,7 @@ system Turais
 system "Ula Mon"
 	pos -64.1218 -559.868
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 640
 	belt 1574
 	link "Bote Asu"
@@ -24340,7 +24340,7 @@ system "Ula Mon"
 system "Ultima Thule"
 	pos -336 -211
 	government Republic
-	attributes "wormhole" "!north"
+	attributes "wormhole" "far north"
 	habitable 2560
 	belt 1635
 	haze _menu/haze-67
@@ -24394,7 +24394,7 @@ system "Ultima Thule"
 system Umbral
 	pos -164 406
 	government Republic
-	attributes "!human" "!south" "!fringe"
+	attributes "human space" "the south" "fringe"
 	habitable 670
 	belt 1345
 	link Tarazed
@@ -24472,7 +24472,7 @@ system Umbral
 system Unagi
 	pos -306 -578
 	government Pirate
-	attributes "!human" "!north" "!fringe"
+	attributes "human space" "far north" "fringe"
 	habitable 320
 	belt 1960
 	haze _menu/haze-33
@@ -24526,7 +24526,7 @@ system Unagi
 system Unukalhai
 	pos -710 405
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 625
 	belt 1968
 	haze _menu/haze-67
@@ -24587,7 +24587,7 @@ system Unukalhai
 system "Uwa Fahn"
 	pos 35.1585 -491.67
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 320
 	belt 1913
 	link "Ya Hai"
@@ -24693,7 +24693,7 @@ system Vaticanus
 system Vega
 	pos -402 182
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "human space" "near earth"
 	habitable 1400
 	belt 1744
 	link Altair
@@ -24757,7 +24757,7 @@ system Vega
 system Vindemiatrix
 	pos -635 257
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 1080
 	belt 1957
 	link Alioth
@@ -24810,7 +24810,7 @@ system Vindemiatrix
 system Volax
 	pos -256 -179
 	government Republic
-	attributes "!human" "!north"
+	attributes "human space" "far north"
 	habitable 1715
 	belt 1424
 	haze _menu/haze-67
@@ -24865,7 +24865,7 @@ system Volax
 system "Wah Ki"
 	pos 14.9925 -612.792
 	government Hai
-	attributes "!hai" "!warzone"
+	attributes "warzone"
 	habitable 425.92
 	belt 1585
 	link "Zuba Zub"
@@ -24934,7 +24934,7 @@ system "Wah Ki"
 system "Wah Oh"
 	pos -205.344 -381.381
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 5000
 	belt 1194
 	haze _menu/haze-67
@@ -25013,7 +25013,7 @@ system "Wah Oh"
 system "Wah Yoot"
 	pos 40.9382 -685.994
 	government "Hai (Unfettered)"
-	attributes "!hai"
+	attributes
 	habitable 1080
 	belt 1222
 	link "Wah Ki"
@@ -25078,7 +25078,7 @@ system "Wah Yoot"
 system Waypoint
 	pos -184 -515
 	government Hai
-	attributes "wormhole" "!hai"
+	attributes "wormhole"
 	habitable 78.125
 	belt 1610
 	haze _menu/haze-67
@@ -25136,7 +25136,7 @@ system Waypoint
 system Wazn
 	pos -385 -131
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "human space" "paradise worlds"
 	habitable 534.375
 	belt 1414
 	haze _menu/haze-67
@@ -25202,7 +25202,7 @@ system Wazn
 system Wei
 	pos -598 369
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 455.625
 	belt 1927
 	link Seginus
@@ -25260,7 +25260,7 @@ system Wei
 system Wezen
 	pos -664 -433
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 2880
 	belt 1913
 	link Naos
@@ -25342,7 +25342,7 @@ system Wezen
 system "World's End"
 	pos 9966.5 7017.5
 	government Uninhabited
-	attributes "!pleiades"
+	attributes
 	habitable 700
 	haze _menu/haze-blackbody
 	object
@@ -25402,7 +25402,7 @@ system "World's End"
 system "Ya Hai"
 	pos -24.9453 -505.571
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 425.92
 	belt 1120
 	link "Ula Mon"
@@ -25477,7 +25477,7 @@ system "Ya Hai"
 system "Yed Prior"
 	pos -810 374
 	government Republic
-	attributes "!human" "!south"
+	attributes "human space" "the south"
 	habitable 455.625
 	belt 1837
 	link Pherkad
@@ -25534,7 +25534,7 @@ system "Yed Prior"
 system Zaurak
 	pos -109 -34
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "human space" "the core"
 	habitable 625
 	belt 1130
 	haze _menu/haze-133
@@ -25592,7 +25592,7 @@ system Zaurak
 system "Zeta Aquilae"
 	pos -369 276
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "human space" "dirt belt"
 	habitable 1400
 	belt 1829
 	haze _menu/haze-133
@@ -25667,7 +25667,7 @@ system "Zeta Aquilae"
 system "Zeta Centauri"
 	pos -835 257
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 455.625
 	belt 1488
 	haze _menu/haze-67
@@ -25723,7 +25723,7 @@ system "Zeta Centauri"
 system Zosma
 	pos -640 -123
 	government Republic
-	attributes "!human" "!deep"
+	attributes "human space" "the deep"
 	habitable 455.625
 	belt 1436
 	link Algieba
@@ -25789,7 +25789,7 @@ system Zosma
 system "Zuba Zub"
 	pos -48.2661 -647.926
 	government Hai
-	attributes "!hai"
+	attributes
 	habitable 425.92
 	belt 1911
 	haze _menu/haze-67
@@ -25855,7 +25855,7 @@ system "Zuba Zub"
 system Zubenelgenubi
 	pos -710 353
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 945
 	belt 1475
 	link Zubeneschamali
@@ -25921,7 +25921,7 @@ system Zubenelgenubi
 system Zubeneschamali
 	pos -759 338
 	government Republic
-	attributes "!human" "!rim"
+	attributes "human space" "the rim"
 	habitable 1250
 	belt 1543
 	haze _menu/haze-67

--- a/data/map.txt
+++ b/data/map.txt
@@ -7169,6 +7169,7 @@ system Convector
 system "Cor Caroli"
 	pos -682 201
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1474
 	link Vindemiatrix
@@ -7227,6 +7228,7 @@ system "Cor Caroli"
 system "Da Ent"
 	pos -6.22391 -462.536
 	government Hai
+	attributes "!hai"
 	habitable 233.28
 	belt 1161
 	link "Ya Hai"
@@ -7287,6 +7289,7 @@ system "Da Ent"
 system "Da Lest"
 	pos -23.2239 -413.536
 	government Hai
+	attributes "!hai"
 	habitable 320
 	belt 1108
 	link "Lom Tahr"
@@ -7341,6 +7344,7 @@ system "Da Lest"
 system Dabih
 	pos -253 427
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 670
 	belt 1088
 	haze _menu/haze-133
@@ -7400,6 +7404,7 @@ system Dabih
 system Danoa
 	pos -239 -321
 	government Republic
+	attributes "!human" "!north"
 	habitable 135
 	belt 1689
 	haze _menu/haze-67
@@ -7468,6 +7473,7 @@ system Danoa
 system "Dark Hills"
 	pos -926.587 619.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 1080
 	belt 1367
 	link Beginning
@@ -7534,6 +7540,7 @@ system "Dark Hills"
 system Debrugt
 	pos -869.587 513.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 640
 	belt 1224
 	link Torbab
@@ -7682,6 +7689,7 @@ system Delia
 system "Delta Capricorni"
 	pos -285 202
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 839.375
 	belt 1329
 	haze _menu/haze-133
@@ -7744,6 +7752,7 @@ system "Delta Capricorni"
 system "Delta Sagittarii"
 	pos -414 416
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1414
 	haze _menu/haze-133
@@ -7810,6 +7819,7 @@ system "Delta Sagittarii"
 system "Delta Velorum"
 	pos -740 90
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1221
 	haze _menu/haze-67
@@ -7868,6 +7878,7 @@ system "Delta Velorum"
 system Deneb
 	pos -348 225
 	government Pug
+	attributes "!human" "!isolated"
 	habitable 625
 	belt 1890
 	haze _menu/haze-133
@@ -7923,6 +7934,7 @@ system Deneb
 system Denebola
 	pos -478 70
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 534.375
 	belt 1050
 	haze _menu/haze-67
@@ -7993,6 +8005,7 @@ system Diespiter
 	asteroids "small metal" 74 2
 	asteroids "small rock" 65 3
 	government Uninhabited
+	attributes "!ember waste"
 	haze _menu/haze-red
 	link Statina
 	minables iron 22 3
@@ -8022,6 +8035,7 @@ system Diespiter
 system Diphda
 	pos -262 61
 	government Syndicate
+	attributes "!human" "!near earth"
 	habitable 590.625
 	belt 1559
 	haze _menu/haze-133
@@ -8154,6 +8168,7 @@ system Dixere
 system Dokdobaru
 	pos -21.5695 -241.812
 	government Quarg
+	attributes "!korath"
 	habitable 700
 	belt 1935
 	haze _menu/haze-133
@@ -8258,6 +8273,7 @@ system Dokdobaru
 system Dschubba
 	pos -598 501
 	government Republic
+	attributes "!human" "!south"
 	habitable 398.125
 	belt 1429
 	link Atria
@@ -8331,6 +8347,7 @@ system Dschubba
 system Dubhe
 	pos -577 -103
 	government Republic
+	attributes "!human" "!deep"
 	habitable 349.375
 	belt 1120
 	link Zosma
@@ -8387,6 +8404,7 @@ system Dubhe
 system "Due Yoot"
 	pos -167.547 -426.683
 	government Hai
+	attributes "!hai"
 	habitable 233.28
 	belt 1854
 	link "Wah Oh"
@@ -8451,6 +8469,7 @@ system "Due Yoot"
 system Durax
 	pos -59 -90
 	government Pirate
+	attributes "!human" "!core" "!fringe"
 	habitable 1080
 	belt 1287
 	haze _menu/haze-133
@@ -8515,6 +8534,7 @@ system Durax
 system Eber
 	pos -532 406
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1199
 	link Alnasl
@@ -8578,6 +8598,7 @@ system Eber
 system Eblumab
 	pos -767.587 703.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 425.92
 	belt 1804
 	haze _menu/haze-133
@@ -8698,6 +8719,7 @@ system Egeria
 	asteroids "medium rock" 20 5
 	asteroids "small rock" 1 8
 	government Uninhabited
+	attributes "!ember waste"
 	haze _menu/haze-red
 	link Vaticanus
 	link Statina
@@ -8729,6 +8751,7 @@ system Egeria
 system "Ehma Ti"
 	pos 39.1085 -749.244
 	government "Hai (Unfettered)"
+	attributes "!hai"
 	habitable 486.68
 	belt 1094
 	link "Wah Yoot"
@@ -8796,6 +8819,7 @@ system "Ehma Ti"
 system Ek'kek'ru
 	pos -287.517 -727.738
 	government Wanderer
+	attributes "!wanderer"
 	habitable 320
 	belt 1517
 	haze _menu/haze-none
@@ -8855,6 +8879,7 @@ system Ek'kek'ru
 system Ekuarik
 	pos -1029.63 426.214
 	government Heliarch
+	attributes "!coalition"
 	habitable 700
 	belt 1711
 	link "Ki War Ek"
@@ -9037,6 +9062,7 @@ system Ekuarik
 system Elnath
 	pos -288 -77
 	government Republic
+	attributes "!human" "!north"
 	habitable 1715
 	belt 1462
 	link Acamar
@@ -9101,6 +9127,7 @@ system Elnath
 system Eltanin
 	pos -328 433
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 455.625
 	belt 1859
 	haze _menu/haze-133
@@ -9160,6 +9187,7 @@ system Eltanin
 system Eneremprukt
 	pos 311.431 -448.812
 	government "Kor Sestor"
+	attributes "!korath" "!automata"
 	habitable 486.68
 	belt 1421
 	link Silikatakfar
@@ -9215,6 +9243,7 @@ system Eneremprukt
 system Enif
 	pos -177 498
 	government Quarg
+	attributes "!human" "!south"
 	habitable 700
 	belt 1974
 	link Sadalmelik
@@ -9303,6 +9332,7 @@ system Enif
 system "Epsilon Leonis"
 	pos -619 -229
 	government Republic
+	attributes "!human" "!deep"
 	habitable 1400
 	belt 1527
 	link Gomeisa
@@ -9377,6 +9407,7 @@ system "Epsilon Leonis"
 system Es'sprak'ai
 	pos -469.044 -733.375
 	government Wanderer
+	attributes "!wanderer"
 	habitable 486.68
 	belt 1928
 	haze _menu/haze-none
@@ -9437,6 +9468,7 @@ system Es'sprak'ai
 system Eshkoshtar
 	pos 156.431 -381.812
 	government "Kor Mereti"
+	attributes "!korath" "!automata"
 	habitable 806.68
 	belt 1105
 	link Mekislepti
@@ -9570,6 +9602,7 @@ system Esix
 system Eteron
 	pos -330 33
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 135
 	belt 1479
 	link Sirius

--- a/data/map.txt
+++ b/data/map.txt
@@ -21234,7 +21234,7 @@ system Salipastart
 system Saquergen
 	pos -482 561
 	government Uninhabited
-	attributes "!human"	"!south" "!isolated" "!nova"
+	attributes "!isolated" "!nova"
 	habitable 100
 	belt 1435
 	asteroids "small rock" 3 3.9105

--- a/data/map.txt
+++ b/data/map.txt
@@ -4413,7 +4413,6 @@ system Antevorta
 system Ap'arak
 	pos -164.62 -781.858
 	government Wanderer
-	attributes "wanderer"
 	habitable 1080
 	belt 1385
 	haze _menu/haze-none
@@ -4977,7 +4976,6 @@ system Avior
 system Aya'k'k
 	pos -434.245 -616.57
 	government Wanderer
-	attributes "wanderer"
 	habitable 486.68
 	belt 1586
 	haze _menu/haze-67
@@ -5755,7 +5753,6 @@ system Boral
 system "Bore Fah"
 	pos 71.7761 -592.536
 	government Hai
-	attributes "hai"
 	habitable 625
 	belt 1823
 	link "Wah Ki"
@@ -5815,7 +5812,6 @@ system "Bore Fah"
 system "Bote Asu"
 	pos 8.87418 -572.768
 	government Hai
-	attributes "hai"
 	habitable 2859.44
 	belt 1613
 	link "Wah Ki"
@@ -6759,7 +6755,6 @@ system Chimitarp
 system Chirr'ay'akai
 	pos -102.761 -749.614
 	government Wanderer
-	attributes "wanderer"
 	habitable 486.68
 	belt 1425
 	haze _menu/haze-33
@@ -6870,7 +6865,6 @@ system Chornifath
 system Chy'chra
 	pos 85.5308 -829.667
 	government Wanderer
-	attributes "wanderer"
 	habitable 625
 	belt 1120
 	haze _menu/haze-33
@@ -7228,7 +7222,6 @@ system "Cor Caroli"
 system "Da Ent"
 	pos -6.22391 -462.536
 	government Hai
-	attributes "hai"
 	habitable 233.28
 	belt 1161
 	link "Ya Hai"
@@ -7289,7 +7282,6 @@ system "Da Ent"
 system "Da Lest"
 	pos -23.2239 -413.536
 	government Hai
-	attributes "hai"
 	habitable 320
 	belt 1108
 	link "Lom Tahr"
@@ -8403,7 +8395,6 @@ system Dubhe
 system "Due Yoot"
 	pos -167.547 -426.683
 	government Hai
-	attributes "hai"
 	habitable 233.28
 	belt 1854
 	link "Wah Oh"
@@ -8750,7 +8741,6 @@ system Egeria
 system "Ehma Ti"
 	pos 39.1085 -749.244
 	government "Hai (Unfettered)"
-	attributes "hai"
 	habitable 486.68
 	belt 1094
 	link "Wah Yoot"
@@ -8818,7 +8808,6 @@ system "Ehma Ti"
 system Ek'kek'ru
 	pos -287.517 -727.738
 	government Wanderer
-	attributes "wanderer"
 	habitable 320
 	belt 1517
 	haze _menu/haze-none
@@ -9406,7 +9395,6 @@ system "Epsilon Leonis"
 system Es'sprak'ai
 	pos -469.044 -733.375
 	government Wanderer
-	attributes "wanderer"
 	habitable 486.68
 	belt 1928
 	haze _menu/haze-none
@@ -9666,7 +9654,6 @@ system Eteron
 system "Fah Root"
 	pos -264.065 -400.135
 	government Hai
-	attributes "hai"
 	habitable 486.68
 	belt 1057
 	haze _menu/haze-67
@@ -9735,7 +9722,6 @@ system "Fah Root"
 system "Fah Soom"
 	pos -179.891 -335.011
 	government Hai
-	attributes "hai"
 	habitable 425.92
 	belt 1185
 	haze _menu/haze-67
@@ -12133,7 +12119,6 @@ system Hatysa
 system "Heia Due"
 	pos -146.177 -481.694
 	government Hai
-	attributes "hai"
 	habitable 1215
 	belt 1079
 	haze _menu/haze-67
@@ -12276,7 +12261,7 @@ system Hesselpost
 system "Hevru Hai"
 	pos -189 -310
 	government Quarg
-	attributes "hai" "ringworld"
+	attributes "ringworld"
 	habitable 700
 	belt 1245
 	link "Fah Soom"
@@ -12391,7 +12376,6 @@ system "Hevru Hai"
 system "Hi Yahr"
 	pos 82.3672 -641.6
 	government "Hai (Unfettered)"
-	attributes "hai"
 	habitable 625
 	belt 1655
 	link "Wah Yoot"
@@ -12733,7 +12717,6 @@ system Hunter
 system Ik'kara'ka
 	pos 56.2159 -888.296
 	government Wanderer
-	attributes "wanderer"
 	habitable 625
 	belt 1497
 	haze _menu/haze-none
@@ -12849,7 +12832,6 @@ system Ildaria
 system "Imo Dep"
 	pos -56.2764 -600.1
 	government Hai
-	attributes "hai"
 	habitable 1715
 	belt 1416
 	haze _menu/haze-67
@@ -12974,7 +12956,6 @@ system Insitor
 system "Io Lowe"
 	pos -94.7566 -527.728
 	government Hai
-	attributes "hai"
 	habitable 135
 	belt 1552
 	haze _menu/haze-67
@@ -13036,7 +13017,6 @@ system "Io Lowe"
 system "Io Mann"
 	pos -192.955 -447.669
 	government Hai
-	attributes "hai"
 	habitable 973.36
 	belt 1132
 	haze _menu/haze-67
@@ -13178,7 +13158,6 @@ system Ipsing
 system Iyech'yek
 	pos -277.37 -693.913
 	government Wanderer
-	attributes "wanderer"
 	habitable 320
 	belt 1613
 	haze _menu/haze-33
@@ -13297,7 +13276,6 @@ system Izar
 system Ka'ch'chrai
 	pos -240.163 -822.448
 	government Wanderer
-	attributes "wanderer"
 	habitable 425.92
 	belt 1745
 	haze _menu/haze-none
@@ -13355,7 +13333,6 @@ system Ka'ch'chrai
 system Ka'pru
 	pos -76.6756 -994.955
 	government Wanderer
-	attributes "wanderer"
 	habitable 1505.92
 	belt 1808
 	haze _menu/haze-33
@@ -14005,7 +13982,6 @@ system "Ki War Ek"
 system Kiro'ku
 	pos -131.923 -884.46
 	government Wanderer
-	attributes "wanderer"
 	habitable 1111.68
 	belt 1308
 	haze _menu/haze-none
@@ -14082,7 +14058,6 @@ system Kiro'ku
 system Kiru'kichi
 	pos -195.063 -662.343
 	government Wanderer
-	attributes "wanderer"
 	habitable 2795
 	belt 1465
 	haze _menu/haze-33
@@ -15308,7 +15283,6 @@ system Lolami
 system "Lom Tahr"
 	pos -94.0437 -446.586
 	government Hai
-	attributes "hai"
 	habitable 2372.76
 	belt 1445
 	link "Ya Hai"
@@ -16032,7 +16006,6 @@ system Meftarkata
 system "Mei Yohn"
 	pos -106.757 -581.698
 	government Hai
-	attributes "hai"
 	habitable 425.92
 	belt 1075
 	haze _menu/haze-67
@@ -19066,7 +19039,6 @@ system Phurad
 system Pik'ro'iyak
 	pos -378.845 -677.001
 	government Wanderer
-	attributes "wanderer"
 	habitable 233.28
 	belt 1279
 	haze _menu/haze-none
@@ -19449,7 +19421,6 @@ system Postverta
 system Prakacha'a
 	pos -35.1114 -802.607
 	government Wanderer
-	attributes "wanderer"
 	habitable 1505.92
 	belt 1637
 	haze _menu/haze-33
@@ -20190,7 +20161,6 @@ system Rastaban
 system "Rati Cal"
 	pos -116.765 -391.123
 	government Hai
-	attributes "hai"
 	habitable 425.92
 	belt 1538
 	link "Due Yoot"
@@ -22018,7 +21988,6 @@ system Sheratan
 system Si'yak'ku
 	pos -329.235 -760.435
 	government Wanderer
-	attributes "wanderer"
 	habitable 1313.28
 	belt 1985
 	haze _menu/haze-none
@@ -22099,7 +22068,6 @@ system Si'yak'ku
 system Sich'ka'ara
 	pos -97.1237 -831.921
 	government Wanderer
-	attributes "wanderer"
 	habitable 1715
 	belt 1744
 	haze _menu/haze-none
@@ -22522,7 +22490,6 @@ system Skeruto
 system Sko'karak
 	pos -304.43 -930.688
 	government Wanderer
-	attributes "wanderer"
 	habitable 320
 	belt 1805
 	haze _menu/haze-none
@@ -24260,7 +24227,6 @@ system Turais
 system "Ula Mon"
 	pos -64.1218 -559.868
 	government Hai
-	attributes "hai"
 	habitable 640
 	belt 1574
 	link "Bote Asu"
@@ -24582,7 +24548,6 @@ system Unukalhai
 system "Uwa Fahn"
 	pos 35.1585 -491.67
 	government Hai
-	attributes "hai"
 	habitable 320
 	belt 1913
 	link "Ya Hai"
@@ -24860,7 +24825,6 @@ system Volax
 system "Wah Ki"
 	pos 14.9925 -612.792
 	government Hai
-	attributes "hai"
 	habitable 425.92
 	belt 1585
 	link "Zuba Zub"
@@ -24929,7 +24893,6 @@ system "Wah Ki"
 system "Wah Oh"
 	pos -205.344 -381.381
 	government Hai
-	attributes "hai"
 	habitable 5000
 	belt 1194
 	haze _menu/haze-67
@@ -25008,7 +24971,6 @@ system "Wah Oh"
 system "Wah Yoot"
 	pos 40.9382 -685.994
 	government "Hai (Unfettered)"
-	attributes "hai"
 	habitable 1080
 	belt 1222
 	link "Wah Ki"
@@ -25396,7 +25358,6 @@ system "World's End"
 system "Ya Hai"
 	pos -24.9453 -505.571
 	government Hai
-	attributes "hai"
 	habitable 425.92
 	belt 1120
 	link "Ula Mon"
@@ -25783,7 +25744,6 @@ system Zosma
 system "Zuba Zub"
 	pos -48.2661 -647.926
 	government Hai
-	attributes "hai"
 	habitable 425.92
 	belt 1911
 	haze _menu/haze-67

--- a/data/map.txt
+++ b/data/map.txt
@@ -75,7 +75,7 @@ galaxy "label graveyard"
 system "1 Axis"
 	pos -1274.63 267.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 745.92
 	belt 1112
 	link "Sol Kimek"
@@ -153,7 +153,7 @@ system "1 Axis"
 system "10 Pole"
 	pos -1356.63 19.2137
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 486.68
 	belt 1765
 	haze _menu/haze-67
@@ -225,7 +225,7 @@ system "10 Pole"
 system "11 Autumn Above"
 	pos -1278.63 148.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 1566.68
 	belt 1099
 	haze _menu/haze-133
@@ -307,7 +307,7 @@ system "11 Autumn Above"
 system "11 Spring Below"
 	pos -1272.63 380.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 912.6
 	belt 1932
 	link "4 Spring Rising"
@@ -387,7 +387,7 @@ system "11 Spring Below"
 system "12 Autumn Above"
 	pos -1276.63 -19.7863
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 1050.92
 	belt 1283
 	link "14 Pole"
@@ -481,7 +481,7 @@ system "12 Autumn Above"
 system "14 Pole"
 	pos -1343.63 -119.786
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 625
 	belt 1881
 	haze _menu/haze-67
@@ -542,7 +542,7 @@ system "14 Pole"
 system "14 Summer Above"
 	pos -1436.63 182.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 1400
 	belt 1093
 	haze _menu/haze-67
@@ -608,7 +608,7 @@ system "14 Summer Above"
 system "14 Winter Below"
 	pos -1143.63 341.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 1111.68
 	belt 1173
 	link "8 Winter Below"
@@ -684,7 +684,7 @@ system "14 Winter Below"
 system "16 Autumn Rising"
 	pos -1305.63 74.2137
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 1715
 	belt 1424
 	link "12 Autumn Above"
@@ -754,7 +754,7 @@ system "16 Autumn Rising"
 system "3 Axis"
 	pos -1235.63 299.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 2372.76
 	belt 1202
 	link "1 Axis"
@@ -822,7 +822,7 @@ system "3 Axis"
 system "3 Pole"
 	pos -1344.63 162.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 625
 	belt 1617
 	link "16 Autumn Rising"
@@ -882,7 +882,7 @@ system "3 Pole"
 system "3 Spring Rising"
 	pos -1414.63 356.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 1080
 	belt 1613
 	haze _menu/haze-33
@@ -955,7 +955,7 @@ system "3 Spring Rising"
 system "4 Axis"
 	pos -1169.63 365.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 425.92
 	belt 1838
 	link "14 Winter Below"
@@ -1018,7 +1018,7 @@ system "4 Axis"
 system "4 Spring Rising"
 	pos -1309.63 321.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 320
 	belt 1801
 	link "1 Axis"
@@ -1083,7 +1083,7 @@ system "4 Spring Rising"
 system "4 Summer Rising"
 	pos -1377.63 207.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 320
 	belt 1860
 	link "3 Pole"
@@ -1143,7 +1143,7 @@ system "4 Summer Rising"
 system "4 Winter Rising"
 	pos -1259.63 248.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 135
 	belt 1345
 	link "Sol Kimek"
@@ -1218,7 +1218,7 @@ system "4 Winter Rising"
 system "5 Axis"
 	pos -1142.63 394.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 233.28
 	belt 1775
 	link "4 Axis"
@@ -1291,7 +1291,7 @@ system "5 Axis"
 system "5 Spring Below"
 	pos -1213.63 415.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 1313.28
 	belt 1104
 	link "4 Axis"
@@ -1363,7 +1363,7 @@ system "5 Spring Below"
 system "5 Summer Above"
 	pos -1387.63 118.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 425.92
 	belt 1133
 	haze _menu/haze-133
@@ -1430,7 +1430,7 @@ system "5 Summer Above"
 system "5 Winter Above"
 	pos -1216.63 208.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 320
 	belt 1414
 	link "4 Winter Rising"
@@ -1494,7 +1494,7 @@ system "5 Winter Above"
 system "7 Autumn Rising"
 	pos -1235.63 177.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 425.92
 	belt 1289
 	link "11 Autumn Above"
@@ -1560,7 +1560,7 @@ system "7 Autumn Rising"
 system "8 Winter Below"
 	pos -1179.63 284.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 486.68
 	belt 1285
 	link "3 Axis"
@@ -1625,7 +1625,7 @@ system "8 Winter Below"
 system "9 Spring Above"
 	pos -1377.63 281.214
 	government Coalition
-	attributes "!kimek" "!coalition"
+	attributes "kimek"
 	habitable 1050.92
 	belt 1397
 	haze _menu/haze-67
@@ -1700,7 +1700,7 @@ system "9 Spring Above"
 system Ablodab
 	pos -854.587 592.051
 	government Coalition
-	attributes "!arach" "!coalition"
+	attributes "arachi"
 	habitable 425.92
 	belt 1368
 	link Debrugt
@@ -1775,7 +1775,7 @@ system Ablodab
 system Ablub
 	pos -581.587 637.051
 	government Coalition
-	attributes "!arach" "!coalition"
+	attributes "arachi"
 	habitable 233.28
 	belt 1641
 	haze _menu/haze-133
@@ -1829,7 +1829,7 @@ system Ablub
 system Acamar
 	pos -284 -3
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 1080
 	belt 1013
 	link Diphda
@@ -1888,7 +1888,7 @@ system Acamar
 system Achernar
 	pos -93 154
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 625
 	belt 1963
 	haze _menu/haze-133
@@ -1960,7 +1960,7 @@ system Achernar
 system Acrux
 	pos -808 192
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 590.625
 	belt 1407
 	haze _menu/haze-67
@@ -2040,7 +2040,7 @@ system Acrux
 system Adhara
 	pos -669 -200
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 670
 	belt 1014
 	link "Epsilon Leonis"
@@ -2146,7 +2146,7 @@ system Aescolanus
 system "Aki'il"
 	pos -83 722
 	government Uninhabited
-	attributes "ember waste" "graveyard" "!isolated"
+	attributes "ember waste" "graveyard"
 	habitable 1505.92
 	asteroids "large metal" 47 5
 	asteroids "large rock" 2 10
@@ -2202,7 +2202,7 @@ system "Aki'il"
 system "Al Dhanab"
 	pos -177 207
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 1080
 	belt 1432
 	haze _menu/haze-133
@@ -2272,7 +2272,7 @@ system "Al Dhanab"
 system Albaldah
 	pos -350 484
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 534.375
 	belt 1622
 	haze _menu/haze-133
@@ -2347,7 +2347,7 @@ system Albaldah
 system Albireo
 	pos -270 503
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 760
 	belt 1030
 	link Tarazed
@@ -2405,7 +2405,7 @@ system Albireo
 system Alcyone
 	pos -80 -144
 	government Pirate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 270
 	belt 1438
 	haze _menu/haze-133
@@ -2472,7 +2472,7 @@ system Alcyone
 system Aldebaran
 	pos -356 -26
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 625
 	belt 1296
 	link Capella
@@ -2518,7 +2518,7 @@ system Aldebaran
 system Alderamin
 	pos -272 258
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 1705
 	belt 1908
 	haze _menu/haze-133
@@ -2583,7 +2583,7 @@ system Alderamin
 system Aldhibain
 	pos -659 451
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 455.625
 	belt 1840
 	link Kornephoros
@@ -2641,7 +2641,7 @@ system Aldhibain
 			period 13.622
 
 system Algenib
-	attributes "!human" "!core" "!fringe"
+	attributes "core"
 	pos -118 341
 	government Pirate
 	habitable 455.625
@@ -2698,7 +2698,7 @@ system Algenib
 			period 42.6838
 
 system Algieba
-	attributes "!human" "!deep"
+	attributes "deep"
 	pos -691 -52
 	government Republic
 	habitable 2695
@@ -2770,7 +2770,7 @@ system Algieba
 system Algol
 	pos -210 17
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 534.375
 	belt 1839
 	haze _menu/haze-133
@@ -2832,7 +2832,7 @@ system Algol
 system Algorel
 	pos -631 145
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 320
 	belt 1993
 	haze _menu/haze-67
@@ -2897,7 +2897,7 @@ system Algorel
 system Alheka
 	pos -350 -271
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 1080
 	belt 1380
 	haze _menu/haze-67
@@ -2956,7 +2956,7 @@ system Alheka
 system Alhena
 	pos -430 -80
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 945
 	belt 1078
 	haze _menu/haze-67
@@ -3026,7 +3026,7 @@ system Alhena
 system Alioth
 	pos -620 315
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 455.625
 	belt 1889
 	link Wei
@@ -3079,7 +3079,7 @@ system Alioth
 system Alkaid
 	pos -825 318
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 1080
 	belt 1142
 	haze _menu/haze-67
@@ -3147,7 +3147,7 @@ system Alkaid
 system Almaaz
 	pos -349 -538
 	government Pirate
-	attributes "!human" "!north" "!fringe"
+	attributes "far north"
 	habitable 1080
 	belt 1873
 	haze _menu/haze-33
@@ -3194,7 +3194,7 @@ system Almaaz
 system Almach
 	pos -7 232
 	government Pirate
-	attributes "!human" "!core" "!fringe"
+	attributes "core"
 	habitable 320
 	belt 1914
 	haze _menu/haze-133
@@ -3257,7 +3257,7 @@ system Almach
 system Alnair
 	pos -272 314
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 135
 	belt 1969
 	haze _menu/haze-133
@@ -3326,7 +3326,7 @@ system Alnair
 system Alnasl
 	pos -553 380
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 640
 	belt 1412
 	haze _menu/haze-133
@@ -3389,7 +3389,7 @@ system Alnasl
 system Alnilam
 	pos -487 -513
 	government Pirate
-	attributes "!human" "!north" "!fringe"
+	attributes "far north"
 	habitable 1715
 	belt 1099
 	haze _menu/haze-33
@@ -3467,7 +3467,7 @@ system Alnilam
 system Alnitak
 	pos -331 -412
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 349.375
 	belt 1907
 	haze _menu/haze-67
@@ -3524,7 +3524,7 @@ system Alnitak
 system Alniyat
 	pos -691 501
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 534.375
 	belt 1760
 	link Pherkad
@@ -3597,7 +3597,7 @@ system Alniyat
 system "Alpha Arae"
 	pos -481 394
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 945
 	belt 1405
 	link "Delta Sagittarii"
@@ -3668,7 +3668,7 @@ system "Alpha Arae"
 system "Alpha Centauri"
 	pos -429 125
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 320
 	belt 1116
 	haze _menu/haze-67
@@ -3731,7 +3731,7 @@ system "Alpha Centauri"
 system "Alpha Hydri"
 	pos -97 98
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 1400
 	belt 1839
 	haze _menu/haze-133
@@ -3785,7 +3785,7 @@ system "Alpha Hydri"
 system Alphard
 	pos -588 -47
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 1080.62
 	belt 1101
 	link Algieba
@@ -3852,7 +3852,7 @@ system Alphard
 system Alphecca
 	pos -546 308
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 1400
 	belt 1101
 	link Alioth
@@ -3902,7 +3902,7 @@ system Alphecca
 system Alpheratz
 	pos -176 125
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 1080.62
 	belt 1645
 	haze _menu/haze-133
@@ -3970,7 +3970,7 @@ system Alpheratz
 system Altair
 	pos -357 161
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 945
 	belt 1830
 	link Vega
@@ -4033,7 +4033,7 @@ system Altair
 system Aludra
 	pos -606 -374
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 455.625
 	belt 1511
 	haze _menu/haze-33
@@ -4097,7 +4097,7 @@ system Aludra
 system "Ancient Hope"
 	pos -1159.59 702.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 455
 	belt 1439
 	haze _menu/haze-67
@@ -4167,7 +4167,7 @@ system "Ancient Hope"
 system Ankaa
 	pos -230 100
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 625
 	belt 1003
 	haze _menu/haze-133
@@ -4222,7 +4222,7 @@ system Ankaa
 system Answer
 	pos -1086.59 631.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 425.92
 	belt 1636
 	haze _menu/haze-none
@@ -4287,7 +4287,7 @@ system Answer
 system Antares
 	pos -711 541
 	government Pirate
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 455.625
 	belt 1778
 	haze _menu/haze-67
@@ -4413,7 +4413,7 @@ system Antevorta
 system Ap'arak
 	pos -164.62 -781.858
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 1080
 	belt 1385
 	haze _menu/haze-none
@@ -4469,7 +4469,7 @@ system Ap'arak
 system Arcturus
 	pos -589 226
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 320
 	belt 1422
 	link Mizar
@@ -4604,7 +4604,7 @@ system Arculus
 system Arneb
 	pos -523 -580
 	government Pirate
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 1715
 	belt 1947
 	haze _menu/haze-none
@@ -4653,7 +4653,7 @@ system Arneb
 system Ascella
 	pos -376 328
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 640
 	belt 1971
 	haze _menu/haze-133
@@ -4719,7 +4719,7 @@ system Ascella
 system Asikafarnut
 	pos 253.431 -584.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 320
 	belt 1342
 	link Silikatakfar
@@ -4784,7 +4784,7 @@ system Asikafarnut
 system Aspidiske
 	pos -690 -282
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 135
 	belt 1885
 	link Avior
@@ -4841,7 +4841,7 @@ system Aspidiske
 system Atria
 	pos -551 532
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 214.375
 	belt 1340
 	link Han
@@ -4907,7 +4907,7 @@ system Atria
 system Avior
 	pos -658 -317
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 1215
 	belt 1097
 	link Aspidiske
@@ -4977,7 +4977,7 @@ system Avior
 system Aya'k'k
 	pos -434.245 -616.57
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 486.68
 	belt 1586
 	haze _menu/haze-67
@@ -5037,7 +5037,7 @@ system Aya'k'k
 system Beginning
 	pos -912.587 694.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 425.92
 	belt 1833
 	link Belonging
@@ -5100,7 +5100,7 @@ system Beginning
 system Bellatrix
 	pos -225 -82
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 670
 	belt 1564
 	link Menkar
@@ -5160,7 +5160,7 @@ system Bellatrix
 system Belonging
 	pos -1007.59 658.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 625
 	belt 1407
 	link "Bright Void"
@@ -5220,7 +5220,7 @@ system Belonging
 system Belug
 	pos -1024.59 388.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 486.68
 	belt 1170
 	link Ekuarik
@@ -5290,7 +5290,7 @@ system Belug
 system Belugt
 	pos -838.587 668.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 486.68
 	belt 1517
 	link Gupta
@@ -5365,7 +5365,7 @@ system Belugt
 system "Beta Lupi"
 	pos -851 417
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 625
 	belt 1261
 	haze _menu/haze-33
@@ -5424,7 +5424,7 @@ system "Beta Lupi"
 system Betelgeuse
 	pos -384 -322
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 1080
 	belt 1641
 	haze _menu/haze-67
@@ -5499,7 +5499,7 @@ system Betelgeuse
 system Bloptab
 	pos -813.587 727.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 1080
 	belt 1061
 	link Blugtad
@@ -5560,7 +5560,7 @@ system Bloptab
 system Blubipad
 	pos -650.587 594.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 1080
 	belt 1567
 	haze _menu/haze-133
@@ -5617,7 +5617,7 @@ system Blubipad
 system Blugtad
 	pos -771.587 680.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 625
 	belt 1841
 	haze _menu/haze-133
@@ -5690,7 +5690,7 @@ system Blugtad
 system Boral
 	pos -502 331
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "dirt belt"
 	habitable 214.375
 	belt 1867
 	link Alphecca
@@ -5906,7 +5906,7 @@ system "Bote Asu"
 system "Bright Void"
 	pos -1059.59 605.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 2795
 	belt 1385
 	haze _menu/haze-67
@@ -5987,7 +5987,7 @@ system "Bright Void"
 system "Broken Bowl"
 	pos -956.587 566.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 1080
 	belt 1648
 	haze _menu/haze-67
@@ -6115,7 +6115,7 @@ system Caeculus
 system Canopus
 	pos -421 -225
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 214.375
 	belt 1530
 	haze _menu/haze-67
@@ -6162,7 +6162,7 @@ system Canopus
 system Capella
 	pos -378 -13
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 455.625
 	belt 1722
 	haze _menu/haze-67
@@ -6233,7 +6233,7 @@ system Capella
 system Caph
 	pos -295 77
 	government Syndicate
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 670
 	belt 1173
 	link Sol
@@ -6297,7 +6297,7 @@ system Caph
 system Cardax
 	pos -211 -215
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 1705
 	belt 1228
 	link Moktar
@@ -6425,7 +6425,7 @@ system Cardea
 system Castor
 	pos -452 -17
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 1715
 	belt 1675
 	haze _menu/haze-67
@@ -6510,7 +6510,7 @@ system Castor
 system Cebalrai
 	pos -461 282
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 625
 	belt 1955
 	link Rutilicus
@@ -6571,7 +6571,7 @@ system Cebalrai
 system Celeborim
 	pos 181.431 -633.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata" "!fringe"
+	attributes "korath"
 	habitable 320
 	belt 1296
 	link Asikafarnut
@@ -6630,7 +6630,7 @@ system Celeborim
 system Chikatip
 	pos -77.5695 -307.812
 	government Uninhabited
-	attributes "!korath" "!fringe"
+	attributes "korath"
 	habitable 425.92
 	belt 1929
 	link Furmeliki
@@ -6686,7 +6686,7 @@ system Chikatip
 system Chimitarp
 	pos 150.431 -287.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 912.6
 	belt 1932
 	haze _menu/haze-133
@@ -6759,7 +6759,7 @@ system Chimitarp
 system Chirr'ay'akai
 	pos -102.761 -749.614
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 486.68
 	belt 1425
 	haze _menu/haze-33
@@ -6809,7 +6809,7 @@ system Chirr'ay'akai
 system Chornifath
 	pos 40.4305 -214.812
 	government Uninhabited
-	attributes "!korath" "!fringe"
+	attributes "korath"
 	habitable 486.68
 	belt 1434
 	haze _menu/haze-133
@@ -6870,7 +6870,7 @@ system Chornifath
 system Chy'chra
 	pos 85.5308 -829.667
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 625
 	belt 1120
 	haze _menu/haze-33
@@ -7169,7 +7169,7 @@ system Convector
 system "Cor Caroli"
 	pos -682 201
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 1080
 	belt 1474
 	link Vindemiatrix
@@ -7228,7 +7228,7 @@ system "Cor Caroli"
 system "Da Ent"
 	pos -6.22391 -462.536
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 233.28
 	belt 1161
 	link "Ya Hai"
@@ -7289,7 +7289,7 @@ system "Da Ent"
 system "Da Lest"
 	pos -23.2239 -413.536
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 320
 	belt 1108
 	link "Lom Tahr"
@@ -7344,7 +7344,7 @@ system "Da Lest"
 system Dabih
 	pos -253 427
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 670
 	belt 1088
 	haze _menu/haze-133
@@ -7404,7 +7404,7 @@ system Dabih
 system Danoa
 	pos -239 -321
 	government Republic
-	attributes "!human" "!north" "!fringe"
+	attributes "far north"
 	habitable 135
 	belt 1689
 	haze _menu/haze-67
@@ -7473,7 +7473,7 @@ system Danoa
 system "Dark Hills"
 	pos -926.587 619.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 1080
 	belt 1367
 	link Beginning
@@ -7540,7 +7540,7 @@ system "Dark Hills"
 system Debrugt
 	pos -869.587 513.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 640
 	belt 1224
 	link Torbab
@@ -7689,7 +7689,7 @@ system Delia
 system "Delta Capricorni"
 	pos -285 202
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 839.375
 	belt 1329
 	haze _menu/haze-133
@@ -7752,7 +7752,7 @@ system "Delta Capricorni"
 system "Delta Sagittarii"
 	pos -414 416
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 320
 	belt 1414
 	haze _menu/haze-133
@@ -7819,7 +7819,7 @@ system "Delta Sagittarii"
 system "Delta Velorum"
 	pos -740 90
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 1080
 	belt 1221
 	haze _menu/haze-67
@@ -7878,7 +7878,6 @@ system "Delta Velorum"
 system Deneb
 	pos -348 225
 	government Pug
-	attributes "!human" "!isolated"
 	habitable 625
 	belt 1890
 	haze _menu/haze-133
@@ -7934,7 +7933,7 @@ system Deneb
 system Denebola
 	pos -478 70
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 534.375
 	belt 1050
 	haze _menu/haze-67
@@ -8005,7 +8004,7 @@ system Diespiter
 	asteroids "small metal" 74 2
 	asteroids "small rock" 65 3
 	government Uninhabited
-	attributes "!ember waste"
+	attributes "ember waste"
 	haze _menu/haze-red
 	link Statina
 	minables iron 22 3
@@ -8035,7 +8034,7 @@ system Diespiter
 system Diphda
 	pos -262 61
 	government Syndicate
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 590.625
 	belt 1559
 	haze _menu/haze-133
@@ -8168,7 +8167,7 @@ system Dixere
 system Dokdobaru
 	pos -21.5695 -241.812
 	government Quarg
-	attributes "!korath" "!efreti" "!ringworld"
+	attributes "korath" "ringworld"
 	habitable 700
 	belt 1935
 	haze _menu/haze-133
@@ -8273,7 +8272,7 @@ system Dokdobaru
 system Dschubba
 	pos -598 501
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 398.125
 	belt 1429
 	link Atria
@@ -8347,7 +8346,7 @@ system Dschubba
 system Dubhe
 	pos -577 -103
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 349.375
 	belt 1120
 	link Zosma
@@ -8404,7 +8403,7 @@ system Dubhe
 system "Due Yoot"
 	pos -167.547 -426.683
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 233.28
 	belt 1854
 	link "Wah Oh"
@@ -8469,7 +8468,7 @@ system "Due Yoot"
 system Durax
 	pos -59 -90
 	government Pirate
-	attributes "!human" "!core" "!fringe"
+	attributes "core"
 	habitable 1080
 	belt 1287
 	haze _menu/haze-133
@@ -8534,7 +8533,7 @@ system Durax
 system Eber
 	pos -532 406
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 320
 	belt 1199
 	link Alnasl
@@ -8598,7 +8597,7 @@ system Eber
 system Eblumab
 	pos -767.587 703.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 425.92
 	belt 1804
 	haze _menu/haze-133
@@ -8719,7 +8718,7 @@ system Egeria
 	asteroids "medium rock" 20 5
 	asteroids "small rock" 1 8
 	government Uninhabited
-	attributes "!ember waste"
+	attributes "ember waste"
 	haze _menu/haze-red
 	link Vaticanus
 	link Statina
@@ -8751,7 +8750,7 @@ system Egeria
 system "Ehma Ti"
 	pos 39.1085 -749.244
 	government "Hai (Unfettered)"
-	attributes "!hai"
+	attributes "hai"
 	habitable 486.68
 	belt 1094
 	link "Wah Yoot"
@@ -8819,7 +8818,7 @@ system "Ehma Ti"
 system Ek'kek'ru
 	pos -287.517 -727.738
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 320
 	belt 1517
 	haze _menu/haze-none
@@ -8879,7 +8878,7 @@ system Ek'kek'ru
 system Ekuarik
 	pos -1029.63 426.214
 	government Heliarch
-	attributes "!coalition"
+	attributes
 	habitable 700
 	belt 1711
 	link "Ki War Ek"
@@ -9062,7 +9061,7 @@ system Ekuarik
 system Elnath
 	pos -288 -77
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 1715
 	belt 1462
 	link Acamar
@@ -9127,7 +9126,7 @@ system Elnath
 system Eltanin
 	pos -328 433
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 455.625
 	belt 1859
 	haze _menu/haze-133
@@ -9187,7 +9186,7 @@ system Eltanin
 system Eneremprukt
 	pos 311.431 -448.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 486.68
 	belt 1421
 	link Silikatakfar
@@ -9243,7 +9242,7 @@ system Eneremprukt
 system Enif
 	pos -177 498
 	government Quarg
-	attributes "!human" "!south" "!ringworld"
+	attributes "south" "ringworld"
 	habitable 700
 	belt 1974
 	link Sadalmelik
@@ -9332,7 +9331,7 @@ system Enif
 system "Epsilon Leonis"
 	pos -619 -229
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 1400
 	belt 1527
 	link Gomeisa
@@ -9407,7 +9406,7 @@ system "Epsilon Leonis"
 system Es'sprak'ai
 	pos -469.044 -733.375
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 486.68
 	belt 1928
 	haze _menu/haze-none
@@ -9468,7 +9467,7 @@ system Es'sprak'ai
 system Eshkoshtar
 	pos 156.431 -381.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 806.68
 	belt 1105
 	link Mekislepti
@@ -9602,7 +9601,7 @@ system Esix
 system Eteron
 	pos -330 33
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 135
 	belt 1479
 	link Sirius
@@ -9667,7 +9666,7 @@ system Eteron
 system "Fah Root"
 	pos -264.065 -400.135
 	government Hai
-	attributes "!hai" "!fringe"
+	attributes "hai"
 	habitable 486.68
 	belt 1057
 	haze _menu/haze-67
@@ -9736,7 +9735,7 @@ system "Fah Root"
 system "Fah Soom"
 	pos -179.891 -335.011
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 425.92
 	belt 1185
 	haze _menu/haze-67
@@ -9797,7 +9796,7 @@ system "Fah Soom"
 system Fala
 	pos -690 64
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 625
 	belt 1264
 	link "Tania Australis"
@@ -9858,7 +9857,7 @@ system Fala
 system "Fallen Leaf"
 	pos -903.587 717.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 320
 	belt 1327
 	link Beginning
@@ -9911,7 +9910,7 @@ system "Fallen Leaf"
 system "Far Horizon"
 	pos -1108.59 726.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 320
 	belt 1242
 	haze _menu/haze-67
@@ -9967,7 +9966,7 @@ system "Far Horizon"
 system Farbutero
 	pos 93.4305 -251.812
 	government Uninhabited
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 625
 	belt 1175
 	haze _menu/haze-133
@@ -10113,7 +10112,7 @@ system Farinus
 system Faronektu
 	pos 292.431 -309.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 1080
 	belt 1630
 	haze _menu/haze-133
@@ -10181,7 +10180,7 @@ system Faronektu
 system Fasitopfar
 	pos 92.4305 -105.812
 	government Uninhabited
-	attributes "archon" "!korath" "!isolated" "!nova"
+	attributes "archon" "korath" "nova"
 	habitable 100
 	belt 1670
 	haze _menu/haze-blackbody
@@ -10289,7 +10288,7 @@ system Fearis
 system "Fell Omen"
 	pos -1156.59 475.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 425.92
 	belt 1240
 	link "Last Word"
@@ -10480,7 +10479,7 @@ system Fereti
 system Feroteri
 	pos 149.431 -205.812
 	government Uninhabited
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 5425.92
 	belt 1419
 	haze _menu/haze-blackbody
@@ -10564,7 +10563,7 @@ system Feroteri
 system Ferukistek
 	pos 307.431 -515.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 486.68
 	belt 1520
 	link Eneremprukt
@@ -10618,7 +10617,7 @@ system Ferukistek
 system Fingol
 	pos -482 113
 	government Republic
-	attributes "!human" "!near earth" "!fringe"
+	attributes "near earth"
 	habitable 135
 	belt 1976
 	haze _menu/haze-none
@@ -10676,7 +10675,7 @@ system Fingol
 system Flugbu
 	pos -903.587 534.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 425.92
 	belt 1843
 	link Torbab
@@ -10741,7 +10740,7 @@ system Flugbu
 system Fomalhaut
 	pos -314 124
 	government Syndicate
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 455.625
 	belt 1854
 	link Altair
@@ -10804,7 +10803,7 @@ system Fomalhaut
 system Fornarep
 	pos 79.4305 -309.812
 	government Uninhabited
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 320
 	belt 1922
 	haze _menu/haze-133
@@ -10871,7 +10870,7 @@ system Fornarep
 system "Four Pillars"
 	pos -1210.59 772.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 486.68
 	belt 1061
 	link "Far Horizon"
@@ -10933,7 +10932,7 @@ system "Four Pillars"
 system Furmeliki
 	pos -35.5695 -281.812
 	government Uninhabited
-	attributes "!korath" "!efreti"
+	attributes "korath"
 	habitable 486.68
 	belt 1577
 	link Dokdobaru
@@ -10995,7 +10994,7 @@ system Furmeliki
 system Gacrux
 	pos -713 184
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 534.375
 	belt 1188
 	link "Cor Caroli"
@@ -11063,7 +11062,7 @@ system Gacrux
 system "Gamma Cassiopeiae"
 	pos -116 293
 	government Syndicate
-	attributes "!human" "!core" "!fringe"
+	attributes "core"
 	habitable 455.625
 	belt 1779
 	haze _menu/haze-133
@@ -11122,7 +11121,7 @@ system "Gamma Cassiopeiae"
 system "Gamma Corvi"
 	pos -906 64
 	government Republic
-	attributes "!coalition" "!rim"
+	attributes "rim"
 	habitable 1535.62
 	belt 1556
 	haze _menu/haze-none
@@ -11245,7 +11244,7 @@ system Gerenus
 system Gienah
 	pos -176 354
 	government Pirate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 534.375
 	belt 1939
 	link Persian
@@ -11380,7 +11379,7 @@ system Giribea
 system Girtab
 	pos -430 481
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 1080
 	belt 1387
 	link Lesath
@@ -11445,7 +11444,7 @@ system Girtab
 system Glubatub
 	pos -650.587 693.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 233.28
 	belt 1093
 	link "Sol Arach"
@@ -11523,7 +11522,7 @@ system Glubatub
 system Gomeisa
 	pos -600 -161
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 911.25
 	belt 1616
 	link Zosma
@@ -11593,7 +11592,7 @@ system Gomeisa
 system "Good Omen"
 	pos -941.587 746.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 1715
 	belt 1598
 	haze _menu/haze-67
@@ -11655,7 +11654,7 @@ system "Good Omen"
 system Gorvi
 	pos -250 -483
 	government Republic
-	attributes "!human" "!north" "!fringe"
+	attributes "far north"
 	habitable 670
 	belt 1345
 	haze _menu/haze-133
@@ -11713,7 +11712,7 @@ system Gorvi
 system Graffias
 	pos -784 517
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 911.25
 	belt 1977
 	link Alniyat
@@ -11777,7 +11776,7 @@ system Graffias
 system Gupta
 	pos -808.587 625.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 912.6
 	belt 1771
 	link Ablodab
@@ -11838,7 +11837,7 @@ system Gupta
 system Hadar
 	pos -788 283
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 455.625
 	belt 1520
 	link "Zeta Centauri"
@@ -11898,7 +11897,7 @@ system Hadar
 system Hamal
 	pos -129 24
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 1080
 	belt 1241
 	haze _menu/haze-133
@@ -11953,7 +11952,7 @@ system Hamal
 system Han
 	pos -610 561
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 1080.62
 	belt 1517
 	link Alniyat
@@ -12012,7 +12011,7 @@ system Han
 system Hassaleh
 	pos -291 -287
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 670
 	belt 1924
 	haze _menu/haze-67
@@ -12073,7 +12072,7 @@ system Hassaleh
 system Hatysa
 	pos -474 -542
 	government Pirate
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 533.75
 	belt 1163
 	haze _menu/haze-33
@@ -12134,7 +12133,7 @@ system Hatysa
 system "Heia Due"
 	pos -146.177 -481.694
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 1215
 	belt 1079
 	haze _menu/haze-67
@@ -12206,7 +12205,7 @@ system "Heia Due"
 system Hesselpost
 	pos -30.5695 -187.812
 	government Uninhabited
-	attributes "!korath" "!efreti" "!fringe"
+	attributes "korath"
 	habitable 486.68
 	belt 1327
 	haze _menu/haze-133
@@ -12277,7 +12276,7 @@ system Hesselpost
 system "Hevru Hai"
 	pos -189 -310
 	government Quarg
-	attributes "!hai" "!ringworld"
+	attributes "hai" "ringworld"
 	habitable 700
 	belt 1245
 	link "Fah Soom"
@@ -12392,7 +12391,7 @@ system "Hevru Hai"
 system "Hi Yahr"
 	pos 82.3672 -641.6
 	government "Hai (Unfettered)"
-	attributes "!hai"
+	attributes "hai"
 	habitable 625
 	belt 1655
 	link "Wah Yoot"
@@ -12450,7 +12449,7 @@ system "Hi Yahr"
 system Hintar
 	pos -422 311
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "dirt belt"
 	habitable 625
 	belt 1725
 	haze _menu/haze-133
@@ -12510,7 +12509,7 @@ system Hintar
 system Holeb
 	pos -590 287
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 1715
 	belt 1181
 	link Alioth
@@ -12558,7 +12557,7 @@ system Holeb
 system Homeward
 	pos -1045.59 477.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 425.92
 	belt 1499
 	link "Silver Bell"
@@ -12624,7 +12623,6 @@ system Homeward
 system Host
 	pos 384.431 -543.812
 	government Uninhabited
-	attributes "!isolated"
 	habitable 486.68
 	belt 1669
 	asteroids "large metal" 1 0.732
@@ -12673,7 +12671,7 @@ system Host
 system Hunter
 	pos -968.587 590.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 425.92
 	belt 1498
 	link "Bright Void"
@@ -12735,7 +12733,7 @@ system Hunter
 system Ik'kara'ka
 	pos 56.2159 -888.296
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 625
 	belt 1497
 	haze _menu/haze-none
@@ -12797,7 +12795,7 @@ system Ik'kara'ka
 system Ildaria
 	pos -702 317
 	government Republic
-	attributes "!human" "!rim" "!wolf-rayet" "!fringe"
+	attributes "rim" "wolf-rayet"
 	habitable 625
 	belt 1132
 	haze _menu/haze-133
@@ -12851,7 +12849,7 @@ system Ildaria
 system "Imo Dep"
 	pos -56.2764 -600.1
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 1715
 	belt 1416
 	haze _menu/haze-67
@@ -12976,7 +12974,7 @@ system Insitor
 system "Io Lowe"
 	pos -94.7566 -527.728
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 135
 	belt 1552
 	haze _menu/haze-67
@@ -13038,7 +13036,7 @@ system "Io Lowe"
 system "Io Mann"
 	pos -192.955 -447.669
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 973.36
 	belt 1132
 	haze _menu/haze-67
@@ -13113,7 +13111,7 @@ system "Io Mann"
 system Ipsing
 	pos -549 160
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "dirt belt"
 	habitable 1400
 	belt 1107
 	haze _menu/haze-67
@@ -13180,7 +13178,7 @@ system Ipsing
 system Iyech'yek
 	pos -277.37 -693.913
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 320
 	belt 1613
 	haze _menu/haze-33
@@ -13234,7 +13232,7 @@ system Iyech'yek
 system Izar
 	pos -784 231
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 1294.38
 	belt 1449
 	haze _menu/haze-67
@@ -13299,7 +13297,7 @@ system Izar
 system Ka'ch'chrai
 	pos -240.163 -822.448
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 425.92
 	belt 1745
 	haze _menu/haze-none
@@ -13357,7 +13355,7 @@ system Ka'ch'chrai
 system Ka'pru
 	pos -76.6756 -994.955
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 1505.92
 	belt 1808
 	haze _menu/haze-33
@@ -13428,7 +13426,7 @@ system Ka'pru
 system Kaliptari
 	pos 85.4305 -402.812
 	government Uninhabited
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 320
 	belt 1089
 	link Skeruto
@@ -13503,7 +13501,7 @@ system Kaliptari
 system "Kappa Centauri"
 	pos -867 480
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 1215
 	belt 1508
 	link Pherkad
@@ -13564,7 +13562,7 @@ system "Kappa Centauri"
 system Kashikt
 	pos -73.5695 -219.812
 	government "Kor Efret"
-	attributes "!korath" "!efreti"
+	attributes "korath"
 	habitable 1715
 	belt 1013
 	link Dokdobaru
@@ -13632,7 +13630,7 @@ system Kashikt
 system Kasikfar
 	pos 10.4305 -127.812
 	government Uninhabited
-	attributes "archon" "!isolated" "!korath" "!nova"
+	attributes "archon" "korath" "nova"
 	habitable 100
 	belt 1539
 	haze _menu/haze-blackbody
@@ -13673,7 +13671,7 @@ system Kasikfar
 system "Kaus Australis"
 	pos -284 395
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 320
 	belt 1281
 	haze _menu/haze-133
@@ -13725,7 +13723,7 @@ system "Kaus Australis"
 system "Kaus Borealis"
 	pos -456 350
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 590.625
 	belt 1074
 	haze _menu/haze-133
@@ -13788,7 +13786,7 @@ system "Kaus Borealis"
 system "Ki War Ek"
 	pos -1106.63 368.214
 	government Heliarch
-	attributes "!coalition" "!ringworld"
+	attributes "ringworld"
 	habitable 700
 	belt 1777
 	haze _menu/haze-133
@@ -14007,7 +14005,7 @@ system "Ki War Ek"
 system Kiro'ku
 	pos -131.923 -884.46
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 1111.68
 	belt 1308
 	haze _menu/haze-none
@@ -14084,7 +14082,7 @@ system Kiro'ku
 system Kiru'kichi
 	pos -195.063 -662.343
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 2795
 	belt 1465
 	haze _menu/haze-33
@@ -14144,7 +14142,7 @@ system Kiru'kichi
 system Kochab
 	pos -731 279
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 320
 	belt 1912
 	haze _menu/haze-67
@@ -14188,7 +14186,7 @@ system Kochab
 system "Kor Ak'Mari"
 	pos 43 42
 	government Korath
-	attributes "!korath" "!exiles" "!isolated" "!wolf-rayet"
+	attributes "korath" "wolf-rayet"
 	habitable 625
 	belt 1606
 	haze _menu/haze-full
@@ -14239,7 +14237,7 @@ system "Kor Ak'Mari"
 system "Kor En'lakfar"
 	pos -31 -33
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath"
 	habitable 1080
 	belt 1115
 	haze _menu/haze-133
@@ -14301,7 +14299,7 @@ system "Kor En'lakfar"
 system "Kor Fel'tar"
 	pos 29 -66
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath"
 	habitable 455.625
 	belt 1444
 	haze _menu/haze-blackbody
@@ -14367,7 +14365,7 @@ system "Kor Fel'tar"
 system "Kor Men"
 	pos 6 -5
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath"
 	habitable 2340
 	belt 1260
 	haze _menu/haze-blackbody
@@ -14430,7 +14428,7 @@ system "Kor Men"
 system "Kor Nor'peli"
 	pos 52 160
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath"
 	habitable 590.625
 	belt 1213
 	haze _menu/haze-blackbody
@@ -14495,7 +14493,7 @@ system "Kor Nor'peli"
 system "Kor Tar'bei"
 	pos 57 106
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath"
 	habitable 214.375
 	belt 1614
 	haze _menu/haze-blackbody
@@ -14552,7 +14550,7 @@ system "Kor Tar'bei"
 system "Kor Zena'i"
 	pos -2 83
 	government Korath
-	attributes "!korath" "!exiles"
+	attributes "korath"
 	habitable 703.125
 	belt 1866
 	haze _menu/haze-blackbody
@@ -14605,7 +14603,7 @@ system "Kor Zena'i"
 system Kornephoros
 	pos -612 424
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 911.25
 	belt 1168
 	link Sabik
@@ -14686,7 +14684,7 @@ system Kornephoros
 system Korsmanath
 	pos 97.4305 -185.812
 	government Uninhabited
-	attributes "!korath" "!automata" "!fringe"
+	attributes "korath"
 	habitable 486.68
 	belt 1775
 	link Feroteri
@@ -14746,7 +14744,7 @@ system Korsmanath
 system Kraz
 	pos -876 204
 	government Republic
-	attributes "!human" "!rim" 
+	attributes "rim" 
 	habitable 1080
 	belt 1056
 	haze _menu/haze-67
@@ -14813,7 +14811,7 @@ system Kraz
 system Kugel
 	pos -230 -26
 	government Syndicate
-	attributes "!human" "!core" "!fringe"
+	attributes "core"
 	habitable 625
 	belt 1051
 	link Acamar
@@ -14882,7 +14880,7 @@ system Kugel
 system Kursa
 	pos -366 -105
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 455
 	belt 1624
 	haze _menu/haze-67
@@ -14999,7 +14997,7 @@ system "Last Word"
 system Lesath
 	pos -516 485
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 1715
 	belt 1865
 	link Atria
@@ -15132,7 +15130,7 @@ system Levana
 system Limen
 	pos -791.99 -12.2491
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "dirt belt"
 	habitable 1715
 	belt 1463
 	haze _menu/haze-33
@@ -15246,7 +15244,7 @@ system Lire
 system Lolami
 	pos -628 -10
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "dirt belt"
 	habitable 1215
 	belt 1072
 	link "Tania Australis"
@@ -15310,7 +15308,7 @@ system Lolami
 system "Lom Tahr"
 	pos -94.0437 -446.586
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 2372.76
 	belt 1445
 	link "Ya Hai"
@@ -15386,7 +15384,7 @@ system "Lom Tahr"
 system "Lone Cloud"
 	pos -1239.59 747.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 233.28
 	belt 1730
 	link "Four Pillars"
@@ -15437,7 +15435,7 @@ system "Lone Cloud"
 system Lucina
 	pos 175.504 176.389
 	government Uninhabited
-	attributes "ember waste" "!fringe"
+	attributes "ember waste"
 	habitable 320
 	belt 1466
 	haze _menu/haze-red
@@ -15493,7 +15491,7 @@ system Lucina
 system Lurata
 	pos -279 463
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 455.625
 	belt 1151
 	haze _menu/haze-133
@@ -15556,7 +15554,7 @@ system Lurata
 system Makferuti
 	pos 288.431 -628.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 621.68
 	belt 1782
 	link Asikafarnut
@@ -15632,7 +15630,7 @@ system Makferuti
 system Markab
 	pos -241 168
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 625
 	belt 1411
 	haze _menu/haze-133
@@ -15715,7 +15713,7 @@ system Markab
 system Markeb
 	pos -602 -305
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 455.625
 	belt 1556
 	haze _menu/haze-33
@@ -15780,7 +15778,7 @@ system Markeb
 system Matar
 	pos -218 272
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 455.625
 	belt 1308
 	haze _menu/haze-133
@@ -15838,7 +15836,7 @@ system Matar
 system Mebla
 	pos -814.587 555.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 486.68
 	belt 1114
 	link Debrugt
@@ -15896,7 +15894,7 @@ system Mebla
 system Mebsuta
 	pos -482 -394
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 670
 	belt 1740
 	haze _menu/haze-33
@@ -15972,7 +15970,7 @@ system Mebsuta
 system Meftarkata
 	pos 52.4305 -276.812
 	government Uninhabited
-	attributes "!korath"
+	attributes "korath"
 	habitable 2201.68
 	belt 1232
 	haze _menu/haze-133
@@ -16034,7 +16032,7 @@ system Meftarkata
 system "Mei Yohn"
 	pos -106.757 -581.698
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 425.92
 	belt 1075
 	haze _menu/haze-67
@@ -16100,7 +16098,7 @@ system "Mei Yohn"
 system Mekislepti
 	pos 137.431 -335.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 1705
 	belt 1673
 	haze _menu/haze-133
@@ -16164,7 +16162,7 @@ system Mekislepti
 system Meblumem
 	pos -722.587 616.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 2201.68
 	belt 1794
 	link "Sol Arach"
@@ -16229,7 +16227,7 @@ system Meblumem
 system Men
 	pos -888 361
 	government Pirate
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 320
 	belt 1531
 	haze _menu/haze-33
@@ -16295,7 +16293,7 @@ system Men
 system Menkalinan
 	pos -400 -61
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 3430
 	belt 1424
 	haze _menu/haze-67
@@ -16363,7 +16361,7 @@ system Menkalinan
 system Menkar
 	pos -183 -52
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 455.625
 	belt 1634
 	haze _menu/haze-133
@@ -16426,7 +16424,7 @@ system Menkar
 system Menkent
 	pos -495 218
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 2340
 	belt 1728
 	link Vega
@@ -16497,7 +16495,7 @@ system Menkent
 system Merak
 	pos -553 60
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 1080.62
 	belt 1769
 	haze _menu/haze-67
@@ -16562,7 +16560,7 @@ system Merak
 system Mesuket
 	pos 220.431 -409.812
 	government Uninhabited
-	attributes "!korath" "!automata" "!warzone"
+	attributes "korath"
 	habitable 425.92
 	belt 1189
 	link Eshkoshtar
@@ -16629,7 +16627,7 @@ system Mesuket
 system Miaplacidus
 	pos -524 -69
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 455.625
 	belt 1236
 	link Tejat
@@ -16704,7 +16702,7 @@ system Miaplacidus
 system Miblulub
 	pos -630.587 670.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 1080
 	belt 1757
 	haze _menu/haze-133
@@ -16786,7 +16784,7 @@ system Miblulub
 system Mimosa
 	pos -895 168
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 320
 	belt 1484
 	haze _menu/haze-67
@@ -16837,7 +16835,7 @@ system Mimosa
 system Minkar
 	pos -823 138
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 670
 	belt 1354
 	haze _menu/haze-67
@@ -16903,7 +16901,7 @@ system Minkar
 system Mintaka
 	pos -304 -462
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 775.625
 	belt 1753
 	haze _menu/haze-67
@@ -16967,7 +16965,7 @@ system Mintaka
 system Mirach
 	pos -166 250
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 292.5
 	belt 1980
 	haze _menu/haze-133
@@ -17036,7 +17034,7 @@ system Mirach
 system Mirfak
 	pos -187 -128
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 320
 	belt 1887
 	link Menkar
@@ -17092,7 +17090,7 @@ system Mirfak
 system Mirzam
 	pos -498 -301
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 1080
 	belt 1025
 	haze _menu/haze-67
@@ -17154,7 +17152,7 @@ system Mirzam
 system Mizar
 	pos -579 184
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 1080
 	belt 1876
 	haze _menu/haze-67
@@ -17207,7 +17205,7 @@ system Mizar
 system Moktar
 	pos -169 -170
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 455
 	belt 1888
 	link Oblate
@@ -17275,7 +17273,7 @@ system Moktar
 system Mora
 	pos -755 23
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 320
 	belt 1176
 	haze _menu/haze-67
@@ -17336,7 +17334,7 @@ system Mora
 system Muhlifain
 	pos -702 242
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 455.625
 	belt 1265
 	haze _menu/haze-67
@@ -17383,7 +17381,7 @@ system Muhlifain
 system Muphrid
 	pos -495 152
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 839.375
 	belt 1759
 	link Menkent
@@ -17441,7 +17439,7 @@ system Muphrid
 system Naos
 	pos -653 -396
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 625
 	belt 1045
 	haze _menu/haze-67
@@ -17515,7 +17513,7 @@ system Naos
 system Naper
 	pos -416 369
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 1715
 	belt 1445
 	link Ascella
@@ -17654,7 +17652,7 @@ system Nenia
 system Nihal
 	pos -262 -121
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 534.375
 	belt 1329
 	link Elnath
@@ -17727,7 +17725,7 @@ system Nihal
 system Nocte
 	pos -467 172
 	government Republic
-	attributes "!human" "!near earth" "!fringe"
+	attributes "near earth"
 	habitable 135
 	belt 1304
 	link Vega
@@ -17846,7 +17844,7 @@ system Nona
 system Nunki
 	pos -393 537
 	government Pirate
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 214.375
 	belt 1930
 	link Albaldah
@@ -17916,7 +17914,7 @@ system Nunki
 system Oblate
 	pos -124 -119
 	government Pirate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 12000
 	belt 1704
 	haze _menu/haze-133
@@ -17975,7 +17973,7 @@ system Oblate
 system Orbona
 	pos -735.99 -97.2491
 	government Republic
-	attributes "!human" "!dirt belt" "!fringe"
+	attributes "dirt belt"
 	habitable 2859.44
 	belt 1507
 	haze _menu/haze-67
@@ -18047,7 +18045,7 @@ system Orbona
 system Orvala
 	pos -334 303
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 533.75
 	belt 1431
 	link "Zeta Aquilae"
@@ -18404,7 +18402,7 @@ system Parca
 system Peacock
 	pos -307 350
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 214.375
 	belt 1870
 	haze _menu/haze-133
@@ -18479,7 +18477,7 @@ system Peacock
 system Pelubta
 	pos -757.587 575.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 9265
 	belt 1709
 	link Meblumem
@@ -18621,7 +18619,7 @@ system Peragenor
 system Peresedersi
 	pos 81.4305 -154.812
 	government Uninhabited
-	attributes "archon" "!korath" "!isolated" "!nova"
+	attributes "archon" "korath" "nova"
 	habitable 100
 	belt 1065
 	haze _menu/haze-blackbody
@@ -18716,7 +18714,7 @@ system Perfica
 system Persian
 	pos -203 331
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 2170.62
 	belt 1308
 	haze _menu/haze-133
@@ -18784,7 +18782,7 @@ system Persian
 system Persitar
 	pos 297.431 -395.812
 	government Uninhabited
-	attributes "!korath" "!isolated" "!nova"
+	attributes "korath" "nova"
 	habitable 100
 	belt 1948
 	haze _menu/haze-blackbody
@@ -18821,7 +18819,7 @@ system Persitar
 system Phact
 	pos -375 -191
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 1080.62
 	belt 1704
 	haze _menu/haze-67
@@ -18894,7 +18892,7 @@ system Phact
 system Phecda
 	pos -607 88
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 320
 	belt 1375
 	link Algorel
@@ -18952,7 +18950,7 @@ system Phecda
 system Pherkad
 	pos -798 451
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 135
 	belt 1924
 	haze _menu/haze-67
@@ -19008,7 +19006,7 @@ system Pherkad
 system Phurad
 	pos -494 -153
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 1080
 	belt 1881
 	link Tejat
@@ -19068,7 +19066,7 @@ system Phurad
 system Pik'ro'iyak
 	pos -378.845 -677.001
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 233.28
 	belt 1279
 	haze _menu/haze-none
@@ -19117,7 +19115,7 @@ system Pik'ro'iyak
 system Plort
 	pos -708.587 723.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 320
 	belt 1490
 	link "Sol Arach"
@@ -19295,7 +19293,7 @@ system Polerius
 system Pollux
 	pos -465 4
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 1080
 	belt 1161
 	haze _menu/haze-67
@@ -19350,7 +19348,7 @@ system Pollux
 system Porrima
 	pos -556 123
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 760
 	belt 1636
 	haze _menu/haze-67
@@ -19418,7 +19416,7 @@ system Porrima
 system Postverta
 	pos 15000 15000
 	government Uninhabited
-	attributes "!ember waste"
+	attributes "ember waste"
 	haze _menu/haze-red
 	asteroids "large metal" 9 3
 	asteroids "large rock" 4 3
@@ -19451,7 +19449,7 @@ system Postverta
 system Prakacha'a
 	pos -35.1114 -802.607
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 1505.92
 	belt 1637
 	haze _menu/haze-33
@@ -19530,7 +19528,7 @@ system Prakacha'a
 system Procyon
 	pos -411 23
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 455.625
 	belt 1763
 	haze _menu/haze-67
@@ -19592,7 +19590,7 @@ system Prosa
 	asteroids "medium rock" 16 1
 	asteroids "small rock" 4 1
 	government Uninhabited
-	attributes "!ember waste"
+	attributes "ember waste"
 	haze _menu/haze-red
 	link Vaticanus
 	minables copper 5 2
@@ -19629,7 +19627,6 @@ system Prosa
 system "Pug Iyik"
 	pos -361.149 -883.233
 	government "Pug (Wanderer)"
-	attributes "!wanderer" "!isolated"
 	habitable 625
 	belt 1286
 	haze _menu/haze-blackbody
@@ -19687,7 +19684,7 @@ system "Pug Iyik"
 system Quaru
 	pos -1080.63 448.214
 	government Heliarch
-	attributes "!coalition" "!ringworld"
+	attributes "ringworld"
 	habitable 700
 	belt 1440
 	haze _menu/haze-133
@@ -20003,7 +20000,7 @@ system Queri
 system Rajak
 	pos -270 -236
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 78.125
 	belt 1410
 	haze _menu/haze-67
@@ -20071,7 +20068,7 @@ system Rajak
 system Rasalhague
 	pos -413 246
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 455.625
 	belt 1282
 	haze _menu/haze-133
@@ -20132,7 +20129,7 @@ system Rasalhague
 system Rastaban
 	pos -463 446
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 1080
 	belt 1041
 	haze _menu/haze-133
@@ -20193,7 +20190,7 @@ system Rastaban
 system "Rati Cal"
 	pos -116.765 -391.123
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 425.92
 	belt 1538
 	link "Due Yoot"
@@ -20247,7 +20244,7 @@ system "Rati Cal"
 system Regor
 	pos -702 -335
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 455.625
 	belt 1305
 	haze _menu/haze-67
@@ -20310,7 +20307,7 @@ system Regor
 system Regulus
 	pos -544 25
 	government Republic
-	attributes "!human" "!near earth" "!fringe"
+	attributes "near earth"
 	habitable 8640
 	belt 1605
 	haze _menu/haze-67
@@ -20463,7 +20460,7 @@ system Relifer
 system Remembrance
 	pos -884.587 641.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 486.68
 	belt 1536
 	link Beginning
@@ -20520,7 +20517,7 @@ system Remembrance
 system Rigel
 	pos -324 -363
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 1080
 	belt 1782
 	link Saiph
@@ -20670,7 +20667,7 @@ system Ritilas
 system Ruchbah
 	pos -174 69
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 2560
 	belt 1598
 	haze _menu/haze-133
@@ -20742,7 +20739,7 @@ system Ruchbah
 system Rutilicus
 	pos -535 273
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 625
 	belt 1771
 	link Arcturus
@@ -20811,7 +20808,7 @@ system Rutilicus
 system Sabik
 	pos -675 379
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 625
 	belt 1609
 	link Unukalhai
@@ -20863,7 +20860,7 @@ system Sabik
 system Sabriset
 	pos 151.724 -426.518
 	government Uninhabited
-	attributes "!korath" "!fringe"
+	attributes "korath"
 	habitable 1566.68
 	belt 1025
 	link Sepriaptu
@@ -20917,7 +20914,7 @@ system Sabriset
 system Sadalmelik
 	pos -145 472
 	government Quarg
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 1715
 	belt 1273
 	link Enif
@@ -20973,7 +20970,7 @@ system Sadalmelik
 system Sadalsuud
 	pos -134 508
 	government Quarg
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 1400
 	belt 1859
 	link Enif
@@ -21035,7 +21032,7 @@ system Sadalsuud
 system Sadr
 	pos -287 543
 	government Republic
-	attributes "!human" "!south" "!fringe"
+	attributes "south"
 	habitable 3859.38
 	belt 1388
 	link Albireo
@@ -21100,7 +21097,6 @@ system Sadr
 system "Sagittarius A*"
 	pos 112 22
 	government Uninhabited
-	attributes "!black hole" "!isolated"
 	habitable 10000
 	haze _menu/haze-full
 	object
@@ -21113,7 +21109,7 @@ system "Sagittarius A*"
 system Saiph
 	pos -375 -390
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 320
 	belt 1690
 	haze _menu/haze-33
@@ -21167,7 +21163,7 @@ system Saiph
 system Salipastart
 	pos 250.431 -370.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata" "!warzone"
+	attributes "korath"
 	habitable 486.68
 	belt 1056
 	haze _menu/haze-133
@@ -21234,7 +21230,7 @@ system Salipastart
 system Saquergen
 	pos -482 561
 	government Uninhabited
-	attributes "!isolated" "!nova"
+	attributes "nova"
 	habitable 100
 	belt 1435
 	asteroids "small rock" 3 3.9105
@@ -21263,7 +21259,7 @@ system Saquergen
 system Sargas
 	pos -542 445
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 911.25
 	belt 1642
 	link Kornephoros
@@ -21314,7 +21310,7 @@ system Sargas
 system Sarin
 	pos -670 293
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 1080
 	belt 1752
 	link Vindemiatrix
@@ -21364,7 +21360,7 @@ system Sarin
 system Sayaiban
 	pos 250.431 -274.812
 	government Drak
-	attributes "archon" "!korath" "!hazard" "!isolated"
+	attributes "archon" "korath"
 	habitable 2035
 	belt 1803
 	asteroids "small rock" 13 2.106
@@ -21419,7 +21415,7 @@ system Sayaiban
 system Scheat
 	pos -205 233
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 625
 	belt 1536
 	haze _menu/haze-133
@@ -21477,7 +21473,7 @@ system Scheat
 system Schedar
 	pos -93 229
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 1080
 	belt 1903
 	haze _menu/haze-133
@@ -21612,7 +21608,7 @@ system Segesta
 system Seginus
 	pos -557 356
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 135
 	belt 1906
 	link Alnasl
@@ -21678,7 +21674,7 @@ system Seginus
 system Seketra
 	pos -24.5695 -356.812
 	government Uninhabited
-	attributes "!korath" "!fringe"
+	attributes "korath"
 	habitable 425.92
 	belt 1465
 	link Skeruto
@@ -21730,7 +21726,7 @@ system Seketra
 system Sepetrosk
 	pos 192.431 -243.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 486.68
 	belt 1286
 	link Chimitarp
@@ -21791,7 +21787,7 @@ system Sepetrosk
 system Sepriaptu
 	pos 139.431 -448.812
 	government Uninhabited
-	attributes "!korath" "!fringe"
+	attributes "korath"
 	habitable 2035
 	belt 1120
 	link Kaliptari
@@ -21843,7 +21839,7 @@ system Sepriaptu
 system Sevrelect
 	pos -114.569 -239.812
 	government "Kor Efret"
-	attributes "!korath" "!efreti"
+	attributes "korath"
 	habitable 320
 	belt 1763
 	haze _menu/haze-67
@@ -21894,7 +21890,7 @@ system Sevrelect
 system Shaula
 	pos -460 527
 	government Pirate
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 625
 	belt 1814
 	link Lesath
@@ -21962,7 +21958,7 @@ system Shaula
 system Sheratan
 	pos -40 45
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 2035
 	belt 1183
 	haze _menu/haze-133
@@ -22022,7 +22018,7 @@ system Sheratan
 system Si'yak'ku
 	pos -329.235 -760.435
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 1313.28
 	belt 1985
 	haze _menu/haze-none
@@ -22103,7 +22099,7 @@ system Si'yak'ku
 system Sich'ka'ara
 	pos -97.1237 -831.921
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 1715
 	belt 1744
 	haze _menu/haze-none
@@ -22156,7 +22152,7 @@ system Sich'ka'ara
 system Silikatakfar
 	pos 248.431 -481.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 425.92
 	belt 1641
 	link Mesuket
@@ -22210,7 +22206,7 @@ system Silikatakfar
 system "Silver Bell"
 	pos -1045.59 541.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 1080
 	belt 1406
 	link "Bright Void"
@@ -22278,7 +22274,7 @@ system "Silver Bell"
 system "Silver String"
 	pos -1022.59 517.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 1080
 	belt 1986
 	link "Silver Bell"
@@ -22343,7 +22339,7 @@ system "Silver String"
 system Similisti
 	pos 210.431 -313.812
 	government "Kor Mereti"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 1080
 	belt 1349
 	haze _menu/haze-133
@@ -22411,7 +22407,7 @@ system Similisti
 system Sirius
 	pos -378 44
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 1800
 	belt 1407
 	link Sol
@@ -22475,7 +22471,7 @@ system Sirius
 system Skeruto
 	pos 28.4305 -339.812
 	government Uninhabited
-	attributes "!korath"
+	attributes "korath"
 	habitable 320
 	belt 1198
 	link Furmeliki
@@ -22526,7 +22522,7 @@ system Skeruto
 system Sko'karak
 	pos -304.43 -930.688
 	government Wanderer
-	attributes "!wanderer"
+	attributes "wanderer"
 	habitable 320
 	belt 1805
 	haze _menu/haze-none
@@ -22579,7 +22575,7 @@ system Sko'karak
 system Sobarati
 	pos 277.431 -557.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 3780
 	belt 1314
 	link Asikafarnut
@@ -22641,7 +22637,7 @@ system Sobarati
 system Sol
 	pos -400 100
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 1080
 	belt 1529
 	haze _menu/haze-67
@@ -22721,7 +22717,7 @@ system Sol
 system "Sol Arach"
 	pos -711.587 649.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 486.68
 	belt 1147
 	haze _menu/haze-133
@@ -22793,7 +22789,7 @@ system "Sol Arach"
 system "Sol Kimek"
 	pos -1310.63 227.214
 	government Coalition
-	attributes "!coalition" "!kimek"
+	attributes "kimek"
 	habitable 425.92
 	belt 1490
 	link "3 Pole"
@@ -22868,7 +22864,7 @@ system "Sol Kimek"
 system "Sol Saryd"
 	pos -1037.59 675.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 1313.28
 	belt 1720
 	link Belonging
@@ -22951,7 +22947,7 @@ system "Sol Saryd"
 system Solifar
 	pos 47.4305 -435.812
 	government Uninhabited
-	attributes "!korath"
+	attributes "korath"
 	habitable 320
 	belt 1517
 	haze _menu/haze-67
@@ -23007,7 +23003,7 @@ system Solifar
 system Sospi
 	pos -317 -161
 	government Republic
-	attributes "!human" "!north" "!fringe"
+	attributes "far north"
 	habitable 1715
 	belt 1715
 	haze _menu/haze-133
@@ -23073,7 +23069,7 @@ system Sospi
 system Speloog
 	pos -967.587 445.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 625
 	belt 1159
 	link Belug
@@ -23140,7 +23136,7 @@ system Speloog
 system Spica
 	pos -906 120
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 625
 	belt 1940
 	haze _menu/haze-33
@@ -23243,7 +23239,7 @@ system Statina
 system "Steep Roof"
 	pos -1113.59 570.051
 	government Coalition
-	attributes "!coalition" "!saryd"
+	attributes "saryd"
 	habitable 1080
 	belt 1100
 	haze _menu/haze-67
@@ -23379,7 +23375,7 @@ system Stercutus
 system Suhail
 	pos -774 -338
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 1715
 	belt 1715
 	haze _menu/haze-33
@@ -23440,7 +23436,7 @@ system Suhail
 system Sumar
 	pos -236 -273
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 2560
 	belt 1778
 	link Cardax
@@ -23500,7 +23496,7 @@ system Sumar
 system Sumprast
 	pos -101.569 -262.812
 	government "Kor Efret"
-	attributes "!korath" "!automata"
+	attributes "korath"
 	habitable 486.68
 	belt 1958
 	haze _menu/haze-67
@@ -23566,7 +23562,7 @@ system Sumprast
 system Tais
 	pos -346 381
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 3645
 	belt 1379
 	haze _menu/haze-133
@@ -23624,7 +23620,7 @@ system Tais
 system Talita
 	pos -519 -26
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 1705
 	belt 1403
 	link Miaplacidus
@@ -23690,7 +23686,7 @@ system Talita
 system "Tania Australis"
 	pos -671 7
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 1080
 	belt 1738
 	link Phecda
@@ -23763,7 +23759,7 @@ system "Tania Australis"
 system Tarazed
 	pos -194 448
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 1215
 	belt 1169
 	link Enif
@@ -23826,7 +23822,7 @@ system Tarazed
 system Tebuteb
 	pos -615.587 710.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 553.28
 	belt 1855
 	link Miblulub
@@ -23888,7 +23884,7 @@ system Tebuteb
 system Tejat
 	pos -489 -107
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 1158.12
 	belt 1447
 	link Phurad
@@ -23966,7 +23962,7 @@ system Tejat
 system Terminus
 	pos -727.99 -23.2491
 	government Republic
-	attributes "wormhole" "!human" "!dirt belt" "!fringe"
+	attributes "wormhole" "dirt belt"
 	habitable 425.92
 	belt 1221
 	haze _menu/haze-67
@@ -24019,7 +24015,6 @@ system Terminus
 system "Terra Incognita"
 	pos 9921.5 7086.5
 	government Uninhabited
-	attributes "!pleiades"
 	link "Over the Rainbow"
 	habitable 455.625
 	haze _menu/haze-blackbody
@@ -24064,7 +24059,7 @@ system "Terra Incognita"
 system Torbab
 	pos -949.587 490.051
 	government Coalition
-	attributes "!coalition" "!arach"
+	attributes "arachi"
 	habitable 1505.92
 	belt 1702
 	link Speloog
@@ -24141,7 +24136,7 @@ system Torbab
 system Tortor
 	pos -255 -424
 	government Republic
-	attributes "!human" "!north" "!fringe"
+	attributes "far north"
 	habitable 455.625
 	belt 1243
 	haze _menu/haze-67
@@ -24208,7 +24203,7 @@ system Tortor
 system Turais
 	pos -691 134
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 320
 	belt 1471
 	link Gacrux
@@ -24265,7 +24260,7 @@ system Turais
 system "Ula Mon"
 	pos -64.1218 -559.868
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 640
 	belt 1574
 	link "Bote Asu"
@@ -24340,7 +24335,7 @@ system "Ula Mon"
 system "Ultima Thule"
 	pos -336 -211
 	government Republic
-	attributes "wormhole" "!north"
+	attributes "wormhole" "far north"
 	habitable 2560
 	belt 1635
 	haze _menu/haze-67
@@ -24394,7 +24389,7 @@ system "Ultima Thule"
 system Umbral
 	pos -164 406
 	government Republic
-	attributes "!human" "!south" "!fringe"
+	attributes "south"
 	habitable 670
 	belt 1345
 	link Tarazed
@@ -24472,7 +24467,7 @@ system Umbral
 system Unagi
 	pos -306 -578
 	government Pirate
-	attributes "!human" "!north" "!fringe"
+	attributes "far north"
 	habitable 320
 	belt 1960
 	haze _menu/haze-33
@@ -24526,7 +24521,7 @@ system Unagi
 system Unukalhai
 	pos -710 405
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 625
 	belt 1968
 	haze _menu/haze-67
@@ -24587,7 +24582,7 @@ system Unukalhai
 system "Uwa Fahn"
 	pos 35.1585 -491.67
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 320
 	belt 1913
 	link "Ya Hai"
@@ -24651,7 +24646,7 @@ system Vaticanus
 	asteroids "small metal" 14 8
 	asteroids "small rock" 3 6
 	government Uninhabited
-	attributes "!ember waste"
+	attributes "ember waste"
 	haze _menu/haze-red
 	link Egeria
 	link Prosa
@@ -24693,7 +24688,7 @@ system Vaticanus
 system Vega
 	pos -402 182
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "near earth"
 	habitable 1400
 	belt 1744
 	link Altair
@@ -24757,7 +24752,7 @@ system Vega
 system Vindemiatrix
 	pos -635 257
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 1080
 	belt 1957
 	link Alioth
@@ -24810,7 +24805,7 @@ system Vindemiatrix
 system Volax
 	pos -256 -179
 	government Republic
-	attributes "!human" "!north"
+	attributes "far north"
 	habitable 1715
 	belt 1424
 	haze _menu/haze-67
@@ -24865,7 +24860,7 @@ system Volax
 system "Wah Ki"
 	pos 14.9925 -612.792
 	government Hai
-	attributes "!hai" "!warzone"
+	attributes "hai"
 	habitable 425.92
 	belt 1585
 	link "Zuba Zub"
@@ -24934,7 +24929,7 @@ system "Wah Ki"
 system "Wah Oh"
 	pos -205.344 -381.381
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 5000
 	belt 1194
 	haze _menu/haze-67
@@ -25013,7 +25008,7 @@ system "Wah Oh"
 system "Wah Yoot"
 	pos 40.9382 -685.994
 	government "Hai (Unfettered)"
-	attributes "!hai"
+	attributes "hai"
 	habitable 1080
 	belt 1222
 	link "Wah Ki"
@@ -25078,7 +25073,7 @@ system "Wah Yoot"
 system Waypoint
 	pos -184 -515
 	government Hai
-	attributes "wormhole" "!hai"
+	attributes "wormhole" "hai"
 	habitable 78.125
 	belt 1610
 	haze _menu/haze-67
@@ -25136,7 +25131,7 @@ system Waypoint
 system Wazn
 	pos -385 -131
 	government Republic
-	attributes "!human" "!paradise"
+	attributes "paradise planets"
 	habitable 534.375
 	belt 1414
 	haze _menu/haze-67
@@ -25202,7 +25197,7 @@ system Wazn
 system Wei
 	pos -598 369
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 455.625
 	belt 1927
 	link Seginus
@@ -25260,7 +25255,7 @@ system Wei
 system Wezen
 	pos -664 -433
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 2880
 	belt 1913
 	link Naos
@@ -25342,7 +25337,6 @@ system Wezen
 system "World's End"
 	pos 9966.5 7017.5
 	government Uninhabited
-	attributes "!pleiades"
 	habitable 700
 	haze _menu/haze-blackbody
 	object
@@ -25402,7 +25396,7 @@ system "World's End"
 system "Ya Hai"
 	pos -24.9453 -505.571
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 425.92
 	belt 1120
 	link "Ula Mon"
@@ -25477,7 +25471,7 @@ system "Ya Hai"
 system "Yed Prior"
 	pos -810 374
 	government Republic
-	attributes "!human" "!south"
+	attributes "south"
 	habitable 455.625
 	belt 1837
 	link Pherkad
@@ -25534,7 +25528,7 @@ system "Yed Prior"
 system Zaurak
 	pos -109 -34
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "core"
 	habitable 625
 	belt 1130
 	haze _menu/haze-133
@@ -25592,7 +25586,7 @@ system Zaurak
 system "Zeta Aquilae"
 	pos -369 276
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "dirt belt"
 	habitable 1400
 	belt 1829
 	haze _menu/haze-133
@@ -25667,7 +25661,7 @@ system "Zeta Aquilae"
 system "Zeta Centauri"
 	pos -835 257
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 455.625
 	belt 1488
 	haze _menu/haze-67
@@ -25723,7 +25717,7 @@ system "Zeta Centauri"
 system Zosma
 	pos -640 -123
 	government Republic
-	attributes "!human" "!deep"
+	attributes "deep"
 	habitable 455.625
 	belt 1436
 	link Algieba
@@ -25789,7 +25783,7 @@ system Zosma
 system "Zuba Zub"
 	pos -48.2661 -647.926
 	government Hai
-	attributes "!hai"
+	attributes "hai"
 	habitable 425.92
 	belt 1911
 	haze _menu/haze-67
@@ -25855,7 +25849,7 @@ system "Zuba Zub"
 system Zubenelgenubi
 	pos -710 353
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 945
 	belt 1475
 	link Zubeneschamali
@@ -25921,7 +25915,7 @@ system Zubenelgenubi
 system Zubeneschamali
 	pos -759 338
 	government Republic
-	attributes "!human" "!rim"
+	attributes "rim"
 	habitable 1250
 	belt 1543
 	haze _menu/haze-67

--- a/data/map.txt
+++ b/data/map.txt
@@ -2146,7 +2146,7 @@ system Aescolanus
 system "Aki'il"
 	pos -83 722
 	government Uninhabited
-	attributes "ember waste" "graveyard"
+	attributes "ember waste" "graveyard" "!isolated"
 	habitable 1505.92
 	asteroids "large metal" 47 5
 	asteroids "large rock" 2 10
@@ -6571,7 +6571,7 @@ system Cebalrai
 system Celeborim
 	pos 181.431 -633.812
 	government "Kor Sestor"
-	attributes "!korath" "!automata"
+	attributes "!korath" "!automata" "!fringe"
 	habitable 320
 	belt 1296
 	link Asikafarnut
@@ -8168,7 +8168,7 @@ system Dixere
 system Dokdobaru
 	pos -21.5695 -241.812
 	government Quarg
-	attributes "!korath"
+	attributes "!korath" "!efreti" "!ringworld"
 	habitable 700
 	belt 1935
 	haze _menu/haze-133
@@ -9243,7 +9243,7 @@ system Eneremprukt
 system Enif
 	pos -177 498
 	government Quarg
-	attributes "!human" "!south"
+	attributes "!human" "!south" "!ringworld"
 	habitable 700
 	belt 1974
 	link Sadalmelik
@@ -9667,6 +9667,7 @@ system Eteron
 system "Fah Root"
 	pos -264.065 -400.135
 	government Hai
+	attributes "!hai" "!fringe"
 	habitable 486.68
 	belt 1057
 	haze _menu/haze-67
@@ -9735,6 +9736,7 @@ system "Fah Root"
 system "Fah Soom"
 	pos -179.891 -335.011
 	government Hai
+	attributes "!hai"
 	habitable 425.92
 	belt 1185
 	haze _menu/haze-67
@@ -9795,6 +9797,7 @@ system "Fah Soom"
 system Fala
 	pos -690 64
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 625
 	belt 1264
 	link "Tania Australis"
@@ -9855,6 +9858,7 @@ system Fala
 system "Fallen Leaf"
 	pos -903.587 717.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 320
 	belt 1327
 	link Beginning
@@ -9907,6 +9911,7 @@ system "Fallen Leaf"
 system "Far Horizon"
 	pos -1108.59 726.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 320
 	belt 1242
 	haze _menu/haze-67
@@ -9962,6 +9967,7 @@ system "Far Horizon"
 system Farbutero
 	pos 93.4305 -251.812
 	government Uninhabited
+	attributes "!korath" "!automata"
 	habitable 625
 	belt 1175
 	haze _menu/haze-133
@@ -10107,6 +10113,7 @@ system Farinus
 system Faronektu
 	pos 292.431 -309.812
 	government "Kor Mereti"
+	attributes "!korath" "!automata"
 	habitable 1080
 	belt 1630
 	haze _menu/haze-133
@@ -10174,7 +10181,7 @@ system Faronektu
 system Fasitopfar
 	pos 92.4305 -105.812
 	government Uninhabited
-	attributes "archon"
+	attributes "archon" "!korath" "!isolated" "!nova"
 	habitable 100
 	belt 1670
 	haze _menu/haze-blackbody
@@ -10282,6 +10289,7 @@ system Fearis
 system "Fell Omen"
 	pos -1156.59 475.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 425.92
 	belt 1240
 	link "Last Word"
@@ -10472,6 +10480,7 @@ system Fereti
 system Feroteri
 	pos 149.431 -205.812
 	government Uninhabited
+	attributes "!korath" "!automata"
 	habitable 5425.92
 	belt 1419
 	haze _menu/haze-blackbody
@@ -10555,6 +10564,7 @@ system Feroteri
 system Ferukistek
 	pos 307.431 -515.812
 	government "Kor Sestor"
+	attributes "!korath" "!automata"
 	habitable 486.68
 	belt 1520
 	link Eneremprukt
@@ -10608,6 +10618,7 @@ system Ferukistek
 system Fingol
 	pos -482 113
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 135
 	belt 1976
 	haze _menu/haze-none
@@ -10665,6 +10676,7 @@ system Fingol
 system Flugbu
 	pos -903.587 534.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 425.92
 	belt 1843
 	link Torbab
@@ -10729,6 +10741,7 @@ system Flugbu
 system Fomalhaut
 	pos -314 124
 	government Syndicate
+	attributes "!human" "!near earth"
 	habitable 455.625
 	belt 1854
 	link Altair
@@ -10791,6 +10804,7 @@ system Fomalhaut
 system Fornarep
 	pos 79.4305 -309.812
 	government Uninhabited
+	attributes "!korath" "!automata"
 	habitable 320
 	belt 1922
 	haze _menu/haze-133
@@ -10857,6 +10871,7 @@ system Fornarep
 system "Four Pillars"
 	pos -1210.59 772.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 486.68
 	belt 1061
 	link "Far Horizon"
@@ -10918,6 +10933,7 @@ system "Four Pillars"
 system Furmeliki
 	pos -35.5695 -281.812
 	government Uninhabited
+	attributes "!korath" "!efreti"
 	habitable 486.68
 	belt 1577
 	link Dokdobaru
@@ -10979,6 +10995,7 @@ system Furmeliki
 system Gacrux
 	pos -713 184
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 534.375
 	belt 1188
 	link "Cor Caroli"
@@ -11046,6 +11063,7 @@ system Gacrux
 system "Gamma Cassiopeiae"
 	pos -116 293
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 455.625
 	belt 1779
 	haze _menu/haze-133
@@ -11104,6 +11122,7 @@ system "Gamma Cassiopeiae"
 system "Gamma Corvi"
 	pos -906 64
 	government Republic
+	attributes "!coalition" "!rim"
 	habitable 1535.62
 	belt 1556
 	haze _menu/haze-none
@@ -11226,6 +11245,7 @@ system Gerenus
 system Gienah
 	pos -176 354
 	government Pirate
+	attributes "!human" "!core"
 	habitable 534.375
 	belt 1939
 	link Persian
@@ -11360,6 +11380,7 @@ system Giribea
 system Girtab
 	pos -430 481
 	government Republic
+	attributes "!human" "!south"
 	habitable 1080
 	belt 1387
 	link Lesath
@@ -11424,6 +11445,7 @@ system Girtab
 system Glubatub
 	pos -650.587 693.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 233.28
 	belt 1093
 	link "Sol Arach"
@@ -11501,6 +11523,7 @@ system Glubatub
 system Gomeisa
 	pos -600 -161
 	government Republic
+	attributes "!human" "!deep"
 	habitable 911.25
 	belt 1616
 	link Zosma
@@ -11570,6 +11593,7 @@ system Gomeisa
 system "Good Omen"
 	pos -941.587 746.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 1715
 	belt 1598
 	haze _menu/haze-67
@@ -11631,6 +11655,7 @@ system "Good Omen"
 system Gorvi
 	pos -250 -483
 	government Republic
+	attributes "!human" "!north" "!fringe"
 	habitable 670
 	belt 1345
 	haze _menu/haze-133
@@ -11688,6 +11713,7 @@ system Gorvi
 system Graffias
 	pos -784 517
 	government Republic
+	attributes "!human" "!south"
 	habitable 911.25
 	belt 1977
 	link Alniyat
@@ -11751,6 +11777,7 @@ system Graffias
 system Gupta
 	pos -808.587 625.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 912.6
 	belt 1771
 	link Ablodab
@@ -11811,6 +11838,7 @@ system Gupta
 system Hadar
 	pos -788 283
 	government Republic
+	attributes "!human" "!rim"
 	habitable 455.625
 	belt 1520
 	link "Zeta Centauri"
@@ -11870,6 +11898,7 @@ system Hadar
 system Hamal
 	pos -129 24
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 1080
 	belt 1241
 	haze _menu/haze-133
@@ -11924,6 +11953,7 @@ system Hamal
 system Han
 	pos -610 561
 	government Republic
+	attributes "!human" "!south"
 	habitable 1080.62
 	belt 1517
 	link Alniyat
@@ -11982,6 +12012,7 @@ system Han
 system Hassaleh
 	pos -291 -287
 	government Republic
+	attributes "!human" "!north"
 	habitable 670
 	belt 1924
 	haze _menu/haze-67
@@ -12042,6 +12073,7 @@ system Hassaleh
 system Hatysa
 	pos -474 -542
 	government Pirate
+	attributes "!human" "!north"
 	habitable 533.75
 	belt 1163
 	haze _menu/haze-33
@@ -12102,6 +12134,7 @@ system Hatysa
 system "Heia Due"
 	pos -146.177 -481.694
 	government Hai
+	attributes "!hai"
 	habitable 1215
 	belt 1079
 	haze _menu/haze-67
@@ -12173,6 +12206,7 @@ system "Heia Due"
 system Hesselpost
 	pos -30.5695 -187.812
 	government Uninhabited
+	attributes "!korath" "!efreti" "!fringe"
 	habitable 486.68
 	belt 1327
 	haze _menu/haze-133
@@ -12243,6 +12277,7 @@ system Hesselpost
 system "Hevru Hai"
 	pos -189 -310
 	government Quarg
+	attributes "!hai" "!ringworld"
 	habitable 700
 	belt 1245
 	link "Fah Soom"
@@ -12357,6 +12392,7 @@ system "Hevru Hai"
 system "Hi Yahr"
 	pos 82.3672 -641.6
 	government "Hai (Unfettered)"
+	attributes "!hai"
 	habitable 625
 	belt 1655
 	link "Wah Yoot"
@@ -12414,6 +12450,7 @@ system "Hi Yahr"
 system Hintar
 	pos -422 311
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 625
 	belt 1725
 	haze _menu/haze-133
@@ -12473,6 +12510,7 @@ system Hintar
 system Holeb
 	pos -590 287
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1715
 	belt 1181
 	link Alioth
@@ -12520,6 +12558,7 @@ system Holeb
 system Homeward
 	pos -1045.59 477.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 425.92
 	belt 1499
 	link "Silver Bell"
@@ -12585,6 +12624,7 @@ system Homeward
 system Host
 	pos 384.431 -543.812
 	government Uninhabited
+	attributes "!isolated" "!TBD"
 	habitable 486.68
 	belt 1669
 	asteroids "large metal" 1 0.732
@@ -12633,6 +12673,7 @@ system Host
 system Hunter
 	pos -968.587 590.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 425.92
 	belt 1498
 	link "Bright Void"
@@ -12694,6 +12735,7 @@ system Hunter
 system Ik'kara'ka
 	pos 56.2159 -888.296
 	government Wanderer
+	attributes "!wanderer"
 	habitable 625
 	belt 1497
 	haze _menu/haze-none
@@ -12755,6 +12797,7 @@ system Ik'kara'ka
 system Ildaria
 	pos -702 317
 	government Republic
+	attributes "!human" "!rim"
 	habitable 625
 	belt 1132
 	haze _menu/haze-133
@@ -12808,6 +12851,7 @@ system Ildaria
 system "Imo Dep"
 	pos -56.2764 -600.1
 	government Hai
+	attributes "!hai"
 	habitable 1715
 	belt 1416
 	haze _menu/haze-67
@@ -12932,6 +12976,7 @@ system Insitor
 system "Io Lowe"
 	pos -94.7566 -527.728
 	government Hai
+	attributes "!hai"
 	habitable 135
 	belt 1552
 	haze _menu/haze-67
@@ -12993,6 +13038,7 @@ system "Io Lowe"
 system "Io Mann"
 	pos -192.955 -447.669
 	government Hai
+	attributes "!hai"
 	habitable 973.36
 	belt 1132
 	haze _menu/haze-67
@@ -13067,6 +13113,7 @@ system "Io Mann"
 system Ipsing
 	pos -549 160
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1400
 	belt 1107
 	haze _menu/haze-67
@@ -13133,6 +13180,7 @@ system Ipsing
 system Iyech'yek
 	pos -277.37 -693.913
 	government Wanderer
+	attributes "!wanderer"
 	habitable 320
 	belt 1613
 	haze _menu/haze-33
@@ -13186,6 +13234,7 @@ system Iyech'yek
 system Izar
 	pos -784 231
 	government Republic
+	attributes "!human" "!rim"
 	habitable 1294.38
 	belt 1449
 	haze _menu/haze-67
@@ -13250,6 +13299,7 @@ system Izar
 system Ka'ch'chrai
 	pos -240.163 -822.448
 	government Wanderer
+	attributes "!wanderer"
 	habitable 425.92
 	belt 1745
 	haze _menu/haze-none
@@ -13307,6 +13357,7 @@ system Ka'ch'chrai
 system Ka'pru
 	pos -76.6756 -994.955
 	government Wanderer
+	attributes "!wanderer"
 	habitable 1505.92
 	belt 1808
 	haze _menu/haze-33
@@ -13377,6 +13428,7 @@ system Ka'pru
 system Kaliptari
 	pos 85.4305 -402.812
 	government Uninhabited
+	attributes "!korath" "!automata"
 	habitable 320
 	belt 1089
 	link Skeruto
@@ -13451,6 +13503,7 @@ system Kaliptari
 system "Kappa Centauri"
 	pos -867 480
 	government Republic
+	attributes "!human" "!south"
 	habitable 1215
 	belt 1508
 	link Pherkad
@@ -13511,6 +13564,7 @@ system "Kappa Centauri"
 system Kashikt
 	pos -73.5695 -219.812
 	government "Kor Efret"
+	attributes "!korath" "!efreti"
 	habitable 1715
 	belt 1013
 	link Dokdobaru
@@ -13578,7 +13632,7 @@ system Kashikt
 system Kasikfar
 	pos 10.4305 -127.812
 	government Uninhabited
-	attributes "archon"
+	attributes "archon" "!isolated" "!korath" "!nova"
 	habitable 100
 	belt 1539
 	haze _menu/haze-blackbody
@@ -13619,6 +13673,7 @@ system Kasikfar
 system "Kaus Australis"
 	pos -284 395
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1281
 	haze _menu/haze-133
@@ -13670,6 +13725,7 @@ system "Kaus Australis"
 system "Kaus Borealis"
 	pos -456 350
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 590.625
 	belt 1074
 	haze _menu/haze-133
@@ -13732,6 +13788,7 @@ system "Kaus Borealis"
 system "Ki War Ek"
 	pos -1106.63 368.214
 	government Heliarch
+	attributes "!coalition" "!ringworld"
 	habitable 700
 	belt 1777
 	haze _menu/haze-133

--- a/data/map.txt
+++ b/data/map.txt
@@ -75,7 +75,7 @@ galaxy "label graveyard"
 system "1 Axis"
 	pos -1274.63 267.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 745.92
 	belt 1112
 	link "Sol Kimek"
@@ -153,7 +153,7 @@ system "1 Axis"
 system "10 Pole"
 	pos -1356.63 19.2137
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 486.68
 	belt 1765
 	haze _menu/haze-67
@@ -225,7 +225,7 @@ system "10 Pole"
 system "11 Autumn Above"
 	pos -1278.63 148.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 1566.68
 	belt 1099
 	haze _menu/haze-133
@@ -307,7 +307,7 @@ system "11 Autumn Above"
 system "11 Spring Below"
 	pos -1272.63 380.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 912.6
 	belt 1932
 	link "4 Spring Rising"
@@ -387,7 +387,7 @@ system "11 Spring Below"
 system "12 Autumn Above"
 	pos -1276.63 -19.7863
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 1050.92
 	belt 1283
 	link "14 Pole"
@@ -481,7 +481,7 @@ system "12 Autumn Above"
 system "14 Pole"
 	pos -1343.63 -119.786
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 625
 	belt 1881
 	haze _menu/haze-67
@@ -542,7 +542,7 @@ system "14 Pole"
 system "14 Summer Above"
 	pos -1436.63 182.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 1400
 	belt 1093
 	haze _menu/haze-67
@@ -608,7 +608,7 @@ system "14 Summer Above"
 system "14 Winter Below"
 	pos -1143.63 341.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 1111.68
 	belt 1173
 	link "8 Winter Below"
@@ -684,7 +684,7 @@ system "14 Winter Below"
 system "16 Autumn Rising"
 	pos -1305.63 74.2137
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 1715
 	belt 1424
 	link "12 Autumn Above"
@@ -754,7 +754,7 @@ system "16 Autumn Rising"
 system "3 Axis"
 	pos -1235.63 299.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 2372.76
 	belt 1202
 	link "1 Axis"
@@ -822,7 +822,7 @@ system "3 Axis"
 system "3 Pole"
 	pos -1344.63 162.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 625
 	belt 1617
 	link "16 Autumn Rising"
@@ -882,7 +882,7 @@ system "3 Pole"
 system "3 Spring Rising"
 	pos -1414.63 356.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 1080
 	belt 1613
 	haze _menu/haze-33
@@ -955,7 +955,7 @@ system "3 Spring Rising"
 system "4 Axis"
 	pos -1169.63 365.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 425.92
 	belt 1838
 	link "14 Winter Below"
@@ -1018,7 +1018,7 @@ system "4 Axis"
 system "4 Spring Rising"
 	pos -1309.63 321.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 320
 	belt 1801
 	link "1 Axis"
@@ -1083,7 +1083,7 @@ system "4 Spring Rising"
 system "4 Summer Rising"
 	pos -1377.63 207.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 320
 	belt 1860
 	link "3 Pole"
@@ -1143,7 +1143,7 @@ system "4 Summer Rising"
 system "4 Winter Rising"
 	pos -1259.63 248.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 135
 	belt 1345
 	link "Sol Kimek"
@@ -1218,7 +1218,7 @@ system "4 Winter Rising"
 system "5 Axis"
 	pos -1142.63 394.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 233.28
 	belt 1775
 	link "4 Axis"
@@ -1291,7 +1291,7 @@ system "5 Axis"
 system "5 Spring Below"
 	pos -1213.63 415.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 1313.28
 	belt 1104
 	link "4 Axis"
@@ -1363,7 +1363,7 @@ system "5 Spring Below"
 system "5 Summer Above"
 	pos -1387.63 118.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 425.92
 	belt 1133
 	haze _menu/haze-133
@@ -1430,7 +1430,7 @@ system "5 Summer Above"
 system "5 Winter Above"
 	pos -1216.63 208.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 320
 	belt 1414
 	link "4 Winter Rising"
@@ -1494,7 +1494,7 @@ system "5 Winter Above"
 system "7 Autumn Rising"
 	pos -1235.63 177.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 425.92
 	belt 1289
 	link "11 Autumn Above"
@@ -1560,7 +1560,7 @@ system "7 Autumn Rising"
 system "8 Winter Below"
 	pos -1179.63 284.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 486.68
 	belt 1285
 	link "3 Axis"
@@ -1625,7 +1625,7 @@ system "8 Winter Below"
 system "9 Spring Above"
 	pos -1377.63 281.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!kimek" "!coalition"
 	habitable 1050.92
 	belt 1397
 	haze _menu/haze-67
@@ -1700,7 +1700,7 @@ system "9 Spring Above"
 system Ablodab
 	pos -854.587 592.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!arach" "!coalition"
 	habitable 425.92
 	belt 1368
 	link Debrugt
@@ -1775,7 +1775,7 @@ system Ablodab
 system Ablub
 	pos -581.587 637.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!arach" "!coalition"
 	habitable 233.28
 	belt 1641
 	haze _menu/haze-133
@@ -1829,7 +1829,7 @@ system Ablub
 system Acamar
 	pos -284 -3
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 1080
 	belt 1013
 	link Diphda
@@ -1888,7 +1888,7 @@ system Acamar
 system Achernar
 	pos -93 154
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 625
 	belt 1963
 	haze _menu/haze-133
@@ -1960,7 +1960,7 @@ system Achernar
 system Acrux
 	pos -808 192
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 590.625
 	belt 1407
 	haze _menu/haze-67
@@ -2040,7 +2040,7 @@ system Acrux
 system Adhara
 	pos -669 -200
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 670
 	belt 1014
 	link "Epsilon Leonis"
@@ -2146,7 +2146,7 @@ system Aescolanus
 system "Aki'il"
 	pos -83 722
 	government Uninhabited
-	attributes "ember waste" "graveyard" "isolated"
+	attributes "ember waste" "graveyard" "!isolated"
 	habitable 1505.92
 	asteroids "large metal" 47 5
 	asteroids "large rock" 2 10
@@ -2202,7 +2202,7 @@ system "Aki'il"
 system "Al Dhanab"
 	pos -177 207
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 1080
 	belt 1432
 	haze _menu/haze-133
@@ -2272,7 +2272,7 @@ system "Al Dhanab"
 system Albaldah
 	pos -350 484
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 534.375
 	belt 1622
 	haze _menu/haze-133
@@ -2347,7 +2347,7 @@ system Albaldah
 system Albireo
 	pos -270 503
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 760
 	belt 1030
 	link Tarazed
@@ -2405,7 +2405,7 @@ system Albireo
 system Alcyone
 	pos -80 -144
 	government Pirate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 270
 	belt 1438
 	haze _menu/haze-133
@@ -2472,7 +2472,7 @@ system Alcyone
 system Aldebaran
 	pos -356 -26
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 625
 	belt 1296
 	link Capella
@@ -2518,7 +2518,7 @@ system Aldebaran
 system Alderamin
 	pos -272 258
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 1705
 	belt 1908
 	haze _menu/haze-133
@@ -2583,7 +2583,7 @@ system Alderamin
 system Aldhibain
 	pos -659 451
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 455.625
 	belt 1840
 	link Kornephoros
@@ -2641,7 +2641,7 @@ system Aldhibain
 			period 13.622
 
 system Algenib
-	attributes "human space" "the core" "fringe"
+	attributes "!human" "!core" "!fringe"
 	pos -118 341
 	government Pirate
 	habitable 455.625
@@ -2698,7 +2698,7 @@ system Algenib
 			period 42.6838
 
 system Algieba
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	pos -691 -52
 	government Republic
 	habitable 2695
@@ -2770,7 +2770,7 @@ system Algieba
 system Algol
 	pos -210 17
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 534.375
 	belt 1839
 	haze _menu/haze-133
@@ -2832,7 +2832,7 @@ system Algol
 system Algorel
 	pos -631 145
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1993
 	haze _menu/haze-67
@@ -2897,7 +2897,7 @@ system Algorel
 system Alheka
 	pos -350 -271
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 1080
 	belt 1380
 	haze _menu/haze-67
@@ -2956,7 +2956,7 @@ system Alheka
 system Alhena
 	pos -430 -80
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 945
 	belt 1078
 	haze _menu/haze-67
@@ -3026,7 +3026,7 @@ system Alhena
 system Alioth
 	pos -620 315
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 455.625
 	belt 1889
 	link Wei
@@ -3079,7 +3079,7 @@ system Alioth
 system Alkaid
 	pos -825 318
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 1080
 	belt 1142
 	haze _menu/haze-67
@@ -3147,7 +3147,7 @@ system Alkaid
 system Almaaz
 	pos -349 -538
 	government Pirate
-	attributes "human space" "far north" "fringe"
+	attributes "!human" "!north" "!fringe"
 	habitable 1080
 	belt 1873
 	haze _menu/haze-33
@@ -3194,7 +3194,7 @@ system Almaaz
 system Almach
 	pos -7 232
 	government Pirate
-	attributes "human space" "the core" "fringe"
+	attributes "!human" "!core" "!fringe"
 	habitable 320
 	belt 1914
 	haze _menu/haze-133
@@ -3257,7 +3257,7 @@ system Almach
 system Alnair
 	pos -272 314
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 135
 	belt 1969
 	haze _menu/haze-133
@@ -3326,7 +3326,7 @@ system Alnair
 system Alnasl
 	pos -553 380
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 640
 	belt 1412
 	haze _menu/haze-133
@@ -3389,7 +3389,7 @@ system Alnasl
 system Alnilam
 	pos -487 -513
 	government Pirate
-	attributes "human space" "far north" "fringe"
+	attributes "!human" "!north" "!fringe"
 	habitable 1715
 	belt 1099
 	haze _menu/haze-33
@@ -3467,7 +3467,7 @@ system Alnilam
 system Alnitak
 	pos -331 -412
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 349.375
 	belt 1907
 	haze _menu/haze-67
@@ -3524,7 +3524,7 @@ system Alnitak
 system Alniyat
 	pos -691 501
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 534.375
 	belt 1760
 	link Pherkad
@@ -3597,7 +3597,7 @@ system Alniyat
 system "Alpha Arae"
 	pos -481 394
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 945
 	belt 1405
 	link "Delta Sagittarii"
@@ -3668,7 +3668,7 @@ system "Alpha Arae"
 system "Alpha Centauri"
 	pos -429 125
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 320
 	belt 1116
 	haze _menu/haze-67
@@ -3731,7 +3731,7 @@ system "Alpha Centauri"
 system "Alpha Hydri"
 	pos -97 98
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 1400
 	belt 1839
 	haze _menu/haze-133
@@ -3785,7 +3785,7 @@ system "Alpha Hydri"
 system Alphard
 	pos -588 -47
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 1080.62
 	belt 1101
 	link Algieba
@@ -3852,7 +3852,7 @@ system Alphard
 system Alphecca
 	pos -546 308
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 1400
 	belt 1101
 	link Alioth
@@ -3902,7 +3902,7 @@ system Alphecca
 system Alpheratz
 	pos -176 125
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 1080.62
 	belt 1645
 	haze _menu/haze-133
@@ -3970,7 +3970,7 @@ system Alpheratz
 system Altair
 	pos -357 161
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 945
 	belt 1830
 	link Vega
@@ -4033,7 +4033,7 @@ system Altair
 system Aludra
 	pos -606 -374
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 455.625
 	belt 1511
 	haze _menu/haze-33
@@ -4097,7 +4097,7 @@ system Aludra
 system "Ancient Hope"
 	pos -1159.59 702.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 455
 	belt 1439
 	haze _menu/haze-67
@@ -4167,7 +4167,7 @@ system "Ancient Hope"
 system Ankaa
 	pos -230 100
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 625
 	belt 1003
 	haze _menu/haze-133
@@ -4222,7 +4222,7 @@ system Ankaa
 system Answer
 	pos -1086.59 631.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 425.92
 	belt 1636
 	haze _menu/haze-none
@@ -4287,7 +4287,7 @@ system Answer
 system Antares
 	pos -711 541
 	government Pirate
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 455.625
 	belt 1778
 	haze _menu/haze-67
@@ -4413,7 +4413,7 @@ system Antevorta
 system Ap'arak
 	pos -164.62 -781.858
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 1080
 	belt 1385
 	haze _menu/haze-none
@@ -4469,7 +4469,7 @@ system Ap'arak
 system Arcturus
 	pos -589 226
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1422
 	link Mizar
@@ -4604,7 +4604,7 @@ system Arculus
 system Arneb
 	pos -523 -580
 	government Pirate
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 1715
 	belt 1947
 	haze _menu/haze-none
@@ -4653,7 +4653,7 @@ system Arneb
 system Ascella
 	pos -376 328
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 640
 	belt 1971
 	haze _menu/haze-133
@@ -4719,7 +4719,7 @@ system Ascella
 system Asikafarnut
 	pos 253.431 -584.812
 	government "Kor Sestor"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 320
 	belt 1342
 	link Silikatakfar
@@ -4784,7 +4784,7 @@ system Asikafarnut
 system Aspidiske
 	pos -690 -282
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 135
 	belt 1885
 	link Avior
@@ -4841,7 +4841,7 @@ system Aspidiske
 system Atria
 	pos -551 532
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 214.375
 	belt 1340
 	link Han
@@ -4907,7 +4907,7 @@ system Atria
 system Avior
 	pos -658 -317
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 1215
 	belt 1097
 	link Aspidiske
@@ -4977,7 +4977,7 @@ system Avior
 system Aya'k'k
 	pos -434.245 -616.57
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 486.68
 	belt 1586
 	haze _menu/haze-67
@@ -5037,7 +5037,7 @@ system Aya'k'k
 system Beginning
 	pos -912.587 694.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 425.92
 	belt 1833
 	link Belonging
@@ -5100,7 +5100,7 @@ system Beginning
 system Bellatrix
 	pos -225 -82
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 670
 	belt 1564
 	link Menkar
@@ -5160,7 +5160,7 @@ system Bellatrix
 system Belonging
 	pos -1007.59 658.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 625
 	belt 1407
 	link "Bright Void"
@@ -5220,7 +5220,7 @@ system Belonging
 system Belug
 	pos -1024.59 388.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 486.68
 	belt 1170
 	link Ekuarik
@@ -5290,7 +5290,7 @@ system Belug
 system Belugt
 	pos -838.587 668.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 486.68
 	belt 1517
 	link Gupta
@@ -5365,7 +5365,7 @@ system Belugt
 system "Beta Lupi"
 	pos -851 417
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 625
 	belt 1261
 	haze _menu/haze-33
@@ -5424,7 +5424,7 @@ system "Beta Lupi"
 system Betelgeuse
 	pos -384 -322
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 1080
 	belt 1641
 	haze _menu/haze-67
@@ -5499,7 +5499,7 @@ system Betelgeuse
 system Bloptab
 	pos -813.587 727.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 1080
 	belt 1061
 	link Blugtad
@@ -5560,7 +5560,7 @@ system Bloptab
 system Blubipad
 	pos -650.587 594.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 1080
 	belt 1567
 	haze _menu/haze-133
@@ -5617,7 +5617,7 @@ system Blubipad
 system Blugtad
 	pos -771.587 680.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 625
 	belt 1841
 	haze _menu/haze-133
@@ -5690,7 +5690,7 @@ system Blugtad
 system Boral
 	pos -502 331
 	government Republic
-	attributes "human space" "dirt belt" "fringe"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 214.375
 	belt 1867
 	link Alphecca
@@ -5906,7 +5906,7 @@ system "Bote Asu"
 system "Bright Void"
 	pos -1059.59 605.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 2795
 	belt 1385
 	haze _menu/haze-67
@@ -5987,7 +5987,7 @@ system "Bright Void"
 system "Broken Bowl"
 	pos -956.587 566.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 1080
 	belt 1648
 	haze _menu/haze-67
@@ -6115,7 +6115,7 @@ system Caeculus
 system Canopus
 	pos -421 -225
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 214.375
 	belt 1530
 	haze _menu/haze-67
@@ -6162,7 +6162,7 @@ system Canopus
 system Capella
 	pos -378 -13
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 455.625
 	belt 1722
 	haze _menu/haze-67
@@ -6233,7 +6233,7 @@ system Capella
 system Caph
 	pos -295 77
 	government Syndicate
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 670
 	belt 1173
 	link Sol
@@ -6297,7 +6297,7 @@ system Caph
 system Cardax
 	pos -211 -215
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 1705
 	belt 1228
 	link Moktar
@@ -6425,7 +6425,7 @@ system Cardea
 system Castor
 	pos -452 -17
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 1715
 	belt 1675
 	haze _menu/haze-67
@@ -6510,7 +6510,7 @@ system Castor
 system Cebalrai
 	pos -461 282
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 625
 	belt 1955
 	link Rutilicus
@@ -6571,7 +6571,7 @@ system Cebalrai
 system Celeborim
 	pos 181.431 -633.812
 	government "Kor Sestor"
-	attributes "korath space" "fringe"
+	attributes "!korath" "!automata" "!fringe"
 	habitable 320
 	belt 1296
 	link Asikafarnut
@@ -6630,7 +6630,7 @@ system Celeborim
 system Chikatip
 	pos -77.5695 -307.812
 	government Uninhabited
-	attributes "korath space" "fringe"
+	attributes "!korath" "!fringe"
 	habitable 425.92
 	belt 1929
 	link Furmeliki
@@ -6686,7 +6686,7 @@ system Chikatip
 system Chimitarp
 	pos 150.431 -287.812
 	government "Kor Mereti"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 912.6
 	belt 1932
 	haze _menu/haze-133
@@ -6759,7 +6759,7 @@ system Chimitarp
 system Chirr'ay'akai
 	pos -102.761 -749.614
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 486.68
 	belt 1425
 	haze _menu/haze-33
@@ -6809,7 +6809,7 @@ system Chirr'ay'akai
 system Chornifath
 	pos 40.4305 -214.812
 	government Uninhabited
-	attributes "korath space" "fringe"
+	attributes "!korath" "!fringe"
 	habitable 486.68
 	belt 1434
 	haze _menu/haze-133
@@ -6870,7 +6870,7 @@ system Chornifath
 system Chy'chra
 	pos 85.5308 -829.667
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 625
 	belt 1120
 	haze _menu/haze-33
@@ -7169,7 +7169,7 @@ system Convector
 system "Cor Caroli"
 	pos -682 201
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1474
 	link Vindemiatrix
@@ -7228,7 +7228,7 @@ system "Cor Caroli"
 system "Da Ent"
 	pos -6.22391 -462.536
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 233.28
 	belt 1161
 	link "Ya Hai"
@@ -7289,7 +7289,7 @@ system "Da Ent"
 system "Da Lest"
 	pos -23.2239 -413.536
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 320
 	belt 1108
 	link "Lom Tahr"
@@ -7344,7 +7344,7 @@ system "Da Lest"
 system Dabih
 	pos -253 427
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 670
 	belt 1088
 	haze _menu/haze-133
@@ -7404,7 +7404,7 @@ system Dabih
 system Danoa
 	pos -239 -321
 	government Republic
-	attributes "human space" "far north" "fringe"
+	attributes "!human" "!north" "!fringe"
 	habitable 135
 	belt 1689
 	haze _menu/haze-67
@@ -7473,7 +7473,7 @@ system Danoa
 system "Dark Hills"
 	pos -926.587 619.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 1080
 	belt 1367
 	link Beginning
@@ -7540,7 +7540,7 @@ system "Dark Hills"
 system Debrugt
 	pos -869.587 513.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 640
 	belt 1224
 	link Torbab
@@ -7689,7 +7689,7 @@ system Delia
 system "Delta Capricorni"
 	pos -285 202
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 839.375
 	belt 1329
 	haze _menu/haze-133
@@ -7752,7 +7752,7 @@ system "Delta Capricorni"
 system "Delta Sagittarii"
 	pos -414 416
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1414
 	haze _menu/haze-133
@@ -7819,7 +7819,7 @@ system "Delta Sagittarii"
 system "Delta Velorum"
 	pos -740 90
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1221
 	haze _menu/haze-67
@@ -7878,7 +7878,7 @@ system "Delta Velorum"
 system Deneb
 	pos -348 225
 	government Pug
-	attributes "human space" "isolated"
+	attributes "!human" "!isolated"
 	habitable 625
 	belt 1890
 	haze _menu/haze-133
@@ -7934,7 +7934,7 @@ system Deneb
 system Denebola
 	pos -478 70
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 534.375
 	belt 1050
 	haze _menu/haze-67
@@ -8035,7 +8035,7 @@ system Diespiter
 system Diphda
 	pos -262 61
 	government Syndicate
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 590.625
 	belt 1559
 	haze _menu/haze-133
@@ -8168,7 +8168,7 @@ system Dixere
 system Dokdobaru
 	pos -21.5695 -241.812
 	government Quarg
-	attributes "korath space" "ringworld"
+	attributes "!korath" "!efreti" "!ringworld"
 	habitable 700
 	belt 1935
 	haze _menu/haze-133
@@ -8273,7 +8273,7 @@ system Dokdobaru
 system Dschubba
 	pos -598 501
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 398.125
 	belt 1429
 	link Atria
@@ -8347,7 +8347,7 @@ system Dschubba
 system Dubhe
 	pos -577 -103
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 349.375
 	belt 1120
 	link Zosma
@@ -8404,7 +8404,7 @@ system Dubhe
 system "Due Yoot"
 	pos -167.547 -426.683
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 233.28
 	belt 1854
 	link "Wah Oh"
@@ -8469,7 +8469,7 @@ system "Due Yoot"
 system Durax
 	pos -59 -90
 	government Pirate
-	attributes "human space" "the core" "fringe"
+	attributes "!human" "!core" "!fringe"
 	habitable 1080
 	belt 1287
 	haze _menu/haze-133
@@ -8534,7 +8534,7 @@ system Durax
 system Eber
 	pos -532 406
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1199
 	link Alnasl
@@ -8598,7 +8598,7 @@ system Eber
 system Eblumab
 	pos -767.587 703.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 425.92
 	belt 1804
 	haze _menu/haze-133
@@ -8751,7 +8751,7 @@ system Egeria
 system "Ehma Ti"
 	pos 39.1085 -749.244
 	government "Hai (Unfettered)"
-	attributes
+	attributes "!hai"
 	habitable 486.68
 	belt 1094
 	link "Wah Yoot"
@@ -8819,7 +8819,7 @@ system "Ehma Ti"
 system Ek'kek'ru
 	pos -287.517 -727.738
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 320
 	belt 1517
 	haze _menu/haze-none
@@ -8879,7 +8879,7 @@ system Ek'kek'ru
 system Ekuarik
 	pos -1029.63 426.214
 	government Heliarch
-	attributes
+	attributes "!coalition"
 	habitable 700
 	belt 1711
 	link "Ki War Ek"
@@ -9062,7 +9062,7 @@ system Ekuarik
 system Elnath
 	pos -288 -77
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 1715
 	belt 1462
 	link Acamar
@@ -9127,7 +9127,7 @@ system Elnath
 system Eltanin
 	pos -328 433
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 455.625
 	belt 1859
 	haze _menu/haze-133
@@ -9187,7 +9187,7 @@ system Eltanin
 system Eneremprukt
 	pos 311.431 -448.812
 	government "Kor Sestor"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 486.68
 	belt 1421
 	link Silikatakfar
@@ -9243,7 +9243,7 @@ system Eneremprukt
 system Enif
 	pos -177 498
 	government Quarg
-	attributes "human space" "the south" "ringworld"
+	attributes "!human" "!south" "!ringworld"
 	habitable 700
 	belt 1974
 	link Sadalmelik
@@ -9332,7 +9332,7 @@ system Enif
 system "Epsilon Leonis"
 	pos -619 -229
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 1400
 	belt 1527
 	link Gomeisa
@@ -9407,7 +9407,7 @@ system "Epsilon Leonis"
 system Es'sprak'ai
 	pos -469.044 -733.375
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 486.68
 	belt 1928
 	haze _menu/haze-none
@@ -9468,7 +9468,7 @@ system Es'sprak'ai
 system Eshkoshtar
 	pos 156.431 -381.812
 	government "Kor Mereti"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 806.68
 	belt 1105
 	link Mekislepti
@@ -9602,7 +9602,7 @@ system Esix
 system Eteron
 	pos -330 33
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 135
 	belt 1479
 	link Sirius
@@ -9667,7 +9667,7 @@ system Eteron
 system "Fah Root"
 	pos -264.065 -400.135
 	government Hai
-	attributes "fringe"
+	attributes "!hai" "!fringe"
 	habitable 486.68
 	belt 1057
 	haze _menu/haze-67
@@ -9736,7 +9736,7 @@ system "Fah Root"
 system "Fah Soom"
 	pos -179.891 -335.011
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 425.92
 	belt 1185
 	haze _menu/haze-67
@@ -9797,7 +9797,7 @@ system "Fah Soom"
 system Fala
 	pos -690 64
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 625
 	belt 1264
 	link "Tania Australis"
@@ -9858,7 +9858,7 @@ system Fala
 system "Fallen Leaf"
 	pos -903.587 717.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 320
 	belt 1327
 	link Beginning
@@ -9911,7 +9911,7 @@ system "Fallen Leaf"
 system "Far Horizon"
 	pos -1108.59 726.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 320
 	belt 1242
 	haze _menu/haze-67
@@ -9967,7 +9967,7 @@ system "Far Horizon"
 system Farbutero
 	pos 93.4305 -251.812
 	government Uninhabited
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 625
 	belt 1175
 	haze _menu/haze-133
@@ -10113,7 +10113,7 @@ system Farinus
 system Faronektu
 	pos 292.431 -309.812
 	government "Kor Mereti"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 1080
 	belt 1630
 	haze _menu/haze-133
@@ -10181,7 +10181,7 @@ system Faronektu
 system Fasitopfar
 	pos 92.4305 -105.812
 	government Uninhabited
-	attributes "archon" "korath space" "isolated" "!nova"
+	attributes "archon" "!korath" "!isolated" "!nova"
 	habitable 100
 	belt 1670
 	haze _menu/haze-blackbody
@@ -10289,7 +10289,7 @@ system Fearis
 system "Fell Omen"
 	pos -1156.59 475.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 425.92
 	belt 1240
 	link "Last Word"
@@ -10480,7 +10480,7 @@ system Fereti
 system Feroteri
 	pos 149.431 -205.812
 	government Uninhabited
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 5425.92
 	belt 1419
 	haze _menu/haze-blackbody
@@ -10564,7 +10564,7 @@ system Feroteri
 system Ferukistek
 	pos 307.431 -515.812
 	government "Kor Sestor"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 486.68
 	belt 1520
 	link Eneremprukt
@@ -10618,7 +10618,7 @@ system Ferukistek
 system Fingol
 	pos -482 113
 	government Republic
-	attributes "human space" "near earth" "fringe"
+	attributes "!human" "!near earth" "!fringe"
 	habitable 135
 	belt 1976
 	haze _menu/haze-none
@@ -10676,7 +10676,7 @@ system Fingol
 system Flugbu
 	pos -903.587 534.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 425.92
 	belt 1843
 	link Torbab
@@ -10741,7 +10741,7 @@ system Flugbu
 system Fomalhaut
 	pos -314 124
 	government Syndicate
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 455.625
 	belt 1854
 	link Altair
@@ -10804,7 +10804,7 @@ system Fomalhaut
 system Fornarep
 	pos 79.4305 -309.812
 	government Uninhabited
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 320
 	belt 1922
 	haze _menu/haze-133
@@ -10871,7 +10871,7 @@ system Fornarep
 system "Four Pillars"
 	pos -1210.59 772.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 486.68
 	belt 1061
 	link "Far Horizon"
@@ -10933,7 +10933,7 @@ system "Four Pillars"
 system Furmeliki
 	pos -35.5695 -281.812
 	government Uninhabited
-	attributes "korath space"
+	attributes "!korath" "!efreti"
 	habitable 486.68
 	belt 1577
 	link Dokdobaru
@@ -10995,7 +10995,7 @@ system Furmeliki
 system Gacrux
 	pos -713 184
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 534.375
 	belt 1188
 	link "Cor Caroli"
@@ -11063,7 +11063,7 @@ system Gacrux
 system "Gamma Cassiopeiae"
 	pos -116 293
 	government Syndicate
-	attributes "human space" "the core" "fringe"
+	attributes "!human" "!core" "!fringe"
 	habitable 455.625
 	belt 1779
 	haze _menu/haze-133
@@ -11122,7 +11122,7 @@ system "Gamma Cassiopeiae"
 system "Gamma Corvi"
 	pos -906 64
 	government Republic
-	attributes "the rim"
+	attributes "!coalition" "!rim"
 	habitable 1535.62
 	belt 1556
 	haze _menu/haze-none
@@ -11245,7 +11245,7 @@ system Gerenus
 system Gienah
 	pos -176 354
 	government Pirate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 534.375
 	belt 1939
 	link Persian
@@ -11380,7 +11380,7 @@ system Giribea
 system Girtab
 	pos -430 481
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 1080
 	belt 1387
 	link Lesath
@@ -11445,7 +11445,7 @@ system Girtab
 system Glubatub
 	pos -650.587 693.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 233.28
 	belt 1093
 	link "Sol Arach"
@@ -11523,7 +11523,7 @@ system Glubatub
 system Gomeisa
 	pos -600 -161
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 911.25
 	belt 1616
 	link Zosma
@@ -11593,7 +11593,7 @@ system Gomeisa
 system "Good Omen"
 	pos -941.587 746.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 1715
 	belt 1598
 	haze _menu/haze-67
@@ -11655,7 +11655,7 @@ system "Good Omen"
 system Gorvi
 	pos -250 -483
 	government Republic
-	attributes "human space" "far north" "fringe"
+	attributes "!human" "!north" "!fringe"
 	habitable 670
 	belt 1345
 	haze _menu/haze-133
@@ -11713,7 +11713,7 @@ system Gorvi
 system Graffias
 	pos -784 517
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 911.25
 	belt 1977
 	link Alniyat
@@ -11777,7 +11777,7 @@ system Graffias
 system Gupta
 	pos -808.587 625.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 912.6
 	belt 1771
 	link Ablodab
@@ -11838,7 +11838,7 @@ system Gupta
 system Hadar
 	pos -788 283
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 455.625
 	belt 1520
 	link "Zeta Centauri"
@@ -11898,7 +11898,7 @@ system Hadar
 system Hamal
 	pos -129 24
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 1080
 	belt 1241
 	haze _menu/haze-133
@@ -11953,7 +11953,7 @@ system Hamal
 system Han
 	pos -610 561
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 1080.62
 	belt 1517
 	link Alniyat
@@ -12012,7 +12012,7 @@ system Han
 system Hassaleh
 	pos -291 -287
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 670
 	belt 1924
 	haze _menu/haze-67
@@ -12073,7 +12073,7 @@ system Hassaleh
 system Hatysa
 	pos -474 -542
 	government Pirate
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 533.75
 	belt 1163
 	haze _menu/haze-33
@@ -12134,7 +12134,7 @@ system Hatysa
 system "Heia Due"
 	pos -146.177 -481.694
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 1215
 	belt 1079
 	haze _menu/haze-67
@@ -12206,7 +12206,7 @@ system "Heia Due"
 system Hesselpost
 	pos -30.5695 -187.812
 	government Uninhabited
-	attributes "korath space" "fringe"
+	attributes "!korath" "!efreti" "!fringe"
 	habitable 486.68
 	belt 1327
 	haze _menu/haze-133
@@ -12277,7 +12277,7 @@ system Hesselpost
 system "Hevru Hai"
 	pos -189 -310
 	government Quarg
-	attributes "ringworld"
+	attributes "!hai" "!ringworld"
 	habitable 700
 	belt 1245
 	link "Fah Soom"
@@ -12392,7 +12392,7 @@ system "Hevru Hai"
 system "Hi Yahr"
 	pos 82.3672 -641.6
 	government "Hai (Unfettered)"
-	attributes
+	attributes "!hai"
 	habitable 625
 	belt 1655
 	link "Wah Yoot"
@@ -12450,7 +12450,7 @@ system "Hi Yahr"
 system Hintar
 	pos -422 311
 	government Republic
-	attributes "human space" "dirt belt" "fringe"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 625
 	belt 1725
 	haze _menu/haze-133
@@ -12510,7 +12510,7 @@ system Hintar
 system Holeb
 	pos -590 287
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 1715
 	belt 1181
 	link Alioth
@@ -12558,7 +12558,7 @@ system Holeb
 system Homeward
 	pos -1045.59 477.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 425.92
 	belt 1499
 	link "Silver Bell"
@@ -12624,7 +12624,7 @@ system Homeward
 system Host
 	pos 384.431 -543.812
 	government Uninhabited
-	attributes "isolated"
+	attributes "!isolated"
 	habitable 486.68
 	belt 1669
 	asteroids "large metal" 1 0.732
@@ -12673,7 +12673,7 @@ system Host
 system Hunter
 	pos -968.587 590.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 425.92
 	belt 1498
 	link "Bright Void"
@@ -12735,7 +12735,7 @@ system Hunter
 system Ik'kara'ka
 	pos 56.2159 -888.296
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 625
 	belt 1497
 	haze _menu/haze-none
@@ -12797,7 +12797,7 @@ system Ik'kara'ka
 system Ildaria
 	pos -702 317
 	government Republic
-	attributes "human space" "the rim" "!wolf-rayet" "fringe"
+	attributes "!human" "!rim" "!wolf-rayet" "!fringe"
 	habitable 625
 	belt 1132
 	haze _menu/haze-133
@@ -12851,7 +12851,7 @@ system Ildaria
 system "Imo Dep"
 	pos -56.2764 -600.1
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 1715
 	belt 1416
 	haze _menu/haze-67
@@ -12976,7 +12976,7 @@ system Insitor
 system "Io Lowe"
 	pos -94.7566 -527.728
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 135
 	belt 1552
 	haze _menu/haze-67
@@ -13038,7 +13038,7 @@ system "Io Lowe"
 system "Io Mann"
 	pos -192.955 -447.669
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 973.36
 	belt 1132
 	haze _menu/haze-67
@@ -13113,7 +13113,7 @@ system "Io Mann"
 system Ipsing
 	pos -549 160
 	government Republic
-	attributes "human space" "dirt belt" "fringe"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 1400
 	belt 1107
 	haze _menu/haze-67
@@ -13180,7 +13180,7 @@ system Ipsing
 system Iyech'yek
 	pos -277.37 -693.913
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 320
 	belt 1613
 	haze _menu/haze-33
@@ -13234,7 +13234,7 @@ system Iyech'yek
 system Izar
 	pos -784 231
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 1294.38
 	belt 1449
 	haze _menu/haze-67
@@ -13299,7 +13299,7 @@ system Izar
 system Ka'ch'chrai
 	pos -240.163 -822.448
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 425.92
 	belt 1745
 	haze _menu/haze-none
@@ -13357,7 +13357,7 @@ system Ka'ch'chrai
 system Ka'pru
 	pos -76.6756 -994.955
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 1505.92
 	belt 1808
 	haze _menu/haze-33
@@ -13428,7 +13428,7 @@ system Ka'pru
 system Kaliptari
 	pos 85.4305 -402.812
 	government Uninhabited
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 320
 	belt 1089
 	link Skeruto
@@ -13503,7 +13503,7 @@ system Kaliptari
 system "Kappa Centauri"
 	pos -867 480
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 1215
 	belt 1508
 	link Pherkad
@@ -13564,7 +13564,7 @@ system "Kappa Centauri"
 system Kashikt
 	pos -73.5695 -219.812
 	government "Kor Efret"
-	attributes "korath space"
+	attributes "!korath" "!efreti"
 	habitable 1715
 	belt 1013
 	link Dokdobaru
@@ -13632,7 +13632,7 @@ system Kashikt
 system Kasikfar
 	pos 10.4305 -127.812
 	government Uninhabited
-	attributes "archon" "isolated" "korath space" "!nova"
+	attributes "archon" "!isolated" "!korath" "!nova"
 	habitable 100
 	belt 1539
 	haze _menu/haze-blackbody
@@ -13673,7 +13673,7 @@ system Kasikfar
 system "Kaus Australis"
 	pos -284 395
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1281
 	haze _menu/haze-133
@@ -13725,7 +13725,7 @@ system "Kaus Australis"
 system "Kaus Borealis"
 	pos -456 350
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 590.625
 	belt 1074
 	haze _menu/haze-133
@@ -13788,7 +13788,7 @@ system "Kaus Borealis"
 system "Ki War Ek"
 	pos -1106.63 368.214
 	government Heliarch
-	attributes "ringworld"
+	attributes "!coalition" "!ringworld"
 	habitable 700
 	belt 1777
 	haze _menu/haze-133
@@ -14007,7 +14007,7 @@ system "Ki War Ek"
 system Kiro'ku
 	pos -131.923 -884.46
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 1111.68
 	belt 1308
 	haze _menu/haze-none
@@ -14084,7 +14084,7 @@ system Kiro'ku
 system Kiru'kichi
 	pos -195.063 -662.343
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 2795
 	belt 1465
 	haze _menu/haze-33
@@ -14144,7 +14144,7 @@ system Kiru'kichi
 system Kochab
 	pos -731 279
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 320
 	belt 1912
 	haze _menu/haze-67
@@ -14188,7 +14188,7 @@ system Kochab
 system "Kor Ak'Mari"
 	pos 43 42
 	government Korath
-	attributes "korath space" "isolated"
+	attributes "!korath" "!exiles" "!isolated" "!wolf-rayet"
 	habitable 625
 	belt 1606
 	haze _menu/haze-full
@@ -14239,7 +14239,7 @@ system "Kor Ak'Mari"
 system "Kor En'lakfar"
 	pos -31 -33
 	government Korath
-	attributes "korath space" "!exiles"
+	attributes "!korath" "!exiles"
 	habitable 1080
 	belt 1115
 	haze _menu/haze-133
@@ -14301,7 +14301,7 @@ system "Kor En'lakfar"
 system "Kor Fel'tar"
 	pos 29 -66
 	government Korath
-	attributes "korath space" "!exiles"
+	attributes "!korath" "!exiles"
 	habitable 455.625
 	belt 1444
 	haze _menu/haze-blackbody
@@ -14367,7 +14367,7 @@ system "Kor Fel'tar"
 system "Kor Men"
 	pos 6 -5
 	government Korath
-	attributes "korath space" "!exiles"
+	attributes "!korath" "!exiles"
 	habitable 2340
 	belt 1260
 	haze _menu/haze-blackbody
@@ -14430,7 +14430,7 @@ system "Kor Men"
 system "Kor Nor'peli"
 	pos 52 160
 	government Korath
-	attributes "korath space" "!exiles"
+	attributes "!korath" "!exiles"
 	habitable 590.625
 	belt 1213
 	haze _menu/haze-blackbody
@@ -14495,7 +14495,7 @@ system "Kor Nor'peli"
 system "Kor Tar'bei"
 	pos 57 106
 	government Korath
-	attributes "korath space" "!exiles"
+	attributes "!korath" "!exiles"
 	habitable 214.375
 	belt 1614
 	haze _menu/haze-blackbody
@@ -14552,7 +14552,7 @@ system "Kor Tar'bei"
 system "Kor Zena'i"
 	pos -2 83
 	government Korath
-	attributes "korath space" "!exiles"
+	attributes "!korath" "!exiles"
 	habitable 703.125
 	belt 1866
 	haze _menu/haze-blackbody
@@ -14605,7 +14605,7 @@ system "Kor Zena'i"
 system Kornephoros
 	pos -612 424
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 911.25
 	belt 1168
 	link Sabik
@@ -14686,7 +14686,7 @@ system Kornephoros
 system Korsmanath
 	pos 97.4305 -185.812
 	government Uninhabited
-	attributes "korath space" "fringe"
+	attributes "!korath" "!automata" "!fringe"
 	habitable 486.68
 	belt 1775
 	link Feroteri
@@ -14746,7 +14746,7 @@ system Korsmanath
 system Kraz
 	pos -876 204
 	government Republic
-	attributes "human space" "the rim" 
+	attributes "!human" "!rim" 
 	habitable 1080
 	belt 1056
 	haze _menu/haze-67
@@ -14813,7 +14813,7 @@ system Kraz
 system Kugel
 	pos -230 -26
 	government Syndicate
-	attributes "human space" "the core" "fringe"
+	attributes "!human" "!core" "!fringe"
 	habitable 625
 	belt 1051
 	link Acamar
@@ -14882,7 +14882,7 @@ system Kugel
 system Kursa
 	pos -366 -105
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 455
 	belt 1624
 	haze _menu/haze-67
@@ -14999,7 +14999,7 @@ system "Last Word"
 system Lesath
 	pos -516 485
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 1715
 	belt 1865
 	link Atria
@@ -15132,7 +15132,7 @@ system Levana
 system Limen
 	pos -791.99 -12.2491
 	government Republic
-	attributes "human space" "dirt belt" "fringe"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 1715
 	belt 1463
 	haze _menu/haze-33
@@ -15246,7 +15246,7 @@ system Lire
 system Lolami
 	pos -628 -10
 	government Republic
-	attributes "human space" "dirt belt" "fringe"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 1215
 	belt 1072
 	link "Tania Australis"
@@ -15310,7 +15310,7 @@ system Lolami
 system "Lom Tahr"
 	pos -94.0437 -446.586
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 2372.76
 	belt 1445
 	link "Ya Hai"
@@ -15386,7 +15386,7 @@ system "Lom Tahr"
 system "Lone Cloud"
 	pos -1239.59 747.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 233.28
 	belt 1730
 	link "Four Pillars"
@@ -15437,7 +15437,7 @@ system "Lone Cloud"
 system Lucina
 	pos 175.504 176.389
 	government Uninhabited
-	attributes "ember waste" "fringe"
+	attributes "ember waste" "!fringe"
 	habitable 320
 	belt 1466
 	haze _menu/haze-red
@@ -15493,7 +15493,7 @@ system Lucina
 system Lurata
 	pos -279 463
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 455.625
 	belt 1151
 	haze _menu/haze-133
@@ -15556,7 +15556,7 @@ system Lurata
 system Makferuti
 	pos 288.431 -628.812
 	government "Kor Sestor"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 621.68
 	belt 1782
 	link Asikafarnut
@@ -15632,7 +15632,7 @@ system Makferuti
 system Markab
 	pos -241 168
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 625
 	belt 1411
 	haze _menu/haze-133
@@ -15715,7 +15715,7 @@ system Markab
 system Markeb
 	pos -602 -305
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 455.625
 	belt 1556
 	haze _menu/haze-33
@@ -15780,7 +15780,7 @@ system Markeb
 system Matar
 	pos -218 272
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 455.625
 	belt 1308
 	haze _menu/haze-133
@@ -15838,7 +15838,7 @@ system Matar
 system Mebla
 	pos -814.587 555.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 486.68
 	belt 1114
 	link Debrugt
@@ -15896,7 +15896,7 @@ system Mebla
 system Mebsuta
 	pos -482 -394
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 670
 	belt 1740
 	haze _menu/haze-33
@@ -15972,7 +15972,7 @@ system Mebsuta
 system Meftarkata
 	pos 52.4305 -276.812
 	government Uninhabited
-	attributes "korath space"
+	attributes "!korath"
 	habitable 2201.68
 	belt 1232
 	haze _menu/haze-133
@@ -16034,7 +16034,7 @@ system Meftarkata
 system "Mei Yohn"
 	pos -106.757 -581.698
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 425.92
 	belt 1075
 	haze _menu/haze-67
@@ -16100,7 +16100,7 @@ system "Mei Yohn"
 system Mekislepti
 	pos 137.431 -335.812
 	government "Kor Mereti"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 1705
 	belt 1673
 	haze _menu/haze-133
@@ -16164,7 +16164,7 @@ system Mekislepti
 system Meblumem
 	pos -722.587 616.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 2201.68
 	belt 1794
 	link "Sol Arach"
@@ -16229,7 +16229,7 @@ system Meblumem
 system Men
 	pos -888 361
 	government Pirate
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 320
 	belt 1531
 	haze _menu/haze-33
@@ -16295,7 +16295,7 @@ system Men
 system Menkalinan
 	pos -400 -61
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 3430
 	belt 1424
 	haze _menu/haze-67
@@ -16363,7 +16363,7 @@ system Menkalinan
 system Menkar
 	pos -183 -52
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 455.625
 	belt 1634
 	haze _menu/haze-133
@@ -16426,7 +16426,7 @@ system Menkar
 system Menkent
 	pos -495 218
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 2340
 	belt 1728
 	link Vega
@@ -16497,7 +16497,7 @@ system Menkent
 system Merak
 	pos -553 60
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 1080.62
 	belt 1769
 	haze _menu/haze-67
@@ -16562,7 +16562,7 @@ system Merak
 system Mesuket
 	pos 220.431 -409.812
 	government Uninhabited
-	attributes "korath space"  "warzone"
+	attributes "!korath" "!automata" "!warzone"
 	habitable 425.92
 	belt 1189
 	link Eshkoshtar
@@ -16629,7 +16629,7 @@ system Mesuket
 system Miaplacidus
 	pos -524 -69
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 455.625
 	belt 1236
 	link Tejat
@@ -16704,7 +16704,7 @@ system Miaplacidus
 system Miblulub
 	pos -630.587 670.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 1080
 	belt 1757
 	haze _menu/haze-133
@@ -16786,7 +16786,7 @@ system Miblulub
 system Mimosa
 	pos -895 168
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 320
 	belt 1484
 	haze _menu/haze-67
@@ -16837,7 +16837,7 @@ system Mimosa
 system Minkar
 	pos -823 138
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 670
 	belt 1354
 	haze _menu/haze-67
@@ -16903,7 +16903,7 @@ system Minkar
 system Mintaka
 	pos -304 -462
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 775.625
 	belt 1753
 	haze _menu/haze-67
@@ -16967,7 +16967,7 @@ system Mintaka
 system Mirach
 	pos -166 250
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 292.5
 	belt 1980
 	haze _menu/haze-133
@@ -17036,7 +17036,7 @@ system Mirach
 system Mirfak
 	pos -187 -128
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 320
 	belt 1887
 	link Menkar
@@ -17092,7 +17092,7 @@ system Mirfak
 system Mirzam
 	pos -498 -301
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 1080
 	belt 1025
 	haze _menu/haze-67
@@ -17154,7 +17154,7 @@ system Mirzam
 system Mizar
 	pos -579 184
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1876
 	haze _menu/haze-67
@@ -17207,7 +17207,7 @@ system Mizar
 system Moktar
 	pos -169 -170
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 455
 	belt 1888
 	link Oblate
@@ -17275,7 +17275,7 @@ system Moktar
 system Mora
 	pos -755 23
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1176
 	haze _menu/haze-67
@@ -17336,7 +17336,7 @@ system Mora
 system Muhlifain
 	pos -702 242
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 455.625
 	belt 1265
 	haze _menu/haze-67
@@ -17383,7 +17383,7 @@ system Muhlifain
 system Muphrid
 	pos -495 152
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 839.375
 	belt 1759
 	link Menkent
@@ -17441,7 +17441,7 @@ system Muphrid
 system Naos
 	pos -653 -396
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 625
 	belt 1045
 	haze _menu/haze-67
@@ -17515,7 +17515,7 @@ system Naos
 system Naper
 	pos -416 369
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 1715
 	belt 1445
 	link Ascella
@@ -17654,7 +17654,7 @@ system Nenia
 system Nihal
 	pos -262 -121
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 534.375
 	belt 1329
 	link Elnath
@@ -17727,7 +17727,7 @@ system Nihal
 system Nocte
 	pos -467 172
 	government Republic
-	attributes "human space" "near earth" "fringe"
+	attributes "!human" "!near earth" "!fringe"
 	habitable 135
 	belt 1304
 	link Vega
@@ -17846,7 +17846,7 @@ system Nona
 system Nunki
 	pos -393 537
 	government Pirate
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 214.375
 	belt 1930
 	link Albaldah
@@ -17916,7 +17916,7 @@ system Nunki
 system Oblate
 	pos -124 -119
 	government Pirate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 12000
 	belt 1704
 	haze _menu/haze-133
@@ -17975,7 +17975,7 @@ system Oblate
 system Orbona
 	pos -735.99 -97.2491
 	government Republic
-	attributes "human space" "dirt belt" "fringe"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 2859.44
 	belt 1507
 	haze _menu/haze-67
@@ -18047,7 +18047,7 @@ system Orbona
 system Orvala
 	pos -334 303
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 533.75
 	belt 1431
 	link "Zeta Aquilae"
@@ -18404,7 +18404,7 @@ system Parca
 system Peacock
 	pos -307 350
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 214.375
 	belt 1870
 	haze _menu/haze-133
@@ -18479,7 +18479,7 @@ system Peacock
 system Pelubta
 	pos -757.587 575.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 9265
 	belt 1709
 	link Meblumem
@@ -18621,7 +18621,7 @@ system Peragenor
 system Peresedersi
 	pos 81.4305 -154.812
 	government Uninhabited
-	attributes "archon" "korath space" "isolated" "!nova"
+	attributes "archon" "!korath" "!isolated" "!nova"
 	habitable 100
 	belt 1065
 	haze _menu/haze-blackbody
@@ -18716,7 +18716,7 @@ system Perfica
 system Persian
 	pos -203 331
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 2170.62
 	belt 1308
 	haze _menu/haze-133
@@ -18784,7 +18784,7 @@ system Persian
 system Persitar
 	pos 297.431 -395.812
 	government Uninhabited
-	attributes "korath space" "isolated" "!nova"
+	attributes "!korath" "!isolated" "!nova"
 	habitable 100
 	belt 1948
 	haze _menu/haze-blackbody
@@ -18821,7 +18821,7 @@ system Persitar
 system Phact
 	pos -375 -191
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 1080.62
 	belt 1704
 	haze _menu/haze-67
@@ -18894,7 +18894,7 @@ system Phact
 system Phecda
 	pos -607 88
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1375
 	link Algorel
@@ -18952,7 +18952,7 @@ system Phecda
 system Pherkad
 	pos -798 451
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 135
 	belt 1924
 	haze _menu/haze-67
@@ -19008,7 +19008,7 @@ system Pherkad
 system Phurad
 	pos -494 -153
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 1080
 	belt 1881
 	link Tejat
@@ -19068,7 +19068,7 @@ system Phurad
 system Pik'ro'iyak
 	pos -378.845 -677.001
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 233.28
 	belt 1279
 	haze _menu/haze-none
@@ -19117,7 +19117,7 @@ system Pik'ro'iyak
 system Plort
 	pos -708.587 723.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 320
 	belt 1490
 	link "Sol Arach"
@@ -19295,7 +19295,7 @@ system Polerius
 system Pollux
 	pos -465 4
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 1080
 	belt 1161
 	haze _menu/haze-67
@@ -19350,7 +19350,7 @@ system Pollux
 system Porrima
 	pos -556 123
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 760
 	belt 1636
 	haze _menu/haze-67
@@ -19451,7 +19451,7 @@ system Postverta
 system Prakacha'a
 	pos -35.1114 -802.607
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 1505.92
 	belt 1637
 	haze _menu/haze-33
@@ -19530,7 +19530,7 @@ system Prakacha'a
 system Procyon
 	pos -411 23
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 455.625
 	belt 1763
 	haze _menu/haze-67
@@ -19629,7 +19629,7 @@ system Prosa
 system "Pug Iyik"
 	pos -361.149 -883.233
 	government "Pug (Wanderer)"
-	attributes "isolated"
+	attributes "!wanderer" "!isolated"
 	habitable 625
 	belt 1286
 	haze _menu/haze-blackbody
@@ -19687,7 +19687,7 @@ system "Pug Iyik"
 system Quaru
 	pos -1080.63 448.214
 	government Heliarch
-	attributes "ringworld"
+	attributes "!coalition" "!ringworld"
 	habitable 700
 	belt 1440
 	haze _menu/haze-133
@@ -20003,7 +20003,7 @@ system Queri
 system Rajak
 	pos -270 -236
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 78.125
 	belt 1410
 	haze _menu/haze-67
@@ -20071,7 +20071,7 @@ system Rajak
 system Rasalhague
 	pos -413 246
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 455.625
 	belt 1282
 	haze _menu/haze-133
@@ -20132,7 +20132,7 @@ system Rasalhague
 system Rastaban
 	pos -463 446
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 1080
 	belt 1041
 	haze _menu/haze-133
@@ -20193,7 +20193,7 @@ system Rastaban
 system "Rati Cal"
 	pos -116.765 -391.123
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 425.92
 	belt 1538
 	link "Due Yoot"
@@ -20247,7 +20247,7 @@ system "Rati Cal"
 system Regor
 	pos -702 -335
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 455.625
 	belt 1305
 	haze _menu/haze-67
@@ -20310,7 +20310,7 @@ system Regor
 system Regulus
 	pos -544 25
 	government Republic
-	attributes "human space" "near earth" "fringe"
+	attributes "!human" "!near earth" "!fringe"
 	habitable 8640
 	belt 1605
 	haze _menu/haze-67
@@ -20463,7 +20463,7 @@ system Relifer
 system Remembrance
 	pos -884.587 641.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 486.68
 	belt 1536
 	link Beginning
@@ -20520,7 +20520,7 @@ system Remembrance
 system Rigel
 	pos -324 -363
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 1080
 	belt 1782
 	link Saiph
@@ -20670,7 +20670,7 @@ system Ritilas
 system Ruchbah
 	pos -174 69
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 2560
 	belt 1598
 	haze _menu/haze-133
@@ -20742,7 +20742,7 @@ system Ruchbah
 system Rutilicus
 	pos -535 273
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 625
 	belt 1771
 	link Arcturus
@@ -20811,7 +20811,7 @@ system Rutilicus
 system Sabik
 	pos -675 379
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 625
 	belt 1609
 	link Unukalhai
@@ -20863,7 +20863,7 @@ system Sabik
 system Sabriset
 	pos 151.724 -426.518
 	government Uninhabited
-	attributes "korath space" "fringe"
+	attributes "!korath" "!fringe"
 	habitable 1566.68
 	belt 1025
 	link Sepriaptu
@@ -20917,7 +20917,7 @@ system Sabriset
 system Sadalmelik
 	pos -145 472
 	government Quarg
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 1715
 	belt 1273
 	link Enif
@@ -20973,7 +20973,7 @@ system Sadalmelik
 system Sadalsuud
 	pos -134 508
 	government Quarg
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 1400
 	belt 1859
 	link Enif
@@ -21035,7 +21035,7 @@ system Sadalsuud
 system Sadr
 	pos -287 543
 	government Republic
-	attributes "human space" "the south" "fringe"
+	attributes "!human" "!south" "!fringe"
 	habitable 3859.38
 	belt 1388
 	link Albireo
@@ -21100,7 +21100,7 @@ system Sadr
 system "Sagittarius A*"
 	pos 112 22
 	government Uninhabited
-	attributes "isolated"
+	attributes "!black hole" "!isolated"
 	habitable 10000
 	haze _menu/haze-full
 	object
@@ -21113,7 +21113,7 @@ system "Sagittarius A*"
 system Saiph
 	pos -375 -390
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 320
 	belt 1690
 	haze _menu/haze-33
@@ -21167,7 +21167,7 @@ system Saiph
 system Salipastart
 	pos 250.431 -370.812
 	government "Kor Mereti"
-	attributes "korath space"  "warzone"
+	attributes "!korath" "!automata" "!warzone"
 	habitable 486.68
 	belt 1056
 	haze _menu/haze-133
@@ -21234,7 +21234,7 @@ system Salipastart
 system Saquergen
 	pos -482 561
 	government Uninhabited
-	attributes "isolated" "!nova"
+	attributes "!isolated" "!nova"
 	habitable 100
 	belt 1435
 	asteroids "small rock" 3 3.9105
@@ -21263,7 +21263,7 @@ system Saquergen
 system Sargas
 	pos -542 445
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 911.25
 	belt 1642
 	link Kornephoros
@@ -21314,7 +21314,7 @@ system Sargas
 system Sarin
 	pos -670 293
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1752
 	link Vindemiatrix
@@ -21364,7 +21364,7 @@ system Sarin
 system Sayaiban
 	pos 250.431 -274.812
 	government Drak
-	attributes "archon" "korath space" "isolated"
+	attributes "archon" "!korath" "!hazard" "!isolated"
 	habitable 2035
 	belt 1803
 	asteroids "small rock" 13 2.106
@@ -21419,7 +21419,7 @@ system Sayaiban
 system Scheat
 	pos -205 233
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 625
 	belt 1536
 	haze _menu/haze-133
@@ -21477,7 +21477,7 @@ system Scheat
 system Schedar
 	pos -93 229
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 1080
 	belt 1903
 	haze _menu/haze-133
@@ -21612,7 +21612,7 @@ system Segesta
 system Seginus
 	pos -557 356
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 135
 	belt 1906
 	link Alnasl
@@ -21678,7 +21678,7 @@ system Seginus
 system Seketra
 	pos -24.5695 -356.812
 	government Uninhabited
-	attributes "korath space" "fringe"
+	attributes "!korath" "!fringe"
 	habitable 425.92
 	belt 1465
 	link Skeruto
@@ -21730,7 +21730,7 @@ system Seketra
 system Sepetrosk
 	pos 192.431 -243.812
 	government "Kor Mereti"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 486.68
 	belt 1286
 	link Chimitarp
@@ -21791,7 +21791,7 @@ system Sepetrosk
 system Sepriaptu
 	pos 139.431 -448.812
 	government Uninhabited
-	attributes "korath space" "fringe"
+	attributes "!korath" "!fringe"
 	habitable 2035
 	belt 1120
 	link Kaliptari
@@ -21843,7 +21843,7 @@ system Sepriaptu
 system Sevrelect
 	pos -114.569 -239.812
 	government "Kor Efret"
-	attributes "korath space"
+	attributes "!korath" "!efreti"
 	habitable 320
 	belt 1763
 	haze _menu/haze-67
@@ -21894,7 +21894,7 @@ system Sevrelect
 system Shaula
 	pos -460 527
 	government Pirate
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 625
 	belt 1814
 	link Lesath
@@ -21962,7 +21962,7 @@ system Shaula
 system Sheratan
 	pos -40 45
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 2035
 	belt 1183
 	haze _menu/haze-133
@@ -22022,7 +22022,7 @@ system Sheratan
 system Si'yak'ku
 	pos -329.235 -760.435
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 1313.28
 	belt 1985
 	haze _menu/haze-none
@@ -22103,7 +22103,7 @@ system Si'yak'ku
 system Sich'ka'ara
 	pos -97.1237 -831.921
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 1715
 	belt 1744
 	haze _menu/haze-none
@@ -22156,7 +22156,7 @@ system Sich'ka'ara
 system Silikatakfar
 	pos 248.431 -481.812
 	government "Kor Sestor"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 425.92
 	belt 1641
 	link Mesuket
@@ -22210,7 +22210,7 @@ system Silikatakfar
 system "Silver Bell"
 	pos -1045.59 541.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 1080
 	belt 1406
 	link "Bright Void"
@@ -22278,7 +22278,7 @@ system "Silver Bell"
 system "Silver String"
 	pos -1022.59 517.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 1080
 	belt 1986
 	link "Silver Bell"
@@ -22343,7 +22343,7 @@ system "Silver String"
 system Similisti
 	pos 210.431 -313.812
 	government "Kor Mereti"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 1080
 	belt 1349
 	haze _menu/haze-133
@@ -22411,7 +22411,7 @@ system Similisti
 system Sirius
 	pos -378 44
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 1800
 	belt 1407
 	link Sol
@@ -22475,7 +22475,7 @@ system Sirius
 system Skeruto
 	pos 28.4305 -339.812
 	government Uninhabited
-	attributes "korath space"
+	attributes "!korath"
 	habitable 320
 	belt 1198
 	link Furmeliki
@@ -22526,7 +22526,7 @@ system Skeruto
 system Sko'karak
 	pos -304.43 -930.688
 	government Wanderer
-	attributes
+	attributes "!wanderer"
 	habitable 320
 	belt 1805
 	haze _menu/haze-none
@@ -22579,7 +22579,7 @@ system Sko'karak
 system Sobarati
 	pos 277.431 -557.812
 	government "Kor Sestor"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 3780
 	belt 1314
 	link Asikafarnut
@@ -22641,7 +22641,7 @@ system Sobarati
 system Sol
 	pos -400 100
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 1080
 	belt 1529
 	haze _menu/haze-67
@@ -22721,7 +22721,7 @@ system Sol
 system "Sol Arach"
 	pos -711.587 649.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 486.68
 	belt 1147
 	haze _menu/haze-133
@@ -22793,7 +22793,7 @@ system "Sol Arach"
 system "Sol Kimek"
 	pos -1310.63 227.214
 	government Coalition
-	attributes "kimek space"
+	attributes "!coalition" "!kimek"
 	habitable 425.92
 	belt 1490
 	link "3 Pole"
@@ -22868,7 +22868,7 @@ system "Sol Kimek"
 system "Sol Saryd"
 	pos -1037.59 675.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 1313.28
 	belt 1720
 	link Belonging
@@ -22951,7 +22951,7 @@ system "Sol Saryd"
 system Solifar
 	pos 47.4305 -435.812
 	government Uninhabited
-	attributes "korath space"
+	attributes "!korath"
 	habitable 320
 	belt 1517
 	haze _menu/haze-67
@@ -23007,7 +23007,7 @@ system Solifar
 system Sospi
 	pos -317 -161
 	government Republic
-	attributes "human space" "far north" "fringe"
+	attributes "!human" "!north" "!fringe"
 	habitable 1715
 	belt 1715
 	haze _menu/haze-133
@@ -23073,7 +23073,7 @@ system Sospi
 system Speloog
 	pos -967.587 445.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 625
 	belt 1159
 	link Belug
@@ -23140,7 +23140,7 @@ system Speloog
 system Spica
 	pos -906 120
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 625
 	belt 1940
 	haze _menu/haze-33
@@ -23243,7 +23243,7 @@ system Statina
 system "Steep Roof"
 	pos -1113.59 570.051
 	government Coalition
-	attributes "saryd space"
+	attributes "!coalition" "!saryd"
 	habitable 1080
 	belt 1100
 	haze _menu/haze-67
@@ -23379,7 +23379,7 @@ system Stercutus
 system Suhail
 	pos -774 -338
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 1715
 	belt 1715
 	haze _menu/haze-33
@@ -23440,7 +23440,7 @@ system Suhail
 system Sumar
 	pos -236 -273
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 2560
 	belt 1778
 	link Cardax
@@ -23500,7 +23500,7 @@ system Sumar
 system Sumprast
 	pos -101.569 -262.812
 	government "Kor Efret"
-	attributes "korath space"
+	attributes "!korath" "!automata"
 	habitable 486.68
 	belt 1958
 	haze _menu/haze-67
@@ -23566,7 +23566,7 @@ system Sumprast
 system Tais
 	pos -346 381
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 3645
 	belt 1379
 	haze _menu/haze-133
@@ -23624,7 +23624,7 @@ system Tais
 system Talita
 	pos -519 -26
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 1705
 	belt 1403
 	link Miaplacidus
@@ -23690,7 +23690,7 @@ system Talita
 system "Tania Australis"
 	pos -671 7
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1738
 	link Phecda
@@ -23763,7 +23763,7 @@ system "Tania Australis"
 system Tarazed
 	pos -194 448
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 1215
 	belt 1169
 	link Enif
@@ -23826,7 +23826,7 @@ system Tarazed
 system Tebuteb
 	pos -615.587 710.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 553.28
 	belt 1855
 	link Miblulub
@@ -23888,7 +23888,7 @@ system Tebuteb
 system Tejat
 	pos -489 -107
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 1158.12
 	belt 1447
 	link Phurad
@@ -23966,7 +23966,7 @@ system Tejat
 system Terminus
 	pos -727.99 -23.2491
 	government Republic
-	attributes "wormhole" "human space" "dirt belt" "fringe"
+	attributes "wormhole" "!human" "!dirt belt" "!fringe"
 	habitable 425.92
 	belt 1221
 	haze _menu/haze-67
@@ -24019,7 +24019,7 @@ system Terminus
 system "Terra Incognita"
 	pos 9921.5 7086.5
 	government Uninhabited
-	attributes
+	attributes "!pleiades"
 	link "Over the Rainbow"
 	habitable 455.625
 	haze _menu/haze-blackbody
@@ -24064,7 +24064,7 @@ system "Terra Incognita"
 system Torbab
 	pos -949.587 490.051
 	government Coalition
-	attributes "arachi space"
+	attributes "!coalition" "!arach"
 	habitable 1505.92
 	belt 1702
 	link Speloog
@@ -24141,7 +24141,7 @@ system Torbab
 system Tortor
 	pos -255 -424
 	government Republic
-	attributes "human space" "far north" "fringe"
+	attributes "!human" "!north" "!fringe"
 	habitable 455.625
 	belt 1243
 	haze _menu/haze-67
@@ -24208,7 +24208,7 @@ system Tortor
 system Turais
 	pos -691 134
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1471
 	link Gacrux
@@ -24265,7 +24265,7 @@ system Turais
 system "Ula Mon"
 	pos -64.1218 -559.868
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 640
 	belt 1574
 	link "Bote Asu"
@@ -24340,7 +24340,7 @@ system "Ula Mon"
 system "Ultima Thule"
 	pos -336 -211
 	government Republic
-	attributes "wormhole" "far north"
+	attributes "wormhole" "!north"
 	habitable 2560
 	belt 1635
 	haze _menu/haze-67
@@ -24394,7 +24394,7 @@ system "Ultima Thule"
 system Umbral
 	pos -164 406
 	government Republic
-	attributes "human space" "the south" "fringe"
+	attributes "!human" "!south" "!fringe"
 	habitable 670
 	belt 1345
 	link Tarazed
@@ -24472,7 +24472,7 @@ system Umbral
 system Unagi
 	pos -306 -578
 	government Pirate
-	attributes "human space" "far north" "fringe"
+	attributes "!human" "!north" "!fringe"
 	habitable 320
 	belt 1960
 	haze _menu/haze-33
@@ -24526,7 +24526,7 @@ system Unagi
 system Unukalhai
 	pos -710 405
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 625
 	belt 1968
 	haze _menu/haze-67
@@ -24587,7 +24587,7 @@ system Unukalhai
 system "Uwa Fahn"
 	pos 35.1585 -491.67
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 320
 	belt 1913
 	link "Ya Hai"
@@ -24693,7 +24693,7 @@ system Vaticanus
 system Vega
 	pos -402 182
 	government Republic
-	attributes "human space" "near earth"
+	attributes "!human" "!near earth"
 	habitable 1400
 	belt 1744
 	link Altair
@@ -24757,7 +24757,7 @@ system Vega
 system Vindemiatrix
 	pos -635 257
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1957
 	link Alioth
@@ -24810,7 +24810,7 @@ system Vindemiatrix
 system Volax
 	pos -256 -179
 	government Republic
-	attributes "human space" "far north"
+	attributes "!human" "!north"
 	habitable 1715
 	belt 1424
 	haze _menu/haze-67
@@ -24865,7 +24865,7 @@ system Volax
 system "Wah Ki"
 	pos 14.9925 -612.792
 	government Hai
-	attributes "warzone"
+	attributes "!hai" "!warzone"
 	habitable 425.92
 	belt 1585
 	link "Zuba Zub"
@@ -24934,7 +24934,7 @@ system "Wah Ki"
 system "Wah Oh"
 	pos -205.344 -381.381
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 5000
 	belt 1194
 	haze _menu/haze-67
@@ -25013,7 +25013,7 @@ system "Wah Oh"
 system "Wah Yoot"
 	pos 40.9382 -685.994
 	government "Hai (Unfettered)"
-	attributes
+	attributes "!hai"
 	habitable 1080
 	belt 1222
 	link "Wah Ki"
@@ -25078,7 +25078,7 @@ system "Wah Yoot"
 system Waypoint
 	pos -184 -515
 	government Hai
-	attributes "wormhole"
+	attributes "wormhole" "!hai"
 	habitable 78.125
 	belt 1610
 	haze _menu/haze-67
@@ -25136,7 +25136,7 @@ system Waypoint
 system Wazn
 	pos -385 -131
 	government Republic
-	attributes "human space" "paradise worlds"
+	attributes "!human" "!paradise"
 	habitable 534.375
 	belt 1414
 	haze _menu/haze-67
@@ -25202,7 +25202,7 @@ system Wazn
 system Wei
 	pos -598 369
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 455.625
 	belt 1927
 	link Seginus
@@ -25260,7 +25260,7 @@ system Wei
 system Wezen
 	pos -664 -433
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 2880
 	belt 1913
 	link Naos
@@ -25342,7 +25342,7 @@ system Wezen
 system "World's End"
 	pos 9966.5 7017.5
 	government Uninhabited
-	attributes
+	attributes "!pleiades"
 	habitable 700
 	haze _menu/haze-blackbody
 	object
@@ -25402,7 +25402,7 @@ system "World's End"
 system "Ya Hai"
 	pos -24.9453 -505.571
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 425.92
 	belt 1120
 	link "Ula Mon"
@@ -25477,7 +25477,7 @@ system "Ya Hai"
 system "Yed Prior"
 	pos -810 374
 	government Republic
-	attributes "human space" "the south"
+	attributes "!human" "!south"
 	habitable 455.625
 	belt 1837
 	link Pherkad
@@ -25534,7 +25534,7 @@ system "Yed Prior"
 system Zaurak
 	pos -109 -34
 	government Syndicate
-	attributes "human space" "the core"
+	attributes "!human" "!core"
 	habitable 625
 	belt 1130
 	haze _menu/haze-133
@@ -25592,7 +25592,7 @@ system Zaurak
 system "Zeta Aquilae"
 	pos -369 276
 	government Republic
-	attributes "human space" "dirt belt"
+	attributes "!human" "!dirt belt"
 	habitable 1400
 	belt 1829
 	haze _menu/haze-133
@@ -25667,7 +25667,7 @@ system "Zeta Aquilae"
 system "Zeta Centauri"
 	pos -835 257
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 455.625
 	belt 1488
 	haze _menu/haze-67
@@ -25723,7 +25723,7 @@ system "Zeta Centauri"
 system Zosma
 	pos -640 -123
 	government Republic
-	attributes "human space" "the deep"
+	attributes "!human" "!deep"
 	habitable 455.625
 	belt 1436
 	link Algieba
@@ -25789,7 +25789,7 @@ system Zosma
 system "Zuba Zub"
 	pos -48.2661 -647.926
 	government Hai
-	attributes
+	attributes "!hai"
 	habitable 425.92
 	belt 1911
 	haze _menu/haze-67
@@ -25855,7 +25855,7 @@ system "Zuba Zub"
 system Zubenelgenubi
 	pos -710 353
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 945
 	belt 1475
 	link Zubeneschamali
@@ -25921,7 +25921,7 @@ system Zubenelgenubi
 system Zubeneschamali
 	pos -759 338
 	government Republic
-	attributes "human space" "the rim"
+	attributes "!human" "!rim"
 	habitable 1250
 	belt 1543
 	haze _menu/haze-67

--- a/data/map.txt
+++ b/data/map.txt
@@ -2472,7 +2472,7 @@ system Alcyone
 system Aldebaran
 	pos -356 -26
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 625
 	belt 1296
 	link Capella
@@ -2897,7 +2897,7 @@ system Algorel
 system Alheka
 	pos -350 -271
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 1080
 	belt 1380
 	haze _menu/haze-67
@@ -2956,7 +2956,7 @@ system Alheka
 system Alhena
 	pos -430 -80
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 945
 	belt 1078
 	haze _menu/haze-67
@@ -3147,7 +3147,7 @@ system Alkaid
 system Almaaz
 	pos -349 -538
 	government Pirate
-	attributes "far north"
+	attributes "north"
 	habitable 1080
 	belt 1873
 	haze _menu/haze-33
@@ -3389,7 +3389,7 @@ system Alnasl
 system Alnilam
 	pos -487 -513
 	government Pirate
-	attributes "far north"
+	attributes "north"
 	habitable 1715
 	belt 1099
 	haze _menu/haze-33
@@ -3467,7 +3467,7 @@ system Alnilam
 system Alnitak
 	pos -331 -412
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 349.375
 	belt 1907
 	haze _menu/haze-67
@@ -3785,7 +3785,7 @@ system "Alpha Hydri"
 system Alphard
 	pos -588 -47
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 1080.62
 	belt 1101
 	link Algieba
@@ -4603,7 +4603,7 @@ system Arculus
 system Arneb
 	pos -523 -580
 	government Pirate
-	attributes "far north"
+	attributes "north"
 	habitable 1715
 	belt 1947
 	haze _menu/haze-none
@@ -5422,7 +5422,7 @@ system "Beta Lupi"
 system Betelgeuse
 	pos -384 -322
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 1080
 	belt 1641
 	haze _menu/haze-67
@@ -6111,7 +6111,7 @@ system Caeculus
 system Canopus
 	pos -421 -225
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 214.375
 	belt 1530
 	haze _menu/haze-67
@@ -6158,7 +6158,7 @@ system Canopus
 system Capella
 	pos -378 -13
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 455.625
 	belt 1722
 	haze _menu/haze-67
@@ -6293,7 +6293,7 @@ system Caph
 system Cardax
 	pos -211 -215
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 1705
 	belt 1228
 	link Moktar
@@ -6421,7 +6421,7 @@ system Cardea
 system Castor
 	pos -452 -17
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 1715
 	belt 1675
 	haze _menu/haze-67
@@ -7396,7 +7396,7 @@ system Dabih
 system Danoa
 	pos -239 -321
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 135
 	belt 1689
 	haze _menu/haze-67
@@ -8867,7 +8867,7 @@ system Ek'kek'ru
 system Ekuarik
 	pos -1029.63 426.214
 	government Heliarch
-	attributes
+	attributes "ringworld"
 	habitable 700
 	belt 1711
 	link "Ki War Ek"
@@ -9050,7 +9050,7 @@ system Ekuarik
 system Elnath
 	pos -288 -77
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 1715
 	belt 1462
 	link Acamar
@@ -11640,7 +11640,7 @@ system "Good Omen"
 system Gorvi
 	pos -250 -483
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 670
 	belt 1345
 	haze _menu/haze-133
@@ -11997,7 +11997,7 @@ system Han
 system Hassaleh
 	pos -291 -287
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 670
 	belt 1924
 	haze _menu/haze-67
@@ -12058,7 +12058,7 @@ system Hassaleh
 system Hatysa
 	pos -474 -542
 	government Pirate
-	attributes "far north"
+	attributes "north"
 	habitable 533.75
 	belt 1163
 	haze _menu/haze-33
@@ -14855,7 +14855,7 @@ system Kugel
 system Kursa
 	pos -366 -105
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 455
 	belt 1624
 	haze _menu/haze-67
@@ -15868,7 +15868,7 @@ system Mebla
 system Mebsuta
 	pos -482 -394
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 670
 	belt 1740
 	haze _menu/haze-33
@@ -16266,7 +16266,7 @@ system Men
 system Menkalinan
 	pos -400 -61
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 3430
 	belt 1424
 	haze _menu/haze-67
@@ -16600,7 +16600,7 @@ system Mesuket
 system Miaplacidus
 	pos -524 -69
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 455.625
 	belt 1236
 	link Tejat
@@ -16874,7 +16874,7 @@ system Minkar
 system Mintaka
 	pos -304 -462
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 775.625
 	belt 1753
 	haze _menu/haze-67
@@ -17063,7 +17063,7 @@ system Mirfak
 system Mirzam
 	pos -498 -301
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 1080
 	belt 1025
 	haze _menu/haze-67
@@ -17625,7 +17625,7 @@ system Nenia
 system Nihal
 	pos -262 -121
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 534.375
 	belt 1329
 	link Elnath
@@ -18149,7 +18149,7 @@ system Ossipago
 system "Over the Rainbow"
 	pos 9904 7176
 	government Uninhabited
-	attributes "pleiades" "wormhole"
+	attributes "pleiades"
 	link "Terra Incognita"
 	habitable 1215
 	haze _menu/haze-blackbody
@@ -18792,7 +18792,7 @@ system Persitar
 system Phact
 	pos -375 -191
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 1080.62
 	belt 1704
 	haze _menu/haze-67
@@ -18979,7 +18979,7 @@ system Pherkad
 system Phurad
 	pos -494 -153
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 1080
 	belt 1881
 	link Tejat
@@ -19265,7 +19265,7 @@ system Polerius
 system Pollux
 	pos -465 4
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 1080
 	belt 1161
 	haze _menu/haze-67
@@ -19971,7 +19971,7 @@ system Queri
 system Rajak
 	pos -270 -236
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 78.125
 	belt 1410
 	haze _menu/haze-67
@@ -20487,7 +20487,7 @@ system Remembrance
 system Rigel
 	pos -324 -363
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 1080
 	belt 1782
 	link Saiph
@@ -21079,7 +21079,7 @@ system "Sagittarius A*"
 system Saiph
 	pos -375 -390
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 320
 	belt 1690
 	haze _menu/haze-33
@@ -22970,7 +22970,7 @@ system Solifar
 system Sospi
 	pos -317 -161
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 1715
 	belt 1715
 	haze _menu/haze-133
@@ -23403,7 +23403,7 @@ system Suhail
 system Sumar
 	pos -236 -273
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 2560
 	belt 1778
 	link Cardax
@@ -23587,7 +23587,7 @@ system Tais
 system Talita
 	pos -519 -26
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 1705
 	belt 1403
 	link Miaplacidus
@@ -23851,7 +23851,7 @@ system Tebuteb
 system Tejat
 	pos -489 -107
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 1158.12
 	belt 1447
 	link Phurad
@@ -24103,7 +24103,7 @@ system Torbab
 system Tortor
 	pos -255 -424
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 455.625
 	belt 1243
 	haze _menu/haze-67
@@ -24301,7 +24301,7 @@ system "Ula Mon"
 system "Ultima Thule"
 	pos -336 -211
 	government Republic
-	attributes "wormhole" "far north"
+	attributes "wormhole" "north"
 	habitable 2560
 	belt 1635
 	haze _menu/haze-67
@@ -24433,7 +24433,7 @@ system Umbral
 system Unagi
 	pos -306 -578
 	government Pirate
-	attributes "far north"
+	attributes "north"
 	habitable 320
 	belt 1960
 	haze _menu/haze-33
@@ -24770,7 +24770,7 @@ system Vindemiatrix
 system Volax
 	pos -256 -179
 	government Republic
-	attributes "far north"
+	attributes "north"
 	habitable 1715
 	belt 1424
 	haze _menu/haze-67
@@ -25035,7 +25035,7 @@ system "Wah Yoot"
 system Waypoint
 	pos -184 -515
 	government Hai
-	attributes "wormhole" "hai"
+	attributes "wormhole"
 	habitable 78.125
 	belt 1610
 	haze _menu/haze-67
@@ -25093,7 +25093,7 @@ system Waypoint
 system Wazn
 	pos -385 -131
 	government Republic
-	attributes "paradise planets"
+	attributes "paradise"
 	habitable 534.375
 	belt 1414
 	haze _menu/haze-67

--- a/data/map.txt
+++ b/data/map.txt
@@ -75,6 +75,7 @@ galaxy "label graveyard"
 system "1 Axis"
 	pos -1274.63 267.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 745.92
 	belt 1112
 	link "Sol Kimek"
@@ -152,6 +153,7 @@ system "1 Axis"
 system "10 Pole"
 	pos -1356.63 19.2137
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 486.68
 	belt 1765
 	haze _menu/haze-67
@@ -223,6 +225,7 @@ system "10 Pole"
 system "11 Autumn Above"
 	pos -1278.63 148.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 1566.68
 	belt 1099
 	haze _menu/haze-133
@@ -304,6 +307,7 @@ system "11 Autumn Above"
 system "11 Spring Below"
 	pos -1272.63 380.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 912.6
 	belt 1932
 	link "4 Spring Rising"
@@ -383,6 +387,7 @@ system "11 Spring Below"
 system "12 Autumn Above"
 	pos -1276.63 -19.7863
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 1050.92
 	belt 1283
 	link "14 Pole"
@@ -476,6 +481,7 @@ system "12 Autumn Above"
 system "14 Pole"
 	pos -1343.63 -119.786
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 625
 	belt 1881
 	haze _menu/haze-67
@@ -536,6 +542,7 @@ system "14 Pole"
 system "14 Summer Above"
 	pos -1436.63 182.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 1400
 	belt 1093
 	haze _menu/haze-67
@@ -601,6 +608,7 @@ system "14 Summer Above"
 system "14 Winter Below"
 	pos -1143.63 341.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 1111.68
 	belt 1173
 	link "8 Winter Below"
@@ -676,6 +684,7 @@ system "14 Winter Below"
 system "16 Autumn Rising"
 	pos -1305.63 74.2137
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 1715
 	belt 1424
 	link "12 Autumn Above"
@@ -745,6 +754,7 @@ system "16 Autumn Rising"
 system "3 Axis"
 	pos -1235.63 299.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 2372.76
 	belt 1202
 	link "1 Axis"
@@ -812,6 +822,7 @@ system "3 Axis"
 system "3 Pole"
 	pos -1344.63 162.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 625
 	belt 1617
 	link "16 Autumn Rising"
@@ -871,6 +882,7 @@ system "3 Pole"
 system "3 Spring Rising"
 	pos -1414.63 356.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 1080
 	belt 1613
 	haze _menu/haze-33
@@ -943,6 +955,7 @@ system "3 Spring Rising"
 system "4 Axis"
 	pos -1169.63 365.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 425.92
 	belt 1838
 	link "14 Winter Below"
@@ -1005,6 +1018,7 @@ system "4 Axis"
 system "4 Spring Rising"
 	pos -1309.63 321.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 320
 	belt 1801
 	link "1 Axis"
@@ -1069,6 +1083,7 @@ system "4 Spring Rising"
 system "4 Summer Rising"
 	pos -1377.63 207.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 320
 	belt 1860
 	link "3 Pole"
@@ -1128,6 +1143,7 @@ system "4 Summer Rising"
 system "4 Winter Rising"
 	pos -1259.63 248.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 135
 	belt 1345
 	link "Sol Kimek"
@@ -1202,6 +1218,7 @@ system "4 Winter Rising"
 system "5 Axis"
 	pos -1142.63 394.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 233.28
 	belt 1775
 	link "4 Axis"
@@ -1274,6 +1291,7 @@ system "5 Axis"
 system "5 Spring Below"
 	pos -1213.63 415.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 1313.28
 	belt 1104
 	link "4 Axis"
@@ -1345,6 +1363,7 @@ system "5 Spring Below"
 system "5 Summer Above"
 	pos -1387.63 118.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 425.92
 	belt 1133
 	haze _menu/haze-133
@@ -1411,6 +1430,7 @@ system "5 Summer Above"
 system "5 Winter Above"
 	pos -1216.63 208.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 320
 	belt 1414
 	link "4 Winter Rising"
@@ -1474,6 +1494,7 @@ system "5 Winter Above"
 system "7 Autumn Rising"
 	pos -1235.63 177.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 425.92
 	belt 1289
 	link "11 Autumn Above"
@@ -1539,6 +1560,7 @@ system "7 Autumn Rising"
 system "8 Winter Below"
 	pos -1179.63 284.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 486.68
 	belt 1285
 	link "3 Axis"
@@ -1603,6 +1625,7 @@ system "8 Winter Below"
 system "9 Spring Above"
 	pos -1377.63 281.214
 	government Coalition
+	attributes "!kimek" "!coalition"
 	habitable 1050.92
 	belt 1397
 	haze _menu/haze-67
@@ -1677,6 +1700,7 @@ system "9 Spring Above"
 system Ablodab
 	pos -854.587 592.051
 	government Coalition
+	attributes "!arach" "!coalition"
 	habitable 425.92
 	belt 1368
 	link Debrugt
@@ -1751,6 +1775,7 @@ system Ablodab
 system Ablub
 	pos -581.587 637.051
 	government Coalition
+	attributes "!arach" "!coalition"
 	habitable 233.28
 	belt 1641
 	haze _menu/haze-133
@@ -1804,6 +1829,7 @@ system Ablub
 system Acamar
 	pos -284 -3
 	government Syndicate
+	attributes "!human" "!syndicate" "!core"
 	habitable 1080
 	belt 1013
 	link Diphda
@@ -1862,6 +1888,7 @@ system Acamar
 system Achernar
 	pos -93 154
 	government Syndicate
+	attributes "!human" "!syndicate" "!core"
 	habitable 625
 	belt 1963
 	haze _menu/haze-133
@@ -1933,6 +1960,7 @@ system Achernar
 system Acrux
 	pos -808 192
 	government Republic
+	attributes "!human" "!free worlds" "!rim"
 	habitable 590.625
 	belt 1407
 	haze _menu/haze-67
@@ -2012,6 +2040,7 @@ system Acrux
 system Adhara
 	pos -669 -200
 	government Republic
+	attributes "!human" "!republic" "!deep"
 	habitable 670
 	belt 1014
 	link "Epsilon Leonis"
@@ -2173,6 +2202,7 @@ system "Aki'il"
 system "Al Dhanab"
 	pos -177 207
 	government Syndicate
+	attributes "!human" "!syndicate" "!core"
 	habitable 1080
 	belt 1432
 	haze _menu/haze-133
@@ -2242,6 +2272,7 @@ system "Al Dhanab"
 system Albaldah
 	pos -350 484
 	government Republic
+	attributes "!human" "!free worlds" "!south"
 	habitable 534.375
 	belt 1622
 	haze _menu/haze-133
@@ -2316,6 +2347,7 @@ system Albaldah
 system Albireo
 	pos -270 503
 	government Republic
+	attributes "!human" "!free worlds" "!south"
 	habitable 760
 	belt 1030
 	link Tarazed
@@ -2373,6 +2405,7 @@ system Albireo
 system Alcyone
 	pos -80 -144
 	government Pirate
+	attributes "!human" "!core"
 	habitable 270
 	belt 1438
 	haze _menu/haze-133
@@ -2439,6 +2472,7 @@ system Alcyone
 system Aldebaran
 	pos -356 -26
 	government Republic
+	attributes "!human" "!republic" "!paradise"
 	habitable 625
 	belt 1296
 	link Capella
@@ -2484,6 +2518,7 @@ system Aldebaran
 system Alderamin
 	pos -272 258
 	government Syndicate
+	attributes "!human" "!syndicate" "!core"
 	habitable 1705
 	belt 1908
 	haze _menu/haze-133
@@ -2548,6 +2583,7 @@ system Alderamin
 system Aldhibain
 	pos -659 451
 	government Republic
+	attributes "!human" "!free worlds" "!south"
 	habitable 455.625
 	belt 1840
 	link Kornephoros
@@ -2605,6 +2641,7 @@ system Aldhibain
 			period 13.622
 
 system Algenib
+	attributes "!human" "!core" "!fringe"
 	pos -118 341
 	government Pirate
 	habitable 455.625
@@ -2661,6 +2698,7 @@ system Algenib
 			period 42.6838
 
 system Algieba
+	attributes "!human" "!republic" "!deep"
 	pos -691 -52
 	government Republic
 	habitable 2695
@@ -2732,6 +2770,7 @@ system Algieba
 system Algol
 	pos -210 17
 	government Syndicate
+	attributes "!human" "!syndicate" "!core"
 	habitable 534.375
 	belt 1839
 	haze _menu/haze-133
@@ -2793,6 +2832,7 @@ system Algol
 system Algorel
 	pos -631 145
 	government Republic
+	attributes "!human" "!republic" "!dirt belt"
 	habitable 320
 	belt 1993
 	haze _menu/haze-67
@@ -2857,6 +2897,7 @@ system Algorel
 system Alheka
 	pos -350 -271
 	government Republic
+	attributes "!human" "!republic" "!north"
 	habitable 1080
 	belt 1380
 	haze _menu/haze-67
@@ -2915,6 +2956,7 @@ system Alheka
 system Alhena
 	pos -430 -80
 	government Republic
+	attributes "!human" "!republic" "!paradise"
 	habitable 945
 	belt 1078
 	haze _menu/haze-67
@@ -2984,6 +3026,7 @@ system Alhena
 system Alioth
 	pos -620 315
 	government Republic
+	attributes "!human" "!republic" "!dirt belt"
 	habitable 455.625
 	belt 1889
 	link Wei
@@ -3036,6 +3079,7 @@ system Alioth
 system Alkaid
 	pos -825 318
 	government Republic
+	attributes "!human" "!republic" "!rim"
 	habitable 1080
 	belt 1142
 	haze _menu/haze-67
@@ -3103,6 +3147,7 @@ system Alkaid
 system Almaaz
 	pos -349 -538
 	government Pirate
+	attributes "!human" "!north" "!fringe"
 	habitable 1080
 	belt 1873
 	haze _menu/haze-33
@@ -3149,6 +3194,7 @@ system Almaaz
 system Almach
 	pos -7 232
 	government Pirate
+	attributes "!human" "!core" "!fringe"
 	habitable 320
 	belt 1914
 	haze _menu/haze-133
@@ -3211,6 +3257,7 @@ system Almach
 system Alnair
 	pos -272 314
 	government Syndicate
+	attributes "!human" "!syndicate" "!core"
 	habitable 135
 	belt 1969
 	haze _menu/haze-133
@@ -3279,6 +3326,7 @@ system Alnair
 system Alnasl
 	pos -553 380
 	government Republic
+	attributes "!human" "!republic" "!dirt belt"
 	habitable 640
 	belt 1412
 	haze _menu/haze-133
@@ -3338,9 +3386,10 @@ system Alnasl
 		distance 1788.8
 		period 1196.22
 
-system Alnilam
+system Alnilam 
 	pos -487 -513
 	government Pirate
+	attributes "!human" "!north" "!fringe"
 	habitable 1715
 	belt 1099
 	haze _menu/haze-33

--- a/data/map.txt
+++ b/data/map.txt
@@ -12624,7 +12624,7 @@ system Homeward
 system Host
 	pos 384.431 -543.812
 	government Uninhabited
-	attributes "!isolated" "!TBD"
+	attributes "!isolated"
 	habitable 486.68
 	belt 1669
 	asteroids "large metal" 1 0.732

--- a/data/map.txt
+++ b/data/map.txt
@@ -5690,7 +5690,7 @@ system Blugtad
 system Boral
 	pos -502 331
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 214.375
 	belt 1867
 	link Alphecca
@@ -11063,7 +11063,7 @@ system Gacrux
 system "Gamma Cassiopeiae"
 	pos -116 293
 	government Syndicate
-	attributes "!human" "!core"
+	attributes "!human" "!core" "!fringe"
 	habitable 455.625
 	belt 1779
 	haze _menu/haze-133
@@ -12450,7 +12450,7 @@ system "Hi Yahr"
 system Hintar
 	pos -422 311
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 625
 	belt 1725
 	haze _menu/haze-133
@@ -12797,7 +12797,7 @@ system Ik'kara'ka
 system Ildaria
 	pos -702 317
 	government Republic
-	attributes "!human" "!rim"
+	attributes "!human" "!rim" "!wolf-rayet" "!fringe"
 	habitable 625
 	belt 1132
 	haze _menu/haze-133
@@ -14007,6 +14007,7 @@ system "Ki War Ek"
 system Kiro'ku
 	pos -131.923 -884.46
 	government Wanderer
+	attributes "!wanderer"
 	habitable 1111.68
 	belt 1308
 	haze _menu/haze-none
@@ -14083,6 +14084,7 @@ system Kiro'ku
 system Kiru'kichi
 	pos -195.063 -662.343
 	government Wanderer
+	attributes "!wanderer"
 	habitable 2795
 	belt 1465
 	haze _menu/haze-33
@@ -14142,6 +14144,7 @@ system Kiru'kichi
 system Kochab
 	pos -731 279
 	government Republic
+	attributes "!human" "!rim"
 	habitable 320
 	belt 1912
 	haze _menu/haze-67
@@ -14185,6 +14188,7 @@ system Kochab
 system "Kor Ak'Mari"
 	pos 43 42
 	government Korath
+	attributes "!korath" "!exiles" "!isolated" "!wolf-rayet"
 	habitable 625
 	belt 1606
 	haze _menu/haze-full
@@ -14235,6 +14239,7 @@ system "Kor Ak'Mari"
 system "Kor En'lakfar"
 	pos -31 -33
 	government Korath
+	attributes "!korath" "!exiles"
 	habitable 1080
 	belt 1115
 	haze _menu/haze-133
@@ -14296,6 +14301,7 @@ system "Kor En'lakfar"
 system "Kor Fel'tar"
 	pos 29 -66
 	government Korath
+	attributes "!korath" "!exiles"
 	habitable 455.625
 	belt 1444
 	haze _menu/haze-blackbody
@@ -14361,6 +14367,7 @@ system "Kor Fel'tar"
 system "Kor Men"
 	pos 6 -5
 	government Korath
+	attributes "!korath" "!exiles"
 	habitable 2340
 	belt 1260
 	haze _menu/haze-blackbody
@@ -14423,6 +14430,7 @@ system "Kor Men"
 system "Kor Nor'peli"
 	pos 52 160
 	government Korath
+	attributes "!korath" "!exiles"
 	habitable 590.625
 	belt 1213
 	haze _menu/haze-blackbody
@@ -14487,6 +14495,7 @@ system "Kor Nor'peli"
 system "Kor Tar'bei"
 	pos 57 106
 	government Korath
+	attributes "!korath" "!exiles"
 	habitable 214.375
 	belt 1614
 	haze _menu/haze-blackbody
@@ -14543,6 +14552,7 @@ system "Kor Tar'bei"
 system "Kor Zena'i"
 	pos -2 83
 	government Korath
+	attributes "!korath" "!exiles"
 	habitable 703.125
 	belt 1866
 	haze _menu/haze-blackbody
@@ -14595,6 +14605,7 @@ system "Kor Zena'i"
 system Kornephoros
 	pos -612 424
 	government Republic
+	attributes "!human" "!south"
 	habitable 911.25
 	belt 1168
 	link Sabik
@@ -14675,6 +14686,7 @@ system Kornephoros
 system Korsmanath
 	pos 97.4305 -185.812
 	government Uninhabited
+	attributes "!korath" "!automata" "!fringe"
 	habitable 486.68
 	belt 1775
 	link Feroteri
@@ -14734,6 +14746,7 @@ system Korsmanath
 system Kraz
 	pos -876 204
 	government Republic
+	attributes "!human" "!rim" 
 	habitable 1080
 	belt 1056
 	haze _menu/haze-67
@@ -14800,6 +14813,7 @@ system Kraz
 system Kugel
 	pos -230 -26
 	government Syndicate
+	attributes "!human" "!core" "!fringe"
 	habitable 625
 	belt 1051
 	link Acamar
@@ -14868,6 +14882,7 @@ system Kugel
 system Kursa
 	pos -366 -105
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 455
 	belt 1624
 	haze _menu/haze-67
@@ -14984,6 +14999,7 @@ system "Last Word"
 system Lesath
 	pos -516 485
 	government Republic
+	attributes "!human" "!south"
 	habitable 1715
 	belt 1865
 	link Atria
@@ -15116,6 +15132,7 @@ system Levana
 system Limen
 	pos -791.99 -12.2491
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1715
 	belt 1463
 	haze _menu/haze-33
@@ -15229,6 +15246,7 @@ system Lire
 system Lolami
 	pos -628 -10
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1215
 	belt 1072
 	link "Tania Australis"
@@ -15292,6 +15310,7 @@ system Lolami
 system "Lom Tahr"
 	pos -94.0437 -446.586
 	government Hai
+	attributes "!hai"
 	habitable 2372.76
 	belt 1445
 	link "Ya Hai"
@@ -15367,6 +15386,7 @@ system "Lom Tahr"
 system "Lone Cloud"
 	pos -1239.59 747.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 233.28
 	belt 1730
 	link "Four Pillars"
@@ -15417,7 +15437,7 @@ system "Lone Cloud"
 system Lucina
 	pos 175.504 176.389
 	government Uninhabited
-	attributes "ember waste"
+	attributes "ember waste" "!fringe"
 	habitable 320
 	belt 1466
 	haze _menu/haze-red
@@ -15473,6 +15493,7 @@ system Lucina
 system Lurata
 	pos -279 463
 	government Republic
+	attributes "!human" "!south"
 	habitable 455.625
 	belt 1151
 	haze _menu/haze-133
@@ -15535,6 +15556,7 @@ system Lurata
 system Makferuti
 	pos 288.431 -628.812
 	government "Kor Sestor"
+	attributes "!korath" "!automata"
 	habitable 621.68
 	belt 1782
 	link Asikafarnut
@@ -15610,6 +15632,7 @@ system Makferuti
 system Markab
 	pos -241 168
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 625
 	belt 1411
 	haze _menu/haze-133
@@ -15692,6 +15715,7 @@ system Markab
 system Markeb
 	pos -602 -305
 	government Republic
+	attributes "!human" "!deep"
 	habitable 455.625
 	belt 1556
 	haze _menu/haze-33
@@ -15756,6 +15780,7 @@ system Markeb
 system Matar
 	pos -218 272
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 455.625
 	belt 1308
 	haze _menu/haze-133
@@ -15813,6 +15838,7 @@ system Matar
 system Mebla
 	pos -814.587 555.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 486.68
 	belt 1114
 	link Debrugt
@@ -15870,6 +15896,7 @@ system Mebla
 system Mebsuta
 	pos -482 -394
 	government Republic
+	attributes "!human" "!north"
 	habitable 670
 	belt 1740
 	haze _menu/haze-33
@@ -15945,6 +15972,7 @@ system Mebsuta
 system Meftarkata
 	pos 52.4305 -276.812
 	government Uninhabited
+	attributes "!korath"
 	habitable 2201.68
 	belt 1232
 	haze _menu/haze-133
@@ -16006,6 +16034,7 @@ system Meftarkata
 system "Mei Yohn"
 	pos -106.757 -581.698
 	government Hai
+	attributes "!hai"
 	habitable 425.92
 	belt 1075
 	haze _menu/haze-67
@@ -16071,6 +16100,7 @@ system "Mei Yohn"
 system Mekislepti
 	pos 137.431 -335.812
 	government "Kor Mereti"
+	attributes "!korath" "!automata"
 	habitable 1705
 	belt 1673
 	haze _menu/haze-133
@@ -16134,6 +16164,7 @@ system Mekislepti
 system Meblumem
 	pos -722.587 616.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 2201.68
 	belt 1794
 	link "Sol Arach"
@@ -16198,6 +16229,7 @@ system Meblumem
 system Men
 	pos -888 361
 	government Pirate
+	attributes "!human" "!south"
 	habitable 320
 	belt 1531
 	haze _menu/haze-33
@@ -16263,6 +16295,7 @@ system Men
 system Menkalinan
 	pos -400 -61
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 3430
 	belt 1424
 	haze _menu/haze-67
@@ -16330,6 +16363,7 @@ system Menkalinan
 system Menkar
 	pos -183 -52
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 455.625
 	belt 1634
 	haze _menu/haze-133
@@ -16392,6 +16426,7 @@ system Menkar
 system Menkent
 	pos -495 218
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 2340
 	belt 1728
 	link Vega
@@ -16462,6 +16497,7 @@ system Menkent
 system Merak
 	pos -553 60
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 1080.62
 	belt 1769
 	haze _menu/haze-67
@@ -16526,6 +16562,7 @@ system Merak
 system Mesuket
 	pos 220.431 -409.812
 	government Uninhabited
+	attributes "!korath" "!automata" "!warzone"
 	habitable 425.92
 	belt 1189
 	link Eshkoshtar
@@ -16592,6 +16629,7 @@ system Mesuket
 system Miaplacidus
 	pos -524 -69
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 455.625
 	belt 1236
 	link Tejat
@@ -16666,6 +16704,7 @@ system Miaplacidus
 system Miblulub
 	pos -630.587 670.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 1080
 	belt 1757
 	haze _menu/haze-133
@@ -16747,6 +16786,7 @@ system Miblulub
 system Mimosa
 	pos -895 168
 	government Republic
+	attributes "!human" "!rim"
 	habitable 320
 	belt 1484
 	haze _menu/haze-67
@@ -16797,6 +16837,7 @@ system Mimosa
 system Minkar
 	pos -823 138
 	government Republic
+	attributes "!human" "!rim"
 	habitable 670
 	belt 1354
 	haze _menu/haze-67
@@ -16862,6 +16903,7 @@ system Minkar
 system Mintaka
 	pos -304 -462
 	government Republic
+	attributes "!human" "!north"
 	habitable 775.625
 	belt 1753
 	haze _menu/haze-67
@@ -16925,6 +16967,7 @@ system Mintaka
 system Mirach
 	pos -166 250
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 292.5
 	belt 1980
 	haze _menu/haze-133
@@ -16993,6 +17036,7 @@ system Mirach
 system Mirfak
 	pos -187 -128
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 320
 	belt 1887
 	link Menkar
@@ -17048,6 +17092,7 @@ system Mirfak
 system Mirzam
 	pos -498 -301
 	government Republic
+	attributes "!human" "!north"
 	habitable 1080
 	belt 1025
 	haze _menu/haze-67
@@ -17109,6 +17154,7 @@ system Mirzam
 system Mizar
 	pos -579 184
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1876
 	haze _menu/haze-67
@@ -17161,6 +17207,7 @@ system Mizar
 system Moktar
 	pos -169 -170
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 455
 	belt 1888
 	link Oblate
@@ -17228,6 +17275,7 @@ system Moktar
 system Mora
 	pos -755 23
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1176
 	haze _menu/haze-67
@@ -17288,6 +17336,7 @@ system Mora
 system Muhlifain
 	pos -702 242
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 455.625
 	belt 1265
 	haze _menu/haze-67
@@ -17334,6 +17383,7 @@ system Muhlifain
 system Muphrid
 	pos -495 152
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 839.375
 	belt 1759
 	link Menkent
@@ -17391,6 +17441,7 @@ system Muphrid
 system Naos
 	pos -653 -396
 	government Republic
+	attributes "!human" "!deep"
 	habitable 625
 	belt 1045
 	haze _menu/haze-67
@@ -17464,6 +17515,7 @@ system Naos
 system Naper
 	pos -416 369
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1715
 	belt 1445
 	link Ascella
@@ -17602,6 +17654,7 @@ system Nenia
 system Nihal
 	pos -262 -121
 	government Republic
+	attributes "!human" "!north"
 	habitable 534.375
 	belt 1329
 	link Elnath
@@ -17674,6 +17727,7 @@ system Nihal
 system Nocte
 	pos -467 172
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 135
 	belt 1304
 	link Vega
@@ -17792,6 +17846,7 @@ system Nona
 system Nunki
 	pos -393 537
 	government Pirate
+	attributes "!human" "!south"
 	habitable 214.375
 	belt 1930
 	link Albaldah
@@ -17861,6 +17916,7 @@ system Nunki
 system Oblate
 	pos -124 -119
 	government Pirate
+	attributes "!human" "!core"
 	habitable 12000
 	belt 1704
 	haze _menu/haze-133
@@ -17919,6 +17975,7 @@ system Oblate
 system Orbona
 	pos -735.99 -97.2491
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 2859.44
 	belt 1507
 	haze _menu/haze-67
@@ -17990,6 +18047,7 @@ system Orbona
 system Orvala
 	pos -334 303
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 533.75
 	belt 1431
 	link "Zeta Aquilae"
@@ -18120,6 +18178,7 @@ system Ossipago
 system "Over the Rainbow"
 	pos 9904 7176
 	government Uninhabited
+	attributes "pleiades" "wormhole"
 	link "Terra Incognita"
 	habitable 1215
 	haze _menu/haze-blackbody
@@ -18345,6 +18404,7 @@ system Parca
 system Peacock
 	pos -307 350
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 214.375
 	belt 1870
 	haze _menu/haze-133
@@ -18419,6 +18479,7 @@ system Peacock
 system Pelubta
 	pos -757.587 575.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 9265
 	belt 1709
 	link Meblumem
@@ -18560,7 +18621,7 @@ system Peragenor
 system Peresedersi
 	pos 81.4305 -154.812
 	government Uninhabited
-	attributes "archon"
+	attributes "archon" "!korath" "!isolated" "!nova"
 	habitable 100
 	belt 1065
 	haze _menu/haze-blackbody
@@ -18655,6 +18716,7 @@ system Perfica
 system Persian
 	pos -203 331
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 2170.62
 	belt 1308
 	haze _menu/haze-133
@@ -18722,6 +18784,7 @@ system Persian
 system Persitar
 	pos 297.431 -395.812
 	government Uninhabited
+	attributes "!korath" "!isolated" "!nova"
 	habitable 100
 	belt 1948
 	haze _menu/haze-blackbody
@@ -18758,6 +18821,7 @@ system Persitar
 system Phact
 	pos -375 -191
 	government Republic
+	attributes "!human" "!north"
 	habitable 1080.62
 	belt 1704
 	haze _menu/haze-67
@@ -18830,6 +18894,7 @@ system Phact
 system Phecda
 	pos -607 88
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1375
 	link Algorel
@@ -18887,6 +18952,7 @@ system Phecda
 system Pherkad
 	pos -798 451
 	government Republic
+	attributes "!human" "!south"
 	habitable 135
 	belt 1924
 	haze _menu/haze-67
@@ -18942,6 +19008,7 @@ system Pherkad
 system Phurad
 	pos -494 -153
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 1080
 	belt 1881
 	link Tejat
@@ -19001,6 +19068,7 @@ system Phurad
 system Pik'ro'iyak
 	pos -378.845 -677.001
 	government Wanderer
+	attributes "!wanderer"
 	habitable 233.28
 	belt 1279
 	haze _menu/haze-none
@@ -19049,6 +19117,7 @@ system Pik'ro'iyak
 system Plort
 	pos -708.587 723.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 320
 	belt 1490
 	link "Sol Arach"
@@ -19226,6 +19295,7 @@ system Polerius
 system Pollux
 	pos -465 4
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 1080
 	belt 1161
 	haze _menu/haze-67
@@ -19280,6 +19350,7 @@ system Pollux
 system Porrima
 	pos -556 123
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 760
 	belt 1636
 	haze _menu/haze-67
@@ -19347,6 +19418,7 @@ system Porrima
 system Postverta
 	pos 15000 15000
 	government Uninhabited
+	attributes "!ember waste"
 	haze _menu/haze-red
 	asteroids "large metal" 9 3
 	asteroids "large rock" 4 3
@@ -19379,6 +19451,7 @@ system Postverta
 system Prakacha'a
 	pos -35.1114 -802.607
 	government Wanderer
+	attributes "!wanderer"
 	habitable 1505.92
 	belt 1637
 	haze _menu/haze-33
@@ -19457,6 +19530,7 @@ system Prakacha'a
 system Procyon
 	pos -411 23
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 455.625
 	belt 1763
 	haze _menu/haze-67
@@ -19518,6 +19592,7 @@ system Prosa
 	asteroids "medium rock" 16 1
 	asteroids "small rock" 4 1
 	government Uninhabited
+	attributes "!ember waste"
 	haze _menu/haze-red
 	link Vaticanus
 	minables copper 5 2
@@ -19554,6 +19629,7 @@ system Prosa
 system "Pug Iyik"
 	pos -361.149 -883.233
 	government "Pug (Wanderer)"
+	attributes "!wanderer" "!isolated"
 	habitable 625
 	belt 1286
 	haze _menu/haze-blackbody
@@ -19611,6 +19687,7 @@ system "Pug Iyik"
 system Quaru
 	pos -1080.63 448.214
 	government Heliarch
+	attributes "!coalition" "!ringworld"
 	habitable 700
 	belt 1440
 	haze _menu/haze-133
@@ -19926,6 +20003,7 @@ system Queri
 system Rajak
 	pos -270 -236
 	government Republic
+	attributes "!human" "!north"
 	habitable 78.125
 	belt 1410
 	haze _menu/haze-67
@@ -19993,6 +20071,7 @@ system Rajak
 system Rasalhague
 	pos -413 246
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 455.625
 	belt 1282
 	haze _menu/haze-133
@@ -20053,6 +20132,7 @@ system Rasalhague
 system Rastaban
 	pos -463 446
 	government Republic
+	attributes "!human" "!south"
 	habitable 1080
 	belt 1041
 	haze _menu/haze-133
@@ -20113,6 +20193,7 @@ system Rastaban
 system "Rati Cal"
 	pos -116.765 -391.123
 	government Hai
+	attributes "!hai"
 	habitable 425.92
 	belt 1538
 	link "Due Yoot"
@@ -20166,6 +20247,7 @@ system "Rati Cal"
 system Regor
 	pos -702 -335
 	government Republic
+	attributes "!human" "!deep"
 	habitable 455.625
 	belt 1305
 	haze _menu/haze-67
@@ -20228,6 +20310,7 @@ system Regor
 system Regulus
 	pos -544 25
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 8640
 	belt 1605
 	haze _menu/haze-67
@@ -20380,6 +20463,7 @@ system Relifer
 system Remembrance
 	pos -884.587 641.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 486.68
 	belt 1536
 	link Beginning
@@ -20436,6 +20520,7 @@ system Remembrance
 system Rigel
 	pos -324 -363
 	government Republic
+	attributes "!human" "!north"
 	habitable 1080
 	belt 1782
 	link Saiph
@@ -20585,6 +20670,7 @@ system Ritilas
 system Ruchbah
 	pos -174 69
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 2560
 	belt 1598
 	haze _menu/haze-133
@@ -20656,6 +20742,7 @@ system Ruchbah
 system Rutilicus
 	pos -535 273
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 625
 	belt 1771
 	link Arcturus
@@ -20724,6 +20811,7 @@ system Rutilicus
 system Sabik
 	pos -675 379
 	government Republic
+	attributes "!human" "!rim"
 	habitable 625
 	belt 1609
 	link Unukalhai
@@ -20775,6 +20863,7 @@ system Sabik
 system Sabriset
 	pos 151.724 -426.518
 	government Uninhabited
+	attributes "!korath" "!fringe"
 	habitable 1566.68
 	belt 1025
 	link Sepriaptu
@@ -20828,6 +20917,7 @@ system Sabriset
 system Sadalmelik
 	pos -145 472
 	government Quarg
+	attributes "!human" "!south"
 	habitable 1715
 	belt 1273
 	link Enif
@@ -20883,6 +20973,7 @@ system Sadalmelik
 system Sadalsuud
 	pos -134 508
 	government Quarg
+	attributes "!human" "!south"
 	habitable 1400
 	belt 1859
 	link Enif
@@ -20944,6 +21035,7 @@ system Sadalsuud
 system Sadr
 	pos -287 543
 	government Republic
+	attributes "!human" "!south" "!fringe"
 	habitable 3859.38
 	belt 1388
 	link Albireo
@@ -21008,6 +21100,7 @@ system Sadr
 system "Sagittarius A*"
 	pos 112 22
 	government Uninhabited
+	attributes "!black hole" "!isolated"
 	habitable 10000
 	haze _menu/haze-full
 	object
@@ -21020,6 +21113,7 @@ system "Sagittarius A*"
 system Saiph
 	pos -375 -390
 	government Republic
+	attributes "!human" "!north"
 	habitable 320
 	belt 1690
 	haze _menu/haze-33
@@ -21073,6 +21167,7 @@ system Saiph
 system Salipastart
 	pos 250.431 -370.812
 	government "Kor Mereti"
+	attributes "!korath" "!automata" "!warzone"
 	habitable 486.68
 	belt 1056
 	haze _menu/haze-133
@@ -21139,6 +21234,7 @@ system Salipastart
 system Saquergen
 	pos -482 561
 	government Uninhabited
+	attributes "!human"	"!south" "!isolated" "!nova"
 	habitable 100
 	belt 1435
 	asteroids "small rock" 3 3.9105

--- a/data/map.txt
+++ b/data/map.txt
@@ -3386,7 +3386,7 @@ system Alnasl
 		distance 1788.8
 		period 1196.22
 
-system Alnilam 
+system Alnilam
 	pos -487 -513
 	government Pirate
 	attributes "!human" "!north" "!fringe"
@@ -6630,7 +6630,7 @@ system Celeborim
 system Chikatip
 	pos -77.5695 -307.812
 	government Uninhabited
-	attributes "!korath"
+	attributes "!korath" "!fringe"
 	habitable 425.92
 	belt 1929
 	link Furmeliki
@@ -7404,7 +7404,7 @@ system Dabih
 system Danoa
 	pos -239 -321
 	government Republic
-	attributes "!human" "!north"
+	attributes "!human" "!north" "!fringe"
 	habitable 135
 	belt 1689
 	haze _menu/haze-67
@@ -10618,7 +10618,7 @@ system Ferukistek
 system Fingol
 	pos -482 113
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "!human" "!near earth" "!fringe"
 	habitable 135
 	belt 1976
 	haze _menu/haze-none
@@ -13113,7 +13113,7 @@ system "Io Mann"
 system Ipsing
 	pos -549 160
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 1400
 	belt 1107
 	haze _menu/haze-67
@@ -15132,7 +15132,7 @@ system Levana
 system Limen
 	pos -791.99 -12.2491
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 1715
 	belt 1463
 	haze _menu/haze-33
@@ -15246,7 +15246,7 @@ system Lire
 system Lolami
 	pos -628 -10
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 1215
 	belt 1072
 	link "Tania Australis"
@@ -17727,7 +17727,7 @@ system Nihal
 system Nocte
 	pos -467 172
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "!human" "!near earth" "!fringe"
 	habitable 135
 	belt 1304
 	link Vega
@@ -17975,7 +17975,7 @@ system Oblate
 system Orbona
 	pos -735.99 -97.2491
 	government Republic
-	attributes "!human" "!dirt belt"
+	attributes "!human" "!dirt belt" "!fringe"
 	habitable 2859.44
 	belt 1507
 	haze _menu/haze-67
@@ -20310,7 +20310,7 @@ system Regor
 system Regulus
 	pos -544 25
 	government Republic
-	attributes "!human" "!near earth"
+	attributes "!human" "!near earth" "!fringe"
 	habitable 8640
 	belt 1605
 	haze _menu/haze-67
@@ -21263,6 +21263,7 @@ system Saquergen
 system Sargas
 	pos -542 445
 	government Republic
+	attributes "!human" "!south"
 	habitable 911.25
 	belt 1642
 	link Kornephoros
@@ -21313,6 +21314,7 @@ system Sargas
 system Sarin
 	pos -670 293
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1752
 	link Vindemiatrix
@@ -21362,7 +21364,7 @@ system Sarin
 system Sayaiban
 	pos 250.431 -274.812
 	government Drak
-	attributes "archon"
+	attributes "archon" "!korath" "!hazard" "!isolated"
 	habitable 2035
 	belt 1803
 	asteroids "small rock" 13 2.106
@@ -21417,6 +21419,7 @@ system Sayaiban
 system Scheat
 	pos -205 233
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 625
 	belt 1536
 	haze _menu/haze-133
@@ -21474,6 +21477,7 @@ system Scheat
 system Schedar
 	pos -93 229
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 1080
 	belt 1903
 	haze _menu/haze-133
@@ -21608,6 +21612,7 @@ system Segesta
 system Seginus
 	pos -557 356
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 135
 	belt 1906
 	link Alnasl
@@ -21673,6 +21678,7 @@ system Seginus
 system Seketra
 	pos -24.5695 -356.812
 	government Uninhabited
+	attributes "!korath" "!fringe"
 	habitable 425.92
 	belt 1465
 	link Skeruto
@@ -21724,6 +21730,7 @@ system Seketra
 system Sepetrosk
 	pos 192.431 -243.812
 	government "Kor Mereti"
+	attributes "!korath" "!automata"
 	habitable 486.68
 	belt 1286
 	link Chimitarp
@@ -21784,6 +21791,7 @@ system Sepetrosk
 system Sepriaptu
 	pos 139.431 -448.812
 	government Uninhabited
+	attributes "!korath" "!fringe"
 	habitable 2035
 	belt 1120
 	link Kaliptari
@@ -21835,6 +21843,7 @@ system Sepriaptu
 system Sevrelect
 	pos -114.569 -239.812
 	government "Kor Efret"
+	attributes "!korath" "!efreti"
 	habitable 320
 	belt 1763
 	haze _menu/haze-67
@@ -21885,6 +21894,7 @@ system Sevrelect
 system Shaula
 	pos -460 527
 	government Pirate
+	attributes "!human" "!south"
 	habitable 625
 	belt 1814
 	link Lesath
@@ -21952,6 +21962,7 @@ system Shaula
 system Sheratan
 	pos -40 45
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 2035
 	belt 1183
 	haze _menu/haze-133
@@ -22011,6 +22022,7 @@ system Sheratan
 system Si'yak'ku
 	pos -329.235 -760.435
 	government Wanderer
+	attributes "!wanderer"
 	habitable 1313.28
 	belt 1985
 	haze _menu/haze-none
@@ -22091,6 +22103,7 @@ system Si'yak'ku
 system Sich'ka'ara
 	pos -97.1237 -831.921
 	government Wanderer
+	attributes "!wanderer"
 	habitable 1715
 	belt 1744
 	haze _menu/haze-none
@@ -22143,6 +22156,7 @@ system Sich'ka'ara
 system Silikatakfar
 	pos 248.431 -481.812
 	government "Kor Sestor"
+	attributes "!korath" "!automata"
 	habitable 425.92
 	belt 1641
 	link Mesuket
@@ -22196,6 +22210,7 @@ system Silikatakfar
 system "Silver Bell"
 	pos -1045.59 541.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 1080
 	belt 1406
 	link "Bright Void"
@@ -22263,6 +22278,7 @@ system "Silver Bell"
 system "Silver String"
 	pos -1022.59 517.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 1080
 	belt 1986
 	link "Silver Bell"
@@ -22327,6 +22343,7 @@ system "Silver String"
 system Similisti
 	pos 210.431 -313.812
 	government "Kor Mereti"
+	attributes "!korath" "!automata"
 	habitable 1080
 	belt 1349
 	haze _menu/haze-133
@@ -22394,6 +22411,7 @@ system Similisti
 system Sirius
 	pos -378 44
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 1800
 	belt 1407
 	link Sol
@@ -22457,6 +22475,7 @@ system Sirius
 system Skeruto
 	pos 28.4305 -339.812
 	government Uninhabited
+	attributes "!korath"
 	habitable 320
 	belt 1198
 	link Furmeliki
@@ -22507,6 +22526,7 @@ system Skeruto
 system Sko'karak
 	pos -304.43 -930.688
 	government Wanderer
+	attributes "!wanderer"
 	habitable 320
 	belt 1805
 	haze _menu/haze-none
@@ -22559,6 +22579,7 @@ system Sko'karak
 system Sobarati
 	pos 277.431 -557.812
 	government "Kor Sestor"
+	attributes "!korath" "!automata"
 	habitable 3780
 	belt 1314
 	link Asikafarnut
@@ -22620,6 +22641,7 @@ system Sobarati
 system Sol
 	pos -400 100
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 1080
 	belt 1529
 	haze _menu/haze-67
@@ -22699,6 +22721,7 @@ system Sol
 system "Sol Arach"
 	pos -711.587 649.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 486.68
 	belt 1147
 	haze _menu/haze-133
@@ -22770,6 +22793,7 @@ system "Sol Arach"
 system "Sol Kimek"
 	pos -1310.63 227.214
 	government Coalition
+	attributes "!coalition" "!kimek"
 	habitable 425.92
 	belt 1490
 	link "3 Pole"
@@ -22844,6 +22868,7 @@ system "Sol Kimek"
 system "Sol Saryd"
 	pos -1037.59 675.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 1313.28
 	belt 1720
 	link Belonging
@@ -22926,6 +22951,7 @@ system "Sol Saryd"
 system Solifar
 	pos 47.4305 -435.812
 	government Uninhabited
+	attributes "!korath"
 	habitable 320
 	belt 1517
 	haze _menu/haze-67
@@ -22981,6 +23007,7 @@ system Solifar
 system Sospi
 	pos -317 -161
 	government Republic
+	attributes "!human" "!north" "!fringe"
 	habitable 1715
 	belt 1715
 	haze _menu/haze-133
@@ -23046,6 +23073,7 @@ system Sospi
 system Speloog
 	pos -967.587 445.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 625
 	belt 1159
 	link Belug
@@ -23112,6 +23140,7 @@ system Speloog
 system Spica
 	pos -906 120
 	government Republic
+	attributes "!human" "!rim"
 	habitable 625
 	belt 1940
 	haze _menu/haze-33
@@ -23175,6 +23204,7 @@ system Statina
 	asteroids "medium metal" 72 3
 	asteroids "small metal" 39 3
 	government Uninhabited
+	attributes "ember waste" "wormhole"
 	haze _menu/haze-red
 	link Diespiter
 	link Egeria
@@ -23213,6 +23243,7 @@ system Statina
 system "Steep Roof"
 	pos -1113.59 570.051
 	government Coalition
+	attributes "!coalition" "!saryd"
 	habitable 1080
 	belt 1100
 	haze _menu/haze-67
@@ -23348,6 +23379,7 @@ system Stercutus
 system Suhail
 	pos -774 -338
 	government Republic
+	attributes "!human" "!deep"
 	habitable 1715
 	belt 1715
 	haze _menu/haze-33
@@ -23408,6 +23440,7 @@ system Suhail
 system Sumar
 	pos -236 -273
 	government Republic
+	attributes "!human" "!north"
 	habitable 2560
 	belt 1778
 	link Cardax
@@ -23467,6 +23500,7 @@ system Sumar
 system Sumprast
 	pos -101.569 -262.812
 	government "Kor Efret"
+	attributes "!korath" "!automata"
 	habitable 486.68
 	belt 1958
 	haze _menu/haze-67
@@ -23532,6 +23566,7 @@ system Sumprast
 system Tais
 	pos -346 381
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 3645
 	belt 1379
 	haze _menu/haze-133
@@ -23589,6 +23624,7 @@ system Tais
 system Talita
 	pos -519 -26
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 1705
 	belt 1403
 	link Miaplacidus
@@ -23654,6 +23690,7 @@ system Talita
 system "Tania Australis"
 	pos -671 7
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1738
 	link Phecda
@@ -23726,6 +23763,7 @@ system "Tania Australis"
 system Tarazed
 	pos -194 448
 	government Republic
+	attributes "!human" "!south"
 	habitable 1215
 	belt 1169
 	link Enif
@@ -23788,6 +23826,7 @@ system Tarazed
 system Tebuteb
 	pos -615.587 710.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 553.28
 	belt 1855
 	link Miblulub
@@ -23849,6 +23888,7 @@ system Tebuteb
 system Tejat
 	pos -489 -107
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 1158.12
 	belt 1447
 	link Phurad
@@ -23926,7 +23966,7 @@ system Tejat
 system Terminus
 	pos -727.99 -23.2491
 	government Republic
-	attributes "wormhole"
+	attributes "wormhole" "!human" "!dirt belt" "!fringe"
 	habitable 425.92
 	belt 1221
 	haze _menu/haze-67
@@ -23979,6 +24019,7 @@ system Terminus
 system "Terra Incognita"
 	pos 9921.5 7086.5
 	government Uninhabited
+	attributes "!pleiades"
 	link "Over the Rainbow"
 	habitable 455.625
 	haze _menu/haze-blackbody
@@ -24023,6 +24064,7 @@ system "Terra Incognita"
 system Torbab
 	pos -949.587 490.051
 	government Coalition
+	attributes "!coalition" "!arach"
 	habitable 1505.92
 	belt 1702
 	link Speloog
@@ -24099,6 +24141,7 @@ system Torbab
 system Tortor
 	pos -255 -424
 	government Republic
+	attributes "!human" "!north" "!fringe"
 	habitable 455.625
 	belt 1243
 	haze _menu/haze-67
@@ -24165,6 +24208,7 @@ system Tortor
 system Turais
 	pos -691 134
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 320
 	belt 1471
 	link Gacrux
@@ -24221,6 +24265,7 @@ system Turais
 system "Ula Mon"
 	pos -64.1218 -559.868
 	government Hai
+	attributes "!hai"
 	habitable 640
 	belt 1574
 	link "Bote Asu"
@@ -24295,7 +24340,7 @@ system "Ula Mon"
 system "Ultima Thule"
 	pos -336 -211
 	government Republic
-	attributes "wormhole"
+	attributes "wormhole" "!north"
 	habitable 2560
 	belt 1635
 	haze _menu/haze-67
@@ -24349,6 +24394,7 @@ system "Ultima Thule"
 system Umbral
 	pos -164 406
 	government Republic
+	attributes "!human" "!south" "!fringe"
 	habitable 670
 	belt 1345
 	link Tarazed
@@ -24426,6 +24472,7 @@ system Umbral
 system Unagi
 	pos -306 -578
 	government Pirate
+	attributes "!human" "!north" "!fringe"
 	habitable 320
 	belt 1960
 	haze _menu/haze-33
@@ -24479,6 +24526,7 @@ system Unagi
 system Unukalhai
 	pos -710 405
 	government Republic
+	attributes "!human" "!rim"
 	habitable 625
 	belt 1968
 	haze _menu/haze-67
@@ -24539,6 +24587,7 @@ system Unukalhai
 system "Uwa Fahn"
 	pos 35.1585 -491.67
 	government Hai
+	attributes "!hai"
 	habitable 320
 	belt 1913
 	link "Ya Hai"
@@ -24602,6 +24651,7 @@ system Vaticanus
 	asteroids "small metal" 14 8
 	asteroids "small rock" 3 6
 	government Uninhabited
+	attributes "!ember waste"
 	haze _menu/haze-red
 	link Egeria
 	link Prosa
@@ -24643,6 +24693,7 @@ system Vaticanus
 system Vega
 	pos -402 182
 	government Republic
+	attributes "!human" "!near earth"
 	habitable 1400
 	belt 1744
 	link Altair
@@ -24706,6 +24757,7 @@ system Vega
 system Vindemiatrix
 	pos -635 257
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1080
 	belt 1957
 	link Alioth
@@ -24758,6 +24810,7 @@ system Vindemiatrix
 system Volax
 	pos -256 -179
 	government Republic
+	attributes "!human" "!north"
 	habitable 1715
 	belt 1424
 	haze _menu/haze-67
@@ -24812,6 +24865,7 @@ system Volax
 system "Wah Ki"
 	pos 14.9925 -612.792
 	government Hai
+	attributes "!hai" "!warzone"
 	habitable 425.92
 	belt 1585
 	link "Zuba Zub"
@@ -24880,6 +24934,7 @@ system "Wah Ki"
 system "Wah Oh"
 	pos -205.344 -381.381
 	government Hai
+	attributes "!hai"
 	habitable 5000
 	belt 1194
 	haze _menu/haze-67
@@ -24958,6 +25013,7 @@ system "Wah Oh"
 system "Wah Yoot"
 	pos 40.9382 -685.994
 	government "Hai (Unfettered)"
+	attributes "!hai"
 	habitable 1080
 	belt 1222
 	link "Wah Ki"
@@ -25022,7 +25078,7 @@ system "Wah Yoot"
 system Waypoint
 	pos -184 -515
 	government Hai
-	attributes "wormhole"
+	attributes "wormhole" "!hai"
 	habitable 78.125
 	belt 1610
 	haze _menu/haze-67
@@ -25080,6 +25136,7 @@ system Waypoint
 system Wazn
 	pos -385 -131
 	government Republic
+	attributes "!human" "!paradise"
 	habitable 534.375
 	belt 1414
 	haze _menu/haze-67
@@ -25145,6 +25202,7 @@ system Wazn
 system Wei
 	pos -598 369
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 455.625
 	belt 1927
 	link Seginus
@@ -25202,6 +25260,7 @@ system Wei
 system Wezen
 	pos -664 -433
 	government Republic
+	attributes "!human" "!deep"
 	habitable 2880
 	belt 1913
 	link Naos
@@ -25283,6 +25342,7 @@ system Wezen
 system "World's End"
 	pos 9966.5 7017.5
 	government Uninhabited
+	attributes "!pleiades"
 	habitable 700
 	haze _menu/haze-blackbody
 	object
@@ -25342,6 +25402,7 @@ system "World's End"
 system "Ya Hai"
 	pos -24.9453 -505.571
 	government Hai
+	attributes "!hai"
 	habitable 425.92
 	belt 1120
 	link "Ula Mon"
@@ -25416,6 +25477,7 @@ system "Ya Hai"
 system "Yed Prior"
 	pos -810 374
 	government Republic
+	attributes "!human" "!south"
 	habitable 455.625
 	belt 1837
 	link Pherkad
@@ -25472,6 +25534,7 @@ system "Yed Prior"
 system Zaurak
 	pos -109 -34
 	government Syndicate
+	attributes "!human" "!core"
 	habitable 625
 	belt 1130
 	haze _menu/haze-133
@@ -25529,6 +25592,7 @@ system Zaurak
 system "Zeta Aquilae"
 	pos -369 276
 	government Republic
+	attributes "!human" "!dirt belt"
 	habitable 1400
 	belt 1829
 	haze _menu/haze-133
@@ -25603,6 +25667,7 @@ system "Zeta Aquilae"
 system "Zeta Centauri"
 	pos -835 257
 	government Republic
+	attributes "!human" "!rim"
 	habitable 455.625
 	belt 1488
 	haze _menu/haze-67
@@ -25658,6 +25723,7 @@ system "Zeta Centauri"
 system Zosma
 	pos -640 -123
 	government Republic
+	attributes "!human" "!deep"
 	habitable 455.625
 	belt 1436
 	link Algieba
@@ -25855,6 +25921,7 @@ system Zubenelgenubi
 system Zubeneschamali
 	pos -759 338
 	government Republic
+	attributes "!human" "!rim"
 	habitable 1250
 	belt 1543
 	haze _menu/haze-67


### PR DESCRIPTION
## Feature Details
This adds attribute tags to every system in the map file. Tags are based on the dominant species/government, with additional tags for sub-regions (such as the Deep), noteworthy points in galactic topography - such as dead-ends, hyperspace "islands", and system-defining phenomena such as the presence of supernova remnants, ringworlds, or wormholes.

New tags are prefixed with a ! to make find-and-replace easier. This isn't necessarily intended to be their final name; just something to facilitate replacement when that's decided on.

Topographical tags:
**!fringe** - applied to uninhabited systems which don't lead to any other inhabited systems. Only explorers, miners, or those with something to hide would have a reason to visit these systems.
**!isolated** - applied to systems which have no hyperspace links. 

System phenomena:
**!ringworld** - This system hosts a ringworld, intact or otherwise.
**!nova** - This system's star has gone nova.
**!wormhole** - This system hosts a wormhole
**!black hole** - This system has a black hole. At the moment this is only applied to Sag. A*.
**!hazard** - This system can destroy your ship if you linger. At the moment this is only applied to Sayaiban (nanobots).
**!warzone** - This system is the front-line of a conflict. At the moment this is applied to Mesuket and Wah Ki. It could, however, find use in the campaigns to generate job board missions based on your faction - relief shipments, rescue/exfiltration, reinforcements, EOD, etc.
**!war-torn** - Not currently applied to any systems. I recommend applying it to ex-warzone systems. Could be used to generate missions regarding reconstruction, EOD, refugee aid/transport, salvage, etc.

**!human** - applied to all systems in greater human space. Includes uninhabited systems, Deneb, Quarg near Tarazed, does not include Remnant or human-inhabited Hai space.

Tags for sub-regions of human space:
**!north
!deep
!paradise
!core
!near earth 
!rim
!dirt belt
!south**

**!coalition** - Greater coalition space, including Heliarch-governed systems.

Tags for sub-regions of Coalition space:
**!arach**
**!saryd**
**!kimek**

**!korath** - This is applied to the full historical extent of Korath civilization, including now-abandoned systems, supernova'd stars, and the current extent of Korath spread.

Tags for sub-regions of Korath space:
**!automata** - Includes uninhabited systems where automata spawn, or have left traces.
**!efreti** - Includes the Quarg ringworld in Korath space.
**!exiles** - Includes the uninhabited star between the two main exile "islands".

**!wanderer** - Describes historical Wanderer space, including territory ceded to the Unfettered. Does not include Wanderer colonies/bases in Korath space.

**!hai** - Applied to all of Hai space, includes the Unfettered

**!ember waste** - Most systems in the ember waste already have the "ember waste" attribute added by Zitchas. My additions are prefixed with the ! to disambiguate. If the change is acceptable these should have the ! taken out.

**!pleiades** - Systems in the galaxy found through the Deneb wormhole.

## UI Screenshots
N/A

## Usage Examples
```
system Peresedersi
	pos 81.4305 -154.812
	government Uninhabited
	attributes "archon" "!korath" "!isolated" "!nova"
```
The system Peresedersi has had three new tags appended to it: "Korath" shows that it's within the historical extent of Korath space (including the current diaspora and their former stomping grounds), "isolated" is appended due to there being no hyperlanes linking to this system, and "nova" on account of the system hosting supernova remnants. Archon was already there.
## Testing Done
None so far (9/26/20)

## Performance Impact
N/A

## Lake's notes and concerns
The main intention behind the addition of these tags is to make it easier to generate missions that target - or exclude - specific regions of space. Along the way I decided adding in noteworthy system-wide features could be conducive to that aim. 

Mixed feelings about tagging the Pleiades system "World's End" with **!ringworld**. There's one there, but generating missions that target it seem like an unintended result. As such, I'm leaving it out unless y'all think otherwise.