### PR TITLE
Player cannot attempt to hail / land / jump / board / whatever while landing / departing

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -531,7 +531,9 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 		
 		if(it.get() == flagship)
 		{
-			MovePlayer(*it, player, activeCommands);
+			// Player cannot do anything if the flagship is landing / departing.
+			if(flagship->Zoom() == 1.)
+				MovePlayer(*it, player, activeCommands);
 			continue;
 		}
 		

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -397,6 +397,10 @@ bool MainPanel::ShowHailPanel()
 	if(!flagship || flagship->IsDestroyed())
 		return false;
 	
+	// Player cannot hail while landing / departing.
+	if(flagship->Zoom() < 1.)
+		return false;
+	
 	shared_ptr<Ship> target = flagship->GetTargetShip();
 	if((SDL_GetModState() & KMOD_SHIFT) && flagship->GetTargetStellar())
 		target.reset();


### PR DESCRIPTION
**Bugfix:** This PR addresses issues #4480 and #4736.

## Fix Details
Player cannot attempt to do anything while landing or departing.

## Testing Done
Landing and departing works normally, so there shouldn't be any issues.

## Save File
[John Brown.txt](https://github.com/endless-sky/endless-sky/files/5904234/John.Brown.txt)