### PR TITLE
test/ci: Disable vsync by default on integration test CI-runs

### DIFF
--- a/tests/config/preferences.txt
+++ b/tests/config/preferences.txt
@@ -23,3 +23,4 @@
 "help: outfitter 3" 1
 "help: stranded" 1
 "help: trading" 1
+vsync 0


### PR DESCRIPTION
**Bugfix:** This PR addresses vsync warnings during integration test CI runs

## Fix Details
This fix adds `vsync 0` to the default preferences of CI-tests.

## Testing Done
Testing in CI is done as part of this PR.

## Save File
N/A