### PR TITLE
[Mechanics] Thermal Expansion Part 1

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -341,6 +341,9 @@ tip "mass with no cargo:"
 tip "mass:"
 	`Mass, in tons. A ship's mass determines how fast it turns and accelerates and its maximum heat before overheating.`
 
+tip "maximum temperature:"
+	`The maximum temperature a ship can reach before it starts to overheat and shuts down.`
+
 tip "operating costs:"
 	`How many credits per day you need to spend to maintain this outfit while it is in active use.`
 
@@ -373,6 +376,9 @@ tip "piercing protection:"
 
 tip "radar jamming:"
 	`Reduces the ability of radar-guided missiles to track your ship. The more radar jamming is installed, the greater the distance at which missiles can be jammed, and the greater the chance that a jammed missile will fly off in a random direction.`
+
+tip "radiative cooling:"
+	`Cools your ship at a rate proportional to the fourth power of its temperature. This value shows the amount of heat removed per second when your ship's temperature is at 1000 K, the maximum for most ships.`
 
 tip "ramscoop:"
 	`Replenishes fuel by harvesting the stellar wind. Ramscoops are more effective when closer to a star. If you add more than one ramscoop, each additional one is less effective: you need four ramscoops to achieve double the recharge rate that one ramscoop provides.`

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -822,8 +822,8 @@ void Engine::Step(bool isActive)
 				info.SetString("target fuel", to_string(fuel));
 				int energy = round(target->Energy() * target->Attributes().Get("energy capacity"));
 				info.SetString("target energy", to_string(energy));
-				int heat = round(100. * target->Heat());
-				info.SetString("target heat", to_string(heat) + "%");
+				int heat = round(target->ShipTemperature());
+				info.SetString("target heat", to_string(heat) + " K");
 			}
 		}
 	}

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -83,6 +83,7 @@ namespace {
 		{"leak resistance fuel", 0},
 		{"leak resistance heat", 0},
 		{"overheat damage rate", 0},
+		{"radiative cooling", 0},
 		{"reverse thrusting shields", 0},
 		{"reverse thrusting hull", 0},
 		{"reverse thrusting energy", 0},

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -784,7 +784,7 @@ void Ship::FinishLoading(bool isNewInstance)
 		attributes.Set("drag", 100.);
 	}
 	if(attributes.Get("maximum temperature") < 0.)
-		warning += "Defaulting " + string("negative" + " \"maximum temperature\" attribute to 1000.0\n";
+		warning += "Defaulting negative \"maximum temperature\" attribute to 1000.0\n";
 	if(attributes.Get("maximum temperature") <= 0.)
 		attributes.Set("maximum temperature", 1000.);
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -785,7 +785,8 @@ void Ship::FinishLoading(bool isNewInstance)
 	}
 	if(attributes.Get("maximum temperature") <= 0.)
 	{
-		warning += "Defaulting " + string(attributes.Get("maximum temperature") ? "invalid" : "missing") + " \"maximum temperature\" attribute to 1000.0\n";
+		warning += "Defaulting " + string(attributes.Get("maximum temperature") ? "invalid" : "missing")
+			+ " \"maximum temperature\" attribute to 1000.0\n";
 		attributes.Set("maximum temperature", 1000.);
 	}
 
@@ -3337,7 +3338,7 @@ double Ship::IdleHeat() const
 	double coolingEfficiency = CoolingEfficiency();
 	double cooling = coolingEfficiency * attributes.Get("cooling");
 	double activeCooling = coolingEfficiency * attributes.Get("active cooling");
-	double radiativeCooling =  coolingEfficiency * attributes.Get("radiative cooling");
+	double radiativeCooling = coolingEfficiency * attributes.Get("radiative cooling");
 
 	// Idle heat is the heat level where:
 	// heat = heat * diss + heatGen - cool - activeCool * heat / (100 * mass)
@@ -3364,7 +3365,8 @@ double Ship::HeatDissipation() const
 // Get the maximum heat level, in heat units (not temperature).
 double Ship::MaximumHeat() const
 {
-	return (attributes.Get("maximum temperature")) / 10. * (cargo.Used() + attributes.Mass() + attributes.Get("heat capacity"));
+	return (attributes.Get("maximum temperature")) / 10. * (cargo.Used() + attributes.Mass()
+			+ attributes.Get("heat capacity"));
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2397,7 +2397,7 @@ void Ship::DoGeneration()
 		}
 		// Apply radiative cooling. The amount of radiative cooling is scaled by the fourth power of
 		// your ship's current temperature.
-		heat -= coolingEfficiency * attributes.Get("radiative cooling") * pow(ShipTemperature() / 1000., 4.);
+		heat -= coolingEfficiency * RadiativeCooling(ShipTemperature());
 	}
 
 	// Don't allow any levels to drop below zero.
@@ -3334,14 +3334,13 @@ double Ship::IdleHeat() const
 	double coolingEfficiency = CoolingEfficiency();
 	double cooling = coolingEfficiency * attributes.Get("cooling");
 	double activeCooling = coolingEfficiency * attributes.Get("active cooling");
-	double radiativeCooling = coolingEfficiency * attributes.Get("radiative cooling");
+	double radiativeCooling = coolingEfficiency * RadiativeCooling(attributes.Get("maximum temperature"));
 
 	// Idle heat is the heat level where:
 	// heat = heat * diss + heatGen - cool - activeCool * heat / (100 * mass)
 	// heat = heat * (diss - activeCool / (100 * mass)) + (heatGen - cool)
 	// heat * (1 - diss + activeCool / (100 * mass)) = (heatGen - cool)
-	double production = max(0., attributes.Get("heat generation") - cooling
-		- radiativeCooling * pow(attributes.Get("maximum temperature") / 1000., 4.));
+	double production = max(0., attributes.Get("heat generation") - cooling - radiativeCooling);
 	double dissipation = HeatDissipation() + activeCooling / MaximumHeat();
 
 	if(!dissipation) return production ? numeric_limits<double>::max() : 0;
@@ -3370,6 +3369,13 @@ double Ship::MaximumHeat() const
 double Ship::ShipTemperature() const
 {
 	return attributes.Get("maximum temperature") * Heat();
+}
+
+
+// Get the ship temperature.
+double Ship::RadiativeCooling(float temp) const
+{
+	return attributes.Get("radiative cooling") * pow(temp / 1000., 4.);
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -785,6 +785,9 @@ void Ship::FinishLoading(bool isNewInstance)
 	}
 	if(attributes.Get("maximum temperature") <= 0.)
 		attributes.Set("maximum temperature", 1000.);
+	if(attributes.Get("maximum temperature") < 0.)
+		warning += "Defaulting " + string(attributes.Get("maximum temperature") ? "invalid" : "missing")
+		+ " \"maximum temperature\" attribute to 1000.0\n";
 
 	// Calculate the values used to determine this ship's value and danger.
 	attraction = CalculateAttraction();
@@ -3337,9 +3340,9 @@ double Ship::IdleHeat() const
 	double radiativeCooling = coolingEfficiency * RadiativeCooling(attributes.Get("maximum temperature"));
 
 	// Idle heat is the heat level where:
-	// heat = heat * diss + heatGen - cool - activeCool * heat / (100 * mass)
-	// heat = heat * (diss - activeCool / (100 * mass)) + (heatGen - cool)
-	// heat * (1 - diss + activeCool / (100 * mass)) = (heatGen - cool)
+	// heat = heat * diss + heatGen - cool - activeCool * heat / (100 * mass) - radiativeCool
+	// heat = heat * (diss - activeCool / (100 * mass)) + (heatGen - cool - radiativeCool)
+	// heat * (1 - diss + activeCool / (100 * mass)) = (heatGen - cool - radiativeCool)
 	double production = max(0., attributes.Get("heat generation") - cooling - radiativeCooling);
 	double dissipation = HeatDissipation() + activeCooling / MaximumHeat();
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -783,11 +783,10 @@ void Ship::FinishLoading(bool isNewInstance)
 		warning += "Defaulting " + string(attributes.Get("drag") ? "invalid" : "missing") + " \"drag\" attribute to 100.0\n";
 		attributes.Set("drag", 100.);
 	}
+	if(attributes.Get("maximum temperature") < 0.)
+		warning += "Defaulting " + string("negative" + " \"maximum temperature\" attribute to 1000.0\n";
 	if(attributes.Get("maximum temperature") <= 0.)
 		attributes.Set("maximum temperature", 1000.);
-	if(attributes.Get("maximum temperature") < 0.)
-		warning += "Defaulting " + string(attributes.Get("maximum temperature") ? "invalid" : "missing")
-		+ " \"maximum temperature\" attribute to 1000.0\n";
 
 	// Calculate the values used to determine this ship's value and danger.
 	attraction = CalculateAttraction();

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2401,7 +2401,7 @@ void Ship::DoGeneration()
 		}
 		// Apply radiative cooling. The amount of radiative cooling is scaled by the fourth power of
 		// your ship's current temperature.
-		heat -= coolingEfficiency * attributes.Get("radiative cooling") * pow(ShipTemperature() / 1000., 4);
+		heat -= coolingEfficiency * attributes.Get("radiative cooling") * pow(ShipTemperature() / 1000., 4.);
 	}
 
 	// Don't allow any levels to drop below zero.
@@ -3346,7 +3346,7 @@ double Ship::IdleHeat() const
 	// heat * (1 - diss + activeCool / (100 * mass)) = (heatGen - cool)
 	double production = max(0., attributes.Get("heat generation") - cooling);
 	double dissipation = HeatDissipation() + activeCooling / MaximumHeat()
-		+ radiativeCooling * attributes.Get("maximum temperature") / 1000.;
+		+ radiativeCooling * pow(attributes.Get("maximum temperature") / 1000., 4.);
 
 	if(!dissipation) return production ? numeric_limits<double>::max() : 0;
 	return production / dissipation;
@@ -3365,7 +3365,7 @@ double Ship::HeatDissipation() const
 // Get the maximum heat level, in heat units (not temperature).
 double Ship::MaximumHeat() const
 {
-	return (attributes.Get("maximum temperature")) / 10. * (cargo.Used() + attributes.Mass()
+	return attributes.Get("maximum temperature") / 10. * (cargo.Used() + attributes.Mass()
 			+ attributes.Get("heat capacity"));
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3344,9 +3344,9 @@ double Ship::IdleHeat() const
 	// heat = heat * diss + heatGen - cool - activeCool * heat / (100 * mass)
 	// heat = heat * (diss - activeCool / (100 * mass)) + (heatGen - cool)
 	// heat * (1 - diss + activeCool / (100 * mass)) = (heatGen - cool)
-	double production = max(0., attributes.Get("heat generation") - cooling);
-	double dissipation = HeatDissipation() + activeCooling / MaximumHeat()
-		+ radiativeCooling * pow(attributes.Get("maximum temperature") / 1000., 4.);
+	double production = max(0., attributes.Get("heat generation") - cooling
+		- radiativeCooling * pow(attributes.Get("maximum temperature") / 1000., 4.));
+	double dissipation = HeatDissipation() + activeCooling / MaximumHeat();
 
 	if(!dissipation) return production ? numeric_limits<double>::max() : 0;
 	return production / dissipation;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3344,7 +3344,8 @@ double Ship::IdleHeat() const
 	// heat = heat * (diss - activeCool / (100 * mass)) + (heatGen - cool)
 	// heat * (1 - diss + activeCool / (100 * mass)) = (heatGen - cool)
 	double production = max(0., attributes.Get("heat generation") - cooling);
-	double dissipation = HeatDissipation() + activeCooling / MaximumHeat() + radiativeCooling;
+	double dissipation = HeatDissipation() + activeCooling / MaximumHeat()
+		+ radiativeCooling * attributes.Get("maximum temperature") / 1000.;
 
 	if(!dissipation) return production ? numeric_limits<double>::max() : 0;
 	return production / dissipation;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -784,11 +784,7 @@ void Ship::FinishLoading(bool isNewInstance)
 		attributes.Set("drag", 100.);
 	}
 	if(attributes.Get("maximum temperature") <= 0.)
-	{
-		warning += "Defaulting " + string(attributes.Get("maximum temperature") ? "invalid" : "missing")
-			+ " \"maximum temperature\" attribute to 1000.0\n";
 		attributes.Set("maximum temperature", 1000.);
-	}
 
 	// Calculate the values used to determine this ship's value and danger.
 	attraction = CalculateAttraction();

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -331,6 +331,8 @@ public:
 	double MaximumHeat() const;
 	// Get the ship's temperature, in units Kelvin.
 	double ShipTemperature() const;
+	// Calculate the power of radiative cooling for a given temperature.
+	double RadiativeCooling(float temp) const;
 	// Calculate the multiplier for cooling efficiency.
 	double CoolingEfficiency() const;
 	// Calculate the ship's drag after accounting for drag reduction.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -329,6 +329,8 @@ public:
 	double HeatDissipation() const;
 	// Get the maximum heat level, in heat units (not temperature).
 	double MaximumHeat() const;
+	// Get the ship's temperature, in units Kelvin.
+	double ShipTemperature() const;
 	// Calculate the multiplier for cooling efficiency.
 	double CoolingEfficiency() const;
 	// Calculate the ship's drag after accounting for drag reduction.

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -308,7 +308,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		+ attributes.Get("solar heat")
 		+ attributes.Get("fuel heat")
 		- ship.CoolingEfficiency() * (attributes.Get("cooling") + attributes.Get("active cooling")
-		+ attributes.Get("radiative cooling"));
+		+ attributes.Get("radiative cooling") * attributes.Get("maximum temperature") / 1000.);
 	tableLabels.push_back("idle:");
 	energyTable.push_back(Format::Number(60. * idleEnergyPerFrame));
 	heatTable.push_back(Format::Number(60. * idleHeatPerFrame));

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -307,7 +307,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	const double idleHeatPerFrame = attributes.Get("heat generation")
 		+ attributes.Get("solar heat")
 		+ attributes.Get("fuel heat")
-		- ship.CoolingEfficiency() * (attributes.Get("cooling") + attributes.Get("active cooling"));
+		- ship.CoolingEfficiency() * (attributes.Get("cooling") + attributes.Get("active cooling")
+		+ attributes.Get("radiative cooling"));
 	tableLabels.push_back("idle:");
 	energyTable.push_back(Format::Number(60. * idleEnergyPerFrame));
 	heatTable.push_back(Format::Number(60. * idleHeatPerFrame));

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -309,7 +309,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		+ attributes.Get("solar heat")
 		+ attributes.Get("fuel heat")
 		- ship.CoolingEfficiency() * (attributes.Get("cooling") + attributes.Get("active cooling")
-		+ attributes.Get("radiative cooling") * pow(attributes.Get("maximum temperature") / 1000., 4.));
+		+ ship.RadiativeCooling(attributes.Get("maximum temperature")));
 	tableLabels.push_back("idle:");
 	energyTable.push_back(Format::Number(60. * idleEnergyPerFrame));
 	heatTable.push_back(Format::Number(60. * idleHeatPerFrame));

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -28,6 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Table.h"
 
 #include <algorithm>
+#include <cmath>
 #include <map>
 #include <sstream>
 
@@ -308,7 +309,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 		+ attributes.Get("solar heat")
 		+ attributes.Get("fuel heat")
 		- ship.CoolingEfficiency() * (attributes.Get("cooling") + attributes.Get("active cooling")
-		+ attributes.Get("radiative cooling") * attributes.Get("maximum temperature") / 1000.);
+		+ attributes.Get("radiative cooling") * pow(attributes.Get("maximum temperature") / 1000., 4.));
 	tableLabels.push_back("idle:");
 	energyTable.push_back(Format::Number(60. * idleEnergyPerFrame));
 	heatTable.push_back(Format::Number(60. * idleHeatPerFrame));


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #(no one asked for this)


No, this is not a realism PR.

## Feature Details
This is a minimalist version of the heat additions I've been showing on Discord, adding two new attributes.

It also adds a ShipTemperature() method to easily get a ship's temperature in units Kelvin, providing an absolute temperature scale that can be referenced along with the current Heat() method, which simply provides the fraction of maximum heat the ship is at. I see this being useful for future additions, including ones I have been working on that are outside the scope of this PR.

First, `maximum temperature` is a new attribute, allowing one to set (or add to) the temperature at which a ship begins to overheat. If left unspecified, this defaults to 1000 K.

Second, `radiative cooling` is a new cooling type. Like `active cooling`, it scales with temperature, but unlike `active cooling` this scaling is not relative to the ship's fraction of maximum heat, but rather the absolute temperature, and the scaling factor is proportional to the fourth power of the ship's temperature. This results in a much steeper scaling curve, meaning a ship with only `radiative cooling` is likely to idle at a higher temperature but be more resistant to forced overheating from things like heat weapons.

For example, this graph shows how a base `radiative cooling` (Y axis) value of 10 scales with temperature (X axis). At 500 K (50% of maximum heat for ships by default) it is only 6% as effective as at 1000 K.

<img src="https://user-images.githubusercontent.com/42621251/208557076-3ef9e409-30eb-4fd8-8f68-a08ff7967dc3.png" width="400" />

## Usage Examples

`maximum temperature` allows ships to be more resistant to overheating without altering their cooling properties, which could be useful for species like the Korath. Alternatively, it could be used to *reduce* a ship's ability to cope with heat, something that could be interesting for, say, a species that evolved with cryogenic biology on an icy moon, whose ships are made of ice and overheat easily.

`maximum temperature` can be thought of as a multiplicative analogue to `heat capacity` - while outfits with `heat capacity` add to a ship's heat capacity, altering its `maximum temperature` applies an overall multiplier to how much heat a ship can hold before it begins to overheat.

There is also the potential for outfits to add or subtract from a ship's `maximum temperature,` but as with attributes like `drag` and `heat dissipation` I feel that this should be discouraged.

While this PR does not currently add `maximum temperature`s to any ships, instead relying on the fallback value of 1000, depending on feedback I would consider adding it to ships in the game (as it's better to avoid relying on the fallback value), with increased values for the Korath, Quarg, and Archon. Suggestions on what exactly those values should be, and any other ships that should use altered values, would be appreciated!



`radiant cooling` occupies a niche in that typical amounts of it result in a ship having a very high idle temperature, but also give it a high degree of resilience when it comes to withstanding heat weapons or other external sources of heat. While a high idle temperature, as of now, does not do much besides making a ship more vulnerable to infrared tracking, there has been much interest expressed on Discord about having outfits and attributes whose effectiveness varies with the ship's ambient temperature.

I have also been working on a pair of attributes allowing for the creation of proper thermal power sources, whose efficiency varies based on their core temperature compared to the ship's ambient temperature. While I believe that is out of the scope of this PR, the ShipTemperature() method would be very helpful for their functionality (and likewise for any similar future attributes that vary based on the ship's absolute temperature), and the balance implications of `radiant cooling` would synergize very well with a ship's idle temperature mattering more.


## Testing Done
I tested ships with varying `maximum temperature` values, along with outfits with different amounts of `radiant cooling`.


## Performance Impact
N/A
