### PR TITLE
feat(content): Added post-Eye breadcrumb mission

### DIFF
--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -17,7 +17,7 @@ mission "Wanderers: Pre-Colony"
 	on offer
 		conversation
 			`With the Eye fully opened, Wanderer ships have begun flooding into this region of space. This desolate planet seems to be of particular interest to them, with drones rapidly surveying in all directions, and a small outpost beginning to form.`
-			`	As you land on the outskirts of this settlement, one of the workers comes up to your ship and explains that this planet will be the staging ground for the Wanderers to explore this new region, but it will take a few weeks to finish. They suggest getting your bearings in these systems before returning to help, as many ships will be needed to help heal the many ruined planets here.`
+			`	As you land on the outskirts of this settlement, one of the workers comes up to you as you leave your ship. "[Greetings, welcome], it is [delightful, pleasing] to see you have come to show your interest in our exploration. Unfortunately, there exists much [hazard, risk] on a world we know so little about. This will be our staging ground to [explore, catalogue] this new region, but it will take some time to be assured of the [safety, security] of our outpost. I suggest you take time to [orient, locate] yourself in these systems while we set up before returning to help. Of course you are welcome when we have [determined, established] safety, there will be many ships needed to help heal the many ruined planets here.`
 				decline
 
 mission "Wanderers: Surveying 1"

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -8,6 +8,18 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
+mission "Wanderers: Pre-Colony"
+	landing
+	source "Spera Anatrusk"
+	to offer
+		has "event: wanderers: the eye opens"
+		not "event: wanderers: spera anatrusk colony"
+	on offer
+		conversation
+			`With the Eye fully opened, Wanderer ships have begun flooding into this region of space. This desolate planet seems to be of particular interest to them, with drones rapidly surveying in all directions, and a small outpost beginning to form.`
+			`	As you land on the outskirts of this settlement, one of the workers comes up to your ship and explains that this planet will be the staging ground for the Wanderers to explore this new region, but it will take a few weeks to finish. They suggest getting your bearings in these systems before returning to help, as many ships will be needed to help heal the many ruined planets here.`
+				decline
+
 mission "Wanderers: Surveying 1"
 	landing
 	name "Wanderer Surveying"

--- a/data/wanderer/wanderers.txt
+++ b/data/wanderer/wanderers.txt
@@ -955,6 +955,8 @@ event "wanderers: the eye opens"
 			sprite planet/wormhole
 			distance 2331.95
 			period 2518.05
+	system Kaliptari
+		government "Wanderer"
 
 event "wanderers: derecho mass production"
 	fleet "Wanderer Defense"


### PR DESCRIPTION
**Content (Missions)**

## Summary
This PR adds a basic mission to Spera Anatrusk, acting as a breadcrumb to alert the player that they'll need to wait until the colony is fully developed. It also changes the Kaliptari system over to the Wanderer government in `the eye opens` event, so that planet attracts player attention on jumping in. Many players have been confused with the end of Wanderers Act 1, going through the Eye but not knowing what to do. With this mission, it should keep the players on the hook while still letting the break naturally happen.

## Alternatives
Rather than a simple landing dialog, should this mission keep a marker on Spera Anatrusk, becoming "completable" once the event is done and the colony is ready? It would act as a reminder of where the player needs to return to, but might give a bit too much information.

For the dialog at the end here, I wrote it in more of a detached, third person due to this being a minor mission, and I also don't feel confident in replicating the exact tone/style of Wanderer dialog. Should it be even more broad, with something along the lines of "You consider returning once the colony is completed"? Or does someone feel confident about replicating Wanderer speech, and getting across what I put down in dialog?

## Save File
This save file can be used to play through the new mission content:
[Wanderer Breadcrumb.txt](https://github.com/endless-sky/endless-sky/files/6331771/Wanderer.Breadcrumb.txt)