### PR TITLE
Add .gitmodules to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ ipch/
 .idea/
 .idea_modules/
 CMakeLists.txt
+/.gitmodules


### PR DESCRIPTION
This PR adds .gitmodules to ignored files, letting developers make use of git submodules to download and track plugins within their local repo, without having to push changes or create a separate branch. For example, you can run a command like this to add endless-sky-high-dpi to your plugins folder:

```
git submodule add -f https://github.com/endless-sky/endless-sky-high-dpi plugins/endless-sky-high-dpi
```
Then you could cd to that plugin folder and use git commands like normal (while the ES git repo would normally override it), and even some git submodule commands to affect them all.

There are a few things to be aware of if you work with submodules:
- When first adding submodules, it looks like it automatically stages .gitmodules and the downloaded plugin, so you'll have to run `git reset HEAD` after adding. But afterwards, those files won't be tracked.
- If working on a branch without this patch, you'll want to make sure you don't commit your .gitmodules file.
- Removing submodules requires a little manual editing of .gitmodules and .git/config, along with deleting the folder.

Definitely some considerations, but for developers working with plugins, it would help greatly with improving the workflow.