### PR TITLE
feat(UI): Add proper hotkeys for parking ships

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -1132,7 +1132,7 @@ interface "info panel"
 	active if "can park"
 	sprite "ui/dialog cancel"
 		center -55 305
-	button P "Park"
+	button k "Par_k"
 		center -55 305
 		dimensions 70 30
 	active
@@ -1140,7 +1140,7 @@ interface "info panel"
 	visible if "show unpark"
 	sprite "ui/dialog cancel"
 		center -55 305
-	button P "Unpark"
+	button k "Unpar_k"
 		center -55 305
 		dimensions 70 30
 	
@@ -1163,13 +1163,13 @@ interface "info panel"
 	visible if "show park all"
 	sprite "ui/wide button"
 		center 145 305
-	button A "Park All"
+	button a "Park _All"
 		center 145 305
 		dimensions 90 30
 	visible if "show unpark all"
 	sprite "ui/wide button"
 		center 145 305
-	button A "Unpark All"
+	button a "Unpark _All"
 		center 145 305
 		dimensions 90 30
 	visible if "show save order"

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -400,7 +400,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 				ScrollAbsolute(selected);
 		}
 	}
-	else if(panelState.CanEdit() && (key == 'P' || (key == 'p' && shift)) && !panelState.AllSelected().empty())
+	else if(panelState.CanEdit() && (key == 'k' || (key == 'p' && shift)) && !panelState.AllSelected().empty())
 	{
 		// Toggle the parked status for all selected ships.
 		bool allParked = true;
@@ -419,7 +419,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 				player.ParkShip(&ship, !allParked);
 		}
 	}
-	else if(panelState.CanEdit() && (key == 'A' || (key == 'a' && shift)) && panelState.Ships().size() > 1)
+	else if(panelState.CanEdit() && (key == 'a') && panelState.Ships().size() > 1)
 	{
 		// Toggle the parked status for all ships except the flagship.
 		bool allParked = true;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4471575/197327132-980106c7-b7bf-439f-9c33-9b55a45b5f76.png)

Previously, the hotkeys for parking an individual ship and parking all ships was Shift+P and Shift+A, respectively. All other buttons (besides Disown, which should probably be obscure for safety) would show hotkeys when holding down alt, besides Park and Park All. This PR sets their hotkeys to K and A, and makes them visible when holding alt. It also maintains the old Shift+P hotkey in case anyone had the committed to muscle memory.