### PR TITLE
feat(content): Reduce payment of "Deal Change 2"

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -11,6 +11,14 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
+mission "bribe test"
+	job
+	repeat
+	npc
+		government "Bounty Hunter"
+		personality staying
+		ship "Sparrow" "Bribe Me"
+
 # Ships of these types can be purchased and also used as mission sources.
 category "ship"
 	"Transport"

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5405,7 +5405,7 @@ mission "Deal Change 2"
 				accept
 	on complete
 		fail "Deal Change 1"
-		payment 500000
+		payment 250000
 		conversation
 			`You follow the coordinates to a clearing within the forests of Greenrock. Several other ships are present near the landing site, all of which wear pirate colors. A person wearing a cloak steps out of one of the vessels to greet you. "I am glad that you were able to trust us," they say. "My name is not Ci, but you may refer to me as such." A gang of pirates emerges from the foliage around your ship and begin to unload the cargo from your ship.`
 			choice

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5320,7 +5320,7 @@ mission "Deal Change 1"
 		attributes "paradise"
 	destination "Skymoot"
 	to offer
-		random < 35
+		random < 10
 	on offer
 		conversation
 			`The spaceport on <origin> is as spirited as ever: to your left, a family wearing floral shirts pull along their luggage, with the man of the family flaunting a souvenir from some far-away planet. To your right, a cleaner whistles a tuneless song while they wipe down a bench.`
@@ -5403,9 +5403,20 @@ mission "Deal Change 2"
 			label accept
 			`	You stand up and stuff the note in your pocket before continuing towards the spaceport.`
 				accept
+	npc
+		government "Bounty Hunter"
+		personality staying nemesis
+		system "Lesath"
+		ship "Falcon (Heavy)" "Turncoat"
+		ship "Clipper" "Deserter"
+	npc
+		government "Bounty Hunter"
+		personality staying nemesis
+		system "Shaula"
+		ship "Osprey (Laser)" "Sellout"
 	on complete
 		fail "Deal Change 1"
-		payment 250000
+		payment 300000
 		conversation
 			`You follow the coordinates to a clearing within the forests of Greenrock. Several other ships are present near the landing site, all of which wear pirate colors. A person wearing a cloak steps out of one of the vessels to greet you. "I am glad that you were able to trust us," they say. "My name is not Ci, but you may refer to me as such." A gang of pirates emerges from the foliage around your ship and begin to unload the cargo from your ship.`
 			choice


### PR DESCRIPTION
Halves the mission's payment, so you can't pay off your entire mortgage in a single mission.