### PR TITLE
Make wanderer engines provide cooling while moving

### DIFF
--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -434,8 +434,8 @@ outfit "Type 1 Radiant Thruster"
 	"engine capacity" -12
 	"thrust" 6.9
 	"thrusting energy" 0.55
-	"thrusting heat" 0.85
-	"cooling" 1.5
+	"thrusting heat" -1.5
+	"cooling" .75
 	"flare sprite" "effect/wanderer flare/tiny"
 		"frame rate" 12
 	"flare sound" "plasma tiny"
@@ -452,8 +452,8 @@ outfit "Type 2 Radiant Thruster"
 	"engine capacity" -27
 	"thrust" 18.5
 	"thrusting energy" 1.3
-	"thrusting heat" 2.4
-	"cooling" 3.6
+	"thrusting heat" -3.6
+	"cooling" 1.8
 	"flare sprite" "effect/wanderer flare/small"
 		"frame rate" 14
 	"flare sound" "plasma small"
@@ -470,8 +470,8 @@ outfit "Type 3 Radiant Thruster"
 	"engine capacity" -42
 	"thrust" 33.1
 	"thrusting energy" 2.2
-	"thrusting heat" 4.3
-	"cooling" 6.5
+	"thrusting heat" -6.5
+	"cooling" 3.25
 	"flare sprite" "effect/wanderer flare/medium"
 		"frame rate" 16
 	"flare sound" "plasma medium"
@@ -488,8 +488,8 @@ outfit "Type 4 Radiant Thruster"
 	"engine capacity" -65
 	"thrust" 58
 	"thrusting energy" 3.7
-	"thrusting heat" 7.6
-	"cooling" 11.7
+	"thrusting heat" -11.7
+	"cooling" 5.85
 	"flare sprite" "effect/wanderer flare/large"
 		"frame rate" 18
 	"flare sound" "plasma large"
@@ -506,8 +506,8 @@ outfit "Type 1 Radiant Steering"
 	"engine capacity" -9
 	"turn" 181
 	"turning energy" .3
-	"turning heat" 0.6
-	"cooling" 1.0
+	"turning heat" -1
+	"cooling" .5
 	"steering flare sprite" "effect/wanderer flare/tiny"
 		"frame rate" 12
 	"steering flare sound" "plasma tiny"
@@ -524,8 +524,8 @@ outfit "Type 2 Radiant Steering"
 	"engine capacity" -20
 	"turn" 476
 	"turning energy" .7
-	"turning heat" 1.5
-	"cooling" 2.1
+	"turning heat" -2.1
+	"cooling" 1.05
 	"steering flare sprite" "effect/wanderer flare/small"
 		"frame rate" 14
 	"steering flare sound" "plasma small"
@@ -542,8 +542,8 @@ outfit "Type 3 Radiant Steering"
 	"engine capacity" -30
 	"turn" 825
 	"turning energy" 1.2
-	"turning heat" 2.6
-	"cooling" 3.9
+	"turning heat" -3.9
+	"cooling" 1.95
 	"steering flare sprite" "effect/wanderer flare/medium"
 		"frame rate" 16
 	"steering flare sound" "plasma medium"
@@ -560,8 +560,8 @@ outfit "Type 4 Radiant Steering"
 	"engine capacity" -47
 	"turn" 1466
 	"turning energy" 2.0
-	"turning heat" 4.5
-	"cooling" 6.7
+	"turning heat" -6.7
+	"cooling" 3.35
 	"steering flare sprite" "effect/wanderer flare/large"
 		"frame rate" 18
 	"steering flare sound" "plasma large"


### PR DESCRIPTION
NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!)

----------------------
**Content (Artwork / Missions / Jobs)**

## Summary
This is a basic, hacky change to wanderer engines to make them run colder. In particular, they now provide only half their passive cooling, but provide their original full cooling as negative engine heat.

-----------------------

**Feature:** This PR tweaks wanderer values by the above values.

## Feature Details
Wanderer engines are described as "working in part by radiation", so I always wondered why they didn't cool the ship while firing.

## Known Issues
Negative engine heat has some... Odd quirks. Namely, the game doesn't display negative thrusting heat at all.

There's also the issue of the fact that negative-heat engines won't fire at full capacity when the ship is too hot, which, while interesting, might cause issues with wanderer civilian ships (since they wouldn't be able to move if running too cold).

The above issues are why this is a draft PR for people to poke around in, rather than a serious content PR.

## Usage Examples
Changed all wanderer engines.

## Testing Done
Testing was done in (an old version of) Omnis. Tested ships with high and low heat amounts.

## Performance Impact
N/A

## Closing Thoughts
Some work code-side needs to be done before consideration for addition into vanilla. "Engine Cooling" should be added to make engines work at full strength regardless of heat (unless we decide the dependence on heat is a desired change?), and the negative thrusting heat not appearing should be fixed as well.