### PR TITLE
Fix: Re-establish Remnant Disabling Behavior

### DIFF
--- a/data/remnant/remnant.txt
+++ b/data/remnant/remnant.txt
@@ -15,7 +15,7 @@ fleet "Small Remnant"
 	commodities Food Clothing Metal Plastic Medical "Heavy Metals"
 	outfitters "Korath Basics" "Korath Exiles" "Ka'het"
 	personality
-		heroic plunders appeasing
+		disables heroic plunders appeasing
 	variant 8
 		"Starling"
 	variant 6
@@ -48,7 +48,7 @@ fleet "Large Remnant"
 	commodities Food Clothing Metal Plastic Medical "Heavy Metals"
 	outfitters "Korath Basics" "Korath Exiles" "Ka'het"
 	personality
-		heroic plunders appeasing
+		disables heroic plunders appeasing
 	variant 6
 		"Albatross"
 		"Starling" 2
@@ -102,7 +102,7 @@ fleet "Remnant Transport"
 	commodities Food Clothing Metal Plastic Medical "Heavy Metals"
 	outfitters "Korath Basics" "Korath Exiles" "Ka'het"
 	personality
-		plunders coward appeasing mining harvests
+		disables plunders coward appeasing mining harvests
 	variant 10
 		"Gull"
 	variant 5
@@ -155,7 +155,7 @@ fleet "Remnant Home Guard"
 	commodities Food Metal Plastic "Heavy Metals"
 	outfitters "Korath Basics" "Korath Exiles" "Ka'het"
 	personality
-		plunders appeasing mining harvests surveillance
+		disables plunders appeasing mining harvests surveillance
 	variant 20
 		"Tern" 1
 	variant 10


### PR DESCRIPTION
**Bugfix:** This PR addresses the serious lore problem of the Remnant not disabling anything when they are explicitly described as doing so (and even penalizing the player when they destroy something instead of disabling in one mission).

## Fix Details
Adds the "disable" tag to the following fleets.
- Small Remnant
- Large Remnant
- Remnant Transport
- Remnant Home Guard

Note: The decoy, light, and large defence fleets are exclusively used for "no-holds-barred desperate fight for survival" situations, and thus explicitly should *not* be concerned about disabling, just like they aren't concerned about appeasing or harvesting.

## Related PR:
https://github.com/endless-sky/endless-sky/pull/5667

Background:
This behavior was originally removed on the expectation that just having the "plunder" would cause the Remnant to disable ships, then plunder them, and *then* destroy them. In practice, however, the Remnant just annihilate everything with no visible plundering going on, and there is definitely no waiting for multiple ships to completely clean out a ship before the destruction happens.

That being said, given the past many months of seeing how it works now, I feel that this does *not* match the intended Remnant behavior, and further more, that neither the "destroy outright" nor the "disable, plunder, and *then* destroy" match the intended "current status quo" behavior of the Remnant/Korath battles. After all, the Remnant *want* the Korath to survive, and return home with their "loot" of food and basic resources. This is, after all, how they ensure that the Korath keep bringing them more ships and outfits to take.

Likewise, the "problem" of the player being able to hang around and eventually have a large set of disabled ships to loot is a very minor problem as far as I'm concerned. The linked PR even *creates* this problem by giving disable to a swath of pirate fleets, ensuring more opportunities to wait around and ninja-salvage ships. The material benefits to the player doing this are minor compared to the value of amassing Shield Beetle or Automaton fleets. (the player can get a fair bit of wealth, but capturing Raiders is much harder than capturing shield beetles or automatons) and have a far weaker impact on overall gameplay.

## Summary:
The old Remnant behavior of just disabling ships and plundering them, then leaving them, is the best fit behavior for what the Remnant are described as doing; and the downsides of having them do this are insignificant.

## Future Ideas:
Ideally, I'd love to see the Remnant have a more complex disabling & plundering routine, where they disable ships, then plunder everything except the HD off it, then give the ship an asteroid class thruster & steering and a couple supercapacitors while filling its cargo hold with food and metals, and then end off by repairing the ship (at least, for Korath ships, anyway). At that point the now repaired ship should be ignored by the Remnant as if it had bribed them, and should immediately hyperjump out of the system, where it will, in lore, be found by other Korath ships who will then either salvage it and take the crew back home, or install a fresh JD so the ship can get itself home. And periodically top up its power. 