### PR TITLE
Removes the Ubuntu CD run

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -118,7 +118,6 @@ jobs:
       - cd_macos_x86_64
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      OUTPUT_UBUNTU: endless-sky-x86_64-continuous.tar.gz
       OUTPUT_APPIMAGE: endless-sky-x86_64-continuous.AppImage
       OUTPUT_WINDOWS: EndlessSky-win64-continuous.zip
       OUTPUT_MACOS: EndlessSky-macOS-continuous.zip
@@ -161,13 +160,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: ${{ github.workspace }} # This will download all files to e.g `./EndlessSky-win64.zip/EndlessSky-win64.zip`
-      - name: Add ${{ env.OUTPUT_UBUNTU }} to release tag
-        run: |
-          github-release upload \
-            --tag continuous \
-            --replace \
-            --name ${{ env.OUTPUT_UBUNTU }} \
-            --file ${{ env.OUTPUT_UBUNTU }}/${{ env.OUTPUT_UBUNTU }}
       - name: Add ${{ env.OUTPUT_APPIMAGE }} to release tag
         run: |
           github-release upload \

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,33 +15,6 @@ concurrency:
 
 jobs:
 
-  cd_ubuntu_x86_64:
-    runs-on: ubuntu-latest
-    env:
-      OUTPUT: endless-sky-x86_64-continuous.tar.gz
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: |
-          sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsdl2-dev libpng-dev libjpeg-turbo8-dev libopenal-dev libmad0-dev libglew-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev uuid-dev
-          python3 -m pip install --user scons
-      - name: Adjust version strings
-        run: ./utils/cd_update_versions.sh
-        shell: bash
-      - name: Build Application
-        run: scons -Qj $(nproc)
-      - name: Run Unit Tests
-        run: scons -Qj $(nproc) test
-      - name: Package Application
-        run: tar -czf ${{ env.OUTPUT }} sounds images/ data/ license.txt keys.txt icon.png endless-sky credits.txt copyright changelog
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.OUTPUT }}
-          path: ${{ env.OUTPUT }}
-
   cd_appimage_x86_64:
     runs-on: ubuntu-20.04
     env:


### PR DESCRIPTION
This PR simply removes the basic Ubuntu CD job. That job isn't very useful because the binary created is only usable on a specific Ubuntu version. For Linux CD releases the AppImage CD is the one to use.