### PR TITLE
Fix Brick's person ship's description typo

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -1384,4 +1384,4 @@ ship "Modified Boxwing"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description `No matter how maligned, every ship has someone out there that loves it.`
-	description `Surprisingly, someone invested a lot of time, money, and effort into transforming this humble boxwing from a flying coffin into a palatial sarcophogus. It is still terribly cramped, but at least it is luxurious and shiny!`
+	description `Surprisingly, someone invested a lot of time, money, and effort into transforming this humble boxwing from a flying coffin into a palatial sarcophagus. It is still terribly cramped, but at least it is luxurious and shiny!`


### PR DESCRIPTION
**Bugfix:** This PR addresses a typo in Brick's person ship description. Thank you to Mr Doom on the discord for pointing this out.

## Fix Details
In the description, `into a palatial sarcophogus.` should be `into a palatial sarcophagus.`.

## Testing Done
lol i changed one letter

## Save File
Any save file works.