### PR TITLE
Add text reminding player to hail Greenrock in the 'Deal Change' missions

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5408,7 +5408,7 @@ mission "Deal Change 2"
 			`	You open your mouth as you lift yourself up, only to find that the other person is already gone. As you look around, you spot a piece of paper with writing lying on the ground beside you. You pick up the note and read it:`
 			``
 			`<first> <last>,`
-			`		You are currently carrying five tons of cargo to Skymoot. This cargo has been described to you as an "inheritance," and you have been promised 100,000 credits as payment for the job. Under no circumstances should you allow the cargo to reach the destination. Instead, bring it to <destination>. You will be paid <payment> if you do so. The back of this note has a code you can use to pass through spaceport security.`
+			`		You are currently carrying five tons of cargo to Skymoot. This cargo has been described to you as an "inheritance," and you have been promised 100,000 credits as payment for the job. Under no circumstances should you allow the cargo to reach the destination. Instead, bring it to <destination>. You will be paid <payment> if you do so. The back of this note has a code you can use to gain clearance to land without the usual toll.`
 			``
 			`	You flip the paper over and see a string of letters and numbers. The note has no signature, nor anything else to identify the person who wrote it.`
 			choice

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5391,7 +5391,7 @@ mission "Deal Change 1"
 mission "Deal Change 2"
 	landing
 	name "Inheritance to <planet>"
-	description "Instead of bringing the inheritance to Skymoot, deliver it to <destination>. You were promised <payment> for doing so. To bypass <planet>'s spaceport toll, hail <planet> and read out the code to the spaceport authority."
+	description "Instead of bringing the inheritance to Skymoot, deliver it to <destination>. You were promised <payment> for doing so. To bypass the spaceport toll, hail <planet> and read out the code to the spaceport authority."
 	source
 		attributes "dirt belt" "south" "rim"
 		not planet "Greenrock"

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5391,7 +5391,7 @@ mission "Deal Change 1"
 mission "Deal Change 2"
 	landing
 	name "Inheritance to <planet>"
-	description "Instead of bringing the inheritance to Skymoot, deliver it to <destination>. You were promised <payment> for doing so."
+	description "Instead of bringing the inheritance to Skymoot, deliver it to <destination>. You were promised <payment> for doing so. To bypass <planet>'s spaceport toll, hail <planet> and read out the code to the spaceport authority."
 	source
 		attributes "dirt belt" "south" "rim"
 		not planet "Greenrock"


### PR DESCRIPTION
## Fix Details
This PR partially addresses #8838 by adding a sentence to the mission description about hailing the spaceport authorities to land.

## Testing Done
Just need to check the new sentence fits the description box in game. It should do.

## Other Solutions
There are other solutions like adding an `on enter` dialogue box pop up when you enter Shaula. But I couldn't think of anything that would fit well, especially if I had to tell the player to hit `shift + T` while selecting Greenrock.