### PR TITLE
Add scope labels to the contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,5 @@ The labels I assign to issues are:
 * **unconfirmed**: More information is needed to be sure this bug is really a bug.
 * **unlikely**: An enhancement or other change that I consider lowest priority, too large or difficult, or not appropriate.
 * **wontfix**: A change that I definitely do not think should be made.
-
 * **art**: A request for anything related to the addition or modification of images, sprites, and graphics.
 * **sound**: A request for the addition or modification of anything to do with sound effects, music or other audio.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,9 @@ The labels I assign to issues are:
 * **unconfirmed**: More information is needed to be sure this bug is really a bug.
 * **unlikely**: An enhancement or other change that I consider lowest priority, too large or difficult, or not appropriate.
 * **wontfix**: A change that I definitely do not think should be made.
+
+Some additional labels might be used to specify the scope of issues:
+* **art**: Everything related to images, sprites, and graphics
+* **sound**: Everything to do with sound
+* **text - long**: Content that contains long blocks of text such as large missions and campaigns
+* **text - short**: Content that contains short blocks of text such as jobs, small missions, descriptions, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ The labels I assign to issues are:
 * **unlikely**: An enhancement or other change that I consider lowest priority, too large or difficult, or not appropriate.
 * **wontfix**: A change that I definitely do not think should be made.
 
-* **art**: Everything related to images, sprites, and graphics
+* **art**: A request for anything related to the addition or modification of images, sprites, and graphics.
 * **sound**: Everything to do with sound
 * **text - long**: Content that contains long blocks of text such as large missions and campaigns
 * **text - short**: Content that contains short blocks of text such as jobs, small missions, descriptions, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,4 +42,4 @@ The labels I assign to issues are:
 * **wontfix**: A change that I definitely do not think should be made.
 
 * **art**: A request for anything related to the addition or modification of images, sprites, and graphics.
-* **sound**: Everything to do with sound
+* **sound**: A request for the addition or modification of anything to do with sound effects, music or other audio.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,4 +43,3 @@ The labels I assign to issues are:
 
 * **art**: A request for anything related to the addition or modification of images, sprites, and graphics.
 * **sound**: Everything to do with sound
-* **text - short**: Content that contains short blocks of text such as jobs, small missions, descriptions, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,6 @@ The labels I assign to issues are:
 * **unlikely**: An enhancement or other change that I consider lowest priority, too large or difficult, or not appropriate.
 * **wontfix**: A change that I definitely do not think should be made.
 
-Some additional labels might be used to specify the scope of issues:
 * **art**: Everything related to images, sprites, and graphics
 * **sound**: Everything to do with sound
 * **text - long**: Content that contains long blocks of text such as large missions and campaigns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,5 +43,4 @@ The labels I assign to issues are:
 
 * **art**: A request for anything related to the addition or modification of images, sprites, and graphics.
 * **sound**: Everything to do with sound
-* **text - long**: Content that contains long blocks of text such as large missions and campaigns
 * **text - short**: Content that contains short blocks of text such as jobs, small missions, descriptions, etc.


### PR DESCRIPTION
This PR updates the `CONTRIBUTING.md` file to contain the descriptions of the `art`, `sound`, `text - long` and `text - short` labels that can be used to show the scope of issues.