### PR TITLE
Bugfix: Smooth music playback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,8 @@ jobs:
         os: [windows-latest]
     steps:
     - uses: actions/checkout@v2
+    - name: Install mingw
+      run: choco install mingw
     - name: Install runtime dependencies
       run: |
         Invoke-WebRequest https://endless-sky.github.io/win64-dev.zip -OutFile win64-dev.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,8 +401,6 @@ jobs:
         os: [windows-latest]
     steps:
     - uses: actions/checkout@v2
-    - name: Install mingw
-      run: choco install mingw
     - name: Install runtime dependencies
       run: |
         Invoke-WebRequest https://endless-sky.github.io/win64-dev.zip -OutFile win64-dev.zip

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -290,6 +290,10 @@ void Audio::PlayMusic(const string &name)
 	if(!isInitialized)
 		return;
 
+	// Skip changing music if the requested name is already playing.
+	if(currentTrack->trackName == name)
+		return;
+
 	// Don't worry about thread safety here, since music will always be started
 	// by the main thread.
 	musicFade = 65536;

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -291,7 +291,7 @@ void Audio::PlayMusic(const string &name)
 		return;
 
 	// Skip changing music if the requested music is already playing.
-	if(currentTrack->GetSource() == name)
+	if(name == currentTrack->GetSource())
 		return;
 
 	// Don't worry about thread safety here, since music will always be started

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -290,8 +290,8 @@ void Audio::PlayMusic(const string &name)
 	if(!isInitialized)
 		return;
 
-	// Skip changing music if the requested name is already playing.
-	if(currentTrack->GetCurrentTrackName() == name)
+	// Skip changing music if the requested music is already playing.
+	if(currentTrack->GetSource() == name)
 		return;
 
 	// Don't worry about thread safety here, since music will always be started

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -291,7 +291,7 @@ void Audio::PlayMusic(const string &name)
 		return;
 
 	// Skip changing music if the requested name is already playing.
-	if(currentTrack->trackName == name)
+	if(currentTrack->GetCurrentTrackName() == name)
 		return;
 
 	// Don't worry about thread safety here, since music will always be started

--- a/source/Music.cpp
+++ b/source/Music.cpp
@@ -112,6 +112,8 @@ void Music::SetSource(const string &name)
 	// Also clear any decoded data left over from the previous file.
 	next.clear();
 
+	trackName = name;
+
 	// Notify the decoding thread that it can start.
 	lock.unlock();
 	condition.notify_all();

--- a/source/Music.cpp
+++ b/source/Music.cpp
@@ -99,6 +99,7 @@ void Music::SetSource(const string &name)
 	// Do nothing if this is the same file we're playing.
 	if(path == previousPath)
 		return;
+	currentSource = name;
 	previousPath = path;
 
 	// Inform the decoding thread that it should switch to decoding a new file.
@@ -112,11 +113,17 @@ void Music::SetSource(const string &name)
 	// Also clear any decoded data left over from the previous file.
 	next.clear();
 
-	currentTrackName = name;
-
 	// Notify the decoding thread that it can start.
 	lock.unlock();
 	condition.notify_all();
+}
+
+
+
+// Get the name of the current music source playing.
+const string &Music::GetSource() const
+{
+	return currentSource;
 }
 
 
@@ -275,11 +282,4 @@ void Music::Decode()
 		mad_stream_finish(&stream);
 		fclose(file);
 	}
-}
-
-
-
-// Return the name of the current music track playing.
-const string Music::GetCurrentTrackName() {
-	return currentTrackName;
 }

--- a/source/Music.cpp
+++ b/source/Music.cpp
@@ -112,7 +112,8 @@ void Music::SetSource(const string &name)
 	// Also clear any decoded data left over from the previous file.
 	next.clear();
 
-	trackName = name;
+	previousTrackName = currentTrackName;
+	currentTrackName = name;
 
 	// Notify the decoding thread that it can start.
 	lock.unlock();
@@ -275,4 +276,18 @@ void Music::Decode()
 		mad_stream_finish(&stream);
 		fclose(file);
 	}
+}
+
+
+
+// Return the name of the current music track playing.
+const string Music::GetCurrentTrackName() {
+	return currentTrackName;
+}
+
+
+
+// Return the name of the previous music track played.
+const string Music::GetPreviousTrackName() {
+	return previousTrackName;
 }

--- a/source/Music.cpp
+++ b/source/Music.cpp
@@ -112,7 +112,6 @@ void Music::SetSource(const string &name)
 	// Also clear any decoded data left over from the previous file.
 	next.clear();
 
-	previousTrackName = currentTrackName;
 	currentTrackName = name;
 
 	// Notify the decoding thread that it can start.
@@ -283,11 +282,4 @@ void Music::Decode()
 // Return the name of the current music track playing.
 const string Music::GetCurrentTrackName() {
 	return currentTrackName;
-}
-
-
-
-// Return the name of the previous music track played.
-const string Music::GetPreviousTrackName() {
-	return previousTrackName;
 }

--- a/source/Music.h
+++ b/source/Music.h
@@ -40,6 +40,8 @@ public:
 	void SetSource(const std::string &name = "");
 	const std::vector<int16_t> &NextChunk();
 
+	std::string trackName = "";
+
 
 private:
 	// This is the entry point for the decoding thread.

--- a/source/Music.h
+++ b/source/Music.h
@@ -40,8 +40,8 @@ public:
 	void SetSource(const std::string &name = "");
 	const std::vector<int16_t> &NextChunk();
 
-	std::string trackName = "";
-
+	const std::string GetCurrentTrackName();
+	const std::string GetPreviousTrackName();
 
 private:
 	// This is the entry point for the decoding thread.
@@ -66,6 +66,8 @@ private:
 	std::thread thread;
 	std::mutex decodeMutex;
 	std::condition_variable condition;
+	std::string currentTrackName = "";
+	std::string previousTrackName = "";
 };
 
 

--- a/source/Music.h
+++ b/source/Music.h
@@ -41,7 +41,6 @@ public:
 	const std::vector<int16_t> &NextChunk();
 
 	const std::string GetCurrentTrackName();
-	const std::string GetPreviousTrackName();
 
 private:
 	// This is the entry point for the decoding thread.
@@ -67,7 +66,6 @@ private:
 	std::mutex decodeMutex;
 	std::condition_variable condition;
 	std::string currentTrackName = "";
-	std::string previousTrackName = "";
 };
 
 

--- a/source/Music.h
+++ b/source/Music.h
@@ -37,10 +37,13 @@ public:
 	Music();
 	~Music();
 
+	// Set the source of music. If the path is empty, this music will be silent.
 	void SetSource(const std::string &name = "");
+	// Get the name of the current music source playing.
+	const std::string &GetSource() const;
+	// Get the next audio buffer to play.
 	const std::vector<int16_t> &NextChunk();
 
-	const std::string GetCurrentTrackName();
 
 private:
 	// This is the entry point for the decoding thread.
@@ -54,6 +57,7 @@ private:
 	std::vector<int16_t> next;
 	std::vector<int16_t> current;
 
+	std::string currentSource;
 	std::string previousPath;
 	// This pointer holds the file for as long as it is owned by the main
 	// thread. When the decode thread takes possession of it, it sets this
@@ -65,7 +69,6 @@ private:
 	std::thread thread;
 	std::mutex decodeMutex;
 	std::condition_variable condition;
-	std::string currentTrackName = "";
 };
 
 


### PR DESCRIPTION
## Summary

While collaborating on adding music to Endless Sky I am hitting up against quirks in the engine.  This is a small bugfix to address a big issue.  However, there will likely be lots of audio-based fixes around music to come as part of this collaboration.

I am developing the plugin "Sounds of Endless Sky" which includes collaboration music by composer @Anthrophantasmus.

https://github.com/samrocketman/sounds-of-endless-sky

## Fix Details

If a track is playing and a new track of the same name is requested, then it will continue playing the track instead of resetting playback to the beginning.

Bug behavior
------------

Music gets reset even if the same track is playing.  The track restarts from the beginning every time it resets.

- Jumping systems resets music.
- Pressing ESC resets music.
- Landing on planets resets music.

Desired behavior
----------------

If the track is already playing it should continue to play.  Do not reset and play from the beginning because this can be jarring.

## Testing Done

When the next track is the same as the current track...

- Jumping systems no longer resets music.
- Pressing ESC no longer resets music.
- Landing on planets no longer resets music.

## Performance Impact

N/A