### PR TITLE
Don't reparent mission NPCs to NPC ships that haven't been spawned

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -805,6 +805,9 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 					auto &npcs = missionIt->NPCs();
 					for(const auto &npc : npcs)
 					{
+						// Don't reparent to NPC ships that have not been spawned.
+						if(!npc.ShouldSpawn())
+							continue;
 						newParent = getParentFrom(npc.Ships());
 						if(newParent)
 							break;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6208.

## Fix Details
The AI code now skips over NPC ships that have not yet been spawned when attempting to reparent mission NPCs.

## Testing Done
No.

## Save File
Use the save file linked in the bug report.