### PR TITLE
Recategorize Hai Centipede to Space Liner

### DIFF
--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -70,7 +70,7 @@ ship "Centipede"
 	sprite "ship/hai centipede"
 	thumbnail "thumbnail/hai centipede"
 	attributes
-		category "Transport"
+		category "Space Liner"
 		"cost" 6300000
 		"shields" 6600
 		"hull" 2400


### PR DESCRIPTION

**Bugfix:** 

## Fix Details
Re-categorize Hai Centipede from Transport to Space Liner as every other high capacity transport (100+ bunks) were all moved to Space Liner recently due to #7059 . It's a little odd the Star Queen with lower bunk is a Space Liner while Hai Centipede isn't. 

This is not considering the oddly very specific specification of Space Liner category in that PR when the very ship it turned into Space Liner itself actually doesn't fit the specification, or to be more specific, this very line `have something like <10% required crew compared to the stock number of passengers` and two of the sampled ship that doesn't fit includes Star Queen (41 req/112 bunks, 38%) and Riptide (47 req/ 223 bunks, 21%). ~~(Or they actually do and I'm just bad at math)~~

## Testing Done
None.

## Save File
Any that have access to Hai Advanced shipyard.
