### PR TITLE
Fix: Cognizance system data sorting

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -8007,6 +8007,7 @@ system Denebola
 		period 2740.45
 
 system Diespiter
+	pos 332 210
 	asteroids "large metal" 76 3
 	asteroids "large rock" 3 1
 	asteroids "medium metal" 26 4
@@ -8041,7 +8042,6 @@ system Diespiter
 	object
 		period 10
 		sprite star/k5-old
-	pos 332 210
 
 system Diphda
 	pos -262 61
@@ -8727,6 +8727,7 @@ system Edusa
 		period 1675.01
 
 system Egeria
+	pos 288 146
 	asteroids "large metal" 5 4
 	asteroids "large rock" 9 7
 	asteroids "medium metal" 86 3
@@ -8762,7 +8763,6 @@ system Egeria
 		distance 74
 		period 19
 		sprite star/g0
-	pos 288 146
 
 system "Ehma Ti"
 	pos 39.1085 -749.244
@@ -19623,6 +19623,7 @@ system Procyon
 		period 3311.38
 
 system Prosa
+	pos 303 194
 	asteroids "large metal" 2 2
 	asteroids "large rock" 16 1
 	asteroids "medium metal" 11 2
@@ -19663,7 +19664,6 @@ system Prosa
 			distance 351
 			period 28
 			sprite planet/dust5
-	pos 303 194
 
 system "Pug Iyik"
 	pos -361.149 -883.233
@@ -23244,6 +23244,7 @@ system Spica
 			period 26.1539
 
 system Statina
+	pos 385 198
 	asteroids "large metal" 3 5
 	asteroids "large rock" 1 4
 	asteroids "medium metal" 72 3
@@ -23285,7 +23286,6 @@ system Statina
 		distance 2754
 		period 389
 		sprite planet/wormhole-red
-	pos 385 198
 
 system "Steep Roof"
 	pos -1113.59 570.051
@@ -24691,6 +24691,7 @@ system "Uwa Fahn"
 		period 5060.21
 
 system Vaticanus
+	pos 324 112
 	asteroids "large metal" 11 7
 	asteroids "large rock" 5 8
 	asteroids "medium metal" 47 11
@@ -24737,7 +24738,6 @@ system Vaticanus
 		distance 2754
 		period 389
 		sprite planet/wormhole-red
-	pos 324 112
 
 system Vega
 	pos -402 182

--- a/data/map.txt
+++ b/data/map.txt
@@ -8012,12 +8012,12 @@ system Diespiter
 	attributes "ember waste" "inaccessible"
 	haze _menu/haze-red
 	link Statina
-	asteroids "small metal" 74 2
-	asteroids "medium metal" 26 4
-	asteroids "large metal" 76 3
 	asteroids "small rock" 65 3
 	asteroids "medium rock" 14 1
 	asteroids "large rock" 3 1
+	asteroids "small metal" 74 2
+	asteroids "medium metal" 26 4
+	asteroids "large metal" 76 3
 	minables iron 22 3
 	minables silicon 46 3
 	minables tungsten 17 3
@@ -8733,11 +8733,11 @@ system Egeria
 	haze _menu/haze-red
 	link Vaticanus
 	link Statina
-	asteroids "medium metal" 86 3
-	asteroids "large metal" 5 4
 	asteroids "small rock" 1 8
 	asteroids "medium rock" 20 5
 	asteroids "large rock" 9 7
+	asteroids "medium metal" 86 3
+	asteroids "large metal" 5 4
 	minables iron 20 4
 	minables lead 28 5
 	hazard "Ember Waste Base Heat" 100
@@ -19456,10 +19456,10 @@ system Postverta
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
 	haze _menu/haze-red
-	asteroids "medium metal" 52 1
-	asteroids "large metal" 9 3
 	asteroids "medium rock" 4 2
 	asteroids "large rock" 4 3
+	asteroids "medium metal" 52 1
+	asteroids "large metal" 9 3
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
 	object
@@ -23250,10 +23250,10 @@ system Statina
 	haze _menu/haze-red
 	link Diespiter
 	link Egeria
+	asteroids "large rock" 1 4
 	asteroids "small metal" 39 3
 	asteroids "medium metal" 72 3
 	asteroids "large metal" 3 5
-	asteroids "large rock" 1 4
 	minables iron 5 6
 	minables silicon 11 5
 	minables titanium 10 4
@@ -24697,12 +24697,12 @@ system Vaticanus
 	haze _menu/haze-red
 	link Egeria
 	link Prosa
-	asteroids "small metal" 14 8
-	asteroids "medium metal" 47 11
-	asteroids "large metal" 11 7
 	asteroids "small rock" 3 6
 	asteroids "medium rock" 11 9
 	asteroids "large rock" 5 8
+	asteroids "small metal" 14 8
+	asteroids "medium metal" 47 11
+	asteroids "large metal" 11 7
 	minables lead 16 13
 	minables tungsten 10 13
 	hazard "Ember Waste Base Heat" 100

--- a/data/map.txt
+++ b/data/map.txt
@@ -8010,6 +8010,7 @@ system Diespiter
 	pos 332 210
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
+	habitable 534.375
 	haze _menu/haze-red
 	link Statina
 	asteroids "small rock" 65 3
@@ -8730,6 +8731,7 @@ system Egeria
 	pos 288 146
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
+	habitable 1505.92
 	haze _menu/haze-red
 	link Vaticanus
 	link Statina
@@ -19455,6 +19457,7 @@ system Postverta
 	pos 15000 15000
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
+	habitable 135
 	haze _menu/haze-red
 	asteroids "medium rock" 4 2
 	asteroids "large rock" 4 3
@@ -19626,6 +19629,7 @@ system Prosa
 	pos 303 194
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
+	habitable 2372.76
 	haze _menu/haze-red
 	link Vaticanus
 	asteroids "medium metal" 11 2
@@ -23247,6 +23251,7 @@ system Statina
 	pos 385 198
 	government Uninhabited
 	attributes "ember waste" "wormhole" "inaccessible"
+	habitable 135
 	haze _menu/haze-red
 	link Diespiter
 	link Egeria
@@ -24694,6 +24699,7 @@ system Vaticanus
 	pos 324 112
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
+	habitable 320
 	haze _menu/haze-red
 	link Egeria
 	link Prosa

--- a/data/map.txt
+++ b/data/map.txt
@@ -8024,24 +8024,24 @@ system Diespiter
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
 	object
-		period 10
 		sprite star/k5-old
+		period 10
 	object
+		sprite planet/ice6
 		distance 745
 		period 394
-		sprite planet/ice6
 	object
+		sprite planet/lava0
 		distance 922
 		period 543
-		sprite planet/lava0
 	object
+		sprite planet/gas11
 		distance 1600
 		period 398
-		sprite planet/gas11
 		object
+			sprite planet/rock3
 			distance 270
 			period 14
-			sprite planet/rock3
 
 system Diphda
 	pos -262 61
@@ -8743,26 +8743,26 @@ system Egeria
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
 	object
+		sprite star/k5-old
 		distance 40
 		offset 180
 		period 19
-		sprite star/k5-old
 	object
+		sprite star/g0
 		distance 74
 		period 19
-		sprite star/g0
 	object
+		sprite planet/ice4
 		distance 248
 		period 61
-		sprite planet/ice4
 	object
+		sprite planet/gas9
 		distance 1326
 		period 2174
-		sprite planet/gas9
 		object
+			sprite planet/rhea
 			distance 270
 			period 16
-			sprite planet/rhea
 
 system "Ehma Ti"
 	pos 39.1085 -749.244
@@ -19463,28 +19463,28 @@ system Postverta
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
 	object
-		period 19
 		sprite star/m4
+		period 19
 	object
+		sprite planet/desert7
 		distance 439
 		period 143
-		sprite planet/desert7
 	object
+		sprite planet/fog0
 		distance 814
 		period 362
-		sprite planet/fog0
 		object
+			sprite planet/dust4
 			distance 202
 			period 21
-			sprite planet/dust4
 	object
+		sprite planet/rock10
 		distance 1208
 		period 654
-		sprite planet/rock10
 	object "Ssil Vida"
+		sprite planet/sheragi_postverta
 		distance 1408
 		period 554
-		sprite planet/sheragi_postverta
 	
 system Prakacha'a
 	pos -35.1114 -802.607
@@ -19637,33 +19637,33 @@ system Prosa
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
 	object
+		sprite star/giant
 		offset 180
 		period 7
-		sprite star/giant
 	object
+		sprite planet/cloud1
 		distance 311
 		period 34
-		sprite planet/cloud1
 	object
+		sprite planet/desert9
 		distance 749
 		period 127
-		sprite planet/desert9
 	object
+		sprite planet/rock6
 		distance 941
 		period 179
-		sprite planet/rock6
 	object
+		sprite planet/gas17
 		distance 1311
 		period 695
-		sprite planet/gas17
 		object
+			sprite planet/callisto
 			distance 227
 			period 14
-			sprite planet/callisto
 		object
+			sprite planet/dust5
 			distance 351
 			period 28
-			sprite planet/dust5
 
 system "Pug Iyik"
 	pos -361.149 -883.233
@@ -23260,32 +23260,32 @@ system Statina
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
 	object
-		period 10
 		sprite star/m4
+		period 10
 	object
+		sprite planet/desert4
 		distance 111
 		period 30
-		sprite planet/desert4
 	object
+		sprite planet/dust3
 		distance 308
 		period 142
-		sprite planet/dust3
 	object
+		sprite planet/gas8
 		distance 636
 		period 420
-		sprite planet/gas8
 	object
+		sprite planet/ice5
 		distance 1364
 		period 84
-		sprite planet/ice5
 		object
+			sprite planet/dust4
 			distance 158
 			period 17
-			sprite planet/dust4
 	object wormhole_link
+		sprite planet/wormhole-red
 		distance 2754
 		period 389
-		sprite planet/wormhole-red
 
 system "Steep Roof"
 	pos -1113.59 570.051
@@ -24708,36 +24708,36 @@ system Vaticanus
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
 	object
-		period 19
 		sprite star/m0
+		period 19
 	object
+		sprite planet/ice6
 		distance 261
 		period 73
-		sprite planet/ice6
 	object
+		sprite planet/tethys
 		distance 768
 		period 368
-		sprite planet/tethys
 	object
 		distance 1670
 		period 1181
 		sprite planet/gas16
 		object
+			sprite planet/lava1
 			distance 204
 			period 14
-			sprite planet/lava1
 	object
+		sprite planet/uranus
 		distance 2105
 		period 3438
-		sprite planet/uranus
 		object
+			sprite planet/luna
 			distance 235
 			period 14
-			sprite planet/luna
 	object wormhole_link
+		sprite planet/wormhole-red
 		distance 2754
 		period 389
-		sprite planet/wormhole-red
 
 system Vega
 	pos -402 182

--- a/data/map.txt
+++ b/data/map.txt
@@ -8008,16 +8008,16 @@ system Denebola
 
 system Diespiter
 	pos 332 210
+	government Uninhabited
+	attributes "ember waste" "inaccessible"
+	haze _menu/haze-red
+	link Statina
 	asteroids "large metal" 76 3
 	asteroids "large rock" 3 1
 	asteroids "medium metal" 26 4
 	asteroids "medium rock" 14 1
 	asteroids "small metal" 74 2
 	asteroids "small rock" 65 3
-	government Uninhabited
-	attributes "ember waste" "inaccessible"
-	haze _menu/haze-red
-	link Statina
 	minables iron 22 3
 	minables silicon 46 3
 	minables tungsten 17 3
@@ -8728,16 +8728,16 @@ system Edusa
 
 system Egeria
 	pos 288 146
-	asteroids "large metal" 5 4
-	asteroids "large rock" 9 7
-	asteroids "medium metal" 86 3
-	asteroids "medium rock" 20 5
-	asteroids "small rock" 1 8
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
 	haze _menu/haze-red
 	link Vaticanus
 	link Statina
+	asteroids "large metal" 5 4
+	asteroids "large rock" 9 7
+	asteroids "medium metal" 86 3
+	asteroids "medium rock" 20 5
+	asteroids "small rock" 1 8
 	minables iron 20 4
 	minables lead 28 5
 	hazard "Ember Waste Base Heat" 100
@@ -19624,15 +19624,15 @@ system Procyon
 
 system Prosa
 	pos 303 194
+	government Uninhabited
+	attributes "ember waste" "inaccessible"
+	haze _menu/haze-red
+	link Vaticanus
 	asteroids "large metal" 2 2
 	asteroids "large rock" 16 1
 	asteroids "medium metal" 11 2
 	asteroids "medium rock" 16 1
 	asteroids "small rock" 4 1
-	government Uninhabited
-	attributes "ember waste" "inaccessible"
-	haze _menu/haze-red
-	link Vaticanus
 	minables copper 5 2
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
@@ -23245,15 +23245,15 @@ system Spica
 
 system Statina
 	pos 385 198
-	asteroids "large metal" 3 5
-	asteroids "large rock" 1 4
-	asteroids "medium metal" 72 3
-	asteroids "small metal" 39 3
 	government Uninhabited
 	attributes "ember waste" "wormhole" "inaccessible"
 	haze _menu/haze-red
 	link Diespiter
 	link Egeria
+	asteroids "large metal" 3 5
+	asteroids "large rock" 1 4
+	asteroids "medium metal" 72 3
+	asteroids "small metal" 39 3
 	minables iron 5 6
 	minables silicon 11 5
 	minables titanium 10 4
@@ -24692,17 +24692,17 @@ system "Uwa Fahn"
 
 system Vaticanus
 	pos 324 112
+	government Uninhabited
+	attributes "ember waste" "inaccessible"
+	haze _menu/haze-red
+	link Egeria
+	link Prosa
 	asteroids "large metal" 11 7
 	asteroids "large rock" 5 8
 	asteroids "medium metal" 47 11
 	asteroids "medium rock" 11 9
 	asteroids "small metal" 14 8
 	asteroids "small rock" 3 6
-	government Uninhabited
-	attributes "ember waste" "inaccessible"
-	haze _menu/haze-red
-	link Egeria
-	link Prosa
 	minables lead 16 13
 	minables tungsten 10 13
 	hazard "Ember Waste Base Heat" 100

--- a/data/map.txt
+++ b/data/map.txt
@@ -8012,25 +8012,20 @@ system Diespiter
 	attributes "ember waste" "inaccessible"
 	haze _menu/haze-red
 	link Statina
-	asteroids "large metal" 76 3
-	asteroids "large rock" 3 1
-	asteroids "medium metal" 26 4
-	asteroids "medium rock" 14 1
 	asteroids "small metal" 74 2
+	asteroids "medium metal" 26 4
+	asteroids "large metal" 76 3
 	asteroids "small rock" 65 3
+	asteroids "medium rock" 14 1
+	asteroids "large rock" 3 1
 	minables iron 22 3
 	minables silicon 46 3
 	minables tungsten 17 3
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
 	object
-		distance 1600
-		period 398
-		sprite planet/gas11
-		object
-			distance 270
-			period 14
-			sprite planet/rock3
+		period 10
+		sprite star/k5-old
 	object
 		distance 745
 		period 394
@@ -8040,8 +8035,13 @@ system Diespiter
 		period 543
 		sprite planet/lava0
 	object
-		period 10
-		sprite star/k5-old
+		distance 1600
+		period 398
+		sprite planet/gas11
+		object
+			distance 270
+			period 14
+			sprite planet/rock3
 
 system Diphda
 	pos -262 61
@@ -8733,15 +8733,28 @@ system Egeria
 	haze _menu/haze-red
 	link Vaticanus
 	link Statina
-	asteroids "large metal" 5 4
-	asteroids "large rock" 9 7
 	asteroids "medium metal" 86 3
-	asteroids "medium rock" 20 5
+	asteroids "large metal" 5 4
 	asteroids "small rock" 1 8
+	asteroids "medium rock" 20 5
+	asteroids "large rock" 9 7
 	minables iron 20 4
 	minables lead 28 5
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
+	object
+		distance 40
+		offset 180
+		period 19
+		sprite star/k5-old
+	object
+		distance 74
+		period 19
+		sprite star/g0
+	object
+		distance 248
+		period 61
+		sprite planet/ice4
 	object
 		distance 1326
 		period 2174
@@ -8750,19 +8763,6 @@ system Egeria
 			distance 270
 			period 16
 			sprite planet/rhea
-	object
-		distance 40
-		offset 180
-		period 19
-		sprite star/k5-old
-	object
-		distance 248
-		period 61
-		sprite planet/ice4
-	object
-		distance 74
-		period 19
-		sprite star/g0
 
 system "Ehma Ti"
 	pos 39.1085 -749.244
@@ -19456,20 +19456,15 @@ system Postverta
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
 	haze _menu/haze-red
-	asteroids "large metal" 9 3
-	asteroids "large rock" 4 3
 	asteroids "medium metal" 52 1
+	asteroids "large metal" 9 3
 	asteroids "medium rock" 4 2
+	asteroids "large rock" 4 3
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
-	object "Ssil Vida"
-		distance 1408
-		period 554
-		sprite planet/sheragi_postverta
 	object
-		distance 1208
-		period 654
-		sprite planet/rock10
+		period 19
+		sprite star/m4
 	object
 		distance 439
 		period 143
@@ -19483,8 +19478,13 @@ system Postverta
 			period 21
 			sprite planet/dust4
 	object
-		period 19
-		sprite star/m4
+		distance 1208
+		period 654
+		sprite planet/rock10
+	object "Ssil Vida"
+		distance 1408
+		period 554
+		sprite planet/sheragi_postverta
 	
 system Prakacha'a
 	pos -35.1114 -802.607
@@ -19628,14 +19628,18 @@ system Prosa
 	attributes "ember waste" "inaccessible"
 	haze _menu/haze-red
 	link Vaticanus
-	asteroids "large metal" 2 2
-	asteroids "large rock" 16 1
 	asteroids "medium metal" 11 2
-	asteroids "medium rock" 16 1
+	asteroids "large metal" 2 2
 	asteroids "small rock" 4 1
+	asteroids "medium rock" 16 1
+	asteroids "large rock" 16 1
 	minables copper 5 2
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
+	object
+		offset 180
+		period 7
+		sprite star/giant
 	object
 		distance 311
 		period 34
@@ -19648,10 +19652,6 @@ system Prosa
 		distance 941
 		period 179
 		sprite planet/rock6
-	object
-		offset 180
-		period 7
-		sprite star/giant
 	object
 		distance 1311
 		period 695
@@ -23250,15 +23250,18 @@ system Statina
 	haze _menu/haze-red
 	link Diespiter
 	link Egeria
+	asteroids "small metal" 39 3
+	asteroids "medium metal" 72 3
 	asteroids "large metal" 3 5
 	asteroids "large rock" 1 4
-	asteroids "medium metal" 72 3
-	asteroids "small metal" 39 3
 	minables iron 5 6
 	minables silicon 11 5
 	minables titanium 10 4
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
+	object
+		period 10
+		sprite star/m4
 	object
 		distance 111
 		period 30
@@ -23271,9 +23274,6 @@ system Statina
 		distance 636
 		period 420
 		sprite planet/gas8
-	object
-		period 10
-		sprite star/m4
 	object
 		distance 1364
 		period 84
@@ -24697,16 +24697,27 @@ system Vaticanus
 	haze _menu/haze-red
 	link Egeria
 	link Prosa
-	asteroids "large metal" 11 7
-	asteroids "large rock" 5 8
-	asteroids "medium metal" 47 11
-	asteroids "medium rock" 11 9
 	asteroids "small metal" 14 8
+	asteroids "medium metal" 47 11
+	asteroids "large metal" 11 7
 	asteroids "small rock" 3 6
+	asteroids "medium rock" 11 9
+	asteroids "large rock" 5 8
 	minables lead 16 13
 	minables tungsten 10 13
 	hazard "Ember Waste Base Heat" 100
 	hazard "Ember Waste Base Storm" 9000
+	object
+		period 19
+		sprite star/m0
+	object
+		distance 261
+		period 73
+		sprite planet/ice6
+	object
+		distance 768
+		period 368
+		sprite planet/tethys
 	object
 		distance 1670
 		period 1181
@@ -24723,17 +24734,6 @@ system Vaticanus
 			distance 235
 			period 14
 			sprite planet/luna
-	object
-		distance 261
-		period 73
-		sprite planet/ice6
-	object
-		distance 768
-		period 368
-		sprite planet/tethys
-	object
-		period 19
-		sprite star/m0
 	object wormhole_link
 		distance 2754
 		period 389


### PR DESCRIPTION
**Bugfix:** This PR addresses the issue that the new systems in the Ember Waste's data isn't sorted correctly.

## Fix Details
Moving system attributes into the following order:
- Pos
- government
- attributes
- haze
- link
- asteroid
    - first by type, then by size.
- minables
- hazards
- objects
    - From innermost to outermost.

