### PR TITLE
Bugfix: Reliability of Loading and Saving test

### DIFF
--- a/data/tests/tests_save_load.txt
+++ b/data/tests/tests_save_load.txt
@@ -57,15 +57,18 @@ test "Loading and Saving"
 		label notAlpha1
 		branch notAlpha1
 			not "flagship system: Alpha Centauri"
+		# Terminate jumping if it still is active.
+		input
+			command forward
 		navigate
 			travel "Sol"
 			"travel destination" Earth
+		input
+			command jump
 		watchdog 12000
 		label notReturned1
 		branch notReturned1
 			not "flagship planet: Earth"
-		apply
-			"test: day" = day
 		assert
 			year == 3013
 			month == 11


### PR DESCRIPTION
**Bugfix:** This PR addresses a test reliability issue

## Fix Details
Apply test-fixes from: https://github.com/quyykk/endless-sky/pull/2
The test was not working reliably, the test assumed that jumping would continue while a new navigation target would be set. This assumption would be false if the jump/navigation code already detected that the end-location was reached before the new targets would be set.

## Testing Done
This will be tested in CI (and was tested for the earlier pull-request).

## Save File
N/A (all data is encoded in the test)