### PR TITLE
feat(ui): removed 'i' key from having an action while in PlayerInfoPanel

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -278,8 +278,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 {
 	bool control = (mod & (KMOD_CTRL | KMOD_GUI));
 	bool shift = (mod & KMOD_SHIFT);
-	if(key == 'd' || key == SDLK_ESCAPE || (key == 'w' && control)
-			|| key == 'i' || command.Has(Command::INFO))
+	if(key == 'd' || key == SDLK_ESCAPE || (key == 'w' && control))
 	{
 		GetUI()->Pop(this);
 	}


### PR DESCRIPTION
**Feature:**

## Feature Details
The PlayerInfo panel is accessed by hitting 'i'.  When on the PlayerInfo panel, hitting 'i' closes the panel.  This is unlike other panels, such as the ShipInfo panel (accessed by 's', but doesn't itself respond to 's').  Most panels have an explicit Done/Leave with associated keypresses (as the PlayerInfo panel does).

## Testing Done
Went to the PlayerInfo panel, hit 'i', it didn't do anything.