### PR TITLE
Improve Remnant Rescue 4 location filter

### DIFF
--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -609,10 +609,9 @@ mission "Remnant: Rescue 4"
 	npc accompany save
 		system
 			attributes "graveyard"
-			not attributes "inaccessible"
 			not government "Remnant"
-			not system "Patir"
-			not system "Aki'il"
+			near "Nona" 100
+				"only unrestricted wormholes"
 		personality escort derelict heroic plunders
 		government "Remnant"
 		fleet

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -610,7 +610,7 @@ mission "Remnant: Rescue 4"
 		system
 			attributes "graveyard"
 			not government "Remnant"
-			near "Nona" 100
+			near "Nona" 20
 				"only unrestricted wormholes"
 		personality escort derelict heroic plunders
 		government "Remnant"


### PR DESCRIPTION
**Feature:**

## Feature Details
Uses new distance calculation options to have the location filter select any system within 100 "jumps" of the system Nona (chosen because it was the origin of the Builders, the most recent sentient inhabitants of this region of space), where a "jump" can be either a hyperlink or an unrestricted wormhole (like the one joining Ritilas and Fearis).
This will cover the same set of systems as before, but now exclusions for any new, nearby systems with similar attributes that are not connected via hyperspace links (like Aki'il or Patir) will not need to be added to this filter.

## Testing Done
Used `--matches` with the new filter and the old filter and see that the results are the same.
(Note: `Body::HasSprite()` will need to be modified to always return `true` when testing location filters traversing wormholes in this way.)
