### PR TITLE
fix(code): Adding the "install" folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin/
 lib/
 x64/
 Debug/
+install/
 Release/
 *.layout
 *.depend


### PR DESCRIPTION
**Bugfix:** This PR addresses issue discovered during testing that Git will attempt to track all the files created by Visual Studio as part of an install test.

## Fix Details
Github currently tracks the `install` folder created by Visual Studio during the build process, potentially considering the creation of an internal complete build as something it needs to track to upload to the repository.

This adds the `install` folder to the list of ignored locations so that Git does not try to capture changes therein.

## Testing Done
N/A

## Save File
N/A