### PR TITLE
Make depth of spaceship in dangerous games 2 more reasonable

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4985,11 +4985,11 @@ mission "Dangerous Games 2"
 			label adventure
 			`	The adventure seekers, who you've spent the trip getting to know, are getting ready. You watch a nearby pair, Daciana and Mussie, helping each other get their wetsuits on. Daciana catches your gaze and grins. "Bafta, mate. Safe sailing, see you on the other side." Karengo gives you a signal and you hurry back to the cockpit to fly out, away from safe shoals and over the watery abyss.`
 			`	At your touch, the ship slowly sinks below the waves. As Karengo warned, most of your navigation systems quickly flash red warnings, then go offline; there is some unknown interference that overwhelms your ship's sensors, which were designed for space first and water second, or fifth, or not at all. Minutes tick by as the crew silently watches one of the few sensors still working.`
-			`	EIGHT KILOMETERS, the depth meter reads.`
-			`	TEN KILOMETERS.`
-			`	SIXTEEN KILOMETERS. A loud, metallic creak echoes through the ship and Mussie jumps, startled.`
+			`	EIGHTY METERS, the depth meter reads.`
+			`	ONE HUNDRED METERS.`
+			`	ONE HUNDRED SIXTY METERS. A loud, metallic creak echoes through the ship and Mussie jumps, startled.`
 			`	Karengo claps him on the back and gives him a signature grin. "Maybe <first> can keep you aboard after this in case they need anything from a high shelf!" Mussie smiles weakly, but his eyes don't leave the readout.`
-			`	TWENTY-FIVE KILOMETERS. "This's it," Karengo announces, "Sub up! Let's see what there is to see. And <first>, keep it to passive sensors. Don't want to attract any undue attention." The ship smoothly descends into the mouth of a massive cave and your visibility, clouded by dark sulfide emissions from the hydrothermal vents at the floor, drops to less than eight meters. 6 personal subpods fan out behind you, their communication equipment syncing with yours to display them as blips on your screen.`
+			`	TWO HUNDRED FIFTY METERS. "This's it," Karengo announces, "Sub up! Let's see what there is to see. And <first>, keep it to passive sensors. Don't want to attract any undue attention." The ship smoothly descends into the mouth of a massive cave and your visibility, clouded by dark sulfide emissions from the hydrothermal vents at the floor, drops to less than eight meters. 6 personal subpods fan out behind you, their communication equipment syncing with yours to display them as blips on your screen.`
 			`	"Ok, <first>," Karengo crackles over the radio. "I'll read you the first clue."`
 			`"No other path may you take"`
 			`"Oiled skins flash and flicker"`

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4985,11 +4985,11 @@ mission "Dangerous Games 2"
 			label adventure
 			`	The adventure seekers, who you've spent the trip getting to know, are getting ready. You watch a nearby pair, Daciana and Mussie, helping each other get their wetsuits on. Daciana catches your gaze and grins. "Bafta, mate. Safe sailing, see you on the other side." Karengo gives you a signal and you hurry back to the cockpit to fly out, away from safe shoals and over the watery abyss.`
 			`	At your touch, the ship slowly sinks below the waves. As Karengo warned, most of your navigation systems quickly flash red warnings, then go offline; there is some unknown interference that overwhelms your ship's sensors, which were designed for space first and water second, or fifth, or not at all. Minutes tick by as the crew silently watches one of the few sensors still working.`
-			`	EIGHTY METERS, the depth meter reads.`
-			`	ONE HUNDRED METERS.`
-			`	ONE HUNDRED SIXTY METERS. A loud, metallic creak echoes through the ship and Mussie jumps, startled.`
+			`	EIGHT HUNDRED KILOPASCALS, the pressure gauge reads.`
+			`	ONE THOUSAND KILOPASCALS.`
+			`	ONE THOUSAND SIX HUNDRED KILOPASCALS. A loud, metallic creak echoes through the ship and Mussie jumps, startled.`
 			`	Karengo claps him on the back and gives him a signature grin. "Maybe <first> can keep you aboard after this in case they need anything from a high shelf!" Mussie smiles weakly, but his eyes don't leave the readout.`
-			`	TWO HUNDRED FIFTY METERS. "This's it," Karengo announces, "Sub up! Let's see what there is to see. And <first>, keep it to passive sensors. Don't want to attract any undue attention." The ship smoothly descends into the mouth of a massive cave and your visibility, clouded by dark sulfide emissions from the hydrothermal vents at the floor, drops to less than eight meters. 6 personal subpods fan out behind you, their communication equipment syncing with yours to display them as blips on your screen.`
+			`	TWO THOUSAND FIVE HUNDRED KILOPASCALS. "This's it," Karengo announces, "Sub up! Let's see what there is to see. And <first>, keep it to passive sensors. Don't want to attract any undue attention." The ship smoothly descends into the mouth of a massive cave and your visibility, clouded by dark sulfide emissions from the hydrothermal vents at the floor, drops to less than eight meters. 6 personal subpods fan out behind you, their communication equipment syncing with yours to display them as blips on your screen.`
 			`	"Ok, <first>," Karengo crackles over the radio. "I'll read you the first clue."`
 			`"No other path may you take"`
 			`"Oiled skins flash and flicker"`

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4987,9 +4987,9 @@ mission "Dangerous Games 2"
 			`	At your touch, the ship slowly sinks below the waves. As Karengo warned, most of your navigation systems quickly flash red warnings, then go offline; there is some unknown interference that overwhelms your ship's sensors, which were designed for space first and water second, or fifth, or not at all. Minutes tick by as the crew silently watches one of the few sensors still working.`
 			`	EIGHT HUNDRED KILOPASCALS, the pressure gauge reads.`
 			`	ONE THOUSAND KILOPASCALS.`
-			`	ONE THOUSAND SIX HUNDRED KILOPASCALS. A loud, metallic creak echoes through the ship and Mussie jumps, startled.`
+			`	ONE THOUSAND TWO HUNDRED KILOPASCALS. A loud, metallic creak echoes through the ship and Mussie jumps, startled.`
 			`	Karengo claps him on the back and gives him a signature grin. "Maybe <first> can keep you aboard after this in case they need anything from a high shelf!" Mussie smiles weakly, but his eyes don't leave the readout.`
-			`	TWO THOUSAND FIVE HUNDRED KILOPASCALS. "This's it," Karengo announces, "Sub up! Let's see what there is to see. And <first>, keep it to passive sensors. Don't want to attract any undue attention." The ship smoothly descends into the mouth of a massive cave and your visibility, clouded by dark sulfide emissions from the hydrothermal vents at the floor, drops to less than eight meters. 6 personal subpods fan out behind you, their communication equipment syncing with yours to display them as blips on your screen.`
+			`	ONE THOUSAND FIVE HUNDRED KILOPASCALS. "This's it," Karengo announces, "Sub up! Let's see what there is to see. And <first>, keep it to passive sensors. Don't want to attract any undue attention." The ship smoothly descends into the mouth of a massive cave and your visibility, clouded by dark sulfide emissions from the hydrothermal vents at the floor, drops to less than eight meters. 6 personal subpods fan out behind you, their communication equipment syncing with yours to display them as blips on your screen.`
 			`	"Ok, <first>," Karengo crackles over the radio. "I'll read you the first clue."`
 			`"No other path may you take"`
 			`"Oiled skins flash and flicker"`


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported several months ago that nobody bothered to fix. 

## Fix Details
Reduces the depth of the player's ship in "Dangerous Games 2" to 3/500. Water pressure is much higher than air pressure, so currently this means the player's ship can withstand extreme pressures, which doesn't make much sense. As this is essentially flavor text, the lore shouldn't be that the player's ship can go 25 km underwater. This ship can still apparently withstand a pressure of 15 atm, but that's a lot better than almost 27 times the pressure of Venus.
EDIT: Also, for the record, the deepest part of an Earth ocean is around 11 km deep.
EDIT 11/14: I switched from a depth meter to a pressure gauge as requested. The depth is still about 250 m.
EDIT 11/16: I further reduced the depth to 150m, as requested.

## Testing Done
Looked at the mission to see if it would make sense to see the species/find the artifacts given, and compared to the description of Poseidos. The description doesn't mention anything about depth, so this shouldn't be an issue.

## Save File
Just read the mission.