### PR TITLE
Fix Starfield Having Motion Blur When Blur is Disabled.

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -981,8 +981,8 @@ list<ShipEvent> &Engine::Events()
 // Draw a frame.
 void Engine::Draw() const
 {
-	GameData::Background().Draw(center, centerVelocity, zoom, (player.Flagship() ?
-		player.Flagship()->GetSystem() : player.GetSystem()));
+	GameData::Background().Draw(center, Preferences::Has("Render motion blur") ? centerVelocity : Point(),
+		zoom, (player.Flagship() ? player.Flagship()->GetSystem() : player.GetSystem()));
 	static const Set<Color> &colors = GameData::Colors();
 	const Interface *hud = GameData::Interfaces().Get("hud");
 

--- a/source/StarField.cpp
+++ b/source/StarField.cpp
@@ -150,7 +150,7 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom, const Syst
 			if(isParallax)
 				zoom = baseZoom * STAR_ZOOM * pow(pass, 0.2);
 
-			float length = Preferences::Has("Render motion blur") ? vel.Length() : 0.;
+			float length = vel.Length();
 			Point unit = length ? vel.Unit() : Point(1., 0.);
 			// Don't zoom the stars at the same rate as the field; otherwise, at the
 			// farthest out zoom they are too small to draw well.

--- a/source/StarField.cpp
+++ b/source/StarField.cpp
@@ -150,7 +150,7 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom, const Syst
 			if(isParallax)
 				zoom = baseZoom * STAR_ZOOM * pow(pass, 0.2);
 
-			float length = vel.Length();
+			float length = Preferences::Has("Render motion blur") ? vel.Length() : 0.;
 			Point unit = length ? vel.Unit() : Point(1., 0.);
 			// Don't zoom the stars at the same rate as the field; otherwise, at the
 			// farthest out zoom they are too small to draw well.


### PR DESCRIPTION
## Fix Details
This PR prevents the starfield from having motion blur when it is disabled.

MB Enabled (was like this before even when disabled):
![Screenshot from 2023-07-08 19-25-40](https://github.com/endless-sky/endless-sky/assets/101683475/2da8b87d-a082-4103-9912-cfd0945f2c85)


MB Disabled:
![Screenshot from 2023-07-08 19-25-53](https://github.com/endless-sky/endless-sky/assets/101683475/ba57dc8d-b4fc-41da-9b09-80afac91efb1)

