### PR TITLE
fix(content): Fix hai reveal check in "hai wormhole warning"

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4606,7 +4606,6 @@ mission "Hai Wormhole Warning"
 			has "First Contact: Unfettered: declined"
 		not "Block Hai Wormhole Warning: offered"
 		not "Wanderers: Alpha Surveillance E: offered"
-		not "Hai Leaks Response 1: offered"
 	on offer
 		log "Was pulled aside by a Navy officer and told to keep the wormhole to the Hai a secret. The Republic doesn't want the knowledge of the wormhole to be widespread, as that could cause chaos for both the Republic and the Hai."
 		conversation

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4606,6 +4606,7 @@ mission "Hai Wormhole Warning"
 			has "First Contact: Unfettered: declined"
 		not "Block Hai Wormhole Warning: offered"
 		not "Wanderers: Alpha Surveillance E: offered"
+		not "hr: meet the team"
 	on offer
 		log "Was pulled aside by a Navy officer and told to keep the wormhole to the Hai a secret. The Republic doesn't want the knowledge of the wormhole to be widespread, as that could cause chaos for both the Republic and the Hai."
 		conversation


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug that I found when looking at the hai wormhole warning mission.

## Summary
The hai wormhole warning mission checks if "Hai Leaks Response 1" is offered, even though that mission doesn't exist. This ~~removes that unnecessary check~~ replaces it with a check that actually works in the current version of the game.

## Screenshots
![image](https://github.com/endless-sky/endless-sky/assets/109186806/c18aa944-0b22-48e6-a11f-cc9617346897)

## Testing Done
Tested to make sure Hai Leaks Response 1 didn't exist.

## Save File
This save file can be used to test these changes:
[Test Pilot~Hai Wormhole Warning.txt](https://github.com/endless-sky/endless-sky/files/13994228/Test.Pilot.Hai.Wormhole.Warning.txt)