### PR TITLE
Create a gravitational weapon tag that causes hit force to ignore mass

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3011,8 +3011,17 @@ void Ship::TakeHazardDamage(vector<Visual> &visuals, const Hazard *hazard, doubl
 
 // Apply a force to this ship, accelerating it. This might be from a weapon
 // impact, or from firing a weapon, for example.
-void Ship::ApplyForce(const Point &force)
+void Ship::ApplyForce(const Point &force, bool gravitational)
 {
+	if(gravitational)
+	{
+		// Treat all ships as if they have a mass of 400. This prevents
+		// gravitational hit force values from needing to be extremely
+		// small in order to have a reasonable effect.
+		acceleration += force / 400.;
+		return;
+	}
+	
 	double currentMass = Mass();
 	if(!currentMass)
 		return;
@@ -3682,7 +3691,7 @@ int Ship::TakeDamage(const Weapon &weapon, double damageScaling, double distance
 		Point d = position - damagePosition;
 		double distance = d.Length();
 		if(distance)
-			ApplyForce((hitForce / distance) * d);
+			ApplyForce((hitForce / distance) * d, weapon.IsGravitational());
 	}
 	
 	// Recalculate the disabled ship check.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -325,7 +325,7 @@ public:
 	void TakeHazardDamage(std::vector<Visual> &visuals, const Hazard *hazard, double strength);
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.
-	void ApplyForce(const Point &force);
+	void ApplyForce(const Point &force, bool gravitational = false);
 	
 	// Check if this ship has bays to carry other ships.
 	bool HasBays() const;

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -48,6 +48,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			isDamageScaled = false;
 		else if(key == "parallel")
 			isParallel = true;
+		else if(key == "gravitational")
+			isGravitational = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -104,6 +104,9 @@ public:
 	// Blast radius weapons will scale damage and hit force based on distance,
 	// unless the "no damage scaling" keyphrase is used in the weapon definition.
 	bool IsDamageScaled() const;
+	// Gravitational weapons deal the same amount of hit force to a ship regardless
+	// of its mass.
+	bool IsGravitational() const;
 	
 	// These values include all submunitions:
 	double ShieldDamage() const;
@@ -163,6 +166,7 @@ private:
 	bool isSafe = false;
 	bool isPhasing = false;
 	bool isDamageScaled = true;
+	bool isGravitational = false;
 	// Guns and missiles are by default aimed a converged point at the
 	// maximum weapons range in front of the ship. When either the installed
 	// weapon or the gun-port (or both) have the isParallel attribute set
@@ -276,6 +280,7 @@ inline double Weapon::HitForce() const { return TotalDamage(HIT_FORCE); }
 inline bool Weapon::IsSafe() const { return isSafe; }
 inline bool Weapon::IsPhasing() const { return isPhasing; }
 inline bool Weapon::IsDamageScaled() const { return isDamageScaled; }
+inline bool Weapon::IsGravitational() const { return isGravitational; }
 
 inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); }
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }


### PR DESCRIPTION
**Feature:** This PR implements the feature request discussed as a way to improve system hazards (#4931).

## Feature Details
Adds a new weapon tag `"gravitational"` that causes the hit force of a weapon to not be affected by the mass of the impacted ship. Uses a fixed scaling of 400 mass as to prevent hit force values from needing to be tiny. That is to say that with the `"gravitational"` tag, all ships will be impacted by hit force as if they have a mass of 400.

## UI Screenshots
N/A

## Usage Examples
All ships hit by this weapon or hazard will be impacted by this hit force of -15 in the same way regardless of mass.
```
[outfit | hazard] <name>
	...
	weapon
		...
		"gravitational"
		"hit force" -15
		...
```

## Testing Done
Gave the gravity system hazard from #5560 the "gravitational" tag and entered Sag A* with multiple ships across a wide range of masses. All ships fall toward the center at (roughly) the same rate (with any different in acceleration being caused by the damage dropoff modifier), whereas without this tag lighter ships get pulled toward the center quicker.

## Performance Impact
N/A
