### PR TITLE
Minor coalition mission fixes

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -1139,7 +1139,7 @@ mission "Saryd Couple 3"
 	destination "Saros"
 	on offer
 		conversation
-			`The couple leaves your ship and heads to a real estate agency. From what they told you during the trip, they have about 1,500,000 credits they can spend, which they claim is in line with the standard properties in the most valued (and most sought-after) locations here, and that they should still have enough money to pay you afterwards.`
+			`The couple leaves your ship and heads to a real estate agency. From what they told you during the trip, they have about two and a half million credits they can spend, which they claim is in line with the standard properties in the most valued (and most sought-after) locations here, and that they should still have enough money to pay you afterwards.`
 			`	They return from consulting, the both of them with disappointed looks on their faces. Inturi starts looking at the ships landing and departing while Aunaris comes talk to you.`
 			`	"Kept watch of one property, for months we had. On a mountain village, overlooking a lake, and with access to a nearby forest, it is. A few days ago, purchased it was," she sighs. "Available, another plot of land neighboring it is, but over half our funds, the land alone costs."`
 			`	Inturi then looks over, as if he had just received a shock, and says, "That's it! A ship! Live in a ship, we could!"`

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -1168,7 +1168,7 @@ mission "Saryd Couple 4"
 	destination "Far Garden"
 	on offer
 		conversation
-			`Inturi heads right to the shipyard, and you help him with the purchase itself. He says that alhough he has worked in many ships over the years, he never went to the shipyard for more than picking up some parts for repair, or to polish a newly produced model.`
+			`Inturi heads right to the shipyard, and you help him with the purchase itself. He says that although he has worked in many ships over the years, he never went to the shipyard for more than picking up some parts for repair, or to polish a newly produced model.`
 			`	Only when you're with him inside the Arach vessel do you think of asking if he even knows how to fly a ship, but he reassures you that it won't be a problem.`
 			`	"To work as a copilot for an old friend, my first job was. Worry about me crashing the ship, you need not," he jokes.`
 			`	He says he will wait for your lead and follow you to <destination> once you depart.`


### PR DESCRIPTION
**Bugfix:** This PR doesn't address an existing issue.

## Fix Details
I noticed two minor problems with the Saryd Couple mission chain while playing a recent continuous build. This PR fixes both:
 * a typographical error: `alhough` -> `although`
 * the couple can't afford their stated purchases: increased budget from `1,500,000` to `two and a half million`

The budget probably needs a little explanation. The Arach Courier's ship data has `"cost" 723000`, which is about half of their original 1.5M budget (the other half being spent on the land). However, that's just the base hull and the actual purchase price of the ship includes the installed outfits, for a total of ~1.2M. In addition, they still need to pay the 325k mission reward -- leaving them with a significant shortfall even before shopping for furniture.

By increasing their budget to 2.5M and inflating property prices a bit, we get the following breakdown:
 * 1.25M for the land (still "over half" the budget, barely)
 * 1.2M for the ship
 * -300k from selling the propulsion systems, presumably they'd keep the power and repair modules
 * 325k for the human taxi service
 * a little left over for furnishings and the Saryd equivalent of ramen

I also rewrote the amount in words to make it feel more like an approximation. (`2.5 million` would also be fine, but `2,500,000` seems way too precise.)

## Testing Done
Minor edits to existing conversation text only, no testing necessary.

## Save File
No save provided.