### PR TITLE
Introduce Mission::CanAccept to avoid accepting missions whose requirements aren't met anymore.

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1130,7 +1130,7 @@ void MapPanel::DrawMissions()
 	for(const Mission &mission : player.AvailableJobs())
 	{
 		const System *system = mission.Destination()->GetSystem();
-		DrawPointer(system, angle[system], mission.HasSpace(player) ? availableColor : unavailableColor);
+		DrawPointer(system, angle[system], mission.CanAccept(player) ? availableColor : unavailableColor);
 	}
 	for(const Mission &mission : player.Missions())
 	{

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -703,6 +703,20 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 
 
 
+bool Mission::CanAccept(const PlayerInfo &player) const
+{
+	auto it = actions.find(OFFER);
+	if(it != actions.end() && !it->second.CanBeDone(player))
+		return false;
+
+	it = actions.find(ACCEPT);
+	if(it != actions.end() && !it->second.CanBeDone(player))
+		return false;
+	return HasSpace(player);
+}
+
+
+
 bool Mission::HasSpace(const PlayerInfo &player) const
 {
 	int extraCrew = 0;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -115,6 +115,7 @@ public:
 	// into account, so before actually offering a mission you should also check
 	// if the player has enough space.
 	bool CanOffer(const PlayerInfo &player, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
+	bool CanAccept(const PlayerInfo &player) const;
 	bool HasSpace(const PlayerInfo &player) const;
 	bool HasSpace(const Ship &ship) const;
 	bool CanComplete(const PlayerInfo &player) const;

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -686,7 +686,7 @@ Point MissionPanel::DrawList(const list<Mission> &list, Point pos,
 				Point(SIDE_WIDTH - 10., 20.),
 				highlight);
 
-		bool canAccept = (&list == &available ? it->HasSpace(player) : IsSatisfied(*it));
+		bool canAccept = (&list == &available ? it->CanAccept(player) : IsSatisfied(*it));
 		font.Draw({it->Name(), {SIDE_WIDTH - 11, Truncate::BACK}},
 			pos, (!canAccept ? dim : isSelected ? selected : unselected));
 	}
@@ -731,7 +731,7 @@ bool MissionPanel::CanAccept() const
 	if(availableIt == available.end())
 		return false;
 
-	return availableIt->HasSpace(player);
+	return availableIt->CanAccept(player);
 }
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6538 

## Fix Details

Introduces a new function called `Mission::CanAccept` that checks whether a mission can be accepted. It checks whether the `on offer` and `on accept` actions can be done (which includes payment but also outfit requirements among others) and whether the player has enough space.

I didn't change the `Mission::HasSpace` function because that function is still useful standalone to avoid duplicating work when `CanOffer` is called as well.

## Testing Done

TBH none (yes I know I'm lazy), but this PR is pretty straightforward I think (at least I hope so). But I'll do more testing if required.