### PR TITLE
Really fail missions after Earth Day deadline

### DIFF
--- a/data/human/near earth jobs.txt
+++ b/data/human/near earth jobs.txt
@@ -50,8 +50,7 @@ mission "To Earth Day celebration [0]"
 				month == 4
 				day < 22
 	to fail
-		month == 4
-		day == 22
+		month * 100 + day >= 422
 	source
 		near "Sol" 1 15
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
@@ -84,8 +83,7 @@ mission "To Earth Day celebration [1]"
 				month == 4
 				day < 22
 	to fail
-		month == 4
-		day == 22
+		month * 100 + day >= 422
 	source
 		near "Sol" 1 15
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"


### PR DESCRIPTION
...instead of failing only if landing somewhere on the very Earth Day.

This PR addresses issue #6526 (using "compact" conditions as per suggestion in #6553 comments)

## Fix Details
It is the minimal fix to make the missions work as intended (according to their current "on fail" condition)
I didn't change the description of the missions as suggested in #6526, as I missed some proof-reading and I'm not sure it would be clearer (the current description might be ok, even if it may surprise people used to deliver after the deadline, like I was ;)

## Testing Done
I edited the save file from #6526 with the new conditions:
- mission succeeds before Earth Day and deadline (same as before)
- mission fails when landing on Earth Day (same as before)
- mission fails when landing after Earth Day (unlike before)
