### PR TITLE
fix(content): Raven has too many torpedos

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -3043,7 +3043,7 @@ ship "Raven"
 	outfits
 		"Heavy Laser" 2
 		"Torpedo Launcher"
-		"Torpedo" 60
+		"Torpedo" 30
 		"Sidewinder Missile Launcher"
 		"Sidewinder Missile" 45
 		


### PR DESCRIPTION
**Bugfix:** This PR addresses issue reported by RecursiveParadoz

## Fix Details
Reduce stock torpedoes from 60 to 30.

## Impacts
- Raven has reduced long-battle torpedo inventory. This makes it a bit fairer for the player, who could never match this configuration.

## Testing Done
Bought  Raven in continuous. Noted that it had more torpedoes than it can actually hold. Sold some. Wasn't until it was below 30 that I could reload it.

## Save File
Any pilot can test this by purchasing a new Raven with and without this fix. 