### PR TITLE
Various fixes to the code found by MSVC

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -21,12 +21,12 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #define STRICT
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#endif
-
+#else
 #include <sys/stat.h>
 #include <dirent.h>
 #include <unistd.h>
 #include <utime.h>
+#endif
 
 #include <algorithm>
 #include <cstdlib>
@@ -483,7 +483,9 @@ string Files::Name(const string &path)
 FILE *Files::Open(const string &path, bool write)
 {
 #if defined _WIN32
-	return _wfopen(Utf8::ToUTF16(path).c_str(), write ? L"w" : L"rb");
+	FILE *file = nullptr;
+	_wfopen_s(&file, Utf8::ToUTF16(path).c_str(), write ? L"w" : L"rb");
+	return file;
 #else
 	return fopen(path.c_str(), write ? "wb" : "rb");
 #endif

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -52,13 +52,16 @@ namespace {
 		static const size_t BUF_SIZE = 24;
 		char buf[BUF_SIZE];
 
-		const tm *date = localtime(&timestamp);
 #ifdef _WIN32
+		tm date;
+		localtime_s(&date, &timestamp);
 		static const char *FORMAT = "%#I:%M %p on %#d %b %Y";
+		return string(buf, strftime(buf, BUF_SIZE, FORMAT, &date));
 #else
+		const tm *date = localtime(&timestamp);
 		static const char *FORMAT = "%-I:%M %p on %-d %b %Y";
-#endif
 		return string(buf, strftime(buf, BUF_SIZE, FORMAT, date));
+#endif
 	}
 
 	// Extract the date from this pilot's most recent save.

--- a/source/Music.cpp
+++ b/source/Music.cpp
@@ -254,7 +254,7 @@ void Music::Decode()
 					break;
 
 				// We'll alternate what channel we read from each time through the loop.
-				int channel = 0;
+				bool channel = false;
 				for(unsigned i = 0; i < 2 * synth.pcm.length; ++i)
 				{
 					// Read the next sample from the next channel.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2550,9 +2550,8 @@ void PlayerInfo::ValidateLoad()
 
 	// Validate the missions that were loaded. Active-but-invalid missions are removed from
 	// the standard mission list, effectively pausing them until necessary data is restored.
-	missions.sort([](const Mission &lhs, const Mission &rhs) noexcept -> bool { return lhs.IsValid(); });
-	auto isInvalidMission = [](const Mission &m) noexcept -> bool { return !m.IsValid(); };
-	auto mit = find_if(missions.begin(), missions.end(), isInvalidMission);
+	auto isInvalidMission = [](const Mission& m) noexcept -> bool { return !m.IsValid(); };
+	auto mit = remove_if(missions.begin(), missions.end(), isInvalidMission);
 	if(mit != missions.end())
 		inactiveMissions.splice(inactiveMissions.end(), missions, mit, missions.end());
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -41,6 +41,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <algorithm>
 #include <cmath>
 #include <ctime>
+#include <functional>
 #include <iterator>
 #include <limits>
 #include <sstream>
@@ -2550,7 +2551,7 @@ void PlayerInfo::ValidateLoad()
 
 	// Validate the missions that were loaded. Active-but-invalid missions are removed from
 	// the standard mission list, effectively pausing them until necessary data is restored.
-	auto mit = partition(missions.begin(), missions.end(), [](const Mission &m) { return m.IsValid(); });
+	auto mit = partition(missions.begin(), missions.end(), mem_fn(&Mission::IsValid));
 	if(mit != missions.end())
 		inactiveMissions.splice(inactiveMissions.end(), missions, mit, missions.end());
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2551,13 +2551,13 @@ void PlayerInfo::ValidateLoad()
 
 	// Validate the missions that were loaded. Active-but-invalid missions are removed from
 	// the standard mission list, effectively pausing them until necessary data is restored.
-	auto mit = partition(missions.begin(), missions.end(), mem_fn(&Mission::IsValid));
+	auto mit = stable_partition(missions.begin(), missions.end(), mem_fn(&Mission::IsValid));
 	if(mit != missions.end())
 		inactiveMissions.splice(inactiveMissions.end(), missions, mit, missions.end());
 
 	// Invalid available jobs or missions are erased (since there is no guarantee
 	// the player will be on the correct planet when a plugin is re-added).
-	auto isInvalidMission = [](const Mission& m) noexcept -> bool { return !m.IsValid(); };
+	auto isInvalidMission = [](const Mission &m) noexcept -> bool { return !m.IsValid(); };
 	availableJobs.remove_if(isInvalidMission);
 	availableMissions.remove_if(isInvalidMission);
 }

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2550,13 +2550,13 @@ void PlayerInfo::ValidateLoad()
 
 	// Validate the missions that were loaded. Active-but-invalid missions are removed from
 	// the standard mission list, effectively pausing them until necessary data is restored.
-	auto isInvalidMission = [](const Mission& m) noexcept -> bool { return !m.IsValid(); };
-	auto mit = remove_if(missions.begin(), missions.end(), isInvalidMission);
+	auto mit = partition(missions.begin(), missions.end(), [](const Mission &m) { return m.IsValid(); });
 	if(mit != missions.end())
 		inactiveMissions.splice(inactiveMissions.end(), missions, mit, missions.end());
 
 	// Invalid available jobs or missions are erased (since there is no guarantee
 	// the player will be on the correct planet when a plugin is re-added).
+	auto isInvalidMission = [](const Mission& m) noexcept -> bool { return !m.IsValid(); };
 	availableJobs.remove_if(isInvalidMission);
 	availableMissions.remove_if(isInvalidMission);
 }

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -275,7 +275,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		Scroll((LINES_PER_PAGE - 2) * direction);
 	}
 	else if(key == SDLK_HOME)
-		Scroll(-player.Ships().size());
+		Scroll(-static_cast<int>(player.Ships().size()));
 	else if(key == SDLK_END)
 		Scroll(player.Ships().size());
 	else if(key == SDLK_UP || key == SDLK_DOWN)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2087,7 +2087,7 @@ void Ship::DoGeneration()
 					carried.emplace_back(1. - bay.ship->Health(), bay.ship.get());
 			sort(carried.begin(), carried.end(), (isYours && Preferences::Has(FIGHTER_REPAIR))
 				// Players may use a parallel strategy, to launch fighters in waves.
-				? [] (const pair<double, Ship *> &lhs, const pair<double, Ship *> &rhs)
+				? +[] (const pair<double, Ship *> &lhs, const pair<double, Ship *> &rhs)
 					{ return lhs.first > rhs.first; }
 				// The default strategy is to prioritize the healthiest ship first, in
 				// order to get fighters back out into the battle as soon as possible.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2087,7 +2087,7 @@ void Ship::DoGeneration()
 					carried.emplace_back(1. - bay.ship->Health(), bay.ship.get());
 			sort(carried.begin(), carried.end(), (isYours && Preferences::Has(FIGHTER_REPAIR))
 				// Players may use a parallel strategy, to launch fighters in waves.
-				? +[] (const pair<double, Ship *> &lhs, const pair<double, Ship *> &rhs)
+				? [] (const pair<double, Ship *> &lhs, const pair<double, Ship *> &rhs)
 					{ return lhs.first > rhs.first; }
 				// The default strategy is to prioritize the healthiest ship first, in
 				// order to get fighters back out into the battle as soon as possible.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -631,15 +631,26 @@ void InitConsole()
 		return;
 
 	// Perform console redirection.
-	FILE *fstdout, *fstderr, *fstdin;
-	freopen_s(&fstdout, "CONOUT$", "w", stdout);
-	freopen_s(&fstderr, "CONOUT$", "w", stderr);
-	freopen_s(&fstdin, "CONIN$", "r", stdin);
-	if(redirectStdout && fstdout)
-		setvbuf(stdout, nullptr, _IOFBF, 4096);
-	if(redirectStderr && fstderr)
-		setvbuf(stderr, nullptr, _IOLBF, 1024);
-	if(redirectStdin && fstdin)
-		setvbuf(stdin, nullptr, _IONBF, 0);
+	if(redirectStdout)
+	{
+		File *fstdout;
+		freopen_s(&fstdout, "CONOUT$", "w", stdout);
+		if(fstdout)
+			setvbuf(stdout, nullptr, _IOFBF, 4096);
+	}
+	if(redirectStderr)
+	{
+		File *fstderr;
+		freopen_s(&fstderr, "CONOUT$", "w", stderr);
+		if(fstderr)
+			setvbuf(stderr, nullptr, _IOLBF, 1024);
+	}
+	if(redirectStdin)
+	{
+		File *fstdin;
+		freopen_s(&fstdin, "CONIN$", "r", stdin);
+		if(fstdin)
+			setvbuf(stdin, nullptr, _IONBF, 0);
+	}
 }
 #endif

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -325,7 +325,7 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 			// When flying around, all test processing must be handled in the
 			// thread-safe section of Engine. When not flying around (and when no
 			// Engine exists), then it is safe to execute the tests from here.
-			auto mainPanel = gamePanels.Root().get();
+			auto mainPanel = gamePanels.Root();
 			if(!isPaused && inFlight && menuPanels.IsEmpty() && mainPanel)
 				mainPanel->SetTestContext(testContext);
 			else
@@ -631,11 +631,15 @@ void InitConsole()
 		return;
 
 	// Perform console redirection.
-	if(redirectStdout && freopen("CONOUT$", "w", stdout))
+	FILE *fstdout, *fstderr, *fstdin;
+	freopen_s(&fstdout, "CONOUT$", "w", stdout);
+	freopen_s(&fstderr, "CONOUT$", "w", stderr);
+	freopen_s(&fstdin, "CONIN$", "r", stdin);
+	if(redirectStdout && fstdout)
 		setvbuf(stdout, nullptr, _IOFBF, 4096);
-	if(redirectStderr && freopen("CONOUT$", "w", stderr))
+	if(redirectStderr && fstderr)
 		setvbuf(stderr, nullptr, _IOLBF, 1024);
-	if(redirectStdin && freopen("CONIN$", "r", stdin))
+	if(redirectStdin && fstdin)
 		setvbuf(stdin, nullptr, _IONBF, 0);
 }
 #endif

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -633,21 +633,21 @@ void InitConsole()
 	// Perform console redirection.
 	if(redirectStdout)
 	{
-		File *fstdout;
+		FILE *fstdout = nullptr;
 		freopen_s(&fstdout, "CONOUT$", "w", stdout);
 		if(fstdout)
 			setvbuf(stdout, nullptr, _IOFBF, 4096);
 	}
 	if(redirectStderr)
 	{
-		File *fstderr;
+		FILE *fstderr = nullptr;
 		freopen_s(&fstderr, "CONOUT$", "w", stderr);
 		if(fstderr)
 			setvbuf(stderr, nullptr, _IOLBF, 1024);
 	}
 	if(redirectStdin)
 	{
-		File *fstdin;
+		FILE *fstdin = nullptr;
 		freopen_s(&fstdin, "CONIN$", "r", stdin);
 		if(fstdin)
 			setvbuf(stdin, nullptr, _IONBF, 0);


### PR DESCRIPTION
This PR is simply a collection of fixes found by MSVC:

- No need to include Posix headers under Windows, MinGW already includes them.
- Use safe functions (`_s`) on Windows instead of unsafe ones.
- Use `partition` instead of abusing `sort`.
- Use a boolean for tick tock-ing instead of an int.
- Cast size_t to int before applying unary `-`.
- Don't call `.get` on a temporary shared_ptr.
- ~~Use a positive lambda for proper conversion between two lambdas~~ reported as a bug to MS