### PR TITLE
Update ubuntu runtime in CI

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -39,7 +39,7 @@ jobs:
           path: ${{ env.OUTPUT }}
 
   cd_appimage_x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARCH: x86_64
       OUTPUT: endless-sky-x86_64-continuous.AppImage

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   appimage_amd64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARCH: x86_64
       OUTPUT: endless-sky-amd64-${{ github.event.release.tag_name }}.AppImage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         opengl: [desktop, gles]
     env:
         CCACHE_DIR: ./ccache/
@@ -114,7 +114,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
     env:
         CCACHE_DIR: ./ccache/
         CXX: ccache g++
@@ -316,9 +316,7 @@ jobs:
         path: ${{ env.ARTIFACT }}
 
 
-  # This section is for tests on ubuntu 16 (and on ubuntu 20).
-  # The tests with Xvfb in this section work fine on ubuntu 16 and on Ubuntu 20, but they don't work on Ubuntu 18.
-  # (Both 18.04 & 20.04 have the same Open GL extension support, but the SDL library fails to initialize for 18.04)
+  # This section is for tests on ubuntu 20 (and on ubuntu 22).
   test_ubuntu-integration:
     needs: [build_ubuntu, changed]
     if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.integration_tests == 'true' }}
@@ -330,15 +328,15 @@ jobs:
           - os: ubuntu-20.04
             opengl: desktop
             glew: libglew2.1
-          # - os: ubuntu-18.04
-          #   opengl: desktop
-          #   glew: libglew2.0
+           - os: ubuntu-22.04
+            opengl: desktop
+            glew: libglew2.0
           - os: ubuntu-20.04
             opengl: gles
             glew: libgles2-mesa
-          # - os: ubuntu-18.04
-          #   opengl: gles
-          #   glew: libgles2-mesa
+          - os: ubuntu-22.04
+            opengl: gles
+            glew: libgles2-mesa
     steps:
     - uses: actions/checkout@v2
     - name: Install runtime dependencies
@@ -371,7 +369,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             glew: libglew2.1
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             glew: libglew2.0
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,6 @@ jobs:
         path: ${{ env.ARTIFACT }}
 
 
-  # This section is for tests on ubuntu 20 (and on ubuntu 22).
   test_ubuntu-integration:
     needs: [build_ubuntu, changed]
     if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.integration_tests == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
           - os: ubuntu-20.04
             opengl: desktop
             glew: libglew2.1
-           - os: ubuntu-22.04
+          - os: ubuntu-22.04
             opengl: desktop
             glew: libglew2.0
           - os: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,7 @@ jobs:
             glew: libglew2.1
           - os: ubuntu-22.04
             opengl: desktop
-            glew: libglew2.0
+            glew: libglew2.2
           - os: ubuntu-20.04
             opengl: gles
             glew: libgles2-mesa
@@ -369,8 +369,8 @@ jobs:
         include:
           - os: ubuntu-20.04
             glew: libglew2.1
-          - os: ubuntu-20.04
-            glew: libglew2.0
+          - os: ubuntu-22.04
+            glew: libglew2.2
     steps:
     - uses: actions/checkout@v2
     - name: Install runtime dependencies

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest]
+        os: [ubuntu-20.04, ubuntu-latest]
     env:
       snapshot: latest-steam-client-general-availability
       tarball: steam-runtime.tar.xz
@@ -134,10 +134,7 @@ jobs:
     - run: steam-runtime/run.sh ./endless-sky -v
     - name: Execute data parsing test
       run: steam-runtime/run.sh ./utils/test_parse.sh ./endless-sky
-    # NOTE: As with the non-Steam integration tests, on Ubuntu 18.04 the call to SDL_GL_CreateContext fails
-    # with SDL error "Could not create GL Context: BadValue (integer parameter out of range for operation)"
     - name: Execute integration tests
-      if: matrix.os != 'ubuntu-18.04'
       env:
           PRINT_GLXINFO: true
       run: steam-runtime/run.sh tests/integration/run_tests_headless.sh

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -33,6 +33,7 @@ namespace {
 
 
 // Load account information from a data file (saved game or starting conditions).
+// I added this comment to trigger the CI
 void Account::Load(const DataNode &node, bool clearFirst)
 {
 	if(clearFirst)

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -33,7 +33,6 @@ namespace {
 
 
 // Load account information from a data file (saved game or starting conditions).
-// I added this comment to trigger the CI
 void Account::Load(const DataNode &node, bool clearFirst)
 {
 	if(clearFirst)


### PR DESCRIPTION
This PR bumps the version of Ubuntu runtimes used in GitHub Workflows. This fixes the recurring issues of CI failure due to the use of Ubuntu 18.04, which is deprecated.

Changes:
 - In places where 18.04 was used by itself, it was changed to 20.04
 - Where it was used alongside 20.04, it was changed to 22.04 (so we now have 20 and 22 instead of 18 and 20).
 
 I also removed some comments related to broken features in 18.04; hopefully we won't run into those issues on the newer versions.