### PR TITLE
Fix: Correcting Smelter-Class thruster reverse heat

### DIFF
--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -557,7 +557,7 @@ outfit "Smelter-Class Thruster"
 	"thrusting heat" 10.2
 	"reverse thrust" 46.08
 	"reverse thrusting energy" 6.06
-	"reverse thrusting heat" 1.5
+	"reverse thrusting heat" 6.12
 	"slowing resistance" 0.048
 	"flare sprite" "effect/remnant flare/large"
 		"frame rate" 3


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5918 

## Fix Details
Changes Smelter reverse thruster heat from 1.5 to 6.12.

Thanks to ph2000bis for spotting this.
