### PR TITLE
Render animated sprites in the hail panel correctly

### DIFF
--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -45,8 +45,7 @@ using namespace std;
 
 
 HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<void(const Government *)> bribeCallback)
-	: player(player), ship(ship), bribeCallback(std::move(bribeCallback)),
-		sprite(ship->GetSprite()), facing(ship->Facing())
+	: player(player), ship(ship), bribeCallback(std::move(bribeCallback)), facing(ship->Facing())
 {
 	SetInterruptible(false);
 
@@ -125,8 +124,7 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<
 
 
 HailPanel::HailPanel(PlayerInfo &player, const StellarObject *object)
-	: player(player), object(object), planet(object->GetPlanet()),
-		sprite(object->GetSprite()), facing(object->Facing())
+	: player(player), object(object), planet(object->GetPlanet()), facing(object->Facing())
 {
 	SetInterruptible(false);
 
@@ -209,6 +207,8 @@ void HailPanel::Draw()
 
 	const Interface *hailUi = GameData::Interfaces().Get("hail panel");
 	hailUi->Draw(info, this);
+
+	const Sprite *sprite = ship ? ship->GetSprite() : object->GetSprite();
 
 	// Draw the sprite, rotated, scaled, and swizzled as necessary.
 	float zoom = min(2.f, 400.f / max(sprite->Width(), sprite->Height()));

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -125,7 +125,8 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<
 
 
 HailPanel::HailPanel(PlayerInfo &player, const StellarObject *object)
-	: player(player), planet(object->GetPlanet()), sprite(object->GetSprite()), facing(object->Facing())
+	: player(player), object(object), planet(object->GetPlanet()),
+		sprite(object->GetSprite()), facing(object->Facing())
 {
 	SetInterruptible(false);
 
@@ -214,6 +215,7 @@ void HailPanel::Draw()
 	Point center(-170., -10.);
 
 	DrawList draw;
+	draw.Clear(step);
 	// If this is a ship, copy its swizzle, animation settings, etc.
 	// Also draw its fighters and weapon hardpoints.
 	if(ship)
@@ -263,7 +265,7 @@ void HailPanel::Draw()
 					addFighter(bay);
 	}
 	else
-		draw.Add(Body(sprite, center, Point(), facing, zoom));
+		draw.Add(Body(*object, center, Point(), facing, zoom));
 
 	draw.Draw();
 
@@ -274,6 +276,8 @@ void HailPanel::Draw()
 	wrap.SetFont(FontSet::Get(14));
 	wrap.Wrap(message);
 	wrap.Draw(Point(-50., -50.), *GameData::Colors().Get("medium"));
+
+	++step;
 }
 
 

--- a/source/HailPanel.h
+++ b/source/HailPanel.h
@@ -60,7 +60,6 @@ private:
 	std::function<void(const Government *)> bribeCallback = nullptr;
 	const StellarObject *object = nullptr;
 	const Planet *planet = nullptr;
-	const Sprite *sprite = nullptr;
 	Angle facing;
 	int step = 0;
 

--- a/source/HailPanel.h
+++ b/source/HailPanel.h
@@ -58,9 +58,11 @@ private:
 	PlayerInfo &player;
 	std::shared_ptr<Ship> ship = nullptr;
 	std::function<void(const Government *)> bribeCallback = nullptr;
+	const StellarObject *object = nullptr;
 	const Planet *planet = nullptr;
 	const Sprite *sprite = nullptr;
 	Angle facing;
+	int step = 0;
 
 	std::string header;
 	std::string message;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #9766

## Summary
Ships and planets in the hail panel should now be properly animated.

## Testing Done
No.
