### PR TITLE
fix(content): Choose which Coalition faction to side with if player joined both

### DIFF
--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -2064,7 +2064,7 @@ mission "Coalition Intro Join Patch"
 				"joined the heliarchs"
 	on offer
 		conversation
-			`(Currently, you have joined both the Coalition's Lunarium and Heliarch factions due to an unintended bug. Please choose which you prefer to be sided with.")
+			`(Currently, you have joined both the Coalition's Lunarium and Heliarch factions due to an unintended bug. Please choose which side you prefer to be with.")
 			choice
 				`	(Side with the Heliarchs.)`
 					goto "heliarch"

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -2058,10 +2058,11 @@ mission "Coalition Intro Join Patch"
 	landing
 	invisible
 	to offer
-		has
-			and
-				"joined the lunarium"
-				"joined the heliarchs"
+		has "joined the lunarium"
+		has "joined the heliarchs"
+		has "event: first lunarium unlock"
+		has "event: first heliarch unlock"
+		has "license: Heliarch"
 	on offer
 		conversation
 			`(Currently, you have joined both the Coalition's Lunarium and Heliarch factions due to an unintended bug. Please choose which side you prefer to be with.")
@@ -2073,12 +2074,12 @@ mission "Coalition Intro Join Patch"
 			action
 				clear "license: Heliarch"
 				clear "joined the heliarchy"
-				event "fix: joined heliarchy"
+				event "fix: chose heliarchy"
 				fail
 
 			label "heliarch"
 				clear "joined the lunarium"
-				event "fix: joined lunarium"
+				event "fix: chose lunarium"
 				fail
 
 event "fix: chose heliarchs"

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -2065,7 +2065,7 @@ mission "Coalition Intro Join Patch"
 		has "license: Heliarch"
 	on offer
 		conversation
-			`(Currently, you have joined both the Coalition's Lunarium and Heliarch factions due to an unintended bug. Please choose which side you prefer to be with.)`
+			`(You have joined both the Coalition's Lunarium and Heliarch factions due to an unintended bug. Please choose which side you prefer to be with.)`
 			choice
 				`	(Side with the Heliarchs.)`
 					goto "heliarch"

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -2074,13 +2074,16 @@ mission "Coalition Intro Join Patch"
 			action
 				clear "license: Heliarch"
 				clear "joined the heliarchs"
-				event "fix: chose heliarchs"
-				fail
+				event "fix: chose lunarium"
+			`	(You've sided with the Lunarium.)`
+				decline
 
 			label "heliarch"
+			action
 				clear "joined the lunarium"
-				event "fix: chose lunarium"
-				fail
+				event "fix: chose heliarchs"
+			`	(You've sided with the Heliarchs.)`
+				decline
 
 event "fix: chose heliarchs"
 	planet "Remote Blue"

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -2065,7 +2065,7 @@ mission "Coalition Intro Join Patch"
 		has "license: Heliarch"
 	on offer
 		conversation
-			`(Currently, you have joined both the Coalition's Lunarium and Heliarch factions due to an unintended bug. Please choose which side you prefer to be with.")
+			`(Currently, you have joined both the Coalition's Lunarium and Heliarch factions due to an unintended bug. Please choose which side you prefer to be with.)`
 			choice
 				`	(Side with the Heliarchs.)`
 					goto "heliarch"

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -2050,3 +2050,79 @@ event "first lunarium unlock"
 		outfitter "Lunarium Basics"
 	planet "Refuge of Belugt"
 		outfitter "Lunarium Basics"
+
+
+
+# Patch for if the player joined both Heliarch and Lunarium prior to a fix.
+mission "Coalition Intro Join Patch"
+	landing
+	invisible
+	to offer
+		has
+			and
+				"joined the lunarium"
+				"joined the heliarchs"
+	on offer
+		conversation
+			`(Currently, you have joined both the Coalition's Lunarium and Heliarch factions due to an unintended bug. Please choose which you prefer to be sided with.")
+			choice
+				`	(Side with the Heliarchs.)`
+					goto "heliarch"
+				`	(Side with the Lunarium.)`
+
+			action
+				clear "license: Heliarch"
+				clear "joined the heliarchy"
+				event "fix: joined heliarchy"
+				fail
+
+			label "heliarch"
+				clear "joined the lunarium"
+				event "fix: joined lunarium"
+				fail
+
+event "fix: chose heliarchs"
+	planet "Remote Blue"
+		remove outfitter "Lunarium Basics"
+	planet "Fourth Shadow"
+		remove outfitter "Lunarium Basics"
+	planet "Into White"
+		remove outfitter "Lunarium Basics"
+	planet "Secret Sky"
+		remove outfitter "Lunarium Basics"
+	planet "Shifting Sand"
+		remove outfitter "Lunarium Basics"
+	planet "Mebla's Portion"
+		remove outfitter "Lunarium Basics"
+	planet "Refuge of Belugt"
+		remove outfitter "Lunarium Basics"
+
+event "fix: chose lunarium"
+	planet "Ring of Friendship"
+		remove outfitter "Heliarch Basics"
+	planet "Ring of Power"
+		remove outfitter "Heliarch Basics"
+	planet "Ring of Wisdom"
+		remove outfitter "Heliarch Basics"
+	planet "Saros"
+		remove outfitter "Heliarch Basics"
+	planet "Ahr"
+		remove outfitter "Heliarch Basics"
+	planet "Ki Patek Ka"
+		remove outfitter "Heliarch Basics"
+	planet "Belug's Plunge"
+		remove outfitter "Heliarch Basics"
+	planet "Stronghold of Flugbu"
+		remove outfitter "Heliarch Basics"
+	planet "Delve of Bloptab"
+		remove outfitter "Heliarch Basics"
+	planet "Far Home"
+		remove outfitter "Heliarch Basics"
+	planet "Dwelling of Speloog"
+		remove outfitter "Heliarch Basics"
+	planet "Blue Interor"
+		remove outfitter "Heliarch Basics"
+	planet "Sandy Two"
+		remove outfitter "Heliarch Basics"
+	planet "Second Rose"
+		remove outfitter "Heliarch Basics"

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -2073,8 +2073,8 @@ mission "Coalition Intro Join Patch"
 
 			action
 				clear "license: Heliarch"
-				clear "joined the heliarchy"
-				event "fix: chose heliarchy"
+				clear "joined the heliarchs"
+				event "fix: chose heliarchs"
 				fail
 
 			label "heliarch"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Prior to the merge of https://github.com/endless-sky/endless-sky/pull/9402, there was a (relatively small?) chance that the player could have joined both the Heliarchs and Lunarium. This PR introduces a patch for those saves who have joined both factions, and forces them to choose one side. Based on their choice, the conditions of the other side are cleared. I've put the patch below the Lunarium intro as this was a result of a Lunarium mission lacking some conditions. 