### PR TITLE
add support for ship bays removal

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -199,7 +199,6 @@ Ship::Ship(const DataNode &node)
 }
 
 
-
 void Ship::Load(const DataNode &node)
 {
 	if(node.Size() >= 2)
@@ -504,6 +503,14 @@ void Ship::Load(const DataNode &node)
 			description += child.Token(1);
 			description += '\n';
 		}
+		else if(!variantName.empty()) {
+			if ((key == "remove") && (child.Size() >= 2)) {
+				if (child.Token(1) == "bays")
+					removeBaseFeature |= (1 << REMOVE_SET_BAYS);
+			}
+			else
+				child.PrintTrace("Skipping unrecognized attribute:");
+		}
 		else if(key != "actions")
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
@@ -756,7 +763,10 @@ void Ship::FinishLoading(bool isNewInstance)
 		}
 		else
 			++it;
-		if(bay.side == Bay::INSIDE && bay.launchEffects.empty() && Crew())
+
+		if (removeBaseFeature.test(REMOVE_SET_BAYS))
+			it = bays.erase(it - 1);
+		else if(bay.side == Bay::INSIDE && bay.launchEffects.empty() && Crew())
 			bay.launchEffects.emplace_back(GameData::Effects().Get("basic launch"));
 	}
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -504,7 +504,8 @@ void Ship::Load(const DataNode &node)
 			description += child.Token(1);
 			description += '\n';
 		}
-		else if(key == "remove" && child.Size() >= 2) {
+		else if(key == "remove" && child.Size() >= 2)
+		{
 			if(child.Token(1) == "bays")
 				removeBays = true;
 			else

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -504,7 +504,7 @@ void Ship::Load(const DataNode &node)
 			description += child.Token(1);
 			description += '\n';
 		}
-		else if( key == "remove" && child.Size() >= 2) {
+		else if(key == "remove" && child.Size() >= 2) {
 			if(variantName.empty())
 			{
 				child.PrintTrace("Skipping invalid 'remove' on a non variant:");

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -199,6 +199,7 @@ Ship::Ship(const DataNode &node)
 }
 
 
+
 void Ship::Load(const DataNode &node)
 {
 	if(node.Size() >= 2)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -509,7 +509,7 @@ void Ship::Load(const DataNode &node)
 			if(child.Token(1) == "bays")
 				removeBays = true;
 			else
-				child.PrintTrace("Skipping unsupported 'remove':");
+				child.PrintTrace("Skipping unsupported \"remove\":");
 		}
 		else if(key != "actions")
 			child.PrintTrace("Skipping unrecognized attribute:");

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -617,7 +617,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			armament = merged;
 		}
 	}
-	else if (removeBays)
+	else if(removeBays)
 		bays.clear();
 	// Check that all the "equipped" weapons actually match what your ship
 	// has, and that they are truly weapons. Remove any excess weapons and

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -617,6 +617,8 @@ void Ship::FinishLoading(bool isNewInstance)
 			armament = merged;
 		}
 	}
+	else if (removeBays)
+		bays.clear();
 	// Check that all the "equipped" weapons actually match what your ship
 	// has, and that they are truly weapons. Remove any excess weapons and
 	// warn if any non-weapon outfits are "installed" in a hardpoint.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -505,11 +505,6 @@ void Ship::Load(const DataNode &node)
 			description += '\n';
 		}
 		else if(key == "remove" && child.Size() >= 2) {
-			if(variantName.empty())
-			{
-				child.PrintTrace("Skipping invalid 'remove' on a non variant:");
-				continue;
-			}
 			if(child.Token(1) == "bays")
 				removeBays = true;
 			else

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -563,7 +563,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			customSwizzle = base->CustomSwizzle();
 		if(baseAttributes.Attributes().empty())
 			baseAttributes = base->baseAttributes;
-		if(bays.empty() && !base->bays.empty())
+		if(bays.empty() && !base->bays.empty() && !removeBays)
 			bays = base->bays;
 		if(enginePoints.empty())
 			enginePoints = base->enginePoints;
@@ -767,10 +767,7 @@ void Ship::FinishLoading(bool isNewInstance)
 		}
 		else
 			++it;
-
-		if (removeBays)
-			it = bays.erase(it - 1);
-		else if(bay.side == Bay::INSIDE && bay.launchEffects.empty() && Crew())
+		if(bay.side == Bay::INSIDE && bay.launchEffects.empty() && Crew())
 			bay.launchEffects.emplace_back(GameData::Effects().Get("basic launch"));
 	}
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -504,13 +504,16 @@ void Ship::Load(const DataNode &node)
 			description += child.Token(1);
 			description += '\n';
 		}
-		else if(!variantName.empty()) {
-			if ((key == "remove") && (child.Size() >= 2)) {
-				if (child.Token(1) == "bays")
-					removeBaseFeature |= (1 << REMOVE_SET_BAYS);
+		else if( key == "remove" && child.Size() >= 2) {
+			if(variantName.empty())
+			{
+				child.PrintTrace("Skipping invalid 'remove' on a non variant:");
+				continue;
 			}
+			if(child.Token(1) == "bays")
+				removeBays = true;
 			else
-				child.PrintTrace("Skipping unrecognized attribute:");
+				child.PrintTrace("Skipping unsupported 'remove':");
 		}
 		else if(key != "actions")
 			child.PrintTrace("Skipping unrecognized attribute:");
@@ -765,7 +768,7 @@ void Ship::FinishLoading(bool isNewInstance)
 		else
 			++it;
 
-		if (removeBaseFeature.test(REMOVE_SET_BAYS))
+		if (removeBays)
 			it = bays.erase(it - 1);
 		else if(bay.side == Bay::INSIDE && bay.launchEffects.empty() && Crew())
 			bay.launchEffects.emplace_back(GameData::Effects().Get("basic launch"));

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -50,10 +50,6 @@ class StellarObject;
 class System;
 class Visual;
 
-enum {
-	REMOVE_SET_BAYS = 0,
-	REMOVE_SET_COUNT
-};
 
 // Class representing a ship (either a model for sale or an instance of it). A
 // ship's information can be saved to a file, so that it can later be read back
@@ -639,7 +635,7 @@ private:
 	std::vector<std::weak_ptr<Ship>> escorts;
 	std::weak_ptr<Ship> parent;
 
-	std::bitset<REMOVE_SET_COUNT> removeBaseFeature;
+	bool removeBays;
 };
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -50,6 +50,7 @@ class System;
 class Visual;
 
 
+
 // Class representing a ship (either a model for sale or an instance of it). A
 // ship's information can be saved to a file, so that it can later be read back
 // in exactly the same state. The same class is used for the player's ship as

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -635,7 +635,7 @@ private:
 	std::vector<std::weak_ptr<Ship>> escorts;
 	std::weak_ptr<Ship> parent;
 
-	bool removeBays;
+	bool removeBays = false;
 };
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -34,6 +34,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <set>
 #include <string>
 #include <vector>
+#include <bitset>
 
 class DamageDealt;
 class DataNode;
@@ -49,7 +50,10 @@ class StellarObject;
 class System;
 class Visual;
 
-
+enum {
+	REMOVE_SET_BAYS = 0,
+	REMOVE_SET_COUNT
+};
 
 // Class representing a ship (either a model for sale or an instance of it). A
 // ship's information can be saved to a file, so that it can later be read back
@@ -634,6 +638,8 @@ private:
 	// Links between escorts and parents.
 	std::vector<std::weak_ptr<Ship>> escorts;
 	std::weak_ptr<Ship> parent;
+
+	std::bitset<REMOVE_SET_COUNT> removeBaseFeature;
 };
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -34,7 +34,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <set>
 #include <string>
 #include <vector>
-#include <bitset>
 
 class DamageDealt;
 class DataNode;


### PR DESCRIPTION
this feature allows bay-less variants for ships that have internal fighter bays.

testing was done with Aerie class to verify it is impossible to buy fighter and insert it into a non existent bay.
plugin which uses this feature can be found at https://github.com/daggs1/Lionheart_Customs

this is a resend of https://github.com/endless-sky/endless-sky/pull/7142 which got closed by mistake due to a fork sync with upstream