### PR TITLE
fix(ui): Always clear orbits view storage

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -809,6 +809,7 @@ void MapDetailPanel::DrawInfo()
 // Draw the planet orbits in the currently selected system, on the current day.
 void MapDetailPanel::DrawOrbits()
 {
+	planets.clear();
 	const Sprite *orbitSprite = SpriteSet::Get("ui/orbits and key");
 	SpriteShader::Draw(orbitSprite, Screen::TopRight() + .5 * Point(-orbitSprite->Width(), orbitSprite->Height()));
 	Point orbitCenter = Screen::TopRight() + Point(-120., 160.);
@@ -870,7 +871,6 @@ void MapDetailPanel::DrawOrbits()
 	}
 
 	// Draw the planets themselves.
-	planets.clear();
 	for(const StellarObject &object : selectedSystem->Objects())
 	{
 		if(object.Radius() <= 0.)


### PR DESCRIPTION
**Bugfix:** This PR fixes #9211.

## Fix Details
Currently, planet list used by the orbits view is cleared only if the system has been visited (see lines 816-817), which causes a bug described in the issue. Moving the clear command up fixes the problem.

## Testing Done
Works good both in visited and unvisited systems.