### PR TITLE
Added government filters to all Coalition news

### DIFF
--- a/data/coalition/coalition news.txt
+++ b/data/coalition/coalition news.txt
@@ -36,6 +36,7 @@ news "heliarch propaganda"
 
 news "longcow rancher"
 	location
+		government "Coalition"
 		attributes "arach" "longcows"
 	name
 		word
@@ -51,6 +52,7 @@ news "longcow rancher"
 
 news "kimek farmer"
 	location
+		government "Coalition"
 		attributes "kimek" "farming"
 	name
 		word
@@ -241,6 +243,7 @@ news "coalition merchant"
 
 news "arach civilian"
 	location
+		government "Coalition"
 		attributes "arach"
 	name
 		word
@@ -255,6 +258,7 @@ news "arach civilian"
 
 news "kimek civilian"
 	location
+		government "Coalition"
 		attributes "kimek"
 	name
 		word
@@ -269,6 +273,7 @@ news "kimek civilian"
 
 news "saryd civilian"
 	location
+		government "Coalition"
 		attributes "saryd"
 	name
 		word


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue from the Discord

## Fix Details
![image](https://user-images.githubusercontent.com/4471575/123529634-d8d30780-d6b7-11eb-879a-262bc66ee8dc.png)
From dankdmitron on the Discord, due to the news attribute filter only checking to see if one of the attributes matches at a given spaceport, and not all of them, the "kimek farmer" news item could show up on any worlds with the "farming" attribute. This is mostly noticeable on something like Vara Rakak in Wanderer space, which didn't have news until just today.

This PR adds a government filter to the rest of the Coalition news items. It is currently redundant on the rest, since arach/kimek/saryd/longcow doesn't show up outside of Coalition space, but it helps to be on the safe side.

## Testing Done
Went to Vara Rakak without the Wanderer news, and saw it was empty, and saw the kimek farmer news item show up in Coalition space.