### PR TITLE
refactor(content,grammar): Rephrase statement in FW Reconciliation

### DIFF
--- a/data/human/free worlds reconciliation.txt
+++ b/data/human/free worlds reconciliation.txt
@@ -1465,7 +1465,7 @@ mission "FW Pug 3: Deep"
 		log "The governor of Valhalla, in the Deep, says that the Pug secretly assisted the people of the Deep to fight against the Alphas centuries ago, during the Alpha Wars. He thinks that the Pug have humanity's best interests at heart, but agrees that they can't be allowed to overthrow the Republic."
 		log "Factions" "Pug" `It is possible that the Pug secretly assisted the humans of the Deep centuries ago by providing them with weapons that helped to turn the tide of the Alpha Wars.`
 		conversation
-			`As you are coming in for a landing, you contact Edrick Flint and see if he's available to talk. A few minutes later, you and Alondo are sitting with him in his office in the government center. "I assume you've heard about the alien invasion?" says Alondo. Edrick nods. "The aliens claimed that they had had dealings with the Deep in the past. Do you know anything about that?"`
+			`As you are coming in for a landing, you contact Edrick Flint and see if he's available to talk. A few minutes later, you and Alondo are sitting with him in his office in the government center. "I assume you've heard about the alien invasion?" says Alondo. Edrick nods. "The aliens claimed that they had dealt with the Deep in the past. Do you know anything about that?"`
 			`	Edrick says, "Can you describe what these aliens look like?"`
 			`	"Pale skin, delicate physique, most of them a little under two meters tall," says Alondo. "Long legs, short torsos. And they probably have blue blood."`
 			`	Edrick pauses for several seconds, then says, "Yes, we had contact with a species that matches that description, back during the Alpha Wars. Some of the folk traditions about 'elves' that still persist here in the Deep are a result of those encounters."`


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6436

## Fix Details
There was some awkward phrasing in line 1468 of FW Reconciliation, where there is the line `"The aliens claimed that they had had dealings with the Deep in the past. Do you know anything about that?"`. While grammatically correct, it is awkward to read. I replaced it with `had dealt with` instead. 

## Testing Done
I changed three words.
