### PR TITLE
fix?(content): HR Geocoris sequence rework

### DIFF
--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -693,4 +693,5 @@ outfit "Failed Control System"
 	thumbnail "outfit/control transceiver"
 	"mass" 1
 	"unplunderable" 1
-	description "This was meant to control some sort of experimental system, but it appears to have failed."
+	"integrated control systems" 1
+	description "This was meant to control some sort of experimental system, but it appears to have failed. Unfortunately it doesn't appear to be safely removable."

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -815,7 +815,7 @@ event "hai ladybug available"
 # The NPC has an outfit used to determine if you managed to get it back safely.
 mission "Hai Leaks Response 4A"
 	name "Recover the Geocoris"
-	description "Recover the stolen Geocoris supporting the pirates in Waypoint, and return to Allhome. (You will need to swap the Geocoris to your flagship, and depart and land again in order to progress the missions properly.)"
+	description "Recover the stolen Geocoris supporting the pirates in Waypoint, and return to Allhome."
 	landing
 	source "Allhome"
 	waypoint "Waypoint"
@@ -827,23 +827,24 @@ mission "Hai Leaks Response 4A"
 		personality staying marked mute
 		system "Waypoint"
 		ship "Geodesic Geocoris (Phylactery)" "Phylactery"
-		dialog `After successfully boarding the Geocoris and defeating its pirate crews, you are greeted by the relieved captive Hai. You promise to escort their ship safely to Allhome. (You will need to swap the Geocoris to your flagship, and depart and land again in order to progress the missions properly.)`
+		dialog `After successfully boarding the Geocoris and defeating its pirate crews, you are greeted by the relieved captive Hai. You send crew aboard to fly the ship and promise to return them safely to Allhome.`
 #	on fail
 #		dialog `You have failed to recover the Geocoris. This is not critical, but does have long-term consequences. If you want the most complete ending, revert to the autosave or another earlier snapshot of the game.`
 #Too hand-holdy for present implementation and content.
 
 
 # Must be able to resolve earlier than the rest in this set.
-#The Geodesic Geocoris may become available to purchase specially later on.
+# The Geodesic Geocoris may become available to purchase specially later on.
 mission "00 Hai Leaks Response 4B"
 	landing
 	source "Allhome"
+	to offer
+		has "outfit (installed): Failed Control System"
 	on offer
-		require "Failed Control System"
-		log `Successfully rescued the kidnapped Hai and reclaimed the Geocoris. Something is different about it.`
+		log `Successfully rescued the kidnapped Hai and reclaimed the Geocoris. This ship has been modified in ways that aren't of Hai origin, and which don't appear to be fully functional.`
 		event "returned geocoris" 365
 		conversation
-			`You have successfully rescued the kidnapped Hai and reclaimed the Geocoris. Something is different about it...`
+			`You have successfully rescued the kidnapped Hai and reclaimed the Geocoris. On your way back to <planet> the crew you sent across to fly it home report that something is different about it... It appears that it has been modified with systems of some kind which are not of Hai design. It also appears that not everything about those systems is perhaps working wholly as intended.`
 				decline
 
 event "returned geocoris"
@@ -873,6 +874,8 @@ ship "Geodesic Geocoris"
 		"hull repair rate" 0.8
 		"hull energy" 0.8
 		"hull heat" 1.2
+		"integrated control systems" -1
+		"integrated systems core" 1
 		weapon
 			"blast radius" 400
 			"shield damage" 4000

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -841,7 +841,7 @@ mission "00 Hai Leaks Response 4B"
 	landing
 	source "Allhome"
 	to offer
-		has "outfit (installed): Failed Control System"
+		has "ship model (all): Geodesic Geocoris"
 	on offer
 		log `Successfully rescued the kidnapped Hai and reclaimed the Geocoris. This ship has been modified in ways that aren't of Hai origin, and which don't appear to be fully functional.`
 		event "returned geocoris" 365

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -760,6 +760,8 @@ mission "Hai Leaks Response 4"
 		personality staying marked target
 		system "Waypoint"
 		ship "Marauder Leviathan (Weapons)" "Black Lich"
+	on visit
+		dialog `You have returned, but the fate of the pirates and the captured Hai is still in doubt. Ensure that the Black Lich is defeated and that the fate of the captured Hai, whether or deceased or safely with you, is certainly known.`
 	to complete
 		or
 			has "00 Hai Leaks Response 4B: declined"

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -761,7 +761,7 @@ mission "Hai Leaks Response 4"
 		system "Waypoint"
 		ship "Marauder Leviathan (Weapons)" "Black Lich"
 	on visit
-		dialog `You have returned, but the fate of the pirates and the captured Hai is still in doubt. Ensure that the Black Lich is defeated and that the fate of the captured Hai, whether or deceased or safely with you, is certainly known.`
+		dialog `You have returned, but the fate of the pirates and the captured Hai is still in doubt. Ensure that the Black Lich is defeated and that the fate of the captured Hai, whether deceased or safely with you, is certainly known.`
 	to complete
 		or
 			has "00 Hai Leaks Response 4B: declined"

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -846,7 +846,7 @@ mission "00 Hai Leaks Response 4B"
 		log `Successfully rescued the kidnapped Hai and reclaimed the Geocoris. This ship has been modified in ways that aren't of Hai origin, and which don't appear to be fully functional.`
 		event "returned geocoris" 365
 		conversation
-			`You have successfully rescued the kidnapped Hai and reclaimed the Geocoris. On your way back to <planet> the crew you sent across to fly it home report that something is different about it... It appears that it has been modified with systems of some kind which are not of Hai design. It also appears that not everything about those systems is perhaps working wholly as intended.`
+			`You have successfully rescued the kidnapped Hai and reclaimed the Geocoris. On your way back to <planet> the crew you sent across to fly it home report that something is different about it... It appears that it has been modified with systems of some kind, which are not of Hai design. It also appears that perhaps not everything about those systems is working wholly as intended.`
 				decline
 
 event "returned geocoris"


### PR DESCRIPTION
So now that #7210 has been merged it was time to look into the Geocoris rescue sequence in Hai Reveal again to fix the "needing to land, swap flagship, take off and land again" issue.

I originally had this rolled into my collection of changes I'm fixing on my own playthrough, but on consideration I thought it was better presented to be tested and inspected as its own thing since it's using a brand new feature.