### PR TITLE
feat(enhancement): Guns-only and turrets-only autofire modes

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3300,7 +3300,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 		// Skip weapons that are not ready to fire.
 		if(!hardpoint.IsReady())
 			continue;
-		
+
 		// Skip weapons omitted by the "Automatic firing" preference.
 		if(isFlagship
 				&& ((Preferences::GetAutoFire() == Preferences::AutoFire::GUNS_ONLY && hardpoint.IsTurret())

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3302,10 +3302,14 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 			continue;
 
 		// Skip weapons omitted by the "Automatic firing" preference.
-		if(isFlagship
-				&& ((Preferences::GetAutoFire() == Preferences::AutoFire::GUNS_ONLY && hardpoint.IsTurret())
-				|| (Preferences::GetAutoFire() == Preferences::AutoFire::TURRETS_ONLY && !hardpoint.IsTurret())))
-			continue;
+		if(isFlagship)
+		{
+			const Preferences::AutoFire autoFireMode = Preferences::GetAutoFire();
+			if(autoFireMode == Preferences::AutoFire::GUNS_ONLY && hardpoint.IsTurret())
+				continue;
+			if(autoFireMode == Preferences::AutoFire::TURRETS_ONLY && !hardpoint.IsTurret())
+				continue;
+		}
 
 		const Weapon *weapon = hardpoint.GetOutfit();
 		// Don't expend ammo for homing weapons that have no target selected.

--- a/source/AI.h
+++ b/source/AI.h
@@ -141,7 +141,7 @@ private:
 	void AimTurrets(const Ship &ship, FireCommand &command, bool opportunistic = false) const;
 	// Fire whichever of the given ship's weapons can hit a hostile target.
 	// Return a bitmask giving the weapons to fire.
-	void AutoFire(const Ship &ship, FireCommand &command, bool secondary = true) const;
+	void AutoFire(const Ship &ship, FireCommand &command, bool secondary = true, bool isFlagship = false) const;
 	void AutoFire(const Ship &ship, FireCommand &command, const Body &target) const;
 
 	// Calculate how long it will take a projectile to reach a target given the

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -113,6 +113,9 @@ namespace {
 	const vector<string> AUTO_AIM_SETTINGS = {"off", "always on", "when firing"};
 	int autoAimIndex = 2;
 
+	const vector<string> AUTO_FIRE_SETTINGS = {"off", "on", "guns only", "turrets only"};
+	int autoFireIndex = 0;
+
 	const vector<string> BOARDING_SETTINGS = {"proximity", "value", "mixed"};
 	int boardingIndex = 0;
 
@@ -179,6 +182,8 @@ void Preferences::Load()
 			statusOverlaySettings[OverlayType::NEUTRAL].SetState(node.Value(1));
 		else if(node.Token(0) == "Automatic aiming")
 			autoAimIndex = max<int>(0, min<int>(node.Value(1), AUTO_AIM_SETTINGS.size() - 1));
+		else if(node.Token(0) == "Automatic firing")
+			autoFireIndex = max<int>(0, min<int>(node.Value(1), AUTO_FIRE_SETTINGS.size() - 1));
 		else if(node.Token(0) == "Parallax background")
 			parallaxIndex = max<int>(0, min<int>(node.Value(1), PARALLAX_SETTINGS.size() - 1));
 		else if(node.Token(0) == "fullscreen")
@@ -233,6 +238,7 @@ void Preferences::Save()
 	out.Write("Show enemy overlays", statusOverlaySettings[OverlayType::ENEMY].ToInt());
 	out.Write("Show neutral overlays", statusOverlaySettings[OverlayType::NEUTRAL].ToInt());
 	out.Write("Automatic aiming", autoAimIndex);
+	out.Write("Automatic firing", autoFireIndex);
 	out.Write("Parallax background", parallaxIndex);
 	out.Write("alert indicator", alertIndicatorIndex);
 	out.Write("previous saves", previousSaveCount);
@@ -471,6 +477,28 @@ const string &Preferences::AutoAimSetting()
 {
 	return AUTO_AIM_SETTINGS[autoAimIndex];
 }
+
+
+
+void Preferences::ToggleAutoFire()
+{
+	autoFireIndex = (autoFireIndex + 1) % AUTO_FIRE_SETTINGS.size();
+}
+
+
+
+Preferences::AutoFire Preferences::GetAutoFire()
+{
+	return static_cast<AutoFire>(autoFireIndex);
+}
+
+
+
+const string &Preferences::AutoFireSetting()
+{
+	return AUTO_FIRE_SETTINGS[autoFireIndex];
+}
+
 
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -50,6 +50,13 @@ public:
 		WHEN_FIRING
 	};
 
+	enum class AutoFire : int_fast8_t {
+		OFF = 0,
+		ON,
+		GUNS_ONLY,
+		TURRETS_ONLY
+	};
+
 	enum class BoardingPriority : int_fast8_t {
 		PROXIMITY = 0,
 		VALUE,
@@ -109,6 +116,11 @@ public:
 	static void ToggleAutoAim();
 	static AutoAim GetAutoAim();
 	static const std::string &AutoAimSetting();
+
+	// Auto fire setting, either "off", "on", "guns only", or "turrets only".
+	static void ToggleAutoFire();
+	static AutoFire GetAutoFire();
+	static const std::string &AutoFireSetting();
 
 	// Background parallax setting, either "fast", "fancy", or "off".
 	static void ToggleParallax();

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -53,6 +53,7 @@ namespace {
 	const int ZOOM_FACTOR_INCREMENT = 10;
 	const string VIEW_ZOOM_FACTOR = "View zoom factor";
 	const string AUTO_AIM_SETTING = "Automatic aiming";
+	const string AUTO_FIRE_SETTING = "Automatic firing";
 	const string SCREEN_MODE_SETTING = "Screen mode";
 	const string VSYNC_SETTING = "VSync";
 	const string STATUS_OVERLAYS_ALL = "Show status overlays";
@@ -233,6 +234,8 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 				Preferences::CycleStatusOverlays(Preferences::OverlayType::NEUTRAL);
 			else if(zone.Value() == AUTO_AIM_SETTING)
 				Preferences::ToggleAutoAim();
+			else if(zone.Value() == AUTO_FIRE_SETTING)
+				Preferences::ToggleAutoFire();
 			else if(zone.Value() == EXPEND_AMMO)
 				Preferences::ToggleAmmoUsage();
 			else if(zone.Value() == TURRET_TRACKING)
@@ -535,7 +538,7 @@ void PreferencesPanel::DrawSettings()
 		"\n",
 		"Gameplay",
 		AUTO_AIM_SETTING,
-		"Automatic firing",
+		AUTO_FIRE_SETTING,
 		BOARDING_PRIORITY,
 		"Control ship with mouse",
 		EXPEND_AMMO,
@@ -651,6 +654,11 @@ void PreferencesPanel::DrawSettings()
 		else if(setting == AUTO_AIM_SETTING)
 		{
 			text = Preferences::AutoAimSetting();
+			isOn = text != "off";
+		}
+		else if(setting == AUTO_FIRE_SETTING)
+		{
+			text = Preferences::AutoFireSetting();
 			isOn = text != "off";
 		}
 		else if(setting == EXPEND_AMMO)


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #8683

## Feature Details
Added two new modes of automatic firing: the setting can be toggled between "off", "on", "guns only" and "turrets only".

## Testing Done
Tested all autofire types.

## Performance Impact
N/A
