### PR TITLE
(Style Fix) Remove extra whitespace from the Met Par Tek 53

### DIFF
--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -1841,7 +1841,6 @@ ship "Met Par Tek 53"
 	turret 38 -28 "Thermal Repeater Turret"
 	turret -40 -8 "Thermal Repeater Turret"
 	turret 40 -8 "Thermal Repeater Turret"
-	
 	explode "tiny explosion" 60
 	explode "small explosion" 30
 	explode "medium explosion" 35

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -689,7 +689,6 @@ ship "Modified Osprey"
 	turret 49.5 20 "Heliarch Repulsor"
 	turret 0 29 "Point Defense Turret"
 	turret 0 89.5 "Point Defense Turret"
-	
 	explode "medium explosion" 24
 	explode "large explosion" 16
 	explode "small explosion" 40


### PR DESCRIPTION
## Fix Details
This is a small, simple style fix that removes an extra piece of whitespace from the Met Par Tek 53's definition. The whitespace is located between the hardpoints and explosions, and is being removed because - as far as I've seen - it is the only ship with this extra whitespace, thus rendering it inconsistent with the datafiles' general layout.

No performance impact or anything like that, this literally just removes one empty line. Shouldn't affect anything besides a tiny win for consistency.