### PR TITLE
Add consistent frequency formatting for person ships

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -404,6 +404,7 @@ person "Captain Nate"
 
 person "Tranquility"
 	government "Merchant"
+	frequency 100
 	personality
 		timid
 	phrase


### PR DESCRIPTION
Very minor, non-functional patch, but this makes frequency between the Tranquility and Subsidurial consistently formatted. The default frequency is 100, so either both should have it marked (in this case), or neither should have a frequency attribute.