### PR TITLE
fix(mechanics): Correctly pick flagship when landed on clearance planet

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1506,13 +1506,14 @@ void PlayerInfo::Land(UI *ui)
 
 	// Ships that are landed with you on the planet should fully recharge.
 	// Those in remote systems restore what they can without landing.
-	bool hasSpaceport = planet->HasSpaceport() && planet->CanUseServices();
+	bool clearance = HasClearance(*this, planet);
+	bool hasSpaceport = planet->HasSpaceport() && (clearance || planet->CanUseServices());
 	for(const shared_ptr<Ship> &ship : ships)
 		if(!ship->IsParked() && !ship->IsDisabled())
 		{
 			if(ship->GetSystem() == system)
 			{
-				if(planet->CanLand(*ship))
+				if(planet->CanLand(*ship) || (clearance && planet->IsAccessible(ship.get())))
 				{
 					ship->Recharge(hasSpaceport);
 					if(!ship->GetPlanet())

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -992,9 +992,11 @@ const shared_ptr<Ship> &PlayerInfo::FlagshipPtr()
 	if(planet)
 	{
 		for(const Mission &mission : missions)
-		{
-			clearance |= mission.HasClearance(planet);
-		}
+			if(mission.HasClearance(planet))
+			{
+				clearance = true;
+				break;
+			}
 	}
 	if(!flagship)
 		for(const shared_ptr<Ship> &it : ships)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1001,14 +1001,7 @@ const shared_ptr<Ship> &PlayerInfo::FlagshipPtr()
 	{
 		bool clearance = false;
 		if(planet)
-		{
-			for(const Mission &mission : missions)
-				if(mission.HasClearance(planet))
-				{
-					clearance = true;
-					break;
-				}
-		}
+			clearance = planet->CanLand() || HasClearance(*this, planet);
 		for(const shared_ptr<Ship> &it : ships)
 			if(!it->IsParked() && it->GetSystem() == system && it->CanBeFlagship()
 				&& (!planet || clearance || planet->CanLand(*it)))

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -988,24 +988,26 @@ Ship *PlayerInfo::Flagship()
 // Determine which ship is the flagship and return the shared pointer to it.
 const shared_ptr<Ship> &PlayerInfo::FlagshipPtr()
 {
-	bool clearance = false;
-	if(planet)
-	{
-		for(const Mission &mission : missions)
-			if(mission.HasClearance(planet))
-			{
-				clearance = true;
-				break;
-			}
-	}
 	if(!flagship)
+	{
+		bool clearance = false;
+		if(planet)
+		{
+			for(const Mission &mission : missions)
+				if(mission.HasClearance(planet))
+				{
+					clearance = true;
+					break;
+				}
+		}
 		for(const shared_ptr<Ship> &it : ships)
 			if(!it->IsParked() && it->GetSystem() == system && it->CanBeFlagship()
-					&& (!planet || clearance || planet->CanLand(*it)))
+			   && (!planet || clearance || planet->CanLand(*it)))
 			{
 				flagship = it;
 				break;
 			}
+	}
 
 	static const shared_ptr<Ship> empty;
 	return (flagship && flagship->IsYours()) ? flagship : empty;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -988,10 +988,18 @@ Ship *PlayerInfo::Flagship()
 // Determine which ship is the flagship and return the shared pointer to it.
 const shared_ptr<Ship> &PlayerInfo::FlagshipPtr()
 {
+	bool clearance = false;
+	if(planet)
+	{
+		for(const Mission &mission : missions)
+		{
+			clearance |= mission.HasClearance(planet);
+		}
+	}
 	if(!flagship)
 		for(const shared_ptr<Ship> &it : ships)
 			if(!it->IsParked() && it->GetSystem() == system && it->CanBeFlagship()
-					&& (!planet || planet->CanLand(*it)))
+					&& (!planet || clearance || planet->CanLand(*it)))
 			{
 				flagship = it;
 				break;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1513,7 +1513,8 @@ void PlayerInfo::Land(UI *ui)
 		{
 			if(ship->GetSystem() == system)
 			{
-				if(planet->CanLand(*ship) || (clearance && planet->IsAccessible(ship.get())))
+				const bool alreadyLanded = ship->GetPlanet() == planet;
+				if(alreadyLanded || planet->CanLand(*ship) || (clearance && planet->IsAccessible(ship.get())))
 				{
 					ship->Recharge(hasSpaceport);
 					if(!ship->GetPlanet())

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1002,7 +1002,7 @@ const shared_ptr<Ship> &PlayerInfo::FlagshipPtr()
 		}
 		for(const shared_ptr<Ship> &it : ships)
 			if(!it->IsParked() && it->GetSystem() == system && it->CanBeFlagship()
-			   && (!planet || clearance || planet->CanLand(*it)))
+				&& (!planet || clearance || planet->CanLand(*it)))
 			{
 				flagship = it;
 				break;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -104,6 +104,15 @@ namespace {
 			return SystemEntry::WORMHOLE;
 		return SystemEntry::TAKE_OFF;
 	}
+
+	bool HasClearance(const PlayerInfo &player, const Planet *planet)
+	{
+		auto CheckClearance = [&planet](const Mission &mission) -> bool
+		{
+			return mission.HasClearance(planet);
+		};
+		return any_of(player.Missions().begin(), player.Missions().end(), CheckClearance);
+	}
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1003,12 +1003,20 @@ const shared_ptr<Ship> &PlayerInfo::FlagshipPtr()
 		if(planet)
 			clearance = planet->CanLand() || HasClearance(*this, planet);
 		for(const shared_ptr<Ship> &it : ships)
-			if(!it->IsParked() && it->GetSystem() == system && it->CanBeFlagship()
-				&& (!planet || clearance || planet->CanLand(*it)))
+		{
+			if(it->IsParked())
+				continue;
+			if(it->GetSystem() != system)
+				continue;
+			if(!it->CanBeFlagship())
+				continue;
+			const bool sameLocation = !planet || it->GetPlanet() == planet;
+			if(sameLocation || (clearance && !it->GetPlanet() && planet->IsAccessible(it.get())))
 			{
 				flagship = it;
 				break;
 			}
+		}
 	}
 
 	static const shared_ptr<Ship> empty;


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #9144

## Fix Details
In `PlayerInfo::FlagshipPtr()`, add a check as to whether any mission gives clearance to the current planet, and make that an allowable condition for setting the flagship. This ensures that even when on a planet for which `Planet::CanLand()` returns false, if the player got there through a mission that allows clearance, they will still be able to depart.

Note that there is still a potential concern here: If the player landed normally, with positive reputation, but some mission/event on the planet caused their reputation with the planet's government to become negative, they might be trapped.

## Testing Done
Loaded a save file exhibiting the bug; observed that it no longer occurred.
Took off and landed a few times to ensure that other related mechanics 

## Save File
This save file can be used to verify the bugfix. The bug will occur when using commit 8d3c807094f117069e6881f52d9979d4cfe8cf33, and will not occur when using this branch's build.
[Hannah Derinden.txt](https://github.com/endless-sky/endless-sky/files/12292930/Hannah.Derinden.txt)
(Note that while the save does have a small amount of plugin content from some WIP testing I was doing, it does not have any plugin dependencies, nor would any of that content affect this issue one way or another.)
