### PR TITLE
Add spellchecking CI with codespell.

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -1,0 +1,19 @@
+		"Woh"
+		"mor"
+		"Grey"
+		"Mitre"
+		"Alph"
+		"Gord"
+		"gard"
+		"Diamond Grey"
+		"Grey Wolf"
+				`	"The Grey Goose."`
+			`	He stops and frowns. "Look at me, rambling like an ol' man. Ser, Captain, I'd like to pay you <payment> to take me home, to <destination>."`
+			`	He smiles sadly. "Skaldgar always had a nose for good folks. Anyways, he told me he had a nephew named Helm who worked at the Norn spaceport. Find 'im and he can get'cha and this stone where it needs to go." The young man than looks you in the eye and gives a slow respectful nod, "For Ol' Skaldgar, may he be findin' ore in hel."`
+			`	Cygnet strokes his mustache. "Tod Copper. Tod Copper. Tell you what, that name doesn' ring a bell. Heck, I don' even keep track of names 'less I get someone impor'ant. If ya lookin' for someone in particular to buy, can I get a description?"`
+					goto shotdown
+			label shotdown
+		"ser"
+		"cach"
+		"oder"
+		" Grat"

--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -40,3 +40,6 @@ integration_tests:
  - 'tests/test_parse.*'
  - 'tests/run_tests*'
  - 'data/tests/**'
+
+codespell:
+ - .codespell.exclude

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ on:
     - keys.txt
     - SConstruct
     - .winmake
+    - .codespell.exclude
   pull_request:
     # Run for any push to any pull request, if it modifies source code or game text.
     types: [opened, synchronize]
@@ -44,6 +45,7 @@ on:
     - keys.txt
     - SConstruct
     - .winmake
+    - .codespell.exclude
 
 
 jobs:
@@ -58,6 +60,7 @@ jobs:
       linux: ${{ steps.filter.outputs.linux }}
       unit_tests: ${{ steps.filter.outputs.unit_tests }}
       integration_tests: ${{ steps.filter.outputs.integration_tests }}
+      codespell: ${{ steps.filter.outputs.codespell }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -501,3 +504,17 @@ jobs:
       # In a perfect world we would run a debug build, but since this will run on PRs, we can limit our search of "what caused the bug" to only the code
       # added by that PR, which means debugging symbols aren't as necessary. (We can ignore the still-reachable cin, cout, cerr inherited file descriptors.)
       run: valgrind --tool=memcheck --leak-check=full --track-origins=yes --track-fds=yes --error-exitcode=1 ./endless-sky -p
+
+
+
+  test_ubuntu-spellcheck:
+    needs: [changed]
+    if: ${{ needs.changed.outputs.data == 'true' || needs.changed.outputs.codespell == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: codespell-project/actions-codespell@master
+      with:
+        builtin: clear,en-GB_to_en-US
+        path: data/
+        exclude_file: .codespell.exclude


### PR DESCRIPTION
## Feature Details

This PR adds a CI run that runs [codespell](https://github.com/codespell-project/codespell) when the `data/` folder was changed to find any typos. In contrast to traditional spellchecking tools that check if a word doesn't exist, codespell checks for misspellings. For example, `thiss` won't get flagged as a typo because the misspelling `thiss` doesn't exist in its database. As such some typos will get missed. But it also means we don't have to a huge list of false positive to filter.

Exclude files are always a bit dumb, but they're necessary. In this case, the whole line with the false positive needs to be copy+pasted into the exclude file. The alternative to this would be to mark the misspelling as not a typo, but then it might be an actual typo somewhere else that wouldn't get detected.

Since the lines to exclude need to match exactly this does mean that any changes to the line need to also update the exclude file. Currently that's 3 lines of long dialog. Not that big of a deal IMO.

## UI Screenshots

When this is merged a typo will get annotated (like a review comment). It looks like this (from a demo):

![spellcheck-demo](https://user-images.githubusercontent.com/85879619/143688340-240ad497-c8cf-4378-9291-9f64525bd42a.png)

## Testing Done

Tested this PR on my fork.