### PR TITLE
[Fix] Coalition Asteroid Energy Reduction

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -92,9 +92,9 @@ system "1 Axis"
 	asteroids "small metal" 1 3.381
 	asteroids "medium metal" 149 4.347
 	asteroids "large metal" 11 3.9606
-	minables lead 11 6.87213
-	minables silicon 35 6.68659
-	minables tungsten 2 5.45307
+	minables lead 11 3.87213
+	minables silicon 35 3.68659
+	minables tungsten 2 4.45307
 	trade Clothing 251
 	trade Electronics 831
 	trade Equipment 469
@@ -171,8 +171,8 @@ system "10 Pole"
 	asteroids "large rock" 2 8.12
 	asteroids "medium metal" 9 11.368
 	asteroids "large metal" 2 4.7096
-	minables neodymium 9 17.5036
-	minables silicon 17 18.2422
+	minables neodymium 9 6.5036
+	minables silicon 17 4.2422
 	trade Clothing 335
 	trade Electronics 832
 	trade Equipment 444
@@ -335,8 +335,8 @@ system "11 Spring Below"
 	asteroids "small metal" 21 1.96
 	asteroids "medium metal" 41 3.696
 	asteroids "large metal" 13 2.128
-	minables silicon 5 6.88994
-	minables tungsten 32 6.67204
+	minables silicon 5 3.88994
+	minables tungsten 32 4.67204
 	trade Clothing 291
 	trade Electronics 710
 	trade Equipment 493
@@ -648,8 +648,8 @@ system "14 Winter Below"
 	asteroids "small metal" 5 3.9744
 	asteroids "medium metal" 3 5.5728
 	asteroids "large metal" 3 2.2896
-	minables neodymium 6 6.79025
-	minables titanium 9 8.6162
+	minables neodymium 6 4.79025
+	minables titanium 9 5.6162
 	trade Clothing 310
 	trade Electronics 787
 	trade Equipment 658
@@ -876,8 +876,8 @@ system "3 Pole"
 	asteroids "small metal" 100 3.1416
 	asteroids "medium metal" 16 1.7864
 	asteroids "large metal" 19 4.466
-	minables lead 2 5.80948
-	minables silicon 42 5.08343
+	minables lead 2 4.80948
+	minables silicon 42 4.08343
 	trade Clothing 240
 	trade Electronics 847
 	trade Equipment 426
@@ -937,8 +937,8 @@ system "3 Spring Rising"
 	asteroids "small metal" 4 5.5917
 	asteroids "medium metal" 12 5.0787
 	asteroids "large metal" 29 3.591
-	minables aluminum 26 7.84109
-	minables silicon 2 11.9047
+	minables aluminum 26 3.84109
+	minables silicon 2 4.9047
 	trade Clothing 218
 	trade Electronics 820
 	trade Equipment 377
@@ -1016,8 +1016,8 @@ system "4 Axis"
 	asteroids "small metal" 8 7.668
 	asteroids "medium metal" 22 7.452
 	asteroids "large metal" 20 6.804
-	minables aluminum 17 9.39886
-	minables iron 3 6.86334
+	minables aluminum 17 4.39886
+	minables iron 3 3.86334
 	trade Clothing 309
 	trade Electronics 724
 	trade Equipment 578
@@ -1081,8 +1081,8 @@ system "4 Spring Rising"
 	asteroids "small metal" 3 11.4492
 	asteroids "medium metal" 42 6.1712
 	asteroids "large metal" 3 8.7696
-	minables iron 16 14.9192
-	minables silver 6 11.5775
+	minables iron 16 4.9192
+	minables silver 6 5.5775
 	trade Clothing 238
 	trade Electronics 785
 	trade Equipment 395
@@ -1150,7 +1150,7 @@ system "4 Summer Rising"
 	asteroids "small metal" 1 7.475
 	asteroids "medium metal" 19 8.8504
 	asteroids "large metal" 1 5.6212
-	minables silicon 3 12.6527
+	minables silicon 3 4.6527
 	trade Clothing 221
 	trade Electronics 851
 	trade Equipment 363
@@ -1293,8 +1293,8 @@ system "5 Axis"
 	asteroids "small metal" 34 6.831
 	asteroids "medium metal" 38 8.91
 	asteroids "large metal" 31 7.0092
-	minables copper 36 7.56345
-	minables iron 23 12.8681
+	minables copper 36 5.56345
+	minables iron 23 4.8681
 	trade Clothing 332
 	trade Electronics 678
 	trade Equipment 605
@@ -1371,8 +1371,8 @@ system "5 Spring Below"
 	asteroids "medium metal" 5 3.7206
 	asteroids "large metal" 3 10.3194
 	minables copper 23 6.90259
-	minables silicon 25 6.11432
-	minables titanium 26 9.46178
+	minables silicon 25 5.11432
+	minables titanium 26 6.46178
 	trade Clothing 342
 	trade Electronics 718
 	trade Equipment 561
@@ -1447,9 +1447,9 @@ system "5 Summer Above"
 	asteroids "small metal" 13 3.9984
 	asteroids "medium metal" 1 3.1752
 	asteroids "large metal" 6 5.8016
-	minables copper 3 5.63642
+	minables copper 3 4.63642
 	minables iron 4 4.74904
-	minables silver 8 7.76172
+	minables silver 8 5.76172
 	trade Clothing 270
 	trade Electronics 823
 	trade Equipment 432
@@ -4253,7 +4253,7 @@ system "Ancient Hope"
 	asteroids "medium rock" 11 5.2693
 	asteroids "large rock" 6 4.9358
 	asteroids "large metal" 3 8.5376
-	minables aluminum 6 11.3536
+	minables aluminum 6 4.3536
 	minables uranium 1 6.83108
 	trade Clothing 314
 	trade Electronics 699
@@ -4383,9 +4383,9 @@ system Answer
 	asteroids "small metal" 16 6.8172
 	asteroids "medium metal" 32 6.8172
 	asteroids "large metal" 24 8.5514
-	minables copper 7 13.583
-	minables neodymium 6 9.23127
-	minables tungsten 18 7.44324
+	minables copper 7 3.583
+	minables neodymium 6 5.23127
+	minables tungsten 18 5.44324
 	trade Clothing 221
 	trade Electronics 703
 	trade Equipment 385
@@ -5282,7 +5282,7 @@ system Beginning
 	asteroids "small metal" 2 5.0778
 	asteroids "medium metal" 7 7.098
 	asteroids "large metal" 19 5.0232
-	minables lead 1 7.49564
+	minables lead 1 4.49564
 	trade Clothing 310
 	trade Electronics 631
 	trade Equipment 448
@@ -5468,9 +5468,9 @@ system Belug
 	asteroids "small metal" 12 8.1648
 	asteroids "medium metal" 108 8.505
 	asteroids "large metal" 1 4.3092
-	minables aluminum 34 11.4021
-	minables titanium 1 14.0326
-	minables uranium 4 14.72
+	minables aluminum 34 4.4021
+	minables titanium 1 5.0326
+	minables uranium 4 6.72
 	trade Clothing 349
 	trade Electronics 737
 	trade Equipment 650
@@ -5760,7 +5760,7 @@ system Bloptab
 	asteroids "small metal" 55 4.23
 	asteroids "medium metal" 21 3.18
 	asteroids "large metal" 4 3.87
-	minables silicon 14 7.35211
+	minables silicon 14 4.35211
 	minables titanium 10 6.77673
 	minables tungsten 8 4.20103
 	trade Clothing 339
@@ -5827,7 +5827,7 @@ system Blubipad
 	asteroids "large rock" 5 5
 	asteroids "medium metal" 7 6.35
 	asteroids "large metal" 9 6.1
-	minables silver 7 9.80748
+	minables silver 7 5.80748
 	trade Clothing 351
 	trade Electronics 668
 	trade Equipment 653
@@ -5890,9 +5890,9 @@ system Blugtad
 	asteroids "small metal" 11 6.075
 	asteroids "medium metal" 17 11.664
 	asteroids "large metal" 1 7.776
-	minables lead 6 8.60749
-	minables platinum 2 12.9822
-	minables silver 2 11.8763
+	minables lead 6 4.60749
+	minables platinum 2 6.9822
+	minables silver 2 5.8763
 	trade Clothing 339
 	trade Electronics 759
 	trade Equipment 653
@@ -7375,8 +7375,8 @@ system Companion
 	asteroids "small metal" 6 9.715
 	asteroids "medium metal" 30 3.915
 	asteroids "large metal" 2 4.1325
-	minables aluminum 2 8.36691
-	minables silicon 7 10.9209
+	minables aluminum 2 5.36691
+	minables silicon 7 4.9209
 	trade Clothing 292
 	trade Electronics 813
 	trade Equipment 442
@@ -7838,7 +7838,7 @@ system "Dark Hills"
 	asteroids "medium metal" 8 1.92
 	asteroids "large metal" 12 4.1472
 	minables gold 2 5.3967
-	minables iron 4 6.82272
+	minables iron 4 4.82272
 	trade Clothing 299
 	trade Electronics 672
 	trade Equipment 385
@@ -9672,8 +9672,8 @@ system Eblumab
 	asteroids "medium metal" 2 4.0612
 	asteroids "large metal" 33 4.5188
 	minables copper 8 6.10344
-	minables iron 6 6.39134
-	minables lead 17 7.069
+	minables iron 6 5.39134
+	minables lead 17 4.069
 	trade Clothing 339
 	trade Electronics 750
 	trade Equipment 648
@@ -11454,7 +11454,7 @@ system "Fell Omen"
 	asteroids "large rock" 34 5.3424
 	asteroids "medium metal" 5 6.6024
 	asteroids "large metal" 1 4.3344
-	minables silicon 71 8.14237
+	minables silicon 71 5.14237
 	minables tungsten 32 8.52992
 	trade Clothing 270
 	trade Electronics 692
@@ -11839,9 +11839,9 @@ system Flugbu
 	asteroids "large rock" 7 4.416
 	asteroids "medium metal" 2 7.5072
 	asteroids "large metal" 4 2.9256
-	minables silicon 3 7.90651
-	minables tungsten 16 7.61572
-	minables uranium 21 5.19184
+	minables silicon 3 4.90651
+	minables tungsten 16 5.61572
+	minables uranium 21 6.19184
 	trade Clothing 298
 	trade Electronics 704
 	trade Equipment 433
@@ -12633,8 +12633,8 @@ system Glubatub
 	asteroids "small metal" 5 3.4713
 	asteroids "medium metal" 43 5.7304
 	asteroids "large metal" 12 6.1161
-	minables aluminum 9 8.60233
-	minables lead 14 9.73445
+	minables aluminum 9 4.60233
+	minables lead 14 5.73445
 	trade Clothing 367
 	trade Electronics 726
 	trade Equipment 597
@@ -13798,9 +13798,9 @@ system Homeward
 	asteroids "small metal" 3 6.1248
 	asteroids "medium metal" 7 3.19
 	asteroids "large metal" 28 4.4022
-	minables platinum 3 9.98007
-	minables silicon 6 5.93079
-	minables uranium 4 7.18515
+	minables platinum 3 7.98007
+	minables silicon 6 4.93079
+	minables uranium 4 6.18515
 	trade Clothing 294
 	trade Electronics 680
 	trade Equipment 585
@@ -13918,8 +13918,8 @@ system Hunter
 	asteroids "small metal" 3 6.669
 	asteroids "medium metal" 1 4.9248
 	asteroids "large metal" 10 7.0794
-	minables silicon 10 7.11503
-	minables tungsten 6 8.18967
+	minables silicon 10 3.11503
+	minables tungsten 6 4.18967
 	trade Clothing 276
 	trade Electronics 736
 	trade Equipment 396
@@ -16780,8 +16780,8 @@ system "Lone Cloud"
 	asteroids "small metal" 4 9.2456
 	asteroids "medium metal" 95 10.1192
 	asteroids "large metal" 9 8.5904
-	minables aluminum 11 7.83953
-	minables silicon 27 14.0224
+	minables aluminum 11 4.83953
+	minables silicon 27 5.0224
 	trade Clothing 185
 	trade Electronics 821
 	trade Equipment 513
@@ -24008,7 +24008,7 @@ system "Silver Bell"
 	asteroids "medium metal" 7 4.3254
 	asteroids "large metal" 8 7.2414
 	minables lead 2 10.4732
-	minables tungsten 3 8.0673
+	minables tungsten 3 4.0673
 	trade Clothing 228
 	trade Electronics 689
 	trade Equipment 485
@@ -24580,7 +24580,7 @@ system "Sol Arach"
 	asteroids "medium metal" 12 6.5016
 	asteroids "large metal" 81 2.8728
 	minables iron 6 4.61643
-	minables silicon 25 7.59101
+	minables silicon 25 4.59101
 	minables titanium 3 5.6753
 	trade Clothing 361
 	trade Electronics 756
@@ -24654,7 +24654,7 @@ system "Sol Kimek"
 	asteroids "large metal" 4 7.3899
 	minables iron 2 7.60621
 	minables lead 2 13.2343
-	minables silicon 7 10.8648
+	minables silicon 7 6.8648
 	trade Clothing 238
 	trade Electronics 812
 	trade Equipment 493
@@ -25118,8 +25118,8 @@ system "Steep Roof"
 	asteroids "small metal" 8 5.2002
 	asteroids "medium metal" 10 2.7702
 	asteroids "large metal" 6 3.2562
-	minables copper 22 6.79651
-	minables silver 18 9.38539
+	minables copper 22 4.79651
+	minables silver 18 6.38539
 	trade Clothing 244
 	trade Electronics 814
 	trade Equipment 388


### PR DESCRIPTION


**Bugfix:**

## Fix Details
Due to the short range of the MCS Resource Extractor, Coalition ships were having trouble mining asteroids, which in some systems was literally impossible for them. I simply went through the Coalition systems and lowered the mineable energy (somewhat arbitrarily) to make things easier for them.

## Testing Done
Flew around and observed that Coalition ships were now able to mine asteroids more easily.

## Save File
N/A