### PR TITLE
chore(code): Remove unused includes

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -35,7 +35,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "ShipEvent.h"
 #include "ShipInfoPanel.h"
 #include "System.h"
-#include "text/truncate.hpp"
 #include "UI.h"
 
 #include <algorithm>

--- a/source/ClickZone.h
+++ b/source/ClickZone.h
@@ -19,7 +19,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Point.h"
 #include "Rectangle.h"
 
-#include <cmath>
 #include <utility>
 
 

--- a/source/HailPanel.h
+++ b/source/HailPanel.h
@@ -19,7 +19,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Panel.h"
 
 #include "Angle.h"
-#include "Point.h"
 
 #include <cstdint>
 #include <memory>

--- a/source/Hazard.h
+++ b/source/Hazard.h
@@ -18,8 +18,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Weapon.h"
 
-#include "Point.h"
-
 
 // Hazards are environmental effects created within systems. They are able to create
 // visual effects and damage or apply status effects to any ships within the system

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -32,7 +32,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/layout.hpp"
 #include "MapOutfitterPanel.h"
 #include "MapShipyardPanel.h"
-#include "pi.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "PointerShader.h"

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -31,7 +31,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "PlayerInfo.h"
 #include "Point.h"
 #include "PreferencesPanel.h"
-#include "Rectangle.h"
 #include "Ship.h"
 #include "Sprite.h"
 #include "StarField.h"

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -29,7 +29,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "GameData.h"
 #include "Information.h"
 #include "Interface.h"
-#include "text/layout.hpp"
 #include "LineShader.h"
 #include "Mission.h"
 #include "Planet.h"

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -25,7 +25,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Format.h"
 #include "GameData.h"
 #include "Hardpoint.h"
-#include "text/layout.hpp"
 #include "Mission.h"
 #include "Outfit.h"
 #include "Planet.h"

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -26,7 +26,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "GameData.h"
 #include "Information.h"
 #include "Interface.h"
-#include "text/layout.hpp"
 #include "Plugins.h"
 #include "Preferences.h"
 #include "Screen.h"

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -16,14 +16,12 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "SpaceportPanel.h"
 
 #include "text/alignment.hpp"
-#include "Color.h"
 #include "text/FontSet.h"
 #include "GameData.h"
 #include "Interface.h"
 #include "News.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
-#include "Point.h"
 #include "Random.h"
 #include "UI.h"
 

--- a/source/comparators/BySeriesAndIndex.h
+++ b/source/comparators/BySeriesAndIndex.h
@@ -16,7 +16,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef BY_SERIES_AND_INDEX_H_
 #define BY_SERIES_AND_INDEX_H_
 
-#include "../CategoryList.h"
 #include "../CategoryTypes.h"
 #include "../GameData.h"
 #include "../Outfit.h"

--- a/source/opengl.cpp
+++ b/source/opengl.cpp
@@ -23,6 +23,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #endif
 #endif
 
+#include <cstring>
+
 #if defined(ES_GLES) || defined(_WIN32)
 namespace {
 	bool HasOpenGLExtension(const char *name)

--- a/source/opengl.cpp
+++ b/source/opengl.cpp
@@ -23,8 +23,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #endif
 #endif
 
-#include <cstring>
-
 #if defined(ES_GLES) || defined(_WIN32)
 namespace {
 	bool HasOpenGLExtension(const char *name)

--- a/source/text/WrappedText.cpp
+++ b/source/text/WrappedText.cpp
@@ -152,7 +152,7 @@ int WrappedText::Height() const
 // Return the width of the longest line of the wrapped text.
 int WrappedText::LongestLineWidth() const
 {
-	return longesLineWidth;
+	return longestLineWidth;
 }
 
 
@@ -213,7 +213,7 @@ void WrappedText::SetText(const char *it, size_t length)
 void WrappedText::Wrap()
 {
 	height = 0;
-	longesLineWidth = 0;
+	longestLineWidth = 0;
 
 	if(text.empty() || !font)
 		return;
@@ -323,8 +323,8 @@ void WrappedText::AdjustLine(size_t &lineBegin, int &lineWidth, bool isEnd)
 	int wordCount = static_cast<int>(words.size() - lineBegin);
 	int extraSpace = wrapWidth - lineWidth;
 
-	if(lineWidth > longesLineWidth)
-		longesLineWidth = lineWidth;
+	if(lineWidth > longestLineWidth)
+		longestLineWidth = lineWidth;
 
 	// Figure out how much space is left over. Depending on the alignment, we
 	// will add that space to the left, to the right, to both sides, or to the

--- a/source/text/WrappedText.h
+++ b/source/text/WrappedText.h
@@ -118,7 +118,7 @@ private:
 	std::vector<Word> words;
 	int height = 0;
 
-	int longesLineWidth = 0;
+	int longestLineWidth = 0;
 };
 
 


### PR DESCRIPTION
**Chore:** This PR removes a number of unused include directives. Also fixes a typo in a variable name; hopefully that won't cause conflicts.

## Fix Details
I mostly removed include directives that were entirely unused; I didn't go out of my way to check for transitive includes and stuff. Duplicated includes are cheaper than unused ones anyway.

WrappedText had a private member called `longesLineWidth`; that has been corrected to `longestLineWidth`.

## Testing Done
Still compiles.

## Save File
N/A