### PR TITLE
Manually specify 30-day deadline for cross-wormhole mission

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -1106,7 +1106,7 @@ mission "Hiding in Plain Sight"
 		government "Hai"
 	destination "Vinci"
 	passengers 2
-	deadline
+	deadline 30
 	to offer
 		random < 30
 		has "First Contact: Hai: offered"


### PR DESCRIPTION
**Bugfix:** This PR addresses a problem discussed in #6261

Recently, the Hiding in Plain Sight mission was changed to have a deadline, and meant to have it calculated automatically with the bare "deadline" keyword.  The automatic calculation depends on the DistanceMap::Days() function, which, unfortunately, will return -1 if it fails to find a route, which, per Amazinite's comment in the above PR, will always happen when the route crosses a wormhole, which it does for this mission.  The calculation then happily plugs in the -1 to compute a deadline of -2 days in the future (i.e. 2 days in the past), which is absurd.

## Fix Details
Manually set a deadline of 30 days for the Hiding in Plain Sight mission.  This doesn't protect against further accidents with the bare "deadline" keyword; I'll file an issue for that shortly.

## Testing Done
Take the save file mentioned below.  Launch, take the one jump to Wah Oh (this part might be unnecessary), and repeatedly land and hit the bar ("Spaceport" button) until you get offered the Hiding in Plain Sight mission, accept it, and look at the deadline date on the mission (or alternately look at the text on the second screen of the offering, where it says "There's a massive convention on [planet] on [date]").  Before the fix, that date will be 2 days in the past.  After the fix, the date will be 30 days in the future.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 3cfedcd99151d0ac80efa73cc701ddf970c86a28, and will not occur when using this branch's build.

[Miles Edgeworth copy previous.txt](https://github.com/endless-sky/endless-sky/files/7275239/Miles.Edgeworth.copy.previous.txt)

