### PR TITLE
[Fix]Remnant: Reducing the search area for Remnant Rescue 5

### DIFF
--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -541,7 +541,7 @@ mission "Remnant: Rescue 5"
 		random < 10
 	npc accompany save
 		system
-			near "Terminus" 4
+			near "Terminus" 2
 		personality derelict timid plunders
 		government "Remnant"
 		fleet


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6560 

## Fix Details
If the Ember Threshold was a little more remote (as it is in the map rework) then this distance is good, but until then I think it better to keep this rescue mission a bit closer to the wormhole. Basically, I'd like this mission to cover all the uninhabited areas but not including any of the inhabited systems.

In the meantime, I'd like to make this just a little more focused. (and, again, once the map rework is done, if it is implemented, this corner has a larger collection of uninhabited systems (It goes up to 3 or even 4 jumps to Tania or Delta), so a larger radius of it would be good.)

## Testing Done
n/a

## Save File
n/a
