### PR TITLE
Remove reference to Republic system Porrima in Remnant event

### DIFF
--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -176,6 +176,8 @@ event "remnant: cognizance 1 systems available"
 		remove attributes "inaccessible"
 	system Egeria
 		remove attributes "inaccessible"
+	system Postverta
+		remove attributes "inaccessible"
 	system Prosa
 		remove attributes "inaccessible"
 	system Statina

--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -176,8 +176,6 @@ event "remnant: cognizance 1 systems available"
 		remove attributes "inaccessible"
 	system Egeria
 		remove attributes "inaccessible"
-	system Porrima
-		remove attributes "inaccessible"
 	system Prosa
 		remove attributes "inaccessible"
 	system Statina


### PR DESCRIPTION
----------------------
**Content (Missions)**

## Summary
For some reason the Republic system Porrima is included in the event "remnant: cognizance 1 systems available" which simply removes attribute "inaccessible".

This commit removes that line.


Maybe -- that was supposed to be Postverta instead? It's the next planet alphabetically after Porrima. Seems to be a little mistake there. So, unless Postverta should *not* be included as a target system in various remnant jobs that require 'not attribute "inaccessible"', this event should probably include it. Because as it stands, Postverta is not getting included those missions.