### PR TITLE
fix(typo): `ring world` -> `ringworld` in gegno intro missions

### DIFF
--- a/data/gegno/gegno intro missions.txt
+++ b/data/gegno/gegno intro missions.txt
@@ -309,7 +309,7 @@ mission "Giaru Gegno: Quarg Contact"
 			branch "has met gegno"
 				has "Visit Quarg in Gegno Space: offered"
 				
-			"After jumping through several systems of many alien ships, a Quarg ring world is a surprisingly familiar sight to you. From the looks of it, this is a fully complete ringworld, a true sight to behold. Trillions of Quarg probably inhabit this ring, but what's more interesting to your eye is that some other aliens are also present. They too are humanoid, and the most common figures you come across are either slightly above or below an average human's height. Their skin is a smooth, light gray, and adorned with different sorts of leather that remind you of medieval human clothing."
+			"After jumping through several systems of many alien ships, a Quarg ringworld is a surprisingly familiar sight to you. From the looks of it, this is a fully complete ringworld, a true sight to behold. Trillions of Quarg probably inhabit this ring, but what's more interesting to your eye is that some other aliens are also present. They too are humanoid, and the most common figures you come across are either slightly above or below an average human's height. Their skin is a smooth, light gray, and adorned with different sorts of leather that remind you of medieval human clothing."
 			`	The mood here is eerie as the Quarg here move in an unusually quiet manner. They are dismissive of the other species walking about, who are equally as dismissive of you. The strange atmosphere around you is finally broken when a few Quarg start to advance towards you, moving much quicker than the rest. After some unidentifiable discussion and gestures between themselves, one of them motions you to follow them.`
 				goto "walking"
 			


### PR DESCRIPTION
**Bugfix:** This PR fixes an incorrectly separated word

## Fix Details
Quarg ringworlds are always one word, not two. There are 285 occurrences of "ringworld", but this is the only "ring world".

## Testing Done
N/A, this is a single word edit, doesn't touch the mission syntax.

## Save File
N/A, same as above.