### PR TITLE
Allow spaces in project path in Xcode

### DIFF
--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -978,7 +978,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/utils/set_dylibs_rpath.sh";
+			shellScript = "\"${SRCROOT}/utils/fetch_sdl2_framework.sh\"";
 		};
 		072599CB26A8C7AB007EC229 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -993,7 +993,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/utils/fetch_sdl2_framework.sh";
+			shellScript = "\"${SRCROOT}/utils/fetch_sdl2_framework.sh\"";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -978,7 +978,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/utils/fetch_sdl2_framework.sh\"";
+			shellScript = "\"${SRCROOT}/utils/set_dylibs_rpath.sh\"";
 		};
 		072599CB26A8C7AB007EC229 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue discussed in Discord where @vitalchip found naming an Xcode checkout of Endless Sky made building fail.

## Fix Details
Add more quotes, that's always the solution!

There's an intermediate step where Xcode copies the script to a file with a name like `/Users/tomb/Library/Developer/Xcode/DerivedData/EndlessSky-fntizoreowhxxyetwmpsmmjusmaf/Build/Intermediates.noindex/EndlessSky.build/Debug/SDL2.build/Script-072599CB26A8C7AB007EC229.sh` that looks like this now:
```
#!/bin/sh
"${SRCROOT}/utils/fetch_sdl2_framework.sh"
```
but didn't have quotes before this change.

## Testing Done
Ran `git clone git@github.com:thomasballinger/endless-sky.git "i hate spaces"`, switched to this branch, opened Xcode and hit the play button on 11.5.1, Xcode 12.5.1