### PR TITLE
fix(content): Reorder Remnant: Deep Surveillance conditions to see last branch

### DIFF
--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -1183,11 +1183,11 @@ mission "Remnant: Deep Surveillance"
 			branch unknown
 				has "deep: did not reveal remnant"
 			
-			branch technology
-				has "Deep: Remnant: Engines: done"
-			
 			branch surveillance
 				has "Deep: Remnant Surveillance: done"
+			
+			branch technology
+				has "Deep: Remnant: Engines: done"
 			
 			choice
 				`	"They know where the Remnant are in the Ember Waste."`


### PR DESCRIPTION
For the main dialog options when accepting Remnant: Deep Surveillance, the order of conditions checks if you've not revealed the Remnant at all, if you've given over technology, or if you've planted the cubes on their worlds, in that order. However, since planting the cubes implies you've given over technology, it will branch before getting there. This PR reverses the order of the technology and surveillance branches, ensuring a player will properly see it.

Big thanks to Kroniicoptor on the discord for digging into playing these missions!