### PR TITLE
Inform the player if they lose their jump drive during FW

### DIFF
--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -1324,9 +1324,9 @@ mission "FW Pug Jump Drive Check"
 	landing
 	to offer
 		has "fw given jump drive"
-		not "event: pug territory liberated"
+		not "outfit (all): Jump Drive"
+		not "event: reconnected delta capricorni"
 	on offer
-		require "Jump Drive" 0
 		conversation
 			`Somehow, you've misplaced or lost the jump drive needed to continue the Free Worlds story! If you are unable to find your jump drive, you should revert to the autosave or another earlier snapshot of the game.`
 				decline

--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -1320,6 +1320,19 @@ mission "FW Pug 2C: A Jump Drive"
 
 
 
+mission "FW Pug Jump Drive Check"
+	landing
+	to offer
+		has "fw given jump drive"
+		not "event: pug territory liberated"
+	on offer
+		require "Jump Drive" 0
+		conversation
+			`Somehow, you've misplaced or lost the jump drive needed to continue the Free Worlds story! If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
+				decline
+
+
+
 mission "FW Pug 2C: Side"
 	landing
 	source

--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -1328,7 +1328,7 @@ mission "FW Pug Jump Drive Check"
 	on offer
 		require "Jump Drive" 0
 		conversation
-			`Somehow, you've misplaced or lost the jump drive needed to continue the Free Worlds story! If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
+			`Somehow, you've misplaced or lost the jump drive needed to continue the Free Worlds story! If you are unable to find your jump drive, you should revert to the autosave or another earlier snapshot of the game.`
 				decline
 
 


### PR DESCRIPTION
## Summary
This PR adds a new mission that triggers if the player doesn't have a jump drive installed or in cargo, such as if they sold it. (It doesn't check planetary storage, however.) All the mission does is tell the player to revert to a previous save.