### PR TITLE
Correctly draw travel plans

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -955,7 +955,6 @@ void MapPanel::DrawTravelPlan()
 		const System *next = player.TravelPlan()[i];
 		bool isHyper = previous->Links().count(next);
 		bool isJump = !isHyper && previous->JumpNeighbors(jumpRange).count(next);
-		bool systemJumpRange = previous->JumpRange() > 0.;
 		bool isWormhole = false;
 		for(const StellarObject &object : previous->Objects())
 			isWormhole |= (object.HasSprite() && object.HasValidPlanet()
@@ -967,14 +966,13 @@ void MapPanel::DrawTravelPlan()
 		if(!isHyper && !isJump && !isWormhole)
 			break;
 
-		double jumpDistance = previous->Position().Distance(next->Position());
 		// Wormholes cost nothing to go through. If this is not a wormhole,
 		// check how much fuel every ship will expend to go through it.
 		if(!isWormhole)
 			for(auto &it : fuel)
 				if(it.second >= 0.)
 				{
-					double cost = isJump ? it.first->JumpDriveFuel(systemJumpRange ? 0. : jumpDistance) : it.first->HyperdriveFuel();
+					double cost = it.first->GetCheapestJumpType(previous, next).second;
 					if(!cost || cost > it.second)
 					{
 						it.second = -1.;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3261,10 +3261,17 @@ double Ship::JumpDriveFuel(double jumpDistance) const
 
 pair<Ship::JumpType, double> Ship::GetCheapestJumpType(const System *destination) const
 {
-	bool linked = currentSystem->Links().count(destination);
+	return GetCheapestJumpType(currentSystem, destination);
+}
+
+
+
+pair<Ship::JumpType, double> Ship::GetCheapestJumpType(const System *from, const System *to) const
+{
+	bool linked = from->Links().count(to);
 	double hyperFuelNeeded = HyperdriveFuel();
-	double jumpFuelNeeded = JumpDriveFuel((linked || currentSystem->JumpRange())
-			? 0. : currentSystem->Position().Distance(destination->Position()));
+	double jumpFuelNeeded = JumpDriveFuel((linked || from->JumpRange())
+			? 0. : from->Position().Distance(to->Position()));
 	if(linked && attributes.Get("hyperdrive") && (!jumpFuelNeeded || hyperFuelNeeded <= jumpFuelNeeded))
 		return make_pair(JumpType::Hyperdrive, hyperFuelNeeded);
 	else if(attributes.Get("jump drive"))

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -320,6 +320,7 @@ public:
 	double HyperdriveFuel() const;
 	double JumpDriveFuel(double jumpDistance = 0.) const;
 	std::pair<JumpType, double> GetCheapestJumpType(const System *destination) const;
+	std::pair<JumpType, double> GetCheapestJumpType(const System *from, const System *to) const;
 	// Get the amount of fuel missing for the next jump (smart refuelling)
 	double JumpFuelMissing() const;
 	// Get the heat level at idle.


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue introduced by #7213.

## Fix Details
Due to a change in #7213 to have Ship::HyperdriveFuel return 0 instead of Ship::JumpDriveFuel if you have no hyperdrive, the travel plan gets drawn incorrectly if you have only a jump drive and are jumping across linked systems. The game incorrectly assumed that if you were jumping between linked systems that HyperdriveFuel would give you the amount of fuel needed to make that jump.

The fix involves creating a new variant of the GetCheapestJumpType method to give the cheapest jump between two given systems instead of only between the ship's current system and destination. The result of this call is then used to determine the cost of a jump between two systems in your travel path.

## Testing Done
Without the change when using a ship equipped with only a jump drive. Despite the travel plan saying otherwise, the flagship is capable of making these jumps:
![image](https://user-images.githubusercontent.com/17688683/196050554-b0857178-6b78-4b2c-83b9-ccb861cccd4c.png)
With the change:
![image](https://user-images.githubusercontent.com/17688683/196050964-229e5f16-ebd5-489c-a9a3-9db41d6e6ac2.png)


