### PR TITLE
Fix 'Fury' appearing too often as a pirate ship name

### DIFF
--- a/data/human/names.txt
+++ b/data/human/names.txt
@@ -4227,7 +4227,6 @@ phrase "bad outcomes"
 		"Blood"
 		"Poison"
 		"Blight"
-		"Fury"
 		"Misfortune"
 		"Damnation"
 		"Contagion"
@@ -4535,7 +4534,7 @@ phrase "pirate subphrase 2"
 	phrase
 		"pirate nouns" 110
 		"pirate nouns that work after bad outcomes" 27
-		"bad outcomes" 53
+		"bad outcomes" 52
 
 phrase "pirate subphrase 3"
 	phrase
@@ -4546,7 +4545,7 @@ phrase "pirate subphrase 3"
 		" "
 	phrase
 		"sinister names" 78
-		"bad outcomes" 53
+		"bad outcomes" 52
 
 phrase "pirate subphrase 4"
 	phrase
@@ -4556,7 +4555,7 @@ phrase "pirate subphrase 4"
 	phrase
 		"pirate nouns" 110
 		"pirate nouns that work after bad outcomes" 27
-		"bad outcomes" 53
+		"bad outcomes" 52
 	# When making a word ending in "s" possessive, only add an apostrophe.
 	replace
 		"s%'s" "s'"
@@ -4581,7 +4580,7 @@ phrase "pirate subphrase 6"
 
 phrase "pirate subphrase 7"
 	phrase
-		"bad outcomes" 53
+		"bad outcomes" 52
 		"pirate adjectives that work as titles" 65
 		"pirate adjectives that don't work as titles" 67
 	word
@@ -4593,7 +4592,7 @@ phrase "pirate subphrase 8"
 	phrase
 		"pirate nouns" 110
 		"pirate nouns that work after bad outcomes" 27
-		"bad outcomes" 53
+		"bad outcomes" 52
 
 phrase "pirate subphrase 9"
 	word


### PR DESCRIPTION
**Bugfix:**

## Fix Details
"Fury" was entered twice on the names list for "bad outcomes", and I've noticed Fury coming up as a pirate ship name at least six times in an hour, although I was using the all-content-plugin (I don't see anything there that would affect this, though). I removed the extra entry and should have fixed everything else that happens with that change. 

## Testing Done
It's a simple fix so I don't know if I have to do anything. I suppose I can download my fork and see if Fury doesn't pop up as often?