### PR TITLE
Fix Face to Maw 1 and 1B offering

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -2812,7 +2812,6 @@ mission "Remnant: remnant research update compatibility"
 
 
 mission "Remnant: Face to Maw 1"
-	minor
 	landing
 	name "Talk to Plume about the void sprites"
 	description "Plume would be very interested in a report on what happened with the void sprites."

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -2857,6 +2857,7 @@ mission "Remnant: Face to Maw 1B"
 	landing
 	to offer
 		has "event: remnant: return the samples timer"
+		has "flagship model: Puffin"
 		or
 			not "Remnant: Cognizance 1: offered"
 			has "Remnant: Cognizance 19: done"


### PR DESCRIPTION
**Bugfix:**

## Fix Details
- Removes `minor` from Face to Maw 1 so it is not blocked by Face to Maw 1B.
- Added `has "flagship model: Puffin"` to the `to offer` conditions of Face to Maw 1B to match Face to Maw 1 so the missions always offer together.
These are also fixed by #9098 but that also reorganises the missions to remove the possibility of this sort of thing occurring in the future.

## Testing Done
0

## Save File
This save file can be used to verify the bugfix. The bug will occur when using [41e3eba](https://github.com/endless-sky/endless-sky/commit/41e3eba00496db934a191ed288e4c47cd971e8b4), and will not occur when using this branch's build.
[warp core 1~3016-10-06.txt](https://github.com/endless-sky/endless-sky/files/12334464/warp.core.1.3016-10-06.txt)

The Summer Leaf flagship has been given gaslining to demonstrate that Face to Maw 1B but not Face to Maw 1 will offer if the ship is not a Puffin.

