### PR TITLE
List outfit cost and requirements above attributes and weapon data

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -319,17 +319,17 @@ int OutfitterPanel::DrawDetails(const Point &center)
 		}
 		categoryZones.emplace_back(collapseDescription);
 
-		Point attrPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
-		Point reqsPoint(startPoint.X(), attrPoint.Y() + outfitInfo.AttributesHeight());
+		Point reqsPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
+		Point attrPoint(startPoint.X(), reqsPoint.Y() + outfitInfo.RequirementsHeight());
 
 		SpriteShader::Draw(background, thumbnailCenter);
 		if(thumbnail)
 			SpriteShader::Draw(thumbnail, thumbnailCenter);
 
-		outfitInfo.DrawAttributes(attrPoint);
 		outfitInfo.DrawRequirements(reqsPoint);
+		outfitInfo.DrawAttributes(attrPoint);
 
-		heightOffset = reqsPoint.Y() + outfitInfo.RequirementsHeight();
+		heightOffset = attrPoint.Y() + outfitInfo.AttributesHeight();
 	}
 
 	// Draw this string representing the selected item (if any), centered in the details side panel


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in the comments of #6963.

## Feature Details
List cost, mass, and installation requirements above the attributes and weapon data of an outfit in the outfit info display in the outshipper panel.

## UI Screenshots

<details> <summary>Long images</summary>

Before | After
-- | --
![image](https://user-images.githubusercontent.com/20605679/215842487-007e71ef-169c-4fc6-b002-45fc2cea60c8.png) | ![image](https://user-images.githubusercontent.com/20605679/215842116-38edcdc6-71ea-4dec-ac0c-9bf14fac5f51.png)
![image](https://user-images.githubusercontent.com/20605679/215842718-be7728c5-71b6-4792-b7a5-cc35c2dbc2c3.png) | ![image](https://user-images.githubusercontent.com/20605679/215842164-b45d13c7-877f-410d-b69f-0d17a8be9f7c.png)
![image](https://user-images.githubusercontent.com/20605679/215842773-af2642a6-bcb0-4fb8-aff6-9e4dd57c23fe.png) | ![image](https://user-images.githubusercontent.com/20605679/215842357-a8583014-6e75-4d5a-9c7a-7ac2d9a12c34.png)
</details>

## Testing Done
Look at the outfit info display for various outfits and see that it appears as expected.

### Automated Tests Added
N/A

## Performance Impact
N/A
