### PR TITLE
Fix crash when dying ships jettison their cargo.

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -354,6 +354,7 @@ int CargoHold::Transfer(const string &commodity, int amount, CargoHold &to)
 	// Remove up to the specified tons of cargo from this cargo hold, adding
 	// them to the given cargo hold if possible. If not possible, add the
 	// remainder back to this cargo hold, even if there is not space for it.
+	// Do not invalidate existing iterators by modifying the container.
 	int removed = Remove(commodity, amount);
 	int added = to.Add(commodity, removed);
 	commodities[commodity] += removed - added;
@@ -372,6 +373,7 @@ int CargoHold::Transfer(const Outfit *outfit, int amount, CargoHold &to)
 	// Remove up to the specified number of items from this cargo hold, adding
 	// them to the given cargo hold if possible. If not possible, add the
 	// remainder back to this cargo hold, even if there is not space for it.
+	// Do not invalidate existing iterators by modifying the container.
 	int removed = Remove(outfit, amount);
 	int added = to.Add(outfit, removed);
 	outfits[outfit] += removed - added;

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -209,7 +209,13 @@ int CargoHold::OutfitsSize() const
 // zero, so this check cannot be done by calling OutfitsSize().
 bool CargoHold::HasOutfits() const
 {
-	return !outfits.empty();
+	// The code for adding and removing outfits does not clear the entry in the
+	// map if its value becomes zero, so we need to check all the entries:
+	for(const auto &it : outfits)
+		if(it.second)
+			return true;
+
+	return false;
 }
 
 
@@ -237,7 +243,9 @@ bool CargoHold::HasMissionCargo() const
 // Check if there is anything in this cargo hold (including passengers).
 bool CargoHold::IsEmpty() const
 {
-	return commodities.empty() && outfits.empty() && missionCargo.empty() && passengers.empty();
+	// The outfits map's entries are not erased if they are equal to zero, so
+	// it's not enough to just test outfits.empty().
+	return commodities.empty() && !HasOutfits() && missionCargo.empty() && passengers.empty();
 }
 
 
@@ -366,9 +374,7 @@ int CargoHold::Transfer(const Outfit *outfit, int amount, CargoHold &to)
 	// remainder back to this cargo hold, even if there is not space for it.
 	int removed = Remove(outfit, amount);
 	int added = to.Add(outfit, removed);
-	int remainder = removed - added;
-	if(remainder)
-		outfits[outfit] += remainder;
+	outfits[outfit] += removed - added;
 
 	return added;
 }
@@ -504,10 +510,6 @@ int CargoHold::Remove(const Outfit *outfit, int amount)
 
 	amount = min(amount, outfits[outfit]);
 	outfits[outfit] -= amount;
-
-	// Remove the entry if there is no instance of this outfit in this cargo hold.
-	if(!outfits[outfit])
-		outfits.erase(outfit);
 	return amount;
 }
 
@@ -562,6 +564,12 @@ int CargoHold::IllegalCargoFine() const
 	// Only the worst illegal outfit is fined.
 	for(const auto &it : outfits)
 	{
+		// The code for adding and removing outfits does not clear the entry in the
+		// map if its value becomes zero, so we need to check if the outfit is
+		// actually inside the cargo hold.
+		if(!it.second)
+			continue;
+
 		int fine = it.first->Get("illegal");
 		if(it.first->Get("atrocity") > 0.)
 			return -1;

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -244,8 +244,8 @@ bool CargoHold::HasMissionCargo() const
 bool CargoHold::IsEmpty() const
 {
 	// The outfits map's entries are not erased if they are equal to zero, so
-	// it's not enough to just test outfits.empty().
-	return commodities.empty() && !HasOutfits() && missionCargo.empty() && passengers.empty();
+	// it's not enough to just test outfits.empty(). Same goes for commodities.
+	return !CommoditiesSize() && !HasOutfits() && missionCargo.empty() && passengers.empty();
 }
 
 


### PR DESCRIPTION
This ones on me. When implementing the feedback from derpy I looked through the code base to see if there were any loops that called `Cargo::Remove` and I missed the one in Ship where a dying ship jettisons its cargo. This was risky anyways tbh and could have been a bug in the future anyways even without that loop. 

This reverts that PR and uses the original fix I had for the issue in question, namely ignoring outfits with no count when calculating the fine.