### PR TITLE
Correct Heavy Rocket Pod Burst Count

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1198,7 +1198,7 @@ outfit "Heavy Rocket Pod"
 		"lifetime" 125
 		"reload" 500
 		"range override" 500
-		"burst count" 3
+		"burst count" 2
 		"burst reload" 240
 		"firing energy" 1
 		"firing heat" 250


### PR DESCRIPTION
Looks like the heavy rocket pod burst count also had its ammo count changed without the burst count being corrected. 