### PR TITLE
Installed plugin autocondition.

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3663,6 +3663,17 @@ void PlayerInfo::RegisterDerivedConditions()
 	visitedSystemProvider.SetGetFunction(visitedSystemFun);
 	visitedSystemProvider.SetHasFunction(visitedSystemFun);
 
+	auto &&pluginProvider = conditions.GetProviderPrefixed("installed plugin: ");
+	auto pluginFun = [this](const string &name) -> bool
+	{
+		const auto &it : Plugins::Get().Find(name.substr(strlen("installed plugin: ")));
+		if(!it)
+			return 0;
+		return 1;
+	};
+	pluginProvider.SetHasFunction(pluginFun);
+	pluginProvider.SetGetFunction(pluginFun);
+
 	// Read-only navigation conditions.
 	auto HyperspaceTravelDays = [](const System *origin, const System *destination) -> int
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3666,7 +3666,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	auto &&pluginProvider = conditions.GetProviderPrefixed("installed plugin: ");
 	auto pluginFun = [this](const string &name) -> bool
 	{
-		const auto &it : Plugins::Get().Find(name.substr(strlen("installed plugin: ")));
+		const auto &it = Plugins::Get().Find(name.substr(strlen("installed plugin: ")));
 		if(!it)
 			return 0;
 		return 1;


### PR DESCRIPTION

**Feature:** This PR implements the feature request detailed and discussed in issue https://github.com/endless-sky/endless-sky/issues/6617

## Feature Details
Add `"installed plugin: <plugin name>"` autocondition that allow other plugin to detect if another plugin is installed.

## UI Screenshots
N/A

## Usage Examples
```
mission "Mega Freight not installed test"
	landing
	to offer
		not `installed plugin: Mega-Freight-main`
	on offer
		conversation
			`Mega Freight not installed.`
				decline

mission "Lost in Midnight Installed test"
	landing
	to offer
		has `installed plugin: Lost-in-Midnight-main`
	on offer
		conversation
			`Lost-in-Midnight installed.`
				decline
```

## Testing Done
Tested with the code above, it works.

### Automated Tests Added
None atm. Need to look into it.

## Performance Impact
N/A
