### PR TITLE
Choose sensible destinations for remnant tech retrieval missions

### DIFF
--- a/changelog
+++ b/changelog
@@ -31,6 +31,7 @@ Version 0.9.13:
       * The Remembrance Day jobs now properly have a deadline. (@Amazinite)
       * Shortened the descriptions of some jobs as to not overflow the UI. (@Amazinite)
       * Added missing "variant" keyword to NPC fleets in several Wanderer missions. (@tehhowch)
+      * Remnant "tech retrieval" missions have more appropriate destinations. (@jerith)
     * Engine bugs:
       * Missions with illegal cargo that fail when scanned can no longer be scanned again before landing. (@Amazinite)
       * The outfitter will no longer allow purchasing licensed outfits under certain circumstances where the player didn't have a license. (@Rakete1111)
@@ -77,7 +78,7 @@ Version 0.9.13:
         * Created an epilogue mission for Barmy Edward. (@beccabunny, @Darcman99)
         * Created a mission where you can inform the Remnant about the research that the Deep are doing on the Ember Waste. (@Amazinite, @Zitchas)
         * The player will now be warned the first time their pirate attraction is greater than 50%. (@Amazinite)
-        * Created a new boarding mission about a secret slave ship (@Pointedstick)
+        * Added a boarding mission about a secret slave ship (@Pointedstick, @oo13)
       * New outfits and ships:
         * Created an ammo storage outfit for Finisher torpedoes. (@Arachi-Lover)
         * Ka'het ships now have power generation and storage outfits. (@beccabunny)

--- a/credits.txt
+++ b/credits.txt
@@ -180,6 +180,7 @@ contributed to Endless Sky:
   jafdy
   Janaszar
   janisozaur
+  jerith
   jjhankins
   jmathes
   jmhorjus

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -1808,6 +1808,7 @@ mission "Remnant: Heavy Laser"
 	source "Viminal"
 	destination
 		government "Remnant"
+		attributes outfitter
 		not distance 0
 	to offer
 		or
@@ -1848,6 +1849,7 @@ mission "Remnant: Plasma Cannon"
 	source "Viminal"
 	destination
 		government "Remnant"
+		attributes outfitter
 		not distance 0
 	to offer
 		or
@@ -1896,6 +1898,7 @@ mission "Remnant: Catalytic Ramscoop"
 	source "Viminal"
 	destination
 		government "Remnant"
+		attributes outfitter
 		not distance 0
 	to offer
 		or
@@ -1935,6 +1938,7 @@ mission "Remnant: Electron Beam"
 	source "Viminal"
 	destination
 		government "Remnant"
+		attributes outfitter
 		not distance 0
 	to offer
 		or
@@ -1974,6 +1978,7 @@ mission "Remnant: D94-YV Shield Generator"
 	source "Viminal"
 	destination
 		government "Remnant"
+		attributes outfitter
 		not distance 0
 	to offer
 		or
@@ -2013,6 +2018,7 @@ mission "Remnant: S-970 Regenerator"
 	source "Viminal"
 	destination
 		government "Remnant"
+		attributes outfitter
 		not distance 0
 	to offer
 		or


### PR DESCRIPTION
**Bugfix:** This PR doesn't address an existing issue.

Upon showing a Remnant engineer my pair of S-970 Regenerators, I was asked to please deliver them to Esquiline. While it's possible that the Remnant have some legitimate reason for building an impact testing facility on a gas giant, actually delivering them in any gaslined ship available to the player requires lots of cargo expansions and imported power/engines small enough to fit in the remaining outfit space. (I'm pretty sure it can be done in a Penguin. It can definitely be done in a Petrel, although there's no in-game indication that Petrels are gaslined. It definitely can't be done in a Puffin or a Tern. It would be easy to do in a Heron, but only if you're @Zitchas. I assume it can be done in a fleet of gaslined ships, but I thought it would be impolite deliver of a dismantled pile of parts.)

## Fix Details
I fixed all the tech retrieval missions by adding `attributes outfitter` to the destination selector, based on the broken jump drive missions having that. I considered adding `planet "Aventine" "Caelian" "Viminal"` instead, but that felt uglier.

## Testing Done
I haven't tested the fix, but I spent *way* too long fiddling with gaslined ships while trying to find a way to complete the buggy mission. (By the time I noticed the problem, my oldest available save already had the mission accepted.)

## Save File
No save provided.