### PR TITLE
feat(testing): Move logging facility out of Files-class to its own class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,6 @@ libendless-sky.a
 # dlls needed to run the binary
 *.dll
 
-# Files::LogError output from unit tests
-errors.txt
-
 # Build Directories and toolchain-generated files
 build/
 obj/

--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		C4264774A89C0001B6FFC60E /* Hazard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C49D4EA08DF168A83B1C7B07 /* Hazard.cpp */; };
 		C7354A3E9C53D6C5E3CC352F /* TestData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02D34A71AE3BC4C93FC6865B /* TestData.cpp */; };
 		CE3F49A88B6DCBE09A711110 /* opengl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3754152958FBC924E9F76A9 /* opengl.cpp */; };
+		DAC24E909BF453D18AEE3DA3 /* Logger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7F240B4AC219841424A387A /* Logger.cpp */; };
 		DF8D57E11FC25842001525DA /* Dictionary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57DF1FC25842001525DA /* Dictionary.cpp */; };
 		DF8D57E51FC25889001525DA /* Visual.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57E21FC25889001525DA /* Visual.cpp */; };
 		DFAAE2A61FD4A25C0072C0A8 /* BatchDrawList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAAE2A21FD4A25C0072C0A8 /* BatchDrawList.cpp */; };
@@ -272,6 +273,7 @@
 		A3134EC4B1CCA5546A10C3EF /* TestContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestContext.cpp; path = source/TestContext.cpp; sourceTree = "<group>"; };
 		A3754152958FBC924E9F76A9 /* opengl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = opengl.cpp; path = source/opengl.cpp; sourceTree = "<group>"; };
 		A7E640C7A366679B27CCADAC /* GameLoadingPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameLoadingPanel.cpp; path = source/GameLoadingPanel.cpp; sourceTree = "<group>"; };
+		A7F240B4AC219841424A387A /* Logger.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Logger.cpp; path = source/Logger.cpp; sourceTree = "<group>"; };
 		A90633FD1EE602FD000DA6C0 /* LogbookPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LogbookPanel.cpp; path = source/LogbookPanel.cpp; sourceTree = "<group>"; };
 		A90633FE1EE602FD000DA6C0 /* LogbookPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LogbookPanel.h; path = source/LogbookPanel.h; sourceTree = "<group>"; };
 		A90C15D71D5BD55700708F3A /* Minable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Minable.cpp; path = source/Minable.cpp; sourceTree = "<group>"; };
@@ -517,6 +519,7 @@
 		A9CC52701950C9F6004E4E22 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		A9CC52711950C9F6004E4E22 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		A9D40D19195DFAA60086EE52 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		AE57401AA43232EDEABFAE13 /* Logger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Logger.h; path = source/Logger.h; sourceTree = "<group>"; };
 		B55C239B2303CE8A005C1A14 /* GameWindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameWindow.cpp; path = source/GameWindow.cpp; sourceTree = "<group>"; };
 		B55C239C2303CE8A005C1A14 /* GameWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameWindow.h; path = source/GameWindow.h; sourceTree = "<group>"; };
 		B590161121ED4A0E00799178 /* Utf8.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Utf8.cpp; path = source/text/Utf8.cpp; sourceTree = "<group>"; };
@@ -878,6 +881,8 @@
 				61FA4C2BB89E08C5E2B8B4B9 /* Variant.cpp */,
 				5EBC44769E84CF0C953D08B3 /* Variant.h */,
 				086E48E490C9BAD6660C7274 /* ExclusiveItem.h */,
+				A7F240B4AC219841424A387A /* Logger.cpp */,
+				AE57401AA43232EDEABFAE13 /* Logger.h */,
 			);
 			name = source;
 			sourceTree = "<group>";
@@ -1271,6 +1276,7 @@
 				F35E4D6EA465D71CDA282EBA /* MenuAnimationPanel.cpp in Sources */,
 				497849B2A4C5EA58A64D316C /* MapPlanetCard.cpp in Sources */,
 				920F40E0ADECA8926F423FDA /* Variant.cpp in Sources */,
+				DAC24E909BF453D18AEE3DA3 /* Logger.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -191,6 +191,8 @@
 		<Unit filename="source/LoadPanel.h" />
 		<Unit filename="source/LocationFilter.cpp" />
 		<Unit filename="source/LocationFilter.h" />
+		<Unit filename="source/Logger.cpp" />
+		<Unit filename="source/Logger.h" />
 		<Unit filename="source/LogbookPanel.cpp" />
 		<Unit filename="source/LogbookPanel.h" />
 		<Unit filename="source/MainPanel.cpp" />

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -12,8 +12,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Armament.h"
 
-#include "Files.h"
 #include "FireCommand.h"
+#include "Logger.h"
 #include "Outfit.h"
 #include "Ship.h"
 
@@ -56,7 +56,7 @@ int Armament::Add(const Outfit *outfit, int count)
 	// Do not equip weapons that do not define how they are mounted.
 	if(!isTurret && !outfit->Get("gun ports"))
 	{
-		Files::LogError("Error: Skipping unmountable outfit \"" + outfit->Name() + "\". Weapon outfits must specify either \"gun ports\" or \"turret mounts\".");
+		Logger::LogError("Error: Skipping unmountable outfit \"" + outfit->Name() + "\". Weapon outfits must specify either \"gun ports\" or \"turret mounts\".");
 		return 0;
 	}
 

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Audio.h"
 
 #include "Files.h"
+#include "Logger.h"
 #include "Music.h"
 #include "Point.h"
 #include "Random.h"
@@ -185,13 +186,13 @@ void Audio::CheckReferences()
 {
 	if(!isInitialized)
 	{
-		Files::LogError("Warning: audio could not be initialized. No audio will play.");
+		Logger::LogError("Warning: audio could not be initialized. No audio will play.");
 		return;
 	}
 
 	for(auto &&it : sounds)
 		if(it.second.Name().empty())
-			Files::LogError("Warning: sound \"" + it.first + "\" is referred to, but does not exist.");
+			Logger::LogError("Warning: sound \"" + it.first + "\" is referred to, but does not exist.");
 }
 
 
@@ -604,7 +605,7 @@ namespace {
 
 			// Unlock the mutex for the time-intensive part of the loop.
 			if(!sound->Load(path, name))
-				Files::LogError("Unable to load sound \"" + name + "\" from path: " + path);
+				Logger::LogError("Unable to load sound \"" + name + "\" from path: " + path);
 		}
 	}
 }

--- a/source/CollisionSet.cpp
+++ b/source/CollisionSet.cpp
@@ -13,8 +13,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "CollisionSet.h"
 
 #include "Body.h"
-#include "Files.h"
 #include "Government.h"
+#include "Logger.h"
 #include "Mask.h"
 #include "Point.h"
 #include "Projectile.h"
@@ -208,7 +208,7 @@ Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 		// Cap projectile velocity to prevent integer overflows.
 		if(!warned)
 		{
-			Files::LogError("Warning: maximum projectile velocity is " + to_string(MAX_VELOCITY));
+			Logger::LogError("Warning: maximum projectile velocity is " + to_string(MAX_VELOCITY));
 			warned = true;
 		}
 		Point newEnd = from + pVelocity.Unit() * USED_MAX_VELOCITY;

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -14,7 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "DataNode.h"
 #include "DataWriter.h"
-#include "Files.h"
+#include "Logger.h"
 #include "Random.h"
 
 #include <algorithm>
@@ -205,7 +205,7 @@ namespace {
 		string message = "Error decomposing complex condition expression:\nFound:\t";
 		for(const string &str : side)
 			message += " \"" + str + "\"";
-		Files::LogError(message);
+		Logger::LogError(message);
 	}
 
 	bool IsUnrepresentable(const string &token)
@@ -745,7 +745,7 @@ void ConditionSet::Expression::SubExpression::GenerateSequence()
 			{
 				if(operators.at(opIndex) != ")")
 				{
-					Files::LogError("Did not find matched parentheses:");
+					Logger::LogError("Did not find matched parentheses:");
 					PrintConditionError(ToStrings());
 					tokens.clear();
 					operators.clear();
@@ -768,7 +768,7 @@ void ConditionSet::Expression::SubExpression::GenerateSequence()
 
 		if(operators.at(workingIndex) == "(" || operators.at(workingIndex) == ")")
 		{
-			Files::LogError("Mismatched parentheses:" + ToString());
+			Logger::LogError("Mismatched parentheses:" + ToString());
 			tokens.clear();
 			operators.clear();
 			sequence.clear();
@@ -794,7 +794,7 @@ bool ConditionSet::Expression::SubExpression::AddOperation(vector<int> &data, si
 	if((leftIndex < tokens.size() && tokens.at(leftIndex).empty())
 			|| (rightIndex < tokens.size() && tokens.at(rightIndex).empty()))
 	{
-		Files::LogError("Unable to obtain valid operand for function \"" + operators.at(opIndex) + "\" with tokens:");
+		Logger::LogError("Unable to obtain valid operand for function \"" + operators.at(opIndex) + "\" with tokens:");
 		PrintConditionError(tokens);
 		tokens.clear();
 		operators.clear();

--- a/source/DataNode.cpp
+++ b/source/DataNode.cpp
@@ -12,7 +12,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "DataNode.h"
 
-#include "Files.h"
+#include "Logger.h"
 
 #include <algorithm>
 #include <cctype>
@@ -121,7 +121,7 @@ double DataNode::Value(const string &token)
 	// Allowed format: "[+-]?[0-9]*[.]?[0-9]*([eE][+-]?[0-9]*)?".
 	if(!IsNumber(token))
 	{
-		Files::LogError("Cannot convert value \"" + token + "\" to a number.");
+		Logger::LogError("Cannot convert value \"" + token + "\" to a number.");
 		return 0.;
 	}
 	const char *it = token.c_str();
@@ -246,7 +246,7 @@ list<DataNode>::const_iterator DataNode::end() const noexcept
 int DataNode::PrintTrace(const string &message) const
 {
 	if(!message.empty())
-		Files::LogError(message);
+		Logger::LogError(message);
 
 	// Recursively print all the parents of this node, so that the user can
 	// trace it back to the right point in the file.
@@ -271,11 +271,11 @@ int DataNode::PrintTrace(const string &message) const
 		if(hasSpace)
 			line += hasQuote ? '`' : '"';
 	}
-	Files::LogError(line);
+	Logger::LogError(line);
 
 	// Put an empty line in the log between each error message.
 	if(!message.empty())
-		Files::LogError("");
+		Logger::LogError("");
 
 	// Tell the caller what indentation level we're at now.
 	return indent;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -18,7 +18,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DamageDealt.h"
 #include "DamageProfile.h"
 #include "Effect.h"
-#include "Files.h"
 #include "FillShader.h"
 #include "Fleet.h"
 #include "Flotsam.h"
@@ -30,6 +29,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Government.h"
 #include "Hazard.h"
 #include "Interface.h"
+#include "Logger.h"
 #include "MapPanel.h"
 #include "Mask.h"
 #include "Messages.h"
@@ -324,7 +324,7 @@ void Engine::Place()
 		else if(!ship->GetSystem())
 		{
 			// Log this error.
-			Files::LogError("Engine::Place: Set fallback system for the NPC \"" + ship->Name() + "\" as it had no system");
+			Logger::LogError("Engine::Place: Set fallback system for the NPC \"" + ship->Name() + "\" as it had no system");
 			ship->SetSystem(player.GetSystem());
 		}
 

--- a/source/EsUuid.cpp
+++ b/source/EsUuid.cpp
@@ -12,7 +12,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "EsUuid.h"
 
-#include "Files.h"
+#include "Logger.h"
 #if defined(_WIN32)
 #include "text/Utf8.h"
 #endif
@@ -39,7 +39,7 @@ EsUuid::UuidType MakeUuid()
 	EsUuid::UuidType value;
 	RPC_STATUS status = UuidCreate(&value.id);
 	if(status == RPC_S_UUID_LOCAL_ONLY)
-		Files::LogError("Created locally unique UUID only");
+		Logger::LogError("Created locally unique UUID only");
 	else if(status == RPC_S_UUID_NO_ADDRESS)
 		throw std::runtime_error("Failed to create UUID");
 
@@ -72,7 +72,7 @@ std::string Serialize(const UUID &id)
 
 	std::string result = (status == RPC_S_OK) ? Utf8::ToUTF8(buf) : "";
 	if(result.empty())
-		Files::LogError("Failed to serialize UUID!");
+		Logger::LogError("Failed to serialize UUID!");
 	else
 		RpcStringFreeW(reinterpret_cast<RPC_WSTR *>(&buf));
 
@@ -183,7 +183,7 @@ EsUuid::EsUuid(const std::string &input)
 	}
 	catch (const std::invalid_argument &err)
 	{
-		Files::LogError(err.what());
+		Logger::LogError(err.what());
 	}
 }
 

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Files.h"
 
 #include "File.h"
+#include "Logger.h"
 
 #include <SDL2/SDL.h>
 
@@ -47,7 +48,7 @@ namespace {
 	string savePath;
 	string testPath;
 
-	mutex errorMutex;
+	mutex errorFileMutex;
 	File errorLog;
 
 	// Convert windows-style directory separators ('\\') to standard '/'.
@@ -434,14 +435,14 @@ void Files::Copy(const string &from, const string &to)
 	// Preserve the timestamps of the original file.
 	struct stat buf;
 	if(stat(from.c_str(), &buf))
-		LogError("Error: Cannot stat \"" + from + "\".");
+		Logger::LogError("Error: Cannot stat \"" + from + "\".");
 	else
 	{
 		struct utimbuf times;
 		times.actime = buf.st_atime;
 		times.modtime = buf.st_mtime;
 		if(utime(to.c_str(), &times))
-			LogError("Error: Failed to preserve the timestamps for \"" + to + "\".");
+			Logger::LogError("Error: Failed to preserve the timestamps for \"" + to + "\".");
 	}
 #endif
 }
@@ -545,10 +546,9 @@ void Files::Write(FILE *file, const string &data)
 
 
 
-void Files::LogError(const string &message)
+void Files::LogErrorToFile(const string &message)
 {
-	lock_guard<mutex> lock(errorMutex);
-	cerr << message << endl;
+	lock_guard<mutex> lock(errorFileMutex);
 	if(!errorLog)
 	{
 		errorLog = File(config + "errors.txt", true);

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -48,7 +48,6 @@ namespace {
 	string savePath;
 	string testPath;
 
-	mutex errorFileMutex;
 	File errorLog;
 
 	// Convert windows-style directory separators ('\\') to standard '/'.
@@ -548,7 +547,6 @@ void Files::Write(FILE *file, const string &data)
 
 void Files::LogErrorToFile(const string &message)
 {
-	lock_guard<mutex> lock(errorFileMutex);
 	if(!errorLog)
 	{
 		errorLog = File(config + "errors.txt", true);

--- a/source/Files.h
+++ b/source/Files.h
@@ -66,6 +66,9 @@ public:
 	static void Write(const std::string &path, const std::string &data);
 	static void Write(FILE *file, const std::string &data);
 
+	// Logging to the error-log. Actual calls should be done through Logger
+	// and not directly here to ensure that other logging actions also
+	// happen (and to ensure thread safety on the logging).
 	static void LogErrorToFile(const std::string &message);
 };
 

--- a/source/Files.h
+++ b/source/Files.h
@@ -66,7 +66,7 @@ public:
 	static void Write(const std::string &path, const std::string &data);
 	static void Write(FILE *file, const std::string &data);
 
-	static void LogError(const std::string &message);
+	static void LogErrorToFile(const std::string &message);
 };
 
 

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -13,9 +13,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Fleet.h"
 
 #include "DataNode.h"
-#include "Files.h"
 #include "GameData.h"
 #include "Government.h"
+#include "Logger.h"
 #include "Phrase.h"
 #include "pi.h"
 #include "Planet.h"
@@ -256,7 +256,7 @@ void Fleet::RemoveInvalidVariants()
 	if(!count)
 		return;
 
-	Files::LogError("Warning: " + (fleetName.empty() ? "unnamed fleet" : "fleet \"" + fleetName + "\"")
+	Logger::LogError("Warning: " + (fleetName.empty() ? "unnamed fleet" : "fleet \"" + fleetName + "\"")
 		+ ": Removing " + to_string(count) + " invalid " + (count > 1 ? "variants" : "variant")
 		+ " (" + to_string(total - variants.TotalWeight()) + " of " + to_string(total) + " weight)");
 }
@@ -379,7 +379,7 @@ void Fleet::Enter(const System &system, list<shared_ptr<Ship>> &ships, const Pla
 		if(!object)
 		{
 			// Log this error.
-			Files::LogError("Fleet::Enter: Unable to find valid stellar object for planet \""
+			Logger::LogError("Fleet::Enter: Unable to find valid stellar object for planet \""
 				+ planet->TrueName() + "\" in system \"" + system.Name() + "\"");
 			return;
 		}
@@ -560,7 +560,7 @@ vector<shared_ptr<Ship>> Fleet::Instantiate(const vector<const Ship *> &ships) c
 		// At least one of this variant's ships is valid, but we should avoid spawning any that are not defined.
 		if(!model->IsValid())
 		{
-			Files::LogError("Warning: Skipping invalid ship model \"" + model->ModelName() + "\" in fleet \"" + fleetName + "\".");
+			Logger::LogError("Warning: Skipping invalid ship model \"" + model->ModelName() + "\" in fleet \"" + fleetName + "\".");
 			continue;
 		}
 

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Files.h"
 #include "ImageBuffer.h"
+#include "Logger.h"
 #include "Screen.h"
 
 #include "opengl.h"
@@ -39,7 +40,7 @@ namespace {
 		string message = SDL_GetError();
 		if(!message.empty())
 		{
-			Files::LogError("(SDL message: \"" + message + "\")");
+			Logger::LogError("(SDL message: \"" + message + "\")");
 			SDL_ClearError();
 			return true;
 		}
@@ -82,7 +83,7 @@ bool GameWindow::Init()
 		return false;
 	}
 	if(mode.refresh_rate && mode.refresh_rate < 60)
-		Files::LogError("Warning: low monitor frame rate detected (" + to_string(mode.refresh_rate) + "). The game will run more slowly.");
+		Logger::LogError("Warning: low monitor frame rate detected (" + to_string(mode.refresh_rate) + "). The game will run more slowly.");
 
 	// Make the window just slightly smaller than the monitor resolution.
 	int minWidth = 640;
@@ -396,7 +397,7 @@ bool GameWindow::HasSwizzle()
 void GameWindow::ExitWithError(const string& message, bool doPopUp)
 {
 	// Print the error message in the terminal and the error file.
-	Files::LogError(message);
+	Logger::LogError(message);
 	checkSDLerror();
 
 	// Show the error message in a message box.

--- a/source/ImageBuffer.cpp
+++ b/source/ImageBuffer.cpp
@@ -13,7 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "ImageBuffer.h"
 
 #include "File.h"
-#include "Files.h"
+#include "Logger.h"
 
 #include <png.h>
 #include <jpeglib.h>
@@ -226,7 +226,7 @@ namespace {
 		} catch (const bad_alloc &) {
 			png_destroy_read_struct(&png, &info, nullptr);
 			const string message = "Failed to allocate contiguous memory for \"" + path + "\"";
-			Files::LogError(message);
+			Logger::LogError(message);
 			throw runtime_error(message);
 		}
 		// Make sure this frame's dimensions are valid.
@@ -235,9 +235,9 @@ namespace {
 			png_destroy_read_struct(&png, &info, nullptr);
 			string message = "Skipped processing \"" + path + "\":\n\tAll image frames must have equal ";
 			if(width && width != buffer.Width())
-				Files::LogError(message + "width: expected " + to_string(buffer.Width()) + " but was " + to_string(width));
+				Logger::LogError(message + "width: expected " + to_string(buffer.Width()) + " but was " + to_string(width));
 			if(height && height != buffer.Height())
-				Files::LogError(message + "height: expected " + to_string(buffer.Height()) + " but was " + to_string(height));
+				Logger::LogError(message + "height: expected " + to_string(buffer.Height()) + " but was " + to_string(height));
 			return false;
 		}
 
@@ -303,7 +303,7 @@ namespace {
 		} catch (const bad_alloc &) {
 			jpeg_destroy_decompress(&cinfo);
 			const string message = "Failed to allocate contiguous memory for \"" + path + "\"";
-			Files::LogError(message);
+			Logger::LogError(message);
 			throw runtime_error(message);
 		}
 		// Make sure this frame's dimensions are valid.
@@ -312,9 +312,9 @@ namespace {
 			jpeg_destroy_decompress(&cinfo);
 			string message = "Skipped processing \"" + path + "\":\t\tAll image frames must have equal ";
 			if(width && width != buffer.Width())
-				Files::LogError(message + "width: expected " + to_string(buffer.Width()) + " but was " + to_string(width));
+				Logger::LogError(message + "width: expected " + to_string(buffer.Width()) + " but was " + to_string(width));
 			if(height && height != buffer.Height())
-				Files::LogError(message + "height: expected " + to_string(buffer.Height()) + " but was " + to_string(height));
+				Logger::LogError(message + "height: expected " + to_string(buffer.Height()) + " but was " + to_string(height));
 			return false;
 		}
 

--- a/source/ImageSet.cpp
+++ b/source/ImageSet.cpp
@@ -12,8 +12,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "ImageSet.h"
 
-#include "Files.h"
 #include "GameData.h"
+#include "Logger.h"
 #include "Mask.h"
 #include "MaskManager.h"
 #include "Sprite.h"
@@ -103,7 +103,7 @@ namespace {
 		// Valid animations (or stills) begin with frame 0.
 		if(frameData.begin()->first != 0)
 		{
-			Files::LogError(prefix + "ignored " + (is2x ? "@2x " : "") + "frame " + to_string(frameData.begin()->first)
+			Logger::LogError(prefix + "ignored " + (is2x ? "@2x " : "") + "frame " + to_string(frameData.begin()->first)
 					+ " (" + to_string(frameData.size()) + " ignored in total). Animations must start at frame 0.");
 			return;
 		}
@@ -123,7 +123,7 @@ namespace {
 		if(next != frameData.end())
 		{
 			size_t ignored = distance(next, frameData.end());
-			Files::LogError(prefix + "missing " + (is2x ? "@2x " : "") + "frame " + to_string(it->first + 1) + " (" + to_string(ignored)
+			Logger::LogError(prefix + "missing " + (is2x ? "@2x " : "") + "frame " + to_string(it->first + 1) + " (" + to_string(ignored)
 					+ (ignored > 1 ? " frames" : " frame") + " ignored in total).");
 		}
 	}
@@ -204,7 +204,7 @@ void ImageSet::ValidateFrames() noexcept(false)
 	// Drop any @2x paths that will not be used.
 	if(paths[1].size() > paths[0].size())
 	{
-		Files::LogError(prefix + to_string(paths[1].size() - paths[0].size())
+		Logger::LogError(prefix + to_string(paths[1].size() - paths[0].size())
 				+ " extra frames for the @2x sprite will be ignored.");
 		paths[1].resize(paths[0].size());
 	}
@@ -235,12 +235,12 @@ void ImageSet::Load() noexcept(false)
 	for(size_t i = 0; i < frames; ++i)
 	{
 		if(!buffer[0].Read(paths[0][i], i))
-			Files::LogError("Failed to read image data for \"" + name + "\" frame #" + to_string(i));
+			Logger::LogError("Failed to read image data for \"" + name + "\" frame #" + to_string(i));
 		else if(makeMasks)
 		{
 			masks[i].Create(buffer[0], i);
 			if(!masks[i].IsLoaded())
-				Files::LogError("Failed to create collision mask for \"" + name + "\" frame #" + to_string(i));
+				Logger::LogError("Failed to create collision mask for \"" + name + "\" frame #" + to_string(i));
 		}
 	}
 	// Now, load the 2x sprites, if they exist. Because the number of 1x frames
@@ -248,7 +248,7 @@ void ImageSet::Load() noexcept(false)
 	for(size_t i = 0; i < frames && i < paths[1].size(); ++i)
 		if(!buffer[1].Read(paths[1][i], i))
 		{
-			Files::LogError("Removing @2x frames for \"" + name + "\" due to read error");
+			Logger::LogError("Removing @2x frames for \"" + name + "\" due to read error");
 			buffer[1].Clear();
 			break;
 		}
@@ -260,7 +260,7 @@ void ImageSet::Load() noexcept(false)
 			|| (name.length() > 7 && !name.compare(0, 7, "outfit/"))
 			|| (name.length() > 10 && !name.compare(0, 10, "thumbnail/"))
 	))
-		Files::LogError("Warning: image \"" + name + "\" will be blurry since width and/or height are not even ("
+		Logger::LogError("Warning: image \"" + name + "\" will be blurry since width and/or height are not even ("
 			+ to_string(buffer[0].Width()) + "x" + to_string(buffer[0].Height()) + ").");
 }
 

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -1,0 +1,42 @@
+/* Logger.cpp
+Copyright (c) 2022 by Peter van der Meer
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "Logger.h"
+
+#include <iostream>
+#include <mutex>
+
+using namespace std;
+
+namespace {
+	std::function<void(const string &message)> logErrorCallback = nullptr;
+	mutex logErrorMutex;
+}
+
+
+
+void Logger::SetLogErrorCallback(std::function<void(const string &message)> callback)
+{
+	logErrorCallback = callback;
+}
+
+
+
+void Logger::LogError(const string &message)
+{
+	lock_guard<mutex> lock(logErrorMutex);
+	// Log by default to stderr.
+	cerr << message << endl;
+	// Perform additional logging through callback if any is registered.
+	if(logErrorCallback)
+		logErrorCallback(message);
+}

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -18,7 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 using namespace std;
 
 namespace {
-	std::function<void(const string &message)> logErrorCallback = nullptr;
+	function<void(const string &message)> logErrorCallback = nullptr;
 	mutex logErrorMutex;
 }
 

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -12,6 +12,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Logger.h"
 
+#include <iostream>
 #include <mutex>
 
 using namespace std;
@@ -33,7 +34,9 @@ void Logger::SetLogErrorCallback(function<void(const string &message)> callback)
 void Logger::LogError(const string &message)
 {
 	lock_guard<mutex> lock(logErrorMutex);
-	// Perform logging through callback if any is registered.
+	// Log by default to stderr.
+	cerr << message << endl;
+	// Perform additional logging through callback if any is registered.
 	if(logErrorCallback)
 		logErrorCallback(message);
 }

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -12,7 +12,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Logger.h"
 
-#include <iostream>
 #include <mutex>
 
 using namespace std;
@@ -34,9 +33,7 @@ void Logger::SetLogErrorCallback(function<void(const string &message)> callback)
 void Logger::LogError(const string &message)
 {
 	lock_guard<mutex> lock(logErrorMutex);
-	// Log by default to stderr.
-	cerr << message << endl;
-	// Perform additional logging through callback if any is registered.
+	// Perform logging through callback if any is registered.
 	if(logErrorCallback)
 		logErrorCallback(message);
 }

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -24,7 +24,7 @@ namespace {
 
 
 
-void Logger::SetLogErrorCallback(std::function<void(const string &message)> callback)
+void Logger::SetLogErrorCallback(function<void(const string &message)> callback)
 {
 	logErrorCallback = callback;
 }

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -26,7 +26,7 @@ namespace {
 
 void Logger::SetLogErrorCallback(function<void(const string &message)> callback)
 {
-	logErrorCallback = callback;
+	logErrorCallback = std::move(callback);
 }
 
 

--- a/source/Logger.h
+++ b/source/Logger.h
@@ -1,0 +1,32 @@
+/* Logger.h
+Copyright (c) 2022 by Peter van der Meer
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef ES_LOGGER_H_
+#define ES_LOGGER_H_
+
+#include <functional>
+#include <string>
+
+
+
+// Default static logging facility, different programs might have different
+// conventions and requirements on how they handle logging, so the running
+// program should register its preferred logging facility when starting up.
+class Logger {
+public:
+	static void SetLogErrorCallback(std::function<void(const std::string &message)> callback);
+	static void LogError(const std::string &message);
+};
+
+
+
+#endif

--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -12,8 +12,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Mask.h"
 
-#include "Files.h"
 #include "ImageBuffer.h"
+#include "Logger.h"
 
 #include <algorithm>
 #include <cmath>
@@ -31,7 +31,7 @@ namespace {
 		const int numPixels = width * height;
 		const uint32_t *begin = image.Pixels() + frame * numPixels;
 		auto LogError = [width, height](string reason) {
-			Files::LogError("Unable to create mask for " + to_string(width) + "x" + to_string(height) + " px image: " + std::move(reason));
+			Logger::LogError("Unable to create mask for " + to_string(width) + "x" + to_string(height) + " px image: " + std::move(reason));
 		};
 		raw.clear();
 

--- a/source/MaskManager.cpp
+++ b/source/MaskManager.cpp
@@ -12,7 +12,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "MaskManager.h"
 
-#include "Files.h"
+#include "Logger.h"
 #include "Sprite.h"
 
 using namespace std;
@@ -49,7 +49,7 @@ void MaskManager::RegisterScale(const Sprite *sprite, double scale)
 	if(lb == scales.end() || lb->first != scale)
 		scales.emplace_hint(lb, scale, vector<Mask>{});
 	else if(!lb->second.empty())
-		Files::LogError("Collision mask for sprite \"" + sprite->Name() + "\" at scale " + PrintScale(scale) + " was already generated.");
+		Logger::LogError("Collision mask for sprite \"" + sprite->Name() + "\" at scale " + PrintScale(scale) + " was already generated.");
 }
 
 
@@ -93,7 +93,7 @@ const std::vector<Mask> &MaskManager::GetMasks(const Sprite *sprite, double scal
 	if(scalesIt == spriteMasks.end())
 	{
 		if(warned.insert(make_pair(sprite, true)).second)
-			Files::LogError("Warning: sprite \"" + sprite->Name() + "\": no collision masks found.");
+			Logger::LogError("Warning: sprite \"" + sprite->Name() + "\": no collision masks found.");
 		return EMPTY;
 	}
 
@@ -114,7 +114,7 @@ const std::vector<Mask> &MaskManager::GetMasks(const Sprite *sprite, double scal
 			for(auto &&s : scales)
 				warning += "\n\t\t" + PrintScale(s.first);
 		}
-		Files::LogError(warning);
+		Logger::LogError(warning);
 	}
 	return EMPTY;
 }

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -22,6 +22,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Interface.h"
 #include "Information.h"
 #include "LoadPanel.h"
+#include "Logger.h"
 #include "MainPanel.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
@@ -60,7 +61,7 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
 		credits = Format::Split(Files::Read(Files::Resources() + "credits.txt"), "\n");
 	else if(showCreditsWarning)
 	{
-		Files::LogError("Warning: interface \"main menu\" does not contain a box for \"credits\"");
+		Logger::LogError("Warning: interface \"main menu\" does not contain a box for \"credits\"");
 		showCreditsWarning = false;
 	}
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -16,10 +16,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataWriter.h"
 #include "Dialog.h"
 #include "DistanceMap.h"
-#include "Files.h"
 #include "text/Format.h"
 #include "GameData.h"
 #include "Government.h"
+#include "Logger.h"
 #include "Messages.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
@@ -1329,7 +1329,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 		reason = n.Validate(true);
 	if(!reason.empty())
 	{
-		Files::LogError("Instantiation Error: NPC template in mission \""
+		Logger::LogError("Instantiation Error: NPC template in mission \""
 			+ Identifier() + "\" uses invalid " + std::move(reason));
 		return result;
 	}
@@ -1347,7 +1347,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	}
 	if(ait != actions.end())
 	{
-		Files::LogError("Instantiation Error: Action \"" + TriggerToText(ait->first) + "\" in mission \""
+		Logger::LogError("Instantiation Error: Action \"" + TriggerToText(ait->first) + "\" in mission \""
 			+ Identifier() + "\" uses invalid " + std::move(reason));
 		return result;
 	}
@@ -1363,7 +1363,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	}
 	if(oit != onEnter.end())
 	{
-		Files::LogError("Instantiation Error: Action \"on enter '" + oit->first->Name() + "'\" in mission \""
+		Logger::LogError("Instantiation Error: Action \"on enter '" + oit->first->Name() + "'\" in mission \""
 			+ Identifier() + "\" uses invalid " + std::move(reason));
 		return result;
 	}
@@ -1379,7 +1379,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	}
 	if(eit != genericOnEnter.end())
 	{
-		Files::LogError("Instantiation Error: Generic \"on enter\" action in mission \""
+		Logger::LogError("Instantiation Error: Generic \"on enter\" action in mission \""
 			+ Identifier() + "\" uses invalid " + std::move(reason));
 		return result;
 	}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -23,6 +23,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "GameData.h"
 #include "Government.h"
 #include "Hardpoint.h"
+#include "Logger.h"
 #include "Messages.h"
 #include "Outfit.h"
 #include "Person.h"
@@ -831,7 +832,7 @@ map<const shared_ptr<Ship>, vector<string>> PlayerInfo::FlightCheck() const
 				// The bays should always be empty. But if not, count that ship too.
 				if(bay.ship)
 				{
-					Files::LogError("Expected bay to be empty for " + ship->ModelName() + ": " + ship->Name());
+					Logger::LogError("Expected bay to be empty for " + ship->ModelName() + ": " + ship->Name());
 					categoryCount[bay.ship->Attributes().Category()].emplace_back(bay.ship);
 				}
 			}
@@ -2479,7 +2480,7 @@ void PlayerInfo::ValidateLoad()
 		else
 			warning += " (no ships could supply a valid player location).";
 
-		Files::LogError(warning);
+		Logger::LogError(warning);
 	}
 
 	// As a result of external game data changes (e.g. unloading a mod) it's possible the player ended up
@@ -2487,13 +2488,13 @@ void PlayerInfo::ValidateLoad()
 	if(planet && !system)
 	{
 		system = planet->GetSystem();
-		Files::LogError("Warning: player system was not specified. Defaulting to the specified planet's system.");
+		Logger::LogError("Warning: player system was not specified. Defaulting to the specified planet's system.");
 	}
 	if(!planet || !planet->IsValid() || !system || !system->IsValid())
 	{
 		system = &startData.GetSystem();
 		planet = &startData.GetPlanet();
-		Files::LogError("Warning: player system and/or planet was not valid. Defaulting to the starting location.");
+		Logger::LogError("Warning: player system and/or planet was not valid. Defaulting to the starting location.");
 	}
 
 	// Every ship ought to have specified a valid location, but if not,
@@ -2503,7 +2504,7 @@ void PlayerInfo::ValidateLoad()
 		if(!ship->GetSystem() || !ship->GetSystem()->IsValid())
 		{
 			ship->SetSystem(system);
-			Files::LogError("Warning: player ship \"" + ship->Name()
+			Logger::LogError("Warning: player ship \"" + ship->Name()
 				+ "\" did not specify a valid system. Defaulting to the player's system.");
 		}
 		// In-system ships that aren't on a valid planet should get moved to the player's planet
@@ -2511,7 +2512,7 @@ void PlayerInfo::ValidateLoad()
 		if(ship->GetSystem() == system && ship->GetPlanet() && !ship->GetPlanet()->IsValid())
 		{
 			ship->SetPlanet(planet);
-			Files::LogError("Warning: in-system player ship \"" + ship->Name()
+			Logger::LogError("Warning: in-system player ship \"" + ship->Name()
 				+ "\" specified an invalid planet. Defaulting to the player's planet.");
 		}
 		// Owned ships that are not in the player's system always start in flight.
@@ -2520,7 +2521,7 @@ void PlayerInfo::ValidateLoad()
 	// Validate the travel plan.
 	if(travelDestination && !travelDestination->IsValid())
 	{
-		Files::LogError("Warning: removed invalid travel plan destination \"" + travelDestination->TrueName() + ".\"");
+		Logger::LogError("Warning: removed invalid travel plan destination \"" + travelDestination->TrueName() + ".\"");
 		travelDestination = nullptr;
 	}
 	if(!travelPlan.empty() && any_of(travelPlan.begin(), travelPlan.end(),
@@ -2528,7 +2529,7 @@ void PlayerInfo::ValidateLoad()
 	{
 		travelPlan.clear();
 		travelDestination = nullptr;
-		Files::LogError("Warning: reset the travel plan due to use of invalid system(s).");
+		Logger::LogError("Warning: reset the travel plan due to use of invalid system(s).");
 	}
 
 	// For old saves, default to the first start condition (the default "Endless Sky" start).

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataWriter.h"
 #include "Files.h"
 #include "GameWindow.h"
+#include "Logger.h"
 #include "Screen.h"
 
 #include <algorithm>
@@ -196,7 +197,7 @@ bool Preferences::ToggleVSync()
 		if(!GameWindow::SetVSync(static_cast<VSync>(targetIndex)))
 		{
 			// Restore original saved setting.
-			Files::LogError("Unable to change VSync state");
+			Logger::LogError("Unable to change VSync state");
 			GameWindow::SetVSync(static_cast<VSync>(vsyncIndex));
 			return false;
 		}

--- a/source/Shader.cpp
+++ b/source/Shader.cpp
@@ -12,7 +12,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Shader.h"
 
-#include "Files.h"
+#include "Logger.h"
 
 #include <cctype>
 #include <cstring>
@@ -50,7 +50,7 @@ Shader::Shader(const char *vertex, const char *fragment)
 		vector<GLchar> infoLog(maxLength);
 		glGetProgramInfoLog(program, maxLength, &maxLength, &infoLog[0]);
 		string error(infoLog.data());
-		Files::LogError(error);
+		Logger::LogError(error);
 
 		throw runtime_error("Linking OpenGL shader program failed.");
 	}
@@ -140,7 +140,7 @@ GLuint Shader::Compile(const char *str, GLenum type)
 
 		glGetShaderInfoLog(object, SIZE, &length, message);
 		error += string(message, length);
-		Files::LogError(error);
+		Logger::LogError(error);
 		throw runtime_error("Shader compilation failed.");
 	}
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -18,11 +18,11 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataNode.h"
 #include "DataWriter.h"
 #include "Effect.h"
-#include "Files.h"
 #include "Flotsam.h"
 #include "text/Format.h"
 #include "GameData.h"
 #include "Government.h"
+#include "Logger.h"
 #include "Mask.h"
 #include "Messages.h"
 #include "Phrase.h"
@@ -143,7 +143,7 @@ namespace {
 	void LogWarning(const string &modelName, const string &name, string &&warning)
 	{
 		string shipID = modelName + (name.empty() ? ": " : " \"" + name + "\": ");
-		Files::LogError(shipID + std::move(warning));
+		Logger::LogError(shipID + std::move(warning));
 	}
 }
 
@@ -648,7 +648,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			message += to_string(undefinedOutfits.size()) + " undefined outfit" + (plural ? "s" : "") + " installed.";
 		}
 
-		Files::LogError(message);
+		Logger::LogError(message);
 	}
 	// Inspect the ship's armament to ensure that guns are in gun ports and
 	// turrets are in turret mounts. This can only happen when the armament
@@ -667,7 +667,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			warning += (hardpoint.IsTurret() ? "turret but is a gun.\n\tturret" : "gun but is a turret.\n\tgun");
 			warning += to_string(2. * hardpoint.GetPoint().X()) + " " + to_string(2. * hardpoint.GetPoint().Y());
 			warning += " \"" + outfit->Name() + "\"";
-			Files::LogError(warning);
+			Logger::LogError(warning);
 		}
 	}
 	cargo.SetSize(attributes.Get("cargo space"));
@@ -730,7 +730,7 @@ void Ship::FinishLoading(bool isNewInstance)
 		outfitNames << "has outfits:\n";
 		for(const auto &it : outfits)
 			outfitNames << '\t' << it.second << " " + it.first->Name() << endl;
-		Files::LogError(message + warning + outfitNames.str());
+		Logger::LogError(message + warning + outfitNames.str());
 	}
 
 	// Ships read from a save file may have non-default shields or hull.
@@ -750,12 +750,12 @@ void Ship::FinishLoading(bool isNewInstance)
 			"Cannot reach target system \"" + targetSystem->Name();
 		if(!currentSystem)
 		{
-			Files::LogError(message + "\" (no current system).");
+			Logger::LogError(message + "\" (no current system).");
 			targetSystem = nullptr;
 		}
 		else if(!currentSystem->Links().count(targetSystem) && (!jumpRange || !currentSystem->JumpNeighbors(jumpRange).count(targetSystem)))
 		{
-			Files::LogError(message + "\" by hyperlink or jump from system \"" + currentSystem->Name() + ".\"");
+			Logger::LogError(message + "\" by hyperlink or jump from system \"" + currentSystem->Name() + ".\"");
 			targetSystem = nullptr;
 		}
 	}

--- a/source/SpriteSet.cpp
+++ b/source/SpriteSet.cpp
@@ -12,7 +12,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "SpriteSet.h"
 
-#include "Files.h"
+#include "Logger.h"
 #include "Sprite.h"
 
 #include <map>
@@ -43,7 +43,7 @@ void SpriteSet::CheckReferences()
 		if(sprite.Height() == 0 && sprite.Width() == 0)
 			// Landscapes are allowed to still be empty.
 			if(pair.first.compare(0, 5, "land/") != 0)
-				Files::LogError("Warning: image \"" + pair.first + "\" is referred to, but has no pixels.");
+				Logger::LogError("Warning: image \"" + pair.first + "\" is referred to, but has no pixels.");
 	}
 }
 

--- a/source/StartConditions.cpp
+++ b/source/StartConditions.cpp
@@ -14,8 +14,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "DataNode.h"
 #include "DataWriter.h"
-#include "Files.h"
 #include "GameData.h"
+#include "Logger.h"
 #include "Planet.h"
 #include "Ship.h"
 #include "Sprite.h"
@@ -147,7 +147,7 @@ void StartConditions::FinishLoading()
 
 	string reason = GetConversation().Validate();
 	if(!GetConversation().IsValidIntro() || !reason.empty())
-		Files::LogError("Warning: The start scenario \"" + Identifier() + "\" (named \""
+		Logger::LogError("Warning: The start scenario \"" + Identifier() + "\" (named \""
 			+ GetDisplayName() + "\") has an invalid starting conversation."
 			+ (reason.empty() ? "" : "\n\t" + std::move(reason)));
 }

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -13,9 +13,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Test.h"
 
 #include "DataNode.h"
-#include "Files.h"
 #include "text/Format.h"
 #include "GameData.h"
+#include "Logger.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "Ship.h"
@@ -516,7 +516,7 @@ void Test::Fail(const TestContext &context, const PlayerInfo &player, const stri
 		message += ": " + testFailReason;
 	message += "\n";
 
-	Files::LogError(message);
+	Logger::LogError(message);
 
 	// Print the callstack if we have any.
 	string stackMessage = "Call-stack:\n";
@@ -530,12 +530,12 @@ void Test::Fail(const TestContext &context, const PlayerInfo &player, const stri
 			stackMessage += " (" + STEPTYPE_TO_TEXT.at(((i->test->steps)[i->step]).stepType) + ")";
 		stackMessage += "\n";
 	}
-	Files::LogError(stackMessage);
+	Logger::LogError(stackMessage);
 
 	// Print some debug information about the flagship and the first 5 escorts.
 	const Ship *flagship = player.Flagship();
 	if(!flagship)
-		Files::LogError("No flagship at the moment of failure.");
+		Logger::LogError("No flagship at the moment of failure.");
 	else
 	{
 		string shipsOverview = "flagship " + ShipToString(*flagship) + "\n";
@@ -553,7 +553,7 @@ void Test::Fail(const TestContext &context, const PlayerInfo &player, const stri
 		}
 		if(escortsNotPrinted > 0)
 			shipsOverview += "(plus " + to_string(escortsNotPrinted) + " additional escorts)\n";
-		Files::LogError(shipsOverview);
+		Logger::LogError(shipsOverview);
 	}
 
 	// Only log the conditions that start with test; we don't want to overload the terminal or errorlog.
@@ -565,11 +565,11 @@ void Test::Fail(const TestContext &context, const PlayerInfo &player, const stri
 		conditions += "Condition: \"" + it->first + "\" = " + to_string(it->second) + "\n";
 
 	if(!conditions.empty())
-		Files::LogError(conditions);
+		Logger::LogError(conditions);
 	else if(player.Conditions().empty())
-		Files::LogError("Player had no conditions set at the moment of failure.");
+		Logger::LogError("Player had no conditions set at the moment of failure.");
 	else
-		Files::LogError("No test conditions were set at the moment of failure.");
+		Logger::LogError("No test conditions were set at the moment of failure.");
 
 	// Throwing a runtime_error is kinda rude, but works for this version of
 	// the tester. Might want to add a menuPanels.QuitError() function in

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -18,6 +18,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "text/FontSet.h"
 #include "ImageSet.h"
 #include "Information.h"
+#include "Logger.h"
 #include "MaskManager.h"
 #include "Music.h"
 #include "PlayerInfo.h"
@@ -44,7 +45,7 @@ namespace {
 	// Log a warning for an "undefined" class object that was never loaded from disk.
 	void Warn(const string &noun, const string &name)
 	{
-		Files::LogError("Warning: " + noun + " \"" + name + "\" is referred to, but not fully defined.");
+		Logger::LogError("Warning: " + noun + " \"" + name + "\" is referred to, but not fully defined.");
 	}
 	// Class objects with a deferred definition should still get named when content is loaded.
 	template <class Type>
@@ -149,7 +150,7 @@ void UniverseObjects::FinishLoading()
 			for(const string &name : category.second)
 				persons.Get(name)->NeverSpawn();
 		else
-			Files::LogError("Unhandled \"disable\" keyword of type \"" + category.first + "\"");
+			Logger::LogError("Unhandled \"disable\" keyword of type \"" + category.first + "\"");
 	}
 }
 
@@ -228,7 +229,7 @@ void UniverseObjects::CheckReferences()
 			Warn("conversation", it.first);
 	// The "default intro" conversation must invoke the prompt to set the player's name.
 	if(!conversations.Get("default intro")->IsValidIntro())
-		Files::LogError("Error: the \"default intro\" conversation must contain a \"name\" node.");
+		Logger::LogError("Error: the \"default intro\" conversation must contain a \"name\" node.");
 	// Effects are serialized as a part of ships.
 	for(auto &&it : effects)
 		if(it.second.Name().empty())
@@ -265,7 +266,7 @@ void UniverseObjects::CheckReferences()
 	// Outfitters are never serialized.
 	for(const auto &it : outfitSales)
 		if(it.second.empty() && !deferred["outfitter"].count(it.first))
-			Files::LogError("Warning: outfitter \"" + it.first + "\" is referred to, but has no outfits.");
+			Logger::LogError("Warning: outfitter \"" + it.first + "\" is referred to, but has no outfits.");
 	// Phrases are never serialized.
 	for(const auto &it : phrases)
 		if(it.second.Name().empty())
@@ -284,7 +285,7 @@ void UniverseObjects::CheckReferences()
 	// Shipyards are never serialized.
 	for(const auto &it : shipSales)
 		if(it.second.empty() && !deferred["shipyard"].count(it.first))
-			Files::LogError("Warning: shipyard \"" + it.first + "\" is referred to, but has no ships.");
+			Logger::LogError("Warning: shipyard \"" + it.first + "\" is referred to, but has no ships.");
 	// System names are used by a number of classes.
 	for(auto &&it : systems)
 		if(it.second.Name().empty() && !NameIfDeferred(deferred["system"], it))
@@ -305,7 +306,7 @@ void UniverseObjects::LoadFile(const string &path, bool debugMode)
 
 	DataFile data(path);
 	if(debugMode)
-		Files::LogError("Parsing: " + path);
+		Logger::LogError("Parsing: " + path);
 
 	for(const DataNode &node : data)
 	{

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -26,6 +26,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "GameWindow.h"
 #include "GameLoadingPanel.h"
 #include "Hardpoint.h"
+#include "Logger.h"
 #include "MenuPanel.h"
 #include "Outfit.h"
 #include "Panel.h"
@@ -87,6 +88,9 @@ int main(int argc, char *argv[])
 	bool printWeapons = false;
 	string testToRunName = "";
 
+	// Ensure that we log errors to the errors.txt file.
+	Logger::SetLogErrorCallback([](const string &errorMessage) { Files::LogErrorToFile(errorMessage); });
+
 	for(const char *const *it = argv + 1; *it; ++it)
 	{
 		string arg = *it;
@@ -129,7 +133,7 @@ int main(int argc, char *argv[])
 
 		if(!testToRunName.empty() && !GameData::Tests().Has(testToRunName))
 		{
-			Files::LogError("Test \"" + testToRunName + "\" not found.");
+			Logger::LogError("Test \"" + testToRunName + "\" not found.");
 			return 1;
 		}
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -89,13 +89,7 @@ int main(int argc, char *argv[])
 	string testToRunName = "";
 
 	// Ensure that we log errors to the errors.txt file.
-	Logger::SetLogErrorCallback([](const string &errorMessage)
-	{
-		// Log by default to stderr.
-		cerr << errorMessage << endl;
-		// And also log to the errors.txt logfile.
-		Files::LogErrorToFile(errorMessage);
-	});
+	Logger::SetLogErrorCallback([](const string &errorMessage) { Files::LogErrorToFile(errorMessage); });
 
 	for(const char *const *it = argv + 1; *it; ++it)
 	{

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -89,7 +89,13 @@ int main(int argc, char *argv[])
 	string testToRunName = "";
 
 	// Ensure that we log errors to the errors.txt file.
-	Logger::SetLogErrorCallback([](const string &errorMessage) { Files::LogErrorToFile(errorMessage); });
+	Logger::SetLogErrorCallback([](const string &errorMessage)
+	{
+		// Log by default to stderr.
+		cerr << errorMessage << endl;
+		// And also log to the errors.txt logfile.
+		Files::LogErrorToFile(errorMessage);
+	});
 
 	for(const char *const *it = argv + 1; *it; ++it)
 	{


### PR DESCRIPTION
**Feature:** This PR implements a minor "foundation" feature as suggested in related work in #7031

## Feature Details
Every class that wanted to do some logging needed to include "Files.h". "Files.cpp" has a dependency on SDL (for the savegame paths and preferences paths), so every class that did some logging automatically got an (indirect) dependency on SDL (which is "platform" layer functionality).

This PR moves the logging to its own "foundation" class, and allows logging to files to be added by registering the relevant callback for this during startup of the game.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
Intentionally triggered a parse-error and noticed that it properly showed up on stdout and in the error.txt file.

## Performance Impact
No noticeable performance impact expected; this type of logging only happens when an issue occurs (which typically shouldn't be very often).