### PR TITLE
fix(content): small changes to Ssil Vida events

### DIFF
--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -761,7 +761,7 @@ event "remnant: ssil vida activation"
 
 
 
-# The default value of a system's "jump range" is 0, in this state, the global default will be used.
+# The default value of a system's "jump range" is 0. In this state, the global default will be used.
 # When the bug preventing ships from jumping when the destination system has too little jump range is fixed,
 # the resetting of jump range on deactivation can be removed. Instead, jump range of other systems nearby
 # may need to be reduced on activation to prevent escorts outside the Postverta cluster jumping into that region.

--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -337,7 +337,7 @@ event "remnant: ssil vida activation"
 		hazard "Ember Waste Base Heat" 100
 		hazard "Ember Waste Base Storm" 9000
 		object
-			sprite star/wr1
+			sprite star/wr
 			period 10
 		object
 			sprite planet/dust6-b
@@ -587,6 +587,7 @@ event "remnant: ssil vida activation"
 			period 654
 		object "Ssil Vida"
 			sprite planet/sheragi_postverta
+				scale 0.5
 			distance 1408
 			period 554
 	system Prosa
@@ -760,6 +761,10 @@ event "remnant: ssil vida activation"
 
 
 
+# The default value of a system's "jump range" is 0, in this state, the global default will be used.
+# When the bug preventing ships from jumping when the destination system has too little jump range is fixed,
+# the resetting of jump range on deactivation can be removed. Instead, jump range of other systems nearby
+# may need to be reduced on activation to prevent escorts outside the Postverta cluster jumping into that region.
 event "remnant: ssil vida deactivation"
 	clear "remnant: ssil vida active"
 	planet Fertriery
@@ -778,6 +783,7 @@ event "remnant: ssil vida deactivation"
 		belt 2000
 		habitable 1505.92
 		haze _menu/haze-red
+		"jump range" 0
 		link Statina
 		link Vaticanus
 		asteroids "small rock" 1 8
@@ -825,6 +831,7 @@ event "remnant: ssil vida deactivation"
 		belt 2000
 		habitable 534.375
 		haze _menu/haze-red
+		"jump range" 0
 		link Statina
 		link Postverta
 		asteroids "small rock" 65 3
@@ -878,6 +885,7 @@ event "remnant: ssil vida deactivation"
 		belt 2000
 		habitable 135
 		haze _menu/haze-red
+		"jump range" 0
 		link Diespiter
 		link Prosa
 		link Statina
@@ -911,6 +919,7 @@ event "remnant: ssil vida deactivation"
 			period 654
 		object "Ssil Vida"
 			sprite planet/sheragi_postverta
+				scale 0.5
 			distance 1408
 			period 554
 	system Prosa
@@ -921,6 +930,7 @@ event "remnant: ssil vida deactivation"
 		habitable 2372.76
 		belt 2000
 		haze _menu/haze-red
+		"jump range" 0
 		link Vaticanus
 		link Postverta
 		asteroids "medium metal" 11 2
@@ -974,6 +984,7 @@ event "remnant: ssil vida deactivation"
 		belt 2000
 		habitable 135
 		haze _menu/haze-red
+		"jump range" 0
 		link Diespiter
 		link Egeria
 		link Postverta
@@ -1024,6 +1035,7 @@ event "remnant: ssil vida deactivation"
 		belt 2000
 		habitable 320
 		haze _menu/haze-red
+		"jump range" 0
 		link Egeria
 		link Prosa
 		asteroids "small rock" 3 6


### PR DESCRIPTION
**Bugfix:**

## Fix Details

- Fix the Caeculus star; the `wr1` sprite no longer exists.
- Fix the scaling of Ssil Vida itself; when all station sprites were doubled in size and scaled to 0.5 in game, these events were not updated.
- Reset `"jump range"` of Postverta and associated systems on deactivation so AI ships can still jump into those systems after deactivation; I'm not sure the refactor that fixes this will be in for 0.9.16.

