### PR TITLE
Update CodeBlocks 64-bit paths to use modern defaults

### DIFF
--- a/EndlessSky.cbp
+++ b/EndlessSky.cbp
@@ -66,7 +66,7 @@
 		<Linker>
 			<Add option="-Wl,--subsystem,windows" />
 			<Add option="-lwinmm" />
-			<Add library="C:\Program Files\mingw64\x86_64-w64-mingw32\lib\libmingw32.a" />
+			<Add library="C:\Program Files\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\x86_64-w64-mingw32\lib\libmingw32.a" />
 			<Add library="C:\dev64\lib\libsdl2main.a" />
 			<Add library="C:\dev64\lib\libsdl2.dll.a" />
 			<Add library="C:\dev64\lib\libpng.dll.a" />
@@ -75,7 +75,7 @@
 			<Add library="C:\dev64\lib\libmad.dll.a" />
 			<Add library="C:\dev64\lib\libopenal32.dll.a" />
 			<Add library="C:\dev64\lib\libglew32.dll.a" />
-			<Add library="C:\Program Files\mingw64\x86_64-w64-mingw32\lib\libopengl32.a" />
+			<Add library="C:\Program Files\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\x86_64-w64-mingw32\lib\libopengl32.a" />
 			<Add directory="C:/dev64/lib" />
 		</Linker>
 		<Unit filename="source/AI.cpp" />


### PR DESCRIPTION
Currently, the CodeBlocks project file has three paths built into it: The precompiled libraries paths (which the wiki mentions you should extract them to that location), the 32-bit MinGW paths (which use a proper path, although for a version from years ago), then the 64-bit MinGW paths. These are not only inconsistent with the 32-bit paths, but completely nonsensical, as a user would only end up with them if they installed MinGW directly into C:\Program Files\ (which would leave other files lose in there, as well).

This PR updates the CodeBlocks project file to use the default install location from the latest version of MinGW (from 3-4 years ago), 8.1.0. It doesn't seem like a single developer working on ES uses the provided defaults, so changing them up will only help a user getting the game compiled with as little configuration as possible.