### PR TITLE
Messages::Add() default to Low importance

### DIFF
--- a/source/Messages.h
+++ b/source/Messages.h
@@ -48,7 +48,7 @@ public:
 
 public:
 	// Add a message to the list along with its level of importance
-	static void Add(const std::string &message, Importance importance);
+	static void Add(const std::string &message, Importance importance = Messages::Importance::Low);
 
 	// Get the messages for the given game step. Any messages that are too old
 	// will be culled out, and new ones that have just been added will have

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -48,7 +48,7 @@ public:
 
 public:
 	// Add a message to the list along with its level of importance
-	static void Add(const std::string &message, Importance importance = Messages::Importance::Low);
+	static void Add(const std::string &message, Importance importance = Importance::Low);
 
 	// Get the messages for the given game step. Any messages that are too old
 	// will be culled out, and new ones that have just been added will have


### PR DESCRIPTION
## Feature Details
Makes Messages::Add() default to Importance::Low if no importance is supplied.

Why? It's easier to do this this than write Messages::Importance::Low once.


## Usage Examples
Before: 
`Messages::Add("Test Message", Messages::Importance::Low);`

After:
`Messages::Add("Test Message");`

In Action:
<img width="542" alt="image" src="https://user-images.githubusercontent.com/101683475/198831644-7352c74b-c6b2-4af1-a5af-f07079d1b366.png">
<img width="174" alt="image" src="https://user-images.githubusercontent.com/101683475/198831703-74bac706-700b-4a63-89da-b8ce5d8e362d.png">

## Performance Impact
None
