### PR TITLE
Fix weapons on captured ships being inoperable until reload

### DIFF
--- a/source/Bitset.cpp
+++ b/source/Bitset.cpp
@@ -87,6 +87,15 @@ void Bitset::Set(size_t index) noexcept
 
 
 
+// Resets all bits in the bitset.
+void Bitset::Reset() noexcept
+{
+	for(auto &it : bits)
+		it = uint64_t(0);
+}
+
+
+
 // Whether any bits are set.
 bool Bitset::Any() const noexcept
 {

--- a/source/Bitset.h
+++ b/source/Bitset.h
@@ -42,6 +42,8 @@ public:
 	bool Test(size_t index) const noexcept;
 	// Sets the bit at the specified index.
 	void Set(size_t index) noexcept;
+	// Resets all bits in the bitset.
+	void Reset() noexcept;
 	// Whether any bits are set.
 	bool Any() const noexcept;
 	// Whether no bits are set.

--- a/source/FireCommand.cpp
+++ b/source/FireCommand.cpp
@@ -59,8 +59,9 @@ void FireCommand::UpdateWith(const FireCommand &other) noexcept
 // Reset this to an empty command.
 void FireCommand::Clear()
 {
-	weapon.Clear();
-	aim.clear();
+	weapon.Reset();
+	for(auto &it : aim)
+		it = '\0';
 }
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7458

Thanks to @quyykk for pointing me to this ~~after I already bisected 0.9.15 and 0.9.16 to find the commit that created the issue.~~

## Fix Details
This issue was introduced by bc586bd20fe9ae770dab048c131697fb957d50f6.
It was clearing the `weapon` Bitset and aim vector of FireCommand, making them empty (no elements).
This means it is not possible to have any weapons fire.
This PR removes the old commands by resetting every element of the two collections to their initial values, indicating no command.

## Testing Done
Capture a ship with any commit from the one creating this bug onwards and it will not fire its weapons and you will not be able to fire its weapons until reloading. With this PR, weapons can be fired immediately, without reloading, like before the bug was introduced.

Co-authored-by: Nick <quyykk@protonmail.com>
