### PR TITLE
Making Beelzebub's Cruisers Uncapturable

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -436,7 +436,7 @@ mission "Deep: Mystery Cubes 2"
 			label accept
 			`	In the end, only one of the merchant captains declines. She is escorted out of the room, and the admiral explains each merchant captain's new role.`
 			`	"We assume that Beelzebub knows where we will be, but we know where he is as well - the stolen Cruisers and the pirate fleet that attacked our base moved toward the Core. Given the severity of the crime that Beelzebub has just committed, he will undoubtedly attempt to get as far away from the law as possible. That leaves us only two possible destinations: Buccaneer Bay, or the anarchist colonies of the Far North. Our best guess is that the colonies are the more appealing option to a warlord.`
-			`	"We'll be setting up multiple blockades in hopes of boxing Beelzebub in as a number of fleets sweep the galaxy. Captain <last>, you will be stationed on <destination> with Lieutenant Paris and a small Navy fleet. Please gather your things and travel there immediately."`
+			`	"We'll be setting up multiple blockades in hopes of boxing Beelzebub in as a number of fleets sweep the galaxy. Those Cruisers need to be destroyed - we can't risk leaving them in pirate hands. Captain <last>, you will be stationed on <destination> with Lieutenant Paris and a small Navy fleet. Please gather your things and travel there immediately."`
 				accept
 			
 	on visit
@@ -534,7 +534,7 @@ mission "Deep: Mystery Cubes 3"
 		fleet
 			names "pirate"
 			variant
-				"Cruiser" 2
+				"Stolen Cruiser" 2
 				"Fury (Laser)" 3
 
 
@@ -617,7 +617,7 @@ mission "Deep: Mystery Cubes 4"
 		fleet
 			names pirate
 			variant
-				"Cruiser" 3
+				"Stolen Cruiser" 3
 				"Marauder Leviathan"
 				"Leviathan (Hai Engines)"
 				"Headhunter (Particle)" 3

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1258,7 +1258,81 @@ ship "Cruiser"
 	"final explode" "final explosion large"
 	description "The Republic Cruiser is a relatively recent design, a much larger version of the Frigate designed to be able to take on an entire pirate fleet if necessary. In addition to a wide variety of weaponry, Cruisers have space to carry four attack drones: fast, pilotless fighters that can be controlled remotely."
 
-
+ship "Stolen Cruiser"
+	sprite "ship/cruiser"
+	thumbnail "thumbnail/cruiser"
+	"never disabled"
+	attributes
+		category "Heavy Warship"
+		licenses
+			"Navy Cruiser"
+		"cost" 11200000
+		"shields" 19600
+		"hull" 6400
+		"required crew" 81
+		"bunks" 136
+		"mass" 680
+		"drag" 10.1
+		"heat dissipation" .45
+		"fuel capacity" 600
+		"cargo space" 60
+		"outfit space" 760
+		"weapon capacity" 320
+		"engine capacity" 170
+		weapon
+			"blast radius" 260
+			"shield damage" 2600
+			"hull damage" 1300
+			"hit force" 3900
+	outfits
+		"Particle Cannon" 4
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 90
+		"Heavy Laser Turret" 2
+		"Heavy Anti-Missile Turret" 2
+		
+		"Fusion Reactor"
+		"LP288a Battery Pack"
+		"D67-TM Shield Generator"
+		"Large Radar Jammer" 2
+		"Liquid Nitrogen Cooler"
+		"Laser Rifle" 20
+		"Fragmentation Grenades" 20
+		"Security Station"
+		"Tactical Scanner"
+		
+		"X4700 Ion Thruster"
+		"X4200 Ion Steering"
+		"Hyperdrive"
+		
+	engine -28 154 0.95
+	engine 28 154 0.95
+	engine -52 151 0.75
+	engine 52 151 0.75
+	gun -30 -55 "Particle Cannon"
+	gun 30 -55 "Particle Cannon"
+	gun -40.5 -52 "Particle Cannon"
+	gun 40.5 -52 "Particle Cannon"
+	gun -30 -30 "Sidewinder Missile Launcher"
+	gun 30 -30 "Sidewinder Missile Launcher"
+	turret 0 -39.5 "Heavy Anti-Missile Turret"
+	turret -32 -23 "Heavy Laser Turret"
+	turret 32 -23 "Heavy Laser Turret"
+	turret 0 0 "Heavy Anti-Missile Turret"
+	bay "Drone" -25 19.5
+	bay "Drone" 25 19.5
+	bay "Drone" -25 49.5
+	bay "Drone" 25 49.5
+	leak "leak" 30 50
+	leak "flame" 50 80
+	leak "big leak" 40 30
+	explode "tiny explosion" 20
+	explode "small explosion" 45
+	explode "medium explosion" 50
+	explode "large explosion" 40
+	explode "huge explosion" 10
+	"final explode" "final explosion large"
+	description "The Republic Cruiser is a relatively recent design, a much larger version of the Frigate designed to be able to take on an entire pirate fleet if necessary. In addition to a wide variety of weaponry, Cruisers have space to carry four attack drones: fast, pilotless fighters that can be controlled remotely. Somebody stole this one, and the Republic wants it destroyed."
 
 ship "Dagger"
 	sprite "ship/dagger"


### PR DESCRIPTION
## Summary
Cruisers in Beelzebub's missions will now be impossible to disable (and thus impossible to capture). Added a line of dialogue to mention that. Since the end mission text assumes they were all destroyed, and it would really be a bit odd if the Republic let you capture and keep them, and coding in the option to capture them and sell them back to the Republic could charitably be described as 'involved'... 

This seemed simplest. Much as I like having three Cruisers now (I got a third one from the surveillance drone mission because they wouldn't stop nosing around), it really doesn't make any sense. 

This is a partial attempt to address some of the issues I found with the Bactrian questline, as described in issue #7826 . There will be others, but this is the most straightforward one and it seemed best to start with it. 

## Testing Done
Absolutely none! While I do intend to test it, I have no saves anywhere near it, and so am not really in a position to do so at the moment. Am going to work my way back there and attempt it. 