### PR TITLE
Allow "Wanderers: Hai Diplomat" to be offered on Mirrorlake

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -89,7 +89,7 @@ mission "Wanderers: Hai Diplomat"
 	description "Travel to Hai-home to pick up a diplomat who can help you communicate with the Wanderers."
 	landing
 	source
-		near "Ya Hai" 1 100
+		not planet "Hai-home"
 		attributes "hai"
 	destination "Hai-home"
 	clearance


### PR DESCRIPTION
**Bugfix:** This PR addresses an [issue reported on discord](https://discord.com/channels/251118043411775489/536900466655887360/841859108952080404) by user sasbot#9952.

## Fix Details
By using `near "Ya Hai" 1 100` as a source filter in the mission "Wanderers: Hai Diplomat", Mirrorlake was excluded as a source and the player couldn't ask for an interpret there. I replaced it by `not planet "Hai-home"`.

## Testing Done
I tested the missions from "First Contact: Wanderer" to "Wanderers: Diplomacy" in three cases: going directly to Hai-home, going to Mirrorlake then Hai-home, and going to a Hai world outside Ya hai then Hai-home.

## Save File
[Test~wanderer-first-contact.txt](https://github.com/endless-sky/endless-sky/files/6465923/Test.wanderer-first-contact.txt)
This save file sets the player on Vara K'chrai with `"First Contact: Wanderer: active"` and enough reputation with the Hai to land on Hai-home.