### PR TITLE
Named colours default alpha to 1

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -220,7 +220,7 @@ government "Forest (Predator)"
 		destroy 0
 		atrocity 0
 
-color "governments: Free" .06 .68 0. 1.
+color "governments: Free" .06 .68 0.
 
 government "Free Worlds"
 	swizzle 2
@@ -276,7 +276,7 @@ government "Gegno"
 		assist 0
 		provoke 10
 
-color "governments: Gegno Scin" .5 .55 .33 1.
+color "governments: Gegno Scin" .5 .55 .33
 
 government "Gegno Scin"
 	swizzle 18
@@ -292,7 +292,7 @@ government "Gegno Scin"
 	"penalty for"
 		assist 0
 
-color "governments: Gegno Vi" .68 .4 .4 1.
+color "governments: Gegno Vi" .68 .4 .4
 
 government "Gegno Vi"
 	swizzle 0
@@ -374,7 +374,7 @@ government "Gegno Vi (Duelist B)"
 	"penalty for"
 		assist 0
 
-color "governments: Hai" .86 .48 .79 1.
+color "governments: Hai" .86 .48 .79
 
 government "Hai"
 	swizzle 0
@@ -534,7 +534,7 @@ government "Heliarch"
 		"Quarg" -.01
 		"Coalition" 1
 
-color "governments: Independent" .78 .36 .36 1.
+color "governments: Independent" .78 .36 .36
 
 government "Independent"
 	swizzle 6
@@ -641,7 +641,7 @@ government "Ka'sei"
 	"hostile hail" "hostile ka'het"
 	"hostile disabled hail" "hostile disabled ka'het"
 
-color "governments: Korath Exiles" .8 .5 .1 1.
+color "governments: Korath Exiles" .8 .5 .1
 
 government "Korath"
 	swizzle 0
@@ -789,7 +789,7 @@ government "Navy (Oathkeeper)"
 	"friendly hail" "friendly navy"
 	"hostile hail" "hostile navy"
 
-color "governments: Neutral" .84 .61 .37 1.
+color "governments: Neutral" .84 .61 .37
 
 government "Neutral"
 	swizzle 0
@@ -811,7 +811,7 @@ government "Parrot"
 	"player reputation" 1
 	"bribe" 0
 
-color "governments: Pirate" .78 0. 0. 1.
+color "governments: Pirate" .78 0. 0.
 
 government "Pirate"
 	swizzle 6
@@ -872,7 +872,7 @@ government "Pirate (Rival)"
 	"hostile hail" "hostile pirate"
 	raid "pirate raid"
 
-color "governments: Pug" .99 .89 .70 1.
+color "governments: Pug" .99 .89 .70
 
 government "Pug"
 	swizzle 0
@@ -932,7 +932,7 @@ government "Quarg"
 		"Medium Graviton Steering"
 		"Quantum Shield Generator"
 
-color "governments: Remnant" .89 .38 .62 1.
+color "governments: Remnant" .89 .38 .62
 
 government "Remnant"
 	swizzle 0
@@ -983,7 +983,7 @@ government "Remnant (Research)"
 	"friendly hail" "remnant uncontacted"
 	"hostile hail" "remnant uncontacted hostile"
 
-color "governments: Republic" .91 .42 .09 1.
+color "governments: Republic" .91 .42 .09
 
 government "Republic"
 	swizzle 0
@@ -1108,7 +1108,7 @@ government "Smuggler (Hai Trafficker)"
 		destroy 0
 		atrocity 0
 
-color "governments: Syndicate" 0. .41 .71 1.
+color "governments: Syndicate" 0. .41 .71
 
 government "Syndicate"
 	swizzle 4
@@ -1178,7 +1178,7 @@ government "Test Dummy"
 	"bribe" 0
 	"fine" 0
 
-color "governments: Ungoverned" .4 .4 .4 1.
+color "governments: Ungoverned" .4 .4 .4
 
 # For space objects of unknown origin, to ensure the player can't land:
 government "Unknown"

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -338,9 +338,9 @@ void UniverseObjects::LoadFile(const string &path, bool debugMode)
 	for(const DataNode &node : data)
 	{
 		const string &key = node.Token(0);
-		if(key == "color" && node.Size() >= 6)
+		if(key == "color" && node.Size() >= 5)
 			colors.Get(node.Token(1))->Load(
-				node.Value(2), node.Value(3), node.Value(4), node.Value(5));
+				node.Value(2), node.Value(3), node.Value(4), node.Size() >= 6 ? node.Value(5) : 1.);
 		else if(key == "conversation" && node.Size() >= 2)
 			conversations.Get(node.Token(1))->Load(node);
 		else if(key == "effect" && node.Size() >= 2)


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #7978

## Feature Details
When loading a colour definition, the game will now accept definitions that only include rgb values, and default the alpha value to 1.
Also, remove the alpha values fromm the government colour definitions added recently.

An alternative to this approach would be to pass `Color::Load()` a DataNode, instead of parsing the node in UniverseObjects and passing four doubles to `Color::Load()`, but, Color doesn't currently include any other class, so maybe it's better not to make it depend on DataNode?

## Usage Examples
```
color "with alpha" .5 .5 .5 1.
color "without alpha" .5 .5 .5
```
These will result in identical colours.

## Testing Done
If the actions pass, I think it's probably good?

### Automated Tests Added
N/A? Unit tests for UniverseObjects seem a bit excessive ffor this.

## Performance Impact
Loading a colour now involves an extra check to the size of the node. This shouldn't be significant.
