### PR TITLE
Keep overlays off if they were off before

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -202,6 +202,14 @@ void Preferences::Load()
 			alertIndicatorIndex = 2;
 		settings.erase(it);
 	}
+
+	it = settings.find("Show status overlays");
+	if(it != settings.end())
+	{
+		if(!it->second)
+			statusOverlaySettings[OverlayType::ALL] = OverlayState::OFF;
+		settings.erase(it);
+	}
 }
 
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -203,6 +203,8 @@ void Preferences::Load()
 		settings.erase(it);
 	}
 
+	// For people updating from a version before the status overlay customization
+	// changes, don't turn all the overlays on if they were off before.
 	it = settings.find("Show status overlays");
 	if(it != settings.end())
 	{


### PR DESCRIPTION
**Feature:**

Thanks to `@auldr#3296` for bringing this up on Discord.

## Feature Details
What the title says. Ensures continuity for people who update from 0.10.0.
