### PR TITLE
Fix MMK hails

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -158,7 +158,6 @@ person "Marauding Max"
 			"got what it takes to "
 			"got the gumption to "
 			"could "
-			"are capable of "
 			"have the guramba to "
 			"are good enough to "
 		word

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -154,16 +154,9 @@ person "Marauding Max"
 			"Do you think you "
 			"Ever wondered if you "
 			"Think you'll also need some luck if you "
-		word
-			"got what it takes to "
-			"got the gumption to "
-			"could "
-			"have the guramba to "
-			"are good enough to "
-		word
-			"capture "
-			"collect "
-			"gather "
+		phrase
+			"MMK subphrase 1" 5
+			"MMK subphrase 2"
 		word
 			"all 28 Marauder models?"
 	phrase
@@ -214,6 +207,26 @@ person "Marauding Max"
 		word
 			"into a REAL marauding warship!"
 	ship "Marauder Fury" "Mad Quest"
+
+phrase "MMK subphrase 1"
+	word
+		"got what it takes to "
+		"got the gumption to "
+		"could "
+		"have the guramba to "
+		"are good enough to "
+	word
+		"capture "
+		"collect "
+		"gather "
+
+phrase "MMK subphrase 2"
+	word
+		"are capable of "
+	word
+		"capturing "
+		"collecting "
+		"gathering "
 
 ship "Marauder Fury"
 	plural "Marauder Furies"


### PR DESCRIPTION
**Bugfix:**

Thanks to @Ferociousfeind for reporting this on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1091776239712346142).

## Fix Details
The `are capable of` option does not produce grammatically correct phrases.
This PR splits this into separate subphrases so a correct sentence is always formed.
An alternative would be to just remove hte line that gives rise to the offending sequence.
