### PR TITLE
fix(mechanics): Shift-R to select the nearest ship, even if hostiles are around

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3238,32 +3238,32 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 
 	if(activeCommands.Has(Command::NEAREST))
 	{
-		// Find the nearest ship to the flagship. If `Shift` is held, consider friendly ships too.
+		// Find the nearest enemy ship to the flagship. If `Shift` is held, consider friendly ships too.
 		double closest = numeric_limits<double>::infinity();
-		int closeState = 0;
+		bool foundActive = false;
 		bool found = false;
 		for(const shared_ptr<Ship> &other : ships)
 			if(other.get() != &ship && other->IsTargetable())
 			{
-				// Sort ships into one of three priority states:
-				// 0 = friendly, 1 = disabled enemy, 2 = active enemy.
-				int state = other->GetGovernment()->IsEnemy(ship.GetGovernment());
+				bool enemy = other->GetGovernment()->IsEnemy(ship.GetGovernment());
 				// Do not let "target nearest" select a friendly ship, so that
 				// if the player is repeatedly targeting nearest to, say, target
 				// a bunch of fighters, they won't start firing on friendly
 				// ships as soon as the last one is gone.
-				if((!state && !shift) || other->IsYours())
+				if((!enemy && !shift) || other->IsYours())
 					continue;
 
-				state += state * !other->IsDisabled();
+				// Sort ships by active or disabled:
+				// Prefer targeting an active ship over a disabled one
+				bool active = !other->IsDisabled();
 
 				double d = other->Position().Distance(ship.Position());
 
-				if(state > closeState || (state == closeState && d < closest))
+				if((!foundActive && active) || (foundActive == active && d < closest))
 				{
 					ship.SetTargetShip(other);
 					closest = d;
-					closeState = state;
+					foundActive = active;
 					found = true;
 				}
 			}


### PR DESCRIPTION
## Summary
Shift-R will now select the nearest ship, friendly or hostile, even if hostiles are in the system. 

That's what the preferences setting says Shift-R does: "Select nearest ship". It currently prefers hostiles instead of selecting whatever ship is nearest. That's not what the preferences window or the comments says. If you wanted to select a hostile, that's what normal R does. So why does shift-R ignore friendlies when hostiles are nearby? You specifically held shift to select friendlies.

Now, this is very old code, so I wonder what the intent is as this has been this way forever. But either this, or the text explaining Shift-R should change. Because shift-TALK doesn't prefer ships - it just talks to the planet. So this should select the closest ship, friendly or not.