### PR TITLE
Assign `wormhole "Pug Wormhole"` to `planet "Pug Wormhole"`

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -35252,6 +35252,7 @@ planet Prime
 		fleet "Large Republic" 17
 
 planet "Pug Wormhole"
+	wormhole "Pug Wormhole"
 
 wormhole "Pug Wormhole"
 	link "Over the Rainbow" Deneb


### PR DESCRIPTION
**Bugfix:**

## Fix Details
A `planet` which is a wormhole should have the relevant `wormhole` object assigned to it.
This does not seem to be done for the Pug Wormhole at the moment.

## Testing Done
soon:tm:

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
As above.
