### PR TITLE
Refactor: Improve game data printing

### DIFF
--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -617,8 +617,9 @@ void PrintData::PrintPlanetAttributes()
 	{
 		cout << it.first;
 		const Planet &planet = it.second;
+		int index = 0;
 		for(const string &attribute : planet.Attributes())
-			cout << ';' << attribute;
+			cout << (index++ ? ';' : ',') << attribute;
 		cout << '\n';
 	}
 }
@@ -638,11 +639,12 @@ void PrintData::PrintPlanetsByAttribute()
 	for(const string &attribute : attributes)
 	{
 		cout << attribute;
+		int index = 0;
 		for(auto &it : GameData::Planets())
 		{
 			const Planet &planet = it.second;
 			if(planet.Attributes().count(attribute))
-				cout << ';' << it.first;
+				cout << (index++ ? ';' : ',') << it.first;
 		}
 		cout << '\n';
 	}
@@ -689,8 +691,9 @@ void PrintData::PrintSystemAttributes()
 	{
 		cout << it.first;
 		const System &system = it.second;
+		int index = 0;
 		for(const string &attribute : system.Attributes())
-			cout << ';' << attribute;
+			cout << (index++ ? ';' : ',') << attribute;
 		cout << '\n';
 	}
 }
@@ -710,11 +713,12 @@ void PrintData::PrintSystemsByAttribute()
 	for(const string &attribute : attributes)
 	{
 		cout << attribute;
+		int index = 0;
 		for(auto &it : GameData::Systems())
 		{
 			const System &system = it.second;
 			if(system.Attributes().count(attribute))
-				cout << ';' << it.first;
+				cout << (index++ ? ';' : ',') << it.first;
 		}
 		cout << '\n';
 	}

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -29,9 +29,9 @@ using namespace std;
 
 namespace {
 	template <class Type>
-	void PrintObjectList(const Set<Type> &objects, bool withQuotes)
+	void PrintObjectList(const Set<Type> &objects, bool withQuotes = false, const string &name = "name")
 	{
-		cout << "name" << '\n';
+		cout << name << '\n';
 		const string start = withQuotes ? "\"" : "";
 		const string end = withQuotes ? "\"\n" : "\n";
 		for(const auto &it : objects)
@@ -39,9 +39,9 @@ namespace {
 	}
 
 	template <class Type>
-	void PrintObjectAttributes(const Set<Type> &objects)
+	void PrintObjectAttributes(const Set<Type> &objects, const string &name = "name")
 	{
-		cout << "name" << ',' << "attributes" << '\n';
+		cout << name << ',' << "attributes" << '\n';
 		for(auto &it : objects)
 		{
 			cout << it.first;
@@ -54,9 +54,9 @@ namespace {
 	}
 
 	template <class Type>
-	void PrintObjectsByAttribute(const Set<Type> &objects)
+	void PrintObjectsByAttribute(const Set<Type> &objects, const string &name = "names")
 	{
-		cout << "attribute" << ',' << "names" << '\n';
+		cout << "attribute" << ',' << name << '\n';
 		set<string> attributes;
 		for(auto &it : objects)
 		{
@@ -549,7 +549,7 @@ void PrintData::Outfits(const char *const *argv)
 	else if(all)
 		PrintOutfitsAllStats();
 	else
-		PrintObjectList<Outfit>(GameData::Outfits(), true);
+		PrintObjectList<Outfit>(GameData::Outfits(), true, "outfit");
 }
 
 
@@ -623,11 +623,11 @@ void PrintData::Planets(const char *const *argv)
 	if(descriptions)
 		PrintPlanetDescriptions();
 	if(attributes && byAttribute)
-		PrintObjectsByAttribute<Planet>(GameData::Planets());
+		PrintObjectsByAttribute<Planet>(GameData::Planets(), "planets");
 	else if(attributes)
-		PrintObjectAttributes<Planet>(GameData::Planets());
+		PrintObjectAttributes<Planet>(GameData::Planets(), "planet");
 	if(!(descriptions || attributes))
-		PrintObjectList<Planet>(GameData::Planets(), false);
+		PrintObjectList<Planet>(GameData::Planets(), false, "planet");
 }
 
 
@@ -660,9 +660,9 @@ void PrintData::Systems(const char *const *argv)
 			byAttribute = true;
 	}
 	if(attributes && byAttribute)
-		PrintObjectsByAttribute<System>(GameData::Systems());
+		PrintObjectsByAttribute<System>(GameData::Systems(), "systems");
 	else if(attributes)
-		PrintObjectAttributes<System>(GameData::Systems());
+		PrintObjectAttributes<System>(GameData::Systems(), "system");
 	else
-		PrintObjectList<System>(GameData::Systems(), false);
+		PrintObjectList<System>(GameData::Systems(), false, "system");
 }

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -27,6 +27,59 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 using namespace std;
 
+namespace {
+	template <class Type>
+	void PrintObjectList(const Set<Type> &objects, bool withQuotes)
+	{
+		cout << "name" << '\n';
+		const string start = withQuotes ? "\"" : "";
+		const string end = withQuotes ? "\"\n" : "\n";
+		for(const auto &it : objects)
+			cout << start << it.first << end;
+	}
+
+	template <class Type>
+	void PrintObjectAttributes(const Set<Type> &objects)
+	{
+		cout << "name" << ',' << "attributes" << '\n';
+		for(auto &it : objects)
+		{
+			cout << it.first;
+			const Type &object = it.second;
+			int index = 0;
+			for(const string &attribute : object.Attributes())
+				cout << (index++ ? ';' : ',') << attribute;
+			cout << '\n';
+		}
+	}
+
+	template <class Type>
+	void PrintObjectsByAttribute(const Set<Type> &objects)
+	{
+		cout << "attribute" << ',' << "names" << '\n';
+		set<string> attributes;
+		for(auto &it : objects)
+		{
+			const Type &object = it.second;
+			for(const string &attribute : object.Attributes())
+				attributes.insert(attribute);
+		}
+		for(const string &attribute : attributes)
+		{
+			cout << attribute;
+			int index = 0;
+			for(auto &it : objects)
+			{
+				const Type &object = it.second;
+				if(object.Attributes().count(attribute))
+					cout << (index++ ? ';' : ',') << it.first;
+			}
+			cout << '\n';
+		}
+	}
+
+}
+
 
 
 bool PrintData::IsPrintDataArgument(const char *const *argv)
@@ -496,15 +549,7 @@ void PrintData::Outfits(const char *const *argv)
 	else if(all)
 		PrintOutfitsAllStats();
 	else
-		PrintOutfitsList();
-}
-
-
-
-void PrintData::PrintOutfitsList()
-{
-	for(auto &it : GameData::Outfits())
-		cout << "\"" << it.first << "\"\n";
+		PrintObjectList<Outfit>(GameData::Outfits(), true);
 }
 
 
@@ -578,20 +623,11 @@ void PrintData::Planets(const char *const *argv)
 	if(descriptions)
 		PrintPlanetDescriptions();
 	if(attributes && byAttribute)
-		PrintPlanetsByAttribute();
+		PrintObjectsByAttribute<Planet>(GameData::Planets());
 	else if(attributes)
-		PrintPlanetAttributes();
+		PrintObjectAttributes<Planet>(GameData::Planets());
 	if(!(descriptions || attributes))
-		PrintPlanetsList();
-}
-
-
-
-void PrintData::PrintPlanetsList()
-{
-	cout << "planet" << '\n';
-	for(auto &it : GameData::Planets())
-		cout << it.first << '\n';
+		PrintObjectList<Planet>(GameData::Planets(), false);
 }
 
 
@@ -605,48 +641,6 @@ void PrintData::PrintPlanetDescriptions()
 		const Planet &planet = it.second;
 		cout << planet.Description() << "::";
 		cout << planet.SpaceportDescription() << "\n";
-	}
-}
-
-
-
-void PrintData::PrintPlanetAttributes()
-{
-	cout << "planet" << ',' << "attributes" << '\n';
-	for(auto &it : GameData::Planets())
-	{
-		cout << it.first;
-		const Planet &planet = it.second;
-		int index = 0;
-		for(const string &attribute : planet.Attributes())
-			cout << (index++ ? ';' : ',') << attribute;
-		cout << '\n';
-	}
-}
-
-
-
-void PrintData::PrintPlanetsByAttribute()
-{
-	cout << "attribute" << ',' << "planets" << '\n';
-	set<string> attributes;
-	for(auto &it : GameData::Planets())
-	{
-		const Planet &planet = it.second;
-		for(const string &attribute : planet.Attributes())
-			attributes.insert(attribute);
-	}
-	for(const string &attribute : attributes)
-	{
-		cout << attribute;
-		int index = 0;
-		for(auto &it : GameData::Planets())
-		{
-			const Planet &planet = it.second;
-			if(planet.Attributes().count(attribute))
-				cout << (index++ ? ';' : ',') << it.first;
-		}
-		cout << '\n';
 	}
 }
 
@@ -666,60 +660,9 @@ void PrintData::Systems(const char *const *argv)
 			byAttribute = true;
 	}
 	if(attributes && byAttribute)
-		PrintSystemsByAttribute();
+		PrintObjectsByAttribute<System>(GameData::Systems());
 	else if(attributes)
-		PrintSystemAttributes();
+		PrintObjectAttributes<System>(GameData::Systems());
 	else
-		PrintSystemsList();
-}
-
-
-
-void PrintData::PrintSystemsList()
-{
-	cout << "system" << '\n';
-	for(auto &it : GameData::Systems())
-		cout << it.first << '\n';
-}
-
-
-
-void PrintData::PrintSystemAttributes()
-{
-	cout << "system" << ',' << "attributes" << '\n';
-	for(auto &it : GameData::Systems())
-	{
-		cout << it.first;
-		const System &system = it.second;
-		int index = 0;
-		for(const string &attribute : system.Attributes())
-			cout << (index++ ? ';' : ',') << attribute;
-		cout << '\n';
-	}
-}
-
-
-
-void PrintData::PrintSystemsByAttribute()
-{
-	cout << "attribute" << ',' << "systems" << '\n';
-	set<string> attributes;
-	for(auto &it : GameData::Systems())
-	{
-		const System &system = it.second;
-		for(const string &attribute : system.Attributes())
-			attributes.insert(attribute);
-	}
-	for(const string &attribute : attributes)
-	{
-		cout << attribute;
-		int index = 0;
-		for(auto &it : GameData::Systems())
-		{
-			const System &system = it.second;
-			if(system.Attributes().count(attribute))
-				cout << (index++ ? ';' : ',') << it.first;
-		}
-		cout << '\n';
-	}
+		PrintObjectList<System>(GameData::Systems(), false);
 }

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -32,10 +32,10 @@ namespace {
 	string ObjectName(const Type &object);
 
 	template <>
-	string ObjectName<Ship>(const Ship &object) { return object.ModelName(); }
+	string ObjectName(const Ship &object) { return object.ModelName(); }
 
 	template <>
-	string ObjectName<Outfit>(const Outfit &object) { return object.Name(); }
+	string ObjectName(const Outfit &object) { return object.Name(); }
 
 	template <class Type>
 	void PrintObjectSales(const Set<Type> &objects, const Set<Sale<Type>> &sales, const string &name = "name", const string &saleName = "sales")
@@ -199,7 +199,7 @@ void PrintData::Ships(const char *const *argv)
 	}
 
 	if(sales)
-		PrintObjectSales<Ship>(GameData::Ships(), GameData::Shipyards(), "ship", "shipyards");
+		PrintObjectSales(GameData::Ships(), GameData::Shipyards(), "ship", "shipyards");
 	else if(loaded)
 		PrintLoadedShipStats(variants);
 	else if(list)
@@ -547,7 +547,7 @@ void PrintData::Outfits(const char *const *argv)
 	}
 
 	if(sales)
-		PrintObjectSales<Outfit>(GameData::Outfits(), GameData::Outfitters(), "outfit", "outfitters");
+		PrintObjectSales(GameData::Outfits(), GameData::Outfitters(), "outfit", "outfitters");
 	else if(all)
 		PrintOutfitsAllStats();
 	else
@@ -601,11 +601,11 @@ void PrintData::Planets(const char *const *argv)
 	if(descriptions)
 		PrintPlanetDescriptions();
 	if(attributes && byAttribute)
-		PrintObjectsByAttribute<Planet>(GameData::Planets(), "planets");
+		PrintObjectsByAttribute(GameData::Planets(), "planets");
 	else if(attributes)
-		PrintObjectAttributes<Planet>(GameData::Planets(), "planet");
+		PrintObjectAttributes(GameData::Planets(), "planet");
 	if(!(descriptions || attributes))
-		PrintObjectList<Planet>(GameData::Planets(), false, "planet");
+		PrintObjectList(GameData::Planets(), false, "planet");
 }
 
 
@@ -638,9 +638,9 @@ void PrintData::Systems(const char *const *argv)
 			byAttribute = true;
 	}
 	if(attributes && byAttribute)
-		PrintObjectsByAttribute<System>(GameData::Systems(), "systems");
+		PrintObjectsByAttribute(GameData::Systems(), "systems");
 	else if(attributes)
-		PrintObjectAttributes<System>(GameData::Systems(), "system");
+		PrintObjectAttributes(GameData::Systems(), "system");
 	else
-		PrintObjectList<System>(GameData::Systems(), false, "system");
+		PrintObjectList(GameData::Systems(), false, "system");
 }

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -38,7 +38,7 @@ namespace {
 	string ObjectName(const Outfit &object) { return object.Name(); }
 
 	template <class Type>
-	void PrintObjectSales(const Set<Type> &objects, const Set<Sale<Type>> &sales, const string &name = "name", const string &saleName = "sales")
+	void PrintObjectSales(const Set<Type> &objects, const Set<Sale<Type>> &sales, const string &name, const string &saleName)
 	{
 		cout << name << ',' << saleName << '\n';
 		map<string, set<string>> itemSales;
@@ -57,7 +57,7 @@ namespace {
 	}
 
 	template <class Type>
-	void PrintObjectList(const Set<Type> &objects, bool withQuotes = false, const string &name = "name")
+	void PrintObjectList(const Set<Type> &objects, bool withQuotes, const string &name)
 	{
 		cout << name << '\n';
 		const string start = withQuotes ? "\"" : "";
@@ -67,7 +67,7 @@ namespace {
 	}
 
 	template <class Type>
-	void PrintObjectAttributes(const Set<Type> &objects, const string &name = "name")
+	void PrintObjectAttributes(const Set<Type> &objects, const string &name)
 	{
 		cout << name << ',' << "attributes" << '\n';
 		for(auto &it : objects)
@@ -82,7 +82,7 @@ namespace {
 	}
 
 	template <class Type>
-	void PrintObjectsByAttribute(const Set<Type> &objects, const string &name = "names")
+	void PrintObjectsByAttribute(const Set<Type> &objects, const string &name)
 	{
 		cout << "attribute" << ',' << name << '\n';
 		set<string> attributes;

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -29,6 +29,34 @@ using namespace std;
 
 namespace {
 	template <class Type>
+	string ObjectName(const Type &object);
+
+	template <>
+	string ObjectName<Ship>(const Ship &object) {return object.ModelName(); }
+
+	template <>
+	string ObjectName<Outfit>(const Outfit &object) { return object.Name(); }
+
+	template <class Type>
+	void PrintObjectSales(const Set<Type> &objects, const Set<Sale<Type>> &sales, const string &name = "name", const string &saleName = "sales")
+	{
+		cout << name << ',' << saleName << '\n';
+		map<string, set<string>> itemSales;
+		for(auto &it : sales)
+			for(auto &it2 : it.second)
+				itemSales[ObjectName(*it2)].insert(it.first);
+		for(auto &it : objects)
+		{
+			if(it.first != ObjectName(it.second))
+				continue;
+			cout << it.first;
+			for(auto &it2 : itemSales[it.first])
+				cout << ',' << it2;
+			cout << '\n';
+		}
+	}
+
+	template <class Type>
 	void PrintObjectList(const Set<Type> &objects, bool withQuotes = false, const string &name = "name")
 	{
 		cout << name << '\n';
@@ -171,7 +199,7 @@ void PrintData::Ships(const char *const *argv)
 	}
 
 	if(sales)
-		PrintShipShipyards();
+		PrintObjectSales<Ship>(GameData::Ships(), GameData::Shipyards(), "ship", "shipyards");
 	else if(loaded)
 		PrintLoadedShipStats(variants);
 	else if(list)
@@ -232,32 +260,6 @@ void PrintData::PrintBaseShipStats()
 		int numFighters = ship.BaysTotal("Fighter");
 		int numDrones = ship.BaysTotal("Drone");
 		cout << numFighters << ',' << numDrones << '\n';
-	}
-}
-
-
-
-void PrintData::PrintShipShipyards()
-{
-	cout << "ship" << ',' << "shipyards" << '\n';
-	map<string, set<string>> ships;
-	for(auto &it : GameData::Shipyards())
-	{
-		for(auto &it2 : it.second)
-		{
-			ships[it2->ModelName()].insert(it.first);
-		}
-	}
-	for(auto &it : GameData::Ships())
-	{
-		if(it.first != it.second.ModelName())
-			continue;
-		cout << it.first;
-		for(auto &it2 : ships[it.first])
-		{
-			cout << ',' << it2;
-		}
-		cout << '\n';
 	}
 }
 
@@ -545,35 +547,11 @@ void PrintData::Outfits(const char *const *argv)
 	}
 
 	if(sales)
-		PrintOutfitOutfitters();
+		PrintObjectSales<Outfit>(GameData::Outfits(), GameData::Outfitters(), "outfit", "outfitters");
 	else if(all)
 		PrintOutfitsAllStats();
 	else
 		PrintObjectList<Outfit>(GameData::Outfits(), true, "outfit");
-}
-
-
-
-void PrintData::PrintOutfitOutfitters()
-{
-	cout << "outfits" << ',' << "outfitters" << '\n';
-	map<string, set<string>> outfits;
-	for(auto &it : GameData::Outfitters())
-	{
-		for(auto &it2 : it.second)
-		{
-			outfits[it2->Name()].insert(it.first);
-		}
-	}
-	for(auto &it : GameData::Outfits())
-	{
-		cout << it.first;
-		for(auto &it2 : outfits[it.first])
-		{
-			cout << ',' << it2;
-		}
-		cout << '\n';
-	}
 }
 
 

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -32,7 +32,7 @@ namespace {
 	string ObjectName(const Type &object);
 
 	template <>
-	string ObjectName<Ship>(const Ship &object) {return object.ModelName(); }
+	string ObjectName<Ship>(const Ship &object) { return object.ModelName(); }
 
 	template <>
 	string ObjectName<Outfit>(const Outfit &object) { return object.Name(); }

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 namespace {
 	template <class Type>
-	string ObjectName(const Type &object);
+	string ObjectName(const Type &object) = delete;
 
 	template <>
 	string ObjectName(const Ship &object) { return object.ModelName(); }

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -551,7 +551,7 @@ void PrintData::Outfits(const char *const *argv)
 	else if(all)
 		PrintOutfitsAllStats();
 	else
-		PrintObjectList<Outfit>(GameData::Outfits(), true, "outfit");
+		PrintObjectList(GameData::Outfits(), true, "outfit");
 }
 
 

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -618,7 +618,7 @@ void PrintData::PrintPlanetAttributes()
 		cout << it.first;
 		const Planet &planet = it.second;
 		for(const string &attribute : planet.Attributes())
-			cout << ',' << attribute;
+			cout << ';' << attribute;
 		cout << '\n';
 	}
 }
@@ -642,7 +642,7 @@ void PrintData::PrintPlanetsByAttribute()
 		{
 			const Planet &planet = it.second;
 			if(planet.Attributes().count(attribute))
-				cout << ',' << it.first;
+				cout << ';' << it.first;
 		}
 		cout << '\n';
 	}
@@ -690,7 +690,7 @@ void PrintData::PrintSystemAttributes()
 		cout << it.first;
 		const System &system = it.second;
 		for(const string &attribute : system.Attributes())
-			cout << ',' << attribute;
+			cout << ';' << attribute;
 		cout << '\n';
 	}
 }
@@ -714,11 +714,8 @@ void PrintData::PrintSystemsByAttribute()
 		{
 			const System &system = it.second;
 			if(system.Attributes().count(attribute))
-				cout << ',' << it.first;
+				cout << ';' << it.first;
 		}
 		cout << '\n';
 	}
 }
-
-
-

--- a/source/PrintData.h
+++ b/source/PrintData.h
@@ -27,7 +27,6 @@ public:
 private:
 	static void Ships(const char *const *argv);
 	static void PrintBaseShipStats();
-	static void PrintShipShipyards();
 	static void PrintLoadedShipStats(bool variants = false);
 	static void PrintShipList(bool variants = false);
 
@@ -38,7 +37,6 @@ private:
 	static void PrintPowerStats();
 
 	static void Outfits(const char *const *argv);
-	static void PrintOutfitOutfitters();
 	static void PrintOutfitsAllStats();
 
 	static void Planets(const char *const *argv);

--- a/source/PrintData.h
+++ b/source/PrintData.h
@@ -38,20 +38,13 @@ private:
 	static void PrintPowerStats();
 
 	static void Outfits(const char *const *argv);
-	static void PrintOutfitsList();
 	static void PrintOutfitOutfitters();
 	static void PrintOutfitsAllStats();
 
 	static void Planets(const char *const *argv);
-	static void PrintPlanetsList();
 	static void PrintPlanetDescriptions();
-	static void PrintPlanetAttributes();
-	static void PrintPlanetsByAttribute();
 
 	static void Systems(const char *const *argv);
-	static void PrintSystemsList();
-	static void PrintSystemAttributes();
-	static void PrintSystemsByAttribute();
 };
 
 #endif


### PR DESCRIPTION
**Bugfix:**

Thanks to @Hecter94 for the feedback leading to the delimiter improvement.

## Fix Details

- Separate the attributes, when listing by planet or system, or the planets or systems when listing by attribute, by semi-colons instead of the comma used to separate the item from its children to improve parsability.
- Refactor attribute, list, and ship/outfit sale printing to use generic namespace methods instead of repeating almost identical code two or three times.
