### PR TITLE
No music and fewer threads

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -35,6 +35,7 @@ opts = Variables()
 opts.AddVariables(
 	EnumVariable("mode", "Compilation mode", "release", allowed_values=("release", "debug", "profile")),
 	EnumVariable("music", "Whether to use music", "on", allowed_values=("on", "off")),
+	EnumVariable("threads", "Whether to use threads", "on", allowed_values=("on", "off")),
 	PathVariable("BUILDDIR", "Directory to store compiled object files in", "build", PathVariable.PathIsDirCreate),
 	PathVariable("BIN_DIR", "Directory to store binaries in", ".", PathVariable.PathIsDirCreate),
 	PathVariable("DESTDIR", "Destination root directory, e.g. if building a package", "", PathVariable.PathAccept),
@@ -81,12 +82,18 @@ game_libs = [
 	"GL",
 	"GLEW",
 	"openal",
-	"pthread",
 ]
 env.Append(LIBS = game_libs)
 
 if env["music"] == "off":
 	flags += ["-DES_NO_MUSIC"]
+
+if env["threads"] == "off":
+	flags += ["-DES_NO_THREADS"]
+else:
+	env.Append(LIBS = [
+		"pthread"
+	]);
 
 # Required build flags. If you want to use SSE optimization, you can turn on
 # -msse3 or (if just building for your own computer) -march=native.

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -29,7 +29,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <list>
 #include <map>
 #include <memory>
+#ifndef ES_NO_THREADS
 #include <thread>
+#endif // ES_NO_THREADS
 #include <utility>
 #include <vector>
 
@@ -163,13 +165,15 @@ private:
 	
 	AI ai;
 	
+#ifndef ES_NO_THREADS
 	std::thread calcThread;
 	std::condition_variable condition;
 	std::mutex swapMutex;
+	bool terminate = false;
+#endif // ES_NO_THREADS
 	
 	bool calcTickTock = false;
 	bool drawTickTock = false;
-	bool terminate = false;
 	bool wasActive = false;
 	DrawList draw[2];
 	BatchDrawList batchDraw[2];

--- a/source/Music.cpp
+++ b/source/Music.cpp
@@ -14,7 +14,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Files.h"
 
+#ifndef ES_NO_MUSIC
 #include <mad.h>
+#endif // ES_NO_MUSIC
 
 #include <algorithm>
 #include <cstring>
@@ -23,8 +25,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
+#ifndef ES_NO_MUSIC
 	// How many bytes to read from the file at a time:
 	const size_t INPUT_CHUNK = 65536;
+#endif // ES_NO_MUSIC
 	// How many samples to put in each output block. Because the output is in
 	// stereo, the duration of the sample is half this amount:
 	const size_t OUTPUT_CHUNK = 32768;
@@ -36,6 +40,7 @@ namespace {
 
 void Music::Init(const vector<string> &sources)
 {
+#ifndef ES_NO_MUSIC
 	for(const string &source : sources)
 	{
 		// Find all the sound files that this resource source provides.
@@ -55,6 +60,7 @@ void Music::Init(const vector<string> &sources)
 			paths[name] = path;
 		}
 	}
+#endif // ES_NO_MUSIC
 }
 
 
@@ -64,8 +70,10 @@ void Music::Init(const vector<string> &sources)
 Music::Music()
 	: silence(OUTPUT_CHUNK, 0)
 {
+#ifndef ES_NO_MUSIC
 	// Don't start the thread until this object is fully constructed.
 	thread = std::thread(&Music::Decode, this);
+#endif // ES_NO_MUSIC
 }
 
 
@@ -73,6 +81,7 @@ Music::Music()
 // Destructor, which waits for the thread to stop.
 Music::~Music()
 {
+#ifndef ES_NO_MUSIC
 	// Tell the decoding thread to stop.
 	{
 		unique_lock<mutex> lock(decodeMutex);
@@ -85,6 +94,7 @@ Music::~Music()
 	// our job to close it.
 	if(nextFile)
 		fclose(nextFile);
+#endif // ES_NO_MUSIC
 }
 
 
@@ -92,6 +102,7 @@ Music::~Music()
 // Set the source of music. If the path is empty, this music will be silent.
 void Music::SetSource(const string &name)
 {
+#ifndef ES_NO_MUSIC
 	// Find a file that provides this music.
 	auto it = paths.find(name);
 	string path = (it == paths.end() ? "" : it->second);
@@ -115,6 +126,7 @@ void Music::SetSource(const string &name)
 	// Notify the decoding thread that it can start.
 	lock.unlock();
 	condition.notify_all();
+#endif // ES_NO_MUSIC
 }
 
 
@@ -122,6 +134,7 @@ void Music::SetSource(const string &name)
 // Get the next audio buffer to play.
 const vector<int16_t> &Music::NextChunk()
 {
+#ifndef ES_NO_MUSIC
 	// Check whether the "next" buffer is ready.
 	unique_lock<mutex> lock(decodeMutex);
 	if(next.size() < OUTPUT_CHUNK)
@@ -137,6 +150,7 @@ const vector<int16_t> &Music::NextChunk()
 	// Once the lock is unlocked, notify the decoding thread to continue.
 	lock.unlock();
 	condition.notify_all();
+#endif // ES_NO_MUSIC
 	
 	// Return the buffer.
 	return current;
@@ -148,6 +162,7 @@ const vector<int16_t> &Music::NextChunk()
 // Entry point for the decoding thread.
 void Music::Decode()
 {
+#ifndef ES_NO_MUSIC
 	// This vector will store the input from the file.
 	vector<unsigned char> input(INPUT_CHUNK, 0);
 	// Objects for MP3 decoding:
@@ -273,4 +288,5 @@ void Music::Decode()
 		mad_stream_finish(&stream);
 		fclose(file);
 	}
+#endif // ES_NO_MUSIC
 }


### PR DESCRIPTION
I found thinking about https://github.com/endless-sky/endless-sky/pull/5591 confusing without the -DNO_THREADS commit as well, so combining these here. I'm looking for any comments about this approach or other potential approaches. At this point it's a given that littering the code ifdefs like this is unlikely to be accepted, so I'm interested in high-level feedback. Finding a subset of changes that could be merged to make the web build patch smaller would also be useful.

@tehhowch has already left several comments about this.
> It's basically correct to assume that removing threads is not upstreamable. What you could/should do is work out a way to convert our use of threads into something compatible with e.g. WebWorkers, so you could upstream a conversion to "EsThread" from std::thread, and in the web build you'd replace the EsThread implementation with WebWorker stuff

and re music on https://github.com/endless-sky/endless-sky/pull/5591
> This seems like a really hacky way to disable music. Wouldn't it be better to make loading libmad optional, and avoid doing so when the compiled binary receives the command line parameter e.g. --no-music?
>
> Then we don't need any ifdefs at all, and systems that won't attempt to load the dynamic library won't need the library in their execution environment.
> 
> A different take on the ifdef approach here would be to ifdef the entire music.cpp and music.h files, and their associated includes / method calls. Then the compiler wouldn't ever see calls to `Music::____`, and there wouldn't be anything at all in music.cpp or music.h
>
> Only the first approach would make it into the upstream here, but the second way could simplify the patch you need to use for the web fork. Though since you would need to modify audio initialization, perhaps not.