### PR TITLE
Let out-of-system escorts without fuel plan their next move

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1598,7 +1598,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 	const System *currentSystem = ship.GetSystem();
 	bool hasFuelCapacity = ship.Attributes().Get("fuel capacity");
 	bool needsFuel = ship.NeedsFuel();
-	bool isStaying = ship.GetPersonality().IsStaying() || !hasFuelCapacity || needsFuel;
+	bool isStaying = ship.GetPersonality().IsStaying() || !hasFuelCapacity;
 	bool parentIsHere = (currentSystem == parent.GetSystem());
 	// Check if the parent has a target planet that is in the parent's system.
 	const Planet *parentPlanet = (parent.GetTargetStellar() ? parent.GetTargetStellar()->GetPlanet() : nullptr);


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #5541.

## Fix Details
This is a small fix-up of #7379 fixing a new report in #5541.

MoveEscort() has two branches that were blocked if an escort was out of fuel. These two branches were responsible for planning how an escort should follow its parent, and already contain code handling the out-of-fuel condition, by either landing to refuel (via SelectRoute) or by moving to the system center as a fallback. Also flying through a wormhole without fuel was blocked as an option as a side effect.

This patch enables taking those branches for escorts without fuel.

## Testing Done
I have tested with the new savegame submitted by eternal-sorrow on Oct 20 at #5541. The escorts now take the wormhole, refuel and join the flagship without user interaction after loading the savegame.

I have also flown around Human/Hai Space and the Ember Waste for some time with a fleet of 6 escorts with various drives and fuel capacities and noticed no strange side effects.

## Save File
#5541 has a savegame by eternal-sorrow.