### PR TITLE
Make the Coalition solars use Solar Heat

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -17,7 +17,7 @@ outfit "Small Collector Module"
 	"mass" 8
 	"outfit space" -6
 	"solar collection" .8
-	"heat generation" .4
+	"solar heat" .4
 	description "Solar power is the mainstay of the Coalition's merchant marine. The design of these panels has been refined over the millennia, growing ever more efficient."
 
 outfit "Large Collector Module"
@@ -29,7 +29,7 @@ outfit "Large Collector Module"
 	"mass" 28
 	"outfit space" -21
 	"solar collection" 3.3
-	"heat generation" 1.5
+	"solar heat" 1.5
 	description "One of these solar panels is enough to meet the energy needs of a medium-sized Coalition civilian ship, especially given the energy efficiency of their engines and the fact that under their laws only Heliarch ships are allowed to have weapons."
 
 outfit "Small Reactor Module"


### PR DESCRIPTION
----------------------
**Content (Stats)**

## Summary
Just changes the Coalition's solar panels' `heat generation` to `solar heat`, which was pointed in the Discord to be more appropriate since it'd scale with the solar collection, rather than being a constant heat.