### PR TITLE
Update Lunarium Combat Training 2 description to include a mention of having to return to Zug

### DIFF
--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -1672,7 +1672,7 @@ mission "Lunarium: Combat Training 1"
 
 mission "Lunarium: Combat Training 2"
 	name "Combat Test"
-	description "Escort Pyakri's fleet to <waypoints>, and help them fight a pirate fleet there to get started with their training. Make sure all of the Lunarium ships survive."
+	description "Escort Pyakri's fleet to <waypoints>, and help them fight a pirate fleet there to get started with their training. Make sure all of the Lunarium ships survive. Return to <origin> once you're finished."
 	landing
 	source "Zug"
 	waypoint "Shaula"


### PR DESCRIPTION
-----------------------
**Bugfix**

## Fix Details
Adds a mention of having to return to `<origin>` (Zug) for the mission description for the Lunarium mission Combat Training 2.

Brought up by MidnightPlugins on the Discord server, thanks!