### PR TITLE
Don't target asteroids past your scanner range

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3713,6 +3713,8 @@ bool AI::TargetMinable(Ship &ship) const
 	auto UpdateBestMinable = MinableStrategy();
 	for(auto &&minable : minables)
 	{
+		if(GetDistanceMetric(*minable) > scanRangeMetric)
+			continue;
 		if(bestMinable)
 			UpdateBestMinable(minable);
 		else


### PR DESCRIPTION
**Bugfix:** This PR fixes an issue reported by "Rocket Witch" on Steam: https://steamcommunity.com/app/404410/discussions/1/5374541530380822538/

## Fix Details

Adds the missing checks that make sure that the asteroid is in fact inside the asteroid scanner range when targeting one.

## Testing Done

not yet
