### PR TITLE
Fix nullpointer dereference, you guessed it, with no flagship!

### DIFF
--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -510,14 +510,14 @@ const Wormhole *Planet::GetWormhole() const
 // land on this planet.
 bool Planet::IsAccessible(const Ship *ship) const
 {
-	if(!ship)
-		return false;
 	// If this is a wormhole that leads to an inaccessible system, no ship can land here.
-	if(wormhole && ship->GetSystem() && wormhole->WormholeDestination(*ship->GetSystem()).Inaccessible())
+	if(wormhole && ship && ship->GetSystem() && wormhole->WormholeDestination(*ship->GetSystem()).Inaccessible())
 		return false;
 	// If there are no required attributes, then any ship may land here.
 	if(IsUnrestricted())
 		return true;
+	if(!ship)
+		return false;
 
 	const auto &shipAttributes = ship->Attributes();
 	return all_of(requiredAttributes.cbegin(), requiredAttributes.cend(),

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -510,14 +510,14 @@ const Wormhole *Planet::GetWormhole() const
 // land on this planet.
 bool Planet::IsAccessible(const Ship *ship) const
 {
+	if(!ship)
+		return false;
 	// If this is a wormhole that leads to an inaccessible system, no ship can land here.
 	if(wormhole && ship->GetSystem() && wormhole->WormholeDestination(*ship->GetSystem()).Inaccessible())
 		return false;
 	// If there are no required attributes, then any ship may land here.
 	if(IsUnrestricted())
 		return true;
-	if(!ship)
-		return false;
 
 	const auto &shipAttributes = ship->Attributes();
 	return all_of(requiredAttributes.cbegin(), requiredAttributes.cend(),


### PR DESCRIPTION
**Bugfix:**

Thanks to @Saugia for reporting and helping debug this on Discord.

## Fix Details
Check if the ship pointer is null *before* dereferencing it.

## Testing Done
The game doesn't crash anymore!

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
Go get your ship destroyed in a system with a wormhole, that'll probably cause it to crash.


