### PR TITLE
Moved the Strong Wind to the Wanderer licence

### DIFF
--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -202,7 +202,7 @@ ship "Strong Wind"
 	attributes
 		category "Medium Warship"
 		licenses
-			"Wanderer Military"
+			"Wanderer"
 		"cost" 16100000
 		"shields" 28500
 		"hull" 19600

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -772,7 +772,7 @@ mission "Wanderers: Unfettered Diplomacy 1C"
 		set "license: Wanderer"
 		log "Managed to broker a temporary ceasefire between the Unfettered Hai and the Wanderers. Was granted access to purchase the non-military Wanderer ships, as a reward."
 		conversation
-			`When you return to <planet>, Iktat Rek meets with Ambassador Sayari and a few of the Wanderer elders. The elders thank you for the role that you played in negotiating a temporary peace, and Rek says, "We will [reward, honor] you by allowing you to purchase our ships, all but the [ship of war, battleship]."`
+			`When you return to <planet>, Iktat Rek meets with Ambassador Sayari and a few of the Wanderer elders. The elders thank you for the role that you played in negotiating a temporary peace, and Rek says, "We will [reward, honor] you by allowing you to purchase our current [civilian, peacekeeping] ships."`
 			`	The elders seem to agree that this is only a temporary solution. The Unfettered cannot be granted a base in Wanderer territory: they would use their few jump drives to move a few warships at a time to that base until they had a fleet too strong for the Wanderers to defeat. Sooner or later, the Unfettered will grow tired of demanding such a base and will return to open warfare.`
 			`	In the meantime, the only way to defuse the situation would be to get all the jump drives out of the hands of the Unfettered - and that means discovering and stopping whoever is supplying those drives to them.`
 


### PR DESCRIPTION
## Summary
The Wanderers are an open handed trust culture. They provide food for the Unfettered to raid, they reach out the the Efreti, they provide a terraforming mind to the Mereti, and they disastrously invite the Exiles to assist with dealing with the Sestor. Regarding the Exiles,  "No," says Rek, "the leaders are right, we must offer them our trust until they prove utterly unworthy of it."

Yet, when it comes to the player, they restrict access to their repurposed exploration ship even though the player has fought beside them and assisted with their diplomacy for no direct financial compensation.

Additionally, the only thing actually restricted is the hull. The weapons systems and reactors needed to power them are available it the outfitter. At this point in the game, the player has access to several equivalent ships that can field those weapons systems and have turret mounts as well, so it's hard to see this being a problem with technology transfer.

Finally, there is a long lag time between license changes. And when the military license comes along it's simultaneous with the Tempest and followed in short order by the Derecho and the Hurricane. That means there is a long period when you might buy a Strong Wind, but can't, followed by a period where you can, but won't because there are better ships on offer.

## Save File
This save file can be used to play through the new mission content:
[Fred Flintstone.txt](https://github.com/endless-sky/endless-sky/files/8444300/Fred.Flintstone.txt)


## Testing Done
I played through with the attached save file. Screenshots below.


## UI Screenshots
![Strong Wind license 2022-04-07_13-07-03](https://user-images.githubusercontent.com/70952724/162234815-fb218ce4-d0c5-4b30-b682-58dcd0f35b64.png)
![Stron Wind Outfitter_2022-04-07_13-09-30](https://user-images.githubusercontent.com/70952724/162234817-ab1180e1-f3b5-43fc-a007-192886fd88ac.png)

