### PR TITLE
refactor(content): Fix a news entry not using phrases

### DIFF
--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -1641,17 +1641,8 @@ news "merchant in pirate space"
 	location
 		government "Pirate"
 	name
-		word
-			"Merchant captain"
-			"Starship captain"
-			"Spacecraft captain"
-			"Spaceship captain"
-			"Freelance captain"
-			"Merchant pilot"
-			"Starship pilot"
-			"Spacecraft pilot"
-			"Spaceship pilot"
-			"Freelance pilot"
+		phrase
+			"merchant names"
 	message
 		word
 			`"`


### PR DESCRIPTION
This news doesn't use the existing "merchant names" phrase, which seems to give the exact same combinations, and is used in two other news.

```
phrase "merchant names"
	word
		"Freelance"
		"Merchant"
		"Spacecraft"
		"Spaceship"
		"Starship"
	word
		" "
	word
		"captain"
		"pilot"
```