### PR TITLE
Hai Reveal: bug fix: remove unneeded clean-up mission and event

### DIFF
--- a/data/hai/hai reveal 6 end.txt
+++ b/data/hai/hai reveal 6 end.txt
@@ -416,25 +416,6 @@ mission "Hai Reveal [C05] Cleanup"
 			`	Maybe you'll have to find out who the Unfettered were stealing their other technologies from. They mentioned another group: the "Wanderers."`
 
 
-# TODO: delete this mission and event before next steam build - just to fix up saves running on continuous.
-mission "Hai Reveal [C05C] Cleanup Check"
-	landing
-	invisible
-	to offer
-		has "Hai Reveal [C05] Cleanup: done"
-		has "Hai Reveal [A11-A] Permanent Fleets: active"
-	on offer
-		fail "Hai Reveal [A11-A] Permanent Fleets"
-		fail "Hai Reveal [B02-A] The Blockade Goes Up"
-		event "stormhold unsuppressed"
-
-event "stormhold unsuppressed"
-	system "Alcyone"
-		add fleet "Small Core Pirates" 400
-		add fleet "Large Core Pirates" 600
-		add fleet "Korath Large Raid" 50000
-		remove fleet "Human Wormhole Guards"
-
 
 
 ########################################################################


### PR DESCRIPTION
**Bugfix:** Fixes #8295 by removing the mission and event

## Fix Details
Hai Reveal [C05C] Cleanup Check and its event are not needed, so I deleted them.

## Testing Done
Replayed Hai Reveal 4-6
