### PR TITLE
Coalition: Remove Pelubta Station as a source for some missions

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -1248,6 +1248,7 @@ mission "Longcow Antibiotics 1"
 		random < 35
 	source
 		attributes arach
+		not attributes "coalition station"
 	stopover "New Finding"
 	destination "Corral of Meblumem"
 	on offer
@@ -1310,6 +1311,7 @@ mission "Arachi Orphans"
 		random < 45
 	source
 		attributes arach
+		not attributes "coalition station"
 	destination "Chosen Nexus"
 	on offer
 		conversation


### PR DESCRIPTION
-----------
**Fix (Missions)**

## Summary
I was testing some stuff ingame when I clicked on the spaceport in Pelubta Station. I was prompted with the Arachi Orphans mission set, which I found very odd since I don't imagine a station is the best place for orphans to grow up in.
Turns out I hadn't removed it as a possible source for this mission, and for the Longcow Antibiotics mission (it's not impossible for the Longcow Ranchers to be around the station when they need to contact the player, but it is pretty weird to get that mission on the station I think).

This just removes Pelubta Station as a possible source for those missions.

Edit: I don't know why line 1948 is being apparently changed here.