### PR TITLE
refactor: don't bother checking for existing description zone

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -254,12 +254,6 @@ int OutfitterPanel::DrawDetails(const Point &center)
 		outfitInfo.Update(*selectedOutfit, player, CanSell(), collapsed.count(DESCRIPTION));
 		selectedItem = selectedOutfit->DisplayName();
 
-		// Find the old description zone and remove it.
-		auto descriptionZone = find_if(categoryZones.begin(), categoryZones.end(),
-			[&](const ClickZone<string> &zone) { return zone.Value() == DESCRIPTION; });
-		if(descriptionZone != categoryZones.end())
-			categoryZones.erase(descriptionZone);
-
 		const Sprite *thumbnail = selectedOutfit->Thumbnail();
 		const float tileSize = thumbnail
 			? max(thumbnail->Height(), static_cast<float>(TileSize()))
@@ -288,12 +282,20 @@ int OutfitterPanel::DrawDetails(const Point &center)
 			SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
 		}
 
-		// Calculate the new ClickZone for the description.
+		// Calculate the ClickZone for the description and update it (or add it).
 		const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
 		const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
-		ClickZone<string> collapseDescription = ClickZone<string>(
-			descriptionCenter, descriptionDimensions, DESCRIPTION);
-		categoryZones.emplace_back(collapseDescription);
+
+		auto descriptionZone = find_if(categoryZones.begin(), categoryZones.end(),
+			[&](const ClickZone<string> &zone) { return zone.Value() == DESCRIPTION; });
+		if(descriptionZone != categoryZones.end())
+			*descriptionZone = {descriptionCenter, descriptionDimensions};
+		else
+		{
+			ClickZone<string> collapseDescription = ClickZone<string>(
+				descriptionCenter, descriptionDimensions, DESCRIPTION);
+			categoryZones.emplace_back(collapseDescription);
+		}
 
 		const Point requirementsPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
 		const Point attributesPoint(startPoint.X(), requirementsPoint.Y() + outfitInfo.RequirementsHeight());

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -282,20 +282,12 @@ int OutfitterPanel::DrawDetails(const Point &center)
 			SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
 		}
 
-		// Calculate the ClickZone for the description and update it (or add it).
+		// Calculate the ClickZone for the description and add it.
 		const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
 		const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
-
-		auto descriptionZone = find_if(categoryZones.begin(), categoryZones.end(),
-			[&](const ClickZone<string> &zone) { return zone.Value() == DESCRIPTION; });
-		if(descriptionZone != categoryZones.end())
-			*descriptionZone = {descriptionCenter, descriptionDimensions};
-		else
-		{
-			ClickZone<string> collapseDescription = ClickZone<string>(
-				descriptionCenter, descriptionDimensions, DESCRIPTION);
-			categoryZones.emplace_back(collapseDescription);
-		}
+		ClickZone<string> collapseDescription = ClickZone<string>(
+			descriptionCenter, descriptionDimensions, DESCRIPTION);
+		categoryZones.emplace_back(collapseDescription);
 
 		const Point requirementsPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
 		const Point attributesPoint(startPoint.X(), requirementsPoint.Y() + outfitInfo.RequirementsHeight());

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -165,12 +165,6 @@ int ShipyardPanel::DrawDetails(const Point &center)
 		shipInfo.Update(*selectedShip, player, collapsed.count(DESCRIPTION));
 		selectedItem = selectedShip->DisplayModelName();
 
-		// Find the old description zone and remove it.
-		auto descriptionZone = find_if(categoryZones.begin(), categoryZones.end(),
-			[&](const ClickZone<string> &zone) { return zone.Value() == DESCRIPTION; });
-		if(descriptionZone != categoryZones.end())
-			categoryZones.erase(descriptionZone);
-
 		const Point spriteCenter(center.X(), center.Y() + 20 + TileSize() / 2);
 		const Point startPoint(center.X() - INFOBAR_WIDTH / 2 + 20, center.Y() + 20 + TileSize());
 		const Sprite *background = SpriteSet::Get("ui/shipyard selected");
@@ -201,12 +195,20 @@ int ShipyardPanel::DrawDetails(const Point &center)
 			SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
 		}
 
-		// Calculate the new ClickZone for the description.
+		// Calculate the ClickZone for the description and update it (or add it).
 		const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
 		const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
-		const ClickZone<string> collapseDescription = ClickZone<string>(
-			descriptionCenter, descriptionDimensions, DESCRIPTION);
-		categoryZones.emplace_back(collapseDescription);
+
+		auto descriptionZone = find_if(categoryZones.begin(), categoryZones.end(),
+			[&](const ClickZone<string> &zone) { return zone.Value() == DESCRIPTION; });
+		if(descriptionZone != categoryZones.end())
+			*descriptionZone = {descriptionCenter, descriptionDimensions};
+		else
+		{
+			const ClickZone<string> collapseDescription = ClickZone<string>(
+				descriptionCenter, descriptionDimensions, DESCRIPTION);
+			categoryZones.emplace_back(collapseDescription);
+		}
 
 		const Point attributesPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
 		const Point outfitsPoint(startPoint.X(), attributesPoint.Y() + shipInfo.AttributesHeight());

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -195,20 +195,12 @@ int ShipyardPanel::DrawDetails(const Point &center)
 			SpriteShader::Draw(collapsedArrow, startPoint + Point(20., 20.));
 		}
 
-		// Calculate the ClickZone for the description and update it (or add it).
+		// Calculate the ClickZone for the description and add it.
 		const Point descriptionDimensions(INFOBAR_WIDTH, descriptionOffset);
 		const Point descriptionCenter(center.X(), startPoint.Y() + descriptionOffset / 2);
-
-		auto descriptionZone = find_if(categoryZones.begin(), categoryZones.end(),
-			[&](const ClickZone<string> &zone) { return zone.Value() == DESCRIPTION; });
-		if(descriptionZone != categoryZones.end())
-			*descriptionZone = {descriptionCenter, descriptionDimensions};
-		else
-		{
-			const ClickZone<string> collapseDescription = ClickZone<string>(
-				descriptionCenter, descriptionDimensions, DESCRIPTION);
-			categoryZones.emplace_back(collapseDescription);
-		}
+		const ClickZone<string> collapseDescription = ClickZone<string>(
+			descriptionCenter, descriptionDimensions, DESCRIPTION);
+		categoryZones.emplace_back(collapseDescription);
 
 		const Point attributesPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
 		const Point outfitsPoint(startPoint.X(), attributesPoint.Y() + shipInfo.AttributesHeight());


### PR DESCRIPTION
**Refactor:**

## Refactor Details
Turns out the vector with the description zone is cleared every cycle, so there's no reason to check if it's still there from the last cycle.  And if someone named a category "description", I think we have other issues.

## Testing Done
Checked to make sure description clickzones behave properly, and that it didn't mess with the category clickzones in the main pane.