### PR TITLE
ui: Fix credits not showing if speed is set to 0

### DIFF
--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -91,6 +91,9 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
 
 	if(player.GetPlanet())
 		Audio::PlayMusic(player.GetPlanet()->MusicName());
+	
+	if(!scrollSpeed)
+		scrollSpeed = 1;
 }
 
 

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -91,7 +91,7 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
 
 	if(player.GetPlanet())
 		Audio::PlayMusic(player.GetPlanet()->MusicName());
-	
+
 	if(!scrollSpeed)
 		scrollSpeed = 1;
 }


### PR DESCRIPTION
**Bug fix**

## Summary
Currently, if you set the credits scroll speed to 0 (with the arrow keys) and make a new instance of the menu panel (enter ship and return to the menu), the credits won't appear.
With this fix, the 0 scrolling speed is reset to the default value (1) on panel construction.

## Testing Done
Tested with the above steps; doesn't seem to break anything.

## Performance Impact
N/A
