### PR TITLE
Refactor Muti-Option Preferences

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3466,7 +3466,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 		// Skip weapons omitted by the "Automatic firing" preference.
 		if(isFlagship)
 		{
-			const auto autoFireMode = Preferences::GetMultiPrefs().autoFire.Get();
+			const auto autoFireMode = Preferences::autoFire.Get();
 			if(autoFireMode == Preferences::AutoFire::GUNS_ONLY && hardpoint.IsTurret())
 				continue;
 			if(autoFireMode == Preferences::AutoFire::TURRETS_ONLY && !hardpoint.IsTurret())
@@ -3897,7 +3897,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 			if(shift)
 				ship.SetTargetShip(shared_ptr<Ship>());
 
-			const auto boardingPriority = Preferences::GetMultiPrefs().boardingPriority.Get();
+			const auto boardingPriority = Preferences::boardingPriority.Get();
 			auto strategy = [&]() noexcept -> function<double(const Ship &)>
 			{
 				Point current = ship.Position();
@@ -4184,7 +4184,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 
 	const shared_ptr<const Ship> target = ship.GetTargetShip();
 	AimTurrets(ship, firingCommands, !Preferences::Has("Turrets focus fire"));
-	if(Preferences::GetMultiPrefs().autoFire.Get() != Preferences::AutoFire::OFF && !ship.IsBoarding()
+	if(Preferences::autoFire.Get() != Preferences::AutoFire::OFF && !ship.IsBoarding()
 			&& !(autoPilot | activeCommands).Has(Command::LAND | Command::JUMP | Command::FLEET_JUMP | Command::BOARD)
 			&& (!target || target->GetGovernment()->IsEnemy()))
 		AutoFire(ship, firingCommands, false, true);
@@ -4246,8 +4246,8 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 		else if(ship.GetTargetStellar())
 			command.SetTurn(TurnToward(ship, ship.GetTargetStellar()->Position() - ship.Position()));
 	}
-	else if((Preferences::GetMultiPrefs().autoAim.Get() == Preferences::AutoAim::ALWAYS_ON
-			|| (Preferences::GetMultiPrefs().autoAim.Get() == Preferences::AutoAim::WHEN_FIRING && isFiring))
+	else if((Preferences::autoAim.Get() == Preferences::AutoAim::ALWAYS_ON
+			|| (Preferences::autoAim.Get() == Preferences::AutoAim::WHEN_FIRING && isFiring))
 			&& !command.Turn() && !ship.IsBoarding()
 			&& ((target && target->GetSystem() == ship.GetSystem() && target->IsTargetable()) || ship.GetTargetAsteroid())
 			&& !autoPilot.Has(Command::LAND | Command::JUMP | Command::FLEET_JUMP | Command::BOARD))

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3466,7 +3466,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 		// Skip weapons omitted by the "Automatic firing" preference.
 		if(isFlagship)
 		{
-			const Preferences::AutoFire autoFireMode = Preferences::GetAutoFire();
+			const auto autoFireMode = Preferences::GetMultiPrefs().autoFire.Get();
 			if(autoFireMode == Preferences::AutoFire::GUNS_ONLY && hardpoint.IsTurret())
 				continue;
 			if(autoFireMode == Preferences::AutoFire::TURRETS_ONLY && !hardpoint.IsTurret())
@@ -3897,7 +3897,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 			if(shift)
 				ship.SetTargetShip(shared_ptr<Ship>());
 
-			const auto boardingPriority = Preferences::GetBoardingPriority();
+			const auto boardingPriority = Preferences::GetMultiPrefs().boardingPriority.Get();
 			auto strategy = [&]() noexcept -> function<double(const Ship &)>
 			{
 				Point current = ship.Position();
@@ -4184,7 +4184,7 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 
 	const shared_ptr<const Ship> target = ship.GetTargetShip();
 	AimTurrets(ship, firingCommands, !Preferences::Has("Turrets focus fire"));
-	if(Preferences::GetAutoFire() != Preferences::AutoFire::OFF && !ship.IsBoarding()
+	if(Preferences::GetMultiPrefs().autoFire.Get() != Preferences::AutoFire::OFF && !ship.IsBoarding()
 			&& !(autoPilot | activeCommands).Has(Command::LAND | Command::JUMP | Command::FLEET_JUMP | Command::BOARD)
 			&& (!target || target->GetGovernment()->IsEnemy()))
 		AutoFire(ship, firingCommands, false, true);
@@ -4246,8 +4246,8 @@ void AI::MovePlayer(Ship &ship, const PlayerInfo &player, Command &activeCommand
 		else if(ship.GetTargetStellar())
 			command.SetTurn(TurnToward(ship, ship.GetTargetStellar()->Position() - ship.Position()));
 	}
-	else if((Preferences::GetAutoAim() == Preferences::AutoAim::ALWAYS_ON
-			|| (Preferences::GetAutoAim() == Preferences::AutoAim::WHEN_FIRING && isFiring))
+	else if((Preferences::GetMultiPrefs().autoAim.Get() == Preferences::AutoAim::ALWAYS_ON
+			|| (Preferences::GetMultiPrefs().autoAim.Get() == Preferences::AutoAim::WHEN_FIRING && isFiring))
 			&& !command.Turn() && !ship.IsBoarding()
 			&& ((target && target->GetSystem() == ship.GetSystem() && target->IsTargetable()) || ship.GetTargetAsteroid())
 			&& !autoPilot.Has(Command::LAND | Command::JUMP | Command::FLEET_JUMP | Command::BOARD))

--- a/source/Date.cpp
+++ b/source/Date.cpp
@@ -62,7 +62,7 @@ Date::Date(int day, int month, int year)
 // Convert a date to a string.
 const string &Date::ToString() const
 {
-	Preferences::DateFormat dateFormat = Preferences::GetDateFormat();
+	Preferences::DateFormat dateFormat = Preferences::GetMultiPrefs().dateFormat.Get();
 
 	if(dateFormat != dateFormatInUse)
 	{
@@ -133,7 +133,7 @@ string Date::LongString() const
 	};
 	const string &month = MONTH[Month() - 1];
 
-	Preferences::DateFormat dateFormat = Preferences::GetDateFormat();
+	Preferences::DateFormat dateFormat = Preferences::GetMultiPrefs().dateFormat.Get();
 	string result;
 	if(dateFormat == Preferences::DateFormat::YMD || dateFormat == Preferences::DateFormat::MDY)
 		result += std::move(month) + " " + std::move(dayString);

--- a/source/Date.cpp
+++ b/source/Date.cpp
@@ -62,7 +62,7 @@ Date::Date(int day, int month, int year)
 // Convert a date to a string.
 const string &Date::ToString() const
 {
-	Preferences::DateFormat dateFormat = Preferences::GetMultiPrefs().dateFormat.Get();
+	Preferences::DateFormat dateFormat = Preferences::dateFormat.Get();
 
 	if(dateFormat != dateFormatInUse)
 	{
@@ -133,7 +133,7 @@ string Date::LongString() const
 	};
 	const string &month = MONTH[Month() - 1];
 
-	Preferences::DateFormat dateFormat = Preferences::GetMultiPrefs().dateFormat.Get();
+	Preferences::DateFormat dateFormat = Preferences::dateFormat.Get();
 	string result;
 	if(dateFormat == Preferences::DateFormat::YMD || dateFormat == Preferences::DateFormat::MDY)
 		result += std::move(month) + " " + std::move(dayString);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -507,7 +507,7 @@ void Engine::Step(bool isActive)
 	{
 		center = flagship->Position();
 		centerVelocity = flagship->Velocity();
-		Preferences::ExtendedJumpEffects jumpEffectState = Preferences::GetMultiPrefs().extendedJumpEffects.Get();
+		Preferences::ExtendedJumpEffects jumpEffectState = Preferences::extendedJumpEffects.Get();
 		if(flagship->IsHyperspacing() && jumpEffectState != Preferences::ExtendedJumpEffects::OFF)
 			centerVelocity *= 1. + pow(flagship->GetHyperspacePercentage() /
 				(jumpEffectState == Preferences::ExtendedJumpEffects::MEDIUM ? 40. : 20.), 2);
@@ -2313,7 +2313,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 	// Checks for player FlotsamCollection setting
 	if(collector->IsYours())
 	{
-		const auto flotsamSetting = Preferences::GetMultiPrefs().flotsamCollection.Get();
+		const auto flotsamSetting = Preferences::flotsamCollection.Get();
 		if(flotsamSetting == Preferences::FlotsamCollection::OFF)
 			return;
 		if(collector == player.Flagship())

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2131,8 +2131,8 @@ void Engine::HandleMouseInput(Command &activeCommands)
 	int mousePosY;
 	if((SDL_GetMouseState(&mousePosX, &mousePosY) & SDL_BUTTON_RMASK) != 0)
 		rightMouseButtonHeld = true;
-	double relX = mousePosX - Screen::RawWidth() / 2;
-	double relY = mousePosY - Screen::RawHeight() / 2;
+	double relX = mousePosX - Screen::RawWidth() / 2.0;
+	double relY = mousePosY - Screen::RawHeight() / 2.0;
 	ai.SetMousePosition(Point(relX, relY));
 
 	// Activate firing command.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -507,7 +507,7 @@ void Engine::Step(bool isActive)
 	{
 		center = flagship->Position();
 		centerVelocity = flagship->Velocity();
-		Preferences::ExtendedJumpEffects jumpEffectState = Preferences::GetExtendedJumpEffects();
+		Preferences::ExtendedJumpEffects jumpEffectState = Preferences::GetMultiPrefs().extendedJumpEffects.Get();
 		if(flagship->IsHyperspacing() && jumpEffectState != Preferences::ExtendedJumpEffects::OFF)
 			centerVelocity *= 1. + pow(flagship->GetHyperspacePercentage() /
 				(jumpEffectState == Preferences::ExtendedJumpEffects::MEDIUM ? 40. : 20.), 2);
@@ -2313,7 +2313,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 	// Checks for player FlotsamCollection setting
 	if(collector->IsYours())
 	{
-		const auto flotsamSetting = Preferences::GetFlotsamCollection();
+		const auto flotsamSetting = Preferences::GetMultiPrefs().flotsamCollection.Get();
 		if(flotsamSetting == Preferences::FlotsamCollection::OFF)
 			return;
 		if(collector == player.Flagship())

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -68,7 +68,7 @@ namespace {
 	// Convert a time_t to a human-readable time and date.
 	string TimestampString(time_t timestamp)
 	{
-		pair<pair<string, string>, size_t> fmt = TimestampFormatString(Preferences::GetMultiPrefs().dateFormat.Get());
+		pair<pair<string, string>, size_t> fmt = TimestampFormatString(Preferences::dateFormat.Get());
 		char* buf = static_cast<char*>(std::malloc(fmt.second));
 
 #ifdef _WIN32

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -68,7 +68,7 @@ namespace {
 	// Convert a time_t to a human-readable time and date.
 	string TimestampString(time_t timestamp)
 	{
-		pair<pair<string, string>, size_t> fmt = TimestampFormatString(Preferences::GetDateFormat());
+		pair<pair<string, string>, size_t> fmt = TimestampFormatString(Preferences::GetMultiPrefs().dateFormat.Get());
 		char* buf = static_cast<char*>(std::malloc(fmt.second));
 
 #ifdef _WIN32

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -28,7 +28,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <map>
+#include <string>
+#include <vector>
 
 using namespace std;
 
@@ -116,17 +119,27 @@ namespace {
 
 	int previousSaveCount = 3;
 
-	Preferences::MultiPreferences multiPreferences {
-		Preferences::MultiPreference<Preferences::AlertIndicator, 0>({"off", "audio", "visual", "both"}),
-		Preferences::MultiPreference<Preferences::AutoAim, 2>({"off", "always on", "when firing"}),
-		Preferences::MultiPreference<Preferences::AutoFire, 0>({"off", "on", "guns only", "turrets only"}),
-		Preferences::MultiPreference<Preferences::BackgroundParallax, 2>({"off", "fancy", "fast"}),
-		Preferences::MultiPreference<Preferences::BoardingPriority, 0>({"proximity", "value", "mixed"}),
-		Preferences::MultiPreference<Preferences::DateFormat, 0>({"dd/mm/yyyy", "mm/dd/yyyy", "yyyy-mm-dd"}),
-		Preferences::MultiPreference<Preferences::ExtendedJumpEffects, 0>({"off", "medium", "heavy"}),
-		Preferences::MultiPreference<Preferences::FlotsamCollection, 1>({"off", "on", "flagship only", "escorts only"}),
-	};
 }
+
+
+
+
+Preferences::MultiPreference<Preferences::AlertIndicator, 0>Preferences::alertIndicator(
+	{"off", "audio", "visual", "both"});
+Preferences::MultiPreference<Preferences::AutoAim, 2>Preferences::autoAim(
+	{"off", "always on", "when firing"});
+Preferences::MultiPreference<Preferences::AutoFire, 0>Preferences::autoFire(
+	{"off", "on", "guns only", "turrets only"});
+Preferences::MultiPreference<Preferences::BackgroundParallax, 2>Preferences::backgroundParallax(
+	{"off", "fancy", "fast"});
+Preferences::MultiPreference<Preferences::BoardingPriority, 0>Preferences::boardingPriority(
+	{"proximity", "value", "mixed"});
+Preferences::MultiPreference<Preferences::DateFormat, 0>Preferences::dateFormat(
+	{"dd/mm/yyyy", "mm/dd/yyyy", "yyyy-mm-dd"});
+Preferences::MultiPreference<Preferences::ExtendedJumpEffects, 0>Preferences::extendedJumpEffects(
+	{"off", "medium", "heavy"});
+Preferences::MultiPreference<Preferences::FlotsamCollection, 1>Preferences::flotsamCollection(
+	{"off", "on", "flagship only", "escorts only"});
 
 
 
@@ -165,9 +178,9 @@ void Preferences::Load()
 		else if(node.Token(0) == "scroll speed" && node.Size() >= 2)
 			scrollSpeed = node.Value(1);
 		else if(node.Token(0) == "boarding target")
-			multiPreferences.boardingPriority.Load(node.Value(1));
+			boardingPriority.Load(node.Value(1));
 		else if(node.Token(0) == "Flotsam collection")
-			multiPreferences.flotsamCollection.Load(node.Value(1));
+			flotsamCollection.Load(node.Value(1));
 		else if(node.Token(0) == "view zoom")
 			zoomIndex = max(0., node.Value(1));
 		else if(node.Token(0) == "vsync")
@@ -183,19 +196,19 @@ void Preferences::Load()
 		else if(node.Token(0) == "Show neutral overlays")
 			statusOverlaySettings[OverlayType::NEUTRAL].SetState(node.Value(1));
 		else if(node.Token(0) == "Automatic aiming")
-			multiPreferences.autoAim.Load(node.Value(1));
+			autoAim.Load(node.Value(1));
 		else if(node.Token(0) == "Automatic firing")
-			multiPreferences.autoFire.Load(node.Value(1));
+			autoFire.Load(node.Value(1));
 		else if(node.Token(0) == "Parallax background")
-			multiPreferences.backgroundParallax.Load(node.Value(1));
+			backgroundParallax.Load(node.Value(1));
 		else if(node.Token(0) == "Extended jump effects")
-			multiPreferences.extendedJumpEffects.Load(node.Value(1));
+			extendedJumpEffects.Load(node.Value(1));
 		else if(node.Token(0) == "fullscreen")
 			screenModeIndex = max<int>(0, min<int>(node.Value(1), SCREEN_MODE_SETTINGS.size() - 1));
 		else if(node.Token(0) == "date format")
-			multiPreferences.dateFormat.Load(node.Value(1));
+			dateFormat.Load(node.Value(1));
 		else if(node.Token(0) == "alert indicator")
-			multiPreferences.alertIndicator.Load(node.Value(1));
+			alertIndicator.Load(node.Value(1));
 		else if(node.Token(0) == "previous saves" && node.Size() >= 2)
 			previousSaveCount = max<int>(3, node.Value(1));
 		else if(node.Token(0) == "alt-mouse turning")
@@ -210,7 +223,7 @@ void Preferences::Load()
 	if(it != settings.end())
 	{
 		if(!it->second)
-			multiPreferences.alertIndicator.Load(2);
+			alertIndicator.Load(2);
 		settings.erase(it);
 	}
 
@@ -230,7 +243,7 @@ void Preferences::Load()
 	if(it != settings.end())
 	{
 		if(!it->second)
-			multiPreferences.flotsamCollection.Load(static_cast<int>(FlotsamCollection::ESCORT));
+			flotsamCollection.Load(static_cast<int>(FlotsamCollection::ESCORT));
 		settings.erase(it);
 	}
 }
@@ -245,21 +258,21 @@ void Preferences::Save()
 	out.Write("window size", Screen::RawWidth(), Screen::RawHeight());
 	out.Write("zoom", Screen::UserZoom());
 	out.Write("scroll speed", scrollSpeed);
-	out.Write("boarding target", multiPreferences.boardingPriority.Index());
-	out.Write("Flotsam collection", multiPreferences.flotsamCollection.Index());
+	out.Write("boarding target", boardingPriority.Index());
+	out.Write("Flotsam collection", flotsamCollection.Index());
 	out.Write("view zoom", zoomIndex);
 	out.Write("vsync", vsyncIndex);
-	out.Write("date format", multiPreferences.dateFormat.Index());
+	out.Write("date format", dateFormat.Index());
 	out.Write("Show all status overlays", statusOverlaySettings[OverlayType::ALL].ToInt());
 	out.Write("Show flagship overlay", statusOverlaySettings[OverlayType::FLAGSHIP].ToInt());
 	out.Write("Show escort overlays", statusOverlaySettings[OverlayType::ESCORT].ToInt());
 	out.Write("Show enemy overlays", statusOverlaySettings[OverlayType::ENEMY].ToInt());
 	out.Write("Show neutral overlays", statusOverlaySettings[OverlayType::NEUTRAL].ToInt());
-	out.Write("Automatic aiming", multiPreferences.autoAim.Index());
-	out.Write("Automatic firing", multiPreferences.autoFire.Index());
-	out.Write("Parallax background", multiPreferences.backgroundParallax.Index());
-	out.Write("Extended jump effects", multiPreferences.extendedJumpEffects.Index());
-	out.Write("alert indicator", multiPreferences.alertIndicator.Index());
+	out.Write("Automatic aiming", autoAim.Index());
+	out.Write("Automatic firing", autoFire.Index());
+	out.Write("Parallax background", backgroundParallax.Index());
+	out.Write("Extended jump effects", extendedJumpEffects.Index());
+	out.Write("alert indicator", alertIndicator.Index());
 	out.Write("previous saves", previousSaveCount);
 
 	for(const auto &it : settings)
@@ -490,7 +503,7 @@ bool Preferences::DisplayVisualAlert()
 
 bool Preferences::DoAlertHelper(Preferences::AlertIndicator toDo)
 {
-	auto value = multiPreferences.alertIndicator.Get();
+	auto value = alertIndicator.Get();
 	if(value == AlertIndicator::BOTH)
 		return true;
 	else if(value == toDo)
@@ -503,10 +516,4 @@ bool Preferences::DoAlertHelper(Preferences::AlertIndicator toDo)
 int Preferences::GetPreviousSaveCount()
 {
 	return previousSaveCount;
-}
-
-
-
-Preferences::MultiPreferences &Preferences::GetMultiPrefs() {
-	return multiPreferences;
 }

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -124,21 +124,21 @@ namespace {
 
 
 
-Preferences::MultiPreference<Preferences::AlertIndicator, 0>Preferences::alertIndicator(
+Preferences::MultiPreference<Preferences::AlertIndicator, 0> Preferences::alertIndicator(
 	{"off", "audio", "visual", "both"});
-Preferences::MultiPreference<Preferences::AutoAim, 2>Preferences::autoAim(
+Preferences::MultiPreference<Preferences::AutoAim, 2> Preferences::autoAim(
 	{"off", "always on", "when firing"});
-Preferences::MultiPreference<Preferences::AutoFire, 0>Preferences::autoFire(
+Preferences::MultiPreference<Preferences::AutoFire, 0> Preferences::autoFire(
 	{"off", "on", "guns only", "turrets only"});
-Preferences::MultiPreference<Preferences::BackgroundParallax, 2>Preferences::backgroundParallax(
+Preferences::MultiPreference<Preferences::BackgroundParallax, 2> Preferences::backgroundParallax(
 	{"off", "fancy", "fast"});
-Preferences::MultiPreference<Preferences::BoardingPriority, 0>Preferences::boardingPriority(
+Preferences::MultiPreference<Preferences::BoardingPriority, 0> Preferences::boardingPriority(
 	{"proximity", "value", "mixed"});
-Preferences::MultiPreference<Preferences::DateFormat, 0>Preferences::dateFormat(
+Preferences::MultiPreference<Preferences::DateFormat, 0> Preferences::dateFormat(
 	{"dd/mm/yyyy", "mm/dd/yyyy", "yyyy-mm-dd"});
-Preferences::MultiPreference<Preferences::ExtendedJumpEffects, 0>Preferences::extendedJumpEffects(
+Preferences::MultiPreference<Preferences::ExtendedJumpEffects, 0> Preferences::extendedJumpEffects(
 	{"off", "medium", "heavy"});
-Preferences::MultiPreference<Preferences::FlotsamCollection, 1>Preferences::flotsamCollection(
+Preferences::MultiPreference<Preferences::FlotsamCollection, 1> Preferences::flotsamCollection(
 	{"off", "on", "flagship only", "escorts only"});
 
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -210,7 +210,7 @@ void Preferences::Load()
 	if(it != settings.end())
 	{
 		if(!it->second)
-			multiPreferences.alertIndicator.Load(2);;
+			multiPreferences.alertIndicator.Load(2);
 		settings.erase(it);
 	}
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -107,6 +107,7 @@ namespace {
 	private:
 		Preferences::OverlayState state = Preferences::OverlayState::OFF;
 	};
+
 	const vector<string> OverlaySetting::OVERLAY_SETTINGS = {"off", "always on", "damaged", "--", "on hit"};
 
 	map<Preferences::OverlayType, OverlaySetting> statusOverlaySettings = {
@@ -118,9 +119,7 @@ namespace {
 	};
 
 	int previousSaveCount = 3;
-
 }
-
 
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -48,48 +48,49 @@ public:
 		VISUAL,
 		BOTH
 	};
+
 	enum class AutoAim : int_fast8_t {
 		OFF = 0,
 		ALWAYS_ON,
 		WHEN_FIRING
 	};
+
 	enum class AutoFire : int_fast8_t {
 		OFF = 0,
 		ON,
 		GUNS_ONLY,
 		TURRETS_ONLY
 	};
+
 	enum class BackgroundParallax : int_fast8_t {
 		OFF = 0,
 		FANCY,
 		FAST
 	};
+
 	enum class BoardingPriority : int_fast8_t {
 		PROXIMITY = 0,
 		VALUE,
 		MIXED
 	};
+
 	enum class DateFormat : int_fast8_t {
 		DMY = 0, // Day-first format. (Sat, 4 Oct 1941)
 		MDY,     // Month-first format. (Sat, Oct 4, 1941)
 		YMD      // All-numeric ISO 8601. (1941-10-04)
 	};
+
 	enum class ExtendedJumpEffects : int_fast8_t {
 		OFF = 0,
 		MEDIUM,
 		HEAVY
 	};
+
 	enum class FlotsamCollection : int_fast8_t {
 		OFF = 0,
 		ON,
 		FLAGSHIP,
 		ESCORT
-	};
-
-	enum class VSync : int_fast8_t {
-		off = 0,
-		on,
-		adaptive,
 	};
 
 	enum class OverlayState : int_fast8_t {
@@ -99,12 +100,19 @@ public:
 		DISABLED,
 		ON_HIT,
 	};
+
 	enum class OverlayType : int_fast8_t {
 		ALL = 0,
 		FLAGSHIP,
 		ESCORT,
 		ENEMY,
 		NEUTRAL
+	};
+
+	enum class VSync : int_fast8_t {
+		off = 0,
+		on,
+		adaptive,
 	};
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -27,22 +27,20 @@ public:
 	template<typename T, int_fast8_t defaultIndex>
 	class MultiPreference {
 	public:
-		MultiPreference<T, defaultIndex>(const std::vector<std::string> &names) : names(names) {
-			index = defaultIndex;
+		MultiPreference<T, defaultIndex>(const std::vector<std::string> &names) : index(defaultIndex), names(names) {}
+
+		const T Get() const {
+			return static_cast<T>(index);
+		}
+		const std::string &GetString() const {
+			return names[index];
+		}
+		const int_fast8_t Index() const {
+			return index;
 		}
 
 		void Toggle() {
 			index = (index + 1) % names.size();
-		};
-		const T Get() const {
-			return static_cast<T>(index);
-		};
-		const std::string &GetString() const {
-			return names[index];
-		};
-
-		const int_fast8_t Index() const {
-			return index;
 		}
 		void Load(int from) {
 			index = std::max<int>(0, std::min<int>(from, names.size() - 1));
@@ -96,25 +94,6 @@ public:
 		ON,
 		FLAGSHIP,
 		ESCORT
-	};
-
-	struct MultiPreferences {
-		// Red alert siren and symbol
-		MultiPreference<AlertIndicator, 0> alertIndicator;
-		// Auto aim setting, either "off", "always on", or "when firing".
-		MultiPreference<AutoAim, 2> autoAim;
-		// Auto fire setting, either "off", "on", "guns only", or "turrets only".
-		MultiPreference<AutoFire, 0> autoFire;
-		// Background parallax setting, either "fast", "fancy", or "off".
-		MultiPreference<BackgroundParallax, 2> backgroundParallax;
-		// Boarding target setting, either "proximity", "value" or "mixed".
-		MultiPreference<BoardingPriority, 0> boardingPriority;
-		// Date format preferences.
-		MultiPreference<DateFormat, 0> dateFormat;
-		// Extended jump effects setting, either "off", "medium", or "heavy".
-		MultiPreference<ExtendedJumpEffects, 0> extendedJumpEffects;
-		// Flotsam setting, either "off", "on", "flagship only", or "escorts only".
-		MultiPreference<FlotsamCollection, 1> flotsamCollection;
 	};
 
 	enum class VSync : int_fast8_t {
@@ -175,14 +154,30 @@ public:
 	static OverlayState StatusOverlaysState(OverlayType type);
 	static const std::string &StatusOverlaysSetting(OverlayType type);
 
-	static MultiPreferences &GetMultiPrefs();
-
 	// Red alert siren and symbol
 	static bool PlayAudioAlert();
 	static bool DisplayVisualAlert();
 	static bool DoAlertHelper(AlertIndicator toDo);
 
 	static int GetPreviousSaveCount();
+
+public:
+	// Red alert siren and symbol
+	static MultiPreference<AlertIndicator, 0> alertIndicator;
+	// Auto aim setting, either "off", "always on", or "when firing".
+	static MultiPreference<AutoAim, 2> autoAim;
+	// Auto fire setting, either "off", "on", "guns only", or "turrets only".
+	static MultiPreference<AutoFire, 0> autoFire;
+	// Background parallax setting, either "fast", "fancy", or "off".
+	static MultiPreference<BackgroundParallax, 2> backgroundParallax;
+	// Boarding target setting, either "proximity", "value" or "mixed".
+	static MultiPreference<BoardingPriority, 0> boardingPriority;
+	// Date format preferences.
+	static MultiPreference<DateFormat, 0> dateFormat;
+	// Extended jump effects setting, either "off", "medium", or "heavy".
+	static MultiPreference<ExtendedJumpEffects, 0> extendedJumpEffects;
+	// Flotsam setting, either "off", "on", "flagship only", or "escorts only".
+	static MultiPreference<FlotsamCollection, 1> flotsamCollection;
 
 };
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -24,16 +24,103 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class Preferences {
 public:
-	enum class VSync : int_fast8_t {
-		off = 0,
-		on,
-		adaptive,
+	template<typename T, int_fast8_t defaultIndex>
+	class MultiPreference {
+	public:
+		MultiPreference<T, defaultIndex>(const std::vector<std::string> &names) : names(names) {
+			index = defaultIndex;
+		}
+
+		void Toggle() {
+			index = (index + 1) % names.size();
+		};
+		const T Get() const {
+			return static_cast<T>(index);
+		};
+		const std::string &GetString() const {
+			return names[index];
+		};
+
+		const int_fast8_t Index() const {
+			return index;
+		}
+		void Load(int from) {
+			index = std::max<int>(0, std::min<int>(from, names.size() - 1));
+		}
+
+	private:
+		int_fast8_t index;
+		const std::vector<std::string> names;
+		
 	};
 
+	enum class AlertIndicator : int_fast8_t {
+		NONE = 0,
+		AUDIO,
+		VISUAL,
+		BOTH
+	};
+	enum class AutoAim : int_fast8_t {
+		OFF = 0,
+		ALWAYS_ON,
+		WHEN_FIRING
+	};
+	enum class AutoFire : int_fast8_t {
+		OFF = 0,
+		ON,
+		GUNS_ONLY,
+		TURRETS_ONLY
+	};
+	enum class BackgroundParallax : int_fast8_t {
+		OFF = 0,
+		FANCY,
+		FAST
+	};
+	enum class BoardingPriority : int_fast8_t {
+		PROXIMITY = 0,
+		VALUE,
+		MIXED
+	};
 	enum class DateFormat : int_fast8_t {
 		DMY = 0, // Day-first format. (Sat, 4 Oct 1941)
 		MDY,     // Month-first format. (Sat, Oct 4, 1941)
 		YMD      // All-numeric ISO 8601. (1941-10-04)
+	};
+	enum class ExtendedJumpEffects : int {
+		OFF = 0,
+		MEDIUM,
+		HEAVY
+	};
+	enum class FlotsamCollection : int_fast8_t {
+		OFF = 0,
+		ON,
+		FLAGSHIP,
+		ESCORT
+	};
+		
+	struct MultiPreferences {
+		// Red alert siren and symbol
+		MultiPreference<AlertIndicator, 0> alertIndicator;
+		// Auto aim setting, either "off", "always on", or "when firing".
+		MultiPreference<AutoAim, 2> autoAim;
+		// Auto fire setting, either "off", "on", "guns only", or "turrets only".
+		MultiPreference<AutoFire, 0> autoFire;
+		// Background parallax setting, either "fast", "fancy", or "off".
+		MultiPreference<BackgroundParallax, 2> backgroundParallax;
+		// Boarding target setting, either "proximity", "value" or "mixed".
+		MultiPreference<BoardingPriority, 0> boardingPriority;
+		// Date format preferences.
+		MultiPreference<DateFormat, 0> dateFormat;
+		// Extended jump effects setting, either "off", "medium", or "heavy".
+		MultiPreference<ExtendedJumpEffects, 0> extendedJumpEffects;
+		// Flotsam setting, either "off", "on", "flagship only", or "escorts only".
+		MultiPreference<FlotsamCollection, 1> flotsamCollection;
+	};
+
+	enum class VSync : int_fast8_t {
+		off = 0,
+		on,
+		adaptive,
 	};
 
 	enum class OverlayState : int_fast8_t {
@@ -43,58 +130,12 @@ public:
 		DISABLED,
 		ON_HIT,
 	};
-
 	enum class OverlayType : int_fast8_t {
 		ALL = 0,
 		FLAGSHIP,
 		ESCORT,
 		ENEMY,
 		NEUTRAL
-	};
-
-	enum class AutoAim : int_fast8_t {
-		OFF = 0,
-		ALWAYS_ON,
-		WHEN_FIRING
-	};
-
-	enum class AutoFire : int_fast8_t {
-		OFF = 0,
-		ON,
-		GUNS_ONLY,
-		TURRETS_ONLY
-	};
-
-	enum class BoardingPriority : int_fast8_t {
-		PROXIMITY = 0,
-		VALUE,
-		MIXED
-	};
-
-	enum class FlotsamCollection : int_fast8_t {
-		OFF = 0,
-		ON,
-		FLAGSHIP,
-		ESCORT
-	};
-
-	enum class BackgroundParallax : int {
-		OFF = 0,
-		FANCY,
-		FAST
-	};
-
-	enum class ExtendedJumpEffects : int {
-		OFF = 0,
-		MEDIUM,
-		HEAVY
-	};
-
-	enum class AlertIndicator : int_fast8_t {
-		NONE = 0,
-		AUDIO,
-		VISUAL,
-		BOTH
 	};
 
 
@@ -109,11 +150,6 @@ public:
 	// and "always."
 	static void ToggleAmmoUsage();
 	static std::string AmmoUsage();
-
-	// Date format preferences.
-	static void ToggleDateFormat();
-	static DateFormat GetDateFormat();
-	static const std::string &DateFormatSetting();
 
 	// Scroll speed preference.
 	static int ScrollSpeed();
@@ -139,45 +175,15 @@ public:
 	static OverlayState StatusOverlaysState(OverlayType type);
 	static const std::string &StatusOverlaysSetting(OverlayType type);
 
-	// Auto aim setting, either "off", "always on", or "when firing".
-	static void ToggleAutoAim();
-	static AutoAim GetAutoAim();
-	static const std::string &AutoAimSetting();
-
-	// Auto fire setting, either "off", "on", "guns only", or "turrets only".
-	static void ToggleAutoFire();
-	static AutoFire GetAutoFire();
-	static const std::string &AutoFireSetting();
-
-	// Background parallax setting, either "fast", "fancy", or "off".
-	static void ToggleParallax();
-	static BackgroundParallax GetBackgroundParallax();
-	static const std::string &ParallaxSetting();
-
-	// Extended jump effects setting, either "off", "medium", or "heavy".
-	static void ToggleExtendedJumpEffects();
-	static ExtendedJumpEffects GetExtendedJumpEffects();
-	static const std::string &ExtendedJumpEffectsSetting();
-
-	// Boarding target setting, either "proximity", "value" or "mixed".
-	static void ToggleBoarding();
-	static BoardingPriority GetBoardingPriority();
-	static const std::string &BoardingSetting();
-
-	// Flotsam setting, either "off", "on", "flagship only", or "escorts only".
-	static void ToggleFlotsam();
-	static FlotsamCollection GetFlotsamCollection();
-	static const std::string &FlotsamSetting();
+	static MultiPreferences &GetMultiPrefs();
 
 	// Red alert siren and symbol
-	static void ToggleAlert();
-	static AlertIndicator GetAlertIndicator();
-	static const std::string &AlertSetting();
 	static bool PlayAudioAlert();
 	static bool DisplayVisualAlert();
 	static bool DoAlertHelper(AlertIndicator toDo);
 
 	static int GetPreviousSaveCount();
+
 };
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -39,7 +39,6 @@ public:
 	private:
 		int_fast8_t index;
 		const std::vector<std::string> names;
-
 	};
 
 	enum class AlertIndicator : int_fast8_t {
@@ -152,15 +151,16 @@ public:
 	static OverlayState StatusOverlaysState(OverlayType type);
 	static const std::string &StatusOverlaysSetting(OverlayType type);
 
-	// Red alert siren and symbol
+	// Red alert siren and symbol.
 	static bool PlayAudioAlert();
 	static bool DisplayVisualAlert();
 	static bool DoAlertHelper(AlertIndicator toDo);
 
 	static int GetPreviousSaveCount();
 
+
 public:
-	// Red alert siren and symbol
+	// Red alert siren and symbol.
 	static MultiPreference<AlertIndicator, 0> alertIndicator;
 	// Auto aim setting, either "off", "always on", or "when firing".
 	static MultiPreference<AutoAim, 2> autoAim;
@@ -176,7 +176,6 @@ public:
 	static MultiPreference<ExtendedJumpEffects, 0> extendedJumpEffects;
 	// Flotsam setting, either "off", "on", "flagship only", or "escorts only".
 	static MultiPreference<FlotsamCollection, 1> flotsamCollection;
-
 };
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -51,7 +51,7 @@ public:
 	private:
 		int_fast8_t index;
 		const std::vector<std::string> names;
-		
+
 	};
 
 	enum class AlertIndicator : int_fast8_t {
@@ -97,7 +97,7 @@ public:
 		FLAGSHIP,
 		ESCORT
 	};
-		
+
 	struct MultiPreferences {
 		// Red alert siren and symbol
 		MultiPreference<AlertIndicator, 0> alertIndicator;

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -27,24 +27,14 @@ public:
 	template<typename T, int_fast8_t defaultIndex>
 	class MultiPreference {
 	public:
-		MultiPreference<T, defaultIndex>(const std::vector<std::string> &names) : index(defaultIndex), names(names) {}
+		MultiPreference<T, defaultIndex>(const std::vector<std::string> &names);
 
-		const T Get() const {
-			return static_cast<T>(index);
-		}
-		const std::string &GetString() const {
-			return names[index];
-		}
-		const int_fast8_t Index() const {
-			return index;
-		}
+		const T Get() const;
+		const std::string &GetString() const;
+		const int_fast8_t Index() const;
 
-		void Toggle() {
-			index = (index + 1) % names.size();
-		}
-		void Load(int from) {
-			index = std::max<int>(0, std::min<int>(from, names.size() - 1));
-		}
+		void Toggle();
+		void Load(int from);
 
 	private:
 		int_fast8_t index;
@@ -84,7 +74,7 @@ public:
 		MDY,     // Month-first format. (Sat, Oct 4, 1941)
 		YMD      // All-numeric ISO 8601. (1941-10-04)
 	};
-	enum class ExtendedJumpEffects : int {
+	enum class ExtendedJumpEffects : int_fast8_t {
 		OFF = 0,
 		MEDIUM,
 		HEAVY
@@ -180,6 +170,52 @@ public:
 	static MultiPreference<FlotsamCollection, 1> flotsamCollection;
 
 };
+
+
+
+template<typename T, int_fast8_t defaultIndex>
+Preferences::MultiPreference<T, defaultIndex>::MultiPreference(const std::vector<std::string> &names)
+	: index(defaultIndex), names(names) {}
+
+
+
+template<typename T, int_fast8_t defaultIndex>
+const T Preferences::MultiPreference<T, defaultIndex>::Get() const
+{
+	return static_cast<T>(index);
+}
+
+
+
+template<typename T, int_fast8_t defaultIndex>
+const std::string &Preferences::MultiPreference<T, defaultIndex>::GetString() const
+{
+	return names[index];
+}
+
+
+
+template<typename T, int_fast8_t defaultIndex>
+const int_fast8_t Preferences::MultiPreference<T, defaultIndex>::Index() const
+{
+	return index;
+}
+
+
+
+template<typename T, int_fast8_t defaultIndex>
+void Preferences::MultiPreference<T, defaultIndex>::Toggle()
+{
+	index = (index + 1) % names.size();
+}
+
+
+
+template<typename T, int_fast8_t defaultIndex>
+void Preferences::MultiPreference<T, defaultIndex>::Load(int from)
+{
+	index = std::max<int>(0, std::min<int>(from, names.size() - 1));
+}
 
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -228,11 +228,11 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 				SDL_WarpMouseInWindow(nullptr, point.X(), point.Y());
 			}
 			else if(zone.Value() == BOARDING_PRIORITY)
-				Preferences::ToggleBoarding();
+				Preferences::GetMultiPrefs().boardingPriority.Toggle();
 			else if(zone.Value() == BACKGROUND_PARALLAX)
-				Preferences::ToggleParallax();
+				Preferences::GetMultiPrefs().backgroundParallax.Toggle();
 			else if(zone.Value() == EXTENDED_JUMP_EFFECTS)
-				Preferences::ToggleExtendedJumpEffects();
+				Preferences::GetMultiPrefs().extendedJumpEffects.Toggle();
 			else if(zone.Value() == VIEW_ZOOM_FACTOR)
 			{
 				// Increase the zoom factor unless it is at the maximum. In that
@@ -259,13 +259,13 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 			else if(zone.Value() == STATUS_OVERLAYS_NEUTRAL)
 				Preferences::CycleStatusOverlays(Preferences::OverlayType::NEUTRAL);
 			else if(zone.Value() == AUTO_AIM_SETTING)
-				Preferences::ToggleAutoAim();
+				Preferences::GetMultiPrefs().autoAim.Toggle();
 			else if(zone.Value() == AUTO_FIRE_SETTING)
-				Preferences::ToggleAutoFire();
+				Preferences::GetMultiPrefs().autoFire.Toggle();
 			else if(zone.Value() == EXPEND_AMMO)
 				Preferences::ToggleAmmoUsage();
 			else if(zone.Value() == FLOTSAM_SETTING)
-				Preferences::ToggleFlotsam();
+				Preferences::GetMultiPrefs().flotsamCollection.Toggle();
 			else if(zone.Value() == TURRET_TRACKING)
 				Preferences::Set(FOCUS_PREFERENCE, !Preferences::Has(FOCUS_PREFERENCE));
 			else if(zone.Value() == REACTIVATE_HELP)
@@ -282,9 +282,9 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 				Preferences::SetScrollSpeed(speed);
 			}
 			else if(zone.Value() == DATE_FORMAT)
-				Preferences::ToggleDateFormat();
+				Preferences::GetMultiPrefs().dateFormat.Toggle();
 			else if(zone.Value() == ALERT_INDICATOR)
-				Preferences::ToggleAlert();
+				Preferences::GetMultiPrefs().alertIndicator.Toggle();
 			// All other options are handled by just toggling the boolean state.
 			else
 				Preferences::Set(zone.Value(), !Preferences::Has(zone.Value()));
@@ -662,18 +662,18 @@ void PreferencesPanel::DrawSettings()
 		string text;
 		if(setting == ZOOM_FACTOR)
 		{
-			isOn = Screen::UserZoom() == Screen::Zoom();
 			text = to_string(Screen::UserZoom());
+			isOn = Screen::UserZoom() == Screen::Zoom();
 		}
 		else if(setting == VIEW_ZOOM_FACTOR)
 		{
-			isOn = true;
 			text = to_string(static_cast<int>(100. * Preferences::ViewZoom()));
+			isOn = true;
 		}
 		else if(setting == SCREEN_MODE_SETTING)
 		{
-			isOn = true;
 			text = Preferences::ScreenModeSetting();
+			isOn = true;
 		}
 		else if(setting == VSYNC_SETTING)
 		{
@@ -707,59 +707,59 @@ void PreferencesPanel::DrawSettings()
 		}
 		else if(setting == AUTO_AIM_SETTING)
 		{
-			text = Preferences::AutoAimSetting();
+			text = Preferences::GetMultiPrefs().autoAim.GetString();
 			isOn = text != "off";
 		}
 		else if(setting == AUTO_FIRE_SETTING)
 		{
-			text = Preferences::AutoFireSetting();
+			text = Preferences::GetMultiPrefs().autoFire.GetString();
 			isOn = text != "off";
 		}
 		else if(setting == EXPEND_AMMO)
 			text = Preferences::AmmoUsage();
 		else if(setting == DATE_FORMAT)
 		{
-			text = Preferences::DateFormatSetting();
+			text = Preferences::GetMultiPrefs().dateFormat.GetString();
 			isOn = true;
 		}
 		else if(setting == FLOTSAM_SETTING)
 		{
-			text = Preferences::FlotsamSetting();
+			text = Preferences::GetMultiPrefs().flotsamCollection.GetString();
 			isOn = text != "off";
 		}
 		else if(setting == TURRET_TRACKING)
 		{
-			isOn = true;
 			text = Preferences::Has(FOCUS_PREFERENCE) ? "focused" : "opportunistic";
+			isOn = true;
 		}
 		else if(setting == FIGHTER_REPAIR)
 		{
-			isOn = true;
 			text = Preferences::Has(FIGHTER_REPAIR) ? "parallel" : "series";
+			isOn = true;
 		}
 		else if(setting == SHIP_OUTLINES)
 		{
-			isOn = true;
 			text = Preferences::Has(SHIP_OUTLINES) ? "fancy" : "fast";
+			isOn = true;
 		}
 		else if(setting == BOARDING_PRIORITY)
 		{
+			text = Preferences::GetMultiPrefs().boardingPriority.GetString();
 			isOn = true;
-			text = Preferences::BoardingSetting();
 		}
 		else if(setting == TARGET_ASTEROIDS_BASED_ON)
 		{
-			isOn = true;
 			text = Preferences::Has(TARGET_ASTEROIDS_BASED_ON) ? "proximity" : "value";
+			isOn = true;
 		}
 		else if(setting == BACKGROUND_PARALLAX)
 		{
-			text = Preferences::ParallaxSetting();
+			text = Preferences::GetMultiPrefs().backgroundParallax.GetString();
 			isOn = text != "off";
 		}
 		else if(setting == EXTENDED_JUMP_EFFECTS)
 		{
-			text = Preferences::ExtendedJumpEffectsSetting();
+			text = Preferences::GetMultiPrefs().extendedJumpEffects.GetString();
 			isOn = text != "off";
 		}
 		else if(setting == REACTIVATE_HELP)
@@ -789,19 +789,19 @@ void PreferencesPanel::DrawSettings()
 				text = to_string(shown) + " / " + to_string(total);
 			else
 			{
-				isOn = true;
 				text = "done";
+				isOn = true;
 			}
 		}
 		else if(setting == SCROLL_SPEED)
 		{
-			isOn = true;
 			text = to_string(Preferences::ScrollSpeed());
+			isOn = true;
 		}
 		else if(setting == ALERT_INDICATOR)
 		{
-			isOn = Preferences::GetAlertIndicator() != Preferences::AlertIndicator::NONE;
-			text = Preferences::AlertSetting();
+			text = Preferences::GetMultiPrefs().alertIndicator.GetString();
+			isOn = Preferences::GetMultiPrefs().alertIndicator.Get() != Preferences::AlertIndicator::NONE;
 		}
 		else
 			text = isOn ? "on" : "off";

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -228,11 +228,11 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 				SDL_WarpMouseInWindow(nullptr, point.X(), point.Y());
 			}
 			else if(zone.Value() == BOARDING_PRIORITY)
-				Preferences::GetMultiPrefs().boardingPriority.Toggle();
+				Preferences::boardingPriority.Toggle();
 			else if(zone.Value() == BACKGROUND_PARALLAX)
-				Preferences::GetMultiPrefs().backgroundParallax.Toggle();
+				Preferences::backgroundParallax.Toggle();
 			else if(zone.Value() == EXTENDED_JUMP_EFFECTS)
-				Preferences::GetMultiPrefs().extendedJumpEffects.Toggle();
+				Preferences::extendedJumpEffects.Toggle();
 			else if(zone.Value() == VIEW_ZOOM_FACTOR)
 			{
 				// Increase the zoom factor unless it is at the maximum. In that
@@ -259,13 +259,13 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 			else if(zone.Value() == STATUS_OVERLAYS_NEUTRAL)
 				Preferences::CycleStatusOverlays(Preferences::OverlayType::NEUTRAL);
 			else if(zone.Value() == AUTO_AIM_SETTING)
-				Preferences::GetMultiPrefs().autoAim.Toggle();
+				Preferences::autoAim.Toggle();
 			else if(zone.Value() == AUTO_FIRE_SETTING)
-				Preferences::GetMultiPrefs().autoFire.Toggle();
+				Preferences::autoFire.Toggle();
 			else if(zone.Value() == EXPEND_AMMO)
 				Preferences::ToggleAmmoUsage();
 			else if(zone.Value() == FLOTSAM_SETTING)
-				Preferences::GetMultiPrefs().flotsamCollection.Toggle();
+				Preferences::flotsamCollection.Toggle();
 			else if(zone.Value() == TURRET_TRACKING)
 				Preferences::Set(FOCUS_PREFERENCE, !Preferences::Has(FOCUS_PREFERENCE));
 			else if(zone.Value() == REACTIVATE_HELP)
@@ -282,9 +282,9 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 				Preferences::SetScrollSpeed(speed);
 			}
 			else if(zone.Value() == DATE_FORMAT)
-				Preferences::GetMultiPrefs().dateFormat.Toggle();
+				Preferences::dateFormat.Toggle();
 			else if(zone.Value() == ALERT_INDICATOR)
-				Preferences::GetMultiPrefs().alertIndicator.Toggle();
+				Preferences::alertIndicator.Toggle();
 			// All other options are handled by just toggling the boolean state.
 			else
 				Preferences::Set(zone.Value(), !Preferences::Has(zone.Value()));
@@ -707,24 +707,24 @@ void PreferencesPanel::DrawSettings()
 		}
 		else if(setting == AUTO_AIM_SETTING)
 		{
-			text = Preferences::GetMultiPrefs().autoAim.GetString();
+			text = Preferences::autoAim.GetString();
 			isOn = text != "off";
 		}
 		else if(setting == AUTO_FIRE_SETTING)
 		{
-			text = Preferences::GetMultiPrefs().autoFire.GetString();
+			text = Preferences::autoFire.GetString();
 			isOn = text != "off";
 		}
 		else if(setting == EXPEND_AMMO)
 			text = Preferences::AmmoUsage();
 		else if(setting == DATE_FORMAT)
 		{
-			text = Preferences::GetMultiPrefs().dateFormat.GetString();
+			text = Preferences::dateFormat.GetString();
 			isOn = true;
 		}
 		else if(setting == FLOTSAM_SETTING)
 		{
-			text = Preferences::GetMultiPrefs().flotsamCollection.GetString();
+			text = Preferences::flotsamCollection.GetString();
 			isOn = text != "off";
 		}
 		else if(setting == TURRET_TRACKING)
@@ -744,7 +744,7 @@ void PreferencesPanel::DrawSettings()
 		}
 		else if(setting == BOARDING_PRIORITY)
 		{
-			text = Preferences::GetMultiPrefs().boardingPriority.GetString();
+			text = Preferences::boardingPriority.GetString();
 			isOn = true;
 		}
 		else if(setting == TARGET_ASTEROIDS_BASED_ON)
@@ -754,12 +754,12 @@ void PreferencesPanel::DrawSettings()
 		}
 		else if(setting == BACKGROUND_PARALLAX)
 		{
-			text = Preferences::GetMultiPrefs().backgroundParallax.GetString();
+			text = Preferences::backgroundParallax.GetString();
 			isOn = text != "off";
 		}
 		else if(setting == EXTENDED_JUMP_EFFECTS)
 		{
-			text = Preferences::GetMultiPrefs().extendedJumpEffects.GetString();
+			text = Preferences::extendedJumpEffects.GetString();
 			isOn = text != "off";
 		}
 		else if(setting == REACTIVATE_HELP)
@@ -800,8 +800,8 @@ void PreferencesPanel::DrawSettings()
 		}
 		else if(setting == ALERT_INDICATOR)
 		{
-			text = Preferences::GetMultiPrefs().alertIndicator.GetString();
-			isOn = Preferences::GetMultiPrefs().alertIndicator.Get() != Preferences::AlertIndicator::NONE;
+			text = Preferences::alertIndicator.GetString();
+			isOn = Preferences::alertIndicator.Get() != Preferences::AlertIndicator::NONE;
 		}
 		else
 			text = isOn ? "on" : "off";

--- a/source/StarField.cpp
+++ b/source/StarField.cpp
@@ -132,7 +132,7 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom, const Syst
 	double baseZoom = zoom;
 
 	// Check preferences for the parallax quality.
-	const auto parallaxSetting = Preferences::GetBackgroundParallax();
+	const auto parallaxSetting = Preferences::GetMultiPrefs().backgroundParallax.Get();
 	int layers = (parallaxSetting == Preferences::BackgroundParallax::FANCY) ? 3 : 1;
 	bool isParallax = (parallaxSetting == Preferences::BackgroundParallax::FANCY ||
 						parallaxSetting == Preferences::BackgroundParallax::FAST);

--- a/source/StarField.cpp
+++ b/source/StarField.cpp
@@ -132,7 +132,7 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom, const Syst
 	double baseZoom = zoom;
 
 	// Check preferences for the parallax quality.
-	const auto parallaxSetting = Preferences::GetMultiPrefs().backgroundParallax.Get();
+	const auto parallaxSetting = Preferences::backgroundParallax.Get();
 	int layers = (parallaxSetting == Preferences::BackgroundParallax::FANCY) ? 3 : 1;
 	bool isParallax = (parallaxSetting == Preferences::BackgroundParallax::FANCY ||
 						parallaxSetting == Preferences::BackgroundParallax::FAST);


### PR DESCRIPTION
## Summary
Refactors multiple preferences to remove common code.

This changes how you would normally get the preference, from `Preferences::Get<preference name>()` to `Preferences::<preference name>.Get()`. This is up to change.

(I've also made the `isOn =` for highlighting enabled preferences go consistently after the `text =`)
