### PR TITLE
fix(bug): Update conditions in Gemini Shipyards jobs

### DIFF
--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -607,10 +607,8 @@ mission "Gemini Shipyards Shipment [0]"
 	to offer
 		random < 15
 		or
-			not "war begins"
-			and
-				has "war begins"
-				has "geminus rebuilt"
+			not "event: war begins"
+			has "event: geminus rebuilt"
 	source
 		near Castor 2 10
 		attributes factory
@@ -630,10 +628,8 @@ mission "Gemini Shipyards Shipment [1]"
 	to offer
 		random < 15
 		or
-			not "war begins"
-			and
-				has "war begins"
-				has "geminus rebuilt"
+			not "event: war begins"
+			has "event: geminus rebuilt"
 	source
 		near Castor 2 10
 		attributes factory


### PR DESCRIPTION
**Bug fix**
This PR addresses the a bug found on Discord by ziproot.

## Summary
The mission incorrectly refers to `war begins` instead of `event: war begins` in its `to offer` node, which means that the job is offered even after the war begins.

Alex Rov also pointed out that the additional `and` was not necessary, because I don't understand logic.
