### PR TITLE
Fix: Removing Surveillance from Person-Zitchas

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -1122,7 +1122,7 @@ person "Zitchas"
 	frequency 200
 	government "Author"
 	personality
-		mining harvests unconstrained surveillance opportunistic
+		mining harvests unconstrained opportunistic
 	system
 		attributes "ember waste"
 	phrase


### PR DESCRIPTION
**Bugfix:** This PR addresses issue regarding Zitchas abandoning drones in systems

## Fix Details
The `Surveillance` personality is currently described as:

> scans random ships and visits random planets in system.

However, it has an intentional but undocumented behaviour in that it also causes ships to abandon drones when departing a system. This is used, for example, by Republic ships leaving surveillance drones behind in systems they want to record the activity in. 

Given that it is not intended to have Zitchas abandon their drones, this PR removes the "surveillance" behaviour.