### PR TITLE
0.10.6 docs update

### DIFF
--- a/changelog
+++ b/changelog
@@ -504,7 +504,7 @@ Version 0.10.2
       * New human news items. (@dorbarker)
       * New jobs in Free Worlds space during the war that involve Military cargo. (@dorbarker)
     * Mission changes:
-      * The "FW Pug 2C" missions now use autoconditions to ensure the appropriate one is offered instead of relying on MissionAction blocking. (@warp_core)
+      * The "FW Pug 2C" missions now use autoconditions to ensure the appropriate one is offered instead of relying on MissionAction blocking. (@warp-core)
       * The "Street Swindle" mission is now invisible, and uses conversation actions to take credits from the player and is always declined. (@lumbar527)
       * Small wording change to "Earth Retirement" mission. (@lumbar527)
       * Various wording changes to Gegno intro missions. (@Saugia)

--- a/changelog
+++ b/changelog
@@ -1,3 +1,36 @@
+Version 0.10.6
+  * Bug fixes:
+    * Content bugs:
+      * Typo fixes. (@AlexBassett, @fingolfin, @tibetiroka, @warp-core)
+      * Gave the Gatling Turret and Javelin Turret 1 required crew each. (@Amazinite)
+      * The "Gemini Shipyards" jobs now check the correct conditions. (@bene-dictator)
+      * Uninhabited systems and Kaus Borealis will now correctly change governments in the course of the Free Worlds campaign. (@bene-dictator)
+      * Added the "ramming" personality to the timer ship in "Sad Archie" so it behaves more like it should. (@ziproot)
+    * Engine bugs:
+      * Animated ship and planet sprites are now correctly rendered in the hail panel. (@warp-core)
+  * Game content:
+    * New content:
+      * Expanded the descriptions of some Hai stations. (@roadrunner56)
+      * Some planet descriptions will now include references to abaondoned Navy bases as they are captured in Free Worlds Checkmate. (@bene-dictator)
+      * Added Merchant hails about dumping cargo to distract pirates. (@tibetiroka)
+    * Balance:
+      * Gave Dreadnought back their fourth Torpedo Launcher. (@warp-core)
+        * And the 30 extra torpedoes this provides space for. They were previously removed when the launchers were made larger.
+        * Replaced the LP144a battery with an LP072a battery to make space.
+      * Made the Lasher Pistol more defensive and less offfensive. (@Amazinite)
+        * Capture attack: 2.6 -> 1.1
+        * Capture defense: 1.4 -> 2.8
+    * Other:
+      * Reduced the spawn rate of Astral Cetaceans and Embersylphs, and removed the large Embersylphs. (@Saugia)
+  * User interface:
+    * Increased the padding between the energy and heat table and the list of installed outfits in the ship info display in the shipyard and outfitter. (@warp-core)
+    * Opening the menu panel with a credits scroll speed of 0 resets the scroll speed. (@TomGoodIdea)
+  * Under the hood:
+    * Removed the declaration of an undefined mmethod. (@warp-core)
+  * CI/CD and development environment:
+    * Added "GOG" as an option for "game source" in the bug report issue template. (@warp-core)
+    * Renamed the feature request issue template to "Feature/Balance/Change Request". (@Amazinite)
+
 Version 0.10.5
   * Big changes:
     * Expanded the mechanics behind asteroid mining, including the addition of mining lasers that increase the yield of asteroids, tractor beams that pull ores toward your ship, and dedicated mining ships in human space. (@Amazinite, @bene-dictator, @Quantumshark, @Saugia)

--- a/credits.txt
+++ b/credits.txt
@@ -224,6 +224,7 @@ contributed to Endless Sky:
   fakepass
   fcfort
   Ferociousfeind
+  fingolfin
   finite-galaxy
   FixItYondu
   flaviojs

--- a/credits.txt
+++ b/credits.txt
@@ -1,5 +1,5 @@
 Welcome to Endless Sky!
-version 0.10.6-alpha
+version 0.10.6
 
 The player's manual and other
 resources are available at:

--- a/endless-sky.6
+++ b/endless-sky.6
@@ -1,4 +1,4 @@
-.TH endless\-sky 6 "27 Jan 2024" "ver. 0.10.6-alpha" "Endless Sky"
+.TH endless\-sky 6 "17 Feb 2024" "ver. 0.10.6" "Endless Sky"
 
 .SH NAME
 endless\-sky \- a space exploration and combat game.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -497,7 +497,7 @@ void PrintHelp()
 void PrintVersion()
 {
 	cerr << endl;
-	cerr << "Endless Sky ver. 0.10.6-alpha" << endl;
+	cerr << "Endless Sky ver. 0.10.6" << endl;
 	cerr << "License GPLv3+: GNU GPL version 3 or later: <https://gnu.org/licenses/gpl.html>" << endl;
 	cerr << "This is free software: you are free to change and redistribute it." << endl;
 	cerr << "There is NO WARRANTY, to the extent permitted by law." << endl;


### PR DESCRIPTION
**Documentation**

## Summary
- Update version numbers from "0.10.6-alpha" to 0.10.6 in:
  - endless-sky.6
  - main.cpp
  - credits.txt
- Update the changelog with commits up to 44d8f28
- Fix a typo in my username in the changelog (warp-core, not warp_core)
- Add 1 new contributor to the credits.
