### PR TITLE
Feature: "fuel cache" Attribute

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2649,7 +2649,12 @@ void Ship::Recharge(bool atSpaceport)
 	if(atSpaceport)
 	{
 		crew = min<int>(max(crew, RequiredCrew()), attributes.Get("bunks"));
-		fuel = attributes.Get("fuel capacity");
+	}
+	if(GetPlanet())
+	{
+		const auto planetAttrs = GetPlanet()->Attributes();
+		if(planetAttrs.find("fuel cache") != planetAttrs.end() || atSpaceport)
+			fuel = attributes.Get("fuel capacity");
 	}
 	pilotError = 0;
 	pilotOkay = 0;


### PR DESCRIPTION
## Summary
@Galaucus (aka Lake) is creating a pirate storyline, and asked me for help implementing a new attribute for planets, called `"fuel cache"`. Basically, it enables a planet to refuel without having a spaceport -- the idea is that pirates have hidden fuel caches on uninhabited planets.

## Testing Done
Playtested the feature, shown in the below pics:

Modded Omnis to have a system with a fuel cache'd planet:
![image](https://user-images.githubusercontent.com/71294739/119243196-95becb00-bb32-11eb-81fd-a3d9f35ed6b5.png)
![image](https://user-images.githubusercontent.com/71294739/119243209-b0913f80-bb32-11eb-92f9-f6a6cfcc5edf.png)

Fuel before landing:
![image](https://user-images.githubusercontent.com/71294739/119243221-c272e280-bb32-11eb-9b1d-08198793de65.png)

Fuel after landing:
![image](https://user-images.githubusercontent.com/71294739/119243227-cef73b00-bb32-11eb-8c9c-398bd7893aa9.png)
