### PR TITLE
Block station and urban destinations for colony missions

### DIFF
--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -2168,7 +2168,7 @@ mission "Colonists [0]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest"
-		not attributes "station"
+		not attributes "station" "urban"
 		distance 2 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on visit
@@ -2192,7 +2192,7 @@ mission "Colonists [1]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest"
-		not attributes "station"
+		not attributes "station" "urban"
 		distance 4 30
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on visit
@@ -2217,7 +2217,7 @@ mission "Stranded Field Trip"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "near earth" "deep" "paradise" "urban"
-		not attributes "station"
+		not attributes "station" "urban"
 		distance 4 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on visit

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -2168,6 +2168,7 @@ mission "Colonists [0]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest"
+		not attributes "station"
 		distance 2 20
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on visit
@@ -2191,6 +2192,7 @@ mission "Colonists [1]"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
 		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest"
+		not attributes "station"
 		distance 4 30
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on visit
@@ -2214,8 +2216,9 @@ mission "Stranded Field Trip"
 		attributes "near earth" "deep" "paradise" "tourism"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
-		distance 4 16
 		attributes "near earth" "deep" "paradise" "urban"
+		not attributes "station"
+		distance 4 16
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	on visit
 		dialog phrase "generic passenger on visit"


### PR DESCRIPTION
**Bugfix:** This PR addresses the issue raised here:
https://discord.com/channels/251118043411775489/308902312741568512/1033844670217846794

Solution suggested by @MidnightPlugins.

## Fix Details
Adds `not attributes "station" "urban"` to each of the colony missions offered in human space.

## Testing Done
I haven't had a chance to test this yet.

## Save File
As far as I know, there's no way to test this with a save file (at least for me) as it's down to the RNG as to whether the bug appears in the first place.