### PR TITLE
Only lower reputation due to atrocities if governments are friendly

### DIFF
--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -579,6 +579,9 @@ string Planet::DemandTribute(PlayerInfo &player) const
 		for(const auto &gov : toProvoke)
 			gov->Offend(ShipEvent::PROVOKE);
 		// Terrorizing a planet is not taken lightly by it or its allies.
+		// TODO: Use a distinct event type for the domination system and
+		// expose syntax for controlling its impact on the targeted government
+		// and those that know it.
 		GetGovernment()->Offend(ShipEvent::ATROCITY);
 		return "Our defense fleet will make short work of you.";
 	}

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -106,7 +106,7 @@ void Politics::Offend(const Government *gov, int eventType, int count)
 			// friendly without the player's behavior toward one of them
 			// influencing their reputation with the other.
 			double penalty = (count * weight) * other->PenaltyFor(eventType);
-			if(eventType & ShipEvent::ATROCITY)
+			if(eventType & ShipEvent::ATROCITY && weight > 0)
 				reputationWith[other] = min(0., reputationWith[other]);
 			
 			reputationWith[other] -= penalty;


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue with demanding tribute affecting reputation with governments.

## Fix Details
A while ago, demanding tribute from a planet was changed to be considered an atrocity. 7675eb7
It has been noted though that since then, demanding tribute from a pirate planet will lower your reputation with the Republic, despite the fact that the Republic has a negative attitude toward pirates. 

As it turns out, committing an atrocity is currently causing your reputation to drop to 0 for *all* governments that have an attitude toward the government you committed an atrocity against, whether that be a positive or negative attitude.
This PR changes it so that atrocities only drop your reputation to 0 with governments that are friendly toward the government you committed an atrocity against.

## Testing Done
While having a positive reputation toward the Republic, demanded tribute from a pirate planet with and without this change. Without this change my reputation with the Republic was dropped to 3. With this change my reputation was unchanged after demanding tribute.

## Save File
Your own save file will probably have a friendly republic and hostile pirates to test this on.