### PR TITLE
micro-refactor: simplify to-offer

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -4126,8 +4126,7 @@ mission "The Book of Skadenga"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	to offer
 		random < 10
-		or
-			has "event: the book"
+		has "event: the book"
 	on offer
 		conversation
 			`As you wander through the spaceport, something catches your eye at a kiosk selling gifts, trinkets, and other odds and ends.`


### PR DESCRIPTION
If I understand how to-offer works, `or` is redundant in this mission because there is only one condition inside it