### PR TITLE
feat(fix): Adjust Face to Maw 1 to require the player to be flying a Puffin

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -2818,6 +2818,7 @@ mission "Remnant: Face to Maw 1"
 	description "Plume would be very interested in a report on what happened with the void sprites."
 	to offer
 		has "event: remnant: return the samples timer"
+		has "flagship model: Puffin"
 		or
 			not "Remnant: Cognizance 1: offered"
 			has "Remnant: Cognizance 19: done"


### PR DESCRIPTION
**Bugfix:** 
This PR addresses issue reported by rumplestiltskin on Discord. Thanks for spotting it!

## Fix Details
Adds the requirement to the Face to Maw 1 that the player must be flying the Puffin; as no other ship matches the mission text.

## Testing Done
n/a

## Save File
[Rebbia Rampart~3023-10-01 Found the Remnant.txt](https://github.com/endless-sky/endless-sky/files/12207927/Rebbia.Rampart.3023-10-01.Found.the.Remnant.txt)
(You'll have to unlock the puffin first. This is merely the closest save available.)
