### PR TITLE
Make bounty jobs more active

### DIFF
--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -1044,7 +1044,7 @@ mission "FW Bounty 1"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			near "Seginus" 1 2
+			near "Seginus" 1 1
 		ship "Hawk (Rocket)" "Cluny"
 		ship "Hawk (Speedy)" "Ferret"
 		ship "Berserker (Afterburner)" "Weasel"
@@ -1098,7 +1098,7 @@ mission "FW Bounty 2"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			near "Delta Sagittarii" 1 2
+			near "Delta Sagittarii" 1 1
 		ship "Behemoth (Speedy)" "Moonless Night"
 		dialog phrase "generic hunted bounty eliminated dialog"
 	

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -2580,16 +2580,17 @@ mission "Recycle garbage"
 
 mission "Bounty Hunting (Very Tiny)"
 	name "Wanted corsair near <system>"
-	description "A small pirate fighter named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A small pirate fighter named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
 		or
-			"combat rating" > 50
+			"combat rating" > 15
 			has "ships: Interceptor"
 			has "ships: Light Warship"
-		"combat rating" < 200
-		random < 40
+		"combat rating" < 80
+		random < 50
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
@@ -2597,7 +2598,7 @@ mission "Bounty Hunting (Very Tiny)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 2
+			distance 1 1
 		fleet
 			names "pirate"
 			variant
@@ -2618,21 +2619,22 @@ mission "Bounty Hunting (Very Tiny)"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 20000
+		payment 25000
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Tiny)"
 	name "Wanted outlaw near <system>"
-	description "A well armed pirate fighter named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A well armed pirate fighter named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
 		or
-			"combat rating" > 100
+			"combat rating" > 30
 			has "ships: Interceptor"
 			has "ships: Light Warship"
-		"combat rating" < 300
-		random < 40
+		"combat rating" < 200
+		random < 45
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
@@ -2640,7 +2642,7 @@ mission "Bounty Hunting (Tiny)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 2
+			distance 1 1
 		fleet
 			names "pirate"
 			variant
@@ -2671,20 +2673,21 @@ mission "Bounty Hunting (Tiny)"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 40000
+		payment 50000
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Very Small)"
 	name "Wanted criminal near <system>"
-	description "A light pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A light pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
 		or
-			"combat rating" > 200
+			"combat rating" > 80
 			has "ships: Light Warship"
 			has "ships: Medium Warship"
-		"combat rating" < 400
+		"combat rating" < 350
 		random < 40
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -2693,7 +2696,7 @@ mission "Bounty Hunting (Very Small)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 2
+			distance 1 1
 		fleet
 			names "pirate"
 			variant
@@ -2722,18 +2725,20 @@ mission "Bounty Hunting (Very Small)"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 80000
+		payment 95000
 		dialog phrase "generic bounty hunting payment dialog"
 
 
 
 mission "Bounty Hunting (Small)"
 	name "Wanted bandit near <system>"
-	description "A low-end pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A medium pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 300
+		"combat rating" > 200
+		"combat rating" < 500
 		random < 40
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -2742,7 +2747,7 @@ mission "Bounty Hunting (Small)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 2
+			distance 1 1
 		fleet
 			names "pirate"
 			variant
@@ -2767,17 +2772,19 @@ mission "Bounty Hunting (Small)"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 150000
+		payment 180000
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Medium)"
 	name "Wanted pirate near <system>"
-	description "A medium pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A sizeable pirate warship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 400
-		random < 20
+		"combat rating" > 350
+		"combat rating" < 1200
+		random < 40
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
@@ -2785,7 +2792,7 @@ mission "Bounty Hunting (Medium)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 2
+			distance 1 1
 		fleet
 			names "pirate"
 			variant
@@ -2804,17 +2811,19 @@ mission "Bounty Hunting (Medium)"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 200000
+		payment 240000
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Big)"
 	name "Wanted warlord near <system>"
-	description "A heavy warship known as the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A heavy warship known as the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
 		"combat rating" > 500
-		random < 20
+		"combat rating" < 2500
+		random < 40
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
@@ -2822,7 +2831,7 @@ mission "Bounty Hunting (Big)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 2
+			distance 1 1
 		fleet
 			names "pirate"
 			variant
@@ -2845,17 +2854,22 @@ mission "Bounty Hunting (Big)"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 250000
+		payment 300000
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Small, Hidden)"
 	name "Disguised bandit near <system>"
-	description "A low-end pirate warship named the <npc> is posing as a merchant ship near the <system> system. Select merchant ships until you find a ship with a matching name, then destroy it and return to <planet> for payment (<payment>)."
+	description "A medium pirate warship named the <npc> is posing as a merchant ship near the <system> system. Select merchant ships until you find a ship with a matching name, then destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 30
 	to offer
-		"combat rating" > 300
-		random < 20
+		"combat rating" > 200
+		or
+			random < 5
+			and
+				"combat rating" < 500
+				random < 20
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
@@ -2888,17 +2902,22 @@ mission "Bounty Hunting (Small, Hidden)"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 250000
+		payment 360000
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Medium, Hidden)"
 	name "Disguised pirate near <system>"
-	description "A medium pirate warship named the <npc> is posing as a merchant ship near the <system> system. Select merchant ships until you find a ship with a matching name, then destroy it and return to <planet> for payment (<payment>)."
+	description "A sizable pirate warship named the <npc> is posing as a merchant ship near the <system> system. Select merchant ships until you find a ship with a matching name, then destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 30
 	to offer
-		"combat rating" > 400
-		random < 10
+		"combat rating" > 350
+		or
+			random < 5
+			and
+				"combat rating" < 1200
+				random < 20
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
@@ -2925,17 +2944,22 @@ mission "Bounty Hunting (Medium, Hidden)"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 350000
+		payment 480000
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Big, Hidden)"
 	name "Disguised warlord near <system>"
-	description "A heavy warship known as the <npc> is posing as a merchant ship near the <system> system. Select merchant ships until you find a ship with a matching name, then destroy it and return to <planet> for payment (<payment>)."
+	description "A heavy warship known as the <npc> is posing as a merchant ship near the <system> system. Select merchant ships until you find a ship with a matching name, then destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 30
 	to offer
 		"combat rating" > 500
-		random < 10
+		or
+			random < 5
+			and
+				"combat rating" < 2500
+				random < 20
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
@@ -2966,7 +2990,7 @@ mission "Bounty Hunting (Big, Hidden)"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 450000
+		payment 600000
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Small, Boarding, Entering)"
@@ -2977,7 +3001,7 @@ mission "Bounty Hunting (Small, Boarding, Entering)"
 	repeat
 	job
 	to offer
-		"combat rating" > 80
+		"combat rating" > 50
 		random < 15
 	on offer
 		require "Brig"
@@ -3051,16 +3075,17 @@ mission "Bounty Hunting (Medium, Boarding, Entering)"
 
 mission "Bounty Hunting (Solo Marauder I)"
 	name "Marauder interceptor near <system>"
-	description "A Marauder interceptor named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A Marauder interceptor named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
 		or
 			"combat rating" > 100
 			has "ships: Interceptor"
 			has "ships: Light Warship"
 		"combat rating" > 50
-		"combat rating" < 600
+		"combat rating" < 500
 		random < 5
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3069,37 +3094,8 @@ mission "Bounty Hunting (Solo Marauder I)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 2
+			distance 1 1
 		fleet "Marauder I"
-		dialog phrase "generic hunted bounty eliminated dialog"
-	on visit
-		dialog phrase "generic bounty hunting on visit"
-	on complete
-		payment 80000
-		dialog phrase "generic bounty hunting payment dialog"
-
-mission "Bounty Hunting (Solo Marauder II)"
-	name "Small Marauder near <system>"
-	description "A small Marauder ship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
-	repeat
-	job
-	to offer
-		or
-			"combat rating" > 200
-			has "ships: Light Warship"
-			has "ships: Medium Warship"
-		"combat rating" > 100
-		"combat rating" < 600
-		random < 5
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
-		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
-	npc kill
-		government "Bounty"
-		personality heroic staying nemesis target
-		system
-			distance 1 2
-		fleet "Marauder II"
 		dialog phrase "generic hunted bounty eliminated dialog"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
@@ -3107,14 +3103,19 @@ mission "Bounty Hunting (Solo Marauder II)"
 		payment 130000
 		dialog phrase "generic bounty hunting payment dialog"
 
-mission "Bounty Hunting (Solo Marauder III)"
-	name "Marauder near <system>"
-	description "A Marauder ship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+mission "Bounty Hunting (Solo Marauder II)"
+	name "Small Marauder near <system>"
+	description "A small Marauder ship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 300
-		"combat rating" < 1550
+		or
+			"combat rating" > 200
+			has "ships: Light Warship"
+			has "ships: Medium Warship"
+		"combat rating" > 100
+		"combat rating" < 500
 		random < 5
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3123,23 +3124,50 @@ mission "Bounty Hunting (Solo Marauder III)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 2
+			distance 1 1
+		fleet "Marauder II"
+		dialog phrase "generic hunted bounty eliminated dialog"
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 200000
+		dialog phrase "generic bounty hunting payment dialog"
+
+mission "Bounty Hunting (Solo Marauder III)"
+	name "Marauder near <system>"
+	description "A Marauder ship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> by <day> for payment (<payment>)."
+	repeat
+	job
+	deadline 14
+	to offer
+		"combat rating" > 300
+		"combat rating" < 1200
+		random < 5
+	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
+		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
+	npc kill
+		government "Bounty"
+		personality heroic staying nemesis target
+		system
+			distance 1 1
 		fleet "Marauder III"
 		dialog phrase "generic hunted bounty eliminated dialog"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 180000
+		payment 310000
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Solo Marauder IV)"
 	name "Large Marauder near <system>"
-	description "A large Marauder ship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> for payment (<payment>)."
+	description "A large Marauder ship named the <npc> has been attacking merchants near the <system> system. Destroy it and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
 		"combat rating" > 500
-		"combat rating" < 2980
+		"combat rating" < 2500
 		random < 5
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3148,22 +3176,23 @@ mission "Bounty Hunting (Solo Marauder IV)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 2
+			distance 1 1
 		fleet "Marauder IV"
 		dialog phrase "generic hunted bounty eliminated dialog"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-		payment 280000
+		payment 500000
 		dialog phrase "generic bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder I)"
 	name "Small Marauders near <system>"
-	description "A fleet of small Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of small Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 600
+		"combat rating" > 500
 		or
 			random < 5
 			and
@@ -3176,27 +3205,28 @@ mission "Bounty Hunting (Marauder I)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 3
+			distance 1 1
 		fleet "Marauder fleet I"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on visit
 		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
-		payment 300000
+		payment 360000
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder II)"
 	name "Small Marauders near <system>"
-	description "A fleet of small Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of small Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 750
+		"combat rating" > 600
 		or
 			random < 5
 			and
 				"combat rating" < 1800
-				random < 30
+				random < 45
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
@@ -3204,27 +3234,28 @@ mission "Bounty Hunting (Marauder II)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 3
+			distance 1 1
 		fleet "Marauder fleet II"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on visit
 		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
-		payment 350000
+		payment 380000
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder III)"
 	name "Small Marauders near <system>"
-	description "A fleet of small Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of small Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 1097
+		"combat rating" > 700
 		or
 			random < 5
 			and
 				"combat rating" < 2200
-				random < 25
+				random < 45
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
@@ -3232,7 +3263,7 @@ mission "Bounty Hunting (Marauder III)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 3
+			distance 1 1
 		fleet "Marauder fleet III"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on visit
@@ -3243,11 +3274,12 @@ mission "Bounty Hunting (Marauder III)"
 
 mission "Bounty Hunting (Marauder IV)"
 	name "Marauders near <system>"
-	description "A fleet of Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 1550
+		"combat rating" > 1200
 		or
 			random < 5
 			and
@@ -3266,16 +3298,17 @@ mission "Bounty Hunting (Marauder IV)"
 	on visit
 		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
-		payment 425000
+		payment 480000
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder V)"
 	name "Marauders near <system>"
-	description "A fleet of Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 2000
+		"combat rating" > 1400
 		or
 			random < 5
 			and
@@ -3288,23 +3321,24 @@ mission "Bounty Hunting (Marauder V)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 3
+			distance 1 1
 		fleet "Marauder fleet V"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on visit
 		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
-		payment 450000
+		payment 500000
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 
 mission "Bounty Hunting (Marauder VI)"
 	name "Marauders near <system>"
-	description "A fleet of Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 2500
+		"combat rating" > 1600
 		or
 			random < 5
 			and
@@ -3317,22 +3351,23 @@ mission "Bounty Hunting (Marauder VI)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 3
+			distance 1 1
 		fleet "Marauder fleet VI"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on visit
 		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
-		payment 475000
+		payment 520000
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder VII)"
 	name "Large Marauders near <system>"
-	description "A fleet of large Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of large Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 2980
+		"combat rating" > 2500
 		random < 20
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3341,22 +3376,23 @@ mission "Bounty Hunting (Marauder VII)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 3
+			distance 1 1
 		fleet "Marauder fleet VII"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on visit
 		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
-		payment 500000
+		payment 620000
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder VIII)"
 	name "Large Marauders near <system>"
-	description "A fleet of large Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of large Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 4000
+		"combat rating" > 2800
 		random < 15
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3365,22 +3401,23 @@ mission "Bounty Hunting (Marauder VIII)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 3
+			distance 1 1
 		fleet "Marauder fleet VIII"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on visit
 		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
-		payment 550000
+		payment 640000
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder IX)"
 	name "Large Marauders near <system>"
-	description "A fleet of large Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of large Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 6000
+		"combat rating" > 3100
 		random < 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -3389,20 +3426,21 @@ mission "Bounty Hunting (Marauder IX)"
 		government "Bounty"
 		personality heroic unconstrained staying nemesis target
 		system
-			distance 1 3
+			distance 1 1
 		fleet "Marauder fleet IX"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on visit
 		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
-		payment 600000
+		payment 660000
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 mission "Bounty Hunting (Marauder X)"
 	name "Large Marauders near <system>"
-	description "A fleet of large Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> for payment (<payment>)."
+	description "A fleet of large Marauder ships, led by a vessel named the <npc>, has been attacking merchants near the <system> system. Destroy the whole fleet and return to <planet> by <day> for payment (<payment>)."
 	repeat
 	job
+	deadline 14
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 		attributes "rim" "south" "north" "dirt belt" "core" "frontier"
@@ -3413,13 +3451,13 @@ mission "Bounty Hunting (Marauder X)"
 		government "Bounty"
 		personality heroic unconstrained staying nemesis target
 		system
-			distance 1 3
+			distance 1 1
 		fleet "Marauder fleet X"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on visit
 		dialog phrase "generic fleet bounty hunting on visit"
 	on complete
-		payment 750000
+		payment 1000000
 		dialog phrase "generic fleet bounty hunting payment dialog"
 
 

--- a/data/human/pirate jobs.txt
+++ b/data/human/pirate jobs.txt
@@ -2226,7 +2226,8 @@ mission "Eliminating Law Enforcement (North, Small)"
 	name "Navy near <system>"
 	repeat
 	job
-	description "A Navy fleet near the <system> system has halted our raids. Destroy them and return to <planet> for a payment of <payment>."
+	description "A Navy fleet near the <system> system has halted our raids. Destroy them and return to <planet> by <day> for a payment of <payment>."
+	deadline 20
 	to offer
 		random < 25
 		"combat rating" > 1100
@@ -2241,7 +2242,7 @@ mission "Eliminating Law Enforcement (North, Small)"
 		fleet "Small Republic" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
-		payment 250000
+		payment 360000
 		"reputation: Pirate" += 5
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the Navy fleet."
 
@@ -2249,7 +2250,8 @@ mission "Eliminating Law Enforcement (North, Large)"
 	name "Navy near <system>"
 	repeat
 	job
-	description "A large Navy fleet near the <system> system has halted our raids. Destroy them and return to <planet> for a payment of <payment>."
+	description "A large Navy fleet near the <system> system has halted our raids. Destroy them and return to <planet> by <day> for a payment of <payment>."
+	deadline 20
 	to offer
 		random < 15
 		"combat rating" > 3000
@@ -2265,7 +2267,7 @@ mission "Eliminating Law Enforcement (North, Large)"
 		fleet "Small Republic" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
-		payment 400000
+		payment 600000
 		"reputation: Pirate" += 10
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the Navy fleet."
 
@@ -2273,7 +2275,8 @@ mission "Eliminating Law Enforcement (Core, Small)"
 	name "Syndicate near <system>"
 	repeat
 	job
-	description "A Syndicate fleet near the <system> system has halted our raids. Destroy them and return to <planet> for a payment of <payment>."
+	description "A Syndicate fleet near the <system> system has halted our raids. Destroy them and return to <planet> by <day> for a payment of <payment>."
+	deadline 25
 	to offer
 		random < 25
 		"combat rating" > 1100
@@ -2288,7 +2291,7 @@ mission "Eliminating Law Enforcement (Core, Small)"
 		fleet "Small Syndicate" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
-		payment 250000
+		payment 360000
 		"reputation: Pirate" += 5
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the Syndicate fleet."
 
@@ -2296,7 +2299,8 @@ mission "Eliminating Law Enforcement (Core, Large)"
 	name "Syndicate near <system>"
 	repeat
 	job
-	description "A large Syndicate fleet near the <system> system has halted our raids. Destroy them and return to <planet> for a payment of <payment>."
+	description "A large Syndicate fleet near the <system> system has halted our raids. Destroy them and return to <planet> by <day> for a payment of <payment>."
+	deadline 25
 	to offer
 		random < 15
 		"combat rating" > 3000
@@ -2312,7 +2316,7 @@ mission "Eliminating Law Enforcement (Core, Large)"
 		fleet "Small Syndicate" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
-		payment 400000
+		payment 600000
 		"reputation: Pirate" += 10
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the Syndicate fleet."
 
@@ -2320,7 +2324,8 @@ mission "Eliminating Law Enforcement (South, Small)"
 	name "Militia near <system>"
 	repeat
 	job
-	description "A militia fleet near the <system> system has halted our raids. Destroy them and return to <planet> for a payment of <payment>."
+	description "A militia fleet near the <system> system has halted our raids. Destroy them and return to <planet> by <day> for a payment of <payment>."
+	deadline 14
 	to offer
 		random < 25
 		"combat rating" > 1100
@@ -2331,11 +2336,11 @@ mission "Eliminating Law Enforcement (South, Small)"
 		government "Militia"
 		personality heroic staying target
 		system
-			distance 1 3
+			distance 1 2
 		fleet "Small Militia" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
-		payment 250000
+		payment 320000
 		"reputation: Pirate" += 5
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the militia fleet."
 
@@ -2343,7 +2348,8 @@ mission "Eliminating Law Enforcement (South, Large)"
 	name "Militia near <system>"
 	repeat
 	job
-	description "A large militia fleet near the <system> system has halted our raids. Destroy them and return to <planet> for a payment of <payment>."
+	description "A large militia fleet near the <system> system has halted our raids. Destroy them and return to <planet> by <day> for a payment of <payment>."
+	deadline 14
 	to offer
 		random < 15
 		"combat rating" > 3000
@@ -2354,12 +2360,12 @@ mission "Eliminating Law Enforcement (South, Large)"
 		government "Militia"
 		personality heroic staying target
 		system
-			distance 1 3
+			distance 1 2
 		fleet "Large Militia"
 		fleet "Small Militia" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
 	on complete
-		payment 400000
+		payment 520000
 		"reputation: Pirate" += 10
 		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the militia fleet."
 
@@ -2367,9 +2373,10 @@ mission "Eliminating Law Enforcement (South, Large)"
 
 mission "Eliminating Competition (North, Small)"
 	name "Competition near <system>"
-	description "A small rival gang is causing trouble near the <system> system. Take them out and return to <planet> for a payment of <payment>."
+	description "A small rival gang is causing trouble near the <system> system. Take them out and return to <planet> by <day> for a payment of <payment>."
 	repeat
 	job
+	deadline 20
 	to offer
 		random < 20
 		"combat rating" > 400
@@ -2391,9 +2398,10 @@ mission "Eliminating Competition (North, Small)"
 
 mission "Eliminating Competition (North, Large)"
 	name "Competition near <system>"
-	description "A large rival gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> for a payment of <payment>."
+	description "A large rival gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> by <day> for a payment of <payment>."
 	repeat
 	job
+	deadline 20
 	to offer
 		random < 10
 		"combat rating" > 1100
@@ -2404,7 +2412,7 @@ mission "Eliminating Competition (North, Large)"
 		government "Pirate (Rival)"
 		personality heroic staying target marked
 		system
-			distance 1 3
+			distance 1 2
 		fleet "Large Northern Pirates" 2
 		fleet "Small Northern Pirates" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
@@ -2416,9 +2424,10 @@ mission "Eliminating Competition (North, Large)"
 
 mission "Eliminating Competition (Core, Small)"
 	name "Competition near <system>"
-	description "A small rival gang is causing trouble near the <system> system. Take them out and return to <planet> for a payment of <payment>."
+	description "A small rival gang is causing trouble near the <system> system. Take them out and return to <planet> by <day> for a payment of <payment>."
 	repeat
 	job
+	deadline 20
 	to offer
 		random < 20
 		"combat rating" > 400
@@ -2440,9 +2449,10 @@ mission "Eliminating Competition (Core, Small)"
 
 mission "Eliminating Competition (Core, Large)"
 	name "Competition near <system>"
-	description "A large rival gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> for a payment of <payment>."
+	description "A large rival gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> by <day> for a payment of <payment>."
 	repeat
 	job
+	deadline 20
 	to offer
 		random < 10
 		"combat rating" > 1100
@@ -2453,7 +2463,7 @@ mission "Eliminating Competition (Core, Large)"
 		government "Pirate (Rival)"
 		personality heroic staying target marked
 		system
-			distance 1 3
+			distance 1 2
 		fleet "Large Core Pirates" 2
 		fleet "Small Core Pirates" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
@@ -2465,9 +2475,10 @@ mission "Eliminating Competition (Core, Large)"
 
 mission "Eliminating Competition (South, Small)"
 	name "Competition near <system>"
-	description "A small rival gang is causing trouble near the <system> system. Take them out and return to <planet> for a payment of <payment>."
+	description "A small rival gang is causing trouble near the <system> system. Take them out and return to <planet> by <day> for a payment of <payment>."
 	repeat
 	job
+	deadline 14
 	to offer
 		random < 20
 		"combat rating" > 400
@@ -2489,9 +2500,10 @@ mission "Eliminating Competition (South, Small)"
 
 mission "Eliminating Competition (South, Large)"
 	name "Competition near <system>"
-	description "A large rival gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> for a payment of <payment>."
+	description "A large rival gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> by <day> for a payment of <payment>."
 	repeat
 	job
+	deadline 14
 	to offer
 		random < 10
 		"combat rating" > 1100
@@ -2502,7 +2514,7 @@ mission "Eliminating Competition (South, Large)"
 		government "Pirate (Rival)"
 		personality heroic staying target marked
 		system
-			distance 1 3
+			distance 1 2
 		fleet "Large Southern Pirates" 2
 		fleet "Small Southern Pirates" 2
 		dialog "The fleet has been eliminated. You can claim the bounty payment by returning to <destination>."
@@ -2514,9 +2526,10 @@ mission "Eliminating Competition (South, Large)"
 
 mission "Eliminating Competition (Marauders, Small)"
 	name "Competition near <system>"
-	description "A small marauder gang is causing trouble near the <system> system. Take them out and return to <planet> for a payment of <payment>."
+	description "A small marauder gang is causing trouble near the <system> system. Take them out and return to <planet> by <day> for a payment of <payment>."
 	repeat
 	job
+	deadline 20
 	to offer
 		random < 5
 		"combat rating" > 600
@@ -2538,9 +2551,10 @@ mission "Eliminating Competition (Marauders, Small)"
 
 mission "Eliminating Competition (Marauders, Medium)"
 	name "Competition near <system>"
-	description "A marauder gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> for a payment of <payment>."
+	description "A marauder gang is gaining too much power. Their leader is currently near the <system> system. Take them and their escorts out and return to <planet> by <day> for a payment of <payment>."
 	repeat
 	job
+	deadline 20
 	to offer
 		random < 5
 		"combat rating" > 1100
@@ -2563,9 +2577,10 @@ mission "Eliminating Competition (Marauders, Medium)"
 
 mission "Eliminating Competition (Marauders, Large)"
 	name "Marauder Elimination"
-	description "The pirates of the <system> system have grown dissatisified with the actions of the ruling Marauder gang. Take them out and return to <planet> for a payment of <payment>."
+	description "The pirates of the <system> system have grown dissatisified with the actions of the ruling Marauder gang. Take them out and return to <planet> by <day> for a payment of <payment>."
 	repeat
 	job
+	deadline 20
 	to offer
 		random < 5
 		"combat rating" > 2100
@@ -2575,7 +2590,7 @@ mission "Eliminating Competition (Marauders, Large)"
 		government "Pirate (Rival)"
 		personality heroic staying target marked
 		system
-			distance 1 3
+			distance 1 2
 		fleet "Marauder I" 2
 		fleet "Marauder II" 2
 		fleet "Marauder III"
@@ -2585,7 +2600,7 @@ mission "Eliminating Competition (Marauders, Large)"
 		"reputation: Pirate (Rival)" = "reputation: Pirate"
 	on complete
 		payment 900000
-		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the rival gang."
+		dialog "The pirates of <planet> gratefully pay you <payment> for eliminating the ruling gang."
 
 
 
@@ -2593,7 +2608,7 @@ mission "Raid on Merchants (North)"
 	name "Merchants near <system>"
 	repeat
 	job
-	description "A merchant fleet has been spotted near the <system> system. Join in destroying them and return to <planet> for a cut of the loot (<payment>)."
+	description "A merchant fleet has been spotted near the <system> system. Join in destroying them and return to <planet> by <day> for a cut of the loot (<payment>)."
 	to offer
 		random < 50
 		"combat rating" > 150
@@ -2879,10 +2894,11 @@ mission "Cargo Theft (North)"
 	name "Convoy near <system>"
 	job
 	repeat
-	description `A merchant convoy has been spotted near the <system> system. A local warlord is interested in having the cargo on the <npc>. Plunder it and return to <planet> for payment of <payment>.`
+	description `A merchant convoy has been spotted near the <system> system. A local warlord is interested in having the cargo on the <npc>. Plunder it and return to <planet> by <day> for payment of <payment>.`
 	to offer
 		random < 15
 		"combat rating" > 3000
+	deadline 20
 	source
 		government Pirate
 		attributes "north pirate"
@@ -2890,7 +2906,8 @@ mission "Cargo Theft (North)"
 		government "Merchant"
 		personality staying heroic target
 		system
-			distance 2 3
+			not government "Pirate"
+			distance 1 4
 		fleet
 			names "civilian"
 			variant
@@ -2913,10 +2930,11 @@ mission "Cargo Theft (Core)"
 	name "Convoy near <system>"
 	job
 	repeat
-	description `A merchant convoy has been spotted near the <system> system. A local warlord is interested in having the cargo on the <npc>. Plunder it and return to <planet> for payment of <payment>.`
+	description `A merchant convoy has been spotted near the <system> system. A local warlord is interested in having the cargo on the <npc>. Plunder it and return to <planet> by <day> for payment of <payment>.`
 	to offer
 		random < 15
 		"combat rating" > 3000
+	deadline 20
 	source
 		government Pirate
 		attributes "core pirate"
@@ -2924,7 +2942,8 @@ mission "Cargo Theft (Core)"
 		government "Merchant"
 		personality staying heroic target
 		system
-			distance 2 3
+			not government "Pirate"
+			distance 2 2
 		fleet
 			names "civilian"
 			variant
@@ -2947,10 +2966,11 @@ mission "Cargo Theft (South)"
 	name "Convoy near <system>"
 	job
 	repeat
-	description `A merchant convoy has been spotted near the <system> system. A local warlord is interested in having the cargo on the <npc>. Plunder it and return to <planet> for payment of <payment>.`
+	description `A merchant convoy has been spotted near the <system> system. A local warlord is interested in having the cargo on the <npc>. Plunder it and return to <planet> by <day> for payment of <payment>.`
 	to offer
 		random < 15
 		"combat rating" > 3000
+	deadline 14
 	source
 		government Pirate
 		attributes "south pirate"
@@ -2958,7 +2978,7 @@ mission "Cargo Theft (South)"
 		government "Merchant"
 		personality staying heroic target
 		system
-			distance 2 3
+			distance 1 2
 		fleet
 			names "civilian"
 			variant
@@ -2981,11 +3001,12 @@ mission "Cargo Theft (South)"
 
 mission "FW Assassination [1]"
 	name "Assassinate a political target"
-	description "A Free Worlds politician who is worrying local slave traders was spotted in their ship, the <npc>, in a nearby system. Assassinate them in order to send a message to the Free Worlds. Payment is <payment>. Be advised that they may have escorts."
+	description "A Free Worlds politician who is worrying local slave traders was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> in order to send a message to the Free Worlds. Payment is <payment>. Be advised that they may have escorts."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 200
+		"combat rating" > 300
 		random < 5
 		"reputation: Pirate" > -100
 		has "event: war begins"
@@ -2996,32 +3017,39 @@ mission "FW Assassination [1]"
 		government "Free Worlds"
 		personality staying target
 		system
-			distance 2 5
+			government "Free Worlds"
+			distance 2 2
 		fleet
 			names civilian
-			variant
-				"Flivver"
-				"Osprey" 2
-			variant
-				"Osprey"
-				"Bastion"
-			variant
-				"Falcon"
+			variant 10
+				"Blackbird"
+			variant 2
+				"Blackbird"
+				"Sparrow"
+			variant 4
+				"Blackbird"
 				"Fury" 2
+			variant 3
+				"Blackbird"
+				"Hawk" 3
+			variant 1
+				"Blackbird"
+				"Osprey"
 		dialog "The target has been destroyed. Return to <destination> for your payment."
 	on complete
-		payment 350000
+		payment 460000
 		dialog "A band of slave traders thank you for eliminating the politician and pay you <payment>."
 		"reputation: Free Worlds" -= 10
 		"reputation: Pirate" += 3
 		
 mission "FW Assassination [2]"
 	name "Assassinate a political target"
-	description "A Free Worlds politician who has angered a powerful pirate warlord was spotted in their ship, the <npc>, in a nearby system. Assassinate them in order to send a message to the Free Worlds. Payment is <payment>. Be advised that they are heavily defended."
+	description "A Free Worlds politician who has angered a powerful pirate warlord was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> in order to send a message to the Free Worlds. Payment is <payment>. Be advised that they may be heavily defended."
 	repeat
 	job
+	deadline 14
 	to offer
-		"combat rating" > 400
+		"combat rating" > 600
 		random < 5
 		"reputation: Pirate" > -50
 		has "event: war begins"
@@ -3032,104 +3060,45 @@ mission "FW Assassination [2]"
 		government "Free Worlds"
 		personality staying target
 		system
-			distance 2 5
+			government "Free Worlds"
+			distance 2 2
 		fleet
 			names civilian
-			variant
-				"Star Queen"
-				"Osprey"
-				"Argosy" 2
-			variant
-				"Star Queen"
+			variant 3
+				"Blackbird"
+			variant 2
+				"Blackbird"
 				"Falcon"
-				"Argosy"
+			variant 3
+				"Blackbird"
+				"Osprey" 2
+			variant 3
+				"Blackbird"
+				"Bastion"
+				"Osprey"
+			variant 2
+				"Blackbird"
+				"Bastion"
+				"Sparrow" 4
+			variant 1
+				"Blackbird"
+				"Fury" 5
+				"Hawk 4
 		dialog "The target has been destroyed. Return to <destination> for your payment."
 	on complete
-		payment 600000
+		payment 800000
 		dialog "The pirate warlord thanks you for eliminating the politician that threatened them and pays you <payment>."
 		"reputation: Free Worlds" -= 15
 		"reputation: Pirate" += 5
 		
-mission "FW Assassination [3]"
-	name "Assassinate a military target"
-	description "A Free Worlds militia commander who has led a number of small raids against pirate gangs in the region has been spotted patrolling a nearby system with their fleet. Assassinate them in order to send a message to the Free Worlds. Payment is <payment>."
-	repeat
-	job
-	to offer
-		"combat rating" > 500
-		random < 5
-		"reputation: Pirate" > 50
-		has "event: war begins"
-	source
-		government "Pirate"
-		attributes "south pirate"
-	npc kill
-		government "Free Worlds"
-		personality staying target
-		system
-			distance 2 4
-		fleet
-			names "free worlds small"
-			variant
-				"Falcon"
-				"Osprey" 2
-				"Sparrow" 4
-			variant
-				"Falcon"
-				"Argosy (Laser)" 3
-				"Hawk" 2
-				"Fury" 2
-		dialog "The target has been destroyed. Return to <destination> for your payment."
-	on complete
-		payment 750000
-		dialog "A gang of pirates on <planet> thank you for taking out the Free Worlds commander and pay you <payment>."
-		"reputation: Free Worlds" -= 20
-		"reputation: Pirate" += 7
-		
-mission "FW Assassination [4]"
-	name "Assassinate a military target"
-	description "Rumor is the Free Worlds are planning a raid on regional pirate gangs. A militia commander said to be leading this raid has been spotted in a nearby system with a large fleet. Assassinate them in order to send a message to the Free Worlds. Payment is <payment>."
-	repeat
-	job
-	to offer
-		"combat rating" > 800
-		random < 5
-		"reputation: Pirate" > 100
-		has "event: war begins"
-	source
-		government "Pirate"
-		attributes "south pirate"
-	npc kill
-		government "Free Worlds"
-		personality staying target
-		system
-			distance 2 4
-		fleet
-			names "free worlds small"
-			variant
-				"Falcon" 2
-				"Bastion" 3
-				"Osprey" 2
-				"Argosy" 2
-			variant
-				"Falcon"
-				"Bastion" 2
-				"Argosy" 5
-				"Fury" 4
-		dialog "The target fleet has been destroyed. Return to <destination> for your payment."
-	on complete
-		payment 1000000
-		dialog "You are greeted by applause from many pirates when you land and a powerful pirate warlord pays you <payment>."
-		"reputation: Free Worlds" -= 25
-		"reputation: Pirate" += 10
-		
 mission "Syndicate Assassination [1]"
 	name "Assassinate a political target"
-	description "A Syndicate politician was spotted passing through a nearby system in their ship, the <npc>. Assassinate them in order to send a message to the Syndicate. Payment is <payment>. Be advised that they may have escorts."
+	description "A Syndicate politician was spotted passing through a nearby system in their ship, the <npc>. Assassinate them by <day> in order to send a message to the Syndicate. Payment is <payment>. Be advised that they may have escorts."
 	repeat
 	job
+	deadline 25
 	to offer
-		"combat rating" > 200
+		"combat rating" > 300
 		random < 5
 		"reputation: Pirate" > -100
 	source
@@ -3139,26 +3108,48 @@ mission "Syndicate Assassination [1]"
 		government "Syndicate"
 		personality staying target
 		system
-			distance 2 5
+			government "Syndicate"
+			distance 2 3
 		fleet
 			names civilian
-			variant
-				"Star Queen"
+			variant 6
+				"Arrow"
+			variant 6
+				"Bounder"
+			variant 2
+				"Arrow"
 				"Quicksilver" 2
+			variant 2
+				"Bounder"
+				"Manta"
+			variant 3
+				"Arrow"
+				"Wasp" 3
+			variant 3
+				"Bounder"
+				"Quicksilver"
+				"Wasp" 2
+			variant 1
+				"Arrow"
+				"Splinter"
+			variant 1
+				"Bounder"
+				"Splinter"
 		dialog "The target has been destroyed. Return to <destination> for your payment."
 	on complete
-		payment 350000
+		payment 460000
 		dialog "A pirate warlord thanks you for eliminating the politician and pays you <payment>."
 		"reputation: Syndicate" -= 10
 		"reputation: Pirate" += 3
 		
 mission "Syndicate Assassination [2]"
 	name "Assassinate a political target"
-	description "A Syndicate politician who has plans that worry many local pirate gangs was spotted in their ship, the <npc>, in a nearby system. Assassinate them in order to send a message to the Syndicate. Payment is <payment>. Be advised that they are heavily defended."
+	description "A Syndicate politician who has plans that worry many local pirate gangs was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> in order to send a message to the Syndicate. Payment is <payment>. Be advised that they may be heavily defended."
 	repeat
 	job
+	deadline 25
 	to offer
-		"combat rating" > 400
+		"combat rating" > 600
 		random < 5
 		"reputation: Pirate" > -50
 	source
@@ -3168,101 +3159,58 @@ mission "Syndicate Assassination [2]"
 		government "Syndicate"
 		personality staying target
 		system
-			distance 2 5
+			government "Syndicate"
+			distance 2 3
 		fleet
 			names civilian
-			variant
-				"Star Queen"
-				"Splinter" 2
-			variant
-				"Star Queen"
+			variant 2
+				"Arrow"
+			variant 3
+				"Bounder"
+			variant 2
+				"Arrow"
+				"Vanguard"
+			variant 2
+				"Bounder"
+				"Protector"
+			variant 4
+				"Arrow"
+				"Quicksilver" 4
+			variant 2
+				"Bounder"
 				"Manta" 2
-		dialog "The targets have been destroyed. Return to <destination> for payment."
+			variant 2
+				"Arrow"
+				"Manta"
+				"Quicksilver" 2
+			variant 4
+				"Bounder"
+				"Splinter"
+				"Wasp" 3
+			variant 2
+				"Arrow"
+				"Manta"
+				"Splinter"
+			variant 2
+				"Bounder"
+				"Splinter" 2
+			variant 1
+				"Arrow" 10
+		dialog "The target has been destroyed. Return to <destination> for payment."
 	on complete
-		payment 600000
+		payment 800000
 		dialog "A band of pirates thank you for eliminating the politician and pay you <payment>."
 		"reputation: Syndicate" -= 15
 		"reputation: Pirate" += 5
 		
-mission "Syndicate Assassination [3]"
-	name "Assassinate a military target"
-	description "A Syndicated Security commander who has led a number of small raids against pirate gangs in the region has been spotted patrolling a nearby system with their fleet. Assassinate them in order to send a message to the Syndicate. Payment is <payment>."
-	repeat
-	job
-	to offer
-		"combat rating" > 500
-		random < 5
-		"reputation: Pirate" > 50
-	source
-		government "Pirate"
-		attributes "core pirate"
-	npc kill
-		government "Syndicate"
-		personality staying target
-		system
-			distance 2 4
-		fleet
-			names "syndicate small"
-			variant
-				"Vanguard"
-				"Manta" 2
-				"Splinter"
-				"Quicksilver" 3
-			variant
-				"Vanguard"
-				"Protector"
-				"Quicksilver" 4
-		dialog "The target has been destroyed. Return to <destination> for your payment."
-	on complete
-		payment 750000
-		dialog "A gang of pirates on <planet> thank you for taking out the Syndicated Security commander and pay you <payment>."
-		"reputation: Syndicate" -= 20
-		"reputation: Pirate" += 7
-		
-mission "Syndicate Assassination [4]"
-	name "Assassinate a military target"
-	description "Rumor is the Syndicate is planning a raid on regional pirate gangs. An important security commander said to be leading this raid has been spotted in a nearby system with a large fleet. Assassinate them in order to send a message to the Syndicate. Payment is <payment>."
-	repeat
-	job
-	to offer
-		"combat rating" > 800
-		random < 5
-		"reputation: Pirate" > 100
-	source
-		government "Pirate"
-		attributes "core pirate"
-	npc kill
-		government "Syndicate"
-		personality staying target
-		system
-			distance 2 4
-		fleet
-			names "syndicate small"
-			variant
-				"Vanguard"
-				"Protector" 2
-				"Splinter" 3
-				"Manta"
-				"Quicksilver" 2
-			variant
-				"Vanguard" 3
-				"Splinter" 2
-				"Manta" 2
-				"Quicksilver" 3
-		dialog "The target and their fleet has been destroyed. Return to <destination> for your payment."
-	on complete
-		payment 1000000
-		dialog "You are greeted by applause from many pirates when you land and a powerful pirate warlord pays you <payment>."
-		"reputation: Syndicate" -= 25
-		"reputation: Pirate" += 10
-		
 mission "Republic Assassination [1]"
 	name "Assassinate a political target"
-	description "A Republic politician who is worrying local pirate gangs was spotted in their ship, the <npc>, in a nearby system. Assassinate them in order to send a message to the Republic. Payment is <payment>. Be advised that they may have escorts."
+	description "A Republic politician who is worrying local pirate gangs was spotted in their ship, the <npc>, in Northern space. Assassinate them by <day> in order to send a message to the Republic. Payment is <payment>. Be advised that they may have escorts."
 	repeat
 	job
+	deadline 20
 	to offer
-		"combat rating" > 200
+		"combat rating" > 300
 		random < 5
 		"reputation: Pirate" > -100
 	source
@@ -3272,16 +3220,43 @@ mission "Republic Assassination [1]"
 		government "Republic"
 		personality staying target
 		system
-			distance 3 5
+			government "Republic"
+			distance 3 6
+			not near "Cardax" 3
 		fleet
 			names civilian
-			variant
+			variant 7
 				"Flivver"
+			variant 7
+				"Scout"
+			variant 3
+				"Flivver"
+				"Raven"
+				"Berserker"
+			variant 2
+				"Scout"
+				"Aerie"
+				"Dagger" 2
+			variant 2
+				"Flivver"
+				"Firebird"
+			variant 3
+				"Scout"
 				"Headhunter" 2
-				"Corvette"
+			variant 1
+				"Flivver"
+				"Gunboat" 2
+			variant 1
+				"Scout"
+				"Frigate"
+			variant 1
+				"Mule"
+				"Dagger"
+			variant 1
+				"Star Queen"
 		dialog "The target has been destroyed. Return to <destination> for your payment."
 	on complete
-		payment 350000
+		payment 460000
 		dialog "A pirate warlord thanks you for eliminating the politician pays you <payment>."
 		"reputation: Republic" -= 10
 		"reputation: Navy (Oathkeeper)" -= 10
@@ -3289,11 +3264,12 @@ mission "Republic Assassination [1]"
 		
 mission "Republic Assassination [2]"
 	name "Assassinate a political target"
-	description "A Republic politician who is worrying local drug traders was spotted in their ship, the <npc>, in a nearby system. Assassinate them in order to send a message to the Republic. Payment is <payment>. Be advised that they are heavily defended."
+	description "A Republic politician who is worrying local drug traders was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> in order to send a message to the Republic. Payment is <payment>. Be advised that they may be heavily defended."
 	repeat
 	job
+	deadline 20
 	to offer
-		"combat rating" > 400
+		"combat rating" > 600
 		random < 5
 		"reputation: Pirate" > -50
 	source
@@ -3303,99 +3279,58 @@ mission "Republic Assassination [2]"
 		government "Republic"
 		personality staying target
 		system
-			distance 3 5
+			government "Republic"
+			distance 3 6
+			not near "Cardax" 3
 		fleet
 			names civilian
-			variant
+			variant 1
+				"Flivver"
+			variant 1
+				"Scout"
+			variant 2
+				"Mule"
+				"Dagger"
+			variant 2
 				"Star Queen"
-				"Headhunter" 3
-				"Firebird" 2
-			variant
-				"Star Queen"
-				"Gunboat" 2
+			variant 2
+				"Flivver"
+				"Aerie"
+				"Dagger" 2
 				"Frigate"
-		dialog "The targets have been destroyed. Return to <destination> for payment."
+			variant 4
+				"Scout"
+				"Headhunter" 4
+			variant 3
+				"Mule"
+				"Dagger"
+				"Raven" 2
+			variant 2
+				"Star Queen"
+				"Corvette"
+				"Firebird"
+			variant 2
+				"Flivver"
+				"Leviathan"
+			variant 2
+				"Scout"
+				"Corvette"
+				"Mule"
+				"Dagger"
+			variant 1
+				"Mule"
+				"Dagger"
+				"Cruiser"
+				"Combat Drone" 4
+			variant 1
+				"Star Queen"
+				"Carrier"
+				"Lance" 4
+				"Combat Drone" 6
+		dialog "The target has been destroyed. Return to <destination> for payment."
 	on complete
-		payment 600000
+		payment 800000
 		dialog "A band of drug traders thank you for eliminating the politician and pay you <payment>."
 		"reputation: Republic" -= 15
 		"reputation: Navy (Oathkeeper)" -= 15
 		"reputation: Pirate" += 5
-		
-mission "Republic Assassination [3]"
-	name "Assassinate a military target"
-	description "A Republic Navy commander who has led a number of small raids against pirate gangs in the region has been spotted patrolling a nearby system with their fleet. Assassinate them in order to send a message to the Republic. Payment is <payment>."
-	repeat
-	job
-	to offer
-		"combat rating" > 600
-		random < 5
-		"reputation: Pirate" > 50
-	source
-		government "Pirate"
-		attributes "north pirate"
-	npc kill
-		government "Republic"
-		personality staying target
-		system
-			distance 3 4
-		fleet
-			names "republic small"
-			variant
-				"Cruiser"
-				"Combat Drone" 4
-				"Frigate" 2
-			variant
-				"Carrier"
-				"Lance" 4
-				"Combat Drone" 6
-				"Gunboat" 2
-				"Rainmaker"
-		dialog "The target has been destroyed. Return to <destination> for your payment."
-	on complete
-		payment 750000
-		dialog "A gang of pirates on <planet> thank you for taking out the Navy commander and pay you <payment>."
-		"reputation: Republic" -= 20
-		"reputation: Navy (Oathkeeper)" -= 20
-		"reputation: Pirate" += 7
-		
-mission "Republic Assassination [4]"
-	name "Assassinate a military target"
-	description "Rumor is the Republic is planning a raid on regional pirate gangs. An important Navy commander said to be leading this raid has been spotted in a nearby system with a large fleet. Assassinate them in order to send a message to the Republic. Payment is <payment>."
-	repeat
-	job
-	to offer
-		"combat rating" > 800
-		random < 5
-		"reputation: Pirate" > 100
-	source
-		government "Pirate"
-		attributes "north pirate"
-	npc kill
-		government "Republic"
-		personality staying target
-		system
-			distance 3 4
-		fleet
-			names "republic small"
-			variant
-				"Carrier" 2
-				"Lance" 8
-				"Combat Drone" 12
-				"Frigate" 3
-			variant
-				"Carrier"
-				"Lance" 4
-				"Combat Drone" 6
-				"Cruiser" 2
-				"Combat Drone" 8
-				"Frigate" 2
-				"Rainmaker" 2
-				"Gunboat" 2
-		dialog "The target and their fleet has been destroyed. Return to <destination> for your payment."
-	on complete
-		payment 1000000
-		dialog "You are greeted by applause from many pirates when you land and a powerful pirate warlord pays you <payment>."
-		"reputation: Republic" -= 25
-		"reputation: Navy (Oathkeeper)" -= 25
-		"reputation: Pirate" += 10

--- a/data/human/pirate jobs.txt
+++ b/data/human/pirate jobs.txt
@@ -3001,7 +3001,7 @@ mission "Cargo Theft (South)"
 
 mission "FW Assassination [1]"
 	name "Assassinate a political target"
-	description "A Free Worlds politician who is worrying local slave traders was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> in order to send a message to the Free Worlds. Payment is <payment>. Be advised that they may have escorts."
+	description "A Free Worlds politician who is worrying local slave traders was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> to send a message to the Free Worlds. Payment is <payment>. Be advised that they may have escorts."
 	repeat
 	job
 	deadline 14
@@ -3044,7 +3044,7 @@ mission "FW Assassination [1]"
 		
 mission "FW Assassination [2]"
 	name "Assassinate a political target"
-	description "A Free Worlds politician who has angered a powerful pirate warlord was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> in order to send a message to the Free Worlds. Payment is <payment>. Be advised that they may be heavily defended."
+	description "A Free Worlds politician who angered a pirate warlord was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> to send a message to the Free Worlds. Payment is <payment>. Be advised that they may be heavily defended."
 	repeat
 	job
 	deadline 14
@@ -3093,7 +3093,7 @@ mission "FW Assassination [2]"
 		
 mission "Syndicate Assassination [1]"
 	name "Assassinate a political target"
-	description "A Syndicate politician was spotted passing through a nearby system in their ship, the <npc>. Assassinate them by <day> in order to send a message to the Syndicate. Payment is <payment>. Be advised that they may have escorts."
+	description "A Syndicate politician was spotted passing through a nearby system in their ship, the <npc>. Assassinate them by <day> to send a message to the Syndicate. Payment is <payment>. Be advised that they may have escorts."
 	repeat
 	job
 	deadline 25
@@ -3144,7 +3144,7 @@ mission "Syndicate Assassination [1]"
 		
 mission "Syndicate Assassination [2]"
 	name "Assassinate a political target"
-	description "A Syndicate politician who has plans that worry many local pirate gangs was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> in order to send a message to the Syndicate. Payment is <payment>. Be advised that they may be heavily defended."
+	description "A Syndicate politician with plans that worry local pirate gangs was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> to send a message to the Syndicate. Payment is <payment>. Be advised that they may be heavily defended."
 	repeat
 	job
 	deadline 25
@@ -3205,7 +3205,7 @@ mission "Syndicate Assassination [2]"
 		
 mission "Republic Assassination [1]"
 	name "Assassinate a political target"
-	description "A Republic politician who is worrying local pirate gangs was spotted in their ship, the <npc>, in Northern space. Assassinate them by <day> in order to send a message to the Republic. Payment is <payment>. Be advised that they may have escorts."
+	description "A Republic politician who is worrying local pirate gangs was spotted in their ship, the <npc>, in Northern space. Assassinate them by <day> to send a message to the Republic. Payment is <payment>. Be advised that they may have escorts."
 	repeat
 	job
 	deadline 20
@@ -3264,7 +3264,7 @@ mission "Republic Assassination [1]"
 		
 mission "Republic Assassination [2]"
 	name "Assassinate a political target"
-	description "A Republic politician who is worrying local drug traders was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> in order to send a message to the Republic. Payment is <payment>. Be advised that they may be heavily defended."
+	description "A Republic politician who is worrying local drug traders was spotted in their ship, the <npc>, in a nearby system. Assassinate them by <day> to send a message to the Republic. Payment is <payment>. Be advised that they may be heavily defended."
 	repeat
 	job
 	deadline 20

--- a/data/human/pirate jobs.txt
+++ b/data/human/pirate jobs.txt
@@ -3083,7 +3083,7 @@ mission "FW Assassination [2]"
 			variant 1
 				"Blackbird"
 				"Fury" 5
-				"Hawk 4
+				"Hawk" 4
 		dialog "The target has been destroyed. Return to <destination> for your payment."
 	on complete
 		payment 800000

--- a/data/human/syndicate jobs.txt
+++ b/data/human/syndicate jobs.txt
@@ -202,9 +202,9 @@ mission "Syndicate target practice [0]"
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
-		payment -40000
+		payment -160000
 	on complete
-		payment 20000
+		payment 80000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
 
 
@@ -221,7 +221,7 @@ mission "Syndicate target practice [1]"
 	to offer
 		random < 20
 		"combat rating" > 50
-		"combat rating" < 200
+		"combat rating" < 250
 		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"
 		government "Test Dummy"
@@ -238,9 +238,9 @@ mission "Syndicate target practice [1]"
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
-		payment -80000
+		payment -300000
 	on complete
-		payment 40000
+		payment 150000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
 
 
@@ -256,7 +256,7 @@ mission "Syndicate target practice [2]"
 		government Syndicate
 	to offer
 		random < 20
-		"combat rating" > 150
+		"combat rating" > 200
 		"combat rating" < 1000
 		"destroyed Syndicate target ship" < 3
 	npc save disable "scan cargo"
@@ -274,9 +274,9 @@ mission "Syndicate target practice [2]"
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
-		payment -120000
+		payment -520000
 	on complete
-		payment 60000
+		payment 260000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
 
 
@@ -309,9 +309,9 @@ mission "Syndicate target practice [3]"
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
-		payment -200000
+		payment -800000
 	on complete
-		payment 100000
+		payment 400000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
 
 ship "Berserker" "Berserker Test Dummy"

--- a/data/human/syndicate jobs.txt
+++ b/data/human/syndicate jobs.txt
@@ -202,7 +202,7 @@ mission "Syndicate target practice [0]"
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
-		payment -160000
+		fine 160000
 	on complete
 		payment 80000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
@@ -238,7 +238,7 @@ mission "Syndicate target practice [1]"
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
-		payment -300000
+		fine 300000
 	on complete
 		payment 150000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
@@ -274,7 +274,7 @@ mission "Syndicate target practice [2]"
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
-		payment -520000
+		fine 520000
 	on complete
 		payment 260000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."
@@ -309,7 +309,7 @@ mission "Syndicate target practice [3]"
 		dialog "The robotic target ship has been destroyed. You are hailed by an angry Syndicate official who fines you <payment> and warns you that further mistakes of this nature may remove you from eligibility for these jobs."
 		"destroyed Syndicate target ship" ++
 		"reputation: Syndicate" --
-		payment -800000
+		fine 800000
 	on complete
 		payment 400000
 		dialog "You transmit the scan results to a team of eager engineers and collect your payment of <payment>."


### PR DESCRIPTION

![jobs](https://user-images.githubusercontent.com/60202690/194056401-eae6c89d-b7b0-491a-8e74-672eb4daba48.png)

## Summary
Right now, bounty jobs are very passive; in most cases, players don't go out of their way to finish them, instead waiting until they stumble across their bounty by happenstance. This is due to a range of reasons:

- Bounty jobs have no investment cost. Unlike cargo or passenger jobs, you can take on an infinite number of bounty jobs.
- Bounty jobs have no chance of failure. Unlike rush or escort missions, bounty jobs stick around, making there be even less of an incentive to finish the job in a timely manner.
- Bounties are annoying to hunt down. Some bounty jobs can force you to check over 15 systems, most of which require copious backtracking to get to.

The fact that bounty jobs are so passive tends lead to the missions list getting filled by bounty jobs, as the rate of bounties offering outpaces the rate of completion. This isn't great, as it means that it is harder to track plot-critical missions, and, in extreme cases, it can end up lagging the game. The difficulty of tracking down bounties also limits dedicated bounty hunters to either camping on a dead-end system or to spend 20+ jumps tracking down a single target.

This PR aims to fix these issues by making bounty hunting a more active activity, by limiting the ability to hoard jobs and making bounties easier to find. Changes include:

- **Bounties have significantly reduced spawn ranges.** Most now spawn within only a single jump of the source, with spawn distances of two and higher being limited to a select few jobs.
  - This change has also been applied to the FW bounty missions.
- **Bounty jobs now have deadlines.** These deadlines are always enough to let the player check every possible system and return to the source.
  - To compensate for this deadline, the reward for most bounty jobs has been increased, depending on the distance the bounty can spawn.
- Bounty jobs have had their offer rates altered:
  - Generally reduced combat rating thresholds, to better reflect how it is exponentially harder to gain CR early compared to later on.
  - Bounty jobs have had their offer rates increased, due to anti-hoarding measures being introduced.
  - Give more jobs a max CR to reduce the amount the player gets flooded by bounty jobs.
- Overhaul the pirate assassination missions to better differentiate them from regular bounty jobs.
   - Assassination missions now have significantly restricted spawn ranges. You can no longer have a job on Deadman's Cove that spawns a fleet in *Vega*, nor can you have a job on Zenith that spawns a politician around Arneb.
  - Changed the fleets of the assassination missions to better fit the lore. Assassination missions will now spawn a weak transport that may or may not be protected by escorts.
  - Cut the "assassinate military target" missions, as they overlapped with the generic "destroy law enforcement" job too much.

![jobs2](https://user-images.githubusercontent.com/60202690/194056411-3bb77e4e-43e4-4691-9ab0-e1b88e6ee99b.png)
