### PR TITLE
Elementary C++ error can cause a crash in NPC MissionAction Conversations

### DIFF
--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Panel.h"
 
+#include "Conversation.h"
 #include "text/WrappedText.h"
 
 #include <functional>
@@ -112,7 +113,7 @@ private:
 	bool useTransactions = false;
 
 	// The conversation we are displaying.
-	const Conversation &conversation;
+	Conversation conversation;
 	// All conversations start with node 0.
 	int node = 0;
 	// This function should be called with the conversation outcome.


### PR DESCRIPTION
**Bugfix:** This fixes a memory corruption error that crash *any build* on *any platform*. Fixes #8870 

## Fix Details
When an NPC MissionAction has a Conversation, the Conversation is destructed before the ConversationPanel can use it. This happened because of an elementary C++ coding mistake:

```C++
class ConversationPanel: public Panel {
...
    const Conversation &conversation;
};
```

You should never, ever, ever, *ever*, use reference members. Either use a regular member, or a managed pointer. The only acceptable time - and maybe not even then - is if you know 100% for certain that the object has a longer lifetime than the reference. (Such as PlayerInfo.) That is *not* the case with a Conversation.

This is the sequence of events:

1. Mission is instantiated, creating a new NPC with a MissionAction that contains the Conversation.
2. The action is triggered. It sends a `const Conversation &` of its conversation to a new ConversationPanel
3. NPC deletes the MissionAction, which deletes the Conversation.
4. The ConversationPanel uses the now-deleted Conversation object.

This is why you should *never* have reference members.

There aren't many ConversationPanels active at once, and Conversations aren't very large. We can manage giving ConversationPanel its own copy of the Conversation.

## Testing Done
Run this mission in Endless Sky in Valgrind:

[crash.txt](https://github.com/endless-sky/endless-sky/files/11710338/crash.txt)

## Save File
Any pilot on New Boston will work. Start a new game, or use any save.