### PR TITLE
feat: Add 2 Drone Bays to the Aerie

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -596,6 +596,7 @@ mission "Deep: Mystery Cubes 4"
 			variant
 				"Aerie" 2
 				"Dagger" 4
+				"Combat Drone" 4
 				"Corvette (Speedy)"
 	npc
 		government "Republic"
@@ -2179,6 +2180,7 @@ mission "Deep: Scientist Rescue 1: Escorts"
 			variant
 				"Aerie"
 				"Dagger" 2
+				"Combat Drone" 2
 
 
 

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1428,6 +1428,7 @@ fleet "Small Deep Merchants"
 	variant 4
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 	variant 6
 		"Mule"
 		"Dagger"
@@ -1462,16 +1463,19 @@ fleet "Large Deep Merchants"
 	variant 5
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 		"Corvette"
 	variant 3
 		"Aerie"
-		"Dagger" 2
+		"Dagger" 2	
+		"Combat Drone" 2
 		"Raven"
 	variant 3
 		"Headhunter" 2
 	variant 3
 		"Aerie" 2
 		"Dagger" 4
+		"Combat Drone" 4
 	variant 8
 		"Bactrian"
 		"Dagger" 3
@@ -1481,12 +1485,14 @@ fleet "Large Deep Merchants"
 		"Raven"
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 	variant 2
 		"Bactrian"
 		"Dagger" 3
 		"Raven (Heavy)"
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 	variant 5
 		"Bactrian"
 		"Dagger" 3
@@ -1524,6 +1530,7 @@ fleet "Small Deep Security"
 	variant 4
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 	variant 3
 		"Raven"
 	variant 1
@@ -1553,26 +1560,32 @@ fleet "Large Deep Security"
 	variant 5
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 		"Corvette"
 	variant 2
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 		"Corvette (Missile)"
 	variant 2
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 		"Corvette (Speedy)"
 	variant 3
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 		"Raven"
 	variant 1
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 		"Raven (Heavy)"
 	variant 1
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 		"Raven (Afterburner)"
 	variant 4
 		"Raven" 2
@@ -1588,6 +1601,7 @@ fleet "Large Deep Security"
 	variant 3
 		"Aerie" 2
 		"Dagger" 4
+		"Combat Drone" 4
 	variant 8
 		"Corvette"
 		"Raven"
@@ -2211,9 +2225,11 @@ fleet "Small Northern Pirates"
 	variant 1
 		"Aerie"
 		"Lance" 2
+		"Combat Drone" 2
 	variant 1
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 	variant 3
 		"Headhunter"
 	variant 2
@@ -2286,21 +2302,26 @@ fleet "Large Northern Pirates"
 	variant 1
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 		"Corvette"
 	variant 1
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 		"Raven"
 	variant 2
 		"Aerie" 2
+		"Combat Drone" 4
 		"Dagger" 4
 	variant 2
 		"Aerie"
 		"Dagger" 2
+		"Combat Drone" 2
 		"Corvette (Missile)"
 	variant 1
 		"Aerie" 2
 		"Dagger" 4
+		"Combat Drone" 4
 		"Firebird"
 	variant 2
 		"Mule"
@@ -2542,6 +2563,7 @@ fleet "Bounty Hunters"
 	variant 1
 		"Aerie"
 		"Lance" 2
+		"Combat Drone" 2
 	variant 1
 		"Corvette"
 		"Fury (Missile)"

--- a/data/human/free worlds reconciliation.txt
+++ b/data/human/free worlds reconciliation.txt
@@ -755,7 +755,7 @@ mission "FW Syndicate Capture 1B"
 		event "fw begin syndicate capture"
 		conversation
 			`As you approach the planet, your ships spread out and begin scanning the ocean surface for a yacht matching the description you were given. After a few tense moments of wondering if Soylent is off-world at the moment, you find the ship.`
-			`	With neither deflector shields nor any weaponry that you can see, the yacht clearly poses no threat to an armed starship. The Aerie that Edrick sent launches its two fighters; when they land on the yacht's deck, armed police officers emerge. Meanwhile your fleet is ready to open fire at the first sign of resistance.`
+			`	With neither deflector shields nor any weaponry that you can see, the yacht clearly poses no threat to an armed starship. The Aerie that Edrick sent launches its two fighters and two drones; when they land on the yacht's deck, armed police officers emerge. Meanwhile your fleet is ready to open fire at the first sign of resistance.`
 			`	The officers soon radio you that they have found Soylent, and they bring him aboard your ship. Amid all the confusion, you notice a figure in diving gear who jumps off the rear of the yacht and disappears beneath the waves - one of Soylent's men, trying to escape. But since his leader is now in your custody, and your mission is accomplished, you see no reason to chase after him.`
 			`	The Oathkeeper captain sends you a brief message: "Your first priority is to reach the Deep with the prisoner. Our crew is prepared to serve as a rearguard, staying behind if necessary to ensure that you survive. Good luck, Captain."`
 				accept

--- a/data/human/free worlds reconciliation.txt
+++ b/data/human/free worlds reconciliation.txt
@@ -755,7 +755,7 @@ mission "FW Syndicate Capture 1B"
 		event "fw begin syndicate capture"
 		conversation
 			`As you approach the planet, your ships spread out and begin scanning the ocean surface for a yacht matching the description you were given. After a few tense moments of wondering if Soylent is off-world at the moment, you find the ship.`
-			`	With neither deflector shields nor any weaponry that you can see, the yacht clearly poses no threat to an armed starship. The Aerie that Edrick sent launches its two fighters and two drones; when they land on the yacht's deck, armed police officers emerge. Meanwhile your fleet is ready to open fire at the first sign of resistance.`
+			`	With neither deflector shields nor any weaponry that you can see, the yacht clearly poses no threat to an armed starship. The Aerie that Edrick sent launches its two fighters; when they land on the yacht's deck, armed police officers emerge. Meanwhile your fleet is ready to open fire at the first sign of resistance.`
 			`	The officers soon radio you that they have found Soylent, and they bring him aboard your ship. Amid all the confusion, you notice a figure in diving gear who jumps off the rear of the yacht and disappears beneath the waves - one of Soylent's men, trying to escape. But since his leader is now in your custody, and your mission is accomplished, you see no reason to chase after him.`
 			`	The Oathkeeper captain sends you a brief message: "Your first priority is to reach the Deep with the prisoner. Our crew is prepared to serve as a rearguard, staying behind if necessary to ensure that you survive. Good luck, Captain."`
 				accept

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -61,6 +61,8 @@ ship "Aerie"
 	turret 31 15.5 "Heavy Laser Turret"
 	bay "Fighter" -43.5 2
 	bay "Fighter" 43.5 2
+	bay "Drone" -43.5 2
+	bay "Drone" 43.5 2
 	leak "leak" 50 50
 	leak "flame" 50 80
 	leak "big leak" 90 30
@@ -69,7 +71,7 @@ ship "Aerie"
 	explode "medium explosion" 25
 	explode "large explosion" 10
 	"final explode" "final explosion medium"
-	description "The Lionheart Aerie is a light carrier, designed to be just big enough for two fighter bays plus a decent armament of its own. Variations on this same ship design have been in use in the Deep for almost half a millennium, but this model comes with the very latest in generator and weapon technology."
+	description "The Lionheart Aerie is a light carrier, designed to be just big enough for two fighter bays, two drone bays, plus a decent armament of its own. Variations on this same ship design have been in use in the Deep for almost half a millennium, but this model comes with the very latest in generator and weapon technology."
 
 
 


### PR DESCRIPTION
## Summary
The lack of accessible drone bays in human space often becomes a nuisance to those who capture drones earlier on. Despite not being extremely useful, many players still partake in capturing them, but currently have to wait until later in the game to either attempt capturing Automata drone carriers (requiring later game builds/JD access), Remnant Ibis (requires decent Remnant story progression), or the Hai Pond Strider (requires Wanderer campaign progression). 

Either this, or the player attempts to capture a Navy Cruiser/Carrier, which despite the Navy becoming hostile at one point in the FW campaign, doesn't seem to be a very solid reason to go out of the way and capture one just for this purpose.

The upcoming Sunder, a small mining ship that will carry two drones, will be a well-needed alleviation to this matter, but that doesn't mean it should be the only human ship able to carry Drones other than Cruisers. If on one end an upcoming small civilian vessel can carry two drones, and the other sits the Navy's large Cruiser/Carrier carrying four, there seems to be a nice spot in the middle for another ship, and the Aerie couldn't be a better fit.

## Implementation
Aeries have been constantly underrated in the game as their signature purpose is to be a small carrier. While an Aerie carrying two missile-oriented fighters can be fairly strong early in the game, they are still decently fightable as fighters are easily dispatched with any sort of decently sized weaponry. There have been talks as to buffing bay capacity for carrier ships, and the Aerie has been highlighted several times.

Adding two Drone bays to the Aerie further excels its particular role of a "pocket" carrier without going as far as to make it a carrier as strong as, well, the Carrier. Since it's such an underrated ship and very underused as many other ships do what it can except better, or don't even need to carry ships to be better, the Aerie deserves some love. Not only this, but this will now provide more incentive to obtain one as it will be another ship that can carry Drones in human space- a much needed utility as described above.

## Placeholding
A point was brought up as to why should a civilian ship be given drone bays if civilians won't be able to use them. I've currently given all Aerie fleets Combat Drones to fill them, and in the future when the Mining Drone is added, they can replace those on civilian fleets. The Deep would be keeping the combat drones (I don't see why the Deep couldn't have them). As for pirates, I'm not sure. They could easily plausibly capture therefore have combat drones, or just have mining drones. Maybe even mining drones refitted with a different weapon (Gatling gun? Javelin Pod?). 

This way, I'm avoiding having any bays empty (though I don't personally see a huge problem with that, but I understand gameplay/lore concerns). Perhaps this might be a time to revisit how obtainable combat drones should be? Either way, I'm fine if it makes more sense to leave the bays empty, or fill them with combat drones in the meantime. I don't think this is a major enough reason to cancel this entire concept.

All instances of an Aerie have been updated, and descriptions edited to match.

## Save File
N/A (I'm sure people can imagine an Aerie with two drones)