### PR TITLE
fix(typo): Add a missing word in a bounty description

### DIFF
--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -3469,7 +3469,7 @@ mission "Bounty Hunting (Big, Local)"
 
 mission "Bounty Hunting (Small, Hidden)"
 	name "Disguised bandit near <system>"
-	description "A medium pirate warship named the <npc> is posing as a merchant ship within two jumps of the <system> system. Find a merchant ship with a matching name and destroy it <day> for payment (<payment>)."
+	description "A medium pirate warship named the <npc> is posing as a merchant ship within two jumps of the <system> system. Find a merchant ship with a matching name and destroy it by <day> for payment (<payment>)."
 	repeat
 	job
 	deadline 30


### PR DESCRIPTION
Added a missing "by" before the deadline; checked other bounty missions and they don't have this problem.