### PR TITLE
CD: Don't install p7zip on MacOS (already installed)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Update Homebrew
         run: brew update
       - name: Install dependencies
-        run: brew install libpng libjpeg-turbo libmad sdl2 p7zip
+        run: brew install libpng libjpeg-turbo libmad sdl2
       - name: Adjust library paths
         run: |
           install_name_tool -id "@rpath/libpng16.16.dylib" /usr/local/lib/libpng16.16.dylib


### PR DESCRIPTION
**Bugfix:** This PR addresses [this error](https://github.com/endless-sky/endless-sky/runs/1666834370) in the CD pipeline.

Note that [the *other* error on that run](https://github.com/endless-sky/endless-sky/runs/1666834401) is likely due to some server issues on github's part; so try, try again.

## Fix Details

The pipeline fails because brew tries to install `p7zip`, which apparently is already installed.

I don't know why this only fails now, as `p7zip` was added to the `macos-10.15` image [months ago](https://github.com/actions/virtual-environments/commit/26b764b1e3ab4be906a1ee672d9bf4beaf651b6b). Regardless, this PR removes `p7zip` from the list of packages to be installed.

On a sidenote: I also tried to apply the `--force` flag, which in my understanding should prevent such issues, but apparently [homebrew thinks otherwise](https://github.com/MCOfficer/endless-sky/runs/1668337130?check_suite_focus=true).

## Testing Done
The pipeline will run as part of this PR.
