### PR TITLE
CI only: Better bash debug output for steam release build

### DIFF
--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -68,24 +68,24 @@ jobs:
           --mount type=bind,ro,src=$(pwd)/get-pip.py,dst=/endless-sky/get-pip.py \
           -e SCHROOT_CHROOT_NAME=steamrt_scout_${{ matrix.platform }} \
           -e LTO_PLUGIN_PATH=/usr/lib/gcc/${{ matrix.arch }}-linux-gnu/5/liblto_plugin.so \
-          -w /endless-sky s_rt /bin/bash -c \
-          'sudo dpkg --clear-avail \
-            && echo "deb http://old-releases.ubuntu.com/ubuntu/ precise main restricted universe multiverse" > /etc/apt/sources.list \
-            && echo "deb http://old-releases.ubuntu.com/ubuntu/ precise-updates main restricted universe multiverse" >> /etc/apt/sources.list \
-            && echo "deb http://old-releases.ubuntu.com/ubuntu/ precise-security main restricted universe multiverse" >> /etc/apt/sources.list \
-            && sudo apt-get update -q \
-            && sudo apt-get install -yq --no-install-recommends libmad0-dev \
-            && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 101 \
-            && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 101 \
-            && update-alternatives --install /usr/bin/cpp cpp-bin /usr/bin/cpp-5 101 \
-            && update-alternatives --auto gcc \
-            && update-alternatives --auto g++ \
-            && update-alternatives --auto cpp-bin \
-            && python3.5 get-pip.py \
-            && python3.5 -m pip install SCons==4.2.0 \
-            && python3.5 $(which scons) -Qj $(nproc) endless-sky test \
-            && mv ./endless-sky build/ \
-            && ./build/endless-sky -v \
+          -w /endless-sky s_rt /bin/bash -o pipefail -exc \
+          'sudo dpkg --clear-avail; \
+            echo "deb http://old-releases.ubuntu.com/ubuntu/ precise main restricted universe multiverse" > /etc/apt/sources.list; \
+            echo "deb http://old-releases.ubuntu.com/ubuntu/ precise-updates main restricted universe multiverse" >> /etc/apt/sources.list; \
+            echo "deb http://old-releases.ubuntu.com/ubuntu/ precise-security main restricted universe multiverse" >> /etc/apt/sources.list; \
+            sudo apt-get update -q; \
+            sudo apt-get install -yq --no-install-recommends libmad0-dev; \
+            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 101; \
+            update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 101; \
+            update-alternatives --install /usr/bin/cpp cpp-bin /usr/bin/cpp-5 101; \
+            update-alternatives --auto gcc; \
+            update-alternatives --auto g++; \
+            update-alternatives --auto cpp-bin; \
+            python3.5 get-pip.py; \
+            python3.5 -m pip install SCons==4.2.0; \
+            python3.5 $(which scons) -Qj $(nproc) endless-sky test; \
+            mv ./endless-sky build/; \
+            ./build/endless-sky -v; \
           '
     - name: Prepare binary
       run: mv build/endless-sky .


### PR DESCRIPTION
## Summary

CI only change for steam releases.

With more frequent steam releases discussion happening on discord the CI code for packaging steam runtime is getting more eyes.  I noticed I could improve debug output for the CI build so I am contributing this.

## Details

When building a docker container or launching shell scripts from CI it is good to use `set -ex` options for `/bin/sh` or `set -o pipefail -ex` when building a `/bin/bash` script.

The options are defined as the following:

| Option for set or /bin/bash | About |
| --- | --- |
| `-o pipefail` </span> | If set, the return value of a pipeline is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands in the pipeline exit successfully. |
| `-e` | Exit immediately if a pipeline... returns a non-zero status.  This is basically the same as putting `&&` between  every semicolon separated command. |
| `-x` | Prints a trace of each command and its expanded arguments before executing it.  If a command fails you'll know on which line because of the printed trace. |

See also [bash manual Set builtin][1].

[1]: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html