### PR TITLE
Run CI workflow when CMake files have been edited

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
     - 'data/**'
     - 'tests/**'
     - '.github/workflows/**'
+    - 'CMakeLists.txt'
+    - 'CMakePresets.json'
     - keys.txt
   pull_request:
     # Run for any push to any pull request, if it modifies source code or game text.
@@ -21,6 +23,8 @@ on:
     - 'data/**'
     - 'tests/**'
     - '.github/workflows/**'
+    - 'CMakeLists.txt'
+    - 'CMakePresets.json'
     - keys.txt
 
 


### PR DESCRIPTION
This makes the CI workflow trigger when changing CMake files that are in the root directory, i.e. not caught by the `source/**` and `tests/**` filters.