### PR TITLE
Split the implicit npc save objective from the accompany objective

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -81,7 +81,7 @@ void NPC::Load(const DataNode &node)
 	if(failIf & ShipEvent::DESTROY && (succeedIf & ShipEvent::DESTROY || succeedIf & ShipEvent::CAPTURE))
 		node.PrintTrace("Error: conflicting NPC mission objective to save and destroy or capture.");
 	if(mustEvade && mustAccompany)
-		node.PrintTrace("Error: conflicting NPC mission objective to accompany and evade.");
+		node.PrintTrace("Warning: NPC mission objective to accompany and evade is synonymous with kill.");
 	if(mustEvade && (succeedIf & ShipEvent::DESTROY || succeedIf & ShipEvent::CAPTURE))
 		node.PrintTrace("Warning: redundant NPC mission objective to evade and destroy or capture.");
 

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -80,6 +80,8 @@ void NPC::Load(const DataNode &node)
 	// Check for incorrect objective combinations.
 	if(failIf & ShipEvent::DESTROY && (succeedIf & ShipEvent::DESTROY || succeedIf & ShipEvent::CAPTURE))
 		node.PrintTrace("Error: conflicting NPC mission objective to save and destroy or capture.");
+	if(mustEvade && mustAccompany)
+		node.PrintTrace("Error: conflicting NPC mission objective to accompany and evade.");
 	if(mustEvade && (succeedIf & ShipEvent::DESTROY || succeedIf & ShipEvent::CAPTURE))
 		node.PrintTrace("Warning: redundant NPC mission objective to evade and destroy or capture.");
 

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -482,15 +482,15 @@ bool NPC::HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable) con
 		for(const shared_ptr<Ship> &ship : ships)
 		{
 			auto it = actions.find(ship.get());
-			// Captured or destroyed ships have either succeeded or no longer count.
-			if(it->second & (ShipEvent::DESTROY | ShipEvent::CAPTURE))
-				continue;
 			// If a derelict ship has not received any ShipEvents, it is immobile.
 			bool isImmobile = ship->GetPersonality().IsDerelict();
 			// The success status calculation can only be based on recorded
 			// events (and the current system).
 			if(it != actions.end())
 			{
+				// Captured or destroyed ships have either succeeded or no longer count.
+				if(it->second & (ShipEvent::DESTROY | ShipEvent::CAPTURE))
+					continue;
 				// A ship that was disabled is considered 'immobile'.
 				isImmobile = (it->second & ShipEvent::DISABLE);
 				// If this NPC is 'derelict' and has no ASSIST on record, it is immobile.


### PR DESCRIPTION
**Feature:** This PR reimplements #7335, but not broken this time.

## Feature Details
Despite the `accompany` npc objective being implicitly save, most instances of the `accompany` objective are paired with the `save` objective, making it seem as though the two don't already overlap. This PR removes the implicit `save` objective from the `accompany` tag. The only `accompany` behavior is now achieved by using `accompany` and `save`.

## Testing Done
Tested #7335 plus the fix from an earlier version of this PR. Accompany now no longer requires an npc to be saved, and evade doesn't break.
