### PR TITLE
Fix: Missing indentation on Heron description, and stylization consistency

### DIFF
--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -490,7 +490,7 @@ ship "Heron"
 	explode "huge explosion" 5
 	"final explode" "final explosion large"
 	description `The Heron is the Remnant's ultimate last resort: Flight. These mobile starports are built to serve as the core elements of evacuation fleets when the Remnant are ultimately pushed to the brink of destruction in their home systems. These massive ships are capable of lifting enormous amounts of resources and operate both in space and on land, and are continuously updated to make full use of the latest technological innovations.`
-	description `The few Herons in existence are carefully guarded secrets that embody the Remnant's core tactics of speed, stealth, and survival. Given the tiny number that exist, they are never available for discretionary use by Remnant captains and are always operated under the authority and direction of a prefect.`
+	description `	The few Herons in existence are carefully guarded secrets that embody the Remnant's core tactics of speed, stealth, and survival. Given the tiny number that exist, they are never available for discretionary use by Remnant captains and are always operated under the authority and direction of a prefect.`
 
 
 

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -489,8 +489,8 @@ ship "Heron"
 	explode "large explosion" 20
 	explode "huge explosion" 5
 	"final explode" "final explosion large"
-	description `The Heron is the Remnant's ultimate last resort: Flight. These mobile starports are built to serve as the core elements of evacuation fleets when the Remnant are ultimately pushed to the brink of destruction in their home systems. These massive ships are capable of lifting enormous amounts of resources and operate both in space and on land, and are continuously updated to make full use of the latest technological innovations.`
-	description `	The few Herons in existence are carefully guarded secrets that embody the Remnant's core tactics of speed, stealth, and survival. Given the tiny number that exist, they are never available for discretionary use by Remnant captains and are always operated under the authority and direction of a prefect.`
+	description "The Heron is the Remnant's ultimate last resort: Flight. These mobile starports are built to serve as the core elements of evacuation fleets when the Remnant are ultimately pushed to the brink of destruction in their home systems. These massive ships are capable of lifting enormous amounts of resources and operate both in space and on land, and are continuously updated to make full use of the latest technological innovations."
+	description "	The few Herons in existence are carefully guarded secrets that embody the Remnant's core tactics of speed, stealth, and survival. Given the tiny number that exist, they are never available for discretionary use by Remnant captains and are always operated under the authority and direction of a prefect."
 
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses a missing paragraph indentation

## Fix Details
2nd paragraph doesn't have an indent. This fixes it. Also swaps the backticks for quotation marks to maintain consistent styling with the rest of the ship descriptions.

Thanks to Arachi on discord for reporting the missing indentation.