### PR TITLE
feat(content): Add sinister assisting mission about a secret slave ship

### DIFF
--- a/changelog
+++ b/changelog
@@ -73,6 +73,7 @@ Version 0.9.13:
         * Created an epilogue mission for Barmy Edward. (@beccabunny, @Darcman99)
         * Created a mission where you can inform the Remnant about the research that the Deep are doing on the Ember Waste. (@Amazinite, @Zitchas)
         * The player will now be warned the first time their pirate attraction is greater than 50%. (@Amazinite)
+        * Created a new boarding mission about a secret slave ship (@Pointedstick)
       * New outfits and ships:
         * Created an ammo storage outfit for Finisher torpedoes. (@Arachi-Lover)
         * Ka'het ships now have power generation and storage outfits. (@beccabunny)

--- a/data/human/boarding missions.txt
+++ b/data/human/boarding missions.txt
@@ -406,3 +406,346 @@ mission "Pirate Mutiny"
 	on complete
 		payment 25000
 		dialog `The pirate crew members thank you for bringing them to <planet>. One of them hands you a small payment of <payment>. You wish them all the best of luck with their new lives and part ways.`
+
+
+
+mission "Slave Crew Rescue (No Brig Variant)"
+	invisible
+	assisting
+	deadline 1
+	to offer
+		random < 10
+	source
+		category "Medium Freighter" "Heavy Freighter"
+		not attributes "automaton"
+	destination "Earth"
+	on offer
+		require "Brig" 0
+		conversation
+			branch "boarding alone" "boarding with a big boarding party"
+				"flagship crew" < 3
+
+			label "boarding alone"
+			branch "flagship is empty" "first mate left on flagship"
+				"flagship crew" == 1
+
+			label "flagship is empty"
+			`You leave your ship empty and board the <origin> alone. Though you aren't expecting any danger, you still feel apprehensive all by yourself on an unknown disabled vessel, so you make sure sure to bring a sidearm. Your apprehension rises as you realize you can't hear any sounds of frantic activity or see crew members scurrying around trying to repair damage like you would expect. Making your way to the bridge, you relax upon seeing a single handsome and well-dressed young man welding a bulkhead. His movements are dexterous and competent, but your practiced eye tells you that the bulkhead is damaged beyond repair, so his work is futile. He looks up and introduces himself as captain Tarquin, offering the princely sum of 350,000 credits for your expert help repairing his vessel.`
+				goto "first decision"
+
+			label "first mate left on flagship"
+			`You leave your first mate in charge of your ship and board the <origin> alone. Though you aren't expecting any danger, you still feel apprehensive all by yourself on an unknown disabled vessel, so you make sure sure to bring a sidearm. Your apprehension rises as you realize you can't hear any sounds of frantic activity or see crew members scurrying around trying to repair damage like you would expect. Making your way to the bridge, you relax upon seeing a single handsome and well-dressed young man welding a bulkhead. His movements are dexterous and competent, but your practiced eye tells you that the bulkhead is damaged beyond repair, so his work is futile. He looks up and introduces himself as captain Tarquin, offering the princely sum of 350,000 credits for your expert help repairing his vessel.`
+				goto "first decision"
+
+			label "boarding with a big boarding party"
+			`As your boarding party clambers aboard the <origin>, you realize you can't hear any sounds of frantic activity or see crew members scurrying around trying to repair damage like you would expect. Making your way to the bridge, you are greeted by a single handsome and well-dressed young man welding a bulkhead. His movements are dexterous and competent, but your practiced eye tells you that the bulkhead is damaged beyond repair, so his work is futile. He looks up and introduces himself as captain Tarquin, offering the princely sum of 350,000 credits for your expert help repairing his vessel.`
+
+			label "first decision"
+			choice
+				`	(Accept this generous payment and help make repairs.)`
+					accept
+				`	"Not to look a gift horse in the mouth, but why are you offering so much money for my assistance?"`
+					goto probe
+				`	"Can we get some help from your crew?"`
+					goto "crew missing"
+				`	"Shouldn't a ship of this size have more crew?"`
+					goto "crew missing"
+
+			label probe
+			`Tarquin laughs self-consciously. "The truth is, I'm a bit desperate," he says. "My cargo hold is full of perishable goods that need to be delivered in three days to a very important client who will probably cut me off if I don't make the deadline. I thought I could save money by hiring inexperienced peasants to crew the ship, but as you can see, that hasn't worked out very well. They're cowering in their quarters even now. I'm offering you my profits from being a cheapskate. We'll call it paying for a lesson learned."`
+				goto "get to work"
+
+			label "crew missing"
+			`Tarquin laughs heartily. "That lot? They're a bunch of simple peasants I picked up on New India, off hiding in their quarters right now. The bumpkins are unaccustomed to this kind of danger, and don't have a lot of technical skills. My fault for being too cheap to hire good help, I suppose. I'm definitely going to pick up some more experienced and reliable crewmen after we get out of this mess."`
+
+			label "get to work"
+			`	"Can we get to work now?"`
+			choice
+				`	(Get to work repairing the ship.)`
+					accept
+				`	(Press the matter.)`
+			`Something about captain Tarquin's explanation doesn't sit right with you, so you keep asking questions to distract him while subtly walking towards the ship's crew section. As you get closer, you start to hear the faint sounds of people banging on walls and yelling for help. You turn back to Tarquin, whose face is displaying an almost uncannily neutral expression, but his body is taut as as though every muscle has tensed up all at once.`
+			choice
+				`	"I think we took a wrong turn. Let's go repair your ship."`
+					goto coward
+				`	"Now I see what kind of ship you're running, but don't worry, you're among friends. No charge for those repairs."`
+					goto "trickster or monster"
+				`	"I'll help you, but the price just rose to a million credits, or I leave you here and tell the authorities that you're running a slave ship."`
+					goto blackmailer
+				`	"I demand that you release your slaves."`
+					goto "the direct approach"
+				`	(Attack him immediately.)`
+					goto "attack but tarquin is prepared"
+
+			label coward
+			`"Yes, let's do that," replies Tarquin. However his friendly attitude is gone and he remains as tense as a steel cable. You work in stony silence and awkwardly collect your payment once the <origin> is up and running again.`
+			apply
+				set "tarquin hates you"
+			`	You feel relieved that the whole situation is over once you're safely back on board your own ship.`
+				accept
+
+			label "trickster or monster"
+			`Tarquin relaxes. "It's so nice to encounter a like-minded captain in this unfriendly galaxy," he says. "I wouldn't dream of accepting repairs for free. Take the money anyway, I insist."`
+			choice
+				`	(Now go repair his ship.)`
+					accept
+				`	(Take advantage of the opening and attack him.)`
+					goto "attack with the element of surprise"
+
+			label "attack with the element of surprise"
+			branch "attack alone with the element of surprise" "attack with a big boarding party"
+				"flagship crew" < 3
+
+			label "attack but tarquin is prepared"
+			branch "attack alone but tarquin is prepared" "attack with a big boarding party"
+				"flagship crew" < 3
+
+			label "attack alone with the element of surprise"
+			`You draw your weapon as fast as you can.`
+			branch "good luck" "bad luck"
+				random < 80
+
+			label "attack alone but tarquin is prepared"
+			branch "good luck" "bad luck"
+				random < 40
+
+			label "attack with a big boarding party"
+			`Tarquin can't hope to stand alone against your entire boarding party and quickly surrenders. A look of cold fury glints in his eyes, even as the rest of his face remains calm.`
+			choice
+				`	(Execute him here and now.)`
+					goto execution
+				`	(Take him prisoner.)`
+
+			`You instruct one of the members of your boarding party to tie him up and guard him. Tarquin curses you foully and bucks around as you search him, finding a concealed handgun and knife, and the credit chip he was going to pay you. You go to rescue the ship's crew.`
+			`	The crew quarters have been fashioned into a brig with stout cell doors. There is no obvious way to open them, so you and your compatriots begin blasting them open.`
+			`	Suddenly, a warning klaxon cuts through the noise with a harsh staccato. The ship's self-destruct sequence has been activated! You race to the room where Tarquin was being held, and find that he has somehow escaped. In his place is an unconscious member of your crew with a savage slash across his face, evidently inflicted by an additional concealed weapon you didn't manage to find. A nearby panel indicates that an escape pod has been jettisoned.`
+			`	The ship will explode in less than 30 seconds. You realize bitterly that there is no chance you can release the prisoners in time, and trying anyway will just get everyone killed. You and your boarding party storm angrily back to your ship and release the docking clamps just in time for the <origin> to disintegrate into a cloud of space debris, cruelly ending the already unhappy lives of captain Tarquin's victims.`
+			apply
+				set "tarquin hates you"
+			`	You vow that it will be the last time you underestimate captain Tarquin, should your paths cross again.`
+				launch
+
+			label execution
+			`You gun captain Tarquin down in cold blood, to the shock of at least one member of your boarding party. Good riddance to bad rubbish, you think, as you search the body of ex-captain Tarquin. You find a concealed handgun and several knives, the credit chip he was going to pay you, and a tiny unlocking device. You go to rescue his crew with it.`
+				goto "rescue the crew"
+
+			label blackmailer
+			branch "blackmailing alone" "blackmailing with a big boarding party"
+				"flagship crew" < 3
+
+			label "blackmailing with a big boarding party"
+			`Tarquin eyes your boarding party and stares at you icily for at least five uncomfortable seconds before finally replying. "Fine," he said coldly, his eyes blazing with barely contained rage, even as the rest of his face remains calm. He remains as tense as a steel cable as you and your team repair the ship in stony silence, awkwardly collecting your payment once the <origin> is up and running again.`
+			apply
+				set "tarquin hates you"
+			`	You feel relieved that the whole situation is over once you're safely back on board your own ship.`
+				decline
+
+			label "blackmailing alone"
+			`"It'll be a cold day in hell before I get blackmailed by someone dumb enough to board a disabled ship all alone," sneers Tarquin.`
+				goto "attack alone but tarquin is prepared"
+
+			label "the direct approach"
+			branch "acting stupid alone" "attack with a big boarding party"
+				"flagship crew" < 3
+
+			label "acting stupid alone"
+			`Captain Tarquin throws back his head and laughs at the exact moment that he draws a concealed pistol and shoots you with it five times - all in the blink of an eye. Your last thoughts concern the effectiveness of his distraction and the foolishness of your bravado.`
+				die
+
+			label "bad luck"
+			`Quick as a flash, he whips out a concealed pistol and drills a hole in your spine before you can react. The dangerous game you were playing ends abruptly.`
+				die
+
+			label "good luck"
+			`Quick as a flash, he whips out a concealed pistol, but you're faster. It's the last mistake he ever makes. You search the body of ex-captain Tarquin, finding several concealed knives in addition to his handgun, the credit chip he was going to pay you, and a tiny unlocking device. You go to rescue the crew with it.`
+				goto "rescue the crew"
+
+			label "rescue the crew"
+			`	The ship's crew quarters have been fashioned into a brig with stout cell doors. Fortunately the unlocking device opens them all, and close to a dozen malnourished wretches stumble out, telling you the whole story: captain Tarquin has been keeping them as slaves for the past several months, locking them in their quarters when the ship makes berth, and with no food as a punishment when they complain. They are quite happy to see his lifeless body sprawled out on the deck plating.`
+			`	You turn the <origin> over to them and return to your ship.`
+				accept
+
+	on decline
+		payment 1000000
+	on accept
+		payment 350000
+
+
+
+mission "Slave Crew Rescue (Brig Variant)"
+	invisible
+	assisting
+	deadline 1
+	passengers 1
+	to offer
+		random < 10
+	source
+		category "Medium Freighter" "Heavy Freighter"
+		not attributes "automaton"
+	destination "Earth"
+	on offer
+		require "Brig"
+		conversation
+			branch "boarding alone" "boarding with a big boarding party"
+				"flagship crew" < 3
+
+			label "boarding alone"
+			branch "flagship is empty" "first mate left on flagship"
+				"flagship crew" == 1
+
+			label "flagship is empty"
+			`You leave your ship empty and board the <origin> alone. Though you aren't expecting any danger, you still feel apprehensive all by yourself on an unknown disabled vessel, so you make sure sure to bring a sidearm. Your apprehension rises as you realize you can't hear any sounds of frantic activity or see crew members scurrying around trying to repair damage like you would expect. Making your way to the bridge, you relax upon seeing a single handsome and well-dressed young man welding a bulkhead. His movements are dexterous and competent, but your practiced eye tells you that the bulkhead is damaged beyond repair, so his work is futile. He looks up and introduces himself as captain Tarquin, offering the princely sum of 350,000 credits for your expert help repairing his vessel.`
+				goto "first decision"
+
+			label "first mate left on flagship"
+			`You leave your first mate in charge of your ship and board the <origin> alone. Though you aren't expecting any danger, you still feel apprehensive all by yourself on an unknown disabled vessel, so you make sure sure to bring a sidearm. Your apprehension rises as you realize you can't hear any sounds of frantic activity or see crew members scurrying around trying to repair damage like you would expect. Making your way to the bridge, you relax upon seeing a single handsome and well-dressed young man welding a bulkhead. His movements are dexterous and competent, but your practiced eye tells you that the bulkhead is damaged beyond repair, so his work is futile. He looks up and introduces himself as captain Tarquin, offering the princely sum of 350,000 credits for your expert help repairing his vessel.`
+				goto "first decision"
+
+			label "boarding with a big boarding party"
+			`As your boarding party clambers aboard the <origin>, you realize you can't hear any sounds of frantic activity or see crew members scurrying around trying to repair damage like you would expect. Making your way to the bridge, you are greeted by a single handsome and well-dressed young man welding a bulkhead. His movements are dexterous and competent, but your practiced eye tells you that the bulkhead is damaged beyond repair, so his work is futile. He looks up and introduces himself as captain Tarquin, offering the princely sum of 350,000 credits for your expert help repairing his vessel.`
+
+			label "first decision"
+			choice
+				`	(Accept this generous payment and help make repairs.)`
+					accept
+				`	"Not to look a gift horse in the mouth, but why are you offering so much money for my assistance?"`
+					goto probe
+				`	"Can we get some help from your crew?"`
+					goto "crew missing"
+				`	"Shouldn't a ship of this size have more crew?"`
+					goto "crew missing"
+
+			label probe
+			`Tarquin laughs self-consciously. "The truth is, I'm a bit desperate," he says. "My cargo hold is full of perishable goods that need to be delivered in three days to a very important client who will probably cut me off if I don't make the deadline. I thought I could save money by hiring inexperienced peasants to crew the ship, but as you can see, that hasn't worked out very well. They're cowering in their quarters even now. I'm offering you my profits from being a cheapskate. We'll call it paying for a lesson learned."`
+				goto "get to work"
+
+			label "crew missing"
+			`Tarquin laughs heartily. "That lot? They're a bunch of simple peasants I picked up on New India, off hiding in their quarters right now. The bumpkins are unaccustomed to this kind of danger, and don't have a lot of technical skills. My fault for being too cheap to hire good help, I suppose. I'm definitely going to pick up some more experienced and reliable crewmen after we get out of this mess."`
+
+			label "get to work"
+			`	"Can we get to work now?"`
+			choice
+				`	(Get to work repairing the ship.)`
+					accept
+				`	(Press the matter.)`
+			`Something about captain Tarquin's explanation doesn't sit right with you, so you keep asking questions to distract him while subtly walking towards the ship's crew section. As you get closer, you start to hear the faint sounds of people banging on walls and yelling for help. You turn back to Tarquin, whose face is displaying an almost uncannily neutral expression, but his body is taut as as though every muscle has tensed up all at once.`
+			choice
+				`	"I think we took a wrong turn. Let's go repair your ship."`
+					goto coward
+				`	"Now I see what kind of ship you're running, but don't worry, you're among friends. No charge for those repairs."`
+					goto "trickster or monster"
+				`	"I'll help you, but the price just rose to a million credits, or I leave you here and tell the authorities that you're running a slave ship."`
+					goto blackmailer
+				`	"I demand that you release your slaves."`
+					goto "the direct approach"
+				`	(Attack him immediately.)`
+					goto "attack but tarquin is prepared"
+
+			label coward
+			`"Yes, let's do that," replies Tarquin. However his friendly attitude is gone and he remains as tense as a steel cable. You work in stony silence and awkwardly collect your payment once the <origin> is up and running again.`
+			apply
+				set "tarquin hates you"
+			`	You feel relieved that the whole situation is over once you're safely back on board your own ship.`
+				accept
+
+			label "trickster or monster"
+			`Tarquin relaxes. "It's so nice to encounter a like-minded captain in this unfriendly galaxy," he says. "I wouldn't dream of accepting repairs for free. Take the money anyway, I insist."`
+			choice
+				`	(Now go repair his ship.)`
+					accept
+				`	(Take advantage of the opening and attack him.)`
+					goto "attack with the element of surprise"
+
+			label "attack with the element of surprise"
+			branch "attack alone with the element of surprise" "attack with a big boarding party"
+				"flagship crew" < 3
+
+			label "attack but tarquin is prepared"
+			branch "attack alone but tarquin is prepared" "attack with a big boarding party"
+				"flagship crew" < 3
+
+			label "attack alone with the element of surprise"
+			`You draw your weapon as fast as you can.`
+			branch "good luck" "bad luck"
+				random < 80
+
+			label "attack alone but tarquin is prepared"
+			branch "good luck" "bad luck"
+				random < 40
+
+			label "attack with a big boarding party"
+			`Tarquin can't hope to stand alone against your entire boarding party and quickly surrenders. A look of cold fury glints in his eyes, even as the rest of his face remains calm.`
+			choice
+				`	(Execute him here and now.)`
+					goto execution
+				`	(Take him prisoner.)`
+
+			`You search Tarquin and find a concealed handgun and several knives, the credit chip he was going to pay you, and a tiny unlocking device. Then you instruct one of the members of your boarding party to lock him in your ship's brig. Tarquin curses you foully as he is marched to captivity at gunpoint. You resolve to figure out what to do with him later, and go to rescue the ship's crew.`
+				goto "rescue the crew with tarquin captured"
+
+			label execution
+			`You gun captain Tarquin down in cold blood, to the shock of at least one member of your boarding party. Good riddance to bad rubbish, you think, as you search the body of ex-captain Tarquin. You find a concealed handgun and several knives, the credit chip he was going to pay you, and a tiny unlocking device. You go to rescue his crew with it.`
+				goto "rescue the crew"
+
+			label blackmailer
+			branch "blackmailing alone" "blackmailing with a big boarding party"
+				"flagship crew" < 3
+
+			label "blackmailing with a big boarding party"
+			`Tarquin eyes your boarding party and stares at you icily for at least five uncomfortable seconds before finally replying. "Fine," he said coldly, his eyes blazing with barely contained rage, even as the rest of his face remains calm. He remains as tense as a steel cable as you and your team repair the ship in stony silence, awkwardly collecting your payment once the <origin> is up and running again.`
+			apply
+				set "tarquin hates you"
+			`	You feel relieved that the whole situation is over once you're safely back on board your own ship.`
+				decline
+
+			label "blackmailing alone"
+			`"It'll be a cold day in hell before I get blackmailed by someone dumb enough to board a disabled ship all alone," sneers Tarquin.`
+				goto "attack alone but tarquin is prepared"
+
+			label "the direct approach"
+			branch "acting stupid alone" "attack with a big boarding party"
+				"flagship crew" < 3
+
+			label "acting stupid alone"
+			`Captain Tarquin throws back his head and laughs at the exact moment that he draws a concealed pistol and shoots you with it five times - all in the blink of an eye. Your last thoughts concern the effectiveness of his distraction and the foolishness of your bravado.`
+				die
+
+			label "bad luck"
+			`Quick as a flash, he whips out a concealed pistol and drills a hole in your spine before you can react. The dangerous game you were playing ends abruptly.`
+				die
+
+			label "good luck"
+			`Quick as a flash, he whips out a concealed pistol, but you're faster. It's the last mistake he ever makes. You search the body of ex-captain Tarquin, finding several concealed knives in addition to his handgun, the credit chip he was going to pay you, and a tiny unlocking device. You go to rescue the crew with it.`
+				goto "rescue the crew"
+
+			label "rescue the crew"
+			`	The ship's crew quarters have been fashioned into a brig with stout cell doors. Fortunately the unlocking device opens them all, and close to a dozen malnourished wretches stumble out, telling you the whole story: captain Tarquin has been keeping them as slaves for the past several months, locking them in their quarters when the ship makes berth, and with no food as a punishment when they complain. They are quite happy to see his lifeless body sprawled out on the deck plating.`
+			`	You turn the <origin> over to them and return to your ship.`
+				accept
+
+			label "rescue the crew with tarquin captured"
+			`	The ship's crew quarters have been fashioned into a brig with stout cell doors. Fortunately the unlocking device opens them all, and close to a dozen malnourished wretches stumble out, telling you the whole story: captain Tarquin has been keeping them as slaves for the past several months, locking them in their quarters when the ship makes berth, and with no food as a punishment when they complain. They are quite happy to hear that he has been taken into captivity.`
+			apply
+				set "captured tarquin"
+			`	You turn the <origin> over to them and return to your ship to figure out what to do with Tarquin.`
+			`	A quick check of the public data in the galactic criminal justice database doesn't reveal that he's wanted for any crimes. You decide to turn him to law enforcement authorities on the nearest planet.`
+				accept
+
+	on decline
+		payment 1000000
+	on accept
+		payment 350000
+
+mission "Turn in Tarquin"
+	description "Deliver captain Tarquin to law enforcement on the nearest planet."
+	passengers 1
+	landing
+	to offer
+		has "captured tarquin"
+	destination "Earth"
+	on offer
+		conversation
+			apply
+				set "turned in tarquin"
+			"You haul captain Tarquin out of your brig and bring him to the portside police station, presenting evidence from your suit cameras and notarized witness statements compiled from your crew members attesting to his crimes of being involved in slavery. The officer on duty thanks you for the service you've rendered, and takes Tarquin into custody. He shoots one final black look at you that sends a shiver up your spine."
+				decline


### PR DESCRIPTION
## Summary
This commit adds a new assisting mission occasionally offered when
patching up a disabled merchant freighter. In it, the player meets a
sinister fellow named captain Tarquin who is running a secret slave
ship, and is given the option to help him, kill him, apprehend him and
turn him into law enforcement, die, or bungle the situation entirely
and let him escape, in which case he harbors a hatred of the player
that may cause him to pop up later in a future minor mission that is
yet to be written.

There are two variants: one if the player has a brig, and one for without one. This is an unfortunate implementation that results in a lot of duplication, and is working around the fact that testing for the presence of an outfit cannot be done inside a conversation.

## Save File
Both variants are quite difficult to trigger as they rely on assisting a merchant ship that was disabled outside the course of the player's own missions and escorts. The easiest way to do so for testing purposes is to alter the basic parameters of whichever mission you want to test to be a boarding mission that triggers on disabled pirate ships, and also add the `repeat` tag. Then just disable and board multiple pirate ships and try out all the options.