### PR TITLE
New wrapped text element for interfaces.

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -586,7 +586,6 @@ interface "planet"
 		center -60 -140
 		dimensions 720 360
 	"wrapped text" description
-		size 14
 		align top left
 		alignment justified
 		from -300 80
@@ -674,7 +673,6 @@ interface "planet"
 
 interface "spaceport"
 	"wrapped text" description
-		size 14
 		align top left
 		alignment justified
 		from -300 80
@@ -692,7 +690,6 @@ interface "spaceport"
 
 	visible if "has portrait"
 	"wrapped text" news
-		size 14
 		align top left
 		alignment justified
 		from -400 -80
@@ -701,7 +698,6 @@ interface "spaceport"
 
 	visible if "has no portrait"
 	"wrapped text" news
-		size 14
 		align top left
 		alignment justified
 		from -400 -80

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -585,6 +585,12 @@ interface "planet"
 	button l
 		center -60 -140
 		dimensions 720 360
+	"wrapped text" description
+		size 14
+		align top left
+		alignment justified
+		from -300 80
+		dimensions 480 0
 	
 	visible if "has shipyard"
 	sprite "ui/planet dialog button"
@@ -666,7 +672,15 @@ interface "planet"
 
 
 
-interface "news"
+interface "spaceport"
+	"wrapped text" description
+		size 14
+		align top left
+		alignment justified
+		from -300 80
+		dimensions 480 0
+
+	visible if "has news"
 	sprite "ui/news"
 		center -160 -45
 	image "portrait"
@@ -675,12 +689,24 @@ interface "news"
 		from -400 -100
 		align center left
 		color "bright"
-	box "message portrait"
+
+	visible if "has portrait"
+	"wrapped text" news
+		size 14
+		align top left
+		alignment justified
 		from -400 -80
-		to -50 10
-	box "message"
+		dimensions 350 0
+		color medium
+
+	visible if "has no portrait"
+	"wrapped text" news
+		size 14
+		align top left
+		alignment justified
 		from -400 -80
-		to 80 10
+		dimensions 480 0
+		color medium
 
 
 

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -666,6 +666,7 @@ bool Interface::WrappedTextElement::ParseLine(const DataNode &node)
 // Report the actual dimensions of the object that will be drawn.
 Point Interface::WrappedTextElement::NativeDimensions(const Information &info, int state) const
 {
+	// Update the underlying wrapped text to update its size and word wrap calculations.
 	text.SetFont(FontSet::Get(fontSize));
 	text.Wrap(info.GetString(name));
 	return Point(text.WrapWidth(), text.Height());
@@ -676,6 +677,9 @@ Point Interface::WrappedTextElement::NativeDimensions(const Information &info, i
 // Draw this element in the given rectangle.
 void Interface::WrappedTextElement::Draw(const Rectangle &rect, const Information &info, int state) const
 {
+	// Before calling Draw NativeDimensions was called to get the bounding box
+	// of the wrapped text.
+	// As such, we do not need to update the underlying text here again.
 	text.Draw(rect.TopLeft(), *color);
 }
 

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -13,10 +13,12 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef INTERFACE_H_
 #define INTERFACE_H_
 
+#include "text/alignment.hpp"
 #include "Color.h"
 #include "Point.h"
 #include "Rectangle.h"
 #include "text/truncate.hpp"
+#include "text/WrappedText.h"
 
 #include <map>
 #include <string>
@@ -171,6 +173,33 @@ private:
 		char buttonKey = '\0';
 		bool isDynamic = false;
 		Truncate truncate = Truncate::NONE;
+	};
+
+	// This class handles "wrapped text" elements.
+	class WrappedTextElement : public Element {
+	public:
+		WrappedTextElement(const DataNode &node, const Point &globalAnchor);
+
+	protected:
+		// Parse the given data line: one that is not recognized by Element
+		// itself. This returns false if it does not recognize the line, either.
+		virtual bool ParseLine(const DataNode &node) override;
+		// Report the actual dimensions of the object that will be drawn.
+		virtual Point NativeDimensions(const Information &info, int state) const override;
+		// Draw this element in the given rectangle.
+		virtual void Draw(const Rectangle &rect, const Information &info, int state) const override;
+
+	private:
+		mutable WrappedText text;
+
+		// The name of the dynamic text.
+		std::string name;
+
+		// Properties of the text to draw.
+		int fontSize = 14;
+		const Color *color = nullptr;
+		Truncate truncate = Truncate::NONE;
+		Alignment alignment = Alignment::LEFT;
 	};
 	
 	// This class handles "bar" and "ring" elements.

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -14,12 +14,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Information.h"
 
-#include "text/alignment.hpp"
 #include "BankPanel.h"
 #include "Command.h"
 #include "ConversationPanel.h"
 #include "Dialog.h"
-#include "text/FontSet.h"
 #include "GameData.h"
 #include "HiringPanel.h"
 #include "Interface.h"
@@ -51,11 +49,6 @@ PlanetPanel::PlanetPanel(PlayerInfo &player, function<void()> callback)
 	bank.reset(new BankPanel(player));
 	spaceport.reset(new SpaceportPanel(player));
 	hiring.reset(new HiringPanel(player));
-	
-	text.SetFont(FontSet::Get(14));
-	text.SetAlignment(Alignment::JUSTIFIED);
-	text.SetWrapWidth(480);
-	text.Wrap(planet.Description());
 	
 	// Since the loading of landscape images is deferred, make sure that the
 	// landscapes for this system are loaded before showing the planet panel.
@@ -130,10 +123,9 @@ void PlanetPanel::Draw()
 				}
 	}
 	
-	ui.Draw(info, this);
-	
 	if(!selectedPanel)
-		text.Draw(Point(-300., 80.), *GameData::Colors().Get("bright"));
+		info.SetString("description", planet.Description());
+	ui.Draw(info, this);
 }
 
 

--- a/source/PlanetPanel.h
+++ b/source/PlanetPanel.h
@@ -15,8 +15,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Panel.h"
 
-#include "text/WrappedText.h"
-
 #include <functional>
 #include <memory>
 
@@ -63,8 +61,6 @@ private:
 	std::shared_ptr<SpaceportPanel> spaceport;
 	std::shared_ptr<Panel> hiring;
 	Panel *selectedPanel = nullptr;
-	
-	WrappedText text;
 };
 
 

--- a/source/SpaceportPanel.h
+++ b/source/SpaceportPanel.h
@@ -16,7 +16,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Panel.h"
 
 #include "Information.h"
-#include "text/WrappedText.h"
 
 class News;
 class PlayerInfo;
@@ -41,15 +40,9 @@ private:
 	
 private:
 	PlayerInfo &player;
-	WrappedText text;
 	
 	// Current news item (if any):
-	bool hasNews = false;
-	bool hasPortrait = false;
-	int portraitWidth;
-	int normalWidth;
-	Information newsInfo;
-	WrappedText newsMessage;
+	Information info;
 };
 
 


### PR DESCRIPTION
## Feature Details

Implements a new kind of text element: The wrapped text element. It's basically a wrapper around `WrappedText`. No visual difference compared to master.

The spaceport and planet panel can now be fully defined using interfaces!

## Usage Examples

```
"wrapped text" <name>
	size <font size>
	alignment <alignment>
	color <color>
        truncate <truncate>
```

## Testing Done

Made sure that there are no differences between this PR and master. Including with news portraits.

## Performance Impact

For simplicity I do not cache the text, so every frame the word wrap of the `WrappedText` gets recalculated. Hope that's ok :)
