### PR TITLE
Update MissionPanel.cpp

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -805,6 +805,7 @@ void MissionPanel::MakeSpaceAndAccept()
 		player.AdjustBasis(it.first, -basis);
 		player.Cargo().Remove(it.first, toSell);
 		player.Accounts().AddCredits(toSell * price);
+		cargoToSell -= toSell;
 	}
 	
 	player.UpdateCargoCapacities();


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6377

## Fix Details
Sell only the required cargo to accept the mission (instead of trying to sell the same required amount from each and all commodities).
The added line was most likely foreseen and forgotten in the algorithm: the "if(cargoToSell <= 0) break;" at line 798 was useless (til now).

## Testing Done
1. Buy at least 2 types of commodities (e.g. 20 food, 20 clothing, 20 metal)
2. "Buy all" whatever, to fill cargo ("free: 0" in hold)
3. Accept a cargo mission (e.g. delivering 15 tons of...)

without fix => You have sold 15 tons of food AND 15 tons of clothing AND 15 tons of metal (and have more than 0 tons free in hold, e.g. 30 tons free)

with the fix => You have sold only 15 tons of anything, you now have 0 tons free in hold.

Other test cases:
- cargo hold not full (e.g. "free: 5" in hold, but delivery of 15 tons) => sold required - free (e.g. only 10 tons), you now have 0 tons free in hold.
- cargo hold "negative" (cargo full, then spaceport mission makes it negative) => sold required - "negative free" (e.g. 23 tons vs. 15), you now have 0 tons free in hold.


Note: I had a few github docs readings, and hopefully this may be the proper way to do a PR (or not...).
Not sure if the "Linked issues" should have been set. I understand it might be intentionally not-linked.