### PR TITLE
Fix: Loss of trailing digits when adding outfit

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -103,7 +103,7 @@ namespace {
 	// This function doesn't modify attribute if valud * count is zero.
 	void AddToAttribute(double &attribute, map<double, int> &partialTerms, double value, int count)
 	{
-		if(value == 0. || count == 0)
+		if(value == 0. || !count)
 			return;
 		
 		auto &countOfValue = partialTerms[value];
@@ -241,6 +241,7 @@ void Outfit::Load(const DataNode &node)
 	convertScan("outfit");
 	convertScan("cargo");
 	
+	partialTerms.clear();
 	partialTerms["mass"][mass] = 1;
 	for(const auto &it : attributes)
 		partialTerms[it.first][it.second] = 1;

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -88,7 +88,7 @@ namespace {
 		}
 	}
 	
-	// Summation that avoids a loss of trailing digits as possible.
+	// Summation that avoids loss of trailing digits as much as possible.
 	double Sum(const map<double, int> &partialTerms)
 	{
 		vector<double> partialSums;
@@ -100,7 +100,7 @@ namespace {
 	}
 	
 	// Add value * count to an attribute.
-	// This function doesn't modify attribute if valud * count is zero.
+	// This function doesn't modify attribute if value * count is zero.
 	void AddToAttribute(double &attribute, map<double, int> &partialTerms, double value, int count)
 	{
 		if(value == 0. || !count)

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -105,6 +105,7 @@ private:
 	std::vector<std::string> licenses;
 	
 	Dictionary attributes;
+	std::map<std::string, std::map<double, int>> partialTerms;
 	
 	// The integers in these pairs/maps indicate the number of
 	// sprites/effects/sounds to be placed/played.


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #3639 and #3645.

## Fix Details
This PR addresses an issue that is caused by an accumulation of a loss of trailing digits when adding an outfit.

#3645 could solve the issue by another way; this PR needs more calculation amount, but is more proper and removes a mysterious parameter EPS.

## Testing Done
1. Load a pilot Sell Issue.
2. Sell all Laser Rifles.
3. Sell all Grenades.
4. Try to sell all Nerve Gases.

Current master cannot sell a last Nerve Gas, but this PR can sell all Nerve Gases.

## Save File
Test file provided by @KiLEdEnNis (same as #3645): [sell_issue.txt](https://github.com/endless-sky/endless-sky/files/1722054/sell_issue.txt)

## Performance Impact
This PR affects a performance only when Adding/Removing outfits and the impact is not noticeable.
