### PR TITLE
OpenGL ES support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04]
+        opengl: [desktop, gles]
     env:
         CCACHE_DIR: ./ccache/
         CXX: ccache g++
@@ -87,13 +88,13 @@ jobs:
       with:
         path: ${{ env.ARTIFACT }}
         # Rebuild the game binary if source code changed, or if instructions on building the game changed.
-        key: ${{ matrix.os }}-artifact-${{ hashFiles('source/**') }}-${{ hashFiles('SConstruct', '.github/workflows/ci.yml') }}
+        key: ${{ matrix.os }}-${{ matrix.opengl }}-artifact-${{ hashFiles('source/**') }}-${{ hashFiles('SConstruct', '.github/workflows/ci.yml') }}
     - name: Install development dependencies
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev uuid-dev scons ccache
+        sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev uuid-dev scons ccache libgles2-mesa
     - name: Print toolchain versions
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
@@ -105,18 +106,18 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.CCACHE_DIR }}
-        key: ${{ matrix.os }}-ccache-${{ github.repository }}-${{ github.ref }}-${{ github.sha }}
+        key: ${{ matrix.os }}-${{ matrix.opengl }}-ccache-${{ github.repository }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ matrix.os }}-ccache-${{ github.repository }}-${{ github.ref }}-
-          ${{ matrix.os }}-ccache-${{ github.repository }}-
-          ${{ matrix.os }}-ccache-
+          ${{ matrix.os }}-${{ matrix.opengl }}-ccache-${{ github.repository }}-${{ github.ref }}-
+          ${{ matrix.os }}-${{ matrix.opengl }}-ccache-${{ github.repository }}-
+          ${{ matrix.os }}-${{ matrix.opengl }}-ccache-
     - name: Compile
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: scons -Qj $(nproc);
+      run: scons -Qj $(nproc) opengl=${{ matrix.opengl }};
     - name: Upload game binary
       uses: actions/upload-artifact@v2
       with:
-        name: binary-${{ matrix.os }}
+        name: binary-${{ matrix.os }}-${{ matrix.opengl }}
         path: ${{ env.ARTIFACT }}
 
   test_ubuntu-unit:
@@ -143,7 +144,7 @@ jobs:
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev uuid-dev scons ccache
+        sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev uuid-dev scons ccache libgles2-mesa
     - name: Cache ccache results
       if: steps.cache-tests.outputs.cache-hit != 'true'
       uses: actions/cache@v2
@@ -326,9 +327,17 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
+            opengl: desktop
             glew: libglew2.1
           # - os: ubuntu-18.04
+          #   opengl: desktop
           #   glew: libglew2.0
+          - os: ubuntu-20.04
+            opengl: gles
+            glew: libgles2-mesa
+          # - os: ubuntu-18.04
+          #   opengl: gles
+          #   glew: libgles2-mesa
     steps:
     - uses: actions/checkout@v2
     - name: Install runtime dependencies
@@ -341,7 +350,7 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@v1.0.0
       with:
-        name: binary-${{ matrix.os }}
+        name: binary-${{ matrix.os }}-${{ matrix.opengl }}
         path: .
     - name: Verify Executable
       run: chmod +x endless-sky && ./endless-sky -v
@@ -357,6 +366,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        opengl: [desktop]
         include:
           - os: ubuntu-20.04
             glew: libglew2.1
@@ -372,7 +382,7 @@ jobs:
     - name: Download game binary
       uses: actions/download-artifact@v2
       with:
-        name: binary-${{ matrix.os }}
+        name: binary-${{ matrix.os }}-${{ matrix.opengl }}
     - name: Verify Executable
       run: chmod +x endless-sky && ./endless-sky -v
     - name: Parse Datafiles
@@ -456,6 +466,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        opengl: [desktop]
         include:
           - os: ubuntu-20.04
             glew: libglew2.1
@@ -469,7 +480,7 @@ jobs:
     - name: Download game binary
       uses: actions/download-artifact@v2
       with:
-        name: binary-${{ matrix.os }}
+        name: binary-${{ matrix.os }}-${{ matrix.opengl }}
     - name: Verify Executable
       run: chmod +x endless-sky && ./endless-sky -v
     - name: Check for load-time memory leaks

--- a/SConstruct
+++ b/SConstruct
@@ -34,6 +34,7 @@ if is_windows_host:
 opts = Variables()
 opts.AddVariables(
 	EnumVariable("mode", "Compilation mode", "release", allowed_values=("release", "debug", "profile")),
+	EnumVariable("opengl", "Whether to use OpenGL or OpenGL ES", "desktop", allowed_values=("desktop", "gles")),
 	PathVariable("BUILDDIR", "Directory to store compiled object files in", "build", PathVariable.PathIsDirCreate),
 	PathVariable("BIN_DIR", "Directory to store binaries in", ".", PathVariable.PathIsDirCreate),
 	PathVariable("DESTDIR", "Destination root directory, e.g. if building a package", "", PathVariable.PathAccept),
@@ -94,12 +95,26 @@ game_libs = [
 	"SDL2",
 	"png",
 	"jpeg",
-	"GL",
-	"GLEW",
 	"openal",
 	"pthread",
 ]
 env.Append(LIBS = game_libs)
+
+if env["opengl"] == "desktop":
+	env.Append(LIBS = [
+		"GL",
+		"GLEW"
+	]);
+else:
+	env.Append(LIBS = [
+		"GLESv2"
+	]);
+	flags += ["-DES_GLES"]
+
+
+# Required build flags. If you want to use SSE optimization, you can turn on
+# -msse3 or (if just building for your own computer) -march=native.
+env.Append(CCFLAGS = flags)
 
 # libmad is not in the Steam runtime, so link it statically:
 if 'steamrt_scout_i386' in chroot_name:

--- a/SConstruct
+++ b/SConstruct
@@ -89,8 +89,6 @@ game_libs = [
 	"turbojpeg.dll",
 	"jpeg.dll",
 	"openal32.dll",
-	"glew32.dll",
-	"opengl32",
 ] if is_windows_host else [
 	"SDL2",
 	"png",
@@ -100,21 +98,24 @@ game_libs = [
 ]
 env.Append(LIBS = game_libs)
 
-if env["opengl"] == "desktop":
+if env["opengl"] == "gles":
+	if is_windows_host:
+		print("OpenGL ES builds are not supported on Windows")
+		Exit(1)
 	env.Append(LIBS = [
-		"GL",
-		"GLEW"
-	]);
+		"GLESv2",
+	])
+	env.Append(CCFLAGS = ["-DES_GLES"])
+elif is_windows_host:
+	env.Append(LIBS = [
+		"glew32.dll",
+		"opengl32",
+	])
 else:
 	env.Append(LIBS = [
-		"GLESv2"
-	]);
-	flags += ["-DES_GLES"]
-
-
-# Required build flags. If you want to use SSE optimization, you can turn on
-# -msse3 or (if just building for your own computer) -march=native.
-env.Append(CCFLAGS = flags)
+		"GL",
+		"GLEW",
+	])
 
 # libmad is not in the Steam runtime, so link it statically:
 if 'steamrt_scout_i386' in chroot_name:

--- a/source/BatchShader.cpp
+++ b/source/BatchShader.cpp
@@ -51,6 +51,8 @@ void BatchShader::Init()
 	
 	static const char *fragmentCode =
 		"// fragment batch shader\n"
+		"precision mediump float;\n"
+		"precision mediump sampler2DArray;\n"
 		"uniform sampler2DArray tex;\n"
 		"uniform float frameCount;\n"
 		

--- a/source/FillShader.cpp
+++ b/source/FillShader.cpp
@@ -50,7 +50,8 @@ void FillShader::Init()
 
 	static const char *fragmentCode =
 		"// fragment fill shader\n"
-		"uniform vec4 color = vec4(1, 1, 1, 1);\n"
+		"precision mediump float;\n"
+		"uniform vec4 color;\n"
 		
 		"out vec4 finalColor;\n"
 		

--- a/source/FogShader.cpp
+++ b/source/FogShader.cpp
@@ -76,6 +76,8 @@ void FogShader::Init()
 
 	static const char *fragmentCode =
 		"// fragment fog shader\n"
+		"precision mediump sampler2D;\n"
+		"precision mediump float;\n"
 		"uniform sampler2D tex;\n"
 		
 		"in vec2 fragTexCoord;\n"

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -144,7 +144,13 @@ bool GameWindow::Init()
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 #endif
-	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);	
+#ifdef ES_GLES
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+#else
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+#endif
 	SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
 		
 	context = SDL_GL_CreateContext(mainWindow);
@@ -159,7 +165,7 @@ bool GameWindow::Init()
 	}
 			
 	// Initialize GLEW.
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(ES_GLES)
 	glewExperimental = GL_TRUE;
 	if(glewInit() != GLEW_OK){
 		ExitWithError("Unable to initialize GLEW!");

--- a/source/LineShader.cpp
+++ b/source/LineShader.cpp
@@ -56,14 +56,15 @@ void LineShader::Init()
 
 	static const char *fragmentCode =
 		"// fragment line shader\n"
-		"uniform vec4 color = vec4(1, 1, 1, 1);\n"
+		"precision mediump float;\n"
+		"uniform vec4 color;\n"
 		
 		"in vec2 tpos;\n"
 		"in float tscale;\n"
 		"out vec4 finalColor;\n"
 		
 		"void main() {\n"
-		"  float alpha = min(tscale - abs(tpos.x * (2 * tscale) - tscale), 1 - abs(tpos.y));\n"
+		"  float alpha = min(tscale - abs(tpos.x * (2.f * tscale) - tscale), 1.f - abs(tpos.y));\n"
 		"  finalColor = color * alpha;\n"
 		"}\n";
 	

--- a/source/OutlineShader.cpp
+++ b/source/OutlineShader.cpp
@@ -66,10 +66,12 @@ void OutlineShader::Init()
 	// aliasing effects between the two.
 	static const char *fragmentCode =
 		"// fragment outline shader\n"
+		"precision mediump float;\n"
+		"precision mediump sampler2DArray;\n"
 		"uniform sampler2DArray tex;\n"
-		"uniform float frame = 0;\n"
-		"uniform float frameCount = 0;\n"
-		"uniform vec4 color = vec4(1, 1, 1, 1);\n"
+		"uniform float frame;\n"
+		"uniform float frameCount;\n"
+		"uniform vec4 color;\n"
 		"uniform vec2 off;\n"
 		"const vec4 weight = vec4(.4, .4, .4, 1.);\n"
 		
@@ -78,7 +80,7 @@ void OutlineShader::Init()
 		"out vec4 finalColor;\n"
 		
 		"float Sobel(float layer) {\n"
-		"  float sum = 0;\n"
+		"  float sum = 0.f;\n"
 		"  for(int dy = -1; dy <= 1; ++dy)\n"
 		"  {\n"
 		"    for(int dx = -1; dx <= 1; ++dx)\n"
@@ -88,12 +90,12 @@ void OutlineShader::Init()
 		"      float ne = dot(texture(tex, vec3(center + vec2(off.x, -off.y), layer)), weight);\n"
 		"      float sw = dot(texture(tex, vec3(center + vec2(-off.x, off.y), layer)), weight);\n"
 		"      float se = dot(texture(tex, vec3(center + vec2(off.x, off.y), layer)), weight);\n"
-		"      float h = nw + sw - ne - se + 2 * (\n"
-		"        dot(texture(tex, vec3(center + vec2(-off.x, 0), layer)), weight)\n"
-		"          - dot(texture(tex, vec3(center + vec2(off.x, 0), layer)), weight));\n"
-		"      float v = nw + ne - sw - se + 2 * (\n"
-		"        dot(texture(tex, vec3(center + vec2(0, -off.y), layer)), weight)\n"
-		"          - dot(texture(tex, vec3(center + vec2(0, off.y), layer)), weight));\n"
+		"      float h = nw + sw - ne - se + 2.f * (\n"
+		"        dot(texture(tex, vec3(center + vec2(-off.x, 0.f), layer)), weight)\n"
+		"          - dot(texture(tex, vec3(center + vec2(off.x, 0.f), layer)), weight));\n"
+		"      float v = nw + ne - sw - se + 2.f * (\n"
+		"        dot(texture(tex, vec3(center + vec2(0.f, -off.y), layer)), weight)\n"
+		"          - dot(texture(tex, vec3(center + vec2(0.f, off.y), layer)), weight));\n"
 		"      sum += h * h + v * v;\n"
 		"    }\n"
 		"  }\n"
@@ -105,7 +107,7 @@ void OutlineShader::Init()
 		"  float second = mod(ceil(frame), frameCount);\n"
 		"  float fade = frame - first;\n"
 		"  float sum = mix(Sobel(first), Sobel(second), fade);\n"
-		"  finalColor = color * sqrt(sum / 180);\n"
+		"  finalColor = color * sqrt(sum / 180.f);\n"
 		"}\n";
 	
 	shader = Shader(vertexCode, fragmentCode);

--- a/source/PointerShader.cpp
+++ b/source/PointerShader.cpp
@@ -40,6 +40,7 @@ void PointerShader::Init()
 {
 	static const char *vertexCode =
 		"// vertex pointer shader\n"
+		"precision mediump float;\n"
 		"uniform vec2 scale;\n"
 		"uniform vec2 center;\n"
 		"uniform vec2 angle;\n"
@@ -58,7 +59,8 @@ void PointerShader::Init()
 
 	static const char *fragmentCode =
 		"// fragment pointer shader\n"
-		"uniform vec4 color = vec4(1, 1, 1, 1);\n"
+		"precision mediump float;\n"
+		"uniform vec4 color;\n"
 		"uniform vec2 size;\n"
 		
 		"in vec2 coord;\n"
@@ -68,8 +70,8 @@ void PointerShader::Init()
 		"  float height = (coord.x + coord.y) / size.x;\n"
 		"  float taper = height * height * height;\n"
 		"  taper *= taper * .5 * size.x;\n"
-		"  float alpha = clamp(.8 * min(coord.x, coord.y) - taper, 0, 1);\n"
-		"  alpha *= clamp(1.8 * (1. - height), 0, 1);\n"
+		"  float alpha = clamp(.8 * min(coord.x, coord.y) - taper, 0.f, 1.f);\n"
+		"  alpha *= clamp(1.8 * (1. - height), 0.f, 1.f);\n"
 		"  finalColor = color * alpha;\n"
 		"}\n";
 	

--- a/source/RingShader.cpp
+++ b/source/RingShader.cpp
@@ -43,6 +43,7 @@ void RingShader::Init()
 {
 	static const char *vertexCode =
 		"// vertex ring shader\n"
+		"precision mediump float;\n"
 		"uniform vec2 scale;\n"
 		"uniform vec2 position;\n"
 		"uniform float radius;\n"
@@ -53,12 +54,13 @@ void RingShader::Init()
 		
 		"void main() {\n"
 		"  coord = (radius + width) * vert;\n"
-		"  gl_Position = vec4((coord + position) * scale, 0, 1);\n"
+		"  gl_Position = vec4((coord + position) * scale, 0.f, 1.f);\n"
 		"}\n";
 
 	static const char *fragmentCode =
 		"// fragment ring shader\n"
-		"uniform vec4 color = vec4(1, 1, 1, 1);\n"
+		"precision mediump float;\n"
+		"uniform vec4 color;\n"
 		"uniform float radius;\n"
 		"uniform float width;\n"
 		"uniform float angle;\n"
@@ -70,16 +72,16 @@ void RingShader::Init()
 		"out vec4 finalColor;\n"
 		
 		"void main() {\n"
-		"  float arc = mod(atan(coord.x, coord.y) + pi + startAngle, 2 * pi);\n"
-		"  float arcFalloff = 1 - min(2 * pi - arc, arc - angle) * radius;\n"
-		"  if(dash != 0)\n"
+		"  float arc = mod(atan(coord.x, coord.y) + pi + startAngle, 2.f * pi);\n"
+		"  float arcFalloff = 1.f - min(2.f * pi - arc, arc - angle) * radius;\n"
+		"  if(dash != 0.f)\n"
 		"  {\n"
 		"    arc = mod(arc, dash);\n"
 		"    arcFalloff = min(arcFalloff, min(arc, dash - arc) * radius);\n"
 		"  }\n"
 		"  float len = length(coord);\n"
 		"  float lenFalloff = width - abs(len - radius);\n"
-		"  float alpha = clamp(min(arcFalloff, lenFalloff), 0, 1);\n"
+		"  float alpha = clamp(min(arcFalloff, lenFalloff), 0.f, 1.f);\n"
 		"  finalColor = color * alpha;\n"
 		"}\n";
 	

--- a/source/Shader.cpp
+++ b/source/Shader.cpp
@@ -98,12 +98,22 @@ GLuint Shader::Compile(const char *str, GLenum type)
 	{
 		version = "#version ";
 		string glsl = reinterpret_cast<const char *>(glGetString(GL_SHADING_LANGUAGE_VERSION));
+		bool found = false;
 		for(char c : glsl)
 		{
+			if(!found && !isdigit(c)) {
+				continue;
+			}
 			if(isspace(c))
 				break;
-			if(isdigit(c))
+			if(isdigit(c)) {
+				found = true;
 				version += c;
+			}
+		}
+		if(glsl.find("GLSL ES") != std::string::npos)
+		{
+			version += " es";
 		}
 		version += '\n';
 	}

--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -20,6 +20,12 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <vector>
 #include <sstream>
 
+#ifdef ES_GLES
+// ES_GLES always uses the shader, not this, so use a dummy value to compile.
+// (the correct value is usually 0x8E46, so don't use that)
+#define GL_TEXTURE_SWIZZLE_RGBA 0xBEEF
+#endif
+
 using namespace std;
 
 namespace {
@@ -79,6 +85,7 @@ void SpriteShader::Init(bool useShaderSwizzle)
 	
 	static const char *vertexCode =
 		"// vertex sprite shader\n"
+		"precision mediump float;\n"
 		"uniform vec2 scale;\n"
 		"uniform vec2 position;\n"
 		"uniform mat2 transform;\n"
@@ -89,7 +96,7 @@ void SpriteShader::Init(bool useShaderSwizzle)
 		"out vec2 fragTexCoord;\n"
 		
 		"void main() {\n"
-		"  vec2 blurOff = 2 * vec2(vert.x * abs(blur.x), vert.y * abs(blur.y));\n"
+		"  vec2 blurOff = 2.f * vec2(vert.x * abs(blur.x), vert.y * abs(blur.y));\n"
 		"  gl_Position = vec4((transform * (vert + blurOff) + position) * scale, 0, 1);\n"
 		"  vec2 texCoord = vert + vec2(.5, .5);\n"
 		"  fragTexCoord = vec2(texCoord.x, max(clip, texCoord.y)) + blurOff;\n"
@@ -98,6 +105,8 @@ void SpriteShader::Init(bool useShaderSwizzle)
 	ostringstream fragmentCodeStream;
 	fragmentCodeStream <<
 		"// fragment sprite shader\n"
+		"precision mediump float;\n"
+		"precision mediump sampler2DArray;\n"
 		"uniform sampler2DArray tex;\n"
 		"uniform float frame;\n"
 		"uniform float frameCount;\n"
@@ -117,9 +126,9 @@ void SpriteShader::Init(bool useShaderSwizzle)
 		"  float second = mod(ceil(frame), frameCount);\n"
 		"  float fade = frame - first;\n"
 		"  vec4 color;\n"
-		"  if(blur.x == 0 && blur.y == 0)\n"
+		"  if(blur.x == 0.f && blur.y == 0.f)\n"
 		"  {\n"
-		"    if(fade != 0)\n"
+		"    if(fade != 0.f)\n"
 		"      color = mix(\n"
 		"        texture(tex, vec3(fragTexCoord, first)),\n"
 		"        texture(tex, vec3(fragTexCoord, second)), fade);\n"
@@ -129,12 +138,12 @@ void SpriteShader::Init(bool useShaderSwizzle)
 		"  else\n"
 		"  {\n"
 		"    color = vec4(0., 0., 0., 0.);\n"
-		"    const float divisor = range * (range + 2) + 1;\n"
+		"    const float divisor = float(range * (range + 2) + 1);\n"
 		"    for(int i = -range; i <= range; ++i)\n"
 		"    {\n"
-		"      float scale = (range + 1 - abs(i)) / divisor;\n"
-		"      vec2 coord = fragTexCoord + (blur * i) / range;\n"
-		"      if(fade != 0)\n"
+		"      float scale = float(range + 1 - abs(i)) / divisor;\n"
+		"      vec2 coord = fragTexCoord + (blur * float(i)) / float(range);\n"
+		"      if(fade != 0.f)\n"
 		"        color += scale * mix(\n"
 		"          texture(tex, vec3(coord, first)),\n"
 		"          texture(tex, vec3(coord, second)), fade);\n"

--- a/source/StarField.cpp
+++ b/source/StarField.cpp
@@ -203,6 +203,7 @@ void StarField::SetUpGraphics()
 
 	static const char *fragmentCode =
 		"// fragment starfield shader\n"
+		"precision mediump float;\n"
 		"in float fragmentAlpha;\n"
 		"in vec2 coord;\n"
 		"out vec4 finalColor;\n"

--- a/source/gl_header.h
+++ b/source/gl_header.h
@@ -14,6 +14,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifdef __APPLE__
 #include <OpenGL/GL3.h>
 #else
+#ifdef ES_GLES
+#include <GLES3/gl3.h>
+#else
 #include <GL/glew.h>
+#endif
 #endif
 

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -39,7 +39,7 @@ namespace {
 		// The glyph to draw. (ASCII value - 32).
 		"uniform int glyph;\n"
 		// Aspect ratio of rendered glyph (unity by default).
-		"uniform float aspect = 1.f;\n"
+		"uniform float aspect;\n"
 		
 		// Inputs from the VBO.
 		"in vec2 vert;\n"
@@ -50,15 +50,16 @@ namespace {
 		
 		// Pick the proper glyph out of the texture.
 		"void main() {\n"
-		"  texCoord = vec2((glyph + corner.x) / 98.f, corner.y);\n"
-		"  gl_Position = vec4((aspect * vert.x + position.x) * scale.x, (vert.y + position.y) * scale.y, 0, 1);\n"
+		"  texCoord = vec2((float(glyph) + corner.x) / 98.f, corner.y);\n"
+		"  gl_Position = vec4((aspect * vert.x + position.x) * scale.x, (vert.y + position.y) * scale.y, 0.f, 1.f);\n"
 		"}\n";
 	
 	const char *fragmentCode =
 		"// fragment font shader\n"
+		"precision mediump float;\n"
 		// The user must supply a texture and a color (white by default).
 		"uniform sampler2D tex;\n"
-		"uniform vec4 color = vec4(1, 1, 1, 1);\n"
+		"uniform vec4 color;\n"
 		
 		// This comes from the vertex shader.
 		"in vec2 texCoord;\n"


### PR DESCRIPTION
## Summary
Adds support for OpenGL ES, a variant of OpenGL targeting embedded systems. The new build flag `opengl` defaults to `desktop` but can be set to `gles` to target these systems. This PR makes shader code acceptable to both OpenGL 3.0 and OpenGL ES 3.0.

Support for OpenGL ES would be useful for targeting Raspberry PIs, mobile devices like iOS or Android, and WebGL. I'm interested in it because it enables an Emscripten build for the web.

## Testing Done
I tested on an ubuntu18 vm with

~~~
scons opengl=gles
MESA_GLES_VERSION_OVERRIDE=3.0 ./endless-sky
~~~

This version check can probably be cheated with MESA_GLES_VERSION_OVERRIDE on any machine that runs the desktop build on Endless Sky because the only OpenGL ES 3.0 features used are those already supported by OpenGL 3.0. (full OpenGL ES 3.0 support is equivalent to OpenGL 4.3) Cheating this version is only necessary on machines that do not support OpenGL ES 3.

I have built and run the default desktop build locally with Xcode on a mac and on this same Ubuntu vm.

## Performance Impact
This is potentially quite performance-sensitive code and I haven't done any performance testing! The shader changes look innocuous to me, it's just making floats and precision explicit. I didn't notice any difference just from running the the game.

This PR depends on https://github.com/endless-sky/endless-sky/pull/6155