### PR TITLE
Add the ability for governments to be provoked when starting a scan.

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -134,6 +134,8 @@ void Government::Load(const DataNode &node)
 			language = child.Token(1);
 		else if(child.Token(0) == "raid" && child.Size() >= 2)
 			raidFleet = GameData::Fleets().Get(child.Token(1));
+		else if(child.Token(0) == "hostile when scanned")
+			hostileWhenScanned = true;
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
@@ -387,4 +389,11 @@ double Government::CrewAttack() const
 double Government::CrewDefense() const
 {
 	return crewDefense;
+}
+
+
+
+bool Government::IsHostileWhenScanned() const
+{
+	return hostileWhenScanned;
 }

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -134,8 +134,8 @@ void Government::Load(const DataNode &node)
 			language = child.Token(1);
 		else if(child.Token(0) == "raid" && child.Size() >= 2)
 			raidFleet = GameData::Fleets().Get(child.Token(1));
-		else if(child.Token(0) == "hostile when scanned")
-			hostileWhenScanned = true;
+		else if(child.Token(0) == "provoked on scan")
+			provokedOnScan = true;
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
@@ -393,7 +393,7 @@ double Government::CrewDefense() const
 
 
 
-bool Government::IsHostileWhenScanned() const
+bool Government::IsProvokedOnScan() const
 {
-	return hostileWhenScanned;
+	return provokedOnScan;
 }

--- a/source/Government.h
+++ b/source/Government.h
@@ -115,6 +115,8 @@ public:
 	// Get the government's crew attack/defense values
 	double CrewAttack() const;
 	double CrewDefense() const;
+
+	bool IsHostileWhenScanned() const;
 	
 	
 private:
@@ -139,6 +141,7 @@ private:
 	const Fleet *raidFleet = nullptr;
 	double crewAttack = 1.;
 	double crewDefense = 2.;
+	bool hostileWhenScanned = false;
 };
 
 

--- a/source/Government.h
+++ b/source/Government.h
@@ -116,7 +116,7 @@ public:
 	double CrewAttack() const;
 	double CrewDefense() const;
 
-	bool IsHostileWhenScanned() const;
+	bool IsProvokedOnScan() const;
 	
 	
 private:
@@ -141,7 +141,7 @@ private:
 	const Fleet *raidFleet = nullptr;
 	double crewAttack = 1.;
 	double crewDefense = 2.;
-	bool hostileWhenScanned = false;
+	bool provokedOnScan = false;
 };
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2394,7 +2394,7 @@ int Ship::Scan()
 					+ Name() + "\" completed its scan of your outfits.", Messages::Importance::High);
 	}
 
-	// Some governments are provoked when scanned.
+	// Some governments are provoked when a scan is started on one of their ships.
 	const Government *gov = target->GetGovernment();
 	if(gov && gov->IsHostileWhenScanned() && !gov->IsEnemy(government)
 			&& (target->Shields() < .9 || target->Hull() < .9 || !target->GetPersonality().IsForbearing())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2393,6 +2393,14 @@ int Ship::Scan()
 			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
 					+ Name() + "\" completed its scan of your outfits.", Messages::Importance::High);
 	}
+
+	// Some governments are provoked when scanned.
+	if(auto gov = target->GetGovernment())
+		if(gov->IsHostileWhenScanned()
+				&& !gov->IsEnemy(government)
+				&& (target->Shields() < .9 || target->Hull() < .9 || !target->GetPersonality().IsForbearing())
+				&& !target->GetPersonality().IsPacifist())
+			result |= ShipEvent::PROVOKE;
 	
 	return result;
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2396,7 +2396,7 @@ int Ship::Scan()
 
 	// Some governments are provoked when a scan is started on one of their ships.
 	const Government *gov = target->GetGovernment();
-	if(gov && gov->IsHostileWhenScanned() && !gov->IsEnemy(government)
+	if(gov && gov->IsProvokedOnScan() && !gov->IsEnemy(government)
 			&& (target->Shields() < .9 || target->Hull() < .9 || !target->GetPersonality().IsForbearing())
 			&& !target->GetPersonality().IsPacifist())
 		result |= ShipEvent::PROVOKE;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2395,12 +2395,11 @@ int Ship::Scan()
 	}
 
 	// Some governments are provoked when scanned.
-	if(auto gov = target->GetGovernment())
-		if(gov->IsHostileWhenScanned()
-				&& !gov->IsEnemy(government)
-				&& (target->Shields() < .9 || target->Hull() < .9 || !target->GetPersonality().IsForbearing())
-				&& !target->GetPersonality().IsPacifist())
-			result |= ShipEvent::PROVOKE;
+	const Government *gov = target->GetGovernment();
+	if(gov && gov->IsHostileWhenScanned() && !gov->IsEnemy(government)
+			&& (target->Shields() < .9 || target->Hull() < .9 || !target->GetPersonality().IsForbearing())
+			&& !target->GetPersonality().IsPacifist())
+		result |= ShipEvent::PROVOKE;
 	
 	return result;
 }

--- a/source/ShipEvent.h
+++ b/source/ShipEvent.h
@@ -43,6 +43,7 @@ public:
 		// of that ship's government; this will result in temporary animosities
 		// between the two governments. If a ship is "forbearing," it can only
 		// be "provoked" if its shields are below 90%.
+		// Some governments are provoked by starting a scan.
 		PROVOKE = (1 << 3),
 		// This ship disabled the given ship. This will have a permanent effect
 		// on your reputation with the given government. This event is generated


### PR DESCRIPTION
## Feature Details

This is a continuation of #6351, which added the ability to specify a rep loss when a government is completely scanned.

This PR adds the ability for governments to be provoked by starting a scan, just like you provoke a friendly government by attacking them. The attribute name isn't great, so feel free to suggest another one.

Just like attacking a gov, whether the government becomes hostiles depends on the personality of the scanned ship (`pacifist` and `forbearing` are the only relevant ones).

## Usage Examples

```
government Remnant
    "hostile when scanned"
```
## Testing Done

Added the attribute to a government and verified that starting a scan provokes them. No effect on governments without this attribute.

## Performance Impact
Negligible.
