### PR TITLE
Allow mission clearance to bypass language barriers

### DIFF
--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -126,10 +126,10 @@ HailPanel::HailPanel(PlayerInfo &player, const StellarObject *object)
 		header = gov->GetName() + " " + planet->Noun() + " \"" + planet->Name() + "\":";
 	hasLanguage = (gov->Language().empty() || player.Conditions().Get("language: " + gov->Language()));
 
-	if(!hasLanguage)
-		message = "(An alien voice says something in a language you do not recognize.)";
-	else if(planet && player.Flagship())
-	{
+	// If the player is hailing a planet, determine if a mission grants them clearance before checking
+	// if they have a language that matches the planet's government. This allows mission clearance
+	// to bypass language barriers.
+	if(planet && player.Flagship())
 		for(const Mission &mission : player.Missions())
 			if(mission.HasClearance(planet) && mission.ClearanceMessage() != "auto"
 					&& mission.HasFullClearance())
@@ -138,6 +138,11 @@ HailPanel::HailPanel(PlayerInfo &player, const StellarObject *object)
 				message = mission.ClearanceMessage();
 				return;
 			}
+
+	if(!hasLanguage)
+		message = "(An alien voice says something in a language you do not recognize.)";
+	else if(planet && player.Flagship())
+	{
 		if(planet->CanLand())
 			message = "You are cleared to land, " + player.Flagship()->Name() + ".";
 		else


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue found in https://github.com/endless-sky/endless-sky/pull/6438#issuecomment-1430292571. 

## Fix Details
Moves the clearance check in the HailPanel constructor for hailing planets above the language check. This means that if any mission that the player has grants clearance to the planet being hailed, it doesn't matter if you lack a shared language with the planet.

## Testing Done
I looked at it and thought "Yeah, that looks good."

## Save File
No thanks.