### PR TITLE
Add new contributors to the credits

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -146,15 +146,19 @@ contributed to Endless Sky:
   AMDmi3
   anarcat
   Anarchist2
+  Aneutronic
   AraCaputDraco
   Arachi-Lover
+  aradapilot
   a-random-lemurian
   arkhne
   Arrow2thekn33
   ashdnazg
   Aurelite
+  Azure3141
   barthalion
   beccabunny
+  bene-dictator
   benflodge
   BlackVegetable
   Bladewood
@@ -164,21 +168,26 @@ contributed to Endless Sky:
   Brick63
   CAPTAIN1947
   ChamEV
-  colbygallup
   comnom
   corecontingency
   Corraban2
   CyberShadow
   czartrak
+  Daeridanii1
+  daggs1
   DarcyManoel
+  dashkal16
   davidarcher
   davidwhitman
   dazuma
   db47h
   DeBlister
+  Deltaspace0
+  DimlyMoonbeam
   DingusShingleton
   Disiuze
   DJF113
+  doches
   dorbarker
   DownsB
   dplepage
@@ -193,8 +202,10 @@ contributed to Endless Sky:
   elgeonmb
   Eloraam
   Elyssaen
+  Ember369
   EndrosG
   EricFromCanada
+  Faileas
   fakepass
   fcfort
   Ferociousfeind
@@ -202,6 +213,7 @@ contributed to Endless Sky:
   FixItYondu
   flaviojs
   Floppa-Priest
+  FoxSylv
   FranchuFranchu
   Fzzr
   Galaucus
@@ -211,7 +223,11 @@ contributed to Endless Sky:
   Hacklin
   Hadron1776
   har9862
+  Hatrask
   Hecter94
+  heirecka
+  hexarobi
+  hmglasgow
   Hurleveur
   Hyugat
   InfiniteDonuts
@@ -231,12 +247,14 @@ contributed to Endless Sky:
   jozef-mitro
   Jugosloven1612
   Just-Existing
+  justinw1320
   kaol
   Karirawri
+  Kepler-69c
   kestrel1110
-  KevinKorzekwa
   kilobyte
   kkuchta
+  Koranir
   kozbot
   Kryes-Omega
   leklachu
@@ -262,6 +280,7 @@ contributed to Endless Sky:
   MCOfficer
   MessyMix
   michel-slm
+  mike-f1
   MillerNerd
   mimirzero
   mOctave
@@ -275,6 +294,7 @@ contributed to Endless Sky:
   NomadicVolcano
   NRK4
   oo13
+  opusforlife2
   Ornok
   OverYrPaygrade
   pakyinw
@@ -293,9 +313,11 @@ contributed to Endless Sky:
   Pointedstick
   prophile
   pscamman
+  Quantumshark
   quyykk
   Rakete1111
   ravenshining
+  real-dam
   realityforge
   Red-57
   redschalken
@@ -309,6 +331,8 @@ contributed to Endless Sky:
   roadrunner56
   Rob59er
   Rocketeer456
+  rovermicrover
+  rrigby
   rugk
   rzahniser
   salqadri
@@ -322,10 +346,12 @@ contributed to Endless Sky:
   ScruffyKitty
   sdennie
   seanfahey
+  sevu
   sfiera
   shitwolfymakes
   sigus
   skilaa
+  skyegallup
   solardawning
   SolraBizna
   SpearDane
@@ -344,6 +370,7 @@ contributed to Endless Sky:
   TheUnfetteredOne
   thewierdnut
   thomasballinger
+  ThrawnCA
   ThrosturX
   Thunderforge
   tibetiroka
@@ -352,16 +379,20 @@ contributed to Endless Sky:
   TJesionowski
   tmbutterworth
   toilethinges
+  TomGoodIdea
   TotalCaesar659
+  tstanke
   TurkeyMcMac
   Turtleroku
   tux2603
   unjown
+  UnorderedSigh
   Vilhelm16
   vitalchip
   W1zrad
   Waffleship
   Waladil
+  wallphoenix
   warp-core
   waterhouse
   Wedge009
@@ -373,10 +404,11 @@ contributed to Endless Sky:
   wjp
   Wrzlprnft
   YellowApple
-  yobbo2020
   yjhn
+  yobbo2020
   ZBok
   Zitchas
+  zlonghofer
   zwparchman
 
 Special thanks to MCOfficer for


### PR DESCRIPTION
**Feature:**

## Feature Details
Updates the list of contributors in the credits.
Some entries have been removed, these correspond to GitHub account name changes.
Many of the additions are new contributors since the last time the list was updated (in October).
A number of the new entries correspond to much older contributions, but don't have accompanying removals. I'm not sure why.
