### PR TITLE
Fix(code): Add a contains check to Mask::WithinRing

### DIFF
--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -379,6 +379,7 @@ bool Mask::WithinRing(Point point, Angle facing, double inner, double outer) con
 	inner *= inner;
 	outer *= outer;
 
+	// Determine if the ring contains any of the outlines of the mask.
 	for(auto &&outline : outlines)
 		for(auto &&p : outline)
 		{
@@ -387,7 +388,14 @@ bool Mask::WithinRing(Point point, Angle facing, double inner, double outer) con
 				return true;
 		}
 
-	return false;
+	// While a ring might not contain any outlines of the mask, it may be
+	// located entirely inside of the mask. This should still count as the
+	// mask being within the ring. The inner radius of the ring must be
+	// smaller than the mask's radius for this to even be a possibility,
+	// as otherwise the center of the ring may be contained within the mask,
+	// but the ring itself can't possibly touch any contents of the mask
+	// because the inner edge of the ring is too far away.
+	return inner < radius && Contains(point, facing);
 }
 
 

--- a/source/Mask.cpp
+++ b/source/Mask.cpp
@@ -390,12 +390,10 @@ bool Mask::WithinRing(Point point, Angle facing, double inner, double outer) con
 
 	// While a ring might not contain any outlines of the mask, it may be
 	// located entirely inside of the mask. This should still count as the
-	// mask being within the ring. The inner radius of the ring must be
-	// smaller than the mask's radius for this to even be a possibility,
-	// as otherwise the center of the ring may be contained within the mask,
-	// but the ring itself can't possibly touch any contents of the mask
-	// because the inner edge of the ring is too far away.
-	return inner < radius && Contains(point, facing);
+	// mask being within the ring. This can only be the case if the
+	// entire ring is smaller than the radius of the mask and the center
+	// of the ring is within the mask.
+	return outer < radius && Contains(point);
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2020,8 +2020,7 @@ bool Ship::FireAntiMissile(const Projectile &projectile, vector<Visual> &visuals
 Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 {
 	Point pullVector;
-	const double distance = flotsam.Position().Distance(position);
-	if(distance > tractorBeamRange || distance - Radius() <= 0)
+	if(flotsam.Position().Distance(position) > tractorBeamRange)
 		return pullVector;
 	if(CannotAct())
 		return pullVector;
@@ -2046,7 +2045,7 @@ Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 	for(unsigned i = 0; i < hardpoints.size(); ++i)
 	{
 		const Weapon *weapon = hardpoints[i].GetOutfit();
-		if(weapon && CanFire(weapon))
+		if(weapon && CanFire(weapon) && flotsam.Position().Distance(position + hardpoints[i].GetPoint()) - 5. > 0.)
 			if(armament.FireTractorBeam(i, *this, flotsam, visuals, Random::Real() < jamChance))
 			{
 				Point hardpointPos = Position() + Zoom() * Facing().Rotate(hardpoints[i].GetPoint());

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2016,7 +2016,7 @@ bool Ship::FireAntiMissile(const Projectile &projectile, vector<Visual> &visuals
 Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 {
 	Point pullVector;
-	const float distance = flotsam.Position().Distance(position);
+	const double distance = flotsam.Position().Distance(position);
 	if(distance > tractorBeamRange || distance - Radius() <= 0)
 		return pullVector;
 	if(CannotAct())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2016,7 +2016,8 @@ bool Ship::FireAntiMissile(const Projectile &projectile, vector<Visual> &visuals
 Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 {
 	Point pullVector;
-	if(flotsam.Position().Distance(position) > tractorBeamRange)
+	const float distance = flotsam.Position().Distance(position);
+	if(distance > tractorBeamRange || distance - Radius() <= 0)
 		return pullVector;
 	if(CannotAct())
 		return pullVector;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2045,7 +2045,7 @@ Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 	for(unsigned i = 0; i < hardpoints.size(); ++i)
 	{
 		const Weapon *weapon = hardpoints[i].GetOutfit();
-		if(weapon && CanFire(weapon) && flotsam.Position().Distance(position + hardpoints[i].GetPoint()) - 5. > 0.)
+		if(weapon && CanFire(weapon))
 			if(armament.FireTractorBeam(i, *this, flotsam, visuals, Random::Real() < jamChance))
 			{
 				Point hardpointPos = Position() + Zoom() * Facing().Rotate(hardpoints[i].GetPoint());


### PR DESCRIPTION
As discussed on discord:
WithinRing only checked if the circle intersected the outline, this allowed for bugs where floatsams bypassed the outline if they moved too fast.
This was fixed by adding a Contains check to the function if the inner radius of the circle is less than the radius of the outline.
As visible in this graphic the inner edge of the ring will always be in the outline, if the inner radius of the ring is smaller than the radius of the outline.
Blue = inner radius of ring
red = radius of outline
triangle = outline
![2024-01-01_16-33](https://github.com/endless-sky/endless-sky/assets/85687254/48774078-bcc0-41a7-b22f-cb390ea36162)
