### PR TITLE
Add tactical scanning to Wanderer warships

### DIFF
--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -154,6 +154,7 @@ ship "Autumn Leaf"
 		"outfit space" 361
 		"weapon capacity" 103
 		"engine capacity" 117
+		"tactical scan power" 25
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -274,6 +275,7 @@ ship "Tempest"
 		"outfit space" 607
 		"weapon capacity" 271
 		"engine capacity" 122
+		"tactical scan power" 35
 		weapon
 			"blast radius" 280
 			"shield damage" 2800
@@ -373,6 +375,7 @@ ship "Derecho"
 		"outfit space" 796
 		"weapon capacity" 342
 		"engine capacity" 164
+		"tactical scan power" 35
 		weapon
 			"blast radius" 340
 			"shield damage" 3400
@@ -474,6 +477,7 @@ ship "Hurricane"
 		"outfit space" 960
 		"weapon capacity" 428
 		"engine capacity" 140
+		"tactical scan power" 50
 		weapon
 			"blast radius" 400
 			"shield damage" 4000
@@ -641,6 +645,7 @@ ship "Winter Gale"
 		"outfit space" 478
 		"weapon capacity" 171
 		"engine capacity" 120
+		"tactical scan power" 25
 		weapon
 			"blast radius" 120
 			"shield damage" 1200


### PR DESCRIPTION
The Strong Wind is the only Wanderer warship that includes tactical scanning and no tactical scanner outfit is available. Given that they have the technology and that they are actively building warships, it seems odd that the newer ships don't have this capability. 

I have added the scanner to all the defined warships that are light warships or above that are added during the game time line. This means that the Autumn Leaf has scanning capabilities while the Summer Leaf does not. I adjusted scan power as well, with the Tempest and Derecho getting one boost to 35 and the Hurricane a boost to 50. 

For  reference, the table below is a listing of current scan capabilities.

Outfits
Coalition	Heliarch Scanning Module	25
Human	Tactical Scanner			32
Sheragi	Electronic Warfare System	25
Remnant	Salvage Scanner			84

Ships
Faction	Ship		Scan Power
Remnant		Albatross		39
Remnant		Gull			26
Remnant		Heron		350
Remnant		Ibis			39
Remnant		Merganser	26
Remnant		Pelican		26
Remnant		Penguin		50
Remnant		Peregrine	50
Remnant		Petrel		20
Remnant		Puffin		52
Remnant		Starling		26
Remnant		Tern		20
Wanderer	Strong Wind	25

## Save File
This save file can be used to play through the new functionality:
[Johnny  NoLicense.txt](https://github.com/endless-sky/endless-sky/files/8562314/Johnny.NoLicense.txt)

## Testing Done
I loaded a completed game save file and checked to see that a ship of each type could scan. I did have one issue with an existing Hurricane (Rita in the save file) did not pick up the attribute change, but a newly purchased Hurricane (Harvey) did. A legacy Tempest picked up the change just fine. 

