### PR TITLE
feature: Add (iterator based) find() and empty() methods to the Set class

### DIFF
--- a/source/Set.h
+++ b/source/Set.h
@@ -34,12 +34,18 @@ public:
 
 	bool Has(const std::string &name) const { return data.count(name); }
 
-	typename std::map<std::string, Type>::iterator begin() { return data.begin(); }
-	typename std::map<std::string, Type>::const_iterator begin() const { return data.begin(); }
-	typename std::map<std::string, Type>::iterator end() { return data.end(); }
-	typename std::map<std::string, Type>::const_iterator end() const { return data.end(); }
+	using setIt = typename std::map<std::string, Type>::iterator;
+	using setCIt = typename std::map<std::string, Type>::const_iterator;
+
+	setIt begin() { return data.begin(); }
+	setCIt begin() const { return data.begin(); }
+	setIt find(const std::string &key) { return data.find(key); }
+	setCIt find(const std::string &key) const { return data.find(key); }
+	setIt end() { return data.end(); }
+	setCIt end() const { return data.end(); }
 
 	int size() const { return data.size(); }
+	bool empty() const { return data.empty(); }
 	// Remove any objects in this set that are not in the given set, and for
 	// those that are in the given set, revert to their contents.
 	void Revert(const Set<Type> &other);

--- a/tests/src/test_set.cpp
+++ b/tests/src/test_set.cpp
@@ -34,12 +34,14 @@ SCENARIO( "a Set can be interacted with by consuming classes even when const", "
 	GIVEN( "data for the key does not exist" ) {
 		const auto s = Set<T>{};
 		REQUIRE( s.size() == 0 );
+		REQUIRE( s.empty() );
 		REQUIRE_FALSE( s.Has(key) );
 
 		WHEN( "Get(key) is called" ) {
 			const auto &dataPtr = s.Get(key);
 			THEN( "the Set increases in size" ) {
 				CHECK( s.size() == 1 );
+				CHECK_FALSE( s.empty() );
 			}
 			THEN( "a valid pointer is returned" ) {
 				CHECK( dataPtr != nullptr );
@@ -54,9 +56,21 @@ SCENARIO( "a Set can be interacted with by consuming classes even when const", "
 			const auto &dataPtr = s.Find(key);
 			THEN( "the Set does not increase in size" ) {
 				CHECK( s.size() == 0 );
+				CHECK( s.empty() );
 			}
 			THEN( "nullptr is returned" ) {
 				CHECK( dataPtr == nullptr );
+			}
+		}
+		
+		WHEN( "find(key) is called" ) {
+			const auto cIt = s.find(key);
+			THEN( "the Set does not increase in size" ) {
+				CHECK( s.size() == 0 );
+				CHECK( s.empty() );
+			}
+			THEN( "the returned iterator equals end" ) {
+				CHECK( cIt == s.end() );
 			}
 		}
 	}
@@ -84,6 +98,19 @@ SCENARIO( "a Set can be interacted with by consuming classes even when const", "
 			THEN( "the same, valid pointer is returned" ) {
 				CHECK( secondPtr == firstPtr );
 			}
+		}
+
+		WHEN( "find(key) is called" ) {
+			const auto cIt = s.find(key);
+			THEN( "the Set does not increase in size" ) {
+				CHECK( s.size() == 1 );
+			}
+			THEN( "the iterator does point to the begin position" ) {
+				CHECK( cIt == s.begin() );
+			}			
+			THEN( "the iterator doesn't point to the end position" ) {
+				CHECK( cIt != s.end() );
+			}			
 		}
 	}
 }


### PR DESCRIPTION
**Feature:** This PR implements the find and empty functions on the set class, as used in #4471

## Feature Details
This PR adds an empty() function to the Set class to check if the set is empty; which is nicer than checking if (size() == 0)).
This PR also adds a find() function to the Set class to allow finding the iterator-position for an element in the Set and to allow iterating further from there.

Those new functions in set are used in #4471, but could be merged ahead of that PR independently. This PR also extends the unit-tests for the set with the 2 new functions.

## UI Screenshots
N/A

## Usage Examples
N/A (use use the functions when you need them)

## Testing Done
Tested by the new unit-tests added in this PR, and tested as part of #4471 (when manually switching formations).

## Performance Impact
None expected.