### PR TITLE
Fix from @vitalchip: Ship::Carry() refuses to carry a disabled ship

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3651,7 +3651,7 @@ bool Ship::CanBeCarried() const
 
 bool Ship::Carry(const shared_ptr<Ship> &ship)
 {
-	if(!ship || !ship->CanBeCarried())
+	if(!ship || !ship->CanBeCarried() || ship->IsDisabled())
 		return false;
 
 	// Check only for the category that we are interested in.


### PR DESCRIPTION
**Bugfix:** This is an alternative fix to #7862

This fix is from @vitalchip. All I did was test it and make a PR.

**Important: There are two competing solutions. Please discuss them here: https://github.com/endless-sky/endless-sky/issues/7862**

## Fix Details
Carriers will refuse to Carry() a disabled ship.

## Testing Done
This does fix the one reproducible test case I have for the Stormhold mission (#7662)

However, I expect there are many corner cases this will break. This is the correct fix for the problem, though.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 0e7747e7f, and will not occur when using this branch's build.
[Friction Diction~3026-01-21  should work but does not.txt](https://github.com/endless-sky/endless-sky/files/10213016/Friction.Diction.3026-01-21.should.work.but.does.not.txt)
