### PR TITLE
Separate flagship overlay colours

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -85,16 +85,16 @@ color "escort hostile" 1. .6 .4 1.
 # Colors used when "status overlays" are enabled, and to show scan progress.
 color "overlay flagship shields" 0. .5 0. .25
 color "overlay flagship hull" .45 .5 0. .25
-color "overlay flagship disabled" .5 0 0 .25
+color "overlay flagship disabled" .5 0. 0. .25
 color "overlay friendly shields" 0. .5 0. .25
 color "overlay friendly hull" .45 .5 0. .25
-color "overlay friendly disabled" .5 0 0 .25
+color "overlay friendly disabled" .5 0. 0. .25
 color "overlay hostile shields" .5 .15 0. .25
 color "overlay hostile hull" .5 .3 0. .25
-color "overlay hostile disabled" .3 .3 0 .25
+color "overlay hostile disabled" .3 .3 0. .25
 color "overlay neutral shields" .43 .55 .70 .75
 color "overlay neutral hull" .45 .5 0. .25
-color "overlay neutral disabled" .5 0 0 .25
+color "overlay neutral disabled" .5 0. 0. .25
 color "overlay outfit scan" .5 .5 .5 .25
 color "overlay cargo scan" .7 .7 .7 .25
 

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -83,6 +83,9 @@ color "escort selected" .2 .8 0. 1.
 color "escort hostile" 1. .6 .4 1.
 
 # Colors used when "status overlays" are enabled, and to show scan progress.
+color "overlay flagship shields" 0. .5 0. .25
+color "overlay flagship hull" .45 .5 0. .25
+color "overlay flagship disabled" .5 0 0 .25
 color "overlay friendly shields" 0. .5 0. .25
 color "overlay friendly hull" .45 .5 0. .25
 color "overlay friendly disabled" .5 0 0 .25

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2600,11 +2600,11 @@ void Engine::CreateStatusOverlays()
 		if(it == flagship)
 			EmplaceStatusOverlay(it, overlaySettings[Preferences::OverlayType::FLAGSHIP], 0);
 		else if(it->GetGovernment()->IsEnemy())
-			EmplaceStatusOverlay(it, overlaySettings[Preferences::OverlayType::ENEMY], 1);
+			EmplaceStatusOverlay(it, overlaySettings[Preferences::OverlayType::ENEMY], 2);
 		else if(it->IsYours() || it->GetPersonality().IsEscort())
-			EmplaceStatusOverlay(it, overlaySettings[Preferences::OverlayType::ESCORT], 0);
+			EmplaceStatusOverlay(it, overlaySettings[Preferences::OverlayType::ESCORT], 1);
 		else
-			EmplaceStatusOverlay(it, overlaySettings[Preferences::OverlayType::NEUTRAL], 2);
+			EmplaceStatusOverlay(it, overlaySettings[Preferences::OverlayType::NEUTRAL], 3);
 	}
 }
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1017,9 +1017,9 @@ void Engine::Draw() const
 			RingShader::Draw(pos, radius + 3., 1.5f, it.outer, color[it.type], 0.f, it.angle);
 		double dashes = (it.type >= 3) ? 0. : 20. * min(1., zoom);
 		if(it.inner > 0.)
-			RingShader::Draw(pos, radius, 1.5f, it.inner, color[4 + it.type], dashes, it.angle);
+			RingShader::Draw(pos, radius, 1.5f, it.inner, color[5 + it.type], dashes, it.angle);
 		if(it.disabled > 0.)
-			RingShader::Draw(pos, radius, 1.5f, it.disabled, color[8 + it.type], dashes, it.angle);
+			RingShader::Draw(pos, radius, 1.5f, it.disabled, color[10 + it.type], dashes, it.angle);
 	}
 
 	// Draw labels on missiles

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -995,15 +995,18 @@ void Engine::Draw() const
 
 	for(const auto &it : statuses)
 	{
-		static const Color color[11] = {
+		static const Color color[14] = {
+			*colors.Get("overlay flagship shields"),
 			*colors.Get("overlay friendly shields"),
 			*colors.Get("overlay hostile shields"),
 			*colors.Get("overlay neutral shields"),
 			*colors.Get("overlay outfit scan"),
+			*colors.Get("overlay flagship hull"),
 			*colors.Get("overlay friendly hull"),
 			*colors.Get("overlay hostile hull"),
 			*colors.Get("overlay neutral hull"),
 			*colors.Get("overlay cargo scan"),
+			*colors.Get("overlay flagship disabled"),
 			*colors.Get("overlay friendly disabled"),
 			*colors.Get("overlay hostile disabled"),
 			*colors.Get("overlay neutral disabled")

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -842,7 +842,7 @@ void Engine::Step(bool isActive)
 		double width = max(target->Width(), target->Height());
 		Point pos = target->Position() - center;
 		statuses.emplace_back(pos, flagship->OutfitScanFraction(), flagship->CargoScanFraction(),
-			0, 10. + max(20., width * .5), 2, Angle(pos).Degrees() + 180.);
+			0., 10. + max(20., width * .5), 4, Angle(pos).Degrees() + 180.);
 	}
 	// Handle any events that change the selected ships.
 	if(groupSelect >= 0)


### PR DESCRIPTION
**Feature:**

Inspired by #8955.

## Feature Details
This PR gives the flagship status overlay its own set of named colours, separate to the escort overlay colours, allows the flagship overlay colours to be customised without modifying the escort colours so they don't have to be the same.

Also, fixes a bug where the scan overlay constructor was not properly updated when the neutral status overlay colours were added resulting in the scan overlays currently using the `neutral overlay shields` for outfit scans and `neutral overlay hull` for cargo scan.

Also, changed an integer literal to a double literal (`0` -> `0.`) to match the value it is passed as.

Also, adds some trialing decimal points to zeroes for consistency with all the other colour definitions.

## UI Screenshots
<details> <summary>Demonstrating the scan ring colour bug:</summary>

Current:
![image](https://github.com/endless-sky/endless-sky/assets/20605679/0a141199-9820-43e7-8e64-af93a8f16206)
With the colours:
```
color "overlay friendly shields" 0. .5 0. .25
color "overlay friendly hull" .45 .5 0. .25
color "overlay friendly disabled" .5 0 0 .25
color "overlay hostile shields" .5 .15 0. .25
color "overlay hostile hull" .5 .3 0. .25
color "overlay hostile disabled" .3 .3 0 .25
#color "overlay neutral shields" .43 .55 .70 .75
#color "overlay neutral hull" .45 .5 0. .25
color "overlay neutral shields" 0. 0. 1. .75
color "overlay neutral hull" 1. 0. 0. .25
color "overlay neutral disabled" .5 0 0 .25
color "overlay outfit scan" .5 .5 .5 .25
color "overlay cargo scan" .7 .7 .7 .25
```
The red neutral hull colour is being used for the cargo scan ring and the blue neutral shields colour for the outfit scan ring.

With this PR:
![image](https://github.com/endless-sky/endless-sky/assets/20605679/d982a5e7-ebf8-4988-aa11-7fcb1fc12496)
Colours:
```
color "overlay flagship shields" 0. .5 0. .25
color "overlay flagship hull" .45 .5 0. .25
color "overlay flagship disabled" .5 0 0 .25
color "overlay friendly shields" 0. .5 0. .25
color "overlay friendly hull" .45 .5 0. .25
color "overlay friendly disabled" .5 0 0 .25
color "overlay hostile shields" .5 .15 0. .25
color "overlay hostile hull" .5 .3 0. .25
color "overlay hostile disabled" .3 .3 0 .25
#color "overlay neutral shields" .43 .55 .70 .75
#color "overlay neutral hull" .45 .5 0. .25
color "overlay neutral shields" 0. 0. 1. .75
color "overlay neutral hull" 1. 0. 0. .25
color "overlay neutral disabled" .5 0 0 .25
color "overlay outfit scan" .5 .5 .5 .25
color "overlay cargo scan" .7 .7 .7 .25
```
The neutral overlay colours are no longer being used for the scan rings.
</details>

<details> <summary>Flagship overlay colours different to escort status overlay:</summary>

![image](https://github.com/endless-sky/endless-sky/assets/20605679/e3f9c7b5-4ccc-4a14-99d2-c877060c55b9)

Colours:
```
color "overlay flagship shields" 0. 0. 1. .25
color "overlay flagship hull" 1. 0. 0. .25
color "overlay flagship disabled" 1. 1. 0. .25
color "overlay friendly shields" 0. .5 0. .25
color "overlay friendly hull" .45 .5 0. .25
color "overlay friendly disabled" .5 0. 0. .25
color "overlay hostile shields" .5 .15 0. .25
color "overlay hostile hull" .5 .3 0. .25
color "overlay hostile disabled" .3 .3 0 .25
color "overlay neutral shields" .43 .55 .70 .75
color "overlay neutral hull" .45 .5 0. .25
color "overlay neutral disabled" .5 0. 0. .25
color "overlay outfit scan" .5 .5 .5 .25
color "overlay cargo scan" .7 .7 .7 .25
```

</details>

## Usage Examples
```
color "overlay flagship shields" 0. 0. 1. .25
color "overlay flagship hull" 1. 0. 0. .25
color "overlay flagship disabled" 1. 1. 0. .25
```

## Testing Done
Produced the screenshots above.

### Automated Tests Added
N/A

## Performance Impact
N/A
