### PR TITLE
Fix an issue with out of system escort refuelling

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1849,6 +1849,10 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 			if(!(parent.IsEnteringHyperspace() || parent.IsReadyToJump()) || !EscortsReadyToJump(ship))
 				command |= Command::WAIT;
 		}
+		else if(needsFuel && systemHasFuel)
+		{
+			Refuel(ship, command);
+		}
 		else if(ship.GetTargetStellar())
 		{
 			MoveToPlanet(ship, command);

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1850,9 +1850,7 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 				command |= Command::WAIT;
 		}
 		else if(needsFuel && systemHasFuel)
-		{
 			Refuel(ship, command);
-		}
 		else if(ship.GetTargetStellar())
 		{
 			MoveToPlanet(ship, command);


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Out of system escorts that have run out of fuel will often refuse to land and refuel if that is an option.
This PR fixes that.

## Testing Done
Use the save file below.
Follow the route to Kraz.
Without this PR, the mission escorts will get stuck in Mimosa. Some are out of fuel, but don't use the planet to refuel and all the other ships are waiting for them.
With this PR, they refuel as needed and all successfully arrive in Kraz.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[warp core.txt](https://github.com/endless-sky/endless-sky/files/11736652/warp.core.txt)

