### PR TITLE
Fix crash when you have no flagship

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -932,7 +932,7 @@ list<ShipEvent> &Engine::Events()
 // Draw a frame.
 void Engine::Draw() const
 {
-	GameData::Background().Draw(center, centerVelocity, zoom, player.Flagship()->GetSystem());
+	GameData::Background().Draw(center, centerVelocity, zoom, (player.Flagship() ? player.Flagship()->GetSystem() : player.GetSystem()));
 	static const Set<Color> &colors = GameData::Colors();
 	const Interface *hud = GameData::Interfaces().Get("hud");
 

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -309,7 +309,6 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 	}
 	else if(key == SDLK_PAGEUP || key == SDLK_PAGEDOWN)
 	{
-
 		int direction = (key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP);
 		Scroll((LINES_PER_PAGE - 2) * direction);
 	}

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -309,6 +309,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 	}
 	else if(key == SDLK_PAGEUP || key == SDLK_PAGEDOWN)
 	{
+
 		int direction = (key == SDLK_PAGEDOWN) - (key == SDLK_PAGEUP);
 		Scroll((LINES_PER_PAGE - 2) * direction);
 	}
@@ -444,7 +445,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 		// Toggle the parked status for all ships in system except the flagship.
 		bool allParked = true;
 		const Ship *flagship = player.Flagship();
-		const System *flagshipSystem = flagship->GetSystem();
+		const System *flagshipSystem = flagship ? flagship->GetSystem() : player.GetSystem();
 		for(const auto &it : panelState.Ships())
 			if(!it->IsDisabled() && it.get() != flagship && it->GetSystem() == flagshipSystem)
 				allParked &= it->IsParked();


### PR DESCRIPTION
**Bugfix:**

Thanks to @1010todd for reporting this on Discord.

## Fix Details
Fixes a crash introduced by https://github.com/endless-sky/endless-sky/commit/95b054f2e5655fcdcaf9cf98893c7876f5384f4e.
Checks that the flagship pointer isn't null before attempting to dereference it.
I suspect there are numerous circumstances where this crash may occur, but the one raised in the original report was of selling the flagship and exiting the shipyard with no ships that can become the flagship.

I also noticed another point where the flagship pointer is dereferenced without checking that it is not null, so added a check to that, though it wasn't responsible for this crash.

## Testing Done
You can see the crash occur if you start a new game and just leave the shipyard before buying a ship.
With this PR, it no longer happens.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
N/A - Just start a new game.
