### PR TITLE
Bugfix: retrigger archon missions for compatibility

### DIFF
--- a/data/drak/drak missions.txt
+++ b/data/drak/drak missions.txt
@@ -113,7 +113,7 @@ mission "Drak guarding Void Sprites"
 		system Nenia
 		ship "Archon (Cloaked)" "Sleeping Dragon"
 
-# Mission for those who had a savefile prior to 0.9.1.5 with the old Archon missions
+# Mission for those who had a savefile prior to 0.9.15 with the old Archon missions
 mission "Drak Compatibility Patch"
 	invisible
 	landing

--- a/data/drak/drak missions.txt
+++ b/data/drak/drak missions.txt
@@ -112,3 +112,11 @@ mission "Drak guarding Void Sprites"
 		personality heroic vindictive staying frugal
 		system Nenia
 		ship "Archon (Cloaked)" "Sleeping Dragon"
+
+mission "Drak Post Compatibility Fix"
+	invisible
+	landing
+	on offer
+		fail "Drak guarding Korath space"
+		fail "Drak guarding Sayaiban"
+		fail "Drak guarding Void Sprites"

--- a/data/drak/drak missions.txt
+++ b/data/drak/drak missions.txt
@@ -114,7 +114,7 @@ mission "Drak guarding Void Sprites"
 		ship "Archon (Cloaked)" "Sleeping Dragon"
 
 # Mission for those who had a savefile prior to 0.9.15 with the old Archon missions
-mission "Drak Compatibility Patch"
+mission "Archon Personality Compatibility Patch"
 	invisible
 	landing
 	on offer

--- a/data/drak/drak missions.txt
+++ b/data/drak/drak missions.txt
@@ -113,10 +113,12 @@ mission "Drak guarding Void Sprites"
 		system Nenia
 		ship "Archon (Cloaked)" "Sleeping Dragon"
 
-mission "Drak Post Compatibility Fix"
+# Mission for those who had a savefile prior to 0.9.1.5 with the old Archon missions
+mission "Drak Compatibility Patch"
 	invisible
 	landing
 	on offer
 		fail "Drak guarding Korath space"
 		fail "Drak guarding Sayaiban"
 		fail "Drak guarding Void Sprites"
+		fail


### PR DESCRIPTION
**Bugfix:** This PR fixes the archon missions.

## Fix Details
We recently changed the Archons and their personality, but since these missions are always active in the savefile we need to fail them so they can trigger again, with the new version.

## Testing Done
I am sure I did not miss-spell the mission names and this should work. I cant try it from phone myself though.

## Save File
This can be tested on any savefile with the old missions.
With the new ones it'll just retrigger them.