### PR TITLE
Bugfix: Mining AI, melee, and other AI distance fix

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2395,14 +2395,19 @@ void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 	// First of all, aim in the direction that will hit this target.
 	AimToAttack(ship, command, target);
 
+	// Calculate this ship's "turning radius"; that is, the smallest circle it
+	// can make while at its current speed.
+	double stepsInFullTurn = 360. / ship.TurnRate();
+	double circumference = stepsInFullTurn * ship.Velocity().Length();
+	double diameter = max(200., circumference / PI);
+
 	const auto facing = ship.Facing().Unit().Dot(direction.Unit());
 	// If the ship has reverse thrusters and the target is behind it, we can
 	// use them to reach the target more quickly.
 	if(facing < -.75 && ship.Attributes().Get("reverse thrust"))
 		command |= Command::BACK;
 	// This isn't perfect, but it works well enough.
-	else if((facing >= 0. &&
-			direction.Length() > max(200., ship.GetAICache().TurningRadius()))
+	else if((facing >= 0. && direction.Length() > diameter)
 			|| (ship.Velocity().Dot(direction) < 0. &&
 				facing) >= .9)
 		command |= Command::FORWARD;

--- a/source/ship/ShipAICache.cpp
+++ b/source/ship/ShipAICache.cpp
@@ -81,7 +81,7 @@ void ShipAICache::Calibrate(const Ship &ship)
 	// can make while at full speed.
 	double stepsInHalfTurn = 180. / ship.TurnRate();
 	double circumference = stepsInHalfTurn * ship.MaxVelocity();
-	turningRadius = circumference / PI;
+	maxTurningRadius = circumference / PI;
 
 	// If this ship was using the artillery AI to run away and bombard its
 	// target from a distance, have it stop running once it is out of ammo. This
@@ -98,12 +98,12 @@ void ShipAICache::Calibrate(const Ship &ship)
 		// The AI shouldn't use the artillery AI if it has no reverse and it's turning
 		// capabilities are very bad. Otherwise it spends most of it's time flying around.
 		useArtilleryAI = (artilleryDPS > totalDPS * .75
-			&& (ship.MaxReverseVelocity() || turningRadius < 0.2 * shortestArtillery));
+			&& (ship.MaxReverseVelocity() || maxTurningRadius < 0.2 * shortestArtillery));
 
 		// Don't try to avoid your own splash damage if it means you whould be losing out
 		// on a lot of DPS. Helps with ships with very slow turning and not a lot of splash
 		// weapons being overly afraid of dying.
-		if(minSafeDistance && !(useArtilleryAI || shortestRange * (splashDPS / totalDPS) > turningRadius))
+		if(minSafeDistance && !(useArtilleryAI || shortestRange * (splashDPS / totalDPS) > maxTurningRadius))
 			minSafeDistance = 0.;
 	}
 }

--- a/source/ship/ShipAICache.h
+++ b/source/ship/ShipAICache.h
@@ -36,7 +36,6 @@ public:
 	double ShortestRange() const;
 	double ShortestArtillery() const;
 	double MinSafeDistance() const;
-	double TurningRadius() const;
 
 
 private:
@@ -46,7 +45,7 @@ private:
 	double shortestRange = 1000.;
 	double shortestArtillery = 4000.;
 	double minSafeDistance = 0.;
-	double turningRadius = 200.;
+	double maxTurningRadius = 200.;
 };
 
 
@@ -56,7 +55,6 @@ inline bool ShipAICache::IsArtilleryAI() const { return useArtilleryAI; }
 inline double ShipAICache::ShortestRange() const { return shortestRange; }
 inline double ShipAICache::ShortestArtillery() const { return shortestArtillery; }
 inline double ShipAICache::MinSafeDistance() const { return minSafeDistance; }
-inline double ShipAICache::TurningRadius() const { return turningRadius; }
 
 
 


### PR DESCRIPTION
Fix Details
-----------

Player escorts and AI escorts misbehave while attacking asteroids.  This fix addresses the issue by reverting a small code change previously made.

Partially reverts https://github.com/endless-sky/endless-sky/pull/7552

The turning radius needs to be calculated based on the ship's current speed instead of the absolute max speed.  This widely varies based on the current ship accelleration and velocity.

This also fixes my afterburner fighter AI which was completely broken due to high ship speeds and accelleration.

Testing Done
------------

- [x] Load ships and AI without the fix and replicated the current (bad) behavior.
- [x] With this fix witnessed the issue is repaired.

Tested with normal fighters doing mining and with after burner fighters mining with extreme speeds.

Performance Impact
------------------

None