### PR TITLE
Enlarge large syndicate fleet

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1698,7 +1698,7 @@ fleet "Large Syndicate"
 		"Splinter"
 		"Quicksilver" 3
 	variant 2
-		"Splinter (Laser)"
+		"Splinter (Laser)" 2
 	variant 2
 		"Splinter (Proton)"
 		"Quicksilver" 3
@@ -1760,6 +1760,12 @@ fleet "Large Syndicate"
 	variant 1
 		"Vanguard (Missile)"
 		"Quicksilver (Proton)" 2
+	variant 1
+		"Protector"
+		"Vanguard (Particle)"
+	variant 1
+		"Protector (Proton)"
+		"Vanguard"
 
 fleet "Small Southern Pirates"
 	government "Pirate"

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1698,7 +1698,8 @@ fleet "Large Syndicate"
 		"Splinter"
 		"Quicksilver" 3
 	variant 2
-		"Splinter (Laser)" 2
+		"Splinter (Laser)"
+		"Quicksilver (Proton)" 3
 	variant 2
 		"Splinter (Proton)"
 		"Quicksilver" 3


### PR DESCRIPTION
**Content**

## Summary
Made the large syndicate fleet slightly larger on average.
Specifically:
The variant that consisted of a single laser Splinter (one low-end medium warship does not in my mind constitute a large fleet) has had three quicksilvers added to match some of the other variants that feature Splinters.
Also added two variants with both of the Syndicated Systems heavy warships, one with the stock Vanguard and the Protector (Proton) and one with the stock Protector and the Vanguard (Particle).

This was prompted in part by the fact that the Raider Attack missions which appear post FW in Syndicate space have become much more difficult with the addition of Firelight missiles to the Palavret, but while those missions could be rebalanced separately I think the very small size of Large Syndicate fleets is still something that should be addressed.