### PR TITLE
Fix path filter for the integration tests

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -40,7 +40,7 @@ integration_tests:
   - 'utils/test_parse.*'
   - 'tests/integration/run_tests*'
   - 'data/tests/**'
-  - 'tests/integration/universes/**'
+  - 'tests/integration/config/plugins/integration-tests/**'
 
 codespell:
   - .codespell.exclude


### PR DESCRIPTION
The path filter for the location of the integration tests was incorrect, which meant that PRs that only modify the integration tests didn't run the integration test CI.