### PR TITLE
use 64 bits instead of 32 to store commands (alternative to #8507)

### DIFF
--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -38,13 +38,14 @@ namespace {
 	// Keep track of any keycodes that are mapped to multiple commands, in order
 	// to display a warning to the player.
 	map<int, int> keycodeCount;
+	// Need a uint64_t 1 to generate Commands.
+	const uint64_t ONE = 1;
 }
 
 
 
 // Command enumeration, including the descriptive strings that are used for the
 // commands both in the preferences panel and in the saved key settings.
-const uint64_t ONE = 1;
 const Command Command::NONE(0, "");
 const Command Command::MENU(ONE << 0, "Show main menu");
 const Command Command::FORWARD(ONE << 1, "Forward thrust");

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -44,39 +44,40 @@ namespace {
 
 // Command enumeration, including the descriptive strings that are used for the
 // commands both in the preferences panel and in the saved key settings.
+const uint64_t ONE = 1;
 const Command Command::NONE(0, "");
-const Command Command::MENU(1uL << 0, "Show main menu");
-const Command Command::FORWARD(1uL << 1, "Forward thrust");
-const Command Command::LEFT(1uL << 2, "Turn left");
-const Command Command::RIGHT(1uL << 3, "Turn right");
-const Command Command::BACK(1uL << 4, "Reverse");
-const Command Command::PRIMARY(1uL << 5, "Fire primary weapon");
-const Command Command::SECONDARY(1uL << 6, "Fire secondary weapon");
-const Command Command::SELECT(1uL << 7, "Select secondary weapon");
-const Command Command::LAND(1uL << 8, "Land on planet / station");
-const Command Command::BOARD(1uL << 9, "Board selected ship");
-const Command Command::HAIL(1uL << 10, "Talk to selected ship");
-const Command Command::SCAN(1uL << 11, "Scan selected ship");
-const Command Command::JUMP(1uL << 12, "Initiate hyperspace jump");
-const Command Command::FLEET_JUMP(1uL << 13, "");
-const Command Command::TARGET(1uL << 14, "Select next ship");
-const Command Command::NEAREST(1uL << 15, "Select nearest hostile ship");
-const Command Command::DEPLOY(1uL << 16, "Deploy / recall fighters");
-const Command Command::AFTERBURNER(1uL << 17, "Fire afterburner");
-const Command Command::CLOAK(1uL << 18, "Toggle cloaking device");
-const Command Command::MAP(1uL << 19, "View star map");
-const Command Command::INFO(1uL << 20, "View player info");
-const Command Command::FULLSCREEN(1uL << 21, "Toggle fullscreen");
-const Command Command::FASTFORWARD(1uL << 22, "Toggle fast-forward");
-const Command Command::FIGHT(1uL << 23, "Fleet: Fight my target");
-const Command Command::GATHER(1uL << 24, "Fleet: Gather around me");
-const Command Command::HOLD(1uL << 25, "Fleet: Hold position");
-const Command Command::AMMO(1uL << 26, "Fleet: Toggle ammo usage");
-const Command Command::WAIT(1uL << 27, "");
-const Command Command::STOP(1ul << 28, "");
-const Command Command::SHIFT(1uL << 29, "");
-const Command Command::MOUSE_TURNING_HOLD(1uL << 30, "Mouse turning (hold)");
-const Command Command::MOUSE_TURNING_TOGGLE(1uL << 31, "Mouse turning (toggle)");
+const Command Command::MENU(ONE << 0, "Show main menu");
+const Command Command::FORWARD(ONE << 1, "Forward thrust");
+const Command Command::LEFT(ONE << 2, "Turn left");
+const Command Command::RIGHT(ONE << 3, "Turn right");
+const Command Command::BACK(ONE << 4, "Reverse");
+const Command Command::PRIMARY(ONE << 5, "Fire primary weapon");
+const Command Command::SECONDARY(ONE << 6, "Fire secondary weapon");
+const Command Command::SELECT(ONE << 7, "Select secondary weapon");
+const Command Command::LAND(ONE << 8, "Land on planet / station");
+const Command Command::BOARD(ONE << 9, "Board selected ship");
+const Command Command::HAIL(ONE << 10, "Talk to selected ship");
+const Command Command::SCAN(ONE << 11, "Scan selected ship");
+const Command Command::JUMP(ONE << 12, "Initiate hyperspace jump");
+const Command Command::FLEET_JUMP(ONE << 13, "");
+const Command Command::TARGET(ONE << 14, "Select next ship");
+const Command Command::NEAREST(ONE << 15, "Select nearest hostile ship");
+const Command Command::DEPLOY(ONE << 16, "Deploy / recall fighters");
+const Command Command::AFTERBURNER(ONE << 17, "Fire afterburner");
+const Command Command::CLOAK(ONE << 18, "Toggle cloaking device");
+const Command Command::MAP(ONE << 19, "View star map");
+const Command Command::INFO(ONE << 20, "View player info");
+const Command Command::FULLSCREEN(ONE << 21, "Toggle fullscreen");
+const Command Command::FASTFORWARD(ONE << 22, "Toggle fast-forward");
+const Command Command::FIGHT(ONE << 23, "Fleet: Fight my target");
+const Command Command::GATHER(ONE << 24, "Fleet: Gather around me");
+const Command Command::HOLD(ONE << 25, "Fleet: Hold position");
+const Command Command::AMMO(ONE << 26, "Fleet: Toggle ammo usage");
+const Command Command::WAIT(ONE << 27, "");
+const Command Command::STOP(ONE << 28, "");
+const Command Command::SHIFT(ONE << 29, "");
+const Command Command::MOUSE_TURNING_HOLD(ONE << 30, "Mouse turning (hold)");
+const Command Command::MOUSE_TURNING_TOGGLE(ONE << 31, "Mouse turning (toggle)");
 
 
 
@@ -391,7 +392,7 @@ Command &Command::operator|=(const Command &command)
 
 
 // Private constructor.
-Command::Command(uint32_t state)
+Command::Command(uint64_t state)
 	: state(state)
 {
 }
@@ -400,7 +401,7 @@ Command::Command(uint32_t state)
 
 // Private constructor that also stores the given description in the lookup
 // table. (This is used for the enumeration at the top of this file.)
-Command::Command(uint32_t state, const string &text)
+Command::Command(uint64_t state, const string &text)
 	: state(state)
 {
 	if(!text.empty())

--- a/source/Command.h
+++ b/source/Command.h
@@ -135,14 +135,14 @@ public:
 
 
 private:
-	explicit Command(uint32_t state);
-	Command(uint32_t state, const std::string &text);
+	explicit Command(uint64_t state);
+	Command(uint64_t state, const std::string &text);
 
 
 private:
 	// The key commands are stored in a single bitmask with
 	// 32 bits for key commands.
-	uint32_t state = 0;
+	uint64_t state = 0;
 	// Turning amount is stored as a separate double to allow fractional values.
 	double turn = 0.;
 };


### PR DESCRIPTION
**Feature:** Switches from a uint32_t to a uint64_t to store commands. This is an alternative to an `std::bitset` discussed in #8507

## Feature Details
A PR in the queue needs a thirty-third command, but we only have room for thirty-two. My PR #8507 used `std::bitset`, but that was found to slow down the game. The `std::bitset` class is well-known to be slower than integer operations, and Command is used many times per frame, so that result isn't surprising. A faster alternative discussed in that PR is a 64-bit integer, which should be enough to last us a while.

## UI Screenshots
N/A

## Usage Examples
An auto-steer key (#8508)

## Testing Done
Made sure the commands still worked. Tried adding a thirty-third command (#8508) and confirmed it worked.

### Automated Tests Added
N/A

## Performance Impact
N/A
