### PR TITLE
Buff the Star Queen

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -3206,11 +3206,11 @@ ship "Star Queen"
 	thumbnail "thumbnail/star queen"
 	attributes
 		category "Space Liner"
-		"cost" 5500000
+		"cost" 4500000
 		"shields" 4100
 		"hull" 2200
-		"required crew" 41
-		"bunks" 112
+		"required crew" 33
+		"bunks" 152
 		"mass" 230
 		"drag" 4.5
 		"heat dissipation" .65

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -3210,7 +3210,7 @@ ship "Star Queen"
 		"shields" 4100
 		"hull" 2200
 		"required crew" 33
-		"bunks" 152
+		"bunks" 112
 		"mass" 230
 		"drag" 4.5
 		"heat dissipation" .65

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -3206,7 +3206,7 @@ ship "Star Queen"
 	thumbnail "thumbnail/star queen"
 	attributes
 		category "Space Liner"
-		"cost" 4500000
+		"cost" 4200000
 		"shields" 4100
 		"hull" 2200
 		"required crew" 33


### PR DESCRIPTION
The Star Queen is not a great ship: at 5.5 million credits hull price, it is the same cost as the Protector, and costs at least 1 million more than every medium warship. Fitting out the Protector with 11 bunk rooms (leaving it with 370 outfit space, 10 more than the Star Queen's total) gives it 113 total bunks versus the Star Queen's 112, which translates into even more passenger space due to the Protector's lower crew requirement. When putting in as many bunks as possible, the Star Queen has 151 passenger space, compared to the Protector's 193 and the Bastion's 131. (Both warships also have a large HP advantage, and the Bastion's hull only costs 3.8 million.) This PR increases the bunk efficiency of the Star Queen, so that it is a more worthwhile choice.

Changes:
- Decreased the Star Queen's crew requirement from 41 to 33. This increases the stock Star Queen passenger capacity from 69 to 77.
- Decreased the Star Queen's hull price from 5.5 million to 4.2 million. This means that the ship is on the level of mid/high-end medium warships, rather than low-end heavy warships.
