### PR TITLE
Increase the outfit name limit by 3 units

### DIFF
--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -112,7 +112,7 @@ protected:
 	static const int SIDE_WIDTH = SIDEBAR_WIDTH + INFOBAR_WIDTH;
 	static const int BUTTON_HEIGHT = 70;
 	static const int SHIP_SIZE = 250;
-	static const int OUTFIT_SIZE = 180;
+	static const int OUTFIT_SIZE = 183;
 
 
 protected:


### PR DESCRIPTION
This PR simply increases the outfit name max limit by 3 units, which means that the Heliarch H2H weapon can be displayed without dots:

Before:

![image](https://user-images.githubusercontent.com/85879619/182197443-85585bd4-a9c2-4723-bd97-c6faf945ea03.png)


After:

![image](https://cdn.discordapp.com/attachments/747839420115189801/1003664028599590932/unknown.png)