### PR TITLE
fix(typo): Add space in pirate hail

### DIFF
--- a/data/human/hails.txt
+++ b/data/human/hails.txt
@@ -2556,7 +2556,7 @@ phrase "friendly pirate"
 		" horrendous "
 		" atrocious "
 		" horrid "
-		""
+		" "
 	word
 		"bad blue"
 		"booster"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4471575/177397553-94b5812d-d289-4cc5-bc1b-e9544187cf47.png)

Could roll a type of friendly pirate hail with no space, which this fixes.