### PR TITLE
Feature: Additional Tutorials

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -82,7 +82,7 @@ help "map advanced shops"
 	`Each ship or outfit can be clicked on, displaying that item's stats while also highlighting any planets where it is sold. Using Shift+click on a ship or outfit after you already have one selected will display that item's stats side by side the the previously selected item.`
 
 help "multiple ships"
-	`Now that you have more than one ship, while landed on a planet you can reorder the ships in your fleet by clicking and dragging them in the shipyard, outfitter, or player info panel. You will use the first ship in the list as your flagship. In the player info panel you can also "park" a ship on a planet if you want to travel somewhere without it coming with you.`
+	`Now that you have more than one ship, while landed on a planet you can reorder the ships in your fleet by clicking and dragging them in the shipyard, outfitter, or player info panel. You will use the first ship in the list as your flagship. In the player info panel (accessed with <View player info>) you can also "park" a ship on a planet if you want to travel somewhere without it coming with you.`
 
 help "multiple ship controls"
 	`Once you're in space with multiple ships that you own, you can give orders to those escorts. Orders will be given to all selected escorts, or if no escorts are selected then all your escorts will receive the order. Escorts can be selected by either clicking on them in space, clicking the ship icon at the bottom left of the screen, or by clicking and dragging to select a group of escorts in space. The list of escort order keys can be found in the preferences panel.`

--- a/data/help.txt
+++ b/data/help.txt
@@ -78,7 +78,7 @@ help "map advanced ports"
 
 help "map advanced shops"
 	`Both the Shipyard and Outfitter panels give the same information: A catalog of any items you've seen in your career, providing detailed statistics at any time. Items will be in categories on the left side of the screen, which can be collapsed individually, or all at once with shift-click on a category name. You can also use the "Find" button in the bottom right to search by name.`
-	`When selecting an item, the details will appear in the top-right. Ports which sell it will be colored yellow, while ports with the correct shop but not the item will teal. You can compare what you've selected with a second item with shift-click, which will put both details side-by-side.`
+	`When selecting an item, the details will appear in the top-right. Ports which sell it will be colored yellow, while ports with the correct shop but not the item will be colored teal. You can compare what you've selected with a second item with shift-click, which will put both details side-by-side.`
 
 help "multiple ships"
 	`Now that you have more than one ship, while landed on a planet you can reorder the ships in your fleet by clicking and dragging them in the shipyard, outfitter, or player info panel. You will use the first ship in the list as your flagship. In the player info panel you can also "park" a ship on a planet if you want to travel somewhere without it coming with you.`
@@ -98,7 +98,7 @@ help "outfitter"
 	`Here, you can buy new equipment for your ship. Your ship has a limited amount of "outfit space," and most outfits use up some of that space.`
 	`Some types of outfits have other requirements as well. For example, only some of your outfit space can be used for engines or weapons; this is your ship's "engine capacity" and "weapon capacity." Guns and missile launchers also require a free "gun port," and turrets require a free "turret mount." Also, missiles can only be bought if you have the right launcher installed.`
 	`Use your scroll wheel, or click and drag, to scroll the view.`
-	`As in the trading panel, you can hold down Shift, Control, or Alt to buy 5 or 20 or 500 of an outfit at once, or multiple keys for larger amounts.`
+	`As in the trading panel, you can hold down Shift, Control, or Alt to buy 5, 20, or 500 of an outfit at once, or multiple keys for larger amounts.`
 
 help "outfitter 2"
 	`Sometimes you may want to buy some outfits directly into your cargo hold instead of having them installed. Perhaps a mission has asked you to retrieve some outfits or you want to carry extra ammunition to refill your ships somewhere that does not stock those weapons. To accomplish this, you need to switch out of installation mode into 'purchase to cargo' mode. This can be achieved by either checking the "show outfits in cargo" box at the bottom left, or control-clicking on your selected ship to deselect it.`

--- a/data/help.txt
+++ b/data/help.txt
@@ -70,24 +70,24 @@ help "map"
 	`This map shows all the star systems you know about and the hyperspace links between them. You can use the map to plot a hyperspace course by clicking on the system you want to travel to. To initiate a jump to that system, close the map and press <Initiate hyperspace jump>.`
 
 help "map advanced"
-	`As you explore more of the galaxy, the star map will quickly become a very powerful tool. Clicking on a distant system will automatically plot the quickest route to it. You can shift-click on systems to plot a route between them, or control-click to select it there setting a route.`
+	`As you explore more of the galaxy, the star map will quickly become a very powerful tool. Clicking on a distant system will automatically plot the quickest route to it. You can Shift+click on systems to plot a route between them, or Control+click to select a system without setting a route to it.`
 	`There are many other useful modes the map can be set to. Click on one of the buttons in the lower right corner to learn more.`
 
 help "map advanced ports"
-	`The Ports panel provides detailed information about every planet, station, or other stellar objects you've come across. Most information can be clicked on (like the word "Outfitter", or on the price of a trade good), which will color every system on the star map appropriately.`
-	`For instance, you can click on "(has been visited)" to see which planets you've visited or not, or click on a trade good price to show how prices change throughout the galaxy. If you have a route planned already, this can be combined with a control-click to inspect trade good prices at stops along the way. A key will be shown on the right to let you know what colors mean in any given mode.`
+	`The ports panel shows you where systems with spaceports are, as well as a plethora of other information. Clicking on the name of the system, the government of the system, the lines under the name of each planet, or any trade commodity will color the map differently, the key to which can be seen on the right side of the screen.`
+	`Clicking the name of a planet, or clicking on a planet in the orbit map on the right side of the screen, will show that planet's description if you have visited it already. Clicking a planet on the orbit map will also tell your auto-pilot to land on that planet after you have arrived at that system at the end of your jump path.`
 
 help "map advanced shops"
-	`Both the Shipyard and Outfitter panels give the same information: A catalog of any items you've seen in your career, providing detailed statistics at any time. Items will be in categories on the left side of the screen, which can be collapsed individually, or all at once with shift-click on a category name. You can also use the "Find" button in the bottom right to search by name.`
-	`When selecting an item, the details will appear in the top-right. Ports which sell it will be colored yellow, while ports with the correct shop but not the item will be colored teal. You can compare what you've selected with a second item with shift-click, which will put both details side-by-side.`
+	`The shipyard and outfitter map panels respectively display the ships and outfits sold on any planets that you have seen. Ships and outfits are displayed in categories which can be collapsed by clicking on the category name. Using Shift+click on a category name will collapse or uncollapse all the categories at once.`
+	`Each ship or outfit can be clicked on, displaying that item's stats while also highlighting any planets where it is sold. Using Shift+click on a ship or outfit after you already have one selected will display that item's stats side by side the the previously selected item.`
 
 help "multiple ships"
 	`Now that you have more than one ship, while landed on a planet you can reorder the ships in your fleet by clicking and dragging them in the shipyard, outfitter, or player info panel. You will use the first ship in the list as your flagship. In the player info panel you can also "park" a ship on a planet if you want to travel somewhere without it coming with you.`
 
 help "multiple ship controls"
-	`When in flight with multiple ships, you have a variety of detailed commands you can give them. A full list can be seen in the Preferences pane, with <Fleet: Hold position> to have your fleet hold position, or <Fleet: Fight my target> to have your fleet focus your target as examples. These orders will apply to all ships by default, or to your selected ones, if any.`
-	`You can select specific escorts by directly clicking on them, or clicking and dragging your mouse to select a group with a box. These groups can be saved with a control group, by setting one with Control+number key, then recalled with that number key. These can also be set in the Player Info panel, accessed with <View player info>.`
-	`Escorts can also be commanded with the mouse. Right Click on empty space will order escorts to fly to and hold a position, while a click on a hostile ship will focus fire, and a click on a friendly target will cause them to follow.`
+	`Once you're in space with multiple ships that you own, you can give orders to those escorts. Orders will be given to all selected escorts, or if no escorts are selected then all your escorts will receive the order. Escorts can be selected by either clicking on them in space, clicking the ship icon at the bottom left of the screen, or by clicking and dragging to select a group of escorts in space. The list of escort order keys can be found in the preferences panel.`
+	`Escorts can also be ordered with the mouse. Right clicking on an empty point in space will order escorts to fly to and hold position at that point, while right clicking on a hostile ship will order your escorts to focus fire on it, and right clicking on a friendly target will cause them to follow it.`
+	`Escorts can be saved into control groups by pressing Control+number key. All selected escorts will then be bound to that number key, selecting the group when pressed.`
 
 help "navigation"
 	`Welcome to the sky! To travel to another star system, press <View star map> to view your map, and click on the system you want to travel to. Your hyperdrive can only travel along the "links" shown on your map. After selecting a destination, close your map and press <Initiate hyperspace jump> to jump to that system.`
@@ -102,7 +102,7 @@ help "outfitter"
 	`As in the trading panel, you can hold down Shift, Control, or Alt to buy 5, 20, or 500 of an outfit at once, or multiple keys for larger amounts.`
 
 help "outfitter 2"
-	`Sometimes you may want to buy some outfits directly into your cargo hold instead of having them installed. Perhaps a mission has asked you to retrieve some outfits or you want to carry extra ammunition to refill your ships somewhere that does not stock those weapons. To accomplish this, you need to switch out of installation mode into 'purchase to cargo' mode. This can be achieved by either checking the "show outfits in cargo" box at the bottom left, or control-clicking on your selected ship to deselect it.`
+	`Sometimes you may want to buy some outfits directly into your cargo hold instead of having them installed. Perhaps a mission has asked you to retrieve some outfits or you want to carry extra ammunition to refill your ships somewhere that does not stock those weapons. To accomplish this, you need to switch out of installation mode into 'purchase to cargo' mode. This can be achieved by either checking the "show outfits in cargo" box at the bottom left, or Control+clicking on your selected ship to deselect it.`
 	`When you are in 'purchase to cargo' mode, your ship information on the right hand side will be replaced by information on how much cargo space you currently have available.`
 	`Outfits that are in your cargo hold can be (re)installed at any outfitter without cost.`
 

--- a/data/help.txt
+++ b/data/help.txt
@@ -12,6 +12,9 @@ help "bank"
 	`This is the bank. Here, you can apply for new mortgages, if your income and credit history allows it. The bank is also a good place to get an overview of your daily expenses: mortgage payments, crew salaries, etc.`
 	`Paying off a mortgage early means you pay less interest to the bank, but it is sometimes wiser to instead use your money to buy a bigger ship which can earn you more income.`
 
+help "bank advanced"
+	`When entering a credit value at the bank, you can put in an exact number, or uses suffixes (K, M, B, T) as shorthand. Entering a value such as "100k" would count as 100,000 credits, for example. Entering a number higher than available will count as the maximum.`
+
 help "basics 1"
 	`Press <View star map> to bring up your map. Select a destination, then close the map and press <Initiate hyperspace jump> to jump. Press <Land on planet / station> to land.`
 
@@ -65,8 +68,25 @@ help "lost 7"
 help "map"
 	`This map shows all the star systems you know about and the hyperspace links between them. You can use the map to plot a hyperspace course by clicking on the system you want to travel to. To initiate a jump to that system, close the map and press <Initiate hyperspace jump>.`
 
+help "map advanced"
+	`As you explore more of the galaxy, the star map will quickly become a very powerful tool. Clicking on a distant system will automatically plot the quickest route to it. If you have missions spread across several systems, you can shift-click each to plot a route between them, or control-click a system to inspect missions there without setting a route.`
+	`There are also many other useful modes the map can be set to. Click on one of the buttons in the lower right corner to learn more.`
+
+help "map advanced ports"
+	`The Ports panel provides detailed information about every planet, station, or other stellar objects you've come across. Most information can be clicked on (like the word "Outfitter", or on the price of a trade good), which will color every system on the star map appropriately.`
+	`For instance, you can click on "(has been visited)" to see which planets you've visited or not, or click on a trade good price to show how prices change throughout the galaxy. If you have a route planned already, this can be combined with a control-click to inspect trade good prices at stops along the way. A key will be shown on the right to let you know what colors mean in any given mode.`
+
+help "map advanced shops"
+	`Both the Shipyard and Outfitter panels give the same information: A catalog of any items you've seen in your career, providing detailed statistics at any time. Items will be in categories on the left side of the screen, which can be collapsed individually, or all at once with shift-click on a category name. You can also use the "Find" button in the bottom right to search by name.`
+	`When selecting an item, the details will appear in the top-right. Ports which sell it will be colored yellow, while ports with the correct shop but not the item will teal. You can compare what you've selected with a second item with shift-click, which will put both details side-by-side.`
+
 help "multiple ships"
 	`Now that you have more than one ship, while landed on a planet you can reorder the ships in your fleet by clicking and dragging them in the shipyard, outfitter, or player info panel. You will use the first ship in the list as your flagship. In the player info panel you can also "park" a ship on a planet if you want to travel somewhere without it coming with you.`
+
+help "multiple ship controls"
+	`When in flight with multiple ships, you have a variety of detailed commands you can give them. A full list can be seen in the Preferences pane, with <Fleet: Hold position> to have your fleet hold position, or <Fleet: Fight my target> to have your fleet focus your target as examples. These orders will apply to all ships by default, or to your selected ones, if any.`
+	`You can select specific escorts by directly clicking on them, or clicking and dragging your mouse to select a group with a box. These groups can be saved with a control group, by setting one with Control+number key, then recalled with that number key. These can also be set in the Player Info panel, accessed with <View player info>.`
+	`Escorts can also be commanded with the mouse. Right Click on empty space will order escorts to fly to and hold a position, while a click on a hostile ship will focus fire, and a click on a friendly target will cause them to follow.`
 
 help "navigation"
 	`Welcome to the sky! To travel to another star system, press <View star map> to view your map, and click on the system you want to travel to. Your hyperdrive can only travel along the "links" shown on your map. After selecting a destination, close your map and press <Initiate hyperspace jump> to jump to that system.`

--- a/data/help.txt
+++ b/data/help.txt
@@ -79,7 +79,7 @@ help "map advanced ports"
 
 help "map advanced shops"
 	`The shipyard and outfitter map panels respectively display the ships and outfits sold on any planets that you have seen. Ships and outfits are displayed in categories which can be collapsed by clicking on the category name. Using Shift+click on a category name will collapse or uncollapse all the categories at once.`
-	`Each ship or outfit can be clicked on, displaying that item's stats while also highlighting any planets where it is sold. Using Shift+click on a ship or outfit after you already have one selected will display that item's stats side by side the the previously selected item.`
+	`Each ship or outfit can be clicked on, displaying that item's stats while also highlighting any planets where it is sold. Using Shift+click on a ship or outfit after you already have one selected will display that item's stats side by side with the previously selected item.`
 
 help "multiple ships"
 	`Now that you have more than one ship, while landed on a planet you can reorder the ships in your fleet by clicking and dragging them in the shipyard, outfitter, or player info panel. You will use the first ship in the list as your flagship. In the player info panel (accessed with <View player info>) you can also "park" a ship on a planet if you want to travel somewhere without it coming with you.`

--- a/data/help.txt
+++ b/data/help.txt
@@ -13,7 +13,8 @@ help "bank"
 	`Paying off a mortgage early means you pay less interest to the bank, but it is sometimes wiser to instead use your money to buy a bigger ship which can earn you more income.`
 
 help "bank advanced"
-	`When entering a credit value at the bank, you can put in an exact number, or uses suffixes (K, M, B, T) as shorthand. Entering a value such as "100k" would count as 100,000 credits, for example. Entering a number higher than available will count as the maximum.`
+	`When entering a credit value at the bank, you can put in an exact number, or uses suffixes K, M, B, and T as shorthand for thousands, millions, billions, and trillions. For example, entering a value such as "100k" would count as 100,000 credits.`
+	`Entering a number that is higher than what you or the bank have available depending if you are paying or applying for a loan will default to the maximum available value. For example, enterting "1m" to pay off a 100,000 credit loan will completely pay off the loan without giving extra, should you have available credits.`
 
 help "basics 1"
 	`Press <View star map> to bring up your map. Select a destination, then close the map and press <Initiate hyperspace jump> to jump. Press <Land on planet / station> to land.`
@@ -69,8 +70,8 @@ help "map"
 	`This map shows all the star systems you know about and the hyperspace links between them. You can use the map to plot a hyperspace course by clicking on the system you want to travel to. To initiate a jump to that system, close the map and press <Initiate hyperspace jump>.`
 
 help "map advanced"
-	`As you explore more of the galaxy, the star map will quickly become a very powerful tool. Clicking on a distant system will automatically plot the quickest route to it. If you have missions spread across several systems, you can shift-click each to plot a route between them, or control-click a system to inspect missions there without setting a route.`
-	`There are also many other useful modes the map can be set to. Click on one of the buttons in the lower right corner to learn more.`
+	`As you explore more of the galaxy, the star map will quickly become a very powerful tool. Clicking on a distant system will automatically plot the quickest route to it. You can shift-click on systems to plot a route between them, or control-click to select it there setting a route.`
+	`There are many other useful modes the map can be set to. Click on one of the buttons in the lower right corner to learn more.`
 
 help "map advanced ports"
 	`The Ports panel provides detailed information about every planet, station, or other stellar objects you've come across. Most information can be clicked on (like the word "Outfitter", or on the price of a trade good), which will color every system on the star map appropriately.`

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -273,12 +273,17 @@ bool BankPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	else if(key == SDLK_DOWN && selectedRow < mortgageRows)
 		++selectedRow;
 	else if(key == SDLK_RETURN && selectedRow < mortgageRows)
+	{
 		GetUI()->Push(new Dialog(this, &BankPanel::PayExtra,
 			"Paying off part of this debt will reduce your daily payments and the "
 			"interest that it costs you. How many extra credits will you pay?"));
-	else if(key == SDLK_RETURN && qualify)
+		DoHelp("bank advanced");
+	}
+	else if(key == SDLK_RETURN && qualify) {
 		GetUI()->Push(new Dialog(this, &BankPanel::NewMortgage,
 			"Borrow how many credits?"));
+		DoHelp("bank advanced");
+	}
 	else if(key == 'a')
 	{
 		// Pay all mortgages, skipping any you cannot afford to pay entirely.

--- a/source/Hazard.cpp
+++ b/source/Hazard.cpp
@@ -42,7 +42,7 @@ void Hazard::Load(const DataNode &node)
 			minDuration = max(0, static_cast<int>(child.Value(1)));
 			maxDuration = max(minDuration, (child.Size() >= 3 ? static_cast<int>(child.Value(2)) : 0));
 		}
-		else if (key == "strength")
+		else if(key == "strength")
 		{
 			minStrength = max(0., child.Value(1));
 			maxStrength = max(minStrength, (child.Size() >= 3) ? child.Value(2) : 0.);

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -107,6 +107,8 @@ void MainPanel::Step()
 		shared_ptr<Ship> target = flagship->GetTargetShip();
 		if(isActive && target && target->IsDisabled() && !target->GetGovernment()->IsEnemy())
 			isActive = !DoHelp("friendly disabled");
+		if(isActive && player.Ships().size() > 1)
+			isActive = !DoHelp("multiple ship controls");
 		if(isActive && !flagship->IsHyperspacing() && flagship->Position().Length() > 10000.
 				&& player.GetDate() <= GameData::Start().GetDate() + 4)
 		{

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -106,7 +106,6 @@ void MapDetailPanel::Step()
 		DoHelp("map");
 	if(GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
 		DoHelp("map advanced ports");
-	
 }
 
 

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -104,7 +104,7 @@ void MapDetailPanel::Step()
 	MapPanel::Step();
 	if(!player.GetPlanet())
 		DoHelp("map");
-	if (GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
+	if(GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
 		DoHelp("map advanced ports");
 	
 }

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -39,6 +39,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Sprite.h"
 #include "SpriteSet.h"
 #include "SpriteShader.h"
+#include "StartConditions.h"
 #include "StellarObject.h"
 #include "System.h"
 #include "Trade.h"
@@ -103,6 +104,9 @@ void MapDetailPanel::Step()
 	MapPanel::Step();
 	if(!player.GetPlanet())
 		DoHelp("map");
+	if (GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
+		DoHelp("map advanced ports");
+	
 }
 
 

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -174,7 +174,7 @@ int MapOutfitterPanel::FindItem(const string &text) const
 
 void MapOutfitterPanel::DrawItems()
 {
-	if (GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
+	if(GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
 		DoHelp("map advanced shops");
 	list.clear();
 	Point corner = Screen::TopLeft() + Point(0, scroll);

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -20,8 +20,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Point.h"
 #include "Screen.h"
 #include "Sprite.h"
+#include "StartConditions.h"
 #include "StellarObject.h"
 #include "System.h"
+#include "UI.h"
 
 #include <algorithm>
 #include <cmath>
@@ -172,6 +174,8 @@ int MapOutfitterPanel::FindItem(const string &text) const
 
 void MapOutfitterPanel::DrawItems()
 {
+	if (GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
+		DoHelp("map advanced shops");
 	list.clear();
 	Point corner = Screen::TopLeft() + Point(0, scroll);
 	for(const string &category : categories)

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -161,7 +161,7 @@ int MapShipyardPanel::FindItem(const string &text) const
 
 void MapShipyardPanel::DrawItems()
 {
-	if (GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
+	if(GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
 		DoHelp("map advanced shops");
 	list.clear();
 	Point corner = Screen::TopLeft() + Point(0, scroll);

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -160,7 +160,7 @@ int MapShipyardPanel::FindItem(const string &text) const
 
 
 void MapShipyardPanel::DrawItems()
-{ 
+{
 	if (GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
 		DoHelp("map advanced shops");
 	list.clear();

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -20,8 +20,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Screen.h"
 #include "Ship.h"
 #include "Sprite.h"
+#include "StartConditions.h"
 #include "StellarObject.h"
 #include "System.h"
+#include "UI.h"
 
 #include <algorithm>
 #include <limits>
@@ -158,7 +160,9 @@ int MapShipyardPanel::FindItem(const string &text) const
 
 
 void MapShipyardPanel::DrawItems()
-{
+{ 
+	if (GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
+		DoHelp("map advanced shops");
 	list.clear();
 	Point corner = Screen::TopLeft() + Point(0, scroll);
 	for(const string &category : categories)

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -37,6 +37,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Sprite.h"
 #include "SpriteSet.h"
 #include "SpriteShader.h"
+#include "StartConditions.h"
 #include "System.h"
 #include "text/truncate.hpp"
 #include "UI.h"
@@ -190,6 +191,8 @@ MissionPanel::MissionPanel(const MapPanel &panel)
 void MissionPanel::Step()
 {
 	MapPanel::Step();
+	if (GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
+		DoHelp("map advanced");
 	DoHelp("jobs");
 }
 

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -191,7 +191,7 @@ MissionPanel::MissionPanel(const MapPanel &panel)
 void MissionPanel::Step()
 {
 	MapPanel::Step();
-	if (GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
+	if(GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= GameData::Start().GetDate() + 12)
 		DoHelp("map advanced");
 	DoHelp("jobs");
 }


### PR DESCRIPTION
## Feature Details
This PR adds new tutorials and tutorial calls to the game, which explain to the player many undocumented features of Endless Sky, either only documented in the wiki, or undocumented entirely.
These include:
- `bank advanced`: Opens when a player first pays off, or applies for a new loan, which explains suffixes available to them.
- `multiple ship controls`: Appears when first launching into space with additional ships, which explains fleet commands, right click to issue spacial commands, and control groups.

The following tutorials are advanced map panel tutorials that appear after roughly two weeks, while on planet. This is done so the player has time to gather a good amount of system, ship, and outfit knowledge, do the tutorial if it wasn't skipped, and so they are in a situation with less pressure, rather than busy navigating to their destination.

They also presume the player starts from the missions panel, which will redirect the player to look at the other panels. I personally did not notice those buttons until after Free Worlds, so hopefully that will help others notice it. A player can theoretically sequence break it by opening the map directly, but starting from the jobs panel is much more likely for new players, and accounting for it would be fairly complex, so I left it as-is.

- `map advanced`: Describes setting waypoints with shift+click, inspecting a system with control+click, searching for systems, before directing them to the other panels below.
- `map advanced ports`: Describes the functionality of the Ports map panel. It tells the player how the map can be filtered/colored by most text elements, looking at the color key to determine what they mean, and how that could be used to find trading opportunities.
- `map advanced shops`: A combo tutorial for the Shipyards/Outfitters map panels. It describes how it keeps track of all ships/outfits the player has seen in shops, how it can show where they're sold, how the player can search for them, how they can collapse all categories with shift+click, and how two items can be compared with shift+click.

Getting involved with the Endless Sky community and going on the Discord server has taught me tons of extremely useful, but hidden or obscure features of the game, even as recently as a week or two ago. However, these should be much more visible to a player in-game, whether new or long-time, and I hope these tutorials communicate that without overwhelming either type of player.

## UI Screenshots
N/A

## Testing Done
Tested that the new tutorials don't overlap over tutorials a new player would see first, and ensured the map tutorials only fired on planet, after the given date.

## Performance Impact
N/A