### PR TITLE
Bugfix(data): fix unlimited money/tripulses exploit

### DIFF
--- a/data/hai/unfettered jobs.txt
+++ b/data/hai/unfettered jobs.txt
@@ -99,7 +99,7 @@ mission "Unfettered Jump Drive 4"
 	job
 	repeat
 	name "Sell Jump Drive"
-	description "Exchange a jump drive for money or weapons, if an outfitter is available."
+	description "Exchange a jump drive on your flagship or in cargo for money, or for weapons, if an outfitter is available."
 	source
 		attributes "unfettered"
 	to offer
@@ -107,6 +107,10 @@ mission "Unfettered Jump Drive 4"
 		not "event: wanderers: unfettered invasion starts"
 	to fail
 		has "Unfettered Jump Drive 4: active"
+	to accept
+		or
+			has "outfit (flagship installed): Jump Drive"
+			has "outfit (cargo): Jump Drive"
 	on accept
 		conversation
 			branch "want outfits"


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8771

## Fix Details
Make sure the player has the drive available to be taken for the mission to be accepted.
~~This is probably showing an underlying issue with the conversation not being parsed properly in the on accept? I'm not sure what's going on but this should quick fix it, whilst adding a functionality to it at the same time (it'll still be shown when you have the drive on an escort and says what you must do to enable the mission)~~ thx warp for pointing out this is the intended behavior

## Testing Done
I tested with a JD installed on flagship or in cargo and I could use the mission
I also tested with a JD sold, no JD, a JD on another ship, a JD in storage, and it was greyed out in those instances.

## Save File
n/a