### PR TITLE
test: Normal gamespeed when integration-testing in debug mode.

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -320,7 +320,8 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 		GameWindow::Step();
 		
 		// When we perform automated testing, then we run the game by default as quickly as possible.
-		if(testContext.testToRun.empty())
+		// Except when debug-mode is set.
+		if(testContext.testToRun.empty() || debugMode)
 			timer.Wait();
 		
 		// If the player ended this frame in-game, count the elapsed time as played time.


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue with the game speed when integration-testing in debug mode

## Fix Details
The integration testing framework was never waiting for the timer.Wait() in main.cpp, even when debugMode was set. This code
changes this to ensure that the framework does wait for the timer when debugging.

## Testing Done
Executed the tests in the framework with debugMode enabled and noticed that the game was running at normal speed.

## Save File
N/A