### PR TITLE
feat(ui): change map none color to darker blue (for shipyard/outfitter lists)

### DIFF
--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -141,7 +141,7 @@ double MapOutfitterPanel::SystemValue(const System *system) const
 		return numeric_limits<double>::quiet_NaN();
 
 	// Visiting a system is sufficient to know what ports are available on its planets.
-	double value = -.5;
+	double value = -1.;
 	for(const StellarObject &object : system->Objects())
 		if(object.HasSprite() && object.HasValidPlanet())
 		{

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -225,7 +225,7 @@ void MapSalesPanel::DrawKey() const
 	Point textOff(10., -.5 * font.Height());
 
 	static const double VALUE[] = {
-		-.5,
+		-1.,
 		0.,
 		1.
 	};

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -141,7 +141,7 @@ double MapShipyardPanel::SystemValue(const System *system) const
 		return numeric_limits<double>::quiet_NaN();
 
 	// Visiting a system is sufficient to know what ports are available on its planets.
-	double value = -.5;
+	double value = -1.;
 	for(const StellarObject &object : system->Objects())
 		if(object.HasSprite() && object.HasValidPlanet())
 		{


### PR DESCRIPTION
**Feature:**

## Feature Details
On the outfitter and shipyard maps, systems are displayed in one of three colors, depending on if they have an outfitter/shipyard or not, and if they sell a selected item (if any).  The color currently used for no outfitter/shipyard is a lighter blue (SystemValue -.5).  This would change it to use a darker blue (SystemValue -1.) to make systems with outfitters/shipyards more apparent.

## UI Screenshots
Before:
![Screenshot from 2023-07-20 10-28-23](https://github.com/endless-sky/endless-sky/assets/11161996/3e5bff4a-74bb-457d-8bb2-742162b66bc8)
After:
![Screenshot from 2023-07-20 10-27-45](https://github.com/endless-sky/endless-sky/assets/11161996/0279e891-7921-4192-901a-afbcb47c3cac)

## Performance Impact
N/A