### PR TITLE
Location filters can be limited to the nearest X systems

### DIFF
--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -649,7 +649,7 @@ bool LocationFilter::Matches(const System *system, const System *origin, bool di
 	// Check this system's distance from the desired reference system.
 	if(center && Distance(center, system, centerCount, centerMaxDistance, centerDistanceOptions) < centerMinDistance)
 		return false;
-	if(origin && ( originMaxDistance >= 0 || originCount > 0 )
+	if(origin && (originMaxDistance >= 0 || originCount > 0)
 			&& Distance(origin, system, originCount, originMaxDistance, originDistanceOptions) < originMinDistance)
 		return false;
 

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -71,7 +71,8 @@ namespace {
 	}
 
 	// Check if the given system is within the given distance of the center.
-	int Distance(const System *center, const System *system, int count, int maximum, DistanceCalculationSettings distanceSettings)
+	int Distance(const System *center, const System *system, int count, int maximum,
+			DistanceCalculationSettings distanceSettings)
 	{
 		// This function should only ever be called from the main thread, but
 		// just to be sure, use mutex protection on the static locals.

--- a/source/LocationFilter.h
+++ b/source/LocationFilter.h
@@ -90,10 +90,12 @@ private:
 	std::set<const Government *> governments;
 	// The reference point and distance limits of a "near <system>" filter.
 	const System *center = nullptr;
+	int centerCount = -1;
 	int centerMinDistance = 0;
 	int centerMaxDistance = 1;
 	DistanceCalculationSettings centerDistanceOptions;
 	// Distance limits used in a "distance" filter.
+	int originCount = -1;
 	int originMinDistance = 0;
 	int originMaxDistance = -1;
 	DistanceCalculationSettings originDistanceOptions;


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #8397

## Feature Details
```ruby

mission "My Mission"
   destination
      # Gather a list of the nearest <count> systems and the source system,
      # and then restrict the list to systems between <min> and <max> distance.
      distance <min> <max> <count>
      # Likewise, but search around <system> instead of source.
      near <system> <min> <max> <count>
```

## Usage Examples
This was proposed for bounty missions. Kill a pirate in one of the nearest 10 systems (`distance 1 100 10`). The difficulty of the job does not depend on system density.

## Testing Done
1. Put this file in data/[nearestthree.txt](https://github.com/endless-sky/endless-sky/files/11647336/nearestthree.txt)
2. Depart.
3. Land on Crossroads.
4. Visit job board.
5. You should see nine jobs looking for waypoints, restricted to the nearest 3 systems.
6. Also, nine jobs looking for stopovers, restricted to the nearest 3 systems.

### Automated Tests Added
Can't think of a way to test this.

## Performance Impact
Performance improvement if this is used in many filters, especially when generating jobs. It will reduce the number of planets searched.