### PR TITLE
Fix questionable grammar in Wayfarer description

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -30082,7 +30082,7 @@ planet Wayfarer
 	attributes factory south
 	landscape land/nasa1
 	description `Wayfarer was initially settled by a team of scientists and diplomats seeking to build a relationship with the Quarg worlds to the galactic southeast of here. Partly through the aid of the Quarg and partly through a desire to emulate them, it has grown into a very technologically advanced world.`
-	description `	Tarazed corporation, a maker of alien-inspired ships and outfits, is one of the largest industries on Wayfarer, and they draw raw materials from throughout this region of space.`
+	description `	The Tarazed Corporation, a maker of alien-inspired ships and outfits, is one of the largest industries on Wayfarer, and they draw raw materials from throughout this region of space.`
 	spaceport `The spaceport is clearly the artifact of an architect who was as familiar with alien architecture as with human. Instead of square angles it has many curved walls and domes. The landing pads jut out from the building at various heights. Some of the landing pads are designed with docking tubes specifically for Quarg visitors, and the ceilings are unusually high to accommodate the Quarg, several of whom are walking around and mingling with the humans here.`
 	shipyard "Basic Ships"
 	shipyard "Tarazed Basics"


### PR DESCRIPTION
TLDR: Wayfarer description grammar is questionable.

`Tarazed corporation` should be `The Tarazed Corporation` instead.