### PR TITLE
Highlight conversation choice when hovering with the mouse.

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -182,10 +182,15 @@ void ConversationPanel::Draw()
 		
 			Point center = point + it.Center();
 			Point size(WIDTH, it.Height());
+
+			auto zone = Rectangle::FromCorner(point, size);
+			// If the mouse is hovering over this choice then we need to highlight it.
+			if(zone.Contains(hoverPoint))
+				choice = index;
 		
 			if(index == choice)
 				FillShader::Fill(center + Point(-5, 0), size + Point(30, 0), selectionColor);
-			AddZone(Rectangle::FromCorner(point, size), [this, index](){ this->ClickChoice(index); });
+			AddZone(zone, [this, index](){ this->ClickChoice(index); });
 			++index;
 		
 			font.Draw(label, point + Point(-15, 0), dim);
@@ -297,6 +302,15 @@ bool ConversationPanel::Drag(double dx, double dy)
 bool ConversationPanel::Scroll(double dx, double dy)
 {
 	return Drag(0., dy * Preferences::ScrollSpeed());
+}
+
+
+
+// Handle selecting choices by hovering with the mouse.
+bool ConversationPanel::Hover(int x, int y)
+{
+	hoverPoint = Point(x, y);
+	return true;
 }
 
 

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -185,7 +185,7 @@ void ConversationPanel::Draw()
 
 			auto zone = Rectangle::FromCorner(point, size);
 			// If the mouse is hovering over this choice then we need to highlight it.
-			if(zone.Contains(hoverPoint))
+			if(isHovering && zone.Contains(hoverPoint))
 				choice = index;
 		
 			if(index == choice)
@@ -199,6 +199,9 @@ void ConversationPanel::Draw()
 	}
 	// Store the total height of the text.
 	maxScroll = min(0., Screen::Top() - (point.Y() - scroll) + font.Height() + 15.);
+
+	// Reset the hover flag. If the mouse is still moving than the flag will be set in the next frame.
+	isHovering = false;
 }
 
 
@@ -310,6 +313,7 @@ bool ConversationPanel::Scroll(double dx, double dy)
 bool ConversationPanel::Hover(int x, int y)
 {
 	hoverPoint = Point(x, y);
+	isHovering = true;
 	return true;
 }
 

--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -131,6 +131,8 @@ private:
 	// have boarded).
 	std::shared_ptr<Ship> ship;
 
+	// Whether the mouse moved in the current frame.
+	bool isHovering = false;
 	Point hoverPoint;
 };
 

--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -53,6 +53,7 @@ protected:
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Scroll(double dx, double dy) override;
+	virtual bool Hover(int x, int y) override;
 	
 	
 private:
@@ -129,6 +130,8 @@ private:
 	// acts upon (e.g. the ship failing a "flight check", or the NPC you
 	// have boarded).
 	std::shared_ptr<Ship> ship;
+
+	Point hoverPoint;
 };
 
 


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed nowhere I think. 

## Feature Details

If you use the mouse to select a choice in a conversation, then it can be confusing since the choice is not highlighted. This PR highlights the choice when hovering with the mouse, as seen in the gif below:

![conversation choice](https://user-images.githubusercontent.com/85879619/141966459-229df5d2-b4cb-4c66-b8af-4edc7f0b0810.gif)


## Testing Done

Tested this with a test mission as seen in the gif.

## Performance Impact

Negligible.
