### PR TITLE
Convert RGB pngs to RGBA before reading.

### DIFF
--- a/source/ImageBuffer.cpp
+++ b/source/ImageBuffer.cpp
@@ -253,6 +253,8 @@ namespace {
 			png_set_expand_gray_1_2_4_to_8(png);
 		if(colorType == PNG_COLOR_TYPE_GRAY || colorType == PNG_COLOR_TYPE_GRAY_ALPHA)
 			png_set_gray_to_rgb(png);
+		if(colorType == PNG_COLOR_TYPE_RGB)
+			png_set_filler(png, 0xFFFF, PNG_FILLER_AFTER);
 		// Let libpng handle any interlaced image decoding.
 		png_set_interlace_handling(png);
 		png_read_update_info(png, info);


### PR DESCRIPTION
**Bugfix:** This PR fixes #6938 

## Fix Details

The image files in #6938 are RGB pngs, i.e. pngs without an alpha channel. ES requires images to be RGBA when loading them, so the fix is to add a alpha channel to such pngs before reading them. This is done for every other type of png already (except rgb only). This PR adds the conversion needed for the last type of png not handled.

I use the recommended way to convert them to RGBA from the [manual](http://www.libpng.org/pub/png/libpng-1.2.5-manual.html) (search for "This code expands them into 4 or 8 bytes for windowing systems").

## Testing Done

The image files from #6938 are correctly displayed in the outfitter with this PR.

## Save File

[Squished Sprite.txt](https://github.com/endless-sky/endless-sky/files/8886392/Squished.Sprite.txt) (you need the plugin from #6938). Open the outfitter and scroll down to the plugin license.
