### PR TITLE
Hai Reveal: bug fix: each HR5 path blocks the other from starting

### DIFF
--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -411,6 +411,7 @@ mission "Hai Reveal [B05-short] The Road Not Taken"
 	to offer
 		has "Hai Reveal [B04] The Road Not Taken: done"
 		has "event: knows about keystones and wormholes"
+		not "Hai Reveal [B05-long] The Red Mystery: offered"
 	on offer
 		fail "Hai Reveal [B02-S] Republic Intelligence Stalkers"
 		log `Giti tripped an alert which places you both under the jurisdiction of a Syndicate Internal Affairs investigation. You've were sent directly to Hephaestus.`
@@ -469,6 +470,7 @@ mission "Hai Reveal [B05-long] The Red Mystery"
 	to offer
 		has "Hai Reveal [B04] The Road Not Taken: done"
 		not "event: knows about keystones and wormholes"
+		not "Hai Reveal [B05-short] The Road Not Taken: offered"
 	on offer
 		conversation
 			`At length you return again to tell Giti about the system with the unstable wormhole in it. You aren't required to land elsewhere on the planet this time, so it's a shorter, if equally crowded, journey to her office.`


### PR DESCRIPTION
**Bugfix:** Fixes #8298 wherein passing through Hai Reveal part 5 once doesn't stop you from getting arrested a second time.

## Fix Details
The two B05 missions (long and short) each refuse to start if the other has been offered. 

## Testing Done
Tested the Timmy save (see below) from #8298 and also ensured that B05 would trigger as it should.

## Save File
The previous save file from @ziproot was broken, and they've provided a new one.
[Timmerson.Timmy.Pre.Glitch.txt](https://github.com/endless-sky/endless-sky/files/10669442/Timmerson.Timmy.Pre.Glitch.txt)

When you fly to Earth, nothing should happen.

Here is another save, just before one of the part 5 routes. You need to depart and land.

[Friction Diction~3026-01-20 TRY20 before B05.txt](https://github.com/endless-sky/endless-sky/files/10637330/Friction.Diction.3026-01-20.TRY20.before.B05.txt)
