### PR TITLE
Change the stock Manta's weapons so that they're symmetrical

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2556,9 +2556,9 @@ ship "Manta"
 			"hit force" 1200
 	outfits
 		"Particle Cannon" 4
-		"Meteor Missile Launcher"
-		"Meteor Missile" 60
-		"Meteor Missile Box" 2
+		"Torpedo Storage Rack"
+		"Torpedo" 21
+		"Torpedo Pod" 2
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
@@ -2575,8 +2575,8 @@ ship "Manta"
 	gun 20 -31 "Particle Cannon"
 	gun -26.5 -30 "Particle Cannon"
 	gun 26.5 -30 "Particle Cannon"
-	gun -68.5 -33 "Meteor Missile Launcher"
-	gun 68.5 -33
+	gun -68.5 -33 "Torpedo Pod"
+	gun 68.5 -33 "Torpedo Pod"
 	leak "leak" 60 50
 	leak "flame" 40 80
 	explode "tiny explosion" 10


### PR DESCRIPTION
Replaces the single meteor missile launcher on the stock Manta with two Torpedo Pods (and changes the ammo storage accordingly). Torpedo pods are sold on every non-pirate planet that sells the Manta, and Torpedoes are sold on every planet that sells it, so this makes sense.
The one asymmetrical Meteor Launcher just looked bad, and the Torpedoes should be more dodgeable for small maneuverable ships (their position right on the sides of the ship should stop it just point-blank destroying smaller ships like the bomber Hawk does).
![image](https://user-images.githubusercontent.com/18634983/218518227-0604423f-fc4f-420b-9c3d-332c30100336.png)
