### PR TITLE
Give the Frigate back its second torpedo launcher

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1883,15 +1883,14 @@ ship "Frigate"
 			"hit force" 1500
 	outfits
 		"Particle Cannon" 2
-		"Torpedo Launcher"
-		"Sidewinder Missile Launcher"
+		"Torpedo Launcher" 2
 		"Torpedo" 60
-		"Sidewinder Missile" 45
 		"Blaster Turret" 2
 		"Anti-Missile Turret"
 		
 		"NT-200 Nucleovoltaic"
-		"LP144a Battery Pack"
+		"LP072a Battery Pack"
+		"LP036a Battery Pack"
 		"D41-HY Shield Generator"
 		"Large Radar Jammer"
 		"Laser Rifle" 5
@@ -1907,7 +1906,7 @@ ship "Frigate"
 	gun -11 -84.5 "Particle Cannon"
 	gun 11 -84.5 "Particle Cannon"
 	gun -11 -84.5 "Torpedo Launcher"
-	gun 11 -84.5 "Sidewinder Missile Launcher"
+	gun 11 -84.5 "Torpedo Launcher"
 	turret 0 -37.5 "Anti-Missile Turret"
 	turret -15.5 -12.5 "Blaster Turret"
 	turret 15.5 -12.5 "Blaster Turret"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
The second torpedo launcher was replaced with a sidewinder missile launcher when many human secondary weapons were made larger and there was no longer enough space in the Frigate for the second torpedo launcher.
This PR replaces the LP144a battery with an LP072a and LP036a which leaves enough room to upgrade from the sidewinder launcher to another torpedo launcher, making the ship not only look better in operation but meaning that fire from both launchers will arrive at the target at approximately the same time, increasing the load on their anti-missile systems.
While this battery configuration offers less capacity than a single LP144a, following the battery buff, it is still more than enough energy for this ship.

