### PR TITLE
Reset swizzle before glUseProgram(0).

### DIFF
--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -271,12 +271,12 @@ void SpriteShader::Add(const Item &item, bool withBlur)
 
 void SpriteShader::Unbind()
 {
-	glBindVertexArray(0);
-	glUseProgram(0);
-	
 	// Reset the swizzle.
 	if(SpriteShader::useShaderSwizzle)
 		glUniform1i(swizzlerI, 0);
 	else
 		glTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_SWIZZLE_RGBA, SWIZZLE[0].data());
+
+	glBindVertexArray(0);
+	glUseProgram(0);
 }


### PR DESCRIPTION
**Bugfix:** This PR addresses issue https://github.com/emscripten-core/emscripten/issues/14079

## Fix Details
The swizzler variable is currently modified after clearing the current program, which seems wrong: [the docs](https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glUniform.xml) for glUniform1i say

> Specify the value of a uniform variable for the current program object

from which I gather there ought to still be a current program object, so this PR moves `glUseProgram(0);` to after this call.

I noticed because a change in the way Emscripten handler shaders caused this code to crash: https://github.com/emscripten-core/emscripten/issues/14079

I don't know on which other platforms this might be a problem. I just moved `glBindVertexArray(0)` to keep it next to `glUseProgram(0)`.

## Testing Done
Works on Linux without using the shader.