### PR TITLE
Add Sound to Ka'het Annihilator Turret.

### DIFF
--- a/data/kahet/kahet outfits.txt
+++ b/data/kahet/kahet outfits.txt
@@ -197,6 +197,7 @@ outfit "Ka'het Annihilator Turret"
 	weapon
 		sprite "projectile/annihilator"
 			"frame rate" 7
+		sound "inhibitor"
 		"hardpoint sprite" "hardpoint/annihilator turret"
 		"hardpoint offset" 15.
 		"hit effect" "bullet impact"


### PR DESCRIPTION
**Bugfix:** 

## Fix Details
The Ka'het Annihilator Turret has no sound associated with it, making it completely silent to fire, as reported by limagb on [Discord.](https://discord.com/channels/251118043411775489/308902312741568512/1028092078619623435)
Unlike the annihilator gun which uses the inhibitor sound effect.

This PR adds the same sound used by the gun to the turret. 

I checked the original PR and saw no mention of the Annihilator turret being silent, so I assume it was not intentionally created this way. 
If it was intentional that the turret does not have a sound effect, and that is desired behaviour, this can be closed.

## Testing Done
Verified that without this fix, firing the turret is completely silent. With this fix, the turret makes the same sound as the gun.