### PR TITLE
content: Narriative change when first offered the Emerald Sword

### DIFF
--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -1280,6 +1280,13 @@ mission "Sheragi Archaeology: The Emerald Sword 2"
 			label return
 			`	"What do I get in return?" you ask.`
 			`	"Fame and fortune, my friend. And if the ship is still there, I think you deserve to keep it," Albert responds. "You've helped me so much, and you went to hell and back to get this black box decoded. Give us some time to assemble a crew to survey the system and help refurbish the ship, and in the meantime, go get us a jump drive. Come back to us once you have it."`
+			choice
+				`   "You're just going to let me have it? Isn't this something of a priceless historical artifact?"`
+					goto askkeepship
+				`   "Thank you."`
+					accept
+			label askkeepship
+			`   Albert responds, "Well, yes, but I'd feel much more comfortable with it in your hands than sitting here on <origin> waiting to be destroyed or stolen in a pirate raid. The millitia works hard, but they can't be everywhere."`
 				accept
 	
 	to complete

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -1286,7 +1286,7 @@ mission "Sheragi Archaeology: The Emerald Sword 2"
 				`   "Thank you."`
 					accept
 			label askkeepship
-			`   Albert responds, "Well, yes, but I'd feel much more comfortable with it in your hands than sitting here on <origin> waiting to be destroyed or stolen in a pirate raid. The millitia works hard, but they can't be everywhere."`
+			`   Albert responds, "Well, yes, but I'd feel much more comfortable with it in your hands than sitting here on <origin> waiting to be destroyed or stolen in a pirate raid. The militia works hard, but they can't be everywhere."`
 				accept
 	
 	to complete

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -1286,7 +1286,7 @@ mission "Sheragi Archaeology: The Emerald Sword 2"
 				`	"Thank you."`
 					accept
 			label askkeepship
-			`	Albert responds, "Well, yes, but I'd feel much more comfortable with it in your hands than sitting here on <origin> waiting to be destroyed or stolen in a pirate raid. The militia works hard, but they can't be everywhere."`
+			`	Albert responds, "Well, yes, but I'd feel much more comfortable with it in your hands than sitting here on <origin> waiting to be destroyed in loose fire during a pirate raid. Besides that though, while the Free Worlds work hard and have a stronger presence here than the Navy ever did, they can't stop everyone who may have an interest in this ship. At least with you it's a moving target."`
 				accept
 	
 	to complete

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -1281,12 +1281,12 @@ mission "Sheragi Archaeology: The Emerald Sword 2"
 			`	"What do I get in return?" you ask.`
 			`	"Fame and fortune, my friend. And if the ship is still there, I think you deserve to keep it," Albert responds. "You've helped me so much, and you went to hell and back to get this black box decoded. Give us some time to assemble a crew to survey the system and help refurbish the ship, and in the meantime, go get us a jump drive. Come back to us once you have it."`
 			choice
-				`   "You're just going to let me have it? Isn't this something of a priceless historical artifact?"`
+				`	"You're just going to let me have it? Isn't this something of a priceless historical artifact?"`
 					goto askkeepship
-				`   "Thank you."`
+				`	"Thank you."`
 					accept
 			label askkeepship
-			`   Albert responds, "Well, yes, but I'd feel much more comfortable with it in your hands than sitting here on <origin> waiting to be destroyed or stolen in a pirate raid. The militia works hard, but they can't be everywhere."`
+			`	Albert responds, "Well, yes, but I'd feel much more comfortable with it in your hands than sitting here on <origin> waiting to be destroyed or stolen in a pirate raid. The militia works hard, but they can't be everywhere."`
 				accept
 	
 	to complete


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Regarding the archaeology mission chain to obtain the Emerald Sword.
Specifically the mission `Sheragi Archaeology: The Emerald Sword 2`

This PR contains small change to the conversation on Zug before heading out to retrieve the emerald Sword acknowledging Albert's willingness to simply allow the player to have the ship.

## Problem
This PR is intended as a potential solution to the (in my opinion) slightly odd situation where an archaeologist is happy to simply promise you what feels like a priceless historical find.
The goal is to still give the player the ship, but to make it feel slightly more reasonable in the narrative.

## Save File
I did not create a save file for this specific change.  Instead I wrote a plugin with the mission copied over and adjusted to be offered from New Boston with no requirements (and renamed to avoid a collision).

jobs.txt:
```
mission "Test - Sheragi Archaeology: The Emerald Sword 2"
	landing
	name "Test - The Emerald Sword"
	description "Test - Bring an additional jump drive to Zug."
	source "New Boston"
#	to offer
#		has "Sheragi Archaeology: The Emerald Sword 1: done"
	
	on offer
		...
```
