### PR TITLE
fix(mechanics): Always face the flight direction on takeoff

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1305,7 +1305,8 @@ void Ship::Place(Point position, Point velocity, Angle angle, bool isDeparting)
 {
 	this->position = position;
 	this->velocity = velocity;
-	this->Turn(angle);
+	this->angle = Angle();
+	Turn(angle);
 
 	// If landed, place the ship right above the planet.
 	// Escorts should take off a bit behind their flagships.


### PR DESCRIPTION
## Fix Summary
Sometimes (but not directly after a reload) when taking off the planet, my ship's flight and facing directions seem to differ randomly.

I think this may be caused by https://github.com/endless-sky/endless-sky/commit/ab87988b41db166d6c6c68380eada99258c85db2 replacing angle assignment with a function that adds the angle to the existing value; if the previous ship angle was non-zero, it corrupts the new value.

## Testing Done
Departed a few times with and without the patch.

## Performance Impact
N/A
