### PR TITLE
Support removal of galaxy sprites

### DIFF
--- a/source/Galaxy.cpp
+++ b/source/Galaxy.cpp
@@ -18,15 +18,29 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "DataNode.h"
 #include "SpriteSet.h"
 
+using namespace std;
+
 
 
 void Galaxy::Load(const DataNode &node)
 {
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "pos" && child.Size() >= 3)
+		const bool remove = child.Token(0) == "remove";
+		const int keyIndex = remove;
+		const bool hasKey = child.Size() > keyIndex;
+		const string &key = hasKey ? child.Token(0) : child.Token(keyIndex);
+
+		if(remove && hasKey)
+		{
+			if(key == "sprite")
+				sprite = nullptr;
+			else
+				child.PrintTrace("Skipping unsupported use of \"remove\":");
+		}
+		else if(key == "pos" && child.Size() >= 3)
 			position = Point(child.Value(1), child.Value(2));
-		else if(child.Token(0) == "sprite" && child.Size() >= 2)
+		else if(key == "sprite" && child.Size() >= 2)
 			sprite = SpriteSet::Get(child.Token(1));
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");


### PR DESCRIPTION
**Feature:**

## Feature Details
Supports the use of:
```
galaxy
    remove sprite
```
To set the sprite of a galaxy to nullpointer (the default value, if no sprite entry was given in the definition.)

