### PR TITLE
[Bug fix] Dump (instead of sell) excess commodities when no spaceport is present

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -66,7 +66,7 @@ PlanetPanel::PlanetPanel(PlayerInfo &player, function<void()> callback)
 	// Since the loading of landscape images is deferred, make sure that the
 	// landscapes for this system are loaded before showing the planet panel.
 	TaskQueue queue;
-	GameData::Preload(queue, planet.Landscape());
+GameData::Preload(queue, planet.Landscape());
 	queue.Wait();
 	queue.ProcessSyncTasks();
 }
@@ -398,7 +398,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		if(outfitsToSell > 0)
 		{
 			out << "\n- ";
-			out << (planet.HasOutfitter() ? "store " : "sell ") << outfitsToSell << " outfit";
+			out << (planet.HasOutfitter() ? "store " : ( planet.IsInhabited() && system.HasTrade() ? "sell " : "dump ")) << outfitsToSell << " outfit";
 			out << (outfitsToSell > 1 ? "s" : "");
 			out << " that none of your ships can hold.";
 			if(!uniquesToSell.empty())
@@ -426,7 +426,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		// Warn about commodities you will have to sell.
 		if(commoditiesToSell > 0)
 		{
-			out << "\n- sell " << Format::CargoString(commoditiesToSell, "cargo");
+			out << "\n-  " << ( planet.IsInhabited() && system.HasTrade() ? "sell " : "dump ") << Format::CargoString(commoditiesToSell, "cargo");
 			out << " that you do not have space for.";
 		}
 		out << "\nAre you sure you want to continue?";

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -398,7 +398,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		if(outfitsToSell > 0)
 		{
 			out << "\n- ";
-			out << (planet.HasOutfitter() ? "store " : ( planet.IsInhabited() && system.HasTrade() ? "sell " : "dump ")) << outfitsToSell << " outfit";
+			out << (planet.HasOutfitter() ? "store " : ( planet.IsInhabited() && planet.CanUseServices() && system.HasTrade() ? "sell " : "dump ")) << outfitsToSell << " outfit";
 			out << (outfitsToSell > 1 ? "s" : "");
 			out << " that none of your ships can hold.";
 			if(!uniquesToSell.empty())
@@ -426,7 +426,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		// Warn about commodities you will have to sell.
 		if(commoditiesToSell > 0)
 		{
-			out << "\n-  " << ( planet.IsInhabited() && system.HasTrade() ? "sell " : "dump ") << Format::CargoString(commoditiesToSell, "cargo");
+			out << "\n-  " << ( planet.IsInhabited() && planet.CanUseServices() && system.HasTrade() ? "sell " : "dump ") << Format::CargoString(commoditiesToSell, "cargo");
 			out << " that you do not have space for.";
 		}
 		out << "\nAre you sure you want to continue?";

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -397,8 +397,9 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		// Warn about outfits that can't be carried.
 		if(outfitsToSell > 0)
 		{
+			bool canSell = planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading);
 			out << "\n- ";
-			out << (planet.HasOutfitter() ? "store " : ( planet.IsInhabited() && planet.CanUseServices() && system.HasTrade() ? "sell " : "dump ")) << outfitsToSell << " outfit";
+			out << (planet.HasOutfitter() ? "store " : (  canSell ? "sell " : "dump ")) << outfitsToSell << " outfit";
 			out << (outfitsToSell > 1 ? "s" : "");
 			out << " that none of your ships can hold.";
 			if(!uniquesToSell.empty())
@@ -426,7 +427,8 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		// Warn about commodities you will have to sell.
 		if(commoditiesToSell > 0)
 		{
-			out << "\n-  " << ( planet.IsInhabited() && planet.CanUseServices() && system.HasTrade() ? "sell " : "dump ") << Format::CargoString(commoditiesToSell, "cargo");
+			bool canSell = planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading);
+			out << "\n- " << ( canSell ? "sell " : "dump ") << Format::CargoString(commoditiesToSell, "cargo");
 			out << " that you do not have space for.";
 		}
 		out << "\nAre you sure you want to continue?";

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -397,7 +397,9 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		// Warn about outfits that can't be carried.
 		if(outfitsToSell > 0)
 		{
-			bool canSell = planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading);
+			bool canSell = planet.CanUseServices() && system.HasTrade()
+				&& planet.GetPort().HasService(Port::ServicesType::Trading);
+
 			out << "\n- ";
 			out << (planet.HasOutfitter() ? "store " : (canSell ? "sell " : "dump ")) << outfitsToSell << " outfit";
 			out << (outfitsToSell > 1 ? "s" : "");
@@ -427,7 +429,9 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		// Warn about commodities you will have to sell.
 		if(commoditiesToSell > 0)
 		{
-			bool canSell = planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading);
+			bool canSell = planet.CanUseServices() && system.HasTrade()
+				&& planet.GetPort().HasService(Port::ServicesType::Trading);
+
 			out << "\n- " << (canSell ? "sell " : "dump ") << Format::CargoString(commoditiesToSell, "cargo");
 			out << " that you do not have space for.";
 		}

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -399,7 +399,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		{
 			bool canSell = planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading);
 			out << "\n- ";
-			out << (planet.HasOutfitter() ? "store " : (  canSell ? "sell " : "dump ")) << outfitsToSell << " outfit";
+			out << (planet.HasOutfitter() ? "store " : (canSell ? "sell " : "dump ")) << outfitsToSell << " outfit";
 			out << (outfitsToSell > 1 ? "s" : "");
 			out << " that none of your ships can hold.";
 			if(!uniquesToSell.empty())
@@ -428,7 +428,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		if(commoditiesToSell > 0)
 		{
 			bool canSell = planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading);
-			out << "\n- " << ( canSell ? "sell " : "dump ") << Format::CargoString(commoditiesToSell, "cargo");
+			out << "\n- " << (canSell ? "sell " : "dump ") << Format::CargoString(commoditiesToSell, "cargo");
 			out << " that you do not have space for.";
 		}
 		out << "\nAre you sure you want to continue?";

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1780,7 +1780,9 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 	int64_t totalBasis = 0;
 	if(leftOver)
 	{
-		bool canSell = planet->CanUseServices() && system->HasTrade() && planet->GetPort().HasService(Port::ServicesType::Trading);
+		bool canSell = planet->CanUseServices() && system->HasTrade()
+			&& planet->GetPort().HasService(Port::ServicesType::Trading);
+
 		if(canSell)
 		{
 			for(const auto &commodity : cargo.Commodities())

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1780,7 +1780,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 	int64_t totalBasis = 0;
 	if(leftOver)
 	{
-		bool canSell = planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading);
+		bool canSell = planet->CanUseServices() && system->HasTrade() && planet->GetPort().HasService(Port::ServicesType::Trading);
 		if(canSell)
 		{
 			for(const auto &commodity : cargo.Commodities())

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1780,7 +1780,8 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 	int64_t totalBasis = 0;
 	if(leftOver)
 	{
-		if(planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading))
+		bool canSell = planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading);
+		if(canSell)
 		{
 			for(const auto &commodity : cargo.Commodities())
 			{
@@ -1804,7 +1805,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 				totalBasis += basis;
 			}
 		}
-		if(!planet->HasOutfitter() && planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading))
+		if(!planet->HasOutfitter() && canSell)
 			for(const auto &outfit : cargo.Outfits())
 			{
 				// Compute the total value for each type of excess outfit.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1780,7 +1780,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 	int64_t totalBasis = 0;
 	if(left_over)
 	{
-		if(planet->IsInhabited() && system->HasTrade())
+		if(planet->IsInhabited() && planet->CanUseServices() && system->HasTrade())
 		{
 			for(const auto &commodity : cargo.Commodities())
 				{
@@ -1804,7 +1804,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 					totalBasis += basis;
 				}
 		}
-		if(!planet->HasOutfitter() && planet->IsInhabited())
+		if(!planet->HasOutfitter() && planet->IsInhabited() && planet->CanUseServices())
 			for(const auto &outfit : cargo.Outfits())
 			{
 				// Compute the total value for each type of excess outfit.
@@ -1815,7 +1815,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 					stockDepreciation.Buy(outfit.first, day, &depreciation);
 				income += cost;
 			}
-		else if(planet->HasOutfitter())
+		else if(planet->HasOutfitter() && planet->CanUseServices())
 			for(const auto &outfit : cargo.Outfits())
 			{
 				// Transfer the outfits from cargo to the storage on this planet.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1773,14 +1773,14 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 	for(const Mission *mission : missionsToRemove)
 		RemoveMission(Mission::ABORT, *mission, ui);
 
-	// Any ordinary cargo left behind can be either sold, stored or dumped.
+	// Any ordinary cargo/outfits left behind can be either sold, stored or dumped.
 	int64_t income = 0;
 	int day = date.DaysSinceEpoch();
 	int64_t left_over = cargo.Used();
 	int64_t totalBasis = 0;
 	if(left_over)
 	{
-		if(planet->IsInhabited() && planet->CanUseServices() && system->HasTrade())
+		if(planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading))
 		{
 			for(const auto &commodity : cargo.Commodities())
 				{
@@ -1804,7 +1804,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 					totalBasis += basis;
 				}
 		}
-		if(!planet->HasOutfitter() && planet->IsInhabited() && planet->CanUseServices())
+		if(!planet->HasOutfitter() && planet.CanUseServices() && system.HasTrade() && planet.GetPort().HasService(Port::ServicesType::Trading))
 			for(const auto &outfit : cargo.Outfits())
 			{
 				// Compute the total value for each type of excess outfit.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1807,7 +1807,19 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 				totalBasis += basis;
 			}
 		}
-		if(!planet->HasOutfitter() && canSell)
+
+		if(planet->HasOutfitter())
+		{
+			if(canUseServices)
+				for(const auto &outfit : cargo.Outfits())
+				{
+					// Transfer the outfits from cargo to the storage on this planet.
+					if(!outfit.second)
+						continue;
+					cargo.Transfer(outfit.first, outfit.second, Storage());
+				}
+		}
+		else if(canSell)
 			for(const auto &outfit : cargo.Outfits())
 			{
 				// Compute the total value for each type of excess outfit.
@@ -1817,14 +1829,6 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 				for(int i = 0; i < outfit.second; ++i)
 					stockDepreciation.Buy(outfit.first, day, &depreciation);
 				income += cost;
-			}
-		else if(planet->HasOutfitter() && planet->CanUseServices())
-			for(const auto &outfit : cargo.Outfits())
-			{
-				// Transfer the outfits from cargo to the storage on this planet.
-				if(!outfit.second)
-					continue;
-				cargo.Transfer(outfit.first, outfit.second, Storage());
 			}
 	}
 


### PR DESCRIPTION
Feature Details
This PR adds a check for the presence of a spaceport on the current planet when selling excess commodities on take-off.  In the case where no spaceport is present the commodities are not sold and simply disappear.  
Excess outfits are also dumped when no trade or outfitter is present, warnings have been added for dumping and storing outfits (overlaps with #7645).

UI Screenshots:

Testing Done
[test test.txt](https://github.com/endless-sky/endless-sky/files/11359226/test.test.txt)
In continuous upon take-off one should receive a message informing that 10 tons of cargo were sold, whereas with this patch applied the message would say that 10 tons of cargo were dumped.

[test test.txt](https://github.com/endless-sky/endless-sky/files/11371941/test.test.txt)
Similar configuration but with outfits.

Performance Impact
N/A.