### PR TITLE
chore(code style): Fix code style issues in master

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -75,7 +75,7 @@ namespace {
 		if(int result = WEXITSTATUS(system(("xdg-open file://" + path).c_str())))
 			Logger::LogError("Warning: xdg-open failed with error code " + to_string(result) + ".");
 #else
-# warning SDL 2.0.14 or higher is needed for opening folders
+#warning SDL 2.0.14 or higher is needed for opening folders!
 		Logger::LogError("Warning: No handler found to open \"" + path + "\" in a new window.");
 #endif
 	}

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -75,7 +75,7 @@ namespace {
 		if(int result = WEXITSTATUS(system(("xdg-open file://" + path).c_str())))
 			Logger::LogError("Warning: xdg-open failed with error code " + to_string(result) + ".");
 #else
-#warning SDL 2.0.14 or higher is needed for opening folders!
+# warning SDL 2.0.14 or higher is needed for opening folders
 		Logger::LogError("Warning: No handler found to open \"" + path + "\" in a new window.");
 #endif
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -626,13 +626,15 @@ void Ship::FinishLoading(bool isNewInstance)
 			armament.Add(it.first, -excess);
 			it.second -= excess;
 
-			LogWarning(VariantName(), Name(), "outfit \"" + it.first->TrueName() + "\" equipped but not included in outfit list.");
+			LogWarning(VariantName(), Name(),
+					"outfit \"" + it.first->TrueName() + "\" equipped but not included in outfit list.");
 		}
 		else if(!it.first->IsWeapon())
 			// This ship was specified with a non-weapon outfit in a
 			// hardpoint. Hardpoint::Install removes it, but issue a
 			// warning so the definition can be fixed.
-			LogWarning(VariantName(), Name(), "outfit \"" + it.first->TrueName() + "\" is not a weapon, but is installed as one.");
+			LogWarning(VariantName(), Name(),
+					"outfit \"" + it.first->TrueName() + "\" is not a weapon, but is installed as one.");
 	}
 
 	// Mark any drone that has no "automaton" value as an automaton, to


### PR DESCRIPTION
Fixes the issues the new CI is whining about. This includes adding two line breaks and the removal of an exclamation mark. The line breaks are straightforward, but the `!` is problematic:

It is part of a preprocessor warning. We didn't have those before, so the style checker CI cannot handle them (it would be a 30 second fix though), but the bigger issue is that these warnings are not entirely portable (for instance, they don't work in visual studio).

For now, I removed the exclamation mark that triggered the error. I can fix the script to handle it, or we could remove the preprocessor warning. Either way, we should probably have a permanent solution.