### PR TITLE
Play landing sound when starting the game with no recent pilot.

### DIFF
--- a/source/GameLoadingPanel.cpp
+++ b/source/GameLoadingPanel.cpp
@@ -58,7 +58,10 @@ void GameLoadingPanel::Step()
 		// Set the game's initial internal state.
 		GameData::FinishLoading();
 
-		player.LoadRecent();
+		// Load the last loaded save file. If there is none then play the default landing sound.
+		// (If a save file is loaded then the same sound is played when loading it).
+		if(!player.LoadRecent())
+			Audio::Play(Audio::Get("landing"));
 
 		GetUI()->Pop(this);
 		GetUI()->Push(new MenuPanel(player, gamePanels));

--- a/source/GameLoadingPanel.cpp
+++ b/source/GameLoadingPanel.cpp
@@ -60,6 +60,8 @@ void GameLoadingPanel::Step()
 
 		// Load the last loaded save file. If there is none then play the default landing sound.
 		// (If a save file is loaded then the same sound is played when loading it).
+		// TODO: Revert this change when implementing sounds & music
+		//       in the loading phase / animation panel.
 		if(!player.LoadRecent())
 			Audio::Play(Audio::Get("landing"));
 


### PR DESCRIPTION
**Bugfix:** This PR fixes #6635 

## Fix Details

Plays the landing sound if no recent save file was loaded.

## Testing Done

Started the game with no save file: On master silence, with this PR you can hear the landing sound.
