### PR TITLE
remove wanderer untranslated hails

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1215,10 +1215,6 @@ government "Wanderer"
 	color .70 .91 .12
 	"player reputation" 1
 	language "Wanderer"
-	"friendly hail" "wanderer untranslated"
-	"friendly disabled hail" "wanderer untranslated"
-	"hostile hail" "wanderer untranslated"
-	"hostile disabled hail" "wanderer untranslated"
 
 # A dummy government used to prevent Hai from entering the wormhole in Waypoint/Ultima Thule, but allowing human merchants and other governments to enter.
 government "Wormhole Alpha"


### PR DESCRIPTION
**Bugfix:** This PR addresses a comment in the discussion of bug #8037 that asks for untranslated hails, implemented in #8038, so that I can have partially-translated hails for korath raids in #8036. @Amazinite said that, "If anything, the bug is that we have untranslated Wanderer hails."

I am of no strong opinion whether the untranslated Wanderer hails should be removed. I'm only submitting a PR for what I was told is a bug.

## Fix Details
Disables untranslated Wanderer hails.

## Testing Done
Made sure the Wanderers still have translated hails

## Save File
Visit the wanderers to see them not talk before you've translated their language:
[Friction Diction~redo.txt](https://github.com/endless-sky/endless-sky/files/10334076/Friction.Diction.redo.txt)

Visit the wanderers to see them talk after you've translated their language:
[Friction Diction~3028-04-18 TRY12 D13 done.txt](https://github.com/endless-sky/endless-sky/files/10334075/Friction.Diction.3028-04-18.TRY12.D13.done.txt)