### PR TITLE
fix(AI): Make owned ships ignore fence.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -974,6 +974,10 @@ bool AI::CanPursue(const Ship &ship, const Ship &target) const
 	if(ship.GetPersonality().IsUnconstrained())
 		return true;
 
+	// Owned ships ignore fence.
+	if(ship.IsYours())
+		return true;
+
 	// Check if the target is beyond the "invisible fence" for this system.
 	const auto fit = fenceCount.find(&target);
 	if(fit == fenceCount.end())


### PR DESCRIPTION
## Fix Details
The `CanPursue` check is applied in target choosing to all ships, including ones in the player's fleet. The fleet ships have no trouble following the player outside of the fence but having `CanPursue` return false in those cases make the ships just sit idly if enemies do follow the player outside of the fence for some reason.

A further refinement could be to make fleet ships follow a fence that's centered around the player, instead.

## Testing Done
The easiest way to reproduce the issue is to fly outside of the fence and demand tribute from a planet. With this patch, the ships in the fleet target and attack the defending ships.

I wouldn't expect this change to affect other behavior.

## Save File
Omitted, if you don't mind. Any save with enough combat rating to enable tributes will do. The bug will occur when using c27eb67b20dc4a450b2e8aa0241b1c9204af5527, and will not occur when using this branch's build.
