### PR TITLE
Handle empty descriptions in shops

### DIFF
--- a/source/ItemInfoDisplay.cpp
+++ b/source/ItemInfoDisplay.cpp
@@ -161,8 +161,7 @@ void ItemInfoDisplay::UpdateDescription(const string &text, const vector<string>
 		description.Wrap(fullText);
 	}
 
-	// Pad by 10 pixels on the top and bottom.
-	// Unless there is no description.
+	// If there is a description, pad by 10 pixels on the top and bottom.
 	descriptionHeight = description.Height();
 	if(descriptionHeight)
 		descriptionHeight += 20;

--- a/source/ItemInfoDisplay.cpp
+++ b/source/ItemInfoDisplay.cpp
@@ -162,7 +162,10 @@ void ItemInfoDisplay::UpdateDescription(const string &text, const vector<string>
 	}
 
 	// Pad by 10 pixels on the top and bottom.
-	descriptionHeight = description.Height() + 20;
+	// Unless there is no description.
+	descriptionHeight = description.Height();
+	if(descriptionHeight)
+		descriptionHeight += 20;
 }
 
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -286,7 +286,7 @@ int OutfitterPanel::DrawDetails(const Point &center)
 				SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
 			}
 
-			// Calculate the new ClickZone for the description.
+			// Calculate the ClickZone for the description and add it.
 			const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
 			const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
 			ClickZone<string> collapseDescription = ClickZone<string>(

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -272,28 +272,33 @@ int OutfitterPanel::DrawDetails(const Point &center)
 		if(thumbnail)
 			SpriteShader::Draw(thumbnail, thumbnailCenter);
 
-		double descriptionOffset = 40.;
+		const bool hasDescription = outfitInfo.DescriptionHeight();
 
-		// Maintenance note: This can be replaced with collapsed.contains() in C++20
-		if(!collapsed.count(DESCRIPTION))
-		{
-			descriptionOffset = outfitInfo.DescriptionHeight();
-			outfitInfo.DrawDescription(startPoint);
-		}
-		else
-		{
-			const Color &dim = *GameData::Colors().Get("medium");
-			font.Draw(DESCRIPTION, startPoint + Point(35., 12.), dim);
-			const Sprite *collapsedArrow = SpriteSet::Get("ui/collapsed");
-			SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
-		}
+		double descriptionOffset = hasDescription ? 40. : 0.;
 
-		// Calculate the new ClickZone for the description.
-		const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
-		const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
-		ClickZone<string> collapseDescription = ClickZone<string>(
-			descriptionCenter, descriptionDimensions, DESCRIPTION);
-		categoryZones.emplace_back(collapseDescription);
+		if(hasDescription)
+		{
+			// Maintenance note: This can be replaced with collapsed.contains() in C++20
+			if(!collapsed.count(DESCRIPTION))
+			{
+				descriptionOffset = outfitInfo.DescriptionHeight();
+				outfitInfo.DrawDescription(startPoint);
+			}
+			else
+			{
+				const Color &dim = *GameData::Colors().Get("medium");
+				font.Draw(DESCRIPTION, startPoint + Point(35., 12.), dim);
+				const Sprite *collapsedArrow = SpriteSet::Get("ui/collapsed");
+				SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
+			}
+
+			// Calculate the new ClickZone for the description.
+			const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
+			const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
+			ClickZone<string> collapseDescription = ClickZone<string>(
+				descriptionCenter, descriptionDimensions, DESCRIPTION);
+			categoryZones.emplace_back(collapseDescription);
+		}
 
 		const Point requirementsPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
 		const Point attributesPoint(startPoint.X(), requirementsPoint.Y() + outfitInfo.RequirementsHeight());

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -185,28 +185,33 @@ int ShipyardPanel::DrawDetails(const Point &center)
 			SpriteShader::Draw(shipSprite, spriteCenter, spriteScale, swizzle);
 		}
 
-		double descriptionOffset = 40.;
+		const bool hasDescription = shipInfo.DescriptionHeight();
 
-		// Maintenance note: This can be replaced with collapsed.contains() in C++20
-		if(!collapsed.count(DESCRIPTION))
-		{
-			descriptionOffset = shipInfo.DescriptionHeight();
-			shipInfo.DrawDescription(startPoint);
-		}
-		else
-		{
-			const Color &dim = *GameData::Colors().Get("medium");
-			font.Draw(DESCRIPTION, startPoint + Point(35., 12.), dim);
-			const Sprite *collapsedArrow = SpriteSet::Get("ui/collapsed");
-			SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
-		}
+		double descriptionOffset = hasDescription ? 40. : 0.;
 
-		// Calculate the new ClickZone for the description.
-		const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
-		const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
-		const ClickZone<string> collapseDescription = ClickZone<string>(
-			descriptionCenter, descriptionDimensions, DESCRIPTION);
-		categoryZones.emplace_back(collapseDescription);
+		if(hasDescription)
+		{
+			// Maintenance note: This can be replaced with collapsed.contains() in C++20
+			if(!collapsed.count(DESCRIPTION))
+			{
+				descriptionOffset = shipInfo.DescriptionHeight();
+				shipInfo.DrawDescription(startPoint);
+			}
+			else
+			{
+				const Color &dim = *GameData::Colors().Get("medium");
+				font.Draw(DESCRIPTION, startPoint + Point(35., 12.), dim);
+				const Sprite *collapsedArrow = SpriteSet::Get("ui/collapsed");
+				SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
+			}
+
+			// Calculate the new ClickZone for the description.
+			const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
+			const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
+			const ClickZone<string> collapseDescription = ClickZone<string>(
+				descriptionCenter, descriptionDimensions, DESCRIPTION);
+			categoryZones.emplace_back(collapseDescription);
+		}
 
 		const Point attributesPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
 		const Point outfitsPoint(startPoint.X(), attributesPoint.Y() + shipInfo.AttributesHeight());

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -199,7 +199,7 @@ int ShipyardPanel::DrawDetails(const Point &center)
 				SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
 			}
 
-			// Calculate the new ClickZone for the description.
+			// Calculate the ClickZone for the description and add it.
 			const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
 			const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
 			const ClickZone<string> collapseDescription = ClickZone<string>(


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Currently, the description click zone and collapsed label will still be created and drawn even if the description is completely empty.
This PR skips these items if the description is empty.

## Testing Done
Visited the outfitter and shipyard and checked items with no description:
Before | After
-- | --
![image](https://github.com/endless-sky/endless-sky/assets/20605679/1be9b47b-0fa0-40b1-9a4b-d2ab7ce5d4f7) | ![image](https://github.com/endless-sky/endless-sky/assets/20605679/e6f4edfc-f285-43e8-ab97-0257bf78add4)
![image](https://github.com/endless-sky/endless-sky/assets/20605679/fde41624-eb1f-4697-a208-07d0f124e540) | 

