### PR TITLE
fix: Fix missing reference parameter

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -901,7 +901,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 				// Find the possible parents for orphaned fighters and drones.
 				auto parentChoices = vector<shared_ptr<Ship>>{};
 				parentChoices.reserve(ships.size() * .1);
-				auto getParentFrom = [&it, &gov, &parentChoices](const list<shared_ptr<Ship>> otherShips) -> shared_ptr<Ship>
+				auto getParentFrom = [&it, &gov, &parentChoices](const list<shared_ptr<Ship>> &otherShips) -> shared_ptr<Ship>
 				{
 					for(const auto &other : otherShips)
 						if(other->GetGovernment() == gov && other->GetSystem() == it->GetSystem() && !other->CanBeCarried())


### PR DESCRIPTION
**Bugfix:** This PR addresses a long-standing performance issue in the game engine.

## Fix Details
One of the lambda functions was copying a massive list of ships on every call, because it wasn't using a reference parameter.

The issue was found by @quyykk using my profiling data.

## Testing Done
Profiling data gathered using CLion's C++ profiler. 

Before:
![Screenshot 2023-09-28_20:20:58](https://github.com/endless-sky/endless-sky/assets/68112292/928a020e-06d4-4c66-ab32-ce15b79c2b2b)

After:
![Screenshot 2023-09-28_20:40:06](https://github.com/endless-sky/endless-sky/assets/68112292/fd5b8083-3d70-4179-b300-8d932d3c5c9b)

The massive amount of malloc/free calls are gone.

The in-game reporting of CPU usage went from 1200%+ to 500-550%, which is a massive improvement.

## Save File
[Test Pilot.txt](https://github.com/endless-sky/endless-sky/files/12752926/Test.Pilot.txt)
