### PR TITLE
Make Unfettered JD jobs fail properly

### DIFF
--- a/data/hai/unfettered jobs.txt
+++ b/data/hai/unfettered jobs.txt
@@ -100,10 +100,11 @@ mission "Unfettered Jump Drive 4"
 	to offer
 		has "Unfettered Jump Drive 3: offered"
 		not "event: wanderers: unfettered invasion starts"
+	to fail
+		has "Unfettered Jump Drive 4: active"
 	on accept
 		dialog "As usual, the Unfettered are more than willing to pay you a million credits for your jump drive, but you do not gain any additional information by talking with them."
 		outfit "Jump Drive" -1
 		outfit "Hyperdrive" 1
 		payment 1000000
 		"reputation: Hai (Unfettered)" >?= 40
-		fail


### PR DESCRIPTION
## Fix Details
This PR addresses that `fail`s in `on accept` don't work (at least for jobs), meaning that the Unfettered JD jobs don't fail. This is fixed by moving the fail trigger to a `to fail` node.

## Testing Done
Took the job; it was already greyed out, and failed upon landing while still allowing another JD job to offer.

## Save File
If I had provided a save file here, would you have downloaded it?