### PR TITLE
fix(typo): Change "enterting" to "entering"

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -14,7 +14,7 @@ help "bank"
 
 help "bank advanced"
 	`When entering a credit value at the bank, you can put in an exact number, or use the suffixes K, M, B, and T as shorthand for thousands, millions, billions, and trillions. For example, entering a value such as "100k" would count as 100,000 credits.`
-	`Entering a number that is higher than what you or the bank have available depending if you are paying or applying for a loan will default to the maximum available value. For example, enterting "1m" to pay off a 100,000 credit loan will completely pay off the loan without giving extra, should you have available credits.`
+	`Entering a number that is higher than what you or the bank have available depending if you are paying or applying for a loan will default to the maximum available value. For example, entering "1m" to pay off a 100,000 credit loan will completely pay off the loan without giving extra, should you have available credits.`
 
 help "basics 1"
 	`Press <View star map> to bring up your map. Select a destination, then close the map and press <Initiate hyperspace jump> to jump. Press <Land on planet / station> to land.`


### PR DESCRIPTION
Small typo fix:
"For example, enterting..." -> "For example, entering..."

Credit to the Discord user Lance for spotting the typo.