### PR TITLE
Don't treat warnings as errors for release builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,6 +28,7 @@
       },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
         "ES_USE_SYSTEM_LIBRARIES": "OFF"
       },
       "condition": {

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -4,11 +4,11 @@ add_library(EndlessSkyLib STATIC EXCLUDE_FROM_ALL)
 target_include_directories(EndlessSkyLib PUBLIC "${LIBMAD_INCLUDE_DIR}")
 if(MSVC)
 	target_compile_options(EndlessSkyLib PUBLIC "/W3" "/permissive-" "/sdl" "/GR-" "/analyze-"
-		"-Wno-nonportable-include-path" "$<$<CONFIG:Release>:/Gy;/WX;/Oi>")
+		"-Wno-nonportable-include-path" "$<$<CONFIG:Release>:/Gy;/Oi>")
 	target_compile_definitions(EndlessSkyLib PUBLIC "_UNICODE" "UNICODE")
 else()
 	target_compile_options(EndlessSkyLib PUBLIC
-		"-Wall" "-pedantic-errors" "-Wold-style-cast" "-fno-rtti" "$<$<CONFIG:Release>:-Werror>")
+		"-Wall" "-pedantic-errors" "-Wold-style-cast" "-fno-rtti")
 endif()
 
 # The 'mingw32' lib needs to be linked first.


### PR DESCRIPTION
This disables treating warnings as errors for release builds, but CI still treats warnings as errors to avoid introducing warnings to the code base.

The reason for disabling it in release builds is that while developing it can be annoying to have to fix warnings that aren't going to make it in the final result anyways. (For example, commenting some bit of code out for testing that produces a unused variable warning).