### PR TITLE
docs: remove Terminal=false line from desktop file

### DIFF
--- a/endless-sky.desktop
+++ b/endless-sky.desktop
@@ -5,7 +5,6 @@ Comment[de]=Weltraumhandels und Kampfsimulator
 Comment[fr]=Jeu d'exploration et de combat dans l'espace
 Exec=endless-sky
 Icon=endless-sky
-Terminal=false
 Type=Application
 Keywords=game;simulator;space;sandbox;rpg;
 Categories=Game;Simulation;


### PR DESCRIPTION
Terminal is a non-required key, and False is the default value if it's
not set, so this line is a no-op and can be removed with no consequences.