### PR TITLE
content/bugfix: Filter out all moons for spacediving.

### DIFF
--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3223,9 +3223,7 @@ mission "Spacediving professionals"
 	destination
 		distance 1 7
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
-		not attributes "station"
-		not attributes "research"
-		not attributes "moon"
+		not attributes "station" "research" "moon"
 	to offer
 		random < 14
 	on visit
@@ -3247,9 +3245,7 @@ mission "Spacediving professionals accident"
 	destination
 		distance 1 7
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
-		not attributes "station"
-		not attributes "research"
-		not attributes "moon"
+		not attributes "station" "research" "moon"
 	to offer
 		"Spacediving professionals: done" > 7
 		random < 2
@@ -3271,9 +3267,7 @@ mission "Spacediving professionals disaster"
 	destination
 		distance 1 7
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
-		not attributes "station"
-		not attributes "research"
-		not attributes "moon"
+		not attributes "station" "research" "moon"
 	to offer
 		has "Spacediving professionals accident: done"
 		random < 1
@@ -3297,9 +3291,7 @@ mission "Spacediving amateurs"
 	destination
 		distance 1 7
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
-		not attributes "station"
-		not attributes "research"
-		not attributes "moon"
+		not attributes "station" "research" "moon"
 	to offer
 		"Spacediving professionals: done" > 3
 		random < 5

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3225,6 +3225,7 @@ mission "Spacediving professionals"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		not attributes "station"
 		not attributes "research"
+		not attributes "moon"
 	to offer
 		random < 14
 	on visit
@@ -3248,6 +3249,7 @@ mission "Spacediving professionals accident"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		not attributes "station"
 		not attributes "research"
+		not attributes "moon"
 	to offer
 		"Spacediving professionals: done" > 7
 		random < 2
@@ -3271,6 +3273,7 @@ mission "Spacediving professionals disaster"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		not attributes "station"
 		not attributes "research"
+		not attributes "moon"
 	to offer
 		has "Spacediving professionals accident: done"
 		random < 1
@@ -3294,8 +3297,9 @@ mission "Spacediving amateurs"
 	destination
 		distance 1 7
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
-		not attributes station
-		not attributes research
+		not attributes "station"
+		not attributes "research"
+		not attributes "moon"
 	to offer
 		"Spacediving professionals: done" > 3
 		random < 5


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6146 (with a workaround)

## Fix Details
Remove moons as suitable destinations for spacediving missions, to reduce the chance that spacedivers dive at locations that have no atmosphere. This doesn't fix the issue completely, but filters out a large set of unsuitable destinations.

The proper future solution seems to be to add attributes to planets that describe in more detail which planets have which properties (like atmosphere, landmass, oceans, volcanos, etc) and then filter on the right attributes.

## Testing Done
The PR system will perform all parsing tests required for this change.

## Save File
N/A