### PR TITLE
feat(enhancement): Support outfit (un)installation costs

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -276,6 +276,9 @@ tip "hull heat multiplier:"
 tip "hull repair rate:"
 	`Amount of hull strength that can be repaired per second. Repairs usually consume energy and may generate heat as well.`
 
+tip "installation cost:"
+	`How much, in credits, it will cost you to install this outfit on your ship.`
+
 tip "repair delay:"
 	`How many seconds it takes for hull repairs to begin after taking hull damage.`
 
@@ -659,6 +662,9 @@ tip "turret mounts needed:"
 
 tip "turret mounts free:"
 	`How many turrets can be mounted on this ship. Turrets fire in the direction of the currently selected target, instead of firing straight forward like guns.`
+
+tip "uninstallation cost:"
+	`How much, in credits, it will cost you to uninstall this outfit from your ship.`
 
 tip "weapon capacity needed:"
 	`Tons of weapon space this outfit takes up.`

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -270,6 +270,10 @@ void Outfit::Load(const DataNode &node)
 		}
 		else if(child.Token(0) == "cost" && child.Size() >= 2)
 			cost = child.Value(1);
+		else if(child.Token(0) == "installation cost" && child.Size() >= 2)
+			installationCost = child.Value(1);
+		else if(child.Token(0) == "uninstallation cost" && child.Size() >= 2)
+			uninstallationCost = child.Value(1);
 		else if(child.Token(0) == "mass" && child.Size() >= 2)
 			mass = child.Value(1);
 		else if(child.Token(0) == "licenses" && (child.HasChildren() || child.Size() >= 2))
@@ -435,6 +439,20 @@ const string &Outfit::Description() const
 
 
 
+const int64_t Outfit::InstallationCost() const
+{
+	return installationCost;
+}
+
+
+
+const int64_t Outfit::UninstallationCost() const
+{
+	return uninstallationCost;
+}
+
+
+
 // Get the licenses needed to purchase this outfit.
 const vector<string> &Outfit::Licenses() const
 {
@@ -512,6 +530,8 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 void Outfit::Add(const Outfit &other, int count)
 {
 	cost += other.cost * count;
+	installationCost += other.installationCost * count;
+	uninstallationCost += other.uninstallationCost * count;
 	mass += other.mass * count;
 	for(const auto &at : other.attributes)
 	{

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -59,6 +59,8 @@ public:
 	const int Index() const;
 	const std::string &Description() const;
 	int64_t Cost() const;
+	const int64_t InstallationCost() const;
+	const int64_t UninstallationCost() const;
 	double Mass() const;
 	// Get the licenses needed to buy or operate this ship.
 	const std::vector<std::string> &Licenses() const;
@@ -114,6 +116,8 @@ private:
 	std::string description;
 	const Sprite *thumbnail = nullptr;
 	int64_t cost = 0;
+	int64_t installationCost = 0;
+	int64_t uninstallationCost = 0;
 	double mass = 0.;
 	// Licenses needed to purchase this item.
 	std::vector<std::string> licenses;

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -402,6 +402,33 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		hasNormalAttributes = true;
 	}
 
+	int64_t installationCost = outfit.InstallationCost();
+	if(installationCost)
+	{
+		attributeLabels.emplace_back("installation cost:");
+		attributeValues.emplace_back(Format::Credits(installationCost));
+		attributesHeight += 20;
+		hasNormalAttributes = true;
+	}
+
+	int64_t uninstallationCost = outfit.UninstallationCost();
+	if(uninstallationCost)
+	{
+		attributeLabels.emplace_back("uninstallation cost:");
+		attributeValues.emplace_back(Format::Credits(uninstallationCost));
+		attributesHeight += 20;
+		hasNormalAttributes = true;
+	}
+
+	if(installationCost || uninstallationCost)
+	{
+		attributeLabels.emplace_back();
+		attributeValues.emplace_back();
+		attributeLabels.emplace_back();
+		attributeValues.emplace_back();
+		attributesHeight += 20;
+	}
+
 	for(const pair<const char *, double> &it : outfit.Attributes())
 	{
 		if(count(EXPECTED_NEGATIVE.begin(), EXPECTED_NEGATIVE.end(), it.first))

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -431,7 +431,7 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 			return "You cannot install this outfit, because the installation process costs "
 				+ Format::CreditString(installationCost) + ", and you only have "
 				+ Format::Credits(credits) + ".";
-		
+
 		// Find if any ship can install the outfit.
 		for(const Ship *ship : playerShips)
 			if(ShipCanBuy(ship, selectedOutfit))


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed in issue #6623

## Feature Details
Outfits can set `"installation cost"` and `"uninstallation cost"` attributes. The costs won't affect buying directly into cargo, moving items from cargo to planetary storage, plundering etc., only installing these oufits on ships at the outfitter.

## UI Screenshots
(The pictures show example values that are not included in the changes.)
An (un)installation cost set to 0 (default) doesn't get listed at all.

![ex1](https://user-images.githubusercontent.com/108272452/234615823-e2bb1806-7514-407d-8a6c-fbb565cd7d17.png)

![ex2](https://user-images.githubusercontent.com/108272452/234615852-eed52167-ddb9-407d-bc72-0fd5349b1f39.png)


## Testing Done
When I had needed amount of credits, the process succeded and the credits were consumed. When I didn't have the credits, the process was blocked and a dialog box was displayed.

## Performance Impact
N/A
