### PR TITLE
Correct message colours

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -170,10 +170,10 @@ color "warning no command" 0.16 0.16 0.13 1.
 
 # Colors used for messages
 color "message importance highest" 1. .5 0. 1.
-color "message importance high" .1 .1 .1 1.
+color "message importance high" 1. 1. 1. 1.
 color "message importance info" 0. 1. .5 1.
-color "message importance daily" .1 .1 .1 1.
-color "message importance low" .1 .1 .1 1.
+color "message importance daily" 1. 1. 1. 1.
+color "message importance low" 1. 1. 1. 1.
 
 color "message log importance highest" 1. .5 0. 1.
 color "message log importance high" .75 .75 .75 1.

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -170,10 +170,10 @@ color "warning no command" 0.16 0.16 0.13 1.
 
 # Colors used for messages
 color "message importance highest" 1. .5 0. 1.
-color "message importance high" .75 .75 .75 1.
+color "message importance high" .1 .1 .1 1.
 color "message importance info" 0. 1. .5 1.
-color "message importance daily" 0. .5 1. 1.
-color "message importance low" .75 .75 .75 1.
+color "message importance daily" .1 .1 .1 1.
+color "message importance low" .1 .1 .1 1.
 
 color "message log importance highest" 1. .5 0. 1.
 color "message log importance high" .75 .75 .75 1.


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in https://github.com/endless-sky/endless-sky/pull/9831#issuecomment-1947593173

## Summary
As mentioned in the linked comment, these message types previously used all white and the colours used in the log were deliberately different. This restores the colours to what they were before.

## Testing Done
No
