### PR TITLE
feat(content): Add reputation gain to Hai jobs

### DIFF
--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -25,6 +25,7 @@ mission "Human Vacation [1]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 8000 150
+		"reputation: Hai" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Human Vacation [2]"
@@ -44,6 +45,7 @@ mission "Human Vacation [2]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 5000 150
+		"reputation: Hai" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [1]"
@@ -63,6 +65,7 @@ mission "Hai Vacation [1]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 6000 150
+		"reputation: Hai" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [2]"
@@ -82,6 +85,7 @@ mission "Hai Vacation [2]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 4000 150
+		"reputation: Hai" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [3]"
@@ -101,6 +105,7 @@ mission "Hai Vacation [3]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 4000 150
+		"reputation: Hai" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [4]"
@@ -121,6 +126,7 @@ mission "Hai Vacation [4]"
 	on complete
 		payment
 		payment 6000
+		"reputation: Hai" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 
@@ -145,6 +151,7 @@ mission "Wealthy Hai [1]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 15000 300
+		"reputation: Hai" += 3
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Wealthy Hai [2]"
@@ -168,6 +175,7 @@ mission "Wealthy Hai [2]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 15000 300
+		"reputation: Hai" += 3
 		dialog phrase "generic passenger dropoff payment"
 
 
@@ -194,6 +202,7 @@ mission "Hai Festival [1]"
 		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 10000 200
+		"reputation: Hai" += 3
 		dialog phrase "hai festival payment dialog"
 
 mission "Hai Festival [2]"
@@ -215,6 +224,7 @@ mission "Hai Festival [2]"
 		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 10000 200
+		"reputation: Hai" += 3
 		dialog phrase "hai festival payment dialog"
 
 mission "Hai Festival [3]"
@@ -236,6 +246,7 @@ mission "Hai Festival [3]"
 		dialog phrase "generic cargo and passenger on visit"
 	on complete
 		payment 10000 200
+		"reputation: Hai" += 3
 		dialog phrase "hai festival payment dialog"
 
 
@@ -276,6 +287,7 @@ mission "Unfettered Aid [0]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 1600
+		"reputation: Hai" += 5
 		dialog phrase "unfettered aid payment dialog"
 
 mission "Unfettered Aid [1]"
@@ -300,6 +312,7 @@ mission "Unfettered Aid [1]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 6000 1800
+		"reputation: Hai" += 5
 		dialog phrase "unfettered aid payment dialog"
 
 mission "Unfettered Aid [2]"
@@ -324,6 +337,7 @@ mission "Unfettered Aid [2]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 7000 2000
+		"reputation: Hai" += 5
 		dialog phrase "unfettered aid payment dialog"
 
 phrase "unfettered tribute payment dialog"
@@ -424,6 +438,7 @@ mission "Delivery to Human Space [0]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 60000
+		"reputation: Hai" += 5
 		dialog phrase "generic cargo delivery payment"
 
 mission "Delivery to Human Space [1]"
@@ -443,6 +458,7 @@ mission "Delivery to Human Space [1]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 60000
+		"reputation: Hai" += 5
 		dialog phrase "generic cargo delivery payment"
 
 mission "Delivery to Human Space [2]"
@@ -462,6 +478,7 @@ mission "Delivery to Human Space [2]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 60000
+		"reputation: Hai" += 5
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Retrieve Human Luxury Goods"
@@ -484,6 +501,7 @@ mission "Hai Retrieve Human Luxury Goods"
 		dialog phrase "generic missing stopover or cargo"
 	on complete
 		payment 120000
+		"reputation: Hai" += 5
 		dialog "Your payment of <payment> is waiting when you touch down, along with delivery instructions. You send the <commodity> by dedicated courier."
 
 mission "Hai Retrieve Human Food"
@@ -506,6 +524,7 @@ mission "Hai Retrieve Human Food"
 		dialog phrase "generic missing stopover or cargo"
 	on complete
 		payment 120000
+		"reputation: Hai" += 5
 		dialog "As soon as you touch down you receive a message from the Hai gourmet with thanks and your payment of <payment>."
 
 mission "Hai Retrieve Human Electronics"
@@ -528,6 +547,7 @@ mission "Hai Retrieve Human Electronics"
 		dialog phrase "generic missing stopover or cargo"
 	on complete
 		payment 120000
+		"reputation: Hai" += 5
 		dialog "The Hai tinkerer is waiting for you when you arrive. They pay you <payment> and then run after the cargo pallets as though they plan to open them right there in the spaceport."
 
 
@@ -571,6 +591,7 @@ mission "Escort to Human Space (Small)"
 				"Freighter (Hai)"
 	on complete
 		payment 120000
+		"reputation: Hai" += 5
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -619,6 +640,7 @@ mission "Escort to Human Space (Medium)"
 				"Freighter (Hai)"
 	on complete
 		payment 180000
+		"reputation: Hai" += 5
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -662,6 +684,7 @@ mission "Escort to Human Space (Large)"
 				"Behemoth (Hai)"
 	on complete
 		payment 240000
+		"reputation: Hai" += 5
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -711,6 +734,7 @@ mission "Escort to Human Space (Extra Large)"
 				"Behemoth (Hai)"
 	on complete
 		payment 300000
+		"reputation: Hai" += 5
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -734,6 +758,7 @@ mission "Hai Passengers [1]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment
+		"reputation: Hai" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Passengers [2]"
@@ -753,6 +778,7 @@ mission "Hai Passengers [2]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment
+		"reputation: Hai" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Passengers [3]"
@@ -772,6 +798,7 @@ mission "Hai Passengers [3]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment
+		"reputation: Hai" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Family [0]"
@@ -793,6 +820,7 @@ mission "Hai Family [0]"
 	on complete
 		payment
 		payment 4000
+		"reputation: Hai" += 2
 		dialog "The family you have been transporting departs your ship after paying you <payment>."
 
 mission "Hai Family [1]"
@@ -814,6 +842,7 @@ mission "Hai Family [1]"
 	on complete
 		payment
 		payment 6000
+		"reputation: Hai" += 2
 		dialog "The family you have been transporting departs your ship after paying you <payment>."
 
 mission "Transport Hai miners to <planet>"
@@ -834,6 +863,7 @@ mission "Transport Hai miners to <planet>"
 	on complete
 		payment
 		payment 2000
+		"reputation: Hai" += 2
 		dialog "You wish the mining family the best of luck on <planet>, and collect your payment of <payment>."
 
 mission "Transport Hai farmers to <planet>"
@@ -854,6 +884,7 @@ mission "Transport Hai farmers to <planet>"
 	on complete
 		payment
 		payment 2000
+		"reputation: Hai" += 2
 		dialog "You wish the farm family the best of luck on <planet>, and collect your payment of <payment>."
 
 mission "Transport Hai mill workers to <planet>"
@@ -874,6 +905,7 @@ mission "Transport Hai mill workers to <planet>"
 	on complete
 		payment
 		payment 2000
+		"reputation: Hai" += 2
 		dialog "You wish the workers the best of luck on <planet>, and collect your payment of <payment>."
 
 mission "Transport Hai workers to <planet>"
@@ -894,6 +926,7 @@ mission "Transport Hai workers to <planet>"
 	on complete
 		payment
 		payment 2000
+		"reputation: Hai" += 2
 		dialog "You wish the workers the best of luck on <planet>, and collect your payment of <payment>."
 
 
@@ -915,6 +948,7 @@ mission "Hai Cargo [0]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [1]"
@@ -934,6 +968,7 @@ mission "Hai Cargo [1]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [2]"
@@ -954,6 +989,7 @@ mission "Hai Cargo [2]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [3]"
@@ -975,6 +1011,7 @@ mission "Hai Cargo [3]"
 	on complete
 		payment
 		payment 2000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [4]"
@@ -996,6 +1033,7 @@ mission "Hai Cargo [4]"
 	on complete
 		payment
 		payment 4000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Bulk Delivery [0]"
@@ -1015,6 +1053,7 @@ mission "Hai Bulk Delivery [0]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Bulk Delivery [1]"
@@ -1035,6 +1074,7 @@ mission "Hai Bulk Delivery [1]"
 	on complete
 		payment
 		payment 2000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Bulk Delivery [2]"
@@ -1056,6 +1096,7 @@ mission "Hai Bulk Delivery [2]"
 	on complete
 		payment
 		payment 4000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Bulk Delivery [0]"
@@ -1077,6 +1118,7 @@ mission "Hai Large Bulk Delivery [0]"
 	on complete
 		payment
 		payment 4000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Bulk Delivery [1]"
@@ -1098,6 +1140,7 @@ mission "Hai Large Bulk Delivery [1]"
 	on complete
 		payment
 		payment 6000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Bulk Delivery [2]"
@@ -1120,6 +1163,7 @@ mission "Hai Large Bulk Delivery [2]"
 	on complete
 		payment
 		payment 8000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Rush Delivery [0]"
@@ -1141,6 +1185,7 @@ mission "Hai Rush Delivery [0]"
 	on complete
 		payment
 		payment 16000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Rush Delivery [1]"
@@ -1162,6 +1207,7 @@ mission "Hai Rush Delivery [1]"
 	on complete
 		payment
 		payment 18000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Rush Delivery [2]"
@@ -1184,6 +1230,7 @@ mission "Hai Rush Delivery [2]"
 	on complete
 		payment
 		payment 20000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Rush Delivery [3]"
@@ -1206,6 +1253,7 @@ mission "Hai Rush Delivery [3]"
 	on complete
 		payment
 		payment 22000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Rush Delivery [0]"
@@ -1228,6 +1276,7 @@ mission "Hai Large Rush Delivery [0]"
 	on complete
 		payment
 		payment 36000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Rush Delivery [1]"
@@ -1250,6 +1299,7 @@ mission "Hai Large Rush Delivery [1]"
 	on complete
 		payment
 		payment 38000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Rush Delivery [2]"
@@ -1273,6 +1323,7 @@ mission "Hai Large Rush Delivery [2]"
 	on complete
 		payment
 		payment 40000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Rush Delivery [3]"
@@ -1296,6 +1347,7 @@ mission "Hai Large Rush Delivery [3]"
 	on complete
 		payment
 		payment 42000
+		"reputation: Hai" += 2
 		dialog phrase "generic cargo delivery payment"
 
 
@@ -1319,4 +1371,5 @@ mission "Hai Prisoner Roleplay"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 15000 150
+		"reputation: Hai" += 5
 		dialog "The Hai depart your ship chittering in excitement. One of them hands you your payment of <payment> before running to catch up with their friends."


### PR DESCRIPTION
This PR adds reputation gain to standard Hai jobs, so that a player can access Hai-Home without being super familiar with the Wah Ki metagame. It gives +2 for standard jobs, +3 for higher-profile jobs, and +5 for jobs that leave Hai space.