### PR TITLE
Stricter copyright checking

### DIFF
--- a/utils/check_copyright.py
+++ b/utils/check_copyright.py
@@ -8,7 +8,7 @@ from debian import copyright
 def check_copyright() -> bool:
     with open('copyright', 'r', encoding='utf-8') as f:
         try:
-            copyright.Copyright(f)
+            copyright.Copyright(f, strict=True)
         except copyright.Error as e:
             print(e)
             return False


### PR DESCRIPTION
**CI/CD/Testing**

This PR makes the existing copyright check more strict. Unfortunately, this is still not good enough to catch all issues, such as the ones #9731 fixes, but it should be better now.

## Summary
I'm still actively looking for a reliable copyright linter, but all of them seem to have issues... I went through most options listed in #9731 and they either didn't work reliably, reported no issues, only did parsing instead of linting, or would be painful to get working in our current CI setup.

## Testing Done
I tested that the checker still runs.