### PR TITLE
Differentiate aborting from failing

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -811,7 +811,7 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	// If this mission was aborted but no ABORT action exists, look for a FAIL
 	// action instead. This is done for backwards compatibility purposes from
 	// when aborting a mission activated the FAIL trigger.
-	if(it == actions.end() && trigger == ABORT)
+	if(trigger == ABORT && it == actions.end())
 		it = actions.find(FAIL);
 	// Don't update any conditions if this action exists and can't be completed.
 	if(it != actions.end() && !it->second.CanBeDone(player, boardingShip))

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -807,6 +807,9 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 		if(!stopovers.empty())
 			return false;
 	}
+	if(trigger == ABORT && HasFailed(player))
+		return false;
+	
 	auto it = actions.find(trigger);
 	// If this mission was aborted but no ABORT action exists, look for a FAIL
 	// action instead. This is done for backwards compatibility purposes from

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -811,7 +811,7 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	// If this mission was aborted but no ABORT action exists, look for a FAIL
 	// action instead. This is done for backwards compatibility purposes from
 	// when aborting a mission activated the FAIL trigger.
-	if(it == actions.end() && trigger == ABORTED)
+	if(it == actions.end() && trigger == ABORT)
 		it = actions.find(FAIL);
 	// Don't update any conditions if this action exists and can't be completed.
 	if(it != actions.end() && !it->second.CanBeDone(player, boardingShip))

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -127,7 +127,7 @@ public:
 	// information or show new UI panels. PlayerInfo::MissionCallback() will be
 	// used as the callback for an `on offer` conversation, to handle its response.
 	// If it is not possible for this change to happen, this function returns false.
-	enum Trigger {COMPLETE, OFFER, ACCEPT, DECLINE, FAIL, DEFER, VISIT, STOPOVER};
+	enum Trigger {COMPLETE, OFFER, ACCEPT, DECLINE, FAIL, ABORT, DEFER, VISIT, STOPOVER};
 	bool Do(Trigger trigger, PlayerInfo &player, UI *ui = nullptr, const std::shared_ptr<Ship> &boardingShip = nullptr);
 	
 	// Get a list of NPCs associated with this mission. Every time the player

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -814,7 +814,7 @@ void MissionPanel::AbortMission()
 	{
 		const Mission &toAbort = *acceptedIt;
 		++acceptedIt;
-		player.RemoveMission(Mission::FAIL, toAbort, GetUI());
+		player.RemoveMission(Mission::ABORT, toAbort, GetUI());
 		if(acceptedIt == accepted.end() && !accepted.empty())
 			--acceptedIt;
 		if(acceptedIt != accepted.end() && !acceptedIt->IsVisible())


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4018.

## Feature Details
Adds a new `on abort` action.
* Only triggers if the mission is aborted by the player.
* Creates a new `"<mission>: aborted"` condition.
* Also creates a `"<mission>: failed"` condition when aborting. (BACKWARDS COMPATIBILITY)
* If a mission is aborted and no `on abort` action exists, any `on fail` action is triggered instead. (BACKWARDS COMPATIBILITY)

## UI Screenshots
N/A

## Usage Examples
See testing done.

Given that aborting a mission creates both the aborted and failed conditions, the following condition sets can be used to test certain outcomes.
Mission failed **OR** aborted:
```
has "<mission>: failed"
```
Mission aborted:
```
has "<mission>: aborted"
```
Mission objective failed:
```
has "<mission>: failed"
not "<mission>: aborted"
```

## Testing Done
Tested the following two missions. For the first mission, aborting properly triggers the on abort action and failing properly triggers the on fail action. For the second mission, since no on abort action exists, aborting properly triggers the on fail action. In both missions, the proper failed and aborted conditions are set given the outcome of the missions. (i.e. both failed and aborted if the mission is aborted, only failed if the mission is failed by objective.)
```
mission "on abort test"
	job
	repeat
	npc save
		government "Hai"
		personality staying
		ship "Shuttle" "If you kill me, I swear."
	on abort
		dialog "You aborted the mission!"
	on fail
		dialog "You failed the objective!"

mission "abort fallback test"
	job
	repeat
	npc save
		government "Hai"
		personality staying
		ship "Shuttle" "If you kill me, I swear."
	on fail
		dialog "You failed the objective or you aborted the mission!"
```

## Performance Impact
N/A
