### PR TITLE
Fix performance regression in Omnis system

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -504,8 +504,9 @@ void Engine::Step(bool isActive)
 		centerVelocity = flagship->Velocity();
 		if(flagship->IsHyperspacing() && Preferences::Has("Extended jump effects"))
 			centerVelocity *= 1. + pow(flagship->GetHyperspacePercentage() / 20., 2);
-		if(doEnter)
+		if(doEnterLabels)
 		{
+			doEnterLabels = false;
 			// Create the planet labels as soon as we entered a new system.
 			labels.clear();
 			for(const StellarObject &object : player.GetSystem()->Objects())
@@ -1264,6 +1265,7 @@ void Engine::EnterSystem()
 		return;
 
 	doEnter = true;
+	doEnterLabels = true;
 	player.IncrementDate();
 	const Date &today = player.GetDate();
 

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -230,6 +230,7 @@ private:
 	int alarmTime = 0;
 	double flash = 0.;
 	bool doFlash = false;
+	bool doEnterLabels = false;
 	bool doEnter = false;
 	bool hadHostiles = false;
 


### PR DESCRIPTION
## Feature Details

Fixes a performance regression in systems with a lot of planet labels introduced in f52da6510be9310675eba63b182334278706141d

## Testing Done

The planet labels still appear.