### PR TITLE
Fix typos in Hai Rescue: Ooonem

### DIFF
--- a/data/hai/hai reveal 2 start.txt
+++ b/data/hai/hai reveal 2 start.txt
@@ -246,10 +246,10 @@ mission "Hai Rescue: Ooonem"
 			`	Following reports of the last time the 'angel of death' was sighted, you end up loitering in a twisting street parallel to a main thoroughfare. The few people using it hurry by quickly, and rarely seem to travel any great distance down this street. One very surly looking individual gives you a sour glare on his way past, a collection of weapons on full display. He looks a lot like you'd expect a bounty hunter to look, and as he moves out of sight you observe a shadow, previously motionless, detach from a spot on a wall and head back your direction, laser rifle pointed in the direction of the departing individual. As the shadow approaches, you see there's a lot of hair sticking out from their hood. Seems you may have indeed found a Hai. Do you want to talk to them?`
 			label start
 			choice
-				`	(Talk to her.)`
+				`	(Talk to them.)`
 				`	(Come back later.)`
 					defer
-			`	As step into her path, she swings the laser rifle towards you and says, "You're either very brave, very stupid, or know something... I should warn you, I'm not going back to them!"`
+			`	As you step into her path, the Hai swings the laser rifle towards you and says, "You're either very brave, very stupid, or know something... I should warn you, I'm not going back to them!"`
 			`	She watches your expression closely and, when you don't appear to be hostile, settles into a wary but more relaxed stance. "You're not one of them. What do you want with me?"`
 			choice
 				`	"I was wondering why a Hai is on a pirate planet."`

--- a/data/hai/hai reveal 2 start.txt
+++ b/data/hai/hai reveal 2 start.txt
@@ -249,7 +249,7 @@ mission "Hai Rescue: Ooonem"
 				`	(Talk to them.)`
 				`	(Come back later.)`
 					defer
-			`	As you step into her path, the Hai swings the laser rifle towards you and says, "You're either very brave, very stupid, or know something... I should warn you, I'm not going back to them!"`
+			`	As you step into their path, the Hai swings the laser rifle towards you and says, "You're either very brave, very stupid, or know something... I should warn you, I'm not going back to them!"`
 			`	She watches your expression closely and, when you don't appear to be hostile, settles into a wary but more relaxed stance. "You're not one of them. What do you want with me?"`
 			choice
 				`	"I was wondering why a Hai is on a pirate planet."`


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Adds a missing 'you', and changes a pronoun from 'her' to 'them', as at that point the player is unable to tell what gender the Hai might be. 'She' is used once the player gets a good look at Ooonem.