### PR TITLE
test(cleanup): Remove obsolete "test:" variables

### DIFF
--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_common.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_common.txt
@@ -639,10 +639,8 @@ test "Start Game"
 		# but to be sure:
 		# save these in temporary conditions to know what they are if it fails, for easier debugging
 		apply
-			"test: name: a b" = "name: a b"
 			"test: Intro [0]: offered" = "Intro [0]: offered"
 			"test: Intro [0]: declined" = "Intro [0]: declined"
-			"test: total ships" = "total ships"
 			"test: ship model: Shuttle" = "ship model: Shuttle"
 			"test: ship model: Sparrow" = "ship model: Sparrow"
 			"test: ship model: Star Barge" = "ship model: Star Barge"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
@@ -232,18 +232,6 @@ test "Enter Name in Conversation"
 			key "Return"
 		call "Depart"
 		call "Test Conditions"
-		# use test-data temporary variables for debugging in case of errors
-		apply
-			"test: %TEST%: NAME IN CONVERSATION: offered" = "%TEST%: NAME IN CONVERSATION: offered"
-			"test: name: Bobbi Bughunter" = "name: Bobbi Bughunter"
-			"test: name: a b" = "name: a b"
-			"test: name: a B" = "name: a B"
-			"test: name: A b" = "name: A b"
-			"test: name: A B" = "name: A B"
-			"test: name: b a" = "name: b a"
-			"test: name: B a" = "name: B a"
-			"test: name: b A" = "name: b A"
-			"test: name: B A" = "name: B A"
 		assert
 			"%TEST%: NAME IN CONVERSATION: offered" == 1
 			"name: a b" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -116,50 +116,6 @@ test "Flagship Attribute Autoconditions"
 	sequence
 		inject "Flagship Attribute Autoconditions Testing"
 		call "Load First Savegame"
-		apply
-			"test: base: cost" = "flagship base attribute: cost"
-			"test: base: mass" = "flagship base attribute: mass"
-			"test: base: bunks" = "flagship base attribute: bunks"
-			"test: base: cargo space" = "flagship base attribute: cargo space"
-			"test: base: cloak" = "flagship base attribute: cloak"
-			"test: base: cloaking energy" = "flagship base attribute: cloaking energy"
-			"test: base: cloaking fuel" = "flagship base attribute: cloaking fuel"
-			"test: base: drag" = "flagship base attribute: drag"
-			"test: base: engine capacity" = "flagship base attribute: engine capacity"
-			"test: base: fuel capacity" = "flagship base attribute: fuel capacity"
-			"test: base: gaslining" = "flagship base attribute: gaslining"
-			"test: base: gun ports" = "flagship base attribute: gun ports"
-			"test: base: heat dissipation" = "flagship base attribute: heat dissipation"
-			"test: base: hull" = "flagship base attribute: hull"
-			"test: base: hull energy" = "flagship base attribute: hull energy"
-			"test: base: hull repair rate" = "flagship base attribute: hull repair rate"
-			"test: base: ion protection" = "flagship base attribute: ion protection"
-			"test: base: scrambling protection" = "flagship base attribute: scrambling protection"
-			"test: base: outfit scan power" = "flagship base attribute: outfit scan power"
-			"test: base: outfit scan speed" = "flagship base attribute: outfit scan speed"
-			"test: base: outfit space" = "flagship base attribute: outfit space"
-			"test: base: ramscoop" = "flagship base attribute: ramscoop"
-			"test: base: remnant node" = "flagship base attribute: remnant node"
-			"test: base: required crew" = "flagship base attribute: required crew"
-			"test: base: shield energy" = "flagship base attribute: shield energy"
-			"test: base: shield generation" = "flagship base attribute: shield generation"
-			"test: base: shields" = "flagship base attribute: shields"
-			"test: base: slowing protection" = "flagship base attribute: slowing protection"
-			"test: base: tactical scan power" = "flagship base attribute: tactical scan power"
-			"test: base: turret mounts" = "flagship base attribute: turret mounts"
-			"test: base: weapon capacity" = "flagship base attribute: weapon capacity"
-
-			"test: base: heat generation" = "flagship base attribute: heat generation"
-
-			"test: cost" = "flagship attribute: cost"
-			"test: mass" = "flagship attribute: mass"
-			"test: drag" = "flagship attribute: drag"
-			"test: engine capacity" = "flagship attribute: engine capacity"
-			"test: gun ports" = "flagship attribute: gun ports"
-			"test: heat generation" = "flagship attribute: heat generation"
-			"test: outfit space" = "flagship attribute: outfit space"
-			"test: weapon capacity" = "flagship attribute: weapon capacity"
-
 		assert
 			"flagship base attribute: cost" == 41627000
 			"flagship base attribute: mass" == 350000
@@ -192,9 +148,7 @@ test "Flagship Attribute Autoconditions"
 			"flagship base attribute: tactical scan power" == 50000
 			"flagship base attribute: turret mounts" == 2000
 			"flagship base attribute: weapon capacity" == 220000
-
 			"flagship base attribute: heat generation" == 0
-
 			"flagship attribute: cost" == 56584000
 			"flagship attribute: mass" == 902100
 			"flagship attribute: drag" == 4300

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_hyperjumps_to_autocondition.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_hyperjumps_to_autocondition.txt
@@ -4,21 +4,6 @@ test "Hyperjumps To Autocondition"
 	sequence
 		inject "Three Earthly Barges"
 		call "Load First Savegame"
-		apply
-			"test: Earth" = "hyperjumps to planet: Earth"
-			"test: Luna" = "hyperjumps to planet: Luna"
-			"test: Sol" = "hyperjumps to system: Sol"
-			"test: Vega" = "hyperjumps to system: Vega"
-			"test: Alnitak" = "hyperjumps to system: Alnitak"
-			"test: Farpoint" = "hyperjumps to planet: Farpoint"
-			"test: Waypoint" = "hyperjumps to system: Waypoint"
-			"test: Sol Saryd" = "hyperjumps to system: Sol Saryd"
-			"test: Spera Anatrusk" = "hyperjumps to planet: Spera Anatrusk"
-			# The following three calls should each print an error about the planet not having a system
-			# and the planet/system not existing, respectively.
-			"test: Mountaintop" = "hyperjumps tp planet: Mountaintop"
-			"test: Csilla" = "hyperjumps to planet: Csilla"
-			"test: Xian" = "hyperjumps to system: Xian"
 		assert
 			# Current planet
 			"hyperjumps to planet: Earth" == 0

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -324,14 +324,9 @@ test "Boarding Test - Repair Friendly Ship"
 		call "Load First Savegame"
 		watchdog 6000
 		call "Launch Quarg Scanning Mission And Board"
-		# copy the test-data in the temporary conditions for debugging when an issue happens
-		apply
-			"test: %TEST%: Wardragon Scanning You!: active" = "%TEST%: Wardragon Scanning You!: active"
 		assert
 			"%TEST%: Wardragon Scanning You!: active" == 1
 		call "Land"
-		apply
-			"test: %TEST%: Wardragon Scanning You!: done" = "%TEST%: Wardragon Scanning You!: done"
 		assert
 			"%TEST%: Wardragon Scanning You!: done" == 1
 
@@ -348,8 +343,6 @@ test "Illegal Test - Ignore and New Illegal"
 		# land back with a fine of 1 for the hyperdrive, nothing from the gas
 		call "Land"
 		# copy the test-data in the temporary conditions for debugging when an issue happens
-		apply
-			"test: unpaid fines" = "unpaid fines"
 		assert
 			"unpaid fines" == 1
 
@@ -365,9 +358,6 @@ test "Atrocity Test - New Atrocity"
 		call "Launch Quarg Scanning Mission And Board"
 		# land back with atrocity having been in effect (should nuke the reputation?)
 		call "Land"
-		# copy the test-data in the temporary conditions for debugging when an issue happens
-		apply
-			"test: reputation: Quarg" = "reputation: Quarg"
 		assert
 			# it'll be 0 from the atrocity and then minus whatever the atrocity reputation hit it
 			"reputation: Quarg" < 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_save_load.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_save_load.txt
@@ -43,12 +43,6 @@ test "Loading and Saving"
 		inject "Three Earthly Barges"
 		call "Load First Savegame"
 		call "Depart"
-		apply
-			"test: Depart: 0 zoom_restore_counter" = "test: Depart: zoom_restore_counter"
-			"test: 0 departed 1" = 1
-			"test: year" = year
-			"test: month" = month
-			"test: day" = day
 		assert
 			year == 3013
 			month == 11
@@ -63,11 +57,6 @@ test "Loading and Saving"
 		label notAlpha1
 		branch notAlpha1
 			not "flagship system: Alpha Centauri"
-		apply
-			"test: 1 entered A Cen 1" = 1
-			"test: year" = year
-			"test: month" = month
-			"test: day" = day
 		# Terminate jumping if it still is active.
 		input
 			command forward
@@ -80,28 +69,12 @@ test "Loading and Saving"
 		label notReturned1
 		branch notReturned1
 			not "flagship planet: Earth"
-		apply
-			"test: 2 returned to Earth 1" = 1
-			"test: year" = year
-			"test: month" = month
-			"test: day" = day
 		assert
 			year == 3013
 			month == 11
 			day == 19
 		call "Save To Default Snapshot"
-		apply
-			"test: 3 saved to default snapshot" = 1
-			"test: year" = year
-			"test: month" = month
-			"test: day" = day
 		call "Depart"
-		apply
-			"test: Depart: 1 zoom_restore_counter" = "test: Depart: zoom_restore_counter"
-			"test: 4 departed again" = 1
-			"test: year" = year
-			"test: month" = month
-			"test: day" = day
 		assert
 			year == 3013
 			month == 11
@@ -118,11 +91,6 @@ test "Loading and Saving"
 		label notAlpha2
 		branch notAlpha2
 			not "flagship system: Alpha Centauri"
-		apply
-			"test: 5 entered A Cen 2" = 1
-			"test: year" = year
-			"test: month" = month
-			"test: day" = day
 		assert
 			year == 3013
 			month == 11

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_ship_sale.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_ship_sale.txt
@@ -7,10 +7,6 @@ test "Sell 0 ships"
 		call "Load First Savegame"
 		call "Depart"
 		# We can only check the conditions after departing, since the conditions are not updated directly after loading or selling.
-		apply
-			"test: ships: Fighter" = "ships: Fighter"
-			"test: ships: Heavy Warship" = "ships: Heavy Warship"
-			"test: ships: ships: Medium Warship" = "ships: Medium Warship"
 		assert
 			and
 				"ships: Fighter" == 2


### PR DESCRIPTION
**Feature:** This PR is a follow-up for PR #8174 .

## Feature Details
Removed variables from the test-scripts that were once needed for debugging, but not anymore since #8174.

## Testing Done
Was tested as part of #8174.

### Automated Tests Added
N/A

## Performance Impact
The test-scripts are likely more readable now.
