### PR TITLE
Allow missions to customize the dialog text when aborting the mission

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -977,7 +977,8 @@ string Mission::BlockedMessage(const PlayerInfo &player)
 
 
 
-string Mission::AbortedMessage(const PlayerInfo &player) const
+// Get a string to show if the player is about to abort this mission.
+string Mission::AbortMessage(const PlayerInfo &player) const
 {
 	string message = "Abort mission \"" + Name() + "\"?";
 	if(!abortMessage.empty())

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -142,8 +142,8 @@ public:
 	// calling this function, any future calls to it will return an empty string
 	// so that you do not display the same message multiple times.
 	std::string BlockedMessage(const PlayerInfo &player);
-	// Get a string to show if this mission is being aborted.
-	std::string AbortedMessage(const PlayerInfo &player) const;
+	// Get a string to show if the player is about to abort this mission.
+	std::string AbortMessage(const PlayerInfo &player) const;
 	// Check if this mission recommends that the game be autosaved when it is
 	// accepted. This should be set for main story line missions that have a
 	// high chance of failing, such as escort missions.

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -142,6 +142,8 @@ public:
 	// calling this function, any future calls to it will return an empty string
 	// so that you do not display the same message multiple times.
 	std::string BlockedMessage(const PlayerInfo &player);
+	// Get a string to show if this mission is being aborted.
+	std::string AbortedMessage(const PlayerInfo &player) const;
 	// Check if this mission recommends that the game be autosaved when it is
 	// accepted. This should be set for main story line missions that have a
 	// high chance of failing, such as escort missions.
@@ -195,6 +197,7 @@ private:
 	std::string displayName;
 	std::string description;
 	std::string blocked;
+	std::string abortMessage;
 	Location location = SPACEPORT;
 
 	EsUuid uuid;

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -288,7 +288,7 @@ bool MissionPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	else if(key == 'A' || (key == 'a' && (mod & KMOD_SHIFT)))
 	{
 		if(acceptedIt != accepted.end() && acceptedIt->IsVisible())
-			GetUI()->Push(new Dialog(this, &MissionPanel::AbortMission, acceptedIt->AbortedMessage(player)));
+			GetUI()->Push(new Dialog(this, &MissionPanel::AbortMission, acceptedIt->AbortMessage(player)));
 		return true;
 	}
 	else if(key == SDLK_LEFT && availableIt == available.end())

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -288,8 +288,7 @@ bool MissionPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	else if(key == 'A' || (key == 'a' && (mod & KMOD_SHIFT)))
 	{
 		if(acceptedIt != accepted.end() && acceptedIt->IsVisible())
-			GetUI()->Push(new Dialog(this, &MissionPanel::AbortMission,
-				"Abort mission \"" + acceptedIt->Name() + "\"?"));
+			GetUI()->Push(new Dialog(this, &MissionPanel::AbortMission, acceptedIt->AbortedMessage(player)));
 		return true;
 	}
 	else if(key == SDLK_LEFT && availableIt == available.end())


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #2640.

## Summary
Adds a new attribute to missions.
* `"abort message"`: The text provided in the abort message is added to the dialog that appears when you attempt to abort a mission.

## Usage example + Screenshot
```
mission "Test Mission"
	job
	repeat
	destination "Earth"
	"abort message" "This mission is SUPER IMPORTANT! You should totally NOT abort it."
```
![image](https://github.com/endless-sky/endless-sky/assets/17688683/a7e78107-afc2-4450-861c-cf24bc58d610)

## Testing Done
The above screenshot.
Also tested that aborting missions without a custom abort message work fine.
