### PR TITLE
fix(content): various minor typos

### DIFF
--- a/data/ka'het/ka'het missions.txt
+++ b/data/ka'het/ka'het missions.txt
@@ -165,7 +165,7 @@ mission "Ringworld Debris"
 			`When you enter this suspiciously empty system, your attention is drawn to your ship's scanners. The proximity detection system is going off, suggesting that something sizable is close to your ship, although whatever it is you can't see it as you look out your cockpit.`
 			`	You turn your ship around and open the hatch of your cargo hold, catching the object. When you go to inspect it, you see a small, extremely dark piece of debris that almost looks to be covered in vantablack, but it doesn't resemble any alloy you've seen on a spaceship or station, bearing semblance to both a crystal and a metallic structure.`
 			scene "scene/ringworld debris"
-			`	In one particular corner you see that there is a small, barely recognizable tube, badly damaged but with a few intact wires creeping out. After tinkering a bit with the wires you manage to connect the debris to your ship's secondary power systems. It barely uses any energy at all, but you can feel the air around it starting to get slightly colder.`
+			`	In one particular corner you see that there is a small, barely recognizable tube, badly damaged but with a few intact wires creeping out. After tinkering a bit with the wires, you manage to connect the debris to your ship's secondary power systems. It barely uses any energy at all, but you can feel the air around it starting to get slightly colder.`
 			`	You unplug it and store the debris in a separate part of your ship. Maybe some alien species could tell you about it, if you were to bring it to them.`
 		fail
 	to complete

--- a/data/map.txt
+++ b/data/map.txt
@@ -29167,7 +29167,7 @@ planet Starcross
 planet "Starting Rubin"
 	attributes kimek "coalition station" shipping wealthy
 	landscape land/space3
-	description `Starting Rubin was far from being the first station constructed around the Kimek homeworld, but it is the oldest one to still be on orbit. It was built as an orbital equivalent to the hunger towers found on the planet it orbits, as a safety measure against the disasters that may affect Ki Patek Ka.`
+	description `Starting Rubin was far from being the first station constructed around the Kimek homeworld, but it is the oldest one to still be in orbit. It was built as an orbital equivalent to the hunger towers found on the planet it orbits, as a safety measure against the disasters that may affect Ki Patek Ka.`
 	description `	Since the residents need little of the food produced, it quickly became the station's primary export, transforming it into one of the largest trading hubs of the region. It has also the largest population of any Coalition station, capable of supporting tens of thousands of Kimek.`
 	spaceport `Despite only having the population of a small city, the arrivals deck of Starting Rubin is as crowded as the largest spaceports. Civilian ships belonging to all three Coalition species can be seen arriving or departing every couple minutes. While there doesn't seem to be any military facility, there are some civilian shops on the station, although they sell nothing but few Kimek items.`
 	shipyard Kimek

--- a/data/quarg/quarg missions.txt
+++ b/data/quarg/quarg missions.txt
@@ -85,7 +85,7 @@ mission "First Contact: Kuwaru Efreti"
 				`	"What crimes did they commit?"`
 					goto crimes
 				`	"What do you mean, 'thinking war machines'?"`
-			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being, they yet reproduce and wage against each other senseless war. Ware their ships should you wander north and east of here, for they wield diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
+			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being, they yet reproduce and wage against each other senseless war. Ware their ships should you wander north and east of here, for they wield weapons diverse and strange, and bring you can we no succor within the bourne of their space."`
 			choice
 				`	"You mentioned 'crimes.' What crimes did they commit?"`
 			`	"Of that we shall not speak, lest awaken in you we the desire to in their footsteps follow. But you may observe the wreckage of their abominations and take warning."`
@@ -95,7 +95,7 @@ mission "First Contact: Kuwaru Efreti"
 			`	"Of that we shall not speak, lest awaken in you we the desire to in their footsteps follow. But you may observe the wreckage of their abominations and take warning."`
 			choice
 				`	"You mentioned 'thinking war machines.' What are those?"`
-			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being, they yet reproduce and wage against each other senseless war. Ware their ships should you wander north and east of here, for they wield diverse weapons and strange, and bring you can we no succor within the bourne of their space."`
+			`	"Robotic starships, and autonomous factories to create them. Though now directed by no living being, they yet reproduce and wage against each other senseless war. Ware their ships should you wander north and east of here, for they wield weapons diverse and strange, and bring you can we no succor within the bourne of their space."`
 			
 			label korath
 			`	You are interrupted as one of the Korath who inhabit this ringworld walks by, and the Quarg says, "Friend Korath, meet the human."`


### PR DESCRIPTION
**Bugfix:** This PR doesn't address any known specific issues. It just cleans up some typos I noticed in a recent playthrough.

## Fix Details
I've included three separate commits for three different minor text corrections. If you disagree with some but agree with others, I'll gladly rebase, drop or amend, and re-push with whichever parts you want to keep.

1. In most of the game text, whenever starting a sentence with a prepositional phrase, the established pattern is to follow that phrase by a comma before proceeding. 16ce09f8 adds a missing comma in one of these cases.
2. The description for "Starting Rubin" says the station is "on orbit" but I'm pretty sure this is meant to say it's "in orbit". The latter is much more typically used to describe the location of one thing orbiting another, whereas the former is far less common and is more often used when referring to an action that occurs while orbiting. 278fc0c2 changes "on" to "in".
3. In some of the "First Contact: Kuwaru Efreti" mission text, one of the Quargs is talking about the Korath. Where it says, "for they wield diverse weapons and strange," I believe it means to say that the _weapons_ are diverse and strange. Otherwise, "strange" isn't referring to anything. 201207da swaps the order to read "for they wield weapons diverse and strange" which I think reads much clearer while otherwise leaving the unusual sentence structure of the Quarg.

## Testing Done
Edited local text files and verified that the game still loads them normally.
