### PR TITLE
fix(bug): Fix pirate spawns

### DIFF
--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -460,6 +460,8 @@ event "initial deployment 3"
 		fleet "Large Southern Merchants" 600
 		fleet "Small Free Worlds" 1000
 		fleet "Large Free Worlds" 1600
+		fleet "Small Southern Pirates" 5000
+		fleet "Large Southern Pirates" 8000
 	system "Aldhibain"
 		fleet "Small Southern Merchants" 400
 		fleet "Large Southern Merchants" 500

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -460,8 +460,8 @@ event "initial deployment 3"
 		fleet "Large Southern Merchants" 600
 		fleet "Small Free Worlds" 1000
 		fleet "Large Free Worlds" 1600
-		fleet "Small Southern Pirates" 5000
-		fleet "Large Southern Pirates" 8000
+		fleet "Small Southern Pirates" 4000
+		fleet "Large Southern Pirates" 6500
 	system "Aldhibain"
 		fleet "Small Southern Merchants" 400
 		fleet "Large Southern Merchants" 500
@@ -777,6 +777,8 @@ event "initial deployment 4"
 		fleet "Large Southern Merchants" 800
 		fleet "Small Free Worlds" 800
 		fleet "Large Free Worlds" 1200
+		fleet "Small Southern Pirates" 5000
+		fleet "Large Southern Pirates" 8000
 		fleet "Navy Surveillance" 800
 	system "Aldhibain"
 		fleet "Small Southern Merchants" 600
@@ -825,6 +827,8 @@ event "capture of Kornephoros"
 		fleet "Large Southern Merchants" 1000
 		fleet "Small Free Worlds" 400
 		fleet "Large Free Worlds" 600
+		fleet "Small Southern Pirates" 6000
+		fleet "Large Southern Pirates" 10000
 	planet "Clink"
 		description `The mining outpost is swarming with Navy guards; they seem to have turned this moon into a temporary base of operations. The mine has been shut down, and no one is being allowed in or out of the mining outpost. It is not clear whether the miners are prisoners, or merely under a very tight watch.`
 		security 1
@@ -881,6 +885,8 @@ event "recapture of Kornephoros"
 		fleet "Large Southern Merchants" 800
 		fleet "Small Free Worlds" 600
 		fleet "Large Free Worlds" 600
+		fleet "Small Southern Pirates" 1400
+		fleet "Large Southern Pirates" 3000
 	system "Kornephoros"
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 800

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -28435,6 +28435,8 @@ system Sabik
 	fleet "Large Southern Merchants" 900
 	fleet "Small Militia" 1200
 	fleet "Large Militia" 2000
+	fleet "Small Southern Pirates" 3000
+	fleet "Large Southern Pirates" 5000
 	object
 		sprite star/g5
 		period 10


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported in #9751

## Summary
Pirates don't spawn in Sabik, even though they spawn in other rim systems, and to get there you must go through Sabik. This gives them the same spawn rates as Zubenelgenubi, as per @Quantumshark.

## Screenshots
TBD

## Testing Done
TBD

## Save File
This save file can be used to test these changes:
TBD