### PR TITLE
fix: Syndicate Security -> Syndicated Security

### DIFF
--- a/data/hai/hai reveal 5 philosophers.txt
+++ b/data/hai/hai reveal 5 philosophers.txt
@@ -14,7 +14,7 @@
 mission "Hai Reveal [B01] Information Blackout"
 	landing
 	name "Information Blackout"
-	description "Meet the Syndicate Security Captain in the spaceport on <origin> when you're ready."
+	description "Meet the Syndicated Security Captain in the spaceport on <origin> when you're ready."
 	source "Sunracer"
 	clearance
 	to offer

--- a/data/hai/hai reveal 7 epilogue.txt
+++ b/data/hai/hai reveal 7 epilogue.txt
@@ -589,7 +589,7 @@ mission "Hai Reveal [D12] Escort Free World Outfitters"
 event "mooncreek main outfitters"
 	planet Mooncreek
 		add outfitter "Lovelace Security"
-		add outfitter "Syndicate Security"
+		add outfitter "Syndicated Security"
 		add outfitter "Hai Security"
 		security 0.8
 

--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -229,7 +229,7 @@ mission "Curious Waiter"
 
 
 
-mission "Syndicate Security Troops"
+mission "Syndicated Security Troops"
 	minor
 	source
 		government "Syndicate"

--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -435,7 +435,7 @@ outfitter "Syndicate Advanced"
 	"Luxury Accommodations"
 	"Scram Drive"
 
-outfitter "Syndicate Security"
+outfitter "Syndicated Security"
 	"Meteor Missile"
 	"Meteor Missile Launcher"
 	"Meteor Missile Box"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -2963,7 +2963,7 @@ ship "Splinter" "Splinter (Proton)"
 	turret "Proton Turret"
 
 
-# Used in the Hai Reveal campaign by a special Syndicate Security team. Should not be used before.
+# Used in the Hai Reveal campaign by a special Syndicated Security team. Should not be used before.
 ship "Splinter" "Splinter (Flamethrower Blaster)"
 	outfits
 		"Heavy Anti-Missile Turret"


### PR DESCRIPTION
**Bugfix:** This PR fixes inconsistent uses of the Syndicate's security forces.

## Fix Details
According to Derpy, it is called Syndicated Security, not Syndicate Security.

Most of the changes here are pretty simple. The two scary ones are the outfitter and the mission name.

The outfitter is only used in a locked part of HR (iirc), so it shouldn't be too bad. The mission, however, is available as-is, so renaming it might cause it to trigger again. (Maybe I should add a condition for the old mission not being done, or just not rename it?)

## Testing Done
N/A

## Save File
N/A