### PR TITLE
Update post-Sestor Wanderer and Korath jobs, news, etc

### DIFF
--- a/data/korath/korath jobs.txt
+++ b/data/korath/korath jobs.txt
@@ -18,7 +18,7 @@ mission "Kor Efreti: Cargo"
 	description "Deliver <cargo> to <destination> for the Kor Efreti. Payment is <payment>."
 	cargo random 10 2 .18
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 50
 	source
 		government "Kor Efret"
@@ -38,7 +38,7 @@ mission "Kor Efreti: Cargo [1]"
 	description "Deliver <cargo> to <destination> for the Kor Efreti. Payment is <payment>."
 	cargo random 10 2 .14
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 20
 	source
 		government "Kor Efret"
@@ -59,7 +59,7 @@ mission "Kor Efreti: Food Cargo [0]"
 	description "The Kor Efreti need some food supplies moved to another planet. Deliver <cargo> to <destination>. Payment is <payment>."
 	cargo "Food" 5 3 .16
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 	source
 		government "Kor Efret"
 		not attributes "station"
@@ -79,7 +79,7 @@ mission "Kor Efreti: Food Cargo [1]"
 	description "The Kor Efreti need some food supplies moved to another planet. Deliver <cargo> to <destination>. Payment is <payment>."
 	cargo "Food" 5 3 .14
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 70
 	source
 		government "Kor Efret"
@@ -102,7 +102,7 @@ mission "Kor Efreti: Industrial to Wanderers"
 	description "The Kor Efreti don't have much manufacturing capability, but the Wanderers could make use of these materials. Deliver <cargo> to <destination>. Payment is <payment>."
 	cargo "Industrial" 5 3 .13
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 75
 	source
 		government "Kor Efret"
@@ -123,7 +123,7 @@ mission "Kor Efreti: Cargo to Wanderers"
 	description "The Kor Efreti don't have much manufacturing capability, but the Wanderers could make use of these materials. Deliver <cargo> to the Wanderers on <destination>. Payment is <payment>."
 	cargo random 5 4 .12
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 60
 	source
 		government "Kor Efret"
@@ -145,7 +145,7 @@ mission "Kor Efreti: Rush Delivery Food"
 	cargo "Food" 10 6 .1
 	deadline
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 60
 	source
 		government "Kor Efret"
@@ -167,7 +167,7 @@ mission "Kor Efreti: Passengers [0]"
 	description "Bring this group of <bunks> Kor Efreti to <destination>. Payment is <payment>."
 	passengers 3 2 .15
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 	source
 		government "Kor Efret"
 	destination
@@ -186,7 +186,7 @@ mission "Kor Efreti: Passengers [1]"
 	description "Bring this group of <bunks> Kor Efreti to <destination>. Payment is <payment>."
 	passengers 3 2 .1
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 60
 	source
 		government "Kor Efret"
@@ -209,7 +209,7 @@ mission "Kor Efreti: Settlers"
 	passengers 10 5 .15
 	cargo "supplies" 5 3 .16
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 90
 	source
 		government "Kor Efret"
@@ -229,7 +229,7 @@ mission "Kor Efreti to Wanderers: Farming"
 	description "Take <bunks> Kor Efreti to learn Wanderer farming methods on <stopovers>, then return them to <planet>. Payment is <payment>."
 	passengers 5 1 .2
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 70
 	source
 		government "Kor Efret"

--- a/data/korath/korath missions.txt
+++ b/data/korath/korath missions.txt
@@ -75,7 +75,7 @@ mission "Setar Fort Heating"
 		near "Kaliptari" 100
 	destination "Setar Fort"
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 60
 	on offer
 		conversation
@@ -245,7 +245,7 @@ mission "Small Scale Delivery"
 	description "Take a small delivery to <destination> for <payment> for a Kor Efret."
 	minor
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 10
 	source
 		government "Kor Efret"

--- a/data/korath/korath news.txt
+++ b/data/korath/korath news.txt
@@ -93,7 +93,7 @@ news "kor efret station friendly"
 			
 news "wanderer at kor efret spaceport"
 	to show
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 	location
 		government "Kor Efret"
 		not attributes "station"

--- a/data/wanderer/wanderer jobs.txt
+++ b/data/wanderer/wanderer jobs.txt
@@ -811,7 +811,7 @@ mission "Wanderer Kor Efreti: Equipment"
 	description "Deliver <cargo> to the Kor Efreti on <destination>. Payment is <payment>."
 	cargo "Equipment" 5 3 .15
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 70
 	source
 		government "Wanderer"
@@ -832,7 +832,7 @@ mission "Wanderer Kor Efreti: Cargo [0]"
 	description "Deliver <cargo> to the Kor Efreti on <destination>. Payment is <payment>."
 	cargo random 5 4 .12
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 40
 	source
 		government "Wanderer"
@@ -853,7 +853,7 @@ mission "Wanderer Kor Efreti: Cargo [1]"
 	description "Deliver <cargo> to the Kor Efreti on <destination>. Payment is <payment>."
 	cargo random 5 4 .10
 	to offer
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 		random < 15
 	source
 		government "Wanderer"

--- a/data/wanderer/wanderer news.txt
+++ b/data/wanderer/wanderer news.txt
@@ -302,7 +302,7 @@ news "Wanderers and the Eye"
 
 news "Wanderers and Korath"
 	to show
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 	location
 		government "Wanderer"
 		not attributes "evacuation"
@@ -328,7 +328,7 @@ news "Wanderers and Korath"
 
 news "Wanderer Linguistics"
 	to show
-		has "Wanderers: Sestor: Final: done"
+		has "wanderers sestor done"
 	location
 		government "Wanderer"
 		not attributes "evacuation"

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -3362,6 +3362,7 @@ mission "Wanderers: Sestor: Final: Patched"
 		log "Discovered that when the Korath exiles shut down the Kor Sestor factory, they also took enough technology from the factory to be able to begin producing war drones of their own. It is possible that the exiles have just become a whole lot more dangerous than they used to be."
 		log "Factions" "Wanderers" `After the Eye opened, creating a wormhole link between Wanderer territory and the region of space that harbors the devastated Korath worlds, the Wanderers have established several new colonies in the Korath sector and have begun to migrate to this area of Space. They have established formal relations with the Kor Efreti and were able to end the war between the Kor Mereti and the Kor Sestor.`
 		log "Factions" "Korath" `The Wanderers, who have begun to establish colonies on some deserted Korath systems, were able to end the war between the Kor Mereti and the Kor Sestor. The Kor Efreti have begun to rebuild their worlds and are tutored in this endeavor by the Wanderers.`
+		set "wanderers sestor done"
 		event "wanderers: exiles have drones" 20
 		event "wanderers: sabira eseskrai colony" 30
 		event "wanderers: sestor eliminated" 40
@@ -3382,6 +3383,7 @@ mission "Wanderers: Sestor: Combined Patch 1"
 	to fail
 		has "Wanderers: Sestor: Final: Patched: offered"
 	on offer
+		set "wanderers sestor done"
 		event "wanderers: sestor planets unrestricted" 40
 		event "wanderers taking jobs from kor efreti" 5
 		event "wanderers: moonbeam mass production" 5


### PR DESCRIPTION
**Bugfix:**

Thanks to `@bossrman#0358` on Discord for reporting this.

## Fix Details
When the final Wanderer Sestor mission was refactored to remove the need for patch missions on new saves, the name was changed. A number of jobs, spaceport conversation missions, and news items were checking for the condition indicating the mission with the old name was done and were not updated to check for the new one.
This PR sets a new condition `wanderers sestor done`, similarly to some used in the FW story, for which all these things will now look.

## Testing Done
None yet.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
If you really want one, I'll make one, but it's perhaps a little excessive.

