### PR TITLE
Fix dragAcceleration formula

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1775,7 +1775,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	if(acceleration)
 	{
 		acceleration *= slowMultiplier;
-		Point dragAcceleration = acceleration - velocity * (attributes.Get("drag") / mass);
+		Point dragAcceleration = acceleration - velocity * (attributes.Get("drag") / (mass/60));
 		// Make sure dragAcceleration has nonzero length, to avoid divide by zero.
 		if(dragAcceleration)
 		{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1775,7 +1775,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	if(acceleration)
 	{
 		acceleration *= slowMultiplier;
-		Point dragAcceleration = acceleration - velocity * (attributes.Get("drag") / (mass/60));
+		Point dragAcceleration = acceleration - velocity * (attributes.Get("drag") / (mass / 60.));
 		// Make sure dragAcceleration has nonzero length, to avoid divide by zero.
 		if(dragAcceleration)
 		{


### PR DESCRIPTION
**Bugfix:** This PR addresses the issue I posted in the Bug-Reporting discord channel

## Fix Details
DragAcceleration formula updated to correctly treat drag as an acceleration in the same units.

The error size is small (~1.65%) but compounds to create significant problems when being used for predictive things such as stopping distances with reverse thrust.

See the excel sheet posted in bug-reporting for the full math explanation.

## Testing Done
Nil - fix arose from testing and finding weird behaviour in related maths

## Save File
Nil

