### PR TITLE
Fix: FW Bloodsea 1.1 Mission oversight, outdated event label

### DIFF
--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -1451,7 +1451,7 @@ mission "FW Bloodsea 1.1"
 		conversation
 			`The local leaders are unwilling to meet aboard your ship, and Alondo is afraid you will be ambushed if you venture too far away from it, so eventually they agree to set up a tent on the landing pad next to yours and meet there. Outside, a storm is raging, the rain mixing with salt spray from the blood-red ocean nearby.`
 			branch peaceful
-				not "event: fw suppressed Bloodsea"
+				not "event: fw suppressed Greenrock"
 			`	Most of the leaders grimace at the sight of you. "What is the invader doing here?" one of them asks to Alondo.`
 			`	"Captain <last> was only following orders, but the officer responsible for giving those orders has been justly punished," Alondo says. "We come in peace this time." The leaders don't seem convinced with that answer, but they agree to continue.`
 			label peaceful
@@ -1468,7 +1468,7 @@ mission "FW Bloodsea 1.1"
 			`	"So, we attack them?" you ask.`
 			label invade
 			branch hostile
-				not "event: fw suppressed Bloodsea"
+				not "event: fw suppressed Greenrock"
 			`	"They didn't seem very happy about you doing that the first time. But..." Alondo pauses for a moment.`
 			label hostile
 			`	"That's certainly the simpler option," he says. "Tomek may have been punished for disobeying the Senate's orders, but we're in a different situation now. Our numbers have swelled because of our victories and new territory, and we now have the Dreadnoughts at our disposal, so occupying Bloodsea is now a viable option.`


### PR DESCRIPTION
Read title,
replaced 
the "event: fw suppressed Bloodsea" which is not used anymore
with "event: fw suppressed Greenrock"

if you want more description tell me