### PR TITLE
Damage taken effects

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2080,14 +2080,14 @@ void Engine::DoCollisions(Projectile &projectile)
 
 				// Only directly targeted ships get provoked by blast weapons.
 				int eventType = ship->TakeDamage(visuals, damage.CalculateDamage(*ship, ship == hit.get()),
-					targeted ? gov : nullptr, closestHit, hitVelocity, projectile.Facing());
+					targeted ? gov : nullptr, projectile.Position() + projectile.Velocity() * closestHit, hitVelocity, projectile.Facing());
 				if(eventType)
 					eventQueue.emplace_back(gov, ship->shared_from_this(), eventType);
 			}
 		}
 		else if(hit)
 		{
-			int eventType = hit->TakeDamage(visuals, damage.CalculateDamage(*hit), gov, closestHit, hitVelocity, projectile.Facing());
+			int eventType = hit->TakeDamage(visuals, damage.CalculateDamage(*hit), gov, projectile.Position() + projectile.Velocity() * closestHit, hitVelocity, projectile.Facing());
 			if(eventType)
 				eventQueue.emplace_back(gov, hit, eventType);
 		}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2080,14 +2080,14 @@ void Engine::DoCollisions(Projectile &projectile)
 
 				// Only directly targeted ships get provoked by blast weapons.
 				int eventType = ship->TakeDamage(visuals, damage.CalculateDamage(*ship, ship == hit.get()),
-					targeted ? gov : nullptr);
+					targeted ? gov : nullptr, closestHit, hitVelocity, projectile.Facing());
 				if(eventType)
 					eventQueue.emplace_back(gov, ship->shared_from_this(), eventType);
 			}
 		}
 		else if(hit)
 		{
-			int eventType = hit->TakeDamage(visuals, damage.CalculateDamage(*hit), gov);
+			int eventType = hit->TakeDamage(visuals, damage.CalculateDamage(*hit), gov, closestHit, hitVelocity, projectile.Facing());
 			if(eventType)
 				eventQueue.emplace_back(gov, hit, eventType);
 		}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2129,7 +2129,7 @@ void Engine::DoWeather(Weather &weather)
 			: shipCollisions.Ring(weather.Origin(), hazard->MinRange(), hazard->MaxRange())))
 		{
 			Ship *hit = reinterpret_cast<Ship *>(body);
-			hit->TakeDamage(visuals, damage.CalculateDamage(*hit), nullptr);
+			hit->DoDamage(visuals, damage.CalculateDamage(*hit));
 		}
 	}
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3408,7 +3408,7 @@ double Ship::MaxReverseVelocity() const
 // DamageDealt from that weapon. The return value is a ShipEvent type,
 // which may be a combination of PROVOKED, DISABLED, and DESTROYED.
 // Create any target effects as sparks.
-int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, double intersection, Point hitVelocity, Angle hitAngle)
+int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, Point intersection, Point hitVelocity, Angle hitAngle)
 {
 	int type = DoDamage(visuals, damage);
 
@@ -3421,22 +3421,24 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 
 	// Create hull/shield hit effect visuals at the point of impact for weapons
 	// fire, if there are any to create.
-		if(shields > 0.)
-		{
-			for(const auto &it : ShieldHitEffects())
-				for(int i = 0; i < it.second; ++i)
-				{
-					visuals.emplace_back(*it.first, position + velocity * intersection, velocity, hitAngle, hitVelocity);
-				}
-		}
-		else
-		{
-			for(const auto &it : HullHitEffects())
-				for(int i = 0; i < it.second; ++i)
-				{
-					visuals.emplace_back(*it.first, position + velocity * intersection, velocity, hitAngle, hitVelocity);
-				}
-		}
+	if(!damage.Hull())
+	{
+		for(const auto &it : ShieldHitEffects())
+			for(int i = 0; i < it.second; ++i)
+			{
+				visuals.emplace_back(*it.first, intersection, velocity, hitAngle, hitVelocity);
+				//visuals.emplace_back(*it.first, velocity, velocity, hitAngle, hitVelocity);
+				//visuals.emplace_back(*it.first, intersection, velocity, hitAngle, hitVelocity);
+			}
+	}
+	else
+	{
+		for(const auto &it : HullHitEffects())
+			for(int i = 0; i < it.second; ++i)
+			{
+				visuals.emplace_back(*it.first, intersection, velocity, hitAngle, hitVelocity);
+			}
+	}
 
 	return type;
 }

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -494,6 +494,8 @@ private:
 	bool neverDisabled = false;
 	bool isCapturable = true;
 	bool isInvisible = false;
+	bool hasHitEffect = false;
+	bool hasShieldHitEffect = false;
 	int customSwizzle = -1;
 	double cloak = 0.;
 	double cloakDisruption = 0.;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -138,6 +138,10 @@ public:
 	// Get the name of this particular ship.
 	const std::string &Name() const;
 
+	// Effects to be created upon certain events that occur to the ship
+	const std::map<const Effect *, int> &ShieldHitEffects() const;
+	const std::map<const Effect *, int> &HullHitEffects() const;
+
 	// Set / Get the name of this model of ship.
 	void SetModelName(const std::string &model);
 	const std::string &ModelName() const;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -343,7 +343,7 @@ public:
 	// DamageDealt from that weapon. The return value is a ShipEvent type,
 	// which may be a combination of PROVOKED, DISABLED, and DESTROYED.
 	// Create any target effects as sparks.
-	int TakeDamage(std::vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, double intersection, Point hitVelocity, Angle hitAngle);
+	int TakeDamage(std::vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, Point intersection, Point hitVelocity, Angle hitAngle);
 	int DoDamage(std::vector<Visual> &visuals, const DamageDealt &damage);
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -343,7 +343,8 @@ public:
 	// DamageDealt from that weapon. The return value is a ShipEvent type,
 	// which may be a combination of PROVOKED, DISABLED, and DESTROYED.
 	// Create any target effects as sparks.
-	int TakeDamage(std::vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment);
+	int TakeDamage(std::vector<Visual> &visuals, const DamageDealt &damage, const Government *sourceGovernment, double intersection, Point hitVelocity, Angle hitAngle);
+	int DoDamage(std::vector<Visual> &visuals, const DamageDealt &damage);
 	// Apply a force to this ship, accelerating it. This might be from a weapon
 	// impact, or from firing a weapon, for example.
 	void ApplyForce(const Point &force, bool gravitational = false);
@@ -455,6 +456,10 @@ private:
 	int swizzle;
 	const Government *government;
 	*/
+
+	// Event effects
+	std::map<const Effect *, int> hullHitEffects;
+	std::map<const Effect *, int> shieldHitEffects;
 
 	// Characteristics of the chassis:
 	bool isDefined = false;


### PR DESCRIPTION
**Feature:**

## Feature Details
This PR implements the ability for ships to define effects created when they damaged by weapons, regardless of which weapon that is. Ships can define different effects for shield damage and hull damage. By default, the hull damage effect is used if the shield damage effect is not defined.

## Screenshots
This is an image of a korath raider/palavret modified to create the blaster impact effect upon receiving shield damage. the banishers used are unmodified from the master branch.
![mod korath](https://user-images.githubusercontent.com/65236599/188502710-b3b4fd06-5807-48f6-9adb-d4d6bcde3c16.png)

This is a screen shot of the same ship, with the same weapons in the same session firing at a quick silver pirate where the effects are not produced.
![pirate](https://user-images.githubusercontent.com/65236599/188502903-10ce280c-269c-42e9-a8ef-ff897957397e.png)


## Usage Examples
This differs from the weapon attribute `"targeted effect"` as the placement of the effect is at the point of impact of the weapon and isn't randomly selected. It also is set by each ship for receiving damage and not for weapons giving damage.

This could be used both in plugins and vanilla. Examples could be having a "shield stress" effect for low tier species receiving shield damage, archons disintegrating incoming projectiles or the dromedary (the new remnant ghost ship thing) sending projectiles to an alternative plane of existence.

Current format:
```
ship "Test-bot"
	sprite "ship/sunder"
	"never disabled"
	attributes
		category "Light Warship"
		"hull" 1000
		"shields" 1000
		"automaton" 1
		"mass" 100
		"drag" 1
		"heat dissipation" .9
		"outfit space" 500
		"weapon capacity" 5
		"hull repair rate" 5
		"energy generation" .7
		"energy capacity" 100
		"turn" 40
		"turning energy" .2
		"thrust" 10
		"thrusting energy" .3
	outfits
		"Nano Strike"
	
	engine 0 0
	gun 0 0
	"hit effect" "hull impact"
	"shield hit effect" "shield impact"
	description "This test craft applies different hit effects to both shields and hull"
```

The effects are defined at the same level as explosions, "never disabled" attributes and ship description. If `"shield hit effect"` is undefined, `"hit effect"` is instead used if that is defined.

## Testing Done
I have tested combinations of `"hit effect"` and `"shield hit effect"` and they work as advertised. Piercing damage produces effects depending on whether it damages shields/hull. If both are damaged by weapons then both may produce effects.
`"hit effect"` carries over to `"shield hit effect"` under the behaviour defined above and effects appear at the point of impact.

[This save file places you on earth with 3 test ships and a star barge equipped with a test weapon: test 2.txt](https://github.com/endless-sky/endless-sky/files/9491738/test.2.txt)

[This is a test plugin for use with the above save file: test plugin.zip](https://github.com/endless-sky/endless-sky/files/9491740/test.plugin.zip)

## Performance Impact
As with all effects, extensive usage by content creators will have negative effects to performance, but with few or no effects performance should not be noticeably impacted.

## Additional notes
The ship `TakeDamage` function has been refactored to allow weather and weapons damage to work properly. `DoDamage` now actually applies damage to the ship and the `TakeDamage` function controls effects and government provocation. This will also allow for further expansion of ship damage controls.