### PR TITLE
Add more buffer space to the bottom of the outfitter and shipyard

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -121,9 +121,9 @@ int OutfitterPanel::TileSize() const
 
 
 
-int OutfitterPanel::VisiblityCheckboxesSize() const
+int OutfitterPanel::VisibilityCheckboxesSize() const
 {
-	return 60;
+	return 30;
 }
 
 
@@ -808,7 +808,7 @@ void OutfitterPanel::DrawKey()
 	Color color[2] = {*GameData::Colors().Get("medium"), *GameData::Colors().Get("bright")};
 	const Sprite *box[2] = {SpriteSet::Get("ui/unchecked"), SpriteSet::Get("ui/checked")};
 
-	Point pos = Screen::BottomLeft() + Point(10., -VisiblityCheckboxesSize() + 10.);
+	Point pos = Screen::BottomLeft() + Point(10., -VisibilityCheckboxesSize() - 20.);
 	Point off = Point(10., -.5 * font.Height());
 	SpriteShader::Draw(box[showForSale], pos);
 	font.Draw("Show outfits for sale", pos + off, color[showForSale]);

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -48,7 +48,7 @@ public:
 
 protected:
 	virtual int TileSize() const override;
-	virtual int VisiblityCheckboxesSize() const override;
+	virtual int VisibilityCheckboxesSize() const override;
 	virtual int DrawPlayerShipInfo(const Point &point) override;
 	virtual bool HasItem(const std::string &name) const override;
 	virtual void DrawItem(const std::string &name, const Point &point, int scrollY) override;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -489,7 +489,7 @@ void ShopPanel::DrawMain()
 
 	// What amount would mainScroll have to equal to make nextY equal the
 	// bottom of the screen? (Also leave space for the "key" at the bottom.)
-	maxMainScroll = max(0., nextY + mainScroll - Screen::Height() / 2 - TILE_SIZE / 2 + VisiblityCheckboxesSize());
+	maxMainScroll = max(0., nextY + mainScroll - Screen::Height() / 2 - TILE_SIZE / 2 + VisibilityCheckboxesSize() + 40.);
 
 	PointerShader::Draw(Point(Screen::Right() - 10 - SIDE_WIDTH, Screen::Top() + 10),
 		Point(0., -1.), 10.f, 10.f, 5.f, Color(mainScroll > 0 ? .8f : .2f, 0.f));
@@ -568,7 +568,7 @@ void ShopPanel::DrawKey()
 
 
 
-int ShopPanel::VisiblityCheckboxesSize() const
+int ShopPanel::VisibilityCheckboxesSize() const
 {
 	return 0;
 }

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -54,7 +54,7 @@ protected:
 
 	// These are for the individual shop panels to override.
 	virtual int TileSize() const = 0;
-	virtual int VisiblityCheckboxesSize() const;
+	virtual int VisibilityCheckboxesSize() const;
 	virtual int DrawPlayerShipInfo(const Point &point) = 0;
 	virtual bool HasItem(const std::string &name) const = 0;
 	virtual void DrawItem(const std::string &name, const Point &point, int scrollY) = 0;


### PR DESCRIPTION
## Feature Details
In 949760972eb3053173f2c89001b4ab936e29c500, the maximum scroll in the outfitter/shipyard was changed from `nextY + mainScroll - Screen::Height() / 2 - TILE_SIZE / 2 + 40.` to `nextY + mainScroll - Screen::Height() / 2 - TILE_SIZE / 2 + VisiblityCheckboxesSize()`, where `VisiblityCheckboxesSize()` is 0 in the shipyard and 60 in the outfitter. This means the bottom of the shipyard lost 40 pixels of space, leading it to become somewhat cramped. Additionally, the extra space in the outfitter is only enough for outfits to be just above the visibility checkboxes. This PR reduces `VisibilityCheckboxesSize()` from 60 to 30, and adds 40 pixels back onto both the outfitter and shipyard. It also fixes a typo.

## UI Screenshots
Before:
![image](https://user-images.githubusercontent.com/60202690/193424142-cd4c99b8-7d62-4a63-bd85-aed23497fd21.png)
![image](https://user-images.githubusercontent.com/60202690/193424148-d641957e-02f2-4977-b278-c2800912cbb2.png)
After:
![image](https://user-images.githubusercontent.com/60202690/193424157-61e4c1e9-743f-46e5-b2ac-ce79b291cbd8.png)
![image](https://user-images.githubusercontent.com/60202690/193424164-6a4050ca-2da4-441c-a765-70433cce0282.png)


## Testing Done
Opened the game and played around on the outfitter/shipyard screen.

## Performance Impact
N/A
