### PR TITLE
Wanderers: Upgrade Danforth's ship with HR model

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1360,7 +1360,7 @@ mission "Wanderers: Alpha Surveillance F"
 	npc accompany save
 		government "Navy (Oathkeeper)"
 		personality escort heroic
-		ship "Cruiser (Jump)" "N.S. Peacemaker"
+		ship "Cruiser (Jump Plasma Anti-Missile)" "N.S. Peacemaker"
 
 
 


### PR DESCRIPTION
## Summary
Danforth's flagship in the mission to destroy the Alpha base on Host takes no advantage of the new tech developed during the Free Worlds. The ships used in the assault on Elenchus do. It makes sense that Danforth would use the same spec ship for the Alpha mission since he already has them. 

## Save File
[Fred Flintstone.txt](https://github.com/endless-sky/endless-sky/files/10354409/Fred.Flintstone.txt)

## Testing Done
Tested using the attached save file. A scan of Danforth's cruiser shows the catalytic ramscoop and other new outfits.
