### PR TITLE
Save cloak status

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -362,8 +362,8 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 		for(const auto &it : player.Ships())
 			if(!it->IsParked() && it->Attributes().Get("cloak"))
 			{
-				isCloaking = !isCloaking;
-				Messages::Add(isCloaking ? "Engaging cloaking device." : "Disengaging cloaking device.");
+				player.SetIsCloaking(!player.IsCloaking());
+				Messages::Add(player.IsCloaking() ? "Engaging cloaking device." : "Disengaging cloaking device.");
 				break;
 			}
 	
@@ -589,7 +589,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 				command |= Command::DEPLOY;
 				Deploy(*it, !fightersRetreat);
 			}
-			if(isCloaking)
+			if(player.IsCloaking())
 				command |= Command::CLOAK;
 		}
 		// Cloak if the AI considers it appropriate.
@@ -3607,7 +3607,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 		command |= Command::DEPLOY;
 		Deploy(ship, !Preferences::Has("Damaged fighters retreat"));
 	}
-	if(isCloaking)
+	if(player.IsCloaking())
 		command |= Command::CLOAK;
 	
 	ship.SetCommands(command);

--- a/source/AI.h
+++ b/source/AI.h
@@ -189,8 +189,6 @@ private:
 	// Command applied by the player's "autopilot."
 	Command autoPilot;
 	
-	bool isCloaking = false;
-	
 	bool escortsAreFrugal = true;
 	bool escortsUseAmmo = true;
 	

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -148,6 +148,8 @@ void PlayerInfo::Load(const string &path)
 			hasFullClearance = true;
 		else if(child.Token(0) == "launching")
 			shouldLaunch = true;
+		else if(child.Token(0) == "cloaking")
+			isCloaking = true;
 		else if(child.Token(0) == "playtime" && child.Size() >= 2)
 			playTime = child.Value(1);
 		else if(child.Token(0) == "travel" && child.Size() >= 2)
@@ -653,6 +655,20 @@ const StellarObject *PlayerInfo::GetStellarObject() const
 bool PlayerInfo::ShouldLaunch() const
 {
 	return shouldLaunch;
+}
+
+
+
+bool PlayerInfo::IsCloaking() const
+{
+	return isCloaking;
+}
+
+
+
+void PlayerInfo::SetIsCloaking(bool cloaking)
+{
+	isCloaking = cloaking;
 }
 
 
@@ -2716,6 +2732,8 @@ void PlayerInfo::Save(const string &path) const
 	// entering their ship (i.e. because a mission forced them to take off).
 	if(shouldLaunch)
 		out.Write("launching");
+	if(isCloaking)
+		out.Write("cloaking");
 	for(const System *system : travelPlan)
 		out.Write("travel", system->Name());
 	if(travelDestination)

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -102,6 +102,10 @@ public:
 	// must leave the planet immediately (without time to do anything else).
 	bool ShouldLaunch() const;
 	
+	// Keep track of whether the player is cloaking.
+	bool IsCloaking() const;
+	void SetIsCloaking(bool cloaking);
+	
 	// Access the player's accounting information.
 	const Account &Accounts() const;
 	Account &Accounts();
@@ -298,6 +302,7 @@ private:
 	const Planet *planet = nullptr;
 	bool shouldLaunch = false;
 	bool isDead = false;
+	bool isCloaking = false;
 	
 	// The amount of in-game time played, in seconds.
 	double playTime = 0.0;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -437,6 +437,8 @@ void Ship::Load(const DataNode &node)
 			hull = child.Value(1);
 		else if(key == "position" && child.Size() >= 3)
 			position = Point(child.Value(1), child.Value(2));
+		else if(key == "cloak" && child.Size() >= 2)
+			cloak = child.Value(1);
 		else if(key == "system" && child.Size() >= 2)
 			currentSystem = GameData::Systems().Get(child.Token(1));
 		else if(key == "planet" && child.Size() >= 2)
@@ -839,6 +841,7 @@ void Ship::Save(DataWriter &out) const
 		out.Write("shields", shields);
 		out.Write("hull", hull);
 		out.Write("position", position.X(), position.Y());
+		out.Write("cloak", cloak);
 		
 		for(const EnginePoint &point : enginePoints)
 		{


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5706

## Fix Details
Cloak status is now saved for the player and for each ship individually (since the player's cloak value is only "desired" cloak - player might not actually be cloaked due to lack of resources)

## Testing Done
Tried to cloak, uncloak, land cloaked and reload, land cloaked and depart, land uncloaked and reload, land uncloaked and depart.

## Save File
[John Brown.txt](https://github.com/endless-sky/endless-sky/files/5990649/John.Brown.txt)