### PR TITLE
Fix bug with outfit display names

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -200,7 +200,7 @@ void Outfit::Load(const DataNode &node)
 	{
 		if(child.Token(0) == "display name" && child.Size() >= 2)
 			displayName = child.Token(1);
-		if(child.Token(0) == "category" && child.Size() >= 2)
+		else if(child.Token(0) == "category" && child.Size() >= 2)
 			category = child.Token(1);
 		else if(child.Token(0) == "plural" && child.Size() >= 2)
 			pluralName = child.Token(1);


### PR DESCRIPTION
**Bugfix:**

Thanks to @Hurleveur for reporting this on Discord.

## Fix Details
After the display names is parsed, since a new if statement begins, the value of the display name token will be inserted into the attributes Dictionary like any other, resulting in it being incorrectly displayed in the outfit info display with a value of 0.
