### PR TITLE
More interface ring options

### DIFF
--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -616,12 +616,6 @@ Interface::BarElement::BarElement(const DataNode &node, const Point &globalAncho
 	// Fill in a default color if none is specified.
 	if(!color)
 		color = GameData::Colors().Get("active");
-
-	// Make sure these values are within the allowed ranges.
-	spanAngle = max(0., spanAngle);
-	spanAngle = min(360., spanAngle);
-	startAngle = max(0., startAngle);
-	startAngle = min(360., startAngle);
 }
 
 
@@ -635,9 +629,9 @@ bool Interface::BarElement::ParseLine(const DataNode &node)
 	else if(node.Token(0) == "size" && node.Size() >= 2)
 		width = node.Value(1);
 	else if(node.Token(0) == "span angle" && node.Size() >= 2)
-		spanAngle = node.Value(1);
+		spanAngle = max(0., min(360., node.Value(1)));
 	else if(node.Token(0) == "start angle" && node.Size() >= 2)
-		startAngle = node.Value(1);
+		startAngle = max(0., min(360., node.Value(1)));
 	else
 		return false;
 

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -636,30 +636,10 @@ bool Interface::BarElement::ParseLine(const DataNode &node)
 		return false;
 
 	// Some input validation.
-	string warning;
-	if(spanAngle < 0.)
-	{
-		spanAngle = 0.;
-		warning = "Warning: \"span angle\" may not be negative. Using 0 instead:";
-	}
-	if(spanAngle > 360.)
-	{
-		spanAngle = 360.;
-		warning = "Warning: \"span angle\" may not exceed 360. Using 360 instead:";
-	}
-	if(startAngle < 0.)
-	{
-		startAngle = 0.;
-		warning = "Warning: \"start angle\" may not be negative. Using 0 instead:";
-	}
-	if(startAngle > 360.)
-	{
-		startAngle = 360.;
-		warning = "Warning: \"start angle\" may not exceed 360. Using 360 instead:";
-	}
-
-	if(!warning.empty())
-		node.PrintTrace(warning);
+	spanAngle = max(0., spanAngle);
+	spanAngle = spanAngle % 360.;
+	startAngle = max(0., startAngle);
+	startAngle = startAngle % 360.;
 
 	return true;
 }

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -686,9 +686,7 @@ void Interface::BarElement::Draw(const Rectangle &rect, const Information &info,
 
 
 		double fraction = value * spanAngle / 360.;
-
 		RingShader::Draw(rect.Center(), .5 * rect.Width(), width, fraction, *color, segments, startAngle);
-
 	}
 	else
 	{

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -616,6 +616,12 @@ Interface::BarElement::BarElement(const DataNode &node, const Point &globalAncho
 	// Fill in a default color if none is specified.
 	if(!color)
 		color = GameData::Colors().Get("active");
+
+	// Make sure these values are within the allowed ranges.
+	spanAngle = max(0., spanAngle);
+	spanAngle = min(360., spanAngle);
+	startAngle = max(0., startAngle);
+	startAngle = min(360., startAngle);
 }
 
 
@@ -634,12 +640,6 @@ bool Interface::BarElement::ParseLine(const DataNode &node)
 		startAngle = node.Value(1);
 	else
 		return false;
-
-	// Some input validation.
-	spanAngle = max(0., spanAngle);
-	spanAngle = spanAngle % 360.;
-	startAngle = max(0., startAngle);
-	startAngle = startAngle % 360.;
 
 	return true;
 }

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -628,8 +628,38 @@ bool Interface::BarElement::ParseLine(const DataNode &node)
 		color = GameData::Colors().Get(node.Token(1));
 	else if(node.Token(0) == "size" && node.Size() >= 2)
 		width = node.Value(1);
+	else if(node.Token(0) == "span angle" && node.Size() >= 2)
+		spanAngle = node.Value(1);
+	else if(node.Token(0) == "start angle" && node.Size() >= 2)
+		startAngle = node.Value(1);
 	else
 		return false;
+
+	// Some input validation.
+	string warning;
+	if(spanAngle < 0.)
+	{
+		spanAngle = 0.;
+		warning = "Warning: \"span angle\" may not be negative. Using 0 instead:";
+	}
+	if(spanAngle > 360.)
+	{
+		spanAngle = 360.;
+		warning = "Warning: \"span angle\" may not exceed 360. Using 360 instead:";
+	}
+	if(startAngle < 0.)
+	{
+		startAngle = 0.;
+		warning = "Warning: \"start angle\" may not be negative. Using 0 instead:";
+	}
+	if(startAngle > 360.)
+	{
+		startAngle = 360.;
+		warning = "Warning: \"start angle\" may not exceed 360. Using 360 instead:";
+	}
+
+	if(!warning.empty())
+		node.PrintTrace(warning);
 
 	return true;
 }
@@ -654,7 +684,9 @@ void Interface::BarElement::Draw(const Rectangle &rect, const Information &info,
 		if(!rect.Width() || !rect.Height())
 			return;
 
-		RingShader::Draw(rect.Center(), .5 * rect.Width(), width, value, *color, segments > 1. ? segments : 0.);
+		double fraction = value * spanAngle / 360.;
+
+		RingShader::Draw(rect.Center(), .5 * rect.Width(), width, fraction, *color, segments > 1. ? segments : 0., startAngle);
 	}
 	else
 	{

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -193,6 +193,8 @@ private:
 		const Color *color = nullptr;
 		float width = 2.f;
 		bool isRing = false;
+		double spanAngle = 360.;
+		double startAngle = 0.;
 	};
 
 


### PR DESCRIPTION
**Feature:**

## Feature Details
Adds support for limiting the span and adjusting the starting angle for rings drawn with an interface.

Both values are given in degrees.
A span angle of less than 360 will accordingly scale down the value that is set for this ring in the given interface information. A span angle of 180 with a value of 0.5 will draw a quarter circle, instead of the half circle it would draw with a span angle of 360.
~~I'll have to check how the start angle part works.~~

## Usage Examples
```html
ring "my arc"
    "span angle" 90
    "start angle" 45
```
