### PR TITLE
fix(content): Let "Hai Wormhole Warning" offer correctly

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4393,8 +4393,8 @@ mission "Block Hai Wormhole Warning"
 	invisible
 	to offer
 		or
-			has "First Contact: Hai"
-			has "First Contact: Unfettered"
+			has "First Contact: Hai: declined"
+			has "First Contact: Unfettered: declined"
 		has "chosen sides"
 		not "main plot completed"
 	on offer
@@ -4407,8 +4407,8 @@ mission "Hai Wormhole Warning"
 		not attributes "deep"
 	to offer
 		or
-			has "First Contact: Hai"
-			has "First Contact: Unfettered"
+			has "First Contact: Hai: declined"
+			has "First Contact: Unfettered: declined"
 		not "Block Hai Wormhole Warning: offered"
 		not "Wanderers: Alpha Surveillance E: offered"
 	on offer


### PR DESCRIPTION
This closes #8340. 

## Summary
This PR changes the conditions for Hai Wormhole Warning so that it can offer to the player. Thanks to luuiscool4567 for pointing it out on Discord a year ago.

While we're here, I can change the conversation so that it offers upon landing, because I feel like it would make more sense than right now. The player has to go to the spaceport first, and if it's so urgent that the intelligence officer has to pull the player away from what they are doing why isn't the officer just going right up to the player's door? I'd like other peoples' feedback first though.

## Save File
[ES Tester.txt](https://github.com/endless-sky/endless-sky/files/10712330/ES.Tester.txt)

Go to Allhome, have the first contact mission offer, go to Farpoint or Prime and try and get the conversation. Works with this PR, does not work on Continuous 6523348.
