### PR TITLE
fix(content): Account for saves that have already done Pirate Troubles

### DIFF
--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -680,7 +680,8 @@ mission "Hai Reveal [A03c] Report to Teeneep"
 	landing
 	name "Report to Teeneep"
 	description `Tell Teeneep about the experience with Scar's Legion.`
-	source government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
+	source
+		government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
 		attributes "spaceport"
 	destination Darkwaste
 	to offer
@@ -721,7 +722,6 @@ mission "Hai Reveal [A05] Take Teeneep to Hai-home"
 	passengers 1
 	blocked `It's probably not advisable to bring so many unnecessary people to a secret location on Darkwaste, you should return when your spare bunks are unoccupied.`
 	to offer
-		has "Hai Reveal [A04] Report to Teeneep: done"
 		has "alondo symbol timer"
 		or
 			has "Hai Reveal [A04] Report to Teeneep: done"

--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -280,14 +280,11 @@ mission "Hai Reveal: Pirate Troubles [0]"
 
 # If older mission chain was done: Need to remove the planet the asteroid orbits, then re-add it without the landable location to reset.
 mission "Hai Reveal: Pirate Troubles [0a]"
+	landing
 	invisible
-	source
-		near "Waypoint" 3
-		government "Hai"
-		not planet "Allhome"
 	to offer
-		has "Pirate Troubles [0]: done"
-		has "Hai Reveal: Pirate Troubles [0]: offered"
+		has "Pirate Troubles [2]: offered"
+		has "Hai Reveal [A03a] Symbol Identification: offered"
 	on offer
 		event "clean danoa"
 

--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -49,8 +49,8 @@ mission "Hai Reveal [A01] Visit Darkwaste"
 		has "event: hai rescue: teeneep message"
 		has "Hai Building Mountaintop [3] Furnishings: done"
 #		or
-#			has "Pirate Troubles [4]: done"
-#			has "Pirate Troubles [4]: declined"
+#			has "Hai Reveal: Pirate Troubles [4]: done"
+#			has "Hai Reveal: Pirate Troubles [4]: declined"
 	on offer
 		conversation
 			`You receive a high priority communication from a Hai woman named Teeneep. The message is brief and cryptic, but you deduce that it refers to the Hai you've rescued from human space in the past. It advises that she needs to talk to you as soon as possible. There is a set of landing coordinates on the uninhabited Hai planet, <planet>.`
@@ -202,7 +202,7 @@ mission "Hai Reveal [A03a1]"
 		attributes "spaceport"
 	to offer
 		has "event: alondo symbol timer"
-		has "Pirate Troubles [0]: done"
+		has "Hai Reveal: Pirate Troubles [0]: done"
 	on offer
 		fail "Hai Reveal [A03a] Symbol Identification"
 		# This presumably does nothing if it's already failed.
@@ -216,13 +216,13 @@ mission "Hai Reveal [A03a2]"
 		government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
 		attributes "spaceport"
 	to offer
-		has "Pirate Troubles [0]: done"
+		has "Hai Reveal: Pirate Troubles [0]: done"
 	on offer
 		fail "Hai Reveal [A03a] Symbol Identification"
 
 
 
-mission "Pirate Troubles [0]"
+mission "Hai Reveal: Hai Reveal: Pirate Troubles [0]"
 	name "Defend <system>"
 	description "A sizable group of pirates has found their way into Hai space and is terrorizing the system. Help the Hai fight back against them."
 	source
@@ -278,7 +278,49 @@ mission "Pirate Troubles [0]"
 
 
 
-mission "Pirate Troubles [1]"
+# If older mission chain was done: Need to remove the planet the asteroid orbits, then re-add it without the landable location to reset.
+mission "Hai Reveal: Hai Reveal: Pirate Troubles [0a]"
+	invisible
+	source
+		near "Waypoint" 3
+		government "Hai"
+		not planet "Allhome"
+	to offer
+		has "Pirate Troubles [0]: done"
+		has "Hai Reveal: Hai Reveal: Pirate Troubles [0]: offered"
+	on offer
+		event "clean danoa"
+
+event "clean danoa"
+	system "Danoa"
+		remove object
+			sprite planet/gas6
+			distance 2069.42
+			period 3240.9
+		add object
+			sprite planet/gas6
+			distance 2069.42
+			period 3240.9
+			object
+				sprite planet/lava1-b
+				distance 293
+				period 11.3672
+			object
+				sprite planet/rock0-b
+				distance 440
+				period 20.9186
+			object
+				sprite planet/lava2-b
+				distance 607
+				period 33.895
+			object
+				sprite "planet/asteroid base"
+				distance 809
+				period 52.153
+
+
+
+mission "Hai Reveal: Pirate Troubles [1]"
 	landing
 	name "Unfettered Humans"
 	description `Track down the leaders of the pirate gang "Scar's Legion" and "persuade" them to stop attacking Hai space, then return to <destination> to tell the Hai.`
@@ -287,7 +329,7 @@ mission "Pirate Troubles [1]"
 	destination "Hai-home"
 	clearance
 	to offer
-		has "Pirate Troubles [0]: done"
+		has "Hai Reveal: Pirate Troubles [0]: done"
 	on offer
 		"reputation: Hai" += 20
 		"reputation: Hai (Wormhole Access)" += 20
@@ -330,12 +372,12 @@ mission "Pirate Troubles [1]"
 
 
 
-mission "Pirate Troubles [1]: Farpoint"
+mission "Hai Reveal: Pirate Troubles [1]: Farpoint"
 	landing
 	invisible
 	source "Farpoint"
 	to offer
-		has "Pirate Troubles [1]: active"
+		has "Hai Reveal: Pirate Troubles [1]: active"
 	on offer
 		conversation
 			`You visit the Navy outpost on <origin> and ask the officers there if they have any information on Scar's Legion. After running a background check on you to make sure you're not up to no good, and sheepishly apologizing once they recognize you, an officer hands you a copy of a folder containing all the information that the Navy has on the gang. "Nothing in here is classified, so you're free to keep it," the officer says.`
@@ -344,13 +386,13 @@ mission "Pirate Troubles [1]: Farpoint"
 
 
 
-mission "Pirate Troubles [1]: Freedom or Zenith"
+mission "Hai Reveal: Pirate Troubles [1]: Freedom or Zenith"
 	landing
 	invisible
 	source
 		planet "Freedom" "Zenith"
 	to offer
-		has "Pirate Troubles [1]: active"
+		has "Hai Reveal: Pirate Troubles [1]: active"
 	on offer
 		payment -5000
 		conversation
@@ -359,12 +401,12 @@ mission "Pirate Troubles [1]: Freedom or Zenith"
 
 
 
-mission "Pirate Troubles [1]: Haven"
+mission "Hai Reveal: Pirate Troubles [1]: Haven"
 	landing
 	invisible
 	source "Haven"
 	to offer
-		has "Pirate Troubles [1]: active"
+		has "Hai Reveal: Pirate Troubles [1]: active"
 	on offer
 		payment -100
 		"scar's legion information" ++
@@ -376,12 +418,12 @@ mission "Pirate Troubles [1]: Haven"
 
 
 
-mission "Pirate Troubles [1]: Stormhold"
+mission "Hai Reveal: Pirate Troubles [1]: Stormhold"
 	landing
 	invisible
 	source "Stormhold"
 	to offer
-		has "Pirate Troubles [1]: active"
+		has "Hai Reveal: Pirate Troubles [1]: active"
 	on offer
 		"scar's legion information" ++
 		conversation
@@ -392,7 +434,7 @@ mission "Pirate Troubles [1]: Stormhold"
 
 
 
-mission "Pirate Troubles [2]"
+mission "Hai Reveal: Pirate Troubles [2]"
 	landing
 	name "Scar's Legion"
 	description "You've pieced together enough information to find out that the Scar's Legion hideout is in one of four systems in the Far North. Search those systems for the gang's hideout and confront them."
@@ -411,26 +453,15 @@ mission "Pirate Troubles [2]"
 	to complete
 		never
 	to fail
-		has "Pirate Troubles [3]: offered"
+		has "Hai Reveal: Pirate Troubles [3]: offered"
 
 event "scar's hideout"
 	system "Danoa"
-		object
-			sprite star/m3
-			period 10
-		object
-			sprite planet/desert7-b
-			distance 168.64
-			period 75.3935
-		object
-			sprite planet/fog0-b
-			distance 693.93
-			period 629.313
-			object
-				sprite planet/mercury
-				distance 174
-				period 15.1961
-		object
+		remove object
+			sprite planet/gas6
+			distance 2069.42
+			period 3240.9
+		add object
 			sprite planet/gas6
 			distance 2069.42
 			period 3240.9
@@ -461,7 +492,7 @@ planet "Scar's Hideout"
 
 
 
-mission "Pirate Troubles [3]"
+mission "Hai Reveal: Pirate Troubles [3]"
 	landing
 	name "Scar's Legion"
 	description "Having declined the tribute, the leader of Scar's Legion has challenged you to a fight to the death. Defeat the <npc>, then return to <destination>."
@@ -568,7 +599,7 @@ event "battle against scar's legion over"
 
 
 
-mission "Pirate Troubles [4]"
+mission "Hai Reveal: Pirate Troubles [4]"
 	landing
 	name "Pirate Tribute"
 	description "Escort the three Hai freighters carrying Hai weapons and technology to <stopovers>, then escort the freighters back to <destination>."
@@ -658,42 +689,44 @@ mission "Pirate Troubles [4]"
 
 
 
+# Temporarily keeping all of this in comments in case I need to draw upon similar functionality in the near future.
+
 # Blame Amazinite for this. They can proc at the same time if you fly around a bunch, but generally shouldn't.
-mission "Hai Reveal [A03b]"
-	invisible
-	source
-		government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
-		attributes "spaceport"
-	to offer
-		# You will only trigger this before A04 if you've already done Pirate Troubles.
-		has "Hai Reveal [A03a] Symbol Identification: offered"
-		or
-			has "Pirate Troubles [4]: done"
-			has "Pirate Troubles [4]: declined"
-		not "Hai Reveal [A04] Report to Teeneep: offered"
-	on offer
-		dialog `You have already completed the Pirate Troubles mission line which is now part of this story, and are seeing this because you're playing an older save. In it you tracked down Scar's Legion and either took them tribute from the Hai, or destroyed them. Your choices there will be considered in the story here.`
-
-
+#mission "Hai Reveal [A03b]"
+#	invisible
+#	source
+#		government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
+#		attributes "spaceport"
+#	to offer
+#		# You will only trigger this before A04 if you've already done Hai Reveal: Pirate Troubles.
+#		has "Hai Reveal [A03a] Symbol Identification: offered"
+#		or
+#			has "Hai Reveal: Pirate Troubles [4]: done"
+#			has "Hai Reveal: Pirate Troubles [4]: declined"
+#		not "Hai Reveal [A04] Report to Teeneep: offered"
+#	on offer
+#		dialog `You have already completed the Hai Reveal: Pirate Troubles mission line which is now part of this story, and are seeing this because you're playing an older save. In it you tracked down Scar's Legion and either took them tribute from the Hai, or destroyed them. Your choices there will be considered in the story here.`
+#
+#
 # This also.
-mission "Hai Reveal [A03c] Report to Teeneep"
-	landing
-	name "Report to Teeneep"
-	description `Tell Teeneep about the experience with Scar's Legion.`
-	source
-		government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
-		attributes "spaceport"
-	destination Darkwaste
-	to offer
-		or
-			has "Hai Reveal [A03b]: offered"
-			has "Hai Reveal [A04] Report to Teeneep: offered"
-		or
-			has "Pirate Troubles [4]: done"
-			has "Pirate Troubles [4]: declined"
-		not "alondo symbol timer"
-	on offer
-		dialog `You are playing a save which has tripped up an issue from being on the continuous build. You have been given a mission marker to resume safely.`
+#mission "Hai Reveal [A03c] Report to Teeneep"
+#	landing
+#	name "Report to Teeneep"
+#	description `Tell Teeneep about the experience with Scar's Legion.`
+#	source
+#		government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
+#		attributes "spaceport"
+#	destination Darkwaste
+#	to offer
+#		or
+#			has "Hai Reveal [A03b]: offered"
+#			has "Hai Reveal [A04] Report to Teeneep: offered"
+#		or
+#			has "Pirate Troubles [4]: done"
+#			has "Pirate Troubles [4]: declined"
+#		not "alondo symbol timer"
+#	on offer
+#		dialog `You are playing a save which has tripped up an issue from being on the continuous build. You have been given a mission marker to resume safely.`
 
 
 
@@ -706,8 +739,8 @@ mission "Hai Reveal [A04] Report to Teeneep"
 	to offer
 		has "alondo symbol timer"
 		or
-			has "Pirate Troubles [4]: done"
-			has "Pirate Troubles [4]: declined"
+			has "Hai Reveal: Pirate Troubles [4]: done"
+			has "Hai Reveal: Pirate Troubles [4]: declined"
 	on offer
 		dialog `Alondo is apparently away somewhere and unavailable for a short while. So, now that the situation with Scar's Legion is resolved, it's time to report to Teeneep about the experience. Maybe it will shed some light on what's going on?`
 
@@ -734,7 +767,7 @@ mission "Hai Reveal [A05] Take Teeneep to Hai-home"
 			`	"So," she says, "please, tell me everything about this recent experience. I must know what happened and what the Elders chose to do."`
 			`	You briefly relay the initial events. Starting with the raid, the request for your assistance, the search that you went on, and the eventual discovery of Scar's Legion and their secret base in Danoa where they issued their demands.`
 			branch "appeased scar"
-				has "Pirate Troubles [4]: done"
+				has "Hai Reveal: Pirate Troubles [4]: done"
 			branch lied
 				has "lied to elders"
 			choice

--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -658,6 +658,44 @@ mission "Pirate Troubles [4]"
 
 
 
+# Blame Amazinite for this. They can proc at the same time if you fly around a bunch, but generally shouldn't.
+mission "Hai Reveal [A03b]"
+	invisible
+	source
+		government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
+		attributes "spaceport"
+	to offer
+		# You will only trigger this before A04 if you've already done Pirate Troubles.
+		has "Hai Reveal [A03a] Symbol Identification: offered"
+		or
+			has "Pirate Troubles [4]: done"
+			has "Pirate Troubles [4]: declined"
+		not "Hai Reveal [A04] Report to Teeneep: offered"
+	on offer
+		dialog `You have already completed the Pirate Troubles mission line which is now part of this story, and are seeing this because you're playing an older save. In it you tracked down Scar's Legion and either took them tribute from the Hai, or destroyed them. Your choices there will be considered in the story here.`
+
+
+# This also.
+mission "Hai Reveal [A03c] Report to Teeneep"
+	landing
+	name "Report to Teeneep"
+	description `Tell Teeneep about the experience with Scar's Legion.`
+	source government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
+		attributes "spaceport"
+	destination Darkwaste
+	to offer
+		or
+			has "Hai Reveal [A03b]: offered"
+			has "Hai Reveal [A04] Report to Teeneep: offered"
+		or
+			has "Pirate Troubles [4]: done"
+			has "Pirate Troubles [4]: declined"
+		not "alondo symbol timer"
+	on offer
+		dialog `You are playing a save which has tripped up an issue from being on the continuous build. You have been given a mission marker to resume safely.`
+
+
+
 mission "Hai Reveal [A04] Report to Teeneep"
 	landing
 	name "Report to Teeneep"
@@ -665,6 +703,7 @@ mission "Hai Reveal [A04] Report to Teeneep"
 	source Hai-home
 	destination Darkwaste
 	to offer
+		has "alondo symbol timer"
 		or
 			has "Pirate Troubles [4]: done"
 			has "Pirate Troubles [4]: declined"
@@ -683,6 +722,10 @@ mission "Hai Reveal [A05] Take Teeneep to Hai-home"
 	blocked `It's probably not advisable to bring so many unnecessary people to a secret location on Darkwaste, you should return when your spare bunks are unoccupied.`
 	to offer
 		has "Hai Reveal [A04] Report to Teeneep: done"
+		has "alondo symbol timer"
+		or
+			has "Hai Reveal [A04] Report to Teeneep: done"
+			has "Hai Reveal [A03b] Report to Teeneep: offered"
 	on visit
 		dialog `Teeneep is on another ship not yet in the system, take off and wait for the ship to arrive in order to continue.`
 	on offer

--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -222,7 +222,7 @@ mission "Hai Reveal [A03a2]"
 
 
 
-mission "Hai Reveal: Hai Reveal: Pirate Troubles [0]"
+mission "Hai Reveal: Pirate Troubles [0]"
 	name "Defend <system>"
 	description "A sizable group of pirates has found their way into Hai space and is terrorizing the system. Help the Hai fight back against them."
 	source
@@ -279,7 +279,7 @@ mission "Hai Reveal: Hai Reveal: Pirate Troubles [0]"
 
 
 # If older mission chain was done: Need to remove the planet the asteroid orbits, then re-add it without the landable location to reset.
-mission "Hai Reveal: Hai Reveal: Pirate Troubles [0a]"
+mission "Hai Reveal: Pirate Troubles [0a]"
 	invisible
 	source
 		near "Waypoint" 3
@@ -287,7 +287,7 @@ mission "Hai Reveal: Hai Reveal: Pirate Troubles [0a]"
 		not planet "Allhome"
 	to offer
 		has "Pirate Troubles [0]: done"
-		has "Hai Reveal: Hai Reveal: Pirate Troubles [0]: offered"
+		has "Hai Reveal: Pirate Troubles [0]: offered"
 	on offer
 		event "clean danoa"
 
@@ -686,47 +686,6 @@ mission "Hai Reveal: Pirate Troubles [4]"
 		"reputation: Hai Merchant (Sympathizers)" += 40
 		payment 500000
 		dialog `With the freighters safely returned, the Hai thank you for resolving the situation with Scar's Legion and hand you <payment> for your help.`
-
-
-
-# Temporarily keeping all of this in comments in case I need to draw upon similar functionality in the near future.
-
-# Blame Amazinite for this. They can proc at the same time if you fly around a bunch, but generally shouldn't.
-#mission "Hai Reveal [A03b]"
-#	invisible
-#	source
-#		government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
-#		attributes "spaceport"
-#	to offer
-#		# You will only trigger this before A04 if you've already done Hai Reveal: Pirate Troubles.
-#		has "Hai Reveal [A03a] Symbol Identification: offered"
-#		or
-#			has "Hai Reveal: Pirate Troubles [4]: done"
-#			has "Hai Reveal: Pirate Troubles [4]: declined"
-#		not "Hai Reveal [A04] Report to Teeneep: offered"
-#	on offer
-#		dialog `You have already completed the Hai Reveal: Pirate Troubles mission line which is now part of this story, and are seeing this because you're playing an older save. In it you tracked down Scar's Legion and either took them tribute from the Hai, or destroyed them. Your choices there will be considered in the story here.`
-#
-#
-# This also.
-#mission "Hai Reveal [A03c] Report to Teeneep"
-#	landing
-#	name "Report to Teeneep"
-#	description `Tell Teeneep about the experience with Scar's Legion.`
-#	source
-#		government "Republic" "Syndicate" "Hai" "Free Worlds" "Independent"
-#		attributes "spaceport"
-#	destination Darkwaste
-#	to offer
-#		or
-#			has "Hai Reveal [A03b]: offered"
-#			has "Hai Reveal [A04] Report to Teeneep: offered"
-#		or
-#			has "Pirate Troubles [4]: done"
-#			has "Pirate Troubles [4]: declined"
-#		not "alondo symbol timer"
-#	on offer
-#		dialog `You are playing a save which has tripped up an issue from being on the continuous build. You have been given a mission marker to resume safely.`
 
 
 


### PR DESCRIPTION
The rework that Amazinite and I developed incorporated an existing story into the plot. 

This accounts for saves which have already done that plot.