### PR TITLE
Revert old bunk adjustments on Rainmaker/Sparrow

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2678,8 +2678,8 @@ ship "Rainmaker"
 		"cost" 1580000
 		"shields" 3500
 		"hull" 1200
-		"required crew" 7
-		"bunks" 14
+		"required crew" 3
+		"bunks" 7
 		"mass" 180
 		"drag" 3.8
 		"heat dissipation" .6
@@ -3020,7 +3020,7 @@ ship "Sparrow"
 		"shields" 1200
 		"hull" 300
 		"required crew" 1
-		"bunks" 2
+		"bunks" 3
 		"mass" 50
 		"drag" .9
 		"heat dissipation" .8


### PR DESCRIPTION
Gefüllte is currently redesigning the Navy Rainmaker's model, and one issue that's come up is creating a mass that could possibly fit the 7 required crew and 14 bunks in a such a small sprite. Looking at when those numbers were set, it seems like MZ went through in commit 408c7a8, and mostly increased required crew/bunks across the board. Most were sensible, but the Rainmaker had its crew more than doubled, and bunks more than _tripled._ That is an extremely excessive increase for a mostly autonomous missile boat, and with approval from Warlord Mike, this PR seeks to (mostly) revert it back to what it was, leaving in a few extra bunks.

Additionally, one of the few bunk reductions in that commit was the Sparrow. It changed the bunk quantity from 3 to 2, which massively changes the feasibility of capturing ships with The Starting Combat Ship. A 2v1 boarding fight, even with weapons, is a very tough prospect, while a 3v1 fight becomes much more feasible. This PR brings the bunk count back up to that range.