### PR TITLE
Record game version in save file

### DIFF
--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		62C3111A1CE172D000409D91 /* Flotsam.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62C311181CE172D000409D91 /* Flotsam.cpp */; };
 		6A5716331E25BE6F00585EB2 /* CollisionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6A5716311E25BE6F00585EB2 /* CollisionSet.cpp */; };
 		6EC347E6A79BA5602BA4D1EA /* StartConditionsPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11EA4AD7A889B6AC1441A198 /* StartConditionsPanel.cpp */; };
+		7F1C4E52BDA69A016B6099DC /* Version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 87D840E4ABDDC70250C20B3D /* Version.cpp */; };
 		87D6407E8B579EB502BFBCE5 /* GameAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F4096A9008E2D8F3304BB /* GameAction.cpp */; };
 		88A64339B56EBA1F7923E1C7 /* GameLoadingPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7E640C7A366679B27CCADAC /* GameLoadingPanel.cpp */; };
 		90CF46CE84794C6186FC6CE2 /* EsUuid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 950742538F8CECF5D4168FBC /* EsUuid.cpp */; };
@@ -213,6 +214,7 @@
 
 /* Begin PBXFileReference section */
 		02D34A71AE3BC4C93FC6865B /* TestData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestData.cpp; path = source/TestData.cpp; sourceTree = "<group>"; };
+		03F44261ACC6D0D28D7640CF /* Version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Version.h; path = source/Version.h; sourceTree = "<group>"; };
 		070CD8152818CC6B00A853BB /* libmad.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libmad.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		072599BE26A8C67D007EC229 /* SDL2.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = SDL2.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		072599CC26A8C942007EC229 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = build/SDL2.framework; sourceTree = "<group>"; };
@@ -257,6 +259,7 @@
 		74F543598EEFB3745287E663 /* Bitset.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Bitset.cpp; path = source/Bitset.cpp; sourceTree = "<group>"; };
 		86AB4B6E9C4C0490AE7F029B /* EsUuid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EsUuid.h; path = source/EsUuid.h; sourceTree = "<group>"; };
 		86D9414E818561143BD298BC /* TextReplacements.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextReplacements.h; path = source/TextReplacements.h; sourceTree = "<group>"; };
+		87D840E4ABDDC70250C20B3D /* Version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Version.cpp; path = source/Version.cpp; sourceTree = "<group>"; };
 		8CB543A1AA20F764DD7FC15A /* MenuAnimationPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MenuAnimationPanel.h; path = source/MenuAnimationPanel.h; sourceTree = "<group>"; };
 		8E8A4C648B242742B22A34FA /* Weather.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Weather.cpp; path = source/Weather.cpp; sourceTree = "<group>"; };
 		950742538F8CECF5D4168FBC /* EsUuid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EsUuid.cpp; path = source/EsUuid.cpp; sourceTree = "<group>"; };
@@ -873,6 +876,8 @@
 				61FA4C2BB89E08C5E2B8B4B9 /* Variant.cpp */,
 				5EBC44769E84CF0C953D08B3 /* Variant.h */,
 				086E48E490C9BAD6660C7274 /* ExclusiveItem.h */,
+				87D840E4ABDDC70250C20B3D /* Version.cpp */,
+				03F44261ACC6D0D28D7640CF /* Version.h */,
 			);
 			name = source;
 			sourceTree = "<group>";
@@ -1265,6 +1270,7 @@
 				E3D54794A1EEF51CD4859170 /* DamageProfile.cpp in Sources */,
 				F35E4D6EA465D71CDA282EBA /* MenuAnimationPanel.cpp in Sources */,
 				920F40E0ADECA8926F423FDA /* Variant.cpp in Sources */,
+				7F1C4E52BDA69A016B6099DC /* Version.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -338,6 +338,7 @@
 		<Unit filename="source/UniverseObjects.h" />
 		<Unit filename="source/Variant.cpp" />
 		<Unit filename="source/Variant.h" />
+		<Unit filename="source/Version.h" />
 		<Unit filename="source/Visual.cpp" />
 		<Unit filename="source/Visual.h" />
 		<Unit filename="source/Weapon.cpp" />

--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -338,6 +338,7 @@
 		<Unit filename="source/UniverseObjects.h" />
 		<Unit filename="source/Variant.cpp" />
 		<Unit filename="source/Variant.h" />
+		<Unit filename="source/Version.cpp" />
 		<Unit filename="source/Version.h" />
 		<Unit filename="source/Visual.cpp" />
 		<Unit filename="source/Visual.h" />

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2823,10 +2823,14 @@ void PlayerInfo::Save(const string &path) const
 
 
 	// Current game version:
-	out.Write("version", Version::GetVersion());
+	out.Write("game version", Version::GetVersion());
 	const auto commitId = Version::GetCommit();
 	if(!commitId.empty())
+	{
+		out.BeginChild();
 		out.Write("commit", commitId);
+		out.EndChild();
+	}
 
 	// Basic player information and persistent UI settings:
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2823,7 +2823,7 @@ void PlayerInfo::Save(const string &path) const
 
 
 	// Current game version:
-	out.Write("version", Version::GetVersionString());
+	out.Write("version", Version::GetString());
 
 	// Basic player information and persistent UI settings:
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -37,6 +37,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "StellarObject.h"
 #include "System.h"
 #include "UI.h"
+#include "Version.h"
 
 #include <algorithm>
 #include <cmath>
@@ -2822,9 +2823,7 @@ void PlayerInfo::Save(const string &path) const
 
 
 	// Current game version:
-	string version = Format::Split(Format::Split(Files::Read(Files::Resources() + "credits.txt"), "\n")[1], " ")[1];
-	version = version.substr(0, version.length() - 1);
-	out.Write("version", version);
+	out.Write("version", Version::GetVersionString());
 
 	// Basic player information and persistent UI settings:
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -46,6 +46,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <limits>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
 using namespace std;
 
@@ -2819,6 +2820,11 @@ void PlayerInfo::Save(const string &path) const
 {
 	DataWriter out(path);
 
+
+	// Current game version:
+	string version = Format::Split(Format::Split(Files::Read(Files::Resources() + "credits.txt"), "\n")[1], " ")[1];
+	version = version.substr(0, version.length() - 1);
+	out.Write("version", version);
 
 	// Basic player information and persistent UI settings:
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2823,7 +2823,10 @@ void PlayerInfo::Save(const string &path) const
 
 
 	// Current game version:
-	out.Write("version", Version::GetString());
+	out.Write("version", Version::GetVersion());
+	const auto commitId = Version::GetCommit();
+	if(!commitId.empty())
+		out.Write("commit", commitId);
 
 	// Basic player information and persistent UI settings:
 

--- a/source/Version.cpp
+++ b/source/Version.cpp
@@ -7,7 +7,10 @@ Foundation, either version 3 of the License, or (at your option) any later versi
 
 Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "Version.h"

--- a/source/Version.cpp
+++ b/source/Version.cpp
@@ -1,4 +1,4 @@
-/* Version.h
+/* Version.cpp
 Copyright (c) 2022 by warp-core
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
@@ -10,14 +10,18 @@ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 */
 
-#ifndef VERSION_H_
-#define VERSION_H_
+#include "Version.h"
 
-// A class to get a string with the game version and
-// the latest commit hash for non-release version.
-class Version {
-public:
-	static const std::string GetString()
-};
+namespace {
+	const std::string GAME_VERSION = "0.9.15-alpha";
+	const std::string COMMIT_ID = "";
+}
 
-#endif
+using namespace std;
+
+static const string Version::GetString()
+{
+	if(COMMIT_ID.empty())
+		return GAME_VERSION;
+	return GAME_VERSION + " " + COMMIT_ID;
+}

--- a/source/Version.cpp
+++ b/source/Version.cpp
@@ -19,7 +19,7 @@ namespace {
 
 using namespace std;
 
-static const string Version::GetString()
+static const string Version::GetString();
 {
 	if(COMMIT_ID.empty())
 		return GAME_VERSION;

--- a/source/Version.cpp
+++ b/source/Version.cpp
@@ -12,14 +12,16 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Version.h"
 
-namespace {
-	const std::string GAME_VERSION = "0.9.15-alpha";
-	const std::string COMMIT_ID = "";
-}
-
 using namespace std;
 
-static const string Version::GetString();
+namespace {
+	const string GAME_VERSION = "0.9.15-alpha";
+	const string COMMIT_ID = "";
+}
+
+
+
+const string Version::GetString()
 {
 	if(COMMIT_ID.empty())
 		return GAME_VERSION;

--- a/source/Version.cpp
+++ b/source/Version.cpp
@@ -21,7 +21,7 @@ namespace {
 
 
 
-const string Version::GetString()
+string Version::GetString()
 {
 	if(COMMIT_ID.empty())
 		return GAME_VERSION;

--- a/source/Version.cpp
+++ b/source/Version.cpp
@@ -27,3 +27,17 @@ string Version::GetString()
 		return GAME_VERSION;
 	return GAME_VERSION + " " + COMMIT_ID;
 }
+
+
+
+const string &Version::GetVersion()
+{
+	return GAME_VERSION;
+}
+
+
+
+const string &Version::GetCommit()
+{
+	return COMMIT_ID;
+}

--- a/source/Version.h
+++ b/source/Version.h
@@ -20,6 +20,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 class Version {
 public:
 	static std::string GetString();
+	static const std::string &GetVersion();
+	static const std::string &GetCommit();
 };
 
 #endif

--- a/source/Version.h
+++ b/source/Version.h
@@ -13,11 +13,13 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef VERSION_H_
 #define VERSION_H_
 
+#include <string>
+
 // A class to get a string with the game version and
 // the latest commit hash for non-release version.
 class Version {
 public:
-	static const std::string GetString()
+	static const std::string GetString();
 };
 
 #endif

--- a/source/Version.h
+++ b/source/Version.h
@@ -7,7 +7,10 @@ Foundation, either version 3 of the License, or (at your option) any later versi
 
 Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 #ifndef VERSION_H_

--- a/source/Version.h
+++ b/source/Version.h
@@ -1,0 +1,31 @@
+/* Version.h
+Copyright (c) 2022 by warp-core
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef VERSION_H_
+#define VERSION_H_
+
+namespace {
+	const std::string GAME_VERSION = "0.9.15-alpha";
+	const std::string COMMIT_ID = "";
+}
+
+class Version {
+public:
+	static std::string GetVersionString()
+	{
+		if(COMMIT_ID == "")
+			return GAME_VERSION;
+		return GAME_VERSION + " " + COMMIT_ID;
+	}
+};
+
+#endif

--- a/source/Version.h
+++ b/source/Version.h
@@ -19,7 +19,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 // the latest commit hash for non-release version.
 class Version {
 public:
-	static const std::string GetString();
+	static std::string GetString();
 };
 
 #endif

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -70,6 +70,8 @@ void PrintWeaponTable();
 void InitConsole();
 #endif
 
+
+
 // Entry point for the EndlessSky executable
 int main(int argc, char *argv[])
 {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -38,6 +38,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Test.h"
 #include "TestContext.h"
 #include "UI.h"
+#include "Version.h"
 
 #include <chrono>
 #include <iostream>
@@ -68,8 +69,6 @@ void PrintWeaponTable();
 #ifdef _WIN32
 void InitConsole();
 #endif
-
-
 
 // Entry point for the EndlessSky executable
 int main(int argc, char *argv[])
@@ -430,7 +429,7 @@ void PrintHelp()
 void PrintVersion()
 {
 	cerr << endl;
-	cerr << "Endless Sky ver. 0.9.15-alpha" << endl;
+	cerr << "Endless Sky ver. " << Version::GetVersionString() << endl;
 	cerr << "License GPLv3+: GNU GPL version 3 or later: <https://gnu.org/licenses/gpl.html>" << endl;
 	cerr << "This is free software: you are free to change and redistribute it." << endl;
 	cerr << "There is NO WARRANTY, to the extent permitted by law." << endl;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -429,7 +429,7 @@ void PrintHelp()
 void PrintVersion()
 {
 	cerr << endl;
-	cerr << "Endless Sky ver. " << Version::GetVersionString() << endl;
+	cerr << "Endless Sky ver. " << Version::GetString() << endl;
 	cerr << "License GPLv3+: GNU GPL version 3 or later: <https://gnu.org/licenses/gpl.html>" << endl;
 	cerr << "This is free software: you are free to change and redistribute it." << endl;
 	cerr << "There is NO WARRANTY, to the extent permitted by law." << endl;

--- a/utils/cd_update_versions.sh
+++ b/utils/cd_update_versions.sh
@@ -6,5 +6,5 @@ set -e
 $(dirname $0)/set_version.sh $(git rev-parse --verify HEAD)
 $(dirname $0)/set_plist_build.sh $(git rev-list --all --count)
 CREDIT_STRING=$(git log --pretty="format: (%h)%n%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \" \')
-perl -p -i -e "s|(version [\d+\.]{2}[\d+](-\w*)?)|\$1$CREDIT_STRING|" credits.txt
+perl -p -i -e "s|(version (\d+\.){2}\d+(-\w*)?)|\$1$CREDIT_STRING|" credits.txt
 rm -rf credits.txt.bak

--- a/utils/cd_update_versions.sh
+++ b/utils/cd_update_versions.sh
@@ -6,5 +6,5 @@ set -e
 $(dirname $0)/set_version.sh $(git rev-parse --verify HEAD)
 $(dirname $0)/set_plist_build.sh $(git rev-list --all --count)
 CREDIT_STRING=$(git log --pretty="format: (%h)%n%nBuilt: $(date -u '+%Y-%m-%d %H:%M') UTC%nLast change by %an: %n %s" -1 | fmt -w 33 -c -s | tr \|\$ _ | tr \" \')
-perl -p -i -e "s|(version [\d.]+(-\w*)?)|\$1$CREDIT_STRING|" credits.txt
+perl -p -i -e "s|(version [\d+\.]{2}[\d+](-\w*)?)|\$1$CREDIT_STRING|" credits.txt
 rm -rf credits.txt.bak

--- a/utils/set_version.sh
+++ b/utils/set_version.sh
@@ -13,7 +13,7 @@ if [[ ${isVersion} -eq 0 ]]; then
     replacement=$1
 elif [[ $1 =~ ^[0-9A-Fa-f]+$ ]]; then
     replacement="($1)"
-    perl -p -i -e "s|(COMMIT_ID = \").*?\"|$1${replacement}\"|ig" source/Version.h
+    perl -p -i -e "s|(COMMIT_ID = \").*?\"|\$1${replacement}\"|ig" source/Version.h
     perl -p -i -e "s|\".*?\" \"(ver\. .*)\" \"|\"$(date '+%d %b %Y')\" \"\$1 ${replacement}\" \"|ig" endless-sky.6
     isVersion=2
 else
@@ -22,7 +22,7 @@ fi
 
 if [[ ${isVersion} -ne 2 ]]; then
     # Update Version.h
-    perl -p -i -e "s|(GAME_VERSION = \").*?\"|$1${replacement}\"|ig" source/Version.h
+    perl -p -i -e "s|(GAME_VERSION = \").*?\"|\$1${replacement}\"|ig" source/Version.h
     # Update endless-sky.6
     perl -p -i -e "s|\".*?\" \"ver\. .+?\"|\"$(date '+%d %b %Y')\" \"${replacement}\"|ig" endless-sky.6
 fi

--- a/utils/set_version.sh
+++ b/utils/set_version.sh
@@ -13,7 +13,7 @@ if [[ ${isVersion} -eq 0 ]]; then
     replacement=$1
 elif [[ $1 =~ ^[0-9A-Fa-f]+$ ]]; then
     replacement="($1)"
-    perl -p -i -e "s|(COMMIT_ID = \").*?\"|\$1${replacement}\"|ig" source/Version.h
+    perl -p -i -e "s|(COMMIT_ID = \").*?\"|\$1${replacement}\"|ig" source/Version.cpp
     perl -p -i -e "s|\".*?\" \"(ver\. .*)\" \"|\"$(date '+%d %b %Y')\" \"\$1 ${replacement}\" \"|ig" endless-sky.6
     isVersion=2
 else
@@ -22,7 +22,7 @@ fi
 
 if [[ ${isVersion} -ne 2 ]]; then
     # Update Version.h
-    perl -p -i -e "s|(GAME_VERSION = \").*?\"|\$1${replacement}\"|ig" source/Version.h
+    perl -p -i -e "s|(GAME_VERSION = \").*?\"|\$1${replacement}\"|ig" source/Version.cpp
     # Update endless-sky.6
     perl -p -i -e "s|\".*?\" \"ver\. .+?\"|\"$(date '+%d %b %Y')\" \"${replacement}\"|ig" endless-sky.6
 fi

--- a/utils/set_version.sh
+++ b/utils/set_version.sh
@@ -6,25 +6,25 @@
 # $ ./utils/set_version.sh "my cool version"
 # $ ./utils/set_version.sh 1.0.0
 
-versionRegex="([0-9]+\.){0,2}[0-9]+"
+versionRegex="(\d+\.){0,2}\d+"
 [[ $1 =~ ^${versionRegex}.*$ ]]
 isVersion=$?
 if [[ ${isVersion} -eq 0 ]]; then
-    replacement="ver. $1"
+    replacement=$1
 elif [[ $1 =~ ^[0-9A-Fa-f]+$ ]]; then
     replacement="($1)"
-    perl -p -i -e "s/(\"Endless Sky .*)\"/\$1 ${replacement}\"/ig" source/main.cpp
-    perl -p -i -e "s/\".*?\" \"(ver\. .*)\" \"/\"$(date '+%d %b %Y')\" \"\$1 ${replacement}\" \"/ig" endless-sky.6
+    perl -p -i -e "s|(COMMIT_ID = \").*?\"|$1${replacement}\"|ig" source/Version.h
+    perl -p -i -e "s|\".*?\" \"(ver\. .*)\" \"|\"$(date '+%d %b %Y')\" \"\$1 ${replacement}\" \"|ig" endless-sky.6
     isVersion=2
 else
     replacement=$1
 fi
 
 if [[ ${isVersion} -ne 2 ]]; then
-    # Update main.cpp
-    perl -p -i -e "s/(\"Endless Sky) .+?\"/\$1 ${replacement}\"/ig" source/main.cpp
+    # Update Version.h
+    perl -p -i -e "s|(GAME_VERSION = \").*?\"|$1${replacement}\"|ig" source/Version.h
     # Update endless-sky.6
-    perl -p -i -e "s/\".*?\" \"ver\. .+?\"/\"$(date '+%d %b %Y')\" \"${replacement}\"/ig" endless-sky.6
+    perl -p -i -e "s|\".*?\" \"ver\. .+?\"|\"$(date '+%d %b %Y')\" \"${replacement}\"|ig" endless-sky.6
 fi
 
 rm -rf source/main.cpp.bak


### PR DESCRIPTION
**Feature:**

## Feature Details
The game will save the version (listed in the second line of the credits file) to the top of the save file.
I haven't implemented any use for it (the game will ignore it when loading a save) but it could be useful later on if, for example, a save breaking change were made.

The current entry in the credits file:
`version 0.9.15-alpha`

The automated release mechanism setup here seems to add a commit hash:
`version 0.9.15-alpha (124fbf4)`
This format will need to be changed to:
`version <version>-(<hash>)`
for this code to handle it properly.

It occurs to me that there may not be an obvious way for the game to tell if a version string is older than the current version (it could potentially parse everything up to the first '-', but I don't think it's possible to chronologise commit hashes without more information).

## Testing Done
Start game, take off, check save.
