### PR TITLE
Hai Reveal: Hai secret leaking does not depend on player reading pug news

### DIFF
--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -20,7 +20,7 @@ mission "Hai Secret Leaker Begins"
 		has "main plot completed"
 	on offer
 		event "pug media coverage" 20 30
-		event "hai secret leaks" 60 90
+		event "hai secret leaks" 40 60
 		fail
 
 event "pug media coverage"

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -20,6 +20,7 @@ mission "Hai Secret Leaker Begins"
 		has "main plot completed"
 	on offer
 		event "pug media coverage" 20 30
+		event "hai secret leaks" 60 90
 		fail
 
 event "pug media coverage"
@@ -55,7 +56,6 @@ mission "Event: Pug Media Coverage"
 	to offer
 		has "event: pug media coverage"
 	on offer
-		event "hai secret leaks" 10 15
 		log "Minor People" "Maduena Kabiru" `A senator from Bounty in the Delta Velorum system. He is somewhat paranoid, and insists upon the Navy taking greater steps to better explore the galaxy beyond human space to search for possible threats.`
 		conversation
 			`As you walk through the spaceport, you can't help but notice that coverage on the events of the Pug invasion still continues to dominate headlines, even though it's been weeks now.`

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -24,6 +24,7 @@ mission "Hai Secret Leaker Begins"
 		fail
 
 event "pug media coverage"
+event "hai secret leaks"
 
 
 
@@ -56,6 +57,7 @@ mission "Event: Pug Media Coverage"
 	to offer
 		has "event: pug media coverage"
 	on offer
+		event "saw pug media coverage"
 		log "Minor People" "Maduena Kabiru" `A senator from Bounty in the Delta Velorum system. He is somewhat paranoid, and insists upon the Navy taking greater steps to better explore the galaxy beyond human space to search for possible threats.`
 		conversation
 			`As you walk through the spaceport, you can't help but notice that coverage on the events of the Pug invasion still continues to dominate headlines, even though it's been weeks now.`
@@ -65,7 +67,7 @@ mission "Event: Pug Media Coverage"
 			`	In this very public space you spot a couple of people who seem to hesitantly recognize you, presumably from other coverage, and so you keep your thoughts to yourself.`
 				decline
 
-event "hai secret leaks"
+event "saw pug media coverage"
 
 
 
@@ -166,6 +168,7 @@ mission "ZZ Event Hai Secret Leaks: RSHU"
 	clearance
 	to offer
 		has "event: hai secret leaks"
+		has "event: saw pug media coverage"
 		has "First Contact: Hai: offered"
 		has "First Contact: Unfettered: offered"
 		not "asked to investigate hai leak"
@@ -192,6 +195,7 @@ mission "ZZ Event Hai Secret Leaks: FWHU"
 	clearance
 	to offer
 		has "event: hai secret leaks"
+		has "event: saw pug media coverage"
 		has "First Contact: Hai: offered"
 		has "First Contact: Unfettered: offered"
 		not "asked to investigate hai leak"
@@ -216,6 +220,7 @@ mission "ZZ Event Hai Secret Leaks: RSH"
 	destination "Allhome"
 	to offer
 		has "event: hai secret leaks"
+		has "event: saw pug media coverage"
 		has "First Contact: Hai: offered"
 		not "First Contact: Unfettered: offered"
 		not "asked to investigate hai leak"
@@ -238,6 +243,7 @@ mission "ZZ Event Hai Secret Leaks: FWH"
 	destination "Allhome"
 	to offer
 		has "event: hai secret leaks"
+		has "event: saw pug media coverage"
 		has "First Contact: Hai: offered"
 		not "First Contact: Unfettered: offered"
 		not "asked to investigate hai leak"
@@ -260,6 +266,7 @@ mission "ZZ Event Hai Secret Leaks: RS"
 	destination "Sunracer"
 	to offer
 		has "event: hai secret leaks"
+		has "event: saw pug media coverage"
 		not "First Contact: Hai: offered"
 		not "asked to investigate hai leak"
 	on offer
@@ -279,6 +286,7 @@ mission "ZZ Event Hai Secret Leaks: FW"
 	destination "Sunracer"
 	to offer
 		has "event: hai secret leaks"
+		has "event: saw pug media coverage"
 		not "First Contact: Hai: offered"
 		not "asked to investigate hai leak"
 	on offer

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -57,7 +57,7 @@ mission "Event: Pug Media Coverage"
 	to offer
 		has "event: pug media coverage"
 	on offer
-		event "saw pug media coverage"
+		set "saw pug media coverage"
 		log "Minor People" "Maduena Kabiru" `A senator from Bounty in the Delta Velorum system. He is somewhat paranoid, and insists upon the Navy taking greater steps to better explore the galaxy beyond human space to search for possible threats.`
 		conversation
 			`As you walk through the spaceport, you can't help but notice that coverage on the events of the Pug invasion still continues to dominate headlines, even though it's been weeks now.`
@@ -66,8 +66,6 @@ mission "Event: Pug Media Coverage"
 			`	One particular paranoid fringe-world politician dominates the air on the channel you're watching here. Councilor Maduena Kabiru from Bounty demands that the edges of human space be better understood, that threats and even potential threats must clearly exist beyond what is already known, and that it is the responsibility of the government to find out and inform the people. While one could definitely argue in favor of his point, it doesn't carry much weight coming from a councilor whose system is a mere two jumps from a brand new Navy base.`
 			`	In this very public space you spot a couple of people who seem to hesitantly recognize you, presumably from other coverage, and so you keep your thoughts to yourself.`
 				decline
-
-event "saw pug media coverage"
 
 
 
@@ -168,7 +166,7 @@ mission "ZZ Event Hai Secret Leaks: RSHU"
 	clearance
 	to offer
 		has "event: hai secret leaks"
-		has "event: saw pug media coverage"
+		has "saw pug media coverage"
 		has "First Contact: Hai: offered"
 		has "First Contact: Unfettered: offered"
 		not "asked to investigate hai leak"
@@ -195,7 +193,7 @@ mission "ZZ Event Hai Secret Leaks: FWHU"
 	clearance
 	to offer
 		has "event: hai secret leaks"
-		has "event: saw pug media coverage"
+		has "saw pug media coverage"
 		has "First Contact: Hai: offered"
 		has "First Contact: Unfettered: offered"
 		not "asked to investigate hai leak"
@@ -220,7 +218,7 @@ mission "ZZ Event Hai Secret Leaks: RSH"
 	destination "Allhome"
 	to offer
 		has "event: hai secret leaks"
-		has "event: saw pug media coverage"
+		has "saw pug media coverage"
 		has "First Contact: Hai: offered"
 		not "First Contact: Unfettered: offered"
 		not "asked to investigate hai leak"
@@ -243,7 +241,7 @@ mission "ZZ Event Hai Secret Leaks: FWH"
 	destination "Allhome"
 	to offer
 		has "event: hai secret leaks"
-		has "event: saw pug media coverage"
+		has "saw pug media coverage"
 		has "First Contact: Hai: offered"
 		not "First Contact: Unfettered: offered"
 		not "asked to investigate hai leak"
@@ -266,7 +264,7 @@ mission "ZZ Event Hai Secret Leaks: RS"
 	destination "Sunracer"
 	to offer
 		has "event: hai secret leaks"
-		has "event: saw pug media coverage"
+		has "saw pug media coverage"
 		not "First Contact: Hai: offered"
 		not "asked to investigate hai leak"
 	on offer
@@ -286,7 +284,7 @@ mission "ZZ Event Hai Secret Leaks: FW"
 	destination "Sunracer"
 	to offer
 		has "event: hai secret leaks"
-		has "event: saw pug media coverage"
+		has "saw pug media coverage"
 		not "First Contact: Hai: offered"
 		not "asked to investigate hai leak"
 	on offer


### PR DESCRIPTION
**Feature:** This PR changes event logic so that the leak of the Hai secret does not depend on the player hearing news about the Pug.

It would be difficult to fix several of @warp-core's troubles in #7527 without this, and I need it for some pug news changes, so I'm hoping this PR can be reviewed and merged quickly. It is a simple PR.

## Feature Details

Presently, the leak of the Hai secret is triggered by the player hearing news about the Pug. I've changed it so that the Hai secret is leaked 40-60 days after the main campaign, regardless of player actions. The pug news mission sets a variable to ensure the hai leak news won't happen at the same time.

This PR solves a few problems:

1. There is no justifiable lore reason why people would wait until Captain Last sees a news show about the Pug before revealing the Hai.
2. I want to add several missions to see the reaction of various human groups to the Pug. (@MasterOfGrey has approved the idea of more Pug reaction missions, and I'm working on three.) The cleanest way to handle that is to separate the event from the pug news.
3. This is necessary to allow some mission changes that will address some of @warp-core's concerns in #7527

EDIT: Originally, I implemented this another way, but I just changed it to use a variable to prevent the Pug & Hai media coverage from happening at the same time. I recall MasterOfGrey suggesting that another conversation.

## Testing Performed

Save just before completing the main campaign. Go visit Earth to end the campaign:
[Friction Diction~3024-03-27 TRY13 at dabih.txt](https://github.com/endless-sky/endless-sky/files/10198053/Friction.Diction.3024-03-27.TRY13.at.dabih.txt)

Save just after completing the main campaign:
[Friction Diction~3024-04-03 TRY13 main plot completed ships present.txt](https://github.com/endless-sky/endless-sky/files/10198004/Friction.Diction.3024-04-03.TRY13.main.plot.completed.ships.present.txt)

Just before Pug media coverage:
[Friction Diction~3024-04-24 TRY13 pug media coverage tomorrow.txt](https://github.com/endless-sky/endless-sky/files/10198007/Friction.Diction.3024-04-24.TRY13.pug.media.coverage.tomorrow.txt)

Just before hai secret is leaked:
[Friction Diction~3024-05-15 TRY13 hai secret leaks tomorrow with variable.txt](https://github.com/endless-sky/endless-sky/files/10198009/Friction.Diction.3024-05-15.TRY13.hai.secret.leaks.tomorrow.with.variable.txt)

## Performance Impact

N/A