### PR TITLE
Undeprecated the simple "fighters <name>" syntax

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -87,14 +87,10 @@ void Fleet::Load(const DataNode &node)
 			government = GameData::Governments().Get(child.Token(1));
 		else if(key == "names" && hasValue)
 			names = GameData::Phrases().Get(child.Token(1));
-		else if(key == "fighters" && hasValue)
+		else if(key == "fighters" && (hasValue || child.HasChildren()))
 		{
-			fighterNames = GameData::Phrases().Get(child.Token(1));
-			if(child.HasChildren())
-				child.PrintTrace("Warning: Skipping unused children of \"fighters\" tag:");
-		}
-		else if(key == "fighters" && child.HasChildren())
-		{
+			if(hasValue)
+				fighterNames = GameData::Phrases().Get(child.Token(1));
 			for(const DataNode &grand : child)
 			{
 				const string &fighterKey = grand.Token(0);

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -90,8 +90,8 @@ void Fleet::Load(const DataNode &node)
 		else if(key == "fighters" && hasValue)
 		{
 			fighterNames = GameData::Phrases().Get(child.Token(1));
-			child.PrintTrace("Warning: Deprecated use of \"fighters\" <names>."
-				" Use \"names\" <names> node under \"fighters\" instead.");
+			if(child.HasChildren())
+				child.PrintTrace("Warning: Skipping unused children of \"fighters\" tag:");
 		}
 		else if(key == "fighters" && child.HasChildren())
 		{


### PR DESCRIPTION
## Details

Undeprecates the simple fighter name syntax that got deprecated in #9029:

```
fleet "some fleet"
    "fighters" <name> # no longer deprecated
```

The reason being is that using the longer form is unnecessary if you don't need your fighters to have a different personality than the parent. ~~I've also added a warning if somebody tries to use both syntax types together.~~

## Testing Done

Verified that the deprecated warning isn't showing up anymore.