### PR TITLE
Outfit Info Display Displays Seconds with an 's'

### DIFF
--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -35,7 +35,7 @@ namespace {
 		make_pair(60. * 100., ""),
 		make_pair(100., "%"),
 		make_pair(100., ""),
-		make_pair(1. / 60., "")
+		make_pair(1. / 60., "s")
 	};
 
 	const map<string, int> SCALE = {


### PR DESCRIPTION
## Feature Details
before:   <img width="122" alt="image" src="https://user-images.githubusercontent.com/101683475/202923100-b9231bdf-352d-4a5e-9e95-b605c78ac901.png">
after:  <img width="119" alt="image" src="https://user-images.githubusercontent.com/101683475/202923600-00993cf2-403f-4543-a83a-4319b9bae0c5.png">


## Performance Impact
N/A
