### PR TITLE
Upload all the Steam depots when creating a release

### DIFF
--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           name: steam-win32-depot
           path: |
-            './install/release/Endless Sky.exe'
+            ./install/release/Endless Sky.exe
             ./install/release/*.dll
 
 
@@ -114,7 +114,7 @@ jobs:
         with:
           name: steam-win64-depot
           path: |
-            './install/release/Endless Sky.exe'
+            ./install/release/Endless Sky.exe
             ./install/release/*.dll
 
 

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -70,6 +70,13 @@ jobs:
         with:
           draft: true
           files: ${{ env.OUTPUT }}
+      - name: Upload Steam Depot
+        uses: actions/upload-artifact@v3
+        with:
+          name: steam-win32-depot
+          path: |
+            './install/release/Endless Sky.exe'
+            ./install/release/*.dll
 
 
   release_windows_x64:
@@ -102,6 +109,13 @@ jobs:
         with:
           draft: true
           files: ${{ env.OUTPUT }}
+      - name: Upload Steam Depot
+        uses: actions/upload-artifact@v3
+        with:
+          name: steam-win64-depot
+          path: |
+            './install/release/Endless Sky.exe'
+            ./install/release/*.dll
 
 
   release_macos_universal:
@@ -152,3 +166,84 @@ jobs:
         with:
           draft: true
           files: ${{ env.OUTPUT }}.dmg
+      - name: Prepare Steam Depot
+        run: |
+          mv "Endless Sky.app/Contents/Resources/endless-sky.icns" .
+          rm -rf "Endless Sky.app/Contents/Resources"
+          mkdir "Endless Sky.app/Contents/Resources"
+          mv endless-sky.icns "Endless Sky.app/Contents/Resources"
+          mkdir depot/
+          mv "Endless Sky.app/" depot/
+      - name: Upload Steam Depot
+        uses: actions/upload-artifact@v3
+        with:
+          name: steam-macos-depot
+          path: depot
+
+
+  release_steam_linux:
+    name: Steam Linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x64, x86]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build Endless Sky
+      run: |
+        cd steam
+        docker-compose run steam-${{ matrix.arch }}
+    - name: Prepare binary
+      run: cp build/steam-${{ matrix.arch }}/endless-sky .
+    - name: Upload Steam Depot
+      uses: actions/upload-artifact@v3
+      with:
+        name: steam-linux${{ matrix.arch == 'x64' && '64' || '32' }}-depot
+        path: endless-sky
+
+
+  deploy_steam:
+    name: Deploy Steam
+    needs: [release_steam_linux, release_windows_x64, release_windows_x86, release_macos_universal]
+    runs-on: ubuntu-latest
+    # environment: steam
+    env:
+      data: steam-data-depot
+      linux32: steam-linux-x86
+      linux64: steam-linux-x64
+      win32: steam-win32
+      win64: steam-win64
+      macos: steam-macos
+    steps:
+    - uses: actions/checkout@v3
+    - name: Upload Steam Data Depot
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.data }}
+        path: |
+          changelog
+          copyright
+          credits.txt
+          icon.png
+          keys.txt
+          license.txt
+          data/
+          images/
+          sounds/
+    # - uses: game-ci/steam-deploy@v1
+    #   with:
+    #     appId: 404410
+    #     buildDescription: canary-${{ github.sha }}
+    #     username: ${{ secrets.STEAM_DEPLOY_UN }}
+    #     password: ${{ secrets.STEAM_DEPLOY_PW }}
+    #     configVdf: ${{ secrets.STEAM_DEPLOY_VDF }}
+    #     ssfnFileName: ${{ secrets.STEAM_DEPLOY_SSFN_NAME }}
+    #     ssfnFileContents: ${{ secrets.STEAM_DEPLOY_SSFN }}
+    #     rootPath: ''
+    #     depot1Path: ${{ env.data }}
+    #     depot3Path: ${{ env.win32 }}
+    #     depot4Path: ${{ env.win64 }}
+    #     depot5Path: ${{ env.macos }}
+    #     depot6Path: ${{ env.linux32 }}
+    #     depot7Path: ${{ env.linux64 }}
+    #     releaseBranch: canary


### PR DESCRIPTION
## Feature Details

Creates all the Steam depot zips as part of the release workflow. Those zips can then be uploaded to Steam as-is.

## Testing Done

Not yet, but it should work (because I copy pasted 95% of it from a previous branch where I tested it)
