### PR TITLE
Mac: automate upload of release builds

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -16,6 +16,8 @@ macos:
  - 'XCode/**'
  - '**/*.xcodeproj'
  - 'icons/endless-sky.iconset/**'
+ - 'utils/fetch_sdl2_framework.sh'
+ - 'utils/set_dylibs_rpath.sh'
  - *build
 
 windows:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -95,7 +95,7 @@ jobs:
   cd_macos_x86_64:
     runs-on: macos-latest
     env:
-      OUTPUT: EndlessSky-macOS10.15-continuous.zip
+      OUTPUT: EndlessSky-macOS-continuous.zip
       SDL2_FRAMEWORK: build/SDL2.framework
     steps:
       - uses: actions/checkout@v2
@@ -136,7 +136,7 @@ jobs:
       OUTPUT_UBUNTU: endless-sky-x86_64-continuous.tar.gz
       OUTPUT_APPIMAGE: endless-sky-x86_64-continuous.AppImage
       OUTPUT_WINDOWS: EndlessSky-win64-continuous.zip
-      OUTPUT_MACOS: EndlessSky-macOS10.15-continuous.zip
+      OUTPUT_MACOS: EndlessSky-macOS-continuous.zip
     steps:
       - uses: actions/checkout@v2
       - name: Install github-release

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -6,7 +6,6 @@ on:
       - published
 
 jobs:
-
   appimage_amd64:
     runs-on: ubuntu-18.04
     env:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -6,6 +6,7 @@ on:
       - published
 
 jobs:
+
   appimage_amd64:
     runs-on: ubuntu-18.04
     env:
@@ -32,4 +33,43 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ${{ env.OUTPUT }}
           asset_name: ${{ env.OUTPUT }}
+          asset_content_type: application/octet-stream
+
+  dmg_macos:
+    runs-on: macos-latest
+    env:
+      OUTPUT: endless-sky-macos-${{ github.event.release.tag_name }}
+      SDL2_FRAMEWORK: build/SDL2.framework
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update Homebrew
+        run: brew update
+      - name: Install dependencies
+        run: brew install libmad libpng jpeg-turbo
+      - name: Restore cached SDL2 framework
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.SDL2_FRAMEWORK }}
+          key: macos-latest-sdl2-${{ hashFiles('utils/fetch_sdl2_framework.sh', 'EndlessSky.xcodeproj/**') }}
+      - name: Build Application
+        run: xcodebuild -configuration "Release" -jobs $(sysctl -n hw.logicalcpu) -quiet
+      - name: Package Application
+        run: |
+          cd build/Release
+          mkdir ${{ env.OUTPUT }}
+          mv Endless\ Sky.app ${{ env.OUTPUT }}
+          ln -s /Applications ${{ env.OUTPUT }}
+          hdiutil create -ov -fs HFS+ -format UDZO -imagekey zlib-level=9 -srcfolder ${{ env.OUTPUT }} ${{ github.workspace }}/${{ env.OUTPUT }}.dmg
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.OUTPUT }}.dmg
+          path: ${{ env.OUTPUT }}.dmg
+      - name: Upload disk image
+        uses: actions/upload-release-asset@v1.0.2
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ env.OUTPUT }}.dmg
+          asset_name: ${{ env.OUTPUT }}.dmg
           asset_content_type: application/octet-stream

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.ARTIFACT }}
-        key: ${{ matrix.os }}-artifacts-${{ hashFiles('source/**') }}-${{ hashFiles('.github/workflows/ci.yml', 'EndlessSky.xcodeproj/**') }} # Any of these files will trigger a rebuild
+        key: ${{ matrix.os }}-artifacts-${{ hashFiles('source/**') }}-${{ hashFiles('.github/workflows/ci.yml', 'EndlessSky.xcodeproj/**', 'utils/set_dylibs_rpath.sh', 'utils/fetch_sdl2_framework.sh') }}
     - name: Update Homebrew
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: brew update
@@ -301,7 +301,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.SDL2_FRAMEWORK }}
-        key: ${{ matrix.os }}-sdl2-${{ hashFiles('utils/fetch_sdl2_framework.sh') }}-${{ hashFiles('.github/workflows/ci.yml', 'EndlessSky.xcodeproj/**') }}
+        key: ${{ matrix.os }}-sdl2-${{ hashFiles('.github/workflows/ci.yml', 'EndlessSky.xcodeproj/**', 'utils/set_dylibs_rpath.sh', 'utils/fetch_sdl2_framework.sh') }}
     - name: Compile
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: xcodebuild -configuration "Release" -jobs $(sysctl -n hw.logicalcpu) -quiet
@@ -437,7 +437,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.SDL2_FRAMEWORK }}
-        key: ${{ matrix.os }}-sdl2-${{ hashFiles('utils/fetch_sdl2_framework.sh') }}-${{ hashFiles('.github/workflows/ci.yml', 'EndlessSky.xcodeproj/**') }}
+        key: ${{ matrix.os }}-sdl2-${{ hashFiles('.github/workflows/ci.yml', 'EndlessSky.xcodeproj/**', 'utils/set_dylibs_rpath.sh', 'utils/fetch_sdl2_framework.sh') }}
     - name: Add support files
       run: |
         mkdir -p Contents/Frameworks Contents/MacOS Contents/Resources

--- a/readme-developer.txt
+++ b/readme-developer.txt
@@ -81,7 +81,7 @@ For example, when making lots of changes to the game, you will generally have th
 
 
 
-Mac OS X:
+macOS:
 
 To build Endless Sky with native tools, you will first need to download Xcode from the App Store.
 
@@ -91,8 +91,9 @@ Once Homebrew is installed, use it to install the libraries you will need:
 
   $ brew install libmad libpng jpeg-turbo
 
-If the versions of those libraries are different from the ones that the Xcode project is set up for, you will need to modify the file paths in the “Frameworks” section in Xcode.
-It is possible that you will also need to modify the “Header Search Paths” and “Library Search Paths” in “Build Settings” to point to wherever Homebrew installed those libraries.
+Homebrew will install the latest version of the libraries, so if the versions of those libraries are different from the ones that the Xcode project is set up for, you will need to modify the file paths in the “Frameworks” section in Xcode. (Occasionally, the Xcode project will be updated to reflect these new versions.)
+It is possible that you will also need to modify the “Header Search Paths” and “Library Search Paths” in “Build Settings”, in case your Homebrew for Intel Mac installation does not use the standard `/usr/local` prefix.
+The first time you build the project, a library for the SDL framework will be downloaded.
 
 *** Note: there is extremely limited development support for macOS, and no intent to support macOS's new ARM architecture. ***
 

--- a/utils/fetch_sdl2_framework.sh
+++ b/utils/fetch_sdl2_framework.sh
@@ -7,11 +7,12 @@ SDL2_VERSION="2.0.14"
 SDL2_URL="https://www.libsdl.org/release/SDL2-${SDL2_VERSION}.dmg"
 SDL2_DMG="${TEMP_ROOT}/sdl2.dmg"
 
-if [ ! -d "${TEMP_ROOT}/SDL2.framework" ]; then
+if [ ! -d "${PROJECT_DIR}/build/SDL2.framework" ]; then
+    mkdir -p "${PROJECT_DIR}/build"
     if [ ! -f "${SDL2_DMG}" ]; then
         curl -sSL -o "${SDL2_DMG}" "${SDL2_URL}"
     fi
     hdiutil attach -quiet -nobrowse "${SDL2_DMG}"
-    cp -R /Volumes/SDL2/SDL2.framework "${TEMP_ROOT}"
+    cp -R /Volumes/SDL2/SDL2.framework "${PROJECT_DIR}/build"
     hdiutil detach -quiet /Volumes/SDL2
 fi


### PR DESCRIPTION
**Build process:** This PR automates the upload of macOS release builds.

## Feature Details
- Adds a job to `cd_release.yaml` which adds the Mac build when a release is published
- Also:
  - renames the macOS CD build to omit the minimum version, since it now runs on 10.9 and later
  - fixes an issue from #6121 where building with Xcode wouldn't find SDL2.framework unless a command line build using `xcodebuild -configuration "Release"` was run first
  - updates macOS section in `readme-developer.txt`

## Testing Done
Works On My Machine™ (macOS 10.12, 10.14, 10.15)