### PR TITLE
feat(mechanics): Abort missions that you don't have space for instead of failing

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -292,7 +292,7 @@ void PlanetPanel::TakeOffIfReady()
 		if(missionCargoToSell > 0 || overbooked > 0)
 		{
 			bool both = ((cargoToSell > 0 && cargo.MissionCargoSize()) && overbooked > 0);
-			out << "If you take off now you will fail a mission due to not having enough ";
+			out << "If you take off now you will abort a mission due to not having enough ";
 
 			if(overbooked > 0)
 			{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1410,14 +1410,14 @@ bool PlayerInfo::TakeOff(UI *ui)
 
 	// By now, all cargo should have been divvied up among your ships. So, any
 	// mission cargo or passengers left behind cannot be carried, and those
-	// missions have failed.
+	// missions have aborted.
 	vector<const Mission *> missionsToRemove;
 	for(const auto &it : cargo.MissionCargo())
 		if(it.second)
 		{
 			if(it.first->IsVisible())
 				Messages::Add("Mission \"" + it.first->Name()
-					+ "\" failed because you do not have space for the cargo."
+					+ "\" aborted because you do not have space for the cargo."
 						, Messages::Importance::Highest);
 			missionsToRemove.push_back(it.first);
 		}
@@ -1426,13 +1426,13 @@ bool PlayerInfo::TakeOff(UI *ui)
 		{
 			if(it.first->IsVisible())
 				Messages::Add("Mission \"" + it.first->Name()
-					+ "\" failed because you do not have enough passenger bunks free."
+					+ "\" aborted because you do not have enough passenger bunks free."
 						, Messages::Importance::Highest);
 			missionsToRemove.push_back(it.first);
 
 		}
 	for(const Mission *mission : missionsToRemove)
-		RemoveMission(Mission::FAIL, *mission, ui);
+		RemoveMission(Mission::ABORT, *mission, ui);
 
 	// Any ordinary cargo left behind can be sold.
 	int64_t income = 0;


### PR DESCRIPTION
**Feature:** Thought of this while reviewing #6615.

## Feature Details
When the player doesn't have enough cargo or bunk space for an active mission when they attempt to depart, the game will prompt them that they will fail the mission if they continue, and choosing to continue then sends the FAIL trigger to that mission. 

This PR changes it so that missions that the player doesn't have enough space for on take off receive the ABORT trigger instead of the FAIL trigger, and all references to mission failure under this scenario have been changed to make it clear that the mission was aborted instead of failed.

The ABORT trigger didn't exist when this code was written, but it makes more sense to say that the mission was aborted instead of failed since it's player action that is removing the mission from their active missions list, which is distinct from normal failure scenarios like losing the cargo or passengers because of a destroyed ship.

## UI Screenshots
Dialog and messages received when accepting a bunch of jobs then departing without enough space for them.
![image](https://user-images.githubusercontent.com/17688683/159058867-f4d64905-827e-41f3-95fd-5103b1f5d7f9.png)
![image](https://user-images.githubusercontent.com/17688683/159058914-1678b63b-2f29-4966-8be3-3f5eb0622f57.png)

## Usage Examples
N/A

## Testing Done
Accepted a mission with a fail and abort action then parked a ship in my fleet so that I no longer had the space for it. Attempted to depart and received a notice that properly mentioned that the mission would be aborted if I continue, as seen in the UI screenshots. Upon departure, observed that the abort action was completed while the fail action was not.

## Performance Impact
N/A
