### PR TITLE
Correctly pass updated ship event list to NPC::DoActions

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -506,7 +506,7 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, const Mission *
 			shipEvents[bay.ship.get()] |= type;
 
 	// Run any mission actions that trigger on this event.
-	DoActions(event, newEvent, player, ui, caller);
+	DoActions(type, newEvent, player, ui, caller);
 
 	// Check if the success status has changed. If so, display a message.
 	if(isVisible && !alreadyFailed && HasFailed())
@@ -733,7 +733,7 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 
 
 // Handle any NPC mission actions that may have been triggered by a ShipEvent.
-void NPC::DoActions(const ShipEvent &event, bool newEvent, PlayerInfo &player, UI *ui, const Mission *caller)
+void NPC::DoActions(const int type, bool newEvent, PlayerInfo &player, UI *ui, const Mission *caller)
 {
 	// Map the ShipEvent that was received to the Triggers it could flip.
 	static const map<int, vector<Trigger>> eventTriggers = {
@@ -746,8 +746,6 @@ void NPC::DoActions(const ShipEvent &event, bool newEvent, PlayerInfo &player, U
 		{ShipEvent::CAPTURE, {CAPTURE}},
 		{ShipEvent::PROVOKE, {PROVOKE}},
 	};
-
-	int type = event.Type();
 
 	// Ships are capable of receiving multiple DESTROY events. Only
 	// handle the first such event, because a ship can't actually be

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -100,7 +100,7 @@ public:
 
 private:
 	// Handle any NPC mission actions that may have been triggered by a ShipEvent.
-	void DoActions(const ShipEvent &event, bool newEvent, PlayerInfo &player, UI *ui, const Mission *caller);
+	void DoActions(const int type, bool newEvent, PlayerInfo &player, UI *ui, const Mission *caller);
 
 
 private:


### PR DESCRIPTION
**Bugfix:** This PR addresses the problem behind #9253

## Fix Details
When NPC::Do is passed a ShipEvent, it copies the type of that event into a local variable and performs some changes:
- If a ship was captured, the event for its destruction is also added.
- Certain events only count if they were performed by the player (assist, board, scan). If any of these events were not performed by the player, they are removed.
However, it then passes the original ShipEvent object to NPC::DoActions, and this method does not repeat those operations.
As a result, while capturing a ship counts as destroying it for hte purposes of the NPC objective, it does not trigger the NPC action for the destruction of the NPC.
This PR passes the local variable that contains the updated events to NPC::DoActions so that it can run the correct triggers.
This also means that assist, board, and scan events performed on NPCs by non-player ships will not trigger the corresponding NPC actions, but I think this is reasonable anyway.

## Testing Done
0

## Alternative Approaches
An alternative could be to add "KILL" to the `eventTriggers` vector for the CAPTURE ShipEvent in NPC::DoActions.
