### PR TITLE
Do not allow `Pact Recon 0` on Glaze

### DIFF
--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -19,7 +19,7 @@ mission "Pact Recon 0"
 		attributes "rim" "south"
 		not government "Pirate"
 		not system "Alniyat" "Atria" "Lesath" "Han"
-		not planet Glaze
+		not planet "Glaze"
 	destination "Glaze"
 	waypoint "Alniyat"
 	waypoint "Atria"

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -19,6 +19,7 @@ mission "Pact Recon 0"
 		attributes "rim" "south"
 		not government "Pirate"
 		not system "Alniyat" "Atria" "Lesath" "Han"
+		not planet Glaze
 	destination "Glaze"
 	waypoint "Alniyat"
 	waypoint "Atria"


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8813 

## Fix Details
In `Pact Recon 0`, Captain Last stumbles upon a recon officer that just happened to be away from Glaze at the moment. She asks you to fly through four systems, and then head to Glaze to meet her upon her return there. The story makes no sense if she is already on Glaze.

## Testing Done
Made the mission `priority` with 100% chance of offer. Checked that it never offered on Glaze, but did offer in other places

## Save File
This save file can be used to verify the bugfix. The bug will occur when using v10.0.1, and will not occur when using this branch's build.

[Zoltan Remnant~3014-01-15 pact recon 0.txt](https://github.com/endless-sky/endless-sky/files/11646333/Zoltan.Remnant.3014-01-15.pact.recon.0.txt)
