### PR TITLE
Replace tabs with spaces in two hails

### DIFF
--- a/data/human/hails.txt
+++ b/data/human/hails.txt
@@ -4815,7 +4815,7 @@ phrase "pirate big raid"
 	word
 		"!"
 
-phrase	"pirate big raid"
+phrase "pirate big raid"
 	word
 		"the "
 	word
@@ -4870,7 +4870,7 @@ phrase	"pirate big raid"
 	word
 		"!"
 
-phrase	"pirate boast"
+phrase "pirate boast"
 	word
 		"We made off with so many ships"
 		"We made off with so many credits"


### PR DESCRIPTION
** Summary
Replaces tabs after `phrase` with spaces, like every other phrase I've seen. I'm not sure if it has any effect on the hails, but we'll at least keep `hails.txt` consistent, hey?

Thank you zuckung for reporting this on the community discord server.