### PR TITLE
Fix heliarch intro

### DIFF
--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2082,7 +2082,7 @@ mission "Heliarch License 1"
 				accept
 	on visit
 		conversation
-			`The Heliarch authorities of the <origin> have offered you a position in the ranks of the Heliarchs. However, you are currently assisting the Lunarium. If you want to meet with the authorities and officialy join the Heliarchy, then come back when you are no longer assisting the Lunarium.`
+			`The Heliarch authorities of the <origin> have offered you a position in the ranks of the Heliarchs. However, you are currently assisting the Lunarium. If you want to meet with the authorities and officially join the Heliarchy, then come back when you are no longer assisting the Lunarium.`
 
 mission "Heliarch License 2"
 	landing

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2076,6 +2076,10 @@ mission "Heliarch License 1"
 			`	"Discussed your exploits, the consuls have. Much satisfaction, your contributions brought us," the Kimek continues.`
 			`	"With you, a meeting they request. To <destination> you must go, if to join our ranks, you so wish," the Arach finishes.`
 				accept
+	on accept
+		"assisting heliarchy" ++
+	on fail
+		"assisting heliarchy" --
 
 mission "Heliarch License 2"
 	landing

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2081,7 +2081,7 @@ mission "Heliarch License 1"
 			`	"With you, a meeting they request. To <destination> you must go, if to join our ranks, you so wish," the Arach finishes.`
 				accept
 	on visit
-		dialog `The Heliarch authorities of the <origin> have offered you a position in the ranks of the Heliarchs. However, you are currently assisting the Lunarium. If you want to meet with the authorities and officially join the Heliarchy, then come back when you are no longer assisting the Lunarium.`
+		dialog `You are currently assisting the Lunarium. Cancel or finish any missions you have for them if you want to join the Heliarchy.`
 
 mission "Heliarch License 2"
 	landing

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2071,7 +2071,7 @@ mission "Heliarch License 1"
 		not "assisting heliarchy"
 		not "assisting lunarium"
 	to complete
-		not "assisting lunarium"	
+		not "assisting lunarium"
 	to fail
 		has "joined the lunarium"
 	on offer

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2081,8 +2081,7 @@ mission "Heliarch License 1"
 			`	"With you, a meeting they request. To <destination> you must go, if to join our ranks, you so wish," the Arach finishes.`
 				accept
 	on visit
-		conversation
-			`The Heliarch authorities of the <origin> have offered you a position in the ranks of the Heliarchs. However, you are currently assisting the Lunarium. If you want to meet with the authorities and officially join the Heliarchy, then come back when you are no longer assisting the Lunarium.`
+		dialog `The Heliarch authorities of the <origin> have offered you a position in the ranks of the Heliarchs. However, you are currently assisting the Lunarium. If you want to meet with the authorities and officially join the Heliarchy, then come back when you are no longer assisting the Lunarium.`
 
 mission "Heliarch License 2"
 	landing

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2070,6 +2070,8 @@ mission "Heliarch License 1"
 		not "joined the lunarium"
 		not "assisting heliarchy"
 		not "assisting lunarium"
+	to complete
+		not "assisting lunarium"	
 	to fail
 		has "joined the lunarium"
 	on offer
@@ -2078,12 +2080,9 @@ mission "Heliarch License 1"
 			`	"Discussed your exploits, the consuls have. Much satisfaction, your contributions brought us," the Kimek continues.`
 			`	"With you, a meeting they request. To <destination> you must go, if to join our ranks, you so wish," the Arach finishes.`
 				accept
-	on accept
-		"assisting heliarchy" ++
-	on fail
-		"assisting heliarchy" --
-	on complete
-		"assisting heliarchy" --
+	on visit
+		conversation
+			`The Heliarch authorities of the <origin> have offered you a position in the ranks of the Heliarchs. However, you are currently assisting the Lunarium. If you want to meet with the authorities and officialy join the Heliarchy, then come back when you are no longer assisting the Lunarium.`
 
 mission "Heliarch License 2"
 	landing

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -1219,6 +1219,8 @@ mission "Heliarch Expedition 5"
 		conversation
 			`When you've touched down on the landing pads, you see you've received a message from the Heliarchs you brought to Ruin, the mysterious world on the other side of the wormhole the Pug left in Deneb. "Captain <last>, finished what research we could do on the broken ring, we have. About to jump back into the Coalition, we are. Imagine I do that like to speak with you after receiving our report, Consul Aulori will, so head you should to the <planet> as soon as possible."`
 				accept
+	on accept
+		"assisting heliarchy" ++
 	on fail
 		"assisting heliarchy" --
 	on complete
@@ -2079,6 +2081,8 @@ mission "Heliarch License 1"
 	on accept
 		"assisting heliarchy" ++
 	on fail
+		"assisting heliarchy" --
+	on complete
 		"assisting heliarchy" --
 
 mission "Heliarch License 2"


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported on [Steam](https://steamcommunity.com/app/404410/discussions/1/3880473965436854772/)

## Fix Details
The heliarch expedition 5 mission now gives `assisting heliarchy` as it was supposed to do. The heliarch license mission gives a warning if you are assisting the lunarium about why you can't join the heliarchs and stays in your jobs list until you are actually able to join. 

## Testing Done
Made sure both lunarium and coalition sides gave and removed the assisting conditions properly after this change. 

## Save File
This was the "save file" given:
![zzcoalitionoffers](https://github.com/endless-sky/endless-sky/assets/109186806/b50474b4-5d43-4475-a3db-b10cf7bead18)
If someone has an actual save file, that would be helpful.