### PR TITLE
**Very** Scuffed Solution to Game Slowdown at Low Display Refresh Rates

### DIFF
--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -93,7 +93,8 @@ bool GameWindow::Init()
 	}
 	if(mode.refresh_rate && mode.refresh_rate < 60)
 		Logger::LogError("Warning: low monitor frame rate detected (" + to_string(mode.refresh_rate) + ")."
-			" The game will run more slowly.");
+			" The game will stutter.");
+	Screen::SetFrameRate(mode.refresh_rate);
 
 	// Make the window just slightly smaller than the monitor resolution.
 	int minWidth = 640;

--- a/source/Screen.cpp
+++ b/source/Screen.cpp
@@ -27,6 +27,7 @@ namespace {
 	int USER_ZOOM = 100;
 	int EFFECTIVE_ZOOM = 100;
 	bool HIGH_DPI = false;
+	int FRAME_RATE = 60;
 }
 
 
@@ -88,6 +89,20 @@ void Screen::SetHighDPI(bool isHighDPI)
 bool Screen::IsHighResolution()
 {
 	return HIGH_DPI || (EFFECTIVE_ZOOM > 100);
+}
+
+
+
+void Screen::SetFrameRate(int frameRate)
+{
+	FRAME_RATE = frameRate;
+}
+
+
+
+int Screen::FrameRate()
+{
+	return FRAME_RATE;
 }
 
 

--- a/source/Screen.h
+++ b/source/Screen.h
@@ -38,6 +38,9 @@ public:
 	// This is true if the screen is high DPI, or if the zoom is above 100%.
 	static bool IsHighResolution();
 
+	static void SetFrameRate(int frameRate);
+	static int FrameRate();
+
 	static Point Dimensions();
 	static int Width();
 	static int Height();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -235,6 +235,7 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 	int testDebugUIDelay = 3 * 60;
 
 	// If fast forwarding, keep track of whether the current frame should be drawn.
+	int skipFrame = 0;
 	uint64_t frame = 0;
 	double newMod = 0;
 
@@ -351,7 +352,8 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 			// We don't skip UI-frames to ensure we test the UI code more.
 			if(inFlight && !debugMode)
 			{
-				if(frame % 30)
+				skipFrame = (skipFrame + 1) % 30;
+				if(skipFrame)
 					continue;
 			}
 			else
@@ -375,18 +377,19 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 				timer.SetFrameRate(frameRate);
 			}
 
-			if(isFastForward && inFlight)
-			{
-				if(frame % 3)
-					continue;
-			}
-
 			if(Screen::FrameRate() < 60)
 			{
 				double oldMod = newMod;
-				newMod = fmod(static_cast<double>(frame), 60./static_cast<double>(Screen::FrameRate()));
+				newMod = fmod(static_cast<double>(frame), 60./Screen::FrameRate());
 
 				if(oldMod < newMod)
+					continue;
+			}
+
+			if(isFastForward && inFlight)
+			{
+				skipFrame = (skipFrame + 1) % 3;
+				if(skipFrame)
 					continue;
 			}
 		}


### PR DESCRIPTION
## Fix Details
This PR makes it so that the game calculates a gamestep twice occasionally with monitors that have <60 frames per second (i.e. it will calculate the gamestep twice every frame at 30fps). This should stop the game from slowing down, at the cost of a pretty nasty stutter.

It's a very scuffed fix, and I just put this out as a option for people that really need it.

It does not apply to monitors with refresh rates at or above 60, and monitors with an fps that is a factor of 60 will also be smooth.