### PR TITLE
feat(content): Adjust how "Heliarch Drill 3" `fails`

### DIFF
--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2030,13 +2030,13 @@ mission "Heliarch Drills 3"
 			"assisting heliarchy" --
 			"reputation: Heliarch" = -1000
 			"reputation: Coalition" = -1000
-			dialog `Although you've disabled the Punisher, you decide to move in and board the ship in order to salvage it, breaking any trust the Heliarchs had in you. It seems that you will not be welcome in Coalition space any longer.`
+			dialog `Although you've disabled the Punisher, you decide to move in and board the ship in order to salvage it, breaking any trust the Heliarchs had in you. They, and the rest of the Coalition, will not be pleased with this.`
 		on capture
 			fail
 			"assisting heliarchy" --
 			"reputation: Heliarch" = -1000
 			"reputation: Coalition" = -1000
-			dialog `After a long, exhausting battle, you and your crew successfully capture the Punisher. With their lives on your hands, the Coalition most certainly won't welcome you anymore in their space.`
+			dialog `After a long, exhausting battle, you and your crew successfully capture the Punisher. With the captain's life on your hands, as well as most of her crew, the Coalition most certainly won't be welcoming you anymore.`
 	on accept
 		"assisting heliarchy" ++
 	# No reputation penalty for aborting this mission.

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2034,8 +2034,8 @@ mission "Heliarch Drills 3"
 		on capture
 			fail
 			"assisting heliarchy" --
-			"reputation: Heliarch" <?= -10
-			"reputation: Coalition" <?= -10
+			"reputation: Heliarch" = -1000
+			"reputation: Coalition" = -1000
 			dialog `You kill them and steal it. Nice.`
 	on accept
 		"assisting heliarchy" ++

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2033,9 +2033,6 @@ mission "Heliarch Drills 3"
 			dialog `After a long, exhausting battle, you and your crew successfully capture the Punisher. With the captain's life on your hands, as well as most of her crew, the Coalition most certainly won't be welcoming you anymore.`
 	on accept
 		"assisting heliarchy" ++
-	# No reputation penalty for aborting this mission.
-	on abort
-		"assisting heliarchy" --
 	on fail
 		"assisting heliarchy" --
 	on visit

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2024,19 +2024,13 @@ mission "Heliarch Drills 3"
 			"assisting heliarchy" --
 			"reputation: Heliarch" = -1000
 			"reputation: Coalition" = -1000
-			dialog `The Punisher's captain tries to hail you as the ship collapses around them, but you never get to hear their final cries. You have failed to simply disable the ship, and doomed the entire crew. It seems that you will not be welcome in Coalition space any longer.`
+			dialog `The Punisher's captain tries to hail you, but you never get to hear their final cries. You have failed to simply disable the ship, and doomed the entire crew. It seems that you will not be welcome in Coalition space any longer.`
 		on board
 			fail
 			"assisting heliarchy" --
 			"reputation: Heliarch" = -1000
 			"reputation: Coalition" = -1000
 			dialog `Although you've disabled the Punisher, you decide to move in and board the ship in order to salvage it, breaking any trust the Heliarchs had in you. They, and the rest of the Coalition, will not be pleased with this.`
-		on capture
-			fail
-			"assisting heliarchy" --
-			"reputation: Heliarch" = -1000
-			"reputation: Coalition" = -1000
-			dialog `After a long, exhausting battle, you and your crew successfully capture the Punisher. With the captain's life on your hands, as well as most of her crew, the Coalition most certainly won't be welcoming you anymore.`
 	on accept
 		"assisting heliarchy" ++
 	# No reputation penalty for aborting this mission.

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2021,15 +2021,23 @@ mission "Heliarch Drills 3"
 		ship "Heliarch Punisher (Scrappy)" "Awaiting Adversary"
 		on kill
 			dialog `The Punisher's captain tries to hail you as the ship collapses around them, but you never get to hear their final cries. You have failed to simply disable the ship, and doomed the entire crew. It seems that you will not be welcome in Coalition space any longer.`
+		on board
+			fail
+			"assisting heliarchy" --
+			"reputation: Heliarch" <?= -1000
+			"reputation: Coalition" <?= -1000
+			dialog `You begin salvaging. Nice.`
+		on capture
+			fail
+			"assisting heliarchy" --
+			"reputation: Heliarch" <?= -10
+			"reputation: Coalition" <?= -10
+			dialog `You kill them and steal it. Nice.`
 	on accept
 		"assisting heliarchy" ++
 	# No reputation penalty for aborting this mission.
 	on abort
 		"assisting heliarchy" --
-	on fail
-		"assisting heliarchy" --
-		"reputation: Heliarch" = -1000
-		"reputation: Coalition" = -1000
 	on visit
 		dialog `You've landed on <planet>, but you have not disabled the <npc> yet. Disable it before returning.`
 	on complete
@@ -2040,9 +2048,9 @@ mission "Heliarch Drills 3"
 		conversation
 			`Magister Lotuora greets you when you return. "Prevailed over one of our Punishers, you have! Perhaps the real threat, you are, not the Quarg," she says, looking at you for a few seconds as if expecting you to laugh. She hands you <payment>, and continues, "Sent a recording of the fight, I was. Learn much from it, I hope we can."`
 			`	She thanks you for helping her with the drills, saying it will be a great help in training the cadets at the local academy. She concludes by wishing you safe travels, and then heads to a Heliarch building.`
-		
 
 
+	
 
 mission "Heliarch License 1"
 	minor

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2020,12 +2020,16 @@ mission "Heliarch Drills 3"
 		system "Torbab"
 		ship "Heliarch Punisher (Scrappy)" "Awaiting Adversary"
 		on kill
+			fail
+			"assisting heliarchy" --
+			"reputation: Heliarch" = -1000
+			"reputation: Coalition" = -1000
 			dialog `The Punisher's captain tries to hail you as the ship collapses around them, but you never get to hear their final cries. You have failed to simply disable the ship, and doomed the entire crew. It seems that you will not be welcome in Coalition space any longer.`
 		on board
 			fail
 			"assisting heliarchy" --
-			"reputation: Heliarch" <?= -1000
-			"reputation: Coalition" <?= -1000
+			"reputation: Heliarch" = -1000
+			"reputation: Coalition" = -1000
 			dialog `You begin salvaging. Nice.`
 		on capture
 			fail

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2019,22 +2019,24 @@ mission "Heliarch Drills 3"
 		personality disables staying nemesis heroic
 		system "Torbab"
 		ship "Heliarch Punisher (Scrappy)" "Awaiting Adversary"
-		on kill
+		on destroy
 			fail
-			"assisting heliarchy" --
 			"reputation: Heliarch" = -1000
 			"reputation: Coalition" = -1000
-			dialog `The Punisher's captain tries to hail you, but you never get to hear their final cries. You have failed to simply disable the ship, and doomed the entire crew. It seems that you will not be welcome in Coalition space any longer.`
+			dialog `The Punisher's captain tries to hail you as the ship collapses around them, but you never get to hear their final cries. You have failed to simply disable the ship, and doomed the entire crew. It seems that you will not be welcome in Coalition space any longer.`
 		on board
 			fail
-			"assisting heliarchy" --
 			"reputation: Heliarch" = -1000
 			"reputation: Coalition" = -1000
 			dialog `Although you've disabled the Punisher, you decide to move in and board the ship in order to salvage it, breaking any trust the Heliarchs had in you. They, and the rest of the Coalition, will not be pleased with this.`
+		on capture
+			dialog `After a long, exhausting battle, you and your crew successfully capture the Punisher. With the captain's life on your hands, as well as most of her crew, the Coalition most certainly won't be welcoming you anymore.`
 	on accept
 		"assisting heliarchy" ++
 	# No reputation penalty for aborting this mission.
 	on abort
+		"assisting heliarchy" --
+	on fail
 		"assisting heliarchy" --
 	on visit
 		dialog `You've landed on <planet>, but you have not disabled the <npc> yet. Disable it before returning.`
@@ -2046,9 +2048,6 @@ mission "Heliarch Drills 3"
 		conversation
 			`Magister Lotuora greets you when you return. "Prevailed over one of our Punishers, you have! Perhaps the real threat, you are, not the Quarg," she says, looking at you for a few seconds as if expecting you to laugh. She hands you <payment>, and continues, "Sent a recording of the fight, I was. Learn much from it, I hope we can."`
 			`	She thanks you for helping her with the drills, saying it will be a great help in training the cadets at the local academy. She concludes by wishing you safe travels, and then heads to a Heliarch building.`
-
-
-	
 
 mission "Heliarch License 1"
 	minor

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2030,13 +2030,13 @@ mission "Heliarch Drills 3"
 			"assisting heliarchy" --
 			"reputation: Heliarch" = -1000
 			"reputation: Coalition" = -1000
-			dialog `You begin salvaging. Nice.`
+			dialog `Although you've disabled the Punisher, you decide to move in and board the ship in order to salvage it, breaking any trust the Heliarchs had in you. It seems that you will not be welcome in Coalition space any longer.`
 		on capture
 			fail
 			"assisting heliarchy" --
 			"reputation: Heliarch" = -1000
 			"reputation: Coalition" = -1000
-			dialog `You kill them and steal it. Nice.`
+			dialog `After a long, exhausting battle, you and your crew successfully capture the Punisher. With their lives on your hands, the Coalition most certainly won't welcome you anymore in their space.`
 	on accept
 		"assisting heliarchy" ++
 	# No reputation penalty for aborting this mission.


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This PR adds `fail` conditions on the `board` or `capture` of the Punisher, and moves the original `fail` conditions into the on `kill` of it as well. This way, the rep loss is instant, rather than pending the player's next landing.

## Save File
This save file can be used to play through the new mission content, courteous of @danaris :
[Hannah_Derinden.txt](https://github.com/endless-sky/endless-sky/files/12754120/Hannah_Derinden.txt)
All you have to do is re-land on Belug and go to the spaceport to accept the mission.
