### PR TITLE
Ships targeted by trigger radius weapons now become provoked

### DIFF
--- a/source/DamageDealt.h
+++ b/source/DamageDealt.h
@@ -25,15 +25,13 @@ class Weapon;
 // blast for Ship::TakeDamage to access.
 class DamageDealt {
 public:
-	DamageDealt(const Weapon &weapon, double scaling, bool isBlast)
-		: weapon(weapon), scaling(scaling), isBlast(isBlast) {}
+	DamageDealt(const Weapon &weapon, double scaling)
+		: weapon(weapon), scaling(scaling) {}
 
 	// The weapon that dealt damage.
 	const Weapon &GetWeapon() const;
 	// The damage scaling that was used for this damage.
 	double Scaling() const;
-	// Whether damage was dealt as a blast.
-	bool IsBlast() const;
 
 	// Instantaneous damage types.
 	double Shield() const noexcept;
@@ -64,7 +62,6 @@ private:
 
 	const Weapon &weapon;
 	double scaling;
-	bool isBlast;
 
 	double hullDamage = 0.;
 	double shieldDamage = 0.;
@@ -86,7 +83,6 @@ private:
 
 inline const Weapon &DamageDealt::GetWeapon() const { return weapon; }
 inline double DamageDealt::Scaling() const { return scaling; }
-inline bool DamageDealt::IsBlast() const { return isBlast; }
 
 inline double DamageDealt::Shield() const noexcept { return shieldDamage; }
 inline double DamageDealt::Hull() const noexcept { return hullDamage; }

--- a/source/DamageProfile.cpp
+++ b/source/DamageProfile.cpp
@@ -46,7 +46,7 @@ DamageProfile::DamageProfile(Weather::ImpactInfo info)
 DamageDealt DamageProfile::CalculateDamage(const Ship &ship, bool ignoreBlast) const
 {
 	bool blast = (isBlast && !ignoreBlast);
-	DamageDealt damage(weapon, Scale(inputScaling, ship, blast), blast);
+	DamageDealt damage(weapon, Scale(inputScaling, ship, blast));
 	PopulateDamage(damage, ship);
 
 	return damage;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2057,7 +2057,7 @@ void Engine::DoCollisions(Projectile &projectile)
 					continue;
 
 				int eventType = ship->TakeDamage(visuals, damage.CalculateDamage(*ship, ship == hit.get()),
-					projectile.GetGovernment(), targeted);
+					gov, targeted);
 				if(eventType)
 					eventQueue.emplace_back(gov, ship->shared_from_this(), eventType);
 			}
@@ -2065,7 +2065,7 @@ void Engine::DoCollisions(Projectile &projectile)
 		else if(hit)
 		{
 			int eventType = hit->TakeDamage(visuals, damage.CalculateDamage(*hit),
-				projectile.GetGovernment(), projectile.Target() == hit.get());
+				gov, projectile.Target() == hit.get());
 			if(eventType)
 				eventQueue.emplace_back(gov, hit, eventType);
 		}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2056,14 +2056,16 @@ void Engine::DoCollisions(Projectile &projectile)
 				if(isSafe && !targeted && !gov->IsEnemy(ship->GetGovernment()))
 					continue;
 
-				int eventType = ship->TakeDamage(visuals, damage.CalculateDamage(*ship, ship == hit.get()), projectile.GetGovernment(), targeted);
+				int eventType = ship->TakeDamage(visuals, damage.CalculateDamage(*ship, ship == hit.get()),
+					projectile.GetGovernment(), targeted);
 				if(eventType)
 					eventQueue.emplace_back(gov, ship->shared_from_this(), eventType);
 			}
 		}
 		else if(hit)
 		{
-			int eventType = hit->TakeDamage(visuals, damage.CalculateDamage(*hit), projectile.GetGovernment());
+			int eventType = hit->TakeDamage(visuals, damage.CalculateDamage(*hit),
+				projectile.GetGovernment(), projectile.Target() == hit.get());
 			if(eventType)
 				eventQueue.emplace_back(gov, hit, eventType);
 		}
@@ -2104,7 +2106,7 @@ void Engine::DoWeather(Weather &weather)
 		for(Body *body : shipCollisions.Ring(weather.Origin(), hazard->MinRange(), hazard->MaxRange()))
 		{
 			Ship *hit = reinterpret_cast<Ship *>(body);
-			hit->TakeDamage(visuals, damage.CalculateDamage(*hit), nullptr);
+			hit->TakeDamage(visuals, damage.CalculateDamage(*hit), nullptr, false);
 		}
 	}
 }

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2056,16 +2056,16 @@ void Engine::DoCollisions(Projectile &projectile)
 				if(isSafe && !targeted && !gov->IsEnemy(ship->GetGovernment()))
 					continue;
 
+				// Only directly targeted ships get provoked by blast weapons.
 				int eventType = ship->TakeDamage(visuals, damage.CalculateDamage(*ship, ship == hit.get()),
-					gov, targeted);
+					targeted ? gov : nullptr);
 				if(eventType)
 					eventQueue.emplace_back(gov, ship->shared_from_this(), eventType);
 			}
 		}
 		else if(hit)
 		{
-			int eventType = hit->TakeDamage(visuals, damage.CalculateDamage(*hit),
-				gov, projectile.Target() == hit.get());
+			int eventType = hit->TakeDamage(visuals, damage.CalculateDamage(*hit), gov);
 			if(eventType)
 				eventQueue.emplace_back(gov, hit, eventType);
 		}
@@ -2106,7 +2106,7 @@ void Engine::DoWeather(Weather &weather)
 		for(Body *body : shipCollisions.Ring(weather.Origin(), hazard->MinRange(), hazard->MaxRange()))
 		{
 			Ship *hit = reinterpret_cast<Ship *>(body);
-			hit->TakeDamage(visuals, damage.CalculateDamage(*hit), nullptr, false);
+			hit->TakeDamage(visuals, damage.CalculateDamage(*hit), nullptr);
 		}
 	}
 }

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2052,10 +2052,11 @@ void Engine::DoCollisions(Projectile &projectile)
 			for(Body *body : shipCollisions.Circle(hitPos, blastRadius))
 			{
 				Ship *ship = reinterpret_cast<Ship *>(body);
-				if(isSafe && projectile.Target() != ship && !gov->IsEnemy(ship->GetGovernment()))
+				bool targeted = (projectile.Target() == ship);
+				if(isSafe && !targeted && !gov->IsEnemy(ship->GetGovernment()))
 					continue;
 
-				int eventType = ship->TakeDamage(visuals, damage.CalculateDamage(*ship, ship == hit.get()), projectile.GetGovernment());
+				int eventType = ship->TakeDamage(visuals, damage.CalculateDamage(*ship, ship == hit.get()), projectile.GetGovernment(), targeted);
 				if(eventType)
 					eventQueue.emplace_back(gov, ship->shared_from_this(), eventType);
 			}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3194,11 +3194,11 @@ double Ship::MaxReverseVelocity() const
 
 
 
-// This ship just got hit by the given weapon. Take damage
-// according to the weapon and the characteristics of how
-// it hit this ship, and add any visuals created as a result
-// of being hit.
-int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, bool targeted)
+// This ship just got hit by a weapon. Take damage according to the
+// DamageDealt from that weapon. The return value is a ShipEvent type,
+// which may be a combination of PROVOKED, DISABLED, and DESTROYED.
+// Create any target effects as sparks.
+int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment)
 {
 	bool wasDisabled = IsDisabled();
 	bool wasDestroyed = IsDestroyed();
@@ -3261,11 +3261,9 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	else if(heat < .9 * MaximumHeat())
 		isOverheated = false;
 
-	// If this ship was hit directly or was directly targeted and did
-	// not consider itself an enemy of the ship that hit it, it is now
-	// "provoked" against that government.
-	if((!damage.IsBlast() || targeted)
-			&& sourceGovernment && !sourceGovernment->IsEnemy(government)
+	// If this ship did not consider itself an enemy of the ship that hit it,
+	// it is now "provoked" against that government.
+	if(sourceGovernment && !sourceGovernment->IsEnemy(government)
 			&& (Shields() < .9 || Hull() < .9 || !personality.IsForbearing())
 			&& !personality.IsPacifist() && damage.GetWeapon().DoesDamage())
 		type |= ShipEvent::PROVOKE;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3198,7 +3198,7 @@ double Ship::MaxReverseVelocity() const
 // according to the weapon and the characteristics of how
 // it hit this ship, and add any visuals created as a result
 // of being hit.
-int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment)
+int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, bool targeted)
 {
 	bool wasDisabled = IsDisabled();
 	bool wasDestroyed = IsDestroyed();
@@ -3261,9 +3261,11 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	else if(heat < .9 * MaximumHeat())
 		isOverheated = false;
 
-	// If this ship was hit directly and did not consider itself an enemy of the
-	// ship that hit it, it is now "provoked" against that government.
-	if(!damage.IsBlast() && sourceGovernment && !sourceGovernment->IsEnemy(government)
+	// If this ship was hit directly or was directly targeted and did
+	// not consider itself an enemy of the ship that hit it, it is now
+	// "provoked" against that government.
+	if((!damage.IsBlast() || targeted)
+			&& sourceGovernment && !sourceGovernment->IsEnemy(government)
 			&& (Shields() < .9 || Hull() < .9 || !personality.IsForbearing())
 			&& !personality.IsPacifist() && damage.GetWeapon().DoesDamage())
 		type |= ShipEvent::PROVOKE;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -330,14 +330,11 @@ public:
 	double MaxVelocity() const;
 	double MaxReverseVelocity() const;
 
-	// This ship just got hit by a projectile or hazard. Take damage according to
-	// what sort of weapon the projectile or hazard has. The return value is a ShipEvent
-	// type, which may be a combination of PROVOKED, DISABLED, and DESTROYED.
-	// If isBlast, this ship was caught in the blast radius of a weapon but was
-	// not necessarily its primary target.
-	// Blast damage is dependent on the distance to the damage source.
+	// This ship just got hit by a weapon. Take damage according to the
+	// DamageDealt from that weapon. The return value is a ShipEvent type,
+	// which may be a combination of PROVOKED, DISABLED, and DESTROYED.
 	// Create any target effects as sparks.
-	int TakeDamage(std::vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, bool targeted);
+	int TakeDamage(std::vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment);
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.
 	void ApplyForce(const Point &force, bool gravitational = false);

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -337,7 +337,7 @@ public:
 	// not necessarily its primary target.
 	// Blast damage is dependent on the distance to the damage source.
 	// Create any target effects as sparks.
-	int TakeDamage(std::vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment);
+	int TakeDamage(std::vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, bool targeted = true);
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.
 	void ApplyForce(const Point &force, bool gravitational = false);

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -337,7 +337,7 @@ public:
 	// not necessarily its primary target.
 	// Blast damage is dependent on the distance to the damage source.
 	// Create any target effects as sparks.
-	int TakeDamage(std::vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, bool targeted = true);
+	int TakeDamage(std::vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, bool targeted);
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.
 	void ApplyForce(const Point &force, bool gravitational = false);


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #4836.

## Fix Details
Currently, if a ship is hit by a blast radius weapon then it does not become provoked, except if that blast radius weapon directly hit the ship. But if a weapon has a trigger radius then it never directly hits the target, meaning trigger radius weapons will not provoke governments. This PR changes it so that ships hit by projectile explosions will become provoked if they were directly targeted by the projectile.

## Testing Done
Fired at friendly ships using trigger radius weapons with and without this change. With this change, targeted ships now become provoked.

## Save File
N/A