### PR TITLE
feat(ui): Display the government name on the planet card

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -185,10 +185,10 @@ interface "map detail panel"
 interface "map planet card"
 	value "text start" 13
 	value "category size" 20
-	value "height" 150
+	value "categories" 5
+	value "extra height" 30
 	value "width" 235
 	value "planet icon max size" 100
-	value "categories" 6
 
 
 

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -185,10 +185,10 @@ interface "map detail panel"
 interface "map planet card"
 	value "text start" 13
 	value "category size" 20
-	value "height" 130
+	value "height" 150
 	value "width" 235
 	value "planet icon max size" 100
-	value "categories" 5
+	value "categories" 6
 
 
 

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -186,7 +186,7 @@ interface "map planet card"
 	value "text start" 13
 	value "category size" 20
 	value "categories" 5
-	value "extra height" 30
+	value "height padding" 30
 	value "width" 235
 	value "planet icon max size" 100
 

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -190,8 +190,7 @@ bool MapDetailPanel::Scroll(double dx, double dy)
 // Only override the ones you need; the default action is to return false.
 bool MapDetailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
-	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
-	const double planetCardHeight = planetCardInterface->GetValue("height");
+	const double planetCardHeight = MapPlanetCard::Height();
 	if((key == SDLK_TAB || command.Has(Command::JUMP)) && player.Flagship())
 	{
 		// Clear the selected planet, if any.
@@ -347,7 +346,7 @@ bool MapDetailPanel::Click(int x, int y, int clicks)
 	const double planetCardWidth = planetCardInterface->GetValue("width");
 	const Interface *mapInterface = GameData::Interfaces().Get("map detail panel");
 	const double arrowOffset = mapInterface->GetValue("arrow x offset");
-	const double planetCardHeight = planetCardInterface->GetValue("height");
+	const double planetCardHeight = MapPlanetCard::Height();
 	if(x < Screen::Left() + 160)
 	{
 		// The player clicked in the left-hand interface. This could be the system
@@ -481,6 +480,7 @@ void MapDetailPanel::GeneratePlanetCards(const System &system)
 	planetCards.clear();
 	SetScroll(0.);
 	unsigned number = 0;
+	MapPlanetCard::ResetSize();
 	for(const StellarObject &object : system.Objects())
 		if(object.HasSprite() && object.HasValidPlanet())
 		{
@@ -647,7 +647,7 @@ void MapDetailPanel::DrawInfo()
 	const Color &back = *GameData::Colors().Get("map side panel background");
 
 	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
-	double planetHeight = planetCardInterface->GetValue("height");
+	double planetCardHeight = MapPlanetCard::Height();
 	double planetWidth = planetCardInterface->GetValue("width");
 	const Interface *mapInterface = GameData::Interfaces().Get("map detail panel");
 	double minPlanetPanelHeight = mapInterface->GetValue("min planet panel height");
@@ -661,7 +661,7 @@ void MapDetailPanel::DrawInfo()
 	// Draw the panel for the planets. If the system was not visited, no planets will be shown.
 	const double minimumSize = max(minPlanetPanelHeight, Screen::Height() - bottomGovY - systemSprite->Height());
 	planetPanelHeight = hasVisited ? min(min(minimumSize, maxPlanetPanelHeight),
-		(planetCards.size()) * planetHeight) : 0.;
+		(planetCards.size()) * planetCardHeight) : 0.;
 	Point size(planetWidth, planetPanelHeight);
 	// This needs to fill from the start of the screen.
 	FillShader::Fill(Screen::TopLeft() + Point(size.X() / 2., size.Y() / 2.),
@@ -680,10 +680,10 @@ void MapDetailPanel::DrawInfo()
 			// Fit another planet, if we can, also give scrolling freedom to reach the planets at the end.
 			// This updates the location of the card so it needs to be called before AvailableSpace().
 			card.DrawIfFits(uiPoint);
-			uiPoint.Y() += planetHeight;
+			uiPoint.Y() += planetCardHeight;
 
 			// Do this all of the time so we can scroll if an element is partially shown.
-			maxScroll += (planetHeight - card.AvailableSpace());
+			maxScroll += (planetCardHeight - card.AvailableSpace());
 		}
 
 		// Edges:

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -50,7 +50,7 @@ MapPlanetCard::MapPlanetCard(const StellarObject &object, unsigned number, bool 
 	governmentName = planet->GetGovernment()->GetName();
 	if(systemGovernmentName.empty())
 		systemGovernmentName = planet->GetSystem()->GetGovernment()->GetName();
-	if(planet->GetGovernment()->GetName() != "Uninhabited" && governmentName != systemGovernmentName)
+	if(governmentName != "Uninhabited" && governmentName != systemGovernmentName)
 		hasGovernments = true;
 
 	if(!hasSpaceport)

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -35,8 +35,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 using namespace std;
 
-std::string MapPlanetCard::systemGovernmentName;
-bool MapPlanetCard::hasGovernments = false;
+namespace {
+	bool hasGovernments = false;
+}
 
 
 
@@ -48,8 +49,7 @@ MapPlanetCard::MapPlanetCard(const StellarObject &object, unsigned number, bool 
 	hasShipyard = planet->HasShipyard();
 	hasOutfitter = planet->HasOutfitter();
 	governmentName = planet->GetGovernment()->GetName();
-	if(systemGovernmentName.empty())
-		systemGovernmentName = planet->GetSystem()->GetGovernment()->GetName();
+	string systemGovernmentName = planet->GetSystem()->GetGovernment()->GetName();
 	if(governmentName != "Uninhabited" && governmentName != systemGovernmentName)
 		hasGovernments = true;
 
@@ -277,7 +277,6 @@ double MapPlanetCard::Height()
 
 void MapPlanetCard::ResetSize()
 {
-	systemGovernmentName.clear();
 	hasGovernments = false;
 }
 

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -43,6 +43,7 @@ MapPlanetCard::MapPlanetCard(const StellarObject &object, unsigned number, bool 
 	hasSpaceport = planet->HasSpaceport();
 	hasShipyard = planet->HasShipyard();
 	hasOutfitter = planet->HasOutfitter();
+	governmentName = planet->GetGovernment()->GetName();
 
 	if(!hasSpaceport)
 		reputationLabel = "No Spaceport";
@@ -102,8 +103,9 @@ MapPlanetCard::ClickAction MapPlanetCard::Click(int x, int y, int clicks)
 			else
 				clickAction = ClickAction::SELECTED;
 
-			static const int SHOW[4] = {MapPanel::SHOW_REPUTATION, MapPanel::SHOW_SHIPYARD,
-										MapPanel::SHOW_OUTFITTER, MapPanel::SHOW_VISITED};
+			static const int SHOW[5] = {MapPanel::SHOW_GOVERNMENT, MapPanel::SHOW_REPUTATION,
+										MapPanel::SHOW_SHIPYARD, MapPanel::SHOW_OUTFITTER,
+										MapPanel::SHOW_VISITED};
 			if(clickAction != ClickAction::SELECTED)
 			{
 				clickAction = static_cast<ClickAction>(SHOW[selectedCategory]);
@@ -182,23 +184,26 @@ bool MapPlanetCard::DrawIfFits(const Point &uiPoint)
 		};
 
 		// Draw the name of the planet.
-		if(FitsCategory(5.))
+		if(FitsCategory(6.))
 			font.Draw({ planetName, alignLeft }, uiPoint + Point(0, textStart), isSelected ? medium : dim);
 
-		// Draw the reputation, shipyard, outfitter and visited.
+		// Draw the government name, reputation, shipyard, outfitter and visited.
 		const double margin = mapInterface->GetValue("text margin");
+		if(FitsCategory(5.))
+			font.Draw(governmentName, uiPoint + Point(margin, textStart + categorySize),
+				governmentName == "Uninhabited" ? faint : medium);
 		if(FitsCategory(4.))
-			font.Draw(reputationLabel, uiPoint + Point(margin, textStart + categorySize),
+			font.Draw(reputationLabel, uiPoint + Point(margin, textStart + categorySize * 2.),
 				hasSpaceport ? medium : faint);
 		if(FitsCategory(3.))
-			font.Draw("Shipyard", uiPoint + Point(margin, textStart + categorySize * 2.),
+			font.Draw("Shipyard", uiPoint + Point(margin, textStart + categorySize * 3.),
 				hasShipyard ? medium : faint);
 		if(FitsCategory(2.))
-			font.Draw("Outfitter", uiPoint + Point(margin, textStart + categorySize * 3.),
+			font.Draw("Outfitter", uiPoint + Point(margin, textStart + categorySize * 4.),
 				hasOutfitter ? medium : faint);
 		if(FitsCategory(1.))
 			font.Draw(hasVisited ? "(has been visited)" : "(not yet visited)",
-				uiPoint + Point(margin, textStart + categorySize * 4.), dim);
+				uiPoint + Point(margin, textStart + categorySize * 5.), dim);
 
 		// Draw the arrow pointing to the selected category.
 		if(FitsCategory(categories - (selectedCategory + 1.)))

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -268,7 +268,7 @@ void MapPlanetCard::Select(bool select)
 double MapPlanetCard::Height()
 {
 	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
-	return planetCardInterface->GetValue("extra height") +
+	return planetCardInterface->GetValue("height padding") +
 		(planetCardInterface->GetValue("categories") + hasGovernments) *
 		planetCardInterface->GetValue("category size");
 }

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -200,7 +200,7 @@ bool MapPlanetCard::DrawIfFits(const Point &uiPoint)
 		const double margin = mapInterface->GetValue("text margin");
 		if(hasGovernments && FitsCategory(categories))
 			font.Draw(governmentName, uiPoint + Point(margin, textStart + categorySize),
-				governmentName == "Uninhabited" ? faint : medium);
+				governmentName == "Uninhabited" ? faint : dim);
 		if(FitsCategory(4.))
 			font.Draw(reputationLabel, uiPoint + Point(margin, textStart + categorySize * (1. + hasGovernments)),
 				hasSpaceport ? medium : faint);

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -29,8 +29,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Politics.h"
 #include "Screen.h"
 #include "SpriteShader.h"
-#include "System.h"
 #include "StellarObject.h"
+#include "System.h"
 #include "text/WrappedText.h"
 
 using namespace std;

--- a/source/MapPlanetCard.h
+++ b/source/MapPlanetCard.h
@@ -31,6 +31,7 @@ class StellarObject;
 class MapPlanetCard {
 public:
 	enum class ClickAction : int {
+		SHOW_GOVERNMENT = MapPanel::SHOW_GOVERNMENT,
 		SHOW_REPUTATION = MapPanel::SHOW_REPUTATION,
 		SHOW_SHIPYARD = MapPanel::SHOW_SHIPYARD,
 		SHOW_OUTFITTER = MapPanel::SHOW_OUTFITTER,
@@ -86,6 +87,7 @@ private:
 	const Sprite *sprite;
 	float spriteScale;
 
+	std::string governmentName;
 	std::string reputationLabel;
 	const std::string &planetName;
 	// The currently select category (outfitter, shipyard, ...)

--- a/source/MapPlanetCard.h
+++ b/source/MapPlanetCard.h
@@ -61,6 +61,9 @@ public:
 
 	void Select(bool select = true);
 
+	static double Height();
+
+	static void ResetSize();
 
 protected:
 	// Highlight this card; this is to be called when it is selected.
@@ -92,6 +95,9 @@ private:
 	const std::string &planetName;
 	// The currently select category (outfitter, shipyard, ...)
 	unsigned selectedCategory = 0;
+
+	static std::string systemGovernmentName;
+	static bool hasGovernments;
 };
 
 

--- a/source/MapPlanetCard.h
+++ b/source/MapPlanetCard.h
@@ -95,9 +95,6 @@ private:
 	const std::string &planetName;
 	// The currently select category (outfitter, shipyard, ...)
 	unsigned selectedCategory = 0;
-
-	static std::string systemGovernmentName;
-	static bool hasGovernments;
 };
 
 

--- a/source/MapPlanetCard.h
+++ b/source/MapPlanetCard.h
@@ -65,6 +65,7 @@ public:
 
 	static void ResetSize();
 
+
 protected:
 	// Highlight this card; this is to be called when it is selected.
 	void Highlight(double availableSpace) const;


### PR DESCRIPTION
**Feature:** This PR resolves #4022
## Feature Details
The name of the planet's government is now displayed on the planet card (map UI), above the friendliness line. Selecting the entry activates the government map mode.

This is enabled for systems that have a planet with government different from that of the system (planets with the special "Uninhabited" government aren't considered).

## UI Screenshots
<details>
<summary>Before</summary>

![b1](https://github.com/endless-sky/endless-sky/assets/108272452/594819f6-086c-4e60-9437-ef414638d09f)

![b2](https://github.com/endless-sky/endless-sky/assets/108272452/bc642032-8e52-418a-aff0-1d3b68029cf9)
</details>

<details>
<summary>After</summary>

![a1](https://github.com/endless-sky/endless-sky/assets/108272452/26b77241-85ac-4070-b0f7-4c259f07454c)
(no difference here)

![tarazed](https://github.com/endless-sky/endless-sky/assets/108272452/aebca989-3b00-452b-95dd-ebc9b39ec2e4)
</details>

## Testing Done
Displays correctly, selecting works.

## Performance Impact
N/A