### PR TITLE
Ionization now causes weapons to jam in addition to draining energy

### DIFF
--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -91,7 +91,7 @@ outfit "Ion Cannon"
 		"shield damage" 168
 		"hull damage" 60
 		"ion damage" 5
-	description "Ion cannons do not inflict as much damage as some other weapons, but they disrupt the electrical systems on any ship they hit, draining its energy and causing its weapons to jam. If a ship has sizable battery reserves, this may not have little effect, but for a ship running at near its energy generation capacity an ion strike can take it out of the battle for a few seconds while it recovers, or otherwise cause it to have difficulty firing its weapons."
+	description "Ion cannons do not inflict as much damage as some other weapons, but they disrupt the electrical systems on any ship they hit, draining its energy and causing its weapons to jam. If a ship has sizable battery reserves, this may have little effect, but for a ship running at near its energy generation capacity an ion strike can take it out of the battle for a few seconds while it recovers, or otherwise cause it to have difficulty firing its weapons."
 
 effect "ion impact"
 	sprite "effect/ion impact"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -91,7 +91,7 @@ outfit "Ion Cannon"
 		"shield damage" 168
 		"hull damage" 60
 		"ion damage" 5
-	description "Ion cannons do not inflict as much damage as some other weapons, but they disrupt the electrical systems on any ship they hit, draining its energy. If a ship has sizable battery reserves, this may not have any effect, but for a ship running at near its energy generation capacity an ion strike can take it out of the battle for a few seconds while it recovers."
+	description "Ion cannons do not inflict as much damage as some other weapons, but they disrupt the electrical systems on any ship they hit, draining its energy and causing its weapons to jam. If a ship has sizable battery reserves, this may not have little effect, but for a ship running at near its energy generation capacity an ion strike can take it out of the battle for a few seconds while it recovers, or otherwise cause it to have difficulty firing its weapons."
 
 effect "ion impact"
 	sprite "effect/ion impact"

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -681,7 +681,7 @@ tip "energy damage / second:"
 	`When hitting a target this weapon reduces the target's energy by this amount per second, or half this amount if the target's shields are up.`
 
 tip "ion damage / second:"
-	`Reduces the target's energy. Ionization slowly wears off over time.`
+	`Reduces the target's energy and causes weapon failures. Ionization slowly wears off over time.`
 
 tip "slowing damage / second:"
 	`Reduces the target's turn rate, acceleration, and top speed. Slowing wears off over time.`
@@ -810,7 +810,7 @@ tip "energy damage / shot:"
 	`Each shot reduces the target ship's energy by this amount, or half this amount if its shields are up.`
 
 tip "ion damage / shot:"
-	`Each shot increases the target's ionization by this amount. Ionization reduces the target's energy and slowly wears off over time.`
+	`Each shot increases the target's ionization by this amount. Ionization reduces the target's energy and causes weapon failures. Ionization slowly wears off over time.`
 
 tip "slowing damage / shot:"
 	`Reduces the target's turn rate, acceleration, and top speed. Slowing wears off over time.`

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -208,7 +208,7 @@ void Armament::Aim(const FireCommand &command)
 
 // Fire the given weapon, if it is ready. If it did not fire because it is
 // not ready, return false.
-void Armament::Fire(int index, Ship &ship, vector<Projectile> &projectiles, vector<Visual> &visuals)
+void Armament::Fire(int index, Ship &ship, vector<Projectile> &projectiles, vector<Visual> &visuals, bool jammed)
 {
 	if(static_cast<unsigned>(index) >= hardpoints.size() || !hardpoints[index].IsReady())
 		return;
@@ -224,15 +224,24 @@ void Armament::Fire(int index, Ship &ship, vector<Projectile> &projectiles, vect
 			it->second += it->first->Reload() * hardpoints[index].BurstRemaining();
 		}
 	}
-	hardpoints[index].Fire(ship, projectiles, visuals);
+	if(jammed)
+		hardpoints[index].Jam();
+	else
+		hardpoints[index].Fire(ship, projectiles, visuals);
 }
 
 
 
-bool Armament::FireAntiMissile(int index, Ship &ship, const Projectile &projectile, vector<Visual> &visuals)
+bool Armament::FireAntiMissile(int index, Ship &ship, const Projectile &projectile, vector<Visual> &visuals, bool jammed)
 {
 	if(static_cast<unsigned>(index) >= hardpoints.size() || !hardpoints[index].IsReady())
 		return false;
+
+	if(jammed)
+	{
+		hardpoints[index].Jam();
+		return false;
+	}
 
 	return hardpoints[index].FireAntiMissile(ship, projectile, visuals);
 }

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -66,9 +66,9 @@ public:
 	void Aim(const FireCommand &command);
 	// Fire the given weapon, if it is ready. If it did not fire because it is
 	// not ready, return false.
-	void Fire(int index, Ship &ship, std::vector<Projectile> &projectiles, std::vector<Visual> &visuals);
+	void Fire(int index, Ship &ship, std::vector<Projectile> &projectiles, std::vector<Visual> &visuals, bool jammed);
 	// Fire the given anti-missile system.
-	bool FireAntiMissile(int index, Ship &ship, const Projectile &projectile, std::vector<Visual> &visuals);
+	bool FireAntiMissile(int index, Ship &ship, const Projectile &projectile, std::vector<Visual> &visuals, bool jammed);
 
 	// Update the reload counters.
 	void Step(const Ship &ship);

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -281,6 +281,19 @@ bool Hardpoint::FireAntiMissile(Ship &ship, const Projectile &projectile, vector
 
 
 
+// This weapon jammed. Increase its reload counters, but don't fire.
+void Hardpoint::Jam()
+{
+	// Since this is only called internally by Armament (no one else has non-
+	// const access), assume Armament checked that this is a valid call.
+
+	// Reset the reload count.
+	reload += outfit->Reload();
+	burstReload += outfit->BurstReload();
+}
+
+
+
 // Install a weapon here (assuming it is empty). This is only for
 // Armament to call internally.
 void Hardpoint::Install(const Outfit *outfit)

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -70,6 +70,8 @@ public:
 	void Fire(Ship &ship, std::vector<Projectile> &projectiles, std::vector<Visual> &visuals);
 	// Fire an anti-missile. Returns true if the missile should be killed.
 	bool FireAntiMissile(Ship &ship, const Projectile &projectile, std::vector<Visual> &visuals);
+	// This weapon jammed. Increase its reload counters, but don't fire.
+	void Jam();
 
 	// Install a weapon here (assuming it is empty). This is only for
 	// Armament to call internally.


### PR DESCRIPTION
**Feature:** This PR implements a feature discussed in relation to #6783 and #5976.

## Feature Details
Ion damage is currently considered rather weak compared to the other special damage types that are used in game right now, and with a PR like #6783 that seeks to buff batteries, ion damage would become even weaker. We could perhaps buff the amount of ion damage dealt by various weapons in the game, but then I imagine that'd just make ion damage a second type of heat damage, as the net effect of both special damage types would be to outright disable the target ship.

This PR seeks to buff ion damage by instead creating an additional effect of ionization, that being that ionized ships will sometimes have their weapons jam when they attempt to fire. A weapon which jams will fail to fire, but will still increment its reload counters. The net effect of this is that ionization acts as a DPS debuff on the target ship, even if the ionization isn't enough to drain the ship's energy to 0.

The more ionized a ship is or the closer its batteries are to 0, the higher chance the ship's weapons will have to jam. The percentage of the ship's energy capacity is used as opposed to the magnitude of the energy capacity so that ionization effects all ships similarly instead of allowing more powerful ships to entirely shrug off ion damage, although ships with better generators and/or a higher energy capacity will still benefit by keeping the jam chance lower than it otherwise would be. Ships without batteries are treated as if they are at 100% energy (as opposed to 0%, as that is the behavior the game already uses elsewhere for ships without any energy capacity).

The jam chance caps out at 50%, and the scaling on the jam chance is such that an ion cannon that is sustaining fire on a target will reach a max jam chance of 5% should the target be at 100% energy. These values are intended as baselines, and we may tweak them in the future as we see fit.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Used a Shield Beetle with 6 ion cannons and attacked several different ships. Observed how their weaponry stuttered when firing, sometimes failing to fire when they otherwise would have.

## Performance Impact
N/A
