### PR TITLE
Allow gifted ships to be defined in place

### DIFF
--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "LocationFilter.h"
 #include "Phrase.h"
 
+#include <list>
 #include <map>
 #include <memory>
 #include <set>
@@ -83,7 +84,8 @@ private:
 	Conversation conversation;
 	
 	std::map<const GameEvent *, std::pair<int, int>> events;
-	std::map<const Ship *, std::string> giftShips;
+	std::map<const Ship *, std::string> giftStockShips;
+	std::list<std::shared_ptr<Ship>> giftShips;
 	std::map<const Outfit *, int> giftOutfits;
 	std::map<const Outfit *, int> requiredOutfits;
 	int64_t payment = 0;


### PR DESCRIPTION
**Feature:** This PR implements the feature request discussed in issue #5400 and #5302.

## Feature Details
This PR solves #5400 by allowing gifted ships to be defined within the mission. Any gifted ships that are only given by name get saved to the save file as a full ship definition, meaning that any named variants get saved in their variant configuration, and therefore gifted in their variant configuration even after reloading a save without the need to save the variant name.

Note that much of the distinction between giftShips and giftStockShips and how they both get merged into giftShips upon instantiation has been lifted from NPC.cpp.

## UI Screenshots
N/A

## Usage Examples/Syntax
```
on *
	give
		ship "<model name>" ["<name>"]
			<ship definition here>
```

## Testing Done
Same testing as #5400.

## Performance Impact
N/A

## Additional Context
Near the end of finishing this PR, I've decided that I think that #5403 is the better solution.

One of the potential reasons why we would allow a gifted ship to be defined in place and therefore have the ship's entire definition be saved to the save file is to allow on-the-fly changes to a ship definition. For example, perhaps you want a gifted ship that is never disabled, you can reference the base model and only change that tag. This is akin to how this is possible to do with `npc` blocks.

After looking through the game though, I can't recall or even find any instance of a ship actually being defined within an `npc` block. All instances of unique ships used for `npc` blocks are defined outside of the mission itself, often just above or below where the mission is defined, but still outside of it. Then looking at the wiki, while it is possible to define a ship entirely within an `npc` block, it actually looks to me that this is undefined behavior, as it is not listed on the wiki. The relevant section of code in NPC.cpp also mentions how having an entire ship definition in an `npc` block is intended for loading from a save file. With gifted ships though, this is entirely unnecessary to do, as a gifted ship from a mission doesn't need to be kept track of by the mission in the same way as an NPC does. NPC ships are written in their entirety to the save file because we need to keep track of their health and other such important stats. For gifted ships though, all we care about is the model and name of the ship, so that's really all we should be saving. And seeing as how the convention is already to define the variant outside of the mission that uses it, I don't see an issue in requiring that a gifted variant be defined outside of the mission as well.

An important thing to note as well is that if you're defining a ship within a `give` or `npc` block, you actually either HAVE to name it on the same line or HAVE to give an ENTIRE ship definition. This is because Ship.cpp only recognizes that a ship is a variant if there is a token after the model name. This informs the game that the given ship has a base model that it should use to fill in any missing information. Otherwise, it thinks it has a whole ship definition, which may not be the case. The following will crash the game if you try to view it anywhere, as you're creating a ship with no attributes and the game doesn't recognize that this ship has a base model since the line with `ship` doesn't have three tokens.
```
give
	ship "Kestrel"
		"never disabled"
```
What this means is that you can't gift a ship that is defined in place with a randomized name unless you're giving an entire ship definition.

Overall, this just seems like a less refined way of doing this as compared to the status quo of defining variants outside of the mission that uses them and simply using #5403 to fix #5400. I'll leave it up to @tehhowch though as to which approach we use, because there's really no harm in using this approach outside of being aware of its pitfalls.