### PR TITLE
test(unit-test-buids): Fix test presets not working

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -419,6 +419,7 @@
     {
       "name": "test",
       "hidden": true,
+      "configuration": "Debug",
       "output": {
         "shortProgress": true,
         "outputOnFailure": true
@@ -432,6 +433,7 @@
     {
       "name": "benchmark",
       "hidden": true,
+      "configuration": "Release",
       "output": {
         "verbosity": "verbose",
         "outputOnFailure": true


### PR DESCRIPTION
This fixes the issue of the test preset `*-test` and `*-benchmark` not running any tests due to a missing configuration field.