### PR TITLE
Improve `--matches` command

### DIFF
--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -110,6 +110,18 @@ namespace {
 		}
 	}
 
+	const set<string> DEFINITION_NODES = {
+		"fleet",
+		"galaxy",
+		"government",
+		"outfitter",
+		"news",
+		"planet",
+		"shipyard",
+		"system",
+		"substitutions",
+		"wormhole",
+	};
 }
 
 
@@ -667,11 +679,17 @@ void PrintData::LocationFilterMatches(const char *const *argv)
 	DataFile file(cin);
 	LocationFilter filter;
 	for(const DataNode &node : file)
-		if(node.Token(0) == "location")
+	{
+		if(node.Token(0) == "changes" || "event")
+			for(const DataNode &child : node)
+				if(DEFINITION_NODES.count(child.Token(0)))
+					GameData::Change(child);
+		else if(node.Token(0) == "location")
 		{
 			filter.Load(node);
 			break;
 		}
+	}
 
 	cout << "Systems matching provided location filter:\n";
 	for(const auto &it : GameData::Systems())


### PR DESCRIPTION
**Feature:**

## Feature Details
You should now be able to include `event`s or `changes` (as they appear in the save file) in the file above the location filter to test.
It occurs to me now that I haven't included linking and unlinking systems but that that should be included here.

## Usage Examples
```
event
    system "Postverta"
        remove hidden
changes
    planet "Spera Anatrusk"
        government "Wanderer"
location
    <your location filter here>
```

## Testing Done
soon:tm:

### Automated Tests Added
To test this robustly, we would probably need to point the executable to a different set of game data, since we cannot write a test for this and assume the map file will remain as we expect at the point of writing the test.

## Performance Impact
N/A
