### PR TITLE
fix(content): Uninhabited systems & Kaus Borealis switch sides throughout the FW campaign

### DIFF
--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -994,6 +994,12 @@ event "Tarazed neutrality"
 		government "Neutral"
 	system "Girtab"
 		government "Neutral"
+	system "Umbral"
+		government "Neutral"
+	system "Sadr"
+		government "Neutral"
+	system "Lurata"
+		government "Neutral"
 	planet "Wayfarer"
 		outfitter "Syndicate Assistance"
 
@@ -1473,6 +1479,8 @@ event "fw southern expansion"
 		fleet "Small Southern Pirates" 3000
 		fleet "Large Southern Pirates" 7000
 		fleet "Navy Surveillance" 3000
+	system "Eltanin"
+		government "Free Worlds"
 	system "Vega"
 		remove fleet "Republic Logistics"
 		add fleet "Republic Logistics" 2500
@@ -1702,6 +1710,12 @@ event "fw expanded and cut"
 		government "Free Worlds"
 	system "Kaus Australis"
 		government "Free Worlds"
+	system "Orvala"
+		government "Free Worlds"
+	system "Tais"
+		government "Free Worlds"
+	system "Naper"
+		government "Free Worlds"
 	system "Delta Sagittarii"
 		government "Republic"
 		fleet "Small Southern Merchants" 2000
@@ -1825,6 +1839,12 @@ event "fw tarazed joins"
 		government "Free Worlds"
 	system "Albireo"
 		government "Free Worlds"
+	system "Umbral"
+		government "Free Worlds"
+	system "Sadr"
+		government "Free Worlds"
+	system "Lurata"
+		government "Free Worlds"
 
 
 
@@ -1834,6 +1854,12 @@ event "fw tarazed republic"
 	system "Dabih"
 		government "Republic"
 	system "Albireo"
+		government "Republic"
+	system "Umbral"
+		government "Republic"
+	system "Sadr"
+		government "Republic"
+	system "Lurata"
 		government "Republic"
 
 
@@ -2525,6 +2551,7 @@ event "fwc attack kaus borealis"
 
 event "fwc capture kaus borealis"
 	system "Alpha Arae"
+		government "Free Worlds"
 		fleet "Small Southern Merchants" 5000
 		fleet "Large Southern Merchants" 6000
 		fleet "Small Free Worlds" 1000
@@ -2536,6 +2563,10 @@ event "fwc capture kaus borealis"
 		fleet "Small Free Worlds" 400
 		fleet "Large Free Worlds" 400
 		fleet "Large Republic" 2000
+	system "Alnasl"
+		government "Free Worlds"
+	system "Eber"
+		government "Free Worlds"
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
 

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1550,6 +1550,12 @@ event "fw northern expansion"
 		government "Free Worlds"
 	system "Wei"
 		government "Free Worlds"
+	system "Alpha Arae"
+		government "Free Worlds"
+	system "Alnasl"
+		government "Free Worlds"
+	system "Eber"
+		government "Free Worlds"
 
 
 
@@ -2551,7 +2557,6 @@ event "fwc attack kaus borealis"
 
 event "fwc capture kaus borealis"
 	system "Alpha Arae"
-		government "Free Worlds"
 		fleet "Small Southern Merchants" 5000
 		fleet "Large Southern Merchants" 6000
 		fleet "Small Free Worlds" 1000
@@ -2563,10 +2568,6 @@ event "fwc capture kaus borealis"
 		fleet "Small Free Worlds" 400
 		fleet "Large Free Worlds" 400
 		fleet "Large Republic" 2000
-	system "Alnasl"
-		government "Free Worlds"
-	system "Eber"
-		government "Free Worlds"
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
 
@@ -3045,6 +3046,12 @@ event "fwc pug defeated"
 		tribute 1200
 			threshold 3500
 			fleet "Large Syndicate" 9
+
+
+
+event "fwc kaus borealis ceded back"
+	system "Kaus Borealis"
+		government "Republic"
 
 
 

--- a/data/human/free worlds 3 checkmate.txt
+++ b/data/human/free worlds 3 checkmate.txt
@@ -2424,6 +2424,7 @@ mission "FWC End"
 		set "free worlds plot completed"
 		set "free worlds checkmate"
 		event "stack core for sale"
+		event "fwc kaus borealis ceded back"
 		conversation
 			`You arrive in the Parliament building just as Alondo and Katya have finished meeting with them. "Good news," says Katya. "We're all officially pardoned. And you, Captain <last>, have become something of a hero."`
 			`	"Better yet," says Alondo, "the war with the Republic is over. We agreed to limiting our territory to its current size, and to a very minor tax to cover the cost of Navy protection if the aliens attack again or some other major catastrophe strikes. In return, the Free Worlds have been granted autonomy from the Republic."`


### PR DESCRIPTION
**Bug fix**: This PR addresses the bug/feature described in #6949

## Summary
Makes uninhabited systems switch to associated gov'ts for the events (`tarazed neutrality`, `southern expansion`, `northern expansion`, `fw expanded cut`, `fw tarazed joins`) and FWC-specific events (`tarazed republic`).

I might have missed some. Testing should tell me whether I have ~~when I do it.~~

## Screenshots
Soon™

## Testing Done
None yet.

## Save File
Will do.