### PR TITLE
feat(enhancement): Add function for proper credit string formatting

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -1330,7 +1330,7 @@ mission "Shady passenger transport 3"
 
 mission "Shady passenger transport 3 - double cross"
 	name "Shady passenger transport"
-	description "Discreetly transport <bunks> passengers to <destination>. Payment will be 350,000 credits. If you are caught with them, the legal consequences may be severe."
+	description "Discreetly transport <bunks> passengers to <destination>. Payment will be <payment>. If you are caught with them, the legal consequences may be severe."
 	"apparent payment" 350000
 	minor
 	source
@@ -2324,7 +2324,7 @@ event "terraforming follow-up"
 
 mission "A wolf, a goat, and a cabbage"
 	job
-	description "Transport a wolf, a goat, and a cabbage to <destination>. Payment will be 100,000 credits."
+	description "Transport a wolf, a goat, and a cabbage to <destination>. Payment will be <payment>."
 	"apparent payment" 100000
 	to offer
 		"day" == 1
@@ -3564,7 +3564,7 @@ mission "Spacediving professionals accident"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay 120,000 credits when they land."
+	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay <payment> when they land."
 	"apparent payment" 120000
 	passengers 5 10
 	source
@@ -3587,7 +3587,7 @@ mission "Spacediving professionals disaster"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay 120,000 credits when they land."
+	description "Head to <destination> with <bunks> professionally equipped skydivers and drop them from the edge of space. They've agreed to pay <payment> when they land."
 	"apparent payment" 120000
 	passengers 5 10
 	source
@@ -3612,7 +3612,7 @@ mission "Spacediving amateurs"
 	job
 	repeat
 	name "Spacediving at <planet>"
-	description "Head to <destination> with <bunks> poorly equipped skydivers and drop them from the edge of space. They've agreed to pay 120,000 credits when they land."
+	description "Head to <destination> with <bunks> poorly equipped skydivers and drop them from the edge of space. They've agreed to pay <payment> when they land."
 	"apparent payment" 120000
 	passengers 5 10
 	source

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -237,7 +237,7 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 
 	auto creditString = [](int64_t payment) -> string
 	{
-		return payment == 1 ? "1 credit" : Format::Credits(payment) + " credits";
+		return Format::CreditString(payment);
 	};
 
 	map<string, int64_t> typesPaid;

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -235,11 +235,6 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 
 	out << "You paid ";
 
-	auto creditString = [](int64_t payment) -> string
-	{
-		return Format::CreditString(payment);
-	};
-
 	map<string, int64_t> typesPaid;
 	if(salariesPaid)
 		typesPaid["crew salaries"] = salariesPaid;
@@ -257,24 +252,24 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 		auto it = typesPaid.begin();
 		for(unsigned int i = 0; i < typesPaid.size() - 1; ++i)
 		{
-			out << creditString(it->second) << " in " << it->first << ", ";
+			out << Format::CreditString(it->second) << " in " << it->first << ", ";
 			++it;
 		}
-		out << "and " << creditString(it->second) << " in " << it->first + ".";
+		out << "and " << Format::CreditString(it->second) << " in " << it->first + ".";
 	}
 	else
 	{
 		if(salariesPaid)
-			out << creditString(salariesPaid) << " in crew salaries"
+			out << Format::CreditString(salariesPaid) << " in crew salaries"
 				<< ((mortgagesPaid || finesPaid || maintenancePaid) ? " and " : ".");
 		if(maintenancePaid)
-			out << creditString(maintenancePaid) << "  in maintenance"
+			out << Format::CreditString(maintenancePaid) << "  in maintenance"
 				<< ((mortgagesPaid || finesPaid) ? " and " : ".");
 		if(mortgagesPaid)
-			out << creditString(mortgagesPaid) << " in mortgages"
+			out << Format::CreditString(mortgagesPaid) << " in mortgages"
 				<< (finesPaid ? " and " : ".");
 		if(finesPaid)
-			out << creditString(finesPaid) << " in fines.";
+			out << Format::CreditString(finesPaid) << " in fines.";
 	}
 	return out.str();
 }

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -245,7 +245,7 @@ void BankPanel::Draw()
 	if(!qualify)
 		amount = "You do not qualify for further loans at this time.";
 	else
-		amount = "You qualify for a new loan of up to " + Format::Credits(qualify) + " credits.";
+		amount = "You qualify for a new loan of up to " + Format::CreditString(qualify) + ".";
 	if(qualify && selectedRow >= mortgageRows)
 		table.DrawHighlight(back);
 	const auto amountLayout = Layout(380, Truncate::MIDDLE);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -662,7 +662,7 @@ void Engine::Step(bool isActive)
 		info.SetBar("disabled hull", min(flagship->Hull(), flagship->DisabledHull()), 20.);
 	}
 	info.SetString("credits",
-		Format::Credits(player.Accounts().Credits()) + " credits");
+		Format::CreditString(player.Accounts().Credits()));
 	bool isJumping = flagship && (flagship->Commands().Has(Command::JUMP) || flagship->IsEnteringHyperspace());
 	if(flagship && flagship->GetTargetStellar() && !isJumping)
 	{

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -396,13 +396,11 @@ GameAction GameAction::Instantiate(map<string, string> &subs, int jumps, int pay
 
 	result.payment = payment + (jumps + 1) * payload * paymentMultiplier;
 	if(result.payment)
-		subs["<payment>"] = Format::Credits(abs(result.payment))
-			+ (result.payment == 1 ? " credit" : " credits");
+		subs["<payment>"] = Format::CreditString(abs(result.payment));
 
 	result.fine = fine;
 	if(result.fine)
-		subs["<fine>"] = Format::Credits(result.fine)
-			+ (result.fine == 1 ? " credit" : " credits");
+		subs["<fine>"] = Format::CreditString(result.fine);
 
 	if(!logText.empty())
 		result.logText = Format::Replace(logText, subs);

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -142,7 +142,7 @@ HailPanel::HailPanel(PlayerInfo &player, const StellarObject *object)
 			SetBribe(planet->GetBribeFraction());
 			if(bribe)
 				message = "If you want to land here, it'll cost you "
-					+ Format::Credits(bribe) + " credits.";
+					+ Format::CreditString(bribe) + ".";
 			else if(gov->IsEnemy())
 				message = "You are not welcome here.";
 			else
@@ -301,7 +301,7 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 				if(!requestedToBribeShip)
 				{
 					message = "If you want us to leave you alone, it'll cost you "
-						+ Format::Credits(bribe) + " credits.";
+						+ Format::CreditString(bribe) + ".";
 					requestedToBribeShip = true;
 				}
 				else
@@ -309,7 +309,7 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 					bribed = ship->GetGovernment();
 					bribed->Bribe();
 					Messages::Add("You bribed a " + bribed->GetName() + " ship "
-						+ Format::Credits(bribe) + " credits to refrain from attacking you today."
+						+ Format::CreditString(bribe) + " to refrain from attacking you today."
 							, Messages::Importance::High);
 				}
 			}
@@ -317,7 +317,7 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 			{
 				planet->Bribe();
 				Messages::Add("You bribed the authorities on " + planet->Name() + " "
-					+ Format::Credits(bribe) + " credits to permit you to land."
+					+ Format::CreditString(bribe) + " to permit you to land."
 						, Messages::Importance::High);
 			}
 		}

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -194,7 +194,7 @@ void MapOutfitterPanel::DrawItems()
 
 		for(const Outfit *outfit : it->second)
 		{
-			string price = Format::Credits(outfit->Cost()) + " credits";
+			string price = Format::CreditString(outfit->Cost());
 
 			string info;
 			if(outfit->Get("minable") > 0.)

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -194,7 +194,7 @@ void MapShipyardPanel::DrawItems()
 
 		for(const Ship *ship : it->second)
 		{
-			string price = Format::Credits(ship->Cost()) + " credits";
+			string price = Format::CreditString(ship->Cost());
 
 			string info = Format::Number(ship->Attributes().Get("shields")) + " shields / ";
 			info += Format::Number(ship->Attributes().Get("hull")) + " hull";

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1345,6 +1345,9 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	subs["<destination>"] = subs["<planet>"] + " in the " + subs["<system>"] + " system";
 	subs["<date>"] = result.deadline.ToString();
 	subs["<day>"] = result.deadline.LongString();
+	if(result.paymentApparent)
+		subs["<payment>"] = Format::Credits(abs(result.paymentApparent))
+				+ (result.paymentApparent == 1 ? " credit" : " credits");
 	// Stopover and waypoint substitutions: iterate by reference to the
 	// pointers so we can check when we're at the very last one in the set.
 	// Stopovers: "<name> in the <system name> system" with "," and "and".

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1346,8 +1346,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	subs["<date>"] = result.deadline.ToString();
 	subs["<day>"] = result.deadline.LongString();
 	if(result.paymentApparent)
-		subs["<payment>"] = Format::Credits(abs(result.paymentApparent))
-				+ (result.paymentApparent == 1 ? " credit" : " credits");
+		subs["<payment>"] = Format::CreditString(abs(result.paymentApparent));
 	// Stopover and waypoint substitutions: iterate by reference to the
 	// pointers so we can check when we're at the very last one in the set.
 	// Stopovers: "<name> in the <system name> system" with "," and "and".

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -352,7 +352,7 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 
 	// Restore the "<payment>" and "<fine>" values from the "on complete" condition, for
 	// use in other parts of this mission.
-	if(result.Payment() && trigger != "complete")
+	if(result.Payment() && (trigger != "complete" || !previousPayment.empty()))
 		subs["<payment>"] = previousPayment;
 	if(result.action.Fine() && trigger != "complete")
 		subs["<fine>"] = previousFine;

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -491,7 +491,7 @@ void OutfitterPanel::FailBuy() const
 	if(!isInCargo && !isInStorage && cost > credits)
 	{
 		GetUI()->Push(new Dialog("You cannot buy this outfit, because it costs "
-			+ Format::Credits(cost) + " credits, and you only have "
+			+ Format::CreditString(cost) + ", and you only have "
 			+ Format::Credits(credits) + "."));
 		return;
 	}
@@ -507,7 +507,7 @@ void OutfitterPanel::FailBuy() const
 	{
 		GetUI()->Push(new Dialog(
 			"You don't have enough money to buy this outfit, because it will cost you an extra "
-			+ Format::Credits(licenseCost) + " credits to buy the necessary licenses."));
+			+ Format::CreditString(licenseCost) + " to buy the necessary licenses."));
 		return;
 	}
 
@@ -997,7 +997,7 @@ void OutfitterPanel::CheckRefill()
 		string message = "Do you want to reload all the ammunition for your ship";
 		message += (count == 1) ? "?" : "s?";
 		if(cost)
-			message += " It will cost " + Format::Credits(cost) + " credits.";
+			message += " It will cost " + Format::CreditString(cost) + ".";
 		GetUI()->Push(new Dialog(this, &OutfitterPanel::Refill, message));
 	}
 }

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -614,7 +614,7 @@ string Planet::DemandTribute(PlayerInfo &player) const
 
 	playerConditions["tribute: " + name] = tribute;
 	GameData::GetPolitics().DominatePlanet(this);
-	return "We surrender. We will pay you " + Format::Credits(tribute) + " credits per day to leave us alone.";
+	return "We surrender. We will pay you " + Format::CreditString(tribute) + " per day to leave us alone.";
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -693,7 +693,7 @@ void PlayerInfo::IncrementDate()
 	{
 		string message = "You receive ";
 		if(salariesIncome)
-			message += Format::Credits(salariesIncome) + " credits salary";
+			message += Format::CreditString(salariesIncome) + " salary";
 		if(salariesIncome && tributeIncome)
 		{
 			if(b.assetsReturns)
@@ -702,13 +702,13 @@ void PlayerInfo::IncrementDate()
 				message += " and ";
 		}
 		if(tributeIncome)
-			message += Format::Credits(tributeIncome) + " credits in tribute";
+			message += Format::CreditString(tributeIncome) + " in tribute";
 		if(salariesIncome && tributeIncome && b.assetsReturns)
 			message += ",";
 		if((salariesIncome || tributeIncome) && b.assetsReturns)
 			message += " and ";
 		if(b.assetsReturns)
-			message += Format::Credits(b.assetsReturns) + " credits based on outfits and ships";
+			message += Format::CreditString(b.assetsReturns) + " based on outfits and ships";
 		message += ".";
 		Messages::Add(message, Messages::Importance::High);
 		accounts.AddCredits(salariesIncome + tributeIncome + b.assetsReturns);
@@ -1660,7 +1660,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 	{
 		// Report how much excess cargo was sold, and what profit you earned.
 		ostringstream out;
-		out << "You sold " << sold << " tons of excess cargo for " << Format::Credits(income) << " credits";
+		out << "You sold " << sold << " tons of excess cargo for " << Format::CreditString(income);
 		if(totalBasis && totalBasis != income)
 			out << " (for a profit of " << (income - totalBasis) << " credits).";
 		else

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -616,7 +616,7 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 
 	table.DrawTruncatedPair("player:", dim, player.FirstName() + " " + player.LastName(),
 		bright, Truncate::MIDDLE, true);
-	table.DrawTruncatedPair("net worth:", dim, Format::Credits(player.Accounts().NetWorth()) + " credits",
+	table.DrawTruncatedPair("net worth:", dim, Format::CreditString(player.Accounts().NetWorth()),
 		bright, Truncate::MIDDLE, true);
 	table.DrawTruncatedPair("time played:", dim, Format::PlayTime(player.GetPlayTime()),
 		bright, Truncate::MIDDLE, true);

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -723,7 +723,7 @@ void ShipInfoPanel::Dump()
 
 	info.Update(**shipIt, player.FleetDepreciation(), player.GetDate().DaysSinceEpoch());
 	if(loss)
-		Messages::Add("You jettisoned " + Format::Credits(loss) + " credits worth of cargo."
+		Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
 			, Messages::Importance::High);
 }
 
@@ -740,7 +740,7 @@ void ShipInfoPanel::DumpPlunder(int count)
 		info.Update(**shipIt, player.FleetDepreciation(), player.GetDate().DaysSinceEpoch());
 
 		if(loss)
-			Messages::Add("You jettisoned " + Format::Credits(loss) + " credits worth of cargo."
+			Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
 				, Messages::Importance::High);
 	}
 }
@@ -760,7 +760,7 @@ void ShipInfoPanel::DumpCommodities(int count)
 		info.Update(**shipIt, player.FleetDepreciation(), player.GetDate().DaysSinceEpoch());
 
 		if(loss)
-			Messages::Add("You jettisoned " + Format::Credits(loss) + " credits worth of cargo."
+			Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
 				, Messages::Importance::High);
 	}
 }

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -263,8 +263,8 @@ void ShipyardPanel::Buy(bool alreadyOwned)
 	modifier = Modifier();
 	string message;
 	if(licenseCost)
-		message = "Note: you will need to pay " + Format::Credits(licenseCost)
-			+ " credits for the licenses required to operate this ship, in addition to its cost."
+		message = "Note: you will need to pay " + Format::CreditString(licenseCost)
+			+ " for the licenses required to operate this ship, in addition to its cost."
 			" If that is okay with you, go ahead and enter a name for your brand new ";
 	else
 		message = "Enter a name for your brand new ";
@@ -363,7 +363,7 @@ void ShipyardPanel::Sell(bool toStorage)
 		toSell.push_back(it->shared_from_this());
 	int64_t total = player.FleetDepreciation().Value(toSell, day);
 
-	message += ((initialCount > 2) ? "\nfor " : " for ") + Format::Credits(total) + " credits?";
+	message += ((initialCount > 2) ? "\nfor " : " for ") + Format::CreditString(total) + "?";
 	GetUI()->Push(new Dialog(this, &ShipyardPanel::SellShip, message, Truncate::MIDDLE));
 }
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -350,7 +350,7 @@ void ShopPanel::DrawButtons()
 		Screen::Bottom() - 65);
 	font.Draw("You have:", creditsPoint, dim);
 
-	const auto credits = Format::Credits(player.Accounts().Credits()) + " credits";
+	const auto credits = Format::CreditString(player.Accounts().Credits());
 	font.Draw({credits, {SIDEBAR_WIDTH - 20, Alignment::RIGHT}}, creditsPoint, bright);
 
 	const Font &bigFont = FontSet::Get(18);

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -76,9 +76,9 @@ TradingPanel::~TradingPanel()
 			+ (tonsSold == 1 ? " ton" : " tons") + " of cargo ";
 
 		if(profit < 0)
-			message += "at a loss of " + Format::Credits(-profit) + " credits.";
+			message += "at a loss of " + Format::CreditString(-profit) + ".";
 		else
-			message += "for a total profit of " + Format::Credits(profit) + " credits.";
+			message += "for a total profit of " + Format::CreditString(profit) + ".";
 
 		Messages::Add(message, Messages::Importance::High);
 	}

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -104,6 +104,7 @@ string Format::CreditString(int64_t value)
 }
 
 
+
 // Convert a time in seconds to years/days/hours/minutes/seconds
 std::string Format::PlayTime(double timeVal)
 {

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -97,12 +97,10 @@ string Format::Credits(int64_t value)
 // then attach the ' credit' or ' credits' suffix to it.
 string Format::CreditString(int64_t value)
 {
-	string creditValue = Credits(value);
 	if(value == 1)
-		creditValue += " credit";
+		return "1 credit";
 	else
-		creditValue += " credits";
-	return creditValue;
+		return Credits(value) + " credits";
 }
 
 

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -93,6 +93,19 @@ string Format::Credits(int64_t value)
 
 
 
+// Convert the given number into abbreviated format as described in Format::Credits,
+// then attach the ' credit' or ' credits' suffix to it.
+string Format::CreditString(int64_t value)
+{
+	string creditValue = Credits(value);
+	if(value == 1)
+		creditValue += " credit";
+	else
+		creditValue += " credits";
+	return creditValue;
+}
+
+
 // Convert a time in seconds to years/days/hours/minutes/seconds
 std::string Format::PlayTime(double timeVal)
 {

--- a/source/text/Format.h
+++ b/source/text/Format.h
@@ -29,6 +29,9 @@ public:
 	// "M" for million, "B" for billion, or "T" for trillion. Any number
 	// above 1 quadrillion is instead shown in scientific notation.
 	static std::string Credits(int64_t value);
+	// Convert the given number into abbreviated format as described in Format::Credits,
+	// then attach the ' credit' or ' credits' suffix to it.
+	static std::string CreditString(int64_t value);
 	// Convert a time in seconds to years/days/hours/minutes/seconds
 	static std::string PlayTime(double timeVal);
 	// Convert the given number to a string, with at most one decimal place.

--- a/tests/unit/src/text/test_format.cpp
+++ b/tests/unit/src/text/test_format.cpp
@@ -244,6 +244,65 @@ TEST_CASE( "Format::Number", "[Format][Number]") {
 	}
 }
 
+TEST_CASE( "Format::Credits", "[Format][Credits]") {
+	SECTION( "1 credit" ) {
+		CHECK( Format::Credits(1) == "1" );
+	}
+	SECTION( "0 credits" ) {
+		CHECK( Format::Credits(0) == "0" );
+	}
+	SECTION( "Positive credits" ) {
+		CHECK( Format::Credits(2) == "2" );
+		CHECK( Format::Credits(1000) == "1,000" );
+		CHECK( Format::Credits(2200) == "2,200" );
+		CHECK( Format::Credits(2200) == "2,200" );
+		CHECK( Format::Credits(1000000) == "1,000,000" );
+		CHECK( Format::Credits(4361000) == "4.361M" );
+		CHECK( Format::Credits(1000000000) == "1,000.000M" );
+		CHECK( Format::Credits(4361000000) == "4.361B" );
+		CHECK( Format::Credits(1000000000000) == "1,000.000B" );
+		CHECK( Format::Credits(4361000000000) == "4.361T" );
+		CHECK( Format::Credits(1000000000000000ll) == "1,000.000T");
+		CHECK( Format::Credits(1000000000000001ll) == "1e+15");
+		CHECK( Format::Credits(4361000000000000ll) == "4.36e+15");
+	}
+	SECTION( "Negative credits" ) {
+		CHECK( Format::Credits(-2) == "-2" );
+		CHECK( Format::Credits(-1000) == "-1,000" );
+		CHECK( Format::Credits(-2200) == "-2,200" );
+		CHECK( Format::Credits(-2200) == "-2,200" );
+		CHECK( Format::Credits(-1000000) == "-1,000,000" );
+		CHECK( Format::Credits(-4361000) == "-4.361M" );
+		CHECK( Format::Credits(-1000000000) == "-1,000.000M" );
+		CHECK( Format::Credits(-4361000000) == "-4.361B" );
+		CHECK( Format::Credits(-1000000000000) == "-1,000.000B" );
+		CHECK( Format::Credits(-4361000000000) == "-4.361T" );
+		CHECK( Format::Credits(-1000000000000000ll) == "-1,000.000T");
+		CHECK( Format::Credits(-1000000000000001ll) == "-1e+15");
+		CHECK( Format::Credits(-4361000000000000ll) == "-4.36e+15");
+	}
+}
+
+TEST_CASE( "Format::CreditString", "[Format][CreditString]") {
+	SECTION( "1 credit" ) {
+		CHECK( Format::CreditString(1) == "1 credit" );
+	}
+	SECTION( "0 credits" ) {
+		CHECK( Format::CreditString(0) == "0 credits" );
+	}
+	SECTION( "Positive credits" ) {
+		CHECK( Format::CreditString(2) == "2 credits" );
+		CHECK( Format::CreditString(1000) == "1,000 credits" );
+		CHECK( Format::CreditString(4361000) == "4.361M credits" );
+	}
+	SECTION( "Negative credits" ) {
+		CHECK( Format::CreditString(-1) == "-1 credits" );
+		CHECK( Format::CreditString(-2) == "-2 credits" );
+		CHECK( Format::CreditString(-1000) == "-1,000 credits" );
+		CHECK( Format::CreditString(-4361000) == "-4.361M credits" );
+	}
+}
+
 // #endregion unit tests
 
 // #region benchmarks


### PR DESCRIPTION
**Feature:** This PR implements the feature requested by @warp-core in #the-hub.

## Feature Details
Adds a new function to Format that appends the credit/credits suffix to the formatted credit amount. This fixes a million minor formatting bugs and reduces the amount of duplicate code.

## Testing Done
Checked the shipyard, jobs, salaries. Formatting works as expected.