### PR TITLE
fix(cd): Don't skip artifact uploads to continuous

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -176,6 +176,7 @@ jobs:
         with:
           path: ${{ github.workspace }} # This will download all files to e.g `./EndlessSky-win64.zip/EndlessSky-win64.zip`
       - name: Add ${{ env.OUTPUT_APPIMAGE }} to release tag
+        continue-on-error: true
         run: |
           github-release upload \
             --tag continuous \
@@ -183,6 +184,7 @@ jobs:
             --name ${{ env.OUTPUT_APPIMAGE }} \
             --file ${{ env.OUTPUT_APPIMAGE }}/${{ env.OUTPUT_APPIMAGE }}
       - name: Add ${{ env.OUTPUT_WINDOWS }} to release tag
+        continue-on-error: true
         run: |
           github-release upload \
             --tag continuous \


### PR DESCRIPTION
**Bugfix:** This PR fixes an edge case where some build artifacts are not uploaded to the continuous release.

## Fix Details
If you check [this](https://github.com/endless-sky/endless-sky/actions/runs/6132248511/job/16643037290) CD job, you will see that the windows artifact's upload failed, causing the fresh macOS artifact to also not get uploaded because the job has already failed.

This PR makes the job continue even if one of the previous uploads fail, so all platforms with successful builds should get their latest artifact uploaded to continuous.

I didn't make the same change in the release CD because if something goes wrong there, having a big red error about it is probably more important than getting more build artifacts.

## Testing Done
I don't know how to test this tbh.

## Save File
N/A