### PR TITLE
Fix license duplication in outfitter panel

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -85,17 +85,6 @@ OutfitterPanel::OutfitterPanel(PlayerInfo &player)
 	for(pair<const string, vector<string>> &it : catalog)
 		sort(it.second.begin(), it.second.end(), BySeriesAndIndex<Outfit>());
 
-	// Add owned licenses
-	const string PREFIX = "license: ";
-	for(auto it = player.Conditions().PrimariesBegin(); it != player.Conditions().PrimariesEnd(); ++it)
-		if(it->first.compare(0, PREFIX.length(), PREFIX) == 0 && it->second > 0)
-		{
-			const string name = it->first.substr(PREFIX.length()) + " License";
-			const Outfit *outfit = GameData::Outfits().Get(name);
-			if(outfit)
-				catalog[outfit->Category()].push_back(name);
-		}
-
 	if(player.GetPlanet())
 		outfitter = player.GetPlanet()->Outfitter();
 }


### PR DESCRIPTION
**Bugfix:**

Thanks to `@Viro#7921` for reporting this on Discord.

## Fix Details
The use of an `std::vector` instead of an `std::set` to store the outfit lists means the items in the collections are not automatically kept unique.
This leads to any licenses the player has appearing twice:
- They are initially added to the list when traversing `GameData::Outfits()`.
- And then again when checking the player's conditions for licenses they might have.
Because, in order to appear in the outfitter, a license condition the player has must still exist as an outfit in `GameData::Outfits()`, it is not actually necessary to check the conditions and add licenses to the `catalog` here, any license with a valid outfit will already be in the `catalog`, and any without would not be added anyway.

## Testing Done
Visit the outfitter with various licenses and see that the ones I have are now no longer duplicated.

bug | with this PR
-- | --
![image](https://user-images.githubusercontent.com/20605679/229575214-7b34b681-e504-4b1e-b1c6-75a5ebf746ce.png) | ![image](https://user-images.githubusercontent.com/20605679/229575731-fc71c1a0-cd0a-4124-a33c-28a0dbfaf05b.png)
![image](https://user-images.githubusercontent.com/20605679/229575329-1a24110d-f051-44ae-9aef-e4591f0d4652.png) | ![image](https://user-images.githubusercontent.com/20605679/229575565-784452fd-a9e3-4c91-a612-9132830243f6.png)


