### PR TITLE
Correct text replacement in FW Pirates: Attack 2

### DIFF
--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -1292,7 +1292,7 @@ mission "FW Pirates: Attack 2"
 	
 	on offer
 		conversation
-			`When you land on <planet>, you find the fleet that Tomek mentioned: a few militia heavy and medium warships, a couple of carriers, three squadrons of interceptors, and even four merchant ships of varying sizes. In total the fleet is nearly as large as one of the fleets that defended Sabik or Kornephoros, but as you survey the motley mix of grizzled militia veterans, young, naive interceptor pilots, and eager merchant captains, you can't help but wonder if a fleet of this size has a good chance against the strongest pirate world in Southern space.`
+			`When you land on <origin>, you find the fleet that Tomek mentioned: a few militia heavy and medium warships, a couple of carriers, three squadrons of interceptors, and even four merchant ships of varying sizes. In total the fleet is nearly as large as one of the fleets that defended Sabik or Kornephoros, but as you survey the motley mix of grizzled militia veterans, young, naive interceptor pilots, and eager merchant captains, you can't help but wonder if a fleet of this size has a good chance against the strongest pirate world in Southern space.`
 			`	The Navy failed to conquer Longjump. Why would a fleet of a similar size be capable of conquering Greenrock? Perhaps the Senate was right in suggesting a diplomatic solution. Or perhaps luck will be in your favor.`
 			choice
 				`	(Go ahead and attack Greenrock, disobeying the Senate's orders regardless of the consequences.)`


### PR DESCRIPTION
**Bugfix:**

## Fix Details
This line is supposed to refer to my current planet, the place where this mission is offered, but `<planet>` is replaced with the name of the destination planet.
This PR changes the replacement to `<origin>` which will be the name of this planet.

## Testing Done
0

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[warp core~~previous-1.txt](https://github.com/endless-sky/endless-sky/files/11715692/warp.core.previous-1.txt)

