### PR TITLE
Fix(swizzlemask): do not apply in ship info panel

### DIFF
--- a/source/SpriteShader.cpp
+++ b/source/SpriteShader.cpp
@@ -348,7 +348,7 @@ void SpriteShader::Add(const Item &item, bool withBlur)
 
 	glUniform1i(swizzleMaskI, 1);
 	// Don't mask full color swizzles that always apply to the whole ship sprite.
-	glUniform1i(useSwizzleMaskI, item.swizzle == 27 || item.swizzleMask == 28 ? 0 : item.swizzleMask);
+	glUniform1i(useSwizzleMaskI, item.swizzle >= 27 ? 0 : item.swizzleMask);
 	glActiveTexture(GL_TEXTURE1);
 	glBindTexture(GL_TEXTURE_2D_ARRAY, item.swizzleMask);
 	glActiveTexture(GL_TEXTURE0);


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported by @Azure3141 

## Fix Details
Swizzlemask was getting applied in the ship info panel, I fixed that

## Testing Done
Lookes in the panel, works

## Save File
random swizzlemask for a maboro for testing:
![pug maboro@sw](https://github.com/endless-sky/endless-sky/assets/85687254/49f7621c-c7c2-4b2a-835c-de42c890dd30)

