### PR TITLE
Reduce combat rating requirement for the Kestrel

### DIFF
--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -17,7 +17,11 @@ mission "Kestrel Testing"
 	source "Wayfarer"
 	waypoint "Umbral"
 	to offer
-		"combat rating" > 2500
+		or
+			"combat rating" > 6000
+			and
+				"combat rating" > 2500
+				has "main plot completed"
 	
 	on offer
 		conversation

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -22,6 +22,9 @@ mission "Kestrel Testing"
 			and
 				"combat rating" > 2500
 				has "main plot completed"
+			and
+				"combat rating" > 1500
+				has "global: unlocked kestrel"
 	
 	on offer
 		conversation
@@ -64,6 +67,7 @@ mission "Kestrel Testing"
 	
 	on complete
 		payment 2000000
+		"global: unlocked kestrel" ++
 		conversation
 			`Atinoda meets up with you soon after you land. "I see that you survived," he says. "Was it a difficult fight?"`
 			choice

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -18,12 +18,9 @@ mission "Kestrel Testing"
 	waypoint "Umbral"
 	to offer
 		or
-			"combat rating" > 6000
+			"combat rating" > 8000
 			and
-				"combat rating" > 2500
-				has "main plot completed"
-			and
-				"combat rating" > 1500
+				"combat rating" > 2000
 				has "global: unlocked kestrel"
 	
 	on offer

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -17,7 +17,7 @@ mission "Kestrel Testing"
 	source "Wayfarer"
 	waypoint "Umbral"
 	to offer
-		"combat rating" > 8000
+		"combat rating" > 2500
 	
 	on offer
 		conversation


### PR DESCRIPTION
This doesn't really fit any of the categories...

## Summary

I reduced the combat rating requirement for the `"Kestrel Testing"` mission from 8000 to 6000, or 2500 with the FW storyline completed.

## Context

While flying around in my shield beetle recently after completing the Free Worlds campaign, I thought I'd go see if I could get the Kestrel. I was surprised to find out that I didn't meet the CR requirement: despite defeating the Pug, fighting numerous battles, and having a ship that overpowered even the Kestrel that I was going to complete the mission for, my CR was 1837 and the requirement was 8000.

I understand that my run did not lend itself well to me accumulating a high combat rating, at least until the end, but it still seems odd to me that you need a higher combat rating than is required to demand tribute from many planets in order to test a warship for Tarazed, when `"Bounty Hunting (Big)"` stops offering once you hit 2500 rep. If you're too powerful to have your time wasted blowing up Leviathans, Falcons, and Vanguards, Tarazed probably knows about you.