### PR TITLE
New ES release process that simplifies the existing one

### DIFF
--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -1,9 +1,9 @@
 name: Release CD
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - v*
 
 jobs:
   release_appimage_x64:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       ARCH: x86_64
-      OUTPUT: Endless_Sky-${{ github.event.release.tag_name }}-x86_64.AppImage
+      OUTPUT: Endless_Sky-${{ github.ref_name }}-x86_64.AppImage
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
@@ -42,6 +42,7 @@ jobs:
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
+          draft: true
           files: ${{ env.OUTPUT }}
 
 
@@ -49,7 +50,7 @@ jobs:
     name: Windows x86
     runs-on: windows-2022
     env:
-      OUTPUT: EndlessSky-win32-${{ github.event.release.tag_name }}.zip
+      OUTPUT: EndlessSky-win32-${{ github.ref_name }}.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
@@ -76,6 +77,7 @@ jobs:
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
+          draft: true
           files: ${{ env.OUTPUT }}
 
 
@@ -83,7 +85,7 @@ jobs:
     name: Windows x64
     runs-on: windows-2022
     env:
-      OUTPUT: EndlessSky-win64-${{ github.event.release.tag_name }}.zip
+      OUTPUT: EndlessSky-win64-${{ github.ref_name }}.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
@@ -111,6 +113,7 @@ jobs:
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
+          draft: true
           files: ${{ env.OUTPUT }}
 
 
@@ -119,7 +122,7 @@ jobs:
     runs-on: macos-12
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      OUTPUT: Endless-Sky-${{ github.event.release.tag_name }}
+      OUTPUT: Endless-Sky-${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup sccache
@@ -162,4 +165,5 @@ jobs:
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
+          draft: true
           files: ${{ env.OUTPUT }}.dmg


### PR DESCRIPTION
This changes the release workflow: Instead of creating a release in GitHub and then having to wait until CI publishes the assets:

1. Create and push a new version tag
2. Wait until CI finishes
3. There will be a draft release with the right assets

This simplifies the release process because the assets don't need to be built in a fork.

## Testing Done

https://github.com/quyykk/endless-sky/actions/runs/4098609045

The generated draft release looks like this:

![image](https://user-images.githubusercontent.com/85879619/216849047-62948dc5-c733-4b35-9d84-bce13e0813d2.png)


And can be modified before being published