### PR TITLE
Test parse script improvements

### DIFF
--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -12,7 +12,7 @@
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
 mission "Escort (Tiny, Northern, Dangerous Destination)"
-	name "Escort to <planet>"
+	name "Escfort to <planet>"
 	description "Despite your relative inexperience, the captain of the <npc> is willing to pay you <payment> for an escort into a dangerous region of space to reach <destination> by <date>."
 	repeat
 	job

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -11,7 +11,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-mission "Escort (Tiny, Northern, Dangerous Destination)"
+missidfon "Escort (Tiny, Northern, Dangerous Destination)"
 	name "Escort to <planet>"
 	description "Despite your relative inexperience, the captain of the <npc> is willing to pay you <payment> for an escort into a dangerous region of space to reach <destination> by <date>."
 	repeat

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -12,7 +12,7 @@
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
 mission "Escort (Tiny, Northern, Dangerous Destination)"
-	name "Escfort to <planet>"
+	name "Escort to <planet>"
 	description "Despite your relative inexperience, the captain of the <npc> is willing to pay you <payment> for an escort into a dangerous region of space to reach <destination> by <date>."
 	repeat
 	job

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -11,7 +11,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-missidfon "Escort (Tiny, Northern, Dangerous Destination)"
+mission "Escort (Tiny, Northern, Dangerous Destination)"
 	name "Escort to <planet>"
 	description "Despite your relative inexperience, the captain of the <npc> is willing to pay you <payment> for an escort into a dangerous region of space to reach <destination> by <date>."
 	repeat

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -17,7 +17,14 @@ $ERR_FILE = Join-Path -Path $FILEDIR -ChildPath "errors.txt";
 if (Test-Path -Path $ERR_FILE) { Remove-Item -Path $ERR_FILE; }
 
 # Parse the game data files
-$p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p','--config',"$FILEDIR" -Wait -PassThru;
+if ($CONFIG)
+{
+  $p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p','--config',"$FILEDIR" -Wait -PassThru;
+}
+else
+{
+  $p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p' -Wait -PassThru;
+}
 
 # Assert there is no content in the "errors.txt" file.
 if ((Test-Path -Path "$ERR_FILE") -and ((Get-Content -Path "$ERR_FILE" -Raw).Length -gt 0))

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -1,28 +1,23 @@
 # PowerShell test script (for testing on Windows CI services)
 param(
   [Parameter(Mandatory=$true, HelpMessage="Path to the Endless Sky executable file")]
-  $EndlessSky #The input binary to execute
+  $EndlessSky, #The input binary to execute
+  [Parameter(HelpMessage="Path to the Endless Sky configuration")]
+  $Config
 )
 # Ensure the argument is a path to the binary (lest Start-Process complain).
 $EndlessSky = Resolve-Path -Path "$EndlessSky" -Relative;
 
-$av = !!$env:APPVEYOR;
-$testName = "Parse Game Data";
-if ($av)
-{
-  Add-AppveyorTest -Name $testName -Framework 'ES' -FileName $EndlessSky -Outcome Running;
-}
 # Remove any existing error files first.
-$FILEDIR = if ($IsWindows -or $Env:OS.ToLower().Contains('windows')) `
+$FILEDIR = if ($IsWindows) `
           { "$env:APPDATA\endless-sky" } `
           else { "$env:HOME/.local/share/endless-sky" };
+if ($Config) { $FILEDIR = $CONFIG; }
 $ERR_FILE = Join-Path -Path $FILEDIR -ChildPath "errors.txt";
 if (Test-Path -Path $ERR_FILE) { Remove-Item -Path $ERR_FILE; }
 
 # Parse the game data files
-$start = $(Get-Date);
-$p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p' -Wait -PassThru;
-$dur = New-TimeSpan -Start $start -End $(Get-Date);
+$p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p','--config',$FILEDIR -Wait -PassThru;
 
 # Assert there is no content in the "errors.txt" file.
 if ((Test-Path -Path "$ERR_FILE") -and ((Get-Content -Path "$ERR_FILE" -Raw).Length -gt 0))
@@ -30,27 +25,8 @@ if ((Test-Path -Path "$ERR_FILE") -and ((Get-Content -Path "$ERR_FILE" -Raw).Len
   $err_msg = "Assertion failed: content written to file $ERR_FILE";
   $content = Get-Content -Path "$ERR_FILE" -Raw;
   Write-Host $content;
-  if ($av)
-  {
-    $messages = @();
-    $content.Split("`n") | ForEach-Object `
-    {
-      if ($_.StartsWith(' ') -or $_.StartsWith('file'))
-        { $messages[-1] += "`n$_"; }
-      elseif ($_) { $messages += $_; }
-    }
-    Update-AppveyorTest -Name $testName -Framework 'ES' -FileName $EndlessSky `
-      -Outcome Failed -Duration $dur.TotalMilliseconds -ErrorMessage $err_msg `
-      -StdErr ($messages -Join "`n`n");
-  }
-
   Write-Error -Message $err_msg -Category ParserError;
   exit 1;
-}
-elseif ($av)
-{
-  Update-AppveyorTest -Name $testName -Framework 'ES' `
-    -FileName $EndlessSky -Outcome Passed -Duration $dur.TotalMilliseconds;
 }
 else { Write-Host "No data-parsing errors were encountered"; }
 exit $p.ExitCode;

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -20,21 +20,19 @@ if (Test-Path -Path $ERR_FILE) { Remove-Item -Path $ERR_FILE; }
 # Parse the game data files
 if ($CONFIG)
 {
-  & "$EndlessSky" -p --config "$FILEDIR" 2> $null | Out-Null;
+  $p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p','--config',"$FILEDIR" -Wait -PassThru -NoNewWindow;
 }
 else
 {
-  & "$EndlessSky" -p 2> $null | Out-Null;
+  $p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p' -Wait -PassThru -NoNewWindow;
 }
 
 # Assert there is no content in the "errors.txt" file.
 if ((Test-Path -Path "$ERR_FILE") -and ((Get-Content -Path "$ERR_FILE" -Raw).Length -gt 0))
 {
   $err_msg = "Assertion failed: content written to file $ERR_FILE";
-  $content = Get-Content -Path "$ERR_FILE" -Raw;
-  Write-Host $content;
   Write-Error -Message $err_msg;
   exit 1;
 }
 else { Write-Host "No data-parsing errors were encountered"; }
-exit $LASTEXITCODE;
+exit $p.ExitCode;

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -17,7 +17,7 @@ $ERR_FILE = Join-Path -Path $FILEDIR -ChildPath "errors.txt";
 if (Test-Path -Path $ERR_FILE) { Remove-Item -Path $ERR_FILE; }
 
 # Parse the game data files
-$p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p','--config',$FILEDIR -Wait -PassThru;
+$p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p','--config',"$FILEDIR" -Wait -PassThru;
 
 # Assert there is no content in the "errors.txt" file.
 if ((Test-Path -Path "$ERR_FILE") -and ((Get-Content -Path "$ERR_FILE" -Raw).Length -gt 0))

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -11,6 +11,7 @@ $EndlessSky = Resolve-Path -Path "$EndlessSky" -Relative;
 # Remove any existing error files first.
 $FILEDIR = if ($IsWindows) `
           { "$env:APPDATA\endless-sky" } `
+          elseif ($IsMacOS) { "$env:HOME/Library/Application Support/endless-sky"} `
           else { "$env:HOME/.local/share/endless-sky" };
 if ($Config) { $FILEDIR = $CONFIG; }
 $ERR_FILE = Join-Path -Path $FILEDIR -ChildPath "errors.txt";

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -11,7 +11,7 @@ $EndlessSky = Resolve-Path -Path "$EndlessSky" -Relative;
 # Remove any existing error files first.
 $FILEDIR = if ($IsWindows) `
           { "$env:APPDATA\endless-sky" } `
-          elseif ($IsMacOS) { "$env:HOME/Library/Application Support/endless-sky"} `
+          elseif ($IsMacOS) { "$env:HOME/Library/Application Support/endless-sky" } `
           else { "$env:HOME/.local/share/endless-sky" };
 if ($Config) { $FILEDIR = $CONFIG; }
 $ERR_FILE = Join-Path -Path $FILEDIR -ChildPath "errors.txt";

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -20,11 +20,11 @@ if (Test-Path -Path $ERR_FILE) { Remove-Item -Path $ERR_FILE; }
 # Parse the game data files
 if ($CONFIG)
 {
-  & "$EndlessSky" -p --config "$FILEDIR" 2> null;
+  & "$EndlessSky" -p --config "$FILEDIR" 2> $null;
 }
 else
 {
-  & "$EndlessSky" -p 2> null;
+  & "$EndlessSky" -p 2> $null;
 }
 
 # Assert there is no content in the "errors.txt" file.

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -20,13 +20,12 @@ if (Test-Path -Path $ERR_FILE) { Remove-Item -Path $ERR_FILE; }
 # Parse the game data files
 if ($CONFIG)
 {
-  & "$EndlessSky" -p --config "$FILEDIR" 2> $null;
+  & "$EndlessSky" -p --config "$FILEDIR" 2> $null | Out-Null;
 }
 else
 {
-  & "$EndlessSky" -p 2> $null;
+  & "$EndlessSky" -p 2> $null | Out-Null;
 }
-& "$EndlessSky" -p;
 
 # Assert there is no content in the "errors.txt" file.
 if ((Test-Path -Path "$ERR_FILE") -and ((Get-Content -Path "$ERR_FILE" -Raw).Length -gt 0))

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -26,9 +26,7 @@ else
 {
   & "$EndlessSky" -p 2> $null;
 }
-Write-Host $ERR_FILE
-$A = Test-Path -Path "$ERR_FILE"
-Write-Host $A
+& "$EndlessSky" -p;
 
 # Assert there is no content in the "errors.txt" file.
 if ((Test-Path -Path "$ERR_FILE") -and ((Get-Content -Path "$ERR_FILE" -Raw).Length -gt 0))

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -20,11 +20,11 @@ if (Test-Path -Path $ERR_FILE) { Remove-Item -Path $ERR_FILE; }
 # Parse the game data files
 if ($CONFIG)
 {
-  $p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p','--config',"$FILEDIR" -Wait -PassThru;
+  & "$EndlessSky" -p --config "$FILEDIR" 2> null;
 }
 else
 {
-  $p = Start-Process -FilePath "$EndlessSky" -ArgumentList '-p' -Wait -PassThru;
+  & "$EndlessSky" -p 2> null;
 }
 
 # Assert there is no content in the "errors.txt" file.
@@ -33,8 +33,8 @@ if ((Test-Path -Path "$ERR_FILE") -and ((Get-Content -Path "$ERR_FILE" -Raw).Len
   $err_msg = "Assertion failed: content written to file $ERR_FILE";
   $content = Get-Content -Path "$ERR_FILE" -Raw;
   Write-Host $content;
-  Write-Error -Message $err_msg -Category ParserError;
+  Write-Error -Message $err_msg;
   exit 1;
 }
 else { Write-Host "No data-parsing errors were encountered"; }
-exit $p.ExitCode;
+exit $LASTEXITCODE;

--- a/utils/test_parse.ps1
+++ b/utils/test_parse.ps1
@@ -26,6 +26,9 @@ else
 {
   & "$EndlessSky" -p 2> $null;
 }
+Write-Host $ERR_FILE
+$A = Test-Path -Path "$ERR_FILE"
+Write-Host $A
 
 # Assert there is no content in the "errors.txt" file.
 if ((Test-Path -Path "$ERR_FILE") -and ((Get-Content -Path "$ERR_FILE" -Raw).Length -gt 0))

--- a/utils/test_parse.sh
+++ b/utils/test_parse.sh
@@ -26,8 +26,14 @@ if [ -f "$ERR_FILE" ]; then
   rm -f "$ERR_FILE"
 fi
 
+if [ "$2" ]; then
+  "$1" -p --config "$FILEDIR" 2>"$RUNTIME_ERRS"
+else
+  "$1" -p 2>"$RUNTIME_ERRS"
+fi
+
 # Parse the game data files.
-if ! "$1" -p --config "$FILEDIR" 2>"$RUNTIME_ERRS"; then
+if [ $? -ne 0 ]; then
   EXIT_CODE=$?
   echo "Error executing file/command '$1':"
   cat "$RUNTIME_ERRS"


### PR DESCRIPTION
This PR does the following:

Powershell:

- Remove AppVeyor logic that isn't used anymore
- Add the optional parameter to specify the config path to pass to the executable.
- I removed ` -or $Env:OS.ToLower().Contains('windows')` because `$Env:OS` is not portable
- Added support for MacOS
- Don't show the error output is twice
- Actually write the error message to stderr. Specifying the category seems to suppress the output (wtf), so I just removed it.

Bash:

- Fixed abort in CI when called with no config folder

## Testing Done

Tested the scripts locally, it works! I also added a dummy change to verify that it works in CI too.