### PR TITLE
Draw any gun hardpoints under the ship (by default)

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -990,6 +990,7 @@ ship "Shooting Star"
 		"Floating Crystal"
 		"Tree Skeleton Key Stone"
 	gun 0 0
+		over
 	turret 0 0
 	turret 0 0
 	turret 0 0

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -26,17 +26,17 @@ using namespace std;
 
 
 // Add a gun hardpoint (fixed-direction weapon).
-void Armament::AddGunPort(const Point &point, const Angle &angle, bool isParallel, const Outfit *outfit)
+void Armament::AddGunPort(const Point &point, const Angle &angle, bool isParallel, bool isUnder, const Outfit *outfit)
 {
-	hardpoints.emplace_back(point, angle, false, isParallel, outfit);
+	hardpoints.emplace_back(point, angle, false, isParallel, isUnder, outfit);
 }
 
 
 
 // Add a turret hardpoint (omnidirectional weapon).
-void Armament::AddTurret(const Point &point, const Outfit *outfit)
+void Armament::AddTurret(const Point &point, bool isUnder, const Outfit *outfit)
 {
-	hardpoints.emplace_back(point, Angle(0.), true, false, outfit);
+	hardpoints.emplace_back(point, Angle(0.), true, false, isUnder, outfit);
 }
 
 

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -39,8 +39,8 @@ class Visual;
 class Armament {
 public:
 	// Add a gun or turret hard-point.
-	void AddGunPort(const Point &point, const Angle &angle, bool isParallel, const Outfit *outfit = nullptr);
-	void AddTurret(const Point &point, const Outfit *outfit = nullptr);
+	void AddGunPort(const Point &point, const Angle &angle, bool isParallel, bool isUnder, const Outfit *outfit = nullptr);
+	void AddTurret(const Point &point, bool isUnder, const Outfit *outfit = nullptr);
 	// This must be called after all the outfit data is loaded. If you add more
 	// of a given weapon than there are slots for it, the extras will not fire.
 	// But, the "gun ports" attribute should keep that from happening. To

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2241,8 +2241,8 @@ void Engine::AddSprites(const Ship &ship)
 	if(ship.IsSteering() && !ship.SteeringEnginePoints().empty())
 		DrawFlareSprites(ship, draw[calcTickTock], ship.SteeringEnginePoints(), ship.Attributes().SteeringFlareSprites(), Ship::EnginePoint::UNDER);
 	
-	drawObject(ship);
-	for(const Hardpoint &hardpoint : ship.Weapons())
+	auto drawHardpoint = [&drawObject, &ship](const Hardpoint &hardpoint) -> void
+	{
 		if(hardpoint.GetOutfit() && hardpoint.GetOutfit()->HardpointSprite().HasSprite())
 		{
 			Body body(
@@ -2253,6 +2253,15 @@ void Engine::AddSprites(const Ship &ship)
 				ship.Zoom());
 			drawObject(body);
 		}
+	};
+	
+	for(const Hardpoint &hardpoint : ship.Weapons())
+		if(!hardpoint.IsTurret())
+			drawHardpoint(hardpoint);
+	drawObject(ship);
+	for(const Hardpoint &hardpoint : ship.Weapons())
+		if(hardpoint.IsTurret())
+			drawHardpoint(hardpoint);
 	
 	if(ship.IsThrusting() && !ship.EnginePoints().empty())
 		DrawFlareSprites(ship, draw[calcTickTock], ship.EnginePoints(), ship.Attributes().FlareSprites(), Ship::EnginePoint::OVER);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2255,14 +2255,12 @@ void Engine::AddSprites(const Ship &ship)
 		}
 	};
 	
-	// Gun hardpoints are drawn under the ship, while turret hardpoints are drawn
-	// over it.
 	for(const Hardpoint &hardpoint : ship.Weapons())
-		if(!hardpoint.IsTurret())
+		if(hardpoint.IsUnder())
 			drawHardpoint(hardpoint);
 	drawObject(ship);
 	for(const Hardpoint &hardpoint : ship.Weapons())
-		if(hardpoint.IsTurret())
+		if(!hardpoint.IsUnder())
 			drawHardpoint(hardpoint);
 	
 	if(ship.IsThrusting() && !ship.EnginePoints().empty())

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2255,6 +2255,8 @@ void Engine::AddSprites(const Ship &ship)
 		}
 	};
 	
+	// Gun hardpoints are drawn under the ship, while turret hardpoints are drawn
+	// over it.
 	for(const Hardpoint &hardpoint : ship.Weapons())
 		if(!hardpoint.IsTurret())
 			drawHardpoint(hardpoint);

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -39,8 +39,8 @@ namespace {
 
 
 // Constructor.
-Hardpoint::Hardpoint(const Point &point, const Angle &baseAngle, bool isTurret, bool isParallel, const Outfit *outfit)
-	: outfit(outfit), point(point * .5), baseAngle(baseAngle), isTurret(isTurret), isParallel(isParallel)
+Hardpoint::Hardpoint(const Point &point, const Angle &baseAngle, bool isTurret, bool isParallel, bool isUnder, const Outfit *outfit)
+	: outfit(outfit), point(point * .5), baseAngle(baseAngle), isTurret(isTurret), isParallel(isParallel), isUnder(isUnder)
 {
 }
 
@@ -112,6 +112,13 @@ bool Hardpoint::IsTurret() const
 bool Hardpoint::IsParallel() const
 {
 	return isParallel;
+}
+
+
+
+bool Hardpoint::IsUnder() const
+{
+	return isUnder;
 }
 
 

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -30,7 +30,7 @@ class Visual;
 class Hardpoint {
 public:
 	// Constructor. Hardpoints may or may not specify what weapon is in them.
-	Hardpoint(const Point &point, const Angle &baseAngle, bool isTurret, bool isParallel, const Outfit *outfit = nullptr);
+	Hardpoint(const Point &point, const Angle &baseAngle, bool isTurret, bool isParallel, bool isUnder, const Outfit *outfit = nullptr);
 	
 	// Get the weapon installed in this hardpoint (or null if there is none).
 	const Outfit *GetOutfit() const;
@@ -45,8 +45,9 @@ public:
 	// Get the angle this weapon ought to point at for ideal gun harmonization.
 	Angle HarmonizedAngle() const;
 	// Shortcuts for querying weapon characteristics.
-	bool IsParallel() const;
 	bool IsTurret() const;
+	bool IsParallel() const;
+	bool IsUnder() const;
 	bool IsHoming() const;
 	bool IsAntiMissile() const;
 	bool CanAim() const;
@@ -95,6 +96,8 @@ private:
 	bool isTurret = false;
 	// Indicates if this hardpoint disallows converging (guns only).
 	bool isParallel = false;
+	// Indicates whether the hardpoint sprite is drawn under the ship.
+	bool isUnder = false;
 	
 	// Angle adjustment for convergence.
 	Angle angle;


### PR DESCRIPTION
**Feature:** This PR implements a feature described in #6062.

## Feature Details
This PR makes it so that any gun hardpoint with a hardpoint sprite will now have the sprite rendered under the ship (by default). Previously, all hardpoint sprites were rendered on top of the ship. While this makes sense for turret hardpoints, which hardpoint sprites were designed for, this doesn't make as much sense if you wanted a gun hardpoint sprite, which is not disallowed from being done.

~~In the future it may be that we allow any hardpoint sprite to arbitrarily be drawn above or below the ship regardless of hardpoint type, but I chose to just draw all gun hardpoint sprites under the ship for the sake of simplicity; all we need right now are gun hardpoints drawn under ships, and allowing turret hardpoints under the ship would introduce issues that would be rather complex to resolve.~~ I've gone ahead and allowed any gun/turret hardpoint to be defined as being drawn under or over, as we need to keep the ability for over drawn guns for the Shooting Star person ship, while under drawn guns are needed for #6062/#6114. While this includes the ability to create under drawn turrets, I still think that actually doing so has issues that need ironed out. I don't plan on tackling such issues in this PR though, so until we tackle them in the future, under drawn turrets shouldn't be in vanilla content.

One issue is that a turret hardpoint drawn under the ship could potentially rotate in such a way that the hardpoint is hidden, while the projectile for the turret would still be drawn on top of the ship, giving the appearance of projectiles coming from nowhere. Vital attempted to resolve this issue by creating two projectile draw layers, one drawn below all ships and one drawn above all ships. The main issue I have with this solution though is that it would allow projectiles to be hidden by ships. That is, an enemy ship could potentially fire at you with a projectile drawn below all ships, only for that projectile to be hidden by other ships friendly to it and suddenly come out from under another ship and hit you with little warning. An alternative solution that was discussed was to clip the projectile sprite from the origin up until it is no longer within the collision mask of the firing ship. This though has issues with ships with holes in them (as holes are not currently cut out of collision masks, so a projectile would be clipped despite being in a region that should make it visible) and with ship geometry where a projectile sprite leaves the collision mask of a ship but then reenters it. (The following image shows an example of this, with the red outlines being a ship's collision mask, the blue square being the hardpoint, and the green lines being projectiles. The bottom-right projectile leaves the collision mask but then reenters it; how would such a projectile be clipped?)
![image](https://user-images.githubusercontent.com/17688683/125202381-3aeb4b00-e228-11eb-877f-a733752d507e.png)

## Screenshots
The following image shows nuclear missiles with hardpoint sprites. Notice how the nuke hardpoint sprites render under the ships, while the turret sprites are still rendered over the ships.
![image](https://user-images.githubusercontent.com/17688683/125202103-f612e480-e226-11eb-8841-4943a077ac2f.png)

## Usage Examples
Just define a hardpoint sprite for a gun as you would have before and it will automatically be drawn under the ship.
New over/under keywords can also be added to weapon hardpoint definitions, similar to how engine and bay hardpoint definitions work.
```
	# guns are under by default
	gun x y
		over
	# turrets are over by default
	turret x y
		under
```

## Testing Done
See screenshots.

## Performance Impact
N/A
