### PR TITLE
Fix AI bugs that cause ships to fly outward forever.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1755,6 +1755,9 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		unsigned i = Random::Int(origin->Objects().size());
 		ship.SetTargetStellar(&origin->Objects()[i]);
 	}
+	else if(shouldStay)
+		// Nowhere to go, and nothing to do, so stay near the system center.
+		MoveTo(ship, command, Point(), Point(), 40, 0.8);
 }
 
 

--- a/source/AI.h
+++ b/source/AI.h
@@ -84,7 +84,7 @@ private:
 	bool CanPursue(const Ship &ship, const Ship &target) const;
 	// Disabled or stranded ships coordinate with other ships to get assistance.
 	void AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship);
-	static bool CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel);
+	bool CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel) const;
 	bool HasHelper(const Ship &ship, const bool needsFuel);
 	// Pick a new target for the given ship.
 	std::shared_ptr<Ship> FindTarget(const Ship &ship) const;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8781 

## Fix Details
There are several situations where the AI can't decide what to do and just lets ships fly outward forever. I discovered these details using numerous print statements to trace AI decisions.

These are the causes:

1. *Bug*: An escort with the `derelict` trait is in the same system as the player's flagship, and has run out of fuel. (Caused by an incorrect `continue` statement.)
2. *Bug*: A ship that is not an escort, and has nothing to do, in a system with no StellarObjects, will fly outward forever.
3. *Bug*: A ship will not de-target a friendly target that has left the system.
4. *Bug*: Ships with friendly targets, that they want to de-target, don't actually de-target. They clear a local `target` pointer, but not the ship's actual target (Ship::SetTargetShip())
5. *Bug*: Ships that are being assisted can choose to assist someone.
6. *Bug*: Ships with certain special behaviors (like surveillance or mining) will stop doing that if they are stranded (ie. out of fuel). If there is nobody they can ask for assistance, they'll be locked in that state.
7. *Not a bug*: nobody can help a derelict except the player's flagship, even after the derelict is no longer disabled.

Items 4-7 cannot directly cause this misbehavior, but they interact with each other to cause the misbehavior. Items 1-3 do directly cause the misbehavior.

I have fixed items 1-6 in this PR. Derelicts still won't ask for help; that is a critical aspect of derelict rescue missions.

## Testing Done

Two tests.

### Albatrosses Flying Forever (#8781)

1. Use this save from #8781: [Notmy Realname~3025-2-14.txt](https://github.com/endless-sky/endless-sky/files/11667288/Notmy.Realname.3025-2-14.txt)
3. Jump to Peragenor
5.  The Ibis and the other three ships should just come out of hyperspace and then move towards your ship.
8. The two Albatrosses will fly directly towards the lower left corner of your screen.
9. If you wait long enough, the Albatrosses will refuel from ramscooping.

### Perfica Fleets

The remnant fleets will display the misbehavior in various situations. Perfica is a great place to see it.

1. Use this save: [Friction Diction~3024-04-26 perfica test.txt](https://github.com/endless-sky/endless-sky/files/11667346/Friction.Diction.3024-04-26.perfica.test.txt)
2. Fly to Perfica
3. Watch what happens.

## Save File
See the previous two sections for saves and instructions. With the top of master (presently `fcafb869e`), you will see the misbehavior. With this branch, you won't.