### PR TITLE
[Coalition] Heliarch Reactors Use Antimatter Catalyzed Fusion

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -45,7 +45,9 @@ outfit "Small Reactor Module"
 	"outfit space" -42
 	"energy generation" 9.8
 	"heat generation" 19
-	description "Solar power is sufficient for commerce, but excessive thriftiness is seldom a winning strategy in warfare. So for ships that must have a reliable energy source to power weapons, the Heliarchs use nuclear reactors."
+	description "Solar power is sufficient for commerce, but excessive thriftiness is seldom a winning strategy in warfare. For ships that must have a reliable energy source to power weapons, the Heliarchs use compact nuclear reactors."
+	description "	A beam of antiprotons triggers fusion in tiny injected fuel pellets, allowing for a complete burnup far more efficient than would otherwise be possible."
+
 
 outfit "Large Reactor Module"
 	category "Power"
@@ -57,7 +59,9 @@ outfit "Large Reactor Module"
 	"outfit space" -98
 	"energy generation" 24.2
 	"heat generation" 45
-	description "This reactor was designed for the most powerful Heliarch warships. Its design has not changed significantly in the millennia since the first battle with the Quarg, but each generation of reactors is made slightly more efficient than the previous ones."
+	description "Though still unable to replicate Quarg power generation technology, Heliarch science teams are constantly looking to realize their most recent guess on how they work. For this larger module, a steady stream of injected antiprotons catalyzes reactions in carefully confined fusion plasma, extracting as much power as physically possible."
+	description "	This advanced fusion reactor was designed for the most powerful Heliarch warships. Its structure has not changed significantly in the millennia since the first battle with the Quarg, but each generation of reactors is made slightly more efficient than the previous ones."
+
 
 outfit "Small Cogeneration Module"
 	category "Power"

--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -48,7 +48,6 @@ outfit "Small Reactor Module"
 	description "Solar power is sufficient for commerce, but excessive thriftiness is seldom a winning strategy in warfare. For ships that must have a reliable energy source to power weapons, the Heliarchs use compact nuclear reactors."
 	description "	A beam of antiprotons triggers fusion in tiny injected fuel pellets, allowing for a complete burnup far more efficient than would otherwise be possible."
 
-
 outfit "Large Reactor Module"
 	category "Power"
 	licenses
@@ -61,7 +60,6 @@ outfit "Large Reactor Module"
 	"heat generation" 45
 	description "Though still unable to replicate Quarg power generation technology, Heliarch science teams are constantly looking to realize their most recent guess on how they work. For this larger module, a steady stream of injected antiprotons catalyzes reactions in carefully confined fusion plasma, extracting as much power as physically possible."
 	description "	This advanced fusion reactor was designed for the most powerful Heliarch warships. Its structure has not changed significantly in the millennia since the first battle with the Quarg, but each generation of reactors is made slightly more efficient than the previous ones."
-
 
 outfit "Small Cogeneration Module"
 	category "Power"


### PR DESCRIPTION
----------------------
**Content (Outfit Description Buffing)**

## Summary
Like many reactors in the game, the Heliarch Reactor Modules are written off as simply being nuclear reactors (assumed fusion, due to the great efficiency). To add some more lore/fluff to their descriptions, and add some more variety to the reactor category game, this PR just updates the descriptions of both Reactor Modules, specifying that they use antimatter catalyzed fusion in order to achieve greater outputs, and linking the advancement to their efforts in understanding the Quarg tech they looted/stole.

The idea to use the antimatter stuff specifically is from @Azure3141 , who also wrote the initial extra paragraphs to go with explaining it in the reactor descriptions. Thanks again!
