### PR TITLE
Equalize Ember Wastes person frequencies

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -840,7 +840,7 @@ outfit "LG Gridfire Turret"
 
 person "Subsidurial"
 	government "Indigenous Lifeform"
-	frequency 100
+	frequency 1000
 	personality
 		timid unconstrained coward appeasing uninterested mining harvests mute
 	ship "Subsidurial"
@@ -851,7 +851,7 @@ person "Subsidurial"
 
 
 person "Prototype B3-CC4"
-	frequency 20000
+	frequency 1000
 	government "Author"
 	personality
 		forbearing mining unconstrained swarming
@@ -1153,7 +1153,7 @@ ship "Marauder Bactrian"
 
 
 person "Zitchas"
-	frequency 200
+	frequency 1000
 	government "Author"
 	personality
 		mining harvests unconstrained opportunistic


### PR DESCRIPTION
This PR tweaks the frequency values for the three Ember Wastes-adjacent person ships. Currenctly, Becca's person ship has an over _one hundred_ times chance to spawn, compared to Zitchas's, and two hundred of the Subsidurial. The values are now adjusted to 1000, giving them a good chance to show up over regular person ships when in the eligible systems, but not overwhelmingly so.