### PR TITLE
Fix: Remnant: moving the eligibility for Learning Sign to be later.

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -983,10 +983,16 @@ mission "Remnant: Learn Sign 1"
 	destination "Aventine"
 	repeat 3
 	to offer
-		has "Remnant: Technology Available: done"
+		has "Remnant: Void Sprites 3: done"
+		has "Remnant: Defense 3: done"
 		not "Remnant: Learn Sign 1: done"
 		not "Remnant: Learn Sign 1: active"
 		random < 30
+		or
+			has "Remnant: Key Stones: done"
+			has "Remnant: Key Stones (Hai): done"
+			has "Remnant: Key Stones (Pre-Hai) 2: done"
+			has "Remnant: Broken Jump Drive 2: done"
 	on offer
 		conversation
 			`As you make your way through the spaceport, you become increasingly aware of how quiet it is. Looking around, you note that it doesn't seem any less busy than usual, just that only a handful of people are paying attention to you. As a result, they have reverted to their normal gestures instead of singing. It feels oddly isolating, and eerie, to realize that there are hundreds of conversations going on around you, yet you can't understand a single one.`

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -983,7 +983,7 @@ mission "Remnant: Learn Sign 1"
 	destination "Aventine"
 	repeat 3
 	to offer
-		has "remnant blood test pure"
+		has "Remnant: Technology Available: done"
 		not "Remnant: Learn Sign 1: done"
 		not "Remnant: Learn Sign 1: active"
 		random < 30


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5427 

## Fix Details
Moved the requirement for the language from "have met the Remnant" to "they've demonstrated a willingness to work with the Remnant.

fixes #5427

Specifically, this mirrors the requirement for the technology available mission, except uses the Void Sprite 3: done criteria instead of the void sprite research event. This later has a 20 day timer on it. The idea that it will tend to mean that the learning sign mission should happen during this gap period that at least some players find distracting and cause to leave the area.

This also means that the learning sign missions cannot be done before the player has done the basic set of missions, thus resolving #5427 