### PR TITLE
Move Ki Patek Ka inwards somewhat

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -30470,8 +30470,8 @@ system "Sol Kimek"
 		period 31.1678
 	object "Ki Patek Ka"
 		sprite planet/ocean1
-		distance 679.68
-		period 343.812
+		distance 466.11
+		period 291.452
 		object "Starting Rubin"
 			sprite planet/station1c
 				scale 0.5


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue I spotted a moment ago

## Fix Details

Before:
![image](https://github.com/endless-sky/endless-sky/assets/18634983/a23d272c-6f22-42d2-a913-685d77cb23f2)

After:
![image](https://github.com/endless-sky/endless-sky/assets/18634983/53541d11-b7cd-4f66-832a-7df447fc76c3)

Two reasons for this. Firstly, and most obviously, having the outermost moon of that gas giant overlap Starting Rubin sometimes is not ideal.
But also, it's mentioned in some Coalition planet descriptions that the Kimek favour hotter, dryer conditions such as savannah and plains environments, which is contrasted with the Saryd preference for cooler boreal forest (description of Far Home). Yet currently Ki Patek Ka sits notably on the outer edge of its star's habitable zone (about 1.5 times further than the ideal habitable distance), which would make hot conditions very rare there, if not turn the planet into an outright ice world. While moving it to the inner edge of the habitable zone isn't possible without overlapping that inner rocky planet, with the planet roughly in the ideal habitable zone, it's reasonable enough that large areas of the savannah that would be present, and the Kimek might reasonably happen to favour them.

## Testing Done
Jumped in and out a bit until I got the right planetary alignment to make sure that starting rubin couldn't overlap the inner planet.

## Save File
None, just go to Sol Kimek.
