### PR TITLE
Fix blurry thumbnail on outfitter selection panel

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -278,7 +278,7 @@ int OutfitterPanel::DrawDetails(const Point &center)
 			? max(thumbnail->Height(), static_cast<float>(TileSize()))
 			: static_cast<float>(TileSize());
 
-		Point thumbnailCenter(center.X(), center.Y() + 20 + tileSize / 2);
+		Point thumbnailCenter(center.X(), center.Y() + 20 + static_cast<int>(tileSize / 2));
 
 		Point startPoint(center.X() - INFOBAR_WIDTH / 2 + 20, center.Y() + 20 + tileSize);
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7424

## Fix Details
Added a `static_cast` so that Y pos of the thumbnail is now an integer.

Tested and works.

## Screenshots
![ui_diff](https://user-images.githubusercontent.com/108272452/222451753-13862159-02fa-4567-b7f7-f597819b836f.png)
