### PR TITLE
This npc kill ship should stay, not 'wait'

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1029,7 +1029,7 @@ mission "Remnant: Cognizance 23"
 		give ship Merganser
 	npc kill
 		government "Korath"
-		personality coward target uninterested waiting
+		personality coward target uninterested staying
 		system
 			system "Farinus"
 		fleet


### PR DESCRIPTION
----------------------
**Content (Missions )**

## Summary
The mission 'First Flight' aka Cognizance 23 mentions a ship in Farinus, and has a waypoint in Farinus, but the 'npc kill' ship there jumps away. It should probably have personality 'staying' instead of 'waiting'

## Save File
This save file can be used to play through the new mission content:
[Test Cognizance 23.txt](https://github.com/endless-sky/endless-sky/files/8829467/Test.Cognizance.23.txt)
Takes a few steps and there's a few other missions in the way but it's a small change.