### PR TITLE
feat(content): Add random lifetime to Flamethrower projectiles

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -681,7 +681,8 @@ outfit "Flamethrower Projectile"
 		"hit effect" "flamethrower hit"
 		"die effect" "flamethrower die"
 		"inaccuracy" 20
-		"lifetime" 22
+		"lifetime" 18
+		"random lifetime" 8
 		"damage dropoff" 0 198
 		"dropoff modifier" .5
 		"shield damage" .8


### PR DESCRIPTION
## Summary
This PR adds some variance to Flamethrower projectiles so that there's less of a clear cut-off when firing.
[(Suggested by Millie the Witch on the Steam forums.)](https://steamcommunity.com/app/404410/discussions/2/3828662280423713943/)