### PR TITLE
Fix Bunrodea first contact mission display

### DIFF
--- a/data/bunrodea/bunrodea missions.txt
+++ b/data/bunrodea/bunrodea missions.txt
@@ -13,6 +13,8 @@
 
 mission "First Contact: Bunrodea (Hostile)"
 	landing
+	name "An Intriguing Invitation"
+	description "You have received an invitation, or summons, to the marked system by some mantis-like aliens who seem to have been following you around human space."
 	source
 		near "Sol" 0 100
 		not attributes "urban" "station"


### PR DESCRIPTION
**Bugfix:**

Thanks to @Terin and @Quantumshark for reporting this on Discord and a different PR earlier today.

## Fix Details
Gives the mission a name and description.

