### PR TITLE
Content: add tribute fleets for the unfettered

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -28841,10 +28841,10 @@ planet Darkcloak
 	spaceport `	It is likely that most of the goods available for trade here were stolen from one of the nearby Hai systems.`
 	shipyard "Mon Ki o'Uden Advanced"
 	outfitter "Unfettered Basics"
-	tribute 3000
+	tribute 3500
 		threshold 10000
-		fleet "Large Unfettered" 50
-		fleet "Small Unfettered" 10
+		fleet "Large Unfettered" 25
+		fleet "Small Unfettered" 15
 
 planet Darkmetal
 	attributes hai "hai tourism" mining
@@ -29314,10 +29314,10 @@ planet Firelode
 	landscape land/mountain25-spfld
 	description `The Unfettered are operating several large strip mines here to collect uranium and plutonium to fuel the generators in their warships. Older, abandoned mining pits are scattered throughout the planet's surface. As a result of the mining activity, the groundwater here has become badly contaminated.`
 	spaceport `The spaceport is in the middle of a large city with typical Hai architecture: raw metal and chamfered corners. However, much of the city appears to have been ruined long ago, probably in a battle. The ruins have not been rebuilt, but instead it appears that most of the ruined buildings have been torn down for scrap metal. Several of the spaceport hangars are in bad repair, as well.`
-	tribute 1500
+	tribute 2000
 		threshold 10000
-		fleet "Large Unfettered" 20
-		fleet "Small Unfettered" 20
+		fleet "Large Unfettered" 15
+		fleet "Small Unfettered" 5
 
 planet "Firka Tesk"
 	attributes korath
@@ -32183,9 +32183,9 @@ planet Warfeed
 	description `Warfeed is mostly covered in oceans, and much of its land area devoted to agriculture. Most of the fields are tilled and harvested by robots, but there are also many scattered homesteads of subsistence farmers, who survive with the aid of little or no technology.`
 	description `	In recent years, both the land and the seas of Warfeed have begun to show the toll of centuries of overharvesting. Large portions of the continents near the equator are now nothing but growing deserts, and even the best remaining farmland is sandy and nutrient-poor. All but the smallest marine organisms have been nearly fished to extinction.`
 	spaceport `This spaceport is a collection of ramshackle wooden buildings and packed dirt landing pads. The wagons piled high with produce and bags of grain would not look out of place in many human ports, but they are being drawn by giant lizards instead of horses or oxen. There are no human beings here, and most of the Hai eye you with suspicion and distaste.`
-	tribute 5000
+	tribute 6000
 		threshold 10000
-		fleet "Large Unfettered" 25
+		fleet "Large Unfettered" 10
 		fleet "Small Unfettered" 100
 
 planet "Warm Slope"

--- a/data/map.txt
+++ b/data/map.txt
@@ -28841,6 +28841,10 @@ planet Darkcloak
 	spaceport `	It is likely that most of the goods available for trade here were stolen from one of the nearby Hai systems.`
 	shipyard "Mon Ki o'Uden Advanced"
 	outfitter "Unfettered Basics"
+	tribute 3000
+		threshold 10000
+		fleet "Large Unfettered" 50
+		fleet "Small Unfettered" 10
 
 planet Darkmetal
 	attributes hai "hai tourism" mining
@@ -29310,6 +29314,10 @@ planet Firelode
 	landscape land/mountain25-spfld
 	description `The Unfettered are operating several large strip mines here to collect uranium and plutonium to fuel the generators in their warships. Older, abandoned mining pits are scattered throughout the planet's surface. As a result of the mining activity, the groundwater here has become badly contaminated.`
 	spaceport `The spaceport is in the middle of a large city with typical Hai architecture: raw metal and chamfered corners. However, much of the city appears to have been ruined long ago, probably in a battle. The ruins have not been rebuilt, but instead it appears that most of the ruined buildings have been torn down for scrap metal. Several of the spaceport hangars are in bad repair, as well.`
+	tribute 1500
+		threshold 10000
+		fleet "Large Unfettered" 20
+		fleet "Small Unfettered" 20
 
 planet "Firka Tesk"
 	attributes korath
@@ -32175,6 +32183,10 @@ planet Warfeed
 	description `Warfeed is mostly covered in oceans, and much of its land area devoted to agriculture. Most of the fields are tilled and harvested by robots, but there are also many scattered homesteads of subsistence farmers, who survive with the aid of little or no technology.`
 	description `	In recent years, both the land and the seas of Warfeed have begun to show the toll of centuries of overharvesting. Large portions of the continents near the equator are now nothing but growing deserts, and even the best remaining farmland is sandy and nutrient-poor. All but the smallest marine organisms have been nearly fished to extinction.`
 	spaceport `This spaceport is a collection of ramshackle wooden buildings and packed dirt landing pads. The wagons piled high with produce and bags of grain would not look out of place in many human ports, but they are being drawn by giant lizards instead of horses or oxen. There are no human beings here, and most of the Hai eye you with suspicion and distaste.`
+	tribute 5000
+		threshold 10000
+		fleet "Large Unfettered" 25
+		fleet "Small Unfettered" 100
 
 planet "Warm Slope"
 	attributes saryd urban


### PR DESCRIPTION
Adds a tribute fleet for each of the 3 default Unfettered planets.
They would not accept tribute on the new ones; they don't even let you land there, and most importantly there isn't anything to tribute from there (yet), the Unfettered understand tribute as food, and money. In order to be considered serious you need to have a significant battle reputation.

I tried to not make the fleets too strong, they are all below remnant level of power.
Darkcloak is well defended being the shipyard and the point from where all ships go, to Wah Ki or to Wanderer space.
Warfeed is their only source of food, they will fight to the last to defend it. That fleet is there to defend the world against potential Korath raids.
Firelode does not matter much. It produces heavy metals but it being cut won't destroy the Unfettered. Furthermore, they do not expect an attack there, and even if there is one its not like there is much to defend, Unfettered are there to go raid (the food does not come from the world itself)

The tributes are not disabled during the war with the wanderers, although I could change that; the idea is that a lot of ships stay behind because of a lack of Jump Drives, and to keep the Hai at bay should they try something. The Unfettered never have to commit too many ships in the attacks on the Wanderers as of yet, and the smaller ships are more likely to stay behind.
I'm open to changes regarding the strength of the fleet and the amount of the tribute itself.