### PR TITLE
Fix custom penalties again

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -173,7 +173,7 @@ void Government::Load(const DataNode &node)
 					customPenalties[GameData::Governments().Get(grand.Token(1))->id].clear();
 				else
 				{
-					auto &pens = customPenalties[GameData::Governments().Get(grand.Token(1))->id];
+					auto &pens = customPenalties[GameData::Governments().Get(grand.Token(0))->id];
 					PenaltyHelper(grand, pens);
 				}
 			}


### PR DESCRIPTION
**Bugfix:**

Thanks to @Hurleveur for discovering this in #8016.

## Fix Details
`child.Token(1)` is the wrong token, and may be out of bounds.
`child.Token(0)` is what we actually want.

## Testing Done
Launching the game with this build with the data changes from #8016 actually works, now.
