### PR TITLE
Feat(ui): Make the message about missions require landing more notable

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -154,8 +154,9 @@ color "warning conflict" .315 .27 .12 1.
 color "warning no command" 0.16 0.16 0.13 1.
 
 # Colors used for messages
-color "message importance highest"	1. .5 0. 1.
-color "message importance default"	1. 1. 1. 1.
+color "message importance highest" 1. .5 0. 1.
+color "message importance info" 0. 1. .5 1.
+color "message importance default" 1. 1. 1. 1.
 
 # Colors used when drawing the map (system names, links, and the player's desired route).
 # (The color of the ring that represents a given system is context-sensitive.)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3805,7 +3805,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 					message += (oxfordComma ? ", and " : " and ");
 			}
 			message += " in the system you are jumping to.";
-			Messages::Add(message, Messages::Importance::High);
+			Messages::Add(message, Messages::Importance::Info);
 		}
 		// If any destination was found, find the corresponding stellar object
 		// and set it as your ship's target planet.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1068,6 +1068,9 @@ void Engine::Draw() const
 			case Messages::Importance::High:
 				color = GameData::Colors().Find("message importance high");
 				break;
+			case Messages::Importance::Info:
+				color = GameData::Colors().Find("message importance info");
+				break;
 			case Messages::Importance::Low:
 				color = GameData::Colors().Find("message importance low");
 				break;

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -32,6 +32,7 @@ public:
 	enum class Importance : uint_least8_t {
 		Highest,
 		High,
+		Info,
 		Low
 	};
 


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #9191

## Feature Details
Added a new message priority, "info", which can be used for messages that should be more visible than normal hails, but are different then a warning.
Currently only used for the message that tells if a mission requires you to land on a planet.

## UI Screenshots
![2023-08-17_13-17](https://github.com/endless-sky/endless-sky/assets/85687254/9bc2f753-f4be-43a5-b1cf-7f61077ccda4)


## Testing Done
See screenshot
