### PR TITLE
Fix plugin name truncation

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -816,7 +816,7 @@ void PreferencesPanel::DrawPlugins()
 
 	const Sprite *box[2] = { SpriteSet::Get("ui/unchecked"), SpriteSet::Get("ui/checked") };
 
-	const int MAX_TEXT_WIDTH = 230;
+	const int MAX_TEXT_WIDTH = 210;
 	Table table;
 	table.AddColumn(-115, {MAX_TEXT_WIDTH, Truncate::MIDDLE});
 	table.SetUnderline(-120, 100);


### PR DESCRIPTION
**Bugfix:**

## Fix Details
When the checkboxes were added to the plugin panel, the x coordinate at which the plugin name starts was moved to the right by 20 pixels, but the allowed width for the plugin name was not reduced and so plugin names can currently extend beyond the expected region before they are truncated.
This reduces the allowed width by 20 pixels to account for the reduced space.

## Testing Done
Open the plugin panel with a plugin that has a very long name and see it is now truncated to an appropriate length, staying within the box for the plugin list.

