### PR TITLE
Make Destination Replacements referring to the Heliarch rings Consistent.

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -164,7 +164,7 @@ event "lost in coalition"
 
 mission "Coalition: Lost: Marker"
 	name "Foreign Aid"
-	description "The Heliarchs have noticed that you've lost your jump drive, being now stranded in Coalition space, and have offered to help. Head to <destination> to speak with them."
+	description "The Heliarchs have noticed that you've lost your jump drive, being now stranded in Coalition space, and have offered to help. Head to the <destination> to speak with them."
 	landing
 	source
 		near "Ekuarik" 1 100
@@ -176,7 +176,7 @@ mission "Coalition: Lost: Marker"
 			`You're approached by a Heliarch delegation shortly after you leave your ship.`
 			`	"Cautiously observed during the past few weeks, scans of your ship have been, Captain <last>," the Saryd begins.`
 			`	"Unlike previous scans, a jump drive in your ship, our scanners found not," the Kimek continues.`
-			`	"Though appreciate the work you here perform, we do, for you to be cut-off from the galaxy, we wish not," the Arach says. "Discussed much, our consuls have, and to help you, they decided. To <destination> you must go, there discussed, the terms will be."`
+			`	"Though appreciate the work you here perform, we do, for you to be cut-off from the galaxy, we wish not," the Arach says. "Discussed much, our consuls have, and to help you, they decided. To the <destination> you must go, there discussed, the terms will be."`
 			choice
 				`	"By that you mean you'll get me another jump drive? That's pretty generous of you."`
 				`	"What? I lost my jump drive? You've gotta be kidding!"`
@@ -186,7 +186,7 @@ mission "Coalition: Lost: Marker"
 			label unaware
 			`	"A good thing that a watchful eye we keep, if noticed you had not," the Kimek says. "But even still, more careful with your outfits you should be."`
 			label end
-			`	You thank them for bringing you this information, and go back to your ship to prepare a route to <destination>.`
+			`	You thank them for bringing you this information, and go back to your ship to prepare a route to the <destination>.`
 				accept
 	to complete
 		never
@@ -195,7 +195,7 @@ mission "Coalition: Lost: Marker"
 
 mission "Coalition: Lost: Offer"
 	name "Jump Drive Loan"
-	description "The Heliarchs have provided you a jump drive to leave Coalition space. Bring another jump drive to <destination> by <date>, to replace the one you borrowed, or they will be extremely angered by you breaking their trust."
+	description "The Heliarchs have provided you a jump drive to leave Coalition space. Bring another jump drive to the <destination> by <date>, to replace the one you borrowed, or they will be extremely angered by you breaking their trust."
 	deadline 333
 	landing
 	source "Ring of Wisdom"
@@ -503,7 +503,7 @@ mission "Coalition Yottrite 8"
 
 mission "Coalition Yottrite 9"
 	name "Yottrite Presentation"
-	description "Transport Lugglop and his team, alongside <cargo>, to <destination>, where they will share with the Coalition's scientific community their findings on Yottrite."
+	description "Transport Lugglop and his team, alongside <cargo>, to the <destination>, where they will share with the Coalition's scientific community their findings on Yottrite."
 	passengers 6
 	cargo "yottrite presentation materials" 6.14
 	blocked "You need <capacity> in order to take on the next mission. Return here when you have the required space free."
@@ -513,7 +513,7 @@ mission "Coalition Yottrite 9"
 	destination "Ring of Wisdom"
 	on offer
 		conversation
-			`You meet Lugglop in the spaceport and follow him to meet with Nasilor, Alituri, and Pichiie, who are overseeing some workers place a few sealed metal crates inside a container and the yottrite sample you just brought here into another. They detail how they have prepared all the material they needed and now just need a transport to <destination>.`
+			`You meet Lugglop in the spaceport and follow him to meet with Nasilor, Alituri, and Pichiie, who are overseeing some workers place a few sealed metal crates inside a container and the yottrite sample you just brought here into another. They detail how they have prepared all the material they needed and now just need a transport to the <destination>.`
 			`	"If with us, you come, Captain, perhaps a better detailed description of the systems where the yottrite was found, you could provide," Nasilor says.`
 			`	"<payment>, I would pay you," Lugglop says.`
 			choice
@@ -713,7 +713,7 @@ mission "Kimek Student 3"
 
 mission "Kimek Student 4"
 	name "Transport Chikee"
-	description "Chikee, the young Kimek whom you've transported many times, has finally become a candidate for elevation to the rank of Heliarch. Bring him to <destination> by <date>."
+	description "Chikee, the young Kimek whom you've transported many times, has finally become a candidate for elevation to the rank of Heliarch. Bring him to the <destination> by <date>."
 	deadline
 	landing
 	passengers 1
@@ -727,7 +727,7 @@ mission "Kimek Student 4"
 		conversation
 			`You're contacted by Chikee when you land.`
 			`	"Captain <last>! Good news and another job for you, I have," he says, asking that you meet him in the spaceport.`
-			`	You head there, and he's already with his bags, prepared to board your ship. "Helped me a lot, House Idriss has. An audience with the Heliarch, on <destination> I have!"`
+			`	You head there, and he's already with his bags, prepared to board your ship. "Helped me a lot, House Idriss has. An audience with the Heliarch, on the <destination> I have!"`
 			`	He tells you that he needs to be there by <date>, and wastes no time as he heads into your ship.`
 				accept
 	on visit


### PR DESCRIPTION
-----------------------
## Fix Details
warp-core pointed out in 6324 I wasn't adding a "the" before using the <destination> replacement when the destination was a Heliarch ring. Turns out I never noticed that "the" in the First Contact missions/the jobs, so all my missions that have the rings as destinations have the issue.

This just adds the "the"s where they were missing. Let me know if I missed any.