### PR TITLE
Fix Adaptive VSync detection.

### DIFF
--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		B5DDA6942001B7F600DBA76A /* News.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5DDA6922001B7F600DBA76A /* News.cpp */; };
 		C4264774A89C0001B6FFC60E /* Hazard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C49D4EA08DF168A83B1C7B07 /* Hazard.cpp */; };
 		C7354A3E9C53D6C5E3CC352F /* TestData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02D34A71AE3BC4C93FC6865B /* TestData.cpp */; };
+		CE3F49A88B6DCBE09A711110 /* opengl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3754152958FBC924E9F76A9 /* opengl.cpp */; };
 		DF8D57E11FC25842001525DA /* Dictionary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57DF1FC25842001525DA /* Dictionary.cpp */; };
 		DF8D57E51FC25889001525DA /* Visual.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57E21FC25889001525DA /* Visual.cpp */; };
 		DFAAE2A61FD4A25C0072C0A8 /* BatchDrawList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAAE2A21FD4A25C0072C0A8 /* BatchDrawList.cpp */; };
@@ -238,6 +239,7 @@
 		A00D4207B8915B5E7E9B4619 /* RandomEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RandomEvent.h; path = source/RandomEvent.h; sourceTree = "<group>"; };
 		A2A948EE929342C8F84C65D1 /* TestContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestContext.h; path = source/TestContext.h; sourceTree = "<group>"; };
 		A3134EC4B1CCA5546A10C3EF /* TestContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestContext.cpp; path = source/TestContext.cpp; sourceTree = "<group>"; };
+		A3754152958FBC924E9F76A9 /* opengl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = opengl.cpp; path = source/opengl.cpp; sourceTree = "<group>"; };
 		A90633FD1EE602FD000DA6C0 /* LogbookPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LogbookPanel.cpp; path = source/LogbookPanel.cpp; sourceTree = "<group>"; };
 		A90633FE1EE602FD000DA6C0 /* LogbookPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LogbookPanel.h; path = source/LogbookPanel.h; sourceTree = "<group>"; };
 		A90C15D71D5BD55700708F3A /* Minable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Minable.cpp; path = source/Minable.cpp; sourceTree = "<group>"; };
@@ -320,7 +322,6 @@
 		A96863171AE6FD0B004FE1FE /* GameData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameData.h; path = source/GameData.h; sourceTree = "<group>"; };
 		A96863181AE6FD0B004FE1FE /* GameEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameEvent.cpp; path = source/GameEvent.cpp; sourceTree = "<group>"; };
 		A96863191AE6FD0B004FE1FE /* GameEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameEvent.h; path = source/GameEvent.h; sourceTree = "<group>"; };
-		A968631A1AE6FD0B004FE1FE /* gl_header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gl_header.h; path = source/gl_header.h; sourceTree = "<group>"; };
 		A968631B1AE6FD0B004FE1FE /* Government.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Government.cpp; path = source/Government.cpp; sourceTree = "<group>"; };
 		A968631C1AE6FD0B004FE1FE /* Government.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Government.h; path = source/Government.h; sourceTree = "<group>"; };
 		A968631D1AE6FD0B004FE1FE /* HailPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HailPanel.cpp; path = source/HailPanel.cpp; sourceTree = "<group>"; };
@@ -502,6 +503,7 @@
 		DFAAE2A51FD4A25C0072C0A8 /* BatchShader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BatchShader.h; path = source/BatchShader.h; sourceTree = "<group>"; };
 		DFAAE2A81FD4A27B0072C0A8 /* ImageSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ImageSet.cpp; path = source/ImageSet.cpp; sourceTree = "<group>"; };
 		DFAAE2A91FD4A27B0072C0A8 /* ImageSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ImageSet.h; path = source/ImageSet.h; sourceTree = "<group>"; };
+		EB634E95A88454ADDB8644B1 /* opengl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = opengl.h; path = source/opengl.h; sourceTree = "<group>"; };
 		F434470BA8F3DE8B46D475C5 /* StartConditionsPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StartConditionsPanel.h; path = source/StartConditionsPanel.h; sourceTree = "<group>"; };
 		F8C14CFB89472482F77C051D /* Weather.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Weather.h; path = source/Weather.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -619,7 +621,6 @@
 				A96863191AE6FD0B004FE1FE /* GameEvent.h */,
 				B55C239B2303CE8A005C1A14 /* GameWindow.cpp */,
 				B55C239C2303CE8A005C1A14 /* GameWindow.h */,
-				A968631A1AE6FD0B004FE1FE /* gl_header.h */,
 				A968631B1AE6FD0B004FE1FE /* Government.cpp */,
 				A968631C1AE6FD0B004FE1FE /* Government.h */,
 				A968631D1AE6FD0B004FE1FE /* HailPanel.cpp */,
@@ -814,6 +815,8 @@
 				A3134EC4B1CCA5546A10C3EF /* TestContext.cpp */,
 				6A4E42FEB3B265A91D5BD2FC /* TextReplacements.cpp */,
 				86D9414E818561143BD298BC /* TextReplacements.h */,
+				A3754152958FBC924E9F76A9 /* opengl.cpp */,
+				EB634E95A88454ADDB8644B1 /* opengl.h */,
 			);
 			name = source;
 			sourceTree = "<group>";
@@ -1163,6 +1166,7 @@
 				87D6407E8B579EB502BFBCE5 /* GameAction.cpp in Sources */,
 				ED5E4F2ABA89E9DE00603E69 /* TestContext.cpp in Sources */,
 				F78A44BAA8252F6D53B24B69 /* TextReplacements.cpp in Sources */,
+				CE3F49A88B6DCBE09A711110 /* opengl.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -326,8 +326,8 @@
 		<Unit filename="source/Weather.cpp" />
 		<Unit filename="source/Weather.h" />
 		<Unit filename="source/WeightedList.h" />
-		<Unit filename="source/opengl.h" />
 		<Unit filename="source/opengl.cpp" />
+		<Unit filename="source/opengl.h" />
 		<Unit filename="source/pi.h" />
 		<Unit filename="source/shift.h" />
 		<Unit filename="source/text/DisplayText.cpp" />

--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -326,7 +326,8 @@
 		<Unit filename="source/Weather.cpp" />
 		<Unit filename="source/Weather.h" />
 		<Unit filename="source/WeightedList.h" />
-		<Unit filename="source/gl_header.h" />
+		<Unit filename="source/opengl.h" />
+		<Unit filename="source/opengl.cpp" />
 		<Unit filename="source/pi.h" />
 		<Unit filename="source/shift.h" />
 		<Unit filename="source/text/DisplayText.cpp" />

--- a/source/FogShader.cpp
+++ b/source/FogShader.cpp
@@ -19,7 +19,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Shader.h"
 #include "System.h"
 
-#include "gl_header.h"
+#include "opengl.h"
 
 #include <algorithm>
 #include <cmath>

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -16,7 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "ImageBuffer.h"
 #include "Screen.h"
 
-#include "gl_header.h"
+#include "opengl.h"
 #include <SDL2/SDL.h>
 
 #include <cstring>
@@ -208,7 +208,7 @@ bool GameWindow::Init()
 	
 	// Check for support of various graphical features.
 	hasSwizzle = HasOpenGLExtension("_texture_swizzle");
-	supportsAdaptiveVSync = HasOpenGLExtension("_swap_control_tear");
+	supportsAdaptiveVSync = OpenGL::HasAdaptiveVSyncSupport();
 	
 	// Enable the user's preferred VSync state, otherwise update to an available
 	// value (e.g. if an external program is forcing a particular VSync state).

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -46,23 +46,6 @@ namespace {
 		
 		return false;
 	}
-	
-	bool HasOpenGLExtension(const char *name) {
-#ifndef __APPLE__
-		auto extensions = reinterpret_cast<const char *>(glGetString(GL_EXTENSIONS));
-		return strstr(extensions, name);
-#else
-		bool value = false;
-		GLint extensionCount = 0;
-		glGetIntegerv(GL_NUM_EXTENSIONS, &extensionCount);
-		for(GLint i = 0; i < extensionCount && !value; ++i)
-		{
-			auto extension = reinterpret_cast<const char *>(glGetStringi(GL_EXTENSIONS, i));
-			value = (extension && strstr(extension, name));
-		}
-		return value;
-#endif
-	}
 }
 
 
@@ -207,7 +190,7 @@ bool GameWindow::Init()
 	glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 	
 	// Check for support of various graphical features.
-	hasSwizzle = HasOpenGLExtension("_texture_swizzle");
+	hasSwizzle = OpenGL::HasSwizzleSupport();
 	supportsAdaptiveVSync = OpenGL::HasAdaptiveVSyncSupport();
 	
 	// Enable the user's preferred VSync state, otherwise update to an available

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -38,7 +38,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "text/truncate.hpp"
 #include "UI.h"
 
-#include "gl_header.h"
+#include "opengl.h"
 
 #include <algorithm>
 #include <stdexcept>

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -40,7 +40,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "System.h"
 #include "UI.h"
 
-#include "gl_header.h"
+#include "opengl.h"
 
 #include <cmath>
 #include <sstream>

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -46,7 +46,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Trade.h"
 #include "UI.h"
 
-#include "gl_header.h"
+#include "opengl.h"
 
 #include <algorithm>
 #include <cctype>

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -37,7 +37,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "System.h"
 #include "UI.h"
 
-#include "gl_header.h"
+#include "opengl.h"
 
 #include <algorithm>
 #include <stdexcept>

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -34,7 +34,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "UI.h"
 #include "text/WrappedText.h"
 
-#include "gl_header.h"
+#include "opengl.h"
 #include <SDL2/SDL.h>
 
 #include <algorithm>

--- a/source/Shader.h
+++ b/source/Shader.h
@@ -13,7 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef SHADER_H_
 #define SHADER_H_
 
-#include "gl_header.h"
+#include "opengl.h"
 
 
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -37,7 +37,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "UI.h"
 #include "text/WrappedText.h"
 
-#include "gl_header.h"
+#include "opengl.h"
 #include <SDL2/SDL.h>
 
 #include <algorithm>

--- a/source/Sprite.cpp
+++ b/source/Sprite.cpp
@@ -16,7 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Preferences.h"
 #include "Screen.h"
 
-#include "gl_header.h"
+#include "opengl.h"
 #include <SDL2/SDL.h>
 
 #include <algorithm>

--- a/source/StarField.h
+++ b/source/StarField.h
@@ -15,7 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Shader.h"
 
-#include "gl_header.h"
+#include "opengl.h"
 
 #include <vector>
 

--- a/source/opengl.cpp
+++ b/source/opengl.cpp
@@ -12,7 +12,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "opengl.h"
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(ES_GLES)
 #ifdef _WIN32
 #include <GL/wglew.h>
 #else
@@ -24,8 +24,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 bool OpenGL::HasAdaptiveVSyncSupport()
 {
-#ifdef __APPLE__
-	// macOS doesn't support Adaptive VSync for OpenGL.
+#if defined(__APPLE__) || defined(ES_GLES)
+	// macOS and OpenGL ES don't support Adaptive VSync for OpenGL.
 	return false;
 #elif defined(_WIN32)
 	return wglewIsSupported("WGL_EXT_swap_control_tear");

--- a/source/opengl.cpp
+++ b/source/opengl.cpp
@@ -45,9 +45,11 @@ namespace {
 
 bool OpenGL::HasAdaptiveVSyncSupport()
 {
-#if defined(__APPLE__) || defined(ES_GLES)
-	// macOS and OpenGL ES don't support Adaptive VSync for OpenGL.
+#ifdef __APPLE__
+	// macOS doesn't support Adaptive VSync for OpenGL.
 	return false;
+#elif defined(ES_GLES)
+	return HasOpenGLExtension("_swap_control_tear");
 #elif defined(_WIN32)
 	return WGL_EXT_swap_control_tear || HasOpenGLExtension("_swap_control_tear");
 #else

--- a/source/opengl.cpp
+++ b/source/opengl.cpp
@@ -12,10 +12,12 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "opengl.h"
 
+#ifndef __APPLE__
 #ifdef _WIN32
 #include <GL/wglew.h>
 #else
 #include <GL/glxew.h>
+#endif
 #endif
 
 

--- a/source/opengl.cpp
+++ b/source/opengl.cpp
@@ -1,0 +1,33 @@
+/* opengl.cpp
+Copyright (c) 2014 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "opengl.h"
+
+#ifdef _WIN32
+#include <GL/wglew.h>
+#else
+#include <GL/glxew.h>
+#endif
+
+
+
+bool OpenGL::HasAdaptiveVSyncSupport()
+{
+#ifdef __APPLE__
+	// macOS doesn't support Adaptive VSync for OpenGL.
+	return false;
+#elif defined(_WIN32)
+	return wglewIsSupported("WGL_EXT_swap_control_tear");
+#else
+	return glxewIsSupported("GLX_EXT_swap_control_tear");
+#endif
+}

--- a/source/opengl.h
+++ b/source/opengl.h
@@ -10,8 +10,8 @@ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 */
 
-#ifndef OPENGL_
-#define OPENGL_
+#ifndef ES_OPENGL_H_
+#define ES_OPENGL_H_
 
 // Include whichever header is used for OpenGL on this operating system.
 #ifdef __APPLE__

--- a/source/opengl.h
+++ b/source/opengl.h
@@ -29,6 +29,7 @@ class OpenGL
 {
 public:
 	static bool HasAdaptiveVSyncSupport();
+	static bool HasSwizzleSupport();
 };
 
 #endif

--- a/source/opengl.h
+++ b/source/opengl.h
@@ -1,4 +1,4 @@
-/* gl_header.h
+/* opengl.h
 Copyright (c) 2014 by Michael Zahniser
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
@@ -9,6 +9,9 @@ Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 */
+
+#ifndef OPENGL_
+#define OPENGL_
 
 // Include whichever header is used for OpenGL on this operating system.
 #ifdef __APPLE__
@@ -21,3 +24,11 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #endif
 #endif
 
+// A helper class for various OpenGL platform specific calls.
+class OpenGL
+{
+public:
+	static bool HasAdaptiveVSyncSupport();
+};
+
+#endif

--- a/source/text/Font.h
+++ b/source/text/Font.h
@@ -15,7 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "../Shader.h"
 
-#include "../gl_header.h"
+#include "../opengl.h"
 
 #include <string>
 


### PR DESCRIPTION
## Fix Details

The Adaptive VSync detection implemented in #5000 is partially incorrect. Adaptive vsync is a platform specific extension and as such it doesn't appear in the list of OpenGL extensions in some drivers on Windows and not at all on Linux. SDL doesn't have a platform agnostic function unfortunately, so we need to call the platform specific functions manually.

I'm not quite sure whether OpenGL ES supports GLX and WGL. I can't seem to find anything except vague mentions in comments on the internet. I just left the existing logic (checking the standard extensions) for now.

## Testing Done

I'm on Linux X11 with the official Nvidia drivers on a GTX 1650M:

- Without this PR: I can switch between vsync off and on in the settings.
- With this PR: I can switch between vsync off, on and adaptive in the settings.

I can't test this on Windows right now, but it should work.