### PR TITLE
Add a Velocity Override to both Twin Blaster Guns

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -51,6 +51,7 @@ outfit "Twin Blaster"
 			"facing" -0.3
 		"inaccuracy" 3
 		"lifetime" 0
+		"velocity override" 10.625
 		"reload" 12
 		"firing energy" 11.6
 		"firing heat" 36
@@ -166,6 +167,7 @@ outfit "Twin Modified Blaster"
 			"facing" -0.45
 		"inaccuracy" 4
 		"lifetime" 0
+		"velocity override" 10
 		"reload" 12
 		"firing energy" 13
 		"firing heat" 50.4


### PR DESCRIPTION
## Summary
The recently added twin blaster guns use submunition to have dual projectiles, however as the main projectile has a `velocity` of 0, the AI isn't able to correctly lead its target using the submunitions. 

This PR adds a `velocity override` to the twin blasters matching their submunition velocity so the AI is able to properly lead its target when firing. 

This save will place you on Greenrock with several sparrows armed with twin blaster guns so you can see them properly leading their targets.
[All Content.txt](https://github.com/endless-sky/endless-sky/files/9835228/All.Content.txt)
