### PR TITLE
Stop blurshader thinking there is centervelocity movement after player death

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -447,7 +447,7 @@ void Engine::Step(bool isActive)
 	else if(flagship)
 	{
 		center = flagship->Position();
-		centerVelocity = flagship->Velocity();
+		centerVelocity = flagship->IsDestroyed() ? Point(0,0) : flagship->Velocity();
 		if(doEnter && flagship->Zoom() == 1. && !flagship->IsHyperspacing())
 		{
 			doEnter = false;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -447,7 +447,7 @@ void Engine::Step(bool isActive)
 	else if(flagship)
 	{
 		center = flagship->Position();
-		centerVelocity = flagship->IsDestroyed() ? Point(0,0) : flagship->Velocity();
+		centerVelocity = flagship->Velocity();
 		if(doEnter && flagship->Zoom() == 1. && !flagship->IsHyperspacing())
 		{
 			doEnter = false;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1292,6 +1292,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 			heat = 0.;
 			ionization = 0.;
 			fuel = 0.;
+			velocity = Point();
 			MarkForRemoval();
 			return;
 		}


### PR DESCRIPTION

**Bugfix:** This PR addresses issue #5220 

## Fix Details
This being my first ever PR and my first hour of scanning through the code - I chose a very simple seeming issue, with little chance to sprawl and create more problems with the fix, that said however, I am obviously not completely au fait with the codebase, so apologies for any mistakes in my understanding.

From what I can see, the `centrevelocity` is what determines the blur shader strength, and the centrevelocity is set in Engine::step() based on flagship velocity, after the flagship "dies" I'm guessing that its velocity is never zeroed, hence the centrevelocity keeps accessing the "dead" ships velocity which is now frozen forever at its last updated value.

I added a conditional in Engine::Step() which asks if the flagship is destroyed, if so, set centrevelocity to Point(0,0) ( no movement ) and if not, uses the ships velocity as normal.

I dont know if this is the best place for this conditional, but it seems better than adding checks elsewhere further down the line in the drawing/shader code ( or changing the ship code to do more stuff when destroyed )


## Testing Done
Itd be hard to see how this change could introduce other errors, but I did the original test case from the linked issue of getting my ship destroyed while in motion, and the motion blur was gone, no other oddities observed ( i.e the screen still moves and stars still blur appropiately before the ship is destroyed )

## Save File
N/A

before: 

<img width="384" alt="Webp net-resizeimage" src="https://user-images.githubusercontent.com/67859015/96919241-67491680-14a3-11eb-821e-b617306a291e.png">

after:

<img width="480" alt="Webp net-resizeimage(1)" src="https://user-images.githubusercontent.com/67859015/96919322-86e03f00-14a3-11eb-8a4a-54c1347d738f.png">


