### PR TITLE
Fix typo in colour name

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -119,7 +119,7 @@ color "ship target outline blink" 1. 1. 1. 0.
 # Colors used for ship target pointers.
 color "ship target pointer player" .2 1. 0. 0.
 color "ship target pointer friendly" .4 .6 1. 0.
-color "sihp target pointer unfriendly" .8 .8 .3 0.
+color "ship target pointer unfriendly" .8 .8 .3 0.
 color "ship target pointer hostile" .85 .3 .2 0.
 color "ship target pointer inactive" .4 .4 .4 0.
 color "ship target pointer special" 1. 1. 1. 0.


### PR DESCRIPTION
**Bugfix:**

Thanks to @movingpictures for mentioning this in https://github.com/endless-sky/endless-sky/pull/8288#issuecomment-1418166305.

## Fix Details
Fix the typo so the defined colour name matches the expected name.

This isn't detected by the data files CI because the colour is only referred to when it is used, which doesn't happen when loading. We might want to do something to improve that at some point.