### PR TITLE
Default to Wayland under Linux

### DIFF
--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -75,6 +75,10 @@ bool GameWindow::Init()
 	// Tell Windows this process is high dpi aware and doesn't need to get scaled.
 	SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
 #endif
+#ifdef __linux__
+	// Default to Wayland under Linux
+	SDL_SetHint(SDL_HINT_VIDEODRIVER, "wayland,x11");
+#endif
 
 	// This needs to be called before any other SDL commands.
 	if(SDL_Init(SDL_INIT_VIDEO) != 0)


### PR DESCRIPTION
**Feature:** This **experimental** PR makes the game use the Wayland compositor on linux by default.

## Feature Details
SDL2 is in the process of transitioning to Wayland, so it's time to start testing if ES will run properly for everyone when the change happens. (It probably will, but you never know.)

This PR provides a Wayland version for public testing. (The game can still run on X11, but it prefers Wayland now.)

If there are no issues, we could even merge this to continuous for a bit to get more people to test it out.

## UI Screenshots
N/A

## Usage Examples
N/A

## Testing Done
The testing was done with a self-compiled version using SDL 2.28.3.
- [x] - The game is running on Wayland in the PR, and on XWayland in master
- [x] - No crashes on startup
- [x] - Changing and using key bindings (including caps lock and modifiers)
- [x] - Effects

On my end, everything appears to be working, but please test in on your system.

### Automated Tests Added
N/A

## Performance Impact
Probably negligible, but might vary across different configurations. Might even be faster.
