### PR TITLE
Recategorise scrambling as a "unique special damage type" rather than as a DoT

### DIFF
--- a/source/DamageProfile.cpp
+++ b/source/DamageProfile.cpp
@@ -169,13 +169,13 @@ void DamageProfile::PopulateDamage(DamageDealt &damage, const Ship &ship) const
 	damage.dischargeDamage = weapon.DischargeDamage() * ScaleType(0., attributes.Get("discharge protection"));
 	damage.corrosionDamage = weapon.CorrosionDamage() * ScaleType(1., attributes.Get("corrosion protection"));
 	damage.ionDamage = weapon.IonDamage() * ScaleType(.5, attributes.Get("ion protection"));
-	damage.scramblingDamage = weapon.ScramblingDamage() * ScaleType(.5, attributes.Get("scramble protection"));
 	damage.burnDamage = weapon.BurnDamage() * ScaleType(.5, attributes.Get("burn protection"));
 	damage.leakDamage = weapon.LeakDamage() * ScaleType(1., attributes.Get("leak protection"));
 
 	// Unique special damage types.
 	// Disruption and slowing are blocked 50% by shields.
 	damage.disruptionDamage = weapon.DisruptionDamage() * ScaleType(.5, attributes.Get("disruption protection"));
+	damage.scramblingDamage = weapon.ScramblingDamage() * ScaleType(.5, attributes.Get("scramble protection"));
 	damage.slowingDamage = weapon.SlowingDamage() * ScaleType(.5, attributes.Get("slowing protection"));
 
 	// Hit force is blocked 0% by shields.

--- a/source/DamageProfile.cpp
+++ b/source/DamageProfile.cpp
@@ -173,7 +173,7 @@ void DamageProfile::PopulateDamage(DamageDealt &damage, const Ship &ship) const
 	damage.leakDamage = weapon.LeakDamage() * ScaleType(1., attributes.Get("leak protection"));
 
 	// Unique special damage types.
-	// Disruption and slowing are blocked 50% by shields.
+	// Disruption, scrambling and slowing are blocked 50% by shields.
 	damage.disruptionDamage = weapon.DisruptionDamage() * ScaleType(.5, attributes.Get("disruption protection"));
 	damage.scramblingDamage = weapon.ScramblingDamage() * ScaleType(.5, attributes.Get("scramble protection"));
 	damage.slowingDamage = weapon.SlowingDamage() * ScaleType(.5, attributes.Get("slowing protection"));


### PR DESCRIPTION
Moves scrambling damage from the DoT with instantaneous analog section to the unique special damage types section.
This places it alongside disruption and slowing, rather than alongside ion, burn, leak, discharge and corrosion.
Also updated the comment to mention that scrambling is 50% blocked by shields, as it already mentioned the same about disruption and slowing.