### PR TITLE
Fix: An unparked, unarmed ship with <=20 cargo space reduces the fleet's piracy threat

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1011,7 +1011,7 @@ pair<double, double> PlayerInfo::RaidFleetFactors() const
 		if(ship->IsParked() || ship->IsDestroyed())
 			continue;
 		
-		attraction += .4 * sqrt(ship->Attributes().Get("cargo space")) - 1.8;
+		attraction += max(0., .4 * sqrt(ship->Attributes().Get("cargo space")) - 1.8);
 		for(const Hardpoint &hardpoint : ship->Weapons())
 			if(hardpoint.GetOutfit())
 			{


### PR DESCRIPTION
**Bugfix:** This is a fix for #5536 .

## Fix Details
I simply wrapped the individual ship cargo factor formula in a `max(0., ...)` to raise negative cargo factors up to zero.

## Testing Done
I parked and unparked a variety of ships with a variety of cargo sizes to ensure that the cargo factor changes were as expected.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 02987b57d6cd414b4da40905bf50dde671f24ad2, and will not occur when using this branch's build.
[Test Test.txt](https://github.com/endless-sky/endless-sky/files/5654389/Test.Test.txt)