### PR TITLE
Fix a bug where some submunitions have wrong velocity.

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -76,8 +76,11 @@ Projectile::Projectile(const Projectile &parent, const Weapon *weapon)
 		if(!parent.weapon->Acceleration())
 		{
 			// Move in this new direction at the same velocity.
-			double parentVelocity = parent.weapon->Velocity();
-			velocity += (this->angle.Unit() - parent.angle.Unit()) * parentVelocity;
+			// Velocity may be negative.
+			Point referenceVector = parent.angle.Unit();
+			double parentVelocity = parent.velocity.Y() * referenceVector.Y()
+				+ parent.velocity.X() * referenceVector.X();
+			velocity = this->angle.Unit() * parentVelocity;
 		}
 	}
 	velocity += this->angle.Unit() * (weapon->Velocity() + Random::Real() * weapon->RandomVelocity());


### PR DESCRIPTION
**Bugfix:** This PR fixed a bug where some submunitions have wrong velocity.

## Fix Details
In current master, some submunitions have wrong velocity because the current master ignores "random velocity" of the original projectile and the parameters of the submunition of the submunition. We can notice the submunitions float in space with bad angle.

This PR corrects the bug. A submunition is applied "velocity", "random velocity", and "inaccuracy" parameters over the last velocity instead of "velocity" of the original projectile.

This PR changes the velocity of some submunitions, probably you want to change some "inaccuracy" if you have a large inaccuracy of a submunition and it's the submunition of the submunition or the original projectile have random velocity.

Current Master, Positive Velocity
![Peek 2020-11-22 21-00](https://user-images.githubusercontent.com/22392249/99903209-512eb000-2d06-11eb-9dbc-08606d821de7.gif)

This PR, Positive Velocity
![Peek 2020-11-22 21-02](https://user-images.githubusercontent.com/22392249/99903183-293f4c80-2d06-11eb-8d3d-f3f5da3a5ca7.gif)

Current Master, Negative Velocity
![Peek 2020-11-22 21-00-n](https://user-images.githubusercontent.com/22392249/99903190-365c3b80-2d06-11eb-9950-5b5f984717d0.gif)

This PR, Negative Velocity
![Peek 2020-11-22 21-02-n](https://user-images.githubusercontent.com/22392249/99903177-1c225d80-2d06-11eb-97f6-1585812b6b53.gif)

## Testing Done
1. Load pilot [projectile test](https://github.com/endless-sky/endless-sky/files/5579423/projectile_test.zip)
2. Depart.
3. Fire the gun.

## Save File
[projectile_test.zip](https://github.com/endless-sky/endless-sky/files/5579423/projectile_test.zip)
