### PR TITLE
fix(content): Add `inscrutable` to Astral Cetaceans

### DIFF
--- a/data/vyrmeid/vyrmeid.txt
+++ b/data/vyrmeid/vyrmeid.txt
@@ -201,6 +201,7 @@ ship "Astral Cetacean"
 		"ramscoop" 5
 		"energy capacity" 2000
 		"energy generation" 160
+		"inscrutable" 1
 
 		"thrust" 24
 		"flare sound" "astral cetacean"

--- a/data/vyrmeid/vyrmeid.txt
+++ b/data/vyrmeid/vyrmeid.txt
@@ -34,11 +34,11 @@ ship "Vyrmeid"
 		"outfit space" 0
 		"weapon capacity" 0
 		"engine capacity" 0
+		"inscrutable" 1
 
 		"hull repair rate" 1
 		"energy capacity" 100
 		"energy generation" 1
-		"inscrutable" 1
 		
 		"thrust" 10
 		"turn" 120
@@ -91,9 +91,9 @@ ship "Vyrmeid" "Vyrmeid (B)"
 		"outfit space" 10
 		"weapon capacity" 0
 		"engine capacity" 0
+		"inscrutable" 1
 
 		"hull repair rate" 1
-		"inscrutable" 1
 
 		"thrust" 12
 		"turn" 60
@@ -142,10 +142,10 @@ ship "Vyrmeid" "Vyrmeid (C)"
 		"outfit space" 0
 		"weapon capacity" 0
 		"engine capacity" 0
+		"inscrutable" 1
 
 		"energy capacity" 1000
 		"energy generation" 100
-		"inscrutable" 1
 
 		"thrust" 6
 		"turn" 80
@@ -196,12 +196,12 @@ ship "Astral Cetacean"
 		"outfit space" 0
 		"weapon capacity" 0
 		"engine capacity" 0
+		"inscrutable" 1
 
 		"hull repair rate" 3
 		"ramscoop" 5
 		"energy capacity" 2000
 		"energy generation" 160
-		"inscrutable" 1
 
 		"thrust" 24
 		"flare sound" "astral cetacean"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Resolves https://github.com/endless-sky/endless-sky/issues/8947 by adding `inscrutable` so you can't actually see the internals of Astral Cetaceans.

## Save File
Have fun and go find one and scan them! (If you really need a save I can make one.)