### PR TITLE
Fix: Remnant Gaslined planet mission eligibility & Cog 19 on complete text tweak

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -4240,6 +4240,7 @@ mission "Remnant: Expanded Horizons Astral 1"
 		not distance 0
 	to offer
 		has "Remnant: Expanded Horizons Quarg 3: done"
+		not attributes "requires: gaslining"
 		random < 25
 	on offer
 		conversation

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -4208,7 +4208,7 @@ mission "Remnant: Cognizance 19"
 	on complete
 		payment 100000
 		event "remnant: cognizance 1 systems available"
-		dialog `As the starport computer downloads the data, your computer displays a message tacked onto the log file: "Thank you for providing your navigational logs. They will be useful to contrast against those of our scouts. A logistics adjustment of <payment> has been authorized for the <ship>."`
+		dialog `As the starport computer downloads the data, your computer displays a message tacked onto the log file: "Thank you for providing the additional data from your navigational logs. It will be useful to contrast against those of our scouts. A logistics adjustment of <payment> has been authorized for the <ship>."`
 
 
 
@@ -4408,6 +4408,7 @@ mission "Remnant: Expanded Horizons Astral 2"
 		government "Remnant"
 	destination
 		government "Remnant"
+		not attributes "requires: gaslining"
 	waypoint "Sagittarius A*"
 	to offer
 		has "Remnant: Expanded Horizons Astral 1: done"

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -4238,9 +4238,9 @@ mission "Remnant: Expanded Horizons Astral 1"
 	destination
 		government "Remnant"
 		not distance 0
+		not attributes "requires: gaslining"
 	to offer
 		has "Remnant: Expanded Horizons Quarg 3: done"
-		not attributes "requires: gaslining"
 		random < 25
 	on offer
 		conversation


### PR DESCRIPTION
**Bugfix:** This PR addresses:
- Reported bugs on Discord about Astral missions requiring the player to go to Esquiline to pick up the research lab, when the later won't fit on a puffin. 

## Fix Details
- Adjusts the "on complete" text for Cognizance 19 to more accurately reflect the nature of the mission. (the Remnant don't need the player's navigational log, they need the *additional data from* their navigational log.)
- Adds an exclusion to Astral 1 & 2 that prevents the destination from being selected as a planet requiring gaslining.

