### PR TITLE
Introduce new jobs to make smaller Marauders easier to obtain

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -2548,6 +2548,88 @@ fleet "Bounty Hunters"
 		"Splinter"
 		"Fury (Heavy)"
 
+fleet "Marauder I"
+	government "Pirate"
+	names "pirate"
+	cargo 1
+	personality
+		plunders
+	variant 3
+		"Marauder Arrow"
+	variant 1
+		"Marauder Arrow (Weapons)"
+	variant 1
+		"Marauder Arrow (Engines)"
+	variant 3
+		"Marauder Bounder"
+	variant 1
+		"Marauder Bounder (Weapons)"
+	variant 1
+		"Marauder Bounder (Engines)"
+
+fleet "Marauder II"
+	government "Pirate"
+	names "pirate"
+	cargo 1
+	personality
+		plunders
+	variant 3
+		"Marauder Quicksilver"
+	variant 1
+		"Marauder Quicksilver (Weapons)"
+	variant 1
+		"Marauder Quicksilver (Engines)"
+	variant 3
+		"Marauder Raven"
+	variant 1
+		"Marauder Raven (Weapons)"
+	variant 1
+		"Marauder Raven (Engines)"
+
+fleet "Marauder III"
+	government "Pirate"
+	names "pirate"
+	cargo 1
+	personality
+		plunders
+	variant 3
+		"Marauder Firebird"
+	variant 1
+		"Marauder Firebird (Weapons)"
+	variant 1
+		"Marauder Firebird (Engines)"
+	variant 3
+		"Marauder Manta"
+	variant 1
+		"Marauder Manta (Weapons)"
+	variant 1
+		"Marauder Manta (Engines)"
+	variant 3
+		"Marauder Splinter"
+	variant 1
+		"Marauder Splinter (Weapons)"
+	variant 1
+		"Marauder Splinter (Engines)"
+
+fleet "Marauder IV"
+	government "Pirate"
+	names "pirate"
+	cargo 1
+	personality
+		plunders
+	variant 3
+		"Marauder Falcon"
+	variant 1
+		"Marauder Falcon (Weapons)"
+	variant 1
+		"Marauder Falcon (Engines)"
+	variant 3
+		"Marauder Leviathan"
+	variant 1
+		"Marauder Leviathan (Weapons)"
+	variant 1
+		"Marauder Leviathan (Engines)"
+
 fleet "Marauder fleet I"
 	government "Pirate"
 	names "pirate"

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -3054,8 +3054,8 @@ mission "Bounty Hunting (Solo Marauder I)"
 	to offer
 		or
 			"combat rating" > 100
-			"ships: Interceptor"
-			"ships: Light Warship"
+			has "ships: Interceptor"
+			has "ships: Light Warship"
 		"combat rating" > 50
 		"combat rating" < 600
 		random < 5

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -2845,45 +2845,6 @@ mission "Bounty Hunting (Big)"
 		payment 250000
 		dialog phrase "generic bounty hunting payment dialog"
 
-mission "Bounty Hunting (Small, Boarding, Entering)"
-	name "Stolen ship near <system>"
-	description "A wanted criminal is fleeing in a stolen ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminal to <destination> to stand trial on <date>. Reward for capture: <payment>."
-	passengers 1
-	deadline 14
-	repeat
-	job
-	to offer
-		"combat rating" > 80
-		random < 15
-	on offer
-		require "Brig"
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
-		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
-	destination
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
-		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
-		distance 2 6
-	npc board
-		government "Bounty"
-		personality timid fleeing uninterested entering target
-		fleet
-			names "civilian"
-			variant
-				"Flivver (Racing)"
-			variant
-				"Arrow"
-			variant
-				"Scout (Speedy)"
-			variant
-				"Clipper (Speedy)"
-		dialog "You blast your way onto the ship and confine the fleeing criminal to your ship's brig. Time to deliver them to <planet>."
-	on visit
-		dialog phrase "generic bounty hunting boarding on visit"
-	on complete
-		payment 175000
-		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal."
-
 mission "Bounty Hunting (Small, Hidden)"
 	name "Disguised bandit near <system>"
 	description "A low-end pirate warship named the <npc> is posing as a merchant ship near the <system> system. Select merchant ships until you find a ship with a matching name, then destroy it and return to <planet> for payment (<payment>)."
@@ -3005,6 +2966,45 @@ mission "Bounty Hunting (Big, Hidden)"
 		payment 450000
 		dialog phrase "generic bounty hunting payment dialog"
 
+mission "Bounty Hunting (Small, Boarding, Entering)"
+	name "Stolen ship near <system>"
+	description "A wanted criminal is fleeing in a stolen ship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminal to <destination> to stand trial on <date>. Reward for capture: <payment>."
+	passengers 1
+	deadline 14
+	repeat
+	job
+	to offer
+		"combat rating" > 80
+		random < 15
+	on offer
+		require "Brig"
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
+	destination
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
+		distance 2 6
+	npc board
+		government "Bounty"
+		personality timid fleeing uninterested entering target
+		fleet
+			names "civilian"
+			variant
+				"Flivver (Racing)"
+			variant
+				"Arrow"
+			variant
+				"Scout (Speedy)"
+			variant
+				"Clipper (Speedy)"
+		dialog "You blast your way onto the ship and confine the fleeing criminal to your ship's brig. Time to deliver them to <planet>."
+	on visit
+		dialog phrase "generic bounty hunting boarding on visit"
+	on complete
+		payment 175000
+		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal."
+
 mission "Bounty Hunting (Medium, Boarding, Entering)"
 	name "Stolen warship near <system>"
 	description "A wanted criminal and several accomplices are fleeing in a stolen warship, the <npc>, which is about to enter this system. Disable and board the vessel and bring the criminals to <destination> to stand trial on <date>. Reward for capture: <payment>."
@@ -3045,6 +3045,114 @@ mission "Bounty Hunting (Medium, Boarding, Entering)"
 	on complete
 		payment 350000
 		dialog "The government of <planet> gratefully pays you <payment> for apprehending the criminal gang."
+
+mission "Bounty Hunting (Solo Marauder I)"
+	name "Marauder interceptor near <system>"
+	description "A Marauder interceptor named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	repeat
+	job
+	to offer
+		or
+			"combat rating" > 100
+			"ships: Interceptor"
+			"ships: Light Warship"
+		"combat rating" > 50
+		"combat rating" < 600
+		random < 5
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
+	npc kill
+		government "Bounty"
+		personality heroic staying nemesis target
+		system
+			distance 1 2
+		fleet "Marauder I"
+		dialog phrase "generic hunted bounty eliminated dialog"
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 80000
+		dialog phrase "generic bounty hunting payment dialog"
+
+mission "Bounty Hunting (Solo Marauder II)"
+	name "Small Marauder near <system>"
+	description "A small Marauder ship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	repeat
+	job
+	to offer
+		or
+			"combat rating" > 200
+			has "ships: Light Warship"
+			has "ships: Medium Warship"
+		"combat rating" > 100
+		"combat rating" < 600
+		random < 5
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
+	npc kill
+		government "Bounty"
+		personality heroic staying nemesis target
+		system
+			distance 1 2
+		fleet "Marauder II"
+		dialog phrase "generic hunted bounty eliminated dialog"
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 130000
+		dialog phrase "generic bounty hunting payment dialog"
+
+mission "Bounty Hunting (Solo Marauder III)"
+	name "Marauder near <system>"
+	description "A Marauder ship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	repeat
+	job
+	to offer
+		"combat rating" > 300
+		"combat rating" < 1550
+		random < 5
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
+	npc kill
+		government "Bounty"
+		personality heroic staying nemesis target
+		system
+			distance 1 2
+		fleet "Marauder III"
+		dialog phrase "generic hunted bounty eliminated dialog"
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 180000
+		dialog phrase "generic bounty hunting payment dialog"
+
+mission "Bounty Hunting (Solo Marauder IV)"
+	name "Large Marauder near <system>"
+	description "A large Marauder ship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	repeat
+	job
+	to offer
+		"combat rating" > 500
+		"combat rating" < 2980
+		random < 5
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
+	npc kill
+		government "Bounty"
+		personality heroic staying nemesis target
+		system
+			distance 1 2
+		fleet "Marauder IV"
+		dialog phrase "generic hunted bounty eliminated dialog"
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 280000
+		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder I)"
 	name "Small Marauders near <system>"

--- a/data/human/pirate jobs.txt
+++ b/data/human/pirate jobs.txt
@@ -2524,22 +2524,23 @@ mission "Eliminating Competition (Marauders, Small)"
 		personality heroic staying target marked
 		system
 			distance 1 2
-		fleet "Marauder fleet III"
+		fleet "Marauder I" 2
+		fleet "Marauder II" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on accept
 		"reputation: Pirate (Rival)" = "reputation: Pirate"
 	on complete
-		payment 400000
+		payment 500000
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the rival gang."
 
-mission "Eliminating Competition (Marauders, Large)"
+mission "Eliminating Competition (Marauders, Medium)"
 	name "Competition near <system>"
-	description "A large marauder gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> for a payment of <payment>."
+	description "A marauder gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> for a payment of <payment>."
 	repeat
 	job
 	to offer
 		random < 5
-		"combat rating" > 2000
+		"combat rating" > 1100
 	source
 		government "Pirate"
 	npc kill
@@ -2547,23 +2548,24 @@ mission "Eliminating Competition (Marauders, Large)"
 		personality heroic staying target marked
 		system
 			distance 1 2
-		fleet "Marauder fleet III"
-		fleet "Marauder fleet VI"
+		fleet "Marauder I"
+		fleet "Marauder II"
+		fleet "Marauder III" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on accept
 		"reputation: Pirate (Rival)" = "reputation: Pirate"
 	on complete
-		payment 900000
+		payment 750000
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the rival gang."
 
-mission "Eliminating Competition (Marauders, Huge)"
+mission "Eliminating Competition (Marauders, Large)"
 	name "Marauder Elimination"
-	description "The pirates of the <system> system have grown dissatisified with the actions of the strongest Marauder gang in the region. Take them out and return to <planet> for a payment of <payment>."
+	description "The pirates of the <system> system have grown dissatisified with the actions of the ruling Marauder gang. Take them out and return to <planet> for a payment of <payment>."
 	repeat
 	job
 	to offer
-		random < 2
-		"combat rating" > 3500
+		random < 5
+		"combat rating" > 2100
 	source
 		government "Pirate"
 	npc kill
@@ -2571,12 +2573,15 @@ mission "Eliminating Competition (Marauders, Huge)"
 		personality heroic staying target marked
 		system
 			distance 1 3
-		fleet "Marauder fleet X" 2
+		fleet "Marauder I" 2
+		fleet "Marauder II" 2
+		fleet "Marauder III"
+		fleet "Marauder IV"
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on accept
 		"reputation: Pirate (Rival)" = "reputation: Pirate"
 	on complete
-		payment 1500000
+		payment 900000
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the rival gang."
 
 

--- a/data/human/pirate jobs.txt
+++ b/data/human/pirate jobs.txt
@@ -2509,6 +2509,76 @@ mission "Eliminating Competition (South, Large)"
 		payment 750000
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the rival gang."
 
+mission "Eliminating Competition (Marauders, Small)"
+	name "Competition near <system>"
+	description "A small marauder gang is causing trouble near the <system> system. Take them out and return to <planet> for a payment of <payment>."
+	repeat
+	job
+	to offer
+		random < 5
+		"combat rating" > 600
+	source
+		government "Pirate"
+	npc kill
+		government "Pirate (Rival)"
+		personality heroic staying target marked
+		system
+			distance 1 2
+		fleet "Marauder fleet III"
+		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
+	on accept
+		"reputation: Pirate (Rival)" = "reputation: Pirate"
+	on complete
+		payment 400000
+		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the rival gang."
+
+mission "Eliminating Competition (Marauders, Large)"
+	name "Competition near <system>"
+	description "A large marauder gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> for a payment of <payment>."
+	repeat
+	job
+	to offer
+		random < 5
+		"combat rating" > 2000
+	source
+		government "Pirate"
+	npc kill
+		government "Pirate (Rival)"
+		personality heroic staying target marked
+		system
+			distance 1 2
+		fleet "Marauder fleet III"
+		fleet "Marauder fleet VI"
+		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
+	on accept
+		"reputation: Pirate (Rival)" = "reputation: Pirate"
+	on complete
+		payment 900000
+		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the rival gang."
+
+mission "Eliminating Competition (Marauders, Huge)"
+	name "Marauder Elimination"
+	description "The pirates of the <system> system have grown dissatisified with the actions of the strongest Marauder gang in the region. Take them out and return to <planet> for a payment of <payment>."
+	repeat
+	job
+	to offer
+		random < 2
+		"combat rating" > 3500
+	source
+		government "Pirate"
+	npc kill
+		government "Pirate (Rival)"
+		personality heroic staying target marked
+		system
+			distance 1 3
+		fleet "Marauder fleet X" 2
+		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
+	on accept
+		"reputation: Pirate (Rival)" = "reputation: Pirate"
+	on complete
+		payment 1500000
+		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the rival gang."
+
 
 
 mission "Raid on Merchants (North)"


### PR DESCRIPTION
## Summary
Currently, Marauder ships only appear after the player has a combat rating of 600 (ignoring mission unique marauders). At that point, the player likely already has a warship far more powerful than any of the marauder ships that can spawn. To make matters worse, Marauder ships only spawn in fleets, meaning that, to get one, you have to be a decent amount stronger than an individual Marauder them to capture them, furthering their irrelevance.

This PR seeks to make solo Marauder runs more feasible by adding new bounty jobs that only spawn single Marauders. These jobs spawn at similar times to the regular bounty jobs, but with a heightened combat rating check and reward, as well as a lower offer rate, since these fights are generally much harder.

Also added are a series of rival Marauder jobs to pirate space. As it stands, a pirate playthrough is, ironically, the playstyle that has the hardest time getting Marauder ships, since Marauder bounties only appear in civilised space. These new jobs should make it easier to get Marauders as a pirate.