### PR TITLE
fix(ci): Fix false positive in content style checker

### DIFF
--- a/utils/contentStyle.json
+++ b/utils/contentStyle.json
@@ -117,7 +117,7 @@
 					},
 					{
 						"description": "incorrect indefinite article",
-						"regex": "((?:\\sa|^A))n ([^aAeEiIoOuUhH\\[\\]\"\\'\\d<\\-])",
+						"regex": "((?:\\sa|^A))n ([^aeiouhA-Z\\[\\]\"\\'\\d<\\-])",
 						"correction": {
 							"replaceWith": "\\1 \\2"
 						}


### PR DESCRIPTION
**Bugfix:** This PR addresses a false positive in the content style checker.

## Fix Details
Some abbreviations could trigger one of the checks. It's fixed now.
See https://discord.com/channels/251118043411775489/266345072554016768/1144277408892067971

## Testing Done
I checked in an online regex matcher thingy, it should be fine now.

## Save File
N/A