### PR TITLE
Make Pug planets briefly uninhabited after they flee

### DIFF
--- a/data/human/events.txt
+++ b/data/human/events.txt
@@ -2109,6 +2109,10 @@ event "pug flee"
 			sprite planet/wormhole
 			distance 2320.29
 			period 1788.2712
+	planet "Pugglemug"
+		attributes uninhabited
+	planet "Pugglequat"
+		attributes uninhabited
 
 
 
@@ -2153,6 +2157,10 @@ event "pug territory liberated"
 		fleet "Large Republic" 900 
 		fleet "Small Syndicate" 1200
 		fleet "Large Syndicate" 2000
+	planet "Pugglemug"
+		remove attributes
+	planet "Pugglequat"
+		remove attributes
 	planet "Rand"
 		security 0.05
 		tribute 500
@@ -2797,6 +2805,10 @@ event "fwc pug defeated"
 		fleet "Large Syndicate" 2000
 	system Nocte
 		government Republic
+	planet "Pugglemug"
+		remove attributes
+	planet "Pugglequat"
+		remove attributes
 	planet "Shiver"
 		security 0.1
 		tribute 300


### PR DESCRIPTION
## PR Details
One thing that struck me odd during the Pug invasion was the fact that, even after the Pug supposedly left, Pugglemug still responds to your hails, Pugglequat requires you to pay to land, and both planets have a functioning bank.
This PR makes it so that, when the pug flee, their planets become briefly uninhabited, until complete Pug liberation occurs.

## Testing Done
Tested during FWC Pug invasion. Testing might need to be done on FWR.

## Save File
Go to Silver, then go to Deneb to see the changes.
[combat testless~~previous-3.txt](https://github.com/endless-sky/endless-sky/files/6133897/combat.testless.previous-3.txt)

