### PR TITLE
Feature: Mining Asteroid Health Bar

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -786,6 +786,7 @@ void Engine::Step(bool isActive)
 		if(flagship->Attributes().Get("tactical scan power"))
 		{
 			info.SetCondition("range display");
+			info.SetBar("target hull", targetAsteroid->Hull(), 20.);
 			int targetRange = round(targetAsteroid->Position().Distance(flagship->Position()));
 			info.SetString("target range", to_string(targetRange));
 		}

--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -220,6 +220,13 @@ void Minable::TakeDamage(const Projectile &projectile)
 
 
 
+double Minable::Hull() const
+{
+	return min(1., hull / maxHull);
+}
+
+
+
 // Determine what flotsam this asteroid will create.
 const map<const Outfit *, int> &Minable::Payload() const
 {

--- a/source/Minable.h
+++ b/source/Minable.h
@@ -68,6 +68,8 @@ public:
 	// Determine what flotsam this asteroid will create.
 	const std::map<const Outfit *, int> &Payload() const;
 
+	// Get hull remaining of this asteroid, as a fraction between 0 and 1.
+	double Hull() const;
 
 private:
 	std::string name;


### PR DESCRIPTION
Summary
-------

This feature was contributed on May 19, 2022.

@RugnirViking made it so that if you have both an asteroid scanner and a tactical scanner, you can see the health of asteroids you have targeted.

Related issues
--------------

This change is split off from and supersedes https://github.com/endless-sky/endless-sky/pull/6840

Complements #6669

Screenshot
----------

![screenshot of asteroid health][1]

[1]: https://user-images.githubusercontent.com/18635337/169382807-4192b883-0476-43e8-a048-3c01c3a499f6.PNG