### PR TITLE
Add a missing "word" in wanderer news.

### DIFF
--- a/data/wanderer/wanderer news.txt
+++ b/data/wanderer/wanderer news.txt
@@ -103,6 +103,7 @@ news "Wanderer civilians, dialog"
 	message
 		word
 			`"`
+		word
 			"Whenever I go on a [journey, trip] through space I always bring some of my [favorite, most cherished] potted plants. It gets [lonely, barren] when you are far from nature." 
 			"I have [heard of, known of] a human captain in Wanderer space, but seeing you is still quite [strange, odd]."
 			"I cannot [imagine, fathom] being unable to fly. How do you manage to get anywhere?"


### PR DESCRIPTION
**Bugfix:** This PR addresses issue in wanderer news.

## Fix Details
Add a missing "word" keyword in wanderer news.

## Testing Done
Print the news.