### PR TITLE
Proposed change for stellars covering text bug.

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -884,12 +884,12 @@ void Engine::Draw() const
 	static const Set<Color> &colors = GameData::Colors();
 	const Interface *hud = GameData::Interfaces().Get("hud");
 	
+	draw[drawTickTock].Draw();
+	batchDraw[drawTickTock].Draw();
+	
 	// Draw any active planet labels.
 	for(const PlanetLabel &label : labels)
 		label.Draw();
-	
-	draw[drawTickTock].Draw();
-	batchDraw[drawTickTock].Draw();
 	
 	for(const auto &it : statuses)
 	{

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -171,6 +171,7 @@ private:
 	bool drawTickTock = false;
 	bool terminate = false;
 	bool wasActive = false;
+	DrawList draw_first[2];
 	DrawList draw[2];
 	BatchDrawList batchDraw[2];
 	Radar radar[2];

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -62,6 +62,8 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 	}
 	float alpha = static_cast<float>(min(.5, max(0., .6 - (position.Length() - radius) * .001 * zoom)));
 	color = Color(color.Get()[0] * alpha, color.Get()[1] * alpha, color.Get()[2] * alpha, 0.);
+	float alpha_shadow = static_cast<float>(min(.833, max(0., 1. - (position.Length() - radius) * .00166 * zoom)));
+	shadow = Color(0., 0., 0., alpha_shadow);
 	
 	if(!system)
 		return;
@@ -127,9 +129,11 @@ void PlanetLabel::Draw() const
 		LineShader::Draw(from, to, 1.3f, color);
 		
 		double nameX = to.X() + (direction < 2 ? 2. : -bigFont.Width(name) - 2.);
+		bigFont.DrawAliased(name, nameX, to.Y() - .5 * bigFont.Height(), shadow);
 		bigFont.DrawAliased(name, nameX, to.Y() - .5 * bigFont.Height(), color);
 		
 		double governmentX = to.X() + (direction < 2 ? 4. : -font.Width(government) - 4.);
+		font.DrawAliased(government, governmentX, to.Y() + .5 * bigFont.Height() + 1., shadow);
 		font.DrawAliased(government, governmentX, to.Y() + .5 * bigFont.Height() + 1., color);
 	}
 	Angle barbAngle(innerAngle + 36.);

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -36,6 +36,7 @@ private:
 	std::string name;
 	std::string government;
 	Color color;
+	Color shadow;
 	int hostility = 0;
 	int direction = 0;
 };


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6194 (and duplicates #2340/#2598/#6176)

## Fix Details
This PR does two things:
1) Reorders the render order so PlanetLabel comes after stellar objects
2) Draws the label twice, once as a high alpha (but still fading with distance) black to make text readable over bright stellars

Step one does this:
<img width="137" alt="Step One" src="https://user-images.githubusercontent.com/80430868/129647198-f0373e8f-1db5-47fb-9efe-abcf54c36a61.png">

Step two does this:
<img width="131" alt="Step Two" src="https://user-images.githubusercontent.com/80430868/129647207-f8c75e2a-31d3-41ee-acc1-990c9ed7662d.png">


## Testing Done
Suggested fix only changes how PlanetLabel is rendered. I did check around other systems to get a feel for other colours, but they all seem fine. "Shadow" fade is made to be as linear as possible with regular text fade.

## Save File
Save file may be found on #6194 for immediate demonstration. Some zooming may be required.