### PR TITLE
Tweaks to the build instructions

### DIFF
--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -6,35 +6,38 @@ First you need a copy of the code (if you intend on working on the game, use you
 > git clone https://github.com/endless-sky/endless-sky
 ```
 
-The game's root directory, where your `git clone`d files reside, will be your starting point for compiling the game.
+The game's root directory, where your `git clone`d files reside, will be your starting point for compiling the game. You can use `cd endless-sky` to enter the game's directory.
 
-Next, you will need to install a couple of dependencies to build the game. There are several different ways to build Endless Sky, depending on your operating system and preference. As an IDE, we recommend using [Visual Studio Code](#visual-studio-code).
+Next, you will need to install a couple of dependencies to build the game. There are several different ways to build Endless Sky, depending on your operating system and preference.
 
 - [Windows](#windows)
 - [Windows (MinGW)](#windows-mingw)
 - [MacOS](#macos)
 - [Linux](#linux)
 
+## Installing build dependencies
 
-## Windows
+### Windows
 
 It is recommended to use the toolchain from Visual Studio to build the game (regardless of the IDE you wish to use).
 
-Download Visual Studio (if you do not want to install Visual Studio, you can alternatively download the VS Build Tools), and make sure to install the following components:
+Download [Visual Studio](https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022) (if you do not want to install Visual Studio, you can alternatively download the [VS Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)), and make sure to install the following components:
 
 - "Desktop Development with C++",
 - "C++ Clang Compiler for Windows",
 - "C++ CMake tools for Windows".
 
-## Windows (MinGW)
+It is recommended to use at least the version from 2022.
+
+### Windows (MinGW)
   
 You can download the [MinGW Winlibs](https://winlibs.com/#download-release) build, which also includes various tools you'll need to build the game as well. It is possible to use other MinGW distributions too (like Msys2 for example).
 
 You'll need the POSIX version of MinGW. For the Winlibs distribution mentioned above, the latest version is currently gcc 13 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-16.0.6-11.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64ucrt-11.0.0-r1.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it to the list).
 
-You will also need to install [CMake](https://cmake.org/download/) (if you don't already have it).
+You will also need to install a recent version of [CMake](https://cmake.org/download/). You can check if you have CMake already installed by running `cmake -v` in command line window.
 
-## MacOS
+### MacOS
 
 Install [Homebrew](https://brew.sh). Once it is installed, use it to install the tools and libraries you will need:
 
@@ -46,7 +49,7 @@ $ brew install cmake ninja mad libpng jpeg-turbo sdl2
 
 If you want to build the libraries from source instead of using Homebrew, you can pass `-DES_USE_SYSTEM_LIBRARIES=OFF` to CMake when configuring.
 
-## Linux
+### Linux
 
 You will need at least CMake 3.21. You can get the latest version from the [offical website](https://cmake.org/download/).
 
@@ -72,20 +75,23 @@ gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL
 
 </details>
 
-## Building from the command line
+## Building the game
+
+Most IDEs have CMake support, and can be used to build the game. We recommend using [Visual Studio Code](#visual-studio-code).
+
+### Building from the command line
 
 Here's a summary of every command you will need for development:
 
 ```bash
 $ cmake --preset <preset>                     # configure project (only needs to be done once)
-$ cmake --build --preset <preset>-debug       # actually build Endless Sky (as well as any tests)
-$ ./build/<preset>/Debug/endless-sky          # run the game
+$ cmake --build --preset <preset>-debug       # build Endless Sky (as well as any tests)
 $ ctest --preset <preset>-test                # run the unit tests
 $ ctest --preset <preset>-benchmark           # run the benchmarks
 $ ctest --preset <preset>-integration         # run the integration tests (Linux only)
 ```
 
-If you'd like to debug a specific integration test (on any OS), you can do so as follows:
+The executable will be located in `build/<preset>/Debug/`. If you'd like to debug a specific integration test (on any OS), you can do so as follows:
 
 ```bash
 $ ctest --preset <preset>-integration-debug -R <name>
@@ -97,21 +103,21 @@ You can get a list of integration tests with `ctest --preset <preset>-integratio
 
 Replace `<preset>` with one of the following presets:
 
-- Windows: `clang-cl` (builds with Clang for Windows), `mingw` (builds with MinGW)
+- Windows: `clang-cl` (builds with Clang for Windows), `mingw` (builds with MinGW), `mingw32` (builds with x86 MinGW)
 - MacOS: `macos` or `macos-arm` (builds with the default compiler, for x64 and ARM64 respectively)
 - Linux: `linux` (builds with the default compiler)
 
-## Using an IDE
+### Using an IDE
 
-### Visual Studio Code
+#### Visual Studio Code
 
-Install the [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) and [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) extensions, and open the project folder under File -> Open Folder.
+After installing VS Code, install the [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) and [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) extensions, and open the project folder under File -> Open Folder.
 
 You'll be asked to select a preset. Select the one you want (see the list above in the previous section for help). If you get asked to configure the project, click on Yes. You can use the bar at the very bottom to select between different configurations (Debug/Release), build, start the game, and execute the unit tests. On the left you can click on the test icon to run individual integration tests.
 
-### Visual Studio
+#### Visual Studio
 
-It is recommened to use Visual Studio 2022, because of its better CMake integration. Once you have installed Visual Studio, you can simply open the root folder.
+It is recommened to use [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022), because of its better CMake integration. Once you have installed Visual Studio, you can simply open the root folder.
 
 <details>
 <summary>Step-by-step instructions for Visual Studio 2022+</summary>
@@ -134,17 +140,17 @@ If you are on an earlier version of Visual Studio, or would like to use an actua
 
 This will create a Visual Studio 2022 solution. If you are using an older version of VS, you will need to adjust the version. Now you will find a complete solution in the `build/` folder. Find the solution and open it and you're good to go!
 
-### Building with Code::Blocks
+#### Code::Blocks
 
-If you want to use the Code::Blocks IDE, from the root of the project folder execute:
+If you want to use the [Code::Blocks](https://www.codeblocks.org/downloads/) IDE, from the root of the project folder execute:
 
 ```powershell
 > cmake -G"CodeBlocks - Ninja" --preset <preset>
 ```
 
-With `<preset>` being one of the available presets (see above for a list). For Windows for example you'd want `mingw`. Now there will be a Code::Blocks project inside `build\mingw`.
+With `<preset>` being one of the available presets (see above for a list). For Windows for example you'd want `clang-cl` or `mingw`. Now there will be a Code::Blocks project inside `build\mingw`.
 
-### Building with XCode
+#### XCode
 
 If you want to use the XCode IDE, from the root of the project folder execute:
 

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -55,7 +55,7 @@ This will create a Visual Studio 2022 solution. If you are using an older versio
   
 You can download the [MinGW Winlibs](https://winlibs.com/#download-release) build, which also includes various tools you'll need to build the game as well. It is possible to use other MinGW distributions too (like Msys2 for example).
 
-You'll need the 64-bit MSVCRT runtime version of MinGW. For the Winlibs distribution mentioned above, the latest version is currently gcc 13 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/13.1.0-16.0.5-11.0.0-msvcrt-r5/winlibs-x86_64-posix-seh-gcc-13.1.0-mingw-w64msvcrt-11.0.0-r5.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it in the list).
+You'll need the POSIX version of MinGW. For the Winlibs distribution mentioned above, the latest version is currently gcc 13 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-16.0.6-11.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64ucrt-11.0.0-r1.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it in the list).
 
 You will also need to install [CMake](https://cmake.org/download/) (if you don't already have it).
 

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -77,8 +77,6 @@ gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL
 
 ## Building the game
 
-Most IDEs have CMake support, and can be used to build the game. We recommend using [Visual Studio Code](#visual-studio-code).
-
 ### Building from the command line
 
 Here's a summary of every command you will need for development:
@@ -109,6 +107,8 @@ Replace `<preset>` with one of the following presets:
 
 ### Using an IDE
 
+Most IDEs have CMake support, and can be used to build the game. We recommend using [Visual Studio Code](#visual-studio-code).
+
 #### Visual Studio Code
 
 After installing VS Code, install the [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) and [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) extensions, and open the project folder under File -> Open Folder.
@@ -120,7 +120,7 @@ You'll be asked to select a preset. Select the one you want (see the list above 
 It is recommened to use [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022), because of its better CMake integration. Once you have installed Visual Studio, you can simply open the root folder.
 
 <details>
-<summary>Step-by-step instructions for Visual Studio 2022+</summary>
+<summary>Step-by-step instructions for Visual Studio 2022 or later</summary>
 
 1. Open the repository's root folder using Visual Studio ("Open Folder")
 2. Wait while Visual Studio loads everything. This may take a few minutes the first time, but should be relatively fast on subsequent loads.

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -1,6 +1,6 @@
 # Build instructions
 
-First you need a copy of the code (if you intend on working on the game use your fork's URL here):
+First you need a copy of the code (if you intend on working on the game, use your fork's URL here):
 
 ```powershell
 > git clone https://github.com/endless-sky/endless-sky
@@ -55,7 +55,7 @@ This will create a Visual Studio 2022 solution. If you are using an older versio
   
 You can download the [MinGW Winlibs](https://winlibs.com/#download-release) build, which also includes various tools you'll need to build the game as well. It is possible to use other MinGW distributions too (like Msys2 for example).
 
-You'll need the POSIX version of MinGW. For the Winlibs distribution mentioned above, the latest version is currently gcc 13 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-16.0.6-11.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64ucrt-11.0.0-r1.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it in the list).
+You'll need the POSIX version of MinGW. For the Winlibs distribution mentioned above, the latest version is currently gcc 13 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-16.0.6-11.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64ucrt-11.0.0-r1.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it to the list).
 
 You will also need to install [CMake](https://cmake.org/download/) (if you don't already have it).
 

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -19,7 +19,7 @@ Next, you will need to install a couple of dependencies to build the game. There
 
 ### Windows
 
-We recommend to use the toolchain from Visual Studio to build the game (regardless of the IDE you wish to use).
+We recommend using the toolchain from Visual Studio to build the game (regardless of the IDE you wish to use).
 
 Download [Visual Studio](https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022) (if you do not want to install Visual Studio, you can alternatively download the [VS Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)), and make sure to install the following components:
 
@@ -27,7 +27,7 @@ Download [Visual Studio](https://visualstudio.microsoft.com/downloads/#visual-st
 - "C++ Clang Compiler for Windows",
 - "C++ CMake tools for Windows".
 
-We recommend to use at least the version from 2022. If you're unsure which edition to use, use the Community edition.
+We recommend using Visual Studio 2022 or newer. If you are unsure of which edition to use, choose Visual Studio Community.
 
 ### Windows (MinGW)
   
@@ -117,7 +117,7 @@ You'll be asked to select a preset. Select the one you want (see the list above 
 
 #### Visual Studio
 
-We recommend to use [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022), because of its better CMake integration. Once you have installed Visual Studio, you can simply open the root folder.
+We recommend using [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022) or newer, because of its better CMake integration. Once you have installed Visual Studio, you can simply open the root folder.
 
 <details>
 <summary>Step-by-step instructions for Visual Studio 2022 or later</summary>

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -35,7 +35,7 @@ You can download the [MinGW Winlibs](https://winlibs.com/#download-release) buil
 
 You'll need the POSIX version of MinGW. For the Winlibs distribution mentioned above, the latest version is currently gcc 13 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-16.0.6-11.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64ucrt-11.0.0-r1.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it to the list).
 
-You will also need to install a recent version of [CMake](https://cmake.org/download/). You can check if you have CMake already installed by running `cmake -v` in command line window.
+You will also need at least [CMake](https://cmake.org/download/) 3.21. You can check if you have CMake already installed by running `cmake -v` in command line window.
 
 ### MacOS
 
@@ -148,7 +148,7 @@ If you want to use the [Code::Blocks](https://www.codeblocks.org/downloads/) IDE
 > cmake -G"CodeBlocks - Ninja" --preset <preset>
 ```
 
-With `<preset>` being one of the available presets (see above for a list). For Windows for example you'd want `clang-cl` or `mingw`. Now there will be a Code::Blocks project inside `build\mingw`.
+With `<preset>` being one of the available presets (see above for a list). For Windows for example you'd want `clang-cl` or `mingw`. Now there will be a Code::Blocks project inside `build\`.
 
 #### XCode
 

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -1,3 +1,5 @@
+# Build instructions
+
 First you need a copy of the code (if you intend on working on the game use your fork's URL here):
 
 ```powershell
@@ -6,38 +8,40 @@ First you need a copy of the code (if you intend on working on the game use your
 
 The game's root directory, where your `git clone`d files reside, will be your starting point for compiling the game.
 
-Next you will need to install a couple of dependencies to build the game.
+Next you will need to install a couple of dependencies to build the game. There are several different ways to build Endless Sky, depending on your operating system and preference.
 
-## Build Environment
+- [Windows](#windows)
+- [MacOS](#macos)
+- [Linux](#linux)
 
-There are several different ways to build Endless Sky, depending on your operating system and preference.
-- [Windows](#Windows)
-- [MacOS](#MacOS)
-- [Linux](#Linux)
+## Windows
 
-## Windows (Visual Studio) <Windows>
-We are currently switching to using VS with cmake. If you wish the older MingW build instructions, they are located at the end of the Windows section.
+It is recommended to use the toolchain from Visual Studio to build the game (regardless of the IDE you wish to use). The other supported toolchain is [MinGW](#mingw).
 
-Download Visual Studio, and make sure to install the following features: 
-- "Desktop Development with C++", 
-- "C++ Clang Compiler for Windows", 
-- "C++ clang-cl for vXXX build tools", and 
+Download Visual Studio (if you do not want to use Visual Studio, you can alternatively download the VS Build Tools), and make sure to install the following components:
+
+- "Desktop Development with C++",
+- "C++ Clang Compiler for Windows",
 - "C++ CMake tools for Windows".
 
-Please note that it is recommened to use VS 2022 (or higher) for its better CMake integration.
+Please note that it is recommended to use VS 2022 (or higher) for its better CMake integration.
 
-### Windows Build Process
+<details>
+<summary>Step-by-step instructions for Visual Studio</summary>
 
-1. Open the endless-sky folder that you cloned in the initial step.
+1. Open the root folder using Visual Studio ("Open Folder")
 2. Wait while Visual Studio loads everything. This may take a few minutes the first time, but should be relatively fast on subsequent loads.
-3. On your toolbar there should be a pulldown menu that says "debug" or "release." Select the version you want to build.
-4. Hit the "build" button, or find the "Build" menu and select "Build All"
+3. On the toolbar you're able to choose between Debug and Release.
+4. You might need to select the target to launch in the dropdown of the Run button (it's the one with the green arrow). Select "Endless Sky (build/.../)" (not the one with install).
+4. Hit the Run button (F5) to build and run the game.
 5. In the status window it will give a scrolling list of actions being completed. Wait until it states "Build Complete"
-6. At this point you should be able to launch the recently completed build by hitting the F5 key or the run button. The recently build executable and essential libraries can be found in your Endless-Sky folder, nested within a subfolder created by Visual Studio during the build process
+6. You'll find the executables and libraries located inside the build directory in the root folder.
 
-#### Notes
+</details>
 
-##### Earlier versions of Visual Studio
+### Notes
+
+#### Earlier versions of Visual Studio
 
 If you are on an earlier version of Visual Studio, or would like to use an actual VS solution, you will need to generate the solution manually as follows:
 
@@ -47,30 +51,19 @@ If you are on an earlier version of Visual Studio, or would like to use an actua
 
 This will create a Visual Studio 2022 solution. If you are using an older version of VS, you will need to adjust the version. Now you will find a complete solution in the `build/` folder. Find the solution and open it and you're good to go!
 
-#### Using Microsoft Visual C++
-
-Using MSVC to compile Endless Sky is not supported. If you try, you will get a ton of warnings (and maybe even a couple of errors) during compilation.
-
-<details>
-
-<summary>Building on Windows using MinGW</summary>
-
+#### MinGW
   
-You can download the [MinGW Winlibs](https://winlibs.com/#download-release) build, which also includes various tools you'll need to build the game as well. It is possible to use other MinGW builds as well.
+You can download the [MinGW Winlibs](https://winlibs.com/#download-release) build, which also includes various tools you'll need to build the game as well. It is possible to use other MinGW distributions too (like Msys2 for example).
 
-You'll need the MSVCRT runtime version, 64-bit. The latest version is currently gcc 12 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.4-10.0.0-msvcrt-r2/winlibs-x86_64-posix-seh-gcc-12.1.0-mingw-w64msvcrt-10.0.0-r2.zip)).
+You'll need the MSVCRT runtime version, 64-bit, of MinGW. For the Winlibs distribution mentioned above, the latest version is currently gcc 13 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/13.1.0-16.0.5-11.0.0-msvcrt-r5/winlibs-x86_64-posix-seh-gcc-13.1.0-mingw-w64msvcrt-11.0.0-r5.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it in the list).
 
-Extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it in the list).
+You will also need to install [CMake](https://cmake.org/download/) (if you don't already have it).
 
-You will also need to install [CMake](https://cmake.org) (if you don't already have it).
-
-</details>
-
-## MacOS <MacOS>
+## MacOS
 
 Install [Homebrew](https://brew.sh). Once it is installed, use it to install the tools and libraries you will need:
 
-```
+```bash
 $ brew install cmake ninja mad libpng jpeg-turbo sdl2 openal-soft
 ```
 
@@ -78,11 +71,11 @@ $ brew install cmake ninja mad libpng jpeg-turbo sdl2 openal-soft
 
 If you want to build the libraries from source instead of using Homebrew, you can pass `-DES_USE_SYSTEM_LIBRARIES=OFF` to CMake when configuring.
 
-## Linux <Linux>
+## Linux
 
 You will need at least CMake 3.21. You can get the latest version from the [offical website](https://cmake.org/download/).
 
-**Note**: If your distro does not provide up-to-date version of the needed libraries, you will need to tell CMake to build the libraries from source by passing `-DES_USE_SYSTEM_LIBRARIES=OFF` to the first cmake command under the command line build instructions.
+**Note**: If your distro does not provide up-to-date version of the needed libraries, you will need to tell CMake to build the libraries from source by passing `-DES_USE_SYSTEM_LIBRARIES=OFF` while configuring.
 
 If you use a reasonably up-to-date distro, then you can use your favorite package manager to install the needed dependencies.
 
@@ -104,7 +97,7 @@ gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL
 
 </details>
 
-# Building from the command line
+## Building from the command line
 
 Here's a summary of every command you will need for development:
 
@@ -130,18 +123,18 @@ You can get a list of integration tests with `ctest --preset <preset>-integratio
 Replace `<preset>` with one of the following presets:
 
 - Windows: `clang-cl` (builds with Clang for Windows), `mingw` (builds with MinGW)
-- MacOS: `macos` or `macos-arm` (builds with the default compiler), `xcode` or `xcode-arm` (builds using the XCode toolchain)
+- MacOS: `macos` or `macos-arm` (builds with the default compiler, for x64 and ARM64 respectively)
 - Linux: `linux` (builds with the default compiler)
 
-# Building with other IDEs
+## Building with other IDEs
 
-## Building with Visual Studio Code
+### Visual Studio Code
 
-Install the [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools), [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools), [CMake Test explorer](https://marketplace.visualstudio.com/items?itemName=fredericbonnet.cmake-test-adapter) extensions and open the project folder under File -> Open Folder.
+Install the [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) and [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) extensions, and open the project folder under File -> Open Folder.
 
-You'll be asked to select a preset. Select the one you want (see the table above). If you get asked to configure the project, click on Yes. You can use the bar at the very bottom to select between different configurations (Debug/Release), build, start the game, and execute the unit tests. On the left you can click on the test icon to run individual integration tests.
+You'll be asked to select a preset. Select the one you want (see the list above in the previous section for help). If you get asked to configure the project, click on Yes. You can use the bar at the very bottom to select between different configurations (Debug/Release), build, start the game, and execute the unit tests. On the left you can click on the test icon to run individual integration tests.
 
-## Building with Code::Blocks
+### Building with Code::Blocks
 
 If you want to use the Code::Blocks IDE, from the root of the project folder execute:
 
@@ -151,15 +144,12 @@ If you want to use the Code::Blocks IDE, from the root of the project folder exe
 
 With `<preset>` being one of the available presets (see above for a list). For Windows for example you'd want `mingw`. Now there will be a Code::Blocks project inside `build\mingw`.
 
-
-
-## Building with XCode
+### Building with XCode
 
 If you want to use the XCode IDE, from the root of the project folder execute:
 
 ```bash
-$ cmake --preset macos -G Xcode # macos-arm for Apple Silicon
+$ cmake -G Xcode --preset macos # macos-arm for Apple Silicon
 ```
 
 The XCode project is located in the `build/` directory.
-

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -8,50 +8,25 @@ First you need a copy of the code (if you intend on working on the game, use you
 
 The game's root directory, where your `git clone`d files reside, will be your starting point for compiling the game.
 
-Next, you will need to install a couple of dependencies to build the game. There are several different ways to build Endless Sky, depending on your operating system and preference.
+Next, you will need to install a couple of dependencies to build the game. There are several different ways to build Endless Sky, depending on your operating system and preference. As an IDE, we recommend using [Visual Studio Code](#visual-studio-code).
 
 - [Windows](#windows)
+- [Windows (MinGW)](#windows-mingw)
 - [MacOS](#macos)
 - [Linux](#linux)
 
+
 ## Windows
 
-It is recommended to use the toolchain from Visual Studio to build the game (regardless of the IDE you wish to use). The other supported toolchain is [MinGW](#mingw).
+It is recommended to use the toolchain from Visual Studio to build the game (regardless of the IDE you wish to use).
 
-Download Visual Studio (if you do not want to use Visual Studio, you can alternatively download the VS Build Tools), and make sure to install the following components:
+Download Visual Studio (if you do not want to install Visual Studio, you can alternatively download the VS Build Tools), and make sure to install the following components:
 
 - "Desktop Development with C++",
 - "C++ Clang Compiler for Windows",
 - "C++ CMake tools for Windows".
 
-Please note that it is recommended to use VS 2022 (or higher) for its better CMake integration.
-
-<details>
-<summary>Step-by-step instructions for Visual Studio</summary>
-
-1. Open the repository's root folder using Visual Studio ("Open Folder")
-2. Wait while Visual Studio loads everything. This may take a few minutes the first time, but should be relatively fast on subsequent loads.
-3. On the toolbar you're able to choose between Debug and Release.
-4. You might need to select the target to launch in the dropdown menu of the Run button (it's the one with the green arrow). Select "Endless Sky (build/.../)" (not the one with install).
-5. Hit the Run button (F5) to build and run the game.
-6. In the status window it will give a scrolling list of actions being completed. Wait until it states "Build Complete"
-7. You'll find the executables and libraries located inside the build directory in the root folder.
-
-</details>
-
-### Notes
-
-#### Earlier versions of Visual Studio
-
-If you are on an earlier version of Visual Studio, or would like to use an actual VS solution, you will need to generate the solution manually as follows:
-
-```powershell
-> cmake --preset clang-cl -G"Visual Studio 17 2022"
-```
-
-This will create a Visual Studio 2022 solution. If you are using an older version of VS, you will need to adjust the version. Now you will find a complete solution in the `build/` folder. Find the solution and open it and you're good to go!
-
-#### MinGW
+## Windows (MinGW)
   
 You can download the [MinGW Winlibs](https://winlibs.com/#download-release) build, which also includes various tools you'll need to build the game as well. It is possible to use other MinGW distributions too (like Msys2 for example).
 
@@ -126,13 +101,38 @@ Replace `<preset>` with one of the following presets:
 - MacOS: `macos` or `macos-arm` (builds with the default compiler, for x64 and ARM64 respectively)
 - Linux: `linux` (builds with the default compiler)
 
-## Building with other IDEs
+## Using an IDE
 
 ### Visual Studio Code
 
 Install the [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) and [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) extensions, and open the project folder under File -> Open Folder.
 
 You'll be asked to select a preset. Select the one you want (see the list above in the previous section for help). If you get asked to configure the project, click on Yes. You can use the bar at the very bottom to select between different configurations (Debug/Release), build, start the game, and execute the unit tests. On the left you can click on the test icon to run individual integration tests.
+
+### Visual Studio
+
+It is recommened to use Visual Studio 2022, because of its better CMake integration. Once you have installed Visual Studio, you can simply open the root folder.
+
+<details>
+<summary>Step-by-step instructions for Visual Studio 2022+</summary>
+
+1. Open the repository's root folder using Visual Studio ("Open Folder")
+2. Wait while Visual Studio loads everything. This may take a few minutes the first time, but should be relatively fast on subsequent loads.
+3. On the toolbar you're able to choose between Debug and Release.
+4. You might need to select the target to launch in the dropdown menu of the Run button (it's the one with the green arrow). Select "Endless Sky (build/.../)" (not the one with install).
+5. Hit the Run button (F5) to build and run the game.
+6. In the status window it will give a scrolling list of actions being completed. Wait until it states "Build Complete"
+7. You'll find the executables and libraries located inside the build directory in the root folder.
+
+</details>
+
+If you are on an earlier version of Visual Studio, or would like to use an actual VS solution, you will need to generate the solution manually as follows:
+
+```powershell
+> cmake --preset clang-cl -G"Visual Studio 17 2022"
+```
+
+This will create a Visual Studio 2022 solution. If you are using an older version of VS, you will need to adjust the version. Now you will find a complete solution in the `build/` folder. Find the solution and open it and you're good to go!
 
 ### Building with Code::Blocks
 

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -8,7 +8,7 @@ First you need a copy of the code (if you intend on working on the game use your
 
 The game's root directory, where your `git clone`d files reside, will be your starting point for compiling the game.
 
-Next you will need to install a couple of dependencies to build the game. There are several different ways to build Endless Sky, depending on your operating system and preference.
+Next, you will need to install a couple of dependencies to build the game. There are several different ways to build Endless Sky, depending on your operating system and preference.
 
 - [Windows](#windows)
 - [MacOS](#macos)
@@ -29,10 +29,10 @@ Please note that it is recommended to use VS 2022 (or higher) for its better CMa
 <details>
 <summary>Step-by-step instructions for Visual Studio</summary>
 
-1. Open the root folder using Visual Studio ("Open Folder")
+1. Open the repository's root folder using Visual Studio ("Open Folder")
 2. Wait while Visual Studio loads everything. This may take a few minutes the first time, but should be relatively fast on subsequent loads.
 3. On the toolbar you're able to choose between Debug and Release.
-4. You might need to select the target to launch in the dropdown of the Run button (it's the one with the green arrow). Select "Endless Sky (build/.../)" (not the one with install).
+4. You might need to select the target to launch in the dropdown menu of the Run button (it's the one with the green arrow). Select "Endless Sky (build/.../)" (not the one with install).
 4. Hit the Run button (F5) to build and run the game.
 5. In the status window it will give a scrolling list of actions being completed. Wait until it states "Build Complete"
 6. You'll find the executables and libraries located inside the build directory in the root folder.
@@ -55,7 +55,7 @@ This will create a Visual Studio 2022 solution. If you are using an older versio
   
 You can download the [MinGW Winlibs](https://winlibs.com/#download-release) build, which also includes various tools you'll need to build the game as well. It is possible to use other MinGW distributions too (like Msys2 for example).
 
-You'll need the MSVCRT runtime version, 64-bit, of MinGW. For the Winlibs distribution mentioned above, the latest version is currently gcc 13 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/13.1.0-16.0.5-11.0.0-msvcrt-r5/winlibs-x86_64-posix-seh-gcc-13.1.0-mingw-w64msvcrt-11.0.0-r5.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it in the list).
+You'll need the 64-bit MSVCRT runtime version of MinGW. For the Winlibs distribution mentioned above, the latest version is currently gcc 13 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/13.1.0-16.0.5-11.0.0-msvcrt-r5/winlibs-x86_64-posix-seh-gcc-13.1.0-mingw-w64msvcrt-11.0.0-r5.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it in the list).
 
 You will also need to install [CMake](https://cmake.org/download/) (if you don't already have it).
 

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -33,9 +33,9 @@ Please note that it is recommended to use VS 2022 (or higher) for its better CMa
 2. Wait while Visual Studio loads everything. This may take a few minutes the first time, but should be relatively fast on subsequent loads.
 3. On the toolbar you're able to choose between Debug and Release.
 4. You might need to select the target to launch in the dropdown menu of the Run button (it's the one with the green arrow). Select "Endless Sky (build/.../)" (not the one with install).
-4. Hit the Run button (F5) to build and run the game.
-5. In the status window it will give a scrolling list of actions being completed. Wait until it states "Build Complete"
-6. You'll find the executables and libraries located inside the build directory in the root folder.
+5. Hit the Run button (F5) to build and run the game.
+6. In the status window it will give a scrolling list of actions being completed. Wait until it states "Build Complete"
+7. You'll find the executables and libraries located inside the build directory in the root folder.
 
 </details>
 

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -19,7 +19,7 @@ Next, you will need to install a couple of dependencies to build the game. There
 
 ### Windows
 
-It is recommended to use the toolchain from Visual Studio to build the game (regardless of the IDE you wish to use).
+We recommend to use the toolchain from Visual Studio to build the game (regardless of the IDE you wish to use).
 
 Download [Visual Studio](https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022) (if you do not want to install Visual Studio, you can alternatively download the [VS Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)), and make sure to install the following components:
 
@@ -27,7 +27,7 @@ Download [Visual Studio](https://visualstudio.microsoft.com/downloads/#visual-st
 - "C++ Clang Compiler for Windows",
 - "C++ CMake tools for Windows".
 
-It is recommended to use at least the version from 2022.
+We recommend to use at least the version from 2022. If you're unsure which edition to use, use the Community edition.
 
 ### Windows (MinGW)
   
@@ -117,7 +117,7 @@ You'll be asked to select a preset. Select the one you want (see the list above 
 
 #### Visual Studio
 
-It is recommened to use [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022), because of its better CMake integration. Once you have installed Visual Studio, you can simply open the root folder.
+We recommend to use [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022), because of its better CMake integration. Once you have installed Visual Studio, you can simply open the root folder.
 
 <details>
 <summary>Step-by-step instructions for Visual Studio 2022 or later</summary>


### PR DESCRIPTION
## Details

Tweaks the build instructions a bit:

- Fix internal hyperlinks
- Removed some unnecessary text
- Tweaked the wording in several places
- Improve organization
- Updated links
- Updated some old steps which didn't apply anymore
- typos
- Fix Markdown formatting