### PR TITLE
build(cmake): Fix CMake build on path with whitespace

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,14 +70,14 @@ set_tests_properties(benchmark PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOU
 # Integration tests.
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/IntegrationTests_tests.cmake"
 	COMMENT "Discover every integration test"
-	COMMAND "${CMAKE_COMMAND}" -DES="$<TARGET_FILE:EndlessSky>"
-		-DBINARY_PATH="${CMAKE_CURRENT_BINARY_DIR}"
-		-DRESOURCE_PATH="${CMAKE_SOURCE_DIR}"
+	COMMAND "${CMAKE_COMMAND}" -DES=$<TARGET_FILE:EndlessSky>
+		-DBINARY_PATH=${CMAKE_CURRENT_BINARY_DIR}
+		-DRESOURCE_PATH=${CMAKE_SOURCE_DIR}
 		-DES_USE_OFFSCREEN=${ES_USE_OFFSCREEN}
 		-P "${CMAKE_CURRENT_SOURCE_DIR}/integration/IntegrationTests.cmake"
 	DEPENDS EndlessSky ${INTEGRATION_TESTS}
 		"${CMAKE_CURRENT_SOURCE_DIR}/integration/IntegrationTests.cmake"
-	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" VERBATIM)
 set_property(DIRECTORY APPEND PROPERTY TEST_INCLUDE_FILES "${CMAKE_CURRENT_BINARY_DIR}/IntegrationTests_tests.cmake")
 add_custom_target(IntegrationTests ALL
 	DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/IntegrationTests_tests.cmake"

--- a/tests/integration/IntegrationTests.cmake
+++ b/tests/integration/IntegrationTests.cmake
@@ -2,7 +2,7 @@ set(ES_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/integration/config")
 
 # Get all the tests to run.
 execute_process(
-	COMMAND "${ES}" --config "${ES_CONFIG}" --tests
+	COMMAND ${ES} --config "${ES_CONFIG}" --tests
 	OUTPUT_VARIABLE INTEGRATION_TESTS
 	ERROR_QUIET
 )


### PR DESCRIPTION
This fixes the CMake build if the current path contains whitespace.

## Testing Done

Cloned the repo in a path containing a whitespace and verified that everything works.