### PR TITLE
docs(PR Template): Add title guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,65 @@
+### How To Title Your PR
+
+A good Pull Request title will use the following structure:
+`<type>(<scope>): [optional faction] Title`
+
+<details>
+ <summary>Suggested Types</summary>
+
+- `build`: Changes that affect the build system or external dependencies.
+- `chore`: Changes to the build process or additional tools and libraries such as documentation generation.
+- `ci`: Changes to our CI configuration files and scripts.
+- `docs`: Documentation only changes
+- `feat`: A new feature
+- `fix`: A bug fix
+- `perf`: A code change that improves performance
+- `refactor`: A code change that neither fixes a bug nor adds a feature
+- `style`: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
+- `test`: Adding missing tests or correcting existing tests
+
+</details>
+
+<details>
+ <summary>Suggested Scopes</summary>
+
+-   `content`: Additional missions, ships, outfits, or other content that doesn't require code changes
+-   `balance`: Addition or modification of existing ship/outfit stats
+-   `mechanics`: Modifications to the game engine which affect gameplay
+-   `UI`: Modifications of existing User Interface elements
+-   `enhancement`: Additional features added to the game engine
+
+</details>
+
+<details>
+ <summary>Suggested Factions</summary>
+
+-   `Human`
+-   `Hai`
+-   `Wanderer`
+-   `Remnant`
+-   `Builder`
+-   `Korath`
+-   `Coalition`
+-   `Quarg`
+-   `Drak`
+-   `Pug`
+-   `Sheragi`
+-   Others not listed are allowed; use your best judgment when necessary.
+
+</details>
+
+<details>
+ <summary>Title</summary>
+
+- Provide a clear, concise, and descriptive title of your PR's function without repeating information already provided with the previous tags.
+
+ </details>
+
+### PR Template
+
 NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
 (You can open a PR to add or improve a section, if you find them lacking!)
+
 
 ----------------------
 **Content (Artwork / Missions / Jobs)**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ A good Pull Request title will use the following structure:
 - `fix`: A bug fix
 - `perf`: A code change that improves performance
 - `refactor`: A code change that neither fixes a bug nor adds a feature
-- `style`: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
+- `style`: Changes that do not affect the meaning of the code (white space, formatting, etc.)
 - `test`: Adding missing tests or correcting existing tests
 
 </details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,11 +22,15 @@ A good Pull Request title will use the following structure:
 <details>
  <summary>Suggested Scopes</summary>
 
--   `content`: Additional missions, ships, outfits, or other content that doesn't require code changes
 -   `balance`: Addition or modification of existing ship/outfit stats
 -   `mechanics`: Modifications to the game engine which affect gameplay
 -   `UI`: Modifications of existing User Interface elements
 -   `enhancement`: Additional features added to the game engine
+-   `AI`: Modification to the game engine which affect NPC/Escort Behavior
+-   `mission`: Addition or Modification of missions
+-   `ship`: Addition or Modification of ships
+-   `outfit`: Addition or Modification of outfits
+-   `content`: Additional content that is not ships, outfits or missions
 
 </details>
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -60,7 +60,6 @@ A good Pull Request title will use the following structure:
 NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
 (You can open a PR to add or improve a section, if you find them lacking!)
 
-
 ----------------------
 **Content (Artwork / Missions / Jobs)**
 


### PR DESCRIPTION
## Summary
This PR updates our PR template with several basic good practice guidelines for titling PRs, as discussed in issue #7504 
This provides contributors with a standardized template for naming PRs, allowing better and more accurate titles that better follow a standardized format. 

This allows reviewers and maintainers to more quickly and easily discern what a specific PR is changing without necessarily needing to view the PR itself. It also helps remove some of the ambiguity of a non-standardized naming scheme. 

Adopting this will also open up a couple of future enhancements, such as:

1. Automated testing to ensure PR titles conform to our guidelines
2. Automatic tagging of PRs based on the title
3. Automatic assignment of PRs based on the title
4. Better categorization of PRs
5. Better and more thorough labeling of PRs

As we get more individuals wishing to contribute and expand our developer and reviewer team, additional guidelines and automation of basic tasks will help minimize repetitive tasks and allow our maintainers to better focus their efforts on improving the project.

Suggestions for additional Types/Scopes/Factions or changes to the definitions of existing ones are welcome.

## Screenshots
![image](https://user-images.githubusercontent.com/15916854/200903359-40f1182a-0f79-486b-8b8f-b9136f3caf00.png)

![image](https://user-images.githubusercontent.com/15916854/200903894-aefdf24a-d4a6-424b-bc16-ff3deacfc882.png)
