### PR TITLE
Use TBB for threading instead of std::threads.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev uuid-dev
+          sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev uuid-dev libtbb-dev
           python3 -m pip install --user scons
       - name: Adjust version strings
         run: ./utils/cd_update_versions.sh
@@ -49,7 +49,7 @@ jobs:
         run: |
           sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev uuid-dev
+          sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev uuid-dev libtbb-dev
           python3 -m pip install --user scons
       - name: Adjust version strings
         run: ./utils/cd_update_versions.sh

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -18,7 +18,7 @@ jobs:
         run: |
           sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev uuid-dev
+          sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev uuid-dev libtbb-dev
           python3 -m pip install --user scons
       - name: Build AppImage
         run: ./utils/build_appimage.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev uuid-dev ccache libgles2-mesa
+        sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev uuid-dev ccache libgles2-mesa libtbb-dev
         python3 -m pip install --user scons
     - name: Print toolchain versions
       if: steps.cache-artifact.outputs.cache-hit != 'true'
@@ -132,7 +132,7 @@ jobs:
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev uuid-dev ccache libgles2-mesa
+        sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev uuid-dev ccache libgles2-mesa libtbb-dev
         python3 -m pip install --user scons
     - name: Cache ccache results
       if: steps.cache-tests.outputs.cache-hit != 'true'
@@ -345,7 +345,7 @@ jobs:
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libpng16-16 libjpeg-turbo8 libopenal1 libmad0 ${{ matrix.glew }} libgl1 uuid-runtime
+        sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libpng16-16 libjpeg-turbo8 libopenal1 libmad0 ${{ matrix.glew }} libgl1 uuid-runtime libtbb-dev
     - name: Install xvfb runtime dependencies
       run: sudo apt-get install -y --no-install-recommends libosmesa6 mesa-utils # TODO: ALSA mocking?
     - name: Download artifact
@@ -379,7 +379,7 @@ jobs:
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libpng16-16 libjpeg-turbo8 libopenal1 libmad0 ${{ matrix.glew }} libgl1 uuid-runtime
+        sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libpng16-16 libjpeg-turbo8 libopenal1 libmad0 ${{ matrix.glew }} libgl1 uuid-runtime libtbb-dev
     - name: Download game binary
       uses: actions/download-artifact@v2
       with:

--- a/SConstruct
+++ b/SConstruct
@@ -92,12 +92,14 @@ game_libs = [
 	"turbojpeg.dll",
 	"jpeg.dll",
 	"openal32.dll",
+    "tbb.dll",
 ] if is_windows_host else [
 	"SDL2",
 	"png",
 	"jpeg",
 	"openal",
 	"pthread",
+    "tbb",
 ]
 env.Append(LIBS = game_libs)
 

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -18,6 +18,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Random.h"
 #include "Sound.h"
 
+#include <tbb/concurrent_map.h>
+#include <tbb/parallel_for_each.h>
+
 #ifndef __APPLE__
 #include <AL/al.h>
 #include <AL/alc.h>
@@ -27,9 +30,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #endif
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <map>
-#include <mutex>
 #include <set>
 #include <stdexcept>
 #include <thread>
@@ -67,12 +70,12 @@ namespace {
 		unsigned source = 0;
 	};
 
-	// Thread entry point for loading the sound files.
-	void Load();
-
 
 	// Mutex to make sure different threads don't modify the audio at the same time.
 	mutex audioMutex;
+
+	// Atomic to keep track of the percentage of sounds that have been loaded.
+	atomic<double> progress;
 
 	// OpenAL settings.
 	ALCdevice *device = nullptr;
@@ -88,17 +91,13 @@ namespace {
 	thread::id mainThreadID;
 
 	// Sound resources that have been loaded from files.
-	map<string, Sound> sounds;
+	tbb::concurrent_map<string, Sound> sounds;
 	// OpenAL "sources" available for playing sounds. There are a limited number
 	// of these, so they must be reused.
 	vector<Source> sources;
 	vector<unsigned> recycledSources;
 	vector<unsigned> endingSources;
 	unsigned maxSources = 255;
-
-	// Queue and thread for loading sound files in the background.
-	map<string, string> loadQueue;
-	thread loadThread;
 
 	// The current position of the "listener," i.e. the center of the screen.
 	Point listener;
@@ -116,7 +115,7 @@ namespace {
 
 
 // Begin loading sounds (in a separate thread).
-void Audio::Init(const vector<string> &sources)
+void Audio::Init(tbb::task_group &group, const vector<string> &sources)
 {
 	device = alcOpenDevice(nullptr);
 	if(!device)
@@ -142,27 +141,44 @@ void Audio::Init(const vector<string> &sources)
 	alDistanceModel(AL_INVERSE_DISTANCE_CLAMPED);
 	alDopplerFactor(0.);
 
-	// Get all the sound files in the game data and all plugins.
-	for(const string &source : sources)
-	{
-		string root = source + "sounds/";
-		vector<string> files = Files::RecursiveList(root);
-		for(const string &path : files)
+	// Get all the sound files in the game data and all plugins,
+	// and load them in parallel.
+	group.run([sources]
 		{
-			if(!path.compare(path.length() - 4, 4, ".wav"))
+			// Stores the location of each sound. Existing sounds may be overwritten
+			// by plugins.
+			map<string, string> data;
+
+			for(const string &source : sources)
 			{
-				// The "name" of the sound is its full path within the "sounds/"
-				// folder, without the ".wav" or "~.wav" suffix.
-				size_t end = path.length() - 4;
-				if(path[end - 1] == '~')
-					--end;
-				loadQueue[path.substr(root.length(), end - root.length())] = path;
+				string root = source + "sounds/";
+				vector<string> files = Files::RecursiveList(root);
+				for(const string &path : files)
+				{
+					if(!path.compare(path.length() - 4, 4, ".wav"))
+					{
+						// The "name" of the sound is its full path within the "sounds/"
+						// folder, without the ".wav" or "~.wav" suffix.
+						size_t end = path.length() - 4;
+						if(path[end - 1] == '~')
+							--end;
+						data[path.substr(root.length(), end - root.length())] = path;
+					}
+				}
 			}
-		}
-	}
-	// Begin loading the files.
-	if(!loadQueue.empty())
-		loadThread = thread(&Load);
+
+			const auto increment = 1. / data.size();
+			tbb::parallel_for_each(data, [&increment](const pair<string, string> &it)
+				{
+					const auto &name = it.first;
+					const auto &path = it.second;
+					if(!sounds[name].Load(path, name))
+						Files::LogError("Unable to load sound \"" + name + "\" from path: " + path);
+
+					auto val = progress.load(memory_order_acquire);
+					progress.store(val + increment, memory_order_release);
+				});
+		});
 
 	// Create the music-streaming threads.
 	currentTrack.reset(new Music());
@@ -199,14 +215,7 @@ void Audio::CheckReferences()
 // Report the progress of loading sounds.
 double Audio::GetProgress()
 {
-	unique_lock<mutex> lock(audioMutex);
-
-	if(loadQueue.empty())
-		return 1.;
-
-	double done = sounds.size();
-	double total = done + loadQueue.size();
-	return done / total;
+	return progress.load(memory_order_acquire);
 }
 
 
@@ -233,7 +242,6 @@ void Audio::SetVolume(double level)
 // "sound/" folder, and without ~ if it's on the end, or the extension.
 const Sound *Audio::Get(const string &name)
 {
-	unique_lock<mutex> lock(audioMutex);
 	return &sounds[name];
 }
 
@@ -438,18 +446,6 @@ void Audio::Step()
 // Shut down the audio system (because we're about to quit).
 void Audio::Quit()
 {
-	// First, check if sounds are still being loaded in a separate thread, and
-	// if so interrupt that thread and wait for it to quit.
-	unique_lock<mutex> lock(audioMutex);
-	if(!loadQueue.empty())
-		loadQueue.clear();
-	if(loadThread.joinable())
-	{
-		lock.unlock();
-		loadThread.join();
-		lock.lock();
-	}
-
 	// Now, stop and delete any OpenAL sources that are playing.
 	for(const Source &source : sources)
 	{
@@ -569,38 +565,5 @@ namespace {
 	const Sound *Source::GetSound() const
 	{
 		return sound;
-	}
-
-
-
-	// Thread entry point for loading sounds.
-	void Load()
-	{
-		string name;
-		string path;
-		Sound *sound;
-		while(true)
-		{
-			{
-				unique_lock<mutex> lock(audioMutex);
-				// If this is not the first time through, remove the previous item
-				// in the queue. This is a signal that it has been loaded, so we
-				// must not remove it until after loading the file.
-				if(!path.empty() && !loadQueue.empty())
-					loadQueue.erase(loadQueue.begin());
-				if(loadQueue.empty())
-					return;
-				name = loadQueue.begin()->first;
-				path = loadQueue.begin()->second;
-
-				// Since we need to unlock the mutex below, create the map entry to
-				// avoid a race condition when accessing sounds' size.
-				sound = &sounds[name];
-			}
-
-			// Unlock the mutex for the time-intensive part of the loop.
-			if(!sound->Load(path, name))
-				Files::LogError("Unable to load sound \"" + name + "\" from path: " + path);
-		}
 	}
 }

--- a/source/Audio.h
+++ b/source/Audio.h
@@ -13,6 +13,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef AUDIO_H_
 #define AUDIO_H_
 
+#include <tbb/task_group.h>
+
 #include <string>
 #include <vector>
 
@@ -30,8 +32,8 @@ class Sound;
 // their source stops calling the "play" function for them.
 class Audio {
 public:
-	// Begin loading sounds (in a separate thread).
-	static void Init(const std::vector<std::string> &sources);
+	// Begin loading sounds.
+	static void Init(tbb::task_group &group, const std::vector<std::string> &sources);
 	static void CheckReferences();
 
 	// Report the progress of loading sounds.

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -25,11 +25,11 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Radar.h"
 #include "Rectangle.h"
 
-#include <condition_variable>
+#include <tbb/task_group.h>
+
 #include <list>
 #include <map>
 #include <memory>
-#include <thread>
 #include <utility>
 #include <vector>
 
@@ -59,7 +59,7 @@ class Weather;
 class Engine {
 public:
 	explicit Engine(PlayerInfo &player);
-	~Engine();
+	~Engine() noexcept;
 
 	// Place all the player's ships, and "enter" the system the player is in.
 	void Place();
@@ -98,7 +98,6 @@ public:
 private:
 	void EnterSystem();
 
-	void ThreadEntryPoint();
 	void CalculateStep();
 
 	void MoveShip(const std::shared_ptr<Ship> &ship);
@@ -169,13 +168,10 @@ private:
 
 	AI ai;
 
-	std::thread calcThread;
-	std::condition_variable condition;
-	std::mutex swapMutex;
+	tbb::task_group calcTask;
 
 	bool calcTickTock = false;
 	bool drawTickTock = false;
-	bool terminate = false;
 	bool wasActive = false;
 	DrawList draw[2];
 	BatchDrawList batchDraw[2];

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -18,6 +18,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Set.h"
 #include "Trade.h"
 
+#include <tbb/task_group.h>
+
 #include <map>
 #include <memory>
 #include <string>
@@ -65,7 +67,7 @@ class TextReplacements;
 // universe.
 class GameData {
 public:
-	static void BeginLoad(bool onlyLoadData, bool debugMode);
+	static void BeginLoad(tbb::task_group &group, bool onlyLoadData, bool debugMode);
 	static void FinishLoading();
 	// Check for objects that are referred to but never defined.
 	static void CheckReferences();

--- a/source/Music.cpp
+++ b/source/Music.cpp
@@ -23,12 +23,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
-	// How many bytes to read from the file at a time:
-	const size_t INPUT_CHUNK = 65536;
-	// How many samples to put in each output block. Because the output is in
-	// stereo, the duration of the sample is half this amount:
-	const size_t OUTPUT_CHUNK = 32768;
-
 	map<string, string> paths;
 }
 
@@ -59,32 +53,17 @@ void Music::Init(const vector<string> &sources)
 
 
 
-// Music constructor, which starts the decoding thread. Initially, the thread
-// has no file to read, so it will sleep until a file is specified.
-Music::Music()
-	: silence(OUTPUT_CHUNK, 0)
-{
-	// Don't start the thread until this object is fully constructed.
-	thread = std::thread(&Music::Decode, this);
-}
-
-
-
 // Destructor, which waits for the thread to stop.
 Music::~Music()
 {
-	// Tell the decoding thread to stop.
-	{
-		unique_lock<mutex> lock(decodeMutex);
-		done = true;
-	}
-	condition.notify_all();
-	thread.join();
+	group.cancel();
+	group.wait();
 
-	// If the decode thread has not yet taken possession of the next file, it is
-	// our job to close it.
-	if(nextFile)
-		fclose(nextFile);
+	mad_synth_finish(&synth);
+	mad_frame_finish(&frame);
+	mad_stream_finish(&stream);
+	if(file)
+		fclose(file);
 }
 
 
@@ -101,30 +80,32 @@ void Music::SetSource(const string &name)
 		return;
 	previousPath = path;
 
-	// Inform the decoding thread that it should switch to decoding a new file.
-	unique_lock<mutex> lock(decodeMutex);
-	if(path.empty())
-		nextFile = nullptr;
-	else
-		nextFile = Files::Open(path);
-	hasNewFile = true;
+	// Cancel the running decoding task.
+	group.cancel();
+	group.wait();
+
+	// Switch to decoding to the new file.
+	file = path.empty() ? nullptr : Files::Open(path);
 
 	// Also clear any decoded data left over from the previous file.
 	next.clear();
 
-	// Notify the decoding thread that it can start.
-	lock.unlock();
-	condition.notify_all();
+	// Now, we have a file to read. Initialize the decoder.
+	mad_stream_init(&stream);
+	mad_frame_init(&frame);
+	mad_synth_init(&synth);
+
+	// Start decoding a single frame from the file.
+	StartDecodingFrame();
 }
 
 
 
 // Get the next audio buffer to play.
-const vector<int16_t> &Music::NextChunk()
+auto Music::NextChunk() -> const Buffer &
 {
 	// Check whether the "next" buffer is ready.
-	unique_lock<mutex> lock(decodeMutex);
-	if(next.size() < OUTPUT_CHUNK)
+	if(!finishedDecodingFrame)
 		return silence;
 
 	// If the next buffer is ready, move a chunk of data into the output buffer.
@@ -134,143 +115,87 @@ const vector<int16_t> &Music::NextChunk()
 	current.insert(current.begin(), next.begin(), next.begin() + OUTPUT_CHUNK);
 	next.erase(next.begin(), next.begin() + OUTPUT_CHUNK);
 
-	// Once the lock is unlocked, notify the decoding thread to continue.
-	lock.unlock();
-	condition.notify_all();
+	// Start decoding the next frame.
+	StartDecodingFrame();
 
 	// Return the buffer.
 	return current;
-
 }
 
 
 
-// Entry point for the decoding thread.
-void Music::Decode()
+// Starts a task that decodes a single frame from the currently loaded file.
+void Music::StartDecodingFrame()
 {
 	// This vector will store the input from the file.
-	vector<unsigned char> input(INPUT_CHUNK, 0);
-	// Objects for MP3 decoding:
-	mad_stream stream;
-	mad_frame frame;
-	mad_synth synth;
-	// Loop until the thread is told to quit.
-	while(true)
-	{
-		// First, wait until a new file has been specified or we're done.
-		FILE *file = nullptr;
-		while(!file)
+	static vector<unsigned char> input(INPUT_CHUNK, 0);
+
+	finishedDecodingFrame = false;
+	group.run([this]
 		{
-			unique_lock<mutex> lock(decodeMutex);
-			while(!done && !hasNewFile)
-				condition.wait(lock);
-
-			// If the "done" variable has been set, exit this thread.
-			if(done)
-				return;
-
-			// The new file now belongs to us, and it's our job to close it.
-			file = nextFile;
-			nextFile = nullptr;
-			hasNewFile = false;
-		}
-
-		// Now, we have a file to read. Initialize the decoder.
-		mad_stream_init(&stream);
-		mad_frame_init(&frame);
-		mad_synth_init(&synth);
-
-		// Loop until we are asked to switch files.
-		while(true)
-		{
-			// If the "next" buffer has filled up, wait until it is retrieved.
-			// Generally try to queue up two chunks worth of samples in it, just
-			// in case NextChunk() gets called twice in rapid succession.
-			unique_lock<mutex> lock(decodeMutex);
-			while(!done && next.size() >= 2 * OUTPUT_CHUNK)
-				condition.wait(lock);
-			// Check if we're done or if we need to switch files.
-			if(done || hasNewFile)
-				break;
-
-			// The lock can be freed until we start filling the output buffer.
-			lock.unlock();
-
-			// See if any input data is left undecoded in the stream. Typically
-			// this is because the last block of input contained a fraction of a
-			// full MP3 frame.
-			size_t remainder = 0;
-			if(stream.next_frame && stream.next_frame < stream.bufend)
-				remainder = stream.bufend - stream.next_frame;
-			if(remainder)
-				memcpy(&input.front(), stream.next_frame, remainder);
-
-			// Now, read a chunk of data from the file.
-			size_t read = fread(&input.front() + remainder, 1, INPUT_CHUNK - remainder, file);
-			// If you get the end of the file, loop around to the beginning.
-			if(!read || feof(file))
-				rewind(file);
-			// If there is nothing to decode, return to the top of this loop.
-			if(!(read + remainder))
-				continue;
-
-			// Hand the input to the stream decoder.
-			mad_stream_buffer(&stream, &input.front(), read + remainder);
-
-			// Loop through the decoded result for that input block.
-			while(true)
+			while(next.size() < OUTPUT_CHUNK)
 			{
-				// Decode the next frame, and check if there is an error.
-				if(mad_frame_decode(&frame, &stream))
+				// See if any input data is left undecoded in the stream. Typically
+				// this is because the last block of input contained a fraction of a
+				// full MP3 frame.
+				size_t remainder = 0;
+				if(stream.next_frame && stream.next_frame < stream.bufend)
+					remainder = stream.bufend - stream.next_frame;
+				if(remainder)
+					memcpy(&input.front(), stream.next_frame, remainder);
+
+				// Now, read a chunk of data from the file.
+				size_t read = fread(&input.front() + remainder, 1, INPUT_CHUNK - remainder, file);
+				// If you get the end of the file, loop around to the beginning.
+				if(!read || feof(file))
+					rewind(file);
+				// If there is nothing to decode, do nothing.
+				if(!(read + remainder))
+					return;
+
+				// Hand the input to the stream decoder.
+				mad_stream_buffer(&stream, &input.front(), read + remainder);
+
+				// Loop through the decoded result for that input block.
+				while(true)
 				{
-					// For recoverable errors, keep going.
-					if(MAD_RECOVERABLE(stream.error))
-						continue;
-					else
+					// Decode the next frame, and check if there is an error.
+					if(mad_frame_decode(&frame, &stream))
+					{
+						// For recoverable errors, keep going.
+						if(MAD_RECOVERABLE(stream.error))
+							continue;
 						break;
-				}
-				// Convert the decoded audio into a PCM signal.
-				mad_synth_frame(&synth, &frame);
+					}
+					// Convert the decoded audio into a PCM signal.
+					mad_synth_frame(&synth, &frame);
 
-				// If the source is mono, read both output channels from the left input.
-				// Otherwise, read two separate input channels.
-				mad_fixed_t *channels[2] = {
-					synth.pcm.samples[0],
-					synth.pcm.samples[synth.pcm.channels > 1]
-				};
+					// If the source is mono, read both output channels from the left input.
+					// Otherwise, read two separate input channels.
+					mad_fixed_t *channels[2] = {
+						synth.pcm.samples[0],
+						synth.pcm.samples[synth.pcm.channels > 1]
+					};
 
-				// For this part, we need access to the output buffer.
-				lock.lock();
-				if(done || hasNewFile)
-					break;
+					// We'll alternate what channel we read from each time through the loop.
+					int channel = 0;
+					for(unsigned i = 0; i < 2 * synth.pcm.length; ++i)
+					{
+						// Read the next sample from the next channel.
+						mad_fixed_t sample = *channels[channel]++;
+						channel = !channel;
 
-				// We'll alternate what channel we read from each time through the loop.
-				int channel = 0;
-				for(unsigned i = 0; i < 2 * synth.pcm.length; ++i)
-				{
-					// Read the next sample from the next channel.
-					mad_fixed_t sample = *channels[channel]++;
-					channel = !channel;
-
-					// Clip and scale the sample to 16 bits.
-					sample += (1L << (MAD_F_FRACBITS - 16));
+						// Clip and scale the sample to 16 bits.
+						sample += (1L << (MAD_F_FRACBITS - 16));
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-					sample = max(-MAD_F_ONE, min(MAD_F_ONE - 1, sample));
+						sample = max(-MAD_F_ONE, min(MAD_F_ONE - 1, sample));
 #pragma GCC diagnostic pop
-					next.push_back(sample >> (MAD_F_FRACBITS + 1 - 16));
+						next.push_back(sample >> (MAD_F_FRACBITS + 1 - 16));
+					}
 				}
-				// Now, the "next" buffer can be used by others. In theory, the
-				// NextChunk() function could take what's in that buffer while
-				// we are right in the middle of this decoding cycle.
-				lock.unlock();
 			}
-		}
 
-		// Clean up.
-		mad_synth_finish(&synth);
-		mad_frame_finish(&frame);
-		mad_stream_finish(&stream);
-		fclose(file);
-	}
+			finishedDecodingFrame = true;
+		});
 }

--- a/source/SpriteQueue.cpp
+++ b/source/SpriteQueue.cpp
@@ -12,39 +12,18 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "SpriteQueue.h"
 
-#include "ImageBuffer.h"
 #include "ImageSet.h"
-#include "Mask.h"
 #include "Sprite.h"
 #include "SpriteSet.h"
-
-#include <algorithm>
-#include <functional>
 
 using namespace std;
 
 
 
-// Constructor, which allocates worker threads.
-SpriteQueue::SpriteQueue()
-{
-	threads.resize(max(4u, thread::hardware_concurrency()));
-	for(thread &t : threads)
-		t = thread(ref(*this));
-}
-
-
-
-// Destructor, which waits for all worker threads to wrap up.
 SpriteQueue::~SpriteQueue()
 {
-	{
-		lock_guard<mutex> lock(readMutex);
-		added = -1;
-	}
-	readCondition.notify_all();
-	for(thread &t : threads)
-		t.join();
+	tasks.cancel();
+	tasks.wait();
 }
 
 
@@ -52,16 +31,13 @@ SpriteQueue::~SpriteQueue()
 // Add a sprite to load.
 void SpriteQueue::Add(const shared_ptr<ImageSet> &images)
 {
-	{
-		lock_guard<mutex> lock(readMutex);
-		// Do nothing if we are destroying the queue already.
-		if(added < 0)
-			return;
+	tasks.run([this, images]
+		{
+			images->Load();
+			++added;
 
-		toRead.push(images);
-		++added;
-	}
-	readCondition.notify_one();
+			toLoad.push(images);
+		});
 }
 
 
@@ -69,7 +45,6 @@ void SpriteQueue::Add(const shared_ptr<ImageSet> &images)
 // Unload the texture for the given sprite (to free up memory).
 void SpriteQueue::Unload(const string &name)
 {
-	unique_lock<mutex> lock(loadMutex);
 	toUnload.push(name);
 }
 
@@ -78,9 +53,6 @@ void SpriteQueue::Unload(const string &name)
 // Determine the fraction of sprites uploaded to the GPU.
 double SpriteQueue::GetProgress() const
 {
-	// Wait until we have completed loading of as many sprites as we have added.
-	// The value of "added" is protected by readMutex.
-	unique_lock<mutex> readLock(readMutex);
 	// Special cases: we're bailing out, or we are done.
 	if(added <= 0 || added == completed)
 		return 1.;
@@ -91,8 +63,25 @@ double SpriteQueue::GetProgress() const
 
 void SpriteQueue::UploadSprites()
 {
-	unique_lock<mutex> lock(loadMutex);
-	DoLoad(lock);
+	while(!toUnload.empty())
+	{
+		string image;
+		if(!toUnload.try_pop(image))
+			break;
+
+		SpriteSet::Modify(image)->Unload();
+	}
+
+	for(int i = 0; i < 100; ++i)
+	{
+		// Extract the one item we should work on uploading right now.
+		shared_ptr<ImageSet> imageSet;
+		if(!toLoad.try_pop(imageSet))
+			break;
+
+		imageSet->Upload(SpriteSet::Modify(imageSet->Name()));
+		++completed;
+	}
 }
 
 
@@ -100,91 +89,5 @@ void SpriteQueue::UploadSprites()
 // Finish loading.
 void SpriteQueue::Finish()
 {
-	// Loop until done loading.
-	while(true)
-	{
-		unique_lock<mutex> lock(loadMutex);
-
-		// Load whatever is already queued up for loading.
-		DoLoad(lock);
-		if(GetProgress() == 1.)
-			break;
-
-		// We still have sprites to upload, but none of them have been read from
-		// disk yet. Wait until one arrives.
-		loadCondition.wait(lock);
-	}
-}
-
-
-
-// Thread entry point.
-void SpriteQueue::operator()()
-{
-	while(true)
-	{
-		unique_lock<mutex> lock(readMutex);
-		while(true)
-		{
-			// To signal this thread that it is time for it to quit, we set
-			// "added" to -1.
-			if(added < 0)
-				return;
-			if(toRead.empty())
-				break;
-
-			// Extract the one item we should work on reading right now.
-			shared_ptr<ImageSet> imageSet = toRead.front();
-			toRead.pop();
-
-			// It's now safe to add to the lists.
-			lock.unlock();
-
-			// Load the sprite.
-			// TODO: investigate catching exceptions from Load() (e.g. bad_alloc), to enable
-			// the UI thread to display a message prior to terminating the process.
-			imageSet->Load();
-
-			{
-				// The texture must be uploaded to OpenGL in the main thread.
-				unique_lock<mutex> lock(loadMutex);
-				toLoad.push(imageSet);
-			}
-			loadCondition.notify_one();
-
-			lock.lock();
-		}
-
-		readCondition.wait(lock);
-	}
-}
-
-
-
-void SpriteQueue::DoLoad(unique_lock<mutex> &lock)
-{
-	while(!toUnload.empty())
-	{
-		Sprite *sprite = SpriteSet::Modify(toUnload.front());
-		toUnload.pop();
-
-		lock.unlock();
-		sprite->Unload();
-		lock.lock();
-	}
-
-	for(int i = 0; !toLoad.empty() && i < 100; ++i)
-	{
-		// Extract the one item we should work on uploading right now.
-		shared_ptr<ImageSet> imageSet = toLoad.front();
-		toLoad.pop();
-
-		// It's now safe to modify the lists.
-		lock.unlock();
-
-		imageSet->Upload(SpriteSet::Modify(imageSet->Name()));
-
-		lock.lock();
-		++completed;
-	}
+	tasks.wait();
 }

--- a/source/SpriteSet.cpp
+++ b/source/SpriteSet.cpp
@@ -15,15 +15,12 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Files.h"
 #include "Sprite.h"
 
-#include <map>
-#include <mutex>
+#include <tbb/concurrent_map.h>
 
 using namespace std;
 
 namespace {
-	map<string, Sprite> sprites;
-
-	mutex modifyMutex;
+	tbb::concurrent_map<string, Sprite> sprites;
 }
 
 
@@ -51,8 +48,6 @@ void SpriteSet::CheckReferences()
 
 Sprite *SpriteSet::Modify(const string &name)
 {
-	lock_guard<mutex> guard(modifyMutex);
-
 	auto it = sprites.find(name);
 	if(it == sprites.end())
 		it = sprites.emplace(name, Sprite(name)).first;

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -68,14 +68,14 @@ namespace {
 
 
 
-future<void> UniverseObjects::Load(const vector<string> &sources, bool debugMode)
+void UniverseObjects::Load(tbb::task_group &group, const vector<string> &sources, bool debugMode)
 {
 	progress = 0.;
 
 	// We need to copy any variables used for loading to avoid a race condition.
 	// 'this' is not copied, so 'this' shouldn't be accessed after calling this
 	// function (except for calling GetProgress which is safe due to the atomic).
-	return async(launch::async, [this, sources, debugMode]() noexcept -> void
+	group.run([this, sources, debugMode]() noexcept -> void
 		{
 			vector<string> files;
 			for(const string &source : sources)

--- a/source/UniverseObjects.h
+++ b/source/UniverseObjects.h
@@ -41,7 +41,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "TextReplacements.h"
 #include "Trade.h"
 
-#include <future>
+#include <tbb/task_group.h>
+
 #include <map>
 #include <string>
 #include <vector>
@@ -59,7 +60,7 @@ class UniverseObjects {
 	friend class GameData;
 public:
 	// Load game objects from the given directories of definitions.
-	std::future<void> Load(const std::vector<std::string> &sources, bool debugMode = false);
+	void Load(tbb::task_group &group, const std::vector<std::string> &sources, bool debugMode = false);
 	// Determine the fraction of data files read from disk.
 	double GetProgress() const;
 	// Resolve every game object dependency.


### PR DESCRIPTION
## Feature Details

This PR switches our use of threads with the [TBB library](https://github.com/oneapi-src/oneTBB). Doing so has several advantages, which I will list below. 

- <details><summary>Efficient use of CPU threads</summary>Currently we spawn a whole separate thread for everything we need to multithread. But we are currently creating more threads than the CPU even has (the image loading threads use up all of the available threads by themselves).

    TBB creates exactly as many threads as the CPU supports automatically. </details>

- <details><summary>Independent tasks are pooled together and distributed across all threads</summary>Currently if let's say the image loading threads have finished loading all the images but the audio loading threading is still working, then we have an inefficient use of resources: There is only one audio thread responsible for loading the audio files, all the other CPU threads in the mean time remain idle.

    TBB efficiently distributes those tasks so that every CPU thread always has work to do.</details>

- <details><summary>Useful abstractions for multithreading that make the code easier to understand (with less lines of code).</summary>TBB includes very useful abstractions (like concurrent containers) that simplify a lot of code. Condition variables are tricky to understand if you've never encountered them and it's easy to make a mistake while implementing them. This PR completely eliminates every use of condition variables and lots of locks which make the multithreading portions of the code easier to understand.

    Also you might have noticed that this PR results in a net *decrease* of the code.</details>

- <details><summary>Adding parallelism to other parts of the code is very easy.</summary>The engine (also AI, collision detection, ...) does a lot of work that can be easily parallelized. With the current threading model actually doing so is not at all straightforward. But with TBB it's as simple as a call to tbb::parallel_for so parallelize a loop (for example), using every available thread on the CPU to execute the work as fast as possible.</details>

This PR also includes a fix for #6475, since it became very easy to fix.

Just to be clear: This PR simply switches the current threading code with TBB. There is no additional parallelism introduced (those are for latter PRs).

The immediate (and possible deal-breaker) disadvantage is the fact that we add yet another dependency to the game, when building and when running. Additionally, this PR requires a newish version of TBB that isn't available in Ubuntu 18. For Windows we can just add the newest version to the win64.dev zip file. This PR is marked as draft cause the additional dependency will cause CI to fail.

Feedback appreciated!

## Testing Done

Played the game a bit. I also ran a thread sanitizer to verify that I haven't accidentally added a race condition. 

## Performance Impact

Speedup due to better use of system resources and increased parallelization. 
