### PR TITLE
Fix condition for copyright CI

### DIFF
--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -64,7 +64,7 @@ jobs:
 
   validate-copyright:
     needs: changed
-    if: ${{ needs.changed.outputs.copyright }}
+    if: ${{ needs.changed.outputs.copyright == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The check copyright CI always ran because the condition always evaluated to true because it was wrong. Not anymore!