### PR TITLE
feat(internal): Vector indexed Dictionary

### DIFF
--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -372,9 +372,12 @@ bool LocationFilter::Matches(const Ship &ship) const
 	{
 		// Create a set from the positive-valued attributes of this ship.
 		set<string> shipAttributes;
-		for(const auto &attr : ship.Attributes().Attributes())
-			if(attr.second > 0.)
-				shipAttributes.insert(shipAttributes.end(), attr.first);
+		for(const dict &attr : ship.Attributes().Attributes())
+		{
+			double value = ship.Attributes().Get(attr);
+			if(value > 0.)
+				shipAttributes.insert(shipAttributes.end(), string(Dictionary::GetName(attr)));
+		}
 		for(const set<string> &attr : attributes)
 			if(!SetsIntersect(attr, shipAttributes))
 				return false;

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -61,6 +61,7 @@ public:
 
 	double Get(const char *attribute) const;
 	double Get(const std::string &attribute) const;
+	double Get(const dict &key) const;
 	const Dictionary &Attributes() const;
 
 	// Determine whether the given number of instances of the given outfit can
@@ -73,6 +74,7 @@ public:
 	// Modify this outfit's attributes. Note that this cannot be used to change
 	// special attributes, like cost and mass.
 	void Set(const char *attribute, double value);
+	void Set(const dict &key, double value);
 
 	// Get this outfit's engine flare sprites, if any.
 	const std::vector<std::pair<Body, int>> &FlareSprites() const;

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -310,19 +310,20 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	attributesHeight = 20;
 
 	bool hasNormalAttributes = false;
-	for(const pair<const char *, double> &it : outfit.Attributes())
+	for(const dict &at : outfit.Attributes())
 	{
 		static const set<string> SKIP = {
 			"outfit space", "weapon capacity", "engine capacity", "gun ports", "turret mounts"
 		};
-		if(SKIP.count(it.first))
+		const char *name = Dictionary::GetName(at);
+		if(SKIP.count(name))
 			continue;
 
-		auto sit = SCALE.find(it.first);
+		auto sit = SCALE.find(name);
 		double scale = (sit == SCALE.end() ? 1. : SCALE_LABELS[sit->second].first);
 		string units = (sit == SCALE.end() ? "" : SCALE_LABELS[sit->second].second);
 
-		auto bit = BOOLEAN_ATTRIBUTES.find(it.first);
+		auto bit = BOOLEAN_ATTRIBUTES.find(name);
 		if(bit != BOOLEAN_ATTRIBUTES.end())
 		{
 			attributeLabels.emplace_back(bit->second);
@@ -331,8 +332,9 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		}
 		else
 		{
-			attributeLabels.emplace_back(static_cast<string>(it.first) + ":");
-			attributeValues.emplace_back(Format::Number(it.second * scale) + units);
+			double value = outfit.Attributes().Get(at);
+			attributeLabels.emplace_back(string(name) + ":");
+			attributeValues.emplace_back(Format::Number(value * scale) + units);
 			attributesHeight += 20;
 		}
 		hasNormalAttributes = true;

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -672,9 +672,12 @@ void OutfitterPanel::Sell(bool toStorage)
 			{
 				// Determine how many of this ammo I must sell to also sell the launcher.
 				int mustSell = 0;
-				for(const pair<const char *, double> &it : ship->Attributes().Attributes())
-					if(it.second < 0.)
-						mustSell = max<int>(mustSell, it.second / ammo->Get(it.first));
+				for(const dict &it : ship->Attributes().Attributes())
+				{
+					double value = ship->Attributes().Attributes().Get(it);
+					if(value < 0.)
+						mustSell = max<int>(mustSell, value / ammo->Get(it));
+				}
 
 				if(mustSell)
 				{
@@ -728,24 +731,28 @@ void OutfitterPanel::FailSell(bool toStorage) const
 		else
 		{
 			for(const Ship *ship : playerShips)
-				for(const pair<const char *, double> &it : selectedOutfit->Attributes())
-					if(ship->Attributes().Get(it.first) < it.second)
+				for(const dict &it : selectedOutfit->Attributes())
+				{
+					double value = selectedOutfit->Get(it);
+					if(ship->Attributes().Get(it) < value)
 					{
+						const char *name = Dictionary::GetName(it);
 						for(const auto &sit : ship->Outfits())
-							if(sit.first->Get(it.first) < 0.)
+							if(sit.first->Get(it) < 0.)
 							{
 								GetUI()->Push(new Dialog("You cannot " + verb + " this outfit, "
-									"because that would cause your ship's \"" + it.first +
+									"because that would cause your ship's \"" + name +
 									"\" value to be reduced to less than zero. "
 									"To " + verb + " this outfit, you must " + verb + " the " +
 									sit.first->Name() + " outfit first."));
 								return;
 							}
 						GetUI()->Push(new Dialog("You cannot " + verb + " this outfit, "
-							"because that would cause your ship's \"" + it.first +
+							"because that would cause your ship's \"" + name +
 							"\" value to be reduced to less than zero."));
 						return;
 					}
+				}
 			GetUI()->Push(new Dialog("You cannot " + verb + " this outfit, "
 				"because something else in your ship depends on it."));
 		}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -847,9 +847,12 @@ void Ship::Save(DataWriter &out) const
 			for(const auto &it : baseAttributes.HyperOutSounds())
 				for(int i = 0; i < it.second; ++i)
 					out.Write("hyperdrive out sound", it.first->Name());
-			for(const auto &it : baseAttributes.Attributes())
-				if(it.second)
-					out.Write(it.first, it.second);
+			for(const dict &it : baseAttributes.Attributes())
+			{
+				double value = baseAttributes.Get(it);
+				if(value)
+					out.Write(Dictionary::GetName(it), value);
+			}
 		}
 		out.EndChild();
 


### PR DESCRIPTION
**Feature:** This PR changes the data structure of `Dictionary` to allow optimizing game engine, as discussed as an option in  #6329

## Feature Details
One result from profiling the game engine was that it was using a lot of time on string comparisons since almost all of ship attributes are stored in a sorted vector that's indexed by string keys, where accesses are O(log n). This PR changes the `Dictionary` class to use a `vector<double>` to store the attribute values and makes the `Dictionary` class itself to give iterators to a vector of offsets to a static table that contains the attribute names.

This new `Dictionary` can still be accessed with string keys and the performance should be comparable to the current `Dictionary` implementation. What's new that it allows looking up the offset value of an attribute and since every instance of a `Dictionary` stores the same attribute value at the same offset, those can be used to access the values at O(1) time instead of O(log n) with a very small constant factor. The vector used to store the attribute values is sparse since Endless Sky uses about 170 variables and not nearly every ship uses most but at this scale I wouldn't consider it an issue.

This PR does only the minimal amount of key changes and just offers a new `Dictionary` as a drop in replacement.

To use this in the future, all that's needed is to store an offset value to a static variable at program initialization time and replace any `Get` or `Set` calls that currently use a string key to use the variable instead. No need to add any code to cache data, just change the line that accesses attributes to use a different constant as the key. Most of the code Endless Sky uses plain string constants as keys so it's pretty much an one line change at the site where the value is used.

## UI Screenshots
N/A

## Usage Examples
I have published a WIP tree that includes key changes to use the new way of accessing attribute values at https://github.com/kaol/endless-sky/tree/wip/int-dictionary

## Testing Done
I've played the game with this feature (along with key changes to some but not all attribute accesses) for hours and the game has been stable.

## Performance Impact
This change alone should have a minimal effect, since it doesn't yet touch what keys are used to access attribute values. With a branch that replaces keys to use offsets, the game is, based on rough profiling with a fully optimized build, about 25% faster and it can have a lot more ships active at the same time before there's noticeable lag.