### PR TITLE
feat(ui): always show subpanel buttons on Planet Panel

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -790,7 +790,7 @@ interface "planet"
 		align left
 		pad 10 0
 	
-	visible if "has ship"
+	active if "has ship"
 	sprite "ui/planet dialog button"
 		center 280 270
 	button d "_Depart"
@@ -799,17 +799,6 @@ interface "planet"
 		size 18
 		align right
 		pad 10 0
-
-	visible if "!has ship"
-	sprite "ui/planet dialog button"
-		center 280 270
-	button "" "Depart"
-		center 280 270
-		dimensions 140 40
-		size 18
-		align right
-		pad 10 0
-
 
 
 

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -789,6 +789,7 @@ interface "planet"
 		size 18
 		align left
 		pad 10 0
+	visible
 	
 	active if "has ship"
 	sprite "ui/planet dialog button"

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -800,6 +800,17 @@ interface "planet"
 		align right
 		pad 10 0
 
+	visible if "!has ship"
+	sprite "ui/planet dialog button"
+		center 280 270
+	button "" "Depart"
+		center 280 270
+		dimensions 140 40
+		size 18
+		align right
+		pad 10 0
+
+
 
 
 interface "spaceport"

--- a/source/HiringPanel.cpp
+++ b/source/HiringPanel.cpp
@@ -85,7 +85,7 @@ void HiringPanel::Draw()
 	info.SetString("passengers", to_string(passengers));
 
 	static const int DAILY_SALARY = 100;
-	int salary = DAILY_SALARY * (flagship ? fleetRequired - 1 : 0);
+	int salary = DAILY_SALARY * (fleetRequired - (flagship ? 1 : 0));
 	int extraSalary = DAILY_SALARY * flagshipExtra;
 	info.SetString("salary required", to_string(salary));
 	info.SetString("salary extra", to_string(extraSalary));

--- a/source/HiringPanel.cpp
+++ b/source/HiringPanel.cpp
@@ -46,14 +46,22 @@ void HiringPanel::Step()
 void HiringPanel::Draw()
 {
 	const Ship *flagship = player.Flagship();
-
 	const Interface *hiring = GameData::Interfaces().Get("hiring");
 	Information info;
 
-	int flagshipBunks = flagship ? flagship->Attributes().Get("bunks") : 0;
-	int flagshipRequired = flagship ? flagship->RequiredCrew() : 0;
-	int flagshipExtra = flagship ? flagship->Crew() - flagshipRequired : 0;
-	int flagshipUnused = flagship ? flagshipBunks - flagship->Crew() : 0;
+	int flagshipBunks = 0;
+	int flagshipRequired = 0;
+	int flagshipExtra = 0;
+	int flagshipUnused = 0;
+
+	if(flagship)
+	{
+		flagshipBunks = flagship->Attributes().Get("bunks");
+		flagshipRequired = flagship->RequiredCrew();
+		flagshipExtra = flagship->Crew() - flagshipRequired;
+		flagshipUnused = flagshipBunks - flagship->Crew();
+	}
+
 	info.SetString("flagship bunks", to_string(flagshipBunks));
 	info.SetString("flagship required", to_string(flagshipRequired));
 	info.SetString("flagship extra", to_string(flagshipExtra));

--- a/source/HiringPanel.cpp
+++ b/source/HiringPanel.cpp
@@ -45,17 +45,15 @@ void HiringPanel::Step()
 
 void HiringPanel::Draw()
 {
-	if(!player.Flagship())
-		return;
-	const Ship &flagship = *player.Flagship();
+	const Ship *flagship = player.Flagship();
 
 	const Interface *hiring = GameData::Interfaces().Get("hiring");
 	Information info;
 
-	int flagshipBunks = flagship.Attributes().Get("bunks");
-	int flagshipRequired = flagship.RequiredCrew();
-	int flagshipExtra = flagship.Crew() - flagshipRequired;
-	int flagshipUnused = flagshipBunks - flagship.Crew();
+	int flagshipBunks = flagship ? flagship->Attributes().Get("bunks") : 0;
+	int flagshipRequired = flagship ? flagship->RequiredCrew() : 0;
+	int flagshipExtra = flagship ? flagship->Crew() - flagshipRequired : 0;
+	int flagshipUnused = flagship ? flagshipBunks - flagship->Crew() : 0;
 	info.SetString("flagship bunks", to_string(flagshipBunks));
 	info.SetString("flagship required", to_string(flagshipRequired));
 	info.SetString("flagship extra", to_string(flagshipExtra));
@@ -79,7 +77,7 @@ void HiringPanel::Draw()
 	info.SetString("passengers", to_string(passengers));
 
 	static const int DAILY_SALARY = 100;
-	int salary = DAILY_SALARY * (fleetRequired - 1);
+	int salary = DAILY_SALARY * (flagship ? fleetRequired - 1 : 0);
 	int extraSalary = DAILY_SALARY * flagshipExtra;
 	info.SetString("salary required", to_string(salary));
 	info.SetString("salary extra", to_string(extraSalary));

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -82,7 +82,7 @@ void PlanetPanel::Step()
 	// If the player starts a new game, exits the shipyard without buying
 	// anything, clicks to another location, then returns to the shipyard
 	// and buys a ship, make sure they are shown an intro mission.
-	if(GetUI()->IsTop(this) || GetUI()->IsTop(bank.get()) || GetUI()->IsTop(trading.get()) || GetUI()->IsTop(hiring.get()))
+	if(GetUI()->IsTop(selectedPanel && selectedPanel != spaceport.get() ? selectedPanel : this))
 	{
 		Mission *mission = player.MissionToOffer(Mission::LANDING);
 		if(mission)

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -80,9 +80,9 @@ void PlanetPanel::Step()
 	}
 
 	// If the player starts a new game, exits the shipyard without buying
-	// anything, clicks to the bank, then returns to the shipyard and buys a
-	// ship, make sure they are shown an intro mission.
-	if(GetUI()->IsTop(this) || GetUI()->IsTop(bank.get()))
+	// anything, clicks to another location, then returns to the shipyard
+	// and buys a ship, make sure they are shown an intro mission.
+	if(GetUI()->IsTop(this) || GetUI()->IsTop(bank.get()) || GetUI()->IsTop(trading.get()) || GetUI()->IsTop(hiring.get()))
 	{
 		Mission *mission = player.MissionToOffer(Mission::LANDING);
 		if(mission)

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -110,28 +110,20 @@ void PlanetPanel::Draw()
 	{
 		if(planet.IsInhabited())
 		{
+			info.SetCondition("is inhabited");
 			info.SetCondition("has bank");
-			if(flagship)
-			{
-				info.SetCondition("is inhabited");
-				if(system.HasTrade())
-					info.SetCondition("has trade");
-			}
+			if(system.HasTrade())
+				info.SetCondition("has trade");
 		}
 
-		if(flagship && planet.HasSpaceport())
+		if(planet.HasSpaceport())
 			info.SetCondition("has spaceport");
 
 		if(planet.HasShipyard())
 			info.SetCondition("has shipyard");
 
 		if(planet.HasOutfitter())
-			for(const auto &it : player.Ships())
-				if(it->GetSystem() == &system && !it->IsDisabled())
-				{
-					info.SetCondition("has outfitter");
-					break;
-				}
+			info.SetCondition("has outfitter");
 	}
 
 	ui.Draw(info, this);
@@ -164,7 +156,7 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 	}
 	else if(key == 'l')
 		selectedPanel = nullptr;
-	else if(key == 't' && hasAccess && flagship && planet.IsInhabited() && system.HasTrade())
+	else if(key == 't' && hasAccess && planet.IsInhabited() && system.HasTrade())
 	{
 		selectedPanel = trading.get();
 		GetUI()->Push(trading);
@@ -174,7 +166,7 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 		selectedPanel = bank.get();
 		GetUI()->Push(bank);
 	}
-	else if(key == 'p' && hasAccess && flagship && planet.HasSpaceport())
+	else if(key == 'p' && hasAccess && planet.HasSpaceport())
 	{
 		selectedPanel = spaceport.get();
 		if(isNewPress)
@@ -188,19 +180,15 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 	}
 	else if(key == 'o' && hasAccess && planet.HasOutfitter())
 	{
-		for(const auto &it : player.Ships())
-			if(it->GetSystem() == &system && !it->IsDisabled())
-			{
-				GetUI()->Push(new OutfitterPanel(player));
-				return true;
-			}
+		GetUI()->Push(new OutfitterPanel(player));
+		return true;
 	}
-	else if(key == 'j' && hasAccess && flagship && planet.IsInhabited())
+	else if(key == 'j' && hasAccess && planet.IsInhabited())
 	{
 		GetUI()->Push(new MissionPanel(player));
 		return true;
 	}
-	else if(key == 'h' && hasAccess && flagship && planet.IsInhabited())
+	else if(key == 'h' && hasAccess && planet.IsInhabited())
 	{
 		selectedPanel = hiring.get();
 		GetUI()->Push(hiring);

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -79,10 +79,12 @@ void PlanetPanel::Step()
 		return;
 	}
 
-	// If the player starts a new game, exits the shipyard without buying
-	// anything, clicks to another location, then returns to the shipyard
-	// and buys a ship, make sure they are shown an intro mission.
-	if(GetUI()->IsTop(selectedPanel && selectedPanel != spaceport.get() ? selectedPanel : this))
+	// Handle missions for locations that aren't handled separately,
+	// treating them all as the landing location. This is mainly to
+	// handle the intro mission in the event the player moves away
+	// from the landing before buying a ship.
+	const Panel *activePanel = selectedPanel ? selectedPanel : this;
+	if(activePanel != spaceport.get() && GetUI()->IsTop(activePanel))
 	{
 		Mission *mission = player.MissionToOffer(Mission::LANDING);
 		if(mission)


### PR DESCRIPTION
**Feature:**

## Feature Details
On the Planet panel, buttons for all subpanels are shown (and active), even if the player doesn't have a flagship (i.e., has no ships on planet).  Depart is inactive unless the player has a ship.  All panels behave properly for the player not having a ship (jobs are listed as unavailable, crew is zero, no commodities can be purchased).

This changes the existing PlanetPanel UI which hides the Trading, Job Board, Spaceport, Outfitter, Hire Crew, and Depart buttons when the player has no flagship.

## Reason for Change
One of the primary reasons a player has no ship is that they're buying a new one, and having access to various information (trading prices, jobs available, outfits available) can inform that decision.  Also, if the player has outfits in storage on the planet, they cannot sell them without access to the Outfitter.  And it just seems weird having the buttons vanish - can't the player walk around the place even if they don't have a ship?

## UI screenshots
![Screenshot from 2023-07-14 13-04-07](https://github.com/endless-sky/endless-sky/assets/11161996/2bab04c4-cebc-4d85-bfa0-2bd0e9da6251)
![Screenshot from 2023-07-13 09-41-37](https://github.com/endless-sky/endless-sky/assets/11161996/33e2637f-7d52-4142-8579-23ba980a3f0b)
![Screenshot from 2023-07-13 09-41-54](https://github.com/endless-sky/endless-sky/assets/11161996/fc22d656-e5c7-495f-9f02-18c3d83ce9d2)
![Screenshot from 2023-07-13 09-41-59](https://github.com/endless-sky/endless-sky/assets/11161996/ad48414e-a475-486c-b43f-a888dd56e143)
![Screenshot from 2023-07-13 09-42-07](https://github.com/endless-sky/endless-sky/assets/11161996/7370dcf5-7a75-430c-8dbc-0aa9645ba552)

## Testing Done
I checked to make sure that missions don't fire when the player has no ships.  Likewise, each panel already does checks that handle the case of no player ships (with the exception of the Hiring panel which assumed that there was at least one crew required).

Obviously, this will supercede #8971 if it gets accepted.