### PR TITLE
fix(content): Change reference to incorrect ship type in FW

### DIFF
--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -29,7 +29,7 @@ mission "Liberate Kornephoros"
 			`	You find Tomek walking among the fleet, conversing with a large group of captains and crew members and assessing the damage they have suffered. When he sees you he says, "Captain <last>! How is <ship> holding together?"`
 			choice
 				`	"She took a bit of a pounding, but I've patched her up."`
-				`	"Just fine. It'd take more than a few Cruisers to destroy the <ship>."`
+				`	"Just fine. It'd take more than a few Carriers to destroy the <ship>."`
 			
 			`	"Glad to hear it," he says before returning to the crowd. "Listen! We need to press our advantage before the Republic has time to call for reinforcements. If we strike quickly, we could be able to retake Kornephoros from them. It's important to break the blockade on that system for the sake of trade with the rest of the galaxy. And on top of that, if you were not aware, Councilor Katya Reynolds was on Clink when the Navy took the system and needs to be rescued." You hear some chatter coming from the crowd as a result of this news; it seems like Katya's investigation on Clink was not public knowledge.`
 			`	"We have a large fleet of reinforcements coming in from the Rim," Tomek continues, "and a few ships here that are able to fight another battle. I need you all to take off, wait for the reinforcements to arrive, and then retake Kornephoros. If the Navy ships retreat, let them retreat. If they surrender, let them surrender. If they stay and fight, disable them if you can. Destroy them only if you must. Am I understood?"`


### PR DESCRIPTION
**Bugfix:** This PR fixes a conversation where Cruisers are referenced instead of Carriers.

## Fix Details
In `Liberate Kornephoros`, FL says `Just fine. It'd take more than a few Cruisers to destroy the <ship>.`

However, in the previous battle (`Defend Sabik`), the navy fleets only had Carriers, and no cruisers.

```
npc evade
		government "Republic"
		personality waiting heroic
		fleet
			names "republic capital"
			fighters "republic fighter"
			variant
				"Carrier"
				"Lance" 4
				"Combat Drone" 6
				"Frigate" 2
				"Gunboat" 3
				"Rainmaker" 3
	npc evade
		government "Republic"
		personality heroic
		system "Kornephoros"
		fleet 2
			names "republic capital"
			fighters "republic fighter"
			variant
				"Carrier"
				"Lance" 4
				"Combat Drone" 6
				"Frigate" 2
				"Gunboat" 3
				"Rainmaker" 3
```