### PR TITLE
Don't build unnecessary debug dependencies

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -183,6 +183,7 @@
       "inherits": "ci",
       "cacheVariables": {
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
+        "VCPKG_HOST_TRIPLET": "linux64-release",
         "VCPKG_TARGET_TRIPLET": "linux64-release",
         "ES_USE_OFFSCREEN": "ON"
       }
@@ -194,6 +195,7 @@
       "inherits": "ci",
       "cacheVariables": {
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
+        "VCPKG_HOST_TRIPLET": "linux64-release",
         "VCPKG_TARGET_TRIPLET": "linux64-release",
         "ES_GLES": "ON",
         "ES_USE_OFFSCREEN": "ON"
@@ -206,6 +208,7 @@
       "inherits": "ci",
       "cacheVariables": {
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
+        "VCPKG_HOST_TRIPLET": "macos64-release",
         "VCPKG_TARGET_TRIPLET": "macos64-release",
         "CMAKE_OSX_ARCHITECTURES": "x86_64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "10.9"
@@ -218,6 +221,7 @@
       "inherits": "ci",
       "cacheVariables": {
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
+        "VCPKG_HOST_TRIPLET": "x64-windows-release",
         "VCPKG_TARGET_TRIPLET": "x64-windows-release",
         "CMAKE_CXX_COMPILER": "clang-cl.exe"
       }
@@ -231,6 +235,7 @@
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "CMAKE_CXX_COMPILER": "x86_64-w64-mingw32-g++",
         "CMAKE_RC_COMPILER": "windres",
+        "VCPKG_HOST_TRIPLET": "win64-release",
         "VCPKG_TARGET_TRIPLET": "win64-release"
       }
     },
@@ -241,6 +246,7 @@
       "inherits": "release",
       "cacheVariables": {
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
+        "VCPKG_HOST_TRIPLET": "linux64-release",
         "VCPKG_TARGET_TRIPLET": "linux64-release"
       }
     },
@@ -252,6 +258,7 @@
       "cacheVariables": {
         "ES_CREATE_BUNDLE": "ON",
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
+        "VCPKG_HOST_TRIPLET": "macos64-release",
         "VCPKG_TARGET_TRIPLET": "macos64-release",
         "CMAKE_OSX_ARCHITECTURES": "x86_64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "10.9"
@@ -269,6 +276,7 @@
       "cacheVariables": {
         "ES_CREATE_BUNDLE": "ON",
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
+        "VCPKG_HOST_TRIPLET": "macos64-release",
         "VCPKG_TARGET_TRIPLET": "macos-arm64-release",
         "CMAKE_OSX_ARCHITECTURES": "arm64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "10.9"
@@ -284,6 +292,7 @@
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "CMAKE_CXX_COMPILER": "x86_64-w64-mingw32-g++",
         "CMAKE_RC_COMPILER": "windres",
+        "VCPKG_HOST_TRIPLET": "win64-release",
         "VCPKG_TARGET_TRIPLET": "win64-release"
       }
     },
@@ -296,6 +305,7 @@
         "ES_CREATE_BUNDLE": "ON",
         "CMAKE_CXX_COMPILER": "i686-w64-mingw32-g++",
         "CMAKE_RC_COMPILER": "windres",
+        "VCPKG_HOST_TRIPLET": "win64-release",
         "VCPKG_TARGET_TRIPLET": "win32-release"
       }
     }


### PR DESCRIPTION
## Details

In CI we don't need to build debug versions of dependencies, we can simply use the release versions all the time. While this doesn't have a big effect right now because host dependencies are currently just a couple of scripts, if they ever change to add executables which will need to be built, this will have an effect.

This is basically future-proofing.