### PR TITLE
Fix scanning

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -223,9 +223,9 @@ outfit "Scanning Module"
 	"mass" 3
 	"outfit space" -3
 	"outfit scan power" 25
-	"outfit scan speed" 1
+	"outfit scan speed" 18
 	"cargo scan power" 25
-	"cargo scan speed" 1
+	"cargo scan speed" 18
 	"tactical scan power" 25
 	description "This system allows the Heliarchs to scan nearby ships, enabling them to detect weapons or illegal goods."
 

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -447,9 +447,9 @@ outfit "Value Detector"
 	thumbnail "outfit/value detector"
 	"mass" 3
 	"outfit space" -3
-	"cargo scan power" 22
-	"cargo scan speed" 4
-	"tactical scan power" 27
+	"cargo scan power" 88
+	"cargo scan speed" 16
+	"tactical scan power" 92
 	description "The Unfettered developed this scanner in order to determine which ships are worth plundering, or which lack the capacity to stand up to their ion weapons. Some Hai consider it rather rudimentary, but it is sufficient to identify the cargo on a ship from afar and provide more detailed information about the tactical condition of enemy vessels. This dual function is useful when fielding experimental weaponry."
 
 outfit "Hai Chasm Batteries"

--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -214,7 +214,7 @@ outfit "Cargo Scanner"
 	"mass" 1
 	"outfit space" -1
 	"cargo scan power" 9
-	"cargo scan speed" 1
+	"cargo scan speed" 5
 	description "This scanner allows you to scan the cargo holds of the ship you are currently targeting, as long as you are flying close enough to it. Patrol craft use cargo scanners to detect illegal contraband. Installing more than one increases the scan range and speed."
 
 outfit "Outfit Scanner"
@@ -224,7 +224,7 @@ outfit "Outfit Scanner"
 	"mass" 2
 	"outfit space" -2
 	"outfit scan power" 25
-	"outfit scan speed" 1
+	"outfit scan speed" 15
 	description "This scanner allows you to determine what outfits are installed in the ship you are currently targeting, if you are willing to risk flying close enough to it to get a reading! The Republic Navy uses these scanners to detect when ships are equipped with illegal weaponry. Installing more than one increases the scan range and speed."
 
 outfit "Asteroid Scanner"

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -625,7 +625,7 @@ outfit "Research Laboratory"
 	"outfit space" -6
 	"asteroid scan power" 84
 	"cargo scan power" 20
-	"cargo scan speed" 1
+	"cargo scan speed" 6
 	"atmosphere scan" 100
 	"required crew" 1
 	"unplunderable" 1
@@ -652,7 +652,7 @@ outfit "Salvage Scanner"
 	"mass" 7
 	"outfit space" -7
 	"outfit scan power" 13
-	"outfit scan speed" 1
+	"outfit scan speed" 12
 	"tactical scan power" 84
 	description "When the Remnant unraveled the alien point defense turrets guarding the vaults on Aventine, they also deciphered the mechanisms that guided the ancient weapons. After significant investments in research and development, they have transformed those guidance systems into sophisticated scanning technology."
 	description "	 While all Remnant ships are equipped with internal scanners, some captains still prefer to boost their range and power to more effectively select enemy ships worth targeting."

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -40,7 +40,7 @@ ship "Albatross"
 		"hull repair rate" 1.5
 		"hull energy" 1.2
 		"outfit scan power" 18
-		"outfit scan speed" 1
+		"outfit scan speed" 24
 		"tactical scan power" 39
 		weapon
 			"blast radius" 360
@@ -291,7 +291,7 @@ ship "Modified Dromedary"
 		"weapon capacity" 270
 		"engine capacity" 195
 		"outfit scan power" 18
-		"outfit scan speed" 1
+		"outfit scan speed" 48
 		"tactical scan power" 39
 		"asteroid scan power" 42
 		"atmosphere scan" 100
@@ -497,7 +497,7 @@ ship "Gull"
 		"cloaking energy" 5
 		"cloaking fuel" .1
 		"outfit scan power" 12
-		"outfit scan speed" 1
+		"outfit scan speed" 20
 		"tactical scan power" 26
 		weapon
 			"blast radius" 80
@@ -659,7 +659,7 @@ ship "Heron"
 		"gaslining" 1
 		"atmosphere scan" 100
 		"outfit scan power" 175
-		"outfit scan speed" 1
+		"outfit scan speed" 120
 		"tactical scan power" 350
 		"force protection" 1
 		"heat protection" 1.5
@@ -784,7 +784,7 @@ ship "Ibis"
 		"hull repair rate" 1.2
 		"hull energy" 0.95
 		"outfit scan power" 18
-		"outfit scan speed" 1
+		"outfit scan speed" 20
 		"tactical scan power" 39
 		weapon
 			"blast radius" 240
@@ -865,7 +865,7 @@ ship "Merganser"
 		"cloaking fuel" .05
 		"atmosphere scan" 100
 		"outfit scan power" 12
-		"outfit scan speed" 1
+		"outfit scan speed" 12
 		"tactical scan power" 26
 		"ion resistance" 0.1
 		"ion resistance energy" -0.05
@@ -963,7 +963,7 @@ ship "Pelican"
 		"hull repair rate" 1
 		"hull energy" 0.75
 		"outfit scan power" 12
-		"outfit scan speed" 1
+		"outfit scan speed" 12
 		"tactical scan power" 26
 		weapon
 			"blast radius" 160
@@ -1049,7 +1049,7 @@ ship "Penguin"
 		"cloaking energy" 3
 		"cloaking fuel" .05
 		"outfit scan power" 50
-		"outfit scan speed" 1
+		"outfit scan speed" 36
 		"tactical scan power" 50
 		"atmosphere scan" 100
 		"ion protection" 0.25
@@ -1152,7 +1152,7 @@ ship "Peregrine"
 		"cloaking fuel" .05
 		"gaslining" 1
 		"outfit scan power" 18
-		"outfit scan speed" 1
+		"outfit scan speed" 22
 		"tactical scan power" 50
 		"ion protection" 0.25
 		"slowing protection" 0.25
@@ -1264,7 +1264,7 @@ ship "Petrel"
 		"hull energy" 0.54
 		"gaslining" 1
 		"outfit scan power" 10
-		"outfit scan speed" 1
+		"outfit scan speed" 14
 		"tactical scan power" 20
 		"asteroid scan power" 30
 		weapon
@@ -1326,7 +1326,7 @@ ship "Puffin"
 		"active cooling" 8
 		"cooling energy" .4
 		"outfit scan power" 24
-		"outfit scan speed" 1
+		"outfit scan speed" 28
 		"tactical scan power" 52
 		"atmosphere scan" 100
 		"ion protection" 0.25
@@ -1375,7 +1375,7 @@ ship "Smew"
 		"hull repair rate" 0.9
 		"hull energy" 0.58
 		"outfit scan power" 14
-		"outfit scan speed" 1
+		"outfit scan speed" 20
 		"tactical scan power" 28
 		"asteroid scan power" 50
 		weapon
@@ -1460,7 +1460,7 @@ ship "Starling"
 		"cloaking energy" 5
 		"cloaking fuel" .1
 		"outfit scan power" 12
-		"outfit scan speed" 1
+		"outfit scan speed" 20
 		"tactical scan power" 26
 		weapon
 			"blast radius" 80
@@ -1617,7 +1617,7 @@ ship "Tern"
 		"hull energy" 0.37
 		"gaslining" 1
 		"outfit scan power" 10
-		"outfit scan speed" 1
+		"outfit scan speed" 12
 		"tactical scan power" 20
 		"atmosphere scan" 100
 		"asteroid scan power" 30


### PR DESCRIPTION

**Bugfix:** Some of you may have noticed that, _whoops_, scanning is impossible now. Okay, not impossible, but unbearably slow. This is my fault, I did not practice due diligence with my PR, and the slowing factors to scanning (distance to target, and size of target) are not at all counterbalanced by a corresponding increase to scanning speed.

## Fix Details
Bumps "scan speed" (outfit and cargo both) very highly upwards to bring scan times down to reasonable levels. Scanning is still slower than it was pre-change, as that was the original vision of the PR, but the speeds displayed in continuous are _not_ intended.

## Testing Done
Flying around in my classy Hurricane with one, or multiple, or many scanners installed, scanning every ship that passes by. With a single outfit and cargo scanner each, scanning is unpleasantly slow on anything except small ships (intended), and with a decent dedication to scanners, even large ships can be scanned in a reasonable amount of time. (So long as you remember that the closer you are, the faster the scan will proceed!)

In the near future, I would like to increase the amount of scanners that ships which do scanning have. No gunboat should really have _just_ one scanner, that is not enough to reasonably scan ships that may be trying to evade a scan. But that's for another day, and gunboats _are_ capable of finishing scans with these changes, though it does take a couple of seconds, you have to sort of "submit" to the scan for them to be able to finish their scans.

## Save File
N/A, any save file where you have access to human scanners should be enough to confirm the changes make scanning much more bearable.
