### PR TITLE
fix(content): Bring marauder bounty distance in line with others

### DIFF
--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -3435,7 +3435,7 @@ mission "Bounty Hunting (Marauder IV)"
 		government "Bounty"
 		personality heroic staying nemesis target
 		system
-			distance 1 3
+			distance 1 1
 		fleet "Marauder fleet IV"
 		dialog phrase "generic hunted bounty fleet eliminated dialog"
 	on visit


### PR DESCRIPTION
All normal bounties were updated to 1 system away in #7317, except the Marauder IV one. This PR makes it consistent with all the others.