### PR TITLE
Mortgage rounding fix

### DIFF
--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -390,11 +390,11 @@ void Account::AddFine(int64_t amount)
 // Check how big a mortgage the player can afford to pay at their current income.
 int64_t Account::Prequalify() const
 {
-	int64_t payments = 0;
+	double payments = 0;
 	int64_t liabilities = 0;
 	for(const Mortgage &mortgage : mortgages)
 	{
-		payments += mortgage.Payment();
+		payments += mortgage.PrecisePayment();
 		liabilities += mortgage.Principal();
 	}
 

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -390,7 +390,7 @@ void Account::AddFine(int64_t amount)
 // Check how big a mortgage the player can afford to pay at their current income.
 int64_t Account::Prequalify() const
 {
-	double payments = 0;
+	double payments = 0.;
 	int64_t liabilities = 0;
 	for(const Mortgage &mortgage : mortgages)
 	{

--- a/source/Mortgage.cpp
+++ b/source/Mortgage.cpp
@@ -194,6 +194,6 @@ double Mortgage::PrecisePayment() const
 	if(!interest)
 		return static_cast<double>(principal) / term;
 
-	double power = pow(1. + interest, term);
+	const double power = pow(1. + interest, term);
 	return principal * interest * power / (power - 1.);
 }

--- a/source/Mortgage.cpp
+++ b/source/Mortgage.cpp
@@ -23,20 +23,23 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 using namespace std;
 
+namespace {
+	const int MORTGAGE_TERM = 365;
+}
+
 
 
 // Find out how much you can afford to borrow with the given annual revenue
 // and the given credit score (which should be between 200 and 800).
 int64_t Mortgage::Maximum(int64_t annualRevenue, int creditScore, double currentPayments)
 {
-	static const int term = 365;
-	const double revenue = annualRevenue - term * currentPayments;
+	const double revenue = annualRevenue - MORTGAGE_TERM * currentPayments;
 	if(revenue <= 0.)
 		return 0;
 
 	const double interest = (600 - creditScore / 2) * .00001;
-	const double power = pow(1. + interest, term);
-	const double multiplier = interest * term * power / (power - 1.);
+	const double power = pow(1. + interest, MORTGAGE_TERM);
+	const double multiplier = interest * MORTGAGE_TERM * power / (power - 1.);
 	return static_cast<int64_t>(max(0., revenue / multiplier));
 }
 

--- a/source/Mortgage.cpp
+++ b/source/Mortgage.cpp
@@ -29,14 +29,14 @@ using namespace std;
 // and the given credit score (which should be between 200 and 800).
 int64_t Mortgage::Maximum(int64_t annualRevenue, int creditScore, double currentPayments)
 {
-	const int term = 365;
-	double revenue = annualRevenue - term * currentPayments;
+	const static int term = 365;
+	const double revenue = annualRevenue - term * currentPayments;
 	if(revenue <= 0)
 		return 0;
 
-	double interest = (600 - creditScore / 2) * .00001;
-	double power = pow(1. + interest, term);
-	double multiplier = interest * term * power / (power - 1.);
+	const double interest = (600 - creditScore / 2) * .00001;
+	const double power = pow(1. + interest, term);
+	const double multiplier = interest * term * power / (power - 1.);
 	return static_cast<int64_t>(max(0., revenue / multiplier));
 }
 

--- a/source/Mortgage.cpp
+++ b/source/Mortgage.cpp
@@ -27,17 +27,17 @@ using namespace std;
 
 // Find out how much you can afford to borrow with the given annual revenue
 // and the given credit score (which should be between 200 and 800).
-int64_t Mortgage::Maximum(int64_t annualRevenue, int creditScore, int64_t currentPayments)
+int64_t Mortgage::Maximum(int64_t annualRevenue, int creditScore, double currentPayments)
 {
 	const int term = 365;
-	annualRevenue -= term * currentPayments;
-	if(annualRevenue <= 0)
+	double revenue = annualRevenue - term * currentPayments;
+	if(revenue <= 0)
 		return 0;
 
 	double interest = (600 - creditScore / 2) * .00001;
 	double power = pow(1. + interest, term);
 	double multiplier = interest * term * power / (power - 1.);
-	return static_cast<int64_t>(max(0., annualRevenue / multiplier));
+	return static_cast<int64_t>(max(0., revenue / multiplier));
 }
 
 
@@ -179,4 +179,18 @@ int64_t Mortgage::Payment() const
 	// Always require every payment to be at least 1 credit.
 	double power = pow(1. + interest, term);
 	return max<int64_t>(1, lround(principal * interest * power / (power - 1.)));
+}
+
+
+
+// Check the amount of the next payment due.
+double Mortgage::PrecisePayment() const
+{
+	if(!term)
+		return principal;
+	if(!interest)
+		return static_cast<double>(principal) / term;
+
+	double power = pow(1. + interest, term);
+	return principal * interest * power / (power - 1.);
 }

--- a/source/Mortgage.cpp
+++ b/source/Mortgage.cpp
@@ -29,9 +29,9 @@ using namespace std;
 // and the given credit score (which should be between 200 and 800).
 int64_t Mortgage::Maximum(int64_t annualRevenue, int creditScore, double currentPayments)
 {
-	const static int term = 365;
+	static const int term = 365;
 	const double revenue = annualRevenue - term * currentPayments;
-	if(revenue <= 0)
+	if(revenue <= 0.)
 		return 0;
 
 	const double interest = (600 - creditScore / 2) * .00001;

--- a/source/Mortgage.h
+++ b/source/Mortgage.h
@@ -32,7 +32,7 @@ class Mortgage {
 public:
 	// Find out how much you can afford to borrow with the given annual revenue
 	// and the given credit score (which should be between 200 and 800).
-	static int64_t Maximum(int64_t annualRevenue, int creditScore, int64_t currentPayments);
+	static int64_t Maximum(int64_t annualRevenue, int creditScore, double currentPayments);
 
 
 public:

--- a/source/Mortgage.h
+++ b/source/Mortgage.h
@@ -68,6 +68,8 @@ public:
 	int Term() const;
 	// Check the amount of the next payment due (rounded to the nearest credit).
 	int64_t Payment() const;
+	// Check the amount of the next payment due.
+	double PrecisePayment() const;
 
 
 private:


### PR DESCRIPTION
**Bugfix:**

## The Bug
Due to rounding errors in Mortage::Payment(), taking loans in certain amounts can result in a greater (or lesser) total amount of loans being offered.

## Fix Details
Added a new method, Mortage::PrecisePayment(), that returns the unrounded payment schedule (double versus int64_t).  This is then used by Account::Prequalify() and Mortage::Maximum() to accurately calculate the maximum loan available.  Splitting up the loans has no effect on the overall amount that can be loaned out.

This change will have small effects on offered loan compared to what they were originally, but they'll be more consistent now and changes appear to be very small (about .1% in my test case, although a set of carefully crafted loans might see a larger change).

## Testing Done
Combined with my previous PR (allowing the starting player to pay off the loan and then get it, or smaller ones, back), it was easy to watch the total loan offered remain constant.