### PR TITLE
Fix attribute typo

### DIFF
--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -210,7 +210,7 @@ mission "Curious Waiter"
 	minor
 	source
 		government "Syndicate"
-		attributes "fatory"
+		attributes "factory"
 		not attributes "station"
 	to offer
 		random < 1


### PR DESCRIPTION
## Summary
Fix typo in culture conversations. 

I haven't tested this, but it seems pretty straightforward to me. I'm pretty sure this is preventing this conversation from ever occurring. 


