### PR TITLE
bug fix: ships scanning will try to stay near their target instead of moving erratically 

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1491,7 +1491,10 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 			target.reset();
 		else
 		{
-			CircleAround(ship, command, *target);
+			if(target->Velocity().Length() > ship.MaxVelocity() * 0.9)
+				CircleAround(ship, command, *target);
+			else
+				MoveTo(ship, command, target->Position(), target->Velocity(), 1., 1.);
 			if(!ship.IsYours() && (ship.IsSpecial() || scanPermissions.at(gov)))
 				command |= Command::SCAN;
 		}
@@ -2488,7 +2491,10 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 			ship.SetTargetShip(shared_ptr<Ship>());
 		else
 		{
-			CircleAround(ship, command, *target);
+			if(target->Velocity().Length() > ship.MaxVelocity() * 0.9)
+				CircleAround(ship, command, *target);
+			else
+				MoveTo(ship, command, target->Position(), target->Velocity(), 1., 1.);
 			command |= Command::SCAN;
 		}
 	}


### PR DESCRIPTION
**Bugfix:** Ships try to stay near their target while scanning it, instead of moving erratically.

Reduces problems described in #8272, #7539, and #7640 caused by ships not trying to stay within their scanning range.

This only solves half the problem: the scanning formula nerfs scanners into oblivion, so that needs to be fixed too. PR #8288 improves the scanning formula to make scanners work again. The combined effect might make scanners too strong, but the tuning parameters added by #8288 can be adjusted to compensate.

## Fix Details
A ship will try to stay near its target when scanning. Previously, the algorithm always used `CircleAround`, which is why ships moved erratically near slower targets, instead of staying within scan range. In this version, they'll still `CircleAround` fast-moving targets, which does a decent job of staying near a target that cannot be reached. However, for a slower-moving target, they'll match its position and velocity, so they're at the dead center of the scanning region. That uses the same movement algorithm as refueling: `MoveTo`.

## Testing Done
Flew around getting scanned, watching the movement patterns of gunboats.

## Save File
Scan tests:
[Aimet Taepip~3029-04-19 Ranoerek Test.txt](https://github.com/endless-sky/endless-sky/files/10689207/Aimet.Taepip.3029-04-19.Ranoerek.Test.txt)
[Aimet Taepip~3029-04-20 Sparrow Test.txt](https://github.com/endless-sky/endless-sky/files/10689208/Aimet.Taepip.3029-04-20.Sparrow.Test.txt)
[Aimet Taepip~3029-04-18 Heavy Shuttle Test.txt](https://github.com/endless-sky/endless-sky/files/10689209/Aimet.Taepip.3029-04-18.Heavy.Shuttle.Test.txt)
[Aimet Taepip~3029-04-18 Clipper Test.txt](https://github.com/endless-sky/endless-sky/files/10689210/Aimet.Taepip.3029-04-18.Clipper.Test.txt)
[Aimet Taepip~3029-04-18 Blackbird Test.txt](https://github.com/endless-sky/endless-sky/files/10689213/Aimet.Taepip.3029-04-18.Blackbird.Test.txt)