### PR TITLE
Rename assign to apply in testframework to match conversation syntax.

### DIFF
--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -45,7 +45,7 @@ namespace{
 	};
 	
 	const map<Test::TestStep::Type, const string> STEPTYPE_TO_TEXT = {
-		{Test::TestStep::Type::ASSIGN, "assign"},
+		{Test::TestStep::Type::APPLY, "apply"},
 		{Test::TestStep::Type::ASSERT, "assert"},
 		{Test::TestStep::Type::BRANCH, "branch"},
 		{Test::TestStep::Type::INJECT, "inject"},

--- a/source/Test.h
+++ b/source/Test.h
@@ -42,7 +42,7 @@ public:
 		// The different types of teststeps.
 		enum class Type {
 			// Step that assigns a value to a condition. Does not cause the game to step.
-			ASSIGN,
+			APPLY,
 			// Step that verifies if a certain condition is true. Does not cause the game to step.
 			ASSERT,
 			// Branch with a label to jump to when the condition in child is true.


### PR DESCRIPTION
**Feature:** This PR implements a small update to the test-framework as discussed in #4308

## Feature Details
The test-framework tries to follow the existing [conversation syntax](https://github.com/endless-sky/endless-sky/wiki/WritingConversations) where possible/applicable.
During some updates I noticed that the `apply` keyword as used in conversations was proposed under a different name `assign` in the test-framework. This PR changes the `assign` keyword to `apply` as used in conversations.

## UI Screenshots
N/A

## Usage Examples
When writing tests, use the `apply` keyword instead of the `assign` keyword.

## Testing Done
Variable rename (variable is not in active use), not explicitly tested.

## Performance Impact
N/A