### PR TITLE
fix(internal): calling `back()` on an empty string

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -292,7 +292,7 @@ void Outfit::Load(const DataNode &node)
 	// Unless this outfit definition isn't declared with the `outfit` keyword,
 	// because then this is probably being done in `add attributes` on a ship,
 	// so the name doesn't matter.
-	if(pluralName.empty())
+	if(!name.empty() && pluralName.empty())
 	{
 		pluralName = name + 's';
 		if((name.back() == 's' || name.back() == 'z') && node.Token(0) == "outfit")


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
While investigating an issue, I discovered a static assertion failing where `.back()` was being called on an empty string.
That call was occurring in `Outfit::Load()` following https://github.com/endless-sky/endless-sky/commit/7eb2186e77a08d64848a8c3a4aedd108a0de6ce4. I suspect it is when a `Ship` calls `Outfit::Load()` and passes it its `attributes` node which will leave the `name` of the `Outfit` empty.

## Testing Done
Build Debug using @quyykk's Visual Studio project and run. Without this addition, a runtime error will occur while loading. With it, no such error is present.
