### PR TITLE
Fix secure package delivery message

### DIFF
--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -469,7 +469,7 @@ phrase "secure package dropoff payment"
 	word
 		` `
 	word
-		`Your bank account immediately notifies you that the agreed-upon payment of <payment> has been deposited. You wonder how they knew.`
+		`Your bank account immediately notifies you that the agreed-upon payment of <payment> has been deposited.`
 
 
 mission "Secure Transport Job (Secret) [0]"


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #7825 

## Fix Details
As mentioned in the bug, there is an apparent oversight where, upon dropping off a "secure package" to a security officer, police officer, ship captain, or reception counter, you wonder how the bank knew the delivery was a success, even though the answer is pretty clear. This is unlike the mystery boxes where you place them in discrete locations. This PR fixes that issue by removing the line of text where you wonder how the bank knew.

## Testing Done
I looked at the various places you could deliver the secure package to in the message:
reception counter: the receptionist reports the delivery
spaceport security officer: they report the delivery
curiosities store: this is the most likely issue. If needed, I can try separating this from the others and having two phrases, one with this one message saying "you wonder how they knew" with a weight of 1 and the main phrase with a weight of 5. It could still be justified as there was someone working at the store who you delivered the package to.
plainclothes officer: they report the delivery
old lady: they report the delivery
ship captain: they report the delivery

## Save File
No save file needed at the moment. I might add one if I end up splitting the one phrase group to make sure the phrases offer equally.