### PR TITLE
Improve `Dictionary::Get` perfomance

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2303,18 +2303,19 @@ void AI::PickUp(Ship &ship, Command &command, const Body &target)
 // energy strain, or undue thermal loads if almost overheated.
 bool AI::ShouldUseAfterburner(Ship &ship)
 {
-	if(!ship.Attributes().Get("afterburner thrust"_fnv1a))
+	const auto &attributes = ship.Attributes();
+	if(!attributes.Get("afterburner thrust"_fnv1a))
 		return false;
 
-	double fuel = ship.Fuel() * ship.Attributes().Get("fuel capacity"_fnv1a);
-	double neededFuel = ship.Attributes().Get("afterburner fuel"_fnv1a);
-	double energy = ship.Energy() * ship.Attributes().Get("energy capacity"_fnv1a);
-	double neededEnergy = ship.Attributes().Get("afterburner energy"_fnv1a);
+	double fuel = ship.Fuel() * attributes.Get("fuel capacity"_fnv1a);
+	double neededFuel = attributes.Get("afterburner fuel"_fnv1a);
+	double energy = ship.Energy() * attributes.Get("energy capacity"_fnv1a);
+	double neededEnergy = attributes.Get("afterburner energy"_fnv1a);
 	if(energy == 0.)
-		energy = ship.Attributes().Get("energy generation"_fnv1a)
-				+ 0.2 * ship.Attributes().Get("solar collection"_fnv1a)
-				- ship.Attributes().Get("energy consumption"_fnv1a);
-	double outputHeat = ship.Attributes().Get("afterburner heat"_fnv1a) / (100 * ship.Mass());
+		energy = attributes.Get("energy generation"_fnv1a)
+				+ 0.2 * attributes.Get("solar collection"_fnv1a)
+				- attributes.Get("energy consumption"_fnv1a);
+	double outputHeat = attributes.Get("afterburner heat"_fnv1a) / (100 * ship.Mass());
 	if((!neededFuel || fuel - neededFuel > ship.JumpNavigation().JumpFuel())
 			&& (!neededEnergy || neededEnergy / energy < 0.25)
 			&& (!outputHeat || ship.Heat() + outputHeat < .9))

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -197,7 +197,7 @@ namespace {
 	bool ShouldRefuel(const Ship &ship, const DistanceMap &route, double fuelCapacity = 0.)
 	{
 		if(!fuelCapacity)
-			fuelCapacity = ship.Attributes().Get("fuel capacity");
+			fuelCapacity = ship.Attributes().Get("fuel capacity"_fnv1a);
 
 		const System *from = ship.GetSystem();
 		const bool systemHasFuel = from->HasFuelFor(ship) && fuelCapacity;
@@ -361,7 +361,7 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 	// Only toggle the "cloak" command if one of your ships has a cloaking device.
 	if(activeCommands.Has(Command::CLOAK))
 		for(const auto &it : player.Ships())
-			if(!it->IsParked() && it->Attributes().Get("cloak"))
+			if(!it->IsParked() && it->Attributes().Get("cloak"_fnv1a))
 			{
 				isCloaking = !isCloaking;
 				Messages::Add(isCloaking ? "Engaging cloaking device." : "Disengaging cloaking device."
@@ -938,7 +938,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 			MoveIndependent(*it, command);
 		else if(parent->GetSystem() != it->GetSystem())
 		{
-			if(personality.IsStaying() || !it->Attributes().Get("fuel capacity"))
+			if(personality.IsStaying() || !it->Attributes().Get("fuel capacity"_fnv1a))
 				MoveIndependent(*it, command);
 			else
 				MoveEscort(*it, command);
@@ -1270,8 +1270,8 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	// mission NPCs) should consider friendly targets for surveillance.
 	if(!isYours && !target && (ship.IsSpecial() || scanPermissions.at(gov)))
 	{
-		bool cargoScan = ship.Attributes().Get("cargo scan power");
-		bool outfitScan = ship.Attributes().Get("outfit scan power");
+		bool cargoScan = ship.Attributes().Get("cargo scan power"_fnv1a);
+		bool outfitScan = ship.Attributes().Get("outfit scan power"_fnv1a);
 		if(cargoScan || outfitScan)
 		{
 			closest = numeric_limits<double>::infinity();
@@ -1467,8 +1467,8 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 	else if(target)
 	{
 		// An AI ship that is targeting a non-hostile ship should scan it, or move on.
-		bool cargoScan = ship.Attributes().Get("cargo scan power");
-		bool outfitScan = ship.Attributes().Get("outfit scan power");
+		bool cargoScan = ship.Attributes().Get("cargo scan power"_fnv1a);
+		bool outfitScan = ship.Attributes().Get("outfit scan power"_fnv1a);
 		if((!cargoScan || Has(gov, target, ShipEvent::SCAN_CARGO))
 				&& (!outfitScan || Has(gov, target, ShipEvent::SCAN_OUTFITS)))
 			target.reset();
@@ -1583,7 +1583,7 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 	else if(ship.GetTargetStellar())
 	{
 		MoveToPlanet(ship, command);
-		if(!shouldStay && ship.Attributes().Get("fuel capacity") && ship.GetTargetStellar()->HasSprite()
+		if(!shouldStay && ship.Attributes().Get("fuel capacity"_fnv1a) && ship.GetTargetStellar()->HasSprite()
 				&& ship.GetTargetStellar()->GetPlanet() && ship.GetTargetStellar()->GetPlanet()->CanLand(ship))
 			command |= Command::LAND;
 		else if(ship.Position().Distance(ship.GetTargetStellar()->Position()) < 100.)
@@ -1602,7 +1602,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 {
 	const Ship &parent = *ship.GetParent();
 	const System *currentSystem = ship.GetSystem();
-	bool hasFuelCapacity = ship.Attributes().Get("fuel capacity");
+	bool hasFuelCapacity = ship.Attributes().Get("fuel capacity"_fnv1a);
 	bool needsFuel = ship.NeedsFuel();
 	bool isStaying = ship.GetPersonality().IsStaying() || !hasFuelCapacity;
 	bool parentIsHere = (currentSystem == parent.GetSystem());
@@ -1818,9 +1818,9 @@ bool AI::ShouldDock(const Ship &ship, const Ship &parent, const System *playerSy
 
 	// If a carried ship has fuel capacity but is very low, it should return if
 	// the parent can refuel it.
-	double maxFuel = ship.Attributes().Get("fuel capacity");
+	double maxFuel = ship.Attributes().Get("fuel capacity"_fnv1a);
 	if(maxFuel && ship.Fuel() < .005 && parent.JumpNavigation().JumpFuel() < parent.Fuel() *
-			parent.Attributes().Get("fuel capacity") - maxFuel)
+			parent.Attributes().Get("fuel capacity"_fnv1a) - maxFuel)
 		return true;
 
 	// If an out-of-combat NPC carried ship is carrying a significant cargo
@@ -1937,7 +1937,7 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed, const Point directi
 
 	// If you have a reverse thruster, figure out whether using it is faster
 	// than turning around and using your main thruster.
-	if(ship.Attributes().Get("reverse thrust"))
+	if(ship.Attributes().Get("reverse thrust"_fnv1a))
 	{
 		// Figure out your stopping time using your main engine:
 		double degreesToTurn = TO_DEG * acos(min(1., max(-1., -velocity.Unit().Dot(angle.Unit()))));
@@ -1945,7 +1945,7 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed, const Point directi
 		forwardTime += stopTime;
 
 		// Figure out your reverse thruster stopping time:
-		double reverseAcceleration = ship.Attributes().Get("reverse thrust") / ship.InertialMass();
+		double reverseAcceleration = ship.Attributes().Get("reverse thrust"_fnv1a) / ship.InertialMass();
 		double reverseTime = (180. - degreesToTurn) / ship.TurnRate();
 		reverseTime += speed / reverseAcceleration;
 
@@ -1984,7 +1984,7 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed, const Point directi
 void AI::PrepareForHyperspace(Ship &ship, Command &command)
 {
 	bool hasHyperdrive = ship.JumpNavigation().HasHyperdrive();
-	double scramThreshold = ship.Attributes().Get("scram drive");
+	double scramThreshold = ship.Attributes().Get("scram drive"_fnv1a);
 	bool hasJumpDrive = ship.JumpNavigation().HasJumpDrive();
 	if(!hasHyperdrive && !hasJumpDrive)
 		return;
@@ -2034,9 +2034,9 @@ void AI::PrepareForHyperspace(Ship &ship, Command &command)
 	}
 	// If we're a jump drive, just stop.
 	else if(isJump)
-		Stop(ship, command, ship.Attributes().Get("jump speed"));
+		Stop(ship, command, ship.Attributes().Get("jump speed"_fnv1a));
 	// Else stop in the fastest way to end facing in the right direction
-	else if(Stop(ship, command, ship.Attributes().Get("jump speed"), direction))
+	else if(Stop(ship, command, ship.Attributes().Get("jump speed"_fnv1a), direction))
 		command.SetTurn(TurnToward(ship, direction));
 }
 
@@ -2148,11 +2148,11 @@ void AI::KeepStation(Ship &ship, Command &command, const Body &target)
 
 	// Determine whether to apply thrust.
 	Point drag = ship.Velocity() * ship.Drag() / mass;
-	if(ship.Attributes().Get("reverse thrust"))
+	if(ship.Attributes().Get("reverse thrust"_fnv1a))
 	{
 		// Don't take drag into account when reverse thrusting, because this
 		// estimate of how it will be applied can be quite inaccurate.
-		Point a = (unit * (-ship.Attributes().Get("reverse thrust") / mass)).Unit();
+		Point a = (unit * (-ship.Attributes().Get("reverse thrust"_fnv1a) / mass)).Unit();
 		double direction = positionWeight * positionDelta.Dot(a) / POSITION_DEADBAND
 			+ velocityWeight * velocityDelta.Dot(a) / VELOCITY_DEADBAND;
 		if(direction > THRUST_DEADBAND)
@@ -2255,7 +2255,7 @@ void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 
 	// If the ship has reverse thrusters and the target is behind it, we can
 	// use them to reach the target more quickly.
-	if(ship.Facing().Unit().Dot(d.Unit()) < -.75 && ship.Attributes().Get("reverse thrust"))
+	if(ship.Facing().Unit().Dot(d.Unit()) < -.75 && ship.Attributes().Get("reverse thrust"_fnv1a))
 		command |= Command::BACK;
 	// This isn't perfect, but it works well enough.
 	else if((ship.Facing().Unit().Dot(d) >= 0. && d.Length() > diameter)
@@ -2303,18 +2303,18 @@ void AI::PickUp(Ship &ship, Command &command, const Body &target)
 // energy strain, or undue thermal loads if almost overheated.
 bool AI::ShouldUseAfterburner(Ship &ship)
 {
-	if(!ship.Attributes().Get("afterburner thrust"))
+	if(!ship.Attributes().Get("afterburner thrust"_fnv1a))
 		return false;
 
-	double fuel = ship.Fuel() * ship.Attributes().Get("fuel capacity");
-	double neededFuel = ship.Attributes().Get("afterburner fuel");
-	double energy = ship.Energy() * ship.Attributes().Get("energy capacity");
-	double neededEnergy = ship.Attributes().Get("afterburner energy");
+	double fuel = ship.Fuel() * ship.Attributes().Get("fuel capacity"_fnv1a);
+	double neededFuel = ship.Attributes().Get("afterburner fuel"_fnv1a);
+	double energy = ship.Energy() * ship.Attributes().Get("energy capacity"_fnv1a);
+	double neededEnergy = ship.Attributes().Get("afterburner energy"_fnv1a);
 	if(energy == 0.)
-		energy = ship.Attributes().Get("energy generation")
-				+ 0.2 * ship.Attributes().Get("solar collection")
-				- ship.Attributes().Get("energy consumption");
-	double outputHeat = ship.Attributes().Get("afterburner heat") / (100 * ship.Mass());
+		energy = ship.Attributes().Get("energy generation"_fnv1a)
+				+ 0.2 * ship.Attributes().Get("solar collection"_fnv1a)
+				- ship.Attributes().Get("energy consumption"_fnv1a);
+	double outputHeat = ship.Attributes().Get("afterburner heat"_fnv1a) / (100 * ship.Mass());
 	if((!neededFuel || fuel - neededFuel > ship.JumpNavigation().JumpFuel())
 			&& (!neededEnergy || neededEnergy / energy < 0.25)
 			&& (!outputHeat || ship.Heat() + outputHeat < .9))
@@ -2439,7 +2439,7 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 	{
 		// Approach the planet and "land" on it (i.e. scan it).
 		MoveToPlanet(ship, command);
-		double atmosphereScan = ship.Attributes().Get("atmosphere scan");
+		double atmosphereScan = ship.Attributes().Get("atmosphere scan"_fnv1a);
 		double distance = ship.Position().Distance(ship.GetTargetStellar()->Position());
 		if(distance < atmosphereScan && !Random::Int(100))
 			ship.SetTargetStellar(nullptr);
@@ -2449,8 +2449,8 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 	else if(target)
 	{
 		// Approach and scan the targeted, friendly ship's cargo or outfits.
-		bool cargoScan = ship.Attributes().Get("cargo scan power");
-		bool outfitScan = ship.Attributes().Get("outfit scan power");
+		bool cargoScan = ship.Attributes().Get("cargo scan power"_fnv1a);
+		bool outfitScan = ship.Attributes().Get("outfit scan power"_fnv1a);
 		// If the pointer to the target ship exists, it is targetable and in-system.
 		bool mustScanCargo = cargoScan && !Has(ship, target, ShipEvent::SCAN_CARGO);
 		bool mustScanOutfits = outfitScan && !Has(ship, target, ShipEvent::SCAN_OUTFITS);
@@ -2469,8 +2469,8 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 
 		// Consider scanning any non-hostile ship in this system that you haven't yet personally scanned.
 		vector<Ship *> targetShips;
-		bool cargoScan = ship.Attributes().Get("cargo scan power");
-		bool outfitScan = ship.Attributes().Get("outfit scan power");
+		bool cargoScan = ship.Attributes().Get("cargo scan power"_fnv1a);
+		bool outfitScan = ship.Attributes().Get("outfit scan power"_fnv1a);
 		if(cargoScan || outfitScan)
 			for(const auto &grit : governmentRosters)
 			{
@@ -2490,7 +2490,7 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 
 		// Consider scanning any planetary object in the system, if able.
 		vector<const StellarObject *> targetPlanets;
-		double atmosphereScan = ship.Attributes().Get("atmosphere scan");
+		double atmosphereScan = ship.Attributes().Get("atmosphere scan"_fnv1a);
 		if(atmosphereScan)
 			for(const StellarObject &object : system->Objects())
 				if(object.HasSprite() && !object.IsStar() && !object.IsStation())
@@ -2646,16 +2646,16 @@ bool AI::DoHarvesting(Ship &ship, Command &command)
 // Check if this ship should cloak. Returns true if this ship decided to run away while cloaking.
 bool AI::DoCloak(Ship &ship, Command &command)
 {
-	if(ship.Attributes().Get("cloak"))
+	if(ship.Attributes().Get("cloak"_fnv1a))
 	{
 		// Never cloak if it will cause you to be stranded.
 		const Outfit &attributes = ship.Attributes();
-		double fuelCost = attributes.Get("cloaking fuel") + attributes.Get("fuel consumption")
-			- attributes.Get("fuel generation");
-		if(attributes.Get("cloaking fuel") && !attributes.Get("ramscoop"))
+		double fuelCost = attributes.Get("cloaking fuel"_fnv1a) + attributes.Get("fuel consumption"_fnv1a)
+			- attributes.Get("fuel generation"_fnv1a);
+		if(attributes.Get("cloaking fuel"_fnv1a) && !attributes.Get("ramscoop"_fnv1a))
 		{
-			double fuel = ship.Fuel() * attributes.Get("fuel capacity");
-			int steps = ceil((1. - ship.Cloaking()) / attributes.Get("cloak"));
+			double fuel = ship.Fuel() * attributes.Get("fuel capacity"_fnv1a);
+			int steps = ceil((1. - ship.Cloaking()) / attributes.Get("cloak"_fnv1a));
 			// Only cloak if you will be able to fully cloak and also maintain it
 			// for as long as it will take you to reach full cloak.
 			fuel -= fuelCost * (1 + 2 * steps);
@@ -2697,7 +2697,7 @@ bool AI::DoCloak(Ship &ship, Command &command)
 		bool cloakFreely = (fuelCost <= 0.) && !ship.GetShipToAssist();
 		// If this ship is injured / repairing, it should cloak while under threat.
 		bool cloakToRepair = (ship.Health() < RETREAT_HEALTH + hysteresis)
-				&& (attributes.Get("shield generation") || attributes.Get("hull repair rate"));
+				&& (attributes.Get("shield generation"_fnv1a) || attributes.Get("hull repair rate"_fnv1a));
 		if(cloakToRepair && (cloakFreely || range < 2000. * (1. + hysteresis)))
 		{
 			command |= Command::CLOAK;
@@ -2794,10 +2794,10 @@ Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &sho
 	// The average term's value will be v / 2. So:
 	stopDistance += .5 * v * v / acceleration;
 
-	if(ship.Attributes().Get("reverse thrust"))
+	if(ship.Attributes().Get("reverse thrust"_fnv1a))
 	{
 		// Figure out your reverse thruster stopping distance:
-		double reverseAcceleration = ship.Attributes().Get("reverse thrust") / ship.InertialMass();
+		double reverseAcceleration = ship.Attributes().Get("reverse thrust"_fnv1a) / ship.InertialMass();
 		double reverseDistance = v * (180. - degreesToTurn) / turnRate;
 		reverseDistance += .5 * v * v / reverseAcceleration;
 
@@ -3096,7 +3096,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary) const
 		// fuel that you cannot leave the system if necessary.
 		if(weapon->FiringFuel())
 		{
-			double fuel = ship.Fuel() * ship.Attributes().Get("fuel capacity");
+			double fuel = ship.Fuel() * ship.Attributes().Get("fuel capacity"_fnv1a);
 			fuel -= weapon->FiringFuel();
 			// If the ship is not ever leaving this system, it does not need to
 			// reserve any fuel.
@@ -3399,7 +3399,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 				}
 			}
 		// If no ship was found, look for nearby asteroids.
-		double asteroidRange = 100. * sqrt(ship.Attributes().Get("asteroid scan power"));
+		double asteroidRange = 100. * sqrt(ship.Attributes().Get("asteroid scan power"_fnv1a));
 		if(!found && asteroidRange)
 		{
 			for(const shared_ptr<Minable> &asteroid : minables)
@@ -3716,7 +3716,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 			command.SetTurn(activeCommands.Has(Command::RIGHT) - activeCommands.Has(Command::LEFT));
 		if(activeCommands.Has(Command::BACK))
 		{
-			if(!activeCommands.Has(Command::FORWARD) && ship.Attributes().Get("reverse thrust"))
+			if(!activeCommands.Has(Command::FORWARD) && ship.Attributes().Get("reverse thrust"_fnv1a))
 				command |= Command::BACK;
 			else if(!activeCommands.Has(Command::RIGHT | Command::LEFT))
 				command.SetTurn(TurnBackward(ship));

--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -53,7 +53,7 @@ namespace {
 	// Perform a binary search on a sorted vector. Return the key's location (or
 	// proper insertion spot) in the first element of the pair, and "true" in
 	// the second element if the key is already in the vector.
-	pair<size_t, bool> Search(const char *key, const vector<pair<const char *, double>> &v)
+	pair<size_t, bool> Search(const char *key, const vector<pair<stringAndHash, double>> &v)
 	{
 		// At each step of the search, we know the key is in [low, high).
 		size_t low = 0;
@@ -62,7 +62,7 @@ namespace {
 		while(low != high)
 		{
 			size_t mid = (low + high) / 2;
-			int cmp = strcmp(key, v[mid].first);
+			int cmp = strcmp(key, v[mid].first.GetString());
 			if(!cmp)
 				return make_pair(mid, true);
 
@@ -95,7 +95,7 @@ double &Dictionary::operator[](const char *key)
 	if(pos.second)
 		return data()[pos.first].second;
 
-	return insert(begin() + pos.first, make_pair(Intern(key), 0.))->second;
+	return insert(begin() + pos.first, make_pair(stringAndHash(Intern(key)), 0.))->second;
 }
 
 

--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -62,10 +62,10 @@ namespace {
 		while(low != high)
 		{
 			size_t mid = (low + high) / 2;
-			if(key.GetHash() == v[mid].first.GetHash())
+			if(key.GetHash().Get() == v[mid].first.GetHash().Get())
 				return make_pair(mid, true);
 
-			if(key.GetHash() < v[mid].first.GetHash())
+			if(key.GetHash().Get() < v[mid].first.GetHash().Get())
 				high = mid;
 			else
 				low = mid + 1;

--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -107,7 +107,7 @@ double &Dictionary::operator[](const string &key)
 
 
 
-double Dictionary::Get(const HashWrapper &hash_wr) const
+double Dictionary::Get(HashWrapper hash_wr) const
 {
 	static Timing timing;
 	const auto start = high_resolution_clock::now();

--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -158,14 +158,27 @@ double Dictionary::Get(const string &key) const
 
 
 
-void Dictionary::CheckCollisions() const
+void DictionaryCollisionChecker::AddKeysWhileChecking(const Dictionary &dict)
 {
-	using element_type = pair<stringAndHash, double>;
-
-	auto equal_found = adjacent_find((*this).begin(), (*this).end()
-			, [](const element_type &a, const element_type &b) {
-		return a.first.GetHash().Get() == b.first.GetHash().Get();
-	});
-	if(equal_found != (*this).end())
-		throw runtime_error { "Found an hash collision on '" + string((*equal_found).first.GetString()) + "'" };
+	// Collect all the keys from the handed Dictionary
+	for(const auto &element : dict)
+	{
+		set<stringAndHash, hash_comparator>::iterator it;
+		bool inserted;
+		tie(it, inserted) = collected_keys.insert(element.first);
+		if(!inserted)
+		{
+			// The element can't be inserted into the set because the
+			// hashes are equal, verify strings are different or there's
+			// a collision
+			if((*it).GetString() != element.first.GetString())
+			{
+				// ...there's a collision:
+				throw runtime_error { "Found an hash collision of '"
+					+ string((*it).GetString())
+					+ "' with '" + string(element.first.GetString()) + "'\n"
+					+ "Please try a different key or contact developers"};
+			}
+		}
+	}
 }

--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -53,7 +53,7 @@ namespace {
 	// Perform a binary search on a sorted vector. Return the key's location (or
 	// proper insertion spot) in the first element of the pair, and "true" in
 	// the second element if the key is already in the vector.
-	pair<size_t, bool> Search(const char *key, const vector<pair<stringAndHash, double>> &v)
+	pair<size_t, bool> Search(stringAndHash key, const vector<pair<stringAndHash, double>> &v)
 	{
 		// At each step of the search, we know the key is in [low, high).
 		size_t low = 0;
@@ -62,11 +62,10 @@ namespace {
 		while(low != high)
 		{
 			size_t mid = (low + high) / 2;
-			int cmp = strcmp(key, v[mid].first.GetString());
-			if(!cmp)
+			if(key.GetHash() == v[mid].first.GetHash())
 				return make_pair(mid, true);
 
-			if(cmp < 0)
+			if(key.GetHash() < v[mid].first.GetHash())
 				high = mid;
 			else
 				low = mid + 1;
@@ -91,7 +90,7 @@ namespace {
 
 double &Dictionary::operator[](const char *key)
 {
-	pair<size_t, bool> pos = Search(key, *this);
+	pair<size_t, bool> pos = Search(stringAndHash(key), *this);
 	if(pos.second)
 		return data()[pos.first].second;
 
@@ -112,7 +111,7 @@ double Dictionary::Get(const char *key) const
 	static Timing timing;
 	const auto start = high_resolution_clock::now();
 
-	pair<size_t, bool> pos = Search(key, *this);
+	pair<size_t, bool> pos = Search(stringAndHash(key), *this);
 
 	const auto stop = high_resolution_clock::now();
 

--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -67,13 +67,13 @@ namespace {
 template <typename Type>
 pair<size_t, bool> Search(Type key, const vector<pair<stringAndHash, double>> &v);
 
-// The dataset is sorted by its 'char *' key (which is indeed the only
-// allowed key used when adding a new element because it's unique), so
-// a bynary search is not possible: do a 'find'
+// Perform a binary search on a sorted vector. Return the key's location (or
+// proper insertion spot) in the first element of the pair, and "true" in
+// the second element if the key is already in the vector.
 template <>
 pair<size_t, bool> Search(const HashWrapper key, const vector<pair<stringAndHash, double>> &v)
 {
-	for(size_t low = 0; low < v.size(); low++)
+	for(size_t low = 0; low < v.size(); ++low)
 	{
 		if(key.Get() == v[low].first.GetHash().Get())
 			return make_pair(low, true);
@@ -81,30 +81,21 @@ pair<size_t, bool> Search(const HashWrapper key, const vector<pair<stringAndHash
 	return make_pair(v.size(), false);
 }
 
-// Perform a binary search on a sorted vector. Return the key's location (or
-// proper insertion spot) in the first element of the pair, and "true" in
-// the second element if the key is already in the vector.
+// The dataset is sorted by its 'hash' key (which is indeed the only
+// allowed key used when adding a new element because it's unique), so
+// a bynary search is not possible: do a 'find'
 template <>
 pair<size_t, bool> Search(const char *key, const vector<pair<stringAndHash, double>> &v)
 {
-	// At each step of the search, we know the key is in [low, high).
-	size_t low = 0;
-	size_t high = v.size();
-
-	while(low != high)
+	for(size_t low = 0; low < v.size(); ++low)
 	{
-		size_t mid = (low + high) / 2;
-		int cmp = strcmp(key, v[mid].first.GetString());
+		int cmp = strcmp(key, v[low].first.GetString());
 		if(!cmp)
-			return make_pair(mid, true);
-
-		if(cmp < 0)
-			high = mid;
-		else
-			low = mid + 1;
+			return make_pair(low, true);
 	}
-	return make_pair(low, false);
+	return make_pair(v.size(), false);
 }
+
 
 
 double &Dictionary::operator[](const char *key)

--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Dictionary.h"
 
+#include <algorithm>
 #include <cstring>
 #include <mutex>
 #include <set>
@@ -153,4 +154,18 @@ double Dictionary::Get(const char *key) const
 double Dictionary::Get(const string &key) const
 {
 	return Get(key.c_str());
+}
+
+
+
+void Dictionary::CheckCollisions() const
+{
+	using element_type = pair<stringAndHash, double>;
+
+	auto equal_found = adjacent_find((*this).begin(), (*this).end()
+			, [](const element_type &a, const element_type &b) {
+		return a.first.GetHash().Get() == b.first.GetHash().Get();
+	});
+	if(equal_found != (*this).end())
+		throw runtime_error { "Found an hash collision on '" + string((*equal_found).first.GetString()) + "'" };
 }

--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -21,35 +21,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <set>
 #include <string>
 
-#include <chrono>
-#include <iostream>
-
 using namespace std;
 
 namespace {
-	using chrono::high_resolution_clock;
-	using chrono::duration_cast;
-	using chrono::duration;
-	using chrono::microseconds;
-
-	class Timing {
-	public:
-		Timing() = default;
-		void AddSample(duration<double, micro> sample) {
-			samples++;
-			average += (sample - average) / samples;
-		};
-		duration<double, micro> GetAverage() const { return average; }
-		int GetNumSamples() const { return samples; }
-		void Reset() {
-			average = {};
-			samples = 0;
-		}
-	private:
-		duration<double, micro> average;
-		int samples;
-	};
-
 	// String interning: return a pointer to a character string that matches the
 	// given string but has static storage duration.
 	const char *Intern(const char *key)
@@ -132,20 +106,7 @@ double &Dictionary::operator[](const string &key)
 
 double Dictionary::Get(HashWrapper hash_wr) const
 {
-	static Timing timing;
-	const auto start = high_resolution_clock::now();
-
 	pair<size_t, bool> pos = Search(hash_wr, *this);
-
-	const auto stop = high_resolution_clock::now();
-
-	timing.AddSample(stop - start);
-
-	if(timing.GetNumSamples() >= 5000)
-	{
-		cout << "Search time (hashed) = " << timing.GetAverage().count() << '\n';
-		timing.Reset();
-	}
 
 	return (pos.second ? data()[pos.first].second : 0.);
 }
@@ -154,20 +115,7 @@ double Dictionary::Get(HashWrapper hash_wr) const
 
 double Dictionary::Get(const char *key) const
 {
-	static Timing timing;
-	const auto start = high_resolution_clock::now();
-
 	pair<size_t, bool> pos = Search(key, *this);
-
-	const auto stop = high_resolution_clock::now();
-
-	timing.AddSample(stop - start);
-
-	if(timing.GetNumSamples() >= 5000)
-	{
-		cout << "Search time = " << timing.GetAverage().count() << '\n';
-		timing.Reset();
-	}
 
 	return (pos.second ? data()[pos.first].second : 0.);
 }

--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -106,6 +106,28 @@ double &Dictionary::operator[](const string &key)
 
 
 
+double Dictionary::Get(const HashWrapper &hash_wr) const
+{
+	static Timing timing;
+	const auto start = high_resolution_clock::now();
+
+	pair<size_t, bool> pos = Search(stringAndHash(hash_wr), *this);
+
+	const auto stop = high_resolution_clock::now();
+
+	timing.AddSample(stop - start);
+
+	if(timing.GetNumSamples() >= 5000)
+	{
+		cout << "Search time (hashed) = " << timing.GetAverage().count() << '\n';
+		timing.Reset();
+	}
+
+	return (pos.second ? data()[pos.first].second : 0.);
+}
+
+
+
 double Dictionary::Get(const char *key) const
 {
 	static Timing timing;

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -60,7 +60,7 @@ public:
 	double &operator[](const char *key);
 	double &operator[](const std::string &key);
 	// Get the value of a key, or 0 if it does not exist:
-	double Get(const HashWrapper hash_wr) const;
+	double Get(HashWrapper hash_wr) const;
 	double Get(const char *key) const;
 	double Get(const std::string &key) const;
 
@@ -72,7 +72,7 @@ public:
 
 
 
-// This class find hash collisions between handed dictionaries.
+// This class find hash collisions between keys in handed dictionaries.
 // If a collision is found 'AddKeysWhileChecking' throw a 'runtime_error'.
 class DictionaryCollisionChecker {
 public:

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "fnv1a.h"
 
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -67,10 +68,31 @@ public:
 	using std::vector<std::pair<stringAndHash, double>>::empty;
 	using std::vector<std::pair<stringAndHash, double>>::begin;
 	using std::vector<std::pair<stringAndHash, double>>::end;
-
-	void CheckCollisions() const;
 };
 
 
+
+// This class find hash collisions between handed dictionaries.
+// If a collision is found 'AddKeysWhileChecking' throw a 'runtime_error'.
+class DictionaryCollisionChecker {
+public:
+	DictionaryCollisionChecker() = default;
+
+	// Add the keys from the given Dictionary and
+	// ensure there aren't collisions, or throw
+	void AddKeysWhileChecking(const Dictionary &dict);
+
+
+private:
+	class hash_comparator {
+	public:
+		bool operator()(const stringAndHash &a, const stringAndHash &b)
+		{
+			return a.GetHash().Get() < b.GetHash().Get();
+		}
+	};
+
+	std::set<stringAndHash, hash_comparator> collected_keys;
+};
 
 #endif

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -84,9 +84,9 @@ public:
 		: str(str)
 		, hash(hash_fnv::fnv1a<hash_fnv::def_type>::hash(str))
 	{}
-	stringAndHash(const HashWrapper &h)
+	stringAndHash(HashWrapper h)
 		: str(nullptr)
-		, hash(h)
+		, hash(std::move(h))
 	{}
 
 	const char *GetString() const { return str; }
@@ -110,7 +110,7 @@ public:
 	double &operator[](const char *key);
 	double &operator[](const std::string &key);
 	// Get the value of a key, or 0 if it does not exist:
-	double Get(const HashWrapper &hash_wr) const;
+	double Get(const HashWrapper hash_wr) const;
 	double Get(const char *key) const;
 	double Get(const std::string &key) const;
 

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -118,6 +118,8 @@ public:
 	using std::vector<std::pair<stringAndHash, double>>::empty;
 	using std::vector<std::pair<stringAndHash, double>>::begin;
 	using std::vector<std::pair<stringAndHash, double>>::end;
+
+	void CheckCollisions() const;
 };
 
 

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -20,7 +20,49 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <utility>
 #include <vector>
 
+// Code from:
+// https://gist.github.com/filsinger/1255697/1972eb676b47116838edaacf923e60b9173199c2
+namespace hash_fnv
+{
+	using def_type = uint32_t;
 
+	template <typename S> struct fnv_internal;
+	template <typename S> struct fnv1;
+	template <typename S> struct fnv1a;
+
+	template <> struct fnv_internal<def_type>
+	{
+		constexpr static def_type default_offset_basis = 0x811C9DC5;
+		constexpr static def_type prime				   = 0x01000193;
+	};
+
+	template <> struct fnv1<def_type> : public fnv_internal<def_type>
+	{
+		constexpr static inline def_type hash(char const*const aString, const def_type val = default_offset_basis)
+		{
+			return (aString[0] == '\0') ? val : hash( &aString[1], ( val * prime ) ^ def_type(aString[0]) );
+		}
+	};
+
+	template <> struct fnv1a<def_type> : public fnv_internal<def_type>
+	{
+		constexpr static inline def_type hash(char const*const aString, const def_type val = default_offset_basis)
+		{
+			return (aString[0] == '\0') ? val : hash( &aString[1], ( val ^ def_type(aString[0]) ) * prime);
+		}
+	};
+} // namespace hash
+
+
+inline constexpr hash_fnv::def_type operator "" _fnv1 (const char* aString, size_t aStrlen)
+{
+	return hash_fnv::fnv1<hash_fnv::def_type>::hash(aString);
+}
+
+inline constexpr hash_fnv::def_type operator "" _fnv1a (const char* aString, size_t aStrlen)
+{
+	return hash_fnv::fnv1a<hash_fnv::def_type>::hash(aString);
+}
 
 // This class stores a mapping from character string keys to values, in a way
 // that prioritizes fast lookup time at the expense of longer construction time

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -68,13 +68,16 @@ class stringAndHash {
 public:
 	stringAndHash(const char *str)
 		: str(str)
+		, hash(hash_fnv::fnv1a<hash_fnv::def_type>::hash(str))
 	{}
 
 	const char *GetString() const { return str; }
+	const hash_fnv::def_type GetHash() const { return hash; }
 
 
 private:
 	const char *str;
+	hash_fnv::def_type hash;
 };
 
 // This class stores a mapping from character string keys to values, in a way

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -53,16 +53,19 @@ namespace hash_fnv
 	};
 } // namespace hash
 
+class HashWrapper {
+public:
+	constexpr explicit HashWrapper(hash_fnv::def_type h) : hash(h) {}
+	constexpr hash_fnv::def_type Get() const { return hash; }
+private:
+	hash_fnv::def_type hash;
+};
 
-inline constexpr hash_fnv::def_type operator "" _fnv1 (const char* aString, size_t aStrlen)
+inline constexpr HashWrapper operator "" _fnv1a (const char* aString, size_t aStrlen)
 {
-	return hash_fnv::fnv1<hash_fnv::def_type>::hash(aString);
+	return HashWrapper(hash_fnv::fnv1a<hash_fnv::def_type>::hash(aString));
 }
 
-inline constexpr hash_fnv::def_type operator "" _fnv1a (const char* aString, size_t aStrlen)
-{
-	return hash_fnv::fnv1a<hash_fnv::def_type>::hash(aString);
-}
 
 class stringAndHash {
 public:
@@ -72,12 +75,12 @@ public:
 	{}
 
 	const char *GetString() const { return str; }
-	const hash_fnv::def_type GetHash() const { return hash; }
+	const HashWrapper GetHash() const { return hash; }
 
 
 private:
 	const char *str;
-	hash_fnv::def_type hash;
+	HashWrapper hash;
 };
 
 // This class stores a mapping from character string keys to values, in a way

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -73,6 +73,10 @@ public:
 		: str(str)
 		, hash(hash_fnv::fnv1a<hash_fnv::def_type>::hash(str))
 	{}
+	stringAndHash(const HashWrapper &h) :
+		str(nullptr),
+		hash(h)
+	{}
 
 	const char *GetString() const { return str; }
 	const HashWrapper GetHash() const { return hash; }
@@ -93,6 +97,7 @@ public:
 	double &operator[](const char *key);
 	double &operator[](const std::string &key);
 	// Get the value of a key, or 0 if it does not exist:
+	double Get(const HashWrapper &hash_wr) const;
 	double Get(const char *key) const;
 	double Get(const std::string &key) const;
 

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -64,11 +64,24 @@ inline constexpr hash_fnv::def_type operator "" _fnv1a (const char* aString, siz
 	return hash_fnv::fnv1a<hash_fnv::def_type>::hash(aString);
 }
 
+class stringAndHash {
+public:
+	stringAndHash(const char *str)
+		: str(str)
+	{}
+
+	const char *GetString() const { return str; }
+
+
+private:
+	const char *str;
+};
+
 // This class stores a mapping from character string keys to values, in a way
 // that prioritizes fast lookup time at the expense of longer construction time
 // compared to an STL map. That makes it suitable for ship attributes, which are
 // changed much less frequently than they are queried.
-class Dictionary : private std::vector<std::pair<const char *, double>> {
+class Dictionary : private std::vector<std::pair<stringAndHash, double>> {
 public:
 	// Access a key for modifying it:
 	double &operator[](const char *key);
@@ -78,9 +91,9 @@ public:
 	double Get(const std::string &key) const;
 
 	// Expose certain functions from the underlying vector:
-	using std::vector<std::pair<const char *, double>>::empty;
-	using std::vector<std::pair<const char *, double>>::begin;
-	using std::vector<std::pair<const char *, double>>::end;
+	using std::vector<std::pair<stringAndHash, double>>::empty;
+	using std::vector<std::pair<stringAndHash, double>>::begin;
+	using std::vector<std::pair<stringAndHash, double>>::end;
 };
 
 

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -16,62 +16,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef DICTIONARY_H_
 #define DICTIONARY_H_
 
+#include "fnv1a.h"
+
 #include <string>
 #include <utility>
 #include <vector>
-
-// Code from:
-// https://gist.github.com/filsinger/1255697/1972eb676b47116838edaacf923e60b9173199c2
-namespace hash_fnv
-{
-	using def_type = uint32_t;
-
-	template <typename S> struct fnv_internal;
-	template <typename S> struct fnv1;
-	template <typename S> struct fnv1a;
-
-	template <> struct fnv_internal<def_type>
-	{
-		constexpr static def_type default_offset_basis = 0x811C9DC5;
-		constexpr static def_type prime = 0x01000193;
-	};
-
-	template <> struct fnv1<def_type> : public fnv_internal<def_type>
-	{
-		constexpr static inline def_type hash(char const *const aString, const def_type val = default_offset_basis)
-		{
-			return (aString[0] == '\0') ? val : hash(&aString[1], (val * prime) ^ def_type(aString[0]));
-		}
-	};
-
-	template <> struct fnv1a<def_type> : public fnv_internal<def_type>
-	{
-		constexpr static inline def_type hash(char const *const aString, const def_type val = default_offset_basis)
-		{
-			return (aString[0] == '\0') ? val : hash(&aString[1], (val ^ def_type(aString[0])) * prime);
-		}
-	};
-} // namespace hash
-
-
-
-// A tiny wrapper to reduce and prevent risks of type mismatch
-// when passing an hash to 'Dictionary::Get' method
-class HashWrapper {
-public:
-	constexpr explicit HashWrapper(hash_fnv::def_type h)
-		: hash(h)
-	{}
-	constexpr hash_fnv::def_type Get() const { return hash; }
-private:
-	hash_fnv::def_type hash;
-};
-
-
-inline constexpr HashWrapper operator "" _fnv1a (const char *aString, size_t aStrlen)
-{
-	return HashWrapper(hash_fnv::fnv1a<hash_fnv::def_type>::hash(aString));
-}
 
 
 
@@ -82,7 +31,7 @@ class stringAndHash {
 public:
 	stringAndHash(const char *str)
 		: str(str)
-		, hash(hash_fnv::fnv1a<hash_fnv::def_type>::hash(str))
+		, hash(hash_fnv1a::fnv1a<hash_fnv1a::def_type>::hash(str))
 	{}
 	stringAndHash(HashWrapper h)
 		: str(nullptr)

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -377,7 +377,7 @@ bool LocationFilter::Matches(const Ship &ship) const
 		set<string> shipAttributes;
 		for(const auto &attr : ship.Attributes().Attributes())
 			if(attr.second > 0.)
-				shipAttributes.insert(shipAttributes.end(), attr.first);
+				shipAttributes.insert(shipAttributes.end(), attr.first.GetString());
 		for(const set<string> &attr : attributes)
 			if(!SetsIntersect(attr, shipAttributes))
 				return false;

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -447,7 +447,7 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 		// have special functionality when negative, though, and are therefore
 		// allowed to have values less than 0.
 		double minimum = 0.;
-		auto it = MINIMUM_OVERRIDES.find(at.first);
+		auto it = MINIMUM_OVERRIDES.find(at.first.GetString());
 		if(it != MINIMUM_OVERRIDES.end())
 		{
 			minimum = it->second;
@@ -457,10 +457,10 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 		}
 
 		// Only automatons may have a "required crew" of 0.
-		if(!strcmp(at.first, "required crew"))
+		if(!strcmp(at.first.GetString(), "required crew"))
 			minimum = !attributes.Get("automaton");
 
-		double value = Get(at.first);
+		double value = Get(at.first.GetString());
 		// Allow for rounding errors:
 		if(value + at.second * count < minimum - EPS)
 			count = (value - minimum) / -at.second + EPS;
@@ -479,9 +479,9 @@ void Outfit::Add(const Outfit &other, int count)
 	mass += other.mass * count;
 	for(const auto &at : other.attributes)
 	{
-		attributes[at.first] += at.second * count;
-		if(fabs(attributes[at.first]) < EPS)
-			attributes[at.first] = 0.;
+		attributes[at.first.GetString()] += at.second * count;
+		if(fabs(attributes[at.first.GetString()]) < EPS)
+			attributes[at.first.GetString()] = 0.;
 	}
 
 	for(const auto &it : other.flareSprites)

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -343,8 +343,6 @@ void Outfit::Load(const DataNode &node)
 	};
 	convertScan("outfit");
 	convertScan("cargo");
-
-	attributes.CheckCollisions();
 }
 
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -312,11 +312,11 @@ void Outfit::Load(const DataNode &node)
 	// Only outfits with the jump drive and jump range attributes can
 	// use the jump range, so only keep track of the jump range on
 	// viable outfits.
-	if(attributes.Get("jump drive") && attributes.Get("jump range"))
-		GameData::AddJumpRange(attributes.Get("jump range"));
+	if(attributes.Get("jump drive"_fnv1a) && attributes.Get("jump range"_fnv1a))
+		GameData::AddJumpRange(attributes.Get("jump range"_fnv1a));
 
 	// Legacy support for turrets that don't specify a turn rate:
-	if(IsWeapon() && attributes.Get("turret mounts") && !TurretTurn() && !AntiMissile())
+	if(IsWeapon() && attributes.Get("turret mounts"_fnv1a) && !TurretTurn() && !AntiMissile())
 	{
 		SetTurretTurn(4.);
 		node.PrintTrace("Warning: Deprecated use of a turret without specified \"turret turn\":");
@@ -415,6 +415,13 @@ const Sprite *Outfit::Thumbnail() const
 
 
 
+double Outfit::Get(const HashWrapper &attribute) const
+{
+	return attributes.Get(attribute);
+}
+
+
+
 double Outfit::Get(const char *attribute) const
 {
 	return attributes.Get(attribute);
@@ -458,9 +465,9 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 
 		// Only automatons may have a "required crew" of 0.
 		if(!strcmp(at.first.GetString(), "required crew"))
-			minimum = !attributes.Get("automaton");
+			minimum = !attributes.Get("automaton"_fnv1a);
 
-		double value = Get(at.first.GetString());
+		double value = Get(at.first.GetHash());
 		// Allow for rounding errors:
 		if(value + at.second * count < minimum - EPS)
 			count = (value - minimum) / -at.second + EPS;

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -343,6 +343,8 @@ void Outfit::Load(const DataNode &node)
 	};
 	convertScan("outfit");
 	convertScan("cargo");
+
+	attributes.CheckCollisions();
 }
 
 

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -63,6 +63,7 @@ public:
 	// Get the image to display in the outfitter when buying this item.
 	const Sprite *Thumbnail() const;
 
+	double Get(const HashWrapper &attribute) const;
 	double Get(const char *attribute) const;
 	double Get(const std::string &attribute) const;
 	const Dictionary &Attributes() const;

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -315,19 +315,19 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	attributesHeight = 20;
 
 	bool hasNormalAttributes = false;
-	for(const pair<const char *, double> &it : outfit.Attributes())
+	for(const pair<stringAndHash, double> &it : outfit.Attributes())
 	{
 		static const set<string> SKIP = {
 			"outfit space", "weapon capacity", "engine capacity", "gun ports", "turret mounts"
 		};
-		if(SKIP.count(it.first))
+		if(SKIP.count(it.first.GetString()))
 			continue;
 
-		auto sit = SCALE.find(it.first);
+		auto sit = SCALE.find(it.first.GetString());
 		double scale = (sit == SCALE.end() ? 1. : SCALE_LABELS[sit->second].first);
 		string units = (sit == SCALE.end() ? "" : SCALE_LABELS[sit->second].second);
 
-		auto bit = BOOLEAN_ATTRIBUTES.find(it.first);
+		auto bit = BOOLEAN_ATTRIBUTES.find(it.first.GetString());
 		if(bit != BOOLEAN_ATTRIBUTES.end())
 		{
 			attributeLabels.emplace_back(bit->second);
@@ -336,7 +336,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		}
 		else
 		{
-			attributeLabels.emplace_back(static_cast<string>(it.first) + ":");
+			attributeLabels.emplace_back(static_cast<string>(it.first.GetString()) + ":");
 			attributeValues.emplace_back(Format::Number(it.second * scale) + units);
 			attributesHeight += 20;
 		}

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -706,9 +706,9 @@ void OutfitterPanel::Sell(bool toStorage)
 			{
 				// Determine how many of this ammo I must sell to also sell the launcher.
 				int mustSell = 0;
-				for(const pair<const char *, double> &it : ship->Attributes().Attributes())
+				for(const pair<stringAndHash, double> &it : ship->Attributes().Attributes())
 					if(it.second < 0.)
-						mustSell = max<int>(mustSell, it.second / ammo->Get(it.first));
+						mustSell = max<int>(mustSell, it.second / ammo->Get(it.first.GetString()));
 
 				if(mustSell)
 				{
@@ -762,21 +762,21 @@ void OutfitterPanel::FailSell(bool toStorage) const
 		else
 		{
 			for(const Ship *ship : playerShips)
-				for(const pair<const char *, double> &it : selectedOutfit->Attributes())
-					if(ship->Attributes().Get(it.first) < it.second)
+				for(const pair<stringAndHash, double> &it : selectedOutfit->Attributes())
+					if(ship->Attributes().Get(it.first.GetString()) < it.second)
 					{
 						for(const auto &sit : ship->Outfits())
-							if(sit.first->Get(it.first) < 0.)
+							if(sit.first->Get(it.first.GetString()) < 0.)
 							{
 								GetUI()->Push(new Dialog("You cannot " + verb + " this outfit, "
-									"because that would cause your ship's \"" + it.first +
+									"because that would cause your ship's \"" + it.first.GetString() +
 									"\" value to be reduced to less than zero. "
 									"To " + verb + " this outfit, you must " + verb + " the " +
 									sit.first->DisplayName() + " outfit first."));
 								return;
 							}
 						GetUI()->Push(new Dialog("You cannot " + verb + " this outfit, "
-							"because that would cause your ship's \"" + it.first +
+							"because that would cause your ship's \"" + it.first.GetString() +
 							"\" value to be reduced to less than zero."));
 						return;
 					}

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -488,7 +488,7 @@ namespace {
 			{
 				const Outfit &outfit = it.second;
 				for(const auto &attribute : outfit.Attributes())
-					attributes.insert(attribute.first);
+					attributes.insert(attribute.first.GetString());
 			}
 			cout << "name" << ',' << "category" << ',' << "cost" << ',' << "mass";
 			for(const auto &attribute : attributes)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -782,7 +782,8 @@ void Ship::FinishLoading(bool isNewInstance)
 	}
 	if(attributes.Get("drag"_fnv1a) <= 0.)
 	{
-		warning += "Defaulting " + string(attributes.Get("drag"_fnv1a) ? "invalid" : "missing") + " \"drag\" attribute to 100.0\n";
+		warning += "Defaulting " + string(attributes.Get("drag"_fnv1a) ? "invalid" : "missing")
+			+ " \"drag\" attribute to 100.0\n";
 		attributes.Set("drag", 100.);
 	}
 
@@ -1955,7 +1956,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 			if(hull < cost)
 				thrustCommand *= hull / cost;
 
-			cost = attributes.Get((thrustCommand > 0.) ?	"thrusting fuel"_fnv1a : "reverse thrusting fuel"_fnv1a);
+			cost = attributes.Get((thrustCommand > 0.) ? "thrusting fuel"_fnv1a : "reverse thrusting fuel"_fnv1a);
 			if(fuel < cost)
 				thrustCommand *= fuel / cost;
 
@@ -1974,18 +1975,30 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 				{
 					double scale = fabs(thrustCommand);
 
-					shields -= scale * attributes.Get(isThrusting ? "thrusting shields" : "reverse thrusting shields");
-					hull -= scale * attributes.Get(isThrusting ? "thrusting hull" : "reverse thrusting hull");
-					energy -= scale * attributes.Get(isThrusting ? "thrusting energy" : "reverse thrusting energy");
-					fuel -= scale * attributes.Get(isThrusting ? "thrusting fuel" : "reverse thrusting fuel");
-					heat += scale * attributes.Get(isThrusting ? "thrusting heat" : "reverse thrusting heat");
-					discharge += scale * attributes.Get(isThrusting ? "thrusting discharge" : "reverse thrusting discharge");
-					corrosion += scale * attributes.Get(isThrusting ? "thrusting corrosion" : "reverse thrusting corrosion");
-					ionization += scale * attributes.Get(isThrusting ? "thrusting ion" : "reverse thrusting ion");
-					burning += scale * attributes.Get(isThrusting ? "thrusting burn" : "reverse thrusting burn");
-					leakage += scale * attributes.Get(isThrusting ? "thrusting leakage" : "reverse thrusting leakage");
-					slowness += scale * attributes.Get(isThrusting ? "thrusting slowing" : "reverse thrusting slowing");
-					disruption += scale * attributes.Get(isThrusting ? "thrusting disruption" : "reverse thrusting disruption");
+					shields -= scale * attributes.Get(isThrusting
+						? "thrusting shields"_fnv1a : "reverse thrusting shields"_fnv1a);
+					hull -= scale * attributes.Get(isThrusting
+						? "thrusting hull"_fnv1a : "reverse thrusting hull"_fnv1a);
+					energy -= scale * attributes.Get(isThrusting
+						? "thrusting energy"_fnv1a : "reverse thrusting energy"_fnv1a);
+					fuel -= scale * attributes.Get(isThrusting
+						? "thrusting fuel"_fnv1a : "reverse thrusting fuel"_fnv1a);
+					heat += scale * attributes.Get(isThrusting
+						? "thrusting heat"_fnv1a : "reverse thrusting heat"_fnv1a);
+					discharge += scale * attributes.Get(isThrusting
+						? "thrusting discharge"_fnv1a : "reverse thrusting discharge"_fnv1a);
+					corrosion += scale * attributes.Get(isThrusting
+						? "thrusting corrosion"_fnv1a : "reverse thrusting corrosion"_fnv1a);
+					ionization += scale * attributes.Get(isThrusting
+						? "thrusting ion"_fnv1a : "reverse thrusting ion"_fnv1a);
+					burning += scale * attributes.Get(isThrusting
+						? "thrusting burn"_fnv1a : "reverse thrusting burn"_fnv1a);
+					leakage += scale * attributes.Get(isThrusting
+						? "thrusting leakage"_fnv1a : "reverse thrusting leakage"_fnv1a);
+					slowness += scale * attributes.Get(isThrusting
+						? "thrusting slowing"_fnv1a : "reverse thrusting slowing"_fnv1a);
+					disruption += scale * attributes.Get(isThrusting
+						? "thrusting disruption"_fnv1a : "reverse thrusting disruption"_fnv1a);
 
 					acceleration += angle.Unit() * (thrustCommand * thrust / mass);
 				}
@@ -1995,21 +2008,21 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 				&& !CannotAct();
 		if(applyAfterburner)
 		{
-			thrust = attributes.Get("afterburner thrust");
-			double shieldCost = attributes.Get("afterburner shields");
-			double hullCost = attributes.Get("afterburner hull");
-			double energyCost = attributes.Get("afterburner energy");
-			double fuelCost = attributes.Get("afterburner fuel");
-			double heatCost = -attributes.Get("afterburner heat");
+			thrust = attributes.Get("afterburner thrust"_fnv1a);
+			double shieldCost = attributes.Get("afterburner shields"_fnv1a);
+			double hullCost = attributes.Get("afterburner hull"_fnv1a);
+			double energyCost = attributes.Get("afterburner energy"_fnv1a);
+			double fuelCost = attributes.Get("afterburner fuel"_fnv1a);
+			double heatCost = -attributes.Get("afterburner heat"_fnv1a);
 
-			double dischargeCost = attributes.Get("afterburner discharge");
-			double corrosionCost = attributes.Get("afterburner corrosion");
-			double ionCost = attributes.Get("afterburner ion");
-			double leakageCost = attributes.Get("afterburner leakage");
-			double burningCost = attributes.Get("afterburner burn");
+			double dischargeCost = attributes.Get("afterburner discharge"_fnv1a);
+			double corrosionCost = attributes.Get("afterburner corrosion"_fnv1a);
+			double ionCost = attributes.Get("afterburner ion"_fnv1a);
+			double leakageCost = attributes.Get("afterburner leakage"_fnv1a);
+			double burningCost = attributes.Get("afterburner burn"_fnv1a);
 
-			double slownessCost = attributes.Get("afterburner slowing");
-			double disruptionCost = attributes.Get("afterburner disruption");
+			double slownessCost = attributes.Get("afterburner slowing"_fnv1a);
+			double disruptionCost = attributes.Get("afterburner disruption"_fnv1a);
 
 			if(thrust && shields >= shieldCost && hull >= hullCost
 				&& energy >= energyCost && fuel >= fuelCost && heat >= heatCost)
@@ -2120,7 +2133,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 				{
 					isBoarding = false;
 					bool isEnemy = government->IsEnemy(target->government);
-					if(isEnemy && Random::Real() < target->Attributes().Get("self destruct"))
+					if(isEnemy && Random::Real() < target->Attributes().Get("self destruct"_fnv1a))
 					{
 						Messages::Add("The " + target->ModelName() + " \"" + target->Name()
 							+ "\" has activated its self-destruct mechanism.", Messages::Importance::High);
@@ -2174,29 +2187,29 @@ void Ship::DoGeneration()
 		// 4. Shields of carried fighters
 		// 5. Transfer of excess energy and fuel to carried fighters.
 
-		const double hullAvailable = attributes.Get("hull repair rate")
-			* (1. + attributes.Get("hull repair multiplier"));
-		const double hullEnergy = (attributes.Get("hull energy")
-			* (1. + attributes.Get("hull energy multiplier"))) / hullAvailable;
-		const double hullFuel = (attributes.Get("hull fuel")
-			* (1. + attributes.Get("hull fuel multiplier"))) / hullAvailable;
-		const double hullHeat = (attributes.Get("hull heat")
-			* (1. + attributes.Get("hull heat multiplier"))) / hullAvailable;
+		const double hullAvailable = attributes.Get("hull repair rate"_fnv1a)
+			* (1. + attributes.Get("hull repair multiplier"_fnv1a));
+		const double hullEnergy = (attributes.Get("hull energy"_fnv1a)
+			* (1. + attributes.Get("hull energy multiplier"_fnv1a))) / hullAvailable;
+		const double hullFuel = (attributes.Get("hull fuel"_fnv1a)
+			* (1. + attributes.Get("hull fuel multiplier"_fnv1a))) / hullAvailable;
+		const double hullHeat = (attributes.Get("hull heat"_fnv1a)
+			* (1. + attributes.Get("hull heat multiplier"_fnv1a))) / hullAvailable;
 		double hullRemaining = hullAvailable;
 		if(!hullDelay)
-			DoRepair(hull, hullRemaining, attributes.Get("hull"), energy, hullEnergy, fuel, hullFuel, heat, hullHeat);
+			DoRepair(hull, hullRemaining, attributes.Get("hull"_fnv1a), energy, hullEnergy, fuel, hullFuel, heat, hullHeat);
 
-		const double shieldsAvailable = attributes.Get("shield generation")
-			* (1. + attributes.Get("shield generation multiplier"));
-		const double shieldsEnergy = (attributes.Get("shield energy")
-			* (1. + attributes.Get("shield energy multiplier"))) / shieldsAvailable;
-		const double shieldsFuel = (attributes.Get("shield fuel")
-			* (1. + attributes.Get("shield fuel multiplier"))) / shieldsAvailable;
-		const double shieldsHeat = (attributes.Get("shield heat")
-			* (1. + attributes.Get("shield heat multiplier"))) / shieldsAvailable;
+		const double shieldsAvailable = attributes.Get("shield generation"_fnv1a)
+			* (1. + attributes.Get("shield generation multiplier"_fnv1a));
+		const double shieldsEnergy = (attributes.Get("shield energy"_fnv1a)
+			* (1. + attributes.Get("shield energy multiplier"_fnv1a))) / shieldsAvailable;
+		const double shieldsFuel = (attributes.Get("shield fuel"_fnv1a)
+			* (1. + attributes.Get("shield fuel multiplier"_fnv1a))) / shieldsAvailable;
+		const double shieldsHeat = (attributes.Get("shield heat"_fnv1a)
+			* (1. + attributes.Get("shield heat multiplier"_fnv1a))) / shieldsAvailable;
 		double shieldsRemaining = shieldsAvailable;
 		if(!shieldDelay)
-			DoRepair(shields, shieldsRemaining, attributes.Get("shields"),
+			DoRepair(shields, shieldsRemaining, attributes.Get("shields"_fnv1a),
 				energy, shieldsEnergy, fuel, shieldsFuel, heat, shieldsHeat);
 
 		if(!bays.empty())
@@ -2221,24 +2234,24 @@ void Ship::DoGeneration()
 			{
 				Ship &ship = *it.second;
 				if(!hullDelay)
-					DoRepair(ship.hull, hullRemaining, ship.attributes.Get("hull"),
+					DoRepair(ship.hull, hullRemaining, ship.attributes.Get("hull"_fnv1a),
 						energy, hullEnergy, heat, hullHeat, fuel, hullFuel);
 				if(!shieldDelay)
-					DoRepair(ship.shields, shieldsRemaining, ship.attributes.Get("shields"),
+					DoRepair(ship.shields, shieldsRemaining, ship.attributes.Get("shields"_fnv1a),
 						energy, shieldsEnergy, heat, shieldsHeat, fuel, shieldsFuel);
 			}
 
 			// Now that there is no more need to use energy for hull and shield
 			// repair, if there is still excess energy, transfer it.
-			double energyRemaining = energy - attributes.Get("energy capacity");
-			double fuelRemaining = fuel - attributes.Get("fuel capacity");
+			double energyRemaining = energy - attributes.Get("energy capacity"_fnv1a);
+			double fuelRemaining = fuel - attributes.Get("fuel capacity"_fnv1a);
 			for(const pair<double, Ship *> &it : carried)
 			{
 				Ship &ship = *it.second;
 				if(energyRemaining > 0.)
-					DoRepair(ship.energy, energyRemaining, ship.attributes.Get("energy capacity"));
+					DoRepair(ship.energy, energyRemaining, ship.attributes.Get("energy capacity"_fnv1a));
 				if(fuelRemaining > 0.)
-					DoRepair(ship.fuel, fuelRemaining, ship.attributes.Get("fuel capacity"));
+					DoRepair(ship.fuel, fuelRemaining, ship.attributes.Get("fuel capacity"_fnv1a));
 			}
 		}
 		// Decrease the shield and hull delays by 1 now that shield generation
@@ -2256,70 +2269,70 @@ void Ship::DoGeneration()
 	// TODO: Mothership gives status resistance to carried ships?
 	if(ionization)
 	{
-		double ionResistance = attributes.Get("ion resistance");
-		double ionEnergy = attributes.Get("ion resistance energy") / ionResistance;
-		double ionFuel = attributes.Get("ion resistance fuel") / ionResistance;
-		double ionHeat = attributes.Get("ion resistance heat") / ionResistance;
+		double ionResistance = attributes.Get("ion resistance"_fnv1a);
+		double ionEnergy = attributes.Get("ion resistance energy"_fnv1a) / ionResistance;
+		double ionFuel = attributes.Get("ion resistance fuel"_fnv1a) / ionResistance;
+		double ionHeat = attributes.Get("ion resistance heat"_fnv1a) / ionResistance;
 		DoStatusEffect(isDisabled, ionization, ionResistance,
 			energy, ionEnergy, fuel, ionFuel, heat, ionHeat);
 	}
 
 	if(disruption)
 	{
-		double disruptionResistance = attributes.Get("disruption resistance");
-		double disruptionEnergy = attributes.Get("disruption resistance energy") / disruptionResistance;
-		double disruptionFuel = attributes.Get("disruption resistance fuel") / disruptionResistance;
-		double disruptionHeat = attributes.Get("disruption resistance heat") / disruptionResistance;
+		double disruptionResistance = attributes.Get("disruption resistance"_fnv1a);
+		double disruptionEnergy = attributes.Get("disruption resistance energy"_fnv1a) / disruptionResistance;
+		double disruptionFuel = attributes.Get("disruption resistance fuel"_fnv1a) / disruptionResistance;
+		double disruptionHeat = attributes.Get("disruption resistance heat"_fnv1a) / disruptionResistance;
 		DoStatusEffect(isDisabled, disruption, disruptionResistance,
 			energy, disruptionEnergy, fuel, disruptionFuel, heat, disruptionHeat);
 	}
 
 	if(slowness)
 	{
-		double slowingResistance = attributes.Get("slowing resistance");
-		double slowingEnergy = attributes.Get("slowing resistance energy") / slowingResistance;
-		double slowingFuel = attributes.Get("slowing resistance fuel") / slowingResistance;
-		double slowingHeat = attributes.Get("slowing resistance heat") / slowingResistance;
+		double slowingResistance = attributes.Get("slowing resistance"_fnv1a);
+		double slowingEnergy = attributes.Get("slowing resistance energy"_fnv1a) / slowingResistance;
+		double slowingFuel = attributes.Get("slowing resistance fuel"_fnv1a) / slowingResistance;
+		double slowingHeat = attributes.Get("slowing resistance heat"_fnv1a) / slowingResistance;
 		DoStatusEffect(isDisabled, slowness, slowingResistance,
 			energy, slowingEnergy, fuel, slowingFuel, heat, slowingHeat);
 	}
 
 	if(discharge)
 	{
-		double dischargeResistance = attributes.Get("discharge resistance");
-		double dischargeEnergy = attributes.Get("discharge resistance energy") / dischargeResistance;
-		double dischargeFuel = attributes.Get("discharge resistance fuel") / dischargeResistance;
-		double dischargeHeat = attributes.Get("discharge resistance heat") / dischargeResistance;
+		double dischargeResistance = attributes.Get("discharge resistance"_fnv1a);
+		double dischargeEnergy = attributes.Get("discharge resistance energy"_fnv1a) / dischargeResistance;
+		double dischargeFuel = attributes.Get("discharge resistance fuel"_fnv1a) / dischargeResistance;
+		double dischargeHeat = attributes.Get("discharge resistance heat"_fnv1a) / dischargeResistance;
 		DoStatusEffect(isDisabled, discharge, dischargeResistance,
 			energy, dischargeEnergy, fuel, dischargeFuel, heat, dischargeHeat);
 	}
 
 	if(corrosion)
 	{
-		double corrosionResistance = attributes.Get("corrosion resistance");
-		double corrosionEnergy = attributes.Get("corrosion resistance energy") / corrosionResistance;
-		double corrosionFuel = attributes.Get("corrosion resistance fuel") / corrosionResistance;
-		double corrosionHeat = attributes.Get("corrosion resistance heat") / corrosionResistance;
+		double corrosionResistance = attributes.Get("corrosion resistance"_fnv1a);
+		double corrosionEnergy = attributes.Get("corrosion resistance energy"_fnv1a) / corrosionResistance;
+		double corrosionFuel = attributes.Get("corrosion resistance fuel"_fnv1a) / corrosionResistance;
+		double corrosionHeat = attributes.Get("corrosion resistance heat"_fnv1a) / corrosionResistance;
 		DoStatusEffect(isDisabled, corrosion, corrosionResistance,
 			energy, corrosionEnergy, fuel, corrosionFuel, heat, corrosionHeat);
 	}
 
 	if(leakage)
 	{
-		double leakResistance = attributes.Get("leak resistance");
-		double leakEnergy = attributes.Get("leak resistance energy") / leakResistance;
-		double leakFuel = attributes.Get("leak resistance fuel") / leakResistance;
-		double leakHeat = attributes.Get("leak resistance heat") / leakResistance;
+		double leakResistance = attributes.Get("leak resistance"_fnv1a);
+		double leakEnergy = attributes.Get("leak resistance energy"_fnv1a) / leakResistance;
+		double leakFuel = attributes.Get("leak resistance fuel"_fnv1a) / leakResistance;
+		double leakHeat = attributes.Get("leak resistance heat"_fnv1a) / leakResistance;
 		DoStatusEffect(isDisabled, leakage, leakResistance,
 			energy, leakEnergy, fuel, leakFuel, heat, leakHeat);
 	}
 
 	if(burning)
 	{
-		double burnResistance = attributes.Get("burn resistance");
-		double burnEnergy = attributes.Get("burn resistance energy") / burnResistance;
-		double burnFuel = attributes.Get("burn resistance fuel") / burnResistance;
-		double burnHeat = attributes.Get("burn resistance heat") / burnResistance;
+		double burnResistance = attributes.Get("burn resistance"_fnv1a);
+		double burnEnergy = attributes.Get("burn resistance energy"_fnv1a) / burnResistance;
+		double burnFuel = attributes.Get("burn resistance fuel"_fnv1a) / burnResistance;
+		double burnHeat = attributes.Get("burn resistance heat"_fnv1a) / burnResistance;
 		DoStatusEffect(isDisabled, burning, burnResistance,
 			energy, burnEnergy, fuel, burnFuel, heat, burnHeat);
 	}
@@ -2328,23 +2341,23 @@ void Ship::DoGeneration()
 	// maximum capacity for the rest of the turn, but must be clamped to the
 	// maximum here before they gain more. This is so that, for example, a ship
 	// with no batteries but a good generator can still move.
-	energy = min(energy, attributes.Get("energy capacity"));
-	fuel = min(fuel, attributes.Get("fuel capacity"));
+	energy = min(energy, attributes.Get("energy capacity"_fnv1a));
+	fuel = min(fuel, attributes.Get("fuel capacity"_fnv1a));
 
 	heat -= heat * HeatDissipation();
 	if(heat > MaximumHeat())
 	{
 		isOverheated = true;
-		double heatRatio = Heat() / (1. + attributes.Get("overheat damage threshold"));
+		double heatRatio = Heat() / (1. + attributes.Get("overheat damage threshold"_fnv1a));
 		if(heatRatio > 1.)
-			hull -= attributes.Get("overheat damage rate") * heatRatio;
+			hull -= attributes.Get("overheat damage rate"_fnv1a) * heatRatio;
 	}
 	else if(heat < .9 * MaximumHeat())
 		isOverheated = false;
 
-	double maxShields = attributes.Get("shields");
+	double maxShields = attributes.Get("shields"_fnv1a);
 	shields = min(shields, maxShields);
-	double maxHull = attributes.Get("hull");
+	double maxHull = attributes.Get("hull"_fnv1a);
 	hull = min(hull, maxHull);
 
 	isDisabled = isOverheated || hull < MinimumHull() || (!crew && RequiredCrew());
@@ -2366,35 +2379,35 @@ void Ship::DoGeneration()
 		if(currentSystem)
 		{
 			double scale = .2 + 1.8 / (.001 * position.Length() + 1);
-			fuel += currentSystem->SolarWind() * .03 * scale * sqrt(attributes.Get("ramscoop"));
+			fuel += currentSystem->SolarWind() * .03 * scale * sqrt(attributes.Get("ramscoop"_fnv1a));
 
 			double solarScaling = currentSystem->SolarPower() * scale;
-			energy += solarScaling * attributes.Get("solar collection");
-			heat += solarScaling * attributes.Get("solar heat");
+			energy += solarScaling * attributes.Get("solar collection"_fnv1a);
+			heat += solarScaling * attributes.Get("solar heat"_fnv1a);
 		}
 
 		double coolingEfficiency = CoolingEfficiency();
-		energy += attributes.Get("energy generation") - attributes.Get("energy consumption");
-		fuel += attributes.Get("fuel generation");
-		heat += attributes.Get("heat generation");
-		heat -= coolingEfficiency * attributes.Get("cooling");
+		energy += attributes.Get("energy generation"_fnv1a) - attributes.Get("energy consumption"_fnv1a);
+		fuel += attributes.Get("fuel generation"_fnv1a);
+		heat += attributes.Get("heat generation"_fnv1a);
+		heat -= coolingEfficiency * attributes.Get("cooling"_fnv1a);
 
 		// Convert fuel into energy and heat only when the required amount of fuel is available.
-		if(attributes.Get("fuel consumption") <= fuel)
+		if(attributes.Get("fuel consumption"_fnv1a) <= fuel)
 		{
-			fuel -= attributes.Get("fuel consumption");
-			energy += attributes.Get("fuel energy");
-			heat += attributes.Get("fuel heat");
+			fuel -= attributes.Get("fuel consumption"_fnv1a);
+			energy += attributes.Get("fuel energy"_fnv1a);
+			heat += attributes.Get("fuel heat"_fnv1a);
 		}
 
 		// Apply active cooling. The fraction of full cooling to apply equals
 		// your ship's current fraction of its maximum temperature.
-		double activeCooling = coolingEfficiency * attributes.Get("active cooling");
+		double activeCooling = coolingEfficiency * attributes.Get("active cooling"_fnv1a);
 		if(activeCooling > 0. && heat > 0. && energy >= 0.)
 		{
 			// Although it's a misuse of this feature, handle the case where
 			// "active cooling" does not require any energy.
-			double coolingEnergy = attributes.Get("cooling energy");
+			double coolingEnergy = attributes.Get("cooling energy"_fnv1a);
 			if(coolingEnergy)
 			{
 				double spentEnergy = min(energy, coolingEnergy * min(1., Heat()));
@@ -2427,7 +2440,8 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships, vector<Visual> &visuals)
 
 	for(Bay &bay : bays)
 		if(bay.ship
-			&& ((bay.ship->Commands().Has(Command::DEPLOY) && !Random::Int(40 + 20 * !bay.ship->attributes.Get("automaton")))
+			&& ((bay.ship->Commands().Has(Command::DEPLOY)
+			&& !Random::Int(40 + 20 * !bay.ship->attributes.Get("automaton"_fnv1a)))
 			|| (ejecting && !Random::Int(6))))
 		{
 			// Resupply any ships launching of their own accord.
@@ -2453,7 +2467,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships, vector<Visual> &visuals)
 
 				// This ship will refuel naturally based on the carrier's fuel
 				// collection, but the carrier may have some reserves to spare.
-				double maxFuel = bay.ship->attributes.Get("fuel capacity");
+				double maxFuel = bay.ship->attributes.Get("fuel capacity"_fnv1a);
 				if(maxFuel)
 				{
 					double spareFuel = fuel - navigation.JumpFuel();
@@ -2521,7 +2535,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder, bool nonDocking)
 		SetShipToAssist(shared_ptr<Ship>());
 		SetTargetShip(shared_ptr<Ship>());
 		bool helped = victim->isDisabled;
-		victim->hull = min(max(victim->hull, victim->MinimumHull() * 1.5), victim->attributes.Get("hull"));
+		victim->hull = min(max(victim->hull, victim->MinimumHull() * 1.5), victim->attributes.Get("hull"_fnv1a));
 		victim->isDisabled = false;
 		// Transfer some fuel if needed.
 		if(victim->NeedsFuel() && CanRefuel(*victim))

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -919,7 +919,7 @@ void Ship::Save(DataWriter &out) const
 					out.Write("hyperdrive out sound", it.first->Name());
 			for(const auto &it : baseAttributes.Attributes())
 				if(it.second)
-					out.Write(it.first, it.second);
+					out.Write(it.first.GetString(), it.second);
 		}
 		out.EndChild();
 

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -273,10 +273,16 @@ void UniverseObjects::CheckReferences()
 
 	// News are never serialized or named, except by events (which would then define them).
 
-	// Outfit names are used by a number of classes.
-	for(auto &&it : outfits)
-		if(it.second.TrueName().empty())
-			NameAndWarn("outfit", it);
+	{
+		DictionaryCollisionChecker dcc;
+		// Outfit names are used by a number of classes.
+		for(auto &&it : outfits)
+		{
+			dcc.AddKeysWhileChecking(it.second.Attributes());
+			if(it.second.TrueName().empty())
+				NameAndWarn("outfit", it);
+		}
+	}
 	// Outfitters are never serialized.
 	for(const auto &it : outfitSales)
 		if(it.second.empty() && !deferred["outfitter"].count(it.first))

--- a/source/fnv1a.h
+++ b/source/fnv1a.h
@@ -1,0 +1,62 @@
+/* fnv1a.h
+Copyright (c) 2017 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef FNV1A_HASHING_H_
+#define FNV1A_HASHING_H_
+
+#include <cstdint>
+
+// Code initially grabbed from:
+// https://gist.github.com/filsinger/1255697/1972eb676b47116838edaacf923e60b9173199c2
+namespace hash_fnv1a
+{
+	using def_type = uint32_t;
+
+	template <typename S> struct fnv1a;
+
+	template <> struct fnv1a<def_type>
+	{
+		constexpr static def_type default_offset_basis = 0x811C9DC5;
+		constexpr static def_type prime = 0x01000193;
+
+		constexpr static inline def_type hash(char const *const aString, const def_type val = default_offset_basis)
+		{
+			return (aString[0] == '\0') ? val : hash(&aString[1], (val ^ def_type(aString[0])) * prime);
+		}
+	};
+} // namespace hash_fnv1a
+
+
+
+// A tiny wrapper to prevent risks of type mismatch
+// when passing an hash to 'Dictionary::Get' method
+class HashWrapper {
+public:
+	constexpr explicit HashWrapper(hash_fnv1a::def_type h)
+		: hash(h)
+	{}
+	constexpr hash_fnv1a::def_type Get() const { return hash; }
+private:
+	hash_fnv1a::def_type hash;
+};
+
+
+inline constexpr HashWrapper operator "" _fnv1a (const char *aString, std::size_t aStrlen)
+{
+	return HashWrapper(hash_fnv1a::fnv1a<hash_fnv1a::def_type>::hash(aString));
+}
+
+
+#endif


### PR DESCRIPTION
**Performance:** This PR improve performance of `Dictionary` by using [FNV1a](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function) hashing funtion

## Summary

As outlined in #6329, a lot of time is spent in `Dictionary::Get` which is called hundreds of time per frame.

In order to lower the time spent there, instead of doing a full string comparison the strings are hashed and only these hash are compared.

This alone leads to a slight performance boost (around ~3%) because hashes are stored _inside_ the vector and there's no need to fetch strings from memory, making the hash computation comparable to the time needed to fetch those strings from (a "colder") memory.

But the bulk of the change is that the hashing algorithm is 'constexpr'-essed: this means that hashes can (and should) be computed at compile-time whenever it's possible, removing needs to hash strings at runtime.
Having a string hash directly computed at compile time means that at runtime the hash is directly used in the binary search inside the vector, reducing time by an average of 20/30% (though peak perfomance halve that time).

The compile time hashing of strings is obtained by simply adding the suffix `_fnv1a` to every string literal passed to `Dictionary::Get`, which cause the selection of an overload that use directly the hash to perform the lookup.

## Couple of Notes

* `stringAndHash` is needed because the _name_ (= the string) of an attribute is still needed: I think that storing the pointer to the char on the same structure is the easier way to retrieve these strings
* An hash collision may happens: I provide a [runtime-check](https://github.com/endless-sky/endless-sky/commit/a721a36feb9ce38e638408acd05e10722ebbb1e2) which trigger an exception if this happens because I think it's a good way to report a collision, but I'm open to changes.
* I improved runtime hashing string literals for only when players are in the game screen, I think further PR can improve loading times and performance in the various screen (starport, outfitter etc...)

## Save File
N/A

## Testing Done

The main test is a bit unusual, but provide a big number of samples:
the [first commit](https://github.com/endless-sky/endless-sky/commit/c3c0a781ddd71b5d038fe3755bed2948a7e94613) instruments the `Dictionary::Get` method using `std::chrono` and print the time averaged over 5 thousand samples.

In [that commit ](https://github.com/endless-sky/endless-sky/commit/91c4ec07dab1ac398a58f34da52be4f0c25bb7e1) the overload use the same method to provide profiling info.

The [last commit](https://github.com/endless-sky/endless-sky/commit/beb2bc7fb73b1f9f6fa72b6915b14bbc0e2f8d2e) revert the profiling.

Here some result obtained on my (really old laptop) machine:
[Dictionary_Get_Timing.ods](https://github.com/endless-sky/endless-sky/files/10068964/Dictionary_Get_Timing.ods)

## Additional Testing

* Tested that sorted insertion of elements by their hash keep vector sorted
* Tested that there aren't collision with the given set of strings

## Performance Impact

Reduction of 20/30% of times spent in `Dictionary::Get` for every compile-time string literal (peaking at ~50%), 
and a reduction of ~3% for run-time strings.
