### PR TITLE
Add tagging system to outfits/ships that can be queried with a "tag:" condition

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -279,13 +279,21 @@ void Outfit::Load(const DataNode &node)
 		{
 			// Add any new licenses that were specified "inline".
 			if(child.Size() >= 2)
-			{
 				for(auto it = ++begin(child.Tokens()); it != end(child.Tokens()); ++it)
 					AddLicense(*it);
-			}
 			// Add any new licenses that were specified as an indented list.
 			for(const DataNode &grand : child)
 				AddLicense(grand.Token(0));
+		}
+		else if(child.Token(0) == "tag" && (child.HasChildren() || child.Size() >= 2))
+		{
+			// Add any new tags that were specified "inline".
+			if(child.Size() >= 2)
+				for(auto it = ++begin(child.Tokens()); it != end(child.Tokens()); ++it)
+					tags.insert(*it);
+			// Add any new tags that were specified as an indented list.
+			for(const DataNode &grand : child)
+				tags.insert(grand.Token(0));
 		}
 		else if(child.Token(0) == "jump range" && child.Size() >= 2)
 		{
@@ -434,10 +442,18 @@ const string &Outfit::Description() const
 
 
 
-// Get the licenses needed to purchase this outfit.
+// Get the licenses needed to purchase this item.
 const vector<string> &Outfit::Licenses() const
 {
 	return licenses;
+}
+
+
+
+	// Get the tags that have been placed on this item.
+const set<string> &Outfit::Tags() const
+{
+	return tags;
 }
 
 

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -21,6 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Dictionary.h"
 
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -44,6 +45,7 @@ public:
 	// These are all the possible category strings for outfits.
 	static const std::vector<std::string> CATEGORIES;
 
+
 public:
 	// An "outfit" can be loaded from an "outfit" node or from a ship's
 	// "attributes" node.
@@ -60,8 +62,10 @@ public:
 	const std::string &Description() const;
 	int64_t Cost() const;
 	double Mass() const;
-	// Get the licenses needed to buy or operate this ship.
+	// Get the licenses needed to buy this item.
 	const std::vector<std::string> &Licenses() const;
+	// Get the tags that have been placed on this item.
+	const std::set<std::string> &Tags() const;
 	// Get the image to display in the outfitter when buying this item.
 	const Sprite *Thumbnail() const;
 
@@ -124,6 +128,7 @@ private:
 	double mass = 0.;
 	// Licenses needed to purchase this item.
 	std::vector<std::string> licenses;
+	std::set<std::string> tags;
 
 	Dictionary attributes;
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3693,6 +3693,37 @@ void PlayerInfo::RegisterDerivedConditions()
 		return retVal;
 	});
 
+	// The following condition checks if the player has an outfit/ship with the given tag.
+	auto &&allTagsProdivder = conditions.GetProviderPrefixed("tag: ");
+	auto allTagsFun = [this](const string &name) -> int
+	{
+		string tag = name.substr(strlen("tag: "));
+		int count = 0;
+		for(const shared_ptr<Ship> &ship : ships)
+		{
+			if(ship->IsDestroyed())
+				continue;
+			if(ship->BaseAttributes().Tags().count(tag))
+				++count;
+			for(const auto &outfit : ship->Outfits())
+				if(outfit.first->Tags().count(tag))
+					count += outfit.second;
+			for(const auto &outfit : ship->Cargo().Outfits())
+				if(outfit.first->Tags().count(tag))
+					count += outfit.second;
+		}
+		for(const auto &outfit : Cargo().Outfits())
+			if(outfit.first->Tags().count(tag))
+				count += outfit.second;
+		for(const auto &storage : planetaryStorage)
+			for(const auto &outfit : storage.second.Outfits())
+				if(outfit.first->Tags().count(tag))
+					count += outfit.second;
+		return count;
+	};
+	allTagsProdivder.SetHasFunction(allTagsFun);
+	allTagsProdivder.SetGetFunction(allTagsFun);
+
 	// This condition corresponds to the method by which the flagship entered the current system.
 	auto &&systemEntryProvider = conditions.GetProviderPrefixed("entered system by: ");
 	auto systemEntryFun = [this](const string &name) -> bool

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -957,6 +957,16 @@ void Ship::Save(DataWriter &out) const
 			for(const auto &it : baseAttributes.HyperOutSounds())
 				for(int i = 0; i < it.second; ++i)
 					out.Write("hyperdrive out sound", it.first->Name());
+			if(!baseAttributes.Tags().empty())
+			{
+				out.Write("tag");
+				out.BeginChild();
+				{
+					for(const string &tag : baseAttributes.Tags())
+						out.Write(tag);
+				}
+				out.EndChild();
+			}
 			for(const auto &it : baseAttributes.Attributes())
 				if(it.second)
 					out.Write(it.first, it.second);


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #2481

## Summary
Adds a new outfit/ship attribute:
* `tag`: An attribute that behaves like `license` in that values are strings that can be defined either in a list on the same line as the `tag`, or as children with each tag on a new line.

Missions can determine if the player has a tagged outfit/ship using the following autocondition:
* `"tag: <tag name>"`: Returns a value for the number of ships or outfits you have with the given tag name.

Note that tags should be a last line of defense; if you're able to check if the player has a certain outfit by checking attributes, you should do so. If you can check outfit names because the number of possible outfits is low, you should do so.

The intention of tagging is to be used in conditions to determine if a mission should offer, a branch should be taken, an NPC should spawn or despawn, etc. for wherever conditions should be used. The intention is not to allow tags to be used to remove outfits of a certain tag from your ship.

## Usage examples
Go wild.

## Testing Done
Tester? I hardly know her.
