### PR TITLE
Coalition Bugfix: Update source filter for Alpha Encounter

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -1409,7 +1409,7 @@ mission "Coalition: Alpha Encounter"
 		random < 1
 	source
 		government "Coalition"
-		not attributes "station"
+		not attributes "coalition station"
 		not planet "Secret Sky" "Remote Blue" "Bloptab's Furnace" "Ahr"
 	on offer
 		event "alitis freed" 1095


### PR DESCRIPTION
-----------------------
**Bugfix:** The "Alpha Encounter" mission in Coalition space has for one of its source filters `not attributes "station"`, when `"station"` isn't an attribute found in any Coalition worlds (the stations there use the separate `"coalition station"` attribute), so it's effectively not doing anything.
So, it could offer in one of the Coalition stations, which isn't intended since it could lead to some odd imagery on how the stations are structured, basically it's just simpler to imagine the events occurring on a regular planet.

## Fix Details
This just changes the attribute filter in the mission from `not attributes "station"` to `not attributes "coalition station"`.