### PR TITLE
Fix thrust becoming unbounded

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1944,23 +1944,23 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		{
 			// Check if we are able to turn.
 			double cost = attributes.Get("turning energy");
-			if(energy < cost * fabs(commands.Turn()))
+			if(cost > 0. && energy < cost * fabs(commands.Turn()))
 				commands.SetTurn(commands.Turn() * energy / cost);
 
 			cost = attributes.Get("turning shields");
-			if(shields < cost * fabs(commands.Turn()))
+			if(cost > 0. && shields < cost * fabs(commands.Turn()))
 				commands.SetTurn(commands.Turn() * shields / cost);
 
 			cost = attributes.Get("turning hull");
-			if(hull < cost * fabs(commands.Turn()))
+			if(cost > 0. && hull < cost * fabs(commands.Turn()))
 				commands.SetTurn(commands.Turn() * hull / cost);
 
 			cost = attributes.Get("turning fuel");
-			if(fuel < cost * fabs(commands.Turn()))
+			if(cost > 0. && fuel < cost * fabs(commands.Turn()))
 				commands.SetTurn(commands.Turn() * fuel / cost);
 
 			cost = -attributes.Get("turning heat");
-			if(heat < cost * fabs(commands.Turn()))
+			if(cost > 0. && heat < cost * fabs(commands.Turn()))
 				commands.SetTurn(commands.Turn() * heat / cost);
 
 			if(commands.Turn())
@@ -1996,27 +1996,27 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 			// Check if we are able to apply this thrust.
 			double cost = attributes.Get((thrustCommand > 0.) ?
 				"thrusting energy" : "reverse thrusting energy");
-			if(energy < cost)
+			if(cost > 0. && energy < cost)
 				thrustCommand *= energy / cost;
 
 			cost = attributes.Get((thrustCommand > 0.) ?
 				"thrusting shields" : "reverse thrusting shields");
-			if(shields < cost)
+			if(cost > 0. && shields < cost)
 				thrustCommand *= shields / cost;
 
 			cost = attributes.Get((thrustCommand > 0.) ?
 				"thrusting hull" : "reverse thrusting hull");
-			if(hull < cost)
+			if(cost > 0. && hull < cost)
 				thrustCommand *= hull / cost;
 
 			cost = attributes.Get((thrustCommand > 0.) ?
 				"thrusting fuel" : "reverse thrusting fuel");
-			if(fuel < cost)
+			if(cost > 0. && fuel < cost)
 				thrustCommand *= fuel / cost;
 
 			cost = -attributes.Get((thrustCommand > 0.) ?
 				"thrusting heat" : "reverse thrusting heat");
-			if(heat < cost)
+			if(cost > 0. && heat < cost)
 				thrustCommand *= heat / cost;
 
 			if(thrustCommand)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1945,23 +1945,23 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 			// Check if we are able to turn.
 			double cost = attributes.Get("turning energy");
 			if(energy < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * energy / (cost * fabs(commands.Turn())));
+				commands.SetTurn(commands.Turn() * energy / cost);
 
 			cost = attributes.Get("turning shields");
 			if(shields < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * shields / (cost * fabs(commands.Turn())));
+				commands.SetTurn(commands.Turn() * shields / cost);
 
 			cost = attributes.Get("turning hull");
 			if(hull < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * hull / (cost * fabs(commands.Turn())));
+				commands.SetTurn(commands.Turn() * hull / cost);
 
 			cost = attributes.Get("turning fuel");
 			if(fuel < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * fuel / (cost * fabs(commands.Turn())));
+				commands.SetTurn(commands.Turn() * fuel / cost);
 
 			cost = -attributes.Get("turning heat");
 			if(heat < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * heat / (cost * fabs(commands.Turn())));
+				commands.SetTurn(commands.Turn() * heat / cost);
 
 			if(commands.Turn())
 			{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1945,23 +1945,23 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 			// Check if we are able to turn.
 			double cost = attributes.Get("turning energy");
 			if(cost > 0. && energy < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * energy / cost);
+				commands.SetTurn(commands.Turn() * energy / (cost * fabs(commands.Turn())));
 
 			cost = attributes.Get("turning shields");
 			if(cost > 0. && shields < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * shields / cost);
+				commands.SetTurn(commands.Turn() * shields / (cost * fabs(commands.Turn())));
 
 			cost = attributes.Get("turning hull");
 			if(cost > 0. && hull < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * hull / cost);
+				commands.SetTurn(commands.Turn() * hull / (cost * fabs(commands.Turn())));
 
 			cost = attributes.Get("turning fuel");
 			if(cost > 0. && fuel < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * fuel / cost);
+				commands.SetTurn(commands.Turn() * fuel / (cost * fabs(commands.Turn())));
 
 			cost = -attributes.Get("turning heat");
 			if(cost > 0. && heat < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * heat / cost);
+				commands.SetTurn(commands.Turn() * heat / (cost * fabs(commands.Turn())));
 
 			if(commands.Turn())
 			{


### PR DESCRIPTION
**Bugfix:**

Thanks to @Terin for reporting this on Discord.

## Fix Details
I am no longer sure of what's going on here, I think it might be a floating point precision error.
This PR now prevents the divisino by zero by not doing the division if the cost is not greater than `0.`.

~~Previously, the logic for scaling down the "turn command" when insufficient energy, fuel, etc, is available was incorrect.~~
~~It was dividing the existing turn command magnitude out of the new value, so the new value would just be `"available energy" / "required energy"`. This is fine when the turn command has a magnitude of `1.`, but for partial turning, this is incorrect.~~
~~Take the example where `turning energy` = `1.`, the existing turn command is `.5`, and the initial energy available if `.4`.~~
~~The `.5` turn command requests up to half turning speed. The required energy is `.5`, since it is half speed. The available energy, however, is `.4`.~~
~~The correct result would be to set the turn command to `.4`, however, it ends up at `.8`.~~
~~Then, it goes to subtract the used energy from the available energy. If this calculation had been correct, it would subtract `.4`, resulting in `0.` energy.~~
~~However, since the turn command is `.8`, the energy has become negative, `-4`.~~
~~The next time `Ship::DoGeneration()` or `Ship::TakeDamage()` is executed, the energy will be be brought up to a positive value, but thrust calculations are performed before that.~~
~~Now, the ship in this save file that demonstrates the... interesting behaviour does not have normal forward thrusters, only an afterburner. It, therefore, has no `"thrusting energy"`.~~
~~When it comes to scaling the "thrust command" in a similar way, it would ordinarily not bother because `cost` is `0.` (since there is no thruster), however, `energy` is now `< 0.`, and so, it does attempt to scale the thrust command by `energy / cost`. Since `cost` is `0.` and `energy` is not, this results in `-inf`, and, well, that's bad.~~

~~This PR corrects the logic for scaling the turn command so `energy` (and the other values tested there) cannot be set below 0.~~
~~Derpy really ought to finish that energy levels thing because this code is disgustingly repetitive.~~

## Testing Done
Load the attached save feil, execute the travel plan, then tell the ship to land. Without this PR, bad things happen, with it, they do not.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[Crisis ManagementCursed~unmodified.txt](https://github.com/endless-sky/endless-sky/files/10727722/Crisis.ManagementCursed.unmodified.txt)
(Save file provided by @Terin.)
