### PR TITLE
Adjust fuel energy mechanics

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2055,10 +2055,12 @@ void Ship::DoGeneration()
 		
 		// Convert fuel into energy and heat only when the required amount of fuel is available.
 		if(attributes.Get("fuel consumption") <= fuel)
-		{	
-			fuel -= attributes.Get("fuel consumption");
-			energy += attributes.Get("fuel energy");
-			heat += attributes.Get("fuel heat");
+		{
+			// Also, only convert fuel if it won't create more power than the batteries can hold.
+			scale = min(1., (attributes.Get("energy capacity") - energy) / attributes.Get("fuel energy"));
+			fuel -= scale * attributes.Get("fuel consumption");
+			energy += scale * attributes.Get("fuel energy");
+			heat += scale * attributes.Get("fuel heat");
 		}
 		
 		// Apply active cooling. The fraction of full cooling to apply equals

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2058,6 +2058,7 @@ void Ship::DoGeneration()
 		{
 			// Also, only convert fuel if it won't create more power than the batteries can hold.
 			double scale = min(1., (attributes.Get("energy capacity") - energy) / attributes.Get("fuel energy"));
+			scale = max(-1., scale);
 			// "regenerative fuel consumption" can run in reverse
 			if (scale < 0)
 				fuel -= scale * attributes.Get("regenerative fuel consumption");

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2057,10 +2057,13 @@ void Ship::DoGeneration()
 		if(attributes.Get("fuel consumption") <= fuel)
 		{
 			// Also, only convert fuel if it won't create more power than the batteries can hold.
-			scale = min(1., (attributes.Get("energy capacity") - energy) / attributes.Get("fuel energy"));
-			fuel -= scale * attributes.Get("fuel consumption");
-			energy += scale * attributes.Get("fuel energy");
-			heat += scale * attributes.Get("fuel heat");
+			if(energy < attributes.Get("energy capacity"))
+			{
+				double scale = min(1., (attributes.Get("energy capacity") - energy) / attributes.Get("fuel energy"));
+				fuel -= scale * attributes.Get("fuel consumption");
+				energy += scale * attributes.Get("fuel energy");
+				heat += scale * attributes.Get("fuel heat");
+			}
 		}
 		
 		// Apply active cooling. The fraction of full cooling to apply equals

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2067,7 +2067,7 @@ void Ship::DoGeneration()
 			if(scale >= 0 || attributes.Get("regenerative fuel consumption"))
 			{
 				energy += scale * attributes.Get("fuel energy");
-				heat += scale * attributes.Get("fuel heat");
+				heat += max(0., scale * attributes.Get("fuel heat"));
 			}
 		}
 		


### PR DESCRIPTION
## Feature Details
This PR changes "fuel consumption" to scale with the amount of energy capacity left to fill in a frame (with a cap at 100% strength), and to shut off if the batteries are already full, for a similar in-universe reason that active cooling scales with heat level. Your scarce hyperspace fuel is not consumed if no energy is being used and the batteries are full, to save on fuel.

It also adds a decidedly higher-tech "regenerative fuel consumption" which can run in reverse, consuming energy and heat to produce fuel. Both attributes will play nice with each other, having 5 of each will let you consume 10 fuel per frame, and if your batteries are being vastly overcharged, you can make back up to 5 fuel per frame.

Adding more "fuel energy" to the mix will actually decrease the amount of fuel you would get in return for some amount of extra energy produced, so that is left as-is, but more "fuel heat" will cause more heat to be sucked out of your ship when your batteries are overcharged, so "fuel heat" takes the maximum between its calculated value and 0 (AKA, it will never go negative and act as a cooling outfit).

## Testing Done
Flew a ship with ramscoop and fuel-consuming energy generation. Simply flying around kept fuel at relatively full. Firing weapons and thrusting and turning all together, depleting the battery, led to fuel slowly draining. Once the batteries refilled, the draining stopped, and the ramscoop started slowly refilling fuel.

Flew a ship with _no_ ramscoop, and a hybrid of regular energy generation and fuel-consuming energy generation. After jumping to deplete fuel, fuel started refilling even though I had no fuel generation or ramscoop. This was because the regular energy generation was overcharging the battery, and so the formula determining how much energy to produce to move "energy" to equal "energy capacity" was negative, consuming energy and heat, and producing fuel. The fix, only considering fuel-consuming energy generation if "energy" is already less than "energy capacity". Now, that only happens to "regenerative fuel consumption".

Flew a ship with no fuel consumption, expecting that to crash the game (by putting a 0 in a denominator) but nothing went wrong. I have not tested "fuel energy" and/or "fuel heat" without "fuel consumption", though, so watch out for that, that might cause a crash. It is not an intended situation, though, so I wouldn't worry about it (after all, you can have weapons use zero-outfit-space outfits as ammo, and the outfitter will cause the game to freeze when calculating how much to restock).

## Performance Impact
This should have no strong performance impact, it's one extra division being done each frame while there is fuel aboard a ship to use. Among the dozens or hundreds of others, I think the game will be fine.