### PR TITLE
fix(mechanics): Apply planetary security fines for illegal cargo

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1555,6 +1555,10 @@ void PlayerInfo::Land(UI *ui)
 
 	// Cargo management needs to be done after updating ship locations (above).
 	UpdateCargoCapacities();
+	// If the player is actually landing (rather than simply loading the game),
+	// new fines may be levied.
+	if(!freshlyLoaded)
+		Fine(ui);
 	// Ships that are landed with you on the planet should pool all their cargo together.
 	PoolCargo();
 	// Adjust cargo cost basis for any cargo lost due to a ship being destroyed.
@@ -1569,15 +1573,9 @@ void PlayerInfo::Land(UI *ui)
 	StepMissions(ui);
 	UpdateCargoCapacities();
 
-	// If the player is actually landing (rather than simply loading the game),
-	// new missions are created and new fines may be levied.
+	// Create whatever missions this planet has to offer.
 	if(!freshlyLoaded)
-	{
-		// Create whatever missions this planet has to offer.
 		CreateMissions();
-		// Check if the player is doing anything illegal.
-		Fine(ui);
-	}
 	// Upon loading the game, prompt the player about any paused missions, but if there are many
 	// do not name them all (since this would overflow the screen).
 	else if(ui && !inactiveMissions.empty())

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -252,6 +252,9 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 			continue;
 		if(ship->GetSystem() != player.GetSystem())
 			continue;
+		const Planet *planet = player.GetPlanet();
+		if(planet && ship->GetPlanet() != planet)
+			continue;
 
 		int failedMissions = 0;
 


### PR DESCRIPTION
**Bugfix:** This PR addresses a bug reported on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1174359125984026644) by @ziproot

## Fix Details
Fines are now applied before cargo is pooled. Before this change, player ships inspected by planetary security had their cargo holds empty (because all cargo had already been moved to the common pool).

Also added a planet check to the core function responsible for fining.

## Testing Done
Tested with some illegal mission cargo and the Nerve Gas.

## Save File
See the original report on Discord.