### PR TITLE
Feat(balance): Give the Dagger +5 engine space and an A120 atomic thruster, to give it a clearer niche and to better match its description

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1440,7 +1440,7 @@ ship "Dagger"
 		"heat dissipation" .9
 		"outfit space" 90
 		"weapon capacity" 20
-		"engine capacity" 30
+		"engine capacity" 35
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -1453,10 +1453,10 @@ ship "Dagger"
 		
 		"nGVF-AA Fuel Cell"
 		"Supercapacitor"
-		"D23-QP Shield Generator"
+		"D14-RN Shield Generator"
 		"Small Radar Jammer"
 		
-		"X1700 Ion Thruster"
+		"A120 Atomic Thruster"
 		"X1200 Ion Steering"
 		
 	engine -8 34


### PR DESCRIPTION
**Balance:**

## Summary
Gives the Dagger +5 engine space (30 -> 35), and replaces its X1700 Ion Thruster with an A120 Atomic Thruster. Shield generator is downgraded from a D23-QP to a D14-RN to make space. This gives the Dagger a top speed of 1466.6, a significant improvement over its previous 685.7, and noticeably better than the 1113.2 that the Finch can achieve with the same engine.

## Reasoning
While various people have talked about the balance of fighters against other options, the balance within the fighter category in human space is in quite a bad position. The Finch is the fastest (thanks to its larger engine space), largest and toughest fighter. The Dagger is slower by ~150, yet the Dagger's description proclaims it to be "Considerably faster than other fighters". Given that the Dagger is a Lionheart ship, manufactured in the Deep, it makes sense for it to run Deep Sky atomic engines, also manufactured in the Deep.
This does make the Dagger a fair bit more expensive, but Lionheart ships do tend to be quite expensive for their size, so that does fit thematically.

As a potential alternative way to fit the new engine rather than downgrading the shield generator, how about giving the Dagger +5 outfit space too (90 -> 95), and just removing the small radar jammer? With the top speed the Dagger gains with an atomic thruster, it doesn't really benefit from the jamming, because it's fast enough that it's very unlikely to be hit by missiles even without the jammer.

## Save File
