### PR TITLE
One more Coalition intro thing

### DIFF
--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2082,7 +2082,7 @@ mission "Heliarch License 2"
 	invisible
 	source "Ring of Friendship"
 	to offer
-		has "Heliarch License 1: active"
+		has "Heliarch License 1: done"
 		not "joined the lunarium"
 		not "assisting lunarium"
 	on offer

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -1876,7 +1876,7 @@ mission "Lunarium: Quarg Interview"
 	source "Remote Blue"
 	destination "Lagrange"
 	to offer
-		has "Lunarium: Questions: active"
+		has "Lunarium: Questions: done"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
 	on offer


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Offers these missions when the previous missions are done instead of active. Those missions are completed upon arriving at hte sources of these missions and so will no longer be active, meaning these missions would otherwise never be offered.

## Testing Done
Tested the Heliarch one. I am now actually offered the second mission upon completing hte first.
