### PR TITLE
Aneutronic patch 1

### DIFF
--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -544,7 +544,7 @@ mission "FW Escort 0"
 		not "FW Escort 1: offered"
 	to fail
 		has "chosen sides"
-
+	
 	on offer
 		conversation
 			`As you are walking through the spaceport, a man in a militia uniform approaches you. Judging by the markings on his uniform, you suspect that he is very highly ranked within the militia.`

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -541,10 +541,11 @@ mission "FW Escort 0"
 	destination "Longjump"
 	to offer
 		random < 20 * "assisted free worlds"
-		and
-			not "FW Escort 1: offered"
 	to fail
-		has "chosen sides"
+		or
+			has "chosen sides"
+			has "FW Escort 1: offered"
+			has "FW Escort 1: done"
 	
 	on offer
 		conversation

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -546,7 +546,6 @@ mission "FW Escort 0"
 			has "chosen sides"
 			has "FW Escort 1: offered"
 			has "FW Escort 1: done"
-	
 	on offer
 		conversation
 			`As you are walking through the spaceport, a man in a militia uniform approaches you. Judging by the markings on his uniform, you suspect that he is very highly ranked within the militia.`

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -541,6 +541,8 @@ mission "FW Escort 0"
 	destination "Longjump"
 	to offer
 		random < 20 * "assisted free worlds"
+		and
+			not "FW Escort 1: offered"
 	to fail
 		has "chosen sides"
 	

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -541,11 +541,10 @@ mission "FW Escort 0"
 	destination "Longjump"
 	to offer
 		random < 20 * "assisted free worlds"
+		not "FW Escort 1: offered"
 	to fail
-		or
-			has "chosen sides"
-			has "FW Escort 1: offered"
-			has "FW Escort 1: done"
+		has "chosen sides"
+
 	on offer
 		conversation
 			`As you are walking through the spaceport, a man in a militia uniform approaches you. Judging by the markings on his uniform, you suspect that he is very highly ranked within the militia.`


### PR DESCRIPTION
Added a check to the "offer" section of the "FW Escort 0" mission that grants backwards compatibility to players by preventing players who completed the old mission chain starting with "FW Escort 1," but did not yet join the Free Worlds from being offered the new mission, which represents the new starting point of the mission chain.

----------------------
**Content (Artwork / Missions / Jobs)**

## Summary
This pull request fixes a compatibility issue caused by the addition of the new "FW Escort 0" mission, which now preceeds "FW Escort 1" in the Free Worlds escort mission chain. See issue #7528.

-----------------------
**Bugfix:** This PR addresses issue #7528

## Fix Details
When the new "FW Escort 0" mission was added, no checks were put in place to prevent the mission from being offered to players who had completed the old mission chain, but not yet joined the Free Worlds officially. This patch adds checks to see if the old starting point of the mission chain (aka: "FW Escort 1") was offered or completed before offering this one to players, and fails "FW Escort 0" immediately if "FW Escort 1" was ever offered or has been completed.

## Save File
N/A

## Testing Done
No testing done yet.

### Automated Tests Added
Not sure what needs to be done here.

## Performance Impact
N/A
