### PR TITLE
Increased Katya's mission chance

### DIFF
--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -1173,7 +1173,7 @@ mission "FW Katya 1"
 	destination "Glory"
 	to offer
 		or
-			random < 10 + 7 * "assisted free worlds" * "assisted free worlds"
+			random < 70 + 7 * "assisted free worlds" * "assisted free worlds"
 			has "flagship planet: Zug"
 	to fail
 		has "chosen sides"


### PR DESCRIPTION
## Summary
OK, so I'm two years into a playthrough and have been intentionally trying to start the FW campaign without success. So I went to take a look at this. This mission needs to spawn early. It is balanced on the expectation that it will. It is written on the expectation that it has. A huge chunk of game content is locked behind it. 

And its spawn chance is 10% base. That is insanely low. 

## Fix Details
Increased it to 70% base, thus ensuring that people actually can engage with the major game storyline promptly. 

## Testing Done
Absolutely none. If this breaks something, the game would have exploded by now. 

## Issue
#7850 