### PR TITLE
Give MZ credit for tooltips.txt

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -1,3 +1,16 @@
+# Copyright (c) 2016 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+
 # Outfit and ship attributes:
 tip "active cooling:"
 	`Provides up to this amount of cooling per second. Active cooling requires energy, but if your heat level is low it runs at a lower cooling rate and lower energy draw. The amount of cooling is proportional to the temperature of your ship, reaching the full level only if you are about to overheat.`

--- a/utils/contentStyle.json
+++ b/utils/contentStyle.json
@@ -7,7 +7,7 @@
 		"forceUnixLineSeparator": true,
 		"trailingEmptyLine": "always",
 		"checkCopyright": true,
-		"copyrightBlacklist": ["data/tooltips.txt"],
+		"copyrightBlacklist": [],
 		"copyrightFormats": [
 			{
 				"holder": "^# (Based on earlier text copyright|Copyright) \\(c\\) \\d{4}(?:(?:-|, )\\d{4})? (by )?.+$",


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8629.

## Fix Details
I used `git log --follow --diff-filter=A --find-renames=40% data/tooltips.txt` to find out when the file was added, and then added a copyright header to it which gives MZ credit for it.

## Testing Done
I opened up Endless Sky and hovered over things to make sure tooltips still popped up.

## Save File
N/A