### PR TITLE
refactor(internal): Force authors to consciously decide the importance level of a Message

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -160,14 +160,14 @@ namespace {
 		{
 			for(Ship *ship : toDeploy)
 				ship->SetDeployOrder(true);
-			Messages::Add("Deployed " + to_string(toDeploy.size()) + " carried ships.");
+			Messages::Add("Deployed " + to_string(toDeploy.size()) + " carried ships.", Messages::Importance::High);
 		}
 		// Otherwise, instruct the carried ships to return to their berth.
 		else if(!toRecall.empty())
 		{
 			for(Ship *ship : toRecall)
 				ship->SetDeployOrder(false);
-			Messages::Add("Recalled " + to_string(toRecall.size()) + " carried ships");
+			Messages::Add("Recalled " + to_string(toRecall.size()) + " carried ships", Messages::Importance::High);
 		}
 	}
 	
@@ -349,7 +349,7 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 		canceled |= (autoPilot.Has(Command::LAND) && !activeCommands.Has(Command::LAND));
 		canceled |= (autoPilot.Has(Command::BOARD) && !activeCommands.Has(Command::BOARD));
 		if(canceled)
-			Messages::Add("Disengaging autopilot.");
+			Messages::Add("Disengaging autopilot.", Messages::Importance::High);
 		autoPilot.Clear();
 	}
 	
@@ -358,7 +358,7 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 		return;
 	
 	if(activeCommands.Has(Command::STOP))
-		Messages::Add("Coming to a stop.");
+		Messages::Add("Coming to a stop.", Messages::Importance::High);
 	
 	// Only toggle the "cloak" command if one of your ships has a cloaking device.
 	if(activeCommands.Has(Command::CLOAK))
@@ -366,7 +366,8 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 			if(!it->IsParked() && it->Attributes().Get("cloak"))
 			{
 				isCloaking = !isCloaking;
-				Messages::Add(isCloaking ? "Engaging cloaking device." : "Disengaging cloaking device.");
+				Messages::Add(isCloaking ? "Engaging cloaking device." : "Disengaging cloaking device."
+					, Messages::Importance::High);
 				break;
 			}
 	
@@ -664,7 +665,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 							toDump -= dumped;
 						}
 					Messages::Add(gov->GetName() + " " + it->Noun() + " \"" + it->Name()
-						+ "\": Please, just take my cargo and leave me alone.");
+						+ "\": Please, just take my cargo and leave me alone.", Messages::Importance::High);
 					threshold = (1. - health) + .1;
 				}
 			}
@@ -3192,7 +3193,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 					message += (oxfordComma ? ", and " : " and ");
 			}
 			message += " in the system you are jumping to.";
-			Messages::Add(message);
+			Messages::Add(message, Messages::Importance::High);
 		}
 		// If any destination was found, find the corresponding stellar object
 		// and set it as your ship's target planet.
@@ -3418,7 +3419,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 				message = "Landing on " + target->Name() + ".";
 		}
 		if(!message.empty())
-			Messages::Add(message);
+			Messages::Add(message, Messages::Importance::High);
 	}
 	else if(activeCommands.Has(Command::JUMP))
 	{
@@ -3447,7 +3448,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 		{
 			// The player is guaranteed to have a travel plan for isWormhole to be true.
 			Messages::Add("Landing on a local wormhole to navigate to the "
-					+ player.TravelPlan().back()->Name() + " system.");
+					+ player.TravelPlan().back()->Name() + " system.", Messages::Importance::High);
 		}
 		if(ship.GetTargetSystem() && !isWormhole)
 		{
@@ -3455,7 +3456,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 			if(player.KnowsName(*ship.GetTargetSystem()))
 				name = ship.GetTargetSystem()->Name();
 			
-			Messages::Add("Engaging autopilot to jump to the " + name + " system.");
+			Messages::Add("Engaging autopilot to jump to the " + name + " system.", Messages::Importance::High);
 		}
 	}
 	else if(activeCommands.Has(Command::SCAN))
@@ -3537,7 +3538,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 		const Planet *planet = player.TravelDestination();
 		if(planet && planet->IsInSystem(ship.GetSystem()) && planet->IsAccessible(&ship))
 		{
-			Messages::Add("Autopilot: landing on " + planet->Name() + ".");
+			Messages::Add("Autopilot: landing on " + planet->Name() + ".", Messages::Importance::High);
 			autoPilot |= Command::LAND;
 			ship.SetTargetStellar(ship.GetSystem()->FindStellar(planet));
 		}
@@ -3571,19 +3572,19 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 	{
 		if(!ship.Attributes().Get("hyperdrive") && !ship.Attributes().Get("jump drive"))
 		{
-			Messages::Add("You do not have a hyperdrive installed.");
+			Messages::Add("You do not have a hyperdrive installed.", Messages::Importance::High);
 			autoPilot.Clear();
 			Audio::Play(Audio::Get("fail"));
 		}
 		else if(!ship.JumpFuel(ship.GetTargetSystem()))
 		{
-			Messages::Add("You cannot jump to the selected system.");
+			Messages::Add("You cannot jump to the selected system.", Messages::Importance::High);
 			autoPilot.Clear();
 			Audio::Play(Audio::Get("fail"));
 		}
 		else if(!ship.JumpsRemaining() && !ship.IsEnteringHyperspace())
 		{
-			Messages::Add("You do not have enough fuel to make a hyperspace jump.");
+			Messages::Add("You do not have enough fuel to make a hyperspace jump.", Messages::Importance::High);
 			autoPilot.Clear();
 			Audio::Play(Audio::Get("fail"));
 		}
@@ -3852,14 +3853,14 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 			return;
 	}
 	if(hasMismatch)
-		Messages::Add(who + description);
+		Messages::Add(who + description, Messages::Importance::High);
 	else
 	{
 		// Clear all the orders for these ships.
 		if(!isValidTarget)
-			Messages::Add(who + "unable to and no longer " + description);
+			Messages::Add(who + "unable to and no longer " + description, Messages::Importance::High);
 		else
-			Messages::Add(who + "no longer " + description);
+			Messages::Add(who + "no longer " + description, Messages::Importance::High);
 		
 		for(const Ship *ship : ships)
 			orders.erase(ship);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -165,7 +165,7 @@ namespace {
 		else
 			tag = ship->ModelName() + " (" + gov + "): ";
 		
-		Messages::Add(tag + message);
+		Messages::Add(tag + message, Messages::Importance::High);
 	}
 	
 	void DrawFlareSprites(const Ship &ship, DrawList &draw, const vector<Ship::EnginePoint> &enginePoints, const vector<pair<Body, int>> &flareSprites, uint8_t side)
@@ -619,7 +619,7 @@ void Engine::Step(bool isActive)
 	}
 	
 	if(flagship && flagship->IsOverheated())
-		Messages::Add("Your ship has overheated.");
+		Messages::Add("Your ship has overheated.", Messages::Importance::High);
 	
 	// Clear the HUD information from the previous frame.
 	info = Information();
@@ -1132,7 +1132,7 @@ void Engine::EnterSystem()
 	
 	Messages::Add("Entering the " + system->Name() + " system on "
 		+ today.ToString() + (system->IsInhabited(flagship) ?
-			"." : ". No inhabited planets detected."));
+			"." : ". No inhabited planets detected."), Messages::Importance::High);
 	
 	// Preload landscapes and determine if the player used a wormhole.
 	// (It is allowed for a wormhole's exit point to have no sprite.)
@@ -1219,7 +1219,7 @@ void Engine::EnterSystem()
 				{
 					raidFleet->Place(*system, newShips);
 					Messages::Add("Your fleet has attracted the interest of a "
-							+ raidGovernment->GetName() + " raiding party.");
+							+ raidGovernment->GetName() + " raiding party.", Messages::Importance::High);
 				}
 	}
 	
@@ -1237,8 +1237,8 @@ void Engine::EnterSystem()
 	// since the new player ships can make at most four jumps before landing.
 	if(today <= player.StartData().GetDate() + 4)
 	{
-		Messages::Add(GameData::HelpMessage("basics 1"));
-		Messages::Add(GameData::HelpMessage("basics 2"));
+		Messages::Add(GameData::HelpMessage("basics 1"), Messages::Importance::High);
+		Messages::Add(GameData::HelpMessage("basics 2"), Messages::Importance::High);
 	}
 }
 
@@ -1816,11 +1816,11 @@ void Engine::HandleMouseClicks()
 					{
 						if(!planet->CanLand(*flagship))
 							Messages::Add("The authorities on " + planet->Name()
-									+ " refuse to let you land.");
+									+ " refuse to let you land.", Messages::Importance::High);
 						else
 						{
 							activeCommands |= Command::LAND;
-							Messages::Add("Landing on " + planet->Name() + ".");
+							Messages::Add("Landing on " + planet->Name() + ".", Messages::Importance::High);
 						}
 					}
 					else
@@ -2106,7 +2106,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 		int free = collector->Cargo().Free();
 		message += " (" + to_string(free) + (free == 1 ? " ton" : " tons");
 		message += " of free space remaining.)";
-		Messages::Add(message);
+		Messages::Add(message, Messages::Importance::High);
 	}
 }
 

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -288,13 +288,15 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 			{
 				ship->GetGovernment()->Bribe();
 				Messages::Add("You bribed a " + ship->GetGovernment()->GetName() + " ship "
-					+ Format::Credits(bribe) + " credits to refrain from attacking you today.");
+					+ Format::Credits(bribe) + " credits to refrain from attacking you today."
+						, Messages::Importance::High);
 			}
 			else
 			{
 				planet->Bribe();
 				Messages::Add("You bribed the authorities on " + planet->Name() + " "
-					+ Format::Credits(bribe) + " credits to permit you to land.");
+					+ Format::Credits(bribe) + " credits to permit you to land."
+						, Messages::Importance::High);
 			}
 			
 			player.Accounts().AddCredits(-bribe);

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -212,7 +212,8 @@ bool MainPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	else if(command.Has(Command::AMMO))
 	{
 		Preferences::ToggleAmmoUsage();
-		Messages::Add("Your escorts will now expend ammo: " + Preferences::AmmoUsage() + ".");
+		Messages::Add("Your escorts will now expend ammo: " + Preferences::AmmoUsage() + "."
+			, Messages::Importance::High);
 	}
 	else if((key == SDLK_MINUS || key == SDLK_KP_MINUS) && !command)
 		Preferences::ZoomViewOut();
@@ -406,9 +407,9 @@ bool MainPanel::ShowHailPanel()
 		target.reset();
 	
 	if(flagship->IsEnteringHyperspace())
-		Messages::Add("Unable to send hail: your flagship is entering hyperspace.");
+		Messages::Add("Unable to send hail: your flagship is entering hyperspace.", Messages::Importance::High);
 	else if(flagship->Cloaking() == 1.)
-		Messages::Add("Unable to send hail: your flagship is cloaked.");
+		Messages::Add("Unable to send hail: your flagship is cloaked.", Messages::Importance::High);
 	else if(target)
 	{
 		// If the target is out of system, always report a generic response
@@ -416,9 +417,10 @@ bool MainPanel::ShowHailPanel()
 		// not. If it's in system and jumping, report that.
 		if(target->Zoom() < 1. || target->IsDestroyed() || target->GetSystem() != player.GetSystem()
 				|| target->Cloaking() == 1.)
-			Messages::Add("Unable to hail target " + target->Noun() + ".");
+			Messages::Add("Unable to hail target " + target->Noun() + ".", Messages::Importance::High);
 		else if(target->IsEnteringHyperspace())
-			Messages::Add("Unable to send hail: " + target->Noun() + " is entering hyperspace.");
+			Messages::Add("Unable to send hail: " + target->Noun() + " is entering hyperspace."
+				, Messages::Importance::High);
 		else
 		{
 			GetUI()->Push(new HailPanel(player, target));
@@ -429,11 +431,11 @@ bool MainPanel::ShowHailPanel()
 	{
 		const Planet *planet = flagship->GetTargetStellar()->GetPlanet();
 		if(!planet)
-			Messages::Add("Unable to send hail.");
+			Messages::Add("Unable to send hail.", Messages::Importance::High);
 		else if(planet->IsWormhole())
 		{
 			static const Phrase *wormholeHail = GameData::Phrases().Get("wormhole hail");
-			Messages::Add(wormholeHail->Get());
+			Messages::Add(wormholeHail->Get(), Messages::Importance::High);
 		}
 		else if(planet->IsInhabited())
 		{
@@ -441,10 +443,11 @@ bool MainPanel::ShowHailPanel()
 			return true;
 		}
 		else
-			Messages::Add("Unable to send hail: " + planet->Noun() + " is not inhabited.");
+			Messages::Add("Unable to send hail: " + planet->Noun() + " is not inhabited."
+				, Messages::Importance::High);
 	}
 	else
-		Messages::Add("Unable to send hail: no target selected.");
+		Messages::Add("Unable to send hail: no target selected.", Messages::Importance::High);
 	
 	return false;
 }

--- a/source/Messages.cpp
+++ b/source/Messages.cpp
@@ -25,11 +25,11 @@ namespace {
 
 
 
-// Add a message to the list.
-void Messages::Add(const string &message, bool isImportant)
+// Add a message to the list along with its level of importance
+void Messages::Add(const string &message, Importance importance)
 {
 	lock_guard<mutex> lock(incomingMutex);
-	incoming.emplace_back(message, isImportant);
+	incoming.emplace_back(message, importance == Importance::High);
 }
 
 

--- a/source/Messages.cpp
+++ b/source/Messages.cpp
@@ -19,7 +19,7 @@ using namespace std;
 namespace {
 	mutex incomingMutex;
 	
-	vector<pair<string, bool>> incoming;
+	vector<pair<string, Messages::Importance>> incoming;
 	vector<Messages::Entry> list;
 }
 
@@ -29,7 +29,7 @@ namespace {
 void Messages::Add(const string &message, Importance importance)
 {
 	lock_guard<mutex> lock(incomingMutex);
-	incoming.emplace_back(message, importance == Importance::High);
+	incoming.emplace_back(message, importance);
 }
 
 
@@ -42,14 +42,14 @@ const vector<Messages::Entry> &Messages::Get(int step)
 	lock_guard<mutex> lock(incomingMutex);
 	
 	// Load the incoming messages.
-	for(const pair<string, bool> &item : incoming)
+	for(const pair<string, Importance> &item : incoming)
 	{
 		const string &message = item.first;
-		bool isImportant = item.second;
+		Importance importance = item.second;
 		
 		// If this message is not important and it is already being shown in the
 		// list, ignore it.
-		if(!isImportant)
+		if(importance == Importance::Low)
 		{
 			bool skip = false;
 			for(const Messages::Entry &entry : list)
@@ -67,7 +67,7 @@ const vector<Messages::Entry> &Messages::Get(int step)
 			// limit how many of them appear at once.
 			it->step -= 60;
 			// Also erase messages that have reached the end of their lifetime.
-			if((isImportant && it->message == message) || it->step < step - 1000)
+			if((importance != Importance::Low && it->message == message) || it->step < step - 1000)
 				it = list.erase(it);
 			else
 				++it;

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -34,7 +34,7 @@ public:
 		std::string message;
 	};
     
-    enum class Importance {
+    enum class Importance : uint_least8_t {
         High,
         Low
     };

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 
 

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -33,10 +33,15 @@ public:
 		int step;
 		std::string message;
 	};
+    
+    enum class Importance {
+        High,
+        Low
+    };
 	
 public:
-	// Add a message to the list.
-	static void Add(const std::string &message, bool isImportant = true);
+	// Add a message to the list along with its level of importance
+	static void Add(const std::string &message, Importance importance);
 	
 	// Get the messages for the given game step. Any messages that are too old
 	// will be culled out, and new ones that have just been added will have

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1023,7 +1023,7 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 		{
 			hasFailed = true;
 			if(isVisible)
-				Messages::Add(message + "Mission failed: \"" + displayName + "\".");
+				Messages::Add(message + "Mission failed: \"" + displayName + "\".", Messages::Importance::High);
 		}
 	}
 	

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -38,7 +38,8 @@ namespace {
 			return;
 		
 		player.BuyShip(model, name, true);
-		Messages::Add("The " + model->ModelName() + " \"" + name + "\" was added to your fleet.");
+		Messages::Add("The " + model->ModelName() + " \"" + name + "\" was added to your fleet."
+			, Messages::Importance::High);
 	}
 	
 	void DoGift(PlayerInfo &player, const Outfit *outfit, int count, UI *ui)
@@ -113,7 +114,7 @@ namespace {
 			message += "cargo hold.";
 		else
 			message += "flagship.";
-		Messages::Add(message);
+		Messages::Add(message, Messages::Importance::High);
 	}
 	
 	int CountInCargo(const Outfit *outfit, const PlayerInfo &player)

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -434,7 +434,7 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, bool isVisible)
 	
 	// Check if the success status has changed. If so, display a message.
 	if(isVisible && !alreadyFailed && HasFailed())
-		Messages::Add("Mission failed.");
+		Messages::Add("Mission failed.", Messages::Importance::High);
 	else if(ui && !alreadySucceeded && HasSucceeded(player.GetSystem(), false))
 	{
 		// If "completing" this NPC displays a conversation, reference

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -547,7 +547,8 @@ void PlayerInfo::IncrementDate()
 	// Check if any missions have failed because of deadlines.
 	for(Mission &mission : missions)
 		if(mission.CheckDeadline(date) && mission.IsVisible())
-			Messages::Add("You failed to meet the deadline for the mission \"" + mission.Name() + "\".");
+			Messages::Add("You failed to meet the deadline for the mission \"" + mission.Name() + "\"."
+				, Messages::Importance::High);
 	
 	// Check what salaries and tribute the player receives.
 	int64_t total[2] = {0, 0};
@@ -568,7 +569,7 @@ void PlayerInfo::IncrementDate()
 		if(total[1])
 			message += Format::Credits(total[1]) + " credits in tribute";
 		message += ".";
-		Messages::Add(message);
+		Messages::Add(message, Messages::Importance::High);
 		accounts.AddCredits(total[0] + total[1]);
 	}
 	
@@ -582,7 +583,7 @@ void PlayerInfo::IncrementDate()
 	// summarizes the payments that were made.
 	string message = accounts.Step(assets, Salaries(), Maintenance());
 	if(!message.empty())
-		Messages::Add(message);
+		Messages::Add(message, Messages::Importance::High);
 	
 	// Reset the reload counters for all your ships.
 	for(const shared_ptr<Ship> &ship : ships)
@@ -1219,7 +1220,7 @@ void PlayerInfo::Land(UI *ui)
 			flagship->AddCrew(added);
 			Messages::Add("You hire " + to_string(added) + (added == 1
 					? " extra crew member to fill your now-empty bunk."
-					: " extra crew members to fill your now-empty bunks."));
+					: " extra crew members to fill your now-empty bunks."), Messages::Importance::High);
 		}
 	}
 	
@@ -1322,7 +1323,8 @@ bool PlayerInfo::TakeOff(UI *ui)
 		if(extra)
 		{
 			flagship->AddCrew(-extra);
-			Messages::Add("You fired " + to_string(extra) + " crew members to free up bunks for passengers.");
+			Messages::Add("You fired " + to_string(extra) + " crew members to free up bunks for passengers."
+				, Messages::Importance::High);
 			flagship->Cargo().SetBunks(flagship->Attributes().Get("bunks") - flagship->Crew());
 			cargo.TransferAll(flagship->Cargo());
 		}
@@ -1332,7 +1334,8 @@ bool PlayerInfo::TakeOff(UI *ui)
 	if(extra > 0)
 	{
 		flagship->AddCrew(-extra);
-		Messages::Add("You fired " + to_string(extra) + " crew members because you have no bunks for them.");
+		Messages::Add("You fired " + to_string(extra) + " crew members because you have no bunks for them."
+			, Messages::Importance::High);
 		flagship->Cargo().SetBunks(flagship->Attributes().Get("bunks") - flagship->Crew());
 	}
 	
@@ -1374,7 +1377,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 		{
 			// The remaining uncarried ships are launched alongside the player.
 			string message = (uncarried > 1) ? "Some escorts were" : "One escort was";
-			Messages::Add(message + " unable to dock with a carrier.");
+			Messages::Add(message + " unable to dock with a carrier.", Messages::Importance::High);
 		}
 	}
 	
@@ -1387,7 +1390,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 		{
 			if(it.first->IsVisible())
 				Messages::Add("Mission \"" + it.first->Name()
-					+ "\" failed because you do not have space for the cargo.");
+					+ "\" failed because you do not have space for the cargo.", Messages::Importance::High);
 			missionsToRemove.push_back(it.first);
 		}
 	for(const auto &it : cargo.PassengerList())
@@ -1395,7 +1398,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 		{
 			if(it.first->IsVisible())
 				Messages::Add("Mission \"" + it.first->Name()
-					+ "\" failed because you do not have enough passenger bunks free.");
+					+ "\" failed because you do not have enough passenger bunks free.", Messages::Importance::High);
 			missionsToRemove.push_back(it.first);
 			
 		}
@@ -1453,7 +1456,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 			out << " (for a profit of " << (income - totalBasis) << " credits).";
 		else
 			out << ".";
-		Messages::Add(out.str());
+		Messages::Add(out.str(), Messages::Importance::High);
 	}
 	
 	return true;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1693,9 +1693,11 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	{
 		pilotError = 30;
 		if(parent.lock() || !isYours)
-			Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it.", false);
+			Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it."
+				, Messages::Importance::Low);
 		else
-			Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it.", false);
+			Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it."
+				, Messages::Importance::Low);
 	}
 	else
 		pilotOkay = 30;
@@ -1851,7 +1853,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 					// boarding sequence (including locking on to the ship) but
 					// not to actually board, if they are cloaked.
 					if(isYours)
-						Messages::Add("You cannot board a ship while cloaked.");
+						Messages::Add("You cannot board a ship while cloaked.", Messages::Importance::High);
 				}
 				else
 				{
@@ -1860,7 +1862,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 					if(isEnemy && Random::Real() < target->Attributes().Get("self destruct"))
 					{
 						Messages::Add("The " + target->ModelName() + " \"" + target->Name()
-							+ "\" has activated its self-destruct mechanism.");
+							+ "\" has activated its self-destruct mechanism.", Messages::Importance::High);
 						GetTargetShip()->SelfDestruct();
 					}
 					else
@@ -2271,22 +2273,24 @@ int Ship::Scan()
 	if(startedScanning && isYours)
 	{
 		if(!target->Name().empty())
-			Messages::Add("Attempting to scan the " + target->Noun() + " \"" + target->Name() + "\".", false);
+			Messages::Add("Attempting to scan the " + target->Noun() + " \"" + target->Name() + "\"."
+				, Messages::Importance::Low);
 		else
-			Messages::Add("Attempting to scan the selected " + target->Noun() + ".", false);
+			Messages::Add("Attempting to scan the selected " + target->Noun() + "."
+				, Messages::Importance::Low);
 	}
 	else if(startedScanning && target->isYours)
 		Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-			+ Name() + "\" is attempting to scan you.", false);
+			+ Name() + "\" is attempting to scan you.", Messages::Importance::Low);
 	
 	if(target->isYours && !isYours)
 	{
 		if(result & ShipEvent::SCAN_CARGO)
 			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-					+ Name() + "\" completed its scan of your cargo.");
+					+ Name() + "\" completed its scan of your cargo.", Messages::Importance::High);
 		if(result & ShipEvent::SCAN_OUTFITS)
 			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-					+ Name() + "\" completed its scan of your outfits.");
+					+ Name() + "\" completed its scan of your outfits.", Messages::Importance::High);
 	}
 	
 	return result;

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -708,7 +708,8 @@ void ShipInfoPanel::Dump()
 	
 	info.Update(**shipIt, player.FleetDepreciation(), player.GetDate().DaysSinceEpoch());
 	if(loss)
-		Messages::Add("You jettisoned " + Format::Credits(loss) + " credits worth of cargo.");
+		Messages::Add("You jettisoned " + Format::Credits(loss) + " credits worth of cargo."
+			, Messages::Importance::High);
 }
 
 
@@ -724,7 +725,8 @@ void ShipInfoPanel::DumpPlunder(int count)
 		info.Update(**shipIt, player.FleetDepreciation(), player.GetDate().DaysSinceEpoch());
 		
 		if(loss)
-			Messages::Add("You jettisoned " + Format::Credits(loss) + " credits worth of cargo.");
+			Messages::Add("You jettisoned " + Format::Credits(loss) + " credits worth of cargo."
+				, Messages::Importance::High);
 	}
 }
 
@@ -743,7 +745,8 @@ void ShipInfoPanel::DumpCommodities(int count)
 		info.Update(**shipIt, player.FleetDepreciation(), player.GetDate().DaysSinceEpoch());
 		
 		if(loss)
-			Messages::Add("You jettisoned " + Format::Credits(loss) + " credits worth of cargo.");
+			Messages::Add("You jettisoned " + Format::Credits(loss) + " credits worth of cargo."
+				, Messages::Importance::High);
 	}
 }
 

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -77,7 +77,7 @@ TradingPanel::~TradingPanel()
 		else
 			message += "for a total profit of " + Format::Credits(profit) + " credits.";
 		
-		Messages::Add(message);
+		Messages::Add(message, Messages::Importance::High);
 	}
 }
 


### PR DESCRIPTION
Changed the second argument to Messages::Add from an optional bool called isImportant that defaulted to _true_ to being a required enum class with two options, Low, which maps to what was previously 'false', and High, which maps to what the default case was. Whilst the interface now effectively allows the addition of new importance levels in future, the underlying data type in the implementation is still a bool. No changes were made to the behavior of the code; the ONLY difference is that it is now explicit in the code, to force authors to make a more conscious decision on whether their message should be considered High importance or Low. Future work, IF ANY, could entail revisiting the Importance::High cases (which is almost every case), or adding additional importance levels, or adding more UI / Audio impact to importance levels.

----------------------
**Code Enhancement**

## Summary
One pain I experienced while playing the game was that important messages like escorts getting destroyed were getting lost. I noticed that there is already an Open issue about it from 4 years ago (#3361). In that issue, one comment suggests adding a priority concept to Messages. So I decided to look at the code, and I found that there is already a boolean called isImportant in the Messages::Add method, however, it is defaulted to 'true', and pretty much every application of the Add method was using the default. On reviewing them, I felt that most likely the authors of those instances perhaps did not consciously choose to mark them as important. This PR is NOT about fixing those concerning cases. Instead, this PR is purely about making sure that in future if any author decides to add a Message, they must be required to make a conscious decision on how important their message is. As such, the parameter is no longer optional. Furthermore, the parameter is now an enum class, ensuring that the usage of the API will make the intended importance crystal clear. It also is now High / Low instead of True / False, just in-case in future someone decides to add more levels.

Note that this is my first PR. I've tried to follow the style guide (namely making sure that I wrap at 120). I've seen the contribution.md file. But if I missed anything or if you don't like anything, let me know; happy to change.

## Usage Examples
`Messages::Add("Disengaging autopilot.", Messages::Importance::High);`

## Testing Done
Played the game and tested both a High and Low importance message. They work, though they do not seem visually different, presumably because the game has no visual impact of message importance.

## Performance Impact
N/A
