### PR TITLE
Skip the Steam auto cloud file when looking for save files

### DIFF
--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -416,7 +416,7 @@ void LoadPanel::UpdateLists()
 	for(const string &path : fileList)
 	{
 		string fileName = Files::Name(path);
-		// Skip the Steam Auto Cloud file, which is created by Steam and not a real save file.
+		// Skip the Steam Auto Cloud file, which is created by Steam but not a real save file.
 		if(fileName == "steam_autocloud.vdf")
 			continue;
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -415,11 +415,11 @@ void LoadPanel::UpdateLists()
 	vector<string> fileList = Files::List(Files::Saves());
 	for(const string &path : fileList)
 	{
-		string fileName = Files::Name(path);
-		// Skip the Steam Auto Cloud file, which is created by Steam but not a real save file.
-		if(fileName == "steam_autocloud.vdf")
+		// Skip any files that aren't text files.
+		if(path.compare(path.length() - 4, 4, ".txt"))
 			continue;
 
+		string fileName = Files::Name(path);
 		// The file name is either "Pilot Name.txt" or "Pilot Name~SnapshotTitle.txt".
 		size_t pos = fileName.find('~');
 		if(pos == string::npos)

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -416,6 +416,10 @@ void LoadPanel::UpdateLists()
 	for(const string &path : fileList)
 	{
 		string fileName = Files::Name(path);
+		// Skip the Steam Auto Cloud file, which is created by Steam and not a real save file.
+		if(fileName == "steam_autocloud.vdf")
+			continue;
+
 		// The file name is either "Pilot Name.txt" or "Pilot Name~SnapshotTitle.txt".
 		size_t pos = fileName.find('~');
 		if(pos == string::npos)


### PR DESCRIPTION
## Feature Details

We're planning on enabling Steam's auto cloud saves, so that save files can be synced across platforms on Steam. For this Steam generates a file called `steam_autocloud.vdf` inside the saves directory. This PR simply tells the game to ignore a file with that name, instead of showing it as a potential save.

## UI Screenshots

![showcase](https://cdn.discordapp.com/attachments/925142669611655169/1028010327125803028/unknown.png)