### PR TITLE
Bugfix: make the marauding max not over outfit space limit

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -260,8 +260,9 @@ ship "Marauder Fury"
 		"Hai Tracker Pod" 2
 		"Meteor Missile Launcher" 2
 		"Meteor Missile Pod" 2
+		"Meteor Missile Box"
 		"Hai Tracker" 112
-		"Meteor Missile" 94
+		"Meteor Missile" 109
 
 		"Systems Core (Small)"
 		"Red Sun Reactor"

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -258,9 +258,10 @@ ship "Marauder Fury"
 			"hit force" 520
 	outfits
 		"Hai Tracker Pod" 2
-		"Meteor Missile Launcher" 4
+		"Meteor Missile Launcher" 2
+		"Meteor Missile Pod" 2
 		"Hai Tracker" 112
-		"Meteor Missile" 140
+		"Meteor Missile" 94
 
 		"Systems Core (Small)"
 		"Red Sun Reactor"
@@ -280,8 +281,8 @@ ship "Marauder Fury"
 	engine 0 46
 	gun -13.5 -36 "Meteor Missile Launcher"
 	gun 13.5 -36 "Meteor Missile Launcher"
-	gun -20 -25 "Meteor Missile Launcher"
-	gun 20 -25 "Meteor Missile Launcher"
+	gun -20 -25 "Meteor Missile Pod"
+	gun 20 -25 "Meteor Missile Pod"
 	gun -6 -41.5
 	gun 6 -41.5
 	gun -43.5 2 "Hai Tracker Pod"


### PR DESCRIPTION
**Bug fix**

## Summary
When you launch the game you get an error about marauding max taking too much outfit and weapon space, due to https://github.com/endless-sky/endless-sky/pull/6260 making the meteor take more space.
![image](https://github.com/endless-sky/endless-sky/assets/94366726/ac1d1ebd-95dd-4c05-89d1-def1b406ab5d)

This equips 2 meteor pods instead of 2 launchers, resulting in 22 gained outfit and weapon space (also added a storage box whilst I was at it).