### PR TITLE
fix: Missing copyright header in test_account.cpp

### DIFF
--- a/tests/unit/src/test_account.cpp
+++ b/tests/unit/src/test_account.cpp
@@ -1,3 +1,15 @@
+/* test_account.cpp
+Copyright (c) 2022 by petervdmeer
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
 #include "es-test.hpp"
 
 // Include only the tested class's header.


### PR DESCRIPTION
**Fix:** This PR fixes the missing copyright header in [test_account.cpp](https://github.com/endless-sky/endless-sky/blob/master/tests/unit/src/test_account.cpp)

## Fix Details
The file was created by @petervdmeer in #6139. The header was never included, even though all other test files have these headers. I think unless @petervdmeer explicitly tells us not to have this header, we should probably include it. (We should wait for their approval of course.)