### PR TITLE
fix(ui): Better switch from mouse to keyboard in plugins menu

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -219,12 +219,17 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 			break;
 		}
 
+	auto index = 0;
 	for(const auto &zone : pluginZones)
+	{
 		if(zone.Contains(point))
 		{
 			selectedPlugin = zone.Value();
+			selected = index;
 			break;
 		}
+		index++;
+	}
 
 	return true;
 }


### PR DESCRIPTION
Stops the changing of the selected item via keyboard from jumping back to the last keyboard-selected item in the plugins.