### PR TITLE
Fix Remnant JD missions destination being Ssil Vida

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -2812,7 +2812,7 @@ mission "Remnant: Broken Jump Drive 5"
 		attributes outfitter
 		not attributes "requires: gaslining"
 		not distance 0
-		not "Ssil Vida"
+		not attributes "remnant station"
 	on offer
 		require "Jump Drive (Broken)"
 		conversation

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -2676,7 +2676,7 @@ mission "Remnant: Broken Jump Drive 2"
 		attributes outfitter
 		not attributes "requires: gaslining"
 		not distance 0
-		not "Ssil Vida"
+		not attributes "remnant station"
 	on offer
 		require "Jump Drive (Broken)"
 		conversation

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -2618,7 +2618,7 @@ mission "Remnant: Broken Jump Drive 1"
 		attributes outfitter
 		not attributes "requires: gaslining"
 		not distance 0
-		not "Ssil Vida"
+		not attributes "remnant station"
 	on offer
 		require "Jump Drive (Broken)"
 		conversation

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -2722,7 +2722,7 @@ mission "Remnant: Broken Jump Drive 3"
 		attributes outfitter
 		not attributes "requires: gaslining"
 		not distance 0
-		not "Ssil Vida"
+		not attributes "remnant station"
 	on offer
 		require "Jump Drive (Broken)"
 		conversation

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -2767,7 +2767,7 @@ mission "Remnant: Broken Jump Drive 4"
 		attributes outfitter
 		not attributes "requires: gaslining"
 		not distance 0
-		not "Ssil Vida"
+		not attributes "remnant station"
 	on offer
 		require "Jump Drive (Broken)"
 		conversation

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -2618,6 +2618,7 @@ mission "Remnant: Broken Jump Drive 1"
 		attributes outfitter
 		not attributes "requires: gaslining"
 		not distance 0
+		not "Ssil Vida"
 	on offer
 		require "Jump Drive (Broken)"
 		conversation
@@ -2675,6 +2676,7 @@ mission "Remnant: Broken Jump Drive 2"
 		attributes outfitter
 		not attributes "requires: gaslining"
 		not distance 0
+		not "Ssil Vida"
 	on offer
 		require "Jump Drive (Broken)"
 		conversation
@@ -2720,6 +2722,7 @@ mission "Remnant: Broken Jump Drive 3"
 		attributes outfitter
 		not attributes "requires: gaslining"
 		not distance 0
+		not "Ssil Vida"
 	on offer
 		require "Jump Drive (Broken)"
 		conversation
@@ -2764,6 +2767,7 @@ mission "Remnant: Broken Jump Drive 4"
 		attributes outfitter
 		not attributes "requires: gaslining"
 		not distance 0
+		not "Ssil Vida"
 	on offer
 		require "Jump Drive (Broken)"
 		conversation
@@ -2808,6 +2812,7 @@ mission "Remnant: Broken Jump Drive 5"
 		attributes outfitter
 		not attributes "requires: gaslining"
 		not distance 0
+		not "Ssil Vida"
 	on offer
 		require "Jump Drive (Broken)"
 		conversation

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -2617,8 +2617,8 @@ mission "Remnant: Broken Jump Drive 1"
 		government "Remnant"
 		attributes outfitter
 		not attributes "requires: gaslining"
-		not distance 0
 		not attributes "remnant station"
+		not distance 0
 	on offer
 		require "Jump Drive (Broken)"
 		conversation
@@ -2675,8 +2675,8 @@ mission "Remnant: Broken Jump Drive 2"
 		government "Remnant"
 		attributes outfitter
 		not attributes "requires: gaslining"
-		not distance 0
 		not attributes "remnant station"
+		not distance 0
 	on offer
 		require "Jump Drive (Broken)"
 		conversation
@@ -2721,8 +2721,8 @@ mission "Remnant: Broken Jump Drive 3"
 		government "Remnant"
 		attributes outfitter
 		not attributes "requires: gaslining"
-		not distance 0
 		not attributes "remnant station"
+		not distance 0
 	on offer
 		require "Jump Drive (Broken)"
 		conversation
@@ -2766,8 +2766,8 @@ mission "Remnant: Broken Jump Drive 4"
 		government "Remnant"
 		attributes outfitter
 		not attributes "requires: gaslining"
-		not distance 0
 		not attributes "remnant station"
+		not distance 0
 	on offer
 		require "Jump Drive (Broken)"
 		conversation
@@ -2811,8 +2811,8 @@ mission "Remnant: Broken Jump Drive 5"
 		government "Remnant"
 		attributes outfitter
 		not attributes "requires: gaslining"
-		not distance 0
 		not attributes "remnant station"
+		not distance 0
 	on offer
 		require "Jump Drive (Broken)"
 		conversation

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -96,6 +96,7 @@ mission "Remnant: Broken Jump Drive job"
 		government "Remnant"
 		attributes outfitter
 		not distance 0
+		not attributes "remnant station"
 	on visit
 		dialog phrase "broken jump drive on visit"
 	on complete

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -95,8 +95,8 @@ mission "Remnant: Broken Jump Drive job"
 	destination
 		government "Remnant"
 		attributes outfitter
-		not distance 0
 		not attributes "remnant station"
+		not distance 0
 	on visit
 		dialog phrase "broken jump drive on visit"
 	on complete


### PR DESCRIPTION
Fix destination from being Ssil Vida

NOTICE: this does now fix the repeatable job board missions

**Bugfix:** This PR addresses issue #{{#8896}}

## Fix Details
		not attributes "remnant station" in six different spaces

## Save File
none, sorry
## Performance Impact
N/A