### PR TITLE
Revert "Fix dragAcceleration formula"

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1806,7 +1806,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	if(acceleration)
 	{
 		acceleration *= slowMultiplier;
-		Point dragAcceleration = acceleration - velocity * (attributes.Get("drag") / (mass / 60.));
+		Point dragAcceleration = acceleration - velocity * (attributes.Get("drag") / mass);
 		// Make sure dragAcceleration has nonzero length, to avoid divide by zero.
 		if(dragAcceleration)
 		{


### PR DESCRIPTION
Reverts endless-sky/endless-sky#5776

This change has scaled ship  top speeds by 1/60. Issue was noted 9th March on the original PR and now reported on Discord and issue #6166


