### PR TITLE
Sort available jobs alphabetically.

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2651,11 +2651,10 @@ void PlayerInfo::CreateMissions()
 		}
 	}
 
-	// Sort missions on the job board by payment.
+	// Sort missions on the job board alphabetically.
 	availableJobs.sort([](const Mission &lhs, const Mission &rhs)
 	{
-		return lhs.GetAction(Mission::COMPLETE).Payment()
-			< rhs.GetAction(Mission::COMPLETE).Payment();
+		return lhs.Name() < rhs.Name();
 	});
 }
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2650,6 +2650,13 @@ void PlayerInfo::CreateMissions()
 				++it;
 		}
 	}
+
+	// Sort missions on the job board by payment.
+	availableJobs.sort([](const Mission &lhs, const Mission &rhs)
+	{
+		return lhs.GetAction(Mission::COMPLETE).Payment()
+			< rhs.GetAction(Mission::COMPLETE).Payment();
+	});
 }
 
 


### PR DESCRIPTION
**Feature:** #236 is related

## Feature Details

<del>This is a pretty simple change: Sort the "available jobs" by payment. The jobs with the smallest payments are at the top while the job with the highest payment is at the very bottom.</del>

After feedback, this PR sorts the list alphabetically.

<hr>

<details>
<summary>Background information</summary>

Sorting jobs by payment/type/distance/... is requested lots of times (see #236). Yesterday I bought some good cargo/transport ships and did lots of jobs. It was pretty annoying to go through the whole list and find out which job paid the most.

This PR defaults jobs by payment and only that. I really don't think all the other sorts make any sense:

- By Cargo Space: cargo space is pretty much proportional to payment, so sorting by payment also sorts by cargo size.
- By Passengers: same as with cargo space.
- By Distance: You can see the distance on the map. It's way easier to get an overview that way than sorting jobs by distance.
- By Due Date: I can't think of a reason why someone would use this sort.

I don't think it's worth to introduce new UI just for all the sort options, since IMO they're going to be unused anyway.
</details>

Thoughts?

## Testing Done

Went through the jobs list and confirmed that the list is indeed sorted.

## Performance Impact

Negligible.
