### PR TITLE
"pragmatic" personality to work around bug in retreat logic

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -656,7 +656,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 			(!personality.IsHeroic() && !personality.IsStaying()
 			&& healthRemaining < RETREAT_HEALTH + .25 * personality.IsCoward()));
 		if(!it->IsYours() && shouldFlee && (personality.IsPragmatic() ||
-			( target && target->GetGovernment()->IsEnemy(gov) && !target->IsDisabled()
+			(target && target->GetGovernment()->IsEnemy(gov) && !target->IsDisabled()
 			&& (!it->GetParent() || !it->GetParent()->GetGovernment()->IsEnemy(gov)))))
 		{
 			// Make sure the ship has somewhere to flee to.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -647,14 +647,17 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 			continue;
 		}
 
-		// Run away if your hostile target is not disabled and you are badly damaged.
+		// Run away if your hostile target is not disabled and you are badly damaged,
+		// unless the ship is pragmatic enough to realize disabling one more ship
+		// isn't worth dying for.
 		// Player ships never stop targeting hostiles, while hostile mission NPCs will
 		// do so only if they are allowed to leave.
 		const bool shouldFlee = (personality.IsFleeing() ||
 			(!personality.IsHeroic() && !personality.IsStaying()
 			&& healthRemaining < RETREAT_HEALTH + .25 * personality.IsCoward()));
-		if(!it->IsYours() && shouldFlee && target && target->GetGovernment()->IsEnemy(gov) && !target->IsDisabled()
-			&& (!it->GetParent() || !it->GetParent()->GetGovernment()->IsEnemy(gov)))
+		if(!it->IsYours() && shouldFlee && (personality.IsPragmatic() ||
+			( target && target->GetGovernment()->IsEnemy(gov) && !target->IsDisabled()
+			&& (!it->GetParent() || !it->GetParent()->GetGovernment()->IsEnemy(gov)))))
 		{
 			// Make sure the ship has somewhere to flee to.
 			const System *system = it->GetSystem();

--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -53,6 +53,7 @@ namespace {
 	const int TARGET = (1 << 26);
 	const int MARKED = (1 << 27);
 	const int LAUNCHING = (1 << 28);
+	const int PRAGMATIC = (1 << 29);
 
 	const map<string, int> TOKEN = {
 		{"pacifist", PACIFIST},
@@ -83,7 +84,8 @@ namespace {
 		{"merciful", MERCIFUL},
 		{"target", TARGET},
 		{"marked", MARKED},
-		{"launching", LAUNCHING}
+		{"launching", LAUNCHING},
+		{"pragmatic", PRAGMATIC}
 	};
 
 	const double DEFAULT_CONFUSION = 10.;
@@ -246,6 +248,13 @@ bool Personality::IsOpportunistic() const
 bool Personality::IsMerciful() const
 {
 	return flags & MERCIFUL;
+}
+
+
+
+bool Personality::IsPragmatic() const
+{
+	return flags & PRAGMATIC;
 }
 
 

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -54,6 +54,7 @@ public:
 	bool IsAppeasing() const;
 	bool IsOpportunistic() const;
 	bool IsMerciful() const;
+	bool IsPragmatic() const;
 
 	// Mission NPC states:
 	bool IsStaying() const;


### PR DESCRIPTION
**Feature:** Adds a *pragmatic* ship personality that works around a major bug in the ship retreat logic.

*Edit: My previous reasoning was backwards, but the consequence is still the same.*

## Feature Details

Here's the bug: when a non-escort ship is severely damaged and wants to retreat, it won't retreat if it has disabled its current target. That means:

1. Several ships are shooting at me, but I've disabled my hostile target.
2. I don't flee because my hostile target is disabled.
3. Now that my target is disabled, I pillage it or select a new target.
4. Other ships are still shooting at me, so I die.

You know all those pirates and Korath who are willing to give their lives just to finish a fight? This bug is the reason.

~~Long-term, the fix is to remove the section of code responsible for this. However, that would require retuning *the entire game*. Instead, I'm adding a personality as a workaround, which will let us remove the bug piece-by-piece.~~

*Edit: The consensus seems to be that, if I am right about this bug, then it should be fixed instead of worked around. However, there is no consensus yet on whether I'm right. I'd like to reach a consensus on the bug vs. no question before opening another PR.*

## UI Screenshots
N/A

## Usage Examples
Korath ships will escape from fights when being swarmed by pirates and Syndicate, instead of volunteering themselves as shooting practice and a source of high-tech outfits.

## Testing Done
Turned on "pragmatic" for Korath Raid, Korath Mining, and Korath Large Raid fleets, and was amazed by the difference.

### Automated Tests Added
N/A

## Performance Impact
negligible
