### PR TITLE
Feat(weapon): new "untouchable" tag that keeps projectiles alive after they collided with a ship and more

### DIFF
--- a/source/AsteroidField.cpp
+++ b/source/AsteroidField.cpp
@@ -147,7 +147,7 @@ Body *AsteroidField::Collide(const Projectile &projectile, double *closestHit)
 		for(int x = 0; x < tileX; ++x)
 		{
 			Point offset = Point(x, y) * WRAP;
-			Body *body = asteroidCollisions.Line(from + offset, to + offset, closestHit);
+			Body *body = asteroidCollisions.Line(from + offset, to + offset, closestHit)[0].first;
 			if(body)
 				hit = body;
 		}

--- a/source/CollisionSet.h
+++ b/source/CollisionSet.h
@@ -45,10 +45,13 @@ public:
 	// Get the first object that collides with the given projectile. If a
 	// "closest hit" value is given, update that value.
 	Body *Line(const Projectile &projectile, double *closestHit = nullptr) const;
+	// Get all objects that collide with the given projectile. If a
+	// "closest hit" value is given, update that value.
+	std::vector<std::pair<Body *, double>> LineAll(const Projectile &projectile, double *closestHit) const;
 	// Check for collisions with a line, which may be a projectile's current
 	// position or its entire expected trajectory (for the auto-firing AI).
-	Body *Line(const Point &from, const Point &to, double *closestHit = nullptr,
-		const Government *pGov = nullptr, const Body *target = nullptr) const;
+	std::vector<std::pair<Body *, double>> Line(const Point &from, const Point &to, double *closestHit = nullptr,
+		const Government *pGov = nullptr, const Body *target = nullptr, bool all = false) const;
 
 	// Get all objects within the given range of the given point.
 	const std::vector<Body *> &Circle(const Point &center, double radius) const;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -75,7 +75,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <cmath>
 #include <string>
-#include <iostream>
 
 using namespace std;
 
@@ -2146,7 +2145,6 @@ void Engine::DoCollisions(Projectile &projectile)
 			if(projectile.GetWeapon().IsMultiHit())
 			{
 				vector<pair<Body *, double>> shipHits = shipCollisions.LineAll(projectile, &closestHit);
-				std::cout<<shipHits.size()<<std::endl;
 				for(const auto &shipHit : shipHits)
 				{
 					Ship *ship = reinterpret_cast<Ship *>(shipHit.first);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2151,7 +2151,7 @@ void Engine::DoCollisions(Projectile &projectile)
 		// "Phasing" projectiles can pass through asteroids. For all other
 		// projectiles, check if they've hit an asteroid that is closer than any
 		// ship that they have hit.
-		if(!projectile.GetWeapon().IsPhasing())
+		if(!projectile.GetWeapon().IsPhasing() && !projectile.GetWeapon().IsUntouchAble())
 		{
 			Body *asteroid = asteroids.Collide(projectile, &closestHit);
 			if(asteroid)

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2188,7 +2188,7 @@ void Engine::DoCollisions(Projectile &projectile)
 
 			const DamageProfile damage(projectile.GetInfo());
 			// If this projectile has a blast radius, find all ships within its
-			// radius. Otherwise, only one is damaged. 
+			// radius. Otherwise, only one is damaged.
 			double blastRadius = projectile.GetWeapon().BlastRadius();
 			bool isSafe = projectile.GetWeapon().IsSafe();
 			if(blastRadius)
@@ -2220,7 +2220,7 @@ void Engine::DoCollisions(Projectile &projectile)
 			if(hits[i].ship)
 				DoGrudge(hits[i].ship, gov);
 		}
-		
+
 	}
 	else if(projectile.MissileStrength())
 	{

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -128,6 +128,18 @@ private:
 	};
 
 
+	struct HitData
+	{
+		std::shared_ptr<Ship> ship;
+		Point velocity;
+		double distance;
+		HitData(std::shared_ptr<Ship> ship, Point velocity, double distance)
+		: ship(ship), velocity(velocity), distance(distance) {}
+		HitData()
+		: ship(nullptr), velocity(Point(0., 0.)), distance(1.) {}
+	};
+
+
 private:
 	void EnterSystem();
 

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -281,14 +281,17 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 // marks the projectile as needing deletion.
 void Projectile::Explode(vector<Visual> &visuals, double intersection, Point hitVelocity)
 {
-	clip = intersection;
-	distanceTraveled += dV.Length() * intersection;
+	if(!weapon->IsUntouchAble())
+	{
+		lifetime = -100;
+		clip = intersection;
+		distanceTraveled += dV.Length() * intersection;
+	}
 	for(const auto &it : weapon->HitEffects())
 		for(int i = 0; i < it.second; ++i)
 		{
 			visuals.emplace_back(*it.first, position + velocity * intersection, velocity, angle, hitVelocity);
 		}
-	lifetime = -100;
 }
 
 

--- a/source/ShipManager.h
+++ b/source/ShipManager.h
@@ -16,9 +16,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef SHIP_MANAGER_H_
 #define SHIP_MANAGER_H_
 
-#include <string>
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 class DataNode;

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -351,7 +351,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 	}
 
 	if(isMultiHit && !isUntouchAble)
-		node.PrintTrace("Warning: Useless use of \"multi hit\" without use of \"untouchable\", projectile will die after first hit.");
+		node.PrintTrace("Warning: Useless use of \"multi hit\" without use of \"untouchable\","
+			"projectile will die after first hit.");
 
 	// Convert the "live effect" counts from occurrences per projectile lifetime
 	// into chance of occurring per frame.

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -58,6 +58,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			isParallel = true;
 		else if(key == "gravitational")
 			isGravitational = true;
+		else if(key == "untouchable")
+			isUntouchAble = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -60,6 +60,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			isGravitational = true;
 		else if(key == "untouchable")
 			isUntouchAble = true;
+		else if(key == "multi hit")
+			isMultiHit = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")
@@ -347,6 +349,9 @@ void Weapon::LoadWeapon(const DataNode &node)
 		tracking = 1.;
 		node.PrintTrace("Warning: Deprecated use of \"homing\" without use of \"[optical|infrared|radar] tracking.\"");
 	}
+
+	if(isMultiHit && !isUntouchAble)
+		node.PrintTrace("Warning: Useless use of \"multi hit\" without use of \"untouchable\", projectile will die after first hit.");
 
 	// Convert the "live effect" counts from occurrences per projectile lifetime
 	// into chance of occurring per frame.

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -152,6 +152,8 @@ public:
 	bool IsGravitational() const;
 	// Untouchable weapons pass through ships dealing damage every frame.
 	bool IsUntouchAble() const;
+	// Multi Hit weapons can hit more than one ship per frame.
+	bool IsMultiHit() const;
 
 	// These values include all submunitions:
 	// Normal damage types:
@@ -232,6 +234,7 @@ private:
 	bool isDamageScaled = true;
 	bool isGravitational = false;
 	bool isUntouchAble = false;
+	bool isMultiHit = false;
 	// Guns and missiles are by default aimed a converged point at the
 	// maximum weapons range in front of the ship. When either the installed
 	// weapon or the gun-port (or both) have the isParallel attribute set
@@ -401,6 +404,7 @@ inline bool Weapon::IsPhasing() const { return isPhasing; }
 inline bool Weapon::IsDamageScaled() const { return isDamageScaled; }
 inline bool Weapon::IsGravitational() const { return isGravitational; }
 inline bool Weapon::IsUntouchAble() const { return isUntouchAble; }
+inline bool Weapon::IsMultiHit() const { return isMultiHit; }
 
 inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); }
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -150,6 +150,8 @@ public:
 	// Gravitational weapons deal the same amount of hit force to a ship regardless
 	// of its mass.
 	bool IsGravitational() const;
+	// Untouchable weapons pass through ships dealing damage every frame.
+	bool IsUntouchAble() const;
 
 	// These values include all submunitions:
 	// Normal damage types:
@@ -229,6 +231,7 @@ private:
 	bool isPhasing = false;
 	bool isDamageScaled = true;
 	bool isGravitational = false;
+	bool isUntouchAble = false;
 	// Guns and missiles are by default aimed a converged point at the
 	// maximum weapons range in front of the ship. When either the installed
 	// weapon or the gun-port (or both) have the isParallel attribute set
@@ -397,6 +400,7 @@ inline bool Weapon::IsSafe() const { return isSafe; }
 inline bool Weapon::IsPhasing() const { return isPhasing; }
 inline bool Weapon::IsDamageScaled() const { return isDamageScaled; }
 inline bool Weapon::IsGravitational() const { return isGravitational; }
+inline bool Weapon::IsUntouchAble() const { return isUntouchAble; }
 
 inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); }
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }


### PR DESCRIPTION
**Important**, this is not a replacement for #6276 as this does not allow for setting a maximum amount of hits, this is more thought for "field" like weapons that only interact with ships but are not something physical themself.

## Feature Details
Adds a new tag, "untouchable" which prevents the projectile from disappearing when it hits a ship.
This can be used for deploy able, field like weapons as an example, as you don't want them to disappear once a ship enters that field. Other use cases would maybe be weapons that shoot dark matter, which only has gravitational impact on the world but pass through ships (I am not saying that's how dark matter really works, just giving an example).
This is just to give some examples, I could probably name some more if you need them.

Damage will be dealt per frame, which can result in very high damage numbers, content creators should keep that in mind.

Adds another tag "multi hit" that makes weapons able to hit multiple ships at the same time, useful for beam weapons. Only works in combination with "untouchable" as a projectile will die after the first hit otherwise.

## UI Screenshots
https://github.com/endless-sky/endless-sky/assets/85687254/ac295835-7dc1-40f2-87a4-8f9002ad8c04

https://github.com/endless-sky/endless-sky/assets/85687254/0e9cc21e-9756-4489-8c27-1b4e31e703dd



## Usage Examples
```
outfit "moving field"
    [...]
    weapon
        [...]
        "untouchable"
        "multi hit"
```

## Testing Done
See the recording

## Performance Impact
N/A
