### PR TITLE
Allow min and max zoom levels to be defined in interfaces.txt

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -240,6 +240,7 @@ contributed to Endless Sky:
   tboby
   tehhowch
   temtemy
+  thebigh2014
   TheMarksman-ES
   thenerdfreak
   TheUnfetteredOne

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -894,6 +894,12 @@ interface "map buttons" bottom right
 
 
 
+interface "map"
+	value "max zoom" 2
+	value "min zoom" -2
+
+
+
 interface "info panel"
 	sprite "ui/info panel"
 		center 0 -5

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -205,9 +205,10 @@ void MapPanel::DrawButtons(const string &condition)
 	// Draw the buttons to switch to other map modes.
 	Information info;
 	info.SetCondition(condition);
-	if(player.MapZoom() == 2)
+	const Interface *mapInterface = GameData::Interfaces().Get("map");
+	if(player.MapZoom() == static_cast<int>(mapInterface->GetValue("max zoom")))
 		info.SetCondition("max zoom");
-	if(player.MapZoom() == -2)
+	if(player.MapZoom() == static_cast<int>(mapInterface->GetValue("min zoom")))
 		info.SetCondition("min zoom");
 	const Interface *interface = GameData::Interfaces().Get("map buttons");
 	interface->Draw(info, this);
@@ -340,6 +341,7 @@ bool MapPanel::AllowFastForward() const
 
 bool MapPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
+	const Interface *mapInterface = GameData::Interfaces().Get("map");
 	if(command.Has(Command::MAP) || key == 'd' || key == SDLK_ESCAPE
 			|| (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI))))
 		GetUI()->Pop(this);
@@ -370,9 +372,9 @@ bool MapPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool
 		return true;
 	}
 	else if(key == '+' || key == '=')
-		player.SetMapZoom(min(2, player.MapZoom() + 1));
+		player.SetMapZoom(min(static_cast<int>(mapInterface->GetValue("max zoom")), player.MapZoom() + 1));
 	else if(key == '-')
-		player.SetMapZoom(max(-2, player.MapZoom() - 1));
+		player.SetMapZoom(max(static_cast<int>(mapInterface->GetValue("min zoom")), player.MapZoom() - 1));
 	else
 		return false;
 	

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -206,9 +206,9 @@ void MapPanel::DrawButtons(const string &condition)
 	Information info;
 	info.SetCondition(condition);
 	const Interface *mapInterface = GameData::Interfaces().Get("map");
-	if(player.MapZoom() == static_cast<int>(mapInterface->GetValue("max zoom")))
+	if(player.MapZoom() >= static_cast<int>(mapInterface->GetValue("max zoom")))
 		info.SetCondition("max zoom");
-	if(player.MapZoom() == static_cast<int>(mapInterface->GetValue("min zoom")))
+	if(player.MapZoom() <= static_cast<int>(mapInterface->GetValue("min zoom")))
 		info.SetCondition("min zoom");
 	const Interface *interface = GameData::Interfaces().Get("map buttons");
 	interface->Draw(info, this);
@@ -453,10 +453,11 @@ bool MapPanel::Scroll(double dx, double dy)
 	// The mouse should be pointing to the same map position before and after zooming.
 	Point mouse = UI::GetMouse();
 	Point anchor = mouse / Zoom() - center;
+	const Interface *mapInterface = GameData::Interfaces().Get("map");
 	if(dy > 0.)
-		player.SetMapZoom(min(2, player.MapZoom() + 1));
+		player.SetMapZoom(min(static_cast<int>(mapInterface->GetValue("max zoom")), player.MapZoom() + 1));
 	else if(dy < 0.)
-		player.SetMapZoom(max(-2, player.MapZoom() - 1));
+		player.SetMapZoom(max(static_cast<int>(mapInterface->GetValue("min zoom")), player.MapZoom() - 1));
 	
 	// Now, Zoom() has changed (unless at one of the limits). But, we still want
 	// anchor to be the same, so:


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #5554

## Feature Details
The default behaviour for the map zoom levels is to use hard coded minimum and maximum values. This feature adds a new interface for the **map** in `data/interfaces.txt` along with the necessary changes in `source/MapPanel.cpp` to utilize the values in `data/interfaces.txt`.  The current default min and max values are maintained for now.

## UI Screenshots
Zoom +4
![Zoom+4](https://user-images.githubusercontent.com/8633708/102667283-3d7c3b00-4146-11eb-9006-a26cce628f27.png)

Zoom +3
![Zoom+3](https://user-images.githubusercontent.com/8633708/102667289-410fc200-4146-11eb-8505-1debf476f90b.jpg)

Zoom -3
![Zoom-3](https://user-images.githubusercontent.com/8633708/102667293-41a85880-4146-11eb-9939-2b8c28079e2c.jpg)

Zoom -4
![Zoom-4](https://user-images.githubusercontent.com/8633708/102667292-41a85880-4146-11eb-94f3-1c691892814c.jpg)

## Usage Examples
`data/interfaces.txt`:
```
interface "map"
	value "max zoom" 4
	value "min zoom" -4
```

## Testing Done
- Changed values in `data/interfaces.txt` and used **+** and **-** buttons to zoom in/out.
- Scrolled map to ensure scrolling uses values.
- Zoom levels outside the currently defined levels will be maintained when loading player, and the **+** or **-** buttons will have the correct state.

## Performance Impact
N/A

## Miscellaneous
Added my Github name to the credits file.