### PR TITLE
Add 'invisible' system tag

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -8012,6 +8012,7 @@ system Diespiter
 	attributes "ember waste" "inaccessible"
 	habitable 534.375
 	haze _menu/haze-red
+	link Postverta
 	link Statina
 	asteroids "small rock" 65 3
 	asteroids "medium rock" 14 1
@@ -19454,12 +19455,15 @@ system Porrima
 			period 11.4255
 
 system Postverta
-	hidden
+	invisible
 	pos 297 269
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
 	habitable 135
 	haze _menu/haze-red
+	link Diespiter
+	link Prosa
+	link Statina
 	asteroids "medium rock" 4 2
 	asteroids "large rock" 4 3
 	asteroids "medium metal" 52 1
@@ -19632,6 +19636,7 @@ system Prosa
 	attributes "ember waste" "inaccessible"
 	habitable 2372.76
 	haze _menu/haze-red
+	link Postverta
 	link Vaticanus
 	asteroids "medium metal" 11 2
 	asteroids "large metal" 2 2
@@ -23256,6 +23261,7 @@ system Statina
 	haze _menu/haze-red
 	link Diespiter
 	link Egeria
+	link Postverta
 	asteroids "large rock" 1 4
 	asteroids "small metal" 39 3
 	asteroids "medium metal" 72 3
@@ -25970,7 +25976,7 @@ system Zubenelgenubi
 		period 1158.05
 
 system Zubenelhakrabi
-	hidden
+	invisible
 	pos -755 365
 	government Uninhabited
 	habitable 486.68

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3954,11 +3954,8 @@ event "remnant: postverta reveal"
 	unvisit Levana
 	unvisit Prosa
 	unvisit Statina
-	link Postverta Diespiter
-	link Postverta Prosa
-	link Postverta Statina
 	system Postverta
-		remove hidden
+		remove invisible
 	system Egeria
 		add object "Wormhole Barren Alpha"
 			sprite planet/wormhole-red

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -1257,7 +1257,7 @@ mission "Sheragi Archaeology: The Emerald Sword 2"
 
 event "zubenelhakrabi discovered"
 	system "Zubenelhakrabi"
-		remove hidden
+		remove invisible
 
 mission "Sheragi Archaeology: The Emerald Sword 3"
 	landing

--- a/source/DistanceMap.cpp
+++ b/source/DistanceMap.cpp
@@ -203,6 +203,10 @@ void DistanceMap::Init(const Ship *ship)
 		Edge top = edges.top();
 		edges.pop();
 		
+		// If the system is invisible, it cannot be used.
+		if(top.next->Invisible())
+			continue;
+		
 		// Source is only defined when given a ship and a destination system.
 		// Once we have a route between them, stop searching for more routes.
 		if(top.next == source)

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -271,8 +271,8 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, float alpha, const System *
 		
 		for(const System *link : system.Links())
 		{
-			// Only draw systems known to be attached to the jump systems.
-			if(!player.HasVisited(system) && !player.HasVisited(*link))
+			// Only draw visible systems known to be attached to the jump systems.
+			if((!player.HasVisited(system) && !player.HasVisited(*link)) || system.Invisible() || link->Invisible())
 				continue;
 			
 			// Draw the system link. This will double-draw the jump
@@ -725,8 +725,8 @@ void MapPanel::UpdateCache()
 	for(const auto &it : GameData::Systems())
 	{
 		const System &system = it.second;
-		// Ignore systems which have been referred to, but not actually defined.
-		if(!system.IsValid())
+		// Ignore systems which are invisible or have been referred to, but not actually defined.
+		if(!system.IsValid() || system.Invisible())
 			continue;
 		// Ignore systems the player has never seen, unless they have a pending mission that lets them see it.
 		if(!player.HasSeen(system) && &system != specialSystem)
@@ -847,10 +847,10 @@ void MapPanel::UpdateCache()
 		for(const System *link : system->Links())
 			if(link < system || !player.HasSeen(*link))
 			{
-				// Only draw links between two systems if one of the two is
+				// Only draw links between two visible systems if one of the two is
 				// visited. Also, avoid drawing twice by only drawing in the
 				// direction of increasing pointer values.
-				if((!player.HasVisited(*system) && !player.HasVisited(*link)) || !link->IsValid())
+				if((!player.HasVisited(*system) && !player.HasVisited(*link)) || !link->IsValid() || link->Invisible())
 					continue;
 				
 				bool isClose = (system == &playerSystem || link == &playerSystem);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -393,7 +393,7 @@ void PlayerInfo::AddChanges(list<DataNode> &changes)
 		{
 			seen.insert(system);
 			for(const System *neighbor : system->VisibleNeighbors())
-				if(!neighbor->Hidden() || system->Links().count(neighbor))
+				if((!neighbor->Hidden() || system->Links().count(neighbor)) && !neighbor->Invisible())
 					seen.insert(neighbor);
 		}
 	}
@@ -1911,7 +1911,7 @@ void PlayerInfo::Visit(const System &system)
 	visitedSystems.insert(&system);
 	seen.insert(&system);
 	for(const System *neighbor : system.VisibleNeighbors())
-		if(!neighbor->Hidden() || system.Links().count(neighbor))
+		if((!neighbor->Hidden() || system.Links().count(neighbor)) && !neighbor->Invisible())
 			seen.insert(neighbor);
 }
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -199,6 +199,8 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			}
 			else if(key == "hidden")
 				hidden = false;
+			else if(key == "invisible")
+				invisible = false;
 			
 			// If not in "overwrite" mode, move on to the next node.
 			if(overwriteAll)
@@ -210,6 +212,8 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		// Handle the attributes which can be "removed."
 		if(key == "hidden")
 			hidden = true;
+		else if(key == "invisible")
+			invisible = true;
 		else if(!hasValue && key != "object")
 		{
 			child.PrintTrace("Expected key to have a value:");
@@ -530,6 +534,14 @@ const set<const System *> &System::JumpNeighbors(double neighborDistance) const
 bool System::Hidden() const
 {
 	return hidden;
+}
+
+
+
+// Whether this system can be seen.
+bool System::Invisible() const
+{
+	return invisible;
 }
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -117,6 +117,8 @@ public:
 	const std::set<const System *> &JumpNeighbors(double neighborDistance) const;
 	// Whether this system can be seen when not linked.
 	bool Hidden() const;
+	// Whether this system can be seen.
+	bool Invisible() const;
 	// Additional travel distance to target for ships entering through hyperspace.
 	double ExtraHyperArrivalDistance() const;
 	// Additional travel distance to target for ships entering using a jumpdrive.
@@ -208,6 +210,8 @@ private:
 	
 	// Defines whether this system can be seen when not linked.
 	bool hidden = false;
+	// Defines whether this system can be seen.
+	bool invisible = false;
 	
 	// Stellar objects, listed in such an order that an object's parents are
 	// guaranteed to appear before it (so that if we traverse the vector in


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed in issue #5734

## Feature Details
`invisible` systems cannot be seen on map or jumped to

NOTE: this PR does not prevent you from using wormholes to go the invisible system.

## Testing Done
Marked Arculus `invisible` and it wasn't drawn on map or reachable via hyperspace. I didn't test if the attribute is removed correctly, but it should work.