### PR TITLE
Make some Remnant news comprehensible after completing sign studies

### DIFF
--- a/data/remnant/remnant news.txt
+++ b/data/remnant/remnant news.txt
@@ -368,6 +368,8 @@ news "remnant comprehensible"
 		word
 			"make out"
 			"catch"
+			"see"
+			"discern"
 		word
 			" is that they are "
 		word

--- a/data/remnant/remnant news.txt
+++ b/data/remnant/remnant news.txt
@@ -360,7 +360,11 @@ news "remnant comprehensible"
 		word
 			". "
 		word
-			"From this angle, all you can "
+			"From this angle, "
+			"Without them facing you, "
+		word
+			"all you can "
+			"what you can "
 		word
 			"make out"
 			"catch"

--- a/data/remnant/remnant news.txt
+++ b/data/remnant/remnant news.txt
@@ -213,6 +213,8 @@ news "remnant security advisory"
 news "remnant incomprehensible"
 	location
 		government "Remnant"
+	to show
+		not "remnant: sign studies complete"
 	name
 		word
 			"Spaceport"
@@ -301,5 +303,73 @@ news "remnant cafeteria"
 			"are signing to each other over a large meal"
 			"are reading reports over a large meal"
 			"are examining holo projections over a large meal"
+		word
+			"."
+
+
+
+news "remnant comprehensible"
+	location
+		government "Remnant"
+	to show
+		has "remnant: sign studies complete"
+	name
+		word
+			"Spaceport"
+			"Loading dock"
+			"Cafeteria"
+			"Landing pad"
+			"Landing dock"
+			"Spaceport alley"
+			"Spaceport hallway"
+	message
+		phrase
+			"Amount of Remnant"
+		word
+			" sign "
+			" gesture "
+		word
+			"quickly"
+			"calmly"
+			"leisurely"
+			"slowly"
+			"deliberately"
+			"carefully"
+			"precisely"
+			"sharply"
+			"briskly"
+			"sweepingly"
+			"intensively"
+			"meticulously"
+			"at length"
+			"vaguely"
+			"briskly"
+			"hurriedly"
+			"hastily"
+			"abruptly"
+			"spontaneously"
+		word
+			" to "
+		word
+			"each other"
+			"another Remnant"
+			"other Remnant"
+			"a Remnant at the information desk"
+			"a dockworker"
+			"something or someone you can't see"
+		word
+			". "
+		word
+			"From this angle, all you can "
+		word
+			"make out"
+			"catch"
+		word
+			" is that they are "
+		word
+			"discussing a recent salvage operation"
+			"making lunch plans"
+			"arguing about engine efficiencies"
+			"gossipping about a visitor from outside the Ember Waste"
 		word
 			"."

--- a/data/remnant/remnant news.txt
+++ b/data/remnant/remnant news.txt
@@ -213,8 +213,6 @@ news "remnant security advisory"
 news "remnant incomprehensible"
 	location
 		government "Remnant"
-	to show
-		not "remnant: sign studies complete"
 	name
 		word
 			"Spaceport"
@@ -376,6 +374,6 @@ news "remnant comprehensible"
 			"discussing a recent salvage operation"
 			"making lunch plans"
 			"arguing about engine efficiencies"
-			"gossipping about a visitor from outside the Ember Waste"
+			"gossiping about a visitor from outside the Ember Waste"
 		word
 			"."


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary

It bothered me a little on my recent playthrough that after going to all the trouble of learning Remnant sign language well enough for complex mission-related conversations, I was still unable to understand random people in spaceports. This PR makes the `remnant incomprehensible` news block conditional on not having learned to sign and adds a `remnant comprehensible` news block (conditional on having learned to sign) that makes the formerly-incomprehensible chatter somewhat more comprehensible.

This isn't particularly imaginative, but it fixes a minor continuity issue and can serve as a starting point for further improvements to Remnant news. I considered having several variants that became progressively more comprehensible through the "learn sign" mission chain, but there's a very short window of opportunity to actually see spaceport news between those missions and it didn't seem worthwhile to add stuff that almost nobody would ever see.

## Save File
No save provided. (I don't currently have access to a computer that can play CI builds.)

## PR Checklist
 - [X] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
