### PR TITLE
Beezelbub outfit changes

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2274,23 +2274,60 @@ mission "Deep: Scientist Rescue 2"
 
 ship "Bactrian" "Bactrian (Cosmic Devil)"
 	outfits
-		"Inhibitor Cannon" 2
-		"Thrasher Turret" 4
-		"Point Defense Turret"
-		"Heavy Anti-Missile Turret"
-		"Boulder Reactor" 2
-		"Hai Ravine Batteries"
-		"Hai Chasm Batteries"
-		"Hai Diamond Regenerator"
-		"Liquid Helium Cooler"
-		"Outfits Expansion" 4
-		"Quantum Keystone"
-		"Ramscoop"
-		`"Bondir" Atomic Thruster`
 		`"Bufaer" Atomic Steering`
-		Hyperdrive
+		`"Bufaer" Atomic Thruster`
+		"Crystal Capacitor"
+		"Fuel Processor"
+		"Interference Plating" 2
+		"Jump Drive"
+		"Korath Banisher"
+		"Korath Grab-Strike" 3
+		"Korath Repeater Rifle" 198
+		"Large Heat Shunt"
+		"Large Radar Jammer"
+		"Nerve Gas" 245
+		"Outfits Expansion" 4
+		"Pulse Rifle" 39
+		"Quantum Keystone"
+		"Scram Drive"
+		"Surveillance Pod" 2
+		"Systems Core (Medium)"
+		"Thrasher Cannon" 3
+		"Thrasher Turret"
+		"Tuning Rifle" 8
+		"Wanderer Anti-Missile"
+		"Wanderer Ramscoop"
+		"White Sun Reactor"
+	gun "Thrasher Cannon"
+	gun -40 -133 "Thrasher Cannon"
+	gun -45 -128 "Thrasher Cannon"
+	turret -22 -148 "Thrasher Turret"
+	turret 26 -80 "Korath Grab-Strike"
+	turret -41 -20 "Korath Grab-Strike"
+	turret 32 -7 "Korath Grab-Strike"
+	turret 53 82 "Wanderer Anti-Missile"
+	turret -37 186 "Korath Banisher"
 
+ship "Korath Chaser" "Korath Chaser (Laughing Point)"
+	outfits
+		`"Basrem" Atomic Steering`
+		`"Basrem" Atomic Thruster`
+		"Korath Fire-Lance"
+		"Pebble Core"
+		"Quantum Keystone"
+		"Small Heat Shunt"
 
+ship "Violin Spider" "Violin Spider (Arogor)"
+	outfits
+		`"Basrem" Atomic Steering`
+		`"Basrem" Atomic Thruster`
+		"Bullfrog Anti-Missile"
+		"Hai Chasm Batteries"
+		"Pebble Core"
+		"Quantum Keystone"
+		Railgun
+		"Railgun Slug" 1000
+		"Small Heat Shunt"
 
 mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 	landing
@@ -2304,6 +2341,18 @@ mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 		government "Pirate"
 		personality staying nemesis
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
+	npc
+		government "Pirate"
+		personality staying nemesis
+		ship "Korath Chaser (Laughing Point)" "Tromes"
+	npc
+		government "Pirate"
+		personality staying nemesis
+		ship "Korath Chaser (Laughing Point)" "Tachan"
+	npc
+		government "Pirate"
+		personality staying nemesis
+		ship "Violin Spider (Arogor)" "Arogor"
 		dialog
 			`After the Bactrian is eliminated, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
@@ -2365,6 +2414,18 @@ mission "Deep: Scientist Rescue 3A"
 		personality staying nemesis
 		system "Arneb"
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
+	npc
+		government "Pirate"
+		personality staying nemesis
+		ship "Korath Chaser (Laughing Point)" "Tromes"
+	npc
+		government "Pirate"
+		personality staying nemesis
+		ship "Korath Chaser (Laughing Point)" "Tachan"
+	npc
+		government "Pirate"
+		personality staying nemesis
+		ship "Violin Spider (Arogor)" "Arogor"
 		dialog
 			`After the Bactrian is eliminated, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2345,13 +2345,7 @@ mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 		government "Pirate"
 		personality staying nemesis
 		ship "Korath Chaser (Laughing Point)" "Tromes"
-	npc
-		government "Pirate"
-		personality staying nemesis
 		ship "Korath Chaser (Laughing Point)" "Tachan"
-	npc
-		government "Pirate"
-		personality staying nemesis
 		ship "Violin Spider (Arogor)" "Arogor"
 		dialog
 			`After the Bactrian is eliminated, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
@@ -2418,13 +2412,7 @@ mission "Deep: Scientist Rescue 3A"
 		government "Pirate"
 		personality staying nemesis
 		ship "Korath Chaser (Laughing Point)" "Tromes"
-	npc
-		government "Pirate"
-		personality staying nemesis
 		ship "Korath Chaser (Laughing Point)" "Tachan"
-	npc
-		government "Pirate"
-		personality staying nemesis
 		ship "Violin Spider (Arogor)" "Arogor"
 		dialog
 			`After the Bactrian is eliminated, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2276,58 +2276,40 @@ ship "Bactrian" "Bactrian (Cosmic Devil)"
 	outfits
 		`"Bufaer" Atomic Steering`
 		`"Bufaer" Atomic Thruster`
+		"Boulder Reactor"
+		"Chameleon Anti-Missile"
 		"Crystal Capacitor"
-		"Fuel Processor"
+		"Emergency Ramscoop"
+		"Epoch Cell"
+		"Hai Diamond Regenerator"
+		"Hai Fissure Batteries"
+		"Hai Tracker" 56
+		"Hai Tracker Pod"
+		"Inhibitor Cannon" 3
 		"Interference Plating" 2
-		"Jump Drive"
-		"Korath Banisher"
-		"Korath Grab-Strike" 3
-		"Korath Repeater Rifle" 198
-		"Large Heat Shunt"
 		"Large Radar Jammer"
+		"Liquid Helium Cooler"
 		"Nerve Gas" 245
-		"Outfits Expansion" 4
-		"Pulse Rifle" 39
+		"Outfit Scanner"
+		"Outfits Expansion" 5
+		"Point Defense Turret"
+		"Pulse Rifle" 237
+		"Pulse Turret" 4
 		"Quantum Keystone"
 		"Scram Drive"
 		"Surveillance Pod" 2
-		"Systems Core (Medium)"
-		"Thrasher Cannon" 3
-		"Thrasher Turret"
+		"Thermoelectric Cooler"
 		"Tuning Rifle" 8
-		"Wanderer Anti-Missile"
-		"Wanderer Ramscoop"
-		"White Sun Reactor"
-	gun "Thrasher Cannon"
-	gun -40 -133 "Thrasher Cannon"
-	gun -45 -128 "Thrasher Cannon"
-	turret -22 -148 "Thrasher Turret"
-	turret 26 -80 "Korath Grab-Strike"
-	turret -41 -20 "Korath Grab-Strike"
-	turret 32 -7 "Korath Grab-Strike"
-	turret 53 82 "Wanderer Anti-Missile"
-	turret -37 186 "Korath Banisher"
-
-ship "Korath Chaser" "Korath Chaser (Laughing Point)"
-	outfits
-		`"Basrem" Atomic Steering`
-		`"Basrem" Atomic Thruster`
-		"Korath Fire-Lance"
-		"Pebble Core"
-		"Quantum Keystone"
-		"Small Heat Shunt"
-
-ship "Violin Spider" "Violin Spider (Arogor)"
-	outfits
-		`"Basrem" Atomic Steering`
-		`"Basrem" Atomic Thruster`
-		"Bullfrog Anti-Missile"
-		"Hai Chasm Batteries"
-		"Pebble Core"
-		"Quantum Keystone"
-		Railgun
-		"Railgun Slug" 1000
-		"Small Heat Shunt"
+	gun "Inhibitor Cannon"
+	gun "Hai Tracker Pod"
+	gun "Inhibitor Cannon"
+	gun "Inhibitor Cannon"
+	turret "Point Defense Turret"
+	turret "Pulse Turret"
+	turret "Pulse Turret"
+	turret "Pulse Turret"
+	turret "Pulse Turret"
+	turret "Chameleon Anti-Missile"
 
 mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 	landing
@@ -2341,12 +2323,6 @@ mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 		government "Pirate"
 		personality staying nemesis
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
-	npc
-		government "Pirate"
-		personality staying nemesis
-		ship "Korath Chaser (Laughing Point)" "Tromes"
-		ship "Korath Chaser (Laughing Point)" "Tachan"
-		ship "Violin Spider (Arogor)" "Arogor"
 		dialog
 			`After the Bactrian is eliminated, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
@@ -2408,12 +2384,6 @@ mission "Deep: Scientist Rescue 3A"
 		personality staying nemesis
 		system "Arneb"
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
-	npc
-		government "Pirate"
-		personality staying nemesis
-		ship "Korath Chaser (Laughing Point)" "Tromes"
-		ship "Korath Chaser (Laughing Point)" "Tachan"
-		ship "Violin Spider (Arogor)" "Arogor"
 		dialog
 			`After the Bactrian is eliminated, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`


### PR DESCRIPTION
**Content (Missions)**

## Summary

At this point, it's down to a slightly more efficient and powerful loadout which emphasizes the Bactrian's role as a pirate capper/looter flagship, with ramscoop and scram drives, interference plating, and nerve gas on top of alien H2H weaponry, while still limiting Remnant tech to solely one ship's worth of loot.

Even as a much smaller change overall, it's still a large improvement in the lore implications/complications of the ship, imo.

![Screenshot (59)](https://user-images.githubusercontent.com/73392427/118689478-0aada000-b7d5-11eb-887e-ff80c484dd3b.png)


Test file with current load out:
[Testy McTestface.txt](https://github.com/endless-sky/endless-sky/files/6547734/Testy.McTestface.txt)