### PR TITLE
bugfix: Fix fighters choosing boarding targets

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1259,6 +1259,10 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 				&& foe->IsDisabled() && !canPlunder)
 			continue;
 
+		// Ships that cannot board or shoot at disabled enemies should not pick them as targets.
+		if((person.Disables() && foe->IsDisabled() && ship.CanBeCarried()))
+			continue;
+
 		// Ships that don't (or can't) plunder strongly prefer active targets.
 		if(!canPlunder)
 			range += 5000. * foe->IsDisabled();

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1259,7 +1259,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 				&& foe->IsDisabled() && !canPlunder)
 			continue;
 
-		// Ships that cannot board or shoot at disabled enemies should not pick them as targets.
+		// Fighters or Drones that cannot board or shoot at disabled enemies should not pick them as targets.
 		if((person.Disables() && foe->IsDisabled() && ship.CanBeCarried()))
 			continue;
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1214,7 +1214,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	double closest = person.IsHunting() ? numeric_limits<double>::infinity() :
 		(minRange > 1000.) ? maxRange * 1.5 : 4000.;
 	bool hasNemesis = false;
-	bool canPlunder = person.Plunders() && ship.Cargo().Free();
+	bool canPlunder = person.Plunders() && ship.Cargo().Free() && !ship.CanBeCarried();
 	// Figure out how strong this ship is.
 	int64_t maxStrength = 0;
 	auto strengthIt = shipStrength.find(&ship);
@@ -1257,10 +1257,6 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 		// Ships which only disable never target already-disabled ships.
 		if((person.Disables() || (!person.IsNemesis() && foe != oldTarget.get()))
 				&& foe->IsDisabled() && !canPlunder)
-			continue;
-
-		// Fighters or Drones that cannot board or shoot at disabled enemies should not pick them as targets.
-		if((person.Disables() && foe->IsDisabled() && ship.CanBeCarried()))
 			continue;
 
 		// Ships that don't (or can't) plunder strongly prefer active targets.


### PR DESCRIPTION
**Bugfix:** This PR fixes a subset of #8228

## Fix Details
Some remnant fighters and drones spawn with 'disables' and 'plunders', which causes them to choose disabled 'olofez as targets - but they cannot actually shoot at them or board them, so they just stay there.

This PR makes it so any ship that cannot board and cannot attack disabled ships will not target them.

## Testing Done
It seems to stop remnant fighters and drones from grouping up on the korath drones.

## Save File
[Test Pilot.txt](https://github.com/endless-sky/endless-sky/files/10615157/Test.Pilot.txt)