### PR TITLE
Hide stuff requiring licensees you don't have in the map sales panels

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -84,6 +84,7 @@ help "map advanced ports"
 help "map advanced shops"
 	`The shipyard and outfitter map panels respectively display the ships and outfits sold on any planets that you have seen. Ships and outfits are displayed in categories which can be collapsed by clicking on the category name. Using Shift+click on a category name will collapse or uncollapse all the categories at once.`
 	`Each ship or outfit can be clicked on, displaying that item's stats while also highlighting any planets where it is sold. Using Shift+click on a ship or outfit after you already have one selected will display that item's stats side by side with the previously selected item.`
+	`Not all ships or outfits you can view in shops will be available to you, some may require licenses which you do not have. Pressing the 'l' key toggles hiding of ships or outfits you do not have licenses for.`
 
 help "multiple ships"
 	`Now that you have more than one ship, while landed on a planet you can reorder the ships in your fleet by clicking and dragging them in the shipyard, outfitter, or player info panel. Ships can also be sorted by clicking on the column headers in the player info panel. You will use the first ship in the list as your flagship. In the player info panel (accessed with <View player info>) you can also "park" a ship on a planet if you want to travel somewhere without it coming with you.`

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -269,7 +269,8 @@ void MapOutfitterPanel::Init()
 			for(const Outfit *outfit : it.second.Outfitter())
 				if(!seen.count(outfit))
 				{
-					catalog[outfit->Category()].push_back(outfit);
+					if(!onlyShowLicensesMet || LicensesMet(outfit->Licenses()))
+						catalog[outfit->Category()].push_back(outfit);
 					seen.insert(outfit);
 				}
 

--- a/source/MapOutfitterPanel.h
+++ b/source/MapOutfitterPanel.h
@@ -51,6 +51,8 @@ protected:
 
 	virtual void DrawItems() override;
 
+
+private:
 	virtual void Init() override;
 
 

--- a/source/MapOutfitterPanel.h
+++ b/source/MapOutfitterPanel.h
@@ -51,9 +51,7 @@ protected:
 
 	virtual void DrawItems() override;
 
-
-private:
-	void Init();
+	virtual void Init() override;
 
 
 private:

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -447,3 +447,13 @@ void MapSalesPanel::ClickCategory(const string &name)
 	else
 		collapsed.insert(name);
 }
+
+
+
+bool MapSalesPanel::LicensesMet(const vector<string> &licenses) const
+{
+	for(const auto &license : licenses)
+		if(!player.Conditions().Has("license: " + license))
+			return false;
+	return true;
+}

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -119,6 +119,11 @@ bool MapSalesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 	else if(key == 'f')
 		GetUI()->Push(new Dialog(
 			this, &MapSalesPanel::DoFind, "Search for:"));
+	else if(key == 'l')
+	{
+		onlyShowLicensesMet = !onlyShowLicensesMet;
+		Init();
+	}
 	else
 		return MapPanel::KeyDown(key, mod, command, isNewPress);
 

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -78,6 +78,8 @@ protected:
 	void ScrollTo(int index);
 	void ClickCategory(const std::string &name);
 
+	bool LicensesMet(const std::vector<std::string> &licenses) const;
+
 
 protected:
 	static const double ICON_HEIGHT;

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -62,8 +62,6 @@ protected:
 
 	virtual void DrawItems() = 0;
 
-	virtual void Init() = 0;
-
 	void DrawKey() const;
 	void DrawPanel() const;
 	void DrawInfo() const;
@@ -94,6 +92,10 @@ protected:
 	const std::vector<std::string> &categories;
 	bool onlyShowSoldHere = false;
 	bool onlyShowLicensesMet = false;
+
+
+private:
+	virtual void Init() = 0;
 
 
 private:

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -93,6 +93,7 @@ protected:
 
 	const std::vector<std::string> &categories;
 	bool onlyShowSoldHere = false;
+	bool onlyShowLicensesMet = false;
 
 
 private:

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -62,6 +62,8 @@ protected:
 
 	virtual void DrawItems() = 0;
 
+	virtual void Init() = 0;
+
 	void DrawKey() const;
 	void DrawPanel() const;
 	void DrawInfo() const;

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -235,7 +235,8 @@ void MapShipyardPanel::Init()
 			for(const Ship *ship : it.second.Shipyard())
 				if(!seen.count(ship))
 				{
-					catalog[ship->Attributes().Category()].push_back(ship);
+					if(!onlyShowLicensesMet || LicensesMet(ship->BaseAttributes().Licenses()))
+						catalog[ship->Attributes().Category()].push_back(ship);
 					seen.insert(ship);
 				}
 

--- a/source/MapShipyardPanel.h
+++ b/source/MapShipyardPanel.h
@@ -53,9 +53,7 @@ protected:
 
 	virtual void DrawItems() override;
 
-
-private:
-	void Init();
+	virtual void Init() override;
 
 
 private:

--- a/source/MapShipyardPanel.h
+++ b/source/MapShipyardPanel.h
@@ -53,6 +53,8 @@ protected:
 
 	virtual void DrawItems() override;
 
+
+private:
 	virtual void Init() override;
 
 


### PR DESCRIPTION
**Feature:** This PR implements the feature request from @Zitchas on Discord.

## Feature Details
Adds the option to toggle not showing outfits and ships you do not have the licenses for with the 'l' key in the map shipyard or outfitter panels.

Setting does not currently persist across switching between different map views or closing and reopening the map altogether.
- Should that state be pilot specific or global (stored in preferences)?

## UI Screenshots
all | only what I have licenses for
-- | --
![image](https://user-images.githubusercontent.com/20605679/216198632-f0bdecfa-8cd4-4afd-a82b-be5054b0523c.png) | ![image](https://user-images.githubusercontent.com/20605679/216198651-8bfa22b6-04ea-4246-a013-b6cfb407a875.png)


## Usage Examples
Press the 'l' ('L') key while in one of the map sales panels.

## Testing Done
Open the map sales panels, press the 'l' key, see that the items I don't have licenses for are removed from the list, then re-added when I press the key again.

### Automated Tests Added
N/A

## Performance Impact
N/A
