### PR TITLE
Fix and clean up closestDeparturePoint calculation

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1992,12 +1992,7 @@ void AI::PrepareForHyperspace(Ship &ship, Command &command)
 	double squaredDeparture = departure * departure + SAFETY_OFFSET;
 	if(ship.Position().LengthSquared() < squaredDeparture)
 	{
-		Point closestDeparturePoint;
-		if(ship.Position())
-			closestDeparturePoint = ship.Position()
-				* (squaredDeparture / ship.Position().LengthSquared());
-		else
-			closestDeparturePoint = Point(1., squaredDeparture);
+		Point closestDeparturePoint = ship.Position().Unit() * (departure + SAFETY_OFFSET);
 		MoveTo(ship, command, closestDeparturePoint, Point(), 0., 0.);
 	}
 	else if(!isJump && scramThreshold)


### PR DESCRIPTION
**Bugfix:** This PR fixes a small issue introduced by #7524

## Fix Details
#7524 scales the current position by a squared factor causing the target point to have a distance from the center potentially far larger than the desired distance.

Also, `Point::Unit()` has a more robust way of detecting potential divisions by zero since the square of a floating point number can be zero without the number itself being zero. Since `Unit()` conveniently also handles this corner case appropriately, we can just call that to clean up this code.

## Testing Done
The code only affects very specific circumstances. I tested it by setting 'departure 10000' on a system and verifying the calculated `MoveTo` gave correct values using printf.
