### PR TITLE
Allow running unit tests on Release build in cmake

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -481,6 +481,20 @@
       }
     },
     {
+      "name": "test-release",
+      "hidden": true,
+      "configuration": "Release",
+      "output": {
+        "shortProgress": true,
+        "outputOnFailure": true
+      },
+      "filter": {
+        "include": {
+          "label": "unit"
+        }
+      }
+    },
+    {
       "name": "benchmark",
       "hidden": true,
       "configuration": "Release",
@@ -583,6 +597,12 @@
       "displayName": "Unit Tests",
       "configurePreset": "linux",
       "inherits": "test"
+    },
+    {
+      "name": "linux-test-release",
+      "displayName": "Unit Tests (Release)",
+      "configurePreset": "linux",
+      "inherits": "test-release"
     },
     {
       "name": "linux-benchmark",


### PR DESCRIPTION
**Feature:** `linux-test-release` preset runs unit tests on Release build

## Feature Details
Before I switched from scons to cmake, I used a script that ran the unit tests just before I ran endless-sky. With cmake, I can't do that unless I build in Debug mode, which forces me to build twice. Thus, I have added the `linux-test-release` preset which will run unit tests on the Release executable.

Aside from the convenience of not having to build twice, this also let you confirm the optimizations do not break the unit tests.

## Testing Done
Ran the unit tests on a Release build!

## Performance Impact
N/A
