### PR TITLE
corrected ship heat capacity in ShipInfoDisplay.cpp

### DIFF
--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -337,7 +337,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 		max(attributes.Get("thrusting energy"), attributes.Get("reverse thrusting energy"))
 		+ attributes.Get("turning energy")
 		+ attributes.Get("afterburner energy");
-	const double movingHeatPerFrame = max(attributes.Get("thrusting heat"), attributes.Get("reverse thrusting heat"))
+	const double movingHeatPerFrame = 
+		max(attributes.Get("thrusting heat"), attributes.Get("reverse thrusting heat"))
 		+ attributes.Get("turning heat")
 		+ attributes.Get("afterburner heat");
 	tableLabels.push_back("moving:");
@@ -373,7 +374,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 
 	attributesHeight += 20;
 	const double maxEnergy = attributes.Get("energy capacity");
-	const double maxHeat = 60. * ship.HeatDissipation() * ship.MaximumHeat();
+	const double maxHeat = (60. * ship.HeatDissipation() + 1. ) * ship.MaximumHeat();
 	tableLabels.push_back("max:");
 	energyTable.push_back(Format::Number(maxEnergy));
 	heatTable.push_back(Format::Number(maxHeat));


### PR DESCRIPTION
**Bugfix:** 

## Fix Details
1 line UI ship attributes display fix
1 line reformat 
--------------------------------------
Previous line 

maxHeat = 60. * ship.HeatDissipation() * ship.MaximumHeat();

calculates only the max. heat dissipation in 1s.

But the max ship heat capacity is 
heat capacity + max heat dissipation:

maxHeat = 60. * ship.HeatDissipation() * ship.MaximumHeat() + ship.MaximumHeat();

## Testing Done
displays different values...

## Save File
--
