### PR TITLE
chore(ci): Update actions/checkout

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -22,7 +22,7 @@ jobs:
       OUTPUT: Endless_Sky-continuous-x86_64.AppImage
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
@@ -57,7 +57,7 @@ jobs:
       OUTPUT: EndlessSky-win64-continuous.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup sccache
         uses: ./.github/sccache
         with:
@@ -90,7 +90,7 @@ jobs:
       OUTPUT: EndlessSky-macOS-continuous.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup sccache
         uses: ./.github/sccache
         with:
@@ -129,7 +129,7 @@ jobs:
       OUTPUT_WINDOWS: EndlessSky-win64-continuous.zip
       OUTPUT_MACOS: EndlessSky-macOS-continuous.zip
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install github-release
         run: |
           go install github.com/github-release/github-release@latest

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -23,6 +23,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Install dependencies
         run: |
           sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
@@ -58,6 +60,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Setup sccache
         uses: ./.github/sccache
         with:
@@ -91,6 +95,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Setup sccache
         uses: ./.github/sccache
         with:
@@ -130,6 +136,8 @@ jobs:
       OUTPUT_MACOS: EndlessSky-macOS-continuous.zip
     steps:
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Install github-release
         run: |
           go install github.com/github-release/github-release@latest

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -12,7 +12,7 @@ jobs:
       OUTPUT: Endless_Sky-${{ github.ref_name }}-x86_64.AppImage
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
@@ -45,7 +45,7 @@ jobs:
       OUTPUT: EndlessSky-win32-${{ github.ref_name }}.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install x86 MinGW
         run: choco install mingw --forcex86 --force
       - uses: lukka/get-cmake@latest
@@ -81,7 +81,7 @@ jobs:
       OUTPUT: EndlessSky-win64-${{ github.ref_name }}.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup sccache
         uses: ./.github/sccache
         with:
@@ -119,7 +119,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OUTPUT: Endless-Sky-${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup sccache
         uses: ./.github/sccache
         with:
@@ -181,7 +181,7 @@ jobs:
       matrix:
         arch: [x64, x86]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build Endless Sky
       run: |
         cd steam
@@ -208,7 +208,7 @@ jobs:
       win64: steam-win64
       macos: steam-macos
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Upload Steam Data Depot
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -13,6 +13,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Install dependencies
         run: |
           sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
@@ -46,6 +48,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Install x86 MinGW
         run: choco install mingw --forcex86 --force
       - uses: lukka/get-cmake@latest
@@ -82,6 +86,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Setup sccache
         uses: ./.github/sccache
         with:
@@ -120,6 +126,8 @@ jobs:
       OUTPUT: Endless-Sky-${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Setup sccache
         uses: ./.github/sccache
         with:
@@ -182,6 +190,8 @@ jobs:
         arch: [x64, x86]
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build Endless Sky
       run: |
         cd steam
@@ -209,6 +219,8 @@ jobs:
       macos: steam-macos
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Upload Steam Data Depot
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install development dependencies
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
@@ -82,7 +82,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup sccache
       uses: ./.github/sccache
     - uses: lukka/get-cmake@latest
@@ -116,7 +116,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup sccache
       uses: ./.github/sccache
     - uses: lukka/get-cmake@latest
@@ -140,7 +140,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup sccache
       uses: ./.github/sccache
     - name: Install pkg-config
@@ -167,7 +167,7 @@ jobs:
       CONTINUOUS: EndlessSky-win64-continuous.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     # If no code changes occurred then we can download the latest continuous.
     - name: Download latest continuous
       if: ${{ needs.changed.outputs.game_code != 'true' && needs.changed.outputs.cmake_files != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Install development dependencies
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
@@ -83,6 +85,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Setup sccache
       uses: ./.github/sccache
     - uses: lukka/get-cmake@latest
@@ -117,6 +121,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Setup sccache
       uses: ./.github/sccache
     - uses: lukka/get-cmake@latest
@@ -141,6 +147,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Setup sccache
       uses: ./.github/sccache
     - name: Install pkg-config
@@ -168,6 +176,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     # If no code changes occurred then we can download the latest continuous.
     - name: Download latest continuous
       if: ${{ needs.changed.outputs.game_code != 'true' && needs.changed.outputs.cmake_files != 'true' }}

--- a/.github/workflows/compute-changes.yml
+++ b/.github/workflows/compute-changes.yml
@@ -51,7 +51,7 @@ jobs:
       parse_script: ${{ steps.filter.outputs.parse_script }}
       content_style_script: ${{ steps.filter.outputs.content_style_script }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - uses: dorny/paths-filter@v2

--- a/.github/workflows/compute-changes.yml
+++ b/.github/workflows/compute-changes.yml
@@ -54,6 +54,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 2
+        show-progress: false
     - uses: dorny/paths-filter@v2
       id: filter
       with:

--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ needs.changed.outputs.codeblocks_files == 'true' || needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: Validate Code::Blocks project files
@@ -36,7 +36,7 @@ jobs:
     if: ${{ needs.changed.outputs.cmake_files == 'true' || needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Validate CMake project files
       run: ./utils/check_cmake.sh
 
@@ -48,7 +48,7 @@ jobs:
     if: ${{ needs.changed.outputs.copyright == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: Install dependencies
@@ -63,7 +63,7 @@ jobs:
     if: ${{ needs.changed.outputs.data == 'true' || needs.changed.outputs.codespell == 'true' || needs.changed.outputs.changelog == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - uses: codespell-project/actions-codespell@master
@@ -80,7 +80,7 @@ jobs:
     if: ${{ needs.changed.outputs.editorconfig_files == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: editorconfig-checker/action-editorconfig-checker@main
     - run: editorconfig-checker
 
@@ -91,7 +91,7 @@ jobs:
     if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' || needs.changed.outputs.code_style_check == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
@@ -107,7 +107,7 @@ jobs:
     if: ${{ needs.changed.outputs.data == 'true' || needs.changed.outputs.content_style_check == 'true' || needs.changed.outputs.integration_tests == 'true' || needs.changed.outputs.content_style_script == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'

--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -25,7 +25,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1
         show-progress: false
     - name: Validate Code::Blocks project files
       run: ./utils/check_codeblocks.sh
@@ -53,7 +52,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1
         show-progress: false
     - name: Install dependencies
       run: python3 -m pip install --user python-debian

--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        show-progress: false
     - name: Validate Code::Blocks project files
       run: ./utils/check_codeblocks.sh
 
@@ -37,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Validate CMake project files
       run: ./utils/check_cmake.sh
 
@@ -51,6 +54,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        show-progress: false
     - name: Install dependencies
       run: python3 -m pip install --user python-debian
     - name: Validate copyright file
@@ -66,6 +70,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        show-progress: false
     - uses: codespell-project/actions-codespell@master
       with:
         builtin: clear,en-GB_to_en-US
@@ -81,6 +86,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - uses: editorconfig-checker/action-editorconfig-checker@main
     - run: editorconfig-checker
 
@@ -92,6 +99,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
@@ -108,6 +117,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -25,6 +25,8 @@ jobs:
       platform: com.valvesoftware.SteamRuntime.Platform-amd64,i386-sniper-runtime.tar.gz
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     # Build the binary
     - name: Save Steam runtime version

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -24,7 +24,7 @@ jobs:
       runtime: steam-container-runtime.tar.gz
       platform: com.valvesoftware.SteamRuntime.Platform-amd64,i386-sniper-runtime.tar.gz
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Build the binary
     - name: Save Steam runtime version


### PR DESCRIPTION
Updates the checkout action used in pretty much every CI/CD job. Unless I missed something, this is the only outdated action we are using.

Also disables progress reporting and removes some redundant configuration.