### PR TITLE
Add the "Selected system: X (Y jumps away)" element to all Map Panels

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -840,8 +840,7 @@ void MapDetailPanel::DrawInfo()
 		text.Draw(Point(Screen::Right() - X_OFFSET - WIDTH, Screen::Top() + 20), medium);
 
 		selectedSystemOffset = -150;
-	} else
-		selectedSystemOffset = 0;
+	}
 }
 
 

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -838,7 +838,10 @@ void MapDetailPanel::DrawInfo()
 		text.SetWrapWidth(WIDTH - 20);
 		text.Wrap(selectedPlanet->Description());
 		text.Draw(Point(Screen::Right() - X_OFFSET - WIDTH, Screen::Top() + 20), medium);
-	}
+
+		selectedSystemOffset = -150;
+	} else
+		selectedSystemOffset = 0;
 }
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1220,7 +1220,7 @@ void MapPanel::DrawTravelPlan()
 
 
 // Fill in the top-middle header bar that names the selected system, and indicates its distance.
-void MapPanel::DrawSelectedSystem() const
+void MapPanel::DrawSelectedSystem()
 {
 	const Sprite *sprite = SpriteSet::Get("ui/selected system");
 	SpriteShader::Draw(sprite, Point(0. + selectedSystemOffset, Screen::Top() + .5f * sprite->Height()));

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -53,6 +53,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Wormhole.h"
 
 #include "opengl.h"
+#include "SpriteSet.h"
 
 #include <algorithm>
 #include <cctype>
@@ -318,6 +319,7 @@ void MapPanel::Draw()
 	DrawSystems();
 	DrawNames();
 	DrawMissions();
+	DrawSelectedSystem();
 }
 
 
@@ -1213,6 +1215,39 @@ void MapPanel::DrawTravelPlan()
 		else
 			LineShader::Draw(from, to, 3.f, drawColor);
 	}
+}
+
+
+
+// Fill in the top-middle header bar that names the selected system, and indicates its distance.
+void MapPanel::DrawSelectedSystem() const
+{
+	const Sprite *sprite = SpriteSet::Get("ui/selected system");
+	SpriteShader::Draw(sprite, Point(0., Screen::Top() + .5f * sprite->Height()));
+
+	string text;
+	if(!player.KnowsName(*selectedSystem))
+		text = "Selected system: unexplored system";
+	else
+		text = "Selected system: " + selectedSystem->Name();
+
+	int jumps = 0;
+	const vector<const System *> &plan = player.TravelPlan();
+	auto it = find(plan.begin(), plan.end(), selectedSystem);
+	if(it != plan.end())
+		jumps = plan.end() - it;
+	else if(distance.HasRoute(selectedSystem))
+		jumps = distance.Days(selectedSystem);
+
+	if(jumps == 1)
+		text += " (1 jump away)";
+	else if(jumps > 0)
+		text += " (" + to_string(jumps) + " jumps away)";
+
+	const Font &font = FontSet::Get(14);
+	Point pos(-175., Screen::Top() + .5 * (30. - font.Height()));
+	font.Draw({text, {350, Alignment::CENTER, Truncate::MIDDLE}},
+			  pos, *GameData::Colors().Get("bright"));
 }
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1223,7 +1223,7 @@ void MapPanel::DrawTravelPlan()
 void MapPanel::DrawSelectedSystem() const
 {
 	const Sprite *sprite = SpriteSet::Get("ui/selected system");
-	SpriteShader::Draw(sprite, Point(0., Screen::Top() + .5f * sprite->Height()));
+	SpriteShader::Draw(sprite, Point(0. + selectedSystemOffset, Screen::Top() + .5f * sprite->Height()));
 
 	string text;
 	if(!player.KnowsName(*selectedSystem))
@@ -1245,7 +1245,7 @@ void MapPanel::DrawSelectedSystem() const
 		text += " (" + to_string(jumps) + " jumps away)";
 
 	const Font &font = FontSet::Get(14);
-	Point pos(-175., Screen::Top() + .5 * (30. - font.Height()));
+	Point pos(-175. + selectedSystemOffset, Screen::Top() + .5 * (30. - font.Height()));
 	font.Draw({text, {350, Alignment::CENTER, Truncate::MIDDLE}},
 		pos, *GameData::Colors().Get("bright"));
 }

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -44,6 +44,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Screen.h"
 #include "Ship.h"
 #include "ShipJumpNavigation.h"
+#include "SpriteSet.h"
 #include "SpriteShader.h"
 #include "StellarObject.h"
 #include "System.h"
@@ -53,7 +54,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Wormhole.h"
 
 #include "opengl.h"
-#include "SpriteSet.h"
 
 #include <algorithm>
 #include <cctype>
@@ -1246,8 +1246,7 @@ void MapPanel::DrawSelectedSystem() const
 
 	const Font &font = FontSet::Get(14);
 	Point pos(-175., Screen::Top() + .5 * (30. - font.Height()));
-	font.Draw({text, {350, Alignment::CENTER, Truncate::MIDDLE}},
-			  pos, *GameData::Colors().Get("bright"));
+	font.Draw({text, {350, Alignment::CENTER, Truncate::MIDDLE}},pos, *GameData::Colors().Get("bright"));
 }
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -320,6 +320,7 @@ void MapPanel::Draw()
 	DrawNames();
 	DrawMissions();
 	DrawSelectedSystem();
+	selectedSystemOffset = 0;
 }
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -320,7 +320,6 @@ void MapPanel::Draw()
 	DrawNames();
 	DrawMissions();
 	DrawSelectedSystem();
-	selectedSystemOffset = 0;
 }
 
 
@@ -1249,6 +1248,10 @@ void MapPanel::DrawSelectedSystem() const
 	Point pos(-175. + selectedSystemOffset, Screen::Top() + .5 * (30. - font.Height()));
 	font.Draw({text, {350, Alignment::CENTER, Truncate::MIDDLE}},
 		pos, *GameData::Colors().Get("bright"));
+
+	// Reset the position of this UI element. If something is in the way, it will be
+	// moved back before it's drawn the next frame.
+	selectedSystemOffset = 0;
 }
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1246,7 +1246,8 @@ void MapPanel::DrawSelectedSystem() const
 
 	const Font &font = FontSet::Get(14);
 	Point pos(-175., Screen::Top() + .5 * (30. - font.Height()));
-	font.Draw({text, {350, Alignment::CENTER, Truncate::MIDDLE}},pos, *GameData::Colors().Get("bright"));
+	font.Draw({text, {350, Alignment::CENTER, Truncate::MIDDLE}},
+		pos, *GameData::Colors().Get("bright"));
 }
 
 

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -169,7 +169,7 @@ protected:
 private:
 	void DrawTravelPlan();
 	// Display the name of and distance to the selected system.
-	void DrawSelectedSystem() const;
+	void DrawSelectedSystem();
 	// Indicate which other systems have player escorts.
 	void DrawEscorts();
 	void DrawWormholes();

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -165,6 +165,8 @@ protected:
 
 private:
 	void DrawTravelPlan();
+	// Display the name of and distance to the selected system.
+	void DrawSelectedSystem() const;
 	// Indicate which other systems have player escorts.
 	void DrawEscorts();
 	void DrawWormholes();

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -162,6 +162,8 @@ protected:
 	std::string tooltip;
 	WrappedText hoverText;
 
+	// An X offset in pixels to be applied to the selected system UI if something
+	// else gets in the way of its default position.
 	int selectedSystemOffset = 0;
 
 private:

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -162,6 +162,7 @@ protected:
 	std::string tooltip;
 	WrappedText hoverText;
 
+	int selectedSystemOffset = 0;
 
 private:
 	void DrawTravelPlan();

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -266,7 +266,6 @@ void MissionPanel::Draw()
 
 	// Now that the mission lists and map elements are drawn, draw the top-most UI elements.
 	DrawKey();
-	DrawSelectedSystem();
 	DrawMissionInfo();
 	DrawTooltips();
 	FinishDrawing("is missions");
@@ -672,39 +671,6 @@ void MissionPanel::DrawKey() const
 		font.Draw(LABEL[i], pos + textOff, i == selected ? bright : dim);
 		pos.Y() += 20.;
 	}
-}
-
-
-
-// Fill in the top-middle header bar that names the selected system, and indicates its distance.
-void MissionPanel::DrawSelectedSystem() const
-{
-	const Sprite *sprite = SpriteSet::Get("ui/selected system");
-	SpriteShader::Draw(sprite, Point(0., Screen::Top() + .5f * sprite->Height()));
-
-	string text;
-	if(!player.KnowsName(*selectedSystem))
-		text = "Selected system: unexplored system";
-	else
-		text = "Selected system: " + selectedSystem->Name();
-
-	int jumps = 0;
-	const vector<const System *> &plan = player.TravelPlan();
-	auto it = find(plan.begin(), plan.end(), selectedSystem);
-	if(it != plan.end())
-		jumps = plan.end() - it;
-	else if(distance.HasRoute(selectedSystem))
-		jumps = distance.Days(selectedSystem);
-
-	if(jumps == 1)
-		text += " (1 jump away)";
-	else if(jumps > 0)
-		text += " (" + to_string(jumps) + " jumps away)";
-
-	const Font &font = FontSet::Get(14);
-	Point pos(-175., Screen::Top() + .5 * (30. - font.Height()));
-	font.Draw({text, {350, Alignment::CENTER, Truncate::MIDDLE}},
-		pos, *GameData::Colors().Get("bright"));
 }
 
 

--- a/source/MissionPanel.h
+++ b/source/MissionPanel.h
@@ -56,8 +56,6 @@ private:
 	void SetSelectedScrollAndCenter(bool immediate = false);
 	// Display and explain the various pointers that may appear on the map.
 	void DrawKey() const;
-	// Display the name of and distance to the selected system.
-	void DrawSelectedSystem() const;
 	// Draw rings around systems that need to be visited for the given mission.
 	void DrawMissionSystem(const Mission &mission, const Color &color) const;
 	// Draw the backgrounds for the "available jobs" and accepted missions/jobs lists.


### PR DESCRIPTION
**Feature:** This PR adds the "Selected system: X (Y jumps away)" element that is currently only on the Missions panel to all map panels.

## UI Screenshots
The ports map panel before:
![ports before](https://github.com/endless-sky/endless-sky/assets/22282562/eacf2557-7061-4e4a-9798-ee948b210a5d)
The ports map panel after, note element in the top center of the screen:
![ports after](https://github.com/endless-sky/endless-sky/assets/22282562/00514b52-13a9-4616-8a1c-c0fba34522eb)

## Testing Done
I tested by going through each panel and seeing if the element was correct.

### Automated Tests Added
N/A

## Performance Impact
N/A
