### PR TITLE
Add "visualStart" to Fix Effect Placement Bug

### DIFF
--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -213,23 +213,19 @@ void Hardpoint::Fire(Ship &ship, vector<Projectile> &projectiles, vector<Visual>
 	// Since this is only called internally by Armament (no one else has non-
 	// const access), assume Armament checked that this is a valid call.
 	Angle aim = ship.Facing();
-
-	// Get projectiles to start at the right position. They are drawn at an
-	// offset of (.5 * velocity) and that velocity includes the velocity of the
-	// ship that fired them.
-	Point start = ship.Position() + aim.Rotate(point) - .5 * ship.Velocity();
-	Point visualStart = ship.Position() + aim.Rotate(point);
+	Point start = ship.Position() + aim.Rotate(point);
 
 	// Apply the aim and hardpoint offset.
 	aim += angle;
 	start += aim.Rotate(outfit->HardpointOffset());
-	visualStart += aim.Rotate(outfit->HardpointOffset());
 
 	// Create a new projectile, originating from this hardpoint.
-	projectiles.emplace_back(ship, start, aim, outfit);
+	// In order to get projectiles to start at the right position they are drawn
+	// at an offset of (.5 * velocity). See BatchDrawList.cpp for more details.
+	projectiles.emplace_back(ship, start - .5 * ship.Velocity(), aim, outfit);
 
 	// Create any effects this weapon creates when it is fired.
-	CreateEffects(outfit->FireEffects(), visualStart, ship.Velocity(), aim, visuals);
+	CreateEffects(outfit->FireEffects(), start, ship.Velocity(), aim, visuals);
 
 	// Update the reload and burst counters, and expend ammunition if applicable.
 	Fire(ship, start, aim);

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -223,6 +223,7 @@ void Hardpoint::Fire(Ship &ship, vector<Projectile> &projectiles, vector<Visual>
 	// Apply the aim and hardpoint offset.
 	aim += angle;
 	start += aim.Rotate(outfit->HardpointOffset());
+	visualStart += aim.Rotate(outfit->HardpointOffset());
 
 	// Create a new projectile, originating from this hardpoint.
 	projectiles.emplace_back(ship, start, aim, outfit);

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -218,6 +218,7 @@ void Hardpoint::Fire(Ship &ship, vector<Projectile> &projectiles, vector<Visual>
 	// offset of (.5 * velocity) and that velocity includes the velocity of the
 	// ship that fired them.
 	Point start = ship.Position() + aim.Rotate(point) - .5 * ship.Velocity();
+	Point visualStart = ship.Position() + aim.Rotate(point);
 
 	// Apply the aim and hardpoint offset.
 	aim += angle;
@@ -227,7 +228,7 @@ void Hardpoint::Fire(Ship &ship, vector<Projectile> &projectiles, vector<Visual>
 	projectiles.emplace_back(ship, start, aim, outfit);
 
 	// Create any effects this weapon creates when it is fired.
-	CreateEffects(outfit->FireEffects(), start, ship.Velocity(), aim, visuals);
+	CreateEffects(outfit->FireEffects(), visualStart, ship.Velocity(), aim, visuals);
 
 	// Update the reload and burst counters, and expend ammunition if applicable.
 	Fire(ship, start, aim);


### PR DESCRIPTION
**Bugfix:** This PR addresses the long-standing issue (in #5857 and lesser-so mentioned elsewhere) that many effects are placed incorrectly at high velocities. (Well, at any velocity other than 0, but the error is proportional with velocity)

## Fix Details
Adds a sister Point variable, "visualStart", which mirrors "start", without the -0.5x velocity compensation. This fixes the issue!
I do not think this change has _any_ wider consequences other than fixing this visual bug. Might as well push this to master, no?

## Testing Done
![image](https://user-images.githubusercontent.com/35383563/164551383-47c29f1d-b357-4970-bba9-b727e669b34f.png)
![image](https://user-images.githubusercontent.com/35383563/164551408-8ff10494-8405-4f9a-8570-ae10f9d0056e.png)
(Mind the plugin content, but this is before and after the change. Notice the streaky stars in the background, we're moving very quickly here.)

## Save File
[bee person.txt](https://github.com/endless-sky/endless-sky/files/8544746/bee.person.txt)
Use this save file, take off from Trinket in the modified (low-drag) Emerald Sword, pick up speed and fire the Dragonflame Cannon to observe whether or not the _effect_ which replaces a projectile is placed correctly. This is my personal all-content save file for testing things, so it might be a little bloated. This save file will work without any plugins- the changes to the ES are in the save file, as all owned ship data is.