### PR TITLE
Run project validation CI on PRs.

### DIFF
--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -2,11 +2,21 @@ name: Validate Project files
 
 on:
   push:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+.[0-9]+
     paths:
       - '.github/workflows/projects_check.yml'
       - 'EndlessSky.xcodeproj/**'
-      - 'EndlessSkyLib.cbp'
-      - 'EndlessSkyTests.cbp'
+      - '*.cbp'
+      - 'source/**'
+      - 'tests/check_*.sh'
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '.github/workflows/projects_check.yml'
+      - 'EndlessSky.xcodeproj/**'
+      - '*.cbp'
       - 'source/**'
       - 'tests/check_*.sh'
 


### PR DESCRIPTION
This PR restores the workflow triggers for the project validation workflow from #6572. I also readded the branches filter, simplified a few things, and fixed the indentation.