### PR TITLE
fix(ui): Reset zoom modifier if "Landing zoom" is off

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -577,12 +577,12 @@ void Engine::Step(bool isActive)
 			else if(zoom.base > zoomTarget)
 				nextZoom.base = max(zoomTarget, zoom.base * (1. / (1. + zoomRatio)));
 		}
-		if(flagship && flagship->Zoom() < 1. && Preferences::Has("Landing zoom"))
+		if(flagship && flagship->Zoom() < 1.)
 		{
-			// Update the current zoom modifier if the flagship is landing or taking off.
 			if(!nextZoom.base)
 				nextZoom.base = zoom.base;
-			nextZoom.modifier = 1. + pow(1. - flagship->Zoom(), 2);
+			// Update the current zoom modifier if the flagship is landing or taking off.
+			nextZoom.modifier = Preferences::Has("Landing zoom") ? 1. + pow(1. - flagship->Zoom(), 2) : 1.;
 		}
 	}
 


### PR DESCRIPTION
## Fix Summary
Fixed an edge case when the Engine is loaded with Landing zoom enabled and then, before departing from the planet, Landing zoom is turned off. This results in broken zoom until you manually zoom in/out.

## Testing Done
Tested these cases: 
 - Landing zoom on -> Engine loaded -> takeoff,
 - on -> Engine -> off -> takeoff,
 - off -> Engine -> takeoff,
 - off -> Engine -> on -> takeoff.

Haven't noticed any buggy behavior.

## Performance Impact
N/A
