### PR TITLE
Change Saryd Traveler category to Utility

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -1939,6 +1939,7 @@ ship "Saryd Traveler"
 		"weapon capacity" 177
 		"engine capacity" 79
 		"asteroid scan power" 36
+		"atmosphere scan" 100
 		weapon
 			"blast radius" 72
 			"shield damage" 720

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -1922,7 +1922,7 @@ ship "Saryd Traveler"
 	sprite "ship/saryd traveler"
 	thumbnail "thumbnail/saryd traveler"
 	attributes
-		category "Transport"
+		category "Utility"
 		licenses
 			Coalition
 		"cost" 3385000


### PR DESCRIPTION
----------------------
**Content Tweak (Ship Category Change Thing)**

## Summary
This PR moves the Saryd Traveler from the Transport category to the Utility category, to have it better fit with its lored description of being a science ship, and the recently added science-y stat `asteroid scan power`.
It also gives it `"atmosphere scan" 100`, as that seems to be something all science ships have, so reinforcing that aspect of it.