### PR TITLE
Silence OpenGL deprecation messages on macOS

### DIFF
--- a/source/opengl.h
+++ b/source/opengl.h
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 // Include whichever header is used for OpenGL on this operating system.
 #ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
 #include <OpenGL/GL3.h>
 #else
 #ifdef ES_GLES


### PR DESCRIPTION
**Bugfix:** This PR addresses the issue where `scons tests` will fail to compile because of all the deprecation messages related to OpenGL being deprecated on macOS since 10.14.  These messages are now silenced because they aren't helping anything.

## Fix Details
Define the `GL_SILENCE_DEPRECATION` macro in opengl.h to silence the messages.

## Testing Done
The messages no longer appear when running `scons tests`.  I can't confirm if compilation can fully succeed, however, as SDL is throwing a couple errors now that the output isn't clogged up with OpenGL messages.

## Save File
N/A, this is a build-time bug only.

