### PR TITLE
fix(content): Missing plural name for Firestorm Battery

### DIFF
--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -1033,6 +1033,7 @@ outfit "Firestorm Torpedo Rack"
 	description "This large cage-like rack is designed to be able to house several deadly Firestorm Torpedoes."
 
 outfit "Firestorm Battery"
+	plural "Firestorm Batteries"
 	category "Secondary Weapons"
 	cost 2383000
 	thumbnail "outfit/firestorm battery"


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
Give it a plural name (`Firestorm Batteries`) so the plural doesn't default to `Firestorm Batterys`.
