### PR TITLE
Change Picture of Kestrel in "Kestrel Available" from top-down to thumbnail

### DIFF
--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -191,7 +191,7 @@ mission "Kestrel Available"
 	destination "Wayfarer"
 	on offer
 		conversation
-			scene ship/kestrel
+			scene thumbnail/kestrel
 			`You receive a message from Charles Atinoda, the ship designer at Tarazed Corporation: "Captain <last>, we are pleased to inform you that our latest warship is now available for sale here on Wayfarer. We've taken all your feedback into account in the final design. Thank you again!"`
 				decline
 


### PR DESCRIPTION
This matches the precedent of using thumbnail images to show ships in conversations, such as the Tempest, Penguin and Emerald Sword.