### PR TITLE
Create Scrappy variant for the Heliarch Interdictor

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -660,6 +660,28 @@ ship "Heliarch Interdictor" "Heliarch Interdictor (Missile)"
 		"Large Steering Module"
 		"Hyperdrive"
 
+ship "Heliarch Interdictor" "Heliarch Interdictor (Scrappy)"
+	outfits
+		"Bombardment Cannon" 2
+		"Bombardment Turret" 2
+
+		"Large Reactor Module"
+		"Small Reactor Module"
+		"Large Battery Module" 2
+		"Overcharged Shield Module"
+		"Overclocked Repair Module" 2
+		"Cooling Module" 3
+		"Scanning Module" 5
+		"Outfits Expansion" 2
+		"Enforcer Riot Staff" 29
+		"Enforcer Confrontation Gear" 29
+
+		"Large Thrust Module" 2
+		"Small Thrust Module"
+		"Large Steering Module" 2
+		"Small Steering Module"
+		"Hyperdrive"
+
 
 ship "Heliarch Judicator"
 	sprite "ship/heliarch judicator"

--- a/data/coalition/coalition.txt
+++ b/data/coalition/coalition.txt
@@ -66,6 +66,8 @@ fleet "Heliarch"
 		"Heliarch Interdictor (Ions)"
 	variant 1
 		"Heliarch Interdictor (Missile)"
+	variant 1
+		"Heliarch Interdictor (Scrappy)"
 	variant 2
 		"Heliarch Hunter (Interdicting)"
 	variant 2


### PR DESCRIPTION
----------------------
**Content (Variant)**

## Summary
I noticed the Heliarch Interdictor was the only Heliarch ship (with the exception of the Rover, which has it as the stock variant) to lack a Scrappy (solely Bombardment Cannons and Turrets) variant, so I made one for it.
This also adds the variant to the Heliarch fleet spawns.