### PR TITLE
(Fix) Pug Flares

### DIFF
--- a/data/pug/pug.txt
+++ b/data/pug/pug.txt
@@ -546,7 +546,7 @@ ship "Pug Zibruka"
 		"Jump Drive"
 		
 	engine -8.5 43
-	engine -8.5 43
+	engine 8.5 43
 	gun -19 -54 "Pug Zapper"
 	gun 19 -54 "Pug Zapper"
 	explode "pug tiny explosion" 10
@@ -598,7 +598,7 @@ ship "Pug Enfolta"
 		"Jump Drive"
 		
 	engine -10 63.5
-	engine -10 63.5
+	engine 10 63.5
 	gun -12.5 -94 "Pug Zapper"
 	gun 12.5 -94 "Pug Zapper"
 	gun -12.5 -94 "Pug Seeker"
@@ -653,7 +653,7 @@ ship "Pug Maboro"
 		"Jump Drive"
 		
 	engine -21 134.5
-	engine -21 134.5
+	engine 21 134.5
 	gun -33.5 -142.5 "Pug Seeker"
 	gun 33.5 -142.5 "Pug Seeker"
 	gun -24.5 -165 "Pug Seeker"


### PR DESCRIPTION
Fixed the engine flares not being mirrored.

The recent change to the pug ship sprites lead to the T1 ships having their engine flares placed on top of each other producing a single lopsided flare in game as seen below.
![unknown](https://user-images.githubusercontent.com/65236599/193439962-79505454-efab-40cb-9a96-a3c9b0db18ce.png)

This PR rectifies that issue by making sure the flares are properly mirrored.