### PR TITLE
Fix(Map): If two governments have the same color and name, show only one in legend

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -581,7 +581,10 @@ void MapDetailPanel::DrawKey()
 			if(find != checkList.end())
 				skip = find->second == it.first->GetName();
 			if(!skip)
+			{
+				checkList.emplace(*it.first->GetColor().Get(), it.first->GetName());
 				distances.emplace_back(it.second, it.first);
+			}
 		}
 		sort(distances.begin(), distances.end());
 		for(unsigned i = 0; i < 4 && i < distances.size(); ++i)

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -572,13 +572,14 @@ void MapDetailPanel::DrawKey()
 		// Each system is colored by the government of the system. Only the
 		// four largest visible governments are labeled in the legend.
 		vector<pair<double, const Government *>> distances;
-		bool skip = false;
+		map<float, string> checkList;
+		bool skip;
 		for(const auto &it : closeGovernments)
 		{
 			skip = false;
-			for(const auto &distance : distances)
-				if(distance.second->GetColor().Get() == it.first->GetColor().Get()
-					&& distance.second->GetName() == it.first->GetName())
+			auto find = checkList.find(*it.first->GetColor().Get());
+			if(find != checkList.end())
+				skip = find->second == it.first->GetName();
 			if(!skip)
 				distances.emplace_back(it.second, it.first);
 		}

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -572,8 +572,16 @@ void MapDetailPanel::DrawKey()
 		// Each system is colored by the government of the system. Only the
 		// four largest visible governments are labeled in the legend.
 		vector<pair<double, const Government *>> distances;
+		bool skip = false;
 		for(const auto &it : closeGovernments)
-			distances.emplace_back(it.second, it.first);
+		{
+			skip = false;
+			for(const auto &distance : distances)
+				if(distance.second->GetColor().Get() == it.first->GetColor().Get()
+					&& distance.second->GetName() == it.first->GetName())
+			if(!skip)
+				distances.emplace_back(it.second, it.first);
+		}
 		sort(distances.begin(), distances.end());
 		for(unsigned i = 0; i < 4 && i < distances.size(); ++i)
 		{


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue discussed in derpys stream

## Fix Details
If two governments have the same color and name, show only one in legend

## Testing Done
- [ ] waiting for tests

## Alternative
have a temporary vector with pairs out of colors and names and use find()
