### PR TITLE
Import DefaultEnvironment from Scons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2,6 +2,7 @@ import os
 import platform
 from SCons.Node.FS import Dir
 from SCons.Errors import SConsEnvironmentError
+from SCons.Defaults import DefaultEnvironment
 
 def pathjoin(*args):
 	return os.path.join(*args)


### PR DESCRIPTION
Some Linux distributions seem to require an explicit import of DefaultEnvironment. Thanks to OpalMist on Discord for reporting