### PR TITLE
Fix deprecated `go get` usage in CD release upload

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install github-release
         run: |
-          go get github.com/github-release/github-release
+          go install github.com/github-release/github-release@latest
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: Set environment variables


### PR DESCRIPTION
**Bugfix:** This PR addresses the failing CD workflows.

## Fix Details

Here's the error for convenience:
```
> Run go get github.com/github-release/github-release
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

## Testing Done
/

## Save File
/

---
PS: Accidentally created the branch here, delete it with the merge.