### PR TITLE
Add a landing destination to every integration test

### DIFF
--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_afterburn_flight.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_afterburn_flight.txt
@@ -120,4 +120,8 @@ test "Afterburner-flight - Simple depart land"
 			"test: steps to wait" = "test: steps to wait" - 1
 		branch "floating"
 			"test: steps to wait" > 0
+		navigate
+			"travel destination" Ruin
 		call "Land"
+		assert
+			"flagship landed" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_capture_override.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_capture_override.txt
@@ -137,6 +137,8 @@ test "Capture Uncapturable With Capturable Override"
 			key a
 		input
 			key d
+		navigate
+			"travel destination" Ruin
 		call "Land"
 		assert
 			"ship model: %TEST%: outfitless wardragon" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_common.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_common.txt
@@ -771,6 +771,8 @@ test "Trigger Ruin Spaceport Mission"
 	description "Launch, land, and go to the spaceport to trigger any potential missions."
 	sequence
 		call "Depart"
+		navigate
+			"travel destination" Ruin
 		call "Land"
 		input
 			key p
@@ -781,6 +783,8 @@ test "Trigger Prime Spaceport Mission"
 	description "Launch, land, and go to the spaceport to trigger any potential missions."
 	sequence
 		call "Depart"
+		navigate
+			"travel destination" Prime
 		call "Land"
 		input
 			key p

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_model_condition.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_model_condition.txt
@@ -23,11 +23,15 @@ test "Clear flagship model condition"
 		assert
 			"flagship model: Finch" == 1
 		# Landing clears the flagship's conditions.
+		navigate
+			"travel destination" "New Boston"
 		call "Land"
 		call "Sell first ship"
 		call "Depart"
 		assert
 			"flagship model: Finch" == 1
+		navigate
+			"travel destination" "New Boston"
 		call "Land"
 		call "Sell first ship"
 		call "Depart"
@@ -35,6 +39,8 @@ test "Clear flagship model condition"
 			and
 				"flagship model: Bactrian" == 1
 				"flagship model: Finch" == 0
+		navigate
+			"travel destination" "New Boston"
 		call "Land"
 		call "Sell first ship"
 		call "Depart"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_framework.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_framework.txt
@@ -112,6 +112,8 @@ test "Test-Framework - Load Depart Land"
 		assert
 			"ships: Light Freighter" == 3
 		watchdog 90000
+		navigate
+			"travel destination" Earth
 		call "Land"
 		assert
 			"flagship landed" > 0
@@ -218,6 +220,8 @@ test "Test-Framework - Mission Injection"
 		call "Depart"
 		assert
 			"flagship landed" == 0
+		navigate
+			"travel destination" Earth
 		call "Land"
 		input
 			key "Return"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -337,6 +337,8 @@ test "Illegal Test - Ignore and New Illegal"
 			"unpaid fines" == 0
 		call "Launch Quarg Scanning Mission And Board"
 		# land back with a fine of 1 for the hyperdrive, nothing from the gas
+		navigate
+			"travel destination" Ruin
 		call "Land"
 		# copy the test-data in the temporary conditions for debugging when an issue happens
 		assert
@@ -353,6 +355,8 @@ test "Atrocity Test - New Atrocity"
 			"reputation: Quarg" == 1000
 		call "Launch Quarg Scanning Mission And Board"
 		# land back with atrocity having been in effect (should nuke the reputation?)
+		navigate
+			"travel destination" Ruin
 		call "Land"
 		assert
 			# it'll be 0 from the atrocity and then minus whatever the atrocity reputation hit it

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_save_load.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_save_load.txt
@@ -95,6 +95,8 @@ test "Saving during conversation"
 		call "Depart"
 		assert
 			"transient" == 0
+		navigate
+			"travel destination" Ruin
 		call "Land"
 		# This condition is set to ensure that the transaction snapshot includes everything before this mission.
 		apply

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_shipyard_outfitter_missions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_shipyard_outfitter_missions.txt
@@ -106,6 +106,8 @@ test "Trigger Shipyard Mission"
 	description "Launch, land, and go to the spaceport to trigger any potential missions in the shipyard."
 	sequence
 		call "Depart"
+		navigate
+			"travel destination" Ruin
 		call "Land"
 		input
 			key s
@@ -116,6 +118,8 @@ test "Trigger Outfitter Mission"
 	description "Launch, land, and go to the spaceport to trigger any potential missions in the outfitter."
 	sequence
 		call "Depart"
+		navigate
+			"travel destination" Ruin
 		call "Land"
 		input
 			key o

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_store_outfits_on_take_off.txt
@@ -282,6 +282,8 @@ test "Store Outfit On Take Off"
 				"outfit (cargo): D23-QP Shield Generator" == 0
 				"outfit (storage): D23-QP Shield Generator" == 1
 		watchdog 90000
+		navigate
+			"travel destination" Winter
 		call "Land"
 		assert
 			and
@@ -316,6 +318,8 @@ test "Sell Outfit On Take Off"
 				"outfit (cargo): D23-QP Shield Generator" == 0
 				"outfit (storage): D23-QP Shield Generator" == 0
 		watchdog 90000
+		navigate
+			"travel destination" Winter
 		call "Land"
 		assert
 			and

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_take_ships.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_take_ships.txt
@@ -87,6 +87,8 @@ test "Checking For A Gifted Ship"
 		call "Load First Savegame"
 		# Make the missions trigger by landing again.
 		call "Depart"
+		navigate
+			"travel destination" Earth
 		call "Land"
 		call "Depart"
 		assert
@@ -99,6 +101,8 @@ test "Checking For A Gifted Ship"
 		call "Load First Savegame"
 		call "Wait 10 steps"
 		call "Depart"
+		navigate
+			"travel destination" Earth
 		call "Land"
 		assert
 			"ship model: Star Barge" == 0
@@ -231,6 +235,8 @@ test "Taking Ship With Outfits And Unconstrained"
 		call "Load First Savegame"
 		call "Depart"
 		# when we land the mission will trigger
+		navigate
+			"travel destination" Ingot
 		call "Land"
 		call "Wait 10 steps"
 		# The missions are checked by alphabetical order, meaning we know that if the third one triggered,


### PR DESCRIPTION
## Fix Details

This PR fixes an issue where sometimes the integration tests would fail because the flagship would not land. This is because, if a destination planet is not specified and the flagship hovers above an uninhabited planet or a star, it will try to land there instead of the actual inhabited planet. By specifying a destination planet, it will always land there.

## Testing Done

A bit hard to test but the integration tests should fail less often.
