### PR TITLE
Fix setting of environment variables in continuous publish workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -144,7 +144,7 @@ jobs:
         run: |
           go get github.com/github-release/github-release
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "${GOPATH}/bin" >> $GITHUB_PATH
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: Set environment variables
         run: |
           echo "GITHUB_USER=$( echo ${{ github.repository }} | cut -d/ -f1 )" >> $GITHUB_ENV
@@ -153,8 +153,8 @@ jobs:
         run: |
           git tag --force continuous ${{ github.sha }}
           git push --tags --force
-      - name: Debugging with tmate
-        uses: mxschmitt/action-tmate@v3.1
+#      - name: Debugging with tmate
+#        uses: mxschmitt/action-tmate@v3.1
       - name: Setup continuous release
         run: |
           DESCRIPTION="Triggered on $(date -u '+%Y/%m/%d, %H:%M') UTC by commit ${{ github.sha }} (@${{ github.actor }})

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - actions-env-fix # TODO
   pull_request:
     types:
       - synchronize
@@ -153,8 +152,6 @@ jobs:
         run: |
           git tag --force continuous ${{ github.sha }}
           git push --tags --force
-#      - name: Debugging with tmate
-#        uses: mxschmitt/action-tmate@v3.1
       - name: Setup continuous release
         run: |
           DESCRIPTION="Triggered on $(date -u '+%Y/%m/%d, %H:%M') UTC by commit ${{ github.sha }} (@${{ github.actor }})

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - actions-env-fix # TODO
   pull_request:
     types:
       - synchronize

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -153,6 +153,8 @@ jobs:
         run: |
           git tag --force continuous ${{ github.sha }}
           git push --tags --force
+      - name: Debugging with tmate
+        uses: mxschmitt/action-tmate@v3.1
       - name: Setup continuous release
         run: |
           DESCRIPTION="Triggered on $(date -u '+%Y/%m/%d, %H:%M') UTC by commit ${{ github.sha }} (@${{ github.actor }})


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue with the pipeline runs.

## Fix Details

The other day, Github disabled the `set-env` command ([blog post](https://github.com/endless-sky/endless-sky/runs/1428472982?check_suite_focus=true)). The fix in 58c7501d8d3636ec2d5b239251aea8fb4e00ac18 was almost correct, but didn't add `$GOPATH/bin` to the path:

```bash
echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
echo "${GOPATH}/bin" >> $GITHUB_PATH
```

Unfortunately, appending to `$GITHUB_ENV` only creates the `$GOPATH` variable for the *next* step, so the second command only adds `/bin` to the PATH.

This PR simply uses `$(go env GOPATH)` again instead of `$GOPATH`.

## Testing Done
https://github.com/MCOfficer/endless-sky/actions/runs/374012805
https://github.com/MCOfficer/endless-sky/releases/tag/continuous


