### PR TITLE
refactor/bugfix: move CanSendHail to ship

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1759,7 +1759,6 @@ void Engine::SendHails()
 	vector<shared_ptr<const Ship>> canSend;
 	canSend.reserve(ships.size());
 
-
 	// When deciding who will send a hail, only consider ships that can send hails.
 	for(auto &it : ships)
 		if(it && it->CanSendHail(player, true))

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -135,33 +135,6 @@ namespace {
 		added.clear();
 	}
 
-	bool CanSendHail(const shared_ptr<const Ship> &ship, const PlayerInfo &player)
-	{
-		const System *playerSystem = player.GetSystem();
-		if(!ship || !playerSystem)
-			return false;
-
-		// Make sure this ship is in the same system as the player.
-		if(ship->GetSystem() != playerSystem)
-			return false;
-
-		// Player ships shouldn't send hails.
-		const Government *gov = ship->GetGovernment();
-		if(!gov || ship->IsYours())
-			return false;
-
-		// Make sure this ship is able to send a hail.
-		if(ship->IsDisabled() || !ship->Crew()
-				|| ship->Cloaking() >= 1. || ship->GetPersonality().IsMute())
-			return false;
-
-		// Ships that don't share a language with the player shouldn't send hails.
-		if(!gov->Language().empty() && !player.Conditions().Get("language: " + gov->Language()))
-			return false;
-
-		return true;
-	}
-
 	// Author the given message from the given ship.
 	void SendMessage(const shared_ptr<const Ship> &ship, const string &message)
 	{
@@ -1791,7 +1764,7 @@ void Engine::SendHails()
 			break;
 		}
 
-	if(!CanSendHail(source, player))
+	if(!source->CanSendHail(player))
 		return;
 
 	// Generate a random hail message.
@@ -2209,7 +2182,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 // all the ships already being in their final position for this step.
 void Engine::DoScanning(const shared_ptr<Ship> &ship)
 {
-	int scan = ship->Scan();
+	int scan = ship->Scan(player);
 	if(scan)
 	{
 		shared_ptr<Ship> target = ship->GetTargetShip();
@@ -2386,7 +2359,7 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 	if(attacker->IsPlayer())
 	{
 		shared_ptr<const Ship> previous = grudge[target->GetGovernment()].lock();
-		if(CanSendHail(previous, player))
+		if(previous->CanSendHail(player))
 		{
 			grudge[target->GetGovernment()].reset();
 			SendMessage(previous, "Thank you for your assistance, Captain "
@@ -2404,7 +2377,7 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 		shared_ptr<const Ship> previous = grudge[attacker].lock();
 		// If the previous ship is destroyed, or was able to send a
 		// "thank you" already, skip sending a new thanks.
-		if(!previous || CanSendHail(previous, player))
+		if(!previous || previous->CanSendHail(player))
 			return;
 	}
 
@@ -2414,7 +2387,7 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 		return;
 	// Ensure that this attacked ship is able to send hails (e.g. not mute,
 	// a player ship, automaton, shares a language with the player, etc.)
-	if(!CanSendHail(target, player))
+	if(!target->CanSendHail(player))
 		return;
 
 	// No active ship has a grudge already against this government.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1764,7 +1764,7 @@ void Engine::SendHails()
 			break;
 		}
 
-	if(!source->CanSendHail(player))
+	if(!source || !source->CanSendHail(player))
 		return;
 
 	// Generate a random hail message.
@@ -2359,7 +2359,7 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 	if(attacker->IsPlayer())
 	{
 		shared_ptr<const Ship> previous = grudge[target->GetGovernment()].lock();
-		if(previous->CanSendHail(player))
+		if(previous && previous->CanSendHail(player))
 		{
 			grudge[target->GetGovernment()].reset();
 			SendMessage(previous, "Thank you for your assistance, Captain "
@@ -2387,7 +2387,7 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 		return;
 	// Ensure that this attacked ship is able to send hails (e.g. not mute,
 	// a player ship, automaton, shares a language with the player, etc.)
-	if(!target->CanSendHail(player))
+	if(!target || !target->CanSendHail(player))
 		return;
 
 	// No active ship has a grudge already against this government.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1439,21 +1439,21 @@ string Ship::GetHail(map<string, string> &&subs) const
 bool Ship::CanSendHail(const PlayerInfo &player) const
 {
 	const System *playerSystem = player.GetSystem();
-	if(!ship || !playerSystem)
+	if(!playerSystem)
 		return false;
 
 	// Make sure this ship is in the same system as the player.
-	if(ship->GetSystem() != playerSystem)
+	if(GetSystem() != playerSystem)
 		return false;
 
 	// Player ships shouldn't send hails.
-	const Government *gov = ship->GetGovernment();
-	if(!gov || ship->IsYours())
+	const Government *gov = GetGovernment();
+	if(!gov || IsYours())
 		return false;
 
 	// Make sure this ship is able to send a hail.
-	if(ship->IsDisabled() || !ship->Crew()
-			|| ship->Cloaking() >= 1. || ship->GetPersonality().IsMute())
+	if(IsDisabled() || !Crew()
+			|| Cloaking() >= 1. || GetPersonality().IsMute())
 		return false;
 
 	// Ships that don't share a language with the player shouldn't send hails.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2702,8 +2702,7 @@ int Ship::Scan(const PlayerInfo &player)
 			Messages::Add("Attempting to scan the selected " + target->Noun() + "."
 				, Messages::Importance::Low);
 
-		if(target->GetPersonality().IsSecretive() && target->GetGovernment()->IsProvokedOnScan()
-			&& target->CanSendHail(player))
+		if(target->GetGovernment()->IsProvokedOnScan() && target->CanSendHail(player))
 		{
 			// If this ship has no name, show its model name instead.
 			string tag;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1452,8 +1452,7 @@ bool Ship::CanSendHail(const PlayerInfo &player, bool allowUntranslated) const
 		return false;
 
 	// Make sure this ship is able to send a hail.
-	if(IsDisabled() || !Crew()
-			|| Cloaking() >= 1. || GetPersonality().IsMute())
+	if(IsDisabled() || !Crew() || Cloaking() >= 1. || GetPersonality().IsMute())
 		return false;
 
 	// Ships that don't share a language with the player shouldn't communicate when hailed directly.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1436,7 +1436,7 @@ string Ship::GetHail(map<string, string> &&subs) const
 
 
 
-bool Ship::CanSendHail(const PlayerInfo &player) const
+bool Ship::CanSendHail(const PlayerInfo &player, bool allowUntranslated) const
 {
 	const System *playerSystem = player.GetSystem();
 	if(!playerSystem)
@@ -1456,8 +1456,10 @@ bool Ship::CanSendHail(const PlayerInfo &player) const
 			|| Cloaking() >= 1. || GetPersonality().IsMute())
 		return false;
 
-	// Ships that don't share a language with the player shouldn't send hails.
-	if(!gov->Language().empty() && !player.Conditions().Get("language: " + gov->Language()))
+	// Ships that don't share a language with the player shouldn't communicate when hailed directly.
+	// Only random event hails should work, and only if the government explicitly has
+	// untranslated hails. This is ensured by the allowUntranslated argument.
+	if(!allowUntranslated && !gov->Language().empty() && !player.Conditions().Get("language: " + gov->Language()))
 		return false;
 
 	return true;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -31,6 +31,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Messages.h"
 #include "Phrase.h"
 #include "Planet.h"
+#include "PlayerInfo.h"
 #include "Preferences.h"
 #include "Projectile.h"
 #include "Random.h"

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -196,7 +196,7 @@ public:
 	const Phrase *GetHailPhrase() const;
 	void SetHailPhrase(const Phrase &phrase);
 	std::string GetHail(std::map<std::string, std::string> &&subs) const;
-	bool CanSendHail(const PlayerInfo &player) const;
+	bool CanSendHail(const PlayerInfo &player, bool allowUntranslated = false) const;
 
 	// Set the commands for this ship to follow this timestep.
 	void SetCommands(const Command &command);

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -195,6 +195,7 @@ public:
 	const Phrase *GetHailPhrase() const;
 	void SetHailPhrase(const Phrase &phrase);
 	std::string GetHail(std::map<std::string, std::string> &&subs) const;
+	bool CanSendHail(const PlayerInfo &player) const;
 
 	// Set the commands for this ship to follow this timestep.
 	void SetCommands(const Command &command);
@@ -214,7 +215,7 @@ public:
 	std::shared_ptr<Ship> Board(bool autoPlunder, bool nonDocking);
 	// Scan the target, if able and commanded to. Return a ShipEvent bitmask
 	// giving the types of scan that succeeded.
-	int Scan();
+	int Scan(const PlayerInfo &player);
 	// Find out what fraction of the scan is complete.
 	double CargoScanFraction() const;
 	double OutfitScanFraction() const;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -45,6 +45,7 @@ class Government;
 class Minable;
 class Phrase;
 class Planet;
+class PlayerInfo;
 class Projectile;
 class StellarObject;
 class System;


### PR DESCRIPTION
**Bugfix:** prevents secretive provoked on scan ships from hailing the player if they are mute or if they do not have the same government

## Fix Details
The CanSendHail method was located in the nameless namespace of Engine (dont ask me why) I moved it to ship so we can check before hailing the player to warn them we'll shoot them (or not)

## Testing Done
if the tests run this is good; the code for CanSendHail is already used all the time, and there are checks within it.
and no referencing nullptr here (I added a check each time)

## Save File
n/a