### PR TITLE
Add MenuAnimationPanel that handles the starting animation and sfx.

### DIFF
--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		DFAAE2AA1FD4A27B0072C0A8 /* ImageSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAAE2A81FD4A27B0072C0A8 /* ImageSet.cpp */; };
 		E3D54794A1EEF51CD4859170 /* DamageProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C62B4D15899E5F47443D0ED6 /* DamageProfile.cpp */; };
 		ED5E4F2ABA89E9DE00603E69 /* TestContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3134EC4B1CCA5546A10C3EF /* TestContext.cpp */; };
+		F35E4D6EA465D71CDA282EBA /* MenuAnimationPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D0FA4800BE72C1B5A7D567B9 /* MenuAnimationPanel.cpp */; };
 		F55745BDBC50E15DCEB2ED5B /* layout.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 9BCF4321AF819E944EC02FB9 /* layout.hpp */; settings = {ATTRIBUTES = (Project, ); }; };
 		F78A44BAA8252F6D53B24B69 /* TextReplacements.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6A4E42FEB3B265A91D5BD2FC /* TextReplacements.cpp */; };
 /* End PBXBuildFile section */
@@ -241,6 +242,7 @@
 		74F543598EEFB3745287E663 /* Bitset.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Bitset.cpp; path = source/Bitset.cpp; sourceTree = "<group>"; };
 		86AB4B6E9C4C0490AE7F029B /* EsUuid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EsUuid.h; path = source/EsUuid.h; sourceTree = "<group>"; };
 		86D9414E818561143BD298BC /* TextReplacements.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextReplacements.h; path = source/TextReplacements.h; sourceTree = "<group>"; };
+		8CB543A1AA20F764DD7FC15A /* MenuAnimationPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MenuAnimationPanel.h; path = source/MenuAnimationPanel.h; sourceTree = "<group>"; };
 		8E8A4C648B242742B22A34FA /* Weather.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Weather.cpp; path = source/Weather.cpp; sourceTree = "<group>"; };
 		950742538F8CECF5D4168FBC /* EsUuid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EsUuid.cpp; path = source/EsUuid.cpp; sourceTree = "<group>"; };
 		98104FFDA18E40F4A712A8BE /* CoreStartData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CoreStartData.h; path = source/CoreStartData.h; sourceTree = "<group>"; };
@@ -506,6 +508,7 @@
 		B5DDA6932001B7F600DBA76A /* News.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = News.h; path = source/News.h; sourceTree = "<group>"; };
 		C49D4EA08DF168A83B1C7B07 /* Hazard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Hazard.cpp; path = source/Hazard.cpp; sourceTree = "<group>"; };
 		C62B4D15899E5F47443D0ED6 /* DamageProfile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DamageProfile.cpp; path = source/DamageProfile.cpp; sourceTree = "<group>"; };
+		D0FA4800BE72C1B5A7D567B9 /* MenuAnimationPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MenuAnimationPanel.cpp; path = source/MenuAnimationPanel.cpp; sourceTree = "<group>"; };
 		DB9A43BA91B3BC47186BF05E /* UniverseObjects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UniverseObjects.h; path = source/UniverseObjects.h; sourceTree = "<group>"; };
 		DC8146D5A145C2DA87D98F1F /* GameLoadingPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameLoadingPanel.h; path = source/GameLoadingPanel.h; sourceTree = "<group>"; };
 		DE844E2BBF82C39B568527CB /* ByName.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ByName.h; path = source/comparators/ByName.h; sourceTree = "<group>"; };
@@ -848,6 +851,8 @@
 				C62B4D15899E5F47443D0ED6 /* DamageProfile.cpp */,
 				19184B47B496B414EC9CE671 /* DamageProfile.h */,
 				5CF247B48EEC7A3C366C1DFA /* DamageDealt.h */,
+				D0FA4800BE72C1B5A7D567B9 /* MenuAnimationPanel.cpp */,
+				8CB543A1AA20F764DD7FC15A /* MenuAnimationPanel.h */,
 			);
 			name = source;
 			sourceTree = "<group>";
@@ -1203,6 +1208,7 @@
 				CE3F49A88B6DCBE09A711110 /* opengl.cpp in Sources */,
 				027A4E858B292CE9F0A06F89 /* FireCommand.cpp in Sources */,
 				E3D54794A1EEF51CD4859170 /* DamageProfile.cpp in Sources */,
+				F35E4D6EA465D71CDA282EBA /* MenuAnimationPanel.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -206,6 +206,8 @@
 		<Unit filename="source/Mask.h" />
 		<Unit filename="source/MaskManager.cpp" />
 		<Unit filename="source/MaskManager.h" />
+		<Unit filename="source/MenuAnimationPanel.cpp" />
+		<Unit filename="source/MenuAnimationPanel.h" />
 		<Unit filename="source/MenuPanel.cpp" />
 		<Unit filename="source/MenuPanel.h" />
 		<Unit filename="source/Messages.cpp" />

--- a/source/GameLoadingPanel.cpp
+++ b/source/GameLoadingPanel.cpp
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "GameData.h"
 #include "Interface.h"
 #include "Information.h"
+#include "MenuAnimationPanel.h"
 #include "MenuPanel.h"
 #include "MaskManager.h"
 #include "PlayerInfo.h"
@@ -58,15 +59,9 @@ void GameLoadingPanel::Step()
 		// Set the game's initial internal state.
 		GameData::FinishLoading();
 
-		// Load the last loaded save file. If there is none then play the default landing sound.
-		// (If a save file is loaded then the same sound is played when loading it).
-		// TODO: Revert this change when implementing sounds & music
-		//       in the loading phase / animation panel.
-		if(!player.LoadRecent())
-			Audio::Play(Audio::Get("landing"));
-
 		GetUI()->Pop(this);
 		GetUI()->Push(new MenuPanel(player, gamePanels));
+		GetUI()->Push(new MenuAnimationPanel(player));
 		finishedLoading = true;
 	}
 }

--- a/source/GameLoadingPanel.cpp
+++ b/source/GameLoadingPanel.cpp
@@ -62,9 +62,8 @@ void GameLoadingPanel::Step()
 		player.LoadRecent();
 
 		GetUI()->Pop(this);
-		auto *animation = new MenuAnimationPanel(player);
-		GetUI()->Push(new MenuPanel(player, gamePanels, animation));
-		GetUI()->Push(animation);
+		GetUI()->Push(new MenuPanel(player, gamePanels));
+		GetUI()->Push(new MenuAnimationPanel());
 
 		finishedLoading = true;
 	}

--- a/source/GameLoadingPanel.cpp
+++ b/source/GameLoadingPanel.cpp
@@ -59,9 +59,13 @@ void GameLoadingPanel::Step()
 		// Set the game's initial internal state.
 		GameData::FinishLoading();
 
+		player.LoadRecent();
+
 		GetUI()->Pop(this);
-		GetUI()->Push(new MenuPanel(player, gamePanels));
-		GetUI()->Push(new MenuAnimationPanel(player));
+		auto *animation = new MenuAnimationPanel(player);
+		GetUI()->Push(new MenuPanel(player, gamePanels, animation));
+		GetUI()->Push(animation);
+
 		finishedLoading = true;
 	}
 }

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -498,8 +498,7 @@ void LoadPanel::LoadCallback()
 
 	player.Load(loadedInfo.Path());
 
-	GetUI()->Pop(this);
-	GetUI()->Pop(GetUI()->Root().get());
+	GetUI()->PopAll();
 	gamePanels.Push(new MainPanel(player));
 	// It takes one step to figure out the planet panel should be created, and
 	// another step to actually place it. So, take two steps to avoid a flicker.

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -498,7 +498,7 @@ void LoadPanel::LoadCallback()
 
 	player.Load(loadedInfo.Path());
 
-	GetUI()->PopAndHigher(GetUI()->Root().get());
+	GetUI()->PopThrough(GetUI()->Root().get());
 	gamePanels.Push(new MainPanel(player));
 	// It takes one step to figure out the planet panel should be created, and
 	// another step to actually place it. So, take two steps to avoid a flicker.

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -498,7 +498,7 @@ void LoadPanel::LoadCallback()
 
 	player.Load(loadedInfo.Path());
 
-	GetUI()->PopAll();
+	GetUI()->PopAndHigher(GetUI()->Root().get());
 	gamePanels.Push(new MainPanel(player));
 	// It takes one step to figure out the planet panel should be created, and
 	// another step to actually place it. So, take two steps to avoid a flicker.

--- a/source/MenuAnimationPanel.cpp
+++ b/source/MenuAnimationPanel.cpp
@@ -15,8 +15,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Angle.h"
 #include "Audio.h"
 #include "Color.h"
-#include "Interface.h"
-#include "Information.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "PointerShader.h"
@@ -28,10 +26,7 @@ MenuAnimationPanel::MenuAnimationPanel(PlayerInfo &player)
 {
 	SetTrapAllEvents(false);
 
-	// Play relevant sounds and music.
 	Audio::Play(Audio::Get("landing"));
-	if(player.GetPlanet())
-		Audio::PlayMusic(player.GetPlanet()->MusicName());
 }
 
 

--- a/source/MenuAnimationPanel.cpp
+++ b/source/MenuAnimationPanel.cpp
@@ -16,13 +16,12 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Audio.h"
 #include "Color.h"
 #include "Planet.h"
-#include "PlayerInfo.h"
 #include "PointerShader.h"
 #include "UI.h"
 
 
 
-MenuAnimationPanel::MenuAnimationPanel(PlayerInfo &player)
+MenuAnimationPanel::MenuAnimationPanel()
 {
 	SetTrapAllEvents(false);
 

--- a/source/MenuAnimationPanel.cpp
+++ b/source/MenuAnimationPanel.cpp
@@ -1,0 +1,60 @@
+/* MenuAnimationPanel.cpp
+Copyright (c) 2022 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "MenuAnimationPanel.h"
+
+#include "Angle.h"
+#include "Audio.h"
+#include "Color.h"
+#include "Interface.h"
+#include "Information.h"
+#include "Planet.h"
+#include "PlayerInfo.h"
+#include "PointerShader.h"
+#include "UI.h"
+
+
+
+MenuAnimationPanel::MenuAnimationPanel(PlayerInfo &player)
+{
+	SetTrapAllEvents(false);
+
+	// Play relevant sounds and music.
+	Audio::Play(Audio::Get("landing"));
+	if(player.GetPlanet())
+		Audio::PlayMusic(player.GetPlanet()->MusicName());
+}
+
+
+
+void MenuAnimationPanel::Step()
+{
+	alpha -= .02f;
+	// Kill this panel if the animation is done.
+	if(alpha <= 0.f)
+		GetUI()->Pop(this);
+}
+
+
+
+void MenuAnimationPanel::Draw()
+{
+	// Draw the shrinking loading circle.
+	Angle da(6.);
+	Angle a(0.);
+	for(int i = 0; i < 60; ++i)
+	{
+		Color color(.5f * alpha, 0.f);
+		PointerShader::Draw(Point(), a.Unit(), 8.f, 20.f, 140.f * alpha, color);
+		a += da;
+	}
+}

--- a/source/MenuAnimationPanel.cpp
+++ b/source/MenuAnimationPanel.cpp
@@ -15,7 +15,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Angle.h"
 #include "Audio.h"
 #include "Color.h"
-#include "Planet.h"
 #include "PointerShader.h"
 #include "UI.h"
 

--- a/source/MenuAnimationPanel.h
+++ b/source/MenuAnimationPanel.h
@@ -15,18 +15,16 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Panel.h"
 
-class PlayerInfo;
-
 
 
 // Class representing the menu animation including sound effects and music
 // that appears when the game is started and everything is loaded.
 class MenuAnimationPanel final : public Panel {
 public:
-	MenuAnimationPanel(PlayerInfo &player);
+	MenuAnimationPanel();
 
-	virtual void Step() override;
-	virtual void Draw() override;
+	void Step() final;
+	void Draw() final;
 
 
 private:

--- a/source/MenuAnimationPanel.h
+++ b/source/MenuAnimationPanel.h
@@ -1,0 +1,38 @@
+/* MenuAnimationPanel.h
+Copyright (c) 2022 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef MENU_ANIMATION_PANEL_H_
+#define MENU_ANIMATION_PANEL_H_
+
+#include "Panel.h"
+
+class PlayerInfo;
+
+
+
+// Class representing the menu animation including sound effects and music
+// that appears when the game is started and everything is loaded.
+class MenuAnimationPanel : public Panel {
+public:
+	MenuAnimationPanel(PlayerInfo &player);
+
+	virtual void Step() override;
+	virtual void Draw() override;
+
+
+private:
+	float alpha = 1.f;
+};
+
+
+
+#endif

--- a/source/MenuAnimationPanel.h
+++ b/source/MenuAnimationPanel.h
@@ -21,7 +21,7 @@ class PlayerInfo;
 
 // Class representing the menu animation including sound effects and music
 // that appears when the game is started and everything is loaded.
-class MenuAnimationPanel : public Panel {
+class MenuAnimationPanel final : public Panel {
 public:
 	MenuAnimationPanel(PlayerInfo &player);
 

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -51,8 +51,8 @@ namespace {
 
 
 
-MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels, const Panel *animationPanel)
-	: player(player), gamePanels(gamePanels), animationPanel(animationPanel), scroll(0)
+MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
+	: player(player), gamePanels(gamePanels), scroll(0)
 {
 	assert(GameData::IsLoaded() && "MenuPanel should only be created after all data is fully loaded");
 	SetIsFullScreen(true);
@@ -75,7 +75,7 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels, const Panel *animationP
 
 void MenuPanel::Step()
 {
-	if(GetUI()->IsTop(this) || (animationPanel && GetUI()->IsTop(animationPanel)))
+	if(GetUI()->IsTop(this))
 	{
 		++scroll;
 		if(scroll >= (20 * credits.size() + 300) * scrollSpeed)
@@ -151,7 +151,7 @@ bool MenuPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	if(player.IsLoaded() && (key == 'e' || command.Has(Command::MENU)))
 	{
 		gamePanels.CanSave(true);
-		GetUI()->PopAndHigher(this);
+		GetUI()->PopThrough(this);
 	}
 	else if(key == 'p')
 		GetUI()->Push(new PreferencesPanel());

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -150,12 +150,7 @@ bool MenuPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	if(player.IsLoaded() && (key == 'e' || command.Has(Command::MENU)))
 	{
 		gamePanels.CanSave(true);
-
-		// If this panel is not the top panel, then the top panel must be the
-		// MenuAnimationPanel. Pop that top panel as well in that case.
-		if(!GetUI()->IsTop(this))
-			GetUI()->Pop(GetUI()->Top().get());
-		GetUI()->Pop(this);
+		GetUI()->PopAll();
 	}
 	else if(key == 'p')
 	{

--- a/source/MenuPanel.h
+++ b/source/MenuPanel.h
@@ -15,7 +15,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Panel.h"
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -29,7 +28,7 @@ class UI;
 // credits and basic information on the currently loaded player.
 class MenuPanel : public Panel {
 public:
-	MenuPanel(PlayerInfo &player, UI &gamePanels, const Panel *animationPanel = nullptr);
+	MenuPanel(PlayerInfo &player, UI &gamePanels);
 
 	virtual void Step() override;
 	virtual void Draw() override;
@@ -43,7 +42,6 @@ protected:
 private:
 	PlayerInfo &player;
 	UI &gamePanels;
-	const Panel *animationPanel;
 
 	std::vector<std::string> credits;
 	unsigned scroll;

--- a/source/MenuPanel.h
+++ b/source/MenuPanel.h
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Panel.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -28,7 +29,7 @@ class UI;
 // credits and basic information on the currently loaded player.
 class MenuPanel : public Panel {
 public:
-	MenuPanel(PlayerInfo &player, UI &gamePanels);
+	MenuPanel(PlayerInfo &player, UI &gamePanels, const Panel *animationPanel = nullptr);
 
 	virtual void Step() override;
 	virtual void Draw() override;
@@ -42,13 +43,10 @@ protected:
 private:
 	PlayerInfo &player;
 	UI &gamePanels;
+	const Panel *animationPanel;
 
 	std::vector<std::string> credits;
 	unsigned scroll;
-
-	// Credits should only scroll if the menu panel is open and not any other as well,
-	// like the preference panel.
-	bool creditsScrolling = true;
 };
 
 

--- a/source/MenuPanel.h
+++ b/source/MenuPanel.h
@@ -45,6 +45,10 @@ private:
 
 	std::vector<std::string> credits;
 	unsigned scroll;
+
+	// Credits should only scroll if the menu panel is open and not any other as well,
+	// like the preference panel.
+	bool creditsScrolling = true;
 };
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1143,8 +1143,11 @@ void PlayerInfo::Land(UI *ui)
 	if(!system || !planet)
 		return;
 
-	Audio::Play(Audio::Get("landing"));
-	Audio::PlayMusic(planet->MusicName());
+	if(!freshlyLoaded)
+	{
+		Audio::Play(Audio::Get("landing"));
+		Audio::PlayMusic(planet->MusicName());
+	}
 
 	// Mark this planet as visited.
 	Visit(*planet);

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -19,6 +19,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <SDL2/SDL.h>
 
 #include <algorithm>
+#include <iterator>
 
 using namespace std;
 
@@ -145,6 +146,15 @@ void UI::Push(const shared_ptr<Panel> &panel)
 void UI::Pop(const Panel *panel)
 {
 	toPop.push_back(panel);
+}
+
+
+
+// Remove every panel on the stack.
+void UI::PopAll()
+{
+	for(const auto &panel : stack)
+		toPop.push_back(panel.get());
 }
 
 

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -19,7 +19,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <SDL2/SDL.h>
 
 #include <algorithm>
-#include <iterator>
 
 using namespace std;
 

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -149,11 +149,15 @@ void UI::Pop(const Panel *panel)
 
 
 
-// Remove every panel on the stack.
-void UI::PopAll()
+// Remove the given panel and every panel that is higher in the stack.
+void UI::PopAndHigher(const Panel *panel)
 {
-	for(const auto &panel : stack)
-		toPop.push_back(panel.get());
+	for(auto it = stack.rbegin(); it != stack.rend(); ++it)
+	{
+		toPop.push_back(it->get());
+		if(it->get() == panel)
+			break;
+	}
 }
 
 

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -150,7 +150,7 @@ void UI::Pop(const Panel *panel)
 
 
 // Remove the given panel and every panel that is higher in the stack.
-void UI::PopAndHigher(const Panel *panel)
+void UI::PopThrough(const Panel *panel)
 {
 	for(auto it = stack.rbegin(); it != stack.rend(); ++it)
 	{

--- a/source/UI.h
+++ b/source/UI.h
@@ -47,8 +47,8 @@ public:
 	// deleted at the start of the next time Step() is called, so it is safe for
 	// a panel to Pop() itself.
 	void Pop(const Panel *panel);
-	// Remove every panel on the stack.
-	void PopAll();
+	// Remove the given panel and every panel that is higher in the stack.
+	void PopAndHigher(const Panel *panel);
 
 	// Check whether the given panel is on top, i.e. is the active one, out of
 	// all panels that are already drawn on this step.

--- a/source/UI.h
+++ b/source/UI.h
@@ -48,7 +48,7 @@ public:
 	// a panel to Pop() itself.
 	void Pop(const Panel *panel);
 	// Remove the given panel and every panel that is higher in the stack.
-	void PopAndHigher(const Panel *panel);
+	void PopThrough(const Panel *panel);
 
 	// Check whether the given panel is on top, i.e. is the active one, out of
 	// all panels that are already drawn on this step.

--- a/source/UI.h
+++ b/source/UI.h
@@ -47,6 +47,8 @@ public:
 	// deleted at the start of the next time Step() is called, so it is safe for
 	// a panel to Pop() itself.
 	void Pop(const Panel *panel);
+	// Remove every panel on the stack.
+	void PopAll();
 
 	// Check whether the given panel is on top, i.e. is the active one, out of
 	// all panels that are already drawn on this step.


### PR DESCRIPTION
## Feature Details

This PR adds a new panel called the MenuAnimationPanel that is responsible for the shrinking circle animation as well as the sound and music that should be played.

## Testing Done

Tested various combinations of opening and closing various panels in the menu, including going into the game and reopening the menu as well as verifying that the animation is still correctly drawn.

Also verified that the landing sounds are still played when playing the game.