### PR TITLE
refactor(content): Buff civilian Coalition ships

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -24,7 +24,7 @@ ship "Arach Courier"
 		"drag" 2.9
 		"heat dissipation" .65
 		"fuel capacity" 300
-		"cargo space" 78
+		"cargo space" 94
 		"outfit space" 148
 		"weapon capacity" 39
 		"engine capacity" 40
@@ -69,7 +69,7 @@ ship "Arach Freighter"
 		"drag" 10.6
 		"heat dissipation" .55
 		"fuel capacity" 500
-		"cargo space" 310
+		"cargo space" 372
 		"outfit space" 349
 		"weapon capacity" 132
 		"engine capacity" 92
@@ -119,7 +119,7 @@ ship "Arach Hulk"
 		"drag" 18.9
 		"heat dissipation" .50
 		"fuel capacity" 500
-		"cargo space" 541
+		"cargo space" 757
 		"outfit space" 520
 		"weapon capacity" 208
 		"engine capacity" 148
@@ -173,7 +173,7 @@ ship "Arach Spindle"
 		"drag" 10.8
 		"heat dissipation" .55
 		"fuel capacity" 500
-		"cargo space" 280
+		"cargo space" 392
 		"outfit space" 434
 		"weapon capacity" 138
 		"engine capacity" 148
@@ -225,7 +225,7 @@ ship "Arach Transport"
 		"drag" 7.2
 		"heat dissipation" .60
 		"fuel capacity" 400
-		"cargo space" 190
+		"cargo space" 228
 		"outfit space" 281
 		"weapon capacity" 96
 		"engine capacity" 70
@@ -1331,12 +1331,12 @@ ship "Kimek Briar"
 		"shields" 3600
 		"hull" 1700
 		"required crew" 3
-		"bunks" 25
+		"bunks" 38
 		"mass" 180
 		"drag" 3.8
 		"heat dissipation" .75
 		"fuel capacity" 700
-		"cargo space" 21
+		"cargo space" 23
 		"outfit space" 245
 		"weapon capacity" 89
 		"engine capacity" 60
@@ -1377,12 +1377,12 @@ ship "Kimek Spire"
 		"shields" 14200
 		"hull" 4900
 		"required crew" 19
-		"bunks" 197
+		"bunks" 296
 		"mass" 570
 		"drag" 8.4
 		"heat dissipation" .60
 		"fuel capacity" 800
-		"cargo space" 64
+		"cargo space" 70
 		"outfit space" 489
 		"weapon capacity" 256
 		"engine capacity" 129
@@ -1431,12 +1431,12 @@ ship "Kimek Thistle"
 		"shields" 7500
 		"hull" 2800
 		"required crew" 7
-		"bunks" 52
+		"bunks" 78
 		"mass" 270
 		"drag" 5.8
 		"heat dissipation" .70
 		"fuel capacity" 700
-		"cargo space" 29
+		"cargo space" 32
 		"outfit space" 321
 		"weapon capacity" 118
 		"engine capacity" 87
@@ -1480,12 +1480,12 @@ ship "Kimek Thorn"
 		"shields" 1400
 		"hull" 800
 		"required crew" 1
-		"bunks" 7
+		"bunks" 10
 		"mass" 80
 		"drag" 1.8
 		"heat dissipation" .80
 		"fuel capacity" 600
-		"cargo space" 12
+		"cargo space" 13
 		"outfit space" 133
 		"weapon capacity" 40
 		"engine capacity" 38
@@ -1525,12 +1525,12 @@ ship "Saryd Runabout"
 		"shields" 2000
 		"hull" 1400
 		"required crew" 2
-		"bunks" 13
+		"bunks" 14
 		"mass" 140
 		"drag" 2.8
 		"heat dissipation" .70
 		"fuel capacity" 400
-		"cargo space" 42
+		"cargo space" 46
 		"outfit space" 172
 		"weapon capacity" 44
 		"engine capacity" 42
@@ -1568,12 +1568,12 @@ ship "Saryd Sojourner"
 		"shields" 13000
 		"hull" 7700
 		"required crew" 17
-		"bunks" 84
+		"bunks" 101
 		"mass" 640
 		"drag" 12.9
 		"heat dissipation" .50
 		"fuel capacity" 800
-		"cargo space" 260
+		"cargo space" 312
 		"outfit space" 568
 		"weapon capacity" 202
 		"engine capacity" 156
@@ -1623,12 +1623,12 @@ ship "Saryd Traveler"
 		"shields" 6500
 		"hull" 4000
 		"required crew" 10
-		"bunks" 45
+		"bunks" 54
 		"mass" 350
 		"drag" 5.5
 		"heat dissipation" .60
 		"fuel capacity" 600
-		"cargo space" 137
+		"cargo space" 164
 		"outfit space" 466
 		"weapon capacity" 177
 		"engine capacity" 79
@@ -1676,12 +1676,12 @@ ship "Saryd Visitor"
 		"shields" 4000
 		"hull" 2400
 		"required crew" 5
-		"bunks" 29
+		"bunks" 32
 		"mass" 270
 		"drag" 4.4
 		"heat dissipation" .65
 		"fuel capacity" 400
-		"cargo space" 98
+		"cargo space" 108
 		"outfit space" 320
 		"weapon capacity" 90
 		"engine capacity" 57

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -1418,7 +1418,7 @@ ship "Kimek Spire"
 	explode "large explosion" 20
 	explode "huge explosion" 5
 	"final explode" "final explosion large"
-	description `The Spire is the largest passenger transport in Coalition space, able to carry nearly two hundred individuals... as long as they're comfortable staying in the tiny bunk rooms that are primarily designed to meet the needs of a Kimek. Most of the ceilings are too short for a Saryd to stand up straight, and the beds are too small for an Arach to stretch their legs out comfortably.`
+	description `The Spire is the largest passenger transport in Coalition space, able to carry nearly three hundred individuals... as long as they're comfortable staying in the tiny bunk rooms that are primarily designed to meet the needs of a Kimek. Most of the ceilings are too short for a Saryd to stand up straight, and the beds are too small for an Arach to stretch their legs out comfortably.`
 
 ship "Kimek Thistle"
 	sprite "ship/kimek thistle"

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -119,7 +119,7 @@ ship "Arach Hulk"
 		"drag" 18.9
 		"heat dissipation" .50
 		"fuel capacity" 500
-		"cargo space" 757
+		"cargo space" 688
 		"outfit space" 520
 		"weapon capacity" 208
 		"engine capacity" 148


### PR DESCRIPTION
----------------------
**(Balance)**

## Summary
It is odd that the Coalition, a group that's been independent and at peace for six thousand years, and which the player can only access once they have a Jump Drive, produces freighters and transports with little advantage over their human counterparts other than slightly more HP, it so I tried my hand at buffing them.
The ship that bugged me the most was the Arach Hulk, the largest freighter in the Coalition, having less cargo space than the Bulk Freighter. I'm not discounting HP as an advantage, but I don't think anyone buys freighters primarily for how much damage they can take.

The buffs are the following:

- Saryd Light Freighters got a 10% increase to bunks and cargo space.
- Saryd Heavy Freighters got a 20% increase to bunks and cargo space.
- All Kimek ships got a 50% increase to bunks, and a 10% increase to cargo space.
- Arach Light Freighters got a 20% increase to cargo space.
- Arach Heavy Freighters got a 40% increase to cargo space.

I don't expect the changes to be perfect as I just made up what the % increases should be in my head, so feel free to suggest other values or even other ways of buffing them.