### PR TITLE
Warn about minor or priority being mixed with landing for missions

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -229,7 +229,6 @@ mission "Coalition: Lost: Offer"
 mission "Coalition Yottrite 1"
 	name "More Yottrite"
 	description "You were offered great payment for bringing three more samples of the rare mineral yottrite to <destination>."
-	minor
 	landing
 	to offer
 		has "Coalition: Contributor: done"

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -273,7 +273,6 @@ mission "Ask the Hai about the Unfettered"
 
 mission "Unfettered Jump Drive 1"
 	name "More Jump Drives"
-	minor
 	description "The Unfettered Hai have promised you rich rewards if you bring them more jump drives."
 	landing
 	to offer
@@ -333,7 +332,6 @@ mission "Unfettered Jump Drive 1"
 
 mission "Unfettered Jump Drive 2"
 	name "More Jump Drives"
-	minor
 	description "The Unfettered Hai have promised you rich rewards, and more information about their plans, if you bring them more jump drives."
 	landing
 	to offer
@@ -376,7 +374,6 @@ mission "Unfettered Jump Drive 2"
 
 mission "Unfettered Jump Drive 3"
 	name "More Jump Drives"
-	minor
 	description "If you find more jump drives, you can sell them to the Unfettered Hai for considerably more money than they are worth elsewhere."
 	landing
 	to offer

--- a/data/human/free worlds epilogue.txt
+++ b/data/human/free worlds epilogue.txt
@@ -200,7 +200,6 @@ mission "FW Epilogue: Danforth"
 
 
 mission "FW Epilogue: Edward"
-	minor
 	landing
 	name `Weapon Testing`
 	description `A test ship with new weaponry is in orbit around <planet>. Fight and disable it (but do not board or destroy it!) and then land to give Barmy Edward feedback on its performance.`

--- a/data/human/free worlds intro.txt
+++ b/data/human/free worlds intro.txt
@@ -1763,7 +1763,6 @@ mission "FW Commitment"
 	landing
 	name "Join the Free Worlds"
 	description "If you want to join the Free Worlds, report to their headquarters on <destination>."
-	minor
 	source
 		government "Free Worlds"
 	destination "Bourne"

--- a/data/human/free worlds side plots.txt
+++ b/data/human/free worlds side plots.txt
@@ -653,7 +653,6 @@ mission "FW Stack Core 1B"
 
 mission "FW Stack Core 1C"
 	landing
-	minor
 	source
 		near "Pherkad" 100
 	to offer

--- a/data/intro missions.txt
+++ b/data/intro missions.txt
@@ -9,7 +9,6 @@
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 mission "Intro [0]"
-	priority
 	name "Passenger to <planet>"
 	description "This old-timer captain offered to ride along with you to <destination>, and to give you some tips along the way."
 	landing

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -2644,7 +2644,6 @@ phrase "broken jump drive on visit"
 mission "Remnant: Broken Jump Drive 1"
 	name "Broken Jump Drive Delivery"
 	description "You have been asked to deliver a broken jump drive to the researchers on <planet>."
-	minor
 	landing
 	repeat
 	to offer

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -292,6 +292,8 @@ void Mission::Load(const DataNode &node)
 	
 	if(displayName.empty())
 		displayName = name;
+	if((isMinor || hasPriority) && location == LANDING)
+		node.PrintTrace("Warning: \"minor\" or \"priority\" tags have no effect on \"landing\" missions.");
 }
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -293,7 +293,7 @@ void Mission::Load(const DataNode &node)
 	if(displayName.empty())
 		displayName = name;
 	if((isMinor || hasPriority) && location == LANDING)
-		node.PrintTrace("Warning: \"minor\" or \"priority\" tags have no effect on \"landing\" missions.");
+		node.PrintTrace("Warning: \"minor\" or \"priority\" tags have no effect on \"landing\" missions:");
 }
 
 


### PR DESCRIPTION
**Feature:** This PR implements a feature that should stop my dumb ass from making changes like https://github.com/endless-sky/endless-sky/commit/62f0226bd1483c0d6ec02b01c258ac9f2993c826 again.

## Feature Details
This PR adds a warning that gets written to the error file if a mission has either the minor or priority tag and also has the landing tag, as minor and priority don't effect landing missions.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Let's see what the test parses turn up.

## Performance Impact
N/A
