### PR TITLE
Added pluralizations for 5 ships

### DIFF
--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -174,6 +174,7 @@ ship "Flea"
 
 
 ship "Geocoris"
+	plural "Geocorises"
 	sprite "ship/hai geocoris"
 	thumbnail "thumbnail/hai geocoris"
 	attributes

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -252,6 +252,7 @@ ship "Auxiliary"
 	description " The Auxiliary was built with modularity in mind, allowing the ship to be fitted for more cargo or bunk space depending on the mission. This modularity makes the ship rather expensive to build, however, and therefore a rare sight to see."
 
 ship "Auxiliary" "Auxiliary (Cargo)"
+	plural "Auxiliaries"
 	sprite "ship/auxiliaryc"
 	thumbnail "thumbnail/auxiliaryc"
 	add attributes
@@ -269,6 +270,7 @@ ship "Auxiliary" "Auxiliary (Cargo)"
 	fighter 0 83
 
 ship "Auxiliary" "Auxiliary (Transport)"
+	plural "Auxiliaries"
 	sprite "ship/auxiliaryt"
 	thumbnail "thumbnail/auxiliaryt"
 	add attributes

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -727,6 +727,7 @@ person "Local God"
 		"never disabled"
 
 ship "Ursa Polaris"
+	plural "Ursa Polaris"
 	sprite "ship/localworldship"
 	attributes
 		category "Heavy Warship"

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -495,6 +495,7 @@ ship "Heron"
 
 
 ship "Ibis"
+	plural "Ibises"
 	sprite "ship/ibis"
 	thumbnail "thumbnail/ibis"
 	attributes


### PR DESCRIPTION
This PR adds pluralizations for Ibises, Geocorsises, the cargo and bunk Navy Auxiliaries, and Ursa Polaris. The back three are not surfaced in the shipyard, but Marauder Furies are not either, so they were made plural for consistency.