### PR TITLE
Fix catch 22 in new south mission

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6374,7 +6374,7 @@ mission "Care Package to South 3a"
 	landing
 	invisible
 	to offer
-		has "Care Package to South 3a: offered"
+		has "Care Package to South 2a: offered"
 		has "FW Pirates: Attack 3: done"
 	on offer
 		conversation


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
A week or two ago a series of new missions in the galactic south were committed in 7379ea7c27356ded3bb8ffc01e89adbb2bf7ff32 as part of PR #9097, however, one of them contained a circular dependency/catch 22 where a mission required itself to be offered in order to offer, as mentioned by @waterhouse [here](https://github.com/endless-sky/endless-sky/pull/9097#discussion_r1330033604). It looks like this was supposed to require the previous mission to offer, so that's what it does now.

## Save File
This save file can be used to play through the new mission content:
The original PR didn't appear to need a save file, so I'm not providing one here. If necessary, I or the OP can provide one.

## Artwork Checklist
~~- [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified~~
~~- [ ] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}~~
~~- [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}~~
Not applicable