### PR TITLE
Fix ammo capacity not matching installed ammo on several ships

### DIFF
--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -615,7 +615,7 @@ ship "Marauder Manta"
 		"Plasma Cannon" 2
 		"Particle Cannon" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile" 60
 		"Quad Blaster Turret"
 		
 		"Dwarf Core"
@@ -653,7 +653,7 @@ ship "Marauder Manta" "Marauder Manta (Engines)"
 	outfits
 		"Plasma Cannon" 4
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile" 60
 		"Quad Blaster Turret"
 		
 		"Dwarf Core"
@@ -688,7 +688,7 @@ ship "Marauder Manta" "Marauder Manta (Weapons)"
 		"Particle Cannon" 2
 		"Proton Gun" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 70
+		"Meteor Missile" 60
 		"Heavy Anti-Missile Turret"
 		
 		"Fission Reactor"

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -212,7 +212,7 @@ ship "Auxiliary"
 			"hit force" 4200
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 100
+		"Sidewinder Missile" 90
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1123,7 +1123,7 @@ ship "Fury" "Fury (Flamethrower)"
 ship "Fury" "Fury (Gatling)"
 	outfits
 		"Gatling Gun" 4
-		"Gatling Gun Ammo" 6000
+		"Gatling Gun Ammo" 12000
 		"nGVF-CC Fuel Cell"
 		"Supercapacitor"
 		"D23-QP Shield Generator"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1123,7 +1123,7 @@ ship "Fury" "Fury (Flamethrower)"
 ship "Fury" "Fury (Gatling)"
 	outfits
 		"Gatling Gun" 4
-		"Gatling Gun Ammo" 12000
+		"Gatling Gun Ammo" 6000
 		"nGVF-CC Fuel Cell"
 		"Supercapacitor"
 		"D23-QP Shield Generator"


### PR DESCRIPTION
## Fix Details
~~Three~~ Two ships, the Marauder Manta, Auxiliary ~~and the Gatling variant of the Fury~~ had more/less ammo than their ammo capacity would allow, this PR fixes that.

<details>
<summary>Marauder Manta had 60 Meteor capacity but 70 Meteors installed</summary>

![image](https://user-images.githubusercontent.com/15916854/163659958-8100d50e-bf3e-4066-b6d2-b0d33d905787.png)

</details>


<details>
<summary>Auxiliary had 90 Sidewinder capacity but 100 Sidewinders installed</summary>

![image](https://user-images.githubusercontent.com/15916854/163659989-7464f3fb-da97-46e4-804a-4dc02694fc08.png)

</details>


## Testing Done
Purchased each ship and added as much ammo as possible and confirmed that it matched the new ammo amounts.

## Save File
This save file will place you on New Boston with all of the edited ships already in your fleet.
[Ammo Fix.txt](https://github.com/endless-sky/endless-sky/files/8499177/Ammo.Fix.txt)

## Note:
I also noticed two Person ships had too much ammo installed for their capacity:
Modified Osprey has 80 Finisher Capacity but has 200 Finishers installed
Marauder Fury has 120 Meteor Capacity but has 140 Meteors installed. 

I left them alone because they're person ships, but I can commit a "fix" for them if desired.