### PR TITLE
emscripten build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,18 @@ scons-local*
 .sconsign.dblite
 /*.d
 
+# emscripten build generated files
+endless-sky.html
+endless-sky.data
+endless-sky.js
+endless-sky.worker.js
+endless-sky.wasm
+endless-sky.wasm.map
+
+# libjpeg-turbo
+2.1.0.tar.gz
+libjpeg-turbo-2.1.0
+
 # Test Reports
 test-report.xml
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,90 @@
+EMSCRIPTEN_ENV := $(shell command -v emmake 2> /dev/null)
+
+clean:
+	rm -f endless-sky.html
+	rm -f endless-sky.js
+	rm -f endless-sky.worker.js
+	rm -f endless-sky.data
+	rm -f endless-sky.wasm
+	rm -f endless-sky.wasm.map
+	rm -f lib/emcc/libendless-sky.a
+2.1.0.tar.gz:
+	wget https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/2.1.0.tar.gz
+libjpeg-turbo-2.1.0: 2.1.0.tar.gz
+	tar xzvf 2.1.0.tar.gz
+# | means libjpeg-turbo-2.1.0 is a "order-only prerequisite" so creating the file doesn't invalidate the dir
+libjpeg-turbo-2.1.0/libturbojpeg.a: | libjpeg-turbo-2.1.0
+ifndef EMSCRIPTEN_ENV
+	$(error "emmake is not available, activate the emscripten env first")
+endif
+	cd libjpeg-turbo-2.1.0; emcmake cmake -G"Unix Makefiles" -DWITH_SIMD=0 -DCMAKE_BUILD_TYPE=Release -Wno-dev
+	cd libjpeg-turbo-2.1.0; emmake make
+dev: endless-sky.html
+	emrun --serve_after_close --serve_after_exit --browser chrome --private_browsing endless-sky.html
+
+COMMON_FLAGS = -O3 -flto\
+		-s USE_SDL=2\
+		-s USE_LIBPNG=1\
+		-pthread\
+		-s DISABLE_EXCEPTION_CATCHING=0
+
+CFLAGS = $(COMMON_FLAGS)\
+	-Duuid_generate_random=uuid_generate\
+	-std=c++11\
+	-Wall\
+	-Werror\
+	-Wold-style-cast\
+	-DES_GLES\
+	-gsource-map\
+	-fno-rtti\
+	-I libjpeg-turbo-2.1.0\
+
+
+# Note that that libmad is not linked! It's mocked out until it works with Emscripten
+LINK_FLAGS = $(COMMON_FLAGS)\
+	-L libjpeg-turbo-2.1.0\
+	-l jpeg\
+	-lidbfs.js\
+	--source-map-base http://localhost:6931/\
+	-s USE_WEBGL2=1\
+	-s ASSERTIONS=2\
+	-s DEMANGLE_SUPPORT=1\
+	-s GL_ASSERTIONS=1\
+	--closure 1\
+	-s ASYNCIFY\
+	-s PTHREAD_POOL_SIZE=7\
+	-s MIN_WEBGL_VERSION=2\
+	-s MAX_WEBGL_VERSION=2\
+	-s WASM_MEM_MAX=2147483648\
+	-s INITIAL_MEMORY=629145600\
+	-s ALLOW_MEMORY_GROWTH=1\
+	--preload-file data\
+	--preload-file images\
+	--preload-file sounds\
+	--preload-file credits.txt\
+	--preload-file keys.txt\
+	-s EXPORTED_RUNTIME_METHODS=['callMain']\
+	--emrun
+
+CPPS := $(shell ls source/*.cpp) $(shell ls source/text/*.cpp)
+CPPS_EXCEPT_MAIN := $(shell ls source/*.cpp | grep -v main.cpp) $(shell ls source/text/*.cpp)
+TEMP := $(subst source/,build/emcc/,$(CPPS))
+OBJS := $(subst .cpp,.o,$(TEMP))
+TEMP := $(subst source/,build/emcc/,$(CPPS_EXCEPT_MAIN))
+OBJS_EXCEPT_MAIN := $(subst .cpp,.o,$(TEMP))
+HEADERS := $(shell ls source/*.h*) $(shell ls source/text/*.h*)
+
+build/emcc/%.o: source/%.cpp
+	mkdir -p build/emcc
+	mkdir -p build/emcc/text
+	em++ $(CFLAGS) -c $< -o $@
+
+lib/emcc/libendless-sky.a: $(OBJS_EXCEPT_MAIN)
+	mkdir -p lib/emcc
+	emar rcs lib/emcc/libendless-sky.a $(OBJS_EXCEPT_MAIN)
+
+endless-sky.html: libjpeg-turbo-2.1.0/libturbojpeg.a lib/emcc/libendless-sky.a build/emcc/main.o
+ifndef EMSCRIPTEN_ENV
+	$(error "em++ is not available, activate the emscripten env first")
+endif
+	em++ -o endless-sky.html $(LINK_FLAGS) build/emcc/main.o lib/emcc/libendless-sky.a

--- a/readme-developer.txt
+++ b/readme-developer.txt
@@ -106,3 +106,29 @@ For the Code::Blocks project, the archive program can be configured in Code::Blo
 The Scons builds can be controlled by setting the appropriate environment variable(s), either directly in the environment or just for the lifetime of the command:
 
   $ AR=gcc-ar scons
+
+
+
+Building for the web:
+
+Mac and Linux (Windows not supported):
+
+Install scons with apt, yum, brew, etc. Unlike the setup instructions for the normal build on Mac above, you will need scons on Mac.
+
+  $ apt install scons  # just run one of these commands, this one is for Debian
+  $ yum install scons  # RPM-based
+  $ brew install scons  # mac
+
+Install Emscripten following the instructions at https://emscripten.org/docs/getting_started/downloads.html
+Use the latest version and source the emsdk_env.sh file so you can run commands like emcc, em++ and emmake.
+The last time I checked, this looked like:
+
+  $ git clone https://github.com/emscripten-core/emsdk.git
+  $ cd emsdk
+  $ ./emsdk install latest
+  $ ./emsdk activate latest
+  $ source ./emsdk_env.sh  # you'll need to run this one each time you open a new terminal
+
+Now back in the endless-sky repo directory run
+
+  $ make dev

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -160,9 +160,16 @@ void Audio::Init(const vector<string> &sources)
 			}
 		}
 	}
+
+#ifndef __EMSCRIPTEN__
 	// Begin loading the files.
 	if(!loadQueue.empty())
 		loadThread = thread(&Load);
+#else
+	// emscripten-compiled code freezes here in the browser
+	// so just load synchronously
+	Load();
+#endif
 	
 	// Create the music-streaming threads.
 	currentTrack.reset(new Music());

--- a/source/FakeMad.h
+++ b/source/FakeMad.h
@@ -1,0 +1,46 @@
+// A header-only no-op implementation of enough of libmad to use in Music.cpp
+// without actually doing anything.
+// Ordinarily provided by <mad.h>
+
+typedef signed long mad_sample_t;
+typedef signed long mad_fixed_t;
+enum mad_error {
+  MAD_ERROR_NONE	   = 0x0000,	/* no error */
+};
+struct mad_stream {
+  unsigned char const *buffer;		/* input bitstream buffer */
+  unsigned char const *bufend;		/* end of buffer */
+  unsigned char const *next_frame;	/* start of next frame */
+  enum mad_error error;			/* error code (see above) */
+};
+
+struct mad_frame {
+  int options;
+};
+
+struct mad_pcm {
+  unsigned int samplerate;		/* sampling frequency (Hz) */
+  unsigned short channels;		/* number of channels */
+  unsigned short length;		/* number of samples per channel */
+  mad_fixed_t samples[2][1152];		/* PCM output samples [ch][sample] */
+};
+struct mad_synth {
+  struct mad_pcm pcm;			/* PCM output */
+};
+
+# define mad_stream_init(synth)  /* nothing */
+# define mad_stream_finish(synth)  /* nothing */
+# define mad_frame_init(synth)  /* nothing */
+# define mad_frame_finish(synth)  /* nothing */
+# define mad_synth_init(synth)  /* nothing */
+# define mad_synth_finish(synth)  /* nothing */
+
+# define mad_stream_buffer(a, b, c)  /* nothing */
+# define mad_synth_frame(a, b)  /* nothing */
+
+int mad_frame_decode(struct mad_frame *, struct mad_stream *){return 0;}
+
+# define MAD_RECOVERABLE(error)	((error) & 0xff00)
+# define MAD_F_FRACBITS		28
+# define MAD_F(x)		((mad_fixed_t) (x##L))
+# define MAD_F_ONE		MAD_F(0x10000000)

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -73,6 +73,11 @@ void Files::Init(const char * const *argv)
 			
 	}
 	
+#ifdef __EMSCRIPTEN__
+	config = "/";
+	resources = "/";
+#endif
+	
 	if(resources.empty())
 	{
 		// Find the path to the resource directory. This will depend on the

--- a/source/ImageBuffer.cpp
+++ b/source/ImageBuffer.cpp
@@ -282,7 +282,7 @@ namespace {
 #pragma GCC diagnostic pop
 		
 		jpeg_stdio_src(&cinfo, file);
-		jpeg_read_header(&cinfo, true);
+		jpeg_read_header(&cinfo, TRUE);
 		cinfo.out_color_space = JCS_EXT_RGBA;
 		
 		// MAYBE: Reading in lots of images in a 32-bit process gets really hairy using the standard approach due to

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -43,6 +43,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <algorithm>
 #include <stdexcept>
 
+#ifdef __EMSCRIPTEN__
+#    include <emscripten.h>
+#endif
+
 using namespace std;
 
 namespace {
@@ -479,6 +483,14 @@ void LoadPanel::WriteSnapshot(const string &sourceFile, const string &snapshotNa
 		UpdateLists();
 		selectedFile = Files::Name(snapshotName);
 		loadedInfo.Load(Files::Saves() + selectedFile);
+
+#ifdef __EMSCRIPTEN__
+		// sync from persisted state into memory and then
+		EM_ASM(FS.syncfs(function(err) {
+			assert(!err);
+			console.log("save snapshot synced to IndexedDB");
+		}););
+#endif
 	}
 	else
 		GetUI()->Push(new Dialog("Error: unable to create the file \"" + snapshotName + "\"."));

--- a/source/Music.cpp
+++ b/source/Music.cpp
@@ -14,7 +14,11 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Files.h"
 
+#ifdef __EMSCRIPTEN__
+#include "FakeMad.h"
+#else
 #include <mad.h>
+#endif
 
 #include <algorithm>
 #include <cstring>

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -46,6 +46,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <sstream>
 #include <stdexcept>
 
+#ifdef __EMSCRIPTEN__
+#    include <emscripten.h>
+#endif
+
 using namespace std;
 
 
@@ -359,6 +363,15 @@ void PlayerInfo::Save() const
 	}
 		
 	Save(filePath);
+
+#ifdef __EMSCRIPTEN__
+	EM_ASM(
+	   // syncfs(false) means save in-memory fs to persistent storage
+	   FS.syncfs(false, function(err) {
+		   assert(!err);
+		   console.log("persisted save file to IndexedDB.");
+	}););
+#endif
 }
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -45,6 +45,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <windows.h>
 #endif
 
+#ifdef __EMSCRIPTEN__
+#    include <emscripten.h>
+#endif
+
 using namespace std;
 
 void PrintHelp();
@@ -60,6 +64,21 @@ void InitConsole();
 // Entry point for the EndlessSky executable
 int main(int argc, char *argv[])
 {
+#ifdef __EMSCRIPTEN__
+	EM_ASM(FS.mkdir('/saves');
+	FS.mount(IDBFS, {}, '/saves');
+
+	// sync from persisted state into memory
+	FS.syncfs(
+		true, function(err) {
+			assert(!err);
+			const contents = FS.lookupPath('saves').node.contents;
+			const numFiles = Object.keys(contents).length;
+			console.log(
+				numFiles ? numFiles : "No",
+				"save files found in IndexedDB.");
+		}););
+#endif
 	// Handle command-line arguments
 #ifdef _WIN32
 	if(argc > 1)


### PR DESCRIPTION
**Feature:** Emscripten build for web browsers

This diff is much smaller than [previous attempts](https://github.com/endless-sky/endless-sky/pull/5595) but there's still plenty to discuss, including whether this is a feature that makes sense to merge at all, regardless of how simple the PR is.

There are at least two remaining hacks (I'm fine with them, but should call attention to them in case others aren't):
* loading sound files synchronously instead of in a thread
* no-op libmad replacement header — https://github.com/endless-sky/endless-sky/pull/6163 could be used to avoid running this code, but without that PR the music code runs and does nothing

If this were a good fit it could be followed up by [a bit more work](https://github.com/thomasballinger/endless-web/pull/17/commits) to make a nicer-looking web build.

## UI Screenshots
![image](https://user-images.githubusercontent.com/458879/128388526-60227509-ee66-4e4e-95a1-ad800c1c430b.png)

## Usage Examples
See [developer-readme](https://github.com/endless-sky/endless-sky/commit/e76d42d36f9a23c9a9080db24cbe8643c228ad2e) for full instructions, the gist is to install emsdk and run `scons -j 8 mode=emcc opengl=gles` then `emrun --serve_after_close --browser firefox endless-sky.html`

## Testing Done
Still compiles and runs when run with XCode on a mac.

## Performance Impact
No changes to the normal build, everything is compile-time.

The performance of the web build is significantly slower than the normal build, particularly loading. Performance is similar to https://play-endless-web.com/.
