### PR TITLE
feat: Add ability to fire all secondary weapons

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3494,9 +3494,9 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 		if(activeCommands.Has(Command::SECONDARY))
 		{
 			int index = 0;
+			const auto &playerSelectedWeapons = player.SelectedWeapons();
 			for(const Hardpoint &hardpoint : ship.Weapons())
 			{
-				const auto playerSelectedWeapons = player.SelectedWeapons();
 				if(hardpoint.IsReady() && (playerSelectedWeapons.find(hardpoint.GetOutfit()) != playerSelectedWeapons.end()))
 					command.SetFire(index);
 				++index;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3496,7 +3496,9 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 			int index = 0;
 			for(const Hardpoint &hardpoint : ship.Weapons())
 			{
-				if(hardpoint.IsReady() && hardpoint.GetOutfit() == player.SelectedWeapon())
+				const Outfit *playerSelectedWeapon = player.SelectedWeapon();
+				if(hardpoint.IsReady() && hardpoint.GetOutfit()->Icon() &&
+						(!playerSelectedWeapon || hardpoint.GetOutfit() == playerSelectedWeapon))
 					command.SetFire(index);
 				++index;
 			}

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3496,9 +3496,8 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 			int index = 0;
 			for(const Hardpoint &hardpoint : ship.Weapons())
 			{
-				const Outfit *playerSelectedWeapon = player.SelectedWeapon();
-				if(hardpoint.IsReady() && hardpoint.GetOutfit()->Icon() &&
-						(!playerSelectedWeapon || hardpoint.GetOutfit() == playerSelectedWeapon))
+				const auto playerSelectedWeapons = player.SelectedWeapons();
+				if(hardpoint.IsReady() && (playerSelectedWeapons.find(hardpoint.GetOutfit()) != playerSelectedWeapons.end()))
 					command.SetFire(index);
 				++index;
 			}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1016,7 +1016,8 @@ void Engine::Draw() const
 		if(pos.Y() < ammoBox.Top() + ammoPad)
 			break;
 		
-		bool isSelected = it.first == player.SelectedWeapon();
+		const Outfit *playerSelectedWeapon = player.SelectedWeapon();
+		bool isSelected = (it.first == playerSelectedWeapon) || (nullptr == playerSelectedWeapon);
 		
 		SpriteShader::Draw(it.first->Icon(), pos + iconOff);
 		SpriteShader::Draw(isSelected ? selectedSprite : unselectedSprite, pos + boxOff);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1016,7 +1016,7 @@ void Engine::Draw() const
 		if(pos.Y() < ammoBox.Top() + ammoPad)
 			break;
 		
-		const auto playerSelectedWeapons = player.SelectedWeapons();
+		const auto &playerSelectedWeapons = player.SelectedWeapons();
 		bool isSelected = (playerSelectedWeapons.find(it.first) != playerSelectedWeapons.end());
 		
 		SpriteShader::Draw(it.first->Icon(), pos + iconOff);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1016,8 +1016,8 @@ void Engine::Draw() const
 		if(pos.Y() < ammoBox.Top() + ammoPad)
 			break;
 		
-		const Outfit *playerSelectedWeapon = player.SelectedWeapon();
-		bool isSelected = (it.first == playerSelectedWeapon) || (nullptr == playerSelectedWeapon);
+		const auto playerSelectedWeapons = player.SelectedWeapons();
+		bool isSelected = (playerSelectedWeapons.find(it.first) != playerSelectedWeapons.end());
 		
 		SpriteShader::Draw(it.first->Icon(), pos + iconOff);
 		SpriteShader::Draw(isSelected ? selectedSprite : unselectedSprite, pos + boxOff);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2058,8 +2058,6 @@ void PlayerInfo::SelectNext()
 	// was selected when we entered this function.
 	if(selectedWeapons.size() == 1)
 		selectedWeapons.clear();
-
-	return;
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1998,10 +1998,10 @@ void PlayerInfo::SetTravelDestination(const Planet *planet)
 
 
 
-// Check which secondary weapon the player has selected.
-const Outfit *PlayerInfo::SelectedWeapon() const
+// Check which secondary weapons the player has selected.
+const set<const Outfit *> &PlayerInfo::SelectedWeapons() const
 {
-	return selectedWeapon;
+	return selectedWeapons;
 }
 
 
@@ -2012,21 +2012,54 @@ void PlayerInfo::SelectNext()
 	if(!flagship || flagship->Outfits().empty())
 		return;
 	
-	// Start with the currently selected weapon, if any.
-	auto it = flagship->Outfits().find(selectedWeapon);
-	if(it == flagship->Outfits().end())
-		it = flagship->Outfits().begin();
-	else
-		++it;
+	// If multiple weapons were selected, then switch to selecting none.
+	if(selectedWeapons.size() > 1)
+	{
+		selectedWeapons.clear();
+		return;
+	}
+	
+	// If no weapon was selected, then we scan from the beginning.
+	auto it = flagship->Outfits().begin();
+	bool hadSingleWeaponSelected = (selectedWeapons.size() == 1);
+	
+	// If a single weapon was selected, then move the iterator to the
+	// outfit directly after it.
+	if(hadSingleWeaponSelected)
+	{
+		auto selectedOutfit = *(selectedWeapons.begin());
+		it = flagship->Outfits().find(selectedOutfit);
+		if(it != flagship->Outfits().end())
+			++it;
+	}
 	
 	// Find the next secondary weapon.
 	for( ; it != flagship->Outfits().end(); ++it)
 		if(it->first->Icon())
 		{
-			selectedWeapon = it->first;
+			selectedWeapons.clear();
+			selectedWeapons.insert(it->first);
 			return;
 		}
-	selectedWeapon = nullptr;
+	
+	// If no weapon was selected and we didn't find any weapons at this point,
+	// then the player just doesn't have any secondary weapons.
+	if(!hadSingleWeaponSelected)
+		return;
+	
+	// Reached the end of the list. Select all possible secondary weapons here.
+	it = flagship->Outfits().begin();
+	for( ; it != flagship->Outfits().end(); ++it)
+		if(it->first->Icon())
+			selectedWeapons.insert(it->first);
+	
+	// If we have only one weapon selected at this point, then the player
+	// only has a single secondary weapon. Clear the list, since the weapon
+	// was selected when we entered this function.
+	if(selectedWeapons.size() == 1)
+		selectedWeapons.clear();
+
+	return;
 }
 
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -224,7 +224,7 @@ public:
 	void SetTravelDestination(const Planet *planet);
 	
 	// Toggle which secondary weapon the player has selected.
-	const Outfit *SelectedWeapon() const;
+	const std::set<const Outfit *> &SelectedWeapons() const;
 	void SelectNext();
 	
 	// Escorts currently selected for giving orders.
@@ -345,7 +345,7 @@ private:
 	std::vector<const System *> travelPlan;
 	const Planet *travelDestination = nullptr;
 	
-	const Outfit *selectedWeapon = nullptr;
+	std::set<const Outfit *> selectedWeapons;
 	
 	std::map<const Outfit *, int> stock;
 	Depreciation depreciation;


### PR DESCRIPTION
**Feature:** This PR implements a feature related to this [comment](https://github.com/endless-sky/endless-sky/issues/1724#issuecomment-254778984)

## Feature Details
This PR adds an "all secondary weapons selected" option after the currently available "no secondary weapon selected" and "single secondary weapon selected" options.
The internal implementation uses a set which will also be suitable for the "mouse selectable set of options" as discussed in https://github.com/endless-sky/endless-sky/issues/1724.

## UI Screenshots
Screenshot of all weapons selected:
![all_weapons_selected](https://user-images.githubusercontent.com/35403542/123311474-84008700-d527-11eb-8e6c-22031c701341.png)

## Usage Examples
Just cycle through the list of available secondary weapons and notice that the new all-weapons-selected option is now also available at the end of the list.

## Testing Done
Tested with firing all secondary weapons (on a ship with 3 separate secondary weapons installed).
Tested with firing individual secondary weapons (on a ship with 3 separate secondary weapons installed).
Tested the selection and firing of a single weapon on a single ship.

## Performance Impact
I don't expect any performance impact (the player keys are checked once per frame only).