### PR TITLE
Don't mention insurance report in Sparrow description

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -3011,7 +3011,7 @@ ship "Sparrow"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description "Classified as an interceptor rather than a fighter because it has its own hyperdrive instead of needing to be carried inside a larger ship, the Tarazed Sparrow is the smallest and cheapest combat ship available. Because of its limited cargo and passenger space, the primary way for a Sparrow pilot to pay the bills is to upgrade the weapons and hunt pirates... or become one. In either case, it is a perilous way to earn a living."
-	description "	Insurance reports indicate that as many as two out of every three first-time ship buyers who choose to pilot a Sparrow lose their ship (and often, their life as well) within the first month of owning it. Pilots who have survived longer than that tend to swear by replacing the stock weapons with missile launchers."
+	description "	Government reports indicate that as many as two out of every three first-time ship buyers who choose to pilot a Sparrow lose their ship (and often, their life as well) within the first month of owning it. Pilots who have survived longer than that tend to swear by replacing the stock weapons with missile launchers."
 
 
 


### PR DESCRIPTION
It's established in some of the spaceport flavor text that ship
insurance doesn't exist. Therefore this text about insurance reports
indicating such-and-such about the Sparrow's longevity doesn't make
sense. Let's change it to something else.