### PR TITLE
Apply license definitions in variants

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -523,7 +523,7 @@ void Outfit::Add(const Outfit &other, int count)
 		if(fabs(attributes[at.first]) < EPS)
 			attributes[at.first] = 0.;
 	}
-
+	licenses.insert(licenses.end(), other.licenses.begin(), other.licenses.end());
 	for(const auto &it : other.flareSprites)
 		AddFlareSprites(flareSprites, it, count);
 	for(const auto &it : other.reverseFlareSprites)


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #8562 wherein the ship "add attributes" property could not add licenses.

## Summary
This works now:

```julia
ship "Base Name" "Variant Name"
     add attributes
        licenses
            "License Name Goes Here"
```

- fixes #8562

## Screenshots

```julia
ship "Archon" "Navy Archon"
	add attributes
		licenses
			Navy
	description `"Lieutenant, are we prepared for the Third Alpha War?"`
	description `	"Yes, sir. I think our new ships are up to the task."`
```

![add-attributes-licenses](https://github.com/endless-sky/endless-sky/assets/116329264/81752df7-40f5-4f07-a5c0-186027bd51ca)

## Usage examples
1. Custom ship variant with fancy stats requires a license.
2. One faction will sell a ship to anyone. Another faction requires a license to buy the same ship.

## Testing Done
1. Put this in [data/add-attributes-licenses.txt](https://github.com/endless-sky/endless-sky/files/13972226/add-attributes-licenses.txt)
2. Depart and land anywhere with a spaceport.
3. Visit the spaceport.
4. Fly to a planet with the "Basic Ships" shipyard. (Luna has that.)
5. Visit the shipyard and buy your Navy Archon, if you have the license and money for it.

## Save File

If you don't happen to have a save in the right spot, here's one:

[Friction Diction~3024-04-03 Main Campaign Done.txt](https://github.com/endless-sky/endless-sky/files/13972234/Friction.Diction.3024-04-03.Main.Campaign.Done.txt)

## Performance Impact
N/A
