### PR TITLE
Pond Strider Alt Start origin -> planet

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2165,7 +2165,7 @@ conversation "solifuge conversation"
 		accept
 	
 	label glad
-	`	"Wonderful," Osen's father responds. "Once you have finished looking, simply return to <origin> and inform the port authorities that you have what we seek, and we will meet with you again." The elders all thank you for giving them more information on the Unfettered Solifuge and bid you safe travels.`
+	`	"Wonderful," Osen's father responds. "Once you have finished looking, simply return to <planet> and inform the port authorities that you have what we seek, and we will meet with you again." The elders all thank you for giving them more information on the Unfettered Solifuge and bid you safe travels.`
 		accept
 
 


### PR DESCRIPTION
----------------------
**Content Fix (Keyword Change Fix Thingy)**

## Summary

The Alt Start branch for the Pond Strider missions have an `origin` keyword, when you actually get this mission anywhere in Hai space. I got it on Frostmark while trading commodities. Leads to an awkward/misleading ending:

![image](https://user-images.githubusercontent.com/82293490/190675508-ee128e14-56dd-4123-b286-8ed0e97b1e9b.png)

This just changes the keyword from `origin` to `planet`, as the destination planet for this alt start mission is Hai-home.