### PR TITLE
Remove unnecessary lines in "remnant commodities.txt"

### DIFF
--- a/data/remnant/remnant commodities.txt
+++ b/data/remnant/remnant commodities.txt
@@ -30,8 +30,6 @@ trade
 		"civil defense emergency supplies"
 		"portable machine shop modules"
 		"local network repeaters and uplinks"
-
-trade
 	commodity "remnant industrial"
 		"chemical process equipment"
 		"reactor vessels"
@@ -62,8 +60,6 @@ trade
 		"sintered metal filters"
 		"industrial gases"
 		"ultrasonic agitators"
-
-trade
 	commodity "remnant outfitter repair"
 		"Inhibitor Cannon"
 		"Thrasher Cannon"
@@ -85,8 +81,6 @@ trade
 		"Crucible-Class Steering"
 		"Forge-Class Steering"
 		"Smelter-Class Steering"
-
-trade
 	commodity "remnant salvage"
 		"salvaged Builder"
 		"Ka'het Nullifier"


### PR DESCRIPTION
No, you didn't see anything.

There shouldn't be any need to separate the different commodities in "remnant commodities.txt" into several trade nodes, as evidenced in the main trade.txt.