### PR TITLE
Sparrow/Flivver Stat Tweaks to Better Match their Roles 

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1608,7 +1608,7 @@ ship "Flivver"
 		"fuel capacity" 500
 		"cargo space" 15
 		"outfit space" 130
-		"weapon capacity" 15
+		"weapon capacity" 16
 		"engine capacity" 45
 		weapon
 			"blast radius" 16
@@ -1616,8 +1616,6 @@ ship "Flivver"
 			"hull damage" 80
 			"hit force" 240
 	outfits
-		"Meteor Missile Pod" 2
-		"Meteor Missile" 14
 		
 		"nGVF-BB Fuel Cell"
 		"KP-6 Photovoltaic Panel" 3

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1606,9 +1606,9 @@ ship "Flivver"
 		"drag" 1.0
 		"heat dissipation" .9
 		"fuel capacity" 500
-		"cargo space" 5
+		"cargo space" 15
 		"outfit space" 130
-		"weapon capacity" 25
+		"weapon capacity" 15
 		"engine capacity" 45
 		weapon
 			"blast radius" 16
@@ -3058,7 +3058,7 @@ ship "Sparrow"
 	attributes
 		category "Interceptor"
 		"cost" 225000
-		"shields" 1200
+		"shields" 1400
 		"hull" 300
 		"required crew" 1
 		"bunks" 3
@@ -3066,9 +3066,9 @@ ship "Sparrow"
 		"drag" .9
 		"heat dissipation" .8
 		"fuel capacity" 300
-		"cargo space" 15
+		"cargo space" 5
 		"outfit space" 130
-		"weapon capacity" 20
+		"weapon capacity" 25
 		"engine capacity" 40
 		weapon
 			"blast radius" 16

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -3064,7 +3064,7 @@ ship "Sparrow"
 		"drag" .9
 		"heat dissipation" .8
 		"fuel capacity" 300
-		"cargo space" 5
+		"cargo space" 15
 		"outfit space" 130
 		"weapon capacity" 25
 		"engine capacity" 40


### PR DESCRIPTION
## Summary
Currently, the stats of the Sparrow and the Flivver are in a bit of a weird place. With the Flivver being slightly more expensive than the Sparrow, it is a logical first upgrade for new players. However, the current stats distribution is opposite to the roles these ships are supposed to fulfill. 

If you're looking for a fast transport ship that's cheap and agile with a small number of bunks and cargo, you should pick the Sparrow since it has the same number of bunks, ten more cargo, and is slightly cheaper to buy

If you're looking for an early warship that's fast, cheap and agile, you should pick the Flivver since it has more HP, weapon space and engine space. 

This seems quite counter to the Sparrow's role as an interceptor and the Flivver's role as a transport. 
As such, I've put together a small selection of proposed tweaks to make each ship a better option for the role they're supposed to fulfill, detailed below:

**Sparrow**

1. Shields: 1200 ->1400; this brings the Sparrow just slightly above the Flivver and Star Barge in terms of combined HP while still being worse than a more dedicated interceptor, like the Wasp or Fury. 
2. Weapon Capacity: 20 -> 25; this brings the Sparrow just slightly below the Wasp and slightly above the Barb, allowing it to mount slightly heavier weapons, such as two javelin pods or a single plasma cannon, giving it a bit more early-game firepower.

**Flivver**

1. Cargo Space 5 -> 15, this brings the Flivver up above most interceptors, such as the Berseker or Wasp, while still being less than the Shuttle in cargo and bunks. It also brings it above the Arrow by 5t, but the Arrow comes with two bunks over the Flivver to compensate for that. 
2. Weapon Capacity 25->16, this brings the Flivver down below any dedicated combat ship while still being above Shuttle, meaning there's still a reason to pick the Flivver over Shuttle without the Flivver beating out other similarly sized combat vessels in terms of weapon space. This also necessitates removing its two meteor missile pods in favour of a single Ion Reverse thruster, further reinforcing its role as a ship designed to move fast, jump fast, and run away from combat rather than fight.

With these changes, the Flivver is now much more desirable as an early-game fast transport craft; with a small but acceptable amount of bunks and cargo, plenty of fuel and a fast speed, it's not quite as good as a dedicated transport like Shuttle. However, it has some benefits that still make it a viable choice. 
Additionally, the Sparrow is now a much more formidable warship, with the extra shields meaning it can survive more damage than the Flivver can and the extra weapon space opening up several new possibilities for early game firepower that veteran and new players alike can take advantage of. 

## Save File
This save file will place you on Follower with a Flivver and a Sparrow with their new stats and loadout so you can see the changes for yourself:
[Sparrow Tweaks.txt](https://github.com/endless-sky/endless-sky/files/9738695/Sparrow.Tweaks.txt)



