### PR TITLE
Fix crash for minables with a negative payload.

### DIFF
--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -152,7 +152,7 @@ bool Minable::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		}
 		for(const auto &it : payload)
 		{
-			if(it.second < 0)
+			if(it.second < 1)
 				continue;
 
 			// Each payload object has a 25% chance of surviving. This creates

--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -152,6 +152,9 @@ bool Minable::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		}
 		for(const auto &it : payload)
 		{
+			if(it.second < 0)
+				continue;
+
 			// Each payload object has a 25% chance of surviving. This creates
 			// a distribution with occasional very good payoffs.
 			for(int amount = Random::Binomial(it.second, .25); amount > 0; amount -= Flotsam::TONS_PER_BOX)


### PR DESCRIPTION
## Fix Details

This PR fixes a crash if you destroyed a minable with a negative payload:

```
minable iron
    payload Iron -50
```

Having a negative payload is now equivalent to it being 0 (i.e. no drop).

## Testing Done

Modified the iron minable as written above. Without this PR the game crashes when breaking the minable.