### PR TITLE
Fix licensing for the Large Cogeneration Module.

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -71,7 +71,8 @@ outfit "Small Cogeneration Module"
 
 outfit "Large Cogeneration Module"
 	category "Power"
-	licenses Coalition
+	licenses
+		Coalition
 	cost 799000
 	thumbnail "outfit/large cogeneration module"
 	"mass" 46


### PR DESCRIPTION
----------------------
**Fix (Outfit Licensing)**

## Summary
The Large Cogeneration Module's license definition wasn't in the right format, this just sets it so that it'll require the license to purchase it.

Issue brought up by Amacita on the discord server.