### PR TITLE
fix(content): Remnant: Fixing a confusing block message in Cognizance 32

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1348,7 +1348,7 @@ mission "Remnant: Cognizance 31"
 
 
 mission "Remnant: Cognizance 32"
-	name "Pickup Refined Fuel"
+	name "Pick Up Refined Fuel"
 	description "Chilia has asked you to pick up 58 tons of refined fuel from <planet> by <date>."
 	blocked "Chilia and Taely look excited about something, but when you inquire, they shake their heads and say you need to have earned their capital license before they can tell you more."
 	deadline 19
@@ -1426,7 +1426,7 @@ mission "Remnant: Cognizance 33"
 	on offer
 		event "remnant: remove hidden"
 		conversation
-			`Your reception is as friendly as <origin>'s reputation suggests: No one is there to meet you, and no one arrives to help load the cargo. All that greets you is a forlorn datapad mounted on a post in front of the pile of crates, requesting that you enter your pickup code to disarm the security sensors, as well as a statement that ships depart as soon as they are done loading. You enter the pickup code Chilia had sent you while you were in flight, load the <ship>, and get ready to head to <planet>.`
+			`Your reception is as friendly as <origin>'s reputation suggests: No one is there to meet you, and no one arrives to help load the cargo. All that greets you is a forlorn datapad mounted on a post in front of the pile of crates, requesting that you enter your pick up code to disarm the security sensors, as well as a statement that ships depart as soon as they are done loading. You enter the code Chilia had sent you while you were in flight, load the <ship>, and get ready to head to <planet>.`
 			`	As you are completing your checks, your sensors alert you to the arrival of a small fleet that seems to be maintaining orbit over this area. It looks like you might have to take steps to avoid observers right away.`
 				accept
 	on enter "Kornephoros"

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1426,7 +1426,7 @@ mission "Remnant: Cognizance 33"
 	on offer
 		event "remnant: remove hidden"
 		conversation
-			`Your reception is as friendly as <origin>'s reputation suggests: No one is there to meet you, and no one arrives to help load the cargo. All that greets you is a forlorn datapad mounted on a post in front of the pile of crates, requesting that you enter your pick up code to disarm the security sensors, as well as a statement that ships depart as soon as they are done loading. You enter the code Chilia had sent you while you were in flight, load the <ship>, and get ready to head to <planet>.`
+			`Your reception is as friendly as <origin>'s reputation suggests: No one is there to meet you, and no one arrives to help load the cargo. All that greets you is a forlorn security console near the pile of crates and a posted statement directing ships to depart as soon as they finish loading. You use the code Chilia had sent to unlock the crates, load the <ship>, and get ready to head to <planet>.`
 			`	As you are completing your checks, your sensors alert you to the arrival of a small fleet that seems to be maintaining orbit over this area. It looks like you might have to take steps to avoid observers right away.`
 				accept
 	on enter "Kornephoros"

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1349,10 +1349,9 @@ mission "Remnant: Cognizance 31"
 
 mission "Remnant: Cognizance 32"
 	name "Pickup Refined Fuel"
-	description "Chilia has asked you to pick up a refined fuel from <planet> by <date>."
+	description "Chilia has asked you to pick up 58 tons of refined fuel from <planet> by <date>."
 	blocked "Chilia and Taely look excited about something, but when you inquire, they shake their heads and say you need to have earned their capital license before they can tell you more."
 	deadline 19
-	cargo "Reserved" 58
 	illegal -1 "Your communication panel beeps insistently with a message that a scan has been detected, and thus the mission has been terminated."
 	stealth
 	infiltrating


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
I'm removing the cargo space requirement and adding to the mission description that they need to pick up 58 tons of material. Not quite as obvious as reserving the space, but hopefully people actually read it.

## Background
Sort of a problematic situation: The reserved cargo was appropriate for (and expects) that the player is switching to the Peregrine that they are given during this mission, so the amount of cargo their current ship has is actually irrelevant and should not block the mission. But there's no way to tell the mission that it needs to reserve that cargo space at the *end* of the "on accept" instead of at the start of the "on offer."

Thanks to Rocky196884 on Discord, among others, for reporting this bug.

## Testing Done
n/a

## Save File
n/a

