### PR TITLE
feat/architecture: Remove GameData dependency from Ship

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -228,7 +228,11 @@ bool GameData::BeginLoad(const char * const *argv)
 	
 	// And, update the ships with the outfits we've now finished loading.
 	for(auto &&it : ships)
-		it.second.FinishLoading(true);
+		it.second.FinishLoading(true,
+			Category(CategoryType::BAY),
+			Effects(),
+			Ships()
+		);
 	for(auto &&it : persons)
 		it.second.FinishLoading();
 	
@@ -1090,7 +1094,14 @@ void GameData::LoadFile(const string &path, bool debugMode)
 		{
 			// Allow multiple named variants of the same ship model.
 			const string &name = node.Token((node.Size() > 2) ? 2 : 1);
-			ships.Get(name)->Load(node);
+			ships.Get(name)->Load(node,
+					effects,
+					outfits,
+					planets,
+					ships,
+					systems,
+					playerGovernment
+				);
 		}
 		else if(key == "shipyard" && node.Size() >= 2)
 			shipSales.Get(node.Token(1))->Load(node, ships);

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -228,10 +228,10 @@ bool GameData::BeginLoad(const char * const *argv)
 	
 	// And, update the ships with the outfits we've now finished loading.
 	for(auto &&it : ships)
-		it.second.FinishLoading(true,
-			Category(CategoryType::BAY),
-			Effects(),
-			Ships()
+		it.second.FinishLoading(true
+			, Category(CategoryType::BAY)
+			, Effects()
+			, Ships()
 		);
 	for(auto &&it : persons)
 		it.second.FinishLoading();
@@ -1094,14 +1094,14 @@ void GameData::LoadFile(const string &path, bool debugMode)
 		{
 			// Allow multiple named variants of the same ship model.
 			const string &name = node.Token((node.Size() > 2) ? 2 : 1);
-			ships.Get(name)->Load(node,
-					effects,
-					outfits,
-					planets,
-					ships,
-					systems,
-					playerGovernment
-				);
+			ships.Get(name)->Load(node
+				, effects
+				, outfits
+				, planets
+				, ships
+				, systems
+				, playerGovernment
+			);
 		}
 		else if(key == "shipyard" && node.Size() >= 2)
 			shipSales.Get(node.Token(1))->Load(node, ships);

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -153,13 +153,14 @@ void NPC::Load(const DataNode &node)
 			{
 				// Loading an NPC from a save file, or an entire ship specification.
 				// The latter may result in references to non-instantiated outfits.
-				ships.emplace_back(make_shared<Ship>(child,
-					GameData::Effects(),
-					GameData::Outfits(),
-					GameData::Planets(),
-					GameData::Ships(),
-					GameData::Systems(),
-					GameData::PlayerGovernment() ));
+				ships.emplace_back(make_shared<Ship>(child
+					, GameData::Effects()
+					, GameData::Outfits()
+					, GameData::Planets()
+					, GameData::Ships()
+					, GameData::Systems()
+					, GameData::PlayerGovernment()
+				));
 				for(const DataNode &grand : child)
 					if(grand.Token(0) == "actions" && grand.Size() >= 2)
 						actions[ships.back().get()] = grand.Value(1);
@@ -214,11 +215,11 @@ void NPC::Load(const DataNode &node)
 		ship->SetGovernment(government);
 		ship->SetPersonality(personality);
 		ship->SetIsSpecial();
-		ship->FinishLoading(false,
-				GameData::Category(CategoryType::BAY),
-				GameData::Effects(),
-				GameData::Ships()
-			);
+		ship->FinishLoading(false
+			, GameData::Category(CategoryType::BAY)
+			, GameData::Effects()
+			, GameData::Ships()
+		);
 	}
 }
 
@@ -600,11 +601,11 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	{
 		// This ship is being defined from scratch.
 		result.ships.push_back(make_shared<Ship>(*ship));
-		result.ships.back()->FinishLoading(true,
-				GameData::Category(CategoryType::BAY),
-				GameData::Effects(),
-				GameData::Ships()
-			);
+		result.ships.back()->FinishLoading(true
+			, GameData::Category(CategoryType::BAY)
+			, GameData::Effects()
+			, GameData::Ships()
+		);
 	}
 	auto shipIt = stockShips.begin();
 	auto nameIt = shipNames.begin();

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -153,7 +153,13 @@ void NPC::Load(const DataNode &node)
 			{
 				// Loading an NPC from a save file, or an entire ship specification.
 				// The latter may result in references to non-instantiated outfits.
-				ships.emplace_back(make_shared<Ship>(child));
+				ships.emplace_back(make_shared<Ship>(child,
+					GameData::Effects(),
+					GameData::Outfits(),
+					GameData::Planets(),
+					GameData::Ships(),
+					GameData::Systems(),
+					GameData::PlayerGovernment() ));
 				for(const DataNode &grand : child)
 					if(grand.Token(0) == "actions" && grand.Size() >= 2)
 						actions[ships.back().get()] = grand.Value(1);
@@ -208,7 +214,11 @@ void NPC::Load(const DataNode &node)
 		ship->SetGovernment(government);
 		ship->SetPersonality(personality);
 		ship->SetIsSpecial();
-		ship->FinishLoading(false);
+		ship->FinishLoading(false,
+				GameData::Category(CategoryType::BAY),
+				GameData::Effects(),
+				GameData::Ships()
+			);
 	}
 }
 
@@ -590,7 +600,11 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	{
 		// This ship is being defined from scratch.
 		result.ships.push_back(make_shared<Ship>(*ship));
-		result.ships.back()->FinishLoading(true);
+		result.ships.back()->FinishLoading(true,
+				GameData::Category(CategoryType::BAY),
+				GameData::Effects(),
+				GameData::Ships()
+			);
 	}
 	auto shipIt = stockShips.begin();
 	auto nameIt = shipNames.begin();

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -35,7 +35,13 @@ void Person::Load(const DataNode &node)
 			// Name ships that are not the flagship with the name provided, if any.
 			// The flagship, and any unnamed fleet members, will be given the name of the Person.
 			bool setName = !ships.empty() && child.Size() >= 3;
-			ships.emplace_back(make_shared<Ship>(child));
+			ships.emplace_back(make_shared<Ship>(child,
+				GameData::Effects(),
+				GameData::Outfits(),
+				GameData::Planets(),
+				GameData::Ships(),
+				GameData::Systems(),
+				GameData::PlayerGovernment() ));
 			if(setName)
 				ships.back()->SetName(child.Token(2));
 		}
@@ -56,7 +62,11 @@ void Person::Load(const DataNode &node)
 void Person::FinishLoading()
 {
 	for(const shared_ptr<Ship> &ship : ships)
-		ship->FinishLoading(true);
+		ship->FinishLoading(true,
+				GameData::Category(CategoryType::BAY),
+				GameData::Effects(),
+				GameData::Ships()
+			);
 }
 
 

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -35,13 +35,14 @@ void Person::Load(const DataNode &node)
 			// Name ships that are not the flagship with the name provided, if any.
 			// The flagship, and any unnamed fleet members, will be given the name of the Person.
 			bool setName = !ships.empty() && child.Size() >= 3;
-			ships.emplace_back(make_shared<Ship>(child,
-				GameData::Effects(),
-				GameData::Outfits(),
-				GameData::Planets(),
-				GameData::Ships(),
-				GameData::Systems(),
-				GameData::PlayerGovernment() ));
+			ships.emplace_back(make_shared<Ship>(child
+				, GameData::Effects()
+				, GameData::Outfits()
+				, GameData::Planets()
+				, GameData::Ships()
+				, GameData::Systems()
+				, GameData::PlayerGovernment()
+			));
 			if(setName)
 				ships.back()->SetName(child.Token(2));
 		}
@@ -62,11 +63,11 @@ void Person::Load(const DataNode &node)
 void Person::FinishLoading()
 {
 	for(const shared_ptr<Ship> &ship : ships)
-		ship->FinishLoading(true,
-				GameData::Category(CategoryType::BAY),
-				GameData::Effects(),
-				GameData::Ships()
-			);
+		ship->FinishLoading(true
+			, GameData::Category(CategoryType::BAY)
+			, GameData::Effects()
+			, GameData::Ships()
+		);
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -178,7 +178,13 @@ void PlayerInfo::Load(const string &path)
 		else if(child.Token(0) == "ship")
 		{
 			// Ships owned by the player have various special characteristics:
-			ships.push_back(make_shared<Ship>(child));
+			ships.push_back(make_shared<Ship>(child,
+				GameData::Effects(),
+				GameData::Outfits(),
+				GameData::Planets(),
+				GameData::Ships(),
+				GameData::Systems(),
+				GameData::PlayerGovernment() ));
 			ships.back()->SetIsSpecial();
 			ships.back()->SetIsYours();
 			// Defer finalizing this ship until we have processed all changes to game state.
@@ -2409,7 +2415,11 @@ void PlayerInfo::ApplyChanges()
 	{
 		// Government changes may have changed the player's ship swizzles.
 		ship->SetGovernment(GameData::PlayerGovernment());
-		ship->FinishLoading(false);
+		ship->FinishLoading(false,
+				GameData::Category(CategoryType::BAY),
+				GameData::Effects(),
+				GameData::Ships()
+			);
 	}
 }
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -178,13 +178,14 @@ void PlayerInfo::Load(const string &path)
 		else if(child.Token(0) == "ship")
 		{
 			// Ships owned by the player have various special characteristics:
-			ships.push_back(make_shared<Ship>(child,
-				GameData::Effects(),
-				GameData::Outfits(),
-				GameData::Planets(),
-				GameData::Ships(),
-				GameData::Systems(),
-				GameData::PlayerGovernment() ));
+			ships.push_back(make_shared<Ship>(child
+				, GameData::Effects()
+				, GameData::Outfits()
+				, GameData::Planets()
+				, GameData::Ships()
+				, GameData::Systems()
+				, GameData::PlayerGovernment()
+			));
 			ships.back()->SetIsSpecial();
 			ships.back()->SetIsYours();
 			// Defer finalizing this ship until we have processed all changes to game state.
@@ -2415,11 +2416,11 @@ void PlayerInfo::ApplyChanges()
 	{
 		// Government changes may have changed the player's ship swizzles.
 		ship->SetGovernment(GameData::PlayerGovernment());
-		ship->FinishLoading(false,
-				GameData::Category(CategoryType::BAY),
-				GameData::Effects(),
-				GameData::Ships()
-			);
+		ship->FinishLoading(false
+			, GameData::Category(CategoryType::BAY)
+			, GameData::Effects()
+			, GameData::Ships()
+		);
 	}
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -745,6 +745,13 @@ void Ship::FinishLoading(bool isNewInstance)
 			targetSystem = nullptr;
 		}
 	}
+	
+	// Load the default effects for this ship.
+	effectDisruptionSpark = GameData::Effects().Get("disruption spark");
+	effectIonSpark = GameData::Effects().Get("ion spark");
+	effectSlowingSpark = GameData::Effects().Get("slowing spark");
+	effectSmoke = GameData::Effects().Get("smoke");
+	effectJumpDrive = GameData::Effects().Get("jump drive");
 }
 
 
@@ -1363,11 +1370,11 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 
 	// Handle ionization effects, etc.
 	if(ionization)
-		CreateSparks(visuals, "ion spark", ionization * .1);
+		CreateSparks(visuals, effectIonSpark, ionization * .1);
 	if(disruption)
-		CreateSparks(visuals, "disruption spark", disruption * .1);
+		CreateSparks(visuals, effectDisruptionSpark, disruption * .1);
 	if(slowness)
-		CreateSparks(visuals, "slowing spark", slowness * .1);
+		CreateSparks(visuals, effectSlowingSpark, slowness * .1);
 	// Jettisoned cargo effects (only for ships in the current system).
 	if(!jettisoned.empty() && !forget)
 	{
@@ -1422,7 +1429,6 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		{
 			if(!forget)
 			{
-				const Effect *effect = GameData::Effects().Get("smoke");
 				double size = Width() + Height();
 				double scale = .03 * size + .5;
 				double radius = .2 * size;
@@ -1437,7 +1443,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 					Point effectVelocity = velocity + angle.Unit() * (scale * Random::Real());
 					Point effectPosition = position + radius * angle.Unit();
 					
-					visuals.emplace_back(*effect, std::move(effectPosition), std::move(effectVelocity), std::move(angle));
+					visuals.emplace_back(*effectSmoke, std::move(effectPosition), std::move(effectVelocity), std::move(angle));
 				}
 				
 				for(unsigned i = 0; i < explosionTotal / 2; ++i)
@@ -1526,7 +1532,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 			double sparkAmount = hyperspaceCount * Width() * Height() * .000006;
 			const map<const Effect *, int> &jumpEffects = attributes.JumpEffects();
 			if(jumpEffects.empty())
-				CreateSparks(visuals, "jump drive", sparkAmount);
+				CreateSparks(visuals, effectJumpDrive, sparkAmount);
 			else
 			{
 				// Spread the amount of particle effects created among all jump effects.
@@ -3821,14 +3827,6 @@ void Ship::CreateExplosion(vector<Visual> &visuals, bool spread)
 			return;
 		}
 	}
-}
-
-
-
-// Place a "spark" effect, like ionization or disruption.
-void Ship::CreateSparks(vector<Visual> &visuals, const string &name, double amount)
-{
-	CreateSparks(visuals, GameData::Effects().Get(name), amount);
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3286,15 +3286,14 @@ bool Ship::CanCarry(const Ship &ship) const
 
 void Ship::AllowCarried(bool allowCarried)
 {
-	const auto &bayCategories = GameData::Category(CategoryType::BAY);
-	canBeCarried = allowCarried && find(bayCategories.begin(), bayCategories.end(), attributes.Category()) != bayCategories.end();
+	preventCarry = !allowCarried;
 }
 
 
 
 bool Ship::CanBeCarried() const
 {
-	return canBeCarried;
+	return canBeCarried && !preventCarry;
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -132,33 +132,34 @@ namespace {
 
 
 // Construct and Load() at the same time.
-Ship::Ship(const DataNode &node,
-		const Set<Effect> &effectsSet,
-		const Set<Outfit> &outfitsSet,
-		const Set<Planet> &planetsSet,
-		const Set<Ship> &shipsSet,
-		const Set<System> &systemsSet,
-		const Government *playerGov
-	)
+Ship::Ship(const DataNode &node
+	, const Set<Effect> &effectsData
+	, const Set<Outfit> &outfitsData
+	, const Set<Planet> &planetsData
+	, const Set<Ship> &shipsData
+	, const Set<System> &systemsData
+	, const Government *playerGov
+)
 {
-	Load(node,
-		effectsSet,
-		outfitsSet,
-		planetsSet,
-		shipsSet,
-		systemsSet,
-		playerGov);
+	Load(node
+		, effectsData
+		, outfitsData
+		, planetsData
+		, shipsData
+		, systemsData
+		, playerGov
+	);
 }
 
 
 
-void Ship::Load(const DataNode &node,
-		const Set<Effect> &effectsSet,
-		const Set<Outfit> &outfitsSet,
-		const Set<Planet> &planetsSet,
-		const Set<Ship> &shipsSet,
-		const Set<System> &systemsSet,
-		const Government *playerGov
+void Ship::Load(const DataNode &node
+		, const Set<Effect> &effectsData
+		, const Set<Outfit> &outfitsData
+		, const Set<Planet> &planetsData
+		, const Set<Ship> &shipsData
+		, const Set<System> &systemsData
+		, const Government *playerGov
 	)
 {
 	if(node.Size() >= 2)
@@ -168,7 +169,7 @@ void Ship::Load(const DataNode &node,
 	}
 	if(node.Size() >= 3)
 	{
-		base = shipsSet.Get(modelName);
+		base = shipsData.Get(modelName);
 		variantName = node.Token(2);
 	}
 	isDefined = true;
@@ -271,12 +272,12 @@ void Ship::Load(const DataNode &node,
 			{
 				hardpoint = Point(child.Value(1), child.Value(2));
 				if(child.Size() >= 4)
-					outfit = outfitsSet.Get(child.Token(3));
+					outfit = outfitsData.Get(child.Token(3));
 			}
 			else
 			{
 				if(child.Size() >= 2)
-					outfit = outfitsSet.Get(child.Token(1));
+					outfit = outfitsData.Get(child.Token(1));
 			}
 			Angle gunPortAngle = Angle(0.);
 			bool gunPortParallel = false;
@@ -347,7 +348,7 @@ void Ship::Load(const DataNode &node,
 					if(grand.Token(0) == "launch effect" && grand.Size() >= 2)
 					{
 						int count = grand.Size() >= 3 ? static_cast<int>(grand.Value(2)) : 1;
-						const Effect *e = effectsSet.Get(grand.Token(1));
+						const Effect *e = effectsData.Get(grand.Token(1));
 						bay.launchEffects.insert(bay.launchEffects.end(), count, e);
 					}
 					else if(grand.Token(0) == "angle" && grand.Size() >= 2)
@@ -379,7 +380,7 @@ void Ship::Load(const DataNode &node,
 				leaks.clear();
 				hasLeak = true;
 			}
-			Leak leak(effectsSet.Get(child.Token(1)));
+			Leak leak(effectsData.Get(child.Token(1)));
 			if(child.Size() >= 3)
 				leak.openPeriod = child.Value(2);
 			if(child.Size() >= 4)
@@ -395,7 +396,7 @@ void Ship::Load(const DataNode &node,
 				hasExplode = true;
 			}
 			int count = (child.Size() >= 3) ? child.Value(2) : 1;
-			explosionEffects[effectsSet.Get(child.Token(1))] += count;
+			explosionEffects[effectsData.Get(child.Token(1))] += count;
 			explosionTotal += count;
 		}
 		else if(key == "final explode" && child.Size() >= 2)
@@ -406,7 +407,7 @@ void Ship::Load(const DataNode &node,
 				hasFinalExplode = true;
 			}
 			int count = (child.Size() >= 3) ? child.Value(2) : 1;
-			finalExplosions[effectsSet.Get(child.Token(1))] += count;
+			finalExplosions[effectsData.Get(child.Token(1))] += count;
 		}
 		else if(key == "outfits")
 		{
@@ -419,7 +420,7 @@ void Ship::Load(const DataNode &node,
 			{
 				int count = (grand.Size() >= 2) ? grand.Value(1) : 1;
 				if(count > 0)
-					outfits[outfitsSet.Get(grand.Token(0))] += count;
+					outfits[outfitsData.Get(grand.Token(0))] += count;
 				else
 					grand.PrintTrace("Skipping invalid outfit count:");
 			}
@@ -437,14 +438,14 @@ void Ship::Load(const DataNode &node,
 		else if(key == "position" && child.Size() >= 3)
 			position = Point(child.Value(1), child.Value(2));
 		else if(key == "system" && child.Size() >= 2)
-			currentSystem = systemsSet.Get(child.Token(1));
+			currentSystem = systemsData.Get(child.Token(1));
 		else if(key == "planet" && child.Size() >= 2)
 		{
 			zoom = 0.;
-			landingPlanet = planetsSet.Get(child.Token(1));
+			landingPlanet = planetsData.Get(child.Token(1));
 		}
 		else if(key == "destination system" && child.Size() >= 2)
-			targetSystem = systemsSet.Get(child.Token(1));
+			targetSystem = systemsData.Get(child.Token(1));
 		else if(key == "parked")
 			isParked = true;
 		else if(key == "description" && child.Size() >= 2)
@@ -467,18 +468,18 @@ void Ship::Load(const DataNode &node,
 // When loading a ship, some of the outfits it lists may not have been
 // loaded yet. So, wait until everything has been loaded, then call this.
 void Ship::FinishLoading(bool isNewInstance,
-		const vector<string> &bayCategories,
-		const Set<Effect> &effectsSet,
-		const Set<Ship> &shipsSet
-	)
+	const vector<string> &bayCategories,
+	const Set<Effect> &effectsData,
+	const Set<Ship> &shipsData
+)
 {
 	// All copies of this ship should save pointers to the "explosion" weapon
 	// definition stored safely in the ship model, which will not be destroyed
 	// until GameData is when the program quits. Also copy other attributes of
 	// the base model if no overrides were given.
-	if(shipsSet.Has(modelName))
+	if(shipsData.Has(modelName))
 	{
-		const Ship *model = shipsSet.Get(modelName);
+		const Ship *model = shipsData.Get(modelName);
 		explosionWeapon = &model->BaseAttributes();
 		if(pluralModelName.empty())
 			pluralModelName = model->pluralModelName;
@@ -711,7 +712,7 @@ void Ship::FinishLoading(bool isNewInstance,
 		else
 			++it;
 		if(bay.side == Bay::INSIDE && bay.launchEffects.empty() && Crew())
-			bay.launchEffects.emplace_back(effectsSet.Get("basic launch"));
+			bay.launchEffects.emplace_back(effectsData.Get("basic launch"));
 	}
 	
 	canBeCarried = find(bayCategories.begin(), bayCategories.end(), attributes.Category()) != bayCategories.end();
@@ -769,11 +770,11 @@ void Ship::FinishLoading(bool isNewInstance,
 	}
 	
 	// Load the default effects for this ship.
-	effectDisruptionSpark = effectsSet.Get("disruption spark");
-	effectIonSpark = effectsSet.Get("ion spark");
-	effectSlowingSpark = effectsSet.Get("slowing spark");
-	effectSmoke = effectsSet.Get("smoke");
-	effectJumpDrive = effectsSet.Get("jump drive");
+	effectDisruptionSpark = effectsData.Get("disruption spark");
+	effectIonSpark = effectsData.Get("ion spark");
+	effectSlowingSpark = effectsData.Get("slowing spark");
+	effectSmoke = effectsData.Get("smoke");
+	effectJumpDrive = effectsData.Get("jump drive");
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -452,7 +452,10 @@ private:
 	// Characteristics of this particular ship:
 	EsUuid uuid;
 	std::string name;
+	// Can this ship physically be carried (is it of a type for which bays exist)?
 	bool canBeCarried = false;
+	// Does anything prevent this ship from being carried (for example it being used as a flagship)?
+	bool preventCarry = false;
 	
 	int forget = 0;
 	bool isInSystem = true;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -427,7 +427,6 @@ private:
 	// either stay over the ship, or spread out if this is the final explosion.
 	void CreateExplosion(std::vector<Visual> &visuals, bool spread = false);
 	// Place a "spark" effect, like ionization or disruption.
-	void CreateSparks(std::vector<Visual> &visuals, const std::string &name, double amount);
 	void CreateSparks(std::vector<Visual> &visuals, const Effect *effect, double amount);
 	
 	
@@ -557,6 +556,12 @@ private:
 	};
 	std::vector<Leak> leaks;
 	std::vector<Leak> activeLeaks;
+	
+	const Effect *effectIonSpark = nullptr;
+	const Effect *effectDisruptionSpark = nullptr;
+	const Effect *effectSlowingSpark = nullptr;
+	const Effect *effectSmoke = nullptr;
+	const Effect *effectJumpDrive = nullptr;
 	
 	// Explosions that happen when the ship is dying:
 	std::map<const Effect *, int> explosionEffects;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -119,29 +119,30 @@ public:
 
 	Ship() = default;
 	// Construct and Load() at the same time.
-	Ship(const DataNode &node,
-		const Set<Effect> &effectsSet,
-		const Set<Outfit> &outfitsSet,
-		const Set<Planet> &planetsSet,
-		const Set<Ship> &shipsSet,
-		const Set<System> &systemsSet,
-		const Government *playerGov);
+	Ship(const DataNode &node
+		, const Set<Effect> &effectsData
+		, const Set<Outfit> &outfitsData
+		, const Set<Planet> &planetsData
+		, const Set<Ship> &shipsData
+		, const Set<System> &systemsData
+		, const Government *playerGov
+	);
 	
 	// Load data for a type of ship:
-	void Load(const DataNode &node,
-		const Set<Effect> &effectsSet,
-		const Set<Outfit> &outfitsSet,
-		const Set<Planet> &planetsSet,
-		const Set<Ship> &shipsSet,
-		const Set<System> &systemsSet,
-		const Government *playerGov
+	void Load(const DataNode &node
+		, const Set<Effect> &effectsData
+		, const Set<Outfit> &outfitsData
+		, const Set<Planet> &planetsData
+		, const Set<Ship> &shipsData
+		, const Set<System> &systemsData
+		, const Government *playerGov
 	);
 	// When loading a ship, some of the outfits it lists may not have been
 	// loaded yet. So, wait until everything has been loaded, then call this.
-	void FinishLoading(bool isNewInstance,
-		const std::vector<std::string> &bayCategories,
-		const Set<Effect> &effectsSet,
-		const Set<Ship> &shipsSet
+	void FinishLoading(bool isNewInstance
+		, const std::vector<std::string> &bayCategories
+		, const Set<Effect> &effectsData
+		, const Set<Ship> &shipsData
 	);
 	// Check that this ship model and all its outfits have been loaded.
 	bool IsValid() const;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -23,6 +23,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Outfit.h"
 #include "Personality.h"
 #include "Point.h"
+#include "Set.h"
 
 #include <list>
 #include <map>
@@ -118,13 +119,30 @@ public:
 
 	Ship() = default;
 	// Construct and Load() at the same time.
-	Ship(const DataNode &node);
+	Ship(const DataNode &node,
+		const Set<Effect> &effectsSet,
+		const Set<Outfit> &outfitsSet,
+		const Set<Planet> &planetsSet,
+		const Set<Ship> &shipsSet,
+		const Set<System> &systemsSet,
+		const Government *playerGov);
 	
 	// Load data for a type of ship:
-	void Load(const DataNode &node);
+	void Load(const DataNode &node,
+		const Set<Effect> &effectsSet,
+		const Set<Outfit> &outfitsSet,
+		const Set<Planet> &planetsSet,
+		const Set<Ship> &shipsSet,
+		const Set<System> &systemsSet,
+		const Government *playerGov
+	);
 	// When loading a ship, some of the outfits it lists may not have been
 	// loaded yet. So, wait until everything has been loaded, then call this.
-	void FinishLoading(bool isNewInstance);
+	void FinishLoading(bool isNewInstance,
+		const std::vector<std::string> &bayCategories,
+		const Set<Effect> &effectsSet,
+		const Set<Ship> &shipsSet
+	);
 	// Check that this ship model and all its outfits have been loaded.
 	bool IsValid() const;
 	// Save a full description of this ship, as currently configured.

--- a/source/StartConditions.cpp
+++ b/source/StartConditions.cpp
@@ -109,7 +109,13 @@ void StartConditions::Load(const DataNode &node)
 			// a 3rd token (i.e. this will be treated as though it were a ship variant definition,
 			// without making the variant available to the rest of GameData).
 			if(child.HasChildren() || child.Size() >= 3)
-				ships.emplace_back(child);
+				ships.emplace_back(child,
+					GameData::Effects(),
+					GameData::Outfits(),
+					GameData::Planets(),
+					GameData::Ships(),
+					GameData::Systems(),
+					GameData::PlayerGovernment() );
 			// If there's only 2 tokens & there's no child nodes, the created instance would be ill-formed.
 			else
 				child.PrintTrace("Skipping unsupported use of a \"stock\" ship (a full definition is required):");
@@ -146,7 +152,11 @@ void StartConditions::Load(const DataNode &node)
 void StartConditions::FinishLoading()
 {
 	for(Ship &ship : ships)
-		ship.FinishLoading(true);
+		ship.FinishLoading(true,
+				GameData::Category(CategoryType::BAY),
+				GameData::Effects(),
+				GameData::Ships()
+			);
 	
 	if(!GetConversation().IsValidIntro())
 		Files::LogError("Warning: The start scenario \"" + Identifier() + "\" (named \""

--- a/source/StartConditions.cpp
+++ b/source/StartConditions.cpp
@@ -109,13 +109,14 @@ void StartConditions::Load(const DataNode &node)
 			// a 3rd token (i.e. this will be treated as though it were a ship variant definition,
 			// without making the variant available to the rest of GameData).
 			if(child.HasChildren() || child.Size() >= 3)
-				ships.emplace_back(child,
-					GameData::Effects(),
-					GameData::Outfits(),
-					GameData::Planets(),
-					GameData::Ships(),
-					GameData::Systems(),
-					GameData::PlayerGovernment() );
+				ships.emplace_back(child
+					, GameData::Effects()
+					, GameData::Outfits()
+					, GameData::Planets()
+					, GameData::Ships()
+					, GameData::Systems()
+					, GameData::PlayerGovernment()
+				);
 			// If there's only 2 tokens & there's no child nodes, the created instance would be ill-formed.
 			else
 				child.PrintTrace("Skipping unsupported use of a \"stock\" ship (a full definition is required):");
@@ -152,11 +153,11 @@ void StartConditions::Load(const DataNode &node)
 void StartConditions::FinishLoading()
 {
 	for(Ship &ship : ships)
-		ship.FinishLoading(true,
-				GameData::Category(CategoryType::BAY),
-				GameData::Effects(),
-				GameData::Ships()
-			);
+		ship.FinishLoading(true
+			, GameData::Category(CategoryType::BAY)
+			, GameData::Effects()
+			, GameData::Ships()
+		);
 	
 	if(!GetConversation().IsValidIntro())
 		Files::LogError("Warning: The start scenario \"" + Identifier() + "\" (named \""


### PR DESCRIPTION
**Feature:** This PR should improve testability of the Ship class as discussed recently on Discord.

## Feature Details
The GameData class dependency is removed from the Ship class and all the data that is required from GameData is provided as parameter during loading of Ship.

This PR is partially intended to start a discussion; is this the direction we want to go? If yes, then we can change more classes to follow the pattern as proposed here. If no, then I hope that the discussion on this PR will provide a better direction.

## UI Screenshots
N/A; this change is not visible for players, but should make it easier to write unit tests.

## Usage Examples
If we want to change more classes the way that the Ship class is changed, then we can use this PR as template (or just add the additional changes here).

## Testing Done
I briefly started endless-sky, loaded an existing pilot and departed with the ship.

## Performance Impact
The only code that is affected is the code that loads data, and the Sets are provided as references, so the impact should be minimal.