### PR TITLE
fix(CI): Fix missing word exclude from the spellcheck CI

### DIFF
--- a/.codespell.words.exclude
+++ b/.codespell.words.exclude
@@ -1,2 +1,3 @@
 aesthetic
 aesthetics
+aesthetically


### PR DESCRIPTION
**Bugfix:** This PR fixes a false positive in the spellcheck CI.

## Fix Details
ES uses the aesthetic/aesthetics variant of the word, instead of the US-only esthetic/esthetic, as shown by the existing excludes. In #6416, this triggered a false positive on the word `aesthetically`.

## Testing Done
N/A

## Save File
N/A