### PR TITLE
Add warning when undefined hazards are used.

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -353,7 +353,7 @@ void GameData::CheckReferences()
 			NameAndWarn("system", it);
 	// Hazards are never serialized.
 	for(const auto &it : hazards)
-		if(!it.second.IsValid() && !deferred["hazard"].count(it.first))
+		if(!it.second.IsValid())
 			Warn("hazard", it.first);
 }
 

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -351,6 +351,10 @@ void GameData::CheckReferences()
 	for(auto &&it : systems)
 		if(it.second.Name().empty() && !NameIfDeferred(deferred["system"], it))
 			NameAndWarn("system", it);
+	// Hazards are never serialized.
+	for(const auto &it : hazards)
+		if(!it.second.IsValid() && !deferred["hazard"].count(it.first))
+			Warn("hazard", it.first);
 }
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue that I randomly found out.

## Fix Details
I was looking at `GameData::CheckReferences` a bit and then realized that hazards aren't checked. So, this PR adds the following warning when an undefined hazard is used:

```
Warning: hazard "test" is referred to, but not fully defined.
```

## Testing Done

Added an undefined hazard and confirmed that the warning is emitted.