### PR TITLE
Fix build with gcc 13 by including <cstdint>

### DIFF
--- a/source/ImageBuffer.h
+++ b/source/ImageBuffer.h
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef IMAGE_BUFFER_H_
 #define IMAGE_BUFFER_H_
 
+#include <cstdint>
 #include <string>
 
 

--- a/source/Sound.cpp
+++ b/source/Sound.cpp
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include <AL/al.h>
 
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 


### PR DESCRIPTION
Like other versions before, gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included. Explicitly include it for uint32_t.

NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!)

## Testing Done
Built locally with gcc 13.0.1_pre20230122