### PR TITLE
fix(content): Consistency fixes in text, adjust Deep's science ship names

### DIFF
--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -386,7 +386,7 @@ mission "Escort science vessel"
 		government "Merchant"
 		personality escort timid
 		fleet
-			names "deep"
+			names "deep science vessel"
 			variant
 				"Scout"
 			variant

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6244,14 +6244,14 @@ mission "Blind Man from Martini"
 			action
 				set "Blind Man from Martini: label daughter"
 				"Blind Man from Martini: taxi questions count" ++
-			`	"Luckily, my daughter was off-planet during the bombings. Anita was studying nanoengineering on Vinci and was going to apply for a job at CyberAcme there. But she gave that up to come take care of me after the bombings. When things were more ironed over, it was the midst of the civil war, and she managed to go back to Vinci and work at CyberAcme then, but... well, she has not been well since then."`
+			`	"Luckily, my daughter was off-planet during the bombings. Anita was studying nanoengineering on Vinci and was going to apply for a job at Polymath there. But she gave that up to come take care of me after the bombings. When things were more ironed over, it was the midst of the civil war, and she managed to go back to Vinci and work at Polymath then, but... well, she has not been well since then."`
 				goto taxi
 
 			label illness
 			action
 				set "Blind Man from Martini: label illness"
 				"Blind Man from Martini: taxi questions count" ++
-			`	"I don't know if I really should tell you this, but Anita was working on a project on nanomachines at CyberAcme when she got back. She was, uh... infected by them by accident. The experimental treatment is meant to try and eliminate the rogue machines, but since they're so small... that's why the treatment is experimental."`
+			`	"I don't know if I really should tell you this, but Anita was working on a project on nanomachines at Polymath when she got back. She was, uh... infected by them by accident. The experimental treatment is meant to try and eliminate the rogue machines, but since they're so small... that's why the treatment is experimental."`
 				goto taxi
 
 			label waiting

--- a/data/human/names.txt
+++ b/data/human/names.txt
@@ -3072,7 +3072,7 @@ phrase "civilian subphrase 15"
 
 phrase "deep science vessel"
 	word
-		"D.G.S. "
+		"D.R.S. "
 	phrase
 		"intellectuals"
 

--- a/data/human/names.txt
+++ b/data/human/names.txt
@@ -3070,6 +3070,12 @@ phrase "civilian subphrase 15"
 
 
 
+phrase "deep science vessel"
+	word
+		"D.G.S. "
+	phrase
+		"intellectuals"
+
 # Law enforcement names:
 
 phrase "republic capital"

--- a/data/human/near earth jobs.txt
+++ b/data/human/near earth jobs.txt
@@ -298,7 +298,7 @@ mission "Tycho Crater Shipyards Shipment [0]"
 
 mission "Tycho Crater Shipyards Shipment [1]"
 	name "Shipment to <planet>"
-	description "Deliver <cargo> to <destination>, the home of Tycho Crater Shipyards, a constituent shipbuilding company of the Republic Navy Yard and the main shipyard of Sol. Payment is <payment>."
+	description "Deliver <cargo> to <destination>, the home of Tycho Crater Shipyards, a constituent of the Republic Navy Yard. Payment is <payment>."
 	cargo "Ship Alloys" 5 2 .1
 	job
 	repeat

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -662,9 +662,9 @@ mission "Lovelace Labs Shipment [0]"
 		payment 0 160
 		dialog phrase "generic cargo delivery payment"
 
-mission "Vinci Nanocircuits Shipment [0]"
+mission "Polymath Nanoinstruments Shipment [0]"
 	name "Shipment to <planet>"
-	description "Deliver <cargo> to <destination>, the home of Vinci Nanocircuits, one of the largest electronics firms in human space. Payment is <payment>."
+	description "Deliver <cargo> to <destination>, the home of Polymath Nanoinstruments, one of the largest electronics firms in human space. Payment is <payment>."
 	cargo Electronics 5 2 .1
 	job
 	repeat


### PR DESCRIPTION
This PR:
* updates a job for Tycho Crater Shipyards which had a different description to the rest
* makes the name of that electronics company on Vinci consistent; it's now Polymath Nanoinstruments instead of Vinci Nanocircuits/Cyberacme (the reference is now slightly more obvious); it was suggested by Azure sometime last year and I forgot lmao
* separates the Deep's science ship names from from Deep Sec ship names; D.R.S. stands for Deep Research Ship (thanks mOctave for suggesting the name). It'd be confusing if the Deep used D.S.S. for both Deep Security Ship and Deep Science Ship.