### PR TITLE
Fix(code): Avoid flotsam getting stuck by tractor beam

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2020,8 +2020,7 @@ bool Ship::FireAntiMissile(const Projectile &projectile, vector<Visual> &visuals
 Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 {
 	Point pullVector;
-	const double distance = flotsam.Position().Distance(position);
-	if(distance > tractorBeamRange || distance - Radius() <= 0)
+	if(flotsam.Position().Distance(position) > tractorBeamRange)
 		return pullVector;
 	if(CannotAct())
 		return pullVector;
@@ -2046,7 +2045,7 @@ Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 	for(unsigned i = 0; i < hardpoints.size(); ++i)
 	{
 		const Weapon *weapon = hardpoints[i].GetOutfit();
-		if(weapon && CanFire(weapon))
+		if(weapon && CanFire(weapon) && flotsam.Position().Distance(position + hardpoints[i].GetPoint()) - 5. > 0.)
 			if(armament.FireTractorBeam(i, *this, flotsam, visuals, Random::Real() < jamChance))
 			{
 				Point hardpointPos = Position() + Zoom() * Facing().Rotate(hardpoints[i].GetPoint());

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2016,7 +2016,7 @@ bool Ship::FireAntiMissile(const Projectile &projectile, vector<Visual> &visuals
 Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 {
 	Point pullVector;
-	const float distance = flotsam.Position().Distance(position);
+	const double distance = flotsam.Position().Distance(position);
 	if(distance > tractorBeamRange || distance - Radius() <= 0)
 		return pullVector;
 	if(CannotAct())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2016,7 +2016,8 @@ bool Ship::FireAntiMissile(const Projectile &projectile, vector<Visual> &visuals
 Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 {
 	Point pullVector;
-	if(flotsam.Position().Distance(position) > tractorBeamRange)
+	const float distance = flotsam.Position().Distance(position);
+	if(distance > tractorBeamRange || distance - Radius() <= 0)
 		return pullVector;
 	if(CannotAct())
 		return pullVector;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described by Saugia on discord

## Summary
See video posted by Saugia:
https://clips.twitch.tv/HonestIronicEmuBudStar-hTnsQaWn-gaHfokm 

I tried to fix this by stopping the tractor beam from trying to pull flotsams that are already in collection range.

## Testing Done
This is hard to test as the issue comes at random, I flew around for 15 minutes and did not encouter it again where as before I already got this after 1 or 2 minutes.
Interestingly this issue did not come up in a scout with a centered turret, dunno why.

## Save File
Plugin adding a tractor beam (extracted from the mining PR):
[tractor-beam.zip](https://github.com/endless-sky/endless-sky/files/13804830/tractor-beam.zip)
Aerie with the beam installed:
[t t.txt](https://github.com/endless-sky/endless-sky/files/13804832/t.t.txt)
