### PR TITLE
Rename feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,11 +1,11 @@
-name: Feature Request
-description: Suggest an idea for this project
+name: Feature/Balance/Change Request
+description: Suggest an idea or change for this project
 
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for filing a feature request! This project has been around for quite a while, so it is quite common for ideas to have come up before. To help save everyone's time, you are required to search for related issues and address any comments and concerns that arose previously.
+        Thanks for filing a feature/change request! This project has been around for quite a while, so it is quite common for ideas to have come up before. To help save everyone's time, you are required to search for related issues and address any comments and concerns that arose previously.
         Otherwise, your issue will be closed--it is not fair to ask maintainers and collaborators to do background research for *your* feature request.
 
         Where should you search?
@@ -16,7 +16,7 @@ body:
   - type: textarea
     attributes:
       label: Problem Description
-      description: Provide a clear and concise description of what underlying issue is addressed by your feature request.
+      description: Provide a clear and concise description of what underlying issue is addressed by your request.
       placeholder: I'm always frustrated when [...]
     validations:
       required: true
@@ -43,4 +43,4 @@ body:
   - type: textarea
     attributes:
       label: Additional Context
-      description: Add any other context or screenshots about the feature request here. If you're proposing new UI features, creating a mock-up can really go a long way in conveying your intent.
+      description: Add any other context or screenshots about the request here. If you're proposing new UI features, creating a mock-up can really go a long way in conveying your intent.


### PR DESCRIPTION
**Documentation**

This PR addresses the bug/feature described in issue #9233

## Summary
As noted in the linked issue, we currently have a "Feature Request" template for requesting new features, but there's no immediately obvious location to ask for balance changes, or changes in general. A feature request sounds like the creation of something new entirely, although not all uses of the feature request template are actually for new features.

This PR renames the feature request template to "Feature/Balance/Change Request", making it more clear that this is the general template that should be used for anything that doesn't fall under any of the other templates.

I've renamed this template to cover all three cases instead of having a new template for each given that the templates would likely all be identical if we were to split them, as we'd ask for the same things regardless.