### PR TITLE
Fix visuals on ships being offset when accelerating.

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1395,7 +1395,6 @@ void Engine::CalculateStep()
 		player.SetSystem(*playerSystem);
 		EnterSystem();
 	}
-	Prune(ships);
 
 	// Move the asteroids. This must be done before collision detection. Minables
 	// may create visuals or flotsam.
@@ -1421,6 +1420,11 @@ void Engine::CalculateStep()
 	for(Visual &visual : visuals)
 		visual.Move();
 	Prune(visuals);
+
+	// Visuals can depend on Ships for visuals centered on them. As such it is only
+	// safe to prune the ship list after the visuals can observe any ships that
+	// are going to be pruned.
+	Prune(ships);
 
 	// Perform various minor actions.
 	SpawnFleets();

--- a/source/Visual.cpp
+++ b/source/Visual.cpp
@@ -61,22 +61,23 @@ Visual::Visual(const Effect &effect, Point pos, const Body &follow, Point veloci
 void Visual::Move()
 {
 	if(lifetime-- <= 0 || (follow && follow->ShouldBeRemoved()))
+	{
 		MarkForRemoval();
+		return;
+	}
+
+	if(follow)
+	{
+		// Match the position + facing of the body that this visual is centered on.
+		position = follow->Position() + follow->Facing().Rotate(positionOffset) + velocityOffset;
+		angle = follow->Facing() + facingOffset;
+
+		velocityOffset += velocity;
+		facingOffset += spin;
+	}
 	else
 	{
-		if(follow)
-		{
-			// Match the position + facing of the body that this visual is centered on.
-			position = follow->Position() + follow->Facing().Rotate(positionOffset) + velocityOffset;
-			angle = follow->Facing() + facingOffset;
-
-			velocityOffset += velocity;
-			facingOffset += spin;
-		}
-		else
-		{
-			position += velocity;
-			angle += spin;
-		}
+		position += velocity;
+		angle += spin;
 	}
 }

--- a/source/Visual.h
+++ b/source/Visual.h
@@ -28,6 +28,8 @@ class Visual : public Body {
 public:
 	Visual() = default;
 	Visual(const Effect &effect, Point pos, Point vel, Angle facing, Point hitVelocity = Point());
+	Visual(const Effect &effect, Point pos, const Body &follow, Point velocityOffset = Point(), Angle facingOffset = Angle());
+
 
 	/* Functions provided by the Body base class:
 	Frame GetFrame(int step = -1) const;
@@ -45,6 +47,13 @@ public:
 private:
 	Angle spin;
 	int lifetime = 0;
+
+	// The body this visual is centered on. Every frame this visual will update its
+	// position to match its center body.
+	const Body *follow = nullptr;
+	Point positionOffset;
+	Point velocityOffset;
+	Angle facingOffset;
 };
 
 


### PR DESCRIPTION
## Fix Details

Visuals are drawn incorrectly when accelerating, they keep the initial velocity they had when created but don't take into account that the ship where the visuals are drawn has accelerated, resulting in the following (sorry for the bad gifs):

![ion offset demo](https://user-images.githubusercontent.com/85879619/169649783-e4ba455c-d351-4844-93e9-2b32c907dc37.gif)

Notice that during the actual jump the ion sparks are not even on the ship anymore and when exiting the jump they catch up with the ship. And if you look closely you can see the same problem just before the jump when the ship turns as well.

Here's how it looks with this PR:

![ion offset with pr](https://user-images.githubusercontent.com/85879619/169650112-a8ab7360-bb0d-4025-9a32-cb3948c5afdf.gif)

Here's a gif of a ship dying while having a lot of initial velocity with this PR. I can post a gif of how this looks on master but it looks very weird since the explosions aren't drawn on the ship itself.

![death with hitforce demo pr](https://user-images.githubusercontent.com/85879619/169651389-3f3a77a3-c262-4935-8bd2-d0cc6c9563dc.gif)

The fix this PR does is to recalculate the position of the visual based on the position and angle of the ship it is centered on.

## Testing Done

I checked the visuals on DoT (using ion), afterburners, leaks and death explosions.
