### PR TITLE
More detailed ship stats list.

### DIFF
--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Depreciation.h"
 #include "text/Format.h"
+#include "GameData.h"
 #include "Outfit.h"
 #include "PlayerInfo.h"
 #include "Ship.h"
@@ -173,7 +174,7 @@ void OutfitInfoDisplay::Update(const Outfit &outfit, const PlayerInfo &player, b
 
 void OutfitInfoDisplay::UpdateShipStats(const Ship &ship)
 {
-	UpdateDescription("", {}, false);
+	UpdateDescription(GameData::Ships().Get(ship.ModelName())->Description(), {}, false);
 
 	requirementLabels.clear();
 	requirementValues.clear();

--- a/source/OutfitInfoDisplay.h
+++ b/source/OutfitInfoDisplay.h
@@ -18,9 +18,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <string>
 #include <vector>
 
+class Outfit;
 class PlayerInfo;
 class Point;
-class Outfit;
+class Ship;
 
 
 
@@ -32,8 +33,9 @@ public:
 	OutfitInfoDisplay() = default;
 	OutfitInfoDisplay(const Outfit &outfit, const PlayerInfo &player, bool canSell = false);
 
-	// Call this every time the ship changes.
+	// Call this every time the outfit changes.
 	void Update(const Outfit &outfit, const PlayerInfo &player, bool canSell = false);
+	void UpdateShipStats(const Ship &ship);
 
 	// Provided by ItemInfoDisplay:
 	// int PanelWidth();

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -20,9 +20,11 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "text/FontSet.h"
 #include "text/Format.h"
 #include "GameData.h"
+#include "Government.h"
 #include "Hardpoint.h"
 #include "text/layout.hpp"
 #include "Outfit.h"
+#include "OutlineShader.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "Point.h"
@@ -232,12 +234,23 @@ int OutfitterPanel::DrawDetails(const Point &center)
 
 	int heightOffset = 20;
 
-	if(selectedOutfit)
+	if(selectedOutfit || selectedShip)
 	{
-		outfitInfo.Update(*selectedOutfit, player, CanSell());
-		selectedItem = selectedOutfit->Name();
+		const Sprite *thumbnail;
+		// Check if we have a ship selected, in which case we show its stats.
+		if(selectedShip)
+		{
+			outfitInfo.UpdateShipStats(*selectedShip);
+			selectedItem = selectedShip->Name();
+			thumbnail = selectedShip->Thumbnail();
+		}
+		else
+		{
+			outfitInfo.Update(*selectedOutfit, player, CanSell());
+			selectedItem = selectedOutfit->Name();
+			thumbnail = selectedOutfit->Thumbnail();
+		}
 
-		const Sprite *thumbnail = selectedOutfit->Thumbnail();
 		const Sprite *background = SpriteSet::Get("ui/outfitter selected");
 
 		float tileSize = thumbnail
@@ -283,7 +296,11 @@ int OutfitterPanel::DrawDetails(const Point &center)
 		Point reqsPoint(startPoint.X(), attrPoint.Y() + outfitInfo.AttributesHeight());
 
 		SpriteShader::Draw(background, thumbnailCenter);
-		if(thumbnail)
+
+		// If this is a ship's stats then draw the outline of the thumbnail.
+		if(thumbnail && selectedShip)
+			OutlineShader::Draw(thumbnail, thumbnailCenter, Point(thumbnail->Width(), thumbnail->Height()), Color(.8f, 1.f));
+		else if(thumbnail)
 			SpriteShader::Draw(thumbnail, thumbnailCenter);
 
 		outfitInfo.DrawAttributes(attrPoint);

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -47,7 +47,7 @@ protected:
 	void DrawButtons();
 	void DrawMain();
 
-	void DrawShip(const Ship &ship, const Point &center, bool isSelected);
+	void DrawShip(const Ship &ship, const Point &center, bool isSelected, bool clickSelectShipAttributes = false);
 
 	// These are for the individual shop panels to override.
 	virtual int TileSize() const = 0;
@@ -175,6 +175,11 @@ private:
 	// Check if the given point is within the button zone, and if so return the
 	// letter of the button (or ' ' if it's not on a button).
 	char CheckButton(int x, int y);
+
+
+private:
+	// The Y coordinate where the last tile of the player's ships ends.
+	double shipTilesEndY = 0.;
 };
 
 


### PR DESCRIPTION
## Feature Details

This PR adds a way to see all stats of a ship in the outfitter (like builtin stats but also the total stats like total thrust for example). I'm not 100% sure about some things so feedback is much appreciated:

- The way this list is shown is where outfits stats are displayed (see screenshot). It is shown when you click on the ship sprite of the normal ship stats section (Not exactly discoverable but UX is hard - If anybody has better ideas feel free to comment).

- The "outfit thumbnail" shown is the ship's thumbnail but wireframed. Again see screenshot. You'll also find two other alternatives to consider. Feel free to comment which one of those 3 is better.

- Something else to discuss is whether to show stats that already appear on the normal stats section (like shields, cargo space, bunks, ...). I filter them out currently, but feel free to provide feedback.

Thanks!

## UI Screenshots

![ship stats full](https://user-images.githubusercontent.com/85879619/156813453-006c7dd9-6a93-463f-ae08-46e9f1b3f61f.png)

<details>
<summary> Alternative ship sprite.</summary>

![advanced-statsv5](https://user-images.githubusercontent.com/85879619/156813592-7efc8eb1-5b09-4b82-91a7-02f89d938a27.png)

![advanced-statsv3](https://user-images.githubusercontent.com/85879619/156813614-68e2fcbb-7cf8-49a4-a732-efa2a49dc0f0.png)

</details>

## Testing Done

Played with this feature in the outfitter.

## Performance Impact

N/A.