### PR TITLE
Update Robotic Musical to use Hai Tourism tag

### DIFF
--- a/data/hai/hai culture conversations.txt
+++ b/data/hai/hai culture conversations.txt
@@ -269,7 +269,7 @@ mission "Robotic Musical 1"
 	minor
 	source
 		government "Hai"
-		attributes "tourism"
+		attributes "hai tourism"
 		not attributes "station"
 	to offer
 		random < 1


### PR DESCRIPTION
From sergekoriakin on the Steam forums, this PR updates the Robotic Musical culture conversation to use the `hai tourism` tag rather than just the `tourism` tag, which does not exist in Hai space.