### PR TITLE
fix(status-messages): Only report insufficient crew on player-owned ships

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1927,7 +1927,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	else if(requiredCrew && static_cast<int>(Random::Int(requiredCrew)) >= Crew())
 	{
 		pilotError = 30;
-		if(isYours)
+		if(isYours || (personality.IsEscort() && Preferences::Has("Extra fleet status messages")))
 		{
 			if(parent.lock())
 				Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it."

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1927,12 +1927,15 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 	else if(requiredCrew && static_cast<int>(Random::Int(requiredCrew)) >= Crew())
 	{
 		pilotError = 30;
-		if(parent.lock() || !isYours)
-			Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it."
-				, Messages::Importance::Low);
-		else
-			Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it."
-				, Messages::Importance::Low);
+		if(isYours)
+		{
+			if(parent.lock())
+				Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it."
+					, Messages::Importance::Low);
+			else
+				Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it."
+					, Messages::Importance::Low);
+		}
 	}
 	else
 		pilotOkay = 30;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8663

## Fix Details
fixes: 8663

## Testing Done
Tested with the savegame from 8663; didn't get the warning messages.
Also did some capturing (getting my crew below the required crew); and got the relevant warning messages.

## Save File
See #8663 for a savegame to verify that the messages no longer get generated.
