### PR TITLE
feat(content): Remnant: Relabelling Albatross as Medium Warship

### DIFF
--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -18,7 +18,7 @@ ship "Albatross"
 	sprite "ship/albatross"
 	thumbnail "thumbnail/albatross"
 	attributes
-		category "Heavy Warship"
+		category "Medium Warship"
 		licenses
 			"Remnant Capital"
 		cost 20250000


### PR DESCRIPTION
**Content**

## Summary
This changes the classification of the Remnant Albatross as a Medium Warship. No stats or attributes have been changed.

Both the design and utilization of the Albatross by the Remnant is more akin to that of the medium warship role, rather than the heavy warship (shield tank build aside). Likewise, it's gun-heavy design and focus on mobility are also more typical traits of medium warships rather than heavy ones. 

This change is basically intended to help contextualize and shape the perception of the Albatross to match the Remnant's view of it. 

No changes to statistics or attributes are planned.

## Save File
This save file can be used to play through the new mission content:
[Rebbia Rampart~3033-01-14 Remnant Capital License.txt](https://github.com/endless-sky/endless-sky/files/11345286/Rebbia.Rampart.3033-01-14.Remnant.Capital.License.txt)

## Artwork Checklist
 - ~~[X] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
 - ~~[X] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}~~
 - ~~[X] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~
