### PR TITLE
Add boolean label/tip for atrocities

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -826,3 +826,9 @@ tip "no bays?"
 
 tip "insufficient energy to fire?"
 	`This ship has insufficient energy storage to fire an installed weapon.`
+
+
+
+# Boolean attributes:
+tip "This outfit is considered an atrocity."
+	`Governments that scan for illegal goods will attack you upon discovering this item in your posession in space, or arrest you if found when landed.`

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -143,7 +143,8 @@ namespace {
 		{"unplunderable", "This outfit cannot be plundered."},
 		{"installable", "This is not an installable item."},
 		{"hyperdrive", "Allows you to make hyperjumps."},
-		{"jump drive", "Lets you jump to any nearby system."}
+		{"jump drive", "Lets you jump to any nearby system."},
+		{"atrocity", "This outfit is considered an atrocity."}
 	};
 }
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4471575/139474075-dbc43da1-8fb4-40fb-b6c3-33c630c8f05a.png)

Since the `atrocity` attribute is a boolean attribute, there is no reason to surface that an outfit has "1 atrocity" to the player. This PR adds the atrocity attribute to the likes of `unplunderable` or `installable`, adding a tag after the main description, saying "This outfit is considered an atrocity." Additionally, a tooltip is provided, explaining more in detail how it will cause you to be attacked in space if scanned, or cause a game over on land.