### PR TITLE
Fix selected choice text added to conversation when some choice nodes are conditionally hidden

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -291,11 +291,11 @@ bool ConversationPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comm
 	else if(key == SDLK_DOWN && choice + 1 < static_cast<int>(choices.size()))
 		++choice;
 	else if((key == SDLK_RETURN || key == SDLK_KP_ENTER) && isNewPress && choice < static_cast<int>(choices.size()))
-		Goto(conversation.NextNodeForChoice(node, MapChoice(choice)), MapChoice(choice));
+		Goto(conversation.NextNodeForChoice(node, MapChoice(choice)), choice);
 	else if(key >= '1' && key < static_cast<SDL_Keycode>('1' + choices.size()))
-		Goto(conversation.NextNodeForChoice(node, MapChoice(key - '1')), MapChoice(key - '1'));
+		Goto(conversation.NextNodeForChoice(node, MapChoice(key - '1')), key - '1');
 	else if(key >= SDLK_KP_1 && key < static_cast<SDL_Keycode>(SDLK_KP_1 + choices.size()))
-		Goto(conversation.NextNodeForChoice(node, MapChoice(key - SDLK_KP_1)), MapChoice(key - SDLK_KP_1));
+		Goto(conversation.NextNodeForChoice(node, MapChoice(key - SDLK_KP_1)), key - SDLK_KP_1);
 	else
 		return false;
 
@@ -453,7 +453,7 @@ void ConversationPanel::ClickName(int side)
 // The player just clicked on a conversation choice.
 void ConversationPanel::ClickChoice(int index)
 {
-	Goto(conversation.NextNodeForChoice(node, MapChoice(index)), MapChoice(index));
+	Goto(conversation.NextNodeForChoice(node, MapChoice(index)), index);
 }
 
 


### PR DESCRIPTION
**Bugfix:** This fixes something I encountered while testing #7660 and an issue in the HR epilogue that has been brought up on Discord by various people (the most useful report coming from @Zitchas.)

## Fix Details
When adding the text of the selected choice to `ConversationPanel::text` (the collection that stores the text that a conversation panel is displaying), it was looking up the selected choice in its own set of chioces (which only contain the choices that were being displayed) using the index of the selected choice in the underlying conversation, which counts all options in this choice node, not only those that were being displayed.
This means that, if the selected choice is after at least one hidden choice, the text conversation panel adds will be from a choice further down the list since the index it attempts to use is too high. This may even be out of bounds, in which case no text will be displayed where the text of the choice should have gone (this is what I saw while testing #7660.)

This fixes that by not converting the selected choice index when it is passed to `ConversationPanel::Goto()`.

## Testing Done
Try making choices in the mission with the attached save file and see that the correct text is displayed.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[HR Convo node test.txt](https://github.com/endless-sky/endless-sky/files/10611896/HR.Convo.node.test.txt)


