### PR TITLE
Make `<payment>` work with `"apparent payment"`

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -1330,7 +1330,7 @@ mission "Shady passenger transport 3"
 
 mission "Shady passenger transport 3 - double cross"
 	name "Shady passenger transport"
-	description "Discreetly transport <bunks> passengers to <destination>. Payment will be 350,000 credits. If you are caught with them, the legal consequences may be severe."
+	description "Discreetly transport <bunks> passengers to <destination>. Payment will be <payment>. If you are caught with them, the legal consequences may be severe."
 	"apparent payment" 350000
 	minor
 	source
@@ -2324,7 +2324,7 @@ event "terraforming follow-up"
 
 mission "A wolf, a goat, and a cabbage"
 	job
-	description "Transport a wolf, a goat, and a cabbage to <destination>. Payment will be 100,000 credits."
+	description "Transport a wolf, a goat, and a cabbage to <destination>. Payment will be <payment>."
 	"apparent payment" 100000
 	to offer
 		"day" == 1
@@ -3564,7 +3564,7 @@ mission "Spacediving professionals accident"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay 120,000 credits when they land."
+	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay <payment> when they land."
 	"apparent payment" 120000
 	passengers 5 10
 	source
@@ -3587,7 +3587,7 @@ mission "Spacediving professionals disaster"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay 120,000 credits when they land."
+	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay <payment> when they land."
 	"apparent payment" 120000
 	passengers 5 10
 	source
@@ -3612,7 +3612,7 @@ mission "Spacediving amateurs"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> poorly equipped skydivers and drop them from the edge of space. They've agreed to pay 120,000 credits when they land."
+	description "Head to <destination> with <bunks> poorly equipped skydivers and drop them from the edge of space. They've agreed to pay <payment> when they land."
 	"apparent payment" 120000
 	passengers 5 10
 	source

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1345,6 +1345,9 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	subs["<destination>"] = subs["<planet>"] + " in the " + subs["<system>"] + " system";
 	subs["<date>"] = result.deadline.ToString();
 	subs["<day>"] = result.deadline.LongString();
+	if(result.paymentApparent)
+		subs["<payment>"] = Format::Credits(abs(result.paymentApparent))
+				+ (result.paymentApparent == 1 ? " credit" : " credits");
 	// Stopover and waypoint substitutions: iterate by reference to the
 	// pointers so we can check when we're at the very last one in the set.
 	// Stopovers: "<name> in the <system name> system" with "," and "and".

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -352,7 +352,7 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 
 	// Restore the "<payment>" and "<fine>" values from the "on complete" condition, for
 	// use in other parts of this mission.
-	if(result.Payment() && trigger != "complete")
+	if(result.Payment() && (trigger != "complete" || !previousPayment.empty()))
 		subs["<payment>"] = previousPayment;
 	if(result.action.Fine() && trigger != "complete")
 		subs["<fine>"] = previousFine;


### PR DESCRIPTION
## Feature Details
This feature allows the `<payment>` text replacement to display the `"apparent payment"` of a mission, if no payment is present in the current trigger. Having any `payment` in the current trigger will work as before, overriding this default.

If there is both a top-level `payment` and `"apparent payment"`, the apparent payment takes priority.

This feature allows hard-coded 'fake' payments to be replaced with formatted text.

## Usage Examples
Have a look at the edited missions.

## Testing Done
All tests passed. The `A wolf, a goat, and a cabbage` mission displayed `100,000 credits` in the description, and `33,000 credits` in the `on complete` trigger. Regular missions still display their payment as before.

### Automated Tests Added
N/A