### PR TITLE
Fix crash when opening the map with outfits stored on planets without a system.

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -101,6 +101,9 @@ namespace {
 			// Get the system in which the planet storage is located.
 			const Planet *planet = hold.first;
 			const System *system = planet->GetSystem();
+			// Skip outfits stored on planets without a system.
+			if(!system)
+				continue;
 
 			for(const auto &outfit: hold.second.Outfits())
 				// Only count a system if it actually stores outfits.


### PR DESCRIPTION
**Bugfix:** This PR fixes a crash mentioned on the Discord by Cmdr Eric of Brideswell. 

## Fix Details

When the map is opened a tally is being made of outfits in planetary storage. However, if there are outfits on a planet without a system (which can happen either through events or by removing plugins) the game crashes when opening the map panel.

## Testing Done

Open the save file below and open the map panel. Without this PR the game crashes.

## Save File

[Hans_Peterson.txt](https://github.com/endless-sky/endless-sky/files/8762826/Hans_Peterson.txt)
