### PR TITLE
Replace the Quarg atrocity mission with proper atrocities

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1144,6 +1144,8 @@ government "Quarg"
 		"Medium Graviton Thruster"
 		"Medium Graviton Steering"
 		"Quantum Shield Generator"
+		ship "Quarg Skylark"
+		ship "Quarg Wardragon"
 
 government "Quarg (Hai)"
 	swizzle 0
@@ -1173,6 +1175,8 @@ government "Quarg (Hai)"
 		"Medium Graviton Thruster"
 		"Medium Graviton Steering"
 		"Quantum Shield Generator"
+		ship "Quarg Skylark"
+		ship "Quarg Wardragon"
 
 government "Quarg (Kor Efret)"
 	swizzle 0
@@ -1201,6 +1205,8 @@ government "Quarg (Kor Efret)"
 		"Medium Graviton Thruster"
 		"Medium Graviton Steering"
 		"Quantum Shield Generator"
+		ship "Quarg Skylark"
+		ship "Quarg Wardragon"
 
 government "Quarg (Gegno)"
 	swizzle 0
@@ -1227,6 +1233,8 @@ government "Quarg (Gegno)"
 		"Medium Graviton Thruster"
 		"Medium Graviton Steering"
 		"Quantum Shield Generator"
+		ship "Quarg Skylark"
+		ship "Quarg Wardragon"
 
 color "governments: Remnant" .89 .38 .62
 

--- a/data/quarg/quarg missions.txt
+++ b/data/quarg/quarg missions.txt
@@ -263,20 +263,6 @@ mission "Ask Quarg About Coalition Early"
 
 
 
-mission "Quarg Ships Atrocity"
-	landing
-	invisible
-	source
-		attributes quarg
-	to offer
-		or
-			has "ship model: Quarg Skylark"
-			has "ship model: Quarg Wardragon"
-	on offer
-		conversation "quarg imprisonment"
-
-
-
 mission "Quarg Pug Arfecta Warning"
 	minor
 	landing

--- a/data/quarg/quarg.txt
+++ b/data/quarg/quarg.txt
@@ -63,7 +63,6 @@ conversation "quarg imprisonment"
 	`	"<first> <last>, you are found to be in illegal possession of Quarg equipment. Our devices are precious and ours alone. Though it is regrettable, we must seize you."`
 	`	They don't allow you to get as much as a word out before one of the guards has locked your arms behind your back, completely halting your attempts to fight back with surprisingly little effort. You are brought before something akin to a Quarg jury, where they lecture you for several hours on how dangerous it is for Quarg apparatus to be stolen and used so lightly by others. At the end of it all, they sentence you to life imprisonment.`
 	`	You spend the rest of your days in the same cell, which although large and comfortable, quickly proves plain and dull. You're kept in very good health and are well-fed, but the Quarg do not allow you to leave the cell and seldom entertain your attempts at striking conversation. You get few visitors and can only wonder what life would've been like had you the chance to live out all these years in freedom, the captain of a starship.`
-		die
 
 # Human Quarg
 fleet "Quarg"


### PR DESCRIPTION
## Summary
Replaced the "Quarg Ships Atrocity" placeholder mission and instead added Quarg ships to the appropriate atrocity lists.
That means detection chance depends on the planet's `security` value (with the mission it's always 100%). Also, the native atrocity conversation is triggered before missions (currently, you can talk to the Quarg in the First Contact and then get arrested).

As the "quarg imprisonment" conversation is no longer used in any mission, the `die` endpoint is not needed.

## Testing Done
Landed with a Quarg flagship on Echo, the death sentence conversation was activated.