### PR TITLE
Add outfitter to Spera Anatrusk

### DIFF
--- a/data/wanderer/wanderers.txt
+++ b/data/wanderer/wanderers.txt
@@ -997,6 +997,7 @@ event "wanderers: spera anatrusk colony"
 		add description `	Hidden deep in a canyon, the Wanderers have begun establishing a military base here.`
 		spaceport `The Wanderers have hollowed out hangars and caves in the soft sandstone walls of this canyon and have begun to build a military base where they can store supplies and repair their ships while trying to decide how best to deal with the new challenges that face them in Korath space.`
 		spaceport `	Oddly enough, they have also found enough time to plant a large garden on a terrace near the base of the canyon, where they are experimenting to find out which plant species will best grow in this arid environment. The Wanderer drive to understand and transform the local ecology is strong, indeed.`
+		outfitter "Wanderer Basics"
 
 event "wanderers: hurricane mass production"
 	fleet "Wanderer Defense"


### PR DESCRIPTION

**Content (Artwork / Missions / Jobs)**

## Summary
The Wanderer colony on Spera Anatrusk in Korath space does not have an outfitter. As this is the first colony in the new territory it would be a critical first step for them to moving. As it is, resupplying thunderhead missiles is an 8 day round trip. A player needing to adjust a ship build or stock equipment will have to go to Kashikt or back through the wormhole. This PR adds a basic outfitter to the Spera Anatrusk colony event.

## Save File
This save file can be used to play through the new mission content:
[Fred Flintstone.txt](https://github.com/endless-sky/endless-sky/files/8613827/Fred.Flintstone.txt)

## Testing Done
Played through the Wanderer campaign until the event triggered. Outfitter showed on the map view and on landing.
![kaliptari outfitter landing view](https://user-images.githubusercontent.com/70952724/166555140-80860565-46bd-41aa-938e-036e35ab4bc2.png)
![kaliptari outfitter map view](https://user-images.githubusercontent.com/70952724/166555146-f0e1ef5c-62e7-4896-a35d-0bda8c9462ae.png)

