### PR TITLE
Don't interrupt fast forward when searching on the map

### DIFF
--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -199,6 +199,13 @@ void Dialog::ParseTextNode(const DataNode &node, size_t startingIndex, string &t
 
 
 
+bool Dialog::AllowsFastForward() const noexcept
+{
+	return allowsFastForward;
+}
+
+
+
 bool Dialog::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
 	auto it = KEY_MAP.find(key);

--- a/source/Dialog.h
+++ b/source/Dialog.h
@@ -72,6 +72,9 @@ template <class T>
 	// Static method used to convert a DataNode into formatted Dialog text.
 	static void ParseTextNode(const DataNode &node, size_t startingIndex, std::string &text);
 
+	// Some dialogs allow fast-forward to stay active.
+	bool AllowsFastForward() const noexcept final;
+
 
 protected:
 	// The use can click "ok" or "cancel", or use the tab key to toggle which
@@ -99,6 +102,7 @@ protected:
 	bool okIsActive;
 	bool isMission;
 	bool isOkDisabled = false;
+	bool allowsFastForward = false;
 
 	std::string input;
 
@@ -132,7 +136,9 @@ Dialog::Dialog(T *t, void (T::*fun)(int), const std::string &text, int initialVa
 template <class T>
 Dialog::Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text,
 	std::string initialValue, Truncate truncate)
-	: stringFun(std::bind(fun, t, std::placeholders::_1)), input(initialValue)
+	: stringFun(std::bind(fun, t, std::placeholders::_1)),
+	allowsFastForward(true),
+	input(initialValue)
 {
 	Init(text, truncate);
 }


### PR DESCRIPTION
**Feature:** This PR strikes another line off my todo list.

## Feature Details
As of right now, when the interrupt fast forward preference is on, going to the map does not interrupt fast forward, but should you attempt to search for anything, the search dialog will interrupt the fast forward, turning it off. This PR changes it so that the Dialog UI panel that is used by MapPanel when searching allows fast forward. All other Dialog types have remained untouched.

I'm admittedly not sure where else the Dialog constructor that MapPanel uses for searching is used, so I'm not sure if this now doesn't interrupt where it should, but I do know that this eases my woes with the search dialog interrupting fast forward when I don't want it to.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Searched for systems, outfits, and ships while on the map with the "interrupt fast forward" preference turn on. Without this change, searching for anything interrupts fast forward. With this change, fast forward remains on when searching for anything on the map.

## Performance Impact
N/A
