### PR TITLE
Customizable capture requirements for ships

### DIFF
--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -88,6 +88,8 @@
 		<Unit filename="source/BoardingPanel.h" />
 		<Unit filename="source/Body.cpp" />
 		<Unit filename="source/Body.h" />
+		<Unit filename="source/CaptureClass.cpp" />
+		<Unit filename="source/CaptureClass.h" />
 		<Unit filename="source/CaptureOdds.cpp" />
 		<Unit filename="source/CaptureOdds.h" />
 		<Unit filename="source/CargoHold.cpp" />

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -896,6 +896,7 @@ interface "boarding"
 		center -40 115
 		dimensions 140 30
 	
+	visible if "!is hijacking"
 	active if "can attack"
 	button a "_Attack"
 		center 120 185
@@ -903,6 +904,17 @@ interface "boarding"
 	
 	active if "can defend"
 	button d "_Defend"
+		center 210 185
+		dimensions 80 30
+	
+	visible if "is hijacking"
+	active if "can attack"
+	button a "Hij_ack"
+		center 120 185
+		dimensions 80 30
+	
+	active if "can defend"
+	button d "With_draw"
 		center 210 185
 		dimensions 80 30
 

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -123,7 +123,10 @@ BoardingPanel::BoardingPanel(PlayerInfo &player, const shared_ptr<Ship> &victim)
 	{
 		// Or may have once been capturable but have since locked down.
 		if(victim->IsLockedDown())
-			messages.push_back("This ship is locked down and be can't captured.");
+		{
+			messages.push_back("This ship is locked down.");
+			messages.push_back("It can't be captured.");
+		}
 		else
 			messages.push_back("This is not a ship that you can capture.");
 	}

--- a/source/BoardingPanel.h
+++ b/source/BoardingPanel.h
@@ -20,10 +20,13 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "CaptureOdds.h"
 
+#include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+class CaptureClass;
 class Outfit;
 class PlayerInfo;
 class Ship;
@@ -58,6 +61,12 @@ private:
 	bool CanCapture() const;
 	// Check if you are in the midst of hand to hand combat.
 	bool CanAttack() const;
+
+	void RunCombat(SDL_Keycode key);
+	bool RunHijacking(SDL_Keycode key);
+	void CaptureVictim();
+
+	double HijackSuccessOdds() const;
 
 	// Handle the keyboard scrolling and selection in the panel list.
 	void DoKeyboardNavigation(const SDL_Keycode key);
@@ -123,10 +132,22 @@ private:
 	bool playerDied = false;
 	bool isCapturing = false;
 	bool isFirstCaptureAction = true;
+	bool isFirstCaptureAttempt = true;
+	bool isHijacking = false;
 	// Calculating the odds of combat success, and the expected casualties, is
 	// non-trivial. So, cache the results for all crew amounts up to full.
 	CaptureOdds attackOdds;
 	CaptureOdds defenseOdds;
+	// The capture classes of the ship being boarded. Stored in a list paired by
+	// the capture class name and the capture class itself. The list is sorted by
+	// an increasing efficiency value from the capture class.
+	std::vector<std::pair<std::string, CaptureClass>> captureRequirements;
+	// The capture classes of the outfits of the boarding ship. Mapping the name
+	// of the capture class to the list of outfits that can be used against that
+	// capture class, paired by a pointer to the outfit being used and its capture
+	// class. Each vector is sorted by a decreasing efficiency value of the capture
+	// class of the outfit.
+	std::map<std::string, std::vector<std::pair<CaptureClass, const Outfit *>>> captureTools;
 	// These messages are shown to report the results of hand to hand combat.
 	std::vector<std::string> messages;
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -74,6 +74,8 @@ target_sources(EndlessSkyLib PRIVATE
 	BoardingPanel.h
 	Body.cpp
 	Body.h
+	CaptureClass.cpp
+	CaptureClass.h
 	CaptureOdds.cpp
 	CaptureOdds.h
 	CargoHold.cpp

--- a/source/CaptureClass.cpp
+++ b/source/CaptureClass.cpp
@@ -1,0 +1,107 @@
+/* CaptureOdds.cpp
+Copyright (c) 2023 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "CaptureClass.h"
+
+#include "DataNode.h"
+#include "DataWriter.h"
+
+#include <algorithm>
+
+using namespace std;
+
+
+CaptureClass::CaptureClass(const DataNode &node)
+{
+	name = node.Token(1);
+
+	for(const DataNode &child : node)
+	{
+		if(child.Size() < 2)
+			child.PrintTrace("Skipping invalid capture class key with no value:");
+		const string &key = child.Token(0);
+		double value = child.Value(1);
+		if(key == "success")
+			successChance = max(0., min(1., value));
+		else if(key == "self destruct")
+			selfDestructChance = max(0., min(1., value));
+		else if(key == "lock down")
+			lockDownChance = max(0., min(1., value));
+		else if(key == "failure break")
+			breakOnSuccessChance = max(0., min(1., value));
+		else if(key == "success break")
+			breakOnFailureChance = max(0., min(1., value));
+		else
+			child.PrintTrace("Skipping unrecognized capture class key:");
+	}
+}
+
+
+
+void CaptureClass::Save(DataWriter &out) const
+{
+	out.Write("capture class", name);
+	out.BeginChild();
+	{
+		out.Write("success", successChance);
+		out.Write("self destruct", selfDestructChance);
+		out.Write("lock down", lockDownChance);
+		out.Write("success break", breakOnSuccessChance);
+		out.Write("failure break", breakOnFailureChance);
+	}
+	out.EndChild();
+}
+
+
+
+const string &CaptureClass::Name() const
+{
+	return name;
+}
+
+
+
+double CaptureClass::SuccessChance() const
+{
+	return successChance;
+}
+
+
+
+double CaptureClass::SelfDestructChance() const
+{
+	return selfDestructChance;
+}
+
+
+
+double CaptureClass::LockDownChance() const
+{
+	return lockDownChance;
+}
+
+
+
+double CaptureClass::BreakOnSuccessChance() const
+{
+	return breakOnSuccessChance;
+}
+
+
+
+double CaptureClass::BreakOnFailureChance() const
+{
+	return breakOnFailureChance;
+}

--- a/source/CaptureClass.h
+++ b/source/CaptureClass.h
@@ -1,0 +1,55 @@
+/* CaptureClass.h
+Copyright (c) 2023 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef CAPTURE_CLASS_H_
+#define CAPTURE_CLASS_H_
+
+#include <string>
+
+class DataNode;
+class DataWriter;
+
+
+
+// A capture class represents the success rate of an outfit in being used to capture
+// a ship, or the ship's success rate in defending against a capture attempt. The
+// outfit and ship must share a capture class of the same name for the outfit to be
+// used on the ship. Capture attempts can also result in the ship self destructing or
+// locking down, or breaking the outfit used.
+class CaptureClass {
+public:
+	CaptureClass(const DataNode &node);
+	void Save(DataWriter &out) const;
+
+	const std::string &Name() const;
+	double SuccessChance() const;
+	double SelfDestructChance() const;
+	double LockDownChance() const;
+	double BreakOnSuccessChance() const;
+	double BreakOnFailureChance() const;
+
+
+private:
+	std::string name;
+	double successChance = 0.;
+	double selfDestructChance = 0.;
+	double lockDownChance = 0.;
+	double breakOnSuccessChance = 0.;
+	double breakOnFailureChance = 0.;
+};
+
+
+
+#endif

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -246,6 +246,8 @@ void Outfit::Load(const DataNode &node)
 			++jumpInSounds[Audio::Get(child.Token(1))];
 		else if(child.Token(0) == "jump out sound" && child.Size() >= 2)
 			++jumpOutSounds[Audio::Get(child.Token(1))];
+		else if(child.Token(0) == "capture class" && child.Size() >= 2)
+			captureClasses.emplace(child.Token(1), child);
 		else if(child.Token(0) == "flotsam sprite" && child.Size() >= 2)
 			flotsamSprite = SpriteSet::Get(child.Token(1));
 		else if(child.Token(0) == "thumbnail" && child.Size() >= 2)
@@ -628,6 +630,14 @@ const map<const Sound *, int> &Outfit::JumpInSounds() const
 const map<const Sound *, int> &Outfit::JumpOutSounds() const
 {
 	return jumpOutSounds;
+}
+
+
+
+// Get this outfit's capture classes, if any.
+const map<string, CaptureClass> &Outfit::CaptureClasses() const
+{
+	return captureClasses;
 }
 
 

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Weapon.h"
 
+#include "CaptureClass.h"
 #include "Dictionary.h"
 
 #include <map>
@@ -95,6 +96,8 @@ public:
 	const std::map<const Sound *, int> &JumpSounds() const;
 	const std::map<const Sound *, int> &JumpInSounds() const;
 	const std::map<const Sound *, int> &JumpOutSounds() const;
+	// Get this outfit's capture classes, if any.
+	const std::map<std::string, CaptureClass> &CaptureClasses() const;
 	// Get the sprite this outfit uses when dumped into space.
 	const Sprite *FlotsamSprite() const;
 
@@ -130,6 +133,7 @@ private:
 	std::map<const Sound *, int> jumpSounds;
 	std::map<const Sound *, int> jumpInSounds;
 	std::map<const Sound *, int> jumpOutSounds;
+	std::map<std::string, CaptureClass> captureClasses;
 	const Sprite *flotsamSprite = nullptr;
 };
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -35,8 +35,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
+class CaptureClass;
 class DamageDealt;
 class DataNode;
 class DataWriter;
@@ -451,6 +453,14 @@ public:
 	std::shared_ptr<Ship> GetParent() const;
 	const std::vector<std::weak_ptr<Ship>> &GetEscorts() const;
 
+	// Tools required to capture this ship, and the tools it has for capturing other ships
+	// of the given capture class names.
+	std::vector<std::pair<std::string, CaptureClass>> CaptureRequirements() const;
+	std::map<std::string, std::vector<std::pair<CaptureClass, const Outfit *>>> CaptureTools(const std::set<std::string> &classNames) const;
+	// Prevent further capture attempts from being made on this ship.
+	void LockDown();
+	bool IsLockedDown() const;
+
 
 private:
 	// Add or remove a ship from this ship's list of escorts.
@@ -513,6 +523,7 @@ private:
 	double steeringDirection = 0.;
 	bool neverDisabled = false;
 	bool isCapturable = true;
+	bool lockedDown = false;
 	bool isInvisible = false;
 	int customSwizzle = -1;
 	double cloak = 0.;


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #2948.

## Feature Details
This PR adds the ability for ships to have requirements in order to be captured, and for specific outfits to be able to meet those requirements. This is done via a new "capture class" attribute of ships and outfits.

This PR only adds the mechanic for this to be possible, and does not implement its use into any ships or new outfits.

### Syntax

* `"capture class" <name>`: The name of the capture class that the ship or outfit is in. When attempting to capture a ship, you must have an outfit with a capture class that matches the ship. If a ship has no capture class, then no outfit is required to capture it. A ship or outfit can have multiple capture classes, allowing one outfit to hijack multiple types of ships, or one ship to be susceptible to multiple types of outfits.

A capture class can have any of the following five children. If any of them is not specified, then a default value of 0 is used. If a ship or outfit has multiple capture classes, then each can be given a different set of children.
* `"success" <odds#>`: A value from 0 to 1 that denotes the odds of success. For the outfit, this means the chance that it successfully hijacks the ship. For the ship, this means the chance is successfully fends off a hijacking attempt. The odds of a successful hijacking are then `(outfit success) * (1 - ship success)`.
* `"self destruct" <odds#>`: A value from 0 to 1 that denotes the odds of the ship self destructing after a failed hijacking attempt. If both the outfit used and the ship have this capture class attribute, then both will roll independently to determine if the ship explodes. That is, the odds of a ship self destructing are `1 - (1 - outfit self destruct) * (1 - ship self destruct)`.
* `"lock down" <odds#>`: A value from 0 to 1 that denotes the odds of the ship locking down after a failed hijacking attempt. A ship which has locked down can no longer have any hijacking attempts made against it. This is a weaker form of self destruct, preventing you from capturing the ship but still allowing you to plunder from it. The game checks if a ship has locked down after checking if the ship has self destructed. As with self destruct, if both the outfit and ship have this attribute then both roll to determine if the ship should lock down.
* `"success break" <odds#>`: A value from 0 to 1 that denotes the odds of the outfit breaking on a successful hijack. An outfit breaking means you lose it, with one outfit of the type used being removed from your flagship. As above, both outfit and ship having this attribute means that both roll.
* `"failure break" <odds#>`: A value from 0 to 1 that denotes the odds of the outfit breaking on a failed hijack. As above, both outfit and ship having this attribute means that both roll.

```
outfit "Crook's Shim"
	"capture class" "low security"
		"success" <#>
		"self destruct" <#>
		"lock down" <#>
		"success break" <#>
		"failure break" <#>

ship "Sparrow"
	attributes
		"capture class" "low security"
			"success" <#>
			"self destruct" <#>
			"lock down" <#>
			"success break" <#>
			"failure break" <#>
```

### Gameplay Behavior
Aside from how each attribute functions as described above, there are some additional gameplay behavioral notes worth making:
* If you lack the tools to capture a ship, then the game won't even let you engage in hand to hand combat and tells you that it's because you lack a tool. I wanted to avoid a scenario where the player boards a ship, wipes out the crew, and only then finds out they can't actually capture it. If a ship requires a tool to capture and you have a matching tool, then the boarding panel lets you know that a tool is required.
* If a ship has multiple capture classes and you have multiple tools for each class, then the game sorts the capture classes of the ship from lowest to highest success rate (i.e. least likely to most likely to resist capture), and then sorts the tool for each capture class by highest to lowest success rate (i.e. most likely to least likely to capture the ship). No other factors such as self destruct, lock down, or break chances are taken into account at the moment. If a tool breaks, then the next best tool by this metric is used. If you run out of tools then no more capture attempts can be made on the ship.
  * Future enhancements could perhaps take more attributes into account, sort by absolute capture chance (e.g. Consider class A on a ship has a 0% defense chance and you have a tool for that class with a 50% success chance. This ship also has class B with a 10% defense chance and you have a tool with a 100% success chance. Your odds of capturing for class A are 50% while your odds of capturing for class B are 90%, but right now since class A is weaker, that attempt is made first.), or in some way give the player the option to choose which tool to use. 
* The odds of your next hijacking attempt succeeding are included in the capture odds stat displayed on the boarding panel, similarly to how the self destruct chance is included. That is, if the tool you are about to use has a 50% chance of succeeding, then the capture odds line will say 50%. This does not take into account how many tools you have (e.g. if you have two tools to use, each with a 50% success rate, then your capture chance is more like 75%) or the chance of your tools breaking (a tool with a success rate of 50% but that never breaks is technically a 100% capture chance) or the ship self destructing or locking down (the aforementioned 50% success rate tool that never breaks would lose capture chance if it also caused the ship to self destruct 10% of the time on failure).
  * Future enhancements could perhaps make the capture odds "more accurate" to your actual chances given repeated capture attempts and all the tools at your disposal. 
  * The above change may not be made, though, if the CaptureOdds class is removed, as has been discussed as a potential course of action in the past (to solve issues like #5811). I did not remove CaptureOdds within this PR due to it being tied up with how the opponent ship decides when to attack or defend, and so I feel that this PR isn't the place to make any changes to CaptureOdds.
* The message written to the boarding panel UI when clicking "Attempt Capture" now changes depending on if this is your first attempt since boarding or not. (Leaving the boarding panel and returning will reset this "first attempt" check.)
* Changed the behavior of the existing `"self destruct"` attribute to only run on the first capture attempt. That is, defending and pulling back then deciding to attempt to capture gain won't be able to cause a self destruct on the second attempt.

## UI Screenshots
<details><summary>Boarding a ship with no capture requirements. Looks the same as before, and killing the crew captures the ship.</summary>

![image](https://user-images.githubusercontent.com/17688683/222987097-d7c98baf-4259-4147-81e7-b7851e5a1af0.png)
![image](https://user-images.githubusercontent.com/17688683/222987113-b59790fb-25f7-4c55-a0cd-aecfc6b277a3.png)
</details>

<details><summary>Boarding a ship with capture requirements where you have the correct tool. You're told that a tool is required, and clearing the crew moves on to a "hijacking" phase of capturing. If you attempt to hijack the ship, you're told what tool was used and the outcome of the attempt. If your tool succeeds then the ship is yours.</summary>

![image](https://user-images.githubusercontent.com/17688683/222987167-fe4f6c50-8b31-4804-ba86-45e919024251.png)
![image](https://user-images.githubusercontent.com/17688683/222987184-f5514ac6-b0a1-44a1-b967-decdd7bb538b.png)
![image](https://user-images.githubusercontent.com/17688683/222987201-9b23d41b-a49c-43a4-8bc6-65cd6af067d1.png)
![image](https://user-images.githubusercontent.com/17688683/222987221-b1b02056-7bf3-45db-a26c-47b9c1e187b6.png)
</details>

<details><summary>If you lack the tools to capture the ship, then you won't be able to engage in hand to hand combat. If you run out of tools, you'll be unable to make more capture attempts unless you return with more tools.</summary>

![image](https://user-images.githubusercontent.com/17688683/222987714-6d017a72-e985-45a4-a4f5-27d7c158b0c5.png)
![image](https://user-images.githubusercontent.com/17688683/222987635-0aefe7c2-27e4-418e-8626-965de0f50f62.png)
</details>

<details><summary>If the ship self destructs then you're kicked out of the boarding panel and met with a dialog.</summary>

![image](https://user-images.githubusercontent.com/17688683/222987248-b35da29f-8d86-4acd-b8f7-6bb4df53d9d2.png)
</details>

<details><summary>If the ship locks down then no more capture attempts can be made. Leaving and returning to the ship, even reloading the save, it will remain uncapturable.</summary>

![image](https://user-images.githubusercontent.com/17688683/222987301-d1de9b97-a835-4ecb-9313-7378c3045820.png)
![image](https://user-images.githubusercontent.com/17688683/222987594-41193de4-1976-416b-b45d-14737cd54ad6.png)
</details>


## Usage Examples

The following could be a way to create a two-tiered capture system for automata ships. Different automata ships could be given different self destruct or lock down rates, or even different success rates if that was desired.
```
outfit "Automata Interface Kit"
	"capture class" "generic automata"
		"success" 0.2
		# No break chance means an interface kit could be used repeatedly.

outfit "Hacked Control Transceiver"
	"capture class" "sestor specific attack"
		"success" 0.85
		# A hack control transceiver would always break when used.
		"failure break" 1
		"success break" 1

ship "Kar Ik Vot 349"
	"capture class" "generic automata"
		# 80% of the time, the interface kit fails. 80% of that time, the ship self destructs.
		# So 16% of the time you get a second chance.
		"self destruct" 0.8
	"capture class" "sestor specific attack"
		# 15% of the time, the hacked control transceiver fails. 50% of that time, the ship self destructs.
		# The remaining 50% of the time, the ship locks down, giving you no second chances, but allowing
		# you to still plunder the ship.
		"self destruct" 0.5
		"lock down" 1
```

## Testing Done
Created a mission with a derelict Headhunter, Aerie, and Cruiser that spawned.
* The Headhunter received no changes. Boarding the Headhunter provided the same behavior as right now; clearing the crew causes the ship to be captured.
* The Aerie was made to require a "Hijacker's Toolkit" outfit to capture. If the player lacks this outfit, the Aerie could not be captured. If the player has the outfit, they're told before engaging in H2H combat that a tool is required. Upon clearing the crew, the player must use the tool to capture the ship. The success chance was not 100%, and so sometimes capturing the ship failed and would need to be attempted again. The toolkit had a chance to break on failure, and so sometimes did. If all toolkits were expended attempting to capture the ship, then the ship could no longer be captured. Outfits that broke were removed from the player's flagship.
* The Cruiser was made to require a "Navy Clearance" outfit to capture. As with the Aerie, not having this outfit prevented capture of the ship, and the crew must have been cleared before attempting to use the clearance outfit. This time, instead of breaking on failure, a failure could result in the Cruiser self destructing or locking down. 25% of the time the ship self destructed, with those times where it didn't self destruct on failure causing it to lock down. A ship which has locked down could no longer be captured. Leaving the boarding panel and returning, the ship still could not be captured. Reloading the save file, the ships could still not be captured.

These were the stats on the outfits tested:
```
outfit "Hijacker's Toolkit"
	"capture class" "human medium warship"
		"success" 0.5
		"success break" 1.0
		"failure break" 0.5

outfit "Navy Clearance"
	"capture class" "navy ship"
		"success" 0.9
		"self destruct" 0.25
		"lock down" 1.0
```

### Automated Tests Added
N/A

## Performance Impact
N/A
