### PR TITLE
Correct a height offset of a text in the Map Outfitter Panel.

### DIFF
--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -351,7 +351,8 @@ void MapSalesPanel::Draw(Point &corner, const Sprite *sprite, bool isForSale, bo
 	// Set the padding so the text takes the same height overall,
 	// regardless of whether it's three lines of text or four.
 	const auto pad = storage.empty() ? PAD : (PAD * 2. / 3.);
-	Point nameOffset(ICON_HEIGHT, .5 * ICON_HEIGHT - PAD - 1.5 * font.Height());
+	const auto lines = storage.empty() ? 3 : 4;
+	Point nameOffset(ICON_HEIGHT, .5 * (ICON_HEIGHT - (lines - 1) * pad - lines * font.Height()));
 	Point priceOffset(ICON_HEIGHT, nameOffset.Y() + font.Height() + pad);
 	Point infoOffset(ICON_HEIGHT, priceOffset.Y() + font.Height() + pad);
 	Point storageOffset(ICON_HEIGHT, infoOffset.Y() + font.Height() + pad);


### PR DESCRIPTION
**Bugfix:** This PR addresses issue derived from #5941.

## Fix Details
In the Map Outfitter Panel, the texts are not centered in the height direction when you store some outfits in a planet.

![current master](https://user-images.githubusercontent.com/22392249/131236010-3bccf680-8807-4235-8da5-c6f8f2b2b9c3.png)

## Testing Done
![this PR](https://user-images.githubusercontent.com/22392249/131236013-516f60e9-b5a4-4df9-a91e-f0c5bb065d79.png)
