### PR TITLE
fix(content): Fix swizzle of Lunarium ships training in human space

### DIFF
--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -1713,7 +1713,7 @@ mission "Lunarium: Combat Training 2"
 	on visit
 		dialog `You land on <planet>, but you're not done with the mission yet. Either some of the Lunarium's ships haven't entered the system yet, or some of the pirate ships in <waypoints> haven't been defeated. Return once everything is in order.`
 	npc accompany save
-		government "Lunarium"
+		government "Lunarium (Hidden)"
 		personality escort
 		ship "Bastion" "Procellarum"
 		ship "Argosy" "Ingenii"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -896,6 +896,21 @@ government "Lunarium"
 		"Heliarch" -.01
 		"Pirate" -.01
 
+government "Lunarium (Hidden)"
+	swizzle 5
+	"crew attack" 1.2
+	"crew defense" 2.7
+	language "Coalition"
+	"player reputation" 1
+	"friendly hail" "friendly lunarium"
+	"friendly disabled hail" "friendly disabled lunarium"
+	"hostile hail" "hostile lunarium"
+	"hostile disabled hail" "hostile disabled lunarium"
+	"attitude toward"
+		"Quarg" .01
+		"Heliarch" -.01
+		"Pirate" -.01
+
 government "Marauder"
 	swizzle 6
 	"player reputation" 1

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -897,6 +897,7 @@ government "Lunarium"
 		"Pirate" -.01
 
 government "Lunarium (Hidden)"
+	"display name" "Lunarium"
 	swizzle 5
 	"crew attack" 1.2
 	"crew defense" 2.7


### PR DESCRIPTION
**Bugfix:** This fixes something mentioned by @Arachi-Lover :
> Their swizzle is ghe FW one but I should change theirs to be the standard Coal one for the time being at least
> Kinda a dumbo they go about not disguised. Anyone want to farm a commit with that too be my guest

## Fix Details
Adds a new government called `Lunarium (Hidden)` that has the same attributes as `Lunarium`, but uses the coalition swizzle.

## Testing Done
None. (I haven't gotten this far yet, so I don't have a save file.)

## Save File
~~Please don't make me play through the entire game to get one~~