### PR TITLE
Remove "minor" from the FW Epilogue missions

### DIFF
--- a/data/human/free worlds epilogue.txt
+++ b/data/human/free worlds epilogue.txt
@@ -57,6 +57,9 @@ mission "FW Epilogue: Alondo"
 	source "Bourne"
 	to offer
 		has "free worlds plot completed"
+		or
+			not "Paradise Fortune 3: done"
+			has "Paradise Fortune 4: offered"
 	
 	on offer
 		conversation

--- a/data/human/free worlds epilogue.txt
+++ b/data/human/free worlds epilogue.txt
@@ -9,7 +9,6 @@
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 mission "FW Epilogue: Ijs and Katya"
-	minor
 	landing
 	source "Winter"
 	to offer
@@ -54,7 +53,6 @@ mission "FW Epilogue: Ijs and Katya"
 
 
 mission "FW Epilogue: Alondo"
-	minor
 	landing
 	source "Bourne"
 	to offer
@@ -92,7 +90,6 @@ mission "FW Epilogue: Alondo"
 
 
 mission "FW Epilogue: Freya"
-	minor
 	landing
 	source "Pugglemug"
 	to offer
@@ -144,7 +141,6 @@ mission "FW Epilogue: Freya"
 
 
 mission "FW Epilogue: Danforth"
-	minor
 	landing
 	source "Farpoint"
 	to offer


### PR DESCRIPTION
**Bugfi:**

## Fix Details
Removes the `minor` attribute from all the FW Epilogue missions, due to them already having `landing`, which cancels `minor` out.
