### PR TITLE
Always use vcpkg's OpenAL Soft on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,13 @@ if(NOT ES_USE_SYSTEM_LIBRARIES)
 	list(APPEND VCPKG_MANIFEST_FEATURES "system-libs")
 endif()
 
-# Tell vcpkg to use system libraries that are missing in the Flatpak or Steam runtime if necessary.
+# Tell vcpkg to use system libraries that are missing on the respective platform.
 if(ES_FLATPAK)
 	list(APPEND VCPKG_MANIFEST_FEATURES "flatpak-libs")
 elseif(ES_STEAM)
 	list(APPEND VCPKG_MANIFEST_FEATURES "steam-libs")
+elseif(APPLE)
+	list(APPEND VCPKG_MANIFEST_FEATURES "macos-libs")
 endif()
 
 # Various helpful options for IDEs.

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -71,7 +71,7 @@ You will also need to install [CMake](https://cmake.org) (if you don't already h
 Install [Homebrew](https://brew.sh). Once it is installed, use it to install the tools and libraries you will need:
 
 ```
-$ brew install cmake ninja mad libpng jpeg-turbo sdl2 openal-soft
+$ brew install cmake ninja mad libpng jpeg-turbo sdl2
 ```
 
 **Note**: If you are on Apple Silicon (and want to compile for ARM), make sure that you are using ARM Homebrew!

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -46,6 +46,12 @@
       "dependencies": [
         "libmad"
       ]
+    },
+    "macos-libs": {
+      "description": "System libraries that are always needed on MacOS.",
+      "dependencies": [
+        "openal-soft"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Details

There seems to be a problem with CMake being unable to find system installed OpenAL Soft on MacOS ARM64, which meant that the build always failed due to being unable to find OpenAL.

This PR fixes this issue by always installing OpenAL Soft as a dependency through vcpkg, instead of requiring the user to install it system-wide.