### PR TITLE
Removable event changes

### DIFF
--- a/source/GameEvent.cpp
+++ b/source/GameEvent.cpp
@@ -128,6 +128,7 @@ void GameEvent::Load(const DataNode &node)
 			changes.push_back(child);
 		else if(child.HasChildren() && child.Token(0) == "to" && child.Token(1) == "remove")
 		{
+			isRemovable = true;
 			toRemove.Load(child);
 		}
 		else if(child.HasChildren() && child.Token(0) == "on" && child.Token(1) == "remove")
@@ -295,6 +296,20 @@ void GameEvent::Remove(PlayerInfo &player)
 	setRemoval.Add("set", "removed event: " + name);
 	setRemoval.Apply(player.Conditions());
 	onRemove->Apply(player, false);
+}
+
+
+
+bool GameEvent::Removable() const
+{
+	return isRemovable;
+}
+
+
+
+ConditionSet GameEvent::ToRemove() const
+{
+	return toRemove;
 }
 
 

--- a/source/GameEvent.h
+++ b/source/GameEvent.h
@@ -63,9 +63,17 @@ public:
 	const Date &GetDate() const;
 	void SetDate(const Date &date);
 
-	void Apply(PlayerInfo &player);
+	void Apply(PlayerInfo &player, bool save = true);
+	void Remove(PlayerInfo &player);
+
+	bool Removable() const;
+	ConditionSet ToRemove() const;
 
 	const std::list<DataNode> &Changes() const;
+
+
+private:
+	GameEvent(const DataNode &node, bool internal);
 
 
 private:
@@ -73,9 +81,12 @@ private:
 	std::string name;
 	bool isDisabled = false;
 	bool isDefined = false;
+	bool isRemover = false;
 
 	ConditionSet conditionsToApply;
+	ConditionSet toRemove;
 	std::list<DataNode> changes;
+	GameEvent *onRemove;
 	std::vector<const System *> systemsToVisit;
 	std::vector<const Planet *> planetsToVisit;
 	std::vector<const System *> systemsToUnvisit;

--- a/source/GameEvent.h
+++ b/source/GameEvent.h
@@ -73,7 +73,7 @@ public:
 
 
 private:
-	GameEvent(const DataNode &node, bool internal);
+	GameEvent(const DataNode &node, bool remover);
 
 
 private:
@@ -81,6 +81,7 @@ private:
 	std::string name;
 	bool isDisabled = false;
 	bool isDefined = false;
+	bool isRemovable = false;
 	bool isRemover = false;
 
 	ConditionSet conditionsToApply;

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -83,8 +83,14 @@ public:
 	// are multiple pilots with the same name it may have a digit appended.)
 	std::string Identifier() const;
 
-	// Apply the given changes and store them in the player's saved game file.
-	void AddChanges(std::list<DataNode> &changes);
+	// Apply the given changes and (usually) store them in the player's saved game file.
+	void AddChanges(std::list<DataNode> &changes, bool addToSave = true);
+
+	// Apply the changes in the given removable event.
+	void AddRemovableChanges(GameEvent &removable);
+
+	void UndoRemovableChanges();
+
 	// Add an event that will happen at the given date.
 	void AddEvent(const GameEvent &event, const Date &date);
 
@@ -285,6 +291,7 @@ public:
 private:
 	// Apply any "changes" saved in this player info to the global game state.
 	void ApplyChanges();
+	void ApplyChanges(std::list<DataNode> &changes);
 	// After loading & applying changes, make sure the player & ship locations are sensible.
 	void ValidateLoad();
 
@@ -367,6 +374,7 @@ private:
 	// Changes that this PlayerInfo wants to make to the global galaxy state:
 	std::vector<std::pair<const Government *, double>> reputationChanges;
 	std::list<DataNode> dataChanges;
+	std::map<int, GameEvent> appliedRemovableChanges;
 	DataNode economy;
 	// Persons that have been killed in this player's universe:
 	std::vector<std::string> destroyedPersons;


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed at https://discord.com/channels/251118043411775489/323990864890298368/976279509043122236
with some earlier discussion at https://discord.com/channels/251118043411775489/266345072554016768/941828721256570962

## Feature Details
An event can be defined with conditions for its removal, when those conditions are met, it will be removed.
The event will need to include changes to be made to runtime objects to achieve the removal of its original changes, but these removing changes will not be written to the save file, instead, the original changes will be removed, and a condition indicating that the event was undone will be set.
Some things an event can do aren't undone. Conditions the event might set won't be removed and system/planet visits/unvisits will not be undone.

Not all the way done yet, I think PlayerInfo::Save and Load still need to be updated for this and I haven't added anything that triggers checking the currently applied removable events against the current conditions for removal.

## UI Screenshots
N/A

## Usage Examples
```
event "name"
    <changes>
    to remove
        "remove event name"
    on remove
        <changes that would previously be placed in a separate event to undo this one>
```

## Testing Done
It builds and it launches. It's possible it'll corrupt saves.

## Performance Impact
N/A
