### PR TITLE
Revert "feat(content): Prevent random Pug fleets from leaving Pug sys…

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1093,8 +1093,6 @@ government "Pug"
 	"friendly disabled hail" "friendly disabled pug"
 	"hostile hail" "hostile pug"
 	"hostile disabled hail" "hostile pug"
-	"travel restrictions"
-		not government "Pug"
 
 # A pug government with distinct reputation toward the player compared to those met during the main campaign.
 government "Pug (Wanderer)"
@@ -1113,8 +1111,6 @@ government "Pug (Wanderer)"
 	"friendly disabled hail" "friendly disabled pug"
 	"hostile hail" "hostile pug"
 	"hostile disabled hail" "hostile pug"
-	"travel restrictions"
-		not government "Pug (Wanderer)"
 
 # Quarg are split up to their respective areas, and an overall one is kept for missions or other use.
 government "Quarg"

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -10244,24 +10244,6 @@ system Deneb
 		distance 1788.4
 		period 1210.08
 
-system "Deneb PD 1"
-	hidden
-	pos -348 225
-	government Pug
-	attributes "inaccessible"
-
-system "Deneb PD 2"
-	hidden
-	pos -348 225
-	government Pug
-	attributes "inaccessible"
-
-system "Deneb PD 3"
-	hidden
-	pos -348 225
-	government Pug
-	attributes "inaccessible"
-
 system Denebola
 	pos -478 70
 	government Republic
@@ -26760,24 +26742,6 @@ system "Pug Iyik"
 			sprite planet/desert4
 			distance 365
 			period 36.706
-
-system "Pug Iyik PD 1"
-	hidden
-	pos -361.149 -883.233
-	government "Pug (Wanderer)"
-	attributes "inaccessible"
-
-system "Pug Iyik PD 2"
-	hidden
-	pos -361.149 -883.233
-	government "Pug (Wanderer)"
-	attributes "inaccessible"
-
-system "Pug Iyik PD 3"
-	hidden
-	pos -361.149 -883.233
-	government "Pug (Wanderer)"
-	attributes "inaccessible"
 
 system Pukako
 	pos 618.64 -440.28


### PR DESCRIPTION
…tems (#9422)"

This reverts commit ac78fdb0f9f12440d532211d234d1553452cac74.

**Bugfix:**

## Fix Details
Reverting this change because of escorts and NPCs being able to pathfind through these systems, which isn't great.
We can re-add it later with other changes to prevent that.
