### PR TITLE
fix(saves): save all location tags for missions

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -369,13 +369,13 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			out.Write("autosave");
 		if(location == LANDING)
 			out.Write("landing");
-		else if(location == SHIPYARD)
+		if(location == SHIPYARD)
 			out.Write("shipyard");
-		else if(location == OUTFITTER)
+		if(location == OUTFITTER)
 			out.Write("outfitter");
-		else if(location == ASSISTING)
+		if(location == ASSISTING)
 			out.Write("assisting");
-		else if(location == BOARDING)
+		if(location == BOARDING)
 		{
 			out.Write("boarding");
 			if(overridesCapture)
@@ -387,7 +387,7 @@ void Mission::Save(DataWriter &out, const string &tag) const
 				out.EndChild();
 			}
 		}
-		else if(location == JOB)
+		if(location == JOB)
 			out.Write("job");
 		if(!clearance.empty())
 		{

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -369,13 +369,13 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			out.Write("autosave");
 		if(location == LANDING)
 			out.Write("landing");
-		if(location == SHIPYARD)
+		else if(location == SHIPYARD)
 			out.Write("shipyard");
-		if(location == OUTFITTER)
+		else if(location == OUTFITTER)
 			out.Write("outfitter");
-		if(location == ASSISTING)
+		else if(location == ASSISTING)
 			out.Write("assisting");
-		if(location == BOARDING)
+		else if(location == BOARDING)
 		{
 			out.Write("boarding");
 			if(overridesCapture)
@@ -387,7 +387,7 @@ void Mission::Save(DataWriter &out, const string &tag) const
 				out.EndChild();
 			}
 		}
-		if(location == JOB)
+		else if(location == JOB)
 			out.Write("job");
 		if(!clearance.empty())
 		{

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -369,9 +369,13 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			out.Write("autosave");
 		if(location == LANDING)
 			out.Write("landing");
-		if(location == ASSISTING)
+		else if(location == SHIPYARD)
+			out.Write("shipyard");
+		else if(location == OUTFITTER)
+			out.Write("outfitter");
+		else if(location == ASSISTING)
 			out.Write("assisting");
-		if(location == BOARDING)
+		else if(location == BOARDING)
 		{
 			out.Write("boarding");
 			if(overridesCapture)
@@ -383,7 +387,7 @@ void Mission::Save(DataWriter &out, const string &tag) const
 				out.EndChild();
 			}
 		}
-		if(location == JOB)
+		else if(location == JOB)
 			out.Write("job");
 		if(!clearance.empty())
 		{


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #9057

## Fix Details
Added code in Mission::Save to save shipyard and landing locations.

## Testing Done
Ran it with #9024 also added for the early shipyard mission, saved at a location the mission would be saved, saved the game, checked the save file, found the tag.  Loaded the game and the mission would not fire in the spaceport, but would in the shipyard.

## Additional Notes
While I was in there, changed save to use else's when checking location, as missions can only be at one location.