### PR TITLE
feat(ui): Outfits in drawshipssidebar

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -124,8 +124,11 @@ int OutfitterPanel::DrawPlayerShipInfo(const Point &point)
 {
 	shipInfo.Update(*playerShip, player, collapsed.count("description"));
 	shipInfo.DrawAttributes(point);
+	const int attributesHeight = shipInfo.AttributesHeight();
+	const Point outfPoint(point.X(), point.Y() + attributesHeight);
+	shipInfo.DrawOutfits(outfPoint);
 
-	return shipInfo.AttributesHeight();
+	return attributesHeight + shipInfo.OutfitsHeight();
 }
 
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -125,8 +125,7 @@ int OutfitterPanel::DrawPlayerShipInfo(const Point &point)
 	shipInfo.Update(*playerShip, player, collapsed.count("description"));
 	shipInfo.DrawAttributes(point);
 	const int attributesHeight = shipInfo.AttributesHeight();
-	const Point outfPoint(point.X(), point.Y() + attributesHeight);
-	shipInfo.DrawOutfits(outfPoint);
+	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
 
 	return attributesHeight + shipInfo.OutfitsHeight();
 }

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -121,8 +121,7 @@ int ShipyardPanel::DrawPlayerShipInfo(const Point &point)
 	shipInfo.Update(*playerShip, player, collapsed.count("description"));
 	shipInfo.DrawAttributes(point, true);
 	const int attributesHeight = shipInfo.GetAttributesHeight(true);
-	const Point outfitsPoint(point.X(), point.Y() + attributesHeight);
-	shipInfo.DrawOutfits(outfitsPoint);
+	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
 
 	return attributesHeight + shipInfo.OutfitsHeight();
 }

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -121,7 +121,8 @@ int ShipyardPanel::DrawPlayerShipInfo(const Point &point)
 	shipInfo.Update(*playerShip, player, collapsed.count("description"));
 	shipInfo.DrawAttributes(point, true);
 	const int attributesHeight = shipInfo.GetAttributesHeight(true);
-	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
+	const Point outfitsPoint(point.X(), point.Y() + attributesHeight);
+	shipInfo.DrawOutfits(outfitsPoint);
 
 	return attributesHeight + shipInfo.OutfitsHeight();
 }

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -120,8 +120,11 @@ int ShipyardPanel::DrawPlayerShipInfo(const Point &point)
 {
 	shipInfo.Update(*playerShip, player, collapsed.count("description"));
 	shipInfo.DrawAttributes(point, true);
+	const int attributesHeight = shipInfo.GetAttributesHeight(true);
+	const Point outfPoint(point.X(), point.Y() + attributesHeight);
+	shipInfo.DrawOutfits(outfPoint);
 
-	return shipInfo.GetAttributesHeight(true);
+	return attributesHeight + shipInfo.OutfitsHeight();
 }
 
 

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -121,8 +121,7 @@ int ShipyardPanel::DrawPlayerShipInfo(const Point &point)
 	shipInfo.Update(*playerShip, player, collapsed.count("description"));
 	shipInfo.DrawAttributes(point, true);
 	const int attributesHeight = shipInfo.GetAttributesHeight(true);
-	const Point outfPoint(point.X(), point.Y() + attributesHeight);
-	shipInfo.DrawOutfits(outfPoint);
+	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
 
 	return attributesHeight + shipInfo.OutfitsHeight();
 }


### PR DESCRIPTION
**Feature:**

## Feature Details
In the Shipyard and Outfitter panels, the selected player ship (if any) will display a list of outfits after the list of attributes, exactly the same as for selected ships in the Shipyard panel (when you're looking at ships you don't own).  If multiple ships are selected, the last one selected will be displayed, same as is currently done for attributes.

This allows for an easy comparison with purchaseable ships, particularly when checking to see what changes you may have made to the stock model of your current ship, in the Shipyard panel.  It's also easier to see what outfits are already installed, as compared to looking through all the listed outfits in the Outfitter panel.

## Testing Done
Took a save file with an existing ship with lots of outftis, looked at it in both panels.  Also tried selling all the outfits and buying more.  The outfits list was updated properly in each case.

## Screenshots
Before:
![before](https://github.com/endless-sky/endless-sky/assets/11161996/cc0b0940-2f18-47bc-b01f-16305d243c7d)

After:
![after](https://github.com/endless-sky/endless-sky/assets/11161996/bc22e7a7-4de1-486c-82ec-be00c5712adc)

(The right-most panel has been scrolled down - the top is the same as the Before shot.)

## Performance Impact
N/A