### PR TITLE
Revert "feat(UI): Additional zoom levels (#8081)"

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -967,40 +967,27 @@ void Engine::Draw() const
 	draw[drawTickTock].Draw();
 	batchDraw[drawTickTock].Draw();
 
-	if(!statuses.empty())
+	for(const auto &it : statuses)
 	{
-		const double zoomFactor = min(1., zoom);
-		double baseDashes = 20. * zoomFactor;
-		// For zoom values between .175 and .2,
-		// gradually scale the number of dashes so we go from
-		// 4 at .2 to 1 at .175.
-		if(zoom < .2 && zoom > .175)
-			baseDashes *= (1. - (.2 - zoom) * 2. * (20. - 1. / .175));
-		// No dashes at zooms of .175 or lower.
-		else if(zoom <= .175)
-			baseDashes = 0.;
-		for(const auto &it : statuses)
-		{
-			static const Color color[8] = {
-				*colors.Get("overlay friendly shields"),
-				*colors.Get("overlay hostile shields"),
-				*colors.Get("overlay outfit scan"),
-				*colors.Get("overlay friendly hull"),
-				*colors.Get("overlay hostile hull"),
-				*colors.Get("overlay cargo scan"),
-				*colors.Get("overlay friendly disabled"),
-				*colors.Get("overlay hostile disabled")
-			};
-			Point pos = it.position * zoom;
-			double radius = it.radius * zoom;
-			if(it.outer > 0.)
-				RingShader::Draw(pos, radius + 3., 1.5f, it.outer, color[it.type], 0.f, it.angle);
-			double dashes = (it.type >= 2) ? 0. : baseDashes;
-			if(it.inner > 0.)
-				RingShader::Draw(pos, radius, 1.5f, it.inner, color[3 + it.type], dashes, it.angle);
-			if(it.disabled > 0.)
-				RingShader::Draw(pos, radius, 1.5f, it.disabled, color[6 + it.type], dashes, it.angle);
-		}
+		static const Color color[8] = {
+			*colors.Get("overlay friendly shields"),
+			*colors.Get("overlay hostile shields"),
+			*colors.Get("overlay outfit scan"),
+			*colors.Get("overlay friendly hull"),
+			*colors.Get("overlay hostile hull"),
+			*colors.Get("overlay cargo scan"),
+			*colors.Get("overlay friendly disabled"),
+			*colors.Get("overlay hostile disabled")
+		};
+		Point pos = it.position * zoom;
+		double radius = it.radius * zoom;
+		if(it.outer > 0.)
+			RingShader::Draw(pos, radius + 3., 1.5f, it.outer, color[it.type], 0.f, it.angle);
+		double dashes = (it.type >= 2) ? 0. : 20. * min(1., zoom);
+		if(it.inner > 0.)
+			RingShader::Draw(pos, radius, 1.5f, it.inner, color[3 + it.type], dashes, it.angle);
+		if(it.disabled > 0.)
+			RingShader::Draw(pos, radius, 1.5f, it.disabled, color[6 + it.type], dashes, it.angle);
 	}
 
 	// Draw labels on missiles

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -37,11 +37,8 @@ namespace {
 	const string EXPEND_AMMO = "Escorts expend ammo";
 	const string FRUGAL_ESCORTS = "Escorts use ammo frugally";
 
-	// This controls the range of zoom scales the player can switch to.
-	// larger values are close-up and small values are farther away
-	const vector<double> ZOOMS = {.105, .125, .15, .175, .2, .25, 0.3, 0.35, 0.4, 0.5, 0.6, 0.7, 0.85,
-		1., 1.2, 1.4, 1.7, 2., 2.4};
-	int zoomIndex = 13;
+	const vector<double> ZOOMS = {.25, .35, .50, .70, 1.00, 1.40, 2.00};
+	int zoomIndex = 4;
 	constexpr double VOLUME_SCALE = .25;
 
 	// Default to fullscreen.


### PR DESCRIPTION
For various reasons:

- @quyykk has noted that changing the zoom indices is undesirable.
- The new lower zoom levels result in previously reasonable asteroid densities consuming a significant amount of GPU time, and not drawing the asteroids altogether has been noted as being undesirable due to the interactions asteroids have with missiles (and any projectiles, but missiles specifically since they tend to have the longest ranges).
- Planet label overlapping becomes an issue again.
- Probably other stuff, check the bug reporting channel on Discord iff you want to know more.