### PR TITLE
Fixed issues that prevented Subsidurial from appearing

### DIFF
--- a/changelog
+++ b/changelog
@@ -12,7 +12,7 @@ Version 0.9.13:
   * Bug fixes:
     * Content bugs:
       * Typo fixes. (@Amazinite, @Anarchist2, @Arachi-Lover, @arkhne, @beccabunny, @Darcman99, @FixItYondu, @Galaucus, @infinitewarp, @MCOfficer, @michel-slm, @pega3, @Rakete1111, @roadrunner56, @tatami4, @tehhowch, @Terin, @thebigh2014, @Thunderforge, @tux2603, @W1zrad, @waterhouse, @Zitchas)
-      * The Subsidurial person ship can now appear in uninhabited systems as intended. (@Zitchas)
+      * The Subsidurial person ship can now appear in uninhabited systems as intended. (@Zitchas, @Terin)
       * "Deep Mystery Cube [3]" no longer offers on stations. (@Anarchist2)
       * Corrected the hull mass of the Faes'mar. (@Amazinite)
       * Tinker's tribute is now properly restored after the main plot. (@Zitchas)

--- a/data/drak/indigenous.txt
+++ b/data/drak/indigenous.txt
@@ -31,6 +31,7 @@ ship "Subsidurial"
 		"inscrutable" 1
 		"gaslining" 1
 		"hyperdrive" 1
+		"jump speed" 1
 	outfits
 		Mouthparts? 3
 	gun 0 -97 Mouthparts?

--- a/data/drak/indigenous.txt
+++ b/data/drak/indigenous.txt
@@ -31,7 +31,7 @@ ship "Subsidurial"
 		"inscrutable" 1
 		"gaslining" 1
 		"hyperdrive" 1
-		"jump speed" 1
+		"jump speed" .2
 	outfits
 		Mouthparts? 3
 	gun 0 -97 Mouthparts?

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -843,7 +843,7 @@ person "Subsidurial"
 	frequency 1000
 	personality
 		timid unconstrained coward appeasing uninterested mining harvests mute
-	ship "Subsidurial"
+	ship "Subsidurial" "Subsidurial"
 		"never disabled"
 	system
 		government "Uninhabited"
@@ -851,8 +851,8 @@ person "Subsidurial"
 
 
 person "Prototype B3-CC4"
-	frequency 1000
 	government "Author"
+	frequency 1000
 	personality
 		forbearing mining unconstrained swarming
 	system
@@ -1084,8 +1084,8 @@ outfit "Tree Skeleton Key Stone"
 
 
 person "Rais Iris XVIII"
-	frequency 200
 	government "Author"
+	frequency 200
 	personality
 		disables heroic plunders opportunistic
 	phrase
@@ -1153,8 +1153,8 @@ ship "Marauder Bactrian"
 
 
 person "Zitchas"
-	frequency 1000
 	government "Author"
+	frequency 1000
 	personality
 		mining harvests unconstrained opportunistic
 	system


### PR DESCRIPTION
**Bugfix:** This PR is a followup to #5104.

## Fix Details
This PR addresses two issues that prevented the Subsidurial from spawning. First, it adds a "jump speed" attribute to it, which is required for a functional hyperdrive to jump in. Second, it adds the second (vestigial) token to the ship definition necessary to spawn the ship, an issue described in #5797.

Also includes minor formatting fixes to the persons file.

## Testing Done
Removed the person ship spawning limiter, which causes all person ships to spawn in at once, and saw the Subsidurial finally coming in with all the rest (while in an uninhabited system).
![image](https://user-images.githubusercontent.com/4471575/111325742-f9f87680-8639-11eb-9387-1b5ab1ec6ba2.png)
