### PR TITLE
feat(mechanic): handle fighter flagship for jump path planning

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1016,7 +1016,7 @@ void MapPanel::DrawTravelPlan()
 	bool hasEscort = false;
 	map<const Ship *, double> fuel;
 	for(const shared_ptr<Ship> &it : player.Ships())
-		if(!it->IsParked() && !it->CanBeCarried() && it->GetSystem() == flagship->GetSystem())
+		if(!it->IsParked() && (!it->CanBeCarried() || &*it == flagship) && it->GetSystem() == flagship->GetSystem())
 		{
 			if(it->IsDisabled())
 			{

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1016,7 +1016,7 @@ void MapPanel::DrawTravelPlan()
 	bool hasEscort = false;
 	map<const Ship *, double> fuel;
 	for(const shared_ptr<Ship> &it : player.Ships())
-		if(!it->IsParked() && (!it->CanBeCarried() || &*it == flagship) && it->GetSystem() == flagship->GetSystem())
+		if(!it->IsParked() && (!it->CanBeCarried() || it.get() == flagship) && it->GetSystem() == flagship->GetSystem())
 		{
 			if(it->IsDisabled())
 			{


### PR DESCRIPTION
**Feature:**

## Feature Details
If the flagship is a fighter that has been modified for jump travel, the travel path will show the correct colors for the amount of fuel it has.

## Additional Notes
In theory, you could extend this idea to any fighter (not just the flagship) that's been modified for jump travel (and isn't able to be carried).  But that would be a lot more work. ;)