### PR TITLE
Allow ship variants to specify additional licenses.

### DIFF
--- a/source/ItemInfoDisplay.cpp
+++ b/source/ItemInfoDisplay.cpp
@@ -129,7 +129,7 @@ void ItemInfoDisplay::ClearHover()
 
 
 
-void ItemInfoDisplay::UpdateDescription(const string &text, const vector<string> &licenses, bool isShip)
+void ItemInfoDisplay::UpdateDescription(const string &text, const set<string> &licenses, bool isShip)
 {
 	if(licenses.empty())
 		description.Wrap(text);
@@ -137,22 +137,22 @@ void ItemInfoDisplay::UpdateDescription(const string &text, const vector<string>
 	{
 		static const string NOUN[2] = {"outfit", "ship"};
 		string fullText = text + "\tTo purchase this " + NOUN[isShip] + " you must have ";
-		for(unsigned i = 0; i < licenses.size(); ++i)
+		for(auto it = licenses.begin(); it != licenses.end(); ++it)
 		{
 			bool isVoweled = false;
 			for(const char &c : "aeiou")
-				if(*licenses[i].begin() == c || *licenses[i].begin() == toupper(c))
+				if(it->front() == c || it->front() == toupper(c))
 					isVoweled = true;
-			if(i)
+			if(it != licenses.begin())
 			{
 				if(licenses.size() > 2)
 					fullText += ", ";
 				else
 					fullText += " ";
+				if(next(it) == licenses.end())
+					fullText += "and ";
 			}
-			if(i && i == licenses.size() - 1)
-				fullText += "and ";
-			fullText += (isVoweled ? "an " : "a ") + licenses[i] + " License";
+			fullText += (isVoweled ? "an " : "a ") + *it + " License";
 		}
 		fullText += ".\n";
 		description.Wrap(fullText);

--- a/source/ItemInfoDisplay.h
+++ b/source/ItemInfoDisplay.h
@@ -16,6 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Point.h"
 #include "text/WrappedText.h"
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -49,7 +50,7 @@ public:
 	
 	
 protected:
-	void UpdateDescription(const std::string &text, const std::vector<std::string> &licenses, bool isShip);
+	void UpdateDescription(const std::string &text, const std::set<std::string> &licenses, bool isShip);
 	Point Draw(Point point, const std::vector<std::string> &labels, const std::vector<std::string> &values) const;
 	void CheckHover(const Table &table, const std::string &label) const;
 	

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -181,20 +181,12 @@ void Outfit::Load(const DataNode &node)
 			mass = child.Value(1);
 		else if(child.Token(0) == "licenses" && (child.HasChildren() || child.Size() >= 2))
 		{
-			auto isNewLicense = [](const vector<string> &c, const string &val) noexcept -> bool {
-				return find(c.begin(), c.end(), val) == c.end();
-			};
 			// Add any new licenses that were specified "inline".
 			if(child.Size() >= 2)
-			{
-				for(auto it = ++begin(child.Tokens()); it != end(child.Tokens()); ++it)
-					if(isNewLicense(licenses, *it))
-						licenses.push_back(*it);
-			}
+				licenses.insert(child.Tokens().begin() + 1, child.Tokens().end());
 			// Add any new licenses that were specified as an indented list.
 			for(const DataNode &grand : child)
-				if(isNewLicense(licenses, grand.Token(0)))
-					licenses.push_back(grand.Token(0));
+				licenses.insert(grand.Token(0));
 		}
 		else if(child.Token(0) == "jump range" && child.Size() >= 2)
 		{
@@ -291,7 +283,7 @@ const string &Outfit::Description() const
 
 
 // Get the licenses needed to purchase this outfit.
-const vector<string> &Outfit::Licenses() const
+const set<string> &Outfit::Licenses() const
 {
 	return licenses;
 }
@@ -363,6 +355,7 @@ void Outfit::Add(const Outfit &other, int count)
 {
 	cost += other.cost * count;
 	mass += other.mass * count;
+	licenses.insert(other.licenses.begin(), other.licenses.end());
 	for(const auto &at : other.attributes)
 	{
 		attributes[at.first] += at.second * count;

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Dictionary.h"
 
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -55,7 +56,7 @@ public:
 	int64_t Cost() const;
 	double Mass() const;
 	// Get the licenses needed to buy or operate this ship.
-	const std::vector<std::string> &Licenses() const;
+	const std::set<std::string> &Licenses() const;
 	// Get the image to display in the outfitter when buying this item.
 	const Sprite *Thumbnail() const;
 	
@@ -105,7 +106,7 @@ private:
 	int64_t cost = 0;
 	double mass = 0.;
 	// Licenses needed to purchase this item.
-	std::vector<std::string> licenses;
+	std::set<std::string> licenses;
 	
 	Dictionary attributes;
 	


### PR DESCRIPTION
## Fix Details

If a variant uses `add attributes` to add a license to the variant then this has no effect. This PR fixes this issue.

Additionally, there is no reason why `licenses` was a vector if every license is unique so I took the initiative to make it a set instead.

## Testing Done

```
ship "Shield Beetle" "Shield Beetle (Unfettered)"
    add attributes
        licenses
            "Unfettered Militia"
```

Adding this variant to a shipyard correctly show the license requirement with this PR and doesn't on master.