### PR TITLE
Testing: new integration test for changing of illegal outfits per government

### DIFF
--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -318,8 +318,7 @@ test "Launch Quarg Scanning Mission And Board"
 		# board the ship so we're sure we get close to it to get scanned
 		input
 			command board
-		# Wait for 5 seconds so it should be repaired and have scanned us
-		# is there a way to know when a dialog pops up?
+		# wait for 5 seconds so it should be repaired and have scanned us
 		apply
 			"test: steps to wait" = 10 * 30
 		label "floating"
@@ -340,6 +339,7 @@ test "Boarding Test - Repair Friendly Ship"
 		call "Load First Savegame"
 		watchdog 6000
 		call "Launch Quarg Scanning Mission And Board"
+		# copy the test-data in the temporary conditions for debugging when an issue happens
 		apply
 			"test: %TEST%: Wardragon Scanning You!: active" = "%TEST%: Wardragon Scanning You!: active"
 		assert
@@ -362,6 +362,7 @@ test "Illegal Test - Ignore and New Illegal"
 		call "Launch Quarg Scanning Mission And Board"
 		# land back with a fine of 1 for the hyperdrive, nothing from the gas
 		call "Land On Ruin helper"
+		# copy the test-data in the temporary conditions for debugging when an issue happens
 		apply
 			"test: unpaid fines" = "unpaid fines"
 		assert
@@ -379,6 +380,7 @@ test "Atrocity Test - New Atrocity"
 		call "Launch Quarg Scanning Mission And Board"
 		# land back with atrocity having been in effect (should nuke the reputation?)
 		call "Land On Ruin helper"
+		# copy the test-data in the temporary conditions for debugging when an issue happens
 		apply
 			"test: reputation: Quarg" = "reputation: Quarg"
 		assert

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -207,11 +207,11 @@ test "Land On Ruin helper"
 	sequence
 		input
 			command land
-		label landing
-		branch landing
-			"flagship planet: Ruin" < 1
-		assert
-			"flagship planet: Ruin" > 0
+		label "landing"
+		# empty input to make time pass
+		input
+		branch "landing"
+			"flagship planet: Ruin" == 0
 
 test "Launch Quarg Scanning Mission And Board"
 	status partial

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -1,3 +1,95 @@
+test-data "quarg rescue"
+	category "savegame"
+	contents
+		pilot Bobbi Bughunter
+		date 16 11 3013
+		system "Terra Incognita"
+		planet Ruin
+		clearance
+		ship "Star Barge"
+			name "Buggy Barge"
+			sprite "ship/star barge"
+			attributes
+				category "Light Freighter"
+				cost 190000
+				mass 70
+				bunks 3
+				"cargo space" 50
+				drag 2.1
+				"engine capacity" 40
+				"fuel capacity" 300
+				"heat dissipation" 0.8
+				hull 1000
+				"outfit space" 130
+				"required crew" 1
+				shields 600
+				"turret mounts" 1
+				"weapon capacity" 20
+				"thrust" 50
+				"turn" 1000
+				"energy generation" 10
+			outfits
+				Hyperdrive
+			crew 1
+			fuel 300
+			shields 600
+			hull 1000
+			position 0 0
+			engine -9 38 1
+			engine 9 38 1
+			system "Terra Incognita"
+			planet Ruin
+		account
+			credits 100000000
+			score 400
+			history
+		visited "Terra Incognita"
+		"visited planet" Ruin
+		"available mission" "%TEST%: Wardragon Scanning You!"
+			name "%TEST%: Wardragon Scanning You!"
+			uuid 9ba505d8-e565-4632-8c7a-c74072b85b5a
+			priority
+			to offer
+				"%TEST%: SCANNING ILLEGALS" != 0
+			destination Ruin
+			npc
+				uuid 01a921d2-b477-4d80-a19e-11aefb2a6464
+				succeed 1
+				government Quarg
+				personality derelict target
+				ship "Quarg Wardragon"
+					name Scanner
+					sprite ship/wardragon
+					thumbnail thumbnail/wardragon
+					uuid 7cc5c522-858d-419c-88a7-f240fc5799d7
+					attributes
+						category "Heavy Warship"
+						cost 5900000
+						mass 360
+						automaton 1
+						drag 9.3
+						"heat dissipation" 0.5
+						hull 50000
+						"outfit scan power" 1e+09
+						"outfit scan speed" 1e+09
+						"energy generation" 10
+						shields 160000
+					fuel 0
+					shields 0
+					hull 1000
+					position 0 0
+					explode "huge explosion" 1
+					system "Terra Incognita"
+			on offer
+				conversation
+					label 0
+					"You must be scanned or be killed."
+						accept
+		conditions
+			"%TEST%: SCANNING ILLEGALS"
+			"Ruin: Landing: offered"
+
+
 test-data "quarg scanning"
 	category "savegame"
 	contents
@@ -96,6 +188,7 @@ test-data "quarg scanning"
 						accept
 		conditions
 			"%TEST%: SCANNING ILLEGALS"
+			"Ruin: Landing: offered"
 
 
 test-data "quarg atrocity"
@@ -148,8 +241,6 @@ test-data "quarg atrocity"
 
 		event "atrocity stuff"
 			government "Quarg"
-				"penalty for"
-					atrocity 1000
 				atrocities
 					Hyperdrive
 				remove "enforces"
@@ -197,6 +288,7 @@ test-data "quarg atrocity"
 						accept
 		conditions
 			"%TEST%: SCANNING ILLEGALS"
+			"Ruin: Landing: offered"
 
 # just so the mission actually works
 mission "%TEST%: Wardragon Scanning You!"
@@ -225,10 +317,11 @@ test "Launch Quarg Scanning Mission And Board"
 		call "Depart"
 		# board the ship so we're sure we get close to it to get scanned
 		input
-			key b
-		# Wait for 10 seconds so it should be repaired
+			command board
+		# Wait for 5 seconds so it should be repaired and have scanned us
+		# is there a way to know when a dialog pops up?
 		apply
-			"test: steps to wait" = 10 * 60
+			"test: steps to wait" = 10 * 30
 		label "floating"
 		# empty input to make time pass
 		input
@@ -236,6 +329,26 @@ test "Launch Quarg Scanning Mission And Board"
 			"test: steps to wait" = "test: steps to wait" - 1
 		branch "floating"
 			"test: steps to wait" > 0
+		input
+			key "return"
+
+test "Boarding Test - Repair Friendly Ship"
+	status active
+	description "Test if you can repair a disabled Quarg ship trough an assist derelict mission."
+	sequence
+		inject "quarg rescue"
+		call "Load First Savegame"
+		watchdog 6000
+		call "Launch Quarg Scanning Mission And Board"
+		apply
+			"test: %TEST%: Wardragon Scanning You!: active" = "%TEST%: Wardragon Scanning You!: active"
+		assert
+			"%TEST%: Wardragon Scanning You!: active" == 1
+		call "Land On Ruin helper"
+		apply
+			"test: %TEST%: Wardragon Scanning You!: done" = "%TEST%: Wardragon Scanning You!: done"
+		assert
+			"%TEST%: Wardragon Scanning You!: done" == 1
 
 test "Illegal Test - Ignore and New Illegal"
 	status active
@@ -243,15 +356,14 @@ test "Illegal Test - Ignore and New Illegal"
 	sequence
 		inject "quarg scanning"
 		call "Load First Savegame"
-		watchdog 12000
+		watchdog 6000
 		assert
-			"fines" == 0
+			"unpaid fines" == 0
 		call "Launch Quarg Scanning Mission And Board"
-		# skip the dialog message for the fine
-		input
-			key "escape"
 		# land back with a fine of 1 for the hyperdrive, nothing from the gas
 		call "Land On Ruin helper"
+		apply
+			"test: unpaid fines" = "unpaid fines"
 		assert
 			"unpaid fines" == 1
 
@@ -261,14 +373,14 @@ test "Atrocity Test - New Atrocity"
 	sequence
 		inject "quarg atrocity"
 		call "Load First Savegame"
-		watchdog 12000
+		watchdog 6000
 		assert
 			"reputation: Quarg" == 1000
 		call "Launch Quarg Scanning Mission And Board"
-		# skip the dialog message for the atrocity
-		input
-			key "escape"
 		# land back with atrocity having been in effect (should nuke the reputation?)
 		call "Land On Ruin helper"
+		apply
+			"test: reputation: Quarg" = "reputation: Quarg"
 		assert
+			# it'll be 0 from the atrocity and then minus whatever the atrocity reputation hit it
 			"reputation: Quarg" < 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -12,10 +12,10 @@ test-data "quarg scanning"
 			attributes
 				category "Light Freighter"
 				cost 190000
-				mass 1
+				mass 70
 				bunks 3
 				"cargo space" 50
-				drag 1
+				drag 2.1
 				"engine capacity" 40
 				"fuel capacity" 300
 				"heat dissipation" 0.8
@@ -25,12 +25,11 @@ test-data "quarg scanning"
 				shields 600
 				"turret mounts" 1
 				"weapon capacity" 20
+				"thrust" 50
+				"turn" 1000
+				"energy generation" 10
 			outfits
-				"X1700 Ion Thruster"
-				"X1200 Ion Steering"
 				Hyperdrive
-				"nGVF-BB Fuel Cell"
-				"LP036a Battery Pack"
 				"Nerve Gas"
 			crew 1
 			fuel 300
@@ -39,10 +38,6 @@ test-data "quarg scanning"
 			position 0 0
 			engine -9 38 1
 			engine 9 38 1
-			turret 0 -8
-			leak leak 60 50
-			explode "tiny explosion" 10
-			explode "small explosion" 10
 			system "Terra Incognita"
 			planet Ruin
 		account
@@ -59,6 +54,46 @@ test-data "quarg scanning"
 				remove "enforces"
 		visited "Terra Incognita"
 		"visited planet" Ruin
+		"available mission" "%TEST%: Wardragon Scanning You!"
+			name "%TEST%: Wardragon Scanning You!"
+			uuid 9ba505d8-e565-4632-8c7a-c74072b85b5a
+			priority
+			to offer
+				"%TEST%: SCANNING ILLEGALS" != 0
+			destination Ruin
+			npc
+				uuid 01a921d2-b477-4d80-a19e-11aefb2a6464
+				succeed 1
+				government Quarg
+				personality derelict surveillance target
+				ship "Quarg Wardragon"
+					name Scanner
+					sprite ship/wardragon
+					thumbnail thumbnail/wardragon
+					uuid 7cc5c522-858d-419c-88a7-f240fc5799d7
+					attributes
+						category "Heavy Warship"
+						cost 5900000
+						mass 360
+						automaton 1
+						drag 9.3
+						"heat dissipation" 0.5
+						hull 50000
+						"outfit scan power" 1e+09
+						"outfit scan speed" 1e+09
+						"energy generation" 10
+						shields 160000
+					fuel 0
+					shields 0
+					hull 1000
+					position 0 0
+					explode "huge explosion" 1
+					system "Terra Incognita"
+			on offer
+				conversation
+					label 0
+					"You must be scanned or be killed."
+						accept
 		conditions
 			"%TEST%: SCANNING ILLEGALS"
 
@@ -79,10 +114,10 @@ test-data "quarg atrocity"
 			attributes
 				category "Light Freighter"
 				cost 190000
-				mass 1
+				mass 70
 				bunks 3
 				"cargo space" 50
-				drag 1
+				drag 2.1
 				"engine capacity" 40
 				"fuel capacity" 300
 				"heat dissipation" 0.8
@@ -92,12 +127,11 @@ test-data "quarg atrocity"
 				shields 600
 				"turret mounts" 1
 				"weapon capacity" 20
+				"thrust" 50
+				"turn" 1000
+				"energy generation" 10
 			outfits
-				"X1700 Ion Thruster"
-				"X1200 Ion Steering"
 				Hyperdrive
-				"nGVF-BB Fuel Cell"
-				"LP036a Battery Pack"
 			crew 1
 			fuel 300
 			shields 600
@@ -105,10 +139,6 @@ test-data "quarg atrocity"
 			position 0 0
 			engine -9 38 1
 			engine 9 38 1
-			turret 0 -8
-			leak leak 60 50
-			explode "tiny explosion" 10
-			explode "small explosion" 10
 			system "Terra Incognita"
 			planet Ruin
 		account
@@ -122,39 +152,55 @@ test-data "quarg atrocity"
 					atrocity 1000
 				atrocities
 					Hyperdrive
-				# they don't have it yet but to be sure
-				remove "death sentence"
 				remove "enforces"
+		# so we dont get a stupid plugin-like error of mission gone
+		event "mission exists!"
+			mission "%TEST%: Wardragon Scanning You!"
 		visited "Terra Incognita"
 		"visited planet" Ruin
+		"available mission" "%TEST%: Wardragon Scanning You!"
+			name "%TEST%: Wardragon Scanning You!"
+			uuid 9ba505d8-e565-4632-8c7a-c74072b85b5a
+			priority
+			to offer
+				"%TEST%: SCANNING ILLEGALS" != 0
+			destination Ruin
+			npc
+				uuid 01a921d2-b477-4d80-a19e-11aefb2a6464
+				succeed 1
+				government Quarg
+				personality derelict surveillance target
+				ship "Quarg Wardragon"
+					name Scanner
+					sprite ship/wardragon
+					thumbnail thumbnail/wardragon
+					uuid 7cc5c522-858d-419c-88a7-f240fc5799d7
+					attributes
+						category "Heavy Warship"
+						cost 5900000
+						mass 360
+						automaton 1
+						drag 9.3
+						"heat dissipation" 0.5
+						hull 50000
+						"outfit scan power" 1e+09
+						"outfit scan speed" 1e+09
+						"energy generation" 10
+						shields 160000
+					fuel 0
+					shields 0
+					hull 1000
+					position 0 0
+					explode "huge explosion" 1
+					system "Terra Incognita"
+			on offer
+				conversation
+					label 0
+					"You must be scanned or be killed."
+						accept
 		conditions
 			"%TEST%: SCANNING ILLEGALS"
 
-
-# No JD so it cant leave it'll only despawn from the mission. No guns so it wont kill us.
-ship "Quarg Wardragon" "%TEST%: Dumbdragon"
-	outfits
-		"Antimatter Core"
-		"Medium Graviton Steering"
-		"Medium Graviton Thruster"
-		"Nanotech Battery"
-	add attributes
-		"outfit scan power" 1000000000
-		"outfit scan speed" 1000000000
-
-mission "%TEST%: Wardragon Scanning You!"
-	priority
-	source "Ruin"
-	to offer
-		has "%TEST%: SCANNING ILLEGALS"
-	on offer
-		conversation
-			"You must be scanned or be killed."
-				accept
-	npc assist
-		government "Quarg"
-		ship "%TEST%: Dumbdragon" "Scanner"
-		personality derelict surveillance target
 
 test "Land On Ruin helper"
 	status partial
@@ -168,9 +214,9 @@ test "Land On Ruin helper"
 		assert
 			"flagship planet: Ruin" > 0
 
-test "Launch Quarg Scanning Mission"
+test "Launch Quarg Scanning Mission And Board"
 	status partial
-	description ""
+	description "Starts the mission, accepts it and then boards the quarg ship to repair it."
 	sequence
 		# launch and accept the mission
 		input

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -221,7 +221,7 @@ test "Launch Quarg Scanning Mission And Board"
 		input
 			key p
 		input
-			key "Return"
+			key "escape"
 		call "Depart"
 		# board the ship so we're sure we get close to it to get scanned
 		input
@@ -249,7 +249,7 @@ test "Illegal Test - Ignore and New Illegal"
 		call "Launch Quarg Scanning Mission And Board"
 		# skip the dialog message for the fine
 		input
-			key "enter"
+			key "escape"
 		# land back with a fine of 1 for the hyperdrive, nothing from the gas
 		call "Land On Ruin helper"
 		assert
@@ -267,7 +267,7 @@ test "Atrocity Test - New Atrocity"
 		call "Launch Quarg Scanning Mission And Board"
 		# skip the dialog message for the atrocity
 		input
-			key "enter"
+			key "escape"
 		# land back with atrocity having been in effect (should nuke the reputation?)
 		call "Land On Ruin helper"
 		assert

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -221,7 +221,7 @@ test "Launch Quarg Scanning Mission And Board"
 		input
 			key p
 		input
-			key "enter"
+			key "Return"
 		call "Depart"
 		# board the ship so we're sure we get close to it to get scanned
 		input

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -46,7 +46,7 @@ test-data "quarg scanning"
 			system "Terra Incognita"
 			planet Ruin
 		account
-			credits 1
+			credits 100000000
 			score 400
 			history
 		mission "Wardragon Scanning You!"
@@ -171,4 +171,4 @@ test "Illegal Test - Ignore and add"
 		# empty input to make time pass, the fine should be of 1 now
 		input
 		branch "landing"
-			"credits" == 0
+			"credits" == (100000000 - 1)

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -63,7 +63,7 @@ test-data "quarg scanning"
 			"%TEST%: SCANNING ILLEGALS"
 
 
-test-data "quarg scanning"
+test-data "quarg atrocity"
 	category "savegame"
 	contents
 		pilot Bobbi Bughunter
@@ -204,7 +204,7 @@ test "Illegal Test - Ignore and New Illegal"
 		# land back with a fine of 1 for the hyperdrive, nothing from the gas
 		call "Land On Ruin helper"
 		assert
-			"fines" == 1
+			"unpaid fines" == 1
 
 test "Atrocity Test - New Atrocity"
 	status active

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -119,6 +119,8 @@ test-data "quarg scanning"
 
 		event "atrocity stuff"
 			government "Quarg"
+				"penalty for"
+					atrocity 1000
 				atrocity
 					Hyperdrive
 				# they don't have it yet but to be sure
@@ -130,6 +132,7 @@ test-data "quarg scanning"
 			"%TEST%: SCANNING ILLEGALS"
 
 
+# No JD so it cant leave it'll only despawn from the mission. No guns so it wont kill us.
 ship "Quarg Wardragon" "%TEST%: Dumbdragon"
 	outfits
 		"Antimatter Core"
@@ -143,6 +146,7 @@ ship "Quarg Wardragon" "%TEST%: Dumbdragon"
 mission "%TEST%: Wardragon Scanning You!"
 	priority
 	landing
+	source "Ruin"
 	to offer
 		has "%TEST%: SCANNING ILLEGALS"
 	on offer
@@ -151,7 +155,6 @@ mission "%TEST%: Wardragon Scanning You!"
 				accept
 	npc assist
 		government "Quarg"
-		# I used another definition that had 1 million scan power but whatever
 		ship "%TEST%: Dumbdragon" "Scanner"
 		personality derelict surveillance target
 
@@ -177,7 +180,7 @@ test "Illegal Test - Ignore and New Illegal"
 		assert
 			"fines" == 0
 		call "Depart"
-		# land again to trigger the mission
+		# land again to trigger the mission and then skip the conversation
 		call "Land On Ruin helper"
 		input
 			command "enter"
@@ -198,7 +201,7 @@ test "Illegal Test - Ignore and New Illegal"
 		# skip the dialog message for the fine
 		input
 			command "enter"
-		# land back with a fine of 1
+		# land back with a fine of 1 for the hyperdrive, nothing from the gas
 		call "Land On Ruin helper"
 		assert
 			"fines" == 1
@@ -213,7 +216,7 @@ test "Atrocity Test - New Atrocity"
 		assert
 			"reputation: Quarg" == 1000
 		call "Depart"
-		# land again to trigger the mission
+		# land again to trigger the mission and then skip the conversation
 		call "Land On Ruin helper"
 		input
 			command "enter"
@@ -234,7 +237,7 @@ test "Atrocity Test - New Atrocity"
 		# skip the dialog message for the fine
 		input
 			command "enter"
-		# land back with a fine of 1
+		# land back with atrocity having been in effect (should nuke the reputation?)
 		call "Land On Ruin helper"
 		assert
 			"reputation: Quarg" < 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -98,7 +98,6 @@ test-data "quarg atrocity"
 				Hyperdrive
 				"nGVF-BB Fuel Cell"
 				"LP036a Battery Pack"
-				"Nerve Gas"
 			crew 1
 			fuel 300
 			shields 600

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -61,6 +61,8 @@ test-data "quarg scanning"
 		"visited planet" Ruin
 		conditions
 			"%TEST%: SCANNING ILLEGALS"
+			# to skip the landing on ruin conversation
+			"Ruin: Landing: offered"
 
 
 test-data "quarg atrocity"
@@ -129,6 +131,8 @@ test-data "quarg atrocity"
 		"visited planet" Ruin
 		conditions
 			"%TEST%: SCANNING ILLEGALS"
+			# to skip the landing on ruin conversation
+			"Ruin: Landing: offered"
 
 
 # No JD so it cant leave it'll only despawn from the mission. No guns so it wont kill us.
@@ -182,9 +186,6 @@ test "Illegal Test - Ignore and New Illegal"
 		call "Land On Ruin helper"
 		input
 			key "enter"
-		# skip the landing on ruin conversation too
-		input
-			key "enter"
 		call "Depart"
 		# board the ship so we're sure we get close to it to get scanned
 		input
@@ -219,9 +220,6 @@ test "Atrocity Test - New Atrocity"
 		call "Depart"
 		# land again to trigger the mission and then skip the conversation
 		call "Land On Ruin helper"
-		input
-			key "enter"
-		# skip the landing on ruin conversation too
 		input
 			key "enter"
 		call "Depart"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -153,9 +153,6 @@ test-data "quarg atrocity"
 				atrocities
 					Hyperdrive
 				remove "enforces"
-		# so we dont get a stupid plugin-like error of mission gone
-		event "mission exists!"
-			mission "%TEST%: Wardragon Scanning You!"
 		visited "Terra Incognita"
 		"visited planet" Ruin
 		"available mission" "%TEST%: Wardragon Scanning You!"
@@ -201,6 +198,8 @@ test-data "quarg atrocity"
 		conditions
 			"%TEST%: SCANNING ILLEGALS"
 
+# just so the mission actually works
+mission "%TEST%: Wardragon Scanning You!"
 
 test "Land On Ruin helper"
 	status partial

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -144,7 +144,6 @@ ship "Quarg Wardragon" "%TEST%: Dumbdragon"
 		"outfit scan speed" 1000000000
 
 mission "%TEST%: Wardragon Scanning You!"
-	priority
 	landing
 	source "Ruin"
 	to offer
@@ -183,11 +182,11 @@ test "Illegal Test - Ignore and New Illegal"
 		# land again to trigger the mission and then skip the conversation
 		call "Land On Ruin helper"
 		input
-			command "enter"
+			key "enter"
 		call "Depart"
 		# board the ship so we're sure we get close to it to get scanned
 		input
-			command board
+			key b
 		# Wait for 10 seconds so it should be repaired
 		apply
 			"test: steps to wait" = 10 * 60
@@ -200,7 +199,7 @@ test "Illegal Test - Ignore and New Illegal"
 			"test: steps to wait" > 0
 		# skip the dialog message for the fine
 		input
-			command "enter"
+			key "enter"
 		# land back with a fine of 1 for the hyperdrive, nothing from the gas
 		call "Land On Ruin helper"
 		assert
@@ -219,11 +218,11 @@ test "Atrocity Test - New Atrocity"
 		# land again to trigger the mission and then skip the conversation
 		call "Land On Ruin helper"
 		input
-			command "enter"
+			key "enter"
 		call "Depart"
 		# board the ship so we're sure we get close to it to get scanned
 		input
-			command board
+			key b
 		# Wait for 10 seconds so it should be boarded
 		apply
 			"test: steps to wait" = 10 * 60
@@ -236,7 +235,7 @@ test "Atrocity Test - New Atrocity"
 			"test: steps to wait" > 0
 		# skip the dialog message for the fine
 		input
-			command "enter"
+			key "enter"
 		# land back with atrocity having been in effect (should nuke the reputation?)
 		call "Land On Ruin helper"
 		assert

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -238,7 +238,7 @@ test "Atrocity Test - New Atrocity"
 			"test: steps to wait" = "test: steps to wait" - 1
 		branch "floating"
 			"test: steps to wait" > 0
-		# skip the dialog message for the fine
+		# skip the dialog message for the atrocity
 		input
 			key "enter"
 		# land back with atrocity having been in effect (should nuke the reputation?)

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -1,0 +1,174 @@
+test-data "quarg scanning"
+	category "savegame"
+	contents
+		pilot Bobbi Bughunter
+		date 16 11 3013
+		system "Terra Incognita"
+		planet Ruin
+		clearance
+		ship "Star Barge"
+			name "Buggy Barge"
+			sprite "ship/star barge"
+			attributes
+				category "Light Freighter"
+				cost 190000
+				mass 70
+				bunks 3
+				"cargo space" 50
+				drag 2.1
+				"engine capacity" 40
+				"fuel capacity" 300
+				"heat dissipation" 0.8
+				hull 1000
+				"outfit space" 130
+				"required crew" 1
+				shields 600
+				"turret mounts" 1
+				"weapon capacity" 20
+			outfits
+				"X1700 Ion Thruster"
+				"X1200 Ion Steering"
+				Hyperdrive
+				"nGVF-BB Fuel Cell"
+				"LP036a Battery Pack"
+				"Nerve Gas"
+			crew 1
+			fuel 300
+			shields 600
+			hull 1000
+			position 0 0
+			engine -9 38 1
+			engine 9 38 1
+			turret 0 -8
+			leak leak 60 50
+			explode "tiny explosion" 10
+			explode "small explosion" 10
+			system "Terra Incognita"
+			planet Ruin
+		account
+			credits 1
+			score 400
+			history
+		mission "Wardragon Scanning You!"
+			name "Wardragon Scanning You!"
+			uuid 50660c05-4451-4bb1-bdac-9b86b9bf8a88
+			npc
+				uuid 3cac29a8-778a-49de-a973-e8ea2514c6f1
+				succeed 1
+				government Quarg
+				personality
+					confusion 10
+					derelict
+					surveillance
+					target
+				ship "Quarg Wardragon"
+					name Scanner
+					sprite ship/wardragon
+					thumbnail thumbnail/wardragon
+					uuid 86da571c-8651-4a0a-a00a-a19fba1c393e
+					attributes
+						category "Heavy Warship"
+						cost 5900000
+						mass 1
+						bunks 185
+						"cargo space" 50
+						drag 1
+						"engine capacity" 120
+						"fuel capacity" 800
+						"heat dissipation" 0.5
+						hull 50000
+						"hull energy" 5
+						"hull repair rate" 5
+						"outfit scan power" 10000000
+						"outfit scan speed" 10000000
+						"outfit space" 600
+						ramscoop 10
+						"required crew" 160
+						shields 160000
+						"turret mounts" 4
+						"weapon capacity" 200
+					outfits
+						"Antimatter Core"
+						"Intrusion Countermeasures" 160
+						"Jump Drive"
+						"Medium Graviton Steering"
+						"Medium Graviton Thruster"
+						"Nanotech Battery"
+						"Quantum Shield Generator"
+						"Quarg Anti-Missile" 2
+						"Quarg Skylance" 2
+					crew 162
+					fuel 800
+					shields 0
+					hull 2884.5
+					position 885.13693 -758.45598
+					engine -14 47
+						zoom 1
+						angle 0
+						under
+					engine 14 47
+						zoom 1
+						angle 0
+						under
+					turret -28 7 "Quarg Skylance"
+						over
+					turret 28 7 "Quarg Skylance"
+						over
+					turret -9 -14 "Quarg Anti-Missile"
+						over
+					turret 9 -14 "Quarg Anti-Missile"
+						over
+					explode "huge explosion" 20
+					explode "large explosion" 40
+					explode "medium explosion" 30
+					explode "small explosion" 16
+					explode "tiny explosion" 12
+					"final explode" "final explosion medium" 1
+					system "Terra Incognita"
+				on offer
+					conversation
+						label 0
+						"You must be scanned or be killed."
+							accept
+
+		event "illegal stuff"
+			government "Quarg"
+				illegals
+					ignore "Nerve Gas"
+					Hyperdrive 1
+		visited "Terra Incognita"
+		"visited planet" Ruin
+
+test "Illegal Test - Ignore and add"
+	status active
+	description "Test if a Quarg ship spawning next to you will give you a fine for an illegal outfit and ignore the fine for another."
+	sequence
+		inject "burning flyers"
+		call "Load First Savegame"
+		watchdog 12000
+		call "Depart"
+		# board the ship so we're sure we get close to it
+		input
+			command board
+		# Wait for 10 seconds so it should be boarded
+		apply
+			"test: steps to wait" = 10 * 60
+		label "floating"
+		# empty input to make time pass
+		input
+		apply
+			"test: steps to wait" = "test: steps to wait" - 1
+		branch "floating"
+			"test: steps to wait" > 0
+		# land back wiht a fine of 1
+		input
+			command land
+		label "landing"
+		# this will despawn the ship
+		call "Depart"
+		input
+			command land
+		# empty input to make time pass, the fine should be of 1 now
+		input
+		branch "landing"
+			"credits" == 0

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -12,10 +12,10 @@ test-data "quarg scanning"
 			attributes
 				category "Light Freighter"
 				cost 190000
-				mass 70
+				mass 10
 				bunks 3
 				"cargo space" 50
-				drag 2.1
+				drag 1
 				"engine capacity" 40
 				"fuel capacity" 300
 				"heat dissipation" 0.8
@@ -49,99 +49,84 @@ test-data "quarg scanning"
 			credits 100000000
 			score 400
 			history
-		mission "%TEST%: Wardragon Scanning You!"
-			name "%TEST%: Wardragon Scanning You!"
-			uuid 58363365-d579-4914-b407-3fb475054588
-			landing
-			destination Ruin
-			npc
-				uuid 449c28f4-922a-493b-89f6-782e5fd741d9
-				succeed 1
-				government Quarg
-				personality
-					confusion 10
-					derelict
-					surveillance
-					target
-				ship "Quarg Wardragon"
-					name Scanner
-					sprite ship/wardragon
-					thumbnail thumbnail/wardragon
-					uuid 52834b2a-711f-439a-aff1-b529613f710e
-					attributes
-						category "Heavy Warship"
-						cost 5900000
-						mass 360
-						bunks 185
-						"cargo space" 50
-						drag 9.3
-						"engine capacity" 120
-						"fuel capacity" 800
-						"heat dissipation" 0.5
-						"outfit scan speed" 1000000
-						"outfit scan power" 1000000
-						hull 50000
-						"hull energy" 5
-						"hull repair rate" 5
-						"outfit space" 600
-						ramscoop 10
-						"required crew" 160
-						shields 160000
-						"turret mounts" 4
-						"weapon capacity" 200
-					outfits
-						"Antimatter Core"
-						"Intrusion Countermeasures" 160
-						"Medium Graviton Steering"
-						"Medium Graviton Thruster"
-						"Nanotech Battery"
-						"Quantum Shield Generator"
-						"Quarg Anti-Missile" 2
-						"Quarg Skylance" 2
-					crew 162
-					fuel 800
-					shields 0
-					hull 2884.5
-					position 0 -1000
-					engine -14 47
-						zoom 1
-						angle 0
-						under
-					engine 14 47
-						zoom 1
-						angle 0
-						under
-					turret -28 7 "Quarg Skylance"
-						over
-					turret 28 7 "Quarg Skylance"
-						over
-					turret -9 -14 "Quarg Anti-Missile"
-						over
-					turret 9 -14 "Quarg Anti-Missile"
-						over
-					explode "huge explosion" 20
-					explode "large explosion" 40
-					explode "medium explosion" 30
-					explode "small explosion" 16
-					explode "tiny explosion" 12
-					"final explode" "final explosion medium" 1
-					system "Terra Incognita"
-			on offer
-				conversation
-					label 0
-					"You must be scanned or be killed."
-						accept
 
 		event "illegal stuff"
 			government "Quarg"
 				illegals
 					ignore "Nerve Gas"
 					Hyperdrive 1
+				# they enforce all currently but to be sure
+				remove "enforces"
 		visited "Terra Incognita"
 		"visited planet" Ruin
 		conditions
-			"%TEST%: Wardragon Scanning You!: active"
-			"%TEST%: Wardragon Scanning You!: offered"
+			"%TEST%: SCANNING ILLEGALS"
+
+
+test-data "quarg scanning"
+	category "savegame"
+	contents
+		pilot Bobbi Bughunter
+		date 16 11 3013
+		system "Terra Incognita"
+		planet Ruin
+		clearance
+		"reputation with"
+			Quarg 1000
+		ship "Star Barge"
+			name "Buggy Barge"
+			sprite "ship/star barge"
+			attributes
+				category "Light Freighter"
+				cost 190000
+				mass 10
+				bunks 3
+				"cargo space" 50
+				drag 1
+				"engine capacity" 40
+				"fuel capacity" 300
+				"heat dissipation" 0.8
+				hull 1000
+				"outfit space" 130
+				"required crew" 1
+				shields 600
+				"turret mounts" 1
+				"weapon capacity" 20
+			outfits
+				"X1700 Ion Thruster"
+				"X1200 Ion Steering"
+				Hyperdrive
+				"nGVF-BB Fuel Cell"
+				"LP036a Battery Pack"
+				"Nerve Gas"
+			crew 1
+			fuel 300
+			shields 600
+			hull 1000
+			position 0 0
+			engine -9 38 1
+			engine 9 38 1
+			turret 0 -8
+			leak leak 60 50
+			explode "tiny explosion" 10
+			explode "small explosion" 10
+			system "Terra Incognita"
+			planet Ruin
+		account
+			credits 100000000
+			score 400
+			history
+
+		event "atrocity stuff"
+			government "Quarg"
+				atrocity
+					Hyperdrive
+				# they don't have it yet but to be sure
+				remove "death sentence"
+				remove "enforces"
+		visited "Terra Incognita"
+		"visited planet" Ruin
+		conditions
 			"%TEST%: SCANNING ILLEGALS"
 
 
@@ -156,6 +141,7 @@ ship "Quarg Wardragon" "%TEST%: Dumbdragon"
 		"outfit scan speed" 1000000000
 
 mission "%TEST%: Wardragon Scanning You!"
+	priority
 	landing
 	to offer
 		has "%TEST%: SCANNING ILLEGALS"
@@ -169,15 +155,70 @@ mission "%TEST%: Wardragon Scanning You!"
 		ship "%TEST%: Dumbdragon" "Scanner"
 		personality derelict surveillance target
 
-test "Illegal Test - Ignore and add"
-	status active
-	description "Test if a Quarg ship spawning next to you will give you a fine for an illegal outfit and ignore the fine for another."
+test "Land On Ruin helper"
+	status partial
+	description "Helper for landing on Ruin."
 	sequence
-		inject "burning flyers"
+		input
+			command land
+		label landing
+		branch landing
+			"flagship planet: Ruin" < 1
+		assert
+			"flagship planet: Ruin" > 0
+
+test "Illegal Test - Ignore and New Illegal"
+	status active
+	description "Test if a Quarg ship spawning disabled in the system will give you a fine for an illegal outfit and ignore the fine for another, after you repaired it."
+	sequence
+		inject "quarg scanning"
 		call "Load First Savegame"
 		watchdog 12000
+		assert
+			"fines" == 0
 		call "Depart"
-		# board the ship so we're sure we get close to it
+		# land again to trigger the mission
+		call "Land On Ruin helper"
+		input
+			command "enter"
+		call "Depart"
+		# board the ship so we're sure we get close to it to get scanned
+		input
+			command board
+		# Wait for 10 seconds so it should be repaired
+		apply
+			"test: steps to wait" = 10 * 60
+		label "floating"
+		# empty input to make time pass
+		input
+		apply
+			"test: steps to wait" = "test: steps to wait" - 1
+		branch "floating"
+			"test: steps to wait" > 0
+		# skip the dialog message for the fine
+		input
+			command "enter"
+		# land back with a fine of 1
+		call "Land On Ruin helper"
+		assert
+			"fines" == 1
+
+test "Atrocity Test - New Atrocity"
+	status active
+	description "Test if a Quarg ship spawning disabled in the system will consider an outfit an atrocity when specified by an event."
+	sequence
+		inject "quarg atrocity"
+		call "Load First Savegame"
+		watchdog 12000
+		assert
+			"reputation: Quarg" == 1000
+		call "Depart"
+		# land again to trigger the mission
+		call "Land On Ruin helper"
+		input
+			command "enter"
+		call "Depart"
+		# board the ship so we're sure we get close to it to get scanned
 		input
 			command board
 		# Wait for 10 seconds so it should be boarded
@@ -190,15 +231,10 @@ test "Illegal Test - Ignore and add"
 			"test: steps to wait" = "test: steps to wait" - 1
 		branch "floating"
 			"test: steps to wait" > 0
-		# land back wiht a fine of 1
+		# skip the dialog message for the fine
 		input
-			command land
-		label "landing"
-		# this will despawn the ship
-		call "Depart"
-		input
-			command land
-		# empty input to make time pass, the fine should be of 1 now
-		input
-		branch "landing"
-			"credits" == (100000000 - 1)
+			command "enter"
+		# land back with a fine of 1
+		call "Land On Ruin helper"
+		assert
+			"reputation: Quarg" < 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -183,6 +183,9 @@ test "Illegal Test - Ignore and New Illegal"
 		call "Land On Ruin helper"
 		input
 			key "enter"
+		# skip the landing on ruin conversation too
+		input
+			key "enter"
 		call "Depart"
 		# board the ship so we're sure we get close to it to get scanned
 		input
@@ -217,6 +220,9 @@ test "Atrocity Test - New Atrocity"
 		call "Depart"
 		# land again to trigger the mission and then skip the conversation
 		call "Land On Ruin helper"
+		input
+			key "enter"
+		# skip the landing on ruin conversation too
 		input
 			key "enter"
 		call "Depart"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -12,7 +12,7 @@ test-data "quarg scanning"
 			attributes
 				category "Light Freighter"
 				cost 190000
-				mass 10
+				mass 1
 				bunks 3
 				"cargo space" 50
 				drag 1
@@ -61,8 +61,6 @@ test-data "quarg scanning"
 		"visited planet" Ruin
 		conditions
 			"%TEST%: SCANNING ILLEGALS"
-			# to skip the landing on ruin conversation
-			"Ruin: Landing: offered"
 
 
 test-data "quarg atrocity"
@@ -81,7 +79,7 @@ test-data "quarg atrocity"
 			attributes
 				category "Light Freighter"
 				cost 190000
-				mass 10
+				mass 1
 				bunks 3
 				"cargo space" 50
 				drag 1
@@ -131,8 +129,6 @@ test-data "quarg atrocity"
 		"visited planet" Ruin
 		conditions
 			"%TEST%: SCANNING ILLEGALS"
-			# to skip the landing on ruin conversation
-			"Ruin: Landing: offered"
 
 
 # No JD so it cant leave it'll only despawn from the mission. No guns so it wont kill us.
@@ -147,7 +143,7 @@ ship "Quarg Wardragon" "%TEST%: Dumbdragon"
 		"outfit scan speed" 1000000000
 
 mission "%TEST%: Wardragon Scanning You!"
-	landing
+	priority
 	source "Ruin"
 	to offer
 		has "%TEST%: SCANNING ILLEGALS"
@@ -172,18 +168,13 @@ test "Land On Ruin helper"
 		assert
 			"flagship planet: Ruin" > 0
 
-test "Illegal Test - Ignore and New Illegal"
-	status active
-	description "Test if a Quarg ship spawning disabled in the system will give you a fine for an illegal outfit and ignore the fine for another, after you repaired it."
+test "Launch Quarg Scanning Mission"
+	status partial
+	description ""
 	sequence
-		inject "quarg scanning"
-		call "Load First Savegame"
-		watchdog 12000
-		assert
-			"fines" == 0
-		call "Depart"
-		# land again to trigger the mission and then skip the conversation
-		call "Land On Ruin helper"
+		# launch and accept the mission
+		input
+			key p
 		input
 			key "enter"
 		call "Depart"
@@ -200,6 +191,17 @@ test "Illegal Test - Ignore and New Illegal"
 			"test: steps to wait" = "test: steps to wait" - 1
 		branch "floating"
 			"test: steps to wait" > 0
+
+test "Illegal Test - Ignore and New Illegal"
+	status active
+	description "Test if a Quarg ship spawning disabled in the system will give you a fine for an illegal outfit and ignore the fine for another, after you repaired it."
+	sequence
+		inject "quarg scanning"
+		call "Load First Savegame"
+		watchdog 12000
+		assert
+			"fines" == 0
+		call "Launch Quarg Scanning Mission And Board"
 		# skip the dialog message for the fine
 		input
 			key "enter"
@@ -217,25 +219,7 @@ test "Atrocity Test - New Atrocity"
 		watchdog 12000
 		assert
 			"reputation: Quarg" == 1000
-		call "Depart"
-		# land again to trigger the mission and then skip the conversation
-		call "Land On Ruin helper"
-		input
-			key "enter"
-		call "Depart"
-		# board the ship so we're sure we get close to it to get scanned
-		input
-			key b
-		# Wait for 10 seconds so it should be boarded
-		apply
-			"test: steps to wait" = 10 * 60
-		label "floating"
-		# empty input to make time pass
-		input
-		apply
-			"test: steps to wait" = "test: steps to wait" - 1
-		branch "floating"
-			"test: steps to wait" > 0
+		call "Launch Quarg Scanning Mission And Board"
 		# skip the dialog message for the atrocity
 		input
 			key "enter"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -121,7 +121,7 @@ test-data "quarg atrocity"
 			government "Quarg"
 				"penalty for"
 					atrocity 1000
-				atrocity
+				atrocities
 					Hyperdrive
 				# they don't have it yet but to be sure
 				remove "death sentence"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -221,7 +221,7 @@ test "Launch Quarg Scanning Mission And Board"
 		input
 			key p
 		input
-			key "escape"
+			key d
 		call "Depart"
 		# board the ship so we're sure we get close to it to get scanned
 		input

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -49,11 +49,13 @@ test-data "quarg scanning"
 			credits 100000000
 			score 400
 			history
-		mission "Wardragon Scanning You!"
-			name "Wardragon Scanning You!"
-			uuid 50660c05-4451-4bb1-bdac-9b86b9bf8a88
+		mission "%TEST%: Wardragon Scanning You!"
+			name "%TEST%: Wardragon Scanning You!"
+			uuid 58363365-d579-4914-b407-3fb475054588
+			landing
+			destination Ruin
 			npc
-				uuid 3cac29a8-778a-49de-a973-e8ea2514c6f1
+				uuid 449c28f4-922a-493b-89f6-782e5fd741d9
 				succeed 1
 				government Quarg
 				personality
@@ -65,22 +67,22 @@ test-data "quarg scanning"
 					name Scanner
 					sprite ship/wardragon
 					thumbnail thumbnail/wardragon
-					uuid 86da571c-8651-4a0a-a00a-a19fba1c393e
+					uuid 52834b2a-711f-439a-aff1-b529613f710e
 					attributes
 						category "Heavy Warship"
 						cost 5900000
-						mass 1
+						mass 360
 						bunks 185
 						"cargo space" 50
-						drag 1
+						drag 9.3
 						"engine capacity" 120
 						"fuel capacity" 800
 						"heat dissipation" 0.5
+						"outfit scan speed" 1000000
+						"outfit scan power" 1000000
 						hull 50000
 						"hull energy" 5
 						"hull repair rate" 5
-						"outfit scan power" 10000000
-						"outfit scan speed" 10000000
 						"outfit space" 600
 						ramscoop 10
 						"required crew" 160
@@ -90,7 +92,6 @@ test-data "quarg scanning"
 					outfits
 						"Antimatter Core"
 						"Intrusion Countermeasures" 160
-						"Jump Drive"
 						"Medium Graviton Steering"
 						"Medium Graviton Thruster"
 						"Nanotech Battery"
@@ -101,7 +102,7 @@ test-data "quarg scanning"
 					fuel 800
 					shields 0
 					hull 2884.5
-					position 885.13693 -758.45598
+					position 0 -1000
 					engine -14 47
 						zoom 1
 						angle 0
@@ -125,11 +126,11 @@ test-data "quarg scanning"
 					explode "tiny explosion" 12
 					"final explode" "final explosion medium" 1
 					system "Terra Incognita"
-				on offer
-					conversation
-						label 0
-						"You must be scanned or be killed."
-							accept
+			on offer
+				conversation
+					label 0
+					"You must be scanned or be killed."
+						accept
 
 		event "illegal stuff"
 			government "Quarg"
@@ -138,6 +139,35 @@ test-data "quarg scanning"
 					Hyperdrive 1
 		visited "Terra Incognita"
 		"visited planet" Ruin
+		conditions
+			"%TEST%: Wardragon Scanning You!: active"
+			"%TEST%: Wardragon Scanning You!: offered"
+			"%TEST%: SCANNING ILLEGALS"
+
+
+ship "Quarg Wardragon" "%TEST%: Dumbdragon"
+	outfits
+		"Antimatter Core"
+		"Medium Graviton Steering"
+		"Medium Graviton Thruster"
+		"Nanotech Battery"
+	add attributes
+		"outfit scan power" 1000000000
+		"outfit scan speed" 1000000000
+
+mission "%TEST%: Wardragon Scanning You!"
+	landing
+	to offer
+		has "%TEST%: SCANNING ILLEGALS"
+	on offer
+		conversation
+			"You must be scanned or be killed."
+				accept
+	npc assist
+		government "Quarg"
+		# I used another definition that had 1 million scan power but whatever
+		ship "%TEST%: Dumbdragon" "Scanner"
+		personality derelict surveillance target
 
 test "Illegal Test - Ignore and add"
 	status active


### PR DESCRIPTION
Related to https://github.com/endless-sky/endless-sky/pull/6407 I was asked to do integration tests so here they are. Just one for now, and marking this as a draft as I'm not sure what to do exactly for the atrocity part

### Automated Tests Added
Added a test where you are in terra incognita with a derelict quarg ship you need to assist.
That way you get close to it and with this absurd scanning it'll scan you and fine you for the hyperdrive (for one credit) but not for the nerve gas because its ignored.
May need to tweak the event and things like that.