### PR TITLE
Add a coarse check on `Mask::Collide`

### DIFF
--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -282,12 +282,12 @@ namespace {
 
 	Point nearestPointOfSegmentToOrigin(Point start, Point end)
 	{
-		if ((start - end).Length() < EPS) return start;
+		if((start - end).Length() < EPS) return start;
 
 		double ret = start.Dot(start - end) / start.DistanceSquared(end);
 
-		if (ret < 0.) return start;
-		if (ret > 1.) return end;
+		if(ret < 0.) return start;
+		if(ret > 1.) return end;
 
 		return start * (1. - ret) + end * ret;
 	}

--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -278,21 +278,6 @@ namespace {
 			radius = max(radius, p.LengthSquared());
 		return sqrt(radius);
 	}
-
-
-	Point NearestPointOfSegmentToOrigin(Point start, Point end)
-	{
-		if((start - end).Length() < EPS) return start;
-
-		double ret = start.Dot(start - end) / start.DistanceSquared(end);
-
-		if(ret <= 0.)
-			return start;
-		if(ret >= 1.)
-			return end;
-
-		return start * (1. - ret) + end * ret;
-	}
 }
 
 
@@ -348,7 +333,7 @@ double Mask::Collide(Point sA, Point vA, Angle facing) const
 		return 1.;
 
 	// Bail out even if segment doesn't touch a circle of 'radius'
-	if(NearestPointOfSegmentToOrigin(sA, sA + vA).Length() > radius)
+	if(DistanceSquared(Point(), sA, sA + vA) > (radius * radius))
 		return 1.;
 
 

--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -25,6 +25,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
+	const double EPS = 0.0000000001;
+
 	// Trace out outlines from an image frame.
 	void Trace(const ImageBuffer &image, int frame, vector<vector<Point>> &raw)
 	{
@@ -280,6 +282,8 @@ namespace {
 
 	Point nearestPointOfSegmentToOrigin(Point start, Point end)
 	{
+		if ((start - end).Length() < EPS) return start;
+
 		double ret = start.Dot(start - end) / start.DistanceSquared(end);
 
 		if (ret < 0.) return start;

--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -22,8 +22,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <cmath>
 #include <limits>
 
-#include <iostream>
-
 using namespace std;
 
 namespace {
@@ -289,29 +287,6 @@ namespace {
 
 		return start * (1. - ret) + end * ret;
 	}
-
-	class Measure {
-	public:
-		Measure()
-			: m_runs(0)
-			, m_contain(0)
-			, m_nearest(0)
-			, m_touch(0)
-			, m_intersect(0)
-		{}
-		void AnotherRun() { m_runs++; }
-		void AnotherContains() { m_contain++; }
-		void AnotherNotTouching() { m_touch++; }
-		void AnotherNearest() { m_nearest++; }
-		void AnotherInstersection() { m_intersect++; }
-
-
-		int m_runs;
-		int m_contain;
-		int m_nearest;
-		int m_touch;
-		int m_intersect;
-	};
 }
 
 
@@ -361,31 +336,14 @@ bool Mask::IsLoaded() const
 // is no collision, the return value is 1.
 double Mask::Collide(Point sA, Point vA, Angle facing) const
 {
-	static Measure measure;
-	if (measure.m_runs >= 5000) {
-		cout << "Mask::Collide results:\n"
-			<< "  NotTouching   = " << measure.m_touch << '\n'
-			<< "  Nearest out   = " << measure.m_nearest << '\n'
-			<< "  Contains      = " << measure.m_contain << '\n'
-			<< "  Intersections = " << measure.m_touch << '\n';
-		measure = {};
-	}
-	measure.AnotherRun();
-
 	// Bail out if we're too far away to possibly be touching.
 	double distance = sA.Length();
 	if(!IsLoaded() || distance > radius + vA.Length())
-	{
-		measure.AnotherNotTouching();
 		return 1.;
-	}
 
 	// Bail out even if segment doesn't touch a circle of 'radius'
 	if(nearestPointOfSegmentToOrigin(sA, sA + vA).Length() > radius)
-	{
-		measure.AnotherNearest();
 		return 1.;
-	}
 
 
 	// Rotate into the mask's frame of reference.
@@ -400,12 +358,8 @@ double Mask::Collide(Point sA, Point vA, Angle facing) const
 	// For simplicity, use a ray pointing straight downwards. A segment then
 	// intersects only if its x coordinates span the point's coordinates.
 	if(distance <= radius && Contains(sA))
-	{
-		measure.AnotherContains();
 		return 0.;
-	}
 
-	measure.AnotherInstersection();
 	return Intersection(sA, vA);
 }
 

--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -25,8 +25,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	const double EPS = 0.0000000001;
-
 	// Trace out outlines from an image frame.
 	void Trace(const ImageBuffer &image, int frame, vector<vector<Point>> &raw)
 	{
@@ -332,10 +330,9 @@ double Mask::Collide(Point sA, Point vA, Angle facing) const
 	if(!IsLoaded() || distance > radius + vA.Length())
 		return 1.;
 
-	// Bail out even if segment doesn't touch a circle of 'radius'
+	// Bail out even if the segment doesn't touch a circle of 'radius'.
 	if(DistanceSquared(Point(), sA, sA + vA) > (radius * radius))
 		return 1.;
-
 
 	// Rotate into the mask's frame of reference.
 	sA = (-facing).Rotate(sA);

--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -280,14 +280,16 @@ namespace {
 	}
 
 
-	Point nearestPointOfSegmentToOrigin(Point start, Point end)
+	Point NearestPointOfSegmentToOrigin(Point start, Point end)
 	{
 		if((start - end).Length() < EPS) return start;
 
 		double ret = start.Dot(start - end) / start.DistanceSquared(end);
 
-		if(ret < 0.) return start;
-		if(ret > 1.) return end;
+		if(ret <= 0.)
+			return start;
+		if(ret >= 1.)
+			return end;
 
 		return start * (1. - ret) + end * ret;
 	}
@@ -346,7 +348,7 @@ double Mask::Collide(Point sA, Point vA, Angle facing) const
 		return 1.;
 
 	// Bail out even if segment doesn't touch a circle of 'radius'
-	if(nearestPointOfSegmentToOrigin(sA, sA + vA).Length() > radius)
+	if(NearestPointOfSegmentToOrigin(sA, sA + vA).Length() > radius)
 		return 1.;
 
 

--- a/source/Mask.h
+++ b/source/Mask.h
@@ -40,7 +40,8 @@ public:
 
 	// Check if this mask intersects the given line segment (from sA to vA). If
 	// it does, return the fraction of the way along the segment where the
-	// intersection occurs. The sA should be relative to this object's center.
+	// intersection occurs. The sA should be relative to this object's center,
+	// while vA should be relative to sA.
 	// If this object contains the given point, the return value is 0. If there
 	// is no collision, the return value is 1.
 	double Collide(Point sA, Point vA, Angle facing) const;


### PR DESCRIPTION
**Performance:** This PR improve performance of `Mask::Collide` by adding a cheap "broad-phase" test

## Summary

As outlined in #6329, one of the (most?) prominent code path is:

> CollisionSet::Line (26.1%) spends a lot of time inserting into a set and calling Mask::Collide.

As far I can see, the member `Mask::Collide` has three ways to return:
1) After checking that the distance of the starting point is so big that even with removing the distance to the end it can "reach" the `Mask::radius`... Put another way: if you draw a circle around starting point of radius equal to the length of the segment, you never touch a circle of `Mask::radius`
2) There's a check to see if the starting point is contained in the `Mask` outline
3) There's a check to see if there's an intersection

Without (I admit, I'm guessing...) checking code, I think (1) is the only coarse check, while (2) and (3) are way more costly (I guess they are checking against the outline, so a lot of things...).
So I added an additional test that helps skipping 2) and 3) : it verifies the minimal distance between the segment and the center (which is, as stated in [this](https://github.com/endless-sky/endless-sky/blob/a17591ed48040a77ce5de072185c33efe27c9abd/source/Mask.cpp#L323) comment, the origin of the mask.

Done.

...Am I reading that correctly?

## Couple of Notes

* Why `Mask::Collide` return a `double`? Is it needed?
* I tried to write a test but it seems this is the biggest task because `Mask` needs an `ImageBuffer` and obtaining a single `ImageBuffer` is not easy...

## Save File
N/A

## Testing Done

...Loaded a save, seems all is fine...

## Additional Testing

* Tested that the algorithm in `nearestPointOfSegmentToOrigin` never return a point nearer than the nearest of its vertices (added an `if` which throw, never thrown)

## Performance Impact

...Faster?