### PR TITLE
Lower amount of missile Furies in small southern pirates

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1697,7 +1697,7 @@ fleet "Small Southern Pirates"
 	variant 1
 		"Fury" 3
 	variant 1
-		"Fury (Missile)" 3
+		"Fury (Missile)" 2
 	variant 1
 		"Fury (Heavy)" 2
 	variant 1


### PR DESCRIPTION
Currently, a small southern pirate fleet can spawn anything from a single Sparrow, to three Furies with two Meteor Missile Launchers each. While there should be some variety, this is too much for the lowest end, and is reduced to two ships in this PR.