### PR TITLE
Change Kestrels to use new bay syntax

### DIFF
--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -308,8 +308,8 @@ ship "Kestrel"
 		"Hyperdrive"
 	engine -14 177
 	engine 14 177
-	fighter -46 106 under
-	fighter 46 106 under
+	bay "Fighter" -46 106 under
+	bay "Fighter" 46 106 under
 	gun -75 57 "Torpedo Launcher"
 	gun 75 57 "Torpedo Launcher"
 	gun -53 61 "Particle Cannon"

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -50,8 +50,8 @@ person "Michael Zahniser"
 		
 		engine -14 177
 		engine 14 177
-		fighter -46 106 under
-		fighter 46 106 under
+		bay "Fighter" -46 106 under
+		bay "Fighter" 46 106 under
 		gun -75 57 "Ion Cannon"
 		gun 75 57 "Ion Cannon"
 		gun -75 57 "Ion Cannon"


### PR DESCRIPTION
Change bay definition of Kestrels to match the change in 79260f206e28370f1a26f1b32b8011babe3794cd.

### Additional note
Also missing are bay definitions for the Prototype Kestrel. Should bays be added to this variant, or be held back for the finalised Kestrel?