### PR TITLE
Add missing quotation mark at the end of an "on complete" dialog

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5309,7 +5309,7 @@ mission "Wool Smuggling 2"
 		dialog phrase "generic cargo on visit"
 	on complete
 		payment 200000
-		dialog `Your cargo of woolen garments is unloaded by several bulky workers led by a one-armed woman. She hands you <payment> for the trouble of transport, then says, "Thanks for the shipment. I know that you captains think that we're all bad, but I'm glad that you were able to aid the more friendly among us.`
+		dialog `Your cargo of woolen garments is unloaded by several bulky workers led by a one-armed woman. She hands you <payment> for the trouble of transport, then says, "Thanks for the shipment. I know that you captains think that we're all bad, but I'm glad that you were able to aid the more friendly among us."`
 
 
 


### PR DESCRIPTION
**Typo fix:**

## Fix Details
The dialog in the on complete ends with speech, but there is no closing quotation mark to accompany the opening one.
This PR adds a quotation mark to the end of the speech.
