### PR TITLE
Make Hai Leaks Response 4B invisible and a couple of other things

### DIFF
--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -818,7 +818,7 @@ mission "Hai Leaks Response 4"
 			label end
 			`	"In any event, let's hope a more permanent solution can be devised soon. In the meantime, the local dealers have decided to start selling the Ladybugs again. I hear it's something about a spike in interest among the humans here, so feel free to have a look at them. I shouldn't get too distracted though, I'm sure they'll be waiting for you back on Hai-home."`
 			branch "saved geocoris2"
-				has "00 Hai Leaks Response 4B: declined"
+				has "ship model (all): Geodesic Geocoris"
 			`	With a final nod of thanks he departs to attend to his business, leaving you free to go about your own.`
 				decline
 			label "saved geocoris2"

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -872,12 +872,14 @@ mission "Hai Leaks Response 4A"
 # Success means the Geodesic Geocoris may become available to purchase specially later on. Not less than 2 years later.
 mission "Hai Leaks Response 4B"
 	landing
+	invisible
 	source "Allhome"
 	to offer
 		has "ship model (all): Geodesic Geocoris"
 	on offer
 		log `Successfully rescued the kidnapped Hai and reclaimed the Geocoris. This ship has been modified in ways that aren't of Hai origin, and which don't appear to be fully functional.`
 		event "returned geocoris" 730
+		fail
 
 event "returned geocoris"
 

--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -26,7 +26,6 @@ mission "Hai Reveal [A00] Darkwaste Timer"
 	destination Darkwaste
 	to offer
 		"hai slave prereq" >= 3
-		"combat rating" > 2400
 		has "Hai Leaks Response 6: done"
 	on offer
 		event "hai rescue: teeneep message" 20 30

--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -135,7 +135,7 @@ mission "Hai Reveal [A02] Symbol Identification"
 			`	"No known human or Hai ship technology exhausts these particles. There are some Hai medical microbots that leave behind something similar, but not quite the same, and those are microbots are self-contained for disposal. We believe this is coming from another race's technology."`
 			`	They share a glance with Teeneep, "We have our suspicions but they're not conclusive yet."`
 			branch questions
-				not "00 Hai Leaks Response 4B: declined"
+				not "Hai Leaks Response 4B: offered"
 			`	"We were able to look at the scan of that modified Geocoris you recovered. It has self-repair systems that use technology which could be responsible for something like this, and we suspect they came from the same place."`
 				goto questions
 			label patterns


### PR DESCRIPTION
**Bugfix:**

## Fix Details
* Makes Hai Leaks Response 4B invisible and fail itself so that it doesn't appear in the mission list, destined for Allhome.
* Update some conditions to refer to the proper things.
* Remove the combat rating requirement on the HR4 trigger; I don't see any good reason for it given that we have to have done the FW story to get here, as well as defeat the pirate armada in Waypoint. It is also rather high. I have reached this point with a combat rating of 1017, there is no reason I should now have to go and farm combat rating just to continue this story ~~that's what the Kestrel is for.~~

## Testing Done
Maybe tomorrow.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[warp core~~previous-42.txt](https://github.com/endless-sky/endless-sky/files/10775566/warp.core.previous-42.txt)


