### PR TITLE
fix(AI): Use unconstrained personality for defense fleet carried ships

### DIFF
--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -371,12 +371,11 @@ Personality Personality::Defender()
 
 
 // Remove target and marked since the defender defeat check doesn't actually care
-// about carried ships.  Remove heroic and staying to make them stick with carriers
-// but use unconstrained to have targeting work outside of the fence.
+// about carried ships.
 Personality Personality::DefenderFighter()
 {
 	Personality defender;
-	defender.flags = UNCONSTRAINED;
+	defender.flags = STAYING | HEROIC | UNCONSTRAINED;
 	return defender;
 }
 

--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -370,6 +370,18 @@ Personality Personality::Defender()
 
 
 
+// Remove target and marked since the defender defeat check doesn't actually care
+// about carried ships.  Remove heroic and staying to make them stick with carriers
+// but use unconstrained to have targeting work outside of the fence.
+Personality Personality::DefenderFighter()
+{
+	Personality defender;
+	defender.flags = UNCONSTRAINED;
+	return defender;
+}
+
+
+
 void Personality::Parse(const DataNode &node, int index, bool remove)
 {
 	const string &token = node.Token(index);

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -76,6 +76,7 @@ public:
 
 	// Personality to use for ships defending a planet from domination:
 	static Personality Defender();
+	static Personality DefenderFighter();
 
 
 private:

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -617,8 +617,15 @@ void Planet::DeployDefense(list<shared_ptr<Ship>> &ships) const
 
 	// All defenders use a special personality.
 	Personality defenderPersonality = Personality::Defender();
+	Personality fighterPersonality = Personality::DefenderFighter();
 	for(auto it = defenders.begin(); it != end; ++it)
+	{
 		(**it).SetPersonality(defenderPersonality);
+		if((**it).HasBays())
+			for(auto bay = (**it).Bays().begin(); bay != (**it).Bays().end(); ++bay)
+				if(bay->ship)
+					bay->ship->SetPersonality(fighterPersonality);
+	}
 
 	++defenseDeployed;
 }


### PR DESCRIPTION
**Bugfix**

## Fix Details
Planetary defense fleets' carried ships don't currently set any specific personality. Specifically they lack the unconstrained flag, which makes them stick close to the carriers but if they reach the player outside of the fence, they won't target them. Since the carriers have it, they may very well end up there.

I tried it a bit and I think it made most sense to only enable unconstrained for them. The defeat check doesn't check for carried ships so having them blink as targets might be misleading. I don't think it'd be worth it to change the defeat check, if somehow a couple of fighters would be only left then it's pretty plausible for them to surrender.

## Testing Done
I messed with some republic planets, which most often have carriers and cruisers. With this change their fighters and drones engage ships in my fleet.

## Save File
Omitted, this is pretty easy to reproduce. Have enough combat rating, fly away and bother some republic planets.  The bug will occur when usinga7818716b9a1e2e56ce337fcdb22e9f474e903e7 , and will not occur when using this branch's build.