### PR TITLE
Allow toggling fullscreen in all panels

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -307,16 +307,16 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 				// and the OpenGL viewport to match.
 				GameWindow::AdjustViewport();
 			}
-			else if(activeUI.Handle(event))
-			{
-				// The UI handled the event.
-			}
 			else if(event.type == SDL_KEYDOWN && !toggleTimeout
 					&& (Command(event.key.keysym.sym).Has(Command::FULLSCREEN)
 					|| (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT))))
 			{
 				toggleTimeout = 30;
 				Preferences::ToggleScreenMode();
+			}
+			else if(activeUI.Handle(event))
+			{
+				// The UI handled the event.
 			}
 			else if(event.type == SDL_KEYDOWN && !event.key.repeat
 					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))


### PR DESCRIPTION
## Details
Toggling fullscreen, unlike opening the menu or toggling fast-forward, is not a "game" command and rather a "window" command. Limiting the ability to do so (in non-interruptible panels) may seem like something's broken.

## Testing Done
Opened the logbook and successfully toggled fullscreen mode.