### PR TITLE
Content: add the solifuge to Unfettered shipyards when deployed during the wanderer campaign

### DIFF
--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -1553,7 +1553,7 @@ ship "Solifuge"
 	attributes
 		category "Heavy Warship"
 		licenses
-			"True Unfettered"
+			"Unfettered Militia"
 		"cost" 22800000
 		"shields" 37800
 		"hull" 11000

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -1553,7 +1553,7 @@ ship "Solifuge"
 	attributes
 		category "Heavy Warship"
 		licenses
-			"Unfettered Militia"
+			"True Unfettered License"
 		"cost" 22800000
 		"shields" 37800
 		"hull" 11000

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -1553,7 +1553,7 @@ ship "Solifuge"
 	attributes
 		category "Heavy Warship"
 		licenses
-			"True Unfettered License"
+			"True Unfettered"
 		"cost" 22800000
 		"shields" 37800
 		"hull" 11000

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2408,6 +2408,8 @@ mission "Wanderers Defend Sich'ka'ara"
 # Compatibility patch for users who completed "Wanderers Defend Sich'ka'ara"
 # before 0.10.3 when the "solifuge deployment" event was added.
 mission "Solifuge Shipyards Patch"
+	landing
+	invisible
 	to offer
 		has "event: battle for sich'ka'ara ends"
 		not "event: solifuge deployment"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2405,7 +2405,8 @@ mission "Wanderers Defend Sich'ka'ara"
 		conversation
 			`The Unfettered fleet has been driven off. Tele'ek thanks you for taking part in defending this world. "Unfortunately," he says, "I just received news that this was only half of the Unfettered [assault, attack]. An equally large fleet attacked the Chirr'ay'akai system, and overwhelmed the defenses there so [quickly, unexpectedly] that some of our people did not have time to [escape, evacuate] and have been forced into hiding. If you're willing to help rescue them, please meet me in the spaceport once I am done [debriefing, informing] the warriors."`
 
-# 0.10.2 Compatibility patch
+# Compatibility patch for users who completed "Wanderers Defend Sich'ka'ara"
+# before 0.10.3 when the "solifuge deployment" event was added.
 mission "Solifuge Shipyards Patch"
 	to offer
 		has "event: battle for sich'ka'ara ends"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2401,8 +2401,18 @@ mission "Wanderers Defend Sich'ka'ara"
 	on complete
 		log "Helped to defend a Wanderer world from yet another Unfettered attack. Meanwhile, the Wanderers are trying to move as many civilians as possible back to their home world, where they will be safe. But, their strategy seems to be based on the hope that sometime soon a wormhole will open and allow the Wanderer people to flee to a new territory and leave their old planets behind for the Unfettered to claim."
 		event "battle for sich'ka'ara ends"
+		event "solifuge deployment"
 		conversation
 			`The Unfettered fleet has been driven off. Tele'ek thanks you for taking part in defending this world. "Unfortunately," he says, "I just received news that this was only half of the Unfettered [assault, attack]. An equally large fleet attacked the Chirr'ay'akai system, and overwhelmed the defenses there so [quickly, unexpectedly] that some of our people did not have time to [escape, evacuate] and have been forced into hiding. If you're willing to help rescue them, please meet me in the spaceport once I am done [debriefing, informing] the warriors."`
+
+# 0.10.2 Compatibility patch
+mission "Solifuge Shipyards Patch"
+	to offer
+		has "event: battle for sich'ka'ara ends"
+		not "event: solifuge deployment"
+	on offer
+		event "solifuge deployment"
+		fail
 
 event "battle for sich'ka'ara ends"
 	system "Sich'ka'ara"
@@ -2422,6 +2432,8 @@ event "battle for sich'ka'ara ends"
 	planet "Kort Vek'kri"
 		attributes "unfettered"
 		spaceport `The Unfettered clearly do not know quite what to make of the Wanderer research station here that they have recently captured. Animals that were once part of various experiments are now wandering loose, and the Unfettered are making only sporadic efforts to keep them well-fed. Every once in a while one of them, driven by sheer hunger, tries to smash its way into one of the crates of military rations that the Unfettered have stacked up in the shade near the main landing pad.`
+	
+event "solifuge deployment"
 	shipyard "Mon Ki o'Uden Advanced"
 		add "Solifuge"
 		add "Violin Spider"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2422,6 +2422,9 @@ event "battle for sich'ka'ara ends"
 	planet "Kort Vek'kri"
 		attributes "unfettered"
 		spaceport `The Unfettered clearly do not know quite what to make of the Wanderer research station here that they have recently captured. Animals that were once part of various experiments are now wandering loose, and the Unfettered are making only sporadic efforts to keep them well-fed. Every once in a while one of them, driven by sheer hunger, tries to smash its way into one of the crates of military rations that the Unfettered have stacked up in the shade near the main landing pad.`
+	shipyard "Mon Ki o'Uden Advanced"
+		add "Solifuge"
+		add "Violin Spider"
 	fleet "Large Unfettered"
 		add variant 3
 			"Solifuge"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Change the license to match the one from the Unfettered campaign and add the new Unfettered ships to the Unfettered shipyards on Darkcloak.
This also splits the relevant event in two parts with the Solifuge part being renamed to "solifuge deployment" for easier finding and savefile clarity.

## Save File
n/a