### PR TITLE
Allow location filters to test if a planet/system has been visited

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -478,7 +478,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 	// First, figure out the comparative strengths of the present governments.
 	const System *playerSystem = player.GetSystem();
 	map<const Government *, int64_t> strength;
-	UpdateStrengths(strength, playerSystem);
+	UpdateStrengths(player, strength, playerSystem);
 	CacheShipLists();
 	
 	// Update the counts of how long ships have been outside the "invisible fence."
@@ -3624,7 +3624,7 @@ bool AI::Has(const Ship &ship, const Government *government, int type) const
 
 
 
-void AI::UpdateStrengths(map<const Government *, int64_t> &strength, const System *playerSystem)
+void AI::UpdateStrengths(const PlayerInfo &player, map<const Government *, int64_t> &strength, const System *playerSystem)
 {
 	// Tally the strength of a government by the cost of its present and able ships.
 	governmentRosters.clear();
@@ -3664,7 +3664,7 @@ void AI::UpdateStrengths(map<const Government *, int64_t> &strength, const Syste
 	
 		// Check if this ship's government has the authority to enforce scans & fines in this system.
 		if(!scanPermissions.count(gov))
-			scanPermissions.emplace(gov, gov && gov->CanEnforce(playerSystem));
+			scanPermissions.emplace(gov, gov && gov->CanEnforce(player, playerSystem));
 
 		// Only have ships update their strength estimate once per second on average.
 		if(!gov || it->GetSystem() != playerSystem || it->IsDisabled() || Random::Int(60))

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -476,9 +476,8 @@ void AI::ClearOrders()
 void AI::Step(const PlayerInfo &player, Command &activeCommands)
 {
 	// First, figure out the comparative strengths of the present governments.
-	const System *playerSystem = player.GetSystem();
 	map<const Government *, int64_t> strength;
-	UpdateStrengths(player, strength, playerSystem);
+	UpdateStrengths(player, strength);
 	CacheShipLists();
 	
 	// Update the counts of how long ships have been outside the "invisible fence."
@@ -500,6 +499,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 		}
 	
 	const Ship *flagship = player.Flagship();
+	const System *playerSystem = player.GetSystem();
 	step = (step + 1) & 31;
 	int targetTurn = 0;
 	int minerCount = 0;
@@ -3624,8 +3624,9 @@ bool AI::Has(const Ship &ship, const Government *government, int type) const
 
 
 
-void AI::UpdateStrengths(const PlayerInfo &player, map<const Government *, int64_t> &strength, const System *playerSystem)
+void AI::UpdateStrengths(const PlayerInfo &player, map<const Government *, int64_t> &strength)
 {
+	const System *playerSystem = player.GetSystem();
 	// Tally the strength of a government by the cost of its present and able ships.
 	governmentRosters.clear();
 	for(const auto &it : ships)

--- a/source/AI.h
+++ b/source/AI.h
@@ -143,7 +143,7 @@ private:
 	bool Has(const Ship &ship, const Government *government, int type) const;
 	
 	// Functions to classify ships based on government and system.
-	void UpdateStrengths(const PlayerInfo &player, std::map<const Government *, int64_t> &strength, const System *playerSystem);
+	void UpdateStrengths(const PlayerInfo &player, std::map<const Government *, int64_t> &strength);
 	void CacheShipLists();
 	
 	

--- a/source/AI.h
+++ b/source/AI.h
@@ -143,7 +143,7 @@ private:
 	bool Has(const Ship &ship, const Government *government, int type) const;
 	
 	// Functions to classify ships based on government and system.
-	void UpdateStrengths(std::map<const Government *, int64_t> &strength, const System *playerSystem);
+	void UpdateStrengths(const PlayerInfo &player, std::map<const Government *, int64_t> &strength, const System *playerSystem);
 	void CacheShipLists();
 	
 	

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1599,7 +1599,7 @@ void Engine::SpawnPersons()
 	// this system.
 	int sum = 0;
 	for(const auto &it : GameData::Persons())
-		sum += it.second.Frequency(player.GetSystem());
+		sum += it.second.Frequency(player, player.GetSystem());
 	// Bail out if there are no eligible persons.
 	if(!sum)
 		return;
@@ -1612,7 +1612,7 @@ void Engine::SpawnPersons()
 	for(const auto &it : GameData::Persons())
 	{
 		const Person &person = it.second;
-		sum -= person.Frequency(player.GetSystem());
+		sum -= person.Frequency(player, player.GetSystem());
 		if(sum < 0)
 		{
 			const System *source = nullptr;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1599,7 +1599,7 @@ void Engine::SpawnPersons()
 	// this system.
 	int sum = 0;
 	for(const auto &it : GameData::Persons())
-		sum += it.second.Frequency(player, player.GetSystem());
+		sum += it.second.Frequency(player);
 	// Bail out if there are no eligible persons.
 	if(!sum)
 		return;
@@ -1612,7 +1612,7 @@ void Engine::SpawnPersons()
 	for(const auto &it : GameData::Persons())
 	{
 		const Person &person = it.second;
-		sum -= person.Frequency(player, player.GetSystem());
+		sum -= person.Frequency(player);
 		if(sum < 0)
 		{
 			const System *source = nullptr;

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -226,10 +226,10 @@ double Government::GetFineFraction() const
 
 // Returns true if this government has no enforcement restrictions, or if the
 // indicated system matches at least one enforcement zone.
-bool Government::CanEnforce(const System *system) const
+bool Government::CanEnforce(const PlayerInfo &player, const System *system) const
 {
 	for(const LocationFilter &filter : enforcementZones)
-		if(filter.Matches(system))
+		if(filter.Matches(player, system))
 			return true;
 	return enforcementZones.empty();
 }
@@ -238,10 +238,10 @@ bool Government::CanEnforce(const System *system) const
 
 // Returns true if this government has no enforcement restrictions, or if the
 // indicated planet matches at least one enforcement zone.
-bool Government::CanEnforce(const Planet *planet) const
+bool Government::CanEnforce(const PlayerInfo &player, const Planet *planet) const
 {
 	for(const LocationFilter &filter : enforcementZones)
-		if(filter.Matches(planet))
+		if(filter.Matches(player, planet))
 			return true;
 	return enforcementZones.empty();
 }

--- a/source/Government.h
+++ b/source/Government.h
@@ -69,8 +69,8 @@ public:
 	double GetFineFraction() const;
 	// A government might not exercise the ability to perform scans or fine
 	// the player in every system.
-	bool CanEnforce(const System *system) const;
-	bool CanEnforce(const Planet *planet) const;
+	bool CanEnforce(const PlayerInfo &player, const System *system) const;
+	bool CanEnforce(const PlayerInfo &player, const Planet *planet) const;
 	// Get the conversation that will be shown if this government gives a death
 	// sentence to the player (for carrying highly illegal cargo).
 	const Conversation *DeathSentence() const;

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -134,7 +134,7 @@ HailPanel::HailPanel(PlayerInfo &player, const StellarObject *object)
 	else if(planet && player.Flagship())
 	{
 		for(const Mission &mission : player.Missions())
-			if(mission.HasClearance(planet) && mission.ClearanceMessage() != "auto"
+			if(mission.HasClearance(player, planet) && mission.ClearanceMessage() != "auto"
 					&& mission.HasFullClearance())
 			{
 				planet->Bribe();

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -218,9 +218,9 @@ void LocationFilter::Save(DataWriter &out) const
 			out.EndChild();
 		}
 		if(visitedPlanet)
-			out.Write("visited planet");
-		if(visitedSystem)
-			out.Write("visited system");
+			out.Write("visited", "planet");
+		else if(visitedSystem)
+			out.Write("visited");
 		if(center)
 			out.Write("near", center->Name(), centerMinDistance, centerMaxDistance);
 	}
@@ -509,10 +509,12 @@ void LocationFilter::LoadChild(const DataNode &child)
 		if(outfits.back().empty())
 			outfits.pop_back();
 	}
-	else if(key == "visited planet")
-		visitedPlanet = true;
-	else if(key == "visited system")
+	else if(key == "visited")
+	{
 		visitedSystem = true;
+		if(child.Size() >= 2 + isNot && child.Token(valueIndex) == "planet")
+			visitedPlanet = true;
+	}
 	else
 		child.PrintTrace("Unrecognized location filter:");
 }

--- a/source/LocationFilter.h
+++ b/source/LocationFilter.h
@@ -22,6 +22,7 @@ class DataWriter;
 class Government;
 class Outfit;
 class Planet;
+class PlayerInfo;
 class Ship;
 class System;
 
@@ -47,19 +48,19 @@ public:
 	bool IsEmpty() const;
 	
 	// If the player is in the given system, does this filter match?
-	bool Matches(const Planet *planet, const System *origin = nullptr) const;
-	bool Matches(const System *system, const System *origin = nullptr) const;
+	bool Matches(const PlayerInfo &player, const Planet *planet, const System *origin = nullptr) const;
+	bool Matches(const PlayerInfo &player, const System *system, const System *origin = nullptr) const;
 	// Ships are chosen based on system/"near" filters, government, category
 	// of ship, outfits installed/carried, and their total attributes.
-	bool Matches(const Ship &ship) const;
+	bool Matches(const PlayerInfo &player, const Ship &ship) const;
 	
 	// Return a new LocationFilter with any "distance" conditions converted
 	// into "near" references, relative to the given system.
 	LocationFilter SetOrigin(const System *origin) const;
 	// Generic find system / find planet methods, based on the given origin
 	// system (e.g. the player's current system) and ability to land.
-	const System *PickSystem(const System *origin) const;
-	const Planet *PickPlanet(const System *origin, bool hasClearance = false, bool requireSpaceport = true) const;
+	const System *PickSystem(const PlayerInfo &player, const System *origin) const;
+	const Planet *PickPlanet(const PlayerInfo &player, const System *origin, bool hasClearance = false, bool requireSpaceport = true) const;
 	
 	
 private:
@@ -68,7 +69,7 @@ private:
 	// Check if the filter matches the given system. If it did not, return true
 	// only if the filter wasn't looking for planet characteristics or if the
 	// didPlanet argument is set (meaning we already checked those).
-	bool Matches(const System *system, const System *origin, bool didPlanet) const;
+	bool Matches(const PlayerInfo &player, const System *system, const System *origin, bool didPlanet) const;
 	
 	
 private:
@@ -87,6 +88,9 @@ private:
 	// Distance limits used in a "distance" filter.
 	int originMinDistance = 0;
 	int originMaxDistance = -1;
+	
+	bool visitedPlanet = false;
+	bool visitedSystem = false;
 	
 	// At least one of the outfits from each set must be available
 	// (to purchase or plunder):

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -89,7 +89,7 @@ public:
 	// marked as failing already, mark it and return true.
 	bool CheckDeadline(const Date &today);
 	// Check if you have special clearance to land on your destination.
-	bool HasClearance(const Planet *planet) const;
+	bool HasClearance(const PlayerInfo &player, const Planet *planet) const;
 	// Get the string to be shown in the destination planet's hailing dialog. If
 	// this is "auto", you don't have to hail them to get landing permission.
 	const std::string &ClearanceMessage() const;

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -412,7 +412,7 @@ bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &
 	
 	// An `on enter` MissionAction may have defined a LocationFilter that
 	// specifies the systems in which it can occur.
-	if(!systemFilter.IsEmpty() && !systemFilter.Matches(player.GetSystem()))
+	if(!systemFilter.IsEmpty() && !systemFilter.Matches(player, player.GetSystem()))
 		return false;
 	return true;
 }

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -480,7 +480,7 @@ bool NPC::HasFailed() const
 
 // Create a copy of this NPC but with the fleets replaced by the actual
 // ships they represent, wildcards in the conversation text replaced, etc.
-NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const System *destination) const
+NPC NPC::Instantiate(const PlayerInfo &player, map<string, string> &subs, const System *origin, const System *destination) const
 {
 	NPC result;
 	result.government = government;
@@ -500,7 +500,7 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	// Pick the system for this NPC to start out in.
 	result.system = system;
 	if(!result.system && !location.IsEmpty())
-		result.system = location.PickSystem(origin);
+		result.system = location.PickSystem(player, origin);
 	if(!result.system)
 		result.system = (isAtDestination && destination) ? destination : origin;
 	// If a planet was specified in the template, it must be in this system.

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -68,7 +68,7 @@ public:
 	
 	// Create a copy of this NPC but with the fleets replaced by the actual
 	// ships they represent, wildcards in the conversation text replaced, etc.
-	NPC Instantiate(std::map<std::string, std::string> &subs, const System *origin, const System *destination) const;
+	NPC Instantiate(const PlayerInfo &player, std::map<std::string, std::string> &subs, const System *origin, const System *destination) const;
 	
 	
 private:

--- a/source/News.cpp
+++ b/source/News.cpp
@@ -111,13 +111,13 @@ bool News::IsEmpty() const
 
 
 // Check if this news item is available given the player's planet and conditions.
-bool News::Matches(const Planet *planet, const map<string, int64_t> &conditions) const
+bool News::Matches(const PlayerInfo &player, const Planet *planet, const map<string, int64_t> &conditions) const
 {
 	// If no location filter is specified, it should never match. This can be
 	// used to create news items that are never shown until an event "activates"
 	// them by specifying their location.
 	// Similarly, by updating a news item with "remove location", it can be deactivated.
-	return location.IsEmpty() ? false : (location.Matches(planet) && toShow.Test(conditions));
+	return location.IsEmpty() ? false : (location.Matches(player, planet) && toShow.Test(conditions));
 }
 
 

--- a/source/News.h
+++ b/source/News.h
@@ -22,6 +22,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 class DataNode;
 class Planet;
+class PlayerInfo;
 class Sprite;
 
 
@@ -35,7 +36,7 @@ public:
 	// Check whether this news item has anything to say.
 	bool IsEmpty() const;
 	// Check if this news item is available given the player's planet and conditions.
-	bool Matches(const Planet *planet, const std::map<std::string, std::int64_t> &conditions) const;
+	bool Matches(const PlayerInfo &player, const Planet *planet, const std::map<std::string, std::int64_t> &conditions) const;
 	
 	// Get the speaker's name.
 	std::string Name() const;

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataNode.h"
 #include "GameData.h"
 #include "Government.h"
+#include "PlayerInfo.h"
 #include "Ship.h"
 #include "System.h"
 
@@ -61,16 +62,17 @@ void Person::FinishLoading()
 
 
 
-// Find out how often this person should appear in the given system. If this
+// Find out how often this person should appear in the player's system. If this
 // person is dead or already active, this will return zero.
-int Person::Frequency(const PlayerInfo &player, const System *system) const
+int Person::Frequency(const PlayerInfo &player) const
 {
 	// Because persons always enter a system via one of the regular hyperspace
 	// links, don't create them in systems with no links.
-	if(!system || IsDestroyed() || IsPlaced() || system->Links().empty())
+	const System *playerSystem = player.GetSystem();
+	if(!playerSystem || IsDestroyed() || IsPlaced() || playerSystem->Links().empty())
 		return 0;
 	
-	return (location.IsEmpty() || location.Matches(player, system)) ? frequency : 0;
+	return (location.IsEmpty() || location.Matches(player, playerSystem)) ? frequency : 0;
 }
 
 

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -63,14 +63,14 @@ void Person::FinishLoading()
 
 // Find out how often this person should appear in the given system. If this
 // person is dead or already active, this will return zero.
-int Person::Frequency(const System *system) const
+int Person::Frequency(const PlayerInfo &player, const System *system) const
 {
 	// Because persons always enter a system via one of the regular hyperspace
 	// links, don't create them in systems with no links.
 	if(!system || IsDestroyed() || IsPlaced() || system->Links().empty())
 		return 0;
 	
-	return (location.IsEmpty() || location.Matches(system)) ? frequency : 0;
+	return (location.IsEmpty() || location.Matches(player, system)) ? frequency : 0;
 }
 
 

--- a/source/Person.h
+++ b/source/Person.h
@@ -35,9 +35,9 @@ public:
 	// Finish loading all the ships in this person specification.
 	void FinishLoading();
 	
-	// Find out how often this person should appear in the given system. If this
+	// Find out how often this person should appear in the player's system. If this
 	// person is dead or already active, this will return zero.
-	int Frequency(const PlayerInfo &player, const System *system) const;
+	int Frequency(const PlayerInfo &player) const;
 	
 	// Get the person's characteristics. The ship object is persistent, i.e. it
 	// will be recycled every time this person appears.

--- a/source/Person.h
+++ b/source/Person.h
@@ -22,6 +22,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 class DataNode;
 class Government;
+class PlayerInfo;
 class Ship;
 class System;
 
@@ -36,7 +37,7 @@ public:
 	
 	// Find out how often this person should appear in the given system. If this
 	// person is dead or already active, this will return zero.
-	int Frequency(const System *system) const;
+	int Frequency(const PlayerInfo &player, const System *system) const;
 	
 	// Get the person's characteristics. The ship object is persistent, i.e. it
 	// will be recycled every time this person appears.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2809,13 +2809,13 @@ void PlayerInfo::Fine(UI *ui)
 	
 	// Planets should not fine you if you have mission clearance or are infiltrating.
 	for(const Mission &mission : missions)
-		if(mission.HasClearance(planet) || (!mission.HasFullClearance() &&
+		if(mission.HasClearance(*this, planet) || (!mission.HasFullClearance() &&
 					(mission.Destination() == planet || mission.Stopovers().count(planet))))
 			return;
 	
 	// The planet's government must have the authority to enforce laws.
 	const Government *gov = planet->GetGovernment();
-	if(!gov->CanEnforce(planet))
+	if(!gov->CanEnforce(*this, planet))
 		return;
 	
 	string message = gov->Fine(*this, 0, nullptr, planet->Security());

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -113,7 +113,7 @@ const News *SpaceportPanel::PickNews() const
 	const Planet *planet = player.GetPlanet();
 	const map<string, int64_t> &conditions = player.Conditions();
 	for(const auto &it : GameData::SpaceportNews())
-		if(!it.second.IsEmpty() && it.second.Matches(planet, conditions))
+		if(!it.second.IsEmpty() && it.second.Matches(player, planet, conditions))
 			matches.push_back(&it.second);
 	
 	return matches.empty() ? nullptr : matches[Random::Int(matches.size())];


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #5395.

## Feature Details
Creates two new keywords for location filters:
* `visited`: The system must have been visited before.
* `visited planet`: The system and planet must have been visited before.

## UI Screenshots
N/A

## Usage Examples
See testing done.

## Testing Done
Tested the following mission on a fresh pilot after visiting a few systems and worlds. One waypoint and stopover was already from a visited location and the other waypoint and stopover were from unvisited locations.
Checking the jobs board, all other jobs appeared to act normally.
```
mission "visited test"
	job
	repeat
	description "Stopovers: <stopovers>. Waypoints: <waypoints>."
	waypoint
		distance 1 100
		visited
	waypoint
		distance 1 100
		not visited
	stopover
		distance 1 100
		visited planet
	stopover
		distance 1 100
		not visited planet
```

## Performance Impact
N/A
