### PR TITLE
fix(ui): Fix map buttons overlapping on smaller screens

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1153,6 +1153,55 @@ interface "map buttons" bottom right
 		size 18
 
 
+interface "map buttons (small screen)" bottom right
+	active if "!is shipyards"
+	sprite "ui/wide button"
+		from -270 -40 to -160 -90
+	button s "_Shipyards"
+		from -260 -50 to -170 -80
+
+	active if "!is outfitters"
+	sprite "ui/wide button"
+		from -270 -50 to -160 0
+	button o "_Outfitters"
+		from -260 -40 to -170 -10
+
+	active if "!is missions"
+	sprite "ui/dialog cancel"
+		from -170 -40 to -80 -90
+	button i "M_issions"
+		from -160 -80 to -90 -50
+
+	active if "!is ports"
+	sprite "ui/dialog cancel"
+		from -170 -50 to -80 0
+	button p "_Ports"
+		from -160 -40 to -90 -10
+
+	active
+	sprite "ui/dialog cancel"
+		from -90 -50 to 0 0
+	button d "_Done"
+		from -80 -40 to -10 -10
+
+	active
+	sprite "ui/dialog cancel"
+		from 0 -40 to -90 -90
+	button f "_Find"
+		from -80 -80 to -10 -50
+
+	sprite "ui/zoom"
+		from 0 -80 to -90 -130
+	active if "!max zoom"
+	button + "_+"
+		from -10 -90 to -40 -120
+		size 18
+	active if "!min zoom"
+	button - "_-"
+		from -50 -90 to -80 -120
+		size 18
+
+
 
 interface "map"
 	value "max zoom" 2

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -274,7 +274,8 @@ void MapPanel::FinishDrawing(const string &buttonCondition)
 		info.SetCondition("max zoom");
 	if(player.MapZoom() <= static_cast<int>(mapInterface->GetValue("min zoom")))
 		info.SetCondition("min zoom");
-	const Interface *mapButtonUi = GameData::Interfaces().Get("map buttons");
+	const Interface *mapButtonUi = GameData::Interfaces().Get(Screen::Width() < 1280
+		? "map buttons (small screen)" : "map buttons");
 	mapButtonUi->Draw(info, this);
 
 	// Draw the tooltips.


### PR DESCRIPTION
**Bugfix:** This PR fixes #8888

## Fix Details
When the screen width is lower than 1280 px, the game reads positions of the mode buttons from a separate interface, displaying the buttons in two rows.

## Testing Done
You can set window size in the preferences file or just resize the game window.

## Save File
N/A