### PR TITLE
fix(variant): Add missing engines to "Korsmanath A'awoj (Special)"

### DIFF
--- a/data/korath/korath variants.txt
+++ b/data/korath/korath variants.txt
@@ -1112,6 +1112,13 @@ ship "Korsmanath A'awoj" "Korsmanath A'awoj (Special)"
 		"Cargo Expansion" 8
 		"Scram Drive"
 
+		"Afterburner (Stellar Class)"
+		"Reverser (Stellar Class)"
+		"Steering (Planetary Class)"
+		"Steering (Stellar Class)"
+		"Thruster (Planetary Class)"
+		"Thruster (Stellar Class)"
+
 	turret "Langrage Hyper-Heaver"
 	turret "Warder Anti-Missile"
 	turret "Banisher Grav-Turret"


### PR DESCRIPTION
**Bugfix**

## Fix Details

@DarcyManoel pointed out via Discord that some Korsmanath A'awojs drift upon spawning, and upon further examination that it lacked engines.

This PR adds its missing engines, identical to the other variants.