### PR TITLE
feat: Add offset and facing angle to submunitions

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -62,7 +62,7 @@ Projectile::Projectile(const Ship &parent, Point position, Angle angle, const We
 
 
 Projectile::Projectile(const Projectile &parent, const Point &offset, const Angle &angle, const Weapon *weapon)
-	: Body(weapon->WeaponSprite(), parent.position + parent.velocity + offset, parent.velocity, parent.angle + angle),
+	: Body(weapon->WeaponSprite(), parent.position + parent.velocity + parent.angle.Rotate(offset), parent.velocity, parent.angle + angle),
 	weapon(weapon), targetShip(parent.targetShip), lifetime(weapon->Lifetime())
 {
 	government = parent.government;
@@ -90,7 +90,7 @@ Projectile::Projectile(const Projectile &parent, const Point &offset, const Angl
 
 
 // Ship explosion.
-Projectile::Projectile(const Point &position, const Weapon *weapon)
+Projectile::Projectile(Point position, const Weapon *weapon)
 	: weapon(weapon)
 {
 	this->position = position;
@@ -112,7 +112,7 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 					visuals.emplace_back(*it.first, position, velocity, angle);
 			
 			for(const auto &it : weapon->Submunitions())
-				for(int i = 0; i < it.count; ++i)
+				for(size_t i = 0; i < it.count; ++i)
 					projectiles.emplace_back(*this, it.offset, it.facing, it.weapon);
 		}
 		MarkForRemoval();

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -93,7 +93,7 @@ Projectile::Projectile(const Projectile &parent, const Point &offset, const Angl
 Projectile::Projectile(Point position, const Weapon *weapon)
 	: weapon(weapon)
 {
-	this->position = position;
+	this->position = std::move(position);
 }
 
 

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -61,8 +61,8 @@ Projectile::Projectile(const Ship &parent, Point position, Angle angle, const We
 
 
 
-Projectile::Projectile(const Projectile &parent, const Weapon *weapon)
-	: Body(weapon->WeaponSprite(), parent.position + parent.velocity, parent.velocity, parent.angle),
+Projectile::Projectile(const Projectile &parent, Point offset, Angle angle, const Weapon *weapon)
+	: Body(weapon->WeaponSprite(), parent.position + parent.velocity + offset, parent.velocity, parent.angle + angle),
 	weapon(weapon), targetShip(parent.targetShip), lifetime(weapon->Lifetime())
 {
 	government = parent.government;
@@ -112,8 +112,8 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 					visuals.emplace_back(*it.first, position, velocity, angle);
 			
 			for(const auto &it : weapon->Submunitions())
-				for(int i = 0; i < it.second; ++i)
-					projectiles.emplace_back(*this, it.first);
+				for(int i = 0; i < it.count; ++i)
+					projectiles.emplace_back(*this, it.offset, it.facing, it.outfit);
 		}
 		MarkForRemoval();
 		return;

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -35,7 +35,7 @@ namespace {
 
 
 
-Projectile::Projectile(const Ship &parent, const Point &position, const Angle &angle, const Weapon *weapon)
+Projectile::Projectile(const Ship &parent, Point position, Angle angle, const Weapon *weapon)
 	: Body(weapon->WeaponSprite(), position, parent.Velocity(), angle),
 	weapon(weapon), targetShip(parent.GetTargetShip()), lifetime(weapon->Lifetime())
 {

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -35,7 +35,7 @@ namespace {
 
 
 
-Projectile::Projectile(const Ship &parent, Point position, Angle angle, const Weapon *weapon)
+Projectile::Projectile(const Ship &parent, const Point &position, const Angle &angle, const Weapon *weapon)
 	: Body(weapon->WeaponSprite(), position, parent.Velocity(), angle),
 	weapon(weapon), targetShip(parent.GetTargetShip()), lifetime(weapon->Lifetime())
 {
@@ -61,7 +61,7 @@ Projectile::Projectile(const Ship &parent, Point position, Angle angle, const We
 
 
 
-Projectile::Projectile(const Projectile &parent, Point offset, Angle angle, const Weapon *weapon)
+Projectile::Projectile(const Projectile &parent, const Point &offset, const Angle &angle, const Weapon *weapon)
 	: Body(weapon->WeaponSprite(), parent.position + parent.velocity + offset, parent.velocity, parent.angle + angle),
 	weapon(weapon), targetShip(parent.targetShip), lifetime(weapon->Lifetime())
 {
@@ -90,7 +90,7 @@ Projectile::Projectile(const Projectile &parent, Point offset, Angle angle, cons
 
 
 // Ship explosion.
-Projectile::Projectile(Point position, const Weapon *weapon)
+Projectile::Projectile(const Point &position, const Weapon *weapon)
 	: weapon(weapon)
 {
 	this->position = position;
@@ -113,7 +113,7 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 			
 			for(const auto &it : weapon->Submunitions())
 				for(int i = 0; i < it.count; ++i)
-					projectiles.emplace_back(*this, it.offset, it.facing, it.outfit);
+					projectiles.emplace_back(*this, it.offset, it.facing, it.weapon);
 		}
 		MarkForRemoval();
 		return;

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -36,10 +36,10 @@ class Weapon;
 // projectiles that may look different or travel in a new direction.
 class Projectile : public Body {
 public:
-	Projectile(const Ship &parent, Point position, Angle angle, const Weapon *weapon);
-	Projectile(const Projectile &parent, Point offset, Angle angle, const Weapon *weapon);
+	Projectile(const Ship &parent, const Point &position, const Angle &angle, const Weapon *weapon);
+	Projectile(const Projectile &parent, const Point &offset, const Angle &angle, const Weapon *weapon);
 	// Ship explosion.
-	Projectile(Point position, const Weapon *weapon);
+	Projectile(const Point &position, const Weapon *weapon);
 	
 	/* Functions provided by the Body base class:
 	Frame GetFrame(int step = -1) const;

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -36,10 +36,10 @@ class Weapon;
 // projectiles that may look different or travel in a new direction.
 class Projectile : public Body {
 public:
-	Projectile(const Ship &parent, const Point &position, const Angle &angle, const Weapon *weapon);
+	Projectile(const Ship &parent, Point position, Angle angle, const Weapon *weapon);
 	Projectile(const Projectile &parent, const Point &offset, const Angle &angle, const Weapon *weapon);
 	// Ship explosion.
-	Projectile(const Point &position, const Weapon *weapon);
+	Projectile(Point position, const Weapon *weapon);
 	
 	/* Functions provided by the Body base class:
 	Frame GetFrame(int step = -1) const;

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -37,7 +37,7 @@ class Weapon;
 class Projectile : public Body {
 public:
 	Projectile(const Ship &parent, Point position, Angle angle, const Weapon *weapon);
-	Projectile(const Projectile &parent, const Weapon *weapon);
+	Projectile(const Projectile &parent, Point offset, Angle angle, const Weapon *weapon);
 	// Ship explosion.
 	Projectile(Point position, const Weapon *weapon);
 	

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -92,19 +92,18 @@ void Weapon::LoadWeapon(const DataNode &node)
 		}
 		else if(key == "submunition")
 		{
-			Submunition subm;
-			subm.outfit = GameData::Outfits().Get(child.Token(1));
-			subm.count = (child.Size() >= 3) ? child.Value(2) : 1;
+			submunitions.emplace_back(
+				GameData::Outfits().Get(child.Token(1)),
+				(child.Size() >= 3) ? child.Value(2) : 1);
 			for(const DataNode &grand : child)
 			{
 				if((grand.Size() >= 2) && (grand.Token(0) == "facing"))
-					subm.facing = Angle(grand.Value(1));
+					submunitions.back().facing = Angle(grand.Value(1));
 				else if((grand.Size() >= 3) && (grand.Token(0) == "offset"))
-					subm.offset = Point(grand.Value(1), grand.Value(2));
+					submunitions.back().offset = Point(grand.Value(1), grand.Value(2));
 				else
 					child.PrintTrace("Skipping unknown or incomplete sub-munition attribute:");
 			}
-			submunitions.emplace_back(subm);
 		}
 		else
 		{
@@ -385,7 +384,7 @@ double Weapon::TotalLifetime() const
 	{
 		totalLifetime = 0.;
 		for(const auto &it : submunitions)
-			totalLifetime = max(totalLifetime, it.outfit->TotalLifetime());
+			totalLifetime = max(totalLifetime, it.weapon->TotalLifetime());
 		totalLifetime += lifetime;
 	}
 	return totalLifetime;
@@ -435,7 +434,7 @@ double Weapon::TotalDamage(int index) const
 		for(int i = 0; i < DAMAGE_TYPES; ++i)
 		{
 			for(const auto &it : submunitions)
-				damage[i] += it.outfit->TotalDamage(i) * it.count;
+				damage[i] += it.weapon->TotalDamage(i) * it.count;
 			doesDamage |= (damage[i] > 0.);
 		}
 	}

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -13,11 +13,13 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef WEAPON_H_
 #define WEAPON_H_
 
+#include "Angle.h"
 #include "Body.h"
 #include "Point.h"
 
 #include <map>
 #include <utility>
+#include <vector>
 
 class DataNode;
 class Effect;
@@ -33,6 +35,18 @@ class Sprite;
 // copy of them, and storing them as class variables instead of in a map of
 // string to double significantly reduces access time.
 class Weapon {
+public:
+	struct Submunition{
+		const Outfit *outfit;
+		// The direction and offset at which the submunition will be fired from
+		// the original projectile. The direction and offset are relative to the
+		// point and direction at which the original projectile dies.
+		Angle facing;
+		Point offset;
+		int count;
+	};
+	
+	
 public:
 	// Load from a "weapon" node, either in an outfit, a ship (explosion), or a hazard.
 	void LoadWeapon(const DataNode &node);
@@ -51,7 +65,7 @@ public:
 	const std::map<const Effect *, int> &HitEffects() const;
 	const std::map<const Effect *, int> &TargetEffects() const;
 	const std::map<const Effect *, int> &DieEffects() const;
-	const std::map<const Outfit *, int> &Submunitions() const;
+	const std::vector<Submunition> &Submunitions() const;
 	
 	// Accessor functions for various attributes.
 	int Lifetime() const;
@@ -182,7 +196,7 @@ private:
 	std::map<const Effect *, int> hitEffects;
 	std::map<const Effect *, int> targetEffects;
 	std::map<const Effect *, int> dieEffects;
-	std::map<const Outfit *, int> submunitions;
+	std::vector<Submunition> submunitions;
 	
 	// This stores whether or not the weapon has been loaded.
 	bool isWeapon = false;

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -41,13 +41,12 @@ public:
 		explicit Submunition(const Weapon *weapon, std::size_t count) noexcept
 			: weapon(weapon), count(count) {};
 		
-		const Weapon *weapon;
-		// The direction and offset at which the submunition will be fired from
-		// the original projectile. The direction and offset are relative to the
-		// point and direction at which the original projectile dies.
+		const Weapon *weapon = nullptr;
+		std::size_t count = 0;
+		// The angular offset from the source projectile, relative to its current facing.
 		Angle facing;
+		// The base offset from the source projectile's position, relative to its current facing.
 		Point offset;
-		int count;
 	};
 	
 	

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -37,7 +37,11 @@ class Sprite;
 class Weapon {
 public:
 	struct Submunition{
-		const Outfit *outfit;
+		Submunition() noexcept = default;
+		explicit Submunition(const Weapon *weapon, std::size_t count) noexcept
+			: weapon(weapon), count(count) {};
+		
+		const Weapon *weapon;
 		// The direction and offset at which the submunition will be fired from
 		// the original projectile. The direction and offset are relative to the
 		// point and direction at which the original projectile dies.


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issues #5376 and #3878

## Feature Details
Closes #5376
Closes #3878
This PR adds an offset and an angle for the submunitions as requested in the 2 linked issues. The newly introduced keywords in this PR are `facing` (to select the angle for the submunition) and `offset` (to set the offset compared to the explosion location) which both are to be used under the `submunition` keyword in the datafiles that describe submunitions.

Chosen implementation is to set the facing and offset keywords in the submunition sections on the "parent-projectile" to allow the same "submunition" to be used on different angles and offsets from a parent projectile (without each angle or offset requiring its own definition).

## UI Screenshots
Attached is [mirv.txt](https://github.com/endless-sky/endless-sky/files/6933484/mirv.txt), a datafile that can be used for testing,. Install the datafile and then just buy the new "Left Splitting Mirv" weapon and some sidewinders at any basic outfitter. Here is a screenshot of the "Left Splitting Mirv" weapon in action:
![triple_left](https://user-images.githubusercontent.com/35403542/128232145-7e8eb73f-c823-41ca-914f-07f42ac83668.png)

## Usage Examples
Here is an example (taken from #5376):
```
outfit "Left Splitting Mirv"
	weapon
		"submunition" "Mirv Fragment" 1
			facing 268
			offset -10 -3
		"submunition" "Mirv Fragment" 1
			facing 270
			offset -10 0
		"submunition" "Mirv Fragment" 1
			facing 272
			offset -10 3
```

## Testing Done
I've tested with the provided datafile and I fired a number of other weapons.

## Performance Impact
Dying projectiles now need to deal with 2 additional variables when creating submunitions; and Angle and a Point. I don't expect any noticeable impact from this.