### PR TITLE
Add a blocked message to Wanderers Invaded 3

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1775,6 +1775,7 @@ mission "Wanderers Invaded 3"
 	source "Varu Mer'ek"
 	destination "Var' Kar'i'i"
 	passengers 1
+	blocked "You receive a message from Isai indicating that she would like to join you for the next mission, but you don't have space right now. Return when you have a bunk free."
 	to offer
 		has "Wanderers Invaded 2: done"
 	on offer

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1809,7 +1809,7 @@ mission "Wanderers Invaded 3"
 		ship "Deep River Transport" "Eka'ta Turuk'ta"
 	on visit
 		dialog
-			`You have reached <planet>, but the Wanderer transports have not all arrived yet. You should take off and wait for them to catch up with you.`
+			`You have reached <planet>, but the Wanderer transports, or your ship carrying Isai, have not all arrived yet. You should take off and wait for them to catch up with you.`
 
 
 


### PR DESCRIPTION
**Bugfix:**

Thanks to ESC#3505 for reporting this on Discord.

## Fix Details
The preceding mission requires no passenger space, but this one does. If the player gets here without any passenger space, there is not currently any indicator of why the next mission isn't offered.
This PR adds a blocked message telling the player why they aren't getting the next mission, and also updates the on visit message to account for the possibility that a player escort is carrying the passenger and has not yet arrived.

## Testing Done
0

