### PR TITLE
fix(content): Keep Ssil Vida's "remnant station" attribute 

### DIFF
--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -283,7 +283,7 @@ event "remnant: merganser fleet"
 
 event "remnant: ssil vida inhabited"
 	planet "Ssil Vida"
-		attributes emitter sheragi remnant
+		attributes emitter "remnant station" sheragi
 		landscape land/station0
 		description `The silence of this station rings in your ears, and as you explore you are increasingly surprised that it even has an atmosphere. It is obviously ancient, and patches of ambiguous green and purple material resembling fungus grow through the walls. Whoever built this station designed it for beings much larger than you - either that, or they liked spacious environments. Even the shortest doorway you pass through is easily double your height. They are always wider than they are tall.`
 		description `	Exploring beyond the docks reveals that most of this facility is infrastructure for some type of massive emitter. It is not clear exactly what it's supposed to be emitting, but it might have something to do with how this system appeared in the first place.`


### PR DESCRIPTION
Keep Ssil Vida's "remnant station" attribute when people start working there

----------------------
**Content (Artwork / Missions / Jobs)**

## Summary
Though Ssil Vida had the "remnant station" attribute added, which prevents the "Broken Jump Drive Bounty" job from picking it as a destination, that attribute is removed upon the "Ssil Vida inhabited" event due to its entire definition being replaced and that event not yet being updated with the new attribute.

## Save File
[Hannah Derinden.txt](https://github.com/endless-sky/endless-sky/files/12073893/Hannah.Derinden.txt)

-----------------------
**Bugfix:** I don't see a reported instance of this bug on GitHub, but I have seen screenshots from other players that verify they experience it too (the job incorrectly pointing to Ssil Vida).

## Fix Details
Add the `"remnant station"` attribute to the definition of Ssil Vida as modified by the event.

Please note: I am unsure whether it is most correct to use that to _replace_ the `remnant` attribute, or to add it as well. I have done the former, but would be happy to edit to do the latter if that is better.

## Testing Done
Have not tested; however, due to the minimal nature of the fix, and the (seemingly) clear oversight in the event, it should be quite safe.

## Save File
(See above)
