### PR TITLE
Fix: Prevent jump commands from being cleared while landing

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -342,7 +342,7 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 	autoPilot |= activeCommands;
 	// While the flagship is landing, it cannot do most actions.
 	if(flagship && flagship->IsLanding())
-		autoPilot.Clear(Command::JUMP | Command::LAND | Command::BOARD | Command::STOP);
+		autoPilot.Clear(Command::LAND | Command::BOARD | Command::STOP);
 	else if(activeCommands.Has(AutopilotCancelCommands()))
 	{
 		bool canceled = (autoPilot.Has(Command::JUMP) && !activeCommands.Has(Command::JUMP));


### PR DESCRIPTION
**Bugfix:** This PR fixes #5744.

## Fix Details
Thanks to Vitalchip, jumping has been removed from the list of commands cleared when in the process of landing. This keeps the jumping command intact while traveling through wormholes, while still not triggering the message fixed in #5733.

**TODO:** Verify possible regression that Vitalchip experienced, where a jump can be queued up on landing, does not occur on other computers.

## Testing Done
Traversed wormhole route with only a single button press. Checked that "Disengaging autopilot" does not trigger while pressing "Jump" while landing.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 774cd9f, and will not occur when using this branch's build.
[Wormhole Pilot.txt](https://github.com/endless-sky/endless-sky/files/6025599/Wormhole.Travel.txt)