### PR TITLE
Skip IsStaying NPCs as player escorts

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -417,7 +417,7 @@ void Engine::Place(const list<NPC> &npcs, shared_ptr<Ship> flagship)
 			// player: the rest of the NPC track it.
 			if(npcFlagship && ship != npcFlagship)
 				ship->SetParent(npcFlagship);
-			else if(!ship->GetPersonality().IsUninterested())
+			else if(!ship->GetPersonality().IsUninterested() && !ship->GetPersonality().IsStaying())
 				ship->SetParent(flagship);
 			else
 				ship->SetParent(nullptr);


### PR DESCRIPTION
Player escorts gets a large list of NPCs.  Player Escorts should probably have their own list.

![img](https://cdn.discordapp.com/attachments/536900466655887360/980317321430196294/Screenshot_taken_at_2022-05-28_23-48-09.png)

Context here https://discord.com/channels/251118043411775489/536900466655887360/980317321719595028