### PR TITLE
Catalytic ramscoop for jump Cruiser

### DIFF
--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1079,7 +1079,7 @@ ship "Cruiser" "Cruiser (Jump)"
 		"Small Radar Jammer"
 		"Liquid Helium Cooler"
 		"Fuel Pod" 2
-		"Ramscoop"
+		"Catalytic Ramscoop"
 		"Outfits Expansion" 2
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"


### PR DESCRIPTION
## Summary
This switches out the basic ramscoop for the catalytic ramscoop on jump cruisers used in the assault on the Pug and by Danforth on the assault on Avalon. 

These ships are already fitted with the newest tech from the Deep including electron beams and typhoons. It makes no sense for them to have less capable ramscoops when they are using jump drives. While it doesn't affect the Pug fights it is needlessly problematic for the assault on Avalon where refueling is a critical component of the plan.

A previous PR using the Hai Reveal configurations was rejected but feedback indicated that this might be an acceptable alternative. See: https://github.com/endless-sky/endless-sky/pull/8063


## Testing Done
Created ship using a custom start file. 

![Catalytic Jump Cruiser](https://user-images.githubusercontent.com/70952724/216789871-a07387ed-15c6-4116-91b8-6ea96dd89725.png)

