### PR TITLE
refactor: Remove now redundant conditions in deep archaeology

### DIFF
--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -114,8 +114,6 @@ mission "Deep Archaeology 3"
 		ship "Raven (Afterburner)" "D.P.S. Wyrd"
 		on kill
 			set "dps wyrd dead"
-		on capture
-			set "dps wyrd dead"
 	
 	npc
 		personality waiting
@@ -124,8 +122,6 @@ mission "Deep Archaeology 3"
 		ship "Raven (Afterburner)" "D.P.S. Skuld"
 		on kill
 			set "dps skuld dead"
-		on capture
-			set "dps skuld dead"
 	
 	npc
 		personality waiting
@@ -133,8 +129,6 @@ mission "Deep Archaeology 3"
 		government "Deep Security"
 		ship "Raven (Afterburner)" "D.P.S. Verthandi"
 		on kill
-			set "dps verthandi dead"
-		on capture
 			set "dps verthandi dead"
 	
 	on complete


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Commit 99a69a7ae1cab14f5b098775e6af16bad282155b (PR #9264) made "on kill" also function when ships are captured, removing the requirement of an additional "on capture" branch. I removed these branches from Deep Archaeology 3 and 5.

## Save File
This save file can be used to play through the new mission content:
[Endless-Sky any%~Deep Archaeology.txt](https://github.com/endless-sky/endless-sky/files/12514737/Endless-Sky.any.Deep.Archaeology.txt)
This is the same one as from PR #8582  where these conditions were initially added.

## Artwork Checklist
n/a