### PR TITLE
feat(outfitter UI): Point ships that have the selected item installed

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -268,6 +268,10 @@ void ShopPanel::DrawShipsSidebar()
 			}
 		}
 
+		if(ship->OutfitCount(selectedOutfit))
+			PointerShader::Draw(Point(point.X() - static_cast<int>(ICON_TILE / 3), point.Y()),
+				Point(1., 0.), 14.f, 12.f, 0., Color(.9f, .9f, .9f, .2f));
+
 		point.X() += ICON_TILE;
 	}
 	point.Y() += ICON_TILE;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -268,7 +268,7 @@ void ShopPanel::DrawShipsSidebar()
 			}
 		}
 
-		if(ship->OutfitCount(selectedOutfit))
+		if(isSelected && playerShips.size() > 1 && ship->OutfitCount(selectedOutfit))
 			PointerShader::Draw(Point(point.X() - static_cast<int>(ICON_TILE / 3), point.Y()),
 				Point(1., 0.), 14.f, 12.f, 0., Color(.9f, .9f, .9f, .2f));
 


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed in issue #8635.

## Feature Details
If more than one ship is selected on the sidebar, all selected ships that have the selected outfit installed are marked with a pointer.

## UI Screenshots
![scr_a](https://user-images.githubusercontent.com/108272452/230459877-105127c7-d0f2-488c-aa50-1deb894c42b6.png)

![scr_b](https://user-images.githubusercontent.com/108272452/230460097-fdc6cd2f-03f2-4be5-a8e6-8aed76d056ef.png)

## Performance Impact
N/A
