### PR TITLE
Automatically select newly captured ships

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -395,6 +395,9 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 					}
 				isCapturing = false;
 				
+				// Select the newly captured ship.
+				player.SelectShip(victim.get(), false);
+				
 				// Report this ship as captured in case any missions care.
 				ShipEvent event(you, victim, ShipEvent::CAPTURE);
 				player.HandleEvent(event, GetUI());


### PR DESCRIPTION
The first thing most players want to do after capturing a ship is to order it away from combat so that it doesn't get killed. As a simple quality of life improvement, a ship should automatically be selected after it is captured, making it faster and easier to issue those urgent, life-saving orders.

Currently, to issue orders to a newly captured ship, the user has to first find the ship on the screen and click it, which doesn't sound too difficult, but a few facts must be kept in mind. First, when there are already a lot of ships nearby, it is very easy to click a different ship by mistake. Second, often the first thing newly captured ships do is aggro towards a group of enemies that will almost instantly destroy it. Third, in particularly chaotic or dangerous battles, newly captured ships can die very quickly; by the time a user has selected the captured ship, it is often too late to save it. Every millisecond counts.

For these reasons, I propose that a ship be automatically selected after capturing it.