### PR TITLE
Add `forest` attribute to Stormhold and change its planet sprite

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -4128,7 +4128,7 @@ planet Stonebreak
 	security 0.3
 
 planet Stormhold
-	attributes core "core pirate" frontier pirate
+	attributes core "core pirate" forest frontier pirate
 	landscape land/fog11
 	description `A cold planet, with dense, foggy atmosphere. As with many pirate outposts, Stormhold is home to an unknown number of villages and hidden outposts, each controlled by a different pirate faction. It is also said that some of the most dangerous fugitives in the galaxy live deep in the forests of this planet, escaping detection by living underground or by avoiding the use of electronic devices.`
 	spaceport `The spaceport is a large town, with a population of roughly thirty thousand. People of all races and cultures mingle freely, while keeping a wary eye open for off-worlders who may be Republic agents in disguise.`

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -3263,7 +3263,7 @@ system Alcyone
 		distance 58.7886
 		period 26.2809
 	object Stormhold
-		sprite planet/ocean0
+		sprite planet/cloud1
 		distance 332.91
 		period 141.461
 	object


### PR DESCRIPTION
## Summary
Stormhold didn't get the `forest` attribute added to it when I PR'd the expansion of that attribute to other planets. It's clearly a forest planet...

I've actually known this for a long time but never changed it until now, hahaha