### PR TITLE
Added scrolling in the logbook category list

### DIFF
--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -245,15 +245,10 @@ bool LogbookPanel::Click(int x, int y, int clicks)
 
 bool LogbookPanel::Drag(double dx, double dy)
 {
-	if ((hoverPoint.X() - Screen::Left()) > SIDEBAR_WIDTH)
-	{
+	if((hoverPoint.X() - Screen::Left()) > SIDEBAR_WIDTH)
 		scroll = max(0., min(maxScroll, scroll - dy));
-	}
 	else
-	{
-		// Scroll sidebar
 		categoryScroll = max(0., min(maxCategoryScroll, categoryScroll - dy));
-	}
 	
 	return true;
 }
@@ -270,7 +265,6 @@ bool LogbookPanel::Scroll(double dx, double dy)
 bool LogbookPanel::Hover(int x, int y)
 {
 	hoverPoint = Point(x, y);
-	
 	return true;
 }
 

--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -227,11 +227,10 @@ bool LogbookPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 			int position = i * LINE_HEIGHT - categoryScroll;
 						
 			// If it's out of bounds, recenter it
-			if (position < MINIMUM_SELECTION_DISTANCE || position > (Screen::Height() - MINIMUM_SELECTION_DISTANCE))
+			if(position < MINIMUM_SELECTION_DISTANCE || position > (Screen::Height() - MINIMUM_SELECTION_DISTANCE))
 				categoryScroll = position - (Screen::Height() / 2);
 
 			categoryScroll = max(categoryScroll, 0.);
-
 		}
 	}
 	

--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -107,7 +107,7 @@ void LogbookPanel::Draw()
 	Point highlightOffset = Point(4. - PAD, 0.) + .5 * highlightSize;
 	Point textOffset(0., .5 * (LINE_HEIGHT - font.Height()));
 	// Start at this point on the screen:
-	Point pos = Screen::TopLeft() + Point(PAD, PAD);
+	Point pos = Screen::TopLeft() + Point(PAD, PAD - categoryScroll);
 	for(size_t i = 0; i < contents.size(); ++i)
 	{
 		if(selectedDate ? dates[i].Month() == selectedDate.Month() : selectedName == contents[i])
@@ -118,6 +118,8 @@ void LogbookPanel::Draw()
 		font.Draw(contents[i], pos + textOffset, dates[i].Month() ? medium : bright);
 		pos.Y() += LINE_HEIGHT;
 	}
+
+	maxCategoryScroll = max(0., maxCategoryScroll + pos.Y() - Screen::Bottom());
 	
 	// Parameters for drawing the main text:
 	WrappedText wrap(font);
@@ -222,7 +224,7 @@ bool LogbookPanel::Click(int x, int y, int clicks)
 	y -= Screen::Top();
 	if(x < SIDEBAR_WIDTH)
 	{
-		size_t index = (y - PAD) / LINE_HEIGHT;
+		size_t index = (y - PAD + categoryScroll) / LINE_HEIGHT;
 		if(index < contents.size())
 		{
 			selectedDate = dates[index];
@@ -243,7 +245,15 @@ bool LogbookPanel::Click(int x, int y, int clicks)
 
 bool LogbookPanel::Drag(double dx, double dy)
 {
-	scroll = max(0., min(maxScroll, scroll - dy));
+	if ((hoverPoint.X() - Screen::Left()) > SIDEBAR_WIDTH)
+	{
+		scroll = max(0., min(maxScroll, scroll - dy));
+	}
+	else
+	{
+		// Scroll sidebar
+		categoryScroll = max(0., min(maxCategoryScroll, categoryScroll - dy));
+	}
 	
 	return true;
 }
@@ -253,6 +263,15 @@ bool LogbookPanel::Drag(double dx, double dy)
 bool LogbookPanel::Scroll(double dx, double dy)
 {
 	return Drag(0., dy * Preferences::ScrollSpeed());
+}
+
+
+
+bool LogbookPanel::Hover(int x, int y)
+{
+	hoverPoint = Point(x, y);
+	
+	return true;
 }
 
 

--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -37,6 +37,10 @@ namespace {
 	const double PAD = 10.;
 	const double WIDTH = SIDEBAR_WIDTH + TEXT_WIDTH;
 	const double LINE_HEIGHT = 25.;
+
+	// The minimum distance in pixels between the selected month and the edge of the screen before the month gets centered
+	const double MINIMUM_SELECTION_DISTANCE = LINE_HEIGHT * 3;
+
 	const double GAP = 30.;
 	const string MONTH[] = {
 		"  January", "  February", "  March", "  April", "  May", "  June",
@@ -210,6 +214,24 @@ bool LogbookPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 			selectedName = contents[i];
 			scroll = 0.;
 			Update(key == SDLK_UP);
+
+			// Find our currently selected item again
+			for(i = 0 ; i < contents.size(); ++i)
+				if(contents[i] == selectedName)
+					break;
+
+			if(i == contents.size())
+				return true;
+
+			// Check if it's too far down or up
+			int position = i * LINE_HEIGHT - categoryScroll;
+						
+			// If it's out of bounds, recenter it
+			if (position < MINIMUM_SELECTION_DISTANCE || position > (Screen::Height() - MINIMUM_SELECTION_DISTANCE))
+				categoryScroll = position - (Screen::Height() / 2);
+
+			categoryScroll = max(categoryScroll, 0.);
+
 		}
 	}
 	

--- a/source/LogbookPanel.h
+++ b/source/LogbookPanel.h
@@ -65,8 +65,8 @@ private:
 	Point hoverPoint;
 	
 	// Current scroll:
-	double scroll = 0.;
 	double categoryScroll = 0.; 
+	double scroll = 0.;
 	mutable double maxCategoryScroll = 0.;
 	mutable double maxScroll = 0.;
 };

--- a/source/LogbookPanel.h
+++ b/source/LogbookPanel.h
@@ -42,6 +42,7 @@ protected:
 	virtual bool Click(int x, int y, int clicks) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Scroll(double dx, double dy) override;
+	virtual bool Hover(int x, int y) override;
 	
 	
 private:
@@ -60,9 +61,13 @@ private:
 	// Other months available for display:
 	std::vector<std::string> contents;
 	std::vector<Date> dates;
+
+	Point hoverPoint;
 	
 	// Current scroll:
 	double scroll = 0.;
+	double categoryScroll = 0.; 
+	mutable double maxCategoryScroll = 0.;
 	mutable double maxScroll = 0.;
 };
 


### PR DESCRIPTION
**Feature:** This PR implements scrolling in the list of categories in the logbook

## Feature Details
Right now, it is possible to scroll the list of dates and sub-categories in the logbook. However, it is not possible to scroll the list of years and categories ("Factions", "People", "3034"). This is an issue, because it means that on low screen resolutions, on large save files it is not possible to access the latest years of the logbook.

## UI Screenshots
![image](https://user-images.githubusercontent.com/38839219/99149978-29897900-2670-11eb-873a-be5e10c009ba.png)

## Usage Examples
No changes to data files are necessary

## Testing Done
I have a large save file which has ~29 years of logbook history. I opened that save's logbook and tried scrolling

## Performance Impact
N/A
