### PR TITLE
Change Cargo Button Text

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -102,7 +102,7 @@ int OutfitterPanel::VisiblityCheckboxesSize() const
 
 string OutfitterPanel::ShipsDeselectText() const
 {
-	return "Cargo";
+	return "Cargo & Storage";
 }
 
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -100,6 +100,13 @@ int OutfitterPanel::VisiblityCheckboxesSize() const
 
 
 
+string OutfitterPanel::ShipsDeselectText() const
+{
+	return "Cargo";
+}
+
+
+
 int OutfitterPanel::DrawPlayerShipInfo(const Point &point)
 {
 	shipInfo.Update(*playerShip, player.FleetDepreciation(), day);

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -46,6 +46,7 @@ public:
 protected:
 	virtual int TileSize() const override;
 	virtual int VisiblityCheckboxesSize() const override;
+	virtual std::string ShipsDeselectText() const override;
 	virtual int DrawPlayerShipInfo(const Point &point) override;
 	virtual bool HasItem(const std::string &name) const override;
 	virtual void DrawItem(const std::string &name, const Point &point, int scrollY) override;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -274,12 +274,12 @@ void ShopPanel::DrawShipsSidebar()
 
 		point.Y() += ICON_TILE;
 		const Point cargoModeButtonCenter = Point(Screen::Right() - SIDEBAR_WIDTH / 2, point.Y());
-		FillShader::Fill(cargoModeButtonCenter, Point(60, 30), playerShip ? back : activeBack);
+		FillShader::Fill(cargoModeButtonCenter, Point(140, 30), playerShip ? back : activeBack);
 		bigFont.Draw(deSelectText,
 			cargoModeButtonCenter - .5 * Point(bigFont.Width(deSelectText), bigFont.Height()),
 			playerShip ? inactive : active);
 
-		zones.emplace_back(cargoModeButtonCenter, Point(60, 30), 'a');
+		zones.emplace_back(cargoModeButtonCenter, Point(140, 30), 'a');
 	}
 	point.Y() += ICON_TILE;
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -263,6 +263,24 @@ void ShopPanel::DrawShipsSidebar()
 
 		point.X() += ICON_TILE;
 	}
+	string deSelectText = ShipsDeselectText();
+	if(!deSelectText.empty())
+	{
+		const Color &back = *GameData::Colors().Get("faint");
+		const Color &activeBack = *GameData::Colors().Get("dim");
+		const Color &active = *GameData::Colors().Get("active");
+		const Color &inactive = *GameData::Colors().Get("inactive");
+		const Font &bigFont = FontSet::Get(18);
+
+		point.Y() += ICON_TILE;
+		const Point cargoModeButtonCenter = Point(Screen::Right() - SIDEBAR_WIDTH / 2, point.Y());
+		FillShader::Fill(cargoModeButtonCenter, Point(60, 30), playerShip ? back : activeBack);
+		bigFont.Draw(deSelectText,
+			cargoModeButtonCenter - .5 * Point(bigFont.Width(deSelectText), bigFont.Height()),
+			playerShip ? inactive : active);
+
+		zones.emplace_back(cargoModeButtonCenter, Point(60, 30), 'a');
+	}
 	point.Y() += ICON_TILE;
 
 	if(playerShip)
@@ -569,6 +587,13 @@ int ShopPanel::VisiblityCheckboxesSize() const
 
 
 
+string ShopPanel::ShipsDeselectText() const
+{
+	return "";
+}
+
+
+
 void ShopPanel::ToggleForSale()
 {
 	sameSelectedTopY = true;
@@ -660,6 +685,11 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		return DoScroll(Screen::Bottom());
 	else if(key == SDLK_PAGEDOWN)
 		return DoScroll(Screen::Top());
+	else if(key == 'a')
+	{
+		playerShip = nullptr;
+		playerShips.clear();
+	}
 	else if(key >= '0' && key <= '9')
 	{
 		int group = key - '0';
@@ -789,6 +819,11 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 
 				selectedShip = zone.GetShip();
 			}
+			else if(zone.GetButton())
+			{
+				Command command;
+				KeyDown(zone.GetButton(), 0,  command, true);
+			}
 			else
 				selectedOutfit = zone.GetOutfit();
 
@@ -914,6 +949,13 @@ ShopPanel::Zone::Zone(Point center, Point size, const Ship *ship, double scrollY
 
 
 
+ShopPanel::Zone::Zone(Point center, Point size, char button, double scrollY)
+	: ClickZone(center, size, nullptr), scrollY(scrollY), button(button)
+{
+}
+
+
+
 ShopPanel::Zone::Zone(Point center, Point size, const Outfit *outfit, double scrollY)
 	: ClickZone(center, size, nullptr), scrollY(scrollY), outfit(outfit)
 {
@@ -931,6 +973,13 @@ const Ship *ShopPanel::Zone::GetShip() const
 const Outfit *ShopPanel::Zone::GetOutfit() const
 {
 	return outfit;
+}
+
+
+
+char ShopPanel::Zone::GetButton() const
+{
+	return button;
 }
 
 

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -52,6 +52,7 @@ protected:
 	// These are for the individual shop panels to override.
 	virtual int TileSize() const = 0;
 	virtual int VisiblityCheckboxesSize() const;
+	virtual std::string ShipsDeselectText() const;
 	virtual int DrawPlayerShipInfo(const Point &point) = 0;
 	virtual bool HasItem(const std::string &name) const = 0;
 	virtual void DrawItem(const std::string &name, const Point &point, int scrollY) = 0;
@@ -88,14 +89,17 @@ protected:
 	public:
 		explicit Zone(Point center, Point size, const Ship *ship, double scrollY = 0.);
 		explicit Zone(Point center, Point size, const Outfit *outfit, double scrollY = 0.);
+		explicit Zone(Point center, Point size, char button, double scrollY = 0.);
 
 		const Ship *GetShip() const;
+		char GetButton() const;
 		const Outfit *GetOutfit() const;
 
 		double ScrollY() const;
 
 	private:
 		double scrollY = 0.;
+		char button = 0;
 		const Outfit *outfit = nullptr;
 	};
 


### PR DESCRIPTION
**Feature:** This PR makes a change to the cargo button text as I suggested #6705


## Feature Details
Instead of "Cargo" the button now reads "Cargo & Storage" and the background size has been updated as necessary.  I think this wording is more obvious but the button itself is a great idea regardless.

## UI Screenshots
![Cargo   Storage](https://user-images.githubusercontent.com/80174383/162652730-0fa7952b-5e06-4b11-9fce-3f40ad645798.png)

## Usage Examples
N/A

## Testing Done
It looks right and no functionality was changed.

## Performance Impact
None
