### PR TITLE
Finisher Pod damage dropoff modifiers

### DIFF
--- a/data/coalition/coalition weapons.txt
+++ b/data/coalition/coalition weapons.txt
@@ -111,6 +111,8 @@ outfit "Finisher Pod"
 		"homing" 2
 		"radar tracking" .8
 		"missile strength" 50
+		"damage dropoff" 1 1
+		"dropoff modifier" 0.85
 		"submunition" "Active Finisher" 1
 	description `Finisher Torpedoes are one of the Heliarchs' most dreaded weapons. In fact, in one way or another most of their other weapons merely exist to hold a ship in place for long enough for a barrage of Finishers to destroy it.`
 
@@ -130,6 +132,8 @@ outfit "Active Finisher"
 		"radar tracking" .8
 		"optical tracking" .5
 		"missile strength" 50
+		"damage dropoff" 4000
+		"dropoff modifier" 1.3
 		"shield damage" 1500
 		"hull damage" 1900
 		"hit force" 750

--- a/data/coalition/coalition weapons.txt
+++ b/data/coalition/coalition weapons.txt
@@ -111,8 +111,8 @@ outfit "Finisher Pod"
 		"homing" 2
 		"radar tracking" .8
 		"missile strength" 50
-		"damage dropoff" 1 1
-		"dropoff modifier" 0.85
+		"shield damage" -225
+		"hull damage" -285
 		"submunition" "Active Finisher" 1
 	description `Finisher Torpedoes are one of the Heliarchs' most dreaded weapons. In fact, in one way or another most of their other weapons merely exist to hold a ship in place for long enough for a barrage of Finishers to destroy it.`
 


### PR DESCRIPTION
Having a submunition called "Active Finisher", which spawns with a rather flashy show of effects after the initial projectile dies off and is faster and lasts longer than said first projectile, it seemed appropriate to me that Finishers make use of the damage dropoff mechanic to have that transition in the state of the Finisher be a bit more meaningful.

I'm not yet much familiar with the way damage dropoff works so may have messed up, but the intended changes was for the first projectile to deal 85% of the total damage, having that modifier from the moment it spawns; once that projectile dies out and the Active Finisher submunition is spawned damage is reverted back to normal, and nearing the end of the weapon's range the damage gains an increasing boost up to 130% damage at the end of the range.

Regarding the value of `4000` used for the Active Finisher dropoff, in asking in the Discord about the range at which the transition from Finisher to Active Finisher happens, Amazinite and Vitalchip said the range would be at ~500 (Amazinite provided a java program to calculate the actual range and then provided this result `Actual range: 497.967653814602`), so something I'm unsure of: would the value of `4000` start counting only after the Active Finisher submunition spawns, or would it start counting from the moment the weapon is fired, thus including the ~500 range where the weapon is still the initial Finisher projectile?