### PR TITLE
Abbreviate large amounts of secondary ammo

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1073,7 +1073,7 @@ void Engine::Draw() const
 		// show the icon without a number.
 		if(it.second < 0)
 			continue;
-		
+
 		string amount = Format::SecondaryAmmo(it.second);
 		Point textPos = pos + textOff + Point(-font.Width(amount), 0.);
 		font.Draw(amount, textPos, isSelected ? selectedColor : unselectedColor);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1069,23 +1069,12 @@ void Engine::Draw() const
 		SpriteShader::Draw(it.first->Icon(), pos + iconOff);
 		SpriteShader::Draw(isSelected ? selectedSprite : unselectedSprite, pos + boxOff);
 
-		string amount = "";
 		// Some secondary weapons may not have limited ammo. In that case, just
 		// show the icon without a number.
 		if(it.second < 0)
-		{
 			continue;
-		}
-		//When the amount of ammo is in the thousands, abbreviate it
-		//instead of displaying the exact value to conserve space in the box
-		else if(it.second >= 1000)
-		{
-			amount = to_string(it.second / 1000) + "." + to_string((it.second - (it.second / 1000) * 1000) / 100) + "k";
-		}
-		else
-		{
-			amount = to_string(it.second);
-		}
+		
+		string amount = Format::SecondaryAmmo(it.second);
 		Point textPos = pos + textOff + Point(-font.Width(amount), 0.);
 		font.Draw(amount, textPos, isSelected ? selectedColor : unselectedColor);
 	}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1068,13 +1068,24 @@ void Engine::Draw() const
 
 		SpriteShader::Draw(it.first->Icon(), pos + iconOff);
 		SpriteShader::Draw(isSelected ? selectedSprite : unselectedSprite, pos + boxOff);
-
+		
+		string amount = "";
 		// Some secondary weapons may not have limited ammo. In that case, just
 		// show the icon without a number.
 		if(it.second < 0)
+		{
 			continue;
-
-		string amount = to_string(it.second);
+		}
+		//When the amount of ammo is in the thousands, abbreviate it
+		//instead of displaying the exact value to conserve space in the box
+		else if(it.second >= 1000)
+		{
+			amount = to_string(it.second / 1000) + "." + to_string((it.second - (it.second / 1000) * 1000) / 100) + "k";
+		}
+		else
+		{
+			amount = to_string(it.second);
+		}
 		Point textPos = pos + textOff + Point(-font.Width(amount), 0.);
 		font.Draw(amount, textPos, isSelected ? selectedColor : unselectedColor);
 	}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1068,7 +1068,7 @@ void Engine::Draw() const
 
 		SpriteShader::Draw(it.first->Icon(), pos + iconOff);
 		SpriteShader::Draw(isSelected ? selectedSprite : unselectedSprite, pos + boxOff);
-		
+
 		string amount = "";
 		// Some secondary weapons may not have limited ammo. In that case, just
 		// show the icon without a number.

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -117,7 +117,18 @@ std::string Format::PlayTime(double timeVal)
 	return result;
 }
 
-
+//
+string Format::SecondaryAmmo(int value)
+{
+		if(value >= 10000)
+		{
+			return to_string(value / 1000) + "." + to_string((value - (value / 1000) * 1000) / 100) + "k";
+		}
+		else
+		{
+			return to_string(value);
+		}
+}
 
 // Convert the given number to a string, with a reasonable number of decimal
 // places. (This is primarily for displaying ship and outfit attributes.)

--- a/source/text/Format.h
+++ b/source/text/Format.h
@@ -28,6 +28,9 @@ public:
 	static std::string Credits(int64_t value);
 	// Convert a time in seconds to years/days/hours/minutes/seconds
 	static std::string PlayTime(double timeVal);
+	//Abbreviates numbers in the tens of thousands with the suffix "k"
+	//to conserve space in the box for secondary ammo
+	static std::string SecondaryAmmo(int value);
 	// Convert the given number to a string, with at most one decimal place.
 	// This is primarily for displaying ship and outfit attributes.
 	static std::string Number(double value);

--- a/source/text/Format.h
+++ b/source/text/Format.h
@@ -28,8 +28,8 @@ public:
 	static std::string Credits(int64_t value);
 	// Convert a time in seconds to years/days/hours/minutes/seconds
 	static std::string PlayTime(double timeVal);
-	//Abbreviates numbers in the tens of thousands with the suffix "k"
-	//to conserve space in the box for secondary ammo
+	// Convert the given number into a string, abbreviating numbers in the tens of thousands
+	//  with the suffix "k", to conserve space in the box for secondary ammo.
 	static std::string SecondaryAmmo(int value);
 	// Convert the given number to a string, with at most one decimal place.
 	// This is primarily for displaying ship and outfit attributes.


### PR DESCRIPTION
**(Partial) bugfix:** This PR addresses issue #6027

## Fix Details
I modified Engine.cpp so that the ammo box for secondary weapons in the bottom-right will abbreviate to show the number in thousands with the "k" suffix rounded down to one decimal place when the amount of ammo is greater than or equal to one thousand. The number displays normally for numbers less than one thousand. This allows large numbers to fit better inside the box.

One limitation of this solution is that this does not address numbers greater than or equal to one hundred thousand, which is theoretically possible in the game in ships with sufficient outfit space. However, I believe this solution is still better than no solution at all.

## Testing Done
I created a pilot and installed a Gatling Gun with various amounts of ammunition. Then I flew around and fired the gun and observed that the number in the box changed correctly.

## Save File
Attached are two save files. The first save may be used to verify that the text switches smoothly between the abbreviated and non-abbreviated forms when the ammo decreases to below one thousand, and the second save may be used to verify that the abbreviated form does indeed fit better than the non-abbreviated number into the box when the amount of ammo is above ten thousand.
[test test~closeto1k.txt](https://github.com/endless-sky/endless-sky/files/9449664/test.test.closeto1k.txt)
[test test~greaterthan10k.txt](https://github.com/endless-sky/endless-sky/files/9449665/test.test.greaterthan10k.txt)


## Performance Impact
Should be very minimal. I used some computational trickery to get the number to abbreviate properly. If anyone happens to think of a method that is somehow more efficient feel free to point it out.
