### PR TITLE
Modifications to New Deep jobs

### DIFF
--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -439,7 +439,7 @@ mission "Secure Transport Job (Secret) [1]"
 	cargo "secure package" 1
 	to offer
 		random < 20
-		not "deep security reveal""
+		not "deep security reveal"
 		"reputation: Deep Security" >= 0
 		"reputation: Deep Security" >= - "secure deep package" * 3
 	source

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -95,7 +95,7 @@ mission "Mystery Cube Delivery Job [0]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		"reputation: Deep Security" += 1
+		"reputation: Deep Security" += 2
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
@@ -127,7 +127,7 @@ mission "Mystery Cube Delivery Job [1]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		"reputation: Deep Security" += 1
+		"reputation: Deep Security" += 2
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
@@ -159,7 +159,7 @@ mission "Mystery Cube Delivery Job [2]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		"reputation: Deep Security" += 1
+		"reputation: Deep Security" += 2
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
@@ -191,7 +191,7 @@ mission "Mystery Cube Delivery Job [3]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		"reputation: Deep Security" += 1
+		"reputation: Deep Security" += 2
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
@@ -223,7 +223,7 @@ mission "Mystery Cube Delivery Job Station"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		"reputation: Deep Security" += 1
+		"reputation: Deep Security" += 2
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff station payment"
@@ -256,7 +256,7 @@ mission "Mystery Cube Retrieval Job"
 	on visit
 		dialog phrase "generic missing stopover or cargo"
 	on complete
-		"reputation: Deep Security" += 1
+		"reputation: Deep Security" += 2
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
@@ -424,7 +424,7 @@ mission "Secure Transport Job (Secret) [0]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 3000 900
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
 
@@ -452,7 +452,7 @@ mission "Secure Transport Job (Secret) [1]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 3000 900
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
 
@@ -480,7 +480,7 @@ mission "Secure Transport Job (Secret) [2]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 3000 900
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
 
@@ -508,7 +508,7 @@ mission "Secure Transport Job (Secret) [3]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 3000 900
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
 
@@ -536,7 +536,7 @@ mission "Secure Transport Job (Secret) [4]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 3000 900
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
 
@@ -633,7 +633,7 @@ mission "Secure Transport Job (Basic) [0]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 3000 900
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
 mission "Secure Transport Job (Basic) [1]"
@@ -660,7 +660,7 @@ mission "Secure Transport Job (Basic) [1]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 3000 900
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
 mission "Secure Transport Job (Deep Security) [0]"
@@ -687,7 +687,7 @@ mission "Secure Transport Job (Deep Security) [0]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 1500
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
 mission "Secure Transport Job (Deep Security) [1]"
@@ -714,7 +714,7 @@ mission "Secure Transport Job (Deep Security) [1]"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 5000 1500
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
 
@@ -832,7 +832,7 @@ mission "Transport Consultants (Deep Security) [0]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 600
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		dialog phrase "stranded consultant dropoff payment"
 
 mission "Transport Consultants (Deep Security) [1]"
@@ -859,7 +859,7 @@ mission "Transport Consultants (Deep Security) [1]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 600
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		dialog phrase "stranded consultant dropoff payment"
 
 
@@ -888,7 +888,7 @@ mission "Urgent Deep Sec Package"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 0 30000
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
 mission "Urgent Deep Sec Consultants [0]"
@@ -916,7 +916,7 @@ mission "Urgent Deep Sec Consultants [0]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 150000 1500
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		dialog phrase "stranded consultant dropoff payment"
 
 mission "Urgent Deep Sec Consultants [1]"
@@ -941,5 +941,5 @@ mission "Urgent Deep Sec Consultants [1]"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 150000 1500
-		"reputation: Deep Security" += 0.5
+		"reputation: Deep Security" += 1
 		dialog phrase "stranded consultant dropoff payment"

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -427,10 +427,6 @@ mission "Secure Transport Job (Secret) [0]"
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 2
-	on abort
-		"reputation: Deep Security" -= 5
 
 mission "Secure Transport Job (Secret) [1]"
 	name "Secure delivery to <planet>"
@@ -459,10 +455,6 @@ mission "Secure Transport Job (Secret) [1]"
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 2
-	on abort
-		"reputation: Deep Security" -= 5
 
 mission "Secure Transport Job (Secret) [2]"
 	name "Secure delivery to <planet>"
@@ -491,10 +483,6 @@ mission "Secure Transport Job (Secret) [2]"
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 2
-	on abort
-		"reputation: Deep Security" -= 5
 
 mission "Secure Transport Job (Secret) [3]"
 	name "Secure delivery to <planet>"
@@ -523,10 +511,6 @@ mission "Secure Transport Job (Secret) [3]"
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 2
-	on abort
-		"reputation: Deep Security" -= 5
 
 mission "Secure Transport Job (Secret) [4]"
 	name "Secure delivery to <planet>"
@@ -555,10 +539,6 @@ mission "Secure Transport Job (Secret) [4]"
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 2
-	on abort
-		"reputation: Deep Security" -= 5
 
 
 mission "Deep Security Package Reveal"
@@ -655,10 +635,6 @@ mission "Secure Transport Job (Basic) [0]"
 		payment 3000 900
 		"reputation: Deep Security" += 0.5
 		dialog phrase "secure package dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 2
-	on abort
-		"reputation: Deep Security" -= 5
 
 mission "Secure Transport Job (Basic) [1]"
 	name "Secure delivery to <planet>"
@@ -686,10 +662,6 @@ mission "Secure Transport Job (Basic) [1]"
 		payment 3000 900
 		"reputation: Deep Security" += 0.5
 		dialog phrase "secure package dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 2
-	on abort
-		"reputation: Deep Security" -= 5
 
 mission "Secure Transport Job (Deep Security) [0]"
 	name "Deep Security delivery to <planet>"
@@ -717,10 +689,6 @@ mission "Secure Transport Job (Deep Security) [0]"
 		payment 5000 1500
 		"reputation: Deep Security" += 0.5
 		dialog phrase "secure package dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 2
-	on abort
-		"reputation: Deep Security" -= 5
 
 mission "Secure Transport Job (Deep Security) [1]"
 	name "Deep Security delivery to <planet>"
@@ -748,10 +716,6 @@ mission "Secure Transport Job (Deep Security) [1]"
 		payment 5000 1500
 		"reputation: Deep Security" += 0.5
 		dialog phrase "secure package dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 2
-	on abort
-		"reputation: Deep Security" -= 5
 
 
 mission "Deep Consultants"
@@ -870,10 +834,6 @@ mission "Transport Consultants (Deep Security) [0]"
 		payment 10000 600
 		"reputation: Deep Security" += 0.5
 		dialog phrase "stranded consultant dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 4
-	on abort
-		"reputation: Deep Security" -= 10
 
 mission "Transport Consultants (Deep Security) [1]"
 	name "Transport Deep Security consultants"
@@ -901,10 +861,6 @@ mission "Transport Consultants (Deep Security) [1]"
 		payment 10000 600
 		"reputation: Deep Security" += 0.5
 		dialog phrase "stranded consultant dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 4
-	on abort
-		"reputation: Deep Security" -= 10
 
 
 mission "Urgent Deep Sec Package"
@@ -934,10 +890,6 @@ mission "Urgent Deep Sec Package"
 		payment 0 30000
 		"reputation: Deep Security" += 0.5
 		dialog phrase "secure package dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 2
-	on abort
-		"reputation: Deep Security" -= 5
 
 mission "Urgent Deep Sec Consultants [0]"
 	name "Rush Deep Security Consultants"
@@ -966,10 +918,6 @@ mission "Urgent Deep Sec Consultants [0]"
 		payment 150000 1500
 		"reputation: Deep Security" += 0.5
 		dialog phrase "stranded consultant dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 4
-	on abort
-		"reputation: Deep Security" -= 10
 
 mission "Urgent Deep Sec Consultants [1]"
 	name "Rush Deep Security Consultants"
@@ -995,7 +943,3 @@ mission "Urgent Deep Sec Consultants [1]"
 		payment 150000 1500
 		"reputation: Deep Security" += 0.5
 		dialog phrase "stranded consultant dropoff payment"
-	on fail
-		"reputation: Deep Security" -= 4
-	on abort
-		"reputation: Deep Security" -= 10

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -422,7 +422,7 @@ mission "Secure Transport Job (Secret) [0]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 3000 900
+		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
@@ -449,7 +449,7 @@ mission "Secure Transport Job (Secret) [1]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 3000 900
+		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
@@ -476,7 +476,7 @@ mission "Secure Transport Job (Secret) [2]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 3000 900
+		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
@@ -503,7 +503,7 @@ mission "Secure Transport Job (Secret) [3]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 3000 900
+		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
@@ -530,7 +530,7 @@ mission "Secure Transport Job (Secret) [4]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 3000 900
+		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
@@ -626,7 +626,7 @@ mission "Secure Transport Job (Basic) [0]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 3000 900
+		payment 3000 750
 		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
@@ -652,7 +652,7 @@ mission "Secure Transport Job (Basic) [1]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 3000 900
+		payment 3000 750
 		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
@@ -678,7 +678,7 @@ mission "Secure Transport Job (Deep Security) [0]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 5000 1500
+		payment 5000 1000
 		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
@@ -704,7 +704,7 @@ mission "Secure Transport Job (Deep Security) [1]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 5000 1500
+		payment 5000 1000
 		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
@@ -820,7 +820,7 @@ mission "Transport Consultants (Deep Security) [0]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 10000 600
+		payment 10000 300
 		"reputation: Deep Security" += 1
 		dialog phrase "stranded consultant dropoff payment"
 
@@ -847,7 +847,7 @@ mission "Transport Consultants (Deep Security) [1]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 10000 600
+		payment 10000 300
 		"reputation: Deep Security" += 1
 		dialog phrase "stranded consultant dropoff payment"
 
@@ -860,13 +860,13 @@ mission "Urgent Deep Sec Package"
 	minor
 	cargo "deep security package" 1
 	to offer
-		random < 2
+		random < 3
 		has "deep security reveal"
 		"reputation: Deep Security" >= 40
 	source
 		attributes "deep"
 	destination
-		distance 2 7
+		distance 6 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station"
@@ -875,7 +875,7 @@ mission "Urgent Deep Sec Package"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 0 30000
+		payment 170000 10000
 		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
@@ -893,7 +893,7 @@ mission "Urgent Deep Sec Consultants [0]"
 	source
 		attributes "deep"
 	destination
-		distance 2 7
+		distance 6 7
 		attributes "deep"
 		attributes "urban"
 		not attributes "station"
@@ -902,7 +902,7 @@ mission "Urgent Deep Sec Consultants [0]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 150000 1500
+		payment 450000 300
 		"reputation: Deep Security" += 1
 		dialog phrase "stranded consultant dropoff payment"
 
@@ -914,11 +914,11 @@ mission "Urgent Deep Sec Consultants [1]"
 	minor
 	passengers 2 6
 	to offer
-		random < 1
+		random < 3
 		has "deep security consultants"
 		"reputation: Deep Security" >= 60
 	source
-		near "Epsilon Leonis" 2 7
+		near "Epsilon Leonis" 3 4
 		attributes "deep"
 		not attributes "station"
 	destination "Valhalla"
@@ -927,6 +927,6 @@ mission "Urgent Deep Sec Consultants [1]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 150000 1500
+		payment 450000 300
 		"reputation: Deep Security" += 1
 		dialog phrase "stranded consultant dropoff payment"

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -95,6 +95,7 @@ mission "Mystery Cube Delivery Job [0]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
+		"reputation: Deep Security" += 1
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
@@ -126,6 +127,7 @@ mission "Mystery Cube Delivery Job [1]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
+		"reputation: Deep Security" += 1
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
@@ -157,6 +159,7 @@ mission "Mystery Cube Delivery Job [2]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
+		"reputation: Deep Security" += 1
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
@@ -188,6 +191,7 @@ mission "Mystery Cube Delivery Job [3]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
+		"reputation: Deep Security" += 1
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
@@ -219,6 +223,7 @@ mission "Mystery Cube Delivery Job Station"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
+		"reputation: Deep Security" += 1
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff station payment"
@@ -251,6 +256,7 @@ mission "Mystery Cube Retrieval Job"
 	on visit
 		dialog phrase "generic missing stopover or cargo"
 	on complete
+		"reputation: Deep Security" += 1
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -428,6 +428,8 @@ mission "Secure Transport Job (Secret) [0]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 3
 
@@ -459,6 +461,8 @@ mission "Secure Transport Job (Secret) [1]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 3
 
@@ -490,6 +494,8 @@ mission "Secure Transport Job (Secret) [2]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 3
 
@@ -521,6 +527,8 @@ mission "Secure Transport Job (Secret) [3]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 3
 
@@ -552,6 +560,8 @@ mission "Secure Transport Job (Secret) [4]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 3
 
@@ -652,6 +662,8 @@ mission "Secure Transport Job (Basic) [0]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 3
 
@@ -683,6 +695,8 @@ mission "Secure Transport Job (Basic) [1]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 3
 
@@ -714,6 +728,8 @@ mission "Secure Transport Job (Deep Security) [0]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 5
 
@@ -745,6 +761,8 @@ mission "Secure Transport Job (Deep Security) [1]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 5
 
@@ -866,6 +884,8 @@ mission "Transport Consultants (Deep Security) [0]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 7
 
@@ -897,6 +917,8 @@ mission "Transport Consultants (Deep Security) [1]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 7
 
@@ -929,6 +951,8 @@ mission "Urgent Deep Sec Package"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 7
 
@@ -960,6 +984,8 @@ mission "Urgent Deep Sec Consultants [0]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 9
 
@@ -989,5 +1015,7 @@ mission "Urgent Deep Sec Consultants [1]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
+	on abort
+		# Nothing
 	on fail
 		"secure deep package" -= 9

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -839,7 +839,7 @@ phrase "stranded consultant dropoff payment"
 
 
 mission "Transport Consultants (Deep Security) [0]"
-	name "Transport Deep Security consultants to <planet>"
+	name "Transport Deep Security consultants"
 	job
 	repeat
 	description "Transport <fare> whose schedules have been ruined by Deep Security to <destination>. Payment is <payment>."
@@ -870,7 +870,7 @@ mission "Transport Consultants (Deep Security) [0]"
 		"reputation: Deep Security" -= 10
 
 mission "Transport Consultants (Deep Security) [1]"
-	name "Transport Deep Security consultants to <planet>"
+	name "Transport Deep Security consultants"
 	job
 	repeat
 	description "Transport <fare> whose schedules have been ruined by Deep Security to <destination>. Payment is <payment>."
@@ -902,7 +902,7 @@ mission "Transport Consultants (Deep Security) [1]"
 
 
 mission "Urgent Deep Sec Package"
-	name "Rush Deep Security Delivery to <planet>"
+	name "Rush Deep Security Delivery"
 	repeat
 	deadline 1 1
 	description "Deliver a Deep Security package to <destination> by <date>. Payment is <payment>."
@@ -934,7 +934,7 @@ mission "Urgent Deep Sec Package"
 		"reputation: Deep Security" -= 5
 
 mission "Urgent Deep Sec Consultants [0]"
-	name "Rush Deep Security Consultants to <planet>"
+	name "Rush Deep Security Consultants"
 	repeat
 	deadline 1 1
 	description "Deliver <bunks> Deep Security consultants to <destination> by <date>. Payment is <payment>."
@@ -966,7 +966,7 @@ mission "Urgent Deep Sec Consultants [0]"
 		"reputation: Deep Security" -= 10
 
 mission "Urgent Deep Sec Consultants [1]"
-	name "Rush Deep Security Consultants to <planet>"
+	name "Rush Deep Security Consultants"
 	repeat
 	deadline 1 1
 	description "Deliver <bunks> Deep Security consultants to <destination> by <date>. Payment is <payment>."

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -76,22 +76,28 @@ phrase "deep mystery cube dropoff station payment"
 		`Your bank account immediately notifies you that the agreed-upon payment of <payment> has been deposited. You wonder how they knew.`
 
 mission "Mystery Cube Delivery Job [0]"
-	name "Mystery delivery to <planet>"
 	job
 	repeat
+	name "Mystery delivery to <planet>"
 	description "Deliver a package to <destination>. Payment is <payment>."
-	cargo "mystery package" 1
-	to offer
-		random < 25
-		"combat rating" > 35
 	source
 		attributes "deep"
 	destination
 		distance 7 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 		not attributes "station"
+	cargo "mystery package" 1
+	to offer
+		random < 25
+		"combat rating" > 35
 	on accept
 		dialog phrase "deep mystery cube pickup"
+	npc
+		government "Bounty Hunter"
+		personality nemesis disables waiting plunders
+		system
+			distance 6 9
+		fleet "Bounty Hunters"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
@@ -99,31 +105,31 @@ mission "Mystery Cube Delivery Job [0]"
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
-	npc
-		government "Bounty Hunter"
-		personality nemesis disables waiting plunders
-		system
-			distance 6 9
-		fleet "Bounty Hunters"
 
 
 mission "Mystery Cube Delivery Job [1]"
-	name "Mystery delivery to <planet>"
 	job
 	repeat
+	name "Mystery delivery to <planet>"
 	description "Deliver a package to <destination>. Payment is <payment>."
-	cargo "mystery package" 1
-	to offer
-		random < 10
-		"combat rating" > 35
 	source
 		attributes "deep"
 	destination
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 		not attributes "station"
+	cargo "mystery package" 1
+	to offer
+		random < 10
+		"combat rating" > 35
 	on accept
 		dialog phrase "deep mystery cube pickup"
+	npc
+		government "Bounty Hunter"
+		personality nemesis disables waiting plunders
+		system
+			distance 6 9
+		fleet "Bounty Hunters"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
@@ -131,31 +137,31 @@ mission "Mystery Cube Delivery Job [1]"
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
-	npc
-		government "Bounty Hunter"
-		personality nemesis disables waiting plunders
-		system
-			distance 6 9
-		fleet "Bounty Hunters"
 
 
 mission "Mystery Cube Delivery Job [2]"
-	name "Mystery delivery to <planet>"
 	job
 	repeat
+	name "Mystery delivery to <planet>"
 	description "Deliver a package to <destination>. Payment is <payment>."
-	cargo "mystery package" 1
-	to offer
-		random < 10
-		"combat rating" > 35
 	source
 		attributes "deep"
 	destination
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 		not attributes "station"
+	cargo "mystery package" 1
+	to offer
+		random < 10
+		"combat rating" > 35
 	on accept
 		dialog phrase "deep mystery cube pickup"
+	npc
+		government "Bounty Hunter"
+		personality nemesis disables waiting plunders
+		system
+			distance 6 9
+		fleet "Bounty Hunters"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
@@ -163,31 +169,31 @@ mission "Mystery Cube Delivery Job [2]"
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
-	npc
-		government "Bounty Hunter"
-		personality nemesis disables waiting plunders
-		system
-			distance 6 9
-		fleet "Bounty Hunters"
 
 
 mission "Mystery Cube Delivery Job [3]"
-	name "Mystery delivery to <planet>"
 	job
 	repeat
+	name "Mystery delivery to <planet>"
 	description "Deliver a package to <destination>. Payment is <payment>."
-	cargo "mystery package" 1
-	to offer
-		random < 10
-		"combat rating" > 35
 	source
 		attributes "deep"
 	destination
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 		not attributes "station"
+	cargo "mystery package" 1
+	to offer
+		random < 10
+		"combat rating" > 35
 	on accept
 		dialog phrase "deep mystery cube pickup"
+	npc
+		government "Bounty Hunter"
+		personality nemesis disables waiting plunders
+		system
+			distance 6 9
+		fleet "Bounty Hunters"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
@@ -195,31 +201,31 @@ mission "Mystery Cube Delivery Job [3]"
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
-	npc
-		government "Bounty Hunter"
-		personality nemesis disables waiting plunders
-		system
-			distance 6 9
-		fleet "Bounty Hunters"
 
 
 mission "Mystery Cube Delivery Job Station"
-	name "Mystery delivery to <planet>"
 	job
 	repeat
+	name "Mystery delivery to <planet>"
 	description "Deliver a package to <destination>. Payment is <payment>."
-	cargo "mystery package" 1
-	to offer
-		random < 7
-		"combat rating" > 35
 	source
 		attributes "deep"
 	destination
 		distance 9 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 		attributes "station"
+	cargo "mystery package" 1
+	to offer
+		random < 7
+		"combat rating" > 35
 	on accept
 		dialog phrase "deep mystery cube pickup"
+	npc
+		government "Bounty Hunter"
+		personality nemesis disables waiting plunders
+		system
+			distance 6 9
+		fleet "Bounty Hunters"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
@@ -227,23 +233,13 @@ mission "Mystery Cube Delivery Job Station"
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff station payment"
-	npc
-		government "Bounty Hunter"
-		personality nemesis disables waiting plunders
-		system
-			distance 6 9
-		fleet "Bounty Hunters"
 
 
 mission "Mystery Cube Retrieval Job"
-	name "Mystery retrieval"
 	job
 	repeat
+	name "Mystery retrieval"
 	description "Retrieve a package from <stopovers>, then return to <destination>. Payment is <payment>."
-	cargo "mystery package" 1
-	to offer
-		random < 10
-		"combat rating" > 35
 	source
 		attributes "deep"
 	stopover
@@ -251,6 +247,16 @@ mission "Mystery Cube Retrieval Job"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Hai" "Quarg"
 		attributes "spaceport"
 		not attributes "station"
+	cargo "mystery package" 1
+	to offer
+		random < 10
+		"combat rating" > 35
+	npc
+		government "Bounty Hunter"
+		personality nemesis disables waiting plunders
+		system
+			distance 10 17
+		fleet "Bounty Hunters"
 	on stopover
 		dialog phrase "deep mystery cube pickup"
 	on visit
@@ -260,27 +266,20 @@ mission "Mystery Cube Retrieval Job"
 		"mystery cube" ++
 		payment 5000 1000
 		dialog phrase "deep mystery cube dropoff payment"
-	npc
-		government "Bounty Hunter"
-		personality nemesis disables waiting plunders
-		system
-			distance 10 17
-		fleet "Bounty Hunters"
 
 
 mission "Transport scientists"
-	name "Transport scientists"
-	description "A team of <bunks> scientists needs some research notes analyzed at the facility on <stopovers>. Take the scientists there and then return them to <planet> for <payment>."
 	job
 	repeat
-	to offer
-		random < 15
-	passengers 5 16
+	description "A team of <bunks> scientists needs some research notes analyzed at the facility on <stopovers>. Take the scientists there and then return them to <planet> for <payment>."
 	source
 		attributes "deep"
 	stopover
 		attributes "research"
 		distance 2 50
+	passengers 5 16
+	to offer
+		random < 15
 	on stopover
 		dialog "The scientists have been giddily discussing the results of their research during the entire trip. You're happy for a bit of peace and quiet as they make tracks for a prominent research lab to have the results analyzed. You prepare for the return journey to <planet>."
 	on visit
@@ -292,17 +291,17 @@ mission "Transport scientists"
 
 
 mission "Escort science vessel"
-	description "The crew of the science vessel <npc> requests an escort to <stopovers> where they plan to study some unusual phenomena. Escort them there and then return them to <planet> for <payment>."
 	job
 	repeat
-	to offer
-		random < 15
-		"combat rating" > 50
+	description "The crew of the science vessel <npc> requests an escort to <stopovers> where they plan to study some unusual phenomena. Escort them there and then return them to <planet> for <payment>."
 	source
 		attributes "research"
 	stopover
 		attributes "quarg" "pirate" "volcanic" "frontier" "dirt belt" "north" "south"
 		distance 6 50
+	to offer
+		random < 15
+		"combat rating" > 50
 	npc
 		government "Pirate"
 		personality nemesis waiting plunders
@@ -346,14 +345,14 @@ mission "Record academic conference"
 	job
 	repeat
 	description "Record an academic conference on <destination> for professors who cannot attend. Credentials and recording equipment will be provided. Payment is <payment>."
-	cargo "recording equipment" 1
-	to offer
-		random < 15
 	source
 		attributes "deep"
 	destination
 		attributes "research" "quarg" "rich" "paradise"
 		distance 4 10
+	cargo "recording equipment" 1
+	to offer
+		random < 15
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
@@ -401,49 +400,43 @@ phrase "secure package dropoff payment"
 
 
 mission "Secure Transport Job (Secret) [0]"
-	name "Secure delivery to <planet>"
 	job
 	repeat
+	name "Secure delivery to <planet>"
 	description "Deliver a secure package of supplies to <destination>. Payment is <payment>."
+	source
+		attributes "deep"
+		not attributes "station"
+	destination
+		distance 2 7
+		attributes "deep"
+		not planet "Valhalla"
+		not attributes "station"
 	cargo "secure package" 1
 	to offer
 		random < 25
 		not "deep security reveal"
 		"reputation: Deep Security" >= 0
-		"reputation: Deep Security" >= - "secure deep package" * 3
-	source
-		attributes "deep"
-		not attributes "station"
-	destination
-		distance 2 7
-		attributes "deep"
-		not planet "Valhalla"
-		not attributes "station"
+		"reputation: Deep Security" >= "secure deep package" * -3
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
 		dialog phrase "generic cargo on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 3
 	on complete
 		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 3
 
 mission "Secure Transport Job (Secret) [1]"
-	name "Secure delivery to <planet>"
 	job
 	repeat
+	name "Secure delivery to <planet>"
 	description "Deliver a secure package of supplies to <destination>. Payment is <payment>."
-	cargo "secure package" 1
-	to offer
-		random < 20
-		not "deep security reveal"
-		"reputation: Deep Security" >= 0
-		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
 		not attributes "station"
@@ -452,31 +445,31 @@ mission "Secure Transport Job (Secret) [1]"
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station"
+	cargo "secure package" 1
+	to offer
+		random < 20
+		not "deep security reveal"
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= "secure deep package" * -3
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
 		dialog phrase "generic cargo on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 3
 	on complete
 		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 3
 
 mission "Secure Transport Job (Secret) [2]"
-	name "Secure delivery to <planet>"
 	job
 	repeat
+	name "Secure delivery to <planet>"
 	description "Deliver a secure package of supplies to <destination>. Payment is <payment>."
-	cargo "secure package" 1
-	to offer
-		random < 20
-		not "deep security reveal"
-		"reputation: Deep Security" >= 0
-		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
 		not attributes "station"
@@ -485,31 +478,31 @@ mission "Secure Transport Job (Secret) [2]"
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station"
+	cargo "secure package" 1
+	to offer
+		random < 20
+		not "deep security reveal"
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= "secure deep package" * -3
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
 		dialog phrase "generic cargo on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 3
 	on complete
 		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 3
 
 mission "Secure Transport Job (Secret) [3]"
-	name "Secure delivery to <planet>"
 	job
 	repeat
+	name "Secure delivery to <planet>"
 	description "Deliver a secure package of supplies to <destination>. Payment is <payment>."
-	cargo "secure package" 1
-	to offer
-		random < 20
-		not "deep security reveal"
-		"reputation: Deep Security" >= 0
-		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
 		not attributes "station"
@@ -518,31 +511,31 @@ mission "Secure Transport Job (Secret) [3]"
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station"
+	cargo "secure package" 1
+	to offer
+		random < 20
+		not "deep security reveal"
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= "secure deep package" * -3
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
 		dialog phrase "generic cargo on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 3
 	on complete
 		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 3
 
 mission "Secure Transport Job (Secret) [4]"
-	name "Secure delivery to <planet>"
 	job
 	repeat
+	name "Secure delivery to <planet>"
 	description "Deliver a secure package of supplies to <destination>. Payment is <payment>."
-	cargo "secure package" 1
-	to offer
-		random < 20
-		not "deep security reveal"
-		"reputation: Deep Security" >= 0
-		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
 		not attributes "station"
@@ -551,19 +544,25 @@ mission "Secure Transport Job (Secret) [4]"
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station"
+	cargo "secure package" 1
+	to offer
+		random < 20
+		not "deep security reveal"
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= "secure deep package" * -3
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
 		dialog phrase "generic cargo on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 3
 	on complete
 		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 3
 
 
 mission "Deep Security Package Reveal"
@@ -632,19 +631,14 @@ mission "Deep Security Package Reveal"
 				set "deep security reveal"
 			`	Agent Wayde appears to flick a subtle salute your direction, or perhaps merely tips an imaginary cap. "Good day, captain. I look forward to working with you in the future."`
 			`	With a quick motion he flicks his hair back out his eyes and jogs away, sending one last wave your direction just before he turns a corner and disappears.`
+				decline
 
 
 mission "Secure Transport Job (Basic) [0]"
-	name "Secure delivery to <planet>"
 	job
 	repeat
+	name "Secure delivery to <planet>"
 	description "Deliver a secure package of supplies to <destination>. Payment is <payment>."
-	cargo "secure package" 1
-	to offer
-		random < 50
-		has "deep security reveal"
-		"reputation: Deep Security" >= 0
-		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
 		not attributes "station"
@@ -653,57 +647,63 @@ mission "Secure Transport Job (Basic) [0]"
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station"
+	cargo "secure package" 1
+	to offer
+		random < 50
+		has "deep security reveal"
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= "secure deep package" * -3
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
 		dialog phrase "generic cargo on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 3
 	on complete
 		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 3
 
 mission "Secure Transport Job (Basic) [1]"
-	name "Secure delivery to <planet>"
 	job
 	repeat
+	name "Secure delivery to <planet>"
 	description "Deliver a secure package of supplies to <destination>. Payment is <payment>."
+	source
+		attributes "deep"
+		not attributes "station"
+	destination
+		distance 2 7
+		attributes "deep"
+		not planet "Valhalla"
+		not attributes "station"
 	cargo "secure package" 1
 	to offer
 		random < 50
 		has "deep security reveal"
 		"reputation: Deep Security" >= 0
-		"reputation: Deep Security" >= - "secure deep package" * 3
-	source
-		attributes "deep"
-		not attributes "station"
-	destination
-		distance 2 7
-		attributes "deep"
-		not planet "Valhalla"
-		not attributes "station"
+		"reputation: Deep Security" >= "secure deep package" * -3
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
 		dialog phrase "generic cargo on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 3
 	on complete
 		payment 3000 750
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 3
 
 mission "Secure Transport Job (Deep Security) [0]"
-	name "Deep Security delivery to <planet>"
 	job
 	repeat
+	name "Deep Security delivery to <planet>"
 	description "Deliver a Deep Security package to <destination>. Payment is <payment>."
 	cargo "deep security package" 1
 	to offer
@@ -723,27 +723,21 @@ mission "Secure Transport Job (Deep Security) [0]"
 		dialog phrase "secure package pickup"
 	on visit
 		dialog phrase "generic cargo on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 5
 	on complete
 		payment 5000 1000
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 5
 
 mission "Secure Transport Job (Deep Security) [1]"
-	name "Deep Security delivery to <planet>"
 	job
 	repeat
+	name "Deep Security delivery to <planet>"
 	description "Deliver a Deep Security package to <destination>. Payment is <payment>."
-	cargo "deep security package" 1
-	to offer
-		random < 20
-		has "deep security reveal"
-		"reputation: Deep Security" >= 40
-		"secure deep package" >= 20
 	source
 		attributes "deep"
 		not attributes "station"
@@ -752,29 +746,39 @@ mission "Secure Transport Job (Deep Security) [1]"
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station"
+	cargo "deep security package" 1
+	to offer
+		random < 20
+		has "deep security reveal"
+		"reputation: Deep Security" >= 40
+		"secure deep package" >= 20
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
 		dialog phrase "generic cargo on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 5
 	on complete
 		payment 5000 1000
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 5
 
 
 mission "Deep Consultants"
 	minor
+	name "Transport consultants to <planet>"
+	description "Julie and her assistant missed their transport and need to reach <destination> by <date> in order to make several important business meetings.."
 	source
 		attributes "deep"
 		attributes "urban"
 		not attributes "station" "moon"
 		not planet "Valhalla"
 	destination "Valhalla"
+	deadline 2 1
+	passengers 2
 	to offer
 		"reputation: Deep Security" >= 60
 		"secure deep package" >= 30
@@ -782,8 +786,6 @@ mission "Deep Consultants"
 		or
 			not "chosen sides"
 			has "main plot completed"
-	passengers 2
-	deadline 2 1
 	on offer
 		conversation
 			`Strolling through the spaceport, you are suddenly accosted by a young and breathless woman. "Please, Captain," she wheezes, "I'm so glad I caught you."`
@@ -857,16 +859,10 @@ phrase "stranded consultant dropoff payment"
 
 
 mission "Transport Consultants (Deep Security) [0]"
-	name "Transport Deep Security consultants"
 	job
 	repeat
+	name "Transport Deep Security consultants"
 	description "Transport <fare> whose schedules have been ruined by Deep Security to <destination>. Payment is <payment>."
-	passengers 1 8
-	to offer
-		random < 20
-		has "deep security consultants"
-		"reputation: Deep Security" >= 60
-		"secure deep package" >= 30
 	source
 		attributes "deep"
 		not attributes "station"
@@ -875,31 +871,31 @@ mission "Transport Consultants (Deep Security) [0]"
 		attributes "deep"
 		attributes "urban"
 		not attributes "station"
+	passengers 1 8
+	to offer
+		random < 20
+		has "deep security consultants"
+		"reputation: Deep Security" >= 60
+		"secure deep package" >= 30
 	on accept
 		dialog phrase "stranded consultant pickup"
 	on visit
 		dialog phrase "generic passenger on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 7
 	on complete
 		payment 10000 300
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 7
 
 mission "Transport Consultants (Deep Security) [1]"
-	name "Transport Deep Security consultants"
 	job
 	repeat
+	name "Transport Deep Security consultants"
 	description "Transport <fare> whose schedules have been ruined by Deep Security to <destination>. Payment is <payment>."
-	passengers 1 8
-	to offer
-		random < 20
-		has "deep security consultants"
-		"reputation: Deep Security" >= 60
-		"secure deep package" >= 30
 	source
 		attributes "deep"
 		not attributes "station"
@@ -908,33 +904,32 @@ mission "Transport Consultants (Deep Security) [1]"
 		attributes "deep"
 		attributes "urban"
 		not attributes "station"
+	passengers 1 8
+	to offer
+		random < 20
+		has "deep security consultants"
+		"reputation: Deep Security" >= 60
+		"secure deep package" >= 30
 	on accept
 		dialog phrase "stranded consultant pickup"
 	on visit
 		dialog phrase "generic passenger on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 7
 	on complete
 		payment 10000 300
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 7
 
 
 mission "Urgent Deep Sec Package"
-	name "Rush Deep Security Delivery"
-	repeat
-	deadline 1 1
-	description "Deliver a Deep Security package to <destination> by <date>. Payment is <payment>."
 	minor
-	cargo "deep security package" 1
-	to offer
-		random < 3
-		has "deep security reveal"
-		"reputation: Deep Security" >= 40
-		"secure deep package" >= 20
+	repeat
+	name "Rush Deep Security Delivery"
+	description "Deliver a Deep Security package to <destination> by <date>. Payment is <payment>."
 	source
 		attributes "deep"
 	destination
@@ -942,8 +937,19 @@ mission "Urgent Deep Sec Package"
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station"
+	deadline 1 1
+	cargo "deep security package" 1
+	to offer
+		random < 3
+		has "deep security reveal"
+		"reputation: Deep Security" >= 40
+		"secure deep package" >= 20
 	on offer
 		dialog `As you are walking through the spaceport, a man approaches you and flashes a Deep Security ID. "Greetings Captain <last>. We need someone to deliver this to <destination> by <date>, taking the most direct route possible."`
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 7
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
@@ -951,23 +957,12 @@ mission "Urgent Deep Sec Package"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 7
 
 mission "Urgent Deep Sec Consultants [0]"
-	name "Rush Deep Security Consultants"
-	repeat
-	deadline 1 1
-	description "Deliver <bunks> Deep Security consultants to <destination> by <date>. Payment is <payment>."
 	minor
-	passengers 2 6
-	to offer
-		random < 1
-		has "deep security consultants"
-		"reputation: Deep Security" >= 60
-		"secure deep package" >= 30
+	repeat
+	name "Rush Deep Security Consultants"
+	description "Deliver <bunks> Deep Security consultants to <destination> by <date>. Payment is <payment>."
 	source
 		attributes "deep"
 	destination
@@ -975,47 +970,54 @@ mission "Urgent Deep Sec Consultants [0]"
 		attributes "deep"
 		attributes "urban"
 		not attributes "station"
+	deadline 1 1
+	passengers 2 6
+	to offer
+		random < 1
+		has "deep security consultants"
+		"reputation: Deep Security" >= 60
+		"secure deep package" >= 30
 	on offer
 		dialog `As you are walking through the spaceport, a harried man approaches you, informing you that <bunks> Deep Security consultants, including himself, are in need of urgent transport to <destination> by <date>, leaving no time for stopovers.`
 	on visit
 		dialog phrase "generic passenger on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 9
 	on complete
 		payment 60000 300
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 9
 
 mission "Urgent Deep Sec Consultants [1]"
-	name "Rush Deep Security Consultants"
 	repeat
-	deadline 1 1
-	description "Deliver <bunks> Deep Security consultants to <destination> by <date>. Payment is <payment>."
 	minor
+	name "Rush Deep Security Consultants"
+	description "Deliver <bunks> Deep Security consultants to <destination> by <date>. Payment is <payment>."
+	source
+		near "Epsilon Leonis" 3 4
+		attributes "deep"
+		not attributes "station"
+	destination "Valhalla"
+	deadline 1 1
 	passengers 2 6
 	to offer
 		random < 3
 		has "deep security consultants"
 		"reputation: Deep Security" >= 60
 		"secure deep package" >= 30
-	source
-		near "Epsilon Leonis" 3 4
-		attributes "deep"
-		not attributes "station"
-	destination "Valhalla"
 	on offer
 		dialog `As you are walking through the spaceport, a harried man approaches you, informing you that <bunks> Deep Security consultants, including himself, are in need of urgent transport to <destination> by <date>, leaving no time for stopovers.`
 	on visit
 		dialog phrase "generic passenger on visit"
+	on abort
+		# No penalty for aborting.
+	on fail
+		"secure deep package" -= 9
 	on complete
 		payment 60000 300
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
-	on abort
-		# Nothing
-	on fail
-		"secure deep package" -= 9

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -568,8 +568,8 @@ mission "Deep Security Package Reveal"
 		attributes "deep"
 		not attributes "station" "moon"
 	to offer
-		"reputation: Deep Security" >= 100
-		"secure deep package" >= 30
+		"reputation: Deep Security" >= 20
+		"secure deep package" >= 15
 		"mystery cube" >= 5
 		not "deep security reveal"
 		or
@@ -700,7 +700,7 @@ mission "Secure Transport Job (Deep Security) [0]"
 	to offer
 		random < 20
 		has "deep security reveal"
-		"reputation: Deep Security" >= 100
+		"reputation: Deep Security" >= 20
 	source
 		attributes "deep"
 		not attributes "station" "moon"
@@ -731,7 +731,7 @@ mission "Secure Transport Job (Deep Security) [1]"
 	to offer
 		random < 20
 		has "deep security reveal"
-		"reputation: Deep Security" >= 100
+		"reputation: Deep Security" >= 20
 	source
 		attributes "deep"
 		not attributes "station" "moon"
@@ -763,8 +763,8 @@ mission "Deep Consultants"
 		not planet "Valhalla"
 	destination "Valhalla"
 	to offer
-		"reputation: Deep Security" >= 100
-		"secure deep package" >= 30
+		"reputation: Deep Security" >= 30
+		"secure deep package" >= 15
 		"mystery cube" >= 5
 		has "deep security reveal"
 		or
@@ -853,7 +853,7 @@ mission "Transport Consultants (Deep Security) [0]"
 	to offer
 		random < 20
 		has "deep security consultants"
-		"reputation: Deep Security" >= 100
+		"reputation: Deep Security" >= 30
 	source
 		attributes "deep"
 		not attributes "station" "moon"
@@ -884,7 +884,7 @@ mission "Transport Consultants (Deep Security) [1]"
 	to offer
 		random < 20
 		has "deep security consultants"
-		"reputation: Deep Security" >= 100
+		"reputation: Deep Security" >= 30
 	source
 		attributes "deep"
 		not attributes "station" "moon"
@@ -917,7 +917,7 @@ mission "Urgent Deep Sec Package"
 	to offer
 		random < 2
 		has "deep security reveal"
-		"reputation: Deep Security" >= 100
+		"reputation: Deep Security" >= 20
 	source
 		attributes "deep"
 		not attributes "station" "moon"
@@ -949,7 +949,7 @@ mission "Urgent Deep Sec Consultants [0]"
 	to offer
 		random < 1
 		has "deep security consultants"
-		"reputation: Deep Security" >= 100
+		"reputation: Deep Security" >= 30
 	source
 		attributes "deep"
 		not attributes "station" "moon"
@@ -981,7 +981,7 @@ mission "Urgent Deep Sec Consultants [1]"
 	to offer
 		random < 1
 		has "deep security consultants"
-		"reputation: Deep Security" >= 100
+		"reputation: Deep Security" >= 30
 	source
 		near "Epsilon Leonis" 2 7
 		attributes "deep"

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -412,12 +412,11 @@ mission "Secure Transport Job (Secret) [0]"
 		"reputation: Deep Security" >= -50
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
@@ -440,12 +439,11 @@ mission "Secure Transport Job (Secret) [1]"
 		"reputation: Deep Security" >= -50
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
@@ -468,12 +466,11 @@ mission "Secure Transport Job (Secret) [2]"
 		"reputation: Deep Security" >= -50
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
@@ -496,12 +493,11 @@ mission "Secure Transport Job (Secret) [3]"
 		"reputation: Deep Security" >= -50
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
@@ -524,12 +520,11 @@ mission "Secure Transport Job (Secret) [4]"
 		"reputation: Deep Security" >= -50
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
@@ -546,10 +541,10 @@ mission "Deep Security Package Reveal"
 	invisible
 	source
 		attributes "deep"
-		not attributes "station" "moon"
+		not attributes "station"
 	to offer
-		"reputation: Deep Security" >= 20
-		"secure deep package" >= 15
+		"reputation: Deep Security" >= 40
+		"secure deep package" >= 20
 		"mystery cube" >= 5
 		not "deep security reveal"
 		or
@@ -621,12 +616,11 @@ mission "Secure Transport Job (Basic) [0]"
 		"reputation: Deep Security" >= -50
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
@@ -648,12 +642,11 @@ mission "Secure Transport Job (Basic) [1]"
 		"reputation: Deep Security" >= -50
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
@@ -672,15 +665,14 @@ mission "Secure Transport Job (Deep Security) [0]"
 	to offer
 		random < 20
 		has "deep security reveal"
-		"reputation: Deep Security" >= 20
+		"reputation: Deep Security" >= 40
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
@@ -699,15 +691,14 @@ mission "Secure Transport Job (Deep Security) [1]"
 	to offer
 		random < 20
 		has "deep security reveal"
-		"reputation: Deep Security" >= 20
+		"reputation: Deep Security" >= 40
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "secure package pickup"
 	on visit
@@ -727,9 +718,7 @@ mission "Deep Consultants"
 		not planet "Valhalla"
 	destination "Valhalla"
 	to offer
-		"reputation: Deep Security" >= 30
-		"secure deep package" >= 15
-		"mystery cube" >= 5
+		"reputation: Deep Security" >= 60
 		has "deep security reveal"
 		or
 			not "chosen sides"
@@ -817,15 +806,15 @@ mission "Transport Consultants (Deep Security) [0]"
 	to offer
 		random < 20
 		has "deep security consultants"
-		"reputation: Deep Security" >= 30
+		"reputation: Deep Security" >= 60
 	source
 		attributes "deep"
-		not attributes "station" "moon"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
 		attributes "urban"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "stranded consultant pickup"
 	on visit
@@ -844,15 +833,15 @@ mission "Transport Consultants (Deep Security) [1]"
 	to offer
 		random < 20
 		has "deep security consultants"
-		"reputation: Deep Security" >= 30
+		"reputation: Deep Security" >= 60
 	source
 		attributes "deep"
-		not attributes "station" "moon"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
 		attributes "urban"
-		not attributes "station" "moon"
+		not attributes "station"
 	on accept
 		dialog phrase "stranded consultant pickup"
 	on visit
@@ -873,15 +862,14 @@ mission "Urgent Deep Sec Package"
 	to offer
 		random < 2
 		has "deep security reveal"
-		"reputation: Deep Security" >= 20
+		"reputation: Deep Security" >= 40
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
-		not attributes "station" "moon"
+		not attributes "station"
 	on offer
 		dialog `As you are walking through the spaceport, a man approaches you and flashes a Deep Security ID. "Greetings Captain <last>. We need someone to deliver this to <destination> by <date>, taking the most direct route possible."`
 	on visit
@@ -901,15 +889,14 @@ mission "Urgent Deep Sec Consultants [0]"
 	to offer
 		random < 1
 		has "deep security consultants"
-		"reputation: Deep Security" >= 30
+		"reputation: Deep Security" >= 60
 	source
 		attributes "deep"
-		not attributes "station" "moon"
 	destination
 		distance 2 7
 		attributes "deep"
 		attributes "urban"
-		not attributes "station" "moon"
+		not attributes "station"
 	on offer
 		dialog `As you are walking through the spaceport, a harried man approaches you, informing you that <bunks> Deep Security consultants, including himself, are in need of urgent transport to <destination> by <date>, leaving no time for stopovers.`
 	on visit
@@ -929,11 +916,11 @@ mission "Urgent Deep Sec Consultants [1]"
 	to offer
 		random < 1
 		has "deep security consultants"
-		"reputation: Deep Security" >= 30
+		"reputation: Deep Security" >= 60
 	source
 		near "Epsilon Leonis" 2 7
 		attributes "deep"
-		not attributes "station" "moon"
+		not attributes "station"
 	destination "Valhalla"
 	on offer
 		dialog `As you are walking through the spaceport, a harried man approaches you, informing you that <bunks> Deep Security consultants, including himself, are in need of urgent transport to <destination> by <date>, leaving no time for stopovers.`

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -409,9 +409,11 @@ mission "Secure Transport Job (Secret) [0]"
 	to offer
 		random < 25
 		not "deep security reveal"
-		"reputation: Deep Security" >= -50
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
@@ -426,6 +428,8 @@ mission "Secure Transport Job (Secret) [0]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on fail
+		"secure deep package" -= 3
 
 mission "Secure Transport Job (Secret) [1]"
 	name "Secure delivery to <planet>"
@@ -435,10 +439,12 @@ mission "Secure Transport Job (Secret) [1]"
 	cargo "secure package" 1
 	to offer
 		random < 20
-		not "deep security reveal"
-		"reputation: Deep Security" >= -50
+		not "deep security reveal""
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
@@ -453,6 +459,8 @@ mission "Secure Transport Job (Secret) [1]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on fail
+		"secure deep package" -= 3
 
 mission "Secure Transport Job (Secret) [2]"
 	name "Secure delivery to <planet>"
@@ -463,9 +471,11 @@ mission "Secure Transport Job (Secret) [2]"
 	to offer
 		random < 20
 		not "deep security reveal"
-		"reputation: Deep Security" >= -50
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
@@ -480,6 +490,8 @@ mission "Secure Transport Job (Secret) [2]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on fail
+		"secure deep package" -= 3
 
 mission "Secure Transport Job (Secret) [3]"
 	name "Secure delivery to <planet>"
@@ -490,9 +502,11 @@ mission "Secure Transport Job (Secret) [3]"
 	to offer
 		random < 20
 		not "deep security reveal"
-		"reputation: Deep Security" >= -50
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
@@ -507,6 +521,8 @@ mission "Secure Transport Job (Secret) [3]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on fail
+		"secure deep package" -= 3
 
 mission "Secure Transport Job (Secret) [4]"
 	name "Secure delivery to <planet>"
@@ -517,9 +533,11 @@ mission "Secure Transport Job (Secret) [4]"
 	to offer
 		random < 20
 		not "deep security reveal"
-		"reputation: Deep Security" >= -50
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
@@ -534,6 +552,8 @@ mission "Secure Transport Job (Secret) [4]"
 		"reputation: Deep Security" += 1
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on fail
+		"secure deep package" -= 3
 
 
 mission "Deep Security Package Reveal"
@@ -613,9 +633,11 @@ mission "Secure Transport Job (Basic) [0]"
 	to offer
 		random < 50
 		has "deep security reveal"
-		"reputation: Deep Security" >= -50
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
@@ -628,7 +650,10 @@ mission "Secure Transport Job (Basic) [0]"
 	on complete
 		payment 3000 750
 		"reputation: Deep Security" += 1
+		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on fail
+		"secure deep package" -= 3
 
 mission "Secure Transport Job (Basic) [1]"
 	name "Secure delivery to <planet>"
@@ -639,9 +664,11 @@ mission "Secure Transport Job (Basic) [1]"
 	to offer
 		random < 50
 		has "deep security reveal"
-		"reputation: Deep Security" >= -50
+		"reputation: Deep Security" >= 0
+		"reputation: Deep Security" >= - "secure deep package" * 3
 	source
 		attributes "deep"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
@@ -654,7 +681,10 @@ mission "Secure Transport Job (Basic) [1]"
 	on complete
 		payment 3000 750
 		"reputation: Deep Security" += 1
+		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on fail
+		"secure deep package" -= 3
 
 mission "Secure Transport Job (Deep Security) [0]"
 	name "Deep Security delivery to <planet>"
@@ -666,8 +696,10 @@ mission "Secure Transport Job (Deep Security) [0]"
 		random < 20
 		has "deep security reveal"
 		"reputation: Deep Security" >= 40
+		"secure deep package" >= 20
 	source
 		attributes "deep"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
@@ -680,7 +712,10 @@ mission "Secure Transport Job (Deep Security) [0]"
 	on complete
 		payment 5000 1000
 		"reputation: Deep Security" += 1
+		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on fail
+		"secure deep package" -= 5
 
 mission "Secure Transport Job (Deep Security) [1]"
 	name "Deep Security delivery to <planet>"
@@ -692,8 +727,10 @@ mission "Secure Transport Job (Deep Security) [1]"
 		random < 20
 		has "deep security reveal"
 		"reputation: Deep Security" >= 40
+		"secure deep package" >= 20
 	source
 		attributes "deep"
+		not attributes "station"
 	destination
 		distance 2 7
 		attributes "deep"
@@ -706,7 +743,10 @@ mission "Secure Transport Job (Deep Security) [1]"
 	on complete
 		payment 5000 1000
 		"reputation: Deep Security" += 1
+		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on fail
+		"secure deep package" -= 5
 
 
 mission "Deep Consultants"
@@ -719,6 +759,7 @@ mission "Deep Consultants"
 	destination "Valhalla"
 	to offer
 		"reputation: Deep Security" >= 60
+		"secure deep package" >= 30
 		has "deep security reveal"
 		or
 			not "chosen sides"
@@ -807,6 +848,7 @@ mission "Transport Consultants (Deep Security) [0]"
 		random < 20
 		has "deep security consultants"
 		"reputation: Deep Security" >= 60
+		"secure deep package" >= 30
 	source
 		attributes "deep"
 		not attributes "station"
@@ -822,7 +864,10 @@ mission "Transport Consultants (Deep Security) [0]"
 	on complete
 		payment 10000 300
 		"reputation: Deep Security" += 1
+		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
+	on fail
+		"secure deep package" -= 7
 
 mission "Transport Consultants (Deep Security) [1]"
 	name "Transport Deep Security consultants"
@@ -834,6 +879,7 @@ mission "Transport Consultants (Deep Security) [1]"
 		random < 20
 		has "deep security consultants"
 		"reputation: Deep Security" >= 60
+		"secure deep package" >= 30
 	source
 		attributes "deep"
 		not attributes "station"
@@ -849,7 +895,10 @@ mission "Transport Consultants (Deep Security) [1]"
 	on complete
 		payment 10000 300
 		"reputation: Deep Security" += 1
+		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
+	on fail
+		"secure deep package" -= 7
 
 
 mission "Urgent Deep Sec Package"
@@ -863,6 +912,7 @@ mission "Urgent Deep Sec Package"
 		random < 3
 		has "deep security reveal"
 		"reputation: Deep Security" >= 40
+		"secure deep package" >= 20
 	source
 		attributes "deep"
 	destination
@@ -877,7 +927,10 @@ mission "Urgent Deep Sec Package"
 	on complete
 		payment 30000 1000
 		"reputation: Deep Security" += 1
+		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
+	on fail
+		"secure deep package" -= 7
 
 mission "Urgent Deep Sec Consultants [0]"
 	name "Rush Deep Security Consultants"
@@ -890,6 +943,7 @@ mission "Urgent Deep Sec Consultants [0]"
 		random < 1
 		has "deep security consultants"
 		"reputation: Deep Security" >= 60
+		"secure deep package" >= 30
 	source
 		attributes "deep"
 	destination
@@ -904,7 +958,10 @@ mission "Urgent Deep Sec Consultants [0]"
 	on complete
 		payment 60000 300
 		"reputation: Deep Security" += 1
+		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
+	on fail
+		"secure deep package" -= 9
 
 mission "Urgent Deep Sec Consultants [1]"
 	name "Rush Deep Security Consultants"
@@ -917,6 +974,7 @@ mission "Urgent Deep Sec Consultants [1]"
 		random < 3
 		has "deep security consultants"
 		"reputation: Deep Security" >= 60
+		"secure deep package" >= 30
 	source
 		near "Epsilon Leonis" 3 4
 		attributes "deep"
@@ -929,4 +987,7 @@ mission "Urgent Deep Sec Consultants [1]"
 	on complete
 		payment 60000 300
 		"reputation: Deep Security" += 1
+		"secure deep package" ++
 		dialog phrase "stranded consultant dropoff payment"
+	on fail
+		"secure deep package" -= 9

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -408,6 +408,7 @@ mission "Secure Transport Job (Secret) [0]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -439,6 +440,7 @@ mission "Secure Transport Job (Secret) [1]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -470,6 +472,7 @@ mission "Secure Transport Job (Secret) [2]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -501,6 +504,7 @@ mission "Secure Transport Job (Secret) [3]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -532,6 +536,7 @@ mission "Secure Transport Job (Secret) [4]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -632,6 +637,7 @@ mission "Secure Transport Job (Basic) [0]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -662,6 +668,7 @@ mission "Secure Transport Job (Basic) [1]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -692,6 +699,7 @@ mission "Secure Transport Job (Deep Security) [0]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -722,6 +730,7 @@ mission "Secure Transport Job (Deep Security) [1]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -799,10 +808,10 @@ phrase "stranded consultant pickup"
 	word
 		` `
 	word
-		`meet the consultants at their hotel accommodation`
-		`collect the consultants from the security station`
-		`fish the consultants out of a seedy bar`
-		`rescue the consultants from some overbearing companions`
+		`meet the <passengers> at their hotel accommodation`
+		`collect the <passengers> from the security station`
+		`fish the <passengers> out of a seedy bar`
+		`rescue the <passengers> from some overbearing companions`
 	word
 		` `
 	word
@@ -820,9 +829,9 @@ phrase "stranded consultant dropoff payment"
 	word
 		` `
 	word
-		`You find out only afterward that they left behind a soiled pair of boots.`
-		`Afterward, you find a tie left hanging on a door handle.`
-		`Later, you find some crumpled documents left behind and wisely tip them into the ship's incinerator without looking at them.`
+		`You find out only afterward that they left behind a soiled pair of boots in one of your cabins.`
+		`Afterward, you find a tie left hanging on one of your ship's door handles.`
+		`Later, you find some crumpled documents left onboard and wisely tip them into the ship's incinerator without looking at them.`
 	word
 		` `
 	word
@@ -833,7 +842,7 @@ mission "Transport Consultants (Deep Security) [0]"
 	name "Transport Deep Security consultants to <planet>"
 	job
 	repeat
-	description "Transport consultants whose schedules have been ruined by Deep Security to <destination>. Payment is <payment>."
+	description "Transport <fare> whose schedules have been ruined by Deep Security to <destination>. Payment is <payment>."
 	passengers 1 8
 	to offer
 		random < 20
@@ -843,6 +852,7 @@ mission "Transport Consultants (Deep Security) [0]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		attributes "urban"
 		not attributes "station" "moon"
@@ -863,7 +873,7 @@ mission "Transport Consultants (Deep Security) [1]"
 	name "Transport Deep Security consultants to <planet>"
 	job
 	repeat
-	description "Transport consultants whose schedules have been ruined by Deep Security to <destination>. Payment is <payment>."
+	description "Transport <fare> whose schedules have been ruined by Deep Security to <destination>. Payment is <payment>."
 	passengers 1 8
 	to offer
 		random < 20
@@ -873,6 +883,7 @@ mission "Transport Consultants (Deep Security) [1]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		attributes "urban"
 		not attributes "station" "moon"
@@ -894,7 +905,7 @@ mission "Urgent Deep Sec Package"
 	name "Rush Deep Security Delivery to <planet>"
 	repeat
 	deadline 1 1
-	description "Deliver <cargo> to <destination> by <date>. Payment is <payment>."
+	description "Deliver a Deep Security package to <destination> by <date>. Payment is <payment>."
 	minor
 	cargo "deep security package" 1
 	to offer
@@ -903,11 +914,12 @@ mission "Urgent Deep Sec Package"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
+		distance 1
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
 	on offer
-		dialog `As you are walking through the spaceport, a man approaches you and flashes a Deep Security ID. "Greetings Captain <last>. We need someone to deliver this to <destination> as soon as possible."`
+		dialog `As you are walking through the spaceport, a man approaches you and flashes a Deep Security ID. "Greetings Captain <last>. We need someone to deliver this to <destination> by <date>, taking the most direct route possible."`
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
@@ -923,7 +935,7 @@ mission "Urgent Deep Sec Consultants [0]"
 	name "Rush Deep Security Consultants to <planet>"
 	repeat
 	deadline 1 1
-	description "Deliver <passengers> to <destination> by <date>. Payment is <payment>."
+	description "Deliver <bunks> Deep Security consultants to <destination> by <date>. Payment is <payment>."
 	minor
 	passengers 2 6
 	to offer
@@ -931,12 +943,13 @@ mission "Urgent Deep Sec Consultants [0]"
 	source
 		attributes "deep"
 		not attributes "station" "moon"
-	destination 
+	destination
+		distance 1
 		attributes "deep"
 		attributes "urban"
 		not attributes "station" "moon"
 	on offer
-		dialog `As you are walking through the spaceport, a harried man approaches you. He is a consultant for Deep Security in need of urgent transport.`
+		dialog `As you are walking through the spaceport, a harried man approaches you, informing you that <bunks> Deep Security consultants, including himself, are in need of urgent transport to <destination> by <date>, leaving no time for stopovers.`
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
@@ -952,17 +965,18 @@ mission "Urgent Deep Sec Consultants [1]"
 	name "Rush Deep Security Consultants to <planet>"
 	repeat
 	deadline 1 1
-	description "Deliver <passengers> to <destination> by <date>. Payment is <payment>."
+	description "Deliver <bunks> Deep Security consultants to <destination> by <date>. Payment is <payment>."
 	minor
 	passengers 2 6
 	to offer
 		random < 5
 	source
+		near "Epsilon Leonis" 1
 		attributes "deep"
 		not attributes "station" "moon"
 	destination "Valhalla"
 	on offer
-		dialog `As you are walking through the spaceport, a harried man approaches you. He is a consultant for Deep Security in need of urgent transport.`
+		dialog `As you are walking through the spaceport, a harried man approaches you, informing you that <bunks> Deep Security consultants, including himself, are in need of urgent transport to <destination> by <date>, leaving no time for stopovers.`
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -408,7 +408,7 @@ mission "Secure Transport Job (Secret) [0]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -440,7 +440,7 @@ mission "Secure Transport Job (Secret) [1]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -472,7 +472,7 @@ mission "Secure Transport Job (Secret) [2]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -504,7 +504,7 @@ mission "Secure Transport Job (Secret) [3]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -536,7 +536,7 @@ mission "Secure Transport Job (Secret) [4]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -637,7 +637,7 @@ mission "Secure Transport Job (Basic) [0]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -668,7 +668,7 @@ mission "Secure Transport Job (Basic) [1]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -699,7 +699,7 @@ mission "Secure Transport Job (Deep Security) [0]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -730,7 +730,7 @@ mission "Secure Transport Job (Deep Security) [1]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -852,7 +852,7 @@ mission "Transport Consultants (Deep Security) [0]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		attributes "urban"
 		not attributes "station" "moon"
@@ -883,7 +883,7 @@ mission "Transport Consultants (Deep Security) [1]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		attributes "urban"
 		not attributes "station" "moon"
@@ -914,7 +914,7 @@ mission "Urgent Deep Sec Package"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		not planet "Valhalla"
 		not attributes "station" "moon"
@@ -944,7 +944,7 @@ mission "Urgent Deep Sec Consultants [0]"
 		attributes "deep"
 		not attributes "station" "moon"
 	destination
-		distance 1
+		distance 2 7
 		attributes "deep"
 		attributes "urban"
 		not attributes "station" "moon"
@@ -971,7 +971,7 @@ mission "Urgent Deep Sec Consultants [1]"
 	to offer
 		random < 5
 	source
-		near "Epsilon Leonis" 1
+		near "Epsilon Leonis" 2 7
 		attributes "deep"
 		not attributes "station" "moon"
 	destination "Valhalla"

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -545,8 +545,7 @@ mission "Secure Transport Job (Secret) [4]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment
-		payment 9000
+		payment 3000 900
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -875,7 +875,7 @@ mission "Urgent Deep Sec Package"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 170000 10000
+		payment 30000 1000
 		"reputation: Deep Security" += 1
 		dialog phrase "secure package dropoff payment"
 
@@ -902,7 +902,7 @@ mission "Urgent Deep Sec Consultants [0]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 450000 300
+		payment 60000 300
 		"reputation: Deep Security" += 1
 		dialog phrase "stranded consultant dropoff payment"
 
@@ -927,6 +927,6 @@ mission "Urgent Deep Sec Consultants [1]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 450000 300
+		payment 60000 300
 		"reputation: Deep Security" += 1
 		dialog phrase "stranded consultant dropoff payment"

--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -417,7 +417,7 @@ mission "Secure Transport Job (Secret) [0]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 50000 10000
+		payment 3000 900
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
@@ -449,7 +449,7 @@ mission "Secure Transport Job (Secret) [1]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 50000 10000
+		payment 3000 900
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
@@ -481,7 +481,7 @@ mission "Secure Transport Job (Secret) [2]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 50000 10000
+		payment 3000 900
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
@@ -513,7 +513,7 @@ mission "Secure Transport Job (Secret) [3]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 50000 10000
+		payment 3000 900
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
@@ -545,7 +545,8 @@ mission "Secure Transport Job (Secret) [4]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 50000 10000
+		payment
+		payment 9000
 		"reputation: Deep Security" += 0.5
 		"secure deep package" ++
 		dialog phrase "secure package dropoff payment"
@@ -646,7 +647,7 @@ mission "Secure Transport Job (Basic) [0]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 50000 10000
+		payment 3000 900
 		"reputation: Deep Security" += 0.5
 		dialog phrase "secure package dropoff payment"
 	on fail
@@ -677,7 +678,7 @@ mission "Secure Transport Job (Basic) [1]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 50000 10000
+		payment 3000 900
 		"reputation: Deep Security" += 0.5
 		dialog phrase "secure package dropoff payment"
 	on fail
@@ -708,7 +709,7 @@ mission "Secure Transport Job (Deep Security) [0]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 80000 15000
+		payment 5000 1500
 		"reputation: Deep Security" += 0.5
 		dialog phrase "secure package dropoff payment"
 	on fail
@@ -739,7 +740,7 @@ mission "Secure Transport Job (Deep Security) [1]"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 80000 15000
+		payment 5000 1500
 		"reputation: Deep Security" += 0.5
 		dialog phrase "secure package dropoff payment"
 	on fail
@@ -861,7 +862,7 @@ mission "Transport Consultants (Deep Security) [0]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 200000 35000
+		payment 10000 600
 		"reputation: Deep Security" += 0.5
 		dialog phrase "stranded consultant dropoff payment"
 	on fail
@@ -892,7 +893,7 @@ mission "Transport Consultants (Deep Security) [1]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 250000 40000
+		payment 10000 600
 		"reputation: Deep Security" += 0.5
 		dialog phrase "stranded consultant dropoff payment"
 	on fail
@@ -910,6 +911,8 @@ mission "Urgent Deep Sec Package"
 	cargo "deep security package" 1
 	to offer
 		random < 2
+		has "deep security reveal"
+		"reputation: Deep Security" >= 100
 	source
 		attributes "deep"
 		not attributes "station" "moon"
@@ -923,7 +926,7 @@ mission "Urgent Deep Sec Package"
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
-		payment 200000 30000
+		payment 0 30000
 		"reputation: Deep Security" += 0.5
 		dialog phrase "secure package dropoff payment"
 	on fail
@@ -939,7 +942,9 @@ mission "Urgent Deep Sec Consultants [0]"
 	minor
 	passengers 2 6
 	to offer
-		random < 5
+		random < 1
+		has "deep security consultants"
+		"reputation: Deep Security" >= 100
 	source
 		attributes "deep"
 		not attributes "station" "moon"
@@ -953,7 +958,7 @@ mission "Urgent Deep Sec Consultants [0]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 300000 60000
+		payment 150000 1500
 		"reputation: Deep Security" += 0.5
 		dialog phrase "stranded consultant dropoff payment"
 	on fail
@@ -969,7 +974,9 @@ mission "Urgent Deep Sec Consultants [1]"
 	minor
 	passengers 2 6
 	to offer
-		random < 5
+		random < 1
+		has "deep security consultants"
+		"reputation: Deep Security" >= 100
 	source
 		near "Epsilon Leonis" 2 7
 		attributes "deep"
@@ -980,7 +987,7 @@ mission "Urgent Deep Sec Consultants [1]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 300000 60000
+		payment 150000 1500
 		"reputation: Deep Security" += 0.5
 		dialog phrase "stranded consultant dropoff payment"
 	on fail


### PR DESCRIPTION
This PR fixes some of the errors present in the jobs committed in 449debe59be4476707ea12a572ec35f7ea6f6ec2, most notably the ability for jobs to have the same destination as a source. It also fixes some of the text substitutions to the correct ones and changes some of the text, such as making it more explicit that the consultants leave behind stuff on your ship and pointing out how time-sensitive the "urgent" missions are. Also included are changes to the payment amounts of each job, integration of rep mechanics to the older mystery cube jobs, and removal of reputation penalties for the jobs, due to being problematic if the player fails/aborts them while at low reputation.