### PR TITLE
Clear the travel destination when the final system in the travel plan is changed

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -793,7 +793,7 @@ void MapPanel::Select(const System *system)
 	}
 
 	// Reset the travel destination if the final system in the travel plan has changed.
-	if(!plan.empty() && plan.front() != previousFinalSystem)
+	if(!plan.empty())
 		player.SetTravelDestination(nullptr);
 }
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -748,7 +748,6 @@ void MapPanel::Select(const System *system)
 	bool isJumping = flagship->IsEnteringHyperspace();
 	const System *source = isJumping ? flagship->GetTargetSystem() : &playerSystem;
 
-	const System *const previousFinalSystem = plan.empty() ? source : plan.front();
 
 	auto mod = SDL_GetModState();
 	// TODO: Whoever called Select should tell us what to do with this system vis-a-vis the travel plan, rather than

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -748,7 +748,7 @@ void MapPanel::Select(const System *system)
 	bool isJumping = flagship->IsEnteringHyperspace();
 	const System *source = isJumping ? flagship->GetTargetSystem() : &playerSystem;
 
-	const System const *previousFinalSystem = plan.empty() ? source : plan.front();
+	const System *const previousFinalSystem = plan.empty() ? source : plan.front();
 
 	auto mod = SDL_GetModState();
 	// TODO: Whoever called Select should tell us what to do with this system vis-a-vis the travel plan, rather than

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -748,7 +748,6 @@ void MapPanel::Select(const System *system)
 	bool isJumping = flagship->IsEnteringHyperspace();
 	const System *source = isJumping ? flagship->GetTargetSystem() : &playerSystem;
 
-
 	auto mod = SDL_GetModState();
 	// TODO: Whoever called Select should tell us what to do with this system vis-a-vis the travel plan, rather than
 	// possibly manipulating it both here and there. Or, we entirely separate Select from travel plan modifications.

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -748,6 +748,8 @@ void MapPanel::Select(const System *system)
 	bool isJumping = flagship->IsEnteringHyperspace();
 	const System *source = isJumping ? flagship->GetTargetSystem() : &playerSystem;
 
+	const System const *previousFinalSystem = plan.empty() ? source : plan.front();
+
 	auto mod = SDL_GetModState();
 	// TODO: Whoever called Select should tell us what to do with this system vis-a-vis the travel plan, rather than
 	// possibly manipulating it both here and there. Or, we entirely separate Select from travel plan modifications.
@@ -789,6 +791,10 @@ void MapPanel::Select(const System *system)
 		if(isJumping)
 			plan.push_back(source);
 	}
+
+	// Reset the travel destination if the final system in the travel plan has changed.
+	if(!plan.empty() && plan.front() != previousFinalSystem)
+		player.SetTravelDestination(nullptr);
 }
 
 


### PR DESCRIPTION
**Refactor:**

## Details
When a system is selected in the map, if that selection results in the final system in the travel plan being different to what it previously was, reset the travel destination planet.
I don't think not resetting this actually causes any problems at the moment, but it is more robust to ensure that it is cleared when the travel plan changes.

