### PR TITLE
feat(UI): Highlight raid alert message

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1232,7 +1232,7 @@ void Engine::EnterSystem()
 				{
 					raidFleet->Place(*system, newShips);
 					Messages::Add("Your fleet has attracted the interest of a "
-							+ raidGovernment->GetName() + " raiding party.", Messages::Importance::High);
+							+ raidGovernment->GetName() + " raiding party.", Messages::Importance::Highest);
 				}
 	}
 	


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4471575/129985858-f86409d2-1ba5-4600-8254-dd9a2e52ec56.png)

This PR sets the raid alert message's importance to Highest, highlighting it orange along with the mission failure or hyperspace alerts. The Raid Warning tutorial mission is still important for specifically laying out why it happens, but now that we have the capability to highlight messages, this seems like one of the more important ones.