### PR TITLE
fix: wrong snapshot names

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -26,6 +26,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <sys/stat.h>
 #include <dirent.h>
 #include <unistd.h>
+#include <utime.h>
 
 #include <algorithm>
 #include <cstdlib>
@@ -436,12 +437,10 @@ void Files::Copy(const string &from, const string &to)
 		LogError("Error: Cannot stat \"" + from + "\".");
 	else
 	{
-#ifdef __APPLE__
-		struct timespec times[] = {buf.st_atimespec, buf.st_mtimespec};
-#else
-		struct timespec times[] = {buf.st_atim, buf.st_mtim};
-#endif
-		if(utimensat(0, to.c_str(), times, 0))
+		struct utimbuf times;
+		times.actime = buf.st_atime;
+		times.modtime = buf.st_mtime;
+		if(utime(to.c_str(), &times))
 			LogError("Error: Failed to preserve the timestamps for \"" + to + "\".");
 	}
 #endif

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -26,7 +26,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <sys/stat.h>
 #include <dirent.h>
 #include <unistd.h>
-#include <utime.h>
 
 #include <algorithm>
 #include <cstdlib>
@@ -437,10 +436,8 @@ void Files::Copy(const string &from, const string &to)
 		LogError("Error: Cannot stat \"" + from + "\".");
 	else
 	{
-		struct utimbuf times;
-		times.actime = buf.st_atime;
-		times.modtime = buf.st_mtime;
-		if(utime(to.c_str(), &times))
+		struct timespec times[] = {buf.st_atim, buf.st_mtim};
+		if(utimensat(0, to.c_str(), times, 0))
 			LogError("Error: Failed to preserve the timestamps for \"" + to + "\".");
 	}
 #endif

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -436,7 +436,11 @@ void Files::Copy(const string &from, const string &to)
 		LogError("Error: Cannot stat \"" + from + "\".");
 	else
 	{
+#ifdef __APPLE__
+		struct timespec times[] = {buf.st_atimespec, buf.st_mtimespec};
+#else
 		struct timespec times[] = {buf.st_atim, buf.st_mtim};
+#endif
 		if(utimensat(0, to.c_str(), times, 0))
 			LogError("Error: Failed to preserve the timestamps for \"" + to + "\".");
 	}

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -26,6 +26,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <sys/stat.h>
 #include <dirent.h>
 #include <unistd.h>
+#include <utime.h>
 
 #include <algorithm>
 #include <cstdlib>
@@ -430,6 +431,18 @@ void Files::Copy(const string &from, const string &to)
 	CopyFileW(Utf8::ToUTF16(from).c_str(), Utf8::ToUTF16(to).c_str(), false);
 #else
 	Write(to, Read(from));
+	// Preserve the timestamps
+	struct stat buf;
+	if(stat(from.c_str(), &buf))
+		LogError("Cannot stat \"" + from + "\"");
+	else
+	{
+		struct utimbuf times;
+		times.actime = buf.st_atime;
+		times.modtime = buf.st_mtime;
+		if(utime(to.c_str(), &times))
+			LogError("Failed to preserve the timestamps for \"" + to + "\"");
+	}
 #endif
 }
 

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -431,17 +431,17 @@ void Files::Copy(const string &from, const string &to)
 	CopyFileW(Utf8::ToUTF16(from).c_str(), Utf8::ToUTF16(to).c_str(), false);
 #else
 	Write(to, Read(from));
-	// Preserve the timestamps
+	// Preserve the timestamps of the original file.
 	struct stat buf;
 	if(stat(from.c_str(), &buf))
-		LogError("Cannot stat \"" + from + "\"");
+		LogError("Error: Cannot stat \"" + from + "\".");
 	else
 	{
 		struct utimbuf times;
 		times.actime = buf.st_atime;
 		times.modtime = buf.st_mtime;
 		if(utime(to.c_str(), &times))
-			LogError("Failed to preserve the timestamps for \"" + to + "\"");
+			LogError("Error: Failed to preserve the timestamps for \"" + to + "\".");
 	}
 #endif
 }

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -421,7 +421,7 @@ void LoadPanel::UpdateLists()
 		sort(it.second.begin(), it.second.end(),
 			[](const pair<string, time_t> &a, const pair<string, time_t> &b) -> bool
 			{
-				return a.second > b.second;
+				return a.second > b.second || (a.second == b.second && a.first < b.first);
 			}
 		);
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6468

## Fix Details
This fix uses the pilot's name as a prefix for the new snapshot.
