### PR TITLE
Feat: add a new `"use crew equivalent as crew"` attribute

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2662,7 +2662,7 @@ int Ship::RequiredCrew() const
 
 int Ship::CrewValue() const
 {
-	double crewEquivalent = attributes.Get("crew equivalent");
+	int crewEquivalent = attributes.Get("crew equivalent");
 	return crewEquivalent ? crewEquivalent : max(Crew(), RequiredCrew());
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2662,7 +2662,7 @@ int Ship::RequiredCrew() const
 
 int Ship::CrewValue() const
 {
-	int crewEquivalent = attributes.Get("crew equivalent")
+	int crewEquivalent = attributes.Get("crew equivalent");
 	if(attributes.get("crew equivalent overrides"))
 		return crewEquivalent ? crewEquivalent : max(Crew(), RequiredCrew());
 	return max(Crew(), RequiredCrew()) + crewEquivalent;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2662,8 +2662,10 @@ int Ship::RequiredCrew() const
 
 int Ship::CrewValue() const
 {
-	int crewEquivalent = attributes.Get("crew equivalent");
-	return crewEquivalent ? crewEquivalent : max(Crew(), RequiredCrew());
+	int crewEquivalent = attributes.Get("crew equivalent")
+	if(attributes.get("crew equivalent overrides"))
+		return crewEquivalent ? crewEquivalent : max(Crew(), RequiredCrew());
+	return max(Crew(), RequiredCrew()) + crewEquivalent;
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2664,7 +2664,7 @@ int Ship::CrewValue() const
 {
 	int crewEquivalent = attributes.Get("crew equivalent");
 	if(attributes.Get("crew equivalent overrides"))
-		return crewEquivalent ? crewEquivalent : max(Crew(), RequiredCrew());
+		return crewEquivalent;
 	return max(Crew(), RequiredCrew()) + crewEquivalent;
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2663,7 +2663,7 @@ int Ship::RequiredCrew() const
 int Ship::CrewValue() const
 {
 	int crewEquivalent = attributes.Get("crew equivalent");
-	if(attributes.Get("crew equivalent overrides"))
+	if(attributes.Get("use crew equivalent as crew"))
 		return crewEquivalent;
 	return max(Crew(), RequiredCrew()) + crewEquivalent;
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2662,7 +2662,8 @@ int Ship::RequiredCrew() const
 
 int Ship::CrewValue() const
 {
-	return max(Crew(), RequiredCrew()) + attributes.Get("crew equivalent");
+	double crewEquivalent = attributes.Get("crew equivalent");
+	return crewEquivalent ? crewEquivalent : max(Crew(), RequiredCrew());
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2663,7 +2663,7 @@ int Ship::RequiredCrew() const
 int Ship::CrewValue() const
 {
 	int crewEquivalent = attributes.Get("crew equivalent");
-	if(attributes.get("crew equivalent overrides"))
+	if(attributes.Get("crew equivalent overrides"))
 		return crewEquivalent ? crewEquivalent : max(Crew(), RequiredCrew());
 	return max(Crew(), RequiredCrew()) + crewEquivalent;
 }


### PR DESCRIPTION
**Feature:** This PR implements the feature request that's been bugging me for a long time

## Feature Details
Right now the only use case of crew equivalent is having drones affect your reputation when they get destroyed for instance, or making some ships count more than what their crew count would show in terms of the reputation hit.

This expands it to anything, meaning one can make a ship matter for 1 or no crew if they feel like it. As suggested by @Amazinite this was made explicit by having to use the `"use crew equivalent as crew"` attribute change the old behavior.

## UI Screenshots
n/a

## Usage Examples
I dont have anything in mind right now, but this always felt too limiting to me

## Testing Done
n/a

### Automated Tests Added
n/a

## Performance Impact
n/a
