### PR TITLE
Autocondition for testing if you can land on a given planet

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3772,6 +3772,15 @@ void PlayerInfo::RegisterDerivedConditions()
 	visitedSystemProvider.SetGetFunction(visitedSystemFun);
 	visitedSystemProvider.SetHasFunction(visitedSystemFun);
 
+	auto &&landingAccessProvider = conditions.GetProviderPrefixed("landing access: ");
+	auto landingAccessFun = [this](const string &name) -> bool
+	{
+		const Planet *planet = GameData::Planets().Find(name.substr(strlen("landing access: ")));
+		return planet && flagship ? planet->CanLand(*flagship) : false;
+	};
+	landingAccessProvider.SetGetFunction(landingAccessFun);
+	landingAccessProvider.SetHasFunction(landingAccessFun);
+
 	auto &&pluginProvider = conditions.GetProviderPrefixed("installed plugin: ");
 	auto pluginFun = [](const string &name) -> bool
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3776,7 +3776,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	auto landingAccessFun = [this](const string &name) -> bool
 	{
 		const Planet *planet = GameData::Planets().Find(name.substr(strlen("landing access: ")));
-		return planet && flagship ? planet->CanLand(*flagship) : false;
+		return (planet && flagship) ? planet->CanLand(*flagship) : false;
 	};
 	landingAccessProvider.SetGetFunction(landingAccessFun);
 	landingAccessProvider.SetHasFunction(landingAccessFun);


### PR DESCRIPTION
**Feature**

This PR offers a clean way of addressing issues like #7663.

## Summary
Adds a new autocondition:
* `"landing access: <planet name>"`: Returns 1 if your flagship is able to land on the given planet. This includes checking that your reputation with the planet's government is greater than the required reputation to land, whether you've dominated the planet, whether your flagship has the necessary `"requires: <attribute>"` attributes, and will also update to reflect whether you've bribed the planet or provoked its government (although this is probably only useful for integration tests). Returns 0 otherwise.

## Usage examples
If you can't land on Earth, be that because you're hostile to the Republic or some other reason, then this mission wouldn't offer.
```
mission "Friendly Earth Visit"
	destination "Earth"
	to offer
		has "landing access: Earth"
```

## Testing Done
Nope.
