### PR TITLE
fix(UI): Adjusted combat rank text to not overflow

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -509,7 +509,7 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		table.DrawGap(5);
 		
 		table.DrawTruncatedPair("rank:", dim,
-			"(" + to_string(combatLevel) + ") - " + combatRating,
+			to_string(combatLevel) + " - " + combatRating,
 			dim, Truncate::MIDDLE, false);
 		table.DrawTruncatedPair("experience:", dim,
 			Format::Number(combatExperience), dim, Truncate::MIDDLE, false);


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4471575/125529814-eb069482-1fc8-4e60-be51-53ac7038d65b.png)

Some later combat rating titles are very long, and caused the new UI to overflow. This PR drops the parenthesis, which makes the longest title/number combination fit.