### PR TITLE
mechanics: Change Dictionary to templated class.

### DIFF
--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -20,33 +20,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
-	// Perform a binary search on a sorted vector. Return the key's location (or
-	// proper insertion spot) in the first element of the pair, and "true" in
-	// the second element if the key is already in the vector.
-	pair<size_t, bool> Search(const char *key, const vector<pair<const char *, double>> &v)
-	{
-		// At each step of the search, we know the key is in [low, high).
-		size_t low = 0;
-		size_t high = v.size();
-		
-		while(low != high)
-		{
-			size_t mid = (low + high) / 2;
-			int cmp = strcmp(key, v[mid].first);
-			if(!cmp)
-				return make_pair(mid, true);
-			
-			if(cmp < 0)
-				high = mid;
-			else
-				low = mid + 1;
-		}
-		return make_pair(low, false);
-	}
-	
 	// String interning: return a pointer to a character string that matches the
 	// given string but has static storage duration.
-	const char *Intern(const char *key)
+	const char *InternalIntern(const char *key)
 	{
 		static set<string> interned;
 		static mutex m;
@@ -59,33 +35,9 @@ namespace {
 
 
 
-double &Dictionary::operator[](const char *key)
+// String interning: return a pointer to a character string that matches the
+// given string but has static storage duration.
+const char *DictionaryGeneric::Intern(const char *key)
 {
-	pair<size_t, bool> pos = Search(key, *this);
-	if(pos.second)
-		return data()[pos.first].second;
-	
-	return insert(begin() + pos.first, make_pair(Intern(key), 0.))->second;
-}
-
-
-
-double &Dictionary::operator[](const string &key)
-{
-	return (*this)[key.c_str()];
-}
-
-
-
-double Dictionary::Get(const char *key) const
-{
-	pair<size_t, bool> pos = Search(key, *this);
-	return (pos.second ? data()[pos.first].second : 0.);
-}
-
-
-
-double Dictionary::Get(const string &key) const
-{
-	return Get(key.c_str());
+	return InternalIntern(key);
 }

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -13,9 +13,19 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef DICTIONARY_H_
 #define DICTIONARY_H_
 
+#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>
+
+
+
+// Needs to be a separate class if we want to share interning.
+// This unfortunately makes the interning function more publicly visible.
+class DictionaryGeneric{
+	public:
+		static const char *Intern(const char *key);
+};
 
 
 
@@ -23,20 +33,90 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 // that prioritizes fast lookup time at the expense of longer construction time
 // compared to an STL map. That makes it suitable for ship attributes, which are
 // changed much less frequently than they are queried.
-class Dictionary : private std::vector<std::pair<const char *, double>> {
+template <typename T>
+class Dictionary : private std::vector<std::pair<const char *, T>> {
 public:
 	// Access a key for modifying it:
-	double &operator[](const char *key);
-	double &operator[](const std::string &key);
+	T &operator[](const char *key);
+	T &operator[](const std::string &key);
 	// Get the value of a key, or 0 if it does not exist:
-	double Get(const char *key) const;
-	double Get(const std::string &key) const;
+	T Get(const char *key) const;
+	T Get(const std::string &key) const;
 	
 	// Expose certain functions from the underlying vector:
-	using std::vector<std::pair<const char *, double>>::empty;
-	using std::vector<std::pair<const char *, double>>::begin;
-	using std::vector<std::pair<const char *, double>>::end;
+	using std::vector<std::pair<const char *, T>>::empty;
+	using std::vector<std::pair<const char *, T>>::begin;
+	using std::vector<std::pair<const char *, T>>::end;
+	
+	
+private:
+	static std::pair<size_t, bool> Search(const char *key, const std::vector<std::pair<const char *, T>> &v);
+
 };
+
+
+
+template <typename T>
+T& Dictionary<T>::operator[](const char *key)
+{
+	std::pair<size_t, bool> pos = Search(key, *this);
+	if(pos.second)
+		return std::vector<std::pair<const char *, T>>::data()[pos.first].second;
+	
+	return this->insert(begin() + pos.first, std::make_pair(DictionaryGeneric::Intern(key), T()))->second;
+}
+
+
+
+template <typename T>
+T &Dictionary<T>::operator[](const std::string &key)
+{
+	return (*this)[key.c_str()];
+}
+
+
+
+template <typename T>
+T Dictionary<T>::Get(const char *key) const
+{
+	std::pair<size_t, bool> pos = Search(key, *this);
+	return (pos.second ? std::vector<std::pair<const char *, T>>::data()[pos.first].second : T());
+}
+
+
+
+template <typename T>
+T Dictionary<T>::Get(const std::string &key) const
+{
+	return Get(key.c_str());
+}
+
+
+
+// Perform a binary search on a sorted vector. Return the key's location (or
+// proper insertion spot) in the first element of the pair, and "true" in
+// the second element if the key is already in the vector.
+template <typename T>
+std::pair<size_t, bool> Dictionary<T>::Search(const char *key, const std::vector<std::pair<const char *, T>> &v)
+{
+	// At each step of the search, we know the key is in [low, high).
+	size_t low = 0;
+	size_t high = v.size();
+	
+	while(low != high)
+	{
+		size_t mid = (low + high) / 2;
+		int cmp = std::strcmp(key, v[mid].first);
+		if(!cmp)
+			return std::make_pair(mid, true);
+		
+		if(cmp < 0)
+			high = mid;
+		else
+			low = mid + 1;
+	}
+	return std::make_pair(low, false);
+}
 
 
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -319,7 +319,7 @@ double Outfit::Get(const string &attribute) const
 
 
 
-const Dictionary &Outfit::Attributes() const
+const Dictionary<double> &Outfit::Attributes() const
 {
 	return attributes;
 }

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -61,7 +61,7 @@ public:
 	
 	double Get(const char *attribute) const;
 	double Get(const std::string &attribute) const;
-	const Dictionary &Attributes() const;
+	const Dictionary<double> &Attributes() const;
 	
 	// Determine whether the given number of instances of the given outfit can
 	// be added to a ship with the attributes represented by this instance. If
@@ -107,7 +107,7 @@ private:
 	// Licenses needed to purchase this item.
 	std::vector<std::string> licenses;
 	
-	Dictionary attributes;
+	Dictionary<double> attributes;
 	
 	// The integers in these pairs/maps indicate the number of
 	// sprites/effects/sounds to be placed/played.


### PR DESCRIPTION
**Feature:** This PR changes the Dictionary class to a templated class (after a discussion on Discord).

## Feature Details
This PR changes the Dictionary class to become a template. Templating the Dictionary class will allow it to be used for other datatypes than doubles as values, for example for usage in the ConditionsStore in #5244.

The change looks relatively large, but that is because code had to be moved from the Dictionary.cpp file to the Dictionary.h file (and because `std::` had to be added at a number of locations.

The Intern function is still shared among all templated instances of Dictionary (this could save a little bit of memory compared to each class having its own version).

## UI Screenshots
N/A

## Usage Examples
Use `Dictionary<type>` instead of `Dictionary` in your code.

## Testing Done
- Executed the automated unit tests.
- Started the game and looked at shipyard, outfitter and ships-overview.

## Performance Impact
Template classes should have the same performance as regular classes.