### PR TITLE
Don't allow "required crew" to be less than 1.

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -71,7 +71,9 @@ namespace {
 		{"shield generation multiplier", -1.},
 		{"shield energy multiplier", -1.},
 		{"shield fuel multiplier", -1.},
-		{"shield heat multiplier", -1.}
+		{"shield heat multiplier", -1.},
+
+		{"required crew", 1},
 	};
 
 	void AddFlareSprites(vector<pair<Body, int>> &thisFlares, const pair<Body, int> &it, int count)

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -21,6 +21,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 
 using namespace std;
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -348,7 +348,7 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 				continue;
 		}
 
-		// If this is a automaton then "required crew" can be 0, but not otherwise.
+		// Only automatons may have a "required crew" of 0.
 		if(!strcmp(at.first, "required crew"))
 			minimum = !attributes.Get("automaton");
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -71,9 +71,7 @@ namespace {
 		{"shield generation multiplier", -1.},
 		{"shield energy multiplier", -1.},
 		{"shield fuel multiplier", -1.},
-		{"shield heat multiplier", -1.},
-
-		{"required crew", 1},
+		{"shield heat multiplier", -1.}
 	};
 
 	void AddFlareSprites(vector<pair<Body, int>> &thisFlares, const pair<Body, int> &it, int count)
@@ -348,6 +346,11 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 			if(!minimum)
 				continue;
 		}
+
+		// If this is a automaton then "required crew" can be 0, but not otherwise.
+		if(!strcmp(at.first, "required crew"))
+			minimum = !attributes.Get("automaton");
+
 		double value = Get(at.first);
 		// Allow for rounding errors:
 		if(value + at.second * count < minimum - EPS)


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6578

## Fix Details

`"required crew"` could be reduced to 0 by buying an android. This means that when selling the android a crew member is hired but that is unnecessary since the player exists, which results in an extra crew being hired. The easiest way to fix this is to disallow `"required crew"` to be less than 1.

## Testing Done

Tested buying and selling androids on ships.