### PR TITLE
fix(content): Give `Void Sprite Parts` plural name

### DIFF
--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -875,6 +875,7 @@ outfit "Void Rifle"
 
 
 outfit "Void Sprite Parts"
+	plural "Void Sprite Parts"
 	category "Unique"
 	cost 500
 	thumbnail "outfit/mouthparts"


### PR DESCRIPTION
**Bugfix:**

Thanks to @pilover100 for reporting this on Discord.

## Fix Details
The lack of explicit plural name means `s` is appended to the normal name for plurals.
This is wrong as it results in `Void Sprite Partss` when the plural should actually be the same as the normal name.
