### PR TITLE
Fix: effects are no longer mirrored

### DIFF
--- a/source/BatchDrawList.cpp
+++ b/source/BatchDrawList.cpp
@@ -126,7 +126,7 @@ bool BatchDrawList::Add(const Body &body, Point position, float clip)
 	
 	// Get unit vectors in the direction of the object's width and height.
 	Point unit = body.Unit() * zoom;
-	Point uw = Point(unit.Y(), -unit.X()) * body.Width();
+	Point uw = Point(-unit.Y(), unit.X()) * body.Width();
 	Point uh = unit * body.Height();
 	
 	// Get the "bottom" corner, the one that won't be clipped.


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5508.

## Fix Details
Corners of the effect image were calculated incorrectly.
Thanks to oo13 for finding the location of the bug.

## Testing Done
I tested this with the void sprites. Since it works correctly for them, I think it should work correctly elsewhere too.

## Save File
[Local God.txt](https://github.com/endless-sky/endless-sky/files/5932977/Local.God.txt) (to test the fix, go to Nenia and shoot some void sprites (-debug flag helps since then you can slow down the game))