### PR TITLE
add bayless ships variants

### DIFF
--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -46,6 +46,10 @@ shipyard "Lionheart Advanced"
 	"Corvette"
 	"Bactrian"
 
+shipyard "Lionheart Custom"
+	"Aerie (No Bays)"
+	"Bactrian (No Bays)"
+
 shipyard "Betelgeuse Basics"
 	"Shuttle"
 	"Heavy Shuttle"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -8,6 +8,12 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
+ship "Aerie" "Aerie (No Bays)"
+	add attributes
+		"cargo space" 160
+	remove bays
+	description "This Aerie variant is the same as the original one but without the internal fighters bays, instead the ship has more cargo volume."
+
 ship "Argosy" "Argosy (Blaster)"
 	outfits
 		"Energy Blaster" 4
@@ -164,6 +170,12 @@ ship "Bactrian" "Bactrian (Hired Gun)"
 		"A525 Atomic Steering"
 		"Hyperdrive"
 
+
+ship "Bactrian" "Bactrian (No Bays)"
+	add attributes
+		"cargo space" 120
+	remove bays
+	description "This Bactrian variant is the same as the original one but without the internal fighters bays, instead the ship has more cargo."
 
 
 ship "Barb" "Barb (Gatling)"

--- a/data/map.txt
+++ b/data/map.txt
@@ -30872,6 +30872,7 @@ planet Valhalla
 	shipyard "Basic Ships"
 	shipyard "Lionheart Basics"
 	shipyard "Lionheart Advanced"
+	shipyard "Lionheart Custom"
 	shipyard "Betelgeuse Basics"
 	outfitter "Common Outfits"
 	outfitter "Ammo North"


### PR DESCRIPTION
with the PR of the code support to remove bays, it is a time to make use of it.
this feature helps best ships with internal bays because they can be replaced with extra cargo space.

Testing:
1. buy the ship
2. verify no bays exists and that the cargo size is bigger than the base model.
3. try to instruct fighters to enter the bay.