### PR TITLE
Make 3 the minimum number of previous saves

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -112,7 +112,7 @@ void Preferences::Load()
 			screenModeIndex = max<int>(0, min<int>(node.Value(1), SCREEN_MODE_SETTINGS.size() - 1));
 		else if(node.Token(0) == "alert indicator")
 			alertIndicatorIndex = max<int>(0, min<int>(node.Value(1), ALERT_INDICATOR_SETTING.size() - 1));
-		else if(node.Token(0) == "previous saves")
+		else if(node.Token(0) == "previous saves" && node.Size() >= 2)
 			previousSaveCount = max<int>(3, node.Value(1));
 		else
 			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -112,14 +112,11 @@ void Preferences::Load()
 			screenModeIndex = max<int>(0, min<int>(node.Value(1), SCREEN_MODE_SETTINGS.size() - 1));
 		else if(node.Token(0) == "alert indicator")
 			alertIndicatorIndex = max<int>(0, min<int>(node.Value(1), ALERT_INDICATOR_SETTING.size() - 1));
-		else if(node.Token(0) == "previous saves" && node.Size() >= 2)
-			previousSaveCount = node.Value(1);
+		else if(node.Token(0) == "previous saves")
+			previousSaveCount = max<int>(3, node.Value(1));
 		else
 			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));
 	}
-
-	if(previousSaveCount < 1)
-		previousSaveCount = 3;
 
 	// For people updating from a version before the visual red alert indicator,
 	// if they have already disabled the warning siren, don't turn the audible alert back on.


### PR DESCRIPTION
**Feature:**

## Feature Details
@quyykk noted that, if a person uses a preferences file the an entry for previous saves on a version of the game without support for that, the value will be set to 1, which is not updated when coming back to a newer version, which could cause issues for anyone moving between versions without remembering to update the value.

Making 3 the minimum means there will never be fewer than the default number of previous saves.
