### PR TITLE
Tutorial: don't show more than one tutorial prompt at a time in the outfitter + show title

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -103,7 +103,7 @@ help "navigation"
 	`When you reach a new system, you can press <Land on planet / station> to land on any inhabited planets that are there.`
 	`Also, don't worry about crashing into asteroids or other ships; your ship will fly safely below or above them.`
 
-help "outfitter basics"
+help "outfitter"
 	`Here, you can buy new equipment for your ship. Your ship has a limited amount of "outfit space," and most outfits use up some of that space.`
 	`Some types of outfits have other requirements as well. For example, only some of your outfit space can be used for engines or weapons; this is your ship's "engine capacity" and "weapon capacity." Guns and missile launchers also require a free "gun port," and turrets require a free "turret mount." Also, missiles can only be bought if you have the right launcher installed.`
 	`Use your scroll wheel, or click and drag, to scroll the view.`

--- a/data/help.txt
+++ b/data/help.txt
@@ -103,18 +103,18 @@ help "navigation"
 	`When you reach a new system, you can press <Land on planet / station> to land on any inhabited planets that are there.`
 	`Also, don't worry about crashing into asteroids or other ships; your ship will fly safely below or above them.`
 
-help "outfitter"
+help "outfitter basics"
 	`Here, you can buy new equipment for your ship. Your ship has a limited amount of "outfit space," and most outfits use up some of that space.`
 	`Some types of outfits have other requirements as well. For example, only some of your outfit space can be used for engines or weapons; this is your ship's "engine capacity" and "weapon capacity." Guns and missile launchers also require a free "gun port," and turrets require a free "turret mount." Also, missiles can only be bought if you have the right launcher installed.`
 	`Use your scroll wheel, or click and drag, to scroll the view.`
 	`As in the trading panel, you can hold down Shift, Control, or Alt to buy 5, 20, or 500 of an outfit at once, or multiple keys for larger amounts.`
 
-help "outfitter 2"
+help "cargo management"
 	`Sometimes you may want to buy some outfits directly into your cargo hold instead of having them installed. Perhaps a mission has asked you to retrieve some outfits or you want to carry extra ammunition to refill your ships somewhere that does not stock those weapons. To accomplish this, you need to switch out of installation mode into 'purchase to cargo' mode. This can be achieved by Control+clicking on your selected ship to deselect it.`
 	`When you are in 'purchase to cargo' mode, your ship information on the right-hand side will be replaced by information on how much cargo space you currently have available.`
 	`Outfits that are in your cargo hold can be (re)installed at any outfitter without cost.`
 
-help "outfitter 3"
+help "uninstalling and storage"
 	`You can also uninstall outfits directly into planetary storage by selecting the outfit and pressing U. This can be useful for if you want to shuffle outfits between ships, store outfits for future use, or simply try on different outfits. Outfits in storage can also be transferred to cargo when you go to 'purchase to cargo' mode. Outfits that are in planetary storage or cargo can be (re)installed at any outfitter without cost.`
 	`If you sell an outfit at an outfitter, then you can immediately buy it back for the same price that you sold it, so long as you do not leave the planet. This means that you do not necessarily need to worry about uninstalling outfits into planetary storage when you are changing outfits around.`
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -109,8 +109,8 @@ void OutfitterPanel::Step()
 	ShopPanel::Step();
 	ShopPanel::CheckForMissions(Mission::OUTFITTER);
 	if(GetUI()->IsTop(this) && !checkedHelp)
-		if(!DoHelp("outfitter") && !DoHelp("outfitter 2") && !DoHelp("outfitter 3"))
-			// All help messages have now been displayed.
+		if(DoHelp("outfitter")) || DoHelp("outfitter 2") || DoHelp("outfitter 3") || true)
+			// A help messages has now been displayed, or all of them.
 			checkedHelp = true;
 }
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -110,9 +110,9 @@ void OutfitterPanel::Step()
 	ShopPanel::CheckForMissions(Mission::OUTFITTER);
 	if(GetUI()->IsTop(this) && !checkedHelp)
 		// Use short-circuiting to only display one of them at a time.
-		// (the first valid condition encountered will make us skip the others since it is an or)
+		// (The first valid condition encountered will make us skip the others.)
 		if(DoHelp("outfitter") || DoHelp("cargo management") || DoHelp("uninstalling and storage") || true)
-			// A help messages has now been displayed, or all of them.
+			// Either a help message was freshly displayed, or all of them have already been seen.
 			checkedHelp = true;
 }
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -109,7 +109,7 @@ void OutfitterPanel::Step()
 	ShopPanel::Step();
 	ShopPanel::CheckForMissions(Mission::OUTFITTER);
 	if(GetUI()->IsTop(this) && !checkedHelp)
-		if(DoHelp("outfitter")) || DoHelp("outfitter 2") || DoHelp("outfitter 3") || true)
+		if(DoHelp("outfitter") || DoHelp("outfitter 2") || DoHelp("outfitter 3") || true)
 			// A help messages has now been displayed, or all of them.
 			checkedHelp = true;
 }

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -109,6 +109,8 @@ void OutfitterPanel::Step()
 	ShopPanel::Step();
 	ShopPanel::CheckForMissions(Mission::OUTFITTER);
 	if(GetUI()->IsTop(this) && !checkedHelp)
+		// Use short-circuiting to only display one of them at a time.
+		// (the first valid condition encountered will make us skip the others since it is an or)
 		if(DoHelp("outfitter") || DoHelp("cargo management") || DoHelp("uninstalling and storage") || true)
 			// A help messages has now been displayed, or all of them.
 			checkedHelp = true;

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -109,7 +109,7 @@ void OutfitterPanel::Step()
 	ShopPanel::Step();
 	ShopPanel::CheckForMissions(Mission::OUTFITTER);
 	if(GetUI()->IsTop(this) && !checkedHelp)
-		if(DoHelp("outfitter") || DoHelp("outfitter 2") || DoHelp("outfitter 3") || true)
+		if(DoHelp("outfitter basics") || DoHelp("cargo management") || DoHelp("uninstalling and storage") || true)
 			// A help messages has now been displayed, or all of them.
 			checkedHelp = true;
 }

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -109,7 +109,7 @@ void OutfitterPanel::Step()
 	ShopPanel::Step();
 	ShopPanel::CheckForMissions(Mission::OUTFITTER);
 	if(GetUI()->IsTop(this) && !checkedHelp)
-		if(DoHelp("outfitter basics") || DoHelp("cargo management") || DoHelp("uninstalling and storage") || true)
+		if(DoHelp("outfitter") || DoHelp("cargo management") || DoHelp("uninstalling and storage") || true)
 			// A help messages has now been displayed, or all of them.
 			checkedHelp = true;
 }

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Point.h"
 #include "Preferences.h"
 #include "Screen.h"
+#include "text/Format.h"
 #include "UI.h"
 
 using namespace std;
@@ -257,7 +258,7 @@ bool Panel::DoHelp(const string &name) const
 		return false;
 
 	Preferences::Set(preference);
-	ui->Push(new Dialog(preference + "\n\n" + message));
+	ui->Push(new Dialog(Format::Capitalize(name) + ":\n\n" + message));
 
 	return true;
 }

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -257,7 +257,7 @@ bool Panel::DoHelp(const string &name) const
 		return false;
 
 	Preferences::Set(preference);
-	ui->Push(new Dialog(message));
+	ui->Push(new Dialog(preference + "\n\n" + message));
 
 	return true;
 }


### PR DESCRIPTION
A big problem of this game is unknown features.
Part of those features are shown in the tutorial but because they overwhelm the player so much nobody reads them.

This just makes only one of them show per outfitter panel (tested, it works)

Also adds a small title of the tutorial:
OUTDATED (now shows `Multiple ships controls:`) as a title
![Screenshot_2022-12-28_17-05-58](https://user-images.githubusercontent.com/94366726/209843556-11f040bd-a6c4-45c1-9a60-49c2346efecb.png)
