### PR TITLE
Tweak: Reword Pug Biodefense Description for Consistency

### DIFF
--- a/data/pug/pug.txt
+++ b/data/pug/pug.txt
@@ -482,7 +482,7 @@ outfit "Pug Biodefenses"
 	thumbnail "outfit/pug biodefenses"
 	"capture defense" 250
 	"unplunderable" 1
-	description "This defense system is designed to release a suite of toxins that are lethal to human beings (and probably to some other species, as well) but which have no effect at all on the Pug."
+	description "This semi-organic defense system is designed to release a highly lethal bioengineered virus capable of rapidly infecting any foreign entities present on the ship that it is installed on while leaving the crew of the ship unharmed. The virus, when combined with the defense system itself, is highly accurate at automatically determining friend from foe. However, it is still recommended that any new crew be given a temporary vaccine before being allowed onboard."
 
 outfit "Pug Peacekeeping Staff"
 	plural "Pug Peacekeeping Staves"


### PR DESCRIPTION
## Summary
This PR introduces a rewording of the description for Pug Biodefenses to resolve the inconsistency brought up in issue #2298

## Save File
This save file will place you on New Boston with an Arfecta equipped with biodefenses:
[Biodefense Description.txt](https://github.com/Hecter94/endless-sky/files/9033860/Biodefense.Description.txt)

## Fix Details
Old Description:
![image](https://user-images.githubusercontent.com/15916854/177019074-1f1e74e3-3dfe-4052-b59b-717ec397913b.png)

Proposed New Description:
![image](https://user-images.githubusercontent.com/15916854/177019118-7fa99164-d70a-4487-b80b-1994d7445d16.png)

With the updated description, there is no longer a lore inconsistency for why Pug Biodefenses work against pug, or why your
 human crew are unharmed by releasing them on their own ship. 