### PR TITLE
Fix: Remove duplicate "atmosphere scan" on Merganser

### DIFF
--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -611,7 +611,6 @@ ship "Merganser"
 		"outfit scan power" 12
 		"outfit scan speed" 1
 		"tactical scan power" 26
-		"atmosphere scan" 100
 		"ion resistance" 0.1
 		"ion resistance energy" -0.05
 		"thrust" 5.0


### PR DESCRIPTION
**Bugfix:**

## Fix Details
This deletes one line with a duplicate `"atmosphere scan" 100` from the Merganser.

Thank you to Hecter on the Discord for reporting it.

