### PR TITLE
Fix Government penalty loading

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -58,6 +58,8 @@ namespace {
 				else
 					child.PrintTrace("Skipping unrecognized attribute:");
 			}
+			else
+				child.PrintTrace("Skipping unrecognized attribute:");
 	}
 
 	// Determine the penalty for the given ShipEvent based on the values in the given map.

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -33,26 +33,27 @@ namespace {
 	void PenaltyHelper(const DataNode &node, map<int, double> &penalties)
 	{
 		for(const DataNode &child : node)
-			if(node.Size() >= 2)
+			if(child.Size() >= 2)
 			{
-				if(node.Token(0) == "assist")
+				const string &key = child.Token(0);
+				if(key == "assist")
 					penalties[ShipEvent::ASSIST] = child.Value(1);
-				else if(node.Token(0) == "disable")
+				else if(key == "disable")
 					penalties[ShipEvent::DISABLE] = child.Value(1);
-				else if(child.Token(0) == "board")
+				else if(key == "board")
 					penalties[ShipEvent::BOARD] = child.Value(1);
-				else if(child.Token(0) == "capture")
+				else if(key == "capture")
 					penalties[ShipEvent::CAPTURE] = child.Value(1);
-				else if(child.Token(0) == "destroy")
+				else if(key == "destroy")
 					penalties[ShipEvent::DESTROY] = child.Value(1);
-				else if(child.Token(0) == "scan")
+				else if(key == "scan")
 				{
 					penalties[ShipEvent::SCAN_OUTFITS] = child.Value(1);
 					penalties[ShipEvent::SCAN_CARGO] = child.Value(1);
 				}
-				else if(child.Token(0) == "provoke")
+				else if(key == "provoke")
 					penalties[ShipEvent::PROVOKE] = child.Value(1);
-				else if(child.Token(0) == "atrocity")
+				else if(key == "atrocity")
 					penalties[ShipEvent::ATROCITY] = child.Value(1);
 				else
 					child.PrintTrace("Skipping unrecognized attribute:");


### PR DESCRIPTION
**Bugfix:**

Thanks to @Hurleveur for reporting this to me.

## Fix Details
#7970 truly is the PR that keeps on giving.
It introduced a bug where loading custom values for a governments default penalties (for actions against itself) was silently skipped due to checking the size of the wrong node.

## Testing Done
Add code to have the game print the `penaltyFor` table for every government and see that it now includes the expected non-default values, without this PR, it does not.

Without fix:
```
Remnant
1 -0.25
2 0
4 0
8 0
16 0.5
32 0.3
64 1
128 1
256 10
Remnant (Research)
1 -0.25
2 0
4 0
8 0
16 0.5
32 0.3
64 1
128 1
256 10
Republic
1 -0.1
2 0
4 0
8 0
16 0.5
32 0.3
64 1
128 1
256 10
```

With fix:
```
Remnant
1 -0.25
2 0.1
4 0.1
8 0
16 1
32 1
64 10
128 10
256 10
Remnant (Research)
1 -0.25
2 0
4 0
8 0
16 1
32 1
64 10
128 10
256 10
Republic
1 -0.1
2 0
4 0
8 0
16 0.5
32 0.3
64 1
128 1
256 10
```

~~Scanning Remnant ships and checking for a permanent reputation change will be a practical test of this, though I have not done that.~~

## Save file
Provided by @Hurleveur:

[John Lennon~1.txt](https://github.com/endless-sky/endless-sky/files/10499967/John.Lennon.1.txt)

Take off, scan the Remnant ship, jump out, see that the Remnant are still hostile, as they should be.
