### PR TITLE
Typo Fix: Remove the extra credits from "Homecoming to skagenda"

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -3935,7 +3935,7 @@ mission "Homecoming to Skadenga"
 		event "hjlod waits" 360
 		conversation
 			`The abandoned village of Udainsakr is cold, dark, and half-buried in unrelenting snow. Everything feels colder than you remember, and you wonder how long before this planet is a perpetual snowball.`
-			`	The five Skadenga you brought are polite and circumspect. Upon landing, they hand you <payment> credits, leave your ship and head for the Goddess-Stone of Skade with its attendant piles of stones. They each navigate their way to a specific cairn, stand there for a moment, speaking or chanting, and then place their stone upon it. Solemnly, they return to you with their task complete. There is nothing else for them to do here, and they request you take them home.`
+			`	The five Skadenga you brought are polite and circumspect. Upon landing, they hand you <payment>, leave your ship and head for the Goddess-Stone of Skade with its attendant piles of stones. They each navigate their way to a specific cairn, stand there for a moment, speaking or chanting, and then place their stone upon it. Solemnly, they return to you with their task complete. There is nothing else for them to do here, and they request you take them home.`
 
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7370

## Fix Details
Removes the extra "credits"