### PR TITLE
Fix pirate escort jobs

### DIFF
--- a/data/human/pirate jobs.txt
+++ b/data/human/pirate jobs.txt
@@ -1850,10 +1850,10 @@ mission "Escort Illegal Cargo (Large, North, Dangerous Path)"
 	source
 		government Republic "Free Worlds" Syndicate Neutral Pirate
 		attributes frontier north "north pirate"
-		distance 3 6
 	destination
 		government "Pirate"
 		attributes "north pirate"
+		distance 3 6
 	npc
 		government Republic
 		personality staying
@@ -1991,10 +1991,10 @@ mission "Escort Illegal Cargo (Large, Core, Dangerous Path)"
 	source
 		government Republic "Free Worlds" Syndicate Neutral Pirate
 		attributes core "core pirate"
-		distance 3 6
 	destination
 		government "Pirate"
 		attributes "core pirate"
+		distance 3 6
 	npc
 		government Syndicate
 		personality staying
@@ -2134,10 +2134,10 @@ mission "Escort Illegal Cargo (Large, South, Dangerous Path)"
 	source
 		government Republic "Free Worlds" Syndicate Neutral Pirate
 		attributes south "south pirate"
-		distance 3 6
 	destination
 		government "Pirate"
 		attributes "south pirate"
+		distance 3 6
 	npc
 		government Militia
 		personality staying


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported on discord (I think)
EDIT: I couldn't find the bug report, so I made a new one.

## Fix Details
Some of the pirate escort jobs had the distance in source, which was meaningless, rather than in destination, which appears like the intended spot. This way the missions offer 3-6 hops away from a pirate world, which prevents it from sending you halfway across the galaxy or to the same world (in which case you just reload your save)

## Testing Done
Tested to make sure the fix worked.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using latest continuous, and will not occur when using this branch's build: [John Doe.txt](https://github.com/endless-sky/endless-sky/files/13065320/John.Doe.txt)
This uses the all content plugin but I have loaded it successfully in vanilla.
