### PR TITLE
Content(UI): Move the title on the main menu up

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -151,7 +151,7 @@ interface "menu background"
 	sprite "_menu/compass"
 		center 0 0
 	sprite "_menu/title"
-		center 0 -170
+		center 0 -200
 
 
 


### PR DESCRIPTION
Someone commented on this and now it annoys me every time I see it.

Before:
![image](https://user-images.githubusercontent.com/17688683/184410580-b5331f64-0fd0-4464-ba5a-9e7fb9f49d03.png)
![image](https://user-images.githubusercontent.com/17688683/184410508-98a2599f-731c-4b0b-84bd-2ac7997da862.png)

After:
![image](https://user-images.githubusercontent.com/17688683/184410655-a4823a76-1810-4739-9a00-7a856e0ece96.png)
![image](https://user-images.githubusercontent.com/17688683/184410433-612760d8-5f5b-434d-9435-0bff426f0438.png)
