### PR TITLE
Add a "ship payload" NPC attribute that determines the payload weight of ships in a mission

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -194,8 +194,8 @@ void Mission::Load(const DataNode &node)
 		}
 		else if(child.Token(0) == "apparent payment" && child.Size() >= 2)
 			paymentApparent = child.Value(1);
-		else if(child.Token(0) == "escort payment" && child.Size() >= 2)
-			escortPayment = child.Value(1);
+		else if(child.Token(0) == "escort payload" && child.Size() >= 2)
+			escortPayload = child.Value(1);
 		else if(ParseContraband(child))
 		{
 			// This was an "illegal" or "stealth" entry. It has already been
@@ -1443,11 +1443,11 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	for(const NPC &npc : npcs)
 	{
 		result.npcs.push_back(npc.Instantiate(subs, sourceSystem, result.destination->GetSystem(), jumps,
-			payload, escortPayment));
+			payload, escortPayload));
 		if(result.npcs.back().GetPersonality().IsEscort())
 			escortShips += result.npcs.back().Ships().size();
 	}
-	payload += escortShips * escortPayment;
+	payload += escortShips * escortPayload;
 
 	// Instantiate the actions. The "complete" action is always first so that
 	// the "<payment>" substitution can be filled in.

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -194,6 +194,8 @@ void Mission::Load(const DataNode &node)
 		}
 		else if(child.Token(0) == "apparent payment" && child.Size() >= 2)
 			paymentApparent = child.Value(1);
+		else if(child.Token(0) == "escort payment" && child.Size() >= 2)
+			escortPayment = child.Value(1);
 		else if(ParseContraband(child))
 		{
 			// This was an "illegal" or "stealth" entry. It has already been
@@ -1436,8 +1438,16 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 			+ Identifier() + "\" uses invalid " + std::move(reason));
 		return result;
 	}
+
+	int64_t escortShips = 0;
 	for(const NPC &npc : npcs)
-		result.npcs.push_back(npc.Instantiate(subs, sourceSystem, result.destination->GetSystem(), jumps, payload));
+	{
+		result.npcs.push_back(npc.Instantiate(subs, sourceSystem, result.destination->GetSystem(), jumps,
+			payload, escortPayment));
+		if(result.npcs.back().GetPersonality().IsEscort())
+			escortShips += result.npcs.back().Ships().size();
+	}
+	payload += escortShips * escortPayment;
 
 	// Instantiate the actions. The "complete" action is always first so that
 	// the "<payment>" substitution can be filled in.

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -194,8 +194,6 @@ void Mission::Load(const DataNode &node)
 		}
 		else if(child.Token(0) == "apparent payment" && child.Size() >= 2)
 			paymentApparent = child.Value(1);
-		else if(child.Token(0) == "escort payload" && child.Size() >= 2)
-			escortPayload = child.Value(1);
 		else if(ParseContraband(child))
 		{
 			// This was an "illegal" or "stealth" entry. It has already been
@@ -1439,15 +1437,11 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 		return result;
 	}
 
-	int64_t escortShips = 0;
+	int64_t npcPayload = 0;
 	for(const NPC &npc : npcs)
-	{
 		result.npcs.push_back(npc.Instantiate(subs, sourceSystem, result.destination->GetSystem(), jumps,
-			payload, escortPayload));
-		if(result.npcs.back().GetPersonality().IsEscort())
-			escortShips += result.npcs.back().Ships().size();
-	}
-	payload += escortShips * escortPayload;
+			payload, npcPayload));
+	payload += npcPayload;
 
 	// Instantiate the actions. The "complete" action is always first so that
 	// the "<payment>" substitution can be filled in.

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -229,6 +229,8 @@ private:
 	int passengerLimit = 0;
 	double passengerProb = 0.;
 	int64_t paymentApparent = 0;
+	// The payment per escort per jump.
+	int64_t escortPayment = 0;
 
 	ConditionSet toOffer;
 	ConditionSet toAccept;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -229,8 +229,10 @@ private:
 	int passengerLimit = 0;
 	double passengerProb = 0.;
 	int64_t paymentApparent = 0;
-	// The payment per escort per jump.
-	int64_t escortPayment = 0;
+	// How much each escort counts toward the mission payload per jump.
+	// For reference, each ton of cargo adds 1 payload while each passenger
+	// adds 10.
+	int64_t escortPayload = 0;
 
 	ConditionSet toOffer;
 	ConditionSet toAccept;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -229,10 +229,6 @@ private:
 	int passengerLimit = 0;
 	double passengerProb = 0.;
 	int64_t paymentApparent = 0;
-	// How much each escort counts toward the mission payload per jump.
-	// For reference, each ton of cargo adds 1 payload while each passenger
-	// adds 10.
-	int64_t escortPayload = 0;
 
 	ConditionSet toOffer;
 	ConditionSet toAccept;

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -119,9 +119,12 @@ void NPC::Load(const DataNode &node)
 
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "system")
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		
+		if(key == "system")
 		{
-			if(child.Size() >= 2)
+			if(hasValue)
 			{
 				if(child.Token(1) == "destination")
 					isAtDestination = true;
@@ -131,30 +134,31 @@ void NPC::Load(const DataNode &node)
 			else
 				location.Load(child);
 		}
-		else if(child.Token(0) == "uuid" && child.Size() >= 2)
+		else if(key == "uuid" && hasValue)
 			uuid = EsUuid::FromString(child.Token(1));
-		else if(child.Token(0) == "planet" && child.Size() >= 2)
+		else if(key == "planet" && hasValue)
 			planet = GameData::Planets().Get(child.Token(1));
-		else if(child.Token(0) == "succeed" && child.Size() >= 2)
+		else if(key == "succeed" && hasValue)
 			succeedIf = child.Value(1);
-		else if(child.Token(0) == "fail" && child.Size() >= 2)
+		else if(key == "fail" && hasValue)
 			failIf = child.Value(1);
-		else if(child.Token(0) == "evade")
+		else if(key == "evade")
 			mustEvade = true;
-		else if(child.Token(0) == "accompany")
+		else if(key == "accompany")
 			mustAccompany = true;
-		else if(child.Token(0) == "government" && child.Size() >= 2)
+		else if(key == "government" && hasValue)
 			government = GameData::Governments().Get(child.Token(1));
-		else if(child.Token(0) == "personality")
+		else if(key == "personality")
 			personality.Load(child);
-		else if(child.Token(0) == "cargo settings" && child.HasChildren())
+		else if(key == "cargo settings" && child.HasChildren())
 		{
 			cargo.Load(child);
 			overrideFleetCargo = true;
 		}
-		else if(child.Token(0) == "dialog")
+		else if(key == "ship payload" && hasValue)
+			shipPayload = child.Value(1);
+		else if(key == "dialog")
 		{
-			bool hasValue = (child.Size() > 1);
 			// Dialog text may be supplied from a stock named phrase, a
 			// private unnamed phrase, or directly specified.
 			if(hasValue && child.Token(1) == "phrase")
@@ -175,11 +179,11 @@ void NPC::Load(const DataNode &node)
 			else
 				Dialog::ParseTextNode(child, 1, dialogText);
 		}
-		else if(child.Token(0) == "conversation" && child.HasChildren())
+		else if(key == "conversation" && child.HasChildren())
 			conversation = ExclusiveItem<Conversation>(Conversation(child));
-		else if(child.Token(0) == "conversation" && child.Size() > 1)
+		else if(key == "conversation" && child.Size() > 1)
 			conversation = ExclusiveItem<Conversation>(GameData::Conversations().Get(child.Token(1)));
-		else if(child.Token(0) == "to" && child.Size() >= 2)
+		else if(key == "to" && hasValue)
 		{
 			if(child.Token(1) == "spawn")
 				toSpawn.Load(child);
@@ -188,7 +192,7 @@ void NPC::Load(const DataNode &node)
 			else
 				child.PrintTrace("Skipping unrecognized attribute:");
 		}
-		else if(child.Token(0) == "on" && child.Size() >= 2)
+		else if(key == "on" && hasValue)
 		{
 			static const map<string, Trigger> trigger = {
 				{"assist", Trigger::ASSIST},
@@ -208,7 +212,7 @@ void NPC::Load(const DataNode &node)
 			else
 				child.PrintTrace("Skipping unrecognized attribute:");
 		}
-		else if(child.Token(0) == "ship")
+		else if(key == "ship")
 		{
 			if(child.HasChildren() && child.Size() == 2)
 			{
@@ -219,7 +223,7 @@ void NPC::Load(const DataNode &node)
 					if(grand.Token(0) == "actions" && grand.Size() >= 2)
 						shipEvents[ships.back().get()] = grand.Value(1);
 			}
-			else if(child.Size() >= 2)
+			else if(hasValue)
 			{
 				// Loading a ship managed by GameData, i.e. "base models" and variants.
 				stockShips.push_back(GameData::Ships().Get(child.Token(1)));
@@ -235,12 +239,12 @@ void NPC::Load(const DataNode &node)
 				child.PrintTrace(message);
 			}
 		}
-		else if(child.Token(0) == "fleet")
+		else if(key == "fleet")
 		{
 			if(child.HasChildren())
 			{
 				fleets.emplace_back(ExclusiveItem<Fleet>(Fleet(child)));
-				if(child.Size() >= 2)
+				if(hasValue)
 				{
 					// Copy the custom fleet in lieu of reparsing the same DataNode.
 					size_t numAdded = child.Value(1);
@@ -248,7 +252,7 @@ void NPC::Load(const DataNode &node)
 						fleets.push_back(fleets.back());
 				}
 			}
-			else if(child.Size() >= 2)
+			else if(hasValue)
 			{
 				auto fleet = ExclusiveItem<Fleet>(GameData::Fleets().Get(child.Token(1)));
 				if(child.Size() >= 3 && child.Value(2) > 1.)
@@ -343,6 +347,9 @@ void NPC::Save(DataWriter &out) const
 		}
 		if(!conversation->IsEmpty())
 			conversation->Save(out);
+
+		if(shipPayload)
+			out.Write("ship payload", shipPayload);
 
 		for(const shared_ptr<Ship> &ship : ships)
 		{
@@ -632,7 +639,7 @@ bool NPC::HasFailed() const
 // Create a copy of this NPC but with the fleets replaced by the actual
 // ships they represent, wildcards in the conversation text replaced, etc.
 NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const System *destination,
-		int jumps, int64_t payload, int64_t escortPayload) const
+		int jumps, int64_t payload, int64_t &npcPayload) const
 {
 	NPC result;
 	result.government = government;
@@ -722,8 +729,9 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 				"\" in NPC uses invalid " + std::move(reason));
 		return result;
 	}
-	if(personality.IsEscort())
-		payload += escortPayload * result.ships.size();
+	int64_t additionalPayload = shipPayload * result.ships.size();
+	payload += additionalPayload;
+	npcPayload += additionalPayload;
 	for(const auto &it : npcActions)
 		result.npcActions[it.first] = it.second.Instantiate(subs, origin, jumps, payload);
 

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -121,7 +121,6 @@ void NPC::Load(const DataNode &node)
 	{
 		const string &key = child.Token(0);
 		bool hasValue = child.Size() >= 2;
-		
 		if(key == "system")
 		{
 			if(hasValue)

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -632,7 +632,7 @@ bool NPC::HasFailed() const
 // Create a copy of this NPC but with the fleets replaced by the actual
 // ships they represent, wildcards in the conversation text replaced, etc.
 NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const System *destination,
-		int jumps, int64_t payload, int64_t escortPayment) const
+		int jumps, int64_t payload, int64_t escortPayload) const
 {
 	NPC result;
 	result.government = government;
@@ -723,7 +723,7 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 		return result;
 	}
 	if(personality.IsEscort())
-		payload += escortPayment * result.ships.size();
+		payload += escortPayload * result.ships.size();
 	for(const auto &it : npcActions)
 		result.npcActions[it.first] = it.second.Instantiate(subs, origin, jumps, payload);
 

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -111,7 +111,9 @@ public:
 	// Create a copy of this NPC but with the fleets replaced by the actual
 	// ships they represent, wildcards in the conversation text replaced, etc.
 	NPC Instantiate(std::map<std::string, std::string> &subs, const System *origin, const System *destination,
-			int jumps, int64_t payload) const;
+			int jumps, int64_t payload, int64_t escortPayment) const;
+
+	const Personality &GetPersonality() const;
 
 
 private:

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -111,7 +111,7 @@ public:
 	// Create a copy of this NPC but with the fleets replaced by the actual
 	// ships they represent, wildcards in the conversation text replaced, etc.
 	NPC Instantiate(std::map<std::string, std::string> &subs, const System *origin, const System *destination,
-			int jumps, int64_t payload, int64_t escortPayload) const;
+			int jumps, int64_t payload, int64_t &npcPayload) const;
 
 	const Personality &GetPersonality() const;
 
@@ -129,6 +129,13 @@ private:
 	// The cargo ships in this NPC will be able to carry.
 	FleetCargo cargo;
 	bool overrideFleetCargo = false;
+
+	// How much each ship in this NPC counts toward the mission payload per jump.
+	// For reference, each ton of cargo adds 1 payload while each passenger
+	// adds 10. This ship payload will be added to this NPC's own actions, while
+	// the ship payload across all NPCs in a mission will be added to the mission's
+	// actions.
+	int64_t shipPayload = 0;
 
 	EsUuid uuid;
 

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -111,7 +111,7 @@ public:
 	// Create a copy of this NPC but with the fleets replaced by the actual
 	// ships they represent, wildcards in the conversation text replaced, etc.
 	NPC Instantiate(std::map<std::string, std::string> &subs, const System *origin, const System *destination,
-			int jumps, int64_t payload, int64_t escortPayment) const;
+			int jumps, int64_t payload, int64_t escortPayload) const;
 
 	const Personality &GetPersonality() const;
 


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #2569.

## Summary
Adds a new attribute to mission NPCs:
* `"ship payload"`: Causes ships in an NPC to count toward the mission's "payload", which is used to determine the total pay for the mission. Mission payload is normally `cargo + 10 * passengers`. With this is becomes `cargo + 10 * passengers + (ship payload * number of NPCs) for each NPC`. Note that the payload is multiplied by the payment multiplier (typically 150), which is then multiplied by `jumps to destination + 1`.
  * By default, NPCs still won't add any payment per jump.

Note that we don't know how many ships are present until after all NPCs are instantiated in a mission, but the instantiation of NPCs uses the mission payload to determine the payments of actions within those NPCs. As such, each NPC action will take the base payload of the mission with only cargo and passengers accounted for and add the NPC's own ship payload. The mission will take into account the payload added by all NPCs, though. For example, if you have two NPC blocks where one has 2 ships, the other has 3, and both have a ship payload of 100, then actions from the mission will add 5 * 100 to the normal mission payload, but each NPC will only add 2 * 100 and 3 * 100 to the payloads that they use respectively.

This also fixes a bug where the `<npc>` text replacement wouldn't work in NPC action text, as actions were being instantiated before the NPC's ships were.

## Usage examples
The payload for the following mission would be `20 + 10 * 4 + 50 * 1 = 110`. That results in `110 * 150 = 16,500` per jump to the destination.
```
mission "Overbooked"
	job
	description "This captain has booked more cargo and passengers than he can fit in his Shuttle. He would like for you to escort him to <destination> while taking care of his overbooked <tons> of cargo and <bunks> passengers. Payment is <payment>."
	destination "Earth"
	passengers 4
	cargo 20
	npc save accompany
		government "Merchant"
		personality escort
		"ship payload" 50
		ship "Shuttle" "Dim Light Bulb"
	on complete
		payment 20000 150
```

## Testing Done
Created a job to escort one ship to Earth with a ship payload of 50 and an on complete payment of `payment 10000 150`. Landed on planets at various distances to Sol with and without the ship payload active and observed that the job payment was higher when the ship payload was active. Also observed that changing the number of ships changed the final payment for the same distance.