### PR TITLE
Fix possible failed truncation

### DIFF
--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -459,7 +459,7 @@ string Font::TruncateBack(const string &str, int &width) const
 		// Loop until the previous width we tried was too long and this one is
 		// too short, or vice versa. Each time, the next string length we try is
 		// interpolated from the previous width.
-		int nextChars = (prevChars * width) / prevWidth;
+		int nextChars = round((double)(prevChars * width) / prevWidth);
 		bool isSame = (nextChars == prevChars);
 		bool prevWorks = (prevWidth <= width);
 		nextChars += (prevWorks ? isSame : -isSame);
@@ -510,7 +510,7 @@ string Font::TruncateFront(const string &str, int &width) const
 		// Loop until the previous width we tried was too long and this one is
 		// too short, or vice versa. Each time, the next string length we try is
 		// interpolated from the previous width.
-		int nextChars = (prevChars * width) / prevWidth;
+		int nextChars = round((double)(prevChars * width) / prevWidth);
 		bool isSame = (nextChars == prevChars);
 		bool prevWorks = (prevWidth <= width);
 		nextChars += (prevWorks ? isSame : -isSame);
@@ -561,7 +561,7 @@ string Font::TruncateMiddle(const string &str, int &width) const
 		// Loop until the previous width we tried was too long and this one is
 		// too short, or vice versa. Each time, the next string length we try is
 		// interpolated from the previous width.
-		int nextChars = (prevChars * width) / prevWidth;
+		int nextChars = round((double)(prevChars * width) / prevWidth);
 		bool isSame = (nextChars == prevChars);
 		bool prevWorks = (prevWidth <= width);
 		nextChars += (prevWorks ? isSame : -isSame);

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -459,7 +459,7 @@ string Font::TruncateBack(const string &str, int &width) const
 		// Loop until the previous width we tried was too long and this one is
 		// too short, or vice versa. Each time, the next string length we try is
 		// interpolated from the previous width.
-		int nextChars = round((double)(prevChars * width) / prevWidth);
+		int nextChars = round(static_cast<double>(prevChars * width) / prevWidth);
 		bool isSame = (nextChars == prevChars);
 		bool prevWorks = (prevWidth <= width);
 		nextChars += (prevWorks ? isSame : -isSame);
@@ -510,7 +510,7 @@ string Font::TruncateFront(const string &str, int &width) const
 		// Loop until the previous width we tried was too long and this one is
 		// too short, or vice versa. Each time, the next string length we try is
 		// interpolated from the previous width.
-		int nextChars = round((double)(prevChars * width) / prevWidth);
+		int nextChars = round(static_cast<double>(prevChars * width) / prevWidth);
 		bool isSame = (nextChars == prevChars);
 		bool prevWorks = (prevWidth <= width);
 		nextChars += (prevWorks ? isSame : -isSame);
@@ -561,7 +561,7 @@ string Font::TruncateMiddle(const string &str, int &width) const
 		// Loop until the previous width we tried was too long and this one is
 		// too short, or vice versa. Each time, the next string length we try is
 		// interpolated from the previous width.
-		int nextChars = round((double)(prevChars * width) / prevWidth);
+		int nextChars = round(static_cast<double>(prevChars * width) / prevWidth);
 		bool isSame = (nextChars == prevChars);
 		bool prevWorks = (prevWidth <= width);
 		nextChars += (prevWorks ? isSame : -isSame);


### PR DESCRIPTION
**Bugfix:**

## Fix Details
It is possible for the truncation algorithm to get stuck switching between two lengths and never terminate correctly (only exiting because of a safety check included for exactly this kind of thing) and is unable to produce truncated text.

I noticed this in the input box of the snapshot save dialog, with the string:
`3020-04-12-Wanderer outfits license acquired`
(Reordering the characters in this string also shows the issue, this exact ordering is not necessary.)

Here, the max width was 209 pixels (220 - 11 for the ellipses.)
It got stuck between 33 characters (216 pixels wide) and 31 characters (196 pixels.)

33 * 209 / 216 = 31.93... -> 31
31 * 209 / 196 = 33.056... -> 33

This PR uses `std::round` instead of just truncating the result of the division.
So, 33 * 209 / 216 = 31.93... -> 32

This is short enough and only one character away from the last checked value, so it is able to terminate correctly and produces truncated text.

I have also applied the same change to the other two truncation methods (middle and back.)

## Testing Done
Tested the problematic string. It is now truncated correctly.

## Save File
N/A

## Screenshots

Before | After
-- | --
![image](https://user-images.githubusercontent.com/20605679/221447734-55be0a06-b0e1-4511-99f0-2d51d589cea1.png) | ![image](https://user-images.githubusercontent.com/20605679/221447796-c5548091-b2c3-42f9-9c76-c07cfd7cc032.png)

