### PR TITLE
"Outfit Factory"- Outfits that Produce Other Outfits

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1564,7 +1564,7 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 	bool wasHyperspacing = ship->IsHyperspacing();
 	// Give the ship the list of visuals so that it can draw explosions,
 	// ion sparks, jump drive flashes, etc.
-	ship->Move(newVisuals, newFlotsam);
+	ship->Move(newVisuals, newFlotsam, step);
 	// Bail out if the ship just died.
 	if(ship->ShouldBeRemoved())
 	{

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -201,6 +201,34 @@ void Outfit::Load(const DataNode &node)
 			// Jump range must be positive.
 			attributes[child.Token(0)] = max(0., child.Value(1));
 		}
+		else if(child.Token(0) == "production")
+		{
+			productions.emplace_back();
+			auto &production = productions.back();
+
+			auto ParseChild = [] (const DataNode &grand, std::map<const Outfit *, int> &map, bool &location)
+			{
+				if(grand.Token(1) == "outfit")
+					location = false;
+				else if(grand.Token(1) != "cargo")
+					grand.PrintTrace("Unrecognized location \"" + grand.Token(1) + "\". Defaulting to \"cargo\":");
+
+				for(const auto &outfit : grand)
+					map[GameData::Outfits().Get(outfit.Token(0))] += (outfit.Size() >= 2 ? outfit.Value(1) : 1.);
+			};
+
+			for(const auto &grand : child)
+			{
+				if(grand.Token(0) == "input" && grand.Size() >= 2)
+					ParseChild(grand, production.input, production.inputFromCargo);
+				else if(grand.Token(0) == "output" && grand.Size() >= 2)
+					ParseChild(grand, production.output, production.outputInCargo);
+				else if(grand.Token(0) == "speed" && grand.Size() >= 2)
+					production.speed = static_cast<int>(grand.Value(1));
+				else
+					grand.PrintTrace("Skipping unrecognized attribute:");
+			}
+		}
 		else if(child.Size() >= 2)
 			attributes[child.Token(0)] = child.Value(1);
 		else
@@ -327,6 +355,13 @@ const Dictionary &Outfit::Attributes() const
 
 
 
+const vector<Outfit::Production> &Outfit::Productions() const
+{
+	return productions;
+}
+
+
+
 // Determine whether the given number of instances of the given outfit can
 // be added to a ship with the attributes represented by this instance. If
 // not, return the maximum number that can be added.
@@ -369,6 +404,9 @@ void Outfit::Add(const Outfit &other, int count)
 		if(fabs(attributes[at.first]) < EPS)
 			attributes[at.first] = 0.;
 	}
+	productions.reserve(productions.size() + other.productions.size() * count);
+	for(int i = 0; i < count; ++i)
+		productions.insert(productions.end(), other.productions.begin(), other.productions.end());
 
 	for(const auto &it : other.flareSprites)
 		AddFlareSprites(flareSprites, it, count);

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -41,6 +41,19 @@ public:
 	// These are all the possible category strings for outfits.
 	static const std::vector<std::string> CATEGORIES;
 
+
+public:
+	// A class that represents the production of outfits, given other outfits.
+	class Production {
+	public:
+		std::map<const Outfit *, int> input;
+		std::map<const Outfit *, int> output;
+		bool inputFromCargo = true;
+		bool outputInCargo = true;
+		int speed = 60;
+	};
+
+
 public:
 	// An "outfit" can be loaded from an "outfit" node or from a ship's
 	// "attributes" node.
@@ -62,6 +75,8 @@ public:
 	double Get(const char *attribute) const;
 	double Get(const std::string &attribute) const;
 	const Dictionary &Attributes() const;
+
+	const std::vector<Production> &Productions() const;
 
 	// Determine whether the given number of instances of the given outfit can
 	// be added to a ship with the attributes represented by this instance. If
@@ -106,6 +121,8 @@ private:
 	double mass = 0.;
 	// Licenses needed to purchase this item.
 	std::vector<std::string> licenses;
+
+	std::vector<Production> productions;
 
 	Dictionary attributes;
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -189,7 +189,7 @@ public:
 	const Command &Commands() const;
 	// Move this ship. A ship may create effects as it moves, in particular if
 	// it is in the process of blowing up.
-	void Move(std::vector<Visual> &visuals, std::list<std::shared_ptr<Flotsam>> &flotsam);
+	void Move(std::vector<Visual> &visuals, std::list<std::shared_ptr<Flotsam>> &flotsam, int step);
 	// Generate energy, heat, etc. (This is called by Move().)
 	void DoGeneration();
 	// Launch any ships that are ready to launch.
@@ -582,6 +582,9 @@ private:
 	const System *targetSystem = nullptr;
 	std::weak_ptr<Minable> targetAsteroid;
 	std::weak_ptr<Flotsam> targetFlotsam;
+
+	// Last production times.
+	std::vector<int> productionSteps;
 
 	// Links between escorts and parents.
 	std::vector<std::weak_ptr<Ship>> escorts;


### PR DESCRIPTION
**Feature:** This PR implements a feature taking advantage of the dynamic nature of the cargo and outfit variables, by allowing outfits to modify the contents of either (or both) while in-flight.

## Feature Details
Outfits, once installed, can remove outfits from outfit or cargo space and (simultaneously) add outfits to outfit or cargo space as defined by certain syntax. This is anticipated to be used for two primary purposes- mining-related refineries which take outfits mined from asteroids and converts them into higher-quality outfits over time, and combat-related mini-factories which consume raw materials and produce ammunition for use in combat, without stopping at a planet to restock. There are other possible uses as well.

Planned before this is merged is the inclusion of the typical stats- shields, hull, energy, fuel, and heat, along with their DoT variants and relative values and such. Perhaps all those 20 attributes could be united under one functionality, in a different PR? Weapons and engines access them, and this would aim to add factories accessing them too. A lot of things access these five stats in these four different ways [regular, relative, DoT, and relative DoT, all together].

One of the parameters of the factory outfits is "speed", which is currently a misnomer. It describes the frames between each attempt at producing the outputs, and is more analogous to "reload" than "max speed". )Low "speed" equals high rate of production.) Speaking of speed, too, I am not 100% set on the way it works. Ideally, the timer set by "speed" (or, say, just reuse the "reload" term) only ticks down on a frame where all the inputs are present (because then it can actually begin the work of producing the outputs), and _then_ if there is no space for the output, it hangs on 1 (or 0?) on the timer, until it has both all the inputs and also the space to place all the outputs.

As well there is a small bug or oversight, where remaining space is not properly accounting for the consumption of the inputs in the process of production of the outputs. This means if an outfit consumes 10 tons of stuff to produce 3 tons of stuff, you need at least 13 tons of space to be able to use it- 10 to store the inputs, and 3 to store the outputs, even though the 3 tons of stuff could go in 3 of the 10 tons of space vacated by the process of producing the outputs.

Also there are merge conflicts that I need to iron out before it can be merged.

## UI Screenshots
As of now, the outfit screen does not properly account for the "production" attribute, and doesn't display its abilities. This is likely to prevent the PR from being merged for a while, until the data can be displayed.

## Usage Examples
As of posting this PR, and likely to be updated as changes come, the added functionality works like this:
```
outfit <outfit name>
    production
        (input | output) (cargo | outfit)
            <outfit name> [<number>]
        [speed <frames>]
```

"input" is what the outfit consumes, "output" is what the outfit produces. "cargo" means it pulls from/puts into the cargo bay, "outfit" means the same for the outfit space of the ship. "speed" is, unintuitively, the number of frames between each attempted production. 

## Testing Done
Created a "piercer factory" which consumes iron and silicon, the mined outfits, and produces piercers into your outfit space. With a piercer launcher installed, this factory installed, and the weapons to mine asteroids and collect the requisite iron and silicon. Additionally, created a "philosopher's stone" outfit (though perhaps an "alchemical stone" or "midas's touch" would've been more fitting?) which consumes lead in your cargo bay and produces gold into your cargo bay (to turn lead into gold!), which revealed a fatal (well, niche) flaw in the current implementation. Future developments are discussed above.

More testing should be done to confirm that the feature works as intended as it is worked upon.

## Performance Impact
I do not think this will be intensive, but it does have the _ability_ to significantly slow down the game. For example, if you have a million outfits with this ability installed, you will be counting down a million counters each frame, and likely checking your ship's outfit makeup a million times every frame, it'll get laggy. But I do not think that is a likely vanilla scenario.
