### PR TITLE
Randomizing Void Sprite Start Frames

### DIFF
--- a/data/drak/indigenous.txt
+++ b/data/drak/indigenous.txt
@@ -57,6 +57,7 @@ ship "Void Sprite"
 	noun "creature"
 	sprite "ship/void sprite/void sprite adult"
 		"frame rate" 14.3
+		"random start frame"
 		rewind
 	thumbnail "thumbnail/void sprite adult"
 	"never disabled"
@@ -109,6 +110,7 @@ effect "void sprite adult death"
 ship "Void Sprite" "Void Sprite (Infant)"
 	sprite "ship/void sprite/void sprite infant"
 		"frame rate" 24.7
+		"random start frame"
 		rewind
 	thumbnail "thumbnail/void sprite infant"
 	"never disabled"


### PR DESCRIPTION
**Bugfix:** This PR addresses the fact that the Void Sprites are synchronized

## Fix Details
After spending some more time hanging out with the new and improved Void Sprites, I realized that they don't have random start frames. This adds that.

## Testing Done
Spent a lot of time visiting Nenia.
