### PR TITLE
NPC scan and surveillance personality behavior changes

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -495,6 +495,9 @@ void AI::Clean()
 	playerActions.clear();
 	swarmCount.clear();
 	fenceCount.clear();
+	cargoScans.clear();
+	outfitScans.clear();
+	scanTime.clear();
 	miningAngle.clear();
 	miningRadius.clear();
 	miningTime.clear();
@@ -645,6 +648,26 @@ void AI::Step(Command &activeCommands)
 		shared_ptr<Flotsam> targetFlotsam = it->GetTargetFlotsam();
 		if(isPresent && it->IsYours() && targetFlotsam && FollowOrders(*it, command))
 			continue;
+		// Determine if this ship was trying to scan its previous target. If so, keep
+		// track of this ship's scan time and count.
+		if(isPresent && !it->IsYours())
+		{
+			// Assume that if the target is friendly, not disabled, of a different
+			// government to this ship, and this ship has scanning capabilities
+			// then it was attempting to scan the target. This isn't a perfect
+			// assumption, but should be good enough for now.
+			bool cargoScan = it->Attributes().Get("cargo scan power");
+			bool outfitScan = it->Attributes().Get("outfit scan power");
+			if((cargoScan || outfitScan) && target && !target->IsDisabled()
+				&& !target->GetGovernment()->IsEnemy(gov) && target->GetGovernment() != gov)
+			{
+				++scanTime[&*it];
+				if(it->CargoScanFraction() == 1.)
+					cargoScans[&*it].insert(&*target);
+				if(it->OutfitScanFraction() == 1.)
+					outfitScans[&*it].insert(&*target);
+			}
+		}
 		if(isPresent && !personality.IsSwarming())
 		{
 			// Each ship only switches targets twice a second, so that it can
@@ -1382,27 +1405,60 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 shared_ptr<Ship> AI::FindNonHostileTarget(const Ship &ship) const
 {
 	shared_ptr<Ship> target;
-	bool cargoScan = ship.Attributes().Get("cargo scan power");
-	bool outfitScan = ship.Attributes().Get("outfit scan power");
-	if(cargoScan || outfitScan)
+
+	// A ship may only make up to 6 successful scans (3 ships scanned if the ship
+	// is using both scanners) and spend up to 2.5 minutes searching for scan targets.
+	// After that, stop scanning targets. This is so that scanning ships in high spawn
+	// rate systems don't build up over time, as they always have a new ship they
+	// can try to scan.
+	// Ships with the surveillance personality may make up to 12 successful scans and
+	// spend 5 minutes searching.
+	bool isSurveillance = ship.GetPersonality().IsSurveillance();
+	int maxScanCount = isSurveillance ? 12 : 6;
+	int searchTime = isSurveillance ? 9000 : 18000;
+	// Ships will stop finding new targets to scan after the above scan time, but
+	// may continue to pursue a target that they already started scanning for an
+	// additional minute.
+	int forfeitTime = searchTime + 3600;
+
+	double cargoScan = ship.Attributes().Get("cargo scan power");
+	double outfitScan = ship.Attributes().Get("outfit scan power");
+	auto cargoScansIt = cargoScans.find(&ship);
+	auto outfitScansIt = outfitScans.find(&ship);
+	auto scanTimeIt = scanTime.find(&ship);
+	int shipScanCount = cargoScansIt != cargoScans.end() ? cargoScansIt->second.size() : 0;
+	shipScanCount += outfitScansIt != outfitScans.end() ? outfitScansIt->second.size() : 0;
+	int shipScanTime = scanTimeIt != scanTime.end() ? scanTimeIt->second : 0;
+	if((cargoScan || outfitScan) && shipScanCount < maxScanCount && shipScanTime < forfeitTime)
 	{
-		const auto allies = GetShipsList(ship, false);
-		// If this ship already has a target, and is in the process of scanning it, prioritise that.
+		// If this ship already has a target, and is in the process of scanning it, prioritise that,
+		// even if the scan time for this ship has exceeded 2.5 minutes.
 		shared_ptr<Ship> oldTarget = ship.GetTargetShip();
 		if(oldTarget && !oldTarget->IsTargetable())
 			oldTarget.reset();
 		if(oldTarget)
 		{
+			// If this ship started scanning this target then continue to scan it
+			// unless it has traveled too far outside of the scan range. Surveillance
+			// ships will continue to pursue targets regardless of range.
 			bool cargoScanInProgress = ship.CargoScanFraction() > 0. && ship.CargoScanFraction() < 1.;
 			bool outfitScanInProgress = ship.OutfitScanFraction() > 0. && ship.OutfitScanFraction() < 1.;
-			if(cargoScanInProgress || outfitScanInProgress)
+			// Divide the distance by 10,000 to normalize to the scan range that
+			// scan power provides.
+			double range = isSurveillance ? 0. : oldTarget->Position().DistanceSquared(ship.Position()) * .0001;
+			if((cargoScanInProgress && range < 2. * cargoScan)
+				|| (outfitScanInProgress && range < 2. * outfitScan))
 				target = std::move(oldTarget);
 		}
-		else
+		else if(shipScanTime < searchTime)
 		{
-			double closest = numeric_limits<double>::infinity();
+			// Don't try chasing targets that are too far away from this ship's scan range.
+			// Surveillance ships will still prioritize nearby targets here, but if there
+			// is no scan target nearby then they will pick a random target in the system
+			// to pursue in DoSurveillance.
+			double closest = max(cargoScan, outfitScan) * 2.;
 			const Government *gov = ship.GetGovernment();
-			for(const auto &it : allies)
+			for(const auto &it : GetShipsList(ship, false))
 				if(it->GetGovernment() != gov)
 				{
 					auto ptr = it->shared_from_this();
@@ -1411,7 +1467,9 @@ shared_ptr<Ship> AI::FindNonHostileTarget(const Ship &ship) const
 							&& (!outfitScan || Has(gov, ptr, ShipEvent::SCAN_OUTFITS)))
 						continue;
 
-					double range = it->Position().DistanceSquared(ship.Position());
+					// Divide the distance by 10,000 to normalize to the scan range that
+					// scan power provides.
+					double range = it->Position().DistanceSquared(ship.Position()) * .0001;
 					if(range < closest)
 					{
 						closest = range;
@@ -2708,14 +2766,15 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 		else if(!isStaying)
 			command |= Command::LAND;
 	}
-	else if(target && target->IsTargetable())
+	else if(target)
 	{
 		// Approach and scan the targeted, friendly ship's cargo or outfits.
 		bool cargoScan = ship.Attributes().Get("cargo scan power");
 		bool outfitScan = ship.Attributes().Get("outfit scan power");
 		// If the pointer to the target ship exists, it is targetable and in-system.
-		bool mustScanCargo = cargoScan && !Has(ship, target, ShipEvent::SCAN_CARGO);
-		bool mustScanOutfits = outfitScan && !Has(ship, target, ShipEvent::SCAN_OUTFITS);
+		const Government *gov = ship.GetGovernment();
+		bool mustScanCargo = cargoScan && !Has(gov, target, ShipEvent::SCAN_CARGO);
+		bool mustScanOutfits = outfitScan && !Has(gov, target, ShipEvent::SCAN_OUTFITS);
 		if(!mustScanCargo && !mustScanOutfits)
 			ship.SetTargetShip(shared_ptr<Ship>());
 		else
@@ -2732,26 +2791,35 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 		const System *system = ship.GetSystem();
 		const Government *gov = ship.GetGovernment();
 
-		// Consider scanning any non-hostile ship in this system that you haven't yet personally scanned.
+		// Consider scanning any non-hostile ship in this system that your government hasn't scanned.
+		// A surveillance ship may only make up to 12 successful scans (6 ships scanned
+		// if the ship is using both scanners) and spend up to 5 minutes searching for
+		// scan targets. After that, stop scanning ship targets. This is so that scanning
+		// ships in high spawn rate systems don't build up over time, as they always have
+		// a new ship they can try to scan.
 		vector<Ship *> targetShips;
 		bool cargoScan = ship.Attributes().Get("cargo scan power");
 		bool outfitScan = ship.Attributes().Get("outfit scan power");
-		if(cargoScan || outfitScan)
-			for(const auto &grit : governmentRosters)
-			{
-				if(gov == grit.first || gov->IsEnemy(grit.first))
-					continue;
-				for(const auto &it : grit.second)
+		auto cargoScansIt = cargoScans.find(&ship);
+		auto outfitScansIt = outfitScans.find(&ship);
+		auto scanTimeIt = scanTime.find(&ship);
+		int shipScanCount = cargoScansIt != cargoScans.end() ? cargoScansIt->second.size() : 0;
+		shipScanCount += outfitScansIt != outfitScans.end() ? outfitScansIt->second.size() : 0;
+		int shipScanTime = scanTimeIt != scanTime.end() ? scanTimeIt->second : 0;
+		if((cargoScan || outfitScan) && shipScanCount < 12 && shipScanTime < 18000)
+		{
+			for(const auto &it : GetShipsList(ship, false))
+				if(it->GetGovernment() != gov)
 				{
 					auto ptr = it->shared_from_this();
-					if((!cargoScan || Has(ship, ptr, ShipEvent::SCAN_CARGO))
-							&& (!outfitScan || Has(ship, ptr, ShipEvent::SCAN_OUTFITS)))
+					if((!cargoScan || Has(gov, ptr, ShipEvent::SCAN_CARGO))
+							&& (!outfitScan || Has(gov, ptr, ShipEvent::SCAN_OUTFITS)))
 						continue;
 
 					if(it->IsTargetable())
 						targetShips.emplace_back(it);
 				}
-			}
+		}
 
 		// Consider scanning any planetary object in the system, if able.
 		vector<const StellarObject *> targetPlanets;
@@ -2781,6 +2849,7 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target) 
 			DoPatrol(ship, command);
 			return;
 		}
+		// Pick one of the valid surveillance targets at random to focus on.
 		unsigned index = Random::Int(total);
 		if(index < targetShips.size())
 			ship.SetTargetShip(targetShips[index]->shared_from_this());

--- a/source/AI.h
+++ b/source/AI.h
@@ -24,6 +24,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <list>
 #include <map>
 #include <memory>
+#include <set>
 #include <vector>
 
 class Angle;
@@ -254,6 +255,9 @@ private:
 	std::map<const Ship *, std::weak_ptr<Ship>> helperList;
 	std::map<const Ship *, int> swarmCount;
 	std::map<const Ship *, int> fenceCount;
+	std::map<const Ship *, std::set<const Ship *>> cargoScans;
+	std::map<const Ship *, std::set<const Ship *>> outfitScans;
+	std::map<const Ship *, int> scanTime;
 	std::map<const Ship *, Angle> miningAngle;
 	std::map<const Ship *, double> miningRadius;
 	std::map<const Ship *, int> miningTime;


### PR DESCRIPTION
**Feature**

This PR addresses the issues with NPC scanning behavior noted by #9706, #4723, and #4240.

## Summary
With this PR, ships with cargo and outfit scanners now behave as follows:
* All ships with scanners:
  * Will not scan ships that have already been scanned by another ship in their government. **(New)**
    * This was previously always the case for non-surveillance ships, but is now also the case for surveillance ships, which would scan any ship they haven't scanned regardless of whether an ally has.
  * Will prefer to scan the closest target to them when finding a new target. **(Unchanged)**
  * Will prefer to continue scanning targets they have already started scanning. **(Unchanged)**
  * Will give up on scanning their target if an addition 1 minute has elapsed past their base search timer. **(New)**
* Only non-surveillance ships:
  * Will make up to 6 successful scan before deciding to do something else. **(New)**
    * A successful scan is when either a cargo or an outfit scan completes. This means that a ship with both types of scanners that finishes both scans for every ship it scans will only scan 3 ships.
  * Will only search for scan targets for up to 2.5 minutes. **(New)**
  * Will give up on scanning their target if the target escapes beyond 2 times their scan range. **(New)**
  * Will only decide to start chasing and scanning a target if it is within 2 times their scan range. **(New)**
* Only surveillance ships:
  * Won't assist you when you hail them. **(Unchanged)**
  * Will make up to 12 successful scans before deciding to do something else. **(New)**
  * Will only search for scan targets for up to 5 minutes. **(New)**
  * Won't give up on scanning their target based on its distance. (Will still give up if their timer has elapsed.) **(New)**
  * If there is a ship within 2 times their scan range that they are able to scan, they will always prefer to scan the ship. **(New)**
  * If there are no ships within 2 times their scan range, they will randomly choose between "scanning" a stellar object in the system (if the ship has the "atmosphere scan" attribute), leaving the system, or choosing a ship in the system regardless of its distance to target and scan. **(New)**
    * Previously, surveillance ships would always prioritize scanning ships if there were any ships in the system to scan before deciding to scan nearby stellar objects or leave the system. (The way DoSurveillance was set up made it seem like the intention was for surveillance ships to sometimes decide to leave the system instead of scanning every single ship, but in practice they would always have found a target before DoSurveillance is called and so track down that target for so long as there were available targets in the system.)

What this means is the following:
* You will no longer get incessantly scanned by NPCs without end.
* NPCs with scanners will no longer continually build up in systems with high spawn rates.
* You can now escape/avoid ships with scanners by keeping your distance from them instead of only being able to either accept the scan or leave the system quicker than they can scan you.

Overall, not only should this result in less annoying behavior from scanning NPCs, but it should also make it so that running illegal goods is more viable given that you won't be scanned multiple times in the same system and you can avoid scanning ships from even targeting you by keeping your distance (which can make large arrival distance systems great places to run through).

## Testing Done + Screenshots.
Idled in Sol with a vanilla version of the game and with this PR. In vanilla, the number of Gunboats in the system quickly increased and remained high.
![image](https://github.com/endless-sky/endless-sky/assets/17688683/20e3c91c-de61-4f91-aae1-e41129704c63)
With this PR, it's still possible for a large number of Gunboats to be in the system at the same time, but unlike vanilla, they eventually start leaving to do other things. Most of the time there are only a few Gunboats flying around.
![image](https://github.com/endless-sky/endless-sky/assets/17688683/d183ff93-cd74-4dd1-9581-2085e9bee307)

Repeated the same experiment in Heia Due, where Hai surveillance personality fleets can spawn. In vanilla, I was scanned multiple times by multiple ships.
![image](https://github.com/endless-sky/endless-sky/assets/17688683/11e839a6-2874-4b96-8b28-effed8945177)
With this PR, I was scanned once and then never again.
![image](https://github.com/endless-sky/endless-sky/assets/17688683/8f5554f6-a26b-4fec-8a98-83a9ac321748)

## Performance Impact
N/A

## Side note
I'm pretty sure we're overusing the surveillance personality. A ship does not need the surveillance personality in order to scan other ships. All it needs is an outfit or cargo scanner and no hostiles in the system to distract it. The surveillance personality was always a way to make such ships more aggressive in their scanning, hence them scanning every ship personally instead of not scanning ships their government has already scanned. I've maintained the more aggressive scanning behavior of the surveillance personality by giving them a higher threshold for how many ships they can scan, for how long, and how they choose their scan targets, but we may still want to reevaluate the fleets we have given the surveillance personality.

## Potential tweaks to these changes
While working on this, I figured that the reason that surveillance ships would scan a ship even if their government already scanned it was to give a sense of overbearingness to the surveillance ships, a sense that I feel is now lost with this PR.

This idea does seem to fit well with the Navy surveillance fleets; surveillance fleets only begin spawning after Geminus and Martini are bombed, and are primarily deployed around the Free Worlds. It makes sense that the Navy would be scanning every ship they can multiple times, as it is possible that the first scan may have missed something. It's also not as if there's a cost to scanning, so the Navy might as well do it as much as they can. And from the Free Worlds perspective, it simply reinforces their distaste for the Republic; even if they don't have issues with the Navy by itself, they understand that the Navy takes orders from the Republic, and that it could be the Republic commanding the Navy to be so liberal with their scanning.

More generally, if the purpose of the surveillance personality is to make smuggling goods more difficult, it's possible to have something like interference plating block the first scan, so it would make sense for surveillance fleets to make multiple scans if they're expecting their scan targets to have interference plating.

If we want to keep this idea of surveillance fleets being overbearing in their scans, there's likely a middle ground between the current "scan every ship as many times times as you can" and this PR's "only scan each ship once per day." Thoughts on making it so that surveillance fleets will still generally avoid scanning ships that have already been scanned by their government, but add a random chance in to ignore the fact that a ship was already scanned and scan it again?

Even if we added this back in, surveillance ships will still each individually only be able to make so many scans and spend so much time scanning before deciding to do something else. It's just that instead of having every single surveillance ship that spawns scan you, the first one would scan you and then maybe every tenth one after that would decide to scan you again.