### PR TITLE
Fix wormhole link drawing for wormholes connecting more than two systems

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1100,7 +1100,7 @@ void MapPanel::DrawWormholes()
 
 		// If an arrow is being drawn, the link will always be drawn too. Draw
 		// the link only for the first instance of it in this set.
-		if(link.from < link.to || count_if(arrowsToDraw.begin(), arrowsToDraw.end(),
+		if(link.from < link.to || !count_if(arrowsToDraw.begin(), arrowsToDraw.end(),
 			[&link](const WormholeArrow &cmp)
 			{ return cmp.from == link.to && cmp.to == link.from; }))
 				LineShader::Draw(from, to, LINK_WIDTH, wormholeDim);


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Fixes a logic error/typo in #7934 that means not all links will be drawn for wormholes connecting more than two systems.

Before:
![image](https://user-images.githubusercontent.com/20605679/214713044-6fd95ec1-8fe9-4215-89bb-89cdcdef9855.png)

After:
![image](https://user-images.githubusercontent.com/20605679/214713098-a0f97cf1-90c0-4d07-9eec-9ef18c808f9e.png)

(Ignore the different colours. They're just me testing stuff.)

## Testing Done
See screenshots

