### PR TITLE
Update Actions and dependencies

### DIFF
--- a/.github/sccache/action.yml
+++ b/.github/sccache/action.yml
@@ -8,7 +8,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set environment variables
-      run: echo "SCCACHE_VERSION=v0.3.3" >> $GITHUB_ENV
+      run: echo "SCCACHE_VERSION=v0.4.1" >> $GITHUB_ENV
       shell: bash
     - name: Download sccache
       run: |

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,20 +35,15 @@ jobs:
       - name: Adjust version strings
         run: ./utils/cd_update_versions.sh
       - uses: lukka/get-cmake@latest
-      - uses: lukka/run-vcpkg@v10
+      - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
+          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'linux-release'
           buildPreset: 'linux-ci-release'
       - name: Package Application
         run: ./utils/build_appimage.sh build/release
-      - name: Prevent saving cache on failure
-        run: |
-          echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-        if: ${{ failure() || cancelled() }}
-        shell: bash
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -71,9 +66,9 @@ jobs:
         run: ./utils/cd_update_versions.sh
         shell: bash
       - uses: lukka/get-cmake@latest
-      - uses: lukka/run-vcpkg@v10
+      - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
+          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'mingw-release'
@@ -82,11 +77,6 @@ jobs:
         run: |
           cmake --install build/release
           7z a ${{ env.OUTPUT }} "./install/release/*"
-      - name: Prevent saving cache on failure
-        run: |
-          echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-        if: ${{ failure() || cancelled() }}
-        shell: bash
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -108,9 +98,9 @@ jobs:
       - name: Install pkg-config
         run: type -P pkg-config || brew install pkg-config
       - uses: lukka/get-cmake@latest
-      - uses: lukka/run-vcpkg@v10
+      - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
+          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'macos-release'
@@ -119,11 +109,6 @@ jobs:
         run: |
           cmake --install build/release
           7z a ${{ env.OUTPUT }} "./install/release/*"
-      - name: Prevent saving cache on failure
-        run: |
-          echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-        if: ${{ failure() || cancelled() }}
-        shell: bash
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -37,7 +37,8 @@ jobs:
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
+          vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'linux-release'
@@ -68,7 +69,8 @@ jobs:
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
+          vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'mingw-release'
@@ -100,7 +102,8 @@ jobs:
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
+          vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'macos-release'

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -25,20 +25,15 @@ jobs:
         with:
           read-only: 'true'
       - uses: lukka/get-cmake@latest
-      - uses: lukka/run-vcpkg@v10
+      - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
+          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'linux-release'
           buildPreset: 'linux-ci-release'
       - name: Package Application
         run: ./utils/build_appimage.sh build/release
-      - name: Prevent saving cache on failure
-        run: |
-          echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-        if: ${{ failure() || cancelled() }}
-        shell: bash
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
@@ -57,9 +52,9 @@ jobs:
       - name: Install x86 MinGW
         run: choco install mingw --forcex86 --force
       - uses: lukka/get-cmake@latest
-      - uses: lukka/run-vcpkg@v10
+      - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
+          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
           prependedCacheKey: mingw-x86
       - uses: lukka/run-cmake@v10
         with:
@@ -69,11 +64,6 @@ jobs:
         run: |
           cmake --install build/release
           7z a ${{ env.OUTPUT }} "./install/release/*"
-      - name: Prevent saving cache on failure
-        run: |
-          echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-        if: ${{ failure() || cancelled() }}
-        shell: bash
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
@@ -94,9 +84,9 @@ jobs:
         with:
           read-only: 'true'
       - uses: lukka/get-cmake@latest
-      - uses: lukka/run-vcpkg@v10
+      - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
+          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'mingw-release'
@@ -105,11 +95,6 @@ jobs:
         run: |
           cmake --install build/release
           7z a ${{ env.OUTPUT }} "./install/release/*"
-      - name: Prevent saving cache on failure
-        run: |
-          echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-        if: ${{ failure() || cancelled() }}
-        shell: bash
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
@@ -132,9 +117,9 @@ jobs:
       - name: Install pkg-config
         run: type -P pkg-config || brew install pkg-config
       - uses: lukka/get-cmake@latest
-      - uses: lukka/run-vcpkg@v10
+      - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
+          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'macos-arm-release'
@@ -159,11 +144,6 @@ jobs:
           cp -r "Endless Sky.app" "${{ env.OUTPUT }}"
           ln -s /Applications "${{ env.OUTPUT }}"
           hdiutil create -ov -fs HFS+ -format UDZO -imagekey zlib-level=9 -srcfolder "${{ env.OUTPUT }}" "${{ github.workspace }}/${{ env.OUTPUT }}.dmg"
-      - name: Prevent saving cache on failure
-        run: |
-          echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-        if: ${{ failure() || cancelled() }}
-        shell: bash
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -27,7 +27,8 @@ jobs:
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
+          vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'linux-release'
@@ -54,8 +55,8 @@ jobs:
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
-          prependedCacheKey: mingw-x86
+          vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'mingw32-release'
@@ -86,7 +87,8 @@ jobs:
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
+          vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'mingw-release'
@@ -119,7 +121,8 @@ jobs:
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
+          vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'macos-arm-release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
     - uses: lukka/get-cmake@latest
     - uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
+        vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+        doNotCache: true
     - uses: lukka/run-cmake@v10
       with:
         configurePreset: ${{ matrix.opengl == 'GL' && 'linux-ci' || 'linux-gles-ci' }}
@@ -85,7 +86,8 @@ jobs:
     - uses: lukka/get-cmake@latest
     - uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
+        vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+        doNotCache: true
     - uses: lukka/run-cmake@v10
       with:
         configurePreset: 'mingw-ci'
@@ -119,8 +121,8 @@ jobs:
     - uses: lukka/get-cmake@latest
     - uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
-        prependedCacheKey: vs-x64
+        vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+        doNotCache: true
     - uses: lukka/run-cmake@v10
       with:
         configurePreset: 'clang-cl-ci'
@@ -146,7 +148,8 @@ jobs:
     - uses: lukka/get-cmake@latest
     - uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
+        vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
+        doNotCache: true
     - uses: lukka/run-cmake@v10
       with:
         configurePreset: 'macos-ci'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,9 @@ jobs:
     - name: Setup sccache
       uses: ./.github/sccache
     - uses: lukka/get-cmake@latest
-    - uses: lukka/run-vcpkg@v10
+    - uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
+        vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
     - uses: lukka/run-cmake@v10
       with:
         configurePreset: ${{ matrix.opengl == 'GL' && 'linux-ci' || 'linux-gles-ci' }}
@@ -69,11 +69,6 @@ jobs:
         testPreset: ${{ matrix.opengl == 'GL' && 'linux-ci' || 'linux-gles-ci' }}
     - name: Run Benchmarks
       run: ctest --preset ${{ matrix.opengl == 'GL' && 'linux-ci-benchmark' || 'linux-gles-ci-benchmark' }}
-    - name: Prevent saving cache on failure
-      run: |
-        echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-      if: ${{ failure() || cancelled() }}
-      shell: bash
 
 
   build_windows:
@@ -88,21 +83,16 @@ jobs:
     - name: Setup sccache
       uses: ./.github/sccache
     - uses: lukka/get-cmake@latest
-    - uses: lukka/run-vcpkg@v10
+    - uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
-    - uses: lukka/run-cmake@v10
+        vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
+    - uses: lukka/run-cmake@v11
       with:
         configurePreset: 'mingw-ci'
         buildPreset: 'mingw-ci'
         testPreset: 'mingw-ci'
     - name: Run Benchmarks
       run: ctest --preset mingw-ci-benchmark
-    - name: Prevent saving cache on failure
-      run: |
-        echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-      if: ${{ failure() || cancelled() }}
-      shell: bash
     - name: Upload binary
       uses: actions/upload-artifact@v3
       with:
@@ -127,9 +117,9 @@ jobs:
     - name: Setup sccache
       uses: ./.github/sccache
     - uses: lukka/get-cmake@latest
-    - uses: lukka/run-vcpkg@v10
+    - uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
+        vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
         prependedCacheKey: vs-x64
     - uses: lukka/run-cmake@v10
       with:
@@ -138,11 +128,6 @@ jobs:
         testPreset: 'clang-cl-ci'
     - name: Run Benchmarks
       run: ctest --preset clang-cl-ci-benchmark
-    - name: Prevent saving cache on failure
-      run: |
-        echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-      if: ${{ failure() || cancelled() }}
-      shell: bash
 
 
   build_macos:
@@ -159,9 +144,9 @@ jobs:
     - name: Install pkg-config
       run: type -P pkg-config || brew install pkg-config
     - uses: lukka/get-cmake@latest
-    - uses: lukka/run-vcpkg@v10
+    - uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: '91dd61bd441a68b4017b61011d0350b2e6aeeccf'
+        vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
     - uses: lukka/run-cmake@v10
       with:
         configurePreset: 'macos-ci'
@@ -169,11 +154,6 @@ jobs:
         testPreset: 'macos-ci'
     - name: Run Benchmarks
       run: ctest --preset macos-ci-benchmark
-    - name: Prevent saving cache on failure
-      run: |
-        echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
-      if: ${{ failure() || cancelled() }}
-      shell: bash
 
 
   test-parse:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     - uses: lukka/run-vcpkg@v11
       with:
         vcpkgGitCommitId: 'c9f906558f9bb12ee9811d6edc98ec9255c6cda5'
-    - uses: lukka/run-cmake@v11
+    - uses: lukka/run-cmake@v10
       with:
         configurePreset: 'mingw-ci'
         buildPreset: 'mingw-ci'

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "builtin",
-    "baseline": "c9f906558f9bb12ee9811d6edc98ec9255c6cda5"
+    "baseline": "69efe9cc2df0015f0bb2d37d55acde4a75c9a25b"
   },
   "overlay-triplets": [ "./overlays" ]
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "builtin",
-    "baseline": "91dd61bd441a68b4017b61011d0350b2e6aeeccf"
+    "baseline": "c9f906558f9bb12ee9811d6edc98ec9255c6cda5"
   },
   "overlay-triplets": [ "./overlays" ]
 }


### PR DESCRIPTION
Another round of updating our dependencies and actions. CI runs should finish quicker because of better caching by the run-vcpkg action.