### PR TITLE
Content(boarding missions): Unfettered threaten to blow up (is it a bluff?)

### DIFF
--- a/data/hai/unfettered duelling.txt
+++ b/data/hai/unfettered duelling.txt
@@ -13,7 +13,7 @@
 
 phrase "unfettered boarded"
 	word
-		`As you board the Unfettered warship you immediately notice something is wrong: the engines are emitting  bursts of fire, something Hai engines would never do. That probably means the ship is getting ready to explode! The captain sends you a message.`
+		`As you board the Unfettered warship you immediately notice something is wrong: the engines are emitting bursts of fire, something Hai engines would never do. That probably means the ship is getting ready to explode! The captain sends you a message.`
 	word
 		`"This is not a fair fight. It is better to die with my crew standing than risk being slaughtered by inferior humans! You will not be allowed to capture this ship and use it against our brothers and sisters. I will take you down with us!"`
 		`"This ship is the property of the True Hai, maybe even the Fettered, but never shall it belong to monkeys! We'd rather die than let you have it."`
@@ -23,7 +23,7 @@ phrase "unfettered boarded"
 # accept means you are disengaged from boarding and the mission triggers.
 # launch is the same but the ship blows up. Decline does nothing.
 conversation "explode or not"
-	`For a moment, it is as if time froze, everyone waiting for the start of the explosion to happen, or for your order to disengage...`
+	`For a moment, it is as if time froze, everyone waiting for the start of the explosion to happen, or for your order to disengage... It would be very risky to try and call their bluff but maybe it is worth the risk? Or maybe there is a better solution to this.`
 	choice
 		`	"Retreat!"`
 			goto retreat

--- a/data/hai/unfettered duelling.txt
+++ b/data/hai/unfettered duelling.txt
@@ -30,8 +30,7 @@ conversation "explode or not"
 		`	"It's a bluff."`
 		`	"Wait! I challenge you to a duel."`
 			goto duel
-	label bluffnobluff
-	# you choose to stay, either they blow up (with you or not) or they called reinforcements
+	label bluffornot
 	branch bluff
 		or
 			and
@@ -51,36 +50,58 @@ conversation "explode or not"
 				or
 					"flagship crew" < 114
 					random > "flagship crew" - 95
+	# not a bluff
+	branch flee
+		has "tried to retreat"
+	# hopefully this very small chance for the ship to explode and you with it will discourage chain farming
 	branch blowup
 		random < 2
-	`	They weren't bluffing, and you already see escape pods leaving the ship, trying to get to a safe distance. Better get out of here quickly!`
+	`	They weren't bluffing, and you already see escape pods leaving the ship, trying to get to a safe distance. Better get out of here quickly! You also notice`
 		launch
 	label blowup
 	`	It was no bluff at all. In fact, they did not even hesitate, nor did they head to their escape pods. They blowed themselves up almost instantly, taking you down with them.`
 		explode
+
 	label bluff
+	branch no-reinforcements
+		has "tried to retreat"
+		random < 25
+	branch reinforcements
+		has "tried to retreat"
 	`	But then, nothing.`
-	`	It seems this was just a bluff, or maybe it was an attempt to stall you? You hear alarms signaling new ships entering the system, and quickly disconnect the boarding clamps to respond to the incoming threat.`
+	`	It seems this was just a bluff, and the engine emmissions were faked. You hear alarms signaling new ships entering the system, and quickly disconnect the boarding clamps to respond to the incoming threat. Maybe this fake self-destruction was to stall you?`
 		accept
 	
 	label retreat
+	action
+		set "tried to retreat"
+	``
+		goto bluffornot
+
+	label flee
+	# since you are leaving there is less chance they are going to blow themselves up
 	branch reinforcements
-		random < 20
-	branch normalretreat
-		random < 80
+		random < 70
 	`	You give the order to retreat as soon as possible, and not a moment too soon as the ship is already starting to explode...`
 		flee
 	label reinforcements
-	`	You start the disengagement procedure, but by the time it is over it is clear they have no intention of actually blowing up. In fact, they have called for reinforcements.`
+	`	You start the disengagement procedure, but by the time it is over it is clear they have no intention of actually blowing up. It is not clear if this is what they intended to do since the start, but if they were going to self-destruct they have changed their mind, and instead called for reinforcements.`
 		accept
-	label normalretreat
+	label no-reinforcements
 	action
 		set "unfettered: no reinforcements"
 	`	Whether or not they were going to explode, it seems you gave your order quick enough for them not to do so. It would probably be wise to leave before they change their minds...`
 		accept
 	
 	label duel
-	`	You can hear some of the crew laughing but the captain disciplines them. "We are not in any position to show disrespect. This captain has shown themselves more adept than us." He says to them, before addressing you. "Very well. In that case come to my ship, we will give you a blade."`
+	branch disciplined-crew
+		random < 70
+	`	You can hear some of the crew laughing but the captain disciplines them. "We are not in any position to show disrespect. This captain has shown themselves more adept than us." He says to them, before addressing you. "Very well. I accept your challenge.`
+		goto details
+	label disciplined-crew
+	`	All is quiet for a moment, as the captain thinks about your offer. "I will not refuse a duel.`
+	label details
+	`	"Come to my ship, and we will give you a blade to prove yourself."`
 	choice
 		`	"What are the terms? What do I have to win?"`
 			goto terms
@@ -92,12 +113,12 @@ conversation "explode or not"
 	label alone
 	`	This seems to anger them, "You dare insult my honor? My word? Fine, take a few soldiers if it reassures you, they will do a fine audience. It was planned you would come with your honor guard anyway."`
 	label terms
-	`	"Now as for the terms of the fight, I assume honor is not enough for you? I will not destroy my ship if you win, and you may do with us what you like. We will not call reinforcements, so you will be able to loot anything you want out of this ship, or even attempt to capture us. We will also remain in this system, defenceless, for a few days.`
-	`	"On top of that, the winner will receive 100 thousand credits from the loser. As for how the duel will happen, it is not meant to be to the death, although we will not use children blades either. As I clearly have an advantage over you I will be fighting weaponless."`
+	`	"As for the terms of the fight, I assume honor is not enough for you, so I will bring the stakes higher. We will not self-destruct our ship if you win, and you may do with us what you like. We will not call for reinforcements either, so you will be able to loot anything you want out of this ship, or even attempt to capture us. We will also remain in this system for a few days.`
+	`	"On top of that, the winner will receive 100 thousand credits from the loser. As for how the duel will happen, it is not meant to be to the death, although we will not use children blades either. Finally, I will be fighting weaponless to equalize the odds."`
 	choice
 		`	"Alright. I will make my way to your ship now."`
 		`	"I won't be tricked into doing this meaningless fight. Self destruct if you want."`
-			goto bluffnobluff
+			goto bluffornot
 	`	You make your way to their ship, with your agreed honor guard of 4 crew members. As you arrive you are directed to a training room, where the captain is waiting for you. They give you a blade, and the captain makes themselves ready, weaponless as they promised. "Ready, captain?"`
 	action
 		set "unfettered: no reinforcements"
@@ -168,7 +189,6 @@ event "unfettered: blood dries quick"
 
 mission "Proud Unfettered Boarded (Small)"
 	boarding
-	minor
 	repeat
 	invisible
 	source
@@ -180,12 +200,12 @@ mission "Proud Unfettered Boarded (Small)"
 	deadline 3
 	to offer
 		or
-			# caps at 50% chance of offering, which happens when you have double their bunks
 			and
 				"flagship crew" <= 20
 				# they won't blow up except if you have more crew than they do bunks but they can bluff
 				random < "flagship crew" * 3 - 12
 			and
+				# caps at 50% chance of offering, which happens when you have double their bunks
 				"flagship crew" > 20
 				random < 50
 	on offer
@@ -194,6 +214,7 @@ mission "Proud Unfettered Boarded (Small)"
 		dialog phrase "unfettered boarded"
 		conversation "explode or not"
 		clear "unfettered: light warship"
+		clear "tried to retreat"
 		event "unfettered: bribe no more!"
 	npc evade
 		government "Hai (Unfettered)"
@@ -207,7 +228,6 @@ mission "Proud Unfettered Boarded (Small)"
 
 mission "Proud Unfettered Boarded (Medium)"
 	boarding
-	minor
 	repeat
 	invisible
 	source
@@ -231,10 +251,10 @@ mission "Proud Unfettered Boarded (Medium)"
 		dialog phrase "unfettered boarded"
 		conversation "explode or not"
 		clear "unfettered: medium warship"
+		clear "tried to retreat"
 		event "unfettered: bribe no more!"
 	npc evade
 		government "Hai (Unfettered)"
-		# being marked, these ships will not be attacked by the Hai.
 		personality entering nemesis vindictive staying marked
 		to spawn
 			not "unfettered: no reinforcements"
@@ -244,7 +264,6 @@ mission "Proud Unfettered Boarded (Medium)"
 
 mission "Proud Unfettered Boarded (Heavy)"
 	boarding
-	minor
 	repeat
 	invisible
 	source
@@ -268,10 +287,10 @@ mission "Proud Unfettered Boarded (Heavy)"
 		dialog phrase "unfettered boarded"
 		conversation "explode or not"
 		clear "unfettered: heavy warship"
+		clear "tried to retreat"
 		event "unfettered: bribe no more!"
 	npc evade
 		government "Hai (Unfettered)"
-		# being marked, these ships will not be attacked by the Hai.
 		personality entering nemesis vindictive staying marked
 		to spawn
 			not "unfettered: no reinforcements"
@@ -279,3 +298,38 @@ mission "Proud Unfettered Boarded (Heavy)"
 		fleet "Small Unfettered" 2
 	on fail
 		event "unfettered: blood dries quick"
+
+# So you think you have enough might for the Unfettered military? Let's see.
+mission "Proud Unfettered Boarded"
+	boarding
+	repeat
+	invisible
+	deadline 1
+	on offer
+		conversation
+			`	Even more Unfettered reinforcements arrive, lured by the promise of a great enemy.`
+				accept
+	npc evade
+		government "Hai (Unfettered)"
+		personality entering nemesis vindictive staying marked
+		to spawn
+			not "unfettered: no reinforcements"
+		to despawn
+			"armament detterence" < 32
+		fleet "Large Unfettered" 2
+	npc evade
+		government "Hai (Unfettered)"
+		personality entering nemesis vindictive staying marked
+		to spawn
+			not "unfettered: no reinforcements"
+		to despawn
+			"armament detterence" < 64
+		fleet "Large Unfettered" 2
+	npc evade
+		government "Hai (Unfettered)"
+		personality entering nemesis vindictive staying marked
+		to spawn
+			not "unfettered: no reinforcements"
+		to despawn
+			"armament detterence" < 100
+		fleet "Large Unfettered" 2

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -184,7 +184,7 @@ mission "Proud Unfettered Boarded (Small)"
 			and
 				"flagship crew" <= 20
 				# they won't blow up except if you have more crew than they do bunks but they can bluff
-				random < ("flagship crew" - 4) * 3
+				random < "flagship crew" * 3 - 12
 			and
 				"flagship crew" > 20
 				random < 50
@@ -221,7 +221,7 @@ mission "Proud Unfettered Boarded (Medium)"
 		or
 			and
 				"flagship crew" <= 68
-				random < ("flagship crew" - 14)
+				random < "flagship crew" - 14
 			and
 				"flagship crew" > 68
 				random < 50
@@ -258,7 +258,7 @@ mission "Proud Unfettered Boarded (Heavy)"
 		or
 			and
 				"flagship crew" <= 95
-				random < ("flagship crew" - 55)
+				random < "flagship crew" - 55
 			and
 				"flagship crew" > 95
 				random < 50

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -90,7 +90,7 @@ conversation "explode or not"
 	`	"You clearly know very little of our ways, captain. The Hai would never attack a defenceless ship, and if you meant the True Hai would attempt such a thing you are mistaken."`
 		goto terms
 	label alone
-	`	This seems to anger them, "You dare insult my honor? My word? Fine, take a few soldiers if it reassures you, they will do a fine audiance. It was planned you would come with your honor gard anyway."`
+	`	This seems to anger them, "You dare insult my honor? My word? Fine, take a few soldiers if it reassures you, they will do a fine audience. It was planned you would come with your honor guard anyway."`
 	label terms
 	`	"Now as for the terms of the fight, I assume honor is not enough for you? I will not destroy my ship if you win, and you may do with us what you like. We will not call reinforcements, so you will be able to loot anything you want out of this ship, or even attempt to capture us. We will also remain in this system, defenceless, for a few days.`
 	`	"On top of that, the winner will receive 100 thousand credits from the loser. As for how the duel will happen, it is not meant to be to the death, although we will not use children blades either. As I clearly have an advantage over you I will be fighting weaponless."`
@@ -98,7 +98,7 @@ conversation "explode or not"
 		`	"Alright. I will make my way to your ship now."`
 		`	"I won't be tricked into doing this meaningless fight. Self destruct if you want."`
 			goto bluffnobluff
-	`	You make your way to their ship, with your agreed 'honor gard' of 4 crew members. As you arrive you are directed to a training room, where the captain is waiting for you. They give you a blade, and the captain makes themselves ready, weaponless as they promised. "Ready, captain?"`
+	`	You make your way to their ship, with your agreed honor guard of 4 crew members. As you arrive you are directed to a training room, where the captain is waiting for you. They give you a blade, and the captain makes themselves ready, weaponless as they promised. "Ready, captain?"`
 	action
 		set "unfettered: no reinforcements"
 	choice

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -1,0 +1,281 @@
+# Copyright (c) 2022 by Hurleveur
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+
+phrase "unfettered boarded"
+	word
+		`As you board the Unfettered warship you immediately notice something is wrong: the engines are emitting  bursts of fire, something Hai engines would never do. That probably means the ship is getting ready to explode! The captain sends you a message.`
+	word
+		`"This is not a fair fight. It is better to die with my crew standing than risk being slaughtered by inferior humans! You will not be allowed to capture this ship and use it against our brothers and sisters. I will take you down with us!"`
+		`"This ship is the property of the True Hai, maybe even the Fettered, but never shall it belong to monkeys! We'd rather die than let you have it."`
+		`"It is truly sad it had to come to this, but we know you will not listen to reason. We have no choice but to destroy our ship."`
+		`"I may not let you have this ship, too many proud Hai have died because of you already. In their memory, it is best it be destroyed."`
+
+# accept means you are disengaged from boarding and the mission triggers.
+# launch is the same but the ship blows up. Decline does nothing.
+conversation "explode or not"
+	`For a moment, it is as if time froze, everyone waiting for the start of the explosion to happen, or for your order to disengage...`
+	choice
+		`	"Retreat!"`
+			goto retreat
+		`	"It's a bluff."`
+		`	"Wait! I challenge you to a duel."`
+			goto duel
+	label bluffnobluff
+	# you choose to stay, either they blow up (with you or not) or they called reinforcements
+	branch bluff
+		or
+			and
+				has "unfettered: light warship"
+				or
+					# if the ships are outnumbered by 25% they will consider blowing up
+					"flagship crew" < 13
+					# the more you outnumber their bunks the more likely they blow up
+					random > "flagship crew" - 10
+			and
+				has "unfettered: medium warship"
+				or
+					"flagship crew" < 45
+					random > "flagship crew" - 36
+			and
+				has "unfettered: heavy warship"
+				or
+					"flagship crew" < 114
+					random > "flagship crew" - 95
+	branch blowup
+		random < 2
+	`	They weren't bluffing, and you already see escape pods leaving the ship, trying to get to a safe distance. Better get out of here quickly!`
+		launch
+	label blowup
+	`	It was no bluff at all. In fact, they did not even hesitate, nor did they head to their escape pods. They blowed themselves up almost instantly, taking you down with them.`
+		explode
+	label bluff
+	`	But then, nothing.`
+	`	It seems this was just a bluff, or maybe it was an attempt to stall you? You hear alarms signaling new ships entering the system, and quickly disconnect the boarding clamps to respond to the incoming threat.`
+		accept
+	
+	label retreat
+	branch reinforcements
+		random < 20
+	branch normalretreat
+		random < 80
+	`	You give the order to retreat as soon as possible, and not a moment too soon as the ship is already starting to explode...`
+		flee
+	label reinforcements
+	`	You start the disengagement procedure, but by the time it is over it is clear they have no intention of actually blowing up. In fact, they have called for reinforcements.`
+		accept
+	label normalretreat
+	action
+		set "unfettered: no reinforcements"
+	`	Whether or not they were going to explode, it seems you gave your order quick enough for them not to do so. It would probably be wise to leave before they change their minds...`
+		accept
+	
+	label duel
+	`	You can hear some of the crew laughing but the captain disciplines them. "We are not in any position to show disrespect. This captain has shown themselves more adept than us." He says to them, before addressing you. "Very well. In that case come to my ship, we will give you a blade."`
+	choice
+		`	"What are the terms? What do I have to win?"`
+			goto terms
+		`	"I would prefer not to come alone to your ship."`
+			goto alone
+		`	"Is there not a risk of getting shot by Hai ships?"`
+	`	"You clearly know very little of our ways, captain. The Hai would never attack a defenceless ship, and if you meant the True Hai would attempt such a thing you are mistaken."`
+		goto terms
+	label alone
+	`	This seems to anger them, "You dare insult my honor? My word? Fine, take a few soldiers if it reassures you, they will do a fine audiance. It was planned you would come with your honor gard anyway."`
+	label terms
+	`	"Now as for the terms of the fight, I assume honor is not enough for you? I will not destroy my ship if you win, and you may do with us what you like. We will not call reinforcements, so you will be able to loot anything you want out of this ship, or even attempt to capture us. We will also remain in this system, defenceless, for a few days.`
+	`	"On top of that, the winner will receive 100 thousand credits from the loser. As for how the duel will happen, it is not meant to be to the death, although we will not use children blades either. As I clearly have an advantage over you I will be fighting weaponless."`
+	choice
+		`	"Alright. I will make my way to your ship now."`
+		`	"I won't be tricked into doing this meaningless fight. Self destruct if you want."`
+			goto bluffnobluff
+	`	You make your way to their ship, with your agreed 'honor gard' of 4 crew members. As you arrive you are directed to a training room, where the captain is waiting for you. They give you a blade, and the captain makes themselves ready, weaponless as they promised. "Ready, captain?"`
+	action
+		set "unfettered: no reinforcements"
+	choice
+		`	"En garde!"`
+	branch immobile
+		random < 50
+	`	In a fraction of a second, the captain goes from being immobile to rushing unto you, quickly covering the distance between the two of you.`
+		goto whatdo
+	label immobile
+	`	The captain does not move, at all. It almost seems like they are a statue, but you presume they are simply waiting for you to make the first move.`
+	label whatdo
+	# Even with this weapon you are completely outclassed. Your only chance it to make the battle end quickly.
+	choice
+		`	(Defend.)`
+			goto defend
+		`	(Dodge.)`
+			goto dodge
+		`	(Attack.)`
+	branch lucky
+		random < 30
+	`	Somehow, the captain deflects your blade with their bare hands, before hitting you with their first, using their relative small size to their advantage. You are left a bit disoriented by the attack. The Unfettered still is within reach of your blade.`
+	choice
+		`	(Attack again now that they are close.)`
+		`	(Move out of the way.)`
+	`	You try to act but lose your footing due to the captain swooping his leg. You fall on your back. And cannot react before they arm wressle you, forcing you to concede the duel. You go back to your ship, ashamed, and proceed to disconnect from the enemy ship after paying the due 100 thousand credits.`
+		goto payup
+	label defend
+	`	Seeing you on the defensive the captain attacks, fainting to the left and then hitting you from the right with a fist of such strength and speed you cannot do anything before they hit, knocking you out in one attack. You hear them laugh before losing consciousness.`
+	label lost
+	`	` # empty line to separate
+	`	Later on, you wake up in your ship, having been brought back by your crew members. One of them explains what happened. "The Unfettered simply moved out of the way when you lost, and demanded we remind you about the money you have to pay. We have already engaged the procedures to disconnect from their ship."`
+	label payup
+	action
+		fine 100000
+	``
+		accept
+	label dodge
+	`	Seeing you waiting the captain moves your way, and readies an attack but were ready for this, and move to the side before hiting them on the back with the side of the sword. The captain embraces their fall, using it to their advantage, grasping your clothes and making you fall as well.`
+	choice
+		`	(Get up.)`
+		`	(Strike.)`
+			goto strike
+	`	You try to get up but they are much faster than you, and stun by hitting you to the head with their foot.`
+		goto lost
+	label strike
+	branch gotlucky
+		random < 30
+	`	You try to strike them as they are rising but they seem to have seen this coming, and jump on you instead, swiftly disarming you and forcing you to concede the fight by applying pressure to your leg in a way you had never seen before. You go back to your ship, ashamed, and proceed to disconnect from the enemy ship after paying the due 100 thousand credits.`
+		goto payup
+	
+	label gotlucky
+	label lucky
+	action
+		payment 100000
+	`	You get lucky and manage to hit the captain with the pomel of the blade, rendering them unconscious and winning the duel. Their crew give you the agreed 100 thousand credits and you make your way back to your ship, victorious.`
+		decline
+	
+
+event "unfettered: bribe no more!"
+	government "Hai (Unfettered)"
+		bribe 0
+
+event "unfettered: blood dries quick"
+	government "Hai (Unfettered)"
+		bribe 0.2
+
+
+mission "Proud Unfettered Boarded (Small)"
+	boarding
+	minor
+	repeat
+	invisible
+	source
+		government "Hai (Unfettered)"
+		category "Light Warship"
+		neighbor
+			attributes "unfettered"
+	destination "Darkcloak"
+	deadline 3
+	to offer
+		or
+			# caps at 50% chance of offering, which happens when you have double their bunks
+			and
+				"flagship crew" <= 20
+				# they won't blow up except if you have more crew than they do bunks but they can bluff
+				random < ("flagship crew" - 4) * 3
+			and
+				"flagship crew" > 20
+				random < 50
+	on offer
+		clear "unfettered: no reinforcements"
+		set "unfettered: light warship"
+		dialog phrase "unfettered boarded"
+		conversation "explode or not"
+		clear "unfettered: light warship"
+		event "unfettered: bribe no more!"
+	npc evade
+		government "Hai (Unfettered)"
+		# being marked, these ships will not be attacked by the Hai.
+		personality entering nemesis vindictive staying marked
+		to spawn
+			not "unfettered: no reinforcements"
+		fleet "Small Unfettered" 2
+	on fail
+		event "unfettered: blood dries quick"
+
+mission "Proud Unfettered Boarded (Medium)"
+	boarding
+	minor
+	repeat
+	invisible
+	source
+		government "Hai (Unfettered)"
+		category "Medium Warship"
+		neighbor
+			attributes "unfettered"
+	destination "Darkcloak"
+	deadline 3
+	to offer
+		or
+			and
+				"flagship crew" <= 68
+				random < ("flagship crew" - 14)
+			and
+				"flagship crew" > 68
+				random < 50
+	on offer
+		clear "unfettered: no reinforcements"
+		set "unfettered: medium warship"
+		dialog phrase "unfettered boarded"
+		conversation "explode or not"
+		clear "unfettered: medium warship"
+		event "unfettered: bribe no more!"
+	npc evade
+		government "Hai (Unfettered)"
+		# being marked, these ships will not be attacked by the Hai.
+		personality entering nemesis vindictive staying marked
+		to spawn
+			not "unfettered: no reinforcements"
+		fleet "Small Unfettered" 3
+	on fail
+		event "unfettered: blood dries quick"
+
+mission "Proud Unfettered Boarded (Heavy)"
+	boarding
+	minor
+	repeat
+	invisible
+	source
+		government "Hai (Unfettered)"
+		category "Heavy Warship"
+		neighbor
+			attributes "unfettered"
+	destination "Darkcloak"
+	deadline 3
+	to offer
+		or
+			and
+				"flagship crew" <= 95
+				random < ("flagship crew" - 55)
+			and
+				"flagship crew" > 95
+				random < 50
+	on offer
+		clear "unfettered: no reinforcements"
+		set "unfettered: heavy warship"
+		dialog phrase "unfettered boarded"
+		conversation "explode or not"
+		clear "unfettered: heavy warship"
+		event "unfettered: bribe no more!"
+	npc evade
+		government "Hai (Unfettered)"
+		# being marked, these ships will not be attacked by the Hai.
+		personality entering nemesis vindictive staying marked
+		to spawn
+			not "unfettered: no reinforcements"
+		fleet "Large Unfettered"
+		fleet "Small Unfettered" 2
+	on fail
+		event "unfettered: blood dries quick"


### PR DESCRIPTION
**Content (Missions)**

## Summary
When you board Unfettered ships they will have a chance to trigger this mission, depending on how much of a crew advantage you have over them.

You then have the choice to either:
-call the bluff (either they blow up, blow up with you or don't blow up and call reinforcements)
-get the hell out (the ship may blow up still or you may just head out, with or without reinforcements for them)
-challenge the leader to a duel for a price of 100 000 for the winner, and guarantee of no reinforcements or blowing up
This third option normally guarantees the ship will stay in the system disabled for 3 days, without the reinforcements it would usually have. The captain also wont kill you.

Smaller ships will mean a smaller reinforcing fleet, ranging from 2 small fleets to 2 small fleets and a large one, and these are not attacked by the Hai and rush you (whilst staying in the system). The Unfettered also are made un-bribable temporarily (didnt test these).
The mission should only trigger in systems next to Uhai systems (but mb that doesnt work for boarding missions idk)

This in addition to https://github.com/endless-sky/endless-sky/pull/7471 should completely fix any beetle farming.

## Save File
just fly in UHai space, will include one soon

## TODO(draft until done):
- [ ] additional reinforcements if you have a big fleet
- [ ] improve the quality of the text as much as I can (ur welcome to help me on this one)