### PR TITLE
fix(content): Fix Remnant: Keystone Research missions

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3207,8 +3207,6 @@ mission "Remnant: Keystone Research 3"
 			`True to Aeolus' word, there are crates of Hai quantum keystones waiting for you. As you ensure they are securely loaded, your comm system informs you that a message has arrived. It has no indication of provenance, but appears to be a notification that a payment of 250,000 credits marked 'on-assignment allowance' has been made to your account.`
 			`	The attached message is brief and to the point. "Greetings, Captain <first>. Hopefully the shipments were waiting for you. We have made arrangements for samples to be acquired from Makerplace, Stonebreak, Giverstone, Cloudfire, Snowfeather, Icelake, and Heartvalley. Once you have collected all those, head to Newhome. There are a few other places that we are still working to set up, and we should have those ready by the time you reach Newhome."`
 				accept
-	on stopover
-		dialog
 	on complete
 		payment 250000
 		dialog

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3131,7 +3131,7 @@ mission "Remnant: Keystone Research 1"
 				`	(Decline.)`
 					decline
 			label crystaldecision
-			`	"Great. They would like you to pick up another 19 keystones. Two differences this time: first, we would like you to pick them up from several different planets. And second, by the time you reach Hai space, we will have made arrangements so the shipments will be already paid for and waiting for you. Pick up the first stones on Allhome, then the next set on Greenwater. I will have a list sent to you by the time you reach Greenwater."`
+			`	"Great. They would like you to pick up another 19 keystones. Two differences this time: first, we would like you to pick them up from several different planets. And second, by the time you reach Hai space, we will have made arrangements so the shipments will be already paid for and waiting for you. Pick up the first stones on Greenwater, then the next set on Allhome. I will have a list sent to you by the time you reach Allhome."`
 			`	"That being said, if you happen to pick up any additional keystones, you can turn them into the logistics office. They will handle the distribution and compensate you accordingly."`
 			choice
 				`	"Wait, how will you get this all set up?"`
@@ -3209,7 +3209,6 @@ mission "Remnant: Keystone Research 3"
 				accept
 	on stopover
 		dialog
-			`You quickly locate and load the shipment of quantum keystones. The packaging comes with brochures and images depicting comfortable-looking Hai relaxing on a spaceship observation deck. "Guaranteed to provide the smoothest flight for your passengers!" reads one of the labels.`
 	on complete
 		payment 250000
 		dialog
@@ -3228,7 +3227,7 @@ mission "Remnant: Keystone Research 3A"
 		has "Remnant: Keystone Research 3: active"
 	on offer
 		conversation
-			`Sure enough, there is a pair of crates waiting for you. This one depicts of a pair of distinguished elderly Hai relaxing in front of a matte painting.`
+			`You quickly locate and load the shipment of quantum keystones. The packaging comes with brochures and images depicting comfortable-looking Hai relaxing on a spaceship observation deck. "Guaranteed to provide the smoothest flight for your passengers!" reads one of the labels.`
 				accept
 
 
@@ -3242,6 +3241,10 @@ mission "Remnant: Keystone Research 3B"
 	cargo "Keystones" 2
 	to offer
 		has "Remnant: Keystone Research 3A: active"
+	on offer
+		conversation
+			`Sure enough, there is a pair of crates waiting for you. This time the brochure depicts a pair of distinguished elderly Hai relaxing in front of a matte painting.`
+				accept
 
 
 
@@ -3315,7 +3318,7 @@ mission "Remnant: Keystone Research 4"
 	cargo "Keystones" 19
 	to offer
 		has "Remnant: Keystone Research 3: done"
-	on accept
+	on offer
 		dialog
 			`As you were reading the previous message, a freight hauler arrives with the last few crates and starts unloading them. Looking over the assembled stack, you note that each crate bears the logos and advertisements for a different organization, shipper, or enterprise. The second message turns out to be a confirmation that you have picked up 19 keystones. While there are no new instructions, the subtext is clear: Time to head back.`
 	on complete

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3317,8 +3317,9 @@ mission "Remnant: Keystone Research 4"
 	to offer
 		has "Remnant: Keystone Research 3: done"
 	on offer
-		dialog
+		conversation
 			`As you were reading the previous message, a freight hauler arrives with the last few crates and starts unloading them. Looking over the assembled stack, you note that each crate bears the logos and advertisements for a different organization, shipper, or enterprise. The second message turns out to be a confirmation that you have picked up 19 keystones. While there are no new instructions, the subtext is clear: Time to head back.`
+				accept
 	on complete
 		payment 2000000
 		conversation


### PR DESCRIPTION

This PR fixes some issues in Remnant: Keystone Research 1, 3 and 4

## Fix Details

- Remnant: Keystone Research 1
In the dialogue, you're told to go to Allhome then Greenwater, but it's the other way around.
(We could also keep the dialogue unchanged and change the  destinations of this mission and the next instead.)

- Remnant: Keystone Research 3 to 3B
The `on stopover` dialogue was intended to be displayed on first `stopover`, but was shown on last instead. I moved it to the following invisible mission which is offered on first stopover (no matter the order in which you visit the planets), and moved and rephrased the dialogue of that mission to the next one. (3A -> 3B | 3 -> 3A)

- Remnant: Keystone Research 4
`on accept` dialogue wasn't displayed (probably because the player doesn't accept the mission), so I replaced `on accept` by  `on offer`.

## Testing Done
Replayed through the questline to check everything worked as intended. 
Did mission 3 several times, visiting the planet in a different order each time to make sure the dialogues were always shown in the right order.

## Save File
[Test.txt](https://github.com/endless-sky/endless-sky/files/6411317/Test.txt)
Save file puts you on Viminal with all necessary conditions. Just Depart/Land/Check the spaceport until the first mission is offered.