### PR TITLE
Create "relative" damage types that deal damage as a percentage of a target's stats

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -105,7 +105,7 @@ tip "    engine capacity:"
 	`How many tons of engines this ship can hold. (To install an engine, you must also have enough total outfit space available.)`
 
 tip "energy protection:"
-	`Protection against weapons taht deal energy damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in energy damage, while a total value of 11 only results in a 10 percent reduction.`
+	`Protection against weapons that deal energy damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in energy damage, while a total value of 11 only results in a 10 percent reduction.`
 
 tip "fighter bays:"
 	`The number of ships from the "Fighter" category that this ship can carry.`

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -104,6 +104,9 @@ tip "engine capacity needed:"
 tip "    engine capacity:"
 	`How many tons of engines this ship can hold. (To install an engine, you must also have enough total outfit space available.)`
 
+tip "energy protection:"
+	`Protection against weapons taht deal energy damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in energy damage, while a total value of 11 only results in a 10 percent reduction.`
+
 tip "fighter bays:"
 	`The number of ships from the "Fighter" category that this ship can carry.`
 
@@ -482,6 +485,9 @@ tip "fuel damage / second:"
 tip "heat damage / second:"
 	`When hitting a target this weapon increases the target's heat by this amount per second, or half this amount if the target's shields are up.`
 
+tip "energy damage / second:"
+	`When hitting a target this weapon reduces the target's energy by this amount per second, or half this amount if the target's shields are up.`
+
 tip "ion damage / second:"
 	`Reduces the target's energy. Ionization slowly wears off over time.`
 
@@ -490,6 +496,21 @@ tip "slowing damage / second:"
 
 tip "disruption damage / second:"
 	`Disrupts the target's shields, allowing weapon damage to "leak through" to the hull even if shields are up. Shield disruption wears off over time.`
+
+tip "% shield damage / second:"
+	`Relative shield damage, converted to damage per second to allow easy comparisons between different weapons.`
+
+tip "% hull damage / second:"
+	`Relative hull damage, converted to damage per second to allow easy comparisons between different weapons.`
+
+tip "% fuel damage / second:"
+	`The amount of fuel lost as a percentage of a target's total fuel per second when hit by this weapon. If its shields are up, the loss will be cut in half.`
+
+tip "% heat damage / second:"
+	`When hitting a target this weapon increases the target's heat as a percentage of its maximum heat capacity by this amount per second, or half this amount if the target's shields are up.`
+
+tip "% energy damage / second:"
+	`When hitting a target this weapon reduces the target's energy as a percentage of its energy capacity by this amount per second, or half this amount if the target's shields are up.`
 
 tip "firing energy / second:"
 	`Energy consumed by this weapon per second when firing.`
@@ -539,6 +560,9 @@ tip "fuel damage / shot:"
 tip "heat damage / shot:"
 	`Each shot increases the target ship's heat by this amount, or half this amount if its shields are up.`
 
+tip "energy damage / shot:"
+	`Each shot reduces the target ship's energy by this amount, or half this amount if its shields are up.`
+
 tip "ion damage / shot:"
 	`Each shot increases the target's ionization by this amount. Ionization reduces the target's energy and slowly wears off over time.`
 
@@ -547,6 +571,21 @@ tip "slowing damage / shot:"
 
 tip "disruption damage / shot:"
 	`Disrupts the target's shields, allowing weapon damage to "leak through" to the hull even if shields are up. Shield disruption wears off over time.`
+
+tip "% shield damage / shot:"
+	`Each shot fired by this weapon does this amount of shield damage as a percentage of the target ship's total shields.`
+
+tip "% hull damage / shot:"
+	`Each shot fired by this weapon does this amount of hull damage as a percentage of the target ship's total hull.`
+
+tip "% fuel damage / shot:"
+	`The amount of fuel lost by the target per shot as a percentage of the ship's total fuel when hit by this weapon. If its shields are up, the loss will be cut in half.`
+
+tip "% heat damage / shot:"
+	`Each shot increases the target ship's heat as a percentage of the ship's maximum heat capacity by this amount, or half this amount if its shields are up.`
+
+tip "% energy damage / shot:"
+	`Each shot reduces the target ship's energy as a percentage of the ship's energy capacity by this amount, or half this amount if its shields are up.`
 
 tip "firing energy / shot:"
 	`Each shot requires this much energy. A weapon will not fire if the ship's batteries do not have at least this amount of energy stored.`

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -103,6 +103,7 @@ namespace {
 		{"threshold percentage", 3},
 		
 		{"disruption protection", 4},
+		{"energy protection", 4},
 		{"force protection", 4},
 		{"fuel protection", 4},
 		{"heat protection", 4},
@@ -298,17 +299,23 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	attributeValues.emplace_back(Format::Number(outfit.Range()));
 	attributesHeight += 20;
 	
-	static const vector<string> VALUE_NAMES = {
-		"shield damage",
-		"hull damage",
-		"fuel damage",
-		"heat damage",
-		"ion damage",
-		"slowing damage",
-		"disruption damage",
-		"firing energy",
-		"firing heat",
-		"firing fuel"
+	static const vector<pair<string, string>> VALUE_NAMES = {
+		{"shield damage", ""},
+		{"hull damage", ""},
+		{"fuel damage", ""},
+		{"heat damage", ""},
+		{"energy damage", ""},
+		{"ion damage", ""},
+		{"slowing damage", ""},
+		{"disruption damage", ""},
+		{"% shield damage", "%"},
+		{"% hull damage", "%"},
+		{"% fuel damage", "%"},
+		{"% heat damage", "%"},
+		{"% energy damage", "%"},
+		{"firing energy", ""},
+		{"firing heat", ""},
+		{"firing fuel", ""}
 	};
 	
 	vector<double> values = {
@@ -316,9 +323,15 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		outfit.HullDamage(),
 		outfit.FuelDamage(),
 		outfit.HeatDamage(),
+		outfit.EnergyDamage(),
 		outfit.IonDamage() * 100.,
 		outfit.SlowingDamage() * 100.,
 		outfit.DisruptionDamage() * 100.,
+		outfit.RelativeShieldDamage() * 100.,
+		outfit.RelativeHullDamage() * 100.,
+		outfit.RelativeFuelDamage() * 100.,
+		outfit.RelativeHeatDamage() * 100.,
+		outfit.RelativeEnergyDamage() * 100.,
 		outfit.FiringEnergy(),
 		outfit.FiringHeat(),
 		outfit.FiringFuel()
@@ -332,8 +345,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		for(unsigned i = 0; i < values.size(); ++i)
 			if(values[i])
 			{
-				attributeLabels.emplace_back(VALUE_NAMES[i] + PER_SECOND);
-				attributeValues.emplace_back(Format::Number(60. * values[i] / reload));
+				attributeLabels.emplace_back(VALUE_NAMES[i].first + PER_SECOND);
+				attributeValues.emplace_back(Format::Number(60. * values[i] / reload) + VALUE_NAMES[i].second);
 				attributesHeight += 20;
 			}
 	}
@@ -403,8 +416,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		for(unsigned i = 0; i < VALUE_NAMES.size(); ++i)
 			if(values[i])
 			{
-				attributeLabels.emplace_back(VALUE_NAMES[i] + PER_SHOT);
-				attributeValues.emplace_back(Format::Number(values[i]));
+				attributeLabels.emplace_back(VALUE_NAMES[i].first + PER_SHOT);
+				attributeValues.emplace_back(Format::Number(values[i]) + VALUE_NAMES[i].second);
 				attributesHeight += 20;
 			}
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3649,14 +3649,20 @@ int Ship::TakeDamage(const Weapon &weapon, double damageScaling, double distance
 	if(weapon.HasDamageDropoff())
 		damageScaling *= weapon.DamageDropoff(distanceTraveled);
 	
-	double shieldDamage = weapon.ShieldDamage() * damageScaling / (1. + attributes.Get("shield protection"));
-	double hullDamage = weapon.HullDamage() * damageScaling / (1. + attributes.Get("hull protection"));
-	double hitForce = weapon.HitForce() * damageScaling / (1. + attributes.Get("force protection"));
-	double fuelDamage = weapon.FuelDamage() * damageScaling / (1. + attributes.Get("fuel protection"));
-	double heatDamage = weapon.HeatDamage() * damageScaling / (1. + attributes.Get("heat protection"));
+	double shieldDamage = (weapon.ShieldDamage() + weapon.RelativeShieldDamage() * attributes.Get("shields"))
+		* damageScaling / (1. + attributes.Get("shield protection"));
+	double hullDamage = (weapon.HullDamage() + weapon.RelativeHullDamage() * attributes.Get("hull"))
+		* damageScaling / (1. + attributes.Get("hull protection"));
+	double energyDamage = (weapon.EnergyDamage() + weapon.RelativeEnergyDamage() * attributes.Get("energy capacity"))
+		* damageScaling / (1. + attributes.Get("energy protection"));
+	double fuelDamage = (weapon.FuelDamage() + weapon.RelativeFuelDamage() * attributes.Get("fuel capacity"))
+		* damageScaling / (1. + attributes.Get("fuel protection"));
+	double heatDamage = (weapon.HeatDamage() + weapon.RelativeHeatDamage() * MaximumHeat())
+		* damageScaling / (1. + attributes.Get("heat protection"));
 	double ionDamage = weapon.IonDamage() * damageScaling / (1. + attributes.Get("ion protection"));
 	double disruptionDamage = weapon.DisruptionDamage() * damageScaling / (1. + attributes.Get("disruption protection"));
 	double slowingDamage = weapon.SlowingDamage() * damageScaling / (1. + attributes.Get("slowing protection"));
+	double hitForce = weapon.HitForce() * damageScaling / (1. + attributes.Get("force protection"));
 	bool wasDisabled = IsDisabled();
 	bool wasDestroyed = IsDestroyed();
 	
@@ -3678,8 +3684,9 @@ int Ship::TakeDamage(const Weapon &weapon, double damageScaling, double distance
 	// For the following damage types, the total effect depends on how much is
 	// "leaking" through the shields.
 	double leakage = (1. - .5 * shieldFraction);
-	// Code in Ship::Move() will handle making sure the fuel amount stays in the
-	// allowable range.
+	// Code in Ship::Move() will handle making sure the fuel and energy amounts
+	// stays in the allowable ranges.
+	energy -= energyDamage * leakage;
 	fuel -= fuelDamage * leakage;
 	heat += heatDamage * leakage;
 	ionization += ionDamage * leakage;

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -166,12 +166,24 @@ void Weapon::LoadWeapon(const DataNode &node)
 				damage[FUEL_DAMAGE] = value;
 			else if(key == "heat damage")
 				damage[HEAT_DAMAGE] = value;
+			else if(key == "energy damage")
+				damage[ENERGY_DAMAGE] = value;
 			else if(key == "ion damage")
 				damage[ION_DAMAGE] = value;
 			else if(key == "disruption damage")
 				damage[DISRUPTION_DAMAGE] = value;
 			else if(key == "slowing damage")
 				damage[SLOWING_DAMAGE] = value;
+			else if(key == "relative shield damage")
+				damage[RELATIVE_SHIELD_DAMAGE] = value;
+			else if(key == "relative hull damage")
+				damage[RELATIVE_HULL_DAMAGE] = value;
+			else if(key == "relative fuel damage")
+				damage[RELATIVE_FUEL_DAMAGE] = value;
+			else if(key == "relative heat damage")
+				damage[RELATIVE_HEAT_DAMAGE] = value;
+			else if(key == "relative energy damage")
+				damage[RELATIVE_ENERGY_DAMAGE] = value;
 			else if(key == "hit force")
 				damage[HIT_FORCE] = value;
 			else if(key == "piercing")

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -109,13 +109,22 @@ public:
 	bool IsGravitational() const;
 	
 	// These values include all submunitions:
+	// Normal damage types:
 	double ShieldDamage() const;
 	double HullDamage() const;
 	double FuelDamage() const;
 	double HeatDamage() const;
+	double EnergyDamage() const;
+	// Status effects:
 	double IonDamage() const;
 	double DisruptionDamage() const;
 	double SlowingDamage() const;
+	// Relative damage types:
+	double RelativeShieldDamage() const;
+	double RelativeHullDamage() const;
+	double RelativeFuelDamage() const;
+	double RelativeHeatDamage() const;
+	double RelativeEnergyDamage() const;
 	// Check if this weapon does damage. If not, attacking a ship with this
 	// weapon is not a provocation (even if you push or pull it).
 	bool DoesDamage() const;
@@ -209,16 +218,26 @@ private:
 	double triggerRadius = 0.;
 	double blastRadius = 0.;
 	
-	static const int DAMAGE_TYPES = 8;
+	static const int DAMAGE_TYPES = 14;
+	// Normal damage types:
 	static const int SHIELD_DAMAGE = 0;
 	static const int HULL_DAMAGE = 1;
 	static const int FUEL_DAMAGE = 2;
 	static const int HEAT_DAMAGE = 3;
-	static const int ION_DAMAGE = 4;
-	static const int DISRUPTION_DAMAGE = 5;
-	static const int SLOWING_DAMAGE = 6;
-	static const int HIT_FORCE = 7;
-	mutable double damage[DAMAGE_TYPES] = {0., 0., 0., 0., 0., 0., 0., 0.};
+	static const int ENERGY_DAMAGE = 4;
+	// Status effects:
+	static const int ION_DAMAGE = 5;
+	static const int DISRUPTION_DAMAGE = 6;
+	static const int SLOWING_DAMAGE = 7;
+	// Relative damage types:
+	static const int RELATIVE_SHIELD_DAMAGE = 8;
+	static const int RELATIVE_HULL_DAMAGE = 9;
+	static const int RELATIVE_FUEL_DAMAGE = 10;
+	static const int RELATIVE_HEAT_DAMAGE = 11;
+	static const int RELATIVE_ENERGY_DAMAGE = 12;
+	
+	static const int HIT_FORCE = 13;
+	mutable double damage[DAMAGE_TYPES] = {};
 	
 	double piercing = 0.;
 	
@@ -286,9 +305,17 @@ inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); 
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }
 inline double Weapon::FuelDamage() const { return TotalDamage(FUEL_DAMAGE); }
 inline double Weapon::HeatDamage() const { return TotalDamage(HEAT_DAMAGE); }
+inline double Weapon::EnergyDamage() const { return TotalDamage(ENERGY_DAMAGE); }
+
 inline double Weapon::IonDamage() const { return TotalDamage(ION_DAMAGE); }
 inline double Weapon::DisruptionDamage() const { return TotalDamage(DISRUPTION_DAMAGE); }
 inline double Weapon::SlowingDamage() const { return TotalDamage(SLOWING_DAMAGE); }
+
+inline double Weapon::RelativeShieldDamage() const { return TotalDamage(RELATIVE_SHIELD_DAMAGE); }
+inline double Weapon::RelativeHullDamage() const { return TotalDamage(RELATIVE_HULL_DAMAGE); }
+inline double Weapon::RelativeFuelDamage() const { return TotalDamage(RELATIVE_FUEL_DAMAGE); }
+inline double Weapon::RelativeHeatDamage() const { return TotalDamage(RELATIVE_HEAT_DAMAGE); }
+inline double Weapon::RelativeEnergyDamage() const { return TotalDamage(RELATIVE_ENERGY_DAMAGE); }
 
 inline bool Weapon::DoesDamage() const { if(!calculatedDamage) TotalDamage(0); return doesDamage; }
 

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -219,24 +219,23 @@ private:
 	double blastRadius = 0.;
 	
 	static const int DAMAGE_TYPES = 14;
+	static const int HIT_FORCE = 0;
 	// Normal damage types:
-	static const int SHIELD_DAMAGE = 0;
-	static const int HULL_DAMAGE = 1;
-	static const int FUEL_DAMAGE = 2;
-	static const int HEAT_DAMAGE = 3;
-	static const int ENERGY_DAMAGE = 4;
+	static const int SHIELD_DAMAGE = 1;
+	static const int HULL_DAMAGE = 2;
+	static const int FUEL_DAMAGE = 3;
+	static const int HEAT_DAMAGE = 4;
+	static const int ENERGY_DAMAGE = 5;
 	// Status effects:
-	static const int ION_DAMAGE = 5;
-	static const int DISRUPTION_DAMAGE = 6;
-	static const int SLOWING_DAMAGE = 7;
+	static const int ION_DAMAGE = 6;
+	static const int DISRUPTION_DAMAGE = 7;
+	static const int SLOWING_DAMAGE = 8;
 	// Relative damage types:
-	static const int RELATIVE_SHIELD_DAMAGE = 8;
-	static const int RELATIVE_HULL_DAMAGE = 9;
-	static const int RELATIVE_FUEL_DAMAGE = 10;
-	static const int RELATIVE_HEAT_DAMAGE = 11;
-	static const int RELATIVE_ENERGY_DAMAGE = 12;
-	
-	static const int HIT_FORCE = 13;
+	static const int RELATIVE_SHIELD_DAMAGE = 9;
+	static const int RELATIVE_HULL_DAMAGE = 10;
+	static const int RELATIVE_FUEL_DAMAGE = 11;
+	static const int RELATIVE_HEAT_DAMAGE = 12;
+	static const int RELATIVE_ENERGY_DAMAGE = 13;
 	mutable double damage[DAMAGE_TYPES] = {};
 	
 	double piercing = 0.;


### PR DESCRIPTION
**Feature:** This PR takes the alternative route to #5568.

## Feature Details
This PR creates various new damage types:
* `"relative shield damage"`: Deals shield damage as a percentage of a target's maximum shield value, where 1 = 100% damage.
* `"relative hull damage"`: Deals hull damage as a percentage of a target's maximum hull value.
* `"relative fuel damage"`: Deals fuel damage as a percentage of a target's fuel capacity.
* `"relative heat damage"`: Deal heat damage as a percentage of a target's heat capcaity.
* `"energy damage"`: Deals damage that subtracts directly from a target's energy. Ionization is now the DoT (damage over time) version of this damage type.
* `"relative energy damage"`: Deals energy damage as a percentage of a target's energy capacity.

Also adds a new protection attribute, `"energy protection"`, to combat the brand new energy damage type.
Speaking of which, damage protection attributes protect against these relative damage types in the same way that they do the normal damage types.

## UI Screenshots
Here is a screenshot of the outfitter with a weapon selected that has all damage types applied, showing the new damage types next to the old one. These new damage types are displayed as `% [type] damage`, as `relative [type] damage` does not fit the UI. A number of people who wanted this mechanic were fine with this naming scheme.
![image](https://user-images.githubusercontent.com/17688683/102841149-5e58c080-43d2-11eb-9aae-9eee989123ab.png)

## Usage Examples
```html
[outfit | hazard] <name>
	...
	weapon
		...
		"energy damage" <amount#>
		"relative shield damage" <amount#>
		"relative hull damage" <amount#>
		"relative energy damage" <amount#>
		"relative fuel damage" <amount#>
		"relative heat damage" <amount#>
		...
```
While energy damage could be a new damage type for normal weapons, I suggest and expect that these relative damage types only be used on hazards, allowing for easier balancing of hazards as to affect all ships in a similar manner instead of heavily damaging smaller ships while leaving larger ships largely unharmed or only slightly harmed by the hazard.

Although there is nothing stopping you from using these on a weapon for a ship, don't expect me to merge any content using these relative damage types in that manner.

## Testing Done
Tested each of the new damage types against a Sparrow and a Raider. The Sparrow and Raider both either die, lose all their energy and fuel at the same time, or gain heat at the same rate depending on the relative damage type used. Energy damage properly subtracts from a ship's stored energy without applying a status effect.

## Performance Impact
N/A
