### PR TITLE
Add new mission where the player tries to get an Unfettered translator

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -13,6 +13,7 @@ mission "First Contact: Hai"
 	source
 		government "Hai"
 	on offer
+		set "discovered hai"
 		conversation
 			branch unfettered
 				has "First Contact: Unfettered: offered"
@@ -133,6 +134,7 @@ mission "First Contact: Unfettered"
 	source
 		attributes "unfettered"
 	on offer
+		set "discovered hai"
 		conversation
 			branch hai
 				has "First Contact: Hai: offered"
@@ -186,7 +188,7 @@ mission "First Contact: Unfettered"
 			
 			label everyone
 			`	"We fight to defend ourselves from extinction," it says.`
-			`	"Extinction'" you ask. "Do you mean that you are not the same species as the other Hai?"`
+			`	"Extinction?" you ask. "Do you mean that you are not the same species as the other Hai?"`
 			`	"Indeed," it says. "We are all that is left of the original Hai. Unaltered. The conquerors. We were masters of a hundred worlds before human monkeys had learned the use of thumbs."`
 				goto masters
 			
@@ -422,6 +424,8 @@ mission "Unfettered Jump Drive 3"
 				`	"Can you tell me what you are using the jump drives for?"`
 				`	"Thank you, I will certainly bring more of them when I am able."`
 					accept
+			apply
+				set "unfettered know of wanderers"
 			`	After a brief and hushed discussion in their own language, one of the leaders says, "You have proven your worth, so we will share our secret. The Hai once owned many worlds on the galactic fringe, a territory we can only visit using the jump drive. Those worlds are fruitful and nearly uninhabited. We will reclaim them as our own, and there will be food there to feed the Unfettered for many thousands of years to come."`
 			branch know
 				has "First Contact: Wanderer: offered"

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -91,7 +91,7 @@ mission "Discovered Hai Space"
 	landing
 	invisible
 	source
-		government "Hai"
+		government "Hai" "Hai (Unfettered)"
 	on offer
 		event "label hai space"
 		fail
@@ -107,16 +107,6 @@ mission "Discovered Wormhole Alpha"
 		never
 	on enter "Ultima Thule"
 		set "wormhole alpha found"
-		fail
-
-# Allows setting of the "hai discovered" condition even if first contact has already occurred
-mission "Hai Discovered Patch"
-	landing
-	invisible
-	source
-		government "Hai" "Hai (Unfettered)"
-	on offer
-		set "discovered hai"
 		fail
 
 

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -13,7 +13,6 @@ mission "First Contact: Hai"
 	source
 		government "Hai"
 	on offer
-		set "discovered hai"
 		conversation
 			branch unfettered
 				has "First Contact: Unfettered: offered"
@@ -110,6 +109,16 @@ mission "Discovered Wormhole Alpha"
 		set "wormhole alpha found"
 		fail
 
+# Allows setting of the "hai discovered" condition even if first contact has already occurred
+mission "Hai Discovered Patch"
+	landing
+	invisible
+	source
+		government "Hai" "Hai (Unfettered)"
+	on offer
+		set "discovered hai"
+		fail
+
 
 
 mission "Assisting Hai"
@@ -134,7 +143,6 @@ mission "First Contact: Unfettered"
 	source
 		attributes "unfettered"
 	on offer
-		set "discovered hai"
 		conversation
 			branch hai
 				has "First Contact: Hai: offered"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -107,7 +107,7 @@ mission "Wanderers: Unfettered Diplomat"
 			label hai
 			choice
 				`	(Yes.)`
-				`	(No; the Hai southern of here are better suited for this.)`
+				`	(No; the other Hai south of here are better suited for this.)`
 					decline
 			label try
 			`	You search around the spaceport for any sign of a local government. Eventually, one of the Hai approaches you, and she says, "You are lost, monkey. What is it that you are looking for?"`

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -36,7 +36,7 @@ mission "First Contact: Wanderer"
 	source
 		attributes "wanderer"
 	to offer
-		has "First Contact: Hai: offered"
+		has "discovered hai"
 	to complete
 		has "Wanderers: Diplomacy: offered"
 	on offer
@@ -84,6 +84,61 @@ event "label wanderer space"
 		sprite "label/wanderers"
 
 
+mission "Wanderers: Unfettered Diplomat"
+	landing
+	source
+		attributes "unfettered"
+	to offer
+		has "First Contact: Wanderer: offered"
+		has "First Contact: Unfettered: offered"
+		not "unfettered know of wanderers"
+		not "Wanderers: Hai Diplomat: offered"
+		not "Wanderers: Diplomacy: offered"
+	on offer
+		conversation
+			`The aliens north of Hai space seem to speak the Hai language. Do you want to look for someone here who could serve as an interpreter?`
+			branch hai
+				has "First Contact: Hai"
+			choice
+				`	(Yes.)`
+					goto try
+				`	(Not right now.)`
+					defer
+			label hai
+			choice
+				`	(Yes.)`
+				`	(No; the Fettered Hai are better suited for this.)`
+					decline
+			label try
+			`	You search around the spaceport for any sign of a local government. Eventually, one of the Hai approaches you, and she says, "You are lost, monkey. What is it that you are looking for?"`
+			choice
+				`	"Do you know where I can talk to an official?"`
+				`	"Do you know where I could find an interpreter?"`
+					goto interpreter
+				`	"I'm doing fine, thank you."`
+					goto decline
+			`	The Hai says, "If your reason for talking to our chiefs is worthwhile, then I will take you to them."`
+			`	"I'm looking for a Hai interpreter," you say.`
+			label interpreter
+			`	She looks back at you quizically. "What purpose would an interpreter serve? You can understand my words, can you not?"`
+			choice
+				`	"I need one to talk to the aliens up north from here."`
+				`	"I think that I'll be better off finding one of the chiefs on my own."`
+					goto decline
+			`	The Hai scrunches up her nose. "Foolish monkey. We have already contacted those aliens; we have little use for another emissary."`
+			choice
+				`	"Can you still provide an interpreter, though?"`
+				`	"I understand."`
+					label end
+			`	"You do not need an interpreter. All you need to know is that those aliens are not worth conversing with."`
+			label end
+			`	The Hai walks away, leaving you to your own devices in the spaceport.`
+				decline
+			label decline
+			`	The Hai scoffs at you. "If you do not seek for help, or seek to help, then you have no place on our worlds." She walks away, and you spend another hour searching the spaceport before giving up and heading back to your ship.`
+				decline
+
+
 
 mission "Wanderers: Hai Diplomat"
 	description "Travel to Hai-home to pick up a diplomat who can help you communicate with the Wanderers."
@@ -95,6 +150,7 @@ mission "Wanderers: Hai Diplomat"
 	clearance
 	to offer
 		has "First Contact: Wanderer: offered"
+		has "First Contact: Hai"
 		not "Wanderers: Diplomacy: offered"
 	on offer
 		conversation

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -36,7 +36,9 @@ mission "First Contact: Wanderer"
 	source
 		attributes "wanderer"
 	to offer
-		has "discovered hai"
+		or
+			has "First Contact: Hai: offered"
+			has "First Contact: Unfettered: offered"
 	to complete
 		has "Wanderers: Diplomacy: offered"
 	on offer

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -107,7 +107,7 @@ mission "Wanderers: Unfettered Diplomat"
 			label hai
 			choice
 				`	(Yes.)`
-				`	(No; the Fettered Hai are better suited for this.)`
+				`	(No; the Hai southern of here are better suited for this.)`
 					decline
 			label try
 			`	You search around the spaceport for any sign of a local government. Eventually, one of the Hai approaches you, and she says, "You are lost, monkey. What is it that you are looking for?"`
@@ -130,7 +130,7 @@ mission "Wanderers: Unfettered Diplomat"
 				`	"Can you still provide an interpreter, though?"`
 				`	"I understand."`
 					goto end
-			`	"You do not need an interpreter. All you need to know is that those aliens are not worth conversing with."`
+			`	"You do not need an interpreter. All you need is to know that those aliens are not worth conversing with."`
 			label end
 			`	The Hai walks away, leaving you to your own devices in the spaceport.`
 				decline

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -110,7 +110,7 @@ mission "Wanderers: Unfettered Diplomat"
 				`	(No; the other Hai south of here are better suited for this.)`
 					decline
 			label try
-			`	You search around the spaceport for any sign of a local government. Eventually, one of the Hai approaches you, and she says, "You are lost, monkey. What is it that you are looking for?"`
+			`	You search around the spaceport for any sign of a local government. Eventually, one of the Hai approaches you. "You are lost, monkey. What is it that you are looking for?"`
 			choice
 				`	"Do you know where I can talk to an official?"`
 				`	"Do you know where I could find an interpreter?"`
@@ -120,7 +120,7 @@ mission "Wanderers: Unfettered Diplomat"
 			`	The Hai says, "If your reason for talking to our chiefs is worthwhile, then I will take you to them."`
 			`	"I'm looking for a Hai interpreter," you say.`
 			label interpreter
-			`	She looks back at you quizically. "What purpose would an interpreter serve? You can understand my words, can you not?"`
+			`	She looks back at you quizzically. "What purpose would an interpreter serve? You can understand my words, can you not?"`
 			choice
 				`	"I need one to talk to the aliens up north from here."`
 				`	"I think that I'll be better off finding one of the chiefs on my own."`

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -129,7 +129,7 @@ mission "Wanderers: Unfettered Diplomat"
 			choice
 				`	"Can you still provide an interpreter, though?"`
 				`	"I understand."`
-					label end
+					goto end
 			`	"You do not need an interpreter. All you need to know is that those aliens are not worth conversing with."`
 			label end
 			`	The Hai walks away, leaving you to your own devices in the spaceport.`


### PR DESCRIPTION
## Summary
This PR adds a new mission where the player tries to enlist the help of the unfettered to help with translating the Wanderer language, covering cases where the player might think that the Unfettered are more trustworthy than their brethren, such as if they enter Hai space from the north.