### PR TITLE
feat(mechanics): Add 'planet stopovers' substitution for shorter list

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1358,8 +1358,9 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 		int count = 0;
 		for(const Planet * const &planet : result.stopovers)
 		{
-			if(count++) {
-				string result =  (&planet != last) ? ", " : (count > 2 ? ", and " : " and ");
+			if(count++)
+			{
+				string result = (&planet != last) ? ", " : (count > 2 ? ", and " : " and ");
 				stopovers += result;
 				planets += result;
 			}

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1352,16 +1352,22 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	// Stopovers: "<name> in the <system name> system" with "," and "and".
 	if(!result.stopovers.empty())
 	{
+		string stopovers;
 		string planets;
 		const Planet * const *last = &*--result.stopovers.end();
 		int count = 0;
 		for(const Planet * const &planet : result.stopovers)
 		{
-			if(count++)
-				planets += (&planet != last) ? ", " : (count > 2 ? ", and " : " and ");
-			planets += planet->Name() + " in the " + planet->GetSystem()->Name() + " system";
+			if(count++) {
+				string result =  (&planet != last) ? ", " : (count > 2 ? ", and " : " and ");
+				stopovers += result;
+				planets += result;
+			}
+			stopovers += planet->Name() + " in the " + planet->GetSystem()->Name() + " system";
+			planets += planet->Name();
 		}
-		subs["<stopovers>"] = planets;
+		subs["<stopovers>"] = stopovers;
+		subs["<planet stopovers>"] = planets;
 	}
 	// Waypoints: "<system name>" with "," and "and".
 	if(!result.waypoints.empty())


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4471575/221457255-65189198-c43c-47eb-8a64-7dc7b3685307.png)
(Project Hawking just as a usage example, not intended replacement)

This PR adds the `<planet stopovers>` text substitution, which lists all stopover planets simply by name, rather than with the system name included in each entry. This allows for stopovers to be talked about more casually in conversation, or lets a single stopover be included in a mission title without clipping.