### PR TITLE
Coalition Bugfix: Long Lost Property to fail condition update

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -2940,7 +2940,9 @@ mission "Coalition: Long Lost Property 2"
 	to complete
 		never
 	to fail
-		has "Coalition: Long Lost Property 3: active"
+		or
+			has "Coalition: Long Lost Property 3: active"
+			has "Coalition: Long Lost Property 3: done"
 
 mission "Coalition: Long Lost Property 3"
 	landing


### PR DESCRIPTION
-----------------------
**Bugfix:** In the Coalition's Long Lost Property missions, mission 2 is meant to serve as a marker to Shaula/Greenrock, in case one lands there but doesn't meet the credits requirement to bribe the junkyard owner. If you have accepted mission 3, that means you've bribed him, thus mission 2 is no longer needed.
However, the current check only sees if the mission is active to fail mission 2. If you never land between accepting mission 3, and completing mission 3, mission 2 won't get cleared out.

## Fix Details
This just makes it so that mission 2's `to fail` has an `or` that checks not only for mission 3 being active, but also if mission 3 has been completed. If one lands between accepting mission 3 and completing it, then the `active` check will clear mission 2 out. If not, then the `done` check will do it.

## Testing Done
I noticed this yesterday on a pilot that had just finished the mission chain. As described, I accepted and completed mission 3 without landing at all in between, so mission 2 was still in my missions list. I quickly played through three more times just now, not landing in two of the times, and landing right after accepting it in another. In both cases where I didn't land, the mission was still there in my missions list, and was never cleared. In the instance where I landed right after accepting mission 3, it cleared out mission 2 as intended.