### PR TITLE
fix(content): Unused government and unnecessary blank lines removal

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -268,36 +268,6 @@ government "Forest (Prey)"
 		destroy 0
 		atrocity 0
 
-government "Forest (Predator)"
-	# Indigenous creatures in large forest zones outside the Milky Way.
-	# These attack the "Forest (Prey)" creatures and the player.
-	# Drak don't look after these since they're beyond Drak territory.
-
-	"display name" "Forest"
-
-	# These indigenous creatures think you look tasty:
-	"player reputation" -1000
-	"attitude toward"
-		"Forest (Prey)" -.01
-		"Author" -.01
-		"Hai" -.01
-		"Hai (Wormhole Access)" -.01
-		"Korath" -.01
-		"Merchant" -.01
-		"Syndicate" -.01
-		"Hai (Friendly Unfettered)" -.01
-		"Hai (Unfettered)" -.01
-		"Pirate" -.01
-		"Pirate (Devil-Run Gang)" -.01
-
-	"penalty for"
-		assist 0
-		disable 0
-		board 0
-		capture 0
-		destroy 0
-		atrocity 0
-
 color "governments: Free" .06 .68 0.
 
 government "Free Worlds"
@@ -1013,7 +983,6 @@ government "Pirate (Devil-Run Gang)"
 		"Syndicate" -.001
 		"Hai (Friendly Unfettered)" -.001
 		"Forest (Prey)" -.001
-		"Forest (Predator)" -.001
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly pirate"

--- a/data/iije/iije.txt
+++ b/data/iije/iije.txt
@@ -302,5 +302,3 @@ fleet "Iije (Surveillance)"
 	variant 1
 		"Ayym"
 		"Jje" 9
-		
-


### PR DESCRIPTION
This is a partial re-PR of #8616.
## Summary
 - Removed the unused `Forest (Predator)` government.
 - Deleted two blank lines at the end of the `iije.txt`, leaving only one.