### PR TITLE
add blackbody haze to saquergen

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -20652,6 +20652,7 @@ system Saquergen
 	government Uninhabited
 	habitable 100
 	belt 1435
+	haze _menu/haze-blackbody
 	asteroids "small rock" 3 3.9105
 	asteroids "medium rock" 1 4.3255
 	asteroids "small metal" 2 6.7143


### PR DESCRIPTION
seems I forgot to add the haze the other nova systems like Persitar and Kasikfar have, so adding it now
pointed out by @ Anarchist2  on discord