### PR TITLE
Filter warning messages from integration tests

### DIFF
--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -72,7 +72,7 @@ function run_single_testrun () {
   #   - A warning that no audio was loaded
   if ! "$ES_EXEC_PATH" --resources "${RESOURCES}" --test "${TEST_NAME}" --config "${ES_CONFIG_PATH}" 2>&1 |\
     sed -e "/^ALSA lib.*$/d" -e "/^AL lib.*$/d" -e "/^(SDL message.*$/d" -e "/^Unable to change VSync.*/d" \
-	    -e "/^Warning: audio could not.*$/d" | sed "s/^/#     /"
+	  -e "/^Warning: audio could not.*$/d" | sed "s/^/#     /"
   then
     echo "# Test \"${TEST_NAME}\" failed!"
     echo "#   temporary directory: ${ES_CONFIG_PATH}"

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -72,7 +72,7 @@ function run_single_testrun () {
   #   - A warning that no audio was loaded
   if ! "$ES_EXEC_PATH" --resources "${RESOURCES}" --test "${TEST_NAME}" --config "${ES_CONFIG_PATH}" 2>&1 |\
     sed -e "/^ALSA lib.*$/d" -e "/^AL lib.*$/d" -e "/^(SDL message.*$/d" -e "/^Unable to change VSync.*/d" \
-	  -e "/^Warning: audio could not.*$/d" | sed "s/^/#     /"
+      -e "/^Warning: audio could not.*$/d" | sed "s/^/#     /"
   then
     echo "# Test \"${TEST_NAME}\" failed!"
     echo "#   temporary directory: ${ES_CONFIG_PATH}"

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -69,8 +69,10 @@ function run_single_testrun () {
   #   - ALSA messages that appear due to missing soundcards in the CI environment
   #   - SDL messages that appear due to limitations of the software renderer
   #   - A VSync message that appears due to no support for native vsync in the software renderer
+  #   - A warning that no audio was loaded
   if ! "$ES_EXEC_PATH" --resources "${RESOURCES}" --test "${TEST_NAME}" --config "${ES_CONFIG_PATH}" 2>&1 |\
-    sed -e "/^ALSA lib.*$/d" -e "/^AL lib.*$/d" -e "/^(SDL message.*$/d" -e "/^Unable to change VSync.*/d" | sed "s/^/#     /"
+    sed -e "/^ALSA lib.*$/d" -e "/^AL lib.*$/d" -e "/^(SDL message.*$/d" -e "/^Unable to change VSync.*/d" \
+	    -e "/^Warning: audio could not.*$/d" | sed "s/^/#     /"
   then
     echo "# Test \"${TEST_NAME}\" failed!"
     echo "#   temporary directory: ${ES_CONFIG_PATH}"

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -65,9 +65,12 @@ function run_single_testrun () {
   local TEST_NAME=$(echo ${TEST} | sed "s/\"//g")
   local RETURN=0
   echo "# Running test \"${TEST_NAME}\":"
-  # Use sed to remove ALSA messages that appear due to missing soundcards in the CI environment
+  # Use sed to remove:
+  #   - ALSA messages that appear due to missing soundcards in the CI environment
+  #   - SDL messages that appear due to limitations of the software renderer
+  #   - A VSync message that appears due to no support for native vsync in the software renderer
   if ! "$ES_EXEC_PATH" --resources "${RESOURCES}" --test "${TEST_NAME}" --config "${ES_CONFIG_PATH}" 2>&1 |\
-    sed -e "/^ALSA lib.*$/d" -e "/^AL lib.*$/d" | sed "s/^/#     /"
+    sed -e "/^ALSA lib.*$/d" -e "/^AL lib.*$/d" -e "/^(SDL message.*$/d" -e "/^Unable to change VSync.*/d" | sed "s/^/#     /"
   then
     echo "# Test \"${TEST_NAME}\" failed!"
     echo "#   temporary directory: ${ES_CONFIG_PATH}"


### PR DESCRIPTION
## Feature Details

Filters VSync related messages from the output of the integration tests. The software renderer used doesn't even support setting the VSync to 0 (i.e. disable), so we have to filter them out.

Also filters out a warning that says that no audio will play: Yes we know, it's CI.

## Testing Done

Ran the integration tests locally, the error messages get correctly filtered out.
