### PR TITLE
Fix vector iterator incompatibility in ShipInfoDisplay

### DIFF
--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -68,7 +68,7 @@ ShipInfoPanel::ShipInfoPanel(PlayerInfo &player, InfoPanelState state)
 	{
 		// Find the player's flagship. It may not be first in the list, if the
 		// first item in the list cannot be a flagship.
-		while(shipIt != player.Ships().end() && shipIt->get() != player.Flagship())
+		while(shipIt != this->panelState.Ships().end() && shipIt->get() != player.Flagship())
 			++shipIt;
 	}
 
@@ -92,7 +92,7 @@ void ShipInfoPanel::Draw()
 	// Fill in the information for how this interface should be drawn.
 	Information interfaceInfo;
 	interfaceInfo.SetCondition("ship tab");
-	if(panelState.CanEdit() && (shipIt != player.Ships().end())
+	if(panelState.CanEdit() && (shipIt != panelState.Ships().end())
 			&& (shipIt->get() != player.Flagship() || (*shipIt)->IsParked()))
 	{
 		if(!(*shipIt)->IsDisabled())
@@ -119,7 +119,7 @@ void ShipInfoPanel::Draw()
 
 	// Draw all the different information sections.
 	ClearZones();
-	if(shipIt == player.Ships().end())
+	if(shipIt == panelState.Ships().end())
 		return;
 	Rectangle cargoBounds = infoPanelUi->GetBox("cargo");
 	DrawShipStats(infoPanelUi->GetBox("stats"));


### PR DESCRIPTION
**Bugfix:**

Thanks to @Terin for reporting this on Discord.

## Fix Details
The iterator is initialised with the `.begin()` position of the `panelState.Ships()` vector, but it is subsequently compared to `player.Ships().end()`. Since this is the past the end iterator of a totally different vector, and so using its past the end iterator while boundary checking `shipIt` is inappropriate.
This also fails a debug assertion in the MSVC compiler.

While `panelState.Ships()` returns a reference to the vector `panelState.ships`, which was initialised with `player.Ships()`, `panelState.ships` is not a reference, but instead copies the `player.Ships()` vector.

## Testing Done
Launch the game, compiled to the Debug target through Visual Studio (using the clang-cl preset) and open the player info panel and then the ship info panel. Without this change, a message box indicating the failure of the debug asseertion should appear. With this PR, you may continue to play the game as normal.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
Any save file with a flagship will do.

