### PR TITLE
fix(content): Make FW: Zug Expansion fire correctly

### DIFF
--- a/data/human/free worlds side plots.txt
+++ b/data/human/free worlds side plots.txt
@@ -21,7 +21,7 @@ mission "FW Zug Expansion: Assisted"
 		near Zubeneschamali 2 4
 	destination "Zug"
 	to offer
-		has "event: tarazed diplomacy"
+		has "event: tarazed assistance"
 		not "FW Diplomacy 1: done"
 	on offer
 		conversation


### PR DESCRIPTION
**Bugfix:**

## Fix Details
The mission "FW: Zug Expansion" requires the event "tarazed diplomacy" to have fired, but that's a mission. This PR changes "tarazed diplomacy" to "tarazed assistance" based off the conversations in #7719  

Thanks to Kroniicoptor on Discord for pointing it out.

## To-do
- [x] Test before merging.
