### PR TITLE
Make "Expedition to Hope 2" provide clearance for the destination planet

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -571,6 +571,7 @@ mission "Expedition to Hope 2"
 	destination
 		distance 2 5
 		government Republic "Free Worlds" Neutral
+	clearance
 	to offer
 		has "Expedition to Hope 1: done"
 	passengers 4


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #8981

## Fix Details
The player is hostile to the Republic, Free Worlds, and Netural governments which prevents "Expedition to Hope 2" from offering because it cannot find a destination location where the player will be allowed to land.
This PR adds `clearance` to the mission so it will select planets that would not otherwise welcome the player.

## Testing Done
Use the attached save. Without this PR, "Expedition to Hope 2" does not trigger when landing on Hope, with it, it does.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[PEPSI MAAAAAAN DUNDUNDUNDUNDUN~bugged save.txt](https://github.com/endless-sky/endless-sky/files/11929962/PEPSI.MAAAAAAN.DUNDUNDUNDUNDUN.bugged.save.txt)

