### PR TITLE
[Variants Tweak] Make Heliarch Hunter variants use Scram Drives

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -441,7 +441,6 @@ ship "Heliarch Hunter"
 
 ship "Heliarch Hunter" "Heliarch Hunter (Interdicting)"
 	outfits
-		"Bombardment Cannon"
 		"Finisher Pod" 2
 		"Finisher Storage Tube"
 		"Finisher Torpedo" 100
@@ -462,7 +461,7 @@ ship "Heliarch Hunter" "Heliarch Hunter (Interdicting)"
 		"Small Thrust Module"
 		"Large Steering Module" 2
 		"Small Steering Module"
-		"Hyperdrive"
+		"Scram Drive"
 	
 	gun "Bombardment Cannon"
 	gun "Finisher Pod"
@@ -479,7 +478,7 @@ ship "Heliarch Hunter" "Heliarch Hunter (Ions)"
 		"Small Reactor Module"
 		"Large Battery Module"
 		"Overcharged Shield Module" 2
-		"Overclocked Repair Module" 2
+		"Overclocked Repair Module"
 		"Cooling Module" 3
 		"Scanning Module"
 		"Outfits Expansion"
@@ -487,21 +486,23 @@ ship "Heliarch Hunter" "Heliarch Hunter (Ions)"
 		"Enforcer Confrontation Gear" 16
 		
 		"Large Thrust Module" 2
+		"Small Thrust Module"
 		"Large Steering Module" 2
-		"Hyperdrive"
+		"Small Steering Module" 2
+		"Scram Drive"
 
 ship "Heliarch Hunter" "Heliarch Hunter (Missile)"
 	outfits
 		"Finisher Pod" 3
-		"Finisher Storage Tube" 8
-		"Finisher Torpedo" 280
+		"Finisher Storage Tube" 6
+		"Finisher Torpedo" 240
 		
-		"Small Reactor Module" 2
-		"Small Battery Module"
+		"Large Reactor Module"
+		"Small Battery Module" 2
 		"Overcharged Shield Module"
 		"Overclocked Repair Module"
 		"Cooling Module" 2
-		"Scanning Module"
+		"Scanning Module" 2
 		"Outfits Expansion"
 		"Enforcer Riot Staff" 27
 		"Enforcer Confrontation Gear" 17
@@ -509,7 +510,7 @@ ship "Heliarch Hunter" "Heliarch Hunter (Missile)"
 		"Large Thrust Module" 2
 		"Small Thrust Module" 3
 		"Large Steering Module" 2
-		"Hyperdrive"
+		"Scram Drive"
 
 ship "Heliarch Hunter" "Heliarch Hunter (Scrappy)"
 	outfits
@@ -522,7 +523,7 @@ ship "Heliarch Hunter" "Heliarch Hunter (Scrappy)"
 		"Overcharged Shield Module"
 		"Overclocked Repair Module" 2
 		"Cooling Module" 3
-		"Scanning Module" 2
+		"Scanning Module"
 		"Outfits Expansion"
 		"Enforcer Riot Staff" 26
 		"Enforcer Confrontation Gear" 18
@@ -530,8 +531,8 @@ ship "Heliarch Hunter" "Heliarch Hunter (Scrappy)"
 		"Large Thrust Module" 2
 		"Small Thrust Module"
 		"Large Steering Module" 2
-		"Small Steering Module" 2
-		"Hyperdrive"
+		"Small Steering Module"
+		"Scram Drive"
 
 
 ship "Heliarch Interdictor"

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -463,7 +463,7 @@ ship "Heliarch Hunter" "Heliarch Hunter (Interdicting)"
 		"Small Steering Module"
 		"Scram Drive"
 	
-	gun "Bombardment Cannon"
+	gun
 	gun "Finisher Pod"
 	gun "Finisher Pod"
 	turret "Heliarch Repulsor"


### PR DESCRIPTION
----------------------
**Content (Variant Balance Tweak?)**

## Summary
Heliarch Hunters are meant to be ships that get in and out of systems quickly, their naturally high fuel capacity being so that they can patrol a lot of systems without refuelling due to their Scram Drive's higher fuel usage.
It turns out though that I forgot to have every variant of the Heliarch Hunter other than Stock actually use SDs. They just had regular HDs.

This PR just changes the loadouts of the other variants of the Heliarch Hunter so that they can fit a SD instead of the HD they previously had.