### PR TITLE
Remove extra 'landing' line in Saving Artifacts mission chain

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4334,7 +4334,6 @@ mission "Saving Artifacts 4"
 			and
 				has "Saving Artifacts 2: done"
 				not "Duel Lokust"
-	landing
 	
 	on visit
 		dialog `You land on <planet>, but realize you haven't acquired the statues from Greenrock yet. Better return to Shaula to make sure Lokust is defeated before claiming them on the planet.`


### PR DESCRIPTION
## Summary
There was an unnecessary `landing` line in Saving Artifacts 4 that was pointed out to me on Discord. This PR deletes that line.
