### PR TITLE
register derived conditions before reading the savefile; and set the …

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -107,12 +107,8 @@ void PlayerInfo::New(const StartConditions &start)
 	SetSystem(start.GetSystem());
 	SetPlanet(&start.GetPlanet());
 	accounts = start.GetAccounts();
-
-	// Register derived conditions before applying start conditions,
-	// so that any that belong in a derived provider go into that correctly.
-	// TODO This should be checked
-	RegisterDerivedConditions();
 	start.GetConditions().Apply(conditions);
+	RegisterDerivedConditions();
 
 	// Generate missions that will be available on the first day.
 	CreateMissions();
@@ -143,9 +139,7 @@ void PlayerInfo::Load(const string &path)
 	// we provide the same access to services in this session, too.
 	bool hasFullClearance = false;
 
-	// Register derived conditions before loading primary conditions from the
-	// savegame. Conditions that belong in a derived provider will then load into
-	// them correctly.
+	// Register derived conditions now, so old primary versions can load into them
 	RegisterDerivedConditions();
 
 	DataFile file(path);
@@ -186,8 +180,8 @@ void PlayerInfo::Load(const string &path)
 		{
 			for(const DataNode &grand : child)
 				if(grand.Size() >= 2)
-					GameData::Governments().Get(grand.Token(0))->
-						SetReputation(grand.Value(1));
+					reputationChanges.emplace_back(
+						GameData::Governments().Get(grand.Token(0)), grand.Value(1));
 		}
 
 		// Records of things you own:

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -7,7 +7,10 @@ Foundation, either version 3 of the License, or (at your option) any later versi
 
 Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "PlayerInfo.h"
@@ -104,10 +107,12 @@ void PlayerInfo::New(const StartConditions &start)
 	SetSystem(start.GetSystem());
 	SetPlanet(&start.GetPlanet());
 	accounts = start.GetAccounts();
-	// Register the derived conditions before applying start conditions, so that any that belong in a derived provider go into that correctly.
+
+	// Register derived conditions before applying start conditions,
+	// so that any that belong in a derived provider go into that correctly.
+	// TODO This should be checked
 	RegisterDerivedConditions();
 	start.GetConditions().Apply(conditions);
-	// RegisterDerivedConditions() used to be here
 
 	// Generate missions that will be available on the first day.
 	CreateMissions();
@@ -138,7 +143,9 @@ void PlayerInfo::Load(const string &path)
 	// we provide the same access to services in this session, too.
 	bool hasFullClearance = false;
 
-	// Register derived conditions before loading conditions from the savegame. That way, conditions that belong in a derived provider get loaded there properly.
+	// Register derived conditions before loading primary conditions from the
+	// savegame. Conditions that belong in a derived provider will then load into
+	// them correctly.
 	RegisterDerivedConditions();
 
 	DataFile file(path);
@@ -179,8 +186,6 @@ void PlayerInfo::Load(const string &path)
 		{
 			for(const DataNode &grand : child)
 				if(grand.Size() >= 2)
-					// reputationChanges.emplace_back(
-					// 	GameData::Governments().Get(grand.Token(0)), grand.Value(1));
 					GameData::Governments().Get(grand.Token(0))->
 						SetReputation(grand.Value(1));
 		}
@@ -304,8 +309,6 @@ void PlayerInfo::Load(const string &path)
 	// Restore access to services, if it was granted previously.
 	if(planet && hasFullClearance)
 		planet->Bribe();
-	// Make the derived conditions available again.
-	// RegisterDerivedConditions(); used to be here
 
 	// Based on the ships that were loaded, calculate the player's capacity for
 	// cargo and passengers.
@@ -1207,7 +1210,8 @@ void PlayerInfo::Land(UI *ui)
 	// do not name them all (since this would overflow the screen).
 	else if(ui && !inactiveMissions.empty())
 	{
-		string message = "These active missions or jobs were deactivated due to a missing definition - perhaps you recently removed a plugin?\n";
+		string message = "These active missions or jobs were deactivated due to a missing definition"
+			" - perhaps you recently removed a plugin?\n";
 		auto mit = inactiveMissions.rbegin();
 		int named = 0;
 		while(mit != inactiveMissions.rend() && (++named < 10))
@@ -2551,35 +2555,45 @@ void PlayerInfo::RegisterDerivedConditions()
 	static constexpr int64_t limit = static_cast<int64_t>(1) << 62;
 
 	auto &&netWorthProvider = conditions.GetProviderNamed("net worth");
-	netWorthProvider.SetGetFunction([this](const string &name) { return min(limit, max(-limit, accounts.NetWorth())); });
+	netWorthProvider.SetGetFunction([this](const string &name)
+		{ return min(limit, max(-limit, accounts.NetWorth())); });
 
 	auto &&creditsProvider = conditions.GetProviderNamed("credits");
-	creditsProvider.SetGetFunction([this](const string &name) { return min(limit, accounts.Credits()); });
+	creditsProvider.SetGetFunction([this](const string &name) {
+		return min(limit, accounts.Credits()); });
 
 	auto &&unpaidMortgagesProvider = conditions.GetProviderNamed("unpaid mortgages");
-	unpaidMortgagesProvider.SetGetFunction([this](const string &name) { return min(limit, accounts.TotalDebt("Mortgage")); });
+	unpaidMortgagesProvider.SetGetFunction([this](const string &name) {
+		return min(limit, accounts.TotalDebt("Mortgage")); });
 
 	auto &&unpaidFinesProvider = conditions.GetProviderNamed("unpaid fines");
-	unpaidFinesProvider.SetGetFunction([this](const string &name) { return min(limit, accounts.TotalDebt("Fine")); });
+	unpaidFinesProvider.SetGetFunction([this](const string &name) {
+		return min(limit, accounts.TotalDebt("Fine")); });
 
 	auto &&unpaidSalariesProvider = conditions.GetProviderNamed("unpaid salaries");
-	unpaidSalariesProvider.SetGetFunction([this](const string &name) { return min(limit, accounts.SalariesOwed()); });
+	unpaidSalariesProvider.SetGetFunction([this](const string &name) {
+		return min(limit, accounts.SalariesOwed()); });
 
 	auto &&unpaidMaintenanceProvider = conditions.GetProviderNamed("unpaid maintenance");
-	unpaidMaintenanceProvider.SetGetFunction([this](const string &name) { return min(limit, accounts.MaintenanceDue()); });
+	unpaidMaintenanceProvider.SetGetFunction([this](const string &name) {
+		return min(limit, accounts.MaintenanceDue()); });
 
 	auto &&creditScoreProvider = conditions.GetProviderNamed("credit score");
-	creditScoreProvider.SetGetFunction([this](const string &name) { return accounts.CreditScore(); });
+	creditScoreProvider.SetGetFunction([this](const string &name) {
+		return accounts.CreditScore(); });
 
 	// Read-only flagship conditions.
 	auto &&flagshipCrewProvider = conditions.GetProviderNamed("flagship crew");
-	flagshipCrewProvider.SetGetFunction([this](const string &name) -> int64_t { return flagship ? flagship->Crew() : 0; });
+	flagshipCrewProvider.SetGetFunction([this](const string &name) -> int64_t {
+		return flagship ? flagship->Crew() : 0; });
 
 	auto &&flagshipRequiredCrewProvider = conditions.GetProviderNamed("flagship required crew");
-	flagshipRequiredCrewProvider.SetGetFunction([this](const string &name) -> int64_t { return flagship ? flagship->RequiredCrew() : 0; });
+	flagshipRequiredCrewProvider.SetGetFunction([this](const string &name) -> int64_t {
+		return flagship ? flagship->RequiredCrew() : 0; });
 
 	auto &&flagshipBunksProvider = conditions.GetProviderNamed("flagship bunks");
-	flagshipBunksProvider.SetGetFunction([this](const string &name) -> int64_t { return flagship ? flagship->Attributes().Get("bunks") : 0; });
+	flagshipBunksProvider.SetGetFunction([this](const string &name) -> int64_t {
+		return flagship ? flagship->Attributes().Get("bunks") : 0; });
 
 	auto &&flagshipModelProvider = conditions.GetProviderPrefixed("flagship model: ");
 	auto flagshipModelFun = [this](const string &name) -> bool
@@ -2593,10 +2607,12 @@ void PlayerInfo::RegisterDerivedConditions()
 
 	// Conditions for your fleet's attractiveness to pirates.
 	auto &&cargoAttractivenessProvider = conditions.GetProviderNamed("cargo attractiveness");
-	cargoAttractivenessProvider.SetGetFunction([this](const string &name) -> int64_t { return RaidFleetFactors().first; });
+	cargoAttractivenessProvider.SetGetFunction([this](const string &name) -> int64_t {
+		return RaidFleetFactors().first; });
 
 	auto &&armamentDeterrence = conditions.GetProviderNamed("armament deterrence");
-	armamentDeterrence.SetGetFunction([this](const string &name) -> int64_t { return RaidFleetFactors().second; });
+	armamentDeterrence.SetGetFunction([this](const string &name) -> int64_t {
+		return RaidFleetFactors().second; });
 
 	auto &&pirateAttractionProvider = conditions.GetProviderNamed("pirate attraction");
 	pirateAttractionProvider.SetGetFunction([this](const string &name) -> int64_t

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -7,10 +7,7 @@ Foundation, either version 3 of the License, or (at your option) any later versi
 
 Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE. See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program. If not, see <https://www.gnu.org/licenses/>.
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 */
 
 #include "PlayerInfo.h"
@@ -107,8 +104,10 @@ void PlayerInfo::New(const StartConditions &start)
 	SetSystem(start.GetSystem());
 	SetPlanet(&start.GetPlanet());
 	accounts = start.GetAccounts();
-	start.GetConditions().Apply(conditions);
+	// Register the derived conditions before applying start conditions, so that any that belong in a derived provider go into that correctly.
 	RegisterDerivedConditions();
+	start.GetConditions().Apply(conditions);
+	// RegisterDerivedConditions() used to be here
 
 	// Generate missions that will be available on the first day.
 	CreateMissions();
@@ -138,6 +137,9 @@ void PlayerInfo::Load(const string &path)
 	// The player may have bribed their current planet in the last session. Ensure
 	// we provide the same access to services in this session, too.
 	bool hasFullClearance = false;
+
+	// Register derived conditions before loading conditions from the savegame. That way, conditions that belong in a derived provider get loaded there properly.
+	RegisterDerivedConditions();
 
 	DataFile file(path);
 	for(const DataNode &child : file)
@@ -177,8 +179,10 @@ void PlayerInfo::Load(const string &path)
 		{
 			for(const DataNode &grand : child)
 				if(grand.Size() >= 2)
-					reputationChanges.emplace_back(
-						GameData::Governments().Get(grand.Token(0)), grand.Value(1));
+					// reputationChanges.emplace_back(
+					// 	GameData::Governments().Get(grand.Token(0)), grand.Value(1));
+					GameData::Governments().Get(grand.Token(0))->
+						SetReputation(grand.Value(1));
 		}
 
 		// Records of things you own:
@@ -301,7 +305,7 @@ void PlayerInfo::Load(const string &path)
 	if(planet && hasFullClearance)
 		planet->Bribe();
 	// Make the derived conditions available again.
-	RegisterDerivedConditions();
+	// RegisterDerivedConditions(); used to be here
 
 	// Based on the ships that were loaded, calculate the player's capacity for
 	// cargo and passengers.
@@ -1203,8 +1207,7 @@ void PlayerInfo::Land(UI *ui)
 	// do not name them all (since this would overflow the screen).
 	else if(ui && !inactiveMissions.empty())
 	{
-		string message = "These active missions or jobs were deactivated due to a missing definition"
-			" - perhaps you recently removed a plugin?\n";
+		string message = "These active missions or jobs were deactivated due to a missing definition - perhaps you recently removed a plugin?\n";
 		auto mit = inactiveMissions.rbegin();
 		int named = 0;
 		while(mit != inactiveMissions.rend() && (++named < 10))
@@ -2548,45 +2551,35 @@ void PlayerInfo::RegisterDerivedConditions()
 	static constexpr int64_t limit = static_cast<int64_t>(1) << 62;
 
 	auto &&netWorthProvider = conditions.GetProviderNamed("net worth");
-	netWorthProvider.SetGetFunction([this](const string &name)
-		{ return min(limit, max(-limit, accounts.NetWorth())); });
+	netWorthProvider.SetGetFunction([this](const string &name) { return min(limit, max(-limit, accounts.NetWorth())); });
 
 	auto &&creditsProvider = conditions.GetProviderNamed("credits");
-	creditsProvider.SetGetFunction([this](const string &name) {
-		return min(limit, accounts.Credits()); });
+	creditsProvider.SetGetFunction([this](const string &name) { return min(limit, accounts.Credits()); });
 
 	auto &&unpaidMortgagesProvider = conditions.GetProviderNamed("unpaid mortgages");
-	unpaidMortgagesProvider.SetGetFunction([this](const string &name) {
-		return min(limit, accounts.TotalDebt("Mortgage")); });
+	unpaidMortgagesProvider.SetGetFunction([this](const string &name) { return min(limit, accounts.TotalDebt("Mortgage")); });
 
 	auto &&unpaidFinesProvider = conditions.GetProviderNamed("unpaid fines");
-	unpaidFinesProvider.SetGetFunction([this](const string &name) {
-		return min(limit, accounts.TotalDebt("Fine")); });
+	unpaidFinesProvider.SetGetFunction([this](const string &name) { return min(limit, accounts.TotalDebt("Fine")); });
 
 	auto &&unpaidSalariesProvider = conditions.GetProviderNamed("unpaid salaries");
-	unpaidSalariesProvider.SetGetFunction([this](const string &name) {
-		return min(limit, accounts.SalariesOwed()); });
+	unpaidSalariesProvider.SetGetFunction([this](const string &name) { return min(limit, accounts.SalariesOwed()); });
 
 	auto &&unpaidMaintenanceProvider = conditions.GetProviderNamed("unpaid maintenance");
-	unpaidMaintenanceProvider.SetGetFunction([this](const string &name) {
-		return min(limit, accounts.MaintenanceDue()); });
+	unpaidMaintenanceProvider.SetGetFunction([this](const string &name) { return min(limit, accounts.MaintenanceDue()); });
 
 	auto &&creditScoreProvider = conditions.GetProviderNamed("credit score");
-	creditScoreProvider.SetGetFunction([this](const string &name) {
-		return accounts.CreditScore(); });
+	creditScoreProvider.SetGetFunction([this](const string &name) { return accounts.CreditScore(); });
 
 	// Read-only flagship conditions.
 	auto &&flagshipCrewProvider = conditions.GetProviderNamed("flagship crew");
-	flagshipCrewProvider.SetGetFunction([this](const string &name) -> int64_t {
-		return flagship ? flagship->Crew() : 0; });
+	flagshipCrewProvider.SetGetFunction([this](const string &name) -> int64_t { return flagship ? flagship->Crew() : 0; });
 
 	auto &&flagshipRequiredCrewProvider = conditions.GetProviderNamed("flagship required crew");
-	flagshipRequiredCrewProvider.SetGetFunction([this](const string &name) -> int64_t {
-		return flagship ? flagship->RequiredCrew() : 0; });
+	flagshipRequiredCrewProvider.SetGetFunction([this](const string &name) -> int64_t { return flagship ? flagship->RequiredCrew() : 0; });
 
 	auto &&flagshipBunksProvider = conditions.GetProviderNamed("flagship bunks");
-	flagshipBunksProvider.SetGetFunction([this](const string &name) -> int64_t {
-		return flagship ? flagship->Attributes().Get("bunks") : 0; });
+	flagshipBunksProvider.SetGetFunction([this](const string &name) -> int64_t { return flagship ? flagship->Attributes().Get("bunks") : 0; });
 
 	auto &&flagshipModelProvider = conditions.GetProviderPrefixed("flagship model: ");
 	auto flagshipModelFun = [this](const string &name) -> bool
@@ -2600,12 +2593,10 @@ void PlayerInfo::RegisterDerivedConditions()
 
 	// Conditions for your fleet's attractiveness to pirates.
 	auto &&cargoAttractivenessProvider = conditions.GetProviderNamed("cargo attractiveness");
-	cargoAttractivenessProvider.SetGetFunction([this](const string &name) -> int64_t {
-		return RaidFleetFactors().first; });
+	cargoAttractivenessProvider.SetGetFunction([this](const string &name) -> int64_t { return RaidFleetFactors().first; });
 
 	auto &&armamentDeterrence = conditions.GetProviderNamed("armament deterrence");
-	armamentDeterrence.SetGetFunction([this](const string &name) -> int64_t {
-		return RaidFleetFactors().second; });
+	armamentDeterrence.SetGetFunction([this](const string &name) -> int64_t { return RaidFleetFactors().second; });
 
 	auto &&pirateAttractionProvider = conditions.GetProviderNamed("pirate attraction");
 	pirateAttractionProvider.SetGetFunction([this](const string &name) -> int64_t


### PR DESCRIPTION
Edit: the finished version does not adjust when the "reputation with" is applied, meaning reputation in that overrides obsolete reputation in conditions. It also does not touch new games, only loaded games.
- If anyone comes across this because their save is corrupted from a mission reputation change that didn't apply, like https://github.com/endless-sky/endless-sky/issues/7217 , you can either load an earlier save than that mission, then this fix should work for you, or you can edit your savefile, then use this fix.

---

Possible solution to https://github.com/endless-sky/endless-sky/issues/7217

This change
- Registers the derived conditions before reading the savefile (or the `start` for a new player)
- When reading the saved "reputation with", stores directly to the GameData government reputation, instead of queuing to save later.

The result
- Any saved primary `condition`s that belong in a derived condition, will load into their correct derived condition setter, then the obsolete primary condition will be forgotten and lost from the savefile
- For reputation, the old conditions (if still there) will overwrite the `"reputation with"` block
- Government reputations will now be all rounded to integers, because the conditions were
- Therefore **this should fix** people's games whether before they hit a reputation-changing mission, or if they've already had one.
  - I haven't looked at what happens if a mission *adjusts* instead of *setting* reputation
- It should also stop future obsolete primary conditions from perma-bugging the game when new derived conditions are implemented
  - but care should be given to where the 'correct' data comes from at the point of the change

Non-results
- Any other derived condition, which is temporarily loaded then applied through `ApplyChanges()` (as reputation was), will overwrite the obsolete conditions with whatever is loaded, effectively ignoring and removing the obsolete conditions instead of applying then removing.
- The warning suggested by @petervdmeer is not implemented. Perhaps with this change it's not needed

Assumptions
- Since mission actions currently affect primary conditions if present, any primary condition reputations will be more correct than their `"reputation with"` counterparts
  - this will wipe any reputation changes other than by mission, since the derived-condition-PR came into effect. Surely mission actions are more important
- `"reputation with"` in the save is always before `"conditions"`. Otherwise, `"reputation with"` will take priority if both provide reputations.
- fractional reputations are not that important, and it's okay to truncate them when making this fix.
- Derived conditions are only ever registered the once: on new/load player
- The savefile is only read once

Testing
- I've tested this on my out-of-sync save, which had Syndicate reputation stuck on ~400 but condition `"reputation: Syndicate" -1000` already set from the mission
- I haven't tested on a new game

Style
- Seems like my Vim, or something, did a bunch of style changes (including the copyright header?!)
- If we do approve this solution, perhaps it's easiest if I just re-do it (it's such a small edit) and make sure not to change other formatting, so as not to clutter edits in git's record

Correctness
- I've made this PR so you can see and try. It needs really carefully checking before being part of the main game
- Both changes I've made, the old way (or the comments) implied it was deliberately done in that order, which I've 'concluded logically' isn't necessary
- I can't promise I haven't overlooked something.
- (I will however continue to look through with this, if we don't simply reject this proposed solution)

Haste
- Any solution to this shouldn't be implemented without careful checking, lest we make this worse!
- But this is a serious bug, stopping people from progressing properly in any campaign that sets reputation, so I think it should be fixed ASAP