### PR TITLE
Fix: Heron Description "Existance"

### DIFF
--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -490,7 +490,7 @@ ship "Heron"
 	explode "huge explosion" 5
 	"final explode" "final explosion large"
 	description `The Heron is the Remnant's ultimate last resort: Flight. These mobile starports are built to serve as the core elements of evacuation fleets when the Remnant are ultimately pushed to the brink of destruction in their home systems. These massive ships are capable of lifting enormous amounts of resources and operate both in space and on land, and are continuously updated to make full use of the latest technological innovations.`
-	description `The few Herons in existence are carefully guarded secrets that embody the Remnant's core tactics of speed, stealth, and survival. Given the tiny number of them in existance, they are never available for discretionary use by Remnant captains and are always operated under the authority and direction of a prefect.`
+	description `The few Herons in existence are carefully guarded secrets that embody the Remnant's core tactics of speed, stealth, and survival. Given the tiny number that exist, they are never available for discretionary use by Remnant captains and are always operated under the authority and direction of a prefect.`
 
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue reported by Dr. Doom (Corraban) on Discord.

## Fix Details
The Heron description has both "existence" and "existance" in subsequent sentences. This PR replaces the erroneous "of them in existance" with "that exist" so it both solves the spelling mistake and the not-terribly-good thing that is having the same descriptor in two sequential sentences.
