### PR TITLE
Bugfix: Prevent some Hai missions on Darkwaste

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -12,7 +12,7 @@ mission "First Contact: Hai"
 	landing
 	source
 		government "Hai"
-		not planet "Darkwaste"
+		not attributes "uninhabitated"
 	on offer
 		conversation
 			branch unfettered
@@ -252,7 +252,7 @@ mission "Ask the Hai about the Unfettered"
 	landing
 	source
 		government "Hai"
-		not planet "Darkwaste"
+		not attributes "uninhabitated"
 	to offer
 		has "First Contact: Hai: offered"
 		has "First Contact: Unfettered: offered"

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -12,6 +12,7 @@ mission "First Contact: Hai"
 	landing
 	source
 		government "Hai"
+		not planet "Darkwaste"
 	on offer
 		conversation
 			branch unfettered
@@ -251,6 +252,7 @@ mission "Ask the Hai about the Unfettered"
 	landing
 	source
 		government "Hai"
+		not planet "Darkwaste"
 	to offer
 		has "First Contact: Hai: offered"
 		has "First Contact: Unfettered: offered"

--- a/data/map.txt
+++ b/data/map.txt
@@ -26898,6 +26898,7 @@ planet Darkstone
 		fleet "Small Militia" 18
 
 planet Darkwaste
+	attributes uninhabited
 	landscape land/canyon10-harro
 	description `This planet seems to have all the conditions necessary for a vibrant, Earth-like ecology. The gravity and temperature are moderate, and there is a fair amount of surface water, although the oceans are quite small. However, aside from a few stunted plants and lichen, there is almost no native life here. Given how skilled the Hai appear to be at terraforming other worlds, it is strange that this one has been left barren.`
 


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported on the [discord](https://discord.com/channels/251118043411775489/460556878334918657/964308597028814858).

## Fix Details
Added `not planet "Darkwaste"` to "First Contact: Hai" and "Ask the Hai about the Unfettered". An alternate fix could be to make Darkwaste not a Hai planet, but I'll leave that decision up to someone else.

## Testing Done
Landed on Darkwaste before any other Hai planet. Then landed on another Hai world and then an unfettered world, before landing back on Darkwaste.

## Save File
[Hai Testman.txt](https://github.com/endless-sky/endless-sky/files/8493882/Hai.Testman.txt)
You start on Prime with a Scout with a Jump Drive and 7 fuel processors, and some Hai and Unfettered territory mapped. This isn't exactly the most optimal ship build for this test, you might die a few times trying to land/leave an Unfettered world.