### PR TITLE
fix(content): Re-add events and missions to avoid breaking saves

### DIFF
--- a/data/human/events.txt
+++ b/data/human/events.txt
@@ -1043,6 +1043,26 @@ event "Thule becomes independent"
 
 
 
+# These two events are no longer used but preserved in case a now deleted mission calling these events is already active.
+event "fw suppressed Bloodsea"
+	system Antares
+		government "Free Worlds"
+		fleet "Small Free Worlds" 800
+		fleet "Large Free Worlds" 1600
+		fleet "Small Southern Pirates" 4000
+		fleet "Large Southern Pirates" 8000
+
+
+
+event "fw abandoned Bloodsea"
+	system Antares
+		government "Pirate"
+		fleet "Small Southern Pirates" 1000
+		fleet "Large Southern Pirates" 2000
+		fleet "Large Militia" 5000
+
+
+
 # TODO: Update event to reduce piracy in various systems.
 event "fw suppressed Greenrock"
 	system "Shaula"

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -1148,9 +1148,7 @@ mission "FW Pirates: Attack 1"
 	to offer
 		has "FW Pirates 2: done"
 		# Backwards compatibility conditions. This mission was renamed, and these conditions avoid it from offering again on older saves.
-		not "FW Pirates 3: offered"
-		not "FW Pirates 3.1: offered"
-		not "FW Pirates 3.2: offered"
+		not "fw first chapter done"
 	to fail
 		has "FW Pirates: Diplomacy 1: done"
 	
@@ -1478,9 +1476,7 @@ mission "FW Pirates: Diplomacy 1"
 	to offer
 		has "FW Pirates 2: done"
 		# Backwards compatibility conditions. This mission was renamed, and these conditions avoid it from offering again on older saves.
-		not "FW Pirates 3: offered"
-		not "FW Pirates 3.1: offered"
-		not "FW Pirates 3.2: offered"
+		not "fw first chapter done"
 	to fail
 		has "FW Pirates: Attack 1: done"
 	

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -1145,6 +1145,8 @@ mission "FW Pirates Patch"
 	landing
 	name "Return to <planet>"
 	description "Return to <destination> to continue your work with the Free Worlds."
+	source
+		not planet "Longjump"
 	destination Longjump
 	to offer
 		or

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -1164,7 +1164,7 @@ mission "FW Pirates Patch"
 		not "FW Refinery 1: offered"
 	on offer
 		conversation
-			`We've made some changes to the Free Worlds story. In order to continue, you should go to <destination>.`
+			`When you updated your game, you were in the middle of a story arc in the Free Worlds campaign that has since been changed. In order to continue, you should go to <destination>.`
 				accept
 
 

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -2032,6 +2032,49 @@ mission "FW Early Warning 5"
 
 
 
+# The following two missions are preserved for backwards compatibility.
+mission "FW Pirates 3.1B"
+	landing
+	name "Report to Tomek"
+	description "Return to Longjump to report to Tomek that <origin> has been pacified."
+	source Bloodsea
+	destination Longjump
+	to offer
+		has "FW Pirates 3.1: done"
+	on fail
+		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
+	
+	on offer
+		log "Disobeyed the Free Worlds Senate by helping to launch an attack on the pirates in the Antares system, rather than pursuing diplomatic relations with the anarchist worlds. It is unclear how long the Free Worlds can afford to maintain control of the system, however."
+		set "fw pirates: victory"
+		conversation
+			`As you bring your ship in for a landing on <origin>, you are struck by the utter futility of the victory you have just won. The locals stand around your ship, sullen and defiant, as you announce that this world is now property of the Free Worlds. True, you have destroyed much of their military strength, but you have no idea what to do to win the hearts of these people.`
+			`	But if nothing else, the battle you have fought here will give merchants in the surrounding systems a respite from piracy for many months to come, while the pirates are busy finding new ships and recruiting new crews. Time to report back to Tomek and see what your next steps will be.`
+				accept
+
+
+
+mission "FW Pirates 3.2B"
+	landing
+	name "Report to Tomek"
+	description "Return to Longjump to report to Tomek that <origin> has been pacified."
+	source Greenrock
+	destination Longjump
+	to offer
+		has "FW Pirates 3.2A: done"
+	on fail
+		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
+	
+	on offer
+		log "Disobeyed the Free Worlds Senate by helping to launch an attack on the pirate home world of Greenrock. Captured the planet after a massive battle, but it is unclear how long the Free Worlds can afford to keep them subdued by force."
+		set "fw pirates: victory"
+		conversation
+			`As you bring your ship in for a landing on <planet>, you are struck by the utter futility of the victory you have just won. The locals stand around your ship, sullen and defiant, as you announce that this world is now property of the Free Worlds. True, you have destroyed much of their military strength, but you have no idea what to do to win the hearts of these people.`
+			`	But if nothing else, the battle you have fought here will give merchants in the surrounding systems a respite from piracy for many months to come, while the pirates are busy finding new ships and recruiting new crews. Time to report back to Tomek and see what your next steps will be.`
+				accept
+
+
+
 mission "FW Senate Hearing"
 	autosave
 	landing
@@ -2041,8 +2084,11 @@ mission "FW Senate Hearing"
 	destination "Bourne"
 	deadline 14
 	to offer
-		has "FW Early Warning 5: done"
-		has "FW Pirates: Attack 3: done"
+		or
+			and
+				has "FW Early Warning 5: done"
+				has "FW Pirates: Attack 3: done"
+			has "fw pirates: victory"
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -1147,7 +1147,7 @@ mission "FW Pirates Patch"
 	description "Return to <destination> to continue your work with the Free Worlds."
 	source
 		not planet "Longjump"
-	destination Longjump
+	destination "Longjump"
 	to offer
 		or
 			has "FW Pirates 3: offered"
@@ -1159,12 +1159,16 @@ mission "FW Pirates Patch"
 			has "FW Pirates 4: offered"
 			has "FW Pirates 4B: offered"
 			has "FW Pirates 4.1: offered"
-		not "FW Pirates: Attack !: offered"
+		not "FW Pirates: Attack 1: offered"
+		not "FW Senate Hearing: offered"
 		not "FW Refinery 1: offered"
 	on offer
 		conversation
 			`We've made some changes to the Free Worlds story. In order to continue, you should go to <destination>.`
 				accept
+
+
+
 mission "FW Pirates: Attack 1"
 	name "Attack Greenrock"
 	description "Disobeying the Senate's orders, head to <destination> and gather a Free Worlds fleet for an all-out attack on the pirate world of Greenrock."

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -2041,11 +2041,8 @@ mission "FW Senate Hearing"
 	destination "Bourne"
 	deadline 14
 	to offer
-		or
-			and
-				has "FW Early Warning 5: done"
-				has "FW Pirates: Attack 3: done"
-			has "fw pirates: victory"
+		has "FW Early Warning 5: done"
+		has "FW Pirates: Attack 3: done"
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -2032,42 +2032,6 @@ mission "FW Early Warning 5"
 
 
 
-# The following two missions are preserved for backwards compatibility.
-mission "FW Pirates 3.1B"
-	landing
-	name "Report to Tomek"
-	description "Return to Longjump to report to Tomek that <origin> has been pacified."
-	source Bloodsea
-	destination Longjump
-	to offer
-		has "FW Pirates 3.1: done"
-	on fail
-		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
-	
-	on offer
-		log "Disobeyed the Free Worlds Senate by helping to launch an attack on the pirates in the Antares system, rather than pursuing diplomatic relations with the anarchist worlds. It is unclear how long the Free Worlds can afford to maintain control of the system, however."
-		set "fw pirates: victory"
-		conversation
-			`As you bring your ship in for a landing on <origin>, you are struck by the utter futility of the victory you have just won. The locals stand around your ship, sullen and defiant, as you announce that this world is now property of the Free Worlds. True, you have destroyed much of their military strength, but you have no idea what to do to win the hearts of these people.`
-			`	But if nothing else, the battle you have fought here will give merchants in the surrounding systems a respite from piracy for many months to come, while the pirates are busy finding new ships and recruiting new crews. Time to report back to Tomek and see what your next steps will be.`
-				accept
-
-
-
-mission "FW Pirates 3.2B"
-	landing
-	name "Report to Tomek"
-	description "Return to Longjump to report to Tomek that <origin> has been pacified."
-	source Greenrock
-	destination Longjump
-		set "fw pirates: victory"
-		conversation
-			`As you bring your ship in for a landing on <planet>, you are struck by the utter futility of the victory you have just won. The locals stand around your ship, sullen and defiant, as you announce that this world is now property of the Free Worlds. True, you have destroyed much of their military strength, but you have no idea what to do to win the hearts of these people.`
-			`	But if nothing else, the battle you have fought here will give merchants in the surrounding systems a respite from piracy for many months to come, while the pirates are busy finding new ships and recruiting new crews. Time to report back to Tomek and see what your next steps will be.`
-				accept
-
-
-
 mission "FW Senate Hearing"
 	autosave
 	landing

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -2060,13 +2060,6 @@ mission "FW Pirates 3.2B"
 	description "Return to Longjump to report to Tomek that <origin> has been pacified."
 	source Greenrock
 	destination Longjump
-	to offer
-		has "FW Pirates 3.2A: done"
-	on fail
-		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
-	
-	on offer
-		log "Disobeyed the Free Worlds Senate by helping to launch an attack on the pirate home world of Greenrock. Captured the planet after a massive battle, but it is unclear how long the Free Worlds can afford to keep them subdued by force."
 		set "fw pirates: victory"
 		conversation
 			`As you bring your ship in for a landing on <planet>, you are struck by the utter futility of the victory you have just won. The locals stand around your ship, sullen and defiant, as you announce that this world is now property of the Free Worlds. True, you have destroyed much of their military strength, but you have no idea what to do to win the hearts of these people.`

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -1140,6 +1140,29 @@ mission "FW Pirates 2"
 
 
 
+# To tell players to go to Longjump to resume the story if they were in the middle of one of the deleted missions.
+mission "FW Pirates Patch"
+	landing
+	name "Return to <planet>"
+	description "Return to <destination> to continue your work with the Free Worlds."
+	destination Longjump
+	to offer
+		or
+			has "FW Pirates 3: offered"
+			has "FW Pirates 3.1: offered"
+			has "FW Pirates 3.2: offered"
+			has "FW Pirates 3.2A: offered"
+			has "FW Pirates 3.1B: offered"
+			has "FW Pirates 3.2B: offered"
+			has "FW Pirates 4: offered"
+			has "FW Pirates 4B: offered"
+			has "FW Pirates 4.1: offered"
+		not "FW Pirates: Attack !: offered"
+		not "FW Refinery 1: offered"
+	on offer
+		conversation
+			`We've made some changes to the Free Worlds story. In order to continue, you should go to <destination>.`
+				accept
 mission "FW Pirates: Attack 1"
 	name "Attack Greenrock"
 	description "Disobeying the Senate's orders, head to <destination> and gather a Free Worlds fleet for an all-out attack on the pirate world of Greenrock."
@@ -1149,6 +1172,7 @@ mission "FW Pirates: Attack 1"
 		has "FW Pirates 2: done"
 		# Backwards compatibility conditions. This mission was renamed, and these conditions avoid it from offering again on older saves.
 		not "fw first chapter done"
+		not "FW Refinery 1: offered"
 	to fail
 		has "FW Pirates: Diplomacy 1: done"
 	
@@ -1477,6 +1501,7 @@ mission "FW Pirates: Diplomacy 1"
 		has "FW Pirates 2: done"
 		# Backwards compatibility conditions. This mission was renamed, and these conditions avoid it from offering again on older saves.
 		not "fw first chapter done"
+		not "FW Refinery 1: offered"
 	to fail
 		has "FW Pirates: Attack 1: done"
 	


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Re-adding the events to avoid an old mission appearing invalid if it was already in progress.
Changed offer conditions so the FW Pirates Attack and Diplomacy arcs can be restarted with the new versions of the missions if a person was previously in the middle of hte chain, but not if they had already completed it sufficiently to move on to FW middle.