### PR TITLE
Remove accidental white supremacy from White Sun

### DIFF
--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -353,7 +353,7 @@ outfit "White Sun Reactor"
 	thumbnail "outfit/white sun"
 	"mass" 127
 	"outfit space" -127
-	"energy generation" 24.8
+	"energy generation" 24.7
 	"heat generation" 32
 	"energy capacity" 6700
 	description "The White Sun is a large nuclear reactor that the Wanderers use for powering their Strong Wind warships."

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -353,7 +353,7 @@ outfit "White Sun Reactor"
 	thumbnail "outfit/white sun"
 	"mass" 127
 	"outfit space" -127
-	"energy generation" 24.7
+	"energy generation" 24.85
 	"heat generation" 32
 	"energy capacity" 6700
 	description "The White Sun is a large nuclear reactor that the Wanderers use for powering their Strong Wind warships."


### PR DESCRIPTION
Turns out that the energy generation on this is 1488, which paired with "white sun" is fairly sketch. This is a very minor tweak that makes the reactor not-Hitlery.

This changes the regen/sec from 1488 to 1485.