### PR TITLE
Refactor: use strength instead of cost directly and optimization of deterrence + cargo attraction

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3725,14 +3725,14 @@ bool AI::Has(const Ship &ship, const Government *government, int type) const
 
 void AI::UpdateStrengths(map<const Government *, int64_t> &strength, const System *playerSystem)
 {
-	// Tally the strength of a government by the cost of its present and able ships.
+	// Tally the strength of a government by the strength of its present and able ships.
 	governmentRosters.clear();
 	for(const auto &it : ships)
 		if(it->GetGovernment() && it->GetSystem() == playerSystem)
 		{
 			governmentRosters[it->GetGovernment()].emplace_back(it.get());
 			if(!it->IsDisabled())
-				strength[it->GetGovernment()] += it->Cost();
+				strength[it->GetGovernment()] += it->Strength();
 		}
 
 	// Strengths of enemies and allies are rebuilt every step.
@@ -3777,7 +3777,7 @@ void AI::UpdateStrengths(map<const Government *, int64_t> &strength, const Syste
 				continue;
 			for(const auto &ally : allies.second)
 				if(!ally->IsDisabled() && ally->Position().Distance(it->Position()) < 2000.)
-					myStrength += ally->Cost();
+					myStrength += ally->Strength();
 		}
 	}
 }

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2414,11 +2414,11 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 		if(ship->GetGovernment() == attacker && ship->GetTargetShip() == target)
 		{
 			++attackerCount;
-			attackerStrength += (ship->Shields() + ship->Hull()) * ship->Cost();
+			attackerStrength += (ship->Shields() + ship->Hull()) * ship->Strength();
 		}
 
 	// Only ask for help if outmatched.
-	double targetStrength = (target->Shields() + target->Hull()) * target->Cost();
+	double targetStrength = (target->Shields() + target->Hull()) * target->Strength();
 	if(attackerStrength <= targetStrength)
 		return;
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1027,8 +1027,8 @@ pair<double, double> PlayerInfo::RaidFleetFactors() const
 		if(ship->IsParked() || ship->IsDestroyed())
 			continue;
 
-		attraction += ship.Attraction();
-		deterrence += ship.Deterence();
+		attraction += ship->Attraction();
+		deterrence += ship->Deterrence();
 	}
 
 	return make_pair(attraction, deterrence);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1028,7 +1028,7 @@ pair<double, double> PlayerInfo::RaidFleetFactors() const
 			continue;
 
 		attraction += ship.Attraction();
-		deterrance += ship.Deterance();
+		deterrence += ship.Deterence();
 	}
 
 	return make_pair(attraction, deterrence);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1027,18 +1027,8 @@ pair<double, double> PlayerInfo::RaidFleetFactors() const
 		if(ship->IsParked() || ship->IsDestroyed())
 			continue;
 
-		attraction += max(0., .4 * sqrt(ship->Attributes().Get("cargo space")) - 1.8);
-		for(const Hardpoint &hardpoint : ship->Weapons())
-			if(hardpoint.GetOutfit())
-			{
-				const Outfit *weapon = hardpoint.GetOutfit();
-				if(weapon->Ammo() && !ship->OutfitCount(weapon->Ammo()))
-					continue;
-				double damage = weapon->ShieldDamage() + weapon->HullDamage()
-					+ (weapon->RelativeShieldDamage() * ship->Attributes().Get("shields"))
-					+ (weapon->RelativeHullDamage() * ship->Attributes().Get("hull"));
-				deterrence += .12 * damage / weapon->Reload();
-			}
+		attraction += ship.Attraction();
+		deterrance += ship.Deterance();
 	}
 
 	return make_pair(attraction, deterrence);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1103,8 +1103,7 @@ double Ship::Deterrence() const
 				continue;
 			double strength = weapon->ShieldDamage() + weapon->HullDamage()
 				+ (weapon->RelativeShieldDamage() * attributes.Get("shields"))
-				+ (weapon->RelativeHullDamage() * attributes.Get("hull"))
-				+ weapon->AntiMissile();
+				+ (weapon->RelativeHullDamage() * attributes.Get("hull"));
 			deterrence += .12 * strength / weapon->Reload();
 		}
 	return deterrence;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1078,6 +1078,39 @@ int64_t Ship::ChassisCost() const
 
 
 
+int64_t Ship::Strength() const
+{
+	return Cost() * Deterrence();
+}
+
+
+
+double Ship::Attraction() const
+{
+	return max(0., .4 * sqrt(Attributes().Get("cargo space")) - 1.8);
+}
+
+
+
+double Ship::Deterrence() const
+{
+	double deterrence = 0.;
+	for(const Hardpoint &hardpoint : Weapons())
+		if(hardpoint.GetOutfit())
+		{
+			const Outfit *weapon = hardpoint.GetOutfit();
+			if(weapon->Ammo() && !OutfitCount(weapon->Ammo()))
+				continue;
+			double strength = weapon->ShieldDamage() + weapon->HullDamage()
+				+ (weapon->RelativeShieldDamage() * attributes.Get("shields"))
+				+ (weapon->RelativeHullDamage() * attributes.Get("hull"))
+				+ weapon->AntiMissile();
+			deterrence += .12 * strength / weapon->Reload();
+		}
+	return deterrence;
+}
+
+
 // Check if this ship is configured in such a way that it would be difficult
 // or impossible to fly.
 vector<string> Ship::FlightCheck() const

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3696,13 +3696,13 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		if(outfit->IsWeapon())
 		{
 			armament.Add(outfit, count);
-			CalculateDeterrence();
+			deterrence = CalculateDeterrence();
 		}
 
 		if(outfit->Get("cargo space"))
 		{
 			cargo.SetSize(attributes.Get("cargo space"));
-			CalculateAttraction();
+			attraction = CalculateAttraction();
 		}
 		if(outfit->Get("hull"))
 			hull += outfit->Get("hull") * count;
@@ -3791,7 +3791,7 @@ void Ship::ExpendAmmo(const Weapon &weapon)
 		heat -= weapon.AmmoUsage() * .5 * ammo->Mass() * MAXIMUM_TEMPERATURE * Heat();
 		AddOutfit(ammo, -weapon.AmmoUsage());
 		if(!OutfitCount(ammo))
-			CalculateDeterrence();
+			deterrence = CalculateDeterrence();
 	}
 
 	energy -= weapon.FiringEnergy() + relativeEnergyChange;
@@ -4093,17 +4093,16 @@ void Ship::CreateSparks(vector<Visual> &visuals, const Effect *effect, double am
 
 
 
-double Ship::CalculateAttraction()
+double Ship::CalculateAttraction() const
 {
-	attraction = max(0., .4 * sqrt(attributes.Get("cargo space")) - 1.8);
-	return attraction;
+	return max(0., .4 * sqrt(attributes.Get("cargo space")) - 1.8);
 }
 
 
 
-double Ship::CalculateDeterrence()
+double Ship::CalculateDeterrence() const
 {
-	deterrence = 0.;
+	double tempDeterrence = 0.;
 	for(const Hardpoint &hardpoint : Weapons())
 		if(hardpoint.GetOutfit())
 		{
@@ -4113,7 +4112,7 @@ double Ship::CalculateDeterrence()
 			double strength = weapon->ShieldDamage() + weapon->HullDamage()
 				+ (weapon->RelativeShieldDamage() * attributes.Get("shields"))
 				+ (weapon->RelativeHullDamage() * attributes.Get("hull"));
-			deterrence += .12 * strength / weapon->Reload();
+			tempDeterrence += .12 * strength / weapon->Reload();
 		}
-	return deterrence;
+	return tempDeterrence;
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -723,7 +723,7 @@ void Ship::FinishLoading(bool isNewInstance)
 	}
 
 	// Only the player's ships make use of attraction and deterrence.
-	if(IsYours())
+	if(isYours)
 	{
 		attraction = CalculateAttraction();
 		deterrence = CalculateDeterrence();
@@ -3701,7 +3701,7 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		{
 			armament.Add(outfit, count);
 			// Only the player's ships make use of attraction and deterrence.
-			if(IsYours())
+			if(isYours)
 				deterrence = CalculateDeterrence();
 		}
 
@@ -3709,7 +3709,7 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		{
 			cargo.SetSize(attributes.Get("cargo space"));
 			// Only the player's ships make use of attraction and deterrence.
-			if(IsYours())
+			if(isYours)
 				attraction = CalculateAttraction();
 		}
 		if(outfit->Get("hull"))
@@ -3799,7 +3799,7 @@ void Ship::ExpendAmmo(const Weapon &weapon)
 		heat -= weapon.AmmoUsage() * .5 * ammo->Mass() * MAXIMUM_TEMPERATURE * Heat();
 		AddOutfit(ammo, -weapon.AmmoUsage());
 		// Only the player's ships make use of attraction and deterrence.
-		if(IsYours() && !OutfitCount(ammo) && ammo->AmmoUsage())
+		if(isYours && !OutfitCount(ammo) && ammo->AmmoUsage())
 			deterrence = CalculateDeterrence();
 	}
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1084,7 +1084,7 @@ int64_t Ship::ChassisCost() const
 
 int64_t Ship::Strength() const
 {
-	return Cost() * Deterrence();
+	return Cost();
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -722,6 +722,7 @@ void Ship::FinishLoading(bool isNewInstance)
 		attributes.Set("drag", 100.);
 	}
 
+	// Only the player's ships make use of attraction and deterrence.
 	if(IsYours())
 	{
 		attraction = CalculateAttraction();
@@ -3699,6 +3700,7 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		if(outfit->IsWeapon())
 		{
 			armament.Add(outfit, count);
+			// Only the player's ships make use of attraction and deterrence.
 			if(IsYours())
 				deterrence = CalculateDeterrence();
 		}
@@ -3706,6 +3708,7 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		if(outfit->Get("cargo space"))
 		{
 			cargo.SetSize(attributes.Get("cargo space"));
+			// Only the player's ships make use of attraction and deterrence.
 			if(IsYours())
 				attraction = CalculateAttraction();
 		}
@@ -3795,6 +3798,7 @@ void Ship::ExpendAmmo(const Weapon &weapon)
 		// A realistic fraction applicable to all cases cannot be computed, so assume 50%.
 		heat -= weapon.AmmoUsage() * .5 * ammo->Mass() * MAXIMUM_TEMPERATURE * Heat();
 		AddOutfit(ammo, -weapon.AmmoUsage());
+		// Only the player's ships make use of attraction and deterrence.
 		if(IsYours() && !OutfitCount(ammo) && ammo->AmmoUsage())
 			deterrence = CalculateDeterrence();
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -722,8 +722,11 @@ void Ship::FinishLoading(bool isNewInstance)
 		attributes.Set("drag", 100.);
 	}
 
-	attraction = CalculateAttraction();
-	deterrence = CalculateDeterrence();
+	if(IsYours())
+	{
+		attraction = CalculateAttraction();
+		deterrence = CalculateDeterrence();
+	}
 
 	if(!warning.empty())
 	{
@@ -3696,13 +3699,15 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		if(outfit->IsWeapon())
 		{
 			armament.Add(outfit, count);
-			deterrence = CalculateDeterrence();
+			if(IsYours())
+				deterrence = CalculateDeterrence();
 		}
 
 		if(outfit->Get("cargo space"))
 		{
 			cargo.SetSize(attributes.Get("cargo space"));
-			attraction = CalculateAttraction();
+			if(IsYours())
+				attraction = CalculateAttraction();
 		}
 		if(outfit->Get("hull"))
 			hull += outfit->Get("hull") * count;
@@ -3790,7 +3795,7 @@ void Ship::ExpendAmmo(const Weapon &weapon)
 		// A realistic fraction applicable to all cases cannot be computed, so assume 50%.
 		heat -= weapon.AmmoUsage() * .5 * ammo->Mass() * MAXIMUM_TEMPERATURE * Heat();
 		AddOutfit(ammo, -weapon.AmmoUsage());
-		if(!OutfitCount(ammo))
+		if(IsYours() && !OutfitCount(ammo) && ammo->AmmoUsage())
 			deterrence = CalculateDeterrence();
 	}
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4116,7 +4116,7 @@ double Ship::CalculateDeterrence() const
 		if(hardpoint.GetOutfit())
 		{
 			const Outfit *weapon = hardpoint.GetOutfit();
-			if(weapon->Ammo() && !OutfitCount(weapon->Ammo()))
+			if(weapon->Ammo() && weapon->AmmoUsage() && !OutfitCount(weapon->Ammo()))
 				continue;
 			double strength = weapon->ShieldDamage() + weapon->HullDamage()
 				+ (weapon->RelativeShieldDamage() * attributes.Get("shields"))

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -153,6 +153,9 @@ public:
 	// Get this ship's cost.
 	int64_t Cost() const;
 	int64_t ChassisCost() const;
+	int64_t Strength() const;
+	double Attraction() const;
+	double Deterrence() const;
 
 	// Check if this ship is configured in such a way that it would be difficult
 	// or impossible to fly.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -443,6 +443,9 @@ private:
 	void CreateSparks(std::vector<Visual> &visuals, const std::string &name, double amount);
 	void CreateSparks(std::vector<Visual> &visuals, const Effect *effect, double amount);
 
+	double CalculateAttraction();
+	double CalculateDeterrence();
+
 
 private:
 	/* Protected member variables of the Body class:
@@ -496,6 +499,9 @@ private:
 	// Cargo and outfit scanning takes time.
 	double cargoScan = 0.;
 	double outfitScan = 0.;
+
+	double attraction = 0.;
+	double deterrence = 0.;
 
 	Command commands;
 	FireCommand firingCommands;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -443,8 +443,8 @@ private:
 	void CreateSparks(std::vector<Visual> &visuals, const std::string &name, double amount);
 	void CreateSparks(std::vector<Visual> &visuals, const Effect *effect, double amount);
 
-	double CalculateAttraction();
-	double CalculateDeterrence();
+	double CalculateAttraction() const;
+	double CalculateDeterrence() const;
 
 
 private:

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -443,6 +443,8 @@ private:
 	void CreateSparks(std::vector<Visual> &visuals, const std::string &name, double amount);
 	void CreateSparks(std::vector<Visual> &visuals, const Effect *effect, double amount);
 
+	// Calculate the attraction and deterrance of this ship, for pirate raids.
+	// This is only useful for the player's ships.
 	double CalculateAttraction() const;
 	double CalculateDeterrence() const;
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -154,6 +154,8 @@ public:
 	int64_t Cost() const;
 	int64_t ChassisCost() const;
 	int64_t Strength() const;
+	// Get the attraction and deterrance of this ship, for pirate raids.
+	// This is only useful for the player's ships.
 	double Attraction() const;
 	double Deterrence() const;
 

--- a/source/Variant.cpp
+++ b/source/Variant.cpp
@@ -74,12 +74,12 @@ const vector<const Ship *> &Variant::Ships() const
 
 
 
-// The strength of a variant is the sum of the cost of its ships.
+// The strength of a variant is the sum of the strength of its ships.
 int64_t Variant::Strength() const
 {
 	int64_t strength = 0;
 	for(const Ship *ship : ships)
-		strength += ship->Cost();
+		strength += ship->Strength();
 	return strength;
 }
 


### PR DESCRIPTION
We'll keep the changes for another PR. This is just refactoring.

I also made temporary values that only change once the ship runs out of ammo or has its outfits changed for deterrence and attraction.
It should result in some nice performance improvements, given strengths used to be updated and recalculated each Step() of AI.

~~But it also now takes into account the deterrence of ships when assessing their strength.
I did this change because often we look at the strength of ships within a system, and just basing it on cost is wrong. The player could for instance look strong in a very costly but undefended alien ship, or with a whole fleet of them.~~

~~This could cause problems with variants that have ships with no guns, and in general make the gunned ones more likely to spawn? I could make variants ignore this and just use the Cost() of the ships within it, if that's a problem.~~
edit: as quyykk pointed out they don't use the actual strength of ships.