### PR TITLE
Balance: Nullifier rebalance

### DIFF
--- a/data/kahet/kahet outfits.txt
+++ b/data/kahet/kahet outfits.txt
@@ -44,7 +44,7 @@ outfit "Ka'het Nullifier"
 		"turn" 73
 		"shield damage" 120
 		"hull damage" 40
-		"energy damage" 80
+		"energy damage" 3200
 		"ion damage" 220
 		"scrambling damage" 10
 		"hit force" 50

--- a/data/kahet/kahet outfits.txt
+++ b/data/kahet/kahet outfits.txt
@@ -44,8 +44,9 @@ outfit "Ka'het Nullifier"
 		"turn" 73
 		"shield damage" 120
 		"hull damage" 40
-		"ion damage" 150
-		"scrambling damage" 150
+		"energy damage" 80
+		"ion damage" 220
+		"scrambling damage" 10
 		"hit force" 50
 		"blast radius" 20
 	description "The Nullifier was one of the largest weapons the Builders ever developed, created specifically to be carried in battle by the Vareti. Although it does almost no damage to shields and hull, one shot is capable of disabling most kinds of reactors in a matter of seconds."


### PR DESCRIPTION
**Balance:**

## Summary
In the same spirit of https://github.com/endless-sky/endless-sky/pull/9070, I've changed the balance between scrambling (nearly removed) and direct ion damage (increased of roughly the 45%), with the addition on top of an energy damage of 3200/shot

## Reasoning
Mentioning again https://github.com/endless-sky/endless-sky/pull/9070 because the reasoning is kind of the same - much of the concept between the two weapons is identical, only that one is bigger and a tier higher than the other. In this case I've gone with an even bigger disparity between scrambling and ion since, despite the nullifier being intended as more powerful, the scrambling can be particularly annoying to fight against in large quantity; energy damage maintains the theme of the weapon, while hopefully avoiding to become instantly an unnecessary nuisance. Before/after:
![image](https://github.com/endless-sky/endless-sky/assets/45330165/6690acf8-cac1-4dc2-9be0-15548a5066ba) ![image](https://github.com/endless-sky/endless-sky/assets/45330165/92955a46-b2cd-47ca-9146-c0a628de7369)


## Save File
Thanks to Hurl, here's a save file to test the Nullifier on an Albatross, with a helpful (friendly) sea scorpion in orbit to act as a test dummy if necessary
[Meri_Lerp.txt](https://github.com/endless-sky/endless-sky/files/12164851/Meri_Lerp.txt)

