### PR TITLE
Added fine 0 and bribe 0 for Governments where those don't make sense

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -14,6 +14,7 @@ government "Alpha"
 	"crew defense" 2.5
 	"player reputation" -1000
 	"bribe" 0
+	"fine" 0
 
 government "Author"
 	"player reputation" 1
@@ -24,6 +25,7 @@ government "Builder"
 	# as long as you don't attack them again they will focus on their usual activities
 	color .91 .13 .82
 	language "Builder"
+	"fine" 0
 	"penalty for"
 		assist 0
 		disable 0
@@ -71,6 +73,7 @@ government "Deep Security"
 	"hostile hail" "hostile deep"
 
 government "Derelict"
+	"fine" 0
 
 government "Drak"
 	swizzle 5
@@ -191,6 +194,8 @@ government "Indigenous Lifeform"
 	# Nothing you do permanently angers indigenous creatures, because they are
 	# not sentient and do not remember you as an individual.
 	"player reputation" 1
+	"bribe" 0
+	"fine" 0
 	"penalty for"
 		assist 0
 		disable 0
@@ -262,6 +267,8 @@ government "Korath"
 
 government "Korath Nanobots"
 	"player reputation" -1000
+	"bribe" 0
+	"fine" 0
 
 government "Kor Efret"
 	swizzle 4
@@ -497,6 +504,7 @@ government "Syndicate (Extremist)"
 		"Republic" -.01
 		"Free Worlds" -.01
 	"bribe" 0
+	"fine" 0
 	"hostile hail" "hostile syndicate"
 
 government "Test Dummy"
@@ -504,9 +512,13 @@ government "Test Dummy"
 	"player reputation" -1000
 	"hostile hail" "test dummy"
 	"hostile disabled hail" "disabled test dummy"
+	"bribe" 0
+	"fine" 0
 
 government "Uninhabited"
 	color .4 .4 .4
+	"bribe" 0
+	"fine" 0
 
 government "Ember Waste"
 	"display name" "???"
@@ -533,6 +545,8 @@ government "Wanderer"
 
 # A dummy government used to prevent Hai from entering the wormhole in Waypoint/Ultima Thule, but allowing human merchants and other governments to enter.
 government "Wormhole Alpha"
+	"bribe" 0
+	"fine" 0
 	"attitude toward"
 		"Hai" -.01
 		"Hai (Unfettered)" -.01


### PR DESCRIPTION
**Content (Governments)** Disabled fines for Governments that shouldn't fine

## Summary
Added `fine 0` and `bribe 0` for some governments (like Indigenous Lifeform) where it makes no sense if those governments give fines.

## Save File
N/A

## Follow Up
I would expect most future governments not to levy fines and to accept bribes, so we might want to do a change in the future to change the defaults for fine and bribe to 0 and only explicitly set them for governments that do levy fines and that do accept bribes.