### PR TITLE
feat(ui): Allow opening the map in outfitter and shipyard

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -639,10 +639,12 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		GetUI()->Pop(this);
 	}
 	else if(command.Has(Command::MAP))
+	{
 		if(isOutfitter)
 			GetUI()->Push(new MapOutfitterPanel(player));
 		else
 			GetUI()->Push(new MapShipyardPanel(player));
+	}
 	else if(key == 'b' || key == 'i' || key == 'c')
 	{
 		const auto result = CanBuy(key == 'i' || key == 'c');

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -26,6 +26,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Format.h"
 #include "GameData.h"
 #include "Government.h"
+#include "MapShipyardPanel.h"
+#include "MapOutfitterPanel.h"
 #include "Mission.h"
 #include "OutlineShader.h"
 #include "Planet.h"
@@ -66,7 +68,7 @@ namespace {
 
 ShopPanel::ShopPanel(PlayerInfo &player, bool isOutfitter)
 	: player(player), day(player.GetDate().DaysSinceEpoch()),
-	planet(player.GetPlanet()), playerShip(player.Flagship()),
+	planet(player.GetPlanet()), isOutfitter(isOutfitter), playerShip(player.Flagship()),
 	categories(GameData::GetCategory(isOutfitter ? CategoryType::OUTFIT : CategoryType::SHIP)),
 	collapsed(player.Collapsed(isOutfitter ? "outfitter" : "shipyard"))
 {
@@ -636,6 +638,11 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		player.UpdateCargoCapacities();
 		GetUI()->Pop(this);
 	}
+	else if(command.Has(Command::MAP))
+		if(isOutfitter)
+			GetUI()->Push(new MapOutfitterPanel(player));
+		else
+			GetUI()->Push(new MapShipyardPanel(player));
 	else if(key == 'b' || key == 'i' || key == 'c')
 	{
 		const auto result = CanBuy(key == 'i' || key == 'c');

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -150,6 +150,7 @@ protected:
 	// Remember the current day, for calculating depreciation.
 	int day;
 	const Planet *planet = nullptr;
+	const bool isOutfitter;
 
 	// The player-owned ship that was first selected in the sidebar (or most recently purchased).
 	Ship *playerShip = nullptr;


### PR DESCRIPTION
**Feature:** This PR resolves #4535

## Feature Details
You can now open the map in outfitter and shipyard, with the default mode depending on where you are. When you close the map, the shop is as you left it (selected item remains selected etc.).

## UI Screenshots
N/A

## Testing Done
yes.

## Performance Impact
N/A
