### PR TITLE
Fix bug when accepting/aborting mission not paning.

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -321,20 +321,8 @@ bool MissionPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	else
 		return MapPanel::KeyDown(key, mod, command, isNewPress);
 	
-	// To reach here, we changed the selected mission. Scroll the active
-	// mission list, update the selected system, and pan the map.
-	if(availableIt != available.end())
-	{
-		selectedSystem = availableIt->Destination()->GetSystem();
-		DoScroll(available, availableIt, availableScroll, false);
-	}
-	else if(acceptedIt != accepted.end())
-	{
-		selectedSystem = acceptedIt->Destination()->GetSystem();
-		DoScroll(accepted, acceptedIt, acceptedScroll, true);
-	}
-	CenterOnSystem(selectedSystem);
-	
+	// To reach here, we changed the selected mission so update the map.
+	UpdateMapForMission();
 	return true;
 }
 
@@ -768,6 +756,7 @@ void MissionPanel::Accept()
 	
 	// Check if any other jobs are available with the same destination. Prefer
 	// jobs that also have the same destination planet.
+	bool sameDestination = false;
 	if(toAccept.Destination())
 	{
 		const Planet *planet = toAccept.Destination();
@@ -775,11 +764,16 @@ void MissionPanel::Accept()
 		for(auto it = available.begin(); it != available.end(); ++it)
 			if(it->Destination() && it->Destination()->IsInSystem(system))
 			{
+				sameDestination = true;
 				availableIt = it;
 				if(it->Destination() == planet)
 					break;
 			}
 	}
+
+	// Since the current mission changed, we need to update the map.
+	if(!sameDestination)
+		UpdateMapForMission();
 }
 
 
@@ -824,6 +818,8 @@ void MissionPanel::AbortMission()
 			--acceptedIt;
 		if(acceptedIt != accepted.end() && !acceptedIt->IsVisible())
 			acceptedIt = accepted.end();
+
+		UpdateMapForMission();
 	}
 }
 
@@ -874,4 +870,22 @@ bool MissionPanel::SelectAnyMission()
 		return availableIt != available.end() || acceptedIt != accepted.end();
 	}
 	return false;
+}
+
+
+
+void MissionPanel::UpdateMapForMission()
+{
+	// Scroll the active mission list, update the selected system, and pan the map.
+	if(availableIt != available.end())
+	{
+		selectedSystem = availableIt->Destination()->GetSystem();
+		DoScroll(available, availableIt, availableScroll, false);
+	}
+	else if(acceptedIt != accepted.end())
+	{
+		selectedSystem = acceptedIt->Destination()->GetSystem();
+		DoScroll(accepted, acceptedIt, acceptedScroll, true);
+	}
+	CenterOnSystem(selectedSystem);
 }

--- a/source/MissionPanel.h
+++ b/source/MissionPanel.h
@@ -75,6 +75,10 @@ private:
 	// selected. Returns true if the selection was changed.
 	bool SelectAnyMission();
 	
+	// A new mission was selected so we need to update the map to reflect that change.
+	void UpdateMapForMission();
+
+
 private:
 	const std::list<Mission> &available;
 	const std::list<Mission> &accepted;


### PR DESCRIPTION
**Bugfix:** couldn't find an issue for this

## Fix Details

When going up/down the mission list, the map updates to show where exactly the destination is. This doesn't happen when accepting/aborting a job. This PR fixes this behavior. Here's a video of the bug. Notice how the map doesn't pan and still shows the initial destination as destination for the other jobs enough though that is not the case.


https://user-images.githubusercontent.com/85879619/127031569-b3530d8d-96c0-450b-a522-9ae74b7d7ca1.mp4



## Testing Done

Tested that the map now pans when accepting/aborting.