### PR TITLE
Add missing departure distance to Dokdobaru

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -10564,6 +10564,7 @@ system Dokdobaru
 	government "Quarg (Kor Efret)"
 	attributes "korath" "ringworld"
 	arrival 700
+	departure 1000
 	habitable 700
 	belt 1935
 	haze _menu/haze-133


### PR DESCRIPTION
-----------------------
## Fix Details
Simply adds `departure 1000` to Dokdobaru (the system in Korath space with a ringworld), as I noticed it didn't have any ingame, seems https://github.com/endless-sky/endless-sky/pull/8026 missed this system.