### PR TITLE
refactor(ui): Define Ship Info hardpoint colors as game data

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -41,6 +41,10 @@ color "shop side panel background" .2 .2 .2 1.
 color "shop side panel footer" .3 .3 .3 1.
 color "shop info panel background" .055 .055 .055 1.
 color "tooltip background" .2 .2 .2 1.
+color "player info hardpoint gun" .5 .375 0. 1.
+color "player info hardpoint gun hover" .8 .6 0. 1.
+color "player info hardpoint turret" 0. .375 .5 1.
+color "player info hardpoint turret hover" 0. .6 .8 1.
 color "logbook sidebar" .09 .09 .09 1.
 color "logbook background" .125 .125 .125 1.
 color "logbook line" .2 .2 .2 1.

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -486,10 +486,13 @@ void ShipInfoPanel::DrawWeapons(const Rectangle &bounds)
 		zones.emplace_back(zoneCenter, LINE_SIZE, index);
 
 		// Determine what color to use for the line.
-		float high = (index == hoverIndex ? .8f : .5f);
-		Color color(high, .75f * high, 0.f, 1.f);
+		Color color;
 		if(isTurret)
-			color = Color(0.f, .75f * high, high, 1.f);
+			color = *GameData::Colors().Get(isHover ? "player info hardpoint turret hover"
+			: "player info hardpoint turret");
+		else
+			color = *GameData::Colors().Get(isHover ? "player info hardpoint gun hover"
+			: "player info hardpoint gun");
 
 		// Draw the line.
 		Point from(fromX[isRight], zoneCenter.Y());


### PR DESCRIPTION
## Refactor Details
Added four new colors to the `interfaces.txt` file: two for guns and two for turrets (normal and hover state).
These colors replace the currently used hardcoded color values of the lines connecting hardpoints with respective weapon names on the Ship Info panel.

## UI Screenshots
Calculated the color values to be the same as currently, so N/A.

## Testing Done
yes.

## Performance Impact
N/A
