### PR TITLE
Quarg Consider their Outfits and Ships Atrocities

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -787,8 +787,18 @@ government "Quarg"
 		"Hai (Wormhole Access)" .01
 		"Pirate" -.01
 		"Pirate (Devil-Run Gang)" -.01
+	"death sentence" "quarg imprisonment"
 	"hostile hail" "hostile quarg"
 	"hostile disabled hail" "hostile quarg"
+	atrocities
+		"Nanotech Battery"
+		"Antimatter Core"
+		"Quarg Skylance"
+		"Quarg Anti-Missile"
+		"Intrusion Countermeasures"
+		"Medium Graviton Thruster"
+		"Medium Graviton Steering"
+		"Quantum Shield Generator"
 
 government "Remnant"
 	swizzle 0

--- a/data/quarg/quarg missions.txt
+++ b/data/quarg/quarg missions.txt
@@ -259,3 +259,18 @@ mission "Ask Quarg About Coalition Early"
 			label end
 			`	Before you can ask it anything else, the Quarg bids you farewell, and walks away.`
 				decline
+
+
+
+mission "Quarg Ships Atrocity"
+	landing
+	invisible
+	source
+		government "Quarg"
+	to offer
+		or
+			has "ship model: Quarg Skylark"
+			has "ship model: Quarg Wardragon"
+	on offer
+		conversation "quarg imprisonment"
+

--- a/data/quarg/quarg.txt
+++ b/data/quarg/quarg.txt
@@ -52,7 +52,7 @@ phrase "hostile quarg"
 		"You must live in peace... or leave the galaxy."
 
 conversation "quarg imprisonment"
-	`Your ship loses all power immediately upon touching down on the landing pad. As you walk around to try and find the problem, you pass by your hatch, already opened, and with dozens of Quarg coming in. They are all clad in elegant full-body armor suits.`
+	`Your ship loses all power immediately upon touching down on the landing pad. As you walk around to try and find the problem, you pass by your hatch. You find that it is already opened with dozens of Quarg coming in, all clad in elegant full-body armor suits.`
 	`	"<first> <last>, you are found to be in illegal possession of Quarg equipment. Our devices are precious, and ours alone. Though it is regrettable, we must seize you."`
 	`	They don't allow you to get as much as a word out before one of the guards has locked your arms behind your back, completely halting your attempts to fight back with surprisingly little effort. You are brought before something akin to a Quarg jury, where they lecture you for several hours on how dangerous it is for Quarg apparatus to be stolen and used so lightly by others. At the end of it all, they sentence you to life imprisonment.`
 	`	You spend the rest of your days in the same cell, which although large and comfortable, quickly proves plain and dull. You're kept in very good health, and are well fed, but the Quarg do not allow you to leave the cell, and seldom entertain your attempts at striking conversation. You get few visitors, and can only wonder what life would've been like had you the chance to live out all these years in freedom, the captain of a starship.`

--- a/data/quarg/quarg.txt
+++ b/data/quarg/quarg.txt
@@ -51,6 +51,12 @@ phrase "hostile quarg"
 		"You have only a short time to learn to live together in peace."
 		"You must live in peace... or leave the galaxy."
 
+conversation "quarg imprisonment"
+	`Your ship loses all power immediately upon touching down on the landing pad. As you walk around to try and find the problem, you pass by your hatch, already opened, and with dozens of Quarg coming in. They are all clad in elegant, clean full-body armor suits.`
+	`	"<first> <last>, you are found to be in illegal possession of Quarg equipment. Our devices are precious, and ours alone. Though it is regrettable, we must seize you."`
+	`	They don't allow you to get as much as a word out before one of the guards has locked your arms behind your back, completely halting your attempts to fight back with surprisingly little effort. You're brought before something akin to a Quarg jury, where you are lectured on for several hours on how dangerous it is for Quarg apparatus to be stolen and used so lightly by others. At the end of it all, they sentece you to life imprisonment.`
+	`	You spend the rest of your days in the same cell, which although large and comfortable, quickly proves plain and dull. You're kept in very good health, and are well fed, but the Quarg do not allow you to leave the cell, and seldom entertain your attempts at striking conversation. You get few visitors, and can only wonder what life would've been like had you the chance to live out all these years in freedom, the captain of a starship.`
+
 fleet "Quarg"
 	government "Quarg"
 	names "quarg"

--- a/data/quarg/quarg.txt
+++ b/data/quarg/quarg.txt
@@ -52,9 +52,9 @@ phrase "hostile quarg"
 		"You must live in peace... or leave the galaxy."
 
 conversation "quarg imprisonment"
-	`Your ship loses all power immediately upon touching down on the landing pad. As you walk around to try and find the problem, you pass by your hatch, already opened, and with dozens of Quarg coming in. They are all clad in elegant, clean full-body armor suits.`
+	`Your ship loses all power immediately upon touching down on the landing pad. As you walk around to try and find the problem, you pass by your hatch, already opened, and with dozens of Quarg coming in. They are all clad in elegant full-body armor suits.`
 	`	"<first> <last>, you are found to be in illegal possession of Quarg equipment. Our devices are precious, and ours alone. Though it is regrettable, we must seize you."`
-	`	They don't allow you to get as much as a word out before one of the guards has locked your arms behind your back, completely halting your attempts to fight back with surprisingly little effort. You're brought before something akin to a Quarg jury, where you are lectured on for several hours on how dangerous it is for Quarg apparatus to be stolen and used so lightly by others. At the end of it all, they sentece you to life imprisonment.`
+	`	They don't allow you to get as much as a word out before one of the guards has locked your arms behind your back, completely halting your attempts to fight back with surprisingly little effort. You are brought before something akin to a Quarg jury, where they lecture you for several hours on how dangerous it is for Quarg apparatus to be stolen and used so lightly by others. At the end of it all, they sentence you to life imprisonment.`
 	`	You spend the rest of your days in the same cell, which although large and comfortable, quickly proves plain and dull. You're kept in very good health, and are well fed, but the Quarg do not allow you to leave the cell, and seldom entertain your attempts at striking conversation. You get few visitors, and can only wonder what life would've been like had you the chance to live out all these years in freedom, the captain of a starship.`
 
 fleet "Quarg"

--- a/data/quarg/quarg.txt
+++ b/data/quarg/quarg.txt
@@ -53,9 +53,9 @@ phrase "hostile quarg"
 
 conversation "quarg imprisonment"
 	`Your ship loses all power immediately upon touching down on the landing pad. As you walk around to try and find the problem, you pass by your hatch. You find that it is already opened with dozens of Quarg coming in, all clad in elegant full-body armor suits.`
-	`	"<first> <last>, you are found to be in illegal possession of Quarg equipment. Our devices are precious, and ours alone. Though it is regrettable, we must seize you."`
+	`	"<first> <last>, you are found to be in illegal possession of Quarg equipment. Our devices are precious and ours alone. Though it is regrettable, we must seize you."`
 	`	They don't allow you to get as much as a word out before one of the guards has locked your arms behind your back, completely halting your attempts to fight back with surprisingly little effort. You are brought before something akin to a Quarg jury, where they lecture you for several hours on how dangerous it is for Quarg apparatus to be stolen and used so lightly by others. At the end of it all, they sentence you to life imprisonment.`
-	`	You spend the rest of your days in the same cell, which although large and comfortable, quickly proves plain and dull. You're kept in very good health, and are well fed, but the Quarg do not allow you to leave the cell, and seldom entertain your attempts at striking conversation. You get few visitors, and can only wonder what life would've been like had you the chance to live out all these years in freedom, the captain of a starship.`
+	`	You spend the rest of your days in the same cell, which although large and comfortable, quickly proves plain and dull. You're kept in very good health and are well fed, but the Quarg do not allow you to leave the cell and seldom entertain your attempts at striking conversation. You get few visitors and can only wonder what life would've been like had you the chance to live out all these years in freedom, the captain of a starship.`
 		die
 
 fleet "Quarg"

--- a/data/quarg/quarg.txt
+++ b/data/quarg/quarg.txt
@@ -56,6 +56,7 @@ conversation "quarg imprisonment"
 	`	"<first> <last>, you are found to be in illegal possession of Quarg equipment. Our devices are precious, and ours alone. Though it is regrettable, we must seize you."`
 	`	They don't allow you to get as much as a word out before one of the guards has locked your arms behind your back, completely halting your attempts to fight back with surprisingly little effort. You are brought before something akin to a Quarg jury, where they lecture you for several hours on how dangerous it is for Quarg apparatus to be stolen and used so lightly by others. At the end of it all, they sentence you to life imprisonment.`
 	`	You spend the rest of your days in the same cell, which although large and comfortable, quickly proves plain and dull. You're kept in very good health, and are well fed, but the Quarg do not allow you to leave the cell, and seldom entertain your attempts at striking conversation. You get few visitors, and can only wonder what life would've been like had you the chance to live out all these years in freedom, the captain of a starship.`
+		die
 
 fleet "Quarg"
 	government "Quarg"


### PR DESCRIPTION
----------------------
**Content (Government Interaction Thing)**

## Summary
The Intrusion Countermeasures description mentions you don't want to get caught by the Quarg with their equipment.
This PR makes it so that all the Quarg outfits are  considered atrocities by them now, and so would result in the player getting imprisoned for life if caught.
~~Currently ships can't be added as atrocities, but when that's possible, should add in the Quarg ships to the list as well.~~
I've now added a mission that'll account for the Quarg ships, and result in the same death endpoint as the outfits do. Thanks Hurleveur for providing the mission code on that.