### PR TITLE
Prevent Cosmic Devil mitosis

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2328,15 +2328,21 @@ mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 	to offer
 		has "Deep: Scientist Rescue 1: done"
 	to fail
-		has "Deep: Scientist Rescue 2: done"
-	npc kill
+		or
+			has "Deep: Scientist Rescue 2: done"
+			has "deep: killed the cosmic devil"
+	to complete
+		never
+	npc
 		government "Pirate"
 		personality staying nemesis
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
-		dialog
-			`After the Bactrian is eliminated, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
-			`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
-			`The transmission cuts out as abruptly as it had started.`
+		on kill
+			set "deep: killed the cosmic devil"
+			dialog
+				`After the Bactrian is eliminated, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
+				`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
+				`The transmission cuts out as abruptly as it had started.`
 
 
 
@@ -2365,8 +2371,7 @@ mission "Deep: Scientist Rescue 3A"
 	waypoint "Arneb"
 	to offer
 		has "Deep: Scientist Rescue 2: done"
-		not "Deep: Scientist Rescue 2: Pirate Bactrian: done"
-		not "Deep: Scientist Rescue 3B: offered"
+		not "deep: killed the cosmic devil"
 	
 	on offer
 		payment 2000000
@@ -2426,8 +2431,7 @@ mission "Deep: Scientist Rescue 3B"
 	invisible
 	to offer
 		has "Deep: Scientist Rescue 2: done"
-		has "Deep: Scientist Rescue 2: Pirate Bactrian: done"
-		not "Deep: Scientist Rescue 3A: offered"
+		has "deep: killed the cosmic devil"
 	
 	on offer
 		set "license: City-Ship"

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2330,7 +2330,7 @@ mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 	to fail
 		or
 			has "Deep: Scientist Rescue 2: done"
-			has "deep: killed the cosmic devil"
+			has "deep: cosmic devil destroyed early"
 	to complete
 		never
 	npc
@@ -2338,7 +2338,7 @@ mission "Deep: Scientist Rescue 2: Pirate Bactrian"
 		personality staying nemesis
 		ship "Bactrian (Cosmic Devil)" "Cosmic Devil"
 		on kill
-			set "deep: killed the cosmic devil"
+			set "deep: cosmic devil destroyed early"
 			dialog
 				`After the Bactrian is eliminated, you receive a transmission from an unknown source. It suddenly opens on its own and an electronically distorted voice begins speaking to you.`
 				`	"Well done, Captain. Well done at being a thorn in my side. You will pay for this. One day."`
@@ -2371,7 +2371,7 @@ mission "Deep: Scientist Rescue 3A"
 	waypoint "Arneb"
 	to offer
 		has "Deep: Scientist Rescue 2: done"
-		not "deep: killed the cosmic devil"
+		not "deep: cosmic devil destroyed early"
 	
 	on offer
 		payment 2000000
@@ -2431,7 +2431,7 @@ mission "Deep: Scientist Rescue 3B"
 	invisible
 	to offer
 		has "Deep: Scientist Rescue 2: done"
-		has "deep: killed the cosmic devil"
+		has "deep: cosmic devil destroyed early"
 	
 	on offer
 		set "license: City-Ship"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #6824

## Summary
This PR prevents an edge case where the player could get their hands on two Cosmic Devils at once. The reason that this could occur is because the mission to return to Arneb to finish off the Cosmic Devil could potentially offer even after the Cosmic Devil was already destroyed due to how the missions checked if the Cosmic Devil was killed.

This PR makes use of newer features so that the moment that the Cosmic Devil is destroyed during the first time you encounter it, a condition `"deep: cosmic devil destroyed early"` is set. This condition is then used to determine if you need to return to Arneb to finish the job, or if you've already completed all objectives for the storyline. 

## Testing Done
I honestly couldn't reproduce the issue anyway. I know for a fact though this this will prevent it from ever occurring, as the Cosmic Devil's death is now known by a condition the moment it happens instead of later when you land on Valhalla. The fact that the condition that was used was originally set upon landing at Valhalla on the same landing that the next mission offered is potentially what caused the issue. 
