### PR TITLE
Apply swizzle when departing to any carried ships too.

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1155,7 +1155,17 @@ void Ship::Place(Point position, Point velocity, Angle angle)
 	targetShip.reset();
 	shipToAssist.reset();
 	if(government)
-		SetSwizzle(customSwizzle >= 0 ? customSwizzle : government->GetSwizzle());
+	{
+		auto swizzle = customSwizzle >= 0 ? customSwizzle : government->GetSwizzle();
+		SetSwizzle(swizzle);
+
+		// Set swizzle for any carried ships too.
+		for(const auto &bay : bays)
+		{
+			if(bay.ship)
+				bay.ship->SetSwizzle(swizzle);
+		}
+	}
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1163,7 +1163,7 @@ void Ship::Place(Point position, Point velocity, Angle angle)
 		for(const auto &bay : bays)
 		{
 			if(bay.ship)
-				bay.ship->SetSwizzle(swizzle);
+				bay.ship->SetSwizzle(bay.ship->customSwizzle >= 0 ? bay.ship->customSwizzle : swizzle);
 		}
 	}
 }


### PR DESCRIPTION
**Bugfix:** This PR fixes #5936 

## Fix Details

When `Place`ing a `Ship` (which happens when departing from a planet) the ship swizzle is updated. This fix updates any carried ships' swizzle too.

## Testing Done
Tested the save file below.

## Save File
This save file is adapted from the save file from the linked issue.
[tommaso.becca.txt](https://github.com/endless-sky/endless-sky/files/6839453/tommaso.becca.txt)
