### PR TITLE
2 quick fixes to Coalition Intros

### DIFF
--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -1467,7 +1467,6 @@ mission "Heliarch Containment 4-A"
 	description "Escort three Kimek Spires full of Heliarch agents to <destination>, where they hope the use of civilian ships will give them the element of surprise."
 	to offer
 		has "event: plasma turret available"
-		has "Heliarch Containment 2: done"
 		has "Heliarch Containment 3: done"
 		not "Lunarium: Questions: done"
 		not "assisting lunarium"

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -1326,6 +1326,7 @@ mission "Lunarium: Propaganda 1"
 	destination "Bright Echo"
 	to offer
 		random < 25
+		has "Coalition: First Contact: done"
 		not "Heliarch License: done"
 		not "assisting heliarchy"
 	on offer


### PR DESCRIPTION
----------------------
**Content (Fix)**

## Summary
Propaganda mission chain didn't require First Contact, which could get potentially awkward.
Containment mission chain had a redundant requirement for mission 2 to have been done by mission 4, despite mission 4 requiring mission 3 to be done and mission 3 requiring mission 2 to be done.