### PR TITLE
Balance: tweak marauder builds, and remove later game content from them

### DIFF
--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -140,7 +140,7 @@ ship "Marauder Bounder"
 
 		"Dwarf Core"
 		"LP072a Battery Pack"
-		"S-270 Regenerator"
+		"Hai Corundum Regenerator"
 		"Outfits Expansion"
 		"Water Coolant System"
 		"Security Station"
@@ -169,12 +169,12 @@ ship "Marauder Bounder" "Marauder Bounder (Engines)"
 	add attributes
 		"engine capacity" 15
 	outfits
-		"Heavy Laser"
 		"Quad Blaster Turret" 2
 		
 		"Dwarf Core"
 		"LP072a Battery Pack"
-		"S-270 Regenerator"
+		"Supercapacitor" 3
+		"D23-QP Shield Generator"
 		"Water Coolant System"
 		"Outfits Expansion"
 		"Laser Rifle" 18
@@ -200,7 +200,7 @@ ship "Marauder Bounder" "Marauder Bounder (Weapons)"
 		
 		"Dwarf Core"
 		"LP072a Battery Pack"
-		"S-270 Regenerator"
+		"D14-RN Shield Generator"
 		"Water Coolant System"
 		"Outfits Expansion"
 		"Security Station"
@@ -246,11 +246,12 @@ ship "Marauder Falcon"
 			"hit force" 2750
 	outfits
 		"Plasma Cannon" 4
-		"Modified Blaster Turret" 4
+		"Quad Blaster Turret" 4
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
-		"D67-TM Shield Generator"
+		"D23-QP Shield Generator"
+		"D94-YV Shield Generator"
 		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 3
@@ -284,17 +285,16 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 	add attributes
 		"engine capacity" 25
 	outfits
-		"Electron Beam" 4
-		"Quad Blaster Turret" 2
-		"Modified Blaster Turret" 2
+		"Proton Gun" 3
+		"Heavy Laser Turret" 4
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
-		"Large Radar Jammer"
-		"Liquid Helium Cooler"
-		"Outfits Expansion" 3
+		"Liquid Nitrogen Cooler"
+		"Outfits Expansion" 4
 		"Laser Rifle" 80
+		"Supercapacitor" 3
 		
 		"A860 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -303,14 +303,14 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 	engine -23.5 140 .7
 	engine 0 151
 	engine 23.5 140 .7
-	gun -16 -86.5 "Electron Beam"
-	gun 16 -86.5 "Electron Beam"
-	gun -19 -76.5 "Electron Beam"
-	gun 19 -76.5 "Electron Beam"
-	turret -16 -29 "Modified Blaster Turret"
-	turret 16 -29 "Modified Blaster Turret"
-	turret -50 39.5 "Quad Blaster Turret"
-	turret 50 39.5 "Quad Blaster Turret"
+	gun -16 -86.5
+	gun 16 -86.5
+	gun -19 -76.5
+	gun 19 -76.5
+	turret -16 -29
+	turret 16 -29
+	turret -50 39.5
+	turret 50 39.5
 	description "Whoever modified this Falcon clearly valued speed above all else. Major sections of the hull have been reconfigured to accommodate the largest possible engines. If hot-rodding across the galaxy in a 1000-ton warship that handles like a Flivver is your dream, look no further."
 
 
@@ -321,7 +321,8 @@ ship "Marauder Falcon" "Marauder Falcon (Weapons)"
 		"weapon capacity" 35
 	outfits
 		"Plasma Cannon" 6
-		"Quad Blaster Turret" 4
+		"Heavy Anti-Missile Turret"
+		"Proton Turret" 3
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
@@ -333,20 +334,21 @@ ship "Marauder Falcon" "Marauder Falcon (Weapons)"
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
+		"Afterburner"
 		"Hyperdrive"
 	
 	engine -16.5 143
 	engine 16.5 143
-	gun -16 -86.5 "Plasma Cannon"
-	gun 16 -86.5 "Plasma Cannon"
-	gun -19 -76.5 "Plasma Cannon"
-	gun 19 -76.5 "Plasma Cannon"
-	gun -24.5 -66.5 "Plasma Cannon"
-	gun 24.5 -66.5 "Plasma Cannon"
-	turret -16 -29 "Quad Blaster Turret"
-	turret 16 -29 "Quad Blaster Turret"
-	turret -50 39.5 "Quad Blaster Turret"
-	turret 50 39.5 "Quad Blaster Turret"
+	gun -16 -86.5
+	gun 16 -86.5
+	gun -19 -76.5
+	gun 19 -76.5
+	gun -24.5 -66.5
+	gun 24.5 -66.5
+	turret -16 -29
+	turret 16 -29
+	turret -50 39.5
+	turret 50 39.5
 	description "Whoever modified this Falcon clearly believed that firepower was everything. Two additional gun ports have been integrated into the hull, and the ship's interior space has been reconfigured to accommodate nearly any set of weapons you can imagine."
 
 
@@ -382,7 +384,7 @@ ship "Marauder Firebird"
 		
 		"Fusion Reactor"
 		"Supercapacitor"
-		"S-970 Regenerator"
+		"D41-HY Shield Generator"
 		"Liquid Helium Cooler"
 		"Outfits Expansion"
 		"Laser Rifle" 25
@@ -420,7 +422,7 @@ ship "Marauder Firebird" "Marauder Firebird (Engines)"
 		"Fusion Reactor"
 		"LP036a Battery Pack"
 		"Supercapacitor"
-		"S-970 Regenerator"
+		"D41-HY Shield Generator"
 		"Liquid Helium Cooler"
 		"Outfits Expansion"
 		"Security Station"
@@ -447,7 +449,7 @@ ship "Marauder Firebird" "Marauder Firebird (Weapons)"
 		
 		"Fusion Reactor"
 		"Supercapacitor"
-		"S-970 Regenerator"
+		"D41-HY Shield Generator"
 		"Liquid Helium Cooler"
 		"Outfits Expansion"
 		"Security Station"
@@ -499,6 +501,7 @@ ship "Marauder Leviathan"
 		"Fusion Reactor"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
+		"Hai Diamond Regenerator"
 		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 2
@@ -533,15 +536,16 @@ ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 	add attributes
 		"engine capacity" 40
 	outfits
-		"Electron Beam" 4
-		"Quad Blaster Turret" 4
+		"Heavy Rocket Launcher" 4
+		"Heavy Rocket" 80
+		"Gatling Turret" 4
+		"Gatling Gun Ammo" 24000
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
-		"D94-YV Shield Generator"
-		"D67-TM Shield Generator"
+		"D94-YV Shield Generator" 3
+		"Supercapacitor" 5
 		"Large Radar Jammer"
-		"Liquid Helium Cooler"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion" 2
 		"Laser Rifle" 69
@@ -563,13 +567,15 @@ ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
 	add attributes
 		"weapon capacity" 35
 	outfits
-		"Particle Cannon" 4
-		"Heavy Laser Turret" 4
+		"Particle Cannon" 2
+		"Ion Cannon" 2
+		"Heavy Laser Turret" 3
+		"Anti-Missile Turret"
 
 		"Fusion Reactor"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
-		"Large Radar Jammer"
+		"Large Radar Jammer" 2
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 2
 		"Laser Rifle" 69
@@ -579,11 +585,11 @@ ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
 		"Ionic Afterburner"
 		"Hyperdrive"
 	
-	gun -37.5 -41.5 "Particle Cannon"
-	gun 37.5 -41.5 "Particle Cannon"
+	gun -37.5 -41.5
+	gun 37.5 -41.5
 	gun -49.5 -29.5 "Particle Cannon"
 	gun 49.5 -29.5 "Particle Cannon"
-	turret -14.5 -11.5 "Heavy Laser Turret"
+	turret -14.5 -11.5
 	turret 14.5 -11.5 "Heavy Laser Turret"
 	turret -26 11.5 "Heavy Laser Turret"
 	turret 26 11.5 "Heavy Laser Turret"
@@ -747,15 +753,15 @@ ship "Marauder Quicksilver"
 		"Heavy Laser" 2
 		"Heavy Anti-Missile Turret"
 		
-		"Fission Reactor"
-		"LP036a Battery Pack"
-		"S-270 Regenerator"
-		"Liquid Nitrogen Cooler"
+		"NT-200 Nucleovoltaic"
+		"Hai Fissure Batteries"
+		"D41-HY Shield Generator"
+		"Water Coolant System"
 		"Security Station" 3
 		"Laser Rifle"
 		
 		"A250 Atomic Thruster"
-		"A375 Atomic Steering"
+		"A255 Atomic Steering"
 		"Hyperdrive"
 	
 	engine -15.5 54
@@ -784,8 +790,8 @@ ship "Marauder Quicksilver" "Marauder Quicksilver (Engines)"
 		"Anti-Missile Turret"
 		
 		"Fission Reactor"
-		"S-270 Regenerator"
-		"LP036a Battery Pack"
+		"D14-RN Shield Generator"
+		"Supercapacitor" 4
 		"Liquid Nitrogen Cooler"
 		"Security Station" 2
 		"Laser Rifle" 5
@@ -836,10 +842,10 @@ ship "Marauder Quicksilver" "Marauder Quicksilver (Weapons)"
 		"Heavy Laser" 2
 		"Heavy Laser Turret"
 		
-		"Fission Reactor"
-		"LP036a Battery Pack"
-		"S-270 Regenerator"
-		"Liquid Nitrogen Cooler"
+		"Dwarf Core"
+		"LP072a Battery Pack"
+		"D67-TM Shield Generator"
+		"Cooling Duct"
 		"Security Station" 4
 		"Laser Rifle"
 		
@@ -910,7 +916,7 @@ ship "Marauder Raven"
 		
 		"Breeder Reactor"
 		"Supercapacitor" 3
-		"S-270 Regenerator"
+		"Hai Corundum Regenerator"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion"
 		
@@ -918,6 +924,7 @@ ship "Marauder Raven"
 		"A375 Atomic Steering"
 		"Volcano Afterburner"
 		"Hyperdrive"
+		"Laser Rifle" 14
 	
 	engine -9.5 63
 	engine 9.5 63
@@ -941,17 +948,18 @@ ship "Marauder Raven" "Marauder Raven (Engines)"
 		"engine capacity" 20
 	outfits
 		"Heavy Laser" 4
-		"Heavy Laser Turret"
+		"Quad Blaster Turret"
 		
 		"Breeder Reactor"
-		"Supercapacitor"
-		"S-270 Regenerator"
+		"Supercapacitor" 3
+		"D23-QP Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion"
 		
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 14
 	
 	engine -10.5 63.5
 	engine 10.5 63.5
@@ -966,22 +974,23 @@ ship "Marauder Raven" "Marauder Raven (Weapons)"
 	add attributes
 		"weapon capacity" 30
 	outfits
-		"Plasma Cannon" 2
+		"Proton Gun" 2
 		"Pulse Cannon" 2
 		"Heavy Laser Turret"
 		
 		"Breeder Reactor"
-		"Supercapacitor" 2
-		"S-270 Regenerator"
+		"Supercapacitor" 3
 		"Liquid Nitrogen Cooler"
+		"Cooling Duct"
 		"Outfits Expansion"
 		
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+		"Laser Rifle" 14
 	
-	gun -13.5 -35.5 "Plasma Cannon"
-	gun 13.5 -35.5 "Plasma Cannon"
+	gun -13.5 -35.5
+	gun 13.5 -35.5
 	gun -21 -28 "Pulse Cannon"
 	gun 21 -28 "Pulse Cannon"
 	turret 0 7.5 "Heavy Laser Turret"

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -245,17 +245,20 @@ ship "Marauder Falcon"
 			"hull damage" 900
 			"hit force" 2750
 	outfits
-		"Plasma Cannon" 4
-		"Quad Blaster Turret" 4
+		"Plasma Cannon" 2
+		"Proton Gun" 2
+		"Modified Blaster Turret" 2
+		"Proton Turret" 2
 		
 		"Fusion Reactor"
+		"Dwarf Core"
 		"LP288a Battery Pack"
-		"D23-QP Shield Generator"
 		"D94-YV Shield Generator"
 		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 3
 		"Laser Rifle" 80
+		"Security Station"
 		
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -265,12 +268,12 @@ ship "Marauder Falcon"
 	engine 16.5 143
 	gun -16 -86.5 "Plasma Cannon"
 	gun 16 -86.5 "Plasma Cannon"
-	gun -19 -76.5 "Plasma Cannon"
-	gun 19 -76.5 "Plasma Cannon"
+	gun -19 -76.5 "Proton Gun"
+	gun 19 -76.5 "Proton Gun"
 	turret -16 -29 "Modified Blaster Turret"
 	turret 16 -29 "Modified Blaster Turret"
-	turret -50 39.5 "Modified Blaster Turret"
-	turret 50 39.5 "Modified Blaster Turret"
+	turret -50 39.5 "Proton Turret"
+	turret 50 39.5 "Proton Turret"
 	explode "tiny explosion" 40
 	explode "small explosion" 55
 	explode "medium explosion" 60
@@ -285,16 +288,18 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 	add attributes
 		"engine capacity" 25
 	outfits
-		"Proton Gun" 3
-		"Heavy Laser Turret" 4
+		"Proton Gun" 4
+		"Modified Blaster Turret" 2
+		"Quad Blaster Turret" 2
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
-		"Liquid Nitrogen Cooler"
+		"Liquid Helium Cooler"
+		"Large Radar Jammer"
 		"Outfits Expansion" 4
 		"Laser Rifle" 80
-		"Supercapacitor" 3
+		"Security Station" 3
 		
 		"A860 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -307,10 +312,10 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 	gun 16 -86.5
 	gun -19 -76.5
 	gun 19 -76.5
-	turret -16 -29
-	turret 16 -29
-	turret -50 39.5
-	turret 50 39.5
+	turret -16 -29 "Modified Blaster Turret"
+	turret 16 -29 "Modified Blaster Turret"
+	turret -50 39.5 "Quad Blaster Turret"
+	turret 50 39.5 "Quad Blaster Turret"
 	description "Whoever modified this Falcon clearly valued speed above all else. Major sections of the hull have been reconfigured to accommodate the largest possible engines. If hot-rodding across the galaxy in a 1000-ton warship that handles like a Flivver is your dream, look no further."
 
 

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -506,7 +506,7 @@ ship "Marauder Leviathan"
 		"Fusion Reactor"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
-		"Hai Diamond Regenerator"
+		"D67-TM Shield Generator"
 		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 2

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -169,11 +169,12 @@ ship "Marauder Bounder" "Marauder Bounder (Engines)"
 	add attributes
 		"engine capacity" 15
 	outfits
+		"Heavy Rocket Pod"
+		"Heavy Rocket" 2
 		"Quad Blaster Turret" 2
 		
 		"Dwarf Core"
 		"LP072a Battery Pack"
-		"Supercapacitor" 3
 		"D23-QP Shield Generator"
 		"Water Coolant System"
 		"Outfits Expansion"
@@ -326,7 +327,7 @@ ship "Marauder Falcon" "Marauder Falcon (Weapons)"
 		"weapon capacity" 35
 	outfits
 		"Plasma Cannon" 6
-		"Heavy Anti-Missile Turret"
+		"Chameleon Anti-Missile"
 		"Proton Turret" 3
 		
 		"Fusion Reactor"
@@ -575,7 +576,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
 		"Particle Cannon" 2
 		"Ion Cannon" 2
 		"Heavy Laser Turret" 3
-		"Anti-Missile Turret"
+		"Bullfrog Anti-Missile"
 
 		"Fusion Reactor"
 		"LP144a Battery Pack"

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -68,15 +68,15 @@ ship "Marauder Arrow" "Marauder Arrow (Engines)"
 		"engine capacity" 20
 	outfits
 		"Heavy Laser" 2
-		"Anti-Missile Turret"
 		
 		"Dwarf Core"
-		"Supercapacitor"
+		"Supercapacitor" 2
 		"D14-RN Shield Generator"
 		"Laser Rifle" 5
 		
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
+		"Volcano Afterburner"
 		"Hyperdrive"
 		
 	description "With expanded engine mounts, this Arrow seems more like an oversized missile than a ship. The beefed-up engines, a little extra outfit capacity, extra shield emitters, and thicker hull plating make this vessel a very competent interceptor."

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -334,7 +334,7 @@ ship "Marauder Falcon" "Marauder Falcon (Weapons)"
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
-		"Afterburner"
+		"Volcano Afterburner"
 		"Hyperdrive"
 	
 	engine -16.5 143

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -252,7 +252,7 @@ ship "Marauder Falcon"
 		
 		"Fusion Reactor"
 		"Dwarf Core"
-		"LP288a Battery Pack"
+		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
 		"Large Radar Jammer"
 		"Liquid Helium Cooler"
@@ -548,7 +548,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
-		"D94-YV Shield Generator" 3
+		"D94-YV Shield Generator" 2
 		"Supercapacitor" 5
 		"Large Radar Jammer"
 		"Liquid Nitrogen Cooler"
@@ -850,7 +850,7 @@ ship "Marauder Quicksilver" "Marauder Quicksilver (Weapons)"
 		"Dwarf Core"
 		"LP072a Battery Pack"
 		"D67-TM Shield Generator"
-		"Cooling Duct"
+		"Cooling Ducts"
 		"Security Station" 4
 		"Laser Rifle"
 		
@@ -986,7 +986,7 @@ ship "Marauder Raven" "Marauder Raven (Weapons)"
 		"Breeder Reactor"
 		"Supercapacitor" 3
 		"Liquid Nitrogen Cooler"
-		"Cooling Duct"
+		"Cooling Ducts"
 		"Outfits Expansion"
 		
 		"A250 Atomic Thruster"

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -549,7 +549,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 		"Fusion Reactor"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator" 2
-		"Supercapacitor" 5
+		"Security Station" 5
 		"Large Radar Jammer"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion" 2


### PR DESCRIPTION
**Balance**

This PR addresses part of a problem described a bit in issue https://github.com/endless-sky/endless-sky/issues/7763

## Summary
The synd shield regen is too easy to acquire from these ships, giving you even less incentive to play checkmate and causing issues if we want to rebalance them, due to how easily and early they're available.
For consistency we also removed the electron guns.

In order to compensate for removing those, I added a smidge more Hai technology to some marauder builds - it could be done more so later on if we feel like this is a good decision. (rn its only 2 small shield gen, one battery and a small a big AM)

Some marauder ships also had a bunch of outfit space left over after the battery buff, and this fills it up, whilst making them and some others a tad bit more original as well.


## Testing Done
n/a

## Save File
n/a