### PR TITLE
Use a more vibrant blue for shields

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -47,7 +47,7 @@ color "logbook line" .2 .2 .2 1.
 color "item selected" 0. 0. 0. .3
 
 # Colors used to draw certain HUD elements in-flight.
-color "shields" .43 .55 .70 .75
+color "shields" .43 .55 .85 .8
 color "hull" .70 .62 .43 .75
 color "disabled hull" .3 0 0 .3
 color "heat" .70 .43 .43 .75


### PR DESCRIPTION
## Feature Details
Use a slightly stronger blue (`.43 .55 .85 .8` rather than `.43 .55 .70 .75`) in the `shields` colour in interfaces.txt
Taken from #8264, as requested.

## UI Screenshots
Old
![image](https://github.com/endless-sky/endless-sky/assets/18634983/3eb175d9-6e38-4e05-a21b-66e468267852)
![image](https://github.com/endless-sky/endless-sky/assets/18634983/4de407e9-377f-4a77-9a38-2ee4086359c6)

New
![image](https://github.com/endless-sky/endless-sky/assets/18634983/e2670929-baaa-4958-ae3f-9207271d9e5d)
![image](https://github.com/endless-sky/endless-sky/assets/18634983/2db6a0d2-eb8b-44be-8fd4-4697ec5b1007)
