### PR TITLE
Add ExclusiveItem class

### DIFF
--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		02D34A71AE3BC4C93FC6865B /* TestData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestData.cpp; path = source/TestData.cpp; sourceTree = "<group>"; };
 		072599BE26A8C67D007EC229 /* SDL2.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = SDL2.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		072599CC26A8C942007EC229 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = build/SDL2.framework; sourceTree = "<group>"; };
+		086E48E490C9BAD6660C7274 /* ExclusiveItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ExclusiveItem.h; path = source/ExclusiveItem.h; sourceTree = "<group>"; };
 		0C90483BB01ECD0E3E8DDA44 /* WeightedList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WeightedList.h; path = source/WeightedList.h; sourceTree = "<group>"; };
 		0DF34095B64BC64F666ECF5F /* CoreStartData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CoreStartData.cpp; path = source/CoreStartData.cpp; sourceTree = "<group>"; };
 		11EA4AD7A889B6AC1441A198 /* StartConditionsPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StartConditionsPanel.cpp; path = source/StartConditionsPanel.cpp; sourceTree = "<group>"; };
@@ -863,6 +864,7 @@
 				8CB543A1AA20F764DD7FC15A /* MenuAnimationPanel.h */,
 				61FA4C2BB89E08C5E2B8B4B9 /* Variant.cpp */,
 				5EBC44769E84CF0C953D08B3 /* Variant.h */,
+				086E48E490C9BAD6660C7274 /* ExclusiveItem.h */,
 			);
 			name = source;
 			sourceTree = "<group>";

--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -134,6 +134,7 @@
 		<Unit filename="source/EscortDisplay.h" />
 		<Unit filename="source/EsUuid.cpp" />
 		<Unit filename="source/EsUuid.h" />
+		<Unit filename="source/ExclusiveItem.h" />
 		<Unit filename="source/File.cpp" />
 		<Unit filename="source/File.h" />
 		<Unit filename="source/Files.cpp" />

--- a/EndlessSkyTests.cbp
+++ b/EndlessSkyTests.cbp
@@ -75,6 +75,7 @@
 		<Unit filename="tests/unit/src/test_datafile.cpp" />
 		<Unit filename="tests/unit/src/test_datanode.cpp" />
 		<Unit filename="tests/unit/src/test_esuuid.cpp" />
+		<Unit filename="tests/unit/src/test_exclusiveItem.cpp" />
 		<Unit filename="tests/unit/src/test_firecommand.cpp" />
 		<Unit filename="tests/unit/src/test_main.cpp" />
 		<Unit filename="tests/unit/src/test_point.cpp" />

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -85,6 +85,14 @@ bool Conversation::RequiresLaunch(int outcome)
 
 
 
+// Construct and Load() at the same time.
+Conversation::Conversation(const DataNode &node, const string &missionName)
+{
+	Load(node, missionName);
+}
+
+
+
 // Load a conversation from file.
 void Conversation::Load(const DataNode &node, const string &missionName)
 {

--- a/source/Conversation.h
+++ b/source/Conversation.h
@@ -54,6 +54,9 @@ public:
 	static bool RequiresLaunch(int outcome);
 
 public:
+	Conversation() = default;
+	// Construct and Load() at the same time.
+	Conversation(const DataNode &node, const std::string &missionName = "");
 	// Read or write to files.
 	void Load(const DataNode &node, const std::string &missionName = "");
 	void Save(DataWriter &out) const;

--- a/source/ExclusiveItem.h
+++ b/source/ExclusiveItem.h
@@ -33,6 +33,8 @@ public:
 	ExclusiveItem(const ExclusiveItem&) = default;
 	ExclusiveItem &operator=(const ExclusiveItem&) = default;
 
+	bool IsStock() const { return stockItem; }
+
 	const Type *operator->() const noexcept { return stockItem ? stockItem : std::addressof(item); }
 	const Type &operator*() const noexcept { return stockItem ? *stockItem : item; }
 

--- a/source/ExclusiveItem.h
+++ b/source/ExclusiveItem.h
@@ -28,16 +28,16 @@ public:
 	ExclusiveItem(const Type *item) : stockItem(item) {}
 	explicit ExclusiveItem(Type &&item) : item(std::move(item)) {}
 
-	ExclusiveItem(ExclusiveItem<Type>&&) = default;
-	ExclusiveItem<Type> &operator=(ExclusiveItem<Type>&&) = default;
-	ExclusiveItem(const ExclusiveItem<Type>&) = default;
-	ExclusiveItem<Type> &operator=(const ExclusiveItem<Type>&) = default;
+	ExclusiveItem(ExclusiveItem&&) = default;
+	ExclusiveItem &operator=(ExclusiveItem&&) = default;
+	ExclusiveItem(const ExclusiveItem&) = default;
+	ExclusiveItem &operator=(const ExclusiveItem&) = default;
 
 	const Type *operator->() const noexcept { return stockItem ? stockItem : std::addressof(item); }
 	const Type &operator*() const noexcept { return stockItem ? *stockItem : item; }
 
-	bool operator==(const ExclusiveItem<Type> &other) const { return this->operator*() == other.operator*(); }
-	bool operator!=(const ExclusiveItem<Type> &other) const { return !(this->operator*() == other.operator*()); }
+	bool operator==(const ExclusiveItem &other) const { return this->operator*() == other.operator*(); }
+	bool operator!=(const ExclusiveItem &other) const { return !(this->operator*() == other.operator*()); }
 
 
 private:

--- a/source/ExclusiveItem.h
+++ b/source/ExclusiveItem.h
@@ -28,16 +28,16 @@ public:
 	ExclusiveItem(const Type *item) : stockItem(item) {}
 	explicit ExclusiveItem(Type &&item) : item(std::move(item)) {}
 
-	ExclusiveItem(ExclusiveItem<Type> &&other) = default;
-	ExclusiveItem(const ExclusiveItem<Type> &other) = default;
+	ExclusiveItem(ExclusiveItem<Type>&&) = default;
+	ExclusiveItem<Type> &operator=(ExclusiveItem<Type>&&) = default;
+	ExclusiveItem(const ExclusiveItem<Type>&) = default;
+	ExclusiveItem<Type> &operator=(const ExclusiveItem<Type>&) = default;
 
 	const Type *operator->() const noexcept { return stockItem ? stockItem : std::addressof(item); }
 	const Type &operator*() const noexcept { return stockItem ? *stockItem : item; }
 
-	ExclusiveItem<Type> &operator=(ExclusiveItem<Type> &&other) = default;
-	ExclusiveItem<Type> &operator=(const ExclusiveItem<Type> &other) = default;
-	bool operator==(const ExclusiveItem<Type> &other) const { return **this == *other; }
-	bool operator!=(const ExclusiveItem<Type> &other) const { return !(**this == *other); }
+	bool operator==(const ExclusiveItem<Type> &other) const { return this->operator*() == other.operator*(); }
+	bool operator!=(const ExclusiveItem<Type> &other) const { return !(this->operator*() == other.operator*()); }
 
 
 private:

--- a/source/ExclusiveItem.h
+++ b/source/ExclusiveItem.h
@@ -28,14 +28,14 @@ public:
 	ExclusiveItem(const Type *item) : stockItem(item) {}
 	explicit ExclusiveItem(Type &&item) : item(std::move(item)) {}
 
-	ExclusiveItem(ExclusiveItem<Type> &&other) : stockItem(other.stockItem), item(std::move(other.item)) {}
-	ExclusiveItem(const ExclusiveItem<Type> &other) : stockItem(other.stockItem), item(other.item) {}
+	ExclusiveItem(ExclusiveItem<Type> &&other) = default;
+	ExclusiveItem(const ExclusiveItem<Type> &other) = default;
 
 	const Type *operator->() const noexcept { return stockItem ? stockItem : std::addressof(item); }
 	const Type &operator*() const noexcept { return stockItem ? *stockItem : item; }
 
-	ExclusiveItem<Type> &operator=(ExclusiveItem<Type> &&other) { stockItem = other.stockItem; item = std::move(other.item); return *this; }
-	ExclusiveItem<Type> &operator=(const ExclusiveItem<Type> &other) { stockItem = other.stockItem; item = other.item; return *this; }
+	ExclusiveItem<Type> &operator=(ExclusiveItem<Type> &&other) = default;
+	ExclusiveItem<Type> &operator=(const ExclusiveItem<Type> &other) = default;
 	bool operator==(const ExclusiveItem<Type> &other) const { return *this == *other; }
 	bool operator!=(const ExclusiveItem<Type> &other) const { return !(*this == other); }
 

--- a/source/ExclusiveItem.h
+++ b/source/ExclusiveItem.h
@@ -1,0 +1,47 @@
+/* ExclusiveItem.h
+Copyright (c) 2022 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef EXCLUSIVE_ITEM_H_
+#define EXCLUSIVE_ITEM_H_
+
+
+
+// An ExclusiveItem is an object stored as either a pointer or a stock
+// object, but not both.
+template <class Type>
+class ExclusiveItem {
+public:
+	ExclusiveItem() = default;
+
+	ExclusiveItem(const Type *item) : stockItem(item) {}
+	explicit ExclusiveItem(Type &&item) : item(std::move(item)) {}
+
+	ExclusiveItem(ExclusiveItem<Type> &&other) : stockItem(other.stockItem), item(std::move(other.item)) {}
+	ExclusiveItem(const ExclusiveItem<Type> &other) : stockItem(other.stockItem), item(other.item) {}
+
+	const Type *operator->() const noexcept { return stockItem ? stockItem : std::addressof(item); }
+	const Type &operator*() const noexcept { return stockItem ? *stockItem : item; }
+
+	ExclusiveItem<Type> &operator=(ExclusiveItem<Type> &&other) { stockItem = other.stockItem; item = std::move(other.item); return *this; }
+	ExclusiveItem<Type> &operator=(const ExclusiveItem<Type> &other) { stockItem = other.stockItem; item = other.item; return *this; }
+	bool operator==(const ExclusiveItem<Type> &other) const { return *this == *other; }
+	bool operator!=(const ExclusiveItem<Type> &other) const { return !(*this == other); }
+
+
+private:
+	const Type *stockItem = nullptr;
+	Type item;
+};
+
+
+
+#endif

--- a/source/ExclusiveItem.h
+++ b/source/ExclusiveItem.h
@@ -18,14 +18,14 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 
 
-// An ExclusiveItem is an object stored as either a pointer or a stock
-// object, but not both.
+// This class provides "data template" classes with abstracted access to an object that
+// is either a reference to a shared, "stock" data or is a locally customized instance.
 template <class Type>
 class ExclusiveItem {
 public:
 	ExclusiveItem() = default;
 
-	ExclusiveItem(const Type *item) : stockItem(item) {}
+	explicit ExclusiveItem(const Type *item) : stockItem(item) {}
 	explicit ExclusiveItem(Type &&item) : item(std::move(item)) {}
 
 	ExclusiveItem(ExclusiveItem&&) = default;
@@ -33,7 +33,7 @@ public:
 	ExclusiveItem(const ExclusiveItem&) = default;
 	ExclusiveItem &operator=(const ExclusiveItem&) = default;
 
-	bool IsStock() const { return stockItem; }
+	bool IsStock() const noexcept { return stockItem; }
 
 	const Type *operator->() const noexcept { return stockItem ? stockItem : std::addressof(item); }
 	const Type &operator*() const noexcept { return stockItem ? *stockItem : item; }

--- a/source/ExclusiveItem.h
+++ b/source/ExclusiveItem.h
@@ -13,6 +13,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef EXCLUSIVE_ITEM_H_
 #define EXCLUSIVE_ITEM_H_
 
+#include <memory>
+#include <utility>
+
 
 
 // An ExclusiveItem is an object stored as either a pointer or a stock

--- a/source/ExclusiveItem.h
+++ b/source/ExclusiveItem.h
@@ -36,8 +36,8 @@ public:
 
 	ExclusiveItem<Type> &operator=(ExclusiveItem<Type> &&other) = default;
 	ExclusiveItem<Type> &operator=(const ExclusiveItem<Type> &other) = default;
-	bool operator==(const ExclusiveItem<Type> &other) const { return *this == *other; }
-	bool operator!=(const ExclusiveItem<Type> &other) const { return !(*this == other); }
+	bool operator==(const ExclusiveItem<Type> &other) const { return **this == *other; }
+	bool operator!=(const ExclusiveItem<Type> &other) const { return !(**this == *other); }
 
 
 private:

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -79,7 +79,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			if(hasValue && child.Token(1) == "phrase")
 			{
 				if(!child.HasChildren() && child.Size() == 3)
-					stockDialogPhrase = GameData::Phrases().Get(child.Token(2));
+					dialogPhrase = ExclusiveItem<Phrase>(GameData::Phrases().Get(child.Token(2)));
 				else
 					child.PrintTrace("Skipping unsupported dialog phrase syntax:");
 			}
@@ -87,7 +87,7 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 			{
 				const DataNode &firstGrand = (*child.begin());
 				if(firstGrand.Size() == 1 && firstGrand.HasChildren())
-					dialogPhrase.Load(firstGrand);
+					dialogPhrase = ExclusiveItem<Phrase>(Phrase(firstGrand));
 				else
 					firstGrand.PrintTrace("Skipping unsupported dialog phrase syntax:");
 			}
@@ -95,9 +95,9 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 				Dialog::ParseTextNode(child, 1, dialogText);
 		}
 		else if(key == "conversation" && child.HasChildren())
-			conversation.Load(child, missionName);
+			conversation = ExclusiveItem<Conversation>(Conversation(child, missionName));
 		else if(key == "conversation" && hasValue)
-			stockConversation = GameData::Conversations().Get(child.Token(1));
+			conversation = ExclusiveItem<Conversation>(GameData::Conversations().Get(child.Token(1)));
 		else if(key == "require" && hasValue)
 		{
 			int count = (child.Size() < 3 ? 1 : static_cast<int>(child.Value(2)));
@@ -153,8 +153,8 @@ void MissionAction::Save(DataWriter &out) const
 			}
 			out.EndChild();
 		}
-		if(!conversation.IsEmpty())
-			conversation.Save(out);
+		if(!conversation->IsEmpty())
+			conversation->Save(out);
 		for(const auto &it : requiredOutfits)
 			out.Write("require", it.first->Name(), it.second);
 
@@ -173,16 +173,8 @@ string MissionAction::Validate() const
 	if(!systemFilter.IsValid())
 		return "system location filter";
 
-	// Stock phrases that generate text must be defined.
-	if(stockDialogPhrase && stockDialogPhrase->IsEmpty())
-		return "stock phrase";
-
-	// Stock conversations must be defined.
-	if(stockConversation && stockConversation->IsEmpty())
-		return "stock conversation";
-
 	// Conversations must have valid actions.
-	string reason = stockConversation ? stockConversation->Validate() : conversation.Validate();
+	string reason = conversation->Validate();
 	if(!reason.empty())
 		return reason;
 
@@ -281,11 +273,11 @@ bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &
 void MissionAction::Do(PlayerInfo &player, UI *ui, const System *destination, const shared_ptr<Ship> &ship, const bool isUnique) const
 {
 	bool isOffer = (trigger == "offer");
-	if(!conversation.IsEmpty() && ui)
+	if(!conversation->IsEmpty() && ui)
 	{
 		// Conversations offered while boarding or assisting reference a ship,
 		// which may be destroyed depending on the player's choices.
-		ConversationPanel *panel = new ConversationPanel(player, conversation, destination, ship);
+		ConversationPanel *panel = new ConversationPanel(player, *conversation, destination, ship);
 		if(isOffer)
 			panel->SetCallback(&player, &PlayerInfo::MissionCallback);
 		// Use a basic callback to handle forced departure outside of `on offer`
@@ -338,16 +330,12 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 	result.action = action.Instantiate(subs, jumps, payload);
 
 	// Create any associated dialog text from phrases, or use the directly specified text.
-	string dialogText = stockDialogPhrase ? stockDialogPhrase->Get()
-		: (!dialogPhrase.Name().empty() ? dialogPhrase.Get()
-		: this->dialogText);
+	string dialogText = !dialogPhrase->IsEmpty() ? dialogPhrase->Get() : this->dialogText;
 	if(!dialogText.empty())
 		result.dialogText = Format::Replace(dialogText, subs);
 
-	if(stockConversation)
-		result.conversation = stockConversation->Instantiate(subs, jumps, payload);
-	else if(!conversation.IsEmpty())
-		result.conversation = conversation.Instantiate(subs, jumps, payload);
+	if(!conversation->IsEmpty())
+		result.conversation = ExclusiveItem<Conversation>(conversation->Instantiate(subs, jumps, payload));
 
 	// Restore the "<payment>" and "<fine>" values from the "on complete" condition, for
 	// use in other parts of this mission.

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -173,6 +173,14 @@ string MissionAction::Validate() const
 	if(!systemFilter.IsValid())
 		return "system location filter";
 
+	// Stock phrases that generate text must be defined.
+	if(dialogPhrase.IsStock() && dialogPhrase->IsEmpty())
+		return "stock phrase";
+
+	// Stock conversations must be defined.
+	if(conversation.IsStock() && conversation->IsEmpty())
+		return "stock conversation";
+
 	// Conversations must have valid actions.
 	string reason = conversation->Validate();
 	if(!reason.empty())

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #define MISSION_ACTION_H_
 
 #include "Conversation.h"
+#include "ExclusiveItem.h"
 #include "GameAction.h"
 #include "LocationFilter.h"
 #include "Phrase.h"
@@ -69,11 +70,8 @@ private:
 	LocationFilter systemFilter;
 
 	std::string dialogText;
-	const Phrase *stockDialogPhrase = nullptr;
-	Phrase dialogPhrase;
-
-	const Conversation *stockConversation = nullptr;
-	Conversation conversation;
+	ExclusiveItem<Phrase> dialogPhrase;
+	ExclusiveItem<Conversation> conversation;
 
 	// Outfits that are required to be owned (or not) for this action to be performable.
 	std::map<const Outfit *, int> requiredOutfits;

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -326,7 +326,7 @@ string NPC::Validate(bool asTemplate) const
 		// If a stock phrase or conversation is given, it must not be empty.
 		if(dialogPhrase.IsStock() && dialogPhrase->IsEmpty())
 			return "stock phrase";
-		if(converstion.IsStock() && conversation->IsEmpty())
+		if(conversation.IsStock() && conversation->IsEmpty())
 			return "stock conversation";
 
 		// NPC fleets, unlike stock fleets, do not need a valid government

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -121,7 +121,7 @@ void NPC::Load(const DataNode &node)
 			if(hasValue && child.Token(1) == "phrase")
 			{
 				if(!child.HasChildren() && child.Size() == 3)
-					stockDialogPhrase = GameData::Phrases().Get(child.Token(2));
+					dialogPhrase = ExclusiveItem<Phrase>(GameData::Phrases().Get(child.Token(2)));
 				else
 					child.PrintTrace("Skipping unsupported dialog phrase syntax:");
 			}
@@ -129,7 +129,7 @@ void NPC::Load(const DataNode &node)
 			{
 				const DataNode &firstGrand = (*child.begin());
 				if(firstGrand.Size() == 1 && firstGrand.HasChildren())
-					dialogPhrase.Load(firstGrand);
+					dialogPhrase = ExclusiveItem<Phrase>(Phrase(firstGrand));
 				else
 					firstGrand.PrintTrace("Skipping unsupported dialog phrase syntax:");
 			}
@@ -137,9 +137,9 @@ void NPC::Load(const DataNode &node)
 				Dialog::ParseTextNode(child, 1, dialogText);
 		}
 		else if(child.Token(0) == "conversation" && child.HasChildren())
-			conversation.Load(child);
+			conversation = ExclusiveItem<Conversation>(Conversation(child));
 		else if(child.Token(0) == "conversation" && child.Size() > 1)
-			stockConversation = GameData::Conversations().Get(child.Token(1));
+			conversation = ExclusiveItem<Conversation>(GameData::Conversations().Get(child.Token(1)));
 		else if(child.Token(0) == "to" && child.Size() >= 2)
 		{
 			if(child.Token(1) == "spawn")
@@ -180,7 +180,7 @@ void NPC::Load(const DataNode &node)
 		{
 			if(child.HasChildren())
 			{
-				fleets.emplace_back(child);
+				fleets.emplace_back(ExclusiveItem<Fleet>(Fleet(child)));
 				if(child.Size() >= 2)
 				{
 					// Copy the custom fleet in lieu of reparsing the same DataNode.
@@ -189,10 +189,14 @@ void NPC::Load(const DataNode &node)
 						fleets.push_back(fleets.back());
 				}
 			}
-			else if(child.Size() >= 3 && child.Value(2) > 1.)
-				stockFleets.insert(stockFleets.end(), child.Value(2), GameData::Fleets().Get(child.Token(1)));
 			else if(child.Size() >= 2)
-				stockFleets.push_back(GameData::Fleets().Get(child.Token(1)));
+			{
+				auto fleet = ExclusiveItem<Fleet>(GameData::Fleets().Get(child.Token(1)));
+				if(child.Size() >= 3 && child.Value(2) > 1.)
+					fleets.insert(fleets.end(), child.Value(2), fleet);
+				else
+					fleets.push_back(fleet);
+			}
 		}
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
@@ -275,8 +279,8 @@ void NPC::Save(DataWriter &out) const
 			}
 			out.EndChild();
 		}
-		if(!conversation.IsEmpty())
-			conversation.Save(out);
+		if(!conversation->IsEmpty())
+			conversation->Save(out);
 
 		for(const shared_ptr<Ship> &ship : ships)
 		{
@@ -319,20 +323,11 @@ string NPC::Validate(bool asTemplate) const
 		if(planet && !planet->IsValid())
 			return "planet \"" + planet->TrueName() + "\"";
 
-		// If a stock phrase or conversation is given, it must not be empty.
-		if(stockDialogPhrase && stockDialogPhrase->IsEmpty())
-			return "stock phrase";
-		if(stockConversation && stockConversation->IsEmpty())
-			return "stock conversation";
-
 		// NPC fleets, unlike stock fleets, do not need a valid government
 		// since they will unconditionally inherit this NPC's government.
 		for(auto &&fleet : fleets)
-			if(!fleet.IsValid(false))
-				return "custom fleet";
-		for(auto &&fleet : stockFleets)
 			if(!fleet->IsValid(false))
-				return "stock fleet";
+				return "fleet";
 	}
 
 	// Ships must always be valid.
@@ -452,8 +447,8 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, bool isVisible)
 	{
 		// If "completing" this NPC displays a conversation, reference
 		// it, to allow the completing event's target to be destroyed.
-		if(!conversation.IsEmpty())
-			ui->Push(new ConversationPanel(player, conversation, nullptr, ship));
+		if(!conversation->IsEmpty())
+			ui->Push(new ConversationPanel(player, *conversation, nullptr, ship));
 		else if(!dialogText.empty())
 			ui->Push(new Dialog(dialogText));
 	}
@@ -601,9 +596,7 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 		result.ships.push_back(make_shared<Ship>(**shipIt));
 		result.ships.back()->SetName(*nameIt);
 	}
-	for(const Fleet &fleet : fleets)
-		fleet.Place(*result.system, result.ships, false);
-	for(const Fleet *fleet : stockFleets)
+	for(const ExclusiveItem<Fleet> &fleet : fleets)
 		fleet->Place(*result.system, result.ships, false);
 	// Ships should either "enter" the system or start out there.
 	for(const shared_ptr<Ship> &ship : result.ships)
@@ -631,16 +624,12 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 		subs["<npc>"] = result.ships.front()->Name();
 
 	// Do string replacement on any dialog or conversation.
-	string dialogText = stockDialogPhrase ? stockDialogPhrase->Get()
-		: (!dialogPhrase.Name().empty() ? dialogPhrase.Get()
-		: this->dialogText);
+	string dialogText = !dialogPhrase->IsEmpty() ? dialogPhrase->Get() : this->dialogText;
 	if(!dialogText.empty())
 		result.dialogText = Format::Replace(dialogText, subs);
 
-	if(stockConversation)
-		result.conversation = stockConversation->Instantiate(subs);
-	else if(!conversation.IsEmpty())
-		result.conversation = conversation.Instantiate(subs);
+	if(!conversation->IsEmpty())
+		result.conversation = ExclusiveItem<Conversation>(conversation->Instantiate(subs));
 
 	return result;
 }

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -323,11 +323,17 @@ string NPC::Validate(bool asTemplate) const
 		if(planet && !planet->IsValid())
 			return "planet \"" + planet->TrueName() + "\"";
 
+		// If a stock phrase or conversation is given, it must not be empty.
+		if(dialogPhrase.IsStock() && dialogPhrase->IsEmpty())
+			return "stock phrase";
+		if(converstion.IsStock() && conversation->IsEmpty())
+			return "stock conversation";
+
 		// NPC fleets, unlike stock fleets, do not need a valid government
 		// since they will unconditionally inherit this NPC's government.
 		for(auto &&fleet : fleets)
 			if(!fleet->IsValid(false))
-				return "fleet";
+				return fleet.IsStock() ? "stock fleet" : "custom fleet";
 	}
 
 	// Ships must always be valid.

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Conversation.h"
 #include "EsUuid.h"
+#include "ExclusiveItem.h"
 #include "Fleet.h"
 #include "LocationFilter.h"
 #include "Personality.h"
@@ -104,11 +105,8 @@ private:
 
 	// Dialog or conversation to show when all requirements for this NPC are met:
 	std::string dialogText;
-	const Phrase *stockDialogPhrase = nullptr;
-	Phrase dialogPhrase;
-
-	Conversation conversation;
-	const Conversation *stockConversation = nullptr;
+	ExclusiveItem<Phrase> dialogPhrase;
+	ExclusiveItem<Conversation> conversation;
 
 	// Conditions that must be met in order for this NPC to be placed or despawned:
 	ConditionSet toSpawn;
@@ -128,8 +126,7 @@ private:
 	std::list<std::shared_ptr<Ship>> ships;
 	std::list<const Ship *> stockShips;
 	std::list<std::string> shipNames;
-	std::list<Fleet> fleets;
-	std::list<const Fleet *> stockFleets;
+	std::list<ExclusiveItem<Fleet>> fleets;
 
 	// This must be done to each ship in this set to complete the mission:
 	int succeedIf = 0;

--- a/source/Phrase.cpp
+++ b/source/Phrase.cpp
@@ -20,6 +20,13 @@ using namespace std;
 
 
 
+Phrase::Phrase(const DataNode &node)
+{
+	Load(node);
+}
+
+
+
 void Phrase::Load(const DataNode &node)
 {
 	// Set the name of this phrase, so we know it has been loaded.

--- a/source/Phrase.h
+++ b/source/Phrase.h
@@ -27,6 +27,10 @@ class DataNode;
 // Class representing a set of rules for generating text strings from words.
 class Phrase {
 public:
+	Phrase() = default;
+	// Construct and Load() at the same time.
+	Phrase(const DataNode &node);
+
 	// Parse the given node into a new branch associated with this phrase.
 	void Load(const DataNode &node);
 

--- a/source/StartConditions.cpp
+++ b/source/StartConditions.cpp
@@ -79,10 +79,7 @@ void StartConditions::Load(const DataNode &node)
 					[&value](const Ship &s) noexcept -> bool { return s.ModelName() == value; }),
 					ships.end());
 			else if(key == "conversation")
-			{
-				stockConversation = nullptr;
-				conversation = Conversation();
-			}
+				conversation = ExclusiveItem<Conversation>();
 			else if(key == "conditions")
 				conditions = ConditionSet();
 			else
@@ -115,9 +112,9 @@ void StartConditions::Load(const DataNode &node)
 				child.PrintTrace("Skipping unsupported use of a \"stock\" ship (a full definition is required):");
 		}
 		else if(key == "conversation" && child.HasChildren() && !add)
-			conversation.Load(child);
+			conversation = ExclusiveItem<Conversation>(Conversation(child));
 		else if(key == "conversation" && hasValue && !child.HasChildren())
-			stockConversation = GameData::Conversations().Get(value);
+			conversation = ExclusiveItem<Conversation>(GameData::Conversations().Get(value));
 		else if(add)
 			child.PrintTrace("Skipping unsupported use of \"add\":");
 		else
@@ -196,7 +193,7 @@ const vector<Ship> &StartConditions::Ships() const noexcept
 
 const Conversation &StartConditions::GetConversation() const
 {
-	return stockConversation ? *stockConversation : conversation;
+	return *conversation;
 }
 
 

--- a/source/StartConditions.h
+++ b/source/StartConditions.h
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "ConditionSet.h"
 #include "Conversation.h"
+#include "ExclusiveItem.h"
 
 #include <string>
 #include <vector>
@@ -59,8 +60,7 @@ private:
 	std::vector<Ship> ships;
 
 	// The conversation to display when a game begins with this scenario.
-	Conversation conversation;
-	const Conversation *stockConversation = nullptr;
+	ExclusiveItem<Conversation> conversation;
 
 	const Sprite *thumbnail = nullptr;
 	// The user-friendly display name for this starting scenario.

--- a/tests/unit/src/test_exclusiveItem.cpp
+++ b/tests/unit/src/test_exclusiveItem.cpp
@@ -16,7 +16,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "../../../source/ExclusiveItem.h"
 
 // ... and any system includes needed for the test file.
-#include <utility>
 
 namespace { // test namespace
 

--- a/tests/unit/src/test_exclusiveItem.cpp
+++ b/tests/unit/src/test_exclusiveItem.cpp
@@ -16,6 +16,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "../../../source/ExclusiveItem.h"
 
 // ... and any system includes needed for the test file.
+#include <utility>
 
 namespace { // test namespace
 
@@ -47,7 +48,7 @@ SCENARIO( "Creating an ExclusiveItem" , "[ExclusiveItem][Creation]" ) {
 
 		WHEN( "an object is added by reference" ) {
 			auto obj = Object(2);
-			item = ExclusiveItem<Object>(obj);
+			item = ExclusiveItem<Object>(std::move(obj));
 			THEN( "the object is obtainable and the item is nonstock" ) {
 				CHECK_FALSE( item.IsStock() );
 				CHECK( item->GetValue() == 2 );
@@ -66,16 +67,16 @@ SCENARIO( "Creating an ExclusiveItem" , "[ExclusiveItem][Creation]" ) {
 	GIVEN( "two exclusive items" ) {
 		auto firstItem = ExclusiveItem<Object>{};
 		auto secondItem = ExclusiveItem<Object>{};
-		
+
 		WHEN( "the contents are equivalent" ) {
 			auto obj = Object(2);
 			firstItem = ExclusiveItem<Object>(&obj);
-			secondItem = ExclusiveItem<Object>(obj);
+			secondItem = ExclusiveItem<Object>(std::move(obj));
 			THEN( "the exclusive items are equivalent" ) {
 				CHECK( firstItem == secondItem );
 			}
 		}
-		
+
 		WHEN( "the contents are not equivalent" ) {
 			firstItem = ExclusiveItem<Object>(Object(2));
 			secondItem = ExclusiveItem<Object>(Object(3));

--- a/tests/unit/src/test_exclusiveItem.cpp
+++ b/tests/unit/src/test_exclusiveItem.cpp
@@ -39,23 +39,22 @@ SCENARIO( "Creating an ExclusiveItem" , "[ExclusiveItem][Creation]" ) {
 	GIVEN( "an exclusive item" ) {
 		auto item = ExclusiveItem<Object>{};
 
-		WHEN( "it is freshly made" ) {
+		WHEN( "it is default-constructed" ) {
 			THEN( "it contains default data" ) {
 				CHECK_FALSE( item.IsStock() );
 				CHECK( item->GetValue() == 0 );
 			}
 		}
 
-		WHEN( "an object is added by reference" ) {
-			auto obj = Object(2);
-			item = ExclusiveItem<Object>(std::move(obj));
+		WHEN( "constructed with an rvalue reference" ) {
+			item = ExclusiveItem<Object>(Object(2));
 			THEN( "the object is obtainable and the item is nonstock" ) {
 				CHECK_FALSE( item.IsStock() );
 				CHECK( item->GetValue() == 2 );
 			}
 		}
 
-		WHEN( "an object is added by pointer" ) {
+		WHEN( "constructed with a pointer to an instance" ) {
 			auto obj = Object(3);
 			item = ExclusiveItem<Object>(&obj);
 			THEN( "the object is obtainable and the item is stock" ) {
@@ -69,9 +68,9 @@ SCENARIO( "Creating an ExclusiveItem" , "[ExclusiveItem][Creation]" ) {
 		auto secondItem = ExclusiveItem<Object>{};
 
 		WHEN( "the contents are equivalent" ) {
-			auto obj = Object(2);
+			const auto obj = Object(2);
 			firstItem = ExclusiveItem<Object>(&obj);
-			secondItem = ExclusiveItem<Object>(std::move(obj));
+			secondItem = ExclusiveItem<Object>(Object(2));
 			THEN( "the exclusive items are equivalent" ) {
 				CHECK( firstItem == secondItem );
 			}

--- a/tests/unit/src/test_exclusiveItem.cpp
+++ b/tests/unit/src/test_exclusiveItem.cpp
@@ -1,0 +1,92 @@
+/* test_exclusiveItem.cpp
+Copyright (c) 2022 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "es-test.hpp"
+
+// Include only the tested class's header.
+#include "../../../source/ExclusiveItem.h"
+
+// ... and any system includes needed for the test file.
+
+namespace { // test namespace
+
+// #region mock data
+class Object {
+	// Some data that the object holds.
+	int value = 0;
+public:
+	Object() = default;
+	Object(int value) : value(value) {}
+	int GetValue() const { return value; }
+	bool operator==(const Object &other) const { return this->value == other.value; }
+};
+// #endregion mock data
+
+
+
+// #region unit tests
+SCENARIO( "Creating an ExclusiveItem" , "[ExclusiveItem][Creation]" ) {
+	GIVEN( "an exclusive item" ) {
+		auto item = ExclusiveItem<Object>{};
+
+		WHEN( "it is freshly made" ) {
+			THEN( "it contains default data" ) {
+				CHECK_FALSE( item.IsStock() );
+				CHECK( item->GetValue() == 0 );
+			}
+		}
+
+		WHEN( "an object is added by reference" ) {
+			auto obj = Object(2);
+			item = ExclusiveItem<Object>(obj);
+			THEN( "the object is obtainable and the item is nonstock" ) {
+				CHECK_FALSE( item.IsStock() );
+				CHECK( item->GetValue() == 2 );
+			}
+		}
+
+		WHEN( "an object is added by pointer" ) {
+			auto obj = Object(3);
+			item = ExclusiveItem<Object>(&obj);
+			THEN( "the object is obtainable and the item is stock" ) {
+				CHECK( item.IsStock() );
+				CHECK( item->GetValue() == 3 );
+			}
+		}
+	}
+	GIVEN( "two exclusive items" ) {
+		auto firstItem = ExclusiveItem<Object>{};
+		auto secondItem = ExclusiveItem<Object>{};
+		
+		WHEN( "the contents are equivalent" ) {
+			auto obj = Object(2);
+			firstItem = ExclusiveItem<Object>(&obj);
+			secondItem = ExclusiveItem<Object>(obj);
+			THEN( "the exclusive items are equivalent" ) {
+				CHECK( firstItem == secondItem );
+			}
+		}
+		
+		WHEN( "the contents are not equivalent" ) {
+			firstItem = ExclusiveItem<Object>(Object(2));
+			secondItem = ExclusiveItem<Object>(Object(3));
+			THEN( "the exclusive items are not equivalent" ) {
+				CHECK( firstItem != secondItem );
+			}
+		}
+	}
+}
+// #endregion unit tests
+
+
+
+} // test namespace


### PR DESCRIPTION
**Feature:** This PR implements yet another piece broken off of #4704, otherwise known as the PR that keeps on giving.

## Feature Details
This PR adds a new template class, the ExclusiveItem ("exclusive" as in "mutually exclusive" [shorten to Mutex? MutexItem?], previously named the UnionItem). An ExclusiveItem is an object that holds either a pointer to or an instance of some other class. The usefulness of this object comes from the fact that there are various objects in the game that can be either defined as root objects or defined in place as a child of some other object. Examples include but are not limited to conversations (defined as a root or a child of a mission action), dialogs (defined as a root or a child of a mission action or NPC), and fleets (defined as a root or a child of an NPC). The way the game currently handles such objects is by having two variables in the containing class, a pointer for if the object is defined as a root object and an instance for if the object was defined in place. An ExclusiveItem removes the need for the containing class to have two variables by taking the responsibility of keeping track of whether the object in question is a stock item (defined as a root object and therefore is a pointer) or a normal item (defined in place and therefore is an instance).

This PR currently does not put the ExclusiveItem class to use, although I do have some uncommitted changes on my end that put it to use for storing Conversations in a MissionAction, and everything appears to work. I can put the ExclusiveItem to use in the places described above and any other places where it could be used if desired.

## Testing Done
Tested that start conversations and mission conversations, dialogs, and NPCs still function properly.

## Performance Impact
N/A
