### PR TITLE
Bugfix: exile rep being positive when deferring the diplomacy

### DIFF
--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -3073,7 +3073,6 @@ mission "Wanderers: Sestor: Exiles 3"
 	on offer
 		log "Succeeded in communicating with the Korath exiles, by landing on the one habitable planet in their territory. (It seems like the exiles might have a taboo against using weapons on that world.) The exiles agreed to send some ships to help disable the remaining Kor Sestor factory."
 		fail "Wanderers: Sestor: Exiles 2"
-		event "wanderers: exiles peaceful"
 		conversation
 			`The Korath ships tail you to the planet's surface, but they do not fire on you. Instead, they hover above your ship for a long, indecisive moment. You hold your fire, and they eventually land in the sand next to you. Their airlocks open, and a few of them step out and approach your ship. They do not appear to be armed. Perhaps they have a cultural taboo against using weapons on this world.`
 			choice
@@ -3087,6 +3086,8 @@ mission "Wanderers: Sestor: Exiles 3"
 					goto end
 				`	"What are they asking for in return?"`
 			`	Rek says, "They request a meeting with our leaders, to work out terms of trade for our mutual benefit. It is something we would certainly agree to with no difficulty."`
+			action
+				event "wanderers: exiles peaceful"
 			label end
 			`	Rek speaks with the Korath again, and then tells you, "They say that three of their 'world-ships' will travel with us to meet with the Wanderer leaders. If they are able to work out favorable terms, and are convinced that the Wanderers have peaceful intentions, they will go with us to the Sestor factory world and shut it down."`
 				accept

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -3071,7 +3071,6 @@ mission "Wanderers: Sestor: Exiles 3"
 	to offer
 		has "Wanderers: Sestor: Exiles 2: active"
 	on offer
-		log "Succeeded in communicating with the Korath exiles, by landing on the one habitable planet in their territory. (It seems like the exiles might have a taboo against using weapons on that world.) The exiles agreed to send some ships to help disable the remaining Kor Sestor factory."
 		fail "Wanderers: Sestor: Exiles 2"
 		conversation
 			`The Korath ships tail you to the planet's surface, but they do not fire on you. Instead, they hover above your ship for a long, indecisive moment. You hold your fire, and they eventually land in the sand next to you. Their airlocks open, and a few of them step out and approach your ship. They do not appear to be armed. Perhaps they have a cultural taboo against using weapons on this world.`
@@ -3087,6 +3086,7 @@ mission "Wanderers: Sestor: Exiles 3"
 				`	"What are they asking for in return?"`
 			`	Rek says, "They request a meeting with our leaders, to work out terms of trade for our mutual benefit. It is something we would certainly agree to with no difficulty."`
 			action
+				log "Succeeded in communicating with the Korath exiles, by landing on the one habitable planet in their territory. (It seems like the exiles might have a taboo against using weapons on that world.) The exiles agreed to send some ships to help disable the remaining Kor Sestor factory."
 				event "wanderers: exiles peaceful"
 			label end
 			`	Rek speaks with the Korath again, and then tells you, "They say that three of their 'world-ships' will travel with us to meet with the Wanderer leaders. If they are able to work out favorable terms, and are convinced that the Wanderers have peaceful intentions, they will go with us to the Sestor factory world and shut it down."`

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -3071,7 +3071,6 @@ mission "Wanderers: Sestor: Exiles 3"
 	to offer
 		has "Wanderers: Sestor: Exiles 2: active"
 	on offer
-		fail "Wanderers: Sestor: Exiles 2"
 		conversation
 			`The Korath ships tail you to the planet's surface, but they do not fire on you. Instead, they hover above your ship for a long, indecisive moment. You hold your fire, and they eventually land in the sand next to you. Their airlocks open, and a few of them step out and approach your ship. They do not appear to be armed. Perhaps they have a cultural taboo against using weapons on this world.`
 			choice
@@ -3085,12 +3084,13 @@ mission "Wanderers: Sestor: Exiles 3"
 					goto end
 				`	"What are they asking for in return?"`
 			`	Rek says, "They request a meeting with our leaders, to work out terms of trade for our mutual benefit. It is something we would certainly agree to with no difficulty."`
-			action
-				log "Succeeded in communicating with the Korath exiles, by landing on the one habitable planet in their territory. (It seems like the exiles might have a taboo against using weapons on that world.) The exiles agreed to send some ships to help disable the remaining Kor Sestor factory."
-				event "wanderers: exiles peaceful"
 			label end
 			`	Rek speaks with the Korath again, and then tells you, "They say that three of their 'world-ships' will travel with us to meet with the Wanderer leaders. If they are able to work out favorable terms, and are convinced that the Wanderers have peaceful intentions, they will go with us to the Sestor factory world and shut it down."`
 				accept
+	on accept
+		log "Succeeded in communicating with the Korath exiles, by landing on the one habitable planet in their territory. (It seems like the exiles might have a taboo against using weapons on that world.) The exiles agreed to send some ships to help disable the remaining Kor Sestor factory."
+		fail "Wanderers: Sestor: Exiles 2"
+		event "wanderers: exiles peaceful"
 	npc accompany save
 		government "Korath"
 		personality escort


### PR DESCRIPTION
**Bugfix:** thx to sndeang51 for mentioning this on the discord

## Fix Details
You would be able to get peace with the exiles without it making any sense because you just left.
I made the event and log fire later, once you actually accept doing this, after talking with them - I didnt move the failing of the previous mission tho caus that one is about establishing contact which you kinda did? I can change that tho

## Testing Done
doesnt feel necessary

## Save File
simple fix so should be fine