### PR TITLE
Feature: Mouse hold is opposite of mouse toggle

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2048,7 +2048,10 @@ void Engine::HandleMouseInput(Command &activeCommands)
 	isMouseHoldEnabled = activeCommands.Has(Command::MOUSE_TURNING_HOLD);
 	if(activeCommands.Has(Command::MOUSE_TURNING_TOGGLE))
 		isMouseToggleEnabled = !isMouseToggleEnabled;
-	isMouseTurningEnabled = (isMouseHoldEnabled || isMouseToggleEnabled);
+	// XOR mouse hold and mouse toggle. If mouse toggle is OFF, then mouse hold
+	// will temporarily turn ON mouse control. If mouse toggle is ON, then mouse
+	// hold will temporarily turn OFF mouse control.
+	isMouseTurningEnabled = (isMouseHoldEnabled ^ isMouseToggleEnabled);
 	Preferences::Set("alt-mouse turning", isMouseTurningEnabled);
 	if(!isMouseTurningEnabled)
 		return;


### PR DESCRIPTION
Summary
-------

While playing with mouse control I would always use mouse toggle to toggle it on and off.  Now that there's mouse control I don't have an easy way to do that with my play style.

* With mouse toggle ON the mouse hold behavior does nothing.

Desired solution
----------------

Mouse hold should always do the opposite of mouse toggle.

- With mouse toggle OFF, the mouse hold should temporarily turn ON mouse control.
- With mouse toggle ON, the mouse hold should temporarily turn OFF mouse control.

Testing Done
------------

I tested both states and the desired outcome occurred.

- [x] With mouse toggle off (right alt), the left alt key (mouse hold) temporarily enabled mouse control only as long as the left alt key was pressed.
- [x] With mouse toggle on, the left alt key (mouse hold) temporarily disabled mouse control only as long as the left alt key was pressed.

Performance Impact
------------------

None.
