### PR TITLE
Fix: Independents hostile before FW

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -216,7 +216,7 @@ government "Independent (Killable)"
 	"player reputation" 10
 	bribe .05
 	fine 0
-	# Nothing you do should anger the Killable Independents, as the
+	# Nothing you do should anger the Killable Independents, as they
 	# should not reveal themselves to you.
 	"penalty for"
 		disable 0

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -214,6 +214,8 @@ government "Independent (Killable)"
 	color .78 .36 .36
 	
 	"player reputation" 10
+	bribe .05
+	fine 0
 	# Nothing you do should anger the Killable Independents, as the
 	# should not reveal themselves to you.
 	"penalty for"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -214,8 +214,13 @@ government "Independent (Killable)"
 	color .78 .36 .36
 	
 	"player reputation" 10
-	"bribe" .05
-	"fine" 0
+	# Nothing you do should anger the Killable Independents, as the
+	# should not reveal themselves to you.
+	"penalty for"
+		disable 0
+		board 0
+		capture 0
+		destroy 0
 	"friendly hail" "friendly civilian"
 	"hostile hail" "hostile civilian"
 

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1058,7 +1058,7 @@ mission "Deep: Project Hawking"
 		dialog `You have arrived on <planet>, but you do not have all the supplies needed for "Project Hawking." Return to <stopovers> to collect all of the required cargo.`
 	
 	npc
-		government "Independent"
+		government "Independent (Killable)"
 		personality staying
 		system "Naos"
 		ship "Marauder Quicksilver (Engines)" "Gusoyn"
@@ -1123,7 +1123,7 @@ mission "Deep: Project Hawking: Carbuncle"
 	to fail
 		has "Deep: Project Hawking: done"
 	npc kill
-		government "Independent"
+		government "Independent (Killable)"
 		personality waiting
 		ship "Marauder Splinter (Engines)" "Abaddon"
 	on offer
@@ -1198,7 +1198,7 @@ mission "Deep: Project Hawking: Prime"
 	to fail
 		has "Deep: Project Hawking: done"
 	npc kill
-		government "Independent"
+		government "Independent (Killable)"
 		personality waiting
 		ship "Marauder Raven (Engines)" "Krampus"
 	on offer
@@ -1238,7 +1238,7 @@ mission "Deep: Project Hawking: Vinci"
 	to fail
 		has "Deep: Project Hawking: done"
 	npc kill
-		government "Independent"
+		government "Independent (Killable)"
 		personality waiting
 		ship "Marauder Manta (Engines)" "Valac"
 	on offer


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5758
fixes #5758 

## Fix Details
This PR makes the Independent ships that follow you be Independent (Killable), so that they do not interfere with the Southern Independent planet & ships.

## Testing Done
I replaced all modified files, since no source code was changed.