### PR TITLE
Don't offer "Remnant: Face to Maw 1B" during Cognizance

### DIFF
--- a/changelog
+++ b/changelog
@@ -27,7 +27,7 @@ Version 0.9.14:
       * The Unfettered now have their own outfitter and shipyard, preventing new Hai technology from being sold by the Unfettered. (@Amazinite)
       * The Independent government will now always be friendly after it is introduced in the Free Worlds campaign. (@Amazinite)
       * Improved some of the wording in "Remnant: Expanded Horizons Storms 1". (@Zitchas)
-      * "Remnant: Face to Maw" no longer offers while you are in the middle of the "Cognizance" string of missions. (@Amazinite)
+      * "Remnant: Face to Maw" no longer offers while you are in the middle of the "Cognizance" string of missions. (@Amazinite, @Ornok)
       * "Remnant: Cognizance 4" no longer uses mission failure to determine player choice, which led to confusion when the mission failed message appeared after making an acceptable choice. (@Amazinite)
       * The mission "Wanderers: Hai Diplomat" can now be offered on Mirrorlake. (@Ornok)
       * Improved some of the wording in "Lagrange Ring: Cargo". (@Arachi-Lover)

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -2950,6 +2950,9 @@ mission "Remnant: Face to Maw 1B"
 	landing
 	to offer
 		has "event: remnant: return the samples timer"
+		or
+			not "Remnant: Cognizance 1: offered"
+			has "Remnant: Cognizance 19: done"
 	to fail
 		or
 			has "Remnant: Face to Maw 1: done"


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5990

## Fix Details
"Remnant: Face to Maw 1" has recently been changed so that it's not offered during the Cognizance missions (18b8c99). The mission "Remnant: Face to Maw 1B" which is supposed to be offered at the same time wasn't updated. That means that during the Cognizance missions, the player can currently be offered "Remnant: Face to Maw 1B" without having "Remnant: Face to Maw 1" too.

This PR gives "Remnant: Face to Maw 1B" the exact same `to offer` conditions as "Remnant: Face to Maw 1".

## Testing Done
Limited. I only tested that the mission doesn't offer during Cognizance.

## Save File
[github-5990-fix.txt](https://github.com/endless-sky/endless-sky/files/6526984/github-5990-fix.txt)
This is a modification of 2phunkey4u's save. It places the player on Viminal with "Remnant: Cognizance 1: active" and "event: remnant: return the samples timer". Before the fix, "Remnant: Face to Maw 1B" would be offered when landing on a gas planet in Nenia.