### PR TITLE
test(ui debug delay): Reduce the input delay when debugging integration tests

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -60,6 +60,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <mmsystem.h>
 #endif
 
+namespace {
+	// The delay in frames when debugging the integration tests.
+	constexpr int UI_DELAY = 60;
+}
+
 using namespace std;
 
 void PrintHelp();
@@ -238,7 +243,7 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 	FrameTimer timer(frameRate);
 	bool isPaused = false;
 	bool isFastForward = false;
-	int testDebugUIDelay = 3 * 60;
+	int testDebugUIDelay = UI_DELAY;
 
 	// If fast forwarding, keep track of whether the current frame should be drawn.
 	int skipFrame = 0;
@@ -350,7 +355,7 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 				Command ignored;
 				runningTest->Step(testContext, player, ignored);
 				// Reset the visual delay.
-				testDebugUIDelay = 3 * 60;
+				testDebugUIDelay = UI_DELAY;
 			}
 			// Skip drawing 29 out of every 30 in-flight frames during testing to speedup testing (unless debug mode is set).
 			// We don't skip UI-frames to ensure we test the UI code more.


### PR DESCRIPTION
This reduces the delay from 3 seconds to 1 second. I execute a couple of integration tests in debug mode and 1 second is more than enough time to keep track of what is going on. 3 seconds is just too much.