### PR TITLE
Fix(oversight): made reputation changes from missions affect all Hai factions

### DIFF
--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -26,6 +26,10 @@ mission "Human Vacation [1]"
 	on complete
 		payment 8000 150
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Human Vacation [2]"
@@ -46,6 +50,10 @@ mission "Human Vacation [2]"
 	on complete
 		payment 5000 150
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [1]"
@@ -66,6 +74,10 @@ mission "Hai Vacation [1]"
 	on complete
 		payment 6000 150
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [2]"
@@ -86,6 +98,10 @@ mission "Hai Vacation [2]"
 	on complete
 		payment 4000 150
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [3]"
@@ -106,6 +122,10 @@ mission "Hai Vacation [3]"
 	on complete
 		payment 4000 150
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Vacation [4]"
@@ -127,6 +147,10 @@ mission "Hai Vacation [4]"
 		payment
 		payment 6000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 
@@ -152,6 +176,10 @@ mission "Wealthy Hai [1]"
 	on complete
 		payment 15000 300
 		"reputation: Hai" += 3
+		"reputation: Hai (Wormhole Access)" += 3
+		"reputation: Hai Merchant" += 3
+		"reputation: Hai Merchant (Human)" += 3
+		"reputation: Hai Merchant (Sympathizers)" += 3
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Wealthy Hai [2]"
@@ -176,6 +204,10 @@ mission "Wealthy Hai [2]"
 	on complete
 		payment 15000 300
 		"reputation: Hai" += 3
+		"reputation: Hai (Wormhole Access)" += 3
+		"reputation: Hai Merchant" += 3
+		"reputation: Hai Merchant (Human)" += 3
+		"reputation: Hai Merchant (Sympathizers)" += 3
 		dialog phrase "generic passenger dropoff payment"
 
 
@@ -203,6 +235,10 @@ mission "Hai Festival [1]"
 	on complete
 		payment 10000 200
 		"reputation: Hai" += 3
+		"reputation: Hai (Wormhole Access)" += 3
+		"reputation: Hai Merchant" += 3
+		"reputation: Hai Merchant (Human)" += 3
+		"reputation: Hai Merchant (Sympathizers)" += 3
 		dialog phrase "hai festival payment dialog"
 
 mission "Hai Festival [2]"
@@ -225,6 +261,10 @@ mission "Hai Festival [2]"
 	on complete
 		payment 10000 200
 		"reputation: Hai" += 3
+		"reputation: Hai (Wormhole Access)" += 3
+		"reputation: Hai Merchant" += 3
+		"reputation: Hai Merchant (Human)" += 3
+		"reputation: Hai Merchant (Sympathizers)" += 3
 		dialog phrase "hai festival payment dialog"
 
 mission "Hai Festival [3]"
@@ -247,6 +287,10 @@ mission "Hai Festival [3]"
 	on complete
 		payment 10000 200
 		"reputation: Hai" += 3
+		"reputation: Hai (Wormhole Access)" += 3
+		"reputation: Hai Merchant" += 3
+		"reputation: Hai Merchant (Human)" += 3
+		"reputation: Hai Merchant (Sympathizers)" += 3
 		dialog phrase "hai festival payment dialog"
 
 
@@ -288,6 +332,10 @@ mission "Unfettered Aid [0]"
 	on complete
 		payment 5000 1600
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog phrase "unfettered aid payment dialog"
 
 mission "Unfettered Aid [1]"
@@ -313,6 +361,10 @@ mission "Unfettered Aid [1]"
 	on complete
 		payment 6000 1800
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog phrase "unfettered aid payment dialog"
 
 mission "Unfettered Aid [2]"
@@ -338,6 +390,10 @@ mission "Unfettered Aid [2]"
 	on complete
 		payment 7000 2000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog phrase "unfettered aid payment dialog"
 
 phrase "unfettered tribute payment dialog"
@@ -439,6 +495,10 @@ mission "Delivery to Human Space [0]"
 	on complete
 		payment 60000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog phrase "generic cargo delivery payment"
 
 mission "Delivery to Human Space [1]"
@@ -459,6 +519,10 @@ mission "Delivery to Human Space [1]"
 	on complete
 		payment 60000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog phrase "generic cargo delivery payment"
 
 mission "Delivery to Human Space [2]"
@@ -479,6 +543,10 @@ mission "Delivery to Human Space [2]"
 	on complete
 		payment 60000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Retrieve Human Luxury Goods"
@@ -502,6 +570,10 @@ mission "Hai Retrieve Human Luxury Goods"
 	on complete
 		payment 120000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog "Your payment of <payment> is waiting when you touch down, along with delivery instructions. You send the <commodity> by dedicated courier."
 
 mission "Hai Retrieve Human Food"
@@ -525,6 +597,10 @@ mission "Hai Retrieve Human Food"
 	on complete
 		payment 120000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog "As soon as you touch down you receive a message from the Hai gourmet with thanks and your payment of <payment>."
 
 mission "Hai Retrieve Human Electronics"
@@ -548,6 +624,10 @@ mission "Hai Retrieve Human Electronics"
 	on complete
 		payment 120000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog "The Hai tinkerer is waiting for you when you arrive. They pay you <payment> and then run after the cargo pallets as though they plan to open them right there in the spaceport."
 
 
@@ -592,6 +672,10 @@ mission "Escort to Human Space (Small)"
 	on complete
 		payment 120000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -641,6 +725,10 @@ mission "Escort to Human Space (Medium)"
 	on complete
 		payment 180000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -685,6 +773,10 @@ mission "Escort to Human Space (Large)"
 	on complete
 		payment 240000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -735,6 +827,10 @@ mission "Escort to Human Space (Extra Large)"
 	on complete
 		payment 300000
 		"reputation: Hai" += 5
+		"reputation: Hai (Wormhole Access)" += 5
+		"reputation: Hai Merchant" += 5
+		"reputation: Hai Merchant (Human)" += 5
+		"reputation: Hai Merchant (Sympathizers)" += 5
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -759,6 +855,10 @@ mission "Hai Passengers [1]"
 	on complete
 		payment
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Passengers [2]"
@@ -779,6 +879,10 @@ mission "Hai Passengers [2]"
 	on complete
 		payment
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Passengers [3]"
@@ -799,6 +903,10 @@ mission "Hai Passengers [3]"
 	on complete
 		payment
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic passenger dropoff payment"
 
 mission "Hai Family [0]"
@@ -821,6 +929,10 @@ mission "Hai Family [0]"
 		payment
 		payment 4000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog "The family you have been transporting departs your ship after paying you <payment>."
 
 mission "Hai Family [1]"
@@ -843,6 +955,10 @@ mission "Hai Family [1]"
 		payment
 		payment 6000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog "The family you have been transporting departs your ship after paying you <payment>."
 
 mission "Transport Hai miners to <planet>"
@@ -864,6 +980,10 @@ mission "Transport Hai miners to <planet>"
 		payment
 		payment 2000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog "You wish the mining family the best of luck on <planet>, and collect your payment of <payment>."
 
 mission "Transport Hai farmers to <planet>"
@@ -885,6 +1005,10 @@ mission "Transport Hai farmers to <planet>"
 		payment
 		payment 2000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog "You wish the farm family the best of luck on <planet>, and collect your payment of <payment>."
 
 mission "Transport Hai mill workers to <planet>"
@@ -906,6 +1030,10 @@ mission "Transport Hai mill workers to <planet>"
 		payment
 		payment 2000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog "You wish the workers the best of luck on <planet>, and collect your payment of <payment>."
 
 mission "Transport Hai workers to <planet>"
@@ -927,6 +1055,10 @@ mission "Transport Hai workers to <planet>"
 		payment
 		payment 2000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog "You wish the workers the best of luck on <planet>, and collect your payment of <payment>."
 
 
@@ -949,6 +1081,10 @@ mission "Hai Cargo [0]"
 	on complete
 		payment
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [1]"
@@ -969,6 +1105,10 @@ mission "Hai Cargo [1]"
 	on complete
 		payment
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [2]"
@@ -990,6 +1130,10 @@ mission "Hai Cargo [2]"
 	on complete
 		payment
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [3]"
@@ -1012,6 +1156,10 @@ mission "Hai Cargo [3]"
 		payment
 		payment 2000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Cargo [4]"
@@ -1034,6 +1182,10 @@ mission "Hai Cargo [4]"
 		payment
 		payment 4000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Bulk Delivery [0]"
@@ -1054,6 +1206,10 @@ mission "Hai Bulk Delivery [0]"
 	on complete
 		payment
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Bulk Delivery [1]"
@@ -1075,6 +1231,10 @@ mission "Hai Bulk Delivery [1]"
 		payment
 		payment 2000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Bulk Delivery [2]"
@@ -1097,6 +1257,10 @@ mission "Hai Bulk Delivery [2]"
 		payment
 		payment 4000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Bulk Delivery [0]"
@@ -1119,6 +1283,10 @@ mission "Hai Large Bulk Delivery [0]"
 		payment
 		payment 4000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Bulk Delivery [1]"
@@ -1141,6 +1309,10 @@ mission "Hai Large Bulk Delivery [1]"
 		payment
 		payment 6000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Large Bulk Delivery [2]"
@@ -1164,6 +1336,10 @@ mission "Hai Large Bulk Delivery [2]"
 		payment
 		payment 8000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Rush Delivery [0]"
@@ -1186,6 +1362,10 @@ mission "Hai Rush Delivery [0]"
 		payment
 		payment 16000
 		"reputation: Hai" += 2
+		"reputation: Hai (Wormhole Access)" += 2
+		"reputation: Hai Merchant" += 2
+		"reputation: Hai Merchant (Human)" += 2
+		"reputation: Hai Merchant (Sympathizers)" += 2
 		dialog phrase "generic cargo delivery payment"
 
 mission "Hai Rush Delivery [1]"

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -549,6 +549,10 @@ mission "Unfettered returning home"
 		dialog
 			`You need not have worried about the reception the Unfettered youth would receive here on Hai-home. Scarcely minutes after you hesitantly contact the Hai government, a happy crowd has gathered around your ship. When he steps out of the hatchway, he looks stunned at being welcomed so warmly. One of the Hai governors thanks you for transporting him, and pays you <payment>.`
 		"reputation: Hai" += 10
+		"reputation: Hai (Wormhole Access)" += 10
+		"reputation: Hai Merchant" += 10
+		"reputation: Hai Merchant (Human)" += 10
+		"reputation: Hai Merchant (Sympathizers)" += 10
 
 
 
@@ -1253,6 +1257,10 @@ mission "Pirate Troubles [1]"
 		has "Pirate Troubles [0]: done"
 	on offer
 		"reputation: Hai" += 20
+		"reputation: Hai (Wormhole Access)" += 20
+		"reputation: Hai Merchant" += 20
+		"reputation: Hai Merchant (Human)" += 20
+		"reputation: Hai Merchant (Sympathizers)" += 20
 		conversation
 			`The battle has ended, but the spaceport still seems more hectic than usual. Ships are jumping in from the surrounding systems to help any injured and to repair any damage that may have occurred. After some hours pass and the commotion has died down, a Hai elder approaches you. "We have heard from the humans here that you are considered a seasoned fighter among your people. May you lend your combat prowess to us to resolve this issue?"`
 			choice
@@ -1536,6 +1544,10 @@ mission "Pirate Troubles [4]"
 			has "accepted scar's legion tribute"
 	on offer
 		"reputation: Hai" += 20
+		"reputation: Hai (Wormhole Access)" += 20
+		"reputation: Hai Merchant" += 20
+		"reputation: Hai Merchant (Human)" += 20
+		"reputation: Hai Merchant (Sympathizers)" += 20
 		payment 2500000
 		conversation
 			`Upon landing on <origin>, the Hai authorities give you <payment> for your assistance in defending their systems and for helping to track down the culprits. You're sent to the council of elders, the elected ruling body of the Hai, to tell them about Scar's Legion. "Please, tell us what has occurred," one of the elders says.`
@@ -1576,6 +1588,10 @@ mission "Pirate Troubles [4]"
 	
 	on decline
 		"reputation: Hai" += 40
+		"reputation: Hai (Wormhole Access)" += 40
+		"reputation: Hai Merchant" += 40
+		"reputation: Hai Merchant (Human)" += 40
+		"reputation: Hai Merchant (Sympathizers)" += 40
 	
 	npc save accompany
 		government "Hai (Wormhole Access)"
@@ -1594,6 +1610,10 @@ mission "Pirate Troubles [4]"
 	
 	on complete
 		"reputation: Hai" += 40
+		"reputation: Hai (Wormhole Access)" += 40
+		"reputation: Hai Merchant" += 40
+		"reputation: Hai Merchant (Human)" += 40
+		"reputation: Hai Merchant (Sympathizers)" += 40
 		payment 500000
 		dialog `With the freighters safely returned, the Hai thank you for resolving the situation with Scar's Legion and hand you <payment> for your help.`
 

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -1139,6 +1139,10 @@ mission "Sheragi Archaeology: The Box 7b"
 
 	on complete
 		"reputation: Hai" += 10
+		"reputation: Hai (Wormhole Access)" += 10
+		"reputation: Hai Merchant" += 10
+		"reputation: Hai Merchant (Human)" += 10
+		"reputation: Hai Merchant (Sympathizers)" += 10
 		conversation
 			`Arriving on Hai-home, you manage to contact the Ministry of Culture, expressing your interests in obtaining Sheragi documents and manuals. After some time on hold, you're scheduled to meet them in person.`
 			`	You get ready and make your way to the city hall, where the Ministry is, to meet with the Hai officials, who are accompanied by a few diplomats. You all sit down at a round table. You describe the discovery of the Sheragi ruins to them and they begin inquiring more about it, curious about the state of preservation of the ruins and what artifacts were found. They seem very excited.`

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -166,6 +166,10 @@ mission "Wanderers: Hai Diplomat"
 	on accept
 		"reputation: Hai" >?= 20
 		"reputation: Hai" += 30
+		"reputation: Hai (Wormhole Access)" += 30
+		"reputation: Hai Merchant" += 30
+		"reputation: Hai Merchant (Human)" += 30
+		"reputation: Hai Merchant (Sympathizers)" += 30
 
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses the comment on the Unfettered campaign PR: https://github.com/endless-sky/endless-sky/pull/6416#issuecomment-1192470104
This was an oversight when adding new factions, and when adding the reputation changes to the jobs.

## Fix Details
The jobs and missions only gave additional reputation for the main Hai faction, which means that you could be at war with the Hai (Whormhole Access), and not the Hai. But then whormhole access Hai aren't meant to have a different reputation with you than the main gov, they're just there when Hai missions take them trough the whormhole.

Then it made little sense that doing missions like transporting goods and peoples did not increase your reputation with the merchant Hai, as they're precisely the ones that would care the most about that.

The fact that you only received reputation for the main faction meant that you could get at war with a subfaction without being at war with the Hai way too easily (like after repping one UHai ship...) and can't even do missions to fix that.

Details: I wrote a script to do this so I'm pretty sure it was done everywhere and without an oversight.

## Testing Done
I didnt feel like any was required. I am sure I modified all the places where the reputation changes happened in the jobs/missions.

## Save File
N/A
