### PR TITLE
Optimize memory usage when loading images at startup

### DIFF
--- a/source/SpriteQueue.cpp
+++ b/source/SpriteQueue.cpp
@@ -27,7 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	// The maximum amount of loded images in the queue that are
+	// The maximum number of loaded images in the queue that are
 	// waiting to be uploaded to the GPU.
 	constexpr int MAX_QUEUE = 100;
 }


### PR DESCRIPTION
## Details

This PR stops loading images past a certain number. For a very small time increase it can reduce memory usage by as much as 3x. (might even be more if for some reason your CPU has like 32 threads).

The following table represents the maximum amount of RAM used at any point during the program's startup. Note that the exact RAM used depends on your CPU (faster and/or thread count).

| | this PR | continuous |
|-|--|---|
| no plugins | 0.4 GB | 1.5 GB |
| high dpi | 1.2 GB| 4.2 GB|

## Performance Impact

The performance impact depends on your CPU, but in the absolute worst case it will be a couple of seconds more load time at startup I believe. I would expect an average CPU to only see a couple hundred ms impact if at all.

My machine sees no impact at all.