### PR TITLE
Prevent negative ion/disruption/slowing via firing

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3410,6 +3410,13 @@ bool Ship::CanFire(const Weapon *weapon) const
 	// have enough heat to spare.
 	if(heat < -(weapon->FiringHeat() + weapon->RelativeFiringHeat() * MaximumHeat()))
 		return false;
+	// Repeat this for various effects which shouldn't drop below 0.
+	if(ionization < -(weapon->FiringIon()))
+		return false;
+	if(disruption < -(weapon->FiringDisruption()))
+		return false;
+	if(slowness < -(weapon->FiringSlowing()))
+		return false;
 	
 	return true;
 }


### PR DESCRIPTION
**Bugfix:** This PR addresses a new crash I discovered!

## Fix Details
Not only does -20 slowing damage break the game, it seems any amount of negative disruption damage breaks the game too. This PR puts firing ion, slowing, and disruption into the same vein as firing heat- negative values are now interpreted as requirements for firing, and so they will not drop below 0.

## Testing Done
(I can't imagine what other issues this would create, but) weapons which have negative firing ion/slowing/disruption do not fire unless your ship has that amount of the value or more.

## Save File
No vanilla weapons have negative firing ion, slowing, or disruption, so you would need to make a plugin with a weapon with such to test in and out of the bugfix, but anything with negative firing ion/slowing/disruption simply breaks the game.