### PR TITLE
Coalition: Minmaxing Heliarch Variants

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -846,6 +846,7 @@ ship "Heliarch Judicator" "Heliarch Judicator (Scrappy)"
 		"Small Reactor Module"
 		"Large Battery Module"
 		"Overcharged Shield Module"
+		"Small Shield Module"
 		"Overclocked Repair Module" 3
 		"Cooling Module" 3
 		"Scanning Module"
@@ -856,7 +857,7 @@ ship "Heliarch Judicator" "Heliarch Judicator (Scrappy)"
 		"Large Thrust Module"
 		"Small Thrust Module" 2
 		"Large Steering Module" 2
-		"Small Steering Module"
+		"Small Steering Module" 2
 		"Scram Drive"
 
 
@@ -965,7 +966,7 @@ ship "Heliarch Neutralizer" "Heliarch Neutralizer (Scrappy)"
 	outfits
 		"Bombardment Cannon" 4
 		
-		"Small Reactor Module" 2
+		"Large Reactor Module"
 		"Small Battery Module" 2
 		"Overcharged Shield Module"
 		"Overclocked Repair Module"
@@ -1113,7 +1114,7 @@ ship "Heliarch Punisher" "Heliarch Punisher (Missile)"
 		"Small Battery Module" 3
 		"Overcharged Shield Module" 3
 		"Overclocked Repair Module" 2
-		"Cooling Module" 3
+		"Cooling Module" 4
 		"Scanning Module" 4
 		"Outfits Expansion" 2
 		"Enforcer Riot Staff" 85

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -292,7 +292,7 @@ ship "Heliarch Breacher"
 		"Finisher Torpedo" 40
 		
 		"Small Reactor Module" 2
-		"Small Battery Module" 2
+		"Small Battery Module"
 		"Overcharged Shield Module"
 		"Overclocked Repair Module"
 		"Cooling Module" 2
@@ -300,8 +300,7 @@ ship "Heliarch Breacher"
 		"Enforcer Riot Staff" 8
 		"Enforcer Confrontation Gear" 6
 		
-		"Large Thrust Module"
-		"Small Thrust Module" 3
+		"Large Thrust Module" 2
 		"Small Steering Module"
 		"Hyperdrive"
 	
@@ -344,7 +343,7 @@ ship "Heliarch Breacher" "Heliarch Breacher (Missile)"
 		"Finisher Torpedo" 160
 		
 		"Small Reactor Module"
-		"Small Battery Module" 2
+		"Small Battery Module"
 		"Large Shield Module"
 		"Large Repair Module"
 		"Cooling Module"
@@ -352,8 +351,7 @@ ship "Heliarch Breacher" "Heliarch Breacher (Missile)"
 		"Enforcer Riot Staff" 9
 		"Enforcer Confrontation Gear" 7
 		
-		"Large Thrust Module"
-		"Small Thrust Module" 3
+		"Large Thrust Module" 2
 		"Large Steering Module"
 		"Small Steering Module"
 		"Hyperdrive"
@@ -364,7 +362,7 @@ ship "Heliarch Breacher" "Heliarch Breacher (Scrappy)"
 		"Bombardment Turret"
 		
 		"Small Reactor Module" 2
-		"Large Battery Module"
+		"Small Battery Module" 2
 		"Overcharged Shield Module"
 		"Overclocked Repair Module"
 		"Cooling Module" 2
@@ -374,8 +372,7 @@ ship "Heliarch Breacher" "Heliarch Breacher (Scrappy)"
 		
 		"Large Thrust Module"
 		"Small Thrust Module"
-		"Large Steering Module"
-		"Small Steering Module" 2
+		"Large Steering Module" 2
 		"Hyperdrive"
 
 
@@ -412,7 +409,7 @@ ship "Heliarch Hunter"
 		"Heliarch Attractor"
 		
 		"Large Reactor Module"
-		"Large Battery Module"
+		"Small Battery Module" 3
 		"Overcharged Shield Module"
 		"Overclocked Repair Module"
 		"Cooling Module" 2
@@ -423,7 +420,7 @@ ship "Heliarch Hunter"
 		"Large Thrust Module" 2
 		"Small Thrust Module"
 		"Large Steering Module"
-		"Small Steering Module" 2
+		"Small Steering Module" 3
 		"Scram Drive"
 	
 	engine -5.5 103 .1
@@ -571,7 +568,7 @@ ship "Heliarch Interdictor"
 		"Heliarch Repulsor"
 		
 		"Large Reactor Module"
-		"Large Battery Module"
+		"Small Battery Module" 4
 		"Overcharged Shield Module"
 		"Overclocked Repair Module"
 		"Cooling Module" 2
@@ -581,6 +578,7 @@ ship "Heliarch Interdictor"
 		
 		"Large Thrust Module" 2
 		"Large Steering Module" 2
+		"Small Steering Module"
 		"Hyperdrive"
 	
 	engine -30 163 .5
@@ -601,14 +599,15 @@ ship "Heliarch Interdictor"
 ship "Heliarch Interdictor" "Heliarch Interdictor (Bombardment)"
 	outfits
 		"Finisher Pod" 2
-		"Finisher Torpedo" 80
+		"Finisher Storage Tube" 2
+		"Finisher Torpedo" 120
 		"Bombardment Turret" 2
 		
 		"Large Reactor Module"
-		"Large Battery Module"
+		"Small Battery Module" 3
 		"Overcharged Shield Module"
 		"Overclocked Repair Module"
-		"Cooling Module"
+		"Cooling Module" 2
 		"Scanning Module" 3
 		"Enforcer Riot Staff" 31
 		"Enforcer Confrontation Gear" 27
@@ -626,8 +625,7 @@ ship "Heliarch Interdictor" "Heliarch Interdictor (Ions)"
 
 		"Large Reactor Module"
 		"Small Reactor Module"
-		"Large Battery Module"
-		"Small Battery Module"
+		"Small Battery Module" 4
 		"Overcharged Shield Module" 2
 		"Overclocked Repair Module" 2
 		"Cooling Module" 3
@@ -638,6 +636,7 @@ ship "Heliarch Interdictor" "Heliarch Interdictor (Ions)"
 
 		"Large Thrust Module" 2
 		"Large Steering Module" 2
+		"Small Steering Module"
 		"Hyperdrive"
 
 ship "Heliarch Interdictor" "Heliarch Interdictor (Missile)"
@@ -667,9 +666,11 @@ ship "Heliarch Interdictor" "Heliarch Interdictor (Scrappy)"
 
 		"Large Reactor Module"
 		"Small Reactor Module"
-		"Large Battery Module" 2
+		"Large Battery Module"
 		"Overcharged Shield Module"
+		"Small Shield Module"
 		"Overclocked Repair Module" 2
+		"Small Repair Module"
 		"Cooling Module" 3
 		"Scanning Module" 5
 		"Outfits Expansion" 2
@@ -711,13 +712,12 @@ ship "Heliarch Judicator"
 			"hit force" 3800
 	outfits
 		"Finisher Pod" 2
-		"Finisher Torpedo" 120
-		"Finisher Storage Tube" 2
+		"Finisher Torpedo" 140
+		"Finisher Storage Tube" 3
 		"Ion Hail Turret"
 		
 		"Large Reactor Module"
-		"Small Battery Module"
-		"Large Battery Module"
+		"Small Battery Module" 2
 		"Overcharged Shield Module"
 		"Overclocked Repair Module" 2
 		"Cooling Module" 2
@@ -844,7 +844,7 @@ ship "Heliarch Judicator" "Heliarch Judicator (Scrappy)"
 		
 		"Large Reactor Module"
 		"Small Reactor Module"
-		"Large Battery Module" 2
+		"Large Battery Module"
 		"Overcharged Shield Module"
 		"Overclocked Repair Module" 3
 		"Cooling Module" 3
@@ -890,10 +890,10 @@ ship "Heliarch Neutralizer"
 		"Ion Rain Gun" 4
 		
 		"Small Reactor Module" 2
-		"Large Battery Module"
+		"Small Battery Module" 3
 		"Overcharged Shield Module"
 		"Overclocked Repair Module"
-		"Cooling Module"
+		"Cooling Module" 2
 		"Scanning Module" 2
 		"Enforcer Riot Staff" 9
 		"Enforcer Confrontation Gear" 11
@@ -947,9 +947,9 @@ ship "Heliarch Neutralizer" "Heliarch Neutralizer (Nimble)"
 		"Ion Rain Gun" 4
 		
 		"Small Reactor Module" 2
-		"Large Battery Module"
+		"Small Battery Module" 2
 		"Overcharged Shield Module"
-		"Large Repair Module"
+		"Overclocked Repair Module"
 		"Cooling Module"
 		"Scanning Module" 2
 		"Enforcer Riot Staff" 10
@@ -966,7 +966,7 @@ ship "Heliarch Neutralizer" "Heliarch Neutralizer (Scrappy)"
 		"Bombardment Cannon" 4
 		
 		"Small Reactor Module" 2
-		"Small Battery Module"
+		"Small Battery Module" 2
 		"Overcharged Shield Module"
 		"Overclocked Repair Module"
 		"Cooling Module" 2
@@ -975,7 +975,7 @@ ship "Heliarch Neutralizer" "Heliarch Neutralizer (Scrappy)"
 		"Enforcer Confrontation Gear" 9
 		
 		"Large Thrust Module"
-		"Small Thrust Module"
+		"Small Thrust Module" 2
 		"Large Steering Module" 2
 		"Hyperdrive"
 
@@ -1024,7 +1024,7 @@ ship "Heliarch Punisher"
 		"Large Thrust Module" 2
 		"Small Thrust Module" 2
 		"Large Steering Module" 2
-		"Small Steering Module" 2
+		"Small Steering Module" 3
 		"Hyperdrive"
 	
 	engine -24 184 .6
@@ -1057,7 +1057,7 @@ ship "Heliarch Punisher" "Heliarch Punisher (Interdicting)"
 		"Bombardment Turret"
 		
 		"Large Reactor Module" 2
-		"Large Battery Module"
+		"Small Battery Module" 3
 		"Overcharged Shield Module" 2
 		"Overclocked Repair Module" 2
 		"Cooling Module" 4
@@ -1066,7 +1066,7 @@ ship "Heliarch Punisher" "Heliarch Punisher (Interdicting)"
 		"Enforcer Confrontation Gear" 42
 		
 		"Large Thrust Module" 2
-		"Small Thrust Module" 2
+		"Small Thrust Module" 3
 		"Large Steering Module" 2
 		"Small Steering Module" 2
 		"Hyperdrive"
@@ -1088,8 +1088,7 @@ ship "Heliarch Punisher" "Heliarch Punisher (Ions)"
 		"Ion Rain Gun" 6
 
 		"Large Reactor Module" 2
-		"Small Reactor Module"
-		"Large Battery Module" 2
+		"Large Battery Module"
 		"Small Battery Module"
 		"Overcharged Shield Module" 3
 		"Overclocked Repair Module" 3
@@ -1099,10 +1098,9 @@ ship "Heliarch Punisher" "Heliarch Punisher (Ions)"
 		"Enforcer Riot Staff" 96
 		"Enforcer Confrontation Gear" 48
 
-		"Large Thrust Module" 2
-		"Small Thrust Module" 2
+		"Large Thrust Module" 3
 		"Large Steering Module" 2
-		"Small Steering Module" 2
+		"Small Steering Module" 3
 		"Hyperdrive"
 
 ship "Heliarch Punisher" "Heliarch Punisher (Missile)"
@@ -1111,13 +1109,13 @@ ship "Heliarch Punisher" "Heliarch Punisher (Missile)"
 		"Finisher Torpedo" 240
 		"Heliarch Repulsor"
 		
-		"Large Reactor Module"
-		"Small Reactor Module"
-		"Large Battery Module" 2
+		"Large Reactor Module" 2
+		"Small Battery Module" 3
 		"Overcharged Shield Module" 3
 		"Overclocked Repair Module" 2
 		"Cooling Module" 3
 		"Scanning Module" 4
+		"Outfits Expansion" 2
 		"Enforcer Riot Staff" 85
 		"Enforcer Confrontation Gear" 40
 		
@@ -1201,8 +1199,8 @@ ship "Heliarch Pursuer"
 		"Ion Rain Gun"
 		
 		"Large Collector Module"
-		"Small Collector Module"
-		"Small Battery Module" 3
+		"Small Collector Module" 2
+		"Small Battery Module"
 		"Small Shield Module"
 		"Small Repair Module"
 		
@@ -1260,7 +1258,8 @@ ship "Heliarch Rover"
 		"Bombardment Cannon" 2
 		
 		"Large Collector Module"
-		"Large Battery Module"
+		"Small Battery Module" 2
+		"Small Cogeneration Module"
 		"Small Shield Module"
 		"Small Repair Module" 3
 		


### PR DESCRIPTION
----------------------
**Content (Ship Loadout Changes)**

## Summary
With the recent buff to Battery outfits, pretty much every ship variant in the game now has way more energy capacity than they realistically need.
The Heliarchs, focused on being ever-ready for a Quarg invasion, would naturally have each ship type they field make the most out of what space and equipment they have available, and as the battery buff gave almost all Heliarch ships a very large boost to their energy capacity, they could lose some of the space used for batteries, and use it instead for some other outfits.

This PR changes the loadouts of most Heliarch ship variants, either switching larger batteries for smaller ones, or reducing the quantity of batteries. I filled up the outfit space that that opened to the best of my abilities, trying to steer the changes to be in line with what the variants should be doing (ie more thrust to the Breachers), or just what boost I found would help most when there wasn't a clear answer.
It also fills up some outfit space that was just going unused for no reason, so some variants got a lot more/larger outfits added to them.

Despite this overall reducing the amount of energy capacity each variant has, that's only in relation to the variants as they are now, after the battery buff. Each variant would still have a good bit more energy capacity than they had before the buff happened.