### PR TITLE
Feature: Middle mouse button hold-enable mouse control

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2074,7 +2074,11 @@ void Engine::HandleMouseClicks()
 // Determines alternate mouse turning, setting player mouse angle, and right-click firing weapons.
 void Engine::HandleMouseInput(Command &activeCommands)
 {
-	isMouseHoldEnabled = activeCommands.Has(Command::MOUSE_TURNING_HOLD);
+	int mousePosX;
+	int mousePosY;
+	Uint32 mouseState = SDL_GetMouseState(&mousePosX, &mousePosY);
+	bool middleMouseButtonHeld = ((mouseState & SDL_BUTTON_MMASK) != 0);
+	isMouseHoldEnabled = activeCommands.Has(Command::MOUSE_TURNING_HOLD) || middleMouseButtonHeld;
 	if(activeCommands.Has(Command::MOUSE_TURNING_TOGGLE))
 	{
 		isMouseToggleEnabled = !isMouseToggleEnabled;
@@ -2088,9 +2092,7 @@ void Engine::HandleMouseInput(Command &activeCommands)
 		return;
 	activeCommands.Set(Command::MOUSE_TURNING_HOLD);
 	bool rightMouseButtonHeld = false;
-	int mousePosX;
-	int mousePosY;
-	if((SDL_GetMouseState(&mousePosX, &mousePosY) & SDL_BUTTON_RMASK) != 0)
+	if((mouseState & SDL_BUTTON_RMASK) != 0)
 		rightMouseButtonHeld = true;
 	double relX = mousePosX - Screen::RawWidth() / 2;
 	double relY = mousePosY - Screen::RawHeight() / 2;


### PR DESCRIPTION
Feature Details
---------------

For a keyboard and mouse, the Left+Alt shortcut is not good for mouse hold shortcut.  If a user attempts to toggle mouse control and fire they press the shortcut Alt+Tab.

This feature request supports the following:

- Enables middle mouse button (not a configurable shortcut) to hold/temporarily enable mouse control.  This is beneficial because it is natural to hold middle mouse button and right click to fire when mouse control is enabled.
- Keep mouse toggle configurable shortcut.  This should remain configurable so that users with broken middle mouse buttons or with a different shortcut preference can customize the shortcut for holding down mouse control.

**Please note:** if a user uses left alt to toggle mouse control you can still use right mouse click to fire instead of Tab.

Usage Examples
--------------

1. Start a new game with a fighter.
2. Fly up to an asteroid without an asteroid scanner.
3. Hold middle mouse button (to temporarily enable mouse control) and then right click to fire at the asteroid.

Related Issues
--------------

* https://github.com/endless-sky/endless-sky/pull/8519
* https://github.com/endless-sky/endless-sky/issues/8419

Testing Done
------------

- [x] Left alt still works to temporarily enable mouse control.  Right clicking still fires.
- [x] Middle mouse button works to temporarily enable mouse control.  Right clicking still fires.
- [x] Right alt still permanently enables mouse control as a toggle.  Pressing right alt again will toggle mouse control.

Performance Impact
------------------

None