### PR TITLE
fix(UI): Don't duplicate government entries in the map key

### DIFF
--- a/source/Color.cpp
+++ b/source/Color.cpp
@@ -43,6 +43,13 @@ bool Color::operator==(const Color &other) const
 
 
 
+bool Color::operator!=(const Color &other) const
+{
+	return !(*this == other);
+}
+
+
+
 // Set all four color components to the given values.
 void Color::Load(double r, double g, double b, double a)
 {

--- a/source/Color.cpp
+++ b/source/Color.cpp
@@ -33,6 +33,16 @@ Color::Color(float r, float g, float b, float a)
 
 
 
+bool Color::operator==(const Color &other) const
+{
+	for(int i = 0; i < 4; ++i)
+		if(color[i] != other.color[i])
+			return false;
+	return true;
+}
+
+
+
 // Set all four color components to the given values.
 void Color::Load(double r, double g, double b, double a)
 {

--- a/source/Color.h
+++ b/source/Color.h
@@ -31,6 +31,7 @@ public:
 	Color(float r, float g, float b, float a = 1.f);
 
 	bool operator==(const Color &other) const;
+	bool operator!=(const Color &other) const;
 
 	// Set this color to the given RGBA values.
 	void Load(double r, double g, double b, double a);

--- a/source/Color.h
+++ b/source/Color.h
@@ -30,6 +30,8 @@ public:
 	// Constructor for colors, opaque unless an alpha is also given.
 	Color(float r, float g, float b, float a = 1.f);
 
+	bool operator==(const Color &other) const;
+
 	// Set this color to the given RGBA values.
 	void Load(double r, double g, double b, double a);
 	// Get the color as a float vector, suitable for use by OpenGL.

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -576,6 +576,8 @@ void MapDetailPanel::DrawKey()
 		vector<pair<double, const Government *>> distances;
 		for(const auto &it : closeGovernments)
 		{
+			if(!it.first)
+				continue;
 			auto displayNameIt = displayNames.find(it.first->GetName());
 			vector<const Government *>::iterator matchingGov;
 			if(displayNameIt != displayNames.end())

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -609,8 +609,7 @@ void MapDetailPanel::DrawKey()
 		// given reputation (0.1, 100, and 10000) are shown for each sign.
 		RingShader::Draw(pos, OUTER, INNER, ReputationColor(1e-1, true, false));
 		RingShader::Draw(pos + Point(12., 0.), OUTER, INNER, ReputationColor(1e2, true, false));
-		RingShader::Draw(pos + Point(24., 0.), OUTER, INNER, ReputationColo
-						r(1e4, true, false));
+		RingShader::Draw(pos + Point(24., 0.), OUTER, INNER, ReputationColor(1e4, true, false));
 		font.Draw("Friendly", pos + textOff + Point(24., 0.), dim);
 		pos.Y() += 20.;
 

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -580,22 +580,19 @@ void MapDetailPanel::DrawKey()
 		}
 		sort(distances.begin(), distances.end());
 		int drawn = 0;
-		vector<pair<string, const Color *>> alreadyDisplayed;
+		vector<pair<string, Color>> alreadyDisplayed;
 		for(const auto &it : distances)
 		{
 			const string &displayName = it.second->GetName();
 			const Color &displayColor = it.second->GetColor();
-			auto foundIt = find_if(alreadyDisplayed.begin(), alreadyDisplayed.end(),
-					[&displayName, &displayColor](const pair<const string, const Color *> &item)
-					{
-						return (item.first == displayName) && (*item.second == displayColor);
-					});
+			auto foundIt = find(alreadyDisplayed.begin(), alreadyDisplayed.end(),
+					make_pair(displayName, displayColor));
 			if(foundIt != alreadyDisplayed.end())
 				continue;
 			RingShader::Draw(pos, OUTER, INNER, GovernmentColor(it.second));
 			font.Draw(it.second->GetName(), pos + textOff, dim);
 			pos.Y() += 20.;
-			alreadyDisplayed.emplace_back(displayName, &displayColor);
+			alreadyDisplayed.emplace_back(displayName, displayColor);
 			++drawn;
 			if(drawn >= 4)
 				break;

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -585,13 +585,12 @@ void MapDetailPanel::DrawKey()
 		{
 			const string &displayName = it.second->GetName();
 			const Color &displayColor = GovernmentColor(it.second);
-			auto lower = alreadyDisplayed.lower_bound(displayName);
-			auto upper = alreadyDisplayed.upper_bound(displayName);
-			auto found = find_if(lower, upper, [&displayColor](const pair<const string, const Color *> &item)
+			auto foundRange = alreadyDisplayed.equal_range(displayName);
+			auto foundIt = find_if(foundRange.first, foundRange.second, [&displayColor](const pair<const string, const Color *> &item)
 					{
 						return *item.second == displayColor;
 					});
-			if(found != upper)
+			if(foundIt != foundRange.second)
 				continue;
 			RingShader::Draw(pos, OUTER, INNER, GovernmentColor(it.second));
 			font.Draw(it.second->GetName(), pos + textOff, dim);

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -584,7 +584,7 @@ void MapDetailPanel::DrawKey()
 		for(const auto &it : distances)
 		{
 			const string &displayName = it.second->GetName();
-			const Color &displayColor = GovernmentColor(it.second);
+			const Color &displayColor = it.second->GetColor();
 			auto foundRange = alreadyDisplayed.equal_range(displayName);
 			auto foundIt = find_if(foundRange.first, foundRange.second, [&displayColor](const pair<const string, const Color *> &item)
 					{

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -577,7 +577,7 @@ void MapDetailPanel::DrawKey()
 		for(const auto &it : closeGovernments)
 		{
 			auto &it2 = displayNames.find(it.first->GetName());
-			if(it2 != displayNames.end() && &it2->second->GetColor() == &it.first->GetColor())
+			if(it2 != displayNames.end() && it2->second->GetColor() == it.first->GetColor())
 			{
 				auto &it3 = find(distances.begin(), distances.end(),
 						[&it2](const pair<double, const Government *> &item)

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -570,27 +570,34 @@ void MapDetailPanel::DrawKey()
 	}
 	else if(commodity == SHOW_GOVERNMENT)
 	{
-		unordered_map<string, const Government *> displayNames;
+		unordered_map<string, vector<const Government *>> displayNames;
 		// Each system is colored by the government of the system. Only the
 		// four largest visible governments are labeled in the legend.
 		vector<pair<double, const Government *>> distances;
 		for(const auto &it : closeGovernments)
 		{
-			auto it2 = displayNames.find(it.first->GetName());
-			if(it2 != displayNames.end() && it2->second->GetColor() == it.first->GetColor())
-			{
-				auto it3 = find_if(distances.begin(), distances.end(),
-						[&it2](const pair<double, const Government *> &item)
+			auto displayNameIt = displayNames.find(it.first->GetName());
+			vector<const Government *>::iterator matchingGov;
+			if(displayNameIt != displayNames.end())
+				matchingGov = find_if(displayNameIt->second.begin(), displayNameIt->second.end(),
+						[&it](const Government *gov)
 						{
-							return item.second == it2->second;
+							return gov->GetColor() == it.first->GetColor();
 						});
-				if(it3 != distances.end() && it3->first > it.second)
-					it3->first = it.second;
+			if(&*matchingGov && matchingGov != displayNameIt->second.end())
+			{
+				auto existingEntry = find_if(distances.begin(), distances.end(),
+						[&matchingGov](const pair<double, const Government *> &item)
+						{
+							return item.second == *matchingGov;
+						});
+				if(existingEntry != distances.end() && existingEntry->first > it.second)
+					existingEntry->first = it.second;
 			}
 			else
 			{
 				distances.emplace_back(it.second, it.first);
-				displayNames[it.first->GetName()] = it.first;
+				displayNames[it.first->GetName()].emplace_back(it.first);
 			}
 		}
 		sort(distances.begin(), distances.end());

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -576,10 +576,10 @@ void MapDetailPanel::DrawKey()
 		vector<pair<double, const Government *>> distances;
 		for(const auto &it : closeGovernments)
 		{
-			auto &it2 = displayNames.find(it.first->GetName());
+			auto it2 = displayNames.find(it.first->GetName());
 			if(it2 != displayNames.end() && it2->second->GetColor() == it.first->GetColor())
 			{
-				auto &it3 = find(distances.begin(), distances.end(),
+				auto it3 = find_if(distances.begin(), distances.end(),
 						[&it2](const pair<double, const Government *> &item)
 						{
 							return item.second == it2->second;

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -590,7 +590,7 @@ void MapDetailPanel::DrawKey()
 			if(foundIt != alreadyDisplayed.end())
 				continue;
 			RingShader::Draw(pos, OUTER, INNER, GovernmentColor(it.second));
-			font.Draw(it.second->GetName(), pos + textOff, dim);
+			font.Draw(displayName, pos + textOff, dim);
 			pos.Y() += 20.;
 			alreadyDisplayed.emplace_back(displayName, displayColor);
 			++drawn;

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -580,22 +580,22 @@ void MapDetailPanel::DrawKey()
 		}
 		sort(distances.begin(), distances.end());
 		int drawn = 0;
-		multimap<const string, const Color *> alreadyDisplayed;
+		vector<pair<const string, const Color *>> alreadyDisplayed;
 		for(const auto &it : distances)
 		{
 			const string &displayName = it.second->GetName();
 			const Color &displayColor = it.second->GetColor();
-			auto foundRange = alreadyDisplayed.equal_range(displayName);
-			auto foundIt = find_if(foundRange.first, foundRange.second, [&displayColor](const pair<const string, const Color *> &item)
+			auto foundIt = find_if(alreadyDisplayed.begin(), alreadyDisplayed.end(),
+					[&displayName, &displayColor](const pair<const string, const Color *> &item)
 					{
-						return *item.second == displayColor;
+						return (item.first == displayName) && (*item.second == displayColor);
 					});
-			if(foundIt != foundRange.second)
+			if(foundIt != alreadyDisplayed.end())
 				continue;
 			RingShader::Draw(pos, OUTER, INNER, GovernmentColor(it.second));
 			font.Draw(it.second->GetName(), pos + textOff, dim);
 			pos.Y() += 20.;
-			alreadyDisplayed.emplace(displayName, &displayColor);
+			alreadyDisplayed.emplace_back(displayName, &displayColor);
 			++drawn;
 			if(drawn >= 4)
 				break;

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -56,6 +56,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <cmath>
 #include <limits>
 #include <set>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -569,11 +570,29 @@ void MapDetailPanel::DrawKey()
 	}
 	else if(commodity == SHOW_GOVERNMENT)
 	{
+		unordered_map<string, const Government *> displayNames;
 		// Each system is colored by the government of the system. Only the
 		// four largest visible governments are labeled in the legend.
 		vector<pair<double, const Government *>> distances;
 		for(const auto &it : closeGovernments)
-			distances.emplace_back(it.second, it.first);
+		{
+			auto &it2 = displayNames.find(it.first->GetName());
+			if(it2 != displayNames.end() && &it2->second->GetColor() == &it.first->GetColor())
+			{
+				auto &it3 = find(distances.begin(), distances.end(),
+						[&it2](const pair<double, const Government *> &item)
+						{
+							return item.second == it2->second;
+						});
+				if(it3 != distances.end() && it3->first > it.second)
+					it3->first = it.second;
+			}
+			else
+			{
+				distances.emplace_back(it.second, it.first);
+				displayNames[it.first->GetName()] = it.first;
+			}
+		}
 		sort(distances.begin(), distances.end());
 		for(unsigned i = 0; i < 4 && i < distances.size(); ++i)
 		{

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -580,7 +580,7 @@ void MapDetailPanel::DrawKey()
 		}
 		sort(distances.begin(), distances.end());
 		int drawn = 0;
-		vector<pair<const string, const Color *>> alreadyDisplayed;
+		vector<pair<string, const Color *>> alreadyDisplayed;
 		for(const auto &it : distances)
 		{
 			const string &displayName = it.second->GetName();

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -586,7 +586,7 @@ void MapDetailPanel::DrawKey()
 						{
 							return gov->GetColor() == it.first->GetColor();
 						});
-			if(&*matchingGov && matchingGov != displayNameIt->second.end())
+			if(displayNameIt != displayNames.end() && matchingGov != displayNameIt->second.end())
 			{
 				auto existingEntry = find_if(distances.begin(), distances.end(),
 						[&matchingGov](const pair<double, const Government *> &item)

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -581,7 +581,7 @@ void MapDetailPanel::DrawKey()
 		sort(distances.begin(), distances.end());
 		int drawn = 0;
 		multimap<const string, const Color *> alreadyDisplayed;
-		for(auto &it : distances)
+		for(const auto &it : distances)
 		{
 			const string &displayName = it.second->GetName();
 			const Color &displayColor = GovernmentColor(it.second);


### PR DESCRIPTION
**Bugfix:**

## Fix Details
As it is, it is possible to have multiple governments with the same display names and map colours. It would then be possible to get two identical entries in the map key.
This PR should prevent this from happening.
It does so by keeping a list of display names of governments under consideration for the key and, if a government being added has a display named matching one already added, the colours for the two governments are compared. If the colours also match, then a new entry will not be added and the existing entry may have its `distance` score updated if the new government has a closer system.

To better facilitate this, an equality operator is also added to Color. It will return false if any of the four elements of the colour array don't match their corresponding element in the other Color, otherwise, it returns true.

## Testing Done
none yet

