### PR TITLE
fix(content): Add clearance to all FW Pug 2C variants

### DIFF
--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -1237,6 +1237,7 @@ mission "FW Pug 2C: Hyperdrive"
 	description "Travel to the Deneb system to investigate the Pug; if possible, make contact with them and determine what their goals and desires are."
 	source Hephaestus
 	destination Pugglemug
+	clearance
 	to offer
 		has "FW Pug 2B: done"
 		not "fw given jump drive"
@@ -1266,6 +1267,7 @@ mission "FW Pug 2C: Scram Drive"
 	description "Travel to the Deneb system to investigate the Pug; if possible, make contact with them and determine what their goals and desires are."
 	source Hephaestus
 	destination Pugglemug
+	clearance
 	to offer
 		has "FW Pug 2B: done"
 		not "fw given jump drive"


### PR DESCRIPTION
**Bugfix:** This PR addresses a bug mentioned on Discord

## Fix Details
Adds `clearance` attribute to `FW Pug 2C: Hyperdrive` and `FW Pug 2C: Scram Drive` missions so now the player can land without bribing if they had their Jump Drive installed in the campaign by the Syndicate.

## Testing Done
done.