### PR TITLE
feat: add music property for government and have planet and system music inherit it

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -139,6 +139,8 @@ void Government::Load(const DataNode &node)
 			raidFleet = GameData::Fleets().Get(child.Token(1));
 		else if(child.Token(0) == "provoked on scan")
 			provokedOnScan = true;
+		else if(child.Token(0) == "music" && child.Size() >= 2)
+			music = child.Token(1);
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
@@ -399,4 +401,9 @@ double Government::CrewDefense() const
 bool Government::IsProvokedOnScan() const
 {
 	return provokedOnScan;
+}
+
+std::string Government::Music() const
+{
+	return music;
 }

--- a/source/Government.h
+++ b/source/Government.h
@@ -118,6 +118,9 @@ public:
 
 	bool IsProvokedOnScan() const;
 
+	// Get non-combat music for this government
+	std::string Music() const;
+
 
 private:
 	unsigned id;
@@ -142,6 +145,7 @@ private:
 	double crewAttack = 1.;
 	double crewDefense = 2.;
 	bool provokedOnScan = false;
+	std::string music;
 };
 
 

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -288,10 +288,13 @@ const Sprite *Planet::Landscape() const
 // If none is configured, defer to that set for the system.
 const string &Planet::MusicName() const
 {
+	if(!music.empty())
+		return music;
+
 	static const System* system = GetSystem();
 	static const string systemMusic = system->MusicName();
 
-	return music.empty() ? systemMusic : music;
+	return systemMusic;
 }
 
 

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -285,9 +285,12 @@ const Sprite *Planet::Landscape() const
 
 
 // Get the name of the ambient audio to play on this planet.
+// If none is configured, defer to that set for the system.
 const string &Planet::MusicName() const
 {
-	return music;
+	static const System* system = GetSystem();
+	const string systemMusic = system->MusicName();
+	return music.empty() ? systemMusic : music;
 }
 
 

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -289,7 +289,8 @@ const Sprite *Planet::Landscape() const
 const string &Planet::MusicName() const
 {
 	static const System* system = GetSystem();
-	const string systemMusic = system->MusicName();
+	static const string systemMusic = system->MusicName();
+
 	return music.empty() ? systemMusic : music;
 }
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -462,9 +462,13 @@ const Government *System::GetGovernment() const
 
 
 // Get the name of the ambient audio to play in this system.
+// If none is set, use the ambient music for the government.
 const string &System::MusicName() const
 {
-	return music;
+	static const Government* government = GetGovernment();
+	static const string governmentMusic = government->Music();
+
+	return music.empty() ? governmentMusic : music;
 }
 
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -465,10 +465,13 @@ const Government *System::GetGovernment() const
 // If none is set, use the ambient music for the government.
 const string &System::MusicName() const
 {
+	if(!music.empty())
+		return music;
+
 	static const Government* government = GetGovernment();
 	static const string governmentMusic = government->Music();
 
-	return music.empty() ? governmentMusic : music;
+	return governmentMusic;
 }
 
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -462,7 +462,7 @@ const Government *System::GetGovernment() const
 
 
 // Get the name of the ambient audio to play in this system.
-// If none is set, use the ambient music for the government.
+// If none is set, defer to that set for the government
 const string &System::MusicName() const
 {
 	if(!music.empty())


### PR DESCRIPTION
**Feature:** This PR implements (a very small part of) the feature request detailed and discussed in: #233 and  #3594

## Feature Details

This adds a new attribute to `government`, `music`, to match that already in use for `planet` and `system`. System music now inherits from its government if it does not have its own explicit music set, likewise planet now inherits from its system.

## UI Screenshots

N/A

## Usage Examples

Refer to #6965 but in the given plugin, add:
```
government "Republic"
	music "music/ByAnthrophantasmus/Republic Space"
```

Then launch from any Republic system *other* than Rutilicus. Likewise to test the planet music, load a file on any Republic planet other than New Boston.

## Testing Done

I did that thing above.

## Performance Impact

This adds one more attribute to initialize and read for `government`, and choosing music to play now makes possibly multiple function calls. However these are imperceptible effects as far as I can tell.
