### PR TITLE
feat(content): Change `FW Katya 2B`'s fleet's government from `Pirate` to `Bounty Hunter`

### DIFF
--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -1552,8 +1552,8 @@ mission "FW Katya 2B"
 		log `Met up with a friend of Katya's named Mr. Eyes, who calls himself a "vigilante nuclear power plant inspector." He thinks he can help hunt down the people who bombed Geminus and Martini, to prove that the Free Worlds were not behind it.`
 	
 	npc
-		government "Pirate"
-		personality nemesis plunders waiting
+		government "Bounty Hunter"
+		personality nemesis plunders staying waiting
 		fleet "Small Core Pirates" 2
 	
 	on visit


### PR DESCRIPTION
During `FW Katya 2A`, Katya says that Ijs is "a little unpopular with big corporations and certain corrupt planetary governments," and in `FW Katya 2B`, Ijs directly says that "the Syndicate hates my guts right now." Despite this, the NPCs in `FW Katya 2B`, who are implied by the previous statements to be Syndicate-paid mercenaries, are just regular pirates, and tend to be destroyed by Syndicate forces themselves. This PR makes the titular change so that this doesn't happen. To compensate for the increased difficulty (especially since this mission might be the first time a player is chased by an enemy with force damage), the fleet now has the `staying` personality.