### PR TITLE
Fix: Correcting the Lampyrid's number of bunks

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -443,7 +443,7 @@ ship "Lampyrid-Class Transport"
 		"shields" 5400
 		"hull" 4400
 		"required crew" 5
-		"bunks" 14
+		"bunks" 22
 		"mass" 240
 		"drag" 8.5
 		"heat dissipation" .7

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -443,7 +443,7 @@ ship "Lampyrid-Class Transport"
 		"shields" 5400
 		"hull" 4400
 		"required crew" 5
-		"bunks" 22
+		"bunks" 23
 		"mass" 240
 		"drag" 8.5
 		"heat dissipation" .7


### PR DESCRIPTION
## Fix Details
The Lampyrid is an easter egg / tribute ship referencing the Firefly-class ship popularized by the TV show of the same name, as well as the Serenity movie. While it is rare to see and even rarer to fly, I thought it would still be a nice detail for those inclined to notice such things that it has the right number of bunks.

This also makes it slightly more useful / relevant for the rare player who actually manages to acquire it, although not massively so. It is still unlikely to ever be more than a trophy ship, but this is a nudge towards usefulness. 

https://firefly.fandom.com/wiki/Serenity
