### PR TITLE
Change Hai colours

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -133,7 +133,7 @@ government "Free Worlds"
 
 government "Hai"
 	swizzle 0
-	color .84 .42 .81
+	color .86 .48 .79
 	
 	"player reputation" 0
 	"attitude toward"
@@ -153,7 +153,7 @@ government "Hai"
 government "Hai (Wormhole Access)"
 	"display name" "Hai"
 	swizzle 0
-	color .84 .42 .81
+	color .86 .48 .79
 	
 	"player reputation" 0
 	"attitude toward"
@@ -172,7 +172,7 @@ government "Hai (Wormhole Access)"
 government "Hai Merchant"
 	"display name" "Hai"
 	swizzle 0
-	color .84 .42 .81
+	color .86 .48 .79
 	
 	"player reputation" 0
 	"attitude toward"
@@ -191,7 +191,7 @@ government "Hai Merchant"
 government "Hai Merchant (Sympathizers)"
 	"display name" "Hai"
 	swizzle 0
-	color .84 .42 .81
+	color .86 .48 .79
 	
 	"player reputation" 0
 	"attitude toward"
@@ -210,7 +210,7 @@ government "Hai Merchant (Sympathizers)"
 government "Hai Merchant (Human)"
 	"display name" "Hai"
 	swizzle 0
-	color .84 .42 .81
+	color .86 .48 .79
 	
 	"player reputation" 0
 	"attitude toward"
@@ -226,7 +226,7 @@ government "Hai Merchant (Human)"
 
 government "Hai (Unfettered)"
 	swizzle 4
-	color .69 .33 .82
+	color .55 .27 .76
 	
 	"player reputation" -1000
 	"attitude toward"


### PR DESCRIPTION
Not sure which category this falls under... I'm using the content template because that's the closest thing there is.

## Summary
Changed the colours of Hai and Unfettered Hai so that they're no longer quite so similar.
Closes https://github.com/endless-sky/endless-sky/issues/7186.

## Save File
This save file can be used to view the map:
[Atlantian Cruise.txt](https://github.com/endless-sky/endless-sky/files/9481449/Atlantian.Cruise.txt)

## Artwork Checklist
N/A

## Colour Comparison
Current Colours:
<img width="263" alt="Before" src="https://user-images.githubusercontent.com/73318970/188245431-9d7e2634-2247-4f69-a478-2c3e8af8921c.png">
New Colours:
<img width="228" alt="After" src="https://user-images.githubusercontent.com/73318970/188245434-17c2c36d-f418-4a25-a040-bb18f7030e66.png">
