### PR TITLE
Use existing Color methods in MapPanel

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -309,10 +309,7 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, float alpha, const System *
 		// might not be linked via hyperspace.
 		Color color = Color(.5f * alpha, 0.f);
 		if(player.HasVisited(system) && system.IsInhabited(flagship) && gov)
-			color = Color(
-				alpha * gov->GetColor().Get()[0],
-				alpha * gov->GetColor().Get()[1],
-				alpha * gov->GetColor().Get()[2], 0.f);
+			color = gov->GetColor().Additive(alpha);
 		RingShader::Draw(from, OUTER, INNER, color);
 
 		for(const System *link : system.Links())
@@ -334,10 +331,7 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, float alpha, const System *
 			gov = link->GetGovernment();
 			Color color = Color(.5f * alpha, 0.f);
 			if(player.HasVisited(*link) && link->IsInhabited(flagship) && gov)
-				color = Color(
-					alpha * gov->GetColor().Get()[0],
-					alpha * gov->GetColor().Get()[1],
-					alpha * gov->GetColor().Get()[2], 0.f);
+				color = gov->GetColor().Additive(alpha);
 			RingShader::Draw(to, OUTER, INNER, color);
 		}
 

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -90,7 +90,8 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 	else if(planet.GetGovernment())
 	{
 		government = "(" + planet.GetGovernment()->GetName() + ")";
-		color = Color::Combine(.5f, planet.GetGovernment()->GetColor(), .3f, Color()).Opaque();
+		color = planet.GetGovernment()->GetColor();
+		color = Color(color.Get()[0] * .5f + .3f, color.Get()[1] * .5f + .3f, color.Get()[2] * .5f + .3f);
 		if(!planet.CanLand())
 			hostility = 3 + 2 * planet.GetGovernment()->IsEnemy();
 	}

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -90,8 +90,7 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 	else if(planet.GetGovernment())
 	{
 		government = "(" + planet.GetGovernment()->GetName() + ")";
-		color = planet.GetGovernment()->GetColor();
-		color = Color(color.Get()[0] * .5f + .3f, color.Get()[1] * .5f + .3f, color.Get()[2] * .5f + .3f);
+		color = Color::Combine(.5f, planet.GetGovernment()->GetColor(), .3f, Color()).Opaque();
 		if(!planet.CanLand())
 			hostility = 3 + 2 * planet.GetGovernment()->IsEnemy();
 	}


### PR DESCRIPTION
**Refactor**

`MapPanel::DrawMiniMap()` was doing some stuff to colour values to achieve the same end result `Color::Additive()` does, so I've changed it to use the method of Color.

I also made a change to the `PlanetLabel` constructor but I think that would have a larger performance impact (still not massive,  it'll only be a few extra floating point multiplications, but enough that I don't think it's worth the simplification, the change there is arguably not simpler to read.)

There's also this but I don't think a combination of the existing Color methods can achieve this result.
Maybe `.Transparent(1.5f).Opaque().Transparent(.4f)`, but that's pretty terrible.
https://github.com/endless-sky/endless-sky/blob/31b2bcda12672199d20e59ce78dd61a6eea4e689/source/MapPanel.cpp#L600-L604