### PR TITLE
feat(mechanics): Allow outfits to generate income

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -245,6 +245,9 @@ tip "hull repair multiplier:"
 tip "illegal:"
 	`Amount of credits you can be fined for carrying this outfit.`
 
+tip "income:"
+	`Amount of credits you receive per day that you own this outfit, even if it is not in active use.`
+
 tip "ion protection:"
 	`Protection against weapons that do ion damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in ion damage, while a total value of 11 only results in a 10 percent reduction.`
 
@@ -298,6 +301,9 @@ tip "mass:"
 
 tip "operating costs:"
 	`How many credits per day you need to spend to maintain this outfit while it is in active use.`
+
+tip "operating income:"
+	`Amount of credits you receive per day that this outfit is in active use.`
 
 tip "outfit scan:"
 	`Lets you scan your target ship's outfits from up to this distance away.`

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -115,13 +115,11 @@ void BankPanel::Draw()
 			income[i] += it->second;
 	}
 	// Check if maintenance needs to be drawn.
-	int64_t assetsReturns = 0;
-	int64_t maintenance = 0;
-	player.MaintenanceAndReturns(maintenance, assetsReturns);
+	PlayerInfo::FleetBalance b = player.MaintenanceAndReturns();
 	int64_t maintenanceDue = player.Accounts().MaintenanceDue();
 	// Figure out how many rows of the display are for mortgages, and also check
 	// whether multiple mortgages have to be combined into the last row.
-	mortgageRows = MAX_ROWS - (salaries != 0 || salariesOwed != 0) - (maintenance != 0 || maintenanceDue != 0) - (assetsReturns != 0) - (income[0] != 0 || income[1] != 0);
+	mortgageRows = MAX_ROWS - (salaries != 0 || salariesOwed != 0) - (b.maintenanceCosts != 0 || maintenanceDue != 0) - (b.assetsReturns != 0 || income[0] != 0 || income[1] != 0);
 	int mortgageCount = player.Accounts().Mortgages().size();
 	mergedMortgages = (mortgageCount > mortgageRows);
 	if(!mergedMortgages)
@@ -193,9 +191,9 @@ void BankPanel::Draw()
 		table.Advance();
 	}
 	// Draw the maintenance costs, if necessary.
-	if(maintenance || maintenanceDue)
+	if(b.maintenanceCosts || maintenanceDue)
 	{
-		totalPayment += maintenance;
+		totalPayment += b.maintenanceCosts;
 
 		table.Draw("Maintenance");
 		if(maintenanceDue)
@@ -206,29 +204,22 @@ void BankPanel::Draw()
 		}
 		else
 			table.Advance(3);
-		table.Draw(maintenance);
+		table.Draw(b.maintenanceCosts);
 		table.Advance();
 	}
-	if(assetsReturns)
-	{
-		totalPayment -= assetsReturns;
-		const auto incomeLayout = Layout(310, Truncate::BACK);
-		table.DrawCustom({"Return on ships and outfits", incomeLayout});
-		table.Advance(3);
-		table.Draw(-(assetsReturns));
-		table.Advance();
-	}
-	if(income[0] || income[1])
+	if(income[0] || income[1] || b.assetsReturns)
 	{
 		// Your daily income offsets expenses.
-		totalPayment -= income[0] + income[1];
+		totalPayment -= income[0] + income[1] + b.assetsReturns;
 
-		static const string LABEL[] = {"", "Your Salary Income", "Your Tribute Income", "Your Salary and Tribute Income"};
+		static const string LABEL[] = {"", "Your Salary Income", "Your Tribute Income", "Your Salary and Tribute Income",
+			"Your Return on Assets Income", "Your Salary and Return on Assets Income",
+			"Your Tribute and Return on Assets Income", "Your Salary, Tribute, and Returns Income" };
 		const auto incomeLayout = Layout(310, Truncate::BACK);
-		table.DrawCustom({LABEL[(income[0] != 0) + 2 * (income[1] != 0)], incomeLayout});
+		table.DrawCustom({LABEL[(income[0] != 0) + 2 * (income[1] != 0) + 4 * (b.assetsReturns != 0)], incomeLayout});
 		// For crew salaries, only the "payment" field needs to be shown.
 		table.Advance(3);
-		table.Draw(-(income[0] + income[1]));
+		table.Draw(-(income[0] + income[1] + b.assetsReturns));
 		table.Advance();
 	}
 

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -115,11 +115,13 @@ void BankPanel::Draw()
 			income[i] += it->second;
 	}
 	// Check if maintenance needs to be drawn.
-	int64_t maintenance = player.Maintenance();
+	int64_t assetsReturns = 0;
+	int64_t maintenance = 0;
+	player.MaintenanceAndReturns(maintenance, assetsReturns);
 	int64_t maintenanceDue = player.Accounts().MaintenanceDue();
 	// Figure out how many rows of the display are for mortgages, and also check
 	// whether multiple mortgages have to be combined into the last row.
-	mortgageRows = MAX_ROWS - (salaries != 0 || salariesOwed != 0) - (maintenance != 0 || maintenanceDue != 0) - (income[0] != 0 || income[1] != 0);
+	mortgageRows = MAX_ROWS - (salaries != 0 || salariesOwed != 0) - (maintenance != 0 || maintenanceDue != 0) - (income[0] != 0 || income[1] != 0) - (assetsReturns != 0);
 	int mortgageCount = player.Accounts().Mortgages().size();
 	mergedMortgages = (mortgageCount > mortgageRows);
 	if(!mergedMortgages)
@@ -205,6 +207,15 @@ void BankPanel::Draw()
 		else
 			table.Advance(3);
 		table.Draw(maintenance);
+		table.Advance();
+	}
+	if(assetsReturns)
+	{
+		totalPayment -= assetsReturns;
+		const auto incomeLayout = Layout(310, Truncate::BACK);
+		table.DrawCustom({"Return on ships and outfits", incomeLayout});
+		table.Advance(3);
+		table.Draw(-(assetsReturns));
 		table.Advance();
 	}
 	if(income[0] || income[1])

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -121,7 +121,7 @@ void BankPanel::Draw()
 	int64_t maintenanceDue = player.Accounts().MaintenanceDue();
 	// Figure out how many rows of the display are for mortgages, and also check
 	// whether multiple mortgages have to be combined into the last row.
-	mortgageRows = MAX_ROWS - (salaries != 0 || salariesOwed != 0) - (maintenance != 0 || maintenanceDue != 0) - (income[0] != 0 || income[1] != 0) - (assetsReturns != 0);
+	mortgageRows = MAX_ROWS - (salaries != 0 || salariesOwed != 0) - (maintenance != 0 || maintenanceDue != 0) - (assetsReturns != 0) - (income[0] != 0 || income[1] != 0);
 	int mortgageCount = player.Accounts().Mortgages().size();
 	mergedMortgages = (mortgageCount > mortgageRows);
 	if(!mergedMortgages)

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -50,8 +50,6 @@ namespace {
 		{"slowing resistance fuel", 0.},
 		{"slowing resistance heat", 0.},
 		{"crew equivalent", 0.},
-		{"maintenance costs", 0.},
-		{"operating costs", 0.},
 		
 		// "Protection" attributes appear in denominators and are incremented by 1.
 		{"disruption protection", -0.99},

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -718,15 +718,15 @@ int64_t PlayerInfo::Maintenance() const
 	// in the player's ships instead of in the pooled cargo, so no outfit
 	// will be counted twice.
 	for(const auto &outfit : Cargo().Outfits())
-		maintenance += outfit.first->Get("maintenance costs") * outfit.second;
+		maintenance += max<int64_t>(0, outfit.first->Get("maintenance costs")) * outfit.second;
 	for(const shared_ptr<Ship> &ship : ships)
 		if(!ship->IsDestroyed())
 		{
-			maintenance += ship->Attributes().Get("maintenance costs");
+			maintenance += max<int64_t>(0, ship->Attributes().Get("maintenance costs"));
 			for(const auto &outfit : ship->Cargo().Outfits())
-				maintenance += outfit.first->Get("maintenance costs") * outfit.second;
+				maintenance += max<int64_t>(0, outfit.first->Get("maintenance costs")) * outfit.second;
 			if(!ship->IsParked())
-				maintenance += ship->Attributes().Get("operating costs");
+				maintenance += max<int64_t>(0, ship->Attributes().Get("operating costs"));
 		}
 	return maintenance;
 }

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -551,7 +551,7 @@ void PlayerInfo::IncrementDate()
 				, Messages::Importance::Highest);
 	
 	// Check what salaries and tribute the player receives.
-	auto getIncome = [&](string prefix){
+	auto getIncome = [&](string prefix) {
 		int64_t total = 0;
 		auto it = conditions.lower_bound(prefix);
 		for( ; it != conditions.end() && !it->first.compare(0, prefix.length(), prefix); ++it)
@@ -716,7 +716,7 @@ int64_t PlayerInfo::Salaries() const
 
 
 
-// Calculate the daily maintenance cost for all ships and in cargo outfits.
+// Calculate the daily maintenance cost and generated income for all ships and in cargo outfits.
 void PlayerInfo::MaintenanceAndReturns(int64_t &maintenance, int64_t &assetReturns) const
 {
 	// If the player is landed, then cargo will be in the player's

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -551,15 +551,15 @@ void PlayerInfo::IncrementDate()
 				, Messages::Importance::Highest);
 	
 	// Check what salaries and tribute the player receives.
-	auto getIncome = [&](string prefix) {
+	auto GetIncome = [&](string prefix) {
 		int64_t total = 0;
 		auto it = conditions.lower_bound(prefix);
 		for( ; it != conditions.end() && !it->first.compare(0, prefix.length(), prefix); ++it)
 			total += it->second;
 		return total;
 	};
-	int64_t salariesIncome = getIncome("salary: ");
-	int64_t tributeIncome = getIncome("tribute: ");
+	int64_t salariesIncome = GetIncome("salary: ");
+	int64_t tributeIncome = GetIncome("tribute: ");
 	int64_t assetsReturns = 0;
 	int64_t maintenanceCosts = 0;
 	MaintenanceAndReturns(maintenanceCosts, assetsReturns);

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -119,7 +119,7 @@ public:
 	// Calculate the daily salaries for crew, not counting crew on "parked" ships.
 	int64_t Salaries() const;
 	// Calculate the daily maintenance cost for all ships and in cargo outfits.
-	int64_t Maintenance() const;
+	void MaintenanceAndReturns(int64_t &maintenance, int64_t &assetReturns) const;
 	
 	// Access the flagship (the first ship in the list). This returns null if
 	// the player does not have any ships that can be a flagship.

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -52,6 +52,11 @@ class UI;
 // and what their current travel plan is, if any.
 class PlayerInfo {
 public:
+	struct FleetBalance {
+		int64_t maintenanceCosts = 0;
+		int64_t assetsReturns = 0;
+	};
+public:
 	PlayerInfo() = default;
 	// Don't allow copying this class.
 	PlayerInfo(const PlayerInfo &) = delete;
@@ -119,7 +124,7 @@ public:
 	// Calculate the daily salaries for crew, not counting crew on "parked" ships.
 	int64_t Salaries() const;
 	// Calculate the daily maintenance cost and generated income for all ships and in cargo outfits.
-	void MaintenanceAndReturns(int64_t &maintenance, int64_t &assetReturns) const;
+	FleetBalance MaintenanceAndReturns() const;
 
 	// Access the flagship (the first ship in the list). This returns null if
 	// the player does not have any ships that can be a flagship.

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -118,7 +118,7 @@ public:
 	Account &Accounts();
 	// Calculate the daily salaries for crew, not counting crew on "parked" ships.
 	int64_t Salaries() const;
-	// Calculate the daily maintenance cost for all ships and in cargo outfits.
+	// Calculate the daily maintenance cost and generated income for all ships and in cargo outfits.
 	void MaintenanceAndReturns(int64_t &maintenance, int64_t &assetReturns) const;
 	
 	// Access the flagship (the first ship in the list). This returns null if


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #6406

## Feature Details
This PR adds the keywords `"income"` and `"operating income"` as suggested in #6406.
This PR also reverts the previous implementation (from #6423) that didn't use those separate keywords.

## UI Screenshots
![bank_panel](https://user-images.githubusercontent.com/35403542/147295908-e720332e-bf08-4a86-bf8e-99d5b97b4958.png)

After commit 8697c90e7346529a7bbed62efafa794d88539936 :
![bank_panel](https://user-images.githubusercontent.com/35403542/148226138-d45db3c7-8b98-4f19-a36c-b38abf2c4c5b.png)

## Usage Examples
See the attached file:
[paying_outfits.txt](https://github.com/endless-sky/endless-sky/files/7771629/paying_outfits.txt)

## Testing Done
Tested with the examples above (and created the screenshots as seen above).

## Performance Impact
No impact is expected, since those calculations only run on launches and jumps (day changes).
