### PR TITLE
Calculate distance-based damageScaling at explode-time

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3170,7 +3170,7 @@ double Ship::MaxReverseVelocity() const
 // according to the weapon and the characteristics of how
 // it hit this ship, and add any visuals created as a result
 // of being hit.
-int Ship::TakeDamage(vector<Visual> &visuals, const Weapon &weapon, double damageScaling, double distanceTraveled, const Point &damagePosition, const Government *sourceGovernment, bool isBlast)
+int Ship::TakeDamage(vector<Visual> &visuals, const Weapon &weapon, double damageScaling, const Point &damagePosition, const Government *sourceGovernment, bool isBlast)
 {
 	if(isBlast && weapon.IsDamageScaled())
 	{
@@ -3187,8 +3187,6 @@ int Ship::TakeDamage(vector<Visual> &visuals, const Weapon &weapon, double damag
 		double rSquared = d * d / (blastRadius * blastRadius);
 		damageScaling *= k / ((1. + rSquared * rSquared) * (1. + rSquared * rSquared));
 	}
-	if(weapon.HasDamageDropoff())
-		damageScaling *= weapon.DamageDropoff(distanceTraveled);
 
 	// Instantaneous damage types:
 	double shieldDamage = (weapon.ShieldDamage() + weapon.RelativeShieldDamage() * attributes.Get("shields"))

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -330,7 +330,7 @@ public:
 	// Blast damage is dependent on the distance to the damage source.
 	// Create any target effects as sparks.
 	int TakeDamage(std::vector<Visual> &visuals, const Weapon &weapon, double damageScaling,
-		double distanceTraveled, const Point &damagePosition, const Government *sourceGovernment, bool isBlast = false);
+		const Point &damagePosition, const Government *sourceGovernment, bool isBlast = false);
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.
 	void ApplyForce(const Point &force, bool gravitational = false);


### PR DESCRIPTION
**Feature:** This PR implements a performance improvement for damage/distance scaling

## Feature Details
This moves the calculation for distance scaling from Ship::TakeDamage() to just before taking the relevant damage.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Not fully tested yet, but I wanted to upload this already so that it could be considered for the refactoring done in #6557.

## Performance Impact
This should give a positive impact when multiple ships are hit by the same distance scaled weapon.
