### PR TITLE
Fix bank tutorial typo

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -13,7 +13,7 @@ help "bank"
 	`Paying off a mortgage early means you pay less interest to the bank, but it is sometimes wiser to instead use your money to buy a bigger ship which can earn you more income.`
 
 help "bank advanced"
-	`When entering a credit value at the bank, you can put in an exact number, or uses suffixes K, M, B, and T as shorthand for thousands, millions, billions, and trillions. For example, entering a value such as "100k" would count as 100,000 credits.`
+	`When entering a credit value at the bank, you can put in an exact number, or use the suffixes K, M, B, and T as shorthand for thousands, millions, billions, and trillions. For example, entering a value such as "100k" would count as 100,000 credits.`
 	`Entering a number that is higher than what you or the bank have available depending if you are paying or applying for a loan will default to the maximum available value. For example, enterting "1m" to pay off a 100,000 credit loan will completely pay off the loan without giving extra, should you have available credits.`
 
 help "basics 1"


### PR DESCRIPTION
Fixed a tutorial typo for the payment dialog. An alternative could be "use suffixes K, M, B, and T...", but I think the current feels more natural.