### PR TITLE
Update Cargo Units in "Remnant: Cognizance 28"

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1245,7 +1245,7 @@ mission "Remnant: Cognizance 28"
 	on offer
 		set "remnant: dusk busy"
 		conversation
-			`Your commlink springs to life as you enter final approach to Caelian, revealing Torza in a flurry of motion. He focuses momentarily on the camera. "Captain <first>, and flying a ship with a substantial lifting capacity, excellent! The Korath have discovered one of our forward operating bases, and we need help evacuating it now. It is located on Baianus in the Parca system. There are 20 people and 280 cubic meters of equipment to retrieve. The Korath have set up a blockade, so you will need something reasonably fast to get through it. You can fight them or not, as you wish, but the primary task is evacuating the outpost. Embers speed your flight, Captain."`
+			`Your commlink springs to life as you enter final approach to Caelian, revealing Torza in a flurry of motion. He focuses momentarily on the camera. "Captain <first>, and flying a ship with a substantial lifting capacity, excellent! The Korath have discovered one of our forward operating bases, and we need help evacuating it now. It is located on Baianus in the Parca system. There are 20 people and 280 tons of equipment to retrieve. The Korath have set up a blockade, so you will need something reasonably fast to get through it. You can fight them or not, as you wish, but the primary task is evacuating the outpost. Embers speed your flight, Captain."`
 				accept
 	npc
 		government "Korath"

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1231,7 +1231,7 @@ mission "Remnant: Cognizance 27"
 
 mission "Remnant: Cognizance 28"
 	name "Recover equipment from Baianus."
-	description "Torza has asked you to recover equipment from Baianus by <date>."
+	description "Torza has asked you to recover 280 tons of equipment and 20 personnel from Baianus by <date>."
 	landing
 	blocked "Over the commlink Torza is a flurry of motion as he issues orders in several directions. 'Right now, we need another ship that can evacuate 280 tons and 20 people. Return here when you have suitable capabilities."
 	deadline 13


### PR DESCRIPTION
## Summary
In "Remnant: Cognizance 28," the standard cargo units are referred to as "cubic meters." As I believe "tons" is the standard, I changed it to match.