### PR TITLE
Bugfix: Do not rely on preference for mouse hold

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3837,7 +3837,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 			&& (!target || target->GetGovernment()->IsEnemy()))
 		AutoFire(ship, firingCommands, false);
 
-	const bool mouseTurning = Preferences::Has("alt-mouse turning");
+	const bool mouseTurning = activeCommands.Has(Command::MOUSE_TURNING_HOLD);
 	if(mouseTurning && !ship.IsBoarding() && !ship.IsReversing())
 		command.SetTurn(TurnToward(ship, mousePosition, 0.9999));
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2054,8 +2054,7 @@ void Engine::HandleMouseInput(Command &activeCommands)
 	isMouseTurningEnabled = (isMouseHoldEnabled ^ isMouseToggleEnabled);
 	if(!isMouseTurningEnabled)
 		return;
-	if(!activeCommands.Has(Command::MOUSE_TURNING_HOLD))
-		activeCommands.Set(Command::MOUSE_TURNING_HOLD);
+	activeCommands.Set(Command::MOUSE_TURNING_HOLD);
 	bool rightMouseButtonHeld = false;
 	int mousePosX;
 	int mousePosY;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -242,6 +242,7 @@ namespace {
 
 Engine::Engine(PlayerInfo &player)
 	: player(player), ai(ships, asteroids.Minables(), flotsam),
+	isMouseToggleEnabled(Preferences::Has("alt-mouse turning")),
 	ammoDisplay(player), shipCollisions(256u, 32u)
 {
 	zoom = Preferences::ViewZoom();
@@ -2046,7 +2047,7 @@ void Engine::HandleMouseInput(Command &activeCommands)
 	if(activeCommands.Has(Command::MOUSE_TURNING_TOGGLE))
 	{
 		isMouseToggleEnabled = !isMouseToggleEnabled;
-		Preferences::Set("alt-mouse turning", isMouseTurningEnabled);
+		Preferences::Set("alt-mouse turning", isMouseToggleEnabled);
 	}
 	// XOR mouse hold and mouse toggle. If mouse toggle is OFF, then mouse hold
 	// will temporarily turn ON mouse control. If mouse toggle is ON, then mouse

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1387,8 +1387,6 @@ void Engine::CalculateStep()
 		return;
 
 	// Handle the mouse input of the mouse navigation
-	if(Preferences::Has("alt-mouse turning") && !isMouseTurningEnabled)
-		activeCommands.Set(Command::MOUSE_TURNING_TOGGLE);
 	HandleMouseInput(activeCommands);
 	// Now, all the ships must decide what they are doing next.
 	ai.Step(player, activeCommands);
@@ -2046,14 +2044,18 @@ void Engine::HandleMouseInput(Command &activeCommands)
 {
 	isMouseHoldEnabled = activeCommands.Has(Command::MOUSE_TURNING_HOLD);
 	if(activeCommands.Has(Command::MOUSE_TURNING_TOGGLE))
+	{
 		isMouseToggleEnabled = !isMouseToggleEnabled;
+		Preferences::Set("alt-mouse turning", isMouseTurningEnabled);
+	}
 	// XOR mouse hold and mouse toggle. If mouse toggle is OFF, then mouse hold
 	// will temporarily turn ON mouse control. If mouse toggle is ON, then mouse
 	// hold will temporarily turn OFF mouse control.
 	isMouseTurningEnabled = (isMouseHoldEnabled ^ isMouseToggleEnabled);
-	Preferences::Set("alt-mouse turning", isMouseTurningEnabled);
 	if(!isMouseTurningEnabled)
 		return;
+	if(!activeCommands.Has(Command::MOUSE_TURNING_HOLD))
+		activeCommands.Set(Command::MOUSE_TURNING_HOLD);
 	bool rightMouseButtonHeld = false;
 	int mousePosX;
 	int mousePosY;


### PR DESCRIPTION
Fix details
-------

Using left alt (mouse control hold) would toggle the preference.  If the player exited the game with alt+f4, then the next time the game launches the mouse control would be toggled in the opposite state.

Due to alt+f4, mouse-hold would act like mouse toggle and exit to save the preference.

AI now relies on active commands instead of reading the preference.

Related Issues
-------------

Partially fixes:

* #8419

Testing Done
------------

- [x] Verified left alt (mouse hold) and right alt (mouse toggle) continue to work normally.
- [x] alt+f4 exits the game but does not cause mouse control toggle.

Performance Impact
------------------

None