### PR TITLE
Fix: Removing the Key Stone from the Puffin

### DIFF
--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -917,13 +917,14 @@ ship "Puffin"
 		"energy capacity" 150
 		"ramscoop" 0.5
 		"cargo space" 8
-		"outfit space" 80
+		"outfit space" 79
 		"engine capacity" 26
 		"shield generation" 0.6
 		"shield energy" 0.4
 		"hull repair rate" 1.2
 		"hull energy" 0.9
 		"gaslining" 1
+		"quantum keystone" 1
 		"cooling" 1
 		"active cooling" 8
 		"cooling energy" .4
@@ -934,7 +935,6 @@ ship "Puffin"
 	outfits
 		"Millennium Cell"
 		"Emergency Ramscoop"
-		"Quantum Key Stone"
 
 		"Anvil-Class Engine"
 		"Hyperdrive"


### PR DESCRIPTION
**Bugfix:** 
This PR addresses the issue reported by clifflocked on the Discord group. Thank you! We always appreciate people playing the game and letting us know when something seems wrong.

Currently, the player can buy the puffin, and then strip it to gain access to Quantum Key Stones before they have the license. This fixes that. 

Of course, they'll still be able to get the anvil-class combined engine...

## Fix Details
Moving the keystone out of the outfits and into the hull.

Correspondingly, this also reduces the available outfit space by 1.
