### PR TITLE
Don't write conditions with a value of 0

### DIFF
--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -185,8 +185,11 @@ void ConditionsStore::Save(DataWriter &out) const
 		// We don't need to save derived conditions that have a provider.
 		if(it->second.provider)
 			continue;
+		// If the condition's value is 0, don't write it at all.
+		if(!it->second.value)
+			continue;
 		// If the condition's value is 1, don't bother writing the 1.
-		else if(it->second.value == 1)
+		if(it->second.value == 1)
 			out.Write(it->first);
 		else
 			out.Write(it->first, it->second.value);


### PR DESCRIPTION
**Bugfix:**

## Fix Details
The check that skipped 0 valued conditions in `ConditionsStore::Save` was removed a little bit ago.
This adds it back in so conditions with a value of 0 are not saved because a value of 0 is no different from the conditions just not being present at all.

## Testing Done
0

