### PR TITLE
Run CMake check when only the integration tests were changed

### DIFF
--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -33,7 +33,7 @@ jobs:
   check_cmake:
     name: CMake
     needs: changed
-    if: ${{ needs.changed.outputs.cmake_files == 'true' || needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' }}
+    if: ${{ needs.changed.outputs.cmake_files == 'true' || needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' || needs.changed.outputs.integration_tests == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Fix Details

The check CMake CI job wasn't running when the only thing changed was an integration test.