### PR TITLE
Fix double stones on albatross variants

### DIFF
--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -128,7 +128,6 @@ ship "Albatross" "Albatross (Turret)"
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
-		"Quantum Key Stone"
 		"Thermoelectric Cooler"
 		"Quantum Key Stone"
 		"Outfits Expansion" 2
@@ -154,7 +153,6 @@ ship "Albatross" "Albatross (Heavy)"
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor" 2
-		"Quantum Key Stone"
 		"Thermoelectric Cooler" 3
 		"Quantum Key Stone"
 		"Outfits Expansion" 4
@@ -186,7 +184,6 @@ ship "Albatross" "Albatross (Shield)"
 
 		"Aeon Cell"
 		"Millennium Cell"
-		"Quantum Key Stone"
 		"Thermoelectric Cooler" 2
 		"Quantum Key Stone"
 		"Outfits Expansion" 6


### PR DESCRIPTION
**Bugfix:**

Some remnant albatross variants have 2 keystones installed instead of the usual 1 (which would be in keeping with the remnant not wasting resources). This PR removes the duplicate keystones being added to the ships.

[Reported on discord by @Mutant: https://discord.com/channels/251118043411775489/688532441324847150/988503845992820757](https://discord.com/channels/251118043411775489/688532441324847150/988503845992820757)