### PR TITLE
Fix outfit licenses propagating onto ships (option 2)

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -277,20 +277,15 @@ void Outfit::Load(const DataNode &node)
 			mass = child.Value(1);
 		else if(child.Token(0) == "licenses" && (child.HasChildren() || child.Size() >= 2))
 		{
-			auto isNewLicense = [](const vector<string> &c, const string &val) noexcept -> bool {
-				return find(c.begin(), c.end(), val) == c.end();
-			};
 			// Add any new licenses that were specified "inline".
 			if(child.Size() >= 2)
 			{
 				for(auto it = ++begin(child.Tokens()); it != end(child.Tokens()); ++it)
-					if(isNewLicense(licenses, *it))
-						licenses.push_back(*it);
+					AddLicense(*it);
 			}
 			// Add any new licenses that were specified as an indented list.
 			for(const DataNode &grand : child)
-				if(isNewLicense(licenses, grand.Token(0)))
-					licenses.push_back(grand.Token(0));
+				AddLicense(grand.Token(0));
 		}
 		else if(child.Token(0) == "jump range" && child.Size() >= 2)
 		{
@@ -545,6 +540,14 @@ void Outfit::Add(const Outfit &other, int count)
 
 
 
+void Outfit::AddLicenses(const Outfit &other)
+{
+	for(const auto &license : other.licenses)
+		AddLicense(license);
+}
+
+
+
 // Modify this outfit's attributes.
 void Outfit::Set(const char *attribute, double value)
 {
@@ -658,4 +661,17 @@ const map<const Sound *, int> &Outfit::JumpOutSounds() const
 const Sprite *Outfit::FlotsamSprite() const
 {
 	return flotsamSprite;
+}
+
+
+
+// Add the license with the given name to the licenses required by this outfit, if it is not already present.
+void Outfit::AddLicense(const string &name)
+{
+	auto isNewLicense = [](const vector<string> &c, const string &val) noexcept -> bool {
+		return find(c.begin(), c.end(), val) == c.end();
+	};
+
+	if(isNewLicense(licenses, name))
+		licenses.push_back(name);
 }

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -523,7 +523,7 @@ void Outfit::Add(const Outfit &other, int count)
 		if(fabs(attributes[at.first]) < EPS)
 			attributes[at.first] = 0.;
 	}
-	licenses.insert(licenses.end(), other.licenses.begin(), other.licenses.end());
+
 	for(const auto &it : other.flareSprites)
 		AddFlareSprites(flareSprites, it, count);
 	for(const auto &it : other.reverseFlareSprites)

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -668,10 +668,7 @@ const Sprite *Outfit::FlotsamSprite() const
 // Add the license with the given name to the licenses required by this outfit, if it is not already present.
 void Outfit::AddLicense(const string &name)
 {
-	auto isNewLicense = [](const vector<string> &c, const string &val) noexcept -> bool {
-		return find(c.begin(), c.end(), val) == c.end();
-	};
-
-	if(isNewLicense(licenses, name))
+	const auto it = find(licenses.begin(), licenses.end(), name);
+	if(it == licenses.end())
 		licenses.push_back(name);
 }

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -76,6 +76,8 @@ public:
 	// For tracking a combination of outfits in a ship: add the given number of
 	// instances of the given outfit to this outfit.
 	void Add(const Outfit &other, int count = 1);
+	// Add the licenses required by the given outfit to this outfit.
+	void AddLicenses(const Outfit &outfit);
 	// Modify this outfit's attributes. Note that this cannot be used to change
 	// special attributes, like cost and mass.
 	void Set(const char *attribute, double value);
@@ -99,6 +101,11 @@ public:
 	const std::map<const Sound *, int> &JumpOutSounds() const;
 	// Get the sprite this outfit uses when dumped into space.
 	const Sprite *FlotsamSprite() const;
+
+
+private:
+	// Add the license with the given name to the licenses required by this outfit, if it is not already present.
+	void AddLicense(const std::string &name);
 
 
 private:

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -696,6 +696,7 @@ void Ship::FinishLoading(bool isNewInstance)
 		// Store attributes from an "add attributes" node in the ship's
 		// baseAttributes so they can be written to the save file.
 		baseAttributes.Add(attributes);
+		baseAttributes.AddLicenses(attributes);
 		addAttributes = false;
 	}
 	// Add the attributes of all your outfits to the ship's base attributes.


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #9722.
This is one fix I have. An alternative is #9723.

## Summary
In 9d8dfc4, `Outfit::Add` will add all the licenses from the other Outfit it is given, as well as all the attributes. This was done for the purpose of copying licenses added to a ship variant via `add attributes` into that ships `baseAttributes` object, instead of discarding them. It has the side effect of also copying the licenses from any outfit added to a ship into its `attributes` object, where the ships base attributes and the attributes of all its outfits are pooled together. It also doesn't maintain uniqueness of the lements of the `licenses` vector. The shipyard looks at the licenses required by the ships `attributes` object, so it ends up seeing all the licenses of all the installed outfits as well as the ship itself, and often sees many duplicates of the license.
This PR does a couple of things:
- Adding licenses in `Outfit::Add` now maintains uniqueness of the elements within the container.
- `Outfit::Add` no longer copies licenses from the other outfit, the licenses from a ships outfits are not all copied into the ship. Instead, a new method is used to copy the licenses. This method is called by `Ship::FinishLoading` alongside adding all the other attributes from the variant definition.

## Testing Done
No
