### PR TITLE
feat(ui): Keyboard Navigation for Preference & Plugin Panels

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -976,24 +976,13 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 
 void PreferencesPanel::HandleUp()
 {
+	selected = max(0, selected - 1);
 	switch(page)
 	{
-	case 'c':
-		if(selected > 0)
-			--selected;
-		break;
 	case 's':
-		if(static_cast<unsigned>(selected) >= prefZones.size())
-			selected = prefZones.size() - 1;
-		if(selected > 0)
-			--selected;
 		selectedItem = prefZones.at(selected).Value();
 		break;
 	case 'p':
-		if(static_cast<unsigned>(selected) >= pluginZones.size())
-			selected = pluginZones.size() - 1;
-		if(selected > 0)
-			--selected;
 		selectedPlugin = pluginZones.at(selected).Value();
 		break;
 	default:
@@ -1008,21 +997,15 @@ void PreferencesPanel::HandleDown()
 	switch(page)
 	{
 	case 'c':
-		if(static_cast<unsigned>(selected + 1) < zones.size())
+		if(selected + 1 < static_cast<int>(zones.size()))
 			selected++;
 		break;
 	case 's':
-		if(static_cast<unsigned>(selected) >= prefZones.size())
-			selected = prefZones.size() - 1;
-		if(static_cast<unsigned>(selected + 1) < prefZones.size())
-			selected++;
+		selected = min(selected + 1, static_cast<int>(prefZones.size() - 1));
 		selectedItem = prefZones.at(selected).Value();
 		break;
 	case 'p':
-		if(static_cast<unsigned>(selected) >= pluginZones.size())
-			selected = pluginZones.size() - 1;
-		if(static_cast<unsigned>(selected + 1) < pluginZones.size())
-			selected++;
+		selected = min(selected + 1, static_cast<int>(pluginZones.size() - 1));
 		selectedPlugin = pluginZones.at(selected).Value();
 		break;
 	default:

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -42,7 +42,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <SDL2/SDL.h>
 
 #include <algorithm>
-#include <string>
 
 using namespace std;
 
@@ -760,6 +759,7 @@ void PreferencesPanel::DrawSettings()
 		table.Draw(text, isOn ? bright : medium);
 	}
 
+	// Ugly hack to ensure that the currently selected item gets properly synced once the preferences map gets populated.
 	if(selectedItem.empty())
 		selectedItem = prefZones.at(selected).Value();
 }

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -976,7 +976,7 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 
 void PreferencesPanel::HandleUp()
 {
-	switch (page)
+	switch(page)
 	{
 	case 'c':
 		if(selected > 0)
@@ -1005,7 +1005,7 @@ void PreferencesPanel::HandleUp()
 
 void PreferencesPanel::HandleDown()
 {
-	switch (page)
+	switch(page)
 	{
 	case 'c':
 		if(static_cast<unsigned>(selected + 1) < zones.size())
@@ -1034,7 +1034,7 @@ void PreferencesPanel::HandleDown()
 
 void PreferencesPanel::HandleConfirm()
 {
-	switch (page)
+	switch(page)
 	{
 	case 'c':
 		editing = selected;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -176,13 +176,13 @@ bool PreferencesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comma
 	{
 		++currentSettingsPage;
 		selected = 0;
-		selectedItem = "";
+		selectedItem.clear();
 	}
 	else if((key == 'r' || key == SDLK_PAGEDOWN) && currentSettingsPage > 0)
 	{
 		--currentSettingsPage;
 		selected = 0;
-		selectedItem = "";
+		selectedItem.clear();
 	}
 	else if((key == 'x' || key == SDLK_DELETE) && (page == 'c'))
 	{
@@ -760,7 +760,7 @@ void PreferencesPanel::DrawSettings()
 		table.Draw(text, isOn ? bright : medium);
 	}
 
-	if(selectedItem == "")
+	if(selectedItem.empty())
 		selectedItem = prefZones.at(selected).Value();
 }
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -214,7 +214,10 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 
 	for(const auto &zone : prefZones)
 		if(zone.Contains(point))
+		{
 			HandleSettingsString(zone.Value(), point);
+			break;
+		}
 
 	for(const auto &zone : pluginZones)
 		if(zone.Contains(point))
@@ -465,17 +468,6 @@ void PreferencesPanel::DrawSettings()
 	int firstY = -248;
 	table.DrawAt(Point(-130, firstY));
 
-	if(hoverItem != oldHoverItem)
-	{
-		latestItem = hoverItem;
-		oldHoverItem = latestItem;
-	}
-	if(selectedItem != oldSelectedItem)
-	{
-		latestItem = selectedItem;
-		oldSelectedItem = latestItem;
-	}
-
 	// About SETTINGS pagination
 	// * An empty string indicates that a category has ended.
 	// * A '\t' character indicates that the first column on this page has
@@ -591,6 +583,8 @@ void PreferencesPanel::DrawSettings()
 		}
 
 		// Record where this setting is displayed, so the user can click on it.
+		// Temporarily reset the row's size so the clickzone can cover the entire preference.
+		table.SetHighlight(-120, 120);
 		prefZones.emplace_back(table.GetCenterPoint(), table.GetRowSize(), setting);
 
 		// Get the "on / off" text for this setting. Setting "isOn"
@@ -759,7 +753,7 @@ void PreferencesPanel::DrawSettings()
 		table.Draw(text, isOn ? bright : medium);
 	}
 
-	// Ugly hack to ensure that the currently selected item gets properly synced once the preferences map gets populated.
+	// Sync the currently selected item after the preferences map has been populated.
 	if(selectedItem.empty())
 		selectedItem = prefZones.at(selected).Value();
 }

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -56,6 +56,12 @@ private:
 
 	void Exit();
 
+	void HandleSettingsString(const std::string &str, Point cursorPosition);
+
+	void HandleUp();
+	void HandleDown();
+	void HandleConfirm();
+
 
 private:
 	int editing;
@@ -69,7 +75,11 @@ private:
 
 	Point hoverPoint;
 	int hoverCount = 0;
+	std::string selectedItem;
 	std::string hoverItem;
+	std::string oldSelectedItem;
+	std::string oldHoverItem;
+	std::string latestItem;
 	std::string tooltip;
 	WrappedText hoverText;
 

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -77,8 +77,6 @@ private:
 	int hoverCount = 0;
 	std::string selectedItem;
 	std::string hoverItem;
-	std::string oldSelectedItem;
-	std::string oldHoverItem;
 	std::string tooltip;
 	WrappedText hoverText;
 

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -79,7 +79,6 @@ private:
 	std::string hoverItem;
 	std::string oldSelectedItem;
 	std::string oldHoverItem;
-	std::string latestItem;
 	std::string tooltip;
 	WrappedText hoverText;
 


### PR DESCRIPTION
While talking with RisingLeaf, I found out that the preferences and plugin panels didn't have keyboard navigation :(

I've added it in :)


