### PR TITLE
Buffed the OSM and the ORM.

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -113,11 +113,11 @@ outfit "Overcharged Shield Module"
 	thumbnail "outfit/overcharged shield module"
 	"mass" 44
 	"outfit space" -44
-	"shield generation" 3.7
-	"shield energy" 3.7
+	"shield generation" 4.6
+	"shield energy" 4.6
 	"shield heat" 1.4
-	"energy consumption" 1.5
-	description "These modular shield generators are the most powerful emitters produced in Coalition space, and as such they are strictly controlled and exclusively used by the Heliarchs. The additions made to the Large Shield Module nearly tripled its shield generation, but at the cost of it requiring a constant supply of energy to stabilize it."
+	"energy consumption" .5
+	description "These modular shield generators are the most powerful emitters produced in Coalition space, and as such they are strictly controlled and exclusively used by the Heliarchs. The additions made to the Large Shield Module more than tripled its shield generation, but at the cost of it requiring a constant supply of energy to stabilize it."
 
 outfit "Small Repair Module"
 	category "Systems"
@@ -153,9 +153,9 @@ outfit "Overclocked Repair Module"
 	thumbnail "outfit/overclocked repair module"
 	"mass" 32
 	"outfit space" -32
-	"hull repair rate" 1.3
-	"hull energy" 1.3
-	"hull heat" 1.14
+	"hull repair rate" 1.4
+	"hull energy" 1.4
+	"hull heat" 1.2
 	"heat generation" .6
 	description "These advanced repair modules are issued to Heliarch ships, providing hull repair unparalleled in all of Coalition space. The legions of small repair drones come with the extensive pathways they use to quickly get around a ship, and as such the outfit can interfere with a ship's cooling and heat dissipation systems."
 


### PR DESCRIPTION
----------------------
**(Balance)**

## Summary
This PR  buffs the Heliarch Overcharged Shield Module and Overclocked Repair Module outfits.
The buff consists of the following:

- Reduced the constant energy consumption of the OSM from 90 to 30.
- Increased the shield generation of the OSM from 222 to 276.
- Increased the hull repair of the ORM from 78 to 84

The sum of the increases in regeneration is exactly 60, the amount subtracted from the energy consumption, that way the active energy usage of both those outfits can also be increased to match the regeneration, keeping them in line with the other Coalition regen outfits.
The changes that aren't purely buffs are the following:

- Increased the shield energy of the OSM from 222 to 276, to match its new shield generation value.
- Increased the hull energy of the ORM from 78 to 84, to match its new hull repair value.
- Increased the hull heat of the ORM from 68.4 to 72, because that number was bugging me.
- Altered the OSM's description so that the comparison to the Large Shield Module's regen fits the OSM's new shield generation value.

Aside from the obvious buff to their regeneration, this PR also helps Heliarch ships with their energy, as the OSM is now passively using only a third of the energy it used to, and as 10% of the redistributed value went to the ORM, the whole 60 energy won't be in use until the ORM is also active, so Heliarch ships will have a little bit more free energy even in combat, until the ORM comes into action that is, so either when shields are down or they face disruption/piercing.
The new values should help make it so that the gap between Heliarch and Quarg regeneration outfits isn't too large, when the time comes for the Quarg to be expanded.
As a comparison to the Large Systems Core, an OSM + ORM combo takes up 76 Outfit space, about 84% of the LSM's 91 Outfit space. Current regen of the combo is at 300 (222 shields + 78 hull), about 74% of the LSM's 408 (360 shields + 48 hull); with these changes the regen of the combo will be at 360 (276 shield + 84 hull), about 88% of the LSM's total regen. In summary, the changes make the OSM + ORM combo a good bit more efficient than the LSM. 
Of course, the LSM does use up a lot more energy for its shield regen, however it also adds a good deal of energy capacity, so I didn't feel it necessary to account for that in the comparison above.