### PR TITLE
fix(type): branch -> branches in Xcode project validation

### DIFF
--- a/.github/workflows/xcode_check.yml
+++ b/.github/workflows/xcode_check.yml
@@ -2,7 +2,7 @@ name: Validate XCode Project
 
 on:
   push:
-    branch:
+    branches:
       - master
       - v[0-9]+.[0-9]+.[0-9]+
     paths:


### PR DESCRIPTION
**Bugfix:** This PR addresses typo in workflow definition `xcode_check.yml`  I noticed it while working in my fork of **master**.

## Fix Details
Corrected keyword `branch` -> `branches`

## Testing Done
Updated my fork of **master** and the check is no longer run on pushes to branches not defined (my `feature/*` and `bug/*` branches).

## Save File
N/A