### PR TITLE
Greatly increase the amount of FW's salary + Make Recon's ending closer to Checkmate's

### DIFF
--- a/data/human/free worlds checkmate.txt
+++ b/data/human/free worlds checkmate.txt
@@ -772,10 +772,10 @@ mission "FWC Checkmate 1"
 		log "Defended Tundra against a major Navy counter-offensive. From here, the only recourse available to the Free Worlds seems to be to push deep into Republic territory and capture the Sol system, forcing the Navy to surrender. Nuclear weapons are now for sale on Solace to aid in the final assault."
 		event "fwc defended cebalrai"
 		event "fwc solace has nukes"
-		"salary: Free Worlds" = 6000
+		"salary: Free Worlds" = 17000
 		conversation
 			`Tomek and Alondo meet you when you land. Tomek says, "Good work aiding in the defense. Now we need to move before the Navy has time to regroup. And the Senate has decided that you will be in charge of the fleet that makes our counterattack."`
-			`	Alondo says, "They have also approved a salary increase for you, to six thousand credits per diem. I know that's probably still not enough, but we are running a bit low on cash."`
+			`	Alondo says, "They have also approved a salary increase for you, to 17 thousand credits per diem. I know that's probably still not enough, but we are running a bit low on cash."`
 			`	"One other thing," says Tomek. "I don't know how you'll feel about this, but I received word from Solace that they have nukes for sale if you want any. I'd advise against it, but it's up to you. Also, since you will be the flagship of our assault, you should make any improvements you feel are necessary to your ship. Then meet us back here, in the spaceport. Of course, if you're ready to go immediately that's fine, too."`
 
 
@@ -2340,13 +2340,12 @@ mission "FWC End"
 	destination Earth
 	to offer
 		has "FWC Pug 6: done"
+	passengers 1
+	blocked "You need at least one bunk free for Freya in order to continue this mission."
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
-		log "Parliament has agreed to a peace treaty, because the threat of alien invasion now seems much more pressing than the civil war with the Free Worlds. Whatever the true intention of the Pug was, the result of their interference is that humanity is at peace once more. There has been great loss of life, but nothing compared to what would have happened if the Free Worlds had tried to conquer Earth."
-		log "It may be a while before members of the Free Worlds manage to re-earn the trust of the rest of humanity, however."
-		log "Factions" "Free Worlds" `Tensions between the Free Worlds and the Republic mounted when additional systems decided to leave the Republic and join the Free Worlds culminating in a series of military confrontations, that ended when the Pug invaded human space. After humanity united to drive out the Pug invaders, the Republic officially granted the Free Worlds autonomy.`
 		"reputation: Republic" += 20
 		conversation
 			`You find Admiral Danforth inspecting the Pug spaceport. "This is all very odd," he says. "I'm glad the aliens appear to have left, but I wish we knew where they came from and whether they're likely to return."`
@@ -2365,8 +2364,12 @@ mission "FWC End"
 				accept
 	
 	on complete
+		log "Parliament has agreed to a peace treaty, because the threat of alien invasion now seems much more pressing than the civil war with the Free Worlds. Whatever the true intention of the Pug was, the result of their interference is that humanity is at peace once more. There has been great loss of life, but nothing compared to what would have happened if the Free Worlds had tried to conquer Earth."
+		log "It may be a while before members of the Free Worlds manage to re-earn the trust of the rest of humanity, however."
+		log "Factions" "Free Worlds" `Tensions between the Free Worlds and the Republic mounted when additional systems decided to leave the Republic and join the Free Worlds culminating in a series of military confrontations, that ended when the Pug invaded human space. After humanity united to drive out the Pug invaders, the Republic officially granted the Free Worlds autonomy.`
 		event "deep sky tech available"
 		event "syndicate tech available"
+		"salary: Free Worlds" = 8900
 		set "main plot completed"
 		set "free worlds plot completed"
 		set "free worlds checkmate"
@@ -2378,7 +2381,7 @@ mission "FWC End"
 			choice
 				`	"That's very generous of them."`
 				`	"I wonder if that's their way of buying our support and keeping us quiet about the supposed defector."`
-			`	"Maybe so," says Alondo. "Now, Captain, your salary will continue to be paid in gratitude for your service, but you are free to return to civilian life. What do you think you will do next?"`
+			`	"Maybe so," says Alondo. "In other news, now that the war has ended, and the Pug have been defeated, the Senate has voted to dissolve the Council, leaving us free to return to civilian life. However, they've also agreed to pay you, <first>, a reduced salary in honor of your service. So, what do you think you will do next?"`
 			choice
 				`	"Build a merchant fleet and live a safe, quiet life."`
 				`	"See if folks in the fringe worlds need any help against the pirates."`

--- a/data/human/free worlds intro.txt
+++ b/data/human/free worlds intro.txt
@@ -1787,7 +1787,7 @@ mission "FW Commitment"
 			`Soon after you land, a courier arrives at your ship and hands you a formal looking letter. It reads:`
 			``
 			`Dear Captain <last>,`
-			`	The Free Worlds Council would like to thank you for the invaluable assistance you have rendered to us recently. We are prepared to offer you a position as an officer in our militia, remaining in command of your own ship. Your starting salary will be 300 credits per diem. If you want to join us, please report to our headquarters on Bourne at your earliest convenience.`
+			`	The Free Worlds Council would like to thank you for the invaluable assistance you have rendered to us recently. We are prepared to offer you a position as an officer in our militia, remaining in command of your own ship. Your starting salary will be 1,100 credits per diem. If you want to join us, please report to our headquarters on Bourne at your earliest convenience.`
 			`	Sincerely,`
 			`				Tomek Voigt`
 			`				Jean-Jacques Soleau`
@@ -1922,7 +1922,7 @@ mission "Defend Sabik"
 	
 	on offer
 		set "license: Militia"
-		"salary: Free Worlds" = 300
+		"salary: Free Worlds" = 1100
 		event "start of hostilities"
 		event "joined the free worlds"
 		conversation

--- a/data/human/free worlds middle.txt
+++ b/data/human/free worlds middle.txt
@@ -705,7 +705,7 @@ mission "FW Southern Break"
 	on offer
 		log "Once again there is no immediate work to be done for the Free Worlds. This would be a good time to earn some money for an upgraded ship, if possible."
 		event "fw occupying the north" 50
-		"salary: Free Worlds" >?= 800
+		"salary: Free Worlds" >?= 2100
 		conversation
 			`You land on Dancer and report to Alondo and Freya that the prisoner transfer is complete. "What do we do now?" you ask.`
 			`	Freya says, "Well, I hope we're done with fighting for a while, now. We'll stay here to hold this system against any Navy retaliation. And, we'll keep hoping that Parliament might come to their senses and agree to a diplomatic end to this conflict. In the meantime I suggest you spend some time doing whatever it is you do to earn money on the side - carrying passengers or freight or hunting pirates. We'll contact you when things begin to move forward again."`
@@ -718,7 +718,7 @@ mission "FW Southern Break"
 			label salary
 			branch end
 				not "FW Pirates 4.1: offered"
-			`	"Before you leave, Captain," Freya says. "The Senate has decided to reinstate your pay after these recent events. You should now have a salary of 800 credits, just like before."`
+			`	"Before you leave, Captain," Freya says. "The Senate has decided to reinstate your pay after these recent events. You should now have a salary of 2,100 credits, just like before."`
 			
 			label end
 			`	Alondo gives you a nod. "We'll contact you as soon as things get interesting again."`
@@ -963,7 +963,7 @@ mission "FW Northern 3"
 		dialog `You land on <planet>, but realize that your escort carrying Freya hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		log "Agreed to become a member of the Free Worlds Council, taking Tomek's spot."
-		"salary: Free Worlds" = 2500
+		"salary: Free Worlds" = 6800
 		conversation
 			`As you are landing on <planet>, Freya says, "I miss Katya. It's hard being the only woman on the Council."`
 			choice

--- a/data/human/free worlds reconciliation.txt
+++ b/data/human/free worlds reconciliation.txt
@@ -1593,11 +1593,11 @@ mission "FW Pug 3B"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
-		"salary: Free Worlds" = 6000
+		"salary: Free Worlds" = 17000
 		conversation
 			`Freya meets you soon after you land. "I've heard the news," she says. "I talked to the Senate, and they think that I should travel with you during your assault on the Pug, in case I can help figure out their technology, maybe even how to restore the hyperspace links. And they say they need Alondo back here to do diplomatic visits and help keep people from panicking."`
 			`	"I guess that makes sense," says Alondo.`
-			`	"Also," says Freya, "the Senate approved a raise for you, <first>. Your new salary will be six thousand credits a day. I hope that means you'll be able to go into battle against the Pug with the strongest ship possible, because I suspect we'll need all the firepower we can get."`
+			`	"Also," says Freya, "the Senate approved a raise for you, <first>. Your new salary will be 17 thousand credits a day. I hope that means you'll be able to go into battle against the Pug with the strongest ship possible, because I suspect we'll need all the firepower we can get."`
 			`	Alondo wishes you the best of luck and leaves to catch a transport to Bourne, while Freya takes you to the spaceport and introduces you to the captains of the two Dreadnoughts that have volunteered to fight the Pug. She also asks you all sorts of technical questions: what sort of propulsion and energy sources the Pug seem to use, what their weapon capabilities are, and whether you saw any sign of the technology that was used to destroy the hyperspace links. You have a hard time answering her, but are glad that she will be with you this time to see the aliens firsthand.`
 				accept
 	
@@ -2551,23 +2551,50 @@ mission "FW Syndicate Extremists 1C"
 		log "Factions" "Syndicate" `It was exposed that the bombings of Gemini and Martini that helped cause the war between the Republic and Free Worlds were the doing of the Syndicate, designed by top executives with the help of a group of Alphas. Despite the claims that all the extremists responsible have been purged and handed over to the Navy, the reputation of the Syndicate will be damaged for years to come.`
 		payment 5000000
 		event "stack core for sale"
+		"salary: Free Worlds" = 8900
 		set "main plot completed"
 		set "free worlds plot completed"
 		set "free worlds reconciliation"
 		conversation
 			`On Earth, you return to something of a hero's welcome, far different from the first time you were here on a diplomatic mission. A crowd of locals gathers in the spaceport to watch your ship land. With the Free Worlds having been instrumental in defeating the aliens, and absolved of any guilt in the terrorist attacks, it seems that most people here are ready to see you as a hero rather than a criminal.`
+			`	Your meeting with Parliament is long and grueling, as they press you and Freya for every detail you can give them about the enigmatic Pug and their apparent motivation in invading human space. The questions about the Syndicate are equally hard to answer. But at the end of the session, one of the members of Parliament informs you that they have authorized an official commendation for you, along with a reward of five million credits "to cover any of your expenses from fighting the aliens."`
+			`	As you walk out, you find Alondo, JJ, and Katya sitting in the courtyard of Parliament. When they spot you walking towards them, JJ waves and says, "<first> and Freya! Am I glad to see the two of you still in one piece! What brings you to Earth?"`
+			choice
+				`	"I received a commendation from Parliament."`
+				`	"Parliament wanted to interrogate us on what happened with the Pug and the Syndicate."`
+					goto know
+				`	"We just needed to deal with some boring administrative stuff."`
+					goto bureaucratic
+			`	"And I'm sure that it was very well deserved," says Katya with a smirk.`
+				goto next
+			
+			label know
+			`	"I hope that they were nicer questioning you than they were to me," Katya says with a grin.`
+				goto next
+			
+			label bureaucratic
+			`	"Well," Katya says while smirking, "You'll be glad to know that you aren't alone in grappling with the bureaucracy."`
+			
+			label next
+			`	"What have you three been doing?" Freya asks.`
 			
 			branch good
 				has "event: navy out of rastaban"
-			`	You discover that Parliament has made a treaty with the Free Worlds, agreeing that the Navy will begin pulling out of any occupied systems, and that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, your war against the Republic is officially over.`
+			`	Alondo says, "We've been talking to Parliament, and they're finally beginning to let off of us. They have signed a treaty with the Free Worlds, agreeing that the Navy will begin pulling out of any occupied systems, and that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, our war against the Republic is officially over."`
 				goto end
 			
 			label good
-			`	You discover that Parliament has made a treaty with the Free Worlds, agreeing that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, your war against the Republic is officially over.`
+			`	Alondo says, "We've been talking to Parliament, and they're finally beginning to let off of us. They have signed a treaty with the Free Worlds, agreeing that the Free Worlds will be allowed autonomy in the region they currently control as long as they do not seek to expand their territory further. As of now, our war against the Republic is officially over."`
 			
 			label end
-			`	Your meeting with Parliament is long and grueling, as they press you and Freya for every detail you can give them about the enigmatic Pug and their apparent motivation in invading human space. The questions about the Syndicate are equally hard to answer. But at the end of the session, one of the members of Parliament informs you that they have authorized an official commendation for you, along with a reward of five million credits "to cover any of your expenses from fighting the aliens, and to help you integrate back into civilian life."`
-			`	The war is over; your work for the Free Worlds is at an end. What you do next is up to you...`
+			`	"What about you two?" says JJ. "How did fighting the Pug go?"`
+			`	You and Freya explain to the rest of the Council how the Pug were defeated, as well as the truth behind the Syndicate starting the war. When you finish, Katya says, "Vanishing aliens, prophetic supercomputers starting wars, Alphas pulling strings in the Syndicate's ranks; if I hadn't seen events just as unbelievable over the last few months, I would write what you're saying off as a bad conspiracy theory."`
+			`	"Well, it looks like the Council is all together again," says JJ, "for the last time, as it so happens. Now that the war has ended, and the Pug have been defeated, the Senate has voted to dissolve the Council, leaving us free to return to civilian life. However, they've also agreed to pay you, <first>, a reduced salary in gratitude of your service. So, what do you think you will do next?"`
+			choice
+				`	"Build a merchant fleet and live a safe, quiet life."`
+				`	"See if folks in the fringe worlds need any help against the pirates."`
+				`	"Use my jump drive to explore beyond human space."`
+			`	"Well, we all wish you the best of luck," says Freya. "We would never have gotten this far without you. Be sure to stay in touch." You hug each of them goodbye, and return to your ship. What you do next is up to you...`
 
 
 

--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -926,11 +926,11 @@ mission "FW Pirates 1"
 			
 			label agree
 			`	"So, here's the plan," he says. "These four systems belong to the pirates." He points to them on the map. "We want you to scout out all four systems. Just a quick fly-through, no need to land on their planets. Then report back to us, and we'll decide what our next step will be."`
-			`	As you are about to leave, he says, "Oh, one other thing: you've been approved for a salary raise to 800 credits. We figure that helping you maintain a slightly larger ship is a worthwhile investment. Congratulations, Captain."`
+			`	As you are about to leave, he says, "Oh, one other thing: you've been approved for a salary raise to 2,100 credits. We figure that helping you maintain a slightly larger ship is a worthwhile investment. Congratulations, Captain."`
 				accept
 	
 	on accept
-		"salary: Free Worlds" = 800
+		"salary: Free Worlds" = 2100
 	
 	on visit
 		dialog phrase "generic waypoint on visit"


### PR DESCRIPTION
## Salaries
As it stands, the salary that the Free Worlds campaign gives out is peanuts: the starter salary can't even cover the crew costs of an Argosy. Having passive sources of income be a decent chunk worse than active sources makes sense from a balance viewpoint, but across the board, salaries pay out negligible amounts (roughly converting 1 cargo space to 150 credits, the initial salary is around 7% of a Raven's earnings, the first pay rise is 10% of a Firebird's, the second is 18% of a Falcon's, and the final salary is 40% of a Dreadnought's) compared to the responsibilities involved (from a lore standpoint, you're no longer an independently operating captain and must put your life on the line protecting the Free Worlds; from a gameplay standpoint, 50% of the known galaxy wants to kill you).

### Reasoning
I've balanced the salary amounts to be equal to the crew costs of a ship the player might have at that point, plus some extra.
* Initial salary: 300 -> 1100
  * The new salary provides a net income of 600 credits when using a Raven, and is equal to 24% of it's cargo job income. It also provides a net income of 1000 credits when using something with less crew requirements, like the Headhunter, but that ship has more cargo space, so the whole salary works out to only being worth 14%.
* First salary increase: 800 -> 2100
  * This is a net income of 1200 credits when using an Osprey.
* Second salary increase: 2500 -> 6800
  * This is only a 1400 credit profit when using a Falcon, but rises to 2300 when using a Leviathan, 3300 when using a Protector, and 4600 in a Vanguard. Given that the Falcon is the most prominent civilian HW during the war, I felt it appropriate to prefer giving it a decent profit margin over balancing for the other Heavies, though the Falcon's income is still only marginally better than an Osprey at the first pay rise.
* Third salary increase: 6000 -> 17000
  * The third salary increase happens at an odd time during both paths: when the player gets it, they are on the cusp of fighting against the Pug. In lieu of this, I've raised the salary to make it easier for players who are struggling against the Pug to get enough credits to upgrade their ship.
* Final salary: 6000 -> 8900
  * Since the original final salary was increased by a large amount, I've added a final salary change to the final mission of each path. This salary is balanced around letting the player fly almost every configuration of a solo Dreadnought at no cost.

## Writing
The text in the endings of both paths have also been updated, not only to reflect the salary decrease, but to also to elaborate more on the events that occur shortly after the war, namely that the Council is dissolved (which otherwise only appears in Alondo's epilogue) and the player is no longer part of the Free Worlds proper (which is said in both paths, but in Recon, it's told to you by the Republic for some reason, and in Checkmate, it isn't explained why you're returning to civilian life). Hopefully the new explanations aren't too long-winded and clunky.

Additionally, the ending of Reconciliation has been rewritten to be closer to how Checkmate ends, with the Council meeting and saying their goodbyes on Earth. I've always felt that Checkmate's ending was more conclusive, probably in part due to MZ writing Checkmate after Recon. Bringing in the Council also makes it easier to explain how information regarding the dissolution of the Council can get to the player.

There's also some general fixes to the way Checkmate's ending is set up.