### PR TITLE
feat(content): Reduce the spawn rate of Astral Cetaceans

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -2345,7 +2345,7 @@ system "Ae Ce L-332"
 	asteroids "large metal" 1 2.1
 	asteroids "medium rock" 11 3.6
 	minables unknown 1 2.7
-	fleet Astral 45000
+	fleet Astral 80000
 	object
 		sprite star/f-dwarf
 		period 10
@@ -17780,7 +17780,7 @@ system "Is Ce B-139"
 	asteroids "medium metal" 5 3.41
 	asteroids "large metal" 2 4.402
 	fleet "Vyrmeid (Plankton)" 300
-	fleet Astral 50000
+	fleet Astral 90000
 	object
 		sprite star/g8
 		period 40
@@ -17804,7 +17804,7 @@ system "Is Ce F-422"
 	asteroids "large rock" 9 2.262
 	asteroids "large metal" 1 3.783
 	fleet "Vyrmeid (Plankton)" 400
-	fleet Astral 50000
+	fleet Astral 100000
 	object
 		sprite star/a5
 		distance 52.236
@@ -17878,7 +17878,7 @@ system "Is Ce G-460"
 	minables silicon 6 10.214
 	minables unknown 2 2.5
 	fleet "Vyrmeid (Plankton)" 700
-	fleet Astral 50000
+	fleet Astral 120000
 	object
 		sprite star/k-dwarf
 		period 10
@@ -17925,7 +17925,7 @@ system "Is Ce J-591"
 	asteroids "large metal" 3 1.664
 	minables silicon 8 3.635
 	fleet "Vyrmeid (Plankton)" 450
-	fleet Astral 50000
+	fleet Astral 110000
 	object
 		sprite star/f-giant
 		distance 60.57
@@ -18109,7 +18109,7 @@ system "Is Il V-263"
 	minables titanium 3 5.731
 	fleet "Vyrmeid (Plankton)" 500
 	fleet "Vyrmeid (Boomerang)" 700
-	fleet Astral 50000
+	fleet Astral 110000
 	object
 		sprite star/b-supergiant
 		period 10
@@ -18157,7 +18157,7 @@ system "Is Il X-626"
 	asteroids "large metal" 1 3.402
 	fleet "Vyrmeid (Plankton)" 500
 	fleet "Vyrmeid (Boomerang)" 800
-	fleet Astral 50000
+	fleet Astral 100000
 	object
 		sprite star/a8
 		distance 48.468
@@ -18200,7 +18200,7 @@ system "Is Il Z-59"
 	minables iron 14 4.93
 	fleet "Vyrmeid (Plankton)" 500
 	fleet "Vyrmeid (Cephalopod)" 600
-	fleet Astral 50000
+	fleet Astral 140000
 	object
 		sprite star/g3
 		distance 67.938

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -2345,7 +2345,7 @@ system "Ae Ce L-332"
 	asteroids "large metal" 1 2.1
 	asteroids "medium rock" 11 3.6
 	minables unknown 1 2.7
-	fleet Astral 80000
+	fleet Astral 50000
 	object
 		sprite star/f-dwarf
 		period 10
@@ -17780,7 +17780,7 @@ system "Is Ce B-139"
 	asteroids "medium metal" 5 3.41
 	asteroids "large metal" 2 4.402
 	fleet "Vyrmeid (Plankton)" 300
-	fleet Astral 90000
+	fleet Astral 55000
 	object
 		sprite star/g8
 		period 40
@@ -17804,7 +17804,7 @@ system "Is Ce F-422"
 	asteroids "large rock" 9 2.262
 	asteroids "large metal" 1 3.783
 	fleet "Vyrmeid (Plankton)" 400
-	fleet Astral 100000
+	fleet Astral 57000
 	object
 		sprite star/a5
 		distance 52.236
@@ -17878,7 +17878,7 @@ system "Is Ce G-460"
 	minables silicon 6 10.214
 	minables unknown 2 2.5
 	fleet "Vyrmeid (Plankton)" 700
-	fleet Astral 120000
+	fleet Astral 65000
 	object
 		sprite star/k-dwarf
 		period 10
@@ -17925,7 +17925,7 @@ system "Is Ce J-591"
 	asteroids "large metal" 3 1.664
 	minables silicon 8 3.635
 	fleet "Vyrmeid (Plankton)" 450
-	fleet Astral 110000
+	fleet Astral 60000
 	object
 		sprite star/f-giant
 		distance 60.57
@@ -18109,7 +18109,7 @@ system "Is Il V-263"
 	minables titanium 3 5.731
 	fleet "Vyrmeid (Plankton)" 500
 	fleet "Vyrmeid (Boomerang)" 700
-	fleet Astral 110000
+	fleet Astral 56000
 	object
 		sprite star/b-supergiant
 		period 10
@@ -18157,7 +18157,7 @@ system "Is Il X-626"
 	asteroids "large metal" 1 3.402
 	fleet "Vyrmeid (Plankton)" 500
 	fleet "Vyrmeid (Boomerang)" 800
-	fleet Astral 100000
+	fleet Astral 62000
 	object
 		sprite star/a8
 		distance 48.468
@@ -18200,7 +18200,7 @@ system "Is Il Z-59"
 	minables iron 14 4.93
 	fleet "Vyrmeid (Plankton)" 500
 	fleet "Vyrmeid (Cephalopod)" 600
-	fleet Astral 140000
+	fleet Astral 75000
 	object
 		sprite star/g3
 		distance 67.938


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR reduces the spawn rate of the Astral Cetacean to a little under half of what it is currently. My original intention for this lifeform is to be super rare, where during your first time exploring the Vyrmeid region, it, for the most part, would be unlikely you see one. As time has passed and I've observed the frequency at which players run into them, I feel as though the spawns can be cut back to truly uphold their mysterious and rare natural spawns (as well as cutting them back the further away from some systems).

I have plans in the future for the player to revisit the area, so there still would be opportunities in which the player returns and runs into one (or perhaps a mission or special condition that explicitly spawns one outside of fleets), etc..