### PR TITLE
codespell CI wrong line numbers fix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,6 +513,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: codespell-project/actions-codespell@master
       with:
         builtin: clear,en-GB_to_en-US


### PR DESCRIPTION
## Fix Details

When CIs are run the PR is merged with the current master implicitly. If a file has changed in master but the PR hasn't been merged with master yet than any line numbers by codespell will be incorrect, as they will refer to the merged file instead of just the PR file.

This PR fixes this issue by checking out only the PRs branch without this merge ([link to the docs](https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit)). Many thanks to @MCOfficer.

## Testing Done

Verified that the checkout doesn't merge with master. If the CI is run on the branch itself without a PR then it still works.