### PR TITLE
feat(ui): Exclusive Fullscreen & Borderless Windowed Screen Modes

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1207,7 +1207,7 @@ tip "View zoom factor"
 	`Increase the zoom factor of the gameplay view when in flight. Can also be changed by the + and - keys and the scroll wheel.`
 
 tip "Screen mode"
-	`Switch the game's fullscreen mode. Fullscreen will trap the mouse cursor to the window and is slightly faster, while borderless will allow other windows to go on top and let the mouse escape the window, but is as slow as windowed. Can also be changed by the "Toggle fullscreen" control.`
+	`Switch the game's fullscreen mode. Fullscreen restricts the mouse cursor to the window and is slightly faster, while borderless allows other windows go on top and lets the mouse escape the window. Can also be changed by the "Toggle fullscreen" control.`
 
 tip "VSync"
 	`Toggle vsync between off, on, and adaptive (should your computer support it).`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1171,7 +1171,7 @@ tip "Show main menu"
 	`Open the main menu.`
 
 tip "Toggle fullscreen"
-	`Toggle whether the game is in fullscreen mode.`
+	`Switch the game's fullscreen mode. See the Screen Mode preference for more detailed explanation.`
 
 tip "Toggle fast-forward"
 	`Toggle a 3x speed fast-forward. Fast-forward may be automatically deactivated by the "Interrupt fast-forward" setting.`
@@ -1207,7 +1207,7 @@ tip "View zoom factor"
 	`Increase the zoom factor of the gameplay view when in flight. Can also be changed by the + and - keys and the scroll wheel.`
 
 tip "Screen mode"
-	`Toggle whether the game is in windowed or fullscreen mode. Can also be toggled by the "Toggle fullscreen" control.`
+	`Switch the game's fullscreen mode. Fullscreen will trap the mouse cursor to the window and is slightly faster, while borderless will allow other windows to go on top and let the mouse escape the window, but is as slow as windowed. Can also be changed by the "Toggle fullscreen" control.`
 
 tip "VSync"
 	`Toggle vsync between off, on, and adaptive (should your computer support it).`

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -32,7 +32,7 @@ using namespace std;
 namespace {
 	SDL_Window *mainWindow = nullptr;
 	SDL_GLContext context = nullptr;
-	int width, height, xPos, yPos = 0;
+	int width, height = 0;
 	bool supportsAdaptiveVSync = false;
 
 	// Logs SDL errors and returns true if found
@@ -133,7 +133,6 @@ bool GameWindow::Init()
 	}
 
 	SDL_GetWindowSize(mainWindow, &width, &height);
-	SDL_GetWindowPosition(mainWindow, &xPos, &yPos);
 	switch(Preferences::ScreenMode())
 	{
 	case 0:
@@ -314,8 +313,6 @@ void GameWindow::AdjustViewport()
 	{
 		width = windowWidth;
 		height = windowHeight;
-		xPos = windowX;
-		yPos = windowY;
 	}
 
 	// Round the window size up to a multiple of 2, even if this
@@ -403,7 +400,7 @@ bool GameWindow::IsMaximized()
 
 bool GameWindow::IsBorderless()
 {
-	return (SDL_GetWindowFlags(mainWindow) & SDL_WINDOW_BORDERLESS);
+	return (SDL_GetWindowFlags(mainWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP);
 }
 
 
@@ -419,10 +416,6 @@ bool GameWindow::TrySetWindowed()
 {
 	SDL_SetWindowFullscreen(mainWindow, 0);
 	SDL_SetWindowSize(mainWindow, width, height);
-	SDL_SetWindowPosition(mainWindow, xPos, yPos);
-
-	SDL_SetWindowResizable(mainWindow, SDL_TRUE);
-	SDL_SetWindowBordered(mainWindow, SDL_TRUE);
 
 	return true;
 }
@@ -431,10 +424,7 @@ bool GameWindow::TrySetWindowed()
 
 bool GameWindow::TrySetFullscreen()
 {
-	// This will generate a window size change event,
-	// no need to adjust the viewport here.
 	SDL_SetWindowFullscreen(mainWindow, SDL_WINDOW_FULLSCREEN);
-
 	return GameWindow::IsFullscreen();
 }
 
@@ -442,18 +432,7 @@ bool GameWindow::TrySetFullscreen()
 
 bool GameWindow::TrySetBorderless()
 {
-	SDL_SetWindowFullscreen(mainWindow, 0);
-	SDL_SetWindowResizable(mainWindow, SDL_FALSE);
-	SDL_SetWindowBordered(mainWindow, SDL_FALSE);
-	SDL_Rect rect;
-	SDL_GetDisplayBounds(SDL_GetWindowDisplayIndex(mainWindow), &rect);
-#ifdef _WIN32 // Hack to prevent weird windows compositing things
-	SDL_SetWindowSize(mainWindow, rect.w, rect.h + 1);
-#else
-	SDL_SetWindowSize(mainWindow, rect.w, rect.h);
-#endif
-	SDL_SetWindowPosition(mainWindow, rect.x, rect.y);
-
+	SDL_SetWindowFullscreen(mainWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
 	return GameWindow::IsBorderless();
 }
 

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -434,6 +434,9 @@ bool GameWindow::TrySetFullscreen()
 {
 	SDL_SetWindowFullscreen(mainWindow, SDL_WINDOW_FULLSCREEN);
 	SDL_SetWindowGrab(mainWindow, SDL_TRUE);
+	SDL_Rect rect;
+	SDL_GetDisplayBounds(SDL_GetWindowDisplayIndex(mainWindow), &rect);
+	SDL_SetWindowSize(mainWindow, rect.w, rect.h);
 
 	return GameWindow::IsFullscreen();
 }

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -416,6 +416,7 @@ bool GameWindow::TrySetWindowed()
 {
 	SDL_SetWindowFullscreen(mainWindow, 0);
 	SDL_SetWindowSize(mainWindow, width, height);
+	SDL_SetWindowGrab(mainWindow, SDL_FALSE);
 
 	return true;
 }
@@ -425,6 +426,7 @@ bool GameWindow::TrySetWindowed()
 bool GameWindow::TrySetFullscreen()
 {
 	SDL_SetWindowFullscreen(mainWindow, SDL_WINDOW_FULLSCREEN);
+	SDL_SetWindowGrab(mainWindow, SDL_TRUE);
 	return GameWindow::IsFullscreen();
 }
 
@@ -433,6 +435,8 @@ bool GameWindow::TrySetFullscreen()
 bool GameWindow::TrySetBorderless()
 {
 	SDL_SetWindowFullscreen(mainWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
+	SDL_SetWindowGrab(mainWindow, SDL_FALSE);
+
 	return GameWindow::IsBorderless();
 }
 

--- a/source/GameWindow.h
+++ b/source/GameWindow.h
@@ -45,7 +45,10 @@ public:
 
 	static bool IsMaximized();
 	static bool IsFullscreen();
-	static void ToggleFullscreen();
+	static bool IsBorderless();
+	static bool TrySetWindowed();
+	static bool TrySetFullscreen();
+	static bool TrySetBorderless();
 
 	// Print the error message in the terminal, error file, and message box.
 	// Checks for video system errors and records those as well.

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -46,9 +46,9 @@ namespace {
 	size_t zoomIndex = 4;
 	constexpr double VOLUME_SCALE = .25;
 
-	// Default to fullscreen.
-	int screenModeIndex = 1;
-	const vector<string> SCREEN_MODE_SETTINGS = {"windowed", "fullscreen"};
+	// Default to borderless fullscreen.
+	int screenModeIndex = 2;
+	const vector<string> SCREEN_MODE_SETTINGS = {"windowed", "fullscreen", "borderless"};
 
 	// Enable standard VSync by default.
 	const vector<string> VSYNC_SETTINGS = {"off", "on", "adaptive"};
@@ -258,6 +258,7 @@ void Preferences::Save()
 
 	out.Write("volume", Audio::Volume() / VOLUME_SCALE);
 	out.Write("window size", Screen::RawWidth(), Screen::RawHeight());
+	out.Write("fullscreen", screenModeIndex);
 	out.Write("zoom", Screen::UserZoom());
 	out.Write("scroll speed", scrollSpeed);
 	out.Write("boarding target", boardingIndex);
@@ -470,8 +471,27 @@ const string &Preferences::ExtendedJumpEffectsSetting()
 
 void Preferences::ToggleScreenMode()
 {
-	GameWindow::ToggleFullscreen();
-	screenModeIndex = GameWindow::IsFullscreen();
+	switch(screenModeIndex)
+	{
+	case 0: // Windowed
+		if (GameWindow::TrySetFullscreen()) screenModeIndex = 1; else if (GameWindow::TrySetBorderless()) screenModeIndex = 2;
+		break;
+	case 1: // Fullscreen
+		if (GameWindow::TrySetBorderless()) screenModeIndex = 2; else if (GameWindow::TrySetWindowed()) screenModeIndex = 0;
+		break;
+	case 2: // Borderless
+		if (GameWindow::TrySetWindowed()) screenModeIndex = 0; else if (GameWindow::TrySetFullscreen()) screenModeIndex = 1;
+		break;
+	default:
+		break;
+	}
+}
+
+
+
+int Preferences::ScreenMode()
+{
+	return screenModeIndex;
 }
 
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -474,13 +474,13 @@ void Preferences::ToggleScreenMode()
 	switch(screenModeIndex)
 	{
 	case 0: // Windowed
-		if (GameWindow::TrySetFullscreen()) screenModeIndex = 1; else if (GameWindow::TrySetBorderless()) screenModeIndex = 2;
+		screenModeIndex = GameWindow::TrySetFullscreen() ? 1 : GameWindow::TrySetBorderless() ? 2 : 0;
 		break;
 	case 1: // Fullscreen
-		if (GameWindow::TrySetBorderless()) screenModeIndex = 2; else if (GameWindow::TrySetWindowed()) screenModeIndex = 0;
+		screenModeIndex = GameWindow::TrySetBorderless() ? 2 : GameWindow::TrySetWindowed() ? 0 : 1;
 		break;
 	case 2: // Borderless
-		if (GameWindow::TrySetWindowed()) screenModeIndex = 0; else if (GameWindow::TrySetFullscreen()) screenModeIndex = 1;
+		screenModeIndex = GameWindow::TrySetWindowed() ? 0 : GameWindow::TrySetFullscreen() ? 1 : 2;
 		break;
 	default:
 		break;

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -128,6 +128,7 @@ public:
 	static const std::vector<double> &Zooms();
 
 	static void ToggleScreenMode();
+	static int ScreenMode();
 	static const std::string &ScreenModeSetting();
 
 	// VSync setting, either "on", "off", or "adaptive".

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -215,7 +215,6 @@ int main(int argc, char *argv[])
 
 	// Remember the window state and preferences if quitting normally.
 	Preferences::Set("maximized", GameWindow::IsMaximized());
-	Preferences::Set("fullscreen", GameWindow::IsFullscreen());
 	Screen::SetRaw(GameWindow::Width(), GameWindow::Height());
 	Preferences::Save();
 	Plugins::Save();


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #6315

## Feature Details
This PR adds an exclusive fullscreen mode to the game. It bypasses the default OS compositor and restricts the mouse to the window. It also adds a borderless mode that is pretty similar to the previous fullscreen mode. Also adds tooltips.

## UI Screenshots
![image](https://github.com/endless-sky/endless-sky/assets/101683475/3b47d74f-0639-4576-9282-f503a752f584)

## Testing Done
Need somebody with a mac to test borderless out, but I've tested windows and will test linux. (Currently broken on linux)

## Performance Impact
Fullscreen is slightly faster than before.
