### PR TITLE
Mechanics: tweak how scrambling works with continuous weapons to prevent flickering

### DIFF
--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -249,9 +249,7 @@ void Armament::Fire(int index, Ship &ship, vector<Projectile> &projectiles, vect
 			it->second += it->first->Reload() * hardpoints[index].BurstRemaining();
 		}
 	}
-	if(jammed)
-		hardpoints[index].Jam();
-	else
+	if(!jammed || !hardpoints[index].Jam())
 		hardpoints[index].Fire(ship, projectiles, visuals);
 }
 

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -233,7 +233,7 @@ void Armament::Aim(const FireCommand &command)
 
 // Fire the given weapon, if it is ready. If it did not fire because it is
 // not ready, return false.
-void Armament::Fire(int index, Ship &ship, vector<Projectile> &projectiles, vector<Visual> &visuals, bool jammed)
+void Armament::Fire(int index, Ship &ship, vector<Projectile> &projectiles, vector<Visual> &visuals, int jammed)
 {
 	if(static_cast<unsigned>(index) >= hardpoints.size() || !hardpoints[index].IsReady())
 		return;
@@ -249,7 +249,7 @@ void Armament::Fire(int index, Ship &ship, vector<Projectile> &projectiles, vect
 			it->second += it->first->Reload() * hardpoints[index].BurstRemaining();
 		}
 	}
-	if(!jammed || !hardpoints[index].Jam())
+	if(!jammed || !hardpoints[index].Jam(jammed))
 		hardpoints[index].Fire(ship, projectiles, visuals);
 }
 

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -72,7 +72,7 @@ public:
 	void Aim(const FireCommand &command);
 	// Fire the given weapon, if it is ready. If it did not fire because it is
 	// not ready, return false.
-	void Fire(int index, Ship &ship, std::vector<Projectile> &projectiles, std::vector<Visual> &visuals, bool jammed);
+	void Fire(int index, Ship &ship, std::vector<Projectile> &projectiles, std::vector<Visual> &visuals, int jammed);
 	// Fire the given anti-missile system.
 	bool FireAntiMissile(int index, Ship &ship, const Projectile &projectile, std::vector<Visual> &visuals, bool jammed);
 

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -288,7 +288,7 @@ bool Hardpoint::FireAntiMissile(Ship &ship, const Projectile &projectile, vector
 
 
 // This weapon jammed. Increase its reload counters, but don't fire.
-bool Hardpoint::Jam()
+bool Hardpoint::Jam(int jam)
 {
 	if(jamImmunity)
 		return false;
@@ -298,10 +298,10 @@ bool Hardpoint::Jam()
 	// Reset the reload count.
 	reload += outfit->Reload();
 
-	// If this is a continuous weapon add half a second immunity to prevent flickering.
+	// If this is a continuous weapon disable it for some time and add immunity for that long again, to prevent flickering.
 	if(reload == 1)
 	{
-		reload = Random::Int(60);
+		reload = Random::Int(jam);
 		jamImmunity = reload * 2.;
 	}
 

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -301,8 +301,8 @@ bool Hardpoint::Jam()
 	// If this is a continuous weapon add half a second immunity to prevent flickering.
 	if(reload == 1)
 	{
-		reload += 30;
-		jamImmunity += 60;
+		reload = Random::Int(60);
+		jamImmunity = reload * 2.;
 	}
 
 	burstReload += outfit->BurstReload();

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -182,6 +182,8 @@ void Hardpoint::Step()
 		return;
 
 	wasFiring = isFiring;
+	if(jamImmunity > 0.)
+		--jamImmunity;
 	if(reload > 0.)
 		--reload;
 	// If the full reload time is elapsed, reset the burst counter.
@@ -286,14 +288,26 @@ bool Hardpoint::FireAntiMissile(Ship &ship, const Projectile &projectile, vector
 
 
 // This weapon jammed. Increase its reload counters, but don't fire.
-void Hardpoint::Jam()
+bool Hardpoint::Jam()
 {
+	if(jamImmunity)
+		return false;
 	// Since this is only called internally by Armament (no one else has non-
 	// const access), assume Armament checked that this is a valid call.
 
 	// Reset the reload count.
 	reload += outfit->Reload();
+
+	// If this is a continuous weapon add half a second immunity to prevent flickering.
+	if(reload == 1)
+	{
+		reload += 30;
+		jamImmunity += 60;
+	}
+
 	burstReload += outfit->BurstReload();
+
+	return true;
 }
 
 

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -75,7 +75,7 @@ public:
 	// Fire an anti-missile. Returns true if the missile should be killed.
 	bool FireAntiMissile(Ship &ship, const Projectile &projectile, std::vector<Visual> &visuals);
 	// This weapon jammed. Increase its reload counters, but don't fire.
-	void Jam();
+	bool Jam();
 
 	// Install a weapon here (assuming it is empty). This is only for
 	// Armament to call internally.
@@ -108,6 +108,7 @@ private:
 	// Angle adjustment for convergence.
 	Angle angle;
 	// Reload timers and other attributes.
+	double jamImmunity = 0.;
 	double reload = 0.;
 	double burstReload = 0.;
 	int burstCount = 0;

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -75,7 +75,7 @@ public:
 	// Fire an anti-missile. Returns true if the missile should be killed.
 	bool FireAntiMissile(Ship &ship, const Projectile &projectile, std::vector<Visual> &visuals);
 	// This weapon jammed. Increase its reload counters, but don't fire.
-	bool Jam();
+	bool Jam(int jam = 0);
 
 	// Install a weapon here (assuming it is empty). This is only for
 	// Armament to call internally.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1921,7 +1921,7 @@ bool Ship::Fire(vector<Projectile> &projectiles, vector<Visual> &visuals)
 			if(weapon->AntiMissile())
 				antiMissileRange = max(antiMissileRange, weapon->Velocity() + weaponRadius);
 			else if(firingCommands.HasFire(i))
-				armament.Fire(i, *this, projectiles, visuals, Random::Real() < jamChance);
+				armament.Fire(i, *this, projectiles, visuals, Random::Real() < jamChance ? jamChance * 100. : 0);
 		}
 	}
 


### PR DESCRIPTION
**Feature:**

## Feature Details
Jamming will now disable continuous weapons for a random amount of time up to the jamming chance. The weapon will then be  immune to further jamming for that same time.

This should prevent flickering, but I'm open to feedback as to how it should be changed.

## UI Screenshots
n/a

## Usage Examples
lasers will no longer flicker as much, hopefully

## Testing Done
it works as expected but mb it is too regular that way I need more thinking on this

### Automated Tests Added
n/a

## Performance Impact
n/a
