### PR TITLE
test: Test-Framework: Fix saving test-subroutine and add test for saving

### DIFF
--- a/data/tests/tests_common.txt
+++ b/data/tests/tests_common.txt
@@ -162,9 +162,7 @@ test "Load First Savegame"
 
 
 test "Save To Default Snapshot"
-	# Broken status due to this bug (the loading happens very fast after saving during automated testing):
-	# https://github.com/endless-sky/endless-sky/issues/4810
-	status broken
+	status active
 	description "Helper function to save the game to the first snapshot. Typically used directly after opening the menu."
 	sequence
 		# Open the menu.
@@ -182,8 +180,10 @@ test "Save To Default Snapshot"
 		input
 			key "enter"
 		# Exit the menu that we are in (and return to the game)
-		input b
-		input e
+		input
+			key b
+		input
+			key e
 
 
 test "Depart"

--- a/data/tests/tests_save_load.txt
+++ b/data/tests/tests_save_load.txt
@@ -33,3 +33,70 @@ test "Loading and Reloading"
 			year == 3013
 			month == 11
 			day == 17
+
+
+test "Loading and Saving"
+	status active
+	description "Test saving of snapshots and re-loading of saved snapshots."
+	sequence
+		# Create/inject the savegame and load it.
+		inject "Three Earthly Barges"
+		call "Load First Savegame"
+		call "Depart"
+		assert
+			year == 3013
+			month == 11
+			day == 17
+		# Set desired travel plan. Travel is in 2 parts, since we should not set
+		# an Earth destination when in the same system as Earth.
+		navigate
+			travel "Alpha Centauri"
+		input
+			command jump
+		watchdog 12000
+		label notAlpha1
+		branch notAlpha1
+			not "flagship system: Alpha Centauri"
+		navigate
+			travel "Sol"
+			"travel destination" Earth
+		watchdog 12000
+		label notReturned1
+		branch notReturned1
+			not "flagship planet: Earth"
+		apply
+			"test: day" = day
+		assert
+			year == 3013
+			month == 11
+			day == 19
+		call "Open Menu"
+		call "Save To Default Snapshot"
+		call "Depart"
+		assert
+			year == 3013
+			month == 11
+			day == 20
+		# Set desired travel plan.
+		navigate
+			travel "Alpha Centauri"
+			travel "Sol"
+			travel "Alpha Centauri"
+		input
+			command jump
+		# Wait loop while jumping to Alpha Centuari (with a timeout for if this jump fails).
+		watchdog 12000
+		label notAlpha2
+		branch notAlpha2
+			not "flagship system: Alpha Centauri"
+		assert
+			year == 3013
+			month == 11
+			day == 21
+		call "Open Menu"
+		call "Load First Savegame"
+		call "Depart"
+		assert
+			year == 3013
+			month == 11
+			day == 20


### PR DESCRIPTION
**Feature:** This PR implements part of the feature detailed and discussed in issue #4308

## Feature Details
This PR fixes the Save-subroutine in the test-framework and adds a test that includes saving.

## UI Screenshots
N/A

## Testing Done
The newly added test is automatically executed in CI.

## Performance Impact
N/A