### PR TITLE
"You have visited" map key highlights uninhabited systems with landable planets

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -699,11 +699,12 @@ void MapPanel::UpdateCache()
 		Color color = UninhabitedColor();
 		if(!player.HasVisited(&system))
 			color = UnexploredColor();
-		else if(system.IsInhabited(player.Flagship()) || commodity == SHOW_SPECIAL)
+		else if(system.IsInhabited(player.Flagship()) || commodity == SHOW_SPECIAL || commodity == SHOW_VISITED)
 		{
 			if(commodity >= SHOW_SPECIAL)
 			{
 				double value = 0.;
+				bool colorSystem = true;
 				if(commodity >= 0)
 				{
 					const Trade::Commodity &com = GameData::Commodities()[commodity];
@@ -733,19 +734,23 @@ void MapPanel::UpdateCache()
 				{
 					bool all = true;
 					bool some = false;
+					colorSystem = false;
 					for(const StellarObject &object : system.Objects())
-						if(object.GetPlanet() && !object.GetPlanet()->IsWormhole())
+						if(object.GetPlanet() && !object.GetPlanet()->IsWormhole()
+							&& object.GetPlanet()->IsAccessible(player.Flagship()))
 						{
 							bool visited = player.HasVisited(object.GetPlanet());
 							all &= visited;
 							some |= visited;
+							colorSystem = true;
 						}
 					value = -1 + some + all;
 				}
 				else
 					value = SystemValue(&system);
 				
-				color = MapColor(value);
+				if(colorSystem)
+					color = MapColor(value);
 			}
 			else if(commodity == SHOW_GOVERNMENT)
 			{


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #5399.

## Feature Details
<insert the title here\>

## UI Screenshots
Map system coloring using:
* commodity key (unchanged, notice Algieba)
![image](https://user-images.githubusercontent.com/17688683/95009818-e1982080-05f2-11eb-946f-c48e14121eb1.png)
* visited key (now highlights uninhabited systems with landable planets, notice Algieba)
![image](https://user-images.githubusercontent.com/17688683/95009861-15734600-05f3-11eb-9ffb-323db65947a5.png)
* visited key (looking at a restricted planet w/o access)
![image](https://user-images.githubusercontent.com/17688683/95009874-2d4aca00-05f3-11eb-8446-f7d8f54519c0.png)
* visited key (looking at a restricted planet w/ access)
![image](https://user-images.githubusercontent.com/17688683/95009885-3dfb4000-05f3-11eb-85f1-f00445913049.png)

## Usage Examples
N/A

## Testing Done
See UI screenshots section.

## Performance Impact
N/A
