### PR TITLE
fix(ui): Capitalize words after whitespace in cargo strings

### DIFF
--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -298,7 +298,7 @@ string Format::Capitalize(const string &str)
 	bool first = true;
 	for(char &c : result)
 	{
-		if(!isalpha(c))
+		if(c == ' ')
 			first = true;
 		else
 		{

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -298,7 +298,7 @@ string Format::Capitalize(const string &str)
 	bool first = true;
 	for(char &c : result)
 	{
-		if(c == ' ')
+		if(isspace(c))
 			first = true;
 		else
 		{

--- a/tests/src/text/test_format.cpp
+++ b/tests/src/text/test_format.cpp
@@ -93,6 +93,29 @@ SCENARIO("A player-entered quantity can be parsed to a number", "[Format][Parse]
 	}
 }
 
+SCENARIO("A string is capitalized", "[Format][Capitalize]") {
+	GIVEN( "The string 'magnesium'" ) {
+		THEN( "capitalizes to 'Magnesium'" ) {
+			CHECK( Format::Capitalize("magnesium") == "Magnesium" );
+		}
+	}
+	GIVEN( "The string 'canned fruit'" ) {
+		THEN( "capitalizes to 'Canned Fruit'" ) {
+			CHECK( Format::Capitalize("canned fruit") == "Canned Fruit" );
+		}
+	}
+	GIVEN( "The string 'de-ionizers'" ) {
+		THEN( "capitalizes to 'De-ionizers'" ) {
+			CHECK( Format::Capitalize("de-ionizers") == "De-ionizers" );
+		}
+	}
+	GIVEN( "The string 'plumber's pipe'" ) {
+		THEN( "capitalizes to 'Plumber's Pipe'" ) {
+			CHECK( Format::Capitalize("plumber's pipe") == "Plumber's Pipe" );
+		}
+	}
+}
+
 // #endregion unit tests
 
 // #region benchmarks


### PR DESCRIPTION
**Bugfix:** This PR fixes #6173.

## Fix Details
This PR causes Format::Capitalize() to only set the bool to capitalize a character when it matches a space, rather than any alphabet letter. The only non-letter characters in commodities.txt are hyphens, apostrophes, and the number 3 for 3D printers. This fixes any issues with apostrophes.

![image](https://user-images.githubusercontent.com/4471575/128790801-254df7cb-0617-41cf-b2e2-81e152c50e1c.png)

By setting it to not capitalize after hyphens, there is a slight issue in terms of fully-hyphenated words, where we get High-performance Automobiles instead of High-Performance Automobiles. However, this leaves us with more proper De-ionizers or By-products, which seems preferable to the other hyphenated words.

![image](https://user-images.githubusercontent.com/4471575/128790961-2e3e1ce5-b9cf-49c0-90f4-61fca6b5616d.png)

## Testing Done
Accepting missions with non-alphabet characters, and observing proper capitalization on them.

## Save File
[asdf asdf.txt](https://github.com/endless-sky/endless-sky/files/6952435/asdf.asdf.txt)