### PR TITLE
Bugfix: Add cost and burst to piracy deterrence calculations

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1062,8 +1062,7 @@ pair<double, double> PlayerInfo::RaidFleetFactors() const
 				double damage = weapon->ShieldDamage() + weapon->HullDamage()
 					+ (weapon->RelativeShieldDamage() * ship->Attributes().Get("shields"))
 					+ (weapon->RelativeHullDamage() * ship->Attributes().Get("hull"));
-				deterrence += max(.12 * damage / weapon->Reload() * weapon->BurstCount(),
-						0.00006 * weapon->Cost());
+				deterrence += max(.12 * damage / weapon->Reload(), 0.00006 * weapon->Cost());
 			}
 	}
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1062,7 +1062,8 @@ pair<double, double> PlayerInfo::RaidFleetFactors() const
 				double damage = weapon->ShieldDamage() + weapon->HullDamage()
 					+ (weapon->RelativeShieldDamage() * ship->Attributes().Get("shields"))
 					+ (weapon->RelativeHullDamage() * ship->Attributes().Get("hull"));
-				deterrence += .12 * damage / weapon->Reload();
+				deterrence += max(.12 * damage / weapon->Reload() * weapon->BurstCount(),
+						0.00012 * weapon->Cost());
 			}
 	}
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1063,7 +1063,7 @@ pair<double, double> PlayerInfo::RaidFleetFactors() const
 					+ (weapon->RelativeShieldDamage() * ship->Attributes().Get("shields"))
 					+ (weapon->RelativeHullDamage() * ship->Attributes().Get("hull"));
 				deterrence += max(.12 * damage / weapon->Reload() * weapon->BurstCount(),
-						0.00012 * weapon->Cost());
+						0.00006 * weapon->Cost());
 			}
 	}
 


### PR DESCRIPTION
**Bugfix:** This PR was created instead of an issue

## Fix Details
Currently the piracy deterrence calculations don't take into account burst size. Additionally, the current formula underestimates weapons which are damaging in ways other than damage numbers, such as ion or knockback weapons.
This is most apparent with Ka'het nullifiers. As one can have a fleet of heavy warships armed with nullifiers and still get a 100% piracy chance due to the base cargo of those warships.
To solve these, the deterrence calculations now use cost as a sanity check. The multiplier of 0.00006 is derived from the stats of the sunbeam, one of the least cost-DPS effective weapons. This should not impact the deterrence of any outfit which already has a reasonable deterrence, only those whose deterrence is far less then their expected values.