### PR TITLE
First rough draft of Void Orchid Mission and jobs.

### DIFF
--- a/data/remnant/remnant 2 side missions.txt
+++ b/data/remnant/remnant 2 side missions.txt
@@ -715,3 +715,37 @@ mission "Remnant: Scent of Rain 1"
 			`	He shakes his head. "But no matter. Planning for the storm is my duty, not yours, and the front is yet to appear.`
 			label scanningpayment
 			`	"We have allocated you <payment> for the risks undertaken. Please use it wisely. While it is my duty to anticipate threats to us all, it is your duty to ensure you are prepared to face the winds they may bring." He turns and strides away, quickly vanishing into the tunnels beneath the spaceport.`
+
+
+
+mission "Remnant: Void Orchid Mania"
+	landing
+	name "Void Orchid Mania."
+	description "Void Orchid have proved to a treasure trove of scientific discoveries. Dusk has requested that you procure him 200."
+	source "Ssil Vida"
+	destination "Ssil Vida"
+	to offer
+		or
+			and
+				has "Remnant: Cognizance 25: done"
+				not "flagship planet: Ssil Vida"
+			has "event: remnant: cognizance calm"
+	on offer
+		conversation
+			`Dusk asks you to go and mine him 200 units of Void Orchid. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.`
+			choice
+				`	"Sure"`
+				`	"No Thanks"`
+					goto rathernot
+			`	Dusk says thank you for helping him.`
+				accept
+			label rathernot
+			`	I understand.`
+				defer
+	on visit
+		dialog `You have returned to <planet>, but you don't have the 200 requested Void Orchids.`
+	on complete
+		outfit "Void Orchid" -200
+		payment 4500000
+		conversation
+			`On <planet> you deliver the 200 Void orchids. "Here is your BLAH BLAH BLAH" Lorem ipsum dolor sit amet, consectetur adipiscing elit.`

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -664,7 +664,8 @@ mission "Remnant: Rescue 5"
 
 # 200 Void Orchids at a premium of 50%
 mission "Remnant: Void Orchid 200"
-	landing
+	job
+	repeat
 	name "Void Orchid Delivery."
 	description "Void Orchid have proved to a treasure trove of scientific discoveries. Remnant scientists on <planet> have requested that you procure them 200 and deliver them to their colleagues on <destination>."
 	source
@@ -689,7 +690,8 @@ mission "Remnant: Void Orchid 200"
 
 # 100 Void Orchids at a premium of 25%
 mission "Remnant: Void Orchid 100"
-	landing
+	job
+	repeat
 	name "Void Orchid Delivery."
 	description "Void Orchid have proved to a treasure trove of scientific discoveries. Remnant scientists on <planet> have requested that you procure them 100 and deliver them to their colleagues on <destination>."
 	source
@@ -714,7 +716,8 @@ mission "Remnant: Void Orchid 100"
 
 # 50 Void Orchids at a premium of 10%
 mission "Remnant: Void Orchid 50"
-	landing
+	job
+	repeat
 	name "Void Orchid Delivery."
 	description "Void Orchid have proved to a treasure trove of scientific discoveries. Remnant scientists on <planet> have requested that you procure them 50 and deliver them to their colleagues on <destination>."
 	source

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -659,3 +659,78 @@ mission "Remnant: Rescue 5"
 	on visit
 		dialog
 			`You have returned, but there is still no word from the missing ship.`
+
+
+
+# 200 Void Orchids at a premium of 50%
+mission "Remnant: Void Orchid 200"
+	landing
+	name "Void Orchid Delivery."
+	description "Void Orchid have proved to a treasure trove of scientific discoveries. Remnant scientists on <planet> have requested that you procure them 200 and deliver them to their colleagues on <destination>."
+	source
+		government "Remnant"
+	destination
+		government "Remnant"
+		not attributes "requires: gaslining"
+		not distance 0
+	destination "Ssil Vida"
+	to offer
+		has "Remnant: Void Orchid Mania: complete"
+		random < 4
+	on visit
+		dialog `You arrived at <destination>, but you don't have the 200 requested Void Orchids.`
+	on complete
+		outfit "Void Orchid" -200
+		payment 4500000
+		conversation
+			`On <destination> you deliver the 200 Void orchids. "Here is your BLAH BLAH BLAH" Lorem ipsum dolor sit amet, consectetur adipiscing elit.`
+
+
+
+# 100 Void Orchids at a premium of 25%
+mission "Remnant: Void Orchid 100"
+	landing
+	name "Void Orchid Delivery."
+	description "Void Orchid have proved to a treasure trove of scientific discoveries. Remnant scientists on <planet> have requested that you procure them 100 and deliver them to their colleagues on <destination>."
+	source
+		government "Remnant"
+	destination
+		government "Remnant"
+		not attributes "requires: gaslining"
+		not distance 0
+	destination "Ssil Vida"
+	to offer
+		has "Remnant: Void Orchid Mania: complete"
+		random < 8
+	on visit
+		dialog `You arrived at <destination>, but you don't have the 100 requested Void Orchids.`
+	on complete
+		outfit "Void Orchid" -100
+		payment 1875000
+		conversation
+			`On <destination> you deliver the 100 Void orchids. "Here is your BLAH BLAH BLAH" Lorem ipsum dolor sit amet, consectetur adipiscing elit.`
+
+
+
+# 50 Void Orchids at a premium of 10%
+mission "Remnant: Void Orchid 50"
+	landing
+	name "Void Orchid Delivery."
+	description "Void Orchid have proved to a treasure trove of scientific discoveries. Remnant scientists on <planet> have requested that you procure them 50 and deliver them to their colleagues on <destination>."
+	source
+		government "Remnant"
+	destination
+		government "Remnant"
+		not attributes "requires: gaslining"
+		not distance 0
+	destination "Ssil Vida"
+	to offer
+		has "Remnant: Void Orchid Mania: complete"
+		random < 12
+	on visit
+		dialog `You arrived at <destination>, but you don't have the 50 requested Void Orchids.`
+	on complete
+		outfit "Void Orchid" -50
+		payment 825000
+		conversation
+			`On <destination> you deliver the 50 Void orchids. "Here is your BLAH BLAH BLAH" Lorem ipsum dolor sit amet, consectetur adipiscing elit.`


### PR DESCRIPTION
## Summary
Adds repeatable jobs to fetch bulk amounts of Void Orchids at a premium. The higher the requested amount the higher the premium. Ranging from 10% @ 50 to 50% @ 200.

Also adds an intro mission.

Mission structure is rough, and the text is just place holder for now.

@Zitchas has an idea to have this as a follow up to some other missions they have an idea for. Leaving this as a draft for now as reference for future use. In the mean time will work on using this "framework" for jobs in human and hai space.

## Save File
This save file can be used to play through the new mission content:
Coming Soon