### PR TITLE
feat(enhancement): A preference to disable flotsam collection by the flagship

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2252,7 +2252,9 @@ void Engine::DoCollection(Flotsam &flotsam)
 			break;
 		}
 	}
-	if(!collector || (collector == player.Flagship() && !Preferences::Has("Flagship flotsam collection")))
+	if(!collector)
+		return;
+	if(collector == player.Flagship() && !Preferences::Has("Flagship flotsam collection"))
 		return;
 
 	// Transfer cargo from the flotsam to the collector ship.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2252,7 +2252,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 			break;
 		}
 	}
-	if(!collector)
+	if(!collector || (collector == player.Flagship() && !Preferences::Has("Flagship flotsam collection")))
 		return;
 
 	// Transfer cargo from the flotsam to the collector ship.

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -133,6 +133,7 @@ void Preferences::Load()
 	// These settings should be on by default. There is no need to specify
 	// values for settings that are off by default.
 	settings["Render motion blur"] = true;
+	settings["Flagship flotsam collection"] = true;
 	settings[FRUGAL_ESCORTS] = true;
 	settings[EXPEND_AMMO] = true;
 	settings["Damaged fighters retreat"] = true;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -538,6 +538,7 @@ void PreferencesPanel::DrawSettings()
 		"Automatic firing",
 		BOARDING_PRIORITY,
 		"Control ship with mouse",
+		"Flagship flotsam collection",
 		EXPEND_AMMO,
 		"Extra fleet status messages",
 		"Fighters transfer cargo",


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed in issue #8685

## Feature Details
Added a "Flagship flotsam collection" preference. When disabled, it prevents the flagship from collecting any flotsam.

## UI Screenshots
N/A

## Testing Done
Yes, works as intended.

## Performance Impact
N/A
