### PR TITLE
feat: Fines in mission actions

### DIFF
--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -230,6 +230,15 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			if(child.Size() >= 3)
 				paymentMultiplier += child.Value(2);
 		}
+		else if(key == "fine")
+		{
+			if(child.Size() < 2)
+				child.PrintTrace("Skipping invalid \"fine\" without amount entry:");
+			else
+				fine += child.Value(1);
+			if(child.Size() > 2)
+				child.PrintTrace("Skipping non-defined parameters after \"fine\" value entry:");				
+		}
 		else if(key == "event" && hasValue)
 		{
 			int minDays = (child.Size() >= 3 ? child.Value(2) : 0);
@@ -320,6 +329,8 @@ void MissionAction::Save(DataWriter &out) const
 			out.Write("require", it.first->Name(), it.second);
 		if(payment)
 			out.Write("payment", payment);
+		if(fine)
+			out.Write("fine", fine);
 		for(const auto &it : events)
 		{
 			if(it.second.first == it.second.second)
@@ -516,6 +527,9 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 	if(payment)
 		player.Accounts().AddCredits(payment);
 	
+	if(fine)
+		player.Accounts().AddFine(fine);
+	
 	for(const auto &it : events)
 		player.AddEvent(*it.first, player.GetDate() + it.second.first);
 	
@@ -558,11 +572,17 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 	result.giftOutfits = giftOutfits;
 	result.requiredOutfits = requiredOutfits;
 	result.payment = payment + (jumps + 1) * payload * paymentMultiplier;
+	result.fine = fine;
 	// Fill in the payment amount if this is the "complete" action.
 	string previousPayment = subs["<payment>"];
 	if(result.payment)
 		subs["<payment>"] = Format::Credits(abs(result.payment))
 			+ (result.payment == 1 ? " credit" : " credits");
+	
+	string previousFine = subs["<fine>"];
+	if(result.fine)
+		subs["<fine>"] = Format::Credits(abs(result.fine))
+			+ (result.fine == 1 ? " credit" : " credits");
 	
 	if(!logText.empty())
 		result.logText = Format::Replace(logText, subs);
@@ -586,10 +606,12 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 	
 	result.conditions = conditions;
 	
-	// Restore the "<payment>" value from the "on complete" condition, for use
-	// in other parts of this mission.
+	// Restore the "<payment>" and "<fine>" values from the "on complete" condition, for
+	// use in other parts of this mission.
 	if(result.payment && trigger != "complete")
 		subs["<payment>"] = previousPayment;
+	if(result.fine && trigger != "complete")
+		subs["<fine>"] = previousFine;
 	
 	return result;
 }

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -235,9 +235,15 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			if(child.Size() < 2)
 				child.PrintTrace("Skipping invalid \"fine\" without amount entry:");
 			else
-				fine += child.Value(1);
+			{
+				int64_t loadedFine = child.Value(1);
+				if(loadedFine > 0)
+					fine += loadedFine;
+				else
+					child.PrintTrace("Skipping invalid \"fine\" with non-positive value:");					
+			}
 			if(child.Size() > 2)
-				child.PrintTrace("Skipping non-defined parameters after \"fine\" value entry:");				
+				child.PrintTrace("Ignoring non-defined parameters after \"fine\" value entry:");				
 		}
 		else if(key == "event" && hasValue)
 		{
@@ -581,7 +587,7 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 	
 	string previousFine = subs["<fine>"];
 	if(result.fine)
-		subs["<fine>"] = Format::Credits(abs(result.fine))
+		subs["<fine>"] = Format::Credits(result.fine)
 			+ (result.fine == 1 ? " credit" : " credits");
 	
 	if(!logText.empty())

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -525,7 +525,6 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 	
 	if(payment)
 		player.Accounts().AddCredits(payment);
-	
 	if(fine)
 		player.Accounts().AddFine(fine);
 	

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -230,20 +230,13 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			if(child.Size() >= 3)
 				paymentMultiplier += child.Value(2);
 		}
-		else if(key == "fine")
+		else if(key == "fine" && hasValue)
 		{
-			if(child.Size() < 2)
-				child.PrintTrace("Skipping invalid \"fine\" without amount entry:");
+			int64_t loadedFine = child.Value(1);
+			if(loadedFine > 0)
+				fine += loadedFine;
 			else
-			{
-				int64_t loadedFine = child.Value(1);
-				if(loadedFine > 0)
-					fine += loadedFine;
-				else
-					child.PrintTrace("Skipping invalid \"fine\" with non-positive value:");					
-			}
-			if(child.Size() > 2)
-				child.PrintTrace("Ignoring non-defined parameters after \"fine\" value entry:");				
+				child.PrintTrace("Skipping invalid \"fine\" with non-positive value:");
 		}
 		else if(key == "event" && hasValue)
 		{

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -92,6 +92,7 @@ private:
 	std::map<const Outfit *, int> requiredOutfits;
 	int64_t payment = 0;
 	int64_t paymentMultiplier = 0;
+	int64_t fine = 0;
 	
 	// When this action is performed, the missions with these names fail.
 	std::set<std::string> fail;


### PR DESCRIPTION
**Feature:** This PR implements the **fines** part of the feature requested and discussed in issue https://github.com/endless-sky/endless-sky/issues/1216

## Feature Details
This PR adds a keyword `fine` that can be used in `on accept`, `on complete`, `on <...>` mission actions.
Attached is a data-file [fines.txt](https://github.com/endless-sky/endless-sky/files/6728590/fines.txt) with 4 missions that can be used to test this feature (the missions are quite silent).

This PR only implements the `fine` keyword, it doesn't implement keywords to add a customized mortgage. I consider it an implementation detail that fines are handled as mortgages, so I consider it appropriate to use a separate keywords for fines and for mortgages (the implementation in https://github.com/endless-sky/endless-sky/pull/5073, minus the types, would then be suitable to handle the mortgages part).

## UI Screenshots
Here is a screenshot of all the fines from the datafile above applied:
![bank_panel_fines](https://user-images.githubusercontent.com/35403542/123688290-1d92a600-d852-11eb-83ed-ed684920778a.png)

## Usage Examples
Example usage:
```
mission ...
  ...
  on ...
    fine 800000
```

## Testing Done
I tested this feature with the 4 missions from the datafile above. Including a check if instantiated mission action fines are written to the savegame.

## Performance Impact
N/A