### PR TITLE
Bugfix(mechanics): support both dialog and conversation for npc

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -117,6 +117,8 @@ void NPC::Load(const DataNode &node)
 			personality.Load(child);
 		else if(child.Token(0) == "dialog")
 		{
+			if(!conversation->IsEmpty())
+				conversationFirst = false;
 			bool hasValue = (child.Size() > 1);
 			// Dialog text may be supplied from a stock named phrase, a
 			// private unnamed phrase, or directly specified.
@@ -455,9 +457,11 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, bool isVisible)
 	{
 		// If "completing" this NPC displays a conversation, reference
 		// it, to allow the completing event's target to be destroyed.
+		if(!dialogText.empty() && !conversationFirst)
+			ui->Push(new Dialog(dialogText));
 		if(!conversation->IsEmpty())
 			ui->Push(new ConversationPanel(player, *conversation, nullptr, ship));
-		else if(!dialogText.empty())
+		if(!dialogText.empty() && conversationFirst)
 			ui->Push(new Dialog(dialogText));
 	}
 }

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -131,6 +131,7 @@ private:
 	std::list<std::string> shipNames;
 	std::list<ExclusiveItem<Fleet>> fleets;
 
+	bool conversationFirst = true;
 	// This must be done to each ship in this set to complete the mission:
 	int succeedIf = 0;
 	int failIf = 0;


### PR DESCRIPTION
**Bugfix:**

## Fix Details
You can specify both a dialog and a conversation for an npc but only the conversation will show, without any warning.

This makes both show, and in the order given in the npc definition, whichever is first will be told first.
I want this behavior for the Unfettered campaign, and if we don't do this then we should at least have a warning that the dialog won't show up. But I see no reason not to support this.

## Testing Done
I don't think its required but I'll test it later if it is

## Save File
Is this required? I could draft a savefile where you disable an npc and get both dialog and convo