### PR TITLE
fix(ui,content): Shorten spacediving job descriptions to avoid overflow in the Missions panel

### DIFF
--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3216,7 +3216,7 @@ mission "Spacediving professionals"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space.  They've agreed to pay <payment> when they land."
+	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay <payment> when they land."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3238,7 +3238,7 @@ mission "Spacediving professionals accident"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space.  They've agreed to pay 120000 credits when they land."
+	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay 120000 credits when they land."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3260,7 +3260,7 @@ mission "Spacediving professionals disaster"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space.  They've agreed to pay 120000 credits when they land."
+	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay 120000 credits when they land."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3216,7 +3216,7 @@ mission "Spacediving professionals"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers, then drop them from the edge of space as you land. They are wearing thermal spacesuits, durable parachutes, and oxygen bottles to ensure their survival. Extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is <payment>."
+	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look professional, but extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is <payment>."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3238,7 +3238,7 @@ mission "Spacediving professionals accident"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers, then drop them from the edge of space as you land. They are wearing thermal spacesuits, durable parachutes, and oxygen bottles to ensure their survival. Extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000."
+	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look professional, but extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3260,7 +3260,7 @@ mission "Spacediving professionals disaster"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers, then drop them from the edge of space as you land. They are wearing thermal spacesuits, durable parachutes, and oxygen bottles to ensure their survival. Extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000."
+	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look professional, but extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3284,7 +3284,7 @@ mission "Spacediving amateurs"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers, then drop them from the edge of space as you land. They are wearing tricked-out wingsuits, brightly-patterned parachutes, and carrying beer bottles for an after-landing celebration. Extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000 credits."
+	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look amateuristic, and extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000 credits."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3238,7 +3238,7 @@ mission "Spacediving professionals accident"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look professional, but extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000."
+	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look professional, but extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000 credits."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3260,7 +3260,7 @@ mission "Spacediving professionals disaster"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look professional, but extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000."
+	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look professional, but extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000 credits."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3216,7 +3216,7 @@ mission "Spacediving professionals"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look professional, but extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is <payment>."
+	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look like professionals. Extreme sports jobs typically carry more risks than regular transport jobs. Payment is <payment>."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3238,7 +3238,7 @@ mission "Spacediving professionals accident"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look professional, but extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000 credits."
+	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look like professionals. Extreme sports jobs typically carry more risks than regular transport jobs. Payment is 120000 credits."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3260,7 +3260,7 @@ mission "Spacediving professionals disaster"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look professional, but extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000 credits."
+	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look like professionals. Extreme sports jobs typically carry more risks than regular transport jobs. Payment is 120000 credits."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3284,7 +3284,7 @@ mission "Spacediving amateurs"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look amateuristic, and extreme sports like skydiving typically carry more risks than regular passenger transports. Payment is 120000 credits."
+	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look amateuristic. Extreme sports jobs typically carry more risks than regular transport jobs. Payment is 120000 credits."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"

--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -3216,7 +3216,7 @@ mission "Spacediving professionals"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look like professionals. Extreme sports jobs typically carry more risks than regular transport jobs. Payment is <payment>."
+	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space.  They've agreed to pay <payment> when they land."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3238,7 +3238,7 @@ mission "Spacediving professionals accident"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look like professionals. Extreme sports jobs typically carry more risks than regular transport jobs. Payment is 120000 credits."
+	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space.  They've agreed to pay 120000 credits when they land."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3260,7 +3260,7 @@ mission "Spacediving professionals disaster"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look like professionals. Extreme sports jobs typically carry more risks than regular transport jobs. Payment is 120000 credits."
+	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space.  They've agreed to pay 120000 credits when they land."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3284,7 +3284,7 @@ mission "Spacediving amateurs"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> skydivers and drop them from the edge of space. They look amateuristic. Extreme sports jobs typically carry more risks than regular transport jobs. Payment is 120000 credits."
+	description "Head to <destination> with <bunks> poorly equipped skydivers and drop them from the edge of space. They've agreed to pay 120000 credits when they land."
 	passengers 5 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Shortened the texts around skydiving as suggested in #6179, because the textbox was overflowing with the texts currently in the game.

Fixes #6179

## Save File
N/A

## PR Checklist
 N/A  
