### PR TITLE
Prevent random Pug fleets from leaving Pug systems

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1077,6 +1077,8 @@ government "Pug"
 	"friendly disabled hail" "friendly disabled pug"
 	"hostile hail" "hostile pug"
 	"hostile disabled hail" "hostile pug"
+	"travel restrictions"
+		not government "Pug"
 
 # A pug government with distinct reputation toward the player compared to those met during the main campaign.
 government "Pug (Wanderer)"
@@ -1095,6 +1097,8 @@ government "Pug (Wanderer)"
 	"friendly disabled hail" "friendly disabled pug"
 	"hostile hail" "hostile pug"
 	"hostile disabled hail" "hostile pug"
+	"travel restrictions"
+		not government "Pug (Wanderer)"
 
 # Quarg are split up to their respective areas, and an overall one is kept for missions or other use.
 government "Quarg"

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -10244,6 +10244,21 @@ system Deneb
 		distance 1788.4
 		period 1210.08
 
+system "Deneb PD 1"
+	hidden
+	pos -348 225
+	government Pug
+
+system "Deneb PD 2"
+	hidden
+	pos -348 225
+	government Pug
+
+system "Deneb PD 3"
+	hidden
+	pos -348 225
+	government Pug
+
 system Denebola
 	pos -478 70
 	government Republic
@@ -26742,6 +26757,22 @@ system "Pug Iyik"
 			sprite planet/desert4
 			distance 365
 			period 36.706
+
+system "Pug Iyik PD 1"
+	hidden
+	pos -361.149 -883.233
+	government "Pug (Wanderer)"
+
+system "Pug Iyik PD 2"
+	hidden
+	pos -361.149 -883.233
+	government "Pug (Wanderer)"
+
+system "Pug Iyik PD 3"
+	hidden
+	pos -361.149 -883.233
+	government "Pug (Wanderer)"
+
 
 system Pukako
 	pos 618.64 -440.28

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -10248,16 +10248,19 @@ system "Deneb PD 1"
 	hidden
 	pos -348 225
 	government Pug
+	attributes "inaccessible"
 
 system "Deneb PD 2"
 	hidden
 	pos -348 225
 	government Pug
+	attributes "inaccessible"
 
 system "Deneb PD 3"
 	hidden
 	pos -348 225
 	government Pug
+	attributes "inaccessible"
 
 system Denebola
 	pos -478 70
@@ -26762,16 +26765,19 @@ system "Pug Iyik PD 1"
 	hidden
 	pos -361.149 -883.233
 	government "Pug (Wanderer)"
+	attributes "inaccessible"
 
 system "Pug Iyik PD 2"
 	hidden
 	pos -361.149 -883.233
 	government "Pug (Wanderer)"
+	attributes "inaccessible"
 
 system "Pug Iyik PD 3"
 	hidden
 	pos -361.149 -883.233
 	government "Pug (Wanderer)"
+	attributes "inaccessible"
 
 system Pukako
 	pos 618.64 -440.28

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -26773,7 +26773,6 @@ system "Pug Iyik PD 3"
 	pos -361.149 -883.233
 	government "Pug (Wanderer)"
 
-
 system Pukako
 	pos 618.64 -440.28
 	government Uninhabited


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Prevent random Pug fleets from leaving Pug systems and jumping into human or Wanderer space by giving the two Pug governments travel restrictions to not travel to any location that isn't one of their own. In order to not have Pug fleets stack up in single systems and still appear to jump in and out, added three hidden "pocket dimension" systems that share a position with the main systems and act as viable jump destinations for Pug fleets.

No changes made to campaign Pug fleets because NPCs don't follow travel restrictions by default.

Resolves #8876.

## Testing done

Observed that Pug fleets still spawn in Pug systems. They sometimes jump out, but they never jumped out to an accessible system, meaning they're jumping to the hidden pocket dimension systems.