### PR TITLE
Add gitignore for VSCode Devcontainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ ipch/
 CMakeLists.txt
 compile_commands.json
 /.gitmodules
+
+# IDE-related files for https://github.com/samrocketman/endless-sky-vscode-devcontainer
+/.clang-format
+*.AppImage
+.devcontainer

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,5 @@ compile_commands.json
 /.gitmodules
 
 # IDE-related files for https://github.com/samrocketman/endless-sky-vscode-devcontainer
-/.clang-format
 *.AppImage
 .devcontainer

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ endless-sky-tests
 libendless-sky.a
 *.exe
 *.lnk
+*.AppImage
 
 # dlls needed to run the binary
 *.dll
@@ -37,6 +38,7 @@ plugins/
 
 # IDEs (no support implied)
 .cache
+.devcontainer
 .vscode
 .vs
 .metadata
@@ -64,7 +66,3 @@ ipch/
 CMakeLists.txt
 compile_commands.json
 /.gitmodules
-
-# IDE-related files for https://github.com/samrocketman/endless-sky-vscode-devcontainer
-*.AppImage
-.devcontainer


### PR DESCRIPTION
I have developed a portable IDE for Endless Sky contributors.  This change ignores files created by the tasks which replicate GitHub actions.

https://github.com/samrocketman/endless-sky-vscode-devcontainer