### PR TITLE
Add a validation CI for the copyright file

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -52,3 +52,6 @@ xcode_files:
 codeblocks_files:
   - '*.cbp'
   - 'utils/check_codeblocks.sh'
+
+copyright:
+  - 'copyright'

--- a/.github/workflows/compute-changes.yml
+++ b/.github/workflows/compute-changes.yml
@@ -21,6 +21,8 @@ on:
         value: ${{ jobs.changed.outputs.xcode_files }}
       codeblocks_files:
         value: ${{ jobs.changed.outputs.codeblocks_files }}
+      copyright:
+        value: ${{ jobs.changed.outputs.copyright }}
 
 jobs:
   changed:
@@ -36,6 +38,7 @@ jobs:
       codespell: ${{ steps.filter.outputs.codespell }}
       xcode_files: ${{ steps.filter.outputs.xcode_files }}
       codeblocks_files: ${{ steps.filter.outputs.codeblocks_files }}
+      copyright: ${{ steps.filter.outputs.copyright }}
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -7,6 +7,7 @@ on:
       - releases/v[0-9]+.[0-9]+.[0-9]+
     paths:
       - '.github/workflows/projects_check.yml'
+      - 'copyright'
       - 'EndlessSky.xcodeproj/**'
       - '*.cbp'
       - 'source/**'
@@ -15,6 +16,7 @@ on:
     types: [opened, synchronize]
     paths:
       - '.github/workflows/projects_check.yml'
+      - 'copyright'
       - 'EndlessSky.xcodeproj/**'
       - '*.cbp'
       - 'source/**'
@@ -53,3 +55,18 @@ jobs:
         fetch-depth: 1
     - name: Validate Code::Blocks project files
       run: ./utils/check_codeblocks.sh
+
+
+
+  validate-copyright:
+    needs: changed
+    if: ${{ needs.changed.outputs.copyright }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Install dependencies
+      run: python3 -m pip install --user python-debian
+    - name: Validate copyright file
+      run: python3 ./utils/check_copyright.py

--- a/copyright
+++ b/copyright
@@ -701,19 +701,19 @@ Comment: Taken from https://www.flickr.com/photos/61135621@N03/5836687124 and cr
 Files:
  images/land/station27*
 Copyright: Sebastian Sinisterra
-Licence: CC BY 2.0
+License: CC BY 2.0
 Comment: Taken from https://www.flickr.com/photos/61135621@N03/17755765778 and cropped.
 
 Files:
  images/land/station28*
 Copyright: mwewering
-Licence: Pixabay License
+License: Pixabay License
 Comment: Taken from https://pixabay.com/photos/corridor-tunnel-architecture-escape-2616414/ and cropped.
 
 Files:
  images/land/station15*
 Copyright: mikecook
-Licence: Pixabay License
+License: Pixabay License
 Comment: Taken from https://pixabay.com/photos/step-industry-steel-3104846/ and cropped.
 
 Files:
@@ -748,6 +748,7 @@ License: public-domain
 Comment: Taken from https://freesound.org/people/Nbs%20Dark/sounds/94185/
 
 Files: sounds/torpedo?hit.wav
+Copyright: Public Domain
 License: public-domain
 
 Files: sounds/meteor.wav
@@ -756,6 +757,7 @@ License: CC-BY-SA-3.0
 Comment: Taken from https://freesound.org/people/18hiltc/sounds/202725/
 
 Files: sounds/sidewinder.wav
+Copyright: Copyright "NHMWretched"
 License: public-domain
 Comment: Taken from https://freesound.org/people/NHMWretched/sounds/151858/
 
@@ -767,6 +769,7 @@ Comment: Taken from http://soundbible.com/1151-Grenade.html
 Files:
  sounds/asteroid crunch small.wav
  sounds/asteroid crunch medium.wav
+Copyright: Copyright AlanCat
 License: public-domain
 Comment: Derived from https://freesound.org/people/AlanCat/sounds/381645/
 
@@ -1466,12 +1469,14 @@ Comment: Derived from works by Michael Zahniser (under the same license) and det
 
 Files:
  sounds/remnant?afterburner.wav
+Copyright: Public Domain
 License: public-domain
 Comment: Based on public domain sounds taken from freesound.org, edit done by Saugia.
 
 Files:
  sounds/firelight.wav
  sounds/firelight?hit.wav
+Copyright: Public Domain
 License: public-domain
 Comment: Based on public domain sounds taken from freesound.org, edits done by Saugia and Lia Gerty.
 

--- a/copyright
+++ b/copyright
@@ -695,7 +695,7 @@ License: public-domain
 Files:
  images/land/station8*
 Copyright: MTA of the State of New York
-Licence: CC BY 2.0
+License: CC BY 2.0
 Comment: Taken from https://www.flickr.com/photos/61135621@N03/5836687124 and cropped.
 
 Files:

--- a/utils/check_copyright.py
+++ b/utils/check_copyright.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+from debian import copyright
+
+# Script that validates the copyright file.
+
+
+def check_copyright() -> bool:
+    with open('copyright', 'r', encoding='utf-8') as f:
+        try:
+            copyright.Copyright(f)
+        except copyright.Error as e:
+            print(e)
+            return False
+        return True
+
+if __name__ == '__main__':
+    if not check_copyright():
+        exit(1)

--- a/utils/check_copyright.py
+++ b/utils/check_copyright.py
@@ -14,6 +14,7 @@ def check_copyright() -> bool:
             return False
         return True
 
+
 if __name__ == '__main__':
     if not check_copyright():
         exit(1)


### PR DESCRIPTION
## Info

This PR adds a new CI checker that validates the copyright file using the official python-debian package. It only checks whether the copyright file is well-formed and nothing else.

In the future we can easily extend this script to check whether a file has no copyright, but currently all files are under MZ's copyright by default, even if they're not from him. That would mean manually specifying every asset that MZ created, instead of relying on the wildcard.

## Testing Done

I intentionally missed an error in the copyright file to check whether the CI runs and catches the error.