### PR TITLE
Always calculate attraction/deterrence

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -777,12 +777,9 @@ void Ship::FinishLoading(bool isNewInstance)
 		attributes.Set("drag", 100.);
 	}
 
-	// Only the player's ships make use of attraction and deterrence.
-	if(isYours)
-	{
-		attraction = CalculateAttraction();
-		deterrence = CalculateDeterrence();
-	}
+	// Calculate the values used to determine this ship's value and danger.
+	attraction = CalculateAttraction();
+	deterrence = CalculateDeterrence();
 
 	if(!warning.empty())
 	{


### PR DESCRIPTION
## Fix Details

The player's piracy threat was updated when the player bought ships. This is because the ship that was bought didn't have a deterrence/attraction value calculated for it. This PR fixes this by always calculating the deterrence and attraction value for ships. In the future a ship's strength will involve those values, so in the future this change won't be unnecessary.

## Testing Done

Bought 100 ships on a starter pilot. Without this PR the ship's piracy threat doesn't change unless reloaded.

## Save File

[op guy.txt](https://github.com/endless-sky/endless-sky/files/10050360/op.guy.txt)


