### PR TITLE
Convert ShopPanel to using the new ScrollVar for its scrolling panes

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -241,7 +241,7 @@ int OutfitterPanel::DetailWidth() const
 
 
 
-int OutfitterPanel::DrawDetails(const Point &center)
+double OutfitterPanel::DrawDetails(const Point &center)
 {
 	string selectedItem = "Nothing Selected";
 	const Font &font = FontSet::Get(14);

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -53,7 +53,7 @@ protected:
 	virtual void DrawItem(const std::string &name, const Point &point) override;
 	virtual int DividerOffset() const override;
 	virtual int DetailWidth() const override;
-	virtual int DrawDetails(const Point &center) override;
+	virtual double DrawDetails(const Point &center) override;
 	virtual BuyResult CanBuy(bool onlyOwned = false) const override;
 	virtual void Buy(bool onlyOwned = false) override;
 	virtual bool CanSell(bool toStorage = false) const override;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -353,12 +353,12 @@ bool PreferencesPanel::Scroll(double dx, double dy)
 
 		if(pluginBox.Contains(hoverPoint))
 		{
-			pluginListScroll.Scroll(dy * Preferences::ScrollSpeed());
+			pluginListScroll.Scroll(-dy * Preferences::ScrollSpeed());
 			return true;
 		}
 		else if(descriptionBox.Contains(hoverPoint) && pluginDescriptionBuffer)
 		{
-			pluginDescriptionScroll.Scroll(dy * Preferences::ScrollSpeed());
+			pluginDescriptionScroll.Scroll(-dy * Preferences::ScrollSpeed());
 			return true;
 		}
 	}
@@ -378,13 +378,13 @@ bool PreferencesPanel::Drag(double dx, double dy)
 		if(pluginBox.Contains(hoverPoint))
 		{
 			// Steps is zero so that we don't animate mouse drags.
-			pluginListScroll.Scroll(dy, 0);
+			pluginListScroll.Scroll(-dy, 0);
 			return true;
 		}
 		else if(descriptionBox.Contains(hoverPoint))
 		{
 			// Steps is zero so that we don't animate mouse drags.
-			pluginDescriptionScroll.Scroll(dy, 0);
+			pluginDescriptionScroll.Scroll(-dy, 0);
 			return true;
 		}
 	}
@@ -879,7 +879,7 @@ void PreferencesPanel::DrawPlugins()
 	table.SetUnderline(pluginListClip->Left() + box[0]->Width(), pluginListClip->Right());
 
 	int firstY = pluginListClip->Top();
-	table.DrawAt(Point(0, firstY + static_cast<int>(pluginListScroll.AnimatedValue())));
+	table.DrawAt(Point(0, firstY - static_cast<int>(pluginListScroll.AnimatedValue())));
 
 	for(const auto &it : Plugins::Get())
 	{
@@ -933,12 +933,12 @@ void PreferencesPanel::DrawPlugins()
 		Rectangle topRight({pluginListBox.Right(), pluginListBox.Top() + POINTER_OFFSET.Y()}, {20.0, 20.0});
 		PointerShader::Draw(topRight.Center(), UP,
 			10.f, 10.f, 5.f, Color(pluginListScroll.IsScrollAtMin() ? .2f : .8f, 0.f));
-		AddZone(topRight, [&]() { pluginListScroll.Scroll(Preferences::ScrollSpeed()); });
+		AddZone(topRight, [&]() { pluginListScroll.Scroll(-Preferences::ScrollSpeed()); });
 
 		Rectangle bottomRight(pluginListBox.BottomRight() - POINTER_OFFSET, {20.0, 20.0});
 		PointerShader::Draw(bottomRight.Center(), DOWN,
 			10.f, 10.f, 5.f, Color(pluginListScroll.IsScrollAtMax() ? .2f : .8f, 0.f));
-		AddZone(bottomRight, [&]() { pluginListScroll.Scroll(-Preferences::ScrollSpeed()); });
+		AddZone(bottomRight, [&]() { pluginListScroll.Scroll(Preferences::ScrollSpeed()); });
 	}
 
 	// Draw the pre-rendered plugin description, if applicable.
@@ -955,7 +955,7 @@ void PreferencesPanel::DrawPlugins()
 		pluginDescriptionBuffer->Draw(
 			descriptionBox.Center(),
 			descriptionBox.Dimensions(),
-			Point(0, -static_cast<int>(pluginDescriptionScroll.AnimatedValue()))
+			Point(0, static_cast<int>(pluginDescriptionScroll.AnimatedValue()))
 		);
 
 		if(pluginDescriptionScroll.Scrollable())
@@ -966,12 +966,12 @@ void PreferencesPanel::DrawPlugins()
 			Rectangle topRight({descriptionBox.Right(), descriptionBox.Top() + POINTER_OFFSET.Y()}, {20.0, 20.0});
 			PointerShader::Draw(topRight.Center(), UP,
 				10.f, 10.f, 5.f, Color(pluginDescriptionScroll.IsScrollAtMin() ? .2f : .8f, 0.f));
-			AddZone(topRight, [&]() { pluginDescriptionScroll.Scroll(Preferences::ScrollSpeed()); });
+			AddZone(topRight, [&]() { pluginDescriptionScroll.Scroll(-Preferences::ScrollSpeed()); });
 
 			Rectangle bottomRight(descriptionBox.BottomRight() - POINTER_OFFSET, {20.0, 20.0});
 			PointerShader::Draw(bottomRight.Center(), DOWN,
 				10.f, 10.f, 5.f, Color(pluginDescriptionScroll.IsScrollAtMax() ? .2f : .8f, 0.f));
-			AddZone(bottomRight, [&]() { pluginDescriptionScroll.Scroll(-Preferences::ScrollSpeed()); });
+			AddZone(bottomRight, [&]() { pluginDescriptionScroll.Scroll(Preferences::ScrollSpeed()); });
 		}
 	}
 }
@@ -1241,8 +1241,8 @@ void PreferencesPanel::HandleConfirm()
 
 void PreferencesPanel::ScrollSelectedPlugin()
 {
-	while(selected * 20 + pluginListScroll < 0)
-		pluginListScroll += Preferences::ScrollSpeed();
-	while(selected * 20 + pluginListScroll > pluginListClip->Height())
-		pluginListScroll -= Preferences::ScrollSpeed();
+	while(selected * 20 - pluginListScroll < 0)
+		pluginListScroll.Scroll(-Preferences::ScrollSpeed());
+	while(selected * 20 - pluginListScroll > pluginListClip->Height())
+		pluginListScroll.Scroll(Preferences::ScrollSpeed());
 }

--- a/source/ScrollVar.h
+++ b/source/ScrollVar.h
@@ -32,6 +32,8 @@ public:
 
 	// Set the maximum size of the scroll content.
 	void SetMaxValue(const T &value);
+	// Get the maximum size of the scroll content.
+	const T &MaxValue() const;
 	// Set the size of the displayable scroll area.
 	void SetDisplaySize(const T &size);
 	// Returns true if scroll buttons are needed.
@@ -70,6 +72,14 @@ void ScrollVar<T>::SetMaxValue(const T &value)
 {
 	maxVal = value;
 	Clamp(0);
+}
+
+
+
+template <typename T>
+const T &ScrollVar<T>::MaxValue() const
+{
+	return maxVal;
 }
 
 

--- a/source/ScrollVar.h
+++ b/source/ScrollVar.h
@@ -28,7 +28,8 @@ template <typename T>
 class ScrollVar: public Animate<T>
 {
 public:
-	ScrollVar(const T &maxVal = T{}, const T &displaySize = T{});
+	ScrollVar() = default;
+	ScrollVar(const T &maxVal, const T &displaySize);
 
 	// Set the maximum size of the scroll content.
 	void SetMaxValue(const T &value);
@@ -48,13 +49,15 @@ public:
 	// Sets the scroll value directly, then clamps it to a suitable range.
 	virtual void Set(const T &current, int steps = 5) override;
 
+	// Shortcut mathmatical operators for convenience.
+	ScrollVar &operator=(const T &v);
 
 private:
 	// Makes sure the animation value stays in range.
 	void Clamp(int steps);
 
-	T maxVal;
-	T displaySize;
+	T maxVal{};
+	T displaySize{};
 };
 
 
@@ -104,7 +107,7 @@ bool ScrollVar<T>::Scrollable() const
 template <typename T>
 bool ScrollVar<T>::IsScrollAtMin() const
 {
-	return this->Value() >= T{};
+	return this->Value() <= T{};
 }
 
 
@@ -112,7 +115,7 @@ bool ScrollVar<T>::IsScrollAtMin() const
 template <typename T>
 bool ScrollVar<T>::IsScrollAtMax() const
 {
-	return this->Value() <= displaySize - maxVal;
+	return this->Value() >= maxVal - displaySize;
 }
 
 
@@ -137,13 +140,21 @@ void ScrollVar<T>::Set(const T &current, int steps)
 template <typename T>
 void ScrollVar<T>::Clamp(int steps)
 {
-	int minScroll = displaySize - maxVal;
-	if(this->Value() > T{} || maxVal < displaySize)
+	int maxScroll = maxVal - displaySize;
+	if(this->Value() < T{} || maxVal < displaySize)
 		Animate<T>::Set(T{}, steps);
-	else if(this->Value() < minScroll)
-		Animate<T>::Set(minScroll, steps);
+	else if(this->Value() > maxScroll)
+		Animate<T>::Set(maxScroll, steps);
 }
 
+
+
+template <typename T>
+ScrollVar<T> &ScrollVar<T>::operator=(const T &v)
+{
+	Set(v);
+	return *this;
+}
 
 
 #endif

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -154,12 +154,12 @@ int ShipyardPanel::DetailWidth() const
 
 
 
-int ShipyardPanel::DrawDetails(const Point &center)
+double ShipyardPanel::DrawDetails(const Point &center)
 {
 	string selectedItem = "No Ship Selected";
 	const Font &font = FontSet::Get(14);
 
-	int heightOffset = 20;
+	double heightOffset = 20;
 
 	if(selectedShip)
 	{

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -46,7 +46,7 @@ protected:
 	virtual void DrawItem(const std::string &name, const Point &point) override;
 	virtual int DividerOffset() const override;
 	virtual int DetailWidth() const override;
-	virtual int DrawDetails(const Point &center) override;
+	virtual double DrawDetails(const Point &center) override;
 	virtual BuyResult CanBuy(bool onlyOwned = false) const override;
 	virtual void Buy(bool onlyOwned = false) override;
 	virtual bool CanSell(bool toStorage = false) const override;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -691,13 +691,13 @@ void ShopPanel::DrawShipsSidebar()
 
 	// Draw this string, centered in the side panel:
 	static const string YOURS = "Your Ships:";
-	Point yoursPoint(Screen::Right() - SIDEBAR_WIDTH, Screen::Top() + 10 + sidebarScroll.AnimatedValue());
+	Point yoursPoint(Screen::Right() - SIDEBAR_WIDTH, Screen::Top() + 10 - sidebarScroll.AnimatedValue());
 	font.Draw({YOURS, {SIDEBAR_WIDTH, Alignment::CENTER}}, yoursPoint, bright);
 
 	// Start below the "Your Ships" label, and draw them.
 	Point point(
 		Screen::Right() - SIDEBAR_WIDTH / 2 - 93,
-		Screen::Top() + SIDEBAR_WIDTH / 2 + sidebarScroll.AnimatedValue() + 40 - 93);
+		Screen::Top() + SIDEBAR_WIDTH / 2 - sidebarScroll.AnimatedValue() + 40 - 93);
 
 	const Planet *here = player.GetPlanet();
 	int shipsHere = 0;
@@ -792,7 +792,7 @@ void ShopPanel::DrawShipsSidebar()
 		font.Draw({space, {SIDEBAR_WIDTH - 20, Alignment::RIGHT}}, point, bright);
 		point.Y() += 20.;
 	}
-	sidebarScroll.SetMaxValue(max(0., point.Y() - sidebarScroll.AnimatedValue() - Screen::Bottom() + BUTTON_HEIGHT));
+	sidebarScroll.SetMaxValue(max(0., point.Y() + sidebarScroll.AnimatedValue() - Screen::Bottom() + BUTTON_HEIGHT));
 
 	PointerShader::Draw(Point(Screen::Right() - 10, Screen::Top() + 10),
 		Point(0., -1.), 10.f, 10.f, 5.f, Color(!sidebarScroll.IsScrollAtMin() ? .8f : .2f, 0.f));
@@ -821,11 +821,11 @@ void ShopPanel::DrawDetailsSidebar()
 
 	Point point(
 		Screen::Right() - SIDE_WIDTH + INFOBAR_WIDTH / 2,
-		Screen::Top() + 10 + infobarScroll.AnimatedValue());
+		Screen::Top() + 10 - infobarScroll.AnimatedValue());
 
-	int heightOffset = DrawDetails(point);
+	double heightOffset = DrawDetails(point);
 
-	infobarScroll.SetMaxValue(max(0., heightOffset - infobarScroll.AnimatedValue() - Screen::Bottom()));
+	infobarScroll.SetMaxValue(max(0., heightOffset + infobarScroll.AnimatedValue() - Screen::Bottom()));
 
 	PointerShader::Draw(Point(Screen::Right() - SIDEBAR_WIDTH - 10, Screen::Top() + 10),
 		Point(0., -1.), 10.f, 10.f, 5.f, Color(!infobarScroll.IsScrollAtMin() ? .8f : .2f, 0.f));
@@ -934,7 +934,7 @@ void ShopPanel::DrawMain()
 
 	const Point begin(
 		(Screen::Width() - columnWidth) / -2,
-		(Screen::Height() - TILE_SIZE) / -2 + mainScroll.AnimatedValue());
+		(Screen::Height() - TILE_SIZE) / -2 - mainScroll.AnimatedValue());
 	Point point = begin;
 	const float endX = Screen::Right() - (SIDE_WIDTH + 1);
 	double nextY = begin.Y() + TILE_SIZE;
@@ -1003,7 +1003,7 @@ void ShopPanel::DrawMain()
 
 	// What amount would mainScroll have to equal to make nextY equal the
 	// bottom of the screen? (Also leave space for the "key" at the bottom.)
-	mainScroll.SetMaxValue(max(0., nextY - mainScroll.AnimatedValue() - Screen::Height() / 2 - TILE_SIZE / 2 +
+	mainScroll.SetMaxValue(max(0., nextY + mainScroll.AnimatedValue() - Screen::Height() / 2 - TILE_SIZE / 2 +
 		VisibilityCheckboxesSize() + 40.));
 
 	PointerShader::Draw(Point(Screen::Right() - 10 - SIDE_WIDTH, Screen::Top() + 10),
@@ -1029,11 +1029,11 @@ int ShopPanel::DrawPlayerShipInfo(const Point &point)
 bool ShopPanel::DoScroll(double dy, int steps)
 {
 	if(activePane == ShopPane::Info)
-		infobarScroll.Scroll(dy, steps);
+		infobarScroll.Scroll(-dy, steps);
 	else if(activePane == ShopPane::Sidebar)
-		sidebarScroll.Scroll(dy, steps);
+		sidebarScroll.Scroll(-dy, steps);
 	else
-		mainScroll.Scroll(dy, steps);
+		mainScroll.Scroll(-dy, steps);
 
 	return true;
 }
@@ -1165,12 +1165,12 @@ void ShopPanel::MainAutoScroll(const vector<Zone>::const_iterator &selected)
 	const int topY = selected->Center().Y() - TILE_SIZE / 2;
 	const int offTop = topY + Screen::Bottom();
 	if(offTop < 0)
-		mainScroll -= offTop;
+		mainScroll += offTop;
 	else
 	{
 		const int offBottom = topY + TILE_SIZE - Screen::Bottom();
 		if(offBottom > 0)
-			mainScroll -= offBottom;
+			mainScroll += offBottom;
 	}
 }
 
@@ -1279,7 +1279,7 @@ void ShopPanel::MainDown()
 	if(it == zones.end())
 	{
 		it = zones.begin();
-		mainScroll = 0;
+		mainScroll = 0.0;
 	}
 	else
 		MainAutoScroll(it);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -62,21 +62,6 @@ namespace {
 	{
 		return ship.GetPlanet() == here;
 	}
-
-	// Update smooth scroll towards scroll.
-	void UpdateSmoothScroll(const double scroll, double &smoothScroll)
-	{
-		const double dy = scroll - smoothScroll;
-		if(dy)
-		{
-			// Handle small increments.
-			if(fabs(dy) < 6 && fabs(dy) > 1)
-				smoothScroll += copysign(1., dy);
-			// Keep scroll value an integer to prevent odd text artifacts.
-			else
-				smoothScroll = round(smoothScroll + dy * 0.2);
-		}
-	}
 }
 
 
@@ -165,12 +150,6 @@ void ShopPanel::Draw()
 		if(selected != zones.end())
 			MainAutoScroll(selected);
 	}
-	if(mainScroll > maxMainScroll)
-		mainScroll = maxMainScroll;
-	if(infobarScroll > maxInfobarScroll)
-		infobarScroll = maxInfobarScroll;
-	if(sidebarScroll > maxSidebarScroll)
-		sidebarScroll = maxSidebarScroll;
 }
 
 
@@ -597,7 +576,7 @@ bool ShopPanel::Drag(double dx, double dy)
 				}
 	}
 	else
-		DoScroll(dy);
+		DoScroll(dy, 0);
 
 	return true;
 }
@@ -698,7 +677,7 @@ void ShopPanel::DrawShipsSidebar()
 	const Color &medium = *GameData::Colors().Get("medium");
 	const Color &bright = *GameData::Colors().Get("bright");
 
-	UpdateSmoothScroll(sidebarScroll, sidebarSmoothScroll);
+	sidebarScroll.Step();
 
 	// Fill in the background.
 	FillShader::Fill(
@@ -712,13 +691,13 @@ void ShopPanel::DrawShipsSidebar()
 
 	// Draw this string, centered in the side panel:
 	static const string YOURS = "Your Ships:";
-	Point yoursPoint(Screen::Right() - SIDEBAR_WIDTH, Screen::Top() + 10 - sidebarSmoothScroll);
+	Point yoursPoint(Screen::Right() - SIDEBAR_WIDTH, Screen::Top() + 10 + sidebarScroll.AnimatedValue());
 	font.Draw({YOURS, {SIDEBAR_WIDTH, Alignment::CENTER}}, yoursPoint, bright);
 
 	// Start below the "Your Ships" label, and draw them.
 	Point point(
 		Screen::Right() - SIDEBAR_WIDTH / 2 - 93,
-		Screen::Top() + SIDEBAR_WIDTH / 2 - sidebarSmoothScroll + 40 - 93);
+		Screen::Top() + SIDEBAR_WIDTH / 2 + sidebarScroll.AnimatedValue() + 40 - 93);
 
 	const Planet *here = player.GetPlanet();
 	int shipsHere = 0;
@@ -813,12 +792,12 @@ void ShopPanel::DrawShipsSidebar()
 		font.Draw({space, {SIDEBAR_WIDTH - 20, Alignment::RIGHT}}, point, bright);
 		point.Y() += 20.;
 	}
-	maxSidebarScroll = max(0., point.Y() + sidebarSmoothScroll - Screen::Bottom() + BUTTON_HEIGHT);
+	sidebarScroll.SetMaxValue(max(0., point.Y() - sidebarScroll.AnimatedValue() - Screen::Bottom() + BUTTON_HEIGHT));
 
 	PointerShader::Draw(Point(Screen::Right() - 10, Screen::Top() + 10),
-		Point(0., -1.), 10.f, 10.f, 5.f, Color(sidebarScroll > 0 ? .8f : .2f, 0.f));
+		Point(0., -1.), 10.f, 10.f, 5.f, Color(!sidebarScroll.IsScrollAtMin() ? .8f : .2f, 0.f));
 	PointerShader::Draw(Point(Screen::Right() - 10, Screen::Bottom() - 80),
-		Point(0., 1.), 10.f, 10.f, 5.f, Color(sidebarScroll < maxSidebarScroll ? .8f : .2f, 0.f));
+		Point(0., 1.), 10.f, 10.f, 5.f, Color(!sidebarScroll.IsScrollAtMax() ? .8f : .2f, 0.f));
 }
 
 
@@ -829,7 +808,7 @@ void ShopPanel::DrawDetailsSidebar()
 	const Color &line = *GameData::Colors().Get("dim");
 	const Color &back = *GameData::Colors().Get("shop info panel background");
 
-	UpdateSmoothScroll(infobarScroll, infobarSmoothScroll);
+	infobarScroll.Step();
 
 	FillShader::Fill(
 		Point(Screen::Right() - SIDEBAR_WIDTH - INFOBAR_WIDTH, 0.),
@@ -842,16 +821,16 @@ void ShopPanel::DrawDetailsSidebar()
 
 	Point point(
 		Screen::Right() - SIDE_WIDTH + INFOBAR_WIDTH / 2,
-		Screen::Top() + 10 - infobarSmoothScroll);
+		Screen::Top() + 10 + infobarScroll.AnimatedValue());
 
 	int heightOffset = DrawDetails(point);
 
-	maxInfobarScroll = max(0., heightOffset + infobarSmoothScroll - Screen::Bottom());
+	infobarScroll.SetMaxValue(max(0., heightOffset - infobarScroll.AnimatedValue() - Screen::Bottom()));
 
 	PointerShader::Draw(Point(Screen::Right() - SIDEBAR_WIDTH - 10, Screen::Top() + 10),
-		Point(0., -1.), 10.f, 10.f, 5.f, Color(infobarScroll > 0 ? .8f : .2f, 0.f));
+		Point(0., -1.), 10.f, 10.f, 5.f, Color(!infobarScroll.IsScrollAtMin() ? .8f : .2f, 0.f));
 	PointerShader::Draw(Point(Screen::Right() - SIDEBAR_WIDTH - 10, Screen::Bottom() - 10),
-		Point(0., 1.), 10.f, 10.f, 5.f, Color(infobarScroll < maxInfobarScroll ? .8f : .2f, 0.f));
+		Point(0., 1.), 10.f, 10.f, 5.f, Color(!infobarScroll.IsScrollAtMax() ? .8f : .2f, 0.f));
 }
 
 
@@ -941,7 +920,7 @@ void ShopPanel::DrawMain()
 	const Sprite *collapsedArrow = SpriteSet::Get("ui/collapsed");
 	const Sprite *expandedArrow = SpriteSet::Get("ui/expanded");
 
-	UpdateSmoothScroll(mainScroll, mainSmoothScroll);
+	mainScroll.Step();
 
 	// Draw all the available items.
 	// First, figure out how many columns we can draw.
@@ -955,7 +934,7 @@ void ShopPanel::DrawMain()
 
 	const Point begin(
 		(Screen::Width() - columnWidth) / -2,
-		(Screen::Height() - TILE_SIZE) / -2 - mainSmoothScroll);
+		(Screen::Height() - TILE_SIZE) / -2 + mainScroll.AnimatedValue());
 	Point point = begin;
 	const float endX = Screen::Right() - (SIDE_WIDTH + 1);
 	double nextY = begin.Y() + TILE_SIZE;
@@ -1024,13 +1003,13 @@ void ShopPanel::DrawMain()
 
 	// What amount would mainScroll have to equal to make nextY equal the
 	// bottom of the screen? (Also leave space for the "key" at the bottom.)
-	maxMainScroll = max(0., nextY + mainSmoothScroll - Screen::Height() / 2 - TILE_SIZE / 2 +
-		VisibilityCheckboxesSize() + 40.);
+	mainScroll.SetMaxValue(max(0., nextY - mainScroll.AnimatedValue() - Screen::Height() / 2 - TILE_SIZE / 2 +
+		VisibilityCheckboxesSize() + 40.));
 
 	PointerShader::Draw(Point(Screen::Right() - 10 - SIDE_WIDTH, Screen::Top() + 10),
-		Point(0., -1.), 10.f, 10.f, 5.f, Color(mainScroll > 0 ? .8f : .2f, 0.f));
+		Point(0., -1.), 10.f, 10.f, 5.f, Color(!mainScroll.IsScrollAtMin() ? .8f : .2f, 0.f));
 	PointerShader::Draw(Point(Screen::Right() - 10 - SIDE_WIDTH, Screen::Bottom() - 10),
-		Point(0., 1.), 10.f, 10.f, 5.f, Color(mainScroll < maxMainScroll ? .8f : .2f, 0.f));
+		Point(0., 1.), 10.f, 10.f, 5.f, Color(!mainScroll.IsScrollAtMax() ? .8f : .2f, 0.f));
 }
 
 
@@ -1047,14 +1026,14 @@ int ShopPanel::DrawPlayerShipInfo(const Point &point)
 
 
 
-bool ShopPanel::DoScroll(double dy)
+bool ShopPanel::DoScroll(double dy, int steps)
 {
 	if(activePane == ShopPane::Info)
-		infobarScroll = max(0., min(maxInfobarScroll, infobarScroll - dy));
+		infobarScroll.Scroll(dy, steps);
 	else if(activePane == ShopPane::Sidebar)
-		sidebarScroll = max(0., min(maxSidebarScroll, sidebarScroll - dy));
+		sidebarScroll.Scroll(dy, steps);
 	else
-		mainScroll = max(0., min(maxMainScroll, mainScroll - dy));
+		mainScroll.Scroll(dy, steps);
 
 	return true;
 }
@@ -1078,11 +1057,11 @@ bool ShopPanel::SetScrollToTop()
 bool ShopPanel::SetScrollToBottom()
 {
 	if(activePane == ShopPane::Info)
-		infobarScroll = maxInfobarScroll;
+		infobarScroll = infobarScroll.MaxValue();
 	else if(activePane == ShopPane::Sidebar)
-		sidebarScroll = maxSidebarScroll;
+		sidebarScroll = sidebarScroll.MaxValue();
 	else
-		mainScroll = maxMainScroll;
+		mainScroll = mainScroll.MaxValue();
 
 	return true;
 }
@@ -1186,12 +1165,12 @@ void ShopPanel::MainAutoScroll(const vector<Zone>::const_iterator &selected)
 	const int topY = selected->Center().Y() - TILE_SIZE / 2;
 	const int offTop = topY + Screen::Bottom();
 	if(offTop < 0)
-		mainScroll += offTop;
+		mainScroll -= offTop;
 	else
 	{
 		const int offBottom = topY + TILE_SIZE - Screen::Bottom();
 		if(offBottom > 0)
-			mainScroll += offBottom;
+			mainScroll -= offBottom;
 	}
 }
 
@@ -1208,8 +1187,7 @@ void ShopPanel::MainLeft()
 	{
 		it = zones.end();
 		--it;
-		mainScroll = maxMainScroll;
-		mainSmoothScroll = maxMainScroll;
+		mainScroll = mainScroll.MaxValue();
 	}
 	else
 	{
@@ -1236,7 +1214,6 @@ void ShopPanel::MainRight()
 	{
 		it = zones.begin();
 		mainScroll = 0;
-		mainSmoothScroll = 0;
 	}
 	else
 		MainAutoScroll(it);
@@ -1266,8 +1243,7 @@ void ShopPanel::MainUp()
 	{
 		it = zones.end();
 		--it;
-		mainScroll = maxMainScroll;
-		mainSmoothScroll = maxMainScroll;
+		mainScroll = mainScroll.MaxValue();
 	}
 	else
 		MainAutoScroll(it);
@@ -1291,7 +1267,6 @@ void ShopPanel::MainDown()
 	if(it == zones.end())
 	{
 		mainScroll = 0;
-		mainSmoothScroll = 0;
 		selectedShip = zones.begin()->GetShip();
 		selectedOutfit = zones.begin()->GetOutfit();
 		return;
@@ -1305,7 +1280,6 @@ void ShopPanel::MainDown()
 	{
 		it = zones.begin();
 		mainScroll = 0;
-		mainSmoothScroll = 0;
 	}
 	else
 		MainAutoScroll(it);

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -83,7 +83,7 @@ protected:
 	virtual void DrawItem(const std::string &name, const Point &point) = 0;
 	virtual int DividerOffset() const = 0;
 	virtual int DetailWidth() const = 0;
-	virtual int DrawDetails(const Point &center) = 0;
+	virtual double DrawDetails(const Point &center) = 0;
 	virtual BuyResult CanBuy(bool onlyOwned = false) const = 0;
 	virtual void Buy(bool onlyOwned = false) = 0;
 	virtual bool CanSell(bool toStorage = false) const = 0;
@@ -165,9 +165,9 @@ protected:
 	const Outfit *selectedOutfit = nullptr;
 	// (It may be worth moving the above pointers into the derived classes in the future.)
 
-	ScrollVar<double> mainScroll = 0.;
-	ScrollVar<double> sidebarScroll = 0.;
-	ScrollVar<double> infobarScroll = 0.;
+	ScrollVar<double> mainScroll;
+	ScrollVar<double> sidebarScroll;
+	ScrollVar<double> infobarScroll;
 	ShopPane activePane = ShopPane::Main;
 	char hoverButton = '\0';
 

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Mission.h"
 #include "OutfitInfoDisplay.h"
 #include "Point.h"
+#include "ScrollVar.h"
 #include "ShipInfoDisplay.h"
 
 #include <map>
@@ -164,15 +165,9 @@ protected:
 	const Outfit *selectedOutfit = nullptr;
 	// (It may be worth moving the above pointers into the derived classes in the future.)
 
-	double mainScroll = 0.;
-	double mainSmoothScroll = 0;
-	double sidebarScroll = 0.;
-	double sidebarSmoothScroll = 0.;
-	double infobarScroll = 0.;
-	double infobarSmoothScroll = 0.;
-	double maxMainScroll = 0.;
-	double maxSidebarScroll = 0.;
-	double maxInfobarScroll = 0.;
+	ScrollVar<double> mainScroll = 0.;
+	ScrollVar<double> sidebarScroll = 0.;
+	ScrollVar<double> infobarScroll = 0.;
 	ShopPane activePane = ShopPane::Main;
 	char hoverButton = '\0';
 
@@ -201,7 +196,7 @@ private:
 
 	int DrawPlayerShipInfo(const Point &point);
 
-	bool DoScroll(double dy);
+	bool DoScroll(double dy, int steps = 5);
 	bool SetScrollToTop();
 	bool SetScrollToBottom();
 	void SideSelect(int count);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(EndlessSkyTests PRIVATE
 	unit/src/test_main.cpp
 	unit/src/test_point.cpp
 	unit/src/test_random.cpp
+	unit/src/test_scrollVar.cpp
 	unit/src/test_set.cpp
 	unit/src/test_ship.cpp
 	unit/src/test_template.txt

--- a/tests/unit/src/test_scrollVar.cpp
+++ b/tests/unit/src/test_scrollVar.cpp
@@ -1,0 +1,132 @@
+/* test_scrollVar.cpp
+Copyright (c) 2023 by thewierdnut
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "es-test.hpp"
+
+// Include only the tested class's header.
+#include "../../../source/ScrollVar.h"
+
+// ... and any system includes needed for the test file.
+
+namespace { // test namespace
+
+// #region mock data
+// #endregion mock data
+
+
+
+// #region unit tests
+TEST_CASE( "ScrollVar::ScrollVar()" ) {
+	ScrollVar<double> sv;
+	CHECK_FALSE(sv.Scrollable());
+	CHECK(sv == 0.0);
+	CHECK(sv.AnimatedValue() == 0.0);
+	CHECK(sv.MaxValue() == 0.0);
+}
+
+TEST_CASE( "ScrollVar::SetMaxValue()" ) {
+	ScrollVar<double> sv;
+	sv.SetMaxValue(10.0);
+	CHECK(sv.Scrollable());
+	CHECK(sv.IsScrollAtMin());
+	CHECK(!sv.IsScrollAtMax());
+	CHECK(sv == 0.0);
+	CHECK(sv.AnimatedValue() == 0.0);
+	CHECK(sv.MaxValue() == 10.0);
+}
+
+TEST_CASE( "ScrollVar::Scroll()" ) {
+	ScrollVar<double> sv;
+	sv.SetMaxValue(10.0);
+	sv.Scroll(5.0);
+	CHECK(sv.Scrollable());
+	CHECK(!sv.IsScrollAtMin());
+	CHECK(!sv.IsScrollAtMax());
+	CHECK(sv == 5.0);
+	CHECK(sv.AnimatedValue() == 0.0);
+	CHECK(sv.MaxValue() == 10.0);
+}
+
+TEST_CASE( "ScrollVar::Step()" ) {
+	ScrollVar<double> sv;
+	sv.SetMaxValue(10.0);
+	sv.Scroll(5.0);
+	CHECK(sv.Scrollable());
+	CHECK(!sv.IsScrollAtMin());
+	CHECK(!sv.IsScrollAtMax());
+	CHECK(sv == 5.0);
+	CHECK(sv.AnimatedValue() == 0.0);
+	CHECK(sv.MaxValue() == 10.0);
+	sv.Step();
+	CHECK(sv.AnimatedValue() == Approx(1.0));
+	sv.Step();
+	CHECK(sv.AnimatedValue() == Approx(2.0));
+	sv.Step();
+	CHECK(sv.AnimatedValue() == Approx(3.0));
+	sv.Step();
+	CHECK(sv.AnimatedValue() == Approx(4.0));
+	sv.Step();
+	CHECK(sv.AnimatedValue() == Approx(5.0));
+	sv.Step();
+	CHECK(sv.AnimatedValue() == Approx(5.0));
+}
+
+TEST_CASE( "ScrollVar::Clamp()" ) {
+	ScrollVar<double> sv;
+	sv.SetMaxValue(10.0);
+	sv.Scroll(15.0);
+
+	CHECK(sv.MaxValue() == 10.0);
+	CHECK(sv == 10.0);
+
+	sv.SetMaxValue(5.0);
+	CHECK(sv.MaxValue() == 5.0);
+	CHECK(sv == 5.0);
+}
+
+TEST_CASE( "ScrollVar::SetDisplaySize()" ) {
+	ScrollVar<double> sv;
+	sv.SetMaxValue(10.0);
+	sv.SetDisplaySize(10);
+	CHECK(!sv.Scrollable());
+
+	sv.SetDisplaySize(5.0);
+	CHECK(sv.Scrollable());
+	CHECK(sv.IsScrollAtMin());
+	CHECK(!sv.IsScrollAtMax());
+
+	sv.Scroll(10.0);
+	CHECK(!sv.IsScrollAtMin());
+	CHECK(sv.IsScrollAtMax());
+	CHECK(sv == 5.0);
+}
+
+// Test code goes here. Preferably, use scenario-driven language making use of the SCENARIO, GIVEN,
+// WHEN, and THEN macros. (There will be cases where the more traditional TEST_CASE and SECTION macros
+// are better suited to declaration of the public API.)
+
+// When writing assertions, prefer the CHECK and CHECK_FALSE macros when probing the scenario, and prefer
+// the REQUIRE / REQUIRE_FALSE macros for fundamental / "validity" assertions. If a CHECK fails, the rest
+// of the block's statements will still be evaluated, but a REQUIRE failure will exit the current block.
+
+// #endregion unit tests
+
+// #region benchmarks
+
+// #endregion benchmarks
+
+
+
+} // test namespace


### PR DESCRIPTION
## Summary
This PR switches the shop panel over to using  `ScrollVar`, and skips the animation when using the mouse to drag the panes. 

## Testing Done
Tested using dragging, keyboard arrows, and mouse wheel in the shipyard, outfitter and plugin preferences pane.
Added a new unit test for ScrollVar.h

## Performance Impact
N/A
