### PR TITLE
[FEATURE] Mission Given @ Shipyard Outfitter

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -210,7 +210,7 @@ void Mission::Load(const DataNode &node)
 			location = BOARDING;
 		else if(child.Token(0) == "shipyard")
 			location = SHIPYARD;
-		else if(child.Token(0) == "outfitter" && child.Size() == 0)
+		else if(child.Token(0) == "outfitter" && child.Size() == 1)
 			location = OUTFITTER;
 		else if(child.Token(0) == "repeat")
 			repeat = (child.Size() == 1 ? 0 : static_cast<int>(child.Value(1)));

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -208,6 +208,10 @@ void Mission::Load(const DataNode &node)
 			location = ASSISTING;
 		else if(child.Token(0) == "boarding")
 			location = BOARDING;
+		else if(child.Token(0) == "shipyard")
+			location = SHIPYARD;
+		else if(child.Token(0) == "outfitter" && child.Size() == 0)
+			location = OUTFITTER;
 		else if(child.Token(0) == "repeat")
 			repeat = (child.Size() == 1 ? 0 : static_cast<int>(child.Value(1)));
 		else if(child.Token(0) == "clearance")

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -86,7 +86,7 @@ public:
 	bool IsMinor() const;
 
 	// Find out where this mission is offered.
-	enum Location {SPACEPORT, LANDING, JOB, ASSISTING, BOARDING};
+	enum Location {SPACEPORT, LANDING, JOB, ASSISTING, BOARDING, SHIPYARD, OUTFITTER};
 	bool IsAtLocation(Location location) const;
 
 	// Information about what you are doing.

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -25,6 +25,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "GameData.h"
 #include "Hardpoint.h"
 #include "text/layout.hpp"
+#include "Mission.h"
 #include "Outfit.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
@@ -106,6 +107,18 @@ void OutfitterPanel::Step()
 {
 	CheckRefill();
 	ShopPanel::Step();
+	if(GetUI()->IsTop(this))
+	{
+		Mission *mission = player.MissionToOffer(Mission::OUTFITTER);
+		// Special case: if the player somehow got to the outfitter before all
+		// landing missions were offered, they can still be offered here:
+		if(!mission)
+			mission = player.MissionToOffer(Mission::LANDING);
+		if(mission)
+			mission->Do(Mission::OFFER, player, GetUI());
+		else
+			player.HandleBlockedMissions(Mission::OUTFITTER, GetUI());
+	}
 	if(GetUI()->IsTop(this) && !checkedHelp)
 		if(!DoHelp("outfitter") && !DoHelp("outfitter 2") && !DoHelp("outfitter 3"))
 			// All help messages have now been displayed.

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -95,7 +95,7 @@ ShipyardPanel::ShipyardPanel(PlayerInfo &player)
 
 
 
-void OutfitterPanel::Step()
+void ShipyardPanel::Step()
 {
 	ShopPanel::Step();
 	if(GetUI()->IsTop(this))

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -25,6 +25,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Format.h"
 #include "GameData.h"
 #include "Government.h"
+#include "Mission.h"
 #include "Phrase.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
@@ -90,6 +91,25 @@ ShipyardPanel::ShipyardPanel(PlayerInfo &player)
 
 	if(player.GetPlanet())
 		shipyard = player.GetPlanet()->Shipyard();
+}
+
+
+
+void OutfitterPanel::Step()
+{
+	ShopPanel::Step();
+	if(GetUI()->IsTop(this))
+	{
+		Mission *mission = player.MissionToOffer(Mission::SHIPYARD);
+		// Special case: if the player somehow got to the shipyard before all
+		// landing missions were offered, they can still be offered here:
+		if(!mission)
+			mission = player.MissionToOffer(Mission::LANDING);
+		if(mission)
+			mission->Do(Mission::OFFER, player, GetUI());
+		else
+			player.HandleBlockedMissions(Mission::SHIPYARD, GetUI());
+	}
 }
 
 

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -37,6 +37,8 @@ class ShipyardPanel : public ShopPanel {
 public:
 	explicit ShipyardPanel(PlayerInfo &player);
 
+	virtual void Step() override;
+
 
 protected:
 	virtual int TileSize() const override;


### PR DESCRIPTION
## Feature Details
Allow missions to be offered at the Shipyard and Outfitter just like at the Spaceport.

## UI Screenshots
N/A

## Usage Examples
```
mission "Test Spaceport Mission"
	spaceport
	source
		government "Republic" "Free Worlds" "Syndicate"
	on offer
		conversation
			`THIS IS A SPACEPORT MISSION YO!`
				decline

mission "Test Shipyard Mission"
	shipyard
	source
		government "Republic" "Free Worlds" "Syndicate"
	on offer
		conversation
			`THIS IS A SHIPYARD MISSION YO!`
				decline

mission "Test Spaceport Mission"
	outfitter
	source
		government "Republic" "Free Worlds" "Syndicate"
	on offer
		conversation
			`THIS IS A OUTFITTER MISSION YO!`
				decline
```

## Testing Done
Created a stable branch of this branch that has a build with the above test missions. Will post link here shortly.

### Automated Tests Added
N/A

## Performance Impact
Same check for missions on Shipyard & Outfitter as there is on spaceport.
