### PR TITLE
Fix: Remnant: Stopping the Void Sprite stopover from displaying on Viminal

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -772,9 +772,8 @@ event "remnant: nenia restored"
 mission "Remnant: Void Sprites 3"
 	landing
 	name "Visit void sprite planets"
-	description `Purchase a "Puffin" from the Remnant world of Viminal, and use it to explore the two gas giants where the void sprites live. Then, return to <planet>.`
+	description `Use the Puffin to explore the two gas giants where the void sprites live. Then, return to <planet>.`
 	source "Aventine"
-	stopover "Viminal"
 	stopover "Nasqueron"
 	stopover "Slylandro"
 	cargo "scanning equipment" 8


### PR DESCRIPTION
**Bugfix:** This PR addresses the issue where <first> skips landing on Viminal, and thus doesn't trigger the `on stopover` text until they return and land on Viminal. 

## Fix Details
Made two corrections to bring the mission in line with how it actually runs now:
- Removed the Viminal stopover
- Altered the mission description.

**Thanks**
Thanks to TheTurkeyChicken and kyoot ploochi on the ES Discord for reporting this bug.
