### PR TITLE
fix(typo): add in a missing space

### DIFF
--- a/data/human/hails.txt
+++ b/data/human/hails.txt
@@ -2409,7 +2409,7 @@ phrase "friendly navy"
 		"the Republic for"
 		"the Navy for"
 	word
-		"" 6
+		" " 6
 		" providing "
 		" ensuring "
 		" giving you "


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8942

## Fix Details
Adds in a missing space.

## Testing Done
Do I need to?

## Save File
N/A, just text changes.