### PR TITLE
refactor(code): Remove universal ramscoop

### DIFF
--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -152,7 +152,7 @@ outfit "Ramscoop"
 	"outfit space" -10
 	"ramscoop" 1
 	description "In the early days of space exploration, when ships could travel through half a dozen systems before encountering an established colony where they could refuel, ramscoops were an essential piece of equipment, harvesting plasma from the solar wind to refill your hyperspace fuel tanks. Although you can install more than one ramscoop, additional ramscoops on a single ship are not as effective as the first."
-	description "	(As a safety measure, all ships are able to harvest tiny amounts of fuel by flying close to a star, but this outfit allows you to accumulate fuel much more quickly. The closer you are to the star, the faster fuel will accumulate.)"
+	description "	Different kinds of stars will generate varying levels of fuel in the solar wind, but in all cases the closer you are to the star, the faster fuel will accumulate."
 
 outfit "Catalytic Ramscoop"
 	category "Systems"

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2346,13 +2346,11 @@ void Ship::DoGeneration()
 		PauseAnimation();
 	else
 	{
-		// Ramscoops work much better when close to the system center. Even if a
-		// ship has no ramscoop, it can harvest a tiny bit of fuel by flying
-		// close to the star. Carried fighters can't collect fuel or energy this way.
+		// Ramscoops work much better when close to the system center.
 		if(currentSystem)
 		{
 			double scale = .2 + 1.8 / (.001 * position.Length() + 1);
-			fuel += currentSystem->SolarWind() * .03 * scale * (sqrt(attributes.Get("ramscoop")) + .05 * scale);
+			fuel += currentSystem->SolarWind() * .03 * scale * sqrt(attributes.Get("ramscoop"));
 
 			double solarScaling = currentSystem->SolarPower() * scale;
 			// Overheated ships produce half as much energy from solar collection.


### PR DESCRIPTION
**Feature:**

## Feature Details
This is an alternate PR to PR #7460 which *only* removes the universal ramscoop. @warp-core suggested that just removing the universal ramscoop without transferring it onto the various drives would be preferable, so here it is by request. I would like to make it clear I think this PR is the better one, however I was under the impression that some people preferred the compromise of removing the universal ramscoop from being baked into the game engine, and instead putting it out where it is accessible to content creators, plug-in creators, and people editing their datafiles.

## Issue:
- Universal fuel ramscoop trivializes fuel management, ensuring that there is never any real risk to disregarding one's fuel gauge.
- Universal fuel ramscoop also creates the lore that any ship in any configuration can reach any system, limited only by its drive type. Ex. a stock shuttle with just a hyperdrive can visit every system in human and hai space without ever needing to land, ask for help to refuel, or loot fuel from a disabled ship. The same stock shuttle but with a Jump Drive could visit every non-hidden system in the galaxy under the same conditions. Yes, it will take a while, but it is still possible. This reinforces the lack of value in exploring, since no effort or risk is involved in doing so.
- Given that the Protagonist is not special or unique, it is expected that NPCs have the same capabilities as the protagonist, and as such also benefit from this trivialization of fuel access.
- Fuel is, effectively, nothing but a waiting game, and running out of fuel does nothing more than force the player to waste some time.
- This also trivializes ramscoops in general, as it means that getting an actual ramscoop is really only necessary if one needs to regain fuel fast, such as in combat to support afterburners or flamethrowers. It functionally isn't necessary for exploration or long range travel, since it will just take up space that is probably needed for irreplaceable outfits like combat stuff.
- This disrespects the capabilities of our players. Managing fuel is not a super hard task, but it is the one challenge or difficulty that currently has a built-in mechanism to ensure that the player never stays at zero fuel, ever. Not even for a few seconds. (caveat: Except at Sag A*). In discussion, what amounts to "but what about the poor new players?" has come up a few times, to which I would like to point out that the EV/O/N franchise, which inspired Endless Sky, had fuel as a hard limit (and fuel cost money, no-one would refuel you for free, and ramscoops didn't work as well), and yet the games were sufficiently popular to inspire MZ to make an entire new game just to be able to play it again. (and many other people to make sequels too.) This suggests to me that our players are very much more capable than we give them credit for.

## Benefits:
- We have a fuel gauge, but it currently isn't much more than an ammo bar for flamethrowers and afterburners. Fuel being a meaningful restriction lends credence to the prominent placement of the fuel bar on our displays.
- Fuel management is an early-game challenge, where the player's primary focus is on learning how to fly, navigate, and find their way around. It is not a particularly hard challenge, but one that is appropriate to new players and people in the early game. It is a challenge that can be overcome in a variety of ways, such as having to intercept a weak pirate or other target in order to steal fuel, or convince a friendly ship to help you out.
- It is also a challenge that can be "solved" by mid & late game players in a variety of ways: A whole variety of outfits that provide ramscoops, coalition has a fuel *generator*, and of course Remnant ships have built-in ramscoops. Players using fleets could also choose to have a tanker ship along specifically for the purpose of carrying bulk quantities of fuel and/or ramscoops (and in fact at least two factions do/will have tanker ships; which doesn't make a lot of sense in the lore if all ships just regenerate fuel on their own without assistance)
- Respect: Let people outfit their ships, and thus create their own experience, as they will. If they want ramscoop, there are plenty of options available. If they don't, there is no need to force them to have it.

## Testing Done
Played the game normally.

### Automated Tests Added
none

## Performance Impact
No visible impact, but there is likely an infinitesimal improvement as it removes two operations done at the end of every ramscoop calculation.


## Future directions and alternate means of preventing soft-locks

Excluding the universal ramscoop, we currently have the following options for players when they get stuck in a system and need to continue onwards:
- Land and refuel. This costs 1 day of game time. Not always available.
- Attack someone, disable them, and board them to take their fuel. This costs combat effort.
- Ask a passing neutral/friendly for assistance. There's almost always someone around to ask for help. Just costs a bit of RL time waiting for them.
- Ask authors for help. Not always possible if someone has attacked the authors, but authors also show up everywhere, including plenty of places that don't have frequent spawns of other things.

There has also been discussion that perhaps the emergency regen should be removed, but instead have some other sort of emergency handling implemented. Some options I've seen mentioned or just thought of:
1. Have a tutorial style "get out of jail free" rescue that triggers the first time a player runs out of fuel in an uninhabited system. If they spend more than 5mins without getting fuel, then trigger a message: "Terrified of being stuck in this system, you carefully fiddle with your your fuel system and manage to collect just enough fuel for a jump. Choose your destination carefully."
2. Have a system whereby, when you are out of fuel and in a system without friendly spawns, the timer on Author ships gets sped up so they will arrive more regularly to help you.
3. Consumable fuel pods. Treated like secondary weapons that you have to select and use, ships can only hold one in a small mount on their hyperdrive. Use it, and you suddenly get a jump worth of fuel, but use up the pod. I suppose theoretically one could have a rack to hold more of them, which could be an interesting way to manage fuel differently.
4. Have a way to call for help. Maybe each ship comes with a one-time-use distress beacon that summons a friendly search-and-rescue ship that will appear and give you some fuel.
