### PR TITLE
Fix: Improved reverse thruster behavior for landing

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1765,12 +1765,6 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition, const
 	
 	bool shouldReverse = false;
 	dp = targetPosition - StoppingPoint(ship, targetVelocity, shouldReverse);
-	if(shouldReverse && dp.Length() < radius)
-	{
-		// We can directly use the reverse thrusters to stop at the target.
-		command |= Command::BACK;
-		return false;
-	}
 
 	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .8);
 	if(!isClose || !isFacing)
@@ -1778,7 +1772,10 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition, const
 	if(isFacing)
 		command |= Command::FORWARD;
 	else if(shouldReverse)
+	{
+		command.SetTurn(TurnToward(ship, velocity));
 		command |= Command::BACK;
+	}
 	
 	return false;
 }

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1766,7 +1766,7 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition, const
 	bool shouldReverse = false;
 	dp = targetPosition - StoppingPoint(ship, targetVelocity, shouldReverse);
 
-	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .8);
+	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .95);
 	if(!isClose || !isFacing)
 		command.SetTurn(TurnToward(ship, dp));
 	if(isFacing)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1767,7 +1767,7 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition, const
 	dp = targetPosition - StoppingPoint(ship, targetVelocity, shouldReverse);
 
 	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .95);
-	if(!isClose || !isFacing)
+	if(!isClose || (!isFacing && !shouldReverse))
 		command.SetTurn(TurnToward(ship, dp));
 	if(isFacing)
 		command |= Command::FORWARD;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5520.

## Fix Details
Thanks to the work of Vitalchip, whose work I'm uploading at this PR at their request. For the original issue:

> What seems to be happening is that on a normal approach the ship reaches the calculated stopping point, cuts thrust and passes the point. This makes the ship turn to face the point and then it decelerates using main engines. When there are reverse thrusters they fire, and instead of smoothly passing the stopping point it gets recalculated due to a decrease in velocity, putting it out in front again. The ship moves forward again to intercept and depending on the magnitude of the reverse thrust they may or may not fire again. This behaviour can also happen right before landing causing the ship to 'slide' sideways under reverse thrust, because its (say) pointing left to intercept the stopping point but firing reverse thrusters will cause it to slow but move right.

For the fix:

> Reverse landings can be improved a bit with a quick code change but they're still slower than a regular landing under most circumstances as the only way I've been able to keep the landing reliable is where forward and reverse thrusters alternate. Anything else I tried just ended up off target at the end and 'circling the drain' to land.

And the final implementation:

> This is the change I made, it just points the ship at its own velocity when reversing, countering drift and stopping the turn around.

## Testing Done
Attempted landing on various objects (planets, wormholes, disabled ships) with the patch, with ships that had a variety of reverse thrusters (Penguin, Arfecta, Emerald Sword), and noticed much smoother landing sequences. For a large ship like the Emerald Sword, it may exhibit a "ratcheting" behavior if coming at the target from an angle, but is still faster than the old behavior. Also appropriately works if the ship has weak reverse thrusters, as it will prioritize the quicker turning and forward thrust.

## Performance Impact
No significant change in CPU utilization when attempting to travel with 500 Penguins through a wormhole.