### PR TITLE
Add a case in "Hai: First Contact" for players who don't enter Hai space

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -39,6 +39,12 @@ mission "First Contact: Hai"
 			
 			label next
 			`	You glance quickly at the human merchant to see his expression, wondering if these aliens can indeed be so benign, but his expression is calm and untroubled. "It's true," he says, "look around you. These buildings have stood for thousands of years. Hai society is so advanced, they need almost no resources to maintain it."`
+			branch wormhole
+				has "Discovered Ultima Thule: failed"
+			choice
+				`	"How did humanity reach this place? Did they use jump drives?"`
+			`	The human merchant raises an eyebrow. "A jump drive? Can't say I'm familiar with what that is. In case you aren't in the know, though, there's a wormhole in Hai space that connects back to a secluded part of human space. Don't bother trying to figure out why and how it's there, because not even the Hai know."`
+			label wormhole
 			choice
 				`	"Why do you allow humans to settle here?"`
 				`	"What do you ask for in return for letting humans settle here?"`
@@ -65,7 +71,12 @@ mission "First Contact: Hai"
 			`	"So I can travel anywhere I want in your territory?" you ask the Hai.`
 			
 			label travel
+			branch jump
+				not "Discovered Ultima Thule: failed"
 			`	"Yes," it says, "but be careful. The north is the territory of some renegade Hai who are misled in their ways: bandits and pirates, living off what they steal from the rest of us. If you travel among them, you will not be safe."`
+				goto end
+			label jump
+			`	"Yes," it says, "but be careful. The north is the territory of some renegade Hai who are misled in their ways: bandits and pirates, living off what they steal from the rest of us. And if what you say about having a jump drive is true, I would be doubly wary. I have heard rumors that the 'Unfettered Hai' are soliciting captains who land on their worlds to give them jump drives."`
 				goto end
 			
 			label question
@@ -92,6 +103,14 @@ mission "Discovered Hai Space"
 event "label hai space"
 	galaxy "label hai"
 		sprite "label/hai"
+
+mission "Discovered Ultima Thule"
+	landing
+	invisible
+	to complete
+		never
+	on enter "Ultima Thule"
+		fail
 
 
 


### PR DESCRIPTION
## Summary
The discussion in #6156 reminded me of how, during my first playthrough, I entered Hai space using a JD and was thoroughly confused as to why Eliot was able to claim that he was born in human space despite being in an area that was 'clearly' only accessible through a jump drive, and I didn't figure out the wormhole even existed until much later. This PR ensures that the player is aware of the wormhole's existence regardless of entry method, and also adds a possible incentive to land on the Unfettered worlds.