### PR TITLE
Change the colour of the flagship in the player info ship list

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -25,7 +25,7 @@ color "faint" .1 .1 .1 0.
 color "dark" .05 .05 .05 0.
 
 # Colors used for drawing ship list in player info panel.
-color "flagship" .5 .5 .1 0.
+color "flagship" 0. 1. .35 0.
 color "disabled" .5 .3 .1 0.
 color "dead" .4 0. 0. 0.
 


### PR DESCRIPTION
**UI** #9212

## Summary
Changes the colour used for the flagship in the ship list in the player info panel from an orange/yellow colour to a bright green.
The currently used colour is close to the new "info" priority message colour. The difference is because the other text colours used in the player info panel are transparent, being drawn additively including the colour of the background (~ 0.157, 0.157, 0.157) while the message text is opaque, not including the background colour (not that that would make much difference when the background is mostly black.)
Alternatively, we could make the `"flagship"` colour used for text in the player info panel opaque and use exactly the same colour as the info priority messages.

## Screenshots:
![image](https://github.com/endless-sky/endless-sky/assets/20605679/444f1ef3-602f-4ac0-bb39-21448a953bb6)
The second ships is disabled but I've changed the disabled colour to the current flagship colour so you can compare the two.
The alternative opaque colour:
![image](https://github.com/endless-sky/endless-sky/assets/20605679/9ad891b5-a73f-4939-b84e-cc5fd7806343)

