### PR TITLE
fix(bug): description zone in shipyard

### DIFF
--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -47,6 +47,9 @@ class System;
 using namespace std;
 
 namespace {
+	// Label for the decription field of the detail pane.
+	const string DESCRIPTION = "description";
+
 	// The name entry dialog should include a "Random" button to choose a random
 	// name using the civilian ship name generator.
 	class NameDialog : public Dialog {
@@ -154,77 +157,69 @@ int ShipyardPanel::DrawDetails(const Point &center)
 {
 	string selectedItem = "No Ship Selected";
 	const Font &font = FontSet::Get(14);
-	const Color &bright = *GameData::Colors().Get("bright");
-	const Color &dim = *GameData::Colors().Get("medium");
-	const Sprite *collapsedArrow = SpriteSet::Get("ui/collapsed");
 
 	int heightOffset = 20;
 
 	if(selectedShip)
 	{
-		shipInfo.Update(*selectedShip, player, collapsed.count("description"));
+		shipInfo.Update(*selectedShip, player, collapsed.count(DESCRIPTION));
 		selectedItem = selectedShip->DisplayModelName();
 
+		// Find the old description zone and remove it.
+		auto descriptionZone = find_if(categoryZones.begin(), categoryZones.end(),
+			[&](const ClickZone<string> &zone) { return zone.Value() == DESCRIPTION; });
+		if(descriptionZone != categoryZones.end())
+			categoryZones.erase(descriptionZone);
+
+		const Point spriteCenter(center.X(), center.Y() + 20 + TileSize() / 2);
+		const Point startPoint(center.X() - INFOBAR_WIDTH / 2 + 20, center.Y() + 20 + TileSize());
 		const Sprite *background = SpriteSet::Get("ui/shipyard selected");
+		SpriteShader::Draw(background, spriteCenter);
+
 		const Sprite *shipSprite = selectedShip->GetSprite();
-		float spriteScale = shipSprite
-			? min(1.f, (INFOBAR_WIDTH - 60.f) / max(shipSprite->Width(), shipSprite->Height()))
-			: 1.f;
+		if(shipSprite)
+		{
+			const float spriteScale = min(1.f, (INFOBAR_WIDTH - 20.f) / max(shipSprite->Width(), shipSprite->Height()));
+			const int swizzle = selectedShip->CustomSwizzle() >= 0
+				? selectedShip->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
+			SpriteShader::Draw(shipSprite, spriteCenter, spriteScale, swizzle);
+		}
 
-		int swizzle = selectedShip->CustomSwizzle() >= 0
-			? selectedShip->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-
-		Point spriteCenter(center.X(), center.Y() + 20 + TileSize() / 2);
-		Point startPoint(center.X() - INFOBAR_WIDTH / 2 + 20, center.Y() + 20 + TileSize());
-
-		double descriptionOffset = 35.;
-		Point descCenter(Screen::Right() - SIDE_WIDTH + INFOBAR_WIDTH / 2, startPoint.Y() + 20.);
+		double descriptionOffset = 40.;
 
 		// Maintenance note: This can be replaced with collapsed.contains() in C++20
-		if(!collapsed.count("description"))
+		if(!collapsed.count(DESCRIPTION))
 		{
 			descriptionOffset = shipInfo.DescriptionHeight();
 			shipInfo.DrawDescription(startPoint);
 		}
 		else
 		{
-			std::string label = "description";
-			font.Draw(label, startPoint + Point(35., 12.), dim);
+			const Color &dim = *GameData::Colors().Get("medium");
+			font.Draw(DESCRIPTION, startPoint + Point(35., 12.), dim);
+			const Sprite *collapsedArrow = SpriteSet::Get("ui/collapsed");
 			SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
 		}
 
 		// Calculate the new ClickZone for the description.
-		Point descDimensions(INFOBAR_WIDTH, descriptionOffset + 10.);
-		ClickZone<std::string> collapseDescription = ClickZone<std::string>(
-			descCenter, descDimensions, std::string("description"));
-
-		// Find the old zone, and replace it with the new zone.
-		for(auto it = categoryZones.begin(); it != categoryZones.end(); ++it)
-		{
-			if(it->Value() == "description")
-			{
-				categoryZones.erase(it);
-				break;
-			}
-		}
+		const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
+		const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
+		const ClickZone<string> collapseDescription = ClickZone<string>(
+			descriptionCenter, descriptionDimensions, DESCRIPTION);
 		categoryZones.emplace_back(collapseDescription);
 
-		Point attrPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
-		Point outfPoint(startPoint.X(), attrPoint.Y() + shipInfo.AttributesHeight());
+		const Point attributesPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
+		const Point outfitsPoint(startPoint.X(), attributesPoint.Y() + shipInfo.AttributesHeight());
+		shipInfo.DrawAttributes(attributesPoint);
+		shipInfo.DrawOutfits(outfitsPoint);
 
-		SpriteShader::Draw(background, spriteCenter);
-		if(shipSprite)
-			SpriteShader::Draw(shipSprite, spriteCenter, spriteScale, swizzle);
-
-		shipInfo.DrawAttributes(attrPoint);
-		shipInfo.DrawOutfits(outfPoint);
-
-		heightOffset = outfPoint.Y() + shipInfo.OutfitsHeight();
+		heightOffset = outfitsPoint.Y() + shipInfo.OutfitsHeight();
 	}
 
 	// Draw this string representing the selected ship (if any), centered in the details side panel
-	Point selectedPoint(center.X() - INFOBAR_WIDTH / 2 + 10, center.Y());
-	font.Draw({selectedItem, {INFOBAR_WIDTH - 20, Alignment::CENTER, Truncate::MIDDLE}},
+	const Color &bright = *GameData::Colors().Get("bright");
+	const Point selectedPoint(center.X() - INFOBAR_WIDTH / 2, center.Y());
+	font.Draw({selectedItem, {INFOBAR_WIDTH, Alignment::CENTER, Truncate::MIDDLE}},
 		selectedPoint, bright);
 
 	return heightOffset;

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -179,7 +179,7 @@ int ShipyardPanel::DrawDetails(const Point &center)
 		const Sprite *shipSprite = selectedShip->GetSprite();
 		if(shipSprite)
 		{
-			const float spriteScale = min(1.f, (INFOBAR_WIDTH - 20.f) / max(shipSprite->Width(), shipSprite->Height()));
+			const float spriteScale = min(1.f, (INFOBAR_WIDTH - 60.f) / max(shipSprite->Width(), shipSprite->Height()));
 			const int swizzle = selectedShip->CustomSwizzle() >= 0
 				? selectedShip->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
 			SpriteShader::Draw(shipSprite, spriteCenter, spriteScale, swizzle);


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Shifted the description clickzone down to match the description text (both collapsed and not).  Also shifted ship name to center it better,

## Testing Done
Checked details display in shipyard, tried clicking in various places.

## Additional Notes
This pulls out the bug fix from #9085, as requested by @warp-core.  It's the mirror of #9194, but for the shipyard rather than the outfitter.