### PR TITLE
Don't show 'shipyard' help message for integration tests

### DIFF
--- a/tests/integration/config/preferences.txt
+++ b/tests/integration/config/preferences.txt
@@ -29,6 +29,7 @@
 "help: cargo management" 1
 "help: uninstalling and storage" 1
 "help: ship info" 1
+"help: shipyard" 1
 "help: stranded" 1
 "help: trading" 1
 "help: try out fighters transfer cargo" 1


### PR DESCRIPTION
## Fix Details

#9515 added a new help message, but it wasn't disabled in the integration tests, which made them fail because it showed the help message in the middle of the test.

## Testing Done

The "Sell X ships" integration tests succeed with this PR, and fail without. ~~CI will also verify~~ guess not.