### PR TITLE
Add ramscoops to outfitters on Haven, Prime and Sunracer

### DIFF
--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -211,6 +211,9 @@ outfitter "Ammo North"
 	"Sidewinder Missile"
 	"Local Map"
 
+outfitter "Northern Explorers"
+	"Ramscoop"
+
 outfitter "Ammo South"
 	"Meteor Missile"
 	"Javelin"

--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -211,14 +211,14 @@ outfitter "Ammo North"
 	"Sidewinder Missile"
 	"Local Map"
 
-outfitter "Northern Explorers"
-	"Ramscoop"
-
 outfitter "Ammo South"
 	"Meteor Missile"
 	"Javelin"
 	"Heavy Rocket"
 	"Local Map"
+
+outfitter "Northern Explorers"
+	"Ramscoop"
 
 outfitter "Deep Sky Basics"
 	"Ramscoop"

--- a/data/map.txt
+++ b/data/map.txt
@@ -27578,6 +27578,7 @@ planet Haven
 	outfitter "Ammo North"
 	outfitter "Ammo South"
 	outfitter "Pirate Outfits"
+	outfitter "Northern Explorers"
 	bribe 0.03
 	security 0
 	tribute 700
@@ -28769,6 +28770,7 @@ planet Prime
 	outfitter "Common Outfits"
 	outfitter "Ammo North"
 	outfitter "Lovelace Basics"
+	outfitter "Northern Explorers"
 	"required reputation" 2
 	bribe 0.05
 	security 0.6
@@ -29482,6 +29484,7 @@ planet Sunracer
 	outfitter "Syndicate Advanced"
 	outfitter "Lovelace Basics"
 	outfitter "Ammo North"
+	outfitter "Northern Explorers"
 	bribe 0.06
 	security 0.7
 	tribute 1700


### PR DESCRIPTION
## Summary
The outfitters adjacent to the largest uninhabited section of space don't carry the ramscoops needed to traverse it. This PR creates a new outfitter definition 'Northern Explorers' which contains only ramscoops and then adds it to the outfitters on Haven/Arneb, Prime/Betelgeuse and Sunracer/Mirfak. Catalytic ramscoops are not added.