### PR TITLE
After accepting a mission, center screen on the next mission

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -780,6 +780,9 @@ void MissionPanel::Accept()
 					break;
 			}
 	}
+
+	if(availableIt != available.end())
+		CenterOnSystem(availableIt->Destination()->GetSystem());
 }
 
 


### PR DESCRIPTION
## Feature Details
After accepting a mission, center on the next auto-selected mission, ie the next mission in the list - just as it would if you clicked it yourself.

## UI Screenshots
N/A - animation only

## Usage Examples
I'm finding it very useful to have the screen zoom to the mission that is next to accept, even if it was automatically selected. Lots of times, I accept a mission, and then the next selected mission is who-knows-where. So it's nice to zoom to the planet so I know where it is.

## Testing Done
Accepted missions! All missions require a destination planet and all planets have a system to zoom to. Easy.
Accepted missions at the end of the list; Accepted missions with no more missions.

## Performance Impact
N/A