### PR TITLE
Feat(balance): nerf the Flamethrower again

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -669,7 +669,7 @@ outfit "Flamethrower"
 		"lifetime" 5
 		"reload" 1
 		"firing energy" .1
-		"firing fuel" .25
+		"firing fuel" .3
 		"firing heat" 4
 	description "A crude but impressive-looking weapon, the Flamethrower ignites your hyperspace fuel and directs a stream of it towards your adversaries. The damage it does is relatively minor, but it can be useful for causing a target that is already operating near its thermal capacity to overheat, temporarily taking it out of the fight."
 
@@ -687,7 +687,7 @@ outfit "Flamethrower Projectile"
 		"dropoff modifier" .5
 		"shield damage" .8
 		"hull damage" .7
-		"heat damage" 150
+		"heat damage" 120
 
 effect "flamethrower die"
 	sprite "effect/explosion/small"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -669,7 +669,7 @@ outfit "Flamethrower"
 		"lifetime" 5
 		"reload" 1
 		"firing energy" .1
-		"firing fuel" .3
+		"firing fuel" .4
 		"firing heat" 4
 	description "A crude but impressive-looking weapon, the Flamethrower ignites your hyperspace fuel and directs a stream of it towards your adversaries. The damage it does is relatively minor, but it can be useful for causing a target that is already operating near its thermal capacity to overheat, temporarily taking it out of the fight."
 
@@ -687,7 +687,7 @@ outfit "Flamethrower Projectile"
 		"dropoff modifier" .5
 		"shield damage" .8
 		"hull damage" .7
-		"heat damage" 120
+		"heat damage" 125
 
 effect "flamethrower die"
 	sprite "effect/explosion/small"


### PR DESCRIPTION
**Balance:**

## Summary
Firing fuel is increased from 15/sec to 24/sec
Heat DPS is reduced from 9000 to 7500

## Reasoning
It's still overpowered. 
The nerf in #7606 was evidently insufficient, and as was discussed on #9470 and #9495 the Flamethrower is still too strong as an applier of heat damage.
I've reduced the heat DPS and increased the firing fuel here. I think 9000 heat damage was simply too much, and hence that does need to be reduced, but where possible I'd like to lean more in the direction of increasing its downside (the firing fuel) rather than reducing the strength of its upside (the heat DPS), since that's a better approach for variety than doing the reverse.
