### PR TITLE
fix(content): Remnant "Rano'erek (Ground Assault)" bounty and variant fix.

### DIFF
--- a/data/korath/korath variants.txt
+++ b/data/korath/korath variants.txt
@@ -137,8 +137,7 @@ ship "Rano'erek" "Rano'erek (Ground Assault)"
 		"bunks" 92
 		"mass" 115
 		"cargo space" -120
-		"outfit space" -370
-		"heat dissipation" -0.04
+		"outfit space" -248
 	outfits
 		"Banisher Grav-Turret" 2
 		"Warder Anti-Missile" 2

--- a/data/korath/korath variants.txt
+++ b/data/korath/korath variants.txt
@@ -133,13 +133,15 @@ ship "Rano'erek" "Rano'erek (Shunt)"
 
 ship "Rano'erek" "Rano'erek (Ground Assault)"
 	"crew" 449
+	add attributes
+		"bunks" 92
+		"cargo space" -120
+		"heat dissipation" -0.04
 	outfits
 		"Banisher Grav-Turret" 2
 		"Warder Anti-Missile" 2
 		
-		"Outfits Expansion" 6
 		"Double Plasma Core"
-		"Bunk Room" 23
 		"Large Heat Shunt"
 		"Fuel Processor"
 		"Thermal Repeater Rifle" 449

--- a/data/korath/korath variants.txt
+++ b/data/korath/korath variants.txt
@@ -135,7 +135,9 @@ ship "Rano'erek" "Rano'erek (Ground Assault)"
 	"crew" 449
 	add attributes
 		"bunks" 92
+		"mass" 115
 		"cargo space" -120
+		"outfit space" -370
 		"heat dissipation" -0.04
 	outfits
 		"Banisher Grav-Turret" 2

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -207,7 +207,7 @@ mission "Remnant: Bounty 5"
 		random < 5
 	npc kill
 		government "Korath"
-		personality heroic vindictive uninterested target marked
+		personality heroic vindictive uninterested target marked staying
 		system
 			attributes "ember waste"
 			not attributes "graveyard"

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -207,7 +207,7 @@ mission "Remnant: Bounty 5"
 		random < 5
 	npc kill
 		government "Korath"
-		personality heroic vindictive uninterested target marked staying
+		personality heroic vindictive target marked staying
 		system
 			attributes "ember waste"
 			not attributes "graveyard"


### PR DESCRIPTION
**Bugfix:** This PR addresses two issues

## Fix Details
1. The target ship wanders aimlessly, and can go a very long ways away, making it almost impossible to find. (Thanks to warp-core for highlighting this to me)
2. While outfit expansions are eminently useful for players and NPCs who are making quick changes to ships and/or one-off ships, they do not make sense for factions that have ready access to shipyards and routinely make use of a specific configuration. (Thanks to Ravenshining for bringing this to my attention)

The fixes:
1. Giving the target ship the "staying" personality so that it doesn't wander. (please note that I would, in fact, like it to wander, but I would prefer to have it stay within the Ember Waste and/or within 2 jumps of its starting system. So having an NPC restriction system whereby we could specify that the NPC will only ever jump to systems that meet regular filters, such as by attribute or distance from starting system, would be much prefered as a long-term solution)
2. The "Rano'erek (Ground Assault)" variant, as befitting a standard version of this ship that the Exiles use, has been converted from being a regular "Rano'erek" with 6 expansions and 23 bunks, to being a variant that has significantly less cargo (and much less outfit space), but has 94 extra bunks.

