### PR TITLE
fix(content) razer -> razor

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4492,7 +4492,7 @@ mission "Dangerous Games 2"
 			`	Karengo claps him on the back and gives him a signature grin. "Maybe <first> can keep you aboard after this in case they need anything from a high shelf!" Mussie smiles weakly, but his eyes don't leave the readout.`
 			`	TWENTY-FIVE KILOMETERS. "This's it," Karengo announces, "Sub up! Let's see what there is to see. And <first>, keep it to passive sensors. Don't want to attract any undue attention." The ship smoothly descends into the mouth of a massive cave and your visibility, clouded by dark sulfide emissions from the hydrothermal vents at the floor, drops to less than eight meters. 6 personal subpods fan out behind you, their communication equipment syncing with yours to display them as blips on your screen.`
 			`	"Ok, <first>," Karengo crackles over the radio. "I'll read you the first clue."`
-			`	"No other path may you take \ Oiled skins flash and flicker \ Razer spikes grow from the deep \ Titanic walls crush and smash \ Heed the beginnings to live".`
+			`	"No other path may you take \ Oiled skins flash and flicker \ Razor spikes grow from the deep \ Titanic walls crush and smash \ Heed the beginnings to live".`
 			choice
 				`	(Go east).`
 					goto east


### PR DESCRIPTION
Razer is a gaming hardware company, not a thing you shave with or a description of sharpness. Given that the context is a crazy person's weird poetry, it's possible this was an intentional typo, but it still stands out to me and seems like an error even if it was intentional, and the correction is correct too, so let's assume it was an unintentional typo and correct it.
