### PR TITLE
Change Cloaking Device's Category to "Unique"

### DIFF
--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -260,7 +260,7 @@ outfit "Surveillance Pod"
 
 
 outfit "Cloaking Device"
-	category "Systems"
+	category "Unique"
 	cost 1200000
 	"mass" 10
 	"outfit space" -10


### PR DESCRIPTION
Figured this was an oversight, considering the cloaking device predates the unique category
