### PR TITLE
bugfix: Disable style checking for vcpkg/cmake C++ files

### DIFF
--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -573,7 +573,7 @@ if __name__ == '__main__':
 		for pattern in sys.argv[1:]:
 			files += glob.glob(pattern, recursive=True)
 	else:
-		files = glob.glob('source/*.cpp', recursive=True) + glob.glob('source/*.h', recursive=True) + glob.glob('tests/*.cpp', recursive=True) + glob.glob('tests/*.h', recursive=True)
+		files = glob.glob('source/**/*.cpp', recursive=True) + glob.glob('source/**/*.h', recursive=True) + glob.glob('tests/**/*.cpp', recursive=True) + glob.glob('tests/**/*.h', recursive=True)
 	files.sort()
 
 	for file in files:

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# check_coding_style.py
+# check_code_style.py
 # Copyright (c) 2022 by tibetiroka
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
@@ -573,7 +573,7 @@ if __name__ == '__main__':
 		for pattern in sys.argv[1:]:
 			files += glob.glob(pattern, recursive=True)
 	else:
-		files = glob.glob('**/*.cpp', recursive=True) + glob.glob('**/*.h', recursive=True)
+		files = glob.glob('source/*.cpp', recursive=True) + glob.glob('source/*.h', recursive=True) + glob.glob('tests/*.cpp', recursive=True) + glob.glob('tests/*.h', recursive=True)
 	files.sort()
 
 	for file in files:


### PR DESCRIPTION
Fixes an issue with the code style checker trying to check the vcpkg files (reported by @thewierdnut). Also fixes the copyright header (reported by @warp-core).

This is not an issue in the main repo, as the CI action doesn't have the vcpkg files.