### PR TITLE
feat(test): Include known failures and missing features in integration tests to run

### DIFF
--- a/endless-sky.6
+++ b/endless-sky.6
@@ -42,10 +42,7 @@ prints any content or whitespace\-formatting errors found while loading data fil
 execute the test case with the given name
 
 .IP \fB\-\-tests
-prints (to STDOUT) a table of available tests, usable for automatic test runs. This option prevents the game from launching.
-
-.IP \fB\-\-list\-tests
-prints (to STDOUT) a list of every runnable test, usable for automatic test runs. This option prevents the game from launching.
+prints (to STDOUT) a list of available tests, usable for automatic test runs. This option prevents the game from launching.
 
 .IP \fB\-s,\ \-\-ships
 prints (to STDOUT) a table of ship stats (just the base stats, not considering any stored outfits). This option prevents the game from launching.

--- a/endless-sky.6
+++ b/endless-sky.6
@@ -44,6 +44,9 @@ execute the test case with the given name
 .IP \fB\-\-tests
 prints (to STDOUT) a table of available tests, usable for automatic test runs. This option prevents the game from launching.
 
+.IP \fB\-\-list\-tests
+prints (to STDOUT) a list of every runnable test, usable for automatic test runs. This option prevents the game from launching.
+
 .IP \fB\-s,\ \-\-ships
 prints (to STDOUT) a table of ship stats (just the base stats, not considering any stored outfits). This option prevents the game from launching.
 .RS

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -374,6 +374,13 @@ const string &Test::Name() const
 
 
 
+Test::Status Test::GetStatus() const
+{
+	return status;
+}
+
+
+
 // Check the game status and perform the next test action.
 void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive) const
 {

--- a/source/Test.h
+++ b/source/Test.h
@@ -116,6 +116,7 @@ public:
 
 public:
 	const std::string &Name() const;
+	Status GetStatus() const;
 	const std::string &StatusText() const;
 
 	// Check the game status and perform the next test action.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -484,7 +484,7 @@ void PrintTestsTable()
 {
 	for(auto &it : GameData::Tests())
 		if(it.second.GetStatus() != Test::Status::PARTIAL
-			&& it.second.GetStatus() != Test::Status::BROKEN)
+				&& it.second.GetStatus() != Test::Status::BROKEN)
 			cout << it.second.Name() << '\n';
 	cout.flush();
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -482,11 +482,11 @@ Conversation LoadConversation()
 // (active/missing feature/known failure)..
 void PrintTestsTable()
 {
-    for(auto &it : GameData::Tests())
-        if(it.second.GetStatus() != Test::Status::PARTIAL
-                && it.second.GetStatus() != Test::Status::BROKEN)
-            cout << it.second.Name() << '\n';
-    cout.flush();
+	for(auto &it : GameData::Tests())
+		if(it.second.GetStatus() != Test::Status::PARTIAL
+			&& it.second.GetStatus() != Test::Status::BROKEN)
+			cout << it.second.Name() << '\n';
+	cout.flush();
 }
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -66,7 +66,6 @@ void PrintVersion();
 void GameLoop(PlayerInfo &player, const Conversation &conversation, const string &testToRun, bool debugMode);
 Conversation LoadConversation();
 void PrintTestsTable();
-void PrintTestsList();
 #ifdef _WIN32
 void InitConsole();
 #endif
@@ -85,7 +84,6 @@ int main(int argc, char *argv[])
 	bool debugMode = false;
 	bool loadOnly = false;
 	bool printTests = false;
-	bool printTestsList = false;
 	bool printData = false;
 	string testToRunName = "";
 
@@ -115,8 +113,6 @@ int main(int argc, char *argv[])
 			testToRunName = *it;
 		else if(arg == "--tests")
 			printTests = true;
-		else if(arg == "--list-tests")
-			printTestsList = true;
 	}
 	if(PrintData::IsPrintDataArgument(argv))
 		printData = true;
@@ -124,7 +120,7 @@ int main(int argc, char *argv[])
 
 	try {
 		// Begin loading the game data.
-		bool isConsoleOnly = loadOnly || printTests || printTestsList || printData;
+		bool isConsoleOnly = loadOnly || printTests || printData;
 		future<void> dataLoading = GameData::BeginLoad(isConsoleOnly, debugMode);
 
 		// If we are not using the UI, or performing some automated task, we should load
@@ -146,11 +142,6 @@ int main(int argc, char *argv[])
 		if(printTests)
 		{
 			PrintTestsTable();
-			return 0;
-		}
-		if(printTestsList)
-		{
-			PrintTestsList();
 			return 0;
 		}
 
@@ -430,7 +421,6 @@ void PrintHelp()
 	cerr << "    -d, --debug: turn on debugging features (e.g. Caps Lock slows down instead of speeds up)." << endl;
 	cerr << "    -p, --parse-save: load the most recent saved game and inspect it for content errors." << endl;
 	cerr << "    --tests: print table of available tests, then exit." << endl;
-	cerr << "    --list-tests: print list of test names that can be run, then exit.." << endl;
 	cerr << "    --test <name>: run given test from resources directory." << endl;
 	PrintData::Help();
 	cerr << endl;
@@ -492,26 +482,11 @@ Conversation LoadConversation()
 // (active/missing feature/known failure)..
 void PrintTestsTable()
 {
-	cout << "status" << '\t' << "name" << '\n';
-	for(auto &it : GameData::Tests())
-	{
-		const Test &test = it.second;
-		cout << test.StatusText() << '\t';
-		cout << "\"" << test.Name() << "\"" << '\n';
-	}
-	cout.flush();
-}
-
-
-
-// This prints out a list of every test.
-void PrintTestsList()
-{
-	for(auto &it : GameData::Tests())
-		if(it.second.GetStatus() != Test::Status::PARTIAL
-				&& it.second.GetStatus() != Test::Status::BROKEN)
-			cout << it.second.Name() << '\n';
-	cout.flush();
+    for(auto &it : GameData::Tests())
+        if(it.second.GetStatus() != Test::Status::PARTIAL
+                && it.second.GetStatus() != Test::Status::BROKEN)
+            cout << it.second.Name() << '\n';
+    cout.flush();
 }
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -66,6 +66,7 @@ void PrintVersion();
 void GameLoop(PlayerInfo &player, const Conversation &conversation, const string &testToRun, bool debugMode);
 Conversation LoadConversation();
 void PrintTestsTable();
+void PrintTestsList();
 #ifdef _WIN32
 void InitConsole();
 #endif
@@ -84,6 +85,7 @@ int main(int argc, char *argv[])
 	bool debugMode = false;
 	bool loadOnly = false;
 	bool printTests = false;
+	bool printTestsList = false;
 	bool printData = false;
 	string testToRunName = "";
 
@@ -113,6 +115,8 @@ int main(int argc, char *argv[])
 			testToRunName = *it;
 		else if(arg == "--tests")
 			printTests = true;
+		else if(arg == "--list-tests")
+			printTestsList = true;
 	}
 	if(PrintData::IsPrintDataArgument(argv))
 		printData = true;
@@ -120,7 +124,7 @@ int main(int argc, char *argv[])
 
 	try {
 		// Begin loading the game data.
-		bool isConsoleOnly = loadOnly || printTests || printData;
+		bool isConsoleOnly = loadOnly || printTests || printTestsList || printData;
 		future<void> dataLoading = GameData::BeginLoad(isConsoleOnly, debugMode);
 
 		// If we are not using the UI, or performing some automated task, we should load
@@ -142,6 +146,11 @@ int main(int argc, char *argv[])
 		if(printTests)
 		{
 			PrintTestsTable();
+			return 0;
+		}
+		if(printTestsList)
+		{
+			PrintTestsList();
 			return 0;
 		}
 
@@ -421,6 +430,7 @@ void PrintHelp()
 	cerr << "    -d, --debug: turn on debugging features (e.g. Caps Lock slows down instead of speeds up)." << endl;
 	cerr << "    -p, --parse-save: load the most recent saved game and inspect it for content errors." << endl;
 	cerr << "    --tests: print table of available tests, then exit." << endl;
+	cerr << "    --list-tests: print list of test names that can be run, then exit.." << endl;
 	cerr << "    --test <name>: run given test from resources directory." << endl;
 	PrintData::Help();
 	cerr << endl;
@@ -489,6 +499,18 @@ void PrintTestsTable()
 		cout << test.StatusText() << '\t';
 		cout << "\"" << test.Name() << "\"" << '\n';
 	}
+	cout.flush();
+}
+
+
+
+// This prints out a list of every test.
+void PrintTestsList()
+{
+	for(auto &it : GameData::Tests())
+		if(it.second.GetStatus() != Test::Status::PARTIAL
+				&& it.second.GetStatus() != Test::Status::BROKEN)
+			cout << it.second.Name() << '\n';
 	cout.flush();
 }
 

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_ship_sale.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_ship_sale.txt
@@ -1,6 +1,6 @@
 test "Sell 0 ships"
 	# Known failure, see https://github.com/endless-sky/endless-sky/issues/6628
-	status "known failure"
+	status active
 	description "Test departing without sell a ship."
 	sequence
 		# Create/inject the savegame and load it.

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_ship_sale.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_ship_sale.txt
@@ -1,5 +1,4 @@
 test "Sell 0 ships"
-	# Known failure, see https://github.com/endless-sky/endless-sky/issues/6628
 	status active
 	description "Test departing without sell a ship."
 	sequence

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -150,7 +150,7 @@ fi
 # Set separator to newline (in case tests have spaces in their name)
 IFS=$'\n'
 
-TESTS=$("${ES_EXEC_PATH}" --list-tests --resources "${RESOURCES}" --config "${ES_CONFIG_TEMPLATE_PATH}")
+TESTS=$("${ES_EXEC_PATH}" --tests --resources "${RESOURCES}" --config "${ES_CONFIG_TEMPLATE_PATH}")
 TESTS_OK=($(echo "${TESTS}")) || true
 NUM_TOTAL=${#TESTS_OK[@]}
 

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -150,12 +150,10 @@ fi
 # Set separator to newline (in case tests have spaces in their name)
 IFS=$'\n'
 
-TESTS=$("${ES_EXEC_PATH}" --tests --resources "${RESOURCES}" --config "${ES_CONFIG_TEMPLATE_PATH}")
-TESTS_OK=($(echo "${TESTS}" | grep -e "^active" | cut -f2)) || true
-TESTS_NOK=($(echo "${TESTS}" | grep -e "^known failure" -e "^missing feature" | cut -f2)) || true
+TESTS=$("${ES_EXEC_PATH}" --list-tests --resources "${RESOURCES}" --config "${ES_CONFIG_TEMPLATE_PATH}")
+TESTS_OK=($(echo "${TESTS}")) || true
 NUM_TOTAL=${#TESTS_OK[@]}
 
-#TODO: Allow running known-failures by default as well (to check if they accidentally got solved)
 if [ ${NUM_TOTAL} -eq 0 ]
 then
   echo "1..1"


### PR DESCRIPTION
## Feature Details

This PR adds a new option, `--list-tests` that lists every runnable (i.e. not partial and not broken) integration test. This simplifies getting the list of tests to run.

I modified the `run_tests.sh` script accordingly, and changed the status of one test because it now succeeds.

## Testing Done

Used the option: it works. Also ran the integration tests, which CI should also run.