### PR TITLE
feat(text): More pleasing grammar in FW Bounty 1

### DIFF
--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -1012,7 +1012,7 @@ mission "FW Escort Second Chance"
 mission "FW Bounty 1"
 	minor
 	name "Free Worlds Bounty Hunting"
-	description `Hunt down and destroy the "Rat Pack," a gang of pirate ships led by a flagship named "Cluny" who have been attacking freighters in Free Worlds space. They were last seen attacking freighters in the Seginus system.`
+	description `Hunt down and destroy the "Rat Pack," a gang of pirate ships led by a flagship named "Cluny" who have been attacking shipping in Free Worlds space. They were last seen going after freighters in the Seginus system.`
 	source
 		government "Free Worlds"
 	to offer

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -1012,7 +1012,7 @@ mission "FW Escort Second Chance"
 mission "FW Bounty 1"
 	minor
 	name "Free Worlds Bounty Hunting"
-	description `Hunt down and destroy the "Rat Pack," a gang of pirate ships led by a flagship named "Cluny" who have been attacking shipping in Free Worlds space. They were last seen going after freighters in the Seginus system.`
+	description `Hunt down and destroy the "Rat Pack," a gang of pirate ships led by a flagship named "Cluny" who have been harassing merchants in Free Worlds space. They were last seen attacking freighters in the Seginus system.`
 	source
 		government "Free Worlds"
 	to offer


### PR DESCRIPTION
**Tweak:** This PR addresses some technically valid but unpleasant grammar I encountered after the description was brought up on Discord.

## What I've Done
All I've done here is edit the description of the mission so that instead of saying "attacking freighters" twice in two sentences it first says "attacking shipping" and then later, "going after freighters."

The text should still be short enough that it doesn't overflow the description box.