### PR TITLE
Add a setting to automatically fire crew for transport missions

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -26,6 +26,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Interface.h"
 #include "text/layout.hpp"
 #include "LineShader.h"
+#include "Messages.h"
 #include "Mission.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
@@ -745,6 +746,14 @@ void MissionPanel::Accept()
 	int crewToFire = 0;
 	if(toAccept.Passengers())
 		crewToFire = toAccept.Passengers() - player.Cargo().BunksFree();
+	// Automatically fire crew, if appropriate.
+	if(crewToFire > 0 && Preferences::Has("Auto fire crew to make space"))
+	{
+		player.Flagship()->AddCrew(-crewToFire);
+		player.UpdateCargoCapacities();
+		Messages::Add("You fired " + to_string(crewToFire) + " crew members to free up bunks for passengers.");
+		crewToFire = 0;
+	}
 	if(cargoToSell > 0 || crewToFire > 0)
 	{
 		ostringstream out;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -457,6 +457,7 @@ void PreferencesPanel::DrawSettings()
 		REACTIVATE_HELP,
 		"Interrupt fast-forward",
 		"Rehire extra crew when lost",
+		"Auto fire crew to make space",
 		SCROLL_SPEED,
 		"Show escort systems on map",
 		"System map sends move orders",


### PR DESCRIPTION
This basically goes with #5601 to make life less tedious for those like me who opportunistically keep a full crew complement just in case there happens to be something to board. I'm not too sure whether it should be a separate setting. Perhaps it would make more sense to wrap it in with the existing "Rehire extra crew when lost" setting, renaming it something like "Automatic crew management". It's worth noting that automatic crew firing already happens for story missions, it's only when accepting job-type missions that you even get this prompt.

A new setting at least won't disrupt anyone who wants to keep the prompt, even while using the automatic rehiring option.

-----------------------
**Feature:** I didn't make a separate issue. This is the issue.

## Feature Details
Added the capability to automatically fire crew when accepting transport missions that require it. This just skips the "you need to fire X crewmembers to accept this mission" dialog and does it without prompting. Cargo still prompts. I added a new preference for this "Auto fire crew to make space", but i'm not sure that's really necessary.

## Usage Examples
Set the new preference, hire a full complement of crew, then accept a transport mission. It should just do it, adding a message about firing crew to make space (which you'll only see after leaving the mission screen).

## Testing Done
Played a fair portion of the Free Worlds campaign with this active. It significantly reduced tedium, in combination with my other "autorehire after transport missions" PR.

## Performance Impact
none
