### PR TITLE
Condense PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-(The lines in brackets (like this one) is instructions for filling out this template. These lines can be deleted.)
+(The lines in parentheses (like this one) are instructions for filling out this template. These lines can be deleted.)
 (The lines in double curly brackets ({{}}) should be replaced as it describes.)
 (You can open a PR to add or improve this template, if you find it lacking!)
 
@@ -22,7 +22,7 @@ This PR addresses the bug/feature described in issue #{{insert number}}
 {{If your changes affect how game data can be defined, provide examples demonstrating the changes here.}}
 
 ## Testing Done
-{{Describe how you tested these changes. How they meet the purpose. Ensure they don't introduce new issues.}}
+{{Describe how you tested these changes. Ensure that new issues aren't introduced.}}
 {{If this is a new feature, have you added any automated tests using the unit or integration testing framework?}}
 
 ## Save File
@@ -30,6 +30,7 @@ This save file can be used to test these changes:
 {{Attach a save file that allows people to easily test your added mission content or see your new in-game art.}}
 
 ## Artwork Checklist
+(If any artwork was added or changed by this PR, the following must be provided.)
  - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
  - [ ] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}
  - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,67 +1,38 @@
-NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
-(You can open a PR to add or improve a section, if you find them lacking!)
+(The lines in brackets (like this one) is instructions for filling out this template. These lines can be deleted.)
+(The lines in double curly brackets ({{}}) should be replaced as it describes.)
+(You can open a PR to add or improve this template, if you find it lacking!)
 
-----------------------
+(Choose one heading, or add your own.)
 **Content (Artwork / Missions / Jobs)**
+**Balance**
+**Feature**
+**Bug fix**
+**CI/CD/Testing**
+**Documentation**
+
+This PR addresses the bug/feature described in issue #{{insert number}}
 
 ## Summary
-{{summarize your content! Include links to related issues, in-game screenshots, etc.}}
+{{Describe and explain your changes. Include links to related issues.}}
+
+## Screenshots
+{{Include before and after screenshots demonstrating your changes, if applicable.}}
+
+## Usage examples
+{{If your changes affect how game data can be defined, provide examples demonstrating the changes here.}}
+
+## Testing Done
+{{Describe how you tested these changes. How they meet the purpose. Ensure they don't introduce new issues.}}
+{{If this is a new feature, have you added any automated tests using the unit or integration testing framework?}}
 
 ## Save File
-This save file can be used to play through the new mission content:
-{{attach a save file that allows people to easily test your added mission content or see your new in-game art}}
+This save file can be used to test these changes:
+{{Attach a save file that allows people to easily test your added mission content or see your new in-game art.}}
 
 ## Artwork Checklist
  - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
  - [ ] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}
  - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}
 
-
------------------------
-**Bugfix:** This PR addresses issue #{{insert number}}
-
-## Fix Details
-{{add details}}
-
-## Testing Done
-{{describe how you tested that the fix doesn't introduce other issues}}
-
-## Save File
-This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
-{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}
-
-
------------------------
-**Balance:**
-
-## Summary
-{{summarize all the changes you made}}
-
-## Reasoning
-{{explain why you think your balance changes are an improvement, including links to any issues you think your balance changes are addressing}}
-
-## Save File
-This save file can be used to test the balance changes.
-{{attach a save file that allows people to easily test the results of your balance changes, if one is useful}}
-
-
------------------------
-**Feature:** This PR implements the feature request detailed and discussed in issue #{{insert number}}
-
-## Feature Details
-{{add details about the feature you implemented}}
-
-## UI Screenshots
-{{attach before + after screenshots of any changes to UI, or replace this line with "N/A"}}
-
-## Usage Examples
-{{if this feature is used in the data files, provide examples!}}
-
-## Testing Done
-{{describe how you tested the new feature}}
-
-### Automated Tests Added
-{{describe the automated tests you added (using the unit-test framework, integration-test framework or otherwise) to reduce the risk of regressions in the future. "N/A" if this PR is not for an in-game feature that needs to remain functional in the future. }}
-
 ## Performance Impact
-{{describe any performance impact (positive or negative). "N/A" if no performance-critical code is changed. }}
+{{If this PR changed code, describe any performance impact (positive or negative). "N/A" if no performance-critical code is changed.}}


### PR DESCRIPTION
**Documentation**

## Summary
The PR template currently has four sections: content, bugfix, balance, and feature.
Each of these sections has a series of subsections. With the idea being that a user should choose one section and then fill in each subsection, which should be relevant to that section.
In practice, there is a lot of overlap in terms of subsections between each section.
For example, all but the bugfix section begin with a "Summary" subsection. The bugfix section beginning with a "Fix Details" subsection, but this is essentially the same as the summary subsections of every other section. The only difference being the name.
All but the feature section have a "Save File" subsection, however, it is perfectly possible for a feature PR to benefit from the inclusion of an appropriate save file to test it.
Similarly, the bugfix and feature sections contain "Testing Done" subsections, but there's no reason that content and balance PRs should be excluded from describing testing done.

This PR condenses the template into a single section. A list of headings is provided at the top (a user may choose to provide their own instead of choosing one of the examples if they prefer.) Below, are many subsections for the user to fill out as appropriate.
