### PR TITLE
Fix duplicate scan dialog display

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1812,7 +1812,7 @@ int Ship::Scan(const PlayerInfo &player)
 					const double depth, const int event)
 	-> void
 	{
-		if(elapsed > SCAN_TIME)
+		if(elapsed >= SCAN_TIME)
 			return;
 		if(distanceSquared > scannerRangeSquared)
 			return;


### PR DESCRIPTION
**Bugfix:**

Thanks to @Amazinite for reporting this.

## Fix Details
Because of the exclusive inequality, a second scan dialog may be displayed after the first if the player presses the scan key again, after closing the first dialog. This shouldn't happen.

## Testing Done
Scanned a ship, closed the dialog, pressed the scan key again and no longer get the scan dialog repeated.
