### PR TITLE
fix(content): Added needed jump variants and put them in for HR

### DIFF
--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -884,7 +884,7 @@ mission "Hai Reveal [B12] Devil-Hide Battle"
 	npc accompany
 		government "Free Worlds"
 		personality escort heroic opportunistic
-		ship "Dreadnought (Jump)" "F.S. Ironwood"
+		ship "Dreadnought (Plasma Jump Keystone)" "F.S. Ironwood"
 
 	# The defenders waiting for you. There are 4 of them, and you have 5 competent allies, and 2 vulnerable allies.
 	# This shouldn't be hard, but the longer you take the greater the odds that another pirate ship returns from somewhere and complicates things.

--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -771,7 +771,7 @@ mission "Hai Reveal [B11] Moving Together"
 	npc save accompany
 		government "Navy (Oathkeeper)"
 		personality escort heroic opportunistic
-		ship "Cruiser (Plasma Anti-Missile)" "N.S. Peacemaker"
+		ship "Cruiser (Jump Plasma Anti-Missile)" "N.S. Peacemaker"
 	on complete
 		payment 600000
 		dialog `You are provided <payment> on arrival to cover ongoing expenses while helping out.`
@@ -876,11 +876,11 @@ mission "Hai Reveal [B12] Devil-Hide Battle"
 	npc save accompany
 		government "Navy (Oathkeeper)"
 		personality escort heroic opportunistic
-		ship "Cruiser (Plasma Anti-Missile)" "N.S. Peacemaker"
+		ship "Cruiser (Jump Plasma Anti-Missile)" "N.S. Peacemaker"
 	npc save accompany
 		government "Republic"
 		personality timid escort opportunistic
-		ship "Auxiliary (Transport)" "N.S. Braveheart"
+		ship "Auxiliary (Jump Transport)" "N.S. Braveheart"
 	npc accompany
 		government "Free Worlds"
 		personality escort heroic opportunistic
@@ -1078,7 +1078,7 @@ mission "Hai Reveal [B13] Freedom"
 	npc save accompany
 		government "Navy (Oathkeeper)"
 		personality escort heroic opportunistic
-		ship "Cruiser (Plasma Anti-Missile)" "N.S. Peacemaker"
+		ship "Cruiser (Jump Plasma Anti-Missile)" "N.S. Peacemaker"
 
 
 

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1178,6 +1178,28 @@ ship "Dreadnought" "Dreadnought (Plasma Blaster Anti-Missile)"
 		"LP144a Battery Pack"
 
 
+# Same as above but repurposed for Hai Reveal.
+ship "Dreadnought" "Dreadnought (Plasma Jump Keystone)"
+	outfits
+		"Heavy Anti-Missile Turret" 3
+		"Armageddon Core"
+		"S-970 Regenerator"
+		"Liquid Helium Cooler" 2
+		"Jump Drive"
+		"Volcano Afterburner"
+		Supercapacitor
+		"Outfits Expansion" 2
+		"Plasma Cannon" 4
+		"A520 Atomic Thruster"
+		"A525 Atomic Steering"
+		"Breeder Reactor"
+		"Quad Blaster Turret" 2
+		"Laser Rifle" 25
+		"Water Coolant System"
+		"S-270 Regenerator" 2
+		"LP144a Battery Pack"
+
+
 
 ship "Falcon" "Falcon (Heavy)"
 	outfits

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -121,6 +121,7 @@ ship "Auxiliary" "Auxiliary (Jump Transport)"
 		"X5200 Ion Steering"
 		"Jump Drive"
 		"Fuel Pod"
+		"Quantum Keystone"
 	gun -12 -186
 	gun 12.5 -186
 	turret 0 -74 "Heavy Anti-Missile Turret"
@@ -1128,6 +1129,7 @@ ship "Cruiser" "Cruiser (Jump Plasma Anti-Missile)"
 		"Fission Reactor"
 		"Laser Rifle" 20
 		"LP144a Battery Pack"
+		"Quantum Keystone"
 
 
 

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1198,6 +1198,7 @@ ship "Dreadnought" "Dreadnought (Plasma Jump Keystone)"
 		"Water Coolant System"
 		"S-270 Regenerator" 2
 		"LP144a Battery Pack"
+		"Quantum Keystone"
 
 
 

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -97,6 +97,43 @@ ship "Arrow" "Arrow (Hai)"
 
 
 
+ship "Auxiliary" "Auxiliary (Jump Transport)"
+	plural "Auxiliaries"
+	sprite "ship/auxiliaryt"
+	thumbnail "thumbnail/auxiliaryt"
+	add attributes
+		"bunks" 112
+		"cargo space" -200
+	outfits
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 90
+		"Quad Blaster Turret" 2
+		"Heavy Anti-Missile Turret" 2
+		"Fusion Reactor"
+		"LP288a Battery Pack"
+		"D94-YV Shield Generator"
+		"D67-TM Shield Generator"
+		"Water Coolant System"
+		"Large Radar Jammer"
+		"Ramscoop"
+		"X4700 Ion Thruster"
+		"X1700 Ion Thruster"
+		"X5200 Ion Steering"
+		"Jump Drive"
+		"Fuel Pod"
+	gun -12 -186
+	gun 12.5 -186
+	turret 0 -74 "Heavy Anti-Missile Turret"
+	turret 0 -17
+	turret 0 20
+	turret 0 78 "Heavy Anti-Missile Turret"
+	bay "Fighter" 0 -74
+	bay "Fighter" 0 -17
+	bay "Fighter" 0 20
+	bay "Fighter" 0 78
+
+
+
 ship "Bactrian" "Bactrian (Hai Engines)"
 	outfits
 		"Sidewinder Missile Launcher" 2
@@ -1053,7 +1090,7 @@ ship "Cruiser" "Cruiser (Mark II)"
 	turret "Heavy Anti-Missile Turret"
 
 
-# Used in the Hai Reveal campaign, Danforth pulls strings with the Free Worlds to get some cruisers equipped for deep-range deployment
+# Used in the Hai Reveal campaign, Danforth pulls strings with the Free Worlds to get some cruisers equipped for deep-range deployment.
 ship "Cruiser" "Cruiser (Plasma Anti-Missile)"
 	outfits
 		"Heavy Anti-Missile Turret" 3
@@ -1062,6 +1099,26 @@ ship "Cruiser" "Cruiser (Plasma Anti-Missile)"
 		"Liquid Helium Cooler" 2
 		"Catalytic Ramscoop"
 		Hyperdrive
+		Afterburner
+		"Outfits Expansion" 2
+		"Plasma Cannon" 6
+		"A520 Atomic Thruster"
+		"A525 Atomic Steering"
+		"Fragmentation Grenades" 20
+		"Fission Reactor"
+		"Laser Rifle" 20
+		"LP144a Battery Pack"
+
+
+# Danforth's personal ship in HR.
+ship "Cruiser" "Cruiser (Jump Plasma Anti-Missile)"
+	outfits
+		"Heavy Anti-Missile Turret" 3
+		"Armageddon Core"
+		"S-970 Regenerator"
+		"Liquid Helium Cooler" 2
+		"Catalytic Ramscoop"
+		"Jump Drive"
 		Afterburner
 		"Outfits Expansion" 2
 		"Plasma Cannon" 6


### PR DESCRIPTION
I'd overlooked making sure Danforth and the Auxiliary had jump drives. This should hopefully sort that out.