### PR TITLE
Allow negative maintenance and operating costs

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -50,6 +50,8 @@ namespace {
 		{"slowing resistance fuel", 0.},
 		{"slowing resistance heat", 0.},
 		{"crew equivalent", 0.},
+		{"maintenance costs", 0.},
+		{"operating costs", 0.},
 		
 		// "Protection" attributes appear in denominators and are incremented by 1.
 		{"disruption protection", -0.99},

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -718,15 +718,15 @@ int64_t PlayerInfo::Maintenance() const
 	// in the player's ships instead of in the pooled cargo, so no outfit
 	// will be counted twice.
 	for(const auto &outfit : Cargo().Outfits())
-		maintenance += max<int64_t>(0, outfit.first->Get("maintenance costs")) * outfit.second;
+		maintenance += outfit.first->Get("maintenance costs") * outfit.second;
 	for(const shared_ptr<Ship> &ship : ships)
 		if(!ship->IsDestroyed())
 		{
-			maintenance += max<int64_t>(0, ship->Attributes().Get("maintenance costs"));
+			maintenance += ship->Attributes().Get("maintenance costs");
 			for(const auto &outfit : ship->Cargo().Outfits())
-				maintenance += max<int64_t>(0, outfit.first->Get("maintenance costs")) * outfit.second;
+				maintenance += outfit.first->Get("maintenance costs") * outfit.second;
 			if(!ship->IsParked())
-				maintenance += max<int64_t>(0, ship->Attributes().Get("operating costs"));
+				maintenance += ship->Attributes().Get("operating costs");
 		}
 	return maintenance;
 }


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #6406

## Feature Details
This PR allows outfits to have negative`"maintenance costs"` and/or negative `"operating costs"`, thus allows the creation of outfits that generate credits for the player.

If we want to include such outfits in the main game, then I would expect some additional work to be needed to improve the display in the bank panel (separate the money-generating-maintenance from the regular-maintenance), but this PR should already be useful for plugin creators as-is.

## UI Screenshots
![neg_maint_costs](https://user-images.githubusercontent.com/35403542/147156668-65d7feb8-dfae-4727-a63d-b893a065afba.png)
![neg_operating_costs](https://user-images.githubusercontent.com/35403542/147156678-8d1e4225-6b0d-4731-9aff-0ba487e74438.png)
![neg_maintenance](https://user-images.githubusercontent.com/35403542/147156783-99343c91-1d96-48d4-9123-91980b7f0060.png)

## Usage Examples
[paying_outfits.txt](https://github.com/endless-sky/endless-sky/files/7765303/paying_outfits.txt)

## Testing Done
I installed the outfits given as example and made a few jumps with them (on a new player without morgage). The jumps each resulted in adding 50 credits (as expected with the amount of installed outfits).

## Performance Impact
None expected. (Maintenance is calculated only on launches and jumps, and the calculation did not really change.)