### PR TITLE
fix(typo): Move apostrophe in Solifuge description

### DIFF
--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -1625,7 +1625,7 @@ ship "Solifuge"
 	explode "large explosion" 50
 	explode "huge explosion" 20
 	"final explode" "final explosion large"
-	description `Impressed by the Alpha's "Giftbringer," the Unfettered endeavored to build their own fighter carrier to take more advantage of their supply of jump drives.`
+	description `Impressed by the Alphas' "Giftbringer," the Unfettered endeavored to build their own fighter carrier to take more advantage of their supply of jump drives.`
 
 ship "Solifuge" "Solifuge (Jump)"
 	outfits


### PR DESCRIPTION
**Bug fix**
This PR addresses a typo reported on Discord by Arachi

## Summary
I moved an apostrophe.

<img width="266" alt="Screenshot 2024-02-12 at 7 45 32 PM" src="https://github.com/endless-sky/endless-sky/assets/115441627/7b24dd07-ca88-4a24-8858-0787cb539baa">
