### PR TITLE
feat(mechanics): Allow boarding missions from NPC ships with flag

### DIFF
--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -49,6 +49,7 @@ namespace {
 	const int TARGET = (1 << 25);
 	const int MARKED = (1 << 26);
 	const int LAUNCHING = (1 << 27);
+	const int OFFERS = (1 << 28);
 	
 	const map<string, int> TOKEN = {
 		{"pacifist", PACIFIST},
@@ -78,7 +79,8 @@ namespace {
 		{"opportunistic", OPPORTUNISTIC},
 		{"target", TARGET},
 		{"marked", MARKED},
-		{"launching", LAUNCHING}
+		{"launching", LAUNCHING},
+		{"offers", OFFERS}
 	};
 	
 	const double DEFAULT_CONFUSION = 10.;
@@ -331,6 +333,13 @@ bool Personality::IsMarked() const
 bool Personality::IsMute() const
 {
 	return flags & MUTE;
+}
+
+
+
+bool Personality::Offers() const
+{
+	return flags & OFFERS;
 }
 
 

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -69,6 +69,7 @@ public:
 	bool IsTarget() const;
 	bool IsMarked() const;
 	bool IsMute() const;
+	bool Offers() const;
 	
 	// Current inaccuracy in this ship's targeting:
 	const Point &Confusion() const;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1615,9 +1615,12 @@ Mission *PlayerInfo::MissionToOffer(Mission::Location location)
 // relationship with the player. If none offer, return nullptr.
 Mission *PlayerInfo::BoardingMission(const shared_ptr<Ship> &ship)
 {
-	// Do not create missions from existing mission NPC's, or the player's ships.
-	if(ship->IsSpecial())
+	// Do not create missions from existing mission NPC's, the player's ships,
+	// or ships with the "Offers" personality that have already been boarded.
+	if(ship->IsSpecial() && (!ship->GetPersonality().Offers() || ship->IsBoardedOfferer()))
 		return nullptr;
+	if(ship->GetPersonality().Offers())
+		ship->SetBoardedOfferer();
 	// Ensure that boarding this NPC again does not create a mission.
 	ship->SetIsSpecial();
 	

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -191,6 +191,8 @@ void Ship::Load(const DataNode &node)
 			customSwizzle = child.Value(1);
 		else if(key == "uuid" && child.Size() >= 2)
 			uuid = EsUuid::FromString(child.Token(1));
+		else if(key == "boarded")
+			boardedOfferer = true;
 		else if(key == "attributes" || add)
 		{
 			if(!add)
@@ -966,6 +968,8 @@ void Ship::Save(DataWriter &out) const
 			out.Write("destination system", targetSystem->Name());
 		if(isParked)
 			out.Write("parked");
+		if(boardedOfferer)
+			out.Write("boarded");
 	}
 	out.EndChild();
 }
@@ -1235,6 +1239,20 @@ void Ship::SetIsSpecial(bool special)
 bool Ship::IsSpecial() const
 {
 	return isSpecial;
+}
+
+
+
+void Ship::SetBoardedOfferer()
+{
+	boardedOfferer = true;
+}
+
+
+
+bool Ship::IsBoardedOfferer() const
+{
+	return boardedOfferer;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -166,6 +166,8 @@ public:
 	void SetGovernment(const Government *government);
 	void SetIsSpecial(bool special = true);
 	bool IsSpecial() const;
+	void SetBoardedOfferer();
+	bool IsBoardedOfferer() const;
 	
 	// If a ship belongs to the player, the player can give it commands.
 	void SetIsYours(bool yours = true);
@@ -460,6 +462,7 @@ private:
 	// "Special" ships cannot be forgotten, and if they land on a planet, they
 	// continue to exist and refuel instead of being deleted.
 	bool isSpecial = false;
+	bool boardedOfferer = false;
 	bool isYours = false;
 	bool isParked = false;
 	bool shouldDeploy = false;

--- a/source/ShipEvent.h
+++ b/source/ShipEvent.h
@@ -62,7 +62,10 @@ public:
 		// you had with the given government, first.
 		ATROCITY = (1 << 8),
 		// This ship just jumped into a different system.
-		JUMP = (1 << 9)
+		JUMP = (1 << 9),
+		// This ship has the Offers personality and was boarded,
+		// potentially giving a mission.
+		BOARDED = (1 << 10)
 	};
 	
 	


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in, and would resolve #6097 

## Feature Details
The other part of half of the coin for the linked issue, this PR lets content creators give the `offers` personality to NPC ships in missions. This overrides the default blocker against NPC/"Special" ships from generating boarding missions, enabling a player to create bespoke derelicts (or ships that you could disable yourself) which can give unique boarding missions.

For example, we could have a mission similar to "Hunted" which periodically, invisibly spawns a derelict within range of the player, and if they happen to stumble upon it, they can get a selection of missions through there. Alternatively, some mission could ask you to destroy a target, but if you disable and board it first, you can get some alternative or bonus outcome.

The implementation checks for the `offers` personality when boarding, and then sets a `boardedOfferer` bool on the ship. Ideally, it would be cleaner to handle it in just the NPC class, but the BoardingMission function under PlayerInfo only checks the ship. As far as I'm aware, you cannot work up from a ship to check if it's an NPC, so it would need to be handled through ships/personalities. The `boardedOfferer` flag is then serialized as `boarded`, if a player saves in that time.

## UI Screenshots
N/A

## Usage Examples
```
mission "Derelict Generator"
	invisible
	landing
	repeat
	deadline 30
	to offer
		random < 3
	npc assist
		government "Derelict"
		personality derelict offers
		system
			distance 3 5
		ship "Freighter" "S.S. Ghost Ship"



mission "Ghost Ship"
	assisting
	destination "Earth"
	to offer
		source
			government "Derelict"
	...
```


## Testing Done
- Ensured ships with the `offers` personality could receive boarding missions
- Boarded once, then tried to board again to confirm that they would not generate a second mission
- Boarded once, saved and reloaded, and tried to board again to see no new mission
- Went to an older `derelict` mission to confirm no boarding missions would spawn off them

## Performance Impact
N/A
