### PR TITLE
fix(typo): Add missing punctuation in FW

### DIFF
--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -379,7 +379,7 @@ mission "FW Syndicate Diplomacy 1B"
 				goto remington
 			
 			label stand
-			`	You take a step into Remington's path as Alondo boards your ship. Remington stops face-to-face with you. "What, a guy can't talk to an old friend?" he says while looking over your shoulder`
+			`	You take a step into Remington's path as Alondo boards your ship. Remington stops face-to-face with you. "What, a guy can't talk to an old friend?" he says while looking over your shoulder.`
 			label remington
 			choice
 				`	"He's clearly not interested."`


### PR DESCRIPTION
Picked up this really cool game called Endless Sky and started helping these green Free Worlds dudes, noticed this missing punctuation mark.

~~I thought I fixed this in #7647. The typo was in fact a few lines away and I didn't notice it.~~