### PR TITLE
#ifdef OpenGL ES specific GLSL.

### DIFF
--- a/source/BatchShader.cpp
+++ b/source/BatchShader.cpp
@@ -52,6 +52,9 @@ void BatchShader::Init()
 	static const char *fragmentCode =
 		"// fragment batch shader\n"
 		"precision mediump float;\n"
+#ifdef ES_GLES
+		"precision mediump sampler2DArray;\n"
+#endif
 		"uniform sampler2DArray tex;\n"
 		"uniform float frameCount;\n"
 

--- a/source/BatchShader.cpp
+++ b/source/BatchShader.cpp
@@ -52,7 +52,6 @@ void BatchShader::Init()
 	static const char *fragmentCode =
 		"// fragment batch shader\n"
 		"precision mediump float;\n"
-		"precision mediump sampler2DArray;\n"
 		"uniform sampler2DArray tex;\n"
 		"uniform float frameCount;\n"
 

--- a/source/FogShader.cpp
+++ b/source/FogShader.cpp
@@ -76,6 +76,9 @@ void FogShader::Init()
 
 	static const char *fragmentCode =
 		"// fragment fog shader\n"
+#ifdef ES_GLES
+		"precision mediump sampler2D;\n"
+#endif
 		"precision mediump float;\n"
 		"uniform sampler2D tex;\n"
 

--- a/source/FogShader.cpp
+++ b/source/FogShader.cpp
@@ -76,7 +76,6 @@ void FogShader::Init()
 
 	static const char *fragmentCode =
 		"// fragment fog shader\n"
-		"precision mediump sampler2D;\n"
 		"precision mediump float;\n"
 		"uniform sampler2D tex;\n"
 

--- a/source/OutlineShader.cpp
+++ b/source/OutlineShader.cpp
@@ -67,7 +67,6 @@ void OutlineShader::Init()
 	static const char *fragmentCode =
 		"// fragment outline shader\n"
 		"precision mediump float;\n"
-		"precision mediump sampler2DArray;\n"
 		"uniform sampler2DArray tex;\n"
 		"uniform float frame;\n"
 		"uniform float frameCount;\n"

--- a/source/OutlineShader.cpp
+++ b/source/OutlineShader.cpp
@@ -67,6 +67,9 @@ void OutlineShader::Init()
 	static const char *fragmentCode =
 		"// fragment outline shader\n"
 		"precision mediump float;\n"
+#ifdef ES_GLES
+		"precision mediump sampler2DArray;\n"
+#endif
 		"uniform sampler2DArray tex;\n"
 		"uniform float frame;\n"
 		"uniform float frameCount;\n"

--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -106,7 +106,6 @@ void SpriteShader::Init(bool useShaderSwizzle)
 	fragmentCodeStream <<
 		"// fragment sprite shader\n"
 		"precision mediump float;\n"
-		"precision mediump sampler2DArray;\n"
 		"uniform sampler2DArray tex;\n"
 		"uniform float frame;\n"
 		"uniform float frameCount;\n"

--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -106,6 +106,9 @@ void SpriteShader::Init(bool useShaderSwizzle)
 	fragmentCodeStream <<
 		"// fragment sprite shader\n"
 		"precision mediump float;\n"
+#ifdef ES_GLES
+		"precision mediump sampler2DArray;\n"
+#endif
 		"uniform sampler2DArray tex;\n"
 		"uniform float frame;\n"
 		"uniform float frameCount;\n"


### PR DESCRIPTION
## Fix Details

Some shaders used invalid GLSL. According to the [wiki](https://www.khronos.org/opengl/wiki/Type_Qualifier_(GLSL)):

> In this case, *type*​ can only be `float` or `int`.

This causes oldish drivers to fail to compile the shaders. This has happened at least once.

## Testing Done

Verified that the relevant shader still work, also using OpenGL ES.

Edit: This PR fixes the compilation error on oldish drivers, confirmed.