### PR TITLE
Add Finisher Storage Tube to stock Interdictor

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -287,7 +287,8 @@ ship "Heliarch Interdictor"
 			"hit force" 3800
 	outfits
 		"Finisher Pod" 2
-		"Finisher Torpedo" 80
+		"Finisher Storage Tube"
+		"Finisher Torpedo" 100
 		"Heliarch Attractor"
 		"Heliarch Repulsor"
 		


### PR DESCRIPTION
I noticed the Heliarch Interdictor had over 20 free Outfit Space in its stock configuration, a lot more than the other 2 Heliarch ships. Seeing as that variant's main source of damage are the Finisher Torpedoes, I added 1 Finisher Storage Tube to its outfits and increased the amount of Finisher Torpedoes it carries from 80 to 100, to use up the extra ammo capacity offered by the Storage Tube.