### PR TITLE
Distance calculation settings in LocationFilters

### DIFF
--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -129,6 +129,8 @@
 		<Unit filename="source/Dialog.h" />
 		<Unit filename="source/Dictionary.cpp" />
 		<Unit filename="source/Dictionary.h" />
+		<Unit filename="source/DistanceCalculationSettings.cpp" />
+		<Unit filename="source/DistanceCalculationSettings.h" />
 		<Unit filename="source/DistanceMap.cpp" />
 		<Unit filename="source/DistanceMap.h" />
 		<Unit filename="source/Distribution.cpp" />

--- a/EndlessSkyTests.cbp
+++ b/EndlessSkyTests.cbp
@@ -78,6 +78,7 @@
 		<Unit filename="tests/unit/src/test_datafile.cpp" />
 		<Unit filename="tests/unit/src/test_datanode.cpp" />
 		<Unit filename="tests/unit/src/test_dictionary.cpp" />
+		<Unit filename="tests/unit/src/test_distance_calculation_settings.cpp" />
 		<Unit filename="tests/unit/src/test_esuuid.cpp" />
 		<Unit filename="tests/unit/src/test_exclusiveItem.cpp" />
 		<Unit filename="tests/unit/src/test_firecommand.cpp" />

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -83,6 +83,8 @@ target_sources(EndlessSkyLib PRIVATE
 	Dialog.h
 	Dictionary.cpp
 	Dictionary.h
+	DistanceCalculationSettings.h
+	DistanceCalculationSettings.cpp
 	DistanceMap.cpp
 	DistanceMap.h
 	Distribution.cpp

--- a/source/DistanceCalculationSettings.cpp
+++ b/source/DistanceCalculationSettings.cpp
@@ -57,7 +57,7 @@ void DistanceCalculationSettings::Load(const DataNode &node)
 
 
 
-WormholeStrategy DistanceCalculationSettings::WormholeStrategy() const
+WormholeStrategy DistanceCalculationSettings::WormholeStrat() const
 {
 	return wormholeStrategy;
 }

--- a/source/DistanceCalculationSettings.cpp
+++ b/source/DistanceCalculationSettings.cpp
@@ -1,0 +1,70 @@
+/* DistanceCalculationSettings.cpp
+Copyright (c) 2023 by warp-core
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "DistanceCalculationSettings.h"
+
+#include "DataNode.h"
+
+using namespace std;
+
+
+
+DistanceCalculationSettings::DistanceCalculationSettings(const DataNode &node)
+{
+	Load(node);
+}
+
+
+
+bool DistanceCalculationSettings::operator!=(const DistanceCalculationSettings &other) const
+{
+	if(wormholeStrategy != other.wormholeStrategy)
+		return true;
+	return assumesJumpDrive != other.assumesJumpDrive;
+}
+
+
+
+void DistanceCalculationSettings::Load(const DataNode &node)
+{
+	for(const auto &child : node)
+	{
+		const string &key = child.Token(0);
+		if(key == "no wormholes")
+			wormholeStrategy = WormholeStrategy::NONE;
+		else if(key == "only unrestricted wormholes")
+			wormholeStrategy = WormholeStrategy::ONLY_UNRESTRICTED;
+		else if(key == "all wormholes")
+			wormholeStrategy = WormholeStrategy::ALL;
+		else if(key == "assumes jump drive")
+			assumesJumpDrive = true;
+		else
+			child.PrintTrace("Invalid distance calculation setting:");
+	}
+}
+
+
+
+WormholeStrategy DistanceCalculationSettings::WormholeStrategy() const
+{
+	return wormholeStrategy;
+}
+
+
+
+bool DistanceCalculationSettings::AssumesJumpDrive() const
+{
+	return assumesJumpDrive;
+}

--- a/source/DistanceCalculationSettings.h
+++ b/source/DistanceCalculationSettings.h
@@ -1,5 +1,5 @@
-/* WormholeStrategy.h
-Copyright (c) 2022 by warp-core
+/* DistanceCalculationSettings.h
+Copyright (c) 2023 by warp-core
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
@@ -13,23 +13,31 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef WORMHOLE_STRATEGY_H_
-#define WORMHOLE_STRATEGY_H_
+#ifndef DISTANCE_CALCULATION_OPTIONS_H_
+#define DISTANCE_CALCULATION_OPTIONS_H_
 
-#include <cstdint>
+#include "WormholeStrategy.h"
+
+class DataNode;
 
 
 
-// Strategies that a DistanceMap can use to determine which wormholes to make use of
-// when plotting a course to a destination, if any.
-enum class WormholeStrategy : int_fast8_t {
-	// Disallow use of any wormholes.
-	NONE,
-	// Disallow use of wormholes which the player cannot access, such as in
-	// the case of a wormhole that requires an attribute to use.
-	ONLY_UNRESTRICTED,
-	// Allow use of all wormholes.
-	ALL,
+class DistanceCalculationSettings {
+public:
+	DistanceCalculationSettings() = default;
+	DistanceCalculationSettings(const DataNode &node);
+
+	bool operator!=(const DistanceCalculationSettings &other) const;
+
+	void Load(const DataNode &node);
+
+	WormholeStrategy WormholeStrategy() const;
+	bool AssumesJumpDrive() const;
+
+
+private:
+	enum WormholeStrategy wormholeStrategy = WormholeStrategy::NONE;
+	bool assumesJumpDrive = false;
 };
 
 

--- a/source/DistanceCalculationSettings.h
+++ b/source/DistanceCalculationSettings.h
@@ -31,7 +31,7 @@ public:
 
 	void Load(const DataNode &node);
 
-	WormholeStrategy WormholeStrategy() const;
+	WormholeStrategy WormholeStrat() const;
 	bool AssumesJumpDrive() const;
 
 

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -81,7 +81,7 @@ namespace {
 		static const System *previousCenter = center;
 		static DistanceMap distance(
 			center,
-			distanceSettings.WormholeStrategy(),
+			distanceSettings.WormholeStrat(),
 			distanceSettings.AssumesJumpDrive(),
 			-1,
 			maximum
@@ -96,7 +96,7 @@ namespace {
 			previousDistanceSettings = distanceSettings;
 			distance = DistanceMap(
 				center,
-				distanceSettings.WormholeStrategy(),
+				distanceSettings.WormholeStrat(),
 				distanceSettings.AssumesJumpDrive(),
 				-1,
 				maximum

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -71,7 +71,7 @@ namespace {
 	}
 
 	// Check if the given system is within the given distance of the center.
-	int Distance(const System *center, const System *system, int maximum)
+	int Distance(const System *center, const System *system, int maximum, DistanceCalculationSettings distanceSettings)
 	{
 		// This function should only ever be called from the main thread, but
 		// just to be sure, use mutex protection on the static locals.
@@ -79,14 +79,28 @@ namespace {
 		lock_guard<mutex> lock(distanceMutex);
 
 		static const System *previousCenter = center;
-		static DistanceMap distance(center, -1, maximum);
+		static DistanceMap distance(
+			center,
+			distanceSettings.WormholeStrategy(),
+			distanceSettings.AssumesJumpDrive(),
+			-1,
+			maximum
+		);
 		static int previousMaximum = maximum;
+		static DistanceCalculationSettings previousDistanceSettings = distanceSettings;
 
-		if(center != previousCenter || maximum > previousMaximum)
+		if(center != previousCenter || maximum > previousMaximum || distanceSettings != previousDistanceSettings)
 		{
 			previousCenter = center;
 			previousMaximum = maximum;
-			distance = DistanceMap(center, -1, maximum);
+			previousDistanceSettings = distanceSettings;
+			distance = DistanceMap(
+				center,
+				distanceSettings.WormholeStrategy(),
+				distanceSettings.AssumesJumpDrive(),
+				-1,
+				maximum
+			);
 		}
 		// If the distance is greater than the maximum, this is not a match.
 		int d = distance.Days(system);
@@ -411,7 +425,7 @@ bool LocationFilter::Matches(const Ship &ship) const
 
 	// Check if this ship's current system meets a "near <system>" criterion.
 	// (Ships only offer missions, so no "distance" criteria need to be checked.)
-	if(center && Distance(center, origin, centerMaxDistance) < centerMinDistance)
+	if(center && Distance(center, origin, centerMaxDistance, centerDistanceOptions) < centerMinDistance)
 		return false;
 
 	return true;
@@ -437,9 +451,11 @@ LocationFilter LocationFilter::SetOrigin(const System *origin) const
 	result.center = origin;
 	result.centerMinDistance = originMinDistance;
 	result.centerMaxDistance = originMaxDistance;
+	result.centerDistanceOptions = originDistanceOptions;
 	// Revert "distance" parameters to their default.
 	result.originMinDistance = 0;
 	result.originMaxDistance = -1;
+	result.originDistanceOptions = DistanceCalculationSettings{};
 
 	return result;
 }
@@ -543,6 +559,9 @@ void LocationFilter::LoadChild(const DataNode &child)
 			centerMinDistance = child.Value(1 + valueIndex);
 			centerMaxDistance = child.Value(2 + valueIndex);
 		}
+
+		if(child.HasChildren())
+			centerDistanceOptions.Load(child);
 	}
 	else if(key == "distance" && child.Size() >= 1 + valueIndex)
 	{
@@ -553,6 +572,9 @@ void LocationFilter::LoadChild(const DataNode &child)
 			originMinDistance = child.Value(valueIndex);
 			originMaxDistance = child.Value(1 + valueIndex);
 		}
+
+		if(child.HasChildren())
+			originDistanceOptions.Load(child);
 	}
 	else if(key == "category" && child.Size() >= 2 + isNot)
 	{
@@ -620,10 +642,10 @@ bool LocationFilter::Matches(const System *system, const System *origin, bool di
 		return false;
 
 	// Check this system's distance from the desired reference system.
-	if(center && Distance(center, system, centerMaxDistance) < centerMinDistance)
+	if(center && Distance(center, system, centerMaxDistance, centerDistanceOptions) < centerMinDistance)
 		return false;
 	if(origin && originMaxDistance >= 0
-			&& Distance(origin, system, originMaxDistance) < originMinDistance)
+			&& Distance(origin, system, originMaxDistance, originDistanceOptions) < originMinDistance)
 		return false;
 
 	return true;

--- a/source/LocationFilter.h
+++ b/source/LocationFilter.h
@@ -16,6 +16,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef LOCATION_FILTER_H_
 #define LOCATION_FILTER_H_
 
+#include "DistanceCalculationSettings.h"
+
 #include <list>
 #include <set>
 #include <string>
@@ -90,9 +92,11 @@ private:
 	const System *center = nullptr;
 	int centerMinDistance = 0;
 	int centerMaxDistance = 1;
+	DistanceCalculationSettings centerDistanceOptions;
 	// Distance limits used in a "distance" filter.
 	int originMinDistance = 0;
 	int originMaxDistance = -1;
+	DistanceCalculationSettings originDistanceOptions;
 
 	// At least one of the outfits from each set must be available
 	// (to purchase or plunder):

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -162,19 +162,7 @@ void Mission::Load(const DataNode &node)
 		}
 		else if(child.Token(0) == "distance calculation settings" && child.HasChildren())
 		{
-			for(const DataNode &grand : child)
-			{
-				if(grand.Token(0) == "no wormholes")
-					distanceCalcSettings.wormholeStrategy = WormholeStrategy::NONE;
-				else if(grand.Token(0) == "only unrestricted wormholes")
-					distanceCalcSettings.wormholeStrategy = WormholeStrategy::ONLY_UNRESTRICTED;
-				else if(grand.Token(0) == "all wormholes")
-					distanceCalcSettings.wormholeStrategy = WormholeStrategy::ALL;
-				else if(grand.Token(0) == "assumes jump drive")
-					distanceCalcSettings.assumesJumpDrive = true;
-				else
-					grand.PrintTrace("Invalid \"distance calculation settings\" child:");
-			}
+			distanceCalcSettings.Load(child);
 		}
 		else if(child.Token(0) == "cargo" && child.Size() >= 3)
 		{
@@ -1497,8 +1485,8 @@ int Mission::CalculateJumps(const System *sourceSystem)
 	{
 		// Find the closest destination to this location.
 		DistanceMap distance(sourceSystem,
-				distanceCalcSettings.wormholeStrategy,
-				distanceCalcSettings.assumesJumpDrive);
+				distanceCalcSettings.WormholeStrategy(),
+				distanceCalcSettings.AssumesJumpDrive());
 		auto it = destinations.begin();
 		auto bestIt = it;
 		int bestDays = distance.Days(*bestIt);
@@ -1520,8 +1508,8 @@ int Mission::CalculateJumps(const System *sourceSystem)
 		destinations.erase(bestIt);
 	}
 	DistanceMap distance(sourceSystem,
-			distanceCalcSettings.wormholeStrategy,
-			distanceCalcSettings.assumesJumpDrive);
+			distanceCalcSettings.WormholeStrategy(),
+			distanceCalcSettings.AssumesJumpDrive());
 	// If currently unreachable, this system adds -1 to the deadline, to match previous behavior.
 	expectedJumps += distance.Days(destination->GetSystem());
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1485,7 +1485,7 @@ int Mission::CalculateJumps(const System *sourceSystem)
 	{
 		// Find the closest destination to this location.
 		DistanceMap distance(sourceSystem,
-				distanceCalcSettings.WormholeStrategy(),
+				distanceCalcSettings.WormholeStrat(),
 				distanceCalcSettings.AssumesJumpDrive());
 		auto it = destinations.begin();
 		auto bestIt = it;
@@ -1508,7 +1508,7 @@ int Mission::CalculateJumps(const System *sourceSystem)
 		destinations.erase(bestIt);
 	}
 	DistanceMap distance(sourceSystem,
-			distanceCalcSettings.WormholeStrategy(),
+			distanceCalcSettings.WormholeStrat(),
 			distanceCalcSettings.AssumesJumpDrive());
 	// If currently unreachable, this system adds -1 to the deadline, to match previous behavior.
 	expectedJumps += distance.Days(destination->GetSystem());

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -18,12 +18,12 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "ConditionSet.h"
 #include "Date.h"
+#include "DistanceCalculationSettings.h"
 #include "EsUuid.h"
 #include "LocationFilter.h"
 #include "MissionAction.h"
 #include "NPC.h"
 #include "TextReplacements.h"
-#include "WormholeStrategy.h"
 
 #include <list>
 #include <map>
@@ -180,13 +180,6 @@ public:
 	// "Instantiate" a mission by replacing randomly selected values and places
 	// with a single choice, and then replacing any wildcard text as well.
 	Mission Instantiate(const PlayerInfo &player, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
-
-
-private:
-	struct DistanceCalculationSettings {
-		WormholeStrategy wormholeStrategy = WormholeStrategy::NONE;
-		bool assumesJumpDrive = false;
-	};
 
 
 private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(EndlessSkyTests PRIVATE
 	unit/src/test_datafile.cpp
 	unit/src/test_datanode.cpp
 	unit/src/test_dictionary.cpp
+	unit/src/test_distance_calculation_settings.cpp
 	unit/src/test_esuuid.cpp
 	unit/src/test_exclusiveItem.cpp
 	unit/src/test_firecommand.cpp

--- a/tests/unit/src/test_distance_calculation_settings.cpp
+++ b/tests/unit/src/test_distance_calculation_settings.cpp
@@ -78,7 +78,7 @@ const DataNode unrestrictedWormholesNode = AsDataNode("node\n\t\"only unrestrict
 const DataNode unrestrictedWormholesJDNode =
 		AsDataNode("node\n\t\"only unrestricted wormholes\"\n\t\"assumes jump drive\"");
 const DataNode allWormholesNode = AsDataNode("node\n\t\"all wormholes\"");
-const DataNode allWormholesJDNode = AsDataNode("node\n\t\"allwormholes\"\n\t\"assumes jump drive\"");
+const DataNode allWormholesJDNode = AsDataNode("node\n\t\"all wormholes\"\n\t\"assumes jump drive\"");
 
 TEST_CASE( "DistanceCalculationSettings::Load", "[DistanceCalculationSettings::Load]") {
 	using T = DistanceCalculationSettings;

--- a/tests/unit/src/test_distance_calculation_settings.cpp
+++ b/tests/unit/src/test_distance_calculation_settings.cpp
@@ -75,7 +75,8 @@ SCENARIO( "A wormmhole strategy and boolean must be stored.", "[DistanceCalculat
 const DataNode defaultNode = AsDataNode("node\n\t\"no wormholes\"");
 const DataNode jdNode = AsDataNode("node\n\t\"assumes jump drive\"");
 const DataNode unrestrictedWormholesNode = AsDataNode("node\n\t\"only unrestricted wormholes\"");
-const DataNode unrestrictedWormholesJDNode = AsDataNode("node\n\t\"only unrestricted wormholes\"\n\t\"assumes jump drive\"");
+const DataNode unrestrictedWormholesJDNode =
+		AsDataNode("node\n\t\"only unrestricted wormholes\"\n\t\"assumes jump drive\"");
 const DataNode allWormholesNode = AsDataNode("node\n\t\"all wormholes\"");
 const DataNode allWormholesJDNode = AsDataNode("node\n\t\"allwormholes\"\n\t\"assumes jump drive\"");
 

--- a/tests/unit/src/test_distance_calculation_settings.cpp
+++ b/tests/unit/src/test_distance_calculation_settings.cpp
@@ -65,7 +65,7 @@ SCENARIO( "A wormmhole strategy and boolean must be stored.", "[DistanceCalculat
 		DistanceCalculationSettings a;
 		WHEN( "the settings are created" ) {
 			THEN( "it represents (NONE, false)" ) {
-				CHECK( a.WormholeStrategy() == WormholeStrategy::NONE );
+				CHECK( a.WormholeStrat() == WormholeStrategy::NONE );
 				CHECK( a.AssumesJumpDrive() == false );
 			}
 		}
@@ -83,32 +83,32 @@ TEST_CASE( "DistanceCalculationSettings::Load", "[DistanceCalculationSettings::L
 	using T = DistanceCalculationSettings;
 	SECTION( "No wormholes, no jump drive") {
 		T settings(defaultNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::NONE );
 		CHECK( settings.AssumesJumpDrive() == false );
 	}
 	SECTION( "No wormholes, jump drive") {
 		T settings(jdNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::NONE );
 		CHECK( settings.AssumesJumpDrive() == true );
 	}
 	SECTION( "Unrestricted wormholes, no jump drive") {
 		T settings(unrestrictedWormholesNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::ONLY_UNRESTRICTED );
 		CHECK( settings.AssumesJumpDrive() == false );
 	}
 	SECTION( "Unrestricted wormholes, jump drive") {
 		T settings(unrestrictedWormholesJDNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::ONLY_UNRESTRICTED );
 		CHECK( settings.AssumesJumpDrive() == true );
 	}
 	SECTION( "All wormholes, no jump drive") {
 		T settings(allWormholesNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::ALL );
 		CHECK( settings.AssumesJumpDrive() == false );
 	}
 	SECTION( "All wormholes, jump drive") {
 		T settings(allWormholesJDNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::ALL );
 		CHECK( settings.AssumesJumpDrive() == true );
 	}
 }
@@ -117,50 +117,50 @@ TEST_CASE( "Copying DistanceCalculationSettings", "[DistanceCalculationSettings]
 	using T = DistanceCalculationSettings;
 	SECTION( "No wormholes, no jump drive") {
 		T settings(defaultNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::NONE );
 		CHECK( settings.AssumesJumpDrive() == false );
 		T copiedSettings = settings;
-		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( copiedSettings.WormholeStrat() == WormholeStrategy::NONE );
 		CHECK( copiedSettings.AssumesJumpDrive() == false );
 	}
 	SECTION( "No wormholes, jump drive") {
 		T settings(jdNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::NONE );
 		CHECK( settings.AssumesJumpDrive() == true );
 		T copiedSettings = settings;
-		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( copiedSettings.WormholeStrat() == WormholeStrategy::NONE );
 		CHECK( copiedSettings.AssumesJumpDrive() == true );
 	}
 	SECTION( "Unrestricted wormholes, no jump drive") {
 		T settings(unrestrictedWormholesNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::ONLY_UNRESTRICTED );
 		CHECK( settings.AssumesJumpDrive() == false );
 		T copiedSettings = settings;
-		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( copiedSettings.WormholeStrat() == WormholeStrategy::ONLY_UNRESTRICTED );
 		CHECK( copiedSettings.AssumesJumpDrive() == false );
 	}
 	SECTION( "Unrestricted wormholes, jump drive") {
 		T settings(unrestrictedWormholesJDNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::ONLY_UNRESTRICTED );
 		CHECK( settings.AssumesJumpDrive() == true );
 		T copiedSettings = settings;
-		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( copiedSettings.WormholeStrat() == WormholeStrategy::ONLY_UNRESTRICTED );
 		CHECK( copiedSettings.AssumesJumpDrive() == true );
 	}
 	SECTION( "All wormholes, no jump drive") {
 		T settings(allWormholesNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::ALL );
 		CHECK( settings.AssumesJumpDrive() == false );
 		T copiedSettings = settings;
-		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( copiedSettings.WormholeStrat() == WormholeStrategy::ALL );
 		CHECK( copiedSettings.AssumesJumpDrive() == false );
 	}
 	SECTION( "All wormholes, jump drive") {
 		T settings(allWormholesJDNode);
-		CHECK( settings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( settings.WormholeStrat() == WormholeStrategy::ALL );
 		CHECK( settings.AssumesJumpDrive() == true );
 		T copiedSettings = settings;
-		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( copiedSettings.WormholeStrat() == WormholeStrategy::ALL );
 		CHECK( copiedSettings.AssumesJumpDrive() == true );
 	}
 }

--- a/tests/unit/src/test_distance_calculation_settings.cpp
+++ b/tests/unit/src/test_distance_calculation_settings.cpp
@@ -1,0 +1,171 @@
+/* test_distance_calculation_settings.cpp
+Copyright (c) 2023 by warp-core
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "es-test.hpp"
+
+// Include only the tested class's header.
+#include "../../../source/DistanceCalculationSettings.h"
+
+// Include a helper for creating well-formed DataNodes.
+#include "datanode-factory.h"
+
+namespace { // test namespace
+// #region mock data
+// #endregion mock data
+
+
+
+// #region unit tests
+TEST_CASE( "DistanceCalculationSettings Basics", "[DistanceCalculationSettings]" ) {
+	using T = DistanceCalculationSettings;
+	SECTION( "Class Traits" ) {
+		CHECK_FALSE( std::is_trivial<T>::value );
+		CHECK( std::is_standard_layout<T>::value );
+		CHECK( std::is_nothrow_destructible<T>::value );
+		CHECK( std::is_trivially_destructible<T>::value );
+	}
+	SECTION( "Construction Traits" ) {
+		CHECK( std::is_default_constructible<T>::value );
+		CHECK_FALSE( std::is_trivially_default_constructible<T>::value );
+		CHECK( std::is_nothrow_default_constructible<T>::value );
+		CHECK( std::is_copy_constructible<T>::value );
+		CHECK( std::is_trivially_copy_constructible<T>::value );
+		CHECK( std::is_nothrow_copy_constructible<T>::value );
+		CHECK( std::is_move_constructible<T>::value );
+		CHECK( std::is_trivially_move_constructible<T>::value );
+		CHECK( std::is_nothrow_move_constructible<T>::value );
+	}
+	SECTION( "Copy Traits" ) {
+		CHECK( std::is_copy_assignable<T>::value );
+		CHECK( std::is_trivially_copyable<T>::value );
+		CHECK( std::is_trivially_copy_assignable<T>::value );
+		CHECK( std::is_nothrow_copy_assignable<T>::value );
+	}
+	SECTION( "Move Traits" ) {
+		CHECK( std::is_move_assignable<T>::value );
+		CHECK( std::is_trivially_move_assignable<T>::value );
+		CHECK( std::is_nothrow_move_assignable<T>::value );
+	}
+}
+
+SCENARIO( "A wormmhole strategy and boolean must be stored.", "[DistanceCalculationSettings]" ) {
+	GIVEN( "No initial values" ) {
+		DistanceCalculationSettings a;
+		WHEN( "the settings are created" ) {
+			THEN( "it represents (NONE, false)" ) {
+				CHECK( a.WormholeStrategy() == WormholeStrategy::NONE );
+				CHECK( a.AssumesJumpDrive() == false );
+			}
+		}
+	}
+}
+
+const DataNode defaultNode = AsDataNode("node\n\t\"no wormholes\"");
+const DataNode jdNode = AsDataNode("node\n\t\"assumes jump drive\"");
+const DataNode unrestrictedWormholesNode = AsDataNode("node\n\t\"only unrestricted wormholes\"");
+const DataNode unrestrictedWormholesJDNode = AsDataNode("node\n\t\"only unrestricted wormholes\"\n\t\"assumes jump drive\"");
+const DataNode allWormholesNode = AsDataNode("node\n\t\"all wormholes\"");
+const DataNode allWormholesJDNode = AsDataNode("node\n\t\"allwormholes\"\n\t\"assumes jump drive\"");
+
+TEST_CASE( "DistanceCalculationSettings::Load", "[DistanceCalculationSettings::Load]") {
+	using T = DistanceCalculationSettings;
+	SECTION( "No wormholes, no jump drive") {
+		T settings(defaultNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( settings.AssumesJumpDrive() == false );
+	}
+	SECTION( "No wormholes, jump drive") {
+		T settings(jdNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( settings.AssumesJumpDrive() == true );
+	}
+	SECTION( "Unrestricted wormholes, no jump drive") {
+		T settings(unrestrictedWormholesNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( settings.AssumesJumpDrive() == false );
+	}
+	SECTION( "Unrestricted wormholes, jump drive") {
+		T settings(unrestrictedWormholesJDNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( settings.AssumesJumpDrive() == true );
+	}
+	SECTION( "All wormholes, no jump drive") {
+		T settings(allWormholesNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( settings.AssumesJumpDrive() == false );
+	}
+	SECTION( "All wormholes, jump drive") {
+		T settings(allWormholesJDNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( settings.AssumesJumpDrive() == true );
+	}
+}
+
+TEST_CASE( "Copying DistanceCalculationSettings", "[DistanceCalculationSettings]") {
+	using T = DistanceCalculationSettings;
+	SECTION( "No wormholes, no jump drive") {
+		T settings(defaultNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( settings.AssumesJumpDrive() == false );
+		T copiedSettings = settings;
+		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( copiedSettings.AssumesJumpDrive() == false );
+	}
+	SECTION( "No wormholes, jump drive") {
+		T settings(jdNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( settings.AssumesJumpDrive() == true );
+		T copiedSettings = settings;
+		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::NONE );
+		CHECK( copiedSettings.AssumesJumpDrive() == true );
+	}
+	SECTION( "Unrestricted wormholes, no jump drive") {
+		T settings(unrestrictedWormholesNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( settings.AssumesJumpDrive() == false );
+		T copiedSettings = settings;
+		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( copiedSettings.AssumesJumpDrive() == false );
+	}
+	SECTION( "Unrestricted wormholes, jump drive") {
+		T settings(unrestrictedWormholesJDNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( settings.AssumesJumpDrive() == true );
+		T copiedSettings = settings;
+		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::ONLY_UNRESTRICTED );
+		CHECK( copiedSettings.AssumesJumpDrive() == true );
+	}
+	SECTION( "All wormholes, no jump drive") {
+		T settings(allWormholesNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( settings.AssumesJumpDrive() == false );
+		T copiedSettings = settings;
+		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( copiedSettings.AssumesJumpDrive() == false );
+	}
+	SECTION( "All wormholes, jump drive") {
+		T settings(allWormholesJDNode);
+		CHECK( settings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( settings.AssumesJumpDrive() == true );
+		T copiedSettings = settings;
+		CHECK( copiedSettings.WormholeStrategy() == WormholeStrategy::ALL );
+		CHECK( copiedSettings.AssumesJumpDrive() == true );
+	}
+}
+// #endregion unit tests
+
+
+
+} // test namespace


### PR DESCRIPTION
**Feature:**

## Feature Details
Adds support to location filter `near` and `distance` nodes for distance calculation settings that determine if non-hyperlinked systems within default jump drive range or wormholes should be considered, similar to what is now possible for mission deadline and payment autocalculations.

Note: if you wish to test the trans-wormhole functionality with the `--matches` command line option, you will need to make a change to the following line:
https://github.com/endless-sky/endless-sky/blob/db89370ee3b369e3b7bdb76685ba29eda52a30db/source/DistanceMap.cpp#L236

I suggest something like:
```c++
				if(/*object.HasSprite() &&*/ object.HasValidPlanet() && object.GetPlanet()->IsWormhole()
```

This is because, when running that command, no images are loaded, and so `object.HasSprite()` will always return `false`, because, even though a valid sprite may exist in the game data, it has not been loaded, and it doesn't really seem worth the effort to develop a better workaround.

## Usage Examples
```
location
	near "Sol" 1000
		"all wormholes"
	not near "Sol" 1000

location
	not near "Sol" 1000
		"only unrestricted wormholes"
	not near "Sol" 1000

location
	near "Sol" 1000
		"assumes jump drive"
	government "Coalition"

location
	near "Sol" 1000
		"all wormholes"
	not near "Sol" 1000

```

## Testing Done
Test examples like the ones above with the `--matches` command line argument and get the expected results.

### Automated Tests Added
I added some unit tests for the new class because I was investigating something that turned out to be unrelated, but I'd already written the tests, so may as well include them.

## Performance Impact
N/A
