### PR TITLE
Hai Reveal: bug fix: do not provide ongoing election updates after the election has ended

### DIFF
--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -1638,7 +1638,7 @@ mission "Hai Reveal [A11-C] Outgoing Election Update 1"
 		not planet "Hai-home"
 		attributes "spaceport"
 	to offer
-		has "Hai Reveal [A11] Sound the Alarm: offered"
+		has "Hai Reveal [A11] Sound the Alarm: active"
 	on offer
 		conversation
 			`The spaceport appears to be operating on a skeleton staff with an increased security presence. Plenty of ships are still coming and going, but they seem to be here strictly on business. The usual milling of tourists, haggling of merchants, and perusal of jobs all appear to have been suspended in favor of efficient boarding and disembarking of Hai with places to go and goods with places to be. The displays in the main thoroughfare have been switched over to wall-to-wall election coverage and the rest of the non-essential sections of the spaceport have been closed.`

--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -1638,7 +1638,8 @@ mission "Hai Reveal [A11-C] Outgoing Election Update 1"
 		not planet "Hai-home"
 		attributes "spaceport"
 	to offer
-		has "Hai Reveal [A11] Sound the Alarm: active"
+		has "Hai Reveal [A11] Sound the Alarm: offered"
+		not "Hai Reveal [A13] A New Elder: offered"
 	on offer
 		conversation
 			`The spaceport appears to be operating on a skeleton staff with an increased security presence. Plenty of ships are still coming and going, but they seem to be here strictly on business. The usual milling of tourists, haggling of merchants, and perusal of jobs all appear to have been suspended in favor of efficient boarding and disembarking of Hai with places to go and goods with places to be. The displays in the main thoroughfare have been switched over to wall-to-wall election coverage and the rest of the non-essential sections of the spaceport have been closed.`


### PR DESCRIPTION
**Bugfix:** Fixes #8258 

## Fix Details
Ensures the ongoing election update mission only triggers when the election is ongoing.

**Edit**: This actually uses an alternative fix, from @warp-core, rather than my original fix to cut off the mission after A12. That's because the text does not explicitly state the election has ended until A13. We may as well leave the election coverage open as long as possible so the player is more likely to see it.

## Testing Done
Tested the election a few ways to ensure it works.

## Save File
[Friction Diction~3025-12-22 TRY16 before A11.txt](https://github.com/endless-sky/endless-sky/files/10609206/Friction.Diction.3025-12-22.TRY16.before.A11.txt)

That's just before A11, which is when the election starts. After that, but before A13, you should see ongoing election coverage at most Hai planets and stations. After A13, you should not see it. (You'll know you've gotten the mission if you receive an option to eat a cafeteria food tray.)