### PR TITLE
Make the Leviathan and Falcon more distinct

### DIFF
--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -228,15 +228,15 @@ ship "Marauder Falcon"
 		"cost" 13900000
 		"shields" 14100
 		"hull" 4100
-		"required crew" 43
-		"bunks" 80
-		"mass" 560
+		"required crew" 57
+		"bunks" 96
+		"mass" 540
 		"drag" 6.7
 		"heat dissipation" .8
 		"fuel capacity" 600
-		"cargo space" 60
-		"outfit space" 580
-		"weapon capacity" 265
+		"cargo space" 80
+		"outfit space" 620
+		"weapon capacity" 275
 		"engine capacity" 165
 		"self destruct" .15
 		weapon
@@ -477,8 +477,8 @@ ship "Marauder Leviathan"
 		"hull" 5500
 		"required crew" 48
 		"bunks" 69
-		"mass" 640
-		"drag" 7.6
+		"mass" 660
+		"drag" 8.1
 		"heat dissipation" .5
 		"fuel capacity" 500
 		"cargo space" 40

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -230,7 +230,7 @@ ship "Marauder Falcon"
 		"hull" 4100
 		"required crew" 57
 		"bunks" 96
-		"mass" 540
+		"mass" 560
 		"drag" 6.7
 		"heat dissipation" .8
 		"fuel capacity" 600
@@ -477,7 +477,7 @@ ship "Marauder Leviathan"
 		"hull" 5500
 		"required crew" 48
 		"bunks" 69
-		"mass" 660
+		"mass" 680
 		"drag" 8.1
 		"heat dissipation" .5
 		"fuel capacity" 500

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1431,14 +1431,14 @@ ship "Falcon"
 		"shields" 12800
 		"hull" 3700
 		"required crew" 52
-		"bunks" 75
-		"mass" 510
+		"bunks" 91
+		"mass" 490
 		"drag" 6.7
 		"heat dissipation" .7
 		"fuel capacity" 600
-		"cargo space" 90
-		"outfit space" 540
-		"weapon capacity" 240
+		"cargo space" 130
+		"outfit space" 560
+		"weapon capacity" 250
 		"engine capacity" 150
 		weapon
 			"blast radius" 160
@@ -2245,8 +2245,8 @@ ship "Leviathan"
 		"hull" 5000
 		"required crew" 43
 		"bunks" 64
-		"mass" 480
-		"drag" 7.6
+		"mass" 580
+		"drag" 8.1
 		"heat dissipation" .5
 		"fuel capacity" 500
 		"cargo space" 80

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1432,7 +1432,7 @@ ship "Falcon"
 		"hull" 3700
 		"required crew" 52
 		"bunks" 91
-		"mass" 490
+		"mass" 510
 		"drag" 6.7
 		"heat dissipation" .7
 		"fuel capacity" 600
@@ -2245,7 +2245,7 @@ ship "Leviathan"
 		"hull" 5000
 		"required crew" 43
 		"bunks" 64
-		"mass" 580
+		"mass" 600
 		"drag" 8.1
 		"heat dissipation" .5
 		"fuel capacity" 500


### PR DESCRIPTION
## Summary
The Falcon and the Leviathan are very similar ships: both cost more than 9 million credits, have the highest health among civilian ships and have 240 weapon space. However, despite costing 1 million more, and having 10 more required crew, the Falcon tends to be inferior to the Leviathan, having less health and significantly less outfit space. This PR aims to both buff the Falcon and make the Falcon and Leviathan more distinct ships, with the Falcon being a balanced ship with the ability to specialise and the Leviathan being specifically combat-focused.

Changes:

- Increased the Leviathan from 480 mass and 7.6 drag to 580 mass and 8.1 drag, and decrease the Falcon from 510 to 490 mass. This makes the speed difference between the two vessels far more noticable and impactful.
- Increased the Falcon's bunks from 75 to 91, and cargo from 90 to 130. This makes the Falcon a better transport, as well as making it better at capturing and plundering.
- Increased the Falcon's outfit space from 540 to 560. This brings the Falcon from having the worst outfit space of all obtainable Heavy Warships to being on par with the Vanguard. Even when considering the use of outfit expansions, the Falcon still comes out 30 outfit space short compared to an outfit-expanded Leviathan.
- Increased the Falcon's weapon space from 240 to 250. This extra weapon space allows the Falcon to mount stronger weaponry than the Leviathan, but its lower outfit space means that it will have to choose between mobility, utility and offence (and it will still have less HP than the Leviathan).
- Changed the Marauder Falcon's crew requirement from being 9 less than the original to being 5 higher. Every other Marauder has more crew requirement than the original.

Changes to the original models are also carried over to the Marauder variants.