### PR TITLE
feat(content): Adding solar to the Modified Dromedary

### DIFF
--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -290,6 +290,7 @@ ship "Modified Dromedary"
 		"outfit space" 740
 		"weapon capacity" 270
 		"engine capacity" 195
+		"solar collection" 1.1
 		"outfit scan power" 18
 		"outfit scan efficiency" 48
 		"tactical scan power" 39


### PR DESCRIPTION
**Content**

## Summary
Thank you to Cracked Emerald and a few others on Discord who pointed out the discrepancy that the Modified Dromedary has a rather large solar array that is not represented in its stats. This gives it `"solar collection" 1.1`, which is equivalent to a single "KP-6 Photovoltaic Array". These aren't particularly powerful, mostly just a flavor tweak. 

For reference, here's the sprite for the modified Dromedary, where you can see the large array near the back. For the scale, this ship has 2140 hull mass, vs the Bactrian's 940. Slightly shorter, but both wider and taller.

![modified dromedary](https://user-images.githubusercontent.com/32169904/222180728-7b9d8096-91f8-4ac1-875d-75e0a002cb50.png)

## Save File
This save file can be used to play through the new mission content:
{{attach a save file that allows people to easily test your added mission content or see your new in-game art}}

## Artwork Checklist
 - ~~[X] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
 - ~~[X] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}~~
 - ~~[X] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~