### PR TITLE
Add support for drawing pointers in an interface

### DIFF
--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Interface.h"
 
+#include "Angle.h"
 #include "DataNode.h"
 #include "text/DisplayText.h"
 #include "FillShader.h"
@@ -26,6 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "LineShader.h"
 #include "OutlineShader.h"
 #include "Panel.h"
+#include "PointerShader.h"
 #include "Rectangle.h"
 #include "RingShader.h"
 #include "Screen.h"
@@ -119,6 +121,8 @@ void Interface::Load(const DataNode &node)
 				elements.push_back(new TextElement(child, anchor));
 			else if(child.Token(0) == "bar" || child.Token(0) == "ring")
 				elements.push_back(new BarElement(child, anchor));
+			else if(child.Token(0) == "pointer")
+				elements.push_back(new PointerElement(child, anchor));
 			else if(child.Token(0) == "line")
 				elements.push_back(new LineElement(child, anchor));
 			else
@@ -680,6 +684,64 @@ void Interface::BarElement::Draw(const Rectangle &rect, const Information &info,
 			LineShader::Draw(from, to, width, *color);
 		}
 	}
+}
+
+
+
+
+// Members of the PointerElement class:
+
+// Constructor.
+Interface::PointerElement::PointerElement(const DataNode &node, const Point &globalAnchor)
+{
+	Load(node, globalAnchor);
+
+	// Fill in a default color if none is specified.
+	if(!color)
+		color = GameData::Colors().Get("medium");
+
+	// Set a default orientation if none is specified.
+	if(!orientation)
+		orientation = Point(0., -1.);
+}
+
+
+
+// Parse the given data line: one that is not recognized by Element
+// itself. This returns false if it does not recognize the line, either.
+bool Interface::PointerElement::ParseLine(const DataNode &node)
+{
+	if(node.Token(0) == "color" && node.Size() >= 2)
+		color = GameData::Colors().Get(node.Token(1));
+	else if(node.Token(0) == "orientation angle" && node.Size() >= 2)
+	{
+		const Angle direction(node.Value(1));
+		orientation = direction.Unit();
+	}
+	else if(node.Token(0) == "orientation vector" && node.Size() >= 3)
+	{
+		orientation.X() = node.Value(1);
+		orientation.Y() = node.Value(2);
+	}
+	else
+		return false;
+
+	return true;
+}
+
+
+
+void Interface::PointerElement::Draw(const Rectangle &rect, const Information &info, int state) const
+{
+	// Avoid crashes for malformed interface elements that are not fully loaded.
+	if(!from.Get() && !to.Get())
+		return;
+	const Point fromP = from.Get();
+	const Point toP = to.Get();
+	const Point center = (fromP + toP) / 2.;
+	const float width = abs(fromP.X() - toP.X());
+	const float height = abs(fromP.Y() - toP.Y());
+	PointerShader::Draw(center, orientation, width, height, 0.f, *color);
 }
 
 

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -733,14 +733,9 @@ bool Interface::PointerElement::ParseLine(const DataNode &node)
 
 void Interface::PointerElement::Draw(const Rectangle &rect, const Information &info, int state) const
 {
-	// Avoid crashes for malformed interface elements that are not fully loaded.
-	if(!from.Get() && !to.Get())
-		return;
-	const Point fromP = from.Get();
-	const Point toP = to.Get();
-	const Point center = (fromP + toP) / 2.;
-	const float width = abs(fromP.X() - toP.X());
-	const float height = abs(fromP.Y() - toP.Y());
+	const Point center = rect.Center();
+	const float width = rect.Width();
+	const float height = rect.Height();
 	PointerShader::Draw(center, orientation, width, height, 0.f, *color);
 }
 

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -196,6 +196,24 @@ private:
 	};
 
 
+	// This class handles "pointer" elements.
+	class PointerElement : public Element {
+	public:
+		PointerElement(const DataNode &node, const Point &globalAnchor);
+
+	protected:
+		// Parse the given data line: one that is not recognized by Element
+		// itself. This returns false if it does not recognize the line, either.
+		virtual bool ParseLine(const DataNode &node) override;
+		// Draw this element in the given rectangle.
+		virtual void Draw(const Rectangle &rect, const Information &info, int state) const override;
+
+	private:
+		const Color *color = nullptr;
+		Point orientation;
+	};
+
+
 	// This class handles "line" elements.
 	class LineElement : public Element {
 	public:


### PR DESCRIPTION
**Feature:**

## Feature Details
Adds a new type of element to Interface: PointerElement.
This allows an interface to draw pointers with customisable position, size, orientation, and colour.

The orientation can either be given as an angle in degrees, counting clockwise with 0 being straight up, or a pair of values corresponding to the x and y components of a vector: positive x is right, positive y is down.

## Usage Examples
```
interface "whatever"
    pointer
        from 10 50
        to 20 70
        "orientation vector" 1 0
        color "my color"
```

```html
pointer
    from <x#> <y#> to <x#> <y#> [<anchor>]
    ["orientation angle" <degrees#>]
    ["orientation vector" <x#> <y#>]
    [color <color>]
```

## Testing Done
It builds!
