### PR TITLE
Ensure that all steps of the player's travel plan are visible

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -603,10 +603,11 @@ void Engine::Step(bool isActive)
 	// Update this here, for thread safety.
 	if(player.HasTravelPlan() && currentSystem == player.TravelPlan().back())
 		player.PopTravel();
-	// Check if the first step of the travel plan is valid.
+	// Check if the player's travel plan is still valid.
 	if(flagship && player.HasTravelPlan())
 	{
 		bool travelPlanIsValid = false;
+		// If the player is traveling through a wormhole to the next system, then the plan is valid.
 		const System *system = player.TravelPlan().back();
 		for(const StellarObject &object : flagship->GetSystem()->Objects())
 			if(object.HasSprite() && object.HasValidPlanet() && object.GetPlanet()->IsWormhole()
@@ -620,7 +621,11 @@ void Engine::Step(bool isActive)
 				travelPlanIsValid = true;
 				break;
 			}
+		// Otherwise, the player must still be within jump range of the next system. 
 		travelPlanIsValid |= flagship->JumpNavigation().CanJump(flagship->GetSystem(), system);
+		// Other steps of the travel plan may have been invalidated as a result of the system no longer being visible.
+		travelPlanIsValid &= all_of(player.TravelPlan().begin(), player.TravelPlan().end(),
+				[this](const System *system) -> bool { return player.HasSeen(*system); });
 		if(!travelPlanIsValid)
 		{
 			if(flagship->GetTargetSystem() == player.TravelPlan().back())
@@ -641,7 +646,6 @@ void Engine::Step(bool isActive)
 	// Update the player's ammo amounts.
 	if(flagship)
 		ammoDisplay.Update(*flagship);
-
 
 	// Display escort information for all ships of the "Escort" government,
 	// and all ships with the "escort" personality, except for fighters that

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -621,7 +621,7 @@ void Engine::Step(bool isActive)
 				travelPlanIsValid = true;
 				break;
 			}
-		// Otherwise, the player must still be within jump range of the next system. 
+		// Otherwise, the player must still be within jump range of the next system.
 		travelPlanIsValid |= flagship->JumpNavigation().CanJump(flagship->GetSystem(), system);
 		// Other steps of the travel plan may have been invalidated as a result of the system no longer being visible.
 		travelPlanIsValid &= all_of(player.TravelPlan().begin(), player.TravelPlan().end(),


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug uncovered during testing of #9396, but it turns out to be a bug in vanilla.

## Summary
If the player has an available mission to an unexplored system, the location and name of that system is revealed to the player. This is the case even if the player has no known route to the system. Should the player have the means to select this system and add it to their travel path and then take off without accepting the mission, the system will remain in the player's travel path despite the fact that they no longer have the knowledge to see it.

To address this, I've added to the current travel plan validation check in Engine::Step. Instead of just checking that the next jump is doable, check that all jumps in the travel plan are visible.

## Screenshots
Available mission to Caph. Select the system (which is possible using a vanilla jump drive), therefore adding it to the travel path.
![image](https://github.com/endless-sky/endless-sky/assets/17688683/46986a9f-d1dc-4014-841c-e59ea1c89149)
Upon departing from the planet, the system is still selected as a part of the travel path, even though it is no longer visible.
![image](https://github.com/endless-sky/endless-sky/assets/17688683/08a10cc9-6d1a-4831-b8db-2f6ac13cf0d7)

## Testing Done
Reproduced the aforementioned bug without this fix. After making this change, taking off from the planet clears the travel path if any of the systems are no longer visible.
![image](https://github.com/endless-sky/endless-sky/assets/17688683/a563fde0-1731-43f7-a66d-794461b8cb09)