### PR TITLE
Feat(content): Remnant: Smew into the shipyard and fleets

### DIFF
--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -1142,6 +1142,8 @@ event "remnant: teciimach deployment"
 			"Merganser (II)"
 			"Petrel" 2
 			"Tern" 4
+		add variant 3
+			"Smew (Teciimach Ferry)"
 	fleet "Small Remnant"
 		remove variant 1
 			"Peregrine"

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -1194,14 +1194,22 @@ ship "Smew"
 
 ship "Smew" "Smew (Miner)"
 	outfits
+		"Millennium Cell"
+		"Quantum Key Stone"
+		"Thermoelectric Cooler"
+		
+		"Anvil-Class Engine"
+		
 		"Thrasher Cannon"
-
-ship "Smew" "Smew (Support)"
-	outfits
-		"Inhibitor Cannon"	
 
 ship "Smew" "Smew (Runabout)"
 	outfits
+		"Millennium Cell"
+		"Quantum Key Stone"
+		"Thermoelectric Cooler"
+		
+		"Anvil-Class Engine"
+		
 		"Hyperdrive"	
 
 

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -1209,7 +1209,19 @@ ship "Smew" "Smew (Runabout)"
 		"Thermoelectric Cooler"
 		
 		"Anvil-Class Engine"
-		"Hyperdrive"	
+		"Hyperdrive"
+
+ship "Smew" "Smew (Teciimach Ferry)"
+	outfits
+		"Teciimach Canister" 3
+		"Teciimach Pod"
+		
+		"Millennium Cell"
+		"Quantum Key Stone"
+		"Thermoelectric Cooler"
+		
+		"Anvil-Class Engine"
+
 
 
 ship "Starling"

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -1194,13 +1194,13 @@ ship "Smew"
 
 ship "Smew" "Smew (Miner)"
 	outfits
+		"Thrasher Cannon"
+		
 		"Millennium Cell"
 		"Quantum Key Stone"
 		"Thermoelectric Cooler"
 		
 		"Anvil-Class Engine"
-		
-		"Thrasher Cannon"
 
 ship "Smew" "Smew (Runabout)"
 	outfits
@@ -1209,7 +1209,6 @@ ship "Smew" "Smew (Runabout)"
 		"Thermoelectric Cooler"
 		
 		"Anvil-Class Engine"
-		
 		"Hyperdrive"	
 
 

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -1191,6 +1191,17 @@ ship "Smew"
 	description "	Though originally designed as lifeboats, the surprisingly mobile freighter-fighter hybrid has seen a remarkable amount of usage in mining fleets, as a way to supplement the otherwise poor cargo capacity of the Ibis. Because their purpose can vary from fleet to fleet, Smews are traditionally sold with a fair amount of free space: enough for a small weapon, upgraded engines, or additional support systems."
 	description "	Fighters do not come equipped with a hyperdrive. You cannot carry a fighter unless you have a ship in your fleet with a fighter bay."
 
+ship "Smew" "Smew (Miner)"
+	outfits
+		"Thrasher Cannon"
+
+ship "Smew" "Smew (Support)"
+	outfits
+		"Inhibitor Cannon"	
+
+ship "Smew" "Smew (Runabout)"
+	outfits
+		"Hyperdrive"	
 
 
 ship "Starling"

--- a/data/remnant/remnant.txt
+++ b/data/remnant/remnant.txt
@@ -175,8 +175,6 @@ fleet "Remnant Home Guard"
 		"Petrel" 2
 		"Tern" 4
 	variant 3
-		"Smew (Support)" 2
-	variant 3
 		"Smew (Miner)" 2
 	variant 2
 		"Smew (Runabout)"

--- a/data/remnant/remnant.txt
+++ b/data/remnant/remnant.txt
@@ -40,6 +40,10 @@ fleet "Small Remnant"
 		"Ibis"
 		"Petrel" 2
 		"Tern" 4
+	variant 4
+		"Ibis"
+		"Smew" 2
+		"Tern" 4
 
 fleet "Large Remnant"
 	government "Remnant"
@@ -160,6 +164,8 @@ fleet "Remnant Home Guard"
 		"Tern" 1
 	variant 10
 		"Tern" 2
+	variant 10
+		"Smew" 1
 	variant 5
 		"Tern" 3
 	variant 5
@@ -168,6 +174,8 @@ fleet "Remnant Home Guard"
 	variant 5
 		"Petrel" 2
 		"Tern" 4
+	variant 5
+		"Smew" 2
 
 fleet "Remnant Decoy Defense"
 	government "Remnant"
@@ -974,6 +982,7 @@ shipyard "Remnant"
 	"Ibis"
 	"Pelican"
 	"Petrel"
+	"Smew"
 	"Tern"
 
 shipyard "Remnant Puffin"

--- a/data/remnant/remnant.txt
+++ b/data/remnant/remnant.txt
@@ -42,7 +42,7 @@ fleet "Small Remnant"
 		"Tern" 4
 	variant 4
 		"Ibis"
-		"Smew" 2
+		"Smew (Miner)" 2
 		"Tern" 4
 
 fleet "Large Remnant"
@@ -174,8 +174,12 @@ fleet "Remnant Home Guard"
 	variant 5
 		"Petrel" 2
 		"Tern" 4
-	variant 5
-		"Smew" 2
+	variant 3
+		"Smew (Support)" 2
+	variant 3
+		"Smew (Miner)" 2
+	variant 2
+		"Smew (Runabout)"
 
 fleet "Remnant Decoy Defense"
 	government "Remnant"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This PR implements the recently merged Smew:
- Adds to the shipyard
- Adds a miner (with a thrasher), a support (with an inhibitor), and a runabout (with an hd) variants.
- Adds all three of these to Remnant fleets in a few instances.
- Including one Ibis+2 miners+4 terns variant for mining operations.