### PR TITLE
Refactor LocationFilter emptiness check

### DIFF
--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -173,6 +173,10 @@ void LocationFilter::Load(const DataNode &node)
 		else
 			LoadChild(child);
 	}
+
+	isEmpty = planets.empty() && attributes.empty() && systems.empty() && governments.empty()
+		&& !center && originMaxDistance < 0 && notFilters.empty() && neighborFilters.empty()
+		&& outfits.empty() && shipCategory.empty();
 }
 
 
@@ -262,9 +266,7 @@ void LocationFilter::Save(DataWriter &out) const
 // Check if this filter contains any specifications.
 bool LocationFilter::IsEmpty() const
 {
-	return planets.empty() && attributes.empty() && systems.empty() && governments.empty()
-		&& !center && originMaxDistance < 0 && notFilters.empty() && neighborFilters.empty()
-		&& outfits.empty() && shipCategory.empty();
+	return isEmpty;
 }
 
 

--- a/source/LocationFilter.h
+++ b/source/LocationFilter.h
@@ -76,6 +76,8 @@ private:
 
 
 private:
+	bool isEmpty = true;
+
 	// The planet must satisfy these conditions:
 	std::set<const Planet *> planets;
 	// It must have at least one attribute from each set in this list:


### PR DESCRIPTION
**Refactor**

## Refactor Details
`LocationFilter::IsEmpty()` checks if a bunch of `std::set`s and `std::list`s are empty, does some integer comparisons, and checks some pointers for nullness. These checks are not individually particularly expensive, but this method does several of them, and doesn't really need to.
Every public method of LocationFilter is const qualified, except the constructors and `Load()`, so this just checks if the LocationFilter is empty at the end of `Load()` and stores that in a bool, the value of which is returned by `LocationFilter::IsEmpty()`, making that method truly trivial.

## Testing Done
~~I'm sure it works fine. What's the worst that can happen?~~

## Performance Impact
Should be a small improvement to `LocationFilter::IsEmpty()`.
