### PR TITLE
BugFix: Switch Remnant: Bounty 4 to spawn a crippled ship

### DIFF
--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -186,7 +186,7 @@ mission "Remnant: Bounty 4"
 			cargo 3
 			commodities "Food" "Clothing" "Metal" "Plastic" "Medical" "Heavy Metals"
 			variant
-				"Rano'erek"
+				"Rano'erek (Crippled)"
 		dialog "You have destroyed the Korath ship. You can now return to <planet> to collect your payment."
 	on visit
 		dialog phrase "generic bounty hunting on visit"


### PR DESCRIPTION
**bugfix:**

## Fix Details
Remnant: Bounty 4 spawns a fully intact Rano'erek with a fully functional Jump Drive, which is not set to be staying, allowing it to jump freely around the Galaxy, even to places the player can't access, or into the middle of human space.

This PR changes the Rano'erek to a crippled version instead without a Jump Drive, so it will stay within Remnant space. 
Alternatively, the fleet could be given "Staying" and maintain its Jump Drive, however as the mission description states:
> A Korath ship is marauding through Remnant territory.

I feel it's best to use the crippled variant so it's still able to move around via hyperdrive.

In the future, we may want to make a new variant used specifically for this mission that's fully intact, simply missing a Jump Drive, but for now, this will fix the issue.

## Testing Done
Accepted the mission "Remnant: Bounty 4", scanned the spawned ship, and verified it did not have a Jump Drive.

## Save File
This save file will place you on Vimnial with "Remnant: Bounty 4" active, and an outfit scanner.
[Bounty Fix.txt](https://github.com/endless-sky/endless-sky/files/9795288/Bounty.Fix.txt)
