### PR TITLE
Fix: eroneous Typhoon Pod Reload value

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1101,7 +1101,7 @@ outfit "Typhoon Pod"
 		"inaccuracy" 5
 		"velocity" 6
 		"lifetime" 1100
-		"reload" 50
+		"reload" 252
 		"burst count" 2
 		"burst reload" 120
 		"firing energy" 4


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6215 
fixes #6215 

## Fix Details
Reload 50 to Reload 252 (this brings the typhoon in line with all other launcher to pod comparisons, wherein the full reload is equal to somewhere between 2.1 and 3 times the launcher reload.

## Testing Done
Checked in game values to see that typhoon pod has changed from significantly faster shots per second than its launcher to below it.
