### PR TITLE
Asteroid and ship selection enhancements

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -738,7 +738,7 @@ void Engine::Step(bool isActive)
 			info.SetBar("target shields", target->Shields());
 			info.SetBar("target hull", target->Hull(), 20.);
 			info.SetBar("target disabled hull", min(target->Hull(), target->DisabledHull()), 20.);
-		
+			
 			// The target area will be a square, with sides proportional to the average
 			// of the width and the height of the sprite.
 			double size = (target->Width() + target->Height()) * .35;
@@ -839,7 +839,7 @@ void Engine::Step(bool isActive)
 		for(const shared_ptr<Minable> &minable : asteroids.Minables())
 		{
 			Point offset = minable->Position() - center;
-			if(offset.Length() > scanRange)
+			if(offset.Length() > scanRange && flagship->GetTargetAsteroid() != minable)
 				continue;
 			
 			targets.push_back({
@@ -1782,6 +1782,10 @@ void Engine::HandleMouseClicks()
 	if(!flagship)
 		return;
 	
+	// Track if player clicked on something.
+	bool clickedAsteroid = false;
+	bool clickedPlanet = false;
+	
 	// Handle escort travel orders sent via the Map.
 	if(player.HasEscortDestination())
 	{
@@ -1820,6 +1824,8 @@ void Engine::HandleMouseClicks()
 					}
 					else
 						flagship->SetTargetStellar(&object);
+					
+					clickedPlanet = true;
 				}
 			}
 	
@@ -1875,11 +1881,16 @@ void Engine::HandleMouseClicks()
 			double range = clickPoint.Distance(position) - minable->Radius();
 			if(range <= clickRange)
 			{
+				clickedAsteroid = true;
 				clickRange = range;
 				flagship->SetTargetAsteroid(minable);
 			}
 		}
 	}
+	
+	// If the player didn't click on anything, clear ship and asteroid targets.
+	if(!clickTarget && !isRightClick && !clickedAsteroid && !clickedPlanet)
+		flagship->SetTargetShip(nullptr);
 }
 
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1782,10 +1782,6 @@ void Engine::HandleMouseClicks()
 	if(!flagship)
 		return;
 	
-	// Track if player clicked on something.
-	bool clickedAsteroid = false;
-	bool clickedPlanet = false;
-	
 	// Handle escort travel orders sent via the Map.
 	if(player.HasEscortDestination())
 	{
@@ -1800,6 +1796,7 @@ void Engine::HandleMouseClicks()
 	
 	// Check for clicks on stellar objects. Only left clicks apply, and the
 	// flagship must not be in the process of landing or taking off.
+	bool clickedPlanet = false;
 	const System *playerSystem = player.GetSystem();
 	if(!isRightClick && flagship->Zoom() == 1.)
 		for(const StellarObject &object : playerSystem->Objects())
@@ -1849,6 +1846,8 @@ void Engine::HandleMouseClicks()
 					break;
 			}
 		}
+		
+	bool clickedAsteroid = false;
 	if(clickTarget)
 	{
 		if(isRightClick)
@@ -1888,7 +1887,7 @@ void Engine::HandleMouseClicks()
 		}
 	}
 	
-	// If the player didn't click on anything, clear ship and asteroid targets.
+	// Treat an "empty" click as a request to clear targets.
 	if(!clickTarget && !isRightClick && !clickedAsteroid && !clickedPlanet)
 		flagship->SetTargetShip(nullptr);
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3475,6 +3475,7 @@ void Ship::SetTargetShip(const shared_ptr<Ship> &ship)
 		cargoScan = 0.;
 		outfitScan = 0.;
 	}
+	targetAsteroid.reset();
 }
 
 
@@ -3504,6 +3505,7 @@ void Ship::SetTargetSystem(const System *system)
 void Ship::SetTargetAsteroid(const shared_ptr<Minable> &asteroid)
 {
 	targetAsteroid = asteroid;
+	targetShip.reset();
 }
 
 


### PR DESCRIPTION
## Summary
This is a reopening of #4366.
Changes in the game:
1. Player cannot have both ship and asteroid targets simultaneously.
2. Clicking on ship deselects selected asteroid.
3. Clicking on asteroid deselects current ship.
4. Clicking on empty space deselects both ship and asteroid.
5. Asteroid target is now highlighted regardless of distance to flagship.

## Save File
[testsave.txt](https://github.com/endless-sky/endless-sky/files/5860438/Broken.Escorts.2.escorts.stuck.txt)