### PR TITLE
Update references to population sizes of human worlds

### DIFF
--- a/data/intro missions.txt
+++ b/data/intro missions.txt
@@ -161,7 +161,7 @@ mission "Intro [3 Transport]"
 	on offer
 		conversation
 			`The spaceport on <origin> is so big and crowded that it takes a long time to find James. The sheer number of people here is almost overwhelming. Homeless men wrapped in old army blankets beg money from well-dressed businessmen. Soldiers in Navy uniforms walk by in groups of ten or twenty, all marching in unison. Starship captains haggle with merchants over trade goods and jobs. Flashes of light come from various landing bays as welders make repairs.`
-			`	When you find James, he's standing by a window, looking out at the city, watching the starships taking off and landing in a continuous stream. "This is it," he says, "where our race began. The world that all the tourists want to visit, and that no one wants to live on. Ten billion people, more industry and exports than any other place in the galaxy. But underneath it all, poverty of a completely different sort from what you've got in the Dirt Belt."`
+			`	When you find James, he's standing by a window, looking out at the city, watching the starships taking off and landing in a continuous stream. "This is it," he says, "where our race began. The world that all the tourists want to visit, and that no one wants to live on. Twenty billion people, more industry and exports than any other place in the galaxy. But underneath it all, poverty of a completely different sort from what you've got in the Dirt Belt."`
 			`	After taking one last glance out the window, he says, "Anyway, we're nearing my destination. Are you willing to take me on one last trip? I need to get to <destination>, and of course I'll pay you quite well to take me there."`
 			choice
 				`	"Of course."`

--- a/data/map.txt
+++ b/data/map.txt
@@ -26657,7 +26657,7 @@ planet "Chosen Nexus"
 planet Clark
 	attributes "dirt belt" forest factory
 	landscape land/valley3
-	description `Clark is a recently settled world, and most of its surface remains covered in dense forests and uninhabited mountains. Because clearing new land is so difficult, agriculture here has not grown far beyond the level of subsistence farming. But the temperate climate has drawn several million settlers, most of whom work in factories that have been planted here by off-world corporations to take advantage of the cheap labor.`
+	description `Clark is a recently settled world, and most of its surface remains covered in dense forests and uninhabited mountains. Because clearing new land is so difficult, agriculture here has not grown far beyond the level of subsistence farming. But the temperate climate has drawn tens of millions of settlers, most of whom work in factories that have been planted here by off-world corporations to take advantage of the cheap labor.`
 	description `	The low cost of living and virtually zero unemployment rate make poverty and crime relatively rare occurrences. Instead there is a pioneering spirit, a startup-world attitude that anything is attainable with a bit of hard work and frugality.`
 	spaceport `The spaceport is at the heart of one of Clark's largest cities, surrounded by smokestacks and factories. There are a few hangars owned by different corporations where their cargo ships can load and unload, but you are relegated to a set of concrete landing pads farther from the main buildings. Large trucks rumble by carrying carts loaded down with cargo crates.`
 	spaceport `	In the central building, dozens of workers fill a large cafeteria with several stations serving different types of food. The mood here feels boisterous and energetic, very different from most of the Dirt Belt worlds you have visited.`
@@ -29239,7 +29239,7 @@ planet Sundrinker
 planet Sunracer
 	attributes core urban factory farming fishing frontier
 	landscape land/myrabella8
-	description `Sunracer is home of Megaparsec, Inc., a shipyard that specializes in designing fast, lightweight ships. It is a well-settled planet with a population of nearly half a billion, and a diverse economy that includes farming and fishing in addition to the shipyards.`
+	description `Sunracer is home of Megaparsec, Inc., a shipyard that specializes in designing fast, lightweight ships. It is a well-settled planet with a population of over a billion, and a diverse economy that includes farming and fishing in addition to the shipyards.`
 	description `	Outside the cities, large regions of undeveloped land still remain. Hovercraft racing is a major local sport, and some massive and elaborate courses have been constructed in the wilderness.`
 	spaceport `On Sunracer, the spaceport and shipyard are one and the same. As you walk among the landing pads and hangars, it is not immediately clear which ships are visiting starships undergoing minor repairs, and which are new ones under construction. A series of enormous cranes tower over one section of landing pads. From them hang hull fragments, engines, and even a few small ships, each being swung from one location within the shipyard to another. Meanwhile, forklifts and flatbed trucks are weaving between the buildings in every direction.`
 	shipyard "Basic Ships"
@@ -29310,7 +29310,7 @@ planet Thule
 planet Thunder
 	attributes rim
 	landscape land/mountain20-harro
-	description `When the first colonists landed, they thought that they had found a dream world on Thunder: perfect gravity, perfect temperature, perfect atmosphere. Unfortunately, they soon discovered that the planet has unusually high tectonic activity, enough that building anything higher than two stories is almost impossible. Because of the earthquakes, attracting settlers has always been difficult for Thunder, and right now the population is only a few million.`
+	description `When the first colonists landed, they thought that they had found a dream world on Thunder: perfect gravity, perfect temperature, perfect atmosphere. Unfortunately, they soon discovered that the planet has unusually high tectonic activity, enough that building anything higher than two stories is almost impossible. Because of the earthquakes, attracting settlers has always been difficult for Thunder, and right now the population is only about thirty million, much less than what this world might otherwise have.`
 	spaceport `The spaceport's landing pads are all solid slabs of metal; poured concrete would be far too prone to cracking. The spaceport village itself is a sprawling collection of squat, sturdy buildings, and a sign near the entrance to the cargo warehouse reads, "Do not stack crates."`
 	outfitter "Basic Outfits"
 	outfitter "Kraz Basics"
@@ -29455,7 +29455,7 @@ planet Vail
 planet Valhalla
 	attributes deep farming fishing urban factory
 	landscape land/mfield3
-	description `Valhalla was the first world to be settled in this region of space, which is known as the Deep. It is rich in natural resources, but all its vast farms and fisheries are insufficient to feed its population of nearly five billion.`
+	description `Valhalla was the first world to be settled in this region of space, which is known as the Deep. It is rich in natural resources, but all its vast farms and fisheries are insufficient to feed its population of over five billion.`
 	description `	The shipyards of Lionheart Industries are located here. Centuries ago, warships built here turned the tide of the Alpha War, and today the ships designed and built in the Deep continue to be some of the most technologically advanced ships in human space - and the most expensive.`
 	spaceport `Surrounding the spaceport is a metropolis of skyscrapers and factories that spreads all the way to the horizon in every direction. The spaceport itself is an imposing building, composed of three towers rising over a hundred stories into the air and connected at various levels by bridges. The docking bays are on the higher levels, with warehouse space lower down and loading platforms for trucks at ground level. Massive cargo elevators run up and down in the center of each building, and the hallways are all wide enough to allow small robotic carts and forklifts in addition to foot traffic.`
 	shipyard "Basic Ships"

--- a/data/map.txt
+++ b/data/map.txt
@@ -29310,7 +29310,7 @@ planet Thule
 planet Thunder
 	attributes rim
 	landscape land/mountain20-harro
-	description `When the first colonists landed, they thought that they had found a dream world on Thunder: perfect gravity, perfect temperature, perfect atmosphere. Unfortunately, they soon discovered that the planet has unusually high tectonic activity, enough that building anything higher than two stories is almost impossible. Because of the earthquakes, attracting settlers has always been difficult for Thunder, and right now the population is only about thirty million, much less than what this world might otherwise have.`
+	description `When the first colonists landed, they thought that they had found a dream world on Thunder: perfect gravity, perfect temperature, perfect atmosphere. Unfortunately, they soon discovered that the planet has unusually high tectonic activity, enough that building anything higher than two stories is almost impossible. Because of the earthquakes, attracting settlers has always been difficult for Thunder, and right now the population is only a few million.`
 	spaceport `The spaceport's landing pads are all solid slabs of metal; poured concrete would be far too prone to cracking. The spaceport village itself is a sprawling collection of squat, sturdy buildings, and a sign near the entrance to the cargo warehouse reads, "Do not stack crates."`
 	outfitter "Basic Outfits"
 	outfitter "Kraz Basics"


### PR DESCRIPTION
**Content**

## TL;DR (Isn't that what a summary is suppose to be?)

I simulated population sizes of all the worlds in human space. Some planets have mentions of their population size, but the numbers I ended up with don't match the descriptions. Instead of lowering the total number of people as given by MZ at roughly 100 billion, and instead of bringing up the population density of lesser inhabited planets by an insane amount just so I could reach that final number without clashing with the planet descriptions that existed, I've decided to change some descriptions according to what I simulated, essentially canonizing the numbers I came up with.

Link to my numbers is [here](https://docs.google.com/spreadsheets/d/1dWKimAiiXrlVCibdjyiFNqtQJdiXJqB7F0Cs9La0Z60/edit?usp=sharing).

The sheet also includes settlement dates for planets where they could be easily known. No, I'm not going to finish creating settlement dates for all planets right now. Yes, I'll eventually do it later, and we can canonize that too.

## (The not so) Summary
A while back now, I asked MZ for population numbers on the various species in the game, and he gave some rough numbers [here](https://github.com/endless-sky/endless-sky/issues/2540#issuecomment-302986796). A question that that has begged though is how those roughly 100 billion humans are spread out across the galaxy. Only a few planet descriptions actually mention anything concrete about population size of the planet, those being Valhalla, Midgard, Thule, Sunracer, Clark, Heartland, New Sahara, Sinter, Prime, Zug, and Thunder. We then learn from the Shuttle intro how many people Earth has. So great! That's 12 planets out of... 157 accounted for. Some other planet descriptions give numbers on a subset of the population, like millions of Amish on Harmony and tens of thousands of homeless on Bourne, but without more information on the proportion of the population within those groups, the descriptions really only give us lower bounds.

There are some more things we can look to, like how Earth is more than twice as populous as the next closest planet, and Chiron is the second most populous planet, but for the most part we don't have much in the way of figuring out how populated various regions of space are. At best we get a description on many worlds of them being sparsely populated or only having a single settlement or only having towns and no cities or being overpopulated. Well what defines a world as sparsely populated? How many people can a single settlement hold? How many people need to be in a region before it's considered a city? How many people does your average town have? How many people does a planet have to be considered overpopulated? Is overpopulation a factor of resources per person or of number of people? We might look to how we'd define these terms on Earth today, but I imagine that cities of the future are far larger and more impressive than those today, so it takes more to be considered a major city in the Republic.

I've wanted for a while now to try and make out how many people are on each planet, but it's only recently after some discussion on Discord that I actually cared to get around to it. Over the course of three days I read through every planet description in human space, as well as looked at all the attributes on all the planets, in order to get a rough idea of the ranking of the planets. Some planets were easy, like I mentioned above, providing a rough number for me. Most though mentioned nothing of population and only described the state of the planet. Using those descriptions of how nice of a place the planet was, and in some cases giving me a timeline of when the planet was settled, I was able to roughly rank all the planets in terms of population by assigning them random population numbers. These original numbers I came up with only came out to about 60 billion, but using the rankings I was able to create a function that would give me population numbers for a planet depending on its rank (although I did have to fiddle with it by often skipping ranks, e.g. most populous planet 20 and most populous planet 21 might have actually been considered rank 20 and rank 22 in the function, and toward the end planet 140 was actually like rank 2000 in the function, but whatever the case I got a distribution I like and a total value that is roughly around the original number of 100 billion).

For the curious, the function I used was an altered curve that describes the current populations of countries on Earth, scaled to fit Earth at about 20 billion. Seeing as how a good number of planets are named `"New <country>"` or `"New <city>"`, comparing planets to countries doesn't seem too out there.

My final spreadsheet for the population of planets can be found [here](https://docs.google.com/spreadsheets/d/1dWKimAiiXrlVCibdjyiFNqtQJdiXJqB7F0Cs9La0Z60/edit?usp=sharing). The top of this spreadsheet includes the population of groups of humans, the first being humanity as a whole, then going down into regions of humanity, some of which overlap. The "no planet of residence" line is a random number that I pulled out that refers to the number of people who basically live on ships, so merchant captains and their crew, or militia members, or maybe even Navy and Syndicated Security members that spend most of their time amongst the stars. The sheet then sorts the planets into regions, sorting the regions alphabetically and sorting the planets within the regions by population size.

As you might be able to see though, I've changed the population sizes of some planets from how they were described. I already mentioned how my original numbers came out to about 60 billion. Well in order to get 40 billion more people, I would have had to create many, many planets with close to or over a billion people on them, and planets described as sparsely populated would have a lot more people on them than I would expect. So instead of trying to force 40 billion into the upper limit that we had, which was 10 billion on Earth and 5 billion at most on any other planet, I decided to tweak some of the numbers we had. This includes bumping Earth's population from 10 billion to 20 billion, which allowed me to drag some other planets up with that, such as increasing Chiron's population from about 5 billion to about 10 billion, and Moonshake's population from the 3.5 or 4 billion that I originally had to about 7 billion. All these changes allowed for me to reach a total population that was close to 100 billion.

While this PR only changes descriptions to match my spreadsheet, everything from my spreadsheet can't be found in game. This is where #3663 gets involved, which entails providing information like this to the player in-game in an in-universe way. My idea as to how this data might be provided in-universe is by saying that this is census data. Perhaps the Republic does a census every 20 or 25 years, and 3000 was when the last census was done. (You can also see that I simulated what the population growth would need to be to hit 100 billion people by 3013, game start, and the answer is an average of 0.195% per year for all of humanity.) The player could then probably get this census data from Alexandria. Other than that, perhaps we create spaceport news that only appears on an exact planet for every planet, giving the player more information on how life is on each planet in the game, including mentions of the population size (perhaps not exact, but rough numbers).

## Save File
N/A

## PR Checklist
N/A