### PR TITLE
Swizzle the Emerald Sword (And Black Diamond)

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -198,7 +198,8 @@ contributed to Endless Sky:
   jozef-mitro
   Jugosloven1612
   Karirawri
-  kestrel1110 (Bereskatuket)
+  kestrel1110
+    Bereskatuket
   KevinKorzekwa
   kilobyte
   kkuchta

--- a/credits.txt
+++ b/credits.txt
@@ -198,6 +198,7 @@ contributed to Endless Sky:
   jozef-mitro
   Jugosloven1612
   Karirawri
+  kestrel1110 (Bereskatuket)
   KevinKorzekwa
   kilobyte
   kkuchta

--- a/credits.txt
+++ b/credits.txt
@@ -199,7 +199,6 @@ contributed to Endless Sky:
   Jugosloven1612
   Karirawri
   kestrel1110
-    Bereskatuket
   KevinKorzekwa
   kilobyte
   kkuchta

--- a/data/sheragi/sheragi ships.txt
+++ b/data/sheragi/sheragi ships.txt
@@ -11,6 +11,7 @@
 ship "Emerald Sword"
 	sprite ship/emeraldsword
 	thumbnail "thumbnail/emeraldsword"
+	swizzle 3
 	attributes
 		category "Heavy Warship"
 		"cost" 100000000
@@ -131,6 +132,7 @@ ship "Emerald Sword"
 ship "Emerald Sword" "Emerald Sword (Fixed)"
 	sprite ship/emeraldsword
 	thumbnail "thumbnail/emeraldsword"
+	swizzle 3
 	outfits
 		"Dragonflame Cannon"
 		"Particle Waveform Turret" 6

--- a/data/sheragi/sheragi ships.txt
+++ b/data/sheragi/sheragi ships.txt
@@ -158,6 +158,7 @@ ship "Emerald Sword" "Emerald Sword (Fixed)"
 ship "Black Diamond"
 	sprite "ship/blackdiamond"
 	thumbnail "thumbnail/blackdiamond"
+	swizzle 9
 	attributes
 		category "Fighter"
 		"cost" 1000000


### PR DESCRIPTION
## Summary
This pull request adds an emerald swizzle to the Emerald Sword. When I play, after getting the Emerald Sword through the mission string, I am always disappointed at the colors changing to my current swizzle. I often simply go into the save file and change it, but it becomes a pain to constantly have to change the pilot file. This pull request makes it so that the ship will permanently have the original Sheragi swizzle.

## Save File
This save file can be used to easily view the change:
[emeraldsword swizzletest.txt](https://github.com/endless-sky/endless-sky/files/6758993/emeraldsword.swizzletest.txt)

## Screenshot
![Swizzled Emerald Sword   Black Diamond](https://user-images.githubusercontent.com/64381519/124600481-c33aac00-de34-11eb-8762-21f1d2255cd4.png)


## PR Checklist
 - [x] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
 - [N/A] I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}
 - [N/A] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}