### PR TITLE
Hai Reveal: stormhold bugfix: "accompany" npcs are allowed to have disabled fighters that are docked in carriers

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -500,12 +500,21 @@ bool NPC::HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable) con
 					&& !(it->second & ShipEvent::ASSIST);
 			}
 			bool isHere = false;
+			bool isCarried = ship->CanBeCarried() && ship->GetParent();
 			// If this ship is being carried, check the parent's system.
-			if(!ship->GetSystem() && ship->CanBeCarried() && ship->GetParent())
+			if(!ship->GetSystem() && isCarried)
 				isHere = ship->GetParent()->GetSystem() == playerSystem;
 			else
 				isHere = (!ship->GetSystem() || ship->GetSystem() == playerSystem);
-			if((isHere && !isImmobile) ^ mustAccompany)
+			// For "evade" fleets, any surviving ships must either not be here or be immobile.
+			// (Windows on disabled ships are so foggy that the inhabitants cannot see out of them.)
+			if(mustEvade && isHere && !isImmobile)
+				return false;
+			// For "accompany" fleets, surviving ships must be in the system.
+			else if(mustAccompany && !isHere)
+				return false;
+			// "Accompany" ships must also be mobile, or be carried by something that is mobile.
+			else if(mustAccompany && isImmobile && !isCarried)
 				return false;
 		}
 

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -500,9 +500,9 @@ bool NPC::HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable) con
 					&& !(it->second & ShipEvent::ASSIST);
 			}
 			bool isHere = false;
-			bool isCarried = ship->CanBeCarried() && ship->GetParent();
+			bool isCarried = !ship->GetSystem() && ship->CanBeCarried() && ship->GetParent();
 			// If this ship is being carried, check the parent's system.
-			if(!ship->GetSystem() && isCarried)
+			if(isCarried)
 				isHere = ship->GetParent()->GetSystem() == playerSystem;
 			else
 				isHere = (!ship->GetSystem() || ship->GetSystem() == playerSystem);


### PR DESCRIPTION
**Bugfix:** Addresses #7662

This is one of three PRs that, together, should fix issue #7862

## Fix Details
People have reported that the stormhold battle in Hai Reveal often doesn't complete. In one instance, I found it was because a fighter was disabled, but docked in a carrier. Presently, the logic requires the fighter to not be disabled, so the mission didn't succeed. Of course, since the fighter is already docked, you can't board it to repair it.

The fix I came up with is to consider a docked ship to be accompanied, even if it is disabled. This makes sense because the ship will land inside its carrier, when the carrier lands.

This is co-authored by @Hurleveur 

~~See  #7848 for the other half of this fix: the carrier should repair the fighter, so it isn't disabled anymore. Unfortunately, that does not fix #7662 on its own, since the NPC actions for that fighter retain the `DISABLED` event forever.~~

EDIT: After further analysis, I'm pretty sure (93% certainty) that this will fix the Stormhold mission since there are no other situations where a fighter with a DISABLED event can break that particular mission. It won't fix other missions that get stuck in this corner case, but at least that mission will succeed.

## Testing Done
Tested a failed attempt at storming stormhold that should have succeeded.

I don't know if there are ways this fix could break things.

## Save File

[Friction Diction~3026-01-21  should work but does not.txt](https://github.com/endless-sky/endless-sky/files/10203381/Friction.Diction.3026-01-21.should.work.but.does.not.txt)

If #7852 is merged first, then that save file cannot be used to verify the fix since it prevents the fighters from having DISABLED in this specific situation.

## Performance Impact
One "if" with a bizarre xor became three "if" statements. May lose you a few nanoseconds.
