### PR TITLE
Give some Heliarch missions "on abort" triggers

### DIFF
--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -1138,6 +1138,9 @@ mission "Heliarch Expedition 3"
 		"assisting heliarchy" ++
 	on complete
 		"assisting heliarchy" --
+	# No penalty for aborting this mission.
+	on abort
+		"assisting heliarchy" --
 	on fail
 		"assisting heliarchy" --
 		"reputation: Heliarch" = -1000
@@ -1191,6 +1194,9 @@ mission "Heliarch Expedition 4"
 			`	"True that is, but repealed, the measure that prohibits everyone leaving was not. Spoken with Arbiter Sedlitaris myself I did, and admit I must that much more at ease I now am. But, still, remain vigilant for the crew's sake, I must. Changed their opinions like me, not many of them have."`
 			label end
 			`	He thanks you again for your help, and with a salute bids you farewell, heading to help the Punisher's crew establish their base of operations inside the caverns. You get back in your ship and fly back to the empty docks of <planet>. Now it's a matter of waiting for the Heliarch teams here to do their job and return to the Coalition.`
+	# No penalty for aborting this mission.
+	on abort
+		"assisting heliarchy" --
 	on fail
 		"assisting heliarchy" --
 		"reputation: Heliarch" = -1000
@@ -2019,6 +2025,9 @@ mission "Heliarch Drills 3"
 			dialog `The Punisher's captain tries to hail you as the ship collapses around them, but you never get to hear their final cries. You have failed to simply disable the ship, and doomed the entire crew. It seems that you will not be welcome in Coalition space any longer.`
 	on accept
 		"assisting heliarchy" ++
+	# No penalty for aborting this mission.
+	on abort
+		"assisting heliarchy" --
 	on fail
 		"assisting heliarchy" --
 		"reputation: Heliarch" = -1000

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -1138,7 +1138,7 @@ mission "Heliarch Expedition 3"
 		"assisting heliarchy" ++
 	on complete
 		"assisting heliarchy" --
-	# No penalty for aborting this mission.
+	# No reputation penalty for aborting this mission.
 	on abort
 		"assisting heliarchy" --
 	on fail
@@ -1194,7 +1194,7 @@ mission "Heliarch Expedition 4"
 			`	"True that is, but repealed, the measure that prohibits everyone leaving was not. Spoken with Arbiter Sedlitaris myself I did, and admit I must that much more at ease I now am. But, still, remain vigilant for the crew's sake, I must. Changed their opinions like me, not many of them have."`
 			label end
 			`	He thanks you again for your help, and with a salute bids you farewell, heading to help the Punisher's crew establish their base of operations inside the caverns. You get back in your ship and fly back to the empty docks of <planet>. Now it's a matter of waiting for the Heliarch teams here to do their job and return to the Coalition.`
-	# No penalty for aborting this mission.
+	# No reputation penalty for aborting this mission.
 	on abort
 		"assisting heliarchy" --
 	on fail
@@ -2025,7 +2025,7 @@ mission "Heliarch Drills 3"
 			dialog `The Punisher's captain tries to hail you as the ship collapses around them, but you never get to hear their final cries. You have failed to simply disable the ship, and doomed the entire crew. It seems that you will not be welcome in Coalition space any longer.`
 	on accept
 		"assisting heliarchy" ++
-	# No penalty for aborting this mission.
+	# No reputation penalty for aborting this mission.
 	on abort
 		"assisting heliarchy" --
 	on fail


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
These missions incur significant reputation penalties when they are failed.
These probably shouldn't apply if the player simply aborts them because they don't want to do them, so the missions need explicit "on abort" triggers else the "on fail" ones will be triggered when aborting.
This adds "on abort" triggers to these missions which do not apply the reputation penalties.
