### PR TITLE
Add an offset when drawing certain sprites

### DIFF
--- a/data/coalition/coalition weapons.txt
+++ b/data/coalition/coalition weapons.txt
@@ -207,6 +207,7 @@ outfit "Heliarch Attractor"
 		sprite "projectile/attractor"
 			"frame rate" 5.2
 			"random start frame"
+			"draw offset" 320
 		"hardpoint sprite" "hardpoint/heliarch attractor"
 		"hardpoint offset" 9.
 		sound "heliarch attractor"
@@ -250,6 +251,7 @@ outfit "Heliarch Repulsor"
 		sprite "projectile/repulsor"
 			"frame rate" 3.2
 			"random start frame"
+			"draw offset" 280
 		"hardpoint sprite" "hardpoint/heliarch repulsor"
 		"hardpoint offset" 9.
 		sound "heliarch repulsor"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -151,6 +151,7 @@ outfit "Beam Laser"
 	weapon
 		sprite "projectile/laser"
 			"frame rate" 1
+			"draw offset" 150
 		sound "laser"
 		"hit effect" "beam laser impact"
 		"inaccuracy" .5
@@ -175,6 +176,7 @@ outfit "Laser Turret"
 	weapon
 		sprite "projectile/2x laser"
 			"frame rate" 1
+			"draw offset" 150
 		"hardpoint sprite" "hardpoint/laser turret"
 		"hardpoint offset" -0.5 8.
 		sound "laser"
@@ -211,6 +213,7 @@ outfit "Heavy Laser"
 	weapon
 		sprite "projectile/heavy laser"
 			"frame rate" 1
+			"draw offset" 200
 		sound "heavy laser"
 		"hit effect" "heavy laser impact"
 		"inaccuracy" .4
@@ -235,6 +238,7 @@ outfit "Heavy Laser Turret"
 	weapon
 		sprite "projectile/2x heavy laser"
 			"frame rate" 1
+			"draw offset" 200
 		"hardpoint sprite" "hardpoint/heavy laser turret"
 		"hardpoint offset" 8.
 		sound "heavy laser"
@@ -272,6 +276,7 @@ outfit "Electron Beam"
 	weapon
 		sprite "projectile/electron"
 			"frame rate" 60
+			"draw offset" 225
 		sound "electron beam"
 		"hit effect" "electron impact"
 		"inaccuracy" .3
@@ -296,6 +301,7 @@ outfit "Electron Turret"
 	weapon
 		sprite "projectile/2x electron"
 			"frame rate" 60
+			"draw offset" 225
 		"hardpoint sprite" "hardpoint/electron turret"
 		"hardpoint offset" 8.
 		sound "electron beam"

--- a/data/ka'het/ka'het outfits.txt
+++ b/data/ka'het/ka'het outfits.txt
@@ -21,6 +21,7 @@ outfit "Ka'het Ravager Beam"
 	weapon
 		sprite "projectile/ravager beam"
 			"frame rate" 15
+			"draw offset" 240
 		sound "disruptor"
 		"hit effect" "ravager impact"
 		"inaccuracy" .2
@@ -44,6 +45,7 @@ outfit "Ka'het Ravager Turret"
 	weapon
 		sprite "projectile/ravager beam"
 			"frame rate" 15
+			"draw offset" 240
 		"hardpoint sprite" "hardpoint/ravager turret"
 		"hardpoint offset" 3.
 		sound "disruptor"

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -65,6 +65,7 @@ outfit "Korath Banisher"
 	weapon
 		sprite "projectile/banisher"
 			"frame rate" 60
+			"draw offset" 295
 		"hardpoint sprite" "hardpoint/banisher"
 		"hardpoint offset" 5.
 		sound "banisher"
@@ -131,6 +132,7 @@ outfit "Korath Fire-Lance"
 		sprite "projectile/fire-lance"
 			"frame rate" 12
 			"random start frame"
+			"draw offset" 275
 		sound "fire-lance"
 		"hit effect" "fire-lance impact"
 		"inaccuracy" .4
@@ -486,6 +488,7 @@ outfit "Korath Disruptor"
 	weapon
 		sprite "projectile/disruptor"
 			"frame rate" 15
+			"draw offset" 240
 		"hardpoint sprite" "hardpoint/disruptor"
 		"hardpoint offset" 15.
 		sound "disruptor"

--- a/data/pug/pug.txt
+++ b/data/pug/pug.txt
@@ -178,6 +178,7 @@ outfit "Pug Zapper"
 			"frame rate" 60
 			"random start frame"
 			"delay" 6
+			"draw offset" 160
 		sound "zapper"
 		"hit effect" "skylance impact"
 		"inaccuracy" .3
@@ -203,6 +204,7 @@ outfit "Pug Zapper Turret"
 		sprite "projectile/lightning"
 			"frame rate" 60
 			"random start frame"
+			"draw offset" 160
 		"hardpoint sprite" "hardpoint/pug zapper turret"
 		"hardpoint offset" 7.
 		sound "zapper"

--- a/data/quarg/quarg outfits.txt
+++ b/data/quarg/quarg outfits.txt
@@ -42,6 +42,7 @@ outfit "Quarg Skylance"
 	weapon
 		sprite "projectile/skylance"
 			"frame rate" 1
+			"draw offset" 250
 		"hardpoint sprite" "hardpoint/quarg skylance"
 		"hardpoint offset" 10
 		sound "skylance"

--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -274,6 +274,7 @@ outfit "Heavy Ion Cyclotron"
 	weapon
 		sprite "projectile/hion"
 			"frame rate" 30
+			"draw offset" 10
 		sound "hion"
 		"hit effect" "proton impact" 3
 		"submunition" "Heavy Ion Fragment" 3

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -22,6 +22,7 @@ outfit "Sunbeam"
 		sprite "projectile/sunbeam"
 			"frame rate" 1.3
 			"random start frame"
+			"draw offset" 270
 		sound "sunbeam"
 		"hit effect" "sunbeam impact"
 		"inaccuracy" .2
@@ -60,6 +61,7 @@ outfit "Sunbeam Turret"
 		sprite "projectile/sunbeam"
 			"frame rate" 1.3
 			"random start frame"
+			"draw offset" 270
 		"hardpoint sprite" "hardpoint/sunbeam turret"
 		"hardpoint offset" 12.
 		sound "sunbeam"
@@ -91,6 +93,7 @@ outfit "Dual Sunbeam Turret"
 		sprite "projectile/2x sunbeam"
 			"frame rate" 1.3
 			"random start frame"
+			"draw offset" 270
 		"hardpoint sprite" "hardpoint/dual sunbeam turret"
 		"hardpoint offset" 12.
 		sound "sunbeam"

--- a/source/BatchDrawList.cpp
+++ b/source/BatchDrawList.cpp
@@ -52,32 +52,6 @@ void BatchDrawList::SetCenter(const Point &center)
 
 
 
-// Add an unswizzled object based on the Body class.
-bool BatchDrawList::Add(const Body &body, float clip)
-{
-	// TODO: Rather than compensate using 1/2 the Visual | Projectile velocity, we should
-	// extend the Sprite class to know its reference point. For most sprites, this will be
-	// the horizontal and vertical middle of the sprite, but for "laser" projectiles, this
-	// would be the middle of a sprite end. Adding such support will then help resolve issues
-	// with drawing things such as very large effects that simulate projectiles. This offset
-	// exists because we use the current position of a projectile, but have varied expectations
-	// of what that position means. For a "laser" projectile, it is created at the ship hardpoint but
-	// we want it to be drawn with its center halfway to the target. For longer-lived projectiles, we
-	// expect the position to be the actual location of the projectile at that point in time.
-	Point position = (body.Position() + .5 * body.Velocity() - center) * zoom;
-	return Add(body, position, clip);
-}
-
-
-
-// TODO: Once we have sprite reference positions, this method will not be needed.
-bool BatchDrawList::AddVisual(const Body &visual)
-{
-	return Add(visual, (visual.Position() - center) * zoom, 1.f);
-}
-
-
-
 // Draw all the items in this list.
 void BatchDrawList::Draw() const
 {
@@ -114,8 +88,11 @@ bool BatchDrawList::Cull(const Body &body, const Point &position) const
 
 
 
-bool BatchDrawList::Add(const Body &body, Point position, float clip)
+bool BatchDrawList::Add(const Body &body, float clip)
 {
+	Point offset = body.GetDrawOffset() * body.Velocity().Unit();
+	Point position = (body.Position() + offset - center) * zoom;
+
 	if(Cull(body, position))
 		return false;
 	

--- a/source/BatchDrawList.h
+++ b/source/BatchDrawList.h
@@ -33,7 +33,6 @@ public:
 	
 	// Add an unswizzled object based on the Body class.
 	bool Add(const Body &body, float clip = 1.f);
-	bool AddVisual(const Body &visual);
 	
 	// Draw all the items in this list.
 	void Draw() const;
@@ -42,9 +41,6 @@ public:
 private:
 	// Determine if the given body should be drawn at all.
 	bool Cull(const Body &body, const Point &position) const;
-	
-	// Add the given body at the given position.
-	bool Add(const Body &body, Point position, float clip);
 	
 	
 private:

--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -94,6 +94,14 @@ int Body::GetSwizzle() const
 
 
 
+// Offset used when drawing the sprite (in direction of velocity).
+int Body::GetDrawOffset() const
+{
+	return drawOffset;
+}
+
+
+
 // Get the frame index for the given time step. If no time step is given, this
 // will return the frame from the most recently given step.
 float Body::GetFrame(int step) const
@@ -210,6 +218,8 @@ void Body::LoadSprite(const DataNode &node)
 		}
 		else if(child.Token(0) == "rewind")
 			rewind = true;
+		else if(child.Token(0) == "draw offset" && child.Size() >= 2)
+			drawOffset = child.Value(1);
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}

--- a/source/Body.h
+++ b/source/Body.h
@@ -47,6 +47,8 @@ public:
 	double Radius() const;
 	// Which color swizzle should be applied to the sprite?
 	int GetSwizzle() const;
+	// Offset used when drawing the sprite (in direction of velocity).
+	int GetDrawOffset() const;
 	// Get the sprite and mask for the given time step.
 	float GetFrame(int step = -1) const;
 	const Mask &GetMask(int step = -1) const;
@@ -118,6 +120,7 @@ private:
 	mutable bool randomize = false;
 	bool repeat = true;
 	bool rewind = false;
+	int drawOffset = 0;
 	int pause = 0;
 	
 	// Record when this object is marked for removal from the game.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1454,7 +1454,7 @@ void Engine::CalculateStep()
 		batchDraw[calcTickTock].Add(projectile, projectile.Clip());
 	// Draw the visuals.
 	for(const Visual &visual : visuals)
-		batchDraw[calcTickTock].AddVisual(visual);
+		batchDraw[calcTickTock].Add(visual);
 	
 	// Keep track of how much of the CPU time we are using.
 	loadSum += loadTimer.Time();


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5479 

## Fix Details
This fix implements the solution recommended in the TODO in BatchDrawList: Add a draw offset to sprites.

Under `"sprite"` this PR adds a `"draw offset" <num>`, which represents the offset of the sprite to draw. The offset is added in direction of the velocity of the projectile.

## Testing Done
I tested this PR with the save file on the linked issue. However, I didn't test any weapon except Beam Laser. I'll do the others soonish.

- [ ] Make sure that I didn't miss a weapon to adjust

## Save File

In the linked issue, the plugin and the save file.
