### PR TITLE
fix(content): Bar off Wanderer space landing anywhere after killing Arfectas

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2751,7 +2751,6 @@ mission "Wanderers Ap'arak 3: Pug 2"
 mission "Wanderers Pug Hostile"
 	landing
 	invisible
-	deadline 1
 	source
 		government "Wanderer"
 	to offer
@@ -2760,7 +2759,7 @@ mission "Wanderers Pug Hostile"
 	on offer
 		conversation
 			`Having defeated the Pug ships guarding Wanderer space, you receive a message from Sobari Tele'ek: "We are [aware? incredulous?] of reports that you have [exterminated, eradicated] our Keepers in the Ap'arak system. This is unacceptable! From now on, you are no longer welcome in our [territory, space]."`
-				launch
+				flee
 		"reputation: Wanderer" <?= -1
 
 mission "Wanderers Ap'arak 3"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2757,11 +2757,11 @@ mission "Wanderers Pug Hostile"
 	source
 		government "Wanderer"
 	to offer
-		has "Wanderers Ap'arak 3: Pug: failed"
+		has "Wanderers Ap'arak 3: Pug 1: failed"
 		has "Wanderers Ap'arak 3: Pug 2: failed"
 	on offer
 		conversation
-			`Having defeated the Pug ships guarding Wanderer space, you receive a message from Sobari Tele'ek: "We are [aware? incredulous?] of reports that you have [exterminated, eradicated] our Keepers in the Ap'arak system. This is unacceptable! From now on, you are no longer welcome in our [territory, space]."`
+			`You receive a message from Sobari Tele'ek: "We are [aware? incredulous?] of reports that you have [exterminated, eradicated] our Keepers in the Ap'arak system. This is unacceptable! From now on, you are no longer welcome in our [territory, space]."`
 				flee
 		set "Wanderers Ap'arak 3: Pug: done"
 		"reputation: Wanderer" <?= -1

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2727,13 +2727,41 @@ mission "Wanderers Ap'arak 3: Pug"
 	source "Varu Tev'kei"
 	to offer
 		has "Wanderers Ap'arak 2: done"
-	npc kill
+	npc save
 		personality staying unconstrained uninterested
 		government "Pug (Wanderer)"
 		ship "Pug Arfecta" "Hork Ekekek Ptui"
+	to complete
+		never
+
+mission "Wanderers Ap'arak 3: Pug 2"
+	landing
+	invisible
+	source "Varu Tev'kei"
+	to offer
+		has "Wanderers Ap'arak 2: done"
+		not "Wanderers Ap'arak 3: done"
+	npc save
+		personality staying unconstrained uninterested
+		government "Pug (Wanderer)"
 		ship "Pug Arfecta" "Graak Sput Kchoo"
-	on complete
-		dialog `Shortly after defeating the Pug ships, you receive a message from Sobari Tele'ek: "We are [aware? incredulous?] of reports that you have [exterminated, eradicated] our Keepers in the Ap'arak system. This is unacceptable! From now on, you are no longer welcome in our [territory, space]."`
+	to complete
+		never
+
+mission "Wanderers Pug Hostile"
+	priority
+	landing
+	invisible
+	deadline 1
+	source
+		government "Wanderer"
+	to offer
+		has "Wanderers Ap'arak 3: Pug: failed"
+		has "Wanderers Ap'arak 3: Pug 2: failed"
+	on offer
+		conversation
+			`Having defeated the Pug ships guarding Wanderer space, you receive a message from Sobari Tele'ek: "We are [aware? incredulous?] of reports that you have [exterminated, eradicated] our Keepers in the Ap'arak system. This is unacceptable! From now on, you are no longer welcome in our [territory, space]."`
+				launch
 		"reputation: Wanderer" <?= -1
 
 mission "Wanderers Ap'arak 3"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2749,7 +2749,6 @@ mission "Wanderers Ap'arak 3: Pug 2"
 		never
 
 mission "Wanderers Pug Hostile"
-	priority
 	landing
 	invisible
 	deadline 1

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2721,6 +2721,8 @@ mission "Wanderers Ap'arak 2"
 
 
 
+# TODO: When "complete anywhere" functionality is available, 
+# condense the following three missions into a single mission
 mission "Wanderers Ap'arak 3: Pug"
 	landing
 	invisible

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2723,12 +2723,13 @@ mission "Wanderers Ap'arak 2"
 
 # TODO: When "complete anywhere" functionality is available, 
 # condense the following three missions into a single mission
-mission "Wanderers Ap'arak 3: Pug"
+mission "Wanderers Ap'arak 3: Pug 1"
 	landing
 	invisible
 	source "Varu Tev'kei"
 	to offer
 		has "Wanderers Ap'arak 2: done"
+		not "Wanderers Ap'arak 3: offered"
 	npc save
 		personality staying unconstrained uninterested
 		government "Pug (Wanderer)"
@@ -2742,7 +2743,7 @@ mission "Wanderers Ap'arak 3: Pug 2"
 	source "Varu Tev'kei"
 	to offer
 		has "Wanderers Ap'arak 2: done"
-		not "Wanderers Ap'arak 3: done"
+		not "Wanderers Ap'arak 3: offered"
 	npc save
 		personality staying unconstrained uninterested
 		government "Pug (Wanderer)"
@@ -2762,6 +2763,7 @@ mission "Wanderers Pug Hostile"
 		conversation
 			`Having defeated the Pug ships guarding Wanderer space, you receive a message from Sobari Tele'ek: "We are [aware? incredulous?] of reports that you have [exterminated, eradicated] our Keepers in the Ap'arak system. This is unacceptable! From now on, you are no longer welcome in our [territory, space]."`
 				flee
+		set "Wanderers Ap'arak 3: Pug: done"
 		"reputation: Wanderer" <?= -1
 
 mission "Wanderers Ap'arak 3"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2729,7 +2729,7 @@ mission "Wanderers Ap'arak 3: Pug 1"
 	source "Varu Tev'kei"
 	to offer
 		has "Wanderers Ap'arak 2: done"
-		not "Wanderers Ap'arak 3: offered"
+		not "Wanderers Ap'arak 3: Pug: offered"
 	npc save
 		personality staying unconstrained uninterested
 		government "Pug (Wanderer)"
@@ -2743,7 +2743,7 @@ mission "Wanderers Ap'arak 3: Pug 2"
 	source "Varu Tev'kei"
 	to offer
 		has "Wanderers Ap'arak 2: done"
-		not "Wanderers Ap'arak 3: offered"
+		not "Wanderers Ap'arak 3: Pug: offered"
 	npc save
 		personality staying unconstrained uninterested
 		government "Pug (Wanderer)"
@@ -2753,18 +2753,17 @@ mission "Wanderers Ap'arak 3: Pug 2"
 
 mission "Wanderers Pug Hostile"
 	landing
-	invisible
 	source
 		government "Wanderer"
 	to offer
 		has "Wanderers Ap'arak 3: Pug 1: failed"
 		has "Wanderers Ap'arak 3: Pug 2: failed"
 	on offer
+		set "Wanderers Ap'arak 3: Pug: done"
+		"reputation: Wanderer" <?= -1
 		conversation
 			`You receive a message from Sobari Tele'ek: "We are [aware? incredulous?] of reports that you have [exterminated, eradicated] our Keepers in the Ap'arak system. This is unacceptable! From now on, you are no longer welcome in our [territory, space]."`
 				flee
-		set "Wanderers Ap'arak 3: Pug: done"
-		"reputation: Wanderer" <?= -1
 
 mission "Wanderers Ap'arak 3"
 	landing


### PR DESCRIPTION
**Content (Mission)**

## Summary
Currently, the player can destroy or capture one or both Arfectas spawned by "Wanderers Ap'arak 3: Pug". Despite this being a terrible act to the Wanderers, due to the way the mission is structure, you can only be penalized if you land on the planet where the mission is spawned, which is out of the way and only has one required landing in the rest of the Wanderers campaign.

From a suggestion from @beccabunny, this PR restructures that mission into two `npc save` missions. Upon both being failed, a third mission will be prompted on landing anywhere in Wanderer space, giving you the reputation hit and kicking you out. This is backwards-compatible with current saves, requiring both missions to be failed, and the second mission only activating if you haven't done the follow-up mission.

Possible tweaks to this PR could be having the mission fail if either of the Arfectas die (although the impression I was given was we wanted to make it both), or having the mission be received as a message anywhere in space, to ensure you can't run from the reputation hit. I believe that keeping the player from landing anywhere in Wanderer space is pressure enough, though.

## Testing Done
Used the included save file to land on Varu Tev'kei, spawning both Arfectas. Destroyed one and landed, and noticed no change. Destroyed the second and landed on a random Wanderer planet, which triggered the mission to make them hostile.

Also used an old save with active Arfectas, and ensured that a third did not spawn.

## Save File
This save file can be used to play through the new mission content. Jump to Ap'arak and land to spawn the Arfectas, which should be hostile:
[Arfecta Test.txt](https://github.com/endless-sky/endless-sky/files/6331600/Arfecta.Test.txt)
