### PR TITLE
Add a mission trigger and a condition to check if the flagship is disabled

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -102,6 +102,8 @@ namespace {
 				return "on waypoint";
 			case Mission::Trigger::DAILY:
 				return "on daily";
+			case Mission::Trigger::DISABLED:
+				return "on disabled";
 			default:
 				return "unknown trigger";
 		}
@@ -305,6 +307,7 @@ void Mission::Load(const DataNode &node)
 				{"stopover", STOPOVER},
 				{"waypoint", WAYPOINT},
 				{"daily", DAILY},
+				{"disabled", DISABLED},
 			};
 			auto it = trigger.find(child.Token(1));
 			if(it != trigger.end())
@@ -1143,6 +1146,9 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 				Messages::Add(message + "Mission failed: \"" + displayName + "\".", Messages::Importance::Highest);
 		}
 	}
+
+	if(event.Type() & ShipEvent::DISABLE && event.Target().get() == player.Flagship())
+		Do(DISABLED, player, ui);
 
 	// Jump events are only created for the player's flagship.
 	if((event.Type() & ShipEvent::JUMP) && event.Actor())

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1147,7 +1147,7 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 		}
 	}
 
-	if(event.Type() & ShipEvent::DISABLE && event.Target().get() == player.Flagship())
+	if((event.Type() & ShipEvent::DISABLE) && event.Target().get() == player.Flagship())
 		Do(DISABLED, player, ui);
 
 	// Jump events are only created for the player's flagship.

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -153,7 +153,7 @@ public:
 	// information or show new UI panels. PlayerInfo::MissionCallback() will be
 	// used as the callback for an `on offer` conversation, to handle its response.
 	// If it is not possible for this change to happen, this function returns false.
-	enum Trigger {COMPLETE, OFFER, ACCEPT, DECLINE, FAIL, ABORT, DEFER, VISIT, STOPOVER, WAYPOINT, DAILY};
+	enum Trigger {COMPLETE, OFFER, ACCEPT, DECLINE, FAIL, ABORT, DEFER, VISIT, STOPOVER, WAYPOINT, DAILY, DISABLED};
 	bool Do(Trigger trigger, PlayerInfo &player, UI *ui = nullptr, const std::shared_ptr<Ship> &boardingShip = nullptr);
 
 	// Get a list of NPCs associated with this mission. Every time the player

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2942,8 +2942,10 @@ void PlayerInfo::RegisterDerivedConditions()
 	flagshipModelProvider.SetGetFunction(flagshipModelFun);
 
 	auto &&flagshipDisabledProvider = conditions.GetProviderNamed("flagship disabled");
-	auto flagshipDisabledFun = [this](const string &name) -> bool {
-		return flagship && flagship->IsDisabled(); };
+	auto flagshipDisabledFun = [this](const string &name) -> bool
+	{
+		return flagship && flagship->IsDisabled();
+	};
 	flagshipDisabledProvider.SetHasFunction(flagshipDisabledFun);
 	flagshipDisabledProvider.SetGetFunction(flagshipDisabledFun);
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2941,6 +2941,12 @@ void PlayerInfo::RegisterDerivedConditions()
 	flagshipModelProvider.SetHasFunction(flagshipModelFun);
 	flagshipModelProvider.SetGetFunction(flagshipModelFun);
 
+	auto &&flagshipDisabledProvider = conditions.GetProviderNamed("flagship disabled");
+	auto flagshipDisabledFun = [this](const string &name) -> bool {
+		return flagship && flagship->IsDisabled(); };
+	flagshipDisabledProvider.SetHasFunction(flagshipDisabledFun);
+	flagshipDisabledProvider.SetGetFunction(flagshipDisabledFun);
+
 	auto flagshipAttributeHelper = [](const Ship *flagship, const string &attribute, bool base) -> int64_t
 	{
 		if(!flagship)


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #8603

## Feature Details
 - Added a new mission trigger and an `"on disabled"` node. It fires up when player's flagship becomes disabled.
 - Added a condition returning 1 if the flagship is disabled.

## Testing Done
Both the trigger and the condition have been tested by inserting some conversations into a mission.

## Performance Impact
Probably none.