### PR TITLE
Switch File I/O to SDL_RWops

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -78,8 +78,10 @@ if 'steamrt_scout' in chroot_name:
 # Required system libraries, such as UUID generator runtimes.
 sys_libs = [
 	"rpcrt4",
+	"sdl2.dll"
 ] if is_windows_host else [
-	"uuid"
+	"uuid",
+	"SDL2"
 ]
 env.Append(LIBS = sys_libs)
 

--- a/SConstruct
+++ b/SConstruct
@@ -77,11 +77,9 @@ if 'steamrt_scout' in chroot_name:
 
 # Required system libraries, such as UUID generator runtimes.
 sys_libs = [
-	"rpcrt4",
-	"sdl2.dll"
+	"rpcrt4"
 ] if is_windows_host else [
-	"uuid",
-	"SDL2"
+	"uuid"
 ]
 env.Append(LIBS = sys_libs)
 

--- a/source/File.cpp
+++ b/source/File.cpp
@@ -14,6 +14,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Files.h"
 
+#include <SDL2/SDL_rwops.h>
+
 using namespace std;
 
 
@@ -35,7 +37,7 @@ File::File(File &&other) noexcept
 File::~File() noexcept
 {
 	if(file)
-		fclose(file);
+		SDL_RWclose(file);
 }
 
 
@@ -56,7 +58,7 @@ File::operator bool() const
 
 
 
-File::operator FILE*() const
+File::operator struct SDL_RWops*() const
 {
 	return file;
 }

--- a/source/File.cpp
+++ b/source/File.cpp
@@ -14,7 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Files.h"
 
-#include <SDL2/SDL_rwops.h>
+
 
 using namespace std;
 
@@ -37,7 +37,7 @@ File::File(File &&other) noexcept
 File::~File() noexcept
 {
 	if(file)
-		SDL_RWclose(file);
+		Files::Close(file);
 }
 
 

--- a/source/File.h
+++ b/source/File.h
@@ -18,7 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 
 
-// RAII wrapper for FILE, to make sure it gets closed if an error occurs.
+// RAII wrapper for SDL_RWops, to make sure it gets closed if an error occurs.
 class File {
 public:
 	File() noexcept = default;
@@ -33,10 +33,10 @@ public:
 	File &operator=(File &&) noexcept;
 
 	operator bool() const;
-	operator FILE*() const;
+	operator struct SDL_RWops*() const;
 
 private:
-	FILE *file = nullptr;
+	struct SDL_RWops *file = nullptr;
 };
 
 

--- a/source/Files.h
+++ b/source/Files.h
@@ -60,11 +60,11 @@ public:
 	static std::string Name(const std::string &path);
 
 	// File IO.
-	static FILE *Open(const std::string &path, bool write = false);
+	static struct SDL_RWops *Open(const std::string &path, bool write = false);
 	static std::string Read(const std::string &path);
-	static std::string Read(FILE *file);
+	static std::string Read(struct SDL_RWops *file);
 	static void Write(const std::string &path, const std::string &data);
-	static void Write(FILE *file, const std::string &data);
+	static void Write(struct SDL_RWops *file, const std::string &data);
 
 	static void LogError(const std::string &message);
 };

--- a/source/Files.h
+++ b/source/Files.h
@@ -61,6 +61,7 @@ public:
 
 	// File IO.
 	static struct SDL_RWops *Open(const std::string &path, bool write = false);
+	static void Close(struct SDL_RWops* ops);
 	static std::string Read(const std::string &path);
 	static std::string Read(struct SDL_RWops *file);
 	static void Write(const std::string &path, const std::string &data);

--- a/source/Music.h
+++ b/source/Music.h
@@ -57,7 +57,7 @@ private:
 	// This pointer holds the file for as long as it is owned by the main
 	// thread. When the decode thread takes possession of it, it sets this
 	// pointer to null.
-	FILE *nextFile = nullptr;
+	struct SDL_RWops *nextFile = nullptr;
 	bool hasNewFile = false;
 	bool done = false;
 

--- a/source/Sound.cpp
+++ b/source/Sound.cpp
@@ -15,6 +15,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "File.h"
 #include "Files.h"
 
+#include <SDL2/SDL_rwops.h>
+
 #ifndef __APPLE__
 #include <AL/al.h>
 #else
@@ -54,7 +56,7 @@ bool Sound::Load(const string &path, const string &name)
 		return false;
 
 	vector<char> data(bytes);
-	if(fread(&data[0], 1, bytes, in) != bytes)
+	if(SDL_RWread(static_cast<SDL_RWops*>(in), &data[0], 1, bytes) != bytes)
 		return false;
 
 	if(!buffer)
@@ -124,7 +126,7 @@ namespace {
 
 				// Skip any further bytes in this chunk.
 				if(subchunkSize > 16)
-					fseek(in, subchunkSize - 16, SEEK_CUR);
+					SDL_RWseek(static_cast<SDL_RWops*>(in), subchunkSize - 16, RW_SEEK_CUR);
 
 				if(audioFormat != 1)
 					return 0;
@@ -144,7 +146,7 @@ namespace {
 				return subchunkSize;
 			}
 			else
-				fseek(in, subchunkSize, SEEK_CUR);
+				SDL_RWseek(static_cast<SDL_RWops*>(in), subchunkSize, RW_SEEK_CUR);
 		}
 	}
 
@@ -153,7 +155,7 @@ namespace {
 	uint32_t Read4(File &in)
 	{
 		unsigned char data[4];
-		if(fread(data, 1, 4, in) != 4)
+		if(SDL_RWread(static_cast<SDL_RWops*>(in), data, 1, 4) != 4)
 			return 0;
 		uint32_t result = 0;
 		for(int i = 0; i < 4; ++i)
@@ -166,7 +168,7 @@ namespace {
 	uint16_t Read2(File &in)
 	{
 		unsigned char data[2];
-		if(fread(data, 1, 2, in) != 2)
+		if(SDL_RWread(static_cast<SDL_RWops*>(in), data, 1, 2) != 2)
 			return 0;
 		uint16_t result = 0;
 		for(int i = 0; i < 2; ++i)


### PR DESCRIPTION
This will support reading files from android-assets, as well as normal
I/O for PCs.


-----------------------
**Feature:** This is the beginning of a series of merges to implement #1502

## Feature Details
Specifically, this switches over to the SDL_RWops api for file I/O. This allows an android port to read from the apk assets as well as from the file system. 


## Testing Done
Tested on android and desktop builds, made sure that files could still be read and written

## Performance Impact
N/A
