### PR TITLE
feat(balance): Nerf the value detector

### DIFF
--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -473,9 +473,9 @@ outfit "Value Detector"
 	thumbnail "outfit/value detector"
 	"mass" 3
 	"outfit space" -3
-	"cargo scan power" 88
+	"cargo scan power" 35
 	"cargo scan efficiency" 16
-	"tactical scan power" 92
+	"tactical scan power" 15
 	description "The Unfettered developed this scanner in order to determine which ships are worth plundering, or which lack the capacity to stand up to their ion weapons. Some Hai consider it rather rudimentary, but it is sufficient to identify the cargo on a ship from afar and provide more detailed information about the tactical condition of enemy vessels. This dual function is useful when fielding experimental weaponry."
 
 outfit "Hai Chasm Batteries"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -471,11 +471,12 @@ outfit "Value Detector"
 	category "Systems"
 	cost 260000
 	thumbnail "outfit/value detector"
-	"mass" 3
-	"outfit space" -3
-	"cargo scan power" 35
-	"cargo scan efficiency" 16
-	"tactical scan power" 20
+	"mass" 5
+	"outfit space" -5
+	"cargo scan power" 75
+	"cargo scan efficiency" 10
+	"tactical scan power" 35
+	"heat generation" 2
 	description "The Unfettered developed this scanner in order to determine which ships are worth plundering, or which lack the capacity to stand up to their ion weapons. Some Hai consider it rather rudimentary, but it is sufficient to identify the cargo on a ship from afar and provide more detailed information about the tactical condition of enemy vessels. This dual function is useful when fielding experimental weaponry."
 
 outfit "Hai Chasm Batteries"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -475,7 +475,7 @@ outfit "Value Detector"
 	"outfit space" -3
 	"cargo scan power" 35
 	"cargo scan efficiency" 16
-	"tactical scan power" 15
+	"tactical scan power" 20
 	description "The Unfettered developed this scanner in order to determine which ships are worth plundering, or which lack the capacity to stand up to their ion weapons. Some Hai consider it rather rudimentary, but it is sufficient to identify the cargo on a ship from afar and provide more detailed information about the tactical condition of enemy vessels. This dual function is useful when fielding experimental weaponry."
 
 outfit "Hai Chasm Batteries"

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -546,7 +546,7 @@ ship "Lightning Bug" "Lightning Bug (Unfettered Shipyards)"
 		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
 		"Quantum Keystone"
-		"Value Detector" 2
+		"Value Detector"
 		"Pebble Core"
 		"Sand Cell"
 		"Hai Gorge Batteries"
@@ -1155,7 +1155,7 @@ ship "Shield Beetle" "Shield Beetle (Unfettered)"
 		"Hai Valley Batteries"
 		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 3
-		"Value Detector" 4
+		"Value Detector" 2
 		"Quantum Keystone"
 		"Pulse Rifle" 65
 		`"Bondir" Atomic Thruster`
@@ -1175,11 +1175,11 @@ ship "Shield Beetle" "Shield Beetle (Unfettered Shipyards)"
 		"Hai Octopus Jammer" 3
 		"Hai Williwaw Cooling" 4
 		"Outfits Expansion" 2
-		"Value Detector" 3
+		"Value Detector" 2
 		"Geode Reactor" 2
 		"Pebble Core"
 		"Hai Gorge Batteries"
-		"Quantum Keystone" 2
+		"Quantum Keystone"
 		"Pulse Rifle" 75
 		`"Bondir" Atomic Thruster`
 		`"Bufaer" Atomic Steering`


### PR DESCRIPTION
## Summary
The value detector added in PR #7019 received a substantial buff as part of PR #7649 resulting it now being the most powerful scanner in the game by quite a large margin.

Value Detector is too strong as it is currently. ~~I suggest dropping tactical scan from 92 to 20, and cargo scan from 88 to 35 to bring it just a bit above human tech overall like most other Hai outfits.~~

I suggest the following:
Tactical Scan Power 92 -> 35
Cargo Scan Power 88 -> 75
Cargo Scan Efficiency 16 -> 10
Mass/Outfit Space 3 -> 5
Add heat generation -> 2

## Details
As a point of comparison, the following chart shows the amount of tactical scan range that each scanner provides per unit of outfit space it uses:

<details>
<summary>Tactical Scan Range/Mass</summary>

![image](https://user-images.githubusercontent.com/15916854/217313607-23de537e-efd7-4bc4-9e7a-696b7b3d2cc3.png)

</details>

The value detector tops the chart at 319.8 tactical scan range per unit of mass, with the second best being the Scanning Module at 166.7
 
![image](https://user-images.githubusercontent.com/15916854/217313977-079b2c40-01a3-4693-9f40-1821bc07835a.png)

In terms of it's cargo scan ability, it once again tops the charts at 29.33 cargo scan per unit of mass, with the second highest being the cargo scanner at 9 cargo scan per unit of mass. 
![image](https://user-images.githubusercontent.com/15916854/217314733-61e1be58-5d0a-4e1d-b478-57558f752e8b.png)


This effectively makes the value detector the best tactical scanner and the best cargo scanner in the game combined into one, being a straight upgrade over every other tactical/cargo scanner by quite a large margin. As this scanner is available from the start of the game, is not license locked, and is easily purchasable, this is far too powerful. 

<details>
<summary> Outdated </summary>
As such, my suggested change is to reduce the cargo scan power down from 88 to 35, and reduce the tactical scan power down from 92 to 20. 
This still leaves it as both the strongest cargo scanner in the game (35 compared to the Scanning Module's 25 or the Research Laboratory's 20), and the most efficient in the game (11.67 cargo scan per unit of mass compared to 9 cargo scan per unit of mass from the cargo scanner):
![image](https://user-images.githubusercontent.com/15916854/217317019-d0cdc7c4-986c-49d2-8e05-bdd42037ef00.png)


However it makes it much weaker in terms of tactical scan, being slightly weaker than the human tactical scanner with 447 scan range compared to the tactical scanner with 566, but is slightly more mass efficient with 149 scan range per unit of mass compared to the tactical scanner at 141 scan range per unit of mass:
![image](https://user-images.githubusercontent.com/15916854/217317297-cbddf3e2-2fb3-4683-8f49-144c170c4563.png)

This makes it a particularly strong cargo scanner, and still a decent tactical scanner, definitely an upgrade over human tech, without being an upgrade over everything. 
It may still be too strong, being roughly comparable to Heliarch level tech even with these changes, but that may be something we want to revisit once we have a better idea of where we want to stand with regards to scanners in general.

</summary>
