### PR TITLE
Separate button for "Sell Outfits"

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1041,17 +1041,18 @@ interface "trade"
 	
 	sprite "ui/wide button"
 		center 130 355
+
+	sprite "ui/wide button"
+		center -50 355
 	
 	active if "can sell"
-	visible if "!can sell outfits"
 	button S "Sell All"
 		center 130 355
 		dimensions 90 30
 	
 	active if "can sell outfits"
-	visible if "can sell outfits"
-	button S "Sell Outfits"
-		center 130 355
+	button X "Sell Outfits"
+		center -50 355
 		dimensions 90 30
 
 


### PR DESCRIPTION
**Feature:** This PR implements an alternative to the features suggested in #8538 and #7055

## Feature Details
The "Sell Outfits" button and "Sell All" button are separate buttons with separate keystrokes. Key `s` with `shift`, `ctrl`, `alt`, etc., only sells commodities and mineables. The keystroke for selling outfits is `shift-x`.

## UI Screenshots
![sell-outfits-button](https://github.com/endless-sky/endless-sky/assets/116329264/3c6bf0e3-b203-4f39-8668-76eb602f5c83)

## Usage Examples
Don't sell your outfits by accident.

## Testing Done
Put outfits and commodities in my cargo bay and wandered from planet to planet seeing if things work as intended.

### Automated Tests Added
Can't think of any.

## Performance Impact
N/A
