### PR TITLE
feat(UX): Swap between main and side panel in shop with keybind

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -686,6 +686,8 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 				playerShip = playerShips.empty() ? nullptr : *playerShips.begin();
 		}
 	}
+	else if(key == SDLK_TAB)
+		activePane = (activePane == ShopPane::Main ? ShopPane::Sidebar : ShopPane::Main);
 	else
 		return false;
 	


### PR DESCRIPTION
**Feature:** This PR implements a suggestion from fluzzlemash on the Steam forums.

## Feature Details
Currently, using the arrow keys in the shop will only navigate between shop items, unless you manually click on the side panel to change focus over there. This PR sets a keybind (in this case, Tab) to change the focus, letting you access that part of the shop with only a keyboard.

Tab was chosen as it is often used to swap between different forms in an interface, but I am open to other keys like space, or even a letter if it makes sense.

A future PR might make a visual distinction between which panel currently has focus, but in the meantime, this would offer some very useful commands to a power user, such as Tab+Shift+Up to select every ship on the planet.

## Testing Done
Navigated between both side panels with items actively selected on each, or no items selected.

## Performance Impact
N/A
