### PR TITLE
bugfix: Fix incorrect string delimiting in DataWriter

### DIFF
--- a/source/DataWriter.cpp
+++ b/source/DataWriter.cpp
@@ -121,27 +121,7 @@ void DataWriter::WriteComment(const string &str)
 // Write a token, given as a character string.
 void DataWriter::WriteToken(const char *a)
 {
-	// Figure out what kind of quotation marks need to be used for this string.
-	bool needsQuoting = !*a || *a == '#';
-	bool hasQuote = false;
-	for(const char *it = a; *it; ++it)
-	{
-		needsQuoting |= (*it <= ' ' && *it >= 0);
-		hasQuote |= (*it == '"');
-	}
-
-	// Write the token, enclosed in quotes if necessary.
-	out << *before;
-	if(needsQuoting && hasQuote)
-		out << '`' << a << '`';
-	else if(needsQuoting)
-		out << '"' << a << '"';
-	else
-		out << a;
-
-	// The next token written will not be the first one on this line, so it only
-	// needs to have a single space before it.
-	before = &space;
+	WriteToken(string(a));
 }
 
 
@@ -149,5 +129,19 @@ void DataWriter::WriteToken(const char *a)
 // Write a token, given as a string object.
 void DataWriter::WriteToken(const string &a)
 {
-	WriteToken(a.c_str());
+	// Figure out what kind of quotation marks need to be used for this string.
+	bool hasSpace = any_of(a.begin(), a.end(), [](char c) { return isspace(c); });
+	bool hasQuote = any_of(a.begin(), a.end(), [](char c) { return (c == '"'); });
+	// Write the token, enclosed in quotes if necessary.
+	out << *before;
+	if(hasQuote)
+		out << '`' << a << '`';
+	else if(hasSpace)
+		out << '"' << a << '"';
+	else
+		out << a;
+
+	// The next token written will not be the first one on this line, so it only
+	// needs to have a single space before it.
+	before = &space;
 }


### PR DESCRIPTION
This was split off from #8725 to make merging this easier. The version in that PR was tested and working, so hopefully this bugfix also will.

**Bugfix**: This PR fixes an edge case where " quotes in text were not delimited correctly in DataWriter.

## Fix Details

## Bug reproduction:

Name a ship `"`. You can choose any other name that contains a `"` and no whitespace.
Load the file - the game will handle it just fine.
Save the file - it gets written as `"""`.
Load it again - the name is now parsed as an empty string.

## Testing Done

Loaded and wrote a save file with the above case.