### PR TITLE
Smarter Appeasement

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -663,15 +663,8 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 				const auto enemies = GetShipsList(*it, true);
 				// Check if any of them are currently capable of firing
 				// on this ship, with a slight buffer
-				bool dangerousEnemy = false;
-				for(const auto &enemy : enemies)
-				{
-					if(!enemy->IsDisabled() && enemy->GetTargetShip() == it)
-					{
-						dangerousEnemy = true;
-						break;
-					}
-				}
+				bool isTargeted = enemies.end() != find_if(enemies.begin(), enemies.end(), [&it](const Ship *foe)
+						{ return !foe->IsDisabled() && foe->GetTargetShip() == it; });
 				// In addition to the checking for a significant loss of health,
 				// make sure someone is targeting you
 				if(1. - health > threshold && dangerousEnemy)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -664,20 +664,16 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 				// Check if any of them are currently capable of firing
 				// on this ship, with a slight buffer
 				bool dangerousEnemy = false;
-				int buffer = 500;
 				for(const auto &enemy : enemies)
 				{
-					double enemyMaxRange = 0.;
-					enemyMaxRange = GetMaxRange(enemy->Weapons());
-					double enemyDistance = enemy->Position().Distance(it->Position());
-					if((enemyMaxRange + buffer) >= enemyDistance && !enemy->IsDisabled())
+					if(!enemy->IsDisabled() && enemy->GetTargetShip() == it)
 					{
 						dangerousEnemy = true;
 						break;
 					}
 				}
 				// In addition to the checking for a significant loss of health,
-				// make sure there is someone around to appease
+				// make sure someone is targeting you
 				if(1. - health > threshold && dangerousEnemy)
 				{
 					int toDump = 11 + (1. - health) * .5 * it->Cargo().Size();

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -479,7 +479,7 @@ void AI::Clean()
 	miningAngle.clear();
 	miningRadius.clear();
 	miningTime.clear();
-	appeasmentThreshold.clear();
+	appeasementThreshold.clear();
 	shipStrength.clear();
 	enemyStrength.clear();
 	allyStrength.clear();
@@ -571,7 +571,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 				if(personality.IsAppeasing())
 				{
 					double health = .5 * it->Shields() + it->Hull();
-					double &threshold = appeasmentThreshold[it.get()];
+					double &threshold = appeasementThreshold[it.get()];
 					threshold = max((1. - health) + .1, threshold);
 				}
 				continue;
@@ -656,32 +656,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 			}
 			// Appeasing ships jettison cargo to distract their pursuers.
 			if(personality.IsAppeasing() && it->Cargo().Used())
-			{
-				double health = .5 * it->Shields() + it->Hull();
-				double &threshold = appeasmentThreshold[it.get()];
-				if(1. - health > threshold)
-				{
-					// In addition to checking for a significant loss of health,
-					// make sure someone is targeting you
-					const auto enemies = GetShipsList(*it, true);
-					bool isTargeted = enemies.end() != find_if(enemies.begin(), enemies.end(), [&it](const Ship *foe)
-							{ return !foe->IsDisabled() && foe->GetTargetShip() == it; });
-					if(isTargeted)
-					{
-						int toDump = 11 + (1. - health) * .5 * it->Cargo().Size();
-						for(const auto &commodity : it->Cargo().Commodities())
-							if(commodity.second && toDump > 0)
-							{
-								int dumped = min(commodity.second, toDump);
-								it->Jettison(commodity.first, dumped, true);
-								toDump -= dumped;
-							}
-						Messages::Add(gov->GetName() + " " + it->Noun() + " \"" + it->Name()
-							+ "\": Please, just take my cargo and leave me alone.", Messages::Importance::High);
-						threshold = (1. - health) + .1;
-					}
-				}
-			}
+				DoAppeasing(it, &appeasementThreshold[it.get()]);
 		}
 
 		// If recruited to assist a ship, follow through on the commitment
@@ -1266,7 +1241,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	// Player ships never stop targeting hostiles, while hostile mission NPCs will
 	// do so only if they are allowed to leave.
 	if(!isYours && target && target->GetGovernment()->IsEnemy(gov) && !isDisabled
-			&& (person.IsFleeing() || (ship.Health() < (RETREAT_HEALTH + .25 * person.IsCoward()) 
+			&& (person.IsFleeing() || (ship.Health() < (RETREAT_HEALTH + .25 * person.IsCoward())
 			&& !person.IsHeroic() && !person.IsStaying() && !parentIsEnemy)))
 	{
 		// Make sure the ship has somewhere to flee to.
@@ -2232,6 +2207,35 @@ bool AI::ShouldUseAfterburner(Ship &ship)
 		return true;
 
 	return false;
+}
+
+
+
+// "Appeasing" ships will dump cargo after being injured, if they are being targeted.
+void AI::DoAppeasing(const shared_ptr<Ship> &ship, double *threshold) const
+{
+	double health = .5 * ship->Shields() + ship->Hull();
+	if(1. - health <= *threshold)
+		return;
+
+	const auto enemies = GetShipsList(*ship, true);
+	if(none_of(enemies.begin(), enemies.end(), [&ship](const Ship *foe) noexcept -> bool
+			{ return !foe->IsDisabled() && foe->GetTargetShip() == ship; }))
+		return;
+
+	int toDump = 11 + (1. - health) * .5 * ship->Cargo().Size();
+	for(auto &&commodity : ship->Cargo().Commodities())
+		if(commodity.second && toDump > 0)
+		{
+			int dumped = min(commodity.second, toDump);
+			ship->Jettison(commodity.first, dumped, true);
+			toDump -= dumped;
+		}
+
+	Messages::Add(ship->GetGovernment()->GetName() + " " + ship->Noun() + " \"" + ship->Name()
+		+ "\": Please, just take my cargo and leave me alone.", Messages::Importance::Low);
+
+	*threshold = (1. - health) + .1;
 }
 
 
@@ -3851,7 +3855,7 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 
 			gaveOrder = true;
 			hasMismatch |= !orders.count(ship);
-			
+
 			Orders &existing = orders[ship];
 			// HOLD_ACTIVE cannot be given as manual order, but we make sure here
 			// that any HOLD_ACTIVE order also matches when an HOLD_POSITION

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -659,7 +659,11 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 			{
 				double health = .5 * it->Shields() + it->Hull();
 				double &threshold = appeasmentThreshold[it.get()];
-				if(1. - health > threshold)
+				// Get the list of hostile (enemy) in the system
+				const auto enemies = GetShipsList(*it, true);
+				// In addition to the checking for a significant loss of health,
+				// make sure there is someone around to appease
+				if(1. - health > threshold && enemies.size() > 0)
 				{
 					int toDump = 11 + (1. - health) * .5 * it->Cargo().Size();
 					for(const auto &commodity : it->Cargo().Commodities())

--- a/source/AI.h
+++ b/source/AI.h
@@ -16,7 +16,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Command.h"
 #include "FireCommand.h"
 #include "Point.h"
-#include "Hardpoint.h"
 
 #include <cstdint>
 #include <list>
@@ -108,6 +107,7 @@ private:
 	// Special decisions a ship might make.
 	static bool ShouldUseAfterburner(Ship &ship);
 	// Special personality behaviors.
+	void DoAppeasing(const std::shared_ptr<Ship> &ship, double *threshold) const;
 	void DoSwarming(Ship &ship, Command &command, std::shared_ptr<Ship> &target);
 	void DoSurveillance(Ship &ship, Command &command, std::shared_ptr<Ship> &target) const;
 	void DoMining(Ship &ship, Command &command);
@@ -178,7 +178,6 @@ private:
 	void UpdateOrders(const Ship &ship);
 
 
-
 private:
 	// Data from the game engine.
 	const List<Ship> &ships;
@@ -222,7 +221,7 @@ private:
 	std::map<const Ship *, Angle> miningAngle;
 	std::map<const Ship *, double> miningRadius;
 	std::map<const Ship *, int> miningTime;
-	std::map<const Ship *, double> appeasmentThreshold;
+	std::map<const Ship *, double> appeasementThreshold;
 
 	std::map<const Ship *, int64_t> shipStrength;
 

--- a/source/AI.h
+++ b/source/AI.h
@@ -176,14 +176,6 @@ private:
 	void IssueOrders(const PlayerInfo &player, const Orders &newOrders, const std::string &description);
 	// Convert order types based on fulfillment status.
 	void UpdateOrders(const Ship &ship);
-	// Get the max range of a list of weapons (usually a ship's weapons) excluding any AMs
-	double GetMaxRange(const std::vector<Hardpoint> &weapons) const;
-	// Overload and add the option to specificy forward facing guns or turrets only
-	double GetMaxRange(const std::vector<Hardpoint> &weapons, bool aimable) const;
-	// Get the min range of a list of weapons (usually a ship's weapons) excluding any AMs
-	double GetMinRange(const std::vector<Hardpoint> &weapons) const;
-	// Overload and add the option to specificy forward facing guns or turrets only
-	double GetMinRange(const std::vector<Hardpoint> &weapons, bool aimable) const;
 
 
 

--- a/source/AI.h
+++ b/source/AI.h
@@ -16,6 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Command.h"
 #include "FireCommand.h"
 #include "Point.h"
+#include "Hardpoint.h"
 
 #include <cstdint>
 #include <list>
@@ -175,6 +176,15 @@ private:
 	void IssueOrders(const PlayerInfo &player, const Orders &newOrders, const std::string &description);
 	// Convert order types based on fulfillment status.
 	void UpdateOrders(const Ship &ship);
+	// Get the max range of a list of weapons (usually a ship's weapons) excluding any AMs
+	double GetMaxRange(const std::vector<Hardpoint> &weapons) const;
+	// Overload and add the option to specificy forward facing guns or turrets only
+	double GetMaxRange(const std::vector<Hardpoint> &weapons, bool aimable) const;
+	// Get the min range of a list of weapons (usually a ship's weapons) excluding any AMs
+	double GetMinRange(const std::vector<Hardpoint> &weapons) const;
+	// Overload and add the option to specificy forward facing guns or turrets only
+	double GetMinRange(const std::vector<Hardpoint> &weapons, bool aimable) const;
+
 
 
 private:


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6720

## Fix Details
Following Amazinite's suggestion in #6720, I made hostiles being in the system a requirement for dumping cargo.  Vitalchip suggested I added a proximity check as well as a disabled check.  The proximity check is based on each individual enemy's max weapons range plus a small buffer (currently 500).

## Testing Done
I observed Remnant ships in the Ember Wastes ion storms with and without Korath ships in the system and they don't surrender their cargo to empty space anymore.  It is difficult to tell for certain if the buffer works perfectly, but I do know the range to distance comparison has an effect because when I was writing the changes I had my buffer (which was comically large because testing) on the wrong side of the comparison and it never triggered.  Do note that if a Korath ship is also affected by the storm and even drifting, it will not count as disabled and will still trigger a cargo dump.

## ~~Save File~~ Map File
This map file ([map.txt](https://github.com/endless-sky/endless-sky/files/8546109/map.txt)) can be used to increase the frequency of ion storms, Korath ships, and Remnant ships in Arculus and increase the frequency of ion storms and Remnant ships in Edusa to more easily verify the bugfix. The bug will occur when using continuous, and will not occur when using this branch's build.