### PR TITLE
Fix Ions Punisher empty space

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -1089,8 +1089,8 @@ ship "Heliarch Punisher" "Heliarch Punisher (Ions)"
 		"Ion Rain Gun" 6
 
 		"Large Reactor Module" 2
+		"Small Reactor Module"
 		"Large Battery Module"
-		"Small Battery Module"
 		"Overcharged Shield Module" 3
 		"Overclocked Repair Module" 3
 		"Cooling Module" 5


### PR DESCRIPTION
----------------------
**Content Fix(missed part of the changes for this variant)**

## Summary
6823 was just merged: https://github.com/endless-sky/endless-sky/commit/0c9f72f48e9465043c3cf87ff1a00e98e367d49d
So I hopped on to check in my game and make sure all the variants were right, and I hadn't accidentally made something go into the negatives for outfit space.
Turns out I missed a change to the Ions variant of the Heliarch Punisher, swapping a Small Battery Module for a Small Reactor Module.

Should've made an ESL2 instance for the PR and checked beforehand, but I forgot, sorry.