### PR TITLE
Ship info display fixes

### DIFF
--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -469,5 +469,5 @@ void ShipInfoDisplay::UpdateOutfits(const Ship &ship, const PlayerInfo &player, 
 	saleHeight += 20;
 	saleLabels.push_back("  + outfits:");
 	saleValues.push_back(Format::Credits(totalCost - chassisCost));
-	saleHeight += 5;
+	saleHeight += 20;
 }

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -144,15 +144,16 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	attributeHeaderLabels.push_back("model:");
 	attributeHeaderValues.push_back(ship.DisplayModelName());
 
+	attributesHeight = 20;
+
 	// Only show the ship category on scrolling panels with no risk of overflow.
 	if(scrollingPanel)
 	{
 		attributeHeaderLabels.push_back("category:");
 		const string &category = ship.BaseAttributes().Category();
 		attributeHeaderValues.push_back(category.empty() ? "???" : category);
+		attributesHeight += 20;
 	}
-
-	attributesHeight = 20;
 
 	attributeLabels.clear();
 	attributeValues.clear();


### PR DESCRIPTION
**Bug fix**

## Summary
The padding between the energy/heat table and the installed outfits list is too small in the shipyard and outfitter.
First, the additional height of the "attributes" section added by the category label was not accounted for.
The padding for player owned ships is then smaller still because the "saleHeight" is not counted properly.
I'm aiming for the padding to be the same for player owned ships and ships available for sale in the shipyard.

## Screenshots
panel | before | after
-- | -- | --
shipyard | ![image](https://github.com/endless-sky/endless-sky/assets/20605679/4822852b-e371-43e7-8f08-e1cde8272c01) | ![image](https://github.com/endless-sky/endless-sky/assets/20605679/dab8438c-d3a1-4d3b-88e5-9cc176bac91a)
outfitter | ![image](https://github.com/endless-sky/endless-sky/assets/20605679/7e1ce916-a8b9-4639-8e79-624183a71807) | ![image](https://github.com/endless-sky/endless-sky/assets/20605679/2f0e5a1e-9386-4515-a6c4-4c30049d152f)

## Testing Done
Visit the shipyard and outfitter and check how much padding there is between the energy/heat table and the outfit list for:
- player owned ships,
- ships for sale.
Also, check the same for player owned ships in the outfitter.
