### PR TITLE
feat(content): Add missing condition to news entry (resolves TODO)

### DIFF
--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -895,7 +895,7 @@ news "mechanic"
 news "ship salesperson"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
-	# TODO: Add filter for only planets with shipyards (once we can use conditions to filter this).
+		attributes "shipyard"
 	name
 		word
 			"Used Spaceship Salesman"


### PR DESCRIPTION
**Content**: Adds a new condition to a job that was requested in a TODO comment.

## Details

The "shipyard" attribute is added to planets that have shipyards. This is what the TODO requested - spaceship salesmen should only appear on planets with shipyards.

## Testing done
I checked that the shipyard attribute works via `--matches`.