### PR TITLE
Feat: add a save for the last spaceport

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -443,6 +443,8 @@ void PlayerInfo::Save() const
 			for(int i = 0; i < 3; ++i)
 				if(Files::Exists(files[i + 1]))
 					Files::Move(files[i + 1], files[i]);
+			if(planet->HasSpaceport())
+				Save(root + "~~last-spaceport.txt");
 		}
 	}
 


### PR DESCRIPTION
**Feature:**

## Feature Details
As pointed out by this comment https://github.com/endless-sky/endless-sky/pull/7730#issuecomment-1329872648 a last spaceport save would be nice to have.
So this PR adds exactly that.

## UI Screenshots
N/A

## Usage Examples
When you're lost in space you know what last save was "safe".

## Testing Done
I did not test this given I'm not on my main computer but there is no way this fails, right?
Used "last-spaceport.txt" as a name so it doesnt mess with anything since there are no spaces or special characters.

### Automated Tests Added
N/A

## Performance Impact
N/A
