### PR TITLE
Coalition Intros: a few balance tweaks

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -244,8 +244,8 @@ outfit "Shield Refactor Module"
 	"mass" 7
 	"outfit space" -7
 	"hull repair rate" -.2
-	"shield energy" .2
-	"shield heat" .24
+	"shield energy" .24
+	"shield heat" .32
 	"shield generation multiplier" .25
 	"hull repair multiplier" -.2
 	description "In theory, all shield generators can operate at a much faster rate than normal, if pushed to their true limit. However, the constant need to reform shields during a heated battle quickly overloads shield generators and damages them in the process. By relocating dedicated hull repair systems to focus exclusively on repairing such damage, this compact device allows shield generators to reach their true potential."
@@ -419,10 +419,10 @@ outfit "Enforcer Riot Staff"
 
 outfit "Anti-Materiel Gun"
 	category "Hand to Hand"
-	cost 128600
+	cost 257200
 	thumbnail "outfit/anti-materiel gun"
-	"capture attack" 3.6
-	"capture defense" 1.8
+	"capture attack" 3.4
+	"capture defense" 1.9
 	"unplunderable" 1
 	description "Easy to use and relatively cheap to manufacture, these weapons were born by refurbishing the Heliarchs' favored arms, with the new barrel shaping the energy into deadly blasts that make short work of even the toughest body armor."
 

--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -246,7 +246,7 @@ outfit "Shield Refactor Module"
 	"hull repair rate" -.2
 	"shield energy" .24
 	"shield heat" .32
-	"shield generation multiplier" .25
+	"shield generation multiplier" .2
 	"hull repair multiplier" -.2
 	description "In theory, all shield generators can operate at a much faster rate than normal, if pushed to their true limit. However, the constant need to reform shields during a heated battle quickly overloads shield generators and damages them in the process. By relocating dedicated hull repair systems to focus exclusively on repairing such damage, this compact device allows shield generators to reach their true potential."
 	description "	A much needed boon against the Heliarch torpedoes' devastating effects on hull plating, the Lunarium highly favors production of this expensive piece due to its advantages over other shield generators."

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -1618,7 +1618,7 @@ mission "Heliarch Drills 1"
 		has "license: Coalition"
 		not "joined the lunarium"
 		not "assisting lunarium"
-		random < 8
+		random < 11
 		"combat rating" >= 8104
 	on offer
 		conversation


### PR DESCRIPTION
-----------------------
**Balance:**

## Summary
Doubles the cost for the `Anti-Materiel Gun`, lowers its attack by .2 and increases its defense by .1
Increases the shield energy and shield heat for the `Shield Refactor Module`, and reduces its shield generation multiplier from 25% to 20%.

Makes the Heliarch Drills mission chain slightly easier to start, by increasing the `random` from 8 to 11

## Reasoning
It has been discussed in the Discord that the `Anti-Materiel Gun` was too cheap and powerful, and that the `Shield Refactor Module`'s downsides weren't enough to counter its boost to shields. This PR addresses both cases.

It was also mentioned in one of the responses in the feedback box for 0.10.3 that the Heliarch side of the Intros is harder to find or start than the Lunarium side. While the current differences in offer conditions are intended, reviewing the existing missions' random offer values I believe the Heliarch Drills random could be increased slightly so as to make it a bit easier to start that chain, as its required `near "Belug" 6 100` distance rules out most of the systems in and around the center of the Coalition, so this should help remedy cases where players need one more mission chain to be offered the join offer and haven't done this one yet.
