### PR TITLE
Bug fix: harvesters get stuck trying to harvest the same flotsam over and over without success

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2651,7 +2651,7 @@ bool AI::DoHarvesting(Ship &ship, Command &command)
 {
 	// If the ship has no target to pick up, do nothing.
 	shared_ptr<Flotsam> target = ship.GetTargetFlotsam();
-	if(target && ship.Cargo().Free() < target->UnitSize())
+	if(target && !ship.CanPickUp(*target))
 	{
 		target.reset();
 		ship.SetTargetFlotsam(target);
@@ -2666,7 +2666,7 @@ bool AI::DoHarvesting(Ship &ship, Command &command)
 		double bestTime = 600.;
 		for(const shared_ptr<Flotsam> &it : flotsam)
 		{
-			if(ship.Cargo().Free() < it->UnitSize())
+			if(!ship.CanPickUp(*it))
 				continue;
 			// Only pick up flotsam that is nearby and that you are facing toward.
 			Point p = it->Position() - ship.Position();

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2229,8 +2229,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 	for(Body *body : shipCollisions.Circle(flotsam.Position(), 5.))
 	{
 		Ship *ship = reinterpret_cast<Ship *>(body);
-		if(!ship->CannotAct() && ship != flotsam.Source() && ship->GetGovernment() != flotsam.SourceGovernment()
-			&& ship->Cargo().Free() >= flotsam.UnitSize())
+		if(!ship->CannotAct() && ship->CanPickUp(flotsam))
 		{
 			collector = ship;
 			break;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4213,6 +4213,15 @@ void Ship::SetParent(const shared_ptr<Ship> &ship)
 
 
 
+bool Ship::CanPickUp(const Flotsam &flotsam) const
+{
+	return this != flotsam.Source()
+		&& (government != flotsam.SourceGovernment() || personality.Harvests())
+		&& cargo.Free() >= flotsam.UnitSize();
+}
+
+
+
 shared_ptr<Ship> Ship::GetParent() const
 {
 	return parent.lock();

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -444,6 +444,8 @@ public:
 	void SetTargetAsteroid(const std::shared_ptr<Minable> &asteroid);
 	void SetTargetFlotsam(const std::shared_ptr<Flotsam> &flotsam);
 
+	bool CanPickUp(const Flotsam &flotsam) const;
+
 	// Manage escorts. When you set this ship's parent, it will automatically
 	// register itself as an escort of that ship, and unregister itself from any
 	// previous parent it had.


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #6476

## Fix Details
The conditions for picking up flotsam did not match the conditions for choosing a flotsam as a target. This caused ships to fly back and forth trying to pick up the same flotsam. One common cause is when a ship explodes, and another ship with the same government tries to pick up the flotsam. Another is if a ship panics, and dumps its cargo, and then another ship from that government wants to pick it up.

This fix moves the conditions to `Ship::CanPickUp(const Flotsam &)` so they're consistent, and it adjusts the logic to be a compromise between the two original sets of conditions:

1. Flotsam must fit in the cargo hold.
2. It did not come from the ship itself.
3. Either the ship has the `harvests` personality, or it is not of the same government as the flotsam.

## Testing Done
Spent a lot of time in Mora, seeing if ships could pick up flotsam, and wouldn't pick invalid flotsam.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 3b64a086d, and will not occur when using this branch's build.

1. Use [Cargo Bug.txt](https://github.com/endless-sky/endless-sky/files/10938264/Cargo.Bug.txt), and fly to Mora. Stay there a while, and you'll see ships pick up flotsam. 
2. #6476 has a test save too