### PR TITLE
Feat: Add 'D' keybind to finish conversation

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -206,7 +206,7 @@ bool ConversationPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comm
 	if(node < 0)
 	{
 		// If the conversation has ended, the only possible action is to exit.
-		if(isNewPress && (key == SDLK_RETURN || key == SDLK_KP_ENTER))
+		if(isNewPress && (key == SDLK_RETURN || key == SDLK_KP_ENTER || key == 'd'))
 		{
 			Exit();
 			return true;


### PR DESCRIPTION
## Feature Details
This PR adds the ability to press 'D' to finish conversations. Currently, you can use the number keys to quickly and seamlessly make dialog choices with the left side of the keyboard, but have to move to the right side or the mouse to finish them. Using the 'D' key would make finishing conversations consistent with various other dialogs through Endless Sky, which can be confirmed with the same binding.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Finished the conversations at the beginning of the game, with the banker and James, by pressing the D key and return, to verify they both continue to work. Continues to work with both lower and uppercase D, and doesn't cause conflicts on the naming panel.

## Performance Impact
N/A