### PR TITLE
Fix release workflow binary names

### DIFF
--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -2,6 +2,10 @@ name: Release CD
 
 on:
   workflow_dispatch:
+    inputs:
+      release_version:
+        required: true
+        type: string
 
 jobs:
   release_appimage_x64:
@@ -9,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       ARCH: x86_64
-      OUTPUT: Endless_Sky-${{ github.ref_name }}-x86_64.AppImage
+      OUTPUT: Endless_Sky-${{ inputs.release_version  }}-x86_64.AppImage
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +46,7 @@ jobs:
     name: Windows x86
     runs-on: windows-2022
     env:
-      OUTPUT: EndlessSky-win32-${{ github.ref_name }}.zip
+      OUTPUT: EndlessSky-win32-${{ inputs.release_version }}.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
@@ -80,7 +84,7 @@ jobs:
     name: Windows x64
     runs-on: windows-2022
     env:
-      OUTPUT: EndlessSky-win64-${{ github.ref_name }}.zip
+      OUTPUT: EndlessSky-win64-${{ inputs.release_version }}.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
@@ -119,7 +123,7 @@ jobs:
     runs-on: macos-12
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      OUTPUT: Endless-Sky-${{ github.ref_name }}
+      OUTPUT: Endless-Sky-${{ inputs.release_version }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/changelog
+++ b/changelog
@@ -39,6 +39,8 @@ Version 0.10.4
     * Added tooltips for all controls and settings. (@Amazinite)
     * Added a key to bring up the help dialog for the current panel on demand. (@TomGoodIdea)
     * The main save file for a pilot will always be listed above all the snapshots in the load panel. (@warp-core)
+  * CI/CD and development environment:
+    * Fix release names when using the release workflow. (@quyykk)
 
 Version 0.10.3
   * Big changes:


### PR DESCRIPTION
## Fix Details

Add an input to the release workflow to provide the version of the release instead of the one from GitHub that isn't accurate.