### PR TITLE
fix(ui) : Shop detail panel click scrolling added

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -760,7 +760,7 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 	if(button)
 		return DoKey(button);
 
-	// Check for clicks in the ShipsSidebar Panel arrows.
+	// Check for clicks on the ShipsSidebar pane arrows.
 	if(x >= Screen::Right() - 20)
 	{
 		if(y < Screen::Top() + 20)
@@ -768,7 +768,7 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 		if(y < Screen::Bottom() - BUTTON_HEIGHT && y >= Screen::Bottom() - BUTTON_HEIGHT - 20)
 			return Scroll(0, -4);
 	}
-	// Check for clicks in the DetailsSidebar Panel arrows.
+	// Check for clicks on the DetailsSidebar pane arrows.
 	else if(x >= Screen::Right() - SIDEBAR_WIDTH - 20 && x < Screen::Right() - SIDEBAR_WIDTH)
 	{
 		if(y < Screen::Top() + 20)
@@ -776,7 +776,7 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 		if(y >= Screen::Bottom() - 20)
 			return Scroll(0, -4);
 	}
-	// Check for clicks in the Main Panel arrows.
+	// Check for clicks on the Main pane arrows.
 	else if(x >= Screen::Right() - SIDE_WIDTH - 20 && x < Screen::Right() - SIDE_WIDTH)
 	{
 		if(y < Screen::Top() + 20)

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -768,7 +768,7 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 		if(y < Screen::Bottom() - BUTTON_HEIGHT && y >= Screen::Bottom() - BUTTON_HEIGHT - 20)
 			return Scroll(0, -4);
 	}
-	else if(x >= Screen::Right() - SIDE_WIDTH - 20 && x < Screen::Right() - SIDE_WIDTH)
+	else if(x >= Screen::Right() - SIDEBAR_WIDTH - 20 && x < Screen::Right() - SIDEBAR_WIDTH)
 	{
 		if(y < Screen::Top() + 20)
 			return Scroll(0, 4);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -760,8 +760,7 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 	if(button)
 		return DoKey(button);
 
-	// Check for clicks in the scroll arrows.
-	// ShipsSidebar Panel
+	// Check for clicks in the ShipsSidebar Panel arrows.
 	if(x >= Screen::Right() - 20)
 	{
 		if(y < Screen::Top() + 20)
@@ -769,7 +768,7 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 		if(y < Screen::Bottom() - BUTTON_HEIGHT && y >= Screen::Bottom() - BUTTON_HEIGHT - 20)
 			return Scroll(0, -4);
 	}
-	// DetailsSidebar Panel
+	// Check for clicks in the DetailsSidebar Panel arrows.
 	else if(x >= Screen::Right() - SIDEBAR_WIDTH - 20 && x < Screen::Right() - SIDEBAR_WIDTH)
 	{
 		if(y < Screen::Top() + 20)
@@ -777,7 +776,7 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 		if(y >= Screen::Bottom() - 20)
 			return Scroll(0, -4);
 	}
-	// Main Panel
+	// Check for clicks in the Main Panel arrows.
 	else if(x >= Screen::Right() - SIDE_WIDTH - 20 && x < Screen::Right() - SIDE_WIDTH)
 	{
 		if(y < Screen::Top() + 20)

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -761,6 +761,7 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 		return DoKey(button);
 
 	// Check for clicks in the scroll arrows.
+	// ShipsSidebar Panel
 	if(x >= Screen::Right() - 20)
 	{
 		if(y < Screen::Top() + 20)
@@ -768,7 +769,16 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 		if(y < Screen::Bottom() - BUTTON_HEIGHT && y >= Screen::Bottom() - BUTTON_HEIGHT - 20)
 			return Scroll(0, -4);
 	}
+	// DetailsSidebar Panel
 	else if(x >= Screen::Right() - SIDEBAR_WIDTH - 20 && x < Screen::Right() - SIDEBAR_WIDTH)
+	{
+		if(y < Screen::Top() + 20)
+			return Scroll(0, 4);
+		if(y >= Screen::Bottom() - 20)
+			return Scroll(0, -4);
+	}
+	// Main Panel
+	else if(x >= Screen::Right() - SIDE_WIDTH - 20 && x < Screen::Right() - SIDE_WIDTH)
 	{
 		if(y < Screen::Top() + 20)
 			return Scroll(0, 4);


### PR DESCRIPTION
**Bugfix:**

## The Bug
On the Shipyard/Outfitter screens, the detail panel (the one in the middle, that has the details of whatever's currently selected in the left panel) has scroll buttons that can't be clicked (although the panel is scrollable other ways, by keypress or scroll mouse).

## Fix Details
Added a section to ShopPanel::Click() to check for clicks on those buttons.

## Testing Done
Opened a game, selected a ship with enough details to be scrollable, tried clicking the buttons.