### PR TITLE
Improve `CollisionSet::Line`

### DIFF
--- a/source/CollisionSet.cpp
+++ b/source/CollisionSet.cpp
@@ -336,7 +336,8 @@ Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 		ry = fullScale - ry;
 
 	// Keep track of which objects we've already considered.
-	set<const Body *> seen;
+	vector<const Body *> seen;
+	seen.reserve(16);
 	while(true)
 	{
 		// Examine all objects in the current grid cell.
@@ -350,9 +351,12 @@ Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 			if(it->x != gx || it->y != gy)
 				continue;
 
-			if(seen.count(it->body))
+			bool present = any_of(seen.begin(), seen.end(), [it](const Body *el) {
+				return el == it->body;
+			});
+			if(present)
 				continue;
-			seen.insert(it->body);
+			seen.push_back(it->body);
 
 			// Check if this projectile can hit this object. If either the
 			// projectile or the object has no government, it will always hit.

--- a/source/CollisionSet.cpp
+++ b/source/CollisionSet.cpp
@@ -180,16 +180,16 @@ Body *CollisionSet::Line(const Projectile &projectile, double *closestHit) const
 Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 		const Government *pGov, const Body *target) const
 {
-	int x = from.X();
-	int y = from.Y();
-	int endX = to.X();
-	int endY = to.Y();
+	const int x = from.X();
+	const int y = from.Y();
+	const int endX = to.X();
+	const int endY = to.Y();
 
 	// Figure out which grid cell the line starts and ends in.
 	int gx = x >> SHIFT;
 	int gy = y >> SHIFT;
-	int endGX = endX >> SHIFT;
-	int endGY = endY >> SHIFT;
+	const int endGX = endX >> SHIFT;
+	const int endGY = endY >> SHIFT;
 
 	Closest closer_result(closestHit ? *closestHit : 1.);
 
@@ -198,9 +198,9 @@ Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 	if(gx == endGX && gy == endGY)
 	{
 		// Examine all objects in the current grid cell.
-		auto i = (gy & WRAP_MASK) * CELLS + (gx & WRAP_MASK);
-		vector<Entry>::const_iterator it = sorted.begin() + counts[i];
-		vector<Entry>::const_iterator end = sorted.begin() + counts[i + 1];
+		const auto index = (gy & WRAP_MASK) * CELLS + (gx & WRAP_MASK);
+		vector<Entry>::const_iterator it = sorted.begin() + counts[index];
+		vector<Entry>::const_iterator end = sorted.begin() + counts[index + 1];
 		for( ; it != end; ++it)
 		{
 			// Skip objects that were put in this same grid cell only because
@@ -216,7 +216,7 @@ Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 
 			const Mask &mask = it->body->GetMask(step);
 			Point offset = from - it->body->Position();
-			double range = mask.Collide(offset, to - from, it->body->Facing());
+			const double range = mask.Collide(offset, to - from, it->body->Facing());
 
 			closer_result.TryNearer(range, it->body);
 		}
@@ -226,7 +226,7 @@ Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 		return closer_result.GetClosestBody();
 	}
 
-	Point pVelocity = (to - from);
+	const Point pVelocity = (to - from);
 	if(pVelocity.Length() > MAX_VELOCITY)
 	{
 		// Cap projectile velocity to prevent integer overflows.
@@ -240,8 +240,8 @@ Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 	}
 
 	// When stepping from one grid cell to the next, we'll go in this direction.
-	int stepX = (x <= endX ? 1 : -1);
-	int stepY = (y <= endY ? 1 : -1);
+	const int stepX = (x <= endX ? 1 : -1);
+	const int stepY = (y <= endY ? 1 : -1);
 	// Calculate the slope of the line, shifted so it is positive in both axes.
 	const uint64_t mx = abs(endX - x);
 	const uint64_t my = abs(endY - y);
@@ -287,7 +287,7 @@ Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 
 			const Mask &mask = it->body->GetMask(step);
 			Point offset = from - it->body->Position();
-			double range = mask.Collide(offset, to - from, it->body->Facing());
+			const double range = mask.Collide(offset, to - from, it->body->Facing());
 
 			closer_result.TryNearer(range, it->body);
 		}
@@ -296,7 +296,7 @@ Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 		if(closer_result.GetClosestBody() || (gx == endGX && gy == endGY))
 			break;
 		// If not, move to the next one. Check whether rx / mx < ry / my.
-		int64_t diff = rx * my - ry * mx;
+		const int64_t diff = rx * my - ry * mx;
 		if(!diff)
 		{
 			// The line is exactly intersecting a corner.
@@ -350,23 +350,23 @@ const vector<Body *> &CollisionSet::Circle(const Point &center, double radius) c
 const vector<Body *> &CollisionSet::Ring(const Point &center, double inner, double outer) const
 {
 	// Calculate the range of (x, y) grid coordinates this ring covers.
-	int minX = static_cast<int>(center.X() - outer) >> SHIFT;
-	int minY = static_cast<int>(center.Y() - outer) >> SHIFT;
-	int maxX = static_cast<int>(center.X() + outer) >> SHIFT;
-	int maxY = static_cast<int>(center.Y() + outer) >> SHIFT;
+	const int minX = static_cast<int>(center.X() - outer) >> SHIFT;
+	const int minY = static_cast<int>(center.Y() - outer) >> SHIFT;
+	const int maxX = static_cast<int>(center.X() + outer) >> SHIFT;
+	const int maxY = static_cast<int>(center.Y() + outer) >> SHIFT;
 
 	// Keep track of which objects we've already considered.
 	set<const Body *> seen;
 	result.clear();
 	for(int y = minY; y <= maxY; ++y)
 	{
-		auto gy = y & WRAP_MASK;
+		const auto gy = y & WRAP_MASK;
 		for(int x = minX; x <= maxX; ++x)
 		{
-			auto gx = x & WRAP_MASK;
-			auto i = gy * CELLS + gx;
-			vector<Entry>::const_iterator it = sorted.begin() + counts[i];
-			vector<Entry>::const_iterator end = sorted.begin() + counts[i + 1];
+			const auto gx = x & WRAP_MASK;
+			const auto index = gy * CELLS + gx;
+			vector<Entry>::const_iterator it = sorted.begin() + counts[index];
+			vector<Entry>::const_iterator end = sorted.begin() + counts[index + 1];
 
 			for( ; it != end; ++it)
 			{
@@ -381,7 +381,7 @@ const vector<Body *> &CollisionSet::Ring(const Point &center, double inner, doub
 
 				const Mask &mask = it->body->GetMask(step);
 				Point offset = center - it->body->Position();
-				double length = offset.Length();
+				const double length = offset.Length();
 				if((length <= outer && length >= inner)
 					|| mask.WithinRing(offset, it->body->Facing(), inner, outer))
 					result.push_back(it->body);

--- a/source/CollisionSet.cpp
+++ b/source/CollisionSet.cpp
@@ -52,11 +52,11 @@ namespace {
 
 		void TryNearer(double new_closest, Body *new_body)
 		{
-			if(new_closest < closest_dist)
-			{
-				closest_dist = new_closest;
-				closest_body = new_body;
-			}
+			if(new_closest >= closest_dist)
+				return;
+
+			closest_dist = new_closest;
+			closest_body = new_body;
 		}
 
 		double GetClosestDistance() const { return closest_dist; }
@@ -156,6 +156,7 @@ void CollisionSet::Finish()
 	}
 	// Now, counts[index] is where a certain bin begins.
 
+	// Initialize 'seen' with 0
 	seen.clear();
 	seen.resize(all.size());
 	seenEpoch = 0;

--- a/source/CollisionSet.cpp
+++ b/source/CollisionSet.cpp
@@ -133,6 +133,7 @@ namespace {
 }
 
 
+
 // Initialize a collision set. The cell size and cell count should both be
 // powers of two; otherwise, they are rounded down to a power of two.
 CollisionSet::CollisionSet(unsigned cellSize, unsigned cellCount)
@@ -335,9 +336,7 @@ Body *CollisionSet::Line(const Point &from, const Point &to, double *closestHit,
 	if(stepY > 0)
 		ry = fullScale - ry;
 
-	// Keep track of which objects we've already considered.
-	vector<const Body *> seen;
-	seen.reserve(16);
+	seen.clear();
 	while(true)
 	{
 		// Examine all objects in the current grid cell.
@@ -438,9 +437,8 @@ const vector<Body *> &CollisionSet::Ring(const Point &center, double inner, doub
 	const int maxX = static_cast<int>(center.X() + outer) >> SHIFT;
 	const int maxY = static_cast<int>(center.Y() + outer) >> SHIFT;
 
-	// Keep track of which objects we've already considered.
-	vector<const Body *> seen;
-	seen.reserve(16);
+	seen.clear();
+
 	result.clear();
 	for(int y = minY; y <= maxY; ++y)
 	{

--- a/source/CollisionSet.cpp
+++ b/source/CollisionSet.cpp
@@ -439,7 +439,8 @@ const vector<Body *> &CollisionSet::Ring(const Point &center, double inner, doub
 	const int maxY = static_cast<int>(center.Y() + outer) >> SHIFT;
 
 	// Keep track of which objects we've already considered.
-	set<const Body *> seen;
+	vector<const Body *> seen;
+	seen.reserve(16);
 	result.clear();
 	for(int y = minY; y <= maxY; ++y)
 	{
@@ -458,9 +459,12 @@ const vector<Body *> &CollisionSet::Ring(const Point &center, double inner, doub
 				if(it->x != x || it->y != y)
 					continue;
 
-				if(seen.count(it->body))
+				bool present = any_of(seen.begin(), seen.end(), [it](const Body *el) {
+					return el == it->body;
+				});
+				if(present)
 					continue;
-				seen.insert(it->body);
+				seen.push_back(it->body);
 
 				const Mask &mask = it->body->GetMask(step);
 				Point offset = center - it->body->Position();

--- a/source/CollisionSet.h
+++ b/source/CollisionSet.h
@@ -96,7 +96,7 @@ private:
 	// Vector for returning the result of a circle query.
 	mutable std::vector<Body *> result;
 
-	// Keep track of which objects we've already considered in "Line" and "Circle" methods.
+	// Keep track of which objects we've already considered
 	mutable std::vector<unsigned> seen;
 	mutable unsigned seenEpoch;
 };

--- a/source/CollisionSet.h
+++ b/source/CollisionSet.h
@@ -64,9 +64,10 @@ private:
 	class Entry {
 	public:
 		Entry() = default;
-		Entry(Body *body, int x, int y) : body(body), x(x), y(y) {}
+		Entry(Body *body, unsigned seenIndex, int x, int y) : body(body), seenIndex(seenIndex), x(x), y(y) {}
 
 		Body *body;
+		unsigned seenIndex;
 		int x;
 		int y;
 	};
@@ -96,7 +97,8 @@ private:
 	mutable std::vector<Body *> result;
 
 	// Keep track of which objects we've already considered in "Line" and "Circle" methods.
-	mutable std::vector<const Body *> seen;
+	mutable std::vector<unsigned> seen;
+	mutable unsigned seenEpoch;
 };
 
 

--- a/source/CollisionSet.h
+++ b/source/CollisionSet.h
@@ -94,6 +94,9 @@ private:
 
 	// Vector for returning the result of a circle query.
 	mutable std::vector<Body *> result;
+
+	// Keep track of which objects we've already considered in "Line" and "Circle" methods.
+	mutable std::vector<const Body *> seen;
 };
 
 


### PR DESCRIPTION
**Performance:** This PR improve performance of `CollisionSet::Line` by replacing `std::set` with `std::vector` and making it a member.

## Summary

As outlined in #6329, one of the (most?) prominent code path is:

> CollisionSet::Line (26.1%) spends a lot of time inserting into a set and calling Mask::Collide.

Replacing that `set` with a more cache friendly `vector` helps improving performances, as anyone can see removing the last commit. [Here](https://github.com/endless-sky/endless-sky/files/10122710/CollisionSet_Line.ods) some numbers.

## Couple of Notes

* No binary search: just a find seems fine because the set of checked objects is limited: on first commit I collected the total number of the objects and is quite low. That can be shown printing `GetNumSamples()`.
* It seems that making the `vector` a member will decrease perfomance: I doubt it do, probably is that I didn't have luck :smile: and that the inspected situations differs...
* I made a "micro-class" to improve a bit readability: that class is inlined in a member and I don't know if your coding style allow such a thing... To me is natural, more or less like using lambdas which are defined and used in place. But let me know if it's ok, or I can drop that commit.

## Save File
N/A

## Testing Done

...Loaded a save, cloaked and jumped to an hot system where I collect profile data... seems all is fine...

## Performance Impact

Time of `CollisionSet::Line` reduced down of up to 60%.
