### PR TITLE
Extended key command and weapon support

### DIFF
--- a/source/Command.h
+++ b/source/Command.h
@@ -138,19 +138,20 @@ public:
 
 
 private:
-	explicit Command(uint64_t state);
-	Command(uint64_t state, const std::string &text);
+	explicit Command(uint64_t keyCommands, uint64_t weapons);
+	Command(uint64_t keyCommands, const std::string &text);
 
 
 private:
-	// The key commands and weapons to fire are stored in a single bitmask, with
-	// 32 bits for key commands and 32 bits for individual weapons.
+	// The key commands stored in a bitmask
+	uint64_t keyCommands = 0;
+	// The weapons to fire stored in a bitmask
 	// Ship::Load gives a soft warning for ships with more than 32 weapons.
-	uint64_t state = 0;
+	uint64_t weapons = 0;
 	// Turning amount is stored as a separate double to allow fractional values.
 	double turn = 0.;
 	// Turret turn rates, reduced to 8 bits to save space.
-	signed char aim[32] = {};
+	signed char aim[64] = {};
 };
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -297,9 +297,9 @@ void Ship::Load(const DataNode &node)
 				armament.AddGunPort(hardpoint, gunPortAngle, gunPortParallel, drawUnder, outfit);
 			else
 				armament.AddTurret(hardpoint, drawUnder, outfit);
-			// Print a warning for the first hardpoint after 32, i.e. only 1 warning per ship.
-			if(armament.Get().size() == 33)
-				child.PrintTrace("Warning: ship has more than 32 weapon hardpoints. Some weapons may not fire:");
+			// Print a warning for the first hardpoint after 64, i.e. only 1 warning per ship.
+			if(armament.Get().size() == 65)
+				child.PrintTrace("Warning: ship has more than 64 weapon hardpoints. Some weapons may not fire:");
 		}
 		else if(key == "never disabled")
 			neverDisabled = true;


### PR DESCRIPTION
## Feature Details
Added support for up to 64 individual key commands and 64 weapons. The previous behaviour is preserved in all cases. 

This eliminates a potential bottleneck in the development of the game. We were already using 29 out of the 32 available command slots and new ships keep getting bigger, so we would have run out of space for either of these after a while. In fact, I've seen command suggestions shot down in discord with something along the lines of 'we don't have space for many new commands, and changing that structure would hurt performance'.

## Testing Done
I've tested that the new version does in fact support 64 commands and weapons.

## Performance Impact
Since there were performance concerns I've done extensive testing in that department.

### Test Environment
Everything was tested on my local machine. I used a fresh build of either versions in 'Release' mode using -O3. The reference commit in the official repository is f9676f5d306d33013f470d89990999026066d1d5. I tried to minimize the amount of background apps running, but the results were still somewhat unreliable. Any additional testing is appreciated.

Details about my machine:
- Windows 10 Pro 21H2 (19044.1526)
- 16GB RAM, 3200 MT/s
- Ryzen 7 3700X 4.4GHz
- Radeon RX 570 (8GB GDDR5, 1300 MHz base, 1750 MHz memory)

### Test Scenarios
The performance impact was measured in 5 real-live test cases. Each one begins with the player departing from a planet. Each scenario was run 5 times (5 times while zoomed in, 5 times while zoomed out).
- no command: The ships received no commands and just drifted around the planet
- follow: The ships were instructed to follow the player's flagship
- hold position: The ships were instructed to hold position
- jump drive: The ships jumped to an adjacent system via Jump Drives. Unfortunately, I couldn't get accurate results with hyperdrives so I excluded those tests from the results.
- combat: A single enemy ships leaves the planet together with the player's fleet.

If you want to reproduce these tests, you can use these save files:
[Test Pilot~Command Test.txt](https://github.com/endless-sky/endless-sky/files/8083032/Test.Pilot.Command.Test.txt) for the first 4 tests
[Test Pilot~Combat Test.txt](https://github.com/endless-sky/endless-sky/files/8083031/Test.Pilot.Combat.Test.txt) for the combat test

### Test Results
ES performance (cpu/gpu load % as reported by the game):

- f9676f5d306d33013f470d89990999026066d1d5:
	- no command:
		- zoomed out:
			- max: 30/28
			- initial: 28/25
			- stable: 29/21
		- zoomed in:
			- max: 29/179
			- initial: 23/12
			- stable 28/9
	- follow:
		- zoomed out:
			- max: 30/31
			- initial: 20/24
			- stable 26/31
		- zoomed in:
			- max: 28/115
			- initial: 18/30
			- stable 25/9
	- hold position:
		- zoomed out:
			- max: 19/18
			- initial: 13/18
			- stable 16/15
		- zoomed in:
			- max: 18/94
			- initial: 19/32
			- stable 15/12
	- jump drive:
		- zoomed out:
			- max: 178/74
			- initial (before jump, during animation): 62/17
			- stable (while holding jump button): 76/25
			- initial (after jump, during animation): 30/66
		- zoomed in:
			- max: 112/22
			- initial (before jump, during animation): 68/10
			- stable (while holding jump button): 76/32
			- initial (after jump, during animation): 31/12
	- combat:
		- zoomed out:
			- max: 2302/179
			- initial: 61/76
			- stable 2280/98
		- zoomed in:
			- max: 2023/337
			- initial: 61/126
			- stable 2020/281
- in the new version:
	- no command:
		- zoomed out:
			- max: 29/30
			- initial: 21/27
			- stable: 27/23
		- zoomed in:
			- max: 26/169 (once I got 257, couldn't verify)
			- initial: 12/25
			- stable: 26/9
	- follow:
		- zoomed out:
			- max: 25/29
			- initial: 20/24
			- stable: 26/23
		- zoomed in:
			- max: 26/120
			- initial: 12/38
			- stable: 25/10
	- hold position:
		- zoomed out:
			- max: 19/25
			- initial: 16/19
			- stable: 13/16
		- zoomed in:
			- max: 23/130
			- initial: 10/19
			- stable: 12/10
	- jump drive:
		- zoomed out:
			- max: 162/82
			- initial (before jump, during animation): 57/32
			- stable (while holding jump button): 68/17
			- initial (after jump, during animation): 43/64
		- zoomed in:
			- max: 112/20
			- initial (before jump, during animation): 71/30
			- stable (while holding jump button): 71/32
			- initial (after jump, during animation): 30/14
	- combat:
		- zoomed out:
			- max: 2261/114
			- initial: 67/79
			- stable: 2030/88 (not sure about what happened here)
		- zoomed in:
			- max: 2298/318
			- initial: 217/51
			- stable: 2015/80
			
Notes: 
 - The player's flagship receives no movement commands in any scenarios, only a single 'jump' command in the jump drive test.
 - In the 'jump drive' test, the jump key was held down until all ships were ready.
 - In the 'zoomed in' tests the maximum GPU load is higher while the 'stable' load is generally lower than in zoomed out scenarios. This is due to certain ships not being rendered during testing, because they drift outside of the screen. Since this is consistent with the game's real-world behaviour, I left the results untouched.
 - All tests were conducted with fast mode ON.
 - The memory usage of the application was monitored via Task Manager, and there was no noticeable difference between the two versions.

TL;DR: There is no real performance loss.
