### PR TITLE
Make hai less defenceless in boarding

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -230,6 +230,8 @@ government "Hai Merchant (Human)"
 government "Hai (Unfettered)"
 	swizzle 4
 	color .55 .27 .76
+	"crew attack" 1.4
+	"crew defense" 2.2
 	
 	"player reputation" -1000
 	"attitude toward"

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -291,6 +291,7 @@ ship "Grasshopper"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling" 2
 		"Quantum Keystone"
+		"Pulse Rifle"
 		`"Benga" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		Hyperdrive
@@ -330,6 +331,7 @@ ship "Grasshopper" "Grasshopper (Surveillance)"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling" 2
 		"Quantum Keystone"
+		"Pulse Rifle"
 		`"Benga" Atomic Thruster`
 		`"Benga" Atomic Steering`
 		Hyperdrive
@@ -367,9 +369,11 @@ ship "Lightning Bug"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
 		"Quantum Keystone"
+		"Pulse Rifle" 2
 		`"Benga" Atomic Thruster`
 		`"Biroo" Atomic Steering`
 		"Hyperdrive"
+
 	engine -40 22
 	engine 40 22
 	gun 0 -40 "Ion Cannon"
@@ -590,6 +594,7 @@ ship "Shield Beetle"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 2
 		"Quantum Keystone"
+		"Pulse Rifle" 55
 		`"Bondir" Atomic Thruster`
 		`"Bufaer" Atomic Steering`
 		"Hyperdrive"
@@ -777,6 +782,7 @@ ship "Solifuge"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 6
 		"Quantum Keystone"
+		"Pulse Rifle" 62
 		`"Benga" Atomic Steering`
 		`"Bufaer" Atomic Steering`
 		`"Bondir" Atomic Thruster`


### PR DESCRIPTION
Simply gave pulse rifles by default to hai warships, as agreed with @MasterOfGrey.
This will help in solving the too easy capping of shield beetles, and showing the Hai as somewhat war ready (civilian ships dont have them though)

I only added as much as the ship's required crew to show this is only an emergency stash in case of need.

edit:
I also buffed the Uhai attack by 0.4 and their defence by 0.2 to make them slightly harder to capture and represent their better ability to fight than the hai, trough a lifetime of training. I could have gone further with the buffing but this way its sure it isnt too big of a buff for now.