### PR TITLE
fix(integration tests): Fix slow GLES integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,21 +330,15 @@ jobs:
           - os: ubuntu-20.04
             opengl: desktop
             glew: libglew2.1
-            driver: x11
           - os: ubuntu-22.04
             opengl: desktop
             glew: libglew2.2
-            driver: x11
           - os: ubuntu-20.04
             opengl: gles
             glew: libgles2-mesa
-            driver: wayland
           - os: ubuntu-22.04
             opengl: gles
             glew: libgles2-mesa
-            driver: wayland
-    env:
-      SDL_VIDEODRIVER: ${{ matrix.driver }}
     steps:
     - uses: actions/checkout@v2
     - name: Install runtime dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,15 +330,21 @@ jobs:
           - os: ubuntu-20.04
             opengl: desktop
             glew: libglew2.1
+            driver: x11
           - os: ubuntu-22.04
             opengl: desktop
             glew: libglew2.2
+            driver: x11
           - os: ubuntu-20.04
             opengl: gles
             glew: libgles2-mesa
+            driver: wayland
           - os: ubuntu-22.04
             opengl: gles
             glew: libgles2-mesa
+            driver: wayland
+    env:
+      SDL_VIDEODRIVER: ${{ matrix.driver }}
     steps:
     - uses: actions/checkout@v2
     - name: Install runtime dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,9 +336,11 @@ jobs:
           - os: ubuntu-20.04
             opengl: gles
             glew: libgles2-mesa
-          - os: ubuntu-22.04
-            opengl: gles
-            glew: libgles2-mesa
+          # Ubuntu 22 has a pretty severe performance regression using OpenGL ES.
+          # Disable it for now.
+          # - os: ubuntu-22.04
+          #   opengl: gles
+          #   glew: libgles2-mesa
     steps:
     - uses: actions/checkout@v2
     - name: Install runtime dependencies
@@ -347,7 +349,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libpng16-16 libjpeg-turbo8 libopenal1 libmad0 ${{ matrix.glew }} libgl1 uuid-runtime
     - name: Install xvfb runtime dependencies
-      run: sudo apt-get install -y --no-install-recommends libosmesa6 mesa-utils libegl1-mesa # TODO: ALSA mocking?
+      run: sudo apt-get install -y --no-install-recommends libosmesa6 mesa-utils # TODO: ALSA mocking?
     - name: Download artifact
       uses: actions/download-artifact@v1.0.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libpng16-16 libjpeg-turbo8 libopenal1 libmad0 ${{ matrix.glew }} libgl1 uuid-runtime
     - name: Install xvfb runtime dependencies
-      run: sudo apt-get install -y --no-install-recommends libosmesa6 mesa-utils # TODO: ALSA mocking?
+      run: sudo apt-get install -y --no-install-recommends libosmesa6 mesa-utils libegl1-mesa # TODO: ALSA mocking?
     - name: Download artifact
       uses: actions/download-artifact@v1.0.0
       with:

--- a/tests/integration/run_tests_headless.sh
+++ b/tests/integration/run_tests_headless.sh
@@ -24,7 +24,4 @@ if ! command -v xvfb-run > /dev/null 2>&1; then
   exit 127
 fi
 
-# Force OpenGL software mode
-export LIBGL_ALWAYS_SOFTWARE=1
-
 exec xvfb-run --auto-servernum --server-args="+extension GLX +render -noreset" ./run_tests.sh "${EXECUTABLE}" "${RESOURCES}"


### PR DESCRIPTION
## Fix Details

This PR does two things:

- Don't force software rendering when running the integration tests. If there is no hardware accelerated driver available, Mesa will fallback to a software driver anyways.
- Disables the Ubuntu 22.04 GLES integration test, since there is a performance regression there.

## Testing Done

It fixes the slow OpenGL ES integration tests on my machine. Hopefully, it will also speed it up in CI.