### PR TITLE
Allow the map to be opened when at the end of a conversation

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -202,8 +202,9 @@ void ConversationPanel::Draw()
 bool ConversationPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
 	// Map popup happens when you press the map key, unless the name text entry
-	// fields are currently active.
-	if(command.Has(Command::MAP) && !choices.empty())
+	// fields are currently active. The name text entry fields are active if
+	// choices is empty and we aren't at the end of the conversation.
+	if(command.Has(Command::MAP) && (!choices.empty() || node < 0))
 		GetUI()->Push(new MapDetailPanel(player, system));
 	if(node < 0)
 	{


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue with attempting to open the map while at the end of a conversation.

## Fix Details
The map is typically capable of being opened by the player while in the middle of a conversation, except in two scenarios:
1. The conversation is currently at a name entry field.
2. The conversation is at its end.

Judging by a comment in ConversationPanel.cpp, only the former scenario is intended to block the player from opening the map. As such, this PR changes it so that the map is allowed to be opened while at the end of a conversation.

## Testing Done
Attempted to open the map at the end of a conversation with and without this change. With this change, the map is able to be opened, while without it the map can't be opened.

Tested that the behavior of pressing `m` while at a name entry field is unchanged.

## Save File
N/A