### PR TITLE
Bugfix: Remove turning flares while stopping

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2028,7 +2028,7 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition,
 
 	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .95);
 	if(!isClose || (!isFacing && !shouldReverse))
-		command.SetTurn(TurnToward(ship, dp, 0.9999));
+		command.SetTurn(TurnToward(ship, dp));
 	if(isFacing)
 		command |= Command::FORWARD;
 	else if(shouldReverse)
@@ -2093,7 +2093,7 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed, const Point directi
 
 		if(reverseTime < forwardTime)
 		{
-			command.SetTurn(TurnToward(ship, velocity, 0.9999));
+			command.SetTurn(TurnToward(ship, velocity));
 			if(velocity.Unit().Dot(angle.Unit()) > limit)
 				command |= Command::BACK;
 			return false;
@@ -3980,7 +3980,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 
 	const bool mouseTurning = activeCommands.Has(Command::MOUSE_TURNING_HOLD);
 	if(mouseTurning && !ship.IsBoarding() && !ship.IsReversing())
-		command.SetTurn(TurnToward(ship, mousePosition, 0.9999));
+		command.SetTurn(TurnToward(ship, mousePosition));
 
 	if(activeCommands)
 	{

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2093,7 +2093,7 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed, const Point directi
 
 		if(reverseTime < forwardTime)
 		{
-			command.SetTurn(TurnToward(ship, velocity));
+			command.SetTurn(TurnToward(ship, velocity, 0.9999));
 			if(velocity.Unit().Dot(angle.Unit()) > limit)
 				command |= Command::BACK;
 			return false;

--- a/source/AI.h
+++ b/source/AI.h
@@ -104,7 +104,7 @@ private:
 	// Determine the value to use in Command::SetTurn() to turn the ship towards the desired facing.
 	// "precision" is an optional argument corresponding to a value of the dot product of the current and target facing
 	// vectors above which no turning should be attempting, to reduce constant, minute corrections.
-	static double TurnToward(const Ship &ship, const Point &vector, const double precision = 1.);
+	static double TurnToward(const Ship &ship, const Point &vector, const double precision = 0.9999);
 	static bool MoveToPlanet(Ship &ship, Command &command);
 	static bool MoveTo(Ship &ship, Command &command, const Point &targetPosition,
 		const Point &targetVelocity, double radius, double slow);


### PR DESCRIPTION
Fix Details
-----------

A player might stop with shift+down or they might be jumping through systems.  If a player is hyper-jumping or stopping, the right-side flares thrust.

### Before

See the subtle right-side thrust flares while stopping.

https://user-images.githubusercontent.com/875669/230754469-c6f20359-0c6b-4c92-89e3-29f271d1c5f5.mp4

### After

In this hyper-jump notice there are no flares on the right side while the ship stops.

https://user-images.githubusercontent.com/875669/230754467-5a44f506-82db-4ec5-aef8-35935f94873d.mp4

Testing Done
------------

- [x] Stop ship and reproduced bug reported on discord
- [x] Made fix and verified bug no longer occurs after.