### PR TITLE
Added display ID setting.

### DIFF
--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -418,6 +418,25 @@ void GameWindow::ToggleFullscreen()
 
 
 
+int GameWindow::CurrentDisplayID()
+{
+	int posX = 0, posY = 0, ID = 0;
+	SDL_GetWindowPosition(mainWindow, &posX, &posY);
+	for(int i = 0; i < SDL_GetNumVideoDisplays(); i++)
+	{
+		SDL_Rect currentDisplay;
+		SDL_GetDisplayBounds(i, &currentDisplay);
+		if(posX >= currentDisplay.x && posX < currentDisplay.w && posY >= currentDisplay.y && posY < currentDisplay.h)
+		{
+			ID = i;
+			break;
+		}
+	}
+	return ID;
+}
+
+
+
 bool GameWindow::HasSwizzle()
 {
 	return hasSwizzle;

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -91,17 +91,17 @@ bool GameWindow::Init()
 		return false;
 	}
 	
-	/* This is a failsafe in case a display got removed.
-	Can't check for SDL_GetNumVideoDisplays() inside Screen::SetDisplayID()
-	because SDL_Init(SDL_INIT_VIDEO) is called here in GameWindow::Init()
-	after Preferences::Load() in main and SDL_GetNumVideoDisplays()
-	always returns 0. */
-	if (Screen::GetDisplayID() >= SDL_GetNumVideoDisplays())
+	// This is a failsafe in case a display got removed.
+	// Can't check for SDL_GetNumVideoDisplays() inside Screen::SetDisplayID()
+	// because SDL_Init(SDL_INIT_VIDEO) is called here in GameWindow::Init()
+	// after Preferences::Load() in main and SDL_GetNumVideoDisplays()
+	// always returns 0.
+	if(Screen::GetDisplayID() >= SDL_GetNumVideoDisplays())
 		Screen::SetDisplayID(0);
 	
 	// Get details about the current display.
 	SDL_DisplayMode mode;
-	if(SDL_GetCurrentDisplayMode(Screen::GetDisplayID(), &mode))	{	
+	if(SDL_GetCurrentDisplayMode(Screen::GetDisplayID(), &mode)) {
 		ExitWithError("Unable to query monitor resolution!");
 		return false;
 	}
@@ -131,9 +131,9 @@ bool GameWindow::Init()
 	
 	// Get window bounds by ID...
 	SDL_Rect gameWindow;
-	SDL_GetDisplayBounds (Screen::GetDisplayID (), &gameWindow);
-	gameWindow.x += (gameWindow.w - windowWidth) / 2; // Center horizontally
-	gameWindow.y += (gameWindow.h - windowHeight) / 2; // Center vertically
+	SDL_GetDisplayBounds(Screen::GetDisplayID(), &gameWindow);
+	gameWindow.x += (gameWindow.w - windowWidth) / 2;
+	gameWindow.y += (gameWindow.h - windowHeight) / 2;
 	gameWindow.w = windowWidth;
 	gameWindow.h = windowHeight;
 	

--- a/source/GameWindow.h
+++ b/source/GameWindow.h
@@ -43,6 +43,7 @@ public:
 	static bool IsMaximized();
 	static bool IsFullscreen();
 	static void ToggleFullscreen();	
+	static int CurrentDisplayID();
 	
 	// Check if the initialized window system supports OpenGL texture_swizzle.
 	static bool HasSwizzle();

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -79,6 +79,8 @@ void Preferences::Load()
 			zoomIndex = max<int>(0, min<int>(node.Value(1), ZOOMS.size() - 1));
 		else if(node.Token(0) == "vsync")
 			vsyncIndex = max<int>(0, min<int>(node.Value(1), VSYNC_SETTINGS.size() - 1));
+		else if(node.Token(0) == "display ID")
+			Screen::SetDisplayID(node.Value(1));
 		else
 			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));
 	}
@@ -96,6 +98,7 @@ void Preferences::Save()
 	out.Write("scroll speed", scrollSpeed);
 	out.Write("view zoom", zoomIndex);
 	out.Write("vsync", vsyncIndex);
+	out.Write("display ID", Screen::GetDisplayID());
 	
 	for(const auto &it : settings)
 		out.Write(it.first, it.second);

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -57,7 +57,7 @@ namespace {
 	const string SCROLL_SPEED = "Scroll speed";
 	const string FIGHTER_REPAIR = "Repair fighters in";
 	const string SHIP_OUTLINES = "Ship outlines in shops";
-	const string DISPLAY_ID = "Display ID (Nees restart.)";
+	const string DISPLAY_ID = "Display ID (Needs restart)";
 }
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -57,6 +57,7 @@ namespace {
 	const string SCROLL_SPEED = "Scroll speed";
 	const string FIGHTER_REPAIR = "Repair fighters in";
 	const string SHIP_OUTLINES = "Ship outlines in shops";
+	const string DISPLAY_ID = "Display ID (Nees restart.)";
 }
 
 
@@ -146,6 +147,12 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 		{
 			// For some settings, clicking the option does more than just toggle a
 			// boolean state keyed by the option's name.
+			if(zone.Value() == DISPLAY_ID)
+			{
+				int newID = Screen::GetDisplayID() + 1;
+				newID %= SDL_GetNumVideoDisplays();
+				Screen::SetDisplayID(newID);
+			}
 			if(zone.Value() == ZOOM_FACTOR)
 			{
 				int newZoom = Screen::UserZoom() + ZOOM_FACTOR_INCREMENT;
@@ -243,7 +250,13 @@ bool PreferencesPanel::Scroll(double dx, double dy)
 	if(!dy || hoverPreference.empty())
 		return false;
 	
-	if(hoverPreference == ZOOM_FACTOR)
+	if(hoverPreference == DISPLAY_ID)
+	{
+		int newID = Screen::GetDisplayID() + 1;
+		newID %= SDL_GetNumVideoDisplays();
+		Screen::SetDisplayID(newID);
+	}
+	else if(hoverPreference == ZOOM_FACTOR)
 	{
 		int zoom = Screen::UserZoom();
 		if(dy < 0. && zoom > ZOOM_FACTOR_MIN)
@@ -430,6 +443,7 @@ void PreferencesPanel::DrawSettings()
 	
 	static const string SETTINGS[] = {
 		"Display",
+		DISPLAY_ID,
 		ZOOM_FACTOR,
 		VIEW_ZOOM_FACTOR,
 		VSYNC_SETTING,
@@ -496,7 +510,15 @@ void PreferencesPanel::DrawSettings()
 		// draws the setting "bright" (i.e. the setting is active).
 		bool isOn = Preferences::Has(setting);
 		string text;
-		if(setting == ZOOM_FACTOR)
+		if(setting == DISPLAY_ID)
+		{
+			if (SDL_GetNumVideoDisplays() > 1)
+				isOn = true;
+			else
+				isOn = false;
+			text = to_string(Screen::GetDisplayID());
+		}
+		else if(setting == ZOOM_FACTOR)
 		{
 			isOn = Screen::UserZoom() == Screen::Zoom();
 			text = to_string(Screen::UserZoom());

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -57,7 +57,6 @@ namespace {
 	const string SCROLL_SPEED = "Scroll speed";
 	const string FIGHTER_REPAIR = "Repair fighters in";
 	const string SHIP_OUTLINES = "Ship outlines in shops";
-	const string DISPLAY_ID = "Display ID (Needs restart)";
 }
 
 
@@ -147,12 +146,6 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 		{
 			// For some settings, clicking the option does more than just toggle a
 			// boolean state keyed by the option's name.
-			if(zone.Value() == DISPLAY_ID)
-			{
-				int newID = Screen::GetDisplayID() + 1;
-				newID %= SDL_GetNumVideoDisplays();
-				Screen::SetDisplayID(newID);
-			}
 			if(zone.Value() == ZOOM_FACTOR)
 			{
 				int newZoom = Screen::UserZoom() + ZOOM_FACTOR_INCREMENT;
@@ -250,13 +243,7 @@ bool PreferencesPanel::Scroll(double dx, double dy)
 	if(!dy || hoverPreference.empty())
 		return false;
 	
-	if(hoverPreference == DISPLAY_ID)
-	{
-		int newID = Screen::GetDisplayID() + 1;
-		newID %= SDL_GetNumVideoDisplays();
-		Screen::SetDisplayID(newID);
-	}
-	else if(hoverPreference == ZOOM_FACTOR)
+	if(hoverPreference == ZOOM_FACTOR)
 	{
 		int zoom = Screen::UserZoom();
 		if(dy < 0. && zoom > ZOOM_FACTOR_MIN)
@@ -443,7 +430,6 @@ void PreferencesPanel::DrawSettings()
 	
 	static const string SETTINGS[] = {
 		"Display",
-		DISPLAY_ID,
 		ZOOM_FACTOR,
 		VIEW_ZOOM_FACTOR,
 		VSYNC_SETTING,
@@ -510,15 +496,7 @@ void PreferencesPanel::DrawSettings()
 		// draws the setting "bright" (i.e. the setting is active).
 		bool isOn = Preferences::Has(setting);
 		string text;
-		if(setting == DISPLAY_ID)
-		{
-			if (SDL_GetNumVideoDisplays() > 1)
-				isOn = true;
-			else
-				isOn = false;
-			text = to_string(Screen::GetDisplayID());
-		}
-		else if(setting == ZOOM_FACTOR)
+		if(setting == ZOOM_FACTOR)
 		{
 			isOn = Screen::UserZoom() == Screen::Zoom();
 			text = to_string(Screen::UserZoom());

--- a/source/Screen.cpp
+++ b/source/Screen.cpp
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
+	int DISPLAY_ID = 0;
 	int RAW_WIDTH = 0;
 	int RAW_HEIGHT = 0;
 	int WIDTH = 0;
@@ -70,6 +71,21 @@ void Screen::SetZoom(int percent)
 	WIDTH = RAW_WIDTH * 100 / EFFECTIVE_ZOOM;
 	HEIGHT = RAW_HEIGHT * 100 / EFFECTIVE_ZOOM;
 }
+
+
+
+int Screen::GetDisplayID()
+{
+	return DISPLAY_ID;
+}
+
+
+
+void Screen::SetDisplayID(int newID)
+{
+	DISPLAY_ID = newID;
+}
+
 
 
 

--- a/source/Screen.h
+++ b/source/Screen.h
@@ -30,6 +30,9 @@ public:
 	static int Zoom();
 	static void SetZoom(int percent);
 	
+	static int GetDisplayID();
+	static void SetDisplayID(int newID);
+	
 	// Specify that this is a high-DPI window.
 	static void SetHighDPI(bool isHighDPI = true);
 	// This is true if the screen is high DPI, or if the zoom is above 100%.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -151,6 +151,7 @@ int main(int argc, char *argv[])
 	Preferences::Set("maximized", GameWindow::IsMaximized());
 	Preferences::Set("fullscreen", GameWindow::IsFullscreen());
 	Screen::SetRaw(GameWindow::Width(), GameWindow::Height());
+	Screen::SetDisplayID(GameWindow::CurrentDisplayID());
 	Preferences::Save();
 	
 	Audio::Quit();


### PR DESCRIPTION
**Feature:** Not sure if it was requested or not, I just fixed an annoyance... (having to drag the window over each time to the other display...)

## Feature Details
You can now specify the display on which you want the game to launch... Until now, it launched on display 0 regardless.

## Usage Examples
~~Go to preferences, and click on Display ID to change it. Changes will take place at next start, so exit and start again.~~
On @tehhowch's request this setting is hidden and automatic, it should now open on whichever display you last closed it.

## Testing Done
I only tested it on my dual display setup under ubuntu linux. It seems to work perfectly to me, but I advise caution...

## Performance Impact
I guess it adds couple of miocroseconds at start. ;)
...and now also a few microseconds before exit. ;)
