### PR TITLE
Update Ringworld Debris Quarg Conversation

### DIFF
--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -283,7 +283,6 @@ mission "Ringworld Debris: Quarg"
 				log "Asked the Quarg about the history of the Graveyard, and have learned about the previous inhabitants of the region, the Builders."
 			`	For the briefest moment, you see patches of skin all over the Quarg's body radically shift from the usual gray to red and blue, some spots mixing into purple, and you could have sworn you saw some part of the iris on its eyes "open" very slightly.`
 			`	After coming back to normal, it ponders for a second, then says, "It was in that system, and it was lost, millennia after the Builders had perished."`
-			label end
 			`	It doesn't seem too inclined on answering any more questions, and swiftly walks away.`
 				decline
 

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -279,17 +279,10 @@ mission "Ringworld Debris: Quarg"
 				`	"What happened to your ringworld in the Graveyard? Was it in the system I found that thing?"`
 				`	(Let the Quarg walk away.)`
 					decline
-			`	For the briefest moment, you see patches of skin all over the Quarg's body radically shift from the usual gray to red and blue, some spots mixing into purple, and you could have sworn you saw some part of the iris on its eyes "open" very slightly.`
-			branch pug
-				has "main plot completed"
 			action
 				log "Asked the Quarg about the history of the Graveyard, and have learned about the previous inhabitants of the region, the Builders."
-			`	After coming back to normal, it ponders for a second, then says, "It was in that system, and it was lost in a war, millennia after the Builders had perished."`
-				goto end
-			label pug
-			action
-				log "Asked the Quarg about the history of the Graveyard. Was told that the ringworld the Quarg had there was lost in their war with the Pug, and have learned about the previous inhabitants of the region, the Builders."
-			`	After coming back to normal, it ponders for a second, then says, "It was in that system, and it was lost in our war with the despicable Pug. When we tried to resist them. By then, the Builders had been gone for millennia."`
+			`	For the briefest moment, you see patches of skin all over the Quarg's body radically shift from the usual gray to red and blue, some spots mixing into purple, and you could have sworn you saw some part of the iris on its eyes "open" very slightly.`
+			`	After coming back to normal, it ponders for a second, then says, "It was in that system, and it was lost, millennia after the Builders had perished."`
 			label end
 			`	It doesn't seem too inclined on answering any more questions, and swiftly walks away.`
 				decline


### PR DESCRIPTION
**Content (Missions)**

Requested by Amazinite on the Discord.

## Summary
Changes the Quarg conversation in their Ringworld Debris mission to be more vague about the fate of the destroyed ringworld.
