### PR TITLE
Use correct version of brown dwarf sprite

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -2448,7 +2448,7 @@ system "Ae Il A-3"
 			period 60
 			offset 20
 	object
-		sprite planet/browndwarf-l-rouge
+		sprite planet/browndwarf-l
 		distance 9784.96
 		period 1100
 		offset 270


### PR DESCRIPTION
**Bugfix:**

## Fix Details
The "rouge" (rogue) brown dwarf sprites are rendered with self-illumination, for use when the object does not have a parent star and has no nearby light source to illuminate it in the usual way.
This system contains four stars, so this brown dwarf is clearly not a rogue planet.
This PR switches the object from using a rogue brown dwarf sprite to the corresponding normal brown dwarf sprite.
