### PR TITLE
Improve the version identification for users.

### DIFF
--- a/XCode/EndlessSky-Info.plist
+++ b/XCode/EndlessSky-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.14</string>
+	<string>0.9.15</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/XCode/EndlessSky-Info.plist
+++ b/XCode/EndlessSky-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.15</string>
+	<string>0.9.14</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/credits.txt
+++ b/credits.txt
@@ -1,5 +1,5 @@
 Welcome to Endless Sky!
-version 0.9.14
+version 0.9.15-alpha
 
 This game is open source.
 To report bugs, give feedback,

--- a/utils/cd_update_versions.sh
+++ b/utils/cd_update_versions.sh
@@ -5,6 +5,6 @@ set -e
 
 $(dirname $0)/set_version.sh $(git rev-parse --verify HEAD)
 $(dirname $0)/set_plist_build.sh $(git rev-list --all --count)
-CREDIT_STRING=$(git log --pretty="format:%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \" \')
-perl -p -i -e "s|version [\d.]+|$CREDIT_STRING|" credits.txt
+CREDIT_STRING=$(git log --pretty="format: (%h)%n%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \" \')
+perl -p -i -e "s|(version [\d.]+.*)|\$1$CREDIT_STRING|" credits.txt
 rm -rf credits.txt.bak

--- a/utils/set_version.sh
+++ b/utils/set_version.sh
@@ -7,26 +7,31 @@
 # $ ./utils/set_version.sh 1.0.0
 
 versionRegex="([0-9]+\.){0,2}[0-9]+"
-[[ $1 =~ ^${versionRegex}$ ]]
+[[ $1 =~ ^${versionRegex}.*$ ]]
 isVersion=$?
 if [[ ${isVersion} -eq 0 ]]; then
     replacement="ver. $1"
 elif [[ $1 =~ ^[0-9A-Fa-f]+$ ]]; then
-    replacement="commit $1"
+	replacement="($1)"
+	perl -p -i -e "s/(\"Endless Sky .*)\"/\$1 ${replacement}\"/ig" source/main.cpp
+	perl -p -i -e "s/\".*?\" \"(ver\. .*)\" \"/\"$(date '+%d %b %Y')\" \"\$1 ${replacement}\" \"/ig" endless-sky.6
+	isVersion=2
 else
     replacement=$1
 fi
 
-# Update main.cpp
-perl -p -i -e "s/(\"Endless Sky) .+?\"/\$1 ${replacement}\"/ig" source/main.cpp
-rm -rf source/main.cpp.bak
+if [[ ${isVersion} -ne 2 ]]; then
+	# Update main.cpp
+	perl -p -i -e "s/(\"Endless Sky) .+?\"/\$1 ${replacement}\"/ig" source/main.cpp
+	# Update endless-sky.6
+	perl -p -i -e "s/\".*?\" \"ver\. .+?\"/\"$(date '+%d %b %Y')\" \"${replacement}\"/ig" endless-sky.6
+fi
 
-# Update manpage.
-perl -p -i -e "s/\".*?\" \"ver\. .+?\"/\"$(date '+%d %b %Y')\" \"${replacement}\"/ig" endless-sky.6
+rm -rf source/main.cpp.bak
 rm -rf endless-sky.6.bak
 
 # Update the XCode plist version, if the input is spec-conformant
-if [[ ${isVersion} -eq 0 ]]; then
+if [[ $1 =~ ^${versionRegex}$ ]]; then
     perl -0777 -p -i -e "s/(CFBundleShortVersionString.*?)\>${versionRegex}/\$1>$1/igs" XCode/EndlessSky-Info.plist
     rm -rf XCode/EndlessSky-Info.plist.bak
 fi


### PR DESCRIPTION
## Feature Details

This PR improves the version identification of ES:

- Changes the current version string inside credits.txt to 0.9.15-alpha, as that is the current version
- The script that adds the "last change" lines to credits.txt no longer deletes the version string
- That same script also adds the commit hash behind the version string (so for example `version 0.9.15-alpha (14a3da2)`)
- Invoking the set version script with a commit hash no longer replaces the version string but adds `(#hash#)` behind the version string (so for example `ver. 0.9.15-alpha (14a3da2)`)

## Testing Done

Invoked the scripts in question to verify that they work as intended with any input string (if applicable).
