### PR TITLE
fix(typo): Don't capitalize "flotsam"

### DIFF
--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -105,7 +105,7 @@ help "fleet asteroid mining shortcuts"
 	`Shortcuts for asteroid targeting:`
 	`	<Select nearest asteroid> selects the nearest asteroid if you have an asteroid scanner.`
 	`	<Fleet: Fight my target> will focus your fleet on mining a targeted asteroid.`
-	`	<Fleet: Harvest Flotsam> will toggle whether your fleet tries to pick up flotsams.`
+	`	<Fleet: Harvest flotsam> will toggle whether your fleet tries to pick up flotsams.`
 	``
 	`Alternate targeting:`
 	`	Left click - will target an asteroid without mining it.`
@@ -114,7 +114,7 @@ help "fleet asteroid mining shortcuts"
 help "fleet harvest tutorial"
 	`You can order your escort to pick up discarded cargo or asteroid flotsam.`
 	``
-	`<Fleet: Harvest Flotsam> will order your fleet to collect flotsam if they have free cargo.`
+	`<Fleet: Harvest flotsam> will order your fleet to collect flotsam if they have free cargo.`
 	``
 	`Equip an asteroid scanner to learn more.`
 

--- a/keys.txt
+++ b/keys.txt
@@ -26,5 +26,5 @@
 "Fleet: Gather around me" 103
 "Fleet: Hold position" 104
 "Fleet: Toggle ammo usage" 117
-"Fleet: Harvest Flotsam" 122
+"Fleet: Harvest flotsam" 122
 "Mouse turning (hold)" 1073742050

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -75,7 +75,7 @@ const Command Command::FASTFORWARD(ONE << 24, "Toggle fast-forward");
 const Command Command::FIGHT(ONE << 25, "Fleet: Fight my target");
 const Command Command::GATHER(ONE << 26, "Fleet: Gather around me");
 const Command Command::HOLD(ONE << 27, "Fleet: Hold position");
-const Command Command::HARVEST(ONE << 28, "Fleet: Harvest Flotsam");
+const Command Command::HARVEST(ONE << 28, "Fleet: Harvest flotsam");
 const Command Command::AMMO(ONE << 29, "Fleet: Toggle ammo usage");
 const Command Command::AUTOSTEER(ONE << 30, "Auto steer");
 const Command Command::WAIT(ONE << 31, "");


### PR DESCRIPTION
# Summary
A typo in one of the fleet commands.
**Note:** The fix probably resets the keybind, but I think it's fine since the command was added in 0.10.1