### PR TITLE
fix(content): Prevent Earth Day jobs offering with deadlines after Earth Day

### DIFF
--- a/data/human/near earth jobs.txt
+++ b/data/human/near earth jobs.txt
@@ -52,7 +52,7 @@ mission "To Earth Day celebration [0]"
 				random < 20
 				month == 4
 				day < 22
-		"days until year end" - "hyperjumps to system: Sol" - "hyperjumps to System: Sol" > 253
+		"days until year end" - 2 * "hyperjumps to system: Sol" > 253
 	to fail
 		month * 100 + day >= 422
 	source
@@ -86,7 +86,7 @@ mission "To Earth Day celebration [1]"
 				random < 20
 				month == 4
 				day < 22
-		"days until year end" - "hyperjumps to system: Sol" - "hyperjumps to System: Sol" > 253
+		"days until year end" - 2 * "hyperjumps to system: Sol" > 253
 	to fail
 		month * 100 + day >= 422
 	source

--- a/data/human/near earth jobs.txt
+++ b/data/human/near earth jobs.txt
@@ -52,7 +52,7 @@ mission "To Earth Day celebration [0]"
 				random < 20
 				month == 4
 				day < 22
-		"days until year end" - "hyperjumps to system: Sol" - "hyperjumps to System: Sol" >= 253
+		"days until year end" - "hyperjumps to system: Sol" - "hyperjumps to System: Sol" > 253
 	to fail
 		month * 100 + day >= 422
 	source
@@ -86,7 +86,7 @@ mission "To Earth Day celebration [1]"
 				random < 20
 				month == 4
 				day < 22
-		"days until year end" - "hyperjumps to system: Sol" - "hyperjumps to System: Sol" >= 253
+		"days until year end" - "hyperjumps to system: Sol" - "hyperjumps to System: Sol" > 253
 	to fail
 		month * 100 + day >= 422
 	source

--- a/data/human/near earth jobs.txt
+++ b/data/human/near earth jobs.txt
@@ -53,7 +53,7 @@ mission "To Earth Day celebration [0]"
 				month == 4
 				day < 22
 		"days until year end" - "hyperjumps to system: Sol" - "hyperjumps to System: Sol" >= 253
-+	to fail
+	to fail
 		month * 100 + day >= 422
 	source
 		near "Sol" 1 15

--- a/data/human/near earth jobs.txt
+++ b/data/human/near earth jobs.txt
@@ -38,7 +38,7 @@ mission "To Earth Day celebration [0]"
 	repeat
 	description `Bring <fare> to <destination> by <date> for the Earth Day celebration on April 22nd. Payment is <payment>.`
 	passengers 4 4 .5
-	deadline
+	deadline 0 2
 	to offer
 		or
 			and
@@ -52,7 +52,8 @@ mission "To Earth Day celebration [0]"
 				random < 20
 				month == 4
 				day < 22
-	to fail
+		"days until year end" - "hyperjumps to system: Sol" - "hyperjumps to System: Sol" >= 253
++	to fail
 		month * 100 + day >= 422
 	source
 		near "Sol" 1 15
@@ -71,7 +72,7 @@ mission "To Earth Day celebration [1]"
 	repeat
 	description `Deliver <cargo> to <destination> by <date> in preparation for the Earth Day celebration on April 22nd. Payment is <payment>.`
 	cargo random 5 2 .1
-	deadline
+	deadline 0 2
 	to offer
 		or
 			and
@@ -85,6 +86,7 @@ mission "To Earth Day celebration [1]"
 				random < 20
 				month == 4
 				day < 22
+		"days until year end" - "hyperjumps to system: Sol" - "hyperjumps to System: Sol" >= 253
 	to fail
 		month * 100 + day >= 422
 	source


### PR DESCRIPTION
**Bugfix:**

## Fix Details
It is currently possible for jobs going to Earth for Earth Day celebrations to offer with deadlines after Earth Day (22nd April). These jobs are, however, failed on that date, and so they may offer with deadlines beyond the date on which they will fail.
This is not good.
This PR uses two of the new autoconditions, `days until year end` and `hyperjumps to system: <system name>` to ensure that the job will not offer at a point when the deadline date will be beyond Earth Day.
`days until year end` is used to ensure no need to treat leap years differently (since the `days since year start` value for 22nd April is different on leap years.)
I've also explicitly set the deadlines of the missions to `0 2`. These are the default values that were already in use, but since the offer condition now assumes the deadline will be 2 times the number of hyperjumps to the destination system, I think it should be made explicit that this is the deadline; if it is ever to be changed, the offer condition should also be updated.
The `days until year end` value for 22nd April should be 253, if I've done the arithmetic right.
31 + 28 + 31 + 22 = 112
365 - 112 = 253

## Testing Done
soon:tm:

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}
