### PR TITLE
Add Remnant Korath Exile Drone Bounties

### DIFF
--- a/data/korath/korath.txt
+++ b/data/korath/korath.txt
@@ -852,6 +852,82 @@ fleet "Kor Mereti Miners"
 	variant 1
 		"Model 8" 3
 
+fleet "Marauder Korath Drone I"
+	government "Korath"
+	names "korath"
+	fighters "korath"
+	cargo 1
+	personality
+		disables plunders opportunistic harvests
+	variant 5
+		"Met Par Tek 53"
+		"Model 8" 6
+	variant 5
+		"Met Par Tek 53"
+		"Model 32"
+		"Model 16" 2
+	variant 5
+		"Met Par Tek 53 (Sniper)"
+		"Model 32"
+		"Model 16" 2
+	variant 5
+		"Model 64"
+		"Model 16" 2
+	variant 5
+		"Model 64"
+		"Model 32"
+	variant 8
+		"Tek Far 71 - Lek"
+		"Far Lek 14" 10
+	variant 8
+		"Tek Far 71 - Lek (Close Quarters)"
+		"Far Lek 14" 10
+	variant 7
+		"Tek Far 78 - Osk"
+		"Far Osk 27" 9
+	variant 6
+		"Tek Far 78 - Osk (Close Quarters)"
+		"Far Osk 27" 9
+	variant 5
+		"Tek Far 109"
+		"Far Lek 14" 9
+		"Far Osk 27" 7
+	variant 5
+		"Model 128"
+
+fleet "Marauder Korath Drone II"
+	government "Korath"
+	names "korath"
+	fighters "korath"
+	cargo 1
+	personality
+		disables plunders opportunistic harvests
+	variant 5
+		"Kar Ik Vot 349"
+		"Model 256"
+		"Model 128" 2
+	variant 5
+		"Kar Ik Vot 349 (Offense)"
+		"Met Par Tek 53 (Sniper)" 2
+		"Model 256"
+	variant 5
+		"Kar Ik Vot 349 (Trapper)"
+		"Met Par Tek 53" 2
+		"Model 64" 4
+	variant 5
+		"Kar Ik Vot 349 (Defense)"
+		"Met Par Tek 53" 2
+		"Model 256"
+	variant 10
+		"Met Par Tek 53" 2
+		"Model 512"
+		"Model 64" 4
+	variant 10
+		"Model 512"
+		"Model 256" 2
+	variant 5
+		"Kar Ik Vot 349"
+		"Model 512"
 
 outfitter "Korath Basics"
 	"Piercer Missile Rack"

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -659,3 +659,60 @@ mission "Remnant: Rescue 5"
 	on visit
 		dialog
 			`You have returned, but there is still no word from the missing ship.`
+
+
+
+mission "Remnant: Bounty Small Korath Drone"
+	job
+	repeat
+	name "Plundering Small Korath Drone Fleet Bounty"
+	description "A small Korath drone fleet is plundering through Remnant territory. Hunt it down, and then return to <planet> to receive your payment of <payment>."
+	source
+		government "Remnant"
+	to offer
+		has "event: wanderers: exiles have drones"
+		has "Remnant: Cognizance 14: done"
+		random < 30
+	npc kill
+		government "Korath"
+		personality heroic vindictive target uninterested waiting marked
+		system
+			distance 1 2
+		fleet "Marauder Korath Drone I"
+		dialog "You have destroyed the Korath drones. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 300000
+		dialog "A Remnant military leader thanks you for hunting down the Korath Drone drones, and gives you the agreed-upon payment of <payment>."
+
+
+
+mission "Remnant: Bounty Large Korath Drone"
+	job
+	repeat
+	name "Pillaging Large Korath Drone Fleet Bounty"
+	description "A large Korath drone fleet is hunting down our miners in the Ember Wastes. Track it down, eliminate it, and then return to <planet> to receive your payment of <payment>."
+	source
+		government "Remnant"
+	to offer
+		has "event: wanderers: exiles have drones"
+		has "Remnant: Cognizance 29: done"
+		or
+			not "remnant: ssil vida active"
+			not "flagship planet: Ssil Vida"
+		random < 5
+	npc kill
+		government "Korath"
+		personality heroic vindictive target marked staying
+		system
+			attributes "ember waste"
+			not attributes "graveyard"
+			not attributes "inaccessible"
+		fleet "Marauder Korath Drone II"
+		dialog "You have destroyed the Korath drones. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 800000
+		dialog "A Remnant military leader thanks you for hunting down the Korath drones, and gives you the agreed-upon payment of <payment>."


### PR DESCRIPTION
## Summary
After finishing the Wanderer campaign to date the player looses the ability to capture Kor Sestor & Kor Mereti drones as they only spawn in Korath Exile space without jump drives. This effectively punishes the player for finishing the Wanderer campaign.

This PR attempts to remedy this by adding two Remnant repeating bounty jobs for taking out Exile Kor Sestor & Kor Mereti drones.

## Save File
This save file can be used to play through the new mission content:
[Save File](https://www.dropbox.com/s/p55oqrdb1fz4cxf/Rover%20Freewing.txt?dl=0)