### PR TITLE
Fix: false positive in integration test

### DIFF
--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -244,6 +244,7 @@ test-data "quarg atrocity"
 				atrocities
 					Hyperdrive
 				remove "enforces"
+				remove "death sentence"
 		visited "Terra Incognita"
 		"visited planet" Ruin
 		"available mission" "%TEST%: Wardragon Scanning You!"


### PR DESCRIPTION
https://github.com/endless-sky/endless-sky/pull/7737 when this was merged it made Quarg kill you in the "death sentence" conversation.
Basegame they don't scan you but in this test they do, so I just gave them the default conversation for the test.
Not sure how dying in middle of space and conditions work out but best not to take risks if the change is one line and can't hurt.