### PR TITLE
[Fix]Remnant: Replacing reference to cloaking device

### DIFF
--- a/data/remnant/remnant.txt
+++ b/data/remnant/remnant.txt
@@ -467,7 +467,7 @@ phrase "friendly remnant"
 	word
 		" by having "
 	word
-		"a cloaking device along"
+		"cloaking functionality"
 		"a secret weapon"
 		"fast engines"
 		"a last resort every Remnant should have"


### PR DESCRIPTION
**Bugfix:** This PR addresses the issue that one of the Remnant hails mentions cloaking devices.

## Fix Details
One of their hails mentions how thankful they are that they had a cloaking device. This is practically saying they have cloaking outfits, which they don't. 

So, this fix replaces "a cloaking device along" with "cloaking functionality". It works in all the phrases, is more accurate, doesn't lead people to expect to find cloaking outfits somewhere, and thus improves the phrases.

