### PR TITLE
Allow WeightedLists to be erased from

### DIFF
--- a/source/WeightedList.h
+++ b/source/WeightedList.h
@@ -19,11 +19,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <stdexcept>
 #include <vector>
 
-template <class Type>
-using iterator = typename std::vector<Type>::iterator;
-template <class Type>
-using const_iterator = typename std::vector<Type>::const_iterator;
-
 
 
 // Template representing a list of objects of a given type where each item in the
@@ -34,13 +29,16 @@ using const_iterator = typename std::vector<Type>::const_iterator;
 template <class Type>
 class WeightedList {
 public:
+	using iterator = typename std::vector<Type>::iterator;
+	using const_iterator = typename std::vector<Type>::const_iterator;
+	
 	const Type &Get() const;
 	std::size_t TotalWeight() const { return total; }
 	
-	iterator<Type> begin() noexcept { return choices.begin(); }
-	const_iterator<Type> begin() const noexcept { return choices.begin(); }
-	iterator<Type> end() noexcept { return choices.end(); }
-	const_iterator<Type> end() const noexcept { return choices.end(); }
+	iterator begin() noexcept { return choices.begin(); }
+	const_iterator begin() const noexcept { return choices.begin(); }
+	iterator end() noexcept { return choices.end(); }
+	const_iterator end() const noexcept { return choices.end(); }
 	
 	void clear() noexcept { choices.clear(); total = 0; }
 	std::size_t size() const noexcept { return choices.size(); }
@@ -51,8 +49,8 @@ public:
 	template <class ...Args>
 	Type &emplace_back(Args&&... args);
 	
-	iterator<Type> eraseAt(iterator<Type> position) noexcept;
-	iterator<Type> erase(iterator<Type> first, iterator<Type> last) noexcept;
+	iterator eraseAt(iterator position) noexcept;
+	iterator erase(iterator first, iterator last) noexcept;
 	
 	
 private:
@@ -96,7 +94,7 @@ Type &WeightedList<Type>::emplace_back(Args&&... args)
 
 
 template <class Type>
-iterator<Type> WeightedList<Type>::eraseAt(iterator<Type> position) noexcept
+typename std::vector<Type>::iterator WeightedList<Type>::eraseAt(typename std::vector<Type>::iterator position) noexcept
 {
 	total -= position->Weight();
 	return choices.erase(position);
@@ -105,7 +103,7 @@ iterator<Type> WeightedList<Type>::eraseAt(iterator<Type> position) noexcept
 
 
 template <class Type>
-iterator<Type> WeightedList<Type>::erase(iterator<Type> first, iterator<Type> last) noexcept
+typename std::vector<Type>::iterator WeightedList<Type>::erase(typename std::vector<Type>::iterator first, typename std::vector<Type>::iterator last) noexcept
 {
 	for(auto it = first; it != last; ++it)
 		total -= it->Weight();

--- a/tests/src/test_weightedList.cpp
+++ b/tests/src/test_weightedList.cpp
@@ -87,6 +87,7 @@ SCENARIO( "Test basic WeightedSet functionality." , "[WeightedList]" ) {
 						CHECK( list.TotalWeight() == 3 );
 					}
 					THEN( "An iterator pointing to the next object in the list is returned." ) {
+						REQUIRE( it != list.end() );
 						CHECK( it->value == 2 );
 						CHECK( it->Weight() == 3 );
 					}
@@ -115,6 +116,7 @@ SCENARIO( "Test basic WeightedSet functionality." , "[WeightedList]" ) {
 						CHECK( list.TotalWeight() == 8 );
 					}
 					THEN( "An iterator pointing to the next object in the list is returned." ) {
+						REQUIRE( it != list.end() );
 						CHECK( it->value == 4 );
 						CHECK( it->Weight() == 5 );
 					}


### PR DESCRIPTION
**Feature:**

## Feature Details
Pulled from #4704. Adds `erase` functions to the WeightedList that allow erasing of a single position or a range of positions when given iterators to the position or range. Functionally similar to the erase functions from a vector, except WeightedList erase functions also update the list's weight according to the weight of the elements removed.

Pulling this out into a separate PR since I need it for other features I'm working on and don't want them to be held up by #4704. This change is independent from other changes from that PR.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
I've created test cases for the new WeightedList behavior.

## Performance Impact
N/A
