### PR TITLE
Correctly trigger NPC actions with simultaneous events

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -753,7 +753,7 @@ void NPC::DoActions(const ShipEvent &event, bool newEvent, PlayerInfo &player, U
 	// Ships are capable of receiving multiple DESTROY events. Only
 	// handle the first such event, because a ship can't actually be
 	// destroyed multiple times.
-	if(type == ShipEvent::DESTROY && !newEvent)
+	if((type & ShipEvent::DESTROY) && !newEvent)
 		type &= ~ShipEvent::DESTROY;
 
 	// Get the actions for the Triggers that could potentially run.

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -457,7 +457,6 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, const Mission *
 	// itself so that this class thinks the ship is destroyed.
 	shared_ptr<Ship> ship;
 	int type = event.Type();
-
 	for(shared_ptr<Ship> &ptr : ships)
 		if(ptr == event.Target())
 		{

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -457,6 +457,7 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, const Mission *
 	// itself so that this class thinks the ship is destroyed.
 	shared_ptr<Ship> ship;
 	int type = event.Type();
+
 	for(shared_ptr<Ship> &ptr : ships)
 		if(ptr == event.Target())
 		{
@@ -753,14 +754,15 @@ void NPC::DoActions(const ShipEvent &event, bool newEvent, PlayerInfo &player, U
 	// handle the first such event, because a ship can't actually be
 	// destroyed multiple times.
 	if(type == ShipEvent::DESTROY && !newEvent)
-		return;
+		type &= ~ShipEvent::DESTROY;
 
 	// Get the actions for the Triggers that could potentially run.
-	auto triggers = eventTriggers.find(type);
-	if(triggers == eventTriggers.end())
-		return;
+	set<Trigger> triggers;
+	for(const auto &it : eventTriggers)
+		if(type & it.first)
+			triggers.insert(it.second.begin(), it.second.end());
 
-	for(Trigger trigger : triggers->second)
+	for(Trigger trigger : triggers)
 	{
 		auto it = npcActions.find(trigger);
 		if(it == npcActions.end())


### PR DESCRIPTION
**Bugfix:**

Thanks to @Anarchist2 for reporting this on Discord.

## Fix Details
When multiple events occur simultaneously (for example, a ship going from not disabled to destroyed in a single hit, such as from heavy rockets) NPC actions will not correctly be triggered because it searches the map of ShipEvents to NPC action triggers for exact matches to the new event, but if the new event is actually multiple simultaneous events, it will not match any of the ShipEvent keys in the map and so will not trigger anything.
This PR traverses the map and adds any triggers triggered by any of the new events to an std::set which is then traversed when actually doing the actions.

## Testing Done
0

