### PR TITLE
Feat(UI): add the local threat from raids to the player info panel

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -652,8 +652,8 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		table.DrawGap(5);
 
 		if(localProb)
-			table.DrawTruncatedPair("local threat: " + attractionRating, dim,
-			"(+" + Format::Decimal(localProb, 1) + ")", dim, Truncate::MIDDLE, false);
+			table.DrawTruncatedPair("local threat: ", dim,
+			lround(100 * localProb) + "%", dim, Truncate::MIDDLE, false);
 		// Format the attraction and deterrence levels with tens places, so it
 		// is clear which is higher even if they round to the same level.
 		table.DrawTruncatedPair("cargo: " + attractionRating, dim,

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -643,7 +643,7 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		for(auto fleet : player.GetSystem()->GetGovernment()->RaidFleets())
 			notHappening -= pow(1. - player.RaidFleetAttraction(fleet, player.GetSystem()), 10.);
 		if(notHappening != 1.)
-			localProb = 1. - min(0., notHappening);
+			localProb = 1. - max(0., notHappening);
 
 		table.DrawGap(10);
 		table.DrawUnderline(dim);

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -653,7 +653,7 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 
 		if(localProb)
 			table.DrawTruncatedPair("local threat: ", dim,
-			lround(100 * localProb) + "%", dim, Truncate::MIDDLE, false);
+			to_string(lround(100 * localProb)) + "%", dim, Truncate::MIDDLE, false);
 		// Format the attraction and deterrence levels with tens places, so it
 		// is clear which is higher even if they round to the same level.
 		table.DrawTruncatedPair("cargo: " + attractionRating, dim,

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -638,6 +638,12 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 	{
 		double attraction = max(0., min(1., .005 * (factors.first - factors.second - 2.)));
 		double prob = 1. - pow(1. - attraction, 10.);
+		double localProb = 0.;
+		double notHappening = 1.;
+		for(auto fleet : fleets)
+			notHappening -= pow(1. - player.RaidFleetAttraction(fleet, player.GetSystem()), 10.);
+		if(notHappening != 1.)
+			localProb = 1. - min(0., notHappening);
 
 		table.DrawGap(10);
 		table.DrawUnderline(dim);
@@ -645,6 +651,9 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		table.Draw(to_string(lround(100 * prob)) + "%", dim);
 		table.DrawGap(5);
 
+		if(localProb)
+			table.DrawTruncatedPair("local threat: " + attractionRating, dim,
+			"(+" + Format::Decimal(localProb, 1) + ")", dim, Truncate::MIDDLE, false);
 		// Format the attraction and deterrence levels with tens places, so it
 		// is clear which is higher even if they round to the same level.
 		table.DrawTruncatedPair("cargo: " + attractionRating, dim,

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -640,7 +640,7 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		double prob = 1. - pow(1. - attraction, 10.);
 		double localProb = 0.;
 		double notHappening = 1.;
-		for(auto fleet : fleets)
+		for(auto fleet : player.GetSystem()->GetGovernment()->RaidFleets())
 			notHappening -= pow(1. - player.RaidFleetAttraction(fleet, player.GetSystem()), 10.);
 		if(notHappening != 1.)
 			localProb = 1. - min(0., notHappening);


### PR DESCRIPTION
**Feature:** This PR displays the local threat from pirates in the player info panel

## Feature Details
A line was added below the piracy threat % displaying the local threat, which depends on all raid fleets and the local ships present.
This is needed before using the more flexible raids, I think.
Note: I'm not UX designed, of course, but I did what I could, and I think that anything is better than a hidden feature.

## UI Screenshots
![screen](https://github.com/endless-sky/endless-sky/assets/94366726/1a6283fe-be9c-43df-a17d-4480038395af)
Thx to @EjoThims for providing this

## Usage Examples
now that players will be able to see it we will have a better idea of what's going on, and make changes to the raids really possible as it wont be weirdly hidden from the player

## Testing Done
not yet

### Automated Tests Added
n/a

## Performance Impact
n/a
