### PR TITLE
NPCs don't offer to refuel ships that do not need fuel.

### DIFF
--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -79,8 +79,8 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<
 	{
 		// Is the player in any need of assistance?
 		const Ship *flagship = player.Flagship();
-		// Check if the player is out of fuel.
-		if(!flagship->JumpsRemaining())
+		// Check if the player is in need of fuel to jump away.
+		if(!flagship->JumpsRemaining() && flagship->JumpFuel() && flagship->Attributes().Get("fuel capacity"))
 		{
 			playerNeedsHelp = true;
 			canGiveFuel = ship->CanRefuel(*flagship);


### PR DESCRIPTION
**Bugfix:** This PR fixes #6192.

## Fix Details

This PR adds an additional check when deciding whether the player's flagship is in need of fuel: The amount of jump fuel it is missing to make a jump.

This basically means that if the player doesn't have a hyperdrive or doesn't have fuel capacity the NPCs won't offer to refuel them.

## Testing Done

Asked for help with a ship without a hyperdrive and with a ship without any fuel capacity. With this PR the NPCs do not come to your help.

