### PR TITLE
First Rough Draft Of Crew Life Insurance Costs After Crew Deaths

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -427,7 +427,7 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 
 
 
-void AI::UpdateEvents(const list<ShipEvent> &events)
+void AI::UpdateEvents(PlayerInfo &player, const list<ShipEvent> &events)
 {
 	for(const ShipEvent &event : events)
 	{
@@ -455,6 +455,22 @@ void AI::UpdateEvents(const list<ShipEvent> &events)
 				if(event.Type() & ShipEvent::PROVOKE)
 					newActions |= ShipEvent::PROVOKE;
 				event.TargetGovernment()->Offend(newActions, target->CrewValue());
+
+				if(event.Type() & ShipEvent::DESTROY)
+				{
+					player.HandleInflectedDestroyEvent(event.Target());
+				}
+			}
+		}
+		const auto &targetGovernment = event.TargetGovernment();
+		if(targetGovernment)
+		{
+			if(targetGovernment->IsPlayer())
+			{
+				if(event.Type() & ShipEvent::DESTROY)
+				{
+					player.HandleIncurredDestroyEvent(event.Target());
+				}
 			}
 		}
 	}

--- a/source/AI.h
+++ b/source/AI.h
@@ -61,7 +61,7 @@ template <class Type>
 	void UpdateKeys(PlayerInfo &player, Command &clickCommands);
 
 	// Allow the AI to track any events it is interested in.
-	void UpdateEvents(const std::list<ShipEvent> &events);
+	void UpdateEvents(PlayerInfo &player, const std::list<ShipEvent> &events);
 	// Reset the AI's memory of events.
 	void Clean();
 	// Clear ship orders. This should be done when the player lands on a planet,

--- a/source/Account.h
+++ b/source/Account.h
@@ -54,6 +54,10 @@ public:
 	const std::vector<Mortgage> &Mortgages() const;
 	void AddMortgage(int64_t principal);
 	void AddFine(int64_t amount);
+	void AddCrewLifeInsuranceCounter(int64_t deaths);
+	void DecayCrewLifeInsuranceCounter();
+	double CrewLifeInsuranceSalariesMultiplier() const;
+	int64_t CalculateCrewLifeInsuranceCost(int64_t salaries) const;
 	int64_t Prequalify() const;
 	// Assets:
 	int64_t NetWorth() const;
@@ -76,6 +80,7 @@ private:
 	int64_t maintenanceDue = 0;
 	// Your credit score determines the interest rate on your mortgages.
 	int creditScore = 400;
+	int64_t crewLifeInsuranceCounter = 0;
 
 	std::vector<Mortgage> mortgages;
 

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -346,6 +346,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 
 				if(Random::Real() * total >= yourPower)
 					you->AddCrew(-1);
+					player.HandleIncurredCrewCasualties(-1);
 				else
 					victim->AddCrew(-1);
 			}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -482,7 +482,7 @@ void Engine::Step(bool isActive)
 		else if(jumpCount > 0)
 			--jumpCount;
 	}
-	ai.UpdateEvents(events);
+	ai.UpdateEvents(player, events);
 	if(isActive)
 	{
 		HandleKeyboardInputs();

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -345,6 +345,14 @@ void PlayerInfo::Load(const string &path)
 		}
 		else if(child.Token(0) == "start")
 			startData.Load(child);
+		else if(child.Token(0) == "incurred crew casualties" && child.Size() >= 2)
+			incurredCrewCasualties = child.Value(1);
+		else if(child.Token(0) == "incurred ship losses" && child.Size() >= 2)
+			incurredShipLosses = child.Value(1);
+		else if(child.Token(0) == "inflicted crew casualties" && child.Size() >= 2)
+			inflictedCrewCasualties = child.Value(1);
+		else if(child.Token(0) == "inflicted ship losses" && child.Size() >= 2)
+			inflictedShipLosses = child.Value(1);
 	}
 	// Modify the game data with any changes that were loaded from this file.
 	ApplyChanges();
@@ -2535,6 +2543,27 @@ set<string> &PlayerInfo::Collapsed(const string &name)
 
 
 
+void HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship)
+{
+	incurredShipLosses++;
+	incurredCrewCasualties += ship ? ship->Crew() : 0;
+}
+
+
+
+void HandleInflectedDestroyEvent(const std::shared_ptr<Ship> &ship)
+{
+	inflictedShipLosses++;
+	inflictedCrewCasualties += ship ? ship->Crew() : 0;
+}
+
+void HandleIncurredCrewCasualties(int deaths)
+{
+	incurredCrewCasualties += deaths;
+}
+
+
+
 // Apply any "changes" saved in this player info to the global game state.
 void PlayerInfo::ApplyChanges()
 {
@@ -3841,6 +3870,11 @@ void PlayerInfo::Save(const string &path) const
 	out.Write();
 	out.WriteComment("How you began:");
 	startData.Save(out);
+
+	out.Write("incurred crew casualties", incurredCrewCasualties);
+	out.Write("incurred ship losses", incurredShipLosses);
+	out.Write("inflicted crew casualties", inflictedCrewCasualties);
+	out.Write("inflicted ship losses", inflictedShipLosses);
 
 	// Write plugins to player's save file for debugging.
 	if(!GameData::PluginAboutText().empty())

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -291,6 +291,9 @@ public:
 	void SetMapZoom(int level);
 	// Get the set of collapsed categories for the named panel.
 	std::set<std::string> &Collapsed(const std::string &name);
+	void HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship);
+	void HandleInflectedDestroyEvent(const std::shared_ptr<Ship> &ship);
+	void HandleIncurredCrewCasualties(int deaths);
 
 
 private:
@@ -407,6 +410,13 @@ private:
 
 	// Basic information about the player's starting scenario.
 	CoreStartData startData;
+
+	// Player Stats
+	int64_t incurredCrewCasualties = 0;
+	int64_t incurredShipLosses = 0;
+
+	int64_t inflictedCrewCasualties = 0;
+	int64_t inflictedShipLosses = 0;
 };
 
 


### PR DESCRIPTION
TODO: UI Changes in the bank and daily messages

Every crew death causes a “life insurance” counter to be incremented on the player account. The  “life insurance”counter also decays, don’t know the exact rate but something like 5% per day.

From a value of 0 to 100 the counter does nothing. But after 100 to 1000 the cost of crew salaries scales by a factor of ( “life insurance”/ 100). 

So at 200  “life insurance” you would pay your normal crew salary plus the salary once over again in “life insurance plan costs”. At the cap of 1,000 you would pay your crew salary plus your crew salary 9 times over as “life insurance plan costs”. 