### PR TITLE
tests: Retry test if it fails on framework/Xvfb issue

### DIFF
--- a/tests/retryable_issues.txt
+++ b/tests/retryable_issues.txt
@@ -1,0 +1,1 @@
+SDL message: "No available video device"

--- a/tests/retryable_issues.txt
+++ b/tests/retryable_issues.txt
@@ -1,1 +1,2 @@
 SDL message: "No available video device"
+(SDL message: "No available video device")

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+HERE=$(cd `dirname $0` && pwd)
+
 # Helper function to print debugging data for failures on graphical environment.
 function print_graphics_data () {
 	if [[ -z ${PRINT_GLXINFO} ]]; then
@@ -26,8 +28,8 @@ function print_graphics_data () {
 
 
 
-function detect_known_issues () {
-	cat "$1" | grep "SDL message: \"No available video device\""
+function detect_retryable_issues () {
+	grep -Fx -f "${HERE}/retryable_issues.txt" "$1"
 }
 
 
@@ -138,7 +140,7 @@ do
 			TEST_RESULT="not ok"
 			if [ -f "${ES_CONFIG_PATH}/errors.txt" ]
 			then
-				KNOWN_ISSUES=$(detect_known_issues "${ES_CONFIG_PATH}/errors.txt")
+				KNOWN_ISSUES=$(detect_retryable_issues "${ES_CONFIG_PATH}/errors.txt")
 				if [ $(echo "${KNOWN_ISSUES}" | wc -w) -gt 0 ]
 				then
 					echo "# Failed on known issue:"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -25,6 +25,12 @@ function print_graphics_data () {
 }
 
 
+
+function detect_known_issues () {
+	cat "$1" | grep "SDL message: \"No available video device\""
+}
+
+
 # Retrieve parameters that give the executable and datafile-paths.
 if [ -z "$1" ] || [ -z "$2" ]; then
   echo "You must supply a path to the binary as an argument,"
@@ -93,38 +99,64 @@ NUM_FAILED=0
 NUM_OK=0
 for TEST in ${TESTS_OK}
 do
-	# Setup environment for the test
-	ES_CONFIG_PATH=$(mktemp --directory)
-	if [ ! $? ]
-	then
-		echo "not ok Couldn't create temporary directory"
-		echo "Bail out! Serious storage issue if we cannot create a temporary directory."
-		exit 1
-	fi
-
-	ES_SAVES_PATH="${ES_CONFIG_PATH}/saves"
-	mkdir -p "${ES_CONFIG_PATH}"
-	mkdir -p "${ES_SAVES_PATH}"
-	cp ${ES_CONFIG_TEMPLATE_PATH}/* ${ES_CONFIG_PATH}
-
-	TEST_NAME=$(echo ${TEST} | sed "s/\"//g")
+	DO_RUN=1
+	RUN_NR=0
 	TEST_RESULT="ok"
-	# Use pipefail and use sed to remove ALSA messages that appear due to missing soundcards in the CI environment
-	set -o pipefail
-	"$ES_EXEC_PATH" --resources "${RESOURCES}" --test "${TEST_NAME}" --config "${ES_CONFIG_PATH}" 2>&1 |\
-		sed -e "/^ALSA lib.*$/d" -e "/^AL lib.*$/d" | sed "s/^/# /"
-	if [ $? -ne 0 ]
-	then
-		echo ""
-		echo "# Test ${TEST} not ok"
-		echo "# temporary directory: ${ES_CONFIG_PATH}"
-		if [ -f "${ES_CONFIG_PATH}/errors.txt" ]
+	while [ ${DO_RUN} -eq 1 ] && [ ${RUN_NR} -lt 5 ]
+	do
+		DO_RUN=0
+		RUN_NR=$((RUN_NR + 1))
+		TEST_RESULT="ok"
+
+		# Setup environment for the test
+		ES_CONFIG_PATH=$(mktemp --directory)
+		if [ ! $? ]
 		then
-			echo "# errors.txt:"
-			cat "${ES_CONFIG_PATH}/errors.txt" | sed "s/^/# /"
+			echo "not ok Couldn't create temporary directory"
+			echo "Bail out! Serious storage issue if we cannot create a temporary directory."
+			exit 1
 		fi
-		print_graphics_data
-		TEST_RESULT="not ok"
+
+		ES_SAVES_PATH="${ES_CONFIG_PATH}/saves"
+		mkdir -p "${ES_CONFIG_PATH}"
+		mkdir -p "${ES_SAVES_PATH}"
+		cp ${ES_CONFIG_TEMPLATE_PATH}/* ${ES_CONFIG_PATH}
+
+		TEST_NAME=$(echo ${TEST} | sed "s/\"//g")
+
+		# Use pipefail and use sed to remove ALSA messages that appear due to missing soundcards in the CI environment
+		set -o pipefail
+		"$ES_EXEC_PATH" --resources "${RESOURCES}" --test "${TEST_NAME}" --config "${ES_CONFIG_PATH}" 2>&1 |\
+			sed -e "/^ALSA lib.*$/d" -e "/^AL lib.*$/d" | sed "s/^/# /"
+		TEST_RETVAL=$?
+
+		if [ ${TEST_RETVAL} -ne 0 ]
+		then
+			echo ""
+			echo "# Test ${TEST} not ok (run ${RUN_NR})"
+			echo "# temporary directory: ${ES_CONFIG_PATH}"
+			TEST_RESULT="not ok"
+			if [ -f "${ES_CONFIG_PATH}/errors.txt" ]
+			then
+				KNOWN_ISSUES=$(detect_known_issues "${ES_CONFIG_PATH}/errors.txt")
+				if [ $(echo "${KNOWN_ISSUES}" | wc -w) -gt 0 ]
+				then
+					echo "# Failed on known issue:"
+					echo "${KNOWN_ISSUES}" | sed "s/^/# /"
+					echo "# (will retry if possible)"
+					echo ""
+					DO_RUN=1
+				else
+					echo "# errors.txt:"
+					cat "${ES_CONFIG_PATH}/errors.txt" | sed "s/^/# /"
+				fi
+			fi
+			print_graphics_data
+		fi
+	done
+
+	if [ ${TEST_RESULT} != "ok" ]
+	then
 		NUM_FAILED=$((NUM_FAILED + 1))
 	else
 		NUM_OK=$((NUM_OK + 1))

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -45,17 +45,17 @@ function detect_retryable_issues () {
 # 2 = fatal failure (should terminate all testing)
 # 3 = recoverable failure (could retry)
 function run_single_testrun () {
-	TEST="$1"
+	local TEST="$1"
 	
 	# Setup environment for the test
-	ES_CONFIG_PATH=$(mktemp --directory)
+	local ES_CONFIG_PATH=$(mktemp --directory)
 	if [ ! $? ]
 	then
 		echo "not ok Couldn't create temporary directory"
 		return 2
 	fi
 	
-	ES_SAVES_PATH="${ES_CONFIG_PATH}/saves"
+	local ES_SAVES_PATH="${ES_CONFIG_PATH}/saves"
 	mkdir -p "${ES_CONFIG_PATH}"
 	mkdir -p "${ES_SAVES_PATH}"
 	cp ${ES_CONFIG_TEMPLATE_PATH}/* ${ES_CONFIG_PATH}
@@ -65,8 +65,8 @@ function run_single_testrun () {
 		return 2
 	fi
 	
-	TEST_NAME=$(echo ${TEST} | sed "s/\"//g")
-	RETURN=0
+	local TEST_NAME=$(echo ${TEST} | sed "s/\"//g")
+	local RETURN=0
 	# Use pipefail and use sed to remove ALSA messages that appear due to missing soundcards in the CI environment
 	set -o pipefail
 	"$ES_EXEC_PATH" --resources "${RESOURCES}" --test "${TEST_NAME}" --config "${ES_CONFIG_PATH}" 2>&1 |\
@@ -79,7 +79,7 @@ function run_single_testrun () {
 		RETURN=1
 		if [ -f "${ES_CONFIG_PATH}/errors.txt" ]
 		then
-			KNOWN_ISSUES=$(detect_retryable_issues "${ES_CONFIG_PATH}/errors.txt")
+			local KNOWN_ISSUES=$(detect_retryable_issues "${ES_CONFIG_PATH}/errors.txt")
 			if [ $(echo "${KNOWN_ISSUES}" | wc -w) -gt 0 ]
 			then
 				echo "# Failed on known issue:"
@@ -100,8 +100,8 @@ function run_single_testrun () {
 
 # Runs a test, including all retries.
 function run_test () {
-	RUN_NR=0
-	TEST_RESULT=3
+	local RUN_NR=0
+	local TEST_RESULT=3
 	while [ ${TEST_RESULT} -eq 3 ] && [ ${RUN_NR} -lt 5 ]
 	do
 		RUN_NR=$((RUN_NR + 1))
@@ -186,7 +186,7 @@ NUM_OK=0
 for TEST in ${TESTS_OK}
 do
 	run_test "${TEST}"
-
+	TEST_RESULT=$?
 	if [ ${TEST_RESULT} -eq 2 ]
 	then
 		echo "Bail out! Encountered serious issue that prevents further testing."


### PR DESCRIPTION
**Feature:** This PR implements a retry mechanism for the CI integration tests if the tests fails on a known framework issue (#4308, #5645)

## Feature Details
If the testframework detects the error-message `SDL message: "No available video device"`, then it will retry to run the test (max 5 times). This SDL errormessage would (usually) not be related to the test itself, but looks like an intermittent issue between endless-sky, Xvfb and Ubuntu 20.04. We should still handle the `SDL message: "No available video device"` error in the future, this PR only acts as a workaround to prevent CI for unrelated PRs from failing on this error-message.

## UI Screenshots
N/A

## Usage Examples
Automatically runs as part of the CI-jobs.

## Testing Done
Tested with succesfull tests, failing tests and tests failing with the specific error-message.

## Performance Impact
N/A