### PR TITLE
Fix race conditions while loading the game.

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -861,3 +861,11 @@ map<string, shared_ptr<ImageSet>> GameData::FindImages()
 	}
 	return images;
 }
+
+
+
+// Thread-safe way to draw the menu background.
+void GameData::DrawMenuBackground(Panel *panel)
+{
+	objects.DrawMenuBackground(panel);
+}

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -41,6 +41,7 @@ class Minable;
 class Mission;
 class News;
 class Outfit;
+class Panel;
 class Person;
 class Phrase;
 class Planet;
@@ -159,6 +160,9 @@ public:
 	static MaskManager &GetMaskManager();
 
 	static const TextReplacements &GetTextReplacements();
+
+	// Thread-safe way to draw the menu background.
+	static void DrawMenuBackground(Panel *panel);
 
 
 private:

--- a/source/GameLoadingPanel.cpp
+++ b/source/GameLoadingPanel.cpp
@@ -73,7 +73,10 @@ void GameLoadingPanel::Draw()
 	glClear(GL_COLOR_BUFFER_BIT);
 	GameData::Background().Draw(Point(), Point());
 
-	GameData::Interfaces().Get("menu background")->Draw(Information(), this);
+	// The interface can only be drawn after the data files have been loaded
+	// to avoid a race condition.
+	if(GameData::IsDataLoaded())
+		GameData::Interfaces().Get("menu background")->Draw(Information(), this);
 
 	// Draw the loading circle.
 	Angle da(ANGLE_OFFSET);

--- a/source/GameLoadingPanel.cpp
+++ b/source/GameLoadingPanel.cpp
@@ -73,10 +73,7 @@ void GameLoadingPanel::Draw()
 	glClear(GL_COLOR_BUFFER_BIT);
 	GameData::Background().Draw(Point(), Point());
 
-	// The interface can only be drawn after the data files have been loaded
-	// to avoid a race condition.
-	if(GameData::IsDataLoaded())
-		GameData::Interfaces().Get("menu background")->Draw(Information(), this);
+	GameData::DrawMenuBackground(this);
 
 	// Draw the loading circle.
 	Angle da(ANGLE_OFFSET);

--- a/source/SpriteSet.cpp
+++ b/source/SpriteSet.cpp
@@ -23,7 +23,7 @@ using namespace std;
 namespace {
 	map<string, Sprite> sprites;
 
-	mutex readMutex;
+	mutex modifyMutex;
 }
 
 
@@ -51,7 +51,7 @@ void SpriteSet::CheckReferences()
 
 Sprite *SpriteSet::Modify(const string &name)
 {
-	lock_guard<mutex> guard(readMutex);
+	lock_guard<mutex> guard(modifyMutex);
 
 	auto it = sprites.find(name);
 	if(it == sprites.end())

--- a/source/SpriteSet.cpp
+++ b/source/SpriteSet.cpp
@@ -16,11 +16,14 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Sprite.h"
 
 #include <map>
+#include <mutex>
 
 using namespace std;
 
 namespace {
 	map<string, Sprite> sprites;
+
+	mutex readMutex;
 }
 
 
@@ -48,6 +51,8 @@ void SpriteSet::CheckReferences()
 
 Sprite *SpriteSet::Modify(const string &name)
 {
+	lock_guard<mutex> guard(readMutex);
+
 	auto it = sprites.find(name);
 	if(it == sprites.end())
 		it = sprites.emplace(name, Sprite(name)).first;

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Files.h"
 #include "text/FontSet.h"
 #include "ImageSet.h"
+#include "Information.h"
 #include "MaskManager.h"
 #include "Music.h"
 #include "PlayerInfo.h"
@@ -311,7 +312,18 @@ void UniverseObjects::LoadFile(const string &path, bool debugMode)
 		else if(key == "hazard" && node.Size() >= 2)
 			hazards.Get(node.Token(1))->Load(node);
 		else if(key == "interface" && node.Size() >= 2)
-			interfaces.Get(node.Token(1))->Load(node);
+		{
+			Interface *interface = interfaces.Get(node.Token(1));
+			interface->Load(node);
+
+			// If we modified the "menu background" interface, then
+			// we also update our cache of it.
+			if(node.Token(1) == "menu background")
+			{
+				lock_guard<mutex> lock(menuBackgroundMutex);
+				menuBackgroundCache = *interface;
+			}
+		}
 		else if(key == "minable" && node.Size() >= 2)
 			minables.Get(node.Token(1))->Load(node);
 		else if(key == "mission" && node.Size() >= 2)
@@ -431,4 +443,12 @@ void UniverseObjects::LoadFile(const string &path, bool debugMode)
 		else
 			node.PrintTrace("Skipping unrecognized root object:");
 	}
+}
+
+
+
+void UniverseObjects::DrawMenuBackground(Panel *panel) const
+{
+	lock_guard<mutex> lock(menuBackgroundMutex);
+	menuBackgroundCache.Draw(Information(), panel);
 }

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -313,15 +313,14 @@ void UniverseObjects::LoadFile(const string &path, bool debugMode)
 			hazards.Get(node.Token(1))->Load(node);
 		else if(key == "interface" && node.Size() >= 2)
 		{
-			Interface *interface = interfaces.Get(node.Token(1));
-			interface->Load(node);
+			interfaces.Get(node.Token(1))->Load(node);
 
 			// If we modified the "menu background" interface, then
 			// we also update our cache of it.
 			if(node.Token(1) == "menu background")
 			{
 				lock_guard<mutex> lock(menuBackgroundMutex);
-				menuBackgroundCache = *interface;
+				menuBackgroundCache = *interfaces.Get(node.Token(1));
 			}
 		}
 		else if(key == "minable" && node.Size() >= 2)

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -320,7 +320,7 @@ void UniverseObjects::LoadFile(const string &path, bool debugMode)
 			if(node.Token(1) == "menu background")
 			{
 				lock_guard<mutex> lock(menuBackgroundMutex);
-				menuBackgroundCache = *interfaces.Get(node.Token(1));
+				menuBackgroundCache.Load(node);
 			}
 		}
 		else if(key == "minable" && node.Size() >= 2)

--- a/source/UniverseObjects.h
+++ b/source/UniverseObjects.h
@@ -47,6 +47,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <vector>
 
 
+class Panel;
 class Sprite;
 
 
@@ -72,6 +73,10 @@ public:
 
 	// Check for objects that are referred to but never defined.
 	void CheckReferences();
+
+	// Draws the current menu background. Unlike accessing the menu background
+	// through GameData, this function is thread-safe.
+	void DrawMenuBackground(Panel *panel) const;
 
 
 private:
@@ -120,7 +125,9 @@ private:
 	std::map<std::string, std::string> tooltips;
 	std::map<std::string, std::string> helpMessages;
 
-
+	// A local cache of the menu background interface for thread-safe access.
+	mutable std::mutex menuBackgroundMutex;
+	Interface menuBackgroundCache;
 };
 
 


### PR DESCRIPTION
## Fix Details

#6279 introduced 2 race conditions while loading. The first one is when drawing the interface in `GameLoadingPanel::Draw` and the second one is concurrent read/writes in `SpriteSet::Modify` called by data objects that store a pointer to a sprite and the sprite loading threads from `SpriteQueue`.

My bad for not catching this earlier.


## Testing Done

Used the thread sanitizer to verify that there are no more race conditions while loading the game.

## Performance Impact

Any access to sprites is now guarded by a mutex, but it shouldn't have a measurable effect on performance I believe (I didn't profile, but CPU load is the same). Most uses of SpriteSet cache the actual Sprite pointer, circumventing the lock. The cases where SpriteSet is used every frame are for various UI elements, so there aren't a lot of locks being taken. Additionally, locking an unconstested mutex, while not free, is pretty cheap.