### PR TITLE
Content: Alternate Dialogue in "FW Senate 1B" if player is fast enough.

### DIFF
--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -1056,7 +1056,7 @@ mission "FW Senate 1B"
 			`You drop off Senator Huygens, who says nothing by way of acknowledging your help except, "It's about time we got here." She hurries off.`
 				goto next
 			label fast
-			`You drop off Senator Huygens, who appears uncharacteristically pleased. "Good work Captain <last>, I see we made good time. It seems you're far more reliable than most captains I work with." she says before walking off.`
+			`You drop off Senator Huygens, who appears uncharacteristically pleased. "Good work Captain <last>, I see we made good time. It seems you're far more reliable than most captains I work with," she says before walking off.`
 			label next
 			`	A few minutes later, someone shouts, "Hello there, Captain <last>!" It's Ijs Springborn. "I'm glad to see you again," he says.`
 			choice

--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -1051,7 +1051,13 @@ mission "FW Senate 1B"
 		dialog `You land on <planet>, but realize that your escort carrying Senator Huygens hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		conversation
+			branch fast
+				has "FW Senate Timer: active"
 			`You drop off Senator Huygens, who says nothing by way of acknowledging your help except, "It's about time we got here." She hurries off.`
+				goto next
+			label fast
+			`You drop off Senator Huygens, who appears uncharacteristically pleased, "Good work Captain <last>, I see we made good time. It seems you're far more reliable than most captains I work with." she says before walking off.`
+			label next
 			`	A few minutes later, someone shouts, "Hello there, Captain <last>!" It's Ijs Springborn. "I'm glad to see you again," he says.`
 			choice
 				`	"You too. What brings you to Bourne?"`
@@ -1075,6 +1081,13 @@ mission "FW Senate 1B"
 			`	"Indeed," he says. "Anyway, I'm off to a meeting, but meet me later in the spaceport if you've got room for some passengers."`
 
 
+mission "FW Senate Timer"
+	invisible
+	landing
+	source "Mere"
+	deadline 7
+	to offer
+		has "FW Senate 1: done"
 
 mission "FW Pirates 2"
 	landing

--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -1057,7 +1057,7 @@ mission "FW Senate 1B"
 			`You drop off Senator Huygens, who appears uncharacteristically pleased. "Good work Captain <last>, I see we made good time. It seems you're far more reliable than most captains I work with," she says before walking off.`
 				goto waiting
 			label slow
-			`You drop off Senator Huygens, who says nothing by way of acknowledging your help except, "It's about time we got here." She hurries off.`			
+			`You drop off Senator Huygens, who says nothing by way of acknowledging your help except, "It's about time we got here." She hurries off.`
 			label waiting
 			`	A few minutes later, someone shouts, "Hello there, Captain <last>!" It's Ijs Springborn. "I'm glad to see you again," he says.`
 			choice

--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -1087,6 +1087,7 @@ mission "FW Senate Timer"
 	source "Mere"
 	deadline 7
 	to offer
+		"passenger space" > 0
 		has "FW Senate 1: done"
 
 mission "FW Pirates 2"

--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -1030,6 +1030,7 @@ mission "FW Senate 1B"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
+		event "fw senate timer" 8
 		log "People" "Ijs Springborn" `Ijs is now working to found the Conservatory, a publicly funded Free Worlds university that will have a particular focus on terraforming technology. Their goal is to make terraforming methods efficient enough that even Dirt Belt worlds will be able to afford them.`
 		conversation
 			`Senator Huygens turns out to be an attractive woman in her mid-fifties, with a dour expression on her face. "About time you showed up," is all she says when you introduce yourself.`
@@ -1051,12 +1052,12 @@ mission "FW Senate 1B"
 		dialog `You land on <planet>, but realize that your escort carrying Senator Huygens hasn't entered the system yet. Better depart and wait for it to arrive.`
 	on complete
 		conversation
-			branch fast
-				has "FW Senate Timer: active"
-			`You drop off Senator Huygens, who says nothing by way of acknowledging your help except, "It's about time we got here." She hurries off.`
-				goto waiting
-			label fast
+			branch slow
+				has "event: fw senate timer"
 			`You drop off Senator Huygens, who appears uncharacteristically pleased. "Good work Captain <last>, I see we made good time. It seems you're far more reliable than most captains I work with," she says before walking off.`
+				goto waiting
+			label slow
+			`You drop off Senator Huygens, who says nothing by way of acknowledging your help except, "It's about time we got here." She hurries off.`			
 			label waiting
 			`	A few minutes later, someone shouts, "Hello there, Captain <last>!" It's Ijs Springborn. "I'm glad to see you again," he says.`
 			choice
@@ -1080,15 +1081,7 @@ mission "FW Senate 1B"
 				`	"Sounds like that could be a great public relations move for convincing more worlds to join us."`
 			`	"Indeed," he says. "Anyway, I'm off to a meeting, but meet me later in the spaceport if you've got room for some passengers."`
 
-
-mission "FW Senate Timer"
-	invisible
-	landing
-	source "Mere"
-	deadline 7
-	to offer
-		"passenger space" > 0
-		has "FW Senate 1: done"
+event "fw senate timer"
 
 mission "FW Pirates 2"
 	landing

--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -1056,7 +1056,7 @@ mission "FW Senate 1B"
 			`You drop off Senator Huygens, who says nothing by way of acknowledging your help except, "It's about time we got here." She hurries off.`
 				goto next
 			label fast
-			`You drop off Senator Huygens, who appears uncharacteristically pleased, "Good work Captain <last>, I see we made good time. It seems you're far more reliable than most captains I work with." she says before walking off.`
+			`You drop off Senator Huygens, who appears uncharacteristically pleased. "Good work Captain <last>, I see we made good time. It seems you're far more reliable than most captains I work with." she says before walking off.`
 			label next
 			`	A few minutes later, someone shouts, "Hello there, Captain <last>!" It's Ijs Springborn. "I'm glad to see you again," he says.`
 			choice

--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -1054,10 +1054,10 @@ mission "FW Senate 1B"
 			branch fast
 				has "FW Senate Timer: active"
 			`You drop off Senator Huygens, who says nothing by way of acknowledging your help except, "It's about time we got here." She hurries off.`
-				goto next
+				goto waiting
 			label fast
 			`You drop off Senator Huygens, who appears uncharacteristically pleased. "Good work Captain <last>, I see we made good time. It seems you're far more reliable than most captains I work with," she says before walking off.`
-			label next
+			label waiting
 			`	A few minutes later, someone shouts, "Hello there, Captain <last>!" It's Ijs Springborn. "I'm glad to see you again," he says.`
 			choice
 				`	"You too. What brings you to Bourne?"`

--- a/data/human/free worlds start.txt
+++ b/data/human/free worlds start.txt
@@ -1083,6 +1083,8 @@ mission "FW Senate 1B"
 
 event "fw senate timer"
 
+
+
 mission "FW Pirates 2"
 	landing
 	name "Southern Patrol"


### PR DESCRIPTION
## Summary
This PR adds an additional invisible mission as well as one additional line of dialogue when transporting the Senator to Bourne as part of FW Senate 1B to address players who have a jump drive and are able to meet the deadline imposed by the Senator in order to resolve issue #6108

## Save File
This save file will place you on Zug with two ships, one equipped with a hyperdrive, one with a jump drive. Using the JD equipped ship will allow you to see the new dialogue, using the HD equipped ship will show the old dialogue:
[Huygens Fix~Example Save.txt](https://github.com/endless-sky/endless-sky/files/9038099/Huygens.Fix.Example.Save.txt)

## Fix Details
Old Dialogue:
![image](https://user-images.githubusercontent.com/15916854/177125191-6d598ec3-2082-4c2c-b610-043741240d56.png)

New Dialogue (If delivered fast enough)
![image](https://user-images.githubusercontent.com/15916854/177125399-021dda54-3553-48db-8dfd-81dd13745072.png)

## Testing Done
Started the mission on Dec 3rd in-game and made sure that the new dialogue would show if the Senator was delivered by Dec 10th, exactly 7 days and that the old dialogue would display if delivered Dec 11th and onward.

## Notes
Currently the dialogue in the mission still implies that it is impossible to get from Mere to Bourne in 7 days, even if the player has a jump drive equipped and knows that it is possible. 
![image](https://user-images.githubusercontent.com/15916854/177126266-7cbff90c-bb9d-42f4-a36c-36ab268effd6.png)

Ideally that line would be removed if the player has a jump drive equipped, however it does not appear possible to do that without having a second copy of the mission, which I didn't feel was worth doing just to change one line of dialogue. 

If requiring an outfit is implemented as a condition, this can be revisted.