### PR TITLE
Print an error when a `key` string parses to SDLK_UNKNOWN for integration tests

### DIFF
--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -85,6 +85,8 @@ namespace {
 		event.key.state = SDL_PRESSED;
 		event.key.repeat = 0;
 		event.key.keysym.sym = SDL_GetKeyFromName(keyName);
+		if(event.key.keysym.sym == SDLK_UNKNOWN)
+			return false;
 		event.key.keysym.mod = modKeys;
 		return SDL_PushEvent(&event);
 	}
@@ -488,7 +490,7 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 					// TODO: combine keys with mouse-inputs
 					for(const string &key : stepToRun.inputKeys)
 						if(!KeyInputToEvent(key.c_str(), stepToRun.modKeys))
-							Fail(context, player, "key input towards SDL eventqueue failed");
+							Fail(context, player, "key \"" + key + + "\"input towards SDL eventqueue failed");
 				}
 				// TODO: handle mouse inputs
 				// Make sure that we run a gameloop to process the input.

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -490,7 +490,7 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 					// TODO: combine keys with mouse-inputs
 					for(const string &key : stepToRun.inputKeys)
 						if(!KeyInputToEvent(key.c_str(), stepToRun.modKeys))
-							Fail(context, player, "key \"" + key + + "\"input towards SDL eventqueue failed");
+							Fail(context, player, "key \"" + key + + "\" input towards SDL eventqueue failed");
 				}
 				// TODO: handle mouse inputs
 				// Make sure that we run a gameloop to process the input.

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_common.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_common.txt
@@ -556,7 +556,7 @@ test "Save To Default Snapshot"
 			key a
 		# Confirm usage of the default snapshot name.
 		input
-			key "enter"
+			key "Return"
 		# Exit the menu that we are in (and return to the game)
 		input
 			key b


### PR DESCRIPTION
**Bugfix:**

## Fix Details
If a string is not parsed to a proper SDL key code, it will return SDLK_UNKNOWN, but this was not previously checked so the game was running the test with that, which is obviously not correct. This makes it easier to tell when your test has a syntax error.

Also, change `key "enter"` to `key "Return"` in the "Save To Default Snapshot" integration test so it actually does what it's supposed to. `enter` is not a valid SDL human readable key string.