### PR TITLE
Output the reason why an integration test failed if it failed because of a segfault

### DIFF
--- a/tests/integration/RunIntegrationTest.cmake
+++ b/tests/integration/RunIntegrationTest.cmake
@@ -12,5 +12,6 @@ execute_process(COMMAND $ENV{ES_INTEGRATION_PREFIX} "${ES}" --config "${TEST_CON
     RESULT_VARIABLE TEST_RESULT)
 
 if(TEST_RESULT)
-    message(FATAL_ERROR "Integration test failed with '${TEST_RESULT}':\n${TEST_OUTPUT}")
+    string(STRIP "${TEST_OUTPUT}" TEST_OUTPUT_STRIPPED)
+    message(FATAL_ERROR "Integration test failed with '${TEST_RESULT}':\n${TEST_OUTPUT_STRIPPED}")
 endif()

--- a/tests/integration/RunIntegrationTest.cmake
+++ b/tests/integration/RunIntegrationTest.cmake
@@ -12,5 +12,5 @@ execute_process(COMMAND $ENV{ES_INTEGRATION_PREFIX} "${ES}" --config "${TEST_CON
     RESULT_VARIABLE TEST_RESULT)
 
 if(TEST_RESULT)
-    message(FATAL_ERROR "Integration test failed with:\n${TEST_OUTPUT}")
+    message(FATAL_ERROR "Integration test failed with '${TEST_RESULT}':\n${TEST_OUTPUT}")
 endif()


### PR DESCRIPTION
## Fix Details

#9246 was merged with failing integration tests because it wasn't clear from the error message what the problem was. Turns out it was a segmentation fault that didn't get caught by the output filter, so it was not shown to the user.

This PR emits the error reason in addition to the application output when an integration test fails. It would look like this for a segmentation fault:

```
Test project /home/user/endless-sky/build/linux
 1/41 Test  #1: Abort Take Off On Excess Outfits In Cargo Warning....***Failed    4.38 sec
CMake Error at integration/RunIntegrationTest.cmake:15 (message):
  Integration test failed with 'Segmentation fault':
```

Without this PR, the `'Segmentation fault'` part is not shown and thus it's impossible to know what caused the failure.

## Testing Done

Deliberately added a segfault to the game, and with this PR it is clear from the error message that a segfault occurred while running the integration test.

Oh and CI will also show it, because the fix hasn't been merged yet.

