### PR TITLE
Turn CollisionSet into a template.

### DIFF
--- a/source/AsteroidField.cpp
+++ b/source/AsteroidField.cpp
@@ -153,11 +153,11 @@ Body *AsteroidField::Collide(const Projectile &projectile, double *closestHit)
 	// very last collision check to be done, if a minable asteroid is the
 	// closest hit, it really is what the projectile struck - that is, we are
 	// not going to later find a ship or something else that is closer.
-	Body *body = minableCollisions.Line(projectile, closestHit);
-	if(body)
+	Minable *minable = minableCollisions.Line(projectile, closestHit);
+	if(minable)
 	{
-		hit = body;
-		reinterpret_cast<Minable *>(body)->TakeDamage(projectile);
+		hit = minable;
+		minable->TakeDamage(projectile);
 	}
 	return hit;
 }

--- a/source/AsteroidField.h
+++ b/source/AsteroidField.h
@@ -84,8 +84,8 @@ private:
 	std::vector<Asteroid> asteroids;
 	std::list<std::shared_ptr<Minable>> minables;
 
-	CollisionSet asteroidCollisions;
-	CollisionSet minableCollisions;
+	CollisionSet<Asteroid> asteroidCollisions;
+	CollisionSet<Minable> minableCollisions;
 };
 
 

--- a/source/CollisionSet.h
+++ b/source/CollisionSet.h
@@ -15,16 +15,17 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <vector>
 
+class Body;
 class Government;
 class Point;
 class Projectile;
-class Body;
 
 
 
 // A CollisionSet allows efficient collision detection by splitting space up
 // into a grid and keeping track of which objects are in each grid cell. A check
 // for collisions can then only examine objects in certain cells.
+template <typename T>
 class CollisionSet {
 public:
 	// Initialize a collision set. The cell size and cell count should both be
@@ -35,32 +36,32 @@ public:
 	// know what animation frame each object is on.
 	void Clear(int step);
 	// Add an object to the set.
-	void Add(Body &body);
+	void Add(T &body);
 	// Finish adding objects (and organize them into the final lookup table).
 	void Finish();
 
 	// Get the first object that collides with the given projectile. If a
 	// "closest hit" value is given, update that value.
-	Body *Line(const Projectile &projectile, double *closestHit = nullptr) const;
+	T *Line(const Projectile &projectile, double *closestHit = nullptr) const;
 	// Check for collisions with a line, which may be a projectile's current
 	// position or its entire expected trajectory (for the auto-firing AI).
-	Body *Line(const Point &from, const Point &to, double *closestHit = nullptr,
+	T *Line(const Point &from, const Point &to, double *closestHit = nullptr,
 		const Government *pGov = nullptr, const Body *target = nullptr) const;
 
 	// Get all objects within the given range of the given point.
-	const std::vector<Body *> &Circle(const Point &center, double radius) const;
+	const std::vector<T *> &Circle(const Point &center, double radius) const;
 	// Get all objects touching a ring with a given inner and outer range
 	// centered at the given point.
-	const std::vector<Body *> &Ring(const Point &center, double inner, double outer) const;
+	const std::vector<T *> &Ring(const Point &center, double inner, double outer) const;
 
 
 private:
 	class Entry {
 	public:
 		Entry() = default;
-		Entry(Body *body, int x, int y) : body(body), x(x), y(y) {}
+		Entry(T *body, int x, int y) : body(body), x(x), y(y) {}
 
-		Body *body;
+		T *body;
 		int x;
 		int y;
 	};
@@ -86,7 +87,7 @@ private:
 	std::vector<unsigned> counts;
 
 	// Vector for returning the result of a circle query.
-	mutable std::vector<Body *> result;
+	mutable std::vector<T *> result;
 };
 
 

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -207,7 +207,7 @@ private:
 	std::map<const Government *, std::weak_ptr<const Ship>> grudge;
 	int grudgeTime = 0;
 
-	CollisionSet shipCollisions;
+	CollisionSet<Ship> shipCollisions;
 
 	int alarmTime = 0;
 	double flash = 0.;


### PR DESCRIPTION
Currently CollisionSet uses a Body, but that means that whenever the code using CollisionSet wants to get the original object back it has to do a cast. It seems cleaner to make CollisionSet a template to avoid those casts.