### PR TITLE
two small spelling mistakes

### DIFF
--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -645,5 +645,5 @@ void Test::Fail(const TestContext &context, const PlayerInfo &player, const stri
 void Test::UnexpectedSuccessResult() const
 {
 	throw runtime_error("Unexpected test result: Test marked with status '" + StatusText()
-		+ "' was not expected to finish succesfully.\n");
+		+ "' was not expected to finish successfully.\n");
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
 	}
 	catch(Test::known_failure_tag)
 	{
-		// This is not an error. Simply exit succesfully.
+		// This is not an error. Simply exit successfully.
 	}
 	catch(const runtime_error &error)
 	{


### PR DESCRIPTION
**Bugfix:** This PR addresses small spelling mistakes in the source code

## Fix Details
Replace occurrences of 'succesfully' with 'successfully'. The second one is in a comment, but is still an easy fix.

## Testing Done
The result builds successfully.