### PR TITLE
add missing goto

### DIFF
--- a/data/bunrodea/bunrodea missions.txt
+++ b/data/bunrodea/bunrodea missions.txt
@@ -152,6 +152,7 @@ mission "First Contact: Bunrodea (Hostile)"
 				`	"Hey, they deserved it. They attacked me first."`
 					goto attacked
 				`	"I have, and for that I apologize."`
+					goto apologize
 				`	"Okay, and?"`
 					goto and
 			


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Fixes a missing goto in First Contact: Bunrodea (Hostile), which caused the Queen to mistakenly accuse you of attacking the Erabu if you apologised for attacking the Guard.
