### PR TITLE
Increase deterrence from relative damage weapons

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -41,6 +41,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <algorithm>
 #include <cmath>
 #include <ctime>
+#include <iostream>
 #include <sstream>
 
 using namespace std;
@@ -1029,7 +1030,9 @@ pair<double, double> PlayerInfo::RaidFleetFactors() const
 				const Outfit *weapon = hardpoint.GetOutfit();
 				if(weapon->Ammo() && !ship->OutfitCount(weapon->Ammo()))
 					continue;
-				double damage = weapon->ShieldDamage() + weapon->HullDamage();
+				double damage = weapon->ShieldDamage() + weapon->HullDamage()
+					+ (weapon->RelativeShieldDamage() * ship->Attributes().Get("shields"))
+					+ (weapon->RelativeHullDamage() * ship->Attributes().Get("hull"));
 				deterrence += .12 * damage / weapon->Reload();
 			}
 	}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -41,7 +41,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <algorithm>
 #include <cmath>
 #include <ctime>
-#include <iostream>
 #include <sstream>
 
 using namespace std;


### PR DESCRIPTION
## Feature Details
This PR modifies the damage value used in deterrence calculations, by letting weapons that deal relative damage add to your fleet's DPS calculate it based on the vitals of the ship that's carrying it. While this is theoretically game-able by having it change based on what ship it's installed on, it would still let a plugin creator use small values of relative damage without completely blowing out the piracy threat scale, and would be better than any constants we could come up with.


## UI Screenshots
![image](https://user-images.githubusercontent.com/4471575/103496136-b0eaa180-4e02-11eb-9023-3449b2996cb5.png)
![image](https://user-images.githubusercontent.com/4471575/103496142-bd6efa00-4e02-11eb-9395-3f267cdb5306.png)

## Testing Done
As shown above, I tested by using two weapons (Deterrence from Omnis, which does 100% damage 60 times a second, and Deterrence Mini, which does 10% damage 1 time a second) on two different types of ships, the Star Barge and the Archon. I parked and unparked various combinations of those ships to see the fleet threat increase appropriately.

## Save File
This zip has a save file with said ships, and a plugin which provides the outfits, so you can see the deterrence changes yourself.
[relative-deterrence.zip](https://github.com/endless-sky/endless-sky/files/5762768/relative-deterrence.zip)

## Performance Impact
N/A
