### PR TITLE
Add a tag for systems that hides them from view unless in visible range

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1835,6 +1835,16 @@ void PlayerInfo::CheckReputationConditions()
 // they have actually visited it).
 bool PlayerInfo::HasSeen(const System &system) const
 {
+	// Shrouded systems are only seen if they're currently in view range, or
+	// if a visited system that is non-shrouded is linked to it.
+	if(system.Shrouded())
+		return (system.VisibleNeighbors().count(this->system) || &system == this->system
+			|| any_of(visitedSystems.begin(), visitedSystems.end(), 
+				[&system](const System *s) noexcept -> bool
+				{
+					return (!s->Shrouded() && s->Links().count(&system));
+				}));
+	
 	if(seen.count(&system))
 		return true;
 	
@@ -1862,7 +1872,8 @@ bool PlayerInfo::HasSeen(const System &system) const
 // Check if the player has visited the given system.
 bool PlayerInfo::HasVisited(const System &system) const
 {
-	return visitedSystems.count(&system);
+	// Shrouded systems are only considered visited if you're currently in them.
+	return (visitedSystems.count(&system) && !system.Shrouded()) || (system.Shrouded() && &system == this->system);
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1838,12 +1838,19 @@ bool PlayerInfo::HasSeen(const System &system) const
 	// Shrouded systems are only seen if they're currently in view range, or
 	// if a visited system that is non-shrouded is linked to it.
 	if(system.Shrouded())
-		return (system.VisibleNeighbors().count(this->system) || &system == this->system
+	{
+		// We always see the system we're in.
+		return &system == this->system
+			// Systems which are shrouded and hidden must be linked to be seen.
+			|| (system.VisibleNeighbors().count(this->system) && !system.Hidden())
 			|| any_of(system.Links().begin(), system.Links().end(), 
 				[&](const System *s) noexcept -> bool
 				{
-					return (!s->Shrouded() && visitedSystems.count(&*s));
-				}));
+					// If we're in a neighboring system then it doesn't matter if
+					// that system is shrouded, we can still see all neighbors.
+					return ((!s->Shrouded() && visitedSystems.count(&*s)) || s == this->system);
+				});
+	}
 	
 	if(seen.count(&system))
 		return true;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1839,10 +1839,10 @@ bool PlayerInfo::HasSeen(const System &system) const
 	// if a visited system that is non-shrouded is linked to it.
 	if(system.Shrouded())
 		return (system.VisibleNeighbors().count(this->system) || &system == this->system
-			|| any_of(visitedSystems.begin(), visitedSystems.end(), 
-				[&system](const System *s) noexcept -> bool
+			|| any_of(system.Links().begin(), system.Links().end(), 
+				[&](const System *s) noexcept -> bool
 				{
-					return (!s->Shrouded() && s->Links().count(&system));
+					return (!s->Shrouded() && visitedSystems.count(&*s));
 				}));
 	
 	if(seen.count(&system))

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -199,6 +199,8 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			}
 			else if(key == "hidden")
 				hidden = false;
+			else if(key == "shrouded")
+				shrouded = false;
 			
 			// If not in "overwrite" mode, move on to the next node.
 			if(overwriteAll)
@@ -210,6 +212,8 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		// Handle the attributes which can be "removed."
 		if(key == "hidden")
 			hidden = true;
+		else if(key == "shrouded")
+			shrouded = true;
 		else if(!hasValue && key != "object")
 		{
 			child.PrintTrace("Expected key to have a value:");
@@ -530,6 +534,14 @@ const set<const System *> &System::JumpNeighbors(double neighborDistance) const
 bool System::Hidden() const
 {
 	return hidden;
+}
+
+
+
+// Whether the location of this system is remembered.
+bool System::Shrouded() const
+{
+	return shrouded;
 }
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -117,6 +117,8 @@ public:
 	const std::set<const System *> &JumpNeighbors(double neighborDistance) const;
 	// Whether this system can be seen when not linked.
 	bool Hidden() const;
+	// Whether the location of this system is remembered.
+	bool Shrouded() const;
 	// Additional travel distance to target for ships entering through hyperspace.
 	double ExtraHyperArrivalDistance() const;
 	// Additional travel distance to target for ships entering using a jumpdrive.
@@ -208,6 +210,8 @@ private:
 	
 	// Defines whether this system can be seen when not linked.
 	bool hidden = false;
+	// Defines whether a system can be remembered when out of view.
+	bool shrouded = false;
 	
 	// Stellar objects, listed in such an order that an object's parents are
 	// guaranteed to appear before it (so that if we traverse the vector in


### PR DESCRIPTION
**Feature:** This PR implements a feature I thought of after b3ef517.

## Feature Details
This PR adds a new system tag:
* `shrouded`: This system can not be seen unless it is within view range or linked to an unshrouded visited system.

As a reminder, hidden's definition is the following:
* `hidden`: This system can not be seen unless it is visited or linked to a visited system.

Combining hidden and shrouded then results in the following behavior:
* This system can not be seen unless it is linked to an unshrouded visited system.

The exact behavior that is desired is that `shrouded` systems are "forgotten" when not within view. This means that a conceivable region of shrouded systems would require the player to remember the system layout and to manually jump system to system, but a system that is forgotten when no in view could have other uses as well.

## Usage Examples + Screenshots
I changed Sol, Alpha Centauri, and a number of other systems to be shrouded.
```
system Sol
	shrouded
	...
```
<details><summary>The following are a collection of screenshots of me flying through these shrouded systems. Observe how those systems that are shrouded and within range are seen, but the system name and their links to other shrouded system are forgotten after leaving.</summary>

![image](https://user-images.githubusercontent.com/17688683/118397395-91615200-b608-11eb-8416-de9038c595b7.png)
![image](https://user-images.githubusercontent.com/17688683/118397404-99b98d00-b608-11eb-97d3-14fcc747c698.png)
![image](https://user-images.githubusercontent.com/17688683/118397413-a50cb880-b608-11eb-8345-381eda3b6eb2.png)
![image](https://user-images.githubusercontent.com/17688683/118397419-adfd8a00-b608-11eb-8397-794c8698414d.png)
</details>

<details><summary>I then added hidden to all these systems so that they are both shrouded and hidden. The behavior is mostly the same, except now I can't see those systems which are within range but not linked to any systems I can see.</summary>

![image](https://user-images.githubusercontent.com/17688683/118397344-59f2a580-b608-11eb-9d65-a19a2e066024.png)
![image](https://user-images.githubusercontent.com/17688683/118397365-670f9480-b608-11eb-896f-99ff1283efa9.png)
</details>

## Testing Done
Tested using the usage example.

## Performance Impact
N/A
