### PR TITLE
Ignore Eclipse IDE folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ plugins/
 # IDEs (no support implied)
 .vscode
 .vs
+.metadata
 *.psess
 *.vsp
 *.vspx


### PR DESCRIPTION
This just adds another folder to the `.gitignore`, ignoring `.metadata`, which is used by the Eclipse C/C++ IDE.