### PR TITLE
Remove some unnecessary code in Interface::BarElement::Draw

### DIFF
--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -654,7 +654,7 @@ void Interface::BarElement::Draw(const Rectangle &rect, const Information &info,
 		if(!rect.Width() || !rect.Height())
 			return;
 
-		RingShader::Draw(rect.Center(), .5 * rect.Width(), width, value, *color, segments > 1. ? segments : 0.);
+		RingShader::Draw(rect.Center(), .5 * rect.Width(), width, value, *color, segments);
 	}
 	else
 	{


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Earlier in this method, the following code is present:
https://github.com/endless-sky/endless-sky/blob/d2d03934c640b6165738b9e92c680f3c9c821101/source/Interface.cpp#L645-L646
This means that `segments` is already either 0 or greater than 1, and so checking that again is unnecessary.
