### PR TITLE
Prevent Remnant Celebration 1 occurring in non-sensical places

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -28349,7 +28349,7 @@ planet Avalon
 	security 0
 
 planet Aventine
-	attributes remnant "remnant capital"
+	attributes remnant "remnant primary"
 	landscape land/mountain17-harro
 	description `This is not a particularly warm world, but it is the best that the first Remnant refugees were able to find when they explored the Ember Waste. It is here that they built their capital, in a deep valley that is almost always shrouded in clouds. In meadows farther up the mountain slopes, a few particularly hardy food crops are grown, but for the most part the Remnant rely on artificial greenhouses or cultured yeast for protein supplements. Remnant cuisine is unlikely to ever become a draw for tourists, even if their isolation here is broken.`
 	spaceport `The oldest buildings in the Remnant capital city harken back to classic human architecture, with stone facades and columns reminiscent of ancient Rome. But as you walk outward toward the more recent additions, the buildings become less and less recognizably human, with curved organic shapes and hundreds of overhanging walkways and balconies. It is as if the layers left behind by centuries of habitation are a frozen record of the slow transition of Remnant culture into something bizarre and almost alien.`
@@ -28570,7 +28570,7 @@ planet Burthen
 		fleet "Small Syndicate" 7
 
 planet Caelian
-	attributes remnant "remnant capital"
+	attributes remnant "remnant primary"
 	landscape land/sky7
 	description `When the first members of the Remnant discovered this region of space, Caelian was the only habitable world they found with enough insolation to be able to operate solar-powered factories and bioreactors. The first settlements were scattered widely, with the houses hidden underground in order to be less visible from space, because they feared that the Alphas would overrun human space and eventually find their way into the Waste. Centuries later, when they learned that the Alpha Wars had ended, they began to expand the factories and settlements more openly.`
 	spaceport `Nearly all members of the Remnant are dark-skinned, either from exposure to high levels of ultraviolet radiation or because that is what their first ancestors who came here looked like. So, they walk around this spaceport village without much fear of the scorching desert sun, bringing supplies back and forth to the houses and to the flat clay pavement of the landing zone. Aside from some camels that the settlers brought with them, there are very few animals here.`
@@ -32137,7 +32137,7 @@ planet "Vibrant Water"
 	security 0.2
 
 planet Viminal
-	attributes remnant "remnant capital"
+	attributes remnant "remnant primary"
 	landscape land/snow3
 	description `This cold and dreary world would certainly not be attractive to any modern settlers, but to those who were fleeing the chaos of the Alpha Wars it had the undeniable advantage of being isolated and undiscovered. Today the main reason for the continuing Remnant presence here is that this is the only world they have found where the Key Stones that enable ships to travel through certain wormholes in the Ember Waste can be found.`
 	spaceport `The spaceport is an enormous dome, built of the same resilient and semi-organic material as the hulls of Remnant ships. An opening at one end of the dome allows ships to fly in and out. Inside, the air is still cold, but at least you are sheltered from the violent winds that sweep across the rest of the planet's surface. Some of the locals, accustomed to the cold, walk about in their shirtsleeves as if this were a balmy summer day.`

--- a/data/map.txt
+++ b/data/map.txt
@@ -28349,7 +28349,7 @@ planet Avalon
 	security 0
 
 planet Aventine
-	attributes remnant
+	attributes remnant "remnant capital"
 	landscape land/mountain17-harro
 	description `This is not a particularly warm world, but it is the best that the first Remnant refugees were able to find when they explored the Ember Waste. It is here that they built their capital, in a deep valley that is almost always shrouded in clouds. In meadows farther up the mountain slopes, a few particularly hardy food crops are grown, but for the most part the Remnant rely on artificial greenhouses or cultured yeast for protein supplements. Remnant cuisine is unlikely to ever become a draw for tourists, even if their isolation here is broken.`
 	spaceport `The oldest buildings in the Remnant capital city harken back to classic human architecture, with stone facades and columns reminiscent of ancient Rome. But as you walk outward toward the more recent additions, the buildings become less and less recognizably human, with curved organic shapes and hundreds of overhanging walkways and balconies. It is as if the layers left behind by centuries of habitation are a frozen record of the slow transition of Remnant culture into something bizarre and almost alien.`
@@ -28570,7 +28570,7 @@ planet Burthen
 		fleet "Small Syndicate" 7
 
 planet Caelian
-	attributes remnant
+	attributes remnant "remnant capital"
 	landscape land/sky7
 	description `When the first members of the Remnant discovered this region of space, Caelian was the only habitable world they found with enough insolation to be able to operate solar-powered factories and bioreactors. The first settlements were scattered widely, with the houses hidden underground in order to be less visible from space, because they feared that the Alphas would overrun human space and eventually find their way into the Waste. Centuries later, when they learned that the Alpha Wars had ended, they began to expand the factories and settlements more openly.`
 	spaceport `Nearly all members of the Remnant are dark-skinned, either from exposure to high levels of ultraviolet radiation or because that is what their first ancestors who came here looked like. So, they walk around this spaceport village without much fear of the scorching desert sun, bringing supplies back and forth to the houses and to the flat clay pavement of the landing zone. Aside from some camels that the settlers brought with them, there are very few animals here.`
@@ -32137,7 +32137,7 @@ planet "Vibrant Water"
 	security 0.2
 
 planet Viminal
-	attributes remnant
+	attributes remnant "remnant capital"
 	landscape land/snow3
 	description `This cold and dreary world would certainly not be attractive to any modern settlers, but to those who were fleeing the chaos of the Alpha Wars it had the undeniable advantage of being isolated and undiscovered. Today the main reason for the continuing Remnant presence here is that this is the only world they have found where the Key Stones that enable ships to travel through certain wormholes in the Ember Waste can be found.`
 	spaceport `The spaceport is an enormous dome, built of the same resilient and semi-organic material as the hulls of Remnant ships. An opening at one end of the dome allows ships to fly in and out. Inside, the air is still cold, but at least you are sheltered from the violent winds that sweep across the rest of the planet's surface. Some of the locals, accustomed to the cold, walk about in their shirtsleeves as if this were a balmy summer day.`

--- a/data/remnant/remnant 2 side missions.txt
+++ b/data/remnant/remnant 2 side missions.txt
@@ -156,7 +156,7 @@ mission "Remnant: Celebration 1"
 	minor
 	source
 		government "Remnant"
-		attributes "remnant capital"
+		attributes "remnant primary"
 	destination "Ssil Vida"
 	to offer
 		has "event: remnant: cognizance calm"

--- a/data/remnant/remnant 2 side missions.txt
+++ b/data/remnant/remnant 2 side missions.txt
@@ -156,6 +156,7 @@ mission "Remnant: Celebration 1"
 	minor
 	source
 		government "Remnant"
+		attributes "remnant capital"
 	destination "Ssil Vida"
 	to offer
 		has "event: remnant: cognizance calm"


### PR DESCRIPTION
**Bugfix:**

Thanks to @samoja12 for reporting this on Discord.
https://discord.com/channels/251118043411775489/688532441324847150/1050574382369615906

## Fix Details
Add `"remnant capital"` attribute to their three most developed planets, and use that as a requirement in the location filter for the source of the Celebration mission since it can otherwise offer on Ssil Vida and Esquiline where the events occurring don't make sense (Ssil Vida is also the destination, so it doesn't make sense for it to offer there, both in terms of mission design and the request made in the conversation.)

I'm not set on the attribute name, an alternative I considered was `"remnant urban"`.

## Testing Done
Used the `--matches` command line argument for the executable to test the previous location filter and this one against a game with all changes in the Remnant story so far applied in a plugin and saw that `Ssil Vida` and `Esquilline` are not present in the list of planets the new location filter matches.
