### PR TITLE
Some fixes to the unit tests

### DIFF
--- a/tests/unit/src/test_esuuid.cpp
+++ b/tests/unit/src/test_esuuid.cpp
@@ -55,7 +55,13 @@ struct Identifiable {
 };
 struct InstantiableContainer : public Identifiable {
 	std::vector<InstantiableContainer> items;
-	std::vector<InstantiableContainer> others;
+	std::list<InstantiableContainer> others;
+
+	InstantiableContainer() noexcept = default;
+	InstantiableContainer(const InstantiableContainer &) noexcept = default;
+	InstantiableContainer &operator=(const InstantiableContainer &) noexcept = default;
+	InstantiableContainer(InstantiableContainer &&other) noexcept = default;
+	InstantiableContainer &operator=(InstantiableContainer &&other) noexcept = default;
 
 	std::vector<std::string> GetIds() const {
 		auto result = std::vector<std::string>{

--- a/tests/unit/src/test_esuuid.cpp
+++ b/tests/unit/src/test_esuuid.cpp
@@ -60,8 +60,8 @@ struct InstantiableContainer : public Identifiable {
 	InstantiableContainer() noexcept = default;
 	InstantiableContainer(const InstantiableContainer &) noexcept = default;
 	InstantiableContainer &operator=(const InstantiableContainer &) noexcept = default;
-	InstantiableContainer(InstantiableContainer &&other) noexcept = default;
-	InstantiableContainer &operator=(InstantiableContainer &&other) noexcept = default;
+	InstantiableContainer(InstantiableContainer &&) noexcept = default;
+	InstantiableContainer &operator=(InstantiableContainer &&) noexcept = default;
 
 	std::vector<std::string> GetIds() const {
 		auto result = std::vector<std::string>{

--- a/tests/unit/src/text/test_displaytext.cpp
+++ b/tests/unit/src/text/test_displaytext.cpp
@@ -34,8 +34,10 @@ using T = DisplayText;
 TEST_CASE( "DisplayText class", "[text][DisplayText]" ) {
 	SECTION( "Class Traits" ) {
 		CHECK_FALSE( std::is_trivial<T>::value );
-		CHECK( std::is_standard_layout<T>::value );
 		CHECK( std::is_nothrow_destructible<T>::value );
+		// Contains a string, thus will not be standard layout unless std::string is.
+		CHECK( std::is_standard_layout<T>::value ==
+			std::is_standard_layout<std::string>::value );
 		// Contains a string, thus will not be trivially destructible unless std::string is.
 		CHECK_FALSE( std::is_trivially_destructible<T>::value );
 		CHECK( std::is_trivially_destructible<T>::value ==


### PR DESCRIPTION
- Uses `std::list` instead of having two vectors (the defaulted noexcept move constructors need to be added because std::list has a throwing move constructor)
- Makes the standard layout check be dependent on std::string, since if it's not (like on the MS STL) the test fails