### PR TITLE
typo: FWC Pug 4 missing period

### DIFF
--- a/data/human/free worlds checkmate.txt
+++ b/data/human/free worlds checkmate.txt
@@ -1709,7 +1709,7 @@ mission "FWC Pug 3D: Reinforcements"
 mission "FWC Pug 4"
 	landing
 	name "Defend <system>"
-	description "Drive off the Pug fleet that is invading <system>"
+	description "Drive off the Pug fleet that is invading <system>."
 	source Oblivion
 	destination Oblivion
 	clearance


### PR DESCRIPTION
Changed `Drive off the Pug fleet that is invading <system>` to `Drive off the Pug fleet that is invading <system>.`.