### PR TITLE
Fix the project check CI when adding a new test file.

### DIFF
--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -11,6 +11,7 @@ on:
       - 'EndlessSky.xcodeproj/**'
       - '*.cbp'
       - 'source/**'
+      - 'tests/unit/**'
       - 'utils/check_*.sh'
   pull_request:
     types: [opened, synchronize]
@@ -20,6 +21,7 @@ on:
       - 'EndlessSky.xcodeproj/**'
       - '*.cbp'
       - 'source/**'
+      - 'tests/unit/**'
       - 'utils/check_*.sh'
 
 concurrency:

--- a/EndlessSkyTests.cbp
+++ b/EndlessSkyTests.cbp
@@ -75,6 +75,7 @@
 		<Unit filename="tests/unit/src/test_conditionsStore.cpp" />
 		<Unit filename="tests/unit/src/test_datafile.cpp" />
 		<Unit filename="tests/unit/src/test_datanode.cpp" />
+		<Unit filename="tests/unit/src/test_dictionary.cpp" />
 		<Unit filename="tests/unit/src/test_esuuid.cpp" />
 		<Unit filename="tests/unit/src/test_exclusiveItem.cpp" />
 		<Unit filename="tests/unit/src/test_firecommand.cpp" />


### PR DESCRIPTION
The project checking CI doesn't run if only new unit tests were added because of a missing trigger path. This PR fixes this issue and adds the missing file to the CodeBlocks project.