### PR TITLE
feat(balance): Adding a fuel pod to afterburner Raven

### DIFF
--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -2642,7 +2642,7 @@ ship "Raven" "Raven (Afterburner)"
 		"Heavy Laser" 4
 		"NT-200 Nucleovoltaic"
 		"D41-HY Shield Generator"
-		"Ramscoop"
+		"Fuel Pod"
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -2642,6 +2642,7 @@ ship "Raven" "Raven (Afterburner)"
 		"Heavy Laser" 4
 		"NT-200 Nucleovoltaic"
 		"D41-HY Shield Generator"
+		"Ramscoop"
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"


### PR DESCRIPTION
## Summary
The Raven has an afterburner variant which does not have a ramscoop equipped, but has the leftover space for one! Since equipping a ramscoop means it can get fuel it used back, and it has space leftover for it, there's no reason for it not to have one. 

Probably shouldn't have chosen to be succinct over delving deep into my reasoning for this change. I have explained in detail my reasoning in the comment below, replying to Zitchas. Thank you, Z, for inducing that!

Due to the discussed points listed below, the ramscoop has been replaced for a fuel pod.