### PR TITLE
Fix outfit licenses propagating onto ships (option 1)

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -277,20 +277,15 @@ void Outfit::Load(const DataNode &node)
 			mass = child.Value(1);
 		else if(child.Token(0) == "licenses" && (child.HasChildren() || child.Size() >= 2))
 		{
-			auto isNewLicense = [](const vector<string> &c, const string &val) noexcept -> bool {
-				return find(c.begin(), c.end(), val) == c.end();
-			};
 			// Add any new licenses that were specified "inline".
 			if(child.Size() >= 2)
 			{
 				for(auto it = ++begin(child.Tokens()); it != end(child.Tokens()); ++it)
-					if(isNewLicense(licenses, *it))
-						licenses.push_back(*it);
+					AddLicense(*it);
 			}
 			// Add any new licenses that were specified as an indented list.
 			for(const DataNode &grand : child)
-				if(isNewLicense(licenses, grand.Token(0)))
-					licenses.push_back(grand.Token(0));
+				AddLicense(grand.Token(0));
 		}
 		else if(child.Token(0) == "jump range" && child.Size() >= 2)
 		{
@@ -523,7 +518,10 @@ void Outfit::Add(const Outfit &other, int count)
 		if(fabs(attributes[at.first]) < EPS)
 			attributes[at.first] = 0.;
 	}
-	licenses.insert(licenses.end(), other.licenses.begin(), other.licenses.end());
+
+	for(const auto &it : other.licenses)
+		AddLicense(it);
+
 	for(const auto &it : other.flareSprites)
 		AddFlareSprites(flareSprites, it, count);
 	for(const auto &it : other.reverseFlareSprites)
@@ -658,4 +656,17 @@ const map<const Sound *, int> &Outfit::JumpOutSounds() const
 const Sprite *Outfit::FlotsamSprite() const
 {
 	return flotsamSprite;
+}
+
+
+
+// Add the license with the given name to the licenses required by this outfit, if it is not already present.
+void Outfit::AddLicense(const string &name)
+{
+	auto isNewLicense = [](const vector<string> &c, const string &val) noexcept -> bool {
+		return find(c.begin(), c.end(), val) == c.end();
+	};
+
+	if(isNewLicense(licenses, name))
+		licenses.push_back(name);
 }

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -102,6 +102,11 @@ public:
 
 
 private:
+	// Add the license with the given name to the licenses required by this outfit, if it is not already present.
+	void AddLicense(const std::string &name);
+
+
+private:
 	bool isDefined = false;
 	std::string trueName;
 	std::string displayName;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -48,7 +48,7 @@ ShipInfoDisplay::ShipInfoDisplay(const Ship &ship, const PlayerInfo &player, boo
 // Panels that have scrolling abilities are not limited by space, allowing more detailed attributes.
 void ShipInfoDisplay::Update(const Ship &ship, const PlayerInfo &player, bool descriptionCollapsed, bool scrollingPanel)
 {
-	UpdateDescription(ship.Description(), ship.Attributes().Licenses(), true);
+	UpdateDescription(ship.Description(), ship.BaseAttributes().Licenses(), true);
 	UpdateAttributes(ship, player, descriptionCollapsed, scrollingPanel);
 	const Depreciation &depreciation = ship.IsYours() ? player.FleetDepreciation() : player.StockDepreciation();
 	UpdateOutfits(ship, player, depreciation);

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -235,7 +235,7 @@ ShopPanel::BuyResult ShipyardPanel::CanBuy(bool onlyOwned) const
 	int64_t cost = player.StockDepreciation().Value(*selectedShip, day);
 
 	// Check that the player has any necessary licenses.
-	int64_t licenseCost = LicenseCost(&selectedShip->Attributes());
+	int64_t licenseCost = LicenseCost(&selectedShip->BaseAttributes());
 	if(licenseCost < 0)
 		return "Buying this ship requires a special license. "
 			"You will probably need to complete some sort of mission to get one.";
@@ -272,7 +272,7 @@ ShopPanel::BuyResult ShipyardPanel::CanBuy(bool onlyOwned) const
 
 void ShipyardPanel::Buy(bool onlyOwned)
 {
-	int64_t licenseCost = LicenseCost(&selectedShip->Attributes());
+	int64_t licenseCost = LicenseCost(&selectedShip->BaseAttributes());
 	if(licenseCost < 0)
 		return;
 
@@ -371,11 +371,11 @@ bool ShipyardPanel::CanSellMultiple() const
 
 void ShipyardPanel::BuyShip(const string &name)
 {
-	int64_t licenseCost = LicenseCost(&selectedShip->Attributes());
+	int64_t licenseCost = LicenseCost(&selectedShip->BaseAttributes());
 	if(licenseCost)
 	{
 		player.Accounts().AddCredits(-licenseCost);
-		for(const string &licenseName : selectedShip->Attributes().Licenses())
+		for(const string &licenseName : selectedShip->BaseAttributes().Licenses())
 			if(!player.HasLicense(licenseName))
 				player.AddLicense(licenseName);
 	}


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #9722.
This is one fix I have. An alternative is #9724.

## Summary
In 9d8dfc4, `Outfit::Add` will add all the licenses from the other Outfit it is given, as well as all the attributes. This was done for the purpose of copying licenses added to a ship variant via `add attributes` into that ships `baseAttributes` object, instead of discarding them. It has the side effect of also copying the licenses from any outfit added to a ship into its `attributes` object, where the ships base attributes and the attributes of all its outfits are pooled together. It also doesn't maintain uniqueness of the lements of the `licenses` vector. The shipyard looks at the licenses required by the ships `attributes` object, so it ends up seeing all the licenses of all the installed outfits as well as the ship itself, and often sees many duplicates of the license.
This PR does a couple of things:
- Adding licenses in `Outfit::Add` now maintains uniqueness of the elements within the container.
- The shipyard now only looks at the license requirements of the ships `baseAttributes` object.

## Testing Done
No
