### PR TITLE
Force full screen for Steam Deck hardware

### DIFF
--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -23,6 +23,13 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <string>
 #include <sstream>
 
+// includes for steam deck hardware detection
+#ifdef __linux__
+#include <sys/statvfs.h>
+#include <sys/sysinfo.h>
+#include <fstream>
+#endif
+
 using namespace std;
 
 namespace {
@@ -46,6 +53,40 @@ namespace {
 
 		return false;
 	}
+
+// The following two functions are only available for Valve Steam Deck support.
+#ifdef __linux__
+	//Files::Read does not work because /sys bytes always returns 4096 for file
+	//size and does not match the contents byte size.
+	string ReadLinuxSysFile(const string &path) {
+		stringstream strStream;
+		ifstream ifs(path);
+		strStream << ifs.rdbuf();
+		string result = strStream.str();
+		// trim trailing newline
+		if (!result.empty() && result[result.length()-1] == '\n') {
+			result.erase(result.length()-1);
+		}
+		return result;
+	}
+
+	// Check if steam deck hardware by reading system vendor and product name.
+	bool IsSteamDeck() {
+		// code name Jupiter is the product for steam deck
+		string DECK_VENDOR = "Valve";
+		string DECK_PRODUCT = "Jupiter";
+
+		const string sys_vendor = "/sys/devices/virtual/dmi/id/sys_vendor";
+		const string sys_product = "/sys/devices/virtual/dmi/id/product_name";
+
+		if(!Files::Exists(sys_vendor) || !Files::Exists(sys_product))
+			return false;
+
+		string vendor = ReadLinuxSysFile(sys_vendor);
+		string product_name = ReadLinuxSysFile(sys_product);
+		return vendor == DECK_VENDOR && product_name == DECK_PRODUCT;
+	}
+#endif
 }
 
 
@@ -107,6 +148,12 @@ bool GameWindow::Init()
 
 	// Settings that must be declared before the window creation.
 	Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
+
+#ifdef __linux__
+	// Force fullscreen for steam deck
+	if(IsSteamDeck())
+		Preferences::Set("fullscreen", true);
+#endif
 
 	if(Preferences::Has("fullscreen"))
 		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -57,6 +57,10 @@ namespace {
 
 // The following two functions are only available for Valve Steam Deck support.
 #ifdef __linux__
+	// Code name Jupiter is the product for the steam deck.
+	const string DECK_VENDOR = "Valve";
+	const string DECK_PRODUCT = "Jupiter";
+
 	// Files::Read does not work because /sys bytes always returns 4096 for file
 	// size and does not match the contents byte size.
 	string ReadLinuxSysFile(const string &path)
@@ -74,10 +78,6 @@ namespace {
 	// Check if steam deck hardware by reading system vendor and product name.
 	bool IsSteamDeck()
 	{
-		// Code name Jupiter is the product for the steam deck.
-		string DECK_VENDOR = "Valve";
-		string DECK_PRODUCT = "Jupiter";
-
 		const string sys_vendor = "/sys/devices/virtual/dmi/id/sys_vendor";
 		const string sys_product = "/sys/devices/virtual/dmi/id/product_name";
 

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -25,9 +25,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 // Includes for steam deck hardware detection.
 #ifdef __linux__
+#include <fstream>
+
 #include <sys/statvfs.h>
 #include <sys/sysinfo.h>
-#include <fstream>
 #endif
 
 using namespace std;
@@ -56,8 +57,8 @@ namespace {
 
 // The following two functions are only available for Valve Steam Deck support.
 #ifdef __linux__
-	//Files::Read does not work because /sys bytes always returns 4096 for file
-	//size and does not match the contents byte size.
+	// Files::Read does not work because /sys bytes always returns 4096 for file
+	// size and does not match the contents byte size.
 	string ReadLinuxSysFile(const string &path)
 	{
 		stringstream strStream;

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -23,7 +23,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <string>
 #include <sstream>
 
-// includes for steam deck hardware detection
+// Includes for steam deck hardware detection.
 #ifdef __linux__
 #include <sys/statvfs.h>
 #include <sys/sysinfo.h>
@@ -58,21 +58,22 @@ namespace {
 #ifdef __linux__
 	//Files::Read does not work because /sys bytes always returns 4096 for file
 	//size and does not match the contents byte size.
-	string ReadLinuxSysFile(const string &path) {
+	string ReadLinuxSysFile(const string &path)
+	{
 		stringstream strStream;
 		ifstream ifs(path);
 		strStream << ifs.rdbuf();
 		string result = strStream.str();
 		// trim trailing newline
-		if (!result.empty() && result[result.length()-1] == '\n') {
-			result.erase(result.length()-1);
-		}
+		if(!result.empty() && result.back() == '\n')
+			result.pop_back();
 		return result;
 	}
 
 	// Check if steam deck hardware by reading system vendor and product name.
-	bool IsSteamDeck() {
-		// code name Jupiter is the product for steam deck
+	bool IsSteamDeck()
+	{
+		// Code name Jupiter is the product for the steam deck.
 		string DECK_VENDOR = "Valve";
 		string DECK_PRODUCT = "Jupiter";
 
@@ -150,7 +151,7 @@ bool GameWindow::Init()
 	Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
 
 #ifdef __linux__
-	// Force fullscreen for steam deck
+	// Force fullscreen for the Steam Deck.
 	if(IsSteamDeck())
 		Preferences::Set("fullscreen", true);
 #endif


### PR DESCRIPTION
Summary
-------

I know it isn't typical for specific hardware to be a part of the game but considering endless sky is published on steam I think it is worth directly supporting steam deck hardware.

On steam deck, the game starts maximized with a vertical pixel buffer instead of fullscreen.  This creates a blank area on the screen and causes controls to lose focus if the area is accidentally clicked.  I've been playing this regularly and miss-clicking the blank area happens very often during game play.

Feature Details
---------------

Use standard kernel APIs to read the hardware vendor and product name in order to determine if running on steam deck.  If steam deck is found, then force full screen ignoring user preference.

Testing Done
------------

* I initially tried using `Files::Read` but the way Linux kernel exposes `/sys` it is impossible to successfully read using default file functions within endless sky.
* I created a build and successfully launched this on steam deck.
* I launched on Linux (not steam deck) and user preferences for fullscreen and maximized are preserved.
* I edited `preferences.txt` and set `fullscreen 0` and `maximized 0`.  Launching the game successfully forces fullscreen with the preference `fullscreen 0`.

Performance Impact
------------------

None