### PR TITLE
Allow weapons to disregard whether the firing hull would cause the wielding ship to become disabled

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3409,8 +3409,10 @@ bool Ship::CanFire(const Weapon *weapon) const
 	if(fuel < weapon->FiringFuel() + weapon->RelativeFiringFuel() * attributes.Get("fuel capacity"))
 		return false;
 	// We do check hull, but we don't check shields. Ships can survive with all shields depleted.
-	// Ships should not disable themselves, so we check if we stay above minimumHull.
-	if(hull - MinimumHull() < weapon->FiringHull() + weapon->RelativeFiringHull() * attributes.Get("hull"))
+	// Ships should not disable themselves, so we check if we stay above minimumHull. That is,
+	// unless the weapon is designed to potentially disable the firing ship.
+	if(!weapon->DisregardFiringHull()
+		&& hull - MinimumHull() < weapon->FiringHull() + weapon->RelativeFiringHull() * attributes.Get("hull"))
 		return false;
 
 	// If a weapon requires heat to fire, (rather than generating heat), we must

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -50,6 +50,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			isParallel = true;
 		else if(key == "gravitational")
 			isGravitational = true;
+		else if(key == "disregard firing hull")
+			disregardFiringHull = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -120,6 +120,9 @@ public:
 	// Gravitational weapons deal the same amount of hit force to a ship regardless
 	// of its mass.
 	bool IsGravitational() const;
+	// Whether ships should use this weapon even if the firing hull cost would cause
+	// the ship to become disabled.
+	bool DisregardFiringHull() const;
 	
 	// These values include all submunitions:
 	// Normal damage types:
@@ -189,6 +192,7 @@ private:
 	bool isPhasing = false;
 	bool isDamageScaled = true;
 	bool isGravitational = false;
+	bool disregardFiringHull = false;
 	// Guns and missiles are by default aimed a converged point at the
 	// maximum weapons range in front of the ship. When either the installed
 	// weapon or the gun-port (or both) have the isParallel attribute set
@@ -334,6 +338,7 @@ inline bool Weapon::IsSafe() const { return isSafe; }
 inline bool Weapon::IsPhasing() const { return isPhasing; }
 inline bool Weapon::IsDamageScaled() const { return isDamageScaled; }
 inline bool Weapon::IsGravitational() const { return isGravitational; }
+inline bool Weapon::DisregardFiringHull() const { return disregardFiringHull; }
 
 inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); }
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }


### PR DESCRIPTION
**Feature:** This PR implements a feature request discussed in relation to #5818.

## Feature Details
This PR adds a new weapon attribute:
* `"disregard firing hull"`: A tag that allows weapons to fire regardless of whether the firing hull cost would cause the firing ship to become disabled.

## UI Screenshots
N/A

## Usage Examples
```
outfit "Ka'het Emergency Deployer"
	...
	weapon
		...
		"disregard firing hull"
		"firing hull" 60
		...
```

## Testing Done
None at all.

## Performance Impact
N/A
