### PR TITLE
Fix race condition inside the MaskManager

### DIFF
--- a/source/MaskManager.cpp
+++ b/source/MaskManager.cpp
@@ -35,6 +35,7 @@ namespace {
 // Move the given masks at 1x scale into the manager's storage.
 void MaskManager::SetMasks(const Sprite *sprite, vector<Mask> &&masks)
 {
+	lock_guard<mutex> lock(spriteMutex);
 	auto &scales = spriteMasks[sprite];
 	auto it = scales.find(DEFAULT);
 	if(it != scales.end())
@@ -48,6 +49,7 @@ void MaskManager::SetMasks(const Sprite *sprite, vector<Mask> &&masks)
 // Add a scale that the given sprite needs to have a mask for.
 void MaskManager::RegisterScale(const Sprite *sprite, double scale)
 {
+	lock_guard<mutex> lock(spriteMutex);
 	auto &scales = spriteMasks[sprite];
 	auto lb = scales.lower_bound(scale);
 	if(lb == scales.end() || lb->first != scale)

--- a/source/MaskManager.h
+++ b/source/MaskManager.h
@@ -19,6 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Mask.h"
 
 #include <map>
+#include <mutex>
 #include <vector>
 
 class Mask;
@@ -46,6 +47,9 @@ public:
 
 private:
 	std::map<const Sprite *, std::map<double, std::vector<Mask>>> spriteMasks;
+
+	// Mutex to make sure different threads don't modify the masks at the same time.
+	std::mutex spriteMutex;
 };
 
 


### PR DESCRIPTION
## Fix Details

Fixes a race condition inside MaskManager. The race condition as reported by the thread sanitizer:

<details>
<summary>stack trace</summary>

```
WARNING: ThreadSanitizer: data race (pid=67562)
  Write of size 8 at 0x55dccb70ecf0 by thread T2:
    #0 std::__1::__tree<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::__map_value_compare<Sprite const*, std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::less<Sprite const*>, true>, std::__1::allocator<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > > > >::__insert_node_at(std::__1::__tree_end_node<std::__1::__tree_node_base<void*>*>*, std::__1::__tree_node_base<void*>*&, std::__1::__tree_node_base<void*>*) /usr/bin/../include/c++/v1/__tree:2084:5 (endless-sky+0x78190b) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #1 std::__1::pair<std::__1::__tree_iterator<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::__tree_node<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, void*>*, long>, bool> std::__1::__tree<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::__map_value_compare<Sprite const*, std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::less<Sprite const*>, true>, std::__1::allocator<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > > > >::__emplace_unique_key_args<Sprite const*, std::__1::piecewise_construct_t const&, std::__1::tuple<Sprite const* const&>, std::__1::tuple<> >(Sprite const* const&, std::__1::piecewise_construct_t const&, std::__1::tuple<Sprite const* const&>&&, std::__1::tuple<>&&) /usr/bin/../include/c++/v1/__tree:2099:9 (endless-sky+0x781139) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #2 std::__1::map<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > >, std::__1::less<Sprite const*>, std::__1::allocator<std::__1::pair<Sprite const* const, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > > > >::operator[](Sprite const* const&) /usr/bin/../include/c++/v1/map:1588:20 (endless-sky+0x77f332) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #3 MaskManager::RegisterScale(Sprite const*, double) /home/user/projects/endless-sky/source/MaskManager.cpp:51:17 (endless-sky+0x77dda8) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #4 Body::LoadSprite(DataNode const&) /home/user/projects/endless-sky/source/Body.cpp:240:30 (endless-sky+0x47d89e) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #5 Effect::Load(DataNode const&) /home/user/projects/endless-sky/source/Effect.cpp:47:4 (endless-sky+0x55da40) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #6 UniverseObjects::LoadFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) /home/user/projects/endless-sky/source/UniverseObjects.cpp:327:32 (endless-sky+0xa92460) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #7 UniverseObjects::Load(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool)::$_0::operator()() const /home/user/projects/endless-sky/source/UniverseObjects.cpp:100:5 (endless-sky+0xa97f85) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #8 decltype(static_cast<UniverseObjects::Load(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool)::$_0&>(fp)()) std::__1::__invoke<UniverseObjects::Load(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool)::$_0&>(UniverseObjects::Load(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool)::$_0&) /usr/bin/../include/c++/v1/type_traits:3640:23 (endless-sky+0xa97c45) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #9 void std::__1::__invoke_void_return_wrapper<void, true>::__call<UniverseObjects::Load(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool)::$_0&>(UniverseObjects::Load(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool)::$_0&) /usr/bin/../include/c++/v1/__functional/invoke.h:61:9 (endless-sky+0xa97bcd) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #10 std::__1::__function::__alloc_func<UniverseObjects::Load(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool)::$_0, std::__1::allocator<UniverseObjects::Load(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool)::$_0>, void ()>::operator()() /usr/bin/../include/c++/v1/__functional/function.h:180:16 (endless-sky+0xa97b8d) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #11 std::__1::__function::__func<UniverseObjects::Load(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool)::$_0, std::__1::allocator<UniverseObjects::Load(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool)::$_0>, void ()>::operator()() /usr/bin/../include/c++/v1/__functional/function.h:354:12 (endless-sky+0xa96189) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #12 std::__1::__function::__value_func<void ()>::operator()() const /usr/bin/../include/c++/v1/__functional/function.h:507:16 (endless-sky+0x545ec1) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #13 std::__1::function<void ()>::operator()() const /usr/bin/../include/c++/v1/__functional/function.h:1184:12 (endless-sky+0x545d25) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #14 (anonymous namespace)::ThreadLoop() /home/user/projects/endless-sky/source/TaskQueue.cpp:76:6 (endless-sky+0xa4e920) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #15 decltype(static_cast<void (*>(fp)()) std::__1::__invoke<void (*)()>(void (*&&)()) /usr/bin/../include/c++/v1/type_traits:3640:23 (endless-sky+0xa61452) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #16 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (*)()>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (*)()>&, std::__1::__tuple_indices<>) /usr/bin/../include/c++/v1/thread:282:5 (endless-sky+0xa61395) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #17 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (*)()> >(void*) /usr/bin/../include/c++/v1/thread:293:5 (endless-sky+0xa60a0f) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)

  Previous write of size 8 at 0x55dccb70ecf0 by main thread:
    #0 std::__1::__tree<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::__map_value_compare<Sprite const*, std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::less<Sprite const*>, true>, std::__1::allocator<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > > > >::__insert_node_at(std::__1::__tree_end_node<std::__1::__tree_node_base<void*>*>*, std::__1::__tree_node_base<void*>*&, std::__1::__tree_node_base<void*>*) /usr/bin/../include/c++/v1/__tree:2084:5 (endless-sky+0x78190b) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #1 std::__1::pair<std::__1::__tree_iterator<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::__tree_node<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, void*>*, long>, bool> std::__1::__tree<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::__map_value_compare<Sprite const*, std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::less<Sprite const*>, true>, std::__1::allocator<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > > > >::__emplace_unique_key_args<Sprite const*, std::__1::piecewise_construct_t const&, std::__1::tuple<Sprite const* const&>, std::__1::tuple<> >(Sprite const* const&, std::__1::piecewise_construct_t const&, std::__1::tuple<Sprite const* const&>&&, std::__1::tuple<>&&) /usr/bin/../include/c++/v1/__tree:2099:9 (endless-sky+0x781139) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #2 std::__1::map<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > >, std::__1::less<Sprite const*>, std::__1::allocator<std::__1::pair<Sprite const* const, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > > > >::operator[](Sprite const* const&) /usr/bin/../include/c++/v1/map:1588:20 (endless-sky+0x77f332) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #3 MaskManager::SetMasks(Sprite const*, std::__1::vector<Mask, std::__1::allocator<Mask> >&&) /home/user/projects/endless-sky/source/MaskManager.cpp:38:17 (endless-sky+0x77dbee) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #4 ImageSet::Upload(Sprite*) /home/user/projects/endless-sky/source/ImageSet.cpp:283:29 (endless-sky+0x6ad5c8) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #5 (anonymous namespace)::LoadSprite(std::__1::shared_ptr<ImageSet> const&)::$_5::operator()() const /home/user/projects/endless-sky/source/GameData.cpp:107:22 (endless-sky+0x613276) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #6 decltype(static_cast<(anonymous namespace)::LoadSprite(std::__1::shared_ptr<ImageSet> const&)::$_5&>(fp)()) std::__1::__invoke<(anonymous namespace)::LoadSprite(std::__1::shared_ptr<ImageSet> const&)::$_5&>((anonymous namespace)::LoadSprite(std::__1::shared_ptr<ImageSet> const&)::$_5&) /usr/bin/../include/c++/v1/type_traits:3640:23 (endless-sky+0x6131d5) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #7 void std::__1::__invoke_void_return_wrapper<void, true>::__call<(anonymous namespace)::LoadSprite(std::__1::shared_ptr<ImageSet> const&)::$_5&>((anonymous namespace)::LoadSprite(std::__1::shared_ptr<ImageSet> const&)::$_5&) /usr/bin/../include/c++/v1/__functional/invoke.h:61:9 (endless-sky+0x61314d) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #8 std::__1::__function::__alloc_func<(anonymous namespace)::LoadSprite(std::__1::shared_ptr<ImageSet> const&)::$_5, std::__1::allocator<(anonymous namespace)::LoadSprite(std::__1::shared_ptr<ImageSet> const&)::$_5>, void ()>::operator()() /usr/bin/../include/c++/v1/__functional/function.h:180:16 (endless-sky+0x6130fd) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #9 std::__1::__function::__func<(anonymous namespace)::LoadSprite(std::__1::shared_ptr<ImageSet> const&)::$_5, std::__1::allocator<(anonymous namespace)::LoadSprite(std::__1::shared_ptr<ImageSet> const&)::$_5>, void ()>::operator()() /usr/bin/../include/c++/v1/__functional/function.h:354:12 (endless-sky+0x611569) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #10 std::__1::__function::__value_func<void ()>::operator()() const /usr/bin/../include/c++/v1/__functional/function.h:507:16 (endless-sky+0x545ec1) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #11 std::__1::function<void ()>::operator()() const /usr/bin/../include/c++/v1/__functional/function.h:1184:12 (endless-sky+0x545d25) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #12 TaskQueue::ProcessTasks() /home/user/projects/endless-sky/source/TaskQueue.cpp:171:3 (endless-sky+0xa4f212) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #13 GameLoop(PlayerInfo&, Conversation const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) /home/user/projects/endless-sky/source/main.cpp:335:3 (endless-sky+0x35b515) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #14 main /home/user/projects/endless-sky/source/main.cpp:189:3 (endless-sky+0x3597a1) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)

  Location is global '(anonymous namespace)::maskManager' of size 24 at 0x55dccb70ece0 (endless-sky+0x1eb2cf0)

  Thread T2 (tid=67565, running) created by main thread at:
    #0 pthread_create <null> (endless-sky+0x2d7ae6) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /usr/bin/../include/c++/v1/__threading_support:375:10 (endless-sky+0xa60979) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #2 std::__1::thread::thread<void (*)(), void>(void (*&&)()) /usr/bin/../include/c++/v1/thread:309:16 (endless-sky+0xa57deb) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #3 TaskQueue::Init() /home/user/projects/endless-sky/source/TaskQueue.cpp:112:7 (endless-sky+0xa4e7ab) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)
    #4 main /home/user/projects/endless-sky/source/main.cpp:124:3 (endless-sky+0x359349) (BuildId: 93ace8f57e7a6f20aa27b80100d63fa26d410c89)

SUMMARY: ThreadSanitizer: data race /usr/bin/../include/c++/v1/__tree:2084:5 in std::__1::__tree<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::__map_value_compare<Sprite const*, std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > >, std::__1::less<Sprite const*>, true>, std::__1::allocator<std::__1::__value_type<Sprite const*, std::__1::map<double, std::__1::vector<Mask, std::__1::allocator<Mask> >, std::__1::less<double>, std::__1::allocator<std::__1::pair<double const, std::__1::vector<Mask, std::__1::allocator<Mask> > > > > > > >::__insert_node_at(std::__1::__tree_end_node<std::__1::__tree_node_base<void*>*>*, std::__1::__tree_node_base<void*>*&, std::__1::__tree_node_base<void*>*)
```

</details>

## Testing Done

Without this PR the thread sanitizer reports multiple data races inside the MaskManager.