### PR TITLE
Save human cultural data for later

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -2205,6 +2205,43 @@ event "remnant: wait for plume"
 
 
 
+conversation "ately cultural data"
+	branch return
+		has "Remnant: Salvage 1B: done"
+	`As you step out into the icy chill of Viminal, you get a message from Taely, the engineering prefect, asking if you could meet her in the cafeteria.`
+	choice
+		`	(Accept her invitation.)`
+		`	(Not right now.)`
+			defer
+	`	Replying that you can, you make your way through the crowds and find an empty table. Moments later Taely appears and grabs two trays from the dispenser before heading towards you. She settles down in the opposite chair with a look of exhaustion.`
+	`	"It is good to see you again, <first>," she sings softly. When you sign a reply she sits up, smiles, and switches to sign. "My, you are a quick learner. This is much faster." Her quick gestures are hard to follow, but the language videos seem to have focused on a practical vocabulary that has most of the words she uses.`
+	`	"I haven't fully..." (She makes a sign that you don't understand, but seems similar to the signs for "break" and "understand".) "...the technology you retrieved for us, but we are learning much from what we have already found. Could you help us catch up with what has happened in ancestral space since our Exodus?"`
+	choice
+		`	"Yes. What can I do to help?"`
+		`	"Sorry, not interested."`
+			decline
+	branch data
+		has "human cultural data"
+	`	"Excellent! According to a friend of mine who is versed in history from the war, there were rumors that a grand library was being built in the Deep to house all of human knowledge. If it exists, that would likely be where to go."`
+		accept
+	label data
+	`	"Excellent! According to a friend of mine who is versed in history from the war, there were rumors that a grand library was being built in the Deep to house all of human knowledge. If it exists..." She stops when she notices you nodding with a knowing expression. "You have already been there? Well, you certainly get around, Captain <last>. I suppose that makes things rather straight forward."`
+	`	"I actually already have a copy of the library's data in my ship," you respond.`
+	`	"Oh, that's even better," Taely trills. "Go ahead and get it."`
+	`	You return to your ship to get the data chip, but when you glance out the cockpit you notice that the spaceport is more animated than usual. Remnant look to be running to their ships as fast as they can when you notice that Taely is halfway up the side of your ship securing a refueling hose and charging cable. As you reach for the commlink she scrambles up to the bridge windows and quickly rattles off a series of signs at you. All you can make out is "Keep it hot, incoming!" Before you can frame a reply she has raced across your wing and leapt to the Albatross parked next to you.`
+		goto launch
+	
+	label return
+	`Having acquired a copy of the archive, you gently set your ship down on Viminal hoping that this information is helpful. The port seems unusually busy, but the comm channels are quiet beyond the bare minimum to keep traffic organized.`
+	`	Before you have even taken the time to shut down the engines Taely is halfway up the side of your ship securing a refueling hose and charging cable. As you reach for the commlink she scrambles up to the bridge windows and quickly rattles off a series of signs at you. All you can make out is "Keep it hot, incoming!" Before you can frame a reply she has raced across your wing and leapt to the Albatross parked next to you.`
+	
+	label launch
+	`	Looking around more carefully, you note that every ship in the port is idling with fuel lines still connected. If this were some Republic port the safety inspectors would be having a nightmare. One Starling is getting holes in its wings patched even as the crew appear to be running prep-for-flight checklists. It also looks like every ship has a guard. Something tells you that right now would be a bad time to take a walk around town.`
+	`	After some tense minutes of waiting, the planetary defense sirens start and the idling ships begin to ascend one by one. You quickly figure out where you are in the launch sequence and follow the stream of craft heading for orbit.`
+		launch
+
+
+
 mission "Remnant: Salvage 1"
 	name "Remnant History Updates"
 	description `The Remnant are interested in learning about what has happened in human space since they left. Find a copy of human history on <destination>.`
@@ -2212,6 +2249,7 @@ mission "Remnant: Salvage 1"
 	source "Viminal"
 	destination "Alexandria"
 	to offer
+		not "human cultural data"
 		has "Remnant: Learn Sign Follow Up: offered"
 		random < 50
 		or
@@ -2220,31 +2258,13 @@ mission "Remnant: Salvage 1"
 			has "Remnant: Heavy Laser: done"
 			has "Remnant: Tech Retrieval: done"
 	on offer
-		conversation
-			`As you step out into the icy chill of Viminal, you get a message from Taely, the engineering prefect, asking if you could meet her in the cafeteria.`
-			choice
-				`	(Not right now.)`
-					defer
-				`	(Accept her invitation.)`
-			`	Replying that you can, you make your way through the crowds and find an empty table. Moments later Taely appears and grabs two trays from the dispenser before heading towards you. She settles down in the opposite chair with a look of exhaustion.`
-			`	"It is good to see you again, <first>," she sings softly. When you sign a reply she sits up, smiles, and switches to sign. "My, you are a quick learner. This is much faster." Her quick gestures are hard to follow, but the language videos seem to have focused on a practical vocabulary that has most of the words she uses.`
-			`	"I haven't fully..." (She makes a sign that you don't understand, but seems similar to the signs for "break" and "understand".) "...the technology you retrieved for us, but we are learning much from what we have already found. Could you help us catch up with what has happened in ancestral space since our Exodus?"`
-			choice
-				`	"Yes. What can I do to help?"`
-				`	"Sorry, not interested."`
-					decline
-			branch library
-				has "Human Cultural Archives: done"
-			`	"Excellent! According to a friend of mine who is versed in history from the war, there were rumors that a grand library was being built in the Deep to house all of human knowledge. If it exists, that would likely be where to go."`
-				accept
-			label library
-			`	"Excellent! According to a friend of mine who is versed in history from the war, there were rumors that a grand library was being built in the Deep to house all of human knowledge. If it exists..." She stops when she notices you nodding with a knowing expression. "You have already been there? Well, you certainly get around, Captain <last>. I suppose that makes things rather straight forward."`
-				accept
+		conversation "taely cultural data"
 	on visit
 		dialog
 			`The station has a small museum gift shop that sells a copy of the entire archive on a data card. It only costs 40 credits, but because you have done a horrible job at managing your finances you do not have even that much cash on hand right now.`
 			`	Go earn some money, then return here.`
 	on complete
+		set "human cultural data"
 		payment -40
 
 
@@ -2270,14 +2290,19 @@ mission "Remnant: Salvage 2"
 	description "Assist in defending <planet> from a Korath raid, then return to the planet."
 	source "Viminal"
 	to offer
-		has "Remnant: Salvage 1B: done"
+		or
+			has "Remnant: Salvage 1B: done"
+			and
+				has "human cultural data"
+				has "Remnant: Learn Sign Follow Up: offered"
+				random < 50
+				or
+					has "Remnant: Catalytic Ramscoop: done"
+					has "Remnant: Plasma Cannon: done"
+					has "Remnant: Heavy Laser: done"
+					has "Remnant: Tech Retrieval: done"
 	on offer
-		conversation
-			`Having acquired a copy of the archive, you gently set your ship down on Viminal hoping that this information is helpful. The port seems unusually busy, but the comm channels are quiet beyond the bare minimum to keep traffic organized.`
-			`	Before you have even taken the time to shut down the engines Taely is halfway up the side of your ship securing a refueling hose and charging cable. As you reach for the commlink she scrambles up to the bridge windows and quickly rattles off a series of signs at you. All you can make out is "Keep it hot, incoming!" Before you can frame a reply she has raced across your wing and leapt to the Albatross parked next to you.`
-			`	Looking around more carefully, you note that every ship in the port is idling with fuel lines still connected. If this were some Republic port the safety inspectors would be having a nightmare. One Starling is getting holes in its wings patched even as the crew appear to be running prep-for-flight checklists. It also looks like every ship has a guard. Something tells you that right now would be a bad time to take a walk around town.`
-			`	After some tense minutes of waiting, the planetary defense sirens start and the idling ships begin to ascend one by one. You quickly figure out where you are in the launch sequence and follow the stream of craft heading for orbit.`
-				launch
+		conversation "taely cultural data"
 	npc
 		government "Remnant"
 		personality staying uninterested disables plunders

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -2205,7 +2205,7 @@ event "remnant: wait for plume"
 
 
 
-conversation "ately cultural data"
+conversation "taely cultural data"
 	branch return
 		has "Remnant: Salvage 1B: done"
 	`As you step out into the icy chill of Viminal, you get a message from Taely, the engineering prefect, asking if you could meet her in the cafeteria.`

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -194,6 +194,55 @@ mission "Wanderers: Translation Machine"
 
 
 
+conversation "eruk cultural data"
+	branch return
+		has "Human Cultural Archives: done"
+	`You land on <origin> and seek out the technologist that Sayari told you to contact: a Hai named Eruk. His eyes light up when you describe what you need from him, and why. "Contact with a new species! How very exciting," he says. "I am glad for Sayari that such an opportunity has been presented to her. But our speaking machines are very valuable. Before I give one to you, will you do a small favor for me?"`
+	choice
+		`	"Of course. What do you need?"`
+			goto need
+		`	"Can't I just pay you for one?"`
+			goto money
+	
+	label need
+	`	He says, "The human immigrants tell me that in the region of your space they call the Deep is a space station, a library that houses human cultural artifacts and a database of human literature and history. Bring me a copy of that database, and I will give you a speaking machine."`
+		goto end
+	
+	label money
+	`	"Money?" he says, with a dismissive gesture. "What use is money? No, from you I desire something far more valuable. The human immigrants tell me that in the region of your space they call the Deep is a space station, a library that houses human cultural artifacts and a database of human literature and history. Bring me a copy of that database, and I will give you a speaking machine."`
+		goto end
+	
+	label end
+	branch data
+		has "human cultural data"
+	choice
+		`	"No problem, I'll bring you a copy of the database as soon as I can."`
+			accept
+		`	"How will I convince them to give me a copy of their data?"`
+	`	Your question seems to utterly confuse him. "Information," he says. "It is what you call a non-rival good, is it not? When I give information, I do not lose it. Sharing it costs me nothing. The librarians, surely they will understand this. Have no fear."`
+		accept
+	
+	label data
+	choice
+		`	"I actually already have a copy of that data."`
+	`	"You do? Please go get it!" he exclaims.`
+	`	You go to your ship to retrieve the data and give it to him upon returning. His eyes light up with excitement as he makes a copy of the card and returns the original to you.`
+		goto give
+	
+	label return
+	`You return to Eruk's workshop and give him the data card. His eyes light up with excitement as he makes a copy of the card and returns the original to you.`
+	
+	label give
+	`	"I have spent my whole life studying human culture," he says. "This is a treasure to me. And now, here is your speaking machine." He hands you a small, spherical device, with speakers and microphones mounted on it, as well as what look like camera lenses. "The device is programmed with the human and Hai languages," he says. "It is not always possible to translate perfectly between our two languages, but it will try to give you a sense of the range of meanings in what is being said."`
+	choice
+		`	"Thank you. I'm eager to try it out!"`
+			accept
+		`	"Is there anything else I need to know?"`
+	`	He humors you by demonstrating how the machine works, holding a conversation with you where he speaks in the Hai language, and the machine automatically translates for you and then translates your responses back into his language. It apparently uses its cameras to track who you are speaking to or listening to. It's an impressive piece of technology, and easy enough to use. You thank him for his help, and return to your ship.`
+		accept
+
+
+
 mission "Human Cultural Archives"
 	description "Eruk, the Hai technologist on <origin>, has agreed to give you a translation machine if you can somehow get him a copy of the human cultural data from <destination>."
 	landing
@@ -201,35 +250,15 @@ mission "Human Cultural Archives"
 	destination "Alexandria"
 	to offer
 		has "Wanderers: Translation Machine: done"
+		not "human cultural data"
 	on offer
-		conversation
-			`You land on <origin> and seek out the technologist that Sayari told you to contact: a Hai named Eruk. His eyes light up when you describe what you need from him, and why. "Contact with a new species! How very exciting," he says. "I am glad for Sayari that such an opportunity has been presented to her. But our speaking machines are very valuable. Before I give one to you, will you do a small favor for me?"`
-			choice
-				`	"Of course. What do you need?"`
-					goto need
-				`	"Can't I just pay you for one?"`
-					goto money
-			
-			label need
-			`	He says, "The human immigrants tell me that in the region of your space they call the Deep is a space station, a library that houses human cultural artifacts and a database of human literature and history. Bring me a copy of that database, and I will give you a speaking machine."`
-				goto end
-			
-			label money
-			`	"Money?" he says, with a dismissive gesture. "What use is money? No, from you I desire something far more valuable. The human immigrants tell me that in the region of your space they call the Deep is a space station, a library that houses human cultural artifacts and a database of human literature and history. Bring me a copy of that database, and I will give you a speaking machine."`
-				goto end
-			
-			label end
-			choice
-				`	"No problem, I'll bring you a copy of the database as soon as I can."`
-					accept
-				`	"How will I convince them to give me a copy of their data?"`
-			`	Your question seems to utterly confuse him. "Information," he says. "It is what you call a non-rival good, is it not? When I give information, I do not lose it. Sharing it costs me nothing. The librarians, surely they will understand this. Have no fear."`
-				accept
+		conversation "eruk cultural data"
 	on visit
 		dialog
 			`The station has a small museum gift shop that sells a copy of the entire archive on a data card. It only costs 40 credits, but because you have done a horrible job at managing your finances you do not have even that much cash on hand right now.`
 			`	Go earn some money, then return here.`
 	on complete
+		set "human cultural data"
 		payment -40
 
 
@@ -254,21 +283,12 @@ mission "Visit Wanderers Again"
 	source "Greenwater"
 	destination "Vara K'chrai"
 	to offer
-		has "Human Cultural Archives: done"
+		has "human cultural data"
 	on offer
-		log "Received a device, created by a Hai scientist, which can translate between human language and the Hai language. Since the Wanderers speak the Hai language, that should make it possible to communicate with them directly."
-		conversation
-			`You return to Eruk's workshop and give him the data card. His eyes light up with excitement. "I have spent my whole life studying human culture," he says. "This is a treasure to me. And now, here is your speaking machine." He hands you a small, spherical device, with speakers and microphones mounted on it, as well as what look like camera lenses. "The device is programmed with the human and Hai languages," he says. "It is not always possible to translate perfectly between our two languages, but it will try to give you a sense of the range of meanings in what is being said."`
-			choice
-				`	"Thank you. I'm eager to try it out!"`
-					accept
-				`	"Is there anything else I need to know?"`
-			`	He humors you by demonstrating how the machine works, holding a conversation with you where he speaks in the Hai language, and the machine automatically translates for you and then translates your responses back into his language. It apparently uses its cameras to track who you are speaking to or listening to. It's an impressive piece of technology, and easy enough to use. You thank him for his help, and return to your ship.`
-				accept
-	
-	on accept
 		set "language: Wanderer"
 		event "wanderer technology available"
+		log "Received a device, created by a Hai scientist, which can translate between human language and the Hai language. Since the Wanderers speak the Hai language, that should make it possible to communicate with them directly."
+		conversation "eruk cultural data"
 
 event "wanderer technology available" # Name unchanged for compatibility
 	government "Wanderer"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
There are currently two missions in the game that have the player travel to Alexandria to get a copy of human cultural data, once for the Hai and once for the Remnant. There's no reason though that the player should have to make this same trip twice when they could have easily just saved a copy of the cultural data for themselves.

This PR makes it so that if you retrieve the cultural data for either the Hai or the Remnant, a condition "human cultural data" is saved. This condition is then used when you are asked by the other group to retrieve this data, allowing the player to skip over a trip to Alexandria. By using this condition instead of checking for the `: done` condition of the opposite mission, this also allows this information to easy be used in the future should anyone else make use of it.

## Save File
No.

## PR Checklist
 - [x] Test that this actually works as intended.
 - [ ] Get approval from @Zitchas since this alters Remnant content.