### PR TITLE
Fix load panel keyboard scrolling up

### DIFF
--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -307,7 +307,7 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 				if(it == files.begin())
 				{
 					it = files.end();
-					sideScroll = 20. * files.size() - 280.;
+					sideScroll = max(0., 20. * files.size() - 280.);
 				}
 				--it;
 			}

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -343,7 +343,7 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 				if(it == pit->second.begin())
 				{
 					it = pit->second.end();
-					centerScroll = 20. * pit->second.size() - 280.;
+					centerScroll = max(0., 20. * pit->second.size() - 280.);
 				}
 				--it;
 			}


### PR DESCRIPTION
**Bugfix:**

## Fix Details
When scrolling up from the top of a short list with the keyboard, all the items will jump to the bottom. This is because the scroll value is being set to a negative number. This PR ensures that the scroll value does not become less than zero.

![image](https://github.com/endless-sky/endless-sky/assets/20605679/4f66a462-f3f2-4750-8f92-437b65d2c21a)

## Testing Done
Tried scrolling up with the keyboard and see that the items remain in the correct positions.

