### PR TITLE
Add a missing #include, caught by gcc 13

### DIFF
--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef PREFERENCES_H_
 #define PREFERENCES_H_
 
+#include <cstdint>
 #include <string>
 
 


### PR DESCRIPTION
This adds a missing #include, caught by gcc 13. Fixes #8439