### PR TITLE
Tweak: Add reverse thruster outfits to stock human ships where appropriate.

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -524,6 +524,7 @@ ship "Behemoth"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
+		"X1100 Ion Reverse Thruster" 2
 		"Scram Drive"
 		
 	engine -34 143 0.8

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -156,13 +156,14 @@ ship "Arrow"
 			"hull damage" 120
 			"hit force" 360
 	outfits
-		"Meteor Missile Pod" 2
-		"Meteor Missile" 14
+		"Sidewinder Missile Pod" 2
+		"Sidewinder Missile" 8
 		"Anti-Missile Turret"
 		
 		"Dwarf Core"
 		"Supercapacitor"
 		"D14-RN Shield Generator"
+		"Small Radar Jammer"
 		"Luxury Accommodations"
 		
 		"A250 Atomic Thruster"
@@ -172,8 +173,8 @@ ship "Arrow"
 		
 	engine -8 56
 	engine 8 56
-	gun -7.5 -36 "Meteor Missile Pod"
-	gun 7.5 -36 "Meteor Missile Pod"
+	gun -7.5 -36 "Sidewinder Missile Pod"
+	gun 7.5 -36 "Sidewinder Missile Pod"
 	turret 0 17.5 "Anti-Missile Turret"
 	leak "leak" 80 50
 	explode "tiny explosion" 12

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1601,11 +1601,13 @@ ship "Flivver"
 		"Meteor Missile" 14
 		
 		"nGVF-BB Fuel Cell"
-		"LP036a Battery Pack"
+		"KP-6 Photovoltaic Panel" 3
+		"Supercapacitor"
 		"D14-RN Shield Generator"
 		
 		"A120 Atomic Thruster"
 		"X1200 Ion Steering"
+		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -16 27

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2767,10 +2767,10 @@ ship "Raven"
 		"Torpedo Launcher" 2
 		"Torpedo" 60
 		
-		"Dwarf Core"
+		"RT-I Radiothermal"
 		"KP-6 Photovoltaic Panel" 2
 		"LP036a Battery Pack"
-		"D41-HY Shield Generator"
+		"D23-QP Shield Generator"
 		"Laser Rifle" 2
 		
 		"X3700 Ion Thruster"

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -681,12 +681,12 @@ ship "Bounder"
 		"Anti-Missile Turret" 2
 		
 		"nGVF-CC Fuel Cell"
+		"KP-6 Photovoltaic Array"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
-		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -12 44

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2983,20 +2983,21 @@ ship "Skein"
 			"hull damage" 500
 			"hit force" 1500
 	outfits
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile Pod" 2
+		"Meteor Missile Box"
+		"Meteor Missile" 29
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
 		"D67-TM Shield Generator" 4
-		"Large Radar Jammer"
 		"Tactical Scanner"
 		"Laser Rifle" 4
 		
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
+		"Capybara Reverse Thruster"
 		"Hyperdrive"
 
 	engine -45 196.5

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -107,6 +107,7 @@ ship "Argosy"
 		
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
+		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -25 91 0.6
@@ -155,18 +156,18 @@ ship "Arrow"
 			"hull damage" 120
 			"hit force" 360
 	outfits
-		"Sidewinder Missile Pod" 2
-		"Sidewinder Missile" 8
+		"Meteor Missile Pod" 2
+		"Meteor Missile" 14
 		"Anti-Missile Turret"
 		
 		"Dwarf Core"
 		"Supercapacitor"
 		"D14-RN Shield Generator"
-		"Small Radar Jammer"
 		"Luxury Accommodations"
 		
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
+		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -8 56
@@ -583,6 +584,7 @@ ship "Berserker"
 		
 		"X2700 Ion Thruster"
 		"X3200 Ion Steering"
+		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -10 45
@@ -680,12 +682,12 @@ ship "Bounder"
 		"Anti-Missile Turret" 2
 		
 		"nGVF-CC Fuel Cell"
-		"KP-6 Photovoltaic Array"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
+		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -12 44
@@ -774,6 +776,7 @@ ship "Bulk Freighter"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
+		"X1100 Ion Reverse Thruster"
 		"Scram Drive"
 		
 	engine -22 198
@@ -907,7 +910,7 @@ ship "Class C Freighter"
 			"hull damage" 1000
 			"hit force" 3000
 	outfits
-		"Heavy Laser Turret" 2
+		"Laser Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
 		"Fission Reactor"
@@ -917,13 +920,14 @@ ship "Class C Freighter"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
+		"X1100 Ion Reverse Thruster" 2
 		"Scram Drive"
 		
 	engine -20 195.5
 	engine 20 195.5
-	turret -12 -155 "Heavy Laser Turret"
+	turret -12 -155 "Laser Turret"
 	turret 12 -155 "Heavy Anti-Missile Turret"
-	turret 30 175 "Heavy Laser Turret"
+	turret 30 175 "Laser Turret"
 	turret -30 175 "Heavy Anti-Missile Turret"
 	bay "Drone" -66 -115 left
 	bay "Drone" -66 -65 left
@@ -1075,6 +1079,7 @@ ship "Container Transport"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
+		"X1100 Ion Reverse Thruster"
 		"Scram Drive"
 		
 	engine -20 195.5
@@ -1139,6 +1144,7 @@ ship "Corvette"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
+		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -11.5 119
@@ -1432,11 +1438,12 @@ ship "Falcon"
 		"LP144a Battery Pack"
 		"D41-HY Shield Generator"
 		"Large Radar Jammer"
-		"Liquid Nitrogen Cooler"
+		"Water Coolant System"
 		"Laser Rifle" 15
 		
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
+		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -16.5 143
@@ -1638,12 +1645,13 @@ ship "Freighter"
 		"Blaster Turret" 2
 		"Heavy Anti-Missile Turret"
 		
-		"nGVF-EE Fuel Cell"
-		"LP036a Battery Pack"
+		"nGVF-DD Fuel Cell"
+		"LP072a Battery Pack"
 		"D14-RN Shield Generator"
 		
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
+		"X1100 Ion Reverse Thruster"
 		"Scram Drive"
 		
 	engine -7.5 92
@@ -2533,11 +2541,12 @@ ship "Osprey"
 		"LP036a Battery Pack"
 		"D41-HY Shield Generator"
 		"Large Radar Jammer"
-		"Liquid Helium Cooler"
+		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 3
 		
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
+		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -42.5 62.5 .8
@@ -2758,14 +2767,15 @@ ship "Raven"
 		"Torpedo Launcher" 2
 		"Torpedo" 60
 		
-		"RT-I Radiothermal"
+		"Dwarf Core"
 		"KP-6 Photovoltaic Panel" 2
-		"LP072a Battery Pack"
+		"LP036a Battery Pack"
 		"D41-HY Shield Generator"
 		"Laser Rifle" 2
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
+		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -9.5 63
@@ -3098,6 +3108,7 @@ ship "Splinter"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
+		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -15.5 115

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -172,8 +172,8 @@ ship "Arrow"
 		
 	engine -8 56
 	engine 8 56
-	gun -7.5 -36 "Sidewinder Missile Pod"
-	gun 7.5 -36 "Sidewinder Missile Pod"
+	gun -7.5 -36 "Meteor Missile Pod"
+	gun 7.5 -36 "Meteor Missile Pod"
 	turret 0 17.5 "Anti-Missile Turret"
 	leak "leak" 80 50
 	explode "tiny explosion" 12

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2294,9 +2294,6 @@ ship "Manta"
 			"hit force" 1200
 	outfits
 		"Particle Cannon" 4
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 75
-		"Meteor Missile Box"
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
@@ -2305,6 +2302,7 @@ ship "Manta"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
+		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -33 38

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2311,8 +2311,8 @@ ship "Manta"
 	gun 21 -35 "Particle Cannon"
 	gun -27 -35 "Particle Cannon"
 	gun 27 -35 "Particle Cannon"
-	gun -66 -32 "Meteor Missile Launcher"
-	gun 66 -32 "Meteor Missile Launcher"
+	gun -66 -32
+	gun 66 -32
 	leak "leak" 60 50
 	leak "flame" 40 80
 	explode "tiny explosion" 10

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1878,6 +1878,7 @@ ship "Hauler"
 		
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
+		"Capybara Reverse Thruster"
 		"Hyperdrive"
 
 	engine -45 122.5
@@ -1924,8 +1925,9 @@ ship "Hauler II"
 			"hull damage" 400
 			"hit force" 1200
 	outfits
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile Pod" 2
+		"Meteor Missile" 59
+		"Meteor Missile Box" 3
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1937,6 +1939,7 @@ ship "Hauler II"
 		
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
+		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -45 159.5
@@ -1983,8 +1986,9 @@ ship "Hauler III"
 			"hull damage" 500
 			"hit force" 1500
 	outfits
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile Pod" 2
+		"Meteor Missile" 59
+		"Meteor Missile Box" 3
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1996,6 +2000,7 @@ ship "Hauler III"
 		
 		"Greyhound Plasma Thruster"
 		"Impala Plasma Steering"
+		"Capybara Reverse Thruster"
 		"Hyperdrive"
 
 	engine -45 196.5
@@ -2981,8 +2986,8 @@ ship "Skein"
 			"hit force" 1500
 	outfits
 		"Meteor Missile Pod" 2
-		"Meteor Missile Box"
 		"Meteor Missile" 29
+		"Meteor Missile Box"
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1142,7 +1142,6 @@ ship "Corvette"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
-		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -11.5 119

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -584,7 +584,6 @@ ship "Berserker"
 		
 		"X2700 Ion Thruster"
 		"X3200 Ion Steering"
-		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -10 45
@@ -910,7 +909,7 @@ ship "Class C Freighter"
 			"hull damage" 1000
 			"hit force" 3000
 	outfits
-		"Laser Turret" 2
+		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
 		"Fission Reactor"
@@ -920,14 +919,13 @@ ship "Class C Freighter"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
-		"X1100 Ion Reverse Thruster" 2
 		"Scram Drive"
 		
 	engine -20 195.5
 	engine 20 195.5
-	turret -12 -155 "Laser Turret"
+	turret -12 -155 "Heavy Laser Turret"
 	turret 12 -155 "Heavy Anti-Missile Turret"
-	turret 30 175 "Laser Turret"
+	turret 30 175 "Heavy Laser Turret"
 	turret -30 175 "Heavy Anti-Missile Turret"
 	bay "Drone" -66 -115 left
 	bay "Drone" -66 -65 left
@@ -1438,12 +1436,11 @@ ship "Falcon"
 		"LP144a Battery Pack"
 		"D41-HY Shield Generator"
 		"Large Radar Jammer"
-		"Water Coolant System"
+		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 15
 		
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
-		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -16.5 143
@@ -2294,6 +2291,9 @@ ship "Manta"
 			"hit force" 1200
 	outfits
 		"Particle Cannon" 4
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 75
+		"Meteor Missile Box"
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
@@ -2302,7 +2302,6 @@ ship "Manta"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
-		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -33 38
@@ -2311,8 +2310,8 @@ ship "Manta"
 	gun 21 -35 "Particle Cannon"
 	gun -27 -35 "Particle Cannon"
 	gun 27 -35 "Particle Cannon"
-	gun -66 -32
-	gun 66 -32
+	gun -66 -32 "Meteor Missile Launcher"
+	gun 66 -32 "Meteor Missile Launcher"
 	leak "leak" 60 50
 	leak "flame" 40 80
 	explode "tiny explosion" 10
@@ -2541,12 +2540,11 @@ ship "Osprey"
 		"LP036a Battery Pack"
 		"D41-HY Shield Generator"
 		"Large Radar Jammer"
-		"Liquid Nitrogen Cooler"
+		"Liquid Helium Cooler"
 		"Laser Rifle" 3
 		
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
-		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -42.5 62.5 .8
@@ -2768,14 +2766,13 @@ ship "Raven"
 		"Torpedo" 60
 		
 		"RT-I Radiothermal"
-		"KP-6 Photovoltaic Panel" 1
-		"LP036a Battery Pack"
-		"D23-QP Shield Generator"
+		"KP-6 Photovoltaic Panel" 2
+		"LP072a Battery Pack"
+		"D41-HY Shield Generator"
 		"Laser Rifle" 2
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
-		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -9.5 63
@@ -3109,7 +3106,6 @@ ship "Splinter"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
-		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -15.5 115

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -168,7 +168,6 @@ ship "Arrow"
 		
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
-		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -8 56

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1144,7 +1144,7 @@ ship "Corvette"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
-		"X1100 Ion Reverse Thruster"
+		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -11.5 119
@@ -2770,14 +2770,14 @@ ship "Raven"
 		"Torpedo" 60
 		
 		"RT-I Radiothermal"
-		"KP-6 Photovoltaic Panel" 2
+		"KP-6 Photovoltaic Panel" 1
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
 		"Laser Rifle" 2
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
-		"X1100 Ion Reverse Thruster"
+		"Capybara Reverse Thruster"
 		"Hyperdrive"
 		
 	engine -9.5 63


### PR DESCRIPTION
## Summary
After the merging of #5792 there are now two additional reverse thrusters available for purchase in human space. 
However to date, not a single ship comes equipped with either of these two new reverse thrusters and only one ship comes equipped with the previous atomic reverse thruster as part of their stock loadout meaning you rarely ever see them.

The intent of this PR is to increase the prevalence of these new outfits by selectively adding them to several human stock loadouts where appropriate to increase the diversity of builds available to a new player, as well as make the entirety of human space appear more "alive" as ships will now maneuver in different ways based on the thrusters they have installed.

You will now see a lot more ships in human space using reverse thrusters and will have more opportunities to buy ships that come with reverse thrusters. 

See below for a full list of changed ships and my justification for them:
<details>
<summary>Argosy</summary>

- Added Capybara Reverse Thruster

Straight Upgrade. As this ship's stock configuration comes with relatively low turning for its class (42.29 when fully loaded), the addition of reverse thrusters helps it to jump faster, land faster and makes it overall more effective in its role of carrying cargo while still being a capable warship. 
(Modified Argosy removes this reverse thruster to install more weaponry which I feel is fitting) 
With reverse thrusters installed, this ship will use them for both landing and jumping.
</details>


<details>
<summary>Behemoth</summary>

- Added Two X1100 Ion Reverse Thrusters

Straight upgrade, faster landing, slightly faster jumping, overall more efficient in its role
</details>

<details>
<summary>Bulk Freighter</summary>

- Added X1100 Ion Reverse Thruster

Straight upgrade. Better maneuverability, faster landing, faster hyperspace jumps. If we don't feel that a single reverse thruster is enough, we could also downgrade the sidewinders to meteors and install a second reverse thruster.
</details>



<details>
<summary>Container Transport</summary>

- Added X1100 Ion Reverse Thruster

Straight Upgrade. Better maneuverability, faster landing, faster hyperspace jumps, overall improvement to the ship as a whole.
</details>


<details>
<summary>Flivver</summary>

- Downgraded LP036a Battery Pack to Supercapacitor
- Added three KP-6 Photovoltaic Panels
- Added X1100 Ion Reverse Thruster

Added based on Feedback: [1096204460](https://github.com/endless-sky/endless-sky/pull/6710#issuecomment-1096204460)

</details>

<details>
<summary>Freighter</summary>

- Downgraded nGVF-EE Fuel Cell to nGVF-DD Fuel Cell
- Upgraded LP036a Battery Pack to LP072a Battery Pack
- Added X1100 Ion Reverse Thruster

The freighter, as a cargo-carrying vessel will need to jump and land often as part of it's normal operating procedure, both of these tasks will be made more efficient with the addition of reverse thrusters. The decreased energy generation from the downgraded Fuel Cell is also not an issue for this ship as it already had too much energy generation, 354 total generation with a maximum draw of 330 meaning it was running a surplus of 24 energy plus had energy storage on top. 
With this change the ship now performs better with the only expense being that it will need to make use of its upgraded battery in rare cases.
</details>

<details>
<summary>Hauler I</summary>

- Added "Capybara Reverse Thruster"

Straight Upgrade. Helps with moving, jumping, landing and escaping from pirates. Overall increases performance of ship at no cost.
</details>
<details>
<summary>Hauler II</summary>

- Downgraded 2 Meteor Missile Launchers to Missile Pods
- Added 3 Meteor Missile Boxes
- Added "Capybara Reverse Thruster"

Almost a straight upgrade, the two meteor missile pods are slightly less effective than the two launchers, but the total missile supply was kept almost unchanged thanks to the addition of three meteor missile boxes. However the introduction of the reverse thruster helps massively with the overall performance of the ship, increasing the speed of jumps, landing and makes escaping from combat a bit easier.
</details>
<details>
<summary>Hauler III</summary>

- Downgraded 2 Meteor Missile Launchers to Missile Pods
- Added 3 Meteor Missile Boxes
- Added "Capybara Reverse Thruster"

Almost a straight upgrade, the two meteor missile pods are slightly less effective than the two launchers, but the total missile supply was kept almost unchanged thanks to the addition of three meteor missile boxes. However the introduction of the reverse thruster helps massively with the overall performance of the ship, increasing the speed of jumps, landing and makes escaping from combat a bit easier.
</details>
<details>
<summary>Skein</summary>

- Downgraded Meteor Missile Launchers to Meteor Missile Pods
- Added a Meteor Missile Box
- Removed Large Radar Jammer
- Added Capybara Reverse Thruster

Added based on feedback in: https://github.com/endless-sky/endless-sky/pull/6710#issuecomment-1098653969
Skein as one of the largest FW warships is remarkably slow to maneuver, especially considering it's role as a carrier. Adding a reverse thruster greatly increases it's jump speed, landing speed, and combat maneuverability. The change to the meteor missile pods does reduce it's overall ammo capacity, however with the addition of the meteor missile box, the total capacity of meteor missiles only drops by 31.
Additionally, while the original Hauler design is designed for simplicity and thus a reverse thruster wouldn't be appropriate, the Skein is designed as a warship and a little extra complexity from reverse thrust is justifiable on such a large and important part of the FW fleet.
</details>


Notes:

- As these are simply tweaks to stock loadouts and not changes to the hull of the ships, this does not impact the limits of the player. If they wish to remove the reverse thrusters and add back weapons/reactors/cooling, they are free to do so.
- This PR does **not** add reverse engine flares, this is by intent. These outfits can be swapped between ships at will, and as such it does not make sense for one ship to have flares whereas the same outfit on a different ship doesn't have flares.
- I would suggest a sweeping change to all human ships to give all of them reverse flares at the same time in order to avoid this inconsistency. That would, however be a change outside the scope of this PR.
- Likewise, this PR is not currently editing Marauders or Variants. However if these changes are accepted, I will handle any Marauder and Variant changes in a separate PR

## Testing
I have confirmed that every one of these ships is displaying with the edited loadout in the appropriate shipyards
I have tested each ship to confirm that they are able to reverse as expected and that they still function in their intended role after the stock loadout changes. 

## Save File
This save file will place you on New Boston with every edited ship already in your fleet:
[Reverser.Test.Save.txt](https://github.com/endless-sky/endless-sky/files/8492179/Reverser.Test.Save.2.txt)




## PR Checklist
~~[X] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
~~[X] I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}~~
~~[X] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the @2x versions of these art assets: {{insert PR link}}~~