### PR TITLE
Fix some ships being unable to jump

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1986,11 +1986,23 @@ double AI::TurnToward(const Ship &ship, const Point &vector, const double precis
 	double dot = vector.Dot(facing);
 	if(dot > 0.)
 	{
+		// Is the facing direction aligned with the target direction with sufficient precision?
+		// The maximum angle between the two directions is given by: arccos(sqrt(precision)).
+		bool close = false;
 		if(precision < 1. && precision > 0. && dot * dot >= precision * vector.LengthSquared() * facing.LengthSquared())
-			return 0.;
+			close = true;
 		double angle = asin(min(1., max(-1., cross / vector.Length()))) * TO_DEG;
-		if(fabs(angle) <= ship.TurnRate())
+		// Is the angle between the facing and target direction smaller than
+		// the angle the ship can turn through in one step?
+		if(fabs(angle) < ship.TurnRate())
+		{
+			// If the ship is within one step of the target direction,
+			// and the facing is already sufficiently aligned with the target direction,
+			// don't turn any further.
+			if(close)
+				return 0.;
 			return -angle / ship.TurnRate();
+		}
 	}
 
 	bool left = cross < 0.;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1989,7 +1989,7 @@ double AI::TurnToward(const Ship &ship, const Point &vector, const double precis
 		// Is the facing direction aligned with the target direction with sufficient precision?
 		// The maximum angle between the two directions is given by: arccos(sqrt(precision)).
 		bool close = false;
-		if(precision < 1. && precision > 0. && dot * dot >= precision * vector.LengthSquared() * facing.LengthSquared())
+		if(precision < 1. && precision > 0. && dot * dot >= precision * vector.LengthSquared())
 			close = true;
 		double angle = asin(min(1., max(-1., cross / vector.Length()))) * TO_DEG;
 		// Is the angle between the facing and target direction smaller than


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8693, and is an alternative to #8698.

## Fix Details
AI::TurnToward will now not stop trying to turn towards the target direction until both the facing is sufficiently well aligned with it (currently, this is within ~0.57 degrees of it) *and* the ship is within one step of turning of it. This means that even slow turning ships continue to turn towards the target direction until they are within one step of it, so they are close enough that they are able to jump.

Also, removed an unnecessary vector magnitude calculation: the vector is already a unit vector.

## Testing Done
Test autopilot hyperspace jumping with a ship with a turn rate of less than 1 degree per second and see that it is able to jump successfully, never getting stuck.
