### PR TITLE
Fix: Making Postverta Properly Hidden

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -8012,7 +8012,6 @@ system Diespiter
 	attributes "ember waste" "inaccessible"
 	habitable 534.375
 	haze _menu/haze-red
-	link Postverta
 	link Statina
 	asteroids "small rock" 65 3
 	asteroids "medium rock" 14 1
@@ -19461,9 +19460,6 @@ system Postverta
 	attributes "ember waste" "inaccessible"
 	habitable 135
 	haze _menu/haze-red
-	link Diespiter
-	link Prosa
-	link Statina
 	asteroids "medium rock" 4 2
 	asteroids "large rock" 4 3
 	asteroids "medium metal" 52 1
@@ -19636,7 +19632,6 @@ system Prosa
 	attributes "ember waste" "inaccessible"
 	habitable 2372.76
 	haze _menu/haze-red
-	link Postverta
 	link Vaticanus
 	asteroids "medium metal" 11 2
 	asteroids "large metal" 2 2
@@ -23261,7 +23256,6 @@ system Statina
 	haze _menu/haze-red
 	link Diespiter
 	link Egeria
-	link Postverta
 	asteroids "large rock" 1 4
 	asteroids "small metal" 39 3
 	asteroids "medium metal" 72 3

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3948,8 +3948,18 @@ mission "Remnant: Cognizance 13"
 	
 
 event "remnant: postverta reveal"
-	system Postverta
-		remove hidden
+	unvisit Caeculus
+	unvisit Egeria
+	unvisit Levana
+	unvisit Prosa
+	unvisit Statina
+	system Caeculus
+		add object "Wormhole Barren Beta"
+			sprite planet/wormhole-red
+			distance 2400
+			period 391
+	system Diespiter
+		add link Postverta
 	system Egeria
 		add object "Wormhole Barren Alpha"
 			sprite planet/wormhole-red
@@ -3960,16 +3970,19 @@ event "remnant: postverta reveal"
 			sprite planet/wormhole-red
 			distance 2313
 			period 389
-	system Caeculus
-		add object "Wormhole Barren Beta"
-			sprite planet/wormhole-red
-			distance 2400
-			period 391
+	system Postverta
+		remove hidden
+		add link Diespiter
+		add link Prosa
+		add link Statina
 	system Prosa
+		add link Postverta
 		add object "Wormhole Barren Beta"
 			sprite planet/wormhole-red
 			distance 2313
 			period 389
+	system Statina
+		add link Postverta
 
 
 

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3949,17 +3949,19 @@ mission "Remnant: Cognizance 13"
 
 event "remnant: postverta reveal"
 	unvisit Caeculus
+	unvisit Diespiter
 	unvisit Egeria
 	unvisit Levana
 	unvisit Prosa
 	unvisit Statina
+	link Postverta Diespiter
+	link Postverta Prosa
+	link Postverta Statina
 	system Caeculus
 		add object "Wormhole Barren Beta"
 			sprite planet/wormhole-red
 			distance 2400
 			period 391
-	system Diespiter
-		add link Postverta
 	system Egeria
 		add object "Wormhole Barren Alpha"
 			sprite planet/wormhole-red
@@ -3972,17 +3974,11 @@ event "remnant: postverta reveal"
 			period 389
 	system Postverta
 		remove hidden
-		add link Diespiter
-		add link Prosa
-		add link Statina
 	system Prosa
-		add link Postverta
 		add object "Wormhole Barren Beta"
 			sprite planet/wormhole-red
 			distance 2313
 			period 389
-	system Statina
-		add link Postverta
 
 
 

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3957,11 +3957,8 @@ event "remnant: postverta reveal"
 	link Postverta Diespiter
 	link Postverta Prosa
 	link Postverta Statina
-	system Caeculus
-		add object "Wormhole Barren Beta"
-			sprite planet/wormhole-red
-			distance 2400
-			period 391
+	system Postverta
+		remove hidden
 	system Egeria
 		add object "Wormhole Barren Alpha"
 			sprite planet/wormhole-red
@@ -3972,8 +3969,11 @@ event "remnant: postverta reveal"
 			sprite planet/wormhole-red
 			distance 2313
 			period 389
-	system Postverta
-		remove hidden
+	system Caeculus
+		add object "Wormhole Barren Beta"
+			sprite planet/wormhole-red
+			distance 2400
+			period 391
 	system Prosa
 		add object "Wormhole Barren Beta"
 			sprite planet/wormhole-red


### PR DESCRIPTION
**Bugfix:** This PR addresses the gameplay element that revealed issue #5734 

## Problem:

- Postverta is described in the mission and lore as a system that appears where there wasn't one previously. This description comes from the Remnant, who have the best scanners available, long experience in the Ember Waste, a very strong astronomical program, and a keen awareness of their environment.
- Currently, this is implemented by giving Postverta the `hidden` tag, which renders it invisible and thus can't be jumped to via JD.
- Unfortunately, if the player can somehow gain access to any of the other Cognizance systems (such as Egeria, Prosa, Statina, or Diespiter) they will be able to follow the hyperdrive links to reveal Postverta, and thereafter be able to see it and jump to it whenever they want.
- This placement is intentional, but the ability for Postverta to be discovered is not. The bulk of the Cognizance systems are intended to fall into the category of "hard to get to, but not-impossible. The player could conceivably reach here at some point in the future." Postverta itself is supposed to *not be there.* This is not "just" a gate keeping mechanism, but rather an actual plot point that will be investigated in future missions. Likewise, this is *not* simply a case of "Postverta is hard to see."

## Fix Details
Changes:
- Removes all links between Postverta and other systems.
- Adjust the Postverta Reveal event to create those links
- Also unvisits all systems changed by this event.

## Testing Done
Repeatedly tested this flying a starling with both hyperdrive and jump drive. Verified that every link is a bidirectional hyperdrive link.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}

