### PR TITLE
refactor: Standardize pluralization in the engine

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -19,6 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Command.h"
 #include "DistanceMap.h"
 #include "Flotsam.h"
+#include "text/Format.h"
 #include "Government.h"
 #include "Hardpoint.h"
 #include "JumpTypes.h"
@@ -3446,7 +3447,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 		if(!destinations.empty())
 		{
 			string message = "Note: you have ";
-			message += (missions == 1 ? "a mission that requires" : "missions that require");
+			message += Format::Noun(missions, "a mission that requires", "missions that require");
 			message += " landing on ";
 			size_t count = destinations.size();
 			bool oxfordComma = (count > 2);
@@ -4121,7 +4122,7 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 		for(const shared_ptr<Ship> &it : player.Ships())
 			if(it.get() != player.Flagship() && !it->IsParked())
 				ships.push_back(it.get());
-		who = ships.size() > 1 ? "Your fleet is " : "Your escort is ";
+		who = Format::Noun(ships.size(), "Your escort is ", "Your fleet is ");
 	}
 	else
 	{
@@ -4131,7 +4132,7 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 			if(ship)
 				ships.push_back(ship.get());
 		}
-		who = ships.size() > 1 ? "The selected escorts are " : "The selected escort is ";
+		who = "The selected " + Format::Noun(ships.size(), "escorts are ", "escort is ");
 	}
 	// This should never happen, but just in case:
 	if(ships.empty())

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2261,8 +2261,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 			player.Harvest(outfit);
 		}
 		else
-			message = name + to_string(amount) + " "
-				+ (amount == 1 ? outfit->DisplayName() : outfit->PluralName()) + ".";
+			message = name + Format::NounString(amount, outfit->DisplayName(), outfit->PluralName()) + ".";
 	}
 	else
 		commodity = flotsam.CommodityType();
@@ -2525,9 +2524,9 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 	if(target->GetPersonality().IsDaring())
 	{
 		message = "Please assist us in destroying ";
-		message += (attackerCount == 1 ? "this " : "these ");
+		message += Format::Noun(attackerCount, "this ", "these ");
 		message += attacker->GetName();
-		message += (attackerCount == 1 ? " ship." : " ships.");
+		message += Format::Noun(attackerCount, " ship") + ".";
 	}
 	else
 	{
@@ -2535,7 +2534,7 @@ void Engine::DoGrudge(const shared_ptr<Ship> &target, const Government *attacker
 		if(attackerCount == 1)
 			message += "a ";
 		message += attacker->GetName();
-		message += (attackerCount == 1 ? " ship" : " ships");
+		message += Format::Noun(attackerCount, " ship");
 		message += ". Please assist us!";
 	}
 	SendMessage(target, message);

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -56,21 +56,21 @@ namespace {
 		}
 
 		Ship *flagship = player.Flagship();
-		bool isSingle = (abs(count) == 1);
-		string nameWas = (isSingle ? outfit->DisplayName() : outfit->PluralName());
+		int countAbs = abs(count);
+		string nameWas = Format::Noun(countAbs, outfit->DisplayName(), outfit->PluralName());
 		if(!flagship || !count || nameWas.empty())
 			return;
 
-		nameWas += (isSingle ? " was" : " were");
+		nameWas += Format::Noun(countAbs, "was", "were");
 		string message;
-		if(isSingle)
+		if(countAbs == 1)
 		{
 			char c = tolower(nameWas.front());
 			bool isVowel = (c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u');
 			message = (isVowel ? "An " : "A ");
 		}
 		else
-			message = to_string(abs(count)) + " ";
+			message = to_string(countAbs) + " ";
 
 		message += nameWas;
 		if(count > 0)
@@ -114,7 +114,7 @@ namespace {
 			{
 				string special = "The " + nameWas;
 				special += " put in your cargo hold because there is not enough space to install ";
-				special += (isSingle ? "it" : "them");
+				special += Format::Noun(countAbs, "it", "them");
 				special += " in your ship.";
 				ui->Push(new Dialog(special));
 			}

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -248,9 +248,7 @@ void MapOutfitterPanel::DrawItems()
 			const std::string storage_details =
 				storedInSystem == 0
 				? ""
-				: storedInSystem == 1
-				? "1 unit in storage"
-				: Format::Number(storedInSystem) + " units in storage";
+				: (Format::Noun(storedInSystem, "unit") + " in storage");
 			Draw(corner, outfit->Thumbnail(), 0, isForSale, outfit == selected,
 				outfit->DisplayName(), price, info, storage_details);
 			list.push_back(outfit);

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1288,11 +1288,11 @@ void MapPanel::DrawTooltips()
 		// If you have both active and parked escorts, call the active ones
 		// "active escorts." Otherwise, just call them "escorts."
 		if(t.activeShips && t.parkedShips)
-			tooltip += to_string(t.activeShips) + (t.activeShips == 1 ? " active escort\n" : " active escorts\n");
+			tooltip += Format::NounString(t.activeShips, "active escort") + "\n";
 		else if(t.activeShips)
-			tooltip += to_string(t.activeShips) + (t.activeShips == 1 ? " escort" : " escorts");
+			tooltip += Format::NounString(t.activeShips, "escort");
 		if(t.parkedShips)
-			tooltip += to_string(t.parkedShips) + (t.parkedShips == 1 ? " parked escort" : " parked escorts");
+			tooltip += Format::NounString(t.parkedShips, "parked escort");
 		if(!t.outfits.empty())
 		{
 			if(t.activeShips || t.parkedShips)
@@ -1302,7 +1302,7 @@ void MapPanel::DrawTooltips()
 			for(const auto &it : t.outfits)
 				sum += it.second;
 
-			tooltip += to_string(sum) + (sum == 1 ? " stored outfit" : " stored outfits");
+			tooltip += Format::NounString(sum, "stored outfit");
 
 			if(HasMultipleLandablePlanets(*hoverSystem) || t.outfits.size() > 1)
 				for(const auto &it : t.outfits)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -941,11 +941,11 @@ string Mission::BlockedMessage(const PlayerInfo &player)
 
 	ostringstream out;
 	if(bunksNeeded > 0)
-		out << (bunksNeeded == 1 ? "another bunk" : to_string(bunksNeeded) + " more bunks");
+		out << Format::NounString(bunksNeeded, "more bunk");
 	if(bunksNeeded > 0 && cargoNeeded > 0)
 		out << " and ";
 	if(cargoNeeded > 0)
-		out << (cargoNeeded == 1 ? "another ton" : to_string(cargoNeeded) + " more tons") << " of cargo space";
+		out << Format::NounString(cargoNeeded, "more ton") << " of cargo space";
 	if(bunksNeeded <= 0 && cargoNeeded <= 0)
 		out << "no additional space";
 	subs["<capacity>"] = out.str();
@@ -1334,8 +1334,8 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	subs["<tons>"] = Format::MassString(result.cargoSize);
 	subs["<cargo>"] = Format::CargoString(result.cargoSize, subs["<commodity>"]);
 	subs["<bunks>"] = to_string(result.passengers);
-	subs["<passengers>"] = (result.passengers == 1) ? "passenger" : "passengers";
-	subs["<fare>"] = (result.passengers == 1) ? "a passenger" : (subs["<bunks>"] + " passengers");
+	subs["<passengers>"] = Format::Noun(result.passengers, "passenger");
+	subs["<fare>"] = Format::NounString(result.passengers, "passenger");
 	if(player.GetPlanet())
 		subs["<origin>"] = player.GetPlanet()->Name();
 	else if(boardingShip)

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -665,10 +665,7 @@ void MissionPanel::DrawSelectedSystem() const
 	else if(distance.HasRoute(selectedSystem))
 		jumps = distance.Days(selectedSystem);
 
-	if(jumps == 1)
-		text += " (1 jump away)";
-	else if(jumps > 0)
-		text += " (" + to_string(jumps) + " jumps away)";
+	text += "(" + Format::NounString(jumps, "jump") + " away)";
 
 	const Font &font = FontSet::Get(14);
 	Point pos(-175., Screen::Top() + .5 * (30. - font.Height()));
@@ -843,8 +840,8 @@ void MissionPanel::DrawMissionInfo()
 	else if(acceptedIt != accepted.end())
 		info.SetCondition("can abort");
 
-	info.SetString("cargo free", to_string(player.Cargo().Free()) + " tons");
-	info.SetString("bunks free", to_string(player.Cargo().BunksFree()) + " bunks");
+	info.SetString("cargo free", Format::MassString(player.Cargo().Free()));
+	info.SetString("bunks free", Format::NounString(player.Cargo().BunksFree(), "bunk"));
 
 	info.SetString("today", player.GetDate().ToString());
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -19,6 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Body.h"
 #include "DataNode.h"
 #include "Effect.h"
+#include "text/Format.h"
 #include "GameData.h"
 #include "SpriteSet.h"
 
@@ -307,10 +308,10 @@ void Outfit::Load(const DataNode &node)
 	// so the name doesn't matter.
 	if(!displayName.empty() && pluralName.empty())
 	{
-		pluralName = displayName + 's';
-		if((displayName.back() == 's' || displayName.back() == 'z') && node.Token(0) == "outfit")
+		pluralName = Format::PluralUnsafe(displayName);
+		if((pluralName.empty()) && node.Token(0) == "outfit")
 			node.PrintTrace("Warning: explicit plural name definition required, but none is provided. Defaulting to \""
-					+ pluralName + "\".");
+					+ (pluralName = Format::Plural(displayName)) + "\".");
 	}
 
 	// Only outfits with the jump drive and jump range attributes can

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -340,8 +340,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 
 			if(overbooked > 0)
 			{
-				out << "bunks available for " << overbooked;
-				out << (overbooked > 1 ? " of the passengers" : " passenger");
+				out << "bunks available for " << Format::NounString(overbooked, "passenger");
 				out << (both ? " and not having enough " : ".");
 			}
 
@@ -352,10 +351,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		else if(nonJumpCount > 0)
 		{
 			out << "If you take off now you will launch with ";
-			if(nonJumpCount == 1)
-				out << "a ship";
-			else
-				out << nonJumpCount << " ships";
+			out << Format::NounString(nonJumpCount, "ship");
 			out << " that will not be able to leave the system.";
 		}
 		// Warn about non-commodity cargo you will have to sell.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1464,9 +1464,8 @@ void PlayerInfo::Land(UI *ui)
 		if(added > 0)
 		{
 			flagship->AddCrew(added);
-			Messages::Add("You hire " + to_string(added) + (added == 1
-					? " extra crew member to fill your now-empty bunk."
-					: " extra crew members to fill your now-empty bunks."), Messages::Importance::High);
+			Messages::Add("You hire " + Format::NounString(added, "extra crew member") + to_string(added)
+					+ "to fill your non-empty " + Format::Noun(added, "bunk") + ".", Messages::Importance::High);
 		}
 	}
 
@@ -1546,7 +1545,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 		if(extra)
 		{
 			flagship->AddCrew(-extra);
-			Messages::Add("You fired " + to_string(extra) + " crew members to free up bunks for passengers."
+			Messages::Add("You fired " + Format::NounString(extra, "crew member") + " to free up bunks for passengers."
 				, Messages::Importance::High);
 			flagship->Cargo().SetBunks(flagship->Attributes().Get("bunks") - flagship->Crew());
 			cargo.TransferAll(flagship->Cargo());
@@ -1557,7 +1556,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 	if(extra > 0)
 	{
 		flagship->AddCrew(-extra);
-		Messages::Add("You fired " + to_string(extra) + " crew members because you have no bunks for them."
+		Messages::Add("You fired " + Format::NounString(extra, "crew member") + " because you have no bunks for them."
 			, Messages::Importance::High);
 		flagship->Cargo().SetBunks(flagship->Attributes().Get("bunks") - flagship->Crew());
 	}
@@ -1599,7 +1598,7 @@ bool PlayerInfo::TakeOff(UI *ui)
 		if(uncarried)
 		{
 			// The remaining uncarried ships are launched alongside the player.
-			string message = (uncarried > 1) ? "Some escorts were" : "One escort was";
+			string message = Format::Noun(uncarried, "Some escorts were", "One escort was");
 			Messages::Add(message + " unable to dock with a carrier.", Messages::Importance::High);
 		}
 	}
@@ -3742,8 +3741,8 @@ void PlayerInfo::StepMissions(UI *ui)
 	if(!visitText.empty())
 	{
 		if(missionVisits > 1)
-			visitText += "\n\t(You have " + Format::Number(missionVisits - 1) + " other unfinished "
-				+ ((missionVisits > 2) ? "missions" : "mission") + " at this location.)";
+			visitText += "\n\t(You have " + Format::NounString(missionVisits - 1, " other unfinished mission")
+					+ " at this location.)";
 		ui->Push(new Dialog(visitText));
 	}
 	// One mission's actions may influence another mission, so loop through one

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -293,7 +293,7 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 				}
 		if(failedMissions && maxFine > 0)
 		{
-			reason += "\n\tYou failed " + Format::Number(failedMissions) + ((failedMissions > 1) ? " missions" : " mission")
+			reason += "\n\tYou failed " + Format::NounString(failedMissions, "mission")
 				+ " after your illegal cargo was discovered.";
 		}
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -522,10 +522,10 @@ void Ship::Load(const DataNode &node)
 	// Variants will import their plural name from the base model in FinishLoading.
 	if(pluralModelName.empty() && variantName.empty())
 	{
-		pluralModelName = modelName + 's';
-		if(modelName.back() == 's' || modelName.back() == 'z')
+		pluralModelName = Format::PluralUnsafe(modelName);
+		if(pluralModelName.empty())
 			node.PrintTrace("Warning: explicit plural name definition required, but none is provided. Defaulting to \""
-					+ pluralModelName + "\".");
+					+ (pluralModelName = Format::Plural(modelName)) + "\".");
 	}
 }
 
@@ -695,14 +695,13 @@ void Ship::FinishLoading(bool isNewInstance)
 	}
 	if(!undefinedOutfits.empty())
 	{
-		bool plural = undefinedOutfits.size() > 1;
 		// Print the ship name once, then all undefined outfits. If we're reporting for a stock ship, then it
 		// doesn't have a name, and missing outfits aren't named yet either. A variant name might exist, though.
 		string message;
 		if(isYours)
 		{
 			message = "Player ship " + modelName + " \"" + name + "\":";
-			string PREFIX = plural ? "\n\tUndefined outfit " : " undefined outfit ";
+			string PREFIX = Format::Noun(undefinedOutfits.size(), "\n\tUndefined outfit ", " undefined outfit ");
 			for(auto &&outfit : undefinedOutfits)
 				message += PREFIX + outfit;
 		}
@@ -710,7 +709,7 @@ void Ship::FinishLoading(bool isNewInstance)
 		{
 			message = variantName.empty() ? "Stock ship \"" + modelName + "\": "
 				: modelName + " variant \"" + variantName + "\": ";
-			message += to_string(undefinedOutfits.size()) + " undefined outfit" + (plural ? "s" : "") + " installed.";
+			message += Format::NounString(undefinedOutfits.size(), "undefined outfit") + " installed.";
 		}
 
 		Logger::LogError(message);

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -195,14 +195,14 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	double emptyMass = attributes.Mass();
 	double currentMass = ship.Mass();
 	attributeLabels.push_back(isGeneric ? "mass with no cargo:" : "mass:");
-	attributeValues.push_back(Format::Number(isGeneric ? emptyMass : currentMass) + " tons");
+	attributeValues.push_back(Format::MassString(isGeneric ? emptyMass : currentMass));
 	attributesHeight += 20;
 	attributeLabels.push_back(isGeneric ? "cargo space:" : "cargo:");
 	if(isGeneric)
-		attributeValues.push_back(Format::Number(attributes.Get("cargo space")) + " tons");
+		attributeValues.push_back(Format::MassString(attributes.Get("cargo space")));
 	else
 		attributeValues.push_back(Format::Number(ship.Cargo().Used())
-			+ " / " + Format::Number(attributes.Get("cargo space")) + " tons");
+			+ " / " + Format::MassString(attributes.Get("cargo space")));
 	attributesHeight += 20;
 	attributeLabels.push_back("required crew / bunks:");
 	attributeValues.push_back(Format::Number(ship.RequiredCrew())

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -269,10 +269,10 @@ void ShipyardPanel::Buy(bool alreadyOwned)
 	else
 		message = "Enter a name for your brand new ";
 
-	if(modifier == 1)
-		message += selectedShip->ModelName() + "! (Or leave it blank to use a randomly chosen name.)";
-	else
-		message += selectedShip->PluralModelName() + "! (Or leave it blank to use randomly chosen names.)";
+	message += Format::Noun(modifier, selectedShip->ModelName(), selectedShip->PluralModelName());
+	message += "! (Or leave it blank to use";
+	message += Format::Noun(modifier, "a randomly chosen name", "randomly chosen names");
+	message += ".)";
 
 	GetUI()->Push(new NameDialog(this, &ShipyardPanel::BuyShip, message));
 }

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -111,7 +111,7 @@ string Format::MassString(double amount)
 {
 	if(amount == 1)
 		return "1 ton";
-	return Format::Number(amount) + " tons";
+	return Number(amount) + " tons";
 }
 
 
@@ -368,6 +368,69 @@ string Format::LowerCase(const string &str)
 	for(char &c : result)
 		c = tolower(c);
 	return result;
+}
+
+
+
+// Convert the given non-empty string (noun) to its plural form.
+// Always returns a non-empty string.
+// The actual result might involve some guesswork, and is not guaranteed to be grammatically correct.
+string Format::Plural(const string &noun)
+{
+	const string nounLower = LowerCase(noun);
+	const string lastWord = nounLower.find_last_of(' ') == string::npos ? nounLower : nounLower.substr(nounLower.find_last_of(' '), nounLower.size());
+	auto endsWith = [&lastWord](const string &suffix){ return lastWord.size() >= suffix.size() && 0 == lastWord.compare(lastWord.size()-suffix.size(), suffix.size(), suffix); };
+	string vowels = "aeiouy";
+	if(noun.back() == 's' || endsWith("sh") || endsWith("ch") || endsWith("ch") || noun.back() == 'x' || noun.back() == 'z')
+		return noun + "es";
+	else if(nounLower.back() == 'f')
+		return noun.substr(0, noun.size() - 1) + "ves";
+	else if(endsWith("fe"))
+		return noun.substr(0, noun.size() - 2) + "ves";
+	else if(nounLower.back() == 'y' && vowels.find(nounLower[nounLower.size() - 2]) == string::npos)
+		return noun.substr(0, noun.size() - 1) + "ies";
+	else if(lastWord == "buffalo" || lastWord == "domino" || lastWord == "domino" || lastWord == "echo" || lastWord == "embargo"
+			|| lastWord == "hero" || lastWord == "mosquito" || lastWord == "potato" || lastWord == "tomato" || lastWord == "torpedo" || lastWord == "veto")
+		return noun + "es";
+	else
+		return noun + "s";
+}
+
+
+
+// Convert the given non-empty string (noun) to its plural form.
+// Returns an empty string if a plural form cannot be safely determined.
+// The returned value is not guaranteed to be grammatically correct.
+string Format::PluralUnsafe(const string &noun)
+{
+	if(noun.back() == 's' || noun.back() == 'z')
+		return "";
+	return noun + "s";
+}
+
+
+
+// Convert the given non-empty string (noun) to its singular or plural form,
+// depending on the specified amount. The plural form can be specified manually, if necessary.
+string Format::Noun(double amount, const string &noun, const string plural)
+{
+	if(amount == 1.)
+		return noun;
+	else
+		if(plural.empty())
+			return Plural(noun);
+		else
+			return plural;
+}
+
+
+
+// Convert the given non-empty string (noun) to its singular or plural form,
+// and adds it to a string after the formatted amount, like in '2 goats'.
+// The plural form can be specified manually, if necessary.
+string Format::NounString(double amount, const string &noun, const string plural)
+{
+	return Number(amount) + " " + Noun(amount, noun, plural);
 }
 
 

--- a/source/text/Format.h
+++ b/source/text/Format.h
@@ -58,6 +58,22 @@ public:
 	static std::string Capitalize(const std::string &str);
 	static std::string LowerCase(const std::string &str);
 
+	// Convert the given non-empty string (noun) to its plural form.
+	// Always returns a non-empty string.
+	// The actual result might involve some guesswork, and is not guaranteed to be grammatically correct.
+	static std::string Plural(const std::string &noun);
+	// Convert the given non-empty string (noun) to its plural form.
+	// Returns an empty string if a plural form cannot be safely determined.
+	// The returned value is not guaranteed to be grammatically correct.
+	static std::string PluralUnsafe(const std::string &noun);
+	// Convert the given non-empty string (noun) to its singular or plural form,
+	// depending on the specified amount. The plural form can be specified manually, if necessary.
+	static std::string Noun(double amount, const std::string &noun, const std::string plural = {});
+	// Convert the given non-empty string (noun) to its singular or plural form,
+	// and adds it to a string after the formatted amount, like in '2 goats'.
+	// The plural form can be specified manually, if necessary.
+	static std::string NounString(double amount, const std::string &noun, const std::string plural = {});
+
 	// Split a single string into substrings with the given separator.
 	static std::vector<std::string> Split(const std::string &str, const std::string &separator);
 };

--- a/tests/unit/src/text/test_format.cpp
+++ b/tests/unit/src/text/test_format.cpp
@@ -353,6 +353,94 @@ TEST_CASE( "Format::CargoString", "[Format][CargoString]") {
 	}
 }
 
+TEST_CASE( "Format::Plural", "[Format][Plural]") {
+	SECTION( "Simple cases" ) {
+		CHECK( Format::Plural("car") == "cars" );
+		CHECK( Format::Plural("variable") == "variables" );
+		CHECK( Format::Plural("ship") == "ships" );
+		CHECK( Format::Plural("credit") == "credits" );
+		CHECK( Format::Plural("ton") == "tons" );
+		CHECK( Format::Plural("action") == "actions" );
+		CHECK( Format::Plural("outfit") == "outfits" );
+		CHECK( Format::Plural("CapitalizedString") == "CapitalizedStrings" );
+	}
+	SECTION( "Ending with -o" ) {
+		CHECK( Format::Plural("volcano") == "volcanos" );
+		CHECK( Format::Plural("potato") == "potatoes" ); // PO-TAY-TOES
+		CHECK( Format::Plural("hero") == "heroes" );
+		CHECK( Format::Plural("torpedo") == "torpedoes" );
+		CHECK( Format::Plural("zero") == "zeros" );
+		CHECK( Format::Plural("Radio") == "Radios" );
+	}
+	SECTION( "Appending -es" ) {
+		CHECK( Format::Plural("bus") == "buses" );
+		CHECK( Format::Plural("truss") == "trusses" );
+		CHECK( Format::Plural("Marsh") == "Marshes" );
+	}
+	SECTION( "Changing -f to -v" ) {
+		CHECK( Format::Plural("leaf") == "leaves" );
+		CHECK( Format::Plural("Knife") == "Knives" );
+	}
+	SECTION( "Changing -y to -i" ) {
+		CHECK( Format::Plural("city") == "cities" );
+		CHECK( Format::Plural("Puppy") == "Puppies" );
+		CHECK( Format::Plural("play") == "plays" );
+	}
+}
+
+TEST_CASE ( "Format::PluralUnsafe", "[Format][PluralUnsafe]" ) {
+	SECTION( "Regular words" ) {
+		CHECK( Format::PluralUnsafe("car") == "cars" );
+		CHECK( Format::PluralUnsafe("variable") == "variables" );
+		CHECK( Format::PluralUnsafe("ship") == "ships" );
+		CHECK( Format::PluralUnsafe("credit") == "credits" );
+		CHECK( Format::PluralUnsafe("ton") == "tons" );
+		CHECK( Format::PluralUnsafe("action") == "actions" );
+		CHECK( Format::PluralUnsafe("outfit") == "outfits" );
+		CHECK( Format::PluralUnsafe("CapitalizedString") == "CapitalizedStrings" );
+	}
+	SECTION( "Unknown cases" ) {
+		CHECK( Format::PluralUnsafe("Geocoris") == "" );
+		CHECK( Format::PluralUnsafe("boss") == "" );
+		CHECK( Format::PluralUnsafe("quartz") == "" );
+	}
+}
+
+TEST_CASE ( "Format::Noun", "[Format][Noun]" ) {
+	SECTION( "Singular, regular words" ) {
+		CHECK( Format::Noun(1., "car") == "car" );
+		CHECK( Format::Noun(1, "variable") == "variable" );
+	}
+	SECTION( "Singular, regular words with explicit plural form" ) {
+		CHECK( Format::Noun(1., "ship", "ships") == "ship" );
+		CHECK( Format::Noun(1, "credit", "credits") == "credit" );
+	}
+	SECTION( "Plural, regular words without explicit plural form" ) {
+		CHECK( Format::Noun(2., "ton") == "tons" );
+		CHECK( Format::Noun(-1.6, "action") == "actions" );
+	}
+	SECTION( "Plurar, irregular words with explicit plural from" ) {
+		CHECK( Format::Noun(2., "potato", "potatoes") == "potatoes" );
+	}
+}
+
+TEST_CASE ( "Format::NounString", "[Format][NounString]" ) {
+	SECTION( "Singular, regular words" ) {
+		CHECK( Format::NounString(1., "car") == "1 car" );
+		CHECK( Format::NounString(1, "variable") == "1 variable" );
+	}
+	SECTION( "Singular, regular words with explicit plural form" ) {
+		CHECK( Format::NounString(1., "ship", "ships") == "1 ship" );
+		CHECK( Format::NounString(1, "credit", "credits") == "1 credit" );
+	}
+	SECTION( "Plural, regular words without explicit plural form" ) {
+		CHECK( Format::NounString(2., "ton") == "2 tons" );
+		CHECK( Format::NounString(-1.6, "action") == "-1.6 actions" );
+	}
+	SECTION( "Plurar, irregular words with explicit plural from" ) {
+		CHECK( Format::NounString(2., "potato", "potatoes") == "2 potatoes" );
+	}
+}
 // #endregion unit tests
 
 // #region benchmarks
@@ -380,6 +468,17 @@ TEST_CASE( "Benchmark Format::Number", "[!benchmark][format]" ) {
 	};
 	BENCHMARK( "A decimal between 1k and 10k" ) {
 		return Format::Number(5555.5555);
+	};
+}
+TEST_CASE( "Benchmark Format::Plural", "[!benchmark][format]" ) {
+	BENCHMARK( "Regular" ) {
+		return Format::Plural("variable");
+	};
+	BENCHMARK( "Whitelisted irregular" ) {
+		return Format::Plural("mosquito");
+	};
+	BENCHMARK( "Common irregular" ) {
+		return Format::Plural("boss");
 	};
 }
 #endif

--- a/tests/unit/src/text/test_format.cpp
+++ b/tests/unit/src/text/test_format.cpp
@@ -363,6 +363,9 @@ TEST_CASE( "Format::Plural", "[Format][Plural]") {
 		CHECK( Format::Plural("action") == "actions" );
 		CHECK( Format::Plural("outfit") == "outfits" );
 		CHECK( Format::Plural("CapitalizedString") == "CapitalizedStrings" );
+		CHECK( Format::Plural("active escort") == "active escorts" );
+		CHECK( Format::Plural("bunk") == "bunks" );
+		CHECK( Format::Plural("extra crew member") == "extra crew members" );
 	}
 	SECTION( "Ending with -o" ) {
 		CHECK( Format::Plural("volcano") == "volcanos" );


### PR DESCRIPTION
**Feature:** This PR introduces some new formatting methods that can be used to conditionally pluralize (?) stuff. Fixes a couple instances where the code didn't cover edge cases (say, firing a single crew member) in the text messages. Also improves the suggestions for plural names of outfits and ship models.

## Feature Details
#### Format::Plural
Attempts to find a plural name for the specified noun. Uses a much more elaborate algorithm for choosing the plural form, but (naturally) it is still not grammatically correct. I don't know how much of the logic we actually need; tbh this entire thing is only a nice-to-have, and I don't think anyone in their right mind would sit down and write something like this. Now that we have it, however, there is no real maintenance cost and it does provide better suggestions on average, so I don't see why we shouldn't keep at least some of it.
#### Format::PluralUnsafe
The old, 'append -s and hope it works' method, used to maintain compatibility with the auto-generated outfit and ship names. All ships and outfits that had plural names generated without warnings should continue to have the same names - only ones with warnings are changed.
#### Format::Noun
Chooses the singular or plural form based on the quantity.
#### Format::NounString
Same as Format::Noun, but also writes the quantity to the string.

### Formatting changes
This PR is a lot more aggressive about formatting changes than the previous one. Some panels previously always displayed 'bunks' or 'tons' - now they all change dynamically. Some texts using 'a something / x somethings' have been changed to '1 something / x somethings'.

### Automated Tests Added
Added unit tests for the new functions. Okay, a hundred lines of tests might be overkill, whatever.

## Performance Impact
Negligible. The new functions aren't called every frame, only when new text is displayed (and even then, rarely). I also added a new benchmark.
