### PR TITLE
Correctly update engine flares with the same sprite, but different scale

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -168,7 +168,8 @@ namespace {
 		auto oit = find_if(thisFlares.begin(), thisFlares.end(),
 			[&it](const pair<Body, int> &flare)
 			{
-				return it.first.GetSprite() == flare.first.GetSprite();
+				return (it.first.GetSprite() == flare.first.GetSprite()
+					&& it.first.Scale() == flare.first.Scale());
 			}
 		);
 


### PR DESCRIPTION
**Bugfix:** This PR fixes #8557

## Fix Details
Changed outfit adding logic so that flares using the same sprite, but having different scale are now treated as separate entries in ship's flare table.

## Testing Done
Tested with steps provided in the original issue.