### PR TITLE
fix(content): Add `uncapturable` to Korsmanath A'awoj variants

### DIFF
--- a/data/korath/korath variants.txt
+++ b/data/korath/korath variants.txt
@@ -1090,6 +1090,7 @@ ship "Ra'at Ik 621" "Ra'at Ik 621 (Probes)"
 
 
 ship "Korsmanath A'awoj" "Korsmanath A'awoj (Strike)"
+	"uncapturable"
 	outfits
 		"Banisher Grav-Turret" 7
 		"Grab-Strike Turret" 4
@@ -1147,6 +1148,7 @@ ship "Korsmanath A'awoj" "Korsmanath A'awoj (Strike)"
 
 
 ship "Korsmanath A'awoj" "Korsmanath A'awoj (Special)"
+	"uncapturable"
 	outfits
 		"Banisher Grav-Turret" 4
 		"Digger Mining Turret" 6
@@ -1205,6 +1207,7 @@ ship "Korsmanath A'awoj" "Korsmanath A'awoj (Special)"
 
 
 ship "Korsmanath A'awoj" "Korsmanath A'awoj (Blaze)"
+	"uncapturable"
 	outfits
 		"Banisher Grav-Turret" 4
 		"Grab-Strike Turret" 2


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7578 

## Fix Details
These ships have very large crew counts, which can cause a crash on some systems when CaptureOdds is run.
The solution for the base ship is to add the `uncapturable` token so CaptureOdds doesn't run for it, but this property is not inherited by variants and so the token needs to be added to each variant definition as well.
