### PR TITLE
feat(UI): Allow the main zoom factor to drop below 100

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -48,7 +48,7 @@ using namespace std;
 namespace {
 	// Settings that require special handling.
 	const string ZOOM_FACTOR = "Main zoom factor";
-	const int ZOOM_FACTOR_MIN = 100;
+	const int ZOOM_FACTOR_MIN = 50;
 	const int ZOOM_FACTOR_MAX = 200;
 	const int ZOOM_FACTOR_INCREMENT = 10;
 	const string VIEW_ZOOM_FACTOR = "View zoom factor";

--- a/source/Screen.cpp
+++ b/source/Screen.cpp
@@ -56,7 +56,7 @@ int Screen::Zoom()
 
 void Screen::SetZoom(int percent)
 {
-	USER_ZOOM = max(100, min(200, percent));
+	USER_ZOOM = max(50, min(200, percent));
 
 	// Make sure the zoom factor is not set too high for the full UI to fit.
 	static const int MIN_WIDTH = 1000; // Width of main menu
@@ -64,8 +64,8 @@ void Screen::SetZoom(int percent)
 	int minZoomX = 100 * RAW_WIDTH / MIN_WIDTH;
 	int minZoomY = 100 * RAW_HEIGHT / MIN_HEIGHT;
 	int minZoom = min(minZoomX, minZoomY);
-	// Never go below 100% zoom, no matter how small the window is
-	minZoom = max(minZoom, 100);
+	// Never go below 50% zoom, no matter how small the window is
+	minZoom = max(minZoom, 50);
 	// Use increments of 10, like the user setting
 	minZoom -= minZoom % 10;
 	EFFECTIVE_ZOOM = min(minZoom, UserZoom());


### PR DESCRIPTION
**Feature:** This PR implements a feature requested on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1117816451005427723).

## Feature Details
You can now set the main zoom factor to a value lower than 100 (but at least 50) to make UI elements smaller.

## Testing Done
It seems it didn't broke anything.

## Performance Impact
N/A
