### PR TITLE
Add underscore for Save Order keyboard shortcut

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -1149,7 +1149,7 @@ interface "info panel"
 	visible if "show save order"
 	sprite "ui/wide button"
 		center -195 305
-	button v "Save Order"
+	button v "Sa_ve Order"
 		center -195 305
 		dimensions 90 30
 


### PR DESCRIPTION
Don't know if this is a bug fix or new feature.

While not holding down alt:
![image](https://user-images.githubusercontent.com/20605679/168190328-d6125ddf-0bf9-445f-be92-d1929cc7dcbb.png)
While holding down alt:
![image](https://user-images.githubusercontent.com/20605679/168190485-ff8847b3-00c0-4b84-b12a-c3087e6d4288.png)

The v key was already acting as a keyboard shortcut, this just means holding down alt underlines it in the button label.