### PR TITLE
Changed obsolete references of the afterburner

### DIFF
--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -145,7 +145,7 @@ ship "Marauder Bounder"
 		
 		"A250 Atomic Thruster"
 		"A255 Atomic Steering"
-		"Afterburner"
+		"Volcano Afterburner"
 		"Hyperdrive"
 		
 	engine -12 44
@@ -855,7 +855,7 @@ ship "Marauder Raven"
 		
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
-		"Afterburner"
+		"Volcano Afterburner"
 		"Hyperdrive"
 	
 	engine -9.5 63

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -635,7 +635,7 @@ ship "Modified Osprey"
 		"Tactical Scanner"
 		"Wanderer Ramscoop"
 		
-		"Afterburner"
+		"Volcano Afterburner"
 		`"Bufaer" Atomic Thruster`
 		"Ionic Afterburner" 5
 		"Type 4 Radiant Thruster"


### PR DESCRIPTION
**Bugfix:**
This PR Replaces 3 occurrences of "Afterburner" with "Volcano Afterburner" to match the current naming scheme as some ships:
Marauder Raven
Marauder Bounder
Modified Osprey
Were not updated to match the new name for the Volcano Afterburner