### PR TITLE
fix(UI): Minor fixes for new scrolling planet panel

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -543,17 +543,6 @@ void MapDetailPanel::DrawInfo()
 	FillShader::Fill(Screen::TopLeft() + Point(size.X() / 2., size.Y() / 2. + startingY / 2.),
 		size + Point(0., startingY), back);
 
-	// Edges:
-	Point pos(Screen::Left(), Screen::Top() + startingY);
-	const Sprite *bottom = SpriteSet::Get("ui/bottom edge");
-	Point edgePos = pos + Point(.5 * size.X(), size.Y());
-	Point bottomOff(-25., .5 * bottom->Height());
-	SpriteShader::Draw(bottom, edgePos + bottomOff);
-
-	const Sprite *right = SpriteSet::Get("ui/right edge");
-	Point rightOff(.5 * (size.X() + right->Width()), -right->Height() / 2.);
-	SpriteShader::Draw(right, edgePos + rightOff);
-
 	const double startingX = mapInterface->GetValue("starting X");
 	Point uiPoint(Screen::Left() + startingX, Screen::Top() + startingY);
 
@@ -611,6 +600,17 @@ void MapDetailPanel::DrawInfo()
 	if(commodity == SHOW_GOVERNMENT)
 		PointerShader::Draw(uiPoint + Point(0., 20.), Point(1., 0.),
 			10.f, 10.f, 0.f, medium);
+
+	// Edges:
+	Point pos(Screen::Left(), Screen::Top() + startingY);
+	const Sprite *bottom = SpriteSet::Get("ui/bottom edge");
+	Point edgePos = pos + Point(.5 * size.X(), size.Y());
+	Point bottomOff(-25., .5 * bottom->Height());
+	SpriteShader::Draw(bottom, edgePos + bottomOff);
+
+	const Sprite *right = SpriteSet::Get("ui/right edge");
+	Point rightOff(.5 * (size.X() + right->Width()), -right->Height() / 2.);
+	SpriteShader::Draw(right, edgePos + rightOff);
 
 	const double relativeTradeY = mapInterface->GetValue("relative trade Y after planet");
 	uiPoint = Point(Screen::Left() + startingX, edgePos.Y() + relativeTradeY);

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -590,7 +590,7 @@ void MapDetailPanel::DrawInfo()
 	const Font &font = FontSet::Get(14);
 	string systemName = player.KnowsName(*selectedSystem) ?
 		selectedSystem->Name() : "Unexplored System";
-	const auto alignLeft = Layout(140, Truncate::BACK);
+	const auto alignLeft = Layout(145, Truncate::BACK);
 	font.Draw({systemName, alignLeft}, uiPoint + Point(0., -7.), medium);
 
 	governmentY = uiPoint.Y() + textMargin;

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -547,7 +547,7 @@ void MapDetailPanel::DrawInfo()
 	Point pos(Screen::Left(), Screen::Top() + startingY);
 	const Sprite *bottom = SpriteSet::Get("ui/bottom edge");
 	Point edgePos = pos + Point(.5 * size.X(), size.Y());
-	Point bottomOff(-30., .5 * bottom->Height());
+	Point bottomOff(-25., .5 * bottom->Height());
 	SpriteShader::Draw(bottom, edgePos + bottomOff);
 
 	const Sprite *right = SpriteSet::Get("ui/right edge");

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -605,11 +605,11 @@ void MapDetailPanel::DrawInfo()
 	Point pos(Screen::Left(), Screen::Top() + startingY);
 	const Sprite *bottom = SpriteSet::Get("ui/bottom edge");
 	Point edgePos = pos + Point(.5 * size.X(), size.Y());
-	Point bottomOff(-25., .5 * bottom->Height());
+	Point bottomOff(-26., .5 * bottom->Height() - 1);
 	SpriteShader::Draw(bottom, edgePos + bottomOff);
 
 	const Sprite *right = SpriteSet::Get("ui/right edge");
-	Point rightOff(.5 * (size.X() + right->Width()), -right->Height() / 2.);
+	Point rightOff(.5 * (size.X() + right->Width()) - 1, -right->Height() / 2.);
 	SpriteShader::Draw(right, edgePos + rightOff);
 
 	const double relativeTradeY = mapInterface->GetValue("relative trade Y after planet");


### PR DESCRIPTION
This PR addresses a few notes from #7065. In particular, the bottom and edge elements are aligned, and text should no longer spill out of the highlighted selection. Larger changes may be required, but these should clean it up for the time.