### PR TITLE
Remove regen attributes from attribute whitelist

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -36,7 +36,6 @@ namespace {
 	// disallowed or undesirable behaviors (such as dividing by zero).
 	const auto MINIMUM_OVERRIDES = map<string, double>{
 		// Attributes which are present and map to zero may have any value.
-		{"shield generation", 0.},
 		{"shield energy", 0.},
 		{"shield fuel", 0.},
 		{"shield heat", 0.},

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -40,7 +40,6 @@ namespace {
 		{"shield energy", 0.},
 		{"shield fuel", 0.},
 		{"shield heat", 0.},
-		{"hull repair rate", 0.},
 		{"hull energy", 0.},
 		{"hull fuel", 0.},
 		{"hull heat", 0.},


### PR DESCRIPTION
-----------------------
**Feature**

## Feature Details
This PR removes `"hull repair rate"` and `"shield generation"` (suggested by quyykk) from the attributes whitelist.
https://github.com/endless-sky/endless-sky/pull/6646 added the Shield Refactor Module, which reduces hull repair by a flat value as well as by a -20% multiplier, while increasing shield regen by 25%.
It was reported on the Discord that the outfit was being installed even in ships which completely lacked hull repair.
That is not intended behavior.
Upon investigation it appears to be happening because https://github.com/endless-sky/endless-sky/pull/6872 added `"hull repair rate"` to the attribute whitelist, allowing it to go below 0, meaning the flat value reduction of hull repair is simply meaningless currently.

This PR thus aims to address that and bring the outfit back to what was intended with respect to its costs and limitations.

It was suggested in the Discord that negative values for `"hull repair rate"` and `"shield generation"` make the ship take constant damage whilst flying, however as such functionality does not yet exist this PR is being made in order to bring the Shield Refactor Module in line with balance in a quicker, easier manner.
Later on once such functionnality exists the attribute could be re-added to the attribute whitelist.

If someone does manage to code in the functionality before the next stable release I'd be ok with that being merged instead of this too, however I don't know how realistic it is to expect that to be done by the release date for next stable.

## Testing Done
None for this PR, but I tested the outfit before opening https://github.com/endless-sky/endless-sky/pull/6646, and the outfit's limitations were working as intended (I was unable to simply install one without having any hull repair to begin with).
After the Discord reports, I tested once again and it is now possible to install one without having any hull repair to begin with, hence the intent for this PR to bring it back to what it was before.
