### PR TITLE
Fix decimal display in ship stat screens (issue #6235)

### DIFF
--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -130,32 +130,43 @@ string Format::Number(double value)
 	bool isNegative = (value < 0.);
 	value = fabs(value);
 	
-	// Only show decimal places for numbers between +/-10'000.
-	double decimal = modf(value, &value);
-	if(decimal && value < 10000)
+	// Numbers <1000 get rounded to two decimal places.
+	// Numbers 1000-10,000 get rounded to one decimal place.
+	// Numbers over 10,000 get rounded to an integer.
+	// Note that rounding a number <1000 may yield 1000; that's fine here.
+	int integer;
+	int tenths = 0;
+	int hundredths = 0;
+	if(value < 1000.)
 	{
-		int tenths = static_cast<int>(decimal * 10.);
-		// Values up to 1000 may have two decimal places.
-		if(value < 1000)
-		{
-			decimal *= 10.;
-			decimal -= static_cast<int>(decimal);
-			// Fix any floating point inaccuracy.
-			decimal = round(decimal * 100.) / 100.;
-			
-			int hundredths = static_cast<int>(decimal * 10.);
-			if(hundredths)
-				result += static_cast<char>('0' + hundredths);
-		}
-		if(tenths)
-		{
-			result += static_cast<char>('0' + tenths);
-			result += '.';
-		}
+		int scaled_value = static_cast<int>(round(value * 100.));
+		integer = scaled_value / 100;
+		tenths = (scaled_value % 100) / 10;
+		hundredths = scaled_value % 10;
+	}
+	else if(value < 10000.)
+	{
+		int scaled_value = static_cast<int>(round(value * 10.));
+		integer = scaled_value / 10;
+		tenths = scaled_value % 10;
+	}
+	else // >=10000
+	{
+		integer = static_cast<int>(round(value));
 	}
 	
+	if(hundredths)
+	{
+		result += static_cast<char>('0' + hundredths);
+	}
+	if(tenths || hundredths)
+	{
+		result += static_cast<char>('0' + tenths);
+		result += '.';
+	}
+
 	// Convert the number to a string, adding commas if needed.
-	FormatInteger(value, isNegative, result);
+	FormatInteger(integer, isNegative, result);
 	return result;
 }
 

--- a/tests/src/text/test_format.cpp
+++ b/tests/src/text/test_format.cpp
@@ -158,6 +158,19 @@ TEST_CASE( "Format::Number", "[Format][Number]") {
 		CHECK( Format::Number(45123.05) == "45,123" );
 		CHECK( Format::Number(-56413.2) == "-56,413" );
 	}
+	SECTION( "#6235: Decimals with 0 in tenths place" ) {
+		CHECK( Format::Number(100.06) == "100.06" );
+		CHECK( Format::Number(1000.03) == "1,000" );
+		CHECK( Format::Number(107.09) == "107.09" );
+		CHECK( Format::Number(0.0123) == "0.01" );
+	}
+	SECTION( "#6235: Rounding up" ) {
+		CHECK( Format::Number(100.0678) == "100.07" );
+		CHECK( Format::Number(1000.06) == "1,000.1" );
+		CHECK( Format::Number(1.046) == "1.05" );
+		CHECK( Format::Number(1.0046) == "1" );
+		CHECK( Format::Number(0.9999) == "1" );
+	}
 }
 
 // #endregion unit tests


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6235

## Fix Details
Change Format::Number to (a) round exactly once at the start, and (b) correctly insert the decimal place and tenths digit in the case where the tenths is zero but the hundredths is nonzero.

## Testing Done
Opening the save file and checking that the numbers on the Blackbird look reasonable (particularly the turning speed); some playing with the fix; and the unit tests in tests/src/text/test_format.cpp.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using anything from 1873fd9ee9a9ad6a4fd210fe03f8d5a6fc7abc25 to the current commit (e.g. 439387647c27869017ef357c4097d2907a7d6d21 ) , and will not occur when using this branch's build.

[JC Penney copy.txt](https://github.com/endless-sky/endless-sky/files/7125535/JC.Penney.copy.txt)