### PR TITLE
fix(typo): Fix typo in Setar Fort Heating mission

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,7 +1,7 @@
 Version 0.9.14:
   * Bug fixes:
     * Content bugs:
-      * Typo fixes. (@alextd, @Amazinite, @Anarchist2, @AraCaputDraco, @Arachi-Lover, @Corraban2, @EjoThims, @InfiniteDonuts, @infinitewarp, @jarekchr, @MCOfficer, @Ornok, @petervdmeer, @tehhowch, @Terin, @Zitchas)
+      * Typo fixes. (@alextd, @Amazinite, @Anarchist2, @AraCaputDraco, @Arachi-Lover, @Corraban2, @dazuma, @EjoThims, @InfiniteDonuts, @infinitewarp, @jarekchr, @MCOfficer, @Ornok, @petervdmeer, @tehhowch, @Terin, @Zitchas)
       * "Remnant: Deep Surveillance" will now offer, as typos in the offer conditions were preventing it from offering. (@alextd, @Amazinite)
       * "Deep: Remnant 3" now properly offers on landing instead of requiring you to visit the spaceport with no direction. (@Amazinite)
       * The Dropship is now sold in Navy Basics shipyards, whereas before it was sold nowhere. (@Amazinite)

--- a/credits.txt
+++ b/credits.txt
@@ -149,6 +149,7 @@ contributed to Endless Sky:
   Darcman99
   davidarcher
   davidwhitman
+  dazuma
   db47h
   DingusShingleton
   Disiuze

--- a/data/korath/korath missions.txt
+++ b/data/korath/korath missions.txt
@@ -119,7 +119,7 @@ mission "Setar Fort Heating"
 	on complete
 		payment 5000
 		conversation
-			`When you arrive on <planet>, a group of Korath is waiting to unload the cargo. You try and imitate their gesture of greeting, holding your hands up with your palms toward the group. The look surprised but hiss approvingly.`
+			`When you arrive on <planet>, a group of Korath is waiting to unload the cargo. You try and imitate their gesture of greeting, holding your hands up with your palms toward the group. They look surprised but hiss approvingly.`
 			`	Soon, all the supplies are off of your ship. The Korath give you a gesture of appreciation, then they begin unpacking it right in the middle of the spaceport. Already, a crowd has begun to gather around the equipment. It looks like it will be put to good use here. When you return to your ship, you see the Wanderer who offered you the job has transferred you your payment of <payment>.`
 			
 mission "Korath Family to Ringworld"


### PR DESCRIPTION
## Summary

Fixed one small typo in the on complete conversation text of the "Setar Fort Heating" mission.
