### PR TITLE
(Bugfix)(Coalition) Add missing "blocked" field to mission Saryd Students 2

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -959,6 +959,7 @@ mission "Saryd Students 2"
 	landing
 	deadline
 	cargo "arach rum" 2
+	blocked "You need <capacity> in order to take on the next mission. Return here when you have the required space free."
 	to offer
 		has "Saryd Students 1: done"
 	source "Weir of Glubatub"


### PR DESCRIPTION
-----------------------
**Bugfix:**

## Fix Details
This PR adds the `blocked` field to the Coalition mission "Saryd Students 2". Without it, one could complete the first mission, having enough money to buy the rum cargo, but not have the free cargo space needed for it, and the game would never inform the player why the sudden end to the mission chain.
This'd also break time as the story dealine mentioned in the first mission's text would be extended indefinetly, given the second `deadline` would only start up once one landed there again with the necessary cargo space.

Fix is just adding the `blocked` and its text.
Issue pointed out by simpson86 on the Discord server. Thanks for the help.