### PR TITLE
test: Add time information to Ember Wastes Navigation test

### DIFF
--- a/data/tests/tests_wormhole_navigation.txt
+++ b/data/tests/tests_wormhole_navigation.txt
@@ -118,7 +118,7 @@ test-data "Ember Wastes Navigation"
 	category "savegame"
 	contents
 		pilot Bobbi Bughunter
-		date 16 11 3013
+		date 16 12 3012
 		system "Tania Australis"
 		planet Ingot
 		clearance
@@ -350,87 +350,175 @@ test "Tests - Ember Wastes Navigation"
 			travel Terminus
 			travel Limen
 			travel Mora
+		assert
+			year == 3012
+			month == 12
+			day == 16
 		call "Depart"
 		# Give jump command.
+		assert
+			year == 3012
+			month == 12
+			day == 17
 		input
 			command	jump
 		watchdog 12000
 		label notMora1
 		branch notMora1
 			not "flagship system: Mora"
+		assert
+			year == 3012
+			month == 12
+			day == 18
 		watchdog 12000
 		label notLimen1
 		branch notLimen1
 			not "flagship system: Limen"
+		assert
+			year == 3012
+			month == 12
+			day == 19
 		watchdog 12000
 		label notTerminus1
 		branch notTerminus1
 			not "flagship system: Terminus"
+		assert
+			year == 3012
+			month == 12
+			day == 20
 		watchdog 12000
 		label notCardea1
 		branch notCardea1
 			not "flagship system: Cardea"
+		assert
+			year == 3012
+			month == 12
+			day == 21
 		watchdog 12000
 		label notInsitor1
 		branch notInsitor1
 			not "flagship system: Insitor"
+		assert
+			year == 3012
+			month == 12
+			day == 22
 		watchdog 12000
 		label notSegesta
 		branch notSegesta
 			not "flagship system: Segesta"
+		assert
+			year == 3012
+			month == 12
+			day == 23
 		watchdog 12000
 		label notStercutus1
 		branch notStercutus1
 			not "flagship system: Stercutus"
+		assert
+			year == 3012
+			month == 12
+			day == 24
 		watchdog 12000
 		label notPeragenor1
 		branch notPeragenor1
 			not "flagship system: Peragenor"
+		assert
+			year == 3012
+			month == 12
+			day == 25
 		watchdog 12000
 		label notEdusa1
 		branch notEdusa1
 			not "flagship system: Edusa"
+		assert
+			year == 3012
+			month == 12
+			day == 26
 		watchdog 12000
 		label notArculus
 		branch notArculus
 			not "flagship system: Arculus"
+		assert
+			year == 3012
+			month == 12
+			day == 27
 		watchdog 12000
 		label notEdusa2
 		branch notEdusa2
 			not "flagship system: Edusa"
+		assert
+			year == 3012
+			month == 12
+			day == 28
 		watchdog 12000
 		label notPeragenor2
 		branch notPeragenor2
 			not "flagship system: Peragenor"
+		assert
+			year == 3012
+			month == 12
+			day == 29
 		watchdog 12000
 		label notStercutus2
 		branch notStercutus2
 			not "flagship system: Stercutus"
+		assert
+			year == 3012
+			month == 12
+			day == 30
 		watchdog 12000
 		label notSegesta2
 		branch notSegesta2
 			not "flagship system: Segesta"
+		assert
+			year == 3012
+			month == 12
+			day == 31
 		watchdog 12000
 		label notAescolanus
 		branch notAescolanus
 			not "flagship system: Aescolanus"
+		assert
+			year == 3013
+			month == 1
+			day == 1
 		watchdog 12000
 		label notCardea2
 		branch notCardea2
 			not "flagship system: Cardea"
+		assert
+			year == 3013
+			month == 1
+			day == 2
 		watchdog 12000
 		label notTerminus2
 		branch notTerminus2
 			not "flagship system: Terminus"
+		assert
+			year == 3013
+			month == 1
+			day == 3
 		watchdog 12000
 		label notLimen2
 		branch notLimen2
 			not "flagship system: Limen"
+		assert
+			year == 3013
+			month == 1
+			day == 4
 		watchdog 12000
 		label notMora2
 		branch notMora2
 			not "flagship system: Mora"
 		watchdog 12000
+		assert
+			year == 3013
+			month == 1
+			day == 5
 		label notTaniaAustralis
 		branch notTaniaAustralis
 			not "flagship system: Tania Australis"
+		assert
+			year == 3013
+			month == 1
+			day == 6

--- a/data/tests/tests_wormhole_navigation.txt
+++ b/data/tests/tests_wormhole_navigation.txt
@@ -350,10 +350,14 @@ test "Tests - Ember Wastes Navigation"
 			travel Terminus
 			travel Limen
 			travel Mora
-		assert
-			year == 3012
-			month == 12
-			day == 16
+		# Our test-savegames don't have the date conditions serialized. Need to
+		# have passed at least one date-transition to get the date conditions set
+		# (until PR https://github.com/endless-sky/endless-sky/pull/5244 removes
+		# this need to serialize the date conditions completely).
+		#assert
+		#	year == 3012
+		#	month == 12
+		#	day == 16
 		call "Depart"
 		# Give jump command.
 		assert


### PR DESCRIPTION
**Feature:** This PR test both the navigation code and the time conditions

## Feature Details
This PR adds time information to the navigation test to verify that the steps take the amount of time that was expected.
This PR also tests the time conditions code itself (which is useful if we move the time conditions to derived automatic conditions as is done in #5244).

## UI Screenshots
N/A

## Usage Examples
Just run the test.

## Testing Done
Just ran the test (in combination with the code from #5244).

## Performance Impact
N/A (doesn't take a lot of additional test-time either)