### PR TITLE
fix(DataWriter): Properly save empty string tokens

### DIFF
--- a/source/DataWriter.cpp
+++ b/source/DataWriter.cpp
@@ -132,7 +132,7 @@ void DataWriter::WriteToken(const string &a)
 	// Figure out what kind of quotation marks need to be used for this string.
 	bool hasSpace = any_of(a.begin(), a.end(), [](char c) { return isspace(c); });
 	bool hasQuote = any_of(a.begin(), a.end(), [](char c) { return (c == '"'); });
-	// If  the token is an empty string, it needs to be wrapped in quotes as thought it had a space.
+	// If the token is an empty string, it needs to be wrapped in quotes as if it had a space.
 	hasSpace |= a.empty();
 	// Write the token, enclosed in quotes if necessary.
 	out << *before;

--- a/source/DataWriter.cpp
+++ b/source/DataWriter.cpp
@@ -132,6 +132,8 @@ void DataWriter::WriteToken(const string &a)
 	// Figure out what kind of quotation marks need to be used for this string.
 	bool hasSpace = any_of(a.begin(), a.end(), [](char c) { return isspace(c); });
 	bool hasQuote = any_of(a.begin(), a.end(), [](char c) { return (c == '"'); });
+	// If  the token is an empty string, it needs to be wrapped in quotes as thought it had a space.
+	hasSpace |= a.empty();
 	// Write the token, enclosed in quotes if necessary.
 	out << *before;
 	if(hasQuote)


### PR DESCRIPTION
**Bugfix:**

Thanks to @Zitchas for reporting the issue that led to me finding this on Discord.

## Fix Details
In #8744, a special case for saving a token that is an empty string was removed, this leads to nothing being saved for empty string tokens, instead of a pair of quote marks (`""`) to indicate that there is indeed a token and that it is just an empty string.

In this case, an empty government name (empty because it was loaded and saved by a version of the game where the original government was undefined) was not correctly saved:
```
government ""
```
Became:
```
government 
```
In this case, NPC::Load sees a single token, and so skips the line and no government is assigned to the ships in that NPC, meaning the government pointer in those Ship objects is null. This led to a crash moments after take off when an attempt to dereference that pointer was made, which is the issue reported by Zitchas.

## Testing Done
Load the attached save file, take off, reload the top save, and take off again.
Without this PR, a crash occurs, and inspecting the newly written save file shows that the NPC in the active mission "Relic of the Past" has no government line. Inspecting the save after the first take off will likely show `government ` in the NPC definition.
With this PR, no crash occurs, and the NPC has `government ""`.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[Rebbia Rampart~3036-01-03_Random_Snapshot.txt](https://github.com/endless-sky/endless-sky/files/11951928/Rebbia.Rampart.3036-01-03_Random_Snapshot.txt)
(Courtesy of @Zitchas.)
