### PR TITLE
Make the player takeoff from the ringworld dock it landed on

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -352,7 +352,8 @@ void Engine::Place()
 			const Personality &person = ship->GetPersonality();
 			bool hasOwnPlanet = ship->GetPlanet();
 			bool launchesWithPlayer = (planet && planet->CanLand(*ship))
-					&& !(person.IsStaying() || person.IsWaiting() || hasOwnPlanet);
+					&& !person.IsStaying() && !person.IsWaiting()
+					&& (!hasOwnPlanet || (ship->IsYours() && ship->GetPlanet() == planet));
 			const StellarObject *object = hasOwnPlanet ?
 					ship->GetSystem()->FindStellar(ship->GetPlanet()) : nullptr;
 			// Default to the player's planet in the case of data definition errors.


### PR DESCRIPTION
## Fix Details

As the title said. Departing from a ringworld now makes you depart from the exact dock you landed on originally, instead of always the same one.

## Testing Done

Landed on a ringworld in many difference places, made sure that I always departed from the same place.