### PR TITLE
[Balance] Buff the Nuclear Missile

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1337,10 +1337,10 @@ outfit "Nuclear Missile"
 		ammo "Nuclear Missile"
 		stream
 		icon "icon/nuke"
-		"hit effect" "nuke explosion"
-		"hit effect" "nuke residue fast" 10
-		"hit effect" "nuke residue slow" 10
+		"submunition" "Active Nuclear Missile"
+		"split range" 300
 		"die effect" "missile death"
+		"hit effect" "medium explosion"
 		"inaccuracy" 1
 		"velocity" 6
 		"lifetime" 800
@@ -1353,19 +1353,43 @@ outfit "Nuclear Missile"
 		"homing" 4
 		"radar tracking" .5
 		"optical tracking" 1
-		"trigger radius" 30
-		"blast radius" 150
-		"shield damage" 9000
-		"hull damage" 7000
-		"hit force" 4000
+		"shield damage" -23700
+		"hull damage" -15800
+		"hit force" -5700
 		"missile strength" 200
 	description "It has been centuries since the last nuclear war was fought, and until very recently, most people in the galaxy assumed that that era of chaos and destruction was forever behind us..."
 	description "	[Nuclear missiles are a one-shot weapon: each missile occupies a gun slot, and after it is fired, the slot it was in is left empty.]"
+
+
+outfit "Active Nuclear Missile"
+	weapon
+		sprite "projectile/missile"
+			"no repeat"
+			"frame rate" .25
+		"hit effect" "nuke explosion"
+		"hit effect" "nuke residue fast" 20
+		"hit effect" "nuke residue slow" 15
+		"die effect" "missile death"
+		"lifetime" 400
+		"acceleration" .8
+		"drag" .1
+		"turn" 4
+		"homing" 4
+		"radar tracking" .5
+		"optical tracking" 1
+		"trigger radius" 270
+		"blast radius" 300
+		"shield damage" 24000
+		"hull damage" 16000
+		"hit force" 6000
+		"missile strength" 200
+
 
 effect "nuke explosion"
 	sprite "effect/explosion/nuke"
 		"no repeat"
 		"frame rate" 30
+		"scale" 2
 	sound "explosion nuke"
 	"lifetime" 15
 	"random angle" 360
@@ -1377,20 +1401,20 @@ effect "nuke residue fast"
 	sprite "effect/explosion/huge"
 		"no repeat"
 		"frame rate" 15
-	"lifetime" 36
+	"lifetime" 48
 	"random angle" 360
 	"random spin" 5
-	"random velocity" 8
+	"random velocity" 12
 	"velocity scale" 0.1
 
 effect "nuke residue slow"
 	sprite "effect/explosion/huge"
 		"no repeat"
 		"frame rate" 10
-	"lifetime" 60
+	"lifetime" 90
 	"random angle" 360
 	"random spin" 5
-	"random velocity" 5
+	"random velocity" 7
 	"velocity scale" 0.1
 
 

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1324,9 +1324,9 @@ outfit "Nuclear Missile"
 	category "Secondary Weapons"
 	cost 1000000
 	thumbnail "outfit/nuke"
-	"mass" 8
-	"outfit space" -8
-	"weapon capacity" -8
+	"mass" 10
+	"outfit space" -10
+	"weapon capacity" -10
 	"gun ports" -1
 	weapon
 		sprite "projectile/missile"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1324,9 +1324,9 @@ outfit "Nuclear Missile"
 	category "Secondary Weapons"
 	cost 1000000
 	thumbnail "outfit/nuke"
-	"mass" 10
-	"outfit space" -10
-	"weapon capacity" -10
+	"mass" 8
+	"outfit space" -8
+	"weapon capacity" -8
 	"gun ports" -1
 	weapon
 		sprite "projectile/missile"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1343,7 +1343,7 @@ outfit "Nuclear Missile"
 		"hit effect" "medium explosion"
 		"inaccuracy" 1
 		"velocity" 6
-		"lifetime" 800
+		"lifetime" 120
 		"reload" 400
 		"firing energy" 10
 		"firing heat" 400

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1343,7 +1343,7 @@ outfit "Nuclear Missile"
 		"hit effect" "medium explosion"
 		"inaccuracy" 1
 		"velocity" 6
-		"lifetime" 120
+		"lifetime" 60
 		"reload" 400
 		"firing energy" 10
 		"firing heat" 400


### PR DESCRIPTION
----------------------
**Content (Artwork / Missions / Jobs)**

## Summary

This buffs the Nuclear Missile reward from FW Checkmate. The Nuclear Missile now works exceptionally well as a "fleet killer" weapon, capable of doing a large amount of damage to a group of ships.

Base shield / hull damage was increased from 9000 / 7000 to 24000 / 16000. While this may seem like a lot (it's about a 2.66x increase for shield damage and a ~2.3x increase in hull damage), the effective damage increase is actually much less. This is because the blast radius and trigger radius of the Nuke has been increased to 300 and 270 respectively. 

According to this chart for the `blast radius` attribute, this ratio of blast radius to trigger radius (90%) results in an effective damage of ~50% of the base weapon damage. This means that the Nuclear Missile effectively does 12000 / 8000 damage to a targeted ship.

<img src = "https://user-images.githubusercontent.com/42621251/233242760-2bc33a4e-7d00-400c-a5a4-f4efa9297e27.png" width="500">

 In practice, this results in two nukes disabling a Cruiser, and three killing a Carrier. Eight nukes are needed to (barely) disable a KIV. This compares with the current nuke, where three nukes disables a Cruiser, four nukes kills a Carrier, and seventeen nukes are needed to kill a KIV (that one's probably so different because Sestor ships tend to have a lot of hull).

Additionally, the Nuclear Missile will only detonate when its target it inside its blast radius (300 pixels), so a nuke hitting a stray asteroid or rogue enemy drone won't make it vaporize everything in the area.

For reference, a Sidewinder does 1300 / 900 shields / hull damage per ton, while the existing nuke does 900 / 700 shield / hull damage person, which is laughable. This PR brings that up to the more respectable values of 2400 / 1600 shield / hull damage per ton, a bit over the damage / ton of the Typhoon for shields, but still below for hull (which has a damage / ton of 2100 / 2100).

This all comes together to make the Nuclear Missile more viable as a weapon against massed targets. If you're willing to spend eight gunports on something like a Weapons Kestrel, you can even kill a single T2 HW! While I don't think this fully addresses the flaws of Checkmate's rewards, it does at least make the nuke somewhat less of a joke.
