### PR TITLE
Content: address wrong usage of Unfettered fleet (HR)

### DIFF
--- a/data/hai/hai fleets.txt
+++ b/data/hai/hai fleets.txt
@@ -662,51 +662,6 @@ fleet "Large Unfettered"
 		"Sea Scorpion (Pulse)"
 		"Shield Beetle (Pulse)"
 
-fleet "Large Friendly Unfettered"
-	government "Hai (Friendly Unfettered)"
-	names "hai"
-	cargo 1
-	personality
-		disables plunders
-	variant 2
-		"Shield Beetle"
-		"Lightning Bug (Pulse)" 2
-	variant 2
-		"Shield Beetle (Tracker)"
-		"Lightning Bug" 2
-	variant 1
-		"Shield Beetle"
-		"Lightning Bug (Pulse)"
-	variant 1
-		"Shield Beetle (Tracker)"
-		"Lightning Bug"
-	variant 3
-		"Shield Beetle (Tracker)"
-		"Shield Beetle"
-	variant 1
-		"Shield Beetle (Tracker)" 2
-	variant 1
-		"Shield Beetle" 2
-	variant 1
-		"Lightning Bug" 5
-	variant 3
-		"Shield Beetle (Pulse)"
-		"Lightning Bug (Pulse)" 2
-	variant 2
-		"Shield Beetle (Pulse)"
-		"Shield Beetle"
-	variant 2
-		"Shield Beetle (Pulse)"
-		"Shield Beetle (Tracker)"
-	variant
-		"Shield Beetle (Pulse)"
-		"Shield Beetle"
-		"Lightning Bug (Pulse)" 2
-	variant
-		"Shield Beetle (Pulse)"
-		"Shield Beetle (Tracker)"
-		"Lightning Bug" 2
-
 fleet "Unfettered Raid"
 	government "Hai (Unfettered)"
 	names "hai"

--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -1470,7 +1470,7 @@ mission "Hai Reveal [A13-A] Unfettered Pickup"
 		government "Hai (Friendly Unfettered)"
 		system "Bote Asu"
 		personality escort heroic opportunistic
-		fleet "Large Friendly Unfettered" 7
+		fleet "Large Unfettered" 7
 
 
 # Ambassadorial Centipede designed to fly deep into hostile space if necessary:

--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -140,7 +140,7 @@ mission "Hai Reveal [B02] Join the Fleet"
 		government "Hai (Friendly Unfettered)"
 		system "Rajak"
 		personality escort heroic opportunistic vindictive waiting
-		fleet "Large Friendly Unfettered" 7
+		fleet "Large Unfettered" 7
 	# Guard fleets are 1 ship each. Unfet are 2.7 on average. Total Fleet Size is is roughly 57 + 10 Syndicate.
 
 	npc kill


### PR DESCRIPTION
The Sea Scorpion was added to the Unfettered's ship but it's not seen in HR because it's using a copy of the `Large Unfettered` fleet.
In order to address that and any similar issue in the future I removed the copy, and replaced references of it by references to the actual `Large Unfettered` fleet.

It is not needed to define a copy of a fleet just to change the government, that can be done by the NPC definition. Since these fleets are only used in NPC definitions this will not cause any issues.