### PR TITLE
Fix(dialog): unfettered tribute missions use the right "on visit" dialog

### DIFF
--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -39,6 +39,9 @@ phrase "generic cargo delivery payment"
 phrase "generic cargo on visit"
 	word
 		`You have reached <planet>, but not all of the cargo is in the system! Better depart and wait for your escorts to arrive in this star system.`
+phrase "generic cargo with stopover on visit"
+	word
+		`You have arrived at <planet>, but you are missing the cargo. Either you have not picked it up yet, or the escort carrying it is not in the system.`
 
 phrase "generic passenger dropoff payment"
 	word

--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -39,9 +39,6 @@ phrase "generic cargo delivery payment"
 phrase "generic cargo on visit"
 	word
 		`You have reached <planet>, but not all of the cargo is in the system! Better depart and wait for your escorts to arrive in this star system.`
-phrase "generic cargo with stopover pickup on visit"
-	word
-		`You have arrived at <planet>, but you are missing the cargo. Either you have not picked it up from <stopovers> yet, or the escort carrying it is not in the system.`
 
 phrase "generic passenger dropoff payment"
 	word

--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -39,9 +39,9 @@ phrase "generic cargo delivery payment"
 phrase "generic cargo on visit"
 	word
 		`You have reached <planet>, but not all of the cargo is in the system! Better depart and wait for your escorts to arrive in this star system.`
-phrase "generic cargo with stopover on visit"
+phrase "generic cargo with stopover pickup on visit"
 	word
-		`You have arrived at <planet>, but you are missing the cargo. Either you have not picked it up yet, or the escort carrying it is not in the system.`
+		`You have arrived at <planet>, but you are missing the cargo. Either you have not picked it up from <stopovers> yet, or the escort carrying it is not in the system.`
 
 phrase "generic passenger dropoff payment"
 	word

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -425,7 +425,7 @@ mission "Unfettered Tribute 1"
 		attributes "hai"
 		attributes "spaceport"
 	on visit
-		dialog phrase "generic cargo on visit"
+		dialog phrase "generic cargo with stopover on visit"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 
@@ -448,7 +448,7 @@ mission "Unfettered Tribute 2"
 		attributes "hai"
 		attributes "spaceport"
 	on visit
-		dialog phrase "generic cargo on visit"
+		dialog phrase "generic cargo with stopover on visit"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 
@@ -471,7 +471,7 @@ mission "Unfettered Tribute 3"
 		attributes "hai"
 		attributes "spaceport"
 	on visit
-		dialog phrase "generic cargo on visit"
+		dialog phrase "generic cargo with stopover on visit"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -425,7 +425,7 @@ mission "Unfettered Tribute 1"
 		attributes "hai"
 		attributes "spaceport"
 	on visit
-		dialog phrase "generic cargo with stopover on visit"
+		dialog phrase "generic cargo with stopover pickup on visit"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 
@@ -448,7 +448,7 @@ mission "Unfettered Tribute 2"
 		attributes "hai"
 		attributes "spaceport"
 	on visit
-		dialog phrase "generic cargo with stopover on visit"
+		dialog phrase "generic cargo with stopover pickup on visit"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 
@@ -471,7 +471,7 @@ mission "Unfettered Tribute 3"
 		attributes "hai"
 		attributes "spaceport"
 	on visit
-		dialog phrase "generic cargo with stopover on visit"
+		dialog phrase "generic cargo with stopover pickup on visit"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -425,7 +425,7 @@ mission "Unfettered Tribute 1"
 		attributes "hai"
 		attributes "spaceport"
 	on visit
-		dialog phrase "generic cargo with stopover pickup on visit"
+		dialog phrase "generic missing stopover or cargo"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 
@@ -448,7 +448,7 @@ mission "Unfettered Tribute 2"
 		attributes "hai"
 		attributes "spaceport"
 	on visit
-		dialog phrase "generic cargo with stopover pickup on visit"
+		dialog phrase "generic missing stopover or cargo"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 
@@ -471,7 +471,7 @@ mission "Unfettered Tribute 3"
 		attributes "hai"
 		attributes "spaceport"
 	on visit
-		dialog phrase "generic cargo with stopover pickup on visit"
+		dialog phrase "generic missing stopover or cargo"
 	on stopover
 		dialog phrase "unfettered tribute pickup dialog"
 


### PR DESCRIPTION
**Bugfix:** This PR addresses an incorrect dialog for the Unfettered tributes.
When you had not yet been to the stopover and arrived at the destination it would say your escort has not entered the system yet. It was reported here: https://github.com/endless-sky/endless-sky/pull/6416#issuecomment-1193354648

## Fix Details
I created a new generic dialog for missions that are cargo with a stopover, and made the unfettered tribute missions use it. I preferred doing it in a generic way, to allow for more missions to use that same dialog. (the Unfettered campaign PR for instance will use it a lot)

I manually checked every single mission with the generic cargo dialog, only the unfettered tribute missions have a stopover, so only those will use it for now.

## Testing Done
The fact this builds properly shows that the name of the dialog is correct, and its just a phrase so it can't be wrong.

## Save File
N/A
