### PR TITLE
Update version numbers for 0.10.2 alpha

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT EndlessSky)
 set(CMAKE_VS_JUST_MY_CODE_DEBUGGING ON)
 
-project("Endless Sky" VERSION 0.10.1
+project("Endless Sky" VERSION 0.10.2
 	DESCRIPTION "Space exploration, trading, and combat game."
 	HOMEPAGE_URL https://endless-sky.github.io/
 	LANGUAGES CXX)

--- a/credits.txt
+++ b/credits.txt
@@ -1,5 +1,5 @@
 Welcome to Endless Sky!
-version 0.10.1
+version 0.10.2-alpha
 
 The player's manual and other
 resources are available at:

--- a/endless-sky.6
+++ b/endless-sky.6
@@ -1,4 +1,4 @@
-.TH endless\-sky 6 "29 May 2023" "ver. 0.10.1" "Endless Sky"
+.TH endless\-sky 6 "29 May 2023" "ver. 0.10.2-alpha" "Endless Sky"
 
 .SH NAME
 endless\-sky \- a space exploration and combat game.

--- a/resources/EndlessSky-Info.plist
+++ b/resources/EndlessSky-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.1</string>
+	<string>0.10.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -459,7 +459,7 @@ void PrintHelp()
 void PrintVersion()
 {
 	cerr << endl;
-	cerr << "Endless Sky ver. 0.10.1" << endl;
+	cerr << "Endless Sky ver. 0.10.2-alpha" << endl;
 	cerr << "License GPLv3+: GNU GPL version 3 or later: <https://gnu.org/licenses/gpl.html>" << endl;
 	cerr << "This is free software: you are free to change and redistribute it." << endl;
 	cerr << "There is NO WARRANTY, to the extent permitted by law." << endl;


### PR DESCRIPTION
**Documentation:**

## Details
Updates version numbers in main.cpp, credits.txt, and endless-sky.6 to `0.10.2-alpha` and in CMakeLists.txt and EndlessSky-Info.plist to `0.10.2` (because I don't think these places support the `-alpha` suffix.)

