### PR TITLE
Fix: Remnant: Fixes capitalization on a variable "remnant: ssil vida active"

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1540,7 +1540,7 @@ mission "Remnant: Cognizance 36"
 	source "Ssil Vida"
 	to offer
 		has "Remnant: Cognizance 35: done"
-		has "Remnant: Ssil Vida Active"
+		has "remnant: ssil vida active"
 	on accept
 		event "remnant: ssil vida deactivation"
 		conversation
@@ -1558,7 +1558,7 @@ mission "Remnant: Cognizance 37"
 	source "Ssil Vida"
 	to offer
 		has "Remnant: Cognizance 35: done"
-		not "Remnant: Ssil Vida Active"
+		not "remnant: ssil vida active"
 	on accept
 		event "remnant: ssil vida activation"
 		conversation

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -19,7 +19,7 @@ mission "Remnant: Bounty"
 	to offer
 		has "Remnant: Defense 2: done"
 		or
-			not "Remnant: Ssil Vida Active"
+			not "remnant: ssil vida active"
 			not "flagship planet: Ssil Vida"
 		random < 60
 	npc kill
@@ -51,7 +51,7 @@ mission "Remnant: Bounty 2"
 	to offer
 		has "Remnant: Salvage 4: offered"
 		or
-			not "Remnant: Ssil Vida Active"
+			not "remnant: ssil vida active"
 			not "flagship planet: Ssil Vida"
 		random < 50
 	npc kill
@@ -81,7 +81,7 @@ mission "Remnant: Broken Jump Drive job"
 	to offer
 		has "Remnant: Broken Jump Drive 5: done"
 		or
-			not "Remnant: Ssil Vida Active"
+			not "remnant: ssil vida active"
 			not "flagship planet: Ssil Vida"
 			
 	source
@@ -198,7 +198,7 @@ mission "Remnant: Bounty 5"
 	to offer
 		has "Remnant: Cognizance 29: done"
 		or
-			not "Remnant: Ssil Vida Active"
+			not "remnant: ssil vida active"
 			not "flagship planet: Ssil Vida"
 		random < 5
 	npc kill


### PR DESCRIPTION
**Bugfix:** This PR addresses the problem of a missed capitalization on things that test for one of the events changed in #6547 

## Fix Details
While the event that sets and clears "remnant: ssil vida active" was correctly changed from in the recent fix, the jobs that depend on it were not. This fixes that part.

## Testing Done
searched through and reviewed everywhere that sets variables in the Remnant missions.

## Reporting

Thanks to Starext on the Discord for reporting this problem.