### PR TITLE
fix(content): Make Nanachi pre-HR requirements not encourage mega fleets

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -836,8 +836,8 @@ mission "Nanachi 1"
 		"combat rating" > 1200
 		has "First Contact: Hai: offered"
 		or
-			has "event: hai-human resolution announced"
 			not "event: hai secret leaks"
+			has "event: hai-human resolution announced"
 	on offer
 		conversation
 			`As you are making your way through the spaceport you notice a worried-looking Hai staring at the local job board and back at some sort of document they are holding.`

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -835,7 +835,7 @@ mission "Nanachi 1"
 		or
 			has "event: hai-human resolution announced"
 			and
-				"net worth" > 2000000000
+				"net worth" > 200000000
 				"combat rating" > 1200
 				has "First Contact: Hai: offered"
 	on offer

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -832,12 +832,12 @@ mission "Nanachi 1"
 	deadline 2 1
 	to offer
 		random < 15
+		"net worth" > 20000000
+		"combat rating" > 1200
+		has "First Contact: Hai: offered"
 		or
 			has "event: hai-human resolution announced"
-			and
-				"net worth" > 200000000
-				"combat rating" > 1200
-				has "First Contact: Hai: offered"
+			not "event: hai secret leaks"
 	on offer
 		conversation
 			`As you are making your way through the spaceport you notice a worried-looking Hai staring at the local job board and back at some sort of document they are holding.`


### PR DESCRIPTION
**Bugfix:** This PR addresses a balance issue with the Nanachi accessibility.

## Problem
The Nanachi missions are designed, I gather, with the primary aim of being post Hai Reveal content. This is fine. They have an alternate criteria that allows them to be accessed prior to Hai Reveal, namely acheiving 2B Networth along with a combat rating of 1200. Now, the combat rating of 1200 is "seasoned fighter", which seems like an appropriate skill level for the mission. 

The Networth, though... Well, just taking a look at things. Right now, the biggest, most expensive ship I can buy is the Shield Beetle, and that's a bit under 34M. To achieve this networth, I'd need a fleet of almost *sixty* of them. (to be exact, 59 Shield Beetles and one additional >12M ship). 

Just to be clear, Networth includes bank balance. So it *could*, I think, be satisfied by someone flying a shuttle who happens to have 2B credits in the bank who happens to have actually put that blaster to exceptionally good use. Possible, but I don't even want to think about how much time it'd take to earn 2B with nothing but a single shuttle.

The general principle we balance around is the expectation of a player flying solo. When we talk about balancing around the player flying fleets, it's generally assumed to be 1-6 escorts, maybe as many as 10, tops. While yes, people can and do sometimes build up massive snowball trading fleets with hundreds of ships, this comes up again and again as a problem to be solved. 

Here in the Nanachi missions, though, we have a situation where we have set up the trigger conditions such that - if someone wants to do these missions prior to Hai Reveal (and, by extension, without doing the FW campaign), then the only option they have is to build up exactly the sort of fleet that we keep labeling as OP and being a problem. We should *not* be giving people additional reasons to build up fleets the likes of which we don't really want to see and keep talking about putting in places measures to discourage.

## Fix Details
edit: originally this simply dropped the requirement from 2B down to 200M. It has since been revised further.

Currently, this reworks the offer conditions so that it requires the player to have a combat rating of 1200 and a networth of 20M, and to have met the Hai, as a baseline.

On top of that, the player needs to have one of two conditions: Either the Hai have *not* been revealed to the human public; or the Hai-human relations have been successfully resolved. This blocks the Nanachi missions from taking place *during* Hai Reveal, but allow it to be equally accessible before and after.

## Clarification

I'm posting this as a bug/balance report and solution in one; so I'd appreciate hearing from those responsible for Nanachi and the Hai missions as to why they chose such a massively high number. If there's other options that serve their purposes better, I'm open to them.

## Alternate
1. Given that I don't think we should ever encourage trade snowballing with targets like this; if this is meant to be a "Really should only happen post HR but we wanted to give a chance at it happening prior to it", then I think we should just drop the NW requirements and replace it with something like a `random < 2`.
2. As another alternative, one could shift the focus to *experience* rather than wealth, and put a time check there. How many years experience would be appropriate? 5, 10? Presumably this alternate is there to give people a chance to see it who haven't done (or perhaps who failed) the main story missions, so a time check would fit that really well.

For example, my current playthrough, I recently discovered and explored Hai space, and I'm in June 3019. That's what, about six years of in-game experience? That's *probably* enough to provide Nanachi with a bit of guidance... (especially if I had the 1200 combat rating, which I don't. Probably another couple years before I achieve that)

I'll be happy to modify this PR to either of those two alternates if people (particularly those focused on the Hai) prefer them. 