### PR TITLE
improvement(content): Increase weight of human launchers and rebalance missiles accordingly

### DIFF
--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -605,7 +605,7 @@ ship "Marauder Manta"
 		"heat dissipation" .8
 		"fuel capacity" 400
 		"cargo space" 10
-		"outfit space" 390
+		"outfit space" 400
 		"weapon capacity" 155
 		"engine capacity" 110
 		"self destruct" .25
@@ -615,8 +615,7 @@ ship "Marauder Manta"
 			"hull damage" 450
 			"hit force" 1350
 	outfits
-		"Plasma Cannon" 2
-		"Particle Cannon" 2
+		"Plasma Cannon" 4
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 60
 		"Quad Blaster Turret"
@@ -634,8 +633,8 @@ ship "Marauder Manta"
 	
 	engine -33 40
 	engine 33 40
-	gun -20 -31 "Particle Cannon"
-	gun 20 -31 "Particle Cannon"
+	gun -20 -31 "Plasma Cannon"
+	gun 20 -31 "Plasma Cannon"
 	gun -26.5 -30 "Plasma Cannon"
 	gun 26.5 -30 "Plasma Cannon"
 	gun -68.5 -33 "Meteor Missile Launcher"

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -36,8 +36,7 @@ ship "Aerie"
 			"hit force" 1200
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 136
-		"Sidewinder Missile Rack" 2
+		"Sidewinder Missile" 90
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		
@@ -321,8 +320,8 @@ ship "Bactrian"
 	outfits
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 90
-		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo Launcher"
+		"Torpedo" 30
 		"Heavy Laser Turret" 4
 		"Heavy Anti-Missile Turret" 2
 		
@@ -339,7 +338,7 @@ ship "Bactrian"
 		
 	engine 18.5 232
 	engine -15 232
-	gun -9 -231.5 "Torpedo Launcher"
+	gun -9 -231.5
 	gun 13.5 -231.5 "Torpedo Launcher"
 	gun 36.5 -197 "Sidewinder Missile Launcher"
 	gun 42 -193 "Sidewinder Missile Launcher"
@@ -835,8 +834,7 @@ ship "Carrier"
 	outfits
 		"Particle Cannon" 4
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 150
-		"Meteor Missile Box" 2
+		"Meteor Missile" 120
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1334,8 +1332,8 @@ ship "Dreadnought"
 			"hull damage" 1300
 			"hit force" 3900
 	outfits
-		"Torpedo Launcher" 4
-		"Torpedo" 120
+		"Torpedo Launcher" 3
+		"Torpedo" 90
 		"Plasma Turret" 3
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1357,7 +1355,7 @@ ship "Dreadnought"
 	gun -9.5 -186 "Torpedo Launcher"
 	gun 9.5 -186 "Torpedo Launcher"
 	gun -18.5 -173.5 "Torpedo Launcher"
-	gun 18.5 -173.5 "Torpedo Launcher"
+	gun 18.5 -173.5
 	turret 0 -99.5 "Plasma Turret"
 	turret -39 -63.5 "Heavy Anti-Missile Turret"
 	turret 39 -63.5 "Heavy Anti-Missile Turret"
@@ -1719,8 +1717,10 @@ ship "Frigate"
 			"hit force" 1500
 	outfits
 		"Particle Cannon" 2
-		"Torpedo Launcher" 2
+		"Torpedo Launcher"
+		"Sidewinder Missile Launcher"
 		"Torpedo" 60
+		"Sidewinder Missile" 45
 		"Blaster Turret" 2
 		"Anti-Missile Turret"
 		
@@ -1741,7 +1741,7 @@ ship "Frigate"
 	gun -11 -84.5 "Particle Cannon"
 	gun 11 -84.5 "Particle Cannon"
 	gun -11 -84.5 "Torpedo Launcher"
-	gun 11 -84.5 "Torpedo Launcher"
+	gun 11 -84.5 "Sidewinder Missile Launcher"
 	turret 0 -37.5 "Anti-Missile Turret"
 	turret -15.5 -12.5 "Blaster Turret"
 	turret 15.5 -12.5 "Blaster Turret"
@@ -2320,9 +2320,9 @@ ship "Manta"
 			"hit force" 1200
 	outfits
 		"Particle Cannon" 4
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 75
-		"Meteor Missile Box"
+		"Meteor Missile Launcher"
+		"Meteor Missile" 60
+		"Meteor Missile Box" 2
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
@@ -2340,7 +2340,7 @@ ship "Manta"
 	gun -26.5 -30 "Particle Cannon"
 	gun 26.5 -30 "Particle Cannon"
 	gun -68.5 -33 "Meteor Missile Launcher"
-	gun 68.5 -33 "Meteor Missile Launcher"
+	gun 68.5 -33
 	leak "leak" 60 50
 	leak "flame" 40 80
 	explode "tiny explosion" 10
@@ -2442,7 +2442,7 @@ ship "Mule"
 		"Sidewinder Missile" 136
 		"Sidewinder Missile Rack" 2
 		"Heavy Laser Turret" 2
-		"Heavy Anti-Missile Turret" 2
+		"Anti-Missile Turret" 2
 		
 		"NT-200 Nucleovoltaic"
 		"KP-6 Photovoltaic Array"
@@ -2461,9 +2461,9 @@ ship "Mule"
 	gun -11 -125 "Sidewinder Missile Launcher"
 	gun 11 -125 "Sidewinder Missile Launcher"
 	turret -22 -53.5 "Heavy Laser Turret"
-	turret 19.5 -39 "Heavy Anti-Missile Turret"
+	turret 19.5 -39 "Anti-Missile Turret"
 	turret 20 33 "Heavy Laser Turret"
-	turret -20.5 103.5 "Heavy Anti-Missile Turret"
+	turret -20.5 103.5 "Anti-Missile Turret"
 	bay "Fighter" -25 -25
 	leak "leak" 50 50
 	leak "flame" 80 80
@@ -2725,8 +2725,8 @@ ship "Rainmaker"
 		"heat dissipation" .6
 		"fuel capacity" 500
 		"cargo space" 25
-		"outfit space" 230
-		"weapon capacity" 60
+		"outfit space" 236
+		"weapon capacity" 66
 		"engine capacity" 50
 		weapon
 			"blast radius" 40
@@ -2791,8 +2791,10 @@ ship "Raven"
 			"hit force" 900
 	outfits
 		"Heavy Laser" 2
-		"Torpedo Launcher" 2
+		"Torpedo Launcher"
 		"Torpedo" 60
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		
 		"RT-I Radiothermal"
 		"KP-6 Photovoltaic Panel" 2
@@ -2809,7 +2811,7 @@ ship "Raven"
 	gun -13.5 -35.5 "Heavy Laser"
 	gun 13.5 -35.5 "Heavy Laser"
 	gun -21 -28 "Torpedo Launcher"
-	gun 21 -28 "Torpedo Launcher"
+	gun 21 -28 "Sidewinder Missile Launcher"
 	leak "leak" 60 50
 	leak "flame" 50 80
 	explode "medium explosion" 24
@@ -3013,7 +3015,8 @@ ship "Skein"
 		"Meteor Missile" 29
 		"Meteor Missile Box"
 		"Quad Blaster Turret" 2
-		"Heavy Anti-Missile Turret" 2
+		"Heavy Anti-Missile Turret"
+		"Anti-Missile Turret"
 		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
@@ -3032,7 +3035,7 @@ ship "Skein"
 	gun 14.5 -166.5
 	turret -21.5 -122 "Quad Blaster Turret"
 	turret 21.5 -122 "Heavy Anti-Missile Turret"
-	turret -18.5 152.5 "Heavy Anti-Missile Turret"
+	turret -18.5 152.5 "Anti-Missile Turret"
 	turret 18.5 152.5 "Quad Blaster Turret"
 	bay "Fighter" -47 -61 under
 	bay "Fighter" 47 -61 under
@@ -3225,8 +3228,8 @@ ship "Star Queen"
 			"hull damage" 300
 			"hit force" 900
 	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		"Heavy Anti-Missile Turret" 2
 		
 		"KP-6 Photovoltaic Array" 4
@@ -3248,7 +3251,7 @@ ship "Star Queen"
 		over
 	gun 0 -113
 	gun -24 -76 "Sidewinder Missile Launcher"
-	gun 24 -76 "Sidewinder Missile Launcher"
+	gun 24 -76
 	turret -21.5 2.5 "Heavy Anti-Missile Turret"
 	turret 21.5 2.5 "Heavy Anti-Missile Turret"
 	leak "leak" 50 50

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -769,8 +769,8 @@ ship "Bulk Freighter"
 			"hull damage" 600
 			"hit force" 1800
 	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		"Laser Turret" 3
 		"Heavy Anti-Missile Turret" 2
 		
@@ -787,7 +787,7 @@ ship "Bulk Freighter"
 	engine -22 198
 	engine 22 198
 	gun -20 -175 "Sidewinder Missile Launcher"
-	gun 20 -175 "Sidewinder Missile Launcher"
+	gun 20 -175
 	turret -12 -155 "Laser Turret"
 	turret 12 -155 "Heavy Anti-Missile Turret"
 	turret 0 5 "Laser Turret"
@@ -1084,8 +1084,8 @@ ship "Container Transport"
 			"hull damage" 600
 			"hit force" 1800
 	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		"Laser Turret" 3
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1102,7 +1102,7 @@ ship "Container Transport"
 	engine -20 195.5
 	engine 20 195.5
 	gun -23.5 -182 "Sidewinder Missile Launcher"
-	gun 23.5 -182 "Sidewinder Missile Launcher"
+	gun 23.5 -182
 	turret 0 -90.5 "Laser Turret"
 	turret 0 -40.5 "Heavy Anti-Missile Turret"
 	turret 0 9.5 "Laser Turret"
@@ -2625,7 +2625,8 @@ ship "Protector"
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 60
 		"Quad Blaster Turret" 6
-		"Heavy Anti-Missile Turret" 2
+		"Heavy Anti-Missile Turret"
+		"Anti-Missile Turret"
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
@@ -2649,7 +2650,7 @@ ship "Protector"
 	turret 68.5 0 "Quad Blaster Turret"
 	turret -48.5 48.5 "Quad Blaster Turret"
 	turret 48.5 48.5 "Quad Blaster Turret"
-	turret 0 30 "Heavy Anti-Missile Turret"
+	turret 0 30 "Anti-Missile Turret"
 	leak "leak" 60 50
 	leak "flame" 20 80
 	explode "tiny explosion" 18

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -918,8 +918,8 @@ ship "Class C Freighter"
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		
 		"Fusion Reactor"
 		"LP036a Battery Pack"
@@ -937,8 +937,8 @@ ship "Class C Freighter"
 		
 	engine -20 195.5
 	engine 20 195.5
-	gun -20 -175 "Meteor Missile Launcher"
-	gun 20 -175 "Meteor Missile Launcher"
+	gun -20 -175 "Sidewinder Missile Launcher"
+	gun 20 -175
 	turret -12 -155 "Quad Blaster Turret"
 	turret 12 -155 "Heavy Anti-Missile Turret"
 	turret 0 5 "Proton Turret"

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2726,8 +2726,8 @@ ship "Rainmaker"
 		"heat dissipation" .6
 		"fuel capacity" 500
 		"cargo space" 25
-		"outfit space" 236
-		"weapon capacity" 66
+		"outfit space" 240
+		"weapon capacity" 70
 		"engine capacity" 50
 		weapon
 			"blast radius" 40

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -400,8 +400,8 @@ ship "Bulk Freighter" "Bulk Freighter (Blaster)"
 		"Anti-Missile Turret"
 		"Heavy Anti-Missile Turret"
 		"Quad Blaster Turret" 3
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile Launcher"
+		"Meteor Missile" 30
 		"Fusion Reactor"
 		"LP036a Battery Pack"
 		"D94-YV Shield Generator"
@@ -446,7 +446,7 @@ ship "Bulk Freighter" "Bulk Freighter (Heavy)"
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 30
+		"Sidewinder Missile" 45
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"KP-6 Photovoltaic Panel" 2
@@ -468,8 +468,8 @@ ship "Bulk Freighter" "Bulk Freighter (Long Haul)"
 		"Laser Turret" 2
 		"Anti-Missile Turret" 2
 		"Quad Blaster Turret"
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		"Fission Reactor"
 		"KP-6 Photovoltaic Panel"
 		"LP144a Battery Pack"
@@ -494,8 +494,8 @@ ship "Bulk Freighter" "Bulk Freighter (Proton)"
 		"Proton Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"Water Coolant System"
@@ -642,8 +642,8 @@ ship "Container Transport" "Container Transport (Blaster)"
 
 ship "Container Transport" "Container Transport (Hai)"
 	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		"Pulse Turret" 3
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
@@ -662,8 +662,8 @@ ship "Container Transport" "Container Transport (Hai)"
 
 ship "Container Transport" "Container Transport (Heavy)"
 	outfits
-		"Laser Turret" 3
-		"Heavy Laser Turret"
+		"Laser Turret" 2
+		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 60
@@ -688,8 +688,8 @@ ship "Container Transport" "Container Transport (Proton)"
 		"Proton Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile Launcher" 1
+		"Sidewinder Missile" 45
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"KP-6 Photovoltaic Panel"
@@ -710,8 +710,8 @@ ship "Container Transport" "Container Transport (Short Haul)"
 	outfits
 		"Anti-Missile Turret" 2
 		"Blaster Turret" 3
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 45
 		"RT-I Radiothermal"
 		"KP-6 Photovoltaic Array"
 		"LP036a Battery Pack"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -665,7 +665,7 @@ ship "Container Transport" "Container Transport (Heavy)"
 		"Laser Turret" 2
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
-		"Sidewinder Missile Launcher
+		"Sidewinder Missile Launcher"
 		"Sidewinder Missile" 45
 		"Fission Reactor"
 		"LP072a Battery Pack"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -665,8 +665,8 @@ ship "Container Transport" "Container Transport (Heavy)"
 		"Laser Turret" 2
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Sidewinder Missile Launcher
+		"Sidewinder Missile" 45
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"KP-6 Photovoltaic Panel" 2
@@ -688,7 +688,7 @@ ship "Container Transport" "Container Transport (Proton)"
 		"Proton Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
-		"Sidewinder Missile Launcher" 1
+		"Sidewinder Missile Launcher"
 		"Sidewinder Missile" 45
 		"Fission Reactor"
 		"LP072a Battery Pack"
@@ -710,7 +710,7 @@ ship "Container Transport" "Container Transport (Short Haul)"
 	outfits
 		"Anti-Missile Turret" 2
 		"Blaster Turret" 3
-		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile Launcher"
 		"Sidewinder Missile" 45
 		"RT-I Radiothermal"
 		"KP-6 Photovoltaic Array"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -43,8 +43,7 @@ ship "Argosy" "Argosy (Missile)"
 		"Meteor Missile Launcher" 4
 		"Meteor Missile" 165
 		"Meteor Missile Box" 3
-		"Anti-Missile Turret"
-		"Heavy Anti-Missile Turret"
+		"Anti-Missile Turret" 2
 		"Fission Reactor"
 		"Supercapacitor"
 		"D41-HY Shield Generator"
@@ -53,7 +52,7 @@ ship "Argosy" "Argosy (Missile)"
 		"A255 Atomic Steering"
 		"Hyperdrive"
 	turret "Anti-Missile Turret"
-	turret "Heavy Anti-Missile Turret"
+	turret "Anti-Missile Turret"
 
 
 ship "Argosy" "Argosy (Proton)"
@@ -102,8 +101,8 @@ ship "Bactrian" "Bactrian (Hai Engines)"
 	outfits
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 90
-		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo Launcher"
+		"Torpedo" 30
 		"Heavy Laser Turret" 4
 		"Heavy Anti-Missile Turret" 2
 		"Fusion Reactor"
@@ -264,7 +263,8 @@ ship "Behemoth" "Behemoth (Heavy)"
 		Torpedo 60
 		"Quad Blaster Turret" 2
 		"Plasma Turret" 2
-		"Heavy Anti-Missile Turret" 2
+		"Heavy Anti-Missile Turret"
+		"Anti-Missile Turret"
 		"Laser Rifle" 16
 		"Fusion Reactor"
 		"Supercapacitor"
@@ -280,7 +280,7 @@ ship "Behemoth" "Behemoth (Heavy)"
 	turret "Plasma Turret"
 	turret "Plasma Turret"
 	turret "Heavy Anti-Missile Turret"
-	turret "Heavy Anti-Missile Turret"
+	turret "Anti-Missile Turret"
 
 
 ship "Behemoth" "Behemoth (Proton)"
@@ -309,8 +309,8 @@ ship "Behemoth" "Behemoth (Proton)"
 
 ship "Behemoth" "Behemoth (Speedy)"
 	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		"Heavy Laser Turret" 6
 		"Breeder Reactor"
 		"LP144a Battery Pack"
@@ -445,8 +445,8 @@ ship "Bulk Freighter" "Bulk Freighter (Heavy)"
 		"Laser Turret" 2
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 30
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"KP-6 Photovoltaic Panel" 2
@@ -530,8 +530,7 @@ ship "Carrier" "Carrier (Jump)"
 		"Liquid Helium Cooler"
 		"Water Coolant System"
 		"Fuel Pod"
-		"Outfits Expansion" 4
-		"Brig"
+		"Outfits Expansion" 5
 		"A860 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Jump Drive"
@@ -561,9 +560,9 @@ ship "Carrier" "Carrier (Mark II)"
 		"LP036a Battery Pack"
 		"Supercapacitor" 3
 		"D94-YV Shield Generator"
-		"Large Radar Jammer" 2
+		"Large Radar Jammer"
 		"Liquid Helium Cooler"
-		"Outfits Expansion" 3
+		"Outfits Expansion" 4
 		"Brig"
 		"Laser Rifle" 45
 		"Fragmentation Grenades" 45
@@ -628,8 +627,8 @@ ship "Clipper" "Clipper (Speedy)"
 ship "Container Transport" "Container Transport (Blaster)"
 	outfits
 		"Quad Blaster Turret" 5
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 30
 		"Fusion Reactor"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
@@ -663,8 +662,8 @@ ship "Container Transport" "Container Transport (Hai)"
 
 ship "Container Transport" "Container Transport (Heavy)"
 	outfits
-		"Laser Turret" 2
-		"Heavy Laser Turret" 2
+		"Laser Turret" 3
+		"Heavy Laser Turret"
 		"Heavy Anti-Missile Turret"
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 60
@@ -753,12 +752,12 @@ ship "Corvette" "Corvette (Missile)"
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 159
 		"Sidewinder Missile Rack" 3
-		"Heavy Anti-Missile Turret" 2
+		"Anti-Missile Turret"
+		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
 		"LP036a Battery Pack"
 		"D67-TM Shield Generator"
 		"Cooling Ducts"
-		"Cargo Expansion"
 		"Laser Rifle" 4
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
@@ -767,6 +766,8 @@ ship "Corvette" "Corvette (Missile)"
 	gun "Sidewinder Missile Launcher"
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
+	turret "Anti-Missile Turret"
+	turret "Heavy Anti-Missile Turret"
 
 
 ship "Corvette" "Corvette (Speedy)"
@@ -802,7 +803,7 @@ ship "Cruiser" "Cruiser (Heavy)"
 		"Small Radar Jammer"
 		"Liquid Helium Cooler"
 		"Ramscoop"
-		"Outfits Expansion"
+		"Outfits Expansion" 2
 		"Brig"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -824,8 +825,8 @@ ship "Cruiser" "Cruiser (Jump)"
 	outfits
 		"Typhoon Launcher" 2
 		"Typhoon Torpedo" 60
-		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 180
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 90
 		"Electron Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Laser Rifle" 20
@@ -846,8 +847,8 @@ ship "Cruiser" "Cruiser (Jump)"
 	gun "Sidewinder Missile Launcher"
 	gun "Typhoon Launcher"
 	gun "Typhoon Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun
+	gun
 	turret "Electron Turret"
 	turret "Electron Turret"
 	turret "Electron Turret"
@@ -858,8 +859,8 @@ ship "Cruiser" "Cruiser (Mark II)"
 	outfits
 		"Typhoon Launcher" 2
 		"Typhoon Torpedo" 60
-		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 180
+		"Sidewinder Missile Launcher" 3
+		"Sidewinder Missile" 134
 		"Electron Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		"Armageddon Core"
@@ -875,10 +876,11 @@ ship "Cruiser" "Cruiser (Mark II)"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
+		"Outfits Expansion"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun
 	gun "Typhoon Launcher"
 	gun "Typhoon Launcher"
 	turret "Heavy Anti-Missile Turret"
@@ -895,7 +897,7 @@ ship "Dreadnought" "Dreadnought (Jump)"
 		"Plasma Turret" 3
 		"Heavy Anti-Missile Turret" 2
 		"Stack Core"
-		"LP144a Battery Pack"
+		"LP072a Battery Pack"
 		"D41-HY Shield Generator"
 		"Small Radar Jammer"
 		"Liquid Helium Cooler"
@@ -928,6 +930,8 @@ ship "Falcon" "Falcon (Heavy)"
 		"Orca Plasma Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Supercapacitor"
+		"Outfits Expansion"
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
 	gun "Meteor Missile Launcher"
@@ -1039,7 +1043,8 @@ ship "Firebird" "Firebird (Missile)"
 		"Torpedo Launcher" 2
 		"Torpedo" 75
 		"Torpedo Storage Rack"
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret"
+		"Laser Turret"
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"D67-TM Shield Generator"
@@ -1052,6 +1057,8 @@ ship "Firebird" "Firebird (Missile)"
 	gun "Meteor Missile Launcher"
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
+	turret "Laser Turret"
+	turret "Heavy Laser Turret"
 
 
 ship "Firebird" "Firebird (Plasma)"
@@ -1617,8 +1624,8 @@ ship "Leviathan" "Leviathan (Plasma Repeater)"
 ship "Manta" "Manta (Mark II)"
 	outfits
 		"Particle Cannon" 4
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"S-270 Regenerator"
@@ -1633,8 +1640,8 @@ ship "Manta" "Manta (Mark II)"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
-	gun "Meteor Missile Launcher"
-	gun "Meteor Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun
 
 
 ship "Manta" "Manta (Nuclear)"
@@ -1792,7 +1799,7 @@ ship "Modified Argosy" "Modified Argosy (Missile)"
 		"Meteor Missile Box" 3
 		"Torpedo Launcher" 2
 		"Torpedo" 60
-		"Heavy Laser Turret"
+		"Laser Turret"
 		"Heavy Anti-Missile Turret"
 		"S3 Thermionic"
 		"LP072a Battery Pack"
@@ -1825,7 +1832,8 @@ ship "Mule" "Mule (Hai Engines)"
 	outfits
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 90
-		"Heavy Laser Turret" 3
+		"Heavy Laser Turret" 2
+		"Laser Turret"
 		"Chameleon Anti-Missile"
 		"Boulder Reactor"
 		"Hai Fissure Batteries"
@@ -1884,7 +1892,8 @@ ship "Nest" "Nest (Sidewinder)"
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 90
 		"Quad Blaster Turret" 2
-		"Heavy Anti-Missile Turret" 2
+		"Anti-Missile Turret"
+		"Heavy Anti-Missile Turret"
 		"S3 Thermionic"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
@@ -1932,11 +1941,9 @@ ship "Osprey" "Osprey (Laser)"
 ship "Osprey" "Osprey (Missile)"
 	outfits
 		"Torpedo Launcher" 2
-		"Torpedo" 75
-		"Torpedo Storage Rack"
+		"Torpedo" 60
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 60
-		"Heavy Rocket Rack" 2
+		"Heavy Rocket" 40
 		"Heavy Laser Turret"
 		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
@@ -1959,8 +1966,8 @@ ship "Osprey" "Osprey (Missile)"
 
 ship "Protector" "Protector (Laser)"
 	outfits
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		"Anti-Missile Turret" 2
 		"Heavy Laser Turret" 4
 		"Fusion Reactor"
@@ -1984,8 +1991,8 @@ ship "Protector" "Protector (Laser)"
 
 ship "Protector" "Protector (Proton)"
 	outfits
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 45
 		"Proton Turret" 4
 		"Heavy Anti-Missile Turret" 2
 		"Fusion Reactor"
@@ -2062,8 +2069,8 @@ ship "Quicksilver" "Quicksilver (Scanner)"
 
 ship "Rainmaker" "Rainmaker (Mark II)"
 	outfits
-		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 180
+		"Sidewinder Missile Launcher" 3
+		"Sidewinder Missile" 135
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
 		"D67-TM Shield Generator"
@@ -2076,7 +2083,7 @@ ship "Rainmaker" "Rainmaker (Mark II)"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun
 
 
 
@@ -2099,7 +2106,6 @@ ship "Raven" "Raven (Heavy)"
 		"Fission Reactor"
 		"Supercapacitor" 3
 		"D23-QP Shield Generator"
-		"Water Coolant System"
 		"Cooling Ducts"
 		"Laser Rifle" 3
 		"A250 Atomic Thruster"
@@ -2117,7 +2123,8 @@ ship "Roost" "Roost (Sidewinder)"
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 90
 		"Quad Blaster Turret" 2
-		"Heavy Anti-Missile Turret" 2
+		"Heavy Anti-Missile Turret"
+		"Anti-Missile Turret"
 		"LP144a Battery Pack"
 		"S3 Thermionic"
 		"D94-YV Shield Generator" 2
@@ -2152,7 +2159,8 @@ ship "Skein" "Skein (Sidewinder)"
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 90
 		"Quad Blaster Turret" 2
-		"Heavy Anti-Missile Turret" 2
+		"Heavy Anti-Missile Turret"
+		"Anti-Missile Turret"
 		"LP144a Battery Pack"
 		"Fission Reactor"
 		"D94-YV Shield Generator" 3
@@ -2276,11 +2284,10 @@ ship "Star Queen" "Star Queen (Hai)"
 ship "Vanguard" "Vanguard (Missile)"
 	outfits
 		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 295
-		"Sidewinder Missile Rack" 5
+		"Sidewinder Missile" 226
+		"Sidewinder Missile Rack" 2
 		"Torpedo Launcher" 3
-		"Torpedo" 120
-		"Torpedo Storage Rack" 2
+		"Torpedo" 90
 		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
 		"Supercapacitor"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -681,14 +681,14 @@ outfit "Meteor Missile Launcher"
 		"hit effect" "missile hit"
 		"inaccuracy" 5
 		"velocity" 0
-		"velocity override" 11
-		"lifetime" 350
+		"velocity override" 20
+		"lifetime" 192
 		"range override" 3850
 		"reload" 80
 		"firing energy" 1
 		"firing heat" 20
-		"acceleration" .2
-		"drag" .018
+		"acceleration" .4
+		"drag" .02
 		"turn" 2
 		"homing" 1
 		"infrared tracking" .65
@@ -696,7 +696,7 @@ outfit "Meteor Missile Launcher"
 		"hull damage" 220
 		"hit force" 220
 		"missile strength" 6
-	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. Meteors are quickly destroyed by anti-missile systems, and their infrared tracking systems have trouble homing in on targets with low heat levels. Nevertheless, their large warheads can spell doom for poorly-defended targets when the missiles are fired in great numbers."
+	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space, with only rudimentary infrared tracking systems that can have trouble homing in on targets with low heat levels. True to its name, the missile reaches a very high speed to leave its target's anti-missile defenses with little time to react. The trade-off is maneuverability, so Meteor Missiles are practically useless against agile targets farther than point-blank range."
 
 outfit "Meteor Missile Pod"
 	category "Secondary Weapons"
@@ -719,16 +719,16 @@ outfit "Meteor Missile Pod"
 		"hit effect" "missile hit"
 		"inaccuracy" 5
 		"velocity" 0
-		"velocity override" 11
-		"lifetime" 350
+		"velocity override" 20
+		"lifetime" 192
 		"range override" 3850
 		"reload" 200
 		"burst count" 7
 		"burst reload" 80
 		"firing energy" 1
 		"firing heat" 20
-		"acceleration" .2
-		"drag" .018
+		"acceleration" .4
+		"drag" .02
 		"turn" 2
 		"homing" 1
 		"infrared tracking" .65
@@ -736,7 +736,7 @@ outfit "Meteor Missile Pod"
 		"hull damage" 220
 		"hit force" 220
 		"missile strength" 6
-	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. Meteors are quickly destroyed by anti-missile systems, and their infrared tracking systems have trouble homing in on targets with low heat levels. Nevertheless, their large warheads can spell doom for poorly-defended targets when the missiles are fired in great numbers."
+	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space, with only rudimentary infrared tracking systems that can have trouble homing in on targets with low heat levels. True to its name, the missile reaches a very high speed to leave its target's anti-missile defenses with little time to react. The trade-off is maneuverability, so Meteor Missiles are practically useless against agile targets farther than point-blank range."
 	description "	Pods enable fighters and other light craft to carry small quantities of missiles into battle while retaining enough space for other weapons. Large ships are better off with full-size launchers."
 
 effect "meteor fire"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -664,7 +664,7 @@ outfit "Meteor Missile Launcher"
 	category "Secondary Weapons"
 	cost 15000
 	thumbnail "outfit/meteor launcher"
-	"mass" 4
+	"mass" 8
 	"outfit space" -14
 	"weapon capacity" -14
 	"gun ports" -1
@@ -769,7 +769,7 @@ outfit "Sidewinder Missile Launcher"
 	category "Secondary Weapons"
 	cost 60000
 	thumbnail "outfit/sidewinder launcher"
-	"mass" 5
+	"mass" 11
 	"outfit space" -20
 	"weapon capacity" -20
 	"gun ports" -1
@@ -957,7 +957,7 @@ outfit "Torpedo Launcher"
 	category "Secondary Weapons"
 	cost 80000
 	thumbnail "outfit/torpedo launcher"
-	"mass" 13
+	"mass" 18
 	"outfit space" -30
 	"weapon capacity" -30
 	"gun ports" -1
@@ -1062,7 +1062,7 @@ outfit "Typhoon Launcher"
 	category "Secondary Weapons"
 	cost 260000
 	thumbnail "outfit/typhoon launcher"
-	"mass" 20
+	"mass" 25
 	"outfit space" -40
 	"weapon capacity" -40
 	"gun ports" -1
@@ -1166,7 +1166,7 @@ outfit "Heavy Rocket Launcher"
 	category "Secondary Weapons"
 	cost 40000
 	thumbnail "outfit/rocket launcher"
-	"mass" 10
+	"mass" 15
 	"outfit space" -25
 	"weapon capacity" -25
 	"gun ports" -1

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -665,8 +665,8 @@ outfit "Meteor Missile Launcher"
 	cost 15000
 	thumbnail "outfit/meteor launcher"
 	"mass" 4
-	"outfit space" -10
-	"weapon capacity" -10
+	"outfit space" -14
+	"weapon capacity" -14
 	"gun ports" -1
 	"meteor capacity" 30
 	weapon
@@ -680,18 +680,20 @@ outfit "Meteor Missile Launcher"
 		"die effect" "missile death"
 		"hit effect" "missile hit"
 		"inaccuracy" 5
-		"velocity" 11
+		"velocity" 0
+		"velocity override" 11
 		"lifetime" 350
+		"range override" 3850
 		"reload" 80
 		"firing energy" 1
 		"firing heat" 20
-		"acceleration" 1
-		"drag" .1
-		"turn" 1.8
+		"acceleration" .2
+		"drag" .018
+		"turn" 2
 		"homing" 1
 		"infrared tracking" .65
-		"shield damage" 260
-		"hull damage" 160
+		"shield damage" 360
+		"hull damage" 220
 		"hit force" 220
 		"missile strength" 6
 	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. Meteors are quickly destroyed by anti-missile systems, and their infrared tracking systems have trouble homing in on targets with low heat levels. Nevertheless, their large warheads can spell doom for poorly-defended targets when the missiles are fired in great numbers."
@@ -716,20 +718,22 @@ outfit "Meteor Missile Pod"
 		"die effect" "missile death"
 		"hit effect" "missile hit"
 		"inaccuracy" 5
-		"velocity" 11
+		"velocity" 0
+		"velocity override" 11
 		"lifetime" 350
+		"range override" 3850
 		"reload" 200
 		"burst count" 7
 		"burst reload" 80
 		"firing energy" 1
 		"firing heat" 20
-		"acceleration" 1
-		"drag" .1
-		"turn" 1.8
+		"acceleration" .2
+		"drag" .018
+		"turn" 2
 		"homing" 1
 		"infrared tracking" .65
-		"shield damage" 260
-		"hull damage" 160
+		"shield damage" 360
+		"hull damage" 220
 		"hit force" 220
 		"missile strength" 6
 	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. Meteors are quickly destroyed by anti-missile systems, and their infrared tracking systems have trouble homing in on targets with low heat levels. Nevertheless, their large warheads can spell doom for poorly-defended targets when the missiles are fired in great numbers."
@@ -766,8 +770,8 @@ outfit "Sidewinder Missile Launcher"
 	cost 60000
 	thumbnail "outfit/sidewinder launcher"
 	"mass" 5
-	"outfit space" -14
-	"weapon capacity" -14
+	"outfit space" -20
+	"weapon capacity" -20
 	"gun ports" -1
 	"sidewinder capacity" 45
 	weapon
@@ -781,18 +785,20 @@ outfit "Sidewinder Missile Launcher"
 		"die effect" "missile death"
 		"hit effect" "missile hit"
 		"inaccuracy" 4
-		"velocity" 14
+		"velocity" 0
+		"velocity override" 14
 		"lifetime" 350
+		"range override" 4900
 		"reload" 60
 		"firing energy" 1
 		"firing heat" 15
-		"acceleration" 1.2
-		"drag" .1
+		"acceleration" .3
+		"drag" .021
 		"turn" 4
 		"homing" 4
 		"radar tracking" .9
-		"shield damage" 180
-		"hull damage" 125
+		"shield damage" 260
+		"hull damage" 180
 		"hit force" 170
 		"missile strength" 12
 	description "The Sidewinder Missile is designed by Lovelace Labs, which is ironically also the designer of the Anti-Missile Turret. Rumors say that the two engineering teams at Lovelace who make the missiles and the anti-missiles are locked in furious competition with each other: the result has been generation after generation of smarter missiles and then smarter turrets to fend them off."
@@ -818,20 +824,22 @@ outfit "Sidewinder Missile Pod"
 		"die effect" "missile death"
 		"hit effect" "missile hit"
 		"inaccuracy" 4
-		"velocity" 14
+		"velocity" 0
+		"velocity override" 14
 		"lifetime" 350
+		"range override" 4900
 		"reload" 150
 		"burst count" 4
 		"burst reload" 60
 		"firing energy" 1
 		"firing heat" 15
-		"acceleration" 1.2
-		"drag" .1
+		"acceleration" .3
+		"drag" .021
 		"turn" 4
 		"homing" 4
 		"radar tracking" .9
-		"shield damage" 180
-		"hull damage" 125
+		"shield damage" 260
+		"hull damage" 180
 		"hit force" 170
 		"missile strength" 12
 	description "The Sidewinder Missile is designed by Lovelace Labs, which is ironically also the designer of the Anti-Missile Turret. Rumors say that the two engineering teams at Lovelace who make the missiles and the anti-missiles are locked in furious competition with each other: the result has been generation after generation of smarter missiles and then smarter turrets to fend them off."
@@ -950,8 +958,8 @@ outfit "Torpedo Launcher"
 	cost 80000
 	thumbnail "outfit/torpedo launcher"
 	"mass" 13
-	"outfit space" -25
-	"weapon capacity" -25
+	"outfit space" -30
+	"weapon capacity" -30
 	"gun ports" -1
 	"torpedo capacity" 30
 	weapon
@@ -965,18 +973,20 @@ outfit "Torpedo Launcher"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 7
+		"velocity" 0
+		"velocity override" 7
 		"lifetime" 900
+		"range override" 6300
 		"reload" 150
 		"firing energy" 2
 		"firing heat" 45
-		"acceleration" .15
-		"drag" .025
+		"acceleration" .1
+		"drag" .015
 		"turn" 1.5
 		"homing" 3
 		"optical tracking" .8
-		"shield damage" 680
-		"hull damage" 680
+		"shield damage" 820
+		"hull damage" 820
 		"hit force" 300
 		"missile strength" 30
 	description "Torpedoes are the most powerful homing weapon, but they move slowly enough that fast ships can simply outrun them, making them most useful against large targets or against small ships at times when they are too distracted to dodge. Torpedo launchers are also much larger than other missile systems, so they are most often found in capital ships."
@@ -1001,20 +1011,22 @@ outfit "Torpedo Pod"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 7
+		"velocity" 0
+		"velocity override" 7
 		"lifetime" 900
+		"range override" 6300
 		"reload" 320
 		"burst count" 3
 		"burst reload" 150
 		"firing energy" 2
 		"firing heat" 45
-		"acceleration" .15
-		"drag" .025
+		"acceleration" .1
+		"drag" .015
 		"turn" 1.5
 		"homing" 3
 		"optical tracking" .8
-		"shield damage" 680
-		"hull damage" 680
+		"shield damage" 820
+		"hull damage" 820
 		"hit force" 300
 		"missile strength" 30
 	description "Torpedoes are the most powerful homing weapon, but they move slowly enough that fast ships can simply outrun them, making them most useful against large targets or against small ships at times when they are too distracted to dodge."
@@ -1051,8 +1063,8 @@ outfit "Typhoon Launcher"
 	cost 260000
 	thumbnail "outfit/typhoon launcher"
 	"mass" 20
-	"outfit space" -35
-	"weapon capacity" -35
+	"outfit space" -40
+	"weapon capacity" -40
 	"gun ports" -1
 	"typhoon capacity" 30
 	weapon
@@ -1066,18 +1078,20 @@ outfit "Typhoon Launcher"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 6
+		"velocity" 0
+		"velocity override" 6
 		"lifetime" 1100
+		"range override" 6600
 		"reload" 120
 		"firing energy" 4
 		"firing heat" 50
 		"acceleration" .1
-		"drag" .02
+		"drag" .017
 		"turn" 1.5
 		"homing" 4
 		"optical tracking" .9
-		"shield damage" 920
-		"hull damage" 920
+		"shield damage" 1050
+		"hull damage" 1050
 		"hit force" 450
 		"missile strength" 40
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."
@@ -1102,20 +1116,22 @@ outfit "Typhoon Pod"
 		"hit effect" "torpedo hit"
 		"die effect" "tiny explosion"
 		"inaccuracy" 5
-		"velocity" 6
+		"velocity" 0
+		"velocity override" 6
 		"lifetime" 1100
+		"range override" 6600
 		"reload" 252
 		"burst count" 2
 		"burst reload" 120
 		"firing energy" 4
 		"firing heat" 50
 		"acceleration" .1
-		"drag" .02
+		"drag" .017
 		"turn" 1.5
 		"homing" 4
 		"optical tracking" .9
-		"shield damage" 920
-		"hull damage" 920
+		"shield damage" 1050
+		"hull damage" 1050
 		"hit force" 450
 		"missile strength" 40
 	description "Typhoon Torpedoes are an improved torpedo technology; they do considerably more damage than ordinary torpedoes. However, they are also much slower, because they are intended mostly for use against large and slow-moving capital ships. As a result, sufficiently skilled pilots can often dodge around them."
@@ -1151,8 +1167,8 @@ outfit "Heavy Rocket Launcher"
 	cost 40000
 	thumbnail "outfit/rocket launcher"
 	"mass" 10
-	"outfit space" -20
-	"weapon capacity" -20
+	"outfit space" -25
+	"weapon capacity" -25
 	"gun ports" -1
 	"rocket capacity" 20
 	weapon
@@ -1164,17 +1180,19 @@ outfit "Heavy Rocket Launcher"
 		"hit effect" "heavy rocket hit"
 		"die effect" "small explosion"
 		"inaccuracy" 1
-		"velocity" 8
+		"velocity" 0
+		"velocity override" 8
 		"lifetime" 125
+		"range override" 1000
 		"reload" 240
 		"firing energy" 1
 		"firing heat" 250
-		"acceleration" .8
-		"drag" .1
+		"acceleration" .2
+		"drag" .025
 		"trigger radius" 20
 		"blast radius" 50
-		"shield damage" 850
-		"hull damage" 720
+		"shield damage" 1060
+		"hull damage" 900
 		"hit force" 600
 		"missile strength" 16
 	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
@@ -1197,20 +1215,22 @@ outfit "Heavy Rocket Pod"
 		"hit effect" "heavy rocket hit"
 		"die effect" "small explosion"
 		"inaccuracy" 1
-		"velocity" 8
+		"velocity" 0
+		"velocity override" 8
 		"lifetime" 125
+		"range override" 1000
 		"reload" 500
 		"range override" 500
 		"burst count" 2
 		"burst reload" 240
 		"firing energy" 1
 		"firing heat" 250
-		"acceleration" .8
-		"drag" .1
+		"acceleration" .2
+		"drag" .025
 		"trigger radius" 20
 		"blast radius" 50
-		"shield damage" 850
-		"hull damage" 720
+		"shield damage" 1060
+		"hull damage" 900
 		"hit force" 600
 		"missile strength" 16
 	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -230,8 +230,8 @@ ship "Marauder Fury"
 		"heat dissipation" .85
 		"fuel capacity" 500
 		"cargo space" 15
-		"outfit space" 240
-		"weapon capacity" 80
+		"outfit space" 256
+		"weapon capacity" 96
 		"engine capacity" 100
 		"ramscoop" 2
 		weapon


### PR DESCRIPTION
## Summary
This PR increases the size of full-sized Human missile launchers (except the Javelin launcher) to differentiate them from the Pod versions and provide an in-game reason for small craft to use Pods: the big ones are too big! This necessitates tweaking the loadouts of many ships, typically to reduce the number of full-sized launchers by one in cases where missile-heavy ships would be overloaded.

Because larger missile launchers would have less DPS per ton, missile damage values are increased to match the same DPS/ton values that they were at before. This makes individual missiles more dangerous if they hit, so an additional change is made to make them hit less often: they are no longer launched at full speed, but rather have to accelerate up to their maximum speed, which is unchanged, (except for the Meteor; see below). This is realistic because it's how real-world missiles work, especially large ones.

The changeset then provides the opportunity to give the Meteor missile a real combat role. It now accelerates to a faster top speed than it used to have (20, up from 11), which makes groups of Meteors capable of getting through light anti-missile defenses once they've accelerated to maximum velocity. This change also makes the Meteor even less useful against maneuvering targets because its high final speed makes it less able to turn to hit them from any angle other than head-on.

The net result:
* Missiles feel more like missiles; when they hit, they hurt! But they are easier to avoid or shoot down.
* Many large ships have fewer launchers, and missiles are now slower overall, which improves the general issue of missile spam a bit--though there is clearly more to be done here.
* Missiles fired at small fast-maneuvering craft hit much less often--even fast-turning missiles like Sidewinders. Instead they often overshoot, turn around, overshoot again, and hit on the third or fourth pass. It looks great in-game, and it's exactly what happens in real-life missile dodging too. In-game, small ships now have more opportunities to dodge or outlast missiles. This is forgiving to new players while still rewarding player skill.
* Missiles fired from point-blank range at targets with anti-missile systems will hit much less often, since the AM defenses have more time to shoot down the missiles while they are still accelerating.
* The Meteor Missile now has a valid combat role and thus a reason for the player to consider using it.
* Heavy Rockets and Meteor missiles fired by enemies are now much much easier to dodge, even as a novice pilot. This should alleviate frustration for new players.
* Differentiates Human missiles from alien missiles, which are apparently advanced enough to be launched at full speed. This is a bigger advantage that it may seem!


## Testing Done
* Started a new game with a shuttle pilot and played for a few hours
* Played through various mission events in the Free Worlds campaigns with some existing pilots
* Played through random bits of the midgame in various existing pilots I have


Note: If the Meteor changes are too controversial, I can remove them from this PR and propose them again if and when this one is merged.