### PR TITLE
Asteroid defuelification

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -2026,7 +2026,6 @@ ship "Asteroid"
 	sprite "asteroid/medium rock/spin"
 		"frame rate" 10
 	attributes
-		"fuel capacity" 1
 		"hull" 10000
 		"mass" 1000
 		"drag" 10


### PR DESCRIPTION
Wyrdean reported on Discord that ships sometimes try to refuel the asteroid used in the terraforming missions. I have removed the fuel capacity from the asteroid to prevent this.

I tried the mission on an edited save with the fuel capacity removed and it worked normally.