### PR TITLE
Hai Reveal: Fix Spruiking conversation

### DIFF
--- a/data/hai/hai reveal 3 early.txt
+++ b/data/hai/hai reveal 3 early.txt
@@ -331,9 +331,9 @@ mission "Hai Building Mountaintop [2a] Sales Job"
 		not planet "Mountaintop"
 		not planet "Darkwaste"
 		government "Hai"
-		not "hai dog and pony final stop"
 	to offer
 		has "Hai Building Mountaintop [2] Recruits: active"
+		not "hai dog and pony final stop"
 	on offer
 		"hai dog and pony" ++
 		conversation

--- a/data/hai/hai reveal 3 early.txt
+++ b/data/hai/hai reveal 3 early.txt
@@ -241,6 +241,9 @@ event "role-play station after construction"
 
 
 
+event "hai dog and pony done"
+
+
 mission "Hai Building Mountaintop [2] Recruits"
 	name "Encourage recruits for Mountaintop"
 	description "Now that the station is going ahead, the Hai need to recruit people to be actors in this movie production. Someone needs to sell it to them, and apparently that someone is you."
@@ -308,7 +311,7 @@ mission "Hai Building Mountaintop [2] Recruits"
 			`	Terry's answering grin is best described as "predatory".`
 				accept
 	on stopover
-		"hai dog and pony done" ++
+		event "hai dog and pony done" 1
 		conversation
 			`You have finally visited every world in Hai space and sold the pitch to the people. With any luck, enough will sign up to make it work. Terry indicates that you may now take her to Mountaintop without further stops, but then adds, "I do have some leftover materials though, so I'll get you to do some final spruiking if you stop anywhere else along the way."`
 	on complete
@@ -317,7 +320,7 @@ mission "Hai Building Mountaintop [2] Recruits"
 		dialog `You finally dock at <planet>, your tedious tour complete. Shortly after, you receive a ping informing you that <payment> has been deposited into your account. Terry must've set it up to happen automatically.`
 
 
-mission "ZZ Hai Building Mountaintop [2a] Sales Job"
+mission "Hai Building Mountaintop [2a] Sales Job"
 	landing
 	invisible
 	source
@@ -331,7 +334,7 @@ mission "ZZ Hai Building Mountaintop [2a] Sales Job"
 		"hai dog and pony" ++
 		conversation
 			branch overdone
-				"hai dog and pony done" >= 1
+				has "event: hai dog and pony done"
 			branch toomany
 				"hai dog and pony" >= 17
 			branch interminable

--- a/data/hai/hai reveal 3 early.txt
+++ b/data/hai/hai reveal 3 early.txt
@@ -242,6 +242,7 @@ event "role-play station after construction"
 
 
 event "hai dog and pony done"
+	clear "hai dog and pony final stop"
 
 
 mission "Hai Building Mountaintop [2] Recruits"
@@ -311,8 +312,9 @@ mission "Hai Building Mountaintop [2] Recruits"
 			`	Terry's answering grin is best described as "predatory".`
 				accept
 	on stopover
-		event "hai dog and pony done" 1
+		set "hai dog and pony final stop"
 		"hai dog and pony" ++
+		event "hai dog and pony done" 1
 		conversation
 			`You have finally visited every world in Hai space and sold the pitch to the people. With any luck, enough will sign up to make it work. Terry indicates that you may now take her to Mountaintop without further stops, but then adds, "I do have some leftover materials though, so I'll get you to do some final spruiking if you stop anywhere else along the way."`
 	on complete
@@ -329,7 +331,7 @@ mission "Hai Building Mountaintop [2a] Sales Job"
 		not planet "Mountaintop"
 		not planet "Darkwaste"
 		government "Hai"
-		"hai dog and pony" != 16
+		not "hai dog and pony final stop"
 	to offer
 		has "Hai Building Mountaintop [2] Recruits: active"
 	on offer

--- a/data/hai/hai reveal 3 early.txt
+++ b/data/hai/hai reveal 3 early.txt
@@ -312,6 +312,7 @@ mission "Hai Building Mountaintop [2] Recruits"
 				accept
 	on stopover
 		event "hai dog and pony done" 1
+		"hai dog and pony" ++
 		conversation
 			`You have finally visited every world in Hai space and sold the pitch to the people. With any luck, enough will sign up to make it work. Terry indicates that you may now take her to Mountaintop without further stops, but then adds, "I do have some leftover materials though, so I'll get you to do some final spruiking if you stop anywhere else along the way."`
 	on complete
@@ -328,6 +329,7 @@ mission "Hai Building Mountaintop [2a] Sales Job"
 		not planet "Mountaintop"
 		not planet "Darkwaste"
 		government "Hai"
+		"hai dog and pony" != 16
 	to offer
 		has "Hai Building Mountaintop [2] Recruits: active"
 	on offer

--- a/data/hai/hai reveal 3 early.txt
+++ b/data/hai/hai reveal 3 early.txt
@@ -323,7 +323,7 @@ mission "Hai Building Mountaintop [2] Recruits"
 		dialog `You finally dock at <planet>, your tedious tour complete. Shortly after, you receive a ping informing you that <payment> has been deposited into your account. Terry must've set it up to happen automatically.`
 
 
-mission "Hai Building Mountaintop [2a] Sales Job"
+mission "ZZ Hai Building Mountaintop [2a] Sales Job"
 	landing
 	invisible
 	source


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8115

## Fix Details
Does a few things:
- Fixes the reported bug where the "overdone" text is presented on the final world.
- Also, prevents that secondary helper mission from presenting at all on the final step; it's weird to have that conversation after the `on stopover` conversation of the main mission.
- Removes the `ZZ` from the beginning of hte helper mission, it seems to just be an invitation for someone else to make a mission with a name beginning `ZZZ` which is just a bit silly.

## Testing Done
Complete the final leg of the mission with the updated mission and don't get the secondary conversation inappropriately.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.

From the report:
[Zara Viscari~original.txt](https://github.com/endless-sky/endless-sky/files/10462259/Zara.Viscari.original.txt)

I've modified the instantiated mission to match the version in this PR so you don't have to start the whole mission again, because that'd be a chore:
[Zara Viscari~updated.txt](https://github.com/endless-sky/endless-sky/files/10462264/Zara.Viscari.updated.txt)

