### PR TITLE
Display profit for the selected commodity as a footer.

### DIFF
--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -169,23 +169,24 @@ void TradingPanel::Draw()
 			canBuy |= isSelected;
 			font.Draw(to_string(price), Point(PRICE_X, y), color);
 
-			int basis = player.GetBasis(commodity.name);
-			if(basis && basis != price && hold)
+			if(isSelected && hold)
 			{
-				string profit = "(profit: " + to_string(price - basis) + ")";
-				font.Draw(profit, Point(LEVEL_X, y), color);
+				int basis = player.GetBasis(commodity.name);
+				if(basis && basis != price)
+				{
+					font.Draw("profit:", Point(NAME_X, lastY), selected);
+					font.Draw(to_string(price - basis), Point(PRICE_X, lastY), selected);
+				}
 			}
+
+			int level = (price - commodity.low);
+			if(level < 0)
+				level = 0;
+			else if(level >= (commodity.high - commodity.low))
+				level = 4;
 			else
-			{
-				int level = (price - commodity.low);
-				if(level < 0)
-					level = 0;
-				else if(level >= (commodity.high - commodity.low))
-					level = 4;
-				else
-					level = (5 * level) / (commodity.high - commodity.low);
-				font.Draw(TRADE_LEVEL[level], Point(LEVEL_X, y), color);
-			}
+				level = (5 * level) / (commodity.high - commodity.low);
+			font.Draw(TRADE_LEVEL[level], Point(LEVEL_X, y), color);
 
 			font.Draw("[buy]", Point(BUY_X, y), color);
 			font.Draw("[sell]", Point(SELL_X, y), color);


### PR DESCRIPTION
## Summary
Trade panel profit is moved to the table footer.

-----------------------
**Feature:** This PR implements the feature request detailed and discussed in issue #8013.

## Feature Details
The profit detail is moved from the commodity line to the footer area, allowing the trade level to be displayed for held commodities. Profit will only be displayed for the selected commodity line.

## UI Screenshots
![8013](https://user-images.githubusercontent.com/102213051/210194175-99e21df5-2e33-4bdd-8fb4-5ac79764e08e.PNG)

## Testing Done
I have bought and sold commodities and observed the profit being displayed correctly, as per the screenshot.

### Automated Tests Added
N/A

## Performance Impact
N/A
