### PR TITLE
Revert the buff to `energy capacity` that the Wanderer Sun reactors recieved in #6783 and nerf the energy generation of Wanderer biochemical cells

### DIFF
--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -301,8 +301,8 @@ outfit "Small Biochemical Cell"
 	thumbnail "outfit/small biochemical"
 	"mass" 17
 	"outfit space" -17
-	"energy generation" 1.6
-	"heat generation" 1.4
+	"energy generation" 1.28
+	"heat generation" 1.12
 	"energy capacity" 7500
 	description "This tiny generator draws energy from the metabolic byproducts of a collection of microorganisms that have been engineered by the Wanderers specifically for this purpose."
 
@@ -314,8 +314,8 @@ outfit "Large Biochemical Cell"
 	thumbnail "outfit/large biochemical"
 	"mass" 63
 	"outfit space" -63
-	"energy generation" 6.2
-	"heat generation" 4.9
+	"energy generation" 4.96
+	"heat generation" 3.92
 	"energy capacity" 30000
 	description "The Wanderers are masters of unusual and efficient technology. This bioreactor is fueled by a culture of microorganisms that produce a small electric charge."
 

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -329,7 +329,7 @@ outfit "Red Sun Reactor"
 	"outfit space" -47
 	"energy generation" 8.3
 	"heat generation" 13
-	"energy capacity" 2200
+	"energy capacity" 1100
 	description "The Wanderers have recently begun producing this tiny reactor as a way to squeeze a bit more energy production into their warships."
 
 outfit "Yellow Sun Reactor"
@@ -342,7 +342,7 @@ outfit "Yellow Sun Reactor"
 	"outfit space" -82
 	"energy generation" 15.2
 	"heat generation" 21
-	"energy capacity" 5200
+	"energy capacity" 2600
 	description "This is a compact nuclear reactor designed by the Wanderers. In addition to generating power, it is able to store a small amount of energy."
 
 outfit "White Sun Reactor"
@@ -355,7 +355,7 @@ outfit "White Sun Reactor"
 	"outfit space" -127
 	"energy generation" 24.85
 	"heat generation" 32
-	"energy capacity" 13400
+	"energy capacity" 6700
 	description "The White Sun is a large nuclear reactor that the Wanderers use for powering their Strong Wind warships."
 
 outfit "Blue Sun Reactor"
@@ -368,7 +368,7 @@ outfit "Blue Sun Reactor"
 	"outfit space" -152
 	"energy generation" 31.3
 	"heat generation" 39
-	"energy capacity" 17800
+	"energy capacity" 8900
 	description "As the Wanderers have begun producing heavy warships, a need has arisen for larger and larger reactor cores to power them."
 
 


### PR DESCRIPTION
**Balance**

## Summary
Reverted the buff to `energy capacity` that the Wanderer Sun reactors (that is, the Red Sun, Yellow Sun, White Sun and Blue Sun) recieved in #6783. As their `energy capacity` was doubled in that PR, this PR halves the current values, returning them to their prior values.

## Reasoning
### 1. Balance
The Blue Sun in particular is simply too strong in its current state. Before accounting for its energy capacity, it is already on par with (marginally more efficient than, in fact) the Triple Plasma Core once cooling requirements are accounted for, while also being smaller (despite the general trend being efficiency increasing with size), and generating less heat (meaning that less efficiency is lost with cooling efficiency, and further reducing the effective space cost relative to the TPC). That's not necessarily a problem in itself - the Blue Sun is a campaign unlock, the TPC is not, so it's reasonable for it to be a little stronger - but that's all only true if you ignore the energy capacity.
With the energy capacity accounted for, the Blue Sun leaves the TPC in the dust, and is comparable to (indeed, slightly more efficient than) the Heliarch Large Reactor Module, which, while smaller, is also half a tier higher.

![Reactors2024-02-01](https://github.com/endless-sky/endless-sky/assets/18634983/abb40721-a548-4a70-a3e9-23f06a72c9ae)
("Wanderer" is with energy capacity ignored, "Wanderer (B)" is with it accounted for. This PR would halve the difference between the two, bringing the "Wanderer (B)" values to a more reasonable position for T2.

### 2. Variety
Part of the intent of #6783 was to make battery outfits, and battery-heavy builds, more favourable. However, the fact that these reactors, already some of the best reactors in the game, provide so much energy capacity means that it's quite rare to actually need to install dedicated batteries at all - between Wanderer reactors and Korath systems cores (which also recieved a doubling to their energy capacity at the same time, which perhaps should also be considered for reversion?), a ship with no dedicated battery already tends to have all the energy capacity it needs.
The Biochemical Cells are effectively battery outfits more than generators, so nerfing their energy capacity wouldn't be productive toward that goal. The Large Biochemical Cell is also somewhat too powerful for its size, but if I were to nerf it I'd personally rather tone down the generation rather than the capacity.
This also makes it harder to deliberately opt for a playstyle of having high energy generation and little-to-no energy capacity, because unless you have access to Heliarch or Quarg reactors the options that are best for energy generation also provide large amounts of energy capacity.