### PR TITLE
Actually put Korati Efreti at the Lagrangian point

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -8390,7 +8390,7 @@ system Dokdobaru
 	object "Korati Efreti"
 		sprite planet/station1k
 		distance 680
-		period 268.086
+		period 349.820
 	object
 		sprite planet/lava3-b
 		distance 812


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
The description of Korati Efreti says it was built at the Lagrangian point between the local star and the planet the Quarg were mining for ringworld building materials. At the Lagrangian point, the orbital period should be the same as the planet, this was not the case.
Assuming it is still supposed to be there, I have increased the orbital period of the station to match that of hte planet and the ringworld.

