### PR TITLE
feat: Make minables have different hull values.

### DIFF
--- a/data/harvesting.txt
+++ b/data/harvesting.txt
@@ -11,7 +11,7 @@
 minable "aluminum"
 	sprite "asteroid/silicon/spin"
 	hull 1000
-	"hull deviation" 100
+	"random hull" 200
 	payload "Aluminum" 40
 	explode "smoke" 40
 	explode "bolide" 40
@@ -32,7 +32,7 @@ outfit "Aluminum"
 minable "copper"
 	sprite "asteroid/gold/spin"
 	hull 1200
-	"hull deviation" 120
+	"random hull" 240
 	payload "Copper" 20
 	explode "smoke" 20
 	explode "bolide" 20
@@ -53,7 +53,7 @@ outfit "Copper"
 minable "gold"
 	sprite "asteroid/gold/spin"
 	hull 2800
-	"hull deviation" 280
+	"random hull" 560
 	payload "Gold" 16
 	explode "smoke" 20
 	explode "bolide" 20
@@ -74,7 +74,7 @@ outfit "Gold"
 minable "iron"
 	sprite "asteroid/iron/spin"
 	hull 1600
-	"hull deviation" 160
+	"random hull" 320
 	payload "Iron" 50
 	explode "smoke" 40
 	explode "bolide" 40
@@ -95,7 +95,7 @@ outfit "Iron"
 minable "lead"
 	sprite "asteroid/lead/spin"
 	hull 800
-	"hull deviation" 80
+	"random hull" 160
 	payload "Lead" 32
 	explode "smoke" 30
 	explode "bolide" 30
@@ -116,7 +116,7 @@ outfit "Lead"
 minable "neodymium"
 	sprite "asteroid/iron/spin"
 	hull 3600
-	"hull deviation" 360
+	"random hull" 720
 	payload "Neodymium" 40
 	explode "smoke" 40
 	explode "bolide" 40
@@ -137,7 +137,7 @@ outfit "Neodymium"
 minable "platinum"
 	sprite "asteroid/silver/spin"
 	hull 4000
-	"hull deviation" 400
+	"random hull" 800
 	payload "Platinum" 16
 	explode "smoke" 20
 	explode "bolide" 20
@@ -158,7 +158,7 @@ outfit "Platinum"
 minable "silicon"
 	sprite "asteroid/silicon/spin"
 	hull 400
-	"hull deviation" 40
+	"random hull" 80
 	payload "Silicon" 50
 	explode "smoke" 40
 	explode "bolide" 40
@@ -179,7 +179,7 @@ outfit "Silicon"
 minable "silver"
 	sprite "asteroid/silver/spin"
 	hull 2000
-	"hull deviation" 200
+	"random hull" 400
 	payload "Silver" 20
 	explode "smoke" 20
 	explode "bolide" 20
@@ -200,7 +200,7 @@ outfit "Silver"
 minable "titanium"
 	sprite "asteroid/titanium/spin"
 	hull 2400
-	"hull deviation" 240
+	"random hull" 480
 	payload "Titanium" 32
 	explode "smoke" 30
 	explode "bolide" 30
@@ -221,7 +221,7 @@ outfit "Titanium"
 minable "tungsten"
 	sprite "asteroid/titanium/spin"
 	hull 4800
-	"hull deviation" 480
+	"random hull" 960
 	payload "Tungsten" 24
 	explode "smoke" 30
 	explode "bolide" 30
@@ -242,7 +242,7 @@ outfit "Tungsten"
 minable "uranium"
 	sprite "asteroid/lead/spin"
 	hull 3200
-	"hull deviation" 320
+	"random hull" 640
 	payload "Uranium" 24
 	explode "smoke" 30
 	explode "bolide" 30
@@ -263,7 +263,7 @@ outfit "Uranium"
 minable "yottrite"
 	sprite "asteroid/yottrite/spin"
 	hull 20000
-	"hull deviation" 2000
+	"random hull" 4000
 	payload "Yottrite" 7
 	explode "smoke" 30
 	explode "bolide" 30
@@ -288,7 +288,7 @@ outfit "Yottrite"
 minable "plant"
 	sprite "asteroid/plant/plant"
 	hull 2800
-	"hull deviation" 280
+	"random hull" 560
 	payload "Void Orchid" 21
 	explode "smoke" 30
 	explode "bolide" 30
@@ -297,7 +297,7 @@ minable "plant"
 minable "plant2"
 	sprite "asteroid/plant2/plant2"
 	hull 2600
-	"hull deviation" 260
+	"random hull" 520
 	payload "Void Orchid" 20
 	explode "smoke" 30
 	explode "bolide" 30
@@ -306,7 +306,7 @@ minable "plant2"
 minable "plant cluster"
 	sprite "asteroid/plant cluster/plant cluster"
 	hull 1200
-	"hull deviation" 120
+	"random hull" 240
 	payload "Void Orchid" 11
 	explode "smoke" 20
 	explode "bolide" 20
@@ -315,7 +315,7 @@ minable "plant cluster"
 minable "large plant"
 	sprite "asteroid/large plant/large plant"
 	hull 3800
-	"hull deviation" 380
+	"random hull" 760
 	payload "Void Orchid" 41
 	explode "smoke" 30
 	explode "bolide" 40
@@ -324,7 +324,7 @@ minable "large plant"
 minable "large plant2"
 	sprite "asteroid/large plant2/large plant2"
 	hull 3600
-	"hull deviation" 360
+	"random hull" 720
 	payload "Void Orchid" 41
 	explode "smoke" 30
 	explode "bolide" 40
@@ -333,7 +333,7 @@ minable "large plant2"
 minable "large plant cluster"
 	sprite "asteroid/large plant cluster/large plant cluster"
 	hull 2200
-	"hull deviation" 220
+	"random hull" 440
 	payload "Void Orchid" 22
 	explode "smoke" 30
 	explode "bolide" 40
@@ -342,7 +342,7 @@ minable "large plant cluster"
 minable "live crystal"
 	sprite "asteroid/livecrystal/livecrystal"
 	hull 1000
-	"hull deviation" 100
+	"random hull" 200
 	payload "Void Orchid" 8
 	explode "smoke" 15
 	explode "bolide" 10
@@ -351,7 +351,7 @@ minable "live crystal"
 minable "space flora"
 	sprite "asteroid/space flora/space flora"
 	hull 1000
-	"hull deviation" 100
+	"random hull" 200
 	payload "Void Orchid" 8
 	explode "smoke" 15
 	explode "bolide" 10
@@ -360,7 +360,7 @@ minable "space flora"
 minable "large space flora"
 	sprite "asteroid/large space flora/large space flora"
 	hull 2000
-	"hull deviation" 200
+	"random hull" 400
 	payload "Void Orchid" 16
 	explode "smoke" 25
 	explode "bolide" 20

--- a/data/harvesting.txt
+++ b/data/harvesting.txt
@@ -10,7 +10,7 @@
 
 minable "aluminum"
 	sprite "asteroid/silicon/spin"
-	hull 1000
+	hull 900
 	"random hull" 200
 	payload "Aluminum" 40
 	explode "smoke" 40
@@ -31,7 +31,7 @@ outfit "Aluminum"
 
 minable "copper"
 	sprite "asteroid/gold/spin"
-	hull 1200
+	hull 1080
 	"random hull" 240
 	payload "Copper" 20
 	explode "smoke" 20
@@ -52,7 +52,7 @@ outfit "Copper"
 
 minable "gold"
 	sprite "asteroid/gold/spin"
-	hull 2800
+	hull 2520
 	"random hull" 560
 	payload "Gold" 16
 	explode "smoke" 20
@@ -73,7 +73,7 @@ outfit "Gold"
 
 minable "iron"
 	sprite "asteroid/iron/spin"
-	hull 1600
+	hull 1440
 	"random hull" 320
 	payload "Iron" 50
 	explode "smoke" 40
@@ -94,7 +94,7 @@ outfit "Iron"
 
 minable "lead"
 	sprite "asteroid/lead/spin"
-	hull 800
+	hull 720
 	"random hull" 160
 	payload "Lead" 32
 	explode "smoke" 30
@@ -115,7 +115,7 @@ outfit "Lead"
 
 minable "neodymium"
 	sprite "asteroid/iron/spin"
-	hull 3600
+	hull 3240
 	"random hull" 720
 	payload "Neodymium" 40
 	explode "smoke" 40
@@ -136,7 +136,7 @@ outfit "Neodymium"
 
 minable "platinum"
 	sprite "asteroid/silver/spin"
-	hull 4000
+	hull 3600
 	"random hull" 800
 	payload "Platinum" 16
 	explode "smoke" 20
@@ -157,7 +157,7 @@ outfit "Platinum"
 
 minable "silicon"
 	sprite "asteroid/silicon/spin"
-	hull 400
+	hull 360
 	"random hull" 80
 	payload "Silicon" 50
 	explode "smoke" 40
@@ -178,7 +178,7 @@ outfit "Silicon"
 
 minable "silver"
 	sprite "asteroid/silver/spin"
-	hull 2000
+	hull 1800
 	"random hull" 400
 	payload "Silver" 20
 	explode "smoke" 20
@@ -199,7 +199,7 @@ outfit "Silver"
 
 minable "titanium"
 	sprite "asteroid/titanium/spin"
-	hull 2400
+	hull 2160
 	"random hull" 480
 	payload "Titanium" 32
 	explode "smoke" 30
@@ -220,7 +220,7 @@ outfit "Titanium"
 
 minable "tungsten"
 	sprite "asteroid/titanium/spin"
-	hull 4800
+	hull 4320
 	"random hull" 960
 	payload "Tungsten" 24
 	explode "smoke" 30
@@ -241,7 +241,7 @@ outfit "Tungsten"
 
 minable "uranium"
 	sprite "asteroid/lead/spin"
-	hull 3200
+	hull 2880
 	"random hull" 640
 	payload "Uranium" 24
 	explode "smoke" 30
@@ -262,7 +262,7 @@ outfit "Uranium"
 
 minable "yottrite"
 	sprite "asteroid/yottrite/spin"
-	hull 20000
+	hull 18000
 	"random hull" 4000
 	payload "Yottrite" 7
 	explode "smoke" 30
@@ -287,7 +287,7 @@ outfit "Yottrite"
 
 minable "plant"
 	sprite "asteroid/plant/plant"
-	hull 2800
+	hull 2520
 	"random hull" 560
 	payload "Void Orchid" 21
 	explode "smoke" 30
@@ -296,7 +296,7 @@ minable "plant"
 
 minable "plant2"
 	sprite "asteroid/plant2/plant2"
-	hull 2600
+	hull 2340
 	"random hull" 520
 	payload "Void Orchid" 20
 	explode "smoke" 30
@@ -305,7 +305,7 @@ minable "plant2"
 
 minable "plant cluster"
 	sprite "asteroid/plant cluster/plant cluster"
-	hull 1200
+	hull 1080
 	"random hull" 240
 	payload "Void Orchid" 11
 	explode "smoke" 20
@@ -314,7 +314,7 @@ minable "plant cluster"
 
 minable "large plant"
 	sprite "asteroid/large plant/large plant"
-	hull 3800
+	hull 3420
 	"random hull" 760
 	payload "Void Orchid" 41
 	explode "smoke" 30
@@ -323,7 +323,7 @@ minable "large plant"
 
 minable "large plant2"
 	sprite "asteroid/large plant2/large plant2"
-	hull 3600
+	hull 3240
 	"random hull" 720
 	payload "Void Orchid" 41
 	explode "smoke" 30
@@ -332,7 +332,7 @@ minable "large plant2"
 
 minable "large plant cluster"
 	sprite "asteroid/large plant cluster/large plant cluster"
-	hull 2200
+	hull 1980
 	"random hull" 440
 	payload "Void Orchid" 22
 	explode "smoke" 30
@@ -341,7 +341,7 @@ minable "large plant cluster"
 
 minable "live crystal"
 	sprite "asteroid/livecrystal/livecrystal"
-	hull 1000
+	hull 900
 	"random hull" 200
 	payload "Void Orchid" 8
 	explode "smoke" 15
@@ -350,7 +350,7 @@ minable "live crystal"
 
 minable "space flora"
 	sprite "asteroid/space flora/space flora"
-	hull 1000
+	hull 900
 	"random hull" 200
 	payload "Void Orchid" 8
 	explode "smoke" 15
@@ -359,7 +359,7 @@ minable "space flora"
 
 minable "large space flora"
 	sprite "asteroid/large space flora/large space flora"
-	hull 2000
+	hull 1800
 	"random hull" 400
 	payload "Void Orchid" 16
 	explode "smoke" 25

--- a/data/harvesting.txt
+++ b/data/harvesting.txt
@@ -11,6 +11,7 @@
 minable "aluminum"
 	sprite "asteroid/silicon/spin"
 	hull 1000
+	"hull deviation" 100
 	payload "Aluminum" 40
 	explode "smoke" 40
 	explode "bolide" 40
@@ -31,6 +32,7 @@ outfit "Aluminum"
 minable "copper"
 	sprite "asteroid/gold/spin"
 	hull 1200
+	"hull deviation" 120
 	payload "Copper" 20
 	explode "smoke" 20
 	explode "bolide" 20
@@ -51,6 +53,7 @@ outfit "Copper"
 minable "gold"
 	sprite "asteroid/gold/spin"
 	hull 2800
+	"hull deviation" 280
 	payload "Gold" 16
 	explode "smoke" 20
 	explode "bolide" 20
@@ -71,6 +74,7 @@ outfit "Gold"
 minable "iron"
 	sprite "asteroid/iron/spin"
 	hull 1600
+	"hull deviation" 160
 	payload "Iron" 50
 	explode "smoke" 40
 	explode "bolide" 40
@@ -91,6 +95,7 @@ outfit "Iron"
 minable "lead"
 	sprite "asteroid/lead/spin"
 	hull 800
+	"hull deviation" 80
 	payload "Lead" 32
 	explode "smoke" 30
 	explode "bolide" 30
@@ -111,6 +116,7 @@ outfit "Lead"
 minable "neodymium"
 	sprite "asteroid/iron/spin"
 	hull 3600
+	"hull deviation" 360
 	payload "Neodymium" 40
 	explode "smoke" 40
 	explode "bolide" 40
@@ -131,6 +137,7 @@ outfit "Neodymium"
 minable "platinum"
 	sprite "asteroid/silver/spin"
 	hull 4000
+	"hull deviation" 400
 	payload "Platinum" 16
 	explode "smoke" 20
 	explode "bolide" 20
@@ -151,6 +158,7 @@ outfit "Platinum"
 minable "silicon"
 	sprite "asteroid/silicon/spin"
 	hull 400
+	"hull deviation" 40
 	payload "Silicon" 50
 	explode "smoke" 40
 	explode "bolide" 40
@@ -171,6 +179,7 @@ outfit "Silicon"
 minable "silver"
 	sprite "asteroid/silver/spin"
 	hull 2000
+	"hull deviation" 200
 	payload "Silver" 20
 	explode "smoke" 20
 	explode "bolide" 20
@@ -191,6 +200,7 @@ outfit "Silver"
 minable "titanium"
 	sprite "asteroid/titanium/spin"
 	hull 2400
+	"hull deviation" 240
 	payload "Titanium" 32
 	explode "smoke" 30
 	explode "bolide" 30
@@ -211,6 +221,7 @@ outfit "Titanium"
 minable "tungsten"
 	sprite "asteroid/titanium/spin"
 	hull 4800
+	"hull deviation" 480
 	payload "Tungsten" 24
 	explode "smoke" 30
 	explode "bolide" 30
@@ -231,6 +242,7 @@ outfit "Tungsten"
 minable "uranium"
 	sprite "asteroid/lead/spin"
 	hull 3200
+	"hull deviation" 320
 	payload "Uranium" 24
 	explode "smoke" 30
 	explode "bolide" 30
@@ -251,6 +263,7 @@ outfit "Uranium"
 minable "yottrite"
 	sprite "asteroid/yottrite/spin"
 	hull 20000
+	"hull deviation" 2000
 	payload "Yottrite" 7
 	explode "smoke" 30
 	explode "bolide" 30
@@ -275,6 +288,7 @@ outfit "Yottrite"
 minable "plant"
 	sprite "asteroid/plant/plant"
 	hull 2800
+	"hull deviation" 280
 	payload "Void Orchid" 21
 	explode "smoke" 30
 	explode "bolide" 30
@@ -283,6 +297,7 @@ minable "plant"
 minable "plant2"
 	sprite "asteroid/plant2/plant2"
 	hull 2600
+	"hull deviation" 260
 	payload "Void Orchid" 20
 	explode "smoke" 30
 	explode "bolide" 30
@@ -291,6 +306,7 @@ minable "plant2"
 minable "plant cluster"
 	sprite "asteroid/plant cluster/plant cluster"
 	hull 1200
+	"hull deviation" 120
 	payload "Void Orchid" 11
 	explode "smoke" 20
 	explode "bolide" 20
@@ -299,6 +315,7 @@ minable "plant cluster"
 minable "large plant"
 	sprite "asteroid/large plant/large plant"
 	hull 3800
+	"hull deviation" 380
 	payload "Void Orchid" 41
 	explode "smoke" 30
 	explode "bolide" 40
@@ -307,6 +324,7 @@ minable "large plant"
 minable "large plant2"
 	sprite "asteroid/large plant2/large plant2"
 	hull 3600
+	"hull deviation" 360
 	payload "Void Orchid" 41
 	explode "smoke" 30
 	explode "bolide" 40
@@ -315,6 +333,7 @@ minable "large plant2"
 minable "large plant cluster"
 	sprite "asteroid/large plant cluster/large plant cluster"
 	hull 2200
+	"hull deviation" 220
 	payload "Void Orchid" 22
 	explode "smoke" 30
 	explode "bolide" 40
@@ -323,6 +342,7 @@ minable "large plant cluster"
 minable "live crystal"
 	sprite "asteroid/livecrystal/livecrystal"
 	hull 1000
+	"hull deviation" 100
 	payload "Void Orchid" 8
 	explode "smoke" 15
 	explode "bolide" 10
@@ -331,6 +351,7 @@ minable "live crystal"
 minable "space flora"
 	sprite "asteroid/space flora/space flora"
 	hull 1000
+	"hull deviation" 100
 	payload "Void Orchid" 8
 	explode "smoke" 15
 	explode "bolide" 10
@@ -339,6 +360,7 @@ minable "space flora"
 minable "large space flora"
 	sprite "asteroid/large space flora/large space flora"
 	hull 2000
+	"hull deviation" 200
 	payload "Void Orchid" 16
 	explode "smoke" 25
 	explode "bolide" 20

--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -47,7 +47,7 @@ void Minable::Load(const DataNode &node)
 		else if(child.Token(0) == "hull" && child.Size() >= 2)
 			hull = max(0., child.Value(1));
 		else if(child.Token(0) == "random hull" && child.Size() >= 2)
-			randomHull = child.Value(1);
+			randomHull = max(0., child.Value(1));
 		else if((child.Token(0) == "payload" || child.Token(0) == "explode") && child.Size() >= 2)
 		{
 			int count = (child.Size() == 2 ? 1 : child.Value(2));

--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -45,9 +45,9 @@ void Minable::Load(const DataNode &node)
 		if(child.Token(0) == "sprite" && child.Size() >= 2)
 			SetSprite(SpriteSet::Get(child.Token(1)));
 		else if(child.Token(0) == "hull" && child.Size() >= 2)
-			hull = child.Value(1);
-		else if(child.Token(0) == "hull deviation" && child.Size() >= 2)
-			hullDeviation = max(0., child.Value(1));
+			hull = max(0., child.Value(1));
+		else if(child.Token(0) == "random hull" && child.Size() >= 2)
+			randomHull = child.Value(1);
 		else if((child.Token(0) == "payload" || child.Token(0) == "explode") && child.Size() >= 2)
 		{
 			int count = (child.Size() == 2 ? 1 : child.Value(2));
@@ -124,11 +124,8 @@ void Minable::Place(double energy, double beltRadius)
 	radius = scale / (1. + eccentricity * cos(theta));
 	position = radius * Point(cos(theta + rotation), sin(theta + rotation));
 
-	// Choose a random hull value for the object.
-	hull += (2. * Random::Real() - 1.) * hullDeviation;
-	// Don't allow a newly placed minable to immediately explode.
-	if(hull < 0.)
-		hull = 0.;
+	// Add a random amount of hull value to the object.
+	hull += Random::Real() * randomHull;
 }
 
 

--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -46,6 +46,8 @@ void Minable::Load(const DataNode &node)
 			SetSprite(SpriteSet::Get(child.Token(1)));
 		else if(child.Token(0) == "hull" && child.Size() >= 2)
 			hull = child.Value(1);
+		else if(child.Token(0) == "hull deviation" && child.Size() >= 2)
+			hullDeviation = max(0., child.Value(1));
 		else if((child.Token(0) == "payload" || child.Token(0) == "explode") && child.Size() >= 2)
 		{
 			int count = (child.Size() == 2 ? 1 : child.Value(2));
@@ -121,6 +123,12 @@ void Minable::Place(double energy, double beltRadius)
 	// Calculate the object's initial position.
 	radius = scale / (1. + eccentricity * cos(theta));
 	position = radius * Point(cos(theta + rotation), sin(theta + rotation));
+
+	// Choose a random hull value for the object.
+	hull += (2. * Random::Real() - 1.) * hullDeviation;
+	// Don't allow a newly placed minable to immediately explode.
+	if(hull < 0.)
+		hull = 0.;
 }
 
 

--- a/source/Minable.h
+++ b/source/Minable.h
@@ -89,7 +89,7 @@ private:
 	// Remaining "hull" strength of the object, before it is destroyed.
 	double hull = 1000.;
 	// A random amount the hull of the object deviates by.
-	double hullDeviation = 100.;
+	double randomHull = 200.;
 	// Material released when this object is destroyed. Each payload item only
 	// has a 25% chance of surviving, meaning that usually the yield is much
 	// lower than the defined limit but occasionally you get quite lucky.

--- a/source/Minable.h
+++ b/source/Minable.h
@@ -89,7 +89,7 @@ private:
 	// Remaining "hull" strength of the object, before it is destroyed.
 	double hull = 1000.;
 	// A random amount the hull of the object deviates by.
-	double randomHull = 200.;
+	double randomHull = 0.;
 	// Material released when this object is destroyed. Each payload item only
 	// has a 25% chance of surviving, meaning that usually the yield is much
 	// lower than the defined limit but occasionally you get quite lucky.

--- a/source/Minable.h
+++ b/source/Minable.h
@@ -88,6 +88,8 @@ private:
 
 	// Remaining "hull" strength of the object, before it is destroyed.
 	double hull = 1000.;
+	// A random amount the hull of the object deviates by.
+	double hullDeviation = 100.;
 	// Material released when this object is destroyed. Each payload item only
 	// has a 25% chance of surviving, meaning that usually the yield is much
 	// lower than the defined limit but occasionally you get quite lucky.


### PR DESCRIPTION
## Feature Details

Currently minables all have the same hull value (minables of the same type that is). This PR introduces a new attribute, `"random hull"`, to specify by how much the hull of a minable should be increased randomly.

I have also updated the minables in the game to have 20% random hull. 

## Usage Examples

```
minable "silver"
	sprite "asteroid/silver/spin"
	hull 2000
	"random hull" 400  # <-- this
	payload "Silver" 20
	explode "smoke" 20
	explode "bolide" 20
	explode "asteroid crunch small"
```

## Testing Done

When to a system with minables and verified that they all have randomly generated hull values.

## Performance Impact

N/A.
