### PR TITLE
bugfix(content): Prevent "financial analyst" news from showing up during the Pug occupation

### DIFF
--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -1260,6 +1260,8 @@ news "retiree"
 news "financial analyst"
 	location
 		attributes "paradise" "near earth"
+		not
+			government Pug
 	name
 		word
 			"Financial analyst"

--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -1260,8 +1260,7 @@ news "retiree"
 news "financial analyst"
 	location
 		attributes "paradise" "near earth"
-		not
-			government Pug
+		not government Pug
 	name
 		word
 			"Financial analyst"


### PR DESCRIPTION
**Bugfix:** This PR removes the "financial analyst" news from Altair and similar systems while they are occupied by the pug.

## Fix Details
Currently, during the occupation, no other news show up, and I don't think this one is anything special.

## Testing Done
Doesn't show up after the government was blocked.

## Save File
[Space Shuttle.txt](https://github.com/endless-sky/endless-sky/files/11756154/Space.Shuttle.txt)