### PR TITLE
Save variant names for gifted ships

### DIFF
--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -33,7 +33,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
-	void DoGift(PlayerInfo &player, const Ship *model, const string &name, UI *ui)
+	void DoGift(PlayerInfo &player, const Ship *model, const string &name)
 	{
 		if(model->ModelName().empty())
 			return;
@@ -314,7 +314,7 @@ void MissionAction::Save(DataWriter &out) const
 			conversation.Save(out);
 		
 		for(const auto &it : giftShips)
-			out.Write("give", "ship", it.first->ModelName(), it.second);
+			out.Write("give", "ship", it.first->VariantName(), it.second);
 		for(const auto &it : giftOutfits)
 			out.Write("outfit", it.first->Name(), it.second);
 		for(const auto &it : requiredOutfits)
@@ -464,7 +464,7 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 			player.AddSpecialLog(it.first, eit.first, eit.second);
 	
 	for(const auto &it : giftShips)
-		DoGift(player, it.first, it.second, ui);
+		DoGift(player, it.first, it.second);
 	// If multiple outfits are being transferred, first remove them before
 	// adding any new ones.
 	for(const auto &it : giftOutfits)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -131,7 +131,10 @@ void Ship::Load(const DataNode &node)
 		pluralModelName = modelName + 's';
 	}
 	if(node.Size() >= 3)
+	{
 		base = GameData::Ships().Get(modelName);
+		variantName = node.Token(2);
+	}
 	
 	government = GameData::PlayerGovernment();
 	equipped.clear();
@@ -849,6 +852,14 @@ const string &Ship::ModelName() const
 const string &Ship::PluralModelName() const
 {
 	return pluralModelName;
+}
+
+
+
+// Get the name of this ship as a variant.
+const string &Ship::VariantName() const
+{
+	return variantName.empty() ? modelName : variantName;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -133,6 +133,8 @@ public:
 	// Get the name of this model of ship.
 	const std::string &ModelName() const;
 	const std::string &PluralModelName() const;
+	// Get the name of this ship as a variant.
+	const std::string &VariantName() const;
 	// Get the generic noun (e.g. "ship") to be used when describing this ship.
 	const std::string &Noun() const;
 	// Get this ship's description.
@@ -428,6 +430,7 @@ private:
 	const Ship *base = nullptr;
 	std::string modelName;
 	std::string pluralModelName;
+	std::string variantName;
 	std::string noun;
 	std::string description;
 	const Sprite *thumbnail = nullptr;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5400.

## Fix Details
This PR fixes #5400 by saving the variant name to the save file instead of just the model name. This means that upon reloading, the correct ship is recognized as the one that should be gifted.

## Testing Done
See the mission mentioned in #5400. Also tested that mission by giving normal Kestrels to ensure that Ship::VariantName() returns modelName if no variantName exists, and it works.

## Save File
N/A

## Additional Context
See #5404 for an alternative approach. I started work on that approach, then finished this one, then figured why not do the second one, then figured out why I like this one after finishing that one. Since I have both finished though, I figured I'd just post both.