### PR TITLE
Rebalance the engine sandbox

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -285,7 +285,7 @@ outfit "Large Steering Module"
 	"mass" 25
 	"outfit space" -25
 	"engine capacity" -25
-	"turn" 711.9
+	"turn" 747
 	"turning energy" 1.0
 	"turning heat" 6.5
 	"steering flare sprite" "effect/coalition flare/large"

--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -39,6 +39,12 @@ ship "Archon"
 		"ion protection" 3
 		"ion resistance" 1
 		"ramscoop" 100
+		"thrust" 80
+		"thrusting energy" 20
+		"thrusting heat" 10
+		"turn" 1600
+		"turning energy" 10
+		"turning heat" 5
 		weapon
 			"blast radius" 200
 			"shield damage" 20000
@@ -54,8 +60,6 @@ ship "Archon"
 		"Drak Distancer" 2
 		"Drak Turret" 3
 		"Drak Turret (Augmented)" 3
-		"Medium Graviton Thruster"
-		"Medium Graviton Steering"
 		"Hyperdrive"
 		"Jump Drive"
 	

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -467,7 +467,7 @@ outfit `"Baellie" Atomic Engines`
 	"thrust" 7.3
 	"thrusting energy" .87
 	"thrusting heat" 1.7
-	"turn" 250
+	"turn" 244
 	"turning energy" .64
 	"turning heat" 1.28
 	"flare sprite" "effect/atomic flare/tiny"
@@ -561,7 +561,7 @@ outfit `"Basrem" Atomic Steering`
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
-	"turn" 309
+	"turn" 301
 	"turning energy" .7
 	"turning heat" 1.6
 	"steering flare sprite" "effect/atomic flare/tiny"
@@ -576,7 +576,7 @@ outfit `"Benga" Atomic Steering`
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
-	"turn" 577
+	"turn" 563
 	"turning energy" 1.1
 	"turning heat" 2.8
 	"steering flare sprite" "effect/atomic flare/tiny"
@@ -591,7 +591,7 @@ outfit `"Biroo" Atomic Steering`
 	"mass" 32
 	"outfit space" -32
 	"engine capacity" -32
-	"turn" 1054
+	"turn" 1028
 	"turning energy" 2.0
 	"turning heat" 5.1
 	"steering flare sprite" "effect/atomic flare/small"
@@ -606,7 +606,7 @@ outfit `"Bondir" Atomic Steering`
 	"mass" 49
 	"outfit space" -49
 	"engine capacity" -49
-	"turn" 1758
+	"turn" 1714
 	"turning energy" 3.2
 	"turning heat" 8.2
 	"steering flare sprite" "effect/atomic flare/medium"
@@ -621,7 +621,7 @@ outfit `"Bufaer" Atomic Steering`
 	"mass" 76
 	"outfit space" -76
 	"engine capacity" -76
-	"turn" 3043
+	"turn" 2967
 	"turning energy" 5.2
 	"turning heat" 13.8
 	"steering flare sprite" "effect/atomic flare/large"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -563,7 +563,7 @@ outfit `"Basrem" Atomic Steering`
 	"engine capacity" -12
 	"turn" 301
 	"turning energy" .7
-	"turning heat" 1.6
+	"turning heat" 1.5
 	"steering flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"steering flare sound" "atomic tiny"
@@ -578,7 +578,7 @@ outfit `"Benga" Atomic Steering`
 	"engine capacity" -20
 	"turn" 563
 	"turning energy" 1.1
-	"turning heat" 2.8
+	"turning heat" 2.85
 	"steering flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"steering flare sound" "atomic tiny"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -465,8 +465,8 @@ outfit `"Baellie" Atomic Engines`
 	"outfit space" -22
 	"engine capacity" -22
 	"thrust" 7.3
-	"thrusting energy" .92
-	"thrusting heat" 1.83
+	"thrusting energy" .87
+	"thrusting heat" 1.7
 	"turn" 250
 	"turning energy" .64
 	"turning heat" 1.28
@@ -486,8 +486,8 @@ outfit `"Basrem" Atomic Thruster`
 	"outfit space" -18
 	"engine capacity" -18
 	"thrust" 12.5
-	"thrusting energy" 1.5
-	"thrusting heat" 2.9
+	"thrusting energy" 1.4
+	"thrusting heat" 2.8
 	"flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"flare sound" "atomic tiny"
@@ -501,8 +501,8 @@ outfit `"Benga" Atomic Thruster`
 	"outfit space" -28
 	"engine capacity" -28
 	"thrust" 22.4
-	"thrusting energy" 2.6
-	"thrusting heat" 5.0
+	"thrusting energy" 2.5
+	"thrusting heat" 4.8
 	"flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"flare sound" "atomic tiny"
@@ -516,8 +516,8 @@ outfit `"Biroo" Atomic Thruster`
 	"outfit space" -44
 	"engine capacity" -44
 	"thrust" 39.4
-	"thrusting energy" 4.2
-	"thrusting heat" 8.6
+	"thrusting energy" 4
+	"thrusting heat" 8.2
 	"flare sprite" "effect/atomic flare/small"
 		"frame rate" 13
 	"flare sound" "atomic small"
@@ -531,8 +531,8 @@ outfit `"Bondir" Atomic Thruster`
 	"outfit space" -63
 	"engine capacity" -63
 	"thrust" 62.8
-	"thrusting energy" 6.4
-	"thrusting heat" 13.4
+	"thrusting energy" 6.1
+	"thrusting heat" 12.7
 	"flare sprite" "effect/atomic flare/medium"
 		"frame rate" 12
 	"flare sound" "atomic medium"
@@ -546,8 +546,8 @@ outfit `"Bufaer" Atomic Thruster`
 	"outfit space" -104
 	"engine capacity" -104
 	"thrust" 114.1
-	"thrusting energy" 10.9
-	"thrusting heat" 23.8
+	"thrusting energy" 10.4
+	"thrusting heat" 22.6
 	"flare sprite" "effect/atomic flare/large"
 		"frame rate" 11
 	"flare sound" "atomic large"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -464,7 +464,7 @@ outfit `"Baellie" Atomic Engines`
 	"mass" 22
 	"outfit space" -22
 	"engine capacity" -22
-	"thrust" 7.7
+	"thrust" 7.3
 	"thrusting energy" .92
 	"thrusting heat" 1.83
 	"turn" 250
@@ -485,7 +485,7 @@ outfit `"Basrem" Atomic Thruster`
 	"mass" 18
 	"outfit space" -18
 	"engine capacity" -18
-	"thrust" 13.2
+	"thrust" 12.5
 	"thrusting energy" 1.5
 	"thrusting heat" 2.9
 	"flare sprite" "effect/atomic flare/tiny"
@@ -500,7 +500,7 @@ outfit `"Benga" Atomic Thruster`
 	"mass" 28
 	"outfit space" -28
 	"engine capacity" -28
-	"thrust" 23.6
+	"thrust" 22.4
 	"thrusting energy" 2.6
 	"thrusting heat" 5.0
 	"flare sprite" "effect/atomic flare/tiny"
@@ -515,7 +515,7 @@ outfit `"Biroo" Atomic Thruster`
 	"mass" 44
 	"outfit space" -44
 	"engine capacity" -44
-	"thrust" 41.5
+	"thrust" 39.4
 	"thrusting energy" 4.2
 	"thrusting heat" 8.6
 	"flare sprite" "effect/atomic flare/small"
@@ -530,7 +530,7 @@ outfit `"Bondir" Atomic Thruster`
 	"mass" 63
 	"outfit space" -63
 	"engine capacity" -63
-	"thrust" 66.1
+	"thrust" 62.8
 	"thrusting energy" 6.4
 	"thrusting heat" 13.4
 	"flare sprite" "effect/atomic flare/medium"
@@ -545,13 +545,14 @@ outfit `"Bufaer" Atomic Thruster`
 	"mass" 104
 	"outfit space" -104
 	"engine capacity" -104
-	"thrust" 120.1
+	"thrust" 114.1
 	"thrusting energy" 10.9
 	"thrusting heat" 23.8
 	"flare sprite" "effect/atomic flare/large"
 		"frame rate" 11
 	"flare sound" "atomic large"
 	description "These thrusters are the largest of the Hai atomic thrusters, and one of the most powerful thrusters in known space. Beat out by only the largest human atomic thrusters, these massive engines provide enough thrust to push around even the largest of ships as if they were fighters."
+
 
 outfit `"Basrem" Atomic Steering`
 	category "Engines"
@@ -627,6 +628,7 @@ outfit `"Bufaer" Atomic Steering`
 		"frame rate" 11
 	"steering flare sound" "atomic large"
 	description "Nine out of ten human captains interviewed in Hai space say that they would choose Hai atomic engines over those of Deep Sky any day... that is, if they could afford such expensive engines."
+
 
 outfit "Pulse Rifle"
 	category "Hand to Hand"

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -68,7 +68,7 @@ outfit "X1050 Ion Engines"
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
-	"thrust" 4.0
+	"thrust" 4.8
 	"thrusting energy" .4
 	"thrusting heat" .6
 	"turn" 110
@@ -91,7 +91,7 @@ outfit "X1700 Ion Thruster"
 	"mass" 16
 	"outfit space" -16
 	"engine capacity" -16
-	"thrust" 6.0
+	"thrust" 7.2
 	"thrusting energy" .6
 	"thrusting heat" .9
 	"flare sprite" "effect/ion flare/tiny"
@@ -107,7 +107,7 @@ outfit "X2700 Ion Thruster"
 	"mass" 27
 	"outfit space" -27
 	"engine capacity" -27
-	"thrust" 11.5
+	"thrust" 13.8
 	"thrusting energy" 1.1
 	"thrusting heat" 1.7
 	"flare sprite" "effect/ion flare/small"
@@ -123,7 +123,7 @@ outfit "X3700 Ion Thruster"
 	"mass" 46
 	"outfit space" -46
 	"engine capacity" -46
-	"thrust" 22.1
+	"thrust" 26.5
 	"thrusting energy" 1.9
 	"thrusting heat" 3.2
 	"flare sprite" "effect/ion flare/medium"
@@ -139,7 +139,7 @@ outfit "X4700 Ion Thruster"
 	"mass" 79
 	"outfit space" -79
 	"engine capacity" -79
-	"thrust" 42.5
+	"thrust" 51
 	"thrusting energy" 3.5
 	"thrusting heat" 6.2
 	"flare sprite" "effect/ion flare/large"
@@ -155,7 +155,7 @@ outfit "X5700 Ion Thruster"
 	"mass" 134
 	"outfit space" -134
 	"engine capacity" -134
-	"thrust" 81.5
+	"thrust" 97.8
 	"thrusting energy" 6.3
 	"thrusting heat" 11.7
 	"flare sprite" "effect/ion flare/huge"
@@ -246,6 +246,23 @@ outfit "X5200 Ion Steering"
 	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
 
 
+outfit "X1100 Ion Reverse Thruster"
+	category "Engines"
+	"cost" 12000
+	thumbnail "outfit/reverse thruster ion"
+	"mass" 16
+	"outfit space" -16
+	"weapon capacity" -16
+	"reverse thrust" 7.2
+	"reverse thrusting energy" .6
+	"reverse thrusting heat" .9
+	"reverse flare sprite" "effect/ion flare/tiny"
+		"frame rate" 1.2
+	"reverse flare sound" "ion tiny"
+	description "Traditionally, ships turn around so that they can use their main thrusters for deceleration. Some ships, however, are too ungainly for such maneuvers to be convenient, or carry sensitive cargo that must not be being swung around quickly. For such ships, a reverse thruster allows them to apply thrust smoothly backwards."
+	description "	Because a reverse thruster must be facing forwards, it must be installed in the weapon section of your ship instead of the engine section."
+
+
 
 outfit "Chipmunk Plasma Thruster"
 	category "Engines"
@@ -254,7 +271,7 @@ outfit "Chipmunk Plasma Thruster"
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
-	"thrust" 9.6
+	"thrust" 11.5
 	"thrusting energy" 1.0
 	"thrusting heat" 1.8
 	"flare sprite" "effect/plasma flare/tiny"
@@ -270,7 +287,7 @@ outfit "Greyhound Plasma Thruster"
 	"mass" 34
 	"outfit space" -34
 	"engine capacity" -34
-	"thrust" 18.4
+	"thrust" 22.1
 	"thrusting energy" 1.8
 	"thrusting heat" 3.4
 	"flare sprite" "effect/plasma flare/small"
@@ -286,7 +303,7 @@ outfit "Impala Plasma Thruster"
 	"mass" 58
 	"outfit space" -58
 	"engine capacity" -58
-	"thrust" 35.4
+	"thrust" 42.5
 	"thrusting energy" 3.2
 	"thrusting heat" 6.5
 	"flare sprite" "effect/plasma flare/medium"
@@ -302,7 +319,7 @@ outfit "Orca Plasma Thruster"
 	"mass" 98
 	"outfit space" -98
 	"engine capacity" -98
-	"thrust" 67.9
+	"thrust" 81.5
 	"thrusting energy" 5.8
 	"thrusting heat" 12.3
 	"flare sprite" "effect/plasma flare/large"
@@ -318,7 +335,7 @@ outfit "Tyrant Plasma Thruster"
 	"mass" 136
 	"outfit space" -136
 	"engine capacity" -136
-	"thrust" 106.3
+	"thrust" 127.6
 	"thrusting energy" 8.6
 	"thrusting heat" 19.1
 	"flare sprite" "effect/plasma flare/huge"
@@ -407,6 +424,23 @@ outfit "Tyrant Plasma Steering"
 	"steering flare sound" "plasma huge"
 	description "As with the corresponding thruster, the Tyrant class steering system is so large and powerful that very few ships can make use of it."
 	description "	Plasma engines are a bit more powerful than ion engines of the same size, but they are less energy efficient and produce more heat."
+
+
+outfit "Capybara Reverse Thruster"
+	category "Engines"
+	"cost" 20000
+	thumbnail "outfit/reverse thruster plasma"
+	"mass" 20
+	"outfit space" -20
+	"weapon capacity" -20
+	"reverse thrust" 11.5
+	"reverse thrusting energy" 1.0
+	"reverse thrusting heat" 1.8
+	"reverse flare sprite" "effect/plasma flare/tiny"
+		"frame rate" 5
+	"reverse flare sound" "plasma tiny"
+	description "Large ships often lack the maneuverability to perform the 180 degree turns needed to come to a stop on short notice. For such massive vessels, a reverse thruster allows them to accelerate smoothly backwards, without needing to turn around."
+	description "	Because a reverse thruster must be facing forwards, it must be installed in the weapon section of your ship instead of the engine section."
 
 
 
@@ -562,9 +596,6 @@ outfit "A865 Atomic Steering"
 	description "Atomic engines are considered by many to be Deep Sky's crowning achievement. Although they are so expensive that relatively few of them are in use, there are few captains who do not dream of one day installing a set of them."
 
 
-
-# Reverse Thrusters
-
 outfit "AR120 Reverse Thruster"
 	category "Engines"
 	"cost" 140000
@@ -579,36 +610,4 @@ outfit "AR120 Reverse Thruster"
 		"frame rate" 14
 	"reverse flare sound" "atomic tiny"
 	description "For pilots who want to pull fancy tricks that most are not capable of duplicating, a reverse thruster allows a ship to accelerate backwards, without needing to turn around."
-	description "	Because a reverse thruster must be facing forwards, it must be installed in the weapon section of your ship instead of the engine section."
-
-outfit "Capybara Reverse Thruster"
-	category "Engines"
-	"cost" 20000
-	thumbnail "outfit/reverse thruster plasma"
-	"mass" 20
-	"outfit space" -20
-	"weapon capacity" -20
-	"reverse thrust" 9.6
-	"reverse thrusting energy" 1.0
-	"reverse thrusting heat" 1.8
-	"reverse flare sprite" "effect/plasma flare/tiny"
-		"frame rate" 5
-	"reverse flare sound" "plasma tiny"
-	description "Large ships often lack the maneuverability to perform the 180 degree turns needed to come to a stop on short notice. For such massive vessels, a reverse thruster allows them to accelerate smoothly backwards, without needing to turn around."
-	description "	Because a reverse thruster must be facing forwards, it must be installed in the weapon section of your ship instead of the engine section."
-
-outfit "X1100 Ion Reverse Thruster"
-	category "Engines"
-	"cost" 12000
-	thumbnail "outfit/reverse thruster ion"
-	"mass" 16
-	"outfit space" -16
-	"weapon capacity" -16
-	"reverse thrust" 6.0
-	"reverse thrusting energy" .6
-	"reverse thrusting heat" .9
-	"reverse flare sprite" "effect/ion flare/tiny"
-		"frame rate" 1.2
-	"reverse flare sound" "ion tiny"
-	description "Traditionally, ships turn around so that they can use their main thrusters for deceleration. Some ships, however, are too ungainly for such maneuvers to be convenient, or carry sensitive cargo that must not be being swung around quickly. For such ships, a reverse thruster allows them to apply thrust smoothly backwards."
 	description "	Because a reverse thruster must be facing forwards, it must be installed in the weapon section of your ship instead of the engine section."

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -12,9 +12,9 @@ outfit "Afterburner"
 	category "Engines"
 	"cost" 70000
 	thumbnail "outfit/afterburner"
-	"mass" 15
-	"outfit space" -15
-	"engine capacity" -15
+	"mass" 10
+	"outfit space" -10
+	"engine capacity" -10
 	"afterburner thrust" 37.5
 	"afterburner fuel" .5
 	"afterburner heat" 10.0
@@ -37,9 +37,9 @@ outfit "Ionic Afterburner"
 	category "Engines"
 	"cost" 340000
 	thumbnail "outfit/ionic afterburner"
-	"mass" 24
-	"outfit space" -24
-	"engine capacity" -24
+	"mass" 16
+	"outfit space" -16
+	"engine capacity" -16
 	"afterburner thrust" 43.5
 	"afterburner fuel" .1
 	"afterburner energy" 5.1

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -43,7 +43,7 @@ outfit "Ionic Afterburner"
 	"afterburner thrust" 29.0
 	"afterburner fuel" .1
 	"afterburner energy" 5.1
-	"afterburner heat" 12.0
+	"afterburner heat" 4.0
 	"afterburner effect" "ionic afterburner"
 	description "The ionic afterburner was designed by the Syndicate to compensate for the primary weakness of an ordinary afterburner: namely, that it consumes hyperspace fuel at a prodigious rate. Ionic afterburners instead use a small amount of fuel combined with a large burst of energy from your ship's batteries to achieve the same effect."
 

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -152,9 +152,9 @@ outfit "X5700 Ion Thruster"
 	category "Engines"
 	"cost" 281000
 	thumbnail "outfit/huge ion thruster"
-	"mass" 134
-	"outfit space" -134
-	"engine capacity" -134
+	"mass" 121
+	"outfit space" -121
+	"engine capacity" -121
 	"thrust" 97.8
 	"thrusting energy" 6.3
 	"thrusting heat" 11.7
@@ -233,9 +233,9 @@ outfit "X5200 Ion Steering"
 	category "Engines"
 	"cost" 225000
 	thumbnail "outfit/huge ion steering"
-	"mass" 100
-	"outfit space" -100
-	"engine capacity" -100
+	"mass" 89
+	"outfit space" -89
+	"engine capacity" -89
 	"turn" 2609
 	"turning energy" 3.5
 	"turning heat" 7.3
@@ -332,9 +332,9 @@ outfit "Tyrant Plasma Thruster"
 	category "Engines"
 	"cost" 389000
 	thumbnail "outfit/huge plasma thruster"
-	"mass" 136
-	"outfit space" -136
-	"engine capacity" -136
+	"mass" 129
+	"outfit space" -129
+	"engine capacity" -129
 	"thrust" 127.6
 	"thrusting energy" 8.6
 	"thrusting heat" 19.1
@@ -413,9 +413,9 @@ outfit "Tyrant Plasma Steering"
 	category "Engines"
 	"cost" 324700
 	thumbnail "outfit/huge plasma steering"
-	"mass" 106
-	"outfit space" -106
-	"engine capacity" -106
+	"mass" 101
+	"outfit space" -101
+	"engine capacity" -101
 	"turn" 3549
 	"turning energy" 4.4
 	"turning heat" 12.5

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -527,7 +527,7 @@ outfit "A125 Atomic Steering"
 	"mass" 16
 	"outfit space" -16
 	"engine capacity" -16
-	"turn" 392
+	"turn" 402
 	"turning energy" 0.9
 	"turning heat" 2.2
 	"steering flare sprite" "effect/atomic flare/tiny"
@@ -542,7 +542,7 @@ outfit "A255 Atomic Steering"
 	"mass" 25
 	"outfit space" -25
 	"engine capacity" -25
-	"turn" 687
+	"turn" 704
 	"turning energy" 1.5
 	"turning heat" 3.7
 	"steering flare sprite" "effect/atomic flare/small"
@@ -557,7 +557,7 @@ outfit "A375 Atomic Steering"
 	"mass" 38
 	"outfit space" -38
 	"engine capacity" -38
-	"turn" 1192
+	"turn" 1222
 	"turning energy" 2.5
 	"turning heat" 6.3
 	"steering flare sprite" "effect/atomic flare/medium"
@@ -572,7 +572,7 @@ outfit "A525 Atomic Steering"
 	"mass" 60
 	"outfit space" -60
 	"engine capacity" -60
-	"turn" 2050
+	"turn" 2101
 	"turning energy" 4.1
 	"turning heat" 10.5
 	"steering flare sprite" "effect/atomic flare/large"
@@ -587,7 +587,7 @@ outfit "A865 Atomic Steering"
 	"mass" 92
 	"outfit space" -92
 	"engine capacity" -92
-	"turn" 3509
+	"turn" 3597
 	"turning energy" 6.6
 	"turning heat" 17.5
 	"steering flare sprite" "effect/atomic flare/huge"

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -15,7 +15,7 @@ outfit "Afterburner"
 	"mass" 15
 	"outfit space" -15
 	"engine capacity" -15
-	"afterburner thrust" 25.0
+	"afterburner thrust" 37.5
 	"afterburner fuel" .5
 	"afterburner heat" 10.0
 	"afterburner effect" "afterburner"
@@ -40,7 +40,7 @@ outfit "Ionic Afterburner"
 	"mass" 24
 	"outfit space" -24
 	"engine capacity" -24
-	"afterburner thrust" 29.0
+	"afterburner thrust" 43.5
 	"afterburner fuel" .1
 	"afterburner energy" 5.1
 	"afterburner heat" 4.0

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -16,7 +16,7 @@ outfit "Afterburner"
 	"outfit space" -10
 	"engine capacity" -10
 	"afterburner thrust" 37.5
-	"afterburner fuel" .5
+	"afterburner fuel" .1
 	"afterburner heat" 10.0
 	"afterburner effect" "afterburner"
 	description "An afterburner works by dumping hyperspace fuel into your engines and igniting it, producing a large amount of thrust. This can be very useful for dodging missiles or briefly escaping from faster opponents, but you must be careful to avoid using up so much fuel that you do not have enough left for hyperspace travel."
@@ -41,7 +41,7 @@ outfit "Ionic Afterburner"
 	"outfit space" -16
 	"engine capacity" -16
 	"afterburner thrust" 43.5
-	"afterburner fuel" .1
+	"afterburner fuel" .025
 	"afterburner energy" 5.1
 	"afterburner heat" 4.0
 	"afterburner effect" "ionic afterburner"

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -71,7 +71,7 @@ outfit "X1050 Ion Engines"
 	"thrust" 4.8
 	"thrusting energy" .4
 	"thrusting heat" .6
-	"turn" 110
+	"turn" 132
 	"turning energy" .25
 	"turning heat" .5
 	"flare sprite" "effect/ion flare/tiny"
@@ -172,7 +172,7 @@ outfit "X1200 Ion Steering"
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
-	"turn" 160
+	"turn" 192
 	"turning energy" .3
 	"turning heat" .6
 	"steering flare sprite" "effect/ion flare/tiny"
@@ -188,7 +188,7 @@ outfit "X2200 Ion Steering"
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
-	"turn" 307
+	"turn" 368
 	"turning energy" .6
 	"turning heat" 1.1
 	"steering flare sprite" "effect/ion flare/small"
@@ -204,7 +204,7 @@ outfit "X3200 Ion Steering"
 	"mass" 35
 	"outfit space" -35
 	"engine capacity" -35
-	"turn" 590
+	"turn" 708
 	"turning energy" 1.1
 	"turning heat" 2.0
 	"steering flare sprite" "effect/ion flare/medium"
@@ -220,7 +220,7 @@ outfit "X4200 Ion Steering"
 	"mass" 59
 	"outfit space" -59
 	"engine capacity" -59
-	"turn" 1132
+	"turn" 1358
 	"turning energy" 1.9
 	"turning heat" 3.9
 	"steering flare sprite" "effect/ion flare/large"
@@ -236,7 +236,7 @@ outfit "X5200 Ion Steering"
 	"mass" 100
 	"outfit space" -100
 	"engine capacity" -100
-	"turn" 2174
+	"turn" 2609
 	"turning energy" 3.5
 	"turning heat" 7.3
 	"steering flare sprite" "effect/ion flare/huge"
@@ -352,7 +352,7 @@ outfit "Chipmunk Plasma Steering"
 	"mass" 15
 	"outfit space" -15
 	"engine capacity" -15
-	"turn" 256
+	"turn" 307
 	"turning energy" .5
 	"turning heat" 1.1
 	"steering flare sprite" "effect/plasma flare/tiny"
@@ -368,7 +368,7 @@ outfit "Greyhound Plasma Steering"
 	"mass" 26
 	"outfit space" -26
 	"engine capacity" -26
-	"turn" 492
+	"turn" 590
 	"turning energy" 0.9
 	"turning heat" 2.1
 	"steering flare sprite" "effect/plasma flare/small"
@@ -384,7 +384,7 @@ outfit "Impala Plasma Steering"
 	"mass" 43
 	"outfit space" -43
 	"engine capacity" -43
-	"turn" 944
+	"turn" 1133
 	"turning energy" 1.6
 	"turning heat" 4.1
 	"steering flare sprite" "effect/plasma flare/medium"
@@ -400,7 +400,7 @@ outfit "Orca Plasma Steering"
 	"mass" 74
 	"outfit space" -74
 	"engine capacity" -74
-	"turn" 1812
+	"turn" 2174
 	"turning energy" 2.9
 	"turning heat" 7.7
 	"steering flare sprite" "effect/plasma flare/large"
@@ -411,14 +411,14 @@ outfit "Orca Plasma Steering"
 
 outfit "Tyrant Plasma Steering"
 	category "Engines"
-	"cost" 382000
+	"cost" 324700
 	thumbnail "outfit/huge plasma steering"
-	"mass" 125
-	"outfit space" -125
-	"engine capacity" -125
-	"turn" 3479
-	"turning energy" 5.2
-	"turning heat" 14.7
+	"mass" 106
+	"outfit space" -106
+	"engine capacity" -106
+	"turn" 3549
+	"turning energy" 4.4
+	"turning heat" 12.5
 	"steering flare sprite" "effect/plasma flare/huge"
 		"frame rate" 9
 	"steering flare sound" "plasma huge"

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -98,7 +98,7 @@ outfit "X1700 Ion Thruster"
 		"frame rate" 1.2
 	"flare sound" "ion tiny"
 	description "This is the smallest thruster that you can buy, so weak that anything larger than a drone will accelerate quite slowly when using this engine. On the other hand, it is also very energy-efficient."
-	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
+	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
 outfit "X2700 Ion Thruster"
 	category "Engines"
@@ -114,7 +114,7 @@ outfit "X2700 Ion Thruster"
 		"frame rate" 1.1
 	"flare sound" "ion small"
 	description "The X2700 ion thruster is intended mostly for use in small, single-person or two-person ships, as well as in fighters. It is also used in larger ships, such as freighters, that have very little space for propulsion systems or energy to drive them. But these larger ships move unbearably slowly as a result."
-	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
+	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
 outfit "X3700 Ion Thruster"
 	category "Engines"
@@ -130,7 +130,7 @@ outfit "X3700 Ion Thruster"
 		"frame rate" 1.0
 	"flare sound" "ion medium"
 	description "The X3700 ion thruster is designed for heavy freighters and small capital ships. In theory, it could be installed in smaller ships too, if they have enough engine space, to attain almost ridiculous speeds."
-	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
+	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
 outfit "X4700 Ion Thruster"
 	category "Engines"
@@ -146,7 +146,7 @@ outfit "X4700 Ion Thruster"
 		"frame rate" 0.9
 	"flare sound" "ion large"
 	description "The X4700 ion thruster was developed when the Republic Navy began building warships so large that the X3700 was not sufficient for them. It allows even a capital ship to move at a respectable speed."
-	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
+	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
 outfit "X5700 Ion Thruster"
 	category "Engines"
@@ -162,7 +162,7 @@ outfit "X5700 Ion Thruster"
 		"frame rate" 0.8
 	"flare sound" "ion huge"
 	description "The X5700 thruster is intended for only the largest of capital ships. When the Syndicate first began producing them, these engines were considered little more than a publicity stunt, because no ship at the time was large enough to hold one."
-	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
+	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
 
 outfit "X1200 Ion Steering"
@@ -179,7 +179,7 @@ outfit "X1200 Ion Steering"
 		"frame rate" 1.2
 	"steering flare sound" "ion tiny"
 	description "This is the smallest set of steering thrusters that you can buy, generally considered suitable only for tiny, pilotless drones. Occasionally pilots looking for some extra outfit space will try swapping out their larger steering systems for one of these, but the results are invariably disappointing."
-	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
+	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
 outfit "X2200 Ion Steering"
 	category "Engines"
@@ -195,7 +195,7 @@ outfit "X2200 Ion Steering"
 		"frame rate" 1.1
 	"steering flare sound" "ion small"
 	description "The X2200 steering system is designed for fighters and other small spacecraft, as well as for use in larger ships when maneuverability is not needed."
-	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
+	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
 outfit "X3200 Ion Steering"
 	category "Engines"
@@ -211,7 +211,7 @@ outfit "X3200 Ion Steering"
 		"frame rate" 1.0
 	"steering flare sound" "ion medium"
 	description "The X3200 steering system is intended for small warships and freighters. It produces enough turning force to lend agility to all but the largest of human ships, and it is considerably more energy-efficient than the plasma-drive alternatives."
-	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
+	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
 outfit "X4200 Ion Steering"
 	category "Engines"
@@ -227,7 +227,7 @@ outfit "X4200 Ion Steering"
 		"frame rate" 0.9
 	"steering flare sound" "ion large"
 	description "The X4200 is a powerful steering system, designed mostly for warships because quick steering is seldom a requirement in freighter design."
-	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
+	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
 outfit "X5200 Ion Steering"
 	category "Engines"
@@ -243,7 +243,7 @@ outfit "X5200 Ion Steering"
 		"frame rate" 0.8
 	"steering flare sound" "ion huge"
 	description "The X5200 is a steering system so large and powerful that only a handful of ships can install it. Due to its limited market, it is produced in small numbers."
-	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space."
+	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
 
 outfit "X1100 Ion Reverse Thruster"

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -313,14 +313,14 @@ outfit "Orca Plasma Thruster"
 
 outfit "Tyrant Plasma Thruster"
 	category "Engines"
-	"cost" 478000
+	"cost" 389000
 	thumbnail "outfit/huge plasma thruster"
-	"mass" 167
-	"outfit space" -167
-	"engine capacity" -167
-	"thrust" 130.5
-	"thrusting energy" 10.5
-	"thrusting heat" 23.5
+	"mass" 136
+	"outfit space" -136
+	"engine capacity" -136
+	"thrust" 106.3
+	"thrusting energy" 8.6
+	"thrusting heat" 19.1
 	"flare sprite" "effect/plasma flare/huge"
 		"frame rate" 9
 	"flare sound" "plasma huge"

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -139,7 +139,7 @@ outfit "X4700 Ion Thruster"
 	"mass" 79
 	"outfit space" -79
 	"engine capacity" -79
-	"thrust" 51
+	"thrust" 53.6
 	"thrusting energy" 3.5
 	"thrusting heat" 6.2
 	"flare sprite" "effect/ion flare/large"
@@ -220,7 +220,7 @@ outfit "X4200 Ion Steering"
 	"mass" 59
 	"outfit space" -59
 	"engine capacity" -59
-	"turn" 1358
+	"turn" 1426
 	"turning energy" 1.9
 	"turning heat" 3.9
 	"steering flare sprite" "effect/ion flare/large"
@@ -319,7 +319,7 @@ outfit "Orca Plasma Thruster"
 	"mass" 98
 	"outfit space" -98
 	"engine capacity" -98
-	"thrust" 81.5
+	"thrust" 85.6
 	"thrusting energy" 5.8
 	"thrusting heat" 12.3
 	"flare sprite" "effect/plasma flare/large"
@@ -400,7 +400,7 @@ outfit "Orca Plasma Steering"
 	"mass" 74
 	"outfit space" -74
 	"engine capacity" -74
-	"turn" 2174
+	"turn" 2283
 	"turning energy" 2.9
 	"turning heat" 7.7
 	"steering flare sprite" "effect/plasma flare/large"

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2128,7 +2128,7 @@ ship "Heavy Shuttle"
 		"fuel capacity" 500
 		"cargo space" 40
 		"outfit space" 130
-		"weapon capacity" 15
+		"weapon capacity" 16
 		"engine capacity" 65
 		weapon
 			"blast radius" 12

--- a/data/pug/pug.txt
+++ b/data/pug/pug.txt
@@ -390,7 +390,7 @@ outfit "Pug Akfar Thruster"
 	"mass" 43
 	"outfit space" -43
 	"engine capacity" -43
-	"thrust" 28.0
+	"thrust" 29.4
 	"thrusting energy" 2.2
 	"thrusting heat" 3.1
 	"flare sprite" "effect/ion flare/medium"
@@ -420,7 +420,7 @@ outfit "Pug Cormet Thruster"
 	"mass" 60
 	"outfit space" -60
 	"engine capacity" -60
-	"thrust" 44.0
+	"thrust" 46.2
 	"thrusting energy" 3.3
 	"thrusting heat" 4.6
 	"flare sprite" "effect/ion flare/large"
@@ -450,7 +450,7 @@ outfit "Pug Lohmar Thruster"
 	"mass" 84
 	"outfit space" -84
 	"engine capacity" -84
-	"thrust" 66.0
+	"thrust" 69.3
 	"thrusting energy" 4.9
 	"thrusting heat" 6.9
 	"flare sprite" "effect/ion flare/huge"

--- a/data/pug/pug.txt
+++ b/data/pug/pug.txt
@@ -405,7 +405,7 @@ outfit "Pug Akfar Steering"
 	"mass" 33
 	"outfit space" -33
 	"engine capacity" -33
-	"turn" 750
+	"turn" 863
 	"turning energy" 1.3
 	"turning heat" 2.1
 	"steering flare sprite" "effect/ion flare/medium"
@@ -435,7 +435,7 @@ outfit "Pug Cormet Steering"
 	"mass" 46
 	"outfit space" -46
 	"engine capacity" -46
-	"turn" 1130
+	"turn" 1300
 	"turning energy" 1.9
 	"turning heat" 3.1
 	"steering flare sprite" "effect/ion flare/large"
@@ -465,7 +465,7 @@ outfit "Pug Lohmar Steering"
 	"mass" 64
 	"outfit space" -64
 	"engine capacity" -64
-	"turn" 1700
+	"turn" 1955
 	"turning energy" 2.8
 	"turning heat" 4.7
 	"steering flare sprite" "effect/ion flare/huge"

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -588,11 +588,11 @@ outfit "Crucible-Class Thruster"
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
-	"thrust" 17.1
-	"thrusting energy" 2.65
-	"thrusting heat" 2.5
 	"reverse thrust" 10.3
 	"reverse thrusting energy" 1.59
+	"thrust" 14.4
+	"thrusting energy" 2.1
+	"thrusting heat" 2.0
 	"reverse thrusting heat" 1.5
 	"slowing resistance" 0.012
 	"flare sprite" "effect/remnant flare/small"
@@ -612,12 +612,12 @@ outfit "Forge-Class Thruster"
 	"mass" 39
 	"outfit space" -39
 	"engine capacity" -39
-	"thrust" 37.0
-	"thrusting energy" 5.15
-	"thrusting heat" 5.0
 	"reverse thrust" 27.62
 	"reverse thrusting energy" 3.09
 	"reverse thrusting heat" 3.0
+	"thrust" 31.5
+	"thrusting energy" 4.4
+	"thrusting heat" 4.25
 	"slowing resistance" 0.024
 	"flare sprite" "effect/remnant flare/medium"
 		"frame rate" 4
@@ -636,12 +636,12 @@ outfit "Smelter-Class Thruster"
 	"mass" 76
 	"outfit space" -76
 	"engine capacity" -76
-	"thrust" 80.6
-	"thrusting energy" 10.1
-	"thrusting heat" 10.2
 	"reverse thrust" 48.4
 	"reverse thrusting energy" 6.06
 	"reverse thrusting heat" 6.12
+	"thrust" 71.1
+	"thrusting energy" 9.5
+	"thrusting heat" 9.6
 	"slowing resistance" 0.048
 	"flare sprite" "effect/remnant flare/large"
 		"frame rate" 3

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -660,7 +660,7 @@ outfit "Crucible-Class Steering"
 	"mass" 14
 	"outfit space" -14
 	"engine capacity" -14
-	"turn" 492.8
+	"turn" 456
 	"turning energy" 1.32
 	"turning heat" 1.4
 	"slowing resistance" 0.008
@@ -678,7 +678,7 @@ outfit "Forge-Class Steering"
 	"mass" 28
 	"outfit space" -28
 	"engine capacity" -28
-	"turn" 1047.2
+	"turn" 995
 	"turning energy" 2.64
 	"turning heat" 3.0
 	"slowing resistance" 0.016
@@ -696,7 +696,7 @@ outfit "Smelter-Class Steering"
 	"mass" 55
 	"outfit space" -55
 	"engine capacity" -55
-	"turn" 2178
+	"turn" 2123
 	"turning energy" 5.21
 	"turning heat" 6.2
 	"slowing resistance" 0.032

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -588,10 +588,10 @@ outfit "Crucible-Class Thruster"
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
-	"thrust" 18.0
+	"thrust" 17.1
 	"thrusting energy" 2.65
 	"thrusting heat" 2.5
-	"reverse thrust" 10.8
+	"reverse thrust" 10.3
 	"reverse thrusting energy" 1.59
 	"reverse thrusting heat" 1.5
 	"slowing resistance" 0.012
@@ -636,10 +636,10 @@ outfit "Smelter-Class Thruster"
 	"mass" 76
 	"outfit space" -76
 	"engine capacity" -76
-	"thrust" 76.8
-	"thrusting energy" 10.10
+	"thrust" 80.6
+	"thrusting energy" 10.1
 	"thrusting heat" 10.2
-	"reverse thrust" 46.08
+	"reverse thrust" 48.4
 	"reverse thrusting energy" 6.06
 	"reverse thrusting heat" 6.12
 	"slowing resistance" 0.048

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -564,9 +564,9 @@ outfit "Anvil-Class Engine"
 	"turn" 369.6
 	"turning energy" 1.05
 	"turning heat" 1.1
-	"reverse thrust" 8.1
-	"reverse thrusting energy" 1.23
-	"reverse thrusting heat" 1.17
+	"reverse thrust" 10.1
+	"reverse thrusting energy" 1.5
+	"reverse thrusting heat" 1.45
 	"slowing resistance" 0.02
 	"flare sprite" "effect/remnant flare/small"
 		"frame rate" 5
@@ -588,11 +588,11 @@ outfit "Crucible-Class Thruster"
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
-	"reverse thrust" 10.3
-	"reverse thrusting energy" 1.59
 	"thrust" 14.4
 	"thrusting energy" 2.1
 	"thrusting heat" 2.0
+	"reverse thrust" 10.8
+	"reverse thrusting energy" 1.6
 	"reverse thrusting heat" 1.5
 	"slowing resistance" 0.012
 	"flare sprite" "effect/remnant flare/small"
@@ -612,12 +612,12 @@ outfit "Forge-Class Thruster"
 	"mass" 39
 	"outfit space" -39
 	"engine capacity" -39
-	"reverse thrust" 27.62
-	"reverse thrusting energy" 3.09
-	"reverse thrusting heat" 3.0
 	"thrust" 31.5
 	"thrusting energy" 4.4
 	"thrusting heat" 4.25
+	"reverse thrust" 23.6
+	"reverse thrusting energy" 3.3
+	"reverse thrusting heat" 3.2
 	"slowing resistance" 0.024
 	"flare sprite" "effect/remnant flare/medium"
 		"frame rate" 4
@@ -636,12 +636,12 @@ outfit "Smelter-Class Thruster"
 	"mass" 76
 	"outfit space" -76
 	"engine capacity" -76
-	"reverse thrust" 48.4
-	"reverse thrusting energy" 6.06
-	"reverse thrusting heat" 6.12
 	"thrust" 71.1
 	"thrusting energy" 9.5
 	"thrusting heat" 9.6
+	"reverse thrust" 53.3
+	"reverse thrusting energy" 7.1
+	"reverse thrusting heat" 7.2
 	"slowing resistance" 0.048
 	"flare sprite" "effect/remnant flare/large"
 		"frame rate" 3

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -529,7 +529,7 @@ outfit "Bellows-Class Afterburner"
 	"engine capacity" -7
 	"slowing resistance" 0.01
 	"afterburner thrust" 153.0
-	"afterburner fuel" 2.0
+	"afterburner fuel" 0.5
 	"afterburner energy" 6.0
 	"afterburner heat" 8.0
 	"afterburner effect" "remnant afterburner"

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -524,9 +524,9 @@ outfit "Bellows-Class Afterburner"
 	category "Engines"
 	"cost" 640000
 	thumbnail "outfit/remnant afterburner"
-	"mass" 13
-	"outfit space" -11
-	"engine capacity" -11
+	"mass" 8
+	"outfit space" -7
+	"engine capacity" -7
 	"slowing resistance" 0.01
 	"afterburner thrust" 153.0
 	"afterburner fuel" 2.0

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -501,7 +501,7 @@ outfit "Type 1 Radiant Steering"
 	"mass" 9
 	"outfit space" -9
 	"engine capacity" -9
-	"turn" 172.8
+	"turn" 181
 	"turning energy" .3
 	"turning heat" 0.6
 	"cooling" 1.0
@@ -519,7 +519,7 @@ outfit "Type 2 Radiant Steering"
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
-	"turn" 454.0
+	"turn" 476
 	"turning energy" .7
 	"turning heat" 1.5
 	"cooling" 2.1
@@ -537,7 +537,7 @@ outfit "Type 3 Radiant Steering"
 	"mass" 30
 	"outfit space" -30
 	"engine capacity" -30
-	"turn" 786.0
+	"turn" 825
 	"turning energy" 1.2
 	"turning heat" 2.6
 	"cooling" 3.9
@@ -555,7 +555,7 @@ outfit "Type 4 Radiant Steering"
 	"mass" 47
 	"outfit space" -47
 	"engine capacity" -47
-	"turn" 1395.9
+	"turn" 1466
 	"turning energy" 2.0
 	"turning heat" 4.5
 	"cooling" 6.7

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -430,8 +430,8 @@ outfit "Type 1 Radiant Thruster"
 	"outfit space" -12
 	"engine capacity" -12
 	"thrust" 6.9
-	"thrusting energy" 0.5
-	"thrusting heat" 0.9
+	"thrusting energy" 0.55
+	"thrusting heat" 0.85
 	"cooling" 1.5
 	"flare sprite" "effect/plasma flare/tiny"
 		"frame rate" 12
@@ -448,8 +448,8 @@ outfit "Type 2 Radiant Thruster"
 	"outfit space" -27
 	"engine capacity" -27
 	"thrust" 18.5
-	"thrusting energy" 1.4
-	"thrusting heat" 2.5
+	"thrusting energy" 1.3
+	"thrusting heat" 2.4
 	"cooling" 3.6
 	"flare sprite" "effect/plasma flare/small"
 		"frame rate" 14
@@ -466,8 +466,8 @@ outfit "Type 3 Radiant Thruster"
 	"outfit space" -42
 	"engine capacity" -42
 	"thrust" 33.1
-	"thrusting energy" 2.3
-	"thrusting heat" 4.4
+	"thrusting energy" 2.2
+	"thrusting heat" 4.3
 	"cooling" 6.5
 	"flare sprite" "effect/plasma flare/medium"
 		"frame rate" 16

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -429,7 +429,7 @@ outfit "Type 1 Radiant Thruster"
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
-	"thrust" 6.6
+	"thrust" 6.9
 	"thrusting energy" 0.5
 	"thrusting heat" 0.9
 	"cooling" 1.5
@@ -447,7 +447,7 @@ outfit "Type 2 Radiant Thruster"
 	"mass" 27
 	"outfit space" -27
 	"engine capacity" -27
-	"thrust" 17.6
+	"thrust" 18.5
 	"thrusting energy" 1.4
 	"thrusting heat" 2.5
 	"cooling" 3.6
@@ -465,7 +465,7 @@ outfit "Type 3 Radiant Thruster"
 	"mass" 42
 	"outfit space" -42
 	"engine capacity" -42
-	"thrust" 31.5
+	"thrust" 33.1
 	"thrusting energy" 2.3
 	"thrusting heat" 4.4
 	"cooling" 6.5
@@ -483,7 +483,7 @@ outfit "Type 4 Radiant Thruster"
 	"mass" 65
 	"outfit space" -65
 	"engine capacity" -65
-	"thrust" 55.2
+	"thrust" 58
 	"thrusting energy" 3.7
 	"thrusting heat" 7.6
 	"cooling" 11.7


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This PR is meant as a stepping stone toward resolving #5271 and is a polished piece of #5779. It also resolves #6624.

The general gist of this PR is to shorten the range of speeds that ships are capable of while also increasing speeds at the low end of the spectrum. Shortening the range of possible speeds means that we won't as often have ships which, when using a reasonable engine loadout, go from normal to way too fast just be changing up the engines. This is mainly done by raising the speed floor rather than lowering the ceiling, which will most benefit default fittings and smaller ships.

The changes:
* **-66% Ionic Afterburner heat**: The Ionic Afterburner is a weaker afterburner that uses less fuel at the cost of having firing energy, which the normal afterburner does not. Given that, it didn't make much sense to me for the Ionic Afterburner to have more heat than the normal afterburner, so I've significantly reduced the Ionic Afterburner's heat.
* **+50% Afterburner and Ionic Afterburner thrust**: These afterburners are generally underutilized, so a 50% thrust buff should hopefully make them more appealing.
* **-33% all afterburner size**: One of the main complaints about afterburners is that people don't want to have to use weaker primary engines in order to fit them. By shrinking afterburner sizes, they become easier to fit, either needing to shrink your main engines by less or potentially by not needing to change your main engines at all.
* **-75% to -80% all afterburner fuel usage**: The other major complaint against afterburners is their fuel consumption, or at least the degree to which they consume fuel. The Afterburner for example chews through 100 fuel in only 3.3 seconds. The amount of fuel drained by using an afterburner simply doesn't match the utility it provides, particularly when you need at least some fuel remaining in order to jump out of the system. As such, I've drastically reduced the amount of fuel that afterburners consume. The Bellows now consumes as much fuel as the old Afterburner, the Afterburner now consumes as much fuel as the old Ionic Afterburner, and the Ionic Afterburner consumes 75% less fuel compared to now.
* **Shrunk the Tyrant thrusters and steering**: This engine pair was the most absurd thing in the game, clocking in at much larger than any other set of engines in the game, so much so that not a single ship in the game could equip both at once. I've shrunk the sizes of these engines from 167/125 to 129/101 and reduced other stats accordingly. I imagine you'll still be hard pressed to equip both at once, but each individually are now much more viable options than they were before.
* **Shrunk X5k Ion thrusters and steering**: This pair wasn't as egregious as the Tyrant pair in terms of unusability, but by shrinking the Tyrant pair it became too close to the X5k Ion pair. Dropped X5k ion sizes from 134/100 to 121/89.
* **+20% Ion and Plasma thrust and turn**: Human Ion and Plasma engines have been the worst engines in the game to have and are often replaced with something better almost immediately. This wasn't helped by the fact that the gap between these two engines and the next best thing was so large. This change, while keeping Ion and Plasma engines on the bottom, greatly reduces the gap between them and the next best engines, dragging the speed floor up with them. The large Ion and Plasma set has received a +26% buff to thrust instead of +20%, as the shrinking of the huge sets made the gap in thrust/ton a little too wide. The shrinking of the hugest set plus the extra bump to the large set makes Ion and Plasma engines more competitive at the high end.
* **+5% Radiant thrust and turn**: Wanderer Radiant engines became fairly similar to human Plasma engines after the above change, so I've buffed Radiant engines slightly to compensate.
* **+2.5% Atomic turn, -5% Hai Atomic thrust, -2.5% Hai Atomic turn, and -5% Hai Atomic thrust energy and heat**: Currently, Hai Atomics are essentially a direct upgrade to human atomics, being smaller while also providing more thrust/ton and at a better energy and heat efficiency. These changes make it so that Hai Atomics are now more of a sidegrade to human Atomics instead of a direct upgrade, giving Hai Atomics comparable thrust/ton to human Atomics but at a slightly better energy and heat efficiency while keeping the smaller sizes.
* **-20%/-15%/-7.5% Remnant thrust, thrust energy, and thrust heat**: Remnant thrusters are currently in the top two or three engines in terms of thrust/ton when compared to other thrusters in the same weight range. This made more sense before #5580 when Remnant thrusters were given in-built reverse thrust, but because they now have that extra bonus I find it appropriate to bring the forward thrust on Remnant engines down a peg. The differential reduction in thrust is also to make the progression curve of Remnant thrusters less flat. The Anvil-Class Engine has been untouched in its forward thrust.
* **Remnant reverse thrust is now 75% the forward thrust**: This is a buff to reverse thrust on Remnant engines, which previous had their reverse thrust at 60% their forward thrust (except for the Forge-Class, which was 75% and probably an error from the PR that added reverse thrust). Combined with the above change to forward thrust, the Anvil-Class gets a +25% reverse thrust buff, the Crucible-Class receives no change, the Forge-Class receives a -15% nerf (because of how it was already at 75% reverse thrust), and the Smelter-Class receives a 16% buff.
* **-7.5%/-5%/-2.5% Remnant turn**: As with Remnant thrusters, Remnant steering had a flat progression curve. This reduces the buff that was given to the steering by #5580, but does not fully revert it. 
* **+5% Pug thrust and +15% Pug turn**: Similarly to the buff to Radiant engines, the buff to Ion and Plasma engines started to encroach on Pug engines, so I've buffed them to compensate.
* **+5% Large Steering Module turn**: This change is as a result of the fact that the LSM shares a size with the A255 Atomic Steering. In buffing the A255, it only made sense to me to buff the LSM as well as to not have them be too close to one another in terms of turn/ton.
* **+1 Heavy Shuttle weapon space**: This resolves #6624, and takes the +1 weapon space suggestion from that issue instead of the -1 outfit space from #6625, as +1 weapon space is the minimum necessary change to resolve that issue.
* **Removed the Graviton engines from Archons**: This is just a visual thing to remove the engine flares to give Archons more of an ethereal feel as opposed to just looking like organic ships with flares coming out their rears. Archons will still move at the same speed as before.

Instead of me posting a bunch of screenshots, here's the links to the Desmos graphs I used to eyeball these. Dots are original values, Xs are changed values. I have an extension that increases the number of colors you can use in Desmos so I have no idea how these will display if you don't have them. Note that I didn't look at Ka'het engines because they're too weird, and I didn't look at Quarg engines because they're placeholders and will be looked at anyway whenever the Quarg get redone.
* Thrusters: https://www.desmos.com/calculator/enpgigpjzb
* Steering: https://www.desmos.com/calculator/urx5jlpknf

## Save File
N/A

## Artwork Checklist
N/A