### PR TITLE
feat(mechanics): Allow for rep changes from provoking a government

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -41,6 +41,7 @@ Government::Government()
 	penaltyFor[ShipEvent::DESTROY] = 1.;
 	penaltyFor[ShipEvent::SCAN_OUTFITS] = 0.;
 	penaltyFor[ShipEvent::SCAN_CARGO] = 0.;
+	penaltyFor[ShipEvent::PROVOKE] = 0.;
 	penaltyFor[ShipEvent::ATROCITY] = 10.;
 
 	id = nextID++;
@@ -106,6 +107,8 @@ void Government::Load(const DataNode &node)
 						penaltyFor[ShipEvent::SCAN_OUTFITS] = grand.Value(1);
 						penaltyFor[ShipEvent::SCAN_CARGO] = grand.Value(1);
 					}
+					else if(grand.Token(0) == "provoke")
+						penaltyFor[ShipEvent::PROVOKE] = grand.Value(1);
 					else if(grand.Token(0) == "atrocity")
 						penaltyFor[ShipEvent::ATROCITY] = grand.Value(1);
 					else

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -99,7 +99,7 @@ void Politics::Offend(const Government *gov, int eventType, int count)
 				provoked.insert(other);
 			}
 		}
-		else if(count && abs(weight) >= .05)
+		if(count && abs(weight) >= .05)
 		{
 			// Weights less than 5% should never cause permanent reputation
 			// changes. This is to allow two governments to be hostile or


### PR DESCRIPTION
This PR hooks up the Provoke ShipEvent as an event that can cause reputation changes. This can allow for the opposite of Forbearing, where a government can take immediate and permanent reputation loss the instant you fire on them, among other uses.