### PR TITLE
feat(content): Add deadline to Corporate Espionage job

### DIFF
--- a/data/human/syndicate jobs.txt
+++ b/data/human/syndicate jobs.txt
@@ -57,8 +57,9 @@ mission "Corporate retreat from <origin>"
 
 
 mission "Corporate espionage"
-	description "The <npc> is about to enter this system. Locate it and make detailed scans of its cargo, which are of considerable interest to a team of Syndicate researchers on <destination>; proceed there for <payment> after retrieving the data."
+	description "The <npc> is about to enter this system. Intercept it and make detailed scans of its cargo for Syndicate researchers on <destination>; proceed there before <date> for <payment> after retrieving the data."
 	job
+	deadline 1 3
 	repeat
 	to offer
 		random < 10


### PR DESCRIPTION
This PR adds a deadline to the Corporate Espionage Syndicate job, and tweaks the mission description. The way these jobs are meant to play out is being prepared to immediately intercept your target ship and scan them right after you take off. If you don't find them in 5-10 seconds, the NPC can and will jump *anywhere* in the galaxy, making it nearly impossible to find them. Adding a deadline makes sure a player can't fruitlessly chase after the target, and that it won't clog up the active mission list.

If we get the capability in the future to limit the movement of NPCs to certain systems, and can persistently mark those areas, that can let the player hold onto these missions for a longer time.