### PR TITLE
Tweak: Making Sagitarius A* deadlier

### DIFF
--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -43,7 +43,7 @@ hazard "Black Hole Accretion Disk"
 		"hit effect" "nano spark"
 		"damage dropoff" 150 600
 		"dropoff modifier" 0
-		"relative shield damage" .00028
+		"relative shield damage" .00056
 
 hazard "Black Hole Event Horizon"
 	"constant strength"
@@ -52,7 +52,7 @@ hazard "Black Hole Event Horizon"
 		"hit effect" "nano spark"
 		"damage dropoff" 0 150
 		"dropoff modifier" 0
-		"relative hull damage" .00028
+		"relative hull damage" .00056
 		"piercing" 10
 
 hazard "Black Hole Gravity"

--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -43,7 +43,7 @@ hazard "Black Hole Accretion Disk"
 		"hit effect" "nano spark"
 		"damage dropoff" 150 600
 		"dropoff modifier" 0
-		"relative shield damage" .00168
+		"relative shield damage" .0018
 
 hazard "Black Hole Event Horizon"
 	"constant strength"
@@ -52,7 +52,7 @@ hazard "Black Hole Event Horizon"
 		"hit effect" "nano spark"
 		"damage dropoff" 0 150
 		"dropoff modifier" 0
-		"relative hull damage" .00084
+		"relative hull damage" .0009
 		"piercing" 10
 
 hazard "Black Hole Gravity"

--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -43,7 +43,7 @@ hazard "Black Hole Accretion Disk"
 		"hit effect" "nano spark"
 		"damage dropoff" 150 600
 		"dropoff modifier" 0
-		"relative shield damage" .00056
+		"relative shield damage" .00168
 
 hazard "Black Hole Event Horizon"
 	"constant strength"
@@ -52,7 +52,7 @@ hazard "Black Hole Event Horizon"
 		"hit effect" "nano spark"
 		"damage dropoff" 0 150
 		"dropoff modifier" 0
-		"relative hull damage" .00056
+		"relative hull damage" .00084
 		"piercing" 10
 
 hazard "Black Hole Gravity"

--- a/data/map.txt
+++ b/data/map.txt
@@ -21155,7 +21155,7 @@ system "Sagittarius A*"
 	government Uninhabited
 	habitable 10000
 	haze _menu/haze-full
-	arrival 2500
+	arrival 2000
 	hazard "Black Hole Gravity" 1
 	hazard "Black Hole Event Horizon" 1
 	hazard "Black Hole Accretion Disk" 1

--- a/data/map.txt
+++ b/data/map.txt
@@ -21155,7 +21155,7 @@ system "Sagittarius A*"
 	government Uninhabited
 	habitable 10000
 	haze _menu/haze-full
-	arrival 1500
+	arrival 2000
 	hazard "Black Hole Gravity" 1
 	hazard "Black Hole Event Horizon" 1
 	hazard "Black Hole Accretion Disk" 1

--- a/data/map.txt
+++ b/data/map.txt
@@ -21155,7 +21155,7 @@ system "Sagittarius A*"
 	government Uninhabited
 	habitable 10000
 	haze _menu/haze-full
-	arrival 2000
+	arrival 2500
 	hazard "Black Hole Gravity" 1
 	hazard "Black Hole Event Horizon" 1
 	hazard "Black Hole Accretion Disk" 1

--- a/data/map.txt
+++ b/data/map.txt
@@ -21155,7 +21155,7 @@ system "Sagittarius A*"
 	government Uninhabited
 	habitable 10000
 	haze _menu/haze-full
-	arrival 500
+	arrival 1500
 	hazard "Black Hole Gravity" 1
 	hazard "Black Hole Event Horizon" 1
 	hazard "Black Hole Accretion Disk" 1


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Amazinite and a few other people suggested that Sagittarius A* wasn't sufficiently scary, and ships with particularly good regen could last rather long periods even right on the event horizon.
So, this PR has two effects:

Firstly, ramps up the damage:
- (accretion disk) shield damage from 0.00028 up to 0.0018
- (event horizon) hull damage from 0.00028 up to 0.0009

Secondly, to maximize the impact and allow players to approach Sag A* instead of just being dropped on it, the system arrival distance has been changed from 500 out to 2000.

## Testing
A range of values and combinations were tested, including:
- Doubling just the shield damage.
- Doubling the shields and small increase to hull damage.
- Various increases in damage. 0.00164 and 0.00082 were good too.

Some of the discussion points:
- While the idea of having Sag A* do damage is a novel one and likely to surprise players, the old damage values were very lenient and easily overcome. A stock Starling could last quite a while just idling in the core, and with a few easy to acquire upgrades could last almost indefinitely.
- As such, it was felt that Sag A* lost its impact very quickly.
- With the revised values it is still possible to do challenges (like fly a stock starling to the center, stop, and then make it out before dying. Can be done with ~50% hull left) but hull will be vanishing fast enough to be really concerning.