### PR TITLE
feat(balance): Make fighters go into a new "wrecked" state

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1174,18 +1174,18 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 
 			// If any able enemies of this ship are in its system, it cannot call for help.
 			const System *system = ship.GetSystem();
-            
-            // If you're a wrecked fighter, and your parent is around, only ask them for help
-            // Otherwise, only ask escorts with bays for help
-            if(ship.IsWrecked())
-            {
-                if(ship.GetParent() && system == ship.GetParent()->GetSystem() && helper != ship.GetParent())
-                    continue;
-                else if((helper->IsYours() && !ship.IsYours()) || !helper->HasBays())
-                    continue;
-                    
-            }
-            
+
+			// If you're a wrecked fighter, and your parent is around, only ask them for help
+			// Otherwise, only ask escorts with bays for help
+			if(ship.IsWrecked())
+			{
+				if(ship.GetParent() && system == ship.GetParent()->GetSystem() && helper != ship.GetParent())
+					continue;
+				else if((helper->IsYours() && !ship.IsYours()) || !helper->HasBays())
+					continue;
+
+			}
+
 			if(helper->GetGovernment()->IsEnemy(gov) && flagship && system == flagship->GetSystem())
 			{
 				// Disabled, overheated, or otherwise untargetable ships pose no threat.
@@ -1322,8 +1322,8 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	if(oldTarget && person.IsTimid() && oldTarget->IsDisabled()
 			&& ship.Position().Distance(oldTarget->Position()) > 1000.)
 		oldTarget.reset();
-    if(oldTarget && !ship.IsYours() && oldTarget->IsWrecked())
-        oldTarget.reset();
+	if(oldTarget && !ship.IsYours() && oldTarget->IsWrecked())
+		oldTarget.reset();
 	// Ships with 'plunders' personality always destroy the ships they have boarded
 	// unless they also have either or both of the 'disables' or 'merciful' personalities.
 	if(oldTarget && person.Plunders() && !person.Disables() && !person.IsMerciful()
@@ -1363,10 +1363,10 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 			continue;
 		if(!CanPursue(ship, *foe))
 			continue;
-        // If this is not a player ship, and it has found one of the player's
-        // wrecked fighters, it will ignore it.
-        if(!ship.IsYours() && foe->IsWrecked())
-            continue;
+		// If this is not a player ship, and it has found one of the player's
+		// wrecked fighters, it will ignore it.
+		if(!ship.IsYours() && foe->IsWrecked())
+			continue;
 
 		// Estimate the range a second from now, so ships prefer foes they are approaching.
 		double range = (foe->Position() + 60. * foe->Velocity()).Distance(
@@ -3601,11 +3601,11 @@ double AI::RendezvousTime(const Point &p, const Point &v, double vp)
 	// to intersect the target?
 	// (p.x + v.x*t)^2 + (p.y + v.y*t)^2 = vp^2*t^2
 	// p.x^2 + 2*p.x*v.x*t + v.x^2*t^2
-	//    + p.y^2 + 2*p.y*v.y*t + v.y^2t^2
-	//    - vp^2*t^2 = 0
+	//	+ p.y^2 + 2*p.y*v.y*t + v.y^2t^2
+	//	- vp^2*t^2 = 0
 	// (v.x^2 + v.y^2 - vp^2) * t^2
-	//    + (2 * (p.x * v.x + p.y * v.y)) * t
-	//    + (p.x^2 + p.y^2) = 0
+	//	+ (2 * (p.x * v.x + p.y * v.y)) * t
+	//	+ (p.x^2 + p.y^2) = 0
 	double a = v.Dot(v) - vp * vp;
 	double b = 2. * p.Dot(v);
 	double c = p.Dot(p);

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3601,11 +3601,11 @@ double AI::RendezvousTime(const Point &p, const Point &v, double vp)
 	// to intersect the target?
 	// (p.x + v.x*t)^2 + (p.y + v.y*t)^2 = vp^2*t^2
 	// p.x^2 + 2*p.x*v.x*t + v.x^2*t^2
-	//	+ p.y^2 + 2*p.y*v.y*t + v.y^2t^2
-	//	- vp^2*t^2 = 0
+	//    + p.y^2 + 2*p.y*v.y*t + v.y^2t^2
+	//    - vp^2*t^2 = 0
 	// (v.x^2 + v.y^2 - vp^2) * t^2
-	//	+ (2 * (p.x * v.x + p.y * v.y)) * t
-	//	+ (p.x^2 + p.y^2) = 0
+	//    + (2 * (p.x * v.x + p.y * v.y)) * t
+	//    + (p.x^2 + p.y^2) = 0
 	double a = v.Dot(v) - vp * vp;
 	double b = 2. * p.Dot(v);
 	double c = p.Dot(p);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2128,11 +2128,13 @@ void Engine::DoCollisions(Projectile &projectile)
 	else
 	{
 		// For weapons with a trigger radius, check if any detectable object will set it off.
+        // The player's wrecked fighters will be ignored.
 		double triggerRadius = projectile.GetWeapon().TriggerRadius();
 		if(triggerRadius)
 			for(const Body *body : shipCollisions.Circle(projectile.Position(), triggerRadius))
 				if(body == projectile.Target() || (gov->IsEnemy(body->GetGovernment())
-						&& reinterpret_cast<const Ship *>(body)->Cloaking() < 1.))
+						&& reinterpret_cast<const Ship *>(body)->Cloaking() < 1.
+                        && !(reinterpret_cast<const Ship *>(body)->IsWrecked())))
 				{
 					closestHit = 0.;
 					break;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2128,13 +2128,13 @@ void Engine::DoCollisions(Projectile &projectile)
 	else
 	{
 		// For weapons with a trigger radius, check if any detectable object will set it off.
-        // The player's wrecked fighters will be ignored.
+		// The player's wrecked fighters will be ignored.
 		double triggerRadius = projectile.GetWeapon().TriggerRadius();
 		if(triggerRadius)
 			for(const Body *body : shipCollisions.Circle(projectile.Position(), triggerRadius))
 				if(body == projectile.Target() || (gov->IsEnemy(body->GetGovernment())
 						&& reinterpret_cast<const Ship *>(body)->Cloaking() < 1.
-                        && !(reinterpret_cast<const Ship *>(body)->IsWrecked())))
+						&& !(reinterpret_cast<const Ship *>(body)->IsWrecked())))
 				{
 					closestHit = 0.;
 					break;

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -90,6 +90,33 @@ void PlanetPanel::Step()
 		else
 			player.HandleBlockedMissions(Mission::LANDING, GetUI());
 	}
+    
+    if(planet.HasShipyard())
+    {
+        int repairedFighters = 0;
+        for(const auto &it : player.Ships())
+        {
+            int repairSelf = it->DoRepairWreckedFighter();
+            if(repairSelf == 0)
+                repairedFighters += it->DoRepairMyWreckedFighters();
+            else
+                repairedFighters += repairSelf;
+        }
+        
+        if(repairedFighters > 0)
+        {
+            ostringstream out;
+            
+            string fighterWord = "fighters";
+            if(repairedFighters == 1)
+            {
+                fighterWord = "fighter";
+            }
+            out << "You quickly see your wrecked " << fighterWord << " transported to the shipyard for repair.";
+            
+            GetUI()->Push(new Dialog(out.str()));
+        }
+    }
 }
 
 

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -90,33 +90,33 @@ void PlanetPanel::Step()
 		else
 			player.HandleBlockedMissions(Mission::LANDING, GetUI());
 	}
-    
-    if(planet.HasShipyard())
-    {
-        int repairedFighters = 0;
-        for(const auto &it : player.Ships())
-        {
-            int repairSelf = it->DoRepairWreckedFighter();
-            if(repairSelf == 0)
-                repairedFighters += it->DoRepairMyWreckedFighters();
-            else
-                repairedFighters += repairSelf;
-        }
-        
-        if(repairedFighters > 0)
-        {
-            ostringstream out;
-            
-            string fighterWord = "fighters";
-            if(repairedFighters == 1)
-            {
-                fighterWord = "fighter";
-            }
-            out << "You quickly see your wrecked " << fighterWord << " transported to the shipyard for repair.";
-            
-            GetUI()->Push(new Dialog(out.str()));
-        }
-    }
+
+	if(planet.HasShipyard())
+	{
+		int repairedFighters = 0;
+		for(const auto &it : player.Ships())
+		{
+			int repairSelf = it->DoRepairWreckedFighter();
+			if(repairSelf == 0)
+				repairedFighters += it->DoRepairMyWreckedFighters();
+			else
+				repairedFighters += repairSelf;
+		}
+		
+		if(repairedFighters > 0)
+		{
+			ostringstream out;
+			
+			string fighterWord = "fighters";
+			if(repairedFighters == 1)
+			{
+				fighterWord = "fighter";
+			}
+			out << "You quickly see your wrecked " << fighterWord << " transported to the shipyard for repair.";
+			
+			GetUI()->Push(new Dialog(out.str()));
+		}
+	}
 }
 
 

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -102,18 +102,18 @@ void PlanetPanel::Step()
 			else
 				repairedFighters += repairSelf;
 		}
-		
+
 		if(repairedFighters > 0)
 		{
 			ostringstream out;
-			
+
 			string fighterWord = "fighters";
 			if(repairedFighters == 1)
 			{
 				fighterWord = "fighter";
 			}
 			out << "You quickly see your wrecked " << fighterWord << " transported to the shipyard for repair.";
-			
+
 			GetUI()->Push(new Dialog(out.str()));
 		}
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2710,21 +2710,21 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	else
 	{
 		// Wrecked fighters take no further damage of any kind
-		
+
 		energy -= damage.Energy();
 		heat += damage.Heat();
 		fuel -= damage.Fuel();
-		
+
 		discharge += damage.Discharge();
 		corrosion += damage.Corrosion();
 		ionization += damage.Ion();
 		scrambling += damage.Scrambling();
 		burning += damage.Burn();
 		leakage += damage.Leak();
-		
+
 		disruption += damage.Disruption();
 		slowness += damage.Slowing();
-		
+
 		if(damage.HitForce())
 			ApplyForce(damage.HitForce(), damage.GetWeapon().IsGravitational());
 	}
@@ -3590,7 +3590,7 @@ void Ship::DoGeneration()
 			for(const pair<double, Ship *> &it : carried)
 			{
 				Ship &ship = *it.second;
-				
+
 				if(ship.IsWrecked())
 					continue;
 				if(!hullDelay)
@@ -4122,7 +4122,7 @@ int Ship::DoRepairWreckedFighter()
 			DoRepair(hull, hullAvailable, attributes.Get("hull"));
 		if(!shieldDelay)
 			DoRepair(shields, shieldsAvailable, attributes.Get("shields"));
-		
+
 		return 1;
 	}
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2706,7 +2706,9 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	if(IsYours() && CanBeCarried() && hull <= 0.1)
 	{
 		hull = 0.1;
-	} else {
+	}
+	else
+	{
 		// Wrecked fighters take no further damage of any kind
 		
 		energy -= damage.Energy();
@@ -4112,7 +4114,7 @@ int Ship::DoRepairMyWreckedFighters()
 int Ship::DoRepairWreckedFighter()
 {
 
-	if (IsWrecked())
+	if(IsWrecked())
 	{
 		double hullAvailable = attributes.Get("hull");
 		double shieldsAvailable = attributes.Get("shields");

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1586,7 +1586,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships, vector<Visual> &visuals)
 
 	for(Bay &bay : bays)
 		if(bay.ship
-            && !bay.ship->IsWrecked()
+			&& !bay.ship->IsWrecked()
 			&& ((bay.ship->Commands().Has(Command::DEPLOY) && !Random::Int(40 + 20 * !bay.ship->attributes.Get("automaton")))
 			|| (ejecting && !Random::Int(6))))
 		{
@@ -1674,37 +1674,37 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder, bool nonDocking)
 			victim->Carry(shared_from_this());
 		return shared_ptr<Ship>();
 	}
-    
-    // If, on the other hand, the target is a wrecked fighter or drone, we pick it up
-    if(victim->CanBeCarried() && victim->IsWrecked())
-    {
-        Carry(victim);
-        return shared_ptr<Ship>();
-    }
+
+	// If, on the other hand, the target is a wrecked fighter or drone, we pick it up
+	if(victim->CanBeCarried() && victim->IsWrecked())
+	{
+		Carry(victim);
+		return shared_ptr<Ship>();
+	}
 
 	// Board a friendly ship, to repair or refuel it.
 	if(!government->IsEnemy(victim->GetGovernment()))
 	{
 		SetShipToAssist(shared_ptr<Ship>());
 		SetTargetShip(shared_ptr<Ship>());
-        // Never repair a wrecked fighter.
-        if(!victim->IsWrecked())
-        {
-            bool helped = victim->isDisabled;
-            victim->hull = min(max(victim->hull, victim->MinimumHull() * 1.5), victim->attributes.Get("hull"));
-            victim->isDisabled = false;
-            // Transfer some fuel if needed.
-            if(victim->NeedsFuel() && CanRefuel(*victim))
-            {
-                helped = true;
-                TransferFuel(victim->JumpFuelMissing(), victim.get());
-            }
-            if(helped)
-            {
-                pilotError = 120;
-                victim->pilotError = 120;
-            }
-        }
+		// Never repair a wrecked fighter.
+		if(!victim->IsWrecked())
+		{
+			bool helped = victim->isDisabled;
+			victim->hull = min(max(victim->hull, victim->MinimumHull() * 1.5), victim->attributes.Get("hull"));
+			victim->isDisabled = false;
+			// Transfer some fuel if needed.
+			if(victim->NeedsFuel() && CanRefuel(*victim))
+			{
+				helped = true;
+				TransferFuel(victim->JumpFuelMissing(), victim.get());
+			}
+			if(helped)
+			{
+				pilotError = 120;
+				victim->pilotError = 120;
+			}
+		}
 		return victim;
 	}
 	if(!victim->IsDisabled())
@@ -2690,7 +2690,7 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 {
 	bool wasDisabled = IsDisabled();
 	bool wasDestroyed = IsDestroyed();
-    bool wasWrecked = IsWrecked();
+	bool wasWrecked = IsWrecked();
 
 	shields -= damage.Shield();
 	if(damage.Shield() && !isDisabled)
@@ -2702,30 +2702,30 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	hull -= damage.Hull();
 	if(damage.Hull() && !isDisabled)
 		hullDelay = max(hullDelay, static_cast<int>(attributes.Get("repair delay")));
-    
-    if(IsYours() && CanBeCarried() && hull <= 0.1)
-    {
-        hull = 0.1;
-    } else {
-        // Wrecked fighters take no further damage of any kind
-        
-        energy -= damage.Energy();
-        heat += damage.Heat();
-        fuel -= damage.Fuel();
-        
-        discharge += damage.Discharge();
-        corrosion += damage.Corrosion();
-        ionization += damage.Ion();
-        scrambling += damage.Scrambling();
-        burning += damage.Burn();
-        leakage += damage.Leak();
-        
-        disruption += damage.Disruption();
-        slowness += damage.Slowing();
-        
-        if(damage.HitForce())
-            ApplyForce(damage.HitForce(), damage.GetWeapon().IsGravitational());
-    }
+
+	if(IsYours() && CanBeCarried() && hull <= 0.1)
+	{
+		hull = 0.1;
+	} else {
+		// Wrecked fighters take no further damage of any kind
+		
+		energy -= damage.Energy();
+		heat += damage.Heat();
+		fuel -= damage.Fuel();
+		
+		discharge += damage.Discharge();
+		corrosion += damage.Corrosion();
+		ionization += damage.Ion();
+		scrambling += damage.Scrambling();
+		burning += damage.Burn();
+		leakage += damage.Leak();
+		
+		disruption += damage.Disruption();
+		slowness += damage.Slowing();
+		
+		if(damage.HitForce())
+			ApplyForce(damage.HitForce(), damage.GetWeapon().IsGravitational());
+	}
 
 	// Prevent various stats from reaching unallowable values.
 	hull = min(hull, attributes.Get("hull"));
@@ -2739,10 +2739,10 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	// Recalculate the disabled ship check.
 	isDisabled = true;
 	isDisabled = IsDisabled();
-    isWrecked = IsWrecked();
+	isWrecked = IsWrecked();
 
 	// Report what happened to this ship from this weapon.
-    // Wrecking a fighter counts the same as destroying it.
+	// Wrecking a fighter counts the same as destroying it.
 	int type = 0;
 	if(!wasDisabled && isDisabled)
 	{
@@ -3408,13 +3408,13 @@ int Ship::StepDestroyed(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flot
 	if(!IsDestroyed())
 		return 0;
 
-    // If it's your fighter, it doesn't get destroyed; it gets wrecked.
-    if(CanBeCarried() && IsYours())
-    {
-        hull = 0.1;
-        return 0;
-    }
-    
+	// If it's your fighter, it doesn't get destroyed; it gets wrecked.
+	if(CanBeCarried() && IsYours())
+	{
+		hull = 0.1;
+		return 0;
+	}
+
 	// Make sure the shields are zero, as well as the hull.
 	shields = 0.;
 
@@ -3588,9 +3588,9 @@ void Ship::DoGeneration()
 			for(const pair<double, Ship *> &it : carried)
 			{
 				Ship &ship = *it.second;
-                
-                if(ship.IsWrecked())
-                    continue;
+				
+				if(ship.IsWrecked())
+					continue;
 				if(!hullDelay)
 					DoRepair(ship.hull, hullRemaining, ship.attributes.Get("hull"),
 						energy, hullEnergy, heat, hullHeat, fuel, hullFuel);
@@ -4087,44 +4087,44 @@ bool Ship::DoLandingLogic()
 
 bool Ship::IsWrecked() const
 {
-    return IsYours() && CanBeCarried() && hull == 0.1;
+	return IsYours() && CanBeCarried() && hull == 0.1;
 }
 
 int Ship::DoRepairMyWreckedFighters()
 {
-    
-    int repairedFighters = 0;
-    for(Bay &bay : bays)
-        if(bay.ship && !bay.ship->IsWrecked())
-        {
-            repairedFighters++;
-            double hullAvailable = bay.ship->attributes.Get("hull");
-            double shieldsAvailable = bay.ship->attributes.Get("shields");
-            if(!hullDelay)
-                DoRepair(bay.ship->hull, hullAvailable, bay.ship->attributes.Get("hull"));
-            if(!shieldDelay)
-                DoRepair(bay.ship->shields, shieldsAvailable, bay.ship->attributes.Get("shields"));
-        }
-    
-    return repairedFighters;
+
+	int repairedFighters = 0;
+	for(Bay &bay : bays)
+		if(bay.ship && !bay.ship->IsWrecked())
+		{
+			repairedFighters++;
+			double hullAvailable = bay.ship->attributes.Get("hull");
+			double shieldsAvailable = bay.ship->attributes.Get("shields");
+			if(!hullDelay)
+				DoRepair(bay.ship->hull, hullAvailable, bay.ship->attributes.Get("hull"));
+			if(!shieldDelay)
+				DoRepair(bay.ship->shields, shieldsAvailable, bay.ship->attributes.Get("shields"));
+		}
+
+	return repairedFighters;
 }
 
 int Ship::DoRepairWreckedFighter()
 {
-    
-    if (IsWrecked())
-    {
-        double hullAvailable = attributes.Get("hull");
-        double shieldsAvailable = attributes.Get("shields");
-        if(!hullDelay)
-            DoRepair(hull, hullAvailable, attributes.Get("hull"));
-        if(!shieldDelay)
-            DoRepair(shields, shieldsAvailable, attributes.Get("shields"));
-        
-        return 1;
-    }
-    
-    return 0;
+
+	if (IsWrecked())
+	{
+		double hullAvailable = attributes.Get("hull");
+		double shieldsAvailable = attributes.Get("shields");
+		if(!hullDelay)
+			DoRepair(hull, hullAvailable, attributes.Get("hull"));
+		if(!shieldDelay)
+			DoRepair(shields, shieldsAvailable, attributes.Get("shields"));
+		
+		return 1;
+	}
+
+	return 0;
 }
 
 void Ship::DoInitializeMovement()

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -457,6 +457,12 @@ public:
 	int GetLingerSteps() const;
 	// The AI wants the ship to linger for one AI step.
 	void Linger();
+    // Check if this ship is a wrecked fighter
+    bool IsWrecked() const;
+    // Restore this ship to full health if it is a wrecked fighter
+    int DoRepairWreckedFighter();
+    // Restore all carried wrecked fighters to full health
+    int DoRepairMyWreckedFighters();
 
 
 private:
@@ -536,6 +542,7 @@ private:
 	bool shouldDeploy = false;
 	bool isOverheated = false;
 	bool isDisabled = false;
+    bool isWrecked = false;
 	bool isBoarding = false;
 	bool hasBoarded = false;
 	bool isFleeing = false;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -457,12 +457,12 @@ public:
 	int GetLingerSteps() const;
 	// The AI wants the ship to linger for one AI step.
 	void Linger();
-    // Check if this ship is a wrecked fighter
-    bool IsWrecked() const;
-    // Restore this ship to full health if it is a wrecked fighter
-    int DoRepairWreckedFighter();
-    // Restore all carried wrecked fighters to full health
-    int DoRepairMyWreckedFighters();
+	// Check if this ship is a wrecked fighter
+	bool IsWrecked() const;
+	// Restore this ship to full health if it is a wrecked fighter
+	int DoRepairWreckedFighter();
+	// Restore all carried wrecked fighters to full health
+	int DoRepairMyWreckedFighters();
 
 
 private:
@@ -542,7 +542,7 @@ private:
 	bool shouldDeploy = false;
 	bool isOverheated = false;
 	bool isDisabled = false;
-    bool isWrecked = false;
+	bool isWrecked = false;
 	bool isBoarding = false;
 	bool hasBoarded = false;
 	bool isFleeing = false;


### PR DESCRIPTION

Introduce a new "wrecked" state for the player's fighters and drones, that they will enter upon taking enough damage to be fully destroyed.

This will prevent them from taking any further damage, and when their carrier lands on a planet with a shipyard, they will be repaired automatically.

----------------------
**Feature:** This PR implements the feature request detailed and discussed in issue #3920
Also related: #4034, #906

## Feature Details
Upon being reduced to 0 hull, fighters and drones (henceforth just "fighters", for simplicity) belonging to the player will, mechanically, have their hull set to 0.1 and go into a "wrecked" state. 
Wrecked fighters will no longer take damage of any kind, and act as "disabled" for most purposes. 
The AI will ignore these ships for targeting purposes, _except_ that they will ask their parent ship for help (if they have no parent ship, they will instead ask any escort with bays for help; if there are none, they're screwed anyway).
In particular, other escorts will no longer go to wrecked fighters to attempt to repair them.
For the flagship, when Boarding a wrecked fighter, it will simply pick it up into the appropriate bay.
Wrecked fighters in bays will not be repaired.
Upon landing on a planet with a shipyard, all wrecked fighters will be immediately repaired, and a dialog indicating this displayed.

This is intended to be a (partial) solution to the issues with fighter balance and frustration. I have read through several past discussions on the topic, and at least thus far have not seen whether there is a real consensus on which of the various suggestions should be implemented, so I hope that this one is seen as reasonable.

## UI Screenshots
Repair dialog:
<img width="868" alt="wrecked-fighter-repair" src="https://github.com/endless-sky/endless-sky/assets/1781491/698ee117-5982-47fe-814c-1d0768e90471">

Otherwise, it just looks like the fighters are disabled.

## Usage Examples
N/A

## Testing Done
Bought an Ibis and some Petrels, manually shot down a Petrel several times and observed the behavior of escorts. 
With the Ibis as my flagship, boarded the wrecked Petrel, successfully loading it aboard, then landed, successfully repairing it.
With the Ibis as an escort, shot down the Petrel and observed the Ibis successfully load it automatically.

### Automated Tests Added
I am, I fear, unfamiliar with automated tests. If this requires some, I will happily take direction, or studiously observe someone else's additions there for future reference.

## Performance Impact
Adds a few (fairly simple) tests to `AI::AskForHelp()`, `AI::FindTarget()`, and `Engine::DoCollisions()`. Adds some checks in `Ship::Move()` that will, for wrecked fighters, disable some methods (such as `DoGeneration()`), thus likely slightly reducing load.
