### PR TITLE
Feat(enhancement): Accept float quality precision for envoiremental effect amount

### DIFF
--- a/source/Hazard.cpp
+++ b/source/Hazard.cpp
@@ -60,7 +60,7 @@ void Hazard::Load(const DataNode &node)
 		}
 		else if(key == "environmental effect")
 		{
-			int count = (child.Size() >= 3) ? child.Value(2) : 1;
+			float count = (child.Size() >= 3) ? child.Value(2) : .1;
 			environmentalEffects[GameData::Effects().Get(child.Token(1))] += count;
 		}
 		else
@@ -142,7 +142,7 @@ double Hazard::MaxRange() const
 
 
 // Visuals to be created while this hazard is active.
-const map<const Effect *, int> &Hazard::EnvironmentalEffects() const
+const map<const Effect *, float> &Hazard::EnvironmentalEffects() const
 {
 	return environmentalEffects;
 }

--- a/source/Hazard.cpp
+++ b/source/Hazard.cpp
@@ -60,7 +60,10 @@ void Hazard::Load(const DataNode &node)
 		}
 		else if(key == "environmental effect")
 		{
-			float count = (child.Size() >= 3) ? child.Value(2) : .1;
+			// Fractional counts may be accepted, since the real count gets multiplied by the strength
+			// of the hazard. The resulting real count will then be rounded down to the nearest int
+			// to determine the number of effects that appear.
+			float count = (child.Size() >= 3) ? child.Value(2) : 1.;
 			environmentalEffects[GameData::Effects().Get(child.Token(1))] += count;
 		}
 		else

--- a/source/Hazard.cpp
+++ b/source/Hazard.cpp
@@ -63,7 +63,7 @@ void Hazard::Load(const DataNode &node)
 			// Fractional counts may be accepted, since the real count gets multiplied by the strength
 			// of the hazard. The resulting real count will then be rounded down to the nearest int
 			// to determine the number of effects that appear.
-			float count = (child.Size() >= 3) ? child.Value(2) : 1.;
+			float count = (child.Size() >= 3) ? static_cast<float>(child.Value(2)) : 1.f;
 			environmentalEffects[GameData::Effects().Get(child.Token(1))] += count;
 		}
 		else

--- a/source/Hazard.h
+++ b/source/Hazard.h
@@ -50,7 +50,7 @@ public:
 	double MaxRange() const;
 
 	// Visuals to be created while this hazard is active.
-	const std::map<const Effect *, int> &EnvironmentalEffects() const;
+	const std::map<const Effect *, float> &EnvironmentalEffects() const;
 
 
 private:
@@ -66,7 +66,7 @@ private:
 	bool systemWide = false;
 	bool deviates = true;
 
-	std::map<const Effect *, int> environmentalEffects;
+	std::map<const Effect *, float> environmentalEffects;
 };
 
 #endif

--- a/source/Weather.cpp
+++ b/source/Weather.cpp
@@ -103,11 +103,11 @@ void Weather::Step(vector<Visual> &visuals, const Point &center)
 	{
 		// Estimate the number of visuals to be generated this frame.
 		// MAYBE: create only a subset of possible effects per frame.
-		int totalAmount = 0;
+		float totalAmount = 0;
 		for(auto &&effect : hazard->EnvironmentalEffects())
 			totalAmount += effect.second;
 		totalAmount *= effectMultiplier;
-		visuals.reserve(visuals.size() + totalAmount);
+		visuals.reserve(visuals.size() + static_cast<int>(totalAmount));
 
 		for(auto &&effect : hazard->EnvironmentalEffects())
 			for(int i = 0; i < effect.second * effectMultiplier; ++i)


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed by me

## Feature Details
For people who like playing with hazards and envoiremental effects, it can be really annoying to not be able to specify lower numbers for the envoiremental effect amount.
This PR modifies this to accept numbers in the float range.

Of course you cannot generate half of an effect, that is why the total number will be rounded.


## Usage Examples
`"environmental effect" "blue nebula fragments" 0.01`

## Testing Done
Tested it with one of my own effects.

## Performance Impact
N/A
