### PR TITLE
Make coward and appeasing trigger earlier

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -644,11 +644,13 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 		if(healthRemaining < RETREAT_HEALTH + .1)
 		{
 			// Cowards abandon their fleets.
-			if(parent && personality.IsCoward())
+			if(personality.IsCoward())
 			{
-				parent.reset();
-				it->SetParent(parent);
-				it->SetTargetShip(nullptr);
+				if(parent) {
+					parent.reset();
+					it->SetParent(parent);
+				}
+				it->SetTargetShip(parent);
 			}
 			// Appeasing ships jettison cargo to distract their pursuers.
 			if(personality.IsAppeasing() && it->Cargo().Used())

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1245,8 +1245,8 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	// Player ships never stop targeting hostiles, while hostile mission NPCs will
 	// do so only if they are allowed to leave.
 	if(!isYours && target && target->GetGovernment()->IsEnemy(gov) && !isDisabled
-			&& (person.IsFleeing() || (ship.Health() < RETREAT_HEALTH && !person.IsHeroic()
-				&& !person.IsStaying() && !parentIsEnemy)))
+			&& (person.IsFleeing() || (ship.Health() < (RETREAT_HEALTH + .25 * person.IsCoward()) 
+			&& !person.IsHeroic() && !person.IsStaying() && !parentIsEnemy)))
 	{
 		// Make sure the ship has somewhere to flee to.
 		const System *system = ship.GetSystem();

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -648,6 +648,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 			{
 				parent.reset();
 				it->SetParent(parent);
+				it->SetTargetShip(nullptr);
 			}
 			// Appeasing ships jettison cargo to distract their pursuers.
 			if(personality.IsAppeasing() && it->Cargo().Used())

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -641,16 +641,13 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 		}
 		
 		// Special actions when a ship is heavily damaged:
-		if(healthRemaining < RETREAT_HEALTH + .1)
+		if(healthRemaining < RETREAT_HEALTH + .25)
 		{
 			// Cowards abandon their fleets.
-			if(personality.IsCoward())
+			if(parent && personality.IsCoward())
 			{
-				if(parent) {
-					parent.reset();
-					it->SetParent(parent);
-				}
-				it->SetTargetShip(parent);
+				parent.reset();
+				it->SetParent(parent);
 			}
 			// Appeasing ships jettison cargo to distract their pursuers.
 			if(personality.IsAppeasing() && it->Cargo().Used())

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -640,34 +640,30 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 			continue;
 		}
 		
-		// Special actions when a ship is heavily damaged:
-		if(healthRemaining < RETREAT_HEALTH + .1)
+		// Cowards abandon their fleets when their shields are down.
+		if(parent && personality.IsCoward() && !it->Shields())
 		{
-			// Cowards abandon their fleets.
-			if(parent && personality.IsCoward())
+			parent.reset();
+			it->SetParent(parent);
+		}
+		// Appeasing ships jettison cargo to distract their pursuers when their ship is heavily damaged.
+		if(healthRemaining < RETREAT_HEALTH + .1 && personality.IsAppeasing() && it->Cargo().Used())
+		{
+			double health = .5 * it->Shields() + it->Hull();
+			double &threshold = appeasmentThreshold[it.get()];
+			if(1. - health > threshold)
 			{
-				parent.reset();
-				it->SetParent(parent);
-			}
-			// Appeasing ships jettison cargo to distract their pursuers.
-			if(personality.IsAppeasing() && it->Cargo().Used())
-			{
-				double health = .5 * it->Shields() + it->Hull();
-				double &threshold = appeasmentThreshold[it.get()];
-				if(1. - health > threshold)
-				{
-					int toDump = 11 + (1. - health) * .5 * it->Cargo().Size();
-					for(const auto &commodity : it->Cargo().Commodities())
-						if(commodity.second && toDump > 0)
-						{
-							int dumped = min(commodity.second, toDump);
-							it->Jettison(commodity.first, dumped, true);
-							toDump -= dumped;
-						}
-					Messages::Add(gov->GetName() + " " + it->Noun() + " \"" + it->Name()
-						+ "\": Please, just take my cargo and leave me alone.", Messages::Importance::High);
-					threshold = (1. - health) + .1;
-				}
+				int toDump = 11 + (1. - health) * .5 * it->Cargo().Size();
+				for(const auto &commodity : it->Cargo().Commodities())
+					if(commodity.second && toDump > 0)
+					{
+						int dumped = min(commodity.second, toDump);
+						it->Jettison(commodity.first, dumped, true);
+						toDump -= dumped;
+					}
+				Messages::Add(gov->GetName() + " " + it->Noun() + " \"" + it->Name()
+					+ "\": Please, just take my cargo and leave me alone.", Messages::Importance::High);
+				threshold = (1. - health) + .1;
 			}
 		}
 		


### PR DESCRIPTION
~~The wiki description says cowards run at 0% shield but they do not, I updated it to match that.~~

The wiki's description needs to be updated to say that this happens to a ship when he reaches critical health, it works almost in the exact same way appeasing does except this one just gets out of there (generally it does match 0 shield but it actually is 35% of total health, meaning hull left before being disabled + shield / full available hull before disabled + full shields)

~~On top of that I discovered that coward wasn't working properly, because the current target was not removed so the ship would just exit the fleet and keep on fighting it's current target instead of getting the heck out of there.
So this makes cowards actually behave as you would expect, instead of stubbornly keeping on attacking the old target.~~

This was my initial theory but further testing revealed it wasn't the case, coward just needed a bit of a boost to when it toggles in order for coward fleet to feel coward and not try leaving when its already too late. As suggested by Amazinite I raised the treshold to 50%. This does affect appeasing ships, but they usually drop their cargo way too late anyway.
The code for making the ship actually flee was also changed to take that treshold into consideration, as suggested.