### PR TITLE
Content: Making the Remnant Secretive (aka scan-hostile)

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -495,7 +495,6 @@ government "Remnant"
 		"Indigenous Lifeform" 0.05
 		"Korath" -.05
 		"Alpha" -.05
-		"Remnant (scannable)" 1
 	"penalty for"
 		assist -0.25
 		disable 1
@@ -507,7 +506,7 @@ government "Remnant"
 	"friendly hail" "remnant uncontacted"
 	"hostile hail" "remnant uncontacted hostile"
 
-government "Remnant (scannable)"
+government "Remnant (research)"
 	"display name" "Remnant"
 	swizzle 0
 	color .89 .38 .62
@@ -522,7 +521,6 @@ government "Remnant (scannable)"
 		"Remnant" 1
 	"penalty for"
 		assist -0.25
-		disable 1
 		board 1
 		capture 10
 		destroy 10

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -501,7 +501,7 @@ government "Remnant"
 		board 1
 		capture 10
 		destroy 10
-		scan 1
+		scan 0.1
 	"provoked on scan"
 	"friendly hail" "remnant uncontacted"
 	"hostile hail" "remnant uncontacted hostile"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -522,6 +522,7 @@ government "Remnant (Research)"
 		"Remnant" 1
 	"penalty for"
 		assist -0.25
+		disable 1
 		board 1
 		capture 10
 		destroy 10

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -506,7 +506,7 @@ government "Remnant"
 	"friendly hail" "remnant uncontacted"
 	"hostile hail" "remnant uncontacted hostile"
 
-government "Remnant (research)"
+government "Remnant (Research)"
 	"display name" "Remnant"
 	swizzle 0
 	color .89 .38 .62

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -495,6 +495,7 @@ government "Remnant"
 		"Indigenous Lifeform" 0.05
 		"Korath" -.05
 		"Alpha" -.05
+		"Remnant (Research)" 1
 	"penalty for"
 		assist -0.25
 		disable 1

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -495,8 +495,35 @@ government "Remnant"
 		"Indigenous Lifeform" 0.05
 		"Korath" -.05
 		"Alpha" -.05
+		"Remnant (scannable)" 1
 	"penalty for"
 		assist -0.25
+		disable 1
+		board 1
+		capture 10
+		destroy 10
+		scan 1
+	"provoked on scan"
+	"friendly hail" "remnant uncontacted"
+	"hostile hail" "remnant uncontacted hostile"
+
+government "Remnant (scannable)"
+	"display name" "Remnant"
+	swizzle 0
+	color .89 .38 .62
+	"crew defense" 2.2
+	
+	"player reputation" 1
+	"bribe" 0
+	"attitude toward"
+		"Indigenous Lifeform" 0.05
+		"Korath" -.05
+		"Alpha" -.05
+		"Remnant" 1
+	"penalty for"
+		assist -0.25
+		disable 1
+		board 1
 		capture 10
 		destroy 10
 	"friendly hail" "remnant uncontacted"

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3378,7 +3378,7 @@ mission "Remnant: Keystone Research 5"
 			`	"Oh, yes. It is actually quite common among the Remnant. I am not a particularly good pilot, but it is considered an important skill that is taught to almost everyone as a part of a general education. It is especially worthwhile for those of us who work directly with starships on a daily basis and may be called upon to move or fly one at a moment's notice." His gestures suggest both pride and humility as he talks about his piloting skills. "Anyway, let's go!"`
 				accept
 	npc "scan outfits" "save"
-		government "Remnant (scannable)"
+		government "Remnant (research)"
 		personality coward disables plunders staying surveillance target mining
 		system "Peragenor"
 		ship "Starling (Keystone)" "Winds of Light"
@@ -3398,7 +3398,7 @@ mission "Remnant: Keystone Research 6"
 	waypoint "Peragenor"
 	source "Viminal"
 	npc "scan outfits" "save"
-		government "Remnant (scannable)"
+		government "Remnant (research)"
 		personality coward disables plunders staying surveillance target mining
 		system "Peragenor"
 		ship "Starling" "Winds of Light"

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3378,7 +3378,7 @@ mission "Remnant: Keystone Research 5"
 			`	"Oh, yes. It is actually quite common among the Remnant. I am not a particularly good pilot, but it is considered an important skill that is taught to almost everyone as a part of a general education. It is especially worthwhile for those of us who work directly with starships on a daily basis and may be called upon to move or fly one at a moment's notice." His gestures suggest both pride and humility as he talks about his piloting skills. "Anyway, let's go!"`
 				accept
 	npc "scan outfits" "save"
-		government "Remnant"
+		government "Remnant (scannable)"
 		personality coward disables plunders staying surveillance target mining
 		system "Peragenor"
 		ship "Starling (Keystone)" "Winds of Light"
@@ -3398,7 +3398,7 @@ mission "Remnant: Keystone Research 6"
 	waypoint "Peragenor"
 	source "Viminal"
 	npc "scan outfits" "save"
-		government "Remnant"
+		government "Remnant (scannable)"
 		personality coward disables plunders staying surveillance target mining
 		system "Peragenor"
 		ship "Starling" "Winds of Light"

--- a/data/remnant/remnant missions.txt
+++ b/data/remnant/remnant missions.txt
@@ -3378,7 +3378,7 @@ mission "Remnant: Keystone Research 5"
 			`	"Oh, yes. It is actually quite common among the Remnant. I am not a particularly good pilot, but it is considered an important skill that is taught to almost everyone as a part of a general education. It is especially worthwhile for those of us who work directly with starships on a daily basis and may be called upon to move or fly one at a moment's notice." His gestures suggest both pride and humility as he talks about his piloting skills. "Anyway, let's go!"`
 				accept
 	npc "scan outfits" "save"
-		government "Remnant (research)"
+		government "Remnant (Research)"
 		personality coward disables plunders staying surveillance target mining
 		system "Peragenor"
 		ship "Starling (Keystone)" "Winds of Light"
@@ -3398,7 +3398,7 @@ mission "Remnant: Keystone Research 6"
 	waypoint "Peragenor"
 	source "Viminal"
 	npc "scan outfits" "save"
-		government "Remnant (research)"
+		government "Remnant (Research)"
 		personality coward disables plunders staying surveillance target mining
 		system "Peragenor"
 		ship "Starling" "Winds of Light"

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -1118,6 +1118,7 @@ ship "Tern"
 		"shields" 500
 		"hull" 2500
 		"automaton" 1
+		"crew equivalent" 1
 		"cargo space" 5
 		"mass" 32
 		"drag" 1.0


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This makes the Remnant hostile to being scanned (they get provoked, and player will take a rep hit for scanning them), as well as bumping up the penalty for disable and boarding them slightly (from the default 0.5 and 0.3 to 1); and creates a separate government that *can* be scanned for times when a research subject is needed.

Also modifies Keystone Research 5 & 6 to make use of this scannable government.

The scannable government is `"Remnant (research)"`

edit. 
 -The reputation hit for scanning has now been dropped from 1 to 0.1.
 -Also added `"crew equivalent" 1` to the Tern so that the Remnant value their loss appropriately.

## PR Checklist
 - ~~[X] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
 - ~~[X] I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}~~
 - ~~[X] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~
