### PR TITLE
Disallow selecting already destroyed ships by clicking/dragging

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1994,7 +1994,7 @@ bool PlayerInfo::SelectShips(const Rectangle &box, bool hasShift)
 	
 	bool matched = false;
 	for(const shared_ptr<Ship> &ship : ships)
-		if(!ship->IsParked() && ship->GetSystem() == system && ship.get() != Flagship()
+		if(!ship->IsDestroyed() && !ship->IsParked() && ship->GetSystem() == system && ship.get() != Flagship()
 				&& box.Contains(ship->Position()))
 		{
 			matched = true;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #4544

## Fix Details
Added a check for ->isDestroyed() in the SelectShips() function before allowing it to be selected.


## Testing Done
Dragging and clicking select on live ships still works normally.
After escort dies, click and drag area it died, and now it is no longer selecting

## Save File
[testy testy.txt](https://github.com/endless-sky/endless-sky/files/5430949/testy.testy.txt)

Just a quick save file with a tougher escort to ensure flagship dies first.
