### PR TITLE
bugfix(content): Require Hai first contact before Unwanted Cargo mission

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -269,11 +269,11 @@ mission "Unwanted Cargo Trigger"
 	landing
 	source
 		government "Hai"
+		not attributes "uninhabited"
 	to offer
 		random < 1
 		"cargo space" > 0
 		not "event: hai secret leaks"
-		has "First Contact: Hai: offered"
 	on offer
 		event "hai in cargo" 14
 		fail

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -273,6 +273,7 @@ mission "Unwanted Cargo Trigger"
 		random < 1
 		"cargo space" > 0
 		not "event: hai secret leaks"
+		has "First Contact: Hai: offered"
 	on offer
 		event "hai in cargo" 14
 		fail


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue raised on Discord [here](https://discord.com/channels/251118043411775489/536900466655887360/1099746823410831560).

## Fix Details
Adds one line requiring the first contact mission. This means that it will still offer on an uninhabited (Hai) planet, but that it won't offer if you don't know about the Hai.

Alternatively, we could do what Terin suggested and block it from offering on uninhabited planets, but this is a more comprehensive method, and you could probably have picked up a missing child anywhere, even if it's not an inhabited planet.

## Testing Done
Tested using the save file. It seems to work fine, although I haven't checked to make sure it still offers when you _have_ done the first contact mission.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 0.10.0, but probably also continuous, and will not occur when using this branch's build.
[SPOILER_Hai_Whisperer.txt](https://github.com/endless-sky/endless-sky/files/11306352/SPOILER_Hai_Whisperer.txt)