### PR TITLE
[Balance] Buff Stock Fighter Kits

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2396,8 +2396,8 @@ ship "Lance"
 	engine -14.5 30.5 0.5
 	engine 14.5 30.5 0.5
 	gun -13.5 -6.5 "Sidewinder Missile Pod"
-	gun 13.5 -6.5 "Energy Blaster"
-	gun 0 -34 "Sidewinder Missile Pod"
+	gun 13.5 -6.5 "Sidewinder Missile Pod"
+	gun 0 -34 "Energy Blaster"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description "The Lance is the primary fighter used by the Republic Navy. As with all fighters, it is weak by itself but very effective as part of a larger squadron."

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1448,12 +1448,12 @@ ship "Dagger"
 			"hit force" 180
 	outfits
 		"Beam Laser"
-		"Javelin Mini Pod"
-		"Javelin" 40
+		"Javelin Mini Pod" 2
+		"Javelin" 80
 		
 		"nGVF-AA Fuel Cell"
 		"Supercapacitor"
-		"D14-RN Shield Generator"
+		"D23-QP Shield Generator"
 		"Small Radar Jammer"
 		
 		"X1700 Ion Thruster"
@@ -1461,9 +1461,9 @@ ship "Dagger"
 		
 	engine -8 34
 	engine 8 34
-	gun -11 -21 "Beam Laser"
-	gun 11 -21 "Javelin Mini Pod"
-	gun 0 -35
+	gun -11 -21 "Javelin Mini Pod"
+	gun 11 -21 "Beam Laser"
+	gun 0 -35 "Javelin Mini Pod"
 	leak "leak" 60 50
 	explode "tiny explosion" 15
 	explode "small explosion" 5
@@ -1675,8 +1675,9 @@ ship "Finch"
 			"hit force" 180
 	outfits
 		"Beam Laser"
-		"Javelin Mini Pod"
-		"Javelin" 40
+		"Javelin Mini Pod" 2
+		"Javelin Storage Crate"
+		"Javelin" 180
 		
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
@@ -1687,9 +1688,9 @@ ship "Finch"
 		
 	engine -5 32
 	engine 5 32
-	gun -7 -14 "Beam Laser"
-	gun 7 -14 "Javelin Mini Pod"
-	gun 0 -31.5
+	gun -7 -14 "Javelin Mini Pod"
+	gun 7 -14 "Beam Laser"
+	gun 0 -31.5 "Javelin Mini Pod"
 	leak "flame" 60 80
 	explode "tiny explosion" 15
 	explode "small explosion" 5
@@ -2380,11 +2381,12 @@ ship "Lance"
 			"hit force" 180
 	outfits
 		"Energy Blaster"
-		"Sidewinder Missile Pod"
-		"Sidewinder Missile" 4
+		"Sidewinder Missile Pod" 2
+		"Sidewinder Missile Rack"
+		"Sidewinder Missile" 31
 		
 		"nGVF-AA Fuel Cell"
-		"LP036a Battery Pack"
+		"Supercapacitor" 4
 		"D14-RN Shield Generator"
 		"Small Radar Jammer" 2
 		
@@ -2393,9 +2395,9 @@ ship "Lance"
 		
 	engine -14.5 30.5 0.5
 	engine 14.5 30.5 0.5
-	gun -13.5 -6.5 "Energy Blaster"
-	gun 13.5 -6.5 "Sidewinder Missile Pod"
-	gun 0 -34
+	gun -13.5 -6.5 "Sidewinder Missile Pod"
+	gun 13.5 -6.5 "Energy Blaster"
+	gun 0 -34 "Sidewinder Missile Pod"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description "The Lance is the primary fighter used by the Republic Navy. As with all fighters, it is weak by itself but very effective as part of a larger squadron."

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1689,8 +1689,8 @@ ship "Finch"
 	engine -5 32
 	engine 5 32
 	gun -7 -14 "Javelin Mini Pod"
-	gun 7 -14 "Beam Laser"
-	gun 0 -31.5 "Javelin Mini Pod"
+	gun 7 -14 "Javelin Mini Pod"
+	gun 0 -31.5 "Beam Laser"
 	leak "flame" 60 80
 	explode "tiny explosion" 15
 	explode "small explosion" 5

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1462,8 +1462,8 @@ ship "Dagger"
 	engine -8 34
 	engine 8 34
 	gun -11 -21 "Javelin Mini Pod"
-	gun 11 -21 "Beam Laser"
-	gun 0 -35 "Javelin Mini Pod"
+	gun 11 -21 "Javelin Mini Pod"
+	gun 0 -35 "Beam Laser"
 	leak "leak" 60 50
 	explode "tiny explosion" 15
 	explode "small explosion" 5


### PR DESCRIPTION
## Summary
This change addresses one of the major problems introduced via pull request #6203, that being that almost all human fighters have received a direct nerf in their efficacy in combat due to underutilized weapon space. With the additional hardpoints added to (most) human fighters in #8469, no tweaks were made to the kits, so this PR attempts to remedy the nerf to human combat fighters due to the former PR.

## Reasoning
I've changed 3 ships in this PR, and only the stock variants: The Finch, the Dagger, and the Lance.

1) The Finch has received a second Javelin Pod and a Javelin Storage crate with no other changes. The reason for this is that the Finch is supposed to be a "top tier fighter", so doubling down on firepower would allow it to better go toe-to-toe with other fighters and small ships.

2) The Dagger has received a second Javelin Pod, like the Finch, but instead of gaining a storage outfit, now carries a D23-QP shield generator over its original D14 version. This change is twofold: While it also buffs the fighter's damage potential, it also differentiates it from the Finch, and reinforces the theme that Lionheart's ships often rely on tougher shields to compensate for lighter hull designs.

3) The Lance has lost its LP036a Battery Pack in favour of 4 Supercapacitors, allowing it to fit not only a second Sidewinder Pod, but a Sidewinder Storage Rack as well. The Lance, being the Navy's combat fighter of choice, relies on its long-ranged damage potential to be an effective combatant (in tandem with combat drones and other navy ships). As such, this change reinforces that role, doubling the fighter's burst damage potential and allowing it to belt out burst after burst without needing a tactical reload every few seconds.

## Save File
N/A