### PR TITLE
Bugfix: prevent negative value for bribes

### DIFF
--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -350,7 +350,10 @@ void HailPanel::SetBribe(double scale)
 	for(const shared_ptr<Ship> &it : player.Ships())
 		value += it->Cost();
 
+	if(value < 0)
+		value = 1;
+
 	bribe = 1000 * static_cast<int64_t>(sqrt(value) * scale);
-	if(scale && bribe <= 0)
+	if(scale && bribe)
 		bribe = 1000;
 }

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -351,6 +351,6 @@ void HailPanel::SetBribe(double scale)
 		value += it->Cost();
 
 	bribe = 1000 * static_cast<int64_t>(sqrt(value) * scale);
-	if(scale && !bribe)
+	if(scale && bribe <= 0)
 		bribe = 1000;
 }

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -354,6 +354,6 @@ void HailPanel::SetBribe(double scale)
 		value = 1;
 
 	bribe = 1000 * static_cast<int64_t>(sqrt(value) * scale);
-	if(scale && bribe)
+	if(scale && !bribe)
 		bribe = 1000;
 }

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -350,10 +350,8 @@ void HailPanel::SetBribe(double scale)
 	for(const shared_ptr<Ship> &it : player.Ships())
 		value += it->Cost();
 
-	if(value < 0)
+	if(value <= 0)
 		value = 1;
 
 	bribe = 1000 * static_cast<int64_t>(sqrt(value) * scale);
-	if(scale && !bribe)
-		bribe = 1000;
 }


### PR DESCRIPTION
**Bugfix:** This PR addresses not being able to land with bribes when your value is negative (with the shooting star having a negative cost)

## Fix Details
Just make sure the total value is at least 1, so we dont have negative bribe with sqrt of a negative int going on.

## Testing Done
this PR with that savefile (you can pay them to land just fine)
![image](https://github.com/endless-sky/endless-sky/assets/94366726/4ee6e2f9-80c9-42fb-ad9f-543f6962be4a)
master:
![image](https://github.com/endless-sky/endless-sky/assets/94366726/fdf2016d-a381-4921-869e-574649e9197b)
which you can't even pay
![image](https://github.com/endless-sky/endless-sky/assets/94366726/49ef04e2-b966-4c25-b85e-2c6d810531c5)

## Save File
[Isatrane_Reck.txt](https://github.com/endless-sky/endless-sky/files/11872182/Isatrane_Reck.txt)

