### PR TITLE
fix(typo): Typo in Fuel Module description

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -207,7 +207,7 @@ outfit "Fuel Module"
 	"fuel capacity" 400
 	"fuel protection" .25
 	description "In their early days of space exploration, the Saryds developed the fuel module to travel far from Saros without worrying about becoming stranded without fuel, or sudden fuel leaks."
-	description "	Nowadays, nearly every system on the Coalition has refuelling facilities, but some captains still find use in the extra jumps these modules offer."
+	description "	Nowadays, nearly every system in the Coalition has refuelling facilities, but some captains still find use in the extra jumps these modules offer."
 
 outfit "Scanning Module"
 	category "Systems"


### PR DESCRIPTION
## Fix Details 
A small typo snuck in with the addition of the Fuel Module in #5838. This PR addresses that. 