### PR TITLE
feat(content): Gegno Intro Content Adjustments (separated from #8750)

### DIFF
--- a/data/gegno/gegno intro missions.txt
+++ b/data/gegno/gegno intro missions.txt
@@ -60,7 +60,7 @@ mission "First Contact: Gegno Vi"
 					goto watch
 				`	(Try to help the alien defeat the beast.)`
 			label help
-			`	You aim your sidearm at the beast, preparing to fire. Instead of digging back under the surface, the beast continues to thrash about where it is while the alien batters it down with their spear weapon. Making sure you don't accidentally hit them, you hold your breath and wait until the right moment comes, aiming for the creature's head. The flailing creature begins to get closer, and your pulse begins to race. A gust of sand blasts directly towards you, and once it clears you fire your weapon. A laser shot flies directly into the face of the beast.`
+			`	You aim your sidearm at the beast, preparing to fire. Instead of digging back under the surface, the beast continues to thrash about where it is while the alien batters it down with their spear weapon. Making sure you don't accidentally hit them, you hold your breath and wait until the right moment comes, aiming for the creature's head. The flailing creature begins to get closer, and your pulse begins to race. A gust of sand blasts directly towards you, and once it clears you fire your weapon. A shot flies directly into the face of the beast.`
 			`	Much to your dismay, the shot almost immediately ricochets off of it. You watch as the massive monster tumbles over you, just barely leaping into the air above. The monster plunges into the earth behind you, and you fall to your back with the wind knocked out of you. You raise your sidearm once more. The creature explodes out of the ground with its gaping mouth pointed upward to the sky. With shaking hands, you take aim once again and pull the trigger.`
 			`	A loud, cannon-like bang follows, but it most certainly did not come from your weapon. The beast before you falls downward in a cloud of black smoke, blasting sand and rubble everywhere with a thud. Once you come to your senses, you see the alien marching out of the creature's mouth.`
 			choice
@@ -118,7 +118,7 @@ mission "First Contact: Gegno Vi"
 					goto observe
 				`	(Assist the Vi in defeating the beast.)`
 			label assist
-			`	You bring your sidearm up to a firing position and wait for the beast. Once again, it jumps out of the sand in an incredible display, but instead of digging back under the surface, the beast continues to thrash about where it is while the Vi batters it down with their spear weapon. Making sure you don't accidentally hit them, you hold your breath and wait until the right moment comes, aiming for the creature's head. The flailing creature begins to get closer, and your pulse begins to race. A gust of sand blasts directly towards you, and once it clears you fire your weapon. A laser shot flies directly into the face of the beast.`
+			`	You bring your sidearm up to a firing position and wait for the beast. Once again, it jumps out of the sand in an incredible display, but instead of digging back under the surface, the beast continues to thrash about where it is while the Vi batters it down with their spear weapon. Making sure you don't accidentally hit them, you hold your breath and wait until the right moment comes, aiming for the creature's head. The flailing creature begins to get closer, and your pulse begins to race. A gust of sand blasts directly towards you, and once it clears you fire your weapon. A shot flies directly into the face of the beast.`
 			`	Much to your dismay, the shot almost immediately ricochets off of it. You watch as the massive monster tumbles over you, just barely leaping into the air above. The monster plunges into the earth behind you, and you fall to your back with the wind knocked out of you. You raise your sidearm once more. The creature explodes out of the ground with its gaping mouth pointed upward to the sky. With shaking hands, you take aim once again and pull the trigger.`
 			`	A loud, cannon-like bang follows, but it most certainly did not come from your weapon. The beast before you falls downward in a cloud of black smoke, blasting sand and rubble everywhere with a thud. Once you come to your senses, you see the Vi marching out of the creature's mouth.`
 			choice
@@ -260,15 +260,8 @@ mission "Visit Quarg in Gegno Space"
 		personality staying
 		system "Heutesl"
 		fleet "Scin Warfleet"
-	npc
-		government "Gegno Scin (Neutral)"
-		personality surveillance
-		system "Heutesl"
-		fleet
-			names "gegno scin"
-			variant
-				"Tridymite"
-				
+
+
 mission "Discover Hostile Quarg"
 	invisible
 	landing
@@ -308,7 +301,7 @@ mission "Giaru Gegno: Quarg Contact"
 		conversation
 			branch "has met gegno"
 				has "Visit Quarg in Gegno Space: offered"
-				
+
 			"After jumping through several systems of many alien ships, a Quarg ringworld is a surprisingly familiar sight to you. From the looks of it, this is a fully complete ringworld, a true sight to behold. Trillions of Quarg probably inhabit this ring, but what's more interesting to your eye is that some other aliens are also present. They too are humanoid, and the most common figures you come across are either slightly above or below an average human's height. Their skin is a smooth, light gray, and adorned with different sorts of leather that remind you of medieval human clothing."
 			`	The mood here is eerie as the Quarg here move in an unusually quiet manner. They are dismissive of the other species walking about, who are equally as dismissive of you. The strange atmosphere around you is finally broken when a few Quarg start to advance towards you, moving much quicker than the rest. After some unidentifiable discussion and gestures between themselves, one of them motions you to follow them.`
 				goto "walking"
@@ -381,7 +374,7 @@ mission "Giaru Gegno: Quarg Contact"
 				`	"Thank you for the information."`
 					goto end
 				`	"It seems that you do not like the paths they've chosen."`
-			`	The Quarg stands up, but as it does so, you watch as a few marks on its otherwise gray skin shift into blue hues with faint traces of purple, though they fade away shortly after. "It is not in our prosperous grasp to persuade the Gegno, as once we did attempt to. They would ensure conflict with us should we interfere, and we have no desire to witness an imperiled uprising of such a sort once more." It pauses for an extended time, then gestures you to stand up as well.`
+			`	The Quarg stands up, but as it does so, you watch as a few marks on its otherwise gray skin shift into blue hues with faint traces of purple, though they fade away shortly after. "It is not in our prosperous grasp to persuade the Gegno, as once we did attempt to. They threaten conflict with us should we interfere, and we have no desire to witness an imperiled uprising of such a sort once more." It pauses for an extended time, then gestures you to stand up as well.`
 			
 			branch "interacted with outsider"
 				has "Visit Quarg in Gegno Space: offered"
@@ -456,11 +449,12 @@ mission "Vi Augen"
 	to complete
 		never
 
-# Gegno Defense Trigger
+
+# Gegno Genocide Trigger
 
 mission "Gegno Genocide Defense"
-	landing
 	invisible
+	landing
 	to offer
 		"reputation: Gegno" < -10
 	to complete
@@ -469,9 +463,9 @@ mission "Gegno Genocide Defense"
 		fail "First Contact: Gegno Vi"
 		fail "Visit Quarg in Gegno Space"
 		fail "Vi Augen"
-		"reputation: Gegno" = -100
-		"reputation: Gegno Vi" = -100
-		"reputation: Gegno Scin" = -100
+		"reputation: Gegno" = -1000
+		"reputation: Gegno Vi" = -1000
+		"reputation: Gegno Scin" = -1000
 		event "gegno: unified defense"
 		conversation
 			`As soon as you land your ship, you suddenly receive an incoming hail. "It was incredibly unwise to engage in the unnecessary destruction of noncombatants belonging to a species not of your own." You recognize the voice belonging to that of a Quarg, though it sounds quite displeased. "A species that is still learning from themselves is vulnerable to outside influence, and your aggressive actions against civilians of the Gegno have resulted in needless events."`
@@ -498,7 +492,6 @@ mission "Gegno Genocide Defense"
 		personality heroic vindictive staying
 		system "Heutesl"
 		ship "Augen" "Vytii Yrrlausei"
-
 
 
 # Gegno Hunter Fleets
@@ -557,7 +550,6 @@ mission "Gegno Hunter Fleets"
 				"Hornfel (Heavy Weapons)"
 				"Eclogite" 3
 				"Coesite" 6
-
 
 
 # Gegno Vi Duels

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -433,35 +433,6 @@ government "Gegno Vi (Duelist B)"
 		board 0.5
 		destroy 0.3
 
-# Gegno governments that are always hostile but do not affect the original governments.
-government "Gegno Vi (Combative)"
-	swizzle 0
-	"display name" "Gegno Vi"
-	language "Gegno"
-	color "governments: Gegno Vi"
-
-	"player reputation" -1
-	"crew attack" 1.3
-	"crew defense" 1.5
-	"attitude toward"
-		"Gegno Scin" -0.01
-	"penalty for"
-		assist 0
-
-government "Gegno Scin (Combative)"
-	swizzle 18
-	"display name" "Gegno Scin"
-	language "Gegno"
-	color "governments: Gegno Scin"
-
-	"player reputation" -1
-	"crew attack" 1.2
-	"crew defense" 1.4
-	"attitude toward"
-		"Gegno Vi" -0.01
-	"penalty for"
-		assist 0
-
 
 color "governments: Hai" .86 .48 .79
 

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -295,6 +295,7 @@ government "Free Worlds that won't enter wormhole"
 	"hostile hail" "hostile free worlds"
 	raid "pirate raid"
 
+
 government "Gegno"
 	swizzle 0
 	language "Gegno"
@@ -310,6 +311,7 @@ government "Gegno"
 	"penalty for"
 		assist 0
 		provoke 10
+		destroy 10
 
 color "governments: Gegno Scin" .67 .73 .44
 
@@ -326,6 +328,9 @@ government "Gegno Scin"
 		"Gegno Vi" -0.01
 	"penalty for"
 		assist 0
+		disable 0.3
+		board 0.5
+		destroy 0.3
 
 color "governments: Gegno Vi" .68 .4 .4
 
@@ -339,10 +344,14 @@ government "Gegno Vi"
 	"crew defense" 1.5
 	"attitude toward"
 		"Gegno" 1
+		"Gegno Vi (Duelist A)" 1
+		"Gegno Vi (Duelist B)" 1
 		"Gegno Scin" -0.01
 	"penalty for"
 		assist 0
-
+		disable 0.3
+		board 0.5
+		destroy 0.3
 
 # Gegno Scin and Vi governments that do not fight each other.
 government "Gegno Scin (Neutral)"
@@ -358,10 +367,12 @@ government "Gegno Scin (Neutral)"
 		"Gegno" 1
 	"penalty for"
 		assist 0
+		disable 0.3
+		board 0.5
+		destroy 0.3
 	"foreign penalties for"
 		"Gegno"
 
-	
 government "Gegno Vi (Neutral)"
 	"display name" "Gegno Vi"
 	swizzle 0
@@ -375,9 +386,11 @@ government "Gegno Vi (Neutral)"
 		"Gegno" 1
 	"penalty for"
 		assist 0
+		disable 0.3
+		board 0.5
+		destroy 0.3
 	"foreign penalties for"
 		"Gegno"
-
 
 # Gegno Vi governments used for dueling.
 government "Gegno Vi (Duelist A)"
@@ -396,6 +409,9 @@ government "Gegno Vi (Duelist A)"
 		"Gegno Vi (Duelist B)" -0.01
 	"penalty for"
 		assist 0
+		disable 0.3
+		board 0.5
+		destroy 0.3
 
 government "Gegno Vi (Duelist B)"
 	swizzle 0
@@ -413,6 +429,39 @@ government "Gegno Vi (Duelist B)"
 		"Gegno Vi (Duelist A)" -0.01
 	"penalty for"
 		assist 0
+		disable 0.3
+		board 0.5
+		destroy 0.3
+
+# Gegno governments that are always hostile but do not affect the original governments.
+government "Gegno Vi (Combative)"
+	swizzle 0
+	"display name" "Gegno Vi"
+	language "Gegno"
+	color "governments: Gegno Vi"
+
+	"player reputation" -1
+	"crew attack" 1.3
+	"crew defense" 1.5
+	"attitude toward"
+		"Gegno Scin" -0.01
+	"penalty for"
+		assist 0
+
+government "Gegno Scin (Combative)"
+	swizzle 18
+	"display name" "Gegno Scin"
+	language "Gegno"
+	color "governments: Gegno Scin"
+
+	"player reputation" -1
+	"crew attack" 1.2
+	"crew defense" 1.4
+	"attitude toward"
+		"Gegno Vi" -0.01
+	"penalty for"
+		assist 0
+
 
 color "governments: Hai" .86 .48 .79
 

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -205,6 +205,7 @@ planet Arroharg
 	description `Arroharg is a low-gravity moon that the Quarg have converted to some sort of harvesting grounds. Massive machines that dwarf your ship seem to be displacing mountainous formations while smaller ones collect from the zones left behind. Most of the architecture here is Quarg-like and is not designed in a way that welcomes visitors very comfortably. The lower levels of the outpost seem to dig deeper into the surface of the moon, but the farther they go down the more complex they become. There's no telling how deep into the moon they go, as they are restricted to anyone but the Quarg.`
 	spaceport `A few Quarg greet you with astonished expressions, but kindly assist you in anything you have trouble with due to the spaceport being designed for them. They communicate mostly in gestures and facial expressions, although this is sometimes hard to decipher. It seems they aren't used to outside visitors here and don't speak your language.`
 	government "Quarg (Gegno)"
+	"required reputation" 1
 	bribe 0
 	security 0.9
 
@@ -1027,7 +1028,7 @@ planet "Dueyu Eitch"
 	shipyard "Gegno Intermediate"
 	outfitter "Gegno Basic"
 	outfitter "Gegno Intermediate"
-	"required reputation" 1
+	"required reputation" 3
 	bribe 0
 	security 0
 
@@ -1117,7 +1118,7 @@ planet "Ef Aourtdye"
 	shipyard "Gegno Advanced"
 	outfitter "Gegno Basic"
 	outfitter "Gegno Intermediate"
-	"required reputation" 1
+	"required reputation" 2
 	bribe 0
 	security 0
 
@@ -1696,6 +1697,7 @@ planet "Giaru Gegno"
 	description `	Despite seeing numerous non-Quarg ships before landing on the ring, you are only guided around parts of the ring where they are not present.`
 	spaceport `There are probably many hundreds of billions of Quarg on this ring, and yet it still manages to feel spacious and lightly populated. They shift past you at a normal walking pace for a Quarg, and don't give you much attention except from the occasional uninterested glance or two. There seems to be little conversation and effort to accommodate you as the only non-Quarg in sight. It seems areas containing the aliens from nearby are off-limits to you.`
 	government "Quarg (Gegno)"
+	"required reputation" 1
 	bribe 0
 	security 1
 
@@ -2162,7 +2164,7 @@ planet "Iemn Eitch"
 	description `Although too cold for a proper civilization, Iemn Eitch has been extensively used in the past as an outpost for the growing Gegno space race. As one of their first few explored worlds, antique-looking architecture is scattered about the surface and looks significantly different to structures found on Dueyu Eitch, perhaps due to the nature of construction in an unfamiliar environment. A few large shipyard-esque platforms continue to service a small number of still active Gegno generation vessels from times past, presumably at a much slower pace than during the earliest days of their space colonization.`
 	spaceport `	Rather than a traditional spaceport, a large and extensive shipyard engulfs a portion of the moon's surface, cluttered with numerous structures from an early colonial period. Several immense hangars, mostly reduced to their bare metal frames, house various archaic spacecraft of times past, with a few of them still servicing the remaining active vessels.`
 	government Gegno
-	"required reputation" 1
+	"required reputation" 2
 	bribe 0
 	security 0
 
@@ -3553,6 +3555,7 @@ planet Ruelogakk
 	description `This Quarg station, although pristine and kept in high order, has been constructed rather recently compared to the complete ringworld the next system over. It appears to be purposed as some sort of resting spot for tourists, though very few docking bays are in use. A hauntingly low number of Quarg are seen walking about the brightly lit abstract hallways of glass with only the faintest hum of machinery.`
 	spaceport `Only a few small alien transports can be seen docked with this station, hooked up to strange devices that seem to match the designs of their ships. Other than that, the alien's presence here seems to be kept at an extreme minimum, with at most one or two seen passing by occasionally.`
 	government "Quarg (Gegno)"
+	"required reputation" 1
 	bribe 0
 	security 0.9
 
@@ -4414,6 +4417,7 @@ planet Truklar
 	description `This world, like others the Quarg live on, has noticeably lower gravity than humans are accustomed to. Several medium-sized extravagant villages are found nested deep within an oddly shaped glass structure, and it is a beautiful sight to behold. Many different, smaller biomes also contain wondrous flora and fauna that don't seem to be native to this particular moon. Despite all of this, structures were not built in accustom to visitors such as the nearby aliens, who find it hard navigating through the narrow hallways.`
 	spaceport `Most of the spaceport is automated Quarg robotics that do not provide any interaction with you besides basic spaceport tasks such as refueling. Occasionally, one of these robots, visually similar to the Quarg themselves, guide you throughout the visitable zones of the port. Otherwise, your presence here is mostly overlooked.`
 	government "Quarg (Gegno)"
+	"required reputation" 1
 	bribe 0
 	security 0.9
 

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -33033,8 +33033,8 @@ system Vesvii
 	minables gold 6 2.4
 	minables iron 9 1.7
 	minables lead 11 2.1
-	fleet "Vi Warfleet" 1100
-	fleet "Scin Warfleet" 1000
+	fleet "Vi Warfleet" 1200
+	fleet "Scin Warfleet" 1200
 	object
 		sprite star/k5-old
 		distance 81.5


### PR DESCRIPTION
## Summary

As #8750 is quite a bit of extra content as-is, I've split off the changes that PR makes to base Gegno content to this one as they are changes that should be changed regardless of the additional content. These changes include:

- A few word changes in existing missions.
- A few data file space consistency fixes.
- A few fleet frequency edits.
- A few reputation edits to missions.
- Edits to the two main Gegno governments that more properly reflect them. (I.e., care less about destruction or disabling, more about stealing and capturing.)
- Adds/adjusts required reputation for Gegno civilian planets for the upcoming content.
- Removal of an npc who's purpose was shifted elsewhere in the upcoming content.