### PR TITLE
Fix Windows Actions caused by recent image update.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -64,7 +64,7 @@ jobs:
   cd_windows_win64:
     runs-on: windows-latest
     env:
-      DIR_MINGW64: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32
+      DIR_MINGW64: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64
       DIR_ESLIB: .\dev64
       OUTPUT: EndlessSky-win64-continuous.zip
       AR: gcc-ar
@@ -89,9 +89,9 @@ jobs:
         run: |
           COPY .\bin\pkgd\release\endless-sky.exe EndlessSky.exe
           COPY ".\dev64\bin\*.dll" .
-          COPY $Env:DIR_MINGW64\lib\libgcc_s_seh-1.dll .
-          COPY $Env:DIR_MINGW64\lib\libstdc++-6.dll .
-          COPY $Env:DIR_MINGW64\lib\libwinpthread-1.dll .
+          COPY $Env:DIR_MINGW64\bin\libgcc_s_seh-1.dll .
+          COPY $Env:DIR_MINGW64\bin\libstdc++-6.dll .
+          COPY $Env:DIR_MINGW64\bin\libwinpthread-1.dll .
           7z a ${{ env.OUTPUT }} .\sounds\ .\images\ .\data\ *.dll license.txt keys.txt icon.png EndlessSky.exe credits.txt copyright changelog
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         os: [windows-latest]
     env:
         SCCACHE_DIR: ./sccache/
-        DIR_MINGW64: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32
+        DIR_MINGW64: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64
         DIR_ESLIB: dev64
         CXX: sccache g++
         ARTIFACT: EndlessSky.exe
@@ -222,7 +222,7 @@ jobs:
         os: [windows-latest]
     env:
         SCCACHE_DIR: ./sccache/
-        DIR_MINGW64: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\x86_64-w64-mingw32
+        DIR_MINGW64: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64
         DIR_ESLIB: .\dev64
         CXX: sccache g++
         AR: gcc-ar
@@ -251,9 +251,9 @@ jobs:
         Expand-Archive win64-dev.zip -DestinationPath . -Force
         Remove-Item win64-dev.zip
         COPY ".\dev64\bin\*.dll" .
-        COPY $Env:DIR_MINGW64\lib\libgcc_s_seh-1.dll .
-        COPY $Env:DIR_MINGW64\lib\libstdc++-6.dll .
-        COPY $Env:DIR_MINGW64\lib\libwinpthread-1.dll .
+        COPY $Env:DIR_MINGW64\bin\libgcc_s_seh-1.dll .
+        COPY $Env:DIR_MINGW64\bin\libstdc++-6.dll .
+        COPY $Env:DIR_MINGW64\bin\libwinpthread-1.dll .
     - name: Cache sccache results
       if: steps.cache-tests.outputs.cache-hit != 'true'
       uses: actions/cache@v2


### PR DESCRIPTION
## Fix Details

Recently Github updated its Windows CI image which updated the provided mingw version from 8 to 11. This caused all of the Windows CI failures recently. At first I read that it could be due to caching problems, but I managed to reproduce the problem on my Windows machine and as it turns out the paths to the required DLLs changed.

So this PR simply fixes the paths used by CD/CI. I didn't update the paths for AppVeyor because AppVeyor still uses mingw 8 (and below) and doesn't even provide mingw 11.

## Testing Done

Hopefully every Windows action succeeds. edit: yay!