### PR TITLE
fix(ui): Decimal number display bug

### DIFF
--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -132,6 +132,8 @@ string Format::Number(double value)
 	
 	// Only show decimal places for numbers between +/-10'000.
 	double decimal = modf(value, &value);
+	// Fix any floating point inaccuracy.
+	decimal = round(decimal * 100.) / 100.;
 	if(decimal && value < 10000)
 	{
 		int tenths = static_cast<int>(decimal * 10.);
@@ -143,11 +145,13 @@ string Format::Number(double value)
 			
 		int hundredths = static_cast<int>(decimal * 10.);
 		// Values up to 1000 may have two decimal places.
-		if(value < 1000)
+		if(value < 1000 && hundredths)
 		{
-			if(hundredths)
-				result += static_cast<char>('0' + hundredths);
+			result += static_cast<char>('0' + hundredths);
 		}
+		//Values of 1000 or more should not display any decimal places if there are no tenths regardless of the hundredth values.
+		else
+			hundredths = 0;
 		if(tenths || hundredths)
 		{
 			result += static_cast<char>('0' + tenths);

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -135,19 +135,20 @@ string Format::Number(double value)
 	if(decimal && value < 10000)
 	{
 		int tenths = static_cast<int>(decimal * 10.);
+		
+		decimal *= 10.;
+		decimal -= static_cast<int>(decimal);
+		// Fix any floating point inaccuracy.
+		decimal = round(decimal * 100.) / 100.;
+			
+		int hundredths = static_cast<int>(decimal * 10.);
 		// Values up to 1000 may have two decimal places.
 		if(value < 1000)
 		{
-			decimal *= 10.;
-			decimal -= static_cast<int>(decimal);
-			// Fix any floating point inaccuracy.
-			decimal = round(decimal * 100.) / 100.;
-			
-			int hundredths = static_cast<int>(decimal * 10.);
 			if(hundredths)
 				result += static_cast<char>('0' + hundredths);
 		}
-		if(tenths)
+		if(tenths || hundredths)
 		{
 			result += static_cast<char>('0' + tenths);
 			result += '.';

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -133,7 +133,7 @@ string Format::Number(double value)
 	// Only show decimal places for numbers between +/-10'000.
 	double decimal = modf(value, &value);
 	// Fix any floating point inaccuracy.
-	decimal = round(decimal * 100.) / 100.;
+	decimal = round(decimal * 1000.) / 1000.;
 	if(decimal && value < 10000)
 	{
 		int tenths = static_cast<int>(decimal * 10.);

--- a/tests/src/text/test_format.cpp
+++ b/tests/src/text/test_format.cpp
@@ -137,15 +137,20 @@ TEST_CASE( "Format::Number", "[Format][Number]") {
 		CHECK( Format::Number(0.51) == "0.51" );
 		CHECK( Format::Number(0.56) == "0.56" );
 		CHECK( Format::Number(0.871) == "0.87" );
+		CHECK( Format::Number(0.072) == "0.07" );
 	}
 	SECTION( "Decimals between 10 and 100" ) {
 		CHECK( Format::Number(44.1234) == "44.12" );
 		CHECK( Format::Number(94.5) == "94.5" );
+		CHECK( Format::Number(10.1) == "10.1" );
+		CHECK( Format::Number(10.01) == "10.01" );
 		CHECK( Format::Number(-12.41) == "-12.41" );
 	}
 	SECTION( "Decimals between 100 and 1000" ) {
 		CHECK( Format::Number(256.) == "256" );
 		CHECK( Format::Number(466.1948) == "466.19" );
+		CHECK( Format::Number(107.093) == "107.09" );
+		CHECK( Format::Number(100.1) == "100.1" );
 		CHECK( Format::Number(-761.1) == "-761.1" );
 	}
 	SECTION( "Decimals between 1000 and 10'000" ) {


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Numbers with a non-zero hundredths digit but a zero in the tenths column were displaying without the decimal point or the zero in the tenths column:

## Testing Done
Seen in game where the value should be 107.09 (turn = 18420, mass = 172, 18420/172 = ~107.093) but displays as 1079.
![image](https://user-images.githubusercontent.com/20605679/131770526-b4db7875-3539-4b57-adf0-ae6b7c62d465.png)
Also tested directly with Format::Number before and after change. Before change, input of 107.09 would have result as '9' at the point of calling FormatInteger, after the change, it is '90.', as expected.


## Save File
[warp core~3014-01-31 number display bug save.txt](https://github.com/endless-sky/endless-sky/files/7095560/warp.core.3014-01-31.number.display.bug.save.txt)

