### PR TITLE
Improve the --weapons table output

### DIFF
--- a/source/GameData.h
+++ b/source/GameData.h
@@ -164,7 +164,10 @@ private:
 	
 	static void PrintShipTable();
 	static void PrintTestsTable();
-	static void PrintWeaponTable();
+	static void PrintGunTable();
+    static void PrintTurretTable();
+    static void PrintSecondaryWeaponTable();
+    static void PrintAntiMissileTable();
 };
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -363,7 +363,10 @@ void PrintHelp()
 	cerr << "    -h, --help: print this help message." << endl;
 	cerr << "    -v, --version: print version information." << endl;
 	cerr << "    -s, --ships: print table of ship statistics, then exit." << endl;
-	cerr << "    -w, --weapons: print table of weapon statistics, then exit." << endl;
+    cerr << "    -g, --guns: print table of gun statistics, then exit." << endl;
+    cerr << "    -tu, --turrets: print table of turret statistics, then exit." << endl;
+    cerr << "    -se, --secondary-weapons: print table of secondary weapon statistics, then exit." << endl;
+    cerr << "    -a, --anti-missile: print table of anti-missile statistics, then exit." << endl;
 	cerr << "    -t, --talk: read and display a conversation from STDIN." << endl;
 	cerr << "    -r, --resources <path>: load resources from given directory." << endl;
 	cerr << "    -c, --config <path>: save user's files to given directory." << endl;


### PR DESCRIPTION
This PR improves the info given when printing weapons tables by adding stats for the special damage types.
It also expands --weapons into --guns, --turrets, --secondary-weapons, and --anti-missile
I updated PrintHelp to reflect these changes.

## Testing Done
I ran each option and verified they were not already used.

## Performance Impact
N/A
