### PR TITLE
feat(content): Core Pirate Ship Variants with Tractor Beams

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -2256,6 +2256,8 @@ fleet "Small Core Pirates"
 	variant 1
 		"Headhunter (Particle)"
 	variant 1
+		"Headhunter (Tractor Beam)"
+	variant 1
 		"Quicksilver" 2
 	variant 1
 		"Quicksilver"
@@ -2328,12 +2330,16 @@ fleet "Large Core Pirates"
 		"Splinter (Laser)" 2
 	variant 1
 		"Splinter (Proton)" 2
+	variant 1
+		"Splinter (Tractor Beam)"
 	variant 2
 		"Falcon"
 	variant 1
 		"Falcon (Heavy)"
 	variant 1
 		"Falcon (Laser)"
+	variant 1
+		"Falcon (Tractor Beam)"
 	variant 2
 		"Firebird"
 	variant 2
@@ -2352,6 +2358,8 @@ fleet "Large Core Pirates"
 		"Protector (Laser)"
 	variant 1
 		"Protector (Proton)"
+	variant 1
+		"Protector (Tractor Beam)"
 	variant 1
 		"Protector"
 

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -3132,7 +3132,7 @@ ship "Protector" "Protector (Quad Blaster)"
 
 ship "Protector" "Protector (Tractor Beam)"
 	outfits
-		"Torpedo Launcher" 2
+		"Torpedo Launcher"
 		"Torpedo" 30
 		"Quad Blaster Turret" 4
 		"Anti-Missile Turret" 2

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1641,6 +1641,28 @@ ship "Falcon" "Falcon (Laser Chaser)"
 		"Heavy Laser" 4
 		"Armageddon Core"
 
+ship "Falcon" "Falcon (Tractor Beam)"
+	outfits
+		"Proton Gun" 4
+		"Quad Blaster Turret" 2
+		"Heavy Anti-Missile Turret"
+		"Tractor Beam"
+		"Breeder Reactor"
+		"LP144a Battery Pack"
+		"D67-TM Shield Generator"
+		"Cargo Expansion"
+		"Laser Rifle" 21
+		"Impala Plasma Thruster"
+		"Orca Plasma Steering"
+		"Hyperdrive"
+	gun "Proton Gun"
+	gun "Proton Gun"
+	gun "Proton Gun"
+	gun "Proton Gun"
+	turret "Heavy Anti-Missile Turret"
+	turret "Tractor Beam"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
 
 ship "Falcon" "Falcon (Javelin)"
 	outfits
@@ -2347,6 +2369,22 @@ ship "Headhunter" "Headhunter (Strike)"
 		"RT-I Radiothermal"
 		"LP072a Battery Pack"
 		"D23-QP Shield Generator"
+		"Greyhound Plasma Thruster"
+		"Greyhound Plasma Steering"
+		"Hyperdrive"
+
+
+ship "Headhunter" "Headhunter (Tractor Beam)"
+	outfits
+		"Twin Modified Blaster" 2
+		"Meteor Missile Pod" 2
+		"Meteor Missile" 29
+		"Meteor Missile Box"
+		"Tractor Beam"
+		"RT-I Radiothermal"
+		"LP072a Battery Pack"
+		"D23-QP Shield Generator"
+		"Cargo Expansion"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
@@ -3092,6 +3130,33 @@ ship "Protector" "Protector (Quad Blaster)"
 		"Hyperdrive"
 
 
+ship "Protector" "Protector (Tractor Beam)"
+	outfits
+		"Torpedo Launcher" 2
+		"Torpedo" 30
+		"Quad Blaster Turret" 4
+		"Anti-Missile Turret" 2
+		"Tractor Beam" 2
+		"Fusion Reactor"
+		"D94-YV Shield Generator"
+		"D67-TM Shield Generator"
+		"Water Coolant System"
+		"Large Radar Jammer"
+		"Cargo Expansion" 2
+		"Laser Rifle" 21
+		"Impala Plasma Thruster"
+		"Greyhound Plasma Steering"
+		"Hyperdrive"
+	turret "Tractor Beam"
+	turret "Quad Blaster Turret"
+	turret "Anti-Missile Turret"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
+	turret "Anti-Missile Turret"
+	turret "Quad Blaster Turret"
+	turret "Tractor Beam"
+
+
 
 ship "Quicksilver" "Quicksilver (Mark II)"
 	outfits
@@ -3414,6 +3479,27 @@ ship "Splinter" "Splinter (Proton)"
 		"Hyperdrive"
 	turret "Proton Turret"
 	turret "Anti-Missile Turret"
+	turret "Proton Turret"
+	
+
+ship "Splinter" "Splinter (Tractor Beam)"
+	outfits
+	outfits
+		"Twin Modified Blaster" 2
+		"Proton Turret" 2
+		"Tractor Beam"
+		"Water Coolant System"
+		"Fission Reactor"
+		"LP036a Battery Pack"
+		"D94-YV Shield Generator"
+		"Small Radar Jammer"
+		"Cargo Expansion"
+		"Laser Rifle" 3
+		"X3700 Ion Thruster"
+		"Impala Plasma Steering"
+		"Hyperdrive"
+	turret "Proton Turret"
+	turret "Tractor Beam"
 	turret "Proton Turret"
 
 


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
With the introduction of mining and tractor beams, Amazinite has talked about adding tractor beams to a few pirate ships to collect flotsams for situations such as when freighters dump their cargo in appeasement (which is especially the case with the Syndicate).

I've added four new Tractor Beam pirate variants for the Headhunter, Splinter, Falcon, and Protector. The Headhunter variant gives a little extra love to Twin Modified blasters, meanwhile the Falcon variant gets a little extra love as the first Falcon variant with Proton Guns. I had considered giving the Vanguard a variant, but I feel it better to not jump on every possibility to give the player a tiny bit of "what if I do it" scenario (along with the Firebird). The Argosy, although sold in Pirate systems by the core, is not present in these fleets, so it also did not get a variant.

Since the Tractor Beam is a Syndicate outfit, these variants are exclusively found in "Core Pirate" fleets, akin to the recent CCOR expansion adding Javelin and Gatling Turrets to southern pirate fleets. The four variants are of ships already present in said fleets, so there are no problems there.