### PR TITLE
Quote strings that begin with a '#'.

### DIFF
--- a/source/DataWriter.cpp
+++ b/source/DataWriter.cpp
@@ -101,7 +101,7 @@ void DataWriter::WriteComment(const string &str)
 void DataWriter::WriteToken(const char *a)
 {
 	// Figure out what kind of quotation marks need to be used for this string.
-	bool hasSpace = !*a;
+	bool hasSpace = !*a || *a == '#';
 	bool hasQuote = false;
 	for(const char *it = a; *it; ++it)
 	{

--- a/source/DataWriter.cpp
+++ b/source/DataWriter.cpp
@@ -101,19 +101,19 @@ void DataWriter::WriteComment(const string &str)
 void DataWriter::WriteToken(const char *a)
 {
 	// Figure out what kind of quotation marks need to be used for this string.
-	bool hasSpace = !*a || *a == '#';
+	bool needsQuoting = !*a || *a == '#';
 	bool hasQuote = false;
 	for(const char *it = a; *it; ++it)
 	{
-		hasSpace |= (*it <= ' ' && *it >= 0);
+		needsQuoting |= (*it <= ' ' && *it >= 0);
 		hasQuote |= (*it == '"');
 	}
 
 	// Write the token, enclosed in quotes if necessary.
 	out << *before;
-	if(hasSpace && hasQuote)
+	if(needsQuoting && hasQuote)
 		out << '`' << a << '`';
-	else if(hasSpace)
+	else if(needsQuoting)
 		out << '"' << a << '"';
 	else
 		out << a;


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported by Apotheon on the Discord.

## Fix Details

When writing strings to file that begin with a `'#'`, `DataWriter` didn't escape them with quotes. As a result, the string got interpreted as a comment and ignored when the file is loaded again by the game.

This PR fixes the issue by quoting strings that begin with a `'#'`. Strings that simply contain a `'#'` on any other position do not pose a problem for the parser.

## Testing Done

Created a new pilot with the name `broken #hi`. The first line is on master and the second one is with this PR.

```
pilot broken #hi
pilot broken "#hi"
```