### PR TITLE
feat(balance): Make the engine variants of the two marauder heavy warships less absurd

### DIFF
--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -282,22 +282,22 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 	sprite "ship/mfalcone"
 	thumbnail "thumbnail/mfalcone"
 	add attributes
-		"engine capacity" 55
+		"engine capacity" 25
 	outfits
 		"Electron Beam" 4
-		"Blaster Turret" 2
+		"Quad Blaster Turret" 2
 		"Modified Blaster Turret" 2
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
-		"D41-HY Shield Generator"
+		"D94-YV Shield Generator"
 		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 3
 		"Laser Rifle" 80
 		
 		"A860 Atomic Thruster"
-		"A865 Atomic Steering"
+		"A525 Atomic Steering"
 		"Hyperdrive"
 	
 	engine -23.5 140 .7
@@ -309,8 +309,8 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 	gun 19 -76.5 "Electron Beam"
 	turret -16 -29 "Modified Blaster Turret"
 	turret 16 -29 "Modified Blaster Turret"
-	turret -50 39.5 "Blaster Turret"
-	turret 50 39.5 "Blaster Turret"
+	turret -50 39.5 "Quad Blaster Turret"
+	turret 50 39.5 "Quad Blaster Turret"
 	description "Whoever modified this Falcon clearly valued speed above all else. Major sections of the hull have been reconfigured to accommodate the largest possible engines. If hot-rodding across the galaxy in a 1000-ton warship that handles like a Flivver is your dream, look no further."
 
 
@@ -531,7 +531,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 	sprite "ship/mleviathane"
 	thumbnail "thumbnail/mleviathane"
 	add attributes
-		"engine capacity" 80
+		"engine capacity" 40
 	outfits
 		"Electron Beam" 4
 		"Quad Blaster Turret" 4
@@ -539,13 +539,14 @@ ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 		"Fusion Reactor"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
+		"D67-TM Shield Generator"
 		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion" 2
 		"Laser Rifle" 69
 		
-		"A860 Atomic Thruster"
+		"A520 Atomic Thruster"
 		"A865 Atomic Steering"
 		"Hyperdrive"
 	


### PR DESCRIPTION
**Balance:**

## Summary
Reduced the engine space of the Marauder Falcon (Engines) by 30, and reduced the engine space of the Marauder Leviathan (Engines) by 40. The Marauder Falcon (Engines) keeps its A860 thruster, but downgrades its steering to A525, while the Marauder Leviathan (Engines) does the reverse - downgrading its thruster to A520, but keeping the A865 steering. The Falcon has the option to run either setup, the Leviathan cannot fit the A860 thruster without downgrading to A375 steering.

Also tweaked the other outfits to make use of the freed-up space and power - the engines Falcon upgrades its shield generator, and swaps its blaster turrets for quad blaster turrets, while the engines Leviathan adds a second shield generator.

## Reasoning
As noted in #8124, the two engines marauder heavy warships are just too fast. They're even faster than the engines marauder light and medium warships, only beaten by the Dagger and the engines marauder Arrow.
The Leviathan gets slightly less engine space than the Falcon, because the Leviathan has more HP and more outfit space, and because the Falcon is supposed to be a faster ship than the Leviathan.

The tweaks to the other outfits mainly focus on adding more shield regen, because it makes sense to me that these ships would be most effective in a hit-and-run role, and adding regen supports that. The Marauder Falcon was upgunned because it had more than 100 weapon space free, which just felt wrong.

## Save File
Any save file with enough combat rating to spawn high-level marauders should work.