### PR TITLE
Add delimiters to strings when printing data

### DIFF
--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -59,9 +59,9 @@ namespace {
 		{
 			if(itemIt.first != ObjectName(itemIt.second))
 				continue;
-			cout << itemIt.first;
+			cout << '"' << itemIt.first << '"';
 			for(auto &saleName : itemSales[itemIt.first])
-				cout << ',' << saleName;
+				cout << ',' << '"' << saleName << '"';
 			cout << '\n';
 		}
 	}
@@ -74,10 +74,10 @@ namespace {
 		cout << saleNoun << ';' << itemNoun << '\n';
 		for(auto &saleIt : sales)
 		{
-			cout << saleIt.first;
+			cout << '"' << saleIt.first << '"';
 			int index = 0;
 			for(auto &item : saleIt.second)
-				cout << (index++ ? ';' : ',') << ObjectName(*item);
+				cout << (index++ ? ';' : ',') << '"' << ObjectName(*item) << '"';
 			cout << '\n';
 		}
 	}
@@ -102,11 +102,11 @@ namespace {
 		cout << name << ',' << "attributes" << '\n';
 		for(auto &it : objects)
 		{
-			cout << it.first;
+			cout << '"' << it.first << '"';
 			const Type &object = it.second;
 			int index = 0;
 			for(const string &attribute : object.Attributes())
-				cout << (index++ ? ';' : ',') << attribute;
+				cout << (index++ ? ';' : ',') << '"' << attribute << '"';
 			cout << '\n';
 		}
 	}
@@ -126,13 +126,13 @@ namespace {
 		}
 		for(const string &attribute : attributes)
 		{
-			cout << attribute;
+			cout << '"' << attribute << '"';
 			int index = 0;
 			for(auto &it : objects)
 			{
 				const Type &object = it.second;
 				if(object.Attributes().count(attribute))
-					cout << (index++ ? ';' : ',') << it.first;
+					cout << (index++ ? ';' : ',') << '"' << it.first << '"';
 			}
 			cout << '\n';
 		}
@@ -148,6 +148,7 @@ namespace {
 				<< "required crew" << ',' << "bunks" << ',' << "cargo space" << ',' << "fuel" << ','
 				<< "outfit space" << ',' << "weapon capacity" << ',' << "engine capacity" << ',' << "gun mounts" << ','
 				<< "turret mounts" << ',' << "fighter bays" << ',' << "drone bays" << '\n';
+
 			for(auto &it : GameData::Ships())
 			{
 				// Skip variants and unnamed / partially-defined ships.
@@ -155,10 +156,10 @@ namespace {
 					continue;
 
 				const Ship &ship = it.second;
-				cout << it.first << ',';
+				cout << '"' << it.first << '"' << ',';
 
 				const Outfit &attributes = ship.BaseAttributes();
-				cout << attributes.Category() << ',';
+				cout << '"' << attributes.Category() << '"' << ',';
 				cout << ship.ChassisCost() << ',';
 				cout << ship.Cost() << ',';
 
@@ -204,6 +205,7 @@ namespace {
 				<< "idle/max heat" << ',' << "max heat generation" << ',' << "max heat dissipation" << ','
 				<< "gun mounts" << ',' << "turret mounts" << ',' << "fighter bays" << ','
 				<< "drone bays" << ',' << "deterrence" << '\n';
+
 			for(auto &it : GameData::Ships())
 			{
 				// Skip variants and unnamed / partially-defined ships, unless specified otherwise.
@@ -211,10 +213,10 @@ namespace {
 					continue;
 
 				const Ship &ship = it.second;
-				cout << it.first << ',';
+				cout << '"' << it.first << '"' << ',';
 
 				const Outfit &attributes = ship.Attributes();
-				cout << attributes.Category() << ',';
+				cout << '"' << attributes.Category() << '"' << ',';
 				cout << ship.Cost() << ',';
 
 				auto mass = attributes.Mass() ? attributes.Mass() : 1.;
@@ -360,8 +362,8 @@ namespace {
 					continue;
 
 				const Outfit &outfit = it.second;
-				cout << it.first << ',';
-				cout << outfit.Category() << ',';
+				cout << '"' << it.first << '"' << ',';
+				cout << '"' << outfit.Category() << '"' << ',';
 				cout << outfit.Cost() << ',';
 				cout << -outfit.Get("weapon capacity") << ',';
 
@@ -427,6 +429,7 @@ namespace {
 				double deterrence = .12 * damage / outfit.Reload();
 				cout << deterrence << '\n';
 			}
+
 			cout.flush();
 		};
 
@@ -438,6 +441,7 @@ namespace {
 				<< "turn heat/s" << ',' << "reverse thrust/s" << ',' << "reverse energy/s" << ','
 				<< "reverse heat/s" << ',' << "afterburner thrust/s" << ',' << "afterburner energy/s" << ','
 				<< "afterburner heat/s" << ',' << "afterburner fuel/s" << '\n';
+
 			for(auto &it : GameData::Outfits())
 			{
 				// Skip non-engines.
@@ -445,7 +449,7 @@ namespace {
 					continue;
 
 				const Outfit &outfit = it.second;
-				cout << it.first << ',';
+				cout << '"' << it.first << '"' << ',';
 				cout << outfit.Cost() << ',';
 				cout << outfit.Mass() << ',';
 				cout << outfit.Get("outfit space") << ',';
@@ -464,6 +468,7 @@ namespace {
 				cout << outfit.Get("afterburner heat") * 60. << ',';
 				cout << outfit.Get("afterburner fuel") * 60. << '\n';
 			}
+
 			cout.flush();
 		};
 
@@ -471,6 +476,7 @@ namespace {
 		{
 			cout << "name" << ',' << "cost" << ',' << "mass" << ',' << "outfit space" << ','
 				<< "energy generation" << ',' << "heat generation" << ',' << "energy capacity" << '\n';
+
 			for(auto &it : GameData::Outfits())
 			{
 				// Skip non-power.
@@ -478,7 +484,7 @@ namespace {
 					continue;
 
 				const Outfit &outfit = it.second;
-				cout << it.first << ',';
+				cout << '"' << it.first << '"' << ',';
 				cout << outfit.Cost() << ',';
 				cout << outfit.Mass() << ',';
 				cout << outfit.Get("outfit space") << ',';
@@ -486,6 +492,7 @@ namespace {
 				cout << outfit.Get("heat generation") << ',';
 				cout << outfit.Get("energy capacity") << '\n';
 			}
+
 			cout.flush();
 		};
 
@@ -498,15 +505,19 @@ namespace {
 				for(const auto &attribute : outfit.Attributes())
 					attributes.insert(attribute.first);
 			}
+
 			cout << "name" << ',' << "category" << ',' << "cost" << ',' << "mass";
 			for(const auto &attribute : attributes)
-				cout << ',' << attribute;
+				cout << ',' << '"' << attribute << '"';
 			cout << '\n';
+
 			for(auto &it : GameData::Outfits())
 			{
 				const Outfit &outfit = it.second;
-				cout << outfit.TrueName() << ',' << outfit.Category() << ','
-					<< outfit.Cost() << ',' << outfit.Mass();
+				cout << '"' << outfit.TrueName() << '"' << ',';
+				cout << '"' << outfit.Category() << '"' << ',';
+				cout << outfit.Cost() << ',';
+				cout << outfit.Mass();
 				for(const auto &attribute : attributes)
 					cout << ',' << outfit.Attributes().Get(attribute);
 				cout << '\n';


### PR DESCRIPTION
**Feature:**

## Feature Details
Adds `"` characters as delimiters around ship and outfit names and categories when printing data since these can have commas in them (and some variant names do) which is problematic given that commas are used to separate fields in each row.

## Testing Done
It built and printed data as expected.
