### PR TITLE
fixed cargo capacity calculation when landing

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1471,7 +1471,7 @@ void PlayerInfo::Land(UI *ui)
 			else
 				ship->Recharge(false);
 		}
-	// do this after updating ship locations (above)
+	// Cargo management needs to be done after updating ship locations (above).
 	UpdateCargoCapacities();
 	// Ships that are landed with you on the planet should pool all their cargo together.
 	for(const shared_ptr<Ship> &ship : ships)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1471,6 +1471,7 @@ void PlayerInfo::Land(UI *ui)
 			else
 				ship->Recharge(false);
 		}
+
 	// Cargo management needs to be done after updating ship locations (above).
 	UpdateCargoCapacities();
 	// Ships that are landed with you on the planet should pool all their cargo together.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1435,11 +1435,9 @@ void PlayerInfo::Land(UI *ui)
 	for(const shared_ptr<Ship> &ship : ships)
 		ship->UnloadBays();
 
-	// Ships that are landed with you on the planet should fully recharge
-	// and pool all their cargo together. Those in remote systems restore
-	// what they can without landing.
+	// Ships that are landed with you on the planet should fully recharge.
+	// Those in remote systems restore what they can without landing.
 	bool hasSpaceport = planet->HasSpaceport() && planet->CanUseServices();
-	UpdateCargoCapacities();
 	for(const shared_ptr<Ship> &ship : ships)
 		if(!ship->IsParked() && !ship->IsDisabled())
 		{
@@ -1448,7 +1446,6 @@ void PlayerInfo::Land(UI *ui)
 				if(planet->CanLand(*ship))
 				{
 					ship->Recharge(hasSpaceport);
-					ship->Cargo().TransferAll(cargo);
 					if(!ship->GetPlanet())
 						ship->SetPlanet(planet);
 				}
@@ -1474,6 +1471,12 @@ void PlayerInfo::Land(UI *ui)
 			else
 				ship->Recharge(false);
 		}
+	// do this after updating ship locations (above)
+	UpdateCargoCapacities();
+	// Ships that are landed with you on the planet should pool all their cargo together.
+	for(const shared_ptr<Ship> &ship : ships)
+		if(ship->GetPlanet() == planet && !ship->IsParked())
+			ship->Cargo().TransferAll(cargo);
 	// Adjust cargo cost basis for any cargo lost due to a ship being destroyed.
 	for(const auto &it : lostCargo)
 		AdjustBasis(it.first, -(costBasis[it.first] * it.second) / (cargo.Get(it.first) + it.second));


### PR DESCRIPTION
NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!)

-----------------------
**Bugfix:** (I found the bug, and made this patch rather than file a bug report)

## Fix Details
When landing, this moves the player cargo hold size calculation and shifting cargo from ship cargo holds to the player cargo hold to after the ships' locations are updated to point to the planet.

## Testing Done
It's a simple fix, I did not do extensive testing.  Having cargo, departing from a planet and immediately landing worked correctly (cargo was found).  Jumping to a new system and landing also worked.

## Save File
[Aria Schafer.txt](https://github.com/endless-sky/endless-sky/files/11850127/Aria.Schafer.txt)

The bug will occur when using https://github.com/endless-sky/endless-sky/commit/0447506d7b113b94b09d80fdf845d56452122f45, and will not occur when using this branch's build.

