### PR TITLE
Create NPCAction that wraps MissionAction for NPCs and records usage to prevent crash

### DIFF
--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -251,6 +251,8 @@
 		<Unit filename="source/Music.h" />
 		<Unit filename="source/NPC.cpp" />
 		<Unit filename="source/NPC.h" />
+		<Unit filename="source/NPCAction.cpp" />
+		<Unit filename="source/NPCAction.h" />
 		<Unit filename="source/News.cpp" />
 		<Unit filename="source/News.h" />
 		<Unit filename="source/Outfit.cpp" />

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -205,6 +205,8 @@ target_sources(EndlessSkyLib PRIVATE
 	Music.h
 	NPC.cpp
 	NPC.h
+	NPCAction.cpp
+	NPCAction.h
 	News.cpp
 	News.h
 	Outfit.cpp

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -46,9 +46,11 @@ public:
 	MissionAction(const DataNode &node, const std::string &missionName);
 
 	void Load(const DataNode &node, const std::string &missionName);
+	void LoadSingle(const DataNode &node, const std::string &missionName);
 	// Note: the Save() function can assume this is an instantiated mission, not
 	// a template, so it only has to save a subset of the data.
 	void Save(DataWriter &out) const;
+	void SaveBody(DataWriter &out) const;
 	// Determine if this MissionAction references content that is not fully defined.
 	std::string Validate() const;
 

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -24,7 +24,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Government.h"
 #include "Logger.h"
 #include "Messages.h"
-#include "MissionAction.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "Random.h"
@@ -778,9 +777,6 @@ void NPC::DoActions(const ShipEvent &event, bool newEvent, PlayerInfo &player, U
 				}))
 		{
 			it->second.Do(player, ui);
-			// All actions are currently one-time-use. Erase the action from
-			// the map so that it can't be reused.
-			npcActions.erase(it);
 		}
 	}
 }

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -22,6 +22,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Fleet.h"
 #include "FleetCargo.h"
 #include "LocationFilter.h"
+#include "NPCAction.h"
 #include "Personality.h"
 #include "Phrase.h"
 
@@ -33,7 +34,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 class DataNode;
 class DataWriter;
 class Government;
-class MissionAction;
 class Planet;
 class PlayerInfo;
 class Ship;
@@ -152,8 +152,8 @@ private:
 	// The ShipEvent actions that have been done to each ship.
 	std::map<const Ship *, int> shipEvents;
 
-	// The MissionActions that this NPC can run on certain events/triggers.
-	std::map<Trigger, MissionAction> npcActions;
+	// The NPCAction that this NPC can run on certain events/triggers.
+	std::map<Trigger, NPCAction> npcActions;
 };
 
 

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -152,7 +152,7 @@ private:
 	// The ShipEvent actions that have been done to each ship.
 	std::map<const Ship *, int> shipEvents;
 
-	// The NPCAction that this NPC can run on certain events/triggers.
+	// The NPCActions that this NPC can run on certain events/triggers.
 	std::map<Trigger, NPCAction> npcActions;
 };
 

--- a/source/NPCAction.cpp
+++ b/source/NPCAction.cpp
@@ -1,0 +1,99 @@
+/* NPCAction.cpp
+Copyright (c) 2023 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "NPCAction.h"
+
+#include "DataNode.h"
+#include "DataWriter.h"
+#include "PlayerInfo.h"
+#include "System.h"
+#include "UI.h"
+
+using namespace std;
+
+
+
+// Construct and Load() at the same time.
+NPCAction::NPCAction(const DataNode &node, const string &missionName)
+{
+	Load(node, missionName);
+}
+
+
+
+void NPCAction::Load(const DataNode &node, const string &missionName)
+{
+	if(node.Size() >= 2)
+		trigger = node.Token(1);
+	for(const DataNode &child : node)
+	{
+		const string &key = child.Token(0);
+
+		if(key == "triggered")
+			triggered = true;
+		else
+			action.LoadSingle(child, missionName);
+	}
+}
+
+
+
+// Note: the Save() function can assume this is an instantiated action, not
+// a template, so it only has to save a subset of the data.
+void NPCAction::Save(DataWriter &out) const
+{
+	out.Write("on", trigger);
+	out.BeginChild();
+	{
+		if(triggered)
+			out.Write("triggered");
+
+		action.SaveBody(out);
+	}
+	out.EndChild();
+}
+
+
+
+// Check this template or instantiated NPCAction to see if any used content
+// is not fully defined (e.g. plugin removal, typos in names, etc.).
+string NPCAction::Validate() const
+{
+	return action.Validate();
+}
+
+
+
+void NPCAction::Do(PlayerInfo &player, UI *ui)
+{
+	// All actions are currently one-time-use. Actions that are used
+	// are marked as triggered, and cannot be used again.
+	if(triggered)
+		return;
+	triggered = true;
+	action.Do(player, ui);
+}
+
+
+
+// Convert this validated template into a populated action.
+NPCAction NPCAction::Instantiate(map<string, string> &subs, const System *origin,
+	int jumps, int64_t payload) const
+{
+	NPCAction result;
+	result.trigger = trigger;
+	result.action = action.Instantiate(subs, origin, jumps, payload);
+	return result;
+}

--- a/source/NPCAction.cpp
+++ b/source/NPCAction.cpp
@@ -37,6 +37,7 @@ void NPCAction::Load(const DataNode &node, const string &missionName)
 {
 	if(node.Size() >= 2)
 		trigger = node.Token(1);
+
 	for(const DataNode &child : node)
 	{
 		const string &key = child.Token(0);

--- a/source/NPCAction.h
+++ b/source/NPCAction.h
@@ -1,0 +1,66 @@
+/* NPCAction.h
+Copyright (c) 2023 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef NPC_ACTION_H_
+#define NPC_ACTION_H_
+
+#include "MissionAction.h"
+
+class DataNode;
+class DataWriter;
+class PlayerInfo;
+class System;
+class UI;
+
+
+
+// A wrapper for a MissionAction that can be triggered by an NPC. Records whether
+// the action has already been done previously, which NPC checks to prevent
+// the action from being done more than once.
+// More functionality to come later, such as changing the personality of an NPC
+// on the fly.
+class NPCAction {
+public:
+	NPCAction() = default;
+	// Construct and Load() at the same time.
+	NPCAction(const DataNode &node, const std::string &missionName);
+
+	void Load(const DataNode &node, const std::string &missionName);
+	// Note: the Save() function can assume this is an instantiated mission, not
+	// a template, so it only has to save a subset of the data.
+	void Save(DataWriter &out) const;
+	// Determine if this NPCAction references content that is not fully defined.
+	std::string Validate() const;
+
+	// Perform this action.
+	void Do(PlayerInfo &player, UI *ui = nullptr);
+
+	// "Instantiate" this action by filling in the wildcard text for the actual
+	// destination, payment, cargo, etc.
+	NPCAction Instantiate(std::map<std::string, std::string> &subs,
+		const System *origin, int jumps, int64_t payload) const;
+
+
+private:
+	std::string trigger;
+	bool triggered = false;
+
+	// Tasks this NPC action performs, such as modifying accounts, inventory, or conditions.
+	MissionAction action;
+};
+
+
+
+#endif


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8870

## Fix Details
Created a new NPCAction class which contains a MissionAction and records whether the action has already been triggered previously. NPCActions which have been triggered cannot be triggered again. This is as opposed to the current behavior of deleting the MissionAction after use, which caused #8870. With this change, the Conversation used by ConversationPanel once again lasts longer than the panel, as it did prior to #7326.

Creating a separate class also lays the groundwork for future enhancements to actions that NPCs can trigger, allowing them to do actions specific to NPCs (such as changing NPC personalities after something has occurred).

Note that this is not necessarily mutually exclusive with the change in #8877. They both fix the crash, but they also do not conflict with one another.

## Testing Done
Tested this mission with the current master and with this PR. I wasn't experiencing a crash without this PR, but the text after the choice did sometimes display something other than what it should have, showing that there was an issue. With this PR, the text after the choice always displayed what it should have.
```
mission "action test"
	job
	repeat
	on enter
	npc kill
		on disable
			conversation
				`Get crashed.`
				choice
					`	"Ok."`
				`	AAAAAAAAAAAAAAAAAAA.`
		personality staying
		government "Pirate"
		ship "Sparrow" "Crasher"
```
Also confirmed that reloading the save file prevents the action from triggering a second time. The action remains in the save file instead of being deleted, and gains the "triggered" child node after being used.
