### PR TITLE
bug(CI): Fix false positive in code style checker

### DIFF
--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -208,6 +208,10 @@ def sanitize(lines, skip_checks=False):
 		line_count += 1
 		segments = []
 		is_escaped = False
+		# Checking for preprocessor text, except includes
+		if line.lstrip().startswith("#") and not line.lstrip().startswith("#include"):
+			line_segments.append(segments)
+			continue
 		# Start index is the beginning of the sequence to be tested
 		start_index = 0
 		# Looking for parts of the file that are not strings or comments


### PR DESCRIPTION
This PR fixes a false positive related to preprocessor warnings. Now all preprocessor texts are completely removed during sanitization, except for the include statements (the "" includes still have their string contents removed, as previously).