### PR TITLE
Have Typhoons sold on planets with major Navy shipyards/outfitters, rather than only in the deep.

### DIFF
--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1847,6 +1847,13 @@ event "deep sky tech available"
 		"Typhoon Storage Tube"
 		"Electron Turret"
 
+event "navy expand typhoon sales"
+	outfitter "Lovelace Advanced"
+		"Typhoon Torpedo"
+		"Typhoon Launcher"
+		"Typhoon Pod"
+		"Typhoon Storage Tube"
+
 
 
 event "navy out of rastaban"

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1854,6 +1854,15 @@ event "navy expand typhoon sales"
 		"Typhoon Pod"
 		"Typhoon Storage Tube"
 
+mission "Navy expands typhoon sales"
+	invisible
+	landing
+	to offer
+		has "event: deep sky tech available"
+	on offer
+		event "navy expand typhoon sales" 120
+		fail
+
 
 
 event "navy out of rastaban"


### PR DESCRIPTION
**Balance**

## Summary
Added an event after the typhoon becomes available, which expands the sale of both the torpedo and its launcher to some worlds with major navy shipyards and outfitters (specifically the `lovelace advanced` outfitter, which is present on Shroud, Ada, Hermes and Geminis, and is also the only outfitter that sells the Navy's Armageddon Cores) a short while after it begins being sold in the Deep.

## Screenshots
Launcher sales before:
![image](https://github.com/endless-sky/endless-sky/assets/18634983/fad091b9-46c5-4dd5-bcb5-f1921ba6a7dd)

Ammunition sales before:
![image](https://github.com/endless-sky/endless-sky/assets/18634983/828075f1-3e19-4a5e-92a8-cde61fd01c40)

Planets to which sales are expanded:
![image](https://github.com/endless-sky/endless-sky/assets/18634983/cf6044ca-3765-404c-99ba-b540fa1e9f09)


## Save File
Any post-FW save file will work. The sales will update after a delay of 120 days.

