### PR TITLE
bugfix: Fix AI timings and actually do what the documentation says

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -527,6 +527,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 	step++;
 	if(step >= 30)
 		step = 0;
+	int targetTurn = 0;
 	int minerCount = 0;
 	const int maxMinerCount = minables.empty() ? 0 : 9;
 	bool opportunisticEscorts = !Preferences::Has("Turrets focus fire");
@@ -626,7 +627,9 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 		{
 			// Each ship only switches targets twice a second, so that it can
 			// focus on damaging one particular ship.
-			if(!step || !target || target->IsDestroyed() || (target->IsDisabled() && personality.Disables())
+			if(++targetTurn >= 30)
+				targetTurn = 0;
+			if(targetTurn == step || !target || target->IsDestroyed() || (target->IsDisabled() && personality.Disables())
 					|| (target->IsFleeing() && personality.IsMerciful()) || !target->IsTargetable())
 			{
 				target = FindTarget(*it);

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -524,8 +524,9 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 	}
 
 	const Ship *flagship = player.Flagship();
-	step = (step + 1) & 31;
-	int targetTurn = 0;
+	step++;
+	if(step >= 30)
+		step = 0;
 	int minerCount = 0;
 	const int maxMinerCount = minables.empty() ? 0 : 9;
 	bool opportunisticEscorts = !Preferences::Has("Turrets focus fire");
@@ -625,8 +626,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 		{
 			// Each ship only switches targets twice a second, so that it can
 			// focus on damaging one particular ship.
-			targetTurn = (targetTurn + 1) & 31;
-			if(targetTurn == step || !target || target->IsDestroyed() || (target->IsDisabled() && personality.Disables())
+			if(!step || !target || target->IsDestroyed() || (target->IsDisabled() && personality.Disables())
 					|| (target->IsFleeing() && personality.IsMerciful()) || !target->IsTargetable())
 			{
 				target = FindTarget(*it);

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -524,8 +524,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 	}
 
 	const Ship *flagship = player.Flagship();
-	step++;
-	if(step >= 30)
+	if(++step >= 30)
 		step = 0;
 	int targetTurn = 0;
 	int minerCount = 0;


### PR DESCRIPTION
**Bugfix:** Fixes the `step` variable of AI.

## Fix Details
According to the documentation, AI.step is
> // The current step count for the AI, ranging from 0 to 30. Its value
> // helps limit how often certain actions occur (such as changing targets).

In reality, it reaches values as high as 31. Also, to clarify, with 60FPS, it should only reach 29, since 0-29 has 30 distinct integer values, so we go through each of them twice. This is what this documentation suggests:
> // Each ship only switches targets twice a second, so that it can
> // focus on damaging one particular ship.

Which was also incorrect, because the timings were off.

This is all fixed now. FindTarget is called twice per second, step stays in [0, 30[.
## Testing Done
~~AI doesn't seem to be any more broken then it already is.~~