### PR TITLE
feat: Split arrival distance into hyperdrive and jump-drive version.

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -21145,7 +21145,7 @@ system "Sagittarius A*"
 	government Uninhabited
 	habitable 10000
 	haze _menu/haze-full
-	arrival 500 jump
+	arrival 500
 	hazard "Black Hole Gravity" 1
 	hazard "Black Hole Event Horizon" 1
 	hazard "Black Hole Accretion Disk" 1

--- a/data/map.txt
+++ b/data/map.txt
@@ -21145,6 +21145,7 @@ system "Sagittarius A*"
 	government Uninhabited
 	habitable 10000
 	haze _menu/haze-full
+	arrival 500 jump
 	hazard "Black Hole Gravity" 1
 	hazard "Black Hole Event Horizon" 1
 	hazard "Black Hole Accretion Disk" 1

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1464,7 +1464,12 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 			Point target;
 			// Except when you arrive at an extra distance from the target,
 			// in that case always use the system-center as target.
-			double extraArrivalDistance = currentSystem->ExtraArrivalDistance();
+			double extraArrivalDistance = 0;
+			if(isUsingJumpDrive)
+				extraArrivalDistance = currentSystem->ExtraJumpArrivalDistance();
+			else
+				extraArrivalDistance = currentSystem->ExtraHyperArrivalDistance();
+			
 			if(extraArrivalDistance == 0)
 			{
 				if(targetPlanet)
@@ -1482,7 +1487,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 			
 			if(isUsingJumpDrive)
 			{
-				position = target + Angle::Random().Unit() * 300. * (Random::Real() + 1.);
+				position = target + Angle::Random().Unit() * (300. * (Random::Real() + 1.) + extraArrivalDistance);
 				return;
 			}
 			

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1464,11 +1464,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 			Point target;
 			// Except when you arrive at an extra distance from the target,
 			// in that case always use the system-center as target.
-			double extraArrivalDistance = 0;
-			if(isUsingJumpDrive)
-				extraArrivalDistance = currentSystem->ExtraJumpArrivalDistance();
-			else
-				extraArrivalDistance = currentSystem->ExtraHyperArrivalDistance();
+			double extraArrivalDistance = isUsingJumpDrive ? currentSystem->ExtraJumpArrivalDistance() : currentSystem->ExtraHyperArrivalDistance();
 			
 			if(extraArrivalDistance == 0)
 			{

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -319,7 +319,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			for(const DataNode &grand : child)
 			{
 				if(grand.Size() < 2)
-					child.PrintTrace("Warning: Keywords below arrival always need a value behind the keyword:");
+					grand.PrintTrace("Skipping distance specification without jump type identifier:");
 				else if(grand.Token(0) == "link")
 					extraHyperArrivalDistance = grand.Value(1);
 				else if(grand.Token(0) == "jump")

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -337,7 +337,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			// as that a hyper-jump-distance negative values would be beyond
 			// the target.
 			if(loadJumpDistance && child.Value(valueIndex) >= 0)
-				extraJumpArrivalDistance= child.Value(valueIndex);
+				extraJumpArrivalDistance = child.Value(valueIndex);
 		}
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -319,7 +319,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			{
 				loadHyperDistance = false;
 				loadJumpDistance = false;
-				for(int i = 2; i < child.Size(); i++)
+				for(int i = 2; i < child.Size(); ++i)
 				{
 					if(child.Token(i) == "link")
 						loadHyperDistance = true;

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -310,7 +310,35 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		else if(key == "object")
 			LoadObject(child, planets);
 		else if(key == "arrival")
-			extraArrivalDistance = child.Value(valueIndex);
+		{
+			bool loadHyperDistance = true;
+			bool loadJumpDistance = true;
+			// Check if we load arrival distances specifically for hyperdrives
+			// or jump drives only.
+			if(child.Size() >= 3)
+			{
+				loadHyperDistance = false;
+				loadJumpDistance = false;
+				for(int i = 2; i < child.Size(); i++)
+				{
+					if(child.Token(i) == "link")
+						loadHyperDistance = true;
+					else if(child.Token(i) == "jump")
+						loadJumpDistance = true;
+					else
+						child.PrintTrace("Warning: Unknown arrival type \"" + child.Token(i) + "\" for arrival distance:");
+				}
+			}
+			if(loadHyperDistance)
+				extraHyperArrivalDistance = child.Value(valueIndex);
+			// We only load additional jump distances if they are above 0.
+			// Jump drives use a circle around the target for targeting,
+			// so a value below 0 doesn't have a meaning in the same way
+			// as that a hyper-jump-distance negative values would be beyond
+			// the target.
+			if(loadJumpDistance && child.Value(valueIndex) >= 0)
+				extraJumpArrivalDistance= child.Value(valueIndex);
+		}
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
@@ -484,9 +512,17 @@ const set<const System *> &System::JumpNeighbors(double neighborDistance) const
 
 
 // Additional travel distance to target for ships entering through hyperspace.
-double System::ExtraArrivalDistance() const
+double System::ExtraHyperArrivalDistance() const
 {
-	return extraArrivalDistance;
+	return extraHyperArrivalDistance;
+}
+
+
+
+// Additional travel distance to target for ships entering using a jumpdrive.
+double System::ExtraJumpArrivalDistance() const
+{
+	return extraJumpArrivalDistance;
 }
 
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -331,13 +331,13 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			}
 			if(loadHyperDistance)
 				extraHyperArrivalDistance = child.Value(valueIndex);
-			// We only load additional jump distances if they are above 0.
+			// Negative jump distances work the same as positive jump
+			// distances.
 			// Jump drives use a circle around the target for targeting,
-			// so a value below 0 doesn't have a meaning in the same way
-			// as that a hyper-jump-distance negative values would be beyond
-			// the target.
-			if(loadJumpDistance && child.Value(valueIndex) >= 0)
-				extraJumpArrivalDistance = child.Value(valueIndex);
+			// so a value below 0 doesn't have the same meaning as for hyper
+			// drives where negative values would be beyond the target.
+			if(loadJumpDistance)
+				extraJumpArrivalDistance = fabs(child.Value(valueIndex));
 		}
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -311,33 +311,27 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			LoadObject(child, planets);
 		else if(key == "arrival")
 		{
-			bool loadHyperDistance = true;
-			bool loadJumpDistance = true;
-			// Check if we load arrival distances specifically for hyperdrives
-			// or jump drives only.
-			if(child.Size() >= 3)
+			if(child.Size() >= 2)
 			{
-				loadHyperDistance = false;
-				loadJumpDistance = false;
-				for(int i = 2; i < child.Size(); ++i)
-				{
-					if(child.Token(i) == "link")
-						loadHyperDistance = true;
-					else if(child.Token(i) == "jump")
-						loadJumpDistance = true;
-					else
-						child.PrintTrace("Warning: Unknown arrival type \"" + child.Token(i) + "\" for arrival distance:");
-				}
+				extraHyperArrivalDistance = child.Value(1);
+				extraJumpArrivalDistance = fabs(child.Value(1));
 			}
-			if(loadHyperDistance)
-				extraHyperArrivalDistance = child.Value(valueIndex);
-			// Negative jump distances work the same as positive jump
-			// distances.
-			// Jump drives use a circle around the target for targeting,
-			// so a value below 0 doesn't have the same meaning as for hyper
-			// drives where negative values would be beyond the target.
-			if(loadJumpDistance)
-				extraJumpArrivalDistance = fabs(child.Value(valueIndex));
+			for(const DataNode &grand : child)
+			{
+				if(grand.Size() < 2)
+					child.PrintTrace("Warning: Keywords below arrival always need a value behind the keyword:");
+				else if(grand.Token(0) == "link")
+					extraHyperArrivalDistance = grand.Value(1);
+				else if(grand.Token(0) == "jump")
+					// Negative jump distances work the same as positive jump
+					// distances.
+					// Jump drives use a circle around the target for targeting,
+					// so a value below 0 doesn't have the same meaning as for hyper
+					// drives where negative values would be beyond the target.
+					extraJumpArrivalDistance = fabs(grand.Value(1));
+				else
+					child.PrintTrace("Warning: Unknown keyword below arrival:");
+			}
 		}
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -318,19 +318,13 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			}
 			for(const DataNode &grand : child)
 			{
-				if(grand.Size() < 2)
-					grand.PrintTrace("Skipping distance specification without jump type identifier:");
-				else if(grand.Token(0) == "link")
+				const string &type = grand.Token(0);
+				if(type == "link" && grand.Size() >= 2)
 					extraHyperArrivalDistance = grand.Value(1);
-				else if(grand.Token(0) == "jump")
-					// Negative jump distances work the same as positive jump
-					// distances.
-					// Jump drives use a circle around the target for targeting,
-					// so a value below 0 doesn't have the same meaning as for hyper
-					// drives where negative values would be beyond the target.
+				else if(type == "jump" && grand.Size() >= 2)
 					extraJumpArrivalDistance = fabs(grand.Value(1));
 				else
-					child.PrintTrace("Warning: Unknown keyword below arrival:");
+					grand.PrintTrace("Skipping unsupported arrival distance limitation:");
 			}
 		}
 		else

--- a/source/System.h
+++ b/source/System.h
@@ -221,7 +221,6 @@ private:
 	// The amount of additional distance that ships will arrive away from the
 	// system center when entering this system through a jumpdrive jump.
 	double extraJumpArrivalDistance = 0.;
-
 	
 	// Commodity prices.
 	std::map<std::string, Price> trade;

--- a/source/System.h
+++ b/source/System.h
@@ -217,9 +217,13 @@ private:
 	
 	// The amount of additional distance that ships will arrive away from the
 	// system center when entering this system through a hyperspace link.
+	// Negative values are allowed, causing ships to jump beyond their target.
 	double extraHyperArrivalDistance = 0.;
 	// The amount of additional distance that ships will arrive away from the
 	// system center when entering this system through a jumpdrive jump.
+	// Jump drives use a circle around the target for targeting, so a value below
+	// 0 doesn't have the same meaning as for hyperdrives. Negative values will
+	// be interpreted as positive values.
 	double extraJumpArrivalDistance = 0.;
 	
 	// Commodity prices.

--- a/source/System.h
+++ b/source/System.h
@@ -114,7 +114,9 @@ public:
 	// systems within that jump range instead of the jump range given.
 	const std::set<const System *> &JumpNeighbors(double neighborDistance) const;
 	// Additional travel distance to target for ships entering through hyperspace.
-	double ExtraArrivalDistance() const;
+	double ExtraHyperArrivalDistance() const;
+	// Additional travel distance to target for ships entering using a jumpdrive.
+	double ExtraJumpArrivalDistance() const;
 	// Get a list of systems you can "see" from here, whether or not there is a
 	// direct hyperspace link to them.
 	const std::set<const System *> &VisibleNeighbors() const;
@@ -213,10 +215,13 @@ private:
 	double solarPower = 0.;
 	double solarWind = 0.;
 	
-	// The amount of additional distance that ships will arrive away from their
-	// target (system center or planet) when entering this system through a
-	// hyperspace link.
-	double extraArrivalDistance = 0.;
+	// The amount of additional distance that ships will arrive away from the
+	// system center when entering this system through a hyperspace link.
+	double extraHyperArrivalDistance = 0.;
+	// The amount of additional distance that ships will arrive away from the
+	// system center when entering this system through a jumpdrive jump.
+	double extraJumpArrivalDistance = 0.;
+
 	
 	// Commodity prices.
 	std::map<std::string, Price> trade;


### PR DESCRIPTION
**Feature:** This PR implements the Jump drive part of the feature request detailed and discussed in #4334

## Feature Details
This PR splits the keywords for arrival distances in systems into a hyperdrive-version, a jumpdrive version and a common syntax to set both.
This feature only works for systems. Setting arrive distances relative to a planet is not implemented yet.

## UI Screenshots
N/A

## Usage Examples
Use the following keywords on relevant systems:
To set a default arrival distance for all (jumpdrive, hyperdrive):
```
arrival <nr>
```

To set a default arrival distance, but a specific one for hyperdrives:
```
arrival <nr>
   link <nr>
```

To set an arrival distance for jump drives only:
```
arrival
   jump <nr>
```

To set an arrival distance for jumpdrive and hyperdrive only (different from first example in case we get a 3rd drive type):
```
arrival
   link <nr> 
   jump <nr> 
```

## Testing Done
Tested with a flight through Acamar, Aldebaran, Capella and Eteron which all had some form of travel distances set.

## Performance Impact
Calculation is just an addition and only performed once per ship per entering of a system. No noticeable performance impact expected.
