### PR TITLE
New auto conditions: visited locations, installed outfits, and total ships

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2356,7 +2356,8 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 			for(const auto &outfit : ship->Outfits())
 				conditions["outfit: " + outfit.first->Name()] += outfit.second;
 		}
-		++conditions["total ships"];
+		if(!ship->IsDestroyed())
+			++conditions["total ships"];
 	}
 	// If boarding a ship, missions should not consider the space available
 	// in the player's entire fleet. The only fleet parameter offered to a

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2341,7 +2341,7 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 	};
 	// Clear any existing ships: or outfit: conditions. (Note: '!' = ' ' + 1.)
 	clearRange(conditions, "ships: ", "ships:!");
-	clearRange(conditions, "outfit: ", "outfits:!");
+	clearRange(conditions, "outfit: ", "outfit:!");
 	// Store special conditions for cargo and passenger space.
 	conditions["cargo space"] = 0;
 	conditions["passenger space"] = 0;
@@ -2371,7 +2371,7 @@ void PlayerInfo::UpdateAutoConditions(bool isBoarding)
 	// Clear any existing flagship system:, planet:, and outfit: conditions. (Note: '!' = ' ' + 1.)
 	clearRange(conditions, "flagship system: ", "flagship system:!");
 	clearRange(conditions, "flagship planet: ", "flagship planet:!");
-	clearRange(conditions, "flagship outfit: ", "flagship outfits:!");
+	clearRange(conditions, "flagship outfit: ", "flagship outfit:!");
 	
 	// Store conditions for flagship current crew, required crew, and bunks.
 	if(flagship)


### PR DESCRIPTION
**Feature:** This PR implements the feature request discussed by https://github.com/endless-sky/endless-sky/issues/2494#issuecomment-704409776.
Effectively resolves #2494.
Resolves #3735.

## Feature Details
Adds the following auto conditions:
* `"total ships"`: How many ships the player has in their fleet, irrespective of their location or parked status.
* `"visited planet: <planet name>"`: Exists for each planet the player has visited.
* `"visited system: <system name>"`: Exists for each system the player has visited.
* `"outfit: <name>"`: Exists for each outfit the player has installed on any ship that is not disabled or parked in system. (Same behavior as `"ships: <category>"`.)
* `"flagship outfit: <name>"`: Exists for each outfit installed on the player's flagship. These outfits are also counted in the previous condition.

## UI Screenshots
N/A

## Usage Examples
They're conditions. You use them like any other condition.

## Testing Done
Loaded the game with these changes. The proper conditions were written to the save file. Conditions were updated after changing my fleet composition. Unvisiting systems/planets removed those conditions.

## Performance Impact
N/A