### PR TITLE
fix(content): Remove `thumbnail` definition from Waverider

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -1986,7 +1986,6 @@ person "Patrol Team"
 
 ship "Waverider"
 	sprite "ship/waverider"
-	thumbnail "thumbnail/waverider"
 	attributes
 		category "Light Warship"
 		"cost" 3000000


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
The Waverider `pers` ship has no thumbnail, so this line left in by accident causes an error message. Some other person ships don't have thumbnails, so it's fine without one.