### PR TITLE
Fix typo in Author hails

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -925,7 +925,7 @@ person "Prototype B3-CC4"
 		word
 			"response"
 			"EM beam"
-			"transmission brust"
+			"transmission burst"
 		word
 			">"
 	phrase


### PR DESCRIPTION
From `brust` to `burst`.