### PR TITLE
Disallow the planet label to jump around under different zooms

### DIFF
--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -44,10 +44,9 @@ namespace {
 	// Check if the given label for the given stellar object and direction overlaps with any other stellar object in the system.
 	bool Overlaps(const System &system, const StellarObject &object, double zoom, double width, int direction)
 	{
-		bool overlaps = false;
-
 		Point start = zoom * (object.Position() +
 			(object.Radius() + INNER_SPACE + LINE_GAP + LINE_LENGTH) * Angle(LINE_ANGLE[direction]).Unit());
+		// Offset the label correctly depending on its location relative to the stellar object.
 		Point unit(LINE_ANGLE[direction] > 180. ? -1. : 1., 0.);
 		Point end = start + unit * width;
 
@@ -61,19 +60,20 @@ namespace {
 			Point otherPos = other.Position() * zoom;
 			double startDistance = otherPos.Distance(start);
 			double endDistance = otherPos.Distance(end);
-			overlaps |= (startDistance < minDistance || endDistance < minDistance);
-			double projection = (otherPos - start).Dot(unit);
+			if(startDistance < minDistance || endDistance < minDistance)
+				return true;
 
+			// Check overlap with the middle of the label, when the end and/or start might not overlap.
+			double projection = (otherPos - start).Dot(unit);
 			if(projection > 0. && projection < width)
 			{
 				double distance = sqrt(startDistance * startDistance - projection * projection);
-				overlaps |= (distance < minDistance);
+				if(distance < minDistance)
+					return true;
 			}
-			if(overlaps)
-				break;
 		}
 
-		return overlaps;
+		return false;
 	}
 }
 

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -46,8 +46,8 @@ namespace {
 	{
 		bool overlaps = false;
 
-		Point start = object.Position() * zoom +
-			(object.Radius() + INNER_SPACE + LINE_GAP + LINE_LENGTH) * zoom * Angle(LINE_ANGLE[direction]).Unit();
+		Point start = zoom * (object.Position() +
+			(object.Radius() + INNER_SPACE + LINE_GAP + LINE_LENGTH) * Angle(LINE_ANGLE[direction]).Unit());
 		Point unit(LINE_ANGLE[direction] > 180. ? -1. : 1., 0.);
 		Point end = start + unit * width;
 

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "pi.h"
 #include "Planet.h"
 #include "PointerShader.h"
+#include "Preferences.h"
 #include "RingShader.h"
 #include "StellarObject.h"
 #include "System.h"
@@ -39,6 +40,41 @@ namespace {
 	const double LINE_GAP = 1.7;
 	const double GAP = 6.;
 	const double MIN_DISTANCE = 30.;
+
+	// Check if the given label for the given stellar object and direction overlaps with any other stellar object in the system.
+	bool Overlaps(const System &system, const StellarObject &object, double zoom, double width, int direction)
+	{
+		bool overlaps = false;
+
+		Point start = object.Position() * zoom +
+			(object.Radius() + INNER_SPACE + LINE_GAP + LINE_LENGTH) * zoom * Angle(LINE_ANGLE[direction]).Unit();
+		Point unit(LINE_ANGLE[direction] > 180. ? -1. : 1., 0.);
+		Point end = start + unit * width;
+
+		for(const StellarObject &other : system.Objects())
+		{
+			if(&other == &object)
+				continue;
+
+			double minDistance = (other.Radius() + MIN_DISTANCE) * zoom;
+
+			Point otherPos = other.Position() * zoom;
+			double startDistance = otherPos.Distance(start);
+			double endDistance = otherPos.Distance(end);
+			overlaps |= (startDistance < minDistance || endDistance < minDistance);
+			double projection = (otherPos - start).Dot(unit);
+
+			if(projection > 0. && projection < width)
+			{
+				double distance = sqrt(startDistance * startDistance - projection * projection);
+				overlaps |= (distance < minDistance);
+			}
+			if(overlaps)
+				break;
+		}
+
+		return overlaps;
+	}
 }
 
 
@@ -71,42 +107,24 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 
 	// Figure out how big the label has to be.
 	double width = max(FontSet::Get(18).Width(name), FontSet::Get(14).Width(government)) + 8.;
+
+	// Try to find a label direction that not overlapping under any zoom.
 	for(int d = 0; d < 4; ++d)
-	{
-		bool overlaps = false;
-
-		Point start = object.Position() * zoom +
-			(radius + INNER_SPACE + LINE_GAP + LINE_LENGTH) * Angle(LINE_ANGLE[d]).Unit();
-		Point unit(LINE_ANGLE[d] > 180. ? -1. : 1., 0.);
-		Point end = start + unit * width;
-
-		for(const StellarObject &other : system->Objects())
-		{
-			if(&other == &object)
-				continue;
-
-			double minDistance = (other.Radius() + MIN_DISTANCE) * zoom;
-
-			Point otherPos = other.Position() * zoom;
-			double startDistance = otherPos.Distance(start);
-			double endDistance = otherPos.Distance(end);
-			overlaps |= (startDistance < minDistance || endDistance < minDistance);
-			double projection = (otherPos - start).Dot(unit);
-
-			if(projection > 0. && projection < width)
-			{
-				double distance = sqrt(startDistance * startDistance - projection * projection);
-				overlaps |= (distance < minDistance);
-			}
-			if(overlaps)
-				break;
-		}
-		if(!overlaps)
+		if(!Overlaps(*system, object, Preferences::MinViewZoom(), width, d)
+				&& !Overlaps(*system, object, Preferences::MaxViewZoom(), width, d))
 		{
 			direction = d;
-			break;
+			return;
 		}
-	}
+
+	// If we can't find a suitable direction, then try to find a direction under the current
+	// zoom that is not overlapping.
+	for(int d = 0; d < 4; ++d)
+		if(!Overlaps(*system, object, zoom, width, d))
+		{
+			direction = d;
+			return;
+		}
 }
 
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -191,6 +191,20 @@ bool Preferences::ZoomViewOut()
 
 
 
+double Preferences::MinViewZoom()
+{
+	return ZOOMS[0];
+}
+
+
+
+double Preferences::MaxViewZoom()
+{
+	return ZOOMS[ZOOMS.size() - 1];
+}
+
+
+
 void Preferences::ToggleScreenMode()
 {
 	GameWindow::ToggleFullscreen();

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -49,6 +49,8 @@ public:
 	static double ViewZoom();
 	static bool ZoomViewIn();
 	static bool ZoomViewOut();
+	static double MinViewZoom();
+	static double MaxViewZoom();
 
 	static void ToggleScreenMode();
 	static const std::string &ScreenModeSetting();


### PR DESCRIPTION
**Bugfix:** This PR addresses fixes #7313 

## Fix Details

This PR does two things:

1. Considers the planet's outer ring when checking for overlap with a label.
2. Prefers a direction where under any zoom level the labels stay in the same direction. This is to avoid the labels jumping around when zooming in/out.

## Testing Done

Used the scenario described in the linked issue. Without this PR the label jumps around, with this PR it stays on the left side.

## Performance Impact

It does a couple more overlap checks per frame (8 to be exact). But I don't expect those to impact performance in any meaningful way.