### PR TITLE
[Fix]Ka'het & Remnant: Dusk can be permanently locked as busy by failing Patir 5 (unintentional)

### DIFF
--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -697,7 +697,7 @@ mission "Ka'het: Patir Mystery 5"
 			`	"Well, I can only suggest to depart from here and set a route straight back to Aventine, while avoiding the Ka'sei. Sorry <first>, but it is preferable that we leave them alone." After all the risk you had to take, you cannot help but nod if this means getting as far from here as possible.`
 				launch
 	
-	npc save
+	npc
 		government "Ka'sei"
 		personality plunders mining harvests staying
 		fleet
@@ -727,13 +727,6 @@ mission "Ka'het: Patir Mystery 5"
 			apply
 				set "ka'het: attacked ka'sei"
 			`You disembark from your ship with Dusk, who is visible angry that you destroyed one of the Ka'sei. "I told you not to attack them! I told you of their importance!" he signs harshly while pacing back and forth. "Oh my, oh my, we can only hope that this does not close any doors for us. Perhaps we can attempt to communicate with them? Tell them it was an accident?" He looks to you as if searching for some reassurance, but you have none to give. "Forget it. I will study what we have gathered, but I am afraid that it will be all that we will ever gather from that system." Dusk storms off without saying goodbye, typing away on his touchpad as he goes.`
-	on fail
-		clear "remnant: dusk busy"
-		event "patir mystery timer" 10
-		conversation
-			apply
-				set "ka'het: attacked ka'sei"
-			`You disembark from your ship with Dusk, who is visible angry that one of the Ka'sei was destroyed. "I told you not to attack them! I told you of their importance!" he signs harshly while pacing back and forth. "Oh my, oh my, we can only hope that this does not close any doors for us. Perhaps we can attempt to communicate with them? Tell them it was an accident?" He looks to you as if searching for some reassurance, but you have none to give. "Forget it. I will study what we have gathered, but I am afraid that it will be all that we will ever gather from that system." Dusk storms off without saying goodbye, typing away on his touchpad as he goes.`
 	
 
 event "pacified ka'sei"

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -727,7 +727,6 @@ mission "Ka'het: Patir Mystery 5"
 			apply
 				set "ka'het: attacked ka'sei"
 			`You disembark from your ship with Dusk, who is visible angry that you destroyed one of the Ka'sei. "I told you not to attack them! I told you of their importance!" he signs harshly while pacing back and forth. "Oh my, oh my, we can only hope that this does not close any doors for us. Perhaps we can attempt to communicate with them? Tell them it was an accident?" He looks to you as if searching for some reassurance, but you have none to give. "Forget it. I will study what we have gathered, but I am afraid that it will be all that we will ever gather from that system." Dusk storms off without saying goodbye, typing away on his touchpad as he goes.`
-	
 
 event "pacified ka'sei"
 	"reputation: Ka'sei" = 1

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -726,7 +726,15 @@ mission "Ka'het: Patir Mystery 5"
 			label attacked
 			apply
 				set "ka'het: attacked ka'sei"
-			`You disembark from your ship with Dusk, who is visible angry that you destroyed one of the Ka'sei. "I told you not to attack them! I told you of their importance!" he yells while pacing back and forth. "Oh my, oh my, we can only hope that this does not close any doors for us. Perhaps we can attempt to communicate with them? Tell them it was an accident?" He looks to you as if searching for some reassurance, but you have none to give. "Forget it. I will study what we have gathered, but I am afraid that it will be all that we will ever gather from that system." Dusk storms off without saying goodbye, typing away on his touchpad as he goes.`
+			`You disembark from your ship with Dusk, who is visible angry that you destroyed one of the Ka'sei. "I told you not to attack them! I told you of their importance!" he signs harshly while pacing back and forth. "Oh my, oh my, we can only hope that this does not close any doors for us. Perhaps we can attempt to communicate with them? Tell them it was an accident?" He looks to you as if searching for some reassurance, but you have none to give. "Forget it. I will study what we have gathered, but I am afraid that it will be all that we will ever gather from that system." Dusk storms off without saying goodbye, typing away on his touchpad as he goes.`
+	on fail
+		clear "remnant: dusk busy"
+		event "patir mystery timer" 10
+		conversation
+			apply
+				set "ka'het: attacked ka'sei"
+			`You disembark from your ship with Dusk, who is visible angry that one of the Ka'sei was destroyed. "I told you not to attack them! I told you of their importance!" he signs harshly while pacing back and forth. "Oh my, oh my, we can only hope that this does not close any doors for us. Perhaps we can attempt to communicate with them? Tell them it was an accident?" He looks to you as if searching for some reassurance, but you have none to give. "Forget it. I will study what we have gathered, but I am afraid that it will be all that we will ever gather from that system." Dusk storms off without saying goodbye, typing away on his touchpad as he goes.`
+	
 
 event "pacified ka'sei"
 	"reputation: Ka'sei" = 1


### PR DESCRIPTION
**Bugfix:** This PR addresses issue of being locked out of Cognizance 21 because Dusk is permanently busy.

## Fix Details
Because the Kasei are labeled as 'NPC save', kiling them fails the mission; in which case the player doesn't get to see the `on complete` text.

This adds on `on fail` conversation that is simply the fail part.

He's emotional, so it makes sense he reverts to his most instinctive form of communication.

Note: I left a copy of the upset conversation in the 'on complete' to cover all our options. With that remaining in place, if the players manage to kill some Ka'sei somehow without triggering the fail; they'll still get the appropriate reaction either way.

## Thanks:
Thanks to Dust on the ES discord for running into this problem and bringing it to my attention!

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}
