### PR TITLE
[mission tweak] Adjust on visits for a couple Coalition missions

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -1271,7 +1271,7 @@ mission "Longcow Antibiotics 1"
 	on stopover
 		dialog `The dockworkers load <cargo> into your cargo hold after verifying you've been hired by the Arach cooperative. A bit after the last crate has been placed, you're contacted by the Arachi, and they say you should bring the antibiotics to <destination>, where they will pay you <payment>.`
 	on visit
-		dialog `You land on <planet>, but realize that your escort carrying the longcow antibiotics hasn't entered the system yet. Better depart and wait for it.`
+		dialog `You land on <planet>, but the Arach ranchers don't come to meet you as you've not brought the longcow antibiotics. Make sure all your ships carrying the cargo arrive in this system after you've picked it up.`
 	on complete
 		"coalition jobs" += 2
 		payment 421000

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -813,7 +813,7 @@ mission "Coalition Outbreak 2"
 	on stopover
 		dialog `A group of Saryd workers is waiting for you, and they load the <cargo> onto your ship. A laboratory worker babbles about how you must care for them.`
 	on visit
-		dialog `You've reached <planet>, but the vaccines aren't here yet. Depart and wait for whichever ships are carrying them to arrive.`
+		dialog `You've reached <planet>, but the vaccines aren't here yet. Once you've picked them up, make sure all ships that are carrying them arrive in this system.`
 	on complete
 		payment 943720
 		"coalition jobs" += 2


### PR DESCRIPTION
-----------------------
**Bugfix:** This PR addresses issue #7595 

## Fix Details
As spotted by damerell in the issue, the `on visit` for mission `"Longcow Antibiotics 1"` assumes you have a missing escort when you get it, when you could simply land on the destination planet without ever picking up the cargo.
Additionally, mission `"Coalition Outbreak 2"` features a pretty similar scenario.
This just changes up the dialogs a bit so that they account for both cases, missing ship or not having picked up the cargo.