### PR TITLE
feat: Integration Test Framework: Add navigate step

### DIFF
--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -159,15 +159,7 @@ void Test::LoadSequence(const DataNode &node)
 				break;
 			case TestStep::Type::NAVIGATE:
 				if(child.Token(0) == "travel" && child.Size() >= 2)
-				{
-					// Using get instead of find since the test might be loaded
-					// before the actual system is loaded.
-					const System *next = GameData::Systems().Get(child.Token(1));
-					if(next)
-						step.travelPlan.push_back(next);
-				}
-				// Using get instead of find since the test might be loaded before
-				// the actual planet is loaded.
+				step.travelPlan.push_back(GameData::Systems().Get(child.Token(1)));
 				else if(child.Token(0) == "travel destination" && child.Size() >= 2)
 					step.travelDestination = GameData::Planets().Get(child.Token(1));
 				else
@@ -352,10 +344,7 @@ void Test::Step(Context &context, UI &menuPanels, UI &gamePanels, PlayerInfo &pl
 			case TestStep::Type::NAVIGATE:
 				player.TravelPlan().clear();
 				player.TravelPlan() = stepToRun.travelPlan;
-				if(stepToRun.travelDestination)
-					player.SetTravelDestination(stepToRun.travelDestination);
-				else
-					player.SetTravelDestination(nullptr);
+				player.SetTravelDestination(stepToRun.travelDestination);
 				break;
 			case TestStep::Type::WATCHDOG:
 				context.watchdog = stepToRun.watchdog;

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -158,9 +158,24 @@ void Test::LoadSequence(const DataNode &node)
 				}
 				break;
 			case TestStep::Type::NAVIGATE:
-				child.PrintTrace("Error: Not yet implemented step type navigation");
-				status = Status::BROKEN;
-				return;
+				if(child.Token(0) == "travel" && child.Size() >= 2)
+				{
+					// Using get instead of find since the test might be loaded
+					// before the actual system is loaded.
+					const System *next = GameData::Systems().Get(child.Token(1));
+					if(next)
+						step.travelPlan.push_back(next);
+				}
+				// Using get instead of find since the test might be loaded before
+				// the actual planet is loaded.
+				else if(child.Token(0) == "travel destination" && child.Size() >= 2)
+					step.travelDestination = GameData::Planets().Get(child.Token(1));
+				else
+				{
+					child.PrintTrace("Error: Invalid or incomplete keywords for navigation");
+					status = Status::BROKEN;
+				}
+				break;
 			case TestStep::Type::WATCHDOG:
 				step.watchdog = child.Size() >= 2 ? child.Value(1) : 0;
 				break;
@@ -335,7 +350,12 @@ void Test::Step(Context &context, UI &menuPanels, UI &gamePanels, PlayerInfo &pl
 				++(context.stepToRun);
 				break;
 			case TestStep::Type::NAVIGATE:
-				Fail(context, player, "Navigate not implemented");
+				player.TravelPlan().clear();
+				player.TravelPlan() = stepToRun.travelPlan;
+				if(stepToRun.travelDestination)
+					player.SetTravelDestination(stepToRun.travelDestination);
+				else
+					player.SetTravelDestination(nullptr);
 				break;
 			case TestStep::Type::WATCHDOG:
 				context.watchdog = stepToRun.watchdog;

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -159,7 +159,7 @@ void Test::LoadSequence(const DataNode &node)
 				break;
 			case TestStep::Type::NAVIGATE:
 				if(child.Token(0) == "travel" && child.Size() >= 2)
-				step.travelPlan.push_back(GameData::Systems().Get(child.Token(1)));
+					step.travelPlan.push_back(GameData::Systems().Get(child.Token(1)));
 				else if(child.Token(0) == "travel destination" && child.Size() >= 2)
 					step.travelDestination = GameData::Planets().Get(child.Token(1));
 				else

--- a/source/Test.h
+++ b/source/Test.h
@@ -72,6 +72,9 @@ public:
 	public:
 		Type stepType = Type::ASSERT;
 		std::string nameOrLabel;
+		// Variables for travelpan/navigate steps.
+		std::vector<const System *> travelPlan;
+		const Planet *travelDestination = nullptr;
 		// For applying condition changes, branching based on conditions or
 		// checking asserts (similar to Conversations).
 		ConditionSet conditions;


### PR DESCRIPTION
**Feature:** This PR implements the navigate step of the test-framework as discussed in #4308

## Feature Details
This adds the navigate step for the test-framework.
The code is nearly identical to the code used for the navigate steps in earlier versions of the framework.

## UI Screenshots
N/A

## Usage Examples
See the testcase at [ES Stories|https://github.com/kikotheexile/Endless-Sky-Civil-War/blob/21e9676e58f01fdb2d7803e1ec0f7efe2b7beaca/data/tests/tests_framework.txt#L118] for the syntax of the navigate step (note that the other steps are using a different syntax though).

## Testing Done
Tested in earlier versions of the framework and tested in ES Stories. I plan to bring the testcases also to ES when the test-framework in ES is more complete.

## Performance Impact
N/A