### PR TITLE
feat: Add Equals function to Dictionary (for future de-duplication of ship.baseAttributes)

### DIFF
--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -93,7 +93,7 @@ double Dictionary::Get(const string &key) const
 
 
 // Compare two dictionaries to see if they contain exactly the same data.
-bool Dictionary::Equals(Dictionary &other)
+bool Dictionary::Equals(const Dictionary &other) const noexcept
 {
 	auto it = begin();
 	auto ito = other.begin();

--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -89,3 +89,19 @@ double Dictionary::Get(const string &key) const
 {
 	return Get(key.c_str());
 }
+
+
+
+// Compare two dictionaries to see if they contain exactly the same data.
+bool Dictionary::Equals(Dictionary &other)
+{
+	auto it = begin();
+	auto ito = other.begin();
+	while(it != end() && ito != other.end()
+		&& it->first == ito->first && it->second == ito->second)
+	{
+		++it;
+		++ito;
+	}
+	return it == end() && ito == other.end();
+}

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -32,6 +32,9 @@ public:
 	double Get(const char *key) const;
 	double Get(const std::string &key) const;
 	
+	// Compare two dictionaries to see if they contain exactly the same data.
+	bool Equals(Dictionary &other);
+	
 	// Expose certain functions from the underlying vector:
 	using std::vector<std::pair<const char *, double>>::empty;
 	using std::vector<std::pair<const char *, double>>::begin;

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -33,7 +33,7 @@ public:
 	double Get(const std::string &key) const;
 	
 	// Compare two dictionaries to see if they contain exactly the same data.
-	bool Equals(Dictionary &other);
+	bool Equals(const Dictionary &other) const noexcept;
 	
 	// Expose certain functions from the underlying vector:
 	using std::vector<std::pair<const char *, double>>::empty;

--- a/tests/src/test_dictionary.cpp
+++ b/tests/src/test_dictionary.cpp
@@ -1,0 +1,99 @@
+/* test_dictionary.cpp
+Copyright (c) 2021 by Peter van der Meer
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "es-test.hpp"
+
+// Include only the tested class's header.
+#include "../../source/Dictionary.h"
+
+// Include helpers here (if needed).
+
+// ... and any system includes needed for the test file.
+#include <map>
+#include <string>
+
+namespace { // test namespace
+
+// #region mock data
+// #endregion mock data
+
+
+
+// #region unit tests
+SCENARIO( "Having an empty Dictionary" , "[Dictionary][Empty]" ) {
+	Dictionary emptyA;
+	GIVEN( "A second empty Dictionary" )
+	{
+		Dictionary emptyB;
+		THEN( "They should compare as equal" )
+		{
+			CHECK(emptyA.Equals(emptyB));
+		}
+	}
+	GIVEN( "A second non-empty Dictionary" )
+	{
+		Dictionary fullC;
+		fullC["dataEntry"] = 5.0;
+		THEN( "They should compare as not-equal")
+		{
+			CHECK_FALSE(emptyA.Equals(fullC));
+			CHECK_FALSE(fullC.Equals(emptyA));
+		}
+	}
+}
+
+SCENARIO( "Having an non-empty Dictionary" , "[Dictionary][NonEmpty}" ) {
+	Dictionary fullA;
+	fullA["dataOne"] = 6.0;
+	fullA["zIndex"] = -0.2;
+	fullA["abstract"] = 1.3;
+	GIVEN( "A second Dictionary with the same content" )
+	{
+		Dictionary fullB;
+		fullB["abstract"] = 1.3;
+		fullB["dataOne"] = 6.0;
+		fullB["zIndex"] = -0.2;
+		THEN( "They should compare as equal" )
+		{
+			CHECK(fullA.Equals(fullB));
+		}
+	}
+	GIVEN( "A second Dictionary with a different key" )
+	{
+		Dictionary fullB;
+		fullB["abstract"] = 1.3;
+		fullB["dataOne"] = 6.0;
+		fullB["yIndex"] = -0.2;
+		THEN( "They should compare as not-equal" )
+		{
+			CHECK_FALSE(fullA.Equals(fullB));
+			CHECK_FALSE(fullB.Equals(fullA));
+		}
+	}
+	GIVEN( "A second Dictionary with a different value" )
+	{
+		Dictionary fullB;
+		fullB["abstract"] = 1.3;
+		fullB["dataOne"] = 12.0;
+		fullB["zIndex"] = -0.2;
+		THEN( "They should compare as not-equal" )
+		{
+			CHECK_FALSE(fullA.Equals(fullB));
+			CHECK_FALSE(fullB.Equals(fullA));
+		}
+	}
+}
+// #endregion unit tests
+
+
+
+} // test namespace


### PR DESCRIPTION
**Feature:** This PR implements a first step towards re-using Ship.baseAttributes among ships.

## Feature Details
The `Ship.baseAttributes` will be identical for most ships of the same Model, but currently every ship in the game contains a copy of all the baseAttributes. Active ships in the game also contain an `const Outfit *explosionWeapon` pointer to the baseAttributes of their Models in GameData to ensure that explosions can be properly shown without pointer-exceptions after the ship-instance dies.

This PR is about adding Equals functions to relevant classes (at initial upload only to the Dictionary class, but I expect Weapon and Outfit to also get an Equals function in this PR or in follow-up PRs). The Equals function should help to centrally store the BaseAttributes without duplication and with the ability to keep a stable pointer to BaseAttributes from the ship (even after it dies, gets removed and still is exploding).

## UI Screenshots /  Usage Examples
N/A

## Testing Done
I added an unit-test for the Equals function in Dictionary.

## Performance Impact
No impact expected in the RealTime section of the game; BaseAttributes don't seem to be used in the RealTime sections of the game, since there the total set of Attributes including the data from installed outfits seems to be relevant.