### PR TITLE
refactor: moved DrawPlayerShipInfo into ShopPanel

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -120,18 +120,6 @@ int OutfitterPanel::VisibilityCheckboxesSize() const
 
 
 
-int OutfitterPanel::DrawPlayerShipInfo(const Point &point)
-{
-	shipInfo.Update(*playerShip, player, collapsed.count("description"));
-	shipInfo.DrawAttributes(point);
-	const int attributesHeight = shipInfo.AttributesHeight();
-	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
-
-	return attributesHeight + shipInfo.OutfitsHeight();
-}
-
-
-
 bool OutfitterPanel::HasItem(const string &name) const
 {
 	const Outfit *outfit = GameData::Outfits().Get(name);

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -49,7 +49,6 @@ public:
 protected:
 	virtual int TileSize() const override;
 	virtual int VisibilityCheckboxesSize() const override;
-	virtual int DrawPlayerShipInfo(const Point &point) override;
 	virtual bool HasItem(const std::string &name) const override;
 	virtual void DrawItem(const std::string &name, const Point &point, int scrollY) override;
 	virtual int DividerOffset() const override;

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -116,18 +116,6 @@ int ShipyardPanel::TileSize() const
 
 
 
-int ShipyardPanel::DrawPlayerShipInfo(const Point &point)
-{
-	shipInfo.Update(*playerShip, player, collapsed.count("description"));
-	shipInfo.DrawAttributes(point, true);
-	const int attributesHeight = shipInfo.GetAttributesHeight(true);
-	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
-
-	return attributesHeight + shipInfo.OutfitsHeight();
-}
-
-
-
 bool ShipyardPanel::HasItem(const string &name) const
 {
 	const Ship *ship = GameData::Ships().Get(name);

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -42,7 +42,6 @@ public:
 
 protected:
 	virtual int TileSize() const override;
-	virtual int DrawPlayerShipInfo(const Point &point) override;
 	virtual bool HasItem(const std::string &name) const override;
 	virtual void DrawItem(const std::string &name, const Point &point, int scrollY) override;
 	virtual int DividerOffset() const override;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -559,6 +559,18 @@ void ShopPanel::CheckForMissions(Mission::Location location)
 
 
 
+int ShopPanel::DrawPlayerShipInfo(const Point &point)
+{
+	shipInfo.Update(*playerShip, player, collapsed.count("description"));
+	shipInfo.DrawAttributes(point, !isOutfitter);
+	const int attributesHeight = shipInfo.GetAttributesHeight(!isOutfitter);
+	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
+
+	return attributesHeight + shipInfo.OutfitsHeight();
+}
+
+
+
 void ShopPanel::FailSell(bool toStorage) const
 {
 }

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -178,344 +178,6 @@ void ShopPanel::Draw()
 
 
 
-void ShopPanel::DrawShipsSidebar()
-{
-	const Font &font = FontSet::Get(14);
-	const Color &medium = *GameData::Colors().Get("medium");
-	const Color &bright = *GameData::Colors().Get("bright");
-	sideDetailHeight = 0;
-
-	// Fill in the background.
-	FillShader::Fill(
-		Point(Screen::Right() - SIDEBAR_WIDTH / 2, 0.),
-		Point(SIDEBAR_WIDTH, Screen::Height()),
-		*GameData::Colors().Get("panel background"));
-	FillShader::Fill(
-		Point(Screen::Right() - SIDEBAR_WIDTH, 0.),
-		Point(1, Screen::Height()),
-		*GameData::Colors().Get("shop side panel background"));
-
-	// Draw this string, centered in the side panel:
-	static const string YOURS = "Your Ships:";
-	Point yoursPoint(Screen::Right() - SIDEBAR_WIDTH, Screen::Top() + 10 - sidebarScroll);
-	font.Draw({YOURS, {SIDEBAR_WIDTH, Alignment::CENTER}}, yoursPoint, bright);
-
-	// Start below the "Your Ships" label, and draw them.
-	Point point(
-		Screen::Right() - SIDEBAR_WIDTH / 2 - 93,
-		Screen::Top() + SIDEBAR_WIDTH / 2 - sidebarScroll + 40 - 93);
-
-	const Planet *here = player.GetPlanet();
-	int shipsHere = 0;
-	for(const shared_ptr<Ship> &ship : player.Ships())
-		shipsHere += CanShowInSidebar(*ship, here);
-	if(shipsHere < 4)
-		point.X() += .5 * ICON_TILE * (4 - shipsHere);
-
-	// Check whether flight check tooltips should be shown.
-	const auto flightChecks = player.FlightCheck();
-	Point mouse = GetUI()->GetMouse();
-	warningType.clear();
-
-	static const Color selected(.8f, 1.f);
-	static const Color unselected(.4f, 1.f);
-	for(const shared_ptr<Ship> &ship : player.Ships())
-	{
-		// Skip any ships that are "absent" for whatever reason.
-		if(!CanShowInSidebar(*ship, here))
-			continue;
-
-		if(point.X() > Screen::Right())
-		{
-			point.X() -= ICON_TILE * ICON_COLS;
-			point.Y() += ICON_TILE;
-		}
-
-		bool isSelected = playerShips.count(ship.get());
-		const Sprite *background = SpriteSet::Get(isSelected ? "ui/icon selected" : "ui/icon unselected");
-		SpriteShader::Draw(background, point);
-		// If this is one of the selected ships, check if the currently hovered
-		// button (if any) applies to it. If so, brighten the background.
-		if(isSelected && ShouldHighlight(ship.get()))
-			SpriteShader::Draw(background, point);
-
-		const Sprite *sprite = ship->GetSprite();
-		if(sprite)
-		{
-			float scale = ICON_SIZE / max(sprite->Width(), sprite->Height());
-			if(Preferences::Has(SHIP_OUTLINES))
-			{
-				Point size(sprite->Width() * scale, sprite->Height() * scale);
-				OutlineShader::Draw(sprite, point, size, isSelected ? selected : unselected);
-			}
-			else
-			{
-				int swizzle = ship->CustomSwizzle() >= 0 ? ship->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-				SpriteShader::Draw(sprite, point, scale, swizzle);
-			}
-		}
-
-		zones.emplace_back(point, Point(ICON_TILE, ICON_TILE), ship.get());
-
-		const auto checkIt = flightChecks.find(ship);
-		if(checkIt != flightChecks.end())
-		{
-			const string &check = (*checkIt).second.front();
-			const Sprite *icon = SpriteSet::Get(check.back() == '!' ? "ui/error" : "ui/warning");
-			SpriteShader::Draw(icon, point + .5 * Point(ICON_TILE - icon->Width(), ICON_TILE - icon->Height()));
-			if(zones.back().Contains(mouse))
-			{
-				warningType = check;
-				warningPoint = zones.back().TopLeft();
-			}
-		}
-
-		if(isSelected && playerShips.size() > 1 && ship->OutfitCount(selectedOutfit))
-			PointerShader::Draw(Point(point.X() - static_cast<int>(ICON_TILE / 3), point.Y()),
-				Point(1., 0.), 14.f, 12.f, 0., Color(.9f, .9f, .9f, .2f));
-
-		point.X() += ICON_TILE;
-	}
-	point.Y() += ICON_TILE;
-
-	if(playerShip)
-	{
-		point.Y() += SHIP_SIZE / 2;
-		point.X() = Screen::Right() - SIDEBAR_WIDTH / 2;
-		DrawShip(*playerShip, point, true);
-
-		Point offset(SIDEBAR_WIDTH / -2, SHIP_SIZE / 2);
-		sideDetailHeight = DrawPlayerShipInfo(point + offset);
-		point.Y() += sideDetailHeight + SHIP_SIZE / 2;
-	}
-	else if(player.Cargo().Size())
-	{
-		point.X() = Screen::Right() - SIDEBAR_WIDTH + 10;
-		font.Draw("cargo space:", point, medium);
-
-		string space = Format::Number(player.Cargo().Free()) + " / " + Format::Number(player.Cargo().Size());
-		font.Draw({space, {SIDEBAR_WIDTH - 20, Alignment::RIGHT}}, point, bright);
-		point.Y() += 20.;
-	}
-	maxSidebarScroll = max(0., point.Y() + sidebarScroll - Screen::Bottom() + BUTTON_HEIGHT);
-
-	PointerShader::Draw(Point(Screen::Right() - 10, Screen::Top() + 10),
-		Point(0., -1.), 10.f, 10.f, 5.f, Color(sidebarScroll > 0 ? .8f : .2f, 0.f));
-	PointerShader::Draw(Point(Screen::Right() - 10, Screen::Bottom() - 80),
-		Point(0., 1.), 10.f, 10.f, 5.f, Color(sidebarScroll < maxSidebarScroll ? .8f : .2f, 0.f));
-}
-
-
-
-void ShopPanel::DrawDetailsSidebar()
-{
-	// Fill in the background.
-	const Color &line = *GameData::Colors().Get("dim");
-	const Color &back = *GameData::Colors().Get("shop info panel background");
-	FillShader::Fill(
-		Point(Screen::Right() - SIDEBAR_WIDTH - INFOBAR_WIDTH, 0.),
-		Point(1., Screen::Height()),
-		line);
-	FillShader::Fill(
-		Point(Screen::Right() - SIDEBAR_WIDTH - INFOBAR_WIDTH / 2, 0.),
-		Point(INFOBAR_WIDTH - 1., Screen::Height()),
-		back);
-
-	Point point(
-		Screen::Right() - SIDE_WIDTH + INFOBAR_WIDTH / 2,
-		Screen::Top() + 10 - infobarScroll);
-
-	int heightOffset = DrawDetails(point);
-
-	maxInfobarScroll = max(0., heightOffset + infobarScroll - Screen::Bottom());
-
-	PointerShader::Draw(Point(Screen::Right() - SIDEBAR_WIDTH - 10, Screen::Top() + 10),
-		Point(0., -1.), 10.f, 10.f, 5.f, Color(infobarScroll > 0 ? .8f : .2f, 0.f));
-	PointerShader::Draw(Point(Screen::Right() - SIDEBAR_WIDTH - 10, Screen::Bottom() - 10),
-		Point(0., 1.), 10.f, 10.f, 5.f, Color(infobarScroll < maxInfobarScroll ? .8f : .2f, 0.f));
-}
-
-
-
-void ShopPanel::DrawButtons()
-{
-	// The last 70 pixels on the end of the side panel are for the buttons:
-	Point buttonSize(SIDEBAR_WIDTH, BUTTON_HEIGHT);
-	FillShader::Fill(Screen::BottomRight() - .5 * buttonSize, buttonSize,
-		*GameData::Colors().Get("shop side panel background"));
-	FillShader::Fill(
-		Point(Screen::Right() - SIDEBAR_WIDTH / 2, Screen::Bottom() - BUTTON_HEIGHT),
-		Point(SIDEBAR_WIDTH, 1), *GameData::Colors().Get("shop side panel footer"));
-
-	const Font &font = FontSet::Get(14);
-	const Color &bright = *GameData::Colors().Get("bright");
-	const Color &dim = *GameData::Colors().Get("medium");
-	const Color &back = *GameData::Colors().Get("panel background");
-
-	const Point creditsPoint(
-		Screen::Right() - SIDEBAR_WIDTH + 10,
-		Screen::Bottom() - 65);
-	font.Draw("You have:", creditsPoint, dim);
-
-	const auto credits = Format::CreditString(player.Accounts().Credits());
-	font.Draw({credits, {SIDEBAR_WIDTH - 20, Alignment::RIGHT}}, creditsPoint, bright);
-
-	const Font &bigFont = FontSet::Get(18);
-	const Color &hover = *GameData::Colors().Get("hover");
-	const Color &active = *GameData::Colors().Get("active");
-	const Color &inactive = *GameData::Colors().Get("inactive");
-
-	const Point buyCenter = Screen::BottomRight() - Point(210, 25);
-	FillShader::Fill(buyCenter, Point(60, 30), back);
-	bool isOwned = IsAlreadyOwned();
-	const Color *buyTextColor;
-	if(!CanBuy(isOwned))
-		buyTextColor = &inactive;
-	else if(hoverButton == (isOwned ? 'i' : 'b'))
-		buyTextColor = &hover;
-	else
-		buyTextColor = &active;
-	string BUY = isOwned ? (playerShip ? "_Install" : "_Cargo") : "_Buy";
-	bigFont.Draw(BUY,
-		buyCenter - .5 * Point(bigFont.Width(BUY), bigFont.Height()),
-		*buyTextColor);
-
-	const Point sellCenter = Screen::BottomRight() - Point(130, 25);
-	FillShader::Fill(sellCenter, Point(60, 30), back);
-	static const string SELL = "_Sell";
-	bigFont.Draw(SELL,
-		sellCenter - .5 * Point(bigFont.Width(SELL), bigFont.Height()),
-		CanSell() ? hoverButton == 's' ? hover : active : inactive);
-
-	const Point leaveCenter = Screen::BottomRight() - Point(45, 25);
-	FillShader::Fill(leaveCenter, Point(70, 30), back);
-	static const string LEAVE = "_Leave";
-	bigFont.Draw(LEAVE,
-		leaveCenter - .5 * Point(bigFont.Width(LEAVE), bigFont.Height()),
-		hoverButton == 'l' ? hover : active);
-
-	int modifier = Modifier();
-	if(modifier > 1)
-	{
-		string mod = "x " + to_string(modifier);
-		int modWidth = font.Width(mod);
-		font.Draw(mod, buyCenter + Point(-.5 * modWidth, 10.), dim);
-		if(CanSellMultiple())
-			font.Draw(mod, sellCenter + Point(-.5 * modWidth, 10.), dim);
-	}
-}
-
-
-
-void ShopPanel::DrawMain()
-{
-	const Font &bigFont = FontSet::Get(18);
-	const Color &dim = *GameData::Colors().Get("medium");
-	const Color &bright = *GameData::Colors().Get("bright");
-	mainDetailHeight = 0;
-
-	const Sprite *collapsedArrow = SpriteSet::Get("ui/collapsed");
-	const Sprite *expandedArrow = SpriteSet::Get("ui/expanded");
-
-	// Draw all the available items.
-	// First, figure out how many columns we can draw.
-	const int TILE_SIZE = TileSize();
-	const int mainWidth = (Screen::Width() - SIDE_WIDTH - 1);
-	// If the user horizontally compresses the window too far, draw nothing.
-	if(mainWidth < TILE_SIZE)
-		return;
-	const int columns = mainWidth / TILE_SIZE;
-	const int columnWidth = mainWidth / columns;
-
-	const Point begin(
-		(Screen::Width() - columnWidth) / -2,
-		(Screen::Height() - TILE_SIZE) / -2 - mainScroll);
-	Point point = begin;
-	const float endX = Screen::Right() - (SIDE_WIDTH + 1);
-	double nextY = begin.Y() + TILE_SIZE;
-	int scrollY = 0;
-	for(const auto &cat : categories)
-	{
-		const string &category = cat.Name();
-		map<string, vector<string>>::const_iterator it = catalog.find(category);
-		if(it == catalog.end())
-			continue;
-
-		// This should never happen, but bail out if we don't know what planet
-		// we are on (meaning there's no way to know what items are for sale).
-		if(!planet)
-			break;
-
-		Point side(Screen::Left() + 5., point.Y() - TILE_SIZE / 2 + 10);
-		point.Y() += bigFont.Height() + 20;
-		nextY += bigFont.Height() + 20;
-
-		bool isCollapsed = collapsed.count(category);
-		bool isEmpty = true;
-		for(const string &name : it->second)
-		{
-			bool isSelected = (selectedShip && GameData::Ships().Get(name) == selectedShip)
-				|| (selectedOutfit && GameData::Outfits().Get(name) == selectedOutfit);
-
-			if(isSelected)
-				selectedTopY = point.Y() - TILE_SIZE / 2;
-
-			if(!HasItem(name))
-				continue;
-			isEmpty = false;
-			if(isCollapsed)
-				break;
-
-			DrawItem(name, point, scrollY);
-
-			point.X() += columnWidth;
-			if(point.X() >= endX)
-			{
-				point.X() = begin.X();
-				point.Y() = nextY;
-				nextY += TILE_SIZE;
-				scrollY = -mainDetailHeight;
-			}
-		}
-
-		if(!isEmpty)
-		{
-			Point size(bigFont.Width(category) + 25., bigFont.Height());
-			categoryZones.emplace_back(Point(Screen::Left(), side.Y()) + .5 * size, size, category);
-			SpriteShader::Draw(isCollapsed ? collapsedArrow : expandedArrow, side + Point(10., 10.));
-			bigFont.Draw(category, side + Point(25., 0.), isCollapsed ? dim : bright);
-
-			if(point.X() != begin.X())
-			{
-				point.X() = begin.X();
-				point.Y() = nextY;
-				nextY += TILE_SIZE;
-				scrollY = -mainDetailHeight;
-			}
-			point.Y() += 40;
-			nextY += 40;
-		}
-		else
-		{
-			point.Y() -= bigFont.Height() + 20;
-			nextY -= bigFont.Height() + 20;
-		}
-	}
-	// This is how much Y space was actually used.
-	nextY -= 40 + TILE_SIZE;
-
-	// What amount would mainScroll have to equal to make nextY equal the
-	// bottom of the screen? (Also leave space for the "key" at the bottom.)
-	maxMainScroll = max(0., nextY + mainScroll - Screen::Height() / 2 - TILE_SIZE / 2 + VisibilityCheckboxesSize() + 40.);
-
-	PointerShader::Draw(Point(Screen::Right() - 10 - SIDE_WIDTH, Screen::Top() + 10),
-		Point(0., -1.), 10.f, 10.f, 5.f, Color(mainScroll > 0 ? .8f : .2f, 0.f));
-	PointerShader::Draw(Point(Screen::Right() - 10 - SIDE_WIDTH, Screen::Bottom() - 10),
-		Point(0., 1.), 10.f, 10.f, 5.f, Color(mainScroll < maxMainScroll ? .8f : .2f, 0.f));
-}
-
-
-
 void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 {
 	const Sprite *back = SpriteSet::Get(
@@ -541,18 +203,6 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 	Point offset(-SIDEBAR_WIDTH / 2, -.5f * SHIP_SIZE + 10.f);
 	font.Draw({name, {SIDEBAR_WIDTH, Alignment::CENTER, Truncate::MIDDLE}},
 		center + offset, *GameData::Colors().Get("bright"));
-}
-
-
-
-int ShopPanel::DrawPlayerShipInfo(const Point &point)
-{
-	shipInfo.Update(*playerShip, player, collapsed.count("description"));
-	shipInfo.DrawAttributes(point, !isOutfitter);
-	const int attributesHeight = shipInfo.GetAttributesHeight(!isOutfitter);
-	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
-
-	return attributesHeight + shipInfo.OutfitsHeight();
 }
 
 
@@ -1010,6 +660,356 @@ const Outfit *ShopPanel::Zone::GetOutfit() const
 double ShopPanel::Zone::ScrollY() const
 {
 	return scrollY;
+}
+
+
+
+void ShopPanel::DrawShipsSidebar()
+{
+	const Font &font = FontSet::Get(14);
+	const Color &medium = *GameData::Colors().Get("medium");
+	const Color &bright = *GameData::Colors().Get("bright");
+	sideDetailHeight = 0;
+
+	// Fill in the background.
+	FillShader::Fill(
+		Point(Screen::Right() - SIDEBAR_WIDTH / 2, 0.),
+		Point(SIDEBAR_WIDTH, Screen::Height()),
+		*GameData::Colors().Get("panel background"));
+	FillShader::Fill(
+		Point(Screen::Right() - SIDEBAR_WIDTH, 0.),
+		Point(1, Screen::Height()),
+		*GameData::Colors().Get("shop side panel background"));
+
+	// Draw this string, centered in the side panel:
+	static const string YOURS = "Your Ships:";
+	Point yoursPoint(Screen::Right() - SIDEBAR_WIDTH, Screen::Top() + 10 - sidebarScroll);
+	font.Draw({YOURS, {SIDEBAR_WIDTH, Alignment::CENTER}}, yoursPoint, bright);
+
+	// Start below the "Your Ships" label, and draw them.
+	Point point(
+		Screen::Right() - SIDEBAR_WIDTH / 2 - 93,
+		Screen::Top() + SIDEBAR_WIDTH / 2 - sidebarScroll + 40 - 93);
+
+	const Planet *here = player.GetPlanet();
+	int shipsHere = 0;
+	for(const shared_ptr<Ship> &ship : player.Ships())
+		shipsHere += CanShowInSidebar(*ship, here);
+	if(shipsHere < 4)
+		point.X() += .5 * ICON_TILE * (4 - shipsHere);
+
+	// Check whether flight check tooltips should be shown.
+	const auto flightChecks = player.FlightCheck();
+	Point mouse = GetUI()->GetMouse();
+	warningType.clear();
+
+	static const Color selected(.8f, 1.f);
+	static const Color unselected(.4f, 1.f);
+	for(const shared_ptr<Ship> &ship : player.Ships())
+	{
+		// Skip any ships that are "absent" for whatever reason.
+		if(!CanShowInSidebar(*ship, here))
+			continue;
+
+		if(point.X() > Screen::Right())
+		{
+			point.X() -= ICON_TILE * ICON_COLS;
+			point.Y() += ICON_TILE;
+		}
+
+		bool isSelected = playerShips.count(ship.get());
+		const Sprite *background = SpriteSet::Get(isSelected ? "ui/icon selected" : "ui/icon unselected");
+		SpriteShader::Draw(background, point);
+		// If this is one of the selected ships, check if the currently hovered
+		// button (if any) applies to it. If so, brighten the background.
+		if(isSelected && ShouldHighlight(ship.get()))
+			SpriteShader::Draw(background, point);
+
+		const Sprite *sprite = ship->GetSprite();
+		if(sprite)
+		{
+			float scale = ICON_SIZE / max(sprite->Width(), sprite->Height());
+			if(Preferences::Has(SHIP_OUTLINES))
+			{
+				Point size(sprite->Width() * scale, sprite->Height() * scale);
+				OutlineShader::Draw(sprite, point, size, isSelected ? selected : unselected);
+			}
+			else
+			{
+				int swizzle = ship->CustomSwizzle() >= 0 ? ship->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
+				SpriteShader::Draw(sprite, point, scale, swizzle);
+			}
+		}
+
+		zones.emplace_back(point, Point(ICON_TILE, ICON_TILE), ship.get());
+
+		const auto checkIt = flightChecks.find(ship);
+		if(checkIt != flightChecks.end())
+		{
+			const string &check = (*checkIt).second.front();
+			const Sprite *icon = SpriteSet::Get(check.back() == '!' ? "ui/error" : "ui/warning");
+			SpriteShader::Draw(icon, point + .5 * Point(ICON_TILE - icon->Width(), ICON_TILE - icon->Height()));
+			if(zones.back().Contains(mouse))
+			{
+				warningType = check;
+				warningPoint = zones.back().TopLeft();
+			}
+		}
+
+		if(isSelected && playerShips.size() > 1 && ship->OutfitCount(selectedOutfit))
+			PointerShader::Draw(Point(point.X() - static_cast<int>(ICON_TILE / 3), point.Y()),
+				Point(1., 0.), 14.f, 12.f, 0., Color(.9f, .9f, .9f, .2f));
+
+		point.X() += ICON_TILE;
+	}
+	point.Y() += ICON_TILE;
+
+	if(playerShip)
+	{
+		point.Y() += SHIP_SIZE / 2;
+		point.X() = Screen::Right() - SIDEBAR_WIDTH / 2;
+		DrawShip(*playerShip, point, true);
+
+		Point offset(SIDEBAR_WIDTH / -2, SHIP_SIZE / 2);
+		sideDetailHeight = DrawPlayerShipInfo(point + offset);
+		point.Y() += sideDetailHeight + SHIP_SIZE / 2;
+	}
+	else if(player.Cargo().Size())
+	{
+		point.X() = Screen::Right() - SIDEBAR_WIDTH + 10;
+		font.Draw("cargo space:", point, medium);
+
+		string space = Format::Number(player.Cargo().Free()) + " / " + Format::Number(player.Cargo().Size());
+		font.Draw({space, {SIDEBAR_WIDTH - 20, Alignment::RIGHT}}, point, bright);
+		point.Y() += 20.;
+	}
+	maxSidebarScroll = max(0., point.Y() + sidebarScroll - Screen::Bottom() + BUTTON_HEIGHT);
+
+	PointerShader::Draw(Point(Screen::Right() - 10, Screen::Top() + 10),
+		Point(0., -1.), 10.f, 10.f, 5.f, Color(sidebarScroll > 0 ? .8f : .2f, 0.f));
+	PointerShader::Draw(Point(Screen::Right() - 10, Screen::Bottom() - 80),
+		Point(0., 1.), 10.f, 10.f, 5.f, Color(sidebarScroll < maxSidebarScroll ? .8f : .2f, 0.f));
+}
+
+
+
+void ShopPanel::DrawDetailsSidebar()
+{
+	// Fill in the background.
+	const Color &line = *GameData::Colors().Get("dim");
+	const Color &back = *GameData::Colors().Get("shop info panel background");
+	FillShader::Fill(
+		Point(Screen::Right() - SIDEBAR_WIDTH - INFOBAR_WIDTH, 0.),
+		Point(1., Screen::Height()),
+		line);
+	FillShader::Fill(
+		Point(Screen::Right() - SIDEBAR_WIDTH - INFOBAR_WIDTH / 2, 0.),
+		Point(INFOBAR_WIDTH - 1., Screen::Height()),
+		back);
+
+	Point point(
+		Screen::Right() - SIDE_WIDTH + INFOBAR_WIDTH / 2,
+		Screen::Top() + 10 - infobarScroll);
+
+	int heightOffset = DrawDetails(point);
+
+	maxInfobarScroll = max(0., heightOffset + infobarScroll - Screen::Bottom());
+
+	PointerShader::Draw(Point(Screen::Right() - SIDEBAR_WIDTH - 10, Screen::Top() + 10),
+		Point(0., -1.), 10.f, 10.f, 5.f, Color(infobarScroll > 0 ? .8f : .2f, 0.f));
+	PointerShader::Draw(Point(Screen::Right() - SIDEBAR_WIDTH - 10, Screen::Bottom() - 10),
+		Point(0., 1.), 10.f, 10.f, 5.f, Color(infobarScroll < maxInfobarScroll ? .8f : .2f, 0.f));
+}
+
+
+
+void ShopPanel::DrawButtons()
+{
+	// The last 70 pixels on the end of the side panel are for the buttons:
+	Point buttonSize(SIDEBAR_WIDTH, BUTTON_HEIGHT);
+	FillShader::Fill(Screen::BottomRight() - .5 * buttonSize, buttonSize,
+		*GameData::Colors().Get("shop side panel background"));
+	FillShader::Fill(
+		Point(Screen::Right() - SIDEBAR_WIDTH / 2, Screen::Bottom() - BUTTON_HEIGHT),
+		Point(SIDEBAR_WIDTH, 1), *GameData::Colors().Get("shop side panel footer"));
+
+	const Font &font = FontSet::Get(14);
+	const Color &bright = *GameData::Colors().Get("bright");
+	const Color &dim = *GameData::Colors().Get("medium");
+	const Color &back = *GameData::Colors().Get("panel background");
+
+	const Point creditsPoint(
+		Screen::Right() - SIDEBAR_WIDTH + 10,
+		Screen::Bottom() - 65);
+	font.Draw("You have:", creditsPoint, dim);
+
+	const auto credits = Format::CreditString(player.Accounts().Credits());
+	font.Draw({credits, {SIDEBAR_WIDTH - 20, Alignment::RIGHT}}, creditsPoint, bright);
+
+	const Font &bigFont = FontSet::Get(18);
+	const Color &hover = *GameData::Colors().Get("hover");
+	const Color &active = *GameData::Colors().Get("active");
+	const Color &inactive = *GameData::Colors().Get("inactive");
+
+	const Point buyCenter = Screen::BottomRight() - Point(210, 25);
+	FillShader::Fill(buyCenter, Point(60, 30), back);
+	bool isOwned = IsAlreadyOwned();
+	const Color *buyTextColor;
+	if(!CanBuy(isOwned))
+		buyTextColor = &inactive;
+	else if(hoverButton == (isOwned ? 'i' : 'b'))
+		buyTextColor = &hover;
+	else
+		buyTextColor = &active;
+	string BUY = isOwned ? (playerShip ? "_Install" : "_Cargo") : "_Buy";
+	bigFont.Draw(BUY,
+		buyCenter - .5 * Point(bigFont.Width(BUY), bigFont.Height()),
+		*buyTextColor);
+
+	const Point sellCenter = Screen::BottomRight() - Point(130, 25);
+	FillShader::Fill(sellCenter, Point(60, 30), back);
+	static const string SELL = "_Sell";
+	bigFont.Draw(SELL,
+		sellCenter - .5 * Point(bigFont.Width(SELL), bigFont.Height()),
+		CanSell() ? hoverButton == 's' ? hover : active : inactive);
+
+	const Point leaveCenter = Screen::BottomRight() - Point(45, 25);
+	FillShader::Fill(leaveCenter, Point(70, 30), back);
+	static const string LEAVE = "_Leave";
+	bigFont.Draw(LEAVE,
+		leaveCenter - .5 * Point(bigFont.Width(LEAVE), bigFont.Height()),
+		hoverButton == 'l' ? hover : active);
+
+	int modifier = Modifier();
+	if(modifier > 1)
+	{
+		string mod = "x " + to_string(modifier);
+		int modWidth = font.Width(mod);
+		font.Draw(mod, buyCenter + Point(-.5 * modWidth, 10.), dim);
+		if(CanSellMultiple())
+			font.Draw(mod, sellCenter + Point(-.5 * modWidth, 10.), dim);
+	}
+}
+
+
+
+void ShopPanel::DrawMain()
+{
+	const Font &bigFont = FontSet::Get(18);
+	const Color &dim = *GameData::Colors().Get("medium");
+	const Color &bright = *GameData::Colors().Get("bright");
+	mainDetailHeight = 0;
+
+	const Sprite *collapsedArrow = SpriteSet::Get("ui/collapsed");
+	const Sprite *expandedArrow = SpriteSet::Get("ui/expanded");
+
+	// Draw all the available items.
+	// First, figure out how many columns we can draw.
+	const int TILE_SIZE = TileSize();
+	const int mainWidth = (Screen::Width() - SIDE_WIDTH - 1);
+	// If the user horizontally compresses the window too far, draw nothing.
+	if(mainWidth < TILE_SIZE)
+		return;
+	const int columns = mainWidth / TILE_SIZE;
+	const int columnWidth = mainWidth / columns;
+
+	const Point begin(
+		(Screen::Width() - columnWidth) / -2,
+		(Screen::Height() - TILE_SIZE) / -2 - mainScroll);
+	Point point = begin;
+	const float endX = Screen::Right() - (SIDE_WIDTH + 1);
+	double nextY = begin.Y() + TILE_SIZE;
+	int scrollY = 0;
+	for(const auto &cat : categories)
+	{
+		const string &category = cat.Name();
+		map<string, vector<string>>::const_iterator it = catalog.find(category);
+		if(it == catalog.end())
+			continue;
+
+		// This should never happen, but bail out if we don't know what planet
+		// we are on (meaning there's no way to know what items are for sale).
+		if(!planet)
+			break;
+
+		Point side(Screen::Left() + 5., point.Y() - TILE_SIZE / 2 + 10);
+		point.Y() += bigFont.Height() + 20;
+		nextY += bigFont.Height() + 20;
+
+		bool isCollapsed = collapsed.count(category);
+		bool isEmpty = true;
+		for(const string &name : it->second)
+		{
+			bool isSelected = (selectedShip && GameData::Ships().Get(name) == selectedShip)
+				|| (selectedOutfit && GameData::Outfits().Get(name) == selectedOutfit);
+
+			if(isSelected)
+				selectedTopY = point.Y() - TILE_SIZE / 2;
+
+			if(!HasItem(name))
+				continue;
+			isEmpty = false;
+			if(isCollapsed)
+				break;
+
+			DrawItem(name, point, scrollY);
+
+			point.X() += columnWidth;
+			if(point.X() >= endX)
+			{
+				point.X() = begin.X();
+				point.Y() = nextY;
+				nextY += TILE_SIZE;
+				scrollY = -mainDetailHeight;
+			}
+		}
+
+		if(!isEmpty)
+		{
+			Point size(bigFont.Width(category) + 25., bigFont.Height());
+			categoryZones.emplace_back(Point(Screen::Left(), side.Y()) + .5 * size, size, category);
+			SpriteShader::Draw(isCollapsed ? collapsedArrow : expandedArrow, side + Point(10., 10.));
+			bigFont.Draw(category, side + Point(25., 0.), isCollapsed ? dim : bright);
+
+			if(point.X() != begin.X())
+			{
+				point.X() = begin.X();
+				point.Y() = nextY;
+				nextY += TILE_SIZE;
+				scrollY = -mainDetailHeight;
+			}
+			point.Y() += 40;
+			nextY += 40;
+		}
+		else
+		{
+			point.Y() -= bigFont.Height() + 20;
+			nextY -= bigFont.Height() + 20;
+		}
+	}
+	// This is how much Y space was actually used.
+	nextY -= 40 + TILE_SIZE;
+
+	// What amount would mainScroll have to equal to make nextY equal the
+	// bottom of the screen? (Also leave space for the "key" at the bottom.)
+	maxMainScroll = max(0., nextY + mainScroll - Screen::Height() / 2 - TILE_SIZE / 2 + VisibilityCheckboxesSize() + 40.);
+
+	PointerShader::Draw(Point(Screen::Right() - 10 - SIDE_WIDTH, Screen::Top() + 10),
+		Point(0., -1.), 10.f, 10.f, 5.f, Color(mainScroll > 0 ? .8f : .2f, 0.f));
+	PointerShader::Draw(Point(Screen::Right() - 10 - SIDE_WIDTH, Screen::Bottom() - 10),
+		Point(0., 1.), 10.f, 10.f, 5.f, Color(mainScroll < maxMainScroll ? .8f : .2f, 0.f));
+}
+
+
+
+int ShopPanel::DrawPlayerShipInfo(const Point &point)
+{
+	shipInfo.Update(*playerShip, player, collapsed.count("description"));
+	shipInfo.DrawAttributes(point, !isOutfitter);
+	const int attributesHeight = shipInfo.GetAttributesHeight(!isOutfitter);
+	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
+
+	return attributesHeight + shipInfo.OutfitsHeight();
 }
 
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -545,6 +545,18 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 
 
 
+int ShopPanel::DrawPlayerShipInfo(const Point &point)
+{
+	shipInfo.Update(*playerShip, player, collapsed.count("description"));
+	shipInfo.DrawAttributes(point, !isOutfitter);
+	const int attributesHeight = shipInfo.GetAttributesHeight(!isOutfitter);
+	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
+
+	return attributesHeight + shipInfo.OutfitsHeight();
+}
+
+
+
 void ShopPanel::CheckForMissions(Mission::Location location)
 {
 	if(!GetUI()->IsTop(this))
@@ -555,18 +567,6 @@ void ShopPanel::CheckForMissions(Mission::Location location)
 		mission->Do(Mission::OFFER, player, GetUI());
 	else
 		player.HandleBlockedMissions(location, GetUI());
-}
-
-
-
-int ShopPanel::DrawPlayerShipInfo(const Point &point)
-{
-	shipInfo.Update(*playerShip, player, collapsed.count("description"));
-	shipInfo.DrawAttributes(point, !isOutfitter);
-	const int attributesHeight = shipInfo.GetAttributesHeight(!isOutfitter);
-	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
-
-	return attributesHeight + shipInfo.OutfitsHeight();
 }
 
 

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -71,13 +71,7 @@ protected:
 
 
 protected:
-	void DrawShipsSidebar();
-	void DrawDetailsSidebar();
-	void DrawButtons();
-	void DrawMain();
-
 	void DrawShip(const Ship &ship, const Point &center, bool isSelected);
-	int DrawPlayerShipInfo(const Point &point);
 
 	void CheckForMissions(Mission::Location location);
 
@@ -196,6 +190,13 @@ protected:
 
 
 private:
+	void DrawShipsSidebar();
+	void DrawDetailsSidebar();
+	void DrawButtons();
+	void DrawMain();
+
+	int DrawPlayerShipInfo(const Point &point);
+
 	bool DoScroll(double dy);
 	bool SetScrollToTop();
 	bool SetScrollToBottom();

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -77,13 +77,13 @@ protected:
 	void DrawMain();
 
 	void DrawShip(const Ship &ship, const Point &center, bool isSelected);
+	int DrawPlayerShipInfo(const Point &point);
 
 	void CheckForMissions(Mission::Location location);
 
 	// These are for the individual shop panels to override.
 	virtual int TileSize() const = 0;
 	virtual int VisibilityCheckboxesSize() const;
-	virtual int DrawPlayerShipInfo(const Point &point);
 	virtual bool HasItem(const std::string &name) const = 0;
 	virtual void DrawItem(const std::string &name, const Point &point, int scrollY) = 0;
 	virtual int DividerOffset() const = 0;

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -83,7 +83,7 @@ protected:
 	// These are for the individual shop panels to override.
 	virtual int TileSize() const = 0;
 	virtual int VisibilityCheckboxesSize() const;
-	virtual int DrawPlayerShipInfo(const Point &point) = 0;
+	virtual int DrawPlayerShipInfo(const Point &point);
 	virtual bool HasItem(const std::string &name) const = 0;
 	virtual void DrawItem(const std::string &name, const Point &point, int scrollY) = 0;
 	virtual int DividerOffset() const = 0;


### PR DESCRIPTION
**Feature:**

## Feature Details
The only difference between the ShipyardPanel and OutfitterPanel versions of DrawPlayerShipInfo was passing a bool that stated whether or not it was for a shipyard or outfitter.  Now that ShopPanel knows which one it is (isOutfitter), there's no reason to have this code duplicated in both kids.

## Testing Done
Checked the displays in both shops.