### PR TITLE
feat(code): move angle unit cache creation to local storage

### DIFF
--- a/source/Angle.cpp
+++ b/source/Angle.cpp
@@ -23,6 +23,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <cstdlib>
 #include <vector>
 
+using namespace std;
+
 namespace {
 	// Suppose you want to be able to turn 360 degrees in one second. Then you are
 	// turning 6 degrees per time step. If the Angle lookup is 2^16 steps, then 6
@@ -32,6 +34,24 @@ namespace {
 	const int32_t MASK = STEPS - 1;
 	const double DEG_TO_STEP = STEPS / 360.;
 	const double STEP_TO_RAD = PI / (STEPS / 2);
+
+	vector<Point> InitUnitCache()
+	{
+		vector<Point> cache;
+		cache.reserve(STEPS);
+		for(int i = 0; i < STEPS; ++i)
+		{
+			const double radians = i * STEP_TO_RAD;
+			// The graphics use the usual screen coordinate system, meaning that
+			// positive Y is down rather than up. Angles are clock angles, i.e.
+			// 0 is 12:00 and angles increase in the clockwise direction. So, an
+			// angle of 0 degrees is pointing in the direction (0, -1).
+			cache.emplace_back(sin(radians), -cos(radians));
+		}
+		return cache;
+	}
+
+	vector<Point> unitCache = InitUnitCache();
 }
 
 
@@ -121,22 +141,7 @@ Angle Angle::operator-() const
 // Get a unit vector in the direction of this angle.
 Point Angle::Unit() const
 {
-	// The very first time this is called, create a lookup table of unit vectors.
-	static std::vector<Point> cache;
-	if(cache.empty())
-	{
-		cache.reserve(STEPS);
-		for(int i = 0; i < STEPS; ++i)
-		{
-			double radians = i * STEP_TO_RAD;
-			// The graphics use the usual screen coordinate system, meaning that
-			// positive Y is down rather than up. Angles are clock angles, i.e.
-			// 0 is 12:00 and angles increase in the clockwise direction. So, an
-			// angle of 0 degrees is pointing in the direction (0, -1).
-			cache.emplace_back(sin(radians), -cos(radians));
-		}
-	}
-	return cache[angle];
+	return unitCache[angle];
 }
 
 

--- a/source/Angle.cpp
+++ b/source/Angle.cpp
@@ -30,10 +30,10 @@ namespace {
 	// turning 6 degrees per time step. If the Angle lookup is 2^16 steps, then 6
 	// degrees is 1092 steps, and your turn speed is accurate to +- 0.05%. That seems
 	// plenty accurate to me. At that step size, the lookup table is exactly 1 MB.
-	const int32_t STEPS = 0x10000;
-	const int32_t MASK = STEPS - 1;
-	const double DEG_TO_STEP = STEPS / 360.;
-	const double STEP_TO_RAD = PI / (STEPS / 2);
+	constexpr int32_t STEPS = 0x10000;
+	constexpr int32_t MASK = STEPS - 1;
+	constexpr double DEG_TO_STEP = STEPS / 360.;
+	constexpr double STEP_TO_RAD = PI / (STEPS / 2);
 
 	vector<Point> InitUnitCache()
 	{
@@ -51,7 +51,7 @@ namespace {
 		return cache;
 	}
 
-	vector<Point> unitCache = InitUnitCache();
+	const vector<Point> unitCache = InitUnitCache();
 }
 
 
@@ -65,18 +65,18 @@ Angle Angle::Random()
 
 
 // Get a random angle between 0 and the given number of degrees.
-Angle Angle::Random(double range)
+Angle Angle::Random(const double range)
 {
 	// The given range would have to be about 22.6 million degrees to overflow
 	// the size of a 32-bit int, which should never happen in normal usage.
-	uint32_t mod = static_cast<uint32_t>(fabs(range) * DEG_TO_STEP) + 1;
+	const uint32_t mod = static_cast<uint32_t>(fabs(range) * DEG_TO_STEP) + 1;
 	return Angle(mod ? static_cast<int32_t>(Random::Int(mod)) & MASK : 0);
 }
 
 
 
 // Construct an Angle from the given angle in degrees.
-Angle::Angle(double degrees) noexcept
+Angle::Angle(const double degrees) noexcept
 	: angle(llround(degrees * DEG_TO_STEP) & MASK)
 {
 	// Make sure llround does not overflow with the values of System::SetDate.
@@ -162,7 +162,7 @@ Point Angle::Rotate(const Point &point) const
 {
 	// If using the normal mathematical coordinate system, this would be easier.
 	// Since we're not, the math is a tiny bit less elegant:
-	Point unit = Unit();
+	const Point unit = Unit();
 	return Point(-unit.Y() * point.X() - unit.X() * point.Y(),
 		-unit.Y() * point.Y() + unit.X() * point.X());
 }
@@ -170,7 +170,7 @@ Point Angle::Rotate(const Point &point) const
 
 
 // Constructor using Angle's internal representation.
-Angle::Angle(int32_t angle)
+Angle::Angle(const int32_t angle)
 	: angle(angle)
 {
 }

--- a/source/pi.h
+++ b/source/pi.h
@@ -19,9 +19,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 
 // Constants to replace M_PI (which is not available on all operating systems).
-const double PI = 3.14159265358979323846;
-const double TO_RAD = PI / 180.;
-const double TO_DEG = 180. / PI;
+constexpr double PI = 3.14159265358979323846;
+constexpr double TO_RAD = PI / 180.;
+constexpr double TO_DEG = 180. / PI;
 
 
 


### PR DESCRIPTION
**Feature:**

## Feature Details
Angle::Unit no longer checks to see if it needs to create its static cache each call.  Instead, the cache is created when the program starts.

I also added const/constexpr as appropriate throughout Angle (which required also hitting pi.h).

## Testing Done
Flew ships around.  Angle::Unit gets a lot of use.

## Performance Impact
Should be a _very_ small improvement when flying, with cache creation time moved to startup instead of showing up whenever.