### PR TITLE
Fix Spaceport Reminder triggering prematurely

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -3796,7 +3796,7 @@ mission "Spaceport Reminder"
 	to offer
 		not "chosen sides"
 		"spaceport reminder year" + "spaceport reminder month" != 0
-		"spaceport reminder year" * 100 + "spaceport reminder month" < "year" * 100 + "month" - 3
+		"spaceport reminder year" * 12 + "spaceport reminder month" < "year" * 12 + "month" - 3
 	on offer
 		conversation
 			`As soon as you touch down on <origin>, you step off your ship and head directly for the job board and trade hub, brushing past several locals on the way. The constant routine of interstellar commerce has been firmly drilled into your brain; you near unconsciously peruse the boards, trying to suss out the most profitable route.`


### PR DESCRIPTION
The previous iteration of the Spaceport Reminder mission would erroneously trigger whenever the current year increased by 1. This PR should hopefully fix that.