### PR TITLE
Mute audio for testing

### DIFF
--- a/endless-sky.6
+++ b/endless-sky.6
@@ -39,10 +39,13 @@ sets the directory where preferences and saved games will be stored.
 prints any content or whitespace\-formatting errors found while loading data files and the most recent saved game. This option prevents the game from launching.
 
 .IP \fB\-\-test\ <name>
-execute the test case with the given name
+execute the test case with the given name.
 
 .IP \fB\-\-tests
 prints (to STDOUT) a list of available tests, usable for automatic test runs. This option prevents the game from launching.
+
+.IP \fB\-\-nomute
+prevents muting the game when running tests.
 
 .IP \fB\-s,\ \-\-ships
 prints (to STDOUT) a table of ship stats (just the base stats, not considering any stored outfits). This option prevents the game from launching.

--- a/endless-sky.6
+++ b/endless-sky.6
@@ -39,7 +39,7 @@ sets the directory where preferences and saved games will be stored.
 prints any content or whitespace\-formatting errors found while loading data files and the most recent saved game. This option prevents the game from launching.
 
 .IP \fB\-\-test\ <name>
-execute the test case with the given name.
+execute the test case with the given name. By default, the game will be muted while running tests.
 
 .IP \fB\-\-tests
 prints (to STDOUT) a list of available tests, usable for automatic test runs. This option prevents the game from launching.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -253,7 +253,8 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 
 	// Data to track progress of testing if/when a test is running.
 	TestContext testContext;
-	if(!testToRunName.empty()){
+	if(!testToRunName.empty())
+	{
 		testContext = TestContext(GameData::Tests().Get(testToRunName));
 		Audio::SetVolume(0);
 	}

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -91,6 +91,7 @@ int main(int argc, char *argv[])
 	bool loadOnly = false;
 	bool printTests = false;
 	bool printData = false;
+	bool noTestMute = false;
 	string testToRunName = "";
 
 	// Ensure that we log errors to the errors.txt file.
@@ -119,6 +120,8 @@ int main(int argc, char *argv[])
 			testToRunName = *it;
 		else if(arg == "--tests")
 			printTests = true;
+		else if(arg == "--nomute")
+			noTestMute = true;
 	}
 	if(PrintData::IsPrintDataArgument(argv))
 		printData = true;
@@ -190,6 +193,11 @@ int main(int argc, char *argv[])
 
 		Audio::Init(GameData::Sources());
 
+		if(!testToRunName.empty() && !noTestMute)
+		{
+			Audio::SetVolume(0);
+		}
+
 		// This is the main loop where all the action begins.
 		GameLoop(player, conversation, testToRunName, debugMode);
 	}
@@ -254,10 +262,7 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 	// Data to track progress of testing if/when a test is running.
 	TestContext testContext;
 	if(!testToRunName.empty())
-	{
 		testContext = TestContext(GameData::Tests().Get(testToRunName));
-		Audio::SetVolume(0);
-	}
 
 	// IsDone becomes true when the game is quit.
 	while(!menuPanels.IsDone())
@@ -437,6 +442,7 @@ void PrintHelp()
 	cerr << "    -p, --parse-save: load the most recent saved game and inspect it for content errors." << endl;
 	cerr << "    --tests: print table of available tests, then exit." << endl;
 	cerr << "    --test <name>: run given test from resources directory." << endl;
+	cerr << "    --nomute: don't mute the game while running tests." << endl;
 	PrintData::Help();
 	cerr << endl;
 	cerr << "Report bugs to: <https://github.com/endless-sky/endless-sky/issues>" << endl;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -253,8 +253,10 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 
 	// Data to track progress of testing if/when a test is running.
 	TestContext testContext;
-	if(!testToRunName.empty())
+	if(!testToRunName.empty()){
 		testContext = TestContext(GameData::Tests().Get(testToRunName));
+		Audio::SetVolume(0);
+	}
 
 	// IsDone becomes true when the game is quit.
 	while(!menuPanels.IsDone())


### PR DESCRIPTION
**Feature:** This PR mutes the game when executing tests.

## Feature Details
I just added a quick `Audio::SetVolume(0)` if a test is passed to the game loop. This doesn't affect any default settings for the volume, nor does it change how the game behaves when not running tests.

## Testing Done
It muted during tests, and didn't mute when playing.