### PR TITLE
Don't create the unnecessary static library for faster builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,60 @@ endif()
 
 # Add the library target.
 add_subdirectory(source)
+
+# Create an interface library that contains common libraries for the game and unit tests.
+add_library(ExternalLibraries INTERFACE)
+
+# The 'mingw32' lib needs to be linked first.
+if(MINGW)
+	target_link_libraries(ExternalLibraries INTERFACE mingw32)
+endif()
+
+# Link with the general libraries.
+target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL
+	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
+
+# Link the needed OS-specific dependencies, if any.
+if(WIN32)
+	target_link_libraries(ExternalLibraries INTERFACE rpcrt4 Winmm)
+else()
+	target_link_libraries(ExternalLibraries INTERFACE pthread)
+endif()
+
+# Link with the UUID library, which is different for each OS.
+if(UNIX)
+	if(APPLE)
+		find_library(UUID_LIB NAMES System PATHS /lib /usr/lib /usr/local/lib)
+		find_path(UUID_INCLUDE uuid/uuid.h /usr/local/include /usr/include)
+		target_link_libraries(ExternalLibraries INTERFACE "${UUID_LIB}")
+		target_include_directories(ExternalLibraries INTERFACE "${UUID_INCLUDE}")
+	elseif(ES_USE_SYSTEM_LIBRARIES)
+		find_library(UUID_LIB uuid)
+		target_link_libraries(ExternalLibraries INTERFACE "${UUID_LIB}")
+	else()
+		find_package(unofficial-libuuid CONFIG REQUIRED)
+		target_link_libraries(ExternalLibraries INTERFACE unofficial::UUID::uuid)
+	endif()
+endif()
+
+# Link with OpenGL or OpenGL ES.
+if(ES_GLES)
+	find_package(OpenGL REQUIRED OpenGL EGL)
+	target_link_libraries(ExternalLibraries INTERFACE OpenGL::OpenGL OpenGL::EGL)
+	target_compile_definitions(EndlessSkyLib PUBLIC ES_GLES)
+else()
+	find_package(OpenGL REQUIRED)
+	target_link_libraries(ExternalLibraries INTERFACE OpenGL::GL)
+
+	if(APPLE)
+		# Apple deprecated OpenGL in MacOS 10.14, but we don't care.
+		target_compile_definitions(EndlessSkyLib PUBLIC GL_SILENCE_DEPRECATION)
+	else()
+		# GLEW is only needed on Linux and Windows.
+		target_link_libraries(ExternalLibraries INTERFACE GLEW::GLEW)
+	endif()
+endif()
+
 # Setup for the testing frameworks.
 include(CTest)
 if(BUILD_TESTING)
@@ -152,25 +206,7 @@ else()
 endif()
 
 # Link with the library dependencies.
-target_link_libraries(EndlessSky PRIVATE EndlessSkyLib $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>)
-
-# Link with OpenGL or OpenGL ES.
-if(ES_GLES)
-	find_package(OpenGL REQUIRED OpenGL EGL)
-	target_link_libraries(EndlessSky PRIVATE OpenGL::OpenGL OpenGL::EGL)
-	target_compile_definitions(EndlessSkyLib PUBLIC ES_GLES)
-else()
-	find_package(OpenGL REQUIRED)
-	target_link_libraries(EndlessSky PRIVATE OpenGL::GL)
-
-	if(APPLE)
-		# Apple deprecated OpenGL in MacOS 10.14, but we don't care.
-		target_compile_definitions(EndlessSkyLib PUBLIC GL_SILENCE_DEPRECATION)
-	else()
-		# GLEW is only needed on Linux and Windows.
-		target_link_libraries(EndlessSky PRIVATE GLEW::GLEW)
-	endif()
-endif()
+target_link_libraries(EndlessSky PRIVATE ExternalLibraries $<TARGET_OBJECTS:EndlessSkyLib> $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>)
 
 # Copy the MinGW runtime DLLs if necessary.
 if(MINGW AND WIN32)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(EndlessSkyLib STATIC EXCLUDE_FROM_ALL)
+add_library(EndlessSkyLib OBJECT)
 
 # Set the appropriate compiler flags.
 target_include_directories(EndlessSkyLib PUBLIC "${LIBMAD_INCLUDE_DIR}")
@@ -9,38 +9,6 @@ if(MSVC)
 else()
 	target_compile_options(EndlessSkyLib PUBLIC
 		"-Wall" "-pedantic-errors" "-Wold-style-cast" "-fno-rtti" "$<$<CONFIG:Release>:-Werror>")
-endif()
-
-# The 'mingw32' lib needs to be linked first.
-if(MINGW)
-	target_link_libraries(EndlessSkyLib PUBLIC mingw32)
-endif()
-
-# Link with the general libraries.
-target_link_libraries(EndlessSkyLib PUBLIC SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL
-	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
-
-# Link the needed OS-specific dependencies, if any.
-if(WIN32)
-	target_link_libraries(EndlessSkyLib PUBLIC rpcrt4 Winmm)
-else()
-	target_link_libraries(EndlessSkyLib PUBLIC pthread)
-endif()
-
-# Link with the UUID library, which is different for each OS.
-if(UNIX)
-	if(APPLE)
-		find_library(UUID_LIB NAMES System PATHS /lib /usr/lib /usr/local/lib)
-		find_path(UUID_INCLUDE uuid/uuid.h /usr/local/include /usr/include)
-		target_link_libraries(EndlessSkyLib PUBLIC "${UUID_LIB}")
-		target_include_directories(EndlessSkyLib PUBLIC "${UUID_INCLUDE}")
-	elseif(ES_USE_SYSTEM_LIBRARIES)
-		find_library(UUID_LIB uuid)
-		target_link_libraries(EndlessSkyLib PUBLIC "${UUID_LIB}")
-	else()
-		find_package(unofficial-libuuid CONFIG REQUIRED)
-		target_link_libraries(EndlessSkyLib PUBLIC unofficial::UUID::uuid)
-	endif()
 endif()
 
 # Every source file (and header file) should be listed here, except main.cpp.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,7 +60,7 @@ list(APPEND INTEGRATION_TESTS
 )
 
 target_include_directories(EndlessSkyTests PRIVATE unit/include)
-target_link_libraries(EndlessSkyTests PRIVATE EndlessSkyLib)
+target_link_libraries(EndlessSkyTests PRIVATE ExternalLibraries $<TARGET_OBJECTS:EndlessSkyLib>)
 
 # CTest support for our unit tests.
 add_test(NAME unit COMMAND EndlessSkyTests)


### PR DESCRIPTION
## Features Details

This avoids the creation of the extra static library that is only used to link to the game and the unit tests. This improves build times because it doesn't link an extra library, especially on MinGW where linking is very slow.

## Testing Done

CI will test everything and verify that everything still builds correctly.