### PR TITLE
Fix plugin icon missing when no @2x is provided

### DIFF
--- a/source/ImageSet.cpp
+++ b/source/ImageSet.cpp
@@ -188,7 +188,7 @@ const string &ImageSet::Name() const
 // Whether this image set is empty, i.e. has no images.
 bool ImageSet::IsEmpty() const
 {
-	return framePaths[0].empty() || framePaths[1].empty();
+	return framePaths[0].empty() && framePaths[1].empty();
 }
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8765 

## Fix Details
#7667 added a check that skips attempting to load plugin icons if one isn't present, eliminating the errors that were printed about plugin icons being referred to but not existing (the user is not referring to them, the game was assuming the icon is provided even though this isn't actually a requirement.)
That check assumed no icon file existed if either a standard DPI or @2x version wasn't present, requiring both. So, if only the standard is provided, it will be ignored since the @2x isn't.
This PR means that the icon loading will only be skipped if both a standard DPI and @2x version are not present. That is, if either is present, the icon will be loaded.

## Testing Done
Delete the @2x version of the high DPI plugin icon and start the game. Check the plugins page and see that the `inactive` sprite is displayed even though the `active` version was used when it was present. Without this PR, no icon appears.

