### PR TITLE
Fix stuck escorts after traveling through a wormhole

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1549,7 +1549,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 		}
 		
 		// If the ship has no destination or the destination is unreachable, route to the parent's system.
-		if(!ship.GetTargetStellar() && (!ship.GetTargetSystem() || !ship.JumpsRemaining()))
+		if(!ship.GetTargetStellar() && (!ship.GetTargetSystem() || !ship.JumpFuel(ship.GetTargetSystem())))
 		{
 			// Route to the parent ship's system and check whether
 			// the ship should land (refuel or wormhole) or jump.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1612,8 +1612,11 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 				{
 					ship.SetTargetStellar(&object);
 					ship.SetTargetSystem(nullptr);
-					MoveToPlanet(ship, command);
-					command |= Command::LAND;
+					if(parent.IsEnteringHyperspace() || parent.IsReadyToJump())
+					{
+						MoveToPlanet(ship, command);
+						command |= Command::LAND;
+					}
 					return;
 				}
 			}

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1548,7 +1548,8 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 				ship.SetTargetStellar(nullptr);
 		}
 		
-		if(!ship.GetTargetStellar() && !ship.GetTargetSystem())
+		// If the ship has no destination or the destination is unreachable, route to the parent's system.
+		if(!ship.GetTargetStellar() && (!ship.GetTargetSystem() || !ship.JumpsRemaining()))
 		{
 			// Route to the parent ship's system and check whether
 			// the ship should land (refuel or wormhole) or jump.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1433,7 +1433,7 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		int jumps = ship.JumpsRemaining(false);
 		// Each destination system has an average priority of 10.
 		// If you only have one jump left, landing should be high priority.
-		int planetWeight = jumps ? (1 + 40 / jumps) : 1;
+		int planetWeight = jumps ? 41 : 1;
 		
 		vector<int> systemWeights;
 		int totalWeight = 0;
@@ -3778,7 +3778,7 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 	// If this is a move command, make sure the fleet is bunched together
 	// enough that each ship takes up no more than about 30,000 square pixels.
 	double maxSquadOffset = sqrt(10000. * squadCount);
-
+	
 	// A target is valid if we have no target, or when the target is in the
 	// same system as the flagship.
 	bool isValidTarget = !newTarget || (newTarget && player.Flagship() &&
@@ -3800,7 +3800,7 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 			
 			gaveOrder = true;
 			hasMismatch |= !orders.count(ship);
-
+			
 			Orders &existing = orders[ship];
 			// HOLD_ACTIVE cannot be given as manual order, but we make sure here
 			// that any HOLD_ACTIVE order also matches when an HOLD_POSITION

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -334,7 +334,6 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 	
 	if(!flagship || flagship->IsDestroyed())
 		return;
-	
 	if(activeCommands.Has(Command::STOP))
 		Messages::Add("Coming to a stop.");
 	
@@ -379,7 +378,6 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 		newOrders.target = player.FlagshipPtr();
 		IssueOrders(player, newOrders, "gathering around your flagship.");
 	}
-	
 	// Get rid of any invalid orders. Carried ships will retain orders in case they are deployed.
 	for(auto it = orders.begin(); it != orders.end(); )
 	{
@@ -1660,7 +1658,6 @@ void AI::Refuel(Ship &ship, Command &command)
 		ship.SetTargetStellar(parentTarget);
 	else if(!CanRefuel(ship, ship.GetTargetStellar()))
 		ship.SetTargetStellar(GetRefuelLocation(ship));
-	
 	if(ship.GetTargetStellar())
 	{
 		MoveToPlanet(ship, command);
@@ -1797,7 +1794,6 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition, const
 	
 	bool shouldReverse = false;
 	dp = targetPosition - StoppingPoint(ship, targetVelocity, shouldReverse);
-	
 	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .95);
 	if(!isClose || (!isFacing && !shouldReverse))
 		command.SetTurn(TurnToward(ship, dp));
@@ -3800,7 +3796,6 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 	// If this is a move command, make sure the fleet is bunched together
 	// enough that each ship takes up no more than about 30,000 square pixels.
 	double maxSquadOffset = sqrt(10000. * squadCount);
-	
 	// A target is valid if we have no target, or when the target is in the
 	// same system as the flagship.
 	bool isValidTarget = !newTarget || (newTarget && player.Flagship() &&
@@ -3822,7 +3817,6 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 			
 			gaveOrder = true;
 			hasMismatch |= !orders.count(ship);
-			
 			Orders &existing = orders[ship];
 			// HOLD_ACTIVE cannot be given as manual order, but we make sure here
 			// that any HOLD_ACTIVE order also matches when an HOLD_POSITION

--- a/source/Command.h
+++ b/source/Command.h
@@ -71,7 +71,7 @@ public:
 	// Modifier command, usually triggered by shift-key. Changes behaviour of
 	// other commands like NEAREST, TARGET, HAIL and BOARD.
 	static const Command SHIFT;
-
+	
 	
 public:
 	// In the given text, replace any instances of command names (in angle

--- a/source/Command.h
+++ b/source/Command.h
@@ -72,7 +72,6 @@ public:
 	// other commands like NEAREST, TARGET, HAIL and BOARD.
 	static const Command SHIFT;
 	
-	
 public:
 	// In the given text, replace any instances of command names (in angle
 	// brackets) with key names (in quotes).

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -96,7 +96,7 @@ void EscortDisplay::Draw(const Rectangle &bounds) const
 		// Draw the system name for any escort not in the current system.
 		if(!escort.system.empty())
 			font.Draw(escort.system, pos + Point(-10., 10.), elsewhereColor);
-
+		
 		Color color;
 		if(escort.isHostile)
 			color = hostileColor;

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -96,7 +96,6 @@ void EscortDisplay::Draw(const Rectangle &bounds) const
 		// Draw the system name for any escort not in the current system.
 		if(!escort.system.empty())
 			font.Draw(escort.system, pos + Point(-10., 10.), elsewhereColor);
-		
 		Color color;
 		if(escort.isHostile)
 			color = hostileColor;

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -241,6 +241,7 @@ const Government *Fleet::GetGovernment() const
 }
 
 
+
 // Choose a fleet to be created during flight, and have it enter the system via jump or planetary departure.
 void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Planet *planet) const
 {
@@ -299,7 +300,7 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 					linkVector.insert(linkVector.end(), 8, neighbor);
 			}
 		}
-	
+		
 		// Find all the inhabited planets this fleet could take off from.
 		vector<const Planet *> planetVector;
 		if(!personality.IsSurveillance())
@@ -307,7 +308,7 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 				if(object.GetPlanet() && object.GetPlanet()->HasSpaceport()
 						&& !object.GetPlanet()->GetGovernment()->IsEnemy(government))
 					planetVector.push_back(object.GetPlanet());
-	
+		
 		// If there is nowhere for this fleet to come from, don't create it.
 		size_t options = linkVector.size() + planetVector.size();
 		if(!options)
@@ -324,7 +325,7 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 		
 		// Choose a random planet or star system to come from.
 		size_t choice = Random::Int(options);
-	
+		
 		// If a planet is chosen, also pick a system to travel to after taking off.
 		if(choice >= linkVector.size())
 		{

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -300,7 +300,6 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 					linkVector.insert(linkVector.end(), 8, neighbor);
 			}
 		}
-		
 		// Find all the inhabited planets this fleet could take off from.
 		vector<const Planet *> planetVector;
 		if(!personality.IsSurveillance())
@@ -308,7 +307,6 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 				if(object.GetPlanet() && object.GetPlanet()->HasSpaceport()
 						&& !object.GetPlanet()->GetGovernment()->IsEnemy(government))
 					planetVector.push_back(object.GetPlanet());
-		
 		// If there is nowhere for this fleet to come from, don't create it.
 		size_t options = linkVector.size() + planetVector.size();
 		if(!options)
@@ -325,7 +323,6 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 		
 		// Choose a random planet or star system to come from.
 		size_t choice = Random::Int(options);
-		
 		// If a planet is chosen, also pick a system to travel to after taking off.
 		if(choice >= linkVector.size())
 		{

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -35,7 +35,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <algorithm>
 #include <cmath>
-#include <iostream>
 
 using namespace std;
 

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -35,6 +35,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <algorithm>
 #include <cmath>
+#include <iostream>
 
 using namespace std;
 
@@ -72,7 +73,7 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 	else if(ship->IsDisabled())
 	{
 		const Ship *flagship = player.Flagship();
-		if(!flagship->JumpsRemaining() || flagship->IsDisabled())
+		if(flagship->NeedsFuel(false) || flagship->IsDisabled())
 			message = "Sorry, we can't help you, because our ship is disabled.";
 	}
 	else
@@ -80,7 +81,7 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
 		// Is the player in any need of assistance?
 		const Ship *flagship = player.Flagship();
 		// Check if the player is out of fuel.
-		if(!flagship->JumpsRemaining())
+		if(flagship->NeedsFuel(false))
 		{
 			playerNeedsHelp = true;
 			canGiveFuel = ship->CanRefuel(*flagship);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2759,7 +2759,7 @@ bool Ship::NeedsFuel(bool followParent) const
 	}
 	if(!jumpFuel)
 		jumpFuel = JumpFuel(targetSystem);
-	return (fuel < jumpFuel) && !(Fuel() == 1.);
+	return (fuel < jumpFuel) && Fuel() != 1.;
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -42,7 +42,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <cmath>
 #include <limits>
 #include <sstream>
-#include <iostream>
 
 using namespace std;
 
@@ -1569,6 +1568,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 						if(object.GetPlanet() == landingPlanet)
 							position = object.Position();
 					SetTargetStellar(nullptr);
+					SetTargetSystem(nullptr);
 					landingPlanet = nullptr;
 				}
 				else if(!isSpecial || personality.IsFleeing())
@@ -2415,7 +2415,7 @@ bool Ship::IsUsingJumpDrive() const
 
 
 
-// Check if this ship is currently able to enter hyperspace to it target.
+// Check if this ship is currently able to enter hyperspace to its target.
 bool Ship::IsReadyToJump(bool waitingIsReady) const
 {
 	// Ships can't jump while waiting for someone else, carried, or if already jumping.
@@ -2745,32 +2745,22 @@ double Ship::DisabledHull() const
 }
 
 
-
-bool Ship::JumpsRemaining(bool followParent) const
+// TODO: fix misuses of this method, as it is now being used to indicate the need for refueling.
+int Ship::JumpsRemaining(bool followParent) const
 {
-	// Make sure this ship has some sort of hyperdrive, and if so return
-	// whether it needs to make a jump and cannot do it.
-	
-	// If the ship is planning to land on a planet (or wormhole), it does not need to jump.
-	if(targetPlanet)
-		return true;
-	
+	// Make sure this ship has some sort of hyperdrive, and if so return how
+	// many jumps it can make.
 	double jumpFuel = 0.;
 	if(!targetSystem && followParent)
 	{
 		// If this ship has no destination, the parent's substitutes for it,
 		// but only if the location is reachable.
-		const auto &p = GetParent();
+		auto p = GetParent();
 		if(p)
-		{
-			const auto &parentTargetSystem = p->GetTargetSystem();
-			jumpFuel = JumpFuel(parentTargetSystem ? parentTargetSystem : p->GetSystem());
-		}
+			jumpFuel = JumpFuel(p->GetTargetSystem());
 	}
 	if(!jumpFuel)
 		jumpFuel = JumpFuel(targetSystem);
-	if(jumpFuel == -1.)
-		return true;
 	return jumpFuel ? fuel / jumpFuel : 0.;
 }
 
@@ -2794,10 +2784,8 @@ double Ship::JumpFuel(const System *destination) const
 	if(attributes.Get("jump drive") && currentSystem->JumpNeighbors(JumpRange()).count(destination))
 		return JumpDriveFuel(linked ? 0. : currentSystem->Position().Distance(destination->Position()));
 	
-	// If the given system is not a possible destination (it should never happen), return -1.
-	Files::LogError("Ship '" + this->name + "' of model '" + this->modelName + "' in system '" 
-		+ this->currentSystem->Name() + "' cannot reach its destination system '" + destination->Name() + "'");
-	return -1.;
+	// If the given system is not reachable via hyperspace in one hop, return 0.
+	return 0.;
 }
 
 
@@ -3232,7 +3220,7 @@ void Ship::Jettison(const Outfit *outfit, int count)
 {
 	if(count < 0)
 		return;
-
+	
 	cargo.Remove(outfit, count);
 	
 	// Jettisoned cargo must carry some of the ship's heat with it. Otherwise

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2759,7 +2759,7 @@ bool Ship::NeedsFuel(bool followParent) const
 	}
 	if(!jumpFuel)
 		jumpFuel = JumpFuel(targetSystem);
-	return (fuel < jumpFuel) && Fuel() != 1.;
+	return (fuel < jumpFuel) && attributes.Get("fuel capacity") && Fuel() != 1.;
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3238,7 +3238,6 @@ void Ship::Jettison(const Outfit *outfit, int count)
 {
 	if(count < 0)
 		return;
-	
 	cargo.Remove(outfit, count);
 	
 	// Jettisoned cargo must carry some of the ship's heat with it. Otherwise

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -280,7 +280,7 @@ public:
 	// Get the number of jumps this ship can make before running out of fuel.
 	// This depends on how much fuel it has and what sort of hyperdrive it uses.
 	// If followParent is false, this ship will not follow the parent.
-	int JumpsRemaining(bool followParent = true) const;
+	bool JumpsRemaining(bool followParent = true) const;
 	// Get the amount of fuel expended per jump.
 	double JumpFuel(const System *destination = nullptr) const;
 	// Get the distance that this ship can jump.
@@ -387,6 +387,7 @@ public:
 	std::shared_ptr<Ship> GetTargetShip() const;
 	std::shared_ptr<Ship> GetShipToAssist() const;
 	const StellarObject *GetTargetStellar() const;
+	// Get ship's target system (it should always be one jump / wormhole pass away).
 	const System *GetTargetSystem() const;
 	// Mining target.
 	std::shared_ptr<Minable> GetTargetAsteroid() const;
@@ -396,6 +397,7 @@ public:
 	void SetTargetShip(const std::shared_ptr<Ship> &ship);
 	void SetShipToAssist(const std::shared_ptr<Ship> &ship);
 	void SetTargetStellar(const StellarObject *object);
+	// Set ship's target system (it should always be one jump / wormhole pass away).
 	void SetTargetSystem(const System *system);
 	// Mining target.
 	void SetTargetAsteroid(const std::shared_ptr<Minable> &asteroid);

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -279,8 +279,9 @@ public:
 	double DisabledHull() const;
 	// Get the number of jumps this ship can make before running out of fuel.
 	// This depends on how much fuel it has and what sort of hyperdrive it uses.
+	// This does not show accurate number of jumps remaining beyond 1.
 	// If followParent is false, this ship will not follow the parent.
-	bool JumpsRemaining(bool followParent = true) const;
+	int JumpsRemaining(bool followParent = true) const;
 	// Get the amount of fuel expended per jump.
 	double JumpFuel(const System *destination = nullptr) const;
 	// Get the distance that this ship can jump.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -282,6 +282,7 @@ public:
 	// This does not show accurate number of jumps remaining beyond 1.
 	// If followParent is false, this ship will not follow the parent.
 	int JumpsRemaining(bool followParent = true) const;
+	bool NeedsFuel(bool followParent = true) const;
 	// Get the amount of fuel expended per jump.
 	double JumpFuel(const System *destination = nullptr) const;
 	// Get the distance that this ship can jump.

--- a/source/StarField.cpp
+++ b/source/StarField.cpp
@@ -95,25 +95,25 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom) const
 	{
 		glUseProgram(shader.Object());
 		glBindVertexArray(vao);
-	
+		
 		float length = vel.Length();
 		Point unit = length ? vel.Unit() : Point(1., 0.);
 		// Don't zoom the stars at the same rate as the field; otherwise, at the
 		// farthest out zoom they are too small to draw well.
 		unit /= pow(zoom, .75);
-	
+		
 		float baseZoom = static_cast<float>(2. * zoom);
 		GLfloat scale[2] = {baseZoom / Screen::Width(), -baseZoom / Screen::Height()};
 		glUniform2fv(scaleI, 1, scale);
-	
+		
 		GLfloat rotate[4] = {
 			static_cast<float>(unit.Y()), static_cast<float>(-unit.X()),
 			static_cast<float>(unit.X()), static_cast<float>(unit.Y())};
 		glUniformMatrix2fv(rotateI, 1, false, rotate);
-	
+		
 		glUniform1f(elongationI, length * zoom);
 		glUniform1f(brightnessI, min(1., pow(zoom, .5)));
-	
+		
 		// Stars this far beyond the border may still overlap the screen.
 		double borderX = fabs(vel.X()) + 1.;
 		double borderY = fabs(vel.Y()) + 1.;
@@ -125,7 +125,7 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom) const
 		// Round down to the start of the nearest tile.
 		minX &= ~(TILE_SIZE - 1l);
 		minY &= ~(TILE_SIZE - 1l);
-	
+		
 		for(int gy = minY; gy < maxY; gy += TILE_SIZE)
 			for(int gx = minX; gx < maxX; gx += TILE_SIZE)
 			{
@@ -141,7 +141,7 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom) const
 				int count = 6 * tileIndex[index + 1] - first;
 				glDrawArrays(GL_TRIANGLES, first, count);
 			}
-	
+		
 		glBindVertexArray(0);
 		glUseProgram(0);
 	}
@@ -200,7 +200,7 @@ void StarField::SetUpGraphics()
 		"  vec2 elongated = vec2(coord.x * size, coord.y * (size + elongation));\n"
 		"  gl_Position = vec4((rotate * elongated + translate + offset) * scale, 0, 1);\n"
 		"}\n";
-
+	
 	static const char *fragmentCode =
 		"// fragment starfield shader\n"
 		"in float fragmentAlpha;\n"
@@ -327,7 +327,7 @@ void StarField::MakeStars(int stars, int width)
 	}
 	// Adjust the tile indices so that tileIndex[i] is the start of tile i.
 	tileIndex.insert(tileIndex.begin(), 0);
-
+	
 	glBufferData(GL_ARRAY_BUFFER, sizeof(data.front()) * data.size(), data.data(), GL_STATIC_DRAW);
 	
 	// Connect the xy to the "vert" attribute of the vertex shader.

--- a/source/StarField.cpp
+++ b/source/StarField.cpp
@@ -95,25 +95,20 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom) const
 	{
 		glUseProgram(shader.Object());
 		glBindVertexArray(vao);
-		
 		float length = vel.Length();
 		Point unit = length ? vel.Unit() : Point(1., 0.);
 		// Don't zoom the stars at the same rate as the field; otherwise, at the
 		// farthest out zoom they are too small to draw well.
 		unit /= pow(zoom, .75);
-		
 		float baseZoom = static_cast<float>(2. * zoom);
 		GLfloat scale[2] = {baseZoom / Screen::Width(), -baseZoom / Screen::Height()};
 		glUniform2fv(scaleI, 1, scale);
-		
 		GLfloat rotate[4] = {
 			static_cast<float>(unit.Y()), static_cast<float>(-unit.X()),
 			static_cast<float>(unit.X()), static_cast<float>(unit.Y())};
 		glUniformMatrix2fv(rotateI, 1, false, rotate);
-		
 		glUniform1f(elongationI, length * zoom);
 		glUniform1f(brightnessI, min(1., pow(zoom, .5)));
-		
 		// Stars this far beyond the border may still overlap the screen.
 		double borderX = fabs(vel.X()) + 1.;
 		double borderY = fabs(vel.Y()) + 1.;
@@ -125,7 +120,6 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom) const
 		// Round down to the start of the nearest tile.
 		minX &= ~(TILE_SIZE - 1l);
 		minY &= ~(TILE_SIZE - 1l);
-		
 		for(int gy = minY; gy < maxY; gy += TILE_SIZE)
 			for(int gx = minX; gx < maxX; gx += TILE_SIZE)
 			{
@@ -141,7 +135,6 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom) const
 				int count = 6 * tileIndex[index + 1] - first;
 				glDrawArrays(GL_TRIANGLES, first, count);
 			}
-		
 		glBindVertexArray(0);
 		glUseProgram(0);
 	}
@@ -200,7 +193,6 @@ void StarField::SetUpGraphics()
 		"  vec2 elongated = vec2(coord.x * size, coord.y * (size + elongation));\n"
 		"  gl_Position = vec4((rotate * elongated + translate + offset) * scale, 0, 1);\n"
 		"}\n";
-	
 	static const char *fragmentCode =
 		"// fragment starfield shader\n"
 		"in float fragmentAlpha;\n"
@@ -327,7 +319,6 @@ void StarField::MakeStars(int stars, int width)
 	}
 	// Adjust the tile indices so that tileIndex[i] is the start of tile i.
 	tileIndex.insert(tileIndex.begin(), 0);
-	
 	glBufferData(GL_ARRAY_BUFFER, sizeof(data.front()) * data.size(), data.data(), GL_STATIC_DRAW);
 	
 	// Connect the xy to the "vert" attribute of the vertex shader.

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -829,7 +829,7 @@ void System::UpdateNeighbors(const Set<System> &systems, double distance)
 		// Skip systems that have no name.
 		if(it.first.empty() || it.second.Name().empty())
 			continue;
-
+		
 		if(&it.second != this && it.second.Position().Distance(position) <= distance)
 			neighborSet.insert(&it.second);
 	}

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -829,7 +829,6 @@ void System::UpdateNeighbors(const Set<System> &systems, double distance)
 		// Skip systems that have no name.
 		if(it.first.empty() || it.second.Name().empty())
 			continue;
-		
 		if(&it.second != this && it.second.Position().Distance(position) <= distance)
 			neighborSet.insert(&it.second);
 	}


### PR DESCRIPTION
**Bugfix:** Fixes these issues:
#2937
#4362 (tested with provided save file)
#3608 (tested with provided save file)
#4582 (tested with provided save file)
#5011 (tested with provided save file)
#5541 (tested)
the issue @Terin mentioned (tested)

## Fix Details
This PR fixes multiple issues with ship pathfinding:
1. ships not immediately following parent if they cannot jump or land on wormhole that the parent is targeting
       consider alternative travel plans (e.g. if parent jumps, but the escort cannot jump, or if the parent lands on wormhole but the escort cannot)
2. ships not following if the parent jumps while landing on wormhole
       reset jump orders while landing
3. ships getting stuck if they go through the wormhole off screen
       reset target system when going through wormhole
4. ships getting stuck with impossible destination if hyperspace link or system disappears
       reset destination system if it is unreachable

Also thanks to @oo13 for their excellent bug report #5541.