### PR TITLE
Fix frames lagging one frame behind rendering.

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1324,6 +1324,7 @@ void Engine::ThreadEntryPoint()
 
 		// Do all the calculations.
 		CalculateStep();
+
 		{
 			unique_lock<mutex> lock(swapMutex);
 			hasFinishedCalculating = true;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -431,8 +431,8 @@ void Engine::Place(const list<NPC> &npcs, shared_ptr<Ship> flagship)
 void Engine::Wait()
 {
 	unique_lock<mutex> lock(swapMutex);
-	while(calcTickTock != drawTickTock)
-		condition.wait(lock);
+	condition.wait(lock, [this] { return hasFinishedCalculating; });
+	drawTickTock = calcTickTock;
 }
 
 
@@ -886,7 +886,8 @@ void Engine::Go()
 	{
 		unique_lock<mutex> lock(swapMutex);
 		++step;
-		drawTickTock = !drawTickTock;
+		calcTickTock = !calcTickTock;
+		hasFinishedCalculating = false;
 	}
 	condition.notify_all();
 }
@@ -1315,8 +1316,7 @@ void Engine::ThreadEntryPoint()
 	{
 		{
 			unique_lock<mutex> lock(swapMutex);
-			while(calcTickTock == drawTickTock && !terminate)
-				condition.wait(lock);
+			condition.wait(lock, [this] { return !hasFinishedCalculating || terminate; });
 
 			if(terminate)
 				break;
@@ -1324,10 +1324,9 @@ void Engine::ThreadEntryPoint()
 
 		// Do all the calculations.
 		CalculateStep();
-
 		{
 			unique_lock<mutex> lock(swapMutex);
-			calcTickTock = drawTickTock;
+			hasFinishedCalculating = true;
 		}
 		condition.notify_one();
 	}

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -175,6 +175,7 @@ private:
 
 	bool calcTickTock = false;
 	bool drawTickTock = false;
+	bool hasFinishedCalculating = true;
 	bool terminate = false;
 	bool wasActive = false;
 	DrawList draw[2];


### PR DESCRIPTION
**Bugfix:** This PR fixes #6475 

## Fix Details

The Engine::Draw() function used one frame before the one it should use, meaning that it was always one frame late. This PR fixes this issue by making it so that Draw() immediately uses the newly calculated draw lists.

## Testing Done

Used the save file from the linked issue to shoot the mission Korath to death. With this PR the kill shot appears behind the dialog as expected. I also used clang's thread sanitizer to verify that this PR doesn't introduce a new race condition.

## Save File

See the linked issue.
