### PR TITLE
fix(content): Ensure "Relic of the Past" does not offer while it is already active

### DIFF
--- a/data/rulei/rulei missions.txt
+++ b/data/rulei/rulei missions.txt
@@ -14,6 +14,8 @@
 mission "Relic of the Past"
 	invisible
 	landing
+	to offer
+		not "Relic of the Past: active"
 	to complete
 		never
 	npc save


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Without this, this mission can offer while it is already active, and since it persists, well, that's not good.

Edit: actually, this isn't a repeat mission, so this might not fix all our problems.