### PR TITLE
Add new ship category conditions to missions

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -3397,7 +3397,7 @@ mission "Pirate Duel"
 		not "ships: Space Liner"
 		not "ships: Utility"
 		not "ships: Superheavy"
-		"ships: Light Warship" + "ships: Light Freighter" + "ships: Transport" + "ships: Interceptor" == 1
+		"ships: Light Warship" + "ships: Light Freighter" + "ships: Transport" + "ships: Interceptor" + "ships: Fighter" + "ships: Drone" == 1
 	
 	on offer
 		conversation

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -3394,6 +3394,9 @@ mission "Pirate Duel"
 		not "ships: Medium Warship"
 		not "ships: Heavy Warship"
 		not "ships: Heavy Freighter"
+		not "ships: Space Liner"
+		not "ships: Utility"
+		not "ships: Superheavy"
 		"ships: Light Warship" + "ships: Light Freighter" + "ships: Transport" + "ships: Interceptor" == 1
 	
 	on offer

--- a/data/human/intro missions.txt
+++ b/data/human/intro missions.txt
@@ -98,7 +98,9 @@ mission "Intro [1 Transport]"
 	passengers 5
 	to offer
 		has "Intro [0]: done"
-		has "ships: Transport"
+		or
+			has "ships: Transport"
+			has "ships: Space Liner"
 		not "Intro [1 Freighter]: offered"
 		not "Intro [1 Interceptor]: offered"
 	
@@ -199,6 +201,7 @@ mission "Intro [1 Freighter]"
 		or
 			has "ships: Light Freighter"
 			has "ships: Heavy Freighter"
+			has "ships: Utility"
 		not "Intro [1 Transport]: offered"
 		not "Intro [1 Interceptor]: offered"
 	
@@ -333,6 +336,7 @@ mission "Intro [1 Interceptor]"
 			has "ships: Light Warship"
 			has "ships: Medium Warship"
 			has "ships: Heavy Warship"
+			has "ships: Superheavy"
 		not "Intro [1 Transport]: offered"
 		not "Intro [1 Freighter]: offered"
 	npc save


### PR DESCRIPTION
**Feature:**

## Feature Details
Updates the Pirate Duel and Intro mission offer conditions to account for the new ship categories (Space Liner, Utility, and Superheavy.)

The Transport intro missions can now also be triggered by Space Liners, the Freighter ones by Utility ships, and the Interceptor ones by Superheavy ships, since the latter two previously also accounted for larger freighters and warships (and fighters and drones), respectively (there was no corresponding category for Transport so that mission only checked one category before.)

Excluded Space Liner, Utility, and Superheavy ships from the Pirate Duel mission and also added Fighter and Drone to the list of categories from which the player may only have a single ship.
