### PR TITLE
Use local CI instead of endless-sky/endless-sky.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   # Figure out what changed, so other jobs in this file can conditionally execute.
   changed:
-    uses: endless-sky/endless-sky/.github/workflows/compute-changes.yml@master
+    uses: ./.github/workflows/compute-changes.yml
 
   build_ubuntu:
     needs: changed


### PR DESCRIPTION
The CI was depending on the compute-changes workflow from the main repository (this one). This means that any fork will also use the workflow from the main repository instead of the local one, which isn't ideal.

This PR changes the absolute path into a relative path so that the repo is self contained.