### PR TITLE
feat: Print firing and hit forces in weapons table overview

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -1260,8 +1260,9 @@ void GameData::PrintShipTable()
 void GameData::PrintWeaponTable()
 {
 	cout << "name" << '\t' << "cost" << '\t' << "space" << '\t' << "range" << '\t'
-		<< "energy/s" << '\t' << "heat/s" << '\t' << "shield/s" << '\t' << "hull/s" << '\t'
-		<< "homing" << '\t' << "strength" << '\n';
+		<< "energy/s" << '\t' << "heat/s" << '\t' << "move/s" << '\t'
+		<< "shield/s" << '\t' << "hull/s" << '\t' << "push/s" << '\t'
+		<< "homing" << '\t' << "strength" <<'\n';
 	for(auto &it : outfits)
 	{
 		// Skip non-weapons and submunitions.
@@ -1279,11 +1280,15 @@ void GameData::PrintWeaponTable()
 		cout << energy << '\t';
 		double heat = outfit.FiringHeat() * 60. / outfit.Reload();
 		cout << heat << '\t';
+		double firingforce = outfit.FiringForce() * 60. / outfit.Reload();
+		cout << firingforce << '\t';
 		
 		double shield = outfit.ShieldDamage() * 60. / outfit.Reload();
 		cout << shield << '\t';
 		double hull = outfit.HullDamage() * 60. / outfit.Reload();
 		cout << hull << '\t';
+		double hitforce = outfit.HitForce() * 60. / outfit.Reload();
+		cout << hitforce << '\t';
 		
 		cout << outfit.Homing() << '\t';
 		double strength = outfit.MissileStrength() + outfit.AntiMissile();

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -1260,7 +1260,7 @@ void GameData::PrintShipTable()
 void GameData::PrintWeaponTable()
 {
 	cout << "name" << '\t' << "cost" << '\t' << "space" << '\t' << "range" << '\t'
-		<< "energy/s" << '\t' << "heat/s" << '\t' << "move/s" << '\t'
+		<< "energy/s" << '\t' << "heat/s" << '\t' << "recoil/s" << '\t'
 		<< "shield/s" << '\t' << "hull/s" << '\t' << "push/s" << '\t'
 		<< "homing" << '\t' << "strength" <<'\n';
 	for(auto &it : outfits)


### PR DESCRIPTION
**Feature:** This PR implements the feature as described in the title

## Feature Details
Firing force and hit-force can be important weapons characteristics to take into account when balancing ships.
This adds those two forces to the weapons table overview so that content creators can easily use them for balancing ships and weapons.

## UI Screenshots
N/A

## Usage Examples
Run `endless-sky --weapons` to get the overview.

## Testing Done
I used the newly printed values to choose weapons for an NPC ship I was creating.

## Performance Impact
None, only affects the printing function which is not run in-game.
