### PR TITLE
New functions to get stage of Hyperjump completion

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1818,7 +1818,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		hyperState = 1;
 	}
 	else
-		hyperState = 0;
+		hyperState = hyperstate == 0 ? 0 : 5;
 
 	if(pilotError)
 		--pilotError;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1611,6 +1611,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	}
 	else if(hyperspaceSystem || hyperspaceCount)
 	{
+		hyperState = (hyperState > 2) ? 4 : 2;
 		// Don't apply external acceleration while jumping.
 		acceleration = Point();
 
@@ -1642,6 +1643,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 
 		if(hyperspaceCount == HYPER_C)
 		{
+			hyperState = 3;
 			currentSystem = hyperspaceSystem;
 			hyperspaceSystem = nullptr;
 			targetSystem = nullptr;
@@ -1813,7 +1815,10 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		pair<Ship::JumpType, double> jumpUsed = GetCheapestJumpType(hyperspaceSystem);
 		isUsingJumpDrive = (jumpUsed.first == JumpType::JumpDrive);
 		hyperspaceFuelCost = jumpUsed.second;
+		hyperState = 1;
 	}
+	else
+		hyperState = 0;
 
 	if(pilotError)
 		--pilotError;
@@ -2837,6 +2842,13 @@ bool Ship::IsHyperspacing() const
 
 
 
+int Ship::HyperCount() const
+{
+	return hyperspaceCount;
+}
+
+
+
 // Check if this ship is hyperspacing, specifically via a jump drive.
 bool Ship::IsUsingJumpDrive() const
 {
@@ -3362,6 +3374,13 @@ double Ship::JumpFuelMissing() const
 		return 0.;
 
 	return jumpFuel - fuel;
+}
+
+
+
+uint8_t Ship::HyperState() const
+{
+	return hyperState;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -259,6 +259,8 @@ public:
 	bool IsEnteringHyperspace() const;
 	// Check if this ship is entering or leaving hyperspace.
 	bool IsHyperspacing() const;
+	// Get the hyperspace completion as a percent
+	int HyperCount() const;
 	// Check if this ship is hyperspacing, specifically via a jump drive.
 	bool IsUsingJumpDrive() const;
 	// Check if this ship is currently able to enter hyperspace to it target.
@@ -333,6 +335,13 @@ public:
 	std::pair<JumpType, double> GetCheapestJumpType(const System *from, const System *to) const;
 	// Get the amount of fuel missing for the next jump (smart refuelling)
 	double JumpFuelMissing() const;
+	// Gets the stage the hyperjump is at.
+	// 0 - Not Jumping
+	// 1 - Jump Starting - one Frame
+	// 2 - Jumping (In original system)
+	// 3 - Switching to next system - One frame
+	// 4 - Finishing Jump (Movement is still locked)
+	uint8_t HyperState() const;
 	// Get the heat level at idle.
 	double IdleHeat() const;
 	// Get the heat dissipation, in heat units per heat unit per frame.
@@ -595,6 +604,7 @@ private:
 	bool isUsingJumpDrive = false;
 	double hyperspaceFuelCost = 0.;
 	Point hyperspaceOffset;
+	uint8_t hyperState = 0;
 
 	double jumpRange = 0.;
 


### PR DESCRIPTION
## Feature Details
Added HyperCount() and HyperStage() methods

HyperCount() returns the hyperspaceCount variable, which is the completion percent of the hyperjump and can be used for things that depend on the percentage of the hyperjump done.

HyperStage() returns an unsigned integer which refers to different 'stages' of the Hyperjump.
Stage 0 is when the ship is not hyperjumping, or has anything to do with a hyperjump.
Stage 1 is active for one frame when the ship is ready to jump.
Stage 2 is active until the system the ship is in is changed.
Stage 3 is active for one frame when the system the ship is in is changed.
Stage 4 is active until control is regained.
Stage 5 is active for one frame when control is regained.

## UI Screenshots
N/A

## Usage Examples
<img width="597" alt="image" src="https://user-images.githubusercontent.com/101683475/198917844-3b875199-ef04-4ea4-9469-cec15292910c.png">

With this code you can do things like make the screen tinted the hyperspace flash colour during the second stage of the hyperjump (the stage were the jump effects are created). (This example code is not part of the PR)

https://user-images.githubusercontent.com/101683475/198930354-17f51304-bf11-4f29-9554-9989bf75512c.mp4




## Testing Done
I put a debug script on and jumped around a bit, and al values seemed normal.

## Performance Impact
N/A
