### PR TITLE
Simplify data parsing CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,7 @@ jobs:
 
   test_memory-leaks-lite:
     name: Memory Leak Test
-    needs: [test_ubuntu-parse, changed]
+    needs: [build_ubuntu, changed]
     if: needs.changed.outputs.game_code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,6 @@ jobs:
   build_macos:
     name: MacOS
     needs: changed
-    # TODO: only build if source changed. otherwise, d/l latest continuous
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -297,20 +296,11 @@ jobs:
       SDL2_FRAMEWORK: build/SDL2.framework
     steps:
     - uses: actions/checkout@v3
-    - name: Restore cached game binary
-      id: cache-artifact
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.ARTIFACT }}
-        key: ${{ matrix.os }}-artifacts-${{ hashFiles('source/**', '.github/workflows/ci.yml', 'EndlessSky.xcodeproj/**', 'utils/set_dylibs_rpath.sh', 'utils/fetch_sdl2_framework.sh') }}
-    - name: Update Homebrew
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: brew update
     - name: Install dependencies
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: brew install libpng jpeg-turbo
+      run: |
+        brew update
+        brew install libpng jpeg-turbo
     - name: Restore cached SDL2 framework
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/cache@v3
       with:
         path: ${{ env.SDL2_FRAMEWORK }}
@@ -318,14 +308,6 @@ jobs:
     - name: Compile
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: xcodebuild -configuration "Release" -jobs $(sysctl -n hw.logicalcpu) -quiet
-    - name: Prepare game binary
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: mv "build/Release/Endless Sky.app/Contents/MacOS/Endless Sky" .
-    - name: Upload game binary
-      uses: actions/upload-artifact@v3
-      with:
-        name: binary-${{ matrix.os }}
-        path: ${{ env.ARTIFACT }}
 
 
   test_ubuntu-integration:
@@ -372,41 +354,10 @@ jobs:
         PRINT_GLXINFO: true
       run: ./tests/integration/run_tests_headless.sh
 
-
-  test_ubuntu-parse:
-    name: Ubuntu Parse
-    needs: [build_ubuntu, changed]
-    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.data == 'true' }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        opengl: [desktop]
-        include:
-          - os: ubuntu-20.04
-            glew: libglew2.1
-          - os: ubuntu-22.04
-            glew: libglew2.2
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install runtime dependencies
-      run: |
-        sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libpng16-16 libjpeg-turbo8 libopenal1 libmad0 ${{ matrix.glew }} libgl1 uuid-runtime libglvnd-dev
-    - name: Download game binary
-      uses: actions/download-artifact@v3
-      with:
-        name: binary-${{ matrix.os }}-${{ matrix.opengl }}
-    - name: Verify Executable
-      run: chmod +x endless-sky && ./endless-sky -v
-    - name: Parse Datafiles
-      run: ./utils/test_parse.sh ./endless-sky
-
-
-  test_windows-parse:
-    name: Windows Parse
+  test-parse:
+    name: Data Parse
     needs: [build_windows, changed]
-    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.data == 'true' }}
+    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.data == 'true' || needs.changed.outputs.integration_tests == 'true' }}
     runs-on: ${{ matrix.os }}
     env:
       DIR_MINGW64: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64
@@ -428,79 +379,10 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: binary-${{ matrix.os }}
-    - name: Parse Datafiles
+    - name: Parse Data
       run: .\utils\test_parse.ps1 EndlessSky.exe
-
-
-  test_macos-parse:
-    name: MacOS Parse
-    needs: [build_macos, changed]
-    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.data == 'true' }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest]
-    env:
-      ES_BINARY: Endless Sky
-      SDL2_FRAMEWORK: build/SDL2.framework
-    steps:
-    - uses: actions/checkout@v3
-    - name: Update Homebrew
-      run: brew update
-    - name: Install dependencies
-      run: brew install libmad libpng jpeg-turbo
-    - name: Restore cached SDL2 framework
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.SDL2_FRAMEWORK }}
-        key: ${{ matrix.os }}-sdl2-${{ hashFiles('.github/workflows/ci.yml', 'EndlessSky.xcodeproj/**', 'utils/set_dylibs_rpath.sh', 'utils/fetch_sdl2_framework.sh') }}
-    - name: Add support files
-      run: |
-        mkdir -p Contents/Frameworks Contents/MacOS Contents/Resources
-        ln -s /usr/local/opt/libmad/lib/libmad.0.dylib Contents/Frameworks/
-        ln -s /usr/local/opt/libpng/lib/libpng16.dylib Contents/Frameworks/
-        ln -s /usr/local/opt/jpeg-turbo/lib/libturbojpeg.0.dylib Contents/Frameworks/
-        mv ${{ env.SDL2_FRAMEWORK }} Contents/Frameworks/
-        cd Contents/Resources/
-        ln -s ../../data
-        ln -s ../../images
-        ln -s ../../sounds
-    - name: Download game binary
-      uses: actions/download-artifact@v3
-      with:
-        name: binary-${{ matrix.os }}
-        path: Contents/MacOS
-    - name: Verify Executable
-      run: chmod +x "Contents/MacOS/${ES_BINARY}" && ./"Contents/MacOS/${ES_BINARY}" -v
-    - name: Parse Datafiles
-      run: ./utils/test_parse.sh ./"Contents/MacOS/${ES_BINARY}"
-
-
-  test_ubuntu-integration-parse:
-    name: Integration Tests Parse
-    needs: [build_ubuntu, changed]
-    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.data == 'true' || needs.changed.outputs.integration_tests == 'true' }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        opengl: [desktop]
-        include:
-          - os: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install runtime dependencies
-      run: |
-        sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libpng16-16 libjpeg-turbo8 libopenal1 libmad0 libglew2.2 libgl1 uuid-runtime libglvnd-dev
-    - name: Download game binary
-      uses: actions/download-artifact@v3
-      with:
-        name: binary-${{ matrix.os }}-${{ matrix.opengl }}
-    - name: Verify Executable
-      run: chmod +x endless-sky && ./endless-sky -v
-    - name: Parse Datafiles
-      run: ./utils/test_parse.sh ./endless-sky tests/integration/config
+    - name: Parse Integration Test Data
+      run: .\utils\test_parse.ps1 EndlessSky.exe tests/integration/config
 
 
   test_memory-leaks-lite:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
       run: ./tests/integration/run_tests_headless.sh
 
   test-parse:
-    name: Data Parse
+    name: Data Files
     needs: [build_windows, changed]
     if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.data == 'true' || needs.changed.outputs.integration_tests == 'true' }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,7 @@ jobs:
   build_macos:
     name: MacOS
     needs: changed
+    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.xcode_files == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -12,7 +12,7 @@
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
 mission "Escort (Tiny, Northern, Dangerous Destination)"
-	name "Escorft to <planet>"
+	name "Escort to <planet>"
 	description "Despite your relative inexperience, the captain of the <npc> is willing to pay you <payment> for an escort into a dangerous region of space to reach <destination> by <date>."
 	repeat
 	job

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -12,7 +12,7 @@
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
 mission "Escort (Tiny, Northern, Dangerous Destination)"
-	name "Escort to <planet>"
+	name "Escorft to <planet>"
 	description "Despite your relative inexperience, the captain of the <npc> is willing to pay you <payment> for an escort into a dangerous region of space to reach <destination> by <date>."
 	repeat
 	job


### PR DESCRIPTION
This simplifies the data parsing CI: Instead of running 4 jobs (one one each platform and an additional one for the integration tests), it only keeps the Windows data parsing job and merges the integration test checks into it as well.

The reason for this is that it is not necessary to parse the data files on each OS; there's nothing OS specific so the 3 jobs will always have the same output.

As a result of this, the MacOS job doesn't have to upload or cache any binaries anymore.

## Testing Done

CI will test it, but I'm only removing stuff.