### PR TITLE
feat(capture): Indicate crew transfer on ship capture

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -373,7 +373,17 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 			{
 				messages.push_back("You have succeeded in capturing this ship.");
 				victim->GetGovernment()->Offend(ShipEvent::CAPTURE, victim->CrewValue());
-				victim->WasCaptured(you);
+				int crewTransferred = victim->WasCaptured(you);
+				if(crewTransferred > 0)
+				{
+					string transferMessage = Format::Number(crewTransferred) + " crew member";
+					if(crewTransferred == 1)
+						transferMessage += " has";
+					else
+						transferMessage += " have";
+					transferMessage += " been transferred.";
+					messages.push_back(transferMessage);
+				}
 				if(!victim->JumpsRemaining() && you->CanRefuel(*victim))
 					you->TransferFuel(victim->JumpFuelMissing(), &*victim);
 				player.AddShip(victim);

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -380,7 +380,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 					if(crewTransferred == 1)
 						transferMessage += " has";
 					else
-						transferMessage += " have";
+						transferMessage += "s have";
 					transferMessage += " been transferred.";
 					messages.push_back(transferMessage);
 				}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3093,7 +3093,8 @@ double Ship::TransferFuel(double amount, Ship *to)
 
 // Convert this ship from one government to another, as a result of boarding
 // actions (if the player is capturing) or player death (poor decision-making).
-void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
+// Returns the number of crew transferred from the capturer.
+int Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 {
 	// Repair up to the point where this ship is just barely not disabled.
 	hull = min(max(hull, MinimumHull() * 1.5), attributes.Get("hull"));
@@ -3138,6 +3139,8 @@ void Ship::WasCaptured(const shared_ptr<Ship> &capturer)
 	}
 	// This ship should not care about its now-unallied escorts.
 	escorts.clear();
+
+	return transfer;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -291,8 +291,8 @@ public:
 	bool CanRefuel(const Ship &other) const;
 	// Give the other ship enough fuel for it to jump.
 	double TransferFuel(double amount, Ship *to);
-	// Mark this ship as property of the given ship.
-	void WasCaptured(const std::shared_ptr<Ship> &capturer);
+	// Mark this ship as property of the given ship. Returns the number of crew transferred from the capturer.
+	int WasCaptured(const std::shared_ptr<Ship> &capturer);
 	// Clear all orders and targets this ship has (after capture or transfer of control).
 	void ClearTargetsAndOrders();
 


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #7608

## Feature Details
Below the line informing the player that they have successfully captured a ship, there will now be a line telling the player how many crew were transferred, unless fewer than 1 were.

## UI Screenshots
![image](https://user-images.githubusercontent.com/20605679/202499777-155b0716-519f-4ebe-ad8c-0a2865a5a2cc.png)

![image](https://user-images.githubusercontent.com/20605679/202499304-9a5f96ac-ec4b-43c3-9cc5-02b2898bd5c8.png)

![image](https://user-images.githubusercontent.com/20605679/202499851-22683027-e1b8-4a5e-b27a-10e86d7b58fb.png)


