### PR TITLE
Fix audio warnings spam when the audio driver can't be initialized.

### DIFF
--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -183,6 +183,12 @@ void Audio::Init(const vector<string> &sources)
 
 void Audio::CheckReferences()
 {
+	if(!isInitialized)
+	{
+		Files::LogError("Warning: audio could not be initialized. No audio will play.");
+		return;
+	}
+
 	for(auto &&it : sounds)
 		if(it.second.Name().empty())
 			Files::LogError("Warning: sound \"" + it.first + "\" is referred to, but does not exist.");


### PR DESCRIPTION
## Fix Details

Since #6229 the integration test logs were spamed by "but does not exist" sound warnings. I have now figured out that this is caused by missing audio drivers in the CI env. With this PR if the audio could not be initialized it emits a single warning: 

> Warning: audio could not be initialized. No audio will play.

## Testing Done

There's not much to test. The CI env ~~should not~~ edit: doesn't emit a million warnings anymore.