### PR TITLE
FW: remove redunant wording

### DIFF
--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -1726,7 +1726,7 @@ mission "FW Early Warning 1"
 			`	"Let's get inside," Tomek says, motioning for a number of militia officers to follow. As they file in, he also motions to you.`
 			choice
 				`	(Go inside.)`
-			`	On the inside there is a large table with a map of the region at its center, much nicer than Tomek's map that he was using on Longjump. "Officer Sullivan, please give us a sitrep on the situation," JJ says.`
+			`	On the inside there is a large table with a map of the region at its center, much nicer than Tomek's map that he was using on Longjump. "Officer Sullivan, please give us a sitrep," JJ says.`
 			`	"Yes, sir. As the quartermaster of Deep, I have been monitoring the results of the early warning sensors installed on Hope by Captain <last>. For months now we would receive only the occasional ping of Navy ships entering the system, presumably scout fleets or fleets passing through the system from the western Dirt Belt to the east.`
 			`	"But starting within the past week, the number of Navy ships passing through the system began to rapidly increase. We went from seeing a fleet every few days to multiple per day, and those fleets that did enter often lingered for a longer amount of time for an unknown reason."`
 			branch sensors


### PR DESCRIPTION
## Summary
Remove redundant wording from a mission: "sitrep on the situation."

## Testing Done
Change made within syntactic boundaries. No breaks reported by VS Code.
