### PR TITLE
Remove GenericName key from Linux desktop file

### DIFF
--- a/endless-sky.desktop
+++ b/endless-sky.desktop
@@ -1,8 +1,5 @@
 [Desktop Entry]
 Name=Endless Sky
-GenericName=Space game
-GenericName[de]=Weltraumspiel
-GenericName[fr]=Jeu spatial
 Comment=Space exploration and combat game
 Comment[de]=Weltraumhandels und Kampfsimulator
 Comment[fr]=Jeu d'exploration et de combat dans l'espace


### PR DESCRIPTION
This key is intended to be used for cases like a music player with a
branded name where you want the user to be able to tell what it is (e.g.
"Music Player"). This doesn't really apply to games; the Comment field
which shows a longer description is more appropriate. On Linux, launcher
menu implementations often prefer the GenericName key over the Comment
when both are present. So let's remove the GenericName because the
Comment text is better and more appropriate.