### PR TITLE
Improve error given on instantiating event with invalid planet or system references

### DIFF
--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -269,8 +269,11 @@ string GameAction::Validate() const
 {
 	// Events which get activated by this action must be valid.
 	for(auto &&event : events)
-		if(!event.first->IsValid())
-			return "event \"" + event.first->Name() + "\"";
+	{
+		string reason = event.first->IsValid();
+		if(!reason.empty())
+			return "event \"" + event.first->Name() + "\" - Reason: " + reason;
+	}
 
 	// Transferred content must be defined & valid.
 	for(auto &&it : giftShips)

--- a/source/GameEvent.cpp
+++ b/source/GameEvent.cpp
@@ -18,7 +18,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "DataWriter.h"
 #include "GameData.h"
 #include "Government.h"
-#include "Logger.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "System.h"

--- a/source/GameEvent.cpp
+++ b/source/GameEvent.cpp
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "DataWriter.h"
 #include "GameData.h"
 #include "Government.h"
+#include "Logger.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "System.h"
@@ -190,7 +191,8 @@ const Date &GameEvent::GetDate() const
 
 // Check that this GameEvent has been loaded from a file (vs. referred to only
 // by name), and that the systems & planets it references are similarly defined.
-bool GameEvent::IsValid() const
+// Returns an empty string if it is valid. If not, a reason will be given in the string.
+string GameEvent::IsValid() const
 {
 	// When Apply is called, we mutate the universe definition before we update
 	// the player's knowledge of the universe. Thus, to determine if a system or
@@ -200,13 +202,13 @@ bool GameEvent::IsValid() const
 	for(auto &&systems : {systemsToVisit, systemsToUnvisit})
 		for(auto &&system : systems)
 			if(!system->IsValid() && !deferred["system"].count(system->Name()))
-				return false;
+				return "contains invalid system \"" + system->Name() + "\".";
 	for(auto &&planets : {planetsToVisit, planetsToUnvisit})
 		for(auto &&planet : planets)
 			if(!planet->IsValid() && !deferred["planet"].count(planet->TrueName()))
-				return false;
+				return "contains invalid planet \"" + planet->TrueName() + "\".";
 
-	return isDefined;
+	return isDefined ? "" : "not defined";
 }
 
 

--- a/source/GameEvent.h
+++ b/source/GameEvent.h
@@ -61,7 +61,8 @@ public:
 
 	// Check if this GameEvent has been loaded (vs. simply referred to) and
 	// if it references any items that have not been defined.
-	bool IsValid() const;
+	// Returns an empty string if it is valid. If not, a reason will be given in the string.
+	string IsValid() const;
 
 	const Date &GetDate() const;
 	void SetDate(const Date &date);

--- a/source/GameEvent.h
+++ b/source/GameEvent.h
@@ -62,7 +62,7 @@ public:
 	// Check if this GameEvent has been loaded (vs. simply referred to) and
 	// if it references any items that have not been defined.
 	// Returns an empty string if it is valid. If not, a reason will be given in the string.
-	string IsValid() const;
+	std::string IsValid() const;
 
 	const Date &GetDate() const;
 	void SetDate(const Date &date);


### PR DESCRIPTION
**Feature:**

## Feature Details
GameEvent::IsValid() will now return a string that will be empty if the event is valid or have a reason (either a planet or system it refers to is not valid or it is not defined) if it is not.
GameAction::Validate() will print this string along with its existing error message to help make fixing stuff easier.
