### PR TITLE
Do not prevent ships targeting an asteroid from looking for ships to target

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -684,7 +684,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 		shared_ptr<Flotsam> targetFlotsam = it->GetTargetFlotsam();
 		if(isPresent && it->IsYours() && targetFlotsam && FollowOrders(*it, command))
 			continue;
-		if(isPresent && !personality.IsSwarming() && !targetAsteroid)
+		if(isPresent && !personality.IsSwarming())
 		{
 			// Each ship only switches targets twice a second, so that it can
 			// focus on damaging one particular ship.


### PR DESCRIPTION
**Bugfix:**

Thanks to riyan_gendut for reporting this on Discord.

## Fix Details
Not allowing ships that are targeting an asteroid to consider ships to target can, in some situations, prevent the target ship of an attack or finish off order from being adopted by the ship as its own target, which leads to the ships doing undesirable things, like landing or leaving the system when they have been told to fire on a specific ship.

## Testing Done
The easiest way to reproduce this seems to be to instruct escorts to fire on an asteroid and then immediately tell them to fire on a ship before they can destroy the asteroid.

https://www.youtube.com/watch?v=J5AOu3RbRmY

Applying the same steps after this change results in the ships behaving correctly instead of what they do in the video: start jumping out of the system.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using the current continuous build, and will not occur when using this branch's build.
[Jahan Hill~original.txt](https://github.com/endless-sky/endless-sky/files/11763595/Jahan.Hill.original.txt)
(This save file requires the Lost in Midnight plugin, linked in the plugins repository.)

