### PR TITLE
fix(content): Avoid mentioning that the player invaded Greenrock with Tomek when they did not invade Greenrock

### DIFF
--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -1429,7 +1429,6 @@ mission "FW Pirates: Attack 2"
 		dialog `You've landed on <planet>, but there are still pirates defending the system. All pirates in the system must be eliminated before <planet> can be taken.`
 	on complete
 		event "fw suppressed Greenrock"
-		set "fw greenrock invader"
 		log "Disobeyed the Free Worlds Senate by helping to launch an attack on the pirate hub world of Greenrock. Captured the planet after a massive battle, but it is unclear how long the Free Worlds can afford to keep them subdued by force."
 		conversation
 			`As the remaining invasion fleet comes in for a landing on <origin>, you spot small pirate ships scattering from the spaceport, not into space, but instead into the far reaches of the Greenrock wilderness. When you reach the spaceport, there is a wild mix of emotions from the locals who remained. Some spit at you and curse you out. Others thank you for driving off the pirates, even if only temporarily. Others still thank you for freeing them and ask for transportation off-world before the slavers return; Greenrock is the hub of the underground slave trade in the galaxy, and it seems in the confusion and rush for some criminals to escape the spaceport, they left their slaves behind.`

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -1429,6 +1429,7 @@ mission "FW Pirates: Attack 2"
 		dialog `You've landed on <planet>, but there are still pirates defending the system. All pirates in the system must be eliminated before <planet> can be taken.`
 	on complete
 		event "fw suppressed Greenrock"
+		set "fw greenrock invader"
 		log "Disobeyed the Free Worlds Senate by helping to launch an attack on the pirate hub world of Greenrock. Captured the planet after a massive battle, but it is unclear how long the Free Worlds can afford to keep them subdued by force."
 		conversation
 			`As the remaining invasion fleet comes in for a landing on <origin>, you spot small pirate ships scattering from the spaceport, not into space, but instead into the far reaches of the Greenrock wilderness. When you reach the spaceport, there is a wild mix of emotions from the locals who remained. Some spit at you and curse you out. Others thank you for driving off the pirates, even if only temporarily. Others still thank you for freeing them and ask for transportation off-world before the slavers return; Greenrock is the hub of the underground slave trade in the galaxy, and it seems in the confusion and rush for some criminals to escape the spaceport, they left their slaves behind.`

--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -1451,7 +1451,7 @@ mission "FW Bloodsea 1.1"
 		conversation
 			`The local leaders are unwilling to meet aboard your ship, and Alondo is afraid you will be ambushed if you venture too far away from it, so eventually they agree to set up a tent on the landing pad next to yours and meet there. Outside, a storm is raging, the rain mixing with salt spray from the blood-red ocean nearby.`
 			branch peaceful
-				not "event: fw suppressed Greenrock"
+				not "fw greenrock invader"
 			`	Most of the leaders grimace at the sight of you. "What is the invader doing here?" one of them asks to Alondo.`
 			`	"Captain <last> was only following orders, but the officer responsible for giving those orders has been justly punished," Alondo says. "We come in peace this time." The leaders don't seem convinced with that answer, but they agree to continue.`
 			label peaceful

--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -1468,7 +1468,7 @@ mission "FW Bloodsea 1.1"
 			`	"So, we attack them?" you ask.`
 			label invade
 			branch hostile
-				not "event: fw suppressed Greenrock"
+				not "fw greenrock invader"
 			`	"They didn't seem very happy about you doing that the first time. But..." Alondo pauses for a moment.`
 			label hostile
 			`	"That's certainly the simpler option," he says. "Tomek may have been punished for disobeying the Senate's orders, but we're in a different situation now. Our numbers have swelled because of our victories and new territory, and we now have the Dreadnoughts at our disposal, so occupying Bloodsea is now a viable option.`

--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -1451,7 +1451,7 @@ mission "FW Bloodsea 1.1"
 		conversation
 			`The local leaders are unwilling to meet aboard your ship, and Alondo is afraid you will be ambushed if you venture too far away from it, so eventually they agree to set up a tent on the landing pad next to yours and meet there. Outside, a storm is raging, the rain mixing with salt spray from the blood-red ocean nearby.`
 			branch peaceful
-				not "fw greenrock invader"
+				not "FW Pirates: Attack 2: done"
 			`	Most of the leaders grimace at the sight of you. "What is the invader doing here?" one of them asks to Alondo.`
 			`	"Captain <last> was only following orders, but the officer responsible for giving those orders has been justly punished," Alondo says. "We come in peace this time." The leaders don't seem convinced with that answer, but they agree to continue.`
 			label peaceful
@@ -1468,7 +1468,7 @@ mission "FW Bloodsea 1.1"
 			`	"So, we attack them?" you ask.`
 			label invade
 			branch hostile
-				not "fw greenrock invader"
+				not "FW Pirates: Attack 2: done"
 			`	"They didn't seem very happy about you doing that the first time. But..." Alondo pauses for a moment.`
 			label hostile
 			`	"That's certainly the simpler option," he says. "Tomek may have been punished for disobeying the Senate's orders, but we're in a different situation now. Our numbers have swelled because of our victories and new territory, and we now have the Dreadnoughts at our disposal, so occupying Bloodsea is now a viable option.`


### PR DESCRIPTION
**Bug fix**
## Summary
I went to Bloodsea for the mission `"FW Bloodsea 1.1"` and got the dialogue labelling me an "invader" when I didn't attack Greenrock with Tomek in `"FW Pirates: Attack 2"`. It turns out that that branch occurs if you have the event `"fw suppressed Greenrock"`, which always occurs no matter what you do. This dialogue only appears if you have done `"FW Pirates: Attack 2"` now.

## Save File
[Tricia McMillan~3016-10-23 Bloodsea condition.txt](https://github.com/endless-sky/endless-sky/files/13840121/Tricia.McMillan.3016-10-23.Bloodsea.condition.txt)

Here's my current save originating from New Tibet. ~~Yes, it's a Hitchiker's Guide character. Also don't judge my Marauder Falcon.~~

## Testing Done
~~Will be done. Pinky promise.~~ Of course it works.