### PR TITLE
fix(content): Shorten Paradise Job: Debtors description to fit

### DIFF
--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -455,7 +455,7 @@ mission "Paradise Job: Debtors"
 	name "Debtors to <planet>"
 	job
 	repeat
-	description `These <bunks> poor souls have bankrupted themselves attempting to live beyond their means. To pay off their debts, the local government will pay you <payment> to transport them securely to <destination> where they can "make themselves useful."`
+	description `These <bunks> poor souls have bankrupted themselves attempting to live beyond their means. In response, the local government will pay you <payment> to transport them securely to <destination> to "make themselves useful."`
 	passengers 20 4 .1
 	to offer
 		random < 15


### PR DESCRIPTION
This PR shortens the description of Paradise Job: Debtors to fit into the description box no matter the destination name. Tested with Guardian Array Sapphire + 16 Autumn Rising as some of the longest planet/system names, and it still fit.