### PR TITLE
Set 'Interrupt fast-forward' to off by default

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -63,7 +63,6 @@ void Preferences::Load()
 	settings["Hide unexplored map regions"] = true;
 	settings["Turrets focus fire"] = true;
 	settings["Ship outlines in shops"] = true;
-	settings["Interrupt fast-forward"] = true;
 	
 	DataFile prefs(Files::Config() + "preferences.txt");
 	for(const DataNode &node : prefs)


### PR DESCRIPTION
This PR removes 'Interrupt fast-forward' as on by default. While this is a handy option for people who frequently board and want 1x speed to safely get away, that is a small part of a game compared to just traveling around at 3x, which this option interferes with by disabling fast-forward as soon as you land. I don't think anyone would suspect this change in behavior is even an option, unless they are hooked into the Discord or Steam forums, and has someone else tell them otherwise.

We've had much, much less disruptive gameplay and UI elements added to the game and default to off, so I do not know why this one defaults to on.