### PR TITLE
Fix: FW Reconciliation 2 pluralization of "member"

### DIFF
--- a/data/human/free worlds reconciliation.txt
+++ b/data/human/free worlds reconciliation.txt
@@ -244,7 +244,7 @@ mission "FW Reconciliation 2"
 					goto pessimism
 			
 			label optimism
-			`	You continue to feel optimistic as Sawyer presents his story and his evidence, corroborated by the additional data collected by Ijs and by Raven's team. But as the member of Parliament begin questioning Sawyer, nearly all their questions sound more like an attack on him than an attempt to learn more about the Syndicate's involvement in the terrorist attacks.`
+			`	You continue to feel optimistic as Sawyer presents his story and his evidence, corroborated by the additional data collected by Ijs and by Raven's team. But as the members of Parliament begin questioning Sawyer, nearly all their questions sound more like an attack on him than an attempt to learn more about the Syndicate's involvement in the terrorist attacks.`
 				goto why
 			
 			label pessimism


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
Reported by pilover100 on Discord. Thanks!

On line 247 the word "member" makes it sound like a single member of parliament is responsible for all the questioning; whereas given the nature of a parliament, it is more likely that many of the members are doing the questioning. This is particularly the case given that other paragraphs in this same scene make a point of emphasizing how many members of parliament there are that come from Syndicate worlds, and how they all seem hostile to him.

## Testing Done
n/a

## Save File
n/a
