### PR TITLE
Change Default MinimumHull Formula

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -150,10 +150,10 @@ tip "heat protection:"
 	`Protection against weapons that do heat damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in heat damage, while a total value of 11 only results in a 10 percent reduction.`
 
 tip "hull repair / max:"
-	`Hull repair rate (per second) and total hull strength. Small ships are disabled when their hull strength drops below 50%; larger ships are disabled at 15%.`
+	`Hull repair rate (per second) and total hull strength. The smallest of ships are disabled when their hull strength drops below about 45%, while very large ships are disabled at close to 10%.`
 
 tip "hull:"
-	`Total hull strength. Small ships are disabled when their hull strength drops below 50%; larger ships are disabled at 15%.`
+	`Total hull strength. Ships with a higher hull strength are able to take more damage as a proportion of their total strength before being disabled; the smallest of ships are disabled when their hull strength drops below about 45%, while very large ships are disabled at close to 10%.`
 
 tip "hull energy:"
 	`Energy consumed per second when repairing the hull.`
@@ -477,6 +477,7 @@ tip "shield damage / second:"
 	`Shield damage, converted to damage per second to allow easy comparisons between different weapons.`
 
 tip "hull damage / second:"
+	`Hull damage, converted to damage per second to allow easy comparisons between different weapons.`
 
 tip "fuel damage / second:"
 	`The amount of fuel lost by the target per second when hit by this weapon. If its shields are up, the loss will be cut in half. A negative amount means fuel is added.`

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -150,10 +150,10 @@ tip "heat protection:"
 	`Protection against weapons that do heat damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in heat damage, while a total value of 11 only results in a 10 percent reduction.`
 
 tip "hull repair / max:"
-	`Hull repair rate (per second) and total hull strength. Small ships are disabled when their hull strength drops below 45%; larger ships are disabled at 15%.`
+	`Hull repair rate (per second) and total hull strength. Small ships are disabled when their hull strength drops below 50%; larger ships are disabled at 15%.`
 
 tip "hull:"
-	`Total hull strength. Small ships are disabled when their hull strength drops below 45%; larger ships are disabled at 15%.`
+	`Total hull strength. Small ships are disabled when their hull strength drops below 50%; larger ships are disabled at 15%.`
 
 tip "hull energy:"
 	`Energy consumed per second when repairing the hull.`
@@ -477,7 +477,6 @@ tip "shield damage / second:"
 	`Shield damage, converted to damage per second to allow easy comparisons between different weapons.`
 
 tip "hull damage / second:"
-	`Hull damage, converted to damage per second to allow easy comparisons between different weapons.`
 
 tip "fuel damage / second:"
 	`The amount of fuel lost by the target per second when hit by this weapon. If its shields are up, the loss will be cut in half. A negative amount means fuel is added.`

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3614,7 +3614,8 @@ double Ship::MinimumHull() const
 		return absoluteThreshold;
 	
 	double thresholdPercent = attributes.Get("threshold percentage");
-	double minimumHull = maximumHull * (thresholdPercent > 0. ? min(thresholdPercent, 1.) : max(.15, min(.45, 10. / sqrt(maximumHull))));
+	double transition = 1 / (1 + 0.001 * maximumHull);
+	double minimumHull = maximumHull * (thresholdPercent > 0. ? min(thresholdPercent, 1.) : 0.1 * (1. - transition) + 0.75 * transition);
 
 	return max(0., floor(minimumHull + attributes.Get("hull threshold")));
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3614,8 +3614,8 @@ double Ship::MinimumHull() const
 		return absoluteThreshold;
 	
 	double thresholdPercent = attributes.Get("threshold percentage");
-	double transition = 1 / (1 + 0.0006 * maximumHull);
-	double minimumHull = maximumHull * (thresholdPercent > 0. ? min(thresholdPercent, 1.) : 0.05 * (1. - transition) + 0.75 * transition);
+	double transition = 1 / (1 + 0.0005 * maximumHull);
+	double minimumHull = maximumHull * (thresholdPercent > 0. ? min(thresholdPercent, 1.) : 0.1 * (1. - transition) + 0.5 * transition);
 
 	return max(0., floor(minimumHull + attributes.Get("hull threshold")));
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3614,8 +3614,8 @@ double Ship::MinimumHull() const
 		return absoluteThreshold;
 	
 	double thresholdPercent = attributes.Get("threshold percentage");
-	double transition = 1 / (1 + 0.001 * maximumHull);
-	double minimumHull = maximumHull * (thresholdPercent > 0. ? min(thresholdPercent, 1.) : 0.1 * (1. - transition) + 0.75 * transition);
+	double transition = 1 / (1 + 0.0006 * maximumHull);
+	double minimumHull = maximumHull * (thresholdPercent > 0. ? min(thresholdPercent, 1.) : 0.05 * (1. - transition) + 0.75 * transition);
 
 	return max(0., floor(minimumHull + attributes.Get("hull threshold")));
 }


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4851, #3448.

## Feature Details
Changes the calculation of a ship's default minimum hull from a mix of 15%, 45%, and 10/sqrt(hull amount), to a continuous curve moving from 75% to 10% roughly over the spectrum of human ship values. A table to give a rough feel for the change (it is not a very large change in actuality)
100 hull = 69.1 minimum
200 hull = 128.3 minimum
300 hull = 180 minimum
400 hull = 225.7 minimum
500 hull = 266.7 minimum
625 hull = 312.5 minimum (the 50% mark)
1000 hull = 425 minimum
1500 hull = 540 minimum
2000 hull = 633.3 minimum
3000 hull = 787.5 minimum
3333.3 hull = 833.3 minimum (the 25% mark)
4000 hull = 920 minimum
5000 hull = 1041.7 minimum
10000 hull = 1590.1 minimum
25000 hull = 3125 minimum (the 12.5% mark)

## UI Screenshots
![image](https://user-images.githubusercontent.com/35383563/123562353-4cd6e380-d77c-11eb-9d6f-d693095ed280.png)
The Wardragon has enough hull to breach the 15% line (its minimum hull is at 11.27%)
![image](https://user-images.githubusercontent.com/35383563/123562415-b656f200-d77c-11eb-8413-d777e1835689.png)
The Gull has 2500 hull, which equates to 714.3 hull, or 28.57%

## Usage Examples
N/A

## Testing Done
Purchased various ships and checked their displayed max hull and the size of the "disable" ring in-flight against the chart. For a moment I was concerned because I was checking shield values and they weren't matching up, but indeed the formula is working as intended.

## Performance Impact
Depending on how intensive a series of min()s and max()s are... MinimumHull() isn't called that often either way.
