### PR TITLE
Fix default status overlay preference

### DIFF
--- a/changelog
+++ b/changelog
@@ -11,7 +11,7 @@ Version 0.10.2
       * Actions against the Gegno civilian government will now correctly impact the player's reputation with the Quarg in Gegno space. (@Saugia)
       * The "financial analyst" news item will no longer appear on human worlds while they are occupied by the Pug. (@tibetiroka)
       * Ensure that the Unfettered escort fleet in Hai Reveal "A13-A" are not erroneously hostile to the player. (@MasterOfGrey)
-      * Make the new status overlay settings respect the old one and turn it off by default (@quyykk, @warp)
+      * Make the new status overlay settings respect the old one and turn it off by default (@quyykk, @warp-core)
     * Engine bugs:
       * Fixed some situations where ships will stop acting and drift forever. (@UnorderedSigh)
       * Fixed a case in AI::DoScatter where ships may get stuck together. (@UnorderedSigh)

--- a/changelog
+++ b/changelog
@@ -11,6 +11,7 @@ Version 0.10.2
       * Actions against the Gegno civilian government will now correctly impact the player's reputation with the Quarg in Gegno space. (@Saugia)
       * The "financial analyst" news item will no longer appear on human worlds while they are occupied by the Pug. (@tibetiroka)
       * Ensure that the Unfettered escort fleet in Hai Reveal "A13-A" are not erroneously hostile to the player. (@MasterOfGrey)
+      * Make the new status overlay settings respect the old one and turn it off by default (@quyykk, @warp)
     * Engine bugs:
       * Fixed some situations where ships will stop acting and drift forever. (@UnorderedSigh)
       * Fixed a case in AI::DoScatter where ships may get stuck together. (@UnorderedSigh)

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -104,9 +104,9 @@ namespace {
 
 	map<Preferences::OverlayType, OverlaySetting> statusOverlaySettings = {
 		{Preferences::OverlayType::ALL, Preferences::OverlayState::OFF},
-		{Preferences::OverlayType::FLAGSHIP, Preferences::OverlayState::OFF},
-		{Preferences::OverlayType::ESCORT, Preferences::OverlayState::OFF},
-		{Preferences::OverlayType::ENEMY, Preferences::OverlayState::OFF},
+		{Preferences::OverlayType::FLAGSHIP, Preferences::OverlayState::ON},
+		{Preferences::OverlayType::ESCORT, Preferences::OverlayState::ON},
+		{Preferences::OverlayType::ENEMY, Preferences::OverlayState::ON},
 		{Preferences::OverlayType::NEUTRAL, Preferences::OverlayState::OFF},
 	};
 
@@ -215,13 +215,7 @@ void Preferences::Load()
 	if(it != settings.end())
 	{
 		if(it->second)
-		{
 			statusOverlaySettings[OverlayType::ALL] = OverlayState::DISABLED;
-			statusOverlaySettings[OverlayType::FLAGSHIP] = OverlayState::ON;
-			statusOverlaySettings[OverlayType::ESCORT] = OverlayState::ON;
-			statusOverlaySettings[OverlayType::ENEMY] = OverlayState::ON;
-			statusOverlaySettings[OverlayType::NEUTRAL] = OverlayState::OFF;
-		}
 		settings.erase(it);
 	}
 }

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -214,7 +214,14 @@ void Preferences::Load()
 	it = settings.find("Show status overlays");
 	if(it != settings.end())
 	{
-		statusOverlaySettings[OverlayType::ALL] = it->second ? OverlayState::ON : OverlayState::OFF;
+		if(it->second)
+		{
+			statusOverlaySettings[OverlayType::ALL] = OverlayState::DISABLED;
+			statusOverlaySettings[OverlayType::FLAGSHIP] = OverlayState::ON;
+			statusOverlaySettings[OverlayType::ESCORT] = OverlayState::ON;
+			statusOverlaySettings[OverlayType::ENEMY] = OverlayState::ON;
+			statusOverlaySettings[OverlayType::NEUTRAL] = OverlayState::OFF;
+		}
 		settings.erase(it);
 	}
 }

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -104,9 +104,9 @@ namespace {
 
 	map<Preferences::OverlayType, OverlaySetting> statusOverlaySettings = {
 		{Preferences::OverlayType::ALL, Preferences::OverlayState::DISABLED},
-		{Preferences::OverlayType::FLAGSHIP, Preferences::OverlayState::ON},
-		{Preferences::OverlayType::ESCORT, Preferences::OverlayState::ON},
-		{Preferences::OverlayType::ENEMY, Preferences::OverlayState::ON},
+		{Preferences::OverlayType::FLAGSHIP, Preferences::OverlayState::OFF},
+		{Preferences::OverlayType::ESCORT, Preferences::OverlayState::OFF},
+		{Preferences::OverlayType::ENEMY, Preferences::OverlayState::OFF},
 		{Preferences::OverlayType::NEUTRAL, Preferences::OverlayState::OFF},
 	};
 
@@ -214,8 +214,7 @@ void Preferences::Load()
 	it = settings.find("Show status overlays");
 	if(it != settings.end())
 	{
-		if(!it->second)
-			statusOverlaySettings[OverlayType::ALL] = OverlayState::OFF;
+		statusOverlaySettings[OverlayType::ALL] = it->second ? OverlayState::ON : OverlayState::OFF;
 		settings.erase(it);
 	}
 }

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -103,7 +103,7 @@ namespace {
 	const vector<string> OverlaySetting::OVERLAY_SETTINGS = {"off", "always on", "damaged", "--"};
 
 	map<Preferences::OverlayType, OverlaySetting> statusOverlaySettings = {
-		{Preferences::OverlayType::ALL, Preferences::OverlayState::DISABLED},
+		{Preferences::OverlayType::ALL, Preferences::OverlayState::OFF},
 		{Preferences::OverlayType::FLAGSHIP, Preferences::OverlayState::OFF},
 		{Preferences::OverlayType::ESCORT, Preferences::OverlayState::OFF},
 		{Preferences::OverlayType::ENEMY, Preferences::OverlayState::OFF},


### PR DESCRIPTION
## Feature Details

Makes the status overlays off by default, and fixes the logic that converts the old preference to the newer name

## Testing Done

Tested this with the three possible variations (new preference file, old preference file "on", old preference file "off")