### PR TITLE
feat(balance): Remove range overrides on missile pods

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -992,7 +992,6 @@ outfit "Javelin Mini Pod"
 		"inaccuracy" 1
 		"velocity" 10
 		"lifetime" 60
-		"range override" 300
 		"reload" 40
 		"burst count" 40
 		"burst reload" 15
@@ -1293,7 +1292,6 @@ outfit "Heavy Rocket Pod"
 		"lifetime" 125
 		"range override" 1000
 		"reload" 500
-		"range override" 500
 		"burst count" 2
 		"burst reload" 240
 		"firing energy" 1


### PR DESCRIPTION
The Javelin Mini Pod has a range override of 300, despite the main launcher not having any override at all. This range override was added when the missile pods were introduced (#5793), to save ammo by shooting at close range and reducing the chance of misses. However, in practice, having access to the full range of the launcher is much better, and the chance of missing is often negligible.

This PR also removes the lower range override of the Heavy Rocket Pod, for reasons noted above, and also to reduce the probability of the AI hitting itself with the blast radius.

Footage of a Dagger vs. a Barb; the 300-range Dagger loses, the 600-range wins:

https://user-images.githubusercontent.com/60202690/232261636-1ace74df-b15a-448f-ac01-7e22777f42d5.mp4

https://user-images.githubusercontent.com/60202690/232261670-04dd2d9d-8c92-40e8-8b4f-c6e039c93726.mp4

