### PR TITLE
code style: Count tabs as four characters each when calculating line length

### DIFF
--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -493,8 +493,14 @@ def check_line_format(lines):
 	line_count = 0
 	for line in lines:
 		line_count += 1
-		if len(line) > 120:
-			errors.append(Error(line, line_count, "lines should hard wrap at 120 characters"))
+		length = 0
+		for char in line:
+			if char == '\t':
+				length += 4
+			else:
+				length += 1
+		if length > 120:
+			errors.append(Error(line, line_count, "lines should hard wrap at 120 characters, with tabs counting as 4"))
 		for char in line:
 			if ord(char) < 0 or ord(char) > 127:
 				errors.append(Error(line, line_count, "files should be plain ASCII"))


### PR DESCRIPTION
## Refactor Details
Modified the script for checking code style so that the line length calculation assumes every `\t` is four characters long.
**Reasoning:**
For example, line A has 120 normal chars, while line B has 117 normal chars and 3 tabs of indent. Visually line B is longer, despite being technically the same length as line A. That inconsistency makes it somewhat hard to determine whether a line should be hard-wrapped.

## Feedback Needed
Leaving the limit at 120 characters results in a few dozen errors when examining the source files. I need to know if it would be better to raise the limit (when set to 130, it gave only three errors, the longest line being 133 iirc), or just adapt the code to the new standard.