### PR TITLE
Don't disable steering keys while mouse turning is on

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3986,7 +3986,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 	{
 		if(activeCommands.Has(Command::FORWARD))
 			command |= Command::FORWARD;
-		if(activeCommands.Has(Command::RIGHT | Command::LEFT) && !mouseTurning)
+		if(activeCommands.Has(Command::RIGHT | Command::LEFT))
 			command.SetTurn(activeCommands.Has(Command::RIGHT) - activeCommands.Has(Command::LEFT));
 		if(activeCommands.Has(Command::BACK))
 		{


### PR DESCRIPTION
**Feature:**

## Feature Details
Mouse turning no longer disables the steering keys.
Hopefully, this makes it clearer to anyone who has unintentionally turned mouse turning on what is going on, since they'll see the ship turning towards the cursor when they release the steering keys.