### PR TITLE
fix(content): Add minor tag and extra formatting to Repulsor Failure

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -3768,6 +3768,7 @@ mission "Thrall Emigration"
 
 mission "Repulsor failure"
 	landing
+	minor
 	# Don't require the player to pay credits again if the player was already allowed to land when this mission triggered.
 	clearance
 	source
@@ -3782,31 +3783,31 @@ mission "Repulsor failure"
 		conversation
 			`When you start de-orbiting, you see a warning that one of the repulsors on your ship is not working.`
 			choice
-				`(Return to orbit to fix the issue in space.)`
+				`	(Return to orbit to fix the issue in space.)`
 					launch
-				`(Attempt to land anyway.)`
+				`	(Attempt to land anyway.)`
 			`Orbital entry is a bit more steep than normal, and your ship is starting to lean a bit.`
 			choice
-				`(Try to return to orbit to fix the issue in space.)`
+				`	(Try to return to orbit to fix the issue in space.)`
 					goto reorbit
-				`(Continue the attempt to land.)`
+				`	(Continue the attempt to land.)`
 			`You're reaching the point where your ship will not be able to re-orbit on its own power. The cockpit is filled with warnings about the descent angle and attitude control.`
 			choice
-				`(Attempt to re-orbit and hope that the ship still makes it.)`
+				`	(Attempt to re-orbit and hope that the ship still makes it.)`
 					goto reorbit
-				`(Proceed with landing, crashing, or dying - whichever one it's gonna be.)`
+				`	(Proceed with landing, crashing, or dying - whichever one it's gonna be.)`
 			`Your decent is still far more steep than normal, and the ship is starting to roll. It is no longer possible to correct both your descend angle and maintain attitude control.`
 			choice
-				`(Prioritize roll stabilization.)`
+				`	(Prioritize roll stabilization.)`
 					goto rolling
-				`(Prioritize lowering the descent angle.)`
-				`(Switch to full auto-pilot control.)`
+				`	(Prioritize lowering the descent angle.)`
+				`	(Switch to full auto-pilot control.)`
 			`Your ship begins to roll faster and faster, but the autopilot somehow manages to soften the descent angle.`
 			choice
-				`(Prioritize roll stabilization now.)`
+				`	(Prioritize roll stabilization now.)`
 					goto rolling
-				`(Continue prioritizing lowering the descent angle.)`
-				`(Let the autopilot handle the landing.)`
+				`	(Continue prioritizing lowering the descent angle.)`
+				`	(Let the autopilot handle the landing.)`
 			branch miracle
 				random < 80
 			`It's not enough! The ship starts rolling even faster, your vision blurs, and consciousness starts to slip from you. The last thing you remember is your ship falling apart...`
@@ -3815,9 +3816,9 @@ mission "Repulsor failure"
 			label rolling
 			`Your ships roll stabilizes, but your descent vector is now almost perpendicular to the surface, and the acceleration straight towards the surface pushes you firmly into your chair.`
 			choice
-				`(Pray for a miracle.)`
-				`(Scream your lungs out.)`
-				`(Silently accept the situation as it is.)`
+				`	(Pray for a miracle.)`
+				`	(Scream your lungs out.)`
+				`	(Silently accept the situation as it is.)`
 			branch miracle
 				random < 70
 			`There is nothing more you can do to save your ship or yourself. The <ship> crashes straight into the ground. Whoever will have to clean this mess up will have a hard time finding your remains.`
@@ -3825,9 +3826,9 @@ mission "Repulsor failure"
 			label miracle
 			`Suddenly, all repulsors come back online at full strength! You feel the seatbelt dig into your skin over the sudden deceleration.`
 			choice
-				`(Let the autopilot handle the landing.)`
-				`(Attempt to perform a manual landing.)`
-				`(Try to return to orbit to fix the issue in space.)`
+				`	(Let the autopilot handle the landing.)`
+				`	(Attempt to perform a manual landing.)`
+				`	(Try to return to orbit to fix the issue in space.)`
 					goto reorbit
 			branch miraclelanding
 				random < 98
@@ -3840,7 +3841,7 @@ mission "Repulsor failure"
 			`	Your ship took extensive damage, you pay 86,100 credits for repairs.`
 				decline
 			label reorbit
-			`The climb back into orbit is turbulent, slow, and difficult, but you make it there safely.`
+			`	The climb back into orbit is turbulent, slow, and difficult, but you make it there safely.`
 				launch
 	on enter
 		dialog

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -3773,12 +3773,10 @@ mission "Repulsor failure"
 	# Don't require the player to pay credits again if the player was already allowed to land when this mission triggered.
 	clearance
 	source
-		not attributes "station"
-		not attributes "gas giant"
-		not attributes "uninhabited"
-		not attributes "korath"
+		not attributes "station" "gas giant" "uninhabited" "korath"
 	to offer
-		random < 8
+		random < 1
+		random < 50
 		credits >= 2000000
 	on offer
 		conversation

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -3768,6 +3768,7 @@ mission "Thrall Emigration"
 
 mission "Repulsor failure"
 	landing
+	invisible
 	minor
 	# Don't require the player to pay credits again if the player was already allowed to land when this mission triggered.
 	clearance
@@ -3786,23 +3787,23 @@ mission "Repulsor failure"
 				`	(Return to orbit to fix the issue in space.)`
 					launch
 				`	(Attempt to land anyway.)`
-			`Orbital entry is a bit more steep than normal, and your ship is starting to lean a bit.`
+			`	Orbital entry is a bit more steep than normal, and your ship is starting to lean a bit.`
 			choice
 				`	(Try to return to orbit to fix the issue in space.)`
 					goto reorbit
 				`	(Continue the attempt to land.)`
-			`You're reaching the point where your ship will not be able to re-orbit on its own power. The cockpit is filled with warnings about the descent angle and attitude control.`
+			`	You're reaching the point where your ship will not be able to re-orbit on its own power. The cockpit is filled with warnings about the descent angle and attitude control.`
 			choice
 				`	(Attempt to re-orbit and hope that the ship still makes it.)`
 					goto reorbit
 				`	(Proceed with landing, crashing, or dying - whichever one it's gonna be.)`
-			`Your decent is still far more steep than normal, and the ship is starting to roll. It is no longer possible to correct both your descend angle and maintain attitude control.`
+			`	Your descent is still far more steep than normal, and the ship is starting to roll. It is no longer possible to correct both your descend angle and maintain attitude control.`
 			choice
 				`	(Prioritize roll stabilization.)`
 					goto rolling
 				`	(Prioritize lowering the descent angle.)`
 				`	(Switch to full auto-pilot control.)`
-			`Your ship begins to roll faster and faster, but the autopilot somehow manages to soften the descent angle.`
+			`	Your ship begins to roll faster and faster, but the autopilot somehow manages to soften the descent angle.`
 			choice
 				`	(Prioritize roll stabilization now.)`
 					goto rolling
@@ -3810,21 +3811,21 @@ mission "Repulsor failure"
 				`	(Let the autopilot handle the landing.)`
 			branch miracle
 				random < 80
-			`It's not enough! The ship starts rolling even faster, your vision blurs, and consciousness starts to slip from you. The last thing you remember is your ship falling apart...`
+			`	It's not enough! The ship starts rolling even faster, your vision blurs, and consciousness starts to slip from you. The last thing you remember is your ship falling apart...`
 			`	By the time your ship fully disintegrates, you've already died.`
 				die
 			label rolling
-			`Your ships roll stabilizes, but your descent vector is now almost perpendicular to the surface, and the acceleration straight towards the surface pushes you firmly into your chair.`
+			`	Your ships roll stabilizes, but your descent vector is now almost perpendicular to the surface, and the acceleration straight towards the surface pushes you firmly into your chair.`
 			choice
 				`	(Pray for a miracle.)`
 				`	(Scream your lungs out.)`
 				`	(Silently accept the situation as it is.)`
 			branch miracle
 				random < 70
-			`There is nothing more you can do to save your ship or yourself. The <ship> crashes straight into the ground. Whoever will have to clean this mess up will have a hard time finding your remains.`
+			`	There is nothing more you can do to save your ship or yourself. The <ship> crashes straight into the ground. Whoever will have to clean this mess up will have a hard time finding your remains.`
 				die
 			label miracle
-			`Suddenly, all repulsors come back online at full strength! You feel the seatbelt dig into your skin over the sudden deceleration.`
+			`	Suddenly, all repulsors come back online at full strength! You feel the seatbelt dig into your skin over the sudden deceleration.`
 			choice
 				`	(Let the autopilot handle the landing.)`
 				`	(Attempt to perform a manual landing.)`
@@ -3832,10 +3833,10 @@ mission "Repulsor failure"
 					goto reorbit
 			branch miraclelanding
 				random < 98
-			`Your ship's trajectory and attitude stabilize, but it was too late. All warning lights in the cockpit are lit and sirens are blaring, but the view out your window of the fast approaching planet surface makes the impending crash more clear than any light or siren does. You experience a few seconds of fear, after which you life ends in a short, big flash.`
+			`	Your ship's trajectory and attitude stabilize, but it was too late. All warning lights in the cockpit are lit and sirens are blaring, but the view out your window of the fast approaching planet surface makes the impending crash more clear than any light or siren does. You experience a few seconds of fear, after which you life ends in a short, big flash.`
 				die
 			label miraclelanding
-			`Your ship's trajectory and attitude stabilize, and somehow the ship crash-lands on the surface.`
+			`	Your ship's trajectory and attitude stabilize, and somehow the ship crash-lands on the surface.`
 			`	You aren't sure what is more miraculous: that you landed near the spaceport or that you're still alive.`
 			`	The authorities are not very impressed and fine you 200,000 credits for reckless flying.`
 			`	Your ship took extensive damage, you pay 86,100 credits for repairs.`

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -296,8 +296,8 @@ void Mission::Load(const DataNode &node)
 
 	if(displayName.empty())
 		displayName = name;
-	if((isMinor || hasPriority) && location == LANDING)
-		node.PrintTrace("Warning: \"minor\" or \"priority\" tags have no effect on \"landing\" missions:");
+	if((hasPriority && location == LANDING)
+		node.PrintTrace("Warning: \"priority\" tag has no effect on \"landing\" missions:");
 }
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -296,7 +296,7 @@ void Mission::Load(const DataNode &node)
 
 	if(displayName.empty())
 		displayName = name;
-	if((hasPriority && location == LANDING)
+	if(hasPriority && location == LANDING)
 		node.PrintTrace("Warning: \"priority\" tag has no effect on \"landing\" missions:");
 }
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -296,8 +296,8 @@ void Mission::Load(const DataNode &node)
 
 	if(displayName.empty())
 		displayName = name;
-	if(hasPriority && location == LANDING)
-		node.PrintTrace("Warning: \"priority\" tag has no effect on \"landing\" missions:");
+	if((isMinor || hasPriority) && location == LANDING)
+		node.PrintTrace("Warning: \"minor\" or \"priority\" tags have no effect on \"landing\" missions:");
 }
 
 


### PR DESCRIPTION
This PR cleans up formatting for the Repulsor Failure mission, and adds a minor tag. Without it, you can have an instance of First Contact with aliens, followed by text saying that you're somehow still in space and haven't fully entered the planet's atmosphere yet. This will ensure that it won't collide with any landing missions.