### PR TITLE
Properly update the version numbers for 0.10.6-alpha

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -1,5 +1,5 @@
 Welcome to Endless Sky!
-version 0.10.5-alpha
+version 0.10.6-alpha
 
 The player's manual and other
 resources are available at:

--- a/endless-sky.6
+++ b/endless-sky.6
@@ -1,4 +1,4 @@
-.TH endless\-sky 6 "27 Jan 2024" "ver. 0.10.5-alpha" "Endless Sky"
+.TH endless\-sky 6 "27 Jan 2024" "ver. 0.10.6-alpha" "Endless Sky"
 
 .SH NAME
 endless\-sky \- a space exploration and combat game.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -497,7 +497,7 @@ void PrintHelp()
 void PrintVersion()
 {
 	cerr << endl;
-	cerr << "Endless Sky ver. 0.10.5-alpha" << endl;
+	cerr << "Endless Sky ver. 0.10.6-alpha" << endl;
 	cerr << "License GPLv3+: GNU GPL version 3 or later: <https://gnu.org/licenses/gpl.html>" << endl;
 	cerr << "This is free software: you are free to change and redistribute it." << endl;
 	cerr << "There is NO WARRANTY, to the extent permitted by law." << endl;


### PR DESCRIPTION
**Documentation**

## Summary
It looks like someone added the `-alpha` but didn't change the numbers from 0.10.5 to 0.10.6.
I don't know who did that.
