### PR TITLE
Fix caching that's been broken for a while

### DIFF
--- a/.github/sccache/action.yml
+++ b/.github/sccache/action.yml
@@ -30,7 +30,7 @@ runs:
       run: (Get-Item .).FullName >> $env:GITHUB_PATH
       shell: pwsh
     - name: Enable sccache
-      run: echo "SSCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+      run: echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
       shell: bash
     - name: Configure sccache
       uses: actions/github-script@v6

--- a/.github/sccache/action.yml
+++ b/.github/sccache/action.yml
@@ -1,14 +1,10 @@
 name: Install sccache
 description: Installs sccache for the current platform
-inputs:
-  read-only:
-    description: Whether the cache should be read-only
-    default: 'false'
 runs:
   using: 'composite'
   steps:
     - name: Set environment variables
-      run: echo "SCCACHE_VERSION=v0.5.4" >> $GITHUB_ENV
+      run: echo "SCCACHE_VERSION=v0.5.0" >> $GITHUB_ENV
       shell: bash
     - name: Download sccache
       run: |
@@ -33,12 +29,8 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       run: (Get-Item .).FullName >> $env:GITHUB_PATH
       shell: pwsh
-    - name: Write to the cache
-      if: ${{ inputs.read-only == 'false' && github.event_name == 'push' }}
-      run: echo "SCCACHE_GHA_CACHE_TO=sccache-${{ github.sha }}" >> $GITHUB_ENV
-      shell: bash
-    - name: Read from the cache
-      run: echo "SCCACHE_GHA_CACHE_FROM=sccache-" >> $GITHUB_ENV
+    - name: Enable sccache
+      run: echo "SSCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
       shell: bash
     - name: Configure sccache
       uses: actions/github-script@v6

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,8 +32,6 @@ jobs:
           sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev
       - name: Setup sccache
         uses: ./.github/sccache
-        with:
-          read-only: 'true'
       - name: Adjust version strings
         run: ./utils/cd_update_versions.sh
       - uses: lukka/get-cmake@latest
@@ -64,8 +62,6 @@ jobs:
           show-progress: false
       - name: Setup sccache
         uses: ./.github/sccache
-        with:
-          read-only: 'true'
       - name: Adjust version strings
         run: ./utils/cd_update_versions.sh
         shell: bash
@@ -99,8 +95,6 @@ jobs:
           show-progress: false
       - name: Setup sccache
         uses: ./.github/sccache
-        with:
-          read-only: 'true'
       - name: Install pkg-config
         run: type -P pkg-config || brew install pkg-config
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -22,8 +22,6 @@ jobs:
           sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev
       - name: Setup sccache
         uses: ./.github/sccache
-        with:
-          read-only: 'true'
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
@@ -90,8 +88,6 @@ jobs:
           show-progress: false
       - name: Setup sccache
         uses: ./.github/sccache
-        with:
-          read-only: 'true'
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
@@ -130,8 +126,6 @@ jobs:
           show-progress: false
       - name: Setup sccache
         uses: ./.github/sccache
-        with:
-          read-only: 'true'
       - name: Install pkg-config
         run: type -P pkg-config || brew install pkg-config
       - uses: lukka/get-cmake@latest

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,6 +28,7 @@
       },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
         "ES_USE_SYSTEM_LIBRARIES": "OFF"
       },
@@ -49,6 +50,7 @@
       },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
         "ES_USE_SYSTEM_LIBRARIES": "OFF",
         "BUILD_TESTING": "OFF"
       },
@@ -182,7 +184,6 @@
       "description": "Builds for Linux for CI purposes",
       "inherits": "ci",
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "VCPKG_HOST_TRIPLET": "linux64-release",
         "VCPKG_TARGET_TRIPLET": "linux64-release",
         "ES_USE_OFFSCREEN": "ON"
@@ -194,7 +195,6 @@
       "description": "Builds for Linux GLES for CI purposes",
       "inherits": "ci",
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "VCPKG_HOST_TRIPLET": "linux64-release",
         "VCPKG_TARGET_TRIPLET": "linux64-release",
         "ES_GLES": "ON",
@@ -207,7 +207,6 @@
       "description": "Builds for MacOS for CI purposes",
       "inherits": "ci",
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "VCPKG_HOST_TRIPLET": "macos64-release",
         "VCPKG_TARGET_TRIPLET": "macos64-release",
         "CMAKE_OSX_ARCHITECTURES": "x86_64",
@@ -220,7 +219,6 @@
       "description": "Builds with clang-cl for CI purposes",
       "inherits": "ci",
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "VCPKG_HOST_TRIPLET": "x64-windows-release",
         "VCPKG_TARGET_TRIPLET": "x64-windows-release",
         "CMAKE_CXX_COMPILER": "clang-cl.exe"
@@ -232,7 +230,6 @@
       "description": "Builds with MinGW for CI purposes",
       "inherits": "ci",
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "CMAKE_CXX_COMPILER": "x86_64-w64-mingw32-g++",
         "CMAKE_RC_COMPILER": "windres",
         "VCPKG_HOST_TRIPLET": "win64-release",


### PR DESCRIPTION
## Fix Details

- Downgrades sccache because the last 3 versions are currently broken
- sccache changed the environment variables to enable its cache somewhere along the way, which meant that nothing was cached
- Removes 'read-only' caches, because they don't really make sense anymore
- Avoid repeating the compiler launcher for CI builds in the preset file
- Reenabled warnings as error for CD builds, because if the command line flags are different the caches won't match.
- Reenabled PR cache writes (see below)

## Experiment

A while back we were constantly hitting GitHub's cache limit of 10GB because we were caching the object files of PRs too. As an experiment, I'm reenabling this caching now as an experiment to see if we will hit the cache limit again. The difference to before is that with sccache the caching is granular and only object files that have been changed will get written to cache, unlike before when we would cache every object file every single commit. This should help a lot in reducing cache duplication and hopefully, we won't hit the cache limit anymore.

If this is not the case, then we'll need to disable cache writing for PRs again.

## Testing Done

CI will test and then we can check the caches to see if anything has been cached. https://github.com/quyykk/endless-sky/pull/15