### PR TITLE
Hai: Set Nanachi job to offer at Giverstone

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -827,12 +827,7 @@ mission "Nanachi 1"
 	name "Escort Nanachi to <planet>"
 	description "Help Nanachi, a Hai who just bought her first ship, make a simple delivery to <destination> by <date>."
 	minor
-	source
-		# This is a mandatory mission, so the range is as far as a
-		# Heavy Shuttle can reach (500 fuel)
-		near "Wah Ki" 1 5
-		government "Hai"
-		not attributes "uninhabited" "station"
+	source "Giverstone"
 	destination "Cloudfire"
 	deadline 2 1
 	to offer


### PR DESCRIPTION
## Summary
The text of the initial Nanachi mission are specific to Giverstone as a location. It describes a little used spaceport with large mineral hauls on offer that are inappropriate for a heavy shuttle. The mission offer, however is set to the maximum range for the heavy shuttle and can offer in Unfettered space and as far away as Hai-Home, locations which don't fit with the description. This change sets the job to offer at Giverstone.

## Testing Done
The change is straightforward. The syntax checker in VS Code reports no issues. I don't have a pilot in a state to readily test it.

