### PR TITLE
Feat(extended jump effects): Add a new level for the setting and disable by default

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -503,8 +503,10 @@ void Engine::Step(bool isActive)
 	{
 		center = flagship->Position();
 		centerVelocity = flagship->Velocity();
-		if(flagship->IsHyperspacing() && Preferences::Has("Extended jump effects"))
-			centerVelocity *= 1. + pow(flagship->GetHyperspacePercentage() / 20., 2);
+		Preferences::ExtendedJumpEffects jumpEffectState = Preferences::GetExtendedJumpEffects();
+		if(flagship->IsHyperspacing() && jumpEffectState != Preferences::ExtendedJumpEffects::OFF)
+			centerVelocity *= 1. + pow(flagship->GetHyperspacePercentage() /
+				(jumpEffectState == Preferences::ExtendedJumpEffects::MEDIUM ? 40. : 20.), 2);
 		if(doEnterLabels)
 		{
 			doEnterLabels = false;

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -129,6 +129,9 @@ namespace {
 	const vector<string> PARALLAX_SETTINGS = {"off", "fancy", "fast"};
 	int parallaxIndex = 2;
 
+	const vector<string> EXTENDED_JUMP_EFFECT_SETTINGS = {"off", "medium", "heavy"};
+	int extendedJumpEffectIndex = 0;
+
 	const vector<string> ALERT_INDICATOR_SETTING = {"off", "audio", "visual", "both"};
 	int alertIndicatorIndex = 3;
 
@@ -196,6 +199,8 @@ void Preferences::Load()
 			autoFireIndex = max<int>(0, min<int>(node.Value(1), AUTO_FIRE_SETTINGS.size() - 1));
 		else if(node.Token(0) == "Parallax background")
 			parallaxIndex = max<int>(0, min<int>(node.Value(1), PARALLAX_SETTINGS.size() - 1));
+		else if(node.Token(0) == "Extended jump effects")
+			extendedJumpEffectIndex = max<int>(0, min<int>(node.Value(1), EXTENDED_JUMP_EFFECT_SETTINGS.size() - 1));
 		else if(node.Token(0) == "fullscreen")
 			screenModeIndex = max<int>(0, min<int>(node.Value(1), SCREEN_MODE_SETTINGS.size() - 1));
 		else if(node.Token(0) == "date format")
@@ -264,6 +269,7 @@ void Preferences::Save()
 	out.Write("Automatic aiming", autoAimIndex);
 	out.Write("Automatic firing", autoFireIndex);
 	out.Write("Parallax background", parallaxIndex);
+	out.Write("Extended jump effects", extendedJumpEffectIndex);
 	out.Write("alert indicator", alertIndicatorIndex);
 	out.Write("previous saves", previousSaveCount);
 
@@ -416,6 +422,30 @@ Preferences::BackgroundParallax Preferences::GetBackgroundParallax()
 const string &Preferences::ParallaxSetting()
 {
 	return PARALLAX_SETTINGS[parallaxIndex];
+}
+
+
+
+void Preferences::ToggleExtendedJumpEffects()
+{
+	int targetIndex = extendedJumpEffectIndex + 1;
+	if(targetIndex == static_cast<int>(EXTENDED_JUMP_EFFECT_SETTINGS.size()))
+		targetIndex = 0;
+	extendedJumpEffectIndex = targetIndex;
+}
+
+
+
+Preferences::ExtendedJumpEffects Preferences::GetExtendedJumpEffects()
+{
+	return static_cast<ExtendedJumpEffects>(extendedJumpEffectIndex);
+}
+
+
+
+const string &Preferences::ExtendedJumpEffectsSetting()
+{
+	return EXTENDED_JUMP_EFFECT_SETTINGS[extendedJumpEffectIndex];
 }
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -83,6 +83,12 @@ public:
 		FAST
 	};
 
+	enum class ExtendedJumpEffects : int {
+		OFF = 0,
+		MEDIUM,
+		HEAVY
+	};
+
 	enum class AlertIndicator : int_fast8_t {
 		NONE = 0,
 		AUDIO,
@@ -146,6 +152,11 @@ public:
 	static void ToggleParallax();
 	static BackgroundParallax GetBackgroundParallax();
 	static const std::string &ParallaxSetting();
+
+	// Extended jump effects setting, either "medium", "heavy", or "off".
+	static void ToggleExtendedJumpEffects();
+	static ExtendedJumpEffects GetExtendedJumpEffects();
+	static const std::string &ExtendedJumpEffectsSetting();
 
 	// Boarding target setting, either "proximity", "value" or "mixed".
 	static void ToggleBoarding();

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -153,7 +153,7 @@ public:
 	static BackgroundParallax GetBackgroundParallax();
 	static const std::string &ParallaxSetting();
 
-	// Extended jump effects setting, either "medium", "heavy", or "off".
+	// Extended jump effects setting, either "off", "medium", or "heavy".
 	static void ToggleExtendedJumpEffects();
 	static ExtendedJumpEffects GetExtendedJumpEffects();
 	static const std::string &ExtendedJumpEffectsSetting();

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -75,6 +75,7 @@ namespace {
 	const string BOARDING_PRIORITY = "Boarding target priority";
 	const string TARGET_ASTEROIDS_BASED_ON = "Target asteroid based on";
 	const string BACKGROUND_PARALLAX = "Parallax background";
+	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
 
 	// How many pages of settings there are.
@@ -231,6 +232,8 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 				Preferences::ToggleBoarding();
 			else if(zone.Value() == BACKGROUND_PARALLAX)
 				Preferences::ToggleParallax();
+			else if(zone.Value() == EXTENDED_JUMP_EFFECTS)
+				Preferences::ToggleExtendedJumpEffects();
 			else if(zone.Value() == VIEW_ZOOM_FACTOR)
 			{
 				// Increase the zoom factor unless it is at the maximum. In that
@@ -563,7 +566,7 @@ void PreferencesPanel::DrawSettings()
 		"Draw starfield",
 		BACKGROUND_PARALLAX,
 		"Show hyperspace flash",
-		"Extended jump effects",
+		EXTENDED_JUMP_EFFECTS,
 		SHIP_OUTLINES,
 		"\t",
 		"HUD",
@@ -752,6 +755,11 @@ void PreferencesPanel::DrawSettings()
 		else if(setting == BACKGROUND_PARALLAX)
 		{
 			text = Preferences::ParallaxSetting();
+			isOn = text != "off";
+		}
+		else if(setting == EXTENDED_JUMP_EFFECTS)
+		{
+			text = Preferences::ExtendedJumpEffectsSetting();
 			isOn = text != "off";
 		}
 		else if(setting == REACTIVATE_HELP)


### PR DESCRIPTION
#9391
## Feature Details
basically the heading, I disabled the the extended jump effects by default, and made it so that you can choose between tow levels of strength, the "medium" level had no performance impact on my end, while the "heavy" level increased my gpu load by a factor 4.

some numbers,
medium increases drawn area by roughly 1500 pixels in each direction
heavy by 3000

My reasoning:
Having effects on that have a heavy gpu load can scare away first time users, so something like this should be off by default.

## UI Screenshots
later if requested

## Testing Done
yes

## Performance Impact
See above
