### PR TITLE
Don't display "Plant2" and "Large Plant2" when targeting those minables

### DIFF
--- a/data/harvesting.txt
+++ b/data/harvesting.txt
@@ -298,6 +298,7 @@ minable "plant"
 	explode "final explosion medium"
 
 minable "plant2"
+	"display name" "Plant"
 	sprite "asteroid/plant2/plant2"
 	hull 2340
 	"random hull" 520
@@ -325,6 +326,7 @@ minable "large plant"
 	explode "final explosion medium"
 
 minable "large plant2"
+	"display name" "Large Plant"
 	sprite "asteroid/large plant2/large plant2"
 	hull 3240
 	"random hull" 720


### PR DESCRIPTION
This gives the "plant2" and "large plant2" minables display names.

<details> <summary>Screenshots</summary>

Before | After
-- | --
![image](https://user-images.githubusercontent.com/20605679/219113501-e28caeaa-e8f3-4ed6-aeb5-34d3333de845.png) | 
![image](https://user-images.githubusercontent.com/20605679/219113849-a1288638-69a3-46a0-a65d-016d9bf4c184.png)
![image](https://user-images.githubusercontent.com/20605679/219113648-d0bce159-680b-453f-b54d-539956593937.png) | 
![image](https://user-images.githubusercontent.com/20605679/219113941-a29d41ec-3629-47ab-b640-26cd8e7786bf.png)

</details>

