### PR TITLE
Bugfix: asserts in Launch and Navigate tests.

### DIFF
--- a/data/tests/tests_framework.txt
+++ b/data/tests/tests_framework.txt
@@ -109,11 +109,11 @@ test "Test-Framework - Load and depart"
 		call "Load First Savegame"
 		# Check startup conditions.
 		assert
-			"ships: Light Freighter" = 3
+			"ships: Light Freighter" == 3
 		call "Depart"
 		# Re-check startup conditions.
 		assert
-			"ships: Light Freighter" = 3
+			"ships: Light Freighter" == 3
 
 
 test "Test-Framework - Recursive Calling"
@@ -162,11 +162,11 @@ test "Test-Framework - Navigate"
 			travel "Sol"
 			travel "Alpha Centauri"
 		assert
-			"ships: Light Freighter" = 3
+			"ships: Light Freighter" == 3
 		call "Depart"
 		# Check startup conditions.
 		assert
-			"ships: Light Freighter" = 3
+			"ships: Light Freighter" == 3
 		# Give jump command.
 		input
 			command	jump


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
Four of the asserts in the integration tests were not comparisons, but they were assignments.
The issue reported by Amazinite in https://github.com/endless-sky/endless-sky/pull/5244#discussion_r711283286 should have been found by those asserts if they had been written correctly.

## Testing Done
Tested the asserts with different numbers (checking for 4 Light Freighters); the tests then fail as expected.

## Save File
N/A