### PR TITLE
fix(content): Wanderer job offering with impossible deadline

### DIFF
--- a/data/wanderer/wanderer jobs.txt
+++ b/data/wanderer/wanderer jobs.txt
@@ -791,9 +791,8 @@ mission "Wanderer Governor Transport"
 	source
 		government "Wanderer"
 		not attributes "evacuation"
-		not planet "Vara K'chrai"
-	destination
-		planet "Vara K'chrai"
+		near "Ka'ch'chrai" 1 10
+	destination "Vara K'chrai"
 	to offer
 		has "language: Wanderer"
 		has "Wanderers Solifuge Recon 2: done"


### PR DESCRIPTION
**Bugfix:** This PR addresses https://steamcommunity.com/app/404410/discussions/1/3388420865125653546/

## Fix Details
Change the source filter to only offer from a system 1 to 10 jumps from Ka'ch'chrai, meaning it can't offer from the other side of the Eye.
