### PR TITLE
fix(content): Trim New Austria's post-bombing description to better fit text box

### DIFF
--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -267,7 +267,7 @@ event "initial deployment 1"
 		fleet "Human Miners" 2000
 	planet "New Austria"
 		description `New Austria is a rugged mountain world, full of snow-capped peaks and valleys so deep and so steep that they rarely see sunlight.`
-		description `	The few settlements that have been built here were developed for mining sapphires and rubies. The sapphires range from blue to yellow to black to clear in color, and are used as industrial abrasives and jewelry.`
+		description `	The few settlements that have been built here were developed for mining sapphires and rubies. The sapphires range from blue to yellow to black to clear in color, and are used for industrial abrasives and jewelry.`
 		description `	For centuries the locals have tried to find a deposit of diamonds, and local folklore revolves around the prosperity that would come to this world if diamonds were ever discovered.`
 		description `	The Navy has recently requisitioned one of the abandoned mining towns and begun refurbishing it for a secure military base, with the mining tunnels used as deep underground bunkers.`
 

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -267,9 +267,9 @@ event "initial deployment 1"
 		fleet "Human Miners" 2000
 	planet "New Austria"
 		description `New Austria is a rugged mountain world, full of snow-capped peaks and valleys so deep and so steep that they rarely see sunlight.`
-		description `The few settlements that have been built here were developed for mining sapphires and rubies. The sapphires found in New Austria range from blue to yellow to black to clear in color, and are used both for industrial abrasives and for jewelry.`
-		description `For centuries the locals have tried to find a deposit of diamonds, and local folklore revolves around the prosperity that would come to this world if diamonds were ever discovered.`
-		description `The Navy has recently requisitioned one of the abandoned mining towns and begun refurbishing it for a secure military base, with the mining tunnels used as deep underground bunkers.`
+		description `	The few settlements that have been built here were developed for mining sapphires and rubies. The sapphires range from blue to yellow to black to clear in color, and are used as industrial abrasives and jewelry.`
+		description `	For centuries the locals have tried to find a deposit of diamonds, and local folklore revolves around the prosperity that would come to this world if diamonds were ever discovered.`
+		description `	The Navy has recently requisitioned one of the abandoned mining towns and begun refurbishing it for a secure military base, with the mining tunnels used as deep underground bunkers.`
 
 event "initial deployment 2"
 	date 14 8 3014

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -267,7 +267,7 @@ event "initial deployment 1"
 		fleet "Human Miners" 2000
 	planet "New Austria"
 		description `New Austria is a rugged mountain world, full of snow-capped peaks and valleys so deep and so steep that they rarely see sunlight.`
-		description `	The few settlements that have been built here were developed for mining sapphires and rubies. The sapphires range from blue to yellow to black to clear in color, and are used for industrial abrasives and jewelry.`
+		description `	The few settlements that have been built here were developed for mining sapphires and rubies. The sapphires range from blue to yellow to black to clear in color and are used for industrial abrasives and jewelry.`
 		description `	For centuries the locals have tried to find a deposit of diamonds, and local folklore revolves around the prosperity that would come to this world if diamonds were ever discovered.`
 		description `	The Navy has recently requisitioned one of the abandoned mining towns and begun refurbishing it for a secure military base, with the mining tunnels used as deep underground bunkers.`
 


### PR DESCRIPTION
Right now, the New Austria description fits into its text box awkwardly: there is more empty space at the top of the box than there is at the bottom. This PR slightly truncates the New Austria `"initial deployment 1"` description, so that there is a spare line of space at the bottom.
![sans](https://github.com/endless-sky/endless-sky/assets/60202690/7d4859e2-8527-4533-bc52-ada5b78e9c4d)

![undertale](https://github.com/endless-sky/endless-sky/assets/60202690/ef1d9026-31e5-4079-a644-25bd514d1ccd)
