### PR TITLE
Wanderer outfits license patch

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -452,6 +452,19 @@ mission "Wanderers Conversation"
 
 
 
+# Compatibility patch for pilots that did the above missions before 0.9.7.
+mission "Wanderers: Outfit License Patch"
+	landing
+	invisible
+	to offer
+		has "Wanderers Conversation: offered"
+		not "license: Wanderer Outfits"
+	on offer
+		set "license: Wanderer Outfits"
+		fail
+
+
+
 mission "Tell Wanderers about the Pug"
 	landing
 	source "Vara K'chrai"


### PR DESCRIPTION
**Bugfix:**

Thanks to @Skeltek for reporting this.

## Fix Details
The original patch granting this license to saves that did the missions before it existed was broken when the point at which the license is granted was moved to a mission later. This PR adds a new patch mission that grants the license if the mission where it is supposed to be granted has occurred and the player does not have it.

## Testing Done
0

