### PR TITLE
Set "Military Response Test" to offer on landing

### DIFF
--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -355,6 +355,7 @@ mission "Local Politics"
 
 
 mission "Military Response Test"
+	landing
 	minor
 	source
 		government "Free Worlds"


### PR DESCRIPTION
Doesn't make much sense for it to offer in the spaceport. Kept the minor tag on.