### PR TITLE
CI only: Support file args for check_code_style.py

### DIFF
--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -564,10 +564,16 @@ def check_include(sanitized_lines, original_lines, file):
 
 
 if __name__ == '__main__':
+	import sys
 	errors = 0
 	warnings = 0
 
-	files = glob.glob('**/*.cpp', recursive=True) + glob.glob('**/*.h', recursive=True)
+	files = []
+	if len(sys.argv[1:]) > 0:
+		for pattern in sys.argv[1:]:
+			files += glob.glob(pattern, recursive=True)
+	else:
+		files = glob.glob('**/*.cpp', recursive=True) + glob.glob('**/*.h', recursive=True)
 	files.sort()
 
 	for file in files:

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -14,6 +14,7 @@
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
 import glob
+import sys
 
 import regex as re
 
@@ -564,7 +565,6 @@ def check_include(sanitized_lines, original_lines, file):
 
 
 if __name__ == '__main__':
-	import sys
 	errors = 0
 	warnings = 0
 


### PR DESCRIPTION
Summary
-------

This is a CI only change meant for local development only.

This change adds support to `utils/check_code_style.py` to optionally receive one or more patterns (or even single files) for the style checker to run against.

Example usage
-------------

For local development, you can run a really fast style check against only files you've changed.  The following is an example for Linux developers.

```bash
git fetch https://github.com/endless-sky/endless-sky.git master
git diff --name-only $(git merge-base FETCH_HEAD HEAD) HEAD '*.cpp' '*.h' \
  | xargs python utils/check_code_style.py
```

The above command runs in under 2 seconds when timed with `time`.  Normally `check_code_style.py` takes over 15 seconds.

Performance Impact
------------------

No impact to GitHub actions.  Drastic improvement for local development.