### PR TITLE
Test fix(integration): check for name working in conversation and initialize variables to 0

### DIFF
--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -110,18 +110,18 @@ private:
 	// The conversation we are displaying.
 	const Conversation &conversation;
 	// All conversations start with node 0.
-	int node;
+	int node = 0;
 	// This function should be called with the conversation outcome.
 	std::function<void(int)> callback = nullptr;
 
 	// Current scroll position.
-	double scroll;
+	double scroll = 0.;
 
 	// The "history" of the conversation up to this point:
 	std::list<Paragraph> text;
 	// The current choices being presented to you, and their indices:
 	std::list<std::pair<Paragraph, int>> choices;
-	int choice;
+	int choice = 0;
 
 	// Text entry fields for changing the player's name.
 	std::string firstName;

--- a/source/Test.h
+++ b/source/Test.h
@@ -103,7 +103,7 @@ public:
 		// Input variables.
 		Command command;
 		std::set<std::string> inputKeys;
-		Uint16 modKeys;
+		Uint16 modKeys = 0;
 
 		// Mouse/Pointer input variables.
 		int XValue = 0;

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
@@ -177,6 +177,7 @@ test "Enter Name in Conversation"
 		input
 			key "Return"
 		call "Depart"
+		call "Land On Ruin helper"
 		# use a test-data temporary variable for debugging in case of errors
 		apply
 			"test: %TEST%: NAME IN CONVERSATION: offered" = "%TEST%: NAME IN CONVERSATION: offered"
@@ -184,4 +185,4 @@ test "Enter Name in Conversation"
 			"test: name: f l" = "name: f l"
 		assert
 			"%TEST%: NAME IN CONVERSATION: offered" == 1
-			"name: f l" == 1
+			"name: F L" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
@@ -167,11 +167,11 @@ test "Enter Name in Conversation"
 			"%TEST%: NAME IN CONVERSATION" = 1
 		call "Trigger Spaceport Mission"
 		input
-			key "f"
+			key "shift" "f"
 		input
 			key "Return"
 		input
-			key "l"
+			key "shift" "l"
 		input
 			key "Return"
 		input
@@ -180,9 +180,8 @@ test "Enter Name in Conversation"
 		# use a test-data temporary variable for debugging in case of errors
 		apply
 			"test: %TEST%: NAME IN CONVERSATION: offered" = "%TEST%: NAME IN CONVERSATION: offered"
-			"test: first name: f" = "first name: f"
-			"test: last name: l" = "last name: l"
+			"test: name: F L" = "name: F L"
+			"test: name: f l" = "name: f l"
 		assert
 			"%TEST%: NAME IN CONVERSATION: offered" == 1
-			"first name: f" == 1
-			"last name: l" == 1
+			"name: f l" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
@@ -180,9 +180,9 @@ test "Enter Name in Conversation"
 		# use a test-data temporary variable for debugging in case of errors
 		apply
 			"test: %TEST%: NAME IN CONVERSATION: offered" = "%TEST%: NAME IN CONVERSATION: offered"
-			"test: <first>" = "<first>"
-			"test: <last>" = "<last>"
+			"test: first name: F" = "first name: F"
+			"test: last name: L" = "last name: L"
 		assert
 			"%TEST%: NAME IN CONVERSATION: offered" == 1
-			"<first>" == "F"
-			"<last>" == "L"
+			"first name: F" == 1
+			"last name: L" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
@@ -167,11 +167,11 @@ test "Enter Name in Conversation"
 			"%TEST%: NAME IN CONVERSATION" = 1
 		call "Trigger Spaceport Mission"
 		input
-			key F
+			key "f"
 		input
 			key "Return"
 		input
-			key L
+			key "l"
 		input
 			key "Return"
 		input
@@ -180,9 +180,9 @@ test "Enter Name in Conversation"
 		# use a test-data temporary variable for debugging in case of errors
 		apply
 			"test: %TEST%: NAME IN CONVERSATION: offered" = "%TEST%: NAME IN CONVERSATION: offered"
-			"test: first name: F" = "first name: F"
-			"test: last name: L" = "last name: L"
+			"test: first name: f" = "first name: f"
+			"test: last name: l" = "last name: l"
 		assert
 			"%TEST%: NAME IN CONVERSATION: offered" == 1
-			"first name: F" == 1
-			"last name: L" == 1
+			"first name: f" == 1
+			"last name: l" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
@@ -167,11 +167,11 @@ test "Enter Name in Conversation"
 			"%TEST%: NAME IN CONVERSATION" = 1
 		call "Trigger Spaceport Mission"
 		input
-			key "shift" "f"
+			key "f"
 		input
 			key "Return"
 		input
-			key "shift" "l"
+			key "l"
 		input
 			key "Return"
 		input
@@ -185,4 +185,4 @@ test "Enter Name in Conversation"
 			"test: name: f l" = "name: f l"
 		assert
 			"%TEST%: NAME IN CONVERSATION: offered" == 1
-			"name: F L" == 1
+			"name: f l" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
@@ -172,6 +172,8 @@ test "Enter Name in Conversation"
 	sequence
 		inject "conditional choice"
 		call "Load First Savegame"
+		assert
+			"name: Bobbi Bughunter" == 1
 		apply
 			"%TEST%: NAME IN CONVERSATION" = 1
 		call "Trigger Spaceport Mission"
@@ -186,7 +188,7 @@ test "Enter Name in Conversation"
 		input
 			key "Return"
 		call "Depart"
-		# use a test-data temporary variable for debugging in case of errors
+		# use test-data temporary variables for debugging in case of errors
 		apply
 			"test: %TEST%: NAME IN CONVERSATION: offered" = "%TEST%: NAME IN CONVERSATION: offered"
 			"test: name: Bobbi Bughunter" = "name: Bobbi Bughunter"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
@@ -112,6 +112,7 @@ mission "%TEST%: NAME IN CONVERSATION"
 		conversation
 			name
 			`	So you are <first> <last>.`
+				accept
 
 
 test "Trigger Spaceport Mission"
@@ -122,6 +123,12 @@ test "Trigger Spaceport Mission"
 		call "Land On Ruin helper"
 		input
 			key p
+
+
+test "Skip Spaceport Mission"
+	status partial
+	description "Just skip a mission by pressing return twice."
+	sequence
 		# press accept (or decline, depending on if it is shown) and then skip the dialog once
 		input
 			key "Return"
@@ -138,6 +145,7 @@ test "Conditional Test"
 		apply
 			"%TEST%: CONDITIONAL CHOICE" = 1
 		call "Trigger Spaceport Mission"
+		call "Skip Spaceport Mission"
 		call "Depart"
 		assert
 			"succeed test" == 1
@@ -152,6 +160,7 @@ test "Conditional Test Goto"
 		apply
 			"%TEST%: CONDITIONAL CHOICE GOTO" = 1
 		call "Trigger Spaceport Mission"
+		call "Skip Spaceport Mission"
 		call "Depart"
 		assert
 			"succeed test" == 1
@@ -167,22 +176,28 @@ test "Enter Name in Conversation"
 			"%TEST%: NAME IN CONVERSATION" = 1
 		call "Trigger Spaceport Mission"
 		input
-			key "f"
+			key a
 		input
 			key "Return"
 		input
-			key "l"
+			key b
 		input
 			key "Return"
 		input
 			key "Return"
 		call "Depart"
-		call "Land On Ruin helper"
 		# use a test-data temporary variable for debugging in case of errors
 		apply
 			"test: %TEST%: NAME IN CONVERSATION: offered" = "%TEST%: NAME IN CONVERSATION: offered"
-			"test: name: F L" = "name: F L"
-			"test: name: f l" = "name: f l"
+			"test: name: Bobbi Bughunter" = "name: Bobbi Bughunter"
+			"test: name: a b" = "name: a b"
+			"test: name: a B" = "name: a B"
+			"test: name: A b" = "name: A b"
+			"test: name: A B" = "name: A B"
+			"test: name: b a" = "name: b a"
+			"test: name: B a" = "name: B a"
+			"test: name: b A" = "name: b A"
+			"test: name: B A" = "name: B A"
 		assert
 			"%TEST%: NAME IN CONVERSATION: offered" == 1
-			"name: f l" == 1
+			"name: a b" == 1


### PR DESCRIPTION
As it was pointed out by @petervdmeer https://github.com/endless-sky/endless-sky/pull/5440#discussion_r1027086484 the integration test was not checking for the name being set to F L correctly.
That was not the main goal of the test, it was mainly to make sure "name" didnt cause a crash or wasnt shown as it happened at one point.

But may as well test this correctly.

Edit: in order to fix this I had to set some variables that were uninitialized and thus just took the value of whatever was left in memory, meaning it would trigger shift, tab and whatnot.