### PR TITLE
Ships get repaired to MinimumHull() + some extra

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2175,7 +2175,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder)
 		SetShipToAssist(shared_ptr<Ship>());
 		SetTargetShip(shared_ptr<Ship>());
 		bool helped = victim->isDisabled;
-		victim->hull = max(victim->hull, victim->MinimumHull());
+		victim->hull = max(victim->hull, victim->MinimumHull() * 1.5);
 		victim->isDisabled = false;
 		// Transfer some fuel if needed.
 		if(!victim->JumpsRemaining() && CanRefuel(*victim))
@@ -2689,7 +2689,7 @@ double Ship::TransferFuel(double amount, Ship *to)
 void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 {
 	// Repair up to the point where this ship is just barely not disabled.
-	hull = max(hull, MinimumHull());
+	hull = max(hull, MinimumHull() * 1.5);
 	isDisabled = false;
 	
 	// Set the new government.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2175,7 +2175,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder)
 		SetShipToAssist(shared_ptr<Ship>());
 		SetTargetShip(shared_ptr<Ship>());
 		bool helped = victim->isDisabled;
-		victim->hull = max(victim->hull, victim->MinimumHull() * 1.5);
+		victim->hull = min(max(victim->hull, victim->MinimumHull() * 1.5), victim->attributes.Get("hull"));
 		victim->isDisabled = false;
 		// Transfer some fuel if needed.
 		if(!victim->JumpsRemaining() && CanRefuel(*victim))
@@ -2689,7 +2689,7 @@ double Ship::TransferFuel(double amount, Ship *to)
 void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 {
 	// Repair up to the point where this ship is just barely not disabled.
-	hull = max(hull, MinimumHull() * 1.5);
+	hull = min(max(hull, MinimumHull() * 1.5), attributes.Get("hull"));
 	isDisabled = false;
 	
 	// Set the new government.


### PR DESCRIPTION
**Feature:** This PR implements the feature request I thought of because I'm amazing.

## Feature Details
Currently when a ship is repaired, it gets repaired to MinimumHull(). Given that a ship becomes disabled if its hull is less than MinimumHull(), being repaired to this point means that any non-zero positive hull damage will immediately cause the ship to become disabled again. This can be especially frustrating when trying to assist a ship in the middle of combat, only to see it immediately become disabled again.

This PR changes it so that ships now get repaired to MinimumHull() * 1.5, giving some buffer room after a ship is repaired before it becomes disabled again.
Ships typically become disabled after reaching 15-45% hull remaining, with smaller ships becoming disabled sooner. Using MinimumHull() * 1.5 means that ships will get repaired to 22.5-67.5%, so smaller ships will gain more hull as a percentage of their max when being repaired compared to larger ships.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Repaired some ships to observe that they were repaired to some level greater than just their minimum hull.
Before repairs.
![image](https://user-images.githubusercontent.com/17688683/111082285-ad3f5f00-84c4-11eb-8573-afe8cf231b8b.png)
After repairs.
![image](https://user-images.githubusercontent.com/17688683/111082288-b29ca980-84c4-11eb-8ec2-f90920ac0ade.png)



## Performance Impact
N/A
