### PR TITLE
feat(ui): Hide storage on planets without outfitters

### DIFF
--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -229,9 +229,12 @@ void MapOutfitterPanel::DrawItems()
 						continue;
 
 					const Planet &planet = *object.GetPlanet();
-					const auto pit = storage.find(&planet);
-					if(pit != storage.end())
-						storedInSystem += pit->second.Get(outfit);
+					if(planet.HasOutfitter())
+					{
+						const auto pit = storage.find(&planet);
+						if(pit != storage.end())
+							storedInSystem += pit->second.Get(outfit);
+					}
 					if(planet.Outfitter().Has(outfit))
 					{
 						isForSale = true;
@@ -275,12 +278,13 @@ void MapOutfitterPanel::Init()
 
 	// Add outfits in storage
 	for(const auto &it : player.PlanetaryStorage())
-		for(const auto &oit : it.second.Outfits())
-			if(!seen.count(oit.first))
-			{
-				catalog[oit.first->Category()].push_back(oit.first);
-				seen.insert(oit.first);
-			}
+		if(it.first->HasOutfitter())
+			for(const auto &oit : it.second.Outfits())
+				if(!seen.count(oit.first))
+				{
+					catalog[oit.first->Category()].push_back(oit.first);
+					seen.insert(oit.first);
+				}
 
 	// Add all known minables.
 	for(const auto &it : player.Harvested())

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -118,7 +118,7 @@ namespace {
 			// Get the system in which the planet storage is located.
 			const Planet *planet = hold.first;
 			const System *system = planet->GetSystem();
-			// Skip outfits stored on planets without a system or an outfiter.
+			// Skip outfits stored on planets without a system or an outfitter.
 			if(!system || !planet->HasOutfitter())
 				continue;
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -118,8 +118,8 @@ namespace {
 			// Get the system in which the planet storage is located.
 			const Planet *planet = hold.first;
 			const System *system = planet->GetSystem();
-			// Skip outfits stored on planets without a system.
-			if(!system)
+			// Skip outfits stored on planets without a system or an outfiter.
+			if(!system || !planet->HasOutfitter())
 				continue;
 
 			for(const auto &outfit : hold.second.Outfits())


### PR DESCRIPTION
## Feature Details
If there are outfits stored on a planet that doesn't have an outfitter, it makes storage on such planet unusable. This may happen, for example, if outfitters are removed by some events (like in Wanderer storyline).

This PR hides any in-game information about storage on planets without outfitters. The storage itself is left untouched in the pilots's save, so it'll be available again if the outfitter is reinstated.

## Testing Done
Checked how it works: there's no storage indicator on the map; tooltip on hover doesn't show storage data, the same for the side panel.

## Performance Impact
No performance impact.