### PR TITLE
Sort files and directories alphabetically.

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -27,6 +27,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <dirent.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
@@ -262,6 +263,8 @@ vector<string> Files::List(string directory)
 	
 	closedir(dir);
 #endif
+
+	sort(list.begin(), list.end());
 	return list;
 }
 
@@ -321,6 +324,8 @@ vector<string> Files::ListDirectories(string directory)
 	
 	closedir(dir);
 #endif
+
+	sort(list.begin(), list.end());
 	return list;
 }
 
@@ -330,6 +335,7 @@ vector<string> Files::RecursiveList(const string &directory)
 {
 	vector<string> list;
 	RecursiveList(directory, &list);
+	sort(list.begin(), list.end());
 	return list;
 }
 


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #6224.

## Feature Details
This PR sorts files and directories by name when loading. This means that for example files inside plugins are now guaranteed to be loaded in order. Currently, the order is unspecified but on Windows it is in 99% of cases alphabetically.

I have encountered several plugins that make use of this order to separate definitions of systems (and more) and this works on Windows. But on Linux for example (not sure about macOS), the order is not by name which results in those plugins breaking. I think it makes sense to sort the files so that file load order is the same no matter what system you're one, especially if Windows basically guarantees alphabetical order.

## Testing Done

Loaded a plugin that makes use of this separation of a definition and confirmed that no errors are generated. On master there are errors.

## Performance Impact
Negligible.
