### PR TITLE
feat(content): Add Missing Nest Mining Variant

### DIFF
--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -2881,7 +2881,6 @@ ship "Nest" "Nest (Sidewinder)"
 		Hyperdrive
 
 
-
 ship "Nest" "Nest (Miner)"
 	outfits
 		"Meteor Missile Launcher" 2

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -2886,8 +2886,9 @@ ship "Nest" "Nest (Miner)"
 	outfits
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 60
+		"Mining Laser Turret"
 		"Tractor Beam" 2
-		"Heavy Anti-Missile Turret" 2
+		"Heavy Anti-Missile Turret"
 		
 		"Asteroid Scanner"
 		"S3 Thermionic"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -2895,7 +2895,7 @@ ship "Nest" "Nest (Miner)"
 		"LP072a Battery Pack"
 		"D41-HY Shield Generator"
 		"Large Radar Jammer"
-		"Cargo Expansion" 2
+		"Cargo Expansion"
 		"Laser Rifle" 3
 		
 		"Capybara Reverse Thruster"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -2882,6 +2882,34 @@ ship "Nest" "Nest (Sidewinder)"
 
 
 
+ship "Nest" "Nest (Miner)"
+	outfits
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 60
+		"Tractor Beam" 2
+		"Heavy Anti-Missile Turret" 2
+		
+		"Asteroid Scanner"
+		"S3 Thermionic"
+		"LP072a Battery Pack"
+		"D41-HY Shield Generator"
+		"Large Radar Jammer"
+		"Cargo Expansion" 2
+		"Laser Rifle" 3
+		
+		"Capybara Reverse Thruster"
+		"Greyhound Plasma Thruster"
+		"Impala Plasma Steering"
+		"Scram Drive"
+	gun "Meteor Missile Launcher"
+	gun "Meteor Missile Launcher"
+	turret "Mining Laser Turret"
+	turret "Tractor Beam"
+	turret "Tractor Beam"
+	turret "Heavy Anti-Missile Turret"
+
+
+
 ship "Nighthawk" "Nighthawk (Raider)"
 	crew 28
 	outfits

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -523,7 +523,7 @@ void Outfit::Add(const Outfit &other, int count)
 		if(fabs(attributes[at.first]) < EPS)
 			attributes[at.first] = 0.;
 	}
-
+	licenses.insert(licenses.end(), other.licenses.begin(), other.licenses.end());
 	for(const auto &it : other.flareSprites)
 		AddFlareSprites(flareSprites, it, count);
 	for(const auto &it : other.reverseFlareSprites)


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This PR adds a mining variant of the Nest that is missing from #9621, pointed out by @SomeTroglodyte.
