### PR TITLE
fix(content): Make Void Sprite Parts non-installable

### DIFF
--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -884,6 +884,7 @@ outfit "Void Sprite Parts"
 	"mass" 1
 	"outfit space" -1
 	"flotsam chance" .5
+	"installable" -1
 	description "This is nothing more and nothing less than a cubic meter of void sprite parts. To the Remnant, this represents both a terrible occurrence and a dreadful opportunity."
 	description "	This could have been very valuable to someone who knew what they were doing, if it had been handled properly. Instead, it is worth little more than the value of the compounds contained within."
 


### PR DESCRIPTION
## Fix Details
Added `"installable" -1` to Void Sprite Parts definition, so they cannot be installed in an outfitter.

## Testing done
 - The player is not able to install Void Sprite Parts on their ship.
 - Void Sprites still have their parts installed.