### PR TITLE
feat(UI): Support spreading settings across multiple pages

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -401,6 +401,19 @@ interface "settings"
 		dimensions 90 30
 		color medium
 		hover bright
+	visible if "show next"
+	sprite "ui/dialog cancel"
+		center -115 210
+	button n "_Next"
+		center -115 210
+		dimensions 70 30
+	visible if "show previous"
+	sprite "ui/wide button"
+		center -210 210
+	button r "P_revious"
+		center -210 210
+		dimensions 90 30
+	
 
 
 

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -397,6 +397,11 @@ interface "settings"
 		dimensions 90 30
 		color bright
 	button p "_Plugins"
+		center -300 -150
+		dimensions 90 30
+		color medium
+		hover bright
+	visible if "multiple pages"
 	sprite "ui/dialog cancel"
 		center -115 210
 	active if "show next"

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -397,19 +397,15 @@ interface "settings"
 		dimensions 90 30
 		color bright
 	button p "_Plugins"
-		center -300 -150
-		dimensions 90 30
-		color medium
-		hover bright
-	visible if "show next"
 	sprite "ui/dialog cancel"
 		center -115 210
+	active if "show next"
 	button n "_Next"
 		center -115 210
 		dimensions 70 30
-	visible if "show previous"
 	sprite "ui/wide button"
 		center -210 210
+	active if "show previous"
 	button r "P_revious"
 		center -210 210
 		dimensions 90 30

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -506,7 +506,7 @@ void PreferencesPanel::DrawSettings()
 			continue;
 		}
 		// Check if this setting is on the page being displayed.
-		// If this setting isn't on the page being displayed, check if it on an earlier page.
+		// If this setting isn't on the page being displayed, check if it is on an earlier page.
 		// If it is, continue to the next setting.
 		// Otherwise, this setting is on a later page,
 		// do not continue as no further settings are to be displayed.

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -502,7 +502,7 @@ void PreferencesPanel::DrawSettings()
 		// Check if this is a page break.
 		if(setting == "\n")
 		{
-			page++;
+			++page;
 			continue;
 		}
 		// Check if this setting is on the page being displaying.

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -63,7 +63,7 @@ namespace {
 	const string SHIP_OUTLINES = "Ship outlines in shops";
 
 	// How many pages of settings there are.
-	const int pageCount = 2;
+	const int pageCount = 1;
 }
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -87,9 +87,11 @@ void PreferencesPanel::Draw()
 
 	Information info;
 	info.SetBar("volume", Audio::Volume());
+	if(pageCount > 1)
+		info.SetCondition("multiple pages");
 	if(settingsPage > 0)
 		info.SetCondition("show previous");
-	if(pageCount > settingsPage + 1)
+	if(settingsPage + 1 < pageCount)
 		info.SetCondition("show next");
 	GameData::Interfaces().Get("menu background")->Draw(info, this);
 	string pageName = (page == 'c' ? "controls" : page == 's' ? "settings" : "plugins");

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -449,7 +449,7 @@ void PreferencesPanel::DrawSettings()
 
 	// An empty string indicates that a category has ended.
 	// A '\t' character indicates that the first column on this page has ended,
-	// and the next line should be drawn at the start of hte next column.
+	// and the next line should be drawn at the start of the next column.
 	// A '\n' character indicates that this page is complete, no further lines should be drawn on this page.
 	// In all three cases, the first non-special string will be considered the category heading
 	// and will be drawn differently to normal setting entries.

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -63,7 +63,7 @@ namespace {
 	const string SHIP_OUTLINES = "Ship outlines in shops";
 
 	// How many pages of settings there are.
-	const int pageCount = 1;
+	const int SETTINGS_PAGE_COUNT = 1;
 }
 
 
@@ -87,11 +87,11 @@ void PreferencesPanel::Draw()
 
 	Information info;
 	info.SetBar("volume", Audio::Volume());
-	if(pageCount > 1)
+	if(SETTINGS_PAGE_COUNT > 1)
 		info.SetCondition("multiple pages");
-	if(settingsPage > 0)
+	if(currentSettingsPage > 0)
 		info.SetCondition("show previous");
-	if(settingsPage + 1 < pageCount)
+	if(currentSettingsPage + 1 < SETTINGS_PAGE_COUNT)
 		info.SetCondition("show next");
 	GameData::Interfaces().Get("menu background")->Draw(info, this);
 	string pageName = (page == 'c' ? "controls" : page == 's' ? "settings" : "plugins");
@@ -130,10 +130,10 @@ bool PreferencesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comma
 		Exit();
 	else if(key == 'c' || key == 's' || key == 'p')
 		page = key;
-	else if((key == 'n' || key == SDLK_PAGEUP) && settingsPage < pageCount - 1)
-		++settingsPage;
-	else if((key == 'r' || key == SDLK_PAGEDOWN) && settingsPage > 0)
-		--settingsPage;
+	else if((key == 'n' || key == SDLK_PAGEUP) && currentSettingsPage < SETTINGS_PAGE_COUNT - 1)
+		++currentSettingsPage;
+	else if((key == 'r' || key == SDLK_PAGEDOWN) && currentSettingsPage > 0)
+		--currentSettingsPage;
 	else
 		return false;
 
@@ -510,9 +510,9 @@ void PreferencesPanel::DrawSettings()
 		// If it is, continue to the next setting.
 		// Otherwise, this setting is on a later page,
 		// do not continue as no further settings are to be displayed.
-		if(page < settingsPage)
+		if(page < currentSettingsPage)
 			continue;
-		else if(page > settingsPage)
+		else if(page > currentSettingsPage)
 			break;
 		// Check if this is a category break or column break.
 		if(setting.empty() || setting == "\t")

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -131,9 +131,9 @@ bool PreferencesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comma
 	else if(key == 'c' || key == 's' || key == 'p')
 		page = key;
 	else if((key == 'n' || key == SDLK_PAGEUP) && settingsPage < pageCount - 1)
-		settingsPage++;
+		++settingsPage;
 	else if((key == 'r' || key == SDLK_PAGEDOWN) && settingsPage > 0)
-		settingsPage--;
+		--settingsPage;
 	else
 		return false;
 
@@ -510,12 +510,10 @@ void PreferencesPanel::DrawSettings()
 		// If it is, continue to the next setting.
 		// Otherwise, this setting is on a later page,
 		// do not continue as no further settings are to be displayed.
-		if(page != settingsPage)
-		{
-			if(page < settingsPage)
-				continue;
+		if(page < settingsPage)
+			continue;
+		else if(page > settingsPage)
 			break;
-		}
 		// Check if this is a category break or column break.
 		if(setting.empty() || setting == "\t")
 		{

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -505,7 +505,7 @@ void PreferencesPanel::DrawSettings()
 			++page;
 			continue;
 		}
-		// Check if this setting is on the page being displaying.
+		// Check if this setting is on the page being displayed.
 		// If this setting isn't on the page being displayed, check if it on an earlier page.
 		// If it is, continue to the next setting.
 		// Otherwise, this setting is on a later page,

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -63,7 +63,7 @@ private:
 	char page = 'c';
 	std::string hoverPreference;
 
-	int settingsPage = 0;
+	int currentSettingsPage = 0;
 
 	std::string selectedPlugin;
 	std::string hoverPlugin;

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -63,6 +63,8 @@ private:
 	char page = 'c';
 	std::string hoverPreference;
 
+	int settingsPage = 0;
+
 	std::string selectedPlugin;
 	std::string hoverPlugin;
 


### PR DESCRIPTION
**Feature:**

## Feature Details
Settings can now be spread across multiple pages, navigated by dynamic `Next` and `Previous` buttons on the left of the bottom edge of the settings panel.
If there is only one page, the buttons will be totally hidden.
Else, both buttons will be visible, but one will be dimmed if there are no more pages in that drection.

## UI Screenshots
<details>
(Note: for the screenshots, I have moved the `Other` category to a new page, but this PR does not include that change.)

![image](https://user-images.githubusercontent.com/20605679/197405930-50a00ceb-4d01-4ca0-8460-8076c948367f.png)

![image](https://user-images.githubusercontent.com/20605679/197405919-c066fe1a-6f01-4e9c-8116-47633f1e5645.png)

</details>

## Testing Done
Open the settings, click the buttons, use the shortcut keys, get the expected behaviour.
