### PR TITLE
BugFix: Add Missing Frugal Personality to Archons

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -754,7 +754,7 @@ mission "Remnant: Void Sprites 3"
 	npc
 		government "Drak (Hostile)"
 		system "Nenia"
-		personality staying heroic nemesis uninterested
+		personality staying heroic nemesis frugal uninterested
 		ship "Archon (Cloaked)" "Lifted Lorax"
 	on stopover
 		conversation
@@ -2067,7 +2067,7 @@ mission "Remnant: Return the Samples"
 	npc
 		government "Drak (Hostile)"
 		system "Nenia"
-		personality staying heroic nemesis uninterested
+		personality staying heroic nemesis frugal uninterested
 		ship "Archon (Cloaked)" "Lifted Lorax"
 	on accept
 		log "People" "Plume" `A Remnant researcher specializing in xenobiology, Plume is at the forefront of recent efforts to restart research on the void sprites and a leading expert in non-carbon based lifeforms.`


### PR DESCRIPTION
**Bugfix:** This PR partially addresses issue: https://github.com/endless-sky/endless-sky/issues/7231

## Fix Details
When https://github.com/endless-sky/endless-sky/pull/6517 was merged, Archons were given more powerful augmented weapons and the "Frugal" personality to ensure they don't use those weapons unless sufficiently damaged.
However, the personality was not applied universally, leading to situations where the player is able to encounter an Archon using its more powerful Augmented weaponry from the start. 

This PR fixes that by adding the frugal personality and ensures that all Archons encountered by the player will not use their augmented weapons unless sufficiently damaged.

## Testing Done
Tested mission Remnant: Void Sprites 3 and confirmed that without this fix, the Archon would use its augmented weaponry while you're trying to dodge it, and with this fix, the Archon will not. 

## Save File
This save file will place you on Aventine with a Puffin with "Remnant: Void Sprites 3" so you can immediately fly to Nenia and verify that the Archon is not using its augmented weapons:
[Archon Fix.txt](https://github.com/endless-sky/endless-sky/files/9693188/Archon.Fix.txt)

Note, this is an alternative to https://github.com/endless-sky/endless-sky/pull/7239, which further adds to the mission string in question and includes additional balance changes, whereas this PR is simply a bugfix. If https://github.com/endless-sky/endless-sky/pull/7239 is merged, this PR can be closed. 