### PR TITLE
Standardise formatting of old transport missions

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -12,7 +12,7 @@
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
 mission "Immigrant Workers"
-	description "This young couple wants to start a new life on <destination>."
+	description "A young couple wants to start a new life on <destination>, and can pay you <payment> to bring them there. They are also bringing along <cargo>."
 	minor
 	passengers 2
 	cargo "luggage and furniture" 2
@@ -29,17 +29,17 @@ mission "Immigrant Workers"
 		log "Minor People" "George and Samantha" `George and Samantha used to work on New Iceland before they decided to leave due to Samantha's conditions.`
 	on offer
 		conversation
-			"As you leave your ship and walk toward the cafeteria at the center of the spaceport, you notice a young couple standing near the edge of the landing area next to a cart loaded high with a jumble of boxes and furniture. Like many of the locals, they are both wearing dust masks over their mouths, and the woman is also wearing goggles."
+			`As you leave your ship and walk toward the cafeteria at the center of the spaceport, you notice a young couple standing near the edge of the landing area next to a cart loaded high with a jumble of boxes and furniture. Like many of the locals, they are both wearing dust masks over their mouths, and the woman is also wearing goggles.`
 			choice
-				"	(Talk to them.)"
-				"	(Ignore them.)"
+				`	(Talk to them.)`
+				`	(Ignore them.)`
 					decline
-			"	The couple introduces themselves as George and Samantha. As you shake hands with them, you notice that Samantha's eyes under the goggles are rimmed in red, and she keeps coughing quietly: a dry, careful cough. George explains that they came here several years ago to take jobs in the factories, but the volcanic fumes have been giving Samantha trouble ever since they arrived. They will pay for transport for themselves and their household goods to <destination>."
+			`	The couple introduces themselves as George and Samantha. As you shake hands with them, you notice that Samantha's eyes under the goggles are rimmed in red, and she keeps coughing quietly: a dry, careful cough. George explains that they came here several years ago to take jobs in the factories, but the volcanic fumes have been giving Samantha trouble ever since they arrived. They can pay <payment> for transport for themselves and <tons> of household goods to <destination>.`
 			choice
-				"	(Accept.)"
-				"	(Decline.)"
+				`	(Accept.)`
+				`	(Decline.)`
 					decline
-			"	They thank you for your assistance, and you give them a hand pushing the heavy cart into your cargo bay."
+			`	They thank you for your assistance, and you give them a hand pushing the heavy cart into your cargo bay.`
 				accept
 	on visit
 		dialog phrase "generic cargo and passenger on visit"
@@ -115,7 +115,7 @@ mission "Pookie, Part 2"
 
 mission "Smuggler's Den, Part 1"
 	name "Refugees to <planet>"
-	description "You met Joe and Maria, a young couple with a newborn baby, on the Smuggler's Den station. They want to start a new life on <destination>."
+	description "Joe and Maria, a young couple with a newborn baby, want to escape slavery and start a new life on <destination>."
 	minor
 	source "Smuggler's Den"
 	destination "Arabia"
@@ -191,7 +191,7 @@ mission "Smuggler's Den, Part 1"
 mission "Smuggler's Den, Part 2"
 	landing
 	name "Refugees to <planet>"
-	description "Joe and Maria were unable to find work on <origin>. Take them to <destination> to see if they can get a job there."
+	description "Unable to find work on <origin>, Joe and Maria want to travel to <destination> to see if they can get a job there."
 	destination "Millrace"
 	passengers 2
 	to offer
@@ -264,7 +264,7 @@ mission "Smuggler's Den: Follow Up"
 
 mission "Expedition to Hope 1"
 	name "Expedition to Hope"
-	description "Transport a team of scientists to the abandoned world of <planet>, where they will be placing some meteorological equipment."
+	description "Transport a team of <bunks> scientists to the abandoned world of <planet>, where they will be placing <tons> of meteorological equipment. Payment will be 80,000 credits."
 	minor
 	source
 		near Wei 2 8
@@ -277,7 +277,7 @@ mission "Expedition to Hope 1"
 	
 	on offer
 		conversation
-			`A group of scientists approaches you and asks if you would be willing to take them to the abandoned planet of Hope, and then back home from there. "The transport we'd arranged for bailed out on us at the last moment," says their leader, a middle-aged man wearing thick-rimmed glasses.`
+			`A group of <bunks> scientists approaches you and asks if you would be willing to take them and <cargo> to the abandoned planet of Hope, and then back home from there. "The transport we'd arranged for bailed out on us at the last moment," says their leader, a middle-aged man wearing thick-rimmed glasses. "We have 80,000 credits allocated for payment."`
 			choice
 				`	"Sure, I'd be glad to help."`
 					goto yes
@@ -304,7 +304,7 @@ mission "Expedition to Hope 1"
 mission "Expedition to Hope 2"
 	landing
 	name "Expedition to Hope"
-	description "Transport the team of scientists home to <destination>."
+	description "Transport the team of <bunks> scientists home to <destination>, to receive the second half of payment."
 	source Hope
 	destination
 		distance 2 5
@@ -329,7 +329,7 @@ mission "Expedition to Hope 2"
 
 mission "Transport Workers A"
 	name "Transport Family"
-	description "Transport this family to <destination>, where they hope that steady work will be easier to come by."
+	description "Transport a family of <bunks>, as well as <cargo>, to <destination>, where they hope that steady work will be easier to come by. Payment is <payment>."
 	minor
 	source
 		attributes "dirt belt"
@@ -342,7 +342,7 @@ mission "Transport Workers A"
 	cargo "household goods" 2
 	
 	on offer
-		dialog `In one of the corners of the spaceport, you meet a family with two kids, and a pile of trunks and boxes spread out next to them. They tell you that they are trying to book passage to <planet>. "Work has gotten way too hard to come by here," explains the father. "I've had seven different jobs in the past year, and none of them lasted more than a month. So we thought we'd try our luck on a Syndicate world."`
+		dialog `In one of the corners of the spaceport, you meet a family with two kids, and a pile of trunks and boxes spread out next to them. They tell you that they are trying to book passage to <planet>. "Work has gotten way too hard to come by here," explains the father. "I've had seven different jobs in the past year, and none of them lasted more than a month. So we thought we'd try our luck on a Syndicate world. We can pay you <payment> for the trouble."`
 	
 	on visit
 		dialog phrase "generic cargo and passenger on visit"
@@ -372,7 +372,7 @@ mission "Transport Workers B"
 				`	"You're traveling all by yourself? You aren't in any trouble, I hope?"`
 				`	"Sorry, I don't expect to be headed that way any time soon."`
 					decline
-			`	"Well, here's the story," he says. "My girlfriend's father won't let us get married until I have some money saved up. They say there's plenty of jobs to be had on <planet>. So I'm headed there to put down roots and get myself established, then in a year or two she can come and join me."`
+			`	"Well, here's the story," he says. "My girlfriend's father won't let us get married until I have some money saved up. They say there's plenty of jobs to be had on <planet>. So I'm headed there to put down roots and get myself established, then in a year or two she can come and join me. Don't worry, I have <payment> that I can give to you."`
 			choice
 				`	"I'd be glad to take you there."`
 					goto thanks
@@ -408,7 +408,7 @@ mission "Transport Workers B"
 
 mission "Transport Workers C"
 	name "Farming Family"
-	description "Transport this family of farmers, and their livestock, to <destination>."
+	description "Transport this family of <bunks> farmers and <tons> of livestock, to <destination>. Payment is <payment>."
 	minor
 	source
 		attributes "dirt belt"
@@ -423,12 +423,12 @@ mission "Transport Workers C"
 	
 	on offer
 		conversation
-			`On the dirt near your landing pad is parked a large wagon, hitched to a draft horse and loaded down with furniture and various farming implements. A family is gathered in the shade of the cart, and several goats and sheep are tied up behind it. Do you approach them and find out where they are headed?`
+			`On the dirt near your landing pad is parked a large wagon, hitched to a draft horse and loaded down with furniture and various farming implements. A family is gathered in the shade of the cart, and several goats and sheep are tied up behind it.`
 			choice
-				`	(Yes.)`
-				`	(No, I'm not interested in carrying livestock in my shiny new space ship.)`
+				`	(Approach the farmers.)`
+				`	(I'm not interested in carrying livestock in my shiny new space ship.)`
 					defer
-			`	The farmers introduce themselves as Jim and Annette Patterson; their kids are Erin, Kyle, and Sarah. "Any chance you've got space for some livestock?" asks Jim. "The droughts the last few years have been fierce, and we're hoping to start a new homestead on <planet>."`
+			`	The farmers introduce themselves as Jim and Annette Patterson; their kids are Erin, Kyle, and Sarah. "Any chance you've got space for <tons> of livestock?" asks Jim. "The droughts the last few years have been fierce, and we're hoping to start a new homestead on <planet>. We have <payment> saved for payment."`
 			choice
 				`	"Sure, I'd be glad to take you there."`
 					accept
@@ -447,7 +447,7 @@ mission "Transport Workers C"
 
 mission "WR Star 1"
 	name "Star Research"
-	description "Fly through the <waypoints> system with this team of scientists, then return them to <destination>."
+	description "Fly through the <waypoints> system with a team of <bunks> scientists and <cargo>, then return them to <destination>."
 	minor
 	source
 		attributes "deep"
@@ -459,7 +459,7 @@ mission "WR Star 1"
 	cargo "sensors" 2
 	
 	on offer
-		dialog `A group of scientists approaches you and asks if you will be headed to the Rim any time soon. "We're doing research on Wolf-Rayet stars," they explain, "and we're hoping to find a captain who can do a fly-by of <waypoints>." Scientific research in the Deep is notoriously well-funded, so they will probably pay you quite well.`
+		dialog `A group of <bunks> scientists approaches you and asks if you will be headed to the Rim any time soon. "We're doing research on Wolf-Rayet stars," they explain, "and we're hoping to find a captain who can do a fly-by of <waypoints>." Scientific research in the Deep is notoriously well-funded, so they will probably pay you quite well.`
 	
 	on visit
 		dialog phrase "generic missing waypoint or cargo and passengers"
@@ -489,7 +489,7 @@ mission "There Might Be Riots 1"
 				`	"What is it?"`
 				`	"Not right now."`
 					defer
-			`	"My name is Becca," she says. "I'm a stage manager for a band, and the transport we had under contract bailed out on us. Any chance you could take us to <destination>? Given the circumstances, we can pay quite well."`
+			`	"My name is Becca," she says. "I'm a stage manager for a band, and the transport we had under contract bailed out on us. Any chance you could take <fare> and <tons> of cargo to <destination>? Given the circumstances, we can pay quite well."`
 			choice
 				`	"Sure!"`
 				`	"Sorry, I'm not headed in that direction right now."`
@@ -750,7 +750,7 @@ mission "There Might Be Riots part 3B"
 
 mission "Drug Running 1"
 	name "Drug Running"
-	description "Bring a shipment of illegal drugs to <destination>. Payment will be <payment>. If you are caught with this cargo, you may be fined."
+	description "Bring a shipment of <cargo> to <destination>. Payment will be <payment>. If you are caught with this cargo, you may be fined."
 	minor
 	repeat
 	source
@@ -766,7 +766,7 @@ mission "Drug Running 1"
 		"said no to drugs" < 4
 	
 	on offer
-		dialog `As you are walking through the spaceport, a man pulls you aside and asks if you would like to help transport some "recreational pharmaceuticals" to <planet> for <payment>. (This sounds like an illegal mission, so you'll need to avoid getting scanned or landing on planets with high security.)`
+		dialog `As you are walking through the spaceport, a man pulls you aside and asks if you would like to help transport <tons> of "recreational pharmaceuticals" to <planet> for <payment>. (This sounds like an illegal mission, so you'll need to avoid getting scanned or landing on planets with high security.)`
 	
 	on accept
 		"said no to drugs" --
@@ -785,7 +785,7 @@ mission "Drug Running 1"
 
 mission "Drug Running 2"
 	name "Drug Running"
-	description "Bring a shipment of illegal drugs to <destination>. Payment will be <payment>. If you are caught with this cargo, you may be fined."
+	description "Bring a shipment of <cargo> to <destination>. Payment will be <payment>. If you are caught with this cargo, you may be fined."
 	minor
 	repeat
 	source
@@ -801,7 +801,7 @@ mission "Drug Running 2"
 		has "Drug Running 1: done"
 	
 	on offer
-		dialog `When you walk into the local bar, a man sitting in the corner waves you over and says in a hushed voice, "Captain, we've got a shipment of the good stuff that needs to get to <planet>. I promise you this will be a very lucrative operation. What do you say?"`
+		dialog `When you walk into the local bar, a man sitting in the corner waves you over and says in a hushed voice, "Captain, we've got <tons> of the good stuff that needs to get to <planet>. I promise you this will be a very lucrative operation. What do you say?"`
 	
 	on visit
 		dialog phrase "generic cargo on visit"
@@ -815,7 +815,7 @@ mission "Drug Running 2"
 
 mission "Drug Running 3"
 	name "Drug Running"
-	description "Bring a shipment of illegal drugs to <destination>. Payment will be <payment>. If you are caught with this cargo, you may be fined."
+	description "Bring a shipment of <cargo> to <destination>. Payment will be <payment>. If you are caught with this cargo, you may be fined."
 	minor
 	repeat
 	source
@@ -1191,7 +1191,7 @@ mission "Shady passenger transport 3 - double cross big payment"
 
 
 mission "Rescue Miners 1"
-	description "Participate in the medical evacuation of some miners injured in a recent accident on <planet>."
+	description "Participate in the medical evacuation of miners injured on <planet> by bringing <bunks> emergency workers and <cargo> to the planet."
 	name "Rescue Miners"
 	minor
 	source
@@ -1207,7 +1207,7 @@ mission "Rescue Miners 1"
 		random < 60
 	
 	on offer
-		dialog `You've just sat down in the spaceport bar and ordered a drink when someone in uniform runs into the room and shouts, "There's been a mine explosion on <planet>! We need all available ships to carry relief workers and supplies and to evacuate the injured to a world where there are better medical facilities." Do you volunteer?`
+		dialog `You've just sat down in the spaceport bar and ordered a drink when someone in uniform runs into the room and shouts, "There's been a mine explosion on <planet>! We need all available ships to carry relief workers and supplies and to evacuate the injured to a world where there are better medical facilities."`
 	on visit
 		dialog phrase "generic cargo and passenger on visit"
 
@@ -1215,7 +1215,7 @@ mission "Rescue Miners 1"
 
 mission "Rescue Miners 2"
 	landing
-	description "Participate in the medical evacuation of some miners injured in a recent accident on <origin>."
+	description "Participate in the medical evacuation of miners injured on <origin> by bringing <bunks> passengers to the medical facilities on <destination>."
 	name "Rescue Miners"
 	destination
 		attributes "core"
@@ -1251,7 +1251,7 @@ mission "Courier 1"
 		distance 4 10
 		government "Republic" "Free Worlds" "Syndicate" "Quarg" "Neutral"
 	on offer
-		dialog `As you are walking through the spaceport, a man approaches you and says, "Excuse me, Captain. I took on a rush delivery to <planet>, but my ship needs repairs and there's no way I can make it there before <day>. Can you take this job for me? The payment for the job is <payment>."`
+		dialog `As you are walking through the spaceport, a man approaches you and says, "Excuse me, Captain. I took on a rush delivery of <cargo> to <planet>, but my ship needs repairs and there's no way I can make it there before <day>. Can you take this job for me? The payment for the job is <payment>."`
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
@@ -1307,7 +1307,7 @@ mission "Courier 2"
 	name "Package to <planet>"
 	repeat
 	deadline
-	description "Deliver a package to <destination> by <date>. Payment is <payment>."
+	description "Deliver a package weighing <tons> to <destination> by <date>. Payment is <payment>."
 	minor
 	cargo package 2
 	to offer
@@ -1331,7 +1331,7 @@ mission "Courier 2"
 mission "Courier 3"
 	name "Papers to <planet>"
 	deadline
-	description "Deliver some legal papers to <destination> by <date>. Payment is <payment>."
+	description "Deliver <tons> of legal papers to <destination> by <date>. Payment is <payment>."
 	minor
 	cargo "legal papers" 1
 	to offer
@@ -1354,7 +1354,7 @@ mission "Courier 3"
 mission "Courier 4"
 	name "Lizard to <planet>"
 	deadline
-	description "Deliver an exotic pet to <destination> by <date>. Payment is <payment>."
+	description "Deliver an exotic pet (weighing <tons>) to <destination> by <date>. Payment is <payment>."
 	minor
 	cargo "exotic lizard" 3
 	to offer
@@ -1372,7 +1372,7 @@ mission "Courier 4"
 				`	(Find out what he wants.)`
 				`	(Ignore him.)`
 					decline
-			`	"My name is Alphonse," he says. "I am a breeder of exotic lizards. A new client on <planet> has just ordered one, and will pay you quite handsomely to transport it. Naturally, being a live animal, it's a rush delivery; it needs to be done by <day>. What do you say?"`
+			`	"My name is Alphonse," he says. "I am a breeder of exotic lizards. A new client on <planet> has just ordered one, and will pay you <payment> to transport it. Naturally, being a live animal, it's a rush delivery; it needs to be done by <day>. What do you say?"`
 			choice
 				`	"I'd be glad to."`
 				`	"Sorry, I'm not interested in that sort of work."`
@@ -1391,7 +1391,7 @@ mission "Courier 4"
 
 mission "Migrant Workers 1"
 	name "Migrant Workers"
-	description "Bring this group of migrant workers to <planet>."
+	description "Bring a group of <bunks> migrant workers to <planet>. Payment is <payment>."
 	minor
 	passengers 6 7
 	source
@@ -1409,7 +1409,7 @@ mission "Migrant Workers 1"
 				`	(Approach them.)`
 				`	(Ignore them.)`
 					defer
-			`	You strike up a conversation with the workers. They say that they are tired of the seasonal fluctuations of farm work, and are looking for something a bit steadier and better paying. "We hear there's always work to be had in the mines on <planet>," they say. "Can you take us there?"`
+			`	You strike up a conversation with the workers. They say that they are tired of the seasonal fluctuations of farm work, and are looking for something a bit steadier and better paying. "We hear there's always work to be had in the mines on <planet>," they say. "Can you take us there? We've pooled together our savings, and can pay you <payment>."`
 			choice
 				`	"Sure!"`
 					accept
@@ -1427,7 +1427,7 @@ mission "Migrant Workers 1"
 
 mission "Humanitarian 1"
 	name "Vaccine to <planet>"
-	description "Bring a shipment of flu vaccines to the lawless world of <planet>. Be sure the medicine gets into the right hands."
+	description "Bring <tons> of flu vaccines to the lawless world of <planet>. Be sure the medicine gets into the right hands."
 	minor
 	cargo "vaccine" 20
 	to offer
@@ -1467,7 +1467,7 @@ mission "Humanitarian 1"
 
 mission "Humanitarian 2"
 	name "Food to <planet>"
-	description "Bring a shipment of food to the lawless world of <planet>, to help alleviate a famine."
+	description "Bring <tons> of food to the lawless world of <planet>, to help alleviate a famine."
 	minor
 	cargo "emergency rations" 50
 	to offer
@@ -1507,7 +1507,7 @@ mission "Humanitarian 2"
 
 mission "Terraforming 1"
 	name "Terraforming Rand"
-	description "Bring a delegation from Rand to the Academy of Planetary Sciences on Glory."
+	description "Bring a delegation of two people from Rand to the Academy of Planetary Sciences on Glory."
 	minor
 	source "Rand"
 	destination "Glory"
@@ -1540,7 +1540,7 @@ mission "Terraforming 1"
 mission "Terraforming 2"
 	landing
 	name "Terraforming Rand"
-	description "Return to Rand with a student who thinks she can terraform the planet cheaply."
+	description "Return to Rand with the delegation and a student who thinks she can terraform the planet cheaply."
 	source "Glory"
 	destination "Rand"
 	passengers 3
@@ -1654,7 +1654,7 @@ mission "Terraforming 3"
 
 mission "Terraforming 4"
 	name "Terraforming Rand"
-	description "Collect some hardy plants that can grow in a low-light environment from <destination>."
+	description "Bring Amy to <destination> to collect some hardy plants that can grow in a low-light environment."
 	source "Rand"
 	destination "New Portland"
 	to offer
@@ -1681,7 +1681,7 @@ mission "Terraforming 4"
 
 mission "Terraforming 5"
 	name "Terraforming Rand"
-	description "Bring some hardy plants that can grow in a low-light environment back to <destination>."
+	description "Bring Amy and <tons> of hardy plants that can grow in a low-light environment back to <destination>."
 	source "New Portland"
 	destination "Rand"
 	to offer
@@ -2554,7 +2554,7 @@ mission "Paradise Fortune 4"
 mission "Northern Blockade"
 	minor
 	name `Mebsuta Disaster`
-	description `<destination> is under attack by pirates. Assist the Republic by delivering <commodity> to the planet as soon as possible.`
+	description `<destination> is under attack by pirates. Assist the Republic by delivering <cargo> to the planet as soon as possible.`
 	source
 		near "Mebsuta" 2 4
 	destination "Featherweight"
@@ -2603,7 +2603,7 @@ mission "Northern Blockade"
 mission "Southern Blockade"
 	minor
 	name `Spaceport Defenses`
-	description `<stopovers> are under attack and in need of spaceport defenses. Drop off your cargo on these three planets and return to <destination> for payment.`
+	description `<stopovers> are under attack and in need of spaceport defenses. Drop off your cargo of <cargo> on these three planets and return to <destination> for payment. (<payment)`
 	source
 		near "Pherkad" 2 4
 		government "Free Worlds"

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -2603,7 +2603,7 @@ mission "Northern Blockade"
 mission "Southern Blockade"
 	minor
 	name `Spaceport Defenses`
-	description `<stopovers> are under attack and in need of spaceport defenses. Drop off your cargo of <cargo> on these three planets and return to <destination> for payment. (<payment)`
+	description `<stopovers> are under attack and in need of spaceport defenses. Drop off your cargo of <cargo> on these three planets and return to <destination> for payment. (<payment>)`
 	source
 		near "Pherkad" 2 4
 		government "Free Worlds"


### PR DESCRIPTION
The descriptions of the old transport missions are somewhat messy; many don't specify what exactly you're carrying, or what the payment is. This PR updates those descriptions to specify as such, and also slightly changes the "on offer" text to mention the cargo/passenger space needed, as well as the payment.