### PR TITLE
Fix accompany tag

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -1596,7 +1596,7 @@ mission "Pirate Troubles [4]"
 		"reputation: Hai Merchant (Human)" += 40
 		"reputation: Hai Merchant (Sympathizers)" += 40
 	
-	npc save accompany
+	npc accompany save
 		government "Hai (Wormhole Access)"
 		personality escort
 		fleet

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2101,7 +2101,7 @@ mission "Deep: Scientist Rescue 1"
 			`	The communications device on his belt rings, and he quickly responds, giving orders to the fleet that will be joining you on the mission. Before you can return to your ship, he says, "Good luck, Captain, and may we all make it out of this alive. We'll meet you in orbit."`
 				accept
 	
-	npc save accompany
+	npc accompany save
 		government "Deep Security"
 		personality escort
 		ship "Mule (Heavy)" "D.S.S. Faraday"
@@ -2256,7 +2256,7 @@ mission "Deep: Scientist Rescue 2"
 		dialog "As your engines roar, you notice a large pirate ship looming over the planet. Even from the underside, it is undeniably a Bactrian, but how a pirate could ever attain one is a mystery."
 		dialog `	You receive a transmission from Lieutenant Paris. "I have a sneaking suspicion that Beelzebub may be behind this. I suggest we jump out of here immediately and make it back to the Deep alive before taking on that Bactrian."`
 	
-	npc save accompany
+	npc accompany save
 		government "Deep Security"
 		personality timid escort
 		ship "Star Queen (Unarmed)" "D.S.S. Alcubierre"

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -2922,7 +2922,7 @@ mission "Hauler VI cargo prototype 1"
 	destination "Skymoot"
 	to offer
 		"armament deterrence" > 0
-	npc accompany
+	npc accompany save
 		government "Merchant"
 		personality escort timid
 		ship "Hauler III" "SB-Labs Testament"
@@ -2992,7 +2992,7 @@ mission "Hauler VI cargo prototype 2"
 	landing
 	to offer
 		has "Hauler VI cargo prototype 1: done"
-	npc accompany
+	npc accompany save
 		government "Merchant"
 		personality escort timid
 		ship "Hauler III" "SB-Labs Testament"
@@ -3013,7 +3013,7 @@ mission "Hauler VI cargo prototype 3"
 	landing
 	to offer
 		has "Hauler VI cargo prototype 2: done"
-	npc accompany
+	npc accompany save
 		government "Merchant"
 		personality escort timid
 		ship "Hauler III" "SB-Labs Testament"

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -442,7 +442,7 @@ mission "Remnant: Cognizance 12"
 	source "Viminal"
 	destination "Esquiline"
 	stopover "Nasqueron"
-	npc accompany
+	npc accompany save
 		government "Remnant"
 		personality timid launching escort
 		fleet
@@ -526,7 +526,7 @@ mission "Remnant: Cognizance 15"
 	destination "Viminal"
 	to offer
 		has "Remnant: Cognizance 14: active"
-	npc accompany
+	npc accompany save
 		government "Ember Waste"
 		personality waiting mute
 		ship "Ember Waste Node" "Unknown Entity"
@@ -549,7 +549,7 @@ mission "Remnant: Cognizance 16"
 			`	After several hours of watching the creature, one captain pushes his way forward to where you, Chilia, and Plume are talking. "I think I have an idea about this thing, Prefect!" the man signs excitedly. "Look at the positions of the glowing tips when it freezes. That pattern there matches the star positions of the main Ember Waste systems when viewed from Peragenor, and that second matches Convector." He pulls out a datapad and pulls up a projection of the starmap. "It is hard to tell due to the imprecision, but it looks like the third freeze is probably Antevorta or Nenia."`
 			`	Plume chimes in, "If those freezes indicate star positions, then the flying and landing behavior in between them may be indicating that it wants you to travel there. Please give it a try."`
 				accept
-	npc accompany
+	npc accompany save
 		government "Ember Waste"
 		personality mute
 		ship "Ember Waste Node" "Unknown Entity"
@@ -613,7 +613,7 @@ mission "Remnant: Cognizance 18"
 			label letsgo
 			`	Chilia continues. "You don't need to actually land anywhere in Nenia this time, Captain. Just make sure the Pelicans get there, load up, and return safely." The two stand up and get ready to leave. "May the Embers burn bright for you, Captain." With that, they disembark and quickly clear the blast area around the landing pad. Around you a large group of Pelicans are warming up, each one synchronizing to your IFF and confirming their status.`
 				accept
-	npc save accompany
+	npc accompany save
 		government "Remnant"
 		personality pacifist coward launching escort
 		fleet

--- a/data/remnant/remnant 2 side missions.txt
+++ b/data/remnant/remnant 2 side missions.txt
@@ -547,7 +547,7 @@ mission "Remnant: Shattered Light 4"
 			`	The dust and debris settle within a few minutes, and soon you and the <ship> are skimming over the vegetation. The approach gives you ample time to appreciate just how massive the Shattered Light is; everything that one could need to lay the foundations for a new colony is packed into a single ship. You note large gashes in the hull, massive sensor arrays, and a shattered dome on top. Based on the mismatch of parts, this ship has been substantially modified from its original hull, and survived untold damage.`
 			`	As you slow to a hover alongside the ship, Ruach appears on your viewscreen. "Well met, Captain! Our theory worked! We managed to snap the Shattered Light back into the Primary Weft, and are now onboard. The systems are dubious, though, so we dare not shut anything down lest we cannot restart it. We would appreciate your assistance in escorting us back to Viminal."`
 				accept
-	npc accompany
+	npc accompany save
 		government "Remnant (Research)"
 		personality launching timid escort
 		planet "Far Monad"

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -72,10 +72,7 @@ void NPC::Load(const DataNode &node)
 		else if(node.Token(i) == "evade")
 			mustEvade = true;
 		else if(node.Token(i) == "accompany")
-		{
 			mustAccompany = true;
-			failIf |= ShipEvent::DESTROY;
-		}
 		else
 			node.PrintTrace("Warning: Skipping unrecognized NPC completion condition \"" + node.Token(i) + "\":");
 	}

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -476,7 +476,7 @@ bool NPC::HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable) con
 
 	// Evaluate the status of each ship in this NPC block. If it has `accompany`,
 	// and is alive then it cannot be disabled and must be in the player's system.
-	// If the NPC block has evade`, the ship can be disabled, destroyed, captured,
+	// If the NPC block has `evade`, the ship can be disabled, destroyed, captured,
 	// or not present.
 	if(mustEvade || mustAccompany)
 		for(const shared_ptr<Ship> &ship : ships)

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -475,15 +475,14 @@ bool NPC::HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable) con
 		return false;
 
 	// Evaluate the status of each ship in this NPC block. If it has `accompany`,
-	// it cannot be disabled and must be in the player's system. If the ship
-	// is destroyed it will not count into the list.
-	// Destroyed `accompany` are handled in HasFailed(). If the NPC block has
-	// `evade`, the ship can be disabled, destroyed, captured, or not present.
+	// and is alive then it cannot be disabled and must be in the player's system.
+	// If the NPC block has evade`, the ship can be disabled, destroyed, captured,
+	// or not present.
 	if(mustEvade || mustAccompany)
 		for(const shared_ptr<Ship> &ship : ships)
 		{
 			auto it = actions.find(ship.get());
-			// Captured or destroyed ships do not count into the list.
+			// Captured or destroyed ships have either succeeded or no longer count.
 			if(it->second & (ShipEvent::DESTROY | ShipEvent::CAPTURE))
 				continue;
 			// If a derelict ship has not received any ShipEvents, it is immobile.
@@ -492,7 +491,7 @@ bool NPC::HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable) con
 			// events (and the current system).
 			if(it != actions.end())
 			{
-				// A ship that was disabled, captured, or destroyed is considered 'immobile'.
+				// A ship that was disabled is considered 'immobile'.
 				isImmobile = (it->second & ShipEvent::DISABLE);
 				// If this NPC is 'derelict' and has no ASSIST on record, it is immobile.
 				isImmobile |= ship->GetPersonality().IsDerelict()

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -474,7 +474,7 @@ bool NPC::HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable) con
 	if(HasFailed())
 		return false;
 
-	// Evaluate the status of each ship in this NPC block. If it has `accompany`,
+	// Evaluate the status of each ship in this NPC block. If it has `accompany`
 	// and is alive then it cannot be disabled and must be in the player's system.
 	// If the NPC block has `evade`, the ship can be disabled, destroyed, captured,
 	// or not present.

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -485,7 +485,7 @@ bool NPC::HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable) con
 			auto it = actions.find(ship.get());
 			// Captured or destroyed ships do not count into the list.
 			if(it->second & (ShipEvent::DESTROY | ShipEvent::CAPTURE))
-			   continue;
+				continue;
 			// If a derelict ship has not received any ShipEvents, it is immobile.
 			bool isImmobile = ship->GetPersonality().IsDerelict();
 			// The success status calculation can only be based on recorded


### PR DESCRIPTION
Changes the `accompany` check to only check for "living" ships being in the players system. To divide `accompany` tag from `save` tag.