### PR TITLE
Two small improvements to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ This save file can be used to play through the new mission content:
 
 
 -----------------------
-**Bugfix:** This PR fixes #{{insert number}}
+**Bugfix:** This PR addresses issue #{{insert number}}
 
 ## Fix Details
 {{add details}}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,12 +13,12 @@ This save file can be used to play through the new mission content:
 
 ## Artwork Checklist
  - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
- - [ ] I created a PR to the [endless-sky-assets repo](https://github.com/EndlessSkyCommunity/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}
+ - [ ] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}
  - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}
 
 
 -----------------------
-**Bugfix:** This PR addresses issue #{{insert number}}
+**Bugfix:** This PR fixes #{{insert number}}
 
 ## Fix Details
 {{add details}}


### PR DESCRIPTION
This PR does the following:

- Uses "fixes" in the bug fix section so that GitHub automatically links the issue specified
- Updates the link to the asset repo

This is a draft because the asset repo hasn't been moved yet.