### PR TITLE
fix(CI): Fix edge case in code style checker

### DIFF
--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -49,7 +49,7 @@ line_include = {re.compile(regex): description for regex, description in {
 	"\\s+$": "trailing whitespace at end of line",
 	# Matches any number of operators that have no leading whitespace,
 	# except if preceded by '(', '[' or '{', or inside a 'case' constant expression.
-	"(?<!^case\\s.*)([^([{\\s" + std_op + "](?<!^.*[^\\w0-9]?operator))[" + std_op + "]+(?<!\\w->[*&])([^.\\)" + std_op + "]|$)(?!\\.\\.\\.)": "missing whitespace before operator"
+	"(?<!^case\\s.*)([^([{\\s" + std_op + "](?<!^.*[^\\w0-9]?operator))[" + std_op + "]+(?<!(->|::)*)([^.\\)" + std_op + "]|$)(?!\\.\\.\\.)": "missing whitespace before operator"
 }.items()}
 # Dict of patterns for selecting potential formatting issues in a full segment.
 # (a segment is a part of a line that is between any strings, chars or comments)

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -49,7 +49,7 @@ line_include = {re.compile(regex): description for regex, description in {
 	"\\s+$": "trailing whitespace at end of line",
 	# Matches any number of operators that have no leading whitespace,
 	# except if preceded by '(', '[' or '{', or inside a 'case' constant expression.
-	"(?<!^case\\s.*)([^([{\\s" + std_op + "](?<!^.*[^\\w0-9]?operator))[" + std_op + "]+([^.\\)" + std_op + "]|$)(?!\\.\\.\\.)": "missing whitespace before operator"
+	"(?<!^case\\s.*)([^([{\\s" + std_op + "](?<!^.*[^\\w0-9]?operator))[" + std_op + "]+(?<!\\w->[*&])([^.\\)" + std_op + "]|$)(?!\\.\\.\\.)": "missing whitespace before operator"
 }.items()}
 # Dict of patterns for selecting potential formatting issues in a full segment.
 # (a segment is a part of a line that is between any strings, chars or comments)

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -49,7 +49,7 @@ line_include = {re.compile(regex): description for regex, description in {
 	"\\s+$": "trailing whitespace at end of line",
 	# Matches any number of operators that have no leading whitespace,
 	# except if preceded by '(', '[' or '{', or inside a 'case' constant expression.
-	"(?<!^case\\s.*)([^([{\\s" + std_op + "](?<!^.*[^\\w0-9]?operator))[" + std_op + "]+(?<!(->|::)\\*)([^.\\)" + std_op + "]|$)(?!\\.\\.\\.)": "missing whitespace before operator"
+	"(?<!^case\\s.*)([^([{\\s" + std_op + "](?<!^.*[^\\w0-9]?operator))[" + std_op + "]+(?<!(->|::|\\.)\\*)([^.\\)" + std_op + "]|$)(?!\\.\\.\\.)": "missing whitespace before operator"
 }.items()}
 # Dict of patterns for selecting potential formatting issues in a full segment.
 # (a segment is a part of a line that is between any strings, chars or comments)

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -49,7 +49,7 @@ line_include = {re.compile(regex): description for regex, description in {
 	"\\s+$": "trailing whitespace at end of line",
 	# Matches any number of operators that have no leading whitespace,
 	# except if preceded by '(', '[' or '{', or inside a 'case' constant expression.
-	"(?<!^case\\s.*)([^([{\\s" + std_op + "](?<!^.*[^\\w0-9]?operator))[" + std_op + "]+(?<!(->|::)*)([^.\\)" + std_op + "]|$)(?!\\.\\.\\.)": "missing whitespace before operator"
+	"(?<!^case\\s.*)([^([{\\s" + std_op + "](?<!^.*[^\\w0-9]?operator))[" + std_op + "]+(?<!(->|::)\\*)([^.\\)" + std_op + "]|$)(?!\\.\\.\\.)": "missing whitespace before operator"
 }.items()}
 # Dict of patterns for selecting potential formatting issues in a full segment.
 # (a segment is a part of a line that is between any strings, chars or comments)


### PR DESCRIPTION
**Bug fix**

~~The unholy function slew the mighty linter~~

## Summary
This PR fixes a rare edge case in the code style checker, namely in code looking like this: `->*`, such as `this->*f`. ~~Apparently this wasn't used anywhere else in the engine.~~ This fixes an issue with #9786, though the other reported style issues are valid.

## Testing Done
I tested that this specific issue is no longer falsely detected on the text, and that all other issues are still reported.