### PR TITLE
Rebalance human primary weapons: buff blasters and cannons, nerf lasers

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -24,10 +24,10 @@ outfit "Energy Blaster"
 		"velocity" 10.625
 		"lifetime" 48
 		"reload" 12
-		"firing energy" 9.6
-		"firing heat" 30
-		"shield damage" 9.6
-		"hull damage" 6
+		"firing energy" 5.8
+		"firing heat" 18
+		"shield damage" 10.6
+		"hull damage" 6.6
 	description "Although not the most accurate or damaging of weapons, the Energy Blaster is popular because it is small enough to be installed on even the tiniest of ships. One blaster is not enough to do appreciable damage to anything larger than a fighter, but a ship equipped with several of them becomes a force to be reckoned with."
 
 outfit "Blaster Turret"
@@ -50,10 +50,10 @@ outfit "Blaster Turret"
 		"velocity" 10.625
 		"lifetime" 48
 		"reload" 6
-		"firing energy" 9.6
-		"firing heat" 30
-		"shield damage" 9.6
-		"hull damage" 6
+		"firing energy" 5.8
+		"firing heat" 18
+		"shield damage" 10.6
+		"hull damage" 6.6
 	description "A Blaster Turret is a pair of Energy Blasters mounted on a rotating platform, allowing it to fire in any direction. Sophisticated software algorithms allow the turret to correct for a target's motion, making the Blaster Turret effective even against small, quickly moving fighters. Because it needs a special mounting point with a 360 degree field of view, not all ships are capable of being equipped with a turret."
 
 outfit "Quad Blaster Turret"
@@ -76,10 +76,10 @@ outfit "Quad Blaster Turret"
 		"velocity" 10.625
 		"lifetime" 48
 		"reload" 3
-		"firing energy" 9.6
-		"firing heat" 30
-		"shield damage" 9.6
-		"hull damage" 6
+		"firing energy" 5.8
+		"firing heat" 18
+		"shield damage" 10.6
+		"hull damage" 6.6
 	description "A Quad Blaster Turret carries four guns on a single turret mount, doubling the firepower of an ordinary Blaster Turret for ships with enough space to install one and energy to drive it."
 
 effect "blaster impact"
@@ -107,10 +107,10 @@ outfit "Modified Blaster"
 		"velocity" 10
 		"lifetime" 48
 		"reload" 12
-		"firing energy" 10.8
-		"firing heat" 42
-		"shield damage" 12
-		"hull damage" 8
+		"firing energy" 6.5
+		"firing heat" 25.2
+		"shield damage" 13.2
+		"hull damage" 8.8
 	description "This is an Energy Blaster that has been tampered with to increase its power slightly, at the cost of reduced range and higher energy consumption. Modified Blasters also produce an extreme amount of heat when firing, increasing the risk that your ship will overheat."
 
 outfit "Modified Blaster Turret"
@@ -133,10 +133,10 @@ outfit "Modified Blaster Turret"
 		"velocity" 10
 		"lifetime" 48
 		"reload" 6
-		"firing energy" 10.8
-		"firing heat" 42
-		"shield damage" 12
-		"hull damage" 8
+		"firing energy" 6.5
+		"firing heat" 25.2
+		"shield damage" 13.2
+		"hull damage" 8.8
 	description "This is a turreted version of the Modified Blaster, which is an Energy Blaster modified for greater power at the cost of higher energy consumption and heat. These turrets are popular with pirates and others who are trying to cram as much firepower into their ships as possible."
 
 
@@ -157,8 +157,8 @@ outfit "Beam Laser"
 		"velocity" 300
 		"lifetime" 1
 		"reload" 1
-		"firing energy" .5
-		"firing heat" 1.2
+		"firing energy" .67
+		"firing heat" 1.6
 		"shield damage" 1
 		"hull damage" 1.3
 	description "In the early part of the space era, the settlements in the region of space known as the Deep developed in relative isolation from the rest of human space. One result of that isolation is that their weapons technology mostly uses beam weapons, instead of the energy projectile weapons that are more common elsewhere."
@@ -184,8 +184,8 @@ outfit "Laser Turret"
 		"velocity" 300
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1
-		"firing heat" 2.4
+		"firing energy" 1.33
+		"firing heat" 3.2
 		"shield damage" 2
 		"hull damage" 2.6
 	description "Laser Turrets are hated by fighter pilots because it is nearly impossible to dodge them once you are within their reach. This turret carries a pair of lasers and can swivel almost instantly to fire on new targets as they approach. Laser Turrets are especially useful when mounted on slow-moving freighters to fend off packs of small pirate vessels."
@@ -217,8 +217,8 @@ outfit "Heavy Laser"
 		"velocity" 400
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1
-		"firing heat" 2.1
+		"firing energy" 1.33
+		"firing heat" 2.8
 		"shield damage" 1.7
 		"hull damage" 2.4
 	description "The Heavy Laser is an upgraded Beam Laser with a significantly longer range and higher power. It is mostly intended for larger ships, where energy and space are plentiful, but some pilots consider a single Heavy Laser to be a worthwhile alternative to a pair of Beam Lasers, because the longer range makes up for the fact that it does not quite deal twice as much damage."
@@ -244,8 +244,8 @@ outfit "Heavy Laser Turret"
 		"velocity" 400
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 2
-		"firing heat" 4.2
+		"firing energy" 2.66
+		"firing heat" 5.6
 		"shield damage" 3.4
 		"hull damage" 4.8
 	description "For ships with enough space to install one, the Heavy Laser Turret is a powerful weapon, equally useful for driving off fighters and for bombarding larger targets with continuous fire without having to worry about pointing your ship in the right direction."
@@ -278,8 +278,8 @@ outfit "Electron Beam"
 		"velocity" 450
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 1.5
-		"firing heat" 2.7
+		"firing energy" 2
+		"firing heat" 3.6
 		"shield damage" 2.4
 		"hull damage" 3.3
 	description "The Electron Beam is a recent development by the Deep Sky labs, a more powerful weapon with a design similar to their perennially popular laser guns."
@@ -305,8 +305,8 @@ outfit "Electron Turret"
 		"velocity" 450
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 3.0
-		"firing heat" 5.4
+		"firing energy" 4
+		"firing heat" 7.2
 		"shield damage" 4.8
 		"hull damage" 6.6
 	description "This turret places two of Deep Sky's recently developed electron beam weapons onto a rotating turret, providing unsurpassed accuracy and power for shooting down fast-moving targets."
@@ -399,8 +399,8 @@ outfit "Particle Cannon"
 		"firing force" 10
 		"firing heat" 120
 		"hit force" 80
-		"shield damage" 54
-		"hull damage" 52
+		"shield damage" 65
+		"hull damage" 62
 	description "The Particle Cannon works by accelerating a short burst of particles to near-relativistic speeds. When mounted on a ship that can turn fast enough to keep it trained on approaching ships, it becomes a nearly unbeatable weapon, capable of destroying smaller ships before they can even approach close enough for their comparatively short-ranged weapons to be effective."
 
 effect "particle impact"
@@ -445,8 +445,8 @@ outfit "Proton Fragment"
 		"inaccuracy" 2
 		"lifetime" 24
 		"hit force" 6
-		"shield damage" 8.4
-		"hull damage" 7
+		"shield damage" 10.1
+		"hull damage" 8.4
 
 effect "proton impact"
 	sprite "effect/proton impact"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This PR is intended as a companion to #6671 and an alternative to #5796.

As of right now, among human primary weapons, lasers are the top dog in practically every scenario. Lasers are relatively small, meaning it's easy to saturate a ship's hardpoints with them. Lasers have very low firing requirements, meaning you don't need to dedicate as much of your outfit space to cooling or energy. And lasers have very high damage for their size, making them great choices in combat. And on top of all that, the instant impact nature of lasers makes them perfect for boarding playstyles where you want to leave your target alive and means that they'll never miss.

The two alternatives to lasers are blasters and cannons.

Blasters as they are right now are essentially a non-choice for the player. They are inferior to lasers in almost all ways. Blasters have lower DPS/ton than lasers. While blasters are smaller even than lasers, lasers already don't have a difficult time saturating a ships hardpoints, meaning that saturating your hardpoints with blasters is just a loss in DPS. Blasters also have CONSIDERABLY firing requirements, with extremely high firing energy and heat: as a comparison, the Modified Blaster requires more energy and heat per second to fire than an Electron Beam does.

Cannons are in a much better spot than blasters are. Cannons are larger than lasers, but they make up for this in their slightly increased DPS (although they do have lower DPS per ton), or in the case of Plasma Cannons they have a special damage type. But the main downside of them is that even though their DPS is comparable, they require much more energy and heat to fire. Cannons also lack the instant impact that lasers have, meaning that even if a cannon has better DPS on paper, it's often still beneficial to choose a laser as a laser won't miss and is, again, perfect for disabling ships.

The goal of this PR is to make all weapons at least somewhat viable instead of having a single clear winner among human primaries. That is, we should not be treating blasters as weapons that are intentionally bad and meant to be replaced ASAP; blasters should have a proper place in the weapon sandbox for the player to make use of.

This PR makes the following changes:
* -40% firing energy and heat for all human blasters.
  * Even a decrease this large still leave blasters less energy and heat efficient than lasers, but the gap is now much, much narrower, making blasters less of a pain to use.
  * This change goes much further than #5796, which I feel doesn't go far enough in making blasters a viable weapon.
* +10% shield and hull damage for all human blasters.
  * This slight bump in DPS means that blasters now have ever so slightly more DPS/ton than lasers instead of having slightly less. The tradeoff then is that blasters aren't instant impact and require more firing energy and heat.
  * This change is in contrast to #5796, which makes blaster damage more balanced while keeping the total DPS the same or even decreasing it in the case of the Energy Blaster.
  * Remember that the number of hardpoints a ship has is still a major limiting factor: even if blasters have higher DPS per ton than lasers, if you can fit the same number of blasters as lasers then the lasers will be the way to go since they have a higher raw DPS.
* +33% firing energy and heat for all human lasers.
  * While a considerably increase relative to what it was, the firing energy and heat were so low on lasers to begin with that this simply brings lasers more in line with other human primary weapons.
  * This change is in contrast to #5796's 50% increase to firing energy alone.
* No change to shield or hull damage for human lasers
  * Given that lasers are the most popular choice for dealing damage, I wanted to leave laser DPS as a baseline and give other human weapons a DPS bump rather than drop the DPS of lasers.
  * This change is in contrast to #5796's flipping of the damage values to make lasers more shield damage heavy than hull damage heavy while also reducing their overall DPS by about 25%. I don't want to change the role that lasers fulfill in being high hull damage weapons, at least not right now.
* +20% shield and hull damage for the Particle Cannon and Proton Gun.
  * The Plasma Cannon has been left out since it already benefits greatly from its heat damage.
  * With leaving laser damage where it is and increasing their firing energy and heat, this brought them closer to where the cannons are at. Instead of lowering the firing energy and heat of cannons to make them more competitive, I've instead given them a damage buff so that now if damage output is the concern, cannons are the way to go, as opposed to before where the Electron Beam, Particle Cannon, and Proton Gun were all pretty close in damage output.

And something to remember: If these changes go too far in one area or another, we can always reel them back in slightly at a later date. But I'd say this is at least a good stepping stone toward a healthier sandbox.

## Save File
N/A

## Artwork Checklist
N/A