### PR TITLE
Update Ki Patek Ka planet sprite.

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -22885,7 +22885,7 @@ system "Sol Kimek"
 		distance 137.16
 		period 31.1342
 	object "Ki Patek Ka"
-		sprite planet/ocean1
+		sprite planet/cloud6
 		distance 679.68
 		period 343.442
 		offset 43.5788


### PR DESCRIPTION
----------------------
**(Sprite update)**

## Summary
Despite the Kimek preferring hotter, drier climates, the sprite used for their home planet, Ki Patek Ka, was that of an ocean world, which caused some confusion as to what the planet was, and what their climate preferences were.
This PR changes the sprite of Ki Patek Ka from ocean1 to cloud6 (the same used for New Wales), which is of the same dimensions so the visual should be all that changes.