### PR TITLE
Add (hidden) preference to disable universal ramscoop

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -47,6 +47,8 @@ namespace {
 	// Enable standard VSync by default.
 	const vector<string> VSYNC_SETTINGS = {"off", "on", "adaptive"};
 	int vsyncIndex = 1;
+
+	bool universalRamscoop = true;
 }
 
 
@@ -90,6 +92,8 @@ void Preferences::Load()
 			vsyncIndex = max<int>(0, min<int>(node.Value(1), VSYNC_SETTINGS.size() - 1));
 		else if(node.Token(0) == "fullscreen")
 			screenModeIndex = max<int>(0, min<int>(node.Value(1), SCREEN_MODE_SETTINGS.size() - 1));
+		else if(node.Token(0) == "universal ramscoop")
+			universalRamscoop = node.Value(1);
 		else
 			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));
 	}
@@ -107,6 +111,7 @@ void Preferences::Save()
 	out.Write("scroll speed", scrollSpeed);
 	out.Write("view zoom", zoomIndex);
 	out.Write("vsync", vsyncIndex);
+	out.Write("universal ramscoop", universalRamscoop ? "1" : "0");
 
 	for(const auto &it : settings)
 		out.Write(it.first, it.second);
@@ -256,4 +261,18 @@ Preferences::VSync Preferences::VSyncState()
 const string &Preferences::VSyncSetting()
 {
 	return VSYNC_SETTINGS[vsyncIndex];
+}
+
+
+
+void Preferences::ToggleUniversalRamscoop()
+{
+	universalRamscoop = !universalRamscoop;
+}
+
+
+
+bool Preferences::UniversalRamscoop()
+{
+	return universalRamscoop;
 }

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -59,6 +59,9 @@ public:
 	static bool ToggleVSync();
 	static Preferences::VSync VSyncState();
 	static const std::string &VSyncSetting();
+
+	static void ToggleUniversalRamscoop();
+	static bool UniversalRamscoop();
 };
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -61,6 +61,7 @@ namespace {
 	const string SCROLL_SPEED = "Scroll speed";
 	const string FIGHTER_REPAIR = "Repair fighters in";
 	const string SHIP_OUTLINES = "Ship outlines in shops";
+	const string UNIVERSAL_RAMSCOOP = "Universal ramscoop";
 }
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -61,7 +61,6 @@ namespace {
 	const string SCROLL_SPEED = "Scroll speed";
 	const string FIGHTER_REPAIR = "Repair fighters in";
 	const string SHIP_OUTLINES = "Ship outlines in shops";
-	const string UNIVERSAL_RAMSCOOP = "Universal ramscoop";
 }
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -61,6 +61,7 @@ namespace {
 	const string SCROLL_SPEED = "Scroll speed";
 	const string FIGHTER_REPAIR = "Repair fighters in";
 	const string SHIP_OUTLINES = "Ship outlines in shops";
+	const string UNIVERSAL_RAMSCOOP = "Universal ramscoop";
 }
 
 
@@ -578,6 +579,11 @@ void PreferencesPanel::DrawSettings()
 		{
 			isOn = true;
 			text = to_string(Preferences::ScrollSpeed());
+		}
+		else if(setting == UNIVERSAL_RAMSCOOP)
+		{
+			isOn = Preferences::UniversalRamscoop();
+			text = isOn ? "on" : "off";
 		}
 		else
 			text = isOn ? "on" : "off";

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -51,6 +51,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
+	const bool UNIVERSAL_RAMSCOOP = !Preferences::Has("Disable universal ramscoop");
+
 	const string FIGHTER_REPAIR = "Repair fighters in";
 	const vector<string> BAY_SIDE = {"inside", "over", "under"};
 	const vector<string> BAY_FACING = {"forward", "left", "right", "back"};
@@ -2328,7 +2330,7 @@ void Ship::DoGeneration()
 		if(currentSystem)
 		{
 			double scale = .2 + 1.8 / (.001 * position.Length() + 1);
-			fuel += currentSystem->SolarWind() * .03 * scale * (sqrt(attributes.Get("ramscoop")) + .05 * scale);
+			fuel += currentSystem->SolarWind() * .03 * scale * (sqrt(attributes.Get("ramscoop")) + (UNIVERSAL_RAMSCOOP * .05 * scale));
 
 			double solarScaling = currentSystem->SolarPower() * scale;
 			// Overheated ships produce half as much energy from solar collection.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -51,8 +51,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	const bool UNIVERSAL_RAMSCOOP = !Preferences::Has("Disable universal ramscoop");
-
 	const string FIGHTER_REPAIR = "Repair fighters in";
 	const vector<string> BAY_SIDE = {"inside", "over", "under"};
 	const vector<string> BAY_FACING = {"forward", "left", "right", "back"};
@@ -2330,7 +2328,7 @@ void Ship::DoGeneration()
 		if(currentSystem)
 		{
 			double scale = .2 + 1.8 / (.001 * position.Length() + 1);
-			fuel += currentSystem->SolarWind() * .03 * scale * (sqrt(attributes.Get("ramscoop")) + ((UNIVERSAL_RAMSCOOP ? 1. : 0.) * .05 * scale));
+			fuel += currentSystem->SolarWind() * .03 * scale * (sqrt(attributes.Get("ramscoop")) + ((Preferences::UniversalRamscoop() ? 1. : 0.) * .05 * scale));
 
 			double solarScaling = currentSystem->SolarPower() * scale;
 			// Overheated ships produce half as much energy from solar collection.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2330,7 +2330,7 @@ void Ship::DoGeneration()
 		if(currentSystem)
 		{
 			double scale = .2 + 1.8 / (.001 * position.Length() + 1);
-			fuel += currentSystem->SolarWind() * .03 * scale * (sqrt(attributes.Get("ramscoop")) + (UNIVERSAL_RAMSCOOP * .05 * scale));
+			fuel += currentSystem->SolarWind() * .03 * scale * (sqrt(attributes.Get("ramscoop")) + ((UNIVERSAL_RAMSCOOP ? 1. : 0.) * .05 * scale));
 
 			double solarScaling = currentSystem->SolarPower() * scale;
 			// Overheated ships produce half as much energy from solar collection.


### PR DESCRIPTION
**Feature:** This is an alternative to #7460

## Feature Details
Adds support for a player to set:
`"Disable universal ramscoop" 1`
In their preferences file to disable the universal ramscoop all ships have.

## Testing Done
I'll let you know in a few minutes.

## Performance Impact
Should not be noteworthy.
