### PR TITLE
"What human beings want" to "what humans want"

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -233,7 +233,7 @@ mission "Wanderers: Translation Machine"
 				`	(Ask her what they are talking about.)`
 				`	(Wait for a break in the conversation.)`
 			`	She holds up a paw to you while speaking a few more sentences to them, then says, "They are saying that the Hai are attacking them, and they want to know why. It must be the Unfettered who are raiding them, and I am trying to explain that the Unfettered do not represent the Hai people as a whole."`
-			`	They continue talking for a while, and then the Wanderers ask you a question. Sayari translates, "They want to know what human beings want, and why you have come to their territory."`
+			`	They continue talking for a while, and then the Wanderers ask you a question. Sayari translates, "They want to know what humans want, and why you have come to their territory."`
 			choice
 				`	"I'm just an individual explorer. I don't represent my species or their governments."`
 					goto explorer


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses the bug/feature described in issue 

## Summary
The Wanderers wonder what the humans want from from them, through Sayari's translation, that they send a representative.

From both the Wanderers and Sayari, a Hai, they are inquiring the intentions of a third race, the Humans.

The appropriate wording should be along the line of "What do the Human want from us?".

I don't think they would refer to humans as "Human beings", because it emphasises an individual. The Wanderers are inquiring about humans as a collective whole.

