### PR TITLE
Delay executing mission actions in "on offer" with a popup.

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -78,6 +78,13 @@ ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &con
 
 
 
+void ConversationPanel::SetAction(const GameAction &action, UI *ui)
+{
+	actionCallback = [this, &action, &ui] { action.Do(player, ui); };
+}
+
+
+
 // Draw this panel.
 void ConversationPanel::Draw()
 {
@@ -400,6 +407,9 @@ void ConversationPanel::Exit()
 				&& ship->Position().Distance(player.Flagship()->Position()) <= 1.)
 			GetUI()->Push(new BoardingPanel(player, ship));
 	}
+	// If any mission actions need to be performed, do them now.
+	if(actionCallback)
+		actionCallback();
 	// Call the exit response handler to manage the conversation's effect
 	// on the player's missions, or force takeoff from a planet.
 	if(callback)

--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -26,6 +26,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 class Color;
 class Conversation;
+class GameAction;
 class PlayerInfo;
 class Point;
 class Ship;
@@ -43,6 +44,7 @@ public:
 
 template <class T>
 	void SetCallback(T *t, void (T::*fun)(int));
+	void SetAction(const GameAction &action, UI *ui);
 
 	// Draw this panel.
 	virtual void Draw() override;
@@ -104,6 +106,9 @@ private:
 	int node;
 	// This function should be called with the conversation outcome.
 	std::function<void(int)> callback = nullptr;
+	// This function should be called when the conversation is done,
+	// since it is at that point that the action is executed.
+	std::function<void()> actionCallback;
 
 	// Current scroll position.
 	double scroll;

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -102,6 +102,13 @@ Dialog::Dialog(const string &text, PlayerInfo &player, const System *system, Tru
 
 
 
+void Dialog::SetAction(const GameAction &action, UI *ui)
+{
+	actionCallback = [this, &action, &ui] { action.Do(*player, ui); };
+}
+
+
+
 // Draw this panel.
 void Dialog::Draw()
 {
@@ -248,12 +255,18 @@ bool Dialog::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool i
 			// don't execute the callback.
 			if(!isOkDisabled)
 			{
+				if(actionCallback)
+					actionCallback();
 				DoCallback();
 				GetUI()->Pop(this);
 			}
 		}
 		else
+		{
+			if(actionCallback)
+				actionCallback();
 			GetUI()->Pop(this);
+		}
 	}
 	else if((key == 'm' || command.Has(Command::MAP)) && system && player)
 		GetUI()->Push(new MapDetailPanel(*player, system));

--- a/source/Dialog.h
+++ b/source/Dialog.h
@@ -23,6 +23,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <string>
 
 class DataNode;
+class GameAction;
 class PlayerInfo;
 class System;
 
@@ -66,6 +67,8 @@ template <class T>
 template <class T>
 	Dialog(T *t, void (T::*fun)(), const std::string &text, Truncate truncate = Truncate::NONE);
 
+	void SetAction(const GameAction &action, UI *ui);
+
 	// Draw this panel.
 	virtual void Draw() override;
 
@@ -89,6 +92,9 @@ private:
 protected:
 	WrappedText text;
 	int height;
+
+	// Used to execute a mission's actions when offering.
+	std::function<void()> actionCallback;
 
 	std::function<void(int)> intFun;
 	std::function<void(const std::string &)> stringFun;

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -322,11 +322,9 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 		{
 			dialog->SetAction(action, ui);
 			ui->Push(dialog);
-		}
-		else
-			action.Do(player, ui);
 
-		return;
+			return;
+		}
 	}
 	else if(isOffer && ui)
 		player.MissionCallback(Conversation::ACCEPT);

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -292,7 +292,10 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 		// conversations.
 		else
 			panel->SetCallback(&player, &PlayerInfo::BasicCallback);
+		panel->SetAction(action, ui);
 		ui->Push(panel);
+
+		return;
 	}
 	else if(!dialogText.empty() && ui)
 	{
@@ -309,10 +312,21 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, co
 		// avoid the player being spammed by dialogs if they have multiple
 		// missions active with the same destination (e.g. in the case of
 		// stacking bounty jobs).
+		Dialog *dialog = nullptr;
 		if(isOffer)
-			ui->Push(new Dialog(text, player, destination));
+			dialog = new Dialog(text, player, destination);
 		else if(isUnique || trigger != "visit")
-			ui->Push(new Dialog(text));
+			dialog = new Dialog(text);
+
+		if(dialog)
+		{
+			dialog->SetAction(action, ui);
+			ui->Push(dialog);
+		}
+		else
+			action.Do(player, ui);
+
+		return;
 	}
 	else if(isOffer && ui)
 		player.MissionCallback(Conversation::ACCEPT);


### PR DESCRIPTION
**Bugfix:** This PR fixes #3746

## Fix Details

This PR solves the linked issue by using the second approach mentioned by tehhowch: Delaying the execution of the actions until after the popup is finished.

## Testing Done

Used the first intro mission and opened and quit the game multiple times during the conversation. On master I saw multiple duplicate log entries. With this PR only one in total.

I did the same thing but changed the intro mission to be a dialog and verified that this PR also fixes the issue for dialogs.

## Save File

No save file, since you can simply start a new game and use the intro missions and the logbook entries.