### PR TITLE
Player can begin jump preparations while departing from a planet

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -531,8 +531,8 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 		
 		if(it.get() == flagship)
 		{
-			// Player cannot do anything if the flagship is landing / departing.
-			if(flagship->Zoom() == 1.)
+			// Player cannot do anything if the flagship is landing.
+			if(!flagship->IsLanding())
 				MovePlayer(*it, player, activeCommands);
 			continue;
 		}
@@ -3302,7 +3302,8 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 				activeCommands.Clear(Command::BOARD);
 		}
 	}
-	else if(activeCommands.Has(Command::LAND) && !ship.IsEnteringHyperspace())
+	// Player cannot attempt to land while departing from a planet.
+	else if(activeCommands.Has(Command::LAND) && !ship.IsEnteringHyperspace() && ship.Zoom() == 1.)
 	{
 		// Track all possible landable objects in the current system.
 		auto landables = vector<const StellarObject *>{};


### PR DESCRIPTION
This is a correction of #5681. I noticed that previously you could initiate jump command while departing from planet and after #5681 you cannot. This PR lets the player do anything except landing while he is departing from a planet.