### PR TITLE
[Content] Remnant: A breath of Calm

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1618,3 +1618,15 @@ mission "Remnant: Cognizance 38"
 			`	As you reach the end of your report, one of the Remnant nods in approval. "We are starting to disseminate your report along with the data Dusk and Gavriil collected. Both copies of the data match, and have passed the initial verifications, so it appears they were not affected by your departing... shift."`
 			`	They look around at the surrounding Remnant, and you have the sudden feeling that there is an entire level of discussion happening around you. You spot Aeolus moving through the crowd to the front, and he gestures with tones of appreciation. "Thank you for all your work on this, <first>. We have a strong appreciation for the risks you have taken alongside us, and I hope we will continue to explore together. That being said, I suspect it will take much collective effort to determine our next course of action." He looks around, and then winks at you. "In the meantime, I have unlocked access to a few more bits of rarer Korath salvage, including access to captured Chasers. It is not much, but it may give you a little more ease of outfitting the <ship>.`
 
+
+
+mission "Remnant: Cognizance 39"
+	name "A breath of calm"
+	landing
+	invisible
+	source
+		government "Remnant"
+	to offer
+		has "Remnant: Cognizance 38: done"
+	on offer
+		event "remnant: cognizance calm" 5

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1621,7 +1621,6 @@ mission "Remnant: Cognizance 38"
 
 
 mission "Remnant: Cognizance 39"
-	name "A breath of calm"
 	landing
 	invisible
 	source

--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -1056,3 +1056,7 @@ event "remnant: cognizance salvage expansion"
 		add shipyard "Remnant Salvage Ships"
 	planet "Caelian"
 		add shipyard "Remnant Salvage Ships"
+
+
+
+event "remnant: cognizance calm"


### PR DESCRIPTION
## Summary
This adds a single invisible mission that triggers a countdown for an event. This count down establishes a small window of calm in which missions that trigger based on the end of the Cognizance chapter will not occur. Basically, a short breather before all the side missions start triggering.

This PR has no player-visible content, but sets the stage for Remnant Chapter 3 as well as the small mission strings that take place after Cognizance 2. It is being PR'd separately so that it can be reviewed and merged quickly, and thus lay the foundation for the material to follow.

## Related
The following three short mission sets all require having this "cognizance calm", although I forgot to include this actual mission and event in some of them.
https://github.com/endless-sky/endless-sky/pull/6761
https://github.com/endless-sky/endless-sky/pull/6707
https://github.com/endless-sky/endless-sky/pull/6655

## Save File
This save file can be used to play through the new mission content:
Any pilot that has completed Cognizance 2 (as in they have turned Ssil Vida on and off and reached the debriefing)

## Artwork Checklist
 - ~~[X] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
 - ~~[X] I created a PR to the [endless-sky-assets repo](https://github.com/EndlessSkyCommunity/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}~~
 - ~~[X] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~

