### PR TITLE
bugfix: Fix ships attempting to re-board boarded targets (#8228)

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1259,7 +1259,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 
 		// Ships which only disable never target already-disabled ships.
 		if((person.Disables() || (!person.IsNemesis() && foe != oldTarget.get()))
-				&& foe->IsDisabled() && (!canPlunder || (canPlunder && Has(ship, foe->shared_from_this(), ShipEvent::BOARD))))
+				&& foe->IsDisabled() && (!canPlunder || Has(ship, foe->shared_from_this(), ShipEvent::BOARD)))
 			continue;
 
 		// Ships that don't (or can't) plunder strongly prefer active targets.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1259,7 +1259,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 
 		// Ships which only disable never target already-disabled ships.
 		if((person.Disables() || (!person.IsNemesis() && foe != oldTarget.get()))
-				&& foe->IsDisabled() && !canPlunder)
+				&& foe->IsDisabled() && (!canPlunder || (canPlunder && Has(ship, foe->shared_from_this(), ShipEvent::BOARD))))
 			continue;
 
 		// Ships that don't (or can't) plunder strongly prefer active targets.


### PR DESCRIPTION
**Bugfix:** This PR fixes #8228

## Fix Details
It appears that the issue was caused by the NPCs re-targeting the ships they just boarded. At least, when I prevented that, it seems to have gone away.

## Testing Done
I couldn't reproduce the issue after this fix. The only similar issue was a bunch of Ibis ships overcorrecting on the target and thus not boarding, but I believe that's being fixed by #8343. Other ships seem to work just fine, even if there are Ibis ships attempting to board.

I have observed that some fleets jump away after the flagship finished boarding, even if the other ships haven't; not sure if that's a bug, or that it's introduced by this fix. (The fleets seem to work fine, they just don't all finish boarding.)

## Save File
Use the save file from the issue.