### PR TITLE
content: adapt the Hai relations to better reflect the Hai-UHai situation

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -425,6 +425,10 @@ government "Hai"
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
 		"Elenctic Commune" .1
+	"custom penalties for"
+		"Hai (Unfettered)"
+			capture 0
+			destroy 0
 	"bribe" .2
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"
@@ -448,6 +452,10 @@ government "Hai (Wormhole Access)"
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
 		"Elenctic Commune" .1
+	"custom penalties for"
+		"Hai (Unfettered)"
+			capture 0
+			destroy 0
 	"bribe" .2
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"
@@ -469,6 +477,10 @@ government "Hai Merchant"
 		"Hai (Friendly Unfettered)" .1
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
+	"custom penalties for"
+		"Hai (Unfettered)"
+			capture 0
+			destroy 0
 	"bribe" .02
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"
@@ -511,6 +523,10 @@ government "Hai Merchant (Human)"
 		"Hai (Friendly Unfettered)" .1
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
+	"custom penalties for"
+		"Hai (Unfettered)"
+			capture 0
+			destroy 0
 	"bribe" .02
 	"friendly hail" "friendly civilian"
 	"hostile hail" "hostile civilian"
@@ -539,6 +555,8 @@ government "Hai (Unfettered)"
 		"Merchant" -.01
 		"Kor Efret" -.01
 		"Elenctic Commune" .1
+	"penalty for"
+		disable 0
 	"bribe" .02
 	"fine" 0
 	"friendly hail" "friendly unfettered"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -425,6 +425,8 @@ government "Hai"
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
 		"Elenctic Commune" .1
+	"penalty for"
+		assist -.2
 	"custom penalties for"
 		"Hai (Unfettered)"
 			capture 0
@@ -452,6 +454,8 @@ government "Hai (Wormhole Access)"
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
 		"Elenctic Commune" .1
+	"penalty for"
+		assist -.2
 	"custom penalties for"
 		"Hai (Unfettered)"
 			capture 0
@@ -477,6 +481,8 @@ government "Hai Merchant"
 		"Hai (Friendly Unfettered)" .1
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
+	"penalty for"
+		assist -.2
 	"custom penalties for"
 		"Hai (Unfettered)"
 			capture 0
@@ -502,6 +508,8 @@ government "Hai Merchant (Sympathizers)"
 		"Hai (Friendly Unfettered)" .5
 		"Hai (Unfettered Civilians)" .5
 		"Merchant" .01
+	"penalty for"
+		assist -.2
 	"bribe" .02
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"
@@ -523,6 +531,8 @@ government "Hai Merchant (Human)"
 		"Hai (Friendly Unfettered)" .1
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
+	"penalty for"
+		assist -.2
 	"custom penalties for"
 		"Hai (Unfettered)"
 			capture 0

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -565,6 +565,10 @@ government "Hai (Unfettered)"
 		"Merchant" -.01
 		"Kor Efret" -.01
 		"Elenctic Commune" .1
+	"foreign penalties for"
+		"Hai (Friendly Unfettered)"
+		"Hai (Unfettered Wanderer Tribute)"
+		"Hai (Unfettered Civilians)"
 	"penalty for"
 		disable 0
 	"bribe" .02
@@ -600,6 +604,8 @@ government "Hai (Friendly Unfettered)"
 		"Hai (Wormhole Access)" .01
 		"Hai (Unfettered)" 1
 		"Elenctic Commune" .01
+	"foreign penalties for"
+		"Hai (Unfettered)"
 	"bribe" .02
 	"fine" 0
 	"friendly hail" "friendly unfettered"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -426,7 +426,7 @@ government "Hai"
 		"Merchant" .01
 		"Elenctic Commune" .1
 	"penalty for"
-		assist -.2
+		assist -.15
 	"custom penalties for"
 		"Hai (Unfettered)"
 			capture 0
@@ -455,7 +455,7 @@ government "Hai (Wormhole Access)"
 		"Merchant" .01
 		"Elenctic Commune" .1
 	"penalty for"
-		assist -.2
+		assist -.15
 	"custom penalties for"
 		"Hai (Unfettered)"
 			capture 0
@@ -482,7 +482,7 @@ government "Hai Merchant"
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
 	"penalty for"
-		assist -.2
+		assist -.15
 	"custom penalties for"
 		"Hai (Unfettered)"
 			capture 0
@@ -509,7 +509,7 @@ government "Hai Merchant (Sympathizers)"
 		"Hai (Unfettered Civilians)" .5
 		"Merchant" .01
 	"penalty for"
-		assist -.2
+		assist -.15
 	"bribe" .02
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"
@@ -532,7 +532,7 @@ government "Hai Merchant (Human)"
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
 	"penalty for"
-		assist -.2
+		assist -.15
 	"custom penalties for"
 		"Hai (Unfettered)"
 			capture 0

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -420,17 +420,13 @@ government "Hai"
 		"Hai Merchant" 1
 		"Hai Merchant (Sympathizers)" 1
 		"Hai Merchant (Human)" 1
-		"Hai (Unfettered)" -.1
+		"Hai (Unfettered)" -.01
 		"Hai (Friendly Unfettered)" .1
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
 		"Elenctic Commune" .1
 	"penalty for"
 		assist -.15
-	"custom penalties for"
-		"Hai (Unfettered)"
-			capture 0
-			destroy 0
 	"bribe" .2
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"
@@ -449,17 +445,13 @@ government "Hai (Wormhole Access)"
 		"Hai Merchant" 1
 		"Hai Merchant (Sympathizers)" 1
 		"Hai Merchant (Human)" 1
-		"Hai (Unfettered)" -.1
+		"Hai (Unfettered)" -.01
 		"Hai (Friendly Unfettered)" .1
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
 		"Elenctic Commune" .1
 	"penalty for"
 		assist -.15
-	"custom penalties for"
-		"Hai (Unfettered)"
-			capture 0
-			destroy 0
 	"bribe" .2
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"
@@ -486,7 +478,6 @@ government "Hai Merchant"
 	"custom penalties for"
 		"Hai (Unfettered)"
 			capture 0
-			destroy 0
 	"bribe" .02
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -533,10 +533,6 @@ government "Hai Merchant (Human)"
 		"Merchant" .01
 	"penalty for"
 		assist -.15
-	"custom penalties for"
-		"Hai (Unfettered)"
-			capture 0
-			destroy 0
 	"bribe" .02
 	"friendly hail" "friendly civilian"
 	"hostile hail" "hostile civilian"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -531,8 +531,6 @@ government "Hai Merchant (Human)"
 		"Hai (Friendly Unfettered)" .1
 		"Hai (Unfettered Civilians)" .1
 		"Merchant" .01
-	"penalty for"
-		assist -.15
 	"bribe" .02
 	"friendly hail" "friendly civilian"
 	"hostile hail" "hostile civilian"


### PR DESCRIPTION
## Lore

I changed the Hai-Unfettered relations:

The Unfettered do not mind being disabled anymore, as you just bested them (they won't be proud to tell anyone!). This means that the player's reputation towards them is more reflective of things they actually mind (and your fleet passively disabling them is fine).
I could make them care less about being boarded, too.

As for the Hai, they should not approve you destroying or capturing their cousins. The compromise is to make them have -0.01 relation, meaning they wont react to you disabling/killing/capping the Unfettered at all.
To compensate for the lower overall reputation that will result of this, I made them care more about you assisting their ships (they go as far as giving you money for it, so they care a lot, especially since being disabled means being at the mercy of the Unfettered - or worse, of pirates)

This will also have the effect of reducing the amount of difference there is between the Hai and Sympathizers reputations, but it increases between the Hai and the Merchant factions