### PR TITLE
fix(ci): run apt update before apt install

### DIFF
--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Test the binary
     - name: Install runtime dependencies
-      run: sudo apt-get install -y --no-install-recommends libosmesa6 mesa-utils
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libosmesa6 mesa-utils
     - name: Restore cached Steam Runtime environment
       id: cache-runtime
       uses: actions/cache@v3

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -42,7 +42,10 @@ jobs:
 
     # Test the binary
     - name: Install runtime dependencies
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libosmesa6 mesa-utils
+      run: |
+        sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libosmesa6 mesa-utils
     - name: Restore cached Steam Runtime environment
       id: cache-runtime
       uses: actions/cache@v3


### PR DESCRIPTION

**Bugfix:** This PR should address an issue in the CI: https://github.com/endless-sky/endless-sky/actions/runs/5769078872/job/15644655853

## Fix Details
Run apt-get update before apt-get install. This is the proper way of installing anyways, so even if it doesn't fix, it's a good change.

## Testing Done
/
