### PR TITLE
Created a CategoryList class for containing and sorting ship and outfit categories

### DIFF
--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -12,8 +12,9 @@
 		03DC4253AA8390FE0A8FB4EA /* MaskManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 499B4DA7A9C7351120660643 /* MaskManager.cpp */; };
 		072599D126A8CB2F007EC229 /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 072599CC26A8C942007EC229 /* SDL2.framework */; };
 		072599D426A8CD5D007EC229 /* SDL2.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 072599CC26A8C942007EC229 /* SDL2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		16AD4CACA629E8026777EA00 /* truncate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2CA44855BD0AFF45DCAEEA5D /* truncate.hpp */; settings = {ATTRIBUTES = (Project, ); }; };
+		0A7F4B4793714E0A8C5D0BA4 /* CategoryList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02F347B587CDABE97B0D83C6 /* CategoryList.cpp */; };
 		1578F883250B5F8A00D318FB /* InfoPanelState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1578F880250B5F8A00D318FB /* InfoPanelState.cpp */; };
+		16AD4CACA629E8026777EA00 /* truncate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2CA44855BD0AFF45DCAEEA5D /* truncate.hpp */; settings = {ATTRIBUTES = (Project, ); }; };
 		301A4FE885A7A12348986C4F /* UniverseObjects.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 389245138CF297EB417DF730 /* UniverseObjects.cpp */; };
 		5155CD731DBB9FF900EF090B /* Depreciation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5155CD711DBB9FF900EF090B /* Depreciation.cpp */; };
 		5AB644C9B37C15C989A9DBE9 /* DisplayText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2E1E458DB603BF979429117C /* DisplayText.cpp */; };
@@ -213,6 +214,7 @@
 
 /* Begin PBXFileReference section */
 		02D34A71AE3BC4C93FC6865B /* TestData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestData.cpp; path = source/TestData.cpp; sourceTree = "<group>"; };
+		02F347B587CDABE97B0D83C6 /* CategoryList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CategoryList.cpp; path = source/CategoryList.cpp; sourceTree = "<group>"; };
 		070CD8152818CC6B00A853BB /* libmad.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libmad.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		072599BE26A8C67D007EC229 /* SDL2.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = SDL2.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		072599CC26A8C942007EC229 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = build/SDL2.framework; sourceTree = "<group>"; };
@@ -221,6 +223,8 @@
 		0DF34095B64BC64F666ECF5F /* CoreStartData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CoreStartData.cpp; path = source/CoreStartData.cpp; sourceTree = "<group>"; };
 		11EA4AD7A889B6AC1441A198 /* StartConditionsPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StartConditionsPanel.cpp; path = source/StartConditionsPanel.cpp; sourceTree = "<group>"; };
 		13B643F6BEC24349F9BC9F42 /* alignment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = alignment.hpp; path = source/text/alignment.hpp; sourceTree = "<group>"; };
+		1578F880250B5F8A00D318FB /* InfoPanelState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = InfoPanelState.cpp; path = source/InfoPanelState.cpp; sourceTree = "<group>"; };
+		1578F882250B5F8A00D318FB /* InfoPanelState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InfoPanelState.h; path = source/InfoPanelState.h; sourceTree = "<group>"; };
 		19184B47B496B414EC9CE671 /* DamageProfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DamageProfile.h; path = source/DamageProfile.h; sourceTree = "<group>"; };
 		191E4107A4F1CBBC2526A0E9 /* MaskManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MaskManager.h; path = source/MaskManager.h; sourceTree = "<group>"; };
 		210C41C0BA33F71A694D5F98 /* Bitset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Bitset.h; path = source/Bitset.h; sourceTree = "<group>"; };
@@ -228,8 +232,6 @@
 		2E1E458DB603BF979429117C /* DisplayText.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DisplayText.cpp; path = source/text/DisplayText.cpp; sourceTree = "<group>"; };
 		2E644A108BCD762A2A1A899C /* Hazard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Hazard.h; path = source/Hazard.h; sourceTree = "<group>"; };
 		2E8047A8987DD8EC99FF8E2E /* Test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Test.cpp; path = source/Test.cpp; sourceTree = "<group>"; };
-		1578F880250B5F8A00D318FB /* InfoPanelState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = InfoPanelState.cpp; path = source/InfoPanelState.cpp; sourceTree = "<group>"; };
-		1578F882250B5F8A00D318FB /* InfoPanelState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InfoPanelState.h; path = source/InfoPanelState.h; sourceTree = "<group>"; };
 		389245138CF297EB417DF730 /* UniverseObjects.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UniverseObjects.cpp; path = source/UniverseObjects.cpp; sourceTree = "<group>"; };
 		46B444A6B2A67F93BB272686 /* ByGivenOrder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ByGivenOrder.h; path = source/comparators/ByGivenOrder.h; sourceTree = "<group>"; };
 		499B4DA7A9C7351120660643 /* MaskManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MaskManager.cpp; path = source/MaskManager.cpp; sourceTree = "<group>"; };
@@ -524,6 +526,7 @@
 		C49D4EA08DF168A83B1C7B07 /* Hazard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Hazard.cpp; path = source/Hazard.cpp; sourceTree = "<group>"; };
 		C62B4D15899E5F47443D0ED6 /* DamageProfile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DamageProfile.cpp; path = source/DamageProfile.cpp; sourceTree = "<group>"; };
 		D0FA4800BE72C1B5A7D567B9 /* MenuAnimationPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MenuAnimationPanel.cpp; path = source/MenuAnimationPanel.cpp; sourceTree = "<group>"; };
+		D2084096AA5EA5209C647493 /* CategoryList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CategoryList.h; path = source/CategoryList.h; sourceTree = "<group>"; };
 		DB9A43BA91B3BC47186BF05E /* UniverseObjects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UniverseObjects.h; path = source/UniverseObjects.h; sourceTree = "<group>"; };
 		DC8146D5A145C2DA87D98F1F /* GameLoadingPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameLoadingPanel.h; path = source/GameLoadingPanel.h; sourceTree = "<group>"; };
 		DE844E2BBF82C39B568527CB /* ByName.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ByName.h; path = source/comparators/ByName.h; sourceTree = "<group>"; };
@@ -873,6 +876,8 @@
 				61FA4C2BB89E08C5E2B8B4B9 /* Variant.cpp */,
 				5EBC44769E84CF0C953D08B3 /* Variant.h */,
 				086E48E490C9BAD6660C7274 /* ExclusiveItem.h */,
+				02F347B587CDABE97B0D83C6 /* CategoryList.cpp */,
+				D2084096AA5EA5209C647493 /* CategoryList.h */,
 			);
 			name = source;
 			sourceTree = "<group>";
@@ -1265,6 +1270,7 @@
 				E3D54794A1EEF51CD4859170 /* DamageProfile.cpp in Sources */,
 				F35E4D6EA465D71CDA282EBA /* MenuAnimationPanel.cpp in Sources */,
 				920F40E0ADECA8926F423FDA /* Variant.cpp in Sources */,
+				0A7F4B4793714E0A8C5D0BA4 /* CategoryList.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -89,6 +89,8 @@
 		<Unit filename="source/CaptureOdds.h" />
 		<Unit filename="source/CargoHold.cpp" />
 		<Unit filename="source/CargoHold.h" />
+		<Unit filename="source/CategoryList.cpp" />
+		<Unit filename="source/CategoryList.h" />
 		<Unit filename="source/CategoryTypes.h" />
 		<Unit filename="source/ClickZone.h" />
 		<Unit filename="source/CollisionSet.cpp" />

--- a/EndlessSkyTests.cbp
+++ b/EndlessSkyTests.cbp
@@ -71,6 +71,7 @@
 		<Unit filename="tests/unit/src/test_account.cpp" />
 		<Unit filename="tests/unit/src/test_angle.cpp" />
 		<Unit filename="tests/unit/src/test_bitset.cpp" />
+		<Unit filename="tests/unit/src/test_categoryList.cpp" />
 		<Unit filename="tests/unit/src/test_conditionSet.cpp" />
 		<Unit filename="tests/unit/src/test_datafile.cpp" />
 		<Unit filename="tests/unit/src/test_datanode.cpp" />

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -10,31 +10,31 @@
 
 # Ships of these types can be purchased and also used as mission sources.
 category "ship"
-	"Transport"
-	"Light Freighter"
-	"Heavy Freighter"
-	"Interceptor"
-	"Light Warship"
-	"Medium Warship"
-	"Heavy Warship"
-	"Fighter"
-	"Drone"
+	"Transport" 10
+	"Light Freighter" 20
+	"Heavy Freighter" 30
+	"Interceptor" 40
+	"Light Warship" 50
+	"Medium Warship" 60
+	"Heavy Warship" 70
+	"Fighter" 80
+	"Drone" 90
 
 
 # Ships of these types are able to be carried by other ships.
 category "bay type"
-	"Drone"
-	"Fighter"
+	"Drone" 10
+	"Fighter" 20
 
 
 # Outfits of these types can be bought and sold via the outfitter.
 category "outfit"
-	"Guns"
-	"Turrets"
-	"Secondary Weapons"
-	"Ammunition"
-	"Systems"
-	"Power"
-	"Engines"
-	"Hand to Hand"
-	"Special"
+	"Guns" 10
+	"Turrets" 20
+	"Secondary Weapons" 30
+	"Ammunition" 40
+	"Systems" 50
+	"Power" 60
+	"Engines" 70
+	"Hand to Hand" 80
+	"Special" 90

--- a/source/CategoryList.cpp
+++ b/source/CategoryList.cpp
@@ -1,0 +1,64 @@
+/* CategoryList.cpp
+Copyright (c) 2022 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "CategoryList.h"
+
+#include "DataNode.h"
+
+#include <algorithm>
+
+using namespace std;
+
+
+
+void CategoryList::Load(const DataNode &node)
+{
+	for(const DataNode &child : node)
+	{
+		// Use the given precedence. If no precedence is given, use the previous
+		// precedence + 1.
+		if(child.Size() > 1)
+			currentPrecedence = child.Value(1);
+		Category cat(child.Token(0), currentPrecedence++);
+
+		// If a given category name already exists, its prescedence will be updated.
+		auto it = find_if(list.begin(), list.end(),
+			[&cat](const Category &c) noexcept -> bool { return cat.name == c.name; });
+		if(it != list.end())
+			it->precedence = cat.precedence;
+		else
+			list.push_back(cat);
+	}
+}
+
+
+
+// Sort the CategoryList. Categories are sorted by precedence. If multiple categories
+//  share the same precedence then they are sorted alphabetically.
+void CategoryList::Sort()
+{
+	sort(list.begin(), list.end(),
+		[](const Category &a, Category &b) noexcept -> bool
+		{
+			return (a.precedence == b.precedence) ? a.name < b.name : a.precedence < b.precedence;
+		});
+}
+
+
+
+// Determine if the CategoryList contains a Category with the given name.
+bool CategoryList::Contains(const string &name) const
+{
+	const auto it = find_if(list.begin(), list.end(),
+		[&name](const Category &c) noexcept -> bool { return name == c.name; });
+	return it != list.end(); 
+}

--- a/source/CategoryList.cpp
+++ b/source/CategoryList.cpp
@@ -60,5 +60,5 @@ bool CategoryList::Contains(const string &name) const
 {
 	const auto it = find_if(list.begin(), list.end(),
 		[&name](const Category &c) noexcept -> bool { return name == c.name; });
-	return it != list.end(); 
+	return it != list.end();
 }

--- a/source/CategoryList.h
+++ b/source/CategoryList.h
@@ -55,7 +55,9 @@ public:
 	// Determine if the CategoryList contains a Category with the given name.
 	bool Contains(const std::string &name) const;
 
+	typename std::vector<Category>::iterator begin() noexcept { return list.begin(); }
 	typename std::vector<Category>::const_iterator begin() const noexcept { return list.begin(); }
+	typename std::vector<Category>::iterator end() noexcept { return list.end(); }
 	typename std::vector<Category>::const_iterator end() const noexcept { return list.end(); }
 
 

--- a/source/CategoryList.h
+++ b/source/CategoryList.h
@@ -1,0 +1,69 @@
+/* CategoryList.h
+Copyright (c) 2022 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef CATEGORY_LIST_H_
+#define CATEGORY_LIST_H_
+
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+class DataNode;
+
+
+
+// A CategoryList is a list of names that are associated to a Category of items (e.g. ships
+// or outfits). Categories within the list are sorted by the precedence of each Category.
+// Any conflicting precedencies are resolved by sorting the names of the Categories
+// alphabetically.
+class CategoryList {
+public:
+	// A Category is a string with some precedence to it. The precedence is used to sort
+	// the Category within the CategoryList. Only the CategoryList has access to the
+	// precedence of each Category. All outside classes can only see the Category's
+	// name.
+	class Category {
+	public:
+		Category(std::string name, int precedence) : name(name), precedence(precedence) {}
+		const std::string &Name() const { return name; }
+
+	private:
+		friend class CategoryList;
+		std::string name;
+		int precedence = 0;
+	};
+
+public:
+	CategoryList() = default;
+
+	void Load(const DataNode &node);
+
+	// Sort the CategoryList. Categories are sorted by precedence. If multiple Categories
+	// share the same precedence then they are sorted alphabetically.
+	void Sort();
+
+	// Determine if the CategoryList contains a Category with the given name.
+	bool Contains(const std::string &name) const;
+
+	typename std::vector<Category>::const_iterator begin() const noexcept { return list.begin(); }
+	typename std::vector<Category>::const_iterator end() const noexcept { return list.end(); }
+
+
+private:
+	std::vector<Category> list;
+	int currentPrecedence = 0;
+};
+
+
+
+#endif

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -371,7 +371,6 @@ void Engine::Place(const list<NPC> &npcs, shared_ptr<Ship> flagship)
 			if(ship->HasBays())
 			{
 				ship->UnloadBays();
-				
 				for(const auto &cat : GameData::GetCategory(CategoryType::BAY))
 				{
 					const string &bayType = cat.Name();

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Engine.h"
 
 #include "Audio.h"
+#include "CategoryList.h"
 #include "CategoryTypes.h"
 #include "CoreStartData.h"
 #include "DamageDealt.h"
@@ -370,8 +371,10 @@ void Engine::Place(const list<NPC> &npcs, shared_ptr<Ship> flagship)
 			if(ship->HasBays())
 			{
 				ship->UnloadBays();
-				for(const string &bayType : GameData::Category(CategoryType::BAY))
+				
+				for(const auto &cat : GameData::GetCategory(CategoryType::BAY))
 				{
+					const string &bayType = cat.Name();
 					int baysTotal = ship->BaysTotal(bayType);
 					if(baysTotal)
 						carriers[bayType][&*ship] = baysTotal;

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Audio.h"
 #include "BatchShader.h"
+#include "CategoryList.h"
 #include "Color.h"
 #include "Command.h"
 #include "Conversation.h"
@@ -712,7 +713,7 @@ const string &GameData::Rating(const string &type, int level)
 
 
 // Strings for ship, bay type, and outfit categories.
-const vector<string> &GameData::Category(const CategoryType type)
+const CategoryList &GameData::GetCategory(const CategoryType type)
 {
 	return objects.categories[type];
 }

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -24,6 +24,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <string>
 #include <vector>
 
+class CategoryList;
 class Color;
 class Conversation;
 class DataNode;
@@ -145,7 +146,7 @@ public:
 	// Strings for combat rating levels, etc.
 	static const std::string &Rating(const std::string &type, int level);
 	// Strings for ship, bay type, and outfit categories.
-	static const std::vector<std::string> &Category(const CategoryType type);
+	static const CategoryList &GetCategory(const CategoryType type);
 
 	static const StarField &Background();
 	static void SetHaze(const Sprite *sprite, bool allowAnimation);

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -12,6 +12,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "LocationFilter.h"
 
+#include "CategoryList.h"
 #include "CategoryTypes.h"
 #include "DataNode.h"
 #include "DataWriter.h"
@@ -294,8 +295,9 @@ bool LocationFilter::IsValid() const
 	if(!shipCategory.empty())
 	{
 		// At least one desired category must be valid.
-		const auto &shipCategories = GameData::Category(CategoryType::SHIP);
-		auto categoriesSet = set<string>(shipCategories.begin(), shipCategories.end());
+		set<string> categoriesSet;
+		for(const auto category : GameData::GetCategory(CategoryType::SHIP))
+			categoriesSet.insert(category.Name());
 		if(!SetsIntersect(shipCategory, categoriesSet))
 			return false;
 	}

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -296,7 +296,7 @@ bool LocationFilter::IsValid() const
 	{
 		// At least one desired category must be valid.
 		set<string> categoriesSet;
-		for(const auto category : GameData::GetCategory(CategoryType::SHIP))
+		for(const auto &category : GameData::GetCategory(CategoryType::SHIP))
 			categoriesSet.insert(category.Name());
 		if(!SetsIntersect(shipCategory, categoriesSet))
 			return false;

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "BoardingPanel.h"
 #include "comparators/ByGivenOrder.h"
+#include "CategoryList.h"
 #include "CoreStartData.h"
 #include "Dialog.h"
 #include "text/Font.h"
@@ -366,7 +367,10 @@ void MainPanel::ShowScanDialog(const ShipEvent &event)
 			out << "This " + target->Noun() + " is not equipped with any outfits.\n";
 
 		// Split target->Outfits() into categories, then iterate over them in order.
-		auto comparator = ByGivenOrder<string>(GameData::Category(CategoryType::OUTFIT));
+		vector<string> categories;
+		for(const auto &category : GameData::GetCategory(CategoryType::OUTFIT))
+			categories.push_back(category.Name());
+		auto comparator = ByGivenOrder<string>(categories);
 		map<string, map<const string, int>, ByGivenOrder<string>> outfitsByCategory(comparator);
 		for(const auto &it : target->Outfits())
 		{

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -179,8 +179,9 @@ void MapOutfitterPanel::DrawItems()
 		DoHelp("map advanced shops");
 	list.clear();
 	Point corner = Screen::TopLeft() + Point(0, scroll);
-	for(const string &category : categories)
+	for(const auto &cat : categories)
 	{
+		const string &category = cat.Name();
 		auto it = catalog.find(category);
 		if(it == catalog.end())
 			continue;

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -51,7 +51,7 @@ const int MapSalesPanel::WIDTH = 270;
 
 MapSalesPanel::MapSalesPanel(PlayerInfo &player, bool isOutfitters)
 	: MapPanel(player, SHOW_SPECIAL),
-	categories(GameData::Category(isOutfitters ? CategoryType::OUTFIT : CategoryType::SHIP)),
+	categories(GameData::GetCategory(isOutfitters ? CategoryType::OUTFIT : CategoryType::SHIP)),
 	isOutfitters(isOutfitters),
 	collapsed(player.Collapsed(isOutfitters ? "outfitter map" : "shipyard map"))
 {
@@ -61,7 +61,7 @@ MapSalesPanel::MapSalesPanel(PlayerInfo &player, bool isOutfitters)
 
 MapSalesPanel::MapSalesPanel(const MapPanel &panel, bool isOutfitters)
 	: MapPanel(panel),
-	categories(GameData::Category(isOutfitters ? CategoryType::OUTFIT : CategoryType::SHIP)),
+	categories(GameData::GetCategory(isOutfitters ? CategoryType::OUTFIT : CategoryType::SHIP)),
 	isOutfitters(isOutfitters),
 	collapsed(player.Collapsed(isOutfitters ? "outfitter map" : "shipyard map"))
 {
@@ -435,8 +435,8 @@ void MapSalesPanel::ClickCategory(const string &name)
 		if(isHidden)
 			collapsed.clear();
 		else
-			for(const string &category : categories)
-				collapsed.insert(category);
+			for(const auto &category : categories)
+				collapsed.insert(category.Name());
 	}
 	else if(isHidden)
 		collapsed.erase(name);

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "MapPanel.h"
 
+#include "CategoryList.h"
 #include "ClickZone.h"
 
 #include <set>
@@ -84,7 +85,7 @@ protected:
 	double scroll = 0.;
 	double maxScroll = 0.;
 
-	const std::vector<std::string> &categories;
+	const CategoryList &categories;
 	bool onlyShowSoldHere = false;
 
 

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -179,8 +179,9 @@ void MapShipyardPanel::DrawItems()
 		DoHelp("map advanced shops");
 	list.clear();
 	Point corner = Screen::TopLeft() + Point(0, scroll);
-	for(const string &category : categories)
+	for(const auto &cat : categories)
 	{
+		const string &category = cat.Name();
 		auto it = catalog.find(category);
 		if(it == catalog.end())
 			continue;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Ship.h"
 
 #include "Audio.h"
+#include "CategoryList.h"
 #include "CategoryTypes.h"
 #include "DamageDealt.h"
 #include "DataNode.h"
@@ -690,11 +691,11 @@ void Ship::FinishLoading(bool isNewInstance)
 	// invalid bays. Add a default "launch effect" to any remaining internal bays if
 	// this ship is crewed (i.e. pressurized).
 	string warning;
-	const auto &bayCategories = GameData::Category(CategoryType::BAY);
+	const auto &bayCategories = GameData::GetCategory(CategoryType::BAY);
 	for(auto it = bays.begin(); it != bays.end(); )
 	{
 		Bay &bay = *it;
-		if(find(bayCategories.begin(), bayCategories.end(), bay.category) == bayCategories.end())
+		if(!bayCategories.Contains(bay.category))
 		{
 			warning += "Invalid bay category: " + bay.category + "\n";
 			it = bays.erase(it);
@@ -706,7 +707,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			bay.launchEffects.emplace_back(GameData::Effects().Get("basic launch"));
 	}
 
-	canBeCarried = find(bayCategories.begin(), bayCategories.end(), attributes.Category()) != bayCategories.end();
+	canBeCarried = bayCategories.Contains(attributes.Category());
 
 	// Issue warnings if this ship has is misconfigured, e.g. is missing required values
 	// or has negative outfit, cargo, weapon, or engine capacity.
@@ -3478,8 +3479,8 @@ bool Ship::CanCarry(const Ship &ship) const
 
 void Ship::AllowCarried(bool allowCarried)
 {
-	const auto &bayCategories = GameData::Category(CategoryType::BAY);
-	canBeCarried = allowCarried && find(bayCategories.begin(), bayCategories.end(), attributes.Category()) != bayCategories.end();
+	const auto &bayCategories = GameData::GetCategory(CategoryType::BAY);
+	canBeCarried = allowCarried && bayCategories.Contains(attributes.Category());
 }
 
 

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "ShipInfoDisplay.h"
 
 #include "text/alignment.hpp"
+#include "CategoryList.h"
 #include "CategoryTypes.h"
 #include "Color.h"
 #include "Depreciation.h"
@@ -270,8 +271,9 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	}
 
 	// Print the number of bays for each bay-type we have
-	for(auto &&bayType : GameData::Category(CategoryType::BAY))
+	for(const auto &category : GameData::GetCategory(CategoryType::BAY))
 	{
+		const string &bayType = category.Name();
 		int totalBays = ship.BaysTotal(bayType);
 		if(totalBays)
 		{

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "ShipInfoPanel.h"
 
 #include "text/alignment.hpp"
+#include "CategoryList.h"
 #include "CategoryTypes.h"
 #include "Command.h"
 #include "Dialog.h"
@@ -348,8 +349,9 @@ void ShipInfoPanel::DrawOutfits(const Rectangle &bounds, Rectangle &cargoBounds)
 	table.DrawAt(start);
 
 	// Draw the outfits in the same order used in the outfitter.
-	for(const string &category : GameData::Category(CategoryType::OUTFIT))
+	for(const auto &cat : GameData::GetCategory(CategoryType::OUTFIT))
 	{
+		const string &category = cat.Name();
 		auto it = outfits.find(category);
 		if(it == outfits.end())
 			continue;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -62,7 +62,7 @@ namespace {
 ShopPanel::ShopPanel(PlayerInfo &player, bool isOutfitter)
 	: player(player), day(player.GetDate().DaysSinceEpoch()),
 	planet(player.GetPlanet()), playerShip(player.Flagship()),
-	categories(GameData::Category(isOutfitter ? CategoryType::OUTFIT : CategoryType::SHIP)),
+	categories(GameData::GetCategory(isOutfitter ? CategoryType::OUTFIT : CategoryType::SHIP)),
 	collapsed(player.Collapsed(isOutfitter ? "outfitter" : "shipyard"))
 {
 	if(playerShip)
@@ -412,8 +412,9 @@ void ShopPanel::DrawMain()
 	const float endX = Screen::Right() - (SIDE_WIDTH + 1);
 	double nextY = begin.Y() + TILE_SIZE;
 	int scrollY = 0;
-	for(const string &category : categories)
+	for(const auto &cat : categories)
 	{
+		const string &category = cat.Name();
 		map<string, set<string>>::const_iterator it = catalog.find(category);
 		if(it == catalog.end())
 			continue;
@@ -752,8 +753,8 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 				{
 					selectedShip = nullptr;
 					selectedOutfit = nullptr;
-					for(const string &category : categories)
-						collapsed.insert(category);
+					for(const auto &category : categories)
+						collapsed.insert(category.Name());
 				}
 				else
 				{

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -15,6 +15,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Panel.h"
 
+#include "CategoryList.h"
 #include "ClickZone.h"
 #include "OutfitInfoDisplay.h"
 #include "Point.h"
@@ -154,7 +155,7 @@ protected:
 	std::vector<ClickZone<std::string>> categoryZones;
 
 	std::map<std::string, std::set<std::string>> catalog;
-	const std::vector<std::string> &categories;
+	const CategoryList &categories;
 	std::set<std::string> &collapsed;
 
 	ShipInfoDisplay shipInfo;

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -151,6 +151,10 @@ void UniverseObjects::FinishLoading()
 		else
 			Files::LogError("Unhandled \"disable\" keyword of type \"" + category.first + "\"");
 	}
+
+	// Sort all category lists.
+	for(auto &list : categories)
+		list.second.Sort();
 }
 
 
@@ -426,17 +430,7 @@ void UniverseObjects::LoadFile(const string &path, bool debugMode)
 				node.PrintTrace("Skipping unrecognized category type:");
 				continue;
 			}
-
-			vector<string> &categoryList = categories[it->second];
-			for(const DataNode &child : node)
-			{
-				// If a given category already exists, it will be
-				// moved to the back of the list.
-				const auto it = find(categoryList.begin(), categoryList.end(), child.Token(0));
-				if(it != categoryList.end())
-					categoryList.erase(it);
-				categoryList.push_back(child.Token(0));
-			}
+			categories[it->second].Load(node);
 		}
 		else if((key == "tip" || key == "help") && node.Size() >= 2)
 		{

--- a/source/UniverseObjects.h
+++ b/source/UniverseObjects.h
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Sale.h"
 #include "Set.h"
 
+#include "CategoryList.h"
 #include "Color.h"
 #include "Conversation.h"
 #include "Effect.h"
@@ -121,7 +122,7 @@ private:
 	std::map<const Sprite *, std::string> landingMessages;
 	std::map<const Sprite *, double> solarPower;
 	std::map<const Sprite *, double> solarWind;
-	std::map<CategoryType, std::vector<std::string>> categories;
+	std::map<CategoryType, CategoryList> categories;
 
 	std::map<std::string, std::string> tooltips;
 	std::map<std::string, std::string> helpMessages;

--- a/tests/unit/src/test_categoryList.cpp
+++ b/tests/unit/src/test_categoryList.cpp
@@ -95,7 +95,7 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 				// sorted = second, third, first
 				CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
 			}
-			
+
 			AND_WHEN( "a list is loaded again without precedence" ) {
 				list.Load(AsDataNode("category test\n\tfourth\n\tfifth"));
 

--- a/tests/unit/src/test_categoryList.cpp
+++ b/tests/unit/src/test_categoryList.cpp
@@ -41,7 +41,7 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 		// A manually sorted list to compare against.
 		std::vector<std::string> sorted;
 		// A helper function for determining if a string is equal to a Category's name.
-		auto equal = [](const std::string &s, const CategoryList::Category &c) noexcept -> bool { return s == c.Name() };
+		auto equal = [](const std::string &s, const CategoryList::Category &c) noexcept -> bool { return s == c.Name(); };
 
 		WHEN( "sorted contents are given to the list without precedence" ) {
 			list.Load(AsDataNode("category test\n\tfirst\n\tsecond\n\tthird"));

--- a/tests/unit/src/test_categoryList.cpp
+++ b/tests/unit/src/test_categoryList.cpp
@@ -94,88 +94,85 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 				list.Sort();
 				// sorted = second, third, first
 				CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
-			}
 
-			AND_WHEN( "a list is loaded again without precedence" ) {
-				list.Load(AsDataNode("category test\n\tfourth\n\tfifth"));
+				AND_WHEN( "a list is loaded again without precedence" ) {
+					list.Load(AsDataNode("category test\n\tfourth\n\tfifth"));
 
-				THEN( "the new categories are at the end of the list in the order they were added" ) {
-					sorted.push_back("fourth"); // Precedence = 5, as the last used precedence was 4.
-					sorted.push_back("fifth"); // Precedence = 6
-					// sorted = second, third, first, fourth, fifth
-					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+					THEN( "the new categories are at the end of the list in the order they were added" ) {
+						sorted.push_back("fourth"); // Precedence = 5, as the last used precedence was 4.
+						sorted.push_back("fifth"); // Precedence = 6
+						// sorted = second, third, first, fourth, fifth
+						CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+					}
+
+					THEN( "sorting the list moves the new categories into the correct positions" ) {
+						sorted[2] = "fourth"; // Precedence = 5, as the last used precedence was 4.
+						sorted.push_back("fifth"); // Precedence = 6
+						sorted.push_back("first"); // Precedence = 7
+						// sorted = second, third, fourth, fifth, first
+						list.Sort();
+						CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+					}
 				}
 
-				THEN( "sorting the list moves the new categories into the correct positions" ) {
-					sorted[2] = "fourth"; // Precedence = 5, as the last used precedence was 4.
-					sorted.push_back("fifth"); // Precedence = 6
-					sorted.push_back("first"); // Precedence = 7
-					// sorted = second, third, fourth, fifth, first
-					list.Sort();
-					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+				AND_WHEN( "a list is loaded again with precedence" ) {
+					list.Load(AsDataNode("category test\n\tfourth 1\n\tfifth 3"));
+
+					THEN( "the new categories are at the end of the list in the order they were added" ) {
+						sorted.push_back("fourth"); // Precedence = 1
+						sorted.push_back("fifth"); // Precedence = 3
+						// sorted = second, third, first, fourth, fifth
+						CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+					}
+
+					THEN( "sorting the list moves the new categories into the correct positions" ) {
+						sorted[0] = "fourth"; // Precedence = 1
+						sorted[1] = "second"; // Precedence = 2
+						sorted[2] = "fifth"; // Precedence = 3
+						sorted.push_back("third"); // Precedence = 4
+						sorted.push_back("first"); // Precedence = 7
+						list.Sort();
+						// sorted = fourth, second, fifth, third, first
+						CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+					}
 				}
-			}
+				
+				AND_WHEN( "a list is loaded again with two categories of the same precedence" ) {
+					list.Load(AsDataNode("category test\n\tfourth 7\n\tfifth 7"));
 
-			AND_WHEN( "a list is loaded again with precedence" ) {
-				list.Load(AsDataNode("category test\n\tfourth 1\n\tfifth 3"));
+					THEN( "the new categories are at the end of the list in the order they were added" ) {
+						sorted.push_back("fourth"); // Precedence = 7
+						sorted.push_back("fifth"); // Precedence = 7
+						// sorted = second, third, first, fourth, fifth
+						CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+					}
 
-				THEN( "the new categories are at the end of the list in the order they were added" ) {
-					sorted.push_back("fourth"); // Precedence = 1
-					sorted.push_back("fifth"); // Precedence = 3
-					// sorted = second, third, first, fourth, fifth
-					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
-				}
-
-				THEN( "sorting the list moves the new categories into the correct positions" ) {
-					sorted[0] = "fourth"; // Precedence = 1
-					sorted[1] = "second"; // Precedence = 2
-					sorted[2] = "fifth"; // Precedence = 3
-					sorted.push_back("third"); // Precedence = 4
-					sorted.push_back("first"); // Precedence = 7
-					list.Sort();
-					// sorted = fourth, second, fifth, third, first
-					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
-				}
-			}
-
-			AND_WHEN( "a list is loaded again with two categories of the same precedence" ) {
-				list.Load(AsDataNode("category test\n\tfourth 7\n\tfifth 7"));
-
-				THEN( "the new categories are at the end of the list in the order they were added" ) {
-					sorted.push_back("fourth"); // Precedence = 7
-					sorted.push_back("fifth"); // Precedence = 7
-					// sorted = second, third, first, fourth, fifth
-					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
-				}
-
-				THEN( "after sorting, the categories with the same precedence become alphabetically ordered" ) {
-					sorted[2] = "fifth"; // Precedence = 7
-					sorted.push_back("first"); // Precedence = 7
-					sorted.push_back("fourth"); // Precedence = 7
-					list.Sort();
-					// sorted = second, third, fifth, first, fourth
-					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
-				}
-			}
-
-			AND_WHEN( "a list is loaded again with a category that already exists but with a different precedence" ) {
-				list.Load(AsDataNode("category test\n\tthird 1"));
-
-				THEN( "the duplicate category's position is unchanged but its precedence is updated" ) {
-					sorted.push_back("second"); // Precedence = 2
-					sorted.push_back("third"); // Precedence = 1
-					sorted.push_back("first"); // Precedence = 6
-					// sorted = second, third, first
-					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+					THEN( "after sorting, the categories with the same precedence become alphabetically ordered" ) {
+						sorted[2] = "fifth"; // Precedence = 7
+						sorted.push_back("first"); // Precedence = 7
+						sorted.push_back("fourth"); // Precedence = 7
+						list.Sort();
+						// sorted = second, third, fifth, first, fourth
+						CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+					}
 				}
 
-				THEN( "after sorting, the duplicate category's position is corrected" ) {
-					sorted.push_back("third"); // Precedence = 1
-					sorted.push_back("second"); // Precedence = 2
-					sorted.push_back("first"); // Precedence = 6
-					list.Sort();
-					// sorted = third, second, first
-					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+				AND_WHEN( "a list is loaded again with a category that already exists but with a different precedence" ) {
+					list.Load(AsDataNode("category test\n\tthird 1"));
+
+					THEN( "the duplicate category's position is unchanged but its precedence is updated" ) {
+						// sorted = second, third, first
+						CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+					}
+
+					THEN( "after sorting, the duplicate category's position is corrected" ) {
+						sorted[0] = "third"; // Precedence = 1
+						sorted[1] = "second"; // Precedence = 2
+						sorted[2] = "first"; // Precedence = 6
+						list.Sort();
+						// sorted = third, second, first
+						CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+					}
 				}
 			}
 		}

--- a/tests/unit/src/test_categoryList.cpp
+++ b/tests/unit/src/test_categoryList.cpp
@@ -148,7 +148,7 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
 				}
 
-				THEN( "the categories with the same precedence become alphabetically ordered" ) {
+				THEN( "after sorting, the categories with the same precedence become alphabetically ordered" ) {
 					sorted[2] = "fifth"; // Precedence = 7
 					sorted[3] = "first"; // Precedence = 7
 					sorted[4] = "fourth"; // Precedence = 7
@@ -159,14 +159,22 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 			}
 
 			AND_WHEN( "a list is loaded again with a category that already exists but with a different precedence" ) {
-				list.Load(AsDataNode("category test\n\tfirst 1"));
-				sorted[0] = "first"; // Precedence = 1
-				sorted[1] = "second"; // Precedence = 2
-				sorted[2] = "third"; // Precedence = 4
+				list.Load(AsDataNode("category test\n\tthird 1"));
 
-				THEN( "the duplicate category has its precedence changed instead of appearing twice" ) {
+				THEN( "the duplicate category's position is unchanged but its precedence is updated" ) {
+					sorted[0] = "second"; // Precedence = 2
+					sorted[1] = "third"; // Precedence = 1
+					sorted[2] = "first"; // Precedence = 6
+					// sorted = second, third, first
+					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+				}
+
+				THEN( "after sorting, the duplicate category's position is corrected" ) {
+					sorted[0] = "third"; // Precedence = 1
+					sorted[1] = "second"; // Precedence = 2
+					sorted[2] = "first"; // Precedence = 6
 					list.Sort();
-					// sorted = first, second, third
+					// sorted = third, second, first
 					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
 				}
 			}

--- a/tests/unit/src/test_categoryList.cpp
+++ b/tests/unit/src/test_categoryList.cpp
@@ -1,0 +1,180 @@
+/* test_categoryList.cpp
+Copyright (c) 2022 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "es-test.hpp"
+
+// Include only the tested class's header.
+#include "../../../source/CategoryList.h"
+
+// Include a helper for creating well-formed DataNodes (to enable creating non-empty CategoryLists).
+#include "datanode-factory.h"
+
+// ... and any system includes needed for the test file.
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace { // test namespace
+
+// #region mock data
+
+// Insert file-local data here, e.g. classes, structs, or fixtures that will be useful
+// to help test this class/method.
+
+// #endregion mock data
+
+
+
+// #region unit tests
+SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
+	GIVEN( "a category list" ) {
+		auto list = CategoryList{};
+		// A manually sorted list to compare against.
+		std::vector<std::string> sorted;
+		// A helper function for determining if a string is equal to a Category's name.
+		auto equal = [](const std::string &s, const CategoryList::Category &c) noexcept -> bool { return s == c.Name() };
+
+		WHEN( "sorted contents are given to the list without precedence" ) {
+			list.Load(AsDataNode("category test\n\tfirst\n\tsecond\n\tthird"));
+			sorted[0] = "first"; // Precedence = 0, as that is the default precedence of the first added cateogry.
+			sorted[1] = "second"; // Precedence = 1, as each new category uses the last used precedence + 1.
+			sorted[2] = "third"; // Precedence = 2
+
+			THEN( "the list is already sorted" ) {
+				// sorted = first, second, third
+				CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+			}
+
+			THEN( "sorting the list does not change its ordering" ) {
+				list.Sort();
+				// sorted = first, second, third
+				CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+			}
+		}
+
+		WHEN( "sorted contents are given to the list with precedence" ) {
+			list.Load(AsDataNode("category test\n\tfirst 10\n\tsecond 20\n\tthird 30"));
+			sorted[0] = "first"; // Precedence = 10
+			sorted[1] = "second"; // Precedence = 20
+			sorted[2] = "third"; // Precedence = 30
+
+			THEN( "the list is already sorted" ) {
+				// sorted = first, second, third
+				CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+			}
+
+			THEN( "sorting the list does not change its ordering" ) {
+				list.Sort();
+				// sorted = first, second, third
+				CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+			}
+		}
+
+		WHEN( "unsorted contents are given to the list with precedence" ) {
+			list.Load(AsDataNode("category test\n\tfirst 7\n\tsecond 2\n\tthird 4"));
+			sorted[0] = "second"; // Precedence = 2
+			sorted[1] = "third"; // Precedence = 4
+			sorted[2] = "first"; // Precedence = 7
+
+			THEN( "the list is unsorted" ) {
+				// sorted = second, third, first
+				CHECK_FALSE( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+			}
+
+			THEN( "sorting the list correctly changes its ordering" ) {
+				list.Sort();
+				// sorted = second, third, first
+				CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+			}
+			
+			AND_WHEN( "a list is loaded again without precedence" ) {
+				list.Load(AsDataNode("category test\n\tfourth\n\tfifth"));
+
+				THEN( "the new categories are at the end of the list in the order they were added" ) {
+					sorted[3] = "fourth"; // Precedence = 5, as the last used precedence was 4.
+					sorted[4] = "fifth"; // Precedence = 6
+					// sorted = second, third, first, fourth, fifth
+					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+				}
+
+				THEN( "sorting the list moves the new categories into the correct positions" ) {
+					sorted[2] = "fourth"; // Precedence = 5, as the last used precedence was 4.
+					sorted[3] = "fifth"; // Precedence = 6
+					sorted[4] = "first"; // Precedence = 7
+					// sorted = second, third, fourth, fifth, first
+					list.Sort();
+					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+				}
+			}
+
+			AND_WHEN( "a list is loaded again with precedence" ) {
+				list.Load(AsDataNode("category test\n\tfourth 1\n\tfifth 3"));
+
+				THEN( "the new categories are at the end of the list in the order they were added" ) {
+					sorted[3] = "fourth"; // Precedence = 1
+					sorted[4] = "fifth"; // Precedence = 3
+					// sorted = second, third, first, fourth, fifth
+					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+				}
+
+				THEN( "sorting the list moves the new categories into the correct positions" ) {
+					sorted[0] = "fourth"; // Precedence = 1
+					sorted[1] = "second"; // Precedence = 2
+					sorted[2] = "fifth"; // Precedence = 3
+					sorted[3] = "third"; // Precedence = 4
+					sorted[4] = "first"; // Precedence = 7
+					list.Sort();
+					// sorted = fourth, second, fifth, third, first
+					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+				}
+			}
+
+			AND_WHEN( "a list is loaded again with two categories of the same precedence" ) {
+				list.Load(AsDataNode("category test\n\tfourth 7\n\tfifth 7"));
+
+				THEN( "the new categories are at the end of the list in the order they were added" ) {
+					sorted[3] = "fourth"; // Precedence = 7
+					sorted[4] = "fifth"; // Precedence = 7
+					// sorted = second, third, first, fourth, fifth
+					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+				}
+
+				THEN( "the categories with the same precedence become alphabetically ordered" ) {
+					sorted[2] = "fifth"; // Precedence = 7
+					sorted[3] = "first"; // Precedence = 7
+					sorted[4] = "fourth"; // Precedence = 7
+					list.Sort();
+					// sorted = second, third, fifth, first, fourth
+					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+				}
+			}
+
+			AND_WHEN( "a list is loaded again with a category that already exists but with a different precedence" ) {
+				list.Load(AsDataNode("category test\n\tfirst 1"));
+				sorted[0] = "first"; // Precedence = 1
+				sorted[1] = "second"; // Precedence = 2
+				sorted[2] = "third"; // Precedence = 4
+
+				THEN( "the duplicate category has its precedence changed instead of appearing twice" ) {
+					list.Sort();
+					// sorted = first, second, third
+					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
+				}
+			}
+		}
+	}
+}
+// #endregion unit tests
+
+
+
+} // test namespace

--- a/tests/unit/src/test_categoryList.cpp
+++ b/tests/unit/src/test_categoryList.cpp
@@ -136,7 +136,7 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 						CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
 					}
 				}
-				
+
 				AND_WHEN( "a list is loaded again with two categories of the same precedence" ) {
 					list.Load(AsDataNode("category test\n\tfourth 7\n\tfifth 7"));
 

--- a/tests/unit/src/test_categoryList.cpp
+++ b/tests/unit/src/test_categoryList.cpp
@@ -45,9 +45,9 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 
 		WHEN( "sorted contents are given to the list without precedence" ) {
 			list.Load(AsDataNode("category test\n\tfirst\n\tsecond\n\tthird"));
-			sorted[0] = "first"; // Precedence = 0, as that is the default precedence of the first added cateogry.
-			sorted[1] = "second"; // Precedence = 1, as each new category uses the last used precedence + 1.
-			sorted[2] = "third"; // Precedence = 2
+			sorted.push_back("first"); // Precedence = 0, as that is the default precedence of the first added cateogry.
+			sorted.push_back("second"); // Precedence = 1, as each new category uses the last used precedence + 1.
+			sorted.push_back("third"); // Precedence = 2
 
 			THEN( "the list is already sorted" ) {
 				// sorted = first, second, third
@@ -63,9 +63,9 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 
 		WHEN( "sorted contents are given to the list with precedence" ) {
 			list.Load(AsDataNode("category test\n\tfirst 10\n\tsecond 20\n\tthird 30"));
-			sorted[0] = "first"; // Precedence = 10
-			sorted[1] = "second"; // Precedence = 20
-			sorted[2] = "third"; // Precedence = 30
+			sorted.push_back("first"); // Precedence = 10
+			sorted.push_back("second"); // Precedence = 20
+			sorted.push_back("third"); // Precedence = 30
 
 			THEN( "the list is already sorted" ) {
 				// sorted = first, second, third
@@ -81,9 +81,9 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 
 		WHEN( "unsorted contents are given to the list with precedence" ) {
 			list.Load(AsDataNode("category test\n\tfirst 7\n\tsecond 2\n\tthird 4"));
-			sorted[0] = "second"; // Precedence = 2
-			sorted[1] = "third"; // Precedence = 4
-			sorted[2] = "first"; // Precedence = 7
+			sorted.push_back("second"); // Precedence = 2
+			sorted.push_back("third"); // Precedence = 4
+			sorted.push_back("first"); // Precedence = 7
 
 			THEN( "the list is unsorted" ) {
 				// sorted = second, third, first
@@ -100,16 +100,16 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 				list.Load(AsDataNode("category test\n\tfourth\n\tfifth"));
 
 				THEN( "the new categories are at the end of the list in the order they were added" ) {
-					sorted[3] = "fourth"; // Precedence = 5, as the last used precedence was 4.
-					sorted[4] = "fifth"; // Precedence = 6
+					sorted.push_back("fourth"); // Precedence = 5, as the last used precedence was 4.
+					sorted.push_back("fifth"); // Precedence = 6
 					// sorted = second, third, first, fourth, fifth
 					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
 				}
 
 				THEN( "sorting the list moves the new categories into the correct positions" ) {
 					sorted[2] = "fourth"; // Precedence = 5, as the last used precedence was 4.
-					sorted[3] = "fifth"; // Precedence = 6
-					sorted[4] = "first"; // Precedence = 7
+					sorted.push_back("fifth"); // Precedence = 6
+					sorted.push_back("first"); // Precedence = 7
 					// sorted = second, third, fourth, fifth, first
 					list.Sort();
 					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
@@ -120,8 +120,8 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 				list.Load(AsDataNode("category test\n\tfourth 1\n\tfifth 3"));
 
 				THEN( "the new categories are at the end of the list in the order they were added" ) {
-					sorted[3] = "fourth"; // Precedence = 1
-					sorted[4] = "fifth"; // Precedence = 3
+					sorted.push_back("fourth"); // Precedence = 1
+					sorted.push_back("fifth"); // Precedence = 3
 					// sorted = second, third, first, fourth, fifth
 					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
 				}
@@ -130,8 +130,8 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 					sorted[0] = "fourth"; // Precedence = 1
 					sorted[1] = "second"; // Precedence = 2
 					sorted[2] = "fifth"; // Precedence = 3
-					sorted[3] = "third"; // Precedence = 4
-					sorted[4] = "first"; // Precedence = 7
+					sorted.push_back("third"); // Precedence = 4
+					sorted.push_back("first"); // Precedence = 7
 					list.Sort();
 					// sorted = fourth, second, fifth, third, first
 					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
@@ -142,16 +142,16 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 				list.Load(AsDataNode("category test\n\tfourth 7\n\tfifth 7"));
 
 				THEN( "the new categories are at the end of the list in the order they were added" ) {
-					sorted[3] = "fourth"; // Precedence = 7
-					sorted[4] = "fifth"; // Precedence = 7
+					sorted.push_back("fourth"); // Precedence = 7
+					sorted.push_back("fifth"); // Precedence = 7
 					// sorted = second, third, first, fourth, fifth
 					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
 				}
 
 				THEN( "after sorting, the categories with the same precedence become alphabetically ordered" ) {
 					sorted[2] = "fifth"; // Precedence = 7
-					sorted[3] = "first"; // Precedence = 7
-					sorted[4] = "fourth"; // Precedence = 7
+					sorted.push_back("first"); // Precedence = 7
+					sorted.push_back("fourth"); // Precedence = 7
 					list.Sort();
 					// sorted = second, third, fifth, first, fourth
 					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
@@ -162,17 +162,17 @@ SCENARIO( "Creating a CategoryList" , "[CategoryList][Creation]" ) {
 				list.Load(AsDataNode("category test\n\tthird 1"));
 
 				THEN( "the duplicate category's position is unchanged but its precedence is updated" ) {
-					sorted[0] = "second"; // Precedence = 2
-					sorted[1] = "third"; // Precedence = 1
-					sorted[2] = "first"; // Precedence = 6
+					sorted.push_back("second"); // Precedence = 2
+					sorted.push_back("third"); // Precedence = 1
+					sorted.push_back("first"); // Precedence = 6
 					// sorted = second, third, first
 					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );
 				}
 
 				THEN( "after sorting, the duplicate category's position is corrected" ) {
-					sorted[0] = "third"; // Precedence = 1
-					sorted[1] = "second"; // Precedence = 2
-					sorted[2] = "first"; // Precedence = 6
+					sorted.push_back("third"); // Precedence = 1
+					sorted.push_back("second"); // Precedence = 2
+					sorted.push_back("first"); // Precedence = 6
 					list.Sort();
 					// sorted = third, second, first
 					CHECK( std::equal(sorted.begin(), sorted.end(), list.begin(), equal) );


### PR DESCRIPTION
**Feature:** This PR implements part of the feature request detailed and discussed in issue #7046.

## Feature Details
This PR created a new CategoryList class that updates the behavior of the `category` root node. The current behavior of the `category` root node is that the order in which the categories are defined is the order in which they appear in game. This means that if a plugin wants to add a new category but they want to have it appear between two existing categories, they must redefine all the categories in the new order that they want.

The new behavior under this PR is that categories can be given "precedence" values that are used to sort them into the desired order instead of tying the order to how they were defined.
```
category <category type>
	<category name> [<precedence>]
```
Categories will now be sorted by ascending precedence values. If a category does not list a precedence, then its precedence becomes 1 + the most recently loaded precedence. If two categories share the same precedence then they are sorted alphabetically.

This PR also gives all vanilla categories precedence values in multiples of 10, allowing plugins to slot new categories between existing ones without having to redefine the categories list in full; the benefit of this is that if multiple plugins want to add new categories between existing ones, they can now all do so instead of only the last loaded plugin's order being accepted with all other plugins having their categories smashed together at the top of the list.

This PR is a stepping stone toward #7046.

## Usage Examples + UI Screenshots
The following is a category defined without any precedence values:
```
category "ship"
	"Transport"
	"Light Freighter"
	"Heavy Freighter"
	"Interceptor"
	"Light Warship"
	"Medium Warship"
	"Heavy Warship"
	"Fighter"
	"Drone"
```
And this one has ascending precedence values with gaps in between for the addition of new categories:
```
category "ship"
	"Transport" 10
	"Light Freighter" 20
	"Heavy Freighter" 30
	"Interceptor" 40
	"Light Warship" 50
	"Medium Warship" 60
	"Heavy Warship" 70
	"Fighter" 80
	"Drone" 90
```
Both of the above result in the same ordering of categories:

<details><summary>Long screenshot</summary>

![image](https://user-images.githubusercontent.com/17688683/180100047-4695c52e-d330-42d6-950f-14b45c74f4f0.png)
</details>

But say we want fighters and drones to show up first. Instead of reordering the list without having any precedence values, one can now give the fighter and drone categories a lower precedence than all other categories:
```
category "ship"
	"Transport" 10
	"Light Freighter" 20
	"Heavy Freighter" 30
	"Interceptor" 40
	"Light Warship" 50
	"Medium Warship" 60
	"Heavy Warship" 70
	"Fighter" 5
	"Drone" 1
```

<details><summary>Long screenshot</summary>

![image](https://user-images.githubusercontent.com/17688683/180100166-f72c07d8-6717-4cad-9fe4-2fc0f689b0a4.png)
</details>

But say we want to give fighters and drone the same precedence:
```
category "ship"
	"Transport" 10
	"Light Freighter" 20
	"Heavy Freighter" 30
	"Interceptor" 40
	"Light Warship" 50
	"Medium Warship" 60
	"Heavy Warship" 70
	"Fighter" 80
	"Drone" 80
```
They would then sort alphabetically, with drone appearing before fighter:

<details><summary>Long screenshot</summary>

![image](https://user-images.githubusercontent.com/17688683/180100212-66d67e7d-c78c-4fb8-96cc-6e00cd68685a.png)
</details>

If a plugin wanted to add a new ship category between interceptors and light warships or a new category after drones, all it would need would be the following:
```
category "ship"
	"Enforcer" 45
	"Mini-Drone" 100
```

## Testing Done
Created a set of test cases for the CategoryList class. Also tested in-game with the above usage examples and UI screenshots.

## Performance Impact
N/A
