### PR TITLE
Enhancement(raids): stack pirate fleets when attraction is high enough

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1334,8 +1334,13 @@ void Engine::EnterSystem()
 	for(const auto &raidFleet : system->GetGovernment()->RaidFleets())
 	{
 		double attraction = player.RaidFleetAttraction(raidFleet, system);
-		if(attraction > 0.)
-			for(int i = 0; i < 10; ++i)
+		double stackedRaids = player.StackedRaids(raidFleet.GetFleet());
+		// If the pirates cannot beat you with the current attack but you have enough cargo, mass them up.
+		if(attraction > (1. + stackedRaids / 10.) &&
+				raidFleet.GetFleet()->Strength() * (10. + stackedRaids) < player.FleetStrength())
+			player.StackRaid(raidFleet.GetFleet(), attraction);
+		else if(attraction > 0.)
+			for(int i = 0; i < 10 + stackedRaids; ++i)
 				if(Random::Real() < attraction)
 				{
 					raidFleet.GetFleet()->Place(*system, newShips);

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -179,6 +179,13 @@ void Fleet::RemoveInvalidVariants()
 
 
 
+const std::string &Fleet::GetName() const
+{
+	return fleetName;
+}
+
+
+
 // Get the government of this fleet.
 const Government *Fleet::GetGovernment() const
 {

--- a/source/Fleet.h
+++ b/source/Fleet.h
@@ -53,6 +53,8 @@ public:
 
 	void Load(const DataNode &node);
 
+	const std::string &GetName() const;
+
 	// Determine if this fleet template uses well-defined data.
 	bool IsValid(bool requireGovernment = true) const;
 	// Ensure any variant selected during gameplay will have at least one ship to spawn.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1367,7 +1367,7 @@ double PlayerInfo::RaidFleetAttraction(const Government::RaidFleet &raid, const 
 				}
 			}
 	}
-	return max(0., min(1., attraction));
+	return max(0., attraction);
 }
 
 
@@ -2785,6 +2785,33 @@ const Depreciation &PlayerInfo::FleetDepreciation() const
 const Depreciation &PlayerInfo::StockDepreciation() const
 {
 	return stockDepreciation;
+}
+
+
+
+int64_t PlayerInfo::FleetStrength() const
+{
+	int64_t strength = 0;
+	for(auto ship : ships)
+		strength += ship->Strength();
+	return strength;
+}
+
+
+
+int PlayerInfo::StackedRaids(const Fleet *fleet) const
+{
+	auto it = raidFleets.find(fleet);
+	if(it == raidFleets.end())
+		return 0;
+	return it->second;
+}
+
+
+
+void PlayerInfo::StackRaid(const Fleet *fleet, double attraction)
+{
+	raidFleets[fleet] += attraction;
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -337,6 +337,9 @@ void PlayerInfo::Load(const string &path)
 			availableMissions.emplace_back(child);
 		else if(child.Token(0) == "conditions")
 			conditions.Load(child);
+		else if(child.Token(0) == "raid fleets")
+			for(const DataNode &grand : child)
+				raidFleets[GameData::Fleets().Find(grand.Token(0))] = grand.Value(1);
 		else if(child.Token(0) == "gifted ships" && child.HasChildren())
 		{
 			for(const DataNode &grand : child)
@@ -4308,6 +4311,17 @@ void PlayerInfo::Save(DataWriter &out) const
 
 	// Save any "primary condition" flags that are set.
 	conditions.Save(out);
+
+	// Save raid fleets that got stacked up.
+	if(!raidFleets.empty())
+	{
+		out.Write("raid fleets")
+		out.BeginChild();
+		{
+			for(const auto &it : raidFleets)
+				out.Write(it.first->GetName(), it.second);
+		}
+	}
 
 	// Save the UUID of any ships given to the player with a specified name, and ship class.
 	if(!giftedShips.empty())

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -313,6 +313,10 @@ public:
 	const Depreciation &FleetDepreciation() const;
 	const Depreciation &StockDepreciation() const;
 
+	int64_t FleetStrength() const;
+	int StackedRaids(const Fleet *fleet) const;
+	void StackRaid(const Fleet *fleet, double attraction);
+
 	// Keep track of what materials you have mined in each system.
 	void Harvest(const Outfit *type);
 	const std::set<std::pair<const System *, const Outfit *>> &Harvested() const;
@@ -395,6 +399,8 @@ private:
 	CargoHold cargo;
 	std::map<const Planet *, CargoHold> planetaryStorage;
 	std::map<std::string, int64_t> costBasis;
+
+	std::map<const Fleet *, int> raidFleets;
 
 	std::multimap<Date, std::string> logbook;
 	std::map<std::string, std::map<std::string, std::string>> specialLogs;

--- a/source/Variant.h
+++ b/source/Variant.h
@@ -39,7 +39,7 @@ public:
 	int Weight() const;
 	const std::vector<const Ship *> &Ships() const;
 
-	// The strength of a variant is the sum of the cost of its ships.
+	// The strength of a variant is the sum of the strength of its ships.
 	int64_t Strength() const;
 
 	bool operator==(const Variant &other) const;


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue https://github.com/endless-sky/endless-sky/issues/7894

## Feature Details
When the attraction is higher than 100%, the pirates will check if they stand a chance against your fleet. So long as they dont and the cargo is worth it, they will stack up, until they reach the given % (could be 300% and thus 30 fleets spawning, but it goes up so long as you do)

In order to do this, the strength of the player's fleet is compared to the strength of the pirates. The fact that they group up when attraction is high enough also means they will stop being such a joke and not spawn at every jump.

You better hide your loot, magot!

## UI Screenshots
![raid!](https://github.com/endless-sky/endless-sky/assets/94366726/3cda614d-268a-4b18-9cde-c51333666c66)

## Usage Examples
{{if this feature is used in the data files, provide examples!}}

## Testing Done
the screenshot has it, no fleets spawned for a few jumps until they were strong enough to kill my mighty star barge fleet - it would also have happened if they could no longer stack up

### Automated Tests Added
N/A

## Performance Impact
N/A
