### PR TITLE
Fix display for some compressed PNGs

### DIFF
--- a/source/ImageBuffer.cpp
+++ b/source/ImageBuffer.cpp
@@ -247,13 +247,24 @@ namespace {
 		}
 
 		// Adjust settings to make sure the result will be a RGBA file.
+		int colorType = png_get_color_type(png, info);
 		int bitDepth = png_get_bit_depth(png, info);
 
-		png_set_packing(png);
+		if(colorType == PNG_COLOR_TYPE_PALETTE)
+			png_set_palette_to_rgb(png);
+		if(png_get_valid(png, info, PNG_INFO_tRNS))
+			png_set_tRNS_to_alpha(png);
+		if(colorType == PNG_COLOR_TYPE_GRAY && bitDepth < 8)
+			png_set_expand_gray_1_2_4_to_8(png);
 		if(bitDepth == 16)
 			png_set_scale_16(png);
-		png_set_expand(png);
-		png_set_filler(png, 0xFFFF, PNG_FILLER_AFTER);
+		if(bitDepth < 8)
+			png_set_packing(png);
+		if(colorType == PNG_COLOR_TYPE_PALETTE || colorType == PNG_COLOR_TYPE_RGB
+				|| colorType == PNG_COLOR_TYPE_GRAY)
+			png_set_add_alpha(png, 0xFFFF, PNG_FILLER_AFTER);
+		if(colorType == PNG_COLOR_TYPE_GRAY || colorType == PNG_COLOR_TYPE_GRAY_ALPHA)
+			png_set_gray_to_rgb(png);
 		// Let libpng handle any interlaced image decoding.
 		png_set_interlace_handling(png);
 		png_read_update_info(png, info);

--- a/source/ImageBuffer.cpp
+++ b/source/ImageBuffer.cpp
@@ -247,19 +247,13 @@ namespace {
 		}
 
 		// Adjust settings to make sure the result will be a RGBA file.
-		int colorType = png_get_color_type(png, info);
 		int bitDepth = png_get_bit_depth(png, info);
 
-		png_set_strip_16(png);
 		png_set_packing(png);
-		if(colorType == PNG_COLOR_TYPE_PALETTE)
-			png_set_palette_to_rgb(png);
-		if(colorType == PNG_COLOR_TYPE_GRAY && bitDepth < 8)
-			png_set_expand_gray_1_2_4_to_8(png);
-		if(colorType == PNG_COLOR_TYPE_GRAY || colorType == PNG_COLOR_TYPE_GRAY_ALPHA)
-			png_set_gray_to_rgb(png);
-		if(colorType == PNG_COLOR_TYPE_RGB)
-			png_set_filler(png, 0xFFFF, PNG_FILLER_AFTER);
+		if(bitDepth == 16)
+			png_set_scale_16(png);
+		png_set_expand(png);
+		png_set_filler(png, 0xFFFF, PNG_FILLER_AFTER);
 		// Let libpng handle any interlaced image decoding.
 		png_set_interlace_handling(png);
 		png_read_update_info(png, info);


### PR DESCRIPTION
## Fix Details

This fixes the usage of some compressed PNGs that were displayed incorrectly. 

## Testing Done

I verified that every other image still gets displayed correctly, and without this PR using a compressed version of the shipyard background it looks like this:

![image](https://user-images.githubusercontent.com/85879619/195939754-dcc08be6-91f6-4926-a75d-58f58206324d.png)

The modified shipyard background:

![shipyard_unselected](https://user-images.githubusercontent.com/85879619/195939984-819de0a7-2c57-4e54-946d-13587ae615a6.png)

