### PR TITLE
Fix dependency update logic to fix future updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,10 @@ set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
 
 # Setup vcpkg.
 if(ES_USE_VCPKG)
+	set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+		CACHE STRING "Vcpkg toolchain file")
 	# No need to bootstrap vcpkg if the toolchain file is explictly provided.
-	if(NOT CMAKE_TOOLCHAIN_FILE)
+	if(CMAKE_TOOLCHAIN_FILE STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
 		include(utils/vcpkg_bootstrap.cmake)
 		x_vcpkg_bootstrap()
 	endif()
@@ -35,8 +37,6 @@ if(ES_USE_VCPKG)
 	set(VCPKG_INSTALL_OPTIONS "--no-print-usage")
 	set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 	set(X_VCPKG_APPLOCAL_DEPS_INSTALL ON)
-	set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-		CACHE STRING "Vcpkg toolchain file")
 endif()
 
 if(NOT ES_USE_SYSTEM_LIBRARIES)


### PR DESCRIPTION
## Details

The logic to properly update the dependencies was a bit broken, which meant that any dependency update didn't properly register and you had to remove the build folder for it to initialize properly if dependencies were updated.

This PR fixes this problem, so that any future dependency updates works seamlessly.  