### PR TITLE
Buff to ion damages

### DIFF
--- a/data/coalition/coalition weapons.txt
+++ b/data/coalition/coalition weapons.txt
@@ -357,7 +357,7 @@ outfit "ion hail"
 		"hit force" 1
 		"shield damage" 12
 		"hull damage" 5
-		"ion damage" .32
+		"ion damage" .64
 
 
 outfit "Ion Rain Gun"
@@ -386,7 +386,7 @@ outfit "Ion Rain Gun"
 		"firing heat" 4
 		"shield damage" 12
 		"hull damage" 5
-		"ion damage" .32
+		"ion damage" .64
 	description "Heliarch ships primarily serve as a police force. This weapon is designed to neutralize a target's offensive capabilities until more Heliarch ships can join the fray."
 
 effect "ion rain impact"

--- a/data/drak/drak outfits.txt
+++ b/data/drak/drak outfits.txt
@@ -56,7 +56,7 @@ outfit "Drak Draining Field"
 		"firing force" 30
 		"hit force" 100
 		"shield damage" 50
-		"ion damage" .5
+		"ion damage" 1
 		"disruption damage" 1
 		"safe"
 	description "This device is the Archon's primary defensive tool: Not only does it disrupt the shields and energy supplies of all hostile ships within it, it also exerts a powerful repelling force that keeps ships from closing in with the Archon."
@@ -85,7 +85,7 @@ outfit "Drak Draining Field (Augmented)"
 		"firing force" 30
 		"hit force" 1000
 		"shield damage" 500
-		"ion damage" 1
+		"ion damage" 2
 		"disruption damage" 2
 		"safe"
 	description "This device is the Archon's primary defensive tool: Not only does it disrupt the shields and energy supplies of all hostile ships within it, it also exerts a powerful repelling force that keeps ships from closing in with the Archon."

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -90,7 +90,7 @@ outfit "Ion Cannon"
 		"hit force" 120
 		"shield damage" 168
 		"hull damage" 60
-		"ion damage" 5
+		"ion damage" 8
 	description "Ion cannons do not inflict as much damage as some other weapons, but they disrupt the electrical systems on any ship they hit, draining its energy and causing its weapons to jam. If a ship has sizable battery reserves, this may have little effect, but for a ship running at near its energy generation capacity an ion strike can take it out of the battle for a few seconds while it recovers, or otherwise cause it to have difficulty firing its weapons."
 
 effect "ion impact"
@@ -166,7 +166,7 @@ outfit "rslug"
 		"optical tracking" .4
 		"shield damage" 4.2
 		"hull damage" 8.4
-		"ion damage" .3
+		"ion damage" .6
 		"hit force" 15
 
 effect "rail sparks"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -90,7 +90,7 @@ outfit "Ion Cannon"
 		"hit force" 120
 		"shield damage" 168
 		"hull damage" 60
-		"ion damage" 8
+		"ion damage" 10
 	description "Ion cannons do not inflict as much damage as some other weapons, but they disrupt the electrical systems on any ship they hit, draining its energy and causing its weapons to jam. If a ship has sizable battery reserves, this may have little effect, but for a ship running at near its energy generation capacity an ion strike can take it out of the battle for a few seconds while it recovers, or otherwise cause it to have difficulty firing its weapons."
 
 effect "ion impact"

--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -21,7 +21,7 @@ hazard "Ember Waste Base Storm"
 	"range" 10000
 	"environmental effect" "ion hazard" 20
 	weapon
-		"ion damage" 0.5
+		"ion damage" 1
 		"shield damage" 5
 		"hull damage" 0.01
 

--- a/data/kahet/kahet outfits.txt
+++ b/data/kahet/kahet outfits.txt
@@ -40,7 +40,7 @@ outfit "Ka'het Nullifier"
 		"turn" 73
 		"shield damage" 120
 		"hull damage" 40
-		"ion damage" 150
+		"ion damage" 300
 		"hit force" 50
 		"blast radius" 20
 	description "The Nullifier was one of the largest weapons the Builders ever developed, created specifically to be carried in battle by the Vareti. Although it does almost no damage to shields and hull, one shot is capable of disabling most kinds of reactors in a matter of seconds."
@@ -257,7 +257,7 @@ outfit "Ka'het EMP Deployer"
 		"blast radius" 200
 		"shield damage" 700
 		"hull damage" 100
-		"ion damage" 48
+		"ion damage" 96
 		"hit force" 90
 		"missile strength" 80
 	description "Eons ago, the Builders were attacked by alien ships which used weapons that ignored their hull and damaged their reactors. Although they never did recover any of these weapons, after years of research they managed to replicate their effects."

--- a/data/quarg/quarg outfits.txt
+++ b/data/quarg/quarg outfits.txt
@@ -55,7 +55,7 @@ outfit "Quarg Skylance"
 		"firing heat" 10
 		"shield damage" 50
 		"hull damage" 40
-		"ion damage" .1
+		"ion damage" .2
 	description "These immensely powerful beam weapons are used by Quarg warships to strike fear into the hearts of all who dare oppose them."
 
 effect "skylance impact"

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -271,7 +271,7 @@ outfit "EMP Torpedo Bay"
 		"blast radius" 200
 		"shield damage" 700
 		"hull damage" 100
-		"ion damage" 48
+		"ion damage" 96
 		"hit force" 90
 		"missile strength" 80
 	description "Electromagnetic pulse weapons were developed by the Remnant during the early days of their colony, when they were living in fear that the Alphas would overrun human space and expand beyond it."

--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -259,7 +259,7 @@ outfit "Particle Waveform Turret"
 		"shield damage" 95
 		"hull damage" 270
 		"heat damage" 224
-		"ion damage" 4.2
+		"ion damage" 8.4
 	description "This ancient Sheragi turret accelerates a dense packet of electrons that, while very ineffective against any kind of shielding, has a very long range and disrupts electrical systems. By the nature of these weapons, one can deduce that their tactics likely involved using the Dragonflame Cannon at long range to break the enemy shields and finishing them off at relatively close range with the Particle Waveform Turrets."
 
 effect "lightning flare"


### PR DESCRIPTION
## Balance
Ion has never been very useful though you still could use it by spamming ion weapons. (not like a tier1 flamethrower disables a t3 ship in seconds... right?)
Recently, it became a joke, with batteries having double their capacity. 
This PR is hoping to change that.
For instance, the nullifier is said to deactivate any ship's reactor within seconds, the Hai adapted all of their ships to counter the use of the ion cannon.
Emp torpedoes just don't do enough to justify using them.

edit - I know noticed they cause weapon jam from https://github.com/endless-sky/endless-sky/pull/6799 but that's really not enough, though it does solve the fact that before using a few ion weapons was completely pointless, it still doesn't really allow one to disable a ship by spamming ion, which is what should happen

The goal of https://github.com/endless-sky/endless-sky/pull/6783 was to make batteries viable, which it did, and not to make ion weapons useless.

I could have opened an issue but I prefer to open this PR so that anyone can try it out and see how it would look, to see if this is too much or still not enough. The only thing ion can accomplish in the game right now is annoy you a bit in Hai space because they spam it so much, and even there you can still ignore it.

## Alternative
We could just change the way ion works to affect power a more. Currently I couldn't manage to disable a Hai ship by use of only ion weapons before its hull made it be disabled, whilst he was moving, regenerating shields, and shooting at me.
Maybe its fine for most that ion doesn't ever disable ships and only makes their weapons jam? That's not what I would want from ion weapons, I think if you equip a few it should indeed only jam the enemy a bit but if you spam them you should be able to disable them with it.