### PR TITLE
fix(mechanics) : bank : spaces interpreted the same way comas were, and added a test

### DIFF
--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -187,6 +187,7 @@ string Format::Decimal(double value, int places)
 
 // Convert a string into a number. As with the output of Number(), the
 // string can have suffixes like "M", "B", etc.
+// It can also contain spaces or "," as separators like 1,000 or 1 000.
 double Format::Parse(const string &str)
 {
 	double place = 1.;
@@ -201,7 +202,7 @@ double Format::Parse(const string &str)
 	{
 		if(*it == '.')
 			place = .1;
-		else if(*it == ',') {}
+		else if(*it == ',' || *it == ' ') {}
 		else if(*it < '0' || *it > '9')
 			break;
 		else

--- a/tests/src/text/test_format.cpp
+++ b/tests/src/text/test_format.cpp
@@ -94,6 +94,12 @@ SCENARIO("A player-entered quantity can be parsed to a number", "[Format][Parse]
 			CHECK( Format::Parse("1,234K") == Approx(1234000.) );
 		}
 	}
+
+	GIVEN( "The string 1 523 004" ) {
+		THEN( "parses to 1523004" ) {
+			CHECK( Format::Parse("1 523 004") == Approx(1523004.) );
+		}
+	}
 }
 
 TEST_CASE( "Format::Capitalize", "[Format][Capitalize]") {


### PR DESCRIPTION
-----------------------
**Bugfix:** This PR addresses issue #6213 

## Fix Details
Treated space the same way as a comma

## Testing Done
Tried to take "1 000" money, which worked, same for 1,000

## Save File
Literally any save file works, just try to access the bank
