### PR TITLE
Document install process for Apple ARM processors

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -207,6 +207,7 @@ contributed to Endless Sky:
   LordInsane
   Luckz
   luiges90
+  lukearndt
   macfreek
   MageKing17
   Mailaender
@@ -307,6 +308,6 @@ contributed to Endless Sky:
 
 Special thanks to MCOfficer for
 creating, managing, and hosting
-the ESLauncher, nightly, & 
+the ESLauncher, nightly, &
 continuous builds that make so
 much of this work possible.

--- a/readme-developer.txt
+++ b/readme-developer.txt
@@ -85,12 +85,30 @@ To build Endless Sky with native tools, you will first need to download Xcode fr
 
 Next, install Homebrew (from http://brew.sh).
 
+ARM Processors:
+
+  If you have an ARM processor, such as the Apple M1, you will need to install an x86_64 version of Homebrew. You can do this by running the normal install command through an `arch` terminal:
+
+  $ arch -x86_64 zsh
+
+  You may find it useful to define an alias that you can use to interact with your x86_64 homebrew:
+
+  alias brex="arch -x86_64 /usr/local/Homebrew/bin/brew"
+
+  Use this alias instead of `brew` in any subsequent homebrew commands.
+
+  Before continuing, make sure that your x86_64 Homebrew install is prefixed to `/usr/local`:
+
+  $ brex --prefix
+  /usr/local
+
 Once Homebrew is installed, use it to install the libraries you will need:
 
-  $ brew install libpng
-  $ brew install libjpeg-turbo
-  $ brew install libmad
-  $ brew install sdl2
+  $ brew install libpng libjpeg-turbo libmad sdl2
+
+ARM version:
+
+  $ brex install libpng libjpg-turbo libmad sdl2
 
 If the versions of those libraries are different from the ones that the Xcode project is set up for, you will need to modify the file paths in the “Frameworks” section in Xcode.
 It is possible that you will also need to modify the “Header Search Paths” and “Library Search Paths” in “Build Settings” to point to wherever Homebrew installed those libraries.
@@ -115,4 +133,4 @@ For the Code::Blocks project, the archive program can be configured in Code::Blo
 
 The Scons builds can be controlled by setting the appropriate environment variable(s), either directly in the environment or just for the lifetime of the command:
 
-  $ AR=gcc-ar RANLIB=gcc-ranlib scons 
+  $ AR=gcc-ar RANLIB=gcc-ranlib scons


### PR DESCRIPTION
I just managed to get Endless Sky building on a computer that has an
Apple M1 processor, which has the new ARM architecture. While I didn't
figure out how to make it compile an ARM release build, I was able to
create an x86_64 build that runs on my machine via Rosetta.

This commit adds some information to the developer readme to help out
anyone else who wants to develop the game from a new macOS device.
