### PR TITLE
One minute Sad Archie

### DIFF
--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -307,8 +307,8 @@ mission "Deep Archaeology 5"
 ship "Timer Ship"
 	attributes
 		"heat dissipation" 1
-		"hull" 3
-		"hull repair rate" .001
+		"hull" 6
+		"hull repair rate" -.001
 		"mass" 100
 		"drag" 5
 		"automaton" 1


### PR DESCRIPTION
**Balance:**

## Summary
Reliably complete Sad Archie by waiting one Real Life Minute

## Reasoning
From my tests Sad Archie will often never complete, and if it does, take several real life minutes to do so. I've had enough patience to do four timed runs (with the mission confirmed active by inspecting the save), and the mission not concluding within 30 RL minutes or more.

That to me contradicts the definition of "game".

With this change, completion delay is just under one RL minute, variance from testing seems +/- 5 seconds, mainly from the Timer Ship needing more or less time to find you. Feels about right to _me_. If you think that too quick, just increase hull, but by god don't give it regeneration so close to the maximum damage it can inflict - I think that's the reason Sad Archie is so annoying: Every Pirate visit will distract the Timer Ship long enough for a full heal, and Pirates seem at least 3 per minute.

## Testing Done
Changed the values in a snapshot save, loaded that in release code and repeated the mission 5 times.