### PR TITLE
macOS: fix crash with background audio on older systems

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Update Homebrew
         run: brew update
       - name: Install dependencies
-        run: brew install libmad libpng jpeg-turbo
+        run: brew install libpng jpeg-turbo
       - name: Restore cached SDL2 framework
         uses: actions/cache@v2
         with:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Update Homebrew
         run: brew update
       - name: Install dependencies
-        run: brew install libmad libpng jpeg-turbo
+        run: brew install libpng jpeg-turbo
       - name: Restore cached SDL2 framework
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
       run: brew update
     - name: Install dependencies
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: brew install libmad libpng jpeg-turbo
+      run: brew install libpng jpeg-turbo
     - name: Restore cached SDL2 framework
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/cache@v2

--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -178,6 +178,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		070CD8162818CE9200A853BB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9CC52611950C9F6004E4E22 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 070CD8102818CC6B00A853BB;
+			remoteInfo = libmad;
+		};
 		072599CE26A8CADA007EC229 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A9CC52611950C9F6004E4E22 /* Project object */;
@@ -205,6 +212,7 @@
 
 /* Begin PBXFileReference section */
 		02D34A71AE3BC4C93FC6865B /* TestData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestData.cpp; path = source/TestData.cpp; sourceTree = "<group>"; };
+		070CD8152818CC6B00A853BB /* libmad.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libmad.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		072599BE26A8C67D007EC229 /* SDL2.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = SDL2.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		072599CC26A8C942007EC229 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = build/SDL2.framework; sourceTree = "<group>"; };
 		0C90483BB01ECD0E3E8DDA44 /* WeightedList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WeightedList.h; path = source/WeightedList.h; sourceTree = "<group>"; };
@@ -493,7 +501,7 @@
 		A9B99D041C616AF200BE7C2E /* MapSalesPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MapSalesPanel.h; path = source/MapSalesPanel.h; sourceTree = "<group>"; };
 		A9BDFB521E00B8AA00A6B27E /* Music.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Music.cpp; path = source/Music.cpp; sourceTree = "<group>"; };
 		A9BDFB531E00B8AA00A6B27E /* Music.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Music.h; path = source/Music.h; sourceTree = "<group>"; };
-		A9BDFB551E00B94700A6B27E /* libmad.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libmad.0.dylib; path = /usr/local/opt/libmad/lib/libmad.0.dylib; sourceTree = "<absolute>"; };
+		A9BDFB551E00B94700A6B27E /* libmad.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libmad.0.dylib; path = build/libmad.0.dylib; sourceTree = "<group>"; };
 		A9C70E0E1C0E5B51000B3D14 /* File.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = File.cpp; path = source/File.cpp; sourceTree = "<group>"; };
 		A9C70E0F1C0E5B51000B3D14 /* File.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = File.h; path = source/File.h; sourceTree = "<group>"; };
 		A9CC52691950C9F6004E4E22 /* Endless Sky.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Endless Sky.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -884,6 +892,7 @@
 			children = (
 				A9CC52691950C9F6004E4E22 /* Endless Sky.app */,
 				072599BE26A8C67D007EC229 /* SDL2.dylib */,
+				070CD8152818CC6B00A853BB /* libmad.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -946,6 +955,21 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		070CD8102818CC6B00A853BB /* libmad */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 070CD8122818CC6B00A853BB /* Build configuration list for PBXNativeTarget "libmad" */;
+			buildPhases = (
+				070CD8112818CC6B00A853BB /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = libmad;
+			productName = libmad;
+			productReference = 070CD8152818CC6B00A853BB /* libmad.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
 		072599BD26A8C67D007EC229 /* SDL2 */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 072599C826A8C67D007EC229 /* Build configuration list for PBXNativeTarget "SDL2" */;
@@ -976,6 +1000,7 @@
 			);
 			dependencies = (
 				072599CF26A8CADA007EC229 /* PBXTargetDependency */,
+				070CD8172818CE9200A853BB /* PBXTargetDependency */,
 			);
 			name = EndlessSky;
 			productName = EndlessSky;
@@ -1010,6 +1035,7 @@
 			targets = (
 				A9CC52681950C9F6004E4E22 /* EndlessSky */,
 				072599BD26A8C67D007EC229 /* SDL2 */,
+				070CD8102818CC6B00A853BB /* libmad */,
 			);
 		};
 /* End PBXProject section */
@@ -1033,6 +1059,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		070CD8112818CC6B00A853BB /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/utils/mad-compat.rb",
+			);
+			outputPaths = (
+				"$(PROJECT_DIR)/build/libmad.0.dylib",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "HOMEBREW_NO_COLOR=1 \"${SRCROOT}/utils/build_custom_libmad.sh\"";
+			showEnvVarsInLog = 0;
+		};
 		072599A726A0CDC9007EC229 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1221,6 +1263,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		070CD8172818CE9200A853BB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 070CD8102818CC6B00A853BB /* libmad */;
+			targetProxy = 070CD8162818CE9200A853BB /* PBXContainerItemProxy */;
+		};
 		072599CF26A8CADA007EC229 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 072599BD26A8C67D007EC229 /* SDL2 */;
@@ -1229,6 +1276,56 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		070CD8132818CC6B00A853BB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				EXECUTABLE_PREFIX = "";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_CPP_EXCEPTIONS = YES;
+				GCC_ENABLE_CPP_RTTI = NO;
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_STYLE = all;
+			};
+			name = Debug;
+		};
+		070CD8142818CC6B00A853BB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				COPY_PHASE_STRIP = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				EXECUTABLE_PREFIX = "";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_CPP_EXCEPTIONS = YES;
+				GCC_ENABLE_CPP_RTTI = NO;
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_STYLE = all;
+			};
+			name = Release;
+		};
 		072599C626A8C67D007EC229 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1391,6 +1488,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"/usr/local/opt/jpeg-turbo/include",
+					"/usr/local/opt/mad-compat/include",
 					/usr/local/include,
 				);
 				INFOPLIST_FILE = "XCode/EndlessSky-Info.plist";
@@ -1420,6 +1518,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"/usr/local/opt/jpeg-turbo/include",
+					"/usr/local/opt/mad-compat/include",
 					/usr/local/include,
 				);
 				INFOPLIST_FILE = "XCode/EndlessSky-Info.plist";
@@ -1438,6 +1537,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		070CD8122818CC6B00A853BB /* Build configuration list for PBXNativeTarget "libmad" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				070CD8132818CC6B00A853BB /* Debug */,
+				070CD8142818CC6B00A853BB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		072599C826A8C67D007EC229 /* Build configuration list for PBXNativeTarget "SDL2" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -1094,10 +1094,10 @@
 			files = (
 			);
 			inputPaths = (
-				"$(TEMP_ROOT)/sdl2.dmg",
+				"$(SRCROOT)/utils/fetch_sdl2_framework.sh",
 			);
 			outputPaths = (
-				"$(TEMP_ROOT)/SDL2.framework",
+				"$(PROJECT_DIR)/build/SDL2.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/utils/build_custom_libmad.sh
+++ b/utils/build_custom_libmad.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Build a customized backwards-compatible version of libmad for macOS.
+
+brew install --formula -s "${SRCROOT}/utils/mad-compat.rb"
+mkdir -p "${PROJECT_DIR}/build"
+cp -f `brew --prefix`/opt/mad-compat/lib/libmad.0.dylib "${PROJECT_DIR}/build"

--- a/utils/fetch_sdl2_framework.sh
+++ b/utils/fetch_sdl2_framework.sh
@@ -3,16 +3,18 @@ set -e
 
 # Download and extract the SDL v2 framework for macOS.
 
-SDL2_VERSION="2.0.14"
+SDL2_VERSION="2.0.22"
 SDL2_URL="https://www.libsdl.org/release/SDL2-${SDL2_VERSION}.dmg"
 SDL2_DMG="${TEMP_ROOT}/sdl2.dmg"
 
-if [ ! -d "${PROJECT_DIR}/build/SDL2.framework" ]; then
-    mkdir -p "${PROJECT_DIR}/build"
-    if [ ! -f "${SDL2_DMG}" ]; then
-        curl -sSL -o "${SDL2_DMG}" "${SDL2_URL}"
-    fi
-    hdiutil attach -quiet -nobrowse "${SDL2_DMG}"
-    cp -R /Volumes/SDL2/SDL2.framework "${PROJECT_DIR}/build"
-    hdiutil detach -quiet /Volumes/SDL2
+if [ -d "${PROJECT_DIR}/build/SDL2.framework" ]; then
+    rm -rf "${PROJECT_DIR}/build/SDL2.framework"
 fi
+if [ -f "${SDL2_DMG}" ]; then
+    rm -rf "${SDL2_DMG}"
+fi
+mkdir -p "${PROJECT_DIR}/build"
+curl -sSL -o "${SDL2_DMG}" "${SDL2_URL}"
+hdiutil attach -quiet -nobrowse "${SDL2_DMG}"
+cp -R /Volumes/SDL2/SDL2.framework "${PROJECT_DIR}/build"
+hdiutil detach -quiet /Volumes/SDL2

--- a/utils/mad-compat.rb
+++ b/utils/mad-compat.rb
@@ -1,0 +1,55 @@
+class MadCompat < Formula
+  desc "MPEG audio decoder (custom build for Endless Sky)"
+  homepage "https://www.underbit.com/products/mad/"
+  url "https://downloads.sourceforge.net/project/mad/libmad/0.15.1b/libmad-0.15.1b.tar.gz"
+  sha256 "bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/libmad[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
+  end
+
+  keg_only "not linked to prevent conflicts with homebrew/core libmad"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  def install
+    # https://github.com/endless-sky/endless-sky - added for backwards compatibility
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
+
+    touch "NEWS"
+    touch "AUTHORS"
+    touch "ChangeLog"
+    system "autoreconf", "-fiv"
+    system "./configure", "--disable-debugging", "--enable-fpm=64bit", "--prefix=#{prefix}"
+    system "make", "CFLAGS=#{ENV.cflags}", "LDFLAGS=#{ENV.ldflags}", "install"
+    (lib+"pkgconfig/mad.pc").write pc_file
+    pkgshare.install "minimad.c"
+  end
+
+  test do
+    system ENV.cc, "-I#{include}", pkgshare/"minimad.c", "-L#{lib}", "-lmad", "-o", "minimad"
+    system "./minimad <#{test_fixtures("test.mp3")} >test.wav"
+    assert_equal 4608, (testpath/"test.wav").size?
+  end
+
+  def pc_file
+    <<~EOS
+      prefix=#{opt_prefix}
+      exec_prefix=${prefix}
+      libdir=${exec_prefix}/lib
+      includedir=${prefix}/include
+
+      Name: mad
+      Description: MPEG Audio Decoder
+      Version: #{version}
+      Requires:
+      Conflicts:
+      Libs: -L${libdir} -lmad -lm
+      Cflags: -I${includedir}
+    EOS
+  end
+end


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6520

## Fix Details
Running on macOS 10.13 and earlier would crash when landing on a base with background audio (the only instance where MP3 decoding is used) with "Symbol not found: ____chkstk_darwin". This is a [common error](https://github.com/nodegui/nodegui/issues/391) associated with using libraries on systems [older than they were compiled for](https://developer.apple.com/forums/thread/680395), and the fix is to set MACOSX_DEPLOYMENT_TARGET when compiling the library. This also highlights the shortcomings of relying on Homebrew to create libraries for distribution, but since libmad doesn't offer binaries of its own for download, using a customized formula for it is our best bet.

## Testing Done
Ran this fork's CD build with the affected savefile on macOS 10.13 and it didn't crash.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 0.9.14, and will not occur when using this branch's build.

[Last_First3014-05-23_CrashLandWyvernStation.txt](https://github.com/endless-sky/endless-sky/files/8568343/Last_First3014-05-23_CrashLandWyvernStation.txt)
