### PR TITLE
doc(requirements): Update the system requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Endless Sky has very minimal system requirements, meaning most systems should be
 
 || Minimum | Recommended |
 |---|----:|----:|
-|RAM | 400 MB | 1 GB |
+|RAM | 500 MB | 1 GB |
 |Graphics | OpenGL 3.0 | OpenGL 3.3 |
-|Storage Free | 200 MB | 400 MB |
+|Storage Free | 250 MB | 1 GB |
 
 ## Building from source
 Most development is done on Linux and Windows, using the [SCons](https://scons.org/) build tool to compile the project. For those wishing to use an IDE, project files are provided for [XCode](https://developer.apple.com/xcode/) and [Code::Blocks](https://www.codeblocks.org/) to simplify the project setup. It is possible to use other IDEs or build systems to compile the game, but support is not provided.  


### PR DESCRIPTION
Updates the systems requirements:

- The RAM used when starting a new game is at bit more than 400MB, so I increased it to 500MB.
- The current size of a release build is 220MB, so I rounded it to the nice number 250MB.
- I increased the recommended storage to 1GB to account for people that want to use the high dpi plugin.