### PR TITLE
Tweak: Make Faction Capitals visible at game start

### DIFF
--- a/data/start.txt
+++ b/data/start.txt
@@ -38,3 +38,12 @@ conversation "default intro"
 	name
 	`	The elevator is so well-tuned that you do not even realize it is moving until it has deposited you back in the lobby. But as you leave the bank, you are smiling. This crazy adventure suddenly feels real to you. You are going to do it. You are finally going to get off this planet.`
 	`	Compared to the bank, you feel much more at home in the shipyard, walking among the rusted out hulks and newer ships that gleam in the sunlight. You smell grease and dirt and rocket fuel; wonderful smells. There are three ship models within your price range. Which one you choose will determine your future...`
+	action
+		event "default intro: map reveal"
+
+event "default intro: map reveal"
+	visit "Sol"
+	visit "Epsilon Leonis"
+	visit "Achernar"
+	visit "Tarazed"
+	visit "Gamma Corvi"


### PR DESCRIPTION
**Content**
## Summary
This PR seeks to address several issues regarding early-game exploration:

1. Many newer players find themselves confused regarding the unintuitive layout of the current map, where a direct route to your destination often has you reach an impassable void of space, requiring backtracking which is a poor player experience.
2. Newer players are often placed into a situation in the early game where they've finished the tutorial and aren't sure about what to do or where to go in order to progress.
3. Several "lore concerns" are repeatedly brought up stating that it is strange for the PC to not know about these important systems which should be well known to most people.

This PR, therefore, automatically reveals four faction "capitals" around the map, namely:

1. Sol - Republic Capital
2. Epsilon Leonis - Deep Capital
3. Achernar - Syndicate Capital
4. Tarazed - Home to Tarazed corporation / Quarg
5. Gamma Corvi - Free Worlds Capital

These systems were picked for being important systems in-lore, as well as being near to the edges of human space, helping to define the overall shape of the galaxy for newer players.

This seeks to alleviate the issues mentioned above by helping newer players get a better grasp as to the overall galaxy layout while still allowing plenty of room to explore and "get lost", it also ensures that no systems near to any "secrets" such as the Remnant or Hai wormholes are revealed by default.

Additionally, having these systems revealed at the start of the game suggests several important areas of the map for the player to explore, two of which are good locations to start off mission chains, one will introduce the player to the Quarg and the other two are planned to be involved in campaigns.

Finally, revealing these systems at game start helps to resolve the "lore concerns" that are often brought up as to why human space, which should be well explored and documented at this point, is completely unknown to the PC

## Save File
N/A - New Save Required

## Region Revealed
![image](https://user-images.githubusercontent.com/15916854/163279979-9eaa839f-3593-4a5f-8426-6fad4e1fd539.png)


## Testing Done
Started a new game and confirmed that these systems were revealed. 
It appears as though there is no way to have the systems be revealed until after the player has launched from their starting planet, so the map will not update until after launch.

## Note
Consider this a sister PR to #6715 both PRs seek to alleviate the same issues, but do so in separate ways. I believe that both could be merged, however I have split them up to allow one or the other or both to be merged based on feedback

## PR Checklist
 - ~~[x] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
 - ~~[x] I created a PR to the [endless-sky-assets repo](https://github.com/EndlessSkyCommunity/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}~~
 - ~~[x] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~