### PR TITLE
fix(typo): Correct automatic aiming preference typo

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -51,7 +51,7 @@ namespace {
 	const int ZOOM_FACTOR_MAX = 200;
 	const int ZOOM_FACTOR_INCREMENT = 10;
 	const string VIEW_ZOOM_FACTOR = "View zoom factor";
-	const string AUTO_AIM_SETTING = "Automatic aimimg";
+	const string AUTO_AIM_SETTING = "Automatic aiming";
 	const string SCREEN_MODE_SETTING = "Screen mode";
 	const string VSYNC_SETTING = "VSync";
 	const string EXPEND_AMMO = "Escorts expend ammo";


### PR DESCRIPTION
Aimimg -> Aiming. Shouldn't cause any preferences to get wiped, since it's only a PreferencesPanel typo.