### PR TITLE
Fix plural for Solar Batteries

### DIFF
--- a/data/bunrodea/bunrodea outfits.txt
+++ b/data/bunrodea/bunrodea outfits.txt
@@ -117,6 +117,7 @@ outfit "Large Nanite Fabricator"
 
 
 outfit "Solar Battery"
+	plural "Solar Batteries"
 	category "Power"
 	cost 49000
 	thumbnail "outfit/solar battery"


### PR DESCRIPTION
Adds a plural entry for Bunrodea Solar Batteries.