### PR TITLE
fix(content): Ensure Unwanted Cargo cannot offer on Alta Hai

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -283,6 +283,7 @@ mission "Unwanted Cargo"
 	description "Bring a Hai child who hid in your cargo hold back to <destination>."
 	source
 		not government "Hai" "Hai (Unfettered)"
+		not near "Heia Due" 0 100
 	destination "Allhome"
 	to offer
 		has "event: hai in cargo"


### PR DESCRIPTION
**Bugfix:**

Thanks to @Arachi-Lover for pointing this out on Discord.

## Fix Details
It is currently possible to get the unwated cargo mission where a Hai child has snuck unto your cargo hold on Alta Hai (the Quarg ringworld in Hai space).
Presumably, the intention is that this mission only offers on the other side of the wormhole.
Not sure if the government line from the filter should be removed now?
