### PR TITLE
feat(content): Nerf rate of Gefu & Grey's person ships

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -1481,7 +1481,7 @@ ship "Modified Boxwing"
 
 person "Gefullte Taubenbrust"
 	government "Author"
-	frequency 1000
+	frequency 200
 	personality
 		heroic plunders opportunistic
 	phrase
@@ -1704,7 +1704,7 @@ effect "fusion cannon cloud"
 
 person "MasterOfGrey"
 	government "Author"
-	frequency 1000
+	frequency 200
 	personality
 		heroic plunders opportunistic
 	system


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
I made the mistake of using Zitchas's person ship frequency for both Gefu's and Grey's ships, which is at 1000, compared to all other person ship rates, which are at around 200-300 (for some reason I thought a larger number meant less frequent, like fleets in the map file). Now you won't see those two more than the others! (Sorry Grey and Gef, you had your time in the spotlight.)

## Save File
N/A