### PR TITLE
fix(content): Add `minor` to "FW Zug Expansion: Assisted"

### DIFF
--- a/data/human/free worlds side plots.txt
+++ b/data/human/free worlds side plots.txt
@@ -14,6 +14,7 @@
 
 
 mission "FW Zug Expansion: Assisted"
+	minor
 	name "Convoy to Zug"
 	description "Escort a convoy of freighters to <destination> for an important project. Expect pirate raids."
 	source


### PR DESCRIPTION
This PR adds `minor` to "FW Zug Expansion: Assisted", preventing it from offering at the same time as another mission in the Free Worlds chain.