### PR TITLE
Break all projectile targeting when you bribe a government

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1127,6 +1127,24 @@ void Engine::SelectGroup(int group, bool hasShift, bool hasControl)
 
 
 
+// Break targeting on all projectiles between the player and the given
+// government; gov projectiles stop targeting the player and player's
+// projectiles stop targeting gov.
+void Engine::BreakTargeting(const Government *gov)
+{
+	const Government *playerGov = GameData::PlayerGovernment();
+	for(Projectile &projectile : projectiles)
+	{
+		const Government *projectileGov = projectile.GetGovernment();
+		const Government *targetGov = projectile.TargetGovernment();
+		if((projectileGov == playerGov && targetGov == gov)
+			|| (projectileGov == gov && targetGov == playerGov))
+			projectile.BreakTarget();
+	}
+}
+
+
+
 void Engine::EnterSystem()
 {
 	ai.Clean();

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -88,6 +88,10 @@ public:
 	void RClick(const Point &point);
 	void SelectGroup(int group, bool hasShift, bool hasControl);
 	
+	// Break targeting on all projectiles between the player and the given
+	// government; gov projectil0es stop targeting the player and player's
+	// projectiles stop targeting gov.
+	void BreakTargeting(const Government *gov);
 	
 private:
 	void EnterSystem();

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -40,8 +40,8 @@ using namespace std;
 
 
 
-HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship)
-	: player(player), ship(ship), sprite(ship->GetSprite()), facing(ship->Facing())
+HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<void(const Government *)> callback)
+	: player(player), ship(ship), callback(callback), sprite(ship->GetSprite()), facing(ship->Facing())
 {
 	SetInterruptible(false);
 	
@@ -233,7 +233,11 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	bool shipIsEnemy = (ship && ship->GetGovernment()->IsEnemy());
 	
 	if(key == 'd' || key == SDLK_ESCAPE || key == SDLK_RETURN || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI))))
+	{
+		if(callback)
+			callback(bribed);
 		GetUI()->Pop(this);
+	}
 	else if(key == 't' && hasLanguage && planet)
 	{
 		if(GameData::GetPolitics().HasDominated(planet))
@@ -286,7 +290,8 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		{
 			if(ship)
 			{
-				ship->GetGovernment()->Bribe();
+				bribed = ship->GetGovernment();
+				bribed->Bribe();
 				Messages::Add("You bribed a " + ship->GetGovernment()->GetName() + " ship "
 					+ Format::Credits(bribe) + " credits to refrain from attacking you today."
 						, Messages::Importance::High);

--- a/source/HailPanel.h
+++ b/source/HailPanel.h
@@ -22,6 +22,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <memory>
 #include <string>
 
+class Government;
 class Planet;
 class PlayerInfo;
 class Ship;
@@ -35,7 +36,7 @@ class StellarObject;
 // to bribe a planet to allow you to land there.
 class HailPanel : public Panel {
 public:
-	HailPanel(PlayerInfo &player, const std::shared_ptr<Ship> &ship);
+	HailPanel(PlayerInfo &player, const std::shared_ptr<Ship> &ship, std::function<void(const Government *)> callback);
 	HailPanel(PlayerInfo &player, const StellarObject *object);
 	
 	virtual void Draw() override;
@@ -53,6 +54,7 @@ private:
 private:
 	PlayerInfo &player;
 	std::shared_ptr<Ship> ship = nullptr;
+	std::function<void(const Government *)> callback = nullptr;
 	const Planet *planet = nullptr;
 	const Sprite *sprite = nullptr;
 	Angle facing;
@@ -61,6 +63,7 @@ private:
 	std::string message;
 	
 	int64_t bribe = 0;
+	const Government *bribed = nullptr;
 	bool playerNeedsHelp = false;
 	bool canGiveFuel = false;
 	bool canRepair = false;

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -204,6 +204,15 @@ bool MainPanel::AllowFastForward() const
 
 
 
+// The hail panel calls this when it closes.
+void MainPanel::OnBribeCallback(const Government *bribed)
+{
+	if(bribed)
+		engine.BreakTargeting(bribed);
+}
+
+
+
 // Only override the ones you need; the default action is to return false.
 bool MainPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
@@ -423,7 +432,8 @@ bool MainPanel::ShowHailPanel()
 				, Messages::Importance::High);
 		else
 		{
-			GetUI()->Push(new HailPanel(player, target));
+			GetUI()->Push(new HailPanel(player, target,
+				[&](const Government *bribed) { MainPanel::OnBribeCallback(bribed); } ));
 			return true;
 		}
 	}

--- a/source/MainPanel.h
+++ b/source/MainPanel.h
@@ -38,6 +38,8 @@ public:
 	
 	// The planet panel calls this when it closes.
 	void OnCallback();
+	// The hail panel calls this when it closes.
+	void OnBribeCallback(const Government *bribed = nullptr);
 	
 	// Send a command to the engine (on behalf of the player).
 	void GiveCommand(const Command &command);

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -314,10 +314,28 @@ const Ship *Projectile::Target() const
 
 
 
+const Government *Projectile::TargetGovernment() const
+{
+	return targetGovernment;
+}
+
+
+
 shared_ptr<Ship> Projectile::TargetPtr() const
 {
 	return targetShip.lock();
 }
+
+
+
+// Clear the targeting information on this projectile.
+void Projectile::BreakTarget()
+{
+	targetShip.reset();
+	cachedTarget = nullptr;
+	targetGovernment = nullptr;
+}
+
 
 
 // TODO: add more conditions in the future. For example maybe proximity to stars

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -66,12 +66,16 @@ public:
 	// Get information on the weapon that fired this projectile.
 	const Weapon &GetWeapon() const;
 	
-	// Find out which ship this projectile is targeting. Note: this pointer is
-	// not guaranteed to be dereferenceable, so only use it for comparing.
+	// Find out which ship or government this projectile is targeting. Note:
+	// this pointer is not guaranteed to be dereferenceable, so only use it
+	// for comparing.
 	const Ship *Target() const;
+	const Government *TargetGovernment() const;
 	// This function is much more costly, so use it only if you need to get a
-	// non-const shared pointer to the target.
+	// non-const shared pointer to the target ship.
 	std::shared_ptr<Ship> TargetPtr() const;
+	// Clear the targeting information on this projectile.
+	void BreakTarget();
 	
 	// Get the distance that this projectile has traveled.
 	double DistanceTraveled() const;


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #2277.

## Feature Details
This PR changes the mechanics of bribing such that when you bribe a government, your projectiles and the projectiles of the government you bribed lose targeting and collision with one another. This prevents the frustrating scenario where you bribe a government that you are in combat with, and just after you have bribed them they become hostile again because projectiles that were in flight when you bribed the government hit their ships, once again provoking them into hostility.

Part of the code in this PR is copied over from #2878, particularly the mechanism for HailPanel using a callback through MainPanel to reach Engine.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Engaged in combat with a pirate who was using missiles while I was using missiles as well. Just before our missiles hit each other, I bribed the pirate and observed how the missiles that were about to impact passed right through each ship. This would be the case for all projectiles, not just missiles.

## Performance Impact
N/A (The projectile list is iterated through only once after bribing to break the targeting on the relevant projectiles. The projectile list is iterated through every frame for collision detection, so adding one more iteration for a single frame after bribing doesn't harm performance.)

## Additional Context
Should this change be seen as too powerful in allowing the player to cheat death (i.e. by bribing the government they're fighting just before receiving a killing blow), then a potential change could be to increasing the size of bribes with each subsequent bribe given to a specific government, at the very least within a single day but potentially over the course of a period of days, or simply increase the bribe costs in general.

It is important to note though that later game hostiles are unable to be bribed, so perhaps bribing being highly forgiving for early game combat is desirable.