### PR TITLE
--no-music flag to disable music

### DIFF
--- a/source/Audio.h
+++ b/source/Audio.h
@@ -31,7 +31,7 @@ class Sound;
 class Audio {
 public:
 	// Begin loading sounds (in a separate thread).
-	static void Init(const std::vector<std::string> &sources);
+	static void Init(const std::vector<std::string> &sources, bool musicEnabled);
 	
 	// Report the progress of loading sounds.
 	static double GetProgress();
@@ -66,6 +66,10 @@ public:
 	
 	// Shut down the audio system (because we're about to quit).
 	static void Quit();
+	
+	
+private:
+	static bool musicEnabled;
 };
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -68,6 +68,7 @@ int main(int argc, char *argv[])
 	Conversation conversation;
 	bool debugMode = false;
 	bool loadOnly = false;
+	bool enableMusic = true;
 	string testToRunName = "";
 
 	for(const char *const *it = argv + 1; *it; ++it)
@@ -91,6 +92,8 @@ int main(int argc, char *argv[])
 			loadOnly = true;
 		else if(arg == "--test" && *++it)
 			testToRunName = *it;
+		else if (arg == "--no-music")
+			enableMusic = false;
 	}
 	
 	try {
@@ -131,7 +134,7 @@ int main(int argc, char *argv[])
 		// Show something other than a blank window.
 		GameWindow::Step();
 		
-		Audio::Init(GameData::Sources());
+		Audio::Init(GameData::Sources(), enableMusic);
 		
 		// This is the main loop where all the action begins.
 		GameLoop(player, conversation, testToRunName, debugMode);


### PR DESCRIPTION
**Feature:** Command line flag to disable music, an alternative to https://github.com/endless-sky/endless-sky/pull/6159.

Motivation: I'd like to be able to turn music off to avoid needing to run these threads in the web build and to avoid needing to implement mp3 decoding (because I'm having trouble compiling libmad on that platform). 

## Feature Details
`--no-music` command line flag prevents music threads from ever being started, short circuits cleanup code, and prevents music from being playing.

## UI Screenshots
N/A

## Usage Examples
`$ /Users/tomb/Library/Developer/Xcode/DerivedData/EndlessSky-asymldgrudnqsdclwufttpzdiyop/Build/Products/Debug/Endless\ Sky.app/Contents/MacOS/Endless\ Sky --no-music`

## Testing Done
Visited Kraken Station with and without the flag, station music track did not play with the flag and did play without it.

## Performance Impact
I didn't notice anything, although this probably uses less CPU. Not strictly relevant but related to performance: I was able to bump down the threadpool size in the web build when using this flag.