### PR TITLE
Trigger the Skadenga questline if you bypassed the "Deep: Questions"

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2765,7 +2765,11 @@ mission "Home for Skadenga 1"
 	minor
 	cargo "Setstokkr" 1
 	to offer
-		has "Deep: Questions: done"
+		or
+			has "Deep: Questions: done"
+			and
+				has "deep: helped before archaeology"
+				has "Deep: Interrogation: offered"
 		random < 50
 	source "Nifel"
 	stopover "Asgard"


### PR DESCRIPTION
**Content (Missions)**

## Summary
The Skagenda quest is triggered with "Deep: Questions". "Deep: Questions" can be skipped by doing both "Deep: Interrogation" and setting "deep: helped before archaeology" first. 'Questions' and 'Interrogation' both trigger the same conversation, so I figure 'Interrogation' should also allow Skagenda to start. So I add in a case to trigger the Skagenda quest with those done as well.

## Save File
This save file can be used to play through the new mission content:
[John Oliver - test Skadenga.txt](https://github.com/endless-sky/endless-sky/files/8872558/John.Oliver.-.test.Skadenga.txt)