### PR TITLE
Make the FW Pug 2C missions more robust

### DIFF
--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -1241,6 +1241,7 @@ mission "FW Pug 2C: Hyperdrive"
 	to offer
 		has "FW Pug 2B: done"
 		not "fw given jump drive"
+		not "outfit (flagship installed): Jump Drive"
 	passengers 1
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
@@ -1271,6 +1272,7 @@ mission "FW Pug 2C: Scram Drive"
 	to offer
 		has "FW Pug 2B: done"
 		not "fw given jump drive"
+		not "outfit (flagship installed): Jump Drive"
 	passengers 1
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
@@ -1291,7 +1293,7 @@ mission "FW Pug 2C: Scram Drive"
 
 
 
-mission "FW Pug 2C: A Jump Drive"
+mission "FW Pug 2C: Jump Drive"
 	landing
 	name "Investigate the Pug"
 	description "Travel to the Deneb system to investigate the Pug; if possible, make contact with them and determine what their goals and desires are."
@@ -1301,18 +1303,17 @@ mission "FW Pug 2C: A Jump Drive"
 	to offer
 		has "FW Pug 2B: done"
 		not "fw given jump drive"
+		has "outfit (flagship installed): Jump Drive"
 	passengers 1
 	on fail
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
-		outfit "Jump Drive" -1
 		conversation
 			`You are directed to land in a hangar some distance away from the spaceport, in a cluster of buildings owned by Syndicated Systems. A team of engineers meets you and asks if they can look over your ship; a few minutes later, one of them says in surprise, "You've already got a jump drive! How did you manage that?" Since you don't need their equipment, they urge you to head directly for Pug space and continue your mission.`
 				accept
 	
 	on accept
-		outfit "Jump Drive" 1
 		set "fw given jump drive"
 		set "already had jump drive"
 	on visit


### PR DESCRIPTION
**Refactor:**

## Details
These three missions previously relied on their `on offer` mission actions blocking the mission if the player did not have the relevant drive to take, and relied on the jump drive option being offered first based on its name.
With some the new autoconditions we have, this is no longer necessary.
It is now possible to ensure that the hyperdrive and scram drive missions are not offered if the player's ship has a jump drive, and so that mission no longer needs to rely on its name.
We can also use the same autocondition to ensure that the jump drive version is only offered if the player has a jump drive installed so there is no longer any need for it to remove and replace a jump drive to block itself if there is no jump drive present.

## Save File
[warp 0.10.1-alpha 2.txt](https://github.com/endless-sky/endless-sky/files/11625577/warp.0.10.1-alpha.2.txt)

