### PR TITLE
Misc CI improvements and tweaks

### DIFF
--- a/.github/sccache/action.yml
+++ b/.github/sccache/action.yml
@@ -8,7 +8,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set environment variables
-      run: echo "SCCACHE_VERSION=v0.4.1" >> $GITHUB_ENV
+      run: echo "SCCACHE_VERSION=v0.5.4" >> $GITHUB_ENV
       shell: bash
     - name: Download sccache
       run: |

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -38,7 +38,6 @@ jobs:
       - uses: lukka/run-vcpkg@v11
         with:
           vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'linux-release'
@@ -70,7 +69,6 @@ jobs:
       - uses: lukka/run-vcpkg@v11
         with:
           vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'mingw-release'
@@ -103,7 +101,6 @@ jobs:
       - uses: lukka/run-vcpkg@v11
         with:
           vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'macos-release'

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -1,9 +1,7 @@
 name: Release CD
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch:
 
 jobs:
   release_appimage_x64:
@@ -28,19 +26,17 @@ jobs:
       - uses: lukka/run-vcpkg@v11
         with:
           vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'linux-release'
           buildPreset: 'linux-ci-release'
       - name: Package Application
         run: ./utils/build_appimage.sh build/release
-      - name: Upload Release
-        uses: softprops/action-gh-release@v1
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
-          draft: true
-          files: ${{ env.OUTPUT }}
-
+          name: ${{ env.OUTPUT }}
+          path: ${{ env.OUTPUT }}
 
   release_windows_x86:
     name: Windows x86
@@ -56,7 +52,6 @@ jobs:
       - uses: lukka/run-vcpkg@v11
         with:
           vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'mingw32-release'
@@ -65,11 +60,11 @@ jobs:
         run: |
           cmake --install build/release
           7z a ${{ env.OUTPUT }} "./install/release/*"
-      - name: Upload Release
-        uses: softprops/action-gh-release@v1
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
-          draft: true
-          files: ${{ env.OUTPUT }}
+          name: ${{ env.OUTPUT }}
+          path: ${{ env.OUTPUT }}
       - name: Upload Steam Depot
         uses: actions/upload-artifact@v3
         with:
@@ -95,7 +90,6 @@ jobs:
       - uses: lukka/run-vcpkg@v11
         with:
           vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'mingw-release'
@@ -104,11 +98,11 @@ jobs:
         run: |
           cmake --install build/release
           7z a ${{ env.OUTPUT }} "./install/release/*"
-      - name: Upload Release
-        uses: softprops/action-gh-release@v1
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
-          draft: true
-          files: ${{ env.OUTPUT }}
+          name: ${{ env.OUTPUT }}
+          path: ${{ env.OUTPUT }}
       - name: Upload Steam Depot
         uses: actions/upload-artifact@v3
         with:
@@ -136,11 +130,10 @@ jobs:
       - uses: lukka/run-vcpkg@v11
         with:
           vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-          doNotCache: true
       - uses: lukka/run-cmake@v10
         with:
           configurePreset: 'macos-arm-release'
-          buildPreset: 'macos-ci-release'
+          buildPreset: 'macos-arm-ci-release'
       - name: Prepare for x64 app bundle
         run: |
           mv "build/release/Endless Sky.app" "Endless Sky.app.arm"
@@ -161,11 +154,11 @@ jobs:
           cp -r "Endless Sky.app" "${{ env.OUTPUT }}"
           ln -s /Applications "${{ env.OUTPUT }}"
           hdiutil create -ov -fs HFS+ -format UDZO -imagekey zlib-level=9 -srcfolder "${{ env.OUTPUT }}" "${{ github.workspace }}/${{ env.OUTPUT }}.dmg"
-      - name: Upload Release
-        uses: softprops/action-gh-release@v1
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
-          draft: true
-          files: ${{ env.OUTPUT }}.dmg
+          name: ${{ env.OUTPUT }}.dmg
+          path: ${{ env.OUTPUT }}.dmg
       - name: Prepare Steam Depot
         run: |
           mv "Endless Sky.app/Contents/Resources/endless-sky.icns" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libosmesa6 mesa-utils libglvnd-dev
+        sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libosmesa6 mesa-utils libglvnd-dev x11-utils
     - name: Disable VM sound card
       run: |
         sudo sh -c 'echo "pcm.!default { type plug slave.pcm \"null\" }"  >> /etc/asound.conf'
@@ -65,7 +65,6 @@ jobs:
     - uses: lukka/run-vcpkg@v11
       with:
         vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-        doNotCache: true
     - uses: lukka/run-cmake@v10
       with:
         configurePreset: ${{ matrix.opengl == 'GL' && 'linux-ci' || 'linux-gles-ci' }}
@@ -90,7 +89,6 @@ jobs:
     - uses: lukka/run-vcpkg@v11
       with:
         vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-        doNotCache: true
     - uses: lukka/run-cmake@v10
       with:
         configurePreset: 'mingw-ci'
@@ -125,7 +123,6 @@ jobs:
     - uses: lukka/run-vcpkg@v11
       with:
         vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-        doNotCache: true
     - uses: lukka/run-cmake@v10
       with:
         configurePreset: 'clang-cl-ci'
@@ -152,7 +149,6 @@ jobs:
     - uses: lukka/run-vcpkg@v11
       with:
         vcpkgGitCommitId: '69efe9cc2df0015f0bb2d37d55acde4a75c9a25b'
-        doNotCache: true
     - uses: lukka/run-cmake@v10
       with:
         configurePreset: 'macos-ci'

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -1,10 +1,7 @@
 name: Steam
 
 on:
-  push:
-    branches:
-      - master
-      - releases/v[0-9]+.[0-9]+.[0-9]+
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}


### PR DESCRIPTION
## Details

- Updates sccache
- Remove unneeded action input
- Change the release workflow to be manually invoked, instead of starting automatically when a tag is pushed (this is to protect against having to force push a tag if an error occurs during building)
- Change the Steam workflow to also be manually invoked only, instead of making it run on every commit. This is because now that the Steam runtime has been updated to use the newer runtime, it is pretty unlikely 
- Attempt to speed up the Ubuntu 22 integration tests