### PR TITLE
feat(balance): Reduce Supercapacitor price from 12 per energy down to 2 per energy to be more inline with other batteries that are in the 1.7 to 1.5 per energy range.

### DIFF
--- a/data/human/power.txt
+++ b/data/human/power.txt
@@ -13,7 +13,7 @@
 
 outfit "Supercapacitor"
 	category "Power"
-	cost 9000
+	cost 1500
 	thumbnail "outfit/supercapacitor"
 	"mass" 2
 	"outfit space" -2


### PR DESCRIPTION
**Balance:**

## Summary
Reduced the cost of the supercapacitor from 9000 to 1500

## Reasoning
LP576a Battery Pack: 1.74 per unit of energy, 575/ton
LP288a Battery Pack: 1.73 per unit of energy, 520/ton
LP144a Battery Pack: 1.66 per unit of energy, 480/ton
LP072a Battery Pack: 1.59 per unit of energy, 440/ton
LP036a Battery Pack: 1.50 per unit of energy, 400/ton
Supercapacitor: 12.00 per unit of energy, 375/ton

As one proceeds from the biggest human battery down to the smallest battery, each step becomes both less dense and less expensive. Starting at 1.739 credits per unit of energy and a density of 575/ton, and decreasing down to the smallest battery at 1.50 credits per unit of energy and a density of 400/ton. Then we get the Supercapacitor, that has less density than even the smallest and least dense of the batteries, and yet is priced at 12.00 credits per unit of energy. Beyond that, in terms of final price, the supercapacitor is 1.5x *higher* than the LP036a battery. Even if one assumes that it's absolutely small size and ability to be tucked into smaller spaces is a noteworthy advantage, it's performance really doesn't merit such a massive increase in price.

As such, this PR reduces its price down to 1500, which is 2.00 credits per energy capacity. I picked this because it thus still retains a bit of a "convenience premium" for being so small, while also allowing it to be used as a way to skimp for people (such as new pilots) who really want to live close to the line and downgrade their energy as far as possible to pay off as much as they can right off the start.

## Impact

Two main impacts: 

This makes supercapacitors actually useful for people who want to swap out their LP036a for something smaller to save some money, which makes them actually useful for something other than just being smaller.

The biggest impact is in regards to fighter affordability. The Lance cost 357900 to purchase. Of that cost, 36000 is for the supercapacitors alone. Reducing the supercapacitor price down to 1500 correspondingly drops the price of the Lance to 327900. This is a 9% reduction in shipyard purchase price. It isn't going to make or break buying the Lance by itself, but it definitely makes it a little less painful to buy and lose.

## Alternate
If one wanted to actually follow the battery progression, then the supercapacitor should actually be reduced down to something closer to 1050, which would be 1.40 credits per energy; or perhaps 1100 which would be 1.46 credits per energy. Both are acceptable to me, depending on how much value "cram 750 energy into a random 2 ton space someone has left over" actually is. I'd argue that it isn't particularly valuable, personally, and would even prefer these lower values; however I went with the higher 2.00 per energy and a 1500 price tag in order to err on the conservative side and not risk dropping it too far.

As such, I'd consider the price in this PR to be a reasonable one, but if people think that 750 energy really isn't that valuable or useful, I'd be happy to drop it down to 1000 (1.33 credits per energy) or either of the other values listed above. Realistically, changes to the price at this point really only affect fighter purchases or brand new pilots, so lower is better but there's very limited gains to be had by going much lower.