### PR TITLE
comments in Personality.h & .cpp warning game will crash at runtime if `PERSONALITY_COUNT` is wrong

### DIFF
--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -25,6 +25,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
+	// Make sure the length of PersonalityTrait matches PERSONALITY_COUNT
+	// or the game will crash at runtime.
 	enum PersonalityTrait {
 		PACIFIST,
 		FORBEARING,

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -95,6 +95,8 @@ private:
 
 
 private:
+	// Make sure this matches the number of items in PersonalityTrait,
+	// or the game will abort at runtime.
 	static const int PERSONALITY_COUNT = 32;
 
 	bool isDefined = false;


### PR DESCRIPTION
**Feature:** To aid in future development, this adds a comment in Personality warning developers to ensure `PERSONALITY_COUNT` matches `PersonalityTrait`

## Feature Details
If the `PERSONALITY_COUNT` is less than the number of elements in `PersonalityTrait`, then `std::bitset` will throw an exception when out-of-bounds personalities are accessed. This *could* be dealt with by putting "if" statements guarding against that everywhere, but I think that's overkill. Instead, I suggest putting in a comment warning about this. Then, everyone will see the comment, and know what they need to do.

There is *nothing wrong* with this aspect of the new Personality class; when you're using an array, you need to make sure the array is large enough. However, this was automatic in the last implementation, and the length has to be synced between two files, so I think we need a comment warning about it.

## Testing Done
Ensured the code still compiled, and checked that the comment was correct by adding a thirty-third trait when `PERSONALITY_COUNT` was 32.

### Automated Tests Added
Simply compiling the code is a sufficient test to ensure comments don't break anything.

## Performance Impact
N/A
