### PR TITLE
feat(UI): Add playtime tracker to Player Info Panel

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -493,6 +493,7 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		bright, Truncate::MIDDLE, true);
 	table.DrawTruncatedPair("net worth:", dim, Format::Credits(player.Accounts().NetWorth()) + " credits",
 		bright, Truncate::MIDDLE, true);
+	table.DrawTruncatedPair("time played:", dim, Format::PlayTime(player.GetPlayTime()), bright, Truncate::MIDDLE, true);
 	
 	// Determine the player's combat rating.
 	int combatLevel = log(max<int64_t>(1, player.GetCondition("combat rating")));

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -493,7 +493,8 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		bright, Truncate::MIDDLE, true);
 	table.DrawTruncatedPair("net worth:", dim, Format::Credits(player.Accounts().NetWorth()) + " credits",
 		bright, Truncate::MIDDLE, true);
-	table.DrawTruncatedPair("time played:", dim, Format::PlayTime(player.GetPlayTime()), bright, Truncate::MIDDLE, true);
+	table.DrawTruncatedPair("time played:", dim, Format::PlayTime(player.GetPlayTime()),
+		bright, Truncate::MIDDLE, true);
 	
 	// Determine the player's combat rating.
 	int combatLevel = log(max<int64_t>(1, player.GetCondition("combat rating")));


### PR DESCRIPTION
## Feature Details
This PR adds a playtime tracker to the Player Info Panel in-game, which counts up in real-time. This lets a player observe or screenshot their progress as a pilot (net worth, fleet size, licenses, etc.), and see how long it has taken them to accomplish that.

## UI Screenshots
![image](https://user-images.githubusercontent.com/4471575/125133093-ef6f5a80-e0ca-11eb-9c38-9245ccaf99b3.png)

## Testing Done
Verified nothing anomalous happened when the time ticks over to add new units (minutes, hours, days).

## Performance Impact
N/A
