### PR TITLE
Add a Link to Endless Sky Mobile's Issue Page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Endless Sky Mobile
+    url: https://github.com/thewierdnut/endless-mobile/issues/
+    about: Please report bugs any issues related to the mobile port here.


### PR DESCRIPTION
Lately, there's been a number of mobile-specific issues which would be better raised on the mobile port's site. So many people play on mobile now that it is probably worth providing a link to where mobile-related issues should be posted, to avoid cluttering up the issues page and creating hassle for everyone.

This PR adds said link to the issue template selection page.

Also, mentioning @thewierdnut since this concerns ES Mobile.