### PR TITLE
Show additional dialogue between accepting mission and closing conversation (FW Katya)

### DIFF
--- a/data/human/free worlds intro.txt
+++ b/data/human/free worlds intro.txt
@@ -1215,9 +1215,12 @@ mission "FW Katya 7B"
 			`	Eyes says, "Mining world. Dusty atmosphere. Frequent meteorite impacts. You could set off a nuke on the far side of that world and the miners would probably sleep right through it."`
 			choice
 				`	"Okay, I'll take you to this one last world, and then we're done."`
-					accept
+					goto thanks
 				`	"Sorry, 'one more world' is what you said two planets ago. I'm done with this."`
 					decline
+			label thanks
+			`	"I promise it will be the last one," says Katya.`
+				accept
 	on visit
 		dialog `You land on <planet>, but you realize that Katya and Mr. Eyes are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 

--- a/data/human/free worlds intro.txt
+++ b/data/human/free worlds intro.txt
@@ -1168,9 +1168,12 @@ mission "FW Katya 7"
 			`	Katya says, "So then we wondered, what sort of world would you go to if you wanted rumblings in the ocean to go unnoticed? Either an unpopulated one, or one with lots of meteorite activity. And that leads us to... Deep." She points out the system on your map. "Mild tidal surges on almost a weekly basis, due to impacts from all the asteroids in system. Perfect place to hide an undersea explosion."`
 			choice
 				`	"Sounds like a good possibility. Let's give it a try!"`
-					accept
+					goto thanks
 				`	"Sorry, I've got some other missions I need to run instead of continuing this wild goose chase."`
 					decline
+			label thanks
+			`	"I appreciate your help, Captain <last>," says Katya.`
+				accept			
 	on visit
 		dialog `You land on <planet>, but you realize that Katya and Mr. Eyes are on one of your escorts that hasn't entered the system yet. Better depart and wait for it to arrive.`
 


### PR DESCRIPTION
## Summary

When accept is a child of one of the choices in a conversation, it feels awkward to read because after clicking the choice, no new text appears and the player has to click [done].

By adding dialogue that appears after the choice, the player sees new content between having to click the choice and click [done].

This is what the game looks like without the change. The last line was a choice, so the player has already read that text.

![image](https://user-images.githubusercontent.com/95149990/145608937-3759484f-d664-46d6-adb9-a49a3778b59b.png)


## PR Checklist
 - [x] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified