### PR TITLE
Syndicate logistics

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1659,6 +1659,155 @@ fleet "Large Syndicate"
 		"Vanguard (Missile)"
 		"Quicksilver (Proton)" 2
 
+fleet "Small Syndicate Logistics"
+	government "Syndicate"
+	names "syndicate logistics"
+	cargo 3
+	personality
+		confusion 25
+		timid appeasing
+	variant 40
+		"Star Barge (Armed)"
+	variant 30
+		"Freighter"
+	variant 20
+		"Freighter (Fancy)"
+	variant 20
+		"Freighter (Proton)"
+	variant 60
+		"Freighter"
+		"Wasp"
+	variant 20
+		"Freighter"
+		"Star Barge (Armed)" 2
+	variant 20
+		"Freighter"
+		"Shuttle" 2
+		"Quicksilver"
+	variant 50
+		"Bounder"
+	variant 30
+		"Bounder (Luxury)"
+		"Wasp"
+	variant 10
+		"Freighter"
+		"Wasp" 2
+	variant 1
+		"Flivver (Luxury)"
+	variant 1
+		"Flivver (Racing)"
+
+fleet "Large Syndicate Logistics"
+	government "Syndicate"
+	names "syndicate logistics"
+	cargo 4
+	personality
+		confusion 20
+		timid appeasing
+	variant 30
+		"Freighter" 2
+		"Quicksilver" 2
+	variant 10
+		"Freighter (Fancy)" 2
+	variant 10
+		"Freighter (Proton)" 2
+		"Quicksilver" 2
+	variant 50
+		"Bulk Freighter"
+		"Wasp (Proton)" 2
+	variant 50
+		"Bulk Freighter"
+		"Wasp"
+		"Wasp (Meteor)"
+	variant 20
+		"Bulk Freighter (Blaster)"
+		"Wasp" 2
+	variant 10
+		"Bulk Freighter (Heavy)"
+		"Wasp (Proton)" 2
+	variant 10
+		"Bulk Freighter (Proton)"
+		"Wasp (Proton)" 2
+	variant 10
+		"Bulk Freighter (Proton)"
+		"Wasp"
+		"Wasp (Meteor)"
+	variant 20
+		"Bulk Freighter"
+	variant 10
+		"Bulk Freighter (Blaster)"
+	variant 5
+		"Bulk Freighter (Heavy)"
+	variant 5
+		"Bulk Freighter (Proton)"
+	variant 20
+		"Star Barge (Armed)" 3
+	variant 10
+		"Bulk Freighter" 2
+		"Quicksilver" 1
+		"Splinter" 1
+	variant 4
+		"Bulk Freighter (Blaster)"
+		"Bulk Freighter (Heavy)"
+		"Quicksilver" 1
+		"Splinter (Laser)" 1
+	variant 4
+		"Bulk Freighter (Blaster)"
+		"Bulk Freighter (Proton)"
+		"Quicksilver" 1
+		"Splinter (Proton)" 1
+	variant 10
+		"Freighter" 4
+		"Quicksilver" 2
+		"Splinter" 1
+	variant 3
+		"Freighter" 4
+		"Quicksilver" 2
+		"Splinter (Laser)" 1
+	variant 3
+		"Freighter" 4
+		"Quicksilver" 2
+		"Splinter (Proton)" 1
+	variant 10
+		"Freighter" 4
+		"Protector" 1
+	variant 2
+		"Freighter" 4
+		"Protector (Laser)" 1
+	variant 2
+		"Freighter" 4
+		"Protector (Proton)" 1
+	variant 10
+		"Bulk Freighter" 2
+		"Protector" 1
+	variant 10
+		"Bulk Freighter" 2
+		"Wasp" 3
+		"Wasp (Meteor)" 2
+	variant 10
+		"Bulk Freighter" 2
+		"Vanguard" 1
+	variant 1
+		"Bulk Freighter (Heavy)" 2
+		"Protector (Laser)" 1
+	variant 1
+		"Bulk Freighter (Proton)" 2
+		"Protector (Proton)" 1
+	variant 1
+		"Bulk Freighter (Heavy)" 2
+		"Vanguard (Particle)" 1
+	variant 1
+		"Bulk Freighter (Heavy)" 2
+		"Vanguard (Missile)" 1
+	variant 20
+		"Bounder"
+		"Quicksilver" 2
+	variant 5
+		"Arrow"
+		"Wasp (Proton)" 2
+	variant 2
+		"Arrow"
+
 fleet "Small Southern Pirates"
 	government "Pirate"
 	names "pirate"

--- a/data/human/names.txt
+++ b/data/human/names.txt
@@ -3076,8 +3076,56 @@ phrase "syndicate logistics"
 		"Parsimony"
 		"Profit"
 		"20 Yards of Linen"
-		"1 Coat"
+
+phrase "syndicate logistics"
+	phrase
+		"one to twelve"
+	phrase
+		"digit"
+	word
+		" rolls of "
+	phrase
+		"commodities counted by rolls"
 		
+phrase "syndicate logistics"
+	phrase
+		"one to twelve"
+	phrase
+		"digit"
+	word
+		" tons of "
+	phrase
+		"commodities counted by tons"
+		
+phrase "syndicate logistics"
+	phrase
+		"one to twelve"
+	phrase
+		"digit"
+	word
+		" drums of "
+	phrase
+		"commodities counted by drums"
+		
+phrase "syndicate logistics"
+	phrase
+		"one to twelve"
+	phrase
+		"digit"
+	word
+		" casks of "
+	phrase
+		"commodities counted by casks"
+		
+phrase "syndicate logistics"
+	phrase
+		"one to twelve"
+	phrase
+		"digit"
+	word
+		" pallets of "
+	phrase
+		"commodities counted by pallets"
 	
 phrase "republic fighter"
 	word

--- a/data/human/names.txt
+++ b/data/human/names.txt
@@ -3102,10 +3102,30 @@ phrase "syndicate logistics"
 		"one to twelve"
 	phrase
 		"digit"
+	word
+		" rolls of "
 	phrase
-		" rolls of ${commodities counted by rolls}"
-		" casks of ${commodities counted by casks}"
-		" heads of ${commodities counted by heads}"
+		"commodities counted by rolls"
+
+phrase "syndicate logistics"
+	phrase
+		"one to twelve"
+	phrase
+		"digit"
+	word
+		" casks of "
+	phrase
+		"commodities counted by casks"
+		
+phrase "syndicate logistics"
+	phrase
+		"one to twelve"
+	phrase
+		"digit"
+	word
+		" heads of "
+	phrase
+		"commodities counted by heads"
 		
 phrase "syndicate logistics"
 	phrase

--- a/data/human/names.txt
+++ b/data/human/names.txt
@@ -2830,7 +2830,7 @@ phrase "commodities counted by rolls"
 		Nylon
 		Fiberglass
 
-phrase "commodities counted by tonnage"
+phrase "commodities counted by tons"
 	word
 		Feed
 		Apples

--- a/data/human/names.txt
+++ b/data/human/names.txt
@@ -3076,16 +3076,6 @@ phrase "syndicate logistics"
 		"Parsimony"
 		"Profit"
 		"20 Yards of Linen"
-
-phrase "syndicate logistics"
-	phrase
-		"one to twelve"
-	phrase
-		"digit"
-	word
-		" rolls of "
-	phrase
-		"commodities counted by rolls"
 		
 phrase "syndicate logistics"
 	phrase
@@ -3108,14 +3098,14 @@ phrase "syndicate logistics"
 		"commodities counted by drums"
 		
 phrase "syndicate logistics"
-	phrase
-		"one to twelve"
-	phrase
-		"digit"
-	word
-		" casks of "
-	phrase
-		"commodities counted by casks"
+  phrase
+    "one to twelve"
+  phrase
+    "digit"
+  phrase
+	" rolls of ${commodities counted by rolls}"
+    " casks of ${commodities counted by casks}"
+    " heads of ${commodities counted by heads}"
 		
 phrase "syndicate logistics"
 	phrase

--- a/data/human/names.txt
+++ b/data/human/names.txt
@@ -3098,14 +3098,14 @@ phrase "syndicate logistics"
 		"commodities counted by drums"
 		
 phrase "syndicate logistics"
-  phrase
-    "one to twelve"
-  phrase
-    "digit"
-  phrase
-	" rolls of ${commodities counted by rolls}"
-    " casks of ${commodities counted by casks}"
-    " heads of ${commodities counted by heads}"
+	phrase
+		"one to twelve"
+	phrase
+		"digit"
+	phrase
+		" rolls of ${commodities counted by rolls}"
+		" casks of ${commodities counted by casks}"
+		" heads of ${commodities counted by heads}"
 		
 phrase "syndicate logistics"
 	phrase

--- a/data/human/names.txt
+++ b/data/human/names.txt
@@ -2591,6 +2591,494 @@ phrase "syndicate small"
 	phrase
 		"digit"
 
+phrase "commodities master"
+	word
+		Feed
+		Apple
+		Avocado
+		Apricot
+		Banana
+		Barley
+		Bean
+		Bread
+		Cereal
+		Butter
+		Anchovy
+		Artichoke
+		Chestnut
+		Fruit
+		Olive
+		Cattle
+		Cheese
+		Chocolate
+		"Cloned Meat"
+		Coffee
+		"Cooking Oil"
+		"Corn Oil"
+		Corn
+		Dairy
+		Egg
+		Fertilizer
+		Fish
+		"Frozen Pizza"
+		Garlic
+		Grain
+		Guava
+		Honey
+		Hops
+		Jerky
+		Lard
+		Mango
+		Molasses
+		Oat
+		"Olive Oil"
+		Onion
+		"Peanut Oil"
+		Pepper
+		Pickle
+		Pineapple
+		Potato
+		Prune
+		Pumpkin
+		"Purified Water"
+		Quinoa
+		Raisin
+		"Ready-to-eat Meal"
+		Rice
+		Salt
+		Seaweed
+		Sheep
+		Shiitake
+		Mushroom
+		"Snack Cake"
+		Soy
+		Spice
+		"Split Pea"
+		Sugar
+		Tea
+		Tortilla
+		Vanilla
+		Vinegar
+		Wheat
+		Yam
+		Aramid
+		"Body Armor"
+		Cloth
+		Tweed
+		Burlap
+		Canvas
+		Carpeting
+		Clothing
+		Coat
+		Cotton
+		Denim
+		Fabric
+		Hat
+		Helmet
+		Linen
+		Shoe
+		Rayon
+		Sailcloth
+		Sock
+		Swimsuit
+		Textile
+		Wool
+		Footwear
+		"Aluminized Steel"
+		Aluminum
+		Beryllium
+		Copper
+		Brass
+		Cadmium
+		Iron
+		Chromium
+		Copper Wire
+		Copper
+		Cupronickel
+		Gallium
+		"Gallium Arsenide"
+		"Galvanized Steel"
+		Indium
+		Manganese
+		"Metallic Foam"
+		Magnesium
+		Molybdenum
+		Monel
+		Nickel
+		Niobium
+		Ore
+		Osmium
+		Pig Iron
+		Platinum
+		Scandium
+		Silicon
+		Silver
+		"Stainless Steel"
+		Tin
+		Titanium
+		Vanadium
+		Zinc
+		Acetone
+		Asphalt
+		Bakelite
+		"Carbon Nanotube"
+		"Carbon Fiber"
+		"Crude Oil"
+		Dacron
+		"Diesel Oil"
+		Lacquer
+		Formaldehyde
+		Mylar
+		Nylon
+		"Organic Polymer"
+		Paint
+		Petrochemical
+		Petroleum
+		Plastics
+		Polyethylene
+		Polystyrene
+		Resin
+		Rubber
+		PVC
+		Xylene
+		Whiskey
+		Antibacterials
+		Antibiotics
+		Antivirals
+		"Artificial Organ"
+		Coffin
+		Pharmaceutical
+		Bleach
+		Clay
+		Diamond
+		Fiberglass
+		Gravel
+		Lubricant
+		Lumber
+		Paint
+		Pesticide
+		Pickle
+		Quicklime
+		Sand
+		Semiconductor
+		"Stem Bolt"
+		Timber
+		Varnish
+		Battery
+		Capacitor
+		PCB
+		Diode
+		"Haptic Material"
+		Microchip
+		Semiconductor
+		Silicone
+		Barium
+		Bismuth
+		Uranium
+		Gold
+		Lead
+		Mercury
+		Neodymium
+		Neptunium
+		Plutonium
+		Polonium
+		Unobtanium
+		Thorium
+		Tungsten
+		Brandy
+		Champagne
+		Cigar
+		Cognac
+		Cosmetic
+		Jewelry
+		Leather
+		Liqueur
+		Lobster
+		Marble
+		Water
+		Orchid
+		Perfume
+		Porcelain
+		Saffron
+		Silk
+		Tobacco
+		Vodka
+		Wine
+		Manure
+		Garbage
+		
+
+phrase "commodities counted by rolls"
+	word
+		Aramid
+		Cloth
+		Tweed
+		Burlap
+		Canvas
+		Carpeting
+		Denim
+		Fabric
+		Linen
+		Rayon
+		Sailcloth
+		Textiles
+		"Copper Wire"
+		"Carbon Nanotubes"
+		"Carbon Fiber"
+		Dacron
+		Mylar
+		Nylon
+		Fiberglass
+
+phrase "commodities counted by tonnage"
+	word
+		Feed
+		Apples
+		Avocados
+		Apricots
+		Barley
+		Beans
+		Bread
+		Cereal
+		Butter
+		Anchovies
+		Chestnuts
+		Fruit
+		Olives
+		Cheese
+		Chocolate
+		"Cloned Meat"
+		"Coffee Beans"
+		Corn
+		Eggs
+		Fertilizer
+		Fish
+		"Frozen Pizza"
+		Garlic
+		Grain
+		Guava
+		Hops
+		Jerky
+		Lard
+		Mangoes
+		Oats
+		Onions
+		Peppers
+		Pineapples
+		Potatoes
+		Prunes
+		Pumpkins
+		Quinoa
+		Raisins
+		Rice
+		Seaweed
+		Shiitake
+		Mushrooms
+		Soy
+		"Split Peas"
+		Sugar
+		Tea
+		Vanilla
+		Wheat
+		Yams
+		Cotton
+		Shoes
+		Wool
+		"Aluminized Steel"
+		Aluminum
+		Beryllium
+		Copper
+		Brass
+		Cadmium
+		Iron
+		Chromium
+		Copper
+		Cupronickel
+		Gallium
+		"Gallium Arsenide"
+		"Galvanized Steel"
+		Indium
+		Manganese
+		Magnesium
+		Molybdenum
+		Monel
+		Nickel
+		Niobium
+		Ore
+		Osmium
+		"Pig Iron"
+		Platinum
+		Scandium
+		Silicon
+		Silver
+		"Stainless Steel"
+		Tin
+		Titanium
+		Vanadium
+		Zinc
+		"Artificial Organs"
+		Pharmaceuticals
+		Clay
+		Diamonds
+		Gravel
+		Sand
+		"Haptic Materials"
+		Microchips
+		Semiconductors
+		Barium
+		Bismuth
+		Uranium
+		Gold
+		Lead
+		Neodymium
+		Neptunium
+		Plutonium
+		Polonium
+		Unobtanium
+		Thorium
+		Tungsten
+		Leather
+		Lobster
+		Marble
+		Orchids
+		Manure
+		Garbage
+
+phrase "commodities counted by drums"
+	word
+		"Cooking Oil"
+		"Corn Oil"
+		Molasses
+		Honey
+		"Olive Oil"
+		"Peanut Oil"
+		"Purified Water"
+		Salt
+		Spice
+		Vinegar
+		Gallium
+		"Metallic Foam"
+		Acetone
+		Asphalt
+		Bakelite
+		"Crude Oil"
+		"Diesel Oil"
+		Lacquer
+		Formaldehyde
+		Paint
+		Petrochemicals
+		Petroleum
+		Resin
+		Xylene
+		Antibacterials
+		Antibiotics
+		Antivirals
+		Bleach
+		Lubricant
+		Paint
+		Quicklime
+		Varnish
+		Silicone
+		Mercury
+		Perfume
+		Vodka
+	
+phrase "commodities counted by casks"
+	word
+		Dairy
+		Pickles
+		Spice
+		Whiskey
+		Brandy
+		Cognac
+		Liquer
+		Wine
+	
+phrase "commodities counted by pallets"
+	word
+		"Ready-to-eat Meals"
+		"Snack Cakes"
+		"Microwave Burritos"
+		"Frozen Pizzas"
+		Tea
+		Tortillas
+		"Body Armor"
+		Clothing
+		Coats
+		Hats
+		Helmets
+		Socks
+		Swimsuits
+		Textiles
+		Footwear
+		"Organic Polymer"
+		Plastics
+		Polyethylene
+		Polystyrene
+		Rubber
+		PVC
+		Coffins
+		Semiconductors
+		"Stem Bolts"
+		Timber
+		Batteries
+		Capacitors
+		PCBs
+		Diodes
+		Champagne
+		Cigars
+		Cosmetics
+		Jewelry
+		Vodka
+		Wine
+
+phrase "commodities counted by heads"
+	word
+		Cattle
+		Sheep
+		Swine
+		Goat
+		"Cloned Bovine-Derived Entity"
+
+
+phrase "syndicate logistics"
+	word
+		"S.L. "
+	word
+		"Invisible Hand"
+		"Perfectly Inelastic"
+		"Perfectly Elastic"
+		"Wealth of Nations"
+		"Absolute Advantage"
+		"Windfall"
+		"Capital"
+		"Venture"
+		"Utility"
+		"Tax Writeoff"
+		"Total Return"
+		"Trust"
+		"Supply"
+		"Sunk Cost"
+		"Rationality"
+		"Risk-free"
+		"Purchasing Power"
+		"Free Enterprise"
+		"Normal Goods"
+		"Market Forces"
+		"Slim Margin"
+		"Liquidity"
+		"Interest"
+		"Hot Money"
+		"First Mover"
+		"Expected Return"
+		"Equilibrium"
+		"Balance of Trade"
+		"Parsimony"
+		"Profit"
+		"20 Yards of Linen"
+		"1 Coat"
+		
+	
 phrase "republic fighter"
 	word
 		"Red "

--- a/data/map.txt
+++ b/data/map.txt
@@ -1853,8 +1853,12 @@ system Acamar
 	trade Medical 576
 	trade Metal 249
 	trade Plastic 483
-	fleet "Large Core Merchants" 3000
-	fleet "Small Core Merchants" 2000
+	fleet "Large Core Merchants" 750
+	fleet "Small Core Merchants" 500
+	fleet "Large Syndicate Logistics" 750
+	fleet "Small Syndicate Logistics" 500
+	fleet "Large Syndicate Logistics" 1500
+	fleet "Small Syndicate Logistics" 1000
 	fleet "Small Republic" 3600
 	fleet "Small Syndicate" 3200
 	object
@@ -1911,10 +1915,12 @@ system Achernar
 	trade Medical 775
 	trade Metal 289
 	trade Plastic 337
-	fleet "Large Core Merchants" 400
+	fleet "Large Core Merchants" 200
 	fleet "Large Syndicate" 600
 	fleet "Small Syndicate" 500
-	fleet "Small Core Merchants" 300
+	fleet "Small Core Merchants" 150
+	fleet "Large Syndicate Logistics" 200
+	fleet "Small Syndicate Logistics" 150
 	fleet "Human Miners" 3000
 	fleet "Republic Logistics" 6000
 	object
@@ -2231,8 +2237,10 @@ system "Al Dhanab"
 	trade Medical 718
 	trade Metal 262
 	trade Plastic 317
-	fleet "Small Core Merchants" 400
-	fleet "Large Core Merchants" 400
+	fleet "Small Core Merchants" 200
+	fleet "Large Core Merchants" 200
+	fleet "Large Syndicate Logistics" 200
+	fleet "Small Syndicate Logistics" 200
 	fleet "Small Syndicate" 1000
 	fleet "Large Syndicate" 800
 	fleet "Republic Logistics" 5300
@@ -2542,8 +2550,10 @@ system Alderamin
 	trade Medical 475
 	trade Metal 237
 	trade Plastic 373
-	fleet "Small Core Merchants" 2000
-	fleet "Large Core Merchants" 3200
+	fleet "Small Core Merchants" 1000
+	fleet "Large Core Merchants" 1600
+	fleet "Large Syndicate Logistics" 1000
+	fleet "Small Syndicate Logistics" 1600
 	fleet "Small Syndicate" 800
 	fleet "Large Syndicate" 800
 	fleet "Small Core Pirates" 1000
@@ -2788,8 +2798,10 @@ system Algol
 	trade Medical 560
 	trade Metal 322
 	trade Plastic 309
-	fleet "Small Core Merchants" 1600
-	fleet "Large Core Merchants" 4000
+	fleet "Small Core Merchants" 800
+	fleet "Large Core Merchants" 2000
+	fleet "Large Syndicate Logistics" 800
+	fleet "Small Syndicate Logistics" 2000
 	fleet "Small Core Pirates" 1800
 	fleet "Large Core Pirates" 5000
 	fleet "Small Syndicate" 2400
@@ -3283,9 +3295,10 @@ system Alnair
 	trade Medical 494
 	trade Metal 241
 	trade Plastic 467
-	fleet "Small Core Merchants" 2000
+	fleet "Small Core Merchants" 1000
 	fleet "Small Core Pirates" 3000
 	fleet "Large Core Pirates" 4000
+	fleet "Small Syndicate Logistics" 1000
 	fleet "Small Syndicate" 4000
 	fleet "Large Syndicate" 6000
 	fleet "Human Miners" 2000
@@ -3751,8 +3764,10 @@ system "Alpha Hydri"
 	trade Medical 531
 	trade Metal 324
 	trade Plastic 390
-	fleet "Small Core Merchants" 900
-	fleet "Large Core Merchants" 3000
+	fleet "Small Core Merchants" 450
+	fleet "Large Core Merchants" 1500
+	fleet "Large Syndicate Logistics" 1500
+	fleet "Small Syndicate Logistics" 450
 	fleet "Small Core Pirates" 2000
 	fleet "Large Core Pirates" 6000
 	fleet "Small Syndicate" 4000
@@ -3929,8 +3944,10 @@ system Alpheratz
 	trade Medical 713
 	trade Metal 340
 	trade Plastic 293
-	fleet "Small Core Merchants" 600
-	fleet "Large Core Merchants" 600
+	fleet "Small Core Merchants" 300
+	fleet "Large Core Merchants" 300
+	fleet "Large Syndicate Logistics" 300
+	fleet "Small Syndicate Logistics" 300
 	fleet "Small Syndicate" 800
 	fleet "Large Syndicate" 2000
 	fleet "Small Core Pirates" 1200
@@ -3990,8 +4007,10 @@ system Altair
 	trade Medical 534
 	trade Metal 335
 	trade Plastic 274
-	fleet "Small Core Merchants" 400
-	fleet "Large Core Merchants" 600
+	fleet "Small Core Merchants" 200
+	fleet "Large Core Merchants" 300
+	fleet "Large Syndicate Logistics" 200
+	fleet "Small Syndicate Logistics" 300
 	fleet "Small Northern Merchants" 1000
 	fleet "Large Northern Merchants" 3000
 	fleet "Small Republic" 3000
@@ -4193,8 +4212,10 @@ system Ankaa
 	trade Medical 596
 	trade Metal 278
 	trade Plastic 353
-	fleet "Small Core Merchants" 600
-	fleet "Large Core Merchants" 700
+	fleet "Small Core Merchants" 300
+	fleet "Large Core Merchants" 350
+	fleet "Large Syndicate Logistics" 350
+	fleet "Small Syndicate Logistics" 300
 	fleet "Small Syndicate" 900
 	fleet "Large Core Pirates" 4000
 	object
@@ -5126,8 +5147,10 @@ system Bellatrix
 	trade Medical 846
 	trade Metal 422
 	trade Plastic 274
-	fleet "Small Core Merchants" 800
-	fleet "Large Core Merchants" 1500
+	fleet "Small Core Merchants" 400
+	fleet "Large Core Merchants" 750
+	fleet "Large Syndicate Logistics" 750
+	fleet "Small Syndicate Logistics" 400
 	fleet "Small Syndicate" 1000
 	fleet "Large Syndicate" 2000
 	fleet "Small Core Pirates" 3000
@@ -6262,8 +6285,10 @@ system Caph
 	trade Medical 532
 	trade Metal 323
 	trade Plastic 299
-	fleet "Small Core Merchants" 500
-	fleet "Large Core Merchants" 600
+	fleet "Small Core Merchants" 250
+	fleet "Large Core Merchants" 300
+	fleet "Large Syndicate Logistics" 300
+	fleet "Small Syndicate Logistics" 250
 	fleet "Small Syndicate" 1600
 	fleet "Human Miners" 2000
 	object
@@ -7724,8 +7749,10 @@ system "Delta Capricorni"
 	trade Medical 492
 	trade Metal 269
 	trade Plastic 292
-	fleet "Small Core Merchants" 700
-	fleet "Large Core Merchants" 800
+	fleet "Small Core Merchants" 350
+	fleet "Large Core Merchants" 400
+	fleet "Large Syndicate Logistics" 400
+	fleet "Small Syndicate Logistics" 350
 	fleet "Small Syndicate" 2000
 	fleet "Small Core Pirates" 4000
 	fleet "Human Miners" 3000
@@ -8072,8 +8099,10 @@ system Diphda
 	trade Medical 600
 	trade Metal 277
 	trade Plastic 392
-	fleet "Small Core Merchants" 2000
-	fleet "Large Core Merchants" 600
+	fleet "Small Core Merchants" 1000
+	fleet "Large Core Merchants" 300
+	fleet "Large Syndicate Logistics" 300
+	fleet "Small Syndicate Logistics" 1000
 	fleet "Small Syndicate" 3000
 	object
 		sprite star/k0
@@ -10785,8 +10814,10 @@ system Fomalhaut
 	trade Medical 531
 	trade Metal 285
 	trade Plastic 267
-	fleet "Small Core Merchants" 1000
-	fleet "Large Core Merchants" 1200
+	fleet "Small Core Merchants" 500
+	fleet "Large Core Merchants" 600
+	fleet "Large Syndicate Logistics" 600
+	fleet "Small Syndicate Logistics" 500
 	fleet "Small Syndicate" 5000
 	fleet "Large Syndicate" 10000
 	fleet "Republic Logistics" 3300
@@ -11946,8 +11977,10 @@ system Hamal
 	trade Medical 633
 	trade Metal 332
 	trade Plastic 404
-	fleet "Small Core Merchants" 1000
-	fleet "Large Core Merchants" 1000
+	fleet "Small Core Merchants" 500
+	fleet "Large Core Merchants" 500
+	fleet "Large Syndicate Logistics" 500
+	fleet "Small Syndicate Logistics" 500
 	fleet "Small Core Pirates" 3000
 	fleet "Large Core Pirates" 8000
 	fleet "Small Syndicate" 4000
@@ -14849,7 +14882,8 @@ system Kugel
 	trade Medical 512
 	trade Metal 335
 	trade Plastic 421
-	fleet "Small Core Merchants" 4000
+	fleet "Small Core Merchants" 2000
+	fleet "Small Syndicate Logistics" 2000
 	fleet "Small Republic" 6000
 	fleet "Small Syndicate" 8000
 	fleet "Large Core Pirates" 4000
@@ -15678,8 +15712,10 @@ system Markab
 	trade Medical 515
 	trade Metal 251
 	trade Plastic 281
-	fleet "Small Core Merchants" 500
-	fleet "Large Core Merchants" 600
+	fleet "Small Core Merchants" 250
+	fleet "Large Core Merchants" 300
+	fleet "Large Syndicate Logistics" 250
+	fleet "Small Syndicate Logistics" 300
 	fleet "Small Syndicate" 600
 	fleet "Large Syndicate" 800
 	fleet "Human Miners" 3000
@@ -15817,8 +15853,10 @@ system Matar
 	trade Medical 641
 	trade Metal 209
 	trade Plastic 407
-	fleet "Small Core Merchants" 2000
-	fleet "Large Core Merchants" 2500
+	fleet "Small Core Merchants" 1000
+	fleet "Large Core Merchants" 1750
+	fleet "Large Syndicate Logistics" 1750
+	fleet "Small Syndicate Logistics" 1000
 	fleet "Small Core Pirates" 2000
 	fleet "Large Core Pirates" 4000
 	fleet "Small Syndicate" 3000
@@ -16408,8 +16446,10 @@ system Menkar
 	trade Medical 769
 	trade Metal 396
 	trade Plastic 285
-	fleet "Small Core Merchants" 800
-	fleet "Large Core Merchants" 1000
+	fleet "Small Core Merchants" 400
+	fleet "Large Core Merchants" 500
+	fleet "Large Syndicate Logistics" 500
+	fleet "Small Syndicate Logistics" 400
 	fleet "Small Syndicate" 1500
 	fleet "Large Syndicate" 2000
 	fleet "Large Core Pirates" 4000
@@ -17012,8 +17052,10 @@ system Mirach
 	trade Medical 686
 	trade Metal 267
 	trade Plastic 299
-	fleet "Small Core Merchants" 1000
-	fleet "Large Core Merchants" 1200
+	fleet "Small Core Merchants" 500
+	fleet "Large Core Merchants" 600
+	fleet "Large Syndicate Logistics" 600
+	fleet "Small Syndicate Logistics" 500
 	fleet "Small Core Pirates" 4000
 	fleet "Small Syndicate" 3000
 	fleet "Large Syndicate" 5000
@@ -17080,8 +17122,10 @@ system Mirfak
 	trade Medical 811
 	trade Metal 451
 	trade Plastic 267
-	fleet "Small Core Merchants" 500
-	fleet "Large Core Merchants" 700
+	fleet "Small Core Merchants" 250
+	fleet "Large Core Merchants" 350
+	fleet "Large Syndicate Logistics" 350
+	fleet "Small Syndicate Logistics" 250
 	fleet "Small Syndicate" 1000
 	fleet "Large Syndicate" 1800
 	object
@@ -17251,8 +17295,10 @@ system Moktar
 	trade Medical 714
 	trade Metal 382
 	trade Plastic 345
-	fleet "Small Core Merchants" 1000
-	fleet "Large Core Merchants" 2000
+	fleet "Small Core Merchants" 500
+	fleet "Large Core Merchants" 1000
+	fleet "Large Syndicate Logistics" 1000
+	fleet "Small Syndicate Logistics" 500
 	fleet "Small Syndicate" 3000
 	fleet "Large Syndicate" 4000
 	fleet "Small Core Pirates" 2000
@@ -19231,8 +19277,10 @@ system Polaris
 	trade Medical 822
 	trade Metal 255
 	trade Plastic 418
-	fleet "Small Core Merchants" 600
-	fleet "Large Core Merchants" 700
+	fleet "Small Core Merchants" 300
+	fleet "Large Core Merchants" 350
+	fleet "Large Syndicate Logistics" 350
+	fleet "Small Syndicate Logistics" 300
 	fleet "Small Syndicate" 1000
 	fleet "Large Syndicate" 2000
 	fleet "Small Core Pirates" 1500
@@ -20740,8 +20788,10 @@ system Ruchbah
 	trade Medical 597
 	trade Metal 334
 	trade Plastic 353
-	fleet "Small Core Merchants" 500
-	fleet "Large Core Merchants" 600
+	fleet "Small Core Merchants" 250
+	fleet "Large Core Merchants" 300
+	fleet "Large Syndicate Logistics" 300
+	fleet "Small Syndicate Logistics" 250
 	fleet "Small Syndicate" 1000
 	fleet "Large Syndicate" 2000
 	fleet "Small Core Pirates" 2000
@@ -21484,8 +21534,10 @@ system Scheat
 	trade Medical 573
 	trade Metal 259
 	trade Plastic 312
-	fleet "Small Core Merchants" 500
-	fleet "Large Core Merchants" 600
+	fleet "Small Core Merchants" 250
+	fleet "Large Core Merchants" 300
+	fleet "Large Syndicate Logistics" 300
+	fleet "Small Syndicate Logistics" 250
 	fleet "Small Syndicate" 1000
 	fleet "Large Syndicate" 2000
 	fleet "Republic Logistics" 4700
@@ -21546,8 +21598,10 @@ system Schedar
 	trade Medical 743
 	trade Metal 325
 	trade Plastic 279
-	fleet "Small Core Merchants" 900
-	fleet "Large Core Merchants" 1000
+	fleet "Small Core Merchants" 450
+	fleet "Large Core Merchants" 500
+	fleet "Large Syndicate Logistics" 500
+	fleet "Small Syndicate Logistics" 450
 	fleet "Small Syndicate" 3000
 	fleet "Large Syndicate" 4000
 	fleet "Small Core Pirates" 2000
@@ -22027,8 +22081,10 @@ system Sheratan
 	trade Medical 596
 	trade Metal 306
 	trade Plastic 355
-	fleet "Small Core Merchants" 1500
-	fleet "Large Core Merchants" 1800
+	fleet "Small Core Merchants" 750
+	fleet "Large Core Merchants" 900
+	fleet "Large Syndicate Logistics" 900
+	fleet "Small Syndicate Logistics" 750
 	fleet "Small Core Pirates" 3000
 	fleet "Large Core Pirates" 5000
 	fleet "Korath Raid" 30000
@@ -22716,8 +22772,10 @@ system Sol
 	fleet "Small Republic" 600
 	fleet "Large Republic" 900
 	fleet "Republic Logistics" 2000
-	fleet "Small Core Merchants" 1000
-	fleet "Large Core Merchants" 2000
+	fleet "Small Core Merchants" 500
+	fleet "Large Core Merchants" 1000
+	fleet "Large Syndicate Logistics" 1000
+	fleet "Small Syndicate Logistics" 500
 	object
 		sprite star/g0
 		period 25.38
@@ -25602,8 +25660,10 @@ system Zaurak
 	trade Medical 671
 	trade Metal 292
 	trade Plastic 376
-	fleet "Small Core Merchants" 800
-	fleet "Large Core Merchants" 1000
+	fleet "Small Core Merchants" 400
+	fleet "Large Core Merchants" 500
+	fleet "Large Syndicate Logistics" 500
+	fleet "Small Syndicate Logistics" 400
 	fleet "Small Syndicate" 1600
 	fleet "Large Syndicate" 2500
 	fleet "Small Core Pirates" 2000


### PR DESCRIPTION
## Summary
New merchant-style fleets are added to the Core region, flying the Syndicate flag. Currently all Syndicate ships in the region are security forces - this gives them something to protect besides simply being space-police. 

The main motivation is to eventually allow for privateering on behalf of any factions in conflict with the Syndicate, or simply to allow someone to enjoy a pirate playstyle while only picking on a megacorporation instead of the "little guys". 

Changes:
-Name lists for Syndicate Logistics, named either after the maiden shipment of that particular vessel or economic jargon
-Syndicate Logistics spawn anywhere Core Merchants already were
-Core Merchants spawn at half the rate

## Save File
Start a new save (or load an old one) and scoot on over to the Core.

## Testing done
[currently underway]
 