### PR TITLE
Coalition Bugfix: Change an on-visit to make more sense

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -2764,7 +2764,7 @@ mission "Coalition: Expeditions Past 9"
 	to fail
 		has "Coalition: Expeditions Past 10: offered"
 	on visit
-		dialog `You land on <planet>, but realize that your escort carrying Sedlitaris hasn't entered the system yet. Better depart and wait for it.`
+		dialog `You haven't yet found the sixth expedition's last pylon. Try searching for it on a route from this system to Ablub.`
 
 mission "Coalition: Expeditions Past 10"
 	landing


### PR DESCRIPTION
-----------------------
**Bugfix:** In the Coalition's Expeditions Past mission chain, Mission 9's on visit doesn't make a whole lot of sense. You're not supposed to land on Hopper again, so being told that your escort with the passenger hasn't arrived yet is very odd. This happened because I just autopilot copy-pasted an on visit from another mission.

This issue was brought up by auldr on the Discord.

## Fix Details
This PR changes the on visit so that instead of saying the escort with the passenger isn't in the system, it tells you that you haven't completed the goal of the mission yet (finding the last pylon), and restates the route one should try to set to look for it.
