### PR TITLE
Make the log after taking drugs trigger properly

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -910,19 +910,19 @@ mission "Hallucination"
 			`	The room begins to spin, and strange things happen...`
 				launch
 	
+	on accept
+		log `Agreed to transport illegal drugs. Tried some of them while refueling and instantly regretted it. The sky truly is endless.`
+	
 	on defer
 		"teetotalar" ++
 	
-	npc save
+	npc kill
 		government "Bad Trip"
 		personality nemesis heroic
 		ship "Hallucination" "Love"
 		ship "Hallucination" "Peace"
 		ship "Hallucination" "Happy"
 		ship "Hallucination" "Shiny"
-		
-	on fail
-		log `Agreed to transport illegal drugs. Tried some of them while refueling and instantly regretted it. The sky truly is endless.`
 
 
 

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -898,7 +898,7 @@ mission "Hallucination"
 	to offer
 		has "Drug Running 2: active"
 		random < 50
-		"teetotalar" < 3
+		"teetotaler" < 3
 	
 	on offer
 		conversation
@@ -914,7 +914,7 @@ mission "Hallucination"
 		log `Agreed to transport illegal drugs. Tried some of them while refueling and instantly regretted it. The sky truly is endless.`
 	
 	on defer
-		"teetotalar" ++
+		"teetotaler" ++
 	
 	npc kill
 		government "Bad Trip"

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -898,6 +898,7 @@ mission "Hallucination"
 	to offer
 		has "Drug Running 2: active"
 		random < 50
+		"teetotalar" < 3
 	
 	on offer
 		conversation
@@ -909,7 +910,10 @@ mission "Hallucination"
 			`	The room begins to spin, and strange things happen...`
 				launch
 	
-	npc kill
+	on defer
+		"teetotalar" ++
+	
+	npc save
 		government "Bad Trip"
 		personality nemesis heroic
 		ship "Hallucination" "Love"
@@ -917,7 +921,7 @@ mission "Hallucination"
 		ship "Hallucination" "Happy"
 		ship "Hallucination" "Shiny"
 		
-	on complete
+	on fail
 		log `Agreed to transport illegal drugs. Tried some of them while refueling and instantly regretted it. The sky truly is endless.`
 
 


### PR DESCRIPTION
Moves the log after taking drugs from being generated when "completing" the mission to when accepting it, so that the player doesn't need to land back on the same planet. Also made the job stop offering after refusing enough times.