### PR TITLE
Fix jump drive usage of hyperlinks from systems with limited jump range

### DIFF
--- a/source/ShipJumpNavigation.cpp
+++ b/source/ShipJumpNavigation.cpp
@@ -143,7 +143,7 @@ pair<JumpType, double> ShipJumpNavigation::GetCheapestJumpType(const System *fro
 	const double distance = from->Position().Distance(to->Position());
 	double jumpFuelNeeded = JumpDriveFuel((linked || from->JumpRange())
 			? 0. : distance);
-	bool canJump = jumpFuelNeeded && (!from->JumpRange() || from->JumpRange() >= distance);
+	bool canJump = jumpFuelNeeded && (linked || !from->JumpRange() || from->JumpRange() >= distance);
 	if(linked && hasHyperdrive && (!canJump || hyperFuelNeeded <= jumpFuelNeeded))
 		return make_pair(JumpType::HYPERDRIVE, hyperFuelNeeded);
 	else if(hasJumpDrive && canJump)


### PR DESCRIPTION
**Bugfix:** This PR addresses issue #https://github.com/endless-sky/endless-sky/pull/9374#issuecomment-1741281313

## Fix Details
The problem of not being able to travel along a hyperlink with only a jump drive (no hyperdrive) from a system with a reduced jump range (so, the other end of the hyperlink is not within the system's jump range) is indeed a recent one, introduced in #9289.
This PR fixes that by addressing the oversight in that PR.
A system being linked will now correctly count as it being accessible by jump drive regardless of jump range and distance.

## Testing Done
Try to jump out of the Yranjiu system with a ship that has only a jump drive, no hyperdrive. It is now possible again.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 9eb74d2 onwards, and will not occur when using this branch's build.
[warp core Yranjiu test~original.txt](https://github.com/endless-sky/endless-sky/files/12773121/warp.core.Yranjiu.test.original.txt)
Follow the pre-planned route to the Yranjiu system and then plan a new route out of there.
