### PR TITLE
Added Windows uuid library to CodeBlocks

### DIFF
--- a/EndlessSky.cbp
+++ b/EndlessSky.cbp
@@ -66,6 +66,7 @@
 					<Add library="libopenal32.dll.a" />
 					<Add library="libglew32.dll.a" />
 					<Add library="libopengl32.a" />
+					<Add library="librpcrt4.a" />
 					<Add directory="C:/dev32/lib" />
 					<Add directory="C:/Program Files (x86)/mingw-w64/i686-5.2.0-posix-dwarf-rt_v4-rev0/mingw32/i686-w64-mingw32/lib" />
 				</Linker>

--- a/EndlessSky.cbp
+++ b/EndlessSky.cbp
@@ -90,6 +90,7 @@
 			<Add library="libopenal32.dll.a" />
 			<Add library="libglew32.dll.a" />
 			<Add library="libopengl32.a" />
+			<Add library="librpcrt4.a" />
 			<Add directory="C:/dev64/lib" />
 			<Add directory="C:/Program Files/mingw-w64/x86_64-8.1.0-posix-seh-rt_v6-rev0/mingw64/x86_64-w64-mingw32/lib" />
 		</Linker>

--- a/EndlessSkyTests.cbp
+++ b/EndlessSkyTests.cbp
@@ -20,6 +20,7 @@
 				</Compiler>
 				<Linker>
 					<Add library="lib/Debug/libendless-sky.a" />
+					<Add library="librpcrt4.a" />
 				</Linker>
 			</Target>
 			<Target title="Release">
@@ -39,6 +40,7 @@
 				<Linker>
 					<Add option="-flto" />
 					<Add library="lib/Release/libendless-sky.a" />
+					<Add library="librpcrt4.a" />
 				</Linker>
 			</Target>
 		</Build>
@@ -60,7 +62,7 @@
 			<Add library="libglew32.dll.a" />
 			<Add library="libopengl32.a" />
 			<Add directory="C:/dev64/lib" />
-			<Add directory="C:/Program Files/mingw64/x86_64-w64-mingw32/lib" />
+			<Add directory="C:/Program Files/mingw-w64/x86_64-8.1.0-posix-seh-rt_v6-rev0/mingw64/x86_64-w64-mingw32/lib" />
 		</Linker>
 		<Unit filename="tests/src/helpers/datanode-factory.cpp" />
 		<Unit filename="tests/src/test_account.cpp" />


### PR DESCRIPTION
-----------------------
**Bugfix:** This PR addresses a minor known issue where CodeBlocks on Windows gets a linker error because it can't find the uuid implementation.

## Fix Details
This bugfix updates the CodeBlocks config by telling it to link with rpcrt4, which provides the Windows equivalent of libuuid.a.

## Testing Done
With the patch, I can now build the project in CodeBlocks on Windows.

## Save File
N/A