### PR TITLE
Corrected passenger name for Pug 4 mission

### DIFF
--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -1829,7 +1829,7 @@ mission "FW Pug 4"
 				"Pug Zibruka" 2
 	
 	on visit
-		dialog `You've landed on <planet>, but there are either still Pug ships circling overhead, or you've left Alondo behind. You should take off and help finish off the Pug or wait for your escort carrying Alondo to arrive.`
+		dialog `You've landed on <planet>, but there are either still Pug ships circling overhead, or you've left Freya behind. You should take off and help finish off the Pug or wait for your escort carrying Alondo to arrive.`
 	on complete
 		event "battle for delta capricorni"
 


### PR DESCRIPTION
## Summary
The on visit dialog for this mission references Alondo as your passenger rather than Freya. This PR is a simple name change only.

Not tested due to the simplicity of the change and the complexity of setting up a test pilot for it.