### PR TITLE
temporarily remove CT from sales to avoid confusion

### DIFF
--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -89,7 +89,6 @@ shipyard "Syndicate Basics"
 
 shipyard "Syndicate Advanced"
 	"Bulk Freighter"
-	"Container Transport"
 	"Protector"
 	"Vanguard"
 	"Arrow"


### PR DESCRIPTION
----------------------
**Content Balance (ship data)**

## Summary

@petervdmeer [commented](https://github.com/endless-sky/endless-sky/pull/5949#issuecomment-870963463) on #5949 that because #5969 has yet to be merged (and will not be merged for 0.9.14) that the lack of stat differences between the BF and CT currently in master might be confusing.  This PR removes the CT from sales.txt.  Determined players may still cap the container version if they desire.