### PR TITLE
fix(content): Add `<bunks>` to core jobs missing them

### DIFF
--- a/data/human/syndicate jobs.txt
+++ b/data/human/syndicate jobs.txt
@@ -415,7 +415,7 @@ mission "Syndicate Prisoner Transport [2]"
 	name "Transport convicted corporate spies"
 	job
 	repeat
-	description `Transport a group of convicted corporate spies to <planet> for their sentences. They must be held in suitable facilities made for the transfer of criminals. Payment is <payment>.`
+	description `Transport a group of <bunks> convicted corporate spies to <planet> for their sentences. They must be held in suitable facilities made for the transfer of criminals. Payment is <payment>.`
 	passengers 3 5
 	source
 		government "Syndicate"
@@ -439,7 +439,7 @@ mission "Syndicate Prisoner Transport [3]"
 	name "Transport detained protesters"
 	job
 	repeat
-	description `Transport a group of detained protesters to <planet> where they will await trial for inciting a riot. They must be held in suitable facilities made for the transfer of criminals. Payment is <payment>.`
+	description `Transport a group of <bunks> detained protesters to <planet> where they will await trial for inciting a riot. They must be held in suitable facilities made for the transfer of criminals. Payment is <payment>.`
 	passengers 10 40 .9
 	source
 		government "Syndicate"
@@ -464,7 +464,7 @@ mission "Syndicate Prisoner Transport [4]"
 	name "Transport detained labor organizers"
 	job
 	repeat
-	description `Transport a group of detained labor organizers to <planet> for "processing" as suspected terrorists. They must be held in suitable facilities made for the transfer of criminals. Payment is <payment>.`
+	description `Transport a group of <bunks> detained labor organizers to <planet> for "processing" as suspected terrorists. They must be held in suitable facilities made for the transfer of criminals. Payment is <payment>.`
 	passengers 3 10 .56
 	source
 		government "Syndicate"
@@ -515,7 +515,7 @@ mission "Return Syndicate Prisoners [1]"
 	name "Return detained protesters home"
 	job
 	repeat
-	description `Transport a group of protesters home to <planet> from their detention on <origin>. Payment is <payment>.`
+	description `Transport a group of <bunks> protesters home to <planet> from their detention on <origin>. Payment is <payment>.`
 	passengers 10 40 .9
 	source
 		government "Syndicate"
@@ -538,7 +538,7 @@ mission "Return Syndicate Prisoners [2]"
 	name "Return detained labor organizers home"
 	job
 	repeat
-	description `Transport a group of labor organizers home to <planet> from their imprisonment on <origin>. Payment is <payment>.`
+	description `Transport a group of <bunks> labor organizers home to <planet> from their imprisonment on <origin>. Payment is <payment>.`
 	passengers 3 15 .9
 	source
 		government "Syndicate"


### PR DESCRIPTION
## Summary
Some Core jobs don't give the player the number of bunks needed to accept the job. This adds that to the descriptions of those jobs.

Before:
<img width="469" alt="Screenshot 2023-10-01 at 5 19 44 PM" src="https://github.com/endless-sky/endless-sky/assets/115441627/ff2f7d24-94f7-4406-bdb4-b562722e377e">

After:
<img width="458" alt="Screenshot 2023-10-01 at 5 24 53 PM" src="https://github.com/endless-sky/endless-sky/assets/115441627/47f5a6cb-35a3-42af-ac74-bbc017f032eb">
