### PR TITLE
Add Range Override/Hit Effect to Newly Added Twin Blasters

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -51,6 +51,7 @@ outfit "Twin Blaster"
 			"facing" -0.3
 		"inaccuracy" 3
 		"lifetime" 0
+		"range override" 510
 		"reload" 12
 		"firing energy" 11.6
 		"firing heat" 36
@@ -166,6 +167,7 @@ outfit "Twin Modified Blaster"
 			"facing" -0.45
 		"inaccuracy" 4
 		"lifetime" 0
+		"range override" 480
 		"reload" 12
 		"firing energy" 13
 		"firing heat" 50.4

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -49,7 +49,7 @@ outfit "Twin Blaster"
 		"submunition" "Blaster Submunition"
 			"offset" -1 0
 			"facing" -0.3
-		"hit effect" "blaster impact"
+		"hit effect" "blaster impact" 2
 		"inaccuracy" 3
 		"lifetime" 0
 		"range override" 510
@@ -166,7 +166,7 @@ outfit "Twin Modified Blaster"
 		"submunition" "Modified Blaster Submunition"
 			"offset" -1 0
 			"facing" -0.45
-		"hit effect" "blaster impact"
+		"hit effect" "blaster impact" 2
 		"inaccuracy" 4
 		"lifetime" 0
 		"range override" 480

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -49,6 +49,7 @@ outfit "Twin Blaster"
 		"submunition" "Blaster Submunition"
 			"offset" -1 0
 			"facing" -0.3
+		"hit effect" "blaster impact"
 		"inaccuracy" 3
 		"lifetime" 0
 		"range override" 510
@@ -165,6 +166,7 @@ outfit "Twin Modified Blaster"
 		"submunition" "Modified Blaster Submunition"
 			"offset" -1 0
 			"facing" -0.45
+		"hit effect" "blaster impact"
 		"inaccuracy" 4
 		"lifetime" 0
 		"range override" 480


### PR DESCRIPTION
BugFix
## Fix Details
The twin blasters added in #7402 use Submunitons to have two separate projectiles, but as the main munition has a lifetime of 0, the weapons show as having a range of 0:

## Testing Done
I loaded the game up and viewed the outfits with and without the fix. 

Without this fix:
![image](https://user-images.githubusercontent.com/15916854/196851434-ef8270f2-c229-45ba-a0b9-aa9b6ddfdd7a.png)

With this fix:
![image](https://user-images.githubusercontent.com/15916854/196851358-f7754b07-d85b-4716-ade8-85479a361c1a.png)

Thanks to @Pointedstick for pointing this out on the original PR