### PR TITLE
Governments can refer to named colours

### DIFF
--- a/source/Color.cpp
+++ b/source/Color.cpp
@@ -57,6 +57,16 @@ void Color::Load(double r, double g, double b, double a)
 	color[1] = static_cast<float>(g);
 	color[2] = static_cast<float>(b);
 	color[3] = static_cast<float>(a);
+
+	isLoaded = true;
+}
+
+
+
+// Check if Load() has been called for this color.
+bool Color::IsLoaded() const
+{
+	return isLoaded;
 }
 
 

--- a/source/Color.h
+++ b/source/Color.h
@@ -35,6 +35,8 @@ public:
 
 	// Set this color to the given RGBA values.
 	void Load(double r, double g, double b, double a);
+	// Check if Load() has been called for this color.
+	bool IsLoaded() const;
 	// Get the color as a float vector, suitable for use by OpenGL.
 	const float *Get() const;
 
@@ -55,6 +57,8 @@ public:
 private:
 	// Store the color as a float vector for easy interfacing with OpenGL.
 	float color[4];
+
+	bool isLoaded = false;
 };
 
 

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -210,8 +210,13 @@ void Government::Load(const DataNode &node)
 			displayName = child.Token(valueIndex);
 		else if(key == "swizzle")
 			swizzle = child.Value(valueIndex);
-		else if(key == "color" && child.Size() >= 3 + valueIndex)
-			color = Color(child.Value(valueIndex), child.Value(valueIndex + 1), child.Value(valueIndex + 2));
+		else if(key == "color")
+		{
+			if(child.Size() >= 3 + valueIndex)
+				color = ExclusiveItem<Color>(Color(child.Value(valueIndex), child.Value(valueIndex + 1), child.Value(valueIndex + 2)));
+			else if(child.Size() >= 1 + valueIndex)
+				color = ExclusiveItem<Color>(GameData::Colors().Get(child.Token(valueIndex)));
+		}
 		else if(key == "death sentence")
 			deathSentence = GameData::Conversations().Get(child.Token(valueIndex));
 		else if(key == "friendly hail")
@@ -278,7 +283,7 @@ int Government::GetSwizzle() const
 // Get the color to use for displaying this government on the map.
 const Color &Government::GetColor() const
 {
-	return color;
+	return *color;
 }
 
 

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -213,7 +213,8 @@ void Government::Load(const DataNode &node)
 		else if(key == "color")
 		{
 			if(child.Size() >= 3 + valueIndex)
-				color = ExclusiveItem<Color>(Color(child.Value(valueIndex), child.Value(valueIndex + 1), child.Value(valueIndex + 2)));
+				color = ExclusiveItem<Color>(Color(child.Value(valueIndex),
+						child.Value(valueIndex + 1), child.Value(valueIndex + 2)));
 			else if(child.Size() >= 1 + valueIndex)
 				color = ExclusiveItem<Color>(GameData::Colors().Get(child.Token(valueIndex)));
 		}

--- a/source/Government.h
+++ b/source/Government.h
@@ -17,6 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #define GOVERNMENT_H_
 
 #include "Color.h"
+#include "ExclusiveItem.h"
 #include "LocationFilter.h"
 
 #include <map>
@@ -134,7 +135,7 @@ private:
 	std::string name;
 	std::string displayName;
 	int swizzle = 0;
-	Color color;
+	ExclusiveItem<Color> color;
 
 	std::vector<double> attitudeToward;
 	double initialPlayerReputation = 0.;

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -317,7 +317,6 @@ void UniverseObjects::CheckReferences()
 	for(auto &&it : formations)
 		if(it.second.Name().empty())
 			NameAndWarn("formation", it);
-	
 	// Any stock colors should have been loaded from game data files.
 	for(const auto &it : colors)
 		if(!it.second.IsLoaded())

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -317,6 +317,11 @@ void UniverseObjects::CheckReferences()
 	for(auto &&it : formations)
 		if(it.second.Name().empty())
 			NameAndWarn("formation", it);
+	
+	// Any stock colors should have been loaded from game data files.
+	for(const auto &it : colors)
+		if(!it.second.IsLoaded())
+			Warn("color", it.first);
 }
 
 


### PR DESCRIPTION
**Feature:**

## Feature Details
Currently, a government colour must be provided as a literal in the government definition.
This PR adds support for instead referencing a named (stock) colour by storing the colour in the government object inside an ExclusiveItem that can point to a stock colour in `GameData::Colors()`.

This could be especially useful in the cases where we have multiple internal governments which we want to appear identical to the player except for some slight behavioural differences; their colours could be defined once and then referred to instead of having the literals repeated many times.


~~It may perhaps be a good idea to add an `isDefined` member to `Color` and check this for every colour in `GameData::Colors()` to ensure any colour names being referred to have actually been defined. I think all named colours are currently only referred to in the engine, not in the content.~~

Such a check has been added to UniverseObjects::CheckReferences()`. Hopefully, it doesn't produce any warnings when the CI runs.

## UI Screenshots
N/A

## Usage Examples
```
color "whatever government colour" .5 .5 .5 1.

government "whatever"
    color "whatever government colour"
```

## Testing Done
It builds!

### Automated Tests Added
I don't think any testing for this usage of ExclusiveItem is necessary, or possible; ExclusiveItem itself already has unit tests.

## Performance Impact
N/A, probably.
