### PR TITLE
feat(balance): Lower hard requirements for cargo/passenger job visibility

### DIFF
--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -263,7 +263,7 @@ mission "Unfettered Aid [0]"
 	cargo "food (aid)" 25 2 .05
 	to offer
 		random < 40
-		"cargo space" > 80
+		"cargo space" >= 50
 		has "Ask the Hai about the Unfettered: offered"
 	source
 		government "Hai"
@@ -287,7 +287,7 @@ mission "Unfettered Aid [1]"
 	cargo "food (aid)" 30 2 .05
 	to offer
 		random < 30
-		"cargo space" > 100
+		"cargo space" > 60
 		has "Ask the Hai about the Unfettered: offered"
 	source
 		government "Hai"
@@ -311,7 +311,7 @@ mission "Unfettered Aid [2]"
 	cargo "food (aid)" 35 2 .05
 	to offer
 		random < 20
-		"cargo space" > 120
+		"cargo space" > 65
 		has "Ask the Hai about the Unfettered: offered"
 	source
 		government "Hai"
@@ -782,7 +782,7 @@ mission "Hai Family [0]"
 	passengers 2 4 .5
 	to offer
 		random < 60
-		"passenger space" > 10
+		"passenger space" >= 5
 	source
 		government "Hai"
 	destination
@@ -803,7 +803,7 @@ mission "Hai Family [1]"
 	passengers 2 4 .5
 	to offer
 		random < 40
-		"passenger space" > 10
+		"passenger space" >= 5
 	source
 		government "Hai"
 	destination
@@ -1066,7 +1066,7 @@ mission "Hai Large Bulk Delivery [0]"
 	cargo random 50 3 .02
 	to offer
 		random < 60
-		"cargo space" > 160
+		"cargo space" > 100
 	source
 		government "Hai"
 	destination
@@ -1087,7 +1087,7 @@ mission "Hai Large Bulk Delivery [1]"
 	cargo random 50 3 .02
 	to offer
 		random < 50
-		"cargo space" > 160
+		"cargo space" > 100
 	source
 		government "Hai"
 	destination
@@ -1108,7 +1108,7 @@ mission "Hai Large Bulk Delivery [2]"
 	cargo random 50 3 .02
 	to offer
 		random < 40
-		"cargo space" > 160
+		"cargo space" > 100
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
@@ -1217,7 +1217,7 @@ mission "Hai Large Rush Delivery [0]"
 	cargo random 30 8 .1
 	to offer
 		random < 80
-		"cargo space" > 80
+		"cargo space" >= 50
 	source
 		government "Hai"
 	destination
@@ -1239,7 +1239,7 @@ mission "Hai Large Rush Delivery [1]"
 	cargo random 30 8 .1
 	to offer
 		random < 60
-		"cargo space" > 80
+		"cargo space" >= 50
 	source
 		government "Hai"
 	destination
@@ -1261,7 +1261,7 @@ mission "Hai Large Rush Delivery [2]"
 	cargo random 30 8 .1
 	to offer
 		random < 40
-		"cargo space" > 80
+		"cargo space" >= 50
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"
@@ -1284,7 +1284,7 @@ mission "Hai Large Rush Delivery [3]"
 	cargo random 30 8 .1
 	to offer
 		random < 30
-		"cargo space" > 80
+		"cargo space" >= 50
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Hai"

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -2009,7 +2009,7 @@ mission "Family [0]"
 	passengers 2 4 .5
 	to offer
 		random < 60
-		"passenger space" > 10
+		"passenger space" >= 5
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2030,7 +2030,7 @@ mission "Family [1]"
 	passengers 2 4 .5
 	to offer
 		random < 50
-		"passenger space" > 10
+		"passenger space" >= 5
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2051,7 +2051,7 @@ mission "Family [2]"
 	passengers 2 4 .5
 	to offer
 		random < 40
-		"passenger space" > 10
+		"passenger space" >= 5
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2072,7 +2072,7 @@ mission "Family [3]"
 	passengers 2 4 .5
 	to offer
 		random < 30
-		"passenger space" > 10
+		"passenger space" >= 5
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2093,7 +2093,7 @@ mission "Strike Breakers [mining]"
 	passengers 5 5 .2
 	to offer
 		random < 10
-		"passenger space" > 20
+		"passenger space" > 15
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2115,7 +2115,7 @@ mission "Strike Breakers [textile]"
 	passengers 5 5 .2
 	to offer
 		random < 10
-		"passenger space" > 20
+		"passenger space" > 15
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2137,7 +2137,7 @@ mission "Strike Breakers [factory]"
 	passengers 5 5 .2
 	to offer
 		random < 10
-		"passenger space" > 20
+		"passenger space" > 15
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2182,7 +2182,7 @@ mission "Colonists [1]"
 	passengers 10 4 .1
 	to offer
 		random < 20
-		"passenger space" > 30
+		"passenger space" > 20
 	source
 		attributes "urban" "near earth" "core" "factory"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -2206,7 +2206,7 @@ mission "Stranded Field Trip"
 	cargo "educational supplies" 2 10 .6
 	to offer
 		random < 10
-		"passenger space" > 50
+		"passenger space" > 30
 	source
 		attributes "near earth" "deep" "paradise" "tourism"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -2409,7 +2409,7 @@ mission "Large Bulk Delivery [0]"
 	cargo random 40 2 .02
 	to offer
 		random < 70
-		"cargo space" > 160
+		"cargo space" > 100
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2430,7 +2430,7 @@ mission "Large Bulk Delivery [1]"
 	cargo random 40 2 .02
 	to offer
 		random < 60
-		"cargo space" > 160
+		"cargo space" > 100
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2451,7 +2451,7 @@ mission "Large Bulk Delivery [2]"
 	cargo random 40 2 .02
 	to offer
 		random < 50
-		"cargo space" > 160
+		"cargo space" > 100
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -2474,7 +2474,7 @@ mission "Large Rush Delivery [0]"
 	cargo random 20 6 .1
 	to offer
 		random < 90
-		"cargo space" > 80
+		"cargo space" >= 50
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2496,7 +2496,7 @@ mission "Large Rush Delivery [1]"
 	cargo random 20 6 .1
 	to offer
 		random < 80
-		"cargo space" > 80
+		"cargo space" >= 50
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2518,7 +2518,7 @@ mission "Large Rush Delivery [2]"
 	cargo random 20 6 .1
 	to offer
 		random < 70
-		"cargo space" > 80
+		"cargo space" >= 50
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -2541,7 +2541,7 @@ mission "Large Rush Delivery [3]"
 	cargo random 20 6 .1
 	to offer
 		random < 60
-		"cargo space" > 80
+		"cargo space" >= 50
 	source
 		attributes "mining" "textiles" "factory" "farming" "fishing" "oil"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -430,7 +430,7 @@ mission "Paradise Job: Parolees"
 	passengers 20 4 .1
 	to offer
 		random < 15
-		"passenger space" > 50
+		"passenger space" > 40
 	on offer
 		require "Brig"
 	source
@@ -454,7 +454,7 @@ mission "Paradise Job: Debtors"
 	passengers 20 4 .1
 	to offer
 		random < 15
-		"passenger space" > 50
+		"passenger space" > 40
 	on offer
 		require "Brig"
 	source
@@ -478,13 +478,10 @@ mission "Paradise Job: Retirees"
 	passengers 7 12 .6
 	cargo "treasured possessions" 7 12 .2
 	to offer
-		random < 10
-		"passenger space" > 30
-		"cargo space" > 120
+		"passenger space" > 15
+		"cargo space" > 40
 	on offer
 		require "Luxury Accommodations"
-	source
-		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest" "urban"
 	destination
 		distance 3 16
 		attributes "paradise"
@@ -503,7 +500,7 @@ mission "Paradise Job: Wilderness Retreat"
 	passengers 10 4 .1
 	to offer
 		random < 10
-		"passenger space" > 30
+		"passenger space" > 25
 	on offer
 		require "Luxury Accommodations"
 	source

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -478,10 +478,13 @@ mission "Paradise Job: Retirees"
 	passengers 7 12 .6
 	cargo "treasured possessions" 7 12 .2
 	to offer
+		random < 10
 		"passenger space" > 15
 		"cargo space" > 40
 	on offer
 		require "Luxury Accommodations"
+	source
+		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest" "urban"
 	destination
 		distance 3 16
 		attributes "paradise"


### PR DESCRIPTION
This PR lowers the required cargo or passenger space for various jobs to spawn across human and Hai space across the board. Currently, many of these more lucrative jobs are completely invisible to players until they upgrade their ship entirely, when many of them could be within reach. In particular, Large Rush Deliveries and Family Transports can sometimes fit on a stock Star Barge/Shuttle, or otherwise fit most with an extra cargo expansion/bunk room or two. However, new players would have no idea these missions would exist until they slowly grind up much lower-paying missions and buy a whole new ship. By having these missions appear sooner, a player can tweak their ship more purposefully without blindly or accidentally stumbling into these new ones.

To make clear: This PR does not affect the quantities of any amounts of cargo/passengers in these missions, just makes them visible with lower requirements.