### PR TITLE
Fix: "Remnant: Rescue 4" - Providing telemetry explanation

### DIFF
--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -493,7 +493,7 @@ mission "Remnant: Rescue 4"
 	job
 	repeat
 	name "Distress Signal: Graveyard"
-	description "A distress signal has been received from the <npc> in the Graveyard. Hurry there, and help return them safely to <destination>."
+	description "A distress signal has been received from the <npc> in the Graveyard. Follow the telemetry data to find them, and help return them safely to <destination>."
 	source
 		government "Remnant"
 	to offer


### PR DESCRIPTION
**Bugfix:** This PR addresses issue reported by Starext on the discord server
 — 

## Fix Details
For this rescue mission, the player receives telemetry info in the form of the target ship being listed as an escort. The description, however, makes no mention of this, so it looks like a bug.

This tweaks the description so that it mentions that there is telemetry data to follow.

Thanks to Starext for reporting this!

## Impact
- No impact on the game or mission chains, however does provide an explanation as to why the player can see the telemetry for the target ship.
- Minor lore impact in demonstrating that the Remnant *do* have telemetry feeds from their ships in the same way that the player can get telemetry on escorts across the galaxy.

