### PR TITLE
Bugfix: log at wrong location for unfettered jump drive source mission

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -871,7 +871,6 @@ mission "Unfettered: Jump Drive Source"
 	to offer
 		has "Wanderers: Jump Drive Source: active"
 	on offer
-		log `Learned from the Unfettered Hai that they have been purchasing jump drives from the Alphas (whom they refer to as "unfettered humans").`
 		conversation
 			`Following Iktat Rek's suggestion, would you like to sell a jump drive to the Hai and see what information you can get in return?`
 			choice
@@ -907,6 +906,7 @@ mission "Unfettered: Jump Drive Source"
 			`	You are able to get no further information from him, but what you already know is quite valuable. You should report back to Iktat Rek and see what he says.`
 				accept
 	on accept
+		log `Learned from the Unfettered Hai that they have been purchasing jump drives from the Alphas (whom they refer to as "unfettered humans").`
 		outfit "Jump Drive" -1
 		outfit "Hyperdrive" 1
 		payment 1000000


### PR DESCRIPTION
**Bugfix:** This PR addresses a log at the wrong location.

## Fix Details
It was reported on the discord that deferring the mission gives you the log, I moved it to when you accept it.

## Testing Done
N/A

## Save File
N/A