### PR TITLE
Fix: Removing an Em-Dash

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -4253,7 +4253,7 @@ mission "Remnant: Expanded Horizons Astral 1"
 			`	"I did. The senior researcher told me that most of the team feels something is not quite right here. They say there are some potential theories, but nothing definitive, so they want me to investigate on my own without contaminating my thoughts with their ideas for now."`
 				goto help
 			label quantumcondensate
-			`	"It is basically a project examining the density of Bose–Einstein condensates as correlated to the revised relativity paradigm's conceptualization of the fabric of space-time. It has a lot of potential implications, particularly for ramscoop, scanner, and weapons technology. At least, that is the hope. For now, though, I am trying to figure out what is off about this data."`
+			`	"It is basically a project examining the density of Bose-Einstein condensates as correlated to the revised relativity paradigm's conceptualization of the fabric of space-time. It has a lot of potential implications, particularly for ramscoop, scanner, and weapons technology. At least, that is the hope. For now, though, I am trying to figure out what is off about this data."`
 			choice
 				`	"Have you asked someone with more experience for advice?"`
 				`	"Don't worry about it."`


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported on GitHub where the em dash appears as three boxes on Linux.

## Fix Details
On line 4256 there is an em dash where there should simply be a hyphen. This has reportedly caused three boxes to appear on Linux.

As a side note, I did a search through all the data files, and couldn't find any other em dashes. (using Notepad++'s "find all in files" feature). Hopefully there are no others. 

## Credits
Thanks to Kanerix on the Discord group for reporting this bug.
