### PR TITLE
Remove PushOrPop after calling every Panel::Step.

### DIFF
--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -99,9 +99,6 @@ void UI::StepAll()
 	// Step all the panels.
 	for(shared_ptr<Panel> &panel : stack)
 		panel->Step();
-
-	// Handle any queud panels added by another panel.
-	PushOrPop();
 }
 
 


### PR DESCRIPTION
This PR simply removes the extra PushOrPop call that seems to be unnecessary. Hopefully the integration tests confirm this.