### PR TITLE
Show different Kestrels on the "for sale" mission

### DIFF
--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -193,15 +193,22 @@ mission "Kestrel Available"
 		conversation
 			branch engines
 				has "kestrel: more engines"
+			
 			branch shields
 				has "kestrel: more shields"
+			
 			scene "thumbnail/kestrelw"
+			``
 				goto message
+			
 			label engines
 			scene "thumbnail/kestrele"
+			``
 				goto message
+			
 			label shields
 			scene "thumbnail/kestrels"
+			``
 			label message
 			`You receive a message from Charles Atinoda, the ship designer at Tarazed Corporation: "Captain <last>, we are pleased to inform you that our latest warship is now available for sale here on Wayfarer. We've taken all your feedback into account in the final design. Thank you again!"`
 				decline

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -191,7 +191,18 @@ mission "Kestrel Available"
 	destination "Wayfarer"
 	on offer
 		conversation
-			scene thumbnail/kestrel
+			branch engines
+				has "kestrel: more engines"
+			branch shields
+				has "kestrel: more shields"
+			scene "thumbnail/kestrelw"
+				goto message
+			label engines
+			scene "thumbnail/kestrele"
+				goto message
+			label shields
+			scene "thumbnail/kestrels"
+			label message
 			`You receive a message from Charles Atinoda, the ship designer at Tarazed Corporation: "Captain <last>, we are pleased to inform you that our latest warship is now available for sale here on Wayfarer. We've taken all your feedback into account in the final design. Thank you again!"`
 				decline
 


### PR DESCRIPTION
Not checking for a default Kestrel, since that shouldn't happen.