### PR TITLE
Fix Steam workflow test parsing

### DIFF
--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -65,9 +65,9 @@ jobs:
     - name: Verify executable
       run: ./steam-container-runtime/depot/run-in-sniper ./build/steam-${{ matrix.arch }}/endless-sky -- -v
     - name: Execute data parsing test
-      run: ./steam-container-runtime/depot/run-in-sniper ./utils/test_parse.sh -- ./build/steam-${{ matrix.arch }}/endless-sky
+      run: ./steam-container-runtime/depot/run-in-sniper "./build/steam-${{ matrix.arch }}/endless-sky -p"
     - name: Execute integration data parsing test
-      run: ./steam-container-runtime/depot/run-in-sniper ./utils/test_parse.sh -- ./build/steam-${{ matrix.arch }}/endless-sky tests/integration/config
+      run: ./steam-container-runtime/depot/run-in-sniper "./build/steam-${{ matrix.arch }}/endless-sky -p --config tests/integration/config"
     - name: Execute tests
       run: |
         cd steam

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Execute data parsing test
       run: ./steam-container-runtime/depot/run-in-sniper ./build/steam-${{ matrix.arch }}/endless-sky -- -p
     - name: Execute integration data parsing test
-      run: ./steam-container-runtime/depot/run-in-sniper "./build/steam-${{ matrix.arch }}/endless-sky -p --config tests/integration/config"
+      run: ./steam-container-runtime/depot/run-in-sniper ./build/steam-${{ matrix.arch }}/endless-sky -- -p --config tests/integration/config
     - name: Execute tests
       run: |
         cd steam

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Verify executable
       run: ./steam-container-runtime/depot/run-in-sniper ./build/steam-${{ matrix.arch }}/endless-sky -- -v
     - name: Execute data parsing test
-      run: ./steam-container-runtime/depot/run-in-sniper "./build/steam-${{ matrix.arch }}/endless-sky -p"
+      run: ./steam-container-runtime/depot/run-in-sniper ./build/steam-${{ matrix.arch }}/endless-sky -- -p
     - name: Execute integration data parsing test
       run: ./steam-container-runtime/depot/run-in-sniper "./build/steam-${{ matrix.arch }}/endless-sky -p --config tests/integration/config"
     - name: Execute tests

--- a/changelog
+++ b/changelog
@@ -151,6 +151,7 @@ Version 0.10.5
     * A new commit will no longer cancel the Actions running for previous commits. (@quyykk)
     * Integration tests are now allowed to run on every platform. (@quyykk)
     * If an integration test fails due to a segfault, a reason is now given so that the error is more clear. (@quyykk)
+    * Update the Steam workflow to use the "-p" argument with Endless Sky to test parse instead of the old, now deleted test parse script. (@MCOfficer, @warp-core)
 
 Version 0.10.4
   * Bug fixes:

--- a/io.github.endless_sky.endless_sky.appdata.xml
+++ b/io.github.endless_sky.endless_sky.appdata.xml
@@ -80,7 +80,7 @@
           <li>Various fixes to missions in the Coalition intro storylines.</li>
         </ul>
         <p>You can find out more in the changelog.</p>
-        <p>A special thanks to the 47 people who contributed to this release!</p>
+        <p>A special thanks to the 48 people who contributed to this release!</p>
       </description>
       <url>https://github.com/endless-sky/endless-sky/blob/v0.10.5/changelog</url>
     </release>


### PR DESCRIPTION
**CI/CD/Testing**

## Summary
The Steam release workflows previously used a test parsing script that has since been deleted.
This PR updates that workflow to test parse the same way the CI test parses (I hope).

## Testing Done
Derpy'll test it.
