### PR TITLE
Fix LoadPanel double clicking

### DIFF
--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -352,8 +352,9 @@ bool LoadPanel::Click(int x, int y, int clicks)
 		for(const auto &it : filesIt->second)
 			if(i++ == selected)
 			{
+				const bool sameSelected = selectedFile == it.first;
 				selectedFile = it.first;
-				if(clicks > 1)
+				if(sameSelected && clicks > 1)
 					KeyDown('l', 0, Command(), true);
 				break;
 			}


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8205

## Fix Details
When double clicking the snapshot list, the game will now only count it as a request to load the selected snapshot if both clicks were on the same snapshot.

## Testing Done
Try double clicking snapshots.
Without this PR, it is possible to click on one snapshot and then another in quick succession and the game will attempt to load the most recently selected snapshot, even though this snapshot was not actually double clicked.
With this PR, the game will only attempt to load the snapshot if both clicks were on the same snapshot.

