### PR TITLE
Increase the power of star/wr, to reflect its very large habitable distance

### DIFF
--- a/data/stars.txt
+++ b/data/stars.txt
@@ -179,7 +179,7 @@ star "star/nova-small"
 	power 0.2
 	wind 4
 star "star/wr"
-	power 0.4
+	power 5
 	wind 4
 star "star/protostar-orange"
 	power 0.5


### PR DESCRIPTION
## Summary
`power` for `star/wr` increased from 0.4 to 5

## Reasoning
In reality, Wolf-Rayet stars are incredibly massive bright stars, shining so brightly that their outer layers of hydrogen are blown away. In the game, they already have a habitable range of 50000, which reflects this. The oddly low `power` value of 0.4 seems very out of place with that habitable range, so I have changed it to 5. This change also makes the WR star more distinct from the carbon star, protostars and the various nova remnants, all of which have high `wind` and low `power`.
The value of 5 was chosen because it is brighter than the 4.2 of the o0 star, but still not quite as bright as the O supergiant, which is currently the brightest (by `power`) star in the game. It could be made higher, since the habitable range around the O supergiant in Genta Bo is only 37100, which would imply that the WR star (with its habitable range of 50000, as seen in Gorvi and Sospi) should have _more_ than the 5.2 power of the O supergiant, so perhaps could be as high as 6?

## Save File
(none)