### PR TITLE
Add check for planet having a sprite before returning valid planet to land on

### DIFF
--- a/source/StellarObject.cpp
+++ b/source/StellarObject.cpp
@@ -57,9 +57,10 @@ double StellarObject::Radius() const
 // If it is possible to land on this planet, this returns the Planet
 // objects that gives more information about it. Otherwise, this
 // function will just return nullptr.
+// Planets without sprites are not landable
 const Planet *StellarObject::GetPlanet() const
 {
-	return planet;
+	return HasSprite() ? planet : nullptr;
 }
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5061 

## Fix Details
As per linked issue, autopilot fails to land on spriteless planet, as it tries to calculate radius /distance from the sprite to start landing process, and constantly circles around a zero point.

Even though the unintended behaviour comes about as trying to use spriteless planets as a form of one-way wormholes, which probably isnt the ideal future way to make these, the behaviour itself is problematic, and I cannot think of any situation where you would want the game to land on a spriteless planet.

Added a conditional in get_planet() to return nullptr if there is no sprite on the object, get_planet() is checked for truthiness in all checks for landable planets in that system, so player and AI and everything else will just not consider it a planet at all, and it can function as a one-way wormhole exit point.

The map still draws a two-way link, but thats probably outside the scope of this little "fix"

## Testing Done
Edited map.txt to make a wormhole link, and on one part of it, deleted the sprite entry.

Appeared in that system, pressed L to land, got the message about no landable planets, AI ships didnt try and go towards it to land.

Tested with a random planet, removing its sprite, and it didnt show up as a landable planet. 

All other planets and landings seemed to work normally.

## Save File
N/A

