### PR TITLE
Fix: Updating Ssil Vida Alert Hologram's copyright

### DIFF
--- a/copyright
+++ b/copyright
@@ -1223,7 +1223,7 @@ Comment: Derived from works by Michael Zahniser (under the same license).
 
 Files:
  images/scene/ssil?vida?alert?hologram*
-Copyright: Jeverett (jeverett on Discord)
+Copyright: J Everett Nichol (jeverett on Discord)
 License: CC-BY-SA-3.0
 Comment: Derived from works by Becca Tommaso (under the same license).
 


### PR DESCRIPTION
**Correction:**

## Fix Details
This corrects the copyright from just being the author's Discord handle, to actually being the name they would like to have attributed to their work.

(Thanks J Everett Nichol for the awesome scene. I'm very glad to have it in the mission!)

(They just got back to me with what name they wanted the copyright attributed to)