### PR TITLE
Replace `shield resistance` on the Embersylph with `ion resistance`.

### DIFF
--- a/data/drak/indigenous.txt
+++ b/data/drak/indigenous.txt
@@ -292,7 +292,6 @@ ship "Embersylph"
 		"gaslining" 1
 		"inscrutable" 1
 		"atmospheric scan" 1000
-		"shield resistance" 1
 	outfits
 		"Absorption Organ" 1
 	turret 0 0 "Absorption Organ"

--- a/data/drak/indigenous.txt
+++ b/data/drak/indigenous.txt
@@ -292,6 +292,7 @@ ship "Embersylph"
 		"gaslining" 1
 		"inscrutable" 1
 		"atmospheric scan" 1000
+		"ion resistance" 1
 	outfits
 		"Absorption Organ" 1
 	turret 0 0 "Absorption Organ"


### PR DESCRIPTION
As noted in #9105.

Shield resistance does not appear anywhere in the source folder - there is no code to handle it. It does nothing.