### PR TITLE
fix: some attributes in Coalition, Core missing

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -26117,6 +26117,7 @@ system Plort
 system Polaris
 	pos -35 126
 	government Syndicate
+	attributes "core"
 	arrival 1715
 	habitable 1715
 	belt 1906

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -5989,7 +5989,7 @@ system Aspidiske
 system Atik
 	pos -66 -52
 	government Uninhabited
-	attributes "bright star" "giant star" "multi-star" "notable star"
+	attributes "bright star" "core" "giant star" "multi-star" "notable star"
 	arrival 5000
 	habitable 15105
 	belt 1240
@@ -8605,6 +8605,7 @@ system Coluber
 system Companion
 	pos -1032.59 709.051
 	government Coalition
+	attribute "saryd"
 	arrival 500
 	habitable 425
 	belt 1786
@@ -23168,7 +23169,7 @@ system Mirzam
 system Misam
 	pos -9 -80
 	government Pirate
-	attributes "multi-star" "notable star"
+	attributes "core" "multi-star" "notable star"
 	arrival 3835
 	habitable 3835
 	belt 1091

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -8605,7 +8605,7 @@ system Coluber
 system Companion
 	pos -1032.59 709.051
 	government Coalition
-	attribute "saryd"
+	attributes "saryd"
 	arrival 500
 	habitable 425
 	belt 1786

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -20514,6 +20514,7 @@ system L-6181
 system "Last Word"
 	pos -1145.59 495.051
 	government Coalition
+	attributes "saryd"
 	arrival 625
 	habitable 625
 	belt 1761


### PR DESCRIPTION
I was doing a silly little project and I noticed some systems were missing their proper locational attributes- two Coalition Saryd systems, and two Pirate Core systems. 

## Fix Details
This just adds attribute "saryd" to the two systems that were missing it, and attribute "core" to the two systems that were missing it.

## Possible Issues
I haven't got confirmation whether Misam and Atik are excluded from the Core attribute on purpose.. As it stands, if Misam (or indeed any other currently Syndicate or Pirate system) has a different government than Pirate then there's the possibility that a "defend against pirates" spaceport mission will fire- that mission for the Core assumes that the planet has a Syndicate defense fleet. This isn't an issue right now, but if #8752 goes through that mission will need to be adjusted to exclude New Tortuga.

Second, this may not be complete as I think. I haven't looked through all the systems for my silly little project yet.

EDIT 1:
Polaris was also missing "core". Note that this will make that same "defend against pirates" spaceport mission fire on Shangri-La, unless specifically changed to not do that.