### PR TITLE
fix(content): Drop Remnant requirement from City-Ship license

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1024,6 +1024,8 @@ mission "Deep: Project Hawking"
 	to offer
 		random < 40
 		has "Deep: Mystery Cubes 4: done"
+		not "Deep: TMBR 0: active"
+		not "Deep: TMBR 1: active"
 		or
 			not "chosen sides"
 			has "main plot completed"
@@ -1282,6 +1284,9 @@ mission "Deep: Remnant 0"
 		has "Deep: Mystery Cubes 4: done"
 		has "Terminus exploration: done"
 		has "First Contact: Hai: offered"
+		or
+			not "Deep: Scientist Rescue 0: offered"
+			has "Deep: Scientist Rescue 3B: done"
 		or
 			not "chosen sides"
 			has "main plot completed"
@@ -1937,6 +1942,9 @@ mission "Deep: Scientist Rescue 0"
 	waypoint "Betelgeuse"
 	to offer
 		has "event: deep: scientist rescue timer"
+		or
+			not "Deep: Remnant 0: offered"
+			has "Deep: Remnant Research: done"
 		or
 			not "chosen sides"
 			has "main plot completed"

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1917,7 +1917,6 @@ mission "Deep: Scientist Rescue Timer"
 	landing
 	invisible
 	to offer
-		has "Deep: Remnant Research: done"
 		has "Deep: Project Hawking: done"
 	on offer
 		event "deep: scientist rescue timer" 60


### PR DESCRIPTION
This PR removes requiring the player to have completed the Deep/Remnant missions for the final set of missions before getting the City-Ship license. By requiring a player to complete those, it softlocks anyone looking to get the Bactrian behind meeting the Hai, with giving no indication that the two are connected. With removing the requirement, a player can obtain the Bactrian by staying in human space, and mostly just need to figure out the Mystery Delivery/Retrieval connection.