### PR TITLE
Support the Home and End keys in the panels

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -271,23 +271,31 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		else
 			plunder[selected].Take(count);
 	}
-	else if((key == SDLK_UP || key == SDLK_DOWN || key == SDLK_PAGEUP || key == SDLK_PAGEDOWN) && !isCapturing)
+	else if((key == SDLK_UP || key == SDLK_DOWN || key == SDLK_PAGEUP
+			|| key == SDLK_PAGEDOWN || key == SDLK_HOME || key == SDLK_END)
+			&& !isCapturing)
 	{
 		// Scrolling the list of plunder.
 		if(key == SDLK_PAGEUP || key == SDLK_PAGEDOWN)
-			Drag(0, 200 * ((key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP)));
+			// With 220 px of content and 20 px height per line, there are 11 lines.
+			selected += 11 * ((key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP));
+		else if(key == SDLK_HOME)
+			selected = 0;
+		else if(key == SDLK_END)
+			selected = static_cast<int>(plunder.size() - 1);
 		else
 		{
-			if(key == SDLK_UP && selected)
+			if(key == SDLK_UP)
 				--selected;
-			else if(key == SDLK_DOWN && selected < static_cast<int>(plunder.size() - 1))
+			else if(key == SDLK_DOWN)
 				++selected;
-
-			// Scroll down at least far enough to view the current item.
-			double minimumScroll = max(0., 20. * selected - 200.);
-			double maximumScroll = 20. * selected;
-			scroll = max(minimumScroll, min(maximumScroll, scroll));
 		}
+		selected = max(0, min(static_cast<int>(plunder.size() - 1), selected));
+
+		// Scroll down at least far enough to view the current item.
+		double minimumScroll = max(0., 20. * selected - 200.);
+		double maximumScroll = 20. * selected;
+		scroll = max(minimumScroll, min(maximumScroll, scroll));
 	}
 	else if(key == 'c' && CanCapture())
 	{

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -274,33 +274,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 	else if((key == SDLK_UP || key == SDLK_DOWN || key == SDLK_PAGEUP
 			|| key == SDLK_PAGEDOWN || key == SDLK_HOME || key == SDLK_END)
 			&& !isCapturing)
-	{
-		// Scrolling the list of plunder.
-		if(key == SDLK_PAGEUP || key == SDLK_PAGEDOWN)
-			// With 220 px of content and 20 px height per line, there are 11
-			// lines. However, although some programs scroll a whole page
-			// (e.g. most KDE programs) it seems to be more common to scroll a
-			// bit less than a whole page (e.g. the most used browsers or
-			// common IDEs), so scroll only 10 lines.
-			selected += 10 * ((key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP));
-		else if(key == SDLK_HOME)
-			selected = 0;
-		else if(key == SDLK_END)
-			selected = static_cast<int>(plunder.size() - 1);
-		else
-		{
-			if(key == SDLK_UP)
-				--selected;
-			else if(key == SDLK_DOWN)
-				++selected;
-		}
-		selected = max(0, min(static_cast<int>(plunder.size() - 1), selected));
-
-		// Scroll down at least far enough to view the current item.
-		double minimumScroll = max(0., 20. * selected - 200.);
-		double maximumScroll = 20. * selected;
-		scroll = max(minimumScroll, min(maximumScroll, scroll));
-	}
+		DoKeyboardNavigation(key);
 	else if(key == 'c' && CanCapture())
 	{
 		// A ship that self-destructs checks once when you board it, and again
@@ -513,6 +487,37 @@ bool BoardingPanel::CanCapture() const
 bool BoardingPanel::CanAttack() const
 {
 	return isCapturing;
+}
+
+
+// Handle the keyboard scrolling and selection in the panel list.
+void BoardingPanel::DoKeyboardNavigation(const SDL_Keycode key)
+{
+		// Scrolling the list of plunder.
+		if(key == SDLK_PAGEUP || key == SDLK_PAGEDOWN)
+			// With 220 px of content and 20 px height per line, there are 11
+			// lines. However, although some programs scroll a whole page
+			// (e.g. most KDE programs) it seems to be more common to scroll a
+			// bit less than a whole page (e.g. the most used browsers or
+			// common IDEs), so scroll only 10 lines.
+			selected += 10 * ((key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP));//TODO scroll richtig aendern
+		else if(key == SDLK_HOME)
+			selected = 0;
+		else if(key == SDLK_END)
+			selected = static_cast<int>(plunder.size() - 1);
+		else
+		{
+			if(key == SDLK_UP)
+				--selected;
+			else if(key == SDLK_DOWN)
+				++selected;
+		}
+		selected = max(0, min(static_cast<int>(plunder.size() - 1), selected));
+
+		// Scroll down at least far enough to view the current item.
+		double minimumScroll = max(0., 20. * selected - 200.);
+		double maximumScroll = 20. * selected;
+		scroll = max(minimumScroll, min(maximumScroll, scroll));
 }
 
 

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -271,9 +271,9 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		else
 			plunder[selected].Take(count);
 	}
-	else if((key == SDLK_UP || key == SDLK_DOWN || key == SDLK_PAGEUP
-			|| key == SDLK_PAGEDOWN || key == SDLK_HOME || key == SDLK_END)
-			&& !isCapturing)
+	else if(!isCapturing &&
+			(key == SDLK_UP || key == SDLK_DOWN || key == SDLK_PAGEUP
+			|| key == SDLK_PAGEDOWN || key == SDLK_HOME || key == SDLK_END))
 		DoKeyboardNavigation(key);
 	else if(key == 'c' && CanCapture())
 	{
@@ -493,31 +493,27 @@ bool BoardingPanel::CanAttack() const
 // Handle the keyboard scrolling and selection in the panel list.
 void BoardingPanel::DoKeyboardNavigation(const SDL_Keycode key)
 {
-		// Scrolling the list of plunder.
-		if(key == SDLK_PAGEUP || key == SDLK_PAGEDOWN)
-			// With 220 px of content and 20 px height per line, there are 11
-			// lines. However, although some programs scroll a whole page
-			// (e.g. most KDE programs) it seems to be more common to scroll a
-			// bit less than a whole page (e.g. the most used browsers or
-			// common IDEs), so scroll only 10 lines.
-			selected += 10 * ((key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP));//TODO scroll richtig aendern
-		else if(key == SDLK_HOME)
-			selected = 0;
-		else if(key == SDLK_END)
-			selected = static_cast<int>(plunder.size() - 1);
-		else
-		{
-			if(key == SDLK_UP)
-				--selected;
-			else if(key == SDLK_DOWN)
-				++selected;
-		}
-		selected = max(0, min(static_cast<int>(plunder.size() - 1), selected));
+	// Scrolling the list of plunder.
+	if(key == SDLK_PAGEUP || key == SDLK_PAGEDOWN)
+		// Keep one of the previous items onscreen while paging through.
+		selected += 10 * ((key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP));
+	else if(key == SDLK_HOME)
+		selected = 0;
+	else if(key == SDLK_END)
+		selected = static_cast<int>(plunder.size() - 1);
+	else
+	{
+		if(key == SDLK_UP)
+			--selected;
+		else if(key == SDLK_DOWN)
+			++selected;
+	}
+	selected = max(0, min(static_cast<int>(plunder.size() - 1), selected));
 
-		// Scroll down at least far enough to view the current item.
-		double minimumScroll = max(0., 20. * selected - 200.);
-		double maximumScroll = 20. * selected;
-		scroll = max(minimumScroll, min(maximumScroll, scroll));
+	// Scroll down at least far enough to view the current item.
+	double minimumScroll = max(0., 20. * selected - 200.);
+	double maximumScroll = 20. * selected;
+	scroll = max(minimumScroll, min(maximumScroll, scroll));
 }
 
 

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -277,8 +277,12 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 	{
 		// Scrolling the list of plunder.
 		if(key == SDLK_PAGEUP || key == SDLK_PAGEDOWN)
-			// With 220 px of content and 20 px height per line, there are 11 lines.
-			selected += 11 * ((key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP));
+			// With 220 px of content and 20 px height per line, there are 11
+			// lines. However, although some programs scroll a whole page
+			// (e.g. most KDE programs) it seems to be more common to scroll a
+			// bit less than a whole page (e.g. the most used browsers or
+			// common IDEs), so scroll only 10 lines.
+			selected += 10 * ((key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP));
 		else if(key == SDLK_HOME)
 			selected = 0;
 		else if(key == SDLK_END)

--- a/source/BoardingPanel.h
+++ b/source/BoardingPanel.h
@@ -56,6 +56,9 @@ private:
 	// Check if you are in the midst of hand to hand combat.
 	bool CanAttack() const;
 
+	// Handle the keyboard scrolling and selection in the panel list.
+	void DoKeyboardNavigation(const SDL_Keycode key);
+
 
 private:
 	// This class represents one item in the list of outfits you can plunder.

--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -179,6 +179,11 @@ bool LogbookPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 		double direction = (key == SDLK_PAGEUP) - (key == SDLK_PAGEDOWN);
 		Drag(0., (Screen::Height() - 100.) * direction);
 	}
+	else if(key == SDLK_HOME || key == SDLK_END)
+	{
+		double direction = (key == SDLK_HOME) - (key == SDLK_END);
+		Drag(0., maxScroll * direction);
+	}
 	else if(key == SDLK_UP || key == SDLK_DOWN)
 	{
 		// Find the index of the currently selected line.

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -97,6 +97,10 @@ bool MapSalesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		scroll += static_cast<double>((Screen::Height() - 100) * ((key == SDLK_PAGEUP) - (key == SDLK_PAGEDOWN)));
 		scroll = min(0., max(-maxScroll, scroll));
 	}
+	else if(key == SDLK_HOME)
+		ScrollTo(0);
+	else if (key == SDLK_END)
+		ScrollTo(zones.size() - 1);
 	else if((key == SDLK_DOWN || key == SDLK_UP) && !zones.empty())
 	{
 		selected += (key == SDLK_DOWN) - (key == SDLK_UP);

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -98,9 +98,9 @@ bool MapSalesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		scroll = min(0., max(-maxScroll, scroll));
 	}
 	else if(key == SDLK_HOME)
-		ScrollTo(0);
-	else if (key == SDLK_END)
-		ScrollTo(zones.size() - 1);
+		scroll = 0;
+	else if(key == SDLK_END)
+		scroll = -maxScroll;
 	else if((key == SDLK_DOWN || key == SDLK_UP) && !zones.empty())
 	{
 		selected += (key == SDLK_DOWN) - (key == SDLK_UP);

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -274,6 +274,10 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		int direction = (key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP);
 		Scroll((LINES_PER_PAGE - 2) * direction);
 	}
+	else if(key == SDLK_HOME)
+		Scroll(-player.Ships().size());
+	else if(key == SDLK_END)
+		Scroll(player.Ships().size());
 	else if(key == SDLK_UP || key == SDLK_DOWN)
 	{
 		if(panelState.AllSelected().empty())

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -660,6 +660,10 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		return DoScroll(Screen::Bottom());
 	else if(key == SDLK_PAGEDOWN)
 		return DoScroll(Screen::Top());
+	else if(key == SDLK_HOME)
+		return DoScroll(max(maxInfobarScroll, maxSidebarScroll));
+	else if(key == SDLK_END)
+		return DoScroll(-max(maxInfobarScroll, maxSidebarScroll));
 	else if(key >= '0' && key <= '9')
 	{
 		int group = key - '0';

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -661,9 +661,9 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	else if(key == SDLK_PAGEDOWN)
 		return DoScroll(Screen::Top());
 	else if(key == SDLK_HOME)
-		return DoScroll(max(maxInfobarScroll, maxSidebarScroll));
+		return DoScrollTop();
 	else if(key == SDLK_END)
-		return DoScroll(-max(maxInfobarScroll, maxSidebarScroll));
+		return DoScrollBottom();
 	else if(key >= '0' && key <= '9')
 	{
 		int group = key - '0';
@@ -963,6 +963,34 @@ bool ShopPanel::DoScroll(double dy)
 
 	*scroll = max(0., min(maximum, *scroll - dy));
 
+	return true;
+}
+
+
+
+bool ShopPanel::DoScrollTop()
+{
+	if(activePane == ShopPane::Info)
+		infobarScroll = 0.;
+	else if(activePane == ShopPane::Sidebar)
+		sidebarScroll = 0.;
+	else
+		mainScroll = 0.;
+
+	return true;
+}
+
+
+
+bool ShopPanel::DoScrollBottom()
+{
+	if(activePane == ShopPane::Info)
+		infobarScroll = maxInfobarScroll;
+	else if(activePane == ShopPane::Sidebar)
+		sidebarScroll = maxSidebarScroll;
+	else
+		mainScroll = maxMainScroll;
+	
 	return true;
 }
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -661,9 +661,9 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	else if(key == SDLK_PAGEDOWN)
 		return DoScroll(Screen::Top());
 	else if(key == SDLK_HOME)
-		return DoScrollTop();
+		return SetScrollToTop();
 	else if(key == SDLK_END)
-		return DoScrollBottom();
+		return SetScrollToBottom();
 	else if(key >= '0' && key <= '9')
 	{
 		int group = key - '0';
@@ -968,7 +968,7 @@ bool ShopPanel::DoScroll(double dy)
 
 
 
-bool ShopPanel::DoScrollTop()
+bool ShopPanel::SetScrollToTop()
 {
 	if(activePane == ShopPane::Info)
 		infobarScroll = 0.;
@@ -982,7 +982,7 @@ bool ShopPanel::DoScrollTop()
 
 
 
-bool ShopPanel::DoScrollBottom()
+bool ShopPanel::SetScrollToBottom()
 {
 	if(activePane == ShopPane::Info)
 		infobarScroll = maxInfobarScroll;

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -166,8 +166,8 @@ protected:
 
 private:
 	bool DoScroll(double dy);
-	bool DoScrollTop();
-	bool DoScrollBottom();
+	bool SetScrollToTop();
+	bool SetScrollToBottom();
 	void SideSelect(int count);
 	void SideSelect(Ship *ship);
 	void MainLeft();

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -166,6 +166,8 @@ protected:
 
 private:
 	bool DoScroll(double dy);
+	bool DoScrollTop();
+	bool DoScrollBottom();
 	void SideSelect(int count);
 	void SideSelect(Ship *ship);
 	void MainLeft();


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #6757

## Feature Details
This supports going to the beginning and end of the lists. This is
useful when there are a lot of entries (e.g. items or ships) and you
want to quickly go to something specific, where you know where it is
located (e.g. a newly captured ship in the PlayerInfoPanel or the
attributes of your flagship in the outfitter panel.

The implementation needs to decide whether there should only be
scrolling or whether the first or last element should also be selected.
The used criteria is:
Does something else change when the selection is changed?
Therefore, only the BoardingPanel selects, which is consistent to how
other line-based GUI elements typically behave (e.g. in a file explorer
or a text file). The implementation of the page up and page down keys in
the BoardingPanel have been adapted to reflect this behavior for
consistency reasons.

## UI Screenshots
N/A

## Usage Examples
- Have a lot of ships, capture a new one, open the PlayerInfoPanel and quickly go to the new one by pressing the end key
- Have a lot of ships, go to the outfitter, select the flagship and press the end key to see its attributes

## Testing Done
I went through all panels and checked, that both keys work as expected. Also I played a bit, so see whether any issues occur.

## Performance Impact
N/A