### PR TITLE
Fix another crash

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -353,12 +353,14 @@ double Government::PenaltyFor(int eventType, const Government *other) const
 
 	const int id = other->id;
 	const auto &penalties = useForeignPenaltiesFor.count(id) ? other->penaltyFor : penaltyFor;
-	if(customPenalties[id].empty())
+
+	const auto it = customPenalties.find(id);
+	if(it == customPenalties.end())
 		return PenaltyHelper(eventType, penalties);
 
 	map<int, double> tempPenalties = penalties;
-	for(const auto &it : customPenalties[id])
-		tempPenalties[it.first] = it.second;
+	for(const auto &penalty : it->second)
+		tempPenalties[penalty.first] = penalty.second;
 	return PenaltyHelper(eventType, tempPenalties);
 }
 

--- a/source/Government.h
+++ b/source/Government.h
@@ -138,7 +138,7 @@ private:
 	ExclusiveItem<Color> color;
 
 	std::vector<double> attitudeToward;
-	std::vector<std::map<int, double>> customPenalties;
+	std::map<unsigned, std::map<int, double>> customPenalties;
 	double initialPlayerReputation = 0.;
 	std::map<int, double> penaltyFor;
 	std::map<const Outfit*, int> illegals;


### PR DESCRIPTION
**Bugfix:**

## Fix Details
https://github.com/endless-sky/endless-sky/commit/b7ebc42c26d20a7f37edafb7d8450ff029e98252 introduced a crash on... well, a lot of things, ~~let's not talk about it.~~

This fixes that issue.

The problem was that `std::vector<>::operator[]` does not insert if the given offset is out of bounds, and its behaviour in this case is undefined.
Instead, use an `std::map` and do `find` to check if the desired element exists before attempting to retrieve data from it.

## Testing Done
Played the game. It doesn't crash anymore!
