### PR TITLE
add a dialog 'unable to switch vsync state' to settings

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -181,7 +181,7 @@ bool Preferences::ZoomViewOut()
 
 
 
-void Preferences::ToggleVSync()
+bool Preferences::ToggleVSync()
 {
 	int targetIndex = vsyncIndex + 1;
 	if(targetIndex == static_cast<int>(VSYNC_SETTINGS.size()))
@@ -197,10 +197,11 @@ void Preferences::ToggleVSync()
 			// Restore original saved setting.
 			Files::LogError("Unable to change VSync state");
 			GameWindow::SetVSync(static_cast<VSync>(vsyncIndex));
-			return;
+			return false;
 		}
 	}
 	vsyncIndex = targetIndex;
+	return true;
 }
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -48,7 +48,7 @@ public:
 	static bool ZoomViewOut();
 	
 	// VSync setting, either "on", "off", or "adaptive".
-	static void ToggleVSync();
+	static bool ToggleVSync();
 	static Preferences::VSync VSyncState();
 	static const std::string &VSyncSetting();
 };

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -173,7 +173,10 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 					while(Preferences::ZoomViewOut()) {}
 			}
 			else if(zone.Value() == VSYNC_SETTING)
-				Preferences::ToggleVSync();
+			{
+				if(!Preferences::ToggleVSync())
+					GetUI()->Push(new Dialog("Unable to change VSync state"));
+			}
 			else if(zone.Value() == EXPEND_AMMO)
 				Preferences::ToggleAmmoUsage();
 			else if(zone.Value() == TURRET_TRACKING)

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -175,7 +175,8 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 			else if(zone.Value() == VSYNC_SETTING)
 			{
 				if(!Preferences::ToggleVSync())
-					GetUI()->Push(new Dialog("Unable to change VSync state"));
+					GetUI()->Push(new Dialog(
+						"Unable to change VSync state. (Your system's graphics settings may be controlling it instead.)"));
 			}
 			else if(zone.Value() == EXPEND_AMMO)
 				Preferences::ToggleAmmoUsage();


### PR DESCRIPTION
This PR adds a dialog to Settings that pops ups when VSync state cannot be changed.
I added this popup because otherwise the UI appears unresponsive.