### PR TITLE
Hai Reveal: label smugglers as mission targets

### DIFF
--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -509,7 +509,7 @@ fleet "Smuggler (Hai Traffickers)"
 	government "Smuggler (Hai Trafficker)"
 	names "civilian"
 	cargo 0
-	personality timid
+	personality timid target
 	variant 3
 		"Blackbird (Hai Trafficker)"
 	variant 2


### PR DESCRIPTION
**Feature:** The Smuggler ships are hard to identify, even if you're in the system with one, because they look similar to other ships. There's almost no visual difference. This PR gives them the "target" personality, so they show up as mission targets. They are, in fact, targets of a mission, so they certainly should have that personality.

Thanks to @bene-dictator for identifying this problem.

EDIT: After a long discussion (see comments) it seems the plan is to change the colors to be a mix of pirate and merchant swizzles, so the ships are totally indistinguishable from regular ones, except that they're blinking due to the target personality. This is because there is no sane reason why the smugglers would all paint their ships differently than everyone else.

This PR must be merged before we can give the smugglers the same swizzles as as pirates and merchants, otherwise it'll be impossible to find them at all.

## UI Screenshots
![smuggler-mission-target](https://user-images.githubusercontent.com/116329264/204581892-021cb0a9-1bdd-4a92-8898-3e9709027983.png)

## Testing Done
Hunted some smugglers with and without this change.

## Performance Impact
N/A