### PR TITLE
Add empty "on abort" sections to Syndicate target practice.

### DIFF
--- a/data/human/free worlds intro.txt
+++ b/data/human/free worlds intro.txt
@@ -1329,6 +1329,9 @@ mission "FW Escort 1"
 	on accept
 		log "Serving as an escort for a Free Worlds supply convoy to Tarazed. It sounds like pirates have been specifically targeting their convoys, recently."
 	
+	on abort
+		# No action, the player just silently walks away from this mission(chain)
+	
 	on fail
 		set "fw intro escort failed"
 	
@@ -1397,6 +1400,9 @@ mission "FW Escort 1B"
 		conversation
 			`You are met at the spaceport by Tomek Voigt, one of the members of the Free Worlds Council. He thanks you and the other escort captains for your service, and pays you each <payment>. "The convoy is heading out again immediately," he says, "so meet me in the spaceport if you are willing to volunteer for escort duty again."`
 	
+	on abort
+		# No action, the player just silently walks away from this mission(chain)
+	
 	on fail
 		set "fw intro escort failed"
 	
@@ -1459,6 +1465,9 @@ mission "FW Escort 2"
 			
 			`	"Great!" says Tomek. "Good luck to all of you, and I hope to see you all safely back here in a couple of weeks."`
 				accept
+	
+	on abort
+		# No action, the player just silently walks away from this mission(chain)
 	
 	on fail
 		set "fw intro escort failed"
@@ -1526,6 +1535,9 @@ mission "FW Escort 2B"
 		conversation
 			`Again, Tomek Voigt meets you at the spaceport, thanks you all for your courage and dedication, and pays you <payment>. Then, he pulls you aside and says, "Captain <last>, if you're interested in helping us further, please meet me in the spaceport bar."`
 	
+	on abort
+		# No action, the player just silently walks away from this mission(chain)
+	
 	on fail
 		set "fw intro escort failed"
 	
@@ -1568,6 +1580,9 @@ mission "FW Escort 3"
 			`Voigt is immensely relieved to see the <npc> returned safely home. "You have done us a great service today, Captain," he says, as he hands you credit chips for <payment>. "I'll be sure to let the Council know how helpful you have been."`
 		"assisted free worlds" ++
 		log "Helped rescue a Free Worlds freighter that had been disabled by pirates. Earned the gratitude of Tomek Voigt, the Council member in charge of the supply convoys."
+	
+	on abort
+		# No action, the player just silently walks away from this mission(chain)
 	
 	on fail
 		set "fw intro escort failed"

--- a/data/human/pirate jobs.txt
+++ b/data/human/pirate jobs.txt
@@ -381,6 +381,9 @@ mission "Stealth Cargo Smuggling (North) [0]"
 			names "republic small"
 			variant
 				"Gunboat"
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Republic" -= 5
 		"reputation: Navy (Oathkeeper)" -= 5
@@ -458,6 +461,9 @@ mission "Stealth Cargo Smuggling (North) [1]"
 		personality heroic staying
 		government Republic
 		fleet "Navy Surveillance"
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Republic" -= 5
 		"reputation: Navy (Oathkeeper)" -= 5
@@ -512,6 +518,9 @@ mission "Stealth Cargo Smuggling (Core) [0]"
 			names "syndicate small"
 			variant
 				"Quicksilver (Scanner)"
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Syndicate" -= 5
 	on visit
@@ -591,6 +600,9 @@ mission "Stealth Cargo Smuggling (Core) [1]"
 			names "syndicate small"
 			variant
 				"Quicksilver (Scanner)" 2
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Syndicate" -= 5
 	on visit
@@ -644,6 +656,9 @@ mission "Stealth Cargo Smuggling (South) [0]"
 			names "militia"
 			variant
 				"Bastion (Scanner)"
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Free Worlds" -= 5
 		"reputation: Militia" -= 5
@@ -724,6 +739,9 @@ mission "Stealth Cargo Smuggling (South) [1]"
 			names "militia"
 			variant
 				"Bastion (Scanner)" 2
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Free Worlds" -= 5
 		"reputation: Militia" -= 5
@@ -780,6 +798,9 @@ mission "Stealth Drug Running (North) [0]"
 			names "republic small"
 			variant
 				"Gunboat"
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Republic" -= 5
 		"reputation: Navy (Oathkeeper)" -= 5
@@ -857,6 +878,9 @@ mission "Stealth Drug Running (North) [1]"
 		personality heroic staying
 		system destination
 		fleet "Navy Surveillance"
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Republic" -= 5
 		"reputation: Navy (Oathkeeper)" -= 5
@@ -911,6 +935,9 @@ mission "Stealth Drug Running (Core) [0]"
 			names "syndicate small"
 			variant
 				"Quicksilver (Scanner)"
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Syndicate" -= 5
 	on visit
@@ -990,6 +1017,9 @@ mission "Stealth Drug Running (Core) [1]"
 			names "syndicate small"
 			variant
 				"Quicksilver (Scanner)" 2
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Syndicate" -= 5
 	on visit
@@ -1043,6 +1073,9 @@ mission "Stealth Drug Running (South) [0]"
 			names "militia"
 			variant
 				"Bastion (Scanner)"
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Free Worlds" -= 5
 		"reputation: Militia" -= 5
@@ -1123,6 +1156,9 @@ mission "Stealth Drug Running (South) [1]"
 			names "militia"
 			variant
 				"Bastion (Scanner)" 2
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your cargo of <commodity> never arrived at its destination. The pirates won't be happy to hear about this."
 	on fail
 		"reputation: Free Worlds" -= 5
 		"reputation: Militia" -= 5
@@ -1308,6 +1344,9 @@ mission "Highly Wanted Passenger (North)"
 		personality heroic staying
 		system destination
 		fleet "Navy Surveillance"
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your passenger never arrived at <destination>. This doesn't help to establish a name as reliable, no-questions-asked, transporter."
 	on fail
 		"reputation: Republic" -= 5
 		"reputation: Navy (Oathkeeper)" -= 5
@@ -1396,6 +1435,9 @@ mission "Highly Wanted Passenger (Core)"
 			names "syndicate small"
 			variant
 				"Quicksilver (Scanner)" 2
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your passenger never arrived at <destination>. This doesn't help to establish a name as reliable, no-questions-asked, transporter."
 	on fail
 		"reputation: Syndicate" -= 5
 	on visit
@@ -1483,6 +1525,9 @@ mission "Highly Wanted Passenger (South)"
 			names "militia"
 			variant
 				"Bastion (Scanner)" 2
+	on abort
+		"reputation: Pirate" -= 1
+		dialog "Your passenger never arrived at <destination>. This doesn't help to establish a name as reliable, no-questions-asked, transporter."
 	on fail
 		"reputation: Free Worlds" -= 5
 		"reputation: Militia" -= 5

--- a/data/human/syndicate jobs.txt
+++ b/data/human/syndicate jobs.txt
@@ -193,7 +193,7 @@ mission "Syndicate target practice [0]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on abort
-		#No penalty
+		# No penalty
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
@@ -229,7 +229,7 @@ mission "Syndicate target practice [1]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on abort
-		#No penalty
+		# No penalty
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
@@ -265,7 +265,7 @@ mission "Syndicate target practice [2]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on abort
-		#No penalty
+		# No penalty
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
@@ -300,7 +300,7 @@ mission "Syndicate target practice [3]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on abort
-		#No penalty
+		# No penalty
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++

--- a/data/human/syndicate jobs.txt
+++ b/data/human/syndicate jobs.txt
@@ -193,6 +193,7 @@ mission "Syndicate target practice [0]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on abort
+		#No penalty
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
@@ -228,6 +229,7 @@ mission "Syndicate target practice [1]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on abort
+		#No penalty
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
@@ -263,6 +265,7 @@ mission "Syndicate target practice [2]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on abort
+		#No penalty
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
@@ -297,6 +300,7 @@ mission "Syndicate target practice [3]"
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
 	on abort
+		#No penalty
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++

--- a/data/human/syndicate jobs.txt
+++ b/data/human/syndicate jobs.txt
@@ -192,6 +192,7 @@ mission "Syndicate target practice [0]"
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
+	on abort
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
@@ -226,6 +227,7 @@ mission "Syndicate target practice [1]"
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
+	on abort
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
@@ -260,6 +262,7 @@ mission "Syndicate target practice [2]"
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
+	on abort
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
@@ -293,6 +296,7 @@ mission "Syndicate target practice [3]"
 		dialog "You scan the disabled craft and take careful measurements of the battle damage. Time to deliver the results on <planet>."
 	on visit
 		dialog "You forgot to either disable or scan the target dummy ship in <system>! You'll need to head back there and do that before you can return here for payment."
+	on abort
 	on fail
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -1711,7 +1711,9 @@ mission "Remnant: Salvage 5"
 	to offer
 		or
 			has "Remnant: Salvage 4: done"
-			has "Remnant: Salvage 4: failed"
+			and
+				has "Remnant: Salvage 4: failed"
+				not "Remnant: Salvage 4: aborted"
 	on offer
 		conversation
 			`As you stroll across the tarmac under the great dome you spot Taely heading your way with a flatbed tractor filled with components in tow.`
@@ -2959,7 +2961,9 @@ mission "Remnant: Cognizance 5"
 	to offer
 		or
 			has "Remnant: Cognizance 4: done"
-			has "Remnant: Cognizance 4: failed"
+			and
+				has "Remnant: Cognizance 4: failed"
+				not "Remnant: Cognizance 4: aborted"
 	on offer
 		conversation
 			branch fleetkilled

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -1690,6 +1690,8 @@ mission "Remnant: Salvage 4"
 			variant
 				"Korath Raider (Hyperdrive)"
 		dialog "You have disabled the Korath ship that was left over from the raid on <planet>. You can now return there to collect your payment."
+	on abort
+		# No action, the player choose to just walk away from this mission(string)
 	on fail
 		payment 350000
 		dialog `You are met by a prefect who looks upset. "The ship was supposed to be disabled so its contents could be salvaged!" he signs angrily. Nonetheless, he shoves a credit chip worth <payment> into your hand. "That's half what you would have earned if the ship had been disabled." He pauses and shakes his head. "I think Taely might have some more work for you in the spaceport, but in the meantime, why don't you go find some Korath to practice disabling? It is a valuable skill among the Remnant."`
@@ -2933,6 +2935,8 @@ mission "Remnant: Cognizance 4"
 				"Korath Chaser" 8
 	on enter "Aescolanus"
 		dialog `You have located the Korath fleet. They do not seem to be going anywhere at the moment.`
+	on abort
+		# No action, the player choose to just walk away from this mission(string)
 	on complete
 		payment 500000
 		conversation


### PR DESCRIPTION
**Content (Jobs)** Don't fine players for ships they didn't destroy in target practice.

## Summary
This PR uses the feature from #5426 to ensure that aborted Syndicate target practice jobs don't fine the player for destroying the dummy ship by providing an empty on abort section.

## Testing Done
I checked both the fail situation and the abort situation (using the compiled code from #5426). The abort situation doesn't give any output, the fail situation still gives the proper message.

## Save File
I can provide a save file if desired, but the change is quite trivial, so I'm not sure if this is needed.
