### PR TITLE
feat(enhancement): Autocondition for counting flagship's bays

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3233,6 +3233,17 @@ void PlayerInfo::RegisterDerivedConditions()
 	flagshipAttributeProvider.SetGetFunction(flagshipAttributeFun);
 	flagshipAttributeProvider.SetHasFunction(flagshipAttributeFun);
 
+	auto &&flagshipBaysProvider = conditions.GetProviderPrefixed("flagship bays: ");
+	auto flagshipBaysFun = [this](const string &name) -> int64_t
+	{
+		if(!flagship)
+			return 0;
+		
+		return flagship->BaysTotal(name.substr(strlen("flagship bays: ")));
+	};
+	flagshipBaysProvider.SetGetFunction(flagshipBaysFun);
+	flagshipBaysProvider.SetHasFunction(flagshipBaysFun);
+
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3238,7 +3238,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	{
 		if(!flagship)
 			return 0;
-		
+
 		return flagship->BaysTotal(name.substr(strlen("flagship bays: ")));
 	};
 	flagshipBaysProvider.SetGetFunction(flagshipBaysFun);


### PR DESCRIPTION
**Feature:** This PR closes #9170
## Feature Details
You can now get the number of bays the flagship has with an autocondition:
`"flagship bays: <category>"`, where `<category>` is category of the bay.

## Testing Done
Seems to work correctly in a conversation.

## Performance Impact
I think N/A
