### PR TITLE
Conflicting keybindings are saved

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -89,7 +89,7 @@ color "radar anomalous" .7 0. 1. 0.
 color "radar blink" 1. 1. 1. 0.
 color "radar viewport" 0. .3 0. 0.
 
-# Colors used for warning and error tooltip backdrops.
+# Colors used for warnings and errors.
 color "error back" .25 .1 .1 1.
 color "warning back" .21 .18 .08 1.
 color "warning conflict" .315 .27 .12 1.

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -92,6 +92,7 @@ color "radar viewport" 0. .3 0. 0.
 # Colors used for warning and error tooltip backdrops.
 color "error back" .25 .1 .1 1.
 color "warning back" .21 .18 .08 1.
+color "warning conflict" .315 .27 .12 1.
 
 # Colors used when drawing the map (system names, links, and the player's desired route).
 # (The color of the ring that represents a given system is context-sensitive.)

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -125,8 +125,8 @@ void Command::LoadSettings(const string &path)
 	for(const auto &it : description)
 		commands[it.second] = it.first;
 	
-	// Each command can only have one keycode, but misconfigured settings can
-	// temporarily cause one keycode to be used for two commands.
+	// Each command can only have one keycode, one keycode can be assigned
+	// to multiple commands.
 	for(const DataNode &node : file)
 	{
 		auto it = commands.find(node.Token(0));
@@ -156,11 +156,11 @@ void Command::SaveSettings(const string &path)
 {
 	DataWriter out(path);
 	
-	for(const auto &it : commandForKeycode)
+	for(const auto &it : keycodeForCommand)
 	{
-		auto dit = description.find(it.second);
+		auto dit = description.find(it.first);
 		if(dit != description.end())
-			out.Write(dit->second, it.first);
+			out.Write(dit->second, it.second);
 	}
 }
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -296,7 +296,7 @@ void PreferencesPanel::DrawControls()
 	const Color &bright = *GameData::Colors().Get("bright");
 	
 	// Check for conflicts.
-	Color warning(.5f, .3f, 0.f, 0.f);
+	const Color &warning = *GameData::Colors().Get("warning conflict");
 	
 	Table table;
 	table.AddColumn(-115, {230, Alignment::LEFT});

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -296,7 +296,7 @@ void PreferencesPanel::DrawControls()
 	const Color &bright = *GameData::Colors().Get("bright");
 	
 	// Check for conflicts.
-	Color red(.3f, 0.f, 0.f, .3f);
+	Color warning(.5f, .3f, 0.f, 0.f);
 	
 	Table table;
 	table.AddColumn(-115, {230, Alignment::LEFT});
@@ -374,7 +374,7 @@ void PreferencesPanel::DrawControls()
 			if(isConflicted || isEditing)
 			{
 				table.SetHighlight(56, 120);
-				table.DrawHighlight(isEditing ? dim: red);
+				table.DrawHighlight(isEditing ? dim: warning);
 			}
 			
 			// Mark the selected row.


### PR DESCRIPTION
Conflicting keybindings are saved to player's save file instead of reverted to default.
This is a reopening of #5611 with red keybinding conflict color changed to yellowish and the comment corrected.
Fixes #5582.