### PR TITLE
Make the missions that trigger the Kestrel available events fail instead of persisting

### DIFF
--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -161,8 +161,7 @@ mission "Kestrel: More Weapons"
 		has "kestrel: more weapons"
 	on offer
 		event "kestrel available: more weapons" 50
-	to complete
-		has "kestrel available"
+		fail
 
 
 
@@ -173,8 +172,7 @@ mission "Kestrel: More Engines"
 		has "kestrel: more engines"
 	on offer
 		event "kestrel available: more engines" 50
-	to complete
-		has "kestrel available"
+		fail
 
 
 
@@ -185,8 +183,7 @@ mission "Kestrel: More Shields"
 		has "kestrel: more shields"
 	on offer
 		event "kestrel available: more shields" 50
-	to complete
-		has "kestrel available"
+		fail
 
 
 


### PR DESCRIPTION
**Refactor:**

## Details
Currently, these missions trigger a delayed event and require a condition set by that event to complete, but they don't do anything else, and there is no need to complete them. The location that the player will have to land on to complete them will also be wherever they first landed after doing the initial Kestrel mission, which could be anywhere.

This PR removes the `to complete` condition set from these missions and instead makes the `on offer` action fail the mission, so it'll set the event to happen on a timer and then be discarded.

No other changes should be necessary; the autoconditions from these missions are never referred to.

## Testing Done
0

