### PR TITLE
Fix planet label culling

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -640,7 +640,7 @@ void Engine::Step(bool isActive)
 				continue;
 
 			Point pos = object.Position() - center;
-			if(pos.Length() - object.Radius() < 600. / zoom)
+			if(pos.Length() - object.Radius() < 800. / zoom)
 				labels.emplace_back(pos, object, currentSystem, zoom);
 		}
 	}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -640,7 +640,7 @@ void Engine::Step(bool isActive)
 				continue;
 
 			Point pos = object.Position() - center;
-			if(pos.Length() - object.Radius() < 800. / zoom)
+			if(pos.Length() - object.Radius() < 600. / zoom)
 				labels.emplace_back(pos, object, currentSystem, zoom);
 		}
 	}

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -60,7 +60,7 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 		color = Color(.3f, .3f, .3f, 1.f);
 		government = "(No government)";
 	}
-	float alpha = static_cast<float>(min(.5, max(0., .6 - (position.Length() - radius) * .001 * zoom)));
+	float alpha = static_cast<float>(min(.5, max(0., .6 - (position.Length() - object.Radius()) * .001 * zoom)));
 	color = Color(color.Get()[0] * alpha, color.Get()[1] * alpha, color.Get()[2] * alpha, 0.);
 
 	if(!system)


### PR DESCRIPTION
**Bugfix:** This PR fixes #6603

## Fix Details
Planet labels were prematurely culled due to a typo/mismatch in the engine. In https://github.com/endless-sky/endless-sky/blob/1075dcb202eacc8655f257bb2a2f0c98b5bf5d07/source/Engine.cpp#L643, the label is culled at 400 pixels of distance, despite the number being 600. The label fades out at 600 pixels, and using 800 in that expression makes it so the labels are culled properly at exactly 600 pixels.

Now a little disclaimer here: as of now, I have _**absolutely no idea**_ about what causes this issue. Based on the original code, the previous author didn't know either. For some reason, there are extra 200 pixels there. If you are more familiar with the code base please, _please_ have a look at this black magic. I verified with console messages, the actual distance is 600 with the new culling, and alpha is near zero (alpha < 0.0015 for 598 distance).

## Testing Done
The fix only affects planet label culling, and according to gameplay testing they are no longer culled prematurely. Based on some debug console messages, the culling happens at exactly 600 pixels.