### PR TITLE
Allow capturing an NPC to be an objective

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -62,6 +62,8 @@ void NPC::Load(const DataNode &node)
 			succeedIf |= ShipEvent::SCAN_CARGO;
 		else if(node.Token(i) == "scan outfits")
 			succeedIf |= ShipEvent::SCAN_OUTFITS;
+		else if(node.Token(i) == "capture")
+			succeedIf |= ShipEvent::CAPTURE;
 		else if(node.Token(i) == "evade")
 			mustEvade = true;
 		else if(node.Token(i) == "accompany")


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #1763.

## Feature Details
Creates a new NPC mission objective: capture.
Yes, it really is just these two lines.

## UI Screenshots
N/A

## Usage Examples
See testing done.

## Testing Done
Tested on the following mission.
```
mission "capture test"
	job
	repeat
	npc capture
		government "Bounty"
		personality staying
		ship "Shuttle" "Cap Me"
		dialog "Oh no, you captured me."
	on complete
		dialog "<npc> was successfully captured."
```

## Performance Impact
N/A
