### PR TITLE
honour CPPFLAGS from environment

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -21,6 +21,8 @@ if 'CXX' in os.environ:
 	env['CXX'] = os.environ['CXX']
 if 'CXXFLAGS' in os.environ:
 	env.Append(CCFLAGS = os.environ['CXXFLAGS'])
+if 'CPPFLAGS' in os.environ:
+	env.Append(CCFLAGS = os.environ['CPPFLAGS'])
 if 'LDFLAGS' in os.environ:
 	env.Append(LINKFLAGS = os.environ['LDFLAGS'])
 if 'AR' in os.environ:


### PR DESCRIPTION
SConstruct already has support for `CXX`, `CXXFLAGS` and `LDFLAGS`. This patch adds `CPPFLAGS`, used by the preprocessing step.

This is handy for e.g. Debian builds which may put some hardening flags there.