### PR TITLE
Fix potential null dereference

### DIFF
--- a/source/System.cpp
+++ b/source/System.cpp
@@ -825,8 +825,9 @@ double System::Danger() const
 {
 	double danger = 0.;
 	for(const auto &fleet : fleets)
-		if(fleet.Get()->GetGovernment()->IsEnemy())
-			danger += static_cast<double>(fleet.Get()->Strength()) / fleet.Period();
+		if(auto *gov = fleet.Get()->GetGovernment())
+			if(gov->IsEnemy())
+				danger += static_cast<double>(fleet.Get()->Strength()) / fleet.Period();
 	return danger;
 }
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -825,9 +825,11 @@ double System::Danger() const
 {
 	double danger = 0.;
 	for(const auto &fleet : fleets)
-		if(auto *gov = fleet.Get()->GetGovernment())
-			if(gov->IsEnemy())
-				danger += static_cast<double>(fleet.Get()->Strength()) / fleet.Period();
+	{
+		auto *gov = fleet.Get()->GetGovernment();
+		if(gov && gov->IsEnemy())
+			danger += static_cast<double>(fleet.Get()->Strength()) / fleet.Period();
+	}
 	return danger;
 }
 


### PR DESCRIPTION
# Fix Details

Fixes a potential null dereference for system fleets without a government. Found by clang's undefined sanitzer.