### PR TITLE
fix(bug), feat(code cleanup): simplify scaling turns; fix error in scaling thrust

### DIFF
--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -355,6 +355,14 @@ void Command::SetTurn(double amount)
 
 
 
+// Scale the existing turn by a fraction between 0 and 1.
+void Command::ScaleTurn(const double scale)
+{
+	turn *= max(0., min(1., scale));
+}
+
+
+
 // Get the turn amount.
 double Command::Turn() const
 {

--- a/source/Command.h
+++ b/source/Command.h
@@ -121,9 +121,11 @@ public:
 	// Get the commands that are set in this and not in the given command.
 	Command AndNot(Command command) const;
 
-	// Get or set the turn amount. The amount must be between -1 and 1, but it
-	// can be a fractional value to allow finer control.
+	// Get, set, or scale the turn amount. The amount must be between -1 and 1,
+	// but it can be a fractional value to allow finer control.  The scale should
+	// be between 0 and 1.
 	void SetTurn(double amount);
+	void ScaleTurn(double scale);
 	double Turn() const;
 
 	// Check if any bits are set in this command (including a nonzero turn).

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4149,23 +4149,23 @@ void Ship::DoMovement(bool &isUsingAfterburner)
 			// Check if we are able to turn.
 			double cost = attributes.Get("turning energy");
 			if(cost > 0. && energy < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * energy / (cost * fabs(commands.Turn())));
+				commands.ScaleTurn(energy / cost);
 
 			cost = attributes.Get("turning shields");
 			if(cost > 0. && shields < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * shields / (cost * fabs(commands.Turn())));
+				commands.ScaleTurn(shields / cost);
 
 			cost = attributes.Get("turning hull");
 			if(cost > 0. && hull < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * hull / (cost * fabs(commands.Turn())));
+				commands.ScaleTurn(hull / cost);
 
 			cost = attributes.Get("turning fuel");
 			if(cost > 0. && fuel < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * fuel / (cost * fabs(commands.Turn())));
+				commands.ScaleTurn(fuel / cost);
 
 			cost = -attributes.Get("turning heat");
 			if(cost > 0. && heat < cost * fabs(commands.Turn()))
-				commands.SetTurn(commands.Turn() * heat / (cost * fabs(commands.Turn())));
+				commands.ScaleTurn(heat / cost);
 
 			if(commands.Turn())
 			{
@@ -4200,27 +4200,27 @@ void Ship::DoMovement(bool &isUsingAfterburner)
 			// Check if we are able to apply this thrust.
 			double cost = attributes.Get((thrustCommand > 0.) ?
 				"thrusting energy" : "reverse thrusting energy");
-			if(cost > 0. && energy < cost)
+			if(cost > 0. && energy < cost * fabs(thrustCommand))
 				thrustCommand *= energy / cost;
 
 			cost = attributes.Get((thrustCommand > 0.) ?
 				"thrusting shields" : "reverse thrusting shields");
-			if(cost > 0. && shields < cost)
+			if(cost > 0. && shields < cost * fabs(thrustCommand))
 				thrustCommand *= shields / cost;
 
 			cost = attributes.Get((thrustCommand > 0.) ?
 				"thrusting hull" : "reverse thrusting hull");
-			if(cost > 0. && hull < cost)
+			if(cost > 0. && hull < cost * fabs(thrustCommand))
 				thrustCommand *= hull / cost;
 
 			cost = attributes.Get((thrustCommand > 0.) ?
 				"thrusting fuel" : "reverse thrusting fuel");
-			if(cost > 0. && fuel < cost)
+			if(cost > 0. && fuel < cost * fabs(thrustCommand))
 				thrustCommand *= fuel / cost;
 
 			cost = -attributes.Get((thrustCommand > 0.) ?
 				"thrusting heat" : "reverse thrusting heat");
-			if(cost > 0. && heat < cost)
+			if(cost > 0. && heat < cost * fabs(thrustCommand))
 				thrustCommand *= heat / cost;
 
 			if(thrustCommand)


### PR DESCRIPTION
**Bugfix:**

## Bug Details
If multiple elements cause thrust to be reduced (such as lack of energy, fuel, heat, etc.) each reduces it fully.  For example, having 1/2 the required energy and 1/2 the required fuel will reduce thrust to 1/4, not to 1/2.

## Fix Details
Take into account prior reductions in thrust when checking to see if further reduction is necessary.  This brings the code into alignment with reducing turns.

## Testing Done
Not much, other than check to make sure the basics still worked.  I'm not sure the problem ever arose in practice.

**Feature:**

## Feature Details
The turn scaling code uses Turn/fabs(Turn) to keep the current sign of the turn.  Command::ScaleTurn will simply scale the turn without having to worry about the sign of the turn.

## Testing Done
Much the same as above.

## Performance Impact
N/A.

## Additional Notes
If you look at the code, you'll see why these are bundled - the resulting code in both places is now very similar.