### PR TITLE
build: Add continuous target for v0.9.15

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,7 +3,6 @@ name: CD
 on:
   push:
     branches:
-      - master
       - v0.9.15
   pull_request:
     types:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - v0.9.15
   pull_request:
     types:
       - synchronize

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,6 +3,7 @@ name: CD
 on:
   push:
     branches:
+      #- master
       - v0.9.15
   pull_request:
     types:


### PR DESCRIPTION
**Build:** Adds the v0.9.15 branch to CD for continuous

-----------------------

## Details
This PR updates the workflow files to target the v0.9.15 branch in addition to master, for the v0.9.15 branch. From my testing, whenever any branch is run, it'll look to the workflows in that branch for what to do. This will let v0.9.15 affect the continuous release, without any changes to master. This will let people download the current changes via the release page, or ESLauncher2.

Once v0.9.15 is ready to merge when MZ lives, this change can be reverted.

## Testing Done
Push this change to v0.9.15 on my repo, then pushed another commit, which was properly added to the continuous release once CI/CD ran.

https://github.com/Terin/endless-sky/releases/tag/continuous