### PR TITLE
Fix typo in human hails

### DIFF
--- a/data/human/hails.txt
+++ b/data/human/hails.txt
@@ -1127,7 +1127,7 @@ phrase "friendly civilian"
 	word
 		" " 4
 		" a meal of "
-		" a serving of"
+		" a serving of "
 	word
 		"asparagus"
 		"garlic"


### PR DESCRIPTION
## Summary
Adds a space to the end of a hail phrase, in order to avoid words being mashed together like so:
![image](https://user-images.githubusercontent.com/65418682/215239743-a7b3ba67-f7d8-4349-967d-b7873f025f9b.png)