### PR TITLE
fix(graphics): Fix Firestorm Animation

### DIFF
--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -959,7 +959,6 @@ outfit "Firelight Missile Bank"
 outfit "Firelight Turning"
 	weapon
 		sprite "projectile/firelight"
-			"frame rate" 12
 		"hit effect" "firelight ring" 20
 		"die effect" "piercer fire"
 		"velocity" 0.1
@@ -979,6 +978,7 @@ outfit "Firelight Activated"
 	weapon
 		sprite "projectile/firelight active"
 			"frame rate" 12
+			"random start frame"
 		"hit effect" "firelight ring" 20
 		"die effect" "small explosion"
 		"velocity" 3

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -1045,8 +1045,8 @@ outfit "Firestorm Battery"
 	"firestorm torpedo capacity" 13
 	weapon
 		sprite "projectile/firestorm torpedo"
-			"frame rate" 2
-			"no repeat"
+			"frame rate" 6
+			"random start frame"
 		"hardpoint sprite" "hardpoint/firestorm battery"
 		sound "firestorm"
 		ammo "Firestorm Torpedo"


### PR DESCRIPTION
**Feature (BugFix)** 

## Fix Details

Fixes the Firestorm Torpedo from having a static animation (4 frames per second, no repeat) to having one similar to the firelight/typhoon effect (6 fps, random start animation). 

This was remains from Nomadic's firestorm effect which just had a "wind-up" glow ~~for some reason~~.

(Also adjusts Firelight data to match.)



## Testing Done
I shot at ships and got shot at by ships. 👍 
