### PR TITLE
Block some jobs from offering if reputation with law enforcement is too low

### DIFF
--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -330,6 +330,7 @@ mission "Transport scientists"
 	passengers 5 16
 	to offer
 		random < 15
+		"reputation: Deep Security" >= 0
 	on stopover
 		dialog "The scientists have been giddily discussing the results of their research during the entire trip. You're happy for a bit of peace and quiet as they make tracks for a prominent research lab to have the results analyzed. You prepare for the return journey to <planet>."
 	on visit
@@ -352,6 +353,7 @@ mission "Escort science vessel"
 	to offer
 		random < 15
 		"combat rating" > 50
+		"reputation: Deep Security" >= 0
 	npc
 		government "Pirate"
 		personality nemesis waiting plunders
@@ -403,6 +405,7 @@ mission "Record academic conference"
 	cargo "recording equipment" 1
 	to offer
 		random < 15
+		"reputation: Deep Security" >= 0
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete

--- a/data/human/dirt belt jobs.txt
+++ b/data/human/dirt belt jobs.txt
@@ -54,6 +54,7 @@ mission "To Remembrance Day celebration [0]"
 				random < 10
 				month == 2
 				day < 19
+		"reputation: Militia" >= 0
 	to fail
 		month == 2
 		day == 19
@@ -89,6 +90,7 @@ mission "To Remembrance Day celebration [1]"
 				random < 20
 				month == 2
 				day < 19
+		"reputation: Militia" >= 0
 	to fail
 		month == 2
 		day == 19
@@ -123,6 +125,7 @@ mission "To Remembrance Day celebration [2]"
 				random < 20
 				month == 2
 				day < 19
+		"reputation: Militia" >= 0
 	to fail
 		month == 2
 		day == 19
@@ -157,6 +160,7 @@ mission "From Remembrance Day celebration [0]"
 				random < 10
 				month == 4
 				day < 20
+		"reputation: Militia" >= 0
 	source
 		attributes "dirt belt"
 	destination
@@ -189,6 +193,7 @@ mission "From Remembrance Day celebration [1]"
 				random < 5
 				month == 4
 				day < 20
+		"reputation: Militia" >= 0
 	source
 		attributes "dirt belt"
 	destination
@@ -211,6 +216,7 @@ mission "Food Convoy [0]"
 	to offer
 		random < 30
 		"combat rating" > 30
+		"reputation: Militia" >= 0
 	source
 		attributes "dirt belt"
 	destination
@@ -264,6 +270,7 @@ mission "Food Convoy [1]"
 	to offer
 		random < 25
 		"combat rating" > 60
+		"reputation: Militia" >= 0
 	source
 		attributes "dirt belt"
 	destination
@@ -309,6 +316,7 @@ mission "Food Convoy [2]"
 	to offer
 		random < 15
 		"combat rating" > 90
+		"reputation: Militia" >= 0
 	source
 		attributes "dirt belt"
 	destination

--- a/data/human/near earth jobs.txt
+++ b/data/human/near earth jobs.txt
@@ -19,6 +19,7 @@ mission "Historical field trip to <planet>"
 	deadline
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		attributes "deep" "paradise"
 	destination
@@ -52,6 +53,7 @@ mission "To Earth Day celebration [0]"
 				random < 20
 				month == 4
 				day < 22
+		"reputation: Republic" >= 0
 	to fail
 		month * 100 + day >= 422
 	source
@@ -85,6 +87,7 @@ mission "To Earth Day celebration [1]"
 				random < 20
 				month == 4
 				day < 22
+		"reputation: Republic" >= 0
 	to fail
 		month * 100 + day >= 422
 	source
@@ -117,6 +120,7 @@ mission "From Earth Day celebration [0]"
 				random < 30
 				month == 6
 				day <= 22
+		"reputation: Republic" >= 0
 	source "Earth"
 	destination
 		distance 1 15
@@ -148,6 +152,7 @@ mission "From Earth Day celebration [1]"
 				random < 10
 				month == 6
 				day <= 22
+		"reputation: Republic" >= 0
 	source "Earth"
 	destination
 		distance 1 15
@@ -167,6 +172,7 @@ mission "Transport farmers to Mars"
 	passengers 2 2 .8
 	to offer
 		random < 50
+		"reputation: Republic" >= 0
 	source "Earth"
 	destination "Mars"
 	on visit
@@ -184,6 +190,7 @@ mission "Transport tourists to Luna"
 	passengers 2 2 .8
 	to offer
 		random < 50
+		"reputation: Republic" >= 0
 	source "Earth"
 	destination "Luna"
 	on visit
@@ -200,6 +207,7 @@ mission "Transport seasonal workers to Earth"
 	passengers 2 2 .8
 	to offer
 		random < 50
+		"reputation: Republic" >= 0
 	source "Mars"
 	destination "Earth"
 	on visit

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -25,6 +25,7 @@ mission "Paradise Job: Care Package"
 		attributes "paradise"
 	destination
 		distance 2 5
+		"reputation: Republic" >= 0
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "paradise" "research" "rich"
 	on visit
@@ -48,6 +49,7 @@ mission "Paradise Job: Birthday Supplies"
 		attributes "paradise"
 	destination
 		distance 2 10
+		"reputation: Republic" >= 0
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "paradise" "rich" "core" "near earth"
 	on visit
@@ -72,6 +74,7 @@ mission "Paradise Job: Art Delivery"
 		attributes "rich"
 	destination
 		distance 2 5
+		"reputation: Republic" >= 0
 		attributes "paradise"
 	on visit
 		dialog phrase "generic cargo on visit"
@@ -91,6 +94,7 @@ mission "Paradise Job: Newlyweds"
 	cargo "wedding gifts" 2 4
 	to offer
 		random < 10
+		"reputation: Republic" >= -5
 	on offer
 		require "Luxury Accommodations"
 	source
@@ -115,6 +119,7 @@ mission "Paradise Job: Theater Props"
 	cargo "Luxury Goods" 9 15
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "rich" "urban"
@@ -138,6 +143,7 @@ mission "Paradise Job: Fine Food"
 	cargo "Food" 9 25
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "farming" "fishing"
@@ -186,6 +192,7 @@ mission "Transport partiers [2]"
 	cargo "snacks and school supplies" 2 4
 	to offer
 		random < 10
+		"reputation: Republic" >= -5
 	on offer
 		require "Luxury Accommodations"
 	source
@@ -207,6 +214,7 @@ mission "Paradise Job: Food Donations"
 	cargo "Food" 7 2 .1
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		attributes "paradise"
 	destination
@@ -227,6 +235,7 @@ mission "Paradise Job: Clothing Donations"
 	cargo "Clothing" 7 2 .1
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		attributes "paradise"
 	destination
@@ -247,6 +256,7 @@ mission "Paradise Job: Medical Aid"
 	cargo "Medical" 7 2 .1
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		attributes "paradise"
 	destination
@@ -267,6 +277,7 @@ mission "Paradise Job: Charity"
 	cargo "Luxury Goods" 7 2 .1
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		attributes "paradise"
 	destination
@@ -288,6 +299,7 @@ mission "Paradise Job: Party Goods"
 	cargo "Luxury Goods" 10 2 .1
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		attributes "paradise"
 	stopover
@@ -313,6 +325,7 @@ mission "Paradise Job: Estate Assets"
 	cargo "Luxury Goods" 18 2 .15
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		attributes "paradise"
 	destination
@@ -334,6 +347,7 @@ mission "Paradise Jobs: Contract Laborers"
 	passengers 13 30
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		attributes "paradise"
 	stopover
@@ -377,6 +391,7 @@ mission "Transport high-class tourists"
 	passengers 8 22
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	on offer
 		require "Luxury Accommodations"
 	source
@@ -399,6 +414,7 @@ mission "Pleasure cruise security"
 	to offer
 		random < 10
 		"combat rating" > 10
+		"reputation: Republic" >= 0
 	source
 		attributes "paradise" "rich"
 	stopover
@@ -484,6 +500,7 @@ mission "Paradise Job: Retirees"
 		random < 10
 		"passenger space" > 15
 		"cargo space" > 40
+		"reputation: Republic" >= 0
 	on offer
 		require "Luxury Accommodations"
 	source
@@ -507,6 +524,7 @@ mission "Paradise Job: Wilderness Retreat"
 	to offer
 		random < 10
 		"passenger space" > 25
+		"reputation: Republic" >= 0
 	on offer
 		require "Luxury Accommodations"
 	source

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -21,11 +21,11 @@ mission "Paradise Job: Care Package"
 	cargo "Food" 1
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		attributes "paradise"
 	destination
 		distance 2 5
-		"reputation: Republic" >= 0
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "paradise" "research" "rich"
 	on visit
@@ -45,11 +45,11 @@ mission "Paradise Job: Birthday Supplies"
 	cargo "Luxury Goods" 1 3
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		attributes "paradise"
 	destination
 		distance 2 10
-		"reputation: Republic" >= 0
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "paradise" "rich" "core" "near earth"
 	on visit
@@ -69,12 +69,12 @@ mission "Paradise Job: Art Delivery"
 	cargo "Luxury Goods" 3 8
 	to offer
 		random < 10
+		"reputation: Republic" >= 0
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "rich"
 	destination
 		distance 2 5
-		"reputation: Republic" >= 0
 		attributes "paradise"
 	on visit
 		dialog phrase "generic cargo on visit"

--- a/data/human/syndicate jobs.txt
+++ b/data/human/syndicate jobs.txt
@@ -20,6 +20,7 @@ mission "Transport executive to <planet>"
 	passengers 1
 	to offer
 		random < 20
+		"reputation: Syndicate" >= 0
 	on offer
 		require "Luxury Accommodations"
 	source
@@ -43,6 +44,7 @@ mission "Corporate retreat from <origin>"
 	passengers 7 18
 	to offer
 		random < 20
+		"reputation: Syndicate" >= 0
 	on offer
 		require "Luxury Accommodations"
 	source
@@ -94,6 +96,7 @@ mission "Document delivery to <planet>"
 	cargo "Confidential documents" 6 12
 	to offer
 		random < 10
+		"reputation: Syndicate" >= 0
 	source
 		government Syndicate
 	destination


### PR DESCRIPTION
**Bugfix/ Mechanic Change:** This PR addresses issue #7663

## Fix Details
Changes some flavour jobs to only offer if reputation with local law enforcement is zero or higher. Republic citizens no longer hire you to take them to Earth for Earth Day if you're at war with the Republic, you're not trusted in the dirt belt, south, and rim if you don't get along with the militia, and the Syndicate won't hire you to transport executives when you're at war with them. The Deep won't get you to do important scientific work if Deep Security is on killing terms with you. Urgent jobs are unaffected, as are those were the parties probably wouldn't care _too_ much if the cargo went missing. Newlyweds and partygoers take some more risks, but still won't travel with you if your reputation drops too low. I haven't changed the basic missions, but I might (in a separate PR) if this is merged.

## Testing Done
Not yet tested. It _should_ work, but please don't merge this until it has been tested and reviewed by a variety of people.

## Save File
Thanks to RNG, a save file wouldn't really work here.