### PR TITLE
bugfix: Don't allow buying outfits the player can't afford

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -392,7 +392,7 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 	}
 
 	// Check if you need to pay, and can't afford it.
-	if(!isInCargo && !isInStorage)
+	if(!onlyOwned)
 	{
 		// Determine what you will have to pay to buy this outfit.
 		int64_t cost = player.StockDepreciation().Value(selectedOutfit, day);


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8687

## Fix Details
CanBuy currently treats any outfits as free when the player has some of them in cargo or storage. The credits, however, are taken normally, which can lead to negative credits.

## Testing Done
Seems to work. 