### PR TITLE
feat(balance): Buff Star Barge Weapon Capacity by 2

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -3513,7 +3513,7 @@ ship "Star Barge"
 		"fuel capacity" 300
 		"cargo space" 50
 		"outfit space" 130
-		"weapon capacity" 20
+		"weapon capacity" 22
 		"engine capacity" 40
 		weapon
 			"blast radius" 16


### PR DESCRIPTION
**Content (Balance)**

## Summary
This PR increases the weapon capacity on the Star Barge by 2, bringing it from 20 weapon capacity to 22 weapon capacity. 
Currently, with 20 weapon capacity and lacking a gun port, the only human weapons a star barge can equip are the blaster turret and modified blaster turret. Expanding that to 22 also gives the Star Barge the option of equipping a Laser Turret. 

The justification for this change is threefold:
1) Adding a second weapon type, other than the two blaster weapons, allows for more early-game experimentation. A new player or a player newly trying the Star Barge gets slightly more variety in their weapon choice.
2) For players interested in mining, the Laser turret is a significantly better option than either blaster turret, with 156 hull DPS rather than the 88 hull DPS on the modified blaster turret.
3) Allowing a laser turret gives the star barge slightly more ability to be modified into something capable of combat. A player that's interested in trying out combat can install a laser turret for a very slightly stronger ship

I think this change, while small, does give just a tiny bit more variety to what the Star Barge can do, letting a newer player that's picked a Star Barge transition over to combat or mining a little bit easier if they want to try out either of those options and gives it the potential to be a nice very early game mining ship alongside the sparrow or shuttle.

## Additional Details

This change also allows the Star Barge to fit three other turrets it wasn't able to before: the Ravager Turret, Chameleon Anti-Missile, and Inhibitor Turret. 
Ravager and Inhibitor seem unlikely to have any value installing on a Star Barge; Chameleon could be a weird but viable option if someone really wants to make a very small and cheap anti-missile ship. 
It also technically allows for equipping an AR120 Reverse Thruster, whereas previously, it was limited to a Capybara reverse thruster. 
Hopefully, neither of these caveats is considered a major balance concern. 

Comparison between the three starting ships with this change:
![image](https://github.com/endless-sky/endless-sky/assets/15916854/ccd2e99b-4d92-4b22-ada3-bba8e1cad86d)

An example early mining build that's now possible with the Star Barge
![image](https://github.com/endless-sky/endless-sky/assets/15916854/76900d7f-a619-4242-adaf-ed5579f3eabd)

Overall, it is my hope that the slight bit of additional variety that this change allows and the small benefit to the new player experience is worth whatever balance concerns may arise from the additional two weapon capacity.