### PR TITLE
feat(content): Changing Ibis license requirement Capital to Remnant

### DIFF
--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -806,7 +806,7 @@ ship "Ibis"
 	attributes
 		category "Medium Warship"
 		licenses
-			"Remnant Capital"
+			Remnant
 		"cost" 11627000
 		"shields" 14400
 		"hull" 6200


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Changes the Ibis from requiring a "Remnant Capital" license to a "Remnant" license.

## Reasoning
Based on my experience playing through the game, the Ibis is not particularly useful once the player has a Capital license, as most combat missions will either require a heavier combat capability, or specialized capabilities (such as cloak, gaslining, or large cargo) none of which the Ibis has. As such, it makes for better progression to let players fly a Starling and upgrade to an Ibis (or let people start out straight into the Ibis if they have the resources for it).

This lets the Ibis be a potential fun upgrade from the Starling, instead of a lackluster combat alternative to the Albatross.

## Save File
This save file can be used to play through the new mission content:
Any pilot with a Remnant license.

## Artwork Checklist
 - ~~[X] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
 - ~~[X] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}~~
 - ~~[X] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~

