### PR TITLE
Allow blast radius projectiles to explode when their lifetime runs out

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2148,8 +2148,7 @@ void Engine::DoCollisions(Projectile &projectile)
 	vector<Collision> collisions;
 	const Government *gov = projectile.GetGovernment();
 
-	// If this "projectile" is a ship explosion, it always explodes.
-	if(!gov)
+	if(projectile.ShouldExplode())
 		collisions.emplace_back(nullptr, CollisionType::NONE, 0.);
 	else if(projectile.GetWeapon().IsPhasing() && projectile.Target())
 	{

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -468,5 +468,5 @@ uint16_t Projectile::HitsRemaining() const
 
 bool Projectile::ShouldExplode() const
 {
-	return !government || (weapon->IsExplodeOnDeath() && lifetime == 1);
+	return !government || (weapon->IsFused() && lifetime == 1);
 }

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -468,5 +468,5 @@ uint16_t Projectile::HitsRemaining() const
 
 bool Projectile::ShouldExplode() const
 {
-	return !government || weapon->IsExplodeOnDeath() && lifeitme == 1;
+	return !government || (weapon->IsExplodeOnDeath() && lifetime == 1);
 }

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -463,3 +463,10 @@ uint16_t Projectile::HitsRemaining() const
 {
 	return hitsRemaining;
 }
+
+
+
+bool Projectile::ShouldExplode() const
+{
+	return !government || weapon->IsExplodeOnDeath() && lifeitme == 1;
+}

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -100,10 +100,8 @@ public:
 	double DistanceTraveled() const;
 	// Get the number of objects this projectile can still collide with.
 	uint16_t HitsRemaining() const;
-	// Get whether this projectile should explode on the next frame.
-	// This is true for ship explosions and projectiles from weapons with
-	// the "isExplodeOnDeath" set to true and that are on the last frame of
-	// their lifetime.
+	// Get whether this projectile should explode the next time collision
+	// detection is run.
 	bool ShouldExplode() const;
 
 

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -100,6 +100,11 @@ public:
 	double DistanceTraveled() const;
 	// Get the number of objects this projectile can still collide with.
 	uint16_t HitsRemaining() const;
+	// Get whether this projectile should explode on the next frame.
+	// This is true for ship explosions and projectiles from weapons with
+	// the "isExplodeOnDeath" set to true and that are on the last frame of
+	// their lifetime.
+	bool ShouldExplode() const;
 
 
 private:

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -58,8 +58,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			isParallel = true;
 		else if(key == "gravitational")
 			isGravitational = true;
-		else if(key == "explode on death")
-			isExplodeOnDeath = true;
+		else if(key == "fused")
+			isFused = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -58,6 +58,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			isParallel = true;
 		else if(key == "gravitational")
 			isGravitational = true;
+		else if(key == "explode on death")
+			isExplodeOnDeath = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -154,6 +154,10 @@ public:
 	// Gravitational weapons deal the same amount of hit force to a ship regardless
 	// of its mass.
 	bool IsGravitational() const;
+	// True if this projectile should create an explosion at the end of its lifetime
+	// instead of simply disappearing or only creating a die effect. Blast radius
+	// weapons will cause a blast at the end of their lifetime.
+	bool IsExplodeOnDeath() const;
 
 	// These values include all submunitions:
 	// Normal damage types:
@@ -239,6 +243,7 @@ private:
 	bool isPhasing = false;
 	bool isDamageScaled = true;
 	bool isGravitational = false;
+	bool isExplodeOnDeath = false;
 	// Guns and missiles are by default aimed a converged point at the
 	// maximum weapons range in front of the ship. When either the installed
 	// weapon or the gun-port (or both) have the isParallel attribute set
@@ -420,6 +425,7 @@ inline bool Weapon::IsSafe() const { return isSafe; }
 inline bool Weapon::IsPhasing() const { return isPhasing; }
 inline bool Weapon::IsDamageScaled() const { return isDamageScaled; }
 inline bool Weapon::IsGravitational() const { return isGravitational; }
+inline bool Weapon::IsExplodeOnDeath() const { return isExplodeOnDeath; }
 
 inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); }
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -157,7 +157,7 @@ public:
 	// True if this projectile should create an explosion at the end of its lifetime
 	// instead of simply disappearing or only creating a die effect. Blast radius
 	// weapons will cause a blast at the end of their lifetime.
-	bool IsExplodeOnDeath() const;
+	bool IsFused() const;
 
 	// These values include all submunitions:
 	// Normal damage types:
@@ -243,7 +243,7 @@ private:
 	bool isPhasing = false;
 	bool isDamageScaled = true;
 	bool isGravitational = false;
-	bool isExplodeOnDeath = false;
+	bool isFused = false;
 	// Guns and missiles are by default aimed a converged point at the
 	// maximum weapons range in front of the ship. When either the installed
 	// weapon or the gun-port (or both) have the isParallel attribute set
@@ -425,7 +425,7 @@ inline bool Weapon::IsSafe() const { return isSafe; }
 inline bool Weapon::IsPhasing() const { return isPhasing; }
 inline bool Weapon::IsDamageScaled() const { return isDamageScaled; }
 inline bool Weapon::IsGravitational() const { return isGravitational; }
-inline bool Weapon::IsExplodeOnDeath() const { return isExplodeOnDeath; }
+inline bool Weapon::IsFused() const { return isFused; }
 
 inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); }
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #9765.

## Summary
Add a new weapon attribute with no value (like "cluster" or "safe").
* `"fused"`: Causes the projectile to explode when it reaches the last frame of its lifetime. Normally, a projectile that reaches the last frame of its lifetime just disappears, creating any "die effect" that may be present on the weapon.

## Usage examples
The following weapon would create an explosion the moment it is fired, dealing 1000 shield or hull damage to everything within 1000 units. The use of "fused" is what causes the projectile to instantly create an explosion without the need of a trigger radius. The use of "safe range override" allows NPCs to ignore the fact that they're about to also damage themself. This is effectively what is desired out of an aura weapon as described in the linked issue.
```
weapon
	reload 180
	lifetime 1
	velocity 0
	"range override" 1000
	"blast radius" 1000
	"safe range override" 0
	"shield damage" 1000
	"hull damage" 1000
	"fused"
```

## Testing Done
Added `"fused"` to a heavy rocket launcher. Without this PR, heavy rockets that reach the end of their lifetime create a small explosion effect, but don't actually damage anything nearby. With this PR, the rockets create their normal hit effect at the end of their lifetime and cause damage to nearby ships.
