### PR TITLE
feat(content): Add pirate raid tutorial

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -124,3 +124,7 @@ help "trading"
 
 help "friendly disabled"
 	`This ship is disabled and needs your help to patch them up! Pressing <Board selected ship> will fly you to their ship and get them up and running again. Just be sure to do it when no one is trying to kill you, or they could get caught in the crossfire!`
+
+help "pirate raid"
+	`Your fleet has attracted the interest of a raiding party! By having too much cargo space in your fleet without enough defenses, word will get out that you're an easy target, and raiders have the possibility of waiting in ambush each jump you make.`
+	`The chance of drawing attention can be seen on the Player Info Panel with <View player info>. To reduce that chance, when on a planet, you can use the Player Info Panel to park ships with lots of cargo space, by selecting them and clicking the Park button at the bottom, or by selling them. Alternatively, you can arm your freighters with offensive weaponry, or buy interceptor or warship escorts to deter the raiders in the first place.`

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1218,6 +1218,7 @@ void Engine::EnterSystem()
 					raidFleet->Place(*system, newShips);
 					Messages::Add("Your fleet has attracted the interest of a "
 							+ raidGovernment->GetName() + " raiding party.");
+					pirateRaid = true;
 				}
 	}
 	

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -87,6 +87,9 @@ public:
 	void Click(const Point &from, const Point &to, bool hasShift);
 	void RClick(const Point &point);
 	void SelectGroup(int group, bool hasShift, bool hasControl);
+
+	// Tutorial boolean set by pirate raids to be read by MainPanel
+	bool pirateRaid;
 	
 	
 private:

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -123,6 +123,8 @@ void MainPanel::Step()
 				GetUI()->Push(new Dialog(GameData::HelpMessage(message)));
 			}
 		}
+		if(isActive && engine.pirateRaid)
+			DoHelp("pirate raid");
 	}
 	
 	engine.Step(isActive);


### PR DESCRIPTION
**Content (Tutorial)**

## Summary
This PR adds a tutorial when the player first encounters a pirate raid, spawned by having too much defenseless cargo, prompted by [this Steam post](https://steamcommunity.com/app/404410/discussions/0/3130541756134242226/). It pauses the game to alert the player the pirates in system are caused by their actions, and having too much cargo space, not just cargo. It then suggests four courses of action:

- Park an offending escort
- Sell an offending escort
- Arm the freighters with more offensive weaponry
- Buy combat escorts

This should hopefully make this mechanic much clearer, than the "Your fleet has attracted the interest of a Pirate raiding party" that disappears in a few seconds in the corner, and the little-context percentage in the Player Info Panel.