### PR TITLE
Dialogue changes about Deep Archaeology due to player's knowledge

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -180,8 +180,17 @@ mission "First Contact: Unfettered"
 				`	"What do you mean, the Hai were altered?"`
 			
 			`	"This is our story," it says. "Once, many worlds beyond wormhole were ours. Once, hundred thousand years now gone. We needed more worlds. A species that does not expand becomes like brackish water, like stunted tree. But dragonfolk in the south had created hyperdrive, and human monkeys had begun banging rocks together in what the Drak said was very intelligent fashion. So we were forbidden from taking more worlds."`
+			branch sheragi
+				has "Rim Archaeology 6: offered"
 			`	"'Dragonfolk?'" you ask. "I've never heard of them."`
 			`	"Sheragi," it says, "they are extinct. Only their dumb ancestors survive, just as monkeys will outlast the thinking humans."`
+				goto altered
+
+			label sheragi
+			`	"'Dragonfolk?'" you ask. "Do you mean the Sheragi?"`
+			`	"Impressive," it replies, "the monkey knows of Sheragi. We outlived them all. Funny that only their dumb ancestors survive, just as monkeys will outlast the thinking humans."`
+
+			label altered
 			`	"How were you altered?" you ask.`
 			`	It says, "We Hai fought Sheragi and took worlds that Drak said belonged to them, worlds that Sheragi had not yet even discovered. Drak retaliated. On all Hai worlds, Drak ships appeared in orbit. Sickness swept each planet: quick fever, strange feeling of frailness, like you are brittle bones with mouth full of dirt. Victims left alive, but all ambition gone, no desire but to die of comfortable old age."`
 			choice

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -242,7 +242,7 @@ mission "Deep Archaeology 5"
 				`	"That's great, but what does it mean for us?"`
 					goto dangerous
 				`	"From what I understand, they've been around for a while, and have mentioned past interference in the Deep."`
-			`	"Well then, we have good reason to believe they fit into our current knowledge of the timeline here. However, I don't think it's a good idea for us to get involved in a volatile alien species like that, especially after the danger we've just fled from."`
+			`	"Well then, if the Pug have admitted to 'interfering' with the Deep in the past then we have good reason to believe they fit into our current knowledge of the timeline here," Albert replies. "Unfortunately we can't just ask the Pug exactly what they've done or when they did it, but simply knowing of their presence here aids in our research."`
 				goto final
 			label dangerous
 			`	"Nothing immediately," says John, "but nevertheless, it is at least useful to know the timeline of events here."`

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -236,7 +236,7 @@ mission "Deep Archaeology 5"
 				goto end
 			label surprise
 			`	Albert and John look at each other confusedly before Albert says, "Who are the Pug, exactly?"`
-			`	You go on to explain to them what you know about the Pug, their invasion into human space, and what you have heard of them interfering with human affairs in the Deep. You also give a brief description of what they look like, which puts a surprised look on both of their faces.
+			`	You go on to explain to them what you know about the Pug, their invasion into human space, and what you have heard of them interfering with human affairs in the Deep. You also give a brief description of what they look like, which puts a surprised look on both of their faces.`
 			`	"Thin, pale, and with blue blood? That's precisely the description that we've had of these aliens based on folk tales," replies Albert.`
 			`	"Well then we have good reason to believe they fit into our current knowledge of the timeline here. However, based on your description Captain <last>, they sound far too dangerous to attempt to seek out, especially after what we just fled from."`
 				goto final

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -225,7 +225,7 @@ mission "Deep Archaeology 5"
 			choice
 				`	"For what purpose?"`
 					goto purpose
-				`	"Wait, are you talking about the Pug?"
+				`	"Wait, are you talking about the Pug?"`
 					goto surprise
 			label purpose
 			`	"I'm not sure," he says. "But I first became interested in the Deep while researching the Alpha Wars. I'm sure you know the history, how humanity was nearly enslaved by psychopathic 'super' humans that we ourselves had created by dabbling in genetic engineering. At that time, the Deep made a sudden, improbable technological leap that allowed them to construct weapons and ships far more powerful than what the Alphas had, and the war against them was won."`

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -225,7 +225,7 @@ mission "Deep Archaeology 5"
 			choice
 				`	"For what purpose?"`
 					goto purpose
-				`	"Wait, are you talking about the Pug?"`
+				`	"Do you think it was the Pug?"`
 					goto surprise
 			label purpose
 			`	"I'm not sure," he says. "But I first became interested in the Deep while researching the Alpha Wars. I'm sure you know the history, how humanity was nearly enslaved by psychopathic 'super' humans that we ourselves had created by dabbling in genetic engineering. At that time, the Deep made a sudden, improbable technological leap that allowed them to construct weapons and ships far more powerful than what the Alphas had, and the war against them was won."`
@@ -235,10 +235,18 @@ mission "Deep Archaeology 5"
 			`	John frowns. "Hemocyanic blood. Not the Quarg, then. Their lungs are odd, but their blood uses hemoglobin for oxygen transport, just like ours."`
 				goto end
 			label surprise
-			`	Albert and John look at each other confusedly before Albert says, "Who are the Pug, exactly?"`
-			`	You go on to explain to them what you know about the Pug, their invasion into human space, and what you have heard of them interfering with human affairs in the Deep. You also give a brief description of what they look like, which puts a surprised look on both of their faces.`
-			`	"Thin, pale, and with blue blood? That's precisely the description that we've had of these aliens based on folk tales," replies Albert.`
-			`	"Well then we have good reason to believe they fit into our current knowledge of the timeline here. However, based on your description Captain <last>, they sound far too dangerous to attempt to seek out, especially after what we just fled from."`
+			`	Albert and John look at each other confusedly for a second before Albert says, "The aliens that invaded human space?"`
+			`	John appears to think hard on the subject before saying, "Of course! I don't know how we didn't think of it. From the descriptions that I've heard about them, they almost exactly match the folk tales in the Deep about 'elves'."`
+			`	"Thin, pale, and blue blooded, yes? Well, I think you may have found our aliens, Captain <last>," replies Albert.`
+			choice
+				`	"That's great, but I think they're far too dangerous to be useful to us now."`
+					goto dangerous
+				`	"From what I understand they've been around for a while, and have mentioned past interference in the Deep."`
+			`	"Well then, we have good reason to believe they fit into our current knowledge of the timeline here. However, I do not think it is the greatest idea for us to get involved in a volatile alien species like that, especially after the danger we've just fled from."`
+				goto final
+			label dangerous
+			`	"I've heard similar," says John, "but nevertheless it is at least useful to know the timeline of events here."`
+			`	"Indeed," replies Albert, "simply knowing of their presence here aids in our research."`
 				goto final
 			label end
 			`	Albert continues, "What I think is that an unknown alien species has been involved in events in the Deep since the beginning, and is perhaps still involved there today. I think this is known to at least some of the Deep's inhabitants."`

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -212,7 +212,7 @@ mission "Deep Archaeology 5"
 		conversation
 			`You breathe a sigh of relief as you land safely in the spaceport on <planet>. "Okay, what was that all about?" you ask.`
 			`	"I honestly don't know," says Albert. "I can tell you what I suspect, though. The history books don't actually say when the Deep was first settled. The first documented expedition to the Deep was in the 24th century, and they found several human colonies already established in the region, claiming to date back to the very dawn of space flight. But I think the first settlers were brought there long before that. Brought there on alien ships."`
-			branch "pug"
+			branch pug
 				or
 					has "FWC Pug 2: offered"
 					has "FW Pug 3: offered"
@@ -235,17 +235,17 @@ mission "Deep Archaeology 5"
 			`	John frowns. "Hemocyanic blood. Not the Quarg, then. Their lungs are odd, but their blood uses hemoglobin for oxygen transport, just like ours."`
 				goto end
 			label surprise
-			`	Albert and John look at each other confusedly for a second before Albert says, "The aliens that invaded human space?"`
-			`	John appears to think hard on the subject before saying, "Of course! I don't know how we didn't think of it. From the descriptions that I've heard about them, they almost exactly match the folk tales in the Deep about 'elves.'"`
-			`	"Thin, pale, and blue blooded, yes? Well, I think you may have found our aliens, Captain <last>," replies Albert.`
+			`	Albert and John give confused looks at each other for a second before Albert says, "The aliens that invaded human space?"`
+			`	John appears to think hard on the subject before saying, "That's certainly an interesting connection. I don't know how we didn't think of it. From the descriptions that I've heard about them, they almost exactly match the folk tales in the Deep about 'elves.'"`
+			`	"Thin, pale, and blue blooded, yes? Well, I think you may have figured something out, Captain <last>," replies Albert.`
 			choice
-				`	"That's great, but I think they're far too dangerous to be useful to us now."`
+				`	"That's great, but what does it mean for us?"`
 					goto dangerous
 				`	"From what I understand, they've been around for a while, and have mentioned past interference in the Deep."`
 			`	"Well then, we have good reason to believe they fit into our current knowledge of the timeline here. However, I don't think it's a good idea for us to get involved in a volatile alien species like that, especially after the danger we've just fled from."`
 				goto final
 			label dangerous
-			`	"I've heard similar," says John, "but nevertheless, it is at least useful to know the timeline of events here."`
+			`	"Nothing immediately," says John, "but nevertheless, it is at least useful to know the timeline of events here."`
 			`	"Indeed," replies Albert, "simply knowing of their presence here aids in our research."`
 				goto final
 			label end

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -236,16 +236,16 @@ mission "Deep Archaeology 5"
 				goto end
 			label surprise
 			`	Albert and John look at each other confusedly for a second before Albert says, "The aliens that invaded human space?"`
-			`	John appears to think hard on the subject before saying, "Of course! I don't know how we didn't think of it. From the descriptions that I've heard about them, they almost exactly match the folk tales in the Deep about 'elves'."`
+			`	John appears to think hard on the subject before saying, "Of course! I don't know how we didn't think of it. From the descriptions that I've heard about them, they almost exactly match the folk tales in the Deep about 'elves.'"`
 			`	"Thin, pale, and blue blooded, yes? Well, I think you may have found our aliens, Captain <last>," replies Albert.`
 			choice
 				`	"That's great, but I think they're far too dangerous to be useful to us now."`
 					goto dangerous
-				`	"From what I understand they've been around for a while, and have mentioned past interference in the Deep."`
-			`	"Well then, we have good reason to believe they fit into our current knowledge of the timeline here. However, I do not think it is the greatest idea for us to get involved in a volatile alien species like that, especially after the danger we've just fled from."`
+				`	"From what I understand, they've been around for a while, and have mentioned past interference in the Deep."`
+			`	"Well then, we have good reason to believe they fit into our current knowledge of the timeline here. However, I don't think it's a good idea for us to get involved in a volatile alien species like that, especially after the danger we've just fled from."`
 				goto final
 			label dangerous
-			`	"I've heard similar," says John, "but nevertheless it is at least useful to know the timeline of events here."`
+			`	"I've heard similar," says John, "but nevertheless, it is at least useful to know the timeline of events here."`
 			`	"Indeed," replies Albert, "simply knowing of their presence here aids in our research."`
 				goto final
 			label end

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -212,19 +212,37 @@ mission "Deep Archaeology 5"
 		conversation
 			`You breathe a sigh of relief as you land safely in the spaceport on <planet>. "Okay, what was that all about?" you ask.`
 			`	"I honestly don't know," says Albert. "I can tell you what I suspect, though. The history books don't actually say when the Deep was first settled. The first documented expedition to the Deep was in the 24th century, and they found several human colonies already established in the region, claiming to date back to the very dawn of space flight. But I think the first settlers were brought there long before that. Brought there on alien ships."`
+			branch "pug"
+				or
+					has "FWC Pug 2: offered"
+					has "FW Pug 3: offered"
 			choice
 				`	"For what purpose?"`
 					goto purpose
 				`	"What aliens? The Quarg?"`
 					goto aliens
+			label pug
+			choice
+				`	"For what purpose?"`
+					goto purpose
+				`	"Wait, are you talking about the Pug?"
+					goto surprise
 			label purpose
 			`	"I'm not sure," he says. "But I first became interested in the Deep while researching the Alpha Wars. I'm sure you know the history, how humanity was nearly enslaved by psychopathic 'super' humans that we ourselves had created by dabbling in genetic engineering. At that time, the Deep made a sudden, improbable technological leap that allowed them to construct weapons and ships far more powerful than what the Alphas had, and the war against them was won."`
 				goto end
 			label aliens
 			`	"There are popular folk tales in the Deep about 'elves,'" says Albert. "Thin, pale, graceful creatures, with blue blood."`
 			`	John frowns. "Hemocyanic blood. Not the Quarg, then. Their lungs are odd, but their blood uses hemoglobin for oxygen transport, just like ours."`
+				goto end
+			label surprise
+			`	Albert and John look at each other confusedly before Albert says, "Who are the Pug, exactly?"`
+			`	You go on to explain to them what you know about the Pug, their invasion into human space, and what you have heard of them interfering with human affairs in the Deep. You also give a brief description of what they look like, which puts a surprised look on both of their faces.
+			`	"Thin, pale, and with blue blood? That's precisely the description that we've had of these aliens based on folk tales," replies Albert.`
+			`	"Well then we have good reason to believe they fit into our current knowledge of the timeline here. However, based on your description Captain <last>, they sound far too dangerous to attempt to seek out, especially after what we just fled from."`
+				goto final
 			label end
 			`	Albert continues, "What I think is that an unknown alien species has been involved in events in the Deep since the beginning, and is perhaps still involved there today. I think this is known to at least some of the Deep's inhabitants."`
+			label final
 			choice
 				`	"So, what do we do now?"`
 				`	"How can we find out more information?"`


### PR DESCRIPTION
**Content (Missions)**

## Summary
Changes to two different conversations relating to the Deep Archaeology missions.

The first is the conversation with Albert Foster when he brings up the Pug in folk tales. If the player managed to play through enough of the FW campaign, they would know of the Pug and as such be able to respond with that knowledge.

The second conversation is with the first contact of the Unfettered Hai where the player may know of the Sheragi due to the Deep Archaeology and as such be able to respond with that knowledge.

It's not an incredibly major change, though for the sake of consistency the player should be able to say this information if they do know about it. One aspect that I considered but could not solve is of the `log` that is entered at the end of the Unfettered Hai conversation, as I could not find a method to make this log change if the conditions are met for the player to already know of the Sheragi.