### PR TITLE
Correctly detect atrocities in a cargo hold when scanning.

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -565,6 +565,8 @@ int CargoHold::IllegalCargoFine() const
 	for(const auto &it : outfits)
 	{
 		int fine = it.first->Get("illegal");
+		if(it.first->Get("atrocity") > 0.)
+			return -1;
 		if(fine < 0)
 			return fine;
 		totalFine = max(totalFine, fine / 2);


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6313

## Fix Details

`CargoHold::IllegalCagoFine` is responsible for calculating the fine for any illegal outfits inside a cargo hold. It only looked for  the `"illegal"` attribute on outfits. This PR makes it check for `"atrocity"` too.

## Testing Done

Tested this PR with the plugin from the issue. Landing on the high security planet correctly issues a death sentence with an atrocity inside the cargo hold. On master it doesn't.

## Save File

See the linked issue.