### PR TITLE
Make the "remnant cafeteria" news item show up

### DIFF
--- a/data/remnant/remnant news.txt
+++ b/data/remnant/remnant news.txt
@@ -282,6 +282,8 @@ news "remnant incomprehensible"
 
 
 news "remnant cafeteria"
+	location
+		government "Remnant"
 	name
 		word
 			"Spaceport"


### PR DESCRIPTION
**Bug fix**

## Summary
The "remnant cafeteria" news item has no "location" in its definition. This means it is never actually shown. From the wiki:
> `location` (optional): A [location filter](https://github.com/endless-sky/endless-sky/wiki/LocationFilters) that is used to identify on which planets this News message can appear. If not provided, or removed, then this news source will not be displayed anywhere.

And, yes, labelling it as "optional" even though the thing won't actually work without it is a bit strange, I'm assuming it's because it will not be considered malformed if no location is provided, as you can reasonably add, remove, or update the location filter through events. Though, this doesn't appear to be the intention here. No such events exists and the message in this news item was previously a part of the news item above it, being split by [this commit](https://github.com/endless-sky/endless-sky/pull/5209/commits/ab58605ff899d1ec860f74ecd7a066e895941ce7) in #5209, with no mention of any intention to prevent these messages from ever appearing.

This PR adds a location filter matching what the other Remnant news items have.

## Testing Done
Zero
