### PR TITLE
Added Job to hire an escort, Just human interceptor for now.

### DIFF
--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -8,6 +8,39 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
+mission "Hire Interceptor Escort(human space interceptor)"
+    name "Hire an Interceptor to accompany you until <date>."
+    description "The capatin of <npc> is offering to accompany you until <date> for <payment>, they are flying an interceptor"
+    repeat
+    job
+    deadline 30
+    to offer
+        random < 90
+    on offer
+        payment -30000
+    source
+        government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+    destination 9 13
+    npc accompany
+        government "Escort"
+        personality escort
+        fleet
+            names "civilian"
+            variant 1
+                "Hawk"
+            variant 2
+                "Sparrow"
+            variant 3
+                "Hawk (Bomber)"
+            variant 4
+                "Fury (Bomber)"
+            variant 4
+                "Fury"
+    to complete
+        never
+    on complete
+        payment 30000
+
 mission "Escort (Tiny, Northern, Dangerous Destination)"
 	name "Escort to <planet>"
 	description "Despite your relative inexperience, the captain of the <npc> is willing to pay you <payment> for an escort into a dangerous region of space to reach <destination> by <date>."


### PR DESCRIPTION
Adds a job which would allow the player to hire an escort, in this case it is just an interceptor and you can only hire within Human space.

----------------------
Content (Missions)

Allows to player to take a job which hires an interceptor escort for 30 days, this cost the player 30000 credits. 
Currently it is only available in human space and only interceptors but that can be expanded upon with relative ease.

[Hire interceptor Test.txt](https://github.com/endless-sky/endless-sky/files/8044969/Hire.interceptor.Test.txt)

![image](https://user-images.githubusercontent.com/57198044/153514366-d8f2e21b-3b01-41b0-90d1-4e4c457ca237.png)
![image](https://user-images.githubusercontent.com/57198044/153514397-96d1519f-09dc-4b20-ad06-21d40d40f26e.png)
![image](https://user-images.githubusercontent.com/57198044/153514459-80b330cc-7a0f-4153-9e50-5ae4a6b316ff.png)
![image](https://user-images.githubusercontent.com/57198044/153514475-99f7e0d7-100f-4180-9588-ca9c1a440c16.png)

I decline to claim any copyright