### PR TITLE
feat(content): Split the Quarg Government

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -349,7 +349,7 @@ government "Gegno"
 	"attitude toward"
 		"Gegno Scin" 0.01
 		"Gegno Vi" 0.01
-		"Quarg" 0.02
+		"Quarg (Gegno)" 0.02
 	"penalty for"
 		assist 0
 		provoke 10
@@ -1002,6 +1002,9 @@ government "Pug"
 	"attitude toward"
 		"Drak" -.01
 		"Quarg" -.01
+		"Quarg (Hai)" -.01
+		"Quarg (Kor Efret)" -.01
+		"Quarg (Gegno)" -.01
 	"friendly hail" "friendly pug"
 	"friendly disabled hail" "friendly disabled pug"
 	"hostile hail" "hostile pug"
@@ -1017,6 +1020,9 @@ government "Pug (Wanderer)"
 	"attitude toward"
 		"Drak" -.01
 		"Quarg" -.01
+		"Quarg (Hai)" -.01
+		"Quarg (Kor Efret)" -.01
+		"Quarg (Gegno)" -.01
 	"friendly hail" "friendly pug"
 	"friendly disabled hail" "friendly disabled pug"
 	"hostile hail" "hostile pug"
@@ -1029,6 +1035,9 @@ government "Quarg"
 	
 	"player reputation" 1
 	"attitude toward"
+		"Quarg (Hai)" 1
+		"Quarg (Kor Efret)" 1
+		"Quarg (Gegno)" 1
 		"Merchant" .01
 		"Kor Efret" .01
 		"Kor Mereti" -.01
@@ -1057,6 +1066,9 @@ government "Quarg (Hai)"
 
 	"player reputation" 1
 	"attitude toward"
+		"Quarg" 1
+		"Quarg (Kor Efret)" 1
+		"Quarg (Gegno)" 1
 		"Merchant" .01
 		"Kor Efret" .01
 		"Kor Mereti" -.01
@@ -1085,6 +1097,9 @@ government "Quarg (Kor Efret)"
 
 	"player reputation" 1
 	"attitude toward"
+		"Quarg" 1
+		"Quarg (Hai)" 1
+		"Quarg (Gegno)" 1
 		"Merchant" .01
 		"Kor Efret" .01
 		"Kor Mereti" -.01
@@ -1113,6 +1128,9 @@ government "Quarg (Gegno)"
 
 	"player reputation" 1
 	"attitude toward"
+		"Quarg" 1
+		"Quarg (Hai)" 1
+		"Quarg (Kor Efret)" 1
 		"Merchant" .01
 		"Kor Efret" .01
 		"Kor Mereti" -.01

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1039,9 +1039,6 @@ government "Quarg"
 		"Quarg (Kor Efret)" 1
 		"Quarg (Gegno)" 1
 		"Merchant" .01
-		"Kor Efret" .01
-		"Kor Mereti" -.01
-		"Kor Sestor" -.01
 		"Hai" .01
 		"Hai (Wormhole Access)" .01
 		"Pirate" -.01
@@ -1070,9 +1067,6 @@ government "Quarg (Hai)"
 		"Quarg (Kor Efret)" 1
 		"Quarg (Gegno)" 1
 		"Merchant" .01
-		"Kor Efret" .01
-		"Kor Mereti" -.01
-		"Kor Sestor" -.01
 		"Hai" .01
 		"Hai (Wormhole Access)" .01
 		"Pirate" -.01
@@ -1100,14 +1094,9 @@ government "Quarg (Kor Efret)"
 		"Quarg" 1
 		"Quarg (Hai)" 1
 		"Quarg (Gegno)" 1
-		"Merchant" .01
 		"Kor Efret" .01
 		"Kor Mereti" -.01
 		"Kor Sestor" -.01
-		"Hai" .01
-		"Hai (Wormhole Access)" .01
-		"Pirate" -.01
-		"Pirate (Devil-Run Gang)" -.01
 	"death sentence" "quarg imprisonment"
 	"hostile hail" "hostile quarg"
 	"hostile disabled hail" "hostile quarg"
@@ -1131,14 +1120,6 @@ government "Quarg (Gegno)"
 		"Quarg" 1
 		"Quarg (Hai)" 1
 		"Quarg (Kor Efret)" 1
-		"Merchant" .01
-		"Kor Efret" .01
-		"Kor Mereti" -.01
-		"Kor Sestor" -.01
-		"Hai" .01
-		"Hai (Wormhole Access)" .01
-		"Pirate" -.01
-		"Pirate (Devil-Run Gang)" -.01
 		"Gegno" 0.1
 	"foreign penalties for"
 		"Gegno"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1037,41 +1037,6 @@ government "Quarg"
 		"Hai (Wormhole Access)" .01
 		"Pirate" -.01
 		"Pirate (Devil-Run Gang)" -.01
-		"Gegno" 0.1
-	"death sentence" "quarg imprisonment"
-	"hostile hail" "hostile quarg"
-	"hostile disabled hail" "hostile quarg"
-	atrocities
-		"Nanotech Battery"
-		"Antimatter Core"
-		"Quarg Skylance"
-		"Quarg Anti-Missile"
-		"Intrusion Countermeasures"
-		"Medium Graviton Thruster"
-		"Medium Graviton Steering"
-		"Quantum Shield Generator"
-
-government "Quarg (Human)"
-	swizzle 0
-	color .88 .77 0
-	"display name" "Quarg"
-
-	"player reputation" 1
-	"attitude toward"
-		"Merchant" .01
-		"Kor Efret" .01
-		"Kor Mereti" -.01
-		"Kor Sestor" -.01
-		"Hai" .01
-		"Hai (Wormhole Access)" .01
-		"Pirate" -.01
-		"Pirate (Devil-Run Gang)" -.01
-		"Gegno" 0.1
-	"foreign penalties for"
-		"Gegno"
-	"custom penalties for"
-		"Gegno"
-			provoke 0.01
 	"death sentence" "quarg imprisonment"
 	"hostile hail" "hostile quarg"
 	"hostile disabled hail" "hostile quarg"
@@ -1100,12 +1065,6 @@ government "Quarg (Hai)"
 		"Hai (Wormhole Access)" .01
 		"Pirate" -.01
 		"Pirate (Devil-Run Gang)" -.01
-		"Gegno" 0.1
-	"foreign penalties for"
-		"Gegno"
-	"custom penalties for"
-		"Gegno"
-			provoke 0.01
 	"death sentence" "quarg imprisonment"
 	"hostile hail" "hostile quarg"
 	"hostile disabled hail" "hostile quarg"
@@ -1134,12 +1093,6 @@ government "Quarg (Kor Efret)"
 		"Hai (Wormhole Access)" .01
 		"Pirate" -.01
 		"Pirate (Devil-Run Gang)" -.01
-		"Gegno" 0.1
-	"foreign penalties for"
-		"Gegno"
-	"custom penalties for"
-		"Gegno"
-			provoke 0.01
 	"death sentence" "quarg imprisonment"
 	"hostile hail" "hostile quarg"
 	"hostile disabled hail" "hostile quarg"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1039,6 +1039,9 @@ government "Quarg"
 		"Quarg (Kor Efret)" 1
 		"Quarg (Gegno)" 1
 		"Merchant" .01
+		"Kor Efret" .01
+		"Kor Mereti" -.01
+		"Kor Sestor" -.01
 		"Hai" .01
 		"Hai (Wormhole Access)" .01
 		"Pirate" -.01

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1022,10 +1022,142 @@ government "Pug (Wanderer)"
 	"hostile hail" "hostile pug"
 	"hostile disabled hail" "hostile pug"
 
+# Quarg are split up to their respective areas, and an overall one is kept for missions or other use.
 government "Quarg"
 	swizzle 0
 	color .88 .77 0
 	
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .01
+		"Kor Efret" .01
+		"Kor Mereti" -.01
+		"Kor Sestor" -.01
+		"Hai" .01
+		"Hai (Wormhole Access)" .01
+		"Pirate" -.01
+		"Pirate (Devil-Run Gang)" -.01
+		"Gegno" 0.1
+	"death sentence" "quarg imprisonment"
+	"hostile hail" "hostile quarg"
+	"hostile disabled hail" "hostile quarg"
+	atrocities
+		"Nanotech Battery"
+		"Antimatter Core"
+		"Quarg Skylance"
+		"Quarg Anti-Missile"
+		"Intrusion Countermeasures"
+		"Medium Graviton Thruster"
+		"Medium Graviton Steering"
+		"Quantum Shield Generator"
+
+government "Quarg (Human)"
+	swizzle 0
+	color .88 .77 0
+	"display name" "Quarg"
+
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .01
+		"Kor Efret" .01
+		"Kor Mereti" -.01
+		"Kor Sestor" -.01
+		"Hai" .01
+		"Hai (Wormhole Access)" .01
+		"Pirate" -.01
+		"Pirate (Devil-Run Gang)" -.01
+		"Gegno" 0.1
+	"foreign penalties for"
+		"Gegno"
+	"custom penalties for"
+		"Gegno"
+			provoke 0.01
+	"death sentence" "quarg imprisonment"
+	"hostile hail" "hostile quarg"
+	"hostile disabled hail" "hostile quarg"
+	atrocities
+		"Nanotech Battery"
+		"Antimatter Core"
+		"Quarg Skylance"
+		"Quarg Anti-Missile"
+		"Intrusion Countermeasures"
+		"Medium Graviton Thruster"
+		"Medium Graviton Steering"
+		"Quantum Shield Generator"
+
+government "Quarg (Hai)"
+	swizzle 0
+	color .88 .77 0
+	"display name" "Quarg"
+
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .01
+		"Kor Efret" .01
+		"Kor Mereti" -.01
+		"Kor Sestor" -.01
+		"Hai" .01
+		"Hai (Wormhole Access)" .01
+		"Pirate" -.01
+		"Pirate (Devil-Run Gang)" -.01
+		"Gegno" 0.1
+	"foreign penalties for"
+		"Gegno"
+	"custom penalties for"
+		"Gegno"
+			provoke 0.01
+	"death sentence" "quarg imprisonment"
+	"hostile hail" "hostile quarg"
+	"hostile disabled hail" "hostile quarg"
+	atrocities
+		"Nanotech Battery"
+		"Antimatter Core"
+		"Quarg Skylance"
+		"Quarg Anti-Missile"
+		"Intrusion Countermeasures"
+		"Medium Graviton Thruster"
+		"Medium Graviton Steering"
+		"Quantum Shield Generator"
+
+government "Quarg (Kor Efret)"
+	swizzle 0
+	color .88 .77 0
+	"display name" "Quarg"
+
+	"player reputation" 1
+	"attitude toward"
+		"Merchant" .01
+		"Kor Efret" .01
+		"Kor Mereti" -.01
+		"Kor Sestor" -.01
+		"Hai" .01
+		"Hai (Wormhole Access)" .01
+		"Pirate" -.01
+		"Pirate (Devil-Run Gang)" -.01
+		"Gegno" 0.1
+	"foreign penalties for"
+		"Gegno"
+	"custom penalties for"
+		"Gegno"
+			provoke 0.01
+	"death sentence" "quarg imprisonment"
+	"hostile hail" "hostile quarg"
+	"hostile disabled hail" "hostile quarg"
+	atrocities
+		"Nanotech Battery"
+		"Antimatter Core"
+		"Quarg Skylance"
+		"Quarg Anti-Missile"
+		"Intrusion Countermeasures"
+		"Medium Graviton Thruster"
+		"Medium Graviton Steering"
+		"Quantum Shield Generator"
+
+government "Quarg (Gegno)"
+	swizzle 0
+	color .88 .77 0
+	"display name" "Quarg"
+
 	"player reputation" 1
 	"attitude toward"
 		"Merchant" .01

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -204,7 +204,7 @@ planet Arroharg
 	landscape land/canyon12
 	description `Arroharg is a low-gravity moon that the Quarg have converted to some sort of harvesting grounds. Massive machines that dwarf your ship seem to be displacing mountainous formations while smaller ones collect from the zones left behind. Most of the architecture here is Quarg-like and is not designed in a way that welcomes visitors very comfortably. The lower levels of the outpost seem to dig deeper into the surface of the moon, but the farther they go down the more complex they become. There's no telling how deep into the moon they go, as they are restricted to anyone but the Quarg.`
 	spaceport `A few Quarg greet you with astonished expressions, but kindly assist you in anything you have trouble with due to the spaceport being designed for them. They communicate mostly in gestures and facial expressions, although this is sometimes hard to decipher. It seems they aren't used to outside visitors here and don't speak your language.`
-	government Quarg
+	government "Quarg (Gegno)"
 	bribe 0
 	security 0.9
 
@@ -1679,7 +1679,7 @@ planet "Giaru Gegno"
 	description `The quality of its structure suggests that this Quarg ringworld had to have been completed rather recently, but there are some notable differences that don't seem Quarg-like. Some of the hangers and docks on the ring are oddly larger than others, and the inner quarters are wider and taller than what is normal for a Quarg. The hangar you currently are parked in, however, seems to be void of these characteristics, and is similar to ones at the Quarg ringworld in human space.`
 	description `	Despite seeing numerous non-Quarg ships before landing on the ring, you are only guided around parts of the ring where they are not present.`
 	spaceport `There are probably many hundreds of billions of Quarg on this ring, and yet it still manages to feel spacious and lightly populated. They shift past you at a normal walking pace for a Quarg, and don't give you much attention except from the occasional uninterested glance or two. There seems to be little conversation and effort to accommodate you as the only non-Quarg in sight. It seems areas containing the aliens from nearby are off-limits to you.`
-	government Quarg
+	government "Quarg (Gegno)"
 	bribe 0
 	security 1
 
@@ -3526,7 +3526,7 @@ planet Ruelogakk
 	landscape land/station5
 	description `This Quarg station, although pristine and kept in high order, has been constructed rather recently compared to the complete ringworld the next system over. It appears to be purposed as some sort of resting spot for tourists, though very few docking bays are in use. A hauntingly low number of Quarg are seen walking about the brightly lit abstract hallways of glass with only the faintest hum of machinery.`
 	spaceport `Only a few small alien transports can be seen docked with this station, hooked up to strange devices that seem to match the designs of their ships. Other than that, the alien's presence here seems to be kept at an extreme minimum, with at most one or two seen passing by occasionally.`
-	government Quarg
+	government "Quarg (Gegno)"
 	bribe 0
 	security 0.9
 
@@ -4378,7 +4378,7 @@ planet Truklar
 	landscape land/mars2
 	description `This world, like others the Quarg live on, has noticeably lower gravity than humans are accustomed to. Several medium-sized extravagant villages are found nested deep within an oddly shaped glass structure, and it is a beautiful sight to behold. Many different, smaller biomes also contain wondrous flora and fauna that don't seem to be native to this particular moon. Despite all of this, structures were not built in accustom to visitors such as the nearby aliens, who find it hard navigating through the narrow hallways.`
 	spaceport `Most of the spaceport is automated Quarg robotics that do not provide any interaction with you besides basic spaceport tasks such as refueling. Occasionally, one of these robots, visually similar to the Quarg themselves, guide you throughout the visitable zones of the port. Otherwise, your presence here is mostly overlooked.`
-	government Quarg
+	government "Quarg (Gegno)"
 	bribe 0
 	security 0.9
 

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -2209,8 +2209,8 @@ system Actannka
 	minables iron 22 3.6
 	minables silver 12 5.36
 	minables titanium 12 5.45
-	fleet "Large Quarg" 1400
-	fleet Quarg 1400
+	fleet "Large Quarg (Gegno)" 1400
+	fleet "Quarg (Gegno) 1400
 	object
 		sprite star/a5
 		period 10
@@ -3470,8 +3470,8 @@ system Aleit
 	trade Medical 605
 	trade Metal 539
 	trade Plastic 378
-	fleet Quarg 1100
-	fleet "Large Quarg" 1600
+	fleet "Quarg (Gegno)" 1100
+	fleet "Large Quarg (Gegno)" 1600
 	fleet "Gegno Basic" 1000
 	object
 		sprite star/g3
@@ -10506,8 +10506,8 @@ system Dokdobaru
 	trade Medical 500
 	trade Metal 473
 	trade Plastic 317
-	fleet Quarg 600
-	fleet "Large Quarg" 800
+	fleet "Quarg (Kor EFret)" 600
+	fleet "Large Quarg (Kor Efret)" 800
 	fleet "Kor Efret Home" 750
 	object
 		sprite star/g3
@@ -10766,7 +10766,7 @@ system "Due Yoot"
 	fleet "Small Human Merchants (Hai)" 3000
 	fleet "Large Human Merchants (Hai)" 6000
 	fleet "Hai Surveillance" 5000
-	fleet Quarg 2000
+	fleet "Quarg (Hai)" 2000
 	object
 		sprite star/m3
 		period 10
@@ -11681,7 +11681,7 @@ system Elifennka
 	asteroids "large metal" 27 4.49
 	minables aluminum 28 8.68
 	minables titanium 31 9.59
-	fleet Quarg 4000
+	fleet "Quarg (Gegno)" 4000
 	object
 		sprite star/a3
 		period 10
@@ -12891,7 +12891,7 @@ system "Fah Root"
 	fleet "Small Human Merchants (Hai)" 15000
 	fleet "Large Human Merchants (Hai)" 25000
 	fleet "Hai Surveillance" 3000
-	fleet Quarg 2000
+	fleet "Quarg (Hai)" 2000
 	object
 		sprite star/k0
 		period 10
@@ -12966,7 +12966,7 @@ system "Fah Soom"
 	fleet "Small Human Merchants (Hai)" 6000
 	fleet "Large Human Merchants (Hai)" 9000
 	fleet "Hai Surveillance" 4000
-	fleet Quarg 1000
+	fleet "Quarg (Hai)" 1000
 	object
 		sprite star/k5
 		period 10
@@ -14897,7 +14897,7 @@ system Ghhil
 	minables silicon 2 6.3
 	minables copper 13 3.31
 	minables titanium 7 4.9
-	fleet Quarg 2000
+	fleet "Quarg (Gegno)" 2000
 	object
 		sprite star/a8
 		period 10
@@ -16134,7 +16134,7 @@ system Heutesl
 	trade Metal 571
 	trade Plastic 196
 	fleet "Gegno Basic" 200
-	fleet Quarg 2800
+	fleet "Quarg (Gegno)" 2800
 	fleet "Gegno Miners" 2000
 	object
 		sprite star/f8
@@ -16189,7 +16189,7 @@ system "Hevru Hai"
 	fleet "Large Hai Merchant (Human)" 7500
 	fleet "Small Human Merchants (Hai)" 9000
 	fleet "Large Human Merchants (Hai)" 15000
-	fleet Quarg 600
+	fleet "Quarg (Hai)" 600
 	object
 		sprite star/g3
 		period 10
@@ -16713,7 +16713,7 @@ system Iigen
 	minables iron 22 1.47
 	fleet "Gegno Basic" 1900
 	fleet "Gegno Miners" 2100
-	fleet Quarg 3500
+	fleet "Quarg (Gegno)" 3500
 	object
 		sprite star/m3
 		period 10
@@ -18649,8 +18649,8 @@ system Kashikt
 	trade Medical 543
 	trade Metal 443
 	trade Plastic 292
-	fleet Quarg 1000
-	fleet "Large Quarg" 2000
+	fleet "Quarg (Kor Efret)" 1000
+	fleet "Large Quarg (Kor Efret)" 2000
 	fleet "Kor Efret Home" 500
 	fleet "Kor Efret Miners" 3600
 	object
@@ -20862,7 +20862,7 @@ system "Lom Tahr"
 	fleet "Small Human Merchants (Hai)" 6000
 	fleet "Large Human Merchants (Hai)" 9000
 	fleet "Hai Surveillance" 3000
-	fleet Quarg 4000
+	fleet "Quarg (Hai)" 4000
 	object
 		sprite star/f0
 		period 10
@@ -29217,8 +29217,8 @@ system Sevrelect
 	trade Medical 603
 	trade Metal 446
 	trade Plastic 288
-	fleet Quarg 1000
-	fleet "Large Quarg" 3000
+	fleet "Quarg (Kor Efret)" 1000
+	fleet "Large Quarg (Kor Efret)" 3000
 	fleet "Kor Efret Home" 500
 	fleet "Kor Efret Miners" 3600
 	object
@@ -31043,8 +31043,8 @@ system Sumprast
 	trade Medical 591
 	trade Metal 483
 	trade Plastic 323
-	fleet Quarg 1000
-	fleet "Large Quarg" 2500
+	fleet "Quarg (Kor Efret)" 1000
+	fleet "Large Quarg (Kor Efret)" 2500
 	fleet "Kor Efret Home" 500
 	fleet "Kor Efret Miners" 3600
 	object
@@ -31815,7 +31815,7 @@ system Tscera
 	asteroids "large metal" 2 4.27
 	minables aluminum 1 5.75
 	minables lead 7 6.19
-	fleet Quarg 3800
+	fleet "Quarg (Gegno)" 3800
 	fleet "Gegno Basic" 3000
 	object
 		sprite star/f0
@@ -33993,7 +33993,7 @@ system "Ya Hai"
 	fleet "Small Human Merchants (Hai)" 12000
 	fleet "Large Human Merchants (Hai)" 17000
 	fleet "Hai Surveillance" 3000
-	fleet Quarg 6000
+	fleet "Quarg (Hai)" 6000
 	object
 		sprite star/k5
 		period 10
@@ -34199,7 +34199,7 @@ system Yllke
 	minables aluminum 42 1.94
 	fleet "Gegno Miners" 3000
 	fleet "Gegno Basic" 1300
-	fleet Quarg 3300
+	fleet "Quarg (Gegno)" 3300
 	object
 		sprite star/b8
 		distance 31.2

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -2192,7 +2192,7 @@ system Acrux
 
 system Actannka
 	pos 1016.73 -706.867
-	government Quarg
+	government "Quarg (Gegno)"
 	arrival 3200
 	habitable 3200
 	belt 1228
@@ -3449,7 +3449,7 @@ system Aldhibain
 
 system Aleit
 	pos 967.604 -690.722
-	government Quarg
+	government "Quarg (Gegno)"
 	attributes "ringworld"
 	arrival 700
 	departure 1000
@@ -10477,7 +10477,7 @@ system Dixere
 
 system Dokdobaru
 	pos -21.5695 -241.812
-	government Quarg
+	government "Quarg (Efret)"
 	attributes "korath" "ringworld"
 	arrival 700
 	habitable 700
@@ -14882,7 +14882,7 @@ system Gerenus
 
 system Ghhil
 	pos 922.4 -714
-	government Quarg
+	government "Quarg (Gegno)"
 	arrival 3000
 	habitable 3000
 	belt 1760
@@ -16162,7 +16162,7 @@ system Heutesl
 
 system "Hevru Hai"
 	pos -189 -310
-	government Quarg
+	government "Quarg (Hai)"
 	attributes "ringworld"
 	arrival 700
 	departure 1000

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -10477,7 +10477,7 @@ system Dixere
 
 system Dokdobaru
 	pos -21.5695 -241.812
-	government "Quarg (Efret)"
+	government "Quarg (Kor Efret)"
 	attributes "korath" "ringworld"
 	arrival 700
 	habitable 700

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -2210,7 +2210,7 @@ system Actannka
 	minables silver 12 5.36
 	minables titanium 12 5.45
 	fleet "Large Quarg (Gegno)" 1400
-	fleet "Quarg (Gegno) 1400
+	fleet "Quarg (Gegno) 1400"
 	object
 		sprite star/a5
 		period 10

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -2210,7 +2210,7 @@ system Actannka
 	minables silver 12 5.36
 	minables titanium 12 5.45
 	fleet "Large Quarg (Gegno)" 1400
-	fleet "Quarg (Gegno) 1400"
+	fleet "Quarg (Gegno)" 1400
 	object
 		sprite star/a5
 		period 10
@@ -10506,7 +10506,7 @@ system Dokdobaru
 	trade Medical 500
 	trade Metal 473
 	trade Plastic 317
-	fleet "Quarg (Kor EFret)" 600
+	fleet "Quarg (Kor Efret)" 600
 	fleet "Large Quarg (Kor Efret)" 800
 	fleet "Kor Efret Home" 750
 	object

--- a/data/quarg/quarg missions.txt
+++ b/data/quarg/quarg missions.txt
@@ -266,7 +266,11 @@ mission "Quarg Ships Atrocity"
 	landing
 	invisible
 	source
-		government "Quarg"
+		or
+			government "Quarg"
+			government "Quarg (Hai)"
+			government "Quarg (Efret)"
+			government "Quarg (Gegno)"
 	to offer
 		or
 			has "ship model: Quarg Skylark"

--- a/data/quarg/quarg missions.txt
+++ b/data/quarg/quarg missions.txt
@@ -266,11 +266,7 @@ mission "Quarg Ships Atrocity"
 	landing
 	invisible
 	source
-		or
-			government "Quarg"
-			government "Quarg (Hai)"
-			government "Quarg (Efret)"
-			government "Quarg (Gegno)"
+		attributes quarg
 	to offer
 		or
 			has "ship model: Quarg Skylark"

--- a/data/quarg/quarg.txt
+++ b/data/quarg/quarg.txt
@@ -65,6 +65,7 @@ conversation "quarg imprisonment"
 	`	You spend the rest of your days in the same cell, which although large and comfortable, quickly proves plain and dull. You're kept in very good health and are well fed, but the Quarg do not allow you to leave the cell and seldom entertain your attempts at striking conversation. You get few visitors and can only wonder what life would've been like had you the chance to live out all these years in freedom, the captain of a starship.`
 		die
 
+# Human Quarg
 fleet "Quarg"
 	government "Quarg"
 	names "quarg"
@@ -78,6 +79,108 @@ fleet "Quarg"
 
 fleet "Large Quarg"
 	government "Quarg"
+	names "quarg"
+	cargo 1
+	personality
+		forbearing opportunistic
+	variant 2
+		"Quarg Skylark" 2
+		"Quarg Wardragon"
+	variant 2
+		"Quarg Wardragon" 2
+		"Quarg Skylark"
+	variant
+		"Quarg Skylark" 2
+		"Quarg Wardragon" 2
+	variant
+		"Quarg Wardragon" 3
+		"Quarg Skylark"
+	variant
+		"Quarg Skylark" 3
+		"Quarg Wardragon"
+
+# Hai Quarg
+fleet "Quarg (Hai)"
+	government "Quarg (Hai)"
+	names "quarg"
+	cargo 3
+	personality
+		forbearing opportunistic
+	variant
+		"Quarg Skylark"
+	variant
+		"Quarg Wardragon"
+
+fleet "Large Quarg (Hai)"
+	government "Quarg (Hai)"
+	names "quarg"
+	cargo 1
+	personality
+		forbearing opportunistic
+	variant 2
+		"Quarg Skylark" 2
+		"Quarg Wardragon"
+	variant 2
+		"Quarg Wardragon" 2
+		"Quarg Skylark"
+	variant
+		"Quarg Skylark" 2
+		"Quarg Wardragon" 2
+	variant
+		"Quarg Wardragon" 3
+		"Quarg Skylark"
+	variant
+		"Quarg Skylark" 3
+		"Quarg Wardragon"
+
+# Kor Efret Quarg
+fleet "Quarg (Kor Efret)"
+	government "Quarg (Kor Efret)"
+	names "quarg"
+	cargo 3
+	personality
+		forbearing opportunistic
+	variant
+		"Quarg Skylark"
+	variant
+		"Quarg Wardragon"
+
+fleet "Large Quarg (Kor Efret)"
+	government "Quarg (Kor Efret)"
+	names "quarg"
+	cargo 1
+	personality
+		forbearing opportunistic
+	variant 2
+		"Quarg Skylark" 2
+		"Quarg Wardragon"
+	variant 2
+		"Quarg Wardragon" 2
+		"Quarg Skylark"
+	variant
+		"Quarg Skylark" 2
+		"Quarg Wardragon" 2
+	variant
+		"Quarg Wardragon" 3
+		"Quarg Skylark"
+	variant
+		"Quarg Skylark" 3
+		"Quarg Wardragon"
+
+# Gegno Quarg
+fleet "Quarg (Gegno)"
+	government "Quarg (Gegno)"
+	names "quarg"
+	cargo 3
+	personality
+		forbearing opportunistic
+	variant
+		"Quarg Skylark"
+	variant
+		"Quarg Wardragon"
+
+fleet "Large Quarg (Gegno)"
+	government "Quarg (Gegno)"
 	names "quarg"
 	cargo 1
 	personality

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -256,7 +256,7 @@ event "wanderers: kaliptari battle begins"
 
 event "wanderers: kaliptari battle ends"
 	system Kaliptari
-		add fleet "Large Quarg" 2000
+		add fleet "Large Quarg (Kor Efret)" 2000
 		add fleet "Small Kor Mereti" 8000
 		add fleet "Large Kor Mereti" 3600
 		add fleet "Wanderer Defense" 1000
@@ -462,7 +462,7 @@ mission "Wanderers: Quarg Assistance 2"
 	on visit
 		dialog `You've reached <planet>, but you left one of the Quarg ships behind. Better depart and wait for it to arrive.`
 	npc accompany save
-		government "Quarg"
+		government "Quarg (Kor Efret)"
 		personality escort
 		ship "Quarg Wardragon" "Elearu-quara"
 		ship "Quarg Wardragon" "Kumawar Kwarca"
@@ -477,7 +477,7 @@ mission "Wanderers: Quarg Defenders"
 	to offer
 		has "Wanderers: Quarg Assistance 2: done"
 	npc kill
-		government "Quarg"
+		government "Quarg (Kor Efret)"
 		personality staying uninterested heroic
 		ship "Quarg Wardragon" "Elearu-quara"
 		ship "Quarg Wardragon" "Kumawar Kwarca"
@@ -714,8 +714,8 @@ event "wanderers: kashikt battle begins"
 
 event "wanderers: kashikt battle ends"
 	system "Kashikt"
-		fleet "Quarg" 1000
-		fleet "Large Quarg" 2000
+		fleet "Quarg (Kor Efret)" 1000
+		fleet "Large Quarg (Kor Efret)" 2000
 		fleet "Kor Efret Home" 1000
 
 mission "Wanderers: Kor Efret 3"
@@ -775,14 +775,14 @@ mission "Wanderers: Kor Efret 3"
 				"Arch-Carrack" 2
 				"Charm-Shallop" 4
 	npc
-		government "Quarg"
+		government "Quarg (Kor Efret)"
 		personality heroic staying entering
 		fleet
 			names "quarg"
 			variant
 				"Quarg Wardragon" 1
 	npc
-		government "Quarg"
+		government "Quarg (Kor Efret)"
 		personality heroic
 		system "Host"
 		fleet
@@ -790,7 +790,7 @@ mission "Wanderers: Kor Efret 3"
 			variant
 				"Quarg Wardragon" 3
 	npc
-		government "Quarg"
+		government "Quarg (Kor Efret)"
 		personality heroic
 		system "Mesuket"
 		fleet
@@ -1070,7 +1070,7 @@ event "wanderers: kor mereti friendly"
 	government "Kor Mereti"
 		"attitude toward"
 			"Wanderer" 1
-	government "Quarg"
+	government "Quarg (Kor Efret)"
 		"attitude toward"
 			"Kor Mereti" 0
 	government "Kor Efret"
@@ -1585,7 +1585,7 @@ event "wanderers: battle in solifar begins"
 
 event "wanderers: battle in solifar ends"
 	system Solifar
-		fleet "Large Quarg" 3000
+		fleet "Large Quarg (Kor Efret)" 3000
 		fleet "Wanderer Defense" 1800
 		fleet "Wanderer Drones" 700
 		fleet "Wanderer Flycatchers" 800
@@ -3309,7 +3309,7 @@ event "wanderers: sestor eliminated"
 event "wanderers: sabira eseskrai colony"
 	system "Skeruto"
 		government "Wanderer"
-		fleet "Large Quarg" 1000
+		fleet "Large Quarg (Kor Efret)" 1000
 		fleet "Wanderer Defense" 1200
 		fleet "Wanderer Drones" 800
 		fleet "Kor Efret Home" 800

--- a/data/wanderer/wanderers.txt
+++ b/data/wanderer/wanderers.txt
@@ -914,21 +914,21 @@ event "wanderers: the eye opens"
 		add fleet "Wanderer Defense" 1600
 		add fleet "Wanderer Drones" 800
 	system Kaliptari
-		fleet "Large Quarg" 2000
+		fleet "Large Quarg (Kor Efret)" 2000
 		fleet "Small Kor Mereti" 8000
 		fleet "Large Kor Mereti" 3600
 		fleet "Wanderer Defense" 1000
 		fleet "Wanderer Drones" 500
 	system Solifar
-		fleet "Large Quarg" 3000
+		fleet "Large Quarg (Kor Efret)" 3000
 		fleet "Wanderer Defense" 1800
 		fleet "Wanderer Drones" 700
 	system Fornarep
-		fleet "Large Quarg" 1000
+		fleet "Large Quarg (Kor Efret)" 1000
 		fleet "Small Kor Mereti" 7000
 		fleet "Large Kor Mereti" 4000
 	system Skeruto
-		fleet "Large Quarg" 1000
+		fleet "Large Quarg (Kor Efret)" 1000
 	system Mekislepti
 		add fleet "Small Kor Mereti" 4000
 		add fleet "Large Kor Mereti" 12000


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
There has been a desire to split the Quarg into more area-specific governments mentioned by @Arachi-Lover , @Amazinite , and other content creators for future use, and to work around use for area-specific conditions, fixes, etc.. This also supports the idea that in the future, we'll have a Coalition Quarg for that related content instead of messing up with the human Quarg, etc.

So far, I've added several location-related Quarg governments, while keeping the original the human Quarg. Each locational Quarg has their own attitudes with the relevant local factions.

All this said, @Arachi-Lover , this means for Coalition content you can make a Quarg (Coalition) gov to use for them, and we can have future Quarg govs separate for newer races.

Something we can keep in mind for a future PR is having different Quarg hails, languages, etc. with different mannerisms for each place. 

## Save File
N/A