### PR TITLE
refactor(internal): Replace public inheritance with composition in MissionAction refactor

### DIFF
--- a/data/human/transport missions.txt
+++ b/data/human/transport missions.txt
@@ -2230,7 +2230,7 @@ mission "Lost Boy 3"
 				`	"I'm sorry but I can't take this from you."`
 					goto reject
 			
-			apply
+			action
 				payment 952
 			`	"This is just so wonderful. There aren't many people around here who would do such a thing for such little pay."`
 				goto end
@@ -3204,7 +3204,7 @@ mission "Earth Retirement"
 					goto reject
 			
 			label payment
-			apply
+			action
 				payment 2000 80
 			`	As you count up the large clump of credits you were handed (the sum comes out to <payment>), they slowly make their way to the train station. Presumably, their new apartment is far from here.`
 				accept

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -149,7 +149,7 @@ void Conversation::Load(const DataNode &node, const string &missionName)
 			// Don't merge "branch" nodes with any other nodes.
 			nodes.emplace_back();
 			nodes.back().canMergeOnto = false;
-			nodes.back().conditions.Load(child);
+			nodes.back().branch.Load(child);
 			// A branch should always specify what node to go to if the test is
 			// true, and may also specify where to go if it is false.
 			for(int i = 1; i <= 2; ++i)
@@ -166,9 +166,9 @@ void Conversation::Load(const DataNode &node, const string &missionName)
 				}
 			}
 		}
-		else if(child.Token(0) == "apply")
+		else if(child.Token(0) == "action" || child.Token(0) == "apply")
 		{
-			// Don't merge "apply" nodes with any other nodes.
+			// Don't merge "action" nodes with any other nodes. Allow the legacy keyword "apply," too.
 			AddNode();
 			nodes.back().canMergeOnto = false;
 			nodes.back().actions.Load(child, missionName);
@@ -239,20 +239,20 @@ void Conversation::Save(DataWriter &out) const
 			
 			if(node.scene)
 				out.Write("scene", node.scene->Name());	
-			if(!node.conditions.IsEmpty())
+			if(!node.branch.IsEmpty())
 			{
 				out.Write("branch", TokenName(node.data[0].second), TokenName(node.data[1].second));
 				// Write the condition set as a child of this node.
 				out.BeginChild();
 				{
-					node.conditions.Save(out);
+					node.branch.Save(out);
 				}
 				out.EndChild();
 				continue;
 			}
 			if(!node.actions.IsEmpty())
 			{
-				out.Write("apply", TokenName(node.data[0].second));
+				out.Write("action");
 				// Write the GameAction as a child of this node.
 				out.BeginChild();
 				{
@@ -315,7 +315,7 @@ string Conversation::Validate() const
 		{
 			string reason = node.actions.Validate();
 			if(!reason.empty())
-				return "conversation applied " + reason;
+				return "conversation action " + std::move(reason);
 		}
 	}
 	return "";
@@ -369,13 +369,13 @@ bool Conversation::IsBranch(int node) const
 	if(static_cast<unsigned>(node) >= nodes.size())
 		return false;
 	
-	return !nodes[node].conditions.IsEmpty();
+	return !nodes[node].branch.IsEmpty();
 }
 
 
 
-// Check if the given conversation node applies an action.
-bool Conversation::IsApply(int node) const
+// Check if the given conversation node performs an action.
+bool Conversation::IsAction(int node) const
 {
 	if(static_cast<unsigned>(node) >= nodes.size())
 		return false;
@@ -392,12 +392,12 @@ const ConditionSet &Conversation::Branch(int node) const
 	if(static_cast<unsigned>(node) >= nodes.size())
 		return empty;
 	
-	return nodes[node].conditions;
+	return nodes[node].branch;
 }
 
 
 // Get the action that the given node applies.
-const GameAction &Conversation::Apply(int node) const
+const GameAction &Conversation::GetAction(int node) const
 {
 	static GameAction empty;
 	if(static_cast<unsigned>(node) >= nodes.size())

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -256,7 +256,7 @@ void Conversation::Save(DataWriter &out) const
 				// Write the GameAction as a child of this node.
 				out.BeginChild();
 				{
-					node.actions.SaveAction(out);
+					node.actions.Save(out);
 				}
 				out.EndChild();
 				continue;
@@ -313,7 +313,7 @@ string Conversation::Validate() const
 	{
 		if(!node.actions.IsEmpty())
 		{
-			string reason = node.actions.ValidateAction();
+			string reason = node.actions.Validate();
 			if(!reason.empty())
 				return "conversation applied " + reason;
 		}

--- a/source/Conversation.h
+++ b/source/Conversation.h
@@ -27,11 +27,11 @@ class Sprite;
 
 
 
-// Class representing a conversation, generally occurring when the you are asked to
+// Class representing a conversation, generally occurring when the player is asked to
 // accept or decline a mission. The conversation can take different paths depending
 // on what responses you choose, leading you to accept, decline, or (rarely) to be
 // killed. A conversation can also branch based on various condition flags that
-// are set for the player, and can also modify those flags.
+// are set for the player, or even trigger various changes to the game's state.
 class Conversation {
 public:
 	// The possible outcomes of a conversation:
@@ -64,9 +64,8 @@ public:
 	// Check if the actions in this conversation are valid.
 	std::string Validate() const;
 	
-	// Do text replacement throughout this conversation and instantiate
-	// any GameActions. This returns a new Conversation object with
-	// things like the player's name filled in.
+	// Generate a new conversation from this template, filling in any text
+	// substitutions and instantiating any actions.
 	Conversation Instantiate(std::map<std::string, std::string> &subs, int jumps = 0, int payload = 0) const;
 	
 	// The beginning of the conversation is node 0. Some nodes have choices for
@@ -75,9 +74,9 @@ public:
 	bool IsChoice(int node) const;
 	int Choices(int node) const;
 	bool IsBranch(int node) const;
-	bool IsApply(int node) const;
+	bool IsAction(int node) const;
 	const ConditionSet &Branch(int node) const;
-	const GameAction &Apply(int node) const;
+	const GameAction &GetAction(int node) const;
 	const std::string &Text(int node, int choice = 0) const;
 	const Sprite *Scene(int node) const;
 	int NextNode(int node, int choice = 0) const;
@@ -93,9 +92,9 @@ private:
 		// choice can be merged into what came before it, to simplify things.
 		explicit Node(bool isChoice = false) noexcept : isChoice(isChoice), canMergeOnto(!isChoice) {}
 		
-		// For applying condition changes or branching based on conditions:
-		ConditionSet conditions;
-		// For applying actions:
+		// The condition expressions that determine the next node to load.
+		ConditionSet branch;
+		// Tasks performed when this node is reached.
 		GameAction actions;
 		// The actual conversation text. If this node is not a choice, there
 		// will only be one entry in the vector. Each entry also stores the
@@ -113,7 +112,7 @@ private:
 	
 	
 private:
-	// Parse the children of the given node to see if then contain any "gotos."
+	// Parse the children of the given node to see if they contain any "gotos."
 	// If so, link them up properly. Return true if gotos were found.
 	bool LoadGotos(const DataNode &node);
 	// Add a label, pointing to whatever node is created next.

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -337,8 +337,8 @@ void ConversationPanel::Goto(int index, int selectedChoice)
 		{
 			// Apply nodes are able to take various actions, be that changing
 			// the player's conditions, granting payments, triggering events,
-			// and more.
-			conversation.Apply(node).DoAction(player);
+			// and more. They are not allowed to spawn additional UI elements.
+			conversation.Apply(node).Do(player, nullptr);
 		}
 		else
 		{

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -333,12 +333,12 @@ void ConversationPanel::Goto(int index, int selectedChoice)
 			// player's condition variables rather than player input.
 			choice = !conversation.Branch(node).Test(player.Conditions());
 		}
-		else if(conversation.IsApply(node))
+		else if(conversation.IsAction(node))
 		{
-			// Apply nodes are able to take various actions, be that changing
+			// Action nodes are able to perform various actions, e.g. changing
 			// the player's conditions, granting payments, triggering events,
 			// and more. They are not allowed to spawn additional UI elements.
-			conversation.Apply(node).Do(player, nullptr);
+			conversation.GetAction(node).Do(player, nullptr);
 		}
 		else
 		{

--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -63,7 +63,7 @@ private:
 	// possibly activating a callback function and, if docked with an NPC,
 	// destroying it or showing the BoardingPanel (if it is hostile).
 	void Exit();
-	// Handle  mouse click on the "ok," "done," or a conversation choice.
+	// Handle mouse click on the "ok," "done," or a conversation choice.
 	void ClickName(int side);
 	void ClickChoice(int index);
 	

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -371,16 +371,8 @@ GameAction GameAction::Instantiate(map<string, string> &subs, int jumps, int pay
 {
 	GameAction result;
 	result.isEmpty = isEmpty;
-	InstantiateAction(result, subs, jumps, payload);
 	
-	return result;
-}
-
-
-
-void GameAction::InstantiateAction(GameAction &result, map<string, string> &subs, int jumps, int payload) const
-{
-	for(const auto &it : events)
+	for(auto &&it : events)
 	{
 		// Allow randomization of event times. The second value in the pair is
 		// always greater than or equal to the first, so Random::Int() will
@@ -389,7 +381,7 @@ void GameAction::InstantiateAction(GameAction &result, map<string, string> &subs
 		result.events[it.first] = make_pair(day, day);
 	}
 	
-	for(const auto &it : giftShips)
+	for(auto &&it : giftShips)
 		result.giftShips.emplace_back(it.first, !it.second.empty() ? it.second : GameData::Phrases().Get("civilian")->Get());
 	result.giftOutfits = giftOutfits;
 	
@@ -405,11 +397,13 @@ void GameAction::InstantiateAction(GameAction &result, map<string, string> &subs
 	
 	if(!logText.empty())
 		result.logText = Format::Replace(logText, subs);
-	for(const auto &it : specialLogText)
-		for(const auto &eit : it.second)
+	for(auto &&it : specialLogText)
+		for(auto &&eit : it.second)
 			result.specialLogText[it.first][eit.first] = Format::Replace(eit.second, subs);
 	
 	result.fail = fail;
 	
 	result.conditions = conditions;
+	
+	return result;
 }

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -135,7 +135,7 @@ void GameAction::Load(const DataNode &node, const string &missionName)
 
 
 // Load a single child at a time, used for streamlining MissionAction::Load.
-void GameAction::LoadSingle(const DataNode &child, const string &missionName, bool conversation)
+void GameAction::LoadSingle(const DataNode &child, const string &missionName)
 {
 	isEmpty = false;
 	

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -220,8 +220,8 @@ void GameAction::Save(DataWriter &out) const
 		}
 		out.EndChild();
 	}
-	for(const auto &it : specialLogText)
-		for(const auto &eit : it.second)
+	for(auto &&it : specialLogText)
+		for(auto &&eit : it.second)
 		{
 			out.Write("log", it.first, eit.first);
 			out.BeginChild();
@@ -232,22 +232,17 @@ void GameAction::Save(DataWriter &out) const
 			}
 			out.EndChild();
 		}
-	for(const auto &it : giftShips)
+	for(auto &&it : giftShips)
 		out.Write("give", "ship", it.first->VariantName(), it.second);
-	for(const auto &it : giftOutfits)
+	for(auto &&it : giftOutfits)
 		out.Write("outfit", it.first->Name(), it.second);
 	if(payment)
 		out.Write("payment", payment);
 	if(fine)
 		out.Write("fine", fine);
-	for(const auto &it : events)
-	{
-		if(it.second.first == it.second.second)
-			out.Write("event", it.first->Name(), it.second.first);
-		else
-			out.Write("event", it.first->Name(), it.second.first, it.second.second);
-	}
-	for(const auto &name : fail)
+	for(auto &&it : events)
+		out.Write("event", it.first->Name(), it.second.first, it.second.second);
+	for(const string &name : fail)
 		out.Write("fail", name);
 
 	conditions.Save(out);

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -161,12 +161,8 @@ void GameAction::LoadAction(const DataNode &child, const string &missionName, bo
 		int count = (child.Size() < 3 ? 1 : static_cast<int>(child.Value(2)));
 		if(count)
 			giftOutfits[GameData::Outfits().Get(child.Token(1))] = count;
-		else if(!conversation)
-		{
-			// "outfit <outfit> 0" means the player must have this outfit.
-			child.PrintTrace("Warning: deprecated use of \"outfit\" with count of 0. Use \"require <outfit>\" instead:");
-			requiredOutfits[GameData::Outfits().Get(child.Token(1))] = 1;
-		}
+		else
+			child.PrintTrace("Skipping invalid outfit quantity:");
 	}
 	else if(key == "payment")
 	{
@@ -283,14 +279,35 @@ string GameAction::ValidateAction() const
 }
 
 
-bool GameAction::IsEmpty() const
+bool GameAction::IsEmpty() const noexcept
 {
 	return empty;
 }
 
 
 
-// Do the actions of the GameAction.
+int64_t GameAction::Payment() const noexcept
+{
+	return payment;
+}
+
+
+
+int64_t GameAction::Fine() const noexcept
+{
+	return fine;
+}
+
+
+
+const map<const Outfit *, int> &GameAction::Outfits() const noexcept
+{
+	return giftOutfits;
+}
+
+
+
+// Perform the specified tasks.
 void GameAction::DoAction(PlayerInfo &player, UI *ui) const
 {
 	if(!logText.empty())

--- a/source/GameAction.h
+++ b/source/GameAction.h
@@ -69,11 +69,6 @@ public:
 	
 	
 private:
-	// Instantiate the data that is specific to a GameAction but not a MissionAction.
-	void InstantiateAction(GameAction &result, std::map<std::string, std::string> &subs, int jumps, int payload) const;
-	
-	
-private:
 	bool isEmpty = true;
 	std::string logText;
 	std::map<std::string, std::map<std::string, std::string>> specialLogText;

--- a/source/GameAction.h
+++ b/source/GameAction.h
@@ -53,7 +53,11 @@ public:
 	std::string ValidateAction() const;
 	
 	// If this action has not been loaded, then it is empty.
-	bool IsEmpty() const;
+	bool IsEmpty() const noexcept;
+	
+	int64_t Payment() const noexcept;
+	int64_t Fine() const noexcept;
+	const std::map<const Outfit *, int> &Outfits() const noexcept;
 	
 	// Perform this action.
 	void DoAction(PlayerInfo &player, UI *ui = nullptr) const;
@@ -63,22 +67,20 @@ public:
 	GameAction Instantiate(std::map<std::string, std::string> &subs, int jumps, int payload) const;
 	
 	
-protected:
+private:
 	// Instantiate the data that is specific to a GameAction but not a MissionAction.
 	void InstantiateAction(GameAction &result, std::map<std::string, std::string> &subs, int jumps, int payload) const;
 	
 	
-protected:
+private:
+	bool empty = true;
 	std::string logText;
 	std::map<std::string, std::map<std::string, std::string>> specialLogText;
 	
 	std::map<const GameEvent *, std::pair<int, int>> events;
 	std::vector<std::pair<const Ship *, std::string>> giftShips;
 	std::map<const Outfit *, int> giftOutfits;
-	// A GameAction contains a map of required outfits, but only a MissionAction
-	// will populate it. This is for the purpose of catching old mission syntax
-	// "outfit <outfit> 0" now being "require <outfit>".
-	std::map<const Outfit *, int> requiredOutfits;
+	
 	int64_t payment = 0;
 	int64_t paymentMultiplier = 0;
 	int64_t fine = 0;
@@ -87,10 +89,6 @@ protected:
 	std::set<std::string> fail;
 	
 	ConditionSet conditions;
-	
-	
-private:
-	bool empty = true;
 };
 
 

--- a/source/GameAction.h
+++ b/source/GameAction.h
@@ -47,7 +47,7 @@ public:
 	
 	void Load(const DataNode &node, const std::string &missionName);
 	// Process a single sibling node.
-	void LoadSingle(const DataNode &child, const std::string &missionName, bool conversation = true);
+	void LoadSingle(const DataNode &child, const std::string &missionName);
 	void Save(DataWriter &out) const;
 	
 	// Determine if this GameAction references content that is not fully defined.

--- a/source/GameAction.h
+++ b/source/GameAction.h
@@ -46,13 +46,14 @@ public:
 	GameAction(const DataNode &node, const std::string &missionName);
 	
 	void Load(const DataNode &node, const std::string &missionName);
-	// Load a single child at a time, used for streamlining MissionAction::Load.
-	void LoadAction(const DataNode &child, const std::string &missionName, bool conversation = true);
-	void SaveAction(DataWriter &out) const;
-	// Determine if this GameAction references content that is not fully defined.
-	std::string ValidateAction() const;
+	// Process a single sibling node.
+	void LoadSingle(const DataNode &child, const std::string &missionName, bool conversation = true);
+	void Save(DataWriter &out) const;
 	
-	// If this action has not been loaded, then it is empty.
+	// Determine if this GameAction references content that is not fully defined.
+	std::string Validate() const;
+	
+	// Whether this action instance contains any tasks to perform.
 	bool IsEmpty() const noexcept;
 	
 	int64_t Payment() const noexcept;
@@ -60,7 +61,7 @@ public:
 	const std::map<const Outfit *, int> &Outfits() const noexcept;
 	
 	// Perform this action.
-	void DoAction(PlayerInfo &player, UI *ui = nullptr) const;
+	void Do(PlayerInfo &player, UI *ui) const;
 	
 	// "Instantiate" this action by filling in the wildcard data for the actual
 	// payment, event delay, etc.
@@ -73,7 +74,7 @@ private:
 	
 	
 private:
-	bool empty = true;
+	bool isEmpty = true;
 	std::string logText;
 	std::map<std::string, std::map<std::string, std::string>> specialLogText;
 	

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -119,7 +119,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 				child.PrintTrace("Unsupported use of \"system\" LocationFilter:");
 		}
 		else
-			action.LoadAction(child, missionName, false);
+			action.LoadSingle(child, missionName, false);
 	}
 }
 
@@ -157,7 +157,7 @@ void MissionAction::Save(DataWriter &out) const
 		for(const auto &it : requiredOutfits)
 			out.Write("require", it.first->Name(), it.second);
 		
-		action.SaveAction(out);
+		action.Save(out);
 	}
 	out.EndChild();
 }
@@ -190,7 +190,7 @@ string MissionAction::Validate() const
 		if(!outfit.first->IsDefined())
 			return "required outfit \"" + outfit.first->Name() + "\"";
 	
-	return action.ValidateAction();
+	return action.Validate();
 }
 
 
@@ -307,7 +307,7 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 	else if(isOffer && ui)
 		player.MissionCallback(Conversation::ACCEPT);
 	
-	action.DoAction(player, ui);
+	action.Do(player, ui);
 }
 
 

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -119,7 +119,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 				child.PrintTrace("Unsupported use of \"system\" LocationFilter:");
 		}
 		else
-			action.LoadSingle(child, missionName, false);
+			action.LoadSingle(child, missionName);
 	}
 }
 

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -105,6 +105,12 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			else
 				child.PrintTrace("Skipping invalid \"require\" amount:");
 		}
+		// The legacy syntax "outfit <outfit> 0" means "the player must have this outfit installed."
+		else if(key == "outfit" && child.Size() >= 3 && child.Token(2) == "0")
+		{
+			child.PrintTrace("Warning: deprecated use of \"outfit\" with count of 0. Use \"require <outfit>\" instead:");
+			requiredOutfits[GameData::Outfits().Get(child.Token(1))] = 1;
+		}
 		else if(key == "system")
 		{
 			if(system.empty() && child.HasChildren())
@@ -113,7 +119,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 				child.PrintTrace("Unsupported use of \"system\" LocationFilter:");
 		}
 		else
-			LoadAction(child, missionName, false);
+			action.LoadAction(child, missionName, false);
 	}
 }
 
@@ -151,7 +157,7 @@ void MissionAction::Save(DataWriter &out) const
 		for(const auto &it : requiredOutfits)
 			out.Write("require", it.first->Name(), it.second);
 		
-		SaveAction(out);
+		action.SaveAction(out);
 	}
 	out.EndChild();
 }
@@ -184,7 +190,7 @@ string MissionAction::Validate() const
 		if(!outfit.first->IsDefined())
 			return "required outfit \"" + outfit.first->Name() + "\"";
 	
-	return ValidateAction();
+	return action.ValidateAction();
 }
 
 
@@ -200,11 +206,11 @@ const string &MissionAction::DialogText() const
 // if it takes away money or outfits that the player does not have.
 bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &boardingShip) const
 {
-	if(player.Accounts().Credits() < -payment)
+	if(player.Accounts().Credits() < -action.Payment())
 		return false;
 	
 	const Ship *flagship = player.Flagship();
-	for(const auto &it : giftOutfits)
+	for(auto &&it : action.Outfits())
 	{
 		// If this outfit is being given, the player doesn't need to have it.
 		if(it.second > 0)
@@ -222,7 +228,7 @@ bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &
 			return false;
 	}
 	
-	for(const auto &it : requiredOutfits)
+	for(auto &&it : requiredOutfits)
 	{
 		int available = 0;
 		// Requiring the player to have 0 of this outfit means all ships and all cargo holds
@@ -301,7 +307,7 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 	else if(isOffer && ui)
 		player.MissionCallback(Conversation::ACCEPT);
 	
-	DoAction(player, ui);
+	action.DoAction(player, ui);
 }
 
 
@@ -319,7 +325,7 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 	
 	string previousPayment = subs["<payment>"];
 	string previousFine = subs["<fine>"];
-	InstantiateAction(result, subs, jumps, payload);
+	result.action = action.Instantiate(subs, jumps, payload);
 	
 	// Create any associated dialog text from phrases, or use the directly specified text.
 	string dialogText = stockDialogPhrase ? stockDialogPhrase->Get()
@@ -335,9 +341,9 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 	
 	// Restore the "<payment>" and "<fine>" values from the "on complete" condition, for
 	// use in other parts of this mission.
-	if(result.payment && trigger != "complete")
+	if(result.action.Payment() && trigger != "complete")
 		subs["<payment>"] = previousPayment;
-	if(result.fine && trigger != "complete")
+	if(result.action.Fine() && trigger != "complete")
 		subs["<fine>"] = previousFine;
 	
 	return result;

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -13,9 +13,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef MISSION_ACTION_H_
 #define MISSION_ACTION_H_
 
-#include "GameAction.h"
-
 #include "Conversation.h"
+#include "GameAction.h"
 #include "LocationFilter.h"
 #include "Phrase.h"
 
@@ -25,6 +24,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 class DataNode;
 class DataWriter;
+class Outfit;
 class PlayerInfo;
 class System;
 class UI;
@@ -32,11 +32,10 @@ class UI;
 
 
 // A MissionAction represents what happens when a Mission reaches a certain
-// milestone. This can include when the Mission is offered, accepted, declined,
-// completed, or failed. A MissionAction can include anything a GameAction can
-// do while also being capable of displaying dialogs or Conversations and requiring
-// that the player have certain outfits for the action to be done.
-class MissionAction : public GameAction {
+// milestone, including offered, accepted, declined, completed, or failed.
+// In addition to performing a GameAction, a MissionAction can gate the task on
+// the ownership of specific outfits and also display dialogs or conversations.
+class MissionAction {
 public:
 	MissionAction() = default;
 	// Construct and Load() at the same time.
@@ -75,6 +74,12 @@ private:
 	
 	const Conversation *stockConversation = nullptr;
 	Conversation conversation;
+	
+	// Outfits that are required to be owned (or not) for this action to be performable.
+	std::map<const Outfit *, int> requiredOutfits;
+	
+	// Tasks this mission action performs, such as modifying accounts, inventory, or conditions.
+	GameAction action;
 };
 
 

--- a/source/StartConditions.cpp
+++ b/source/StartConditions.cpp
@@ -148,9 +148,11 @@ void StartConditions::FinishLoading()
 	for(Ship &ship : ships)
 		ship.FinishLoading(true);
 	
-	if(!GetConversation().IsValidIntro() || !GetConversation().Validate().empty())
+	string reason = GetConversation().Validate();
+	if(!GetConversation().IsValidIntro() || !reason.empty())
 		Files::LogError("Warning: The start scenario \"" + Identifier() + "\" (named \""
-			+ GetDisplayName() + "\") has an invalid starting conversation.");
+			+ GetDisplayName() + "\") has an invalid starting conversation."
+			+ (reason.empty() ? "" : "\n\t" + std::move(reason)));
 }
 
 


### PR DESCRIPTION
## Feature Details
Public inheritance should really only be used when the derived classes are to be used via the base class interface. #5157 added public inheritance (_object A_ IS-A _object B_) between MissionAction and the new "GameAction" class solely for code reuse, when composition (_object A_ HAS-A _object B_) is the preferred approach.

Inheritance also enabled atypical access by other classes (e.g. Mission) to reach inside of MissionAction and consume internals that it has no business knowing about (the full GameAction interface). No code actually did this, but the encapsulation was broken, which made this possible to do more easily.

To additionally distinguish the new capabilities in conversations, the keyword "action" is permitted wherever "apply" was permitted. For legacy support, "apply" is still permitted. It's possible we may want to restrict "apply" nodes to their previous role, rather than allowing them to trigger actions, but the only real reason we might want that is to allow for condition names that would otherwise be treated by the GameAction class as some other directive. However, conditions generally consist of multiple tokens with some mathematical operator, or an extremely reduced keyword set that doesn't have future utility to the GameAction class itself (e.g. `set <single token>`), so the likelihood of a custom condition that overlaps with GameAction keyword syntax is extremely low.

## Testing Done
Game still loads.

## Performance Impact
n/a