### PR TITLE
A small refactor to planet selection for in-system escorts that can't land on the player's planet in PlayerInfo::Land

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1458,10 +1458,8 @@ void PlayerInfo::Land(UI *ui)
 					if(!landingObject)
 						landingObject = AI::FindLandingLocation(*ship, false);
 					if(landingObject)
-					{
 						ship->SetPlanet(landingObject->GetPlanet());
-						ship->Recharge(foundSpaceport);
-					}
+					ship->Recharge(foundSpaceport);
 				}
 			}
 			else

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1457,17 +1457,13 @@ void PlayerInfo::Land(UI *ui)
 				else
 				{
 					const StellarObject *landingObject = AI::FindLandingLocation(*ship);
+					const bool foundSpaceport = landingObject;
+					if(!landingObject)
+						landingObject = AI::FindLandingLocation(*ship, false);
 					if(landingObject)
 					{
 						ship->SetPlanet(landingObject->GetPlanet());
-						ship->Recharge();
-					}
-					else
-					{
-						landingObject = AI::FindLandingLocation(*ship, false);
-						if(landingObject)
-							ship->SetPlanet(landingObject->GetPlanet());
-						ship->Recharge(false);
+						ship->Recharge(foundSpaceport);
 					}
 				}
 			}


### PR DESCRIPTION
**Refactor:**

## Details
Shouldn't change the result of the code, just does it in a way that doesn't duplicate lines, doesn't nest as much, and I think is clearer.
