### PR TITLE
Added an "on save" NPC action

### DIFF
--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -117,6 +117,28 @@ namespace {
 			message += "flagship.";
 		Messages::Add(message, Messages::Importance::High);
 	}
+
+	int CountInCargo(const Outfit *outfit, const PlayerInfo &player)
+	{
+		int available = 0;
+		// If landed, all cargo from available ships is pooled together.
+		if(player.GetPlanet())
+			available += player.Cargo().Get(outfit);
+		// Otherwise only count outfits in the cargo holds of in-system ships.
+		else
+		{
+			const System *here = player.GetSystem();
+			for(const auto &ship : player.Ships())
+			{
+				if(ship->IsDisabled() || ship->IsParked())
+					continue;
+				if(ship->GetSystem() == here || (ship->CanBeCarried()
+						&& !ship->GetSystem() && ship->GetParent()->GetSystem() == here))
+					available += ship->Cargo().Get(outfit);
+			}
+		}
+		return available;
+	}
 }
 
 
@@ -303,6 +325,39 @@ const map<const Outfit *, int> &GameAction::Outfits() const noexcept
 const vector<ShipManager> &GameAction::Ships() const noexcept
 {
 	return giftShips;
+}
+
+
+
+// Check if this action can be completed right now.
+bool GameAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &boardingShip) const
+{	
+	if(player.Accounts().Credits() < -payment)
+		return false;
+
+	const Ship *flagship = player.Flagship();
+	for(auto &&it : giftOutfits)
+	{
+		// If this outfit is being given, the player doesn't need to have it.
+		if(it.second > 0)
+			continue;
+
+		// Outfits may always be taken from the flagship. If landed, they may also be taken from
+		// the collective cargo hold of any in-system, non-disabled escorts (player.Cargo()). If
+		// boarding, consider only the flagship's cargo hold. If in-flight, show mission status
+		// by checking the cargo holds of ships that would contribute to player.Cargo if landed.
+		int available = flagship ? flagship->OutfitCount(it.first) : 0;
+		available += boardingShip ? flagship->Cargo().Get(it.first)
+				: CountInCargo(it.first, player);
+
+		if(available < -it.second)
+			return false;
+	}
+
+	for(auto &&it : giftShips)
+		if(!it.CanBeDone(player))
+			return false;
+	return true;
 }
 
 

--- a/source/GameAction.h
+++ b/source/GameAction.h
@@ -66,6 +66,8 @@ public:
 	const std::map<const Outfit *, int> &Outfits() const noexcept;
 	const std::vector<ShipManager> &Ships() const noexcept;
 
+	// Check if this action can be completed right now.
+	bool CanBeDone(const PlayerInfo &player, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
 	// Perform this action.
 	void Do(PlayerInfo &player, UI *ui, const Mission *caller) const;
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1067,6 +1067,9 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	{
 		--player.Conditions()[name + ": active"];
 		++player.Conditions()[name + ": done"];
+		// Run any SAVE actions on NPCs from this mission.
+		for(auto &npc : npcs)
+			npc.DoAction(NPC::Trigger::SAVE, player, ui, this);
 	}
 
 	// "Jobs" should never show dialogs when offered, nor should they call the

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -222,32 +222,7 @@ const string &MissionAction::DialogText() const
 // if it takes away money or outfits that the player does not have.
 bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &boardingShip) const
 {
-	if(player.Accounts().Credits() < -Payment())
-		return false;
-
 	const Ship *flagship = player.Flagship();
-	for(auto &&it : action.Outfits())
-	{
-		// If this outfit is being given, the player doesn't need to have it.
-		if(it.second > 0)
-			continue;
-
-		// Outfits may always be taken from the flagship. If landed, they may also be taken from
-		// the collective cargo hold of any in-system, non-disabled escorts (player.Cargo()). If
-		// boarding, consider only the flagship's cargo hold. If in-flight, show mission status
-		// by checking the cargo holds of ships that would contribute to player.Cargo if landed.
-		int available = flagship ? flagship->OutfitCount(it.first) : 0;
-		available += boardingShip ? flagship->Cargo().Get(it.first)
-				: CountInCargo(it.first, player);
-
-		if(available < -it.second)
-			return false;
-	}
-
-	for(auto &&it : action.Ships())
-		if(!it.CanBeDone(player))
-			return false;
-
 	for(auto &&it : requiredOutfits)
 	{
 		// Maps are not normal outfits; they represent the player's spatial awareness.
@@ -292,7 +267,7 @@ bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &
 	// specifies the systems in which it can occur.
 	if(!systemFilter.IsEmpty() && !systemFilter.Matches(player.GetSystem()))
 		return false;
-	return true;
+	return action.CanBeDone(player, boardingShip);
 }
 
 

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -63,6 +63,8 @@ public:
 		ENCOUNTER,
 		// Can be triggered by either the CAPTURE or DESTROY events.
 		KILL,
+		// Triggered when the mission is completed and this NPC is still alive.
+		SAVE,
 	};
 
 
@@ -99,6 +101,7 @@ public:
 	// Handle the given ShipEvent.
 	void Do(const ShipEvent &event, PlayerInfo &player, UI *ui = nullptr,
 		const Mission *caller = nullptr, bool isVisible = true);
+	void DoAction(Trigger trigger, PlayerInfo &player, UI *ui = nullptr, const Mission *caller = nullptr);
 	// Determine if the NPC is in a successful state, assuming the player is in the given system.
 	// (By default, a despawnable NPC has succeeded and is not actually checked.)
 	bool HasSucceeded(const System *playerSystem, bool ignoreIfDespawnable = true) const;

--- a/source/NPCAction.cpp
+++ b/source/NPCAction.cpp
@@ -77,12 +77,18 @@ string NPCAction::Validate() const
 
 
 
+// Determine if this action can be done.
+bool NPCAction::CanBeDone(const PlayerInfo &player) const
+{
+	return !triggered && action.CanBeDone(player);
+}
+
+
+
 void NPCAction::Do(PlayerInfo &player, UI *ui, const Mission *caller)
 {
 	// All actions are currently one-time-use. Actions that are used
 	// are marked as triggered, and cannot be used again.
-	if(triggered)
-		return;
 	triggered = true;
 	action.Do(player, ui, caller);
 }

--- a/source/NPCAction.h
+++ b/source/NPCAction.h
@@ -45,6 +45,8 @@ public:
 	// Determine if this NPCAction references content that is not fully defined.
 	std::string Validate() const;
 
+	// Determine if this action can be done.
+	bool CanBeDone(const PlayerInfo &player) const;
 	// Perform this action.
 	void Do(PlayerInfo &player, UI *ui = nullptr, const Mission *caller = nullptr);
 


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue comment https://github.com/endless-sky/endless-sky/issues/2569#issuecomment-307309701

## Summary
Adds a new NPC action
* `on save`: When the mission is completed, if no ships in this NPC have been lost, then this mission action fires.

There's a lot of refactoring involved in this one, as I also noticed that we were never checking if an NPC action can be done before triggering it. Therefore, NPCAction and GameAction now have CanBeDone functions like MissionAction has. If CanBeDone returns false, the action can never run.

## Usage examples
For the following mission, losing each NPC individually wouldn't fail the mission. Losing all three NPCs would fail the mission due to the "lost npc" condition hitting 3. For each NPC that is still alive when the mission completes, you gain 100k credits.
```
mission "Save what you can!"
	npc accompany
		government "Merchant"
		personality escort
		ship "Star Barge" "Thing 1"
		on kill
			"lost npc" ++
		on save
			payment 100000
	npc accompany
		government "Merchant"
		personality escort
		ship "Star Barge" "Thing 2"
		on kill
			"lost npc" ++
		on save
			payment 100000
	npc accompany
		government "Merchant"
		personality escort
		ship "Star Barge" "The Cat in the Hat"
		on kill
			"lost npc" ++
		on save
			payment 100000
	to fail
		"lost npc" == 3
```

## Testing Done
No, but I really should.
