### PR TITLE
Store excess outfits in cargo on take off

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1527,16 +1527,25 @@ bool PlayerInfo::TakeOff(UI *ui)
 			it->second -= basis;
 			totalBasis += basis;
 		}
-		for(const auto &outfit : cargo.Outfits())
-		{
-			// Compute the total value for each type of excess outfit.
-			if(!outfit.second)
-				continue;
-			int64_t cost = depreciation.Value(outfit.first, day, outfit.second);
-			for(int i = 0; i < outfit.second; ++i)
-				stockDepreciation.Buy(outfit.first, day, &depreciation);
-			income += cost;
-		}
+		if(!planet->HasOutfitter())
+			for(const auto &outfit : cargo.Outfits())
+			{
+				// Compute the total value for each type of excess outfit.
+				if(!outfit.second)
+					continue;
+				int64_t cost = depreciation.Value(outfit.first, day, outfit.second);
+				for(int i = 0; i < outfit.second; ++i)
+					stockDepreciation.Buy(outfit.first, day, &depreciation);
+				income += cost;
+			}
+		else
+			for(const auto &outfit : cargo.Outfits())
+			{
+				// Compute the total value for each type of excess outfit.
+				if(!outfit.second)
+					continue;
+				cargo.Transfer(outfit.first, outfit.second, *Storage());
+			}
 	}
 	accounts.AddCredits(income);
 	cargo.Clear();

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1541,10 +1541,10 @@ bool PlayerInfo::TakeOff(UI *ui)
 		else
 			for(const auto &outfit : cargo.Outfits())
 			{
-				// Compute the total value for each type of excess outfit.
+				// Transfer the outfits from cargo to the storage on this planet.
 				if(!outfit.second)
 					continue;
-				cargo.Transfer(outfit.first, outfit.second, *Storage());
+				cargo.Transfer(outfit.first, outfit.second, *Storage(true));
 			}
 	}
 	accounts.AddCredits(income);

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
@@ -1,0 +1,318 @@
+test-data "A Sparrow and a Shuttle and a Shield Generator on Prime"
+	category "savegame"
+	contents
+		pilot Billy Bughunter
+		date 29 11 3013
+		system Betelgeuse
+		planet Prime
+		# Set some reputations to positive to avoid combat
+		"reputation with"
+			Bounty 1
+			"Bounty Hunter" 1
+			Pirate 1
+		# What you own:
+		ship Sparrow
+			name "Agincourt"
+			sprite ship/sparrow
+			thumbnail thumbnail/sparrow
+			uuid 65f19ee4-5cc2-452c-9695-cc918710853c
+			attributes
+				category Interceptor
+				cost 225000
+				mass 50
+				bunks 3
+				"cargo space" 15
+				drag 0.9
+				"engine capacity" 40
+				"fuel capacity" 300
+				"gun ports" 2
+				"heat dissipation" 0.8
+				hull 300
+				"outfit space" 130
+				"required crew" 1
+				shields 1400
+				"weapon capacity" 25
+			outfits
+				"Beam Laser" 2
+				"Chipmunk Plasma Steering"
+				"Chipmunk Plasma Thruster"
+				"D14-RN Shield Generator"
+				Hyperdrive
+				"LP036a Battery Pack"
+				"nGVF-BB Fuel Cell"
+			crew 1
+			fuel 300
+			shields 1400
+			hull 300
+			engine -5 35
+				zoom 1
+				angle 0
+				under
+			engine 5 35
+				zoom 1
+				angle 0
+				under
+			gun -7 -10 "Beam Laser"
+				under
+			gun 7 -10 "Beam Laser"
+				under
+			leak flame 60 80
+			explode "small explosion" 5
+			explode "tiny explosion" 15
+			system Betelgeuse
+			planet Prime
+		ship Shuttle
+			name "Arkhangelsk"
+			sprite ship/shuttle
+				"frame rate" 15
+				delay 14
+			thumbnail thumbnail/shuttle
+			uuid aa995c01-8b9f-43ca-8a46-a5fb77797af8
+			attributes
+				category Transport
+				cost 180000
+				mass 70
+				bunks 6
+				"cargo space" 20
+				drag 1.7
+				"engine capacity" 60
+				"fuel capacity" 400
+				"gun ports" 1
+				"heat dissipation" 0.8
+				hull 600
+				"outfit space" 120
+				"required crew" 1
+				shields 500
+				"weapon capacity" 10
+			outfits
+				"D14-RN Shield Generator"
+				Hyperdrive
+				"LP036a Battery Pack"
+				"X2200 Ion Steering"
+				"X2700 Ion Thruster"
+				"nGVF-AA Fuel Cell"
+			crew 1
+			fuel 400
+			shields 500
+			hull 600
+			engine -6 30
+				zoom 1
+				angle 0
+				under
+			engine 6 30
+				zoom 1
+				angle 0
+				under
+			gun 0 -31
+				under
+			leak leak 60 50
+			explode "small explosion" 5
+			explode "tiny explosion" 10
+			system Betelgeuse
+			planet Prime
+		account
+			credits 0
+			score 400
+			history
+		cargo
+			outfits
+				"D23-QP Shield Generator" 1
+		visited Betelgeuse
+		"visited planet" Prime
+
+
+test-data "A Sparrow and a Shuttle and a Shield Generator on Winter"
+	category "savegame"
+	contents
+		pilot Billy Bughunter
+		date 29 11 3013
+		system "Yed Prior"
+		planet Winter
+		# Set some reputations to positive to avoid combat
+		"reputation with"
+			Bounty 1
+			"Bounty Hunter" 1
+			Pirate 1
+		# What you own:
+		ship Sparrow
+			name "Agincourt"
+			sprite ship/sparrow
+			thumbnail thumbnail/sparrow
+			uuid 65f19ee4-5cc2-452c-9695-cc918710853c
+			attributes
+				category Interceptor
+				cost 225000
+				mass 50
+				bunks 3
+				"cargo space" 15
+				drag 0.9
+				"engine capacity" 40
+				"fuel capacity" 300
+				"gun ports" 2
+				"heat dissipation" 0.8
+				hull 300
+				"outfit space" 130
+				"required crew" 1
+				shields 1400
+				"weapon capacity" 25
+			outfits
+				"Beam Laser" 2
+				"Chipmunk Plasma Steering"
+				"Chipmunk Plasma Thruster"
+				"D14-RN Shield Generator"
+				Hyperdrive
+				"LP036a Battery Pack"
+				"nGVF-BB Fuel Cell"
+			crew 1
+			fuel 300
+			shields 1400
+			hull 300
+			engine -5 35
+				zoom 1
+				angle 0
+				under
+			engine 5 35
+				zoom 1
+				angle 0
+				under
+			gun -7 -10 "Beam Laser"
+				under
+			gun 7 -10 "Beam Laser"
+				under
+			leak flame 60 80
+			explode "small explosion" 5
+			explode "tiny explosion" 15
+			system "Yed Prior"
+			planet Winter
+		ship Shuttle
+			name "Arkhangelsk"
+			sprite ship/shuttle
+				"frame rate" 15
+				delay 14
+			thumbnail thumbnail/shuttle
+			uuid aa995c01-8b9f-43ca-8a46-a5fb77797af8
+			attributes
+				category Transport
+				cost 180000
+				mass 70
+				bunks 6
+				"cargo space" 20
+				drag 1.7
+				"engine capacity" 60
+				"fuel capacity" 400
+				"gun ports" 1
+				"heat dissipation" 0.8
+				hull 600
+				"outfit space" 120
+				"required crew" 1
+				shields 500
+				"weapon capacity" 10
+			outfits
+				"D14-RN Shield Generator"
+				Hyperdrive
+				"LP036a Battery Pack"
+				"X2200 Ion Steering"
+				"X2700 Ion Thruster"
+				"nGVF-AA Fuel Cell"
+			crew 1
+			fuel 400
+			shields 500
+			hull 600
+			engine -6 30
+				zoom 1
+				angle 0
+				under
+			engine 6 30
+				zoom 1
+				angle 0
+				under
+			gun 0 -31
+				under
+			leak leak 60 50
+			explode "small explosion" 5
+			explode "tiny explosion" 10
+			system "Yed Prior"
+			planet Winter
+		account
+			credits 0
+			score 400
+			history
+		cargo
+			outfits
+				"D23-QP Shield Generator" 1
+		visited "Yed Prior"
+		"visited planet" Winter
+
+
+test "Store Outfit On Take Off"
+	status active
+	description "Test the automatic storing of a an outfit in cargo that cannot fit in any ships after taking off."
+	sequence
+		# Create/inject the savegame and load it.
+		inject "A Sparrow and a Shuttle and a Shield Generator on Prime"
+		call "Load First Savegame"
+		# Check startup conditions.
+		assert
+			and
+				"credits" == 0
+				"outfit: D23-QP Shield Generator" == 1
+				"outfit (cargo): D23-QP Shield Generator" == 1
+				"outfit (storage): D23-QP Shield Generator" == 0
+		call "Depart"
+		# Re-check startup conditions.
+		assert
+			and
+				"credits" == 0
+				"outfit: D23-QP Shield Generator" == 0
+				"outfit (cargo): D23-QP Shield Generator" == 0
+				"outfit (storage): D23-QP Shield Generator" == 1
+		watchdog 90000
+		input
+			command land
+		label landing
+		branch landing
+			"flagship planet: Prime" < 1
+		assert
+			and
+				"flagship planet: Prime" > 0
+				"credits" == 0
+				"outfit: D23-QP Shield Generator" == 1
+				"outfit (cargo): D23-QP Shield Generator" == 0
+				"outfit (storage): D23-QP Shield Generator" == 1
+
+
+test "Sell Outfit On Take Off"
+	status active
+	description "Test the automatic selling of an outfit in cargo that cannot fit in any ships after taking off from a planet with no outfitter""
+	sequence
+		# Create/inject the savegame and load it.
+		inject "A Sparrow and a Shuttle and a Shield Generator on Winter"
+		call "Load First Savegame"
+		# Check startup conditions.
+		assert
+			and
+				"credits" == 0
+				"outfit: D23-QP Shield Generator" == 1
+				"outfit (cargo): D23-QP Shield Generator" == 1
+				"outfit (storage): D23-QP Shield Generator" == 0
+		call "Depart"
+		# Re-check startup conditions.
+		assert
+			and
+				"credits" > 0
+				"outfit: D23-QP Shield Generator" == 0
+				"outfit (cargo): D23-QP Shield Generator" == 0
+				"outfit (storage): D23-QP Shield Generator" == 0
+		watchdog 90000
+		input
+			command land
+		label landing
+		branch landing
+			"flagship planet: Winter" < 1
+		assert
+			and
+				"flagship planet: Winter" > 0
+				"credits" > 0
+				"outfit: D23-QP Shield Generator" == 0
+				"outfit (cargo): D23-QP Shield Generator" == 0
+				"outfit (storage): D23-QP Shield Generator" == 0

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
@@ -262,7 +262,7 @@ test "Store Outfit On Take Off"
 		# Re-check startup conditions.
 		assert
 			and
-				"credits" == 0
+				"credits" > 0
 				"outfit: D23-QP Shield Generator" == 0
 				"outfit (cargo): D23-QP Shield Generator" == 0
 				"outfit (storage): D23-QP Shield Generator" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
@@ -262,7 +262,7 @@ test "Store Outfit On Take Off"
 		# Re-check startup conditions.
 		assert
 			and
-				"credits" > 0
+				"credits" == 0
 				"outfit: D23-QP Shield Generator" == 0
 				"outfit (cargo): D23-QP Shield Generator" == 0
 				"outfit (storage): D23-QP Shield Generator" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
@@ -111,7 +111,7 @@ test-data "A Sparrow and a Shuttle and a Shield Generator on Prime"
 			system Betelgeuse
 			planet Prime
 		account
-			credits 0
+			credits 100
 			score 400
 			history
 		cargo
@@ -254,7 +254,7 @@ test "Store Outfit On Take Off"
 		# Check startup conditions.
 		assert
 			and
-				"credits" == 0
+				"credits" == 100
 				"outfit: D23-QP Shield Generator" == 1
 				"outfit (cargo): D23-QP Shield Generator" == 1
 				"outfit (storage): D23-QP Shield Generator" == 0

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
@@ -283,7 +283,7 @@ test "Store Outfit On Take Off"
 
 test "Sell Outfit On Take Off"
 	status active
-	description "Test the automatic selling of an outfit in cargo that cannot fit in any ships after taking off from a planet with no outfitter""
+	description "Test the automatic selling of an outfit in cargo that cannot fit in any ships after taking off from a planet with no outfitter."
 	sequence
 		# Create/inject the savegame and load it.
 		inject "A Sparrow and a Shuttle and a Shield Generator on Winter"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
@@ -276,7 +276,6 @@ test "Store Outfit On Take Off"
 			and
 				"flagship planet: Prime" > 0
 				"credits" == 0
-				"outfit: D23-QP Shield Generator" == 1
 				"outfit (cargo): D23-QP Shield Generator" == 0
 				"outfit (storage): D23-QP Shield Generator" == 1
 


### PR DESCRIPTION
**Feature:**

## Feature Details
Instead of always selling excess outfits that cannot fit in ships on take off, move them to the local storage, if hte planet has an outfitter.

## Testing Done
Have an outfit in cargo that can't actually fit in any of your ships and take off.
It would previously be sold, and should still be if you are at a planet without an outfitter. (It may not actually be possible to get into this situation without save editing.)
If you are at a planet with an outfitter, it should be moved to the storage on that planet.

### Automated Tests Added
Adds two new tests:
One checks that an outfit that cannot be carried is correctly moved to storage on taking off from a planet with an outfitter.
The other checks that an outfit that cannot be carried is still correctly sold when taking off from a planet with no outfitter.

## Performance Impact
N/A
