### PR TITLE
Allow carried ships to be the player's flagship

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1179,12 +1179,12 @@ bool PlayerInfo::TakeOff(UI *ui)
 		return false;
 	
 	if(flagship)
-		flagship->IsFlagship(false);
+		flagship->AllowCarried(true);
 	flagship.reset();
 	flagship = FlagshipPtr();
 	if(!flagship)
 		return false;
-	flagship->IsFlagship(true);
+	flagship->AllowCarried(false);
 	
 	shouldLaunch = false;
 	Audio::Play(Audio::Get("takeoff"));

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1178,10 +1178,13 @@ bool PlayerInfo::TakeOff(UI *ui)
 	if(!system || !planet)
 		return false;
 	
+	if(flagship)
+		flagship->IsFlagship(false);
 	flagship.reset();
 	flagship = FlagshipPtr();
 	if(!flagship)
 		return false;
+	flagship->IsFlagship(true);
 	
 	shouldLaunch = false;
 	Audio::Play(Audio::Get("takeoff"));

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2795,7 +2795,7 @@ void Ship::AddCrew(int count)
 // Check if this is a ship that can be used as a flagship.
 bool Ship::CanBeFlagship() const
 {
-	return !CanBeCarried() && RequiredCrew() && Crew() && !IsDisabled();
+	return RequiredCrew() && Crew() && !IsDisabled();
 }
 
 
@@ -2990,9 +2990,16 @@ bool Ship::CanCarry(const Ship &ship) const
 
 
 
+void Ship::IsFlagship(bool isFlagshipChange)
+{
+	isFlagship = isFlagshipChange;
+}
+
+
+
 bool Ship::CanBeCarried() const
 {
-	return canBeCarried;
+	return isFlagship ? false : canBeCarried;
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2990,16 +2990,16 @@ bool Ship::CanCarry(const Ship &ship) const
 
 
 
-void Ship::IsFlagship(bool isFlagshipChange)
+void Ship::AllowCarried(bool allowCarried)
 {
-	isFlagship = isFlagshipChange;
+	canBeCarried = allowCarried && BAY_TYPES.count(attributes.Category()) > 0;
 }
 
 
 
 bool Ship::CanBeCarried() const
 {
-	return isFlagship ? false : canBeCarried;
+	return canBeCarried;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -331,8 +331,8 @@ public:
 	// Check if this ship has a bay free for the given other ship, and the
 	// bay is not reserved for one of its existing escorts.
 	bool CanCarry(const Ship &ship) const;
-	// Change whether this ship is allowed to be carried regardless of its
-	// category.
+	// Change whether this ship can be carried. If false, the ship cannot be
+	// carried. If true, the ship can be carried if its category allows it.
 	void AllowCarried(bool allowCarried);
 	// Check if this is a ship of a type that can be carried.
 	bool CanBeCarried() const;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -331,6 +331,9 @@ public:
 	// Check if this ship has a bay free for the given other ship, and the
 	// bay is not reserved for one of its existing escorts.
 	bool CanCarry(const Ship &ship) const;
+	// Mark this ship as being the player's flagship, meaning it can't be
+	// carried regardless of its category.
+	void IsFlagship(bool isFlagshipChange);
 	// Check if this is a ship of a type that can be carried.
 	bool CanBeCarried() const;
 	// Move the given ship into one of the bays, if possible.
@@ -436,6 +439,7 @@ private:
 	const Sprite *thumbnail = nullptr;
 	// Characteristics of this particular ship:
 	std::string name;
+	bool isFlagship = false;
 	bool canBeCarried = false;
 	
 	int forget = 0;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -331,9 +331,9 @@ public:
 	// Check if this ship has a bay free for the given other ship, and the
 	// bay is not reserved for one of its existing escorts.
 	bool CanCarry(const Ship &ship) const;
-	// Mark this ship as being the player's flagship, meaning it can't be
-	// carried regardless of its category.
-	void IsFlagship(bool isFlagshipChange);
+	// Change whether this ship is allowed to be carried regardless of its
+	// category.
+	void AllowCarried(bool allowCarried);
 	// Check if this is a ship of a type that can be carried.
 	bool CanBeCarried() const;
 	// Move the given ship into one of the bays, if possible.
@@ -439,7 +439,6 @@ private:
 	const Sprite *thumbnail = nullptr;
 	// Characteristics of this particular ship:
 	std::string name;
-	bool isFlagship = false;
 	bool canBeCarried = false;
 	
 	int forget = 0;


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #1643.

## Feature Details
Title says it all. Fighters, drones, or any carried ship category in the future can be piloted by the player as a flagship, if they so choose.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
<details><summary>Tested by changing my flagship to a Finch. Was able to successfully depart solo, as well as with carries as escorts. Carried ships as escorts work normally.</summary>

![image](https://user-images.githubusercontent.com/17688683/96145254-0766d480-0ed3-11eb-8990-9fb3ad027d11.png)
![image](https://user-images.githubusercontent.com/17688683/96145286-0df54c00-0ed3-11eb-9964-0828629998b5.png)
![image](https://user-images.githubusercontent.com/17688683/96145296-12216980-0ed3-11eb-8e8c-c1570965c0da.png)
![image](https://user-images.githubusercontent.com/17688683/96145314-1483c380-0ed3-11eb-8cbc-c1f304848c3d.png)
</details>

## Performance Impact
N/A
