### PR TITLE
Fix possible bug in new `remove` feature

### DIFF
--- a/source/System.cpp
+++ b/source/System.cpp
@@ -299,7 +299,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 				auto last = removeIt + 1;
 				size_t removed = 1;
 				// Remove any child objects too.
-				for( ; last != objects.end() && last->parent != -1; ++last, ++removed)
+				for( ; last != objects.end() && last->parent >= index; ++last, ++removed)
 					if(last->planet)
 						planets.Get(last->planet->TrueName())->RemoveSystem(this);
 				last = objects.erase(removeIt, last);


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Currently, the `remove` keyword for `object`s in `system`s will allow targeting a child object but then would potentially remove other objects with the same parent, which is undesired.

Thanks to @Amazinite for help finding this bug.

## Testing Done
soon:tm: