### PR TITLE
Irene brower follow up change

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6400,6 +6400,8 @@ mission "Care Package to South 2b"
 	to offer
 		has "Care Package to South 1: done"
 		has "FW Pirates: Diplomacy 4: done"
+	to accept
+		has "FW Early Warning 1: offered"
 	on offer
 		conversation
 			`As you leave the quartermaster's building, you spot a familiar face coming in the other direction: Irene Brower, the gunnery sergeant you delivered a care package to before the war, though she seems to have master sergeant insignia now. She's on crutches, with what looks like a brand-new prosthetic leg. When she spots you, her pained face brightens. "Hey, I know you! You brought me that package from Tor before. Thanks!" She shifts her weight, then winces and shifts it back.`

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6412,13 +6412,13 @@ mission "Care Package to South 2b"
 				`	"So... that prosthetic is very new, then?"`
 					goto new
 				`	"With that prosthetic, soon you'll have a leg up on the rest of us, eh?"`
-			`	She grins broadly at your pun. "Yep! Just here to get a float chair for the first few weeks of adjustment."`
+			`	She grins broadly at your pun. "Yep! Just here to get a float chair for the first few weeks of adjustment.`
 				goto leave
 			label sorry
-			`	She waves it off, but her face softens. "Thanks. I'm here to pick up a float chair, for the first six weeks of adjustment."`
+			`	She waves it off, but her face softens. "Thanks. I'm here to pick up a float chair, for the first six weeks of adjustment.`
 				goto leave
 			label new
-			`	She nods. "Yep, just came from getting it fitted, and gotta check in at the quartermaster's to get myself a float chair for the first six weeks of adjustment to it."`
+			`	She nods. "Yep, just came from getting it fitted, and gotta check in at the quartermaster's to get myself a float chair for the first six weeks of adjustment to it.`
 			label leave
 			`	"Six months of medical leave, then I'll be back in action. And hopefully assigned to ships a little less eager to jump into the thick of it when it's not really necessary, eh?"`
 			`	You join in her wry chuckle, then she gives you a wave with one crutch and bids you farewell.`


### PR DESCRIPTION
**Bug fix**

## Summary
The follow-up on Deep currently appears before the main story mission conversation it is supposed to follow.
Consequently, you exit the quartermaster's office immediately upon landing in the Irene Brower conversation and then enter it in the main FW mission conversation immediately after.
This PR prevents the Irene Brower conversation from appearing before the main FW one.

I also removed some quote marks at the end of lines where the next line begins with speech from the same person.

## Testing Done
Use the provided save file with and without these changes.
Without this PR, the Irene Brower conversation appears first, with it, it appears second, as it should.

## Save File
This save file can be used to test these changes:
[warp core care package test~original.txt](https://github.com/endless-sky/endless-sky/files/14187938/warp.core.care.package.test.original.txt)
