### PR TITLE
Reduce Quantum Keystone/Key Stone mass

### DIFF
--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -358,7 +358,7 @@ outfit "Quantum Keystone"
 	category "Systems"
 	cost 12000
 	thumbnail "outfit/keystone"
-	"mass" 1
+	"mass" 0.1
 	"outfit space" -1
 	"quantum keystone" 1
 	description "This chunk of rock from the mountains on the Hai homeworld is apparently nothing more than a good luck charm, but the Hai have decorated their ships with them since the height of their empire. More superstitious Hai claim that the stones somehow reduce the nausea induced by hyperspace jumps by making travel between star systems easier, and many wealthy Hai refuse to book passage on a ship without one."

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -497,7 +497,7 @@ outfit "Quantum Key Stone"
 		Remnant
 	cost 240000
 	thumbnail "outfit/keystone"
-	"mass" 1
+	"mass" 0.1
 	"outfit space" -1
 	"quantum keystone" 1
 	description "This precious artifact attunes a ship's quantum oscillations in a way that allows it to travel through certain otherwise impassable wormholes in the Ember Waste. The stones are rare and valuable, because they can only be mined from one location in the Waste."


### PR DESCRIPTION
Take 2.

Accidentally nuked the previous PR (#6786), so reopening here.

Summary: It doesn't make much sense for keystones to be as large as they are metrically, so I'm trimming them down.