### PR TITLE
Skip ghost outfits when calculating the fine for outfits in a cargo hold.

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -564,6 +564,12 @@ int CargoHold::IllegalCargoFine() const
 	// Only the worst illegal outfit is fined.
 	for(const auto &it : outfits)
 	{
+		// The code for adding and removing outfits does not clear the entry in the
+		// map if its value becomes zero, so we need to check if the outfit is
+		// actually inside the cargo hold.
+		if(!it.second)
+			continue;
+
 		int fine = it.first->Get("illegal");
 		if(it.first->Get("atrocity") > 0.)
 			return -1;

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -348,9 +348,7 @@ int CargoHold::Transfer(const string &commodity, int amount, CargoHold &to)
 	// remainder back to this cargo hold, even if there is not space for it.
 	int removed = Remove(commodity, amount);
 	int added = to.Add(commodity, removed);
-	int remainder = removed - added;
-	if(remainder)
-		commodities[commodity] += remainder;
+	commodities[commodity] += removed - added;
 
 	return added;
 }
@@ -493,10 +491,6 @@ int CargoHold::Remove(const string &commodity, int amount)
 
 	amount = min(amount, commodities[commodity]);
 	commodities[commodity] -= amount;
-
-	// Remove this commodity if it isn't in this cargo hold anymore.
-	if(!commodities[commodity])
-		commodities.erase(commodity);
 	return amount;
 }
 

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -116,26 +116,27 @@ void CargoHold::Save(DataWriter &out) const
 	// Save all outfits, even ones which have only been referred to.
 	bool firstOutfit = true;
 	for(const auto &it : outfits)
-	{
-		// It is possible this cargo hold contained no commodities, meaning
-		// we must print the opening tag now.
-		if(first)
+		if(it.second)
 		{
-			out.Write("cargo");
-			out.BeginChild();
-		}
-		first = false;
+			// It is possible this cargo hold contained no commodities, meaning
+			// we must print the opening tag now.
+			if(first)
+			{
+				out.Write("cargo");
+				out.BeginChild();
+			}
+			first = false;
 
-		// If this is the first outfit to be written, print the opening tag.
-		if(firstOutfit)
-		{
-			out.Write("outfits");
-			out.BeginChild();
-		}
-		firstOutfit = false;
+			// If this is the first outfit to be written, print the opening tag.
+			if(firstOutfit)
+			{
+				out.Write("outfits");
+				out.BeginChild();
+			}
+			firstOutfit = false;
 
-		out.Write(it.first->Name(), it.second);
-	}
+			out.Write(it.first->Name(), it.second);
+		}
 	// Back out any indentation blocks that are set, depending on what sorts of
 	// cargo were written to the file.
 	if(!firstOutfit)

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -348,7 +348,9 @@ int CargoHold::Transfer(const string &commodity, int amount, CargoHold &to)
 	// remainder back to this cargo hold, even if there is not space for it.
 	int removed = Remove(commodity, amount);
 	int added = to.Add(commodity, removed);
-	commodities[commodity] += removed - added;
+	int remainder = removed - added;
+	if(remainder)
+		commodities[commodity] += remainder;
 
 	return added;
 }
@@ -491,6 +493,10 @@ int CargoHold::Remove(const string &commodity, int amount)
 
 	amount = min(amount, commodities[commodity]);
 	commodities[commodity] -= amount;
+
+	// Remove this commodity if it isn't in this cargo hold anymore.
+	if(!commodities[commodity])
+		commodities.erase(commodity);
 	return amount;
 }
 


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported on Steam: https://steamcommunity.com/app/404410/discussions/0/4536825080749745672/

## Fix Details

CargoHold's never clear outfits inside their map when their count reaches zero. The code for determining the fine of the illegal outfits inside that cargo hold didn't check whether there is actually an outfit (i.e. it's count is > 0), resulting in fines for outfits that were once in your cargo hold but not anymore.

## Testing Done

I tested this a while back. Adding Nerve Gas to your cargo hold and then removing it and landing on a high security planet no longer gets you a fine.

