### PR TITLE
feat(mechanics): Allow fleets to spawn derelicts

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -300,7 +300,7 @@ const Government *Fleet::GetGovernment() const
 // Choose a fleet to be created during flight, and have it enter the system via jump or planetary departure.
 void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Planet *planet) const
 {
-	if(!total || variants.empty())
+	if(!total || variants.empty() || personality.IsDerelict())
 		return;
 	
 	// Pick a fleet variant to instantiate.
@@ -491,7 +491,11 @@ void Fleet::Place(const System &system, list<shared_ptr<Ship>> &ships, bool carr
 		
 		Angle angle = Angle::Random();
 		Point pos = center.first + Angle::Random().Unit() * OffsetFrom(center);
-		double velocity = Random::Real() * ship->MaxVelocity();
+		double velocity = 0;
+		if(!ship->GetPersonality().IsDerelict())
+			velocity = Random::Real() * ship->MaxVelocity();
+		else
+			ship->Disable();
 		
 		ships.push_front(ship);
 		ship->SetSystem(&system);


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #6097

## Feature Details
As said in the original issue, missions in Endless Sky have a lot of power to provide interesting situations while boarding disabled ships. However, this is limited only to naturally spawned ships, which were either disabled by yourself or an enemy of theirs.

This PR lets naturally spawned fleets make use of the `derelict` personality. If a ship from that fleet spawns as the player enters from/takes off into that system, it will be disabled and stationary. Then, no other ships from that fleet will be allowed to jump in.

Content creators can then have events which add a derelict fleet to a given system, of a specific government type that are the only ones eligible for specific boarding missions. We may be able to add derelicts to human space broadly, as well, for more generic derelict boarding missions.

## UI Screenshots
N/A

## Usage Examples
```
fleet "Civilian Derelicts"
	government "Derelict"
	personality
		derelict
	variant 20
		...

system ...
	fleet "Civilian Derelicts" 10000
```

## Testing Done
Having derelict fleets be built into a system, having them added with an event, and confirmed that derelict NPC still function without issue.

## Performance Impact
N/A
