### PR TITLE
Allow projectiles to emit sub-projectiles while they are alive

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -159,7 +159,7 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 		double range = sourceEmission.emissionRange;
 		if(emission.armingTime)
 			--emission.armingTime;
-		else if(emission.burstReload <= 0. && emission.burstCount 
+		else if(emission.burstReload <= 0. && emission.burstCount
 				&& (!range || (target && position.DistanceSquared(target->Position()) < range * range)))
 		{
 			for(size_t i = 0; i < sourceEmission.projectileCount; ++i)

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -67,6 +67,13 @@ Projectile::Projectile(const Ship &parent, Point position, Angle angle, const We
 	// If a random lifetime is specified, add a random amount up to that amount.
 	if(weapon->RandomLifetime())
 		lifetime += Random::Int(weapon->RandomLifetime() + 1);
+
+	for(const Weapon::Emission &emission : weapon->Emissions())
+	{
+		const Weapon *const weapon = emission.weapon;
+		if(weapon && weapon->IsWeapon())
+			emissions.emplace_back(emission);
+	}
 }
 
 
@@ -92,6 +99,13 @@ Projectile::Projectile(const Projectile &parent, const Point &offset, const Angl
 	// If a random lifetime is specified, add a random amount up to that amount.
 	if(weapon->RandomLifetime())
 		lifetime += Random::Int(weapon->RandomLifetime() + 1);
+
+	for(const Weapon::Emission &emission : weapon->Emissions())
+	{
+		const Weapon *const weapon = emission.weapon;
+		if(weapon && weapon->IsWeapon())
+			emissions.emplace_back(emission);
+	}
 }
 
 
@@ -146,7 +160,7 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 		if(emission.armingTime)
 			--emission.armingTime;
 		else if(emission.burstReload <= 0. && emission.burstCount 
-				&& (!range || (target && target->Position().DistanceSquared(position) < range * range)))
+				&& (!range || (target && position.DistanceSquared(target->Position()) < range * range)))
 		{
 			for(size_t i = 0; i < sourceEmission.projectileCount; ++i)
 			{

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Angle.h"
 #include "Point.h"
+#include "Weapon.h"
 
 #include <cstdint>
 #include <memory>
@@ -28,7 +29,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 class Government;
 class Ship;
 class Visual;
-class Weapon;
 
 
 
@@ -103,11 +103,27 @@ public:
 
 
 private:
+	class LiveEmission {
+	public:
+		LiveEmission(const Weapon::Emission &emission)
+			: sourceEmission(emission), armingTime(emission.armingTime), burstCount(emission.weapon->BurstCount()) {}
+
+		const Weapon::Emission &sourceEmission;
+		std::size_t fired = 0;
+		int armingTime = 0;
+		double reload = 0.;
+		double burstReload = 0.;
+		int burstCount = 1;
+	};
+
+
+private:
 	void CheckLock(const Ship &target);
 
 
 private:
 	const Weapon *weapon = nullptr;
+	std::vector<LiveEmission> emissions;
 
 	std::weak_ptr<Ship> targetShip;
 	const Ship *cachedTarget = nullptr;

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -477,6 +477,13 @@ const vector<Weapon::Submunition> &Weapon::Submunitions() const
 
 
 
+const vector<Weapon::Emission> &Weapon::Emissions() const
+{
+	return emissions;
+}
+
+
+
 double Weapon::TotalLifetime() const
 {
 	if(rangeOverride)

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -28,6 +28,39 @@ using namespace std;
 
 
 
+Weapon::Emission::Emission(const DataNode &node)
+{
+	weapon = GameData::Outfits().Get(node.Token(1));
+	projectileCount = node.Size() >= 3 ? node.Value(2) : 1;
+
+	for(const DataNode &child : node)
+	{
+		const string &key = child.Token(0);
+		if(key == "aim at target")
+			aimAtTarget = true;
+		else if(child.Size() < 2)
+			child.PrintTrace("Unrecognized attribute:");
+		else
+		{
+			double value = child.Value(1);
+			if(key == "facing")
+				facing = Angle(value);
+			else if(key == "offset" && child.Size() >= 3)
+				offset = Point(value, child.Value(2));
+			else if(key == "emission range")
+				emissionRange = value;
+			else if(key == "emission count")
+				emissionCount = static_cast<size_t>(value);
+			else if(key == "arming time")
+				armingTime = value;
+			else
+				child.PrintTrace("Unrecognized attribute:");
+		}
+	}
+}
+
+
+
 // Load from a "weapon" node, either in an outfit or in a ship (explosion).
 void Weapon::LoadWeapon(const DataNode &node)
 {
@@ -113,6 +146,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 					child.PrintTrace("Skipping unknown or incomplete submunition attribute:");
 			}
 		}
+		else if(key == "emission")
+			emissions.emplace_back(child);
 		else if(key == "inaccuracy")
 		{
 			inaccuracy = child.Value(1);

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -57,7 +57,7 @@ public:
 
 	struct Emission {
 		Emission() noexcept = default;
-		explicit Emission(const DataNode &node) noexcept;
+		explicit Emission(const DataNode &node);
 
 		const Weapon *weapon = nullptr;
 		// The number of projectiles created each time the source projectile emits this weapon.

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -42,7 +42,7 @@ class Sprite;
 // string to double significantly reduces access time.
 class Weapon {
 public:
-	struct Submunition{
+	struct Submunition {
 		Submunition() noexcept = default;
 		explicit Submunition(const Weapon *weapon, std::size_t count) noexcept
 			: weapon(weapon), count(count) {};
@@ -53,6 +53,31 @@ public:
 		Angle facing;
 		// The base offset from the source projectile's position, relative to its current facing.
 		Point offset;
+	};
+
+	struct Emission {
+		Emission() noexcept = default;
+		explicit Emission(const DataNode &node) noexcept;
+
+		const Weapon *weapon = nullptr;
+		// The number of projectiles created each time the source projectile emits this weapon.
+		std::size_t projectileCount = 0;
+		// The number of times this emission can be activated over the lifetime of the source projectile.
+		std::size_t emissionCount = 0;
+		// The angular offset from the source projectile, relative to its current facing.
+		Angle facing;
+		// The base offset from the source projectile's position, relative to its current facing.
+		Point offset;
+		// If the source projectile has a target, the target must be within this range of the source
+		// projectile in order for an emission to occur. If zero, then fire the emission regardless
+		// of range.
+		double emissionRange = 0.;
+		// If true, the emitted projectile is aimed at the target ship of the source projectile.
+		// The above facing angle is added on top of that.
+		bool aimAtTarget = false;
+		// The number of frames that must pass after the source projectile is created in order
+		// for this emission to be spawned.
+		int armingTime = 0;
 	};
 
 
@@ -75,6 +100,7 @@ public:
 	const std::map<const Effect *, int> &TargetEffects() const;
 	const std::map<const Effect *, int> &DieEffects() const;
 	const std::vector<Submunition> &Submunitions() const;
+	const std::vector<Emission> &Emissions() const;
 
 	// Accessor functions for various attributes.
 	int Lifetime() const;
@@ -231,6 +257,7 @@ private:
 	std::map<const Effect *, int> targetEffects;
 	std::map<const Effect *, int> dieEffects;
 	std::vector<Submunition> submunitions;
+	std::vector<Emission> emissions;
 
 	// This stores whether or not the weapon has been loaded.
 	bool isWeapon = false;


### PR DESCRIPTION
**Feature**

This PR implements a feature I thought about a while back and wanted to wait until projectile penetration was a thing before doing.

## Summary
Currently, weapons are able to spawn projectiles that split into smaller projectiles when the main projectile dies. What it is impossible to do though is have a projectile spawn smaller projectiles over the course of its lifetime.

This PR introduces an "emission" mechanic. Projectiles are able to have various emitters that can spawn sub projectiles over the course of the main projectile's lifetime. This adds the following weapon attribute:
* `"emission" <weapon name> [<projectile count>]`: This weapon's projectiles will emit projectiles from the weapon of the given name. If a projectile count is given, then that number of projectiles will spawn every time that the main projectile emits. If not listed, then only one projectile is spawned per emission. The `"emission"` keyword can have the following children:
  * `"facing" <angle>`: Behaves like "facing" on a submunition, changing the angle that the subprojectile is spawned at relative to the main projectile.
  * `"offset" <x> <y>`: Behaves like "offset" on a submunition, changing the location that the subprojectile is spawned at relative to the main projectile.
  * `"arming time" <frames>`: If present, this many frames must pass before the main projectile can start emitting subprojectiles. If not present, the main projectile will immediately fire its subprojectiles upon being spawned in (assuming that other conditions for emitting are met).
  * `"emission count" <count>`: If present, the main projectile can only emit up to this many times over the course of its lifetime. After the emission count is reached, no more subprojectiles will be emitted. If not listed, the only limit is the lifetime of the projectile.
  * `"emission range" <distance>`: If present, the main projectile must have a target in order to emit its subprojectiles. The target must be within this range for an emission to occur.
  * `"aim at target"`: A valueless attribute that if present causes subprojectiles to spawn in facing the target of the main projectile. This does not prevent subprojectiles from emitting if there is no target.

The rate at which emissions occur is controlled by the reload, burst reload, and burst count attributes of the emission weapon. So for example, if a weapon has a lifetime of 100 frames, an emission with an arming time of 20 frames, and the emission weapon has a reload of 10 frames, then the projectile will take 20 frames to arm, then spawn in subprojectiles from the emission every 10 frames until the main projectile dies.

Unlike submunitions, the emissions that a projectile has do not increase the damage of the projectile when it impacts a ship, as submunitions will add their damage to the damage of the main projectile upon impact if the submunitions never got a chance to spawn in.

## Usage examples
The following "Mini Missile Spawner" weapon would spawn a projectile that deals 100 shield or hull damage upon impact. After 10 frames, the spawner will be armed and start spawning two mini-missiles at a time. These mini-missiles will fire in bursts of 3 each with 2 frames in between until waiting for 10 frames per missile in the burst to fire again. Since the spawner has an emission count of 2, this will result in waves of 6 mini missiles. Since subprojectiles share the target of the main projectile, these subprojectiles will home in on whatever ship the spawner was targetting, although the spawner itself has no tracking capabilities/
```
outfit "Mini Missile Spawner"
	weapon
		sprite "projectile/mini missile spawn"
		emission "Mini Missile" 2
			"arming time" 10
			"aim at target"
			"emission range" 500
		lifetime 100
		velocity 5
		"shield damage" 100
		"hull damage" 100
		"missile strength" 100

outfit "Mini Missile"
	weapon
		inaccuracy 20
		sprite "projectile/mini missile"
		reload 10
		"burst reload" 2
		"burst count" 3
		"shield damage" 10
		"hull damage" 10
		"homing" 3
		"infrared tracking" .5
		lifetime 50
		velocity 10
		"missile strength" 5
```

## Testing Done
I'll get to it.

