### PR TITLE
Fix some outfitter buttons bugs

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -509,7 +509,7 @@ int CargoHold::Add(const Outfit *outfit, int amount)
 	// If the outfit has mass and this cargo hold has a size limit, apply it.
 	double mass = outfit->Mass();
 	if(size >= 0 && mass > 0.)
-		amount = max(0, min(amount, static_cast<int>(Free() / mass)));
+		amount = max(0, min(amount, static_cast<int>(FreePrecise() / mass)));
 	outfits[outfit] += amount;
 	return amount;
 }

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -421,7 +421,7 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 	{
 		// Buying into cargo, so check cargo space vs mass.
 		double mass = selectedOutfit->Mass();
-		double freeCargo = player.Cargo().Free();
+		double freeCargo = player.Cargo().FreePrecise();
 		if(!mass || freeCargo >= mass)
 			return true;
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -361,11 +361,17 @@ void ShopPanel::DrawButtons()
 
 	const Point buyCenter = Screen::BottomRight() - Point(210, 25);
 	FillShader::Fill(buyCenter, Point(60, 30), back);
+	const Color &buyTextColor;
+	if(!CanBuy(IsAlreadyOwned()))
+		buyTextColor = inactive;
+	else if(hoverButton == (IsAlreadyOwned() ? 'i' : 'b'))
+		buyTextColor = hover;
+	else
+		buyTextColor = active;
 	string BUY = IsAlreadyOwned() ? (playerShip ? "_Install" : "_Cargo") : "_Buy";
 	bigFont.Draw(BUY,
 		buyCenter - .5 * Point(bigFont.Width(BUY), bigFont.Height()),
-		CanBuy(IsAlreadyOwned()) ? hoverButton == (IsAlreadyOwned() ? 'i' : 'b')
-		? hover : active : inactive);
+		buyTextColor);
 
 	const Point sellCenter = Screen::BottomRight() - Point(130, 25);
 	FillShader::Fill(sellCenter, Point(60, 30), back);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -361,14 +361,15 @@ void ShopPanel::DrawButtons()
 
 	const Point buyCenter = Screen::BottomRight() - Point(210, 25);
 	FillShader::Fill(buyCenter, Point(60, 30), back);
+	bool isOwned = IsAlreadyOwned();
 	const Color *buyTextColor;
-	if(!CanBuy(IsAlreadyOwned()))
+	if(!CanBuy(isOwned))
 		buyTextColor = &inactive;
-	else if(hoverButton == (IsAlreadyOwned() ? 'i' : 'b'))
+	else if(hoverButton == (isOwned ? 'i' : 'b'))
 		buyTextColor = &hover;
 	else
 		buyTextColor = &active;
-	string BUY = IsAlreadyOwned() ? (playerShip ? "_Install" : "_Cargo") : "_Buy";
+	string BUY = isOwned ? (playerShip ? "_Install" : "_Cargo") : "_Buy";
 	bigFont.Draw(BUY,
 		buyCenter - .5 * Point(bigFont.Width(BUY), bigFont.Height()),
 		*buyTextColor);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -364,7 +364,8 @@ void ShopPanel::DrawButtons()
 	string BUY = IsAlreadyOwned() ? (playerShip ? "_Install" : "_Cargo") : "_Buy";
 	bigFont.Draw(BUY,
 		buyCenter - .5 * Point(bigFont.Width(BUY), bigFont.Height()),
-		CanBuy() ? hoverButton == 'b' ? hover : active : inactive);
+		CanBuy(IsAlreadyOwned()) ? hoverButton == (IsAlreadyOwned() ? 'i' : 'b')
+		? hover : active : inactive);
 
 	const Point sellCenter = Screen::BottomRight() - Point(130, 25);
 	FillShader::Fill(sellCenter, Point(60, 30), back);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -361,17 +361,17 @@ void ShopPanel::DrawButtons()
 
 	const Point buyCenter = Screen::BottomRight() - Point(210, 25);
 	FillShader::Fill(buyCenter, Point(60, 30), back);
-	const Color &buyTextColor;
+	const Color *buyTextColor;
 	if(!CanBuy(IsAlreadyOwned()))
-		buyTextColor = inactive;
+		buyTextColor = &inactive;
 	else if(hoverButton == (IsAlreadyOwned() ? 'i' : 'b'))
-		buyTextColor = hover;
+		buyTextColor = &hover;
 	else
-		buyTextColor = active;
+		buyTextColor = &active;
 	string BUY = IsAlreadyOwned() ? (playerShip ? "_Install" : "_Cargo") : "_Buy";
 	bigFont.Draw(BUY,
 		buyCenter - .5 * Point(bigFont.Width(BUY), bigFont.Height()),
-		buyTextColor);
+		*buyTextColor);
 
 	const Point sellCenter = Screen::BottomRight() - Point(130, 25);
 	FillShader::Fill(sellCenter, Point(60, 30), back);


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8623
## Fix Details
 - Fixed the `Cargo` button text being always dark, and the `Install` button not highlighting on hover.
 - Changed the value of one variable in the CanBuy function that should definitely use the floating-point FreePrecise instead of the integer Free.