### PR TITLE
Mission pane, down arrow, now zooms to system

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -282,6 +282,9 @@ bool MissionPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	else if(key == SDLK_UP)
 	{
 		SelectAnyMission();
+		// If SelectAnyMission() returns true, it just auto-selected the first mission on a side,
+		//  so iterate back one step and wrap to the end of the list
+		// If false, a mission was already selected, so, well, iterate one step back all the same.
 		if(availableIt != available.end())
 		{
 			// All available missions are, by definition, visible.
@@ -299,11 +302,14 @@ bool MissionPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 			} while(!acceptedIt->IsVisible());
 		}
 	}
-	else if(key == SDLK_DOWN && !SelectAnyMission())
+	else if(key == SDLK_DOWN)
 	{
-		// Keyed "Down," and didn't auto-select the first mission on a side,
-		// so update the existing selected mission.
-		if(availableIt != available.end())
+		if(SelectAnyMission())
+		{
+			// If SelectAnyMission() auto-selected the first mission on a side,
+			// don't need to update the existing selected mission.
+		}
+		else if(availableIt != available.end())
 		{
 			++availableIt;
 			if(availableIt == available.end())


### PR DESCRIPTION
-----------------------
**Bugfix:** 

## Fix Details
Fix a subtle bug : opening the mission pane and hitting the down arrow to select the first mission NOW zooms the screen to that system. Just like every other time you select a mission.

The result of 'SelectAnyMission' was being used in the wrong if statement. When it did its job and selected the first mission, it would skip over the code to iterate to the next mission (as the down key usually would). Sure. But that means it would then pass the keypress to the superclass MapPanel, and also skip over the following code that scrolled and centered on that system.

So the call to SelectAnyMission just needed to be nested deeper so that any keydown press is entirely handled in MissionPanel. (Code change does mean it's not passing the down-arrow keypress to MapPanel, which is fine since MapPanel doesn't use that key anyway)

## Testing Done
Opened various mission panels!

## Save File
Any save file will see this change!