### PR TITLE
Use pilot name to test deletion

### DIFF
--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -216,10 +216,10 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	else if(key == 'd' && !selectedPilot.empty())
 	{
 		GetUI()->Push(new Dialog(this, &LoadPanel::DeletePilot,
-			"Are you sure you want to delete the selected pilot, \"" + (player.FirstName() + " " + player.LastName())
+			"Are you sure you want to delete the selected pilot, \"" + loadedInfo.Name()
 				+ "\", and all their saved games?\n\n(This will permanently delete the pilot data.)\n"
 				+ "Confirm the name of the pilot you want to delete.",
-				[this](const string &pilot) { return pilot == (player.FirstName() + " " + player.LastName()); }));
+				[this](const string &pilot) { return pilot == loadedInfo.Name(); }));
 	}
 	else if(key == 'a' && !player.IsDead() && player.IsLoaded())
 	{

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -216,10 +216,10 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	else if(key == 'd' && !selectedPilot.empty())
 	{
 		GetUI()->Push(new Dialog(this, &LoadPanel::DeletePilot,
-			"Are you sure you want to delete the selected pilot, \"" + selectedPilot
+			"Are you sure you want to delete the selected pilot, \"" + (player.FirstName() + " " + player.LastName())
 				+ "\", and all their saved games?\n\n(This will permanently delete the pilot data.)\n"
 				+ "Confirm the name of the pilot you want to delete.",
-				[this](const string &pilot) { return pilot == selectedPilot; }));
+				[this](const string &pilot) { return pilot == (player.FirstName() + " " + player.LastName()); }));
 	}
 	else if(key == 'a' && !player.IsDead() && player.IsLoaded())
 	{


### PR DESCRIPTION
### **Bugfix:** This PR addresses issue #6882

## Fix Details
This fix avoids situations where the file name is used and the file name and pilot name don't match up.

## Testing Done
Loaded a savegame with has mis-matching file and pilot names, the game now accepts the pilot name and rejects the file name (if it differs from the pilot name)

## Save File
This save file can be used to verify the bugfix. The bug will occur when using f2e933b17f0f66afd749e35233e83174abcf7698, and will not occur when using this branch's build.
This save file (with mis-matching file and pilot names) can be used: [recent.txt](https://github.com/endless-sky/endless-sky/files/8791531/recent.txt)

Additionally the delete prompt also correctly displays the pilot name.

## Screenshots showing the new behaviour:
Note that the file name is `recent.txt` and the pilot name `Blockade Runner`
![image](https://user-images.githubusercontent.com/65236599/170836084-8bc47feb-7e09-42f1-8575-8442b530ae0e.png)
![image](https://user-images.githubusercontent.com/65236599/170836092-798060d8-5a6a-4226-b6ca-99508d3df20b.png)
