### PR TITLE
Add support for clangd compilation db.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ plugins/
 *.db
 
 # IDEs (no support implied)
+.cache
 .vscode
 .vs
 .metadata
@@ -61,4 +62,5 @@ ipch/
 .idea/
 .idea_modules/
 CMakeLists.txt
+compile_commands.json
 /.gitmodules

--- a/SConstruct
+++ b/SConstruct
@@ -145,7 +145,7 @@ try:
     env.Tool('compilation_db')
     cbd = env.CompilationDatabase()
     Alias('cbd', cbd)
-except SConsEnvironmentError:
+except:
     # scons before 4.0.0 is used. In that case, simply don't provide a compilation database.
     pass
 

--- a/SConstruct
+++ b/SConstruct
@@ -145,7 +145,6 @@ def RecursiveGlob(pattern, dir_name=buildDirectory):
 try:
     env.Tool('compilation_db')
     cbd = env.CompilationDatabase()
-    Alias('cbd', cbd)
 # scons before 4.0.0 is used. In that case, simply don't provide a compilation database.
 except EnvironmentError:
     pass

--- a/SConstruct
+++ b/SConstruct
@@ -141,9 +141,13 @@ def RecursiveGlob(pattern, dir_name=buildDirectory):
 	matches = [i for i in matches if not '{}main.cpp'.format(os.path.sep) in str(i)]
 	return matches
 
-env.Tool('compilation_db')
-cbd = env.CompilationDatabase()
-Alias('cbd', cbd)
+try:
+    env.Tool('compilation_db')
+    cbd = env.CompilationDatabase()
+    Alias('cbd', cbd)
+except SConsEnvironmentError:
+    # scons before 4.0.0 is used. In that case, simply don't provide a compilation database.
+    pass
 
 # By default, invoking scons will build the backing archive file and then the game binary.
 sourceLib = env.StaticLibrary(pathjoin(libDirectory, "endless-sky"), RecursiveGlob("*.cpp", buildDirectory))

--- a/SConstruct
+++ b/SConstruct
@@ -4,7 +4,7 @@
 import os
 import platform
 from SCons.Node.FS import Dir
-from SCons.Errors import SConsEnvironmentError
+from SCons.Errors import *
 
 def pathjoin(*args):
 	return os.path.join(*args)
@@ -146,8 +146,10 @@ try:
     env.Tool('compilation_db')
     cbd = env.CompilationDatabase()
     Alias('cbd', cbd)
+# scons before 4.0.0 is used. In that case, simply don't provide a compilation database.
+except EnvironmentError:
+    pass
 except SConsEnvironmentError:
-    # scons before 4.0.0 is used. In that case, simply don't provide a compilation database.
     pass
 
 # By default, invoking scons will build the backing archive file and then the game binary.

--- a/SConstruct
+++ b/SConstruct
@@ -144,7 +144,7 @@ def RecursiveGlob(pattern, dir_name=buildDirectory):
 
 try:
     env.Tool('compilation_db')
-    cbd = env.CompilationDatabase()
+    env.CompilationDatabase()
 # scons before 4.0.0 is used. In that case, simply don't provide a compilation database.
 except EnvironmentError:
     pass

--- a/SConstruct
+++ b/SConstruct
@@ -4,6 +4,7 @@
 import os
 import platform
 from SCons.Node.FS import Dir
+from SCons.Errors import SConsEnvironmentError
 
 def pathjoin(*args):
 	return os.path.join(*args)
@@ -145,7 +146,7 @@ try:
     env.Tool('compilation_db')
     cbd = env.CompilationDatabase()
     Alias('cbd', cbd)
-except:
+except SConsEnvironmentError:
     # scons before 4.0.0 is used. In that case, simply don't provide a compilation database.
     pass
 

--- a/SConstruct
+++ b/SConstruct
@@ -12,7 +12,7 @@ def pathjoin(*args):
 # If we are compiling on Windows, then we need to change the toolset to MinGW.
 is_windows_host = platform.system().startswith('Windows')
 scons_toolset = ['mingw' if is_windows_host else 'default']
-env = DefaultEnvironment(tools = scons_toolset, ENV = os.environ)
+env = DefaultEnvironment(tools = scons_toolset, ENV = os.environ, COMPILATIONDB_USE_ABSPATH=True)
 
 if 'CXX' in os.environ:
 	env['CXX'] = os.environ['CXX']
@@ -140,6 +140,10 @@ def RecursiveGlob(pattern, dir_name=buildDirectory):
 	matches += Glob(pathjoin(str(dir_name), pattern))
 	matches = [i for i in matches if not '{}main.cpp'.format(os.path.sep) in str(i)]
 	return matches
+
+env.Tool('compilation_db')
+cbd = env.CompilationDatabase()
+Alias('cbd', cbd)
 
 # By default, invoking scons will build the backing archive file and then the game binary.
 sourceLib = env.StaticLibrary(pathjoin(libDirectory, "endless-sky"), RecursiveGlob("*.cpp", buildDirectory))

--- a/SConstruct
+++ b/SConstruct
@@ -149,8 +149,6 @@ try:
     env.CompilationDatabase()
     env.Default('compile_commands.json')
 # scons before 4.0.0 is used. In that case, simply don't provide a compilation database.
-except EnvironmentError:
-    pass
 except SConsEnvironmentError:
     pass
 

--- a/SConstruct
+++ b/SConstruct
@@ -145,6 +145,7 @@ def RecursiveGlob(pattern, dir_name=buildDirectory):
 try:
     env.Tool('compilation_db')
     env.CompilationDatabase()
+    env.Default('compile_commands.json')
 # scons before 4.0.0 is used. In that case, simply don't provide a compilation database.
 except EnvironmentError:
     pass

--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,7 @@
 import os
 import platform
 from SCons.Node.FS import Dir
-from SCons.Errors import SconsEnvironmentError
+from SCons.Errors import SConsEnvironmentError
 
 def pathjoin(*args):
 	return os.path.join(*args)
@@ -146,8 +146,7 @@ def RecursiveGlob(pattern, dir_name=buildDirectory):
 
 try:
     env.Tool('compilation_db')
-    env.CompilationDatabase()
-    env.Default('compile_commands.json')
+    env.Default(env.CompilationDatabase())
 # scons before 4.0.0 is used. In that case, simply don't provide a compilation database.
 except SConsEnvironmentError:
     pass

--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,7 @@
 import os
 import platform
 from SCons.Node.FS import Dir
-from SCons.Errors import *
+from SCons.Errors import SconsEnvironmentError
 
 def pathjoin(*args):
 	return os.path.join(*args)


### PR DESCRIPTION
## Feature Details

Adds support for compilation db, which is a database/file used by LSP servers like clangd to properly index source files (like an IDE). The file is generated by running `scons cbd`. This requires scons 4, which was released July 2020.

This PR also adds clangd's cache folder and the compilation db itself to the git ignore list.


