### PR TITLE
Fix a segfault on losing your ship during boarding

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1446,7 +1446,8 @@ void Engine::CalculateStep()
 	bool flagshipWasUntargetable = (flagship && !flagship->IsTargetable());
 	bool wasHyperspacing = (flagship && flagship->IsEnteringHyperspace());
 	// First, move the player's flagship.
-	MoveShip(player.FlagshipPtr());
+	if(flagship)
+		MoveShip(player.FlagshipPtr());
 	const System *flagshipSystem = (flagship ? flagship->GetSystem() : nullptr);
 	bool flagshipIsTargetable = (flagship && flagship->IsTargetable());
 	bool flagshipBecameTargetable = flagshipWasUntargetable && flagshipIsTargetable;


### PR DESCRIPTION
**Bug fix**

Thanks to @alexrovw for reporting this on Discord and in #9717.

## Summary
The flagship pointer is passed to "Engine::MoveShip" without null-checking, and that method assumes the pointer it is given isn't null.
This PR adds a check that the pointer isn't null.

## Testing Done
Attempt to capture a ship that has too many crew for me. Lose. Close the boarding panel. From faad2481691b1890844131ddd67ec6a60cf54c75 onwards, without this PR, the game crashes. With this PR, it doesn't.

## Save File
This save file can be used to test these changes:
[on encounter segfault test~3013-11-22.txt](https://github.com/endless-sky/endless-sky/files/14036930/on.encounter.segfault.test.3013-11-22.txt)
Take off, board one of the disabled ships. Attempt capture. Fail. Close the boarding panel. Crash.
