### PR TITLE
Add Ship Info tutorial

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -86,7 +86,7 @@ help "multiple ships"
 
 help "ship info"
 	`The Ship Info tab lets you view detailed information about ships in your fleet at any time. This gives any information you could see at a shipyard or outfitter on planet, along with showing how cargo and passengers are distributed among each ship.`
-	`Ships can be renamed in this panel by clicking on the ship name. You can also rearrange where guns or turrets are placed on your ship, by dragging the name of a weapon to another location. For example, you could place an anti-missile turret in a more central turret mount, or swap a long-range missile launcher near the front with a short-range beam weapon.`
+	`Ships can be renamed in this panel by clicking on the ship name. You can also rearrange where guns or turrets are placed on your ship while landed, by dragging the name of a weapon to another location. For example, you could place an anti-missile turret in a more central turret mount, or swap a long-range missile launcher near the front with a short-range beam weapon.`
 
 help "multiple ship controls"
 	`Once you're in space with multiple ships that you own, you can give orders to those escorts. Orders will be given to all selected escorts, or if no escorts are selected then all your escorts will receive the order. Escorts can be selected by either clicking on them in space, clicking the ship icon at the bottom left of the screen, or by clicking and dragging to select a group of escorts in space. The list of escort order keys can be found in the preferences panel.`

--- a/data/help.txt
+++ b/data/help.txt
@@ -85,8 +85,8 @@ help "multiple ships"
 	`Now that you have more than one ship, while landed on a planet you can reorder the ships in your fleet by clicking and dragging them in the shipyard, outfitter, or player info panel. You will use the first ship in the list as your flagship. In the player info panel (accessed with <View player info>) you can also "park" a ship on a planet if you want to travel somewhere without it coming with you.`
 
 help "ship info"
-	`The Ship Info tab lets you view detailed information about ships in your fleet at any time. This gives any information you could see at a shipyard or outfitter on planet, along with showing how cargo and passengers are distributed among each ship.`
-	`Ships can be renamed in this panel by clicking on the ship name. You can also rearrange where guns or turrets are placed on your ship while landed, by dragging the name of a weapon to another location. For example, you could place an anti-missile turret in a more central turret mount, or swap a long-range missile launcher near the front with a short-range beam weapon.`
+	`The ship info tab lets you view detailed information about ships in your fleet at any time. This includes any information you could see at a shipyard or outfitter, as well as the cargo and passengers distributed among each ship.`
+	`Ships can be renamed in this panel by clicking on the ship's name. While landed on a planet, you are able to change how guns and turrets are arranged by dragging the name of a weapon to another gun or turret location. While in flight, you are able to jettison individual pieces of cargo by clicking on the name of the cargo.`
 
 help "multiple ship controls"
 	`Once you're in space with multiple ships that you own, you can give orders to those escorts. Orders will be given to all selected escorts, or if no escorts are selected then all your escorts will receive the order. Escorts can be selected by either clicking on them in space, clicking the ship icon at the bottom left of the screen, or by clicking and dragging to select a group of escorts in space. The list of escort order keys can be found in the preferences panel.`

--- a/data/help.txt
+++ b/data/help.txt
@@ -86,7 +86,7 @@ help "multiple ships"
 
 help "ship info"
 	`The Ship Info tab lets you view detailed information about ships in your fleet at any time. This gives any information you could see at a shipyard or outfitter on planet, along with showing how cargo and passengers are distributed among each ship.`
-	`Ships can be renamed in this panel by clicking on the ship name. You can also rearrange where guns or turrets are placed on your ship, by dragging the name of a weapon to another location.`
+	`Ships can be renamed in this panel by clicking on the ship name. You can also rearrange where guns or turrets are placed on your ship, by dragging the name of a weapon to another location. For example, you could place an anti-missile turret in a more central turret mount, or swap a long-range missile launcher near the front with a short-range beam weapon.`
 
 help "multiple ship controls"
 	`Once you're in space with multiple ships that you own, you can give orders to those escorts. Orders will be given to all selected escorts, or if no escorts are selected then all your escorts will receive the order. Escorts can be selected by either clicking on them in space, clicking the ship icon at the bottom left of the screen, or by clicking and dragging to select a group of escorts in space. The list of escort order keys can be found in the preferences panel.`

--- a/data/help.txt
+++ b/data/help.txt
@@ -84,6 +84,10 @@ help "map advanced shops"
 help "multiple ships"
 	`Now that you have more than one ship, while landed on a planet you can reorder the ships in your fleet by clicking and dragging them in the shipyard, outfitter, or player info panel. You will use the first ship in the list as your flagship. In the player info panel (accessed with <View player info>) you can also "park" a ship on a planet if you want to travel somewhere without it coming with you.`
 
+help "ship info"
+	`The Ship Info tab lets you view detailed information about ships in your fleet at any time. This gives any information you could see at a shipyard or outfitter on planet, along with showing how cargo and passengers are distributed among each ship.`
+	`Ships can be renamed in this panel by clicking on the ship name. You can also rearrange where guns or turrets are placed on your ship, by dragging the name of a weapon to another location.`
+
 help "multiple ship controls"
 	`Once you're in space with multiple ships that you own, you can give orders to those escorts. Orders will be given to all selected escorts, or if no escorts are selected then all your escorts will receive the order. Escorts can be selected by either clicking on them in space, clicking the ship icon at the bottom left of the screen, or by clicking and dragging to select a group of escorts in space. The list of escort order keys can be found in the preferences panel.`
 	`Escorts can also be ordered with the mouse. Right clicking on an empty point in space will order escorts to fly to and hold position at that point, while right clicking on a hostile ship will order your escorts to focus fire on it, and right clicking on a friendly target will cause them to follow it.`

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -68,6 +68,13 @@ ShipInfoPanel::ShipInfoPanel(PlayerInfo &player, int index)
 
 
 
+void ShipInfoPanel::Step ()
+{
+	DoHelp("ship info");
+}
+
+
+
 void ShipInfoPanel::Draw()
 {
 	// Dim everything behind this panel.

--- a/source/ShipInfoPanel.h
+++ b/source/ShipInfoPanel.h
@@ -39,6 +39,7 @@ class ShipInfoPanel : public Panel {
 public:
 	explicit ShipInfoPanel(PlayerInfo &player, int index = -1);
 	
+	virtual void Step() override;
 	virtual void Draw() override;
 	
 	


### PR DESCRIPTION
## Feature Details
One last tutorial I hope to get in before the cutoff. Was considering putting it the original PR after I posted it, but it got merged so quickly!

This tutorial covers the Ship Info tab, more explicitly explaining how to re-arrange hardpoints, and describing the completely undocumented ability to rename ships. After seeing #5625 mention how they had to edit saves to rename ships, and other recent mentions on the Discord server, I figured this was worth getting in. It can be expanded if something like #4714 gets merged in the future, as well.

Very few code changes unlike #5622, just a simple override of Step() like the other panels.

## UI Screenshots
![image](https://user-images.githubusercontent.com/4471575/104416945-3de7d600-553a-11eb-9193-e00457fa747e.png)
