### PR TITLE
Fix capture override integration test

### DIFF
--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_capture_override.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_capture_override.txt
@@ -100,10 +100,6 @@ test-data "Capture Uncapturable With Capturable Override Mission"
 				"override capture"
 			to offer
 				has "%TEST%: ILLEGAL CAPTURE"
-			on offer
-				conversation
-					`Skip this and get your own Quarg automaton, today!`
-						accept
 			destination "Earth"
 
 
@@ -124,12 +120,8 @@ test "Capture Uncapturable With Capturable Override"
 		label "floating"
 		# empty input to make time pass
 		input
-			key return
 		branch "floating"
 			not "%TEST%: Capture That Quarg!: offered"
-		# skip dialog
-		input
-			key "return"
 		# attempt capture and attack, then close the panel and land
 		input
 			key c


### PR DESCRIPTION
## Fix Details

Fixes the capture override integration test . It seems like there was some sort of race condition where the boarding panel gets closed by accident. This PR fixes this issue by simply removing the unnecessary panel that gets shown when the mission is offered.

## Testing Done

Ran the integration test one hundred times to make sure that there isn't any problems left. CI should also succeed.