### PR TITLE
Allow ionization to affect disabled ships

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1904,7 +1904,6 @@ void Ship::DoGeneration()
 		
 		double coolingEfficiency = CoolingEfficiency();
 		energy += attributes.Get("energy generation") - attributes.Get("energy consumption");
-		energy -= ionization;
 		fuel += attributes.Get("fuel generation");
 		heat += attributes.Get("heat generation");
 		heat -= coolingEfficiency * attributes.Get("cooling");
@@ -1938,7 +1937,7 @@ void Ship::DoGeneration()
 	
 	// Don't allow any levels to drop below zero.
 	fuel = max(0., fuel);
-	energy = max(0., energy);
+	energy = max(0., energy - ionization);
 	heat = max(0., heat);
 }
 


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue I spotted while working on #4520.

## Fix Details
Ships which are disabled are currently unaffected by ion damage. This PR changes that so that no matter the state of a ship, ion damage affects it.

The issue was that ionization was subtracted from energy just after the energy was increased according to energy generation, but this code was not reached if the ship was disabled. Moved where ionization is subtracted from energy outside of the chunk of code that didn't run if the ship was disabled.

## Testing Done
Attacked a disabled ship with and without this change using a weapon with ion damage while using a tac scanner to check energy levels. Without this change the ship's energy levels don't drop while disabled. With this change they do drop.

## Save File
N/A