### PR TITLE
Fix a crash when spawning a defense fleet with no government

### DIFF
--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -111,6 +111,9 @@ bool Politics::IsEnemy(const Government *first, const Government *second) const
 // reputation.
 void Politics::Offend(const Government *gov, int eventType, int count)
 {
+	if(!gov)
+		return;
+
 	if(gov->IsPlayer())
 		return;
 

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -77,6 +77,9 @@ void Politics::Reset()
 
 bool Politics::IsEnemy(const Government *first, const Government *second) const
 {
+	if(!first || !second)
+		return false;
+
 	if(first == second)
 		return false;
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #9135

## Fix Details
`Politics::IsEnemy` now returns false if either government pointer is null and doesn't dereference either.
This essentially means no ship or planet can be hostile to a ship without a government.

## Testing Done
Carry out the reproduction steps from the linked issue.
