### PR TITLE
Fix plugins with a custom name

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -105,6 +105,9 @@ namespace {
 	void LoadPlugin(const string &path)
 	{
 		const auto *plugin = Plugins::Load(path);
+		if(!plugin)
+			return;
+
 		if(plugin->enabled)
 			sources.push_back(path);
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3726,7 +3726,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	auto pluginFun = [](const string &name) -> bool
 	{
 		const Plugin *plugin = Plugins::Get().Find(name.substr(strlen("installed plugin: ")));
-		return plugin ? plugin->enabled : false;
+		return plugin ? plugin->IsValid() && plugin->enabled : false;
 	};
 	pluginProvider.SetHasFunction(pluginFun);
 	pluginProvider.SetGetFunction(pluginFun);

--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -128,7 +128,8 @@ void Plugins::Save()
 	out.BeginChild();
 	{
 		for(const auto &it : plugins)
-			out.Write(it.first, it.second.currentState);
+			if(it.second.IsValid())
+				out.Write(it.first, it.second.currentState);
 	}
 	out.EndChild();
 }

--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -93,7 +93,8 @@ const Plugin *Plugins::Load(const string &path)
 	if(plugin && plugin->IsValid())
 	{
 		Logger::LogError("Warning: Skipping plugin located at \"" + path
-			+ "\" because another plugin with the same name has already been loaded");
+			+ "\" because another plugin with the same name has already been loaded from: \""
+			+ plugin->path + "\".");
 		return nullptr;
 	}
 

--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -89,7 +89,7 @@ const Plugin *Plugins::Load(const string &path)
 		Logger::LogError("Warning: Missing required \"name\" field inside plugin.txt");
 
 	// Plugin names should be unique.
-	auto *plugin = plugins.Find(name);
+	auto *plugin = plugins.Get(name);
 	if(plugin && plugin->IsValid())
 	{
 		Logger::LogError("Warning: Skipping plugin located at \"" + path
@@ -97,8 +97,6 @@ const Plugin *Plugins::Load(const string &path)
 		return nullptr;
 	}
 
-	if(!plugin)
-		plugin = plugins.Get(name);
 	plugin->name = std::move(name);
 	plugin->path = path;
 	// Read the deprecated about.txt content if no about text was specified.

--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -97,6 +97,8 @@ const Plugin *Plugins::Load(const string &path)
 		return nullptr;
 	}
 
+	if(!plugin)
+		plugin = plugins.Get(name);
 	plugin->name = std::move(name);
 	plugin->path = path;
 	// Read the deprecated about.txt content if no about text was specified.

--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -59,7 +59,7 @@ bool Plugin::IsValid() const
 
 
 
-// Try to load a plugin at the given path. Returns true if loading succeeded.
+// Attempt to load a plugin at the given path.
 const Plugin *Plugins::Load(const string &path)
 {
 	// Get the name of the folder containing the plugin.
@@ -87,6 +87,14 @@ const Plugin *Plugins::Load(const string &path)
 	// 'name' is a required field for plugins with a plugin description file.
 	if(Files::Exists(pluginFile) && !hasName)
 		Logger::LogError("Warning: Missing required \"name\" field inside plugin.txt");
+
+	// Plugin names should be unique.
+	if(plugins.Find(name))
+	{
+		Logger::LogError("Warning: Skipping plugin located at \"" + path
+			+ "\" because another plugin with the same name has already been loaded");
+		return nullptr;
+	}
 
 	auto *plugin = plugins.Get(name);
 	plugin->name = std::move(name);

--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -89,14 +89,14 @@ const Plugin *Plugins::Load(const string &path)
 		Logger::LogError("Warning: Missing required \"name\" field inside plugin.txt");
 
 	// Plugin names should be unique.
-	if(plugins.Find(name))
+	auto *plugin = plugins.Find(name);
+	if(!plugin || plugin->IsValid())
 	{
 		Logger::LogError("Warning: Skipping plugin located at \"" + path
 			+ "\" because another plugin with the same name has already been loaded");
 		return nullptr;
 	}
 
-	auto *plugin = plugins.Get(name);
 	plugin->name = std::move(name);
 	plugin->path = path;
 	// Read the deprecated about.txt content if no about text was specified.

--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -90,7 +90,7 @@ const Plugin *Plugins::Load(const string &path)
 
 	// Plugin names should be unique.
 	auto *plugin = plugins.Find(name);
-	if(!plugin || plugin->IsValid())
+	if(plugin && plugin->IsValid())
 	{
 		Logger::LogError("Warning: Skipping plugin located at \"" + path
 			+ "\" because another plugin with the same name has already been loaded");

--- a/source/Plugins.h
+++ b/source/Plugins.h
@@ -46,7 +46,7 @@ struct Plugin {
 // This object is updated by toggling plugins in the Preferences UI.
 class Plugins {
 public:
-	// Load a plugin at the given path.
+	// Attempt to load a plugin at the given path.
 	static const Plugin *Load(const std::string &path);
 
 	static void LoadSettings();

--- a/source/Set.h
+++ b/source/Set.h
@@ -33,6 +33,7 @@ public:
 	const Type *Get(const std::string &name) const { return &data[name]; }
 	// If an item already exists in this set, get it. Otherwise, return a null
 	// pointer rather than creating the item.
+	Type *Find(const std::string &name);
 	const Type *Find(const std::string &name) const;
 
 	bool Has(const std::string &name) const { return data.count(name); }
@@ -53,6 +54,15 @@ public:
 private:
 	mutable std::map<std::string, Type> data;
 };
+
+
+
+template <class Type>
+Type *Set<Type>::Find(const std::string &name)
+{
+	auto it = data.find(name);
+	return (it == data.end() ? nullptr : &it->second);
+}
 
 
 

--- a/source/Set.h
+++ b/source/Set.h
@@ -33,7 +33,6 @@ public:
 	const Type *Get(const std::string &name) const { return &data[name]; }
 	// If an item already exists in this set, get it. Otherwise, return a null
 	// pointer rather than creating the item.
-	Type *Find(const std::string &name);
 	const Type *Find(const std::string &name) const;
 
 	bool Has(const std::string &name) const { return data.count(name); }
@@ -55,14 +54,6 @@ private:
 	mutable std::map<std::string, Type> data;
 };
 
-
-
-template <class Type>
-Type *Set<Type>::Find(const std::string &name)
-{
-	auto it = data.find(name);
-	return (it == data.end() ? nullptr : &it->second);
-}
 
 
 

--- a/source/Set.h
+++ b/source/Set.h
@@ -56,7 +56,6 @@ private:
 
 
 
-
 template <class Type>
 const Type *Set<Type>::Find(const std::string &name) const
 {


### PR DESCRIPTION
**Bugfix:** This PR fixes #9237

## Fix Details

Plugins with a custom name where saved under the folder name, instead of of the custom name. This PR fixes this by properly storing the plugin with its custom name in the plugins set.

## Testing Done

Tested with the steps described in the linked issue, which are fixed with this PR.