### PR TITLE
Fix(code): Message Log, check if a message to compare exists

### DIFF
--- a/source/Messages.cpp
+++ b/source/Messages.cpp
@@ -39,7 +39,7 @@ void Messages::Add(const string &message, Importance importance)
 {
 	lock_guard<mutex> lock(incomingMutex);
 	incoming.emplace_back(message, importance);
-	if(!logged.size() || message != logged.front().first)
+	if(logged.empty() || message != logged.front().first)
 	{
 		logged.emplace_front(message, importance);
 		if(logged.size() > MAX_LOG)

--- a/source/Messages.cpp
+++ b/source/Messages.cpp
@@ -39,7 +39,7 @@ void Messages::Add(const string &message, Importance importance)
 {
 	lock_guard<mutex> lock(incomingMutex);
 	incoming.emplace_back(message, importance);
-	if(message != logged.front().first)
+	if(!logged.size() || message != logged.front().first)
 	{
 		logged.emplace_front(message, importance);
 		if(logged.size() > MAX_LOG)


### PR DESCRIPTION

**Bug fix**

This PR addresses the bug/feature described in issue #9674

## Summary
Adds a missing check otherwise you get a nullptr


## Testing Done
Launched on the same type of machine as in the issue, but that should not be related

