### PR TITLE
feat(content): Add `lingering` to Gegno Protolith Fleet

### DIFF
--- a/data/gegno/gegno fleets.txt
+++ b/data/gegno/gegno fleets.txt
@@ -95,7 +95,7 @@ fleet "Gegno Old"
 	names "gegno vi"
 	cargo 2
 	personality
-		timid
+		timid lingering
 	variant
 		"Protolith"
 


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
The intent of the Protolith is to appear as a very old Gegno Generation ship, lacking a hyperdrive, that spawns very rarely in Heutesl and flies between the planets. The AI under these circumstances either goes to land on the other inhabited planet in the system, or sometimes, it will take off and immediately land back on the planet it takes off from.

Adding the `lingering` personality makes this behavior appear less goofy as the ship will spend a small amount of time longer in space, even if is going to land on the same planet, rather than fly directly back to it.