### PR TITLE
bugfix: Fix segfault on empty ship-list in ShipInfoPanels.

### DIFF
--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -111,6 +111,8 @@ void ShipInfoPanel::Draw()
 	
 	// Draw all the different information sections.
 	ClearZones();
+	if(shipIt == player.Ships().end())
+		return;
 	Rectangle cargoBounds = infoPanelUi->GetBox("cargo");
 	DrawShipStats(infoPanelUi->GetBox("stats"));
 	DrawOutfits(infoPanelUi->GetBox("outfits"), cargoBounds);
@@ -758,12 +760,21 @@ void ShipInfoPanel::Disown()
 	if(shipIt == player.Ships().end() || shipIt->get() == player.Flagship())
 		return;
 	
-	// Because you can never disown your flagship, the player's ship list will
-	// never become empty as a result of disowning a ship.
 	const Ship *ship = shipIt->get();
+	// We can remove the very first ship in the list, if the flagship is later
+	// in the list or if the player only owns ships that cannot be flagships (due
+	// to such ships being somewhere else or due to the ships not having crew).
+	// Removing the very first ship will cause the iterator to become invalid,
+	// so then we need to reset it. This is especially true if the player only
+	// has one ship which cannot be a flagship and then disowns that ship.
+	bool invalidatedIterator = false;
 	if(shipIt != player.Ships().begin())
 		--shipIt;
+	else
+		invalidatedIterator = true;
 	
 	player.DisownShip(ship);
+	if(invalidatedIterator)
+		shipIt=player.Ships().begin();
 	UpdateInfo();
 }


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue with ShipInfoPanels causing segfaults on an empty ships-list

## Fix Details
The original code in ShipInfoPanels assumed that the ships-list always contains at least 1 ship; the flagship. But it is possible for a player to only own ships that are not suitable as flagship, for example because of all ships being on another planet than the player. Disowning ships through the ShipInfoPanel caused the game to crash in such cases.

This PR updates the code to be able to deal with invalidated iterators and/or with empty lists.

## Testing Done
I manually tested this with two situations:
- The player owns a drone that have no crew (and thus cannot be a flagship).
- The player only owns ships in another system (and thus cannot be a flagship).

## Save File
I plan to create one or two automated tests using the integration-test-framework to show this issue, but didn't get to that yet.