### PR TITLE
Fix puny

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -370,7 +370,7 @@ mission "Pookie, Part 5"
 			label lazy
 			action
 				log `Saved a dog from a hound-racing ring, and tried to give her a home. However, her alleged owner rejected her. Eventually decided to keep her.`
-				outfit `"Puny"`
+				outfit "Puny"
 			`	You lean back in your seat as the taxi passes through the town without interruption. Not long after you find yourself back in the spaceport, with Puny still in your care. With nowhere else to go, you decide to bring Puny aboard your ship. As you lead her, she happily strolls up the landing ramp and settles into one of your bunks.`
 				decline
 

--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -395,7 +395,7 @@ outfit "Nerve Gas"
 	description "This is a highly illegal weapon for hand-to-hand combat when boarding an enemy ship. Because chemical weapons are banned by interstellar law, you can be severely fined for getting caught in possession of nerve gas canisters. But, they do clear out an enemy ship quicker than just about anything else..."
 
 
-outfit `"Puny"`
+outfit "Puny"
 	category "Unique"
 	thumbnail "outfit/unknown"
 	description `A poodle you rescued from a dubious racing complex on Freedom. She appears to have formed a strong bond with you, willing to stick by your side.`

--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -397,6 +397,7 @@ outfit "Nerve Gas"
 
 outfit "Puny"
 	category "Unique"
+	"display name" `"Puny"`
 	thumbnail "outfit/unknown"
 	description `A poodle you rescued from a dubious racing complex on Freedom. She appears to have formed a strong bond with you, willing to stick by your side.`
 	description `	Her history matches with Pookie's, but Pookie's owner claimed that Puny was not hers. Puny is also vastly less urine-prone; you suspect that the race organizers may have toilet-trained her.`


### PR DESCRIPTION
**Bugfix:**

Thanks to Village#7886 on Discord for reporting this.

## Fix Details
The outfit `"Puny"` is defined as `` `"Puny"` ``; the quotation marks are a part of the intended name.
Unfortunately, this runs into an issue.
When writing single word tokens, the game does not enclose them in quotation marks, since those are optional for single word tokens. So, if the player has this outfit, it is written to the save file as `"Puny"`, omitting the backticks that the base definition includes because it is a single word token.
Then, when parsing that, it interprets those quotes as optional, since that's how quotes work on single word tokens, so it ignores them and uses the name `Puny`, which does not match the name of the outfit, `"Puny"`.
This PR renames the outfit to `Puny`, and gives it a display name `"Puny"` so it still appears the same.

## Testing Done
Instantiate the mission referencing the outfit into a save file before this PR. Then attempt to load it with this PR. The game doesn't disable it, and because writing the outfit name to the save file already removes the backticks and only writes `"Puny"`, which is then loaded as `Puny`, I don't expect any compatibility issues.
