### PR TITLE
Rename "hit effect" for hazards to "target effect".

### DIFF
--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -40,7 +40,7 @@ hazard "Black Hole Accretion Disk"
 	"constant strength"
 	"range" 600
 	weapon
-		"hit effect" "nano spark"
+		"target effect" "nano spark"
 		"damage dropoff" 150 600
 		"dropoff modifier" 0
 		"relative shield damage" .0018
@@ -49,7 +49,7 @@ hazard "Black Hole Event Horizon"
 	"constant strength"
 	"range" 150
 	weapon
-		"hit effect" "nano spark"
+		"target effect" "nano spark"
 		"damage dropoff" 0 150
 		"dropoff modifier" 0
 		"relative hull damage" .0009

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2031,7 +2031,7 @@ void Engine::DoWeather(Weather &weather)
 		// and max ranges at the hazard's origin. Any ship touching this ring takes
 		// hazard damage.
 		for(Body *body : shipCollisions.Ring(Point(), hazard->MinRange(), hazard->MaxRange()))
-			reinterpret_cast<Ship *>(body)->TakeHazardDamage(visuals, hazard, multiplier);
+			reinterpret_cast<Ship *>(body)->TakeDamage(visuals, hazard, multiplier);
 	}
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -21,7 +21,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "text/Format.h"
 #include "GameData.h"
 #include "Government.h"
-#include "Hazard.h"
 #include "Mask.h"
 #include "Messages.h"
 #include "Phrase.h"
@@ -3048,16 +3047,16 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 
 
 
-// This ship just got hit by the given hazard. Take damage according to what
+// This ship just got hit by an hazard. Take damage according to what
 // sort of weapon the hazard has, and create any hit effects as sparks.
-void Ship::TakeHazardDamage(vector<Visual> &visuals, const Hazard *hazard, double strength)
+void Ship::TakeDamage(vector<Visual> &visuals, const Weapon *weapon, double damageScaling)
 {
 	// Rather than exactly compute the distance between the hazard origin and
 	// the closest point on the ship, estimate it using the mask's Radius.
 	double distanceTraveled = position.Length() - GetMask().Radius();
-	TakeDamage(*hazard, strength, distanceTraveled, Point(), hazard->BlastRadius() > 0.);
-	for(const auto &effect : hazard->TargetEffects())
-		CreateSparks(visuals, effect.first, effect.second * strength);
+	TakeDamage(*weapon, damageScaling, distanceTraveled, Point(), weapon->BlastRadius() > 0.);
+	for(const auto &effect : weapon->TargetEffects())
+		CreateSparks(visuals, effect.first, effect.second * damageScaling);
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3056,7 +3056,7 @@ void Ship::TakeHazardDamage(vector<Visual> &visuals, const Hazard *hazard, doubl
 	// the closest point on the ship, estimate it using the mask's Radius.
 	double distanceTraveled = position.Length() - GetMask().Radius();
 	TakeDamage(*hazard, strength, distanceTraveled, Point(), hazard->BlastRadius() > 0.);
-	for(const auto &effect : hazard->HitEffects())
+	for(const auto &effect : hazard->TargetEffects())
 		CreateSparks(visuals, effect.first, effect.second * strength);
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3047,7 +3047,7 @@ int Ship::TakeDamage(const Projectile &projectile, bool isBlast)
 
 
 
-// This ship just got hit by an hazard. Take damage according to what
+// This ship just got hit by a hazard. Take damage according to what
 // sort of weapon the hazard has, and create any hit effects as sparks.
 void Ship::TakeDamage(vector<Visual> &visuals, const Weapon *weapon, double damageScaling)
 {

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -35,7 +35,6 @@ class DataWriter;
 class Effect;
 class Flotsam;
 class Government;
-class Hazard;
 class Minable;
 class Phrase;
 class Planet;
@@ -323,9 +322,9 @@ public:
 	// not necessarily its primary target.
 	// Blast damage is dependent on the distance to the damage source.
 	int TakeDamage(const Projectile &projectile, bool isBlast = false);
-	// This ship just got hit by the given hazard. Take damage according to what
+	// This ship just got hit by an hazard. Take damage according to what
 	// sort of weapon the hazard has, and create any hit effects as sparks.
-	void TakeHazardDamage(std::vector<Visual> &visuals, const Hazard *hazard, double strength);
+	void TakeDamage(std::vector<Visual> &visuals, const Weapon *weapon, double damageScaling);
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.
 	void ApplyForce(const Point &force, bool gravitational = false);

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -322,7 +322,7 @@ public:
 	// not necessarily its primary target.
 	// Blast damage is dependent on the distance to the damage source.
 	int TakeDamage(const Projectile &projectile, bool isBlast = false);
-	// This ship just got hit by an hazard. Take damage according to what
+	// This ship just got hit by a hazard. Take damage according to what
 	// sort of weapon the hazard has, and create any hit effects as sparks.
 	void TakeDamage(std::vector<Visual> &visuals, const Weapon *weapon, double damageScaling);
 	// Apply a force to this ship, accelerating it. This might be from a weapon

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -80,6 +80,11 @@ void Weapon::LoadWeapon(const DataNode &node)
 			int count = (child.Size() >= 3) ? child.Value(2) : 1;
 			hitEffects[GameData::Effects().Get(child.Token(1))] += count;
 		}
+		else if(key == "target effect")
+		{
+			int count = (child.Size() >= 3) ? child.Value(2) : 1;
+			targetEffects[GameData::Effects().Get(child.Token(1))] += count;
+		}
 		else if(key == "die effect")
 		{
 			int count = (child.Size() >= 3) ? child.Value(2) : 1;
@@ -336,6 +341,13 @@ const map<const Effect *, int> &Weapon::LiveEffects() const
 const map<const Effect *, int> &Weapon::HitEffects() const
 {
 	return hitEffects;
+}
+
+
+
+const map<const Effect *, int> &Weapon::TargetEffects() const
+{
+	return targetEffects;
 }
 
 

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -49,6 +49,7 @@ public:
 	const std::map<const Effect *, int> &FireEffects() const;
 	const std::map<const Effect *, int> &LiveEffects() const;
 	const std::map<const Effect *, int> &HitEffects() const;
+	const std::map<const Effect *, int> &TargetEffects() const;
 	const std::map<const Effect *, int> &DieEffects() const;
 	const std::map<const Outfit *, int> &Submunitions() const;
 	
@@ -179,6 +180,7 @@ private:
 	std::map<const Effect *, int> fireEffects;
 	std::map<const Effect *, int> liveEffects;
 	std::map<const Effect *, int> hitEffects;
+	std::map<const Effect *, int> targetEffects;
 	std::map<const Effect *, int> dieEffects;
 	std::map<const Outfit *, int> submunitions;
 	


### PR DESCRIPTION
**Feature:** This PR replaces the "hit effect" keyword for hazards by "target effect" as discussed in #5751

## Feature Details
This is just the rename to differentiate between "hit effect" (effect at point of impact, for projectile weapons) and "target effect" (as effects over a ship shape, for hazards) and some changes to make the hazard-weapon-terminology more in line with the projectile-weapon-terminilogy.
There are a number of other improvements being discussed in #5751, but the discussion was just started so I want to give a bit more time to discuss before creating other improvements.

## UI Screenshots
N/A (only the keyword changed)

## Usage Examples
See `data/hazards.txt` for the replaced keyword.

## Testing Done
Flown to Sagittarius A* and got my ship destroyed there in a cloud of nano particles.

## Performance Impact
None expected.