### PR TITLE
feat(code): Change version to 0.10.0-alpha

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -446,7 +446,7 @@ void PrintHelp()
 void PrintVersion()
 {
 	cerr << endl;
-	cerr << "Endless Sky ver. 0.9.17-alpha" << endl;
+	cerr << "Endless Sky ver. 0.10.0-alpha" << endl;
 	cerr << "License GPLv3+: GNU GPL version 3 or later: <https://gnu.org/licenses/gpl.html>" << endl;
 	cerr << "This is free software: you are free to change and redistribute it." << endl;
 	cerr << "There is NO WARRANTY, to the extent permitted by law." << endl;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8222 

## Fix Details
As the next version of the game, as per Amazinite's announcement, will be 0.10.0, then continuous should self-identify as the alpha version thereof. 

## Testing Done
{{describe how you tested that the fix doesn't introduce other issues}}

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
N/A.