### PR TITLE
feat: Add 3 seconds delay for UI-actions when debugging tests.

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -337,7 +337,7 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 				// from within the engine at the moment.
 				Command ignored;
 				runningTest->Step(testContext, player, ignored);
-				// Set the UI delay (of 3 seconds) for the next test-step for if we are debugging.
+				// Reset the visual delay.
 				testDebugUIDelay = 3 * 60;
 			}
 			// Skip drawing 29 out of every 30 in-flight frames during testing to speedup testing (unless debug mode is set).

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -226,6 +226,7 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 	FrameTimer timer(frameRate);
 	bool isPaused = false;
 	bool isFastForward = false;
+	int testDebugUIDelay = 3 * 60;
 
 	// If fast forwarding, keep track of whether the current frame should be drawn.
 	int skipFrame = 0;
@@ -328,12 +329,16 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 			auto mainPanel = gamePanels.Root().get();
 			if(!isPaused && inFlight && menuPanels.IsEmpty() && mainPanel)
 				mainPanel->SetTestContext(testContext);
+			else if(debugMode && testDebugUIDelay > 0)
+				--testDebugUIDelay;
 			else
 			{
 				// The command will be ignored, since we only support commands
 				// from within the engine at the moment.
 				Command ignored;
 				runningTest->Step(testContext, player, ignored);
+				// Set the UI delay (of 3 seconds) for the next test-step for if we are debugging.
+				testDebugUIDelay = 3 * 60;
 			}
 			// Skip drawing 29 out of every 30 in-flight frames during testing to speedup testing (unless debug mode is set).
 			// We don't skip UI-frames to ensure we test the UI code more.


### PR DESCRIPTION
**Feature:** This PR implements a debugging feature for the integration tests framework.

## Feature Details
This PR add 3 seconds delay for UI-actions when debugging tests:
If UI actions only take 1/60th of a second, then that is too fast for people that are debugging to see what actually happens. If UI actions take 3 seconds, then that seems to be slow enough to make things visible, and fast enough not to make the test feel slow.

## UI Screenshots
N/A

## Usage Examples
To be used when manually running an integration test with the `--debug` flag.

## Testing Done
Manually ran some integration tests for #6975

## Performance Impact
No impact expected; the delay is only used during active testing, and overhead of a single integer operation should be minimal.
