### PR TITLE
Fix crash when opening player info panel with no flagship

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -222,7 +222,7 @@ void PlayerInfoPanel::Draw()
 		bool allParkedSystem = true;
 		bool hasOtherShips = false;
 		const Ship *flagship = player.Flagship();
-		const System *flagshipSystem = flagship->GetSystem();
+		const System *flagshipSystem = flagship ? flagship->GetSystem() : player.GetSystem();
 		for(const auto &it : panelState.Ships())
 			if(!it->IsDisabled() && it.get() != flagship)
 			{


### PR DESCRIPTION
**Bugfix:**

## Fix Details
The flagship pointer was being dereferenced without first checking that it isn't null. In the case where you just sold your only unparked ship, this would cause a crash.

## Testing Done
Sell the flagship and try opening hte player info panel. Without this PR, the game crashes.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[crash tester.txt](https://github.com/endless-sky/endless-sky/files/10187629/crash.tester.txt)

