### PR TITLE
Build flag to remove support for music and libmad

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -35,6 +35,7 @@ opts = Variables()
 opts.AddVariables(
 	EnumVariable("mode", "Compilation mode", "release", allowed_values=("release", "debug", "profile")),
 	EnumVariable("opengl", "Whether to use OpenGL or OpenGL ES", "desktop", allowed_values=("desktop", "gles")),
+	EnumVariable("music", "Whether to use music", "on", allowed_values=("on", "off")),
 	PathVariable("BUILDDIR", "Directory to store compiled object files in", "build", PathVariable.PathIsDirCreate),
 	PathVariable("BIN_DIR", "Directory to store binaries in", ".", PathVariable.PathIsDirCreate),
 	PathVariable("DESTDIR", "Destination root directory, e.g. if building a package", "", PathVariable.PathAccept),
@@ -117,13 +118,17 @@ else:
 		"GLEW",
 	])
 
-# libmad is not in the Steam runtime, so link it statically:
-if 'steamrt_scout_i386' in chroot_name:
-	env.Append(LIBS = File("/usr/lib/i386-linux-gnu/libmad.a"))
-elif 'steamrt_scout_amd64' in chroot_name:
-	env.Append(LIBS = File("/usr/lib/x86_64-linux-gnu/libmad.a"))
-else:
-	env.Append(LIBS = "mad")
+if env["music"] == "off":
+	flags += ["-DES_NO_MUSIC"]
+
+if env["music"] == "on":
+	# libmad is not in the Steam runtime, so link it statically:
+	if 'steamrt_scout_i386' in chroot_name:
+		env.Append(LIBS = File("/usr/lib/i386-linux-gnu/libmad.a"))
+	elif 'steamrt_scout_amd64' in chroot_name:
+		env.Append(LIBS = File("/usr/lib/x86_64-linux-gnu/libmad.a"))
+	else:
+		env.Append(LIBS = "mad")
 
 
 binDirectory = '' if env["BIN_DIR"] == '.' else pathjoin(env["BIN_DIR"], env["mode"])

--- a/source/Music.cpp
+++ b/source/Music.cpp
@@ -14,7 +14,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Files.h"
 
+#ifndef ES_NO_MUSIC
 #include <mad.h>
+#endif // ES_NO_MUSIC
 
 #include <algorithm>
 #include <cstring>
@@ -23,8 +25,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
+#ifndef ES_NO_MUSIC
 	// How many bytes to read from the file at a time:
 	const size_t INPUT_CHUNK = 65536;
+#endif // ES_NO_MUSIC
 	// How many samples to put in each output block. Because the output is in
 	// stereo, the duration of the sample is half this amount:
 	const size_t OUTPUT_CHUNK = 32768;
@@ -36,6 +40,7 @@ namespace {
 
 void Music::Init(const vector<string> &sources)
 {
+#ifndef ES_NO_MUSIC
 	for(const string &source : sources)
 	{
 		// Find all the sound files that this resource source provides.
@@ -55,6 +60,7 @@ void Music::Init(const vector<string> &sources)
 			paths[name] = path;
 		}
 	}
+#endif // ES_NO_MUSIC
 }
 
 
@@ -64,8 +70,10 @@ void Music::Init(const vector<string> &sources)
 Music::Music()
 	: silence(OUTPUT_CHUNK, 0)
 {
+#ifndef ES_NO_MUSIC
 	// Don't start the thread until this object is fully constructed.
 	thread = std::thread(&Music::Decode, this);
+#endif // ES_NO_MUSIC
 }
 
 
@@ -73,6 +81,7 @@ Music::Music()
 // Destructor, which waits for the thread to stop.
 Music::~Music()
 {
+#ifndef ES_NO_MUSIC
 	// Tell the decoding thread to stop.
 	{
 		unique_lock<mutex> lock(decodeMutex);
@@ -85,6 +94,7 @@ Music::~Music()
 	// our job to close it.
 	if(nextFile)
 		fclose(nextFile);
+#endif // ES_NO_MUSIC
 }
 
 
@@ -92,6 +102,7 @@ Music::~Music()
 // Set the source of music. If the path is empty, this music will be silent.
 void Music::SetSource(const string &name)
 {
+#ifndef ES_NO_MUSIC
 	// Find a file that provides this music.
 	auto it = paths.find(name);
 	string path = (it == paths.end() ? "" : it->second);
@@ -115,6 +126,7 @@ void Music::SetSource(const string &name)
 	// Notify the decoding thread that it can start.
 	lock.unlock();
 	condition.notify_all();
+#endif // ES_NO_MUSIC
 }
 
 
@@ -122,6 +134,7 @@ void Music::SetSource(const string &name)
 // Get the next audio buffer to play.
 const vector<int16_t> &Music::NextChunk()
 {
+#ifndef ES_NO_MUSIC
 	// Check whether the "next" buffer is ready.
 	unique_lock<mutex> lock(decodeMutex);
 	if(next.size() < OUTPUT_CHUNK)
@@ -137,6 +150,7 @@ const vector<int16_t> &Music::NextChunk()
 	// Once the lock is unlocked, notify the decoding thread to continue.
 	lock.unlock();
 	condition.notify_all();
+#endif // ES_NO_MUSIC
 	
 	// Return the buffer.
 	return current;
@@ -148,6 +162,7 @@ const vector<int16_t> &Music::NextChunk()
 // Entry point for the decoding thread.
 void Music::Decode()
 {
+#ifndef ES_NO_MUSIC
 	// This vector will store the input from the file.
 	vector<unsigned char> input(INPUT_CHUNK, 0);
 	// Objects for MP3 decoding:
@@ -273,4 +288,5 @@ void Music::Decode()
 		mad_stream_finish(&stream);
 		fclose(file);
 	}
+#endif // ES_NO_MUSIC
 }


### PR DESCRIPTION
Reopening https://github.com/endless-sky/endless-sky/pull/5591

## Summary
Adds a build flag for building with no music, removing the need for libmad.

The gameplay effect is small: only one music track is included in the game, `sounds/ambient/machinery` which plays on space stations.

My motivation for this is [a web build of Endless Sky](https://github.com/thomasballinger/endless-web/pull/16/commits), for which I've not yet been able to get libmad working.

## Discussion

@tehhowch on this patch previously:

> This seems like a really hacky way to disable music. Wouldn't it be better to make loading libmad optional, and avoid doing so when the compiled binary receives the command line parameter e.g. `--no-music`?
> 
> Then we don't need any ifdefs at all, and systems that won't attempt to load the dynamic library won't need the library in their execution environment.
> 
> A different take on the ifdef approach here would be to ifdef the entire music.cpp and music.h files, and their associated includes / method calls. Then the compiler wouldn't ever see calls to `Music::____`, and there wouldn't be anything at all in music.cpp or music.h
> 
> Only the first approach would make it into the upstream here, but the second way could simplify the patch you need to use for the web fork. Though since you would need to modify audio initialization, perhaps not.

Dynamically loading libmad sounds like the approach to pursue here, but I'm creating this PR before I have that for discussion.
