### PR TITLE
Fix flickering in the shop panel when going up with nothing selected.

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -1118,7 +1118,7 @@ void ShopPanel::MainUp()
 	if(it == zones.end())
 	{
 		--it;
-		mainScroll = max(0., mainScroll + it->Center().Y() + start->Center().Y());
+		mainScroll = max(0., min(maxMainScroll, mainScroll + it->Center().Y() + start->Center().Y()));
 		selectedShip = it->GetShip();
 		selectedOutfit = it->GetOutfit();
 		return;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -1047,7 +1047,7 @@ void ShopPanel::MainLeft()
 	if(it == zones.end())
 	{
 		--it;
-		mainScroll += it->Center().Y() - start->Center().Y();
+		mainScroll = maxMainScroll;
 		selectedShip = it->GetShip();
 		selectedOutfit = it->GetOutfit();
 		return;
@@ -1083,6 +1083,7 @@ void ShopPanel::MainRight()
 	// Special case: nothing is selected. Select the first item.
 	if(it == zones.end())
 	{
+		// Already at mainScroll = 0, no scrolling needed.
 		selectedShip = start->GetShip();
 		selectedOutfit = start->GetOutfit();
 		return;
@@ -1100,6 +1101,8 @@ void ShopPanel::MainRight()
 	{
 		if(it->Center().Y() != previousY)
 			mainScroll += it->Center().Y() - previousY - mainDetailHeight;
+		if(mainScroll > maxMainScroll)
+			mainScroll = maxMainScroll;
 		selectedShip = it->GetShip();
 		selectedOutfit = it->GetOutfit();
 	}
@@ -1118,7 +1121,7 @@ void ShopPanel::MainUp()
 	if(it == zones.end())
 	{
 		--it;
-		mainScroll = max(0., min(maxMainScroll, mainScroll + it->Center().Y() + start->Center().Y()));
+		mainScroll = maxMainScroll;
 		selectedShip = it->GetShip();
 		selectedOutfit = it->GetOutfit();
 		return;
@@ -1159,6 +1162,7 @@ void ShopPanel::MainDown()
 	// Special case: nothing is selected. Select the first item.
 	if(it == zones.end())
 	{
+		// Already at mainScroll = 0, no scrolling needed.
 		selectedShip = start->GetShip();
 		selectedOutfit = start->GetOutfit();
 		return;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -1118,7 +1118,7 @@ void ShopPanel::MainUp()
 	if(it == zones.end())
 	{
 		--it;
-		mainScroll = max(0., mainScroll + it->Center().Y() - start->Center().Y());
+		mainScroll = max(0., mainScroll + it->Center().Y() + start->Center().Y());
 		selectedShip = it->GetShip();
 		selectedOutfit = it->GetOutfit();
 		return;


### PR DESCRIPTION
**Bugfix:** This PR fixes #5966

## Fix Details

The wrong sign was used when calculating the amount of scroll to apply when nothing is selected and the Up key is pressed. This resulted in way too much scroll - the last entry moved to the very top of the screen and then in the next frame got immediately moved back down - which caused the flickering.

## Testing Done

Verified that the scenario in the issues is fixed and that this didn't introduce any other bugs.