### PR TITLE
Fix fewer crew than required 

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -305,7 +305,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 	const CargoHold &cargo = player.DistributeCargo();
 	// Are you overbooked? Don't count fireable flagship crew.
 	// (If your ship can't support its required crew, it is counted as having no fireable crew.)
-	const int overbooked = cargo.Passengers() - flagship->Crew() + flagship->RequiredCrew();
+	const int overbooked = cargo.Passengers() - max(0, flagship->Crew() - flagship->RequiredCrew());
 	const int missionCargoToSell = cargo.MissionCargoSize();
 	// Will you have to sell something other than regular cargo?
 	const int commoditiesToSell = cargo.CommoditiesSize();


### PR DESCRIPTION
**Bugfix:**

## Fix Details
This bound was previously removed by mistake.
Not having it means that, if you try taking off with fewer crew than your ship requires, the game will think you are "overbooked," that is, it thinks you have more mission passengers than you can carry, even when this is not the case.

## Testing Done
Use the below save file.
Without this PR, attempting to depart gives a dialog indicating that a mission will be aborted because I cannot carry 48 of its passengers, even though the mission only has 1 passenger and I have plenty of bunks for it (it will actually give the warning even if I have no missions.) Taking off doesn't actually abort the mission.
With this PR, no warning is displayed.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using a576744, and will not occur when using this branch's build.
[warp core Misreported overbooking~original.txt](https://github.com/endless-sky/endless-sky/files/12704933/warp.core.Misreported.overbooking.original.txt)

