### PR TITLE
Fix "Trash Fire Crops" source location filter

### DIFF
--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -143,7 +143,8 @@ mission "Trash Fire Crops"
 	minor
 	source
 		government "Republic"
-		attributes "dirt belt" "farming"
+		attributes "dirt belt"
+		attributes "farming"
 		not attributes "station"
 	to offer
 		random < 1


### PR DESCRIPTION
**Bugfix:**

## Fix Details
`attributes "dirt belt" "farming"` matches locations with either of these attributes. This doesn't seem to match the content of the conversation. It includes farming worlds that aren't in the dirt belt and dirt belt worlds that aren't farming.

```
attributes "dirt belt"
attributes "farming"
```
Will only match locations with both of these attributes, which is much more in line with the conversation.

## Testing Done

<details> <summary>Planets matched by the current filter:</summary>

Arabia
Big Sky
Bounty
Clark
Cornucopia
Darkstone
Flood
Gemstone
Harmony
Heartland
Hopper
Ingot
Lichen
Mars
New Argentina
New Austria
New Boston
New Britain
New Greenland
New Holland
New Iceland
New India
New Kansas
New Portland
New Sahara
New Tibet
New Wales
New Washington
Oasis
Oblivion
Poisonwood
Rand
Rust
Sinter
Skillet
Splashdown
Starcross
Sundrinker
Tundra
Vail
Valhalla
Watcher
Zug

</details>

<details> <summary>Worlds matched by the filter in this PR:</summary>

Big Sky
Bounty
Heartland
New Argentina
New Boston
New Britain
New Holland
New India
New Portland

</details>

