### PR TITLE
feat: Remove PlayerInfo dependency from ship / Move hail-subs to PlayerInfo

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1776,9 +1776,7 @@ void Engine::SendHails()
 		return;
 
 	// Generate a random hail message.
-	map<string, string> stubs;
-	player.FillHailSubs(stubs);
-	SendMessage(source, source->GetHail(stubs));
+	SendMessage(source, source->GetHail(player.GetSubstitutions()));
 }
 
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1776,7 +1776,9 @@ void Engine::SendHails()
 		return;
 
 	// Generate a random hail message.
-	SendMessage(source, source->GetHail(player));
+	map<string, string> stubs;
+	player.FillHailSubs(stubs);
+	SendMessage(source, source->GetHail(stubs));
 }
 
 

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -114,7 +114,11 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<
 	}
 
 	if(message.empty())
-		message = ship->GetHail(player);
+	{
+		map<string, string> stubs;
+		player.FillHailSubs(stubs);
+		message = ship->GetHail(stubs);
+	}
 }
 
 

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -114,11 +114,7 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<
 	}
 
 	if(message.empty())
-	{
-		map<string, string> stubs;
-		player.FillHailSubs(stubs);
-		message = ship->GetHail(stubs);
-	}
+		message = ship->GetHail(player.GetSubstitutions());
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1875,8 +1875,9 @@ void PlayerInfo::CheckReputationConditions()
 
 
 
-void PlayerInfo::FillHailSubs(map<string, string> &subs)
+map<string, string> PlayerInfo::GetSubstitutions()
 {
+	map<string, string> subs;
 	GameData::GetTextReplacements().Substitutions(subs, Conditions());
 
 	subs["<first>"] = FirstName();
@@ -1887,6 +1888,7 @@ void PlayerInfo::FillHailSubs(map<string, string> &subs)
 	subs["<system>"] = GetSystem()->Name();
 	subs["<date>"] = GetDate().ToString();
 	subs["<day>"] = GetDate().LongString();
+	return subs;
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1875,7 +1875,7 @@ void PlayerInfo::CheckReputationConditions()
 
 
 
-map<string, string> PlayerInfo::GetSubstitutions()
+map<string, string> PlayerInfo::GetSubstitutions() const
 {
 	map<string, string> subs;
 	GameData::GetTextReplacements().Substitutions(subs, Conditions());

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1875,6 +1875,22 @@ void PlayerInfo::CheckReputationConditions()
 
 
 
+void PlayerInfo::FillHailSubs(map<string, string> &subs)
+{
+	GameData::GetTextReplacements().Substitutions(subs, Conditions());
+
+	subs["<first>"] = FirstName();
+	subs["<last>"] = LastName();
+	if(Flagship())
+		subs["<ship>"] = Flagship()->Name();
+
+	subs["<system>"] = GetSystem()->Name();
+	subs["<date>"] = GetDate().ToString();
+	subs["<day>"] = GetDate().LongString();
+}
+
+
+
 // Check if the player knows the location of the given system (whether or not
 // they have actually visited it).
 bool PlayerInfo::HasSeen(const System &system) const

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -211,6 +211,7 @@ public:
 	// can use to modify the player's reputation with other governments.
 	void SetReputationConditions();
 	void CheckReputationConditions();
+	void FillHailSubs(std::map<std::string, std::string> &subs);
 
 	// Check what the player knows about the given system or planet.
 	bool HasSeen(const System &system) const;

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -211,7 +211,7 @@ public:
 	// can use to modify the player's reputation with other governments.
 	void SetReputationConditions();
 	void CheckReputationConditions();
-	void FillHailSubs(std::map<std::string, std::string> &subs);
+	std::map<std::string, std::string> GetSubstitutions();
 
 	// Check what the player knows about the given system or planet.
 	bool HasSeen(const System &system) const;

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -211,7 +211,7 @@ public:
 	// can use to modify the player's reputation with other governments.
 	void SetReputationConditions();
 	void CheckReputationConditions();
-	std::map<std::string, std::string> GetSubstitutions();
+	std::map<std::string, std::string> GetSubstitutions() const;
 
 	// Check what the player knows about the given system or planet.
 	bool HasSeen(const System &system) const;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -26,7 +26,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Messages.h"
 #include "Phrase.h"
 #include "Planet.h"
-#include "PlayerInfo.h"
 #include "Preferences.h"
 #include "Projectile.h"
 #include "Random.h"
@@ -1322,26 +1321,14 @@ void Ship::SetHail(const Phrase &phrase)
 
 
 
-string Ship::GetHail(const PlayerInfo &player) const
+string Ship::GetHail(map<string, string> &subs) const
 {
 	string hailStr = hail ? hail->Get() : government ? government->GetHail(isDisabled) : "";
 
 	if(hailStr.empty())
 		return hailStr;
 
-	map<string, string> subs;
-	GameData::GetTextReplacements().Substitutions(subs, player.Conditions());
-
-	subs["<first>"] = player.FirstName();
-	subs["<last>"] = player.LastName();
-	if(player.Flagship())
-		subs["<ship>"] = player.Flagship()->Name();
-
 	subs["<npc>"] = Name();
-	subs["<system>"] = player.GetSystem()->Name();
-	subs["<date>"] = player.GetDate().ToString();
-	subs["<day>"] = player.GetDate().LongString();
-
 	return Format::Replace(hailStr, subs);
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1321,7 +1321,7 @@ void Ship::SetHail(const Phrase &phrase)
 
 
 
-string Ship::GetHail(map<string, string> subs) const
+string Ship::GetHail(map<string, string> &&subs) const
 {
 	string hailStr = hail ? hail->Get() : government ? government->GetHail(isDisabled) : "";
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1321,7 +1321,7 @@ void Ship::SetHail(const Phrase &phrase)
 
 
 
-string Ship::GetHail(map<string, string> &subs) const
+string Ship::GetHail(map<string, string> subs) const
 {
 	string hailStr = hail ? hail->Get() : government ? government->GetHail(isDisabled) : "";
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -39,7 +39,6 @@ class Government;
 class Minable;
 class Phrase;
 class Planet;
-class PlayerInfo;
 class Projectile;
 class StellarObject;
 class System;
@@ -183,7 +182,7 @@ public:
 	// Get a random hail message, or set the object used to generate them. If no
 	// object is given the government's default will be used.
 	void SetHail(const Phrase &phrase);
-	std::string GetHail(const PlayerInfo &player) const;
+	std::string GetHail(std::map<std::string, std::string> &subs) const;
 
 	// Set the commands for this ship to follow this timestep.
 	void SetCommands(const Command &command);

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -182,7 +182,7 @@ public:
 	// Get a random hail message, or set the object used to generate them. If no
 	// object is given the government's default will be used.
 	void SetHail(const Phrase &phrase);
-	std::string GetHail(std::map<std::string, std::string> &subs) const;
+	std::string GetHail(std::map<std::string, std::string> subs) const;
 
 	// Set the commands for this ship to follow this timestep.
 	void SetCommands(const Command &command);

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -182,7 +182,7 @@ public:
 	// Get a random hail message, or set the object used to generate them. If no
 	// object is given the government's default will be used.
 	void SetHail(const Phrase &phrase);
-	std::string GetHail(std::map<std::string, std::string> subs) const;
+	std::string GetHail(std::map<std::string, std::string> &&subs) const;
 
 	// Set the commands for this ship to follow this timestep.
 	void SetCommands(const Command &command);


### PR DESCRIPTION
**Feature:** This PR implements part of the feature implemented in #6502

## Feature Details
This PR moves the filling of the subs for hailing from Ship to PlayerInfo. This move results in Ship no longer needing to include PlayerInfo.h and it removes a reference to GameData from Ship.
This change is split off from #6502 because it can be described, tested and merged standalone.

## UI Screenshots
N/A (the game should still look the same)

## Usage Examples
N/A (code change only)

## Testing Done
I tested by replacing the `data/human/hails.txt` file by [hails.txt](https://github.com/endless-sky/endless-sky/files/7920320/hails.txt) and then hailing a friendly civilian ship during flight. The text-replacements showed up as expected.

## Performance Impact
No impact is expected, the handling of empty hails could theoretically be a bit slower (since the subs now get generated, even if we don't use them), but we typically don't have many empty hails in the game so practical impact is expected to be none.