### PR TITLE
Remove dynamic cast in test

### DIFF
--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -469,11 +469,11 @@ void Test::Step(Context &context, UI &menuPanels, UI &gamePanels, PlayerInfo &pl
 					if(gamePanels.Root() != gamePanels.Top())
 						Fail(context, player, "engine not active due to panel on top, and can only send commands to the engine");
 					
-					// Both get as well as the cast can result in a nullpointer. In both cases we
-					// will fail the test, since we expect the MainPanel to be here.
-					auto mainPanel = dynamic_cast<MainPanel *>(gamePanels.Root().get());
+					// The get can result in a nullpointer which will will fail the test
+					// since we expect the MainPanel to be here.
+					auto mainPanel = static_cast<MainPanel *>(gamePanels.Root().get());
 					if(!mainPanel)
-						Fail(context, player, "root gamepanel of wrong type when sending command");
+						Fail(context, player, "no root gamepanel when sending command");
 
 					mainPanel->GiveCommand(stepToRun.command);
 				}


### PR DESCRIPTION
**Refactor** This PR makes a small change to https://github.com/endless-sky/endless-sky/pull/5736 to remove the `dynamic_cast`, currently the only feature in the codebase requiring C++ runtime type info support, thereby allowing `-fno-rtt` to be used.

This seems like a decent place to do a dynamic cast instead: in a test! I have no significant experience in C++ codebases to have an opinion here. I'm just removing this because it's convenient to me and it follows the coding style guide to avoid dynamic casts.

## Testing Done
Compiles.

## Performance Impact
Nothing observed. Reading about `dynamic_cast` vs `static_cast`, there could be something small here.