### PR TITLE
Record distribution of off world mission cargo and passengers

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3598,7 +3598,7 @@ void PlayerInfo::Save(const string &path) const
 			out.BeginChild();
 			{
 				for(const auto &it : toSave)
-					for(const auto &sit: it.second)
+					for(const auto &sit : it.second)
 						out.Write(it.first, sit.first, sit.second);
 			}
 			out.EndChild();

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -73,6 +73,34 @@ namespace {
 			ships[0] = flagship;
 		}
 	}
+
+
+
+	void DistributeMissionCargo(map<string, map<string, int>> &toDistribute, const list<Mission> &missions, vector<shared_ptr<Ship>> &ships, CargoHold &cargo, bool passengers)
+	{
+		for(const auto &it : toDistribute)
+		{
+			const auto missionIt = find_if(missions.begin(), missions.end(),
+					[&it](const Mission &mission) {return mission.UUID().ToString() == it.first; });
+			if(missionIt != missions.end())
+			{
+				const Mission *cargoOf = &*missionIt;
+				for(const auto &shipCargo : it.second)
+				{
+					auto shipIt = find_if(ships.begin(), ships.end(),
+							[&shipCargo](const shared_ptr<Ship> &ship) {return ship->UUID().ToString() == shipCargo.first; });
+					if(shipIt != ships.end())
+					{
+						Ship *destination = shipIt->get();
+						if(passengers)
+							cargo.TransferPassengers(cargoOf, shipCargo.second, destination->Cargo());
+						else
+							cargo.Transfer(cargoOf, shipCargo.second, destination->Cargo());
+					}
+				}
+			}
+		}
+	}
 }
 
 
@@ -148,6 +176,13 @@ void PlayerInfo::Load(const string &path)
 {
 	// Make sure any previously loaded data is cleared.
 	Clear();
+
+	// A listing of missions and the ships where their cargo or passengers were when the game was saved.
+	// Missions and ships are referred to by string UUIDs.
+	// Any mission cargo or passengers that were in the player's system will not be recorded here,
+	// as that can be safely redistributed from the player's overall CargoHold to any ships in their system.
+	map<string, map<string, int>> missionCargoToDistribute;
+	map<string, map<string, int>> missionPassengersToDistribute;
 
 	filePath = path;
 	// Strip anything after the "~" from snapshots, so that the file we save
@@ -255,6 +290,19 @@ void PlayerInfo::Load(const string &path)
 			missions.emplace_back(child);
 			cargo.AddMissionCargo(&missions.back());
 		}
+		else if((child.Token(0) == "mission cargo" || child.Token(0) == "mission passengers") && child.HasChildren())
+		{
+			map<string, map<string, int>> &toDistribute = (child.Token(0) == "mission cargo")
+					? missionCargoToDistribute : missionPassengersToDistribute;
+			for(const DataNode &grand : child)
+				if(grand.Token(0) == "player ships" && grand.HasChildren())
+					for(const DataNode &great : grand)
+					{
+						if(great.Size() != 3)
+							continue;
+						toDistribute[great.Token(0)][great.Token(1)] = great.Value(2);
+					}
+		}
 		else if(child.Token(0) == "available job")
 			availableJobs.emplace_back(child);
 		else if(child.Token(0) == "sort type")
@@ -337,6 +385,9 @@ void PlayerInfo::Load(const string &path)
 	// Based on the ships that were loaded, calculate the player's capacity for
 	// cargo and passengers.
 	UpdateCargoCapacities();
+
+	DistributeMissionCargo(missionCargoToDistribute, missions, ships, cargo, false);
+	DistributeMissionCargo(missionPassengersToDistribute, missions, ships, cargo, true);
 
 	// If no depreciation record was loaded, every item in the player's fleet
 	// will count as non-depreciated.
@@ -3523,6 +3574,41 @@ void PlayerInfo::Save(const string &path) const
 		mission.Save(out);
 	for(const Mission &mission : inactiveMissions)
 		mission.Save(out);
+	
+	map<string, map<string, int>> offWorldMissionCargo;
+	map<string, map<string, int>> offWorldMissionPassengers;
+	for(const auto &it : ships)
+	{
+		const Ship &ship = *it.get();
+		// If the ship is at the player's planet, its mission cargo allocation does not need to be saved.
+		if(ship.GetPlanet() == planet)
+			continue;
+		for(const auto &cargo : ship.Cargo().MissionCargo())
+			offWorldMissionCargo[cargo.first->UUID().ToString()][ship.UUID().ToString()] = cargo.second;
+		for(const auto &passengers : ship.Cargo().PassengerList())
+			offWorldMissionPassengers[passengers.first->UUID().ToString()][ship.UUID().ToString()] = passengers.second;
+	}
+	if(!offWorldMissionCargo.empty())
+	{
+		out.Write("mission cargo");
+		out.BeginChild();
+		out.Write("player ships");
+		out.BeginChild();
+		for(const auto &it : offWorldMissionCargo)
+			for(const auto &it2 : it.second)
+				out.Write(it.first, it2.first, it2.second);
+	}
+	if(!offWorldMissionPassengers.empty())
+	{
+		out.Write("mission passengers");
+		out.BeginChild();
+		out.Write("player ships");
+		out.BeginChild();
+		for(const auto &it : offWorldMissionPassengers)
+			for(const auto &it2 : it.second)
+				out.Write(it.first, it2.first, it2.second);
+	}
+
 	for(const Mission &mission : availableJobs)
 		mission.Save(out, "available job");
 	for(const Mission &mission : availableMissions)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -364,14 +364,14 @@ void PlayerInfo::Load(const string &path)
 		for(const auto &it : toDistribute)
 		{
 			const auto missionIt = find_if(missions.begin(), missions.end(),
-					[&it](const Mission &mission) {return mission.UUID().ToString() == it.first; });
+					[&it](const Mission &mission) { return mission.UUID().ToString() == it.first; });
 			if(missionIt != missions.end())
 			{
 				const Mission *cargoOf = &*missionIt;
 				for(const auto &shipCargo : it.second)
 				{
 					auto shipIt = find_if(ships.begin(), ships.end(),
-							[&shipCargo](const shared_ptr<Ship> &ship) {return ship->UUID().ToString() == shipCargo.first; });
+							[&shipCargo](const shared_ptr<Ship> &ship) { return ship->UUID().ToString() == shipCargo.first; });
 					if(shipIt != ships.end())
 					{
 						Ship *destination = shipIt->get();
@@ -3593,12 +3593,16 @@ void PlayerInfo::Save(const string &path) const
 		else
 			out.Write("mission cargo");
 		out.BeginChild();
-		out.Write("player ships");
-		out.BeginChild();
-		for(const auto &it : toSave)
-			for(const auto &it2 : it.second)
-				out.Write(it.first, it2.first, it2.second);
-		out.EndChild();
+		{
+			out.Write("player ships");
+			out.BeginChild();
+			{
+				for(const auto &it : toSave)
+					for(const auto &sit: it.second)
+						out.Write(it.first, sit.first, sit.second);
+			}
+			out.EndChild();
+		}
 		out.EndChild();
 	};
 	if(!offWorldMissionCargo.empty())

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3573,7 +3573,6 @@ void PlayerInfo::Save(const string &path) const
 		mission.Save(out);
 	for(const Mission &mission : inactiveMissions)
 		mission.Save(out);
-	
 	map<string, map<string, int>> offWorldMissionCargo;
 	map<string, map<string, int>> offWorldMissionPassengers;
 	for(const auto &it : ships)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3597,6 +3597,8 @@ void PlayerInfo::Save(const string &path) const
 		for(const auto &it : offWorldMissionCargo)
 			for(const auto &it2 : it.second)
 				out.Write(it.first, it2.first, it2.second);
+		out.EndChild();
+		out.EndChild();
 	}
 	if(!offWorldMissionPassengers.empty())
 	{
@@ -3607,6 +3609,8 @@ void PlayerInfo::Save(const string &path) const
 		for(const auto &it : offWorldMissionPassengers)
 			for(const auto &it2 : it.second)
 				out.Write(it.first, it2.first, it2.second);
+		out.EndChild();
+		out.EndChild();
 	}
 
 	for(const Mission &mission : availableJobs)


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #1624 

This is an alternative approach to that in #5723.

## Fix Details
When saving, two new blocks may be added between `missions` and `available jobs`: `mission cargo` and `mission passengers`.
These blocks will contain UUIDs for missions and ships and cargo/passenger counts for any mission cargo or passengers on ships not at the player's current planet.
The format will be:
```
"mission cargo" | "mission passengers"
  "player ships"
    <mission UUID> <ship UUID> <count>
```
`player ships` is included for some measure of future-proofing. In #5723, @tehhowch suggested NPC ships potentially being able to carry mission cargo. While that feature is not implemented here, this does leave room for that to be added without needing to change the save syntax introduced here, only expand on it.

## Testing Done
Have multiple ships. Accept many jobs, more cargo and passengers than will ffit on my flagship.
Take off. Have my fleet hold position. Go to a different system and land (ideally, not the destination of any of hte jobs).
Reload the save.
Without this PR, all cargo and passengers will be at my location, and trying to take off will give a dialog saying I will fail the missions because I do not have space for all the cargo and passengers.
With this PR, the cargo and passengers remain on the ship(s) they were before and taking offf fails no missions.

## Save File
[test est~~previous-1.txt](https://github.com/endless-sky/endless-sky/files/9930572/test.est.previous-1.txt)
[test est.txt](https://github.com/endless-sky/endless-sky/files/9930571/test.est.txt)

