### PR TITLE
Ships with fuel generation recharge on uninhabited planets.

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2725,10 +2725,7 @@ void Ship::Recharge(bool atSpaceport)
 		return;
 	
 	if(atSpaceport)
-	{
 		crew = min<int>(max(crew, RequiredCrew()), attributes.Get("bunks"));
-		fuel = attributes.Get("fuel capacity");
-	}
 	pilotError = 0;
 	pilotOkay = 0;
 	
@@ -2738,6 +2735,8 @@ void Ship::Recharge(bool atSpaceport)
 		hull = attributes.Get("hull");
 	if(atSpaceport || attributes.Get("energy generation"))
 		energy = attributes.Get("energy capacity");
+	if(atSpaceport || attributes.Get("fuel generation"))
+		fuel = attributes.Get("fuel capacity");
 	
 	heat = IdleHeat();
 	ionization = 0.;


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue mentioned on the Discord by @1010todd.

## Fix Details

Ships with the attribute `"fuel generation"` now correctly recharge their fuel completely if they land on an uninhabited planet. This isn't currently the case.

## Testing Done

A ship with `"fuel generation"` correctly recharges its fuel on an uninhabited planet.