### PR TITLE
feat(UI): show variant names in shipyards

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -193,7 +193,9 @@ void Ship::Load(const DataNode &node)
 					? "no key." : "key: " + child.Token(1)));
 			continue;
 		}
-		if(key == "sprite")
+		if(key == "shipyard display name" && child.Size() > 1)
+			shipyardDisplayName = child.Token(1);
+		else if(key == "sprite")
 			LoadSprite(child);
 		else if(child.Token(0) == "thumbnail" && child.Size() >= 2)
 			thumbnail = SpriteSet::Get(child.Token(1));
@@ -1033,6 +1035,15 @@ const string &Ship::PluralModelName() const
 const string &Ship::VariantName() const
 {
 	return variantName.empty() ? modelName : variantName;
+}
+
+
+
+// Get the name to display when this ship is being sold in a shipyard.
+// If no specific name was set, returns the same as ModelName();
+const string &Ship::ShipyardDisplayName() const
+{
+	return shipyardDisplayName.empty() ? modelName : shipyardDisplayName;
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -193,6 +193,8 @@ void Ship::Load(const DataNode &node)
 					? "no key." : "key: " + child.Token(1)));
 			continue;
 		}
+		if(key == "hull display name" && child.Size() > 1)
+			hullDisplayName = child.Token(1);
 		if(key == "shipyard display name" && child.Size() > 1)
 			shipyardDisplayName = child.Token(1);
 		else if(key == "sprite")
@@ -1019,7 +1021,7 @@ void Ship::SetModelName(const string &model)
 
 const string &Ship::ModelName() const
 {
-	return modelName;
+	return hullDisplayName.empty() ? modelName : hullDisplayName;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -144,6 +144,9 @@ public:
 	const std::string &PluralModelName() const;
 	// Get the name of this ship as a variant.
 	const std::string &VariantName() const;
+	// Get the name to display when this ship is being sold in a shipyard.
+	// If no specific name was set, returns the same as ModelName();
+	const std::string &ShipyardDisplayName() const;
 	// Get the generic noun (e.g. "ship") to be used when describing this ship.
 	const std::string &Noun() const;
 	// Get this ship's description.
@@ -458,6 +461,7 @@ private:
 	std::string modelName;
 	std::string pluralModelName;
 	std::string variantName;
+	std::string shipyardDisplayName;
 	std::string noun;
 	std::string description;
 	const Sprite *thumbnail = nullptr;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -461,6 +461,7 @@ private:
 	std::string modelName;
 	std::string pluralModelName;
 	std::string variantName;
+	std::string hullDisplayName;
 	std::string shipyardDisplayName;
 	std::string noun;
 	std::string description;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -514,7 +514,7 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 
 	// Draw the ship name.
 	const Font &font = FontSet::Get(14);
-	const string &name = ship.Name().empty() ? ship.ModelName() : ship.Name();
+	const string &name = ship.Name().empty() ? (ship.VariantName().empty() ? ship.ModelName() : ship.VariantName()) : ship.Name();
 	Point offset(-SIDEBAR_WIDTH / 2, -.5f * SHIP_SIZE + 10.f);
 	font.Draw({name, {SIDEBAR_WIDTH, Alignment::CENTER, Truncate::MIDDLE}},
 		center + offset, *GameData::Colors().Get("bright"));

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -514,7 +514,7 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 
 	// Draw the ship name.
 	const Font &font = FontSet::Get(14);
-	const string &name = ship.Name().empty() ? (ship.VariantName().empty() ? ship.ModelName() : ship.VariantName()) : ship.Name();
+	const string &name = ship.Name().empty() ? ship.VariantName() : ship.Name();
 	Point offset(-SIDEBAR_WIDTH / 2, -.5f * SHIP_SIZE + 10.f);
 	font.Draw({name, {SIDEBAR_WIDTH, Alignment::CENTER, Truncate::MIDDLE}},
 		center + offset, *GameData::Colors().Get("bright"));

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -514,7 +514,7 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 
 	// Draw the ship name.
 	const Font &font = FontSet::Get(14);
-	const string &name = ship.Name().empty() ? ship.VariantName() : ship.Name();
+	const string &name = ship.Name().empty() ? ship.ShipyardDisplayName() : ship.Name();
 	Point offset(-SIDEBAR_WIDTH / 2, -.5f * SHIP_SIZE + 10.f);
 	font.Draw({name, {SIDEBAR_WIDTH, Alignment::CENTER, Truncate::MIDDLE}},
 		center + offset, *GameData::Colors().Get("bright"));


### PR DESCRIPTION
**Feature:** This PR implements (sort of) the feature request detailed and discussed in issue #5325

## Feature Details
~If a ship being listed in a shipyard has a `VariantName()`, display that name instead of the `ModelName()`.~
Adds a new ship property: `"shipyard display name"`
If a ship has defines a `"shipyard display name"`, that name will be displayed when the ship appears in the shipyard, otherwise the normal `modelName` will be used. The `"shipyard display name"` is not used anywhere else.

An alternative would be to pass `ShopPanel::DrawShip()` the same `name` parameter that `ShipyardPanel::DrawItem()` gets because this is the name used to identify the ship in the `GameData::Ships()` Set and the name the content creator would have listed in the shipyard definition and so would be the variant name in the case of variants.
https://github.com/endless-sky/endless-sky/compare/master...warp-core:endless-sky:Show-variant-names-in-shipyards-but-differently-this-time
The alternative approach is demonstrated here, I think it is worse.

## UI Screenshots
Before:
![image](https://user-images.githubusercontent.com/20605679/184494883-7a3b8a3b-818f-4680-a6dc-f3f51480e585.png)

After:
![image](https://user-images.githubusercontent.com/20605679/184546416-f16d4449-b587-4e5d-ac41-ef8805e6cd11.png)


## Usage Examples
```
ship "Auxiliary (Cargo)"
    ...
    "shipyard display name" "Auxiliary - Cargo"
```

## Testing Done
Checked shipyard. All base ships appear as before.

## Performance Impact
N/A
