### PR TITLE
Dragonriders/Karengo Mission: Correct planet references

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4371,7 +4371,7 @@ mission "Dangerous Games 1"
 				`	(Leave.)`
 					decline
 			`	"... so then he asks me, 'Have you ever ridden one?' And I look back at this crazy joithead and I say, 'You're a crazy joithead.' But he's got me thinking, y'know? Nobody has ever ridden one. Least, not nobody that could talk after." He lets out a sharp laugh, then raises his voice. "So I ask you all: who wants to join Karengo to make history? Who wants to ride a dragon? I'll supply the jetpacks, you supply the courage."`
-			`	You've heard the stories of the dragons flying through <planet>'s skies as a child. Great beasts; graceful and dangerous, the apex predators of the air; they are strikingly similar to the dragons described in ancient legends. <planet> is host to many dangerous creatures, and these living myths hold a place at the top of that list.`
+			`	You've heard the stories of the dragons flying through Skymoot's skies as a child. Great beasts; graceful and dangerous, the apex predators of the air; they are strikingly similar to the dragons described in ancient legends. Skymoot is host to many dangerous creatures, and these living myths hold a place at the top of that list.`
 			`	A cheer goes up from the men, especially the drunk ones. Karengo starts to hand out death and accident waivers and collect money for the expedition. Suddenly, his expression darkens as he cocks his head, listening to an earpiece. "Listen up!" he yells. "Seems my regular pilot got in the way of some less reputable folk, and my replacement pilot lost his balls this evening and can't find 'em! We need ourselves a ship and a captain to bring this lot to <stopovers>! Who's brave enough? Who else wants to make history?"`
 			choice
 				`	"Captain <last>, at your service. We leave at dawn!"`
@@ -4380,7 +4380,7 @@ mission "Dangerous Games 1"
 					goto money
 				`	(Stay silent.)`
 			`	You remain silent as Karengo surveys the crowd. "What, nobody with a ship has the cojones to make history? I didn't know this bar was full of a bunch of sissies."`
-			`	One captain in the back of the bar jumps up. "Mama didn't raise no sissy! I'll bring you all to <planet>." A cheer rises up from the crowd and the captain is treated to several rounds of drinks. After the captain and all the passengers are sufficiently drunk, they saunter their way out of the bar, drunkenly singing about adventure as they go.`
+			`	One captain in the back of the bar jumps up. "Mama didn't raise no sissy! I'll bring you all to Skymoot." A cheer rises up from the crowd and the captain is treated to several rounds of drinks. After the captain and all the passengers are sufficiently drunk, they saunter their way out of the bar, drunkenly singing about adventure as they go.`
 				decline
 			label accept
 			`	After a cheer rises up from the crowd, you're treated to several rounds of drinks by your passengers; you sense any attempt to refuse would be ignored. You're unsure of how much you drank, but it was enough to make sure that you didn't remember. You wake up significantly after dawn with empty bottles and unconscious men strewn all over the ship's mess hall. Karengo peels himself off the floor and gives you a crooked smile, shielding his eyes from the light. "Alright, <last>," he says, "let's do this."`


### PR DESCRIPTION
NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!)

----------------------
**Content  Missions**

## Summary
The Dragonriders mission currently uses the substitution <planet> in the mission code when the location referenced is <stopovers>. This makes for confusion reading as it talks about dragons flying through the air of the planet you are on when you take the mission. This mission can only take place on one planet: Skymoot. And, as Skymoot is hard coded in the later text of the mission, I've done the same here. Testing with <stopovers> is a bit clumsy as it lists both the planet and the system.


-----------------------
**Bugfix:** This PR addresses issue #{{insert number}}
This was reported on the Discord but not formal bug was created.
https://discord.com/channels/251118043411775489/536900466655887360/1018081161815261205

## Fix Details
Hard coded reference to Skymoot.

## Testing Done
Adjusted frequency and tested. 
![Dragonriders-to-Skymoot](https://user-images.githubusercontent.com/70952724/191811128-975d4548-7846-417e-beb5-9d7a1d461ad8.png)

