### PR TITLE
fix: use backticks in Basrem Reverse Thrusters description to allow use of quotes

### DIFF
--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -681,7 +681,7 @@ outfit `"Basrem" Reverse Thruster`
 	"reverse flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"reverse flare sound" "atomic tiny"
-	description "The tiny "Basrem" Reverse Thrusters allow even the smallest of Hai ships additional maneuverability beyond normal steering. Many young Hai find these an invaluable investment when first setting out on their own."
+	description `The tiny "Basrem" Reverse Thrusters allow even the smallest of Hai ships additional maneuverability beyond normal steering. Many young Hai find these an invaluable investment when first setting out on their own.`
 
 outfit `"Benga" Reverse Thruster`
 	category "Engines"


### PR DESCRIPTION
**Bugfix:** 

Basrem Reverse Thrusters description displays incorrectly.

<img width="278" alt="Screenshot 2023-02-20 at 2 41 50 PM" src="https://user-images.githubusercontent.com/1037883/220209036-aae19d83-fa05-4f96-a920-d245cb1eb999.png">


## Fix Details

Just add backticks instead of quote marks in the description

## Testing Done

Just edited the file directly.


