### PR TITLE
More Likely and Tougher Ember Waste Raids

### DIFF
--- a/data/korath/korath.txt
+++ b/data/korath/korath.txt
@@ -383,7 +383,7 @@ fleet "Korath Ember Waste Large Raid"
 	outfitters "Korath Exiles Remnant Donations"
 	personality
 		disables plunders opportunistic harvests
-	variant 15
+	variant 3
 		"Palavret (Ember)"
 		"'olofez" 2
 	variant 3

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -17987,7 +17987,7 @@ system "Kor Nor'peli"
 	fleet "Korath Defense" 1700
 	fleet "Korath Large Raid" 16000
 	fleet "Korath Ember Waste Raid" 1350
-	fleet "Korath Ember Waste Large Raid" 20000
+	fleet "Korath Ember Waste Large Raid" 2700
 	fleet "Korath Surveillance" 48000
 	fleet "Korath Civilian Large" 2000
 	fleet "Korath Home" 900
@@ -18065,7 +18065,7 @@ system "Kor Tar'bei"
 	fleet "Korath Defense" 2600
 	fleet "Korath Ember Waste Raid" 3050
 	fleet "Korath Surveillance" 50000
-	fleet "Korath Ember Waste Large Raid" 30000
+	fleet "Korath Ember Waste Large Raid" 6000
 	fleet "Korsmanath A'awojs" 900
 	object
 		sprite star/m3


### PR DESCRIPTION
## Summary
The ember wastes large raid is more common, and the fleet itself was reweighted so that while the small ships are still the most common, the worldship spawns are now 3/16 instead of 3/28

-----------------------
**Feature:** This PR implements the feature request detailed and discussed in issue #8390 

## Feature Details
30000 to 6000 frequency, 5x as common.
15 to 3, now the raider is 5x less common

## Testing Done
Did not test, but based on the math the JD 577 WS should appear once every 24 minutes or so 

## Performance Impact
N/A Theoretically slightly higher, as the system, will be marginally more populated
