### PR TITLE
Specify a toolchain host architecture for the Windows Clang build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -125,6 +125,10 @@
       "displayName": "clang-cl",
       "description": "Builds with clang-cl on Windows",
       "inherits": "base",
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      },
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows",
         "CMAKE_CXX_COMPILER": "clang-cl.exe"

--- a/source/Weather.h
+++ b/source/Weather.h
@@ -8,7 +8,7 @@ Foundation, either version 3 of the License, or (at your option) any later versi
 Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE. See the GNU General Public License for more details.
-f
+
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 */

--- a/source/Weather.h
+++ b/source/Weather.h
@@ -8,7 +8,7 @@ Foundation, either version 3 of the License, or (at your option) any later versi
 Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE. See the GNU General Public License for more details.
-
+f
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 */


### PR DESCRIPTION
This fixes a misconfiguration by VSCode using the clang-cl preset.