### PR TITLE
expanded planet label drawing

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -330,6 +330,7 @@ void Engine::Place()
 		Place(mission.NPCs(), flagship);
 
 	// Get the coordinates of the planet the player is leaving.
+	const System *system = player.GetSystem();
 	const Planet *planet = player.GetPlanet();
 	Point planetPos;
 	double planetRadius = 0.;
@@ -348,7 +349,7 @@ void Engine::Place()
 		Angle angle = Angle::Random();
 		// Any ships in the same system as the player should be either
 		// taking off from a specific planet or nearby.
-		if(ship->GetSystem() == player.GetSystem() && !ship->IsDisabled())
+		if(ship->GetSystem() == system && !ship->IsDisabled())
 		{
 			const Personality &person = ship->GetPersonality();
 			bool hasOwnPlanet = ship->GetPlanet();
@@ -372,7 +373,7 @@ void Engine::Place()
 		{
 			// Log this error.
 			Logger::LogError("Engine::Place: Set fallback system for the NPC \"" + ship->Name() + "\" as it had no system");
-			ship->SetSystem(player.GetSystem());
+			ship->SetSystem(system);
 		}
 
 		// If the position is still (0, 0), the special ship is in a different
@@ -392,6 +393,13 @@ void Engine::Place()
 	ships.splice(ships.end(), newShips);
 
 	player.SetPlanet(nullptr);
+
+	// Create the planet labels.
+	labels.clear();
+	if(system)
+		for(const StellarObject &object : system->Objects())
+			if(object.HasSprite() && object.HasValidPlanet() && object.GetPlanet()->IsAccessible(flagship.get()))
+				labels.emplace_back(labels, *system, object, zoom);
 }
 
 
@@ -658,20 +666,9 @@ void Engine::Step(bool isActive)
 				missileLabels.emplace_back(AlertLabel(pos, projectile, flagship, zoom));
 		}
 
-	// Create the planet labels.
-	labels.clear();
-	if(currentSystem && Preferences::Has("Show planet labels"))
-	{
-		for(const StellarObject &object : currentSystem->Objects())
-		{
-			if(!object.HasSprite() || !object.HasValidPlanet() || !object.GetPlanet()->IsAccessible(flagship.get()))
-				continue;
-
-			Point pos = object.Position() - center;
-			if(pos.Length() - object.Radius() < 600. / zoom)
-				labels.emplace_back(pos, object, currentSystem, zoom, labels);
-		}
-	}
+	// Update the planet label positions.
+	for(PlanetLabel &label : labels)
+		label.Update(center, zoom);
 
 	if(flagship && flagship->IsOverheated())
 		Messages::Add("Your ship has overheated.", Messages::Importance::Highest);
@@ -992,8 +989,9 @@ void Engine::Draw() const
 	const Interface *hud = GameData::Interfaces().Get("hud");
 
 	// Draw any active planet labels.
-	for(const PlanetLabel &label : labels)
-		label.Draw();
+	if(Preferences::Has("Show planet labels"))
+		for(const PlanetLabel &label : labels)
+			label.Draw();
 
 	draw[drawTickTock].Draw();
 	batchDraw[drawTickTock].Draw();

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -393,13 +393,6 @@ void Engine::Place()
 	ships.splice(ships.end(), newShips);
 
 	player.SetPlanet(nullptr);
-
-	// Create the planet labels.
-	labels.clear();
-	if(system)
-		for(const StellarObject &object : system->Objects())
-			if(object.HasSprite() && object.HasValidPlanet() && object.GetPlanet()->IsAccessible(flagship.get()))
-				labels.emplace_back(labels, *system, object, zoom);
 }
 
 
@@ -1362,6 +1355,13 @@ void Engine::EnterSystem()
 		Messages::Add(GameData::HelpMessage("basics 1"), Messages::Importance::High);
 		Messages::Add(GameData::HelpMessage("basics 2"), Messages::Importance::High);
 	}
+
+	// Create the planet labels.
+	labels.clear();
+	if(system)
+		for(const StellarObject &object : system->Objects())
+			if(object.HasSprite() && object.HasValidPlanet() && object.GetPlanet()->IsAccessible(flagship))
+				labels.emplace_back(labels, *system, object, zoom);
 }
 
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -669,7 +669,7 @@ void Engine::Step(bool isActive)
 
 			Point pos = object.Position() - center;
 			if(pos.Length() - object.Radius() < 600. / zoom)
-				labels.emplace_back(pos, object, currentSystem, zoom);
+				labels.emplace_back(pos, object, currentSystem, zoom, labels);
 		}
 	}
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1361,7 +1361,7 @@ void Engine::EnterSystem()
 	if(system)
 		for(const StellarObject &object : system->Objects())
 			if(object.HasSprite() && object.HasValidPlanet() && object.GetPlanet()->IsAccessible(flagship))
-				labels.emplace_back(labels, *system, object, zoom);
+				labels.emplace_back(labels, *system, object);
 }
 
 

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -47,10 +47,10 @@ namespace {
 	constexpr double MIN_DISTANCE = 30.;
 	constexpr double BORDER = 2.;
 
-	// Find the intersection of a ray and a box, both centered on the origin.
+	// Find the intersection of a ray and a rectangle, both centered on the origin.
 	Point GetOffset(const Point &unit, const Point &dimensions)
 	{
-		// Box ranges from (-width/2, -height/2) to (width/2, height/2).
+		// Rectangle ranges from (-width/2, -height/2) to (width/2, height/2).
 		const Point box = dimensions * .5;
 
 		// Check to avoid division by zero.
@@ -121,10 +121,10 @@ PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system
 	}
 
 	// Cache the offsets for both labels; center labels.
-	const Point offset = GetOffset(Angle(innerAngle).Unit(), box.Dimensions()) - box.Dimensions() * .5;
-	const double nameX = (box.Width() - bigFont.Width(name)) * .5;
+	const Point offset = GetOffset(Angle(innerAngle).Unit(), labelDimensions) - labelDimensions * .5;
+	const double nameX = (labelDimensions.X() - bigFont.Width(name)) * .5;
 	nameOffset = Point(offset.X() + nameX, offset.Y() + BORDER);
-	const double governmentX = (box.Width() - font.Width(government)) * .5;
+	const double governmentX = (labelDimensions.X() - font.Width(government)) * .5;
 	governmentOffset = Point(offset.X() + governmentX, nameOffset.Y() + nameHeight + 1.);
 }
 

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -55,13 +55,9 @@ namespace {
 		const Rectangle box = label + start + halfUnit * label.Width();
 
 		for(const StellarObject &other : system.Objects())
-		{
-			if(&other == &object)
-				continue;
-
-			if(box.Overlaps(other.Position() * zoom, other.Radius() * zoom + MIN_DISTANCE))
+			if(&other != &object && box.Overlaps(other.Position() * zoom,
+					other.Radius() * zoom + MIN_DISTANCE))
 				return true;
-		}
 
 		return false;
 	}
@@ -95,9 +91,9 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 	if(!system)
 		return;
 
+	// Figure out how big the label has to be.
 	const Font &font = FontSet::Get(14);
 	const Font &bigFont = FontSet::Get(18);
-	// Figure out how big the label has to be.
 	const double width = max(bigFont.Width(name) + 4., font.Width(government) + 8.);
 	const double height = bigFont.Height() + 1. + font.Height();
 	// Adjust down so attachment point is at center of name.

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -170,6 +170,7 @@ void PlanetLabel::Draw() const
 		const Point to = from + unit * LINE_LENGTH;
 		LineShader::Draw(from, to, 1.3f, labelColor);
 
+		// Use non-rounding version to prevent labels from jittering.
 		FontSet::Get(18).DrawAliased(name, to.X() + nameOffset.X(),
 			to.Y() + nameOffset.Y(), labelColor);
 		FontSet::Get(14).DrawAliased(government, to.X() + governmentOffset.X(),

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -66,8 +66,7 @@ namespace {
 
 
 
-PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system,
-		const StellarObject &object, const double zoom)
+PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system, const StellarObject &object)
 	: objectPosition(object.Position()), objectRadius(object.Radius())
 {
 	const Planet &planet = *object.GetPlanet();
@@ -108,19 +107,6 @@ PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system
 			break;
 		}
 	}
-
-	// If we can't find a suitable direction, then try to find a direction under the current
-	// zoom that is not overlapping.
-	if(!innerAngle)
-		for(const double angle : LINE_ANGLES)
-		{
-			SetBoundingBox(labelDimensions, angle, nameHeight);
-			if(!CheckOverlaps(labels, system, object, zoom, GetBoundingBox(zoom)))
-			{
-				innerAngle = angle;
-				break;
-			}
-		}
 
 	// No good choices, so set this to the default.
 	if(!innerAngle)

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -38,7 +38,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	// Label offset angles, in order of preference.
+	// Label offset angles, in order of preference (non-negative only).
 	constexpr array<double, 8> LINE_ANGLES = {60., 120., 300., 240., 30., 150., 330., 210.};
 	constexpr double LINE_LENGTH = 60.;
 	constexpr double INNER_SPACE = 10.;
@@ -103,7 +103,7 @@ PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system
 	const bool bottomSide = 135. < innerAngle && innerAngle < 225.;
 
 	// Have to adjust the more extreme angles differently or it looks bad.
-	const double yOffset = topSide ? nameHeight * .75 : bottomSide ? nameHeight * .25 : nameHeight * .5;
+	const double yOffset = (topSide ? .75 : bottomSide ? .25 : .5) * nameHeight;
 
 	// Cache the offsets for both labels.
 	nameOffset = Point(rightSide ? 2. : -bigFont.Width(name) - 2., -yOffset);
@@ -173,8 +173,8 @@ void PlanetLabel::SetBoundingBox(const Point &labelDimensions, const double angl
 	const bool bottomSide = 135. < angle && angle < 225.;
 
 	// Offset the label depending on its position relative to the stellar object.
-	const double xOffset = (rightSide ? labelDimensions.X() : -labelDimensions.X()) * 0.5;
-	const double yOffset = topSide ? nameHeight * .75 : bottomSide ? nameHeight * .25 : nameHeight * .5;
+	const double xOffset = (rightSide ? .5 : -.5) * labelDimensions.X();
+	const double yOffset = (topSide ? .75 : bottomSide ? .25 : .5) * nameHeight;
 	box = Rectangle(unit * (INNER_SPACE + LINE_GAP + LINE_LENGTH) +
 		Point(xOffset, labelDimensions.Y() * .5 - yOffset), labelDimensions);
 }

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -164,7 +164,7 @@ void PlanetLabel::Draw() const
 		PointerShader::Draw(position, barbAngle.Unit(), 15.f, 15.f, barbRadius, labelColor);
 	}
 
-	// Draw planet label, if any.
+	// Draw planet name label, if any.
 	if(!name.empty())
 	{
 		const Point unit = Angle(innerAngle).Unit();

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -104,7 +104,7 @@ PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system
 	for(const double angle : LINE_ANGLES)
 	{
 		SetBoundingBox(labelDimensions, angle);
-		if(allZooms.end() == find_if(allZooms.begin(), allZooms.end(),
+		if(none_of(allZooms.begin(), allZooms.end(),
 				[&](const double zoom)
 				{
 					return HasOverlaps(labels, system, object, zoom);

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -44,8 +44,8 @@ namespace {
 	constexpr double GAP = 6.;
 	constexpr double MIN_DISTANCE = 30.;
 
-	// Check if the given label for the given stellar object and direction overlaps
-	// with any existing label or any stellar object in the system.
+	// Check if the label for the given stellar object overlaps
+	// with any existing label or any other stellar object in the system.
 	bool CheckOverlaps(const vector<PlanetLabel> &labels, const System &system,
 			const StellarObject &object, const double zoom, const Rectangle &box)
 	{
@@ -75,14 +75,13 @@ PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system
 	else if(planet.GetGovernment())
 	{
 		government = "(" + planet.GetGovernment()->GetName() + ")";
-		color = planet.GetGovernment()->GetColor();
-		color = Color(color.Get()[0] * .5f + .3f, color.Get()[1] * .5f + .3f, color.Get()[2] * .5f + .3f);
+		color = Color::Combine(.5f, planet.GetGovernment()->GetColor(), .3f, Color());
 		if(!planet.CanLand())
 			hostility = 3 + 2 * planet.GetGovernment()->IsEnemy();
 	}
 	else
 	{
-		color = Color(.3f, .3f, .3f, 1.f);
+		color = Color(.3f);
 		government = "(No government)";
 	}
 
@@ -99,7 +98,7 @@ PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system
 	// Try to find a label direction that is not overlapping under any zoom.
 	for(int d = 0; d < 4; ++d)
 	{
-		SetBoundingBox(label, object, d);
+		SetBoundingBox(label, d);
 		if(!CheckOverlaps(labels, system, object, minZoom, box + zoomOffset * minZoom)
 				&& !CheckOverlaps(labels, system, object, maxZoom, box + zoomOffset * maxZoom))
 		{
@@ -112,7 +111,7 @@ PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system
 	// zoom that is not overlapping.
 	for(int d = 0; d < 4; ++d)
 	{
-		SetBoundingBox(label, object, d);
+		SetBoundingBox(label, d);
 		if(!CheckOverlaps(labels, system, object, zoom, box + zoomOffset * zoom))
 		{
 			direction = d;
@@ -120,8 +119,8 @@ PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system
 		}
 	}
 
-	// No good choices, so reset this to the default.
-	SetBoundingBox(label, object, direction);
+	// No good choices, so set this to the default.
+	SetBoundingBox(label, direction);
 }
 
 
@@ -136,44 +135,45 @@ void PlanetLabel::Update(const Point &center, const double zoom)
 
 void PlanetLabel::Draw() const
 {
-	// Don't draw if too far away from center of screen.
+	// Don't draw if too far away from the center of the screen.
 	const double offset = position.Length() - radius;
 	if(offset >= 600.)
 		return;
 
 	// Fade label as we get farther from the center of the screen.
-	const float alpha = static_cast<float>(min(.5, max(0., .6 - offset * .001)));
-	const Color labelColor = Color(color.Get()[0] * alpha, color.Get()[1] * alpha, color.Get()[2] * alpha, 0.);
-
-	// Draw any active planet labels.
-	const Font &font = FontSet::Get(14);
-	const Font &bigFont = FontSet::Get(18);
+	const Color labelColor = color.Additive(min(.5, .6 - offset * .001));
 
 	// The angle of the outer ring should be reduced by just enough that the
-	// circumference is reduced by 6 pixels.
-	double innerAngle = LINE_ANGLE[direction];
-	double outerAngle = innerAngle - 360. * GAP / (2. * PI * radius);
-	Point unit = Angle(innerAngle).Unit();
+	// circumference is reduced by GAP pixels.
+	const double innerAngle = LINE_ANGLE[direction];
+	const double outerAngle = innerAngle - 360. * GAP / (2. * PI * radius);
+	const Point unit = Angle(innerAngle).Unit();
 	RingShader::Draw(position, radius + INNER_SPACE, 2.3f, .9f, labelColor, 0.f, innerAngle);
 	RingShader::Draw(position, radius + INNER_SPACE + GAP, 1.3f, .6f, labelColor, 0.f, outerAngle);
 
+	// Draw any active planet labels.
 	if(!name.empty())
 	{
-		Point from = position + (radius + INNER_SPACE + LINE_GAP) * unit;
-		Point to = from + LINE_LENGTH * unit;
+		const Point from = position + (radius + INNER_SPACE + LINE_GAP) * unit;
+		const Point to = from + LINE_LENGTH * unit;
 		LineShader::Draw(from, to, 1.3f, labelColor);
 
-		double nameX = to.X() + (direction < 2 ? 2. : -bigFont.Width(name) - 2.);
-		bigFont.DrawAliased(name, nameX, to.Y() - .5 * bigFont.Height(), labelColor);
+		const Font &bigFont = FontSet::Get(18);
+		const double halfHeight = bigFont.Height() * .5;
+		const double nameX = to.X() + (direction < 2 ? 2. : -bigFont.Width(name) - 2.);
+		bigFont.DrawAliased(name, nameX, to.Y() - halfHeight, labelColor);
 
-		double governmentX = to.X() + (direction < 2 ? 4. : -font.Width(government) - 4.);
-		font.DrawAliased(government, governmentX, to.Y() + .5 * bigFont.Height() + 1., labelColor);
+		const Font &font = FontSet::Get(14);
+		const double governmentX = to.X() + (direction < 2 ? 4. : -font.Width(government) - 4.);
+		font.DrawAliased(government, governmentX, to.Y() + halfHeight + 1., labelColor);
 	}
+
+	const double barbRadius = radius + 25.;
 	Angle barbAngle(innerAngle + 36.);
 	for(int i = 0; i < hostility; ++i)
 	{
-		barbAngle += Angle(800. / (radius + 25.));
-		PointerShader::Draw(position, barbAngle.Unit(), 15.f, 15.f, radius + 25., labelColor);
+		barbAngle += Angle(800. / barbRadius);
+		PointerShader::Draw(position, barbAngle.Unit(), 15.f, 15.f, barbRadius, labelColor);
 	}
 }
 
@@ -181,17 +181,17 @@ void PlanetLabel::Draw() const
 
 bool PlanetLabel::Overlaps(const Rectangle &otherBox, const double zoom) const
 {
-	return (box + zoom * zoomOffset).Overlaps(otherBox);
+	return (box + zoomOffset * zoom).Overlaps(otherBox);
 }
 
 
 
-void PlanetLabel::SetBoundingBox(const Rectangle &label, const StellarObject &object, const int direction)
+void PlanetLabel::SetBoundingBox(const Rectangle &label, const int d)
 {
-	const Point unit = Angle(LINE_ANGLE[direction]).Unit();
-	zoomOffset = object.Position() + unit * object.Radius();
+	const Point unit = Angle(LINE_ANGLE[d]).Unit();
+	zoomOffset = objectPosition + unit * objectRadius;
 
 	// Offset the label depending on its position relative to the stellar object.
-	const Point halfUnit(LINE_ANGLE[direction] < 180. ? .5 : -.5, 0.);
+	const Point halfUnit(LINE_ANGLE[d] < 180. ? .5 : -.5, 0.);
 	box = label + unit * (INNER_SPACE + LINE_GAP + LINE_LENGTH) + halfUnit * label.Width();
 }

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -99,7 +99,7 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 	// Adjust down so attachment point is at center of name.
 	const Rectangle label({0., (height - bigFont.Height()) / 2.}, {width, height});
 
-	// Try to find a label direction that not overlapping under any zoom.
+	// Try to find a label direction that is not overlapping under any zoom.
 	for(int d = 0; d < 4; ++d)
 		if(!Overlaps(*system, object, Preferences::MinViewZoom(), label, d)
 				&& !Overlaps(*system, object, Preferences::MaxViewZoom(), label, d))

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -36,21 +36,21 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	const double LINE_ANGLE[4] = {60., 120., 300., 240.};
-	const double LINE_LENGTH = 60.;
-	const double INNER_SPACE = 10.;
-	const double LINE_GAP = 1.7;
-	const double GAP = 6.;
-	const double MIN_DISTANCE = 30.;
+	constexpr double LINE_ANGLE[4] = {60., 120., 300., 240.};
+	constexpr double LINE_LENGTH = 60.;
+	constexpr double INNER_SPACE = 10.;
+	constexpr double LINE_GAP = 1.7;
+	constexpr double GAP = 6.;
+	constexpr double MIN_DISTANCE = 30.;
 
 	// Check if the given label for the given stellar object and direction overlaps
 	// with any other stellar object in the system.
 	bool Overlaps(const System &system, const StellarObject &object, const double zoom,
 			const Rectangle &label, const int direction)
 	{
-		const Point start = zoom * (object.Position() + Angle(LINE_ANGLE[direction]).Unit() *
-			(object.Radius() + INNER_SPACE + LINE_GAP + LINE_LENGTH));
-		// Offset the label depending on its location relative to the stellar object.
+		const Point start = zoom * object.Position() + Angle(LINE_ANGLE[direction]).Unit() *
+			(zoom * object.Radius() + INNER_SPACE + LINE_GAP + LINE_LENGTH);
+		// Offset the label depending on its position relative to the stellar object.
 		const Point halfUnit(LINE_ANGLE[direction] < 180. ? .5 : -.5, 0.);
 		const Rectangle box = label + start + halfUnit * label.Width();
 
@@ -89,7 +89,7 @@ PlanetLabel::PlanetLabel(const Point &position, const StellarObject &object, con
 		color = Color(.3f, .3f, .3f, 1.f);
 		government = "(No government)";
 	}
-	float alpha = static_cast<float>(min(.5, max(0., .6 - (position.Length() - object.Radius()) * .001 * zoom)));
+	const float alpha = static_cast<float>(min(.5, max(0., .6 - (position.Length() - object.Radius()) * .001 * zoom)));
 	color = Color(color.Get()[0] * alpha, color.Get()[1] * alpha, color.Get()[2] * alpha, 0.);
 
 	if(!system)

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -31,7 +31,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Wormhole.h"
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <vector>
 
@@ -39,7 +38,7 @@ using namespace std;
 
 namespace {
 	// Label offset angles, in order of preference (non-negative only).
-	constexpr array<double, 12> LINE_ANGLES = {60., 120., 300., 240., 30., 150., 330., 210., 90., 270., 0., 180.};
+	const vector<double> LINE_ANGLES = {60., 120., 300., 240., 30., 150., 330., 210., 90., 270., 0., 180.};
 	constexpr double LINE_LENGTH = 60.;
 	constexpr double INNER_SPACE = 10.;
 	constexpr double LINE_GAP = 1.7;
@@ -101,12 +100,15 @@ PlanetLabel::PlanetLabel(const vector<PlanetLabel> &labels, const System &system
 	const Point labelDimensions = {labelWidth + BORDER * 2., labelHeight + BORDER * 2.};
 
 	// Try to find a label direction that is not overlapping under any zoom.
-	const double minZoom = Preferences::MinViewZoom();
-	const double maxZoom = Preferences::MaxViewZoom();
+	const vector<double> &allZooms = Preferences::Zooms();
 	for(const double angle : LINE_ANGLES)
 	{
 		SetBoundingBox(labelDimensions, angle);
-		if(!HasOverlaps(labels, system, object, minZoom) && !HasOverlaps(labels, system, object, maxZoom))
+		if(allZooms.end() == find_if(allZooms.begin(), allZooms.end(),
+				[&](const double zoom)
+				{
+					return HasOverlaps(labels, system, object, zoom);
+				}))
 		{
 			innerAngle = angle;
 			break;

--- a/source/PlanetLabel.cpp
+++ b/source/PlanetLabel.cpp
@@ -38,7 +38,7 @@ using namespace std;
 
 namespace {
 	// Label offset angles, in order of preference (non-negative only).
-	const vector<double> LINE_ANGLES = {60., 120., 300., 240., 30., 150., 330., 210., 90., 270., 0., 180.};
+	constexpr double LINE_ANGLES[] = {60., 120., 300., 240., 30., 150., 330., 210., 90., 270., 0., 180.};
 	constexpr double LINE_LENGTH = 60.;
 	constexpr double INNER_SPACE = 10.;
 	constexpr double LINE_GAP = 1.7;

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -49,7 +49,7 @@ private:
 	Point objectPosition;
 	double objectRadius;
 
-	// Bounding box = box + zoomOffset * zoom; only used for overlap detection.
+	// Used for overlap detection during label creation.
 	Rectangle box;
 	Point zoomOffset;
 

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -41,14 +41,15 @@ public:
 
 
 private:
-	void SetBoundingBox(const Rectangle &label, int direction);
+	void SetBoundingBox(const Point &labelDimensions, double angle, int nameHeight);
+	Rectangle GetBoundingBox(double zoom) const;
 
 
 private:
 	Point objectPosition;
 	double objectRadius;
 
-	// Bounding box = box + zoomOffset * zoom.
+	// Bounding box = box + zoomOffset * zoom; only used for overlap detection.
 	Rectangle box;
 	Point zoomOffset;
 
@@ -58,9 +59,11 @@ private:
 
 	std::string name;
 	std::string government;
+	Point nameOffset;
+	Point governmentOffset;
 	Color color;
 	int hostility = 0;
-	int direction = 0;
+	double innerAngle = 0.;
 };
 
 

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -41,17 +41,21 @@ public:
 
 
 private:
-	void SetBoundingBox(const Rectangle &label, const StellarObject &object, int direction);
+	void SetBoundingBox(const Rectangle &label, int direction);
 
 
 private:
 	Point objectPosition;
 	double objectRadius;
-	// box + zoom * zoomOffset = the label's boundary box, as drawn.
-	Point zoomOffset;
+
+	// Bounding box = box + zoomOffset * zoom.
 	Rectangle box;
+	Point zoomOffset;
+
+	// Position and radius for drawing label.
 	Point position;
-	double radius = 0.;
+	double radius;
+
 	std::string name;
 	std::string government;
 	Color color;

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -39,7 +39,7 @@ public:
 
 private:
 	// Overlap detection.
-	void SetBoundingBox(const Point &labelDimensions, double angle, int nameHeight);
+	void SetBoundingBox(const Point &labelDimensions, double angle);
 	Rectangle GetBoundingBox(double zoom) const;
 	bool HasOverlaps(const std::vector<PlanetLabel> &labels, const System &system,
 		const StellarObject &object, double zoom) const;

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -47,7 +47,7 @@ private:
 
 private:
 	Point objectPosition;
-	double objectRadius;
+	double objectRadius = 0.;
 
 	// Used for overlap detection during label creation.
 	Rectangle box;
@@ -55,7 +55,7 @@ private:
 
 	// Position and radius for drawing label.
 	Point position;
-	double radius;
+	double radius = 0.;
 
 	std::string name;
 	std::string government;

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -63,7 +63,7 @@ private:
 	Point governmentOffset;
 	Color color;
 	int hostility = 0;
-	double innerAngle = 0.;
+	double innerAngle = -1.;
 };
 
 

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -30,8 +30,10 @@ class System;
 
 class PlanetLabel {
 public:
-	PlanetLabel(const Point &position, const StellarObject &object, const System *system, double zoom,
-		const std::vector<PlanetLabel> &labels);
+	PlanetLabel(const std::vector<PlanetLabel> &labels, const System &system,
+		const StellarObject &object, double zoom);
+
+	void Update(const Point &center, double zoom);
 
 	void Draw() const;
 
@@ -43,10 +45,12 @@ private:
 
 
 private:
-	Point position;
+	Point objectPosition;
+	double objectRadius;
 	// box + zoom * zoomOffset = the label's boundary box, as drawn.
 	Point zoomOffset;
 	Rectangle box;
+	Point position;
 	double radius = 0.;
 	std::string name;
 	std::string government;

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -18,8 +18,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Color.h"
 #include "Point.h"
+#include "Rectangle.h"
 
 #include <string>
+#include <vector>
 
 class StellarObject;
 class System;
@@ -28,13 +30,23 @@ class System;
 
 class PlanetLabel {
 public:
-	PlanetLabel(const Point &position, const StellarObject &object, const System *system, double zoom);
+	PlanetLabel(const Point &position, const StellarObject &object, const System *system, double zoom,
+		const std::vector<PlanetLabel> &labels);
 
 	void Draw() const;
+
+	bool Overlaps(const Rectangle &box, double zoom) const;
+
+
+private:
+	void SetBoundingBox(const Rectangle &label, const StellarObject &object, int direction);
 
 
 private:
 	Point position;
+	// box + zoom * zoomOffset = the label's boundary box, as drawn.
+	Point zoomOffset;
+	Rectangle box;
 	double radius = 0.;
 	std::string name;
 	std::string government;

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -30,8 +30,7 @@ class System;
 
 class PlanetLabel {
 public:
-	PlanetLabel(const std::vector<PlanetLabel> &labels, const System &system,
-		const StellarObject &object, double zoom);
+	PlanetLabel(const std::vector<PlanetLabel> &labels, const System &system, const StellarObject &object);
 
 	void Update(const Point &center, double zoom);
 

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -36,12 +36,13 @@ public:
 
 	void Draw() const;
 
-	bool Overlaps(const Rectangle &box, double zoom) const;
-
 
 private:
+	// Overlap detection.
 	void SetBoundingBox(const Point &labelDimensions, double angle, int nameHeight);
 	Rectangle GetBoundingBox(double zoom) const;
+	bool HasOverlaps(const std::vector<PlanetLabel> &labels, const System &system,
+		const StellarObject &object, double zoom) const;
 
 
 private:

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -358,6 +358,13 @@ double Preferences::MaxViewZoom()
 
 
 
+const vector<double> &Preferences::Zooms()
+{
+	return ZOOMS;
+}
+
+
+
 // Starfield parallax.
 void Preferences::ToggleParallax()
 {

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 
 
@@ -106,6 +107,7 @@ public:
 	static bool ZoomViewOut();
 	static double MinViewZoom();
 	static double MaxViewZoom();
+	static const std::vector<double> &Zooms();
 
 	static void ToggleScreenMode();
 	static const std::string &ScreenModeSetting();

--- a/source/Rectangle.cpp
+++ b/source/Rectangle.cpp
@@ -15,6 +15,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Rectangle.h"
 
+#include <algorithm>
+
+using namespace std;
+
 
 
 // Construct a rectangle by specifying the two corners rather than the

--- a/source/Rectangle.cpp
+++ b/source/Rectangle.cpp
@@ -200,6 +200,6 @@ bool Rectangle::Overlaps(const Point &circle, const double radius) const
 	if(Contains(circle))
 		return true;
 
-	const Point closest = {min(Left(), max(Right(), circle.X())), min(Top(), max(Bottom(), circle.Y()))};
+	const Point closest = {max(Left(), min(Right(), circle.X())), max(Top(), min(Bottom(), circle.Y()))};
 	return (circle - closest).LengthSquared() < radius * radius;
 }

--- a/source/Rectangle.cpp
+++ b/source/Rectangle.cpp
@@ -187,3 +187,15 @@ bool Rectangle::Overlaps(const Rectangle &other) const
 {
 	return !(other.Left() > Right() || other.Right() < Left() || other.Top() > Bottom() || other.Bottom() < Top());
 }
+
+
+
+bool Rectangle::Overlaps(const Point &circle, const double radius) const
+{
+	// Handle case where circle is entirely within rectangle.
+	if(Contains(circle))
+		return true;
+
+	const Point closest = {min(Left(), max(Right(), circle.X())), min(Top(), max(Bottom(), circle.Y()))};
+	return (circle - closest).LengthSquared() < radius * radius;
+}

--- a/source/Rectangle.cpp
+++ b/source/Rectangle.cpp
@@ -200,6 +200,6 @@ bool Rectangle::Overlaps(const Point &circle, const double radius) const
 	if(Contains(circle))
 		return true;
 
-	const Point closest = {max(Left(), min(Right(), circle.X())), max(Top(), min(Bottom(), circle.Y()))};
+	const Point closest = Point(max(Left(), min(Right(), circle.X())), max(Top(), min(Bottom(), circle.Y())));
 	return (circle - closest).LengthSquared() < radius * radius;
 }

--- a/source/Rectangle.h
+++ b/source/Rectangle.h
@@ -65,7 +65,7 @@ public:
 	bool Contains(const Rectangle &other) const;
 	// Check if the given rectangle overlaps with this one.
 	bool Overlaps(const Rectangle &other) const;
-	// Check if given circle overlaps with this rectangle.
+	// Check if the given circle overlaps with this rectangle.
 	bool Overlaps(const Point &center, double radius) const;
 
 

--- a/source/Rectangle.h
+++ b/source/Rectangle.h
@@ -65,6 +65,8 @@ public:
 	bool Contains(const Rectangle &other) const;
 	// Check if the given rectangle overlaps with this one.
 	bool Overlaps(const Rectangle &other) const;
+	// Check if given circle overlaps with this rectangle.
+	bool Overlaps(const Point &center, double radius) const;
 
 
 private:


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #9181

## Feature Details
This extends some of the changes made in #9181.  Most of the code changes shown here are already in that PR.  Only the last 3 or so commits (at submission time (more now ;)) go beyond that.

Planet labels can now be drawn at any angle, and the list of angles has been expanded to include the cardinal directions.  The labels are centered rather than left/right justified.  Every zoom level is checked for overlaps.

## UI Screenshots
Possible Label Positions Before 9181:
![Screenshot from 2023-08-22 15-10-49](https://github.com/endless-sky/endless-sky/assets/11161996/a68c2999-c88f-4428-9cbc-c4375df04d80)
Possible Label Positions After 9181:
![Screenshot from 2023-08-22 15-09-36](https://github.com/endless-sky/endless-sky/assets/11161996/7b52b673-4393-42de-8138-79df4f9c623d)
Possible Label Positions After This:
![Screenshot from 2023-08-24 15-01-01](https://github.com/endless-sky/endless-sky/assets/11161996/bd97bf15-c7ab-4829-8641-3fd717b30abc)
Centering of labels when government is the longer string:
![Screenshot from 2023-08-24 15-02-30](https://github.com/endless-sky/endless-sky/assets/11161996/35de3c38-6f7c-4f0e-b8dd-c0f71c39c57b)
Labels with no government:
![Screenshot from 2023-08-24 15-00-03](https://github.com/endless-sky/endless-sky/assets/11161996/bd6c8ae6-d296-4712-aa3a-1b6185eaa3ac)
How it looks in practice:
![Screenshot from 2023-08-24 15-04-30](https://github.com/endless-sky/endless-sky/assets/11161996/8bf83fb9-56d2-4cea-80cc-e82bb7381f99)

## Performance Impact
Not too much, given that this only affects the label offset calculation, which is done once, on system entry.  Even with checking all zoom levels, going into a ringworld system, the delay is imperceptable on my system.  The drawing routines are untouched.