### PR TITLE
Fix Deep: TMBR 0 persisting after TMBR 1 is offered

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -720,6 +720,8 @@ mission "Deep: TMBR 0"
 			`	The group looks visibly disappointed. A few minutes of talking later, they inform you that they must depart for Midgard and say their farewells.`
 				decline
 	to complete
+		never
+	to fail
 		has "Deep: TMBR 1: offered"
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7969

## Fix Details
This fix was designed by @Amacita, ~~so blame him if it doesn't work.~~

`Deep: TMBR 0` will now fail when `Deep: TMBR 1` is offered instead of completing when you land at the destination after being offered the next mission.
`Deep: TMBR 0` will still appear in the mission list for a day or two after collecting `Deep: TMBR 1` (or, until a reload, whichever is first), I don't think it's possible to do any better than that currently.

## Save File
[TMBR tester~Valhalla-before-receiving-TMBR-0.txt](https://github.com/endless-sky/endless-sky/files/10521108/TMBR.tester.3013-12-06.txt)
[TMBR tester~Allhome-with-TMBR-0-acitve.txt](https://github.com/endless-sky/endless-sky/files/10521111/TMBR.tester.3013-12-24.txt)

## Testing Done
~~I didn't test this yet.~~
Using the attached save file(s), receive TMBR 1 and have TMBR 0 disappear from the list shortly after.

