### PR TITLE
Fix collision masks for scaled player ships

### DIFF
--- a/source/GameLoadingPanel.cpp
+++ b/source/GameLoadingPanel.cpp
@@ -58,13 +58,14 @@ void GameLoadingPanel::Step()
 		// e.g. due to capitalization errors or other typos.
 		SpriteSet::CheckReferences();
 		Audio::CheckReferences();
-		// All sprites with collision masks should also have their 1x scaled versions, so create
-		// any additional scaled masks from the default one.
-		GameData::GetMaskManager().ScaleMasks();
 		// Set the game's initial internal state.
 		GameData::FinishLoading();
 
 		player.LoadRecent();
+
+		// All sprites with collision masks should also have their 1x scaled versions, so create
+		// any additional scaled masks from the default one.
+		GameData::GetMaskManager().ScaleMasks();
 
 		GetUI()->Pop(this);
 		if(conversation.IsEmpty())

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -30,6 +30,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Interface.h"
 #include "text/layout.hpp"
 #include "MainPanel.h"
+#include "MaskManager.h"
 #include "PlayerInfo.h"
 #include "Preferences.h"
 #include "Rectangle.h"
@@ -550,6 +551,7 @@ void LoadPanel::LoadCallback()
 	gamePanels.CanSave(true);
 
 	player.Load(loadedInfo.Path());
+	GameData::GetMaskManager().ScaleMasks();
 
 	GetUI()->PopThrough(GetUI()->Root().get());
 	gamePanels.Push(new MainPanel(player));

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -551,6 +551,8 @@ void LoadPanel::LoadCallback()
 	gamePanels.CanSave(true);
 
 	player.Load(loadedInfo.Path());
+
+	// Scale any new masks that might have been added by the newly loaded save file.
 	GameData::GetMaskManager().ScaleMasks();
 
 	GetUI()->PopThrough(GetUI()->Root().get());

--- a/source/MaskManager.cpp
+++ b/source/MaskManager.cpp
@@ -72,15 +72,12 @@ void MaskManager::ScaleMasks()
 			continue;
 
 		const auto &baseMasks = baseIt->second;
-		for(auto it = scales.begin(); it != baseIt; ++it)
+		for(auto it = scales.begin(); it != scales.end(); ++it)
 		{
-			auto &masks = it->second;
-			masks.reserve(baseMasks.size());
-			for(auto &&mask : baseMasks)
-				masks.push_back(mask * it->first);
-		}
-		for(auto it = next(baseIt); it != scales.end(); ++it)
-		{
+			// Skip mask generation for scales that have already been generated previously.
+			if(it == baseIt || !it->second.empty())
+				continue;
+
 			auto &masks = it->second;
 			masks.reserve(baseMasks.size());
 			for(auto &&mask : baseMasks)

--- a/source/MaskManager.cpp
+++ b/source/MaskManager.cpp
@@ -74,11 +74,12 @@ void MaskManager::ScaleMasks()
 		const auto &baseMasks = baseIt->second;
 		for(auto &it : scales)
 		{
+			auto &masks = it.second;
+
 			// Skip mask generation for scales that have already been generated previously.
-			if(!it.second.empty())
+			if(!masks.empty())
 				continue;
 
-			auto &masks = it.second;
 			masks.reserve(baseMasks.size());
 			for(auto &&mask : baseMasks)
 				masks.push_back(mask * it.first);

--- a/source/MaskManager.cpp
+++ b/source/MaskManager.cpp
@@ -75,7 +75,7 @@ void MaskManager::ScaleMasks()
 		for(auto it = scales.begin(); it != scales.end(); ++it)
 		{
 			// Skip mask generation for scales that have already been generated previously.
-			if(it == baseIt || !it->second.empty())
+			if(!it->second.empty())
 				continue;
 
 			auto &masks = it->second;

--- a/source/MaskManager.cpp
+++ b/source/MaskManager.cpp
@@ -72,16 +72,16 @@ void MaskManager::ScaleMasks()
 			continue;
 
 		const auto &baseMasks = baseIt->second;
-		for(auto it = scales.begin(); it != scales.end(); ++it)
+		for(auto &it : scales)
 		{
 			// Skip mask generation for scales that have already been generated previously.
-			if(!it->second.empty())
+			if(!it.second.empty())
 				continue;
 
-			auto &masks = it->second;
+			auto &masks = it.second;
 			masks.reserve(baseMasks.size());
 			for(auto &&mask : baseMasks)
-				masks.push_back(mask * it->first);
+				masks.push_back(mask * it.first);
 		}
 	}
 }


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported by "Atypical Swiftclaw" on Discord.

## Fix Details

Masks for scaled sprites are currently only generated for sprites defined in the data files. If you happen to have a ship with a scale, but this scaled sprite doesn't appear anywhere in the data files, your ship will not have a collision mask.

This PR fixes this issue by scaling the mask only after the player has been loaded, and rescales any missing mask when loading a new save through the load panel. Previously generated masks that aren't used anymore are still being kept around, but that's not a big issue.

## Testing Done

Used a save file with a scaled ship that isn't in the data files. Tried directly loading into it and loading it through the load panel. This PR fixes both cases.

## Save File

[f f.txt](https://github.com/endless-sky/endless-sky/files/12868847/f.f.txt) Depart and tribute the planet 
