### PR TITLE
oversight: fix apparent substitutions in the Tripulse mission

### DIFF
--- a/data/hai/unfettered 0 prologue.txt
+++ b/data/hai/unfettered 0 prologue.txt
@@ -303,8 +303,10 @@ mission "Unfettered Jump Drive Trading"
 	invisible
 	source "Darkcloak"
 	substitutions
+		<hood> ""
 		<hood> ", with their face hidden"
 			has "unfettered: blade rodeo"
+		<learned> ""
 		<learned> "It did take you two tries, but I am glad that you were able to learn from your mistake."
 			"unfettered: blade rodeo" == 1
 		<learned> "You finally learned from your mistakes. This is why our challenges are never fatal."


### PR DESCRIPTION
Very simple: I assumed that an unset substitution would default to being empty (aka, show nothing) but in fact it defaults to not doing anything, for some reason.

So this makes them empty.