### PR TITLE
Bugfix(AI): account for special damages for forbearing

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3554,7 +3554,7 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	if(damage.Ion())
 	{
 		double scale = Energy() * 220.;
-		double ionWeaponJamChance = ionization > .1 ? min(0.5, scale ? ionization / scale : 1.) : 0.;
+		ionWeaponJamChance = ionization > .1 ? min(0.5, scale ? ionization / scale : 1.) : 0.;
 	}
 	// If this ship did not consider itself an enemy of the ship that hit it,
 	// it is now "provoked" against that government.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3550,13 +3550,17 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	else if(heat < .9 * MaximumHeat())
 		isOverheated = false;
 
-	double scale = Energy() * 220.;
-	double jamChance = ionization > .1 ? min(0.5, scale ? ionization / scale : 1.) : 0.;
+	double ionWeaponJamChance = 0.;
+	if(damage.Ion())
+	{
+		double scale = Energy() * 220.;
+		double ionWeaponJamChance = ionization > .1 ? min(0.5, scale ? ionization / scale : 1.) : 0.;
+	}
 	// If this ship did not consider itself an enemy of the ship that hit it,
 	// it is now "provoked" against that government.
 	if(sourceGovernment && !sourceGovernment->IsEnemy(government)
 			&& (!personality.IsForbearing() || Shields() < .9 || Hull() < .9
-				|| isOverheated || jamChance > 0.1 || slowness > 10.)
+				|| isOverheated || ionWeaponJamChance > 0.1 || slowness > 10. && damage.Slowing())
 			&& !personality.IsPacifist() && damage.GetWeapon().DoesDamage())
 		type |= ShipEvent::PROVOKE;
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3550,10 +3550,13 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	else if(heat < .9 * MaximumHeat())
 		isOverheated = false;
 
+	double scale = Energy() * 220.;
+	double jamChance = ionization > .1 ? min(0.5, scale ? ionization / scale : 1.) : 0.;
 	// If this ship did not consider itself an enemy of the ship that hit it,
 	// it is now "provoked" against that government.
 	if(sourceGovernment && !sourceGovernment->IsEnemy(government)
-			&& (Shields() < .9 || Hull() < .9 || !personality.IsForbearing())
+			&& (!personality.IsForbearing() || Shields() < .9 || Hull() < .9
+				|| isOverheated || jamChance > 0.1 || slowness > 10.)
 			&& !personality.IsPacifist() && damage.GetWeapon().DoesDamage())
 		type |= ShipEvent::PROVOKE;
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3559,7 +3559,7 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	// it is now "provoked" against that government.
 	if(sourceGovernment && !sourceGovernment->IsEnemy(government)
 			&& (!personality.IsForbearing() || Shields() < .9 || Hull() < .9
-				|| isOverheated || ionWeaponJamChance > 0.1 || slowness > 10. && damage.Slowing())
+				|| isOverheated || ionWeaponJamChance > 0.1 || (slowness > 10. && damage.Slowing()))
 			&& !personality.IsPacifist() && damage.GetWeapon().DoesDamage())
 		type |= ShipEvent::PROVOKE;
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3557,15 +3557,15 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	// If this ship did not consider itself an enemy of the ship that hit it,
 	// it is now "provoked" against that government.
 	if(sourceGovernment && !sourceGovernment->IsEnemy(government)
-			&& personality.IsForbearing() && !personality.IsPacifist()
-			&& (((damage.Shield() || damage.Discharge()) && Shields() < .9)
-			|| ((damage.Hull() || damage.Corrosion()) && Hull() < .9)
-			|| ((damage.Heat() || damage.Burn()) && isOverheated)
-			|| (damage.Ion() && CalculateJamChance(Energy(), ionization) > 0.1)
-			|| (damage.Slowing() && slowness > 10.)
-			|| ((damage.Energy() || damage.Ion()) && Energy() < 0.5)
-			|| ((damage.Fuel() || damage.Leak()) && fuel < JumpFuel() * 2.)
-			|| (damage.Disruption() && disruption > 100.)))
+			&& !personality.IsPacifist() && (!personality.IsForbearing()
+				|| ((damage.Shield() || damage.Discharge()) && Shields() < .9)
+				|| ((damage.Hull() || damage.Corrosion()) && Hull() < .9)
+				|| ((damage.Heat() || damage.Burn()) && isOverheated)
+				|| ((damage.Energy() || damage.Ion()) && Energy() < 0.5)
+				|| ((damage.Fuel() || damage.Leak()) && fuel < JumpFuel() * 2.)
+				|| (damage.Ion() && CalculateJamChance(Energy(), ionization) > 0.1)
+				|| (damage.Slowing() && slowness > 10.)
+				|| (damage.Disruption() && disruption > 100.)))
 		type |= ShipEvent::PROVOKE;
 
 	// Create target effect visuals, if there are any.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3559,7 +3559,7 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	// it is now "provoked" against that government.
 	if(sourceGovernment && !sourceGovernment->IsEnemy(government)
 			&& (!personality.IsForbearing() || Shields() < .9 || Hull() < .9
-				|| isOverheated || ionWeaponJamChance > 0.1 || (slowness > 10. && damage.Slowing()))
+				|| isOverheated || ionWeaponJamChance > 0.1 || slowness > 10.)
 			&& !personality.IsPacifist() && damage.GetWeapon().DoesDamage())
 		type |= ShipEvent::PROVOKE;
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -173,7 +173,7 @@ namespace {
 		}
 		return transferred;
 	}
-	
+
 	// Ships which are ionized have a chance for their weapons to jam,
 	// delaying their firing for another reload cycle. The less energy
 	// a ship has relative to its max and the more ionized the ship is,


### PR DESCRIPTION
**Bugfix:** This PR addresses forbearing personality not accounting for special damage types, meaning you can overheat them and let them disable themselves by moving around without them doing anything about it.

## Fix Details
Forbearing ships will now be provoked when either:
-taking shield/discharge damage and shields are lower than 90%
-taking hull/corrosion damage and hull is lower than 90%
-taking heat/burn damage and is overheated
-taking ion damage and has 10% chance of jamming
-taking ion/energy damage and its energy is lower than 50%
-taking slowing damage and is slown by 10%
-taking fuel damage and has no more than 2 jumps worth of fuel left
-taking disruption damage and has more than 100 disruption

Instead of just when hull/shields are lower than 90%.

## Testing Done
n/a
Seems pretty straightforward to me and I prefer to see if these kind of changes are welcomed before eventually testing.

## Save File
n/a