### PR TITLE
Change landing messages for uninhabited worlds

### DIFF
--- a/source/System.cpp
+++ b/source/System.cpp
@@ -421,10 +421,10 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		static const string STAR = "You cannot land on a star!";
 		static const string HOTPLANET = "This planet is too hot to land on.";
 		static const string COLDPLANET = "This planet is too cold to land on.";
-		static const string UNINHABITEDPLANET = "This planet doesn't have any place suiatble for landing.";
+		static const string UNINHABITEDPLANET = "This planet doesn't have any place suitable for landing.";
 		static const string HOTMOON = "This moon is too hot to land on.";
 		static const string COLDMOON = "This moon is too cold to land on.";
-		static const string UNINHABITEDMOON = "This moon doesn't have any place suiatble for landing.";
+		static const string UNINHABITEDMOON = "This moon doesn't have any place suitable for landing.";
 		static const string STATION = "This station cannot be docked with.";
 
 		double fraction = root->distance / habitable;

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -421,10 +421,10 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		static const string STAR = "You cannot land on a star!";
 		static const string HOTPLANET = "This planet is too hot to land on.";
 		static const string COLDPLANET = "This planet is too cold to land on.";
-		static const string UNINHABITEDPLANET = "This planet is uninhabited.";
+		static const string UNINHABITEDPLANET = "This planet doesn't have any place suiatble for landing.";
 		static const string HOTMOON = "This moon is too hot to land on.";
 		static const string COLDMOON = "This moon is too cold to land on.";
-		static const string UNINHABITEDMOON = "This moon is uninhabited.";
+		static const string UNINHABITEDMOON = "This moon doesn't have any place suiatble for landing.";
 		static const string STATION = "This station cannot be docked with.";
 
 		double fraction = root->distance / habitable;

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -421,10 +421,10 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		static const string STAR = "You cannot land on a star!";
 		static const string HOTPLANET = "This planet is too hot to land on.";
 		static const string COLDPLANET = "This planet is too cold to land on.";
-		static const string UNINHABITEDPLANET = "This planet doesn't have any place suitable for landing.";
+		static const string UNINHABITEDPLANET = "This planet doesn't have anywhere you can land.";
 		static const string HOTMOON = "This moon is too hot to land on.";
 		static const string COLDMOON = "This moon is too cold to land on.";
-		static const string UNINHABITEDMOON = "This moon doesn't have any place suitable for landing.";
+		static const string UNINHABITEDMOON = "This moon doesn't have anywhere you can land.";
 		static const string STATION = "This station cannot be docked with.";
 
 		double fraction = root->distance / habitable;


### PR DESCRIPTION
## Summary
When you try to land on a non-landable planet or moon within sun's green zone, it tells you the planet/moon is uninhabited. But there are lots of uninhabited planets you can land on, so it shouldn't be a problem.

I reworded two standard landing messages and now they say there's no place suitable for landing.

## Additional notes
Of course, there's a question why on the whole planet there isn't even a single larger grassland, but I think that's the difference between landable and non-landable planets.