### PR TITLE
Don't cancel commits to the main branch

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -10,7 +10,7 @@ on:
       - opened
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize]
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group:  ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  group:  ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Feature Details

Commits are currently cancelling previous commits' runs just like PRs are. Now that the integration tests run much quicker, there isn't really a reason to do this anymore. Currently the commit list has a lot of Xs due to cancelled runs which isn't great because it makes it harder to pinpoint actual failures versus just cancelled runs.

This continues to cancel old PR runs.

## Testing Done

Tested both commits on the main branch and PRs to it to verify that the behavior works.