### PR TITLE
Make Lasher Pistols more defensive than offensive

### DIFF
--- a/data/bunrodea/bunrodea outfits.txt
+++ b/data/bunrodea/bunrodea outfits.txt
@@ -210,10 +210,10 @@ outfit "Dark Reactor"
 
 outfit "Lasher Pistol"
 	category "Hand to Hand"
-	cost 230000
+	cost 47000
 	thumbnail "outfit/lasher pistol"
-	"capture attack" 2.6
-	"capture defense" 1.4
+	"capture attack" 1.1
+	"capture defense" 2.8
 	"unplunderable" 1
 	description "During their wars with the Korath, it was not uncommon for Bunrodean vessels to be boarded by Korath raiders looking for technology and supplies to steal. As such, effective small arms weapons became an essential part of every Bunrodean crew that may need to fight off any boarding parties."
 


### PR DESCRIPTION
**Balance**

This PR addresses the issue described in #8559

## Summary
I believe the original intention of the Lasher Pistol was for it to have flipped stats to the Korath Repeater Rifle. The description didn't actually make sense with that intention, though.

I've changed the stats so that they are now more in line with the description. I've also massively dropped the price because there's no good reason it's that high.
