### PR TITLE
Don't spam "does not have enough crew" message until it clears the queue.

### DIFF
--- a/changelog
+++ b/changelog
@@ -48,6 +48,7 @@ Version 0.9.14:
   * User interface:
     * The "interrupt fast-forward" setting now defaults to off instead of on. (@Terin)
     * Fixed a misaligned UI element in the map panel. (@Terin)
+    * Messages about low crew ships are no longer considered "important," meaning they will no longer be pushed to the bottom of the message list every time they trigger and drown out other messages. (@ravenshining)
   * Under the hood:
     * Combined checking if a stellar object has a planet and if that planet is valid into a single method. (@tehhowch)
     * Having multiple missing frames for a sprite are now logged to the error file on a single line instead of generating a new line for each missing frame. (@ashdnazg, @tehhowch)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1700,9 +1700,9 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	{
 		pilotError = 30;
 		if(parent.lock() || !isYours)
-			Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it.",false);
+			Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it.", false);
 		else
-			Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it.",false);
+			Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it.", false);
 	}
 	else
 		pilotOkay = 30;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1700,9 +1700,9 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	{
 		pilotError = 30;
 		if(parent.lock() || !isYours)
-			Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it.");
+			Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it.",false);
 		else
-			Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it.");
+			Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it.",false);
 	}
 	else
 		pilotOkay = 30;


### PR DESCRIPTION
**Feature:** This PR reduces message log spam from ships with not enough crew.

## Feature Details

The `<ship> is moving erratically because you do not have enough crew to pilot it.` messages have been marked as unimportant, so they will not redisplay at the bottom of the screen until they are cleared from the message queue - that is, after about 17 seconds, or sooner if there are many messages from other sources coming in.

~~In practise, a message from a severely shorthanded vessel will still be shown at almost all times, but~~  <- This is what I expected, but ES is bit lazy about cleaning the queue.  Rather, if you are in a quiet area of space you might not see any messages at all until a different messages is triggered, then you'll get the crew message(s).

As expected, however, it will not compete with other messages for display in the queue, and it will scroll up in an orderly fashion, rather than having ships chaotically competing for the front position.

**Reasoning**
In the current game, when one captures a ship and is either severely shorthanded as a result or there are many captured ships, the message log quickly becomes flooded with complaints that there are not enough crew - up to one per ship every half second - drowning out all other messages.  While perhaps realistic - there may not be enough crew members to handle communications - this is extremely annoying and detracts from gameplay, as the player may easily miss more important messages.

**Related Issue Links**
Issue #773 suggested removing this message from escort ships entirely, but MZ said it was worth having the message show.  Rather than eliminating the message entirely, this PR simply reduces its frequency.

Thinking along 773's same lines, and retaining a nod to realism, I could instead only mark escort ships' complaints as unimportant.  This would still disrupt your communications when your flagship is short-handed, but at least escorts would not do this to you.  My preference however is to mark all such messages as unimportant as this PR does currently.

**Describe alternatives you've considered**

I've also tried and tested adding a cooldown to the messages that is only as long as it takes for a message to start fading (about 10 seconds, which is shorter than the time it takes for a message to be erased from the queue).  Although it worked, that method required adding more lines of code; this PR's method is much simpler.

## Testing Done
Capturing a ship and then basking in the newfound readability of the message log.

## Performance Impact
If anything I'd expect this to be mildly positive.