### PR TITLE
Recategorises the Heliarch License

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -432,6 +432,6 @@ outfit "Coalition License"
 	description "Completed a lot of Coalition jobs and received permission to purchase civilian technology and ships."
 
 outfit "Heliarch License"
-	category "Special"
+	category "Licenses"
 	thumbnail "outfit/heliarch license"
 	description "An ornate circlet of gold and platinum, it serves as both a symbol of rank and as a license to access exclusive Heliarch facilities. Custom-made to fit a human's head, it's surprisingly light and comfortable."


### PR DESCRIPTION
(this doesn't really fit anywhere so I'm just going to put it as a fix)

## Fix Details
Recategorises the Heliarch License to conform with all other licenses

## Testing Done
<img width="435" alt="image" src="https://github.com/endless-sky/endless-sky/assets/32188044/53fdffaf-380d-476f-b4a4-ea6c7768f465">