### PR TITLE
Vertically centered the items in load and start panels.

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -281,7 +281,7 @@ interface "start conditions menu"
 		dimensions 230 20
 	# Visual padding applied to each scenario item
 	box "start entry text padding"
-		dimensions 5 3
+		dimensions 5 2
 
 
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -150,9 +150,10 @@ void LoadPanel::Draw()
 	// The list has space for 14 entries. Alpha should be 100% for Y = -157 to
 	// 103, and fade to 0 at 10 pixels beyond that.
 	Point point(-470., -157. - sideScroll);
+	const double centerY = font.Height() / 2;
 	for(const auto &it : files)
 	{
-		Rectangle zone(point + Point(110., 7.), Point(230., 20.));
+		Rectangle zone(point + Point(110., centerY), Point(230., 20.));
 		bool isHighlighted = (it.first == selectedPilot || (hasHover && zone.Contains(hoverPoint)));
 		
 		double alpha = min(1., max(0., min(.1 * (113. - point.Y()), .1 * (point.Y() - -167.))));
@@ -173,7 +174,7 @@ void LoadPanel::Draw()
 		for(const auto &it : files.find(selectedPilot)->second)
 		{
 			const string &file = it.first;
-			Rectangle zone(point + Point(110., 7.), Point(230., 20.));
+			Rectangle zone(point + Point(110., centerY), Point(230., 20.));
 			double alpha = min(1., max(0., min(.1 * (113. - point.Y()), .1 * (point.Y() - -167.))));
 			bool isHovering = (alpha && hasHover && zone.Contains(hoverPoint));
 			bool isHighlighted = (file == selectedFile || isHovering);


### PR DESCRIPTION
**Bugfix:** This PR addresses issue where the items in load and start panels slightly misaligned vertically.

## Fix Details
Especially in low res, I can see the texts of the items in load and start panels slightly misaligned to lower than preferences panel.

current version
preferences
![preferences](https://user-images.githubusercontent.com/22392249/108693173-dcefec80-7540-11eb-911c-916b0799664e.png)
Upper margin of 'l' and 'h' is 3 dots, lower's of 'p', 'y', 'g' is 2 dots.

load panel
![load_panel](https://user-images.githubusercontent.com/22392249/108693202-e5e0be00-7540-11eb-9b1e-c3d2a06b9b14.png)
Upper margin of 'l' and 'h' is 4 dots, lower's of 'p', 'y', 'g' is 1 dots.

start panel
![start_panel](https://user-images.githubusercontent.com/22392249/108693220-eda06280-7540-11eb-9586-3f8377888bd5.png)
Upper margin of 'l' and 'h' is 4 dots, lower's of 'p', 'y', 'g' is 1 dots.

## Testing Done
This PR
load panel
![load_panel2](https://user-images.githubusercontent.com/22392249/108693255-f98c2480-7540-11eb-9570-d7b00b88cb63.png)
Upper margin of 'l' and 'h' is 3 dots, lower's of 'p', 'y', 'g' is 2 dots.

start panel
![start_panel2](https://user-images.githubusercontent.com/22392249/108693280-014bc900-7541-11eb-842e-14d3a9e4b75a.png)
Upper margin of 'l' and 'h' is 3 dots, lower's of 'p', 'y', 'g' is 2 dots.
