### PR TITLE
Add Mammoth to Advanced Nothern Pirates Sales

### DIFF
--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -108,6 +108,7 @@ shipyard "Advanced Northern Pirates"
 	"Aerie"
 	"Leviathan"
 	"Mule"
+	"Mammoth"
 
 shipyard "Southern Pirates"
 	"Argosy"


### PR DESCRIPTION
## Summary
{{summarize your content! Include links to related issues, in-game screenshots, etc.}}

the mammoth is a unique moded pirate behemoth that comes up it one signle free world mission. it is not obtainable in any other way.

this pull reqeust adds the mammoth to the sale list of advanced human pirates, since its close to the Betelgeuse Shipyard and it would make sense that these pirates might have captured one and modded them.

i think its a waste of content to have this cool unique ship be so underused.
Note that this ship is not part of a mod, its vanilla content

![image](https://github.com/endless-sky/endless-sky/assets/25199983/5887291c-713e-4bc9-b7c2-fb455506b71c)
