### PR TITLE
feat(saving): Write installed plugins to save file

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3081,7 +3081,8 @@ void PlayerInfo::Save(const string &path) const
 	startData.Save(out);
 
 	// Write plugins to player's save file for debugging.
-	if(!GameData::PluginAboutText().empty()) {
+	if(!GameData::PluginAboutText().empty())
+	{
 		out.Write();
 		out.WriteComment("Installed plugins:");
 		out.Write("plugins");

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3079,6 +3079,18 @@ void PlayerInfo::Save(const string &path) const
 	out.Write();
 	out.WriteComment("How you began:");
 	startData.Save(out);
+
+	// Write plugins to player's save file for debugging.
+	if(!GameData::PluginAboutText().empty()) {
+		out.Write();
+		out.WriteComment("Installed plugins:");
+		out.Write("plugins");
+		out.BeginChild();
+		for(const auto &plugin : GameData::PluginAboutText()) {
+			out.Write(plugin.first);
+		}
+		out.EndChild();
+	}
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3087,7 +3087,8 @@ void PlayerInfo::Save(const string &path) const
 		out.WriteComment("Installed plugins:");
 		out.Write("plugins");
 		out.BeginChild();
-		for(const auto &plugin : GameData::PluginAboutText()) {
+		for(const auto &plugin : GameData::PluginAboutText())
+		{
 			out.Write(plugin.first);
 		}
 		out.EndChild();

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3088,9 +3088,7 @@ void PlayerInfo::Save(const string &path) const
 		out.Write("plugins");
 		out.BeginChild();
 		for(const auto &plugin : GameData::PluginAboutText())
-		{
 			out.Write(plugin.first);
-		}
 		out.EndChild();
 	}
 }


### PR DESCRIPTION
A (much simpler) companion to #7057, this PR will write any plugins a player has installed to the end of their save file, if they have any. Between this and recording the game version, it should be much easier to debug any issues a pilot is having from the save file alone.