### PR TITLE
Fix typos in boarding missions.txt

### DIFF
--- a/data/human/boarding missions.txt
+++ b/data/human/boarding missions.txt
@@ -93,9 +93,9 @@ phrase "assist merchant 1-1"
 
 phrase "assist merchant 1-2"
 	word
-		`you altered course`
-		`you went out of your way`
-		`you may have altered your own flight plans`
+		`you altered course `
+		`you went out of your way `
+		`you may have altered your own flight plans `
 
 phrase "assist merchant 1-2 hazardous"
 	word

--- a/data/human/boarding missions.txt
+++ b/data/human/boarding missions.txt
@@ -150,9 +150,9 @@ phrase "assist merchant 3"
 	word
 		`captain `
 	word
-		`gives you`
-		`offers you`
-		`rewards you with`
+		`gives you `
+		`offers you `
+		`rewards you with `
 
 phrase "assist merchant 4"
 	word

--- a/data/human/boarding missions.txt
+++ b/data/human/boarding missions.txt
@@ -150,9 +150,9 @@ phrase "assist merchant 3"
 	word
 		`captain `
 	word
-		`gives you `
-		`offers you `
-		`rewards you with `
+		`gives you`
+		`offers you`
+		`rewards you with`
 
 phrase "assist merchant 4"
 	word


### PR DESCRIPTION
**Bug fix**


## Summary
Adds spaces to reward phrases in boarding missions.txt to prevent word merging
