### PR TITLE
Tweak: Adjust intro mission dialogue to encourage a map purchase

### DIFF
--- a/data/intro missions.txt
+++ b/data/intro missions.txt
@@ -61,7 +61,7 @@ mission "Intro [0]"
 			`	"Great," he says. "My name is James, by the way."`
 			`	"<first> <last>," you say.`
 			`	"I'm looking forward to traveling with you, Captain <last>," says James.`
-			`	As you're helping him wheel his luggage aboard and showing him his bunk, he says, "Before we take off, you might head on over to the trading center and stock up on medical goods; we can sell those for a good profit on <planet>.  Also make sure to visit the local outfitter, while they don't sell much here compared to on the big manufacturing worlds, every world with an outfitter will at least carry a map with information on the neighboring systems, I'd suggest buying one so we don't get lost.`
+			`	As you're helping him wheel his luggage aboard and showing him his bunk, he says, "Before we take off, you might head on over to the trading center and stock up on medical goods; we can sell those for a good profit on <planet>.  Also make sure to visit the local outfitter, while they don't sell much here compared to on the big manufacturing worlds, every world with an outfitter will at least carry a map with information on the neighboring systems, I'd suggest buying one as it takes a bit of the guesswork out of navigation. It isn't a requirement, though: Some captains like exploring instead."`
 				accept
 	
 	on accept

--- a/data/intro missions.txt
+++ b/data/intro missions.txt
@@ -61,7 +61,7 @@ mission "Intro [0]"
 			`	"Great," he says. "My name is James, by the way."`
 			`	"<first> <last>," you say.`
 			`	"I'm looking forward to traveling with you, Captain <last>," says James.`
-			`	As you're helping him wheel his luggage aboard and showing him his bunk, he says, "Before we take off, you might head on over to the trading center and stock up on medical goods; we can sell those for a good profit on <planet>. Or take a look at the outfitter if you like, but they don't sell much here compared to on the big manufacturing worlds."`
+			`    As you're helping him wheel his luggage aboard and showing him his bunk, he says, "Before we take off, You might head on over to the trading center and stock up on medical goods; we can sell those for a good profit on <planet>.  Also make sure to visit the local outfitter, while they don't sell much here compared to on the big manufacturing worlds, every world with an outfitter will at least carry a map with information on the neighboring systems, I'd suggest buying one so we don't get lost.`
 				accept
 	
 	on accept
@@ -250,7 +250,7 @@ mission "Intro [2 Freighter]"
 				`	"Sounds good. Let's do it!"`
 				`	"Sorry, no way am I loading up my shiny new starship with smelly fish."`
 					decline
-			`	"Great!" he says. "You might want to stop by the outfitter and buy a local map, by the way. Hyperspace routes aren't always logical, and the last thing you want to do is get lost and end up with a pile of rotten fish that no one wants filling up your cargo hold."`
+			`	"Great!" he says. "I mentioned this earlier but you might want to stop by the outfitter and buy a local map. Hyperspace routes aren't always logical, and the last thing you want to do is get lost and end up with a pile of rotten fish that no one wants filling up your cargo hold."`
 				accept
 	
 	on complete

--- a/data/intro missions.txt
+++ b/data/intro missions.txt
@@ -61,7 +61,7 @@ mission "Intro [0]"
 			`	"Great," he says. "My name is James, by the way."`
 			`	"<first> <last>," you say.`
 			`	"I'm looking forward to traveling with you, Captain <last>," says James.`
-			`	As you're helping him wheel his luggage aboard and showing him his bunk, he says, "Before we take off, you might head on over to the trading center and stock up on medical goods; we can sell those for a good profit on <planet>.  Also make sure to visit the local outfitter, while they don't sell much here compared to on the big manufacturing worlds, every world with an outfitter will at least carry a map with information on the neighboring systems, I'd suggest buying one as it takes a bit of the guesswork out of navigation. It isn't a requirement, though: Some captains like exploring instead."`
+			`	As you're helping him wheel his luggage aboard and showing him his bunk, he says, "Before we take off, you might head on over to the trading center and stock up on medical goods; we can sell those for a good profit on <planet>. Also make sure to visit the local outfitter. While they don't sell much here compared to on the big manufacturing worlds, every world with an outfitter will at least carry a map with information on the neighboring systems. Buying them can help if you're not quite sure where you're going."`
 				accept
 	
 	on accept
@@ -250,7 +250,7 @@ mission "Intro [2 Freighter]"
 				`	"Sounds good. Let's do it!"`
 				`	"Sorry, no way am I loading up my shiny new starship with smelly fish."`
 					decline
-			`	"Great!" he says. "I mentioned this earlier but you might want to stop by the outfitter and buy a local map. Hyperspace routes aren't always logical, and the last thing you want to do is get lost and end up with a pile of rotten fish that no one wants filling up your cargo hold."`
+			`	"Great!" he says. "I mentioned this earlier, but you might want to stop by the outfitter and buy a local map. Hyperspace routes aren't always logical, and the last thing you want to do is get lost and end up with a pile of rotten fish that no one wants filling up your cargo hold."`
 				accept
 	
 	on complete

--- a/data/intro missions.txt
+++ b/data/intro missions.txt
@@ -61,7 +61,7 @@ mission "Intro [0]"
 			`	"Great," he says. "My name is James, by the way."`
 			`	"<first> <last>," you say.`
 			`	"I'm looking forward to traveling with you, Captain <last>," says James.`
-			`    As you're helping him wheel his luggage aboard and showing him his bunk, he says, "Before we take off, You might head on over to the trading center and stock up on medical goods; we can sell those for a good profit on <planet>.  Also make sure to visit the local outfitter, while they don't sell much here compared to on the big manufacturing worlds, every world with an outfitter will at least carry a map with information on the neighboring systems, I'd suggest buying one so we don't get lost.`
+			`	As you're helping him wheel his luggage aboard and showing him his bunk, he says, "Before we take off, you might head on over to the trading center and stock up on medical goods; we can sell those for a good profit on <planet>.  Also make sure to visit the local outfitter, while they don't sell much here compared to on the big manufacturing worlds, every world with an outfitter will at least carry a map with information on the neighboring systems, I'd suggest buying one so we don't get lost.`
 				accept
 	
 	on accept

--- a/data/start.txt
+++ b/data/start.txt
@@ -38,3 +38,5 @@ conversation "default intro"
 	name
 	`	The elevator is so well-tuned that you do not even realize it is moving until it has deposited you back in the lobby. But as you leave the bank, you are smiling. This crazy adventure suddenly feels real to you. You are going to do it. You are finally going to get off this planet.`
 	`	Compared to the bank, you feel much more at home in the shipyard, walking among the rusted out hulks and newer ships that gleam in the sunlight. You smell grease and dirt and rocket fuel; wonderful smells. There are three ship models within your price range. Which one you choose will determine your future...`
+	action
+		outfit "Local Map"

--- a/data/start.txt
+++ b/data/start.txt
@@ -38,5 +38,3 @@ conversation "default intro"
 	name
 	`	The elevator is so well-tuned that you do not even realize it is moving until it has deposited you back in the lobby. But as you leave the bank, you are smiling. This crazy adventure suddenly feels real to you. You are going to do it. You are finally going to get off this planet.`
 	`	Compared to the bank, you feel much more at home in the shipyard, walking among the rusted out hulks and newer ships that gleam in the sunlight. You smell grease and dirt and rocket fuel; wonderful smells. There are three ship models within your price range. Which one you choose will determine your future...`
-	action
-		outfit "Local Map"


### PR DESCRIPTION
**Content**

## Summary
~~This PR automatically adds a free local map to the player when starting a new game.~~
This PR is a tweak to the intro dialogue given by James, the player is now encouraged to visit the outfitter, rather than discouraged and is specifically told to buy a map.

This seeks to address a number of issues:

1. Many newer players find themselves unaware of the existence of the map, or what it does. 
2. Newer players often find themselves getting lost or unsure what to do upon starting a new game, ensuring that the player will purchase a map in order to reveal nearby systems helps to provide a good starting point while still leaving a lot of space for future exploration.

## Save File
N/A - New Save Required to access content

## Region Revealed
![image](https://user-images.githubusercontent.com/15916854/163275514-d136fb6a-af6f-413e-baf1-9e1b953c08ab.png)

## Testing Done
Started a new game and confirmed that the dialogue with James was updated accordingly.

## PR Checklist

-  ~~[x] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
-  ~~[x] I created a PR to the [endless-sky-assets repo](https://github.com/EndlessSkyCommunity/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}~~
-  ~~[x] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~