### PR TITLE
fix troff errors in endless-sky.6

### DIFF
--- a/endless-sky.6
+++ b/endless-sky.6
@@ -81,9 +81,9 @@ prints a table of outfits and all attributes used by any outfits present.
 .IP \fB\-\-sales
 prints (to STDOUT) a list of all shipyards and outfitters and the ships and outfits they each contain.
 .RS
-.IP \fB\-\s,\ \-\-ships
+.IP \fB\-s,\ \-\-ships
 prints a list of shipyards and the ships they each contain.
-.IP \fB\-\o,\ \-\-outfits
+.IP \fB\-o,\ \-\-outfits
 pritns a list of outfitters and the outfits they each contain.
 .RE
 


### PR DESCRIPTION
**Bugfix:** This PR addresses a warning from troff:
```
troff:<standard input>:84: warning: expected numeric expression, got an escaped ' '
```

## Fix Details
Remove the escaping backslash from the letters to turn them back to ordinary text and not special sequences.

## Testing Done
There are no more warnings from troff after the fix.