### PR TITLE
Add 'd' key shortcut to delete a pilot.

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -301,7 +301,7 @@ interface "load menu"
 		center -420 155
 		dimensions 120 30
 	active if "pilot selected"
-	button D "Delete"
+	button d "_Delete"
 		center -285 155
 		dimensions 90 30
 	

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -213,7 +213,7 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		// StartConditionsPanel also handles the case where there's no scenarios.
 		GetUI()->Push(new StartConditionsPanel(player, gamePanels, GameData::StartOptions(), this));
 	}
-	else if(key == 'D' && !selectedPilot.empty())
+	else if(key == 'd' && !selectedPilot.empty())
 	{
 		GetUI()->Push(new Dialog(this, &LoadPanel::DeletePilot,
 			"Are you sure you want to delete the selected pilot, \"" + selectedPilot


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4891

## Feature Details

Readds a shortcut to delete a pilot since deleting a pilot is now impossible to do accidentally. This doesn't add a shortcut to remove a snapshot because that confirmation dialog is too easy to dismiss. 

## Testing Done

Pressing 'd' correctly opens the delete confirmation dialog.

## Performance Impact
N/A
