### PR TITLE
Significant Slash to New Tortuga's Tribute Amount 

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -2725,7 +2725,7 @@ planet "New Tortuga"
 	"required reputation" -10
 	bribe 0.03
 	security 0
-	tribute 1000
+	tribute 1400
 		threshold 5000
 		fleet "Large Core Pirates" 10
 		fleet "Small Core Pirates" 15

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -2725,7 +2725,7 @@ planet "New Tortuga"
 	"required reputation" -10
 	bribe 0.03
 	security 0
-	tribute 6000
+	tribute 1000
 		threshold 5000
 		fleet "Large Core Pirates" 10
 		fleet "Small Core Pirates" 15


### PR DESCRIPTION
## Summary
I slashed New Tortuga's tribute amount down to a sixth of it's original amount due to how obnoxiously high it was. I'm open to changing the amount if it seems too low, but I'd like to keep it down below greenrock's amount of 1800 credits. Thanks to @Arachi-Lover for pointing this out on discord.

## Testing Done
I tested multiple different planets to gauge their tribute with my fleet of various assorted warships. I found that with New Tortuga zero got killed, with Greenrock one got killed, and with Rust, surprisingly, two got killed. Due to how strong rust is I bumped it all the way down to 1000 credits. I'd say that it needs to be below Greenrock's tribute amount for sure, but I'm definitely open to changing the value if it feels too low.
