### PR TITLE
feat(balance): Adding a reverse thruster to the Mule's standard loadout

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2690,6 +2690,7 @@ ship "Mule"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
+		"X1100 Ion Reverse Thruster"
 		"Hyperdrive"
 		
 	engine 11 128


### PR DESCRIPTION
## Summary
I noticed the standard Mule has both the weapons and outfit space to receive a X1100 Ion Reverse Thruster. Tested it, and it makes the ship more manoeuvrable for jumps and for landing. Very much worth it for a measly 12k credits.