### PR TITLE
refactor(content,weapons): Rebalance human lasers and blasters 

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -883,18 +883,12 @@ fleet "Human Miners"
 		confusion 20
 		timid frugal mining harvests
 	variant 5
-		"Sparrow"
-	variant 1
+		"Sparrow (Miner)"
+	variant 5
 		"Fury"
-	variant 2
-		"Fury (Miner)"
 	variant 1
-		"Hawk"
-	variant 2
 		"Hawk (Miner)"
 	variant 1
-		"Headhunter"
-	variant 2
 		"Headhunter (Miner)"
 
 fleet "Small Free Worlds"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1096,19 +1096,6 @@ ship "Fury" "Fury (Missile)"
 		"Hyperdrive"
 
 
-ship "Fury" "Fury (Miner)"
-	outfits
-		"Heavy Laser" 2
-		"nGVF-CC Fuel Cell"
-		"Supercapacitor"
-		"D14-RN Shield Generator"
-		"Asteroid Scanner"
-		"X2700 Ion Thruster"
-		"X2200 Ion Steering"
-		"Hyperdrive"
-
-
-
 ship "Gunboat" "Gunboat (Mark II)"
 	outfits
 		"Electron Beam" 2
@@ -1242,7 +1229,7 @@ ship "Hawk" "Hawk (Speedy)"
 
 ship "Hawk" "Hawk (Miner)"
 	outfits
-		"Heavy Laser" 2
+		"Modified Blaster" 2
 		"S3 Thermionic"
 		"LP036a Battery Pack"
 		"D41-HY Shield Generator"
@@ -1977,6 +1964,19 @@ ship "Sparrow" "Sparrow (Gatling)"
 		"Chipmunk Plasma Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
+
+
+
+ship "Sparrow" "Sparrow (Miner)"
+	outfits
+		"Energy Blaster" 2
+		"nGVF-AA Fuel Cell"
+		"LP036a Battery Pack"
+		"D14-RN Shield Generator"
+		"Chipmunk Plasma Thruster"
+		"Chipmunk Plasma Steering"
+		"Hyperdrive"
+
 
 
 ship "Sparrow" "Sparrow (Patrol)"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -20,15 +20,15 @@ outfit "Energy Blaster"
 		sprite "projectile/blaster"
 		sound "blaster"
 		"hit effect" "blaster impact"
-		"inaccuracy" 3
+		"inaccuracy" 6
 		"velocity" 10.625
 		"lifetime" 48
 		"reload" 12
-		"firing energy" 9.6
+		"firing energy" 7
 		"firing heat" 30
-		"shield damage" 9.6
-		"hull damage" 6
-	description "Although not the most accurate or damaging of weapons, the Energy Blaster is popular because it is small enough to be installed on even the tiniest of ships. One blaster is not enough to do appreciable damage to anything larger than a fighter, but a ship equipped with several of them becomes a force to be reckoned with."
+		"shield damage" 8
+		"hull damage" 8
+	description "Although not the most accurate or damaging of weapons, the Energy Blaster remains popular because it is equally effective against shields and armor, and its size and power needs are so small that it can be installed on even the tiniest of ships. One blaster is not enough to do appreciable damage to anything larger than a fighter, but a ship equipped with many of them becomes a force to be reckoned with - though it may require supplemental cooling systems to avoid overheating in the middle of a fight."
 
 outfit "Blaster Turret"
 	category "Turrets"
@@ -45,15 +45,15 @@ outfit "Blaster Turret"
 		"hardpoint offset" 9.
 		sound "blaster"
 		"hit effect" "blaster impact"
-		"inaccuracy" 3
+		"inaccuracy" 6
 		"turret turn" 3.7
 		"velocity" 10.625
 		"lifetime" 48
 		"reload" 6
-		"firing energy" 9.6
+		"firing energy" 7
 		"firing heat" 30
-		"shield damage" 9.6
-		"hull damage" 6
+		"shield damage" 8
+		"hull damage" 8
 	description "A Blaster Turret is a pair of Energy Blasters mounted on a rotating platform, allowing it to fire in any direction. Sophisticated software algorithms allow the turret to correct for a target's motion, making the Blaster Turret effective even against small, quickly moving fighters. Because it needs a special mounting point with a 360 degree field of view, not all ships are capable of being equipped with a turret."
 
 outfit "Quad Blaster Turret"
@@ -71,15 +71,15 @@ outfit "Quad Blaster Turret"
 		"hardpoint offset" 9.
 		sound "blaster"
 		"hit effect" "blaster impact"
-		"inaccuracy" 3
+		"inaccuracy" 6
 		"turret turn" 3.2
 		"velocity" 10.625
 		"lifetime" 48
 		"reload" 3
-		"firing energy" 9.6
+		"firing energy" 7
 		"firing heat" 30
-		"shield damage" 9.6
-		"hull damage" 6
+		"shield damage" 8
+		"hull damage" 8
 	description "A Quad Blaster Turret carries four guns on a single turret mount, doubling the firepower of an ordinary Blaster Turret for ships with enough space to install one and energy to drive it."
 
 effect "blaster impact"
@@ -103,14 +103,14 @@ outfit "Modified Blaster"
 		sprite "projectile/mod blaster"
 		sound "mod blaster"
 		"hit effect" "blaster impact"
-		"inaccuracy" 4
+		"inaccuracy" 8
 		"velocity" 10
 		"lifetime" 48
 		"reload" 12
-		"firing energy" 10.8
+		"firing energy" 10
 		"firing heat" 42
-		"shield damage" 12
-		"hull damage" 8
+		"shield damage" 10
+		"hull damage" 10
 	description "This is an Energy Blaster that has been tampered with to increase its power slightly, at the cost of reduced range and higher energy consumption. Modified Blasters also produce an extreme amount of heat when firing, increasing the risk that your ship will overheat."
 
 outfit "Modified Blaster Turret"
@@ -128,15 +128,15 @@ outfit "Modified Blaster Turret"
 		"hardpoint offset" 9.
 		sound "mod blaster"
 		"hit effect" "blaster impact"
-		"inaccuracy" 4
+		"inaccuracy" 8
 		"turret turn" 3.5
 		"velocity" 10
 		"lifetime" 48
 		"reload" 6
-		"firing energy" 10.8
+		"firing energy" 10
 		"firing heat" 42
-		"shield damage" 12
-		"hull damage" 8
+		"shield damage" 10
+		"hull damage" 10
 	description "This is a turreted version of the Modified Blaster, which is an Energy Blaster modified for greater power at the cost of higher energy consumption and heat. These turrets are popular with pirates and others who are trying to cram as much firepower into their ships as possible."
 
 
@@ -157,11 +157,12 @@ outfit "Beam Laser"
 		"velocity" 300
 		"lifetime" 1
 		"reload" 1
-		"firing energy" .5
+		"firing energy" .75
 		"firing heat" 1.2
-		"shield damage" 1
-		"hull damage" 1.3
-	description "In the early part of the space era, the settlements in the region of space known as the Deep developed in relative isolation from the rest of human space. One result of that isolation is that their weapons technology mostly uses beam weapons, instead of the energy projectile weapons that are more common elsewhere."
+		"shield damage" 1.3
+		"hull damage" .4
+	description "In the early part of the space era, the settlements in the region of space known as the Deep developed in relative isolation from the rest of human space. One result of that isolation is that their weapons technology mostly uses beam weapons, instead of the energy projectile weapons that are more common elsewhere. Like most examples of Deep technology, these weapons are extremely efficient, though power-hungry."
+	description "	Laser weapons do a great deal of damage to shields, but they are practically useless against armor."
 
 outfit "Laser Turret"
 	category "Turrets"
@@ -184,11 +185,12 @@ outfit "Laser Turret"
 		"velocity" 300
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1
+		"firing energy" 1.5
 		"firing heat" 2.4
-		"shield damage" 2
-		"hull damage" 2.6
+		"shield damage" 2.6
+		"hull damage" .8
 	description "Laser Turrets are hated by fighter pilots because it is nearly impossible to dodge them once you are within their reach. This turret carries a pair of lasers and can swivel almost instantly to fire on new targets as they approach. Laser Turrets are especially useful when mounted on slow-moving freighters to fend off packs of small pirate vessels."
+	description "	Laser weapons do a great deal of damage to shields, but they are practically useless against armor."
 
 effect "beam laser impact"
 	sprite "effect/laser impact"
@@ -217,11 +219,12 @@ outfit "Heavy Laser"
 		"velocity" 400
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1
+		"firing energy" 1.5
 		"firing heat" 2.1
-		"shield damage" 1.7
-		"hull damage" 2.4
+		"shield damage" 2.2
+		"hull damage" .7
 	description "The Heavy Laser is an upgraded Beam Laser with a significantly longer range and higher power. It is mostly intended for larger ships, where energy and space are plentiful, but some pilots consider a single Heavy Laser to be a worthwhile alternative to a pair of Beam Lasers, because the longer range makes up for the fact that it does not quite deal twice as much damage."
+	description "	Laser weapons do a great deal of damage to shields, but they are practically useless against armor."
 
 outfit "Heavy Laser Turret"
 	category "Turrets"
@@ -244,11 +247,12 @@ outfit "Heavy Laser Turret"
 		"velocity" 400
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 2
+		"firing energy" 3.0
 		"firing heat" 4.2
-		"shield damage" 3.4
-		"hull damage" 4.8
+		"shield damage" 4.4
+		"hull damage" 1.4
 	description "For ships with enough space to install one, the Heavy Laser Turret is a powerful weapon, equally useful for driving off fighters and for bombarding larger targets with continuous fire without having to worry about pointing your ship in the right direction."
+	description "	Laser weapons do a great deal of damage to shields, but they are practically useless against armor."
 
 effect "heavy laser impact"
 	sprite "effect/heavy laser impact"
@@ -278,10 +282,10 @@ outfit "Electron Beam"
 		"velocity" 450
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1.5
+		"firing energy" 2.25
 		"firing heat" 2.7
-		"shield damage" 2.4
-		"hull damage" 3.3
+		"shield damage" 3.1
+		"hull damage" 1.0
 	description "The Electron Beam is a recent development by the Deep Sky labs, a more powerful weapon with a design similar to their perennially popular laser guns."
 
 outfit "Electron Turret"
@@ -305,10 +309,10 @@ outfit "Electron Turret"
 		"velocity" 450
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 3.0
+		"firing energy" 4.5
 		"firing heat" 5.4
-		"shield damage" 4.8
-		"hull damage" 6.6
+		"shield damage" 6.2
+		"hull damage" 2.0
 	description "This turret places two of Deep Sky's recently developed electron beam weapons onto a rotating turret, providing unsurpassed accuracy and power for shooting down fast-moving targets."
 
 effect "electron impact"


### PR DESCRIPTION
This is a standalone weapon balance change inspired by https://github.com/endless-sky/endless-sky/pull/5772 and https://github.com/endless-sky/endless-sky/pull/5779, intended to be merged ahead of them.

Ever since I started playing Endless Sky, Laser and Blaster weapons have felt wrong to me, causing me to immediately gravitate to other weapons, even creating the Proton Turret to satisfy my desire for a human turret with no Lasers or Blasters on it. The reason for this was the muddiness of these weapons: both generally did the same things with had similar functional characteristics; it felt like where was rarely a good reason to choose one over the other.

Over the years, the situation has been somewhat improved to differentiate these weapons' ranges and damage profiles. However now Lasers are in an extremely weird spot where they do a ton of hull damage but consume little energy, which is 100% backwards from how lasers behave according to the laws of physics. It makes them feel like nonsense cartoon weapons.

---

This PR differentiates Lasers and Blasters in a way that makes sense:

- Lasers now consume 50% more energy and do 30% more damage to shields, but 1/3 as much damage to armor - almost none at all!
- Blasters now have a balanced damage profile, but at a 17% lower level than their current shield damage, and with lower energy consumption too. To compensate, their inaccuracy is doubled.

The net effect of these changes is to strongly differentiate the weapons and give them distinct battle roles and styles of play. Laser weapons are now used for cracking open shields, but other weapons must be used against the target's exposed hull or else the target can simply jump away to safety! And their perfect accuracy now matters more, because Blasters are less accurate, particularly against very small fast ships due to the reduced accuracy. Blasters by are now true jack-of-all-trades weapons, but their low damage output makes them the master of none.

All told, gun combat is now slower, more tactical, and more forgiving:
- Because Blaster weapons now do less damage to shields, Human shield generators can absorb more of the damage with their regen.
- Because Laser weapons now take much much longer to disable a ship than they did before, ships under laser fire now have much more time to escape - particularly if they have relatively strong Hull values, as many freighter class ships do.
- Both gun types now benefit from the addition or partial substitution of missile weapons for different reasons: for Lasers, missiles can do much-needed hull damage, while for Blasters, missiles offer a much-needed net DPS boost to overcome the target's shield regen.

Because these changes are fairly self-contained, ships' default weapon loadouts need no adjusting, and extensive playtesting should not be required. I did a bunch with various ships with various loadouts in various stages of the Free Worlds campaign, and found things to be fine, with battles overall taking a bit longer and being more fun.

---

Human mining ships and fleets are adjusted because using Laser weapons against asteroids no longer makes any sense. Ultimately, some sort of dedicated mining weapon may be desirable to create.