### PR TITLE
Fix: Display Info of starts

### DIFF
--- a/source/StartConditionsPanel.cpp
+++ b/source/StartConditionsPanel.cpp
@@ -306,6 +306,7 @@ void StartConditionsPanel::Select(StartConditionsList::iterator it)
 	}
 
 	// Update the information summary.
+	info.SetCondition("chosen start");
 	if(startIt->GetThumbnail())
 		info.SetSprite("thumbnail", startIt->GetThumbnail());
 	info.SetString("name", startIt->Revealed(GameData::GlobalConditions())


### PR DESCRIPTION
## Fix Details
reverts a change that removed the setting of a necessary interface variable.

## Testing Done
tested, info is showed again

## Save File
create a new pilot and see everything displayed correctly

