### PR TITLE
Docs(manual): Add a reference to the player's manual in the credits.

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -1,6 +1,10 @@
 Welcome to Endless Sky!
 version 0.9.17-alpha
 
+The player's manual is available at:
+https://github.com/endless-sky/
+endless-sky/wiki/PlayersManual
+
 This game is open source.
 To report bugs, give feedback,
 or contribute to story writing,

--- a/credits.txt
+++ b/credits.txt
@@ -1,9 +1,9 @@
 Welcome to Endless Sky!
 version 0.9.17-alpha
 
-The player's manual is available at:
-https://github.com/endless-sky/
-endless-sky/wiki/PlayersManual
+The player's manual and other
+resources are available at:
+https://endless-sky.github.io
 
 This game is open source.
 To report bugs, give feedback,


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #7583

## Feature Details
Although PR #7958 is adding Loading Hints to the start up, it would also be useful to point players towards the wiki manual.

## UI Screenshots
![7583](https://user-images.githubusercontent.com/102213051/210314199-8eaed119-4fbb-4762-af5b-8eb5d135d4a8.PNG)

## Testing Done
Starting the game displays the updated credits including the link to the player's manual.

### Automated Tests Added
N/A

## Performance Impact
N/A
