### PR TITLE
Don't cache Angle::Unit

### DIFF
--- a/source/Angle.cpp
+++ b/source/Angle.cpp
@@ -121,22 +121,7 @@ Angle Angle::operator-() const
 // Get a unit vector in the direction of this angle.
 Point Angle::Unit() const
 {
-	// The very first time this is called, create a lookup table of unit vectors.
-	static std::vector<Point> cache;
-	if(cache.empty())
-	{
-		cache.reserve(STEPS);
-		for(int i = 0; i < STEPS; ++i)
-		{
-			double radians = i * STEP_TO_RAD;
-			// The graphics use the usual screen coordinate system, meaning that
-			// positive Y is down rather than up. Angles are clock angles, i.e.
-			// 0 is 12:00 and angles increase in the clockwise direction. So, an
-			// angle of 0 degrees is pointing in the direction (0, -1).
-			cache.emplace_back(sin(radians), -cos(radians));
-		}
-	}
-	return cache[angle];
+	return Point(sin(angle * STEP_TO_RAD), -cos(angle * STEP_TO_RAD));
 }
 
 

--- a/source/Angle.cpp
+++ b/source/Angle.cpp
@@ -121,6 +121,10 @@ Angle Angle::operator-() const
 // Get a unit vector in the direction of this angle.
 Point Angle::Unit() const
 {
+	// The graphics use the usual screen coordinate system, meaning that
+	// positive Y is down rather than up. Angles are clock angles, i.e.
+	// 0 is 12:00 and angles increase in the clockwise direction. So, an
+	// angle of 0 degrees is pointing in the direction (0, -1).
 	return Point(sin(angle * STEP_TO_RAD), -cos(angle * STEP_TO_RAD));
 }
 

--- a/source/Angle.h
+++ b/source/Angle.h
@@ -63,10 +63,9 @@ private:
 
 
 private:
-	// The angle is stored as an integer value between 0 and 2^16 - 1. This is
-	// so that any angle can be mapped to a unit vector (a very common operation)
-	// with just a single array lookup. It also means that "wrapping" angles
-	// to the range of 0 to 360 degrees can be done via a bit mask.
+	// The angle is stored as an integer value between 0 and 2^16 - 1.
+	// It means that "wrapping" angles to the range of 0 to 360 degrees can be
+	// done via a bit mask.
 	int32_t angle = 0;
 };
 


### PR DESCRIPTION
Profiling shows the uncached version is twice as fast. It also saves a megabyte of regularly accessed memory which should relieve some cache pressure.