### PR TITLE
[Fix] Remnant: Give Cog 27 the landing attribute

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1206,6 +1206,7 @@ mission "Remnant: Cognizance 26"
 mission "Remnant: Cognizance 27"
 	name "Check in with Torza on <planet>"
 	description "Torza should have a team ready on <planet>."
+	landing
 	source "Ssil Vida"
 	destination "Caelian"
 	to offer


### PR DESCRIPTION
**Bugfix:** This PR addresses issue reported by matthew.najmon on the Discord

## Fix Details
This is just a reminder mission to send the player to see Torza, which will remain active until Torza can actually be met. This adds the "landing" attribute so that it triggers properly instead of relying on them going to the spaceport.

Thanks for spotting this behavior!

Note: The mission currently triggers just fine (and invisibly) if someone went to the spaceport. Since most veteran players go to the spaceport regularly when doing campaign missions, I suspect most of us just got the mission that way and didn't realize it.