### PR TITLE
feat(UI) Giving the Star a unique color on the Radar

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -105,7 +105,7 @@ color "radar special" 0.5 1. 0.5 0.
 color "radar anomalous" .7 0. 1. 0.
 color "radar blink" 1. 1. 1. 0.
 color "radar viewport" 0. .3 0. 0.
-color "radar star" 0.7 1. 1.
+color "radar star" 0.7 1. 1. 0.
 
 # Colors used for warnings and errors.
 color "error back" .25 .1 .1 1.

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -101,10 +101,11 @@ color "radar friendly" .4 .6 1. 0.
 color "radar unfriendly" .8 .8 .4 0.
 color "radar hostile" .85 .3 .2 0.
 color "radar inactive" .4 .4 .4 0.
-color "radar special" 1. 1. 1. 0.
+color "radar special" 0.5 1. 0.5 0.
 color "radar anomalous" .7 0. 1. 0.
 color "radar blink" 1. 1. 1. 0.
 color "radar viewport" 0. .3 0. 0.
+color "radar star" 0.7 1. 1.
 
 # Colors used for warnings and errors.
 color "error back" .25 .1 .1 1.

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -98,7 +98,7 @@ color "missile dangerous" 1. .1 .1 1.
 # Colors used in the radar map while in-flight.
 color "radar player" .2 1. 0. 0.
 color "radar friendly" .4 .6 1. 0.
-color "radar unfriendly" .8 .8 .4 0.
+color "radar unfriendly" .8 .8 .3 0.
 color "radar hostile" .85 .3 .2 0.
 color "radar inactive" .4 .4 .4 0.
 color "radar special" 1. 1. 1. 0.

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -101,11 +101,11 @@ color "radar friendly" .4 .6 1. 0.
 color "radar unfriendly" .8 .8 .4 0.
 color "radar hostile" .85 .3 .2 0.
 color "radar inactive" .4 .4 .4 0.
-color "radar special" 0.5 1. 0.5 0.
+color "radar special" 1. 1. 1. 0.
 color "radar anomalous" .7 0. 1. 0.
 color "radar blink" 1. 1. 1. 0.
 color "radar viewport" 0. .3 0. 0.
-color "radar star" 0.7 1. 1. 0.
+color "radar star" .6 .6 .6 0.
 
 # Colors used for warnings and errors.
 color "error back" .25 .1 .1 1.

--- a/source/Radar.cpp
+++ b/source/Radar.cpp
@@ -52,6 +52,7 @@ void Radar::SetCenter(const Point &center)
 }
 
 
+
 // Add an object. If "inner" is 0 it is a dot; otherwise, it is a ring. The
 // given position should be in world units (not shrunk to radar units).
 void Radar::Add(int type, Point position, double outer, double inner)

--- a/source/Radar.cpp
+++ b/source/Radar.cpp
@@ -52,9 +52,6 @@ void Radar::SetCenter(const Point &center)
 }
 
 
-// Planets and stars both are circles, so they have "inner" as 0, but I can't
-// tell where it sets that. This may be clue to find where the identity of an object
-// is identified as a star.
 // Add an object. If "inner" is 0 it is a dot; otherwise, it is a ring. The
 // given position should be in world units (not shrunk to radar units).
 void Radar::Add(int type, Point position, double outer, double inner)

--- a/source/Radar.cpp
+++ b/source/Radar.cpp
@@ -33,6 +33,7 @@ const int Radar::SPECIAL = 5;
 const int Radar::ANOMALOUS = 6;
 const int Radar::BLINK = 7;
 const int Radar::VIEWPORT = 8;
+const int Radar::STAR = 9;
 
 
 
@@ -51,7 +52,9 @@ void Radar::SetCenter(const Point &center)
 }
 
 
-
+// Planets and stars both are circles, so they have "inner" as 0, but I can't
+// tell where it sets that. This may be clue to find where the identity of an object
+// is identified as a star.
 // Add an object. If "inner" is 0 it is a dot; otherwise, it is a ring. The
 // given position should be in world units (not shrunk to radar units).
 void Radar::Add(int type, Point position, double outer, double inner)
@@ -144,7 +147,8 @@ const Color &Radar::GetColor(int type)
 		*GameData::Colors().Get("radar special"),
 		*GameData::Colors().Get("radar anomalous"),
 		*GameData::Colors().Get("radar blink"),
-		*GameData::Colors().Get("radar viewport")
+		*GameData::Colors().Get("radar viewport"),
+		*GameData::Colors().Get("radar star")
 	};
 
 	if(static_cast<size_t>(type) >= color.size())

--- a/source/Radar.h
+++ b/source/Radar.h
@@ -37,6 +37,7 @@ public:
 	static const int ANOMALOUS;
 	static const int BLINK;
 	static const int VIEWPORT;
+	static const int STAR;
 
 
 public:

--- a/source/StellarObject.cpp
+++ b/source/StellarObject.cpp
@@ -98,7 +98,7 @@ const string &StellarObject::LandingMessage() const
 int StellarObject::RadarType(const Ship *ship) const
 {
 	if(IsStar())
-		return Radar::SPECIAL;
+		return Radar::STAR;
 	else if(!planet || !planet->IsAccessible(ship))
 		return Radar::INACTIVE;
 	else if(planet->IsWormhole())

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -915,7 +915,7 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 }
 
 
-
+// This looks relevant to setting if an object is a star, but it has no explanation.
 void System::LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing)
 {
 	const string &key = node.Token(0);

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -915,7 +915,6 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 }
 
 
-// This looks relevant to setting if an object is a star, but it has no explanation.
 void System::LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing)
 {
 	const string &key = node.Token(0);

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -915,6 +915,7 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 }
 
 
+
 void System::LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing)
 {
 	const string &key = node.Token(0);


### PR DESCRIPTION
## Feature Details
Fix #7979 

As described in that issue, I have a lot of trouble in differentiating the star(s) from whatever I have selected and the unfriendlies. Only on close inspection is the difference visible.

This PR adds the support to have a unique star color specified in interfaces.txt which is used exclusively for coloring the star on the radar. As this exposes the color in the data files, it can then be manually adjusted if people wish to do so.

I have picked .6 .6 .6 .0 because stars share significant similarities with the inactive planets. We cannot land on stars, and generally don't interact with them at all. However, it is a little brighter to help it stand out from the other inactive planets, and as such allow people to determine where the center of the system is to assist in collecting solar power and fuel. It is also not as bright as it used to be, so it won't blend into the color used by the "Special", which is what our selection indicator uses.

To further clarity and differentiation, I have also applied the change to the unfriendly color, changing it from .8 .8 .4 to .8 .8 .3 It is a very minor change, but it makes it a little less washed out, and thus less likely to get confused with the white for the "special" color (aka selection) or the light grey of the star.

## UI Screenshots

![Radar with new star color grey and hostiles more yellow](https://user-images.githubusercontent.com/32169904/210094105-65182cb2-2c28-4193-af88-159764723334.png)

Note the difference in shades between the inactive, star, unfriendly, and selected target.

## Usage Examples
Within `interfaces.txt` it adds `color "radar star" .6 .6 .6 0.`

## Testing Done
Played the game and looked at the stars. Checked out systems with different sized stars and pairs of stars.

### Automated Tests Added
none

## Performance Impact
N/A
