### PR TITLE
Add Reverse Modules to Kimek Briar

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -1555,6 +1555,7 @@ ship "Kimek Briar"
 		"Small Shield Module" 2
 		
 		"Large Thrust Module"
+		"Large Reverse Module"
 		"Large Steering Module"
 		"Hyperdrive"
 		
@@ -1580,6 +1581,7 @@ ship "Kimek Briar" "Kimek Briar (Miner)"
 		"Small Shield Module" 2
 		
 		"Large Thrust Module"
+		"Large Reverse Module"
 		"Large Steering Module"
 		"Hyperdrive"
 


### PR DESCRIPTION

**Content Fix (Missing Outfit)**

The Kimek Briar was accidentally left out when Reverse Modules were added to Coalition civilian ships.
This PR just adds one Large Reverse Module to both stock and the Miner variant.

Reported by DoomKorath on the discord, good eye on that.
