### PR TITLE
[Content] Fix overlapping of Coalition Megastructures & Planets

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -22786,7 +22786,7 @@ system "Silver Bell"
 		period 503.253
 	object "Chosen Nexus"
 		sprite planet/cloud3
-		distance 1355.87
+		distance 1500
 		period 607.680
 	object
 		sprite planet/gas3-b

--- a/data/map.txt
+++ b/data/map.txt
@@ -1769,7 +1769,7 @@ system Ablodab
 			period 24
 	object
 		sprite planet/gas5
-		distance 1141.05
+		distance 1376.54
 		period 747.863
 		object
 			sprite planet/tethys-b
@@ -1782,7 +1782,7 @@ system Ablodab
 			period 24.6
 	object
 		sprite planet/cloud5
-		distance 1754.3
+		distance 2252.22
 		period 1425.67
 		object "Silo of Ablodab"
 			sprite planet/station6c


### PR DESCRIPTION
**Content (Artwork)**

## Summary
This PR fixes the overlapping of the new Coalition Megastructures and other Coalition Planets in their respective systems (Ablodab and Silver Bell).

![image](https://user-images.githubusercontent.com/93169396/175974602-455fe2d7-4728-4739-b237-7f0f121a64d0.png)

![image](https://user-images.githubusercontent.com/93169396/175976083-5e729b31-3355-4cb1-91a2-c5cc441c94c6.png)

~~## Save File~~
~~This save file can be used to play through the new mission content:~~
~~{{attach a save file that allows people to easily test your added mission content or see your new in-game art}}~~

~~## Artwork Checklist~~
~~- [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
~~- [ ] I created a PR to the [endless-sky-assets repo](https://github.com/EndlessSkyCommunity/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}~~
~~- [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~