### PR TITLE
Don't write out 1 inside the storage text amount for consistency.

### DIFF
--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -243,7 +243,7 @@ void MapOutfitterPanel::DrawItems()
 				storedInSystem == 0
 				? ""
 				: storedInSystem == 1
-				? "One unit in storage"
+				? "1 unit in storage"
 				: Format::Number(storedInSystem) + " units in storage";
 			Draw(corner, outfit->Thumbnail(), 0, isForSale, outfit == selected,
 				outfit->Name(), price, info, storage_details);


### PR DESCRIPTION
This PR simply replaces a "One" with "1" for consistency with other numbers and other parts where only one thing is mentioned (like "1 ton" and not "One ton").

Thanks to @pilover100 for reporting!