### PR TITLE
Buff scan efficiency

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1789,11 +1789,11 @@ int Ship::Scan(const PlayerInfo &player)
 	if(!cargoDistanceSquared && !outfitDistanceSquared)
 		return 0;
 
-	double cargoSpeed = attributes.Get("cargo scan efficiency");
+	double cargoSpeed = attributes.Get("cargo scan efficiency") * 100;
 	if(!cargoSpeed)
 		cargoSpeed = cargoDistanceSquared;
 
-	double outfitSpeed = attributes.Get("outfit scan efficiency");
+	double outfitSpeed = attributes.Get("outfit scan efficiency") * 100;
 	if(!outfitSpeed)
 		outfitSpeed = outfitDistanceSquared;
 


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue reported on Discord

## Fix Details
Scan efficiency is now multiplied by 100 before getting the "speed" variable. This essentially means scanning is ten times faster than it was before, however, due to the maximum scan time of ten seconds, this really means that ships can actually have noticeable changes in scan times with more scanners. It is still a "minigame" of trying to stay near the ship, and there is still a noticable difference between ships with a lot of cargo and not much cargo, and the same for outfits. Scan power is untouched. This importantly makes the "corporate espionage" mission possible, however, with strong enough scanners you might even be able to scan a cruiser in under ten seconds. 

## Testing Done
- [x] Check scanning ships
- [x] Check illegal missions

## Save File
This save file can be used to verify the bugfix. The bug will occur when using 0.10.4 stable, and will not occur when using this branch's build.

Taken from PR #8288 

Scanning ships:
[Morgan Atrasco.txt](https://github.com/endless-sky/endless-sky/files/10549443/Morgan.Atrasco.txt)
It appears like it still takes around ten seconds no matter what.

[Morgan Atrasco~Corporate Espionage.txt](https://github.com/endless-sky/endless-sky/files/13367379/Morgan.Atrasco.Corporate.Espionage.txt)
On the other hand, for Corporate Espionage, I was able to do it with 13 cargo scanners. It could be possible to do it with less if you have a faster ship.

Illegal missions:
[Lenny.Lightfighters](https://github.com/endless-sky/endless-sky/files/10611805/Lenny.Lightfingers.txt)
I had no issues with this.

Illegal missions (big ship): 
[Ranoerek.Test.txt](https://github.com/endless-sky/endless-sky/files/10614015/Aimet.Taepip.3029-04-19.Ranoerek.Test.txt)
I had no issues with this.

EDIT: After testing, it still takes a while most of the time, but dedicated layouts can do it in less time.