### PR TITLE
feat: Allow automatic determination of bay types (low performance and feature limited plugins only).

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -147,10 +147,7 @@ const vector<string> Ship::CATEGORIES = {
 
 
 // Set of ship types that can be carried in bays.
-const set<string> Ship::BAY_TYPES = {
-	"Drone",
-	"Fighter"
-};
+set<string> Ship::BAY_TYPES = {};
 
 
 
@@ -319,12 +316,13 @@ void Ship::Load(const DataNode &node)
 				category = child.Token(1);
 				childOffset += 1;
 			}
-			if(!BAY_TYPES.count(category))
+			if(find(CATEGORIES.begin(), CATEGORIES.end(), category) == CATEGORIES.end())
 			{
 				child.PrintTrace("Warning: Invalid category defined for bay:");
 				continue;
 			}
-			
+			// BAY_TYPES is a set, so no need to check if the type was already present.
+			BAY_TYPES.insert(category);
 			if(!hasBays)
 			{
 				bays.clear();

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -56,8 +56,9 @@ class Ship : public Body, public std::enable_shared_from_this<Ship> {
 public:
 	// These are all the possible category strings for ships.
 	static const std::vector<std::string> CATEGORIES;
-	// Allow retrieving the available bay types for the current game;
-	static const std::set<std::string> BAY_TYPES;
+	// Allow retrieving the available bay types for the current game.
+	// Non-const, generated from the bays we encounter.
+	static std::set<std::string> BAY_TYPES;
 	
 	class Bay {
 	public:


### PR DESCRIPTION
**Feature:** This PR implements the feature request to allow more bay-types, but only for plugins that can accept the performance hit and additional carried-ship limitations.

## Feature Details
The types of bays are no longer checked against their own list, but checked against the list of valid categories. This will in theory allow any ship-type to be used as carried ship, but it will also set performance issues and the carried-ship-limitations on any ship that could theoretically be carried somewhere.
This is not for usage with existing categories in the main/vanilla game due to the performance issues and carried-ship-limitations,  but this can allow some plugin writers to experiment with additional carried ship types.

PR #3502 is related in that that PR attempts to make the categories lists themselves configurable (which would allow new carried categories without the negative impact of making existing non-carried categories carried). I was actually looking at #3502 when I decided to create this PR.

## UI Screenshots
From a test-ship:
![additional_bay](https://user-images.githubusercontent.com/35403542/118377268-8983bc80-b5cc-11eb-8cfb-45be7b94fe8d.png)

## Usage Examples
Set the category for some bay on some ship to a different category than "Fighter" or "Drone" and notice that the new category can be carried in the ship.

## Testing Done
Edited a save-game and replaced 2 "Fighter" bays by an "Interceptor" bay (and one by an "Anterceptor" bay to trigger the error-message).

## Performance Impact
I expect minimal impact (as long as this feature is not used for other carried categories than Fighter and Drone in the vanilla/main game). I don't know if c++ has optimizations for const-sets which we might be missing now that BAY_TYPES is no longer a const set.