### PR TITLE
feat(content): Add new ship variants optimised for long-range carrier tactics

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1534,6 +1534,9 @@ fleet "Small Deep Security"
 	variant 4
 		"Aerie"
 		"Dagger" 2
+	variant 2
+		"Aerie (Javelin Resupply)"
+		"Dagger (Javelin Light)" 2
 	variant 3
 		"Raven"
 	variant 1
@@ -1613,6 +1616,9 @@ fleet "Large Deep Security"
 	variant 3
 		"Corvette (Speedy)"
 		"Corvette (Missile)"
+	variant 2
+		"Aerie (Javelin Resupply)" 2
+		"Dagger (Javelin Light) 4
 
 fleet "Small Oathkeeper"
 	government "Navy (Oathkeeper)"

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1618,7 +1618,7 @@ fleet "Large Deep Security"
 		"Corvette (Missile)"
 	variant 2
 		"Aerie (Javelin Resupply)" 2
-		"Dagger (Javelin Light) 4
+		"Dagger (Javelin Light)" 4
 
 fleet "Small Oathkeeper"
 	government "Navy (Oathkeeper)"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -11,6 +11,22 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
+ship "Aerie" "Aerie (Javelin Resupply)"
+	outfits
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 90
+		"Javelin Storage Crate" 14
+		"Javelin" 1400
+		"Anti-Missile Turret" 2
+		"Heavy Anti-Missile Turret"
+		"Dwarf Core"
+		"LP072a Battery Pack"
+		"D67-TM Shield Generator"
+		"Laser Rifle" 2
+		"X3700 Ion Thruster"
+		"X3200 Ion Steering"
+		"Hyperdrive"
+
 ship "Argosy" "Argosy (Blaster)"
 	outfits
 		"Energy Blaster" 4
@@ -1341,6 +1357,15 @@ ship "Cutthroat" "Cutthroat (Jousting)"
 	gun -11 -8.5 "Twin Modified Blaster"
 	gun 11 -8.5 "Twin Modified Blaster"
 
+
+Ship "Dagger" "Dagger (Javelin Light)"
+	outfits
+		"Javelin Mini Pod" 3
+		"Javelin" 120
+		"Supercapacitor"
+		"nVGF-AA Fuel Cell"
+		"A120 Atmoic Thruster"
+		"X1200 Ion Steering"
 
 
 ship "Dreadnought" "Dreadnought (Jump)"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -26,6 +26,9 @@ ship "Aerie" "Aerie (Javelin Resupply)"
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
 		"Hyperdrive"
+	turret "Heavy Anti-Missile Turret"
+	turret "Anti-Missile Turret"
+	turret "Anti-Missile Turret"
 
 
 ship "Argosy" "Argosy (Blaster)"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -27,6 +27,7 @@ ship "Aerie" "Aerie (Javelin Resupply)"
 		"X3200 Ion Steering"
 		"Hyperdrive"
 
+
 ship "Argosy" "Argosy (Blaster)"
 	outfits
 		"Energy Blaster" 4

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1362,7 +1362,7 @@ ship "Cutthroat" "Cutthroat (Jousting)"
 	gun 11 -8.5 "Twin Modified Blaster"
 
 
-Ship "Dagger" "Dagger (Javelin Light)"
+ship "Dagger" "Dagger (Javelin Light)"
 	outfits
 		"Javelin Mini Pod" 3
 		"Javelin" 120

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1368,7 +1368,7 @@ Ship "Dagger" "Dagger (Javelin Light)"
 		"Javelin" 120
 		"Supercapacitor"
 		"nVGF-AA Fuel Cell"
-		"A120 Atmoic Thruster"
+		"A120 Atomic Thruster"
 		"X1200 Ion Steering"
 
 

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1367,7 +1367,7 @@ ship "Dagger" "Dagger (Javelin Light)"
 		"Javelin Mini Pod" 3
 		"Javelin" 120
 		"Supercapacitor"
-		"nVGF-AA Fuel Cell"
+		"nGVF-AA Fuel Cell"
 		"A120 Atomic Thruster"
 		"X1200 Ion Steering"
 


### PR DESCRIPTION
**Content**

## Summary
As pointed out in #9429, carriers currently tend to engage at close ranges, preventing them repairing their fighters. I suggested there that carriers built as long-range missile boats would solve that problem, provided they had the mobility to maintain their distance. This PR adds ships built in such a manner to the Deep Security fleets.
The Aerie build here shares the 422.19 top speed of the stock Aerie, which should provide an ideal compromise between being able to stay out of combat without becoming frustrating to chase down.
The Dagger build is a quite effective one that I have had a fair amount of success with.

![image](https://github.com/endless-sky/endless-sky/assets/18634983/eb9e343d-ce49-4015-ae29-14ac818492ad)
![image](https://github.com/endless-sky/endless-sky/assets/18634983/e314bde8-4ed9-4a0c-860d-f2dacb4a23b3)
