### PR TITLE
feat: Ignore flotsam that was explicitly dumped by same government

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -660,7 +660,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 						if(commodity.second && toDump > 0)
 						{
 							int dumped = min(commodity.second, toDump);
-							it->Jettison(commodity.first, dumped);
+							it->Jettison(commodity.first, dumped, true);
 							toDump -= dumped;
 						}
 					Messages::Add(gov->GetName() + " " + it->Noun() + " \"" + it->Name()

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2046,7 +2046,8 @@ void Engine::DoCollection(Flotsam &flotsam)
 	for(Body *body : shipCollisions.Circle(flotsam.Position(), 5.))
 	{
 		Ship *ship = reinterpret_cast<Ship *>(body);
-		if(!ship->CannotAct() && ship != flotsam.Source() && ship->Cargo().Free() >= flotsam.UnitSize())
+		if(!ship->CannotAct() && ship != flotsam.Source() && ship->Cargo().Free() >= flotsam.UnitSize() &&
+			ship->GetGovernment() != flotsam.SourceGovernment())
 		{
 			collector = ship;
 			break;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2047,7 +2047,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 	{
 		Ship *ship = reinterpret_cast<Ship *>(body);
 		if(!ship->CannotAct() && ship != flotsam.Source() && ship->GetGovernment() != flotsam.SourceGovernment()
-			&& ship->Cargo().Free() >= flotsam.UnitSize()
+			&& ship->Cargo().Free() >= flotsam.UnitSize())
 		{
 			collector = ship;
 			break;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2046,8 +2046,8 @@ void Engine::DoCollection(Flotsam &flotsam)
 	for(Body *body : shipCollisions.Circle(flotsam.Position(), 5.))
 	{
 		Ship *ship = reinterpret_cast<Ship *>(body);
-		if(!ship->CannotAct() && ship != flotsam.Source() && ship->Cargo().Free() >= flotsam.UnitSize() &&
-			ship->GetGovernment() != flotsam.SourceGovernment())
+		if(!ship->CannotAct() && ship != flotsam.Source() && ship->GetGovernment() != flotsam.SourceGovernment()
+			&& ship->Cargo().Free() >= flotsam.UnitSize()
 		{
 			collector = ship;
 			break;

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -32,8 +32,8 @@ const int Flotsam::TONS_PER_BOX = 5;
 
 
 // Constructors for flotsam carrying either a commodity or an outfit.
-Flotsam::Flotsam(const string &commodity, int count)
-	: commodity(commodity), count(count)
+Flotsam::Flotsam(const string &commodity, int count, const Government *sourceGovernment)
+	: commodity(commodity), count(count), sourceGovernment(sourceGovernment)
 {
 	lifetime = Random::Int(3600) + 7200;
 	// Scale lifetime in proportion to the expected amount per box.
@@ -43,8 +43,8 @@ Flotsam::Flotsam(const string &commodity, int count)
 
 
 
-Flotsam::Flotsam(const Outfit *outfit, int count)
-	: outfit(outfit), count(count)
+Flotsam::Flotsam(const Outfit *outfit, int count, const Government *sourceGovernment)
+	: outfit(outfit), count(count), sourceGovernment(sourceGovernment)
 {
 	// The more the outfit costs, the faster this flotsam should disappear.
 	int lifetimeBase = 3000000000 / (outfit->Cost() * count + 1000000);
@@ -119,6 +119,15 @@ void Flotsam::Move(vector<Visual> &visuals)
 const Ship *Flotsam::Source() const
 {
 	return source;
+}
+
+
+
+// Ships from this Government should not pick up this flotsam because it
+// was explicitly dumped by a member of this government.
+const Government *Flotsam::SourceGovernment() const
+{
+	return sourceGovernment;
 }
 
 

--- a/source/Flotsam.h
+++ b/source/Flotsam.h
@@ -21,6 +21,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <vector>
 
 class Effect;
+class Government;
 class Outfit;
 class Ship;
 class Visual;
@@ -30,8 +31,8 @@ class Visual;
 class Flotsam : public Body {
 public:
 	// Constructors for flotsam carrying either a commodity or an outfit.
-	Flotsam(const std::string &commodity, int count);
-	Flotsam(const Outfit *outfit, int count);
+	Flotsam(const std::string &commodity, int count, const Government *sourceGovernment = nullptr);
+	Flotsam(const Outfit *outfit, int count, const Government *sourceGovernment = nullptr);
 	
 	/* Functions provided by the Body base class:
 	Frame GetFrame(int step = -1) const;
@@ -55,6 +56,10 @@ public:
 	
 	// This is the one ship that cannot pick up this flotsam.
 	const Ship *Source() const;
+	// Ships from this Government should not pick up this flotsam because it
+	// was explicitly dumped by a member of this government. (NPCs typically
+	// perform this type of dumping to appease pirates.)
+	const Government *SourceGovernment() const;
 	// This is what the flotsam contains:
 	const std::string &CommodityType() const;
 	const Outfit *OutfitType() const;
@@ -82,6 +87,7 @@ private:
 	std::string commodity;
 	const Outfit *outfit = nullptr;
 	int count = 0;
+	const Government *sourceGovernment = nullptr;
 };
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3278,7 +3278,7 @@ const CargoHold &Ship::Cargo() const
 
 
 // Display box effects from jettisoning this much cargo.
-void Ship::Jettison(const string &commodity, int tons)
+void Ship::Jettison(const string &commodity, int tons, bool wasDumped)
 {
 	cargo.Remove(commodity, tons);
 	
@@ -3286,13 +3286,15 @@ void Ship::Jettison(const string &commodity, int tons)
 	// jettisoning cargo would increase the ship's temperature.
 	heat -= tons * MAXIMUM_TEMPERATURE * Heat();
 	
+	const Government *notForGov = wasDumped ? GetGovernment() : nullptr;
+	
 	for( ; tons > 0; tons -= Flotsam::TONS_PER_BOX)
-		jettisoned.emplace_back(new Flotsam(commodity, (Flotsam::TONS_PER_BOX < tons) ? Flotsam::TONS_PER_BOX : tons));
+		jettisoned.emplace_back(new Flotsam(commodity, (Flotsam::TONS_PER_BOX < tons) ? Flotsam::TONS_PER_BOX : tons, notForGov));
 }
 
 
 
-void Ship::Jettison(const Outfit *outfit, int count)
+void Ship::Jettison(const Outfit *outfit, int count, bool wasDumped)
 {
 	if(count < 0)
 		return;
@@ -3304,10 +3306,12 @@ void Ship::Jettison(const Outfit *outfit, int count)
 	double mass = outfit->Mass();
 	heat -= count * mass * MAXIMUM_TEMPERATURE * Heat();
 	
+	const Government *notForGov = wasDumped ? GetGovernment() : nullptr;
+	
 	const int perBox = (mass <= 0.) ? count : (mass > Flotsam::TONS_PER_BOX) ? 1 : static_cast<int>(Flotsam::TONS_PER_BOX / mass);
 	while(count > 0)
 	{
-		jettisoned.emplace_back(new Flotsam(outfit, (perBox < count) ? perBox : count));
+		jettisoned.emplace_back(new Flotsam(outfit, (perBox < count) ? perBox : count, notForGov));
 		count -= perBox;
 	}
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3278,7 +3278,7 @@ const CargoHold &Ship::Cargo() const
 
 
 // Display box effects from jettisoning this much cargo.
-void Ship::Jettison(const string &commodity, int tons, bool wasDumped)
+void Ship::Jettison(const string &commodity, int tons, bool wasAppeasing)
 {
 	cargo.Remove(commodity, tons);
 	
@@ -3286,7 +3286,7 @@ void Ship::Jettison(const string &commodity, int tons, bool wasDumped)
 	// jettisoning cargo would increase the ship's temperature.
 	heat -= tons * MAXIMUM_TEMPERATURE * Heat();
 	
-	const Government *notForGov = wasDumped ? GetGovernment() : nullptr;
+	const Government *notForGov = wasAppeasing ? GetGovernment() : nullptr;
 	
 	for( ; tons > 0; tons -= Flotsam::TONS_PER_BOX)
 		jettisoned.emplace_back(new Flotsam(commodity, (Flotsam::TONS_PER_BOX < tons) ? Flotsam::TONS_PER_BOX : tons, notForGov));
@@ -3294,7 +3294,7 @@ void Ship::Jettison(const string &commodity, int tons, bool wasDumped)
 
 
 
-void Ship::Jettison(const Outfit *outfit, int count, bool wasDumped)
+void Ship::Jettison(const Outfit *outfit, int count, bool wasAppeasing)
 {
 	if(count < 0)
 		return;
@@ -3306,7 +3306,7 @@ void Ship::Jettison(const Outfit *outfit, int count, bool wasDumped)
 	double mass = outfit->Mass();
 	heat -= count * mass * MAXIMUM_TEMPERATURE * Heat();
 	
-	const Government *notForGov = wasDumped ? GetGovernment() : nullptr;
+	const Government *notForGov = wasAppeasing ? GetGovernment() : nullptr;
 	
 	const int perBox = (mass <= 0.) ? count : (mass > Flotsam::TONS_PER_BOX) ? 1 : static_cast<int>(Flotsam::TONS_PER_BOX / mass);
 	while(count > 0)

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -366,8 +366,8 @@ public:
 	CargoHold &Cargo();
 	const CargoHold &Cargo() const;
 	// Display box effects from jettisoning this much cargo.
-	void Jettison(const std::string &commodity, int tons, bool wasDumped = false);
-	void Jettison(const Outfit *outfit, int count, bool wasDumped = false);
+	void Jettison(const std::string &commodity, int tons, bool wasAppeasing = false);
+	void Jettison(const Outfit *outfit, int count, bool wasAppeasing = false);
 	
 	// Get the current attributes of this ship.
 	const Outfit &Attributes() const;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -366,8 +366,8 @@ public:
 	CargoHold &Cargo();
 	const CargoHold &Cargo() const;
 	// Display box effects from jettisoning this much cargo.
-	void Jettison(const std::string &commodity, int tons);
-	void Jettison(const Outfit *outfit, int count);
+	void Jettison(const std::string &commodity, int tons, bool wasDumped = false);
+	void Jettison(const Outfit *outfit, int count, bool wasDumped = false);
 	
 	// Get the current attributes of this ship.
 	const Outfit &Attributes() const;

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -677,12 +677,12 @@ void ShipInfoPanel::Dump()
 		int64_t basis = player.GetBasis(selectedCommodity, amount);
 		loss += basis;
 		player.AdjustBasis(selectedCommodity, -basis);
-		(*shipIt)->Jettison(selectedCommodity, amount);
+		(*shipIt)->Jettison(selectedCommodity, amount, true);
 	}
 	else if(plunderAmount > 0)
 	{
 		loss += plunderAmount * selectedPlunder->Cost();
-		(*shipIt)->Jettison(selectedPlunder, plunderAmount);
+		(*shipIt)->Jettison(selectedPlunder, plunderAmount, true);
 	}
 	else if(commodities)
 	{
@@ -691,7 +691,7 @@ void ShipInfoPanel::Dump()
 			int64_t basis = player.GetBasis(it.first, it.second);
 			loss += basis;
 			player.AdjustBasis(it.first, -basis);
-			(*shipIt)->Jettison(it.first, it.second);
+			(*shipIt)->Jettison(it.first, it.second, true);
 		}
 	}
 	else
@@ -699,7 +699,7 @@ void ShipInfoPanel::Dump()
 		for(const auto &it : cargo.Outfits())
 		{
 			loss += it.first->Cost() * max(0, it.second);
-			(*shipIt)->Jettison(it.first, it.second);
+			(*shipIt)->Jettison(it.first, it.second, true);
 		}
 	}
 	selectedCommodity.clear();
@@ -719,7 +719,7 @@ void ShipInfoPanel::DumpPlunder(int count)
 	if(count > 0)
 	{
 		loss += count * selectedPlunder->Cost();
-		(*shipIt)->Jettison(selectedPlunder, count);
+		(*shipIt)->Jettison(selectedPlunder, count, true);
 		info.Update(**shipIt, player.FleetDepreciation(), player.GetDate().DaysSinceEpoch());
 		
 		if(loss)
@@ -738,7 +738,7 @@ void ShipInfoPanel::DumpCommodities(int count)
 		int64_t basis = player.GetBasis(selectedCommodity, count);
 		loss += basis;
 		player.AdjustBasis(selectedCommodity, -basis);
-		(*shipIt)->Jettison(selectedCommodity, count);
+		(*shipIt)->Jettison(selectedCommodity, count, true);
 		info.Update(**shipIt, player.FleetDepreciation(), player.GetDate().DaysSinceEpoch());
 		
 		if(loss)

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -677,12 +677,12 @@ void ShipInfoPanel::Dump()
 		int64_t basis = player.GetBasis(selectedCommodity, amount);
 		loss += basis;
 		player.AdjustBasis(selectedCommodity, -basis);
-		(*shipIt)->Jettison(selectedCommodity, amount, true);
+		(*shipIt)->Jettison(selectedCommodity, amount);
 	}
 	else if(plunderAmount > 0)
 	{
 		loss += plunderAmount * selectedPlunder->Cost();
-		(*shipIt)->Jettison(selectedPlunder, plunderAmount, true);
+		(*shipIt)->Jettison(selectedPlunder, plunderAmount);
 	}
 	else if(commodities)
 	{
@@ -691,7 +691,7 @@ void ShipInfoPanel::Dump()
 			int64_t basis = player.GetBasis(it.first, it.second);
 			loss += basis;
 			player.AdjustBasis(it.first, -basis);
-			(*shipIt)->Jettison(it.first, it.second, true);
+			(*shipIt)->Jettison(it.first, it.second);
 		}
 	}
 	else
@@ -699,7 +699,7 @@ void ShipInfoPanel::Dump()
 		for(const auto &it : cargo.Outfits())
 		{
 			loss += it.first->Cost() * max(0, it.second);
-			(*shipIt)->Jettison(it.first, it.second, true);
+			(*shipIt)->Jettison(it.first, it.second);
 		}
 	}
 	selectedCommodity.clear();
@@ -719,7 +719,7 @@ void ShipInfoPanel::DumpPlunder(int count)
 	if(count > 0)
 	{
 		loss += count * selectedPlunder->Cost();
-		(*shipIt)->Jettison(selectedPlunder, count, true);
+		(*shipIt)->Jettison(selectedPlunder, count);
 		info.Update(**shipIt, player.FleetDepreciation(), player.GetDate().DaysSinceEpoch());
 		
 		if(loss)
@@ -738,7 +738,7 @@ void ShipInfoPanel::DumpCommodities(int count)
 		int64_t basis = player.GetBasis(selectedCommodity, count);
 		loss += basis;
 		player.AdjustBasis(selectedCommodity, -basis);
-		(*shipIt)->Jettison(selectedCommodity, count, true);
+		(*shipIt)->Jettison(selectedCommodity, count);
 		info.Update(**shipIt, player.FleetDepreciation(), player.GetDate().DaysSinceEpoch());
 		
 		if(loss)


### PR DESCRIPTION
**Feature:** This PR implements a feature to improve the appeasing/flotsam dump behavior

## Feature Details
This PR let's ship ignore (not pickup) flotsam that was explicitly dumped by other ships of their own government.

Only explicit dumps (for example to appease pirates) are ignored; ships still pickup flotsam from same-gov ships that explode.
Explicit dumps are triggered in AI.cpp (for NPCs) and in ShipInfoPanel (by the player).

Related to https://github.com/endless-sky/endless-sky/issues/4100 since this PR removes the long-life flotsam option as mentioned in that PR.


## UI Screenshots
N/A

## Usage Examples
Player playing as a pirate: intimidate merchants and notice that the flotsam that they dump doesn't get collected by other merchants.
Player playing as merchant: dump cargo and notice that your escorts don't pick it up.
Attached is a savegame [Flotsam Dumper.txt](https://github.com/endless-sky/endless-sky/files/6743608/Flotsam.Dumper.txt) to test this.

## Testing Done
- Loaded attached savegame.
- Departed
- Shot some asteroids.
- Picked up the flotsam (by own ships and by cargo escort ships).
- Wait for cargo ships to fully surrounded my shuttle.
- Dumped cargo.
- Noticed that my escorts didn't pickup the flotsam dumped by me.

## Performance Impact
No significant impact expected.
