### PR TITLE
Make the language check a part of CanSendHail

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -132,7 +132,8 @@ namespace {
 			return false;
 		
 		// Player ships shouldn't send hails.
-		if(!ship->GetGovernment() || ship->IsYours())
+		const Government *gov = ship->GetGovernment();
+		if(!gov || ship->IsYours())
 			return false;
 		
 		// Make sure this ship is able to send a hail.
@@ -141,7 +142,6 @@ namespace {
 			return false;
 		
 		// Ships that don't share a language with the player shouldn't send hails.
-		const Government *gov = ship->GetGovernment();
 		if(!gov->Language().empty() && !player.GetCondition("language: " + gov->Language()))
 			return false;
 		

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -121,8 +121,9 @@ namespace {
 		added.clear();
 	}
 	
-	bool CanSendHail(const shared_ptr<const Ship> &ship, const System *playerSystem)
+	bool CanSendHail(const shared_ptr<const Ship> &ship, const PlayerInfo &player)
 	{
+		const System *playerSystem = player.GetSystem();
 		if(!ship || !playerSystem)
 			return false;
 		
@@ -137,6 +138,11 @@ namespace {
 		// Make sure this ship is able to send a hail.
 		if(ship->IsDisabled() || !ship->Crew()
 				|| ship->Cloaking() >= 1. || ship->GetPersonality().IsMute())
+			return false;
+		
+		// Ships that don't share a language with the player shouldn't send hails.
+		const Government *gov = ship->GetGovernment();
+		if(!gov->Language().empty() && !player.GetCondition("language: " + gov->Language()))
 			return false;
 		
 		return true;
@@ -1657,7 +1663,7 @@ void Engine::SendHails()
 			break;
 		}
 	
-	if(!CanSendHail(source, player.GetSystem()))
+	if(!CanSendHail(source, player))
 		return;
 	
 	// Generate a random hail message.
@@ -2175,7 +2181,7 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 	if(attacker->IsPlayer())
 	{
 		shared_ptr<const Ship> previous = grudge[target->GetGovernment()].lock();
-		if(CanSendHail(previous, player.GetSystem()))
+		if(CanSendHail(previous, player))
 		{
 			grudge[target->GetGovernment()].reset();
 			SendMessage(previous, "Thank you for your assistance, Captain "
@@ -2193,7 +2199,7 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 		shared_ptr<const Ship> previous = grudge[attacker].lock();
 		// If the previous ship is destroyed, or was able to send a
 		// "thank you" already, skip sending a new thanks.
-		if(!previous || CanSendHail(previous, player.GetSystem()))
+		if(!previous || CanSendHail(previous, player))
 			return;
 	}
 	
@@ -2202,13 +2208,9 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 	if(target->GetGovernment()->IsEnemy() || !attacker->IsEnemy())
 		return;
 	// Ensure that this attacked ship is able to send hails (e.g. not mute,
-	// a player ship, automaton, etc.)
-	if(!CanSendHail(target, player.GetSystem()))
+	// a player ship, automaton, shares a language with the player, etc.)
+	if(!CanSendHail(target, player))
 		return;
-	// If the hailer has a special language, the player must understand it.
-	if(!target->GetGovernment()->Language().empty())
-		if(!player.GetCondition("language: " + target->GetGovernment()->Language()))
-			return;
 	
 	// No active ship has a grudge already against this government.
 	// Check the relative strength of this ship and its attackers.


### PR DESCRIPTION
**Bugfix:** This PR might address issue #4078.

## Fix Details
Adds the check to see if the hailing ship shares a language with the player to the CanSendHail function. This should prevent ships from hailing the player when a language is not shared under any circumstance, as CanSendHail is always checked before sending a hail message.

Still not sure how the World Ship in #4078 sent a disabled hail, though, as disabled ships do not send random hails, and the only way to view disabled hails is to hail a disabled ship, as best I can tell.

## Testing Done
Flew around Ka'het space with and without this change. Without this change, Ka'het ships would occasionally hail me, but hailing them returned the expected alien language response. With this change, I was never hailed by a Ka'het ship. The same should extend to Korath ships.

## Save File
N/A