### PR TITLE
Remove ShopPanel::Search declaration

### DIFF
--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -107,7 +107,6 @@ protected:
 
 	void DoFind(const std::string &text);
 	virtual int FindItem(const std::string &text) const = 0;
-	static int Search(const std::string &str, const std::string &sub);
 
 	int64_t LicenseCost(const Outfit *outfit, bool onlyOwned = false) const;
 


### PR DESCRIPTION
**Bug fix**

## Summary
There is no method definition for this declaration. It looks like the declaration is left over from when #9515 was being worked on.

## Testing Done
It still builds without this declaration.
