### PR TITLE
Correctly draw ships with custom swizzles inside the map panel.

### DIFF
--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -244,7 +244,7 @@ void MapOutfitterPanel::DrawItems()
 				: storedInSystem == 1
 				? "One unit in storage"
 				: Format::Number(storedInSystem) + " units in storage";
-			Draw(corner, outfit->Thumbnail(), isForSale, outfit == selected,
+			Draw(corner, outfit->Thumbnail(), 0, isForSale, outfit == selected,
 				outfit->Name(), price, info, storage_details);
 			list.push_back(outfit);
 		}

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -55,8 +55,6 @@ MapSalesPanel::MapSalesPanel(PlayerInfo &player, bool isOutfitters)
 	isOutfitters(isOutfitters),
 	collapsed(player.Collapsed(isOutfitters ? "outfitter map" : "shipyard map"))
 {
-	if(!isOutfitters)
-		swizzle = GameData::PlayerGovernment()->GetSwizzle();
 }
 
 
@@ -68,8 +66,6 @@ MapSalesPanel::MapSalesPanel(const MapPanel &panel, bool isOutfitters)
 	collapsed(player.Collapsed(isOutfitters ? "outfitter map" : "shipyard map"))
 {
 	commodity = SHOW_SPECIAL;
-	if(!isOutfitters)
-		swizzle = GameData::PlayerGovernment()->GetSwizzle();
 }
 
 
@@ -195,6 +191,20 @@ bool MapSalesPanel::Scroll(double dx, double dy)
 
 
 
+int MapSalesPanel::SelectedSpriteSwizzle() const
+{
+	return 0;
+}
+
+
+
+int MapSalesPanel::CompareSpriteSwizzle() const
+{
+	return 0;
+}
+
+
+
 void MapSalesPanel::DrawKey() const
 {
 	const Sprite *back = SpriteSet::Get("ui/sales key");
@@ -294,13 +304,13 @@ void MapSalesPanel::DrawInfo() const
 			topLeft.X() += compareInfo.PanelWidth() + box->Width();
 
 			SpriteShader::Draw(box, topLeft + Point(-50., 100.));
-			DrawSprite(topLeft + Point(-95., 5.), SelectedSprite());
-			DrawSprite(topLeft + Point(-95., 105.), CompareSprite());
+			DrawSprite(topLeft + Point(-95., 5.), SelectedSprite(), SelectedSpriteSwizzle());
+			DrawSprite(topLeft + Point(-95., 105.), CompareSprite(), CompareSpriteSwizzle());
 		}
 		else
 		{
 			SpriteShader::Draw(box, topLeft + Point(-60., 50.));
-			DrawSprite(topLeft + Point(-95., 5.), SelectedSprite());
+			DrawSprite(topLeft + Point(-95., 5.), SelectedSprite(), SelectedSpriteSwizzle());
 		}
 		selectedInfo.DrawAttributes(topLeft);
 	}
@@ -329,20 +339,24 @@ bool MapSalesPanel::DrawHeader(Point &corner, const string &category)
 
 
 
-void MapSalesPanel::DrawSprite(const Point &corner, const Sprite *sprite) const
+void MapSalesPanel::DrawSprite(const Point &corner, const Sprite *sprite, int swizzle) const
 {
 	if(sprite)
 	{
 		Point iconOffset(.5 * ICON_HEIGHT, .5 * ICON_HEIGHT);
 		double scale = min(.5, min((ICON_HEIGHT - 2.) / sprite->Height(), (ICON_HEIGHT - 2.) / sprite->Width()));
+
+		// No swizzle was specified, so default to the player swizzle.
+		if(swizzle == -1)
+			swizzle = GameData::PlayerGovernment()->GetSwizzle();
 		SpriteShader::Draw(sprite, corner + iconOffset, scale, swizzle);
 	}
 }
 
 
 
-void MapSalesPanel::Draw(Point &corner, const Sprite *sprite, bool isForSale, bool isSelected,
-		const string &name, const string &price, const string &info,
+void MapSalesPanel::Draw(Point &corner, const Sprite *sprite, int swizzle, bool isForSale,
+		bool isSelected, const string &name, const string &price, const string &info,
 		const std::string &storage)
 {
 	const Font &font = FontSet::Get(14);
@@ -363,7 +377,7 @@ void MapSalesPanel::Draw(Point &corner, const Sprite *sprite, bool isForSale, bo
 		if(isSelected)
 			FillShader::Fill(corner + .5 * blockSize, blockSize, selectionColor);
 
-		DrawSprite(corner, sprite);
+		DrawSprite(corner, sprite, swizzle);
 
 		const Color &mediumColor = *GameData::Colors().Get("medium");
 		const Color &dimColor = *GameData::Colors().Get("dim");

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -64,7 +64,7 @@ protected:
 	void DrawInfo() const;
 
 	bool DrawHeader(Point &corner, const std::string &category);
-	void DrawSprite(const Point &corner, const Sprite *sprite, int swizzle = 0) const;
+	void DrawSprite(const Point &corner, const Sprite *sprite, int swizzle) const;
 	void Draw(Point &corner, const Sprite *sprite, int swizzle, bool isForSale, bool isSelected,
 		const std::string &name, const std::string &price, const std::string &info,
 		const std::string &storage = "");

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -46,6 +46,8 @@ protected:
 
 	virtual const Sprite *SelectedSprite() const = 0;
 	virtual const Sprite *CompareSprite() const = 0;
+	virtual int SelectedSpriteSwizzle() const;
+	virtual int CompareSpriteSwizzle() const;
 	virtual const ItemInfoDisplay &SelectedInfo() const = 0;
 	virtual const ItemInfoDisplay &CompareInfo() const = 0;
 	virtual const std::string &KeyLabel(int index) const = 0;
@@ -62,8 +64,8 @@ protected:
 	void DrawInfo() const;
 
 	bool DrawHeader(Point &corner, const std::string &category);
-	void DrawSprite(const Point &corner, const Sprite *sprite) const;
-	void Draw(Point &corner, const Sprite *sprite, bool isForSale, bool isSelected,
+	void DrawSprite(const Point &corner, const Sprite *sprite, int swizzle = 0) const;
+	void Draw(Point &corner, const Sprite *sprite, int swizzle, bool isForSale, bool isSelected,
 		const std::string &name, const std::string &price, const std::string &info,
 		const std::string &storage = "");
 
@@ -96,8 +98,6 @@ private:
 	std::vector<ClickZone<int>> zones;
 	int selected = -1;
 	int compare = -1;
-
-	int swizzle = 0;
 };
 
 

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -65,6 +65,20 @@ const Sprite *MapShipyardPanel::CompareSprite() const
 
 
 
+int MapShipyardPanel::SelectedSpriteSwizzle() const
+{
+	return selected->CustomSwizzle();
+}
+
+
+
+int MapShipyardPanel::CompareSpriteSwizzle() const
+{
+	return compare->CustomSwizzle();
+}
+
+
+
 const ItemInfoDisplay &MapShipyardPanel::SelectedInfo() const
 {
 	return selectedInfo;
@@ -199,7 +213,8 @@ void MapShipyardPanel::DrawItems()
 			const Sprite *sprite = ship->Thumbnail();
 			if(!sprite)
 				sprite = ship->GetSprite();
-			Draw(corner, sprite, isForSale, ship == selected, ship->ModelName(), price, info);
+			Draw(corner, sprite, ship->CustomSwizzle(), isForSale, ship == selected,
+					ship->ModelName(), price, info);
 			list.push_back(ship);
 		}
 	}

--- a/source/MapShipyardPanel.h
+++ b/source/MapShipyardPanel.h
@@ -37,6 +37,8 @@ public:
 protected:
 	virtual const Sprite *SelectedSprite() const override;
 	virtual const Sprite *CompareSprite() const override;
+	virtual int SelectedSpriteSwizzle() const override;
+	virtual int CompareSpriteSwizzle() const override;
 	virtual const ItemInfoDisplay &SelectedInfo() const override;
 	virtual const ItemInfoDisplay &CompareInfo() const override;
 	virtual const std::string &KeyLabel(int index) const override;


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported by @1010todd on the Discord.

## Fix Details

The fix involves correctly passing the custom swizzle of ships to the function that draws the thumbnails.

## Testing Done

Verified that the Emerald Sword is correctly swizzled inside the map shipyard panel as well as a few other ships with custom swizzles. Verified that outfits don't get swizzled and that the ships without a custom swizzle are swizzled according to the player's gov.