### PR TITLE
Remove unnecessary condition check from "Ringworld Debris: Quarg"

### DIFF
--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -243,7 +243,6 @@ mission "Ringworld Debris: Quarg"
 		attributes "quarg"
 	to offer
 		has "ringworld debris"
-		has "Graveyard Label: offered"
 		has "First Contact: Quarg: offered"
 	on offer
 		conversation


### PR DESCRIPTION
Previously, the mission could only offer after landing in the Graveyard, a requirement that doesn't match up with the other ringworld debris missions.