### PR TITLE
Disable broken integration tests

### DIFF
--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_capture_override.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_capture_override.txt
@@ -108,7 +108,7 @@ test-data "Capture Uncapturable With Capturable Override Mission"
 
 
 test "Capture Uncapturable With Capturable Override"
-	status active
+	status broken
 	description "Starts the mission, accepts it and then boards the quarg ship to capture it."
 	sequence
 		inject "Capture Uncapturable With Capturable Override Mission"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
@@ -208,7 +208,7 @@ test "Conditional Test Goto"
 
 
 test "Conditional Test Out of Bound"
-	status active
+	status broken
 	description "Test if a first conversation option does not show up but the second one does, when the given condition is set. Also makes sure goto still works as expected."
 	sequence
 		inject "Conversation Conditions Test Missions"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -344,7 +344,7 @@ test "Boarding Test - Repair Friendly Ship"
 			"%TEST%: Wardragon Scanning You!: done" == 1
 
 test "Illegal Test - Ignore and New Illegal"
-	status active
+	status broken
 	description "Test if a Quarg ship spawning disabled in the system will give you a fine for an illegal outfit and ignore the fine for another, after you repaired it."
 	sequence
 		inject "quarg scanning save"
@@ -360,7 +360,7 @@ test "Illegal Test - Ignore and New Illegal"
 			"unpaid fines" == 1
 
 test "Atrocity Test - New Atrocity"
-	status active
+	status broken
 	description "Test if a Quarg ship spawning disabled in the system will consider an outfit an atrocity when specified by an event."
 	sequence
 		inject "quarg atrocity save"


### PR DESCRIPTION
I went through a couple of failing integration tests and I disabled them. They are probably failing because of some race condition, because locally they never fail.