### PR TITLE
Fix a bug when displaying the amount of harvested materials a ship has in cargo

### DIFF
--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -359,14 +359,14 @@ void MainPanel::ShowScanDialog(const ShipEvent &event)
 					out << "This " + target->Noun() + " is carrying:\n";
 				first = false;
 
-				out << "\t" << it.second;
+				out << "\t";
 				if(it.first->Get("installable") < 0.)
 				{
 					int tons = ceil(it.second * it.first->Mass());
 					out << Format::CargoString(tons, Format::LowerCase(it.first->PluralName())) << "\n";
 				}
 				else
-					out << " " << (it.second == 1 ? it.first->DisplayName(): it.first->PluralName()) << "\n";
+					out << it.second << " " << (it.second == 1 ? it.first->DisplayName(): it.first->PluralName()) << "\n";
 			}
 		if(first)
 			out << "This " + target->Noun() + " is not carrying any cargo.\n";

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -366,7 +366,7 @@ void MainPanel::ShowScanDialog(const ShipEvent &event)
 					out << Format::CargoString(tons, Format::LowerCase(it.first->PluralName())) << "\n";
 				}
 				else
-					out << it.second << " " << (it.second == 1 ? it.first->DisplayName(): it.first->PluralName()) << "\n";
+					out << it.second << " " << (it.second == 1 ? it.first->DisplayName() : it.first->PluralName()) << "\n";
 			}
 		if(first)
 			out << "This " + target->Noun() + " is not carrying any cargo.\n";


### PR DESCRIPTION
**Bugfix:**

Thanks to @Hurleveur for reporting this on Discord.

## Fix Details
The number of units of the outfit the ship has in cargo is first added to the output stream, then the mass of those outfits is added to it, resulting in the value being duplicated.
For example:
![image](https://github.com/endless-sky/endless-sky/assets/20605679/4f3118d9-beec-449d-850c-1d9207d02885)
This creature actually only has 27 tonnes of the first item and 13 tonnes of the second, but those values are being added to the output string twice so they appear as 2727 and 1313.
This PR removes the duplication.

## Testing Done
Scan ships carrying harvested materials in cargo.
Without this change, the value is repeated, with it, the correct values are shown.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
[warp void sprite cargo testing.txt](https://github.com/endless-sky/endless-sky/files/12146237/warp.void.sprite.cargo.testing.txt)
Scan some Korath or Remnant ships.
[warp void sprite cargo testing~modified.txt](https://github.com/endless-sky/endless-sky/files/12146238/warp.void.sprite.cargo.testing.modified.txt)
Scan some Void Sprites.
