### PR TITLE
Fix capitalization of "License" to "license" for "Remnant: Deep Surveillance"

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -1070,7 +1070,7 @@ mission "Remnant: Deep Surveillance"
 		government "Remnant"
 	stopover "Valhalla"
 	to offer
-		has "License: Remnant"
+		has "license: Remnant"
 		or
 			and
 				has "Terminus Exploration: done"


### PR DESCRIPTION
-----------------------
**Bugfix:** 

## Fix Details
Fix capitalization of "License" to "license" so the mission "Remnant: Deep Surveillance" can actually trigger.

## Testing Done
It's a one character change! Can't go wrong. Tested that it now triggers.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 65d14e, and will not occur when using this branch's build.
[Nine Of Thirteen.txt](https://github.com/endless-sky/endless-sky/files/6338069/Nine.Of.Thirteen.txt)