### PR TITLE
fix(content): Correct offer conditions of `"Small Pirate gambling"`

### DIFF
--- a/data/human/frontier jobs.txt
+++ b/data/human/frontier jobs.txt
@@ -242,7 +242,7 @@ mission "Small Pirate gambling"
 	repeat
 	to offer
 		random < 3
-		"reputation: Pirates" < 0
+		"reputation: Pirate" < 0
 		"combat rating" < 200
 		credits > 14357
 	source


### PR DESCRIPTION
`"reputation: Pirates"` can never be below zero, because there is no government named `Pirates`.
<!-- spooky hidden text wooo -->