### PR TITLE
fix: Use double quotes in the mission fail message

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1114,7 +1114,7 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 	if(event.TargetGovernment()->IsPlayer() && !hasFailed)
 	{
 		bool failed = false;
-		string message = "Your ship '" + event.Target()->Name() + "' has been ";
+		string message = "Your ship \"" + event.Target()->Name() + "\" has been ";
 		if(event.Type() & ShipEvent::DESTROY)
 		{
 			// Destroyed ships carrying mission cargo result in failed missions.


### PR DESCRIPTION
## Fix Details
Modified the `Your ship '...' has been lost. Mission failed: ...` message to use double quotes around the ship's name. Now it's consistent with other messages that mention a ship's name.