### PR TITLE
Fix: Remnant Astral 2: Makes the scene reference lowercase

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3711,7 +3711,7 @@ mission "Remnant: Expanded Horizons Astral 2"
 					goto astraldone
 				`	"Would you mind if I came too?"`
 			`	"Not at all, Captain. The view should be remarkable, and so long as we stay inside the shields, the radiation will not pose a problem." You quickly don your spacesuit and join Dawn outside on the hull. As promised, the view is indeed magnificent. Dawn signs occasionally, pointing out various features, and you appreciate that out here, sound would just be incongruous with the natural splendor.`
-			scene "scene/Sagittarius A"
+			scene "scene/sagittarius a"
 			label astraldone
 			`	After what feels like hours, the equipment notifies you that it has finished taking its readings, and Dawn packs up the data in carefully shielded data crystals. Everything is ready to return to <destination>.`
 	on complete


### PR DESCRIPTION
**Bugfix:** This PR addresses issue reported by oo13 on Discord

## Fix Details
Fixed the discrepancy that the mission reference for the scene was uppercase, whereas the image name is lowercase.

"scene/Sagittarius A" -> "scene/sagittarius a"

Thanks to oo13 on Discord for spotting this!

## Testing Done
Asked oo13 if they can test this PR.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using the current continuous, and will not occur when using this branch's build.
GitHub is currently being problematic about letting me upload a pilot file, so here's a link to discord where I have uploaded a pilot file: https://discord.com/channels/251118043411775489/536900466655887360/784768232796061756