### PR TITLE
Update copyright to add UnorderedSigh and NomadicVolcano to Hai Reveal

### DIFF
--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -1,5 +1,5 @@
-# Copyright (c) 2020 MasterOfGrey and NomadicVolcano
-# Copyright (c) 2022 UnorderedSigh
+# Copyright (c) 2020-2022 MasterOfGrey and NomadicVolcano
+# Copyright (c) 2022 MasterOfGrey and UnorderedSigh
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -1,6 +1,5 @@
-# Copyright (c) 2020 MasterOfGrey
-# Derived in part from work copyright (c) 2020 NomadicVolcano
-# With updates copyright (c) 2022 UnorderedSigh
+# Copyright (c) 2020 MasterOfGrey and NomadicVolcano
+# Copyright (c) 2022 UnorderedSigh
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -1,4 +1,6 @@
 # Copyright (c) 2020 MasterOfGrey
+# Derived in part from work copyright (c) 2020 NomadicVolcano
+# With updates copyright (c) 2022 UnorderedSigh
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 Nomadic Volcano
+# With updates copyright (c) 2022 UnorderedSigh
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -1,5 +1,5 @@
-# Copyright (c) 2020 Nomadic Volcano
-# Copyright (c) 2022 UnorderedSigh
+# Copyright (c) 2020-2022 Nomadic Volcano
+# Copyright (c) 2022 Nomadic Volcano and UnorderedSigh
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Nomadic Volcano
-# With updates copyright (c) 2022 UnorderedSigh
+# Copyright (c) 2022 UnorderedSigh
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
**Feature:** Adds @UnorderedSigh and @NomadicVolcano to copyright notices in the appropriate parts of Hai Reveal

I've made major modifications to parts 4 and 5, so I put that in the copyright notice.

Some of part 4 was modified from NomadicVolcano's work, but she received no attribution. Technically, the GPL does not require attribution, but it is bad precedent to make a derived work without giving the original author credit. I added her to part 4, with her verbal permission.

EDIT: I'm not trying to make "territorial claim" on Hai Reveal. It's just, when I spend 150+ hours working on something, and people use that work, I'd like more attribution than just a line in the game credits. There is precedent for this in the korath txt files.