### PR TITLE
Add editorconfig for credits file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,11 @@ indent_style = unset
 indent_style = space
 indent_size = 2
 
+# Credits file
+[credits.txt]
+indent_style = space
+indent_size = 2
+
 # Markdown
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
**Feature:**

## Feature Details
Adds an entry in the .editorconfig file for the credits.txt file.
Without this, VSCode expects 4 space wide tabs for indentation, marking the double space indentations used in this file as erroneous, and will not use this indentation style. With this, it recognises those indentations as correct and will use that indentation style itself.
