### PR TITLE
Fix integration test warnings: `scan speed` => `scan efficiency`

### DIFF
--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -71,7 +71,7 @@ test-data "quarg rescue save"
 						"heat dissipation" 0.5
 						hull 50000
 						"outfit scan power" 1e+09
-						"outfit scan speed" 1e+09
+						"outfit scan efficiency" 1e+09
 						"energy generation" 10
 						shields 160000
 					fuel 0
@@ -170,7 +170,7 @@ test-data "quarg scanning save"
 						"heat dissipation" 0.5
 						hull 50000
 						"outfit scan power" 1e+09
-						"outfit scan speed" 1e+09
+						"outfit scan efficiency" 1e+09
 						"energy generation" 10
 						shields 160000
 					fuel 0
@@ -270,7 +270,7 @@ test-data "quarg atrocity save"
 						"heat dissipation" 0.5
 						hull 50000
 						"outfit scan power" 1e+09
-						"outfit scan speed" 1e+09
+						"outfit scan efficiency" 1e+09
 						"energy generation" 10
 						shields 160000
 					fuel 0

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_wormhole_navigation.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_wormhole_navigation.txt
@@ -44,7 +44,7 @@ test-data "Wormhole Navigation Save"
 				"gaslining" 1
 				"atmosphere scan" 100
 				"outfit scan power" 175
-				"outfit scan speed" 1
+				"outfit scan efficiency" 1
 				"tactical scan power" 350
 				"force protection" 1
 				"heat protection" 1.5
@@ -161,7 +161,7 @@ test-data "Ember Wastes Navigation Save"
 				"gaslining" 1
 				"atmosphere scan" 100
 				"outfit scan power" 175
-				"outfit scan speed" 1
+				"outfit scan efficiency" 1
 				"tactical scan power" 350
 				"force protection" 1
 				"heat protection" 1.5


### PR DESCRIPTION
**Bugfix:** Changes `scan speed` to `scan efficiency` in integration tests.

## Fix Details
The integration tests use "scan speed" instead of "scan efficiency" in several places, which leads to warnings about using a deprecated feature during the integration tests. This PR updates the attribute name, to get rid of the warnings.

## Testing Done
Manually ran the tests to check that no unexpected warnings were generated.

## Save File
N/A