### PR TITLE
Condition that allows rolling a random value in a specified range

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3747,6 +3747,27 @@ void PlayerInfo::RegisterDerivedConditions()
 		return true;
 	});
 
+	// A condition for returning a random integer in the range [0, input). Input may be a number,
+	// or it may be the name of a condition. For example, "roll: 100" would roll a random
+	// integer in the range [0, 100), but if you had a condition "max roll" with a value of 100,
+	// calling "roll: max roll" would provide a value from the same range.
+	// Returns 0 if the input condition's value is <= 1.
+	auto &&randomRollProvider = conditions.GetProviderPrefixed("roll: ");
+	auto randomRollFun = [this](const string &name) -> int64_t
+	{
+		string input = name.substr(strlen("roll: "));
+		int64_t value = 0;
+		if(DataNode::IsNumber(input))
+			value = static_cast<int64_t>(DataNode::Value(input));
+		else
+			value = conditions.Get(input);
+		if(value <= 1)
+			return 0;
+		return Random::Int(value);
+	};
+	randomRollProvider.SetHasFunction(randomRollFun);
+	randomRollProvider.SetGetFunction(randomRollFun);
+
 	// Global conditions setters and getters:
 	auto &&globalProvider = conditions.GetProviderPrefixed("global: ");
 	globalProvider.SetHasFunction([](const string &name) -> bool


### PR DESCRIPTION
**Feature:**

## Feature Details
This PR adds a new derived condition, `"roll: <input>"`, which rolls a random number in the range [0, input). The input can either be a number (which gets converted to an integer), or the name of a condition. If a condition name is provided, then the value of that condition is used as the input to the random function. If a value is provided that is <= 1, then the output will always be 0.

The existing `random` condition is hardcoded to always roll in the range [0, 100). By adding this condition, we can now roll random numbers in any arbitrary range that we want. Allowing the input to be a condition also allows for ranges that change dynamically depending on the state of the input condition.

## UI Screenshots
N/A

## Usage Examples
See testing done.

## Testing Done
Tested the following mission with "roll: deathroll" and "roll: 100". Using the former, each subsequent roll in the game always decreased. Using the latter, the rolls bounced around until someone landed on 1.
```
mission "Deathroll"
	invisible
	repeat
	on offer
		conversation
			`Gamble in a deathroll game?`
			choice
				`	(Yes.)`
				`	(No.)`
					decline
			
			`	The dealer flips a coin.`
			action
				deathroll = 100
			
			branch you
				random < 50
			`	The dealer gets to go first.`
				goto rollD
			
			label you
			`	You get to go first.`
				goto rollP
			
			label rollD
			action
				deathroll = "roll: deathroll" + 1
			`	The dealer rolls &[deathroll].`
			branch rollP
				deathroll > 1
			action
				payment 10000
			`	You won <payment>.`
				decline
			
			label rollP
			action
				deathroll = "roll: deathroll" + 1
			`	You roll &[deathroll].`
			branch loser
				deathroll <= 1
			choice
				`	(Continue playing.)`
					goto rollD
				`	(Forfeit)`
			
			label loser
			action
				payment -10000
			`	You lost <payment>`
				decline
```

### Automated Tests Added
None.

## Performance Impact
N/A
