### PR TITLE
feat: (Planetary Storage) Implement anti-frustration feature to access in-system outfits.

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1081,11 +1081,13 @@ map<const Planet *, CargoHold *> &PlayerInfo::Storage(bool forceCreate)
 	// Add other planets from the current system.
 	if(system && !systemStorageCached)
 	{
-		for(auto it : system->Objects())
+		for(auto &&it : system->Objects())
 		{
-			auto sysPlanet = it.GetPlanet();
-			if(sysPlanet && planetaryStorage.count(sysPlanet))
-				systemStorage[sysPlanet] = &planetaryStorage[sysPlanet];
+			if(!it.HasValidPlanet())
+				continue;
+			auto planetIt = planetaryStorage.find(it.GetPlanet());
+			if(planetIt != planetaryStorage.end())
+				systemStorage[planetIt->first] = &(planetIt->second);
 		}
 		systemStorageCached = true;
 	}

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -142,8 +142,10 @@ public:
 	// Get cargo information.
 	CargoHold &Cargo();
 	const CargoHold &Cargo() const;
-	// Get items stored on the player's current planet.
-	CargoHold *Storage(bool forceCreate = false);
+	// Get items stored on the players current planet and in the players
+	// current system. If parameter forceCreate is set to true, then the
+	// storage for the current planet will be created if it doesn't exist.
+	std::map<const Planet *, CargoHold *> &Storage(bool forceCreate = false);
 	// Get items stored on all planets (for map display).
 	const std::map<const Planet *, CargoHold> &PlanetaryStorage() const;
 	// Get cost basis for commodities.
@@ -314,7 +316,10 @@ private:
 	std::vector<std::weak_ptr<Ship>> selectedShips;
 	std::map<const Ship *, int> groups;
 	CargoHold cargo;
+	// All planetary storage and cached data of all storage in the current system.
 	std::map<const Planet *, CargoHold> planetaryStorage;
+	bool systemStorageCached = false;
+	std::map<const Planet *, CargoHold *> systemStorage;
 	std::map<std::string, int64_t> costBasis;
 	
 	std::multimap<Date, std::string> logbook;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -54,6 +54,15 @@ namespace {
 	{
 		return ship.GetSystem() == here && !ship.IsDisabled();
 	}
+	
+	bool InPlayerStorage(PlayerInfo &player, const Outfit *outfit)
+	{
+		for(auto it : player.Storage(false))
+			if(it.second->Get(outfit))
+				return true;
+		
+		return false;
+	}
 }
 
 
@@ -543,7 +552,7 @@ bool ShopPanel::CanSellMultiple() const
 bool ShopPanel::IsAlreadyOwned() const
 {
 	return (playerShip && selectedOutfit && player.Cargo().Get(selectedOutfit))
-		|| (player.Storage() && player.Storage()->Get(selectedOutfit));
+		|| InPlayerStorage(player, selectedOutfit);
 }
 
 
@@ -587,7 +596,7 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		GetUI()->Pop(this);
 	}
 	else if(key == 'b' || ((key == 'i' || key == 'c') && selectedOutfit && (player.Cargo().Get(selectedOutfit)
-			|| (player.Storage() && player.Storage()->Get(selectedOutfit)))))
+			|| InPlayerStorage(player, selectedOutfit))))
 	{
 		if(!CanBuy(key == 'i' || key == 'c'))
 			FailBuy();
@@ -871,7 +880,7 @@ int64_t ShopPanel::LicenseCost(const Outfit *outfit) const
 	// sold to the shop, then ignore its license requirement, if any. (Otherwise there
 	// would be no way to use or transfer license-restricted outfits between ships.)
 	if((player.Cargo().Get(outfit) && playerShip) || player.Stock(outfit) > 0 ||
-			(player.Storage() && player.Storage()->Get(outfit)))
+			InPlayerStorage(player, outfit))
 		return 0;
 	
 	const Sale<Outfit> &available = player.GetPlanet()->Outfitter();

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -57,7 +57,7 @@ namespace {
 	
 	bool InPlayerStorage(PlayerInfo &player, const Outfit *outfit)
 	{
-		for(auto it : player.Storage(false))
+		for(auto &&it : player.Storage(false))
 			if(it.second->Get(outfit))
 				return true;
 		

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -55,7 +55,7 @@ namespace {
 		return ship.GetSystem() == here && !ship.IsDisabled();
 	}
 	
-	bool InPlayerStorage(PlayerInfo &player, const Outfit *outfit)
+	bool InPlayerStorage(PlayerInfo &player, const Outfit &outfit)
 	{
 		for(auto &&it : player.Storage(false))
 			if(it.second->Get(outfit))

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -58,7 +58,7 @@ namespace {
 	bool InPlayerStorage(PlayerInfo &player, const Outfit &outfit)
 	{
 		for(auto &&it : player.Storage(false))
-			if(it.second->Get(outfit))
+			if(it.second->Get(&outfit))
 				return true;
 		
 		return false;
@@ -552,7 +552,7 @@ bool ShopPanel::CanSellMultiple() const
 bool ShopPanel::IsAlreadyOwned() const
 {
 	return (playerShip && selectedOutfit && player.Cargo().Get(selectedOutfit))
-		|| InPlayerStorage(player, selectedOutfit);
+		|| InPlayerStorage(player, *selectedOutfit);
 }
 
 
@@ -596,7 +596,7 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		GetUI()->Pop(this);
 	}
 	else if(key == 'b' || ((key == 'i' || key == 'c') && selectedOutfit && (player.Cargo().Get(selectedOutfit)
-			|| InPlayerStorage(player, selectedOutfit))))
+			|| InPlayerStorage(player, *selectedOutfit))))
 	{
 		if(!CanBuy(key == 'i' || key == 'c'))
 			FailBuy();
@@ -876,11 +876,14 @@ bool ShopPanel::Scroll(double dx, double dy)
 
 int64_t ShopPanel::LicenseCost(const Outfit *outfit) const
 {
+	if(!outfit)
+		return 0;
+	
 	// If the player is attempting to install an outfit from cargo, storage, or that they just
 	// sold to the shop, then ignore its license requirement, if any. (Otherwise there
 	// would be no way to use or transfer license-restricted outfits between ships.)
 	if((player.Cargo().Get(outfit) && playerShip) || player.Stock(outfit) > 0 ||
-			InPlayerStorage(player, outfit))
+			InPlayerStorage(player, *outfit))
 		return 0;
 	
 	const Sale<Outfit> &available = player.GetPlanet()->Outfitter();


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed as follow-up in #4443

## Feature Details
Allows accessing to outfits from other planets in the same system, similar to how ships can be outfitted as long as they are in the same system.

As discussed in:
- https://github.com/endless-sky/endless-sky/pull/4443#issuecomment-678489280
- https://github.com/endless-sky/endless-sky/issues/5939#issuecomment-834559751
- https://github.com/endless-sky/endless-sky/pull/5942

## UI Screenshots
N/A (screenshots are the same as for planetary storage)

## Usage Examples
Example 1:
- Store outfits on some planet.
- Use them to outfit ships on another planet in the same system.

Example 2 (from jostephd): 
- Store outfits on some planet.
- Land on another planet in the same system, that also has an outfitter.
- Equip the flagship with the stored outfits.

## Testing Done
Performed the following test-sequence:
- Uninstalled 4 outfits on Earth
- Flew to Luna, checked that there were 4 outfits in storage
- Uninstalled 2 more outfits, checked that there were 6 in storage.
- Reinstalled all outfits, checked that all were re-installed.
- Uninstalled 4 outfits on Earth
- Flew to Luna, checked that there were 4 outfits in storage
- Uninstalled 2 more outfits, checked that there were 6 in storage.
- Jumped to Alpha Centauri and landed on Chiron.
- Checked through the map that there were 6 outfits in storage on Sol.
- Checked that there were no outfits listed as in storage on Chiron.

## Performance Impact
The code changed is not performance critical and the lookup of relevant planets (for the system) is cached. I don't expect noticeable impact.
