### PR TITLE
Properly account for suspension from the FW militia in FW Diplomacy 1

### DIFF
--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -30,7 +30,9 @@ mission "FW Diplomacy 1"
 		conversation
 			`As you are landing, you receive a message from JJ, on behalf of the Council. The message reads:`
 			branch suspended
-				has "FW Pirates 4.1: offered"
+				or
+					has "FW Pirates 4.1: offered"
+					has "event: fw stripped of service"
 			`	Captain <last>, sorry that we have been out of contact. We need your help once again, to assist in a diplomatic mission. Please meet up with Alondo on <planet> as soon as possible. He will give you more information.`
 				goto end
 			

--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -726,6 +726,7 @@ mission "FW Southern Break"
 			label salary
 			branch end
 				not "FW Pirates 4.1: offered"
+				not "event: fw stripped of service"
 			`	"Before you leave, Captain," Freya says. "The Senate has decided to reinstate your pay after these recent events. You should now have a salary of 2,100 credits, just like before."`
 			
 			label end


### PR DESCRIPTION
**Bugfix:**

## Fix Details
The missions towards the end of FW start were changed in #7000 but this condition in FW middle still refers to the old mission name, which no longer exists.
This PR updates it so it also refers to a condition that is set by the current missions.

## Testing Done
0

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[warp core~~previous-1.txt](https://github.com/endless-sky/endless-sky/files/11715932/warp.core.previous-1.txt)

Travel the Winter and FW Diplomacy 1 should be available.
