### PR TITLE
Re-organizing the Build Instructions

### DIFF
--- a/readme-cmake.md
+++ b/readme-cmake.md
@@ -8,12 +8,54 @@ The game's root directory, where your `git clone`d files reside, will be your st
 
 Next you will need to install a couple of dependencies to build the game.
 
-## Windows
+## Build Environment
 
-Download Visual Studio, and make sure to install the following features: "Desktop Development with C++", "C++ Clang Compiler for Windows", "C++ clang-cl for vXXX build tools", and "C++ CMake tools for Windows".
+There are several different ways to build Endless Sky, depending on your operating system and preference.
+- [Windows](#Windows)
+- [MacOS](#MacOS)
+- [Linux](#Linux)
 
-## Windows (MinGW)
+## Windows (Visual Studio) <Windows>
+We are currently switching to using VS with cmake. If you wish the older MingW build instructions, they are located at the end of the Windows section.
 
+Download Visual Studio, and make sure to install the following features: 
+- "Desktop Development with C++", 
+- "C++ Clang Compiler for Windows", 
+- "C++ clang-cl for vXXX build tools", and 
+- "C++ CMake tools for Windows".
+
+Please note that it is recommened to use VS 2022 (or higher) for its better CMake integration.
+
+### Windows Build Process
+
+1. Open the endless-sky folder that you cloned in the initial step.
+2. Wait while Visual Studio loads everything. This may take a few minutes the first time, but should be relatively fast on subsequent loads.
+3. On your toolbar there should be a pulldown menu that says "debug" or "release." Select the version you want to build.
+4. Hit the "build" button, or find the "Build" menu and select "Build All"
+5. In the status window it will give a scrolling list of actions being completed. Wait until it states "Build Complete"
+6. At this point you should be able to launch the recently completed build by hitting the F5 key or the run button. The recently build executable and essential libraries can be found in your Endless-Sky folder, nested within a subfolder created by Visual Studio during the build process
+
+#### Notes
+
+##### Earlier versions of Visual Studio
+
+If you are on an earlier version of Visual Studio, or would like to use an actual VS solution, you will need to generate the solution manually as follows:
+
+```powershell
+> cmake --preset clang-cl -G"Visual Studio 17 2022"
+```
+
+This will create a Visual Studio 2022 solution. If you are using an older version of VS, you will need to adjust the version. Now you will find a complete solution in the `build/` folder. Find the solution and open it and you're good to go!
+
+#### Using Microsoft Visual C++
+
+Using MSVC to compile Endless Sky is not supported. If you try, you will get a ton of warnings (and maybe even a couple of errors) during compilation.
+
+<details>
+
+<summary>Building on Windows using MinGW</summary>
+
+  
 You can download the [MinGW Winlibs](https://winlibs.com/#download-release) build, which also includes various tools you'll need to build the game as well. It is possible to use other MinGW builds as well.
 
 You'll need the MSVCRT runtime version, 64-bit. The latest version is currently gcc 12 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.4-10.0.0-msvcrt-r2/winlibs-x86_64-posix-seh-gcc-12.1.0-mingw-w64msvcrt-10.0.0-r2.zip)).
@@ -22,7 +64,9 @@ Extract the zip file in a folder whose path doesn't contain a space (C:\ for exa
 
 You will also need to install [CMake](https://cmake.org) (if you don't already have it).
 
-## MacOS
+</details>
+
+## MacOS <MacOS>
 
 Install [Homebrew](https://brew.sh). Once it is installed, use it to install the tools and libraries you will need:
 
@@ -34,7 +78,7 @@ $ brew install cmake ninja mad libpng jpeg-turbo sdl2 openal-soft
 
 If you want to build the libraries from source instead of using Homebrew, you can pass `-DES_USE_SYSTEM_LIBRARIES=OFF` to CMake when configuring.
 
-## Linux
+## Linux <Linux>
 
 It is recommended to use a newish CMake, although CMake 3.16 is the lowest supported. You can get the latest version from the [offical website](https://cmake.org/download/). To follow the instructions written below, you will need at least CMake 3.21.
 
@@ -89,7 +133,7 @@ Replace `<preset>` with one of the following presets:
 - MacOS: `macos` or `macos-arm` (builds with the default compiler), `xcode` or `xcode-arm` (builds using the XCode toolchain)
 - Linux: `linux` (builds with the default compiler)
 
-# Building with an IDE
+# Building with other IDEs
 
 ## Building with Visual Studio Code
 
@@ -107,19 +151,7 @@ If you want to use the Code::Blocks IDE, from the root of the project folder exe
 
 With `<preset>` being one of the available presets (see above for a list). For Windows for example you'd want `mingw`. Now there will be a Code::Blocks project inside `build\mingw`.
 
-## Building with Visual Studio
 
-It is recommened to use VS 2022 (or higher) for its better CMake integration. Simply open the folder and hit build.
-
-If you are on an earlier version, or would like to use an actual VS solution, you will need to generate the solution manually as follows:
-
-```powershell
-> cmake --preset clang-cl -G"Visual Studio 17 2022"
-```
-
-This will create a Visual Studio 2022 solution. If you are using an older version of VS, you will need to adjust the version. Now you will find a complete solution in the `build/` folder. Find the solution and open it and you're good to go!
-
-**Note**: Using MSVC to compile Endless Sky is not supported. If you try, you will get a ton of warnings (and maybe even a couple of errors) during compilation.
 
 ## Building with XCode
 


### PR DESCRIPTION
**Documentation**

## Summary
This is primarily moving the Visual Studio build instructions into the windows section, and clarifying that the MingW build instructions are a separate process. This also adds some additional detail to make it more friendly to first-time users.

## Save File
Not in-game content

## Artwork Checklist
- N/A
