### PR TITLE
Adjust display of bursty continuous weapons

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -774,7 +774,7 @@ tip "% firing shields / second:"
 	`Relative shields loss when this weapon is fired, converted to loss per second to allow easy comparisons between different weapons.`
 
 tip "shots / second:"
-	`How many projectiles per second this weapon fires. Weapons that fire continuously do not require batteries if the ship's energy generation is higher than the weapon's energy consumption. Except weapons which fire continuously, but only in bursts. For these weapons, the percentage uptime will be given in brackets.`
+	`How many projectiles per second this weapon fires. Weapons that fire continuously do not require batteries if the ship's energy generation per second is higher than the weapon's firing energy per second. Some continuous fire weapons only fire a fraction of the time, in which case the ship's energy production must be higher than the weapon's firing energy divided by the firing time to not require batteries.`
 
 tip "turret turn rate:"
 	`How fast this turret turns to track its targets, in degrees per second.`

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -774,7 +774,7 @@ tip "% firing shields / second:"
 	`Relative shields loss when this weapon is fired, converted to loss per second to allow easy comparisons between different weapons.`
 
 tip "shots / second:"
-	`How many projectiles per second this weapon fires. Weapons that fire continuously do not require batteries if the ship's energy generation is higher than the weapon's energy consumption.`
+	`How many projectiles per second this weapon fires. Weapons that fire continuously do not require batteries if the ship's energy generation is higher than the weapon's energy consumption. Except weapons which fire continuously, but only in bursts. For these weapons, the percentage uptime will be given in brackets.`
 
 tip "turret turn rate:"
 	`How fast this turret turns to track its targets, in degrees per second.`

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -458,9 +458,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 			}
 	}
 
-	bool isContinuous = (reload <= 1);
-	double burstReload = outfit.BurstReload();
-	bool isContinuousBurst = (outfit.BurstCount() > 1 && burstReload <= 1 && outfit.TotalLifetime() == 1);
+	bool isContinuous = (reload <= 1. && outfit.TotalLifetime() == 1.);
+	bool isContinuousBurst = (outfit.BurstCount() > 1 && outfit.BurstReload() <= 1. && outfit.TotalLifetime() == 1.);
 	attributeLabels.emplace_back("shots / second:");
 	if(isContinuous)
 		attributeValues.emplace_back("continuous");

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -459,9 +459,13 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	}
 
 	bool isContinuous = (reload <= 1);
+	double burstReload = outfit.BurstReload();
+	bool isContinuousBurst = (outfit.BurstCount() > 1 && burstReload <= 1);
 	attributeLabels.emplace_back("shots / second:");
 	if(isContinuous)
 		attributeValues.emplace_back("continuous");
+	else if(isContinuousBurst)
+		attributeValues.emplace_back("continuous (" + Format::Number(lround(outfit.BurstReload() * 100. / reload)) + "%)");
 	else
 		attributeValues.emplace_back(Format::Number(60. / reload));
 	attributesHeight += 20;
@@ -517,7 +521,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 
 	// Add per-shot values to the table. If the weapon fires continuously,
 	// the values have already been added.
-	if(!isContinuous)
+	if(!(isContinuous || isContinuousBurst))
 	{
 		static const string PER_SHOT = " / shot:";
 		for(unsigned i = 0; i < VALUE_NAMES.size(); ++i)

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -460,7 +460,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 
 	bool isContinuous = (reload <= 1);
 	double burstReload = outfit.BurstReload();
-	bool isContinuousBurst = (outfit.BurstCount() > 1 && burstReload <= 1);
+	bool isContinuousBurst = (outfit.BurstCount() > 1 && burstReload <= 1 && outfit.TotalLifeTime() = 1);
 	attributeLabels.emplace_back("shots / second:");
 	if(isContinuous)
 		attributeValues.emplace_back("continuous");

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -460,7 +460,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 
 	bool isContinuous = (reload <= 1);
 	double burstReload = outfit.BurstReload();
-	bool isContinuousBurst = (outfit.BurstCount() > 1 && burstReload <= 1 && outfit.TotalLifeTime() = 1);
+	bool isContinuousBurst = (outfit.BurstCount() > 1 && burstReload <= 1 && outfit.TotalLifetime() == 1);
 	attributeLabels.emplace_back("shots / second:");
 	if(isContinuous)
 		attributeValues.emplace_back("continuous");

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -458,8 +458,9 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 			}
 	}
 
-	bool isContinuous = (reload <= 1. && outfit.TotalLifetime() == 1.);
-	bool isContinuousBurst = (outfit.BurstCount() > 1 && outfit.BurstReload() <= 1. && outfit.TotalLifetime() == 1.);
+	bool oneFrame = (outfit.TotalLifetime() == 1.);
+	bool isContinuous = (reload <= 1. && oneFrame);
+	bool isContinuousBurst = (outfit.BurstCount() > 1 && outfit.BurstReload() <= 1. && oneFrame);
 	attributeLabels.emplace_back("shots / second:");
 	if(isContinuous)
 		attributeValues.emplace_back("continuous");

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -521,7 +521,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 
 	// Add per-shot values to the table. If the weapon fires continuously,
 	// the values have already been added.
-	if(!(isContinuous || isContinuousBurst))
+	if(!isContinuous && !isContinuousBurst)
 	{
 		static const string PER_SHOT = " / shot:";
 		for(unsigned i = 0; i < VALUE_NAMES.size(); ++i)


### PR DESCRIPTION
**Feature/Bugfix**

## Feature Details
Weapons such as the Moonbeams or Slicers fire in bursts, but fire continuously (every frame) during those bursts.
This results in 'per shot' stats being displayed as well as a numerical shots per second value.
This PR changes OutfitInfoDisplay so weapons with a burst reload of 1 or less and a burst count of more than 1 and `TotalLifetime()`s of exactly 1 will be marked as `continuous (#%)` and won't display 'per shot' stats.
The `#` value is an integer percentage of up time (produced with `Format::Number(lround(burstReload * 100. / reload))`).

~~The Gatling Gun is also affected. Given it's characteristics, this may not be appropriate.~~

Also, the game will only treat weapons with a reload of 1 or less as continuous if the `TotalLifetime()` is exactly 1, so a non-laser weapon that fires 60 times per second will have a fire rate of 60 instead of appearing to be continuous. The Heavy Ion Cyclotron is an example.

## UI Screenshots
<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/20605679/183298644-6ec42583-35fb-4ccc-8d73-1a1bddc59b47.png)
![image](https://user-images.githubusercontent.com/20605679/183298660-e679db8b-1ed6-4714-a855-d16522896a21.png)
![image](https://user-images.githubusercontent.com/20605679/183298669-7d520806-1345-4e31-b9e0-e14d95dd80a9.png)

![image](https://user-images.githubusercontent.com/20605679/183305596-5984b014-f0e0-49d3-9ed9-7ef726f3d59c.png)

</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/20605679/183298433-abb990a8-8245-4205-a597-cfcea2223a39.png)
![image](https://user-images.githubusercontent.com/20605679/183298445-92deeda1-19c1-496a-930d-f488d8a2e162.png)
![image](https://user-images.githubusercontent.com/20605679/183298457-a2bb6215-06cc-4323-b733-13a8f810e098.png)

![image](https://user-images.githubusercontent.com/20605679/183305574-b2098f8e-2539-4025-a929-df3bee63906c.png)

</details>

## Testing Done
Viewed the OutfitInfoDisplay in the outfitter for all weapons in the continuous build.

## Performance Impact
N/A
