### PR TITLE
Shift-accept job auto-fires crew 

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -255,7 +255,7 @@ bool MissionPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 {
 	if(key == 'a' && CanAccept())
 	{
-		Accept();
+		Accept((mod & KMOD_SHIFT));
 		return true;
 	}
 	else if(key == 'A' || (key == 'a' && (mod & KMOD_SHIFT)))
@@ -736,7 +736,7 @@ bool MissionPanel::CanAccept() const
 
 
 
-void MissionPanel::Accept()
+void MissionPanel::Accept(bool force)
 {
 	const Mission &toAccept = *availableIt;
 	int cargoToSell = 0;
@@ -747,6 +747,11 @@ void MissionPanel::Accept()
 		crewToFire = toAccept.Passengers() - player.Cargo().BunksFree();
 	if(cargoToSell > 0 || crewToFire > 0)
 	{
+		if(force)
+		{
+			MakeSpaceAndAccept();
+			return;
+		}
 		ostringstream out;
 		if(cargoToSell > 0 && crewToFire > 0)
 			out << "You must fire " << crewToFire << " of your flagship's non-essential crew members and sell "

--- a/source/MissionPanel.h
+++ b/source/MissionPanel.h
@@ -62,7 +62,7 @@ private:
 	void DrawMissionInfo();
 
 	bool CanAccept() const;
-	void Accept();
+	void Accept(bool force = false);
 	void MakeSpaceAndAccept();
 	void AbortMission();
 


### PR DESCRIPTION
## Summary
Shift-accept a job to auto-fire crew and auto-sell cargo to make room for the job, instead of popping up a dialogue that you'll just say 'yes' to.

Shift-'a' key does this. Shift-clicking the accept button won't - since the code for button presses doesn't seem to have access to 'shift' state.


## Save File
Easy enough to buy cargo and hire crew to see this change.