### PR TITLE
fix(typo): Correct autoPilot to autopilot (same as #8285, but for code)

### DIFF
--- a/source/AI.h
+++ b/source/AI.h
@@ -198,7 +198,7 @@ private:
 	int step = 0;
 
 	// Command applied by the player's "autopilot."
-	Command autoPilot;
+	Command autopilot;
 	// Position of the cursor, for when the player is using mouse turning.
 	Point mousePosition;
 	// General firing command for ships. This is a data member to avoid


### PR DESCRIPTION
Terin was afraid to touch the code, and this also might have conflicts with a lot of other PRs, so it is now a separate PR.

Autopilot is a single word; don't capitalize it to autoPilot.

Game still compiles and appears to run fine.