### PR TITLE
Content: give the harvest personality to unfettered, and add more cargo to the logistic fleets

### DIFF
--- a/data/hai/hai fleets.txt
+++ b/data/hai/hai fleets.txt
@@ -693,7 +693,7 @@ fleet "Small Unfettered"
 	names "hai"
 	cargo 1
 	personality
-		disables plunders
+		disables plunders harvests
 	variant 3
 		"Lightning Bug (Pulse)" 2
 	variant 3
@@ -715,7 +715,7 @@ fleet "Large Unfettered"
 	names "hai"
 	cargo 1
 	personality
-		disables plunders
+		disables plunders harvests
 	variant 2
 		"Shield Beetle (Unfettered)"
 		"Lightning Bug (Pulse)" 2
@@ -797,7 +797,7 @@ fleet "Large Plundering Unfettered"
 	names "hai"
 	cargo 1
 	personality
-		disables plunders coward
+		disables plunders coward harvests
 	variant 2
 		"Shield Beetle"
 		"Lightning Bug (Pulse)" 2

--- a/data/hai/hai fleets.txt
+++ b/data/hai/hai fleets.txt
@@ -643,7 +643,7 @@ fleet "Large Hai Merchant (Human)"
 fleet "Unfettered Logistics"
 	government "Hai (Unfettered Civilians)"
 	names "hai"
-	cargo 1
+	cargo 3
 	commodities "Food" "Heavy Metals" "Medical"
 	personality
 		confusion 25


### PR DESCRIPTION
**Content**

## Summary
I simply added the harvests personality to all unfettered fleets (which wont affect their mission instances).
This means you can dump cargo to distract them, which makes sense as thats what they're supposed to be doing: getting supplies - they should get the supplies the appeasing merchants throw at them. In fact they should almost be raiding mainly to get those, I think.

I looked at the code for cargo and it gives a random amount up to the total amount of cargo available. This means some logistic ships could have been moving around with very little cargo, which makes little sense.

## Testing Done
I don't think this is required?
