### PR TITLE
Heatsink

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -221,8 +221,8 @@ tip "heat generation:"
 tip "heat protection:"
 	`Protection against weapons that do heat damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in heat damage, while a total value of 11 only results in a 10 percent reduction.`
 
-tip "heatsink:"
-	`Materials with high specific heat can make for powerful heatsinks. One "heatsink" is equal to one ton of mass, for holding heat.`
+tip "heat capacity:"
+	`Increases the maximum heat that this ship is able to withstand before becoming overheated. A value of one has the same influence on a ship's maximum heat as one ton of mass, without the effects that mass has on movement.`
 
 tip "hull (repair):"
 	`Total hull strength and repair rate (per second). The smallest of ships are disabled when their hull strength drops below about 45%, while very large ships are disabled at close to 10%.`

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -221,6 +221,9 @@ tip "heat generation:"
 tip "heat protection:"
 	`Protection against weapons that do heat damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in heat damage, while a total value of 11 only results in a 10 percent reduction.`
 
+tip "heatsink:"
+	`Materials with high specific heat can make for powerful heatsinks. One "heatsink" is equal to one ton of mass, for holding heat.`
+
 tip "hull (repair):"
 	`Total hull strength and repair rate (per second). The smallest of ships are disabled when their hull strength drops below about 45%, while very large ships are disabled at close to 10%.`
 

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -324,10 +324,10 @@ tip "map:"
 	`How many star systems are included in this map.`
 
 tip "mass with no cargo:"
-	`Mass of this ship when not carrying any cargo or fighters. Cargo increases mass, which reduces acceleration and turn rate.`
+	`Mass of this ship when not carrying any cargo or fighters. Cargo increases mass, which reduces acceleration and turn rate and increases maximum heat before overheating.`
 
 tip "mass:"
-	`Mass, in tons. A ship's mass determines how fast it turns and accelerates.`
+	`Mass, in tons. A ship's mass determines how fast it turns and accelerates and its maximum heat before overheating.`
 
 tip "operating costs:"
 	`How many credits per day you need to spend to maintain this outfit while it is in active use.`

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3197,7 +3197,7 @@ double Ship::HeatDissipation() const
 // Get the maximum heat level, in heat units (not temperature).
 double Ship::MaximumHeat() const
 {
-	return MAXIMUM_TEMPERATURE * (cargo.Used() + attributes.Mass());
+	return MAXIMUM_TEMPERATURE * (cargo.Used() + attributes.Mass() + attributes.Get("heatsink"));
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3197,7 +3197,7 @@ double Ship::HeatDissipation() const
 // Get the maximum heat level, in heat units (not temperature).
 double Ship::MaximumHeat() const
 {
-	return MAXIMUM_TEMPERATURE * (cargo.Used() + attributes.Mass() + attributes.Get("heatsink"));
+	return MAXIMUM_TEMPERATURE * (cargo.Used() + attributes.Mass() + attributes.Get("heat capacity"));
 }
 
 


### PR DESCRIPTION
**Feature:** This PR implements a heat-sink attribute.

## Feature Details
`MaximumHeat()` is used throughout the game, for all sorts of calculations. This makes adjusting it extremely easy. If an outfit has `"heatsink" 1`, then the ship it is installed on will have +100 maximum heat capacity (mass does the same thing, while also slowing down thrusters)

## UI Screenshots
N/A

## Usage Examples
```
outfit "Large Heat Shunt"
	category "Systems"
	cost 790000
	thumbnail "outfit/large heat shunt"
	"mass" 24
	"outfit space" -24
	"cooling" 54
	"heatsink" 36
	description "Without these powerful cooling systems, most Korath warships would overheat within seconds as soon as they began to fire their weapons."
```

## Testing Done
Putting a large amount of "heatsink" onto the cooling ducts outfit, and then putting a large number of those onto a ship. This vastly increases the ship's thermal capacity, and firing weapons with huge firing heat causes a much smaller jump on the right-hand-side heat bar than if there were no cooling ducts on the ship. The attribute works as intended.

## Performance Impact
I do not know if accessing attributes is expensive (it is probably not), most likely this does not impact performance.
