### PR TITLE
fix(typo): fix minor typos in two missions

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -1784,7 +1784,7 @@ mission "Nanachi 4"
 				`	"Can't you just postpone the festival until the pirates are taken care of?"`
 			`	Xavier collapses back to the table, holding his head in both hands. "Those paintings and sculptures were our main attraction! They're worth tens of billions! It'll take months before the Navy ever notices the pirates there and makes it safe for the convoy to come here. The art exhibition is scheduled three weeks from now!"`
 			`	As they try to figure out what to do, Nanachi speaks up. "I'll go there. I pilot a human ship and if we just need to transfer cargo from one ship to the other, I could get out of there quickly. Nobody would notice that a Hai ever went there."`
-			`	"Are you insane?" Vanessa says, "If they managed to take down that Leviathan, you wouldn't last a second! Besides, our convoy was extremely fast. If even they were caught your chances of outrunning the pirates are next to nothing!"`
+			`	"Are you insane?" Vanessa says, "If they managed to take down that Leviathan, you wouldn't last a second! Besides, our convoy was extremely fast. If even they were caught, your chances of outrunning the pirates are next to nothing!"`
 			`	"Captain <last>," Nanachi turns to you. "I know you already helped me way more than anyone would ever be willing to, and I'm really grateful for that, but would you be willing to help me one last time, to get to that planet, and travel back here?" While it's certain that for a pirate fleet to take down a Leviathan so easily they must be incredibly powerful and this could be extremely dangerous, you're sure that if Nanachi tries to get to Prime by herself she'll just get herself killed.`
 			choice
 				`	"Alright, I'll make sure we reach Prime and get back here safely."`

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -2113,9 +2113,9 @@ mission "Terminus exploration"
 			branch skip
 				not "First Contact: Hai: offered"
 			action
-				log `Ivan said that although he's not sure if the anomaly is a wormhole or not, it does bear striking resemblance to the wormhole that leads to the Hai.`
+				log `Ivan said that although he's not sure if the anomaly is a wormhole or not, it does bear a striking resemblance to the wormhole that leads to the Hai.`
 			`	"You mean the wormhole to the Hai?" you ask.`
-			`	"Interesting, you know of it," Ivan responds. "The anomaly in Terminus bearings striking resemblance to it in some of our readings, although it is very different in others."`
+			`	"Interesting, you know of it," Ivan responds. "The anomaly in Terminus bears a striking resemblance to it in some of our readings, although it is very different in others."`
 				goto end
 			label skip
 			action


### PR DESCRIPTION
This just fixes a couple minor typos in mission text that I spotted in a recent playthrough.