### PR TITLE
Ensure Remnant Gascraft event compatibility

### DIFF
--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -66,6 +66,14 @@ event "remnant: puffin"
 
 
 
+# Replaced by the "remnant: puffin" event but the listed here so older versions of the "Remnant: Void Sprites 3" mission in their save file when they update do not have issues with this event being undefined.
+# The actual content of the event is not strictly necessary, since a patch mission already exists that applies the new event if the condition for this event is present.
+# But the event still needs to be declared so it can be considered "defined" by the game, otherwise, it will disable the mission referring to it.
+# If we ever do something that makes save files from an older version of the game incompatible, this can be removed.
+event "remnant: gascraft"
+
+
+
 event "remnant: void sprite research"
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7632

## Fix Details
In #5001, the Gascraft was renamed to "Puffin", and the names of the event referring to it and the shipyard it was in were also updated.
This, for the most part, should not cause issues, but someone who already has the old version of the mission in their save file but has not yet completed it will encounter issues if they update to a version of the game after the rename (as has happened in the mentioned issue). The mission refers to the event "remnant: gascraft" but this event no longer exists and so the game disables the mission, assuming the non-existent content is from a plugin that has been removed and not wanting to risk breaking something by letting the incomplete mission run.
This PR adds a line `event "remnant: gascraft"` so the event is defined and the mission is not disabled, and a comment explaining why it is there
This event does not have any content, as a patch mission already exists that will apply the new "remnant: puffin" event if the condition for the "remnant: gascraft" event is present.

It seems various places where the game is distributed on Linux are still providing a very old version, and since there has been discussions of updating those, more people are likely to encounter issues like in #7632, even if it is unlikely that a person happens to update with this mission active.

## Testing Done
Loading the save in the linked issue (also linked below) without this PR (in the current version of the game), will result in a messge telling the player that the "Visit void sprite planets" mission (`Remnant: Void Sprites 3`) has been disabled because it is not fully defined.
With this PR, that is no longer be the case.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
https://github.com/endless-sky/endless-sky/files/10031749/Sticky.Digit.txt


