### PR TITLE
feat(content): Mention the presence of abandoned Navy bases on planets during Checkmate

### DIFF
--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -2538,6 +2538,8 @@ event "fwc capture kaus borealis"
 		fleet "Large Republic" 2000
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
+		description `	Many of the inhabitants wear dust masks to avoid letting the particulate matter from the volcanoes accumulate in their lungs.`
+		description `	The Navy had begun building a massive military base on New Iceland after they had been pushed out of the Southern Rim, but their defeat in this system by the Free Worlds has led to the base being abandoned prematurely.`
 
 
 
@@ -2664,8 +2666,9 @@ event "fwc capture menkent"
 		fleet "Human Miners" 2000
 	planet "New Austria"
 		description `New Austria is a rugged mountain world, full of snow-capped peaks and valleys so deep and so steep that they rarely see sunlight.`
-		description `The few settlements that have been built here were developed for mining sapphires and rubies. The sapphires found in New Austria range from blue to yellow to black to clear in color, and are used both for industrial abrasives and for jewelry.`
-		description `For centuries the locals have been trying to find a deposit of diamonds, which would sell for much higher prices than sapphires, and local folklore revolves around the prosperity that would come to this world if diamonds were ever discovered.`
+		description `	The few settlements that have been built here were developed for mining sapphires and rubies. The sapphires found in New Austria range from blue to yellow to black to clear in color, and are used both for industrial abrasives and for jewelry.`
+		description `	For centuries the locals have been trying to find a deposit of diamonds, which would sell for much higher prices than sapphires, and local folklore revolves around the prosperity that would come to this world if diamonds were ever discovered.`
+		description `	The Navy once had a military base here, but they vacated it when the Free Worlds captured this system as part of the "Checkmate" plan.`
 
 
 

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1490,6 +1490,7 @@ event "fw southern expansion"
 		fleet "Republic Logistics" 4000
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
+		description `	Many of the inhabitants wear dust masks to avoid letting the particulate matter from the volcanoes accumulate in their lungs.`
 		description `	In the wake of their defeat in the south, the Navy has begun to set up a massive new base here on New Iceland, in order to allow them to continue to have a strong presence in this sector.`
 
 


### PR DESCRIPTION
**Content (Planet Descriptions)**
This PR adds new lines to planets that used to hold Navy bases but were abandoned as a result of the Checkmate plan.

## Summary
The text mentioning the new Navy bases that are built in New Iceland and New Austria as a result of the civil war is removed in Checkmate once you begin to take more Republic systems. I've added lines mentioning these bases back as I thought that it didn't seem right for them to simply disappear.

Also fixes the fact that New Austria's decription loses its indented lines when it is captured in `fwc capture menkent`, and New Iceland loses the line `Many of the inhabitants wear dust masks to avoid letting the particulate matter from the volcanoes accumulate in their lungs` in `fw southern expansion` since there was no apparent reason for it being removed.

In the future, we might add another event that causes the Navy to start using those bases again – especially since the peace treaty between the FW and the Republic in Checkmate talks about the Republic patrolling the Southern Rim.

## Screenshots
**New Iceland** (`fw southern expansion`)
<img width="1440" alt="Screenshot 2024-02-07 at 5 32 30 PM" src="https://github.com/endless-sky/endless-sky/assets/115441627/a6422fd1-e623-423b-8d3c-d60433009f1d">

**New Iceland** (`fwc attack kaus borealis`)
<img width="1440" alt="Screenshot 2024-02-07 at 5 18 24 PM" src="https://github.com/endless-sky/endless-sky/assets/115441627/134320ec-71d0-4570-b12f-f206eaf164c6">

**New Austria** (`fwc capture menkent`)
<img width="1440" alt="Screenshot 2024-02-07 at 5 18 42 PM" src="https://github.com/endless-sky/endless-sky/assets/115441627/b976db19-aff7-4731-894e-ee24238d2ef3">

## Testing Done
Tested to see if length fits. It's appended to the current text changes in the associated events so it should work fine. I _did not_ test it by playing Checkmate, but if anyone wants, I'll do it.
