### PR TITLE
fix(ui): Limit heat meter length on escort HUD

### DIFF
--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -180,7 +180,7 @@ EscortDisplay::Icon::Icon(const Ship &ship, bool isHere, bool fleetIsJumping, bo
 	isSelected(isSelected),
 	cost(ship.Cost()),
 	system((!isHere && ship.GetSystem()) ? ship.GetSystem()->Name() : ""),
-	low{ship.Shields(), ship.Hull(), ship.Energy(), ship.Heat(), ship.Fuel()},
+	low{ship.Shields(), ship.Hull(), ship.Energy(), min(ship.Heat(), 1.), ship.Fuel()},
 	high(low),
 	ships(1, &ship)
 {


### PR DESCRIPTION
## Fix Details
Set a limit for escort heat bars so that they no longer overlap with the message log when a ship is overheated.

## UI Screenshots
Before:
![Screenshot_20231122_200041](https://github.com/endless-sky/endless-sky/assets/108272452/efd7129f-aa20-4a24-991b-581ec9807882)
After:
![Screenshot_20231122_195945](https://github.com/endless-sky/endless-sky/assets/108272452/06a498af-cf57-4d76-a521-09282be08875)
