### PR TITLE
feat(content): Add Split-Quarg governments to Heliarch Relations

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -606,6 +606,9 @@ government "Heliarch"
 	"hostile disabled hail" "hostile disabled heliarch"
 	"attitude toward"
 		"Quarg" -.01
+		"Quarg (Hai)" -.01
+		"Quarg (Kor Efret)" -.01
+		"Quarg (Gegno)" -.01
 		"Coalition" 1
 
 color "governments: Independent" .78 .36 .36


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This PR adds each Quarg government that was split in https://github.com/endless-sky/endless-sky/pull/8561/files#diff-52ab6c2e7dd87148c178b0cb37499256a21fa460b750065a596d6cce76b0e3ac to the Heliarch's relationships, so that they are properly fired upon should they ever find themselves in Coalition space (see the Wanderer missions that give the player Quarg escorts).

## Save File
N/A