### PR TITLE
Content(hazard): Add a weak hazard to neutron stars

### DIFF
--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -100,3 +100,13 @@ hazard "Small Black Hole Gravity"
 		"damage dropoff" 120 1700
 		"dropoff modifier" 0
 
+
+
+hazard "Neutron Star Magnetic Field"
+	"constant strength"
+	"range" 450
+	weapon
+		"target effect" "spark"
+		"damage dropoff" 0 450
+		"dropoff modifier" 0
+		"shield damage" 2

--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -109,4 +109,4 @@ hazard "Neutron Star Magnetic Field"
 		"target effect" "spark"
 		"damage dropoff" 0 450
 		"dropoff modifier" 0
-		"shield damage" 2
+		"shield damage" 6

--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -106,7 +106,6 @@ hazard "Neutron Star Magnetic Field"
 	"constant strength"
 	"range" 450
 	weapon
-		"target effect" "spark"
 		"damage dropoff" 0 450
 		"dropoff modifier" 0
 		"shield damage" 6

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -16635,6 +16635,7 @@ system Kanguwa
 	asteroids "large rock" 17 1.8
 	asteroids "medium metal" 52 2.6
 	asteroids "large metal" 40 2.7
+	hazard "Neutron Star Magnetic Field" 1
 	object
 		sprite star/neutron
 		period 10


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Neutron stars currently look impressive, but that's it. This seems strange when you take in account that they are some of the most dense objects in the universe with incredible strong magnetic fields. That's why I added a weak hazard to them, that attacks shields.

The only neutron star right now is in the rulei system and therefore saugia said their ship should be able to nullify the effects of the hazard. Right now the rulei have no shield generation, so it was impossible for me to adapt the damage to their generation.
But they will probably get shield generation soon and I think the current value should be in an ok area?

If not we can always change it later.



