### PR TITLE
Update persons.txt

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -674,7 +674,7 @@ person "Local God"
 			" and "
 		word
 			"retire as an outfit dealer."
-			"open a univeral outfitter."
+			"open a universal outfitter."
 			"start dealing exotic outfits."
 			"sell outfits from everywhere."
 			"stock outfits from all over the place."


### PR DESCRIPTION
fixed a misspelling. changed "open a univeral [sic] outfitter." to "open a universal outfitter."
 
-----------------------
**Bugfix:** This PR addresses issue #5391 

## Fix Details
added the letter s to fix the typo 

## Testing Done
it's just a typo fix, i have bad memories with cmake please don't get mad at me for not testing.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}


