### PR TITLE
fix(map): Prevent dereferencing nullpointer

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1195,6 +1195,8 @@ void MapPanel::DrawMissions()
 	for(const Mission &mission : player.AvailableJobs())
 	{
 		const System *system = mission.Destination()->GetSystem();
+		if(!system)
+			continue;
 		auto &it = missionCount[system];
 		if(mission.CanAccept(player))
 			++it.available;
@@ -1207,6 +1209,8 @@ void MapPanel::DrawMissions()
 			continue;
 
 		const System *system = mission.Destination()->GetSystem();
+		if(!system)
+			continue;
 
 		// Reserve a maximum of half of the slots for available missions.
 		auto &&it = missionCount[system];


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7564.

## Fix Details
Ensures that the game doesn't try to dereference a null pointer, which causes a crash.

The second of the pair of checks added here fix the issue, but the first is probably a good idea anyway.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
https://github.com/endless-sky/endless-sky/files/9993600/a.a.txt

