### PR TITLE
fix(doc) Update copyright file.

### DIFF
--- a/copyright
+++ b/copyright
@@ -5,6 +5,7 @@ Source: https://github.com/endless-sky/endless-sky
 
 Files: *
 Copyright: Michael Zahniser <mzahniser@gmail.com>
+           endless-sky contributors (see credits.txt and changelog)
 License: GPL-3+
 
 Files: images/*


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5346.

## Fix Details
The file "copyright" doesn't indicate some authors.
This PR adds "endless-sky contributors" to the default item of copyright.

You may still claim your copyright if you want because this PR modifies only the default line.

## Testing Done
N/A

## Save File
N/A
