### PR TITLE
Add exclamation mark for black hole landing

### DIFF
--- a/data/landing messages.txt
+++ b/data/landing messages.txt
@@ -85,7 +85,7 @@
 	"planet/wormhole"
 	"planet/wormhole-red"
 
-"landing message" "You cannot land on a black hole."
+"landing message" "You cannot land on a black hole!"
 	"star/black-hole"
 	"star/black-hole-core"
 


### PR DESCRIPTION
If trying to land on a star gives "You cannot land on a star!" with an exclamation mark, then landing on a black hole _definitely_ should give one, as well.