### PR TITLE
fix(typo): Remove duplicate backtick in a tooltip definition

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -381,7 +381,7 @@ tip "outfit scan power:"
 	`The range of this outfit scanner is proportional to the square root of this value.`
 
 tip "outfit scan speed:"
-	``Determines how long it takes to perform an outfit scan. A higher value will correspond to a quicker scan.`
+	`Determines how long it takes to perform an outfit scan. A higher value will correspond to a quicker scan.`
 
 tip "outfit scan efficiency:"
 	`The maximum speed of this outfit scanner is proportional to the square root of this value. The observed scan speed will be impacted by multiple factors. Targets which are farther away or have a larger outfit capacity will take longer to scan.`


### PR DESCRIPTION
**Bugfix:**

## Fix Details
This extra backtick shouldn't be here.
Though, I'm not sure it's possible to have the `outfit scan speed` attribute appear in game anymore, so the tooltip might be entirely unnecessary now.
