### PR TITLE
Danforth is now timid when facing Sestor ships in Wanderers: Alpha Surveillance G

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1390,7 +1390,7 @@ mission "Wanderers: Alpha Surveillance G"
 	
 	npc accompany save
 		government "Navy (Oathkeeper)"
-		personality escort heroic
+		personality escort timid
 		ship "Cruiser (Jump)" "N.S. Peacemaker"
 	npc
 		government "Alpha"


### PR DESCRIPTION
**Content (Missions)**

## Summary
Danforth's cruiser is now timid rather than heroic during Wanderers: Alpha Surveillance G.
This follows immediately from Danforth saying "My ship is no match for them. Let's get out of here.", so going off that he should probably be trying to avoid combat, rather than flying his cruiser directly at a 349. 
