### PR TITLE
Fix movement bug in DoScatter that causes some ships to "lock together"

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2949,9 +2949,10 @@ bool AI::DoCloak(Ship &ship, Command &command)
 
 void AI::DoScatter(Ship &ship, Command &command)
 {
-	if(!command.Has(Command::FORWARD))
+	if(!command.Has(Command::FORWARD) && !command.Has(Command::BACK))
 		return;
 
+	double flip = command.Has(Command::BACK) ? -1 : 1;
 	double turnRate = ship.TurnRate();
 	double acceleration = ship.Acceleration();
 	// TODO: If there are many ships, use CollisionSet::Circle or another
@@ -2972,8 +2973,9 @@ void AI::DoScatter(Ship &ship, Command &command)
 		if(fabs(other->Acceleration() / acceleration - 1.) > .05)
 			continue;
 
-		// Move away from this ship. What side of me is it on?
-		command.SetTurn(offset.Cross(ship.Facing().Unit()) > 0. ? 1. : -1.);
+		// We are too close to this ship. Turn away from it if we aren't already facing away.
+		if(fabs(other->Facing().Unit().Dot(ship.Facing().Unit())) > 0.99) // 0.99 => 8 degrees
+			command.SetTurn(flip * offset.Cross(ship.Facing().Unit()) > 0. ? 1. : -1.);
 		return;
 	}
 }


### PR DESCRIPTION
**Bugfix:** DoScatter sometimes causes ships to "lock together" in X patterns.

## Fix Details
The source of the problem is more clear when you add reverse and steering engine flares to the Moneymaker ships . The ships are thrashing between trying to turn away from each other and trying to turn towards their destination. In this case, they want to fly right, but they can't face that way.

https://github.com/endless-sky/endless-sky/assets/116329264/28005b73-927e-4ca9-a403-97ecbf54a13f

There are two behaviors that are fighting against each other.

1. If a ship has reverse thrusters, it will come to a full stop and then point in the direction it wants to go.
2. If two ships are closer than 20 pixels (unscaled), they'll turn away from one another.

The bigger bug is in the second step. The ships will keep turning farther and farther away because they don't check if they're already facing away from one another. If I fix that, then the problem goes away. As an added measure, the DoScatter will also work properly when reverse thrusters are on.

## Testing Done
Flew some ships around, making sure they work as expected, not locking together. Also, checked that ships scatter.

## Save File
Depart the planet with your fleet of oddly-outfitted Container Transports. If you can get them to bunch up closely together, and then tell them to fly to the same place, sometimes they'll lock up. It may take a few tries.

[Friction Diction~3024-04-06 change containers.txt](https://github.com/endless-sky/endless-sky/files/11659505/Friction.Diction.3024-04-06.change.containers.txt)