### PR TITLE
Hide unknown ship models

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -796,7 +796,8 @@ void Engine::Step(bool isActive)
 			targetUnit = target->Facing().Unit();
 		info.SetSprite("target sprite", target->GetSprite(), targetUnit, target->GetFrame(step));
 		info.SetString("target name", target->Name());
-		info.SetString("target type", target->ModelName());
+		std::string targetModel = (player.ShipModelIsKnown(*target.get())) ? target->ModelName() : "Unknown Ship Model";
+		info.SetString("target type", targetModel);
 		if(!target->GetGovernment())
 			info.SetString("target government", "No Government");
 		else

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -845,6 +845,25 @@ void Engine::Step(bool isActive)
 				info.SetString("target energy", to_string(energy));
 				int heat = round(100. * target->Heat());
 				info.SetString("target heat", to_string(heat) + "%");
+
+				// if the player has a tactical scanner powerfull enough, it can detect the model of the
+				// ship by reading information the target ship leaks if ti is near enough.
+				// so based on the following formula: avg(tactical scan values for all scanners in the game)*1.5
+				// gets us to 80 (rounding up), the minimal power is 80.
+				if(flagship->Attributes().Get("tactical scan power") >= 80)
+				{
+					// the range is 35% from the scan power.
+					int maximalDetectionRange = tacticalRange * 0.35;
+
+					if(maximalDetectionRange >= targetRange)
+					{
+						std::string message = "The " + target->Name() + " was detected as a \"" +
+									target->VariantName() + "\" model ship";
+
+						Messages::Add(message, Messages::Importance::High);
+						player.DiscoverShipModel(*target.get());
+					}
+				}
 			}
 		}
 	}

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -41,6 +41,8 @@ namespace {
 		player.BuyShip(model, name, true);
 		Messages::Add("The " + model->ModelName() + " \"" + name + "\" was added to your fleet."
 			, Messages::Importance::High);
+
+		player.DiscoverShipModel(*model);
 	}
 
 	void DoGift(PlayerInfo &player, const Outfit *outfit, int count, UI *ui)

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -178,6 +178,8 @@ int MapShipyardPanel::FindItem(const string &text) const
 
 void MapShipyardPanel::DrawItems()
 {
+	bool headerDrawed = false;
+
 	if(GetUI()->IsTop(this) && player.GetPlanet() && player.GetDate() >= player.StartData().GetDate() + 12)
 		DoHelp("map advanced shops");
 	list.clear();
@@ -186,10 +188,6 @@ void MapShipyardPanel::DrawItems()
 	{
 		auto it = catalog.find(category);
 		if(it == catalog.end())
-			continue;
-
-		// Draw the header. If this category is collapsed, skip drawing the items.
-		if(DrawHeader(corner, category))
 			continue;
 
 		for(const Ship *ship : it->second)
@@ -210,12 +208,21 @@ void MapShipyardPanel::DrawItems()
 						break;
 					}
 			}
-			if(!isForSale && onlyShowSoldHere)
+			if((!isForSale && onlyShowSoldHere) || !player.ShipModelIsKnown(*ship))
 				continue;
 
 			const Sprite *sprite = ship->Thumbnail();
 			if(!sprite)
 				sprite = ship->GetSprite();
+
+			if(!headerDrawed)
+			{
+				// Draw the header. If this category is collapsed, skip drawing the items.
+				if(DrawHeader(corner, category))
+					break;
+
+				headerDrawed = true;
+			}
 			Draw(corner, sprite, ship->CustomSwizzle(), isForSale, ship == selected,
 					ship->ModelName(), price, info);
 			list.push_back(ship);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -57,6 +57,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
+	const string KNOWN_SHIP_MODEL_KEY = "known ship model";
+
 	// Move the flagship to the start of your list of ships. It does not make sense
 	// that the flagship would change if you are reunited with a different ship that
 	// was higher up the list.
@@ -381,6 +383,8 @@ void PlayerInfo::Load(const string &path)
 		}
 		else if(child.Token(0) == "start")
 			startData.Load(child);
+		else if((child.Token(0) == KNOWN_SHIP_MODEL_KEY) && (child.Size() >= 2))
+			DiscoverShipModel(*GameData::Ships().Get(child.Token(1)));
 	}
 	// Modify the game data with any changes that were loaded from this file.
 	ApplyChanges();
@@ -4108,6 +4112,10 @@ void PlayerInfo::Save(DataWriter &out) const
 			}
 	}
 	out.EndChild();
+
+	//  Save a list of all known ships to the player
+	for(auto &&it : knownShipModels)
+		out.Write(KNOWN_SHIP_MODEL_KEY, it);
 
 	out.Write();
 	out.WriteComment("How you began:");

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2697,6 +2697,20 @@ set<string> &PlayerInfo::Collapsed(const string &name)
 
 
 
+bool PlayerInfo::ShipModelIsKnown(const Ship& ship) const
+{
+	return true;
+}
+
+
+
+void PlayerInfo::DiscoverShipModel(const Ship& ship)
+{
+	knownShipModels.insert(ship.VariantName());
+}
+
+
+
 // Apply any "changes" saved in this player info to the global game state.
 void PlayerInfo::ApplyChanges()
 {

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -57,6 +57,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
+	const string HIDE_SHIP_MODELS = "Hide unknown ship models";
+
 	const string KNOWN_SHIP_MODEL_KEY = "known ship model";
 
 	// Move the flagship to the start of your list of ships. It does not make sense
@@ -2703,7 +2705,7 @@ set<string> &PlayerInfo::Collapsed(const string &name)
 
 bool PlayerInfo::ShipModelIsKnown(const Ship& ship) const
 {
-	return true;
+	return (Preferences::Has(HIDE_SHIP_MODELS)) ? knownShipModels.count(ship.VariantName()) : true;;
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2705,7 +2705,7 @@ set<string> &PlayerInfo::Collapsed(const string &name)
 
 bool PlayerInfo::ShipModelIsKnown(const Ship& ship) const
 {
-	return (Preferences::Has(HIDE_SHIP_MODELS)) ? knownShipModels.count(ship.VariantName()) : true;;
+	return (Preferences::Has(HIDE_SHIP_MODELS)) ? knownShipModels.count(ship.VariantName()) : true;
 }
 
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -311,6 +311,10 @@ public:
 	// Get the set of collapsed categories for the named panel.
 	std::set<std::string> &Collapsed(const std::string &name);
 
+	// Methods for changing or getting if an ship model is known to the player.
+	bool ShipModelIsKnown(const Ship &ship) const;
+	void DiscoverShipModel(const Ship &ship);
+
 
 private:
 	// Apply any "changes" saved in this player info to the global game state.
@@ -396,6 +400,7 @@ private:
 	std::set<const System *> seen;
 	std::set<const System *> visitedSystems;
 	std::set<const Planet *> visitedPlanets;
+	std::set<std::string> knownShipModels;
 	std::vector<const System *> travelPlan;
 	const Planet *travelDestination = nullptr;
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -63,6 +63,8 @@ namespace {
 	int alertIndicatorIndex = 3;
 
 	int previousSaveCount = 3;
+
+	const string HIDE_SHIP_MODELS = "Hide unknown ship models";
 }
 
 
@@ -86,6 +88,7 @@ void Preferences::Load()
 	settings["Hide unexplored map regions"] = true;
 	settings["Turrets focus fire"] = true;
 	settings["Ship outlines in shops"] = true;
+	settings[HIDE_SHIP_MODELS] = false;
 
 	DataFile prefs(Files::Config() + "preferences.txt");
 	for(const DataNode &node : prefs)

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -66,6 +66,7 @@ namespace {
 	const string BOARDING_PRIORITY = "Boarding target priority";
 	const string BACKGROUND_PARALLAX = "Parallax background";
 	const string ALERT_INDICATOR = "Alert indicator";
+	const string HIDE_SHIP_MODELS = "Hide unknown ship models";
 
 	// How many pages of settings there are.
 	const int SETTINGS_PAGE_COUNT = 2;
@@ -528,7 +529,8 @@ void PreferencesPanel::DrawSettings()
 		"Show escort systems on map",
 		"Show stored outfits on map",
 		"System map sends move orders",
-		ALERT_INDICATOR
+		ALERT_INDICATOR,
+		HIDE_SHIP_MODELS
 	};
 	bool isCategory = true;
 	int page = 0;

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -90,7 +90,12 @@ ShipyardPanel::ShipyardPanel(PlayerInfo &player)
 		catalog[it.second.Attributes().Category()].insert(it.first);
 
 	if(player.GetPlanet())
+	{
 		shipyard = player.GetPlanet()->Shipyard();
+
+		for(auto it : shipyard)
+			player.DiscoverShipModel(*it);
+	}
 }
 
 


### PR DESCRIPTION
the goal of this feature is to hide unknown ship models marking them as unknown until the below condition are met.

when the feature is enabled, the logic is as follows:
an ship will be marked as unknown until:

1. the player visits a shipyard, all models are marked as known.
2. the ship is captured.
3. the ship is given.
4. the tactical scan power is high enough and the target ship is close enough.

the latter case is special and comes to address models which aren't purchasable (like the korath models).
this feature affects the shipyard map too, if enabled, you won't know if a ship is in a shipyard of the player didn't visited the shipyard

this feature depends on a preference key which is set to off by default.
the code is written as such so switching between the mode of the feature only affects the UI.

test: enter new shipyard, tactical scan of a ship, ship was bought (same flow as gifted ship)

performance impact should be minimal and based on the std::set's insert and count complexity time.

screenshots:
![es-map-before](https://user-images.githubusercontent.com/90052312/225734190-d593f299-7127-46de-a398-7e794462e6eb.jpg)
![es-map-after](https://user-images.githubusercontent.com/90052312/225734197-fbddead5-03dd-41c2-8934-db4b1c77b8c4.jpg)
![es_detected](https://user-images.githubusercontent.com/90052312/225734201-5e1bdc7f-e104-4900-8a68-46627ca66cc5.jpg)
