### PR TITLE
Qualify std::move

### DIFF
--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -297,7 +297,7 @@ void Mask::Create(const ImageBuffer &image, int frame)
 			continue;
 		
 		radius = max(radius, ComputeRadius(outline));
-		outlines.push_back(move(outline));
+		outlines.push_back(std::move(outline));
 		outlines.back().shrink_to_fit();
 	}
 	outlines.shrink_to_fit();

--- a/source/MaskManager.cpp
+++ b/source/MaskManager.cpp
@@ -36,7 +36,7 @@ void MaskManager::SetMasks(const Sprite *sprite, std::vector<Mask> &&masks)
 	if(it != scales.end())
 		it->second.swap(masks);
 	else
-		scales.emplace(DEFAULT, move(masks));
+		scales.emplace(DEFAULT, std::move(masks));
 }
 
 


### PR DESCRIPTION
My motivation for this is compiling with Emscripten 3.1.24 but it seems like a good thing to do anyway.