### PR TITLE
Fix crash when opening the outfitter

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -132,7 +132,7 @@ bool OutfitterPanel::HasItem(const string &name) const
 	if(showCargo && player.Cargo().Get(outfit))
 		return true;
 
-	if(showStorage && player.Storage() && player.Storage()->Get(outfit))
+	if(showStorage && player.Storage().Get(outfit))
 		return true;
 
 	for(const Ship *ship : playerShips)
@@ -198,7 +198,7 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 	if(!outfitter.Has(outfit) && outfit->Get("installable") >= 0.)
 		stock = max(0, player.Stock(outfit));
 	int cargo = player.Cargo().Get(outfit);
-	int storage = player.Storage() ? player.Storage()->Get(outfit) : 0;
+	int storage = player.Storage().Get(outfit);
 
 	string message;
 	if(cargo && storage && stock)
@@ -335,7 +335,7 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 
 	// Check if the outfit is available to get at all.
 	bool isInCargo = player.Cargo().Get(selectedOutfit);
-	bool isInStorage = player.Storage() && player.Storage()->Get(selectedOutfit);
+	bool isInStorage = player.Storage().Get(selectedOutfit);
 	bool isInStore = outfitter.Has(selectedOutfit) || player.Stock(selectedOutfit) > 0;
 	if(isInStorage && (onlyOwned || isInStore || playerShip))
 	{
@@ -504,10 +504,10 @@ void OutfitterPanel::Buy(bool onlyOwned)
 		{
 			if(onlyOwned)
 			{
-				if(!player.Storage() || !player.Storage()->Get(selectedOutfit))
+				if(!player.Storage().Get(selectedOutfit))
 					continue;
 				player.Cargo().Add(selectedOutfit);
-				player.Storage()->Remove(selectedOutfit);
+				player.Storage().Remove(selectedOutfit);
 			}
 			else
 			{
@@ -532,8 +532,8 @@ void OutfitterPanel::Buy(bool onlyOwned)
 
 			if(player.Cargo().Get(selectedOutfit))
 				player.Cargo().Remove(selectedOutfit);
-			else if(player.Storage() && player.Storage()->Get(selectedOutfit))
-				player.Storage()->Remove(selectedOutfit);
+			else if(player.Storage().Get(selectedOutfit))
+				player.Storage().Remove(selectedOutfit);
 			else if(onlyOwned || !(player.Stock(selectedOutfit) > 0 || outfitter.Has(selectedOutfit)))
 				break;
 			else
@@ -561,7 +561,7 @@ bool OutfitterPanel::CanSell(bool toStorage) const
 	if(player.Cargo().Get(selectedOutfit))
 		return true;
 
-	if(!toStorage && player.Storage() && player.Storage()->Get(selectedOutfit))
+	if(!toStorage && player.Storage().Get(selectedOutfit))
 		return true;
 
 	for(const Ship *ship : playerShips)
@@ -575,15 +575,12 @@ bool OutfitterPanel::CanSell(bool toStorage) const
 
 void OutfitterPanel::Sell(bool toStorage)
 {
-	// Retrieve the players storage. If we want to store to storage, then
-	// we also request storage to be created if possible.
-	// Will be nullptr if no storage is available.
-	CargoHold *storage = player.Storage(toStorage);
+	CargoHold &storage = player.Storage();
 
 	if(player.Cargo().Get(selectedOutfit))
 	{
 		player.Cargo().Remove(selectedOutfit);
-		if(toStorage && storage && storage->Add(selectedOutfit))
+		if(toStorage && storage.Add(selectedOutfit))
 		{
 			// Transfer to planetary storage completed.
 			// The storage->Add() function should never fail as long as
@@ -611,7 +608,7 @@ void OutfitterPanel::Sell(bool toStorage)
 				ship->AddCrew(-selectedOutfit->Get("required crew"));
 			ship->Recharge();
 
-			if(toStorage && storage && storage->Add(selectedOutfit))
+			if(toStorage && storage.Add(selectedOutfit))
 			{
 				// Transfer to planetary storage completed.
 			}
@@ -643,8 +640,8 @@ void OutfitterPanel::Sell(bool toStorage)
 				if(mustSell)
 				{
 					ship->AddOutfit(ammo, -mustSell);
-					if(toStorage && storage)
-						mustSell -= storage->Add(ammo, mustSell);
+					if(toStorage)
+						mustSell -= storage.Add(ammo, mustSell);
 					if(mustSell)
 					{
 						int64_t price = player.FleetDepreciation().Value(ammo, day, mustSell);
@@ -657,9 +654,9 @@ void OutfitterPanel::Sell(bool toStorage)
 		return;
 	}
 
-	if(!toStorage && storage && storage->Get(selectedOutfit))
+	if(!toStorage && storage.Get(selectedOutfit))
 	{
-		storage->Remove(selectedOutfit);
+		storage.Remove(selectedOutfit);
 		int64_t price = player.FleetDepreciation().Value(selectedOutfit, day);
 		player.Accounts().AddCredits(price);
 		player.AddStock(selectedOutfit, 1);
@@ -680,7 +677,7 @@ void OutfitterPanel::FailSell(bool toStorage) const
 	else
 	{
 		bool hasOutfit = player.Cargo().Get(selectedOutfit);
-		hasOutfit = hasOutfit || (!toStorage && player.Storage() && player.Storage()->Get(selectedOutfit));
+		hasOutfit = hasOutfit || (!toStorage && player.Storage().Get(selectedOutfit));
 		for(const Ship *ship : playerShips)
 			if(ship->OutfitCount(selectedOutfit))
 			{
@@ -894,7 +891,7 @@ void OutfitterPanel::CheckRefill()
 			if(amount > 0)
 			{
 				bool available = outfitter.Has(outfit) || player.Stock(outfit) > 0;
-				available = available || player.Cargo().Get(outfit) || player.Storage()->Get(outfit);
+				available = available || player.Cargo().Get(outfit) || player.Storage().Get(outfit);
 				if(available)
 					needed[outfit] += amount;
 			}
@@ -905,7 +902,7 @@ void OutfitterPanel::CheckRefill()
 	for(auto &it : needed)
 	{
 		// Don't count cost of anything installed from cargo or storage.
-		it.second = max(0, it.second - player.Cargo().Get(it.first) - player.Storage()->Get(it.first));
+		it.second = max(0, it.second - player.Cargo().Get(it.first) - player.Storage().Get(it.first));
 		if(!outfitter.Has(it.first))
 			it.second = min(it.second, max(0, player.Stock(it.first)));
 		cost += player.StockDepreciation().Value(it.first, day, it.second);
@@ -937,7 +934,7 @@ void OutfitterPanel::Refill()
 			if(neededAmmo > 0)
 			{
 				// Fill first from any stockpiles in storage.
-				const int fromStorage = player.Storage()->Remove(outfit, neededAmmo);
+				const int fromStorage = player.Storage().Remove(outfit, neededAmmo);
 				neededAmmo -= fromStorage;
 				// Then from cargo.
 				const int fromCargo = player.Cargo().Remove(outfit, neededAmmo);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1410,16 +1410,11 @@ const CargoHold &PlayerInfo::Cargo() const
 
 
 
-// Get planetary storage information for current planet. Returns a pointer,
-// since we might not be on a planet, or since the storage might be empty.
-CargoHold *PlayerInfo::Storage(bool forceCreate)
+// Get items stored on the player's current planet.
+CargoHold &PlayerInfo::Storage()
 {
-	if(planet && (forceCreate || planetaryStorage.count(planet)))
-		return &(planetaryStorage[planet]);
-
-	// Nullptr can be returned when forceCreate is true if there is no
-	// planet; nullptr is the best we can offer in such cases.
-	return nullptr;
+	assert(planet && "can't get planetary storage in-flight");
+	return planetaryStorage[planet];
 }
 
 
@@ -1792,7 +1787,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 				// Transfer the outfits from cargo to the storage on this planet.
 				if(!outfit.second)
 					continue;
-				cargo.Transfer(outfit.first, outfit.second, *Storage(true));
+				cargo.Transfer(outfit.first, outfit.second, Storage());
 			}
 	}
 	accounts.AddCredits(income);

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -185,7 +185,7 @@ public:
 	CargoHold &Cargo();
 	const CargoHold &Cargo() const;
 	// Get items stored on the player's current planet.
-	CargoHold *Storage(bool forceCreate = false);
+	CargoHold &Storage();
 	// Get items stored on all planets (for map display).
 	const std::map<const Planet *, CargoHold> &PlanetaryStorage() const;
 	// Get cost basis for commodities.

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -240,7 +240,7 @@ bool ShopPanel::CanSellMultiple() const
 bool ShopPanel::IsAlreadyOwned() const
 {
 	return (playerShip && selectedOutfit && player.Cargo().Get(selectedOutfit))
-		|| (player.Storage() && player.Storage()->Get(selectedOutfit));
+		|| player.Storage().Get(selectedOutfit);
 }
 
 
@@ -610,7 +610,7 @@ int64_t ShopPanel::LicenseCost(const Outfit *outfit, bool onlyOwned) const
 	// If the player is attempting to install an outfit from cargo, storage, or that they just
 	// sold to the shop, then ignore its license requirement, if any. (Otherwise there
 	// would be no way to use or transfer license-restricted outfits between ships.)
-	bool owned = (player.Cargo().Get(outfit) && playerShip) || (player.Storage() && player.Storage()->Get(outfit));
+	bool owned = (player.Cargo().Get(outfit) && playerShip) || player.Storage().Get(outfit);
 	if((owned && onlyOwned) || player.Stock(outfit) > 0)
 		return 0;
 


### PR DESCRIPTION
**Bugfix:** This PR fixes #9334 

## Fix Details

Refactors the problematic function in question to always return a valid storage.

## Testing Done

Open the outfitter with a ship that needs ammo on a planet without storage. Without this PR, it crashes.

