### PR TITLE
feat(ui): change mission list accepting advance to be more intuitive

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -968,10 +968,12 @@ void MissionPanel::Accept(bool force)
 
 	++availableIt;
 	player.AcceptJob(toAccept, GetUI());
-	if(availableIt == available.end() && !available.empty())
-		--availableIt;
 
 	cycleInvolvedIndex = 0;
+	if(available.empty())
+		return;
+	if(availableIt == available.end())
+		--availableIt;
 
 	// Check if any other jobs are available with the same destination. Prefer
 	// jobs that also have the same destination planet.

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -971,22 +971,48 @@ void MissionPanel::Accept(bool force)
 	if(availableIt == available.end() && !available.empty())
 		--availableIt;
 
+	cycleInvolvedIndex = 0;
+
 	// Check if any other jobs are available with the same destination. Prefer
 	// jobs that also have the same destination planet.
 	if(toAccept.Destination())
 	{
+		const list<Mission>::const_iterator startHere = availableIt;
 		const Planet *planet = toAccept.Destination();
 		const System *system = planet->GetSystem();
-		for(auto it = available.begin(); it != available.end(); ++it)
+		bool stillLooking = true;
+		for(auto it = startHere; it != available.end(); ++it)
 			if(it->Destination() && it->Destination()->IsInSystem(system))
 			{
-				availableIt = it;
 				if(it->Destination() == planet)
-					break;
+				{
+					availableIt = it;
+					return;
+				}
+				else if(stillLooking)
+				{
+					stillLooking = false;
+					availableIt = it;
+				}
 			}
+		for(auto it = startHere; it != available.begin(); )
+		{
+			--it;
+			if(it->Destination() && it->Destination()->IsInSystem(system))
+			{
+				if(it->Destination() == planet)
+				{
+					availableIt = it;
+					return;
+				}
+				else if(stillLooking)
+				{
+					stillLooking = false;
+					availableIt = it;
+				}
+			}
+		}
 	}
-
-	cycleInvolvedIndex = 0;
 }
 
 


### PR DESCRIPTION
**Feature:**

## Feature Details
When accepting a mission on the MissionPanel, when there are >2 available missions in the same system, try to advance forward in the list from the current position.  If there's no mission at the same system forward, then look backwards from the current position.  The old behavior is to reset to the first one available at that system.

This makes it easier to accept multiple missions to the same system while avoiding the first mission to the system, for example if the first mission is a Scout mission following by three Marauder missions.  In the original, after selecting each Marauder mission the selection would reset to the Scout, requiring moving the selection.  With the new code, if you selected the a Marauder mission, after each accept it would advance to the next one.

It's a little more complex when there are missions to different planets in the same system.  If the other missions are all at other planets, the old code would advance to the last of those missions.  The new code will advance to the first of those missions.

## Testing Done
Accepted missions in various positions, with various numbers at the system.

## Save File
[Karla Hoffman~three missions.txt](https://github.com/endless-sky/endless-sky/files/12329848/Karla.Hoffman.three.missions.txt)
It's hard sometimes to find >2 missions given to the same system.

## Performance Impact
N/A

## Additional Notes
The code would be much simpler if I didn't keep the previous behavior of preferring missions at the same planet.