### PR TITLE
Fixed Deep merchant fleets using D.S.S. names

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1411,8 +1411,7 @@ fleet "Navy Surveillance"
 
 fleet "Small Deep Merchants"
 	government "Merchant"
-	names "deep"
-	fighters "deep fighter"
+	names "civilian"
 	cargo 0
 	personality
 		heroic
@@ -1446,8 +1445,7 @@ fleet "Small Deep Merchants"
 
 fleet "Large Deep Merchants"
 	government "Merchant"
-	names "deep"
-	fighters "deep fighter"
+	names "civilian"
 	cargo 0
 	personality
 		heroic


### PR DESCRIPTION
-----------------------
**Bugfix:** I haven't seen this in the issues list.

## Fix Details
Merchant ships in Deep space have been popping up with names from the Deep Security list instead of the merchant list.  I edited fleets.txt to prevent this.

## Testing Done
I flew around the Deep looking at ship names.  Nothing out of the ordinary popped up in terms of either names or ships.

[Deep Merchant.txt](https://github.com/endless-sky/endless-sky/files/6959214/Deep.Merchant.txt)
