### PR TITLE
Check if a ship is overheated during Ship::TakeDamage

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3719,15 +3719,14 @@ int Ship::TakeDamage(const Weapon &weapon, double damageScaling, double distance
 	if(!wasDestroyed && IsDestroyed())
 		type |= ShipEvent::DESTROY;
 	
-	// Check if the ship is disabled by being overheated. Do this now so that
-	// overheated ships don't count as disabled for the purposes of missions.
-	// Do a full overheat check here in case the overheating was caused by
-	// taking damage.
+	// Inflicted heat damage may also disable a ship, but does not trigger a "DISABLE" event.
 	if(heat > MaximumHeat())
+	{
 		isOverheated = true;
+		isDisabled = true;
+	}
 	else if(heat < .9 * MaximumHeat())
 		isOverheated = false;
-	isDisabled |= isOverheated;
 	
 	return type;
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3727,7 +3727,7 @@ int Ship::TakeDamage(const Weapon &weapon, double damageScaling, double distance
 		isOverheated = true;
 	else if(heat < .9 * MaximumHeat())
 		isOverheated = false;
-	isDisabled = isOverheated || isDisabled;
+	isDisabled |= isOverheated;
 	
 	return type;
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3719,5 +3719,15 @@ int Ship::TakeDamage(const Weapon &weapon, double damageScaling, double distance
 	if(!wasDestroyed && IsDestroyed())
 		type |= ShipEvent::DESTROY;
 	
+	// Check if the ship is disabled by being overheated. Do this now so that
+	// overheated ships don't count as disabled for the purposes of missions.
+	// Do a full overheat check here in case the overheating was caused by
+	// taking damage.
+	if(heat > MaximumHeat())
+		isOverheated = true;
+	else if(heat < .9 * MaximumHeat())
+		isOverheated = false;
+	isDisabled = isOverheated || isDisabled;
+	
 	return type;
 }


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue spotted by Terin on Discord.

## Fix Details
Adds a check to see if a ship is overheated at the end of TakeDamage.

Currently in the game, the only time that a ship checks if it is overheated is after it has finished its shield and hull generation. This results in a scenario where a ship that has been overheated will do its shield and hull generation for a frame after taking damage, since TakeDamage overwrites the isDisabled bool that should stop shield and hull generation without checking to see that the ship has been overheated.

## Testing Done
Attacked a Shield Beetle with a flamethrower before and after this change. Before, causing the ship to take damage while overheated would activate its shield generation. After, the ship no longer generates its shields for a frame after taking damage, with everything else working normally. (The ship still properly becomes unoverheated, overheated ships still flash in the HUD.)

## Save File
N/A