### PR TITLE
fix(preferences): Save extended jump effects value correctly

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -155,7 +155,6 @@ void Preferences::Load()
 	settings["Show planet labels"] = true;
 	settings["Show asteroid scanner overlay"] = true;
 	settings["Show hyperspace flash"] = true;
-	settings["Extended jump effects"] = true;
 	settings["Draw background haze"] = true;
 	settings["Draw starfield"] = true;
 	settings["Hide unexplored map regions"] = true;


### PR DESCRIPTION
## Fix Details
Removed "Extended jump effects" from boolean settings. Before, it was saved twice: first with the correct value, then with the default value of true (1), which can't be changed as the old boolean setting is no longer connected with the UI. When loading such corrupted file, the game first loads the correct value and then overwrites it with 1.

## Testing Done
yes.