### PR TITLE
bugfix: Add parameter to CanBuy to indicate if owned items should be checked

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -303,12 +303,12 @@ int OutfitterPanel::DrawDetails(const Point &center)
 
 
 
-bool OutfitterPanel::CanBuy() const
+bool OutfitterPanel::CanBuy(bool checkAlreadyOwned) const
 {
 	if(!planet || !selectedOutfit)
 		return false;
 	
-	bool isAlreadyOwned = IsAlreadyOwned();
+	bool isAlreadyOwned = checkAlreadyOwned && IsAlreadyOwned();
 	if(!(outfitter.Has(selectedOutfit) || player.Stock(selectedOutfit) > 0 || isAlreadyOwned))
 		return false;
 	
@@ -357,7 +357,7 @@ void OutfitterPanel::Buy(bool alreadyOwned)
 	}
 	
 	int modifier = Modifier();
-	for(int i = 0; i < modifier && CanBuy(); ++i)
+	for(int i = 0; i < modifier && CanBuy(alreadyOwned); ++i)
 	{
 		// Special case: maps.
 		int mapSize = selectedOutfit->Get("map");
@@ -416,7 +416,7 @@ void OutfitterPanel::Buy(bool alreadyOwned)
 		
 		for(Ship *ship : shipsToOutfit)
 		{
-			if(!CanBuy())
+			if(!CanBuy(alreadyOwned))
 				return;
 		
 			if(player.Cargo().Get(selectedOutfit))

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -51,7 +51,7 @@ protected:
 	virtual int DividerOffset() const override;
 	virtual int DetailWidth() const override;
 	virtual int DrawDetails(const Point &center) override;
-	virtual bool CanBuy() const override;
+	virtual bool CanBuy(bool checkAlreadyOwned = true) const override;
 	virtual void Buy(bool alreadyOwned = false) override;
 	virtual void FailBuy() const override;
 	virtual bool CanSell(bool toStorage = false) const override;

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -223,7 +223,7 @@ int ShipyardPanel::DrawDetails(const Point &center)
 
 
 
-bool ShipyardPanel::CanBuy() const
+bool ShipyardPanel::CanBuy(bool checkAlreadyOwned) const
 {
 	if(!selectedShip)
 		return false;

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -43,7 +43,7 @@ protected:
 	virtual int DividerOffset() const override;
 	virtual int DetailWidth() const override;
 	virtual int DrawDetails(const Point &center) override;
-	virtual bool CanBuy() const override;
+	virtual bool CanBuy(bool checkAlreadyOwned = true) const override;
 	virtual void Buy(bool alreadyOwned = false) override;
 	virtual void FailBuy() const override;
 	virtual bool CanSell(bool toStorage = false) const override;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -589,7 +589,7 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	else if(key == 'b' || ((key == 'i' || key == 'c') && selectedOutfit && (player.Cargo().Get(selectedOutfit)
 			|| (player.Storage() && player.Storage()->Get(selectedOutfit)))))
 	{
-		if(!CanBuy())
+		if(!CanBuy(key == 'i' || key == 'c'))
 			FailBuy();
 		else
 		{

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -57,7 +57,7 @@ protected:
 	virtual int DividerOffset() const = 0;
 	virtual int DetailWidth() const = 0;
 	virtual int DrawDetails(const Point &center) = 0;
-	virtual bool CanBuy() const = 0;
+	virtual bool CanBuy(bool checkAlreadyOwned = true) const = 0;
 	virtual void Buy(bool alreadyOwned = false) = 0;
 	virtual void FailBuy() const = 0;
 	virtual bool CanSell(bool toStorage = false) const = 0;


### PR DESCRIPTION
## Fix Details
This is a quick fix for the CanBuy function that was checking both items for sale as well as items already owned. That behavior was not correct if the player was asking for explicit buying. The function now has an additional boolean parameter to indicate if the already owned items should be checked or not.
Fixes: https://github.com/endless-sky/endless-sky/issues/5787

## Testing Done
Executed the test-scenario from #5787 and performed some buy/sell actions of other outfits in the same game.

## Save File
See the description in #5787 on how to setup a test-scenario quickly.