### PR TITLE
`language: Hai`: Split Wanderer and Hai languages in game data files

### DIFF
--- a/data/hai/hai culture conversations.txt
+++ b/data/hai/hai culture conversations.txt
@@ -82,7 +82,7 @@ mission "The Meme Wars 1"
 		conversation
 			`Stepping into the spaceport you are beset by a riot of color. Every blank surface that's not usually paid advertising space seems to be festooned with dangling holographic projectors, banners, and ribbons. There's even actual paper fliers and posters, apparently taped to whatever surface will bear them. At first you wonder if there's some sort of festival going on, but as you watch a young Hai wearing a hood slaps up another holo projector, creating a cartoonish root vegetable with a sword, which begins hacking at the adjacent hologram, some kind of impressionist concept of a Hai elder made up of iridescent triangles. The young Hai then proceeds to tear down a banner and slap some goo on a massive poster which begins dissolving before a pair of security guards, wearing some very obviously non-standard additions to their uniforms, chase him back out of the spaceport.`
 			branch translator
-				has "language: Wanderer"
+				has "language: Hai"
 			`	As you watch, the triangular elder being holoprojected seems to flicker and then fizzles out as the battery unit fades, apparently under the assault of the root vegetable which appears to do a victory dance, before proceeding to act out something that makes precisely no sense to you.`
 			`	A little further on you encounter two different groups of protesters, assuming that's what they are, weaving in and out of the spaceport's entrances like some kind of conga line. The triangular elder and opposing root vegetable make several reappearances on their placards, some of them holographically animated.`
 			`	A different security guard, this one in regular attire, appears at your elbow. "You look a little lost. Don't worry, it's just a meme war. Carry on with your business and don't touch the meme items and no one should bother you over it."`
@@ -221,7 +221,7 @@ mission "Academy Motto"
 		not attributes "station"
 	to offer
 		random < 1
-		has "language: Wanderer"
+		has "language: Hai"
 	on offer
 		conversation
 			`On this particular day, the spaceport is crowded beyond belief by some arcane confluence of chance and logistics. Despite having resolved the bulk of your business the port authorities have informed you that there is no safe departure slot open for at least seven hours (and even that's not a promise). This leaves you alone to fill in your unexpected bit of time in the early morning.`
@@ -278,7 +278,7 @@ mission "Robotic Musical 1"
 			`Passing down the main thoroughfare of this spaceport you almost ignore a stack of haphazardly piled crates in the median strip. It's not uncommon for recently unloaded crates to temporarily sit in front of different businesses in a port, placed conspicuously out of the way of the flow of foot traffic, but it is the disordered piling that seems out of place.`
 			`	No sooner do you slow your step to give it your attention though, than the pile of crates immediately springs to life.`
 			branch translator
-				has "language: Wanderer"
+				has "language: Hai"
 			`	Music plays and some half dozen robotic caricatures of Hai in exaggerated dress spring forth from various crates and begin to caper about in a series of interactions presumably intended to be comedic, at least judging by how they keep turning away from each other to "look" at the audience and wink. Holoprojected banners and glyphs, presumably advertisement information, flicker through a series of displays as it goes through a cycle before the entire cohort appear to finish up; each onlooker the recipient of some kind of entreaty from at least one robot, before they immediately clamber back into the crates.`
 			`	Throughout this a handful of Hai have stopped to watch, and a couple of them let out small chuckles at the conclusion before continuing on their way. Most of them simply roll their eyes and move on though. One child wanders too close as their parents steer around it and a little red holographic warning sign briefly flashes at them. No one seems keen to explain what you just saw, and for the moment the crates remain resolutely closed.`
 			action

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -295,7 +295,7 @@ mission "Unwanted Cargo"
 			`The "Check Cargo" light for your ship begins blinking when you land, meaning that a cargo crate may have come loose in flight. You shut off the ship's engines and walk to the cargo hold.`
 			`	You check every cargo crate in the hold, but can't find anything wrong. Right as you decide to leave, one of the smaller crates begins rocking back and forth.`
 			branch translator
-				has "language: Wanderer"
+				has "language: Hai"
 				
 			`	You hear a voice come from the crate, but it is not a language you understand. The voice continues to speak, and you recognize it as the Hai language.`
 			choice

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -363,6 +363,7 @@ mission "Visit Wanderers Again"
 		has "human cultural data"
 	on offer
 		set "language: Wanderer"
+		set "language: Hai"
 		event "wanderer technology available"
 		log "Received a device, created by a Hai scientist, which can translate between human language and the Hai language. Since the Wanderers speak the Hai language, that should make it possible to communicate with them directly."
 		conversation "eruk cultural data"
@@ -373,6 +374,20 @@ event "wanderer technology available" # Name unchanged for compatibility
 		"friendly disabled hail" "friendly disabled wanderer"
 		"hostile hail" "hostile wanderer"
 		"hostile disabled hail" "hostile disabled wanderer"
+
+
+
+# Compatibility patch for saves before "language: Hai" variable was added.
+mission "Hai Language Patch"
+	landing
+	invisible
+	source
+	to offer
+		has "Visit Wanderers Again: offered"
+		not "language: Hai"
+	on offer
+		set "language: Hai"
+		fail
 
 
 

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -381,7 +381,6 @@ event "wanderer technology available" # Name unchanged for compatibility
 mission "Hai Language Patch"
 	landing
 	invisible
-	source
 	to offer
 		has "Visit Wanderers Again: offered"
 		not "language: Hai"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Hai Reveal requires the player to *not* know the Hai language, while the Wanderers Campaign requires the player to know the Wanderers language. The opposite is not true: the player does not need to even know the Wanderers exist to play Hai Reveal, and the Wanderers campaign does not need the player to understand the native language of the Hai.

Presently, the game data files do not differentiate between knowledge of the Hai and Wanderers languages since the only device you ever get that can translate, will translate both languages. In a hypothetical future where we can play the Wanderers campaign before Hai Reveal (or at the same time), there must be a way to speak Wanderer, but not Hai.

This PR implements that by adding `language: Hai` in the right places. The mission Visit Wanderers Again gives you both, and there's an invisible patch mission to give you the `language: Hai` if you finished Visit Wanderers Again but didn't get `language: Hai`.

We may need a great many other changes for the Wanderers campaign to be played before Hai Reveal (or at the same time), but this is at least a symbolic, and necessary, first step.

## Save File
This is the mission to get the database to trade for the translator. It happens after Hai Reveal part 6, and works on top of master (as of this writing). You can play with and without these changes, and you'll see the variables in the saves are correct.

[Friction Diction~3026-06-28 get database.txt](https://github.com/endless-sky/endless-sky/files/10788878/Friction.Diction.3026-06-28.get.database.txt)
