### PR TITLE
System wide hazards

### DIFF
--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -11,14 +11,14 @@
 hazard "Ember Waste Base Heat"
 	"duration" 1 200
 	"strength" 0.25 1.75
-	"system wide"
+	"system-wide"
 	weapon
 		"relative heat damage" 0.00035
 
 hazard "Ember Waste Base Storm"
 	"duration" 300 1500
 	"strength" 1 3
-	"system wide"
+	"system-wide"
 	"range" 8000
 	"environmental effect" "ion hazard" 16
 	weapon

--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -11,15 +11,16 @@
 hazard "Ember Waste Base Heat"
 	"duration" 1 200
 	"strength" 0.25 1.75
-	"range" 20000
+	"system wide"
 	weapon
 		"relative heat damage" 0.00035
 
 hazard "Ember Waste Base Storm"
 	"duration" 300 1500
 	"strength" 1 3
-	"range" 10000
-	"environmental effect" "ion hazard" 20
+	"system wide"
+	"range" 8000
+	"environmental effect" "ion hazard" 16
 	weapon
 		"ion damage" 0.5
 		"shield damage" 5

--- a/source/CollisionSet.cpp
+++ b/source/CollisionSet.cpp
@@ -69,6 +69,7 @@ void CollisionSet::Clear(int step)
 	added.clear();
 	sorted.clear();
 	counts.clear();
+	all.clear();
 	// The counts vector starts with two sentinel slots that will be used in the
 	// course of performing the radix sort.
 	counts.resize(CELLS * CELLS + 2u, 0u);
@@ -96,6 +97,9 @@ void CollisionSet::Add(Body &body)
 			++counts[gy * CELLS + gx + 2];
 		}
 	}
+	
+	// Also save a pointer to this object irrespective of its grid location.
+	all.emplace_back(&body);
 }
 
 
@@ -364,4 +368,11 @@ const vector<Body *> &CollisionSet::Ring(const Point &center, double inner, doub
 		}
 	}
 	return result;
+}
+
+
+
+const vector<Body *> &CollisionSet::All() const
+{
+	return all;
 }

--- a/source/CollisionSet.h
+++ b/source/CollisionSet.h
@@ -53,6 +53,9 @@ public:
 	// centered at the given point.
 	const std::vector<Body *> &Ring(const Point &center, double inner, double outer) const;
 
+	// Get all objects within this collision set.
+	const std::vector<Body *> &All() const;
+
 
 private:
 	class Entry {
@@ -80,6 +83,7 @@ private:
 	int step;
 
 	// Vectors to store the objects in the collision set.
+	std::vector<Body *> all;
 	std::vector<Entry> added;
 	std::vector<Entry> sorted;
 	// After Finish(), counts[index] is where a certain bin begins.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1414,7 +1414,7 @@ void Engine::CalculateStep()
 
 	// Step the weather.
 	for(Weather &weather : activeWeather)
-		weather.Step(newVisuals, flagship ? flagship->Position() : Point());
+		weather.Step(newVisuals, center);
 	Prune(activeWeather);
 
 	// Move the visuals.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1414,7 +1414,7 @@ void Engine::CalculateStep()
 
 	// Step the weather.
 	for(Weather &weather : activeWeather)
-		weather.Step(newVisuals, center);
+		weather.Step(newVisuals, flagship ? flagship->Position() : center);
 	Prune(activeWeather);
 
 	// Move the visuals.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1414,7 +1414,7 @@ void Engine::CalculateStep()
 
 	// Step the weather.
 	for(Weather &weather : activeWeather)
-		weather.Step(newVisuals);
+		weather.Step(newVisuals, flagship ? flagship->Position() : Point());
 	Prune(activeWeather);
 
 	// Move the visuals.
@@ -2109,7 +2109,8 @@ void Engine::DoWeather(Weather &weather)
 		// Get all ship bodies that are touching a ring defined by the hazard's min
 		// and max ranges at the hazard's origin. Any ship touching this ring takes
 		// hazard damage.
-		for(Body *body : shipCollisions.Ring(weather.Origin(), hazard->MinRange(), hazard->MaxRange()))
+		for(Body *body : (hazard->SystemWide() ? shipCollisions.All()
+			: shipCollisions.Ring(weather.Origin(), hazard->MinRange(), hazard->MaxRange())))
 		{
 			Ship *hit = reinterpret_cast<Ship *>(body);
 			hit->TakeDamage(visuals, damage.CalculateDamage(*hit), nullptr);

--- a/source/Hazard.cpp
+++ b/source/Hazard.cpp
@@ -34,6 +34,8 @@ void Hazard::Load(const DataNode &node)
 			LoadWeapon(child);
 		else if(key == "constant strength")
 			deviates = false;
+		else if(key == "system wide")
+			systemWide = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping hazard attribute with no value specified:");
 		else if(key == "period")
@@ -125,6 +127,13 @@ double Hazard::MinRange() const
 double Hazard::MaxRange() const
 {
 	return maxRange;
+}
+
+
+
+bool Hazard::SystemWide() const
+{
+	return systemWide;
 }
 
 

--- a/source/Hazard.cpp
+++ b/source/Hazard.cpp
@@ -34,7 +34,7 @@ void Hazard::Load(const DataNode &node)
 			LoadWeapon(child);
 		else if(key == "constant strength")
 			deviates = false;
-		else if(key == "system wide")
+		else if(key == "system-wide")
 			systemWide = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping hazard attribute with no value specified:");

--- a/source/Hazard.h
+++ b/source/Hazard.h
@@ -41,8 +41,8 @@ public:
 	double MinRange() const;
 	double MaxRange() const;
 	// Whether this hazard affects every ship in the system irrespective of its distance
-	// from the hazard origin. MinRange and MaxRange still get used for the generation of
-	// environmental effects.
+	// from the hazard origin. Environmental effects will be generated about the player's
+	// flagship. MinRange and MaxRange still get used for the generation of these effects.
 	bool SystemWide() const;
 
 	// Visuals to be created while this hazard is active.

--- a/source/Hazard.h
+++ b/source/Hazard.h
@@ -40,6 +40,10 @@ public:
 	// The minimum and maximum distances from the origin in which this hazard has an effect.
 	double MinRange() const;
 	double MaxRange() const;
+	// Whether this hazard affects every ship in the system irrespective of its distance
+	// from the hazard origin. MinRange and MaxRange still get used for the generation of
+	// environmental effects.
+	bool SystemWide() const;
 
 	// Visuals to be created while this hazard is active.
 	const std::map<const Effect *, int> &EnvironmentalEffects() const;
@@ -55,6 +59,7 @@ private:
 	double minRange = 0.;
 	// Hazards given no range only extend out to the invisible fence defined in AI.cpp.
 	double maxRange = 10000.;
+	bool systemWide = false;
 	bool deviates = true;
 
 	std::map<const Effect *, int> environmentalEffects;

--- a/source/Weather.cpp
+++ b/source/Weather.cpp
@@ -70,7 +70,7 @@ const Point &Weather::Origin() const
 
 
 // Create any environmental effects and decrease the lifetime of this weather.
-void Weather::Step(vector<Visual> &visuals, Point flagPos)
+void Weather::Step(vector<Visual> &visuals, Point center)
 {
 	// Environmental effects are created by choosing a random angle and distance from
 	// their origin, then creating the effect there.
@@ -85,9 +85,9 @@ void Weather::Step(vector<Visual> &visuals, Point flagPos)
 	totalAmount *= currentStrength;
 	visuals.reserve(visuals.size() + totalAmount);
 
-	// If a hazard is system wide then use the flagship as the origin position
-	// for new effects. Damage is still dealt from the weather's origin.
-	const Point &effectOrigin = hazard->SystemWide() ? flagPos : origin;
+	// If a hazard is system-wide then use the center of the screen as the
+	// origin for new effects. Damage is still dealt from the weather's origin.
+	const Point &effectOrigin = hazard->SystemWide() ? center : origin;
 	for(auto &&effect : hazard->EnvironmentalEffects())
 		for(int i = 0; i < effect.second * currentStrength; ++i)
 		{

--- a/source/Weather.cpp
+++ b/source/Weather.cpp
@@ -70,7 +70,7 @@ const Point &Weather::Origin() const
 
 
 // Create any environmental effects and decrease the lifetime of this weather.
-void Weather::Step(vector<Visual> &visuals, Point center)
+void Weather::Step(vector<Visual> &visuals, const Point &center)
 {
 	// Environmental effects are created by choosing a random angle and distance from
 	// their origin, then creating the effect there.

--- a/source/Weather.cpp
+++ b/source/Weather.cpp
@@ -70,7 +70,7 @@ const Point &Weather::Origin() const
 
 
 // Create any environmental effects and decrease the lifetime of this weather.
-void Weather::Step(vector<Visual> &visuals, Point flagship)
+void Weather::Step(vector<Visual> &visuals, Point flagPos)
 {
 	// Environmental effects are created by choosing a random angle and distance from
 	// their origin, then creating the effect there.
@@ -87,7 +87,7 @@ void Weather::Step(vector<Visual> &visuals, Point flagship)
 
 	// If a hazard is system wide then use the flagship as the origin position
 	// for new effects. Damage is still dealt from the weather's origin.
-	Point effectOrigin = hazard->SystemWide() ? flagship : origin;
+	const Point &effectOrigin = hazard->SystemWide() ? flagPos : origin;
 	for(auto &&effect : hazard->EnvironmentalEffects())
 		for(int i = 0; i < effect.second * currentStrength; ++i)
 		{

--- a/source/Weather.cpp
+++ b/source/Weather.cpp
@@ -70,7 +70,7 @@ const Point &Weather::Origin() const
 
 
 // Create any environmental effects and decrease the lifetime of this weather.
-void Weather::Step(vector<Visual> &visuals)
+void Weather::Step(vector<Visual> &visuals, Point flagship)
 {
 	// Environmental effects are created by choosing a random angle and distance from
 	// their origin, then creating the effect there.
@@ -85,12 +85,15 @@ void Weather::Step(vector<Visual> &visuals)
 	totalAmount *= currentStrength;
 	visuals.reserve(visuals.size() + totalAmount);
 
+	// If a hazard is system wide then use the flagship as the origin position
+	// for new effects. Damage is still dealt from the weather's origin.
+	Point effectOrigin = hazard->SystemWide() ? flagship : origin;
 	for(auto &&effect : hazard->EnvironmentalEffects())
 		for(int i = 0; i < effect.second * currentStrength; ++i)
 		{
 			Point angle = Angle::Random().Unit();
 			double magnitude = (maxRange - minRange) * sqrt(Random::Real());
-			Point pos = origin + (minRange + magnitude) * angle;
+			Point pos = effectOrigin + (minRange + magnitude) * angle;
 			visuals.emplace_back(*effect.first, std::move(pos), Point(), Angle::Random());
 		}
 

--- a/source/Weather.h
+++ b/source/Weather.h
@@ -50,7 +50,7 @@ public:
 	// The origin of the hazard.
 	const Point &Origin() const;
 	// Create any environmental effects and decrease the lifetime of this weather.
-	void Step(std::vector<Visual> &newVisuals, Point center);
+	void Step(std::vector<Visual> &newVisuals, const Point &center);
 	// Calculate this weather's strength for the current frame, to be used to find
 	// out what the current period and damage multipliers are.
 	void CalculateStrength();

--- a/source/Weather.h
+++ b/source/Weather.h
@@ -50,7 +50,7 @@ public:
 	// The origin of the hazard.
 	const Point &Origin() const;
 	// Create any environmental effects and decrease the lifetime of this weather.
-	void Step(std::vector<Visual> &newVisuals);
+	void Step(std::vector<Visual> &newVisuals, Point flagship);
 	// Calculate this weather's strength for the current frame, to be used to find
 	// out what the current period and damage multipliers are.
 	void CalculateStrength();

--- a/source/Weather.h
+++ b/source/Weather.h
@@ -50,7 +50,7 @@ public:
 	// The origin of the hazard.
 	const Point &Origin() const;
 	// Create any environmental effects and decrease the lifetime of this weather.
-	void Step(std::vector<Visual> &newVisuals, Point flagship);
+	void Step(std::vector<Visual> &newVisuals, Point flagPos);
 	// Calculate this weather's strength for the current frame, to be used to find
 	// out what the current period and damage multipliers are.
 	void CalculateStrength();

--- a/source/Weather.h
+++ b/source/Weather.h
@@ -50,7 +50,7 @@ public:
 	// The origin of the hazard.
 	const Point &Origin() const;
 	// Create any environmental effects and decrease the lifetime of this weather.
-	void Step(std::vector<Visual> &newVisuals, Point flagPos);
+	void Step(std::vector<Visual> &newVisuals, Point center);
 	// Calculate this weather's strength for the current frame, to be used to find
 	// out what the current period and damage multipliers are.
 	void CalculateStrength();


### PR DESCRIPTION
**Feature:** This PR is intended as an alternative to #6480.

## Feature Details
This PR adds a new "system-wide" tag that can be placed on hazards. This tag causes the damage dealt by the hazard to affect every ship in the system irrespective of its distance to the hazard origin (but the distance from the origin is still taken into account where that matters for damage scaling). This tag also causes center of the screen (the player's flagship position, up until the flagship explodes) to be used as the origin position for any effects, but the damage origin remains the same as it was before. This means that the min and max range can still be changed to change the size and shape of the effect generation around the player flagship.

This PR makes a change to CollisionSet to keep a simple vector with pointers to all the bodies in the CollisionSet. This vector is returned by CollisionSet::All, which is called if a hazard is system wide, removing the need to calculate all the ships in the system numerous times as was done in #6480, as shipCollisions already contains all the ships in-system.

Note that if the player's ship is going fast, the fact that the effects are only being generated around the flagship may become noticeable as the player will spot more effects behind them than in front of them. I've reduced the range on the ion storm effect generation from 10k to 8k, as that is about double the asteroid tile distance, which should be sufficient for even the largest of screens to never be able to spot the edge of the effect generation by zooming out. (Part of allowing the range attribute to still tweak effect generation allows us to easily change the size of effect generation with screen sizes, whereas #6480 hardcoded the effect generation range.)

## UI Screenshots
N/A

## Usage Examples
See the changes to the Ember Waste hazards.

## Testing Done
Entered the Ember Waste with the changes made to the two hazards there to make them system-wide. Stayed near the system center and waited for an ion storm to hit and observed effects being created as they should, then flew extremely far from the system center and got hit by another ion storm that still damaged my ship and created effects.

## Performance Impact
N/A
