### PR TITLE
fix(content): Remnant - Cognizance - Void Sprite Parts

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -53,8 +53,8 @@ mission "Remnant: Cognizance 1"
 		personality entering forbearing timid uninterested surveillance staying
 		fleet
 			names "korath"
-			cargo 1
-			commodities "void sprite parts"
+			cargo
+			outfitter "Void Sprite Parts"
 			variant
 				"Palavret (Ember)"
 				"'olofez" 2
@@ -116,8 +116,8 @@ mission "Remnant: Cognizance 2"
 		personality forbearing timid uninterested surveillance staying
 		fleet
 			names "korath"
-			cargo 1
-			commodities "void sprite parts"
+			cargo
+			outfitter "Void Sprite Parts"
 			variant
 				"Palavret (Ember)"
 				"'olofez" 2
@@ -177,8 +177,8 @@ mission "Remnant: Cognizance 4"
 		system "Aescolanus"
 		fleet
 			names "korath"
-			cargo 2
-			commodities "void sprite parts"
+			cargo
+			outfitter "Void Sprite Parts"
 			variant
 				"Rano'erek"
 				"Palavret (Ember)" 4
@@ -237,8 +237,8 @@ mission "Remnant: Cognizance 5"
 		system "Nenia"
 		fleet
 			names "korath"
-			cargo 2
-			commodities "void sprite parts"
+			cargo
+			outfitter "Void Sprite Parts"
 			variant
 				"Rano'erek"
 				"Palavret (Ember)" 4

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -54,7 +54,7 @@ mission "Remnant: Cognizance 1"
 		fleet
 			names "korath"
 			cargo
-			outfitter "Void Sprite Parts"
+			outfitters "Void Sprite Parts"
 			variant
 				"Palavret (Ember)"
 				"'olofez" 2
@@ -117,7 +117,7 @@ mission "Remnant: Cognizance 2"
 		fleet
 			names "korath"
 			cargo
-			outfitter "Void Sprite Parts"
+			outfitters "Void Sprite Parts"
 			variant
 				"Palavret (Ember)"
 				"'olofez" 2
@@ -178,7 +178,7 @@ mission "Remnant: Cognizance 4"
 		fleet
 			names "korath"
 			cargo
-			outfitter "Void Sprite Parts"
+			outfitters "Void Sprite Parts"
 			variant
 				"Rano'erek"
 				"Palavret (Ember)" 4
@@ -238,7 +238,7 @@ mission "Remnant: Cognizance 5"
 		fleet
 			names "korath"
 			cargo
-			outfitter "Void Sprite Parts"
+			outfitters "Void Sprite Parts"
 			variant
 				"Rano'erek"
 				"Palavret (Ember)" 4

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -53,7 +53,6 @@ mission "Remnant: Cognizance 1"
 		personality entering forbearing timid uninterested surveillance staying
 		fleet
 			names "korath"
-			cargo
 			outfitters "Void Sprite Parts"
 			variant
 				"Palavret (Ember)"
@@ -116,7 +115,6 @@ mission "Remnant: Cognizance 2"
 		personality forbearing timid uninterested surveillance staying
 		fleet
 			names "korath"
-			cargo
 			outfitters "Void Sprite Parts"
 			variant
 				"Palavret (Ember)"
@@ -177,7 +175,6 @@ mission "Remnant: Cognizance 4"
 		system "Aescolanus"
 		fleet
 			names "korath"
-			cargo
 			outfitters "Void Sprite Parts"
 			variant
 				"Rano'erek"
@@ -237,7 +234,6 @@ mission "Remnant: Cognizance 5"
 		system "Nenia"
 		fleet
 			names "korath"
-			cargo
 			outfitters "Void Sprite Parts"
 			variant
 				"Rano'erek"

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -876,11 +876,12 @@ outfit "Void Rifle"
 
 outfit "Void Sprite Parts"
 	category "Unique"
-	cost 250000
+	cost 500
 	thumbnail "outfit/mouthparts"
 	"mass" 1
 	"outfit space" -1
 	description "This is nothing more and nothing less than a cubic meter of void sprite parts. To the Remnant, this represents both a terrible occurrence and a dreadful opportunity."
+	description "	This could have been very valuable to someone who knew what they were doing, if it had been handled properly. Instead, it is worth little more than the value of the minerals and resources contained within."
 
 
 

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -874,6 +874,16 @@ outfit "Void Rifle"
 
 
 
+outfit "Void Sprite Parts"
+	category "Unique"
+	cost 250000
+	thumbnail "outfit/mouthparts"
+	"mass" 1
+	"outfit space" -1
+	description "This is nothing more and nothing less than a cubic meter of void sprite parts. To the Remnant, this represents both a terrible occurance and an dreadful opportunity."
+
+
+
 # Special
 
 outfit "Remnant License"

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -881,7 +881,7 @@ outfit "Void Sprite Parts"
 	"mass" 1
 	"outfit space" -1
 	description "This is nothing more and nothing less than a cubic meter of void sprite parts. To the Remnant, this represents both a terrible occurrence and a dreadful opportunity."
-	description "	This could have been very valuable to someone who knew what they were doing, if it had been handled properly. Instead, it is worth little more than the value of the minerals and resources contained within."
+	description "	This could have been very valuable to someone who knew what they were doing, if it had been handled properly. Instead, it is worth little more than the value of the compounds contained within."
 
 
 

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -880,7 +880,7 @@ outfit "Void Sprite Parts"
 	thumbnail "outfit/mouthparts"
 	"mass" 1
 	"outfit space" -1
-	description "This is nothing more and nothing less than a cubic meter of void sprite parts. To the Remnant, this represents both a terrible occurance and an dreadful opportunity."
+	description "This is nothing more and nothing less than a cubic meter of void sprite parts. To the Remnant, this represents both a terrible occurrence and an dreadful opportunity."
 
 
 

--- a/data/remnant/remnant.txt
+++ b/data/remnant/remnant.txt
@@ -1057,3 +1057,6 @@ outfitter "Remnant Salvage"
 	"Steering (Asteroid Class)"
 	"Steering (Planetary Class)"
 	"Fire-Lance"
+
+outfitter "Void Sprite Parts"
+	"Void Sprite Parts"


### PR DESCRIPTION
**Bugfix:** This PR addresses issue of Void Sprite Parts not showing up where they're supposed to.
pointed out in: https://github.com/endless-sky/endless-sky/pull/7261

## Fix Details
- Creates a Void Sprite Parts outfit (Uses the Mouthparts sprite, since that is, literally, a part of the Void Sprites.
- With a specific outfitter for it (this outfitter is not visible anywhere, but is used to populate fleet cargo)
