### PR TITLE
feat(content): Rename Hai "Railgun" to "Skipper Railgun" using `display name`

### DIFF
--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -204,7 +204,7 @@ outfit "Railgun Slug"
 	description "Skipper Railgun Slugs incorporate energy-discharging capacitors that deal a small amount of ion damage to their target. Although not terribly damaging, this ion damage combined with the significant recoil that each shot has turns Flea drones into effective long-range support ships."
 
 outfit "Railgun Slug Rack"
-	"display name" "Skipper Railgun Slug Rack"
+	"display name" "Skipper Slug Rack"
 	category "Ammunition"
 	cost 15000
 	thumbnail "outfit/railslug rack"
@@ -212,7 +212,7 @@ outfit "Railgun Slug Rack"
 	"outfit space" -3
 	"railgun slug capacity" 500
 	ammo "Railgun Slug"
-	description "This railgun slug rack is used to store and load extra Skipper railgun ammunition."
+	description "This railgun slug rack is used to store and load extra Skipper Railgun ammunition."
 
 outfit "Railgun"
 	"display name" "Skipper Railgun"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -195,14 +195,16 @@ outfit "Ionic Turret Prototype"
 
 
 outfit "Railgun Slug"
+	"display name" "Skipper Railgun Slug"
 	category "Ammunition"
 	cost 13
 	thumbnail "outfit/railslug"
 	"mass" 0.003
 	"railgun slug capacity" -1
-	description "These Railgun Slugs incorporate energy-discharging capacitors that deal a small amount of ion damage to their target. Although not terribly damaging, this ion damage combined with the significant recoil that each shot has turns Flea drones into effective long-range support ships."
+	description "Skipper Railgun Slugs incorporate energy-discharging capacitors that deal a small amount of ion damage to their target. Although not terribly damaging, this ion damage combined with the significant recoil that each shot has turns Flea drones into effective long-range support ships."
 
 outfit "Railgun Slug Rack"
+	"display name" "Skipper Railgun Slug Rack"
 	category "Ammunition"
 	cost 15000
 	thumbnail "outfit/railslug rack"
@@ -210,9 +212,10 @@ outfit "Railgun Slug Rack"
 	"outfit space" -3
 	"railgun slug capacity" 500
 	ammo "Railgun Slug"
-	description "The railgun slug rack is used to store and load extra railgun ammunition."
+	description "This railgun slug rack is used to store and load extra Skipper railgun ammunition."
 
 outfit "Railgun"
+	"display name" "Skipper Railgun"
 	category "Secondary Weapons"
 	cost 20000
 	thumbnail "outfit/railgun"
@@ -239,7 +242,7 @@ outfit "Railgun"
 		"firing force" 70
 		"stream"
 		"submunition" "rslug" 1
-	description "The Hai designed this weapon to best complement their Flea drones. Each Railgun provides a significant amount of force upon firing, pushing the Flea drone backwards and therefore forcing it to keep its distance from its target."
+	description "The Hai designed this weapon to best complement their Flea drones. Each Skipper Railgun provides a significant amount of force upon firing, pushing the Flea drone backwards and therefore forcing it to keep its distance from its target."
 	description "	Flea drone pilots joke that they provide more thrust than engines of similar size, so Unfettered should be using them at the back of their ships. There's probably a cultural component to the joke that many miss, because it's told quite often and the Hai laugh hysterically about it - every time."
 
 outfit "rslug"

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -280,7 +280,7 @@ ship "Flea"
 	gun 0 -27 "Railgun"
 	leak "leak" 60 50
 	explode "tiny explosion" 15
-	description `This combat drone is built to amplify the strength of any combat force for as few credits as possible. It was designed in conjunction with the tactical recoil of the Railgun to allow it to kite its targets, prolonging its combat efficacy while it supports its allies with debilitating ion damage.`
+	description `This combat drone is built to amplify the strength of any combat force for as few credits as possible. It was designed in conjunction with the tactical recoil of the Skipper Railgun to allow it to kite its targets, prolonging its combat efficacy while it supports its allies with debilitating ion damage.`
 	description "	Drones do not come equipped with a hyperdrive. You cannot carry a drone unless you have a ship in your fleet with a drone bay."
 
 ship "Flea" "Flea (Pulse)"
@@ -773,7 +773,7 @@ ship "Pond Strider"
 	explode "large explosion" 40
 	explode "huge explosion" 10
 	"final explode" "final explosion large"
-	description "The Hai upgraded their original Pond Strider after acquiring hull repair technology through alien diplomacy. These improvements have greatly reduced casualties in their conflict with the Unfettered, since the light Pond Striders become vulnerable as they collect damaged drones. Besides enabling the ship to repair damaged drones, the Hai have cleverly innovated the Railgun to make the Pond Strider and Fleas into very efficient combat support for their fleets."
+	description "The Hai upgraded their original Pond Strider after acquiring hull repair technology through alien diplomacy. These improvements have greatly reduced casualties in their conflict with the Unfettered, since the light Pond Striders become vulnerable as they collect damaged drones. Besides enabling the ship to repair damaged drones, the Hai have cleverly innovated the Skipper Railgun to make the Pond Strider and Fleas into very efficient combat support for their fleets."
 
 ship "Pond Strider" "Pond Strider (Tracker)"
 	outfits


### PR DESCRIPTION
This is a re-PR of https://github.com/endless-sky/endless-sky/pull/8908.

A lot of discussion occurs around Endless Sky's "Railgun". While we don't follow realism to the T, the fact that the Railgun is simply named "Railgun" implies that it is *the* Railgun in the game. Although the principles are the same, it is truly of more Hai-nature with the ion damage and the special tactical use of it on smaller ships.

This PR adds "Skipper Railgun" as a display name for the Railgun and related oufits. Skipper is another terminology for water strider bugs, and the Railgun's main aspect is the tactical usage of the recoil on Fleas, allowing them to "skip" around. This presents the weapon as even more so of Hai origin, and not the Railgun of the ES universe.

Originally, this replaced the name and deprecated the Railgun, but since we have display names for outfits, it's much more efficient to simply give it a display name, and have any compatibility issues untouched. This still means that any future Railgun-esque weapons cannot use the strict "Railgun" name for an outfit or assets, though other railguns could/would/should also have some sort of noun or adjective in their names anyway. 

Descriptions are still edited to match.

![image](https://github.com/endless-sky/endless-sky/assets/93169396/1b515a37-5d71-4323-adc6-7edc01fa9917)
