### PR TITLE
Add warning if unknown sounds are used.

### DIFF
--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -181,6 +181,15 @@ void Audio::Init(const vector<string> &sources)
 
 
 
+void Audio::CheckReferences()
+{
+	for(auto &&it : sounds)
+		if(it.second.Name().empty())
+			Files::LogError("Warning: sound \"" + it.first + "\" is referred to, but does not exist.");
+}
+
+
+
 // Report the progress of loading sounds.
 double Audio::GetProgress()
 {

--- a/source/Audio.h
+++ b/source/Audio.h
@@ -32,6 +32,7 @@ class Audio {
 public:
 	// Begin loading sounds (in a separate thread).
 	static void Init(const std::vector<std::string> &sources);
+	static void CheckReferences();
 	
 	// Report the progress of loading sounds.
 	static double GetProgress();

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -385,12 +385,10 @@ double GameData::Progress()
 	{
 		if(!initiallyLoaded)
 		{
-			// Now that we have finished loading all the basic sprites, we can look for invalid file paths,
-			// e.g. due to capitalization errors or other typos. Landscapes are allowed to still be empty.
-			auto unloaded = SpriteSet::CheckReferences();
-			for(const auto &path : unloaded)
-				if(path.compare(0, 5, "land/") != 0)
-					Files::LogError("Warning: image \"" + path + "\" is referred to, but has no pixels.");
+			// Now that we have finished loading all the basic sprites and sounds, we can look for invalid file paths,
+			// e.g. due to capitalization errors or other typos.
+			SpriteSet::CheckReferences();
+			Audio::CheckReferences();
 			initiallyLoaded = true;
 		}
 	}

--- a/source/SpriteSet.cpp
+++ b/source/SpriteSet.cpp
@@ -12,6 +12,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "SpriteSet.h"
 
+#include "Files.h"
 #include "Sprite.h"
 
 #include <map>
@@ -31,16 +32,16 @@ const Sprite *SpriteSet::Get(const string &name)
 
 
 
-set<string> SpriteSet::CheckReferences()
+void SpriteSet::CheckReferences()
 {
-	auto unloaded = set<string>{};
 	for(const auto &pair : sprites)
 	{
 		const Sprite &sprite = pair.second;
 		if(sprite.Height() == 0 && sprite.Width() == 0)
-			unloaded.insert(pair.first);
+			// Landscapes are allowed to still be empty.
+			if(pair.first.compare(0, 5, "land/") != 0)
+				Files::LogError("Warning: image \"" + pair.first + "\" is referred to, but has no pixels.");
 	}
-	return unloaded;
 }
 
 

--- a/source/SpriteSet.h
+++ b/source/SpriteSet.h
@@ -28,8 +28,8 @@ public:
 	// Get a pointer to the sprite data with the given name.
 	static const Sprite *Get(const std::string &name);
 	
-	// Inspect the sprite map and return any paths that loaded no data.
-	static std::set<std::string> CheckReferences();
+	// Inspect the sprite map and warn if some images contain no data.
+	static void CheckReferences();
 	
 	
 private:


### PR DESCRIPTION
**Feature:** This PR implements the feature request briefly mentioned on the discord.

## Feature Details
This PR adds a warning if any unknown sounds (so sounds that don't exist on the file system) are used. Previously there was no warning. The warning added:

```
Warning: sound "blasterbb" is referred to, but does not exist.
```

## Testing Done

Added invalid sounds in plugins and in the data files and verified that the warning is emitted.

## Performance Impact
Loops through every sound once when the game is loaded. Unlikely that this is going to have a big impact when starting the game.
