### PR TITLE
Keep escorts close to parent while flying towards planet for landing.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1620,9 +1620,13 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 	{
 		ship.SetTargetSystem(nullptr);
 		ship.SetTargetStellar(parent.GetTargetStellar());
-		MoveToPlanet(ship, command);
 		if(parent.IsLanding() || parent.CanLand())
+		{
+			MoveToPlanet(ship, command);
 			command |= Command::LAND;
+		}
+		else
+			KeepStation(ship, command, parent);
 	}
 	else if(parent.Commands().Has(Command::BOARD) && parent.GetTargetShip().get() == &ship)
 		Stop(ship, command, .2);


### PR DESCRIPTION
**Feature:** This PR implements the feature request discussed in a [comment](https://github.com/endless-sky/endless-sky/pull/5583#discussion_r549862995) on #5583

## Feature Details
This PR changes the escorts behaviour to Keepstation around its parent while the parent is flying to a planet for landing. Escorts will also go for landing once the parent is landing. 
Escorts slower than the parent will just follow the parent. Escorts faster than the parent will stay near the parent.

## UI Screenshots
N/A

## Usage Examples
N/A (behaviour is automatically executed by escorts)

## Testing Done
Departed from planet with faster and slower escorts and checked that they stay with the parent during landing.
Also waited near the planet for some time to check AI fleet behaviour.

## Performance Impact
No impact expected, KeepStation is very common behaviour for escort ships.