### PR TITLE
fix(mechanics): check player.Cargo() for required outfits

### DIFF
--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -249,6 +249,7 @@ bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &
 		bool checkAll = !it.second;
 		if(checkAll)
 		{
+			available += player.Cargo().Get(it.first);
 			for(const auto &ship : player.Ships())
 				if(!ship->IsDestroyed())
 				{


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6574.

## Fix Details
Added a line of code to take into account `player.Cargo()` when checking required outfits.

## Testing Done
Tested by following the reproduction steps in the relevant issue (#6574) and observing nothing out-of-place.

Only tested with the `on offer` and `on complete` triggers on the `landing` mission. The code appears to be the same with the other `on`-triggers. `player.Cargo` seems to be zeroed for `boarding`/`assisting` missions, so shouldn't affect the `available` counter.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 898df94cf1bccc6b523cc126838cd2308f59ef3c, and will not occur when using this branch's build.

https://gist.github.com/TrebledJ/e8ee3cd83bca8d299a66d3f0e2659860
