### PR TITLE
A way to get every planet and system matching a provided LocationFilter

### DIFF
--- a/endless-sky.6
+++ b/endless-sky.6
@@ -99,6 +99,9 @@ prints (to STDOUT) a list of all system attributes and which systems have them.
 .RE
 .RE
 
+.IP \fB\-\-matches
+reads a data file from STDIN and looks for a "location" node at the root level (i.e. not indentated). If it finds one, prints a list of all systems and planets which match the location filter in that node.
+
 .SH AUTHOR
 Michael Zahniser (mzahniser@gmail.com)
 

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -15,7 +15,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "PrintData.h"
 
+#include "DataFile.h"
+#include "DataNode.h"
 #include "GameData.h"
+#include "LocationFilter.h"
 #include "Outfit.h"
 #include "Planet.h"
 #include "Ship.h"
@@ -116,9 +119,10 @@ bool PrintData::IsPrintDataArgument(const char *const *argv)
 	for(const char *const *it = argv + 1; *it; ++it)
 	{
 		string arg = *it;
-		if(arg == "-s" || arg == "--ships" || arg == "-w" || arg == "--weapons" ||
-				arg == "-o" || arg == "--outfits" || arg == "-e" || arg == "--engines" ||
-				arg == "--power" || arg == "--planets" || arg == "--systems")
+		if(arg == "-s" || arg == "--ships" || arg == "-w" || arg == "--weapons"
+				|| arg == "-o" || arg == "--outfits" || arg == "-e" || arg == "--engines"
+				|| arg == "--power" || arg == "--planets" || arg == "--systems"
+				|| arg == "--matches")
 			return true;
 	}
 	return false;
@@ -145,6 +149,8 @@ void PrintData::Print(const char *const *argv)
 			Planets(argv);
 		else if(arg == "--systems")
 			Systems(argv);
+		else if(arg == "--matches")
+			LocationFilterMatches(argv);
 	}
 	cout.flush();
 }
@@ -175,6 +181,9 @@ void PrintData::Help()
 	cerr << "        --attributes: prints a list of all systems and their attributes." << endl;
 	cerr << "            --reverse: prints a list of all system attributes and which systems have them."
 			<< endl;
+	cerr << "    --matches: prints a list of all planets and systems matching a location filter passed in a text file."
+			<< endl;
+	cerr << "        The first node of the location filter should be `location`." << endl;
 }
 
 
@@ -644,4 +653,27 @@ void PrintData::Systems(const char *const *argv)
 		PrintObjectAttributes(GameData::Systems(), "system");
 	else
 		PrintObjectList(GameData::Systems(), false, "system");
+}
+
+
+
+void PrintData::LocationFilterMatches(const char *const *argv)
+{
+	DataFile file(cin);
+	LocationFilter filter;
+	for(const DataNode &node : file)
+		if(node.Token(0) == "location")
+		{
+			filter.Load(node);
+			break;
+		}
+
+	cout << "Systems matching provided location filter:\n";
+	for(const auto &it : GameData::Systems())
+		if(filter.Matches(&it.second))
+			cout << it.first << '\n';
+	cout << "Planets matching provided location filter:\n";
+	for(const auto &it : GameData::Planets())
+		if(filter.Matches(&it.second))
+			cout << it.first << '\n';
 }

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -181,7 +181,7 @@ void PrintData::Help()
 	cerr << "        --attributes: prints a list of all systems and their attributes." << endl;
 	cerr << "            --reverse: prints a list of all system attributes and which systems have them."
 			<< endl;
-	cerr << "    --matches: prints a list of all planets and systems matching a location filter passed in a text file."
+	cerr << "    --matches: prints a list of all planets and systems matching a location filter passed in STDIN."
 			<< endl;
 	cerr << "        The first node of the location filter should be `location`." << endl;
 }

--- a/source/PrintData.h
+++ b/source/PrintData.h
@@ -43,6 +43,8 @@ private:
 	static void PrintPlanetDescriptions();
 
 	static void Systems(const char *const *argv);
+
+	static void LocationFilterMatches(const char *const *argv);
 };
 
 #endif


### PR DESCRIPTION
**Feature:**

## Feature Details
Adds a command line option for testing a LocationFilter to get a list of all the planets and systems that will match it.

## UI Screenshots
![image](https://user-images.githubusercontent.com/20605679/202925767-26d9d2e9-dbc8-47f7-bb91-62b9dcd013a3.png)
Using the current LocationFilter for the Remnant Graveyard rescue job.

## Usage Examples
`EndlessSky.exe --matches < "location filter file.txt"` (In Windows command prompt.)
