### PR TITLE
Fix missing padding in the ship info panel.

### DIFF
--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -87,9 +87,7 @@ void ShipInfoDisplay::DrawAttributes(const Point &topLeft, const bool sale) cons
 		FillShader::Fill(point + Point(.5 * WIDTH, 5.), Point(WIDTH - 20., 1.), color);
 	}
 	else
-	{
 		point -= Point(0, 10.);
-	}
 
 	// Body.
 	point = Draw(point, attributeLabels, attributeValues);
@@ -141,6 +139,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 
 	attributeLabels.clear();
 	attributeValues.clear();
+	attributesHeight += 20;
 
 	const Outfit &attributes = ship.Attributes();
 


### PR DESCRIPTION
**Bugfix:** This PR fixes #6711

## Fix Details

In #6326 the padding for the ship info display was calculated incorrectly: There was an additional entry added without the corresponding change to the height variable. This PR fixes this issue by readding this padding and a small style issue.

## Testing Done

Verified that you are able to see every line from the ship info display in the outfitter and shipyard.