### PR TITLE
[Mechanic] Inertia Reduction

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -280,6 +280,9 @@ tip "illegal:"
 
 tip "income:"
 	`Amount of credits you receive per day that you own this outfit, even if it is not in active use.`
+	
+tip "inertia reduction:"
+	`Reduces effective ship mass. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in inertia, while a total value of 11 only results in a 10 percent reduction.`
 
 tip "ion protection:"
 	`Protection against weapons that do ion damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in ion damage, while a total value of 11 only results in a 10 percent reduction.`

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1931,7 +1931,7 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed, const Point directi
 		forwardTime += stopTime;
 
 		// Figure out your reverse thruster stopping time:
-		double reverseAcceleration = ship.Attributes().Get("reverse thrust") / ship.Mass();
+		double reverseAcceleration = ship.Attributes().Get("reverse thrust") / ship.InertialMass();
 		double reverseTime = (180. - degreesToTurn) / ship.TurnRate();
 		reverseTime += speed / reverseAcceleration;
 
@@ -2064,7 +2064,7 @@ void AI::KeepStation(Ship &ship, Command &command, const Body &target)
 	double maxV = ship.MaxVelocity();
 	double accel = ship.Acceleration();
 	double turn = ship.TurnRate();
-	double mass = ship.Mass();
+	double mass = ship.InertialMass();
 	Point unit = ship.Facing().Unit();
 	double currentAngle = ship.Facing().Degrees();
 	// This is where we want to be relative to where we are now:
@@ -2773,7 +2773,7 @@ Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &sho
 	if(ship.Attributes().Get("reverse thrust"))
 	{
 		// Figure out your reverse thruster stopping distance:
-		double reverseAcceleration = ship.Attributes().Get("reverse thrust") / ship.Mass();
+		double reverseAcceleration = ship.Attributes().Get("reverse thrust") / ship.InertialMass();
 		double reverseDistance = v * (180. - degreesToTurn) / turnRate;
 		reverseDistance += .5 * v * v / reverseAcceleration;
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -140,6 +140,7 @@ namespace {
 		{"discharge protection", -0.99},
 		{"drag reduction", -0.99},
 		{"corrosion protection", -0.99},
+		{"inertia reduction", -0.99},
 		{"ion protection", -0.99},
 		{"leak protection", -0.99},
 		{"burn protection", -0.99},

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -176,6 +176,7 @@ namespace {
 		{"fuel protection", 4},
 		{"heat protection", 4},
 		{"hull protection", 4},
+		{"inertia reduction", 4},
 		{"ion protection", 4},
 		{"leak protection", 4},
 		{"piercing protection", 4},

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3462,9 +3462,10 @@ bool Ship::CanBeFlagship() const
 
 
 
+// Account for inertia reduction
 double Ship::Mass() const
 {
-	return carriedMass + cargo.Used() + attributes.Mass();
+	return carriedMass + cargo.Used() + attributes.Mass() / (1 + attributes.Get("inertia reduction"));
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3462,7 +3462,8 @@ bool Ship::CanBeFlagship() const
 
 
 
-// Account for inertia reduction
+// Account for inertia reduction, which only affects the ship's mass and not cargo or carried ships.
+// It also has no effect on maximum heat or heat capacity.
 double Ship::Mass() const
 {
 	return carriedMass + cargo.Used() + attributes.Mass() / (1 + attributes.Get("inertia reduction"));

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2453,7 +2453,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships, vector<Visual> &visuals)
 			bay.ship->SetParent(shared_from_this());
 			bay.ship->UnmarkForRemoval();
 			// Update the cached sum of carried ship masses.
-			carriedMass -= bay.ship->InertialMass();
+			carriedMass -= bay.ship->Mass();
 			// Create the desired launch effects.
 			for(const Effect *effect : bay.launchEffects)
 				visuals.emplace_back(*effect, exitPoint, velocity, launchAngle);
@@ -3469,11 +3469,10 @@ double Ship::Mass() const
 
 
 
-// Account for inertia reduction, which only affects the ship's mass and not cargo or carried ships.
-// It also has no effect on maximum heat or heat capacity.
+// Account for inertia reduction, which affects movement but has no effect on the ship's heat capacity.
 double Ship::InertialMass() const
 {
-	return (carriedMass + cargo.Used() + attributes.Mass()) / (1. + attributes.Get("inertia reduction"));
+	return Mass() / (1. + attributes.Get("inertia reduction"));
 }
 
 
@@ -3724,7 +3723,7 @@ bool Ship::Carry(const shared_ptr<Ship> &ship)
 			TransferAmmo(toRestock, *ship, *this);
 
 			// Update the cached mass of the mothership.
-			carriedMass += ship->InertialMass();
+			carriedMass += ship->Mass();
 			return true;
 		}
 	return false;
@@ -3737,7 +3736,7 @@ void Ship::UnloadBays()
 	for(Bay &bay : bays)
 		if(bay.ship)
 		{
-			carriedMass -= bay.ship->InertialMass();
+			carriedMass -= bay.ship->Mass();
 			bay.ship->SetSystem(currentSystem);
 			bay.ship->SetPlanet(landingPlanet);
 			bay.ship->UnmarkForRemoval();

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3473,7 +3473,7 @@ double Ship::Mass() const
 // It also has no effect on maximum heat or heat capacity.
 double Ship::InertialMass() const
 {
-	return carriedMass + cargo.Used() + attributes.Mass() / (1. + attributes.Get("inertia reduction"));
+	return (carriedMass + cargo.Used() + attributes.Mass()) / (1. + attributes.Get("inertia reduction"));
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3473,7 +3473,7 @@ double Ship::Mass() const
 // It also has no effect on maximum heat or heat capacity.
 double Ship::InertialMass() const
 {
-	return carriedMass + cargo.Used() + attributes.Mass() / (1 + attributes.Get("inertia reduction"));
+	return carriedMass + cargo.Used() + attributes.Mass() / (1. + attributes.Get("inertia reduction"));
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -356,6 +356,7 @@ public:
 
 	// Get this ship's movement characteristics.
 	double Mass() const;
+	double InertialMass() const;
 	double TurnRate() const;
 	double Acceleration() const;
 	double MaxVelocity() const;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -192,7 +192,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(Format::Number(attributes.Get("hull")));
 	}
 	attributesHeight += 20;
-	double emptyMass = attributes.Mass();
+	double emptyMass = attributes.Mass() / (1 + attributes.Get("inertia reduction"));
 	double currentMass = ship.Mass();
 	attributeLabels.push_back(isGeneric ? "mass with no cargo:" : "mass:");
 	attributeValues.push_back(Format::Number(isGeneric ? emptyMass : currentMass) + " tons");

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -195,7 +195,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	double emptyMass = attributes.Mass() / (1. + attributes.Get("inertia reduction"));
 	double currentMass = ship.InertialMass();
 	attributeLabels.push_back(isGeneric ? "mass with no cargo:" : "mass:");
-	attributeValues.push_back(Format::Number(isGeneric ? emptyMass : currentMass) + " tons");
+	attributeValues.push_back(Format::Number(isGeneric ? attributes.Mass() : ship.Mass()) + " tons");
 	attributesHeight += 20;
 	attributeLabels.push_back(isGeneric ? "cargo space:" : "cargo:");
 	if(isGeneric)

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -192,8 +192,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(Format::Number(attributes.Get("hull")));
 	}
 	attributesHeight += 20;
-	double emptyMass = ship.InertialMass();
-	double currentMass = attributes.Mass();
+	double emptyMass = attributes.Mass() / (1. + attributes.Get("inertia reduction"));
+	double currentMass = ship.InertialMass();
 	attributeLabels.push_back(isGeneric ? "mass with no cargo:" : "mass:");
 	attributeValues.push_back(Format::Number(isGeneric ? emptyMass : currentMass) + " tons");
 	attributesHeight += 20;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -192,8 +192,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(Format::Number(attributes.Get("hull")));
 	}
 	attributesHeight += 20;
-	double emptyMass = attributes.Mass() / (1 + attributes.Get("inertia reduction"));
-	double currentMass = ship.Mass();
+	double emptyMass = ship.InertialMass();
+	double currentMass = attributes.Mass();
 	attributeLabels.push_back(isGeneric ? "mass with no cargo:" : "mass:");
 	attributeValues.push_back(Format::Number(isGeneric ? emptyMass : currentMass) + " tons");
 	attributesHeight += 20;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -217,7 +217,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 			+ " / " + Format::Number(fuelCapacity));
 	attributesHeight += 20;
 
-	double fullMass = emptyMass + attributes.Get("cargo space");
+	double fullMass = emptyMass + attributes.Get("cargo space") / (1. + attributes.Get("inertia reduction"));
 	isGeneric &= (fullMass != emptyMass);
 	double forwardThrust = attributes.Get("thrust") ? attributes.Get("thrust") : attributes.Get("afterburner thrust");
 	attributeLabels.push_back(string());

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -192,10 +192,10 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		attributeValues.push_back(Format::Number(attributes.Get("hull")));
 	}
 	attributesHeight += 20;
-	double emptyMass = attributes.Mass() / (1. + attributes.Get("inertia reduction"));
-	double currentMass = ship.InertialMass();
+	double emptyMass = attributes.Mass();
+	double currentMass = ship.Mass();
 	attributeLabels.push_back(isGeneric ? "mass with no cargo:" : "mass:");
-	attributeValues.push_back(Format::Number(isGeneric ? attributes.Mass() : ship.Mass()) + " tons");
+	attributeValues.push_back(Format::Number(isGeneric ? emptyMass : currentMass) + " tons");
 	attributesHeight += 20;
 	attributeLabels.push_back(isGeneric ? "cargo space:" : "cargo:");
 	if(isGeneric)
@@ -217,7 +217,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 			+ " / " + Format::Number(fuelCapacity));
 	attributesHeight += 20;
 
-	double fullMass = emptyMass + attributes.Get("cargo space") / (1. + attributes.Get("inertia reduction"));
+	double fullMass = emptyMass + attributes.Get("cargo space");
 	isGeneric &= (fullMass != emptyMass);
 	double forwardThrust = attributes.Get("thrust") ? attributes.Get("thrust") : attributes.Get("afterburner thrust");
 	attributeLabels.push_back(string());
@@ -230,6 +230,11 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	attributeValues.push_back(Format::Number(60. * forwardThrust / ship.Drag()));
 	attributesHeight += 20;
 
+	// Movement stats are influenced by inertia redeuction.
+	double reduction = 1. + attributes.Get("inertia reduction");
+	emptyMass /= reduction;
+	currentMass /= reduction;
+	fullMass /= reduction;
 	attributeLabels.push_back("acceleration:");
 	if(!isGeneric)
 		attributeValues.push_back(Format::Number(3600. * forwardThrust / currentMass));


### PR DESCRIPTION
[Was making this really a better use of time than paying attention to my orbital mechanics class?]


## Summary
This adds a new attribute, `inertia reduction`, that reduces a ship's effective mass. It works similarly to the various protection attributes, where the new mass value is given by

`inertial mass = mass / (1 + inertia reduction)`

This is done in such a way that does not affect maximum heat / heat capacity. The attribute only affects mass with regards to movement.

## Feature Details
A positive mass reduction value makes a ship less massy. For example, `mass reduction` 1 would cut your ship's inertia in half.
This only affects your base ship and its outfits. Cargo and docked fighters/drones will not be affected.

Inertia reduction can also be negative, up to -0.99. This lets you increase a ship's inertia by up to a factor of 100, if you wanted to do that for some reason.


## Usage Examples
This can be added to an outfit or ship (though in that case you should just directly reduce the mass lol) in the same way as any other attribute.


For example,
<img src=https://i.gyazo.com/3bdda7b2f635634219ef975c6cdb7390.png width="200" />


I see this as being most useful as a way to further differentiate different species' engines beyond our current options, such as for advanced civilizations like the Quarg. I believe @Hurleveur has an open PR that could use this.

## UI Screenshots

A Scout's stats with no inertia reduction vs with the "Negative Energy Stress Tensor" (`inertia reduction` 1) installed.

<img src=https://i.gyazo.com/30863b2ee95d077f23a93e7155533cb7.png width="200" />


<img src=https://i.gyazo.com/2c8165d36ef8b6a1a0d14cba53739141.png width="200" />



## Testing Done
Made an outfit that had the `inertia reduction` attribute and flew around, noting the increased acceleration and turning. Also tried an outfit with negative inertia reduction and was able to see the ship get more massive.

## Performance Impact
N/A