### PR TITLE
fix(typo): Fixes a warning about the order of includes in Panel.cpp

### DIFF
--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -19,10 +19,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Command.h"
 #include "Dialog.h"
 #include "FillShader.h"
+#include "text/Format.h"
 #include "GameData.h"
 #include "Point.h"
 #include "Preferences.h"
-#include "text/Format.h"
 #include "Screen.h"
 #include "UI.h"
 


### PR DESCRIPTION
Fixes the order of includes.