### PR TITLE
Fix a bug where causes an undefined behavior.

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -233,13 +233,13 @@ void MissionPanel::Draw()
 		Screen::TopLeft() + Point(0., -availableScroll),
 		"Missions available here:",
 		available.size());
-	DrawList(available, pos);
+	DrawList(available, pos, availableIt);
 	
 	pos = DrawPanel(
 		Screen::TopRight() + Point(-SIDE_WIDTH, -acceptedScroll),
 		"Your current missions:",
 		AcceptedVisible());
-	DrawList(accepted, pos);
+	DrawList(accepted, pos, acceptedIt);
 	
 	// Now that the mission lists and map elements are drawn, draw the top-most UI elements.
 	DrawKey();
@@ -663,7 +663,8 @@ Point MissionPanel::DrawPanel(Point pos, const string &label, int entries) const
 
 
 
-Point MissionPanel::DrawList(const list<Mission> &list, Point pos) const
+Point MissionPanel::DrawList(const list<Mission> &list, Point pos,
+	const std::list<Mission>::const_iterator &selectIt) const
 {
 	const Font &font = FontSet::Get(14);
 	const Color &highlight = *GameData::Colors().Get("faint");
@@ -678,7 +679,7 @@ Point MissionPanel::DrawList(const list<Mission> &list, Point pos) const
 		
 		pos.Y() += 20.;
 		
-		bool isSelected = (it == availableIt || it == acceptedIt);
+		bool isSelected = it == selectIt;
 		if(isSelected)
 			FillShader::Fill(
 				pos + Point(.5 * SIDE_WIDTH - 5., 8.),

--- a/source/MissionPanel.h
+++ b/source/MissionPanel.h
@@ -57,7 +57,8 @@ private:
 	// Draw the backgrounds for the "available jobs" and accepted missions/jobs lists.
 	Point DrawPanel(Point pos, const std::string &label, int entries) const;
 	// Draw the display names of the given missions, using the reference point.
-	Point DrawList(const std::list<Mission> &list, Point pos) const;
+	Point DrawList(const std::list<Mission> &list, Point pos,
+		const std::list<Mission>::const_iterator &selectIt) const;
 	void DrawMissionInfo();
 	
 	bool CanAccept() const;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue causes an undefined behavior in Job Board.

It's undefined behavior to compare iterators that refer to elements of different containers. (§ 24.2.5 [forward.iterators#2])

The debug library on GCC (activated by -D_GLIBCXX_DEBUG) aborts the program when you enter Job Board from the planet panel.

## Fix Details
This PR makes the function receive a parameter for the comparison.

## Testing Done
I added option -D_GLIBCXX_DEBUG, and entered the Job Board.