### PR TITLE
fix(content): Set Dredger bounty requirement to done instead of failed

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3696,7 +3696,11 @@ mission "Remnant: Bounty 3"
 	source
 		government "Remnant"
 	to offer
-		has "Remnant: Cognizance 4: done"
+		# 0.9.13 Compatibility patch
+		or
+			has "Remnant: Cognizance 4: done"
+			has "Remnant: Cognizance 4: failed"
+		not "Remnant: Cognizance 4: aborted"
 		random < 40
 	npc kill
 		government "Korath"
@@ -3723,10 +3727,11 @@ mission "Remnant: Cognizance 5"
 	source "Caelian"
 	waypoint "Aescolanus"
 	to offer
+		# 0.9.13 Compatibility patch
 		or
 			has "Remnant: Cognizance 4: done"
-			# 0.9.13 Compatibility patch
 			has "Remnant: Cognizance 4: failed"
+		not "Remnant: Cognizance 4: aborted"
 	on offer
 		conversation
 			branch fleetkilled

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3696,7 +3696,7 @@ mission "Remnant: Bounty 3"
 	source
 		government "Remnant"
 	to offer
-		has "Remnant: Cognizance 4: failed"
+		has "Remnant: Cognizance 4: done"
 		random < 40
 	npc kill
 		government "Korath"

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3723,7 +3723,10 @@ mission "Remnant: Cognizance 5"
 	source "Caelian"
 	waypoint "Aescolanus"
 	to offer
-		has "Remnant: Cognizance 4: done"
+		or
+			has "Remnant: Cognizance 4: done"
+			# 0.9.13 Compatibility patch
+			has "Remnant: Cognizance 4: failed"
 	on offer
 		conversation
 			branch fleetkilled


### PR DESCRIPTION
One of the two Dredger bounty mission from #5841 has a requirement of a failed Cognizance mission, which seems to be impossible. This changes the condition to `done` instead, making it appear.