### PR TITLE
HOTFIX: crash with some travel plans containing wormholes

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1045,7 +1045,7 @@ void MapPanel::DrawTravelPlan()
 				&& object.GetPlanet()->GetWormhole()->IsMappable()
 				&& player.HasVisited(*previous) && player.HasVisited(*next)
 				&& &object.GetPlanet()->GetWormhole()->WormholeDestination(*previous) == next);
-			if(isWormhole && object.HasValidPlanet() && object.GetPlanet()->IsWormhole())
+			if(isWormhole && !wormholeColor.IsLoaded())
 				wormholeColor = *object.GetPlanet()->GetWormhole()->GetLinkColor();
 		}
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1045,7 +1045,7 @@ void MapPanel::DrawTravelPlan()
 				&& object.GetPlanet()->GetWormhole()->IsMappable()
 				&& player.HasVisited(*previous) && player.HasVisited(*next)
 				&& &object.GetPlanet()->GetWormhole()->WormholeDestination(*previous) == next);
-			if(isWormhole)
+			if(isWormhole && object.HasValidPlanet() && object.GetPlanet()->IsWormhole())
 				wormholeColor = *object.GetPlanet()->GetWormhole()->GetLinkColor();
 		}
 


### PR DESCRIPTION
**Bugfix:** This PR addresses https://github.com/endless-sky/endless-sky/pull/9104 causing crashes when drawing the wormhole links

## Fix Details
the isWormhole just looked if one of the object was a wormhole and we get this color many times, on all of them - except half of them can be badly instantiated, not valid, or not wormholes (because it is |= and not = so it will stay true for objects after the wormhole itself)


I dont know if this is the optimal way to do this and dont care tbh we just need to hotfix this crash.

## Testing Done
I used multiple of my save files that crash without the two guards being added to see

## Save File
[Ariavne_Sootleaf.txt](https://github.com/endless-sky/endless-sky/files/12230959/Ariavne_Sootleaf.txt)
this one insta crashes on opening the map - justifying the first guarding close

[Friction.Diction.3026-02-19.TRY10.part.5.begin.txt](https://github.com/endless-sky/endless-sky/files/12230964/Friction.Diction.3026-02-19.TRY10.part.5.begin.txt)
this one crashes as well, because of the existance of the HR station that aint a wormhole and is after the wormhole itself - this justified the second guarding close