### PR TITLE
Update TradingPanel.cpp (sell-all)

### DIFF
--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -238,19 +238,18 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	{
 		for(const auto &it : player.Cargo().Commodities())
 		{
-			int64_t amount = it.second;
 			int64_t price = system.Trade(it.first);
-			if(!price || !amount)
+			if(!price || !it.second)
 				continue;
 
-			int64_t basis = player.GetBasis(it.first, -amount);
-			player.AdjustBasis(it.first, basis);
-			profit += amount * price + basis;
-			tonsSold += amount;
+			int64_t basis = player.GetBasis(it.first, -it.second);
+			profit += it.second * price + basis;
+			tonsSold += it.second;
 
-			player.Accounts().AddCredits(amount * price);
-			player.Cargo().Remove(it.first, amount);
-			GameData::AddPurchase(system, it.first, -amount);
+			GameData::AddPurchase(system, it.first, -it.second);
+			player.AdjustBasis(it.first, basis);
+			player.Accounts().AddCredits(it.second * price);
+			player.Cargo().Remove(it.first, it.second);
 		}
 		int day = player.GetDate().DaysSinceEpoch();
 		for(const auto &it : player.Cargo().Outfits())

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -238,7 +238,7 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	{
 		for(const auto &it : player.Cargo().Commodities())
 		{
-			const std::string &commodity = it.first;
+			const string &commodity = it.first;
 			const int64_t &amount = it.second;
 			int64_t price = system.Trade(commodity);
 			if(!price || !amount)

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -236,21 +236,21 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 		Buy(1000000000);
 	else if(key == 'S' || (key == 's' && (mod & KMOD_SHIFT)))
 	{
-		for(const auto &it : GameData::Commodities())
+		for(const auto &it : player.Cargo().Commodities())
 		{
-			int64_t amount = player.Cargo().Get(it.name);
-			int64_t price = system.Trade(it.name);
+			int64_t amount = it.second;
+			int64_t price = system.Trade(it.first);
 			if(!price || !amount)
 				continue;
 
-			int64_t basis = player.GetBasis(it.name, -amount);
-			player.AdjustBasis(it.name, basis);
+			int64_t basis = player.GetBasis(it.first, -amount);
+			player.AdjustBasis(it.first, basis);
 			profit += amount * price + basis;
 			tonsSold += amount;
 
-			player.Cargo().Remove(it.name, amount);
 			player.Accounts().AddCredits(amount * price);
-			GameData::AddPurchase(system, it.name, -amount);
+			player.Cargo().Remove(it.first, amount);
+			GameData::AddPurchase(system, it.first, -amount);
 		}
 		int day = player.GetDate().DaysSinceEpoch();
 		for(const auto &it : player.Cargo().Outfits())

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -238,32 +238,36 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	{
 		for(const auto &it : player.Cargo().Commodities())
 		{
-			int64_t price = system.Trade(it.first);
-			if(!price || !it.second)
+			const auto commodity = it.first;
+			const auto amount = it.second;
+			int64_t price = system.Trade(commodity);
+			if(!price || !amount)
 				continue;
 
-			int64_t basis = player.GetBasis(it.first, -it.second);
-			profit += it.second * price + basis;
-			tonsSold += it.second;
+			int64_t basis = player.GetBasis(commodity, -amount);
+			profit += amount * price + basis;
+			tonsSold += amount;
 
-			GameData::AddPurchase(system, it.first, -it.second);
-			player.AdjustBasis(it.first, basis);
-			player.Accounts().AddCredits(it.second * price);
-			player.Cargo().Remove(it.first, it.second);
+			GameData::AddPurchase(system, commodity, -amount);
+			player.AdjustBasis(commodity, basis);
+			player.Accounts().AddCredits(amount * price);
+			player.Cargo().Remove(commodity, amount);
 		}
 		int day = player.GetDate().DaysSinceEpoch();
 		for(const auto &it : player.Cargo().Outfits())
 		{
-			if(it.first->Get("minable") <= 0. && !sellOutfits)
+			const auto outfit = it.first;
+			const auto amount = it.second;
+			if(outfit->Get("minable") <= 0. && !sellOutfits)
 				continue;
 
-			int64_t value = player.FleetDepreciation().Value(it.first, day, it.second);
+			int64_t value = player.FleetDepreciation().Value(outfit, day, amount);
 			profit += value;
-			tonsSold += static_cast<int>(it.second * it.first->Mass());
+			tonsSold += static_cast<int>(amount * outfit->Mass());
 
-			player.AddStock(it.first, it.second);
+			player.AddStock(outfit, amount);
 			player.Accounts().AddCredits(value);
-			player.Cargo().Remove(it.first, it.second);
+			player.Cargo().Remove(outfit, amount);
 		}
 	}
 	else if(command.Has(Command::MAP))

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -256,7 +256,7 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 		int day = player.GetDate().DaysSinceEpoch();
 		for(const auto &it : player.Cargo().Outfits())
 		{
-			const Outfit * const &outfit = it.first;
+			const Outfit * const outfit = it.first;
 			const int64_t &amount = it.second;
 			if(outfit->Get("minable") <= 0. && !sellOutfits)
 				continue;

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -238,8 +238,8 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	{
 		for(const auto &it : player.Cargo().Commodities())
 		{
-			const auto commodity = it.first;
-			const auto amount = it.second;
+			const std::string commodity = it.first;
+			const int64_t amount = it.second;
 			int64_t price = system.Trade(commodity);
 			if(!price || !amount)
 				continue;
@@ -256,8 +256,8 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 		int day = player.GetDate().DaysSinceEpoch();
 		for(const auto &it : player.Cargo().Outfits())
 		{
-			const auto outfit = it.first;
-			const auto amount = it.second;
+			const Outfit *outfit = it.first;
+			const int64_t amount = it.second;
 			if(outfit->Get("minable") <= 0. && !sellOutfits)
 				continue;
 

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -238,8 +238,8 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	{
 		for(const auto &it : player.Cargo().Commodities())
 		{
-			const std::string commodity = it.first;
-			const int64_t amount = it.second;
+			const std::string &commodity = it.first;
+			const int64_t &amount = it.second;
 			int64_t price = system.Trade(commodity);
 			if(!price || !amount)
 				continue;
@@ -256,8 +256,8 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 		int day = player.GetDate().DaysSinceEpoch();
 		for(const auto &it : player.Cargo().Outfits())
 		{
-			const Outfit *outfit = it.first;
-			const int64_t amount = it.second;
+			const Outfit * &outfit = it.first;
+			const int64_t &amount = it.second;
 			if(outfit->Get("minable") <= 0. && !sellOutfits)
 				continue;
 

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -256,7 +256,7 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 		int day = player.GetDate().DaysSinceEpoch();
 		for(const auto &it : player.Cargo().Outfits())
 		{
-			const Outfit * &outfit = it.first;
+			const Outfit * const &outfit = it.first;
 			const int64_t &amount = it.second;
 			if(outfit->Get("minable") <= 0. && !sellOutfits)
 				continue;


### PR DESCRIPTION
Changed sell-all loop to only go over commodities in player's cargo, not all commodities in the game.  This now matches the following loop that sells all outfits in the player's cargo.

## Testing
Sell-all works normally, with a variety of commodities/outfits.