### PR TITLE
Use Windows Sleep for framerate control

### DIFF
--- a/source/FrameTimer.cpp
+++ b/source/FrameTimer.cpp
@@ -61,7 +61,7 @@ void FrameTimer::Wait()
 			next = now + step;
 
 #ifdef _WIN32
-		Sleep(chrono::duraction_cast<chrono::milliseconds>(next - now).count());
+		Sleep(chrono::duration_cast<chrono::milliseconds>(next - now).count());
 #else
 		this_thread::sleep_until(next);
 #endif

--- a/source/FrameTimer.cpp
+++ b/source/FrameTimer.cpp
@@ -14,6 +14,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <thread>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 using namespace std;
 
 
@@ -56,7 +60,11 @@ void FrameTimer::Wait()
 		if(now + step + maxLag < next)
 			next = now + step;
 
+#ifdef _WIN32
+		Sleep(chrono::duraction_cast<chrono::milliseconds>(next - now).count());
+#else
 		this_thread::sleep_until(next);
+#endif
 		now = chrono::steady_clock::now();
 	}
 	// If the lag is too high, don't try to do catch-up.

--- a/source/FrameTimer.cpp
+++ b/source/FrameTimer.cpp
@@ -62,6 +62,9 @@ void FrameTimer::Wait()
 		if(now + step + maxLag < next)
 			next = now + step;
 
+		// The Winpthreads implementation of sleep on MinGW > 8 is inaccurate when
+		// compared to the native Windows Sleep function.
+		// See the thread starting with https://sourceforge.net/p/mingw-w64/mailman/message/37013810/.
 #ifdef _WIN32
 		Sleep(chrono::duration_cast<chrono::milliseconds>(next - now).count());
 #else

--- a/source/FrameTimer.cpp
+++ b/source/FrameTimer.cpp
@@ -15,7 +15,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <thread>
 
 #ifdef _WIN32
-#include <Windows.h>
+#define STRICT
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #endif
 
 using namespace std;


### PR DESCRIPTION
## Fix Details

Due to the recent update to MinGW 11, it turns out that the Winpthread implementation that MinGW uses for the C++11 threading library sleeps too long. This seems to be a "problem" since MinGW 9 with the only solution being to use the native Windows sleep function instead of the Winpthread implementation.

Sleeping too long is technically valid behavior, but this meant that the game wasn't running at 60fps. So this PR #ifdef the sleeping call to use the Windows Sleep function.

## Testing Done

Used a frame viewer to verify that this PR fixes the framerate drops that occur using the MinGW 11 executable from Github Actions.
