### PR TITLE
feat: Use lambda expression for adding incomes in BankPanel.

### DIFF
--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -47,7 +47,7 @@ namespace {
 	// Helper function to collapse (summarize, multiply or otherwise combine) a number of
 	// conditions (that start with the same prefix) into a single value.
 	// The caller of this function should provide the lamba expression that performs the
-	// actual collapsing. This function just calls the collapse-funtion once for every
+	// actual collapsing. This function just calls the collapse-function once for every
 	// condition that matches the prefix.
 	template <typename A>
 	void CollapseConditions(const map<string, int64_t> &conditions, const string &prefix, A collapseFun)

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -43,6 +43,19 @@ namespace {
 	
 	// Maximum number of rows of mortages, etc. to draw.
 	const int MAX_ROWS = 8;
+	
+	// Helper function to collapse (summarize, multiply or otherwise combine) a number of
+	// conditions (that start with the same prefix) into a single value.
+	// The caller of this function should provide the lamba expression that performs the
+	// actual collapsing. This function just calls the collapse-funtion once for every
+	// condition that matches the prefix.
+	template <typename A>
+	void CollapseConditions(const map<string, int64_t> &conditions, const string &prefix, A collapseFun)
+	{
+		auto it = conditions.lower_bound(prefix);
+		for( ; it != conditions.end() && !it->first.compare(0, prefix.length(), prefix); ++it)
+			collapseFun(it->second);
+	}
 }
 
 
@@ -108,9 +121,10 @@ void BankPanel::Draw()
 	static const string prefix[2] = {"salary: ", "tribute: "};
 	for(int i = 0; i < 2; ++i)
 	{
-		auto it = player.Conditions().lower_bound(prefix[i]);
-		for( ; it != player.Conditions().end() && !it->first.compare(0, prefix[i].length(), prefix[i]); ++it)
-			income[i] += it->second;
+		CollapseConditions(player.Conditions(), prefix[i],
+			[&income, i](int64_t a) {
+				income[i] += a;
+			});
 	}
 	// Check if maintenance needs to be drawn.
 	int64_t maintenance = player.Maintenance();


### PR DESCRIPTION
**Feature:** This PR implements a small step towards the **on-demand conditions** as proposed in issue #5017

## Feature Details
PR #5244 already added some functions to abstract access to the conditions, but the GetConditionSum function from that PR looked a bit too specialized in a generic environment.
This PR makes a first step towards a more generic CollapseConditions function that should provide the same functionality of GetConditionSum from #5244, but in a more generic (and better performing) way by having the collapsing function (sum) provided as lambda expression parameter.

The CollapseConditions function should become a member of the class that contains the conditions in or after PR #5244 (and should get the conditions from the class instead of as parameter), but it doesn't look out of place in its current shape in BankPanel until the discussion there is done on how the new class will look.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Checked if the BankPanel for one of my savegames gave the correct number for Salary and Tribute income.

## Performance Impact
The lamba-expression can convert directly from the input-conditions to the desired target-format, so performance should be better than for the GetConditionSum function (and should be near the original performance of the direct map-accesses).

The affected code is not performance critical, so I don't expect many people to care a lot.