### PR TITLE
Install the AppStream metadata file inside the correct location.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -197,7 +197,7 @@ env.Install("$DESTDIR$PREFIX/games", sky)
 env.Install("$DESTDIR$PREFIX/share/applications", "endless-sky.desktop")
 
 # Install app center metadata:
-env.Install("$DESTDIR$PREFIX/share/appdata", "endless-sky.appdata.xml")
+env.Install("$DESTDIR$PREFIX/share/metainfo", "endless-sky.appdata.xml")
 
 # Install icons, keeping track of all the paths.
 # Most Ubuntu apps supply 16, 22, 24, 32, 48, and 256, and sometimes others.

--- a/utils/build_appimage.sh
+++ b/utils/build_appimage.sh
@@ -9,11 +9,11 @@ set -e
 cp icons/icon_512x512.png endless-sky.png
 
 # Build
-scons -Qj $(nproc) install DESTDIR=AppDir
+scons -Qj $(nproc) install DESTDIR=AppDir PREFIX=/usr
 
 # Inside an AppImage, the executable is a link called "AppRun" at the root of AppDir/.
 # Keeping the data files next to the executable is perfectly valid, so we just move them to AppDir/ to avoid errors.
-mv AppDir/usr/local/share/games/endless-sky/* AppDir/
+mv AppDir/usr/share/games/endless-sky/* AppDir/
 
 # Now build the actual AppImage
 curl -sSL https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o linuxdeploy && chmod +x linuxdeploy


### PR DESCRIPTION
We have a useful AppData xml file that provides various metadata information to various software using AppStream. However, we install this file inside the `appdata/` folder, which is very old legacy at this point. Even Ubuntu 16 supports the new recommended folder, `metainfo/` ([source](https://freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location)). So this PR changes the install location.

The AppImage we distribute also automatically gets support for metadata information, as there the only supported folder for metadata is `/usr/share/metainfo`.