### PR TITLE
fix the failing unit test compilation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -108,8 +108,6 @@ def RecursiveGlob(pattern, dir_name=buildDirectory):
 		if isinstance(sub_dir, Dir)]
 	# Add source files in this directory, except for main.cpp
 	matches += Glob(pathjoin(str(dir_name), pattern))
-	for i in matches:
-		print(i)
 	matches = [i for i in matches if not "/main.cpp" in str(i)]
 	return matches
 

--- a/SConstruct
+++ b/SConstruct
@@ -108,7 +108,9 @@ def RecursiveGlob(pattern, dir_name=buildDirectory):
 		if isinstance(sub_dir, Dir)]
 	# Add source files in this directory, except for main.cpp
 	matches += Glob(pathjoin(str(dir_name), pattern))
-	matches = [i for i in matches if not "main.cpp" in str(i)]
+	for i in matches:
+		print(i)
+	matches = [i for i in matches if not "/main.cpp" in str(i)]
 	return matches
 
 # By default, invoking scons will build the backing archive file and then the game binary.


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue introduced in 599142ac9a1ec88dc1ee525c1c776ac29f8ee9ac

## Fix Details

599142ac9a1ec88dc1ee525c1c776ac29f8ee9ac changed the recursive glob in `SConstruct` to exclude anything containing `main.cpp`, rather than anything ending in `/main.cpp`. This caused the file `tests/src/test_main.cpp` to be excluded when compiling unit tests, which caused all unit test compilations to fail.

This fix simply re-adds the leading slash, so `test_main.cpp` isn't excluded anymore. This could in theory also match files such as `foo/main.cpp/myfile.cpp`, but I don't think we'll be seeing those anytime soon...

## Testing Done
Waited for the CI run to not blow up.

