### PR TITLE
Fix/standardize capitalization of names in news entries

### DIFF
--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -898,11 +898,13 @@ news "ship salesperson"
 	# TODO: Add filter for only planets with shipyards (once we can use conditions to filter this).
 	name
 		word
-			"Used spaceship salesman"
-			"Used spaceship saleswoman"
-			"Used spaceship salesperson"
-			"Used spaceship seller"
-			"Used spaceship dealer"
+			"Used spaceship "
+		word
+			"salesman"
+			"saleswoman"
+			"salesperson"
+			"seller"
+			"dealer"
 	message
 		word
 			`"`

--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -279,7 +279,7 @@ news "street vendor"
 	name
 		word
 			"Street vendor"
-			"Open-Air Market vendor"
+			"Open-air market vendor"
 			"Food stall operator"
 	message
 		word
@@ -898,11 +898,11 @@ news "ship salesperson"
 	# TODO: Add filter for only planets with shipyards (once we can use conditions to filter this).
 	name
 		word
-			"Used Spaceship Salesman"
-			"Used Spaceship Saleswoman"
-			"Used Spaceship Salesperson"
-			"Used Spaceship Seller"
-			"Used Spaceship Dealer"
+			"Used spaceship salesman"
+			"Used spaceship saleswoman"
+			"Used spaceship salesperson"
+			"Used spaceship seller"
+			"Used spaceship dealer"
 	message
 		word
 			`"`
@@ -1001,7 +1001,7 @@ news "public relations worker"
 	name
 		word
 			"PR consultant"
-			"Crisis Consultant"
+			"Crisis consultant"
 	message
 		word
 			`"`
@@ -1535,7 +1535,7 @@ news "republic soldier"
 		attributes "military"
 	name
 		word
-			"Republic Soldier"
+			"Republic soldier"
 	message
 		word
 			`"`
@@ -1561,7 +1561,7 @@ news "syndicate soldier"
 		attributes "military"
 	name
 		word
-			"Syndicate Soldier"
+			"Syndicate soldier"
 	message
 		word
 			`"`
@@ -1728,7 +1728,7 @@ news "spaceport video advertisement"
 		government "Republic"
 	name
 		word
-			"Spaceport Video Screen"
+			"Spaceport video screen"
 	message
 		word
 			`You see a video of stuntmen making a jump from the edge of space. The "do not try this at home", "illegal on many planets", and "high risk/deadly" warnings at the end of the video suggest that this might become quite a popular sport.`
@@ -1763,7 +1763,7 @@ news "syndicate pa system"
 		not attributes "station"
 	name
 		word
-			"Public Announcement System"
+			"Public announcement system"
 	message
 		word
 			`"`
@@ -1812,7 +1812,7 @@ news "tourist pa system"
 		attributes "deep" "rich" "paradise" "tourism"
 	name
 		word
-			"Public Announcement System"
+			"Public announcement system"
 	message
 		word
 			`"`

--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -1331,7 +1331,7 @@ news "work coach"
 	name
 		word
 			"Corporate consultant"
-			"Work/Life balance coach"
+			"Work/life balance coach"
 			"Work efficiency coach"
 	message
 		word


### PR DESCRIPTION
Most news entries only capitalize the first word of the name, however these few capitalize either multiple words, or all of them.

Note: There is an entry in remnant next.txt with the name "System Security" that I didn't fix, because I think that's referring to an organization. Not entirely sure, though.