### PR TITLE
Make LG's gridfire friendly-safe

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -760,7 +760,7 @@ ship "Ursa Polaris"
 			"hit force" 6000
 	outfits
 		"Quarg Skylance"
-		"Pug Gridfire Turret" 3
+		"LG Gridfire Turret" 3
 		"Plasma Turret"
 		"Korath Disruptor" 5
 		"Quarg Anti-Missile" 5
@@ -781,13 +781,13 @@ ship "Ursa Polaris"
 	turret 27 -162 "Quarg Skylance"
 	turret 27 -162 "Korath Disruptor"
 	turret 94.5 -52.5 "Quarg Anti-Missile"
-	turret 94.5 -52.5 "Pug Gridfire Turret"
+	turret 94.5 -52.5 "LG Gridfire Turret"
 	turret 94.5 -52.5 "Korath Disruptor"
 	turret 80.5 53 "Quarg Anti-Missile"
-	turret 80.5 53 "Pug Gridfire Turret"
+	turret 80.5 53 "LG Gridfire Turret"
 	turret 80.5 53 "Korath Disruptor"
 	turret 21 25.5 "Quarg Anti-Missile"
-	turret 21 25.5 "Pug Gridfire Turret"
+	turret 21 25.5 "LG Gridfire Turret"
 	turret 21 25.5 "Korath Disruptor"
 	turret -69.5 -43 "Quarg Anti-Missile"
 	turret -69.5 -43 "Plasma Turret"
@@ -798,6 +798,27 @@ ship "Ursa Polaris"
 	explode "large explosion" 40
 	explode "huge explosion" 50
 
+outfit "LG Gridfire Turret"
+          category "Turrets"
+          "turret mounts" -1
+          weapon
+                    "hardpoint sprite" "hardpoint/pug gridfire turret"
+                    "fire effect" "gridfire fire"
+                    "hit effect" "gridfire hit" 2
+                    "hit effect" "gridfire cloud"
+                    "phasing"
+                    "velocity" 1440
+                    "lifetime" 1
+                    "reload" 20
+                    "turret turn" 20
+                    "firing energy" 800
+                    "firing heat" 400
+                    "firing force" 150
+                    "shield damage" 600
+                    "hull damage" 600
+                    "blast radius" 40
+                    "piercing" .3
+                    "safe"
 
 
 person "Subsidurial"

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -799,26 +799,26 @@ ship "Ursa Polaris"
 	explode "huge explosion" 50
 
 outfit "LG Gridfire Turret"
-          category "Turrets"
-          "turret mounts" -1
-          weapon
-                    "hardpoint sprite" "hardpoint/pug gridfire turret"
-                    "fire effect" "gridfire fire"
-                    "hit effect" "gridfire hit" 2
-                    "hit effect" "gridfire cloud"
-                    "phasing"
-                    "velocity" 1440
-                    "lifetime" 1
-                    "reload" 20
-                    "turret turn" 20
-                    "firing energy" 800
-                    "firing heat" 400
-                    "firing force" 150
-                    "shield damage" 600
-                    "hull damage" 600
-                    "blast radius" 40
-                    "piercing" .3
-                    "safe"
+	category "Turrets"
+	"turret mounts" -1
+	weapon
+		"hardpoint sprite" "hardpoint/pug gridfire turret"
+		"fire effect" "gridfire fire"
+		"hit effect" "gridfire hit" 2
+		"hit effect" "gridfire cloud"
+		"phasing"
+		"velocity" 1440
+		"lifetime" 1
+		"reload" 20
+		"turret turn" 20
+		"firing energy" 800
+		"firing heat" 400
+		"firing force" 150
+		"shield damage" 600
+		"hull damage" 600
+		"blast radius" 40
+		"piercing" .3
+		"safe"
 
 
 person "Subsidurial"


### PR DESCRIPTION
## Summary

This marks LG's person ship's gridfire turrets as "safe" so they don't blow up unsuspecting players.

Gridfire is invisible and deadly to early game ships, and uses damage mechanics not present in human space.  Should Local God appear in the early game, and happen to attack a ship near the player, the player and their escorts may be easily destroyed or disabled.  Unlike, for example, Pointedstick's heavy rocket attacks, the Gridfire cannot be seen or dodged, may come from far off-screen, and may leave the player in the confusing (to new players) state of being disabled with their shields up.

For me, losing a valuable escort and having my flagship disabled out of the blue despite being nowhere near the local furball, it was a surprising annoyance and cause for a scum-save, for a new player I imagine this would be cause for great confusion and frustration with the game.

## Fix Details

A duplicate, pared-down version of the Gridfire turret, named "LG Gridfire Turret," with the "safe" attribute applied, has been added to persons.txt, and Ursa Polaris has been armed with them instead of standard Pug gridfires.

## Save File

This save gives you an Archon equipped with the modified gridfire turret, and 100 void sprites to test it on.

[Local Cod.txt](https://github.com/endless-sky/endless-sky/files/5338056/Local.Cod.txt)

## Testing Done

I armed a ship with the modified gridfires to ensure they worked.