### PR TITLE
Use separate color for disabled ships in Player Info Panel

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -559,6 +559,7 @@ void PlayerInfoPanel::DrawFleet(const Rectangle &bounds)
 	Color bright = *GameData::Colors().Get("bright");
 	Color elsewhere = *GameData::Colors().Get("dim");
 	Color dead(.4f, 0.f, 0.f, 0.f);
+	Color disabled(.5f, .3f, .1f, 0.f);
 	
 	// Table attributes.
 	Table table;
@@ -600,9 +601,10 @@ void PlayerInfoPanel::DrawFleet(const Rectangle &bounds)
 		const Ship &ship = **sit;
 		bool isElsewhere = (ship.GetSystem() != player.GetSystem());
 		isElsewhere |= (ship.CanBeCarried() && player.GetPlanet());
-		bool isDead = ship.IsDestroyed() || ship.IsDisabled();
+		bool isDead = ship.IsDestroyed();
+		bool isDisabled = ship.IsDisabled();
 		bool isHovered = (index == hoverIndex);
-		table.SetColor(isDead ? dead : isElsewhere ? elsewhere : isHovered ? bright : dim);
+		table.SetColor(isDead ? dead : isDisabled ? disabled : isElsewhere ? elsewhere : isHovered ? bright : dim);
 		
 		// Store this row's position, to handle hovering.
 		zones.emplace_back(table.GetCenterPoint(), table.GetRowSize(), index);


### PR DESCRIPTION
## Feature Details
Currently, any ships that are disabled or destroyed will show up as red on the Player Info Panel list. This is good for providing immediate feedback that something happened to your fleet. However, this does not communicate if it's a problem that can be fixed (a disabled ship to be repaired), or something you can't do anything about (a destroyed ship) just by looking at colors.

This PR makes it easier to tell at a glance how much trouble you're in after a fight, by making disabled ships appear as an orange color instead of red.

## UI Screenshots
![image](https://user-images.githubusercontent.com/4471575/101652532-f97d8d80-3a03-11eb-9f26-26d8748e8cdc.png)

## Testing Done
Brought ships in various fleets to disabled, then destroyed states, to make sure they were properly updating when that state changes. Color will update from orange to red as soon as a ship's hull reaches 0.

## Performance Impact
N/A
