### PR TITLE
Boarding: Give <count> x <mass> even if <mass> is 1

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -560,8 +560,7 @@ const string &BoardingPanel::Plunder::Name() const
 
 
 
-// Get the mass, in the format "<count> x <unit mass>". If this is a
-// commodity, no unit mass is given (because it is 1). If the count is
+// Get the mass, in the format "<count> x <unit mass>". If the count is
 // 1, only the unit mass is reported.
 const string &BoardingPanel::Plunder::Size() const
 {
@@ -620,9 +619,7 @@ void BoardingPanel::Plunder::Take(int count)
 void BoardingPanel::Plunder::UpdateStrings()
 {
 	double mass = UnitMass();
-	if(!outfit)
-		size = to_string(count);
-	else if(count == 1)
+	if(count == 1)
 		size = Format::Number(mass);
 	else
 		size = to_string(count) + " x " + Format::Number(mass);


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in ~~issue #{{insert number}}~~ this PR

## Feature Details
In the plunder dialog, show commodities as `<count> x 1` rather than as `<count>`.

Why? Because otherwise, when scanning the "size" column, outfits and commodities are both listed as `<a single integer>`, even though commodities are divisible and outfits aren't. That is, before this PR, `Hyperdrive | 20` and `Luxury Goods | 20` could appear, even though a ship with 10 free cargo space could use the latter but not the former. (In the latter, `<mass> = 1` and `<count> = 20`; in the former, the `<count> = 1` and `<mass> = 20`.)

## UI Screenshots
![2021-05-18-021807_337x119_scrot](https://user-images.githubusercontent.com/24784687/118580759-f9867400-b77f-11eb-98f3-edd8dd55fac3.png)

The `x 1` part is new.

## Usage Examples
N/A

## Testing Done
Created a test mission with a `derelict` Carrier and boarded it.

## Performance Impact
N/A

## Additional context
Kinda related to the texty (fourth) mockup in https://github.com/endless-sky/endless-sky/issues/5962#issue-891407056.

Similar listing in the ship info dialog: https://github.com/endless-sky/endless-sky/pull/2985
