### PR TITLE
Tweaks to paradise jobs on pirate worlds

### DIFF
--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -512,14 +512,13 @@ mission "Paradise Job: Pirate Retirees (Illegal)"
 	illegal 15000 `In addition to the fine, the "retirees" and their posessions are removed from your ship.`
 	stealth
 	to offer
-		random < 100
+		random < 5
 		"passenger space" > 15
 		"cargo space" > 40
 	to accept
 		has "outfit: Luxury Accommodations"
 	source
 		government "Pirate"
-		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest" "urban"
 	destination
 		distance 3 16
 		attributes "paradise"
@@ -538,14 +537,13 @@ mission "Paradise Job: Pirate Retirees (Legal)"
 	passengers 4 10 .6
 	stealth
 	to offer
-		random < 100
+		random < 5
 		"passenger space" > 15
 		"cargo space" > 40
 	to accept
 		has "outfit: Luxury Accommodations"
 	source
 		government "Pirate"
-		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest" "urban"
 	destination
 		distance 3 16
 		attributes "paradise"

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -439,6 +439,7 @@ mission "Paradise Job: Parolees"
 	to accept
 		has "outfit: Brig"
 	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "mining" "fishing" "textiles" "factory" "farming" "oil"
 	destination
 		distance 2 18
@@ -511,7 +512,7 @@ mission "Paradise Job: Pirate Retirees (Illegal)"
 	illegal 15000 `In addition to the fine, the "retirees" and their posessions are removed from your ship.`
 	stealth
 	to offer
-		random < 5
+		random < 100
 		"passenger space" > 15
 		"cargo space" > 40
 	to accept
@@ -537,7 +538,7 @@ mission "Paradise Job: Pirate Retirees (Legal)"
 	passengers 4 10 .6
 	stealth
 	to offer
-		random < 5
+		random < 100
 		"passenger space" > 15
 		"cargo space" > 40
 	to accept

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -509,7 +509,7 @@ mission "Paradise Job: Pirate Retirees (Illegal)"
 	description `This coterie of <bunks> wealthy "retirees" is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions.`
 	passengers 4 10 .6
 	cargo "treasured possessions" 4 10 .2
-	illegal 15000 `In addition to the fine, the "retirees" and their possessions are removed from your ship.`
+	illegal 15000 `After scanning your ship, law enforcement notifies you. Apparently the "retirees" you've been carting around are secretly wanted individuals. After taking boarding your ship, they arrest the so-called retirees and search through their "treasured posessions," which are innocent enough, besides being obtained illegally. In the end, they confiscate the posessions and take away the criminals, leaving you with a small fine and a black mark on your record that isn't going to help your reputation.`
 	stealth
 	to offer
 		random < 5
@@ -535,7 +535,7 @@ mission "Paradise Job: Pirate Retirees (Legal)"
 	repeat
 	description `This coterie of <bunks> wealthy "retirees" is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions.`
 	passengers 4 10 .6
-	stealth
+	cargo "treasured possessions" 4 10 .2
 	to offer
 		random < 5
 		"passenger space" > 15

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -509,7 +509,7 @@ mission "Paradise Job: Pirate Retirees (Illegal)"
 	description `This coterie of <bunks> wealthy "retirees" is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions.`
 	passengers 4 10 .6
 	cargo "treasured possessions" 4 10 .2
-	illegal 15000 `After scanning your ship, law enforcement notifies you. Apparently the "retirees" you've been carting around are secretly wanted individuals. After taking boarding your ship, they arrest the so-called retirees and search through their "treasured posessions," which are innocent enough, besides being obtained illegally. In the end, they confiscate the posessions and take away the criminals, leaving you with a small fine and a black mark on your record that isn't going to help your reputation.`
+	illegal 15000 `After scanning your ship, law enforcement notifies you. Apparently the "retirees" you've been carting around are secretly wanted individuals. After taking boarding your ship, they arrest the so-called retirees and search through their "treasured possessions," which are innocent enough, besides being obtained illegally. In the end, they confiscate the possessions and take away the criminals, leaving you with a small fine and a black mark on your record that isn't going to help your reputation.`
 	stealth
 	to offer
 		random < 5

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -509,7 +509,7 @@ mission "Paradise Job: Pirate Retirees (Illegal)"
 	description `This coterie of <bunks> wealthy "retirees" is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions.`
 	passengers 4 10 .6
 	cargo "treasured possessions" 4 10 .2
-	illegal 15000 `After scanning your ship, law enforcement notifies you. Apparently the "retirees" you've been carting around are secretly wanted individuals. After taking boarding your ship, they arrest the so-called retirees and search through their "treasured possessions," which are innocent enough, besides being obtained illegally. In the end, they confiscate the possessions and take away the criminals, leaving you with a small fine and a black mark on your record that isn't going to help your reputation.`
+	illegal 15000 `After scanning your ship, law enforcement notifies you. Apparently the "retirees" you've been carting around are secretly wanted individuals. After taking boarding your ship, they arrest the so-called retirees and search through their "treasured possessions," which are innocent enough, besides being obtained illegally. In the end, they confiscate the possessions and take away the criminals, leaving you with a small fine.`
 	stealth
 	to offer
 		random < 5

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -509,7 +509,7 @@ mission "Paradise Job: Pirate Retirees (Illegal)"
 	description "This coterie of <bunks> wealthy retirees is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions."
 	passengers 4 10 .6
 	cargo "treasured possessions" 4 10 .2
-	illegal 15000 `In addition to the fine, the "retirees" and their posessions are removed from your ship.`
+	illegal 15000 `In addition to the fine, the "retirees" and their possessions are removed from your ship.`
 	stealth
 	to offer
 		random < 5

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -506,7 +506,7 @@ mission "Paradise Job: Pirate Retirees (Illegal)"
 	name "Wealthy retirees to <planet>"
 	job
 	repeat
-	description "This coterie of <bunks> wealthy retirees is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions."
+	description `This coterie of <bunks> wealthy "retirees" is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions.`
 	passengers 4 10 .6
 	cargo "treasured possessions" 4 10 .2
 	illegal 15000 `In addition to the fine, the "retirees" and their possessions are removed from your ship.`
@@ -526,14 +526,14 @@ mission "Paradise Job: Pirate Retirees (Illegal)"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 15000 300
-		dialog "You bid goodbye to the retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite and full of highly amusing, though often morally questionable, anecdotes. Once the last of their belongings have been safely unloaded your accounts receive the payment of <payment> from an anyonymous source."
+		dialog "You bid goodbye to the self-proclaimed retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite, if raucous, and full of highly amusing, though often morally questionable, anecdotes. Once the last of their belongings have been safely unloaded your accounts receive the payment of <payment> from an anyonymous source."
 
 
 mission "Paradise Job: Pirate Retirees (Legal)"
 	name "Wealthy retirees to <planet>"
 	job
 	repeat
-	description "This coterie of <bunks> wealthy retirees is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions."
+	description `This coterie of <bunks> wealthy "retirees" is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions.`
 	passengers 4 10 .6
 	stealth
 	to offer
@@ -551,7 +551,7 @@ mission "Paradise Job: Pirate Retirees (Legal)"
 		dialog phrase "generic passenger on visit"
 	on complete
 		payment 10000 200
-		dialog "You bid goodbye to the retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite and full of highly amusing, though often morally questionable, anecdotes. Once the last of their belongings have been safely unloaded your accounts receive the payment of <payment> from an anyonymous source."
+		dialog "You bid goodbye to the self-proclaimed retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite, if raucous, and full of highly amusing, though often morally questionable, anecdotes. Once the last of their belongings have been safely unloaded your accounts receive the payment of <payment> from an anyonymous source."
 
 
 mission "Paradise Job: Wilderness Retreat"

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -489,6 +489,7 @@ mission "Paradise Job: Retirees"
 	to accept
 		has "outfit: Luxury Accommodations"
 	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest" "urban"
 	destination
 		distance 3 16
@@ -498,6 +499,60 @@ mission "Paradise Job: Retirees"
 	on complete
 		payment 10000 200
 		dialog "You bid goodbye to the retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite and full of highly amusing, though often morally questionable, anecdotes. Once the last of their belongings have been safely unloaded your accounts receive the payment of <payment> from their travel broker."
+
+
+mission "Paradise Job: Pirate Retirees (Illegal)"
+	name "Wealthy retirees to <planet>"
+	job
+	repeat
+	description "This coterie of <bunks> wealthy retirees is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions."
+	passengers 4 10 .6
+	cargo "treasured possessions" 4 10 .2
+	illegal 15000 `In addition to the fine, the "retirees" and their posessions are removed from your ship.`
+	stealth
+	to offer
+		random < 5
+		"passenger space" > 15
+		"cargo space" > 40
+	to accept
+		has "outfit: Luxury Accommodations"
+	source
+		government "Pirate"
+		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest" "urban"
+	destination
+		distance 3 16
+		attributes "paradise"
+	on visit
+		dialog phrase "generic passenger on visit"
+	on complete
+		payment 15000 300
+		dialog "You bid goodbye to the retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite and full of highly amusing, though often morally questionable, anecdotes. Once the last of their belongings have been safely unloaded your accounts receive the payment of <payment> from an anyonymous source."
+
+
+mission "Paradise Job: Pirate Retirees (Legal)"
+	name "Wealthy retirees to <planet>"
+	job
+	repeat
+	description "This coterie of <bunks> wealthy retirees is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions."
+	passengers 4 10 .6
+	stealth
+	to offer
+		random < 5
+		"passenger space" > 15
+		"cargo space" > 40
+	to accept
+		has "outfit: Luxury Accommodations"
+	source
+		government "Pirate"
+		attributes "frontier" "dirt belt" "south" "farming" "mining" "rim" "forest" "urban"
+	destination
+		distance 3 16
+		attributes "paradise"
+	on visit
+		dialog phrase "generic passenger on visit"
+	on complete
+		payment 10000 200
+		dialog "You bid goodbye to the retirees, who were somewhat prone to spilling drinks or irritating you whilst attempting to do work. They were otherwise extremely polite and full of highly amusing, though often morally questionable, anecdotes. Once the last of their belongings have been safely unloaded your accounts receive the payment of <payment> from an anyonymous source."
 
 
 mission "Paradise Job: Wilderness Retreat"
@@ -512,6 +567,7 @@ mission "Paradise Job: Wilderness Retreat"
 	to accept
 		has "outfit: Luxury Accommodations"
 	source
+		government "Republic" "Free Worlds" "Syndicate" "Neutral"
 		attributes "urban" "near earth" "core" "paradise"
 	destination
 		distance 6 20


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue raised [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1085268056311337040).

## Fix Details
I've blocked the paradise wilderness retreat job and the parolee job from offering on pirate planets. In addition, I have split the "Paradise Job: Wealthy Retirees" into three jobs: one which doesn't offer on pirate worlds, one which does but you won't get fined for, and one which does and is illegal. The pirate world versions are noticeably more shady, but generally follow the same lines as the original.

## Testing Done
I've tested the new jobs, and haven't seen the old jobs where they shouldn't be. For some reason, I'm not getting caught with the illegal pirates though, although the syntax looks fine to me and no errors or warnings are on the console.

## Save File
This save file can be used to take the new jobs (available on job board).
[Atlantian Cruise.txt](https://github.com/endless-sky/endless-sky/files/10972812/Atlantian.Cruise.txt)
