### PR TITLE
Make Quarg escorts in "Wanderers: Sestor: Quarg Help 2" actually help fight the Sestor ships

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1158,6 +1158,7 @@ government "Quarg (Hai)"
 		"Quarg (Kor Efret)" 1
 		"Quarg (Gegno)" 1
 		"Merchant" .01
+		"Kor Sestor" -.01
 		"Hai" .01
 		"Hai (Wormhole Access)" .01
 		"Pirate" -.01


### PR DESCRIPTION
**Bugfix:**

## Fix Details
Makes the "Quarg (Hai)" government hostile to the Kor Sestor so the Quarg ships that come to assist in the defence of Farpoint from the Alpha controlled Sestor ships will actually help.

## Testing Done
Without this change, the Quarg won't help fight the Sestor. With it they will.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using continuous, and will not occur when using this branch's build.
[warp core.txt](https://github.com/endless-sky/endless-sky/files/12910975/warp.core.txt)

