### PR TITLE
test(integration): Print relevant conditions on test failure instead of only test conditions

### DIFF
--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -443,6 +443,23 @@ void ConditionSet::Apply(ConditionsStore &conditions) const
 
 
 
+// Get the names of the conditions that are relevant for this ConditionSet.
+set<string> ConditionSet::RelevantConditions() const
+{
+	set<std::string> result;
+	// Add the names from the expressions.
+	// TODO: also sub-expressions?
+	for(const auto &expr : expressions)
+		result.emplace(expr.Name());
+	// Add the names from the children.
+	for(const auto &child : children)
+		for(const auto &rc : child.RelevantConditions())
+			result.emplace(rc);
+	return result;
+}
+
+
+
 // Check if this set is satisfied by either the created, temporary conditions, or the given conditions.
 bool ConditionSet::TestSet(const ConditionsStore &conditions, const ConditionsStore &created) const
 {

--- a/source/ConditionSet.h
+++ b/source/ConditionSet.h
@@ -17,6 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #define CONDITION_SET_H_
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -61,6 +62,9 @@ public:
 	// (Order of operations is like the order of specification: all sibling
 	// expressions are applied, then any and/or nodes are applied.)
 	void Apply(ConditionsStore &conditions) const;
+
+	// Get the names of the conditions that are modified by this ConditionSet.
+	std::set<std::string> RelevantConditions() const;
 
 
 private:

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -552,7 +552,7 @@ std::set<std::string> Test::RelevantConditions() const
 			case TestStep::Type::CALL:
 				{
 					auto calledTest = GameData::Tests().Find(step.nameOrLabel);
-					if(nullptr == calledTest)
+					if(!calledTest)
 						continue;
 
 					for(const auto &name : calledTest->RelevantConditions())

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -534,7 +534,7 @@ const string &Test::StatusText() const
 
 
 // Get the names of the conditions relevant for this test.
-const std::set<std::string> Test::RelevantConditions() const
+std::set<std::string> Test::RelevantConditions() const
 {
 	set<string> conditionNames;
 	for(const auto &step : steps)

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -31,6 +31,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <map>
 #include <numeric>
+#include <set>
 #include <stdexcept>
 
 using namespace std;
@@ -532,6 +533,41 @@ const string &Test::StatusText() const
 
 
 
+// Get the names of the conditions relevant for this test.
+const std::set<std::string> Test::RelevantConditions() const
+{
+	set<string> conditionNames;
+	for(const auto &step : steps)
+	{
+		switch(step.stepType)
+		{
+			case TestStep::Type::APPLY:
+			case TestStep::Type::ASSERT:
+			case TestStep::Type::BRANCH:
+				{
+					for(const auto &name : step.conditions.RelevantConditions())
+						conditionNames.emplace(name);
+				}
+				break;
+			case TestStep::Type::CALL:
+				{
+					auto calledTest = GameData::Tests().Find(step.nameOrLabel);
+					if(nullptr == calledTest)
+						continue;
+
+					for(const auto &name : calledTest->RelevantConditions())
+						conditionNames.emplace(name);
+				}
+				break;
+			default:
+				continue;
+		}
+	}
+	return conditionNames;
+}
+
+
+
 // Fail the test using the given message as reason.
 void Test::Fail(const TestContext &context, const PlayerInfo &player, const string &testFailReason) const
 {
@@ -580,13 +616,13 @@ void Test::Fail(const TestContext &context, const PlayerInfo &player, const stri
 		Logger::LogError(shipsOverview);
 	}
 
-	// Only log the conditions that start with test; we don't want to overload the terminal or errorlog.
-	// Future versions of the test-framework could also print all conditions that are used in the test.
+	// Print all conditions that are used in the test.
 	string conditions = "";
-	const string TEST_PREFIX = "test: ";
-	auto it = player.Conditions().PrimariesLowerBound(TEST_PREFIX);
-	for( ; it != player.Conditions().PrimariesEnd() && !it->first.compare(0, TEST_PREFIX.length(), TEST_PREFIX); ++it)
-		conditions += "Condition: \"" + it->first + "\" = " + to_string(it->second) + "\n";
+	for(const auto &it : RelevantConditions())
+	{
+		const auto &val = player.Conditions().HasGet(it);
+		conditions += "Condition: \"" + it + "\" = " + (val.first ? to_string(val.second) : "(not set)") + "\n";
+	}
 
 	if(!conditions.empty())
 		Logger::LogError(conditions);

--- a/source/Test.h
+++ b/source/Test.h
@@ -118,6 +118,7 @@ public:
 	const std::string &Name() const;
 	Status GetStatus() const;
 	const std::string &StatusText() const;
+	const std::set<std::string> RelevantConditions() const;
 
 	// Check the game status and perform the next test action.
 	void Step(TestContext &context, PlayerInfo &player, Command &commandToGive) const;

--- a/source/Test.h
+++ b/source/Test.h
@@ -118,7 +118,7 @@ public:
 	const std::string &Name() const;
 	Status GetStatus() const;
 	const std::string &StatusText() const;
-	const std::set<std::string> RelevantConditions() const;
+	std::set<std::string> RelevantConditions() const;
 
 	// Check the game status and perform the next test action.
 	void Step(TestContext &context, PlayerInfo &player, Command &commandToGive) const;


### PR DESCRIPTION
**Feature:** This PR implements a feature of the integration testing framework #4308

## Feature Details
The integration testing framework will now print all relevant conditions for a failing test, instead of only printing the conditions explicitly marked for testing.

This feature should reduce some overhead of defining variables twice when creating new testcases.

## UI Screenshots
(Mockups)
Before:
```
Condition: "test: loopControl" = (not set)
```

After:
```
Condition: "test: loopControl" = (not set)
Condition: "variable I really want to see" = 7
```

## Usage Examples
N/A, just run the tests as usual.

## Testing Done
Tested by printing all conditions in the test-listing from main.
Tested by making one of the tests fail, and verifying that the conditions were printed.

### Automated Tests Added
This is part of the automated testing suite.

## Performance Impact
None expected, should only be active when tests fail.
