### PR TITLE
(Bugfix)(Coalition) Added missing goto+label to the 'Saryd University Lecture' mission

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -1624,8 +1624,10 @@ mission "Saryd University Lecture"
 				`	"There are many independent worlds that are not ruled by one singular government. Some groups there support piracy, but others are peaceful."`
 					goto pirategood
 			`	"Stamped out, may lawlessness soon be," says the Heliarch in a solemn tone of voice. She picks a Saryd for the next question.`
+				goto questionfour
 			label pirategood
 			`	Your microphone starts to fizzle out as you attempt to answer. The Heliarch's eight eyes are all on you, and you sense that it might not be a good idea to finish your sentence. The Heliarch selects a Saryd for the next question.`
+			label questionfour
 			`	"A fairly comprehensive map of human space, we have." The Saryd brings out a star map of the galactic south. "But of the core, we know not. Inform us of the galaxy, can you?"`
 			choice
 				`	(Tell them about the Korath.)`


### PR DESCRIPTION
**Bugfix**

## Fix Details
This PR adds a goto, along with its corresponding label, to skip the 'pirategood' response when not choosing that option.

Before when selecting the option,
`"There are many independent worlds that are not ruled by one singular government. Some groups there support piracy, but others are peaceful."`
the text for Heliarch censoring you would be displayed erroneously. The new goto should skip this if you don't choose that option.

I might have made a mistake with the syntax, but it looks good from what I've seen in the rest of the file.