### PR TITLE
Feature - Attempting to salvage Painted-Sky's expanded hardpoint support code.

### DIFF
--- a/source/Command.h
+++ b/source/Command.h
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <cstdint>
 #include <string>
+#include <bitset>
 
 class DataNode;
 
@@ -138,21 +139,20 @@ public:
 	
 	
 private:
-	explicit Command(uint64_t state);
-	Command(uint64_t state, const std::string &text);
+	explicit Command(uint32_t state);
+	Command(uint32_t state, const std::string &text);
 	
 	
 private:
-	// The key commands and weapons to fire are stored in a single bitmask, with
-	// 32 bits for key commands and 32 bits for individual weapons.
-	// Ship::Load gives a soft warning for ships with more than 32 weapons.
-	uint64_t state = 0;
+	// 512 bits for weapons firing.
+	uint64_t firing_weps[8] = {};
+	// The key commands are stored in a single bitmask, with 32 bits for key commands.
+	uint32_t state = 0;
 	// Turning amount is stored as a separate double to allow fractional values.
 	double turn = 0.;
+	// std::bitset<512> firing_weps;
 	// Turret turn rates, reduced to 8 bits to save space.
-	signed char aim[32] = {};
+	signed char aim[512] = {};
 };
-
-
 
 #endif

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -282,9 +282,9 @@ void Ship::Load(const DataNode &node)
 				armament.AddGunPort(hardpoint, gunPortAngle, gunPortParallel, drawUnder, outfit);
 			else
 				armament.AddTurret(hardpoint, drawUnder, outfit);
-			// Print a warning for the first hardpoint after 32, i.e. only 1 warning per ship.
-			if(armament.Get().size() == 33)
-				child.PrintTrace("Warning: ship has more than 32 weapon hardpoints. Some weapons may not fire:");
+			// Print a warning for the first hardpoint after 512, i.e. only 1 warning per ship.
+			if(armament.Get().size() == 513)
+				child.PrintTrace("Warning: ship has more than 512 weapon hardpoints. Some weapons may not fire:");
 		}
 		else if(key == "never disabled")
 			neverDisabled = true;
@@ -2085,7 +2085,7 @@ void Ship::DoGeneration()
 		
 		// Convert fuel into energy and heat only when the required amount of fuel is available.
 		if(attributes.Get("fuel consumption") <= fuel)
-		{	
+		{
 			fuel -= attributes.Get("fuel consumption");
 			energy += attributes.Get("fuel energy");
 			heat += attributes.Get("fuel heat");


### PR DESCRIPTION
**Feature:** This is an attempt to see if we can salvage #4635 

Note: I'm not really a coder, so I'm not sure how much coding I can do on this, but it seemed pretty close to done, and I think the capacities it introduces are beneficial, particularly for plug-in support. First off, though, is seeing if it will build and pass tests...

## Feature Details
Re-implements Painted-Sky's code changes to allow large numbers of hardpoints in an up-to-date codebase.

See https://github.com/endless-sky/endless-sky/pull/4635 for conversation and development history.

## UI Screenshots
*images to come*

## Usage Examples
Mainly for plug-in support (Looking at you, Star Wars plugins with Destroyers with hundreds of turrets), although it could be used for - lacking a better word - boss fights in missions. Facing a world-ship that was actually Heron+ sized could realistically make use of 32+

## Testing Done
(to come)

## Performance Impact
Extreme numbers of turrets is expected to have an impact, but this change shouldn't affect current vanilla performance significantly.
