### PR TITLE
fix(mechanics): Draw overlays with the correct zoom level

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -504,12 +504,10 @@ void Engine::Step(bool isActive)
 	wasActive = isActive;
 	Audio::Update(center);
 
-	// Now that the calculation thread it is safe to update to the new zoom value.
-	if(nextZoom)
-	{
-		zoom = nextZoom;
-		nextZoom = 0.;
-	}
+	// Update the zoom value now that the calculation thread is paused.
+	// TODO: std::exchange
+	swap(zoom, nextZoom);
+	nextZoom = 0.; 
 	// Smoothly zoom in and out.
 	if(isActive)
 	{

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -509,7 +509,7 @@ void Engine::Step(bool isActive)
 	{
 		// TODO: std::exchange
 		zoom = nextZoom;
-		nextZoom = 0.; 
+		nextZoom = 0.;
 	}
 	// Smoothly zoom in and out.
 	if(isActive)

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -505,9 +505,12 @@ void Engine::Step(bool isActive)
 	Audio::Update(center);
 
 	// Update the zoom value now that the calculation thread is paused.
-	// TODO: std::exchange
-	swap(zoom, nextZoom);
-	nextZoom = 0.; 
+	if(nextZoom)
+	{
+		// TODO: std::exchange
+		zoom = nextZoom;
+		nextZoom = 0.; 
+	}
 	// Smoothly zoom in and out.
 	if(isActive)
 	{

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -504,6 +504,12 @@ void Engine::Step(bool isActive)
 	wasActive = isActive;
 	Audio::Update(center);
 
+	// Update the zoom value to the new one.
+	if(nextZoom)
+	{
+		zoom = nextZoom;
+		nextZoom = 0.;
+	}
 	// Smoothly zoom in and out.
 	if(isActive)
 	{
@@ -518,9 +524,9 @@ void Engine::Step(bool isActive)
 
 			double zoomRatio = max(MIN_SPEED, min(MAX_SPEED, abs(log2(zoom) - log2(zoomTarget)) * ZOOM_SPEED));
 			if(zoom < zoomTarget)
-				zoom = min(zoomTarget, zoom * (1. + zoomRatio));
+				nextZoom = min(zoomTarget, zoom * (1. + zoomRatio));
 			else if(zoom > zoomTarget)
-				zoom = max(zoomTarget, zoom * (1. / (1. + zoomRatio)));
+				nextZoom = max(zoomTarget, zoom * (1. / (1. + zoomRatio)));
 		}
 	}
 
@@ -1338,6 +1344,10 @@ void Engine::ThreadEntryPoint()
 void Engine::CalculateStep()
 {
 	FrameTimer loadTimer;
+
+	// The zoom for this step is either the next or if it
+	// didn't change the current one.
+	const double zoom = nextZoom ? nextZoom : this->zoom;
 
 	// Clear the list of objects to draw.
 	draw[calcTickTock].Clear(step, zoom);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -504,7 +504,7 @@ void Engine::Step(bool isActive)
 	wasActive = isActive;
 	Audio::Update(center);
 
-	// Update the zoom value to the new one.
+	// Now that the calculation thread it is safe to update to the new zoom value.
 	if(nextZoom)
 	{
 		zoom = nextZoom;
@@ -1345,8 +1345,9 @@ void Engine::CalculateStep()
 {
 	FrameTimer loadTimer;
 
-	// The zoom for this step is either the next or if it
-	// didn't change the current one.
+	// If there is a pending zoom update then use it
+	// because the zoom will get updated in the main thread
+	// as soon as the calculation thread is finished.
 	const double zoom = nextZoom ? nextZoom : this->zoom;
 
 	// Clear the list of objects to draw.

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -238,6 +238,8 @@ private:
 	TestContext *testContext = nullptr;
 
 	double zoom = 1.;
+	// Tracks the next zoom change so that objects aren't drawn at different zooms.
+	double nextZoom = 0.;
 
 	double load = 0.;
 	int loadCount = 0;

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -238,7 +238,7 @@ private:
 	TestContext *testContext = nullptr;
 
 	double zoom = 1.;
-	// Tracks the next zoom change so that objects aren't drawn at different zooms.
+	// Tracks the next zoom change so that objects aren't drawn at different zooms in a single frame.
 	double nextZoom = 0.;
 
 	double load = 0.;


### PR DESCRIPTION
## Fix Details

When zooming in and out the `zoom` variable is changed right in the middle of a frame. This means that objects are drawn at different zoom levels depending on if they appeared before or after when the `zoom` variable gets updated. This mainly affects things like status overlays and planet labels.

This PR fixes this issue by storing the zoom change in another variable that gets updated at the start of a frame.

The reason for why `zoom` isn't updated with `nextZoom` inside `CalculateStep` is because that would cause a race condition between `Draw` and `CalculateStep`.

## Testing Done

Quickly zoomed in and out and paying attention to the planet labels and the status overlays. With this PR they are consistent while without they seems to be one frame too slow.