### PR TITLE
fix(content): Teciimach mission source

### DIFF
--- a/data/remnant/remnant 2 side missions.txt
+++ b/data/remnant/remnant 2 side missions.txt
@@ -352,7 +352,8 @@ mission "Remnant: Teciimach Deployment"
 	name "New EMP deployment"
 	description "The Remnant are deploying a new version of the EMP, and invite you to watch."
 	source
-		attributes "shipyard" "remnant"
+		attributes "shipyard"
+		attributes "remnant"
 	to offer
 		has "event: remnant: cognizance calm"
 		has "event: remnant: research update bjd1"


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Currently, the location filter on the source of the recently added Teciimach mission only requires a planet with either of the attributes `"shipyard"` or `"remnant"`, meaning it can offer on a non-Remnant world with a shipyard, or a Remnant world with no shipyard.
This change means it will require both attributes, so it'll only offer on Remnant worlds with shipyards.

## Testing Done
![image](https://user-images.githubusercontent.com/20605679/188223763-2e9c7e61-b610-4c02-a8f8-5d20fd36f763.png)
As is, I can receive the mission on Zug.
