### PR TITLE
Balance: Buff Biochemical Cells

### DIFF
--- a/data/human/power.txt
+++ b/data/human/power.txt
@@ -84,7 +84,7 @@ outfit "KP-6 Photovoltaic Array"
 
 outfit "nGVF-AA Fuel Cell"
 	category "Power"
-	cost 40000
+	cost 35000
 	thumbnail "outfit/tiny fuel cell"
 	"mass" 20
 	"outfit space" -20

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -301,8 +301,8 @@ outfit "Small Biochemical Cell"
 	thumbnail "outfit/small biochemical"
 	"mass" 17
 	"outfit space" -17
-	"energy generation" 1.6
-	"heat generation" 1.4
+	"energy generation" 2
+	"heat generation" 1.75
 	"energy capacity" 3000
 	description "This tiny generator draws energy from the metabolic byproducts of a collection of microorganisms that have been engineered by the Wanderers specifically for this purpose."
 
@@ -314,9 +314,9 @@ outfit "Large Biochemical Cell"
 	thumbnail "outfit/large biochemical"
 	"mass" 63
 	"outfit space" -63
-	"energy generation" 6.2
-	"heat generation" 4.9
-	"energy capacity" 7000
+	"energy generation" 7.75
+	"heat generation" 6.125
+	"energy capacity" 12000
 	description "The Wanderers are masters of unusual and efficient technology. This bioreactor is fueled by a culture of microorganisms that produce a small electric charge."
 
 outfit "Red Sun Reactor"

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -301,9 +301,9 @@ outfit "Small Biochemical Cell"
 	thumbnail "outfit/small biochemical"
 	"mass" 17
 	"outfit space" -17
-	"energy generation" 2
-	"heat generation" 1.75
-	"energy capacity" 3000
+	"energy generation" 1.6
+	"heat generation" 1.4
+	"energy capacity" 7500
 	description "This tiny generator draws energy from the metabolic byproducts of a collection of microorganisms that have been engineered by the Wanderers specifically for this purpose."
 
 outfit "Large Biochemical Cell"
@@ -314,9 +314,9 @@ outfit "Large Biochemical Cell"
 	thumbnail "outfit/large biochemical"
 	"mass" 63
 	"outfit space" -63
-	"energy generation" 7.75
-	"heat generation" 6.125
-	"energy capacity" 12000
+	"energy generation" 6.2
+	"heat generation" 4.9
+	"energy capacity" 30000
 	description "The Wanderers are masters of unusual and efficient technology. This bioreactor is fueled by a culture of microorganisms that produce a small electric charge."
 
 outfit "Red Sun Reactor"

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -297,7 +297,7 @@ outfit "Small Biochemical Cell"
 	category "Power"
 	licenses
 		"Wanderer Outfits"
-	cost 287500
+	cost 230000
 	thumbnail "outfit/small biochemical"
 	"mass" 17
 	"outfit space" -17
@@ -310,7 +310,7 @@ outfit "Large Biochemical Cell"
 	category "Power"
 	licenses
 		"Wanderer Outfits"
-	cost 1175000
+	cost 940000
 	thumbnail "outfit/large biochemical"
 	"mass" 63
 	"outfit space" -63

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -297,7 +297,7 @@ outfit "Small Biochemical Cell"
 	category "Power"
 	licenses
 		"Wanderer Outfits"
-	cost 230000
+	cost 287500
 	thumbnail "outfit/small biochemical"
 	"mass" 17
 	"outfit space" -17
@@ -310,7 +310,7 @@ outfit "Large Biochemical Cell"
 	category "Power"
 	licenses
 		"Wanderer Outfits"
-	cost 940000
+	cost 1175000
 	thumbnail "outfit/large biochemical"
 	"mass" 63
 	"outfit space" -63


### PR DESCRIPTION
**Balance?**

## Summary
Significantly increase the energy capacities of the small and large Biochemical Cells.
3k -> 7.5k on the small.
7k -> 30k on the large.
Also, reduce the price of the nGVF-AA Fuel Cell from 40k to 35k because it seemed a little too close to the nGVF-BB Fuel Cell and raising the price on that would put it too close to the cell above and just lead to inflation of everything.

~~25% increase in energy and heat generation for the two Biochemical Cells, and increase the energy capacity of the large Biochemical Cell so it has slightly higher energy capacity/ton than the small, instead of significantly lower as it was before.
Buffs were chosen by @Amazinite in response to my suggestion that the proposed Hailstone fighters would need Red Sun Reactors because Small Biochemical Cells don't really produce a lot of power.~~