### PR TITLE
fix(bug): check for exact turn prior to jumping

### DIFF
--- a/source/Angle.cpp
+++ b/source/Angle.cpp
@@ -23,6 +23,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <cstdlib>
 #include <vector>
 
+using namespace std;
+
 namespace {
 	// Suppose you want to be able to turn 360 degrees in one second. Then you are
 	// turning 6 degrees per time step. If the Angle lookup is 2^16 steps, then 6
@@ -118,11 +120,25 @@ Angle Angle::operator-() const
 
 
 
+bool Angle::operator==(const Angle &other) const
+{
+	return angle == other.angle;
+}
+
+
+
+bool Angle::operator!=(const Angle &other) const
+{
+	return angle != other.angle;
+}
+
+
+
 // Get a unit vector in the direction of this angle.
 Point Angle::Unit() const
 {
 	// The very first time this is called, create a lookup table of unit vectors.
-	static std::vector<Point> cache;
+	static vector<Point> cache;
 	if(cache.empty())
 	{
 		cache.reserve(STEPS);

--- a/source/Angle.h
+++ b/source/Angle.h
@@ -49,6 +49,9 @@ public:
 	Angle &operator-=(const Angle &other);
 	Angle operator-() const;
 
+	bool operator==(const Angle &other) const;
+	bool operator!=(const Angle &other) const;
+
 	// Get a unit vector in the direction of this angle.
 	Point Unit() const;
 	// Convert an Angle object to degrees, in the range -180 to 180.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2124,7 +2124,7 @@ bool Ship::IsReadyToJump(bool waitingIsReady) const
 	// and pointed in the right direction.
 	if(!isJump && scramThreshold)
 	{
-		double deviation = fabs(direction.Unit().Cross(velocity));
+		const double deviation = fabs(direction.Unit().Cross(velocity));
 		if(deviation > scramThreshold)
 			return false;
 	}
@@ -2134,11 +2134,11 @@ bool Ship::IsReadyToJump(bool waitingIsReady) const
 	if(!isJump)
 	{
 		// Figure out if we're within one turn step of facing this system.
-		bool left = direction.Cross(angle.Unit()) < 0.;
-		Angle turned = angle + TurnRate() * (left - !left);
-		bool stillLeft = direction.Cross(turned.Unit()) < 0.;
+		const bool left = direction.Cross(angle.Unit()) < 0.;
+		const Angle turned = angle + TurnRate() * (left - !left);
+		const bool stillLeft = direction.Cross(turned.Unit()) < 0.;
 
-		if(left == stillLeft)
+		if(left == stillLeft && turned != Angle(direction))
 			return false;
 	}
 


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #9136

## Fix Details
When testing to see if a ship is ready to jump, explicitly check for an exact turn (that is, one step of turning will align the ship in exactly the right direction).  In some instances, the default logic could fail because of rounding errors introduced by converting to/from Angle.

## Testing Done
Ran 100 ships over 24 jumps twice.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 4174fff, and will not occur when using this branch's build.

[Asteroid Miner~Arculus.txt](https://github.com/endless-sky/endless-sky/files/12294232/Asteroid.Miner.Arculus.txt)

## Alternate Approach
<strike>AI::TurnToward could be modified so that this case wouldn't come up.</strike>  Actually, I think this case can always come up, and modifying AI::TurnToward would at best just make it rarer.

## Gritty Details
Ship::IsReadyToJump checks (for non-jump drives) to see if the ship is within one step-turn of facing the correct direction (the vector from the current system to the remote system).  It does this by seeing if the ship's current facing is left/right of the desired direction, and then seeing if one step of turning will switch that.  However, since angles are quantized, it's possible for one step of turning to reach the desired angle and _still_ be to the same left/right side of the directional vector, so this also checks to see if the angle after turning is the same as the quantized angle of the desired direction.