### PR TITLE
(fix) New Wanderer jobs corrections

### DIFF
--- a/data/wanderer/wanderer jobs.txt
+++ b/data/wanderer/wanderer jobs.txt
@@ -831,10 +831,11 @@ mission "Wanderers to Kor Efreti"
 	stopover
 		distance 2 8
 		government "Kor Efret"
+		not attributes "station"
 	on visit
 		dialog phrase "generic missing stopover or passengers"
 	on stopover
-		dialog `The Wanderers tour the planet to investigate the envoronmental problems this Kor Efret world faces. They try to point out specific things to the Korath accompanying them, but it's not very effective. After a few hours, they've gathered enough data and are ready to return home.`
+		dialog `The Wanderers tour the planet to investigate the environmental problems this Kor Efret world faces. They try to point out specific things to the Korath accompanying them, but it's not very effective. After a few hours, they've gathered enough data and are ready to return home.`
 	on complete
 		payment 35000 300
 		dialog `When you return, the Wanderers thank you for taking them to the Kor Efreti and hand you <payment> before disembarking.`


### PR DESCRIPTION
Fixes issue #5379 opened by @ roadrunner56.

-Corrected a typo
-Ensured station could not be a stopover for the job by adding `not attributes "station"` to stopover

To the best of my knowledge and some quick testing, this fixes the issue, but @tehhowch said something that made me a little hesitant:
> dynamic stopover filters in 0.9.13 are a small bit more lenient in the landing locations they can select, so pure government filters may not be sufficiently specific

So it sounds like there could be some things going on under the hood that I'm not fully aware of. If someone with a bit more knowledge of the code could check this in regards to @ tehhowch 's comment it would be much appreciated.

This save can be used to test this:
[Firstname Lastname~test start.txt](https://github.com/endless-sky/endless-sky/files/5288233/Firstname.Lastname.test.start.txt)
