### PR TITLE
fix(ui): Fix planet being offset from its label when landing

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -659,12 +659,10 @@ void Engine::Step(bool isActive)
 				missileLabels.emplace_back(AlertLabel(pos, projectile, flagship, zoom));
 		}
 
+	// Update the planet label positions.
 	if(isActive)
-	{
-		// Update the planet label positions.
 		for(PlanetLabel &label : labels)
 			label.Update(center, zoom);
-	}
 
 	if(flagship && flagship->IsOverheated())
 		Messages::Add("Your ship has overheated.", Messages::Importance::Highest);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -643,26 +643,25 @@ void Engine::Step(bool isActive)
 			escorts.Add(*escort, escort->GetSystem() == currentSystem, fleetIsJumping, isSelected);
 		}
 
-	// Create the status overlays.
 	statuses.clear();
-	if(isActive)
-		CreateStatusOverlays();
-
-	// Create missile overlays.
 	missileLabels.clear();
-	if(Preferences::Has("Show missile overlays"))
-		for(const Projectile &projectile : projectiles)
-		{
-			Point pos = projectile.Position() - center;
-			if(projectile.MissileStrength() && projectile.GetGovernment()->IsEnemy()
-					&& (pos.Length() < max(Screen::Width(), Screen::Height()) * .5 / zoom))
-				missileLabels.emplace_back(AlertLabel(pos, projectile, flagship, zoom));
-		}
-
-	// Update the planet label positions.
 	if(isActive)
+	{
+		// Create the status overlays.
+		CreateStatusOverlays();
+		// Create missile overlays.
+		if(Preferences::Has("Show missile overlays"))
+			for(const Projectile &projectile : projectiles)
+			{
+				Point pos = projectile.Position() - center;
+				if(projectile.MissileStrength() && projectile.GetGovernment()->IsEnemy()
+						&& (pos.Length() < max(Screen::Width(), Screen::Height()) * .5 / zoom))
+					missileLabels.emplace_back(AlertLabel(pos, projectile, flagship, zoom));
+			}
+		// Update the planet label positions.
 		for(PlanetLabel &label : labels)
 			label.Update(center, zoom);
+	}
 
 	if(flagship && flagship->IsOverheated())
 		Messages::Add("Your ship has overheated.", Messages::Importance::Highest);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -659,9 +659,12 @@ void Engine::Step(bool isActive)
 				missileLabels.emplace_back(AlertLabel(pos, projectile, flagship, zoom));
 		}
 
-	// Update the planet label positions.
-	for(PlanetLabel &label : labels)
-		label.Update(center, zoom);
+	if(isActive)
+	{
+		// Update the planet label positions.
+		for(PlanetLabel &label : labels)
+			label.Update(center, zoom);
+	}
 
 	if(flagship && flagship->IsOverheated())
 		Messages::Add("Your ship has overheated.", Messages::Importance::Highest);


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7631

## Fix Details
I think the planet label was updated one too many times.

Actually, I'm not 100% sure if that was the issue, but it seems to be gone now, so I guess that was it? ~~I don't know much about the UI code.~~

## Testing Done
Landed a couple times. Seems to be gone now.

## Save File
Literally any save file.
