### PR TITLE
Allow weapons to deal shield/hull damage as a percentage of a ship's total shields/hull

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3642,6 +3642,11 @@ int Ship::TakeDamage(const Weapon &weapon, double damageScaling, double distance
 	
 	double shieldDamage = weapon.ShieldDamage() * damageScaling / (1. + attributes.Get("shield protection"));
 	double hullDamage = weapon.HullDamage() * damageScaling / (1. + attributes.Get("hull protection"));
+	if(weapon.IsPercentScaled())
+	{
+		shieldDamage = shieldDamage / 100. * attributes.Get("shields");
+		hullDamage = hullDamage / 100. * attributes.Get("hull");
+	}
 	double hitForce = weapon.HitForce() * damageScaling / (1. + attributes.Get("force protection"));
 	double fuelDamage = weapon.FuelDamage() * damageScaling / (1. + attributes.Get("fuel protection"));
 	double heatDamage = weapon.HeatDamage() * damageScaling / (1. + attributes.Get("heat protection"));

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -46,6 +46,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			isPhasing = true;
 		else if(key == "no damage scaling")
 			isDamageScaled = false;
+		else if(key == "percent scaling")
+			isPercentScaled = true;
 		else if(key == "parallel")
 			isParallel = true;
 		else if(child.Size() < 2)

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -104,6 +104,9 @@ public:
 	// Blast radius weapons will scale damage and hit force based on distance,
 	// unless the "no damage scaling" keyphrase is used in the weapon definition.
 	bool IsDamageScaled() const;
+	// A percent scaled weapon deals shield and hull damage as a percentage of the
+	// ship's total shields and hull.
+	bool IsPercentScaled() const;
 	
 	// These values include all submunitions:
 	double ShieldDamage() const;
@@ -163,6 +166,7 @@ private:
 	bool isSafe = false;
 	bool isPhasing = false;
 	bool isDamageScaled = true;
+	bool isPercentScaled = false;
 	// Guns and missiles are by default aimed a converged point at the
 	// maximum weapons range in front of the ship. When either the installed
 	// weapon or the gun-port (or both) have the isParallel attribute set
@@ -276,6 +280,7 @@ inline double Weapon::HitForce() const { return TotalDamage(HIT_FORCE); }
 inline bool Weapon::IsSafe() const { return isSafe; }
 inline bool Weapon::IsPhasing() const { return isPhasing; }
 inline bool Weapon::IsDamageScaled() const { return isDamageScaled; }
+inline bool Weapon::IsPercentScaled() const { return isPercentScaled; }
 
 inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); }
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }


### PR DESCRIPTION
**Feature:** This PR implements the feature request discussed as a way to improve system hazards (#4931).

## Feature Details
Adds a new weapon tag `"percent scaling"` that causes shield and hull damage to be scaled to deal a percentage of a ship's total shield and hull. A shield damage value of 1 while the percent scaling tag is present will deal damage equal to 1% of a ship's shields upon impact.

## UI Screenshots
N/A

## Usage Examples
All ships hit by this weapon or hazard will die in about 16 seconds (assuming continuous fire, as `100 / (.1 * 60) = 16.7 seconds`) regardless of how much hull they have.
```
[outfit | hazard] <name>
	...
	weapon
		...
		"percent scaling"
		"hull damage" 0.1
		"piercing" 1
		...
```
## Testing Done
Gave `"percent scaling"` to the deadly gravity hazard from #5560, as well as a piercing of 1, a hull damage of 0.1, and a period of 1. Tested on multiple ships, all which which died in roughly 16 seconds regardless of how much hull they had.

## Performance Impact
N/A
