### PR TITLE
feat: Don't let player ships autofire at disabled ships that were boarded.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2904,7 +2904,8 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 		// Homing weapons revert to "dumb firing" if they have no target.
 		if(weapon->Homing() && currentTarget)
 		{
-			bool hasBoarded = Has(ship, currentTarget, ShipEvent::BOARD);
+			// NPCs shoot ships that they just plundered.
+			bool hasBoarded = !ship.IsYours() && Has(ship, currentTarget, ShipEvent::BOARD);
 			if(currentTarget->IsDisabled() && spareDisabled && !hasBoarded && !disabledOverride)
 				continue;
 			// Don't fire secondary weapons at targets that have started jumping.
@@ -2938,8 +2939,8 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 		// For non-homing weapons:
 		for(const auto &target : enemies)
 		{
-			// Don't shoot ships we want to plunder.
-			bool hasBoarded = Has(ship, target, ShipEvent::BOARD);
+			// NPCs shoot ships that they just plundered.
+			bool hasBoarded = !ship.IsYours() && Has(ship, target, ShipEvent::BOARD);
 			if(target->IsDisabled() && spareDisabled && !hasBoarded && !disabledOverride)
 				continue;
 			


### PR DESCRIPTION
**Feature:** This PR implements the bugfix/feature request discussed in #5382 

## Feature Details
Ships (mostly the player flagship) owned by the player no longer automatically fires at ships that were previously boarded.

Amazinite did all the work to find the relevant code (and posted that in  #5382), I just created the relevant PR for it.

## UI Screenshots
N/A

## Usage Examples
The relevant actions to trigger this change are:
- Get yourself a ship with turrets
- Enable auto-fire
- Board some ship
- Notice that the ship doesn't get fired upon by your ship after boarding

## Testing Done
I checked that:
- Navy ships still fire at disabled ships.
- Free world ships still don't fire at disabled ships.
- Player ships no longer auto-fire at disabled ships after boarding.

## Performance Impact
The ship->IsYours() function just returns the value of a boolean, so I expect no serious performance impact.
