### PR TITLE
Fix: Changing MCO's person ship to have 12000 hull instead of 1200

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -1052,7 +1052,7 @@ ship "Marauder Bactrian"
 		category "Transport"
 		"cost" 17600000
 		"shields" 30000
-		"hull" 1200
+		"hull" 12000
 		"required crew" 70
 		"bunks" 93
 		"mass" 650


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Dropping from 8700 hull to 1200 hull seems like an extreme weakening of the base ship. Increasing from 8700 to 12000 seems reasonable for the appearance and being a person ship.  So this fix assumes that the 1200 is an error wherein it is missing a 0, and adds that missing zero.

