### PR TITLE
Give required crew to the Javelin and Gatling Turrets

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1097,6 +1097,7 @@ outfit "Javelin Turret"
 	"outfit space" -31
 	"weapon capacity" -31
 	"turret mounts" -1
+	"required crew" 1
 	"javelin capacity" 400
 	weapon
 		sprite "projectile/javelin"
@@ -1564,6 +1565,7 @@ outfit "Gatling Turret"
 	"outfit space" -23
 	"weapon capacity" -23
 	"turret mounts" -1
+	"required crew" 1
 	"gatling round capacity" 6000
 	weapon
 		sound "gatling"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in https://steamcommunity.com/app/404410/discussions/1/4204741842670747847/

## Summary
Aside from AM turrets and the tractor beam, which are automated, all turrets in human space require crew. The Javelin and Gatling Turrets currently don't require crew, but they should. Added one required crew to each. May no variants that you guys made become undercrewed.