### PR TITLE
Add 'staying' to the Korath fleet in Remnant Defense 1.

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -267,7 +267,7 @@ mission "Remnant: Defense 1"
 		fleet "Large Remnant"
 	npc evade
 		government "Korath"
-		personality heroic plunders harvests target
+		personality staying heroic plunders harvests target
 		fleet "Korath Ember Waste Raid" 6
 	on visit
 		dialog "There are still Korath raiders circling overhead. You should take off and help the Remnant ships to fight them."


### PR DESCRIPTION
On one of my save files I noticed that there was a Korath fleet following me into Human space. I found that pretty funny.

The Korath fleet in Remnant Defense 1 attack the Remnant planet and as such they should stay in that system.