### PR TITLE
Add missing hyperdrive to "Pure Finishers" Punisher variant.

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -1149,6 +1149,7 @@ ship "Heliarch Punisher" "Heliarch Punisher (Pure Finishers)"
 		"Large Thrust Module" 4
 		"Small Thrust Module"
 		"Large Steering Module" 2
+		"Hyperdrive"
 
 ship "Heliarch Punisher" "Heliarch Punisher (Scrappy)"
 	outfits


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue found by Kitteh on the Discord.

## Fix Details

The "Pure Finishers" was missing a hyperdrive. This PR fixes this oversight.