### PR TITLE
Improve the linux CMake instructions a bit

### DIFF
--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -55,7 +55,7 @@ You can use your favorite package manager to install the needed dependencies. If
 <summary>DEB-based distros</summary>
 
 ```
-g++ cmake ninja-build libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglew-dev libopenal-dev libmad0-dev uuid-dev
+g++ cmake ninja-build curl libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglew-dev libopenal-dev libmad0-dev uuid-dev
 ```
 
 </details>

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -49,11 +49,7 @@ If you want to build the libraries from source instead of using Homebrew, you ca
 
 ### Linux
 
-You will need at least CMake 3.21. You can get the latest version from the [offical website](https://cmake.org/download/).
-
-**Note**: If your distro does not provide up-to-date version of the needed libraries, you will need to tell CMake to build the libraries from source by passing `-DES_USE_SYSTEM_LIBRARIES=OFF` while configuring.
-
-If you use a reasonably up-to-date distro, then you can use your favorite package manager to install the needed dependencies.
+You can use your favorite package manager to install the needed dependencies. If you're using a slower moving distro like Ubuntu or Debian (or any derivatives thereof), make sure to use at least Ubuntu 22.04 LTS or Debian 12. If you are using an older version of those distributions, see the note below.
 
 <details>
 <summary>DEB-based distros</summary>
@@ -72,6 +68,8 @@ gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL
 ```
 
 </details>
+
+**Note**: If your distro does not provide up-to-date version of the needed libraries, you will need to tell CMake to build the libraries from source by passing `-DES_USE_SYSTEM_LIBRARIES=OFF` while configuring. You will also need at least CMake 3.21. You can get the latest version from the [offical website](https://cmake.org/download/). Additional dependencies will likely need to be installed to build the libraries from source as well.
 
 ## Building the game
 
@@ -101,7 +99,9 @@ Replace `<preset>` with one of the following presets:
 
 - Windows: `clang-cl` (builds with Clang for Windows), `mingw` (builds with MinGW), `mingw32` (builds with x86 MinGW)
 - MacOS: `macos` or `macos-arm` (builds with the default compiler, for x64 and ARM64 respectively)
-- Linux: `linux` (builds with the default compiler)
+- Linux: `linux` (builds with the default compiler), `linux-gles` (compiles with GLES instead of OpenGL support)
+
+You can list all of available presets with `cmake --list-presets`.
 
 ### Using an IDE
 

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -51,6 +51,8 @@ If you want to build the libraries from source instead of using Homebrew, you ca
 
 You can use your favorite package manager to install the needed dependencies. If you're using a slower moving distro like Ubuntu or Debian (or any derivatives thereof), make sure to use at least Ubuntu 22.04 LTS or Debian 12. If you are using an older version of those distributions, see the note below.
 
+**Note**: If your distro does not provide up-to-date version of the needed libraries, you will need to tell CMake to build the libraries from source by passing `-DES_USE_SYSTEM_LIBRARIES=OFF` while configuring. You will also need at least CMake 3.21. You can get the latest version from the [offical website](https://cmake.org/download/). Additional dependencies will likely need to be installed to build the libraries from source as well.
+
 <details>
 <summary>DEB-based distros</summary>
 
@@ -68,8 +70,6 @@ gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL
 ```
 
 </details>
-
-**Note**: If your distro does not provide up-to-date version of the needed libraries, you will need to tell CMake to build the libraries from source by passing `-DES_USE_SYSTEM_LIBRARIES=OFF` while configuring. You will also need at least CMake 3.21. You can get the latest version from the [offical website](https://cmake.org/download/). Additional dependencies will likely need to be installed to build the libraries from source as well.
 
 ## Building the game
 

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -49,9 +49,11 @@ If you want to build the libraries from source instead of using Homebrew, you ca
 
 ### Linux
 
-You can use your favorite package manager to install the needed dependencies. If you're using a slower moving distro like Ubuntu or Debian (or any derivatives thereof), make sure to use at least Ubuntu 22.04 LTS or Debian 12. If you are using an older version of those distributions, see the note below.
+You can use your favorite package manager to install the needed dependencies. If you're using a slower moving distro like Ubuntu or Debian (or any derivatives thereof), make sure to use at least Ubuntu 22.04 LTS or Debian 12.
+If your distro does not provide up-to-date version of these libraries, you will need to tell CMake to build the libraries from source by passing `-DES_USE_SYSTEM_LIBRARIES=OFF` while configuring. Older versions of Ubuntu and Debian, for example, will need this. Additional dependencies will likely need to be installed to build the libraries from source as well.
 
-**Note**: If your distro does not provide up-to-date version of the needed libraries, you will need to tell CMake to build the libraries from source by passing `-DES_USE_SYSTEM_LIBRARIES=OFF` while configuring. You will also need at least CMake 3.21. You can get the latest version from the [offical website](https://cmake.org/download/). Additional dependencies will likely need to be installed to build the libraries from source as well.
+In addition to the below dependencies, you will also need CMake 3.21 or newer. You can get the latest version from the [offical website](https://cmake.org/download/).
+
 
 <details>
 <summary>DEB-based distros</summary>


### PR DESCRIPTION
**Bugfix:** This PR fixes #9450 

## Fix Details

Improves the CMake docs for Linux a bit:

- Mention the minimum version needed for Debian/Ubuntu
- Add gles preset mention
- Mention `cmake --list-presets`
- Add a short sentence about needing to install additional dependencies when building from source.