### PR TITLE
feat(refactor): change ShopPanel drawing to check for rescroll earlier

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -115,10 +115,24 @@ void ShopPanel::Draw()
 	zones.clear();
 	categoryZones.clear();
 
+	DrawMain();
+
+	// If the selected item on the main pane was drawn in a different location, scroll
+	// such that it's now in the same location and redraw.
+	if(sameSelectedTopY)
+	{
+		sameSelectedTopY = false;
+		if(selectedTopY != oldSelectedTopY)
+		{
+			mainScroll = max(0., min(maxMainScroll, mainScroll + selectedTopY - oldSelectedTopY));
+			Draw();
+			return;
+		}
+	}
+
 	DrawShipsSidebar();
 	DrawDetailsSidebar();
 	DrawButtons();
-	DrawMain();
 	DrawKey();
 
 	shipInfo.DrawTooltips();
@@ -161,16 +175,6 @@ void ShopPanel::Draw()
 		}
 	}
 
-	if(sameSelectedTopY)
-	{
-		sameSelectedTopY = false;
-		if(selectedTopY != oldSelectedTopY)
-		{
-			// Redraw with the same selected top (item in the same place).
-			mainScroll = max(0., min(maxMainScroll, mainScroll + selectedTopY - oldSelectedTopY));
-			Draw();
-		}
-	}
 	mainScroll = min(mainScroll, maxMainScroll);
 }
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -107,26 +107,28 @@ void ShopPanel::Step()
 
 void ShopPanel::Draw()
 {
-	const double oldSelectedTopY = selectedTopY;
-
 	glClear(GL_COLOR_BUFFER_BIT);
 
 	// Clear the list of clickable zones.
 	zones.clear();
 	categoryZones.clear();
 
+	const double oldSelectedTopY = selectedTopY;
 	DrawMain();
-
-	// If the selected item on the main pane was drawn in a different location, scroll
-	// such that it's now in the same location and redraw.
+	// If the selected item on the main pane was drawn on a different line,
+	// scroll such that it's now on the same line and redraw.
 	if(sameSelectedTopY)
 	{
 		sameSelectedTopY = false;
 		if(selectedTopY != oldSelectedTopY)
 		{
-			mainScroll = max(0., min(maxMainScroll, mainScroll + selectedTopY - oldSelectedTopY));
-			Draw();
-			return;
+			const double newScroll = max(0., min(maxMainScroll, mainScroll + selectedTopY - oldSelectedTopY));
+			if(mainScroll != newScroll)
+			{
+				mainScroll = newScroll;
+				Draw();
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
**Feature:**

## Feature Details
In ShopPanel::Draw(), the entire panel can be redrawn to bring a selected item in the item list its former Y coord.  However, it only needs to draw the main pane to calculate the Y coord, not the whole panel, so this draws the main pane first and checks if it needs to redraw, rather than drawing everything.

## Testing Done
Messed around in the Outfitters with the toggles and ship selection.

## Performance Impact
Slight improvement after doing something that can trigger this section of code (toggling items for sale/in cargo/in storage, or changing the selected player ship).