### PR TITLE
Eat any parse errors when discovering integration tests

### DIFF
--- a/tests/integration/IntegrationTests.cmake
+++ b/tests/integration/IntegrationTests.cmake
@@ -4,7 +4,11 @@ set(ES_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/integration/config")
 execute_process(
 	COMMAND "${ES}" --config "${ES_CONFIG}" --tests
 	OUTPUT_VARIABLE INTEGRATION_TESTS
+	ERROR_QUIET
 )
+# Delete the errors.txt file if any. This file is generated if there were
+# parse errors, but we don't care about those.
+file(REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/integration/config/errors.txt")
 
 string(REPLACE "\n" ";" INTEGRATION_TESTS_LIST "${INTEGRATION_TESTS}")
 


### PR DESCRIPTION
## Fix Details

If any errors are emitted when discovering the integration tests, then the build output shows them and it creates the errors.txt file. This PR suppresses both of these, because they aren't useful.

## Testing Done

Added a dummy error, and without this PR the build output is spammed and a errors.txt file is generated.
