### PR TITLE
feat(testing): Add some rudamentary checks for indefinite articles to the content style checker

### DIFF
--- a/utils/contentStyle.json
+++ b/utils/contentStyle.json
@@ -111,7 +111,7 @@
 					},
 					{
 						"description": "incorrect indefinite article",
-						"regex": "(\\sa) ((?!one|once|hour)[aeio](?!u))",
+						"regex": "((?:\\sa|^A)) ((?!one|once|hour)[aeio](?!u))",
 						"isError": false,
 						"correction": {
 							"replaceWith": "\\1n \\2"
@@ -119,7 +119,7 @@
 					},
 					{
 						"description": "incorrect indefinite article",
-						"regex": "(\\sa)n ([^aAeEiIoOuUhH\\[\\]\"\\'\\d<\\-])",
+						"regex": "((?:\\sa|^A))n ([^aAeEiIoOuUhH\\[\\]\"\\'\\d<\\-])",
 						"isError": false,
 						"correction": {
 							"replaceWith": "\\1 \\2"

--- a/utils/contentStyle.json
+++ b/utils/contentStyle.json
@@ -108,6 +108,22 @@
 						"correction": {
 							"replaceWith": "\\1 \\2"
 						}
+					},
+					{
+						"description": "incorrect indefinite article",
+						"regex": "(\\sa) ((?!one|once|hour)[aeio](?!u))",
+						"isError": false,
+						"correction": {
+							"replaceWith": "\\1n \\2"
+						}
+					},
+					{
+						"description": "incorrect indefinite article",
+						"regex": "(\\sa)n ([^aAeEiIoOuUhH\\[\\]\"\\'\\d<\\-])",
+						"isError": false,
+						"correction": {
+							"replaceWith": "\\1 \\2"
+						}
 					}
 				]
 			},

--- a/utils/contentStyle.json
+++ b/utils/contentStyle.json
@@ -104,7 +104,6 @@
 					{
 						"description": "missing space before comment",
 						"regex": "(^\\s*#+)([^\\s#])",
-						"isError": false,
 						"correction": {
 							"replaceWith": "\\1 \\2"
 						}
@@ -112,7 +111,6 @@
 					{
 						"description": "incorrect indefinite article",
 						"regex": "((?:\\sa|^A)) ((?!one|once|hour)[aeio](?!u))",
-						"isError": false,
 						"correction": {
 							"replaceWith": "\\1n \\2"
 						}
@@ -120,7 +118,6 @@
 					{
 						"description": "incorrect indefinite article",
 						"regex": "((?:\\sa|^A))n ([^aAeEiIoOuUhH\\[\\]\"\\'\\d<\\-])",
-						"isError": false,
 						"correction": {
 							"replaceWith": "\\1 \\2"
 						}


### PR DESCRIPTION
**Feature:** This PR adds two new regex-based checks to the content style checker that check whether 'a' and 'an' are used correctly. Some additional safeguards might be required in the future if a new alien race's language abuses these rules, or if there are some rare edge cases not listed. (Works with all current wanderer dialog.)

The checks only give a warning so it won't fail the CI for any new languages.

## Testing Done
Found typos. Didn't find anything else. The new checks work correctly with the --auto-correct option.