### PR TITLE
fix(content): Update parts of Return to Paradise

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6850,8 +6850,8 @@ mission "FW Refugees to Humanika"
 		log "Minor People" "Penny Little, Rosa Perkins, and Eduardo" `A young family who wanted to escape a potential war in human space. Took them to the planet Humanika, where the Quarg let humans settle.`
 
 mission "Returning to Paradise"
-	name "Take a family home to <planet>."
-	description "A family worried about the potential destruction within the Free Worlds wants to cut their vacation short and go home to <destination>."
+	name "Transport family home to <planet>"
+	description `A family worried about the potential destruction within the Free Worlds wants to cut their vacation short and go home to <destination>. They promise to "pay you very well."`
 	source
 		government "Free Worlds"
 		attributes "tourism"
@@ -6864,7 +6864,9 @@ mission "Returning to Paradise"
 		has "assisted free worlds"
 	on offer
 		conversation
-			`After looking around <origin>'s spaceport, you head back to your ship to find a middle-aged couple and two grade-school girls (probably their daughters, you reason) waiting for you at your landing pad. While the man tries to resolve an argument between the two girls, the lady notices you immediately and begins to approach you. "Thank goodness you're here," she says. "We've been going from ship to ship looking for transport back home to the Paradise Planets. This war has caught us right in the middle of our vacation and we can't risk being anywhere near here when the Navy attacks, especially with our little angels," she gestures toward her daughters, now in a full-blown fight. "If you can find the time to take us to <planet>, we will pay you very well."`
+			`After looking around <origin>'s spaceport, you head back to your ship to find a middle-aged couple and two grade-school girls (probably their daughters, you reason) waiting for you at your landing pad. While the man tries to resolve an argument between the two girls, the lady notices you immediately and begins to approach you.`
+			`	"Thank goodness you're here," she says. "We've been going from ship to ship looking for transport back home to <destination>. This war has caught us right in the middle of our vacation and we can't risk being anywhere near here when the Navy attacks, especially with our little angels," she gestures toward her daughters, now in a full-blown fight.`
+			`	She looks back at you pleadingly. "If you can find the time to take us to <planet>, we will pay you very well."`
 			choice
 				`	"Sure, I'll take you."`
 				`	"Okay, but that's pretty far. This better be worth it."`


### PR DESCRIPTION
The mission name of the Return to Paradise mission has a full stop (which generally should not happen), and the destination is not necessarily clear from the dialogue that the player gets. So I've added some paragraph breaks and made the lady repeat her destination.

~~I purposely make mistakes in my PRs to inflate my PR count in the future. On my way to becoming one of the top 15 contributors!~~