### PR TITLE
fix(content): Add 'on fail' dialog for Defend New Tibet

### DIFF
--- a/data/human/free worlds middle.txt
+++ b/data/human/free worlds middle.txt
@@ -2024,6 +2024,8 @@ mission "FW Defend New Tibet"
 	passengers 2
 	to offer
 		has "FW Rand 1B: done"
+	on fail
+		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
 		log "As a member of the Council, must make the deciding vote on a difficult decision. A defector from the Syndicate is claiming to have proof that the Syndicate was behind the bombings of Martini and Geminus. If that is true, the Republic may agree to make peace with the Free Worlds. But, refusing to return the defector to the Syndicate would certainly earn their enmity."


### PR DESCRIPTION
This PR adds an `on fail` dialog to Defend New Tibet, the branching point for Free Worlds to Reconciliation vs. Checkmate. I've seen at least two cases of players ending up having the mission passenger on an escort which gets destroyed in the ensuing battle, and silently being unable to continue right before the climax of the whole campaign. Having an `on fail` dialog ensures that players won't miss that it happened, and from what I can tell, it does not conflict with this mission requiring a decline to start the Checkmate branch.