### PR TITLE
Prevent fuel-based generators running unnecessarily

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3759,7 +3759,8 @@ void Ship::DoGeneration()
 		double excessEnergy = energy - attributes.Get("energy capacity");
 		double fuelEnergy = -attributes.Get("fuel energy");
 		double fuelHeat = -attributes.Get("fuel heat");
-		DoRepair(fuel, excessEnergy, attributes.Get("fuel consumption"), energy, fuelEnergy, 0., 0., heat, fuelHeat);
+
+		DoRepair(fuel, excessEnergy, attributes.Get("fuel consumption"), energy, fuelEnergy, fuel, 0., heat, fuelHeat);
 	}
 
 	// However, this is no excuse to not explicitly cap the variables.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3750,6 +3750,19 @@ void Ship::DoGeneration()
 	// maximum capacity for the rest of the turn, but must be clamped to the
 	// maximum here before they gain more. This is so that, for example, a ship
 	// with no batteries but a good generator can still move.
+
+	// If some or all excess energy is due to "fuel energy", then run
+	// "fuel consumption" in reverse to "retcon" the energy generation.
+
+	if(attributes.Get("fuel consumption") > 0. && attributes.Get("fuel energy") > 0.)
+	{
+		double excessEnergy = energy - attributes.Get("energy capacity");
+		double fuelEnergy = -attributes.Get("fuel energy");
+		double fuelHeat = -attributes.Get("fuel heat");
+		doRepair(fuel, excessEnergy, attributes.Get("fuel consumption"), energy, fuelEnergy, 0., 0., heat, fuelHeat)
+	}
+
+	// However, this is no excuse to not explicitly cap the variables.
 	energy = min(energy, attributes.Get("energy capacity"));
 	fuel = min(fuel, attributes.Get("fuel capacity"));
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3759,7 +3759,7 @@ void Ship::DoGeneration()
 		double excessEnergy = energy - attributes.Get("energy capacity");
 		double fuelEnergy = -attributes.Get("fuel energy");
 		double fuelHeat = -attributes.Get("fuel heat");
-		DoRepair(fuel, excessEnergy, attributes.Get("fuel consumption"), energy, fuelEnergy, 0., 0., heat, fuelHeat)
+		DoRepair(fuel, excessEnergy, attributes.Get("fuel consumption"), energy, fuelEnergy, 0., 0., heat, fuelHeat);
 	}
 
 	// However, this is no excuse to not explicitly cap the variables.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3759,7 +3759,7 @@ void Ship::DoGeneration()
 		double excessEnergy = energy - attributes.Get("energy capacity");
 		double fuelEnergy = -attributes.Get("fuel energy");
 		double fuelHeat = -attributes.Get("fuel heat");
-		doRepair(fuel, excessEnergy, attributes.Get("fuel consumption"), energy, fuelEnergy, 0., 0., heat, fuelHeat)
+		DoRepair(fuel, excessEnergy, attributes.Get("fuel consumption"), energy, fuelEnergy, 0., 0., heat, fuelHeat)
 	}
 
 	// However, this is no excuse to not explicitly cap the variables.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3754,7 +3754,12 @@ void Ship::DoGeneration()
 	// If some or all excess energy is due to "fuel energy", then run
 	// "fuel consumption" in reverse to "retcon" the energy generation.
 
-	if(attributes.Get("fuel consumption") > 0. && attributes.Get("fuel energy") > 0.)
+	// Of future note: The assumption that fuel was, in fact, burned last frame,
+	// is not always true. If a ship runs out of fuel, but still has an energy
+	// surplus, it will actually backfill its fuel with excess energy, until it
+	// has enough to burn again.
+
+	if(!isDisabled && attributes.Get("fuel consumption") > 0. && attributes.Get("fuel energy") > 0.)
 	{
 		double excessEnergy = energy - attributes.Get("energy capacity");
 		double fuelEnergy = -attributes.Get("fuel energy");
@@ -3763,7 +3768,7 @@ void Ship::DoGeneration()
 		DoRepair(fuel, excessEnergy, attributes.Get("fuel consumption"), energy, fuelEnergy, fuel, 0., heat, fuelHeat);
 	}
 
-	// However, this is no excuse to not explicitly cap the variables.
+	// However, this is no excuse to not explicitly clamp the variables.
 	energy = min(energy, attributes.Get("energy capacity"));
 	fuel = min(fuel, attributes.Get("fuel capacity"));
 


### PR DESCRIPTION
**Feature:** I am not in the habit of making an issue for talking about an idea before making a PR for it :)
(However, it was recently requested of me to dig this up, over in the ES discord: https://discord.com/channels/251118043411775489/266345072554016768/1157545165527986226)

## Feature Details
Fuel is a limited resource, so it makes sense to use it wisely. This "retcons" fuel usage if the batteries are overcharged at the end of the frame, or "refunds" the player if they could not keep the energy generated by burning fuel.

## UI Screenshots
N/A

## Usage Examples
No changes in usage, just safety in knowing fuel won't be burned unless the energy actually gets used.

## Testing Done
I haven't tested if this still works with the potentially-new context of ship.cpp! But I DID test it the last time I did this! That counts for something, right?

### Automated Tests Added
N/A

## Performance Impact
This makes a couple of calls to attributes directly, which I recall is a sort-of expensive process. Nothing to be worried about (it happens hundreds of times already across the rest of ship.cpp) but it is more straws onto the pile of things happening for every ship every frame.
