### PR TITLE
Update `fail` action with no mission name behavior

### DIFF
--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -90,15 +90,15 @@ bool Conversation::RequiresLaunch(int outcome)
 
 
 // Construct and Load() at the same time.
-Conversation::Conversation(const DataNode &node, const string &missionName)
+Conversation::Conversation(const DataNode &node)
 {
-	Load(node, missionName);
+	Load(node);
 }
 
 
 
 // Load a conversation from file.
-void Conversation::Load(const DataNode &node, const string &missionName)
+void Conversation::Load(const DataNode &node)
 {
 	// Make sure this really is a conversation specification.
 	if(node.Token(0) != "conversation")
@@ -184,7 +184,7 @@ void Conversation::Load(const DataNode &node, const string &missionName)
 			// Don't merge "action" nodes with any other nodes. Allow the legacy keyword "apply," too.
 			AddNode();
 			nodes.back().canMergeOnto = false;
-			nodes.back().actions.Load(child, missionName);
+			nodes.back().actions.Load(child);
 		}
 		// Check for common errors such as indenting a goto incorrectly:
 		else if(child.Size() > 1)

--- a/source/Conversation.h
+++ b/source/Conversation.h
@@ -60,9 +60,9 @@ public:
 public:
 	Conversation() = default;
 	// Construct and Load() at the same time.
-	Conversation(const DataNode &node, const std::string &missionName = "");
+	Conversation(const DataNode &node);
 	// Read or write to files.
-	void Load(const DataNode &node, const std::string &missionName = "");
+	void Load(const DataNode &node);
 	void Save(DataWriter &out) const;
 	// Check if any data is loaded in this conversation object.
 	bool IsEmpty() const noexcept;

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -61,8 +61,8 @@ namespace {
 
 // Constructor.
 ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &conversation,
-	const System *system, const shared_ptr<Ship> &ship, bool useTransactions)
-	: player(player), useTransactions(useTransactions), conversation(conversation),
+	const Mission *caller, const System *system, const shared_ptr<Ship> &ship, bool useTransactions)
+	: player(player), caller(caller), useTransactions(useTransactions), conversation(conversation),
 	scroll(0.), system(system), ship(ship)
 {
 #if defined _WIN32
@@ -399,7 +399,7 @@ void ConversationPanel::Goto(int index, int selectedChoice)
 			// Action nodes are able to perform various actions, e.g. changing
 			// the player's conditions, granting payments, triggering events,
 			// and more. They are not allowed to spawn additional UI elements.
-			conversation.GetAction(node).Do(player, nullptr);
+			conversation.GetAction(node).Do(player, nullptr, caller);
 		}
 		else if(conversation.ShouldDisplayNode(player.Conditions(), node))
 		{

--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -29,6 +29,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class Color;
 class Conversation;
+class Mission;
 class PlayerInfo;
 class Point;
 class Ship;
@@ -43,8 +44,8 @@ class System;
 class ConversationPanel : public Panel {
 public:
 	ConversationPanel(PlayerInfo &player, const Conversation &conversation,
-		const System *system = nullptr, const std::shared_ptr<Ship> &ship = nullptr,
-		bool useTransactions = false);
+		const Mission *caller = nullptr, const System *system = nullptr,
+		const std::shared_ptr<Ship> &ship = nullptr, bool useTransactions = false);
 
 template <class T>
 	void SetCallback(T *t, void (T::*fun)(int));
@@ -107,6 +108,9 @@ private:
 private:
 	// Reference to the player, to apply any changes to them.
 	PlayerInfo &player;
+
+	// A pointer to the mission that called this conversation.
+	const Mission *caller = nullptr;
 
 	// Should we use a PlayerInfo transaction to prevent save-load glitches?
 	bool useTransactions = false;

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -354,15 +354,17 @@ void GameAction::Do(PlayerInfo &player, UI *ui, const Mission *caller) const
 	for(const auto &it : events)
 		player.AddEvent(*it.first, player.GetDate() + it.second.first);
 
-	if(!fail.empty() || failCaller)
+	if(!fail.empty())
 	{
 		// If this action causes this or any other mission to fail, mark that
 		// mission as failed. It will not be removed from the player's mission
 		// list until it is safe to do so.
 		for(const Mission &mission : player.Missions())
-			if(fail.count(mission.Identifier()) || (failCaller && &mission == caller))
+			if(fail.count(mission.Identifier()))
 				player.FailMission(mission);
 	}
+	if(failCaller && caller)
+		player.FailMission(*caller);
 
 	// Check if applying the conditions changes the player's reputations.
 	conditions.Apply(player.Conditions());

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -354,7 +354,7 @@ void GameAction::Do(PlayerInfo &player, UI *ui, const Mission *caller) const
 	for(const auto &it : events)
 		player.AddEvent(*it.first, player.GetDate() + it.second.first);
 
-	if(!fail.empty())
+	if(!fail.empty() || failCaller)
 	{
 		// If this action causes this or any other mission to fail, mark that
 		// mission as failed. It will not be removed from the player's mission

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -402,6 +402,7 @@ GameAction GameAction::Instantiate(map<string, string> &subs, int jumps, int pay
 			result.specialLogText[it.first][eit.first] = Format::Replace(eit.second, subs);
 
 	result.fail = fail;
+	result.failCaller = failCaller;
 
 	result.conditions = conditions;
 

--- a/source/GameAction.h
+++ b/source/GameAction.h
@@ -29,6 +29,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 class DataNode;
 class DataWriter;
 class GameEvent;
+class Mission;
 class Outfit;
 class PlayerInfo;
 class Ship;
@@ -47,11 +48,11 @@ class GameAction {
 public:
 	GameAction() = default;
 	// Construct and Load() at the same time.
-	GameAction(const DataNode &node, const std::string &missionName);
+	GameAction(const DataNode &node);
 
-	void Load(const DataNode &node, const std::string &missionName);
+	void Load(const DataNode &node);
 	// Process a single sibling node.
-	void LoadSingle(const DataNode &child, const std::string &missionName);
+	void LoadSingle(const DataNode &child);
 	void Save(DataWriter &out) const;
 
 	// Determine if this GameAction references content that is not fully defined.
@@ -66,7 +67,7 @@ public:
 	const std::vector<ShipManager> &Ships() const noexcept;
 
 	// Perform this action.
-	void Do(PlayerInfo &player, UI *ui) const;
+	void Do(PlayerInfo &player, UI *ui, const Mission *caller) const;
 
 	// "Instantiate" this action by filling in the wildcard data for the actual
 	// payment, event delay, etc.
@@ -88,6 +89,8 @@ private:
 
 	// When this action is performed, the missions with these names fail.
 	std::set<std::string> fail;
+	// When this action is performed, the mission that called this action is failed.
+	bool failCaller = false;
 
 	ConditionSet conditions;
 };

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -287,7 +287,7 @@ void Mission::Load(const DataNode &node)
 		else if(child.Token(0) == "substitutions" && child.HasChildren())
 			substitutions.Load(child);
 		else if(child.Token(0) == "npc")
-			npcs.emplace_back(child, name);
+			npcs.emplace_back(child);
 		else if(child.Token(0) == "on" && child.Size() >= 2 && child.Token(1) == "enter")
 		{
 			// "on enter" nodes may either name a specific system or use a LocationFilter
@@ -295,10 +295,10 @@ void Mission::Load(const DataNode &node)
 			if(child.Size() >= 3)
 			{
 				MissionAction &action = onEnter[GameData::Systems().Get(child.Token(2))];
-				action.Load(child, name);
+				action.Load(child);
 			}
 			else
-				genericOnEnter.emplace_back(child, name);
+				genericOnEnter.emplace_back(child);
 		}
 		else if(child.Token(0) == "on" && child.Size() >= 2)
 		{
@@ -318,7 +318,7 @@ void Mission::Load(const DataNode &node)
 			};
 			auto it = trigger.find(child.Token(1));
 			if(it != trigger.end())
-				actions[it->second].Load(child, name);
+				actions[it->second].Load(child);
 			else
 				child.PrintTrace("Skipping unrecognized attribute:");
 		}
@@ -1084,7 +1084,7 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	// mission dialog or conversation. Invisible missions don't show this
 	// marker.
 	if(it != actions.end())
-		it->second.Do(player, ui, (destination && isVisible) ? destination->GetSystem() : nullptr, boardingShip, IsUnique());
+		it->second.Do(player, ui, this, (destination && isVisible) ? destination->GetSystem() : nullptr, boardingShip, IsUnique());
 	else if(trigger == OFFER && location != JOB)
 		player.MissionCallback(Conversation::ACCEPT);
 
@@ -1201,7 +1201,7 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 	}
 
 	for(NPC &npc : npcs)
-		npc.Do(event, player, ui, isVisible);
+		npc.Do(event, player, ui, this, isVisible);
 }
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1084,7 +1084,8 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	// mission dialog or conversation. Invisible missions don't show this
 	// marker.
 	if(it != actions.end())
-		it->second.Do(player, ui, this, (destination && isVisible) ? destination->GetSystem() : nullptr, boardingShip, IsUnique());
+		it->second.Do(player, ui, this, (destination && isVisible) ? destination->GetSystem() : nullptr,
+			boardingShip, IsUnique());
 	else if(trigger == OFFER && location != JOB)
 		player.MissionCallback(Conversation::ACCEPT);
 

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -28,6 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class DataNode;
 class DataWriter;
+class Mission;
 class Outfit;
 class PlayerInfo;
 class System;
@@ -43,10 +44,10 @@ class MissionAction {
 public:
 	MissionAction() = default;
 	// Construct and Load() at the same time.
-	MissionAction(const DataNode &node, const std::string &missionName);
+	MissionAction(const DataNode &node);
 
-	void Load(const DataNode &node, const std::string &missionName);
-	void LoadSingle(const DataNode &node, const std::string &missionName);
+	void Load(const DataNode &node);
+	void LoadSingle(const DataNode &node);
 	// Note: the Save() function can assume this is an instantiated mission, not
 	// a template, so it only has to save a subset of the data.
 	void Save(DataWriter &out) const;
@@ -64,8 +65,9 @@ public:
 	bool RequiresGiftedShip(const std::string &shipId) const;
 	// Perform this action. If a conversation is shown, the given destination
 	// will be highlighted in the map if you bring it up.
-	void Do(PlayerInfo &player, UI *ui = nullptr, const System *destination = nullptr,
-		const std::shared_ptr<Ship> &ship = nullptr, const bool isUnique = true) const;
+	void Do(PlayerInfo &player, UI *ui = nullptr, const Mission *caller = nullptr,
+		const System *destination = nullptr, const std::shared_ptr<Ship> &ship = nullptr,
+		const bool isUnique = true) const;
 
 	// "Instantiate" this action by filling in the wildcard text for the actual
 	// destination, payment, cargo, etc.

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -81,7 +81,8 @@ public:
 
 	// Handle the given ShipEvent.
 	enum Trigger {KILL, BOARD, ASSIST, DISABLE, SCAN_CARGO, SCAN_OUTFITS, CAPTURE, PROVOKE};
-	void Do(const ShipEvent &event, PlayerInfo &player, UI *ui = nullptr, const Mission *caller = nullptr, bool isVisible = true);
+	void Do(const ShipEvent &event, PlayerInfo &player, UI *ui = nullptr,
+		const Mission *caller = nullptr, bool isVisible = true);
 	// Determine if the NPC is in a successful state, assuming the player is in the given system.
 	// (By default, a despawnable NPC has succeeded and is not actually checked.)
 	bool HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable = true) const;

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -34,6 +34,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 class DataNode;
 class DataWriter;
 class Government;
+class Mission;
 class Planet;
 class PlayerInfo;
 class Ship;
@@ -58,9 +59,9 @@ public:
 	~NPC() noexcept = default;
 
 	// Construct and Load() at the same time.
-	NPC(const DataNode &node, const std::string &missionName);
+	NPC(const DataNode &node);
 
-	void Load(const DataNode &node, const std::string &missionName);
+	void Load(const DataNode &node);
 	// Note: the Save() function can assume this is an instantiated mission, not
 	// a template, so fleets will be replaced by individual ships already.
 	void Save(DataWriter &out) const;
@@ -80,7 +81,7 @@ public:
 
 	// Handle the given ShipEvent.
 	enum Trigger {KILL, BOARD, ASSIST, DISABLE, SCAN_CARGO, SCAN_OUTFITS, CAPTURE, PROVOKE};
-	void Do(const ShipEvent &event, PlayerInfo &player, UI *ui = nullptr, bool isVisible = true);
+	void Do(const ShipEvent &event, PlayerInfo &player, UI *ui = nullptr, const Mission *caller = nullptr, bool isVisible = true);
 	// Determine if the NPC is in a successful state, assuming the player is in the given system.
 	// (By default, a despawnable NPC has succeeded and is not actually checked.)
 	bool HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable = true) const;
@@ -98,7 +99,7 @@ public:
 
 private:
 	// Handle any NPC mission actions that may have been triggered by a ShipEvent.
-	void DoActions(const ShipEvent &event, bool newEvent, PlayerInfo &player, UI *ui = nullptr);
+	void DoActions(const ShipEvent &event, bool newEvent, PlayerInfo &player, UI *ui, const Mission *caller);
 
 
 private:

--- a/source/NPCAction.cpp
+++ b/source/NPCAction.cpp
@@ -26,14 +26,14 @@ using namespace std;
 
 
 // Construct and Load() at the same time.
-NPCAction::NPCAction(const DataNode &node, const string &missionName)
+NPCAction::NPCAction(const DataNode &node)
 {
-	Load(node, missionName);
+	Load(node);
 }
 
 
 
-void NPCAction::Load(const DataNode &node, const string &missionName)
+void NPCAction::Load(const DataNode &node)
 {
 	if(node.Size() >= 2)
 		trigger = node.Token(1);
@@ -45,7 +45,7 @@ void NPCAction::Load(const DataNode &node, const string &missionName)
 		if(key == "triggered")
 			triggered = true;
 		else
-			action.LoadSingle(child, missionName);
+			action.LoadSingle(child);
 	}
 }
 
@@ -77,14 +77,14 @@ string NPCAction::Validate() const
 
 
 
-void NPCAction::Do(PlayerInfo &player, UI *ui)
+void NPCAction::Do(PlayerInfo &player, UI *ui, const Mission *caller)
 {
 	// All actions are currently one-time-use. Actions that are used
 	// are marked as triggered, and cannot be used again.
 	if(triggered)
 		return;
 	triggered = true;
-	action.Do(player, ui);
+	action.Do(player, ui, caller);
 }
 
 

--- a/source/NPCAction.h
+++ b/source/NPCAction.h
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class DataNode;
 class DataWriter;
+class Mission;
 class PlayerInfo;
 class System;
 class UI;
@@ -35,9 +36,9 @@ class NPCAction {
 public:
 	NPCAction() = default;
 	// Construct and Load() at the same time.
-	NPCAction(const DataNode &node, const std::string &missionName);
+	NPCAction(const DataNode &node);
 
-	void Load(const DataNode &node, const std::string &missionName);
+	void Load(const DataNode &node);
 	// Note: the Save() function can assume this is an instantiated mission, not
 	// a template, so it only has to save a subset of the data.
 	void Save(DataWriter &out) const;
@@ -45,7 +46,7 @@ public:
 	std::string Validate() const;
 
 	// Perform this action.
-	void Do(PlayerInfo &player, UI *ui = nullptr);
+	void Do(PlayerInfo &player, UI *ui = nullptr, const Mission *caller = nullptr);
 
 	// "Instantiate" this action by filling in the wildcard text for the actual
 	// destination, payment, cargo, etc.

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -280,7 +280,7 @@ void PlanetPanel::TakeOffIfReady()
 				else
 				{
 					GetUI()->Push(new ConversationPanel(player,
-						*GameData::Conversations().Get("flight check: " + check), nullptr, result.first));
+						*GameData::Conversations().Get("flight check: " + check), nullptr, nullptr, result.first));
 					return;
 				}
 			}

--- a/source/ShipManager.h
+++ b/source/ShipManager.h
@@ -16,9 +16,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef SHIP_MANAGER_H_
 #define SHIP_MANAGER_H_
 
-#include <string>
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 class DataNode;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #9093.

## Fix Details
The documentation for `fail` is as follows:
> This causes the named mission (*or this mission, if no name is given*) to fail immediately.

Emphasis on "or this mission, if no name is given". The current behavior is not simply "this mission," but "all missions of this type."

Changed "fail" without a mission name provided to only fail the calling mission. The old behavior of failing all missions of the same type can still be used by explicitly providing the mission name.

This was accomplished by replacing the behavior of using the name of the mission that loaded the action to instead set a "failCaller" boolean. This avoids the need to pass around the name of the mission that is loading the various actions that the mission can trigger. Instead, whenever an action is done, a pointer to the calling mission is passed along. (This could potentially be replaced with a pointer to the UUID of the calling mission.)

## Testing Done
Tested using the attached save file. There are two bounty ships in the next system over. Destroy one and land to observe the behavior on the other mission.
* Bugged behavior: destroying one ship and landing fails both missions.
* Fixed behavior: destroying one ship and landing fails only the mission for that ship, leaving the other mission untouched.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 522b7d6, and will not occur when using this branch's build.
[Test Pilot.txt](https://github.com/endless-sky/endless-sky/files/12208664/Test.Pilot.txt)
