### PR TITLE
Enough fuel renders as just one solid bar of fuel

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -633,8 +633,10 @@ void Engine::Step(bool isActive)
 		info.SetString("location", currentSystem->Name());
 	info.SetString("date", player.GetDate().ToString());
 	if(flagship)
-	{ //if there is a lot of fuel, display a solid homogenous bar instead of many notches in the bar
-		if ( flagship->Attributes().Get("fuel capacity") <= 1200)
+	{
+		const double fuelCap = 2000.;
+		// if there is a lot of fuel, display a solid homogenous bar instead of many notches in the bar
+		if ( flagship->Attributes().Get("fuel capacity") <= fuelCap)
 		{
 			info.SetBar("fuel", flagship->Fuel(),
 				flagship->Attributes().Get("fuel capacity") * .01);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -635,11 +635,12 @@ void Engine::Step(bool isActive)
 	if(flagship)
 	{
 		const double fuelCap = 2000.;
-		// if there is a lot of fuel, display a solid homogenous bar instead of many notches in the bar
-		if ( flagship->Attributes().Get("fuel capacity") <= fuelCap)
+		// If there is a lot of fuel, display a solid homogenous bar,
+		// instead of many notches in the bar.
+		if(flagship->Attributes().Get("fuel capacity") <= fuelCap)
 		{
 			info.SetBar("fuel", flagship->Fuel(),
-				flagship->Attributes().Get("fuel capacity") * .01);
+				    flagship->Attributes().Get("fuel capacity") * .01);
 		} else {
 			info.SetBar("fuel", flagship->Fuel());
 		}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -633,9 +633,14 @@ void Engine::Step(bool isActive)
 		info.SetString("location", currentSystem->Name());
 	info.SetString("date", player.GetDate().ToString());
 	if(flagship)
-	{
-		info.SetBar("fuel", flagship->Fuel(),
-			flagship->Attributes().Get("fuel capacity") * .01);
+	{ //if there is a lot of fuel, display a solid homogenous bar instead of many notches in the bar
+		if ( flagship->Attributes().Get("fuel capacity") <= 1200)
+		{
+			info.SetBar("fuel", flagship->Fuel(),
+				flagship->Attributes().Get("fuel capacity") * .01);
+		} else {
+			info.SetBar("fuel", flagship->Fuel());
+		}
 		info.SetBar("energy", flagship->Energy());
 		double heat = flagship->Heat();
 		info.SetBar("heat", min(1., heat));

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -634,16 +634,14 @@ void Engine::Step(bool isActive)
 	info.SetString("date", player.GetDate().ToString());
 	if(flagship)
 	{
-		const double fuelCap = 2000.;
+		const double MAX_FUEL_DISPLAY = 5000.;
+		double fuelCap = flagship->Attributes().Get("fuel capacity");
 		// If there is a lot of fuel, display a solid homogenous bar,
 		// instead of many notches in the bar.
-		if(flagship->Attributes().Get("fuel capacity") <= fuelCap)
-		{
-			info.SetBar("fuel", flagship->Fuel(),
-				    flagship->Attributes().Get("fuel capacity") * .01);
-		} else {
+		if(fuelCap <= MAX_FUEL_DISPLAY )
+			info.SetBar("fuel", flagship->Fuel(), fuelCap* .01);
+		else
 			info.SetBar("fuel", flagship->Fuel());
-		}
 		info.SetBar("energy", flagship->Energy());
 		double heat = flagship->Heat();
 		info.SetBar("heat", min(1., heat));

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -638,7 +638,7 @@ void Engine::Step(bool isActive)
 		double fuelCap = flagship->Attributes().Get("fuel capacity");
 		// If there is a lot of fuel, display a solid homogenous bar,
 		// instead of many notches in the bar.
-		if(fuelCap <= MAX_FUEL_DISPLAY )
+		if(fuelCap <= MAX_FUEL_DISPLAY)
 			info.SetBar("fuel", flagship->Fuel(), fuelCap* .01);
 		else
 			info.SetBar("fuel", flagship->Fuel());

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -187,6 +187,7 @@ namespace {
 	}
 	
 	const double RADAR_SCALE = .025;
+	const double MAX_FUEL_DISPLAY = 5000.;
 }
 
 
@@ -634,7 +635,6 @@ void Engine::Step(bool isActive)
 	info.SetString("date", player.GetDate().ToString());
 	if(flagship)
 	{
-		const double MAX_FUEL_DISPLAY = 5000.;
 		double fuelCap = flagship->Attributes().Get("fuel capacity");
 		// If there is a lot of fuel, display a solid homogenous bar,
 		// instead of many notches in the bar.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -636,10 +636,10 @@ void Engine::Step(bool isActive)
 	if(flagship)
 	{
 		double fuelCap = flagship->Attributes().Get("fuel capacity");
-		// If there is a lot of fuel, display a solid homogenous bar,
-		// instead of many notches in the bar.
+		// If the flagship has a large amount of fuel, display a solid bar.
+		// Otherwise, display a segment for every 100 fuel.
 		if(fuelCap <= MAX_FUEL_DISPLAY)
-			info.SetBar("fuel", flagship->Fuel(), fuelCap* .01);
+			info.SetBar("fuel", flagship->Fuel(), fuelCap * .01);
 		else
 			info.SetBar("fuel", flagship->Fuel());
 		info.SetBar("energy", flagship->Energy());


### PR DESCRIPTION
**Feature:** The fuel bar will not break into a million pieces if you have a very large amount of fuel

## Feature Details
If you have more than 1200 fuel (12 bars) on your ship, the fuel bar renders as one instead of 13 or 600 bars, or whatever crazy amount you may have.

## UI Screenshots
If you've ever flown a ship with only 100 fuel, you know what the bar will look like.

## Testing Done
Y'all are magicians testing these builds without some sort of game launcher that doesn't require you to compile the game by hand. Will heckin' test on ships with low fuel, and very high fuel, and fuel values not divisible by 100, after I make the pull request and ESL2 can grab this PR number. You know how it be.

## Performance Impact
Adds one check to a process I believe should occur once per frame, but I don't think checking the inequality of a variable to a constant is very intensive, this shouldn't impact anything.
