### PR TITLE
feat(enhancement): Add "timer" trigger for missions

### DIFF
--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -338,6 +338,30 @@ outfit "Timer Submunition"
 		"hull damage" .15
 		"no damage scaling"
 
+# mission "Sad Archie"
+# 	landing
+# 	invisible
+# 	to offer
+# 		has "There Might Be Riots part 3B: done"
+# 	destination "Zug"
+# 	
+# 	npc disable
+# 		government "Test Dummy"
+# 		system "Ildaria"
+# 		personality unconstrained heroic nemesis
+# 		ship "Timer Ship" "Timer"
+# 		conversation
+# 			`As your ship drifts through the cloud of dust that surrounds Ildaria, it occurs to you that this must be the "cloudy star out along the Rim" that Ulrich from There Might Be Riots told you about. Remembering his story, you shut your eyes and attempt to meditate. But instead, you just fall asleep.`
+# 			scene "scene/eso0"
+# 			`You dream that you leave this star system and return to Zug, but when you land there everything is different: the cities you remember are gone, and in their place are other cities with strange architecture, populated by gargantuan dragon-like creatures.`
+# 			`	Time speeds up, and you watch as the dragon cities grow and spread out. You see one city buried under a massive lava flow, starships buzzing around it like a cloud of flies to carry people and goods to safety. Other cities are destroyed by war, and then abruptly the dragon-people are all gone and their cities lie vacant. Buildings crumble, and the forests reclaim the land.`
+# 			`	Then you wake up and find yourself back in your ship, in the Ildaria system. Weird.`
+# 	
+# 	on complete
+# 		log `Experienced a strange vision while drifting in the Ildaria system that looked like the fall of a civilization of dragon-people. The terrain on the planet of Zug looks strikingly similar to this vision.`
+# 		conversation
+# 			`On a whim, as you're landing on Zug you pull up a geological map of the planet and find that the geography you dreamt of while drifting in the Ildaria system was surprisingly close to the real thing. There's even a massive basalt outcropping right where you saw a lava flow burying a city. There's no way your ship's sensors can tell what's underneath it, though.`
+
 mission "Sad Archie"
 	landing
 	invisible
@@ -345,17 +369,19 @@ mission "Sad Archie"
 		has "There Might Be Riots part 3B: done"
 	destination "Zug"
 	
-	npc disable
-		government "Test Dummy"
-		system "Ildaria"
-		personality unconstrained heroic nemesis
-		ship "Timer Ship" "Timer"
-		conversation
-			`As your ship drifts through the cloud of dust that surrounds Ildaria, it occurs to you that this must be the "cloudy star out along the Rim" that Ulrich from There Might Be Riots told you about. Remembering his story, you shut your eyes and attempt to meditate. But instead, you just fall asleep.`
-			scene "scene/eso0"
-			`You dream that you leave this star system and return to Zug, but when you land there everything is different: the cities you remember are gone, and in their place are other cities with strange architecture, populated by gargantuan dragon-like creatures.`
-			`	Time speeds up, and you watch as the dragon cities grow and spread out. You see one city buried under a massive lava flow, starships buzzing around it like a cloud of flies to carry people and goods to safety. Other cities are destroyed by war, and then abruptly the dragon-people are all gone and their cities lie vacant. Buildings crumble, and the forests reclaim the land.`
-			`	Then you wake up and find yourself back in your ship, in the Ildaria system. Weird.`
+	timer "Sad Archie Timer" 120 60
+		system Ildaria
+		idle
+		uncloaked
+		reset "leave system"
+		proximity 1200 close
+		on timeup
+			conversation 
+				`As your ship drifts through the cloud of dust that surrounds Ildaria, it occurs to you that this must be the "cloudy star out along the Rim" that Ulrich from There Might Be Riots told you about. Remembering his story, you shut your eyes and attempt to meditate. But instead, you just fall asleep.`
+				scene "scene/eso0"
+				`You dream that you leave this star system and return to Zug, but when you land there everything is different: the cities you remember are gone, and in their place are other cities with strange architecture, populated by gargantuan dragon-like creatures.`
+				`	Time speeds up, and you watch as the dragon cities grow and spread out. You see one city buried under a massive lava flow, starships buzzing around it like a cloud of flies to carry people and goods to safety. Other cities are destroyed by war, and then abruptly the dragon-people are all gone and their cities lie vacant. Buildings crumble, and the forests reclaim the land.`
+				`	Then you wake up and find yourself back in your ship, in the Ildaria system. Weird.`
 	
 	on complete
 		log `Experienced a strange vision while drifting in the Ildaria system that looked like the fall of a civilization of dragon-people. The terrain on the planet of Zug looks strikingly similar to this vision.`

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -315,6 +315,8 @@ target_sources(EndlessSkyLib PRIVATE
 	TestData.h
 	TextReplacements.cpp
 	TextReplacements.h
+	Timer.cpp
+	Timer.h
 	Trade.cpp
 	Trade.h
 	TradingPanel.cpp

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -143,6 +143,9 @@ void MainPanel::Step()
 	}
 
 	engine.Step(isActive);
+	
+	if(isActive)
+		player.StepMissionTimers(GetUI());
 
 	// Splice new events onto the eventQueue for (eventual) handling. No
 	// other classes use Engine::Events() after Engine::Step() completes.

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -288,6 +288,8 @@ void Mission::Load(const DataNode &node)
 			substitutions.Load(child);
 		else if(child.Token(0) == "npc")
 			npcs.emplace_back(child, name);
+		else if(child.Token(0) == "timer")
+			timers.emplace_back(child, name);
 		else if(child.Token(0) == "on" && child.Size() >= 2 && child.Token(1) == "enter")
 		{
 			// "on enter" nodes may either name a specific system or use a LocationFilter
@@ -453,6 +455,8 @@ void Mission::Save(DataWriter &out, const string &tag) const
 
 		for(const NPC &npc : npcs)
 			npc.Save(out);
+		for(const Timer &timer : timers)
+			timer.Save(out);
 
 		// Save all the actions, because this might be an "available mission" that
 		// has not been received yet but must still be included in the saved game.
@@ -856,6 +860,10 @@ bool Mission::IsSatisfied(const PlayerInfo &player) const
 	for(const NPC &npc : npcs)
 		if(!npc.HasSucceeded(player.GetSystem()))
 			return false;
+	// All timers must be complete
+	for(const Timer &timer : timers)
+		if(!timer.IsComplete())
+			return false;
 
 	// If any of the cargo for this mission is being carried by a ship that is
 	// not in this system, the mission cannot be completed right now.
@@ -1127,6 +1135,13 @@ void Mission::UpdateNPCs(const PlayerInfo &player)
 {
 	for(auto &npc : npcs)
 		npc.UpdateSpawning(player);
+}
+
+
+// Get a list of Timers associated with this mission.
+list<Timer> &Mission::Timers()
+{
+	return timers;
 }
 
 
@@ -1437,6 +1452,10 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	}
 	for(const NPC &npc : npcs)
 		result.npcs.push_back(npc.Instantiate(subs, sourceSystem, result.destination->GetSystem(), jumps, payload));
+	
+	// Instantiate the Timers.
+	for(const Timer &timer : timers)
+		result.timers.push_back(timer.Instantiate(subs, sourceSystem, jumps, payload));
 
 	// Instantiate the actions. The "complete" action is always first so that
 	// the "<payment>" substitution can be filled in.

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -24,6 +24,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "MissionAction.h"
 #include "NPC.h"
 #include "TextReplacements.h"
+#include "Timer.h"
 
 #include <list>
 #include <map>
@@ -160,6 +161,8 @@ public:
 	// Get a list of NPCs associated with this mission. Every time the player
 	// takes off from a planet, they should be added to the active ships.
 	const std::list<NPC> &NPCs() const;
+	// Get a list of timers associated with this mission.
+	std::list<Timer> &Timers();
 	// Update which NPCs are active based on their spawn and despawn conditions.
 	void UpdateNPCs(const PlayerInfo &player);
 	// Checks if the given ship belongs to one of the mission's NPCs.
@@ -254,6 +257,8 @@ private:
 
 	// NPCs:
 	std::list<NPC> npcs;
+	// Timers:
+	std::list<Timer> timers;
 
 	// Actions to perform:
 	std::map<Trigger, MissionAction> actions;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -43,6 +43,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "StartConditions.h"
 #include "StellarObject.h"
 #include "System.h"
+#include "Timer.h"
 #include "UI.h"
 
 #include <algorithm>
@@ -4041,6 +4042,15 @@ void PlayerInfo::StepMissions(UI *ui)
 			missionsToRemove.push_back(it.first);
 	for(const Mission *mission : missionsToRemove)
 		cargo.RemoveMissionCargo(mission);
+}
+
+
+void PlayerInfo::StepMissionTimers(UI *ui)
+{
+	for(Mission &mission : missions)
+		for(Timer &timer : mission.Timers())
+			if(!timer.IsComplete())
+				timer.Step(*this, ui);
 }
 
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -332,7 +332,9 @@ public:
 	std::set<std::string> &Collapsed(const std::string &name);
 	// Should help dialogs relating to carriers be displayed?
 	bool DisplayCarrierHelp() const;
-
+	
+	// Advance any active mission timers that meet the right criteria
+	void StepMissionTimers(UI *ui);
 
 private:
 	// Apply any "changes" saved in this player info to the global game state.

--- a/source/Timer.cpp
+++ b/source/Timer.cpp
@@ -1,0 +1,266 @@
+/* Timer.cpp
+Copyright (c) 2023 by Timothy Collett
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Timer.h"
+
+#include "DataNode.h"
+#include "DataWriter.h"
+#include "GameData.h"
+#include "Logger.h"
+#include "Planet.h"
+#include "PlayerInfo.h"
+#include "Random.h"
+#include "Ship.h"
+#include "StellarObject.h"
+#include "UI.h"
+
+using namespace std;
+
+Timer::Timer(const DataNode &node, const std::string &missionName)
+{
+	Load(node, missionName);
+}
+
+void Timer::Load(const DataNode &node, const string &missionName)
+{
+	if(node.Size() > 1)
+		name = node.Token(1);
+	if(node.Size() > 2)
+		base = static_cast<int64_t>(node.Value(2));
+	if(node.Size() > 3)
+		rand = static_cast<uint32_t>(node.Value(3));
+	
+	timeToWait = base + Random::Int(rand);
+	
+	for(const DataNode &child : node)
+	{
+		if(child.Token(0) == "idle")
+			requireIdle = true;
+		else if(child.Token(0) == "system" && child.Size() > 1)
+			system = GameData::Systems().Get(child.Token(1));
+		else if(child.Token(0) == "proximity")
+		{
+			if(child.Size() > 1)
+				proximity = child.Value(1);
+			if(child.Size() > 2)
+			{
+				if(child.Token(2) == "close")
+					closeTo = true;
+				else if(child.Token(2) == "far")
+					closeTo = false;
+			}
+			if(child.HasChildren())
+			{
+				const DataNode &firstGrand = (*child.begin());
+				proximityCenter = GameData::Planets().Get(firstGrand.Token(0));
+			}
+		}
+		else if(child.Token(0) == "uncloaked")
+			requireUncloaked = true;
+		else if(child.Token(0) == "reset")
+		{
+			if(child.Size() > 1 && child.Token(1) == "leave system")
+				resetCondition = ResetCondition::LEAVE_SYSTEM;
+			else if(child.Size() > 1 && child.Token(1) == "leave zone")
+				resetCondition = ResetCondition::LEAVE_ZONE;
+			else if(child.Size() > 1 && child.Token(1) == "pause")
+				resetCondition = ResetCondition::PAUSE;
+		}
+		// We keep "on timeup" as separate tokens so that it's compatible with MissionAction syntax
+		else if(child.Token(0) == "on" && child.Size() > 1 && child.Token(1) == "timeup")
+			action.Load(child, missionName);
+			
+	}
+}
+
+// Note: the Save() function can assume this is an instantiated Timer, not a template,
+// so the time to wait will be saved fully calculated, and with any elapsed time subtracted
+void Timer::Save(DataWriter &out) const
+{
+	// If this NPC should no longer appear in-game, don't serialize it.
+	if(isComplete)
+		return;
+
+	int64_t timeRemaining = timeToWait - timeElapsed;
+	out.Write("timer", name, timeRemaining);
+	out.BeginChild();
+	{
+		out.Write("system", system->Name());
+		if(requireIdle)
+			out.Write("idle");
+		if(requireUncloaked)
+			out.Write("uncloaked");
+		if(resetCondition != ResetCondition::NONE)
+		{
+			static const map<ResetCondition, string> resets = {
+				{LEAVE_SYSTEM, "leave system"},
+				{LEAVE_ZONE, "leave zone"},
+				{PAUSE, "pause"}
+			};
+			auto it = resets.find(resetCondition);
+			if(it != resets.end())
+				out.Write("reset", it->second);
+		}
+		if(proximity > 0.)
+		{
+			string distance = "close";
+			if(!closeTo)
+				distance = "far";
+			out.Write("proximity", proximity, distance);
+			if(proximityCenter != nullptr)
+			{
+				out.BeginChild();
+				{
+					out.Write(proximityCenter->Name());
+				}
+			}
+		}
+		
+		action.Save(out);
+	}
+	out.EndChild();
+}
+
+// Calculate the total time to wait, including any random value,
+// and instantiate the triggered action
+Timer Timer::Instantiate(map<string, string> &subs,
+						const System *origin, int jumps, int64_t payload) const
+{
+	Timer result;
+	result.name = name;
+	result.base = base;
+	result.rand = rand;
+	result.requireIdle = requireIdle;
+	result.requireUncloaked = requireUncloaked;
+	result.system = system;
+	result.proximity = proximity;
+	result.proximityCenter = proximityCenter;
+	result.closeTo = closeTo;
+	result.resetCondition = resetCondition;
+	
+	result.timeToWait = timeToWait;
+	result.timeElapsed = timeElapsed;
+	result.isComplete = isComplete;
+	result.isActive = isActive;
+	
+	result.action = action.Instantiate(subs, origin, jumps, payload);
+	
+	return result;
+}
+
+uint64_t Timer::TimeToWait() const
+{
+	return timeToWait;
+}
+
+bool Timer::RequireIdle() const
+{
+	return requireIdle;
+}
+
+bool Timer::CloseTo() const
+{
+	return closeTo;
+}
+
+const System *Timer::GetSystem() const
+{
+	return system;
+}
+
+double Timer::Proximity() const
+{
+	return proximity;
+}
+
+const Planet *Timer::ProximityCenter() const
+{
+	return proximityCenter;
+}
+
+bool Timer::IsComplete() const
+{
+	return isComplete;
+}
+
+void Timer::ResetOn(ResetCondition cond)
+{
+	bool reset = cond == resetCondition;
+	reset |= (cond == LEAVE_ZONE && resetCondition == PAUSE);
+	reset |= (cond == LEAVE_SYSTEM && (resetCondition == PAUSE || resetCondition == LEAVE_ZONE));
+	if(isActive && reset)
+	{
+		timeElapsed = 0;
+		timeToWait = base + Random::Int(rand);
+	}
+}
+
+void Timer::Step(PlayerInfo &player, UI *ui)
+{
+	if(isComplete)
+		return;
+	if(player.Flagship()->GetSystem() != system)
+	{
+		ResetOn(LEAVE_SYSTEM);
+		isActive = false;
+		return;
+	}
+	if(requireIdle)
+	{
+		bool shipIdle = (!player.Flagship()->IsThrusting() && !player.Flagship()->IsSteering() && !player.Flagship()->IsReversing());
+		for(const Hardpoint &weapon : player.Flagship()->Weapons())
+			shipIdle &= !weapon.WasFiring();
+		if(!shipIdle)
+		{
+			ResetOn(PAUSE);
+			isActive = false;
+			return;
+		}
+	}
+	if(requireUncloaked)
+	{
+		double cloak = player.Flagship()->Cloaking();
+		if(cloak != 0.)
+		{
+			ResetOn(PAUSE);
+			isActive = false;
+			return;
+		}
+	}
+	if(proximity > 0.)
+	{
+		Point center = Point(0, 0);
+		if(proximityCenter)
+		{
+			const StellarObject *proximityObject = system->FindStellar(proximityCenter);
+			center = proximityObject->Position();
+		}
+		double dist = (player.Flagship()->Position() - center).Length();
+		if((closeTo && dist > proximity) || (!closeTo && dist < proximity))
+		{
+			ResetOn(LEAVE_ZONE);
+			isActive = false;
+			return;
+		}
+	}
+	isActive = true;
+	timeElapsed += (1./60.);
+	if(timeElapsed >= timeToWait)
+	{
+		action.Do(player, ui);
+		player.Conditions().Add("timer: " + name + ": complete", 1);
+		isComplete = true;
+	}
+}

--- a/source/Timer.h
+++ b/source/Timer.h
@@ -1,0 +1,114 @@
+/* Timer.h
+Copyright (c) 2023 by Timothy Collett
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef ES_TIMER_H_
+#define ES_TIMER_H_
+
+#include "MissionAction.h"
+#include "System.h"
+
+#include <cstdint>
+#include <string>
+#include <map>
+
+class DataNode;
+class DataWriter;
+class Planet;
+class PlayerInfo;
+class UI;
+
+// Class representing a timer for triggering mission actions
+// This requires a specification of how long to wait (base + randint(rand)),
+// a system to wait in, and whether to reset the timer upon leaving the system
+// and can optionally require the player to be idle (no acceleration), and/or
+// within or beyond a certain proximity to the system center or a
+// specific (named) system object
+class Timer {
+public:
+	Timer() = default;
+	Timer(const DataNode &node, const std::string &missionName);
+	// Set up the timer from its data file node
+	void Load(const DataNode &node, const std::string &missionName);
+	// Note: the Save() function can assume this is an instantiated Timer, not a template,
+	// so the time to wait will be saved fully calculated, and with any elapsed time subtracted
+	void Save(DataWriter &out) const;
+	
+	// Get the total time to wait, including the random value
+	uint64_t TimeToWait() const;
+	// Get whether the timer requires the player to be idle
+	bool RequireIdle() const;
+	// Get the required proximity radius to a system object or the system center
+	// If 0., no proximity is required
+	double Proximity() const;
+	// Get whether the player needs to be close to or far from the specified center
+	bool CloseTo() const;
+	// Get the system the timer is specified for
+	const System *GetSystem() const;
+	// Get the named system object used for calculating the proximity center
+	const Planet *ProximityCenter() const;
+	// Get whether the timer is currently active
+	bool IsComplete() const;
+	
+	// Calculate the total time to wait, including any random value
+	Timer Instantiate(std::map<std::string, std::string> &subs,
+					 const System *origin, int jumps, int64_t payload) const;
+	// Progress the timer within the main loop
+	void Step(PlayerInfo &player, UI *ui);
+
+private:
+	enum ResetCondition { NONE, PAUSE, LEAVE_ZONE, LEAVE_SYSTEM };
+	void ResetOn(ResetCondition cond);
+
+private:
+	// The name of the timer
+	std::string name;
+	// The basic amount of time to wait, with the optional random values
+	uint64_t base = 0;
+	uint32_t rand = 0;
+	
+	// The system the timer is for
+	const System *system = nullptr;
+
+	// Whether the timer requires the player to be idle
+	bool requireIdle = false;
+	// Whether the timer requires the player to be uncloaked to advance
+	bool requireUncloaked = false;
+	// What circumstances will reset the timer: leaving the system,
+	// leaving the proximity zone (if applicable), or any circumstance that stops the timer
+	ResetCondition resetCondition = NONE;
+	// If proximity is specified, this determines whether the timer will only advance while
+	// close to or far from the specified center; default is close to
+	bool closeTo = true;
+	// This specifies the radius around the proximity center to be checked
+	double proximity = 0.;
+	// This specifies the system object to be the center; if this is nullptr, but proximity
+	// is positive, then the system center is used instead
+	const Planet *proximityCenter = nullptr;
+	
+	// The action to be performed when the timer elapses
+	MissionAction action;
+	
+	// Used for holding the calculated time to wait and current timer value when it's actually active
+	int64_t timeToWait = 0;
+	double timeElapsed = 0.;
+	// Set to true once the timer has run to completion so we don't keep trying to save or run it
+	bool isComplete = false;
+	// Set to true when all the conditions are met
+	bool isActive = false;
+};
+
+
+
+#endif


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #4475 

Adds a new `timer` element to mission specifications, allowing for actions to trigger after a certain amount of time spent in a given system.

## Feature Details
The element has the following format:

`timer "<Timer Name>" <base time> [random time]`
`    system "<system name>"`
`    [idle]`
`    [uncloaked]`
`    [proximity <radius> [close|far]]`
`        ["<planet name>"]`
`    on timeup`
`        <action/conversation>`

## UI Screenshots
N/A

## Usage Examples
This PR includes a modification of the "Sad Archie" mission to use the timer rather than the existing Timer Ship mechanism.

## Testing Done
- [x] the timer correctly loads from and saves to the datafiles
- [x] it times the number of seconds specified
- [x] it pauses on activity, on cloak, and when the player is too far away from the target zone
- [x] it correctly triggers the action
- [x] it correctly saves the fact that the timer completed to the savefile
- [x] it correctly allows the mission to complete when the timer is complete
- [ ] it saves the time remaining when leaving the system if allowed
- [ ] it saves the time remaining when landing, quitting, and reloading the save if allowed
- [ ] it resets the time remaining on leaving the target zone, on leaving the system, or on any action that pauses the countdown if specified
- [ ] it safely handles the target system being removed from the map after the mission is loaded
- [ ] it correctly prevents the mission from completing when the timer is not yet complete

### Automated Tests Added
I have no experience with creating tests, and am unclear on whether this needs them.

## Performance Impact
Performance impact should be minimal. It adds a loop through active missions to check for timers, and through the active timers to step through them, but each call of the `Timer::Step()` method is quite lightweight, and no appreciable performance impact was observed.
