### PR TITLE
Fix a bug where an information of your cargo space is not shown in the Shop Panel.

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -280,7 +280,7 @@ void ShopPanel::DrawShipsSidebar()
 		font.Draw("cargo space:", point, medium);
 		
 		string space = Format::Number(player.Cargo().Free()) + " / " + Format::Number(player.Cargo().Size());
-		font.Draw({space, {SIDE_WIDTH - 20, Alignment::RIGHT}}, point, bright);
+		font.Draw({space, {SIDEBAR_WIDTH - 20, Alignment::RIGHT}}, point, bright);
 		point.Y() += 20.;
 	}
 	maxSidebarScroll = max(0., point.Y() + sidebarScroll - Screen::Bottom() + BUTTON_HEIGHT);


### PR DESCRIPTION
**Bugfix:** This PR addresses issue a bug that @Amazinite describes in Discord.

## Fix Details
This PR fixes a bug where an information of your cargo space is not shown in the Shop Panel.
This bug is introduced by 48926c015e39bb04ab2d81bdb27a5f3a175459d1.

You enter a shipyard and deselect your flagship, 'cargo space:' is shown under the shape of your ship but no _free space / cargo capacity_.

## Testing Done
I enter a shipyard and deselect my flagship, the shop shows me _free space / cargo capacity_.