### PR TITLE
Events can trigger other events

### DIFF
--- a/data/human/events.txt
+++ b/data/human/events.txt
@@ -33,6 +33,10 @@ mission "remembrance day"
 
 event "war begins"
 	date 4 7 3014
+	event "initial deployment 1" 20
+	event "initial deployment 2" 41
+	event "initial deployment 3" 56
+	event "initial deployment 4" 75
 	system "Gamma Corvi"
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 600
@@ -155,7 +159,6 @@ mission "event: war begins"
 				decline
 
 event "initial deployment 1"
-	date 24 7 3014
 	system "Spica"
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 1700
@@ -261,7 +264,6 @@ event "initial deployment 1"
 		description `The Navy has recently requisitioned one of the abandoned mining towns and begun refurbishing it for a secure military base, with the mining tunnels used as deep underground bunkers.`
 
 event "initial deployment 2"
-	date 14 8 3014
 	planet "Martini"
 		"required reputation" 10
 	system "Izar"
@@ -430,7 +432,10 @@ event "initial deployment 2"
 		fleet "Navy Surveillance" 1600
 
 event "initial deployment 3"
-	date 29 8 3014
+	event "southern carriers 1" 90
+	event "southern carriers 2" 180
+	event "southern carriers 3" 270
+	event "southern carriers 4" 360
 	system "Zubenelgenubi"
 		fleet "Small Southern Merchants" 500
 		fleet "Large Southern Merchants" 900
@@ -507,18 +512,6 @@ event "initial deployment 3"
 		fleet "Small Republic" 1100
 		fleet "Large Republic" 800
 		fleet "Navy Surveillance" 1200
-
-mission "Southern Carriers Trigger"
-	landing
-	invisible
-	to offer
-		has "event: initial deployment 3"
-	on offer
-		event "southern carriers 1" 90
-		event "southern carriers 2" 180
-		event "southern carriers 3" 270
-		event "southern carriers 4" 360
-		fail
 
 event "southern carriers 1"
 	shipyard "Syndicate Basics"
@@ -666,7 +659,6 @@ event "southern carriers 4"
 			"Lance (Gatling)" 4
 
 event "initial deployment 4"
-	date 17 9 3014
 	planet "Geminus"
 		"required reputation" 10
 	system "Sargas"

--- a/source/GameEvent.h
+++ b/source/GameEvent.h
@@ -20,6 +20,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <list>
 #include <string>
 #include <vector>
+#include <map>
 
 class DataWriter;
 class Planet;
@@ -62,6 +63,7 @@ private:
 	std::vector<const Planet *> planetsToVisit;
 	std::vector<const System *> systemsToUnvisit;
 	std::vector<const Planet *> planetsToUnvisit;
+	std::map<const GameEvent *, std::pair<int, int>> subEvents;
 };
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -537,6 +537,9 @@ void PlayerInfo::IncrementDate()
 	conditions["year"] = date.Year();
 	
 	// Check if any special events should happen today.
+	// Note that while events can add other events, they always get added to
+	// the end of the linked list, and thus are applied recursively with no
+	// extra handling. Just don't create any circular dependencies please.
 	auto it = gameEvents.begin();
 	while(it != gameEvents.end())
 	{


### PR DESCRIPTION
**New Feature:** Events can trigger other events, just as missions can trigger events.

## Feature Details
Added functionality and handling so that events can trigger other events. Delays and randomized delays are also handled. This simplifies event specification by removing the requirement for "trigger" missions in some simple cases. One such simple case is the initial war deployment, which has been updated to use this new system.

## UI Screenshots
N/A

## Usage Examples
Example usage is part of the commit. For instance in stead of having an invisible trigger mission
```
mission "Southern Carriers Trigger"
	landing
	invisible
	to offer
		has "event: initial deployment 3"
	on offer
		event "southern carriers 1" 90
		event "southern carriers 2" 180
		event "southern carriers 3" 270
		event "southern carriers 4" 360
		fail
```
It can just be put in the event itself as
```
event "initial deployment 3"
	event "southern carriers 1" 90
	event "southern carriers 2" 180
	event "southern carriers 3" 270
	event "southern carriers 4" 360
	[...]
```

## Testing Done
Changed the dates on the initial war deployment and stepped through by taking off and landing until each milestone occurred, examining the save file after each deployment. Results appear as expected.

## Performance Impact
N/A