### PR TITLE
Fix untranslated hails again

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1340,6 +1340,7 @@ government "Wanderer"
 	color .70 .91 .12
 	"player reputation" 1
 	language "Wanderer"
+	"send untranslated hails"
 	"friendly hail" "wanderer untranslated"
 	"friendly disabled hail" "wanderer untranslated"
 	"hostile hail" "wanderer untranslated"

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -321,6 +321,8 @@ void Government::Load(const DataNode &node)
 		else if(key == "foreign penalties for")
 			for(const DataNode &grand : child)
 				useForeignPenaltiesFor.insert(GameData::Governments().Get(grand.Token(0))->id);
+		else if(key == "send untranslated hails")
+			sendUntranslatedHails = true;
 		else if(!hasValue)
 			child.PrintTrace("Error: Expected key to have a value:");
 		else if(key == "player reputation")
@@ -359,8 +361,6 @@ void Government::Load(const DataNode &node)
 			hostileDisabledHail = GameData::Phrases().Get(child.Token(valueIndex));
 		else if(key == "language")
 			language = child.Token(valueIndex);
-		else if(key == "send untranslated hails")
-			sendUntranslatedHails = true;
 		else if(key == "enforces" && child.Token(valueIndex) == "all")
 		{
 			enforcementZones.clear();

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -180,6 +180,8 @@ void Government::Load(const DataNode &node)
 				hostileDisabledHail = nullptr;
 			else if(key == "language")
 				language.clear();
+			else if(key == "send untranslated hails")
+				sendUntranslatedHails = false;
 			else if(key == "trusted")
 				trusted.clear();
 			else if(key == "enforces")
@@ -357,6 +359,8 @@ void Government::Load(const DataNode &node)
 			hostileDisabledHail = GameData::Phrases().Get(child.Token(valueIndex));
 		else if(key == "language")
 			language = child.Token(valueIndex);
+		else if(key == "send untranslated hails")
+			sendUntranslatedHails = true;
 		else if(key == "enforces" && child.Token(valueIndex) == "all")
 		{
 			enforcementZones.clear();

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -542,6 +542,14 @@ const string &Government::Language() const
 
 
 
+// Find out if this government should send custom hails even if the player does not know its language.
+bool Government::SendUntranslatedHails() const
+{
+	return sendUntranslatedHails;
+}
+
+
+
 // Pirate raids in this government's systems use these fleet definitions. If
 // it is empty, there are no pirate raids.
 // The second attribute denotes the minimal and maximal attraction required for the fleet to appear.

--- a/source/Government.h
+++ b/source/Government.h
@@ -171,6 +171,7 @@ private:
 	const Phrase *hostileHail = nullptr;
 	const Phrase *hostileDisabledHail = nullptr;
 	std::string language;
+	bool sendUntranslatedHails = false;
 	std::vector<RaidFleet> raidFleets;
 	double crewAttack = 1.;
 	double crewDefense = 2.;

--- a/source/Government.h
+++ b/source/Government.h
@@ -105,6 +105,8 @@ public:
 	std::string GetHail(bool isDisabled) const;
 	// Find out if this government speaks a different language.
 	const std::string &Language() const;
+	// Find out if this government should send custom hails even if the player does not know its language.
+	bool SendUntranslatedHails() const;
 	// Pirate raids in this government's systems use these fleet definitions. If
 	// it is empty, there are no pirate raids.
 	// The second attribute denotes the minimal and maximal attraction required for the fleet to appear.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1474,7 +1474,7 @@ bool Ship::CanSendHail(const PlayerInfo &player, bool allowUntranslated) const
 	// Ships that don't share a language with the player shouldn't communicate when hailed directly.
 	// Only random event hails should work, and only if the government explicitly has
 	// untranslated hails. This is ensured by the allowUntranslated argument.
-	if(!allowUntranslated && !gov->Language().empty() && !player.Conditions().Get("language: " + gov->Language()))
+	if(!(allowUntranslated && gov->SendUntranslatedHails()) && !gov->Language().empty() && !player.Conditions().Get("language: " + gov->Language()))
 		return false;
 
 	return true;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1474,7 +1474,8 @@ bool Ship::CanSendHail(const PlayerInfo &player, bool allowUntranslated) const
 	// Ships that don't share a language with the player shouldn't communicate when hailed directly.
 	// Only random event hails should work, and only if the government explicitly has
 	// untranslated hails. This is ensured by the allowUntranslated argument.
-	if(!(allowUntranslated && gov->SendUntranslatedHails()) && !gov->Language().empty() && !player.Conditions().Get("language: " + gov->Language()))
+	if(!(allowUntranslated && gov->SendUntranslatedHails())
+			&& !gov->Language().empty() && !player.Conditions().Get("language: " + gov->Language()))
 		return false;
 
 	return true;


### PR DESCRIPTION
**Bugfix:**

Thanks to @Rob59er and @KimDare75#9315 (on Discord) for reporting this on Discord in relation to the Ka'het and Korath, respectively.

## Fix Details
Governments are given default disabled hails, and now that random interval hails can be sent even if the player doesn't know the government's language (to allow untranslated hails like the Wanderers have), these default disabled hails are used when a.
This changes it so hails from a ship the player does not have the language for are only sent if the government is explicitly set to "send untranslated hails".

## Testing Done
None

# Usage examples
```
government "Whoever"
    "send untranslated hails"

government "Whoever"
    remove "send untranslated hails"
```
