### PR TITLE
test (maintenance): Combine testToRun and stepToRun into single callstack variable

### DIFF
--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -519,25 +519,16 @@ void Test::Fail(const TestContext &context, const PlayerInfo &player, const stri
 	Files::LogError(message);
 
 	// Print the callstack if we have any.
-	auto stackDepth = context.callstack.size();
 	string stackMessage = "Call-stack:\n";
-	if(stackDepth == 0)
+	if(context.callstack.size() == 0)
 		stackMessage += "  No callstack info at moment of failure.";
-	while(stackDepth > 0)
+
+	for(auto i = context.callstack.rbegin(); i != context.callstack.rend(); ++i )
 	{
-		if(context.callstack.size() < stackDepth)
-			stackMessage += "At unknown test!\n";
-		else
-		{
-			// Indexing starts from 0, but the stack counter starts at 1.
-			auto testPrint = context.callstack[stackDepth - 1].test;
-			auto testStepNr = context.callstack[stackDepth - 1].step;
-			stackMessage += "- \"" + testPrint->Name() + "\", step: " + to_string(1 + testStepNr);
-			if(testStepNr < testPrint->steps.size())
-				stackMessage += " (" + STEPTYPE_TO_TEXT.at((testPrint->steps[testStepNr]).stepType) + ")";
-			stackMessage += "\n";
-		}
-		--stackDepth;
+		stackMessage += "- \"" + i->test->Name() + "\", step: " + to_string(1 + i->step);
+		if(i->step < i->test->steps.size())
+			stackMessage += " (" + STEPTYPE_TO_TEXT.at(((i->test->steps)[i->step]).stepType) + ")";
+		stackMessage += "\n";
 	}
 	Files::LogError(stackMessage);
 

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -385,12 +385,11 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 	// If the step to run is beyond the end of the steps, then we finished
 	// the current test (and step to the step higher in the stack or we are
 	// done testing if we are at toplevel).
-	if(context.stepToRun.back() >= steps.size())
+	if(context.callstack.back().step >= steps.size())
 	{
-		context.testToRun.pop_back();
-		context.stepToRun.pop_back();
+		context.callstack.pop_back();
 
-		if(context.stepToRun.empty())
+		if(context.callstack.empty())
 		{
 			// Done, no failures, exit the game with exitcode success.
 			SendQuitEvent();
@@ -398,7 +397,7 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 		}
 		else
 			// Step beyond the call statement we just finished.
-			++(context.stepToRun.back());
+			++(context.callstack.back().step);
 
 		// We changed the active test or are quitting, so don't run the current one.
 		continueGameLoop = true;
@@ -407,7 +406,7 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 	// All processing was done just before this step started.
 	context.branchesSinceGameStep.clear();
 
-	while(context.stepToRun.back() < steps.size() && !continueGameLoop)
+	while(context.callstack.back().step < steps.size() && !continueGameLoop)
 	{
 		// Fail if we encounter a watchdog timeout
 		if(context.watchdog == 1)
@@ -415,34 +414,34 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 		else if(context.watchdog > 1)
 			--(context.watchdog);
 
-		const TestStep &stepToRun = steps[context.stepToRun.back()];
+		const TestStep &stepToRun = steps[context.callstack.back().step];
 		switch(stepToRun.stepType)
 		{
 			case TestStep::Type::APPLY:
 				stepToRun.conditions.Apply(player.Conditions());
-				++(context.stepToRun.back());
+				++(context.callstack.back().step);
 				break;
 			case TestStep::Type::ASSERT:
 				if(!stepToRun.conditions.Test(player.Conditions()))
 					Fail(context, player, "asserted false");
-				++(context.stepToRun.back());
+				++(context.callstack.back().step);
 				break;
 			case TestStep::Type::BRANCH:
 				// If we encounter a branch entry twice, then resume the gameloop before the second encounter.
 				// Encountering branch entries twice typically only happen in "wait loops" and we should give
 				// the game cycles to proceed if we are in a wait loop for something that happens over time.
-				if(context.branchesSinceGameStep.count(context.stepToRun))
+				if(context.branchesSinceGameStep.count(context.callstack.back()))
 				{
 					continueGameLoop = true;
 					break;
 				}
-				context.branchesSinceGameStep.emplace(context.stepToRun);
+				context.branchesSinceGameStep.emplace(context.callstack.back());
 				if(stepToRun.conditions.Test(player.Conditions()))
-					context.stepToRun.back() = jumpTable.find(stepToRun.jumpOnTrueTarget)->second;
+					context.callstack.back().step = jumpTable.find(stepToRun.jumpOnTrueTarget)->second;
 				else if(!stepToRun.jumpOnFalseTarget.empty())
-					context.stepToRun.back() = jumpTable.find(stepToRun.jumpOnFalseTarget)->second;
+					context.callstack.back().step = jumpTable.find(stepToRun.jumpOnFalseTarget)->second;
 				else
-					++(context.stepToRun.back());
+					++(context.callstack.back().step);
 				break;
 			case TestStep::Type::CALL:
 				{
@@ -450,8 +449,7 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 					if(nullptr == calledTest)
 						Fail(context, player, "Calling non-existing test \"" + stepToRun.nameOrLabel + "\"");
 					// Put the called test on the stack and start it from 0.
-					context.testToRun.push_back(calledTest);
-					context.stepToRun.push_back(0);
+					context.callstack.push_back({calledTest, 0});
 					// Break the loop to switch to the test just pushed.
 				}
 				continueGameLoop = true;
@@ -463,7 +461,7 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 					if(!testData->Inject())
 						Fail(context, player, "injecting data failed");
 				}
-				++(context.stepToRun.back());
+				++(context.callstack.back().step);
 				break;
 			case TestStep::Type::INPUT:
 				if(stepToRun.command)
@@ -479,20 +477,20 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 				// TODO: handle mouse inputs
 				// Make sure that we run a gameloop to process the input.
 				continueGameLoop = true;
-				++(context.stepToRun.back());
+				++(context.callstack.back().step);
 				break;
 			case TestStep::Type::LABEL:
-				++(context.stepToRun.back());
+				++(context.callstack.back().step);
 				break;
 			case TestStep::Type::NAVIGATE:
 				player.TravelPlan().clear();
 				player.TravelPlan() = stepToRun.travelPlan;
 				player.SetTravelDestination(stepToRun.travelDestination);
-				++(context.stepToRun.back());
+				++(context.callstack.back().step);
 				break;
 			case TestStep::Type::WATCHDOG:
 				context.watchdog = stepToRun.watchdog;
-				++(context.stepToRun.back());
+				++(context.callstack.back().step);
 				break;
 			default:
 				Fail(context, player, "Unknown step type");
@@ -521,19 +519,19 @@ void Test::Fail(const TestContext &context, const PlayerInfo &player, const stri
 	Files::LogError(message);
 
 	// Print the callstack if we have any.
-	auto stackDepth = context.stepToRun.size();
+	auto stackDepth = context.callstack.size();
 	string stackMessage = "Call-stack:\n";
 	if(stackDepth == 0)
 		stackMessage += "  No callstack info at moment of failure.";
 	while(stackDepth > 0)
 	{
-		if(context.testToRun.size() < stackDepth)
+		if(context.callstack.size() < stackDepth)
 			stackMessage += "At unknown test!\n";
 		else
 		{
 			// Indexing starts from 0, but the stack counter starts at 1.
-			auto testPrint = context.testToRun[stackDepth - 1];
-			auto testStepNr = context.stepToRun[stackDepth - 1];
+			auto testPrint = context.callstack[stackDepth - 1].test;
+			auto testStepNr = context.callstack[stackDepth - 1].step;
 			stackMessage += "- \"" + testPrint->Name() + "\", step: " + to_string(1 + testStepNr);
 			if(testStepNr < testPrint->steps.size())
 				stackMessage += " (" + STEPTYPE_TO_TEXT.at((testPrint->steps[testStepNr]).stepType) + ")";

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -520,7 +520,7 @@ void Test::Fail(const TestContext &context, const PlayerInfo &player, const stri
 
 	// Print the callstack if we have any.
 	string stackMessage = "Call-stack:\n";
-	if(context.callstack.size() == 0)
+	if(context.callstack.empty())
 		stackMessage += "  No callstack info at moment of failure.";
 
 	for(auto i = context.callstack.rbegin(); i != context.callstack.rend(); ++i )

--- a/source/TestContext.cpp
+++ b/source/TestContext.cpp
@@ -39,5 +39,5 @@ bool TestContext::ActiveTestStep::operator==(const ActiveTestStep &rhs) const
 
 bool TestContext::ActiveTestStep::operator<(const ActiveTestStep &rhs) const
 {
-	return this->test < rhs.test || (this->test == rhs.test && this->step < rhs.step);
+	return test < rhs.test || (test == rhs.test && step < rhs.step);
 }

--- a/source/TestContext.cpp
+++ b/source/TestContext.cpp
@@ -41,10 +41,3 @@ bool TestContext::ActiveTestStep::operator<(const ActiveTestStep &rhs) const
 {
 	return this->test < rhs.test || (this->test == rhs.test && this->step < rhs.step);
 }
-
-
-
-bool TestContext::ActiveTestStep::operator>(const ActiveTestStep &rhs) const
-{
-	return this->test > rhs.test || (this->test == rhs.test && this->step > rhs.step);
-}

--- a/source/TestContext.cpp
+++ b/source/TestContext.cpp
@@ -17,7 +17,7 @@ class Test;
 
 
 // Constructor to be used when running an actual test.
-TestContext::TestContext(const Test *toRun) : testToRun(1, toRun)
+TestContext::TestContext(const Test *toRun) : callstack({{toRun, 0}})
 {
 }
 
@@ -25,5 +25,26 @@ TestContext::TestContext(const Test *toRun) : testToRun(1, toRun)
 
 const Test *TestContext::CurrentTest() const noexcept
 {
-	return testToRun.empty() ? nullptr : testToRun.back();
+	return callstack.empty() ? nullptr : callstack.back().test;
+}
+
+
+
+bool TestContext::ActiveTestStep::operator==(const ActiveTestStep &rhs) const
+{
+	return this->test==rhs.test && this->step==rhs.step;
+}
+
+
+
+bool TestContext::ActiveTestStep::operator<(const ActiveTestStep &rhs) const
+{
+	return this->test < rhs.test || (this->test == rhs.test && this->step < rhs.step);
+}
+
+
+
+bool TestContext::ActiveTestStep::operator>(const ActiveTestStep &rhs) const
+{
+	return this->test > rhs.test || (this->test == rhs.test && this->step > rhs.step);
 }

--- a/source/TestContext.cpp
+++ b/source/TestContext.cpp
@@ -32,7 +32,7 @@ const Test *TestContext::CurrentTest() const noexcept
 
 bool TestContext::ActiveTestStep::operator==(const ActiveTestStep &rhs) const
 {
-	return this->test==rhs.test && this->step==rhs.step;
+	return test == rhs.test && step == rhs.step;
 }
 
 

--- a/source/TestContext.h
+++ b/source/TestContext.h
@@ -39,7 +39,6 @@ private:
 		// Support operators for usage in containers like map and set.
 		bool operator==(const ActiveTestStep &rhs) const;
 		bool operator<(const ActiveTestStep &rhs) const;
-		bool operator>(const ActiveTestStep &rhs) const;
 	};
 
 private:

--- a/source/TestContext.h
+++ b/source/TestContext.h
@@ -28,13 +28,24 @@ public:
 
 
 private:
-	// Pointer to the test we are running.
-	std::vector<const Test *> testToRun;
+	// Struct to describe a running test and running test-step within the test.
+	struct ActiveTestStep{
+		const Test *test;
+		unsigned int step;
+
+		// Support operators for usage in containers like map and set.
+		bool operator==(const ActiveTestStep &rhs) const;
+		bool operator<(const ActiveTestStep &rhs) const;
+		bool operator>(const ActiveTestStep &rhs) const;
+	};
+
+private:
+	// Reference to the currently running test and test-step within the test.
+	std::vector<ActiveTestStep> callstack;
 
 	// Teststep to run.
-	std::vector<unsigned int> stepToRun = { 0 };
 	unsigned int watchdog = 0;
-	std::set<std::vector<unsigned int>> branchesSinceGameStep;
+	std::set<ActiveTestStep> branchesSinceGameStep;
 };
 
 #endif

--- a/source/TestContext.h
+++ b/source/TestContext.h
@@ -29,7 +29,7 @@ public:
 
 private:
 	// Struct to describe a running test and running test-step within the test.
-	struct ActiveTestStep{
+	class ActiveTestStep {
 		const Test *test;
 		unsigned int step;
 

--- a/source/TestContext.h
+++ b/source/TestContext.h
@@ -28,11 +28,14 @@ public:
 
 
 private:
-	// Struct to describe a running test and running test-step within the test.
+	// Class to describe a running test and running test-step within the test.
 	class ActiveTestStep {
+	public:
 		const Test *test;
 		unsigned int step;
 
+
+	public:
 		// Support operators for usage in containers like map and set.
 		bool operator==(const ActiveTestStep &rhs) const;
 		bool operator<(const ActiveTestStep &rhs) const;


### PR DESCRIPTION
**Bugfix:** This PR addresses the review comment from https://github.com/endless-sky/endless-sky/pull/6290#discussion_r779266292

## Fix Details
Combined the variables testToRun and stepToRun in the TestContext class into single callstack variable. A single vector with both the active test and test-step is more clear than two separate vectors that are treated as one.

## Testing Done
Executed the set of integration tests.

## Save File
N/A