### PR TITLE
Allow commas in player-entered bank payments.

### DIFF
--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -186,6 +186,7 @@ double Format::Parse(const string &str)
 	{
 		if(*it == '.')
 			place = .1;
+		else if(*it == ',') {}
 		else if(*it < '0' || *it > '9')
 			break;
 		else

--- a/tests/src/text/test_format.cpp
+++ b/tests/src/text/test_format.cpp
@@ -79,6 +79,20 @@ SCENARIO("A unit of playing time is to be made human-readable", "[Format][PlayTi
 	}
 }
 
+SCENARIO("A player-entered quantity can be parsed to a number", "[Format][Parse]") {
+	GIVEN( "The string 123.45" ) {
+		THEN( "parses to 123.45" ) {
+			CHECK( Format::Parse("123.45") == 123.45);
+		}
+	}
+
+	GIVEN( "The string 1,234K" ) {
+		THEN( "parses to 1234000" ) {
+			CHECK( Format::Parse("1,234K") == 1234000);
+		}
+	}
+}
+
 // #endregion unit tests
 
 // #region benchmarks


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #{{insert number}}

## Feature Details
Allow the player to enter mortgage payment numbers that include commas, like 1,000,000.

## UI Screenshots
N/A

## Testing Done
Tested a payment of 10,000 in the game.

## Performance Impact
N/A - parse code is only ever called on manually-entered user input.
