### PR TITLE
Use "free" instead of "0" for outfits that are free.

### DIFF
--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -248,7 +248,7 @@ void OutfitInfoDisplay::UpdateRequirements(const Outfit &outfit, const PlayerInf
 		out << "cost (" << (100 * buyValue) / cost << "%):";
 		requirementLabels.push_back(out.str());
 	}
-	requirementValues.push_back(Format::Credits(buyValue));
+	requirementValues.push_back(buyValue ? Format::Credits(buyValue) : "free");
 	requirementsHeight += 20;
 
 	if(canSell && sellValue != buyValue)


### PR DESCRIPTION
This simply changes the outfit info display to read `cost: free` instead of `cost: 0`. I think it's an improvement because it's a bit weird to see an attribute with the value of 0.

![free cost](https://user-images.githubusercontent.com/85879619/167838832-caccbf4a-faf0-4f70-99ce-964ea2a5553d.png)
