### PR TITLE
feat(settings): Allow conflicting keybindings to be saved (#5582).

### DIFF
--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -156,11 +156,11 @@ void Command::SaveSettings(const string &path)
 {
 	DataWriter out(path);
 	
-	for(const auto &it : commandForKeycode)
+	for(const auto &it : keycodeForCommand)
 	{
-		auto dit = description.find(it.second);
+		auto dit = description.find(it.first);
 		if(dit != description.end())
-			out.Write(dit->second, it.first);
+			out.Write(dit->second, it.second);
 	}
 }
 


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #5582 

## Feature Details
Keybindings that conflict are saved as is, in stead of only saving one of the conflicting keybindings.

Previously key bindings were saved per-key. I changed it to save per-command. Save file format remains unchanged.

## UI Screenshots
No change. Conflicts are still marked in red.

## Usage Examples
No change to existing usage.

## Testing Done
My preferred setup with both cloaking and afterburner bound to the same key now saves and loads correctly.

## Performance Impact
none