### PR TITLE
Bugfix(UI): invalid system are no longer selectable by pressing tab

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -224,10 +224,10 @@ bool MapDetailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command
 		auto bestAngle = make_pair(4., 0.);
 		for(const System *it : links)
 		{
-			// Skip the currently selected link, if any. Also skip links to
+			// Skip the currently selected link, if any, and non valid system links. Also skip links to
 			// systems the player has not seen, and skip hyperspace links if the
 			// player has not visited either end of them.
-			if(it == original)
+			if(!it->IsValid() || it == original)
 				continue;
 			if(!player.HasSeen(*it))
 				continue;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #2369

## Fix Details
Systems that are not valid are skipped when pressing tab.

## Testing Done
This could cause some issues with Ssil Vida? I'll test it real quick.
edit: I could still jump (those systems wouldnt have an invalid definition but doesnt hurt to be sure)
All this changes is the behavior when pressing alt or J to have it select the next available (and now, valid) system.

## Save File
Without these changes going into the map and pressing tab selects the 0,0 system on this savefile (bloated with plugins caus one of them has an invalid system idk which, it doesnt matter its fixed)
[Hur leveur.txt](https://github.com/endless-sky/endless-sky/files/10011242/Hur.leveur.txt)
Upon taking off Ssil Vida still works
[John Lennon3rd.txt](https://github.com/endless-sky/endless-sky/files/10011098/John.Lennon3rd.txt)
