### PR TITLE
feat(content): Transport Category Rework

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -10,9 +10,11 @@
 
 # Ships of these types can be purchased and also used as mission sources.
 category "ship"
-	"Transport"
 	"Light Freighter"
 	"Heavy Freighter"
+	"Transport"
+	"Space Liner"
+	"Utility"
 	"Interceptor"
 	"Light Warship"
 	"Medium Warship"

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -10,10 +10,10 @@
 
 # Ships of these types can be purchased and also used as mission sources.
 category "ship"
-	"Light Freighter"
-	"Heavy Freighter"
 	"Transport"
 	"Space Liner"
+	"Light Freighter"
+	"Heavy Freighter"
 	"Utility"
 	"Interceptor"
 	"Light Warship"

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -1483,7 +1483,7 @@ ship "Kimek Spire"
 	sprite "ship/kimek spire"
 	thumbnail "thumbnail/kimek spire"
 	attributes
-		category "Transport"
+		category "Space Liner"
 		licenses
 			Coalition
 		"cost" 9375000
@@ -1679,7 +1679,7 @@ ship "Saryd Sojourner"
 	sprite "ship/saryd sojourner"
 	thumbnail "thumbnail/saryd sojourner"
 	attributes
-		category "Heavy Freighter"
+		category "Utility"
 		licenses
 			Coalition
 		"cost" 11075000
@@ -1791,7 +1791,7 @@ ship "Saryd Visitor"
 	sprite "ship/saryd visitor"
 	thumbnail "thumbnail/saryd visitor"
 	attributes
-		category "Light Freighter"
+		category "Transport"
 		licenses
 			Coalition
 		"cost" 1982000

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -1635,7 +1635,7 @@ ship "Saryd Runabout"
 	sprite "ship/saryd runabout"
 	thumbnail "thumbnail/saryd runabout"
 	attributes
-		category "Light Freighter"
+		category "Transport"
 		licenses
 			Coalition
 		"cost" 942000
@@ -1736,7 +1736,7 @@ ship "Saryd Traveler"
 	sprite "ship/saryd traveler"
 	thumbnail "thumbnail/saryd traveler"
 	attributes
-		category "Heavy Freighter"
+		category "Transport"
 		licenses
 			Coalition
 		"cost" 3385000

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -967,7 +967,7 @@ ship "Water Bug"
 	sprite "ship/hai water bug"
 	thumbnail "thumbnail/hai water bug"
 	attributes
-		category "Heavy Freighter"
+		category "Light Freighter"
 		"cost" 6500000
 		"shields" 7900
 		"hull" 4500

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -296,7 +296,7 @@ ship "Bactrian"
 	attributes
 		licenses
 			City-Ship
-		category "Heavy Warship"
+		category "Utility"
 		"cost" 17600000
 		"shields" 17500
 		"hull" 8600
@@ -2415,7 +2415,7 @@ ship "Mule"
 	sprite "ship/mule"
 	thumbnail "thumbnail/mule"
 	attributes
-		category "Medium Warship"
+		category "Utility"
 		"cost" 4080000
 		"shields" 5400
 		"hull" 4400

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2477,7 +2477,7 @@ ship "Nest"
 	sprite "ship/nest"
 	thumbnail "thumbnail/nest"
 	attributes
-		category "Medium Warship"
+		category "Utility"
 		"cost" 2500000
 		"shields" 2500
 		"hull" 3700
@@ -2822,7 +2822,7 @@ ship "Roost"
 	sprite "ship/roost"
 	thumbnail "thumbnail/roost"
 	attributes
-		category "Medium Warship"
+		category "Utility"
 		"cost" 3000000
 		"shields" 2900
 		"hull" 5200
@@ -2984,7 +2984,7 @@ ship "Skein"
 	sprite "ship/skein"
 	thumbnail "thumbnail/skein"
 	attributes
-		category "Medium Warship"
+		category "Utility"
 		licenses
 			"Militia"
 		"cost" 3500000

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -189,7 +189,7 @@ ship "Auxiliary"
 	sprite "ship/auxiliaryh"
 	thumbnail "thumbnail/auxiliaryh"
 	attributes
-		category "Transport"
+		category "Utility"
 		licenses
 			"Navy Auxiliary"
 		"cost" 13720000
@@ -3202,7 +3202,7 @@ ship "Star Queen"
 	sprite "ship/star queen"
 	thumbnail "thumbnail/star queen"
 	attributes
-		category "Transport"
+		category "Space Liner"
 		"cost" 5500000
 		"shields" 4100
 		"hull" 2200

--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -155,7 +155,7 @@ ship "Korath Raider"
 	sprite "ship/raider"
 	thumbnail "thumbnail/raider"
 	attributes
-		category "Medium Warship"
+		category "Utility"
 		"cost" 16570000
 		"shields" 27000
 		"hull" 9000
@@ -315,7 +315,7 @@ ship "Korath Raider Mark XLII"
 	sprite "ship/raider xlii"
 	thumbnail "thumbnail/raider xlii"
 	attributes
-		category "Medium Warship"
+		category "Utility"
 		"cost" 22895000
 		"shields" 29500
 		"hull" 11000
@@ -502,7 +502,7 @@ ship "Korath World-Ship"
 	sprite "ship/world-ship a"
 	thumbnail "thumbnail/world-ship a"
 	attributes
-		category "Heavy Freighter"
+		category "Utility"
 		cost 27690000
 		shields 47000
 		hull 34000

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -373,7 +373,7 @@ ship "Gull" "Gull (Bunks)"
 ship "Heron"
 	sprite "ship/heron"
 	attributes
-		category "Transport"
+		category "Utility"
 		licenses
 			"Remnant Capital"
 		"cost" 256375000

--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -818,7 +818,7 @@ ship "Deep River Transport"
 	sprite "ship/deep river"
 	thumbnail "thumbnail/deep river"
 	attributes
-		category "Heavy Freighter"
+		category "Space Liner"
 		licenses
 			Wanderer
 		"cost" 18300000
@@ -870,7 +870,7 @@ ship "Riptide"
 	sprite "ship/riptide"
 	thumbnail "thumbnail/riptide"
 	attributes
-		category "Transport"
+		category "Space Liner"
 		licenses
 			Wanderer
 		"cost" 21120000


### PR DESCRIPTION
**Content (Revision)**

## Summary
Current ship class categories are... inadequate. Most of the recent debate has covered lumping everything of a certain size into one category such as Super Heavy (unpopular), and the suitability of categories for certain ships such as the Raider (most recently).

This is an attempt to reconcile those problems in a way that enhances the existing framework instead of either tacking onto it or shoehorning it.

To that end, this introduces two new categories and shuffles a few ships around.

### Categories: 

- Transport: This is a word that is used widely to refer to the movement of both goods and people, including people who may be armed. The only really consistent thing about the use of this word both in games and IRL is that its associated with ships that _lack the meaningful capacity to defend themselves_. Typically they're either completely vulnerable, or vulnerable to anything that isn't at least two weight-classes smaller than them. Accordingly this is now a category reserved for ships on the smaller side in ES.
- Space Liner: At a certain point when you carry minimal cargo, minimal armaments, and have something like <10% required crew compared to the stock number of passengers, you're not just a transport anymore. You do one thing - and that is carry people. You might be big enough to shoot down an irritating Interceptor, but you certainly don't have any defence against something designed to take out ships larger than itself. You've specialised in transporting, people specifically, since you're not a freighter.
- Utility: When you're not built for war, and you're not built for cargo, and you're not built for ferrying people, but you can do all of those things and possibly serve as a floating home for some, what are you? The answer is utility, because that's what you have - the ability to do a lot of different things, better than many ships, but not as well as a dedicated ship in your weight class.
(Possible renames: "Utility Ship", "Utility Cruiser", "Utility Vessels"? I like just "Utility" tbh tho.)

### Reasoning: 

People have asked for a "Heavy Transport" category, but frankly that would then imply a "Light Transport" category which is a) boring, and b) only a partial solution to the ongoing ship category discussions. It would also lower overall naming diversity and leave the Interceptor on its lonesome as the only standout.

Ultimately ships like the Worldships, Heron, Auxilliary, etc. are not good fits for a category that's clearly flavoured for moving people, and other ships like the Raider, the Geodesic Geocoris in Hai Reveal, and even the Sojourner, are poor fits for being classified as either warships or freighters.

Therefore this diversification, from "flexible but helpless" into pathways of "dedicated and helpless" or "flexible and resilient" captures the diversity of that problem - and also (since freighters are also "dedicated and helpless") allows for alignment with in-universe expectations that support the categories.
In safe stable spaces you would expect to see Freighters, Space Liners, and only small Transports. (See: Hai)
In dangerous or unstable spaces you would expect to encounter a greater preponderance of Utility classes, and only heavier freighters and faster/durable Transports. (See: Korath)

### Specific Notes: 

1. The Water Bug was moved to be a Light Freighter - It has _the same_ hull mass as the Gull (another Light Freighter) and only a little more cargo. It's also thoroughly dwarfed by the Geocoris as a freighter, making its reclassification quite logical as it's _much_ closer to the Aphid by comparison.
2. The Saryd Traveler may describe itself in terms that imply utility, but it doesn't feel to me like it really carries enough to up it to the Utility category, its cargo space is still well down in the Light Freighter range, and while it has the weapon slots for utility. its mass and capacities are just a little low. - Making it a Transport also frees up the Sojourner to be a Utility category ship as the pinnacle of that design philosophy. - It also means that while the Arach do Freight and do it well, the Kimek and Saryd which both run Transports with this (Saryd freighters weren't really ever freighters) have their distinguishing philosophies in that as they go up in sizes, one gets more specialised, and one gets more versatile. (And neither attempt to claim competition with the Arach freighter classifications.)
3. The Star Queen actually has a very high required crew, and were it not for the description literally calling it out as a liner, would probably not be put in that category - I would in fact be inclined to leave it in Transport could I not already hear the objections.