### PR TITLE
fix(bug): HR Bugfixes 5

### DIFF
--- a/data/hai/hai reveal 6 end.txt
+++ b/data/hai/hai reveal 6 end.txt
@@ -22,7 +22,7 @@ mission "Hai Reveal [C01] Cleanup"
 	passengers 4
 	blocked "You need <bunks> passenger spaces to transport Xilin, Alondo, Sayari and Teeneep."
 	to offer
-		has "Hai Reveal [B13] Freedom: done"
+		has "Hai Reveal [B14] Journey to Peace: done"
 	on offer
 		event "mountaintop ascendant"
 		fail "Hai Reveal [B12-A] Devil-Hide Fleet"


### PR DESCRIPTION
**Bugfix:** This PR addresses the bug reported here:
![image](https://user-images.githubusercontent.com/60949828/236629646-ec0914ba-fc20-4ef4-ab53-accc8710d148.png)

## Fix Details
Change mission `to offer` condition to be properly sequential.

## Testing Done
None

## Save File
n/a

## Background
There was a point in time where one particular mission needed to look at the mission before its previous one to trigger correctly.
[B14] was added in the rework and I think this got overlooked as possibly being that case, which I actually don't think exists anymore.