### PR TITLE
Feat(enhancement): destroyed persons autocondition

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2892,7 +2892,6 @@ void PlayerInfo::ApplyChanges()
 
 	// Check if any special persons have been destroyed.
 	GameData::DestroyPersons(destroyedPersons);
-	destroyedPersons.clear();
 
 	// Check which planets you have dominated.
 	for(auto it = tributeReceived.begin(); it != tributeReceived.end(); ++it)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3675,7 +3675,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	auto &&destroyedPersonProvider = conditions.GetProviderPrefixed("person destroyed: ");
 	auto destroyedPersonFun = [](const string &name) -> bool
 	{
-		const Person *person = GameData::Persons().Get(name.substr(strlen("person destroyed: ")));
+		const Person *person = GameData::Persons().Find(name.substr(strlen("person destroyed: ")));
 		return person ? person->IsDestroyed() : false;
 	};
 	destroyedPersonProvider.SetGetFunction(destroyedPersonFun);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2892,6 +2892,7 @@ void PlayerInfo::ApplyChanges()
 
 	// Check if any special persons have been destroyed.
 	GameData::DestroyPersons(destroyedPersons);
+	destroyedPersons.clear();
 
 	// Check which planets you have dominated.
 	for(auto it = tributeReceived.begin(); it != tributeReceived.end(); ++it)
@@ -3672,10 +3673,9 @@ void PlayerInfo::RegisterDerivedConditions()
 	pluginProvider.SetGetFunction(pluginFun);
 
 	auto &&destroyedPersonProvider = conditions.GetProviderPrefixed("destroyed person: ");
-	auto destroyedPersonFun = [this](const string &name) -> bool
+	auto destroyedPersonFun = [](const string &name) -> bool
 	{
-		return std::find(destroyedPersons.begin(), destroyedPersons.end(), 
-			name.substr(strlen("destroyed person: "))) != destroyedPersons.end();
+		return GameData::Persons().Has(name.substr(strlen("destroyed person: ")));
 	};
 	destroyedPersonProvider.SetGetFunction(destroyedPersonFun);
 	destroyedPersonProvider.SetHasFunction(destroyedPersonFun);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3672,6 +3672,15 @@ void PlayerInfo::RegisterDerivedConditions()
 	pluginProvider.SetHasFunction(pluginFun);
 	pluginProvider.SetGetFunction(pluginFun);
 
+	auto &&destroyedPersonProvider = conditions.GetProviderPrefixed("destroyed person: ");
+	auto destroyedPersonFun = [this](const string &name) -> bool
+	{
+		return std::find(destroyedPersons.begin(), destroyedPersons.end(), 
+			name.substr(strlen("destroyed person: "))) != destroyedPersons.end();
+	};
+	destroyedPersonProvider.SetGetFunction(destroyedPersonFun);
+	destroyedPersonProvider.SetHasFunction(destroyedPersonFun);
+
 	// Read-only navigation conditions.
 	auto HyperspaceTravelDays = [](const System *origin, const System *destination) -> int
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3675,7 +3675,8 @@ void PlayerInfo::RegisterDerivedConditions()
 	auto &&destroyedPersonProvider = conditions.GetProviderPrefixed("destroyed person: ");
 	auto destroyedPersonFun = [](const string &name) -> bool
 	{
-		return GameData::Persons().Has(name.substr(strlen("destroyed person: ")));
+		const Person *person = GameData::Persons().Get(name.substr(strlen("destroyed person: ")));
+		return person ? person->IsDestroyed() : false;
 	};
 	destroyedPersonProvider.SetGetFunction(destroyedPersonFun);
 	destroyedPersonProvider.SetHasFunction(destroyedPersonFun);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3672,10 +3672,10 @@ void PlayerInfo::RegisterDerivedConditions()
 	pluginProvider.SetHasFunction(pluginFun);
 	pluginProvider.SetGetFunction(pluginFun);
 
-	auto &&destroyedPersonProvider = conditions.GetProviderPrefixed("destroyed person: ");
+	auto &&destroyedPersonProvider = conditions.GetProviderPrefixed("person destroyed: ");
 	auto destroyedPersonFun = [](const string &name) -> bool
 	{
-		const Person *person = GameData::Persons().Get(name.substr(strlen("destroyed person: ")));
+		const Person *person = GameData::Persons().Get(name.substr(strlen("person destroyed: ")));
 		return person ? person->IsDestroyed() : false;
 	};
 	destroyedPersonProvider.SetGetFunction(destroyedPersonFun);


### PR DESCRIPTION
## Feature Details
One can use "destroyed person: <name>" to find out if it died.

## UI Screenshots
n/a

## Usage Examples
This can be mostly useful for plugins, that would for instance spawn custom person ships or react to you killing one of them.

## Testing Done
I made the authors spawn all the time to snatch Tranquility (was noted in my savefile) and then made a small mission to see if it was always on (it isnt) and if it works properly (the mission offered as planned)
re-tested, still works

### Automated Tests Added
n/a

## Performance Impact
n/a
~~Small extra memory usage because we dont clear the destroyed authors anymore (that's why it wasnt working when I first tested it lol) but memory really doesnt matter even for old computers, especially at this scale.~~ realized I could do it another way so none
