### PR TITLE
Remnant shattered light tweaks

### DIFF
--- a/data/remnant/remnant 2 side missions.txt
+++ b/data/remnant/remnant 2 side missions.txt
@@ -482,7 +482,7 @@ mission "Remnant: Shattered Light 3"
 	cargo "equipment" 19
 	passengers 13
 	source "Viminal"
-	waypoint "Coluber"
+	waypoint "Levana"
 	to offer
 		has "Remnant: Shattered Light 2: done"
 	on offer
@@ -501,6 +501,9 @@ mission "Remnant: Shattered Light 3"
 			`	Her gestures take on an appreciative tone. "The Maudrakoi made extensive use of the materials that make our ships and architecture so distinctive, and this has allowed their cities and technologies to survive the eons since they went extinct. One technology of note is they had an interesting ability to manipulate space. They used this to make large, highly complex objects, and then, for lack of a better term, partially embed them in pocket dimensions so as to not be entirely present. They used this frequently to allow equipment and materials to be much smaller than normal." She shrugs, and gestures with a frustrated tone. "We cannot replicate it, but we have figured out how to disrupt the compression, and thus recover the artifact."`
 			`	The hologram shifts back to showing the Shattered Light. "This ship does not show the same signatures as the Maudrakoi artifacts, but we think it is sufficiently similar that our equipment should work on it too. Hopefully. In any case, though, time is passing, so we should start loading." With that, the Remnant gather their equipment and head out.`
 				accept
+	on enter "Levana"
+		dialog
+			`Ruach pores over the scanning arrays before reporting that the subject seems to have moved location since your last visit. She suggests searching nearby systems to locate it.`
 	npc "scan outfits"
 		government "Ember Waste"
 		personality uninterested waiting staying mute

--- a/data/remnant/remnant 2 side missions.txt
+++ b/data/remnant/remnant 2 side missions.txt
@@ -482,7 +482,7 @@ mission "Remnant: Shattered Light 3"
 	cargo "equipment" 19
 	passengers 13
 	source "Viminal"
-	waypoint "Levana"
+	waypoint "Coluber"
 	to offer
 		has "Remnant: Shattered Light 2: done"
 	on offer
@@ -501,9 +501,9 @@ mission "Remnant: Shattered Light 3"
 			`	Her gestures take on an appreciative tone. "The Maudrakoi made extensive use of the materials that make our ships and architecture so distinctive, and this has allowed their cities and technologies to survive the eons since they went extinct. One technology of note is they had an interesting ability to manipulate space. They used this to make large, highly complex objects, and then, for lack of a better term, partially embed them in pocket dimensions so as to not be entirely present. They used this frequently to allow equipment and materials to be much smaller than normal." She shrugs, and gestures with a frustrated tone. "We cannot replicate it, but we have figured out how to disrupt the compression, and thus recover the artifact."`
 			`	The hologram shifts back to showing the Shattered Light. "This ship does not show the same signatures as the Maudrakoi artifacts, but we think it is sufficiently similar that our equipment should work on it too. Hopefully. In any case, though, time is passing, so we should start loading." With that, the Remnant gather their equipment and head out.`
 				accept
-	on enter "Levana"
+	on enter "Coluber"
 		dialog
-			`Ruach pores over the scanning arrays before reporting that the subject seems to have moved location since your last visit. She suggests searching nearby systems to locate it.`
+			`Ruach briefly checks the scanning arrays before reporting that; unsurprisingly, the subject seems to not be present. She suggests searching nearby systems to locate it.`
 	npc "scan outfits"
 		government "Ember Waste"
 		personality uninterested waiting staying mute

--- a/data/remnant/remnant 2 side missions.txt
+++ b/data/remnant/remnant 2 side missions.txt
@@ -502,8 +502,7 @@ mission "Remnant: Shattered Light 3"
 			`	The hologram shifts back to showing the Shattered Light. "This ship does not show the same signatures as the Maudrakoi artifacts, but we think it is sufficiently similar that our equipment should work on it too. Hopefully. In any case, though, time is passing, so we should start loading." With that, the Remnant gather their equipment and head out.`
 				accept
 	on enter "Coluber"
-		dialog
-			`Ruach briefly checks the scanning arrays before reporting that; unsurprisingly, the subject seems to not be present. She suggests searching nearby systems to locate it.`
+		dialog `Ruach briefly checks the scanning arrays before reporting that, unsurprisingly, the ship seems to not be present. She suggests searching nearby systems to locate it.`
 	npc "scan outfits"
 		government "Ember Waste"
 		personality uninterested waiting staying mute


### PR DESCRIPTION
## Summary
I just did the shattered light missions, and I liked them. One thing that stuck out to me though was that after finding the ship in Levana the next mission sets a waypoint in Coluber. The ship wasn't even found there, and when you go to Coluber its not there. So I decided to move the waypoint to where you found the ship and add an on enter message saying its not there.

## Alternative Approach
You could either have  the on enter message be in Coluber, or have the waypoint be in the system where you Dromedary goes after you scan it in Levana.