### PR TITLE
Fix "Laborer" mission (AKA "Out of Work").

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4006,6 +4006,7 @@ mission "Laborer"
 		government "Republic" "Free Worlds" "Syndicate" "Independent" "Neutral"
 		attributes "mining"
 	destination
+		government "Republic" "Free Worlds" "Syndicate" "Independent" "Neutral"
 		attributes "mining"
 	to offer
 		random < 15


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
It is currently possible that the 'Laborer' mission can have a destination outside of human space, which in the context of the mission does not make sense. I added a destination filter to avoid this.
