### PR TITLE
fix(ui): Correctly check for double clicks on ship list of Player Info panel

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -542,11 +542,14 @@ bool PlayerInfoPanel::Click(int x, int y, int clicks)
 	}
 	else
 	{
+		const bool sameIndex = panelState.SelectedIndex() == hoverIndex;
+		panelState.SelectOnly(hoverIndex);
 		// If not landed, clicking a ship name takes you straight to its info.
-		panelState.SetSelectedIndex(hoverIndex);
-
-		GetUI()->Pop(this);
-		GetUI()->Push(new ShipInfoPanel(player, std::move(panelState)));
+		if(!panelState.CanEdit() || sameIndex)
+		{
+			GetUI()->Pop(this);
+			GetUI()->Push(new ShipInfoPanel(player, std::move(panelState)));
+		}
 	}
 
 	return true;


### PR DESCRIPTION
## Fix Details
Fixed the bug when you perform a double click, but the first click is on one ship and the second one is on another ship. Currently, it opens an info panel for the second ship.
With this change, it just selects the second ship without switching to any ship info panel.

## Testing Done
Everything else works as before: tested both landed and in flight.