### PR TITLE
change line to Center() as expected by shader

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -870,7 +870,7 @@ interface "hiring"
 		align right
 	
 	line
-		from -60 95
+		center -60 95
 		dimensions 480 1
 
 	label "bunks"
@@ -952,7 +952,7 @@ interface "hiring"
 
 interface "trade"
 	line
-		from -60 95
+		center -60 95
 		dimensions 480 1
 
 	active if "can buy"
@@ -981,7 +981,7 @@ interface "trade"
 
 interface "bank"
 	line
-		from -60 95
+		center -60 95
 		dimensions 480 1
 
 	active if "can pay"

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -719,5 +719,5 @@ void Interface::LineElement::Draw(const Rectangle &rect, const Information &info
 	// Avoid crashes for malformed interface elements that are not fully loaded.
 	if(!from.Get() && !to.Get())
 		return;
-	FillShader::Fill(rect.TopLeft(), rect.Dimensions(), *color);
+	FillShader::Fill(rect.Center(), rect.Dimensions(), *color);
 }


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7918

## Fix Details
Previously using TopLeft() instead of Center(), which made all line elements shift to the left by 50%, and made it impossible to anchor them correctly.

The line elements are now rendered on the configured coordinates, and the existing line elements have been changed from "from" to "center", which keeps them where they are expected.

## Testing Done
Verified the hiring, trade, and bank dialog line elements are visually unaffected, and verified that adding a new line anchored to both sides of the screen now works. 
