### PR TITLE
Use named colours for governments

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1178,9 +1178,9 @@ government "Test Dummy"
 	"bribe" 0
 	"fine" 0
 
-# For space objects of unknown origin, to ensure the player can't land:
 color "governments: Ungoverned" .4 .4 .4
 
+# For space objects of unknown origin, to ensure the player can't land:
 government "Unknown"
 	swizzle 1
 	color "governments: Ungoverned"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -290,10 +290,12 @@ government "Gegno Scin"
 	"penalty for"
 		assist 0
 
+color "governments: Gegno Vi" .68 .4 .4
+
 government "Gegno Vi"
 	swizzle 0
 	language "Gegno"
-	color 0.68 0.4 0.4
+	color "governments: Gegno Vi"
 
 	"player reputation" 0
 	"crew attack" 1.3
@@ -324,7 +326,7 @@ government "Gegno Vi (Neutral)"
 	"display name" "Gegno Vi"
 	swizzle 0
 	language "Gegno"
-	color 0.68 0.4 0.4
+	color "governments: Gegno Vi"
 
 	"player reputation" 0
 	"crew attack" 1.3
@@ -340,7 +342,7 @@ government "Gegno Vi (Duelist A)"
 	swizzle 0
 	"display name" "Gegno Vi"
 	language "Gegno"
-	color 0.68 0.4 0.4
+	color "governments: Gegno Vi"
 
 	"player reputation" 0
 	"crew attack" 1.3
@@ -357,7 +359,7 @@ government "Gegno Vi (Duelist B)"
 	swizzle 0
 	"display name" "Gegno Vi"
 	language "Gegno"
-	color 0.68 0.4 0.4
+	color "governments: Gegno Vi"
 
 	"player reputation" 0
 	"crew attack" 1.3

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -156,6 +156,19 @@ government "Drak (Hostile)"
 	"attitude toward"
 		"Indigenous Lifeform" 1
 
+government "Elenctic Commune"
+	swizzle 0
+	color "governments: Neutral"
+	
+	"player reputation" 1000
+	"attitude toward"
+		"Hai" .1
+		"Hai (Friendly Unfettered)" .1
+		"Pirate" -.2
+		"Pirate (Devil-Run Gang)" -.2
+		"Smuggler (Hai Trafficker)" -.2
+	"bribe" .05
+
 government "Escort"
 	swizzle 5
 	"fine" 0
@@ -786,18 +799,6 @@ government "Parrot"
 	"player reputation" 1
 	"bribe" 0
 
-government "Elenctic Commune"
-	swizzle 0
-	color .84 .61 .37
-	
-	"player reputation" 1000
-	"attitude toward"
-		"Hai" .1
-		"Hai (Friendly Unfettered)" .1
-		"Pirate" -.2
-		"Pirate (Devil-Run Gang)" -.2
-		"Smuggler (Hai Trafficker)" -.2
-	"bribe" .05
 color "governments: Pirate" .78 0 0
 
 government "Pirate"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1156,13 +1156,15 @@ government "Test Dummy"
 	"fine" 0
 
 # For space objects of unknown origin, to ensure the player can't land:
+color "governments: Ungoverned" .4 .4 .4
+
 government "Unknown"
 	swizzle 1
-	color .4 .4 .4
+	color "governments: Ungoverned"
 	"player reputation" -1000
 
 government "Uninhabited"
-	color .4 .4 .4
+	color "governments: Ungoverned"
 	"bribe" 0
 	"fine" 0
 

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -370,9 +370,11 @@ government "Gegno Vi (Duelist B)"
 	"penalty for"
 		assist 0
 
+color "governments: Hai" .86 .48 .79
+
 government "Hai"
 	swizzle 0
-	color .86 .48 .79
+	color "governments: Hai"
 	
 	"player reputation" 0
 	"attitude toward"
@@ -394,7 +396,7 @@ government "Hai"
 government "Hai (Wormhole Access)"
 	"display name" "Hai"
 	swizzle 0
-	color .86 .48 .79
+	color "governments: Hai"
 	
 	"player reputation" 0
 	"attitude toward"
@@ -415,7 +417,7 @@ government "Hai (Wormhole Access)"
 government "Hai Merchant"
 	"display name" "Hai"
 	swizzle 0
-	color .86 .48 .79
+	color "governments: Hai"
 	
 	"player reputation" 0
 	"attitude toward"
@@ -434,7 +436,7 @@ government "Hai Merchant"
 government "Hai Merchant (Sympathizers)"
 	"display name" "Hai"
 	swizzle 0
-	color .86 .48 .79
+	color "governments: Hai"
 	
 	"player reputation" 0
 	"attitude toward"
@@ -453,7 +455,7 @@ government "Hai Merchant (Sympathizers)"
 government "Hai Merchant (Human)"
 	"display name" "Hai"
 	swizzle 0
-	color .86 .48 .79
+	color "governments: Hai"
 	
 	"player reputation" 0
 	"attitude toward"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1087,9 +1087,11 @@ government "Smuggler (Hai Trafficker)"
 		destroy 0
 		atrocity 0
 
+color "governments: Syndicate" 0 .41 .71
+
 government "Syndicate"
 	swizzle 4
-	color 0 .41 .71
+	color "governments: Syndicate"
 	
 	"player reputation" 2
 	"attitude toward"
@@ -1107,7 +1109,7 @@ government "Syndicate"
 government "Syndicate that won't enter wormhole"
 	"display name" "Syndicate"
 	swizzle 4
-	color 0 .41 .71
+	color "governments: Syndicate"
 	
 	"player reputation" 2
 	"attitude toward"
@@ -1124,7 +1126,7 @@ government "Syndicate that won't enter wormhole"
 
 government "Syndicate (Extremist)"
 	swizzle 1
-	color 0 .41 .71
+	color "governments: Syndicate"
 	
 	"player reputation" -1000
 	"attitude toward"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -633,9 +633,11 @@ government "Ka'sei"
 	"hostile hail" "hostile ka'het"
 	"hostile disabled hail" "hostile disabled ka'het"
 
+color "governments: Korath Exiles" .8 .5 .1
+
 government "Korath"
 	swizzle 0
-	color .8 .5 .1
+	color "governments: Korath Exiles"
 	"crew attack" 1.4
 	"crew defense" 2.6
 	language "Korath"
@@ -650,7 +652,7 @@ government "Korath"
 government "Korath (Civilian)"
 	"display name" "Korath"
 	swizzle 2
-	color .8 .5 .1
+	color "governments: Korath Exiles"
 	"crew attack" 1.1
 	"crew defense" 2.1
 	language "Korath"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -64,7 +64,7 @@ government "Bounty (Disguised)"
 
 government "Bounty Hunter"
 	swizzle 6
-	color .78 0 0
+	color "governments: Pirate"
 
 	"player reputation" -1000
 	"bribe" .2
@@ -74,7 +74,7 @@ government "Bounty Hunter"
 government "Bounty Hunter that Won't Enter Hai Space"
 	"display name" "Bounty Hunter"
 	swizzle 6
-	color .78 0 0
+	color "governments: Pirate"
 
 	"player reputation" -1000
 	"bribe" .2
@@ -84,7 +84,7 @@ government "Bounty Hunter that Won't Enter Hai Space"
 government "Bounty Hunter that Attacks Hai"
 	"display name" "Bounty Hunter"
 	swizzle 6
-	color .78 0 0
+	color "governments: Pirate"
 	
 	"attitude toward"
 		"Hai (Friendly Unfettered)" -.3
@@ -799,7 +799,7 @@ government "Elenctic Commune"
 
 government "Pirate"
 	swizzle 6
-	color .78 0 0
+	color "governments: Pirate"
 	
 	"player reputation" -10
 	"attitude toward"
@@ -818,7 +818,7 @@ government "Pirate"
 
 government "Pirate (Devil-Run Gang)"
 	swizzle 6
-	color .78 0 0
+	color "governments: Pirate"
 	"display name" "Pirate"
 	
 	"player reputation" -1000
@@ -840,7 +840,7 @@ government "Pirate (Devil-Run Gang)"
 government "Pirate (Rival)"
 	"display name" "Pirate"
 	swizzle 6
-	color .78 0 0
+	color "governments: Pirate"
 	
 	"player reputation" -10
 	"attitude toward"
@@ -1040,7 +1040,7 @@ government "Republic (Friendly)"
 
 government "Scar's Legion"
 	swizzle 6
-	color .78 0 0
+	color "governments: Pirate"
 	"player reputation" 10
 	"attitude toward"
 		"Merchant" -0.01
@@ -1053,7 +1053,7 @@ government "Scar's Legion"
 government "Scar's Legion (Killable)"
 	"display name" "Scar's Legion"
 	swizzle 6
-	color .78 0 0
+	color "governments: Pirate"
 	"player reputation" -1000
 	bribe 0
 	fine 0

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -745,7 +745,7 @@ government "Navy Intelligence"
 
 government "Navy (Oathkeeper)"
 	swizzle 0
-	color .91 .42 .09
+	color "governments: Republic"
 	"crew attack" 1.2
 	"crew defense" 2.2
 	
@@ -964,9 +964,11 @@ government "Remnant (Research)"
 	"friendly hail" "remnant uncontacted"
 	"hostile hail" "remnant uncontacted hostile"
 
+color "governments: Republic" .91 .42 .09
+
 government "Republic"
 	swizzle 0
-	color .91 .42 .09
+	color "governments: Republic"
 	"crew attack" 1.2
 	"crew defense" 2.2
 	
@@ -999,7 +1001,7 @@ government "Republic Intelligence"
 government "Republic that won't enter wormhole"
 	"display name" Republic
 	swizzle 0
-	color .91 .42 .09
+	color "governments: Republic"
 	"crew attack" 1.2
 	"crew defense" 2.2
 	

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -528,9 +528,11 @@ government "Heliarch"
 		"Quarg" -.01
 		"Coalition" 1
 
+color "governments: Independent" .78 .36 .36
+
 government "Independent"
 	swizzle 6
-	color .78 .36 .36
+	color "governments: Independent"
 	
 	"player reputation" 10
 	"bribe" .05
@@ -543,7 +545,7 @@ government "Independent"
 government "Independent (Killable)"
 	"display name" "Independent"
 	swizzle 6
-	color .78 .36 .36
+	color "governments: Independent"
 	
 	"player reputation" 10
 	"bribe" .05

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -220,7 +220,7 @@ government "Forest (Predator)"
 		destroy 0
 		atrocity 0
 
-color "governments: Free" .06 .68 0
+color "governments: Free" .06 .68 0 1
 
 government "Free Worlds"
 	swizzle 2
@@ -276,7 +276,7 @@ government "Gegno"
 		assist 0
 		provoke 10
 
-color "governments: Gegno Scin" .5 .55 .33
+color "governments: Gegno Scin" .5 .55 .33 1
 
 government "Gegno Scin"
 	swizzle 18
@@ -292,7 +292,7 @@ government "Gegno Scin"
 	"penalty for"
 		assist 0
 
-color "governments: Gegno Vi" .68 .4 .4
+color "governments: Gegno Vi" .68 .4 .4 1
 
 government "Gegno Vi"
 	swizzle 0
@@ -374,7 +374,7 @@ government "Gegno Vi (Duelist B)"
 	"penalty for"
 		assist 0
 
-color "governments: Hai" .86 .48 .79
+color "governments: Hai" .86 .48 .79 1
 
 government "Hai"
 	swizzle 0
@@ -534,7 +534,7 @@ government "Heliarch"
 		"Quarg" -.01
 		"Coalition" 1
 
-color "governments: Independent" .78 .36 .36
+color "governments: Independent" .78 .36 .36 1
 
 government "Independent"
 	swizzle 6
@@ -641,7 +641,7 @@ government "Ka'sei"
 	"hostile hail" "hostile ka'het"
 	"hostile disabled hail" "hostile disabled ka'het"
 
-color "governments: Korath Exiles" .8 .5 .1
+color "governments: Korath Exiles" .8 .5 .1 1
 
 government "Korath"
 	swizzle 0
@@ -789,7 +789,7 @@ government "Navy (Oathkeeper)"
 	"friendly hail" "friendly navy"
 	"hostile hail" "hostile navy"
 
-color "governments: Neutral" .84 .61 .37
+color "governments: Neutral" .84 .61 .37 1
 
 government "Neutral"
 	swizzle 0
@@ -811,7 +811,7 @@ government "Parrot"
 	"player reputation" 1
 	"bribe" 0
 
-color "governments: Pirate" .78 0 0
+color "governments: Pirate" .78 0 0 1
 
 government "Pirate"
 	swizzle 6
@@ -872,7 +872,7 @@ government "Pirate (Rival)"
 	"hostile hail" "hostile pirate"
 	raid "pirate raid"
 
-color "governments: Pug" .99 .89 .70
+color "governments: Pug" .99 .89 .70 1
 
 government "Pug"
 	swizzle 0
@@ -932,7 +932,7 @@ government "Quarg"
 		"Medium Graviton Steering"
 		"Quantum Shield Generator"
 
-color "governments: Remnant" .89 .38 .62
+color "governments: Remnant" .89 .38 .62 1
 
 government "Remnant"
 	swizzle 0
@@ -983,7 +983,7 @@ government "Remnant (Research)"
 	"friendly hail" "remnant uncontacted"
 	"hostile hail" "remnant uncontacted hostile"
 
-color "governments: Republic" .91 .42 .09
+color "governments: Republic" .91 .42 .09 1
 
 government "Republic"
 	swizzle 0
@@ -1108,7 +1108,7 @@ government "Smuggler (Hai Trafficker)"
 		destroy 0
 		atrocity 0
 
-color "governments: Syndicate" 0 .41 .71
+color "governments: Syndicate" 0 .41 .71 1
 
 government "Syndicate"
 	swizzle 4
@@ -1178,7 +1178,7 @@ government "Test Dummy"
 	"bribe" 0
 	"fine" 0
 
-color "governments: Ungoverned" .4 .4 .4
+color "governments: Ungoverned" .4 .4 .4 1
 
 # For space objects of unknown origin, to ensure the player can't land:
 government "Unknown"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -276,10 +276,12 @@ government "Gegno"
 		assist 0
 		provoke 10
 
+color "governments: Gegno Scin" .5 .55 .33
+
 government "Gegno Scin"
 	swizzle 18
 	language "Gegno"
-	color 0.5 0.55 0.33
+	color "governments: Gegno Scin"
 
 	"player reputation" 0
 	"crew attack" 1.2
@@ -312,7 +314,7 @@ government "Gegno Scin (Neutral)"
 	"display name" "Gegno Scin"
 	swizzle 18
 	language "Gegno"
-	color 0.5 0.55 0.33
+	color "governments: Gegno Scin"
 
 	"player reputation" 0
 	"crew attack" 1.2

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -920,9 +920,11 @@ government "Quarg"
 		"Medium Graviton Steering"
 		"Quantum Shield Generator"
 
+color "governments: Remnant" .89 .38 .62
+
 government "Remnant"
 	swizzle 0
-	color .89 .38 .62
+	color "governments: Remnant""
 	"crew defense" 2.2
 	
 	"player reputation" 1
@@ -948,7 +950,7 @@ government "Remnant"
 government "Remnant (Research)"
 	"display name" "Remnant"
 	swizzle 0
-	color .89 .38 .62
+	color "governments: Remnant"
 	"crew defense" 2.2
 	
 	"player reputation" 1

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -764,9 +764,11 @@ government "Navy (Oathkeeper)"
 	"friendly hail" "friendly navy"
 	"hostile hail" "hostile navy"
 
+color "governments: Neutral" .84 .61 .37
+
 government "Neutral"
 	swizzle 0
-	color .84 .61 .37
+	color "governments: Neutral"
 	
 	"player reputation" 1
 	"attitude toward"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -220,7 +220,7 @@ government "Forest (Predator)"
 		destroy 0
 		atrocity 0
 
-color "governments: Free" .06 .68 0 1
+color "governments: Free" .06 .68 0. 1.
 
 government "Free Worlds"
 	swizzle 2
@@ -276,7 +276,7 @@ government "Gegno"
 		assist 0
 		provoke 10
 
-color "governments: Gegno Scin" .5 .55 .33 1
+color "governments: Gegno Scin" .5 .55 .33 1.
 
 government "Gegno Scin"
 	swizzle 18
@@ -292,7 +292,7 @@ government "Gegno Scin"
 	"penalty for"
 		assist 0
 
-color "governments: Gegno Vi" .68 .4 .4 1
+color "governments: Gegno Vi" .68 .4 .4 1.
 
 government "Gegno Vi"
 	swizzle 0
@@ -374,7 +374,7 @@ government "Gegno Vi (Duelist B)"
 	"penalty for"
 		assist 0
 
-color "governments: Hai" .86 .48 .79 1
+color "governments: Hai" .86 .48 .79 1.
 
 government "Hai"
 	swizzle 0
@@ -534,7 +534,7 @@ government "Heliarch"
 		"Quarg" -.01
 		"Coalition" 1
 
-color "governments: Independent" .78 .36 .36 1
+color "governments: Independent" .78 .36 .36 1.
 
 government "Independent"
 	swizzle 6
@@ -641,7 +641,7 @@ government "Ka'sei"
 	"hostile hail" "hostile ka'het"
 	"hostile disabled hail" "hostile disabled ka'het"
 
-color "governments: Korath Exiles" .8 .5 .1 1
+color "governments: Korath Exiles" .8 .5 .1 1.
 
 government "Korath"
 	swizzle 0
@@ -789,7 +789,7 @@ government "Navy (Oathkeeper)"
 	"friendly hail" "friendly navy"
 	"hostile hail" "hostile navy"
 
-color "governments: Neutral" .84 .61 .37 1
+color "governments: Neutral" .84 .61 .37 1.
 
 government "Neutral"
 	swizzle 0
@@ -811,7 +811,7 @@ government "Parrot"
 	"player reputation" 1
 	"bribe" 0
 
-color "governments: Pirate" .78 0 0 1
+color "governments: Pirate" .78 0. 0. 1.
 
 government "Pirate"
 	swizzle 6
@@ -872,7 +872,7 @@ government "Pirate (Rival)"
 	"hostile hail" "hostile pirate"
 	raid "pirate raid"
 
-color "governments: Pug" .99 .89 .70 1
+color "governments: Pug" .99 .89 .70 1.
 
 government "Pug"
 	swizzle 0
@@ -932,7 +932,7 @@ government "Quarg"
 		"Medium Graviton Steering"
 		"Quantum Shield Generator"
 
-color "governments: Remnant" .89 .38 .62 1
+color "governments: Remnant" .89 .38 .62 1.
 
 government "Remnant"
 	swizzle 0
@@ -983,7 +983,7 @@ government "Remnant (Research)"
 	"friendly hail" "remnant uncontacted"
 	"hostile hail" "remnant uncontacted hostile"
 
-color "governments: Republic" .91 .42 .09 1
+color "governments: Republic" .91 .42 .09 1.
 
 government "Republic"
 	swizzle 0
@@ -1108,7 +1108,7 @@ government "Smuggler (Hai Trafficker)"
 		destroy 0
 		atrocity 0
 
-color "governments: Syndicate" 0 .41 .71 1
+color "governments: Syndicate" 0. .41 .71 1.
 
 government "Syndicate"
 	swizzle 4
@@ -1178,7 +1178,7 @@ government "Test Dummy"
 	"bribe" 0
 	"fine" 0
 
-color "governments: Ungoverned" .4 .4 .4 1
+color "governments: Ungoverned" .4 .4 .4 1.
 
 # For space objects of unknown origin, to ensure the player can't land:
 government "Unknown"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -796,6 +796,7 @@ government "Elenctic Commune"
 		"Pirate (Devil-Run Gang)" -.2
 		"Smuggler (Hai Trafficker)" -.2
 	"bribe" .05
+color "governments: Pirate" .78 0 0
 
 government "Pirate"
 	swizzle 6

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -220,9 +220,11 @@ government "Forest (Predator)"
 		destroy 0
 		atrocity 0
 
+color "governments: Free" .06 .68 0
+
 government "Free Worlds"
 	swizzle 2
-	color .06 .68 0
+	color "governments: Free"
 	
 	"player reputation" 1
 	"attitude toward"
@@ -242,7 +244,7 @@ government "Free Worlds"
 government "Free Worlds that won't enter wormhole"
 	"display name" "Free Worlds"
 	swizzle 2
-	color .06 .68 0
+	color "governments: Free"
 	
 	"player reputation" 1
 	"attitude toward"
@@ -734,7 +736,7 @@ government "Merchant"
 
 government "Militia"
 	swizzle 2
-	color .06 .68 0
+	color "governments: Free"
 	
 	"player reputation" 0
 	"attitude toward"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -862,9 +862,11 @@ government "Pirate (Rival)"
 	"hostile hail" "hostile pirate"
 	raid "pirate raid"
 
+color "governments: Pug" .99 .89 .70
+
 government "Pug"
 	swizzle 0
-	color .99 .89 .70
+	color "governments: Pug"
 	
 	"player reputation" 1
 	"attitude toward"
@@ -879,7 +881,7 @@ government "Pug"
 government "Pug (Wanderer)"
 	"display name" "Pug"
 	swizzle 0
-	color .99 .89 .70
+	color "governments: Pug"
 	
 	"player reputation" 1
 	"attitude toward"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -936,7 +936,7 @@ color "governments: Remnant" .89 .38 .62 1
 
 government "Remnant"
 	swizzle 0
-	color "governments: Remnant""
+	color "governments: Remnant"
 	"crew defense" 2.2
 	
 	"player reputation" 1


### PR DESCRIPTION
Many governments use the same colours, leading to repetitions of the same colour literal throughout the file.
This PR uses 4dbbb5e to define those colour literals once and have the relevant governments refer to those named colours instead.

The named colour is defined above the primary government to use it. In most cases, this is the first government to use it, but the Republic colour, for example, is defined immediately above the Republic government even though the Navy (Oathkeeper) government has used it further up.

I notice that a lot of these probably don't need to have colours at all, so I'm wondering if the colour should just be removed from those governments entirely?

Also, moved the Elenctic Commune government up to where it should be alphabetically. It looks like it wasn't moved when it was renamed from `Philosophers`.

I also noticed that the `Smuggler (Hai Trafficker)` government has the same colour as the Coalition (this is also one I don't think actually needs a colour, unless the smugglers own a planet somewhere?)