### PR TITLE
Use an unused government

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -417,6 +417,7 @@ government "Hai"
 	"player reputation" 0
 	"attitude toward"
 		"Hai (Wormhole Access)" 1
+		"Hai Merchant" 1
 		"Hai Merchant (Sympathizers)" 1
 		"Hai Merchant (Human)" 1
 		"Hai (Unfettered)" -.1
@@ -439,6 +440,7 @@ government "Hai (Wormhole Access)"
 	"player reputation" 0
 	"attitude toward"
 		"Hai" 1
+		"Hai Merchant" 1
 		"Hai Merchant (Sympathizers)" 1
 		"Hai Merchant (Human)" 1
 		"Hai (Unfettered)" -.1
@@ -447,6 +449,27 @@ government "Hai (Wormhole Access)"
 		"Merchant" .01
 		"Elenctic Commune" .1
 	"bribe" .2
+	"friendly hail" "friendly hai"
+	"friendly disabled hail" "friendly disabled hai"
+	"hostile hail" "hostile hai"
+	"hostile disabled hail" "hostile disabled hai"
+
+government "Hai Merchant"
+	"display name" "Hai"
+	swizzle 0
+	color "governments: Hai"
+	
+	"player reputation" 0
+	"attitude toward"
+		"Hai" 1
+		"Hai (Wormhole Access)" 1
+		"Hai Merchant (Sympathizers)" .95
+		"Hai Merchant (Human)" .95
+		"Hai (Unfettered)" -.1
+		"Hai (Friendly Unfettered)" .1
+		"Hai (Unfettered Civilians)" .1
+		"Merchant" .01
+	"bribe" .02
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"
 	"hostile hail" "hostile hai"
@@ -461,6 +484,7 @@ government "Hai Merchant (Sympathizers)"
 	"attitude toward"
 		"Hai" 1
 		"Hai (Wormhole Access)" 1
+		"Hai Merchant" .95
 		"Hai Merchant (Human)" .95
 		"Hai (Unfettered)" .01
 		"Hai (Friendly Unfettered)" .5
@@ -481,6 +505,7 @@ government "Hai Merchant (Human)"
 	"attitude toward"
 		"Hai" 1
 		"Hai (Wormhole Access)" 1
+		"Hai Merchant" .95
 		"Hai Merchant (Sympathizers)" .95
 		"Hai (Unfettered)" -.2
 		"Hai (Friendly Unfettered)" .1
@@ -503,6 +528,7 @@ government "Hai (Unfettered)"
 		"Hai (Unfettered Wanderer Tribute)" 2
 		"Hai" -.01
 		"Hai (Wormhole Access)" -.01
+		"Hai Merchant" -.01
 		"Hai Merchant (Sympathizers)" .1
 		"Hai (Friendly Unfettered)" 1
 		"Hai (Unfettered Civilians)" 2
@@ -1393,6 +1419,7 @@ government "Wormhole Alpha"
 	"fine" 0
 	"attitude toward"
 		"Hai" -.01
+		"Hai Merchant" -.01
 		"Hai Merchant (Sympathizers)" -.01
 		"Hai Merchant (Human)" -.01
 		"Hai (Unfettered)" -.01

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -417,7 +417,6 @@ government "Hai"
 	"player reputation" 0
 	"attitude toward"
 		"Hai (Wormhole Access)" 1
-		"Hai Merchant" 1
 		"Hai Merchant (Sympathizers)" 1
 		"Hai Merchant (Human)" 1
 		"Hai (Unfettered)" -.1
@@ -440,7 +439,6 @@ government "Hai (Wormhole Access)"
 	"player reputation" 0
 	"attitude toward"
 		"Hai" 1
-		"Hai Merchant" 1
 		"Hai Merchant (Sympathizers)" 1
 		"Hai Merchant (Human)" 1
 		"Hai (Unfettered)" -.1
@@ -449,27 +447,6 @@ government "Hai (Wormhole Access)"
 		"Merchant" .01
 		"Elenctic Commune" .1
 	"bribe" .2
-	"friendly hail" "friendly hai"
-	"friendly disabled hail" "friendly disabled hai"
-	"hostile hail" "hostile hai"
-	"hostile disabled hail" "hostile disabled hai"
-
-government "Hai Merchant"
-	"display name" "Hai"
-	swizzle 0
-	color "governments: Hai"
-	
-	"player reputation" 0
-	"attitude toward"
-		"Hai" 1
-		"Hai (Wormhole Access)" 1
-		"Hai Merchant (Sympathizers)" .95
-		"Hai Merchant (Human)" .95
-		"Hai (Unfettered)" -.1
-		"Hai (Friendly Unfettered)" .1
-		"Hai (Unfettered Civilians)" .1
-		"Merchant" .01
-	"bribe" .02
 	"friendly hail" "friendly hai"
 	"friendly disabled hail" "friendly disabled hai"
 	"hostile hail" "hostile hai"
@@ -484,7 +461,6 @@ government "Hai Merchant (Sympathizers)"
 	"attitude toward"
 		"Hai" 1
 		"Hai (Wormhole Access)" 1
-		"Hai Merchant" .95
 		"Hai Merchant (Human)" .95
 		"Hai (Unfettered)" .01
 		"Hai (Friendly Unfettered)" .5
@@ -505,7 +481,6 @@ government "Hai Merchant (Human)"
 	"attitude toward"
 		"Hai" 1
 		"Hai (Wormhole Access)" 1
-		"Hai Merchant" .95
 		"Hai Merchant (Sympathizers)" .95
 		"Hai (Unfettered)" -.2
 		"Hai (Friendly Unfettered)" .1
@@ -528,7 +503,6 @@ government "Hai (Unfettered)"
 		"Hai (Unfettered Wanderer Tribute)" 2
 		"Hai" -.01
 		"Hai (Wormhole Access)" -.01
-		"Hai Merchant" -.01
 		"Hai Merchant (Sympathizers)" .1
 		"Hai (Friendly Unfettered)" 1
 		"Hai (Unfettered Civilians)" 2
@@ -1419,7 +1393,6 @@ government "Wormhole Alpha"
 	"fine" 0
 	"attitude toward"
 		"Hai" -.01
-		"Hai Merchant" -.01
 		"Hai Merchant (Sympathizers)" -.01
 		"Hai Merchant (Human)" -.01
 		"Hai (Unfettered)" -.01

--- a/data/hai/hai fleets.txt
+++ b/data/hai/hai fleets.txt
@@ -199,7 +199,7 @@ fleet "Hai Wormhole Guards"
 		"Lightning Bug (Pulse)" 2
 
 fleet "Small Hai Merchant"
-	government "Hai"
+	government "Hai Merchant"
 	names "hai"
 	cargo 3
 	personality
@@ -282,7 +282,7 @@ fleet "Small Hai Merchant"
 		"Cicada"
 
 fleet "Large Hai Merchant"
-	government "Hai"
+	government "Hai Merchant"
 	names "hai"
 	cargo 4
 	personality


### PR DESCRIPTION
**Bugfix:**

## Fix Details
The government "Hai Merchant" is never used. ~~The only references to it are its own definition and attitudes towards it from various other governments. None of these attitudes do anything, though, because no ship with this government will ever appear in the vanilla game. This PR removes the government definition along with all those attitudes because they don't do anything and can only lead to confusion.~~
This PR adds it to the "Small Hai Merchant" and "Large Hai Merchant" fleets per https://github.com/endless-sky/endless-sky/pull/9111#issuecomment-1661280560.

## Testing Done
~~Launch the game, see that it doesn't produce any errors about the government being referred to but not fully defined (will need to make sure recent.txt is empty because the save file will have a reference to it in its attitudes.)
Also, search all the game files and see that the only remaining matches for `"Hai Merchant"` are in phrases within news items.~~
0