### PR TITLE
Mechanics: Frugal performance improvement and clarification

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2962,9 +2962,9 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary) const
 	bool beFrugal = (ship.IsYours() && !escortsUseAmmo);
 	if(person.IsFrugal() || (ship.IsYours() && escortsAreFrugal && escortsUseAmmo))
 	{
-		// Frugal ships only expend ammunition if they have lost 50% of shields
-		// and hull combined, or if they are outgunned.
-		beFrugal = (ship.Hull() + ship.Shields() < 1.5);
+		// Frugal ships do not expend ammunition except if they have lost 50%
+		// of shields and hull combined, or if they are outgunned.
+		beFrugal = (ship.Hull() + ship.Shields() > 1.5);
 		if(beFrugal)
 		{
 			auto ait = allyStrength.find(ship.GetGovernment());

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2965,10 +2965,13 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary) const
 		// Frugal ships only expend ammunition if they have lost 50% of shields
 		// and hull combined, or if they are outgunned.
 		beFrugal = (ship.Hull() + ship.Shields() < 1.5);
-		auto ait = allyStrength.find(ship.GetGovernment());
-		auto eit = enemyStrength.find(ship.GetGovernment());
-		if(!beFrugal && ait != allyStrength.end() && eit != enemyStrength.end() && ait->second < eit->second)
-			beFrugal = false;
+		if(beFrugal)
+		{
+			auto ait = allyStrength.find(ship.GetGovernment());
+			auto eit = enemyStrength.find(ship.GetGovernment());
+			if(ait != allyStrength.end() && eit != enemyStrength.end() && ait->second < eit->second)
+				beFrugal = false;
+		}
 	}
 
 	// Special case: your target is not your enemy. Do not fire, because you do

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2963,11 +2963,11 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary) const
 	if(person.IsFrugal() || (ship.IsYours() && escortsAreFrugal && escortsUseAmmo))
 	{
 		// Frugal ships only expend ammunition if they have lost 50% of shields
-		// or hull, or if they are outgunned.
-		beFrugal = (ship.Hull() + ship.Shields() > 1.5);
+		// and hull combined, or if they are outgunned.
+		beFrugal = (ship.Hull() + ship.Shields() < 1.5);
 		auto ait = allyStrength.find(ship.GetGovernment());
 		auto eit = enemyStrength.find(ship.GetGovernment());
-		if(ait != allyStrength.end() && eit != enemyStrength.end() && ait->second < eit->second)
+		if(!beFrugal && ait != allyStrength.end() && eit != enemyStrength.end() && ait->second < eit->second)
 			beFrugal = false;
 	}
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2964,7 +2964,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary) const
 	{
 		// The frugal personality is only active when ships have more than 75% of their total health,
 		// and are not outgunned.
-		beFrugal = ship.Health() > .75;
+		beFrugal = (ship.Health() > .75);
 		if(beFrugal)
 		{
 			auto ait = allyStrength.find(ship.GetGovernment());

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2962,9 +2962,9 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary) const
 	bool beFrugal = (ship.IsYours() && !escortsUseAmmo);
 	if(person.IsFrugal() || (ship.IsYours() && escortsAreFrugal && escortsUseAmmo))
 	{
-		// Frugal ships do not expend ammunition except if they have lost 50%
-		// of shields and hull combined, or if they are outgunned.
-		beFrugal = (ship.Hull() + ship.Shields() > 1.5);
+		// The frugal personality is only active when ships have more than 75% of their total health,
+		// and are not outgunned.
+		beFrugal = ship.Health() > .75;
 		if(beFrugal)
 		{
 			auto ait = allyStrength.find(ship.GetGovernment());


### PR DESCRIPTION
Just improved the logic a bit to not calculate stuff without need.
Also I made sure to clarify the comment so that others would not make the same mistake I did.
Sorry.

~~Quickly, merge this before anyone notices!~~
~~This was literally doing the opposite of what it was saying for the hull and shield (only being true when those were higher than 150% combined)~~
~~On top of that, that part was overwritten by the strength in the system; whereas this personality is advertised to activate when either of those conditions is true.~~

~~This meant that frugal escorts did not work properly, and same thing for the Augmented Archon weapons; you could kill the archon all you wanted, so long as you did so in a ship costing less.~~