### PR TITLE
Changed conditions for calling DoRepair for carried ships.

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2004,7 +2004,7 @@ void Ship::DoGeneration()
 				Ship &ship = *it.second;
 				if(energyRemaining > 0.)	
 					DoRepair(ship.energy, energyRemaining, ship.attributes.Get("energy capacity"));	
-				if(fuelRemaining >0.)	
+				if(fuelRemaining > 0.)	
 					DoRepair(ship.fuel, fuelRemaining, ship.attributes.Get("fuel capacity"));
 			}
 		}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1997,12 +1997,14 @@ void Ship::DoGeneration()
 			
 			// Now that there is no more need to use energy for hull and shield
 			// repair, if there is still excess energy, transfer it.
-			double energyRemaining = min(0., energy - attributes.Get("energy capacity"));
-			double fuelRemaining = min(0., fuel - attributes.Get("fuel capacity"));
+			double energyRemaining = energy - attributes.Get("energy capacity");
+			double fuelRemaining = fuel - attributes.Get("fuel capacity");
 			for(const pair<double, Ship *> &it : carried)
 			{
 				Ship &ship = *it.second;
+                if(energyRemaining > 0.)
 				DoRepair(ship.energy, energyRemaining, ship.attributes.Get("energy capacity"));
+                if(fuelRemaining >0.)
 				DoRepair(ship.fuel, fuelRemaining, ship.attributes.Get("fuel capacity"));
 			}
 		}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2002,10 +2002,10 @@ void Ship::DoGeneration()
 			for(const pair<double, Ship *> &it : carried)
 			{
 				Ship &ship = *it.second;
-                if(energyRemaining > 0.)
-                    DoRepair(ship.energy, energyRemaining, ship.attributes.Get("energy capacity"));
-                if(fuelRemaining >0.)
-                    DoRepair(ship.fuel, fuelRemaining, ship.attributes.Get("fuel capacity"));
+				if(energyRemaining > 0.)	
+					DoRepair(ship.energy, energyRemaining, ship.attributes.Get("energy capacity"));	
+				if(fuelRemaining >0.)	
+					DoRepair(ship.fuel, fuelRemaining, ship.attributes.Get("fuel capacity"));
 			}
 		}
 		// Decrease the shield and hull delays by 1 now that shield generation

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2003,9 +2003,9 @@ void Ship::DoGeneration()
 			{
 				Ship &ship = *it.second;
                 if(energyRemaining > 0.)
-				DoRepair(ship.energy, energyRemaining, ship.attributes.Get("energy capacity"));
+                    DoRepair(ship.energy, energyRemaining, ship.attributes.Get("energy capacity"));
                 if(fuelRemaining >0.)
-				DoRepair(ship.fuel, fuelRemaining, ship.attributes.Get("fuel capacity"));
+                    DoRepair(ship.fuel, fuelRemaining, ship.attributes.Get("fuel capacity"));
 			}
 		}
 		// Decrease the shield and hull delays by 1 now that shield generation


### PR DESCRIPTION
NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!) 

----------------------


## Summary
Current code does not recharge carried ships with either excess energy or excess fuel since min(0,<value>) will never return greater than zero.

## Save File
N/A

## PR Checklist
 N/A
  
  
-----------------------
**Bugfix:** This PR addresses issue #{{insert number}}

Unreported bug, found while playing with battery only fighters.

## Fix Details
Code could be changed to max(0, excess energy/excess fuel) and pass the value regardless but I feel it is better to check for excess energy/fuel and then only call DoRepair if they exist, potentially saving multiple calls when there was no excess available to begin with.

## Testing Done
Tested before and after with battery only fighters, before saw no progressive recharge from the carrier. After saw immediate recharging of all fighters from carriers excess.

## Save File
No save file, any carried ship with only batteries will show the problem.


-----------------------
**Feature:** This PR implements the feature request detailed and discussed in issue #{{insert number}}

## Feature Details
N/A

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
N/A

## Performance Impact
No performance impact expected or observed.