### PR TITLE
Print shipyard or outfitter list with items available in each

### DIFF
--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -42,34 +42,35 @@ namespace {
 	string ObjectName(const Outfit &object) { return object.TrueName(); }
 
 	template <class Type>
-	void PrintObjectSales(const Set<Type> &objects, const Set<Sale<Type>> &sales,
-		const string &name, const string &saleName)
+	void PrintItemSales(const Set<Type> &items, const Set<Sale<Type>> &sales,
+		const string &itemNoun, const string &saleNoun)
 	{
-		cout << name << ',' << saleName << '\n';
+		cout << itemNoun << ',' << saleNoun << '\n';
 		map<string, set<string>> itemSales;
-		for(auto &it : sales)
-			for(auto &it2 : it.second)
-				itemSales[ObjectName(*it2)].insert(it.first);
-		for(auto &it : objects)
+		for(auto &saleIt : sales)
+			for(auto &itemIt : saleIt.second)
+				itemSales[ObjectName(*itemIt)].insert(saleIt.first);
+		for(auto &itemIt : items)
 		{
-			if(it.first != ObjectName(it.second))
+			if(itemIt.first != ObjectName(itemIt.second))
 				continue;
-			cout << it.first;
-			for(auto &it2 : itemSales[it.first])
-				cout << ',' << it2;
+			cout << itemIt.first;
+			for(auto &saleName : itemSales[itemIt.first])
+				cout << ',' << saleName;
 			cout << '\n';
 		}
 	}
 
 	template <class Type>
-	void PrintSales(const Set<Sale<Type>> &sales, const string &saleName, const string &name)
+	void PrintSales(const Set<Sale<Type>> &sales, const string &saleNoun, const string &itemNoun)
 	{
-		cout << saleName << ',' << name << '\n';
-		for(auto &sale : sales)
+		cout << saleNoun << ',' << itemNoun << '\n';
+		for(auto &saleIt : sales)
 		{
-			cout it.first;
-			for(auto &item : sale)
-				cout << ',' << ObjectName(item);
+			cout << saleIt.first;
+			int index = 0;
+			for(auto &item : saleIt.second)
+				cout << (index++ ? ';' : ',') << ObjectName(*item);
 			cout << '\n';
 		}
 	}
@@ -233,7 +234,7 @@ void PrintData::Ships(const char *const *argv)
 	}
 
 	if(sales)
-		PrintObjectSales(GameData::Ships(), GameData::Shipyards(), "ship", "shipyards");
+		PrintItemSales(GameData::Ships(), GameData::Shipyards(), "ship", "shipyards");
 	else if(loaded)
 		PrintLoadedShipStats(variants);
 	else if(list)
@@ -586,7 +587,7 @@ void PrintData::Outfits(const char *const *argv)
 	}
 
 	if(sales)
-		PrintObjectSales(GameData::Outfits(), GameData::Outfitters(), "outfit", "outfitters");
+		PrintItemSales(GameData::Outfits(), GameData::Outfitters(), "outfit", "outfitters");
 	else if(all)
 		PrintOutfitsAllStats();
 	else
@@ -629,9 +630,9 @@ void PrintData::Sales(const char *const *argv)
 	for(const char *const *it = argv + 2; *it; ++it)
 	{
 		string arg = *it;
-		if(arg == "--ships")
+		if(arg == "-s" || arg == "--ships")
 			ships = true;
-		else if(arg == "--outfits")
+		else if(arg == "-o" || arg == "--outfits")
 			outfits = true;
 	}
 

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -64,7 +64,7 @@ namespace {
 	template <class Type>
 	void PrintSales(const Set<Sale<Type>> &sales, const string &saleNoun, const string &itemNoun)
 	{
-		cout << saleNoun << ',' << itemNoun << '\n';
+		cout << saleNoun << ';' << itemNoun << '\n';
 		for(auto &saleIt : sales)
 		{
 			cout << saleIt.first;

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -62,6 +62,19 @@ namespace {
 	}
 
 	template <class Type>
+	void PrintSales(const Set<Sale<Type>> &sales, const string &saleName, const string &name)
+	{
+		cout << saleName << ',' << name << '\n';
+		for(auto &sale : sales)
+		{
+			cout it.first;
+			for(auto &item : sale)
+				cout << ',' << ObjectName(item);
+			cout << '\n';
+		}
+	}
+
+	template <class Type>
 	void PrintObjectList(const Set<Type> &objects, bool withQuotes, const string &name)
 	{
 		cout << name << '\n';
@@ -121,8 +134,8 @@ bool PrintData::IsPrintDataArgument(const char *const *argv)
 		string arg = *it;
 		if(arg == "-s" || arg == "--ships" || arg == "-w" || arg == "--weapons"
 				|| arg == "-o" || arg == "--outfits" || arg == "-e" || arg == "--engines"
-				|| arg == "--power" || arg == "--planets" || arg == "--systems"
-				|| arg == "--matches")
+				|| arg == "--power" || arg == "--sales" || arg == "--planets"
+				|| arg == "--systems" || arg == "--matches")
 			return true;
 	}
 	return false;
@@ -136,7 +149,10 @@ void PrintData::Print(const char *const *argv)
 	{
 		string arg = *it;
 		if(arg == "-s" || arg == "--ships")
+		{
 			Ships(argv);
+			break;
+		}
 		else if(arg == "-w" || arg == "--weapons")
 			PrintWeaponStats();
 		else if(arg == "-e" || arg == "--engines")
@@ -144,7 +160,15 @@ void PrintData::Print(const char *const *argv)
 		else if(arg == "--power")
 			PrintPowerStats();
 		else if(arg == "-o" || arg == "--outfits")
+		{
 			Outfits(argv);
+			break;
+		}
+		else if(arg == "--sales")
+		{
+			Sales(argv);
+			break;
+		}
 		else if(arg == "--planets")
 			Planets(argv);
 		else if(arg == "--systems")
@@ -593,6 +617,33 @@ void PrintData::PrintOutfitsAllStats()
 			cout << ',' << outfit.Attributes().Get(attribute);
 		cout << '\n';
 	}
+}
+
+
+
+void PrintData::Sales(const char *const *argv)
+{
+	bool ships = false;
+	bool outfits = false;
+
+	for(const char *const *it = argv + 2; *it; ++it)
+	{
+		string arg = *it;
+		if(arg == "--ships")
+			ships = true;
+		else if(arg == "--outfits")
+			outfits = true;
+	}
+
+	if(!(ships || outfits))
+	{
+		ships = true;
+		outfits = true;
+	}
+	if(ships)
+		PrintSales(GameData::Shipyards(), "shipyards", "ships");
+	if(outfits)
+		PrintSales(GameData::Outfitters(), "outfitters", "outfits");
 }
 
 

--- a/source/PrintData.h
+++ b/source/PrintData.h
@@ -39,6 +39,8 @@ private:
 	static void Outfits(const char *const *argv);
 	static void PrintOutfitsAllStats();
 
+	static void Sales(const char *const *argv);
+
 	static void Planets(const char *const *argv);
 	static void PrintPlanetDescriptions();
 


### PR DESCRIPTION
**Feature:**

## Feature Details
It seems I previously overlooked the option to print a list of shipyards/outfitters and the items they sell instead of a list of ships/outfits and the sales they appear in.

## UI Screenshots
N/A

## Usage Examples
Prints shipyards and outfitters:
```
EndlessSky.exe --sales
EndlessSky.exe --sales -s -o
EndlessSky.exe --sales --ships -o
EndlessSky.exe --sales -s --outfits
EndlessSky.exe --sales --ships --outfits
```
Prints shipyards only:
```
EndlessSky.exe --sales -s
EndlessSky.exe --sales --ships
```
Prints outfitters only:
```
EndlessSky.exe --sales -o
EndlessSky.exe --sales --outfits
```

The result should look something like:
```
shipyards;ships
<shipyard name>;<ship 1 name>,<ship 2 name>
<shipyard name>
<shipyard name>;<ship 1 name>
```

I've also made some changes to names of a method and various variables within it to better match what they do.

## Testing Done
Used the commands and got the expected data.

### Automated Tests Added
N/A?

## Performance Impact
N/A
