### PR TITLE
hotfix: new ships not refreshing jump abilities

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -202,8 +202,9 @@ Ship::Ship(const DataNode &node)
 
 
 
-Ship::Ship(Ship &ship)
+Ship::Ship(const Ship &ship)
 {
+	*this = ship;
 	// We need to make sure these point to this ship and not the stock model.
 	navigation = ShipJumpNavigation(*this);
 	AICache = ShipAICache(*this);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -202,6 +202,15 @@ Ship::Ship(const DataNode &node)
 
 
 
+Ship::Ship(Ship &ship)
+{
+	// We need to make sure these point to this ship and not the stock model.
+	navigation = ShipJumpNavigation(*this);
+	AICache = ShipAICache(*this);
+}
+
+
+
 void Ship::Load(const DataNode &node)
 {
 	if(node.Size() >= 2)

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -472,6 +472,10 @@ private:
 	double CalculateAttraction() const;
 	double CalculateDeterrence() const;
 
+	// Make sure nobody uses the copy assignement operator
+	// because that would mean the ship does not have AI or navigation properly instantiated.
+	Ship &operator=(const Ship &ship) = default;
+
 
 private:
 	// Protected member variables of the Body class:

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -472,10 +472,6 @@ private:
 	double CalculateAttraction() const;
 	double CalculateDeterrence() const;
 
-	// Make sure nobody uses the copy assignement operator
-	// because that would mean the ship does not have AI or navigation properly instantiated.
-	Ship &operator=(const Ship &ship) = default;
-
 
 private:
 	// Protected member variables of the Body class:

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -127,7 +127,7 @@ public:
 	// Construct and Load() at the same time.
 	Ship(const DataNode &node);
 	// Copy constructor.
-	Ship(Ship &ship);
+	Ship(const Ship &ship);
 
 	// Load data for a type of ship:
 	void Load(const DataNode &node);

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -126,6 +126,8 @@ public:
 	Ship() = default;
 	// Construct and Load() at the same time.
 	Ship(const DataNode &node);
+	// Copy constructor.
+	Ship(Ship &ship);
 
 	// Load data for a type of ship:
 	void Load(const DataNode &node);

--- a/source/ShipJumpNavigation.cpp
+++ b/source/ShipJumpNavigation.cpp
@@ -42,8 +42,6 @@ ShipJumpNavigation::ShipJumpNavigation(const Ship &ship)
 // Calibrate this ship's jump navigation information, caching its jump costs, range, and capabilities.
 void ShipJumpNavigation::Calibrate()
 {
-	if(!ship)
-		return;
 	mass = ship->Mass();
 
 	const Outfit &attributes = ship->Attributes();
@@ -128,8 +126,6 @@ double ShipJumpNavigation::JumpDriveFuel(double distance) const
 // If no jump method is possible, returns JumpType::None with a jump cost of 0.
 pair<JumpType, double> ShipJumpNavigation::GetCheapestJumpType(const System *destination) const
 {
-	if(!ship->GetSystem())
-		return make_pair(JumpType::NONE, 0.);
 	return GetCheapestJumpType(ship->GetSystem(), destination);
 }
 

--- a/source/StartConditions.cpp
+++ b/source/StartConditions.cpp
@@ -88,7 +88,7 @@ void StartConditions::Load(const DataNode &node)
 				ships.clear();
 			else if(key == "ship" && hasValue)
 				ships.erase(remove_if(ships.begin(), ships.end(),
-					[&value](const Ship *s) noexcept -> bool { return s->ModelName() == value; }),
+					[&value](const Ship &s) noexcept -> bool { return s.ModelName() == value; }),
 					ships.end());
 			else if(key == "conversation")
 				conversation = ExclusiveItem<Conversation>();

--- a/source/StartConditions.cpp
+++ b/source/StartConditions.cpp
@@ -88,7 +88,7 @@ void StartConditions::Load(const DataNode &node)
 				ships.clear();
 			else if(key == "ship" && hasValue)
 				ships.erase(remove_if(ships.begin(), ships.end(),
-					[&value](const Ship &s) noexcept -> bool { return s.ModelName() == value; }),
+					[&value](const Ship *s) noexcept -> bool { return s->ModelName() == value; }),
 					ships.end());
 			else if(key == "conversation")
 				conversation = ExclusiveItem<Conversation>();


### PR DESCRIPTION
When a ship is bought we copy it
But we copy the navigation class too, with the pointer to the old ship in it! Meaning we keep the same abilities as that old ship until you reload the game.

This defines the copy constructor of ship manually, to fix that issue. I tested it, it works!

Testing done:
Buy a ship, equip it with a jump drive (provided it didnt have one), remove the hyperdrive, take off and try to jump. Master will not allow you to jump whereas this PR does.