### PR TITLE
fix(ui): Add missing message colors

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -170,7 +170,11 @@ color "warning no command" 0.16 0.16 0.13 1.
 
 # Colors used for messages
 color "message importance highest" 1. .5 0. 1.
+color "message importance high" .75 .75 .75 1.
 color "message importance info" 0. 1. .5 1.
+color "message importance daily" 0. .5 1. 1.
+color "message importance low" .75 .75 .75 1.
+
 color "message log importance highest" 1. .5 0. 1.
 color "message log importance high" .75 .75 .75 1.
 color "message log importance info" 0. 1. .5 1.


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #9818

## Summary
Adds the missing colors for messages.