### PR TITLE
feat(scaling): Tell Windows ES is high dpi aware using a manifest file

### DIFF
--- a/endless-sky.exe.manifest
+++ b/endless-sky.exe.manifest
@@ -9,7 +9,7 @@
       <dpiAware>true/pm</dpiAware>
     </asmv3:windowsSettings>
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
-      <dpiAwareness>PerMonitorV2, permonitor, unaware</dpiAwareness>
+      <dpiAwareness>permonitorv2, permonitor, system</dpiAwareness>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>

--- a/endless-sky.exe.manifest
+++ b/endless-sky.exe.manifest
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <assemblyIdentity type="win32" 
+                    name="io.github.endless-sky" 
+                    version="0.9.14.0" 
+  />
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true/pm</dpiAware>
+    </asmv3:windowsSettings>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <dpiAwareness>PerMonitorV2, permonitor, unaware</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/endless-sky.exe.manifest
+++ b/endless-sky.exe.manifest
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-  <assemblyIdentity type="win32" 
-                    name="io.github.endless-sky" 
-                    version="0.9.14.0" 
+  <assemblyIdentity type="win32"
+                    name="io.github.endless-sky"
+                    version="0.9.14.0"
   />
   <asmv3:application>
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">

--- a/source/WinApp.rc
+++ b/source/WinApp.rc
@@ -1,1 +1,3 @@
+#include "winuser.h"
 AppIcon ICON "../icons/WinApp.ico"
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST endless-sky.exe.manifest

--- a/utils/set_version.sh
+++ b/utils/set_version.sh
@@ -30,8 +30,11 @@ fi
 rm -rf source/main.cpp.bak
 rm -rf endless-sky.6.bak
 
-# Update the XCode plist version, if the input is spec-conformant
+# Update the XCode plist and Win32 manifest version, if the input is spec-conformant
 if [[ $1 =~ ^${versionRegex}$ ]]; then
     perl -0777 -p -i -e "s/(CFBundleShortVersionString.*?)\>${versionRegex}/\$1>$1/igs" XCode/EndlessSky-Info.plist
     rm -rf XCode/EndlessSky-Info.plist.bak
+
+    perl -p -i -e "s/(^\s*version=)\".+(\.0)\"/\$1\"${versionRegex}\$2\"/ig" endless-sky.exe.manifest
+    rm -rf endless-sky.exe.manifest.bak
 fi


### PR DESCRIPTION
**Bugfix:** This PR fixes #7133 

## Fix Details

This PR embeds an application manifest on Windows, specifying that the game is DPI aware and doesn't need any scaling done by Windows itself.

## Testing Done

Set my DPI to 175%. Starting the game with this PR results in a not zoomed-in game.