### PR TITLE
Fix usage of SDL_GetPrefPath

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -154,6 +154,9 @@ void Files::Init(const char * const *argv)
 	if(config.back() != '/')
 		config += '/';
 
+	if(!Exists(config))
+		throw runtime_error("Unable to create config directory!");
+
 	savePath = config + "saves/";
 	CreateFolder(savePath);
 
@@ -165,7 +168,9 @@ void Files::Init(const char * const *argv)
 	if(!Exists(dataPath) || !Exists(imagePath) || !Exists(soundPath))
 		throw runtime_error("Unable to find the resource directories!");
 	if(!Exists(savePath))
-		throw runtime_error("Unable to create config directory!");
+		throw runtime_error("Unable to create save directory!");
+	if(!Exists(config + "plugins/"))
+		throw runtime_error("Unable to create plugins directory!");
 }
 
 

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -556,7 +556,7 @@ void Files::Write(FILE *file, const string &data)
 
 void Files::CreateFolder(const std::string &path)
 {
-	if(Files::Exists(path))
+	if(Exists(path))
 		return;
 
 #ifdef _WIN32

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -140,38 +140,26 @@ void Files::Init(const char * const *argv)
 
 	if(config.empty())
 	{
-		// Find the path to the directory for saved games (and create it if it does
-		// not already exist). This can also be overridden in the command line.
-		char *str = SDL_GetPrefPath("endless-sky", "saves");
+		// Create the directory for the saved games, preferences, etc., if necessary.
+		char *str = SDL_GetPrefPath(nullptr, "endless-sky");
 		if(!str)
-			throw runtime_error("Unable to get path to saves directory!");
-
-		savePath = str;
-#if defined _WIN32
-		FixWindowsSlashes(savePath);
-#endif
+			throw runtime_error("Unable to get path to config directory!");
+		config = str;
 		SDL_free(str);
-		if(savePath.back() != '/')
-			savePath += '/';
-		config = savePath.substr(0, savePath.rfind('/', savePath.length() - 2) + 1);
 	}
-	else
-	{
-#if defined _WIN32
-		FixWindowsSlashes(config);
+
+#ifdef _WIN32
+	FixWindowsSlashes(config);
 #endif
-		if(config.back() != '/')
-			config += '/';
-		savePath = config + "saves/";
-	}
+	if(config.back() != '/')
+		config += '/';
+
+	savePath = config + "saves/";
+	CreateDirectory(savePath);
 
 	// Create the "plugins" directory if it does not yet exist, so that it is
 	// clear to the user where plugins should go.
-	{
-		char *str = SDL_GetPrefPath("endless-sky", "plugins");
-		if(str != nullptr)
-			SDL_free(str);
-	}
+	CreateDirectory(config + "plugins/");
 
 	// Check that all the directories exist.
 	if(!Exists(dataPath) || !Exists(imagePath) || !Exists(soundPath))
@@ -558,6 +546,21 @@ void Files::Write(FILE *file, const string &data)
 
 	fwrite(&data[0], 1, data.size(), file);
 }
+
+
+
+void Files::CreateDirectory(const std::string &path)
+{
+	if(Files::Exists(path))
+		return;
+
+#ifdef _WIN32
+	CreateDirectoryW(Utf8::ToUtf16(path).c_str(), nullptr);
+#else
+	mkdir(path.c_str(), 0700);
+#endif
+}
+
 
 
 

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -555,7 +555,7 @@ void Files::CreateFolder(const std::string &path)
 		return;
 
 #ifdef _WIN32
-	CreateDirectoryW(Utf8::ToUtf16(path).c_str(), nullptr);
+	CreateDirectoryW(Utf8::ToUTF16(path).c_str(), nullptr);
 #else
 	mkdir(path.c_str(), 0700);
 #endif

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -155,11 +155,11 @@ void Files::Init(const char * const *argv)
 		config += '/';
 
 	savePath = config + "saves/";
-	CreateDirectory(savePath);
+	CreateFolder(savePath);
 
 	// Create the "plugins" directory if it does not yet exist, so that it is
 	// clear to the user where plugins should go.
-	CreateDirectory(config + "plugins/");
+	CreateFolder(config + "plugins/");
 
 	// Check that all the directories exist.
 	if(!Exists(dataPath) || !Exists(imagePath) || !Exists(soundPath))
@@ -549,7 +549,7 @@ void Files::Write(FILE *file, const string &data)
 
 
 
-void Files::CreateDirectory(const std::string &path)
+void Files::CreateFolder(const std::string &path)
 {
 	if(Files::Exists(path))
 		return;

--- a/source/Files.h
+++ b/source/Files.h
@@ -68,7 +68,7 @@ public:
 	static std::string Read(FILE *file);
 	static void Write(const std::string &path, const std::string &data);
 	static void Write(FILE *file, const std::string &data);
-	static void CreateDirectory(const std::string &path);
+	static void CreateFolder(const std::string &path);
 
 	// Open this user's plugins directory in their native file explorer.
 	static void OpenUserPluginFolder();

--- a/source/Files.h
+++ b/source/Files.h
@@ -68,6 +68,7 @@ public:
 	static std::string Read(FILE *file);
 	static void Write(const std::string &path, const std::string &data);
 	static void Write(FILE *file, const std::string &data);
+	static void CreateDirectory(const std::string &path);
 
 	// Open this user's plugins directory in their native file explorer.
 	static void OpenUserPluginFolder();


### PR DESCRIPTION
**Bugfix:** This PR addresses fixes #9295 

## Fix Details

This corrects the SDL_GetPrefPath call, to properly get the user-defined config folder on every platform. This was broken on Android.

/cc @thewierdnut 

## Testing Done

Tested this on Linux. I haven't tested the others, but I don't expect there to be any problems.