### PR TITLE
Add deprecated Korath ships

### DIFF
--- a/data/deprecated ships.txt
+++ b/data/deprecated ships.txt
@@ -1,0 +1,835 @@
+# Copyright (c) 2014-2016 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+
+# Note: this file contains ships that are no longer used in the game, but that
+# must be maintained in case of any save file or plugin still referencing them.
+
+ship "Korath Dredger"
+	sprite "ship/dredger"
+	thumbnail "thumbnail/dredger"
+	attributes
+		category "Heavy Freighter"
+		"cost" 29370000
+		"shields" 32500
+		"hull" 16500
+		"required crew" 137
+		"bunks" 357
+		"mass" 1503
+		"drag" 17.1
+		"heat dissipation" .45
+		"fuel capacity" 900
+		"cargo space" 675
+		"outfit space" 763
+		"weapon capacity" 276
+		"engine capacity" 206
+		weapon
+			"blast radius" 300
+			"shield damage" 4600
+			"hull damage" 2300
+			"hit force" 5900
+	outfits
+		"Grab-Strike Turret" 2
+		"Banisher Grav-Turret"
+		"Warder Anti-Missile"
+		"Digger Mining Turret" 3
+		
+		"Systems Core (Large)"
+		"Triple Plasma Core"
+		"Large Heat Shunt" 2
+		"Small Heat Shunt"
+		"Fuel Processor"
+		"Thermal Repeater Rifle" 190
+		
+		"Reverser (Lunar Class)"
+		"Steering (Planetary Class)"
+		"Thruster (Planetary Class)"
+		"Scram Drive"
+		"Jump Drive"
+		
+	turret 0 -153 "Grab-Strike Turret"
+	turret -37.5 -152.5 "Digger Mining Turret"
+	turret 37.5 -152.5 "Grab-Strike Turret"
+	turret -45 -27.5 "Warder Anti-Missile"
+	turret 45 -27.5 "Digger Mining Turret"
+	turret -85.5 128 "Digger Mining Turret"
+	turret 85.5 128 "Banisher Grav-Turret"
+	engine 0 179
+	engine -32 164 .7
+	engine 32 164 .7
+	"reverse engine" -116 -68
+		zoom 0.6
+	"reverse engine" 116 -68
+		zoom 0.6
+	"reverse engine" -80.5 73
+		over
+		zoom 0.7
+	"reverse engine" 80.5 73
+		over
+		zoom 0.7
+	bay "Fighter" -93.5 -61
+	bay "Fighter" 93.5 -61
+	bay "Fighter" -84 174
+		back
+	bay "Fighter" 84 174
+		back
+	explode "tiny explosion" 120
+	explode "small explosion" 60
+	explode "medium explosion" 70
+	explode "large explosion" 50
+	explode "huge explosion" 15
+	"final explode" "final explosion large"
+	description "After the Korath were exiled from their homelands, efficient resource collection became a priority. World-ships were too precious to risk on dangerous forays, and Raiders lacked the cargo capacity. The Dredger was born as an answer to this problem, featuring an abundance of cargo and passenger space, with formidable defensive armament. With such a complement, these bulky ships can also offer potent support for frontline Raiders."
+
+
+ship "Korath Raider"
+	sprite "ship/raider"
+	thumbnail "thumbnail/raider"
+	attributes
+		category "Utility"
+		"cost" 16570000
+		"shields" 27000
+		"hull" 9000
+		"required crew" 145
+		"bunks" 250
+		"mass" 720
+		"drag" 12
+		"heat dissipation" .5
+		"fuel capacity" 600
+		"cargo space" 175
+		"outfit space" 777
+		"weapon capacity" 339
+		"engine capacity" 159
+		weapon
+			"blast radius" 250
+			"shield damage" 3600
+			"hull damage" 1800
+			"hit force" 5400
+	outfits
+		"Grab-Strike Turret" 4
+		"Banisher Grav-Turret"
+		"Warder Anti-Missile"
+		"Firelight Missile Bank" 2
+		"Firelight Storage Rack"
+		"Firelight Missile" 50
+		
+		"Double Plasma Core"
+		"Generator (Inferno Class)"
+		"Systems Core (Medium)"
+		"Large Heat Shunt"
+		"Small Heat Shunt" 3
+		"Fuel Processor"
+		"Thermal Repeater Rifle" 196
+		
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Bow Drive (Meteor Class)"
+		"Jump Drive"
+	
+	engine -20 127
+	engine 20 127
+	"reverse engine" -9 -154
+		zoom 0.7
+	"reverse engine" 9 -154
+		zoom 0.7
+	gun 32.5 -1 "Firelight Missile Bank"
+		angle 60
+	gun -32.5 -1 "Firelight Missile Bank"
+		angle 300
+	turret -10 -143 "Grab-Strike Turret"
+	turret 10 -143 "Grab-Strike Turret"
+	turret -36 -141 "Grab-Strike Turret"
+	turret 36 -141 "Grab-Strike Turret"
+	turret 0 41 "Banisher Grav-Turret"
+	turret 0 94 "Warder Anti-Missile"
+	bay "Fighter" -80 151 back
+	bay "Fighter" 80 151 back
+	explode "tiny explosion" 20
+	explode "small explosion" 45
+	explode "medium explosion" 50
+	explode "large explosion" 40
+	explode "huge explosion" 10
+	"final explode" "final explosion large"
+	description "Successive Raider designs have been the Korath warship of choice for plundering neighboring species for generations."
+	description "This model, like all Exile ships, has been adapted to house as many Korath as possible, as comfortably as possible, inflating its size beyond similarly classed warships. The spaceborne construction techniques employed allow for the ship's easy replacement, facilitating continued raids of nearby systems."
+
+
+ship "Korath Chaser"
+	sprite "ship/chaser"
+	thumbnail "thumbnail/chaser"
+	attributes
+		category "Fighter"
+		"cost" 671000
+		"shields" 2300
+		"hull" 900
+		"required crew" 1
+		"bunks" 1
+		"mass" 40
+		"drag" .9
+		"heat dissipation" .9
+		"outfit space" 92
+		"weapon capacity" 25
+		"engine capacity" 30
+		weapon
+			"blast radius" 48
+			"shield damage" 320
+			"hull damage" 160
+			"hit force" 480
+	outfits
+		"Korath Fire-Lance"
+		
+		"Generator (Furnace Class)"
+		"Small Heat Shunt"
+		"Thermal Repeater Rifle"
+		
+		"Thruster (Asteroid Class)"
+		"Steering (Asteroid Class)"
+	
+	engine -7 23
+	engine 7 23
+	gun 0 -28 "Korath Fire-Lance"
+	explode "tiny explosion" 20
+	description "The Korath Chaser is a fighter carried by most of their capital ships."
+	description "	Fighters do not come equipped with a hyperdrive. You cannot carry a fighter unless you have a ship in your fleet with a fighter bay."
+
+
+ship "Korath World-Ship"
+	sprite "ship/world-ship a"
+	thumbnail "thumbnail/world-ship a"
+	attributes
+		category "Utility"
+		cost 27690000
+		shields 47000
+		hull 34000
+		"required crew" 794
+		"bunks" 1492
+		"mass" 1735
+		"drag" 21
+		"heat dissipation" .4
+		"fuel capacity" 1000
+		"cargo space" 264
+		"outfit space" 839
+		"weapon capacity" 314
+		"engine capacity" 165
+		weapon
+			"blast radius" 400
+			"shield damage" 8000
+			"hull damage" 4000
+			"hit force" 12000
+	outfits
+		"Grab-Strike Turret" 2
+		"Banisher Grav-Turret" 3
+		"Warder Anti-Missile" 3
+		
+		"Triple Plasma Core"
+		"Systems Core (Large)"
+		"Large Heat Shunt" 2
+		"Fuel Processor"
+		"Thermal Repeater Rifle" 150
+		"Microbot Defense Station" 19
+		
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Hyperdrive"
+	
+	engine -37 343 .8
+	engine 0 343 .9
+	engine 37 343 .8
+	turret -76 -157 "Grab-Strike Turret"
+	turret 76 -157 "Banisher Grav-Turret"
+	turret -59 -135 "Warder Anti-Missile"
+	turret 59 -135 "Grab-Strike Turret"
+	turret -61 -6 "Banisher Grav-Turret"
+	turret 61 -6 "Warder Anti-Missile"
+	turret -66 210 "Warder Anti-Missile"
+	turret 66 210 "Banisher Grav-Turret"
+	explode "tiny explosion" 30
+	explode "small explosion" 45
+	explode "medium explosion" 50
+	explode "large explosion" 40
+	explode "huge explosion" 50
+	"final explode" "final explosion large"
+	description "Korath World-Ships are massive nomadic habitats that hold all that is left of their people."
+
+
+ship "Korath World-Ship" "Korath World-Ship B"
+	sprite "ship/world-ship b"
+	thumbnail "thumbnail/world-ship b"
+	turret -76 -219 "Grab-Strike Turret"
+	turret 76 -219 "Grab-Strike Turret"
+	turret -75 -112 "Banisher Grav-Turret"
+	turret 75 -112 "Banisher Grav-Turret"
+	turret 0 -92 "Warder Anti-Missile"
+	turret -83 165 "Warder Anti-Missile"
+	turret 83 165 "Warder Anti-Missile"
+	turret 0 277 "Banisher Grav-Turret"
+
+
+ship "Korath World-Ship" "Korath World-Ship C"
+	sprite "ship/world-ship c"
+	thumbnail "thumbnail/world-ship c"
+	turret -45 -243 "Warder Anti-Missile"
+	turret 45 -243 "Grab-Strike Turret"
+	turret -47 -136 "Grab-Strike Turret"
+	turret 47 -136 "Banisher Grav-Turret"
+	turret -70 57 "Warder Anti-Missile"
+	turret 70 57 "Banisher Grav-Turret"
+	turret -91 290 "Banisher Grav-Turret"
+	turret 91 290 "Warder Anti-Missile"
+
+ship "Korath Dredger" "Korath Dredger (Civilian)"
+	add attributes
+		"atmosphere scan" 1
+	outfits
+		"Digger Mining Turret" 2
+		"Shunt-Strike Turret"
+		"Langrage Hyper-Heaver"
+		"Banisher Grav-Turret"
+		"Warder Anti-Missile" 2
+		
+		"Liquid Sodium Cooler"
+		"Fuel Processor" 2
+		"Systems Core (Large)"
+		"Triple Plasma Core"
+		"Korath Repeater Rifle" 206
+		"Microbot Defense Station" 8
+		
+		"Afterburner (Asteroid Class)"
+		"Steering (Planetary Class)"
+		"Reverser (Lunar Class)"
+		"Thruster (Planetary Class)"
+		"Scram Drive"
+	
+	turret "Digger Mining Turret"
+	turret "Shunt-Strike Turret"
+	turret "Digger Mining Turret"
+	turret "Warder Anti-Missile"
+	turret "Langrage Hyper-Heaver"
+	turret "Banisher Grav-Turret"
+	turret "Warder Anti-Missile"
+
+
+ship "Korath Dredger" "Korath Dredger (Crippled)"
+	outfits
+		"Banisher Grav-Turret"
+		"Digger Mining Turret"
+		"Grab-Strike Turret"
+		"Warder Anti-Missile"
+		
+		"Triple Plasma Core"
+		"Large Heat Shunt"
+		"Small Heat Shunt" 4
+		"Fuel Processor"
+		"Korath Repeater Rifle" 190
+		
+		"Reverser (Lunar Class)"
+		"Steering (Lunar Class)"
+		"Steering (Asteroid Class)"
+		"Thruster (Lunar Class)"
+		"Thruster (Asteroid Class)"
+		"Hyperdrive"
+		"Jump Drive (Broken)"
+		
+	turret
+	turret "Digger Mining Turret"
+	turret
+	turret "Grab-Strike Turret"
+	turret
+	turret "Warder Anti-Missile"
+	turret "Banisher Grav-Turret"
+
+
+ship "Korath Dredger" "Korath Dredger (Digger)"
+	outfits
+		"Digger Mining Turret" 5
+		"Warder Anti-Missile"
+		"Banisher Grav-Turret"
+		
+		"Large Heat Shunt" 2
+		"Small Heat Shunt" 3
+		"Fuel Processor"
+		"Systems Core (Medium)"
+		"Triple Plasma Core"
+		"Korath Repeater Rifle" 206
+		"Cargo Expansion"
+		
+		"Reverser (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Thruster (Stellar Class)"
+		"Jump Drive"
+		"Scram Drive"
+	
+	turret "Digger Mining Turret"
+	turret "Digger Mining Turret"
+	turret "Digger Mining Turret"
+	turret "Banisher Grav-Turret"
+	turret "Warder Anti-Missile"
+	turret "Digger Mining Turret"
+	turret "Digger Mining Turret"
+
+
+ship "Korath Dredger" "Korath Dredger (Shunt)"
+	outfits
+		"Shunt-Strike Turret" 4
+		"Banisher Grav-Turret"
+		"Warder Anti-Missile" 2
+		
+		"Liquid Sodium Cooler"
+		"Fuel Processor"
+		"Systems Core (Large)"
+		"Triple Plasma Core"
+		"Korath Repeater Rifle" 206
+		
+		"Reverser (Asteroid Class)"
+		"Steering (Planetary Class)"
+		"Thruster (Planetary Class)"
+		"Jump Drive"
+		"Scram Drive"
+	
+	turret "Shunt-Strike Turret"
+	turret "Shunt-Strike Turret"
+	turret "Warder Anti-Missile"
+	turret "Shunt-Strike Turret"
+	turret "Shunt-Strike Turret"
+	turret "Banisher Grav-Turret"
+	turret "Warder Anti-Missile"
+
+
+ship "Korath Dredger" "Korath Dredger (Ground Assault)"
+	"crew" 449
+	outfits
+		"Banisher Grav-Turret" 2
+		"Warder Anti-Missile" 2
+		
+		"Outfits Expansion" 6
+		"Double Plasma Core"
+		"Bunk Room" 23
+		"Large Heat Shunt"
+		"Fuel Processor"
+		"Korath Repeater Rifle" 449
+		
+		"Reverser (Asteroid Class)"
+		"Steering (Lunar Class)"
+		"Thruster (Lunar Class)"
+		"Hyperdrive"
+		"Jump Drive"
+
+	turret 
+	turret
+	turret
+	turret "Warder Anti-Missile"
+	turret "Banisher Grav-Turret"
+	turret "Warder Anti-Missile"
+	turret "Banisher Grav-Turret"
+
+
+ship "Korath Dredger" "Korath Dredger (Heaver)"
+	outfits
+		"Langrage Hyper-Heaver" 4
+		"Warder Anti-Missile" 3
+
+		"Double Plasma Core"
+		"Generator (Furnace Class)"
+		"Large Heat Shunt"
+		"Systems Core (Large)"
+		"Fuel Processor" 5
+		"Korath Repeater Rifle" 190
+
+		"Reverser (Asteroid Class)"
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Jump Drive"
+
+	turret "Warder Anti-Missile"
+	turret "Langrage Hyper-Heaver"
+	turret "Langrage Hyper-Heaver"
+	turret "Warder Anti-Missile"
+	turret "Warder Anti-Missile"
+	turret "Langrage Hyper-Heaver"
+	turret "Langrage Hyper-Heaver"
+
+
+ship "Korath Raider" "Korath Raider (Blaze)"
+	outfits
+		"Blaze-Pike Turret" 4
+		"Digger Mining Turret"
+		"Warder Anti-Missile"
+		"Firelight Missile Bank" 2
+		"Firelight Missile" 40
+		
+		"Triple Plasma Core"
+		"Large Heat Shunt" 2
+		"Small Heat Shunt" 3
+		"Systems Core (Medium)"
+		"Fuel Processor"
+		"Korath Repeater Rifle" 196
+		
+		"Reverser (Asteroid Class)"
+		"Steering (Planetary Class)"
+		"Thruster (Planetary Class)"
+		"Jump Drive"
+	
+	gun "Firelight Missile Bank"
+	gun "Firelight Missile Bank"
+	turret "Blaze-Pike Turret"
+	turret "Blaze-Pike Turret"
+	turret "Blaze-Pike Turret"
+	turret "Blaze-Pike Turret"
+	turret "Digger Mining Turret"
+	turret "Warder Anti-Missile"
+
+
+ship "Korath Raider" "Korath Raider (Crippled)"
+	outfits
+		"Grab-Strike Turret" 2
+		"Banisher Grav-Turret"
+		"Warder Anti-Missile"
+		"Firelight Missile Bank"
+		"Firelight Missile" 9
+		
+		"Triple Plasma Core"
+		"Liquid Sodium Cooler"
+		"Korath Repeater Rifle" 196
+		"Outfits Expansion"
+		
+		"Bow Drive (Meteor Class)"
+		"Thruster (Asteroid Class)"
+		"Thruster (Lunar Class)"
+		"Steering (Asteroid Class)"
+		"Steering (Lunar Class)"
+		"Afterburner (Asteroid Class)"
+		"Jump Drive (Broken)"
+		"Hyperdrive"
+	
+	gun
+	gun "Firelight Missile Bank"
+	turret
+	turret
+	turret "Grab-Strike Turret"
+	turret "Grab-Strike Turret"
+	turret "Banisher Grav-Turret"
+	turret "Warder Anti-Missile"
+
+
+ship "Korath Raider" "Korath Raider (Ember)"
+	outfits
+		"Grab-Strike Turret" 4
+		"Banisher Grav-Turret"
+		"Warder Anti-Missile"
+		"Firelight Missile Bank" 2
+		"Firelight Missile" 50
+		"Firelight Storage Rack"
+		
+		"Triple Plasma Core"
+		"Systems Core (Medium)"
+		"Liquid Sodium Cooler"
+		"Small Heat Shunt"
+		"Fuel Processor"
+		"Korath Repeater Rifle" 196
+		"Outfits Expansion" 2
+		
+		"Bow Drive (Meteor Class)"
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Afterburner (Asteroid Class)"
+		"Jump Drive"
+		"Hyperdrive"
+	
+	gun "Firelight Missile Bank"
+	gun "Firelight Missile Bank"
+	turret "Grab-Strike Turret"
+	turret "Grab-Strike Turret"
+	turret "Grab-Strike Turret"
+	turret "Grab-Strike Turret"
+	turret "Banisher Grav-Turret"
+	turret "Warder Anti-Missile"
+
+
+ship "Korath Raider" "Korath Raider (Ember Blaze)"
+	outfits
+		"Blaze-Pike Turret" 4
+		"Digger Mining Turret"
+		"Warder Anti-Missile"
+		"Firelight Missile Bank" 2
+		"Firelight Storage Rack"
+		"Firelight Missile" 50
+		
+		"Triple Plasma Core"
+		"Large Heat Shunt" 3
+		"Systems Core (Medium)"
+		"Fuel Processor"
+		"Outfits Expansion" 2
+		"Korath Repeater Rifle" 196
+		
+		"Reverser (Asteroid Class)"
+		"Steering (Planetary Class)"
+		"Thruster (Planetary Class)"
+		"Jump Drive"
+		"Hyperdrive"
+	
+	gun "Firelight Missile Bank"
+	gun "Firelight Missile Bank"
+	turret "Blaze-Pike Turret"
+	turret "Blaze-Pike Turret"
+	turret "Blaze-Pike Turret"
+	turret "Blaze-Pike Turret"
+	turret "Digger Mining Turret"
+	turret "Warder Anti-Missile"
+
+
+ship "Korath Raider" "Korath Raider (Ember Shunt)"
+	outfits
+		"Shunt-Strike Turret" 4
+		"Banisher Grav-Turret"
+		"Warder Anti-Missile"
+		"Firelight Missile Bank" 2
+		"Firelight Storage Rack"
+		"Firelight Missile" 50
+		
+		"Triple Plasma Core"
+		"Systems Core (Medium)"
+		"Systems Core (Small)"
+		"Liquid Sodium Cooler"
+		"Small Heat Shunt"
+		"Fuel Processor"
+		"Outfits Expansion"
+		"Korath Repeater Rifle" 196
+		
+		"Reverser (Comet Class)"
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Jump Drive"
+		"Hyperdrive"
+	
+	gun "Firelight Missile Bank"
+	gun "Firelight Missile Bank"
+	turret "Shunt-Strike Turret"
+	turret "Shunt-Strike Turret"
+	turret "Shunt-Strike Turret"
+	turret "Shunt-Strike Turret"
+	turret "Banisher Grav-Turret"
+	turret "Warder Anti-Missile"
+
+
+ship "Korath Raider" "Korath Raider (Hyperdrive)"
+	outfits
+		"Grab-Strike Turret" 4
+		"Banisher Grav-Turret"
+		"Warder Anti-Missile"
+		"Firelight Missile Bank" 2
+		"Firelight Missile" 36
+		"Firelight Storage Rack"
+		
+		"Triple Plasma Core"
+		"Systems Core (Medium)"
+		"Liquid Sodium Cooler"
+		"Fuel Processor"
+		"Korath Repeater Rifle" 196
+		"Outfits Expansion"
+		
+		"Bow Drive (Meteor Class)"
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Jump Drive (Broken)"
+		"Hyperdrive"
+	
+	gun "Firelight Missile Bank"
+	gun "Firelight Missile Bank"
+	turret "Grab-Strike Turret"
+	turret "Grab-Strike Turret"
+	turret "Grab-Strike Turret"
+	turret "Grab-Strike Turret"
+	turret "Banisher Grav-Turret"
+	turret "Warder Anti-Missile"
+
+
+
+ship "Korath Chaser" "Korath Chaser (Expeller)"
+	outfits
+		"Expeller Grav-Ray"
+		
+		"Generator (Candle Class)"
+		"Systems Core (Tiny)"
+		"Korath Repeater Rifle" 
+		
+		"Thruster (Asteroid Class)"
+		"Bow Drive (Meteor Class)"
+
+
+ship "Korath Chaser" "Korath Chaser (Digger)"
+	outfits
+		"Digger Mining Beam"
+		
+		"Generator (Candle Class)"
+		"Systems Core (Tiny)"
+		"Korath Repeater Rifle" 
+		"Cargo Expansion"
+		"Interference Plating"
+				
+		"Engine (Meteor Class)"
+
+
+ship "Korath Chaser" "Korath Chaser (World-Ship)"
+	add attributes
+		"atmosphere scan" 1
+	outfits
+		"Generator (Candle Class)"
+		"Systems Core (Tiny)"
+		"Small Bunk Room"
+		"Korath Repeater Rifle" 3
+		
+		"Steering (Asteroid Class)"
+		"Afterburner (Asteroid Class)"
+		"Hyperdrive"
+
+
+
+ship "Korath World-Ship" "Korath World-Ship A (Jump)"
+	outfits
+		"Grab-Strike Turret" 2
+		"Banisher Grav-Turret" 3
+		"Warder Anti-Missile" 3
+		
+		"Triple Plasma Core"
+		"Systems Core (Large)"
+		"Large Heat Shunt" 2
+		"Fuel Processor"
+		"Korath Repeater Rifle" 150
+		"Microbot Defense Station" 20
+		
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Jump Drive"
+	
+	turret -76 -157 "Grab-Strike Turret"
+	turret 76 -157 "Banisher Grav-Turret"
+	turret -59 -135 "Warder Anti-Missile"
+	turret 59 -135 "Grab-Strike Turret"
+	turret -61 -6 "Banisher Grav-Turret"
+	turret 61 -6 "Warder Anti-Missile"
+	turret -66 210 "Warder Anti-Missile"
+	turret 66 210 "Banisher Grav-Turret"
+
+
+
+ship "Korath World-Ship" "Korath World-Ship B (Crippled)"
+	sprite "ship/world-ship b"
+	outfits
+		"Banisher Grav-Turret" 3
+		"Warder Anti-Missile"
+		
+		"Triple Plasma Core"
+		"Large Heat Shunt" 2
+		"Korath Repeater Rifle" 150
+		"Microbot Defense Station" 20
+		"Outfits Expansion"
+		
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Jump Drive (Broken)"
+		"Hyperdrive"
+	
+	turret -76 -219
+	turret 76 -219
+	turret -75 -112 "Banisher Grav-Turret"
+	turret 75 -112 "Banisher Grav-Turret"
+	turret 0 -92 "Warder Anti-Missile"
+	turret -83 165
+	turret 83 165
+	turret 0 277 "Banisher Grav-Turret"
+
+
+ship "Korath World-Ship" "Korath World-Ship B (Ember)"
+	sprite "ship/world-ship b"
+	outfits
+		"Grab-Strike Turret" 2
+		"Banisher Grav-Turret" 3
+		"Warder Anti-Missile" 3
+		
+		"Triple Plasma Core"
+		"Systems Core (Large)"
+		"Large Heat Shunt" 2
+		"Fuel Processor"
+		"Korath Repeater Rifle" 150
+		"Microbot Defense Station" 18
+		"Outfits Expansion"
+		
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Jump Drive"
+		"Hyperdrive"
+		
+	turret -76 -219 "Grab-Strike Turret"
+	turret 76 -219 "Grab-Strike Turret"
+	turret -75 -112 "Banisher Grav-Turret"
+	turret 75 -112 "Banisher Grav-Turret"
+	turret 0 -92 "Warder Anti-Missile"
+	turret -83 165 "Warder Anti-Missile"
+	turret 83 165 "Warder Anti-Missile"
+	turret 0 277 "Banisher Grav-Turret"
+
+
+ship "Korath World-Ship" "Korath World-Ship B (Jump)"
+	sprite "ship/world-ship b"
+	outfits
+		"Grab-Strike Turret" 2
+		"Banisher Grav-Turret" 3
+		"Warder Anti-Missile" 3
+		
+		"Triple Plasma Core"
+		"Systems Core (Large)"
+		"Large Heat Shunt" 2
+		"Fuel Processor"
+		"Korath Repeater Rifle" 150
+		"Microbot Defense Station" 20
+		
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Jump Drive"
+	
+	turret -76 -219 "Grab-Strike Turret"
+	turret 76 -219 "Grab-Strike Turret"
+	turret -75 -112 "Banisher Grav-Turret"
+	turret 75 -112 "Banisher Grav-Turret"
+	turret 0 -92 "Warder Anti-Missile"
+	turret -83 165 "Warder Anti-Missile"
+	turret 83 165 "Warder Anti-Missile"
+	turret 0 277 "Banisher Grav-Turret"
+
+
+
+ship "Korath World-Ship" "Korath World-Ship C (Jump)"
+	sprite "ship/world-ship c"
+	outfits
+		"Grab-Strike Turret" 2
+		"Banisher Grav-Turret" 3
+		"Warder Anti-Missile" 3
+		
+		"Triple Plasma Core"
+		"Systems Core (Large)"
+		"Large Heat Shunt" 2
+		"Fuel Processor"
+		"Korath Repeater Rifle" 150
+		"Microbot Defense Station" 20
+		
+		"Thruster (Planetary Class)"
+		"Steering (Planetary Class)"
+		"Jump Drive"
+	
+	turret -45 -247 "Warder Anti-Missile"
+	turret 45 -247 "Grab-Strike Turret"
+	turret -47 -140 "Grab-Strike Turret"
+	turret 47 -140 "Banisher Grav-Turret"
+	turret -70 53 "Warder Anti-Missile"
+	turret 70 53 "Banisher Grav-Turret"
+	turret -91 286 "Banisher Grav-Turret"
+	turret 91 286 "Warder Anti-Missile"


### PR DESCRIPTION
This adds the old Korath ships to a new `deprecated ships.txt` file. The ship stats are the ones just before the rename, but using the new (renamed) outfits instead of the old ones.

This is to maintain compatibility if you use a plugin that relies on the old Korath names. I don't think it's a good idea to break every plugin that uses Korath ships, even if save files are unaffected. However, plugin authors are encouraged to update the references to the new names.

