### PR TITLE
Revert "feat(mechanics): don't disable cooling and active cooling when overheated"

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -16,7 +16,7 @@ tip "acceleration:"
 	`How quickly this ship gains speed. The higher a ship's mass (including the mass of any cargo or fighters it is carrying), the slower it accelerates.`
 
 tip "active cooling:"
-	`Cooling provided per second when running at full strength. Active cooling requires energy, but if your heat level is low it runs at a lower cooling rate and lower energy draw. The amount of cooling is proportional to the temperature of your ship, reaching the full level only if your ship is overheated.`
+	`Cooling provided per second when running at full strength. Active cooling requires energy, but if your heat level is low it runs at a lower cooling rate and lower energy draw. The amount of cooling is proportional to the temperature of your ship, reaching the full level only if you are about to overheat.`
 
 tip "afterburner energy:"
 	`Energy consumed per second when firing this afterburner.`
@@ -130,7 +130,7 @@ tip "cooling:"
 	`Heat dissipated per second. This is for when your ship's built-in heat dissipation is not sufficient to keep it from overheating.`
 
 tip "cooling energy:"
-	`Energy consumed per second when active cooling is running at full strength (because your ship is overheated).`
+	`Energy consumed per second when active cooling is running at full strength (because your ship's temperature is approaching the overheating threshold).`
 
 tip "cooling inefficiency:"
 	`Interference with your ship's cooling abilities. Its cooling systems will only be about 75% effective at a cooling inefficiency of 5, and 30% at an inefficiency of 10.`

--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -199,7 +199,7 @@ outfit "Cooling Module"
 	"outfit space" -5
 	"active cooling" 21
 	"cooling energy" 1.4
-	description "This Cooling Module consumes energy. To conserve power, it does not ramp up to full strength unless a ship is overheated."
+	description "This Cooling Module consumes energy. To conserve power, it does not ramp up to full strength unless a ship is very close to overheating."
 
 outfit "Fuel Module"
 	category "Systems"

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3769,34 +3769,7 @@ void Ship::DoGeneration()
 	double maxHull = MaxHull();
 	hull = min(hull, maxHull);
 
-	bool isIncapacitated = hull < MinimumHull() || (!crew && RequiredCrew());
-	isDisabled = isOverheated || isIncapacitated;
-
-	if(!isIncapacitated)
-	{
-		double coolingEfficiency = CoolingEfficiency();
-		heat -= coolingEfficiency * attributes.Get("cooling");
-		double activeCooling = coolingEfficiency * attributes.Get("active cooling");
-		// Apply active cooling. The fraction of full cooling to apply equals
-		// your ship's current fraction of its maximum temperature.
-		if(activeCooling > 0. && heat > 0. && energy >= 0.)
-		{
-			// Active cooling always runs at 100% power if overheated
-			// even if below 100% heat.
-			double heatFraction = (isOverheated ? 1. : Heat());
-			// Handle the case where "active cooling"
-			// does not require any energy.
-			double coolingEnergy = attributes.Get("cooling energy");
-			if(coolingEnergy)
-			{
-				double spentEnergy = min(energy, coolingEnergy * heatFraction);
-				heat -= activeCooling * spentEnergy / coolingEnergy;
-				energy -= spentEnergy;
-			}
-			else
-				heat -= activeCooling * heatFraction;
-		}
-	}
+	isDisabled = isOverheated || hull < MinimumHull() || (!crew && RequiredCrew());
 
 	// Update ship supply levels.
 	if(isDisabled)
@@ -3815,9 +3788,11 @@ void Ship::DoGeneration()
 			heat += solarScaling * attributes.Get("solar heat");
 		}
 
+		double coolingEfficiency = CoolingEfficiency();
 		energy += attributes.Get("energy generation") - attributes.Get("energy consumption");
 		fuel += attributes.Get("fuel generation");
 		heat += attributes.Get("heat generation");
+		heat -= coolingEfficiency * attributes.Get("cooling");
 
 		// Convert fuel into energy and heat only when the required amount of fuel is available.
 		if(attributes.Get("fuel consumption") <= fuel)
@@ -3827,6 +3802,23 @@ void Ship::DoGeneration()
 			heat += attributes.Get("fuel heat");
 		}
 
+		// Apply active cooling. The fraction of full cooling to apply equals
+		// your ship's current fraction of its maximum temperature.
+		double activeCooling = coolingEfficiency * attributes.Get("active cooling");
+		if(activeCooling > 0. && heat > 0. && energy >= 0.)
+		{
+			// Handle the case where "active cooling"
+			// does not require any energy.
+			double coolingEnergy = attributes.Get("cooling energy");
+			if(coolingEnergy)
+			{
+				double spentEnergy = min(energy, coolingEnergy * min(1., Heat()));
+				heat -= activeCooling * spentEnergy / coolingEnergy;
+				energy -= spentEnergy;
+			}
+			else
+				heat -= activeCooling * min(1., Heat());
+		}
 	}
 
 	// Don't allow any levels to drop below zero.


### PR DESCRIPTION
Reverts endless-sky/endless-sky#8968.
Resolves #9470.

#8968 was a nerf to heat damage, but it affected it in the wrong way, I think. As outlined in #9470, some ships, particularly the Kor Sestor, benefited disproportionately, and the balance of the wanderer campaign and heat weapons in general was negatively affected as a result. I felt that was a problem with #7042, and I agree that it's a problem with #8968.