### PR TITLE
Enhancement(UI): select the destination planet from the new map UI

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -393,6 +393,8 @@ bool MapDetailPanel::Click(int x, int y, int clicks)
 				else if(clickAction != MapPlanetCard::ClickAction::NONE)
 				{
 					selectedPlanet = card.GetPlanet();
+					if(selectedPlanet && player.Flagship())
+						player.SetTravelDestination(selectedPlanet);
 					if(clickAction != MapPlanetCard::ClickAction::SELECTED)
 						SetCommodity(static_cast<int>(clickAction));
 				}


### PR DESCRIPTION
**Feature:** This PR implements the small feature request from the last comment of the planetary UI issue (https://github.com/endless-sky/endless-sky/issues/7065)

## Feature Details
Selecting a planet in the UI on the left selects it in the radar, and selecting it in the radar selects it for the flagship.
This makes it so selecting in the UI also selects it for the flagship.

## UI Screenshots
N/A

## Usage Examples
Select a planet nicely from the map as you would from the radar.

## Testing Done
~~Being on phone I cant test it. But its the exact same code as for radar selection, in the same context. There is no way this fails.~~
Thx to @quyykk for doing some testing

## Performance Impact
N/A
