### PR TITLE
Fix race condition while loading the audio.

### DIFF
--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -576,6 +576,10 @@ namespace {
 					return;
 				name = loadQueue.begin()->first;
 				path = loadQueue.begin()->second;
+
+				// Since we need to unlock the mutex below, create the map entry to
+				// avoid a race condition when accessing sounds' size.
+				sounds[name];
 			}
 			
 			// Unlock the mutex for the time-intensive part of the loop.

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -563,6 +563,7 @@ namespace {
 	{
 		string name;
 		string path;
+		Sound *sound;
 		while(true)
 		{
 			{
@@ -579,11 +580,11 @@ namespace {
 
 				// Since we need to unlock the mutex below, create the map entry to
 				// avoid a race condition when accessing sounds' size.
-				sounds[name];
+				sound = &sounds[name];
 			}
 			
 			// Unlock the mutex for the time-intensive part of the loop.
-			if(!sounds[name].Load(path, name))
+			if(!sound->Load(path, name))
 				Files::LogError("Unable to load sound \"" + name + "\" from path: " + path);
 		}
 	}


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5462 

## Fix Details

I fixed this by creating the `sounds` entry inside the mutex lock instead of outside, so that loading the sound file and accessing `sounds`'s size do not clash.

## Testing Done

I couldn't get thread sanitizer to error out, but I verified using OP's error message that I correctly identified the two functions that race (`map::operator[]` and `map::size`).

However, I reduced the code into a small example to test my fix. If you remove the comment (my fix), then the race condition disappears. The example can be found here: https://godbolt.org/z/fP5r9s

## Save File
N/A