### PR TITLE
Ships with "disables" personality no longer kill plundered ships

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1664,7 +1664,7 @@ fleet "Small Southern Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		plunders harvests
+		disables plunders harvests
 		confusion 20
 	variant 8
 		"Sparrow"
@@ -1844,7 +1844,7 @@ fleet "Small Independent"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 		confusion 20
 	variant 8
 		"Sparrow"
@@ -1962,7 +1962,7 @@ fleet "Small Core Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		plunders harvests
+		disables plunders harvests
 		confusion 20
 	variant 3
 		"Quicksilver"
@@ -2077,7 +2077,7 @@ fleet "Small Northern Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		plunders harvests
+		disables plunders harvests
 		confusion 20
 	variant 5
 		"Sparrow"

--- a/data/remnant/remnant.txt
+++ b/data/remnant/remnant.txt
@@ -13,7 +13,7 @@ fleet "Small Remnant"
 	names "remnant"
 	cargo 2
 	personality
-		heroic disables plunders appeasing
+		heroic plunders appeasing
 	variant 8
 		"Starling"
 	variant 6
@@ -40,38 +40,30 @@ fleet "Large Remnant"
 	names "remnant"
 	cargo 2
 	personality
-		heroic disables plunders appeasing
+		heroic plunders appeasing
 	variant 6
 		"Albatross"
-		"Starling" 2
 	variant 6
 		"Albatross (Sniper)"
-		"Starling (Sniper)" 2
 	variant 6
 		"Albatross (Turret)"
-		"Starling (Thrasher)" 2
 	variant 6
 		"Albatross (Heavy)"
-		"Starling (Heavy)" 2
 	variant 3
 		"Albatross"
-		"Starling (Hunter)" 2
 	variant 3
 		"Albatross (Sniper)"
-		"Starling (Hunter)" 2
 	variant 2
 		"Albatross"
-		"Albatross (Sniper)"
 	variant 2
 		"Albatross (Heavy)"
-		"Albatross (Turret)"
 
 fleet "Remnant Transport"
 	government "Remnant"
 	names "remnant"
 	cargo 2
 	personality
-		disables plunders coward appeasing mining harvests
+		plunders coward appeasing mining harvests
 	variant 10
 		"Gull"
 	variant 5
@@ -110,7 +102,7 @@ fleet "Remnant Home Guard"
 	names "remnant"
 	cargo 2
 	personality
-		disables plunders appeasing mining harvests surveillance
+		plunders appeasing mining harvests surveillance
 	variant 20
 		"Tern" 1
 	variant 10

--- a/data/remnant/remnant.txt
+++ b/data/remnant/remnant.txt
@@ -43,20 +43,28 @@ fleet "Large Remnant"
 		heroic plunders appeasing
 	variant 6
 		"Albatross"
+		"Starling" 2
 	variant 6
 		"Albatross (Sniper)"
+		"Starling (Sniper)" 2
 	variant 6
 		"Albatross (Turret)"
+		"Starling (Thrasher)" 2
 	variant 6
 		"Albatross (Heavy)"
+		"Starling (Heavy)" 2
 	variant 3
 		"Albatross"
+		"Starling (Hunter)" 2
 	variant 3
 		"Albatross (Sniper)"
+		"Starling (Hunter)" 2
 	variant 2
 		"Albatross"
+		"Albatross (Sniper)"
 	variant 2
 		"Albatross (Heavy)"
+		"Albatross (Turret)"
 
 fleet "Remnant Transport"
 	government "Remnant"

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2876,7 +2876,8 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 		currentTarget.reset();
 	
 	// Only fire on disabled targets if you don't want to plunder them.
-	bool spareDisabled = (person.Disables() || (person.Plunders() && ship.Cargo().Free()));
+	bool plunders = (person.Plunders() && ship.Cargo().Free());
+	bool disables = person.Disables();
 	
 	// Don't use weapons with firing force if you are preparing to jump.
 	bool isWaitingToJump = ship.Commands().Has(Command::JUMP | Command::WAIT);
@@ -2949,7 +2950,7 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 		{
 			// NPCs shoot ships that they just plundered.
 			bool hasBoarded = !ship.IsYours() && Has(ship, currentTarget, ShipEvent::BOARD);
-			if(currentTarget->IsDisabled() && spareDisabled && (!hasBoarded || person.Disables()) && !disabledOverride)
+			if(currentTarget->IsDisabled() && (disables || (plunders && !hasBoarded)) && !disabledOverride)
 				continue;
 			// Don't fire secondary weapons at targets that have started jumping.
 			if(weapon->Icon() && currentTarget->IsEnteringHyperspace())
@@ -2984,7 +2985,7 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 		{
 			// NPCs shoot ships that they just plundered.
 			bool hasBoarded = !ship.IsYours() && Has(ship, target, ShipEvent::BOARD);
-			if(target->IsDisabled() && spareDisabled && (!hasBoarded || person.Disables()) && !disabledOverride)
+			if(target->IsDisabled() && (disables || (plunders && !hasBoarded)) && !disabledOverride)
 				continue;
 			
 			Point p = target->Position() - start;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1401,10 +1401,6 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 			MoveTo(ship, command, target->Position(), target->Velocity(), 40., .8);
 			command |= Command::BOARD;
 		}
-		else if(hasBoarded && ship.GetPersonality().Disables())
-		{
-			// Ships with "disables" personality don't destroy their targets after boarding.
-		}
 		else
 			Attack(ship, command, *target);
 		return;
@@ -2953,7 +2949,7 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 		{
 			// NPCs shoot ships that they just plundered.
 			bool hasBoarded = !ship.IsYours() && Has(ship, currentTarget, ShipEvent::BOARD);
-			if(currentTarget->IsDisabled() && spareDisabled && !hasBoarded && !disabledOverride)
+			if(currentTarget->IsDisabled() && spareDisabled && (!hasBoarded || person.Disables()) && !disabledOverride)
 				continue;
 			// Don't fire secondary weapons at targets that have started jumping.
 			if(weapon->Icon() && currentTarget->IsEnteringHyperspace())
@@ -2988,7 +2984,7 @@ void AI::AutoFire(const Ship &ship, Command &command, bool secondary) const
 		{
 			// NPCs shoot ships that they just plundered.
 			bool hasBoarded = !ship.IsYours() && Has(ship, target, ShipEvent::BOARD);
-			if(target->IsDisabled() && spareDisabled && !hasBoarded && !disabledOverride)
+			if(target->IsDisabled() && spareDisabled && (!hasBoarded || person.Disables()) && !disabledOverride)
 				continue;
 			
 			Point p = target->Position() - start;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1090,13 +1090,6 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	if(!gov || ship.GetPersonality().IsPacifist())
 		return target;
 	
-	// Ships with 'plunders' personality always destroy the ships they have boarded.
-	const Personality &person = ship.GetPersonality();
-	shared_ptr<Ship> oldTarget = ship.GetTargetShip();
-	if(oldTarget && oldTarget->IsTargetable() && oldTarget->IsDisabled() && person.Plunders()
-			&& !person.Disables() && Has(ship, oldTarget, ShipEvent::BOARD))
-		return oldTarget;
-	
 	bool isYours = ship.IsYours();
 	if(isYours)
 	{
@@ -1117,11 +1110,17 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	if(!maxRange)
 		return target;
 	
+	const Personality &person = ship.GetPersonality();
+	shared_ptr<Ship> oldTarget = ship.GetTargetShip();
 	if(oldTarget && !oldTarget->IsTargetable())
 		oldTarget.reset();
 	if(oldTarget && person.IsTimid() && oldTarget->IsDisabled()
 			&& ship.Position().Distance(oldTarget->Position()) > 1000.)
 		oldTarget.reset();
+	// Ships with 'plunders' personality always destroy the ships they have boarded.
+	if(oldTarget && oldTarget->IsDisabled() && person.Plunders()
+			&& !person.Disables() && Has(ship, oldTarget, ShipEvent::BOARD))
+		return oldTarget;
 	shared_ptr<Ship> parentTarget;
 	bool parentIsEnemy = (ship.GetParent() && ship.GetParent()->GetGovernment()->IsEnemy(gov));
 	if(ship.GetParent() && !parentIsEnemy)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1118,8 +1118,8 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 			&& ship.Position().Distance(oldTarget->Position()) > 1000.)
 		oldTarget.reset();
 	// Ships with 'plunders' personality always destroy the ships they have boarded.
-	if(oldTarget && oldTarget->IsDisabled() && person.Plunders()
-			&& !person.Disables() && Has(ship, oldTarget, ShipEvent::BOARD))
+	if(oldTarget && person.Plunders() && !person.Disables() 
+			&& oldTarget->IsDisabled() && Has(ship, oldTarget, ShipEvent::BOARD))
 		return oldTarget;
 	shared_ptr<Ship> parentTarget;
 	bool parentIsEnemy = (ship.GetParent() && ship.GetParent()->GetGovernment()->IsEnemy(gov));

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1090,6 +1090,13 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	if(!gov || ship.GetPersonality().IsPacifist())
 		return target;
 	
+	// Ships with 'plunders' personality always destroy the ships they have boarded.
+	const Personality &person = ship.GetPersonality();
+	shared_ptr<Ship> oldTarget = ship.GetTargetShip();
+	if(oldTarget && oldTarget->IsTargetable() && oldTarget->IsDisabled() && person.Plunders()
+			&& !person.Disables() && Has(ship, oldTarget, ShipEvent::BOARD))
+		return oldTarget;
+	
 	bool isYours = ship.IsYours();
 	if(isYours)
 	{
@@ -1110,8 +1117,6 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	if(!maxRange)
 		return target;
 	
-	const Personality &person = ship.GetPersonality();
-	shared_ptr<Ship> oldTarget = ship.GetTargetShip();
 	if(oldTarget && !oldTarget->IsTargetable())
 		oldTarget.reset();
 	if(oldTarget && person.IsTimid() && oldTarget->IsDisabled()

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1401,6 +1401,10 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 			MoveTo(ship, command, target->Position(), target->Velocity(), 40., .8);
 			command |= Command::BOARD;
 		}
+		else if(hasBoarded && ship.GetPersonality().Disables())
+		{
+			// Ships with "disables" personality don't destroy their targets after boarding.
+		}
 		else
 			Attack(ship, command, *target);
 		return;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2177,15 +2177,14 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder)
 	{
 		// Take any commodities that fit.
 		victim->cargo.TransferAll(cargo, false);
-		// Stop targeting this ship.
-		SetTargetShip(shared_ptr<Ship>());
 		
 		// Pause for two seconds before moving on.
 		pilotError = 120;
 	}
 	
 	// Stop targeting this ship (so you will not board it again right away).
-	SetTargetShip(shared_ptr<Ship>());
+	if(personality.Disables() || !personality.Plunders())
+		SetTargetShip(shared_ptr<Ship>());
 	return victim;
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2183,7 +2183,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder)
 	}
 	
 	// Stop targeting this ship (so you will not board it again right away).
-	if(personality.Disables() || !personality.Plunders())
+	if(!autoPlunder || personality.Disables())
 		SetTargetShip(shared_ptr<Ship>());
 	return victim;
 }


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5540

This creates another problem: endless plundering (since the plundered ships are no longer killed, every ship entering the system that can plunder it does so).

## Save File
[Craig.McCauley.txt](https://github.com/endless-sky/endless-sky/files/5881207/Craig.McCauley.txt)