### PR TITLE
feat(balance): Make the FW Cloak Irremovable

### DIFF
--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -2434,7 +2434,8 @@ mission "FW Syndicate Extremists 1A"
 			
 			`	"I don't see why not," says Danforth, fixing Alastair with a piercing gaze. "It's certainly better than leaving it in Syndicate hands."`
 			label end
-			`	Alastair tells you that the device is being kept on Hephaestus, and the engineers there can install it in your ship. Meanwhile, Danforth will call in the rest of his Oathkeeper fleet. "And when we're through with this, I'll be seeing to it that this Oracle is destroyed so that this can never happen again," says Danforth. Alastair gives a meek nod in agreement. "Now, where are the Alphas."`
+			`	Alastair tells you that the device is being kept on Hephaestus, and the engineers there can install it in your ship. "We still don't understand much about the device, and it's very difficult to work with," he says. "Once installed, the device can't be removed. Make sure you fly over with your best ship."` 
+			`	Meanwhile, Danforth will call in the rest of his Oathkeeper fleet. "And when we're through with this, I'll be seeing to it that this Oracle is destroyed so that this can never happen again," says Danforth. Alastair gives a meek nod in agreement. "Now, where are the Alphas."`
 			`	"The Alphas are holed up on Buccaneer Bay," says Alastair, "an old pirate world. Good luck in defeating them."`
 				accept
 	

--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -2434,7 +2434,7 @@ mission "FW Syndicate Extremists 1A"
 			
 			`	"I don't see why not," says Danforth, fixing Alastair with a piercing gaze. "It's certainly better than leaving it in Syndicate hands."`
 			label end
-			`	Alastair tells you that the device is being kept on Hephaestus, and the engineers there can install it in your ship. "We still don't understand much about the device, and it's very difficult to work with," he says. "Once installed, the device can't be removed. Make sure you fly over with your best ship."` 
+			`	Alastair tells you that the device is being kept on Hephaestus, and the engineers there can install it in your ship. "We still don't understand much about the device, and it's very difficult to work with," he says. "Once installed, the device can't be removed. Make sure you fly over with your best ship."`
 			`	Meanwhile, Danforth will call in the rest of his Oathkeeper fleet. "And when we're through with this, I'll be seeing to it that this Oracle is destroyed so that this can never happen again," says Danforth. Alastair gives a meek nod in agreement. "Now, where are the Alphas."`
 			`	"The Alphas are holed up on Buccaneer Bay," says Alastair, "an old pirate world. Good luck in defeating them."`
 				accept

--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -264,6 +264,7 @@ outfit "Cloaking Device"
 	cost 1200000
 	"mass" 10
 	"outfit space" -10
+	"cloaking deevice" -1
 	"cloak" .01
 	"cloaking energy" 1
 	"cloaking fuel" .2


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
There has been a lot of discussion with the nature of cloaking devices in Endless Sky, a majority of the time being how strong they are and whether or not that strength should be more intricate and/or have more downsides. The biggest example of this is the Cloaking Device given to the player in FW 3: Reconciliation. While this Cloak is a mysterious device, mentioned to be stolen from a Korath ship's cargo bay, it is a pretty powerful outfit that the player can obtain, and is seen used by a great majority of players, as opposed to the Nuclear Missile. https://github.com/endless-sky/endless-sky/pull/8670 addresses some buffs that would be appropriate, so I've opened this PR to address an adjustment that seems more appropriate for the Cloak given to the player.

In game, cloaking devices see little variance, being almost seemingly omnipotent devices that hide a given ship from detection. There have been nerfs to it in the past to make the Cloak's stats and purpose itself a bit more balanced, but I find that they didn't completely address the true nature of the Cloak's over-usage - the ability to be outfitted on anything at any time.

As a strange alien device that the Syndicate know nothing about, it is somewhat odd that the player can go to any outfitter they choose, and equip the Cloak to any ship they desire. Somewhat relevant from all the way back in https://github.com/endless-sky/endless-sky/pull/3669: 

>"It doesn't seem logical to me that you would be able to plunder the cloaking device with on-ship tools, yet not be able to uninstall it with a full outfitter."

While the same argument can be made for the JD, I believe that it makes more sense to be able to mount a hyperdrive-esq system, versus a cloaking system, and due to the usage of it in-game.

After many discussions over time, a common compromise that was brought up to balance the Cloak better was to make it unable to be uninstalled. This would mean that the Cloak itself didn't receive any direct nerfs, but the utility of being able to install it on anything, especially strong late-game ships, would be removed. In addition, this does not remove the ability to install it on any ship, as a player could still capture whatever ship they desired outside of the FW Campaign, bring it during it, and install it normally.

What this does is make the Cloak a more seemingly mysterious device that the player can't just willy-nilly throw it wherever and whenever they want, and makes the ship the player chooses to install it on much more important and iconic. Additionally, this also makes other existing cloaks more valuable such as the Remnant or even Arfecta ones, making the value of those vessels more important as well.

This is not to say future cloaks *shouldn't* ever be uninstall-able. I believe more alien-story cloaks, such as those of the aforementioned, would make more sense to have removable cloaks (even if they aren't the ones currently in the game), as well as giving those cloaks an opportunity to be more special than the FW Cloak with possible future varieties in capabilities, as opposed to a Cloak given in the human campaign being omnipresent.

Note: This PR is to address the *current* FW Cloak. If the desire is to change the reward to something mentioned, such as an ECM, that discussion should be for another PR.

## Save File
This save file can be used to play through the new mission content:
I'm working on getting a save to test this. Will report back soon.
