### PR TITLE
Adjust M- and K- class supergiants' solar wind values to fit the trend in similar stars

### DIFF
--- a/data/stars.txt
+++ b/data/stars.txt
@@ -160,10 +160,10 @@ star "star/g-supergiant"
 	wind 2.9
 star "star/k-supergiant"
 	power 1.8
-	wind 2
+	wind 3
 star "star/m-supergiant"
 	power 1.6
-	wind 2
+	wind 3.1
 
 # Special stars.
 star "star/carbon"


### PR DESCRIPTION
Two different ways of looking at this one:
If you look at the trend within the supergiants, the trend is increasing solar wind and decreasing solar power as you go to redder spectral classes, except that the K supergiant's solar wind weirdly goes down instead of up, and the M supergiant has the same.
If you look at the trend from giants to supergiants, you can see that each supergiant has a solar wind 1.0 higher than the corresponding giant, except for the K supergiant which has the same as the K giant, and the M supergiant which has .1 less than the M giant.

This PR adjusts the solar wind values of the M and K supergiants to fit both of these trends.