### PR TITLE
Fix(input): recognize release of caps lock(fast forward) even when game window is not in front.

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1183,7 +1183,7 @@ tip "Toggle fullscreen"
 	`Toggle whether the game is in fullscreen mode.`
 
 tip "Toggle fast-forward"
-	`Toggle a 3x speed fast-forward. Fast-forward may be automatically deactivated by the "Interrupt fast-forward" setting.`
+	`Toggle a 3x speed fast-forward. Fast-forward may be automatically deactivated by the "Interrupt fast-forward" setting. If the key is set to caps-lock it will also be updated when the game window is not in focus.`
 
 tip "Show help"
 	`Display the help dialogs that are relevant to your current UI panel and situation. Uses the same help dialogs from the "Reactivate first-time help" setting, forcing them to appear even if they have already appeared before.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1183,7 +1183,7 @@ tip "Toggle fullscreen"
 	`Toggle whether the game is in fullscreen mode.`
 
 tip "Toggle fast-forward"
-	`Toggle a 3x speed fast-forward. Fast-forward may be automatically deactivated by the "Interrupt fast-forward" setting. If the key is set to caps-lock it will also be updated when the game window is not in focus.`
+	`Toggle a 3x speed fast-forward. Fast-forward may be automatically deactivated by the "Interrupt fast-forward" setting. If the key is set to caps-lock then the caps-lock state will be used to determine the fast-forward state.`
 
 tip "Show help"
 	`Display the help dialogs that are relevant to your current UI panel and situation. Uses the same help dialogs from the "Reactivate first-time help" setting, forcing them to appear even if they have already appeared before.`

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -43,7 +43,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "TestContext.h"
 #include "UI.h"
 
-#include <SDL2/SDL_keycode.h>
 #include <chrono>
 #include <iostream>
 #include <map>

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -43,6 +43,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "TestContext.h"
 #include "UI.h"
 
+#include <SDL2/SDL_keycode.h>
 #include <chrono>
 #include <iostream>
 #include <map>
@@ -314,10 +315,18 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 			{
 				// The UI handled the event.
 			}
+			else if(event.type == SDL_KEYDOWN && !event.key.repeat
+					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD))
+					&& !Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD))
+			{
+				isFastForward = !isFastForward;
+			}
 		}
 
-		// Check if caps lock is active, if yes fast forward should be on.
-		isFastForward = SDL_GetModState() & KMOD_CAPS;
+		// Special case: If fastforward is on capslock, update on mod state and not
+		// on keypress.
+		if(Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD))
+			isFastForward = SDL_GetModState() & KMOD_CAPS;
 	};
 
 	// Game loop when running the game normally.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -43,6 +43,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "TestContext.h"
 #include "UI.h"
 
+#include <SDL2/SDL_keycode.h>
 #include <chrono>
 #include <iostream>
 #include <map>
@@ -314,11 +315,7 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 			{
 				// The UI handled the event.
 			}
-			else if(event.type == SDL_KEYDOWN && !event.key.repeat
-					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))
-			{
-				isFastForward = !isFastForward;
-			}
+			isFastForward = SDL_GetModState() & KMOD_CAPS;
 		}
 	};
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -43,7 +43,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "TestContext.h"
 #include "UI.h"
 
-#include <SDL2/SDL_keycode.h>
 #include <chrono>
 #include <iostream>
 #include <map>
@@ -315,8 +314,10 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 			{
 				// The UI handled the event.
 			}
-			isFastForward = SDL_GetModState() & KMOD_CAPS;
 		}
+
+		// Check if caps lock is active, if yes fast forward should be on.
+		isFastForward = SDL_GetModState() & KMOD_CAPS;
 	};
 
 	// Game loop when running the game normally.


### PR DESCRIPTION
**Bug fix**

as in: #5177

## Summary
ES only recognizes the caps lock while the game window is in front. This can lead to a situation where you switched windows, released caps lock, switch back and the game is still in fast forward.

I don't think this behavior is intended , so instead of only recognizing the key press, fast forward gets now updated per frame with SDL_GetModState , if it is on capslock

## Testing Done
Yes

## Performance Impact
N/A
