### PR TITLE
Bugfix: Reduce overthrusting when landing or boarding

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1926,7 +1926,7 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition,
 
 	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .95);
 	if(!isClose || (!isFacing && !shouldReverse))
-		command.SetTurn(TurnToward(ship, dp));
+		command.SetTurn(TurnToward(ship, dp, 0.9999));
 	if(isFacing)
 		command |= Command::FORWARD;
 	else if(shouldReverse)


### PR DESCRIPTION
Summary
-------

When ships land on a planet or wormhole or board a ship... it tends to over-compensate by constantly turning left and right.

The following video shows the issue by showing constant over-correction.

https://user-images.githubusercontent.com/875669/218235164-8da2f77f-1ce2-4b62-9540-89caaea2fdea.mp4

Fix Details
-----------

Reduce the turning accuracy required when the ship is flying toward its target to land or board.

The following video shows the fix.

https://user-images.githubusercontent.com/875669/218235163-7834a677-73c2-446d-8cf2-a90c071c60ca.mp4

Related issues
--------------

* https://github.com/endless-sky/endless-sky/pull/8304
* https://github.com/endless-sky/endless-sky/pull/7703

Testing Done
------------

- [x] Verified landing on planet looks nice.
- [x] Verified landing on wormhole looks nice.
- [x] Verified boarding a disabled ship looks nice.

Performance Impact
------------------

None