### PR TITLE
Skip capacity check on Uninstall v2

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -582,9 +582,13 @@ void OutfitterPanel::Sell(bool toCargo)
 			if(selectedOutfit->Get("required crew"))
 				ship->AddCrew(-selectedOutfit->Get("required crew"));
 			ship->Recharge();
-			if(toCargo && player.Cargo().Add(selectedOutfit))
+			if(toCargo)
 			{
-				// Transfer to cargo completed.
+				// Transfer to cargo even if it would exceed the capacity.
+				int size = player.Cargo().Size();
+				player.Cargo().SetSize(-1);
+				player.Cargo().Add(selectedOutfit);
+				player.Cargo().SetSize(size);
 			}
 			else
 			{


### PR DESCRIPTION
**Feature:** This PR implements a trivial quality-of-life feature

## Feature Details
Having 'u' sometimes uninstall the outfits and sometimes sell them is very confusing.
Always place uninstalled outfits into the cargo hold, even if it exceeds its capacity.
This change will make swapping active and inactive outfits much more comfortable.

## UI Screenshots
N/A

## Testing Done
None, sorry.
It is modeled after existing code, so it should be OK.

## Performance Impact
N/A

Thank you!