### PR TITLE
Sign over copyright of Hai Reveal to MasterOfGrey and Michael Zahniser

### DIFF
--- a/copyright
+++ b/copyright
@@ -499,7 +499,7 @@ Comment: Derived from works by Michael Zahniser (under the same license).
 
 Files:
  sounds/pincer*
-Copyright: David White <dave@whitevine.net>
+Copyright: Michael Zahniser
 License: GPL-2
 Comment: Modified from Battle for Wesnoth (https://www.wesnoth.org) sounds, which are copyright David White <dave@whitevine.net> under GPL 2 or later.
 

--- a/copyright
+++ b/copyright
@@ -499,21 +499,20 @@ Comment: Derived from works by Michael Zahniser (under the same license).
 
 Files:
  sounds/pincer*
-Copyright: Nomadic Volcano (nomadicvolcano@gmail.com)
+Copyright: David White <dave@whitevine.net>
 License: GPL-2
-Comment: Nomadic Volcano modified these from Battle for Wesnoth (https://www.wesnoth.org) sounds, which are copyright David White <dave@whitevine.net> under GPL 2 or later.
+Comment: Modified from Battle for Wesnoth (https://www.wesnoth.org) sounds, which are copyright David White <dave@whitevine.net> under GPL 2 or later.
 
 Files:
  images/*/pincer*
 Copyright: None; CC0 (Public Domain)
 License: CC0
-Comment: Textures by https://texture.ninja, other art by NomadicVolcano (nomadicvolcano@gmail.com).
+Comment: Public domain textures by https://texture.ninja
 
 Files:
  images/planet/rogue-radiating*
 Copyright: None; CC0 (Public Domain)
 License: CC0
-Comment: Created by NomadicVolcano (nomadicvolcano@gmail.com)
 
 Files: images/outfit/railslug?rack*
 Copyright: Becca Tommaso (tommasobecca03@gmail.com)
@@ -1099,23 +1098,21 @@ Files:
  images/planet/station?hai?eight?geocoris*
 Copyright: None (CC0: Public Domain)
 License: CC0
-Comment: Made by Nomadic Volcano with textures from texture.ninja.
+Comment: Public domain textures from texture.ninja.
 
 Files:
  images/planet/wormhole-syndicate-ad*
-Copyright: NomadicVolcano (NomadicVolcano@gmail.com)
+Copyright: Michael Zahniser
 License: CC-BY-SA-4.0
-Comment: Derived from works by Michael Zahniser (under the same license)
 
 Files:
  images/planet/station?hai?geocoris*
-Copyright: Nomadic Volcano (NomadicVolcano@gmail.com)
+Copyright: Michael Zahniser
 License: CC-BY-SA-4.0
-Comment: rotate, flip, scale the "images/thumbnail/hai geocoris@2x.png" by Michael Zahniser (under the same license)
 
 Files:
  images/effect/firestorm?ring*
-Copyright: NomadicVolcano (NomadicVolcano@gmail.com).
+Copyright: None (CC0: Public Domain)
 License: CC0
 
 Files:
@@ -1157,7 +1154,7 @@ Comment: Derived from work by Becca Tomaso (under the same licence).
 Files:
  images/outfit/liquid?sodium*
 Copyright: Lia Gerty (https://github.com/ravenshining)
-Comment: Derived from works by Saugia (under the same licence) and NomadicVolcano (public domain).
+Comment: Derived from works by Saugia (under the same licence) and public domain works previously submitted to Endless Sky.
 License: CC-BY-SA-4.0
 
 Files:
@@ -1175,7 +1172,7 @@ Files:
  images/projectile/digger*
 Copyright: Lia Gerty (https://github.com/ravenshining)
 License: CC-BY-SA-4.0
-Comment: Derived from work by NomadicVolcano (public domain).
+Comment: Derived from public domain work previously submitted to Endless Sky.
 
 Files:
  images/planet/browndwarf-t-rouge*
@@ -1230,21 +1227,20 @@ Files:
  images/thumbnail/kas-ik?tek?7*
 Copyright: None (CC0 Public Domain)
 License: CC0
-Comment: Work by Nomadic Volcano (NomadicVolcano@gmail.com) based on textures from texture.ninja
+Comment: Uses public domain textures from texture.ninja
 
 Files:
  images/hardpoint/digger?turret*
  images/outfit/korath?digger?turret*
  images/outfit/korath?digger*
-Copyright: Nomadic Volcano (NomadicVolcano@gmail.com)
+Copyright: Becca Tommaso and Michael Zahniser
 License: CC-BY-SA-4.0
 Comment: Derived from works by Becca Tommaso and Michael Zahniser (under the same license).
 
 Files:
  images/*/korath*reverser*
-Copyright: Nomadic Volcano (NomadicVolcano@gmail.com)
+Copyright: Michael Zahniser
 License: CC-BY-SA-4.0
-Comment: Derived from works by Michael Zahniser (under the same license).
 
 
 Files:
@@ -1701,7 +1697,7 @@ Files:
  images/thumbnail/rai-alorej*
 Copyright: Saugia <https://github.com/Saugia>
 License: CC-BY-SA-4.0
-Comment: Derived from works by NomadicVolcano (public domain).
+Comment: Derived from public domain works previously submitted to Endless Sky
 
 Files:
  images/outfit/microbot?defense?station*

--- a/copyright
+++ b/copyright
@@ -501,7 +501,7 @@ Files:
  sounds/pincer*
 Copyright: Michael Zahniser
 License: GPL-2
-Comment: Modified from Battle for Wesnoth (https://www.wesnoth.org) sounds, which are copyright David White <dave@whitevine.net> under GPL 2 or later.
+Comment: Created by a past contributor modified from Battle for Wesnoth (https://www.wesnoth.org/) sounds, which are copyright David White [dave@whitevine.net](mailto:dave@whitevine.net) under GPL 2 or later. Rights relinquished to Michael Zahniser.
 
 Files:
  images/*/pincer*
@@ -1104,11 +1104,13 @@ Files:
  images/planet/wormhole-syndicate-ad*
 Copyright: Michael Zahniser
 License: CC-BY-SA-4.0
+Comment: Created by a past contributor derived from works by Michael Zahniser (under the same license). Rights relinquished to Michael Zahniser.
 
 Files:
  images/planet/station?hai?geocoris*
 Copyright: Michael Zahniser
 License: CC-BY-SA-4.0
+Comment: Created by a past contributor derived from works by Michael Zahniser (under the same license). Rights relinquished to Michael Zahniser.
 
 Files:
  images/effect/firestorm?ring*
@@ -1235,12 +1237,13 @@ Files:
  images/outfit/korath?digger*
 Copyright: Becca Tommaso and Michael Zahniser
 License: CC-BY-SA-4.0
-Comment: Derived from works by Becca Tommaso and Michael Zahniser (under the same license).
+Comment: Created by a past contributor derived from works by Becca Tommaso and Michael Zahniser (under the same license). Rights relinquished to Becca Tommaso and Michael Zahniser.
 
 Files:
  images/*/korath*reverser*
 Copyright: Michael Zahniser
 License: CC-BY-SA-4.0
+Comment: Created by a past contributor derived from works by Michael Zahniser (under the same license). Rights relinquished to Michael Zahniser.
 
 
 Files:

--- a/data/hai/hai news.txt
+++ b/data/hai/hai news.txt
@@ -1,5 +1,4 @@
-# Copyright (c) 2020 by Nomadic Volcano
-# Based on earlier text copyright (c) 2017 by Michael Zahniser
+# Copyright (c) 2017 by Michael Zahniser
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/hai/hai reveal 2 start.txt
+++ b/data/hai/hai reveal 2 start.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Nomadic Volcano
+# Copyright (c) 2020 MasterOfGrey
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Nomadic Volcano
+# Copyright (c) 2020 MasterOfGrey
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/hai/hai reveal news.txt
+++ b/data/hai/hai reveal news.txt
@@ -1,5 +1,4 @@
-# Copyright (c) 2020 by Nomadic Volcano
-# Based on earlier text copyright (c) 2017 by Michael Zahniser
+# Copyright (c) 2017 by Michael Zahniser
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/whispering void/critters.txt
+++ b/data/whispering void/critters.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 by Nomadic Volcano
+# Copyright (c) 2020 by MasterOfGrey
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/whispering void/elenchus.txt
+++ b/data/whispering void/elenchus.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 NomadicVolcano
+# Copyright (c) 2020 MasterOfGrey
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
**Feature:** Transfers copyright of Hai Reveal

## Feature Details
I'd like to keep my name off of copyrights. Any Hai Reveal files with my name on it that had significant work from MasterOfGrey are now (C) MasterOfGrey. The ones that didn't are now Michael Zahniser. (I think the news was 100% me, but i'm only 85% certain of that. @MasterOfGrey can correct me if I'm wrong.)

The recipients of the copyright, or their legal representatives, should approve this PR.

## Performance Impact
Code is 100% faster?
