### PR TITLE
feat(enhancement): Make inscrutable on player ships useful

### DIFF
--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -35,6 +35,9 @@ namespace {
 	// Check if the ship evades being cargo scanned.
 	bool EvadesCargoScan(const Ship &ship)
 	{
+		if(ship.Attributes().Get("inscrutable"))
+			return true;
+
 		// Illegal goods can be hidden inside legal goods to avoid detection.
 		const int contraband = ship.Cargo().IllegalCargoAmount();
 		const int netIllegalCargo = contraband - ship.Attributes().Get("scan concealment");
@@ -50,7 +53,8 @@ namespace {
 	// Check if the ship evades being outfit scanned.
 	bool EvadesOutfitScan(const Ship &ship)
 	{
-		return Random::Real() > 1. / (1. + ship.Attributes().Get("scan interference"));
+		return ship.Attributes().Get("inscrutable") ||
+				Random::Real() > 1. / (1. + ship.Attributes().Get("scan interference"));
 	}
 }
 

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -35,9 +35,6 @@ namespace {
 	// Check if the ship evades being cargo scanned.
 	bool EvadesCargoScan(const Ship &ship)
 	{
-		if(ship.Attributes().Get("inscrutable"))
-			return true;
-
 		// Illegal goods can be hidden inside legal goods to avoid detection.
 		const int contraband = ship.Cargo().IllegalCargoAmount();
 		const int netIllegalCargo = contraband - ship.Attributes().Get("scan concealment");

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -50,7 +50,7 @@ namespace {
 	// Check if the ship evades being outfit scanned.
 	bool EvadesOutfitScan(const Ship &ship)
 	{
-		return ship.Attributes().Get("inscrutable") ||
+		return ship.Attributes().Get("inscrutable") > 0. ||
 				Random::Real() > 1. / (1. + ship.Attributes().Get("scan interference"));
 	}
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2745,10 +2745,16 @@ int Ship::Scan(const PlayerInfo &player)
 	{
 		if(result & ShipEvent::SCAN_CARGO)
 			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-					+ Name() + "\" completed its scan of your cargo.", Messages::Importance::High);
+					+ Name() + (target->attributes.Get("inscrutable")
+					? "\" completed its scan of your cargo with no results."
+					: "\" completed its scan of your cargo."),
+					Messages::Importance::High);
 		if(result & ShipEvent::SCAN_OUTFITS)
 			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-					+ Name() + "\" completed its scan of your outfits.", Messages::Importance::High);
+					+ Name() + (target->attributes.Get("inscrutable")
+					? "\" completed its scan of your outfits with no results."
+					: "\" completed its scan of your outfits."),
+					Messages::Importance::High);
 	}
 
 	// Some governments are provoked when a scan is completed on one of their ships.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2746,13 +2746,13 @@ int Ship::Scan(const PlayerInfo &player)
 		if(result & ShipEvent::SCAN_CARGO)
 			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
 					+ Name() + (target->attributes.Get("inscrutable")
-					? "\" completed its scan of your cargo with no results."
+					? "\" completed its scan of your cargo with no useful results."
 					: "\" completed its scan of your cargo."),
 					Messages::Importance::High);
 		if(result & ShipEvent::SCAN_OUTFITS)
 			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
 					+ Name() + (target->attributes.Get("inscrutable")
-					? "\" completed its scan of your outfits with no results."
+					? "\" completed its scan of your outfits with no useful results."
 					: "\" completed its scan of your outfits."),
 					Messages::Importance::High);
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2748,7 +2748,7 @@ int Ship::Scan(const PlayerInfo &player)
 					+ Name() + "\" completed its scan of your cargo.", Messages::Importance::High);
 		if(result & ShipEvent::SCAN_OUTFITS)
 			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-					+ Name() + (target->attributes.Get("inscrutable")
+					+ Name() + (target->attributes.Get("inscrutable") > 0.
 					? "\" completed its scan of your outfits with no useful results."
 					: "\" completed its scan of your outfits."),
 					Messages::Importance::High);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2745,10 +2745,7 @@ int Ship::Scan(const PlayerInfo &player)
 	{
 		if(result & ShipEvent::SCAN_CARGO)
 			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-					+ Name() + (target->attributes.Get("inscrutable")
-					? "\" completed its scan of your cargo with no useful results."
-					: "\" completed its scan of your cargo."),
-					Messages::Importance::High);
+					+ Name() + "\" completed its scan of your cargo.", Messages::Importance::High);
 		if(result & ShipEvent::SCAN_OUTFITS)
 			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
 					+ Name() + (target->attributes.Get("inscrutable")


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #5544
## Feature Details
When a player ship with `inscrutable` attribute gets scanned by an NPC, a special scan message is displayed. Even if the ship has some illegal outfits or cargo, fines aren't applied and stealth missions don't fail.

## Additional notes
While testing this, I saw some scan messages overlapping another messages, leaving some dim letters of the original messages. Not sure what causes such behavior or if it was happening before.