### PR TITLE
Update Heliarch Investigate job description to mention return to origin

### DIFF
--- a/data/coalition/coalition jobs.txt
+++ b/data/coalition/coalition jobs.txt
@@ -1497,7 +1497,7 @@ mission "Heliarch Investigate"
 	job
 	repeat
 	name `Investigate signs of criminal activity`
-	description `Land on <stopovers>, where you and <bunks> other Heliarch agents will investigate an area where suspicious activity was reported. Payment is <payment>.`
+	description `Land on <stopovers>, where you and <bunks> other Heliarch agents will investigate an area where suspicious activity was reported. When you've finished, return to <origin> to receive <payment>.`
 	passengers 6 11
 	to offer
 		random < 60


### PR DESCRIPTION
-----------------------
**Bugfix:** Job Description

## Fix Details
Tweaks the job description for the `"Heliarch Investigate"` job to include mention of having to return to the `<origin>` to receive the payment.

Pointed out by MidnightPlugins on the Discord server, thanks!