### PR TITLE
Option to permanently underline shortcut keys on button labels

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -445,6 +445,7 @@ void PreferencesPanel::DrawSettings()
 		"Rotate flagship in HUD",
 		"Show planet labels",
 		"Show mini-map",
+		"Always underline shortcuts",
 		"",
 		"AI",
 		"Automatic aiming",

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "DisplayText.h"
 #include "../ImageBuffer.h"
 #include "../Point.h"
+#include "../Preferences.h"
 #include "../Screen.h"
 #include "truncate.hpp"
 
@@ -236,7 +237,7 @@ int Font::Space() const noexcept
 
 void Font::ShowUnderlines(bool show) noexcept
 {
-	showUnderlines = show;
+	showUnderlines = show || Preferences::Has("Always underline shortcuts");
 }
 
 


### PR DESCRIPTION
**Feature:**

Inspired by a suggestions from @samrocketman and zredfire#8549 on Discord.

## Feature Details
Adds an option in the preferences panel, in the display section, to enable always underlining shortcut keys on button labels.
The preference defaults to false.

## UI Screenshots
![image](https://user-images.githubusercontent.com/20605679/197349399-e1bd5b9c-5bcb-47cb-99da-3f21a5c52876.png)


## Testing Done
Launch the game, look at various buttons with the preference off and on to ensure that the underlines show up when expected and not when not. Also, hold alt to ensure that that still enables the unerlines when the preference is off and does nothing when it is on.

## Performance Impact
N/A, probably.
