### PR TITLE
[Fix] Remove Drak Ammo capacity attribute from the Archon

### DIFF
--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -39,7 +39,6 @@ ship "Archon"
 		"ion protection" 3
 		"ion resistance" 1
 		"ramscoop" 100
-		"Drak Ammunition capacity" 120000000
 		weapon
 			"blast radius" 200
 			"shield damage" 20000


### PR DESCRIPTION
----------------------
**Content Fix**
The Drak Ammunition the augmented Drak weapons used was removed in favor of having them "use" 0 Jump Drives to fire, so there's no need for this attribute.