### PR TITLE
ConversationPanel enter&down keys go past end of choice list when "to display" is used

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -288,9 +288,9 @@ bool ConversationPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comm
 	// return, or by pressing a number key.
 	if(key == SDLK_UP && choice > 0)
 		--choice;
-	else if(key == SDLK_DOWN && choice < conversation.Choices(node) - 1)
+	else if(key == SDLK_DOWN && choice + 1 < static_cast<int>(choices.size()))
 		++choice;
-	else if((key == SDLK_RETURN || key == SDLK_KP_ENTER) && isNewPress && choice < conversation.Choices(node))
+	else if((key == SDLK_RETURN || key == SDLK_KP_ENTER) && isNewPress && choice < static_cast<int>(choices.size()))
 		Goto(conversation.NextNodeForChoice(node, MapChoice(choice)), MapChoice(choice));
 	else if(key >= '1' && key < static_cast<SDL_Keycode>('1' + choices.size()))
 		Goto(conversation.NextNodeForChoice(node, MapChoice(key - '1')), MapChoice(key - '1'));


### PR DESCRIPTION
**Bugfix:** Fixes #7675 

## Fix Details
When the new `to display` feature is used, the number of choices displayed can be fewer than the total number in the txt. The logic for the SDLK_DOWN and SDLK_RETURN does not check the number of displayed choices, so the cursor can go past the end of the list, and an out-of-bounds option's goto can be followed.

## Testing Done
I have several PRs open that use `to display`, and they all cause this. You can also use my test file.
[test.txt](https://github.com/endless-sky/endless-sky/files/10052033/test.txt)
