### PR TITLE
fix(content): Disable Gegno Intro if player has not met the Quarg

### DIFF
--- a/data/gegno/gegno intro missions.txt
+++ b/data/gegno/gegno intro missions.txt
@@ -29,6 +29,7 @@ mission "First Contact: Gegno Vi"
 	passengers 1
 	to offer
 		not "Gegno Genocide Defense: offered"
+		has "First Contact: Quarg: offered"
 	on offer
 		conversation
 			branch "second encounter"
@@ -292,7 +293,6 @@ mission "Giaru Gegno: Quarg Contact"
 	landing
 	source "Giaru Gegno"
 	to offer
-		has "First Contact: Quarg: offered"
 		not "Gegno Genocide Defense: offered"
 	on offer
 		log "Factions" "Gegno" `The Gegno are a humanoid species to the galactic east of the core, split amongst themselves into branches. One branch is the Gegno Vi, who are spoken of to be strong and forceful brutes. The other is the Gegno Scin, mentioned to be progressers of research and technology. Apart from them, a majority of the Gegno's population consists of complacent civilians.`


### PR DESCRIPTION
This PR temporarily addresses the bug/feature described in issue #9611

## Summary
This PR introduces a temporary fix suggested by @warp-core to the Gegno Intro where in which if the player has not met the Quarg, the intro comes to an abrupt hault. The "First Contact: Quarg" requirement has been moved to the first Gegno mission.

As the Quarg conversation originally requires you having done the Quarg first contact in human space, if you skip out of human space to do the new content, you run into a wall and the mission series stops here until you go back to human space and meet the Quarg. Although this is an edge-case, it still can happen, and having no missions is preferable to broken missions.

Although this is a solution, in the future I wish to explore Quarg first contact missions, and instead of outright locking the player out, have varying branches in the conversations that change based on what Quarg you've met first. For instance, you could also have landed on the Efret Quarg ringworld before meeting the human Quarg, which results in no conversation, though that isn't breaking any mission chain.