### PR TITLE
Feature: Conditional Starts

### DIFF
--- a/GlobalConditions.cpp
+++ b/GlobalConditions.cpp
@@ -1,0 +1,60 @@
+/* GlobalSettings.cpp
+ Copyright (c) 2014 by RisingLeaf
+
+ Endless Sky is free software: you can redistribute it and/or modify it under the
+ terms of the GNU General Public License as published by the Free Software
+ Foundation, either version 3 of the License, or (at your option) any later version.
+
+ Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "DataFile.h"
+#include "DataNode.h"
+#include "DataWriter.h"
+#include "Files.h"
+#include "GlobalConditions.h"
+
+#include <map>
+
+using namespace std;
+
+namespace {
+	map<string, bool> globalConditions;
+};
+
+
+
+void GlobalConditions::Load()
+{
+	DataFile prefs(Files::Config() + "globalConditions.txt");
+	for(const DataNode &node : prefs)
+		globalConditions[node.Token(0)] = (node.Size() == 1 || node.Value(1));
+}
+
+
+
+void GlobalConditions::Save()
+{
+	DataWriter out(Files::Config() + "globalConditions.txt");
+	for(const auto &it : globalConditions)
+		out.Write(it.first, it.second);
+}
+
+
+
+bool GlobalConditions::HasSetting(const std::string settingName)
+{
+	return globalConditions[settingName];
+}
+
+
+
+void GlobalConditions::SetSetting(const std::string settingName, bool active)
+{
+	globalConditions[settingName] = active;
+}

--- a/GlobalConditions.h
+++ b/GlobalConditions.h
@@ -1,0 +1,36 @@
+/* GlobalConditions.h
+ Copyright (c) 2014 by RisingLeaf
+
+ Endless Sky is free software: you can redistribute it and/or modify it under the
+ terms of the GNU General Public License as published by the Free Software
+ Foundation, either version 3 of the License, or (at your option) any later version.
+
+ Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef GLOBALCONDITIONS_H_
+#define GLOBALCONDITIONS_H_
+
+#include <string>
+
+class DataNode;
+
+
+
+class GlobalConditions {
+public:
+	static void Load();
+	static void Save();
+
+	static bool HasSetting(const std::string settingName);
+	static void SetSetting(const std::string settingName, bool active = true);
+};
+
+
+
+#endif /* GlobalSettings_h */

--- a/source/GameAction.h
+++ b/source/GameAction.h
@@ -87,6 +87,9 @@ private:
 	// When this action is performed, the missions with these names fail.
 	std::set<std::string> fail;
 
+	// When this actions is performed, set these global conditions.
+	std::set<std::string> globalCondtions;
+
 	ConditionSet conditions;
 };
 

--- a/source/StartConditions.cpp
+++ b/source/StartConditions.cpp
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "DataNode.h"
 #include "DataWriter.h"
 #include "GameData.h"
+#include "GlobalConditions.h"
 #include "Logger.h"
 #include "Planet.h"
 #include "Ship.h"
@@ -118,6 +119,9 @@ void StartConditions::Load(const DataNode &node)
 			conversation = ExclusiveItem<Conversation>(Conversation(child));
 		else if(key == "conversation" && hasValue && !child.HasChildren())
 			conversation = ExclusiveItem<Conversation>(GameData::Conversations().Get(value));
+		else if(key == "to display" && child.HasChildren())
+			for(const DataNode &grand : child)
+				toDisplay.emplace_back(grand.Token(0));
 		else if(add)
 			child.PrintTrace("Skipping unsupported use of \"add\":");
 		else
@@ -218,4 +222,14 @@ const std::string &StartConditions::GetDisplayName() const noexcept
 const std::string &StartConditions::GetDescription() const noexcept
 {
 	return description;
+}
+
+
+
+const bool StartConditions::CanBeDisplayed() const
+{
+	for(const auto &globalCondition : toDisplay)
+		if(!GlobalConditions::HasSetting(globalCondition))
+			return false;
+	return true;
 }

--- a/source/StartConditions.h
+++ b/source/StartConditions.h
@@ -55,6 +55,7 @@ public:
 	const std::string &GetDisplayName() const noexcept;
 	const std::string &GetDescription() const noexcept;
 
+	const bool CanBeDisplayed() const;
 
 private:
 	// Conditions that will be set for any pilot that begins with this scenario.
@@ -69,6 +70,8 @@ private:
 	// The user-friendly display name for this starting scenario.
 	std::string name;
 	std::string description;
+
+	std::vector<std::string> toDisplay;
 };
 
 

--- a/source/StartConditionsPanel.cpp
+++ b/source/StartConditionsPanel.cpp
@@ -97,8 +97,10 @@ void StartConditionsPanel::Draw()
 
 	const Font &font = FontSet::Get(14);
 	for(auto it = scenarios.begin(); it != scenarios.end();
-			++it, pos += Point(0., entryBox.Height()))
+			++it)
 	{
+		if(!it->CanBeDisplayed())
+			continue;
 		// Any scenario wholly outside the bounds can be skipped.
 		const auto zone = Rectangle::FromCorner(pos, entryBox.Dimensions());
 		if(!(entriesContainer.Contains(zone.TopLeft()) || entriesContainer.Contains(zone.BottomRight())))
@@ -114,6 +116,7 @@ void StartConditionsPanel::Draw()
 
 		const auto name = DisplayText(it->GetDisplayName(), Truncate::BACK);
 		font.Draw(name, pos + entryTextPadding, (isHighlighted ? bright : medium).Transparent(opacity));
+		pos += Point(0., entryBox.Height());
 	}
 
 	// TODO: Prevent lengthy descriptions from overflowing.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -28,6 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "GameData.h"
 #include "GameLoadingPanel.h"
 #include "GameWindow.h"
+#include "GlobalConditions.h"
 #include "Hardpoint.h"
 #include "Logger.h"
 #include "MenuPanel.h"
@@ -167,6 +168,7 @@ int main(int argc, char *argv[])
 #endif
 
 		Preferences::Load();
+		GlobalConditions::Load();
 
 		if(!GameWindow::Init())
 			return 1;
@@ -198,6 +200,7 @@ int main(int argc, char *argv[])
 	Preferences::Set("fullscreen", GameWindow::IsFullscreen());
 	Screen::SetRaw(GameWindow::Width(), GameWindow::Height());
 	Preferences::Save();
+	GlobalConditions::Save();
 
 	Audio::Quit();
 	GameWindow::Quit();


### PR DESCRIPTION
## Feature Details
This PR implements what I call global conditions. These conditions are not bound to one player save, they are available "global". Therefore starts can be created that are only displayed when these conditions are set.

## Usage Examples
```
start "default"
    "to display"
        "global condition 1"
        "global condition 2"
        ...
```
```
mission
    on enter
        "global set" "global condition 1"
#or
conversation
    action
        "global set" "global condition 1"
```

## Testing Done
I will test this soon

## Performance Impact
N/A