### PR TITLE
fix(minor): HR: "Hai Leaks Response 2B" do not offer on Watcher

### DIFF
--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -663,7 +663,7 @@ mission "Hai Leaks Response 2B"
 	landing
 	source
 		government "Republic" "Syndicate" "Free Worlds"
-		not planet "Deep" "Foundry"
+		not planet "Deep" "Foundry" "Watcher"
 	to offer
 		has "Hai Leaks Response 2: active"
 	on offer


### PR DESCRIPTION
**Bugfix:** This PR addresses issue https://discord.com/channels/251118043411775489/536900466655887360/1051558436183220254

## Fix Details
Adds Watcher to the planets this mission should not be offered on
