### PR TITLE
Hai Reveal: Fix Agent Kopkow log

### DIFF
--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -320,7 +320,7 @@ mission "Hai Reveal [B05-short] The Road Not Taken"
 		has "event: knows about keystones and wormholes"
 	on offer
 		log `Giti tripped an alert which places you both under the jurisdiction of a Syndicate Internal Affairs investigation. You've were sent directly to Hephaestus.`
-		log `Agent Kopkow` `A Republic Intelligence officer who intercepted your investigation with Giti before involving you with Syndicate Internal Affairs.`
+		log "Minor People" "Agent Kopkow" `A Republic Intelligence officer who intercepted your investigation with Giti before involving you with Syndicate Internal Affairs.`
 		conversation "giti tripped an alert"
 	on fail
 		"reputation: Republic" <?= -100


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7592

## Fix Details
Ensures that the log for Agent Kopkow goes into the Minor People tab instead of creating a new tab.
It doesn't seem to me like he is a "People", so he goes into the minor category.
I don't think any of the existing PRs already handle this ~~but there's a lot to check so maybe I missed it. None seem to be mentioning the issue, though.~~

