### PR TITLE
Adjust Active Cooling Mechanic

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2463,8 +2463,8 @@ void Ship::DoGeneration()
 		double activeCooling = coolingEfficiency * attributes.Get("active cooling");
 		if(activeCooling > 0. && heat > 0. && energy >= 0.)
 		{
-			// Although it's a misuse of this feature, handle the case where
-			// "active cooling" does not require any energy.
+			// Handle the case where "active cooling"
+			// does not require any energy.
 			double coolingEnergy = attributes.Get("cooling energy");
 			if(coolingEnergy)
 			{
@@ -2473,7 +2473,7 @@ void Ship::DoGeneration()
 				energy -= spentEnergy;
 			}
 			else
-				heat -= activeCooling;
+				heat -= activeCooling * min(1., Heat());
 		}
 	}
 


### PR DESCRIPTION
Azure recently made me aware of the obscure fact that active cooling with zero cooling energy causes active cooling to run at full blast at all times, rather than scaled with heat as a percentage of maximum. So, if this was a cooling outfit which used no energy, realistically you would want it to run at full blast, yes. But honestly if this was a cooling outfit which used no energy, it should be using `cooling`, rather than `active cooling`. We have `active cooling` for its specific behavior scaling with heat.

So, I've adjusted the case where there is no cooling energy, to be more consistent with behavior when there is cooling energy.