### PR TITLE
Don't leak the destination of invisible missions from the special marker

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -950,6 +950,12 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	// If this trigger has actions tied to it, perform them. Otherwise, check
 	// if this is a non-job mission that just got offered and if so,
 	// automatically accept it.
+	// Actions that are performed only receive the mission destination
+	// system if the mission is visible. This is because the purpose of
+	// a MissionAction being given the destination system is for drawing
+	// a special marker at the destination if the map is opened during any
+	// mission dialog or conversation. Invisible missions don't show this
+	// marker.
 	if(it != actions.end())
 		it->second.Do(player, ui, (destination && isVisible) ? destination->GetSystem() : nullptr, boardingShip, IsUnique());
 	else if(trigger == OFFER && location != JOB)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -951,7 +951,7 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	// if this is a non-job mission that just got offered and if so,
 	// automatically accept it.
 	if(it != actions.end())
-		it->second.Do(player, ui, destination ? destination->GetSystem() : nullptr, boardingShip, IsUnique());
+		it->second.Do(player, ui, (destination && isVisible) ? destination->GetSystem() : nullptr, boardingShip, IsUnique());
 	else if(trigger == OFFER && location != JOB)
 		player.MissionCallback(Conversation::ACCEPT);
 	


### PR DESCRIPTION
**Bugfix:** This PR addresses issue with the destination of invisible missions being able to be known by opening the map during an invisible mission's on offer conversation.

## Fix Details
It is currently permissible for invisible missions to have on offer conversations. During an on offer conversation, the player is capable of opening the map and viewing a special marker placed at the mission's destination. This marker is created regardless of the visibility of the mission. Invisible missions otherwise don't create map markers of any kind, and the special map marker should be no different.

This PR makes it so that invisible missions do not pass the destination system to any MissionActions, which normally pass the destination to any created Dialogs or ConversationPanels, which only use the destination system otherwise for passing to a MapDetailPanel that displays the special marker, meaning special markers will no longer be created for invisible missions.

## Testing Done
Created an invisible mission with an on offer conversation and opened the map during the conversation with and without this change. With this change, no special marker is created. Without this change, a special marker is created at the mission's destination.

## Save File
N/A