### PR TITLE
NPC max mining time gamerule

### DIFF
--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -36,3 +36,8 @@ gamerules
 	# DEFAULT: 1000
 	# ALLOWABLE VALUES: any integer >= 0
 	"no person spawn weight" 1000
+	
+	# NPC ships with mining personality will spend this much amount of time in frames to mine in the system.
+	# DEFAULT: 3600
+	# ALLOWABLE VALUES: any integer >= 0
+	"npc max mining time" 3600

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -37,7 +37,10 @@ gamerules
 	# ALLOWABLE VALUES: any integer >= 0
 	"no person spawn weight" 1000
 	
-	# NPC ships with mining personality will spend this many frames mining in the system.
-	# DEFAULT: 3600
+	# NPC ships with the mining personality will spend this many frames mining in the current system
+	# before deciding to do something else. The purpose of this limit is so that NPC ships can be seen
+	# by the player to show how to mine without also stripping the system bare of minable asteroids.
+	# This limit does not apply to mining ships that are spawned by a mission.
+	# DEFAULT: 3600 frames (one minute)
 	# ALLOWABLE VALUES: any integer >= 0
 	"npc max mining time" 3600

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -19,6 +19,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Command.h"
 #include "DistanceMap.h"
 #include "Flotsam.h"
+#include "GameData.h"
+#include "Gamerules.h"
 #include "Government.h"
 #include "Hardpoint.h"
 #include "JumpTypes.h"
@@ -812,7 +814,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 			// Miners with free cargo space and available mining time should mine. Mission NPCs
 			// should mine even if there are other miners or they have been mining a while.
 			if(it->Cargo().Free() >= 5 && IsArmed(*it) && (it->IsSpecial()
-					|| (++miningTime[&*it] < 3600 && ++minerCount < maxMinerCount)))
+					|| (++miningTime[&*it] < GameData::GetGamerules().NPCMaxMiningTime() && ++minerCount < maxMinerCount)))
 			{
 				if(it->HasBays())
 				{

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -556,6 +556,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 	const int maxMinerCount = minables.empty() ? 0 : 9;
 	bool opportunisticEscorts = !Preferences::Has("Turrets focus fire");
 	bool fightersRetreat = Preferences::Has("Damaged fighters retreat");
+	const int npcMaxMiningTime = GameData::GetGamerules().NPCMaxMiningTime();
 	for(const auto &it : ships)
 	{
 		// Skip any carried fighters or drones that are somehow in the list.
@@ -814,7 +815,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 			// Miners with free cargo space and available mining time should mine. Mission NPCs
 			// should mine even if there are other miners or they have been mining a while.
 			if(it->Cargo().Free() >= 5 && IsArmed(*it) && (it->IsSpecial()
-					|| (++miningTime[&*it] < GameData::GetGamerules().NPCMaxMiningTime() && ++minerCount < maxMinerCount)))
+					|| (++miningTime[&*it] < npcMaxMiningTime && ++minerCount < maxMinerCount)))
 			{
 				if(it->HasBays())
 				{

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -42,6 +42,8 @@ void Gamerules::Load(const DataNode &node)
 			personSpawnPeriod = max<int>(1, child.Value(1));
 		else if(key == "no person spawn weight")
 			noPersonSpawnWeight = max<int>(0, child.Value(1));
+		else if(key == "npc max mining time")
+			npcMaxMiningTime = max<int>(0, child.Value(1));
 		else
 			child.PrintTrace("Skipping unrecognized gamerule:");
 	}
@@ -66,4 +68,9 @@ int Gamerules::PersonSpawnPeriod() const
 int Gamerules::NoPersonSpawnWeight() const
 {
 	return noPersonSpawnWeight;
+}
+
+int Gamerules::NPCMaxMiningTime() const
+{
+	return npcMaxMiningTime;
 }

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -70,6 +70,8 @@ int Gamerules::NoPersonSpawnWeight() const
 	return noPersonSpawnWeight;
 }
 
+
+
 int Gamerules::NPCMaxMiningTime() const
 {
 	return npcMaxMiningTime;

--- a/source/Gamerules.h
+++ b/source/Gamerules.h
@@ -32,12 +32,14 @@ public:
 	bool UniversalRamscoopActive() const;
 	int PersonSpawnPeriod() const;
 	int NoPersonSpawnWeight() const;
+	int NPCMaxMiningTime() const;
 
 
 private:
 	bool universalRamscoop = true;
 	int personSpawnPeriod = 36000;
 	int noPersonSpawnWeight = 1000;
+	int npcMaxMiningTime = 3600;
 };
 
 


### PR DESCRIPTION

-----------------------
**Feature:** This PR implements the feature request detailed and discussed in issue. None. 

## Feature Details
Make the max mining time for NPC with mining personality a gamerule. This will allow plugin that adds larger mining ships with larger cargo holds to allow more time for those ships to fill their cargo.

## UI Screenshots
N/A

## Usage Examples
```
gamerules
	"npc max mining time" 3600
```
## Testing Done
VSC doesn't say anything.

### Automated Tests Added
N/A

## Performance Impact
idk, hopefully little to none.
