### PR TITLE
Add 1 more Small Heat Shunt to stock Raider

### DIFF
--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -183,7 +183,7 @@ ship "Korath Raider"
 		"Triple Plasma Core"
 		"Systems Core (Medium)"
 		"Large Heat Shunt" 2
-		"Small Heat Shunt"
+		"Small Heat Shunt" 2
 		"Fuel Processor"
 		"Korath Repeater Rifle" 196
 		


### PR DESCRIPTION
----------------------
**Balance**

## Summary
The Stock Korath Raider currently has 12 outfit space going unused. Since it's particularly vulnerable to heat, as usual for the Korath, it's odd that they wouldn't put one more Small Heat Shunt there to help keep heat down a bit more.

This just changes the Raider's SHS number from 1 to 2, using 7 of that 12 outfit space it had available.