### PR TITLE
planet check for ships, rather than system

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -127,7 +127,7 @@ void PlanetPanel::Draw()
 
 		if(planet.HasOutfitter())
 			for(const auto &it : player.Ships())
-				if(it->GetPlanet() == &planet && !it->IsDisabled())
+				if(it->GetPlanet() == &planet)
 				{
 					info.SetCondition("has outfitter");
 					break;
@@ -189,7 +189,7 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 	else if(key == 'o' && hasAccess && planet.HasOutfitter())
 	{
 		for(const auto &it : player.Ships())
-			if(it->GetPlanet() == &planet && !it->IsDisabled())
+			if(it->GetPlanet() == &planet)
 			{
 				GetUI()->Push(new OutfitterPanel(player));
 				return true;

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -127,7 +127,7 @@ void PlanetPanel::Draw()
 
 		if(planet.HasOutfitter())
 			for(const auto &it : player.Ships())
-				if(it->GetSystem() == &system && !it->IsDisabled())
+				if(it->GetPlanet() == &planet && !it->IsDisabled())
 				{
 					info.SetCondition("has outfitter");
 					break;
@@ -189,7 +189,7 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 	else if(key == 'o' && hasAccess && planet.HasOutfitter())
 	{
 		for(const auto &it : player.Ships())
-			if(it->GetSystem() == &system && !it->IsDisabled())
+			if(it->GetPlanet() == &planet && !it->IsDisabled())
 			{
 				GetUI()->Push(new OutfitterPanel(player));
 				return true;


### PR DESCRIPTION
**Refactor:**

## Fix Details
When checking to see if the outfitter can be accessed, see if non-disabled ships are present on the planet, rather than in the system, as only the former will always be available for outfitting.

## Testing Done
It's a pretty trivial change, and the ShopPanel::DrawShipsSidebar() code already does this check and won't display ships not on planet (doing the check in ShopPanel::CanShowInSideBar()).  So I just tried it out on a new game a saved game and it worked as expected.