### PR TITLE
Fix "Visit void sprite planets" mission dialog

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -720,7 +720,7 @@ mission "Remnant: Void Sprites 3"
 			`	You also observe some void sprites leaving the planet, soaring upward on thermal updrafts. As they rise, their bodies swell to several times their original size, like an aerostat balloon gaining altitude. But clearly they have another form of propulsion as well, something akin to the antigravity repulsors that human ships use to travel from a planet's surface into orbit.`
 			`	After collecting some atmospheric samples for good measure, you prepare to return to <planet>. Hopefully the Archon will calm down once it sees that you have not attacked or disturbed the Sprites on either of these planets.`
 	on visit
-		dialog phrase "generic stopover on visit"
+		dialog phrase "generic missing stopover or cargo"
 	on complete
 		event "remnant: void sprite research" 20
 		log "Factions" "Void Sprites" `The "void sprites" are space-dwelling lifeforms. They are apparently not sentient. They evolved in the atmosphere of a gas giant, but have some biological mechanism for altering or reflecting gravity that allows them to fly into outer space, in the same way that human ships use antigravity to escape a planet's gravity well. The void sprites are not particularly powerful or dangerous creatures, but they are guarded by a Drak Archon.`


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #9567

## Summary
This changes the `on visit` dialog to `generic missing stopover or cargo`, so that if the player lands on Nenia without the necessary cargo being present (i.e. it was on one of their escorts that are not in the system), it gives the appropriate dialog and informs the player why the mission wasn't completed.
Thanks to @bMorgan01 and Amazinite for pointing the issue out and providing a solution, respectively.

## Testing Done
0

