### PR TITLE
feat: Generate Ship::equipped on demand instead of on load

### DIFF
--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -176,6 +176,18 @@ const vector<Hardpoint> &Armament::Get() const
 
 
 
+// Get an overview of how many weapon-outfits are equipped.
+std::map<const Outfit *, int> Armament::GetEquipped() const
+{
+	map<const Outfit *, int> equipped;
+	for(const Hardpoint &hardpoint : hardpoints)
+		if(hardpoint.GetOutfit())
+			++equipped[hardpoint.GetOutfit()];
+	return equipped;
+}
+
+
+
 // Determine how many fixed gun hardpoints are on this ship.
 int Armament::GunCount() const
 {

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -178,18 +178,6 @@ const vector<Hardpoint> &Armament::Get() const
 
 
 
-// Get an overview of how many weapon-outfits are equipped.
-std::map<const Outfit *, int> Armament::GetEquipped() const
-{
-	map<const Outfit *, int> equipped;
-	for(const Hardpoint &hardpoint : hardpoints)
-		if(hardpoint.GetOutfit())
-			++equipped[hardpoint.GetOutfit()];
-	return equipped;
-}
-
-
-
 // Determine how many fixed gun hardpoints are on this ship.
 int Armament::GunCount() const
 {

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -45,7 +45,7 @@ public:
 	// of a given weapon than there are slots for it, the extras will not fire.
 	// But, the "gun ports" attribute should keep that from happening. To
 	// remove a weapon, just pass a negative value here.
-	void Add(const Outfit *outfit, int count = 1);
+	int Add(const Outfit *outfit, int count = 1);
 	// Call this once all the outfits have been loaded to make sure they are all
 	// set up properly (even the ones that were pre-assigned to a hardpoint).
 	void FinishLoading();

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -59,6 +59,7 @@ public:
 
 	// Access the array of weapon hardpoints.
 	const std::vector<Hardpoint> &Get() const;
+	std::map<const Outfit *, int> GetEquipped() const;
 	int GunCount() const;
 	int TurretCount() const;
 

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -59,7 +59,6 @@ public:
 
 	// Access the array of weapon hardpoints.
 	const std::vector<Hardpoint> &Get() const;
-	std::map<const Outfit *, int> GetEquipped() const;
 	int GunCount() const;
 	int TurretCount() const;
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -552,7 +552,9 @@ void Ship::FinishLoading(bool isNewInstance)
 	auto equipped = armament.GetEquipped();
 	for(auto &it : equipped)
 	{
-		int excess = it.second - outfits[it.first];
+		auto outfitIt = outfits.find(it.first);
+		int nrOutfits = (outfitIt != outfits.end() ? outfitIt->second : 0);
+		int excess = it.second - nrOutfits;
 		if(excess > 0)
 		{
 			// If there are more hardpoints specifying this outfit than there

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -618,7 +618,15 @@ void Ship::FinishLoading(bool isNewInstance)
 				count -= eit->second;
 
 			if(count)
-				armament.Add(it.first, count);
+				count -= armament.Add(it.first, count);
+			if(count)
+			{
+				string warning = modelName;
+				if(!name.empty())
+					warning += " \"" + name + "\"";
+				warning += ": weapon \"" + it.first->Name() + "\" installed, but insufficient slots to use it.";
+				Files::LogError(warning);
+			}
 		}
 	}
 	if(!undefinedOutfits.empty())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -580,13 +580,13 @@ void Ship::FinishLoading(bool isNewInstance)
 			armament.Add(it.first, -excess);
 			it.second -= excess;
 
-			LogWarning(ModelName(), Name(), std::move("outfit \"" + it.first->Name() + "\" equipped but not included in outfit list."));
+			LogWarning(VariantName(), Name(), std::move("outfit \"" + it.first->Name() + "\" equipped but not included in outfit list."));
 		}
 		else if(!it.first->IsWeapon())
 			// This ship was specified with a non-weapon outfit in a
 			// hardpoint. Hardpoint::Install removes it, but issue a
 			// warning so the definition can be fixed.
-			LogWarning(ModelName(), Name(), std::move("outfit \"" + it.first->Name() + "\" is not a weapon, but is installed as one."));
+			LogWarning(VariantName(), Name(), std::move("outfit \"" + it.first->Name() + "\" is not a weapon, but is installed as one."));
 	}
 
 	// Mark any drone that has no "automaton" value as an automaton, to
@@ -629,7 +629,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			{
 				count -= armament.Add(it.first, count);
 				if(count)
-					LogWarning(ModelName(), Name(), std::move("weapon \"" + it.first->Name() + "\" installed, but insufficient slots to use it."));
+					LogWarning(VariantName(), Name(), std::move("weapon \"" + it.first->Name() + "\" installed, but insufficient slots to use it."));
 			}
 		}
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -142,10 +142,8 @@ namespace {
 
 	void LogWarning(const string &modelName, const string &name, string &&warning)
 	{
-		string shipID = modelName;
-		if(!name.empty())
-			shipID += " \"" + name + "\"";
-		Files::LogError(shipID + ": " + warning);
+		string shipID = modelName + (name.empty() ? ": " : " \"" + name + "\": ");
+		Files::LogError(shipID + std::move(warning));
 	}
 }
 
@@ -580,13 +578,13 @@ void Ship::FinishLoading(bool isNewInstance)
 			armament.Add(it.first, -excess);
 			it.second -= excess;
 
-			LogWarning(VariantName(), Name(), std::move("outfit \"" + it.first->Name() + "\" equipped but not included in outfit list."));
+			LogWarning(VariantName(), Name(), "outfit \"" + it.first->Name() + "\" equipped but not included in outfit list.");
 		}
 		else if(!it.first->IsWeapon())
 			// This ship was specified with a non-weapon outfit in a
 			// hardpoint. Hardpoint::Install removes it, but issue a
 			// warning so the definition can be fixed.
-			LogWarning(VariantName(), Name(), std::move("outfit \"" + it.first->Name() + "\" is not a weapon, but is installed as one."));
+			LogWarning(VariantName(), Name(), "outfit \"" + it.first->Name() + "\" is not a weapon, but is installed as one.");
 	}
 
 	// Mark any drone that has no "automaton" value as an automaton, to
@@ -629,7 +627,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			{
 				count -= armament.Add(it.first, count);
 				if(count)
-					LogWarning(VariantName(), Name(), std::move("weapon \"" + it.first->Name() + "\" installed, but insufficient slots to use it."));
+					LogWarning(VariantName(), Name(), "weapon \"" + it.first->Name() + "\" installed, but insufficient slots to use it.");
 			}
 		}
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -553,8 +553,8 @@ void Ship::FinishLoading(bool isNewInstance)
 	for(auto &it : equipped)
 	{
 		auto outfitIt = outfits.find(it.first);
-		int nrOutfits = (outfitIt != outfits.end() ? outfitIt->second : 0);
-		int excess = it.second - nrOutfits;
+		int amount = (outfitIt != outfits.end() ? outfitIt->second : 0);
+		int excess = it.second - amount;
 		if(excess > 0)
 		{
 			// If there are more hardpoints specifying this outfit than there

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -580,13 +580,13 @@ void Ship::FinishLoading(bool isNewInstance)
 			armament.Add(it.first, -excess);
 			it.second -= excess;
 
-			LogWarning(modelName, name, std::move("outfit \"" + it.first->Name() + "\" equipped but not included in outfit list."));
+			LogWarning(ModelName(), Name(), std::move("outfit \"" + it.first->Name() + "\" equipped but not included in outfit list."));
 		}
 		else if(!it.first->IsWeapon())
 			// This ship was specified with a non-weapon outfit in a
 			// hardpoint. Hardpoint::Install removes it, but issue a
 			// warning so the definition can be fixed.
-			LogWarning(modelName, name, std::move("outfit \"" + it.first->Name() + "\" is not a weapon, but is installed as one."));
+			LogWarning(ModelName(), Name(), std::move("outfit \"" + it.first->Name() + "\" is not a weapon, but is installed as one."));
 	}
 
 	// Mark any drone that has no "automaton" value as an automaton, to
@@ -629,7 +629,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			{
 				count -= armament.Add(it.first, count);
 				if(count)
-					LogWarning(modelName, name, std::move("weapon \"" + it.first->Name() + "\" installed, but insufficient slots to use it."));
+					LogWarning(ModelName(), Name(), std::move("weapon \"" + it.first->Name() + "\" installed, but insufficient slots to use it."));
 			}
 		}
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -140,7 +140,7 @@ namespace {
 		return equipped;
 	}
 
-	void LogWarning(const string &modelName, const string &name, const string &warning)
+	void LogWarning(const string &modelName, const string &name, string &&warning)
 	{
 		string shipID = modelName;
 		if(!name.empty())
@@ -580,13 +580,13 @@ void Ship::FinishLoading(bool isNewInstance)
 			armament.Add(it.first, -excess);
 			it.second -= excess;
 
-			LogWarning(modelName, name, "outfit \"" + it.first->Name() + "\" equipped but not included in outfit list.");
+			LogWarning(modelName, name, std::move("outfit \"" + it.first->Name() + "\" equipped but not included in outfit list."));
 		}
 		else if(!it.first->IsWeapon())
 			// This ship was specified with a non-weapon outfit in a
 			// hardpoint. Hardpoint::Install removes it, but issue a
 			// warning so the definition can be fixed.
-			LogWarning(modelName, name, ": outfit \"" + it.first->Name() + "\" is not a weapon, but is installed as one.");
+			LogWarning(modelName, name, std::move("outfit \"" + it.first->Name() + "\" is not a weapon, but is installed as one."));
 	}
 
 	// Mark any drone that has no "automaton" value as an automaton, to
@@ -629,7 +629,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			{
 				count -= armament.Add(it.first, count);
 				if(count)
-					LogWarning(modelName, name, "weapon \"" + it.first->Name() + "\" installed, but insufficient slots to use it.");
+					LogWarning(modelName, name, std::move("weapon \"" + it.first->Name() + "\" installed, but insufficient slots to use it."));
 			}
 		}
 	}

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -509,9 +509,6 @@ private:
 	std::vector<EnginePoint> reverseEnginePoints;
 	std::vector<EnginePoint> steeringEnginePoints;
 	Armament armament;
-	// While loading, keep track of which outfits already have been equipped.
-	// (That is, they were specified as linked to a given gun or turret point.)
-	std::map<const Outfit *, int> equipped;
 
 	// Various energy levels:
 	double shields = 0.;


### PR DESCRIPTION
**Feature:** This PR changes the Ship::equipped vector to be generated on demand

## Feature Details
The Ship::equipped vector was generated during loading, but it was also possible to generate the numbers directly from ship.armament. Using generation makes the code a little bit simpler and benefits changes like moving the ship-loading to a different class (as is being done in #6502)

Testing this feature showed that some warnings were missing (also in the original code before this PR), the missing warnings were added.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Tested the new feature with the attached [tests_equipped.txt](https://github.com/endless-sky/endless-sky/files/7921010/tests_equipped.txt) datafile:
- Copy the datafile to the data-directory.
- Start the game (and notice warnings for the "Messed" ships)
- Check if the ships in-game correspond to the definition.

## Performance Impact
No significant impact is expected; this change might have some minor impact on FinishLoading (due to an extra for-loop that generates the equipped data based on the hardpoints).