### PR TITLE
Do not offer landing missions in the shipyard or outfitter

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -535,10 +535,6 @@ void ShopPanel::CheckForMissions(Mission::Location location)
 		return;
 
 	Mission *mission = player.MissionToOffer(location);
-	// Special case: if the player somehow got to the outfitter before all
-	// landing missions were offered, they can still be offered here:
-	if(!mission)
-		mission = player.MissionToOffer(Mission::LANDING);
 	if(mission)
 		mission->Do(Mission::OFFER, player, GetUI());
 	else


### PR DESCRIPTION
**Bugfix:**

## Fix Details
The support for offering missions in the shipyard and outfitter included the same special case used in the shipyard where, if no more missions are available for the shipyard or outfitter, it will offer any landing missions that were not already offered.
This makes some sense in the spaceport since it is possible to depart from the spaceport without visiting the normal `landed` panel, but this is not the case for the shipyard and outfitter, we must pass through the planet panel before leaving.
Additionally, it results for some perhaps undesired behaviour where, for example, James appears immediately upon purchasing a ship, instead of after leaving the shipyard with a ship.
I expect it is also now possible to get other missions offered in the shipyard or outfitter when they would have previously been offered after leaving: if you have negative cargo space, perhaps because a mission just gave you an outfit you don't have space for, other missions will not offer. You might go into either the outfitter or shipyard and either buy more cargo space or sell the excess cargo and then immediately get the previously blocked mission, instead of what will currently happen where it will be given after leaving the shop.
