### PR TITLE
Fix building tests

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -145,7 +145,7 @@ test = env.Program(
 	 # Add Catch header & additional test includes to the existing search paths
 	CPPPATH=(env.get('CPPPATH', []) + [pathjoin('tests', 'include')]),
 	# Do not link against the actual implementations of SDL, OpenGL, etc.
-	LIBS=sys_libs,
+	LIBS=sys_libs + game_libs,
 	# Pass the necessary link flags for a console program.
 	LINKFLAGS=[x for x in env.get('LINKFLAGS', []) if x not in ('-mwindows',)]
 )


### PR DESCRIPTION
There are multiple references to the functions from `game_libs` even when in test code.

This fixes linking of test binary.

## Fix Details
https://github.com/endless-sky/endless-sky/pull/5153#issuecomment-890399322

```
$ scons mode=debug -j 8 test
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
g++ -o tests/endless-sky-tests tests/build/helpers/datanode-factory.o tests/build/text/test_alignment.o tests/build/text/test_displaytext.o tests/build/text/test_format.o tests/build/text/test_layout.o tests/build/text/test_truncate.o tests/build/test_account.o tests/build/test_conditionSet.o tests/build/test_datanode.o tests/build/test_esuuid.o tests/build/test_main.o tests/build/test_point.o tests/build/test_random.o tests/build/test_set.o tests/build/test_ship.o tests/build/test_weightedList.o lib/debug/libendless-sky.a -luuid
/usr/bin/ld: lib/debug/libendless-sky.a(Files.o): in function `Files::Init(char const* const*)':
/home/xx/workspace/endless-sky/source/Files.cpp:80: undefined reference to `SDL_GetBasePath'
/usr/bin/ld: /home/xx/workspace/endless-sky/source/Files.cpp:85: undefined reference to `SDL_free'
/usr/bin/ld: /home/xx/workspace/endless-sky/source/Files.cpp:125: undefined reference to `SDL_GetPrefPath'
/usr/bin/ld: /home/xx/workspace/endless-sky/source/Files.cpp:133: undefined reference to `SDL_free'
/usr/bin/ld: /home/xx/workspace/endless-sky/source/Files.cpp:151: undefined reference to `SDL_GetPrefPath'
/usr/bin/ld: /home/xx/workspace/endless-sky/source/Files.cpp:153: undefined reference to `SDL_free'
collect2: error: ld returned 1 exit status
scons: *** [tests/endless-sky-tests] Error 1
scons: building terminated because of errors.
```

It seems all your tests in CI are executed in release mode

## Testing Done
Compiled it without and with this PR