### PR TITLE
fix(bug): remove EMP torpedoes from Remnant Core Outfitter; add Teciimachs instead

### DIFF
--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -1182,6 +1182,9 @@ event "remnant: teciimach deployment"
 		add "Teciimach Pod"
 		add "Teciimach Canister"
 		add "Teciimach Canister Rack"
+	outfitter "Remnant Core"
+		remove "EMP Torpedo"
+		add "Teciimach Canister"
 	fleet "Small Remnant"
 		add variant 5
 			"Merganser (II)" 2


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug described on discord

## Summary
Ssil Vida has a unique outfitter called `Remnant Core` which fails to receive an update after Teciimachs are rolled out, making it the only place in the game where you can still buy EMP Torpedoes. This PR fixes the issue by removing EMP Torpedoes and replacing them with Teciimach canisters in the associated event.
