### PR TITLE
Fix: Overly-indented conversation in Transport Missions.txt

### DIFF
--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3133,14 +3133,14 @@ mission "Pirate Duel"
 		"reputation: Independent (Killable)" = 10
 		payment 250000
 		conversation
-				`When you land on Wayfarer, you look up bounties and wanted pirate documents, searching for any mention of the Anglerfish and the Esca. Eventually, you find a bounty for the destruction of the Anglerfish.`
-				choice
-					`	(Take the bounty money.)`
-						goto end
-					`	(Read more about the bounty.)`
-				`	You decide to read more of the bounty documents. It appears that the pirate that you killed was Enrico Snake, a pirate that mainly dealt in cargo smuggling. However, he also had a curious tick of hunting aspiring privateers by luring them to Umbral, where he easily took them out with his superior ship.`
-				label end
-				`	You head to the local authorities, and show them your combat logs of your fight against the Anglerfish. They pay you <payment> for your effort.`
+			`When you land on Wayfarer, you look up bounties and wanted pirate documents, searching for any mention of the Anglerfish and the Esca. Eventually, you find a bounty for the destruction of the Anglerfish.`
+			choice
+				`	(Take the bounty money.)`
+					goto end
+				`	(Read more about the bounty.)`
+			`	You decide to read more of the bounty documents. It appears that the pirate that you killed was Enrico Snake, a pirate that mainly dealt in cargo smuggling. However, he also had a curious tick of hunting aspiring privateers by luring them to Umbral, where he easily took them out with his superior ship.`
+			label end
+			`	You head to the local authorities, and show them your combat logs of your fight against the Anglerfish. They pay you <payment> for your effort.`
 
 ship "Vanguard" "Vanguard (Plasma Slow)"
 	outfits


### PR DESCRIPTION
**Bugfix:** This PR addresses erroneous indentation in the conversation starting on line 3136 of `transport missions.txt`

## Fix Details
Removed one tab from each line of this conversation.

## Credit

Thanks to 7even for spotting this problem!