### PR TITLE
Default to "fast" parallax

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -55,6 +55,7 @@ namespace {
 	const vector<string> BOARDING_SETTINGS = {"proximity", "value", "mixed"};
 	int boardingIndex = 0;
 
+	// Enable "fast" parallax by default. "fancy" is too GPU heavy, especially for low-end hardware.
 	const vector<string> PARALLAX_SETTINGS = {"off", "fancy", "fast"};
 	int parallaxIndex = 2;
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -56,7 +56,7 @@ namespace {
 	int boardingIndex = 0;
 
 	const vector<string> PARALLAX_SETTINGS = {"off", "fancy", "fast"};
-	int parallaxIndex = 1;
+	int parallaxIndex = 2;
 
 	const vector<string> ALERT_INDICATOR_SETTING = {"off", "audio", "visual", "both"};
 	int alertIndicatorIndex = 3;


### PR DESCRIPTION
The "fancy" parallax option is pretty GPU taxing. The default should be the "fast" option, so that users on low-end hardware don't start to think that newer versions of the game use more resources than it actually needs.

