### PR TITLE
Fix uninstalling a Command Center

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -476,7 +476,7 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 
 		// Only automatons may have a "required crew" of 0.
 		if(!strcmp(at.first, "required crew"))
-			minimum = !(attributes.Get("automaton") + other.attributes.Get("automaton"));
+			minimum = !(attributes.Get("automaton") || other.attributes.Get("automaton"));
 
 		double value = Get(at.first);
 		// Allow for rounding errors:

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -476,7 +476,7 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 
 		// Only automatons may have a "required crew" of 0.
 		if(!strcmp(at.first, "required crew"))
-			minimum = !attributes.Get("automaton");
+			minimum = !(attributes.Get("automaton") + other.attributes.Get("automaton"));
 
 		double value = Get(at.first);
 		// Allow for rounding errors:


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7390

## Fix Details
Changed how the game checks if the ship is an automaton, by taking also the automaton value of the outfit being uninstalled.

## Testing Done
Captured a Model 16, removed weapons requiring additional crew, installed and uninstalled a Command Center without problems.

## Save File
See the original issue.