### PR TITLE
Improvements and fixes to the MacOS CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_dependent_option(ES_GLES "Build the game with OpenGL ES" OFF UNIX OFF)
 cmake_dependent_option(ES_USE_SYSTEM_LIBRARIES "Use system libraries instead of the vcpkg ones." ON UNIX OFF)
 cmake_dependent_option(ES_USE_OFFSCREEN
 	"Use SDL's offscreen backend instead of Xvfb for the integration tests" OFF UNIX OFF)
+cmake_dependent_option(ES_CREATE_BUNDLE "Create a Bundle instead of an executable" OFF APPLE OFF)
 
 # Support Debug and Release configurations.
 set(CMAKE_CONFIGURATION_TYPES "Debug" "Release" CACHE STRING "" FORCE)
@@ -105,7 +106,7 @@ if(BUILD_TESTING)
 endif()
 
 # Create game target.
-if(APPLE)
+if(APPLE AND ES_CREATE_BUNDLE)
 	add_executable(EndlessSky MACOSX_BUNDLE source/main.cpp)
 
 	# MacOS bundles are a bit special and need every resource specified when

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -151,42 +151,6 @@
       }
     },
     {
-      "name": "xcode",
-      "displayName": "Xcode",
-      "description": "Builds with Xcode on x64-based MacOS",
-      "inherits": "base",
-      "generator": "Xcode",
-      "cacheVariables": {
-        "CMAKE_OSX_ARCHITECTURES": "x86_64",
-        "VCPKG_TARGET_TRIPLET": "x64-osx-dynamic"
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
-    },
-    {
-      "name": "xcode-arm",
-      "displayName": "Xcode ARM",
-      "description": "Builds with Xcode on ARM-based MacOS",
-      "inherits": "base",
-      "generator": "Xcode",
-      "cacheVariables": {
-        "CMAKE_OSX_ARCHITECTURES": "arm64",
-        "VCPKG_TARGET_TRIPLET": "arm64-osx-dynamic"
-      },
-      "architecture": {
-        "value": "arm64",
-        "strategy": "external"
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
-    },
-    {
       "name": "linux-ci",
       "displayName": "Linux CI",
       "description": "Builds for Linux for CI purposes",
@@ -316,30 +280,6 @@
       "name": "macos-arm-release",
       "displayName": "Release",
       "configurePreset": "macos-arm",
-      "inherits": "release"
-    },
-    {
-      "name": "xcode-debug",
-      "displayName": "Debug",
-      "configurePreset": "xcode",
-      "inherits": "debug"
-    },
-    {
-      "name": "xcode-release",
-      "displayName": "Release",
-      "configurePreset": "xcode",
-      "inherits": "release"
-    },
-    {
-      "name": "xcode-arm-debug",
-      "displayName": "Debug",
-      "configurePreset": "xcode-arm",
-      "inherits": "debug"
-    },
-    {
-      "name": "xcode-arm-release",
-      "displayName": "Release",
-      "configurePreset": "xcode-arm",
       "inherits": "release"
     },
     {
@@ -570,30 +510,6 @@
       "name": "macos-arm-benchmark",
       "displayName": "Benchmarks",
       "configurePreset": "macos-arm",
-      "inherits": "benchmark"
-    },
-    {
-      "name": "xcode-test",
-      "displayName": "Tests",
-      "configurePreset": "xcode",
-      "inherits": "test"
-    },
-    {
-      "name": "xcode-benchmark",
-      "displayName": "Benchmarks",
-      "configurePreset": "xcode",
-      "inherits": "benchmark"
-    },
-    {
-      "name": "xcode-arm-test",
-      "displayName": "Tests",
-      "configurePreset": "xcode-arm",
-      "inherits": "test"
-    },
-    {
-      "name": "xcode-arm-benchmark",
-      "displayName": "Benchmarks",
-      "configurePreset": "xcode-arm",
       "inherits": "benchmark"
     },
     {

--- a/readme-cmake.md
+++ b/readme-cmake.md
@@ -30,7 +30,9 @@ Install [Homebrew](https://brew.sh). Once it is installed, use it to install the
 $ brew install cmake ninja mad libpng jpeg-turbo sdl2 openal-soft
 ```
 
-**Note**: If you are on Apple Silicon (and want to compile for ARM), make sure that you are using ARM Homebrew.
+**Note**: If you are on Apple Silicon (and want to compile for ARM), make sure that you are using ARM Homebrew!
+
+If you want to build the libraries from source instead of using Homebrew, you can pass `-DES_USE_SYSTEM_LIBRARIES=OFF` to CMake when configuring.
 
 ## Linux
 
@@ -116,7 +118,7 @@ This will create a Visual Studio 2022 solution. If you are using an older versio
 If you want to use the XCode IDE, from the root of the project folder execute:
 
 ```bash
-$ cmake --preset xcode # xcode-arm for Apple Silicon
+$ cmake --preset macos -G Xcode # macos-arm for Apple Silicon
 ```
 
 The XCode project is located in the `build/` directory.

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -123,10 +123,6 @@ void Files::Init(const char * const *argv)
 		resources = LOCAL_PATH + RESOURCE_PATH;
 	else if(!resources.compare(0, STANDARD_PATH.length(), STANDARD_PATH))
 		resources = STANDARD_PATH + RESOURCE_PATH;
-#elif defined __APPLE__
-	// Special case for Mac OS X: the resources are in ../Resources relative to
-	// the folder the binary is in.
-	resources = resources + "../Resources/";
 #endif
 	// If the resources are not here, search in the directories containing this
 	// one. This allows, for example, a Mac app that does not actually have the


### PR DESCRIPTION
This PR includes 3 improvements to the MacOS CMake build:

1. Do not create a bundle by default. Bundles aren't updated when new data/image/sound files are added, so they're not useful for active development.
2. Remove the xcode presets. Use the macos presets instead with `-G Xcode`.
3. The workaround is not needed because SDL_GetBasePath returns the correct path already.