### PR TITLE
Fix: Reset snapshots scroll when swapping to different pilot

### DIFF
--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -327,6 +327,7 @@ bool LoadPanel::Click(int x, int y, int clicks)
 			{
 				selectedPilot = it.first;
 				selectedFile = it.second.front().first;
+				centerScroll = 0;
 			}
 	}
 	else if(x >= -110 && x < 110)


### PR DESCRIPTION
## Fix Details
If you have a pilot with enough snapshots and scroll down to the bottom, then you swap to a pilot with only the default amount of saves, the center panel will appear blank unless you scroll up. This PR causes the center scroll value to reset when selecting a new pilot.

## Testing Done
Tested that the scroll properly resets when selecting a new pilot, and stays as-is when clicking anything else.

## UI Screenshots
Here's the bug without the fix. With the fix, you'll just see things as normal.
![image](https://user-images.githubusercontent.com/4471575/105621470-46a79a00-5dcd-11eb-90b4-0c68e3cc028c.png)

## Save Files
Save file includes a pilot with many snapshots, in case you don't have one
[saves.zip](https://github.com/endless-sky/endless-sky/files/5861593/saves.zip)
