### PR TITLE
fix(outfitter): Don't allow bypassing license requirements

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -346,7 +346,7 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 			"so there is no reason to buy another.";
 
 	// Check that the player has any necessary licenses.
-	int64_t licenseCost = LicenseCost(selectedOutfit);
+	int64_t licenseCost = LicenseCost(selectedOutfit, onlyOwned);
 	if(licenseCost < 0)
 		return "You cannot buy this outfit, because it requires a license that you don't have.";
 
@@ -487,7 +487,7 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 
 void OutfitterPanel::Buy(bool onlyOwned)
 {
-	int64_t licenseCost = LicenseCost(selectedOutfit);
+	int64_t licenseCost = LicenseCost(selectedOutfit, onlyOwned);
 	if(licenseCost)
 	{
 		player.Accounts().AddCredits(-licenseCost);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -924,13 +924,13 @@ bool ShopPanel::Scroll(double dx, double dy)
 
 
 
-int64_t ShopPanel::LicenseCost(const Outfit *outfit) const
+int64_t ShopPanel::LicenseCost(const Outfit *outfit, bool onlyOwned) const
 {
 	// If the player is attempting to install an outfit from cargo, storage, or that they just
 	// sold to the shop, then ignore its license requirement, if any. (Otherwise there
 	// would be no way to use or transfer license-restricted outfits between ships.)
-	if((player.Cargo().Get(outfit) && playerShip) || player.Stock(outfit) > 0 ||
-			(player.Storage() && player.Storage()->Get(outfit)))
+	bool owned = (player.Cargo().Get(outfit) && playerShip) || (player.Storage() && player.Storage()->Get(outfit));
+	if((owned && onlyOwned) || player.Stock(outfit) > 0)
 		return 0;
 
 	const Sale<Outfit> &available = player.GetPlanet()->Outfitter();

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -110,7 +110,7 @@ protected:
 	virtual bool Release(int x, int y) override;
 	virtual bool Scroll(double dx, double dy) override;
 
-	int64_t LicenseCost(const Outfit *outfit) const;
+	int64_t LicenseCost(const Outfit *outfit, bool onlyOwned = false) const;
 
 
 protected:


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8089

## Bug Details
Currently if the player has an outfit in planetary storage, the game omits any license requirements of the outfit, even when buying from the outfitter using [b] key.

## Testing Done
Yes. If the problem seems to persist, depart and land as you may have some outfits in stock.