### PR TITLE
Makefile: curl should fail on invalid status

### DIFF
--- a/.winmake
+++ b/.winmake
@@ -99,7 +99,7 @@ ifeq ($(needs_tarball),true)
 # Download / Unpack the tarball, and mark it as up-to-date (vs. the packaged-on date).
 scons-local-%.tar.gz:
 	@echo "No system installation of SCons, downloading version $(SCONS_VERSION)"
-	curl -sS -L http://sourceforge.net/projects/scons/files/scons-local/$(SCONS_VERSION)/$@ > $@
+	curl -sSf -L http://sourceforge.net/projects/scons/files/scons-local/$(SCONS_VERSION)/$@ > $@
 	@touch $@
 scons-local: scons-local-$(SCONS_VERSION).tar.gz
 	@echo "Unpacking tarball into $@"


### PR DESCRIPTION
**Bugfix:** This PR addresses a rare issue in the windows build.

The Makefile tries to download scons if it doesn't exist on the system yet. However, if sourceforge has issues and indicates this with status codes, it will still proceed to unpack the response as tarball (or rather, attempt to). This results in opaque errors such as

```
No system installation of SCons, downloading version 4.0.1
curl -sS -L http://sourceforge.net/projects/scons/files/scons-local/4.0.1/scons-local-4.0.1.tar.gz > scons-local-4.0.1.tar.gz
Unpacking tarball into scons-local
tar: Error opening archive: Unrecognized archive format
```

(from <https://github.com/endless-sky/endless-sky/runs/1819132923?check_suite_focus=true>)

## Fix Details
This PR adds the `-f` flag to the curl invocation. We already use `-S` which makes curl fail on errors, but not on status code. `-f` makes curl also fail on invalid status codes.

## Testing Done
Simulated a sourceforge issue with a wrong URL:
```
❯ make -f .winmake
No system installation of SCons, downloading version 4.0.1
curl -sSf -L http://sourceforge.net/prasdfojects/scons/files/scons-local/4.0.1/scons-local-4.0.1.tar.gz > scons-local-4.0.1.tar.gz
curl: (22) The requested URL returned error: 404 
make: *** [.winmake:102: scons-local-4.0.1.tar.gz] Error 22
```