### PR TITLE
Fix(map): use the correct wormhole color on travel plan

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1004,7 +1004,7 @@ void MapPanel::DrawTravelPlan()
 	const Color &defaultColor = *colors.Get("map travel ok flagship");
 	const Color &outOfFlagshipFuelRangeColor = *colors.Get("map travel ok none");
 	const Color &withinFleetFuelRangeColor = *colors.Get("map travel ok fleet");
-	const Color &wormholeColor = *colors.Get("map travel wormhole");
+	Color wormholeColor;
 
 	// At each point in the path, keep track of how many ships in the
 	// fleet are able to make it this far.
@@ -1038,12 +1038,16 @@ void MapPanel::DrawTravelPlan()
 		bool isJump = !isHyper && previous->JumpNeighbors(jumpRange).count(next);
 		bool isWormhole = false;
 		for(const StellarObject &object : previous->Objects())
+		{
 			isWormhole |= (object.HasSprite() && object.HasValidPlanet()
 				&& object.GetPlanet()->IsWormhole()
 				&& player.HasVisited(*object.GetPlanet())
 				&& object.GetPlanet()->GetWormhole()->IsMappable()
 				&& player.HasVisited(*previous) && player.HasVisited(*next)
 				&& &object.GetPlanet()->GetWormhole()->WormholeDestination(*previous) == next);
+			if(isWormhole)
+				wormholeColor = *object.GetPlanet()->GetWormhole()->GetLinkColor();
+		}
 
 		if(!isHyper && !isJump && !isWormhole)
 			break;


### PR DESCRIPTION
## Fix Details
Uses the custom wormhole color for the travel plan too.

## Testing Done
before:
![2023-07-31_14-35](https://github.com/endless-sky/endless-sky/assets/85687254/3fce6b9b-f802-49a2-b996-cd3e96ac3960)
after:
![2023-07-31_14-34](https://github.com/endless-sky/endless-sky/assets/85687254/6992bbd0-fe7b-429b-88a8-f891ac2d23e8)


## Save File
just look at the map and select a route with a custom wormhole color
