### PR TITLE
Fix clunky wording in FWC Pug 4B

### DIFF
--- a/data/human/free worlds checkmate.txt
+++ b/data/human/free worlds checkmate.txt
@@ -1876,7 +1876,7 @@ mission "FWC Pug 4B"
 			`	"Well," she says, "you're the captain, I'll leave that choice up to you."`
 				accept
 			label detour
-			`	"Thanks," she says, "let's just hope that we can get some real answers."`
+			`	"Thanks," she says, "Let's just hope that we can get some real answers."`
 				accept
 	on visit
 		dialog `You land on <planet>, but you realize that Freya and the graviton reflector are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`

--- a/data/human/free worlds checkmate.txt
+++ b/data/human/free worlds checkmate.txt
@@ -1876,8 +1876,7 @@ mission "FWC Pug 4B"
 			`	"Well," she says, "you're the captain, I'll leave that choice up to you."`
 				accept
 			label detour
-			`	"Trust me," she says, "it's worth it, if we can get some real answers."`
-			`	"Straight answers from the Quarg?" you say. "Not likely, but it can't hurt to try."`
+			`	"Thanks," she says, "let's just hope that we can get some real answers."`
 				accept
 	on visit
 		dialog `You land on <planet>, but you realize that Freya and the graviton reflector are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`


### PR DESCRIPTION
The dialogue used during FWC Pug 4B when you accept Freya's request to check with the Quarg is particularly clunky.

Freya asks the player that they should try to go to the Quarg, the player responds with yes, then Freya asks the player to trust her on this, even though the player has already said they wanted to go, then the player replies saying that "it can't hurt to try", despite having already explicitly saying that they wanted to go.

This PR changes it so that when the player accepts Freya's request, she only thanks the player and expresses her hope in getting useful answers.