### PR TITLE
Add noexcept to Angle's constructors.

### DIFF
--- a/source/Angle.cpp
+++ b/source/Angle.cpp
@@ -55,7 +55,7 @@ Angle Angle::Random(double range)
 
 
 // Default constructor: generates an angle pointing straight up.
-Angle::Angle()
+Angle::Angle() noexcept
 	: angle(0)
 {
 }
@@ -63,7 +63,7 @@ Angle::Angle()
 
 
 // Construct an Angle from the given angle in degrees.
-Angle::Angle(double degrees)
+Angle::Angle(double degrees) noexcept
 	: angle(llround(degrees * DEG_TO_STEP) & MASK)
 {
 	// Make sure llround does not overflow with the values of System::SetDate.
@@ -75,7 +75,7 @@ Angle::Angle(double degrees)
 
 
 // Construct an angle pointing in the direction of the given vector.
-Angle::Angle(const Point &point)
+Angle::Angle(const Point &point) noexcept
 	: Angle(TO_DEG * atan2(point.X(), -point.Y()))
 {
 }

--- a/source/Angle.cpp
+++ b/source/Angle.cpp
@@ -54,14 +54,6 @@ Angle Angle::Random(double range)
 
 
 
-// Default constructor: generates an angle pointing straight up.
-Angle::Angle() noexcept
-	: angle(0)
-{
-}
-
-
-
 // Construct an Angle from the given angle in degrees.
 Angle::Angle(double degrees) noexcept
 	: angle(llround(degrees * DEG_TO_STEP) & MASK)

--- a/source/Angle.h
+++ b/source/Angle.h
@@ -32,12 +32,12 @@ public:
 	
 public:
 	// The default constructor creates an angle pointing up (zero degrees).
-	Angle();
+	Angle() noexcept;
 	// Construct an Angle from the given angle in degrees. Allow this conversion
 	// to be implicit to allow syntax like "angle += 30".
-	Angle(double degrees);
+	Angle(double degrees) noexcept;
 	// Construct an angle pointing in the direction of the given vector.
-	explicit Angle(const Point &point);
+	explicit Angle(const Point &point) noexcept;
 	
 	// Mathematical operators.
 	Angle operator+(const Angle &other) const;

--- a/source/Angle.h
+++ b/source/Angle.h
@@ -32,7 +32,7 @@ public:
 	
 public:
 	// The default constructor creates an angle pointing up (zero degrees).
-	Angle() noexcept;
+	Angle() noexcept = default;
 	// Construct an Angle from the given angle in degrees. Allow this conversion
 	// to be implicit to allow syntax like "angle += 30".
 	Angle(double degrees) noexcept;
@@ -64,7 +64,7 @@ private:
 	// so that any angle can be mapped to a unit vector (a very common operation)
 	// with just a single array lookup. It also means that "wrapping" angles
 	// to the range of 0 to 360 degrees can be done via a bit mask.
-	int32_t angle;
+	int32_t angle = 0;
 };
 
 #endif


### PR DESCRIPTION
## Fix Details

This PR adds `noexcept` to `Angle`'s constructors (only the default constructor is needed but I added it to the others as well). This is needed to fix a compilation error on older versions of gcc and clang. 

What happened is that the behavior of explicitly defaulted constructors with different exceptions specifications (see `Weapon::Submunition` which has a defaulted `noexcept` constructor while its data member `Angle` doesn't) changed via a defect report. Before: compiler error. After: valid code.

This defect report came several years after C++11 was released and as such older compilers that support C++11 but were released before this change in behavior miscompile the code.