### PR TITLE
Add "GoG" as an option for "Game source" in the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -68,6 +68,7 @@ body:
       description: From where did you obtain your current game version?
       options:
         - Steam
+        - GoG
         - ESLauncher2
         - Built from source
         - GitHub Releases

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -68,7 +68,7 @@ body:
       description: From where did you obtain your current game version?
       options:
         - Steam
-        - GoG
+        - GOG
         - ESLauncher2
         - Built from source
         - GitHub Releases


### PR DESCRIPTION
**Documentation**

This PR is inspired by #9729.

## Summary
Adds "GoG" as an option in the drop down menu for "game source" in the bug report issue template, so users who got the game from GoG don't need to choose "other" and then enter "GoG" manually.

## Testing Done
No
