### PR TITLE
Don't Smooth Dragging

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -597,7 +597,12 @@ bool ShopPanel::Drag(double dx, double dy)
 				}
 	}
 	else
+	{
 		DoScroll(dy);
+		infobarSmoothScroll = infobarScroll;
+		sidebarSmoothScroll = sidebarScroll;
+		mainSmoothScroll = mainScroll;
+	}
 
 	return true;
 }


### PR DESCRIPTION
Hotfix, a better solution might be to use nut's ScrollVars.

Prevents smooth scrolling from applying when using the mouse to drag, thereby preventing there being a delay between the actual mouse movement and the screen's scrolling.