### PR TITLE
fix(typo/mechanic): fleet entry point priority

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -332,7 +332,7 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 				// If this ship is not "welcome" in the current system, prefer to have
 				// it enter from a system that is friendly to it. (This is for realism,
 				// so attack fleets don't come from what ought to be a safe direction.)
-				if(isWelcomeHere || neighbor->GetGovernment()->IsEnemy(government))
+				if(isWelcomeHere || !neighbor->GetGovernment()->IsEnemy(government))
 					linkVector.push_back(neighbor);
 				else
 					linkVector.insert(linkVector.end(), 8, neighbor);


### PR DESCRIPTION
**Bugfix:** Noticed this while looking to implement #6864

## Fix Details
Expected behaviour (as described in comment):
If a fleet is welcome in this system (`isWelcomeHere` is true), neighbouring systems should not be deprioritised regardless of government.
If a fleet is not welcome in this system, neighbouring systems should be deprioritised if they are allies of this government (or hostile to the entering fleet?)

However, `neighbor->GetGovernment()->IsEnemy(government)` will be true if the government of the neighbouring system is enemies with `government`, which is the government of this fleet.

Strictly speaking, the comment says enemy fleets should not enter from systems that are not enemies of this system, not that they shouldn't enter from systems that are enemies of the fleet. So should this perhaps compare the government of the neighbouring system with the government of this system? Or against both the government of this system and teh enterig fleet?
