### PR TITLE
fix: Traveller -> Traveller

### DIFF
--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -989,7 +989,7 @@ news "human tourism"
 		word
 			"Tourist"
 			"Sightseer"
-			"Traveller"
+			"Traveler"
 	message
 		word
 			`"`


### PR DESCRIPTION
**Bugfix:**

## Fix Details
As per https://github.com/endless-sky/endless-sky/pull/5755#discussion_r646040671, we use traveller with one L. This is the last instance of the word spelled with two L.
