### PR TITLE
feat(ui): Display fighters of the hailed ship

### DIFF
--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -234,11 +234,9 @@ void HailPanel::Draw()
 
 		if(hasFighters)
 			for(const Ship::Bay &bay : ship->Bays())
-			{
 				if(bay.side == Ship::Bay::UNDER && bay.ship)
 					draw.Add(Body(*bay.ship, center + zoom * facing.Rotate(bay.point),
 						Point(), facing + bay.facing, zoom));
-			}
 		for(const Hardpoint &hardpoint : ship->Weapons())
 			if(hardpoint.IsUnder())
 				addHardpoint(hardpoint);
@@ -248,11 +246,9 @@ void HailPanel::Draw()
 				addHardpoint(hardpoint);
 		if(hasFighters)
 			for(const Ship::Bay &bay : ship->Bays())
-			{
 				if(bay.side == Ship::Bay::OVER && bay.ship)
 					draw.Add(Body(*bay.ship, center + zoom * facing.Rotate(bay.point),
 						Point(), facing + bay.facing, zoom));
-			}
 	}
 	else
 		draw.Add(Body(sprite, center, Point(), facing, zoom));

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -214,7 +214,7 @@ void HailPanel::Draw()
 
 	DrawList draw;
 	// If this is a ship, copy its swizzle, animation settings, etc.
-	// Also draw its fighters and hardpoints.
+	// Also draw its fighters and weapon hardpoints.
 	if(ship)
 	{
 		bool hasFighters = ship->PositionFighters();

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -231,12 +231,24 @@ void HailPanel::Draw()
 				draw.Add(body);
 			}
 		};
+		auto addFighter = [this, &draw, &center, zoom](const Ship::Bay &bay) -> void
+		{
+			if(bay.ship)
+			{
+				Body body(
+					*bay.ship,
+					center + zoom * facing.Rotate(bay.point),
+					Point(),
+					facing + bay.facing,
+					zoom);
+				draw.Add(body);
+			}
+		};
 
 		if(hasFighters)
 			for(const Ship::Bay &bay : ship->Bays())
-				if(bay.side == Ship::Bay::UNDER && bay.ship)
-					draw.Add(Body(*bay.ship, center + zoom * facing.Rotate(bay.point),
-						Point(), facing + bay.facing, zoom));
+				if(bay.side == Ship::Bay::UNDER)
+					addFighter(bay);
 		for(const Hardpoint &hardpoint : ship->Weapons())
 			if(hardpoint.IsUnder())
 				addHardpoint(hardpoint);
@@ -246,9 +258,8 @@ void HailPanel::Draw()
 				addHardpoint(hardpoint);
 		if(hasFighters)
 			for(const Ship::Bay &bay : ship->Bays())
-				if(bay.side == Ship::Bay::OVER && bay.ship)
-					draw.Add(Body(*bay.ship, center + zoom * facing.Rotate(bay.point),
-						Point(), facing + bay.facing, zoom));
+				if(bay.side == Ship::Bay::OVER)
+					addFighter(bay);
 	}
 	else
 		draw.Add(Body(sprite, center, Point(), facing, zoom));

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -214,14 +214,12 @@ void HailPanel::Draw()
 
 	DrawList draw;
 	// If this is a ship, copy its swizzle, animation settings, etc.
+	// Also draw its fighters and hardpoints.
 	if(ship)
-		draw.Add(Body(*ship, center, Point(), facing, zoom));
-	else
-		draw.Add(Body(sprite, center, Point(), facing, zoom));
-
-	// If hailing a ship, draw its turret sprites.
-	if(ship)
-		for(const Hardpoint &hardpoint : ship->Weapons())
+	{
+		bool hasFighters = ship->PositionFighters();
+		auto addHardpoint = [this, &draw, &center, zoom](const Hardpoint &hardpoint) -> void
+		{
 			if(hardpoint.GetOutfit() && hardpoint.GetOutfit()->HardpointSprite().HasSprite())
 			{
 				Body body(
@@ -232,6 +230,33 @@ void HailPanel::Draw()
 					zoom);
 				draw.Add(body);
 			}
+		};
+
+		if(hasFighters)
+			for(const Ship::Bay &bay : ship->Bays())
+			{
+				if(bay.side == Ship::Bay::UNDER && bay.ship)
+					draw.Add(Body(*bay.ship, center + zoom * facing.Rotate(bay.point),
+						Point(), facing + bay.facing, zoom));
+			}
+		for(const Hardpoint &hardpoint : ship->Weapons())
+			if(hardpoint.IsUnder())
+				addHardpoint(hardpoint);
+		draw.Add(Body(*ship, center, Point(), facing, zoom));
+		for(const Hardpoint &hardpoint : ship->Weapons())
+			if(!hardpoint.IsUnder())
+				addHardpoint(hardpoint);
+		if(hasFighters)
+			for(const Ship::Bay &bay : ship->Bays())
+			{
+				if(bay.side == Ship::Bay::OVER && bay.ship)
+					draw.Add(Body(*bay.ship, center + zoom * facing.Rotate(bay.point),
+						Point(), facing + bay.facing, zoom));
+			}
+	}
+	else
+		draw.Add(Body(sprite, center, Point(), facing, zoom));
+
 	draw.Draw();
 
 	// Draw the current message.


### PR DESCRIPTION
**Feature:** This PR resolves #4466

## Feature Details
When you hail a ship carrying fighters or drones externally, the carried ships are visible on the hail panel.

Also fixed displaying `under` hardpoints (haven't tested how it behaved before, but the code seemed to display all hardpoints on top of the ship sprite).

## UI Screenshots
Before:
![before](https://github.com/endless-sky/endless-sky/assets/108272452/a1854df0-d2b4-4fa1-90fb-101261e5e4c0)
After:
![after](https://github.com/endless-sky/endless-sky/assets/108272452/53fe2af7-28fc-49fc-be4b-9bb00fa5ea07)

## Testing Done
Fighters (over and under) and hardpoints (over and under) display correctly.

## Performance Impact
N/A
