### PR TITLE
fix(mechanics): Surveillance personality no longer overrides staying

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2381,6 +2381,7 @@ void AI::DoSwarming(Ship &ship, Command &command, shared_ptr<Ship> &target)
 
 void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) const
 {
+	bool isStaying = ship.GetPersonality().IsStaying();
 	// Since DoSurveillance is called after target-seeking and firing, if this
 	// ship has a target, that target is guaranteed to be targetable.
 	if(target && (target->GetSystem() != ship.GetSystem() || target->IsEnteringHyperspace()))
@@ -2397,7 +2398,7 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 	}
 
 	// Choose a surveillance behavior.
-	if(ship.GetTargetSystem())
+	if(ship.GetTargetSystem() && !isStaying)
 	{
 		// Unload surveillance drones in this system before leaving.
 		PrepareForHyperspace(ship, command);
@@ -2416,7 +2417,7 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 		double distance = ship.Position().Distance(ship.GetTargetStellar()->Position());
 		if(distance < atmosphereScan && !Random::Int(100))
 			ship.SetTargetStellar(nullptr);
-		else
+		else if(!isStaying)
 			command |= Command::LAND;
 	}
 	else if(target)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2398,11 +2398,14 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 	}
 
 	// Choose a surveillance behavior.
-	if(ship.GetTargetSystem() && !isStaying)
+	if(ship.GetTargetSystem())
 	{
 		// Unload surveillance drones in this system before leaving.
-		PrepareForHyperspace(ship, command);
-		command |= Command::JUMP;
+		if(!isStaying)
+		{
+			PrepareForHyperspace(ship, command);
+			command |= Command::JUMP;
+		}
 		if(ship.HasBays())
 		{
 			command |= Command::DEPLOY;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2381,7 +2381,7 @@ void AI::DoSwarming(Ship &ship, Command &command, shared_ptr<Ship> &target)
 
 void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) const
 {
-	bool isStaying = ship.GetPersonality().IsStaying();
+	const bool isStaying = ship.GetPersonality().IsStaying();
 	// Since DoSurveillance is called after target-seeking and firing, if this
 	// ship has a target, that target is guaranteed to be targetable.
 	if(target && (target->GetSystem() != ship.GetSystem() || target->IsEnteringHyperspace()))


### PR DESCRIPTION
**Bugfix:**

Thank you to all the people who have reported the issue with the Winds of Light not actually staying in Peragenor, both on Steam and Discord.

## Fix Details
It turns out that AI::DoSurveillance() was setting jump and land commands on ships without checking if they were `staying` and so should not receive such commands. I do not know how long this has been the case, but it does happen in 0.9.14.
The issue was only discovered relatively recently where the Winds of Light, the Starling you are required to scan in the missions: `Remnant: Keystone Research 5` (and 6) which has both `staying` and `surveillance` personalities.
The behaviour of it not staying is also, however, rather intermittent, but the frequency with which this behaviour is exhibited can be drastically increased by removing all StellarObjects from Peragenor (optionally including the wormhole). After doing this, it will quickly leave the system (if the wormhole is present, it will usually use this route, but it does sometimes jump to Stercutus via hyperdrive) after you enter. In my observations, it tends to then stay in the system it is in until you enter, at which point it will rapidly leave. I do not understand this behaviour, since it seems independent of the StellarObjects in the system, unlike the behaviour in the initial system. Regardless, a ship with `staying` should not leave its starting system, so subsequent behaviour is (hopefully) irrelevant.

## Testing Done
Take off with the appropriate mission active, go to Peragenor, see the ship leave before this PR, and not leave with this PR.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[ThisTookTooLong ToFigureOut~3019-07-05.txt](https://github.com/endless-sky/endless-sky/files/9915108/ThisTookTooLong.ToFigureOut.3019-07-05.txt)
(Note: I have already applied the removal of all StellarObjects but the wormhole in Peragenor in the changes section of this save file.)

