### PR TITLE
feat(ui): Change Shortcut Key for Buy/Sell All

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1211,7 +1211,7 @@ interface "trade"
 	active if "can buy"
 	sprite "ui/dialog cancel"
 		center 40 355
-	button B "Buy All"
+	button u "B_uy All"
 		center 40 355
 		dimensions 70 30
 	
@@ -1220,13 +1220,13 @@ interface "trade"
 	
 	active if "can sell"
 	visible if "!can sell outfits"
-	button S "Sell All"
+	button e "S_ell All"
 		center 130 355
 		dimensions 90 30
 	
 	active if "can sell outfits"
 	visible if "can sell outfits"
-	button S "Sell Outfits"
+	button e "S_ell Outfits"
 		center 130 355
 		dimensions 90 30
 

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -234,9 +234,9 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 		Buy(1);
 	else if(key == SDLK_MINUS || key == SDLK_KP_MINUS || key == SDLK_BACKSPACE || key == SDLK_DELETE)
 		Buy(-1);
-	else if(key == 'B' || (key == 'b' && (mod & KMOD_SHIFT)))
+	else if(key == 'u')
 		Buy(1000000000);
-	else if(key == 'S' || (key == 's' && (mod & KMOD_SHIFT)))
+	else if(key == 'e')
 	{
 		for(const auto &it : player.Cargo().Commodities())
 		{

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -234,9 +234,9 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 		Buy(1);
 	else if(key == SDLK_MINUS || key == SDLK_KP_MINUS || key == SDLK_BACKSPACE || key == SDLK_DELETE)
 		Buy(-1);
-	else if(key == 'u')
+	else if(key == 'u' || key == 'B' || (key == 'b' && (mod & KMOD_SHIFT)))
 		Buy(1000000000);
-	else if(key == 'e')
+	else if(key == 'e' || key == 'S' || (key == 's' && (mod & KMOD_SHIFT)))
 	{
 		for(const auto &it : player.Cargo().Commodities())
 		{


### PR DESCRIPTION
**Feature**

This PR addresses the problem described in issue #9473

## Summary

Pretty much changed the keys of Buy All and Sell All:
- Buy All 'B' -> 'u'
- Sell All 'S' -> 'e'

in `TradingPanel.cpp`

And also modified `data/_ui/interfaces` to underline the `u` and `e`

## Screenshots

Note that `Alt` is pressed in all images.

| Original | After Changes |
|----------|---------------|
|![before, alt sell all](https://github.com/endless-sky/endless-sky/assets/63902100/6fbf9e5c-b622-4db7-bfce-82ef4eff5b17)|![after, alt sell all](https://github.com/endless-sky/endless-sky/assets/63902100/27c4eab9-6caf-47af-9bd6-f922c17154f0)|
|![before, alt sell outfits](https://github.com/endless-sky/endless-sky/assets/63902100/3f39d474-e576-4522-9355-d23dcdaa43c3)|![after, alt sell outfits](https://github.com/endless-sky/endless-sky/assets/63902100/2f6498e5-591b-4d63-bf27-c55966769e3a)|

## Testing Done
I build the game (both in Debug and Release mode), run it, obtained the screenshots, run the unit test, benchmark, and integration-debug tests.

## Performance Impact
N/A
