### PR TITLE
fix(content): Stop "Immigrant Workers" from going to Pirate space

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -20,6 +20,7 @@ mission "Immigrant Workers"
 		random < 50
 	source "New Iceland"
 	destination
+		not government "Pirate"
 		attributes "core"
 		attributes "factory" "textile"
 	on complete


### PR DESCRIPTION
Recently, New Tortuga was added as a pirate world with the attributes "core" and "factory". However, this makes the planet eligible to be a destination for "Immigrant Workers", which doesn't make sense in terms of both gameplay and story. This PR adds a government filter onto the mission.