### PR TITLE
Balance: ion cannon 20% ions buff

### DIFF
--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -118,8 +118,8 @@ outfit "Ion Cannon"
 		"hit force" 120
 		"shield damage" 168
 		"hull damage" 60
-		"ion damage" 5
-		"scrambling damage" 5
+		"ion damage" 6.5
+		"scrambling damage" 4.5
 	description "Ion cannons do not inflict as much damage as some other weapons, but they disrupt the electrical systems on any ship they hit, draining its energy and causing its weapons to jam. If a ship has sizable battery reserves, this may have little effect, but for a ship running at near its energy generation capacity an ion strike can take it out of the battle for a few seconds while it recovers, or otherwise cause it to have difficulty firing its weapons."
 
 effect "ion impact"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -118,8 +118,8 @@ outfit "Ion Cannon"
 		"hit force" 120
 		"shield damage" 168
 		"hull damage" 60
-		"ion damage" 6.5
-		"scrambling damage" 4.5
+		"ion damage" 6
+		"scrambling damage" 6
 	description "Ion cannons do not inflict as much damage as some other weapons, but they disrupt the electrical systems on any ship they hit, draining its energy and causing its weapons to jam. If a ship has sizable battery reserves, this may have little effect, but for a ship running at near its energy generation capacity an ion strike can take it out of the battle for a few seconds while it recovers, or otherwise cause it to have difficulty firing its weapons."
 
 effect "ion impact"


### PR DESCRIPTION
**Balance:**

## Summary
The ion cannon went from 5 ion 5 scrambling to 6 6 scrambling.
The scrambling element's interaction with lasers will get a rework soon I just dont know how yet.

## Reasoning
Currently the weapon is only borderline useful if you spam it a lot, although some say the scrambling part is too good in duels (I didnt notice that myself tho)
~~Hence why I am reducing it, whilst increasing the ion side of the weapon, but I could go to say 4 on it, and only buff it by 5% in total? Or make it 6 - 4.5? (or 6.5-4 but then its getting close to prototype territory, which could be fine)~~ changed to sticking with 6 6 because the normal version should not be "prototyped"

I like the ion cannon keep on being sort of a jack of trades, not too good but good against some factions still, that's why I don't want to remove scrambling from it.
I also think removing the scrambling effect for full ion would make this too strong against anything but Hai, Ka'het and Remnant, so I don't want to go that way.


note: this is the last buff I'm thinking on doing, I wont touch the shields being bad or smth else, it's just that the ion cannon are a terror in lore but then they kinda suck in game, you're better going with proton cannons or smth most of the time. The Hai and UHai are currently way overreacting to them.

## Save File
These save files can be used to test the balance changes.
[Emile.Lancer.IC.txt](https://github.com/endless-sky/endless-sky/files/12157769/Emile.Lancer.IC.txt)
Have fun in Wah Ki. Yes, it will not be very effective due to the high (Hai) batteries. It shouldnt be good but it should be good enough to warrant them spamming batteries, and punish those who dont.
[Emile.Lancer.IC~~pirates.txt](https://github.com/endless-sky/endless-sky/files/12157786/Emile.Lancer.IC.pirates.txt)
Here against pirates; it should be a menace against them. Right now if they have so much as 6k batteries you almost take the shields down faster than you ionize them properly, using 6 ion cannons.
[Emile.Lancer.IC~~korath-pirates.txt](https://github.com/endless-sky/endless-sky/files/12157865/Emile.Lancer.IC.korath-pirates.txt)
Koraths are one of the most vulnerable to scrambling/ion with pretty much no batteries (they should have gotten buffed like the rest but eh not a discussion for this PR)