### PR TITLE
Feat(enhancement): add a way to define special penalties such as provoke and atrocity, and to nullify them

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -490,6 +490,10 @@ government "Hai Merchant (Sympathizers)"
 		"Hai (Friendly Unfettered)" .5
 		"Hai (Unfettered Civilians)" .5
 		"Merchant" .01
+	"custom penalties for"
+		"Hai (Unfettered)"
+			provoke 0 "none"
+			board 0 "provoke"
 	"bribe" .02
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -31,31 +31,49 @@ using namespace std;
 
 namespace {
 	// Load ShipEvent strings and corresponding numerical values into a map.
-	void PenaltyHelper(const DataNode &node, map<int, double> &penalties)
+	void PenaltyHelper(const DataNode &node, map<int, Government::PenaltyEffect> &penalties)
 	{
-		for(const DataNode &child : node)
-			if(child.Size() >= 2)
+		auto loadPenalty = [&penalties](const DataNode& child, int eventType) -> void
+		{
+			double amount = child.Value(1);
+			Government::SpecialPenalty specialPenalty = Government::SpecialPenalty::NONE;
+			if (child.Size() >= 3)
 			{
-				const string &key = child.Token(0);
-				if(key == "assist")
-					penalties[ShipEvent::ASSIST] = child.Value(1);
+				const string& effect = child.Token(2);
+				if (effect == "none")
+					specialPenalty = Government::SpecialPenalty::NONE;
+				else if(effect == "provoke")
+					specialPenalty = Government::SpecialPenalty::PROVOKE;
+				else if(effect == "atrocity")
+					specialPenalty = Government::SpecialPenalty::ATROCITY;
+				else
+					child.PrintTrace("Skipping unrecognized reputation effect:");
+			}
+			penalties[eventType] = Government::PenaltyEffect(amount, specialPenalty);
+		};
+		for (const DataNode& child : node)
+			if (child.Size() >= 2)
+			{
+				const string& key = child.Token(0);
+				if (key == "assist")
+					loadPenalty(child, ShipEvent::ASSIST);
 				else if(key == "disable")
-					penalties[ShipEvent::DISABLE] = child.Value(1);
+					loadPenalty(child, ShipEvent::DISABLE);
 				else if(key == "board")
-					penalties[ShipEvent::BOARD] = child.Value(1);
+					loadPenalty(child, ShipEvent::BOARD);
 				else if(key == "capture")
-					penalties[ShipEvent::CAPTURE] = child.Value(1);
+					loadPenalty(child, ShipEvent::CAPTURE);
 				else if(key == "destroy")
-					penalties[ShipEvent::DESTROY] = child.Value(1);
+					loadPenalty(child, ShipEvent::DESTROY);
 				else if(key == "scan")
 				{
-					penalties[ShipEvent::SCAN_OUTFITS] = child.Value(1);
-					penalties[ShipEvent::SCAN_CARGO] = child.Value(1);
+					loadPenalty(child, ShipEvent::SCAN_OUTFITS);
+					loadPenalty(child, ShipEvent::SCAN_CARGO);
 				}
 				else if(key == "provoke")
-					penalties[ShipEvent::PROVOKE] = child.Value(1);
+					loadPenalty(child, ShipEvent::PROVOKE);
 				else if(key == "atrocity")
-					penalties[ShipEvent::ATROCITY] = child.Value(1);
+					loadPenalty(child, ShipEvent::ATROCITY);
 				else
 					child.PrintTrace("Skipping unrecognized attribute:");
 			}
@@ -64,13 +82,18 @@ namespace {
 	}
 
 	// Determine the penalty for the given ShipEvent based on the values in the given map.
-	double PenaltyHelper(int eventType, const map<int, double> &penalties)
+	Government::PenaltyEffect PenaltyHelper(int eventType, const map<int, Government::PenaltyEffect> &penalties)
 	{
 		double penalty = 0.;
+		Government::SpecialPenalty specialPenalty = Government::SpecialPenalty::NONE;
 		for(const auto &it : penalties)
 			if(eventType & it.first)
-				penalty += it.second;
-		return penalty;
+			{
+				penalty += it.second.reputationChange;
+				if(it.second.specialPenalty > specialPenalty)
+					specialPenalty = it.second.specialPenalty;
+			}
+		return {penalty, specialPenalty};
 	}
 
 	unsigned nextID = 0;
@@ -110,15 +133,15 @@ double Government::RaidFleet::MaxAttraction() const
 Government::Government()
 {
 	// Default penalties:
-	penaltyFor[ShipEvent::ASSIST] = -0.1;
-	penaltyFor[ShipEvent::DISABLE] = 0.5;
-	penaltyFor[ShipEvent::BOARD] = 0.3;
-	penaltyFor[ShipEvent::CAPTURE] = 1.;
-	penaltyFor[ShipEvent::DESTROY] = 1.;
-	penaltyFor[ShipEvent::SCAN_OUTFITS] = 0.;
-	penaltyFor[ShipEvent::SCAN_CARGO] = 0.;
-	penaltyFor[ShipEvent::PROVOKE] = 0.;
-	penaltyFor[ShipEvent::ATROCITY] = 10.;
+	penaltyFor[ShipEvent::ASSIST] = PenaltyEffect(-.1);
+	penaltyFor[ShipEvent::DISABLE] = PenaltyEffect(.5);
+	penaltyFor[ShipEvent::BOARD] = PenaltyEffect(.3);
+	penaltyFor[ShipEvent::CAPTURE] = PenaltyEffect(1.);
+	penaltyFor[ShipEvent::DESTROY] = PenaltyEffect(1.);
+	penaltyFor[ShipEvent::SCAN_OUTFITS] = PenaltyEffect();
+	penaltyFor[ShipEvent::SCAN_CARGO] = PenaltyEffect();
+	penaltyFor[ShipEvent::PROVOKE] = PenaltyEffect(0., SpecialPenalty::PROVOKE);
+	penaltyFor[ShipEvent::ATROCITY] = PenaltyEffect(10., SpecialPenalty::ATROCITY);
 
 	id = nextID++;
 }
@@ -479,7 +502,7 @@ double Government::InitialPlayerReputation() const
 // Get the amount that your reputation changes for the given offense against the given government.
 // The given value should be a combination of one or more ShipEvent values.
 // Returns 0 if the Government is null.
-double Government::PenaltyFor(int eventType, const Government *other) const
+Government::PenaltyEffect Government::PenaltyFor(int eventType, const Government *other) const
 {
 	if(!other)
 		return 0.;
@@ -494,7 +517,7 @@ double Government::PenaltyFor(int eventType, const Government *other) const
 	if(it == customPenalties.end())
 		return PenaltyHelper(eventType, penalties);
 
-	map<int, double> tempPenalties = penalties;
+	map<int, PenaltyEffect> tempPenalties = penalties;
 	for(const auto &penalty : it->second)
 		tempPenalties[penalty.first] = penalty.second;
 	return PenaltyHelper(eventType, tempPenalties);

--- a/source/Government.h
+++ b/source/Government.h
@@ -47,6 +47,20 @@ class System;
 // bribe than others.
 class Government {
 public:
+	enum class SpecialPenalty : int {
+		NONE = 0,
+		PROVOKE,
+		ATROCITY
+	};
+
+	struct PenaltyEffect {
+		double reputationChange;
+		SpecialPenalty specialPenalty;
+		PenaltyEffect(double reputationChange = 0., SpecialPenalty specialPenalty = SpecialPenalty::NONE) :
+			reputationChange(reputationChange), specialPenalty(specialPenalty) 
+		{}
+	};
+
 	class RaidFleet {
 		public:
 			RaidFleet(const Fleet *fleet, double minAttraction, double maxAttraction);
@@ -85,7 +99,7 @@ public:
 	// Get the amount that your reputation changes for the given offense against the given government.
 	// The given value should be a combination of one or more ShipEvent values.
 	// Returns 0 if the Government is null.
-	double PenaltyFor(int eventType, const Government *other) const;
+	PenaltyEffect PenaltyFor(int eventType, const Government *other) const;
 	// In order to successfully bribe this government you must pay them this
 	// fraction of your fleet's value. (Zero means they cannot be bribed.)
 	double GetBribeFraction() const;
@@ -164,11 +178,11 @@ private:
 
 	std::vector<double> attitudeToward;
 	std::set<const Government *> trusted;
-	std::map<unsigned, std::map<int, double>> customPenalties;
+	std::map<unsigned, std::map<int, PenaltyEffect>> customPenalties;
 	double initialPlayerReputation = 0.;
 	double reputationMax = std::numeric_limits<double>::max();
 	double reputationMin = std::numeric_limits<double>::lowest();
-	std::map<int, double> penaltyFor;
+	std::map<int, PenaltyEffect> penaltyFor;
 	std::map<const Outfit*, int> illegals;
 	std::map<const Outfit*, bool> atrocities;
 	double bribe = 0.;

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -115,10 +115,11 @@ void Politics::Offend(const Government *gov, int eventType, int count)
 	{
 		const Government *other = &it.second;
 		double weight = other->AttitudeToward(gov);
+		Government::PenaltyEffect penalty = other->PenaltyFor(eventType, gov);
 
 		// You can provoke a government even by attacking an empty ship, such as
 		// a drone (count = 0, because count = crew).
-		if(eventType & ShipEvent::PROVOKE)
+		if(penalty.specialPenalty == Government::SpecialPenalty::PROVOKE)
 		{
 			if(weight > 0.)
 			{
@@ -134,11 +135,11 @@ void Politics::Offend(const Government *gov, int eventType, int count)
 			// changes. This is to allow two governments to be hostile or
 			// friendly without the player's behavior toward one of them
 			// influencing their reputation with the other.
-			double penalty = (count * weight) * other->PenaltyFor(eventType, gov);
-			if(eventType & ShipEvent::ATROCITY && weight > 0)
+			double reputationChange =  (count * weight) * penalty.reputationChange;
+			if(penalty.specialPenalty == Government::SpecialPenalty::ATROCITY && weight > 0)
 				Politics::SetReputation(other, min(0., reputationWith[other]));
 
-			Politics::AddReputation(other, -penalty);
+			Politics::AddReputation(other, -reputationChange);
 		}
 	}
 }


### PR DESCRIPTION
**Feature:** 
This will resolve the annoying sympathizers when you're just defending yourself, @MasterOfGrey asked me to implement this.

## Feature Details
Add a way to define special penalties such as "none" that will cancel what provoke or atrocity does, and "provoke", "atrocity" that are pretty self explanatory.
This means that the action of provoking can be removed for instance (say for the sympathizers when you provoke the Unfettered) and it can be added for other actions (such as boarding, in this case)
It can also be cumulated with a reputation effect like usual.

## UI Screenshots
n/a

## Usage Examples
The Gegno may now use an atrocity on the provoke of civilians, meaning there is no longer a need to keep a strict reputation and whatnot @Saugia 

note: we could even expand it later on, thats why I didnt use shipevent (I could have just modified them as a reference or smth but that felt hacky) and instead use these special penalties.


## Testing Done
I used the data changes in this PR (Leaf is coming! run!) + renamed the sympathizers to know if it was them, and make them react upon disabling for easy testing.
I then went into Wah Ki and provoked Unfettered. The sympathizers did not respond.
In my testing the radar turned red as I disabled and then destroyed Unfettered ships, and Sympathizers became hostile.

### Automated Tests Added
idk if it's applicable but I could craft one ig...?

## Performance Impact
A very small impact that nobody will notice: the penalty effect is gathered before checking if it will have a reputation effect. But really it doesnt matter.
Also would take a wee bit longer on loading but really nobody will notice ~~except if I forgot a reference somewhere~~
