### PR TITLE
fix(content): Update several Quarg fleets

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -8188,7 +8188,7 @@ system Chikatip
 	trade Medical 606
 	trade Metal 283
 	trade Plastic 278
-	fleet "Large Quarg" 2000
+	fleet "Large Quarg (Kor Efret)" 2000
 	fleet "Kor Efret Miners" 10800
 	object
 		sprite star/k5
@@ -8369,7 +8369,7 @@ system Chornifath
 	trade Medical 508
 	trade Metal 468
 	trade Plastic 373
-	fleet "Large Quarg" 1000
+	fleet "Large Quarg (Kor Efret)" 1000
 	object
 		sprite star/k0
 		period 10
@@ -13295,7 +13295,7 @@ system Farbutero
 	trade Medical 549
 	trade Metal 450
 	trade Plastic 403
-	fleet "Large Quarg" 2000
+	fleet "Large Quarg (Kor Efret)" 2000
 	fleet "Small Kor Mereti" 9400
 	fleet "Large Kor Mereti" 5000
 	object
@@ -13830,7 +13830,7 @@ system Feroteri
 	trade Medical 492
 	trade Metal 406
 	trade Plastic 451
-	fleet "Large Quarg" 3000
+	fleet "Large Quarg (Kor Efret)" 3000
 	fleet "Small Kor Mereti" 12000
 	fleet "Large Kor Mereti" 6400
 	object
@@ -14165,7 +14165,7 @@ system Fornarep
 	trade Medical 694
 	trade Metal 438
 	trade Plastic 375
-	fleet "Large Quarg" 2000
+	fleet "Large Quarg (Kor Efret)" 2000
 	fleet "Small Kor Mereti" 9000
 	fleet "Large Kor Mereti" 5800
 	object
@@ -14332,7 +14332,7 @@ system Furmeliki
 	trade Medical 536
 	trade Metal 346
 	trade Plastic 313
-	fleet "Large Quarg" 1000
+	fleet "Large Quarg (Kor Efret)" 1000
 	object
 		sprite star/k0
 		period 10
@@ -16163,7 +16163,7 @@ system Hesselpost
 	trade Medical 484
 	trade Metal 536
 	trade Plastic 281
-	fleet "Large Quarg" 1000
+	fleet "Large Quarg (Kor Efret)" 1000
 	fleet "Kor Efret Miners" 7200
 	object
 		sprite star/k0
@@ -18539,7 +18539,7 @@ system Kaliptari
 	trade Medical 675
 	trade Metal 334
 	trade Plastic 398
-	fleet "Large Quarg" 3000
+	fleet "Large Quarg (Kor Efret)" 3000
 	fleet "Small Kor Mereti" 10000
 	fleet "Large Kor Mereti" 4800
 	object
@@ -20200,7 +20200,7 @@ system Korsmanath
 	trade Medical 479
 	trade Metal 427
 	trade Plastic 440
-	fleet "Large Quarg" 3000
+	fleet "Large Quarg (Kor Efret)" 3000
 	fleet "Small Kor Mereti" 8000
 	object
 		sprite star/k0
@@ -21870,7 +21870,7 @@ system Meftarkata
 	trade Medical 599
 	trade Metal 484
 	trade Plastic 334
-	fleet "Large Quarg" 1000
+	fleet "Large Quarg (Kor Efret)" 1000
 	fleet "Kor Efret Miners" 7200
 	object
 		sprite star/f5
@@ -28228,7 +28228,7 @@ system Sabriset
 	trade Medical 621
 	trade Metal 275
 	trade Plastic 441
-	fleet "Large Quarg" 4000
+	fleet "Large Quarg (Kor Efret)" 4000
 	object
 		sprite star/g0
 		distance 34.3036
@@ -29145,7 +29145,7 @@ system Seketra
 	trade Medical 635
 	trade Metal 327
 	trade Plastic 286
-	fleet "Large Quarg" 3000
+	fleet "Large Quarg (Kor Efret)" 3000
 	object
 		sprite star/k5
 		period 10
@@ -29268,7 +29268,7 @@ system Sepriaptu
 	trade Medical 604
 	trade Metal 320
 	trade Plastic 449
-	fleet "Large Quarg" 4000
+	fleet "Large Quarg (Kor Efret)" 4000
 	object
 		sprite star/f5
 		distance 15.0211
@@ -30085,7 +30085,7 @@ system Skeruto
 	trade Medical 621
 	trade Metal 393
 	trade Plastic 333
-	fleet "Large Quarg" 2000
+	fleet "Large Quarg (Kor Efret)" 2000
 	object
 		sprite star/m0
 		period 10
@@ -30614,7 +30614,7 @@ system Solifar
 	trade Medical 678
 	trade Metal 285
 	trade Plastic 442
-	fleet "Large Quarg" 4000
+	fleet "Large Quarg (Kor Efret)" 4000
 	object
 		sprite star/m0
 		period 10

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -2126,7 +2126,7 @@ mission "Wanderers: Sestor: Quarg Help 2"
 	on accept
 		log "Recruited some Quarg warships to help defend human space from the Kor Sestor drones, which are now presumably under Alpha control."
 	npc accompany save
-		government "Quarg (Kor Efret)"
+		government "Quarg (Hai)"
 		personality heroic waiting escort
 		ship "Quarg Wardragon" "Leukos-nikeseh"
 		ship "Quarg Wardragon" "Purros-machaira"
@@ -2217,7 +2217,7 @@ mission "Wanderers: Sestor: Farpoint Attack 2"
 	on visit
 		dialog `Danforth notices your ship land as the sky lights up with the explosions of Navy ships. "Did you use the bomb?" he asks. The stress in his voice is palpable. You shake your head. "Then what the hell are you doing here? Get up there and drop the bomb already!"`
 	npc
-		government "Quarg (Kor Efret)"
+		government "Quarg (Hai)"
 		personality heroic staying
 		ship "Quarg Wardragon" "Leukos-nikeseh"
 		ship "Quarg Wardragon" "Purros-machaira"

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -2126,7 +2126,7 @@ mission "Wanderers: Sestor: Quarg Help 2"
 	on accept
 		log "Recruited some Quarg warships to help defend human space from the Kor Sestor drones, which are now presumably under Alpha control."
 	npc accompany save
-		government "Quarg"
+		government "Quarg (Efret)"
 		personality heroic waiting escort
 		ship "Quarg Wardragon" "Leukos-nikeseh"
 		ship "Quarg Wardragon" "Purros-machaira"
@@ -2217,7 +2217,7 @@ mission "Wanderers: Sestor: Farpoint Attack 2"
 	on visit
 		dialog `Danforth notices your ship land as the sky lights up with the explosions of Navy ships. "Did you use the bomb?" he asks. The stress in his voice is palpable. You shake your head. "Then what the hell are you doing here? Get up there and drop the bomb already!"`
 	npc
-		government "Quarg"
+		government "Quarg (Efret)"
 		personality heroic staying
 		ship "Quarg Wardragon" "Leukos-nikeseh"
 		ship "Quarg Wardragon" "Purros-machaira"

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -2126,7 +2126,7 @@ mission "Wanderers: Sestor: Quarg Help 2"
 	on accept
 		log "Recruited some Quarg warships to help defend human space from the Kor Sestor drones, which are now presumably under Alpha control."
 	npc accompany save
-		government "Quarg (Efret)"
+		government "Quarg (Kor Efret)"
 		personality heroic waiting escort
 		ship "Quarg Wardragon" "Leukos-nikeseh"
 		ship "Quarg Wardragon" "Purros-machaira"
@@ -2217,7 +2217,7 @@ mission "Wanderers: Sestor: Farpoint Attack 2"
 	on visit
 		dialog `Danforth notices your ship land as the sky lights up with the explosions of Navy ships. "Did you use the bomb?" he asks. The stress in his voice is palpable. You shake your head. "Then what the hell are you doing here? Get up there and drop the bomb already!"`
 	npc
-		government "Quarg (Efret)"
+		government "Quarg (Kor Efret)"
 		personality heroic staying
 		ship "Quarg Wardragon" "Leukos-nikeseh"
 		ship "Quarg Wardragon" "Purros-machaira"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This PR updates several Quarg fleets in old Korath space to use the proper Quarg "Kor Efret" government, and updates two Quarg governments used in Wanderers Middle that are recruited from the Quarg (Hai) ringworld, not the regular Quarg or Kor Efret Quarg.

#9408 solves any issues with pre-determined Quarg fleets that I had missed before.