### PR TITLE
Allow ctest to repeatedly run integration tests

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -37,6 +37,7 @@ cmake_files:
   - source/CMakeLists.txt
   - tests/CMakeLists.txt
   - tests/integration/IntegrationTests.cmake
+  - tests/integration/RunIntegrationTest.cmake
   - utils/vcpkg_bootstrap.cmake
   - utils/check_cmake.sh
   - CMakePresets.json

--- a/tests/integration/IntegrationTests.cmake
+++ b/tests/integration/IntegrationTests.cmake
@@ -11,11 +11,7 @@ execute_process(
 file(REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/integration/config/errors.txt")
 
 string(REPLACE "\n" ";" INTEGRATION_TESTS_LIST "${INTEGRATION_TESTS}")
-
-# Empty the temp config directory.
 set(TEST_CONFIGS "${BINARY_PATH}/integration_configs")
-set(TEST_SCRIPT "file(REMOVE_RECURSE \"${TEST_CONFIGS}\")")
-set(TEST_SCRIPT "${TEST_SCRIPT}\nfile(MAKE_DIRECTORY \"${TEST_CONFIGS}\")\n")
 
 # Choose between using the offscreen backend and Xvfb.
 if(ES_USE_OFFSCREEN)
@@ -26,16 +22,17 @@ endif()
 
 # Add each test as CTest.
 foreach(test ${INTEGRATION_TESTS_LIST})
-	# Copy the template config
-	set(TEST_CONFIG "${TEST_CONFIGS}/${test}")
-	set(COPY_CONFIG "file(COPY \"${ES_CONFIG}\" DESTINATION \"${TEST_CONFIGS}\")")
-	set(RENAME_CONFIG "file(RENAME \"${TEST_CONFIGS}/config\" \"${TEST_CONFIG}\")")
-
 	if(UNIX AND NOT APPLE)
 		# Launches the integration tests in release mode: In the background and as fast as possible.
 		set(ADD_TEST
-	"add_test([==[${test}]==]
-		$ENV{ES_INTEGRATION_PREFIX} ${XFVB} \"${ES}\" --config \"${TEST_CONFIG}\" --resources \"${RESOURCE_PATH}\" --test \"${test}\")")
+	"add_test([==[${test}]==] \"${CMAKE_COMMAND}\"
+		-DXFVB=${XFVB}
+		-DES=${ES}
+		-DTEST_CONFIGS=${TEST_CONFIGS}
+		\"-Dtest=${test}\"
+		-DRESOURCE_PATH=${RESOURCE_PATH}
+		-DES_CONFIG=${ES_CONFIG}
+		-P \"${CMAKE_SOURCE_DIR}/integration/RunIntegrationTest.cmake\")")
 		set(SET_TEST_PROPS
 	"set_tests_properties([==[${test}]==] PROPERTIES
 		WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\"
@@ -44,13 +41,19 @@ foreach(test ${INTEGRATION_TESTS_LIST})
 
 	# Launches the integration tests in debug mode, so that they can be followed.
 	set(ADD_TEST_DEBUG
-"add_test([==[[debug] ${test}]==]
-	$ENV{ES_INTEGRATION_PREFIX} \"${ES}\" --config \"${TEST_CONFIG}\" --resources \"${RESOURCE_PATH}\" --test \"${test}\" --debug)")
+	"add_test([==[[debug] ${test}]==] \"${CMAKE_COMMAND}\"
+		-DES=${ES}
+		-DTEST_CONFIGS=${TEST_CONFIGS}
+		\"-Dtest=${test}\"
+		-DRESOURCE_PATH=${RESOURCE_PATH}
+		-DES_CONFIG=${ES_CONFIG}
+		-DDEBUG=--debug
+		-P \"${CMAKE_SOURCE_DIR}/integration/RunIntegrationTest.cmake\")")
 	set(SET_TEST_PROPS_DEBUG
 "set_tests_properties([==[[debug] ${test}]==] PROPERTIES
 	WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\"
 	LABELS integration-debug)")
-	set(TEST_SCRIPT ${TEST_SCRIPT}${COPY_CONFIG}\n${RENAME_CONFIG}\n${ADD_TEST}\n${SET_TEST_PROPS}\n${ADD_TEST_DEBUG}\n${SET_TEST_PROPS_DEBUG}\n)
+	set(TEST_SCRIPT ${TEST_SCRIPT}\n${ADD_TEST}\n${SET_TEST_PROPS}\n${ADD_TEST_DEBUG}\n${SET_TEST_PROPS_DEBUG}\n)
 endforeach()
 
 file(WRITE "${BINARY_PATH}/IntegrationTests_tests.cmake" "${TEST_SCRIPT}")

--- a/tests/integration/RunIntegrationTest.cmake
+++ b/tests/integration/RunIntegrationTest.cmake
@@ -1,0 +1,16 @@
+set(TEST_CONFIG "${TEST_CONFIGS}/${test}")
+
+# Clean the config folder of the integration test.
+file(REMOVE_RECURSE "${TEST_CONFIG}")
+file(COPY "${ES_CONFIG}" DESTINATION "${TEST_CONFIGS}")
+file(RENAME "${TEST_CONFIGS}/config" "${TEST_CONFIG}")
+
+# Run the integration test
+execute_process(COMMAND $ENV{ES_INTEGRATION_PREFIX} ${XFVB} "${ES}" --config "${TEST_CONFIG}" --resources "${RESOURCE_PATH}" --test "${test}" ${DEBUG}
+    OUTPUT_VARIABLE TEST_OUTPUT
+    ERROR_VARIABLE TEST_OUTPUT
+    RESULT_VARIABLE TEST_RESULT)
+
+if(TEST_RESULT)
+    message(FATAL_ERROR "Integration test failed with:\n${TEST_OUTPUT}")
+endif()


### PR DESCRIPTION
## Feature Details

Running the integration tests in a loop (by passing `--repeat` to ctest) was broken and caused failures for some integration tests. The reason was that the config folder was not properly cleaned between individual runs, and the old files would conflict with the integration test.

## Testing Done

Ran the integration tests on `--repeat` in debug mode and verified that the config environment is properly cleaned up, and that the integration tests stop failing.