### PR TITLE
Remove mentions of Wanderers in news before you learn their language

### DIFF
--- a/data/wanderer/wanderer news.txt
+++ b/data/wanderer/wanderer news.txt
@@ -9,7 +9,43 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
+news "wanderer civilians, no dialog 1, pre language"
+	to show
+		not "language: Wanderer"
+	location
+		government "Wanderer"
+		not attributes "evacuation"
+	name
+		word
+			"Alien"
+	message
+		word
+			"Many buildings near the spaceport have plants growing on their roofs. An indignant squawk draws your attention to an alien as they rapidly flap away from an automated watering system dousing them where they stood."
+			"Outside the spaceport, you see an alien performing maintenance on some sort of irrigation system. Once they get it working, it begins to water a field of plants."
+			"An alien dockworker unloads complex scientific equipment from a ship. More surprising, however, is the fact that they unload several bags of fertilizer from it as well."
+
+news "wanderer civilian's no dialog 2, pre language"
+	to show
+		not "language: Wanderer"
+	location
+		government "Wanderer"
+		not attributes "evacuation"
+	name
+		word
+			"Group of Aliens"
+	message
+		word
+			"While walking through the spaceport, you see several aliens flying through the air, about to land. They do not notice you, and you duck to avoid them."
+			"A crowd of aliens has formed around an object. Upon closer inspection, it appears to be some sort of technological device."
+			"As you walk by a group of aliens, they begin to coo and chitter at you. Evidently they have not seen something like you before."
+			"A group of smaller aliens appear to be playing a game similar to hopscotch, but instead of hopping they fly to their spots."
+			"On a booth near the spaceport, a group of aliens are playing on objects that look vaguely like wooden flutes. Their music is quiet and lacks a discernible melody."
+			"Two aliens are at a table. They appear to be playing some sort of board game using shell pieces."
+			"A crowd of smaller aliens follow a larger alien through the spaceport. The large alien talks to them as they follow, as the small aliens take notes."
+
 news "wanderer civilians, no dialog 1"
+	to show
+		has "language: Wanderer"
 	location
 		government "Wanderer"
 		not attributes "evacuation"
@@ -23,6 +59,8 @@ news "wanderer civilians, no dialog 1"
 			"A Wanderer dockworker unloads complex scientific equipment from a ship. More surprising, however, is the fact that they unload several bags of fertilizer from it as well."
 
 news "wanderer civilian's no dialog 2"
+	to show
+		has "language: Wanderer"
 	location
 		government "Wanderer"
 		not attributes "evacuation"

--- a/data/wanderer/wanderer news.txt
+++ b/data/wanderer/wanderer news.txt
@@ -9,24 +9,19 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-news "wanderer civilians, no dialog 1, pre language"
-	to show
-		not "language: Wanderer"
+news "wanderer civilians, no dialog 1"
 	location
 		government "Wanderer"
 		not attributes "evacuation"
 	name
 		word
-			"Alien"
+			"Individual"
 	message
 		word
-			"Many buildings near the spaceport have plants growing on their roofs. An indignant squawk draws your attention to an alien as they rapidly flap away from an automated watering system dousing them where they stood."
 			"Outside the spaceport, you see someone performing maintenance on some sort of irrigation system. Once they get it working, it begins to water a field of plants."
 			"A dockworker unloads complex scientific equipment from a ship. More surprising, however, is the fact that they unload several bags of fertilizer from it as well."
 
-news "wanderer civilian's no dialog 2, pre language"
-	to show
-		not "language: Wanderer"
+news "wanderer civilians no dialog 2"
 	location
 		government "Wanderer"
 		not attributes "evacuation"
@@ -35,15 +30,10 @@ news "wanderer civilian's no dialog 2, pre language"
 			"Group"
 	message
 		word
-			"While walking through the spaceport, you see several aliens flying through the air, about to land. They do not notice you, and you duck to avoid them."
 			"A crowd has formed around an object. Upon closer inspection, it appears to be some sort of technological device."
-			"As you walk by a group of aliens, they begin to coo and chitter at you. Evidently they have not seen something like you before."
-			"A group of smaller aliens appear to be playing a game similar to hopscotch, but instead of hopping they fly to their spots."
 			"On a booth near the spaceport, a group is playing on objects that look vaguely like wooden flutes. Their music is quiet and lacks a discernible melody."
-			"Two aliens are at a table. They appear to be playing some sort of board game using shell pieces."
-			"A crowd of smaller aliens follow a larger alien through the spaceport. The large alien talks to them as they follow, as the small aliens take notes."
 
-news "wanderer civilians, no dialog 1"
+news "wanderer civilians, no dialog 1, post language"
 	to show
 		has "language: Wanderer"
 	location
@@ -55,10 +45,8 @@ news "wanderer civilians, no dialog 1"
 	message
 		word
 			"Many buildings near the spaceport have plants growing on their roofs. An indignant squawk draws your attention to a Wanderer as they rapidly flap away from an automated watering system dousing them where they stood."
-			"Outside the spaceport, you see a Wanderer performing maintenance on some sort of irrigation system. Once they get it working, it begins to water a field of plants."
-			"A Wanderer dockworker unloads complex scientific equipment from a ship. More surprising, however, is the fact that they unload several bags of fertilizer from it as well."
 
-news "wanderer civilian's no dialog 2"
+news "wanderer civilians no dialog 2, post language"
 	to show
 		has "language: Wanderer"
 	location
@@ -70,10 +58,8 @@ news "wanderer civilian's no dialog 2"
 	message
 		word
 			"While walking through the spaceport, you see several Wanderers flying through the air, about to land. They do not notice you, and you duck to avoid them."
-			"A crowd of Wanderers has formed around an object. Upon closer inspection, it appears to be some sort of technological device."
 			"As you walk by a group of Wanderers, they begin to coo and chitter at you. Evidently they have not seen something like you before."
 			"A group of Wanderer children appear to be playing a game similar to hopscotch, but instead of hopping they fly to their spots."
-			"On a booth near the spaceport, a group of Wanderers are playing on objects that look vaguely like wooden flutes. Their music is quiet and lacks a discernible melody."
 			"Two Wanderers are at a table. They appear to be playing some sort of board game using shell pieces."
 			"A crowd of Wanderer children follow an adult through the spaceport. The adult talks to them as they follow, as the children take notes."
 

--- a/data/wanderer/wanderer news.txt
+++ b/data/wanderer/wanderer news.txt
@@ -21,8 +21,8 @@ news "wanderer civilians, no dialog 1, pre language"
 	message
 		word
 			"Many buildings near the spaceport have plants growing on their roofs. An indignant squawk draws your attention to an alien as they rapidly flap away from an automated watering system dousing them where they stood."
-			"Outside the spaceport, you see an alien performing maintenance on some sort of irrigation system. Once they get it working, it begins to water a field of plants."
-			"An alien dockworker unloads complex scientific equipment from a ship. More surprising, however, is the fact that they unload several bags of fertilizer from it as well."
+			"Outside the spaceport, you see someone performing maintenance on some sort of irrigation system. Once they get it working, it begins to water a field of plants."
+			"A dockworker unloads complex scientific equipment from a ship. More surprising, however, is the fact that they unload several bags of fertilizer from it as well."
 
 news "wanderer civilian's no dialog 2, pre language"
 	to show
@@ -32,14 +32,14 @@ news "wanderer civilian's no dialog 2, pre language"
 		not attributes "evacuation"
 	name
 		word
-			"Group of Aliens"
+			"Group"
 	message
 		word
 			"While walking through the spaceport, you see several aliens flying through the air, about to land. They do not notice you, and you duck to avoid them."
-			"A crowd of aliens has formed around an object. Upon closer inspection, it appears to be some sort of technological device."
+			"A crowd has formed around an object. Upon closer inspection, it appears to be some sort of technological device."
 			"As you walk by a group of aliens, they begin to coo and chitter at you. Evidently they have not seen something like you before."
 			"A group of smaller aliens appear to be playing a game similar to hopscotch, but instead of hopping they fly to their spots."
-			"On a booth near the spaceport, a group of aliens are playing on objects that look vaguely like wooden flutes. Their music is quiet and lacks a discernible melody."
+			"On a booth near the spaceport, a group is playing on objects that look vaguely like wooden flutes. Their music is quiet and lacks a discernible melody."
 			"Two aliens are at a table. They appear to be playing some sort of board game using shell pieces."
 			"A crowd of smaller aliens follow a larger alien through the spaceport. The large alien talks to them as they follow, as the small aliens take notes."
 


### PR DESCRIPTION
You only learn the name of the Wanderers when you get the Hai translator, but news that explicitly name the Wanderers can be encounter before that point. This PR duplicates the wordless news items and removes any direct mention of Wanderers.