### PR TITLE
Fix(content): Add unplunderable to the lasher pistol

### DIFF
--- a/data/bunrodea/bunrodea outfits.txt
+++ b/data/bunrodea/bunrodea outfits.txt
@@ -214,6 +214,7 @@ outfit "Lasher Pistol"
 	thumbnail "outfit/lasher pistol"
 	"capture attack" 2.6
 	"capture defense" 1.4
+	"unplunderable" 1
 	description "During their wars with the Korath, it was not uncommon for Bunrodean vessels to be boarded by Korath raiders looking for technology and supplies to steal. As such, effective small arms weapons became an essential part of every Bunrodean crew that may need to fight off any boarding parties."
 
 


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue raised by BBHood217 on the discord.

## Fix Details
Adds the missing `unplunderable` attribute to the lasher pistol.

## Testing Done
None

## Save File
None