### PR TITLE
chore(CI): Update Github Actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Package Application
         run: ./utils/build_appimage.sh build/release
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
@@ -78,7 +78,7 @@ jobs:
           cmake --install build/release
           7z a ${{ env.OUTPUT }} "./install/release/*"
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
@@ -110,7 +110,7 @@ jobs:
           cmake --install build/release
           7z a ${{ env.OUTPUT }} "./install/release/*"
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
@@ -166,7 +166,7 @@ jobs:
               --pre-release
           fi
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ${{ github.workspace }} # This will download all files to e.g `./EndlessSky-win64.zip/EndlessSky-win64.zip`
       - name: Add ${{ env.OUTPUT_APPIMAGE }} to release tag

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Package Application
         run: ./utils/build_appimage.sh build/release
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
@@ -68,12 +68,12 @@ jobs:
           cmake --install build/release
           7z a ${{ env.OUTPUT }} "./install/release/*"
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
       - name: Upload Steam Depot
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: steam-win64-depot
           path: |
@@ -124,7 +124,7 @@ jobs:
           ln -s /Applications "${{ env.OUTPUT }}"
           hdiutil create -ov -fs HFS+ -format UDZO -imagekey zlib-level=9 -srcfolder "${{ env.OUTPUT }}" "${{ github.workspace }}/${{ env.OUTPUT }}.dmg"
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OUTPUT }}.dmg
           path: ${{ env.OUTPUT }}.dmg
@@ -137,7 +137,7 @@ jobs:
           mkdir depot/
           mv "Endless Sky.app/" depot/
       - name: Upload Steam Depot
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: steam-macos-depot
           path: depot
@@ -157,7 +157,7 @@ jobs:
     - name: Prepare binary
       run: cp build/steam-x64/endless-sky .
     - name: Upload Steam Depot
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: steam-linux64-depot
         path: endless-sky
@@ -179,7 +179,7 @@ jobs:
       with:
         show-progress: false
     - name: Upload Steam Data Depot
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.data }}
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,12 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset mingw-ci-benchmark
     - name: Upload binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: binary-windows
         path: ./build/ci/Endless Sky.exe
     - name: Upload DLLs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: windows-dlls
         path: ./build/ci/*.dll
@@ -191,12 +191,12 @@ jobs:
     # Otherwise download the binary from CI.
     - name: Download game binary from CI
       if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.cmake_files == 'true' }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: binary-windows
     - name: Download DLLs from CI
       if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.cmake_files == 'true' }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: windows-dlls
     - name: Parse Datafiles

--- a/.github/workflows/compute-changes.yml
+++ b/.github/workflows/compute-changes.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         fetch-depth: 2
         show-progress: false
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         filters: .github/path-filters.yml

--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -99,7 +99,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -117,7 +117,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -47,7 +47,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends libosmesa6 mesa-utils
     - name: Restore cached Steam Runtime environment
       id: cache-runtime
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ env.runtime }}
@@ -73,7 +73,7 @@ jobs:
         cd steam
         docker-compose run test-steam-${{ matrix.arch }}
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: binary-steam-${{ matrix.arch }}
         path: build/steam-${{ matrix.arch }}/endless-sky


### PR DESCRIPTION
**CI/CD/Testing**

This PR updates various Github Actions.

## Summary

`download-artifact` and `upload-artifact` updated to `v4`, bringing some massive improvements:
> up to 80% faster download times and 96% faster upload times

`paths-filter`, `cache`, `setup-python` were updated to no longer use the unsupported Node 16.