### PR TITLE
Don't load a non-existent plugin icon

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -849,8 +849,11 @@ void GameData::LoadSources()
 		else if(Files::Exists(*it + "icon@2x.jpg"))
 			icon->Add(*it + "icon@2x.jpg");
 
-		icon->ValidateFrames();
-		spriteQueue.Add(icon);
+		if(!icon->IsEmpty())
+		{
+			icon->ValidateFrames();
+			spriteQueue.Add(icon);
+		}
 	}
 }
 

--- a/source/ImageSet.cpp
+++ b/source/ImageSet.cpp
@@ -185,6 +185,14 @@ const string &ImageSet::Name() const
 
 
 
+// Whether this image set is empty, i.e. has no images.
+bool ImageSet::IsEmpty() const
+{
+	return framePaths[0].empty() || framePaths[1].empty();
+}
+
+
+
 // Add a single image to this set. Assume the name of the image has already
 // been checked to make sure it belongs in this set.
 void ImageSet::Add(string path)

--- a/source/ImageSet.h
+++ b/source/ImageSet.h
@@ -50,6 +50,8 @@ public:
 
 	// Get the name of the sprite for this image set.
 	const std::string &Name() const;
+	// Whether this image set is empty, i.e. has no images.
+	bool IsEmpty() const;
 	// Add a single image to this set. Assume the name of the image has already
 	// been checked to make sure it belongs in this set.
 	void Add(std::string path);


### PR DESCRIPTION
## Feature Details

Makes it so that plugins without a icon don't generate the following warning:

```
Warning: image "<plugin>" is referred to, but has no pixels.
```

## Testing Done

The warning disappears with this PR.
