### PR TITLE
Remove Zenith required reputation when not bombing

### DIFF
--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -2810,8 +2810,6 @@ mission "Wanderers: Sestor Alt: Alnilam 3"
 	to offer
 		has "Wanderers: Sestor Alt: Alnilam 2: done"
 	on offer
-		event "liberated zenith"
-		fail "Wanderers: Sestor Alt: Zenith Patch"
 		conversation
 			`Danforth's troops set up a defensive circle around the entrance to the Alpha base. It appears that they have achieved the element of surprise: the Alphas did not know that the Navy had already located their base, and were probably counting on having a longer time to evacuate. The troop transports were carrying concrete mixers and mining drills; apparently their plan is to seal the Alphas underground and then drill down through the ice and bedrock to bomb and collapse the bunker.`
 			`	As the Navy troops begin pouring the concrete, the massive gate to the tunnel bursts open and more Alphas than you have ever seen in one place come flooding out, several dozen of them. But even these superhuman soldiers cannot survive the concentrated firepower of hundreds of Navy troops. The air fills with explosions and smoke and powdered snow, but as far as you can tell not one of the Alphas escapes alive.`
@@ -2830,8 +2828,7 @@ mission "Wanderers: Sestor Alt: Zenith Patch"
 	landing
 	invisible
 	to offer
-		has "Wanderers: Sestor Alt: Alnilam 3: offered"
-		not "event: liberated zenith"
+		has "Wanderers: Sestor Alt: Alnilam 2: done"
 	on offer
 		event "liberated zenith"
 		fail

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -2796,11 +2796,6 @@ mission "Wanderers: Sestor Alt: Alnilam 2"
 
 
 
-event "liberated zenith"
-	planet "Zenith"
-		bribe .04
-		"required reputation" 0
-
 mission "Wanderers: Sestor Alt: Alnilam 3"
 	landing
 	name "Return to <planet>"
@@ -2823,6 +2818,11 @@ mission "Wanderers: Sestor Alt: Alnilam 3"
 		ship "Cruiser (Mark II)" "R.N.S. Virtue"
 	on visit
 		dialog `You've reached <planet>, but not all of the Navy Cruisers have entered the system yet. Better depart and wait for them to arrive.`
+
+event "liberated zenith"
+	planet "Zenith"
+		bribe .04
+		"required reputation" 0
 
 mission "Wanderers: Sestor Alt: Zenith Patch"
 	landing

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -2797,7 +2797,7 @@ mission "Wanderers: Sestor Alt: Alnilam 2"
 
 
 event "liberated zenith"
-	planet Zenith
+	planet "Zenith"
 		bribe .04
 		"required reputation" 0
 

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -2796,6 +2796,11 @@ mission "Wanderers: Sestor Alt: Alnilam 2"
 
 
 
+event "liberated zenith"
+	planet Zenith
+		bribe .04
+		"required reputation" 0
+
 mission "Wanderers: Sestor Alt: Alnilam 3"
 	landing
 	name "Return to <planet>"

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -2810,6 +2810,8 @@ mission "Wanderers: Sestor Alt: Alnilam 3"
 	to offer
 		has "Wanderers: Sestor Alt: Alnilam 2: done"
 	on offer
+		event "liberated zenith"
+		fail "Wanderers: Sestor Alt: Zenith Patch"
 		conversation
 			`Danforth's troops set up a defensive circle around the entrance to the Alpha base. It appears that they have achieved the element of surprise: the Alphas did not know that the Navy had already located their base, and were probably counting on having a longer time to evacuate. The troop transports were carrying concrete mixers and mining drills; apparently their plan is to seal the Alphas underground and then drill down through the ice and bedrock to bomb and collapse the bunker.`
 			`	As the Navy troops begin pouring the concrete, the massive gate to the tunnel bursts open and more Alphas than you have ever seen in one place come flooding out, several dozen of them. But even these superhuman soldiers cannot survive the concentrated firepower of hundreds of Navy troops. The air fills with explosions and smoke and powdered snow, but as far as you can tell not one of the Alphas escapes alive.`

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -2824,6 +2824,16 @@ mission "Wanderers: Sestor Alt: Alnilam 3"
 	on visit
 		dialog `You've reached <planet>, but not all of the Navy Cruisers have entered the system yet. Better depart and wait for them to arrive.`
 
+mission "Wanderers: Sestor Alt: Zenith Patch"
+	landing
+	invisible
+	to offer
+		has "Wanderers: Sestor Alt: Alnilam 3: offered"
+		not "event: liberated zenith"
+	on offer
+		event "liberated zenith"
+		fail
+
 
 
 mission "Wanderers: Sestor Alt: Return to Wanderers"


### PR DESCRIPTION
**Bugfix:**

Thanks to @Jeva1930#1930 on Discord for reporting this.

## Fix Details
When Alnilam and Zenith are occupied by the Alpha controlled Sestor fleet, the required reputation for Zenith (so, with the Pirate government) is set to 1000, and the option to bribe is disabled.
When Zenith is bombed, the default values (required reputation of 0 and a bribe fraction of 0.04) are restored, but if the player does not bomb Zenith, no such change is made, and so it is not possible to land there without either a mission providing clearance or a reputation with the Pirate government of at least 1000. This doesn't really make sense.

This PR adds an event which reset the required reputation and bribe fraction only and makes use of it upon eliminating the Alphas there with the help of the Navy (after not bombing the place).

## Testing Done
None

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
Not yet:tm:

