### PR TITLE
Fix viewport not resizing when switching to fullscreeen on Linux

### DIFF
--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -382,6 +382,11 @@ void GameWindow::ToggleFullscreen()
 	}
 	else
 		SDL_SetWindowFullscreen(mainWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
+
+	// On Linux SDL doesn't generate a window size change event in certain cases,
+	// so we force adjust the viewport to guarantee that the viewport is the correct
+	// size.
+	AdjustViewport();
 }
 
 


### PR DESCRIPTION
## Fix Details

When switching to fullscreen mode under Linux SDL doesn't seem to be generating the SDL_WINDOWEVENT_SIZE_CHANGED event, which meant that we never updated the viewport, resulting in this:

![fullscreen](https://user-images.githubusercontent.com/85879619/184529265-eaa5bbc9-9838-49c1-9ddf-1f9d694b475c.png)

As a workaround, call `AdjustViewport` right after toggling fullscreen. My bad for not catching this earlier, my window manager seems to prefer a sort of maximized borderless fullscreen window.

To reproduce:

1. Open ES
2. Press F11 (press F11 again if you were already in fullscreen at the beginning)
3. note that the viewport is too small

I have filed a bug upstream: https://github.com/libsdl-org/SDL/issues/6050

## Testing Done

This fixes the issue on my machine, both on a native build and as a Steam runtime build.
