### PR TITLE
feat(UI): Escort HUD improvements

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -74,6 +74,7 @@ color "waypoint" .1 .2 .9 1.
 color "waypoint back" 0. .3 .7 .5
 
 # Colors for the Escort HUD that is displayed in-flight.
+color "escort disabled"  .4 .4 .4 0.
 color "escort present" .8 .8 .8 1.
 color "escort elsewhere" .4 .4 .6 1.
 color "escort not ready" .9 .8 0. 1.

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -74,7 +74,7 @@ color "waypoint" .1 .2 .9 1.
 color "waypoint back" 0. .3 .7 .5
 
 # Colors for the Escort HUD that is displayed in-flight.
-color "escort disabled"  .4 .4 .4 0.
+color "escort disabled" .4 .4 .4 0.
 color "escort present" .8 .8 .8 1.
 color "escort elsewhere" .4 .4 .6 1.
 color "escort not ready" .9 .8 0. 1.

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -195,7 +195,7 @@ EscortDisplay::Icon::Icon(const Ship &ship, bool isHere, bool fleetIsJumping, bo
 	cannotJump(fleetIsJumping && !ship.IsHyperspacing() && !ship.JumpsRemaining()),
 	isSelected(isSelected),
 	cost(ship.Cost()),
-	system((!isHere && ship.GetSystem()) ? ship.GetSystem()->Name() : ""),
+	system(ship.GetSystem() ? isHere ? "" : ship.GetSystem()->Name() : "(docked)"),
 	low{ship.Shields(), ship.Hull(), ship.Energy(), ship.Heat(), ship.Fuel()},
 	high(low),
 	ships(1, &ship)

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "LineShader.h"
 #include "OutlineShader.h"
 #include "Point.h"
+#include "PointerShader.h"
 #include "Rectangle.h"
 #include "Ship.h"
 #include "Sprite.h"
@@ -109,10 +110,12 @@ void EscortDisplay::Draw(const Rectangle &bounds) const
 			color = cannotJumpColor;
 		else if(escort.notReadyToJump)
 			color = notReadyToJumpColor;
-		else if(escort.isSelected)
-			color = selectedColor;
 		else
 			color = hereColor;
+
+		// Draw the selection pointer
+		if(escort.isSelected)
+			PointerShader::Draw(pos, Point(1., 0.), ICON_SIZE / 2, ICON_SIZE / 2, -ICON_SIZE / 2, selectedColor);
 
 		// Figure out what scale should be applied to the ship sprite.
 		float scale = min(ICON_SIZE / escort.sprite->Width(), ICON_SIZE / escort.sprite->Height());

--- a/source/EscortDisplay.h
+++ b/source/EscortDisplay.h
@@ -56,6 +56,7 @@ private:
 		void Merge(const Icon &other);
 
 		const Sprite *sprite;
+		bool isDisabled;
 		bool isHere;
 		bool isHostile;
 		bool notReadyToJump;


### PR DESCRIPTION
## Feature Details
1. Disabled ships are displayed in grey to avoid confusing them with docked ships.
2. Escort selection is indicated with a pointer instead of icon color change.

## UI Screenshots
Before:
![2 2](https://user-images.githubusercontent.com/108272452/233855238-ed45f9b8-c688-4c82-bde9-90a4a3bb7039.png)

After:
![2 1](https://user-images.githubusercontent.com/108272452/233855217-f60e95ce-1a7d-483e-8343-c3669c81d605.png)

(Both images show the same situation: the Black Diamonds carried and selected, the Shield Beetle disabled, the first Albatross selected, and the second Albatross disabled in another system.)

## Performance Impact
N/A

## Alternative Approaches
#4711 suggested to use the selection color for icons more frequently, but I think using a pointer is better as it doesn't hide normal icon colors.