### PR TITLE
fix(UI): Ensure planet label overlap check works correctly at all zoom levels

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -910,12 +910,12 @@ void Engine::Draw() const
 	static const Set<Color> &colors = GameData::Colors();
 	const Interface *hud = GameData::Interfaces().Get("hud");
 
+	draw[drawTickTock].Draw();
+	batchDraw[drawTickTock].Draw();
+
 	// Draw any active planet labels.
 	for(const PlanetLabel &label : labels)
 		label.Draw();
-
-	draw[drawTickTock].Draw();
-	batchDraw[drawTickTock].Draw();
 
 	for(const auto &it : statuses)
 	{

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -910,12 +910,12 @@ void Engine::Draw() const
 	static const Set<Color> &colors = GameData::Colors();
 	const Interface *hud = GameData::Interfaces().Get("hud");
 
-	draw[drawTickTock].Draw();
-	batchDraw[drawTickTock].Draw();
-
 	// Draw any active planet labels.
 	for(const PlanetLabel &label : labels)
 		label.Draw();
+
+	draw[drawTickTock].Draw();
+	batchDraw[drawTickTock].Draw();
 
 	for(const auto &it : statuses)
 	{

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -72,22 +72,24 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 	{
 		bool overlaps = false;
 
-		Point start = object.Position() +
+		Point start = object.Position() * zoom +
 			(radius + INNER_SPACE + LINE_GAP + LINE_LENGTH) * Angle(LINE_ANGLE[d]).Unit();
 		Point unit(LINE_ANGLE[d] > 180. ? -1. : 1., 0.);
-		Point end = start + unit * width;
+		Point end = start + unit * width ;
 
 		for(const StellarObject &other : system->Objects())
 		{
 			if(&other == &object)
 				continue;
 
-			double minDistance = other.Radius() + MIN_DISTANCE;
+			double minDistance = (other.Radius() * zoom) + MIN_DISTANCE;
 
-			double startDistance = other.Position().Distance(start);
-			double endDistance = other.Position().Distance(end);
+			Point otherPos = other.Position() * zoom;
+			double startDistance = otherPos.Distance(start);
+			double endDistance = otherPos.Distance(end);
 			overlaps |= (startDistance < minDistance || endDistance < minDistance);
-			double projection = (other.Position() - start).Dot(unit);
+			double projection = (otherPos - start).Dot(unit);
+
 			if(projection > 0. && projection < width)
 			{
 				double distance = sqrt(startDistance * startDistance - projection * projection);

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -75,7 +75,7 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 		Point start = object.Position() * zoom +
 			(radius + INNER_SPACE + LINE_GAP + LINE_LENGTH) * Angle(LINE_ANGLE[d]).Unit();
 		Point unit(LINE_ANGLE[d] > 180. ? -1. : 1., 0.);
-		Point end = start + unit * width ;
+		Point end = start + unit * width;
 
 		for(const StellarObject &other : system->Objects())
 		{

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -82,7 +82,7 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 			if(&other == &object)
 				continue;
 
-			double minDistance = (other.Radius() * zoom) + MIN_DISTANCE;
+			double minDistance = (other.Radius() + MIN_DISTANCE) * zoom;
 
 			Point otherPos = other.Position() * zoom;
 			double startDistance = otherPos.Distance(start);


### PR DESCRIPTION
**Bugfix:** This PR addresses https://discord.com/channels/251118043411775489/266345072554016768/978383077116084244

## Fix Details
The code that checks if planet labels will overlap with other StellarObjects in the system wasn't properly accounting for zoom.
This should now be fixed.

## Testing Done
Before:
![image](https://user-images.githubusercontent.com/20605679/169899564-b61ea1c3-897c-4804-95f4-05233c277aa4.png)
After:
![image](https://user-images.githubusercontent.com/20605679/169919205-e0b8ee7d-b0c4-47bf-acf3-3b129b0efa7c.png)
![image](https://user-images.githubusercontent.com/20605679/169919216-445a9d14-2689-4f43-be5c-b0d36d155c37.png)
![image](https://user-images.githubusercontent.com/20605679/169919306-b8859845-3487-481e-adef-3a7e19a5687d.png)



## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
Take off and zoom out a bunch.
[test test - Copy.txt](https://github.com/endless-sky/endless-sky/files/8757852/test.test.-.Copy.txt)