### PR TITLE
[Content]Repeatable Unfettered Jobs Grant Clearance

### DIFF
--- a/data/hai/unfettered jobs.txt
+++ b/data/hai/unfettered jobs.txt
@@ -26,6 +26,7 @@ mission "Unfettered Tribute 1"
 	name "Hai Tribute to <planet>"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land with the tribute from the other Hai."
 	description "Collect a tribute payment of <tons> of food from <stopovers>, and bring it to the Unfettered on <destination>. Your share of the tribute will be <payment>."
 	to offer
 		has "Unfettered Jump Drive 2: offered"
@@ -49,6 +50,7 @@ mission "Unfettered Tribute 2"
 	name "Hai Tribute to <planet>"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land with the tribute from the other Hai."
 	description "Collect a tribute payment of <tons> of food from <stopovers>, and bring it to the Unfettered on <destination>. Your share of the tribute will be <payment>."
 	to offer
 		has "Unfettered Jump Drive 2: offered"
@@ -72,6 +74,7 @@ mission "Unfettered Tribute 3"
 	name "Hai Tribute to <planet>"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land with the tribute from the other Hai."
 	description "Collect a tribute payment of <tons> of food from <stopovers>, and bring it to the Unfettered on <destination>. Your share of the tribute will be <payment>."
 	to offer
 		has "Unfettered Jump Drive 2: offered"
@@ -188,6 +191,7 @@ phrase "unfettered mining payment dialog"
 mission "Unfettered Silicon Asteroid Mining"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land and deliver the minerals."
 	name "Gather Silicon from asteroids"
 	description "Mine and collect 50 tons of silicon, then bring the minerals to <destination> for <payment>. Silicon is available in the asteroid field of Wah Yoot."
 	source "Darkcloak"
@@ -202,6 +206,7 @@ mission "Unfettered Silicon Asteroid Mining"
 mission "Unfettered Silicon Asteroid Mining 2"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land and deliver the minerals."
 	name "Gather Silicon from asteroids"
 	description "Mine and collect 100 tons of silicon, then bring the minerals to <destination> for <payment>. Silicon is available in the asteroid field in Wah Yoot."
 	source "Darkcloak"
@@ -217,6 +222,7 @@ mission "Unfettered Silicon Asteroid Mining 2"
 mission "Unfettered Silver Asteroid Mining"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land and deliver the minerals."
 	name "Gather Silver from asteroids"
 	description "Mine and collect 15 tons of silver, then bring the minerals back to <destination> for <payment>. Silver is available in the asteroid field in Ehma Ti."
 	source
@@ -233,6 +239,7 @@ mission "Unfettered Silver Asteroid Mining"
 mission "Unfettered Silver Asteroid Mining 2"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land and deliver the minerals."
 	name "Gather Silver from asteroids"
 	description "Mine and collect 30 tons of silver, then bring the minerals to <destination> for <payment>. Silver is available in the asteroid field in Ehma Ti."
 	source
@@ -251,6 +258,7 @@ mission "Unfettered Silver Asteroid Mining 2"
 mission "Unfettered Lead Asteroid Mining"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land and deliver the minerals."
 	name "Gather Lead from asteroids"
 	description "Mine and collect 35 tons of lead, then bring the minerals to <destination> for <payment>. Lead is available in the asteroid field in Wah Yoot."
 	source
@@ -268,6 +276,7 @@ mission "Unfettered Lead Asteroid Mining"
 mission "Unfettered Lead Asteroid Mining 2"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land and deliver the minerals."
 	name "Gather Lead from asteroids"
 	description "Mine and collect 70 tons of lead, then bring the minerals to <destination> for <payment>. Lead is available in the asteroid field in Wah Yoot."
 	source
@@ -298,6 +307,7 @@ phrase "unfettered medicals payment dialog"
 mission "Unfettered Small Medicals Rush"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land with the much needed medical supplies."
 	name "Express medical supplies to <planet>"
 	description "The Unfettered hospitals on <destination> are in urgent need of resupply. Collect <tons> of medical supplies from <stopovers>, and bring it to the Unfettered before <date> for <payment>."
 	deadline 5 1
@@ -323,6 +333,7 @@ mission "Unfettered Small Medicals Rush"
 mission "Unfettered Big Medicals Rush"
 	job
 	repeat
+	clearance "After speaking with the Unfettered and explaining your presence, they give you permission to land with the much needed medical supplies."
 	name "Medical supplies to <planet>"
 	description "The Unfettered hospitals on <destination> are in need of resupply. Collect <tons> of medical supplies from <stopovers>, and bring it to the Unfettered before <date> for <payment>."
 	deadline 10 1


### PR DESCRIPTION
**Content (Jobs)**

## Summary
Repeatable Unfettered jobs grant clearance, to mirror Hai tribute jobs that also do so. This means it is possible to keep landing on Unfettered worlds without bribing the planets while still being hostile with them, as long as you always have a job to complete, which is a better presentation of lore anyway.