### PR TITLE
fix(ui): Fix some shop info bar display bugs

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -323,7 +323,7 @@ int OutfitterPanel::DrawDetails(const Point &center)
 	}
 
 	// Draw this string representing the selected item (if any), centered in the details side panel
-	Point selectedPoint(center.X() - .5 * INFOBAR_WIDTH, center.Y());
+	Point selectedPoint(center.X() - INFOBAR_WIDTH / 2 + 10, center.Y());
 	font.Draw({selectedItem, {INFOBAR_WIDTH - 20, Alignment::CENTER, Truncate::MIDDLE}},
 		selectedPoint, bright);
 

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -180,7 +180,7 @@ int ShipyardPanel::DrawDetails(const Point &center)
 		const Sprite *background = SpriteSet::Get("ui/shipyard selected");
 		const Sprite *shipSprite = selectedShip->GetSprite();
 		float spriteScale = shipSprite
-			? min(1.f, (INFOBAR_WIDTH - 20.f) / max(shipSprite->Width(), shipSprite->Height()))
+			? min(1.f, (INFOBAR_WIDTH - 60.f) / max(shipSprite->Width(), shipSprite->Height()))
 			: 1.f;
 
 		int swizzle = selectedShip->CustomSwizzle() >= 0
@@ -235,7 +235,7 @@ int ShipyardPanel::DrawDetails(const Point &center)
 	}
 
 	// Draw this string representing the selected ship (if any), centered in the details side panel
-	Point selectedPoint(center.X() - INFOBAR_WIDTH / 2, center.Y());
+	Point selectedPoint(center.X() - INFOBAR_WIDTH / 2 + 10, center.Y());
 	font.Draw({selectedItem, {INFOBAR_WIDTH - 20, Alignment::CENTER, Truncate::MIDDLE}},
 		selectedPoint, bright);
 


### PR DESCRIPTION
## Fix Details
1. Made ship sprite scaling more restrictive, so that the ship won't appear larger than the background.
2. Made the item name look more centered (both shipyard and outfitter).

## UI Screenshots
Before:
![1](https://github.com/endless-sky/endless-sky/assets/108272452/601dee6b-02c1-49e1-b3bd-5bddc9c99f11)
After:
![2](https://github.com/endless-sky/endless-sky/assets/108272452/1e7be97c-74ca-4245-88c9-cbaf79f71c1f)
