### PR TITLE
Fix Typo in "Remnant: Cognizance 9"

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -378,7 +378,7 @@ mission "Remnant: Cognizance 9"
 	on offer
 		log "People" "Gavriil" `A technician that works with Plume, and a talented astrobiologist. Gavriil is the project lead for the repurposed Esquiline station.`
 		conversation
-			`You walk into Plume's lab and are greeted by a large stack of crates and equipment. Plume and another Remnant are gathered around the stack, checking items off a list. "Ah, <first>! Good timing. We were just finishing the inventory of supplies that need to go on this delivery. He gestures to the engineer. "This is Gavriil, one of our best technologists and a skilled astrobiologist in his own right. They will be going with you."`
+			`You walk into Plume's lab and are greeted by a large stack of crates and equipment. Plume and another Remnant are gathered around the stack, checking items off a list. "Ah, <first>! Good timing. We were just finishing the inventory of supplies that need to go on this delivery." He gestures to the engineer. "This is Gavriil, one of our best technologists and a skilled astrobiologist in his own right. They will be going with you."`
 			`	"It will be a pleasure to work with you," signs Gavriil, making a short bow. "We will be traveling to a research station on <planet>. Yes, it is a gas giant." He smiles at that. "I have to get some equipment set up and get the core systems online. There will be a few more loads of materials afterwards." He looks askance at you. "Shall we get started?"`
 				accept
 	on complete


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
I found a typo in the dialog for a Remnant mission, and fixed it.

-----------------------
**Bugfix:** This PR addresses issue #7568

## Fix Details
In "Remnant: Cognizance 9," there was a missing quote mark at the end of some dialog. The missing quote mark was added.
