### PR TITLE
Give the wanderers non-default crew attack and defence stats

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1337,6 +1337,8 @@ government "Ember Waste"
 
 government "Wanderer"
 	swizzle 2
+	"crew attack" 1.4
+	"crew defense" 1.8
 	color .70 .91 .12
 	"player reputation" 1
 	language "Wanderer"


### PR DESCRIPTION
**Content**

## Summary
It has been noted many times in various places that the Wanderers' talons (as mentioned in their first contact mission -  `They do not appear to be armed, but their talons are eight or nine centimeters long.`) should give them an advantage in hand-to-hand combat compared to humans.
At the same time, the Wanderers are birdlike and flying, so it is likely that they share the hollow bones of earth birds, a necessary adaptation to reduce weight enough to allow flight. I think it is reasonable for this to translate to a defensive weakness, as blunt force trauma and shockwaves from explosives would be far more damaging to their hollow bones.
Based on this, the stats given here are 1.4 attack and 1.8 defence, as compared to the default 1 attack and 2 defence that they
currently have.
This will make their ships slightly easier to capture overall, but since they already have low crew counts and no hand-to-hand weapons they're already extremely easy to capture, the only limit being that there's no way to get the ships out of wanderer space once they're captured.
So, overall this should serve as a neat little flavour change without causing issues for the game balance.