### PR TITLE
feat(UI): Provide more detail/terminology for combat rating

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -507,9 +507,8 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		table.DrawGap(5);
 		
 		table.DrawTruncatedPair("rank:", dim,
-			to_string(combatLevel), dim, Truncate::MIDDLE, false);
-		table.DrawTruncatedPair("title:", dim,
-			combatRating, dim, Truncate::MIDDLE, false);
+			"(" + to_string(combatLevel) + ") - " + combatRating,
+			dim, Truncate::MIDDLE, false);
 		table.DrawTruncatedPair("experience:", dim,
 			Format::Number(combatExperience), dim, Truncate::MIDDLE, false);
 		bool maxRank = (combatRating == GameData::Rating("combat", combatLevel + 1));

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -512,12 +512,10 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 			combatRating, dim, Truncate::MIDDLE, false);
 		table.DrawTruncatedPair("experience:", dim,
 			Format::Number(combatExperience), dim, Truncate::MIDDLE, false);
-		if(combatRating == GameData::Rating("combat", combatLevel + 1))
-			table.DrawTruncatedPair("    for next rank:", dim,
-				"MAX", dim, Truncate::MIDDLE, false);
-		else
-			table.DrawTruncatedPair("    for next rank:", dim,
-				Format::Number(ceil(exp(combatLevel + 1))), dim, Truncate::MIDDLE, false);
+		bool maxRank = (combatRating == GameData::Rating("combat", combatLevel + 1));
+		table.DrawTruncatedPair("    for next rank:", dim,
+				maxRank ? "MAX" : Format::Number(ceil(exp(combatLevel + 1))),
+				dim, Truncate::MIDDLE, false);
 	}
 	
 	// Display the factors affecting piracy targeting the player.

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -495,7 +495,8 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		bright, Truncate::MIDDLE, true);
 	
 	// Determine the player's combat rating.
-	int combatLevel = log(max<int64_t>(1, player.GetCondition("combat rating")));
+	int combatExperience = player.GetCondition("combat rating");
+	int combatLevel = log(max<int64_t>(1, combatExperience));
 	const string &combatRating = GameData::Rating("combat", combatLevel);
 	if(!combatRating.empty())
 	{
@@ -505,8 +506,18 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		table.Advance();
 		table.DrawGap(5);
 		
-		table.DrawTruncatedPair(combatRating, dim,
-			"(" + to_string(combatLevel) + ")", dim, Truncate::MIDDLE, false);
+		table.DrawTruncatedPair("rank:", dim,
+			to_string(combatLevel), dim, Truncate::MIDDLE, false);
+		table.DrawTruncatedPair("title:", dim,
+			combatRating, dim, Truncate::MIDDLE, false);
+		table.DrawTruncatedPair("experience:", dim,
+			Format::Number(combatExperience), dim, Truncate::MIDDLE, false);
+		if(combatRating == GameData::Rating("combat", combatLevel + 1))
+			table.DrawTruncatedPair("    for next rank:", dim,
+				"MAX", dim, Truncate::MIDDLE, false);
+		else
+			table.DrawTruncatedPair("    for next rank:", dim,
+				Format::Number(ceil(exp(combatLevel + 1))), dim, Truncate::MIDDLE, false);
 	}
 	
 	// Display the factors affecting piracy targeting the player.


### PR DESCRIPTION
## Feature Details
This PR expands the combat rating section in the Player Info Panel. Since the start, combat rating on the game's end is a number, usually in the thousands when a player has fought enough, which is tracked as a condition for various missions or tribute. This is surfaced to the player, also as "Combat Rating", but as the log of the internal number. This results in a drastically different value than what is expected for missions, leading to lots of confusion when a guide says combat rating of 15 is required, and they go "Oh no, but I only have 3!", when they meet the requirement just fine.

With help from Derpy, this breaks down the terminology to the player more, and surfaces the internal tracking number:

- Combat Rank: The currently surfaced Combat Rating
- Combat Title: The string associated with the current Combat Rating
- Combat XP: The internal combat rating number
- XP required for next rank: Shows the next log rollover, for how much it'll take for the next rank. This becomes `MAX` once the maximum combat rating, as defined in data, is reached.

This should make it much clearer to people asking for help/reading guides, where it can be said "You'll need 15 combat XP, or be at about combat rank 3." It also lets someone who's interested in chasing a higher combat rating for bragging rights to have a better idea of where they're at.

Ideally, I'd prefer if we could replace `combat rating` in the data with `combat xp`, and maybe with an additional `combat rank` as a shorthand, but that would break plenty of data and plugins. Maybe combat rating could be kept for backwards compatibility, and combat XP/rank would be used going forward, but that's a separate issue/PR.

## UI Screenshots
![image](https://user-images.githubusercontent.com/4471575/125133923-2b56ef80-e0cc-11eb-8e1c-08e6fb49d63e.png)

## Testing Done
Seeing the combat rating properly roll over when a new rank is reached, and making sure MAX is displayed for max combat rating, depending on what's used in data.

## Performance Impact
N/A
