### PR TITLE
Fix missing 'word' in 'friendly navy' phrase.

### DIFF
--- a/data/human/hails.txt
+++ b/data/human/hails.txt
@@ -2782,7 +2782,7 @@ phrase "navy warning adverb"
 phrase "friendly navy"
 	word 
 		"It is "
-		
+	word
 		"illegal"
 		"prohibited"
 		"an illegal act"


### PR DESCRIPTION
## Fix Details
I noticed the following message appear today:

![friendlyNavyBug](https://user-images.githubusercontent.com/102213051/210339783-53ad788a-6036-4003-9d45-38641c645305.PNG)

Looking through the human hail.txt file, it appears there is a missing 'word' in 'friendly navy' phrases.

![friendlyNavyHail](https://user-images.githubusercontent.com/102213051/210339944-cb96b7fb-792b-40f0-95ee-dad6dc4f8f0d.PNG)

## Testing Done
I've corrected this and can see the messages appearing correctly now.

![friendlyNavyFix1](https://user-images.githubusercontent.com/102213051/210340104-88eb4f22-e78c-4f27-8999-318339265ad9.PNG)

![friendlyNavyFix2](https://user-images.githubusercontent.com/102213051/210340119-1efbc83c-6e2c-4225-a63a-2b9d69a7ac73.PNG)
