### PR TITLE
fix(copyright): Fix errors in the copyright file

### DIFF
--- a/copyright
+++ b/copyright
@@ -614,7 +614,7 @@ Comment:
 Files:
  images/land/station47*
 Copyright: Adrien Olichon
-License: UNSPLASH
+License: Unsplash
 Comment:
  Taken from https://archive.is/zTEVA. This image was uploaded to
  unsplash.com after June 2017, so it is subject to the

--- a/copyright
+++ b/copyright
@@ -2283,7 +2283,7 @@ Copyright: Daeridanii (https://github.com/Daeridanii1)
 License: CC0
 Comment: selected and unselected versions of images/ui/find, by Ember369 (https://github.com/Ember369)
 
-License: UNSPLASH
+License: Unsplash
  Unsplash grants you an irrevocable, nonexclusive, worldwide copyright
  license to download, copy, modify, distribute, perform, and use photos
  from Unsplash for free, including for commercial purposes, without

--- a/copyright
+++ b/copyright
@@ -105,7 +105,7 @@ Files:
  images/land/canyon9*
 Copyright: Emily Mell <hasmidas@gmail.com>
 License: public-domain
-Comment: Based on public domain images taken from unsplash.com
+ Based on public domain images taken from unsplash.com
 
 Files:
  images/icon/gat*
@@ -237,7 +237,6 @@ Files:
  images/land/mercury1*
 Copyright: NASA/Johns Hopkins University Applied Physics Laboratory/Carnegie Institution of Washington
 License: public-domain
-Comment:
  Taken from https://archive.is/dd4hA. This image is an
  artist's impression of the surface of Mercury, produced
  for the MESSENGER mission. Because it was produced for
@@ -247,43 +246,9 @@ Files:
  images/land/sea23*
 Copyright: Dan Stark
 License: public-domain
-Comment:
  Taken from https://archive.is/qvHPl. This image was
  uploaded to unsplash.com before June 2017, so it is
  in the public domain.
-
-Files:
- images/land/station46*
-Copyright: Bruno Thethe
-License: Unsplash License
-Comment:
- Taken from https://archive.is/FpG3p. This image was uploaded to
- unsplash.com after June 2017, so it is subject to the
- Unsplash License. It was also uploaded after February 2018,
- so it is subject to an additional restriction limiting the
- sale of unaltered copies.
-
-Files:
- images/land/station47*
-Copyright: Adrien Olichon
-License: Unsplash License
-Comment:
- Taken from https://archive.is/zTEVA. This image was uploaded to
- unsplash.com after June 2017, so it is subject to the
- Unsplash License. It was also uploaded after February 2018,
- so it is subject to an additional restriction limiting the
- sale of unaltered copies.
-
-Files:
- images/land/station48*
-Copyright: Miquel Parera
-License: Unsplash License
-Comment:
- Taken from https://archive.is/UjGht. This image was uploaded to
- unsplash.com after June 2017, so it is subject to the
- Unsplash License. It was also uploaded after February 2018,
- so it is subject to an additional restriction limiting the
- sale of unaltered copies.
 
 Files: images/land/bwerner*
 Copyright: Berthold Werner (commons.wikimedia.org/wiki/User:Berthold_Werner)
@@ -321,17 +286,6 @@ Files: images/land/*-iridium*
 Copyright: @Iridium Ore (blueajp@gmail.com)
 License: CC-BY-SA-4.0
 
-Files: images/land/lava11*
-Copyright: National Archives and Records Administration
-License: public-domain
-Comment: Taken from Wikimedia Commons. Cropped and edited.
-
-Files:
- images/land/station12*
-Copyright: Office of War Information
-License: public-domain
-Comment: Taken from Wikimedia Commons. Cropped and edited.
-
 Files: images/land/*-spfld*
 Copyright: Eric Denni (spfldsatellite@gmail.com)
 License: CC-BY-SA-4.0
@@ -353,6 +307,13 @@ Files:
  images/effect/jump?drive?red*
 Copyright: Zachary Siple
 License: CC-BY-SA-4.0
+
+Files:
+ images/outfit/security?station*
+ images/ship/peregrine/*
+Copyright: Becca Tommaso (tommasobecca03@gmail.com)
+License: CC-BY-SA-4.0
+Comment: Derived from works by Michael Zahniser and Evan Fluharty (under the same license).
 
 Files:
  images/outfit/korath?rifle*
@@ -427,131 +388,23 @@ Comment: Derived from works by Evan Fluharty (under the same license).
 License: CC-BY-SA-4.0
 
 Files:
- images/effect/remnant?afterburner/remnant?afterburner*
- images/effect/mhd?spark*
- images/land/nasa9*
- images/hardpoint/annihilator?turret*
- images/hardpoint/hai?ionic?turret*
- images/hardpoint/inhibitor?turret*
- images/hardpoint/ion?hail?turret*
- images/hardpoint/ravager?turret*
- images/outfit/inhibitor?turret*
- images/outfit/ion?hail?turret*
- images/hardpoint/shooting?star?flare/ss-rays*
- images/outfit/overcharged?shield?module*
- images/outfit/overclocked?repair?module*
- images/outfit/ramscoop*
- images/outfit/remnant?afterburner*
- images/outfit/remnant?capital?license*
- images/outfit/research?laboratory*
- images/outfit/salvage?scanner*
- images/outfit/tiny?remnant?engine*
- images/outfit/void?rifle*
- images/outfit/fragmentation?grenades*
- images/outfit/nerve?gas*
- images/outfit/catalytic?ramscoop*
- images/outfit/anti-missile*
- images/outfit/blaster?turret*
- images/outfit/blaster*
- images/outfit/breeder*
- images/outfit/bunk?room*
- images/outfit/dwarf?core*
- images/outfit/electron?beam*
- images/outfit/electron?turret*
- images/outfit/fission*
- images/outfit/flamethrower*
- images/outfit/hai?ionic?blaster*
- images/outfit/hai?ionic?turret*
- images/outfit/heavy?anti-missile*
- images/outfit/heavy?laser?turret*
- images/outfit/heavy?laser*
- images/outfit/huge?fuel?cell*
- images/outfit/large?fuel?cell*
- images/outfit/medium?fuel?cell*
- images/outfit/small?fuel?cell*
- images/outfit/tiny?fuel?cell*
- images/outfit/huge?shield*
- images/outfit/large?shield*
- images/outfit/medium?shield*
- images/outfit/small?shield*
- images/outfit/tiny?shield*
- images/outfit/hyperdrive*
- images/outfit/large?radar?jammer*
- images/outfit/small?radar?jammer*
- images/outfit/meteor*
- images/outfit/meteor?launcher*
- images/outfit/meteor?pod*
- images/outfit/meteor?storage*
- images/outfit/mod?blaster?turret*
- images/outfit/mod?blaster*
- images/outfit/particle?cannon*
- images/outfit/plasma?cannon*
- images/outfit/plasma?turret*
- images/outfit/proton?gun*
- images/outfit/quad?blaster?turret*
- images/outfit/rocket*
- images/outfit/rocket?launcher*
- images/outfit/rocket?pod*
- images/outfit/rocket?storage*
- images/outfit/sidewinder*
- images/outfit/sidewinder?launcher*
- images/outfit/sidewinder?pod*
- images/outfit/sidewinder?storage*
- images/outfit/small?bunk?room*
- images/outfit/small?nucleovoltaic*
- images/outfit/small?radiothermal*
- images/outfit/small?thermionic*
- images/outfit/stack?core*
- images/outfit/surveillance?pod*
- images/outfit/banisher*
- images/outfit/command?center*
- images/outfit/fire-lance*
- images/outfit/piercer*
- images/outfit/piercer?launcher*
- images/outfit/korath?piercer?storage*
- images/outfit/reverse?thruster?ion*
- images/outfit/reverse?thruster?plasma*
- images/outfit/rock?0*
- images/outfit/rock?1*
- images/outfit/rock?2*
- images/outfit/rock?3*
- images/outfit/rock?4*
- images/scene/penguinscene*
- images/ship/hai?sea?scorpion*
- images/ship/ibis*
- images/ship/mbactriane*
- images/ship/merganser*
- images/ship/penguin/*
- images/ship/petrel*
- images/ship/tern*
- images/ship/shooting?star/shooting?star*
- images/ship/pug?zibruka*
- images/ship/pug?enfolta*
- images/ship/pug?maboro*
- images/ship/pug?arfecta*
- images/thumbnail/hai?sea?scorpion*
- images/thumbnail/ibis*
- images/thumbnail/merganser*
- images/thumbnail/penguin*
- images/thumbnail/petrel*
- images/thumbnail/tern*
- images/planet/station1c*
- images/planet/station2c*
- images/planet/station3c*
- images/ship/archon?b*
- images/ship/archon?c*
- images/asteroid/plant*
- images/asteroid/plant2*
- images/asteroid/plant?cluster*
- images/asteroid/space?flora*
- images/asteroid/large?plant*
- images/asteroid/large?plant2*
- images/asteroid/large?plant?cluster*
- images/asteroid/large?space?flora*
- images/asteroid/yottrite*
-Copyright: Becca Tommaso (tommasobecca03@gmail.com)
-License: CC-BY-SA-4.0
-Comment: Derived from works by Michael Zahniser (under the same license).
+ images/land/desert0*
+ images/land/earthrise*
+ images/land/nasa*
+ images/land/space*
+ images/land/station1*
+ images/land/station2*
+ images/land/station3*
+Copyright: NASA
+License: public-domain
+ From NASA, and therefore in the public domain because they were created by
+ government employees while doing work for the government.
+
+Files:
+ images/land/station12*
+Copyright: Office of War Information
+License: public-domain
+ Taken from Wikimedia Commons. Cropped and edited.
 
 Files:
  images/*/pincer*
@@ -749,23 +602,48 @@ License: public-domain
  placed in the public domain.
 
 Files:
+ images/land/station46*
+Copyright: Bruno Thethe
+License: UNSPLASH
+Comment:
+ Taken from https://archive.is/FpG3p. This image was uploaded to
+ unsplash.com after June 2017, so it is subject to the
+ Unsplash License. It was also uploaded after February 2018,
+ so it is subject to an additional restriction limiting the
+ sale of unaltered copies.
+
+Files:
+ images/land/station47*
+Copyright: Adrien Olichon
+License: UNSPLASH
+Comment:
+ Taken from https://archive.is/zTEVA. This image was uploaded to
+ unsplash.com after June 2017, so it is subject to the
+ Unsplash License. It was also uploaded after February 2018,
+ so it is subject to an additional restriction limiting the
+ sale of unaltered copies.
+
+Files:
+ images/land/station48*
+Copyright: Miquel Parera
+License: UNSPLASH
+Comment:
+ Taken from https://archive.is/UjGht. This image was uploaded to
+ unsplash.com after June 2017, so it is subject to the
+ Unsplash License. It was also uploaded after February 2018,
+ so it is subject to an additional restriction limiting the
+ sale of unaltered copies.
+
+Files: images/land/lava11*
+Copyright: National Archives and Records Administration
+License: public-domain
+ Taken from Wikimedia Commons. Cropped and edited.
+
+Files:
  images/land/lava0*
 Copyright: USGS
 License: public-domain
  From the USGS, and therefore in the public domain because they were created by
- government employees while doing work for the government.
-
-Files:
- images/land/desert0*
- images/land/earthrise*
- images/land/nasa*
- images/land/space*
- images/land/station1*
- images/land/station2*
- images/land/station3*
-Copyright: NASA
-License: public-domain
- From NASA, and therefore in the public domain because they were created by
  government employees while doing work for the government.
 
 Files:
@@ -825,7 +703,7 @@ Comment: Derived from works by NASA and Michael Zahniser.
 Files: sounds/*
 Copyright: Various
 License: public-domain
-Comment: Based on public domain sounds taken from freesound.org.
+ Based on public domain sounds taken from freesound.org.
 
 Files:
  sounds/pincer*
@@ -841,7 +719,7 @@ Comment: Taken from http://soundbible.com/1467-Grenade-Explosion.html
 Files: sounds/missile?hit.wav
 Copyright: Copyright "Nbs Dark"
 License: public-domain
-Comment: Taken from https://freesound.org/people/Nbs%20Dark/sounds/94185/
+ Taken from https://freesound.org/people/Nbs%20Dark/sounds/94185/
 
 Files: sounds/torpedo?hit.wav
 Copyright: Public Domain
@@ -855,7 +733,7 @@ Comment: Taken from https://freesound.org/people/18hiltc/sounds/202725/
 Files: sounds/sidewinder.wav
 Copyright: Copyright "NHMWretched"
 License: public-domain
-Comment: Taken from https://freesound.org/people/NHMWretched/sounds/151858/
+ Taken from https://freesound.org/people/NHMWretched/sounds/151858/
 
 Files: sounds/explosion?huge.wav
 Copyright: Copyright Mike Koenig
@@ -867,7 +745,7 @@ Files:
  sounds/asteroid?crunch?medium.wav
 Copyright: Copyright AlanCat
 License: public-domain
-Comment: Derived from https://freesound.org/people/AlanCat/sounds/381645/
+ Derived from https://freesound.org/people/AlanCat/sounds/381645/
 
 Files: sounds/asteroid?crunch?large.wav
 Copyright: Copyright "BW_Clowes"
@@ -889,13 +767,6 @@ Files:
 Copyright: Becca Tommaso (tommasobecca03@gmail.com)
 License: CC-BY-SA-4.0
 Comment: Derived from works by Frederick Goy IV (under the same license).
-
-Files:
- images/outfit/security?station*
- images/ship/peregrine/*
-Copyright: Becca Tommaso (tommasobecca03@gmail.com)
-License: CC-BY-SA-4.0
-Comment: Derived from works by Michael Zahniser and Evan Fluharty (under the same license).
 
 Files:
  images/ship/nest*
@@ -1213,6 +1084,133 @@ Copyright: Becca Tommaso (tommasobecca03@gmail.com)
 License: CC-BY-SA-4.0
 
 Files:
+ images/effect/remnant?afterburner/remnant?afterburner*
+ images/effect/mhd?spark*
+ images/land/nasa9*
+ images/hardpoint/annihilator?turret*
+ images/hardpoint/hai?ionic?turret*
+ images/hardpoint/inhibitor?turret*
+ images/hardpoint/ion?hail?turret*
+ images/hardpoint/ravager?turret*
+ images/outfit/inhibitor?turret*
+ images/outfit/ion?hail?turret*
+ images/hardpoint/shooting?star?flare/ss-rays*
+ images/outfit/overcharged?shield?module*
+ images/outfit/overclocked?repair?module*
+ images/outfit/ramscoop*
+ images/outfit/remnant?afterburner*
+ images/outfit/remnant?capital?license*
+ images/outfit/research?laboratory*
+ images/outfit/salvage?scanner*
+ images/outfit/tiny?remnant?engine*
+ images/outfit/void?rifle*
+ images/outfit/fragmentation?grenades*
+ images/outfit/nerve?gas*
+ images/outfit/catalytic?ramscoop*
+ images/outfit/anti-missile*
+ images/outfit/blaster?turret*
+ images/outfit/blaster*
+ images/outfit/breeder*
+ images/outfit/bunk?room*
+ images/outfit/dwarf?core*
+ images/outfit/electron?beam*
+ images/outfit/electron?turret*
+ images/outfit/fission*
+ images/outfit/flamethrower*
+ images/outfit/hai?ionic?blaster*
+ images/outfit/hai?ionic?turret*
+ images/outfit/heavy?anti-missile*
+ images/outfit/heavy?laser?turret*
+ images/outfit/heavy?laser*
+ images/outfit/huge?fuel?cell*
+ images/outfit/large?fuel?cell*
+ images/outfit/medium?fuel?cell*
+ images/outfit/small?fuel?cell*
+ images/outfit/tiny?fuel?cell*
+ images/outfit/huge?shield*
+ images/outfit/large?shield*
+ images/outfit/medium?shield*
+ images/outfit/small?shield*
+ images/outfit/tiny?shield*
+ images/outfit/hyperdrive*
+ images/outfit/large?radar?jammer*
+ images/outfit/small?radar?jammer*
+ images/outfit/meteor*
+ images/outfit/meteor?launcher*
+ images/outfit/meteor?pod*
+ images/outfit/meteor?storage*
+ images/outfit/mod?blaster?turret*
+ images/outfit/mod?blaster*
+ images/outfit/particle?cannon*
+ images/outfit/plasma?cannon*
+ images/outfit/plasma?turret*
+ images/outfit/proton?gun*
+ images/outfit/quad?blaster?turret*
+ images/outfit/rocket*
+ images/outfit/rocket?launcher*
+ images/outfit/rocket?pod*
+ images/outfit/rocket?storage*
+ images/outfit/sidewinder*
+ images/outfit/sidewinder?launcher*
+ images/outfit/sidewinder?pod*
+ images/outfit/sidewinder?storage*
+ images/outfit/small?bunk?room*
+ images/outfit/small?nucleovoltaic*
+ images/outfit/small?radiothermal*
+ images/outfit/small?thermionic*
+ images/outfit/stack?core*
+ images/outfit/surveillance?pod*
+ images/outfit/banisher*
+ images/outfit/command?center*
+ images/outfit/fire-lance*
+ images/outfit/piercer*
+ images/outfit/piercer?launcher*
+ images/outfit/korath?piercer?storage*
+ images/outfit/reverse?thruster?ion*
+ images/outfit/reverse?thruster?plasma*
+ images/outfit/rock?0*
+ images/outfit/rock?1*
+ images/outfit/rock?2*
+ images/outfit/rock?3*
+ images/outfit/rock?4*
+ images/scene/penguinscene*
+ images/ship/hai?sea?scorpion*
+ images/ship/ibis*
+ images/ship/mbactriane*
+ images/ship/merganser*
+ images/ship/penguin/*
+ images/ship/petrel*
+ images/ship/tern*
+ images/ship/shooting?star/shooting?star*
+ images/ship/pug?zibruka*
+ images/ship/pug?enfolta*
+ images/ship/pug?maboro*
+ images/ship/pug?arfecta*
+ images/thumbnail/hai?sea?scorpion*
+ images/thumbnail/ibis*
+ images/thumbnail/merganser*
+ images/thumbnail/penguin*
+ images/thumbnail/petrel*
+ images/thumbnail/tern*
+ images/planet/station1c*
+ images/planet/station2c*
+ images/planet/station3c*
+ images/ship/archon?b*
+ images/ship/archon?c*
+ images/asteroid/plant*
+ images/asteroid/plant2*
+ images/asteroid/plant?cluster*
+ images/asteroid/space?flora*
+ images/asteroid/large?plant*
+ images/asteroid/large?plant2*
+ images/asteroid/large?plant?cluster*
+ images/asteroid/large?space?flora*
+ images/asteroid/yottrite*
+Copyright: Becca Tommaso (tommasobecca03@gmail.com)
+License: CC-BY-SA-4.0
+Comment: Derived from works by Michael Zahniser (under the same license).
+
+Files:
  images/label/graveyard*
 Copyright: @RestingImmortal
 License: CC-BY-SA-4.0
@@ -1443,12 +1441,12 @@ Comment: Derived from works by Michael Zahniser (under the same license).
 Files: sounds/dragonflame*
 Copyright: TheHadnot
 License: public-domain
-Comment: Taken from https://freesound.org/people/TheHadnot/sounds/160880/
+ Taken from https://freesound.org/people/TheHadnot/sounds/160880/
 
 Files: sounds/pwave*
 Copyright: aust_paul
 License: public-domain
-Comment: Taken from https://freesound.org/people/aust_paul/sounds/30935/
+ Taken from https://freesound.org/people/aust_paul/sounds/30935/
 
 Files: sounds/hion*
 Copyright: michael_kur95
@@ -1703,7 +1701,7 @@ Comment: Derived from works by Michael Zahniser and Maximilian Korber (under the
 Files: sounds/ionball*
 Copyright: pluralz
 License: public-domain
-Comment: Taken from https://freesound.org/people/pluralz/sounds/475806/
+ Taken from https://freesound.org/people/pluralz/sounds/475806/
 
 Files:
  images/outfit/tiny?korath?engine*
@@ -1983,7 +1981,7 @@ Files:
  sounds/tractor?beam*
 Copyright: Saugia <https://github.com/Saugia>
 License: public-domain
-Comment: Based on public domain sounds taken from freesound.org, edits done by Saugia.
+ Based on public domain sounds taken from freesound.org, edits done by Saugia.
 
 Files:
  images/ship/hai?cicada*
@@ -2082,14 +2080,14 @@ Files:
  sounds/remnant?afterburner.wav
 Copyright: Public Domain
 License: public-domain
-Comment: Based on public domain sounds taken from freesound.org, edit done by Saugia.
+ Based on public domain sounds taken from freesound.org, edit done by Saugia.
 
 Files:
  sounds/firelight.wav
  sounds/firelight?hit.wav
 Copyright: Public Domain
 License: public-domain
-Comment: Based on public domain sounds taken from freesound.org, edits done by Saugia and Lia Gerty.
+ Based on public domain sounds taken from freesound.org, edits done by Saugia and Lia Gerty.
 
 Files:
  images/effect/ember?tear/ember?tear?fire*
@@ -2285,7 +2283,7 @@ Copyright: Daeridanii (https://github.com/Daeridanii1)
 License: CC0
 Comment: selected and unselected versions of images/ui/find, by Ember369 (https://github.com/Ember369)
 
-License: Unsplash License
+License: UNSPLASH
  Unsplash grants you an irrevocable, nonexclusive, worldwide copyright
  license to download, copy, modify, distribute, perform, and use photos
  from Unsplash for free, including for commercial purposes, without

--- a/copyright
+++ b/copyright
@@ -603,7 +603,7 @@ License: public-domain
 Files:
  images/land/station46*
 Copyright: Bruno Thethe
-License: UNSPLASH
+License: Unsplash
 Comment:
  Taken from https://archive.is/FpG3p. This image was uploaded to
  unsplash.com after June 2017, so it is subject to the

--- a/copyright
+++ b/copyright
@@ -589,7 +589,6 @@ Files:
  images/land/station43*
  images/land/station44*
  images/land/station45*
- images/land/station46*
  images/land/water0*
  images/land/water3*
  images/land/water4*

--- a/copyright
+++ b/copyright
@@ -723,6 +723,7 @@ License: public-domain
 Files: sounds/torpedo?hit.wav
 Copyright: Public Domain
 License: public-domain
+ Taken from a now-defunct public domain sharing site. Please contact Pointedstick (Nate Graham <pointedstick@zoho.com>) for legal enquires.
 
 Files: sounds/meteor.wav
 Copyright: Copyright "18hiltc"

--- a/copyright
+++ b/copyright
@@ -25,19 +25,6 @@ License: public-domain
  and placed in the public domain. (Exceptions noted below.)
 
 Files:
- images/outfit/*battery?hai*
- images/outfit/anti-missile?hai*
- images/outfit/cooling?ducts?hai*
- images/outfit/dwarf?core?hai*
- images/outfit/fission?hai*
- images/outfit/fusion?hai*
- images/outfit/heavy?anti-missile?hai*
- images/ship/mfury*
-Copyright: Maximilian Korber
-License: CC-BY-SA-4.0
-Comment: Derived from works by Michael Zahniser (under the same license).
-
-Files:
  images/outfit/bullet*
  images/scene/sagittarius?a*
  images/ship/hai?solifuge*
@@ -49,17 +36,6 @@ Files:
 Copyright: Maximilian Korber
 License: CC-BY-SA-4.0
 Comment: Derived from works by Christian Rhodes (under the same license).
-
-Files:
- images/effect/railspark*
- images/projectile/tinyflare*
- images/outfit/*engines?hai*
- images/outfit/*steering?hai*
- images/outfit/*thruster?hai*
- images/outfit/tiny?ion?engines*
-Copyright: Iaz Poolar
-License: CC-BY-SA-4.0
-Comment: Derived from works by Michael Zahniser (under the same license).
 
 Files:
  images/projectile/bullet*
@@ -356,13 +332,6 @@ License: public-domain
  placed in the public domain.
 
 Files:
- images/outfit/quarg?skylance*
- images/hardpoint/quarg?skylance*
-Copyright: Evan Fluharty (Evanfluharty@gmail.com)
-License: CC-BY-SA-4.0
-Comment: Derived and completed from works by Maximilian Korber (Wrzlprnft), @Karirawri, and originally drawn up by Tommy Thach (Bladewood) (all under the same license)
-
-Files:
  images/outfit/quarg*
  images/hardpoint/quarg*
  images/outfit/small?quarg*
@@ -374,6 +343,13 @@ Files:
  images/outfit/hai?geode*
 Copyright: Evan Fluharty (Evanfluharty@gmail.com)
 License: CC-BY-SA-4.0
+
+Files:
+ images/outfit/quarg?skylance*
+ images/hardpoint/quarg?skylance*
+Copyright: Evan Fluharty (Evanfluharty@gmail.com)
+License: CC-BY-SA-4.0
+Comment: Derived and completed from works by Maximilian Korber (Wrzlprnft), @Karirawri, and originally drawn up by Tommy Thach (Bladewood) (all under the same license)
 
 Files:
  images/outfit/enforcer?riot?staff*
@@ -1201,6 +1177,19 @@ Files:
  images/asteroid/large?space?flora*
  images/asteroid/yottrite*
 Copyright: Becca Tommaso (tommasobecca03@gmail.com)
+License: CC-BY-SA-4.0
+Comment: Derived from works by Michael Zahniser (under the same license).
+
+Files:
+ images/outfit/*battery?hai*
+ images/outfit/anti-missile?hai*
+ images/outfit/cooling?ducts?hai*
+ images/outfit/dwarf?core?hai*
+ images/outfit/fission?hai*
+ images/outfit/fusion?hai*
+ images/outfit/heavy?anti-missile?hai*
+ images/ship/mfury*
+Copyright: Maximilian Korber
 License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license).
 
@@ -2062,6 +2051,17 @@ Files:
 Copyright: Saugia <https://github.com/Saugia>
 License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license) and Iaz Poolar (under the same license).
+
+Files:
+ images/effect/railspark*
+ images/projectile/tinyflare*
+ images/outfit/*engines?hai*
+ images/outfit/*steering?hai*
+ images/outfit/*thruster?hai*
+ images/outfit/tiny?ion?engines*
+Copyright: Iaz Poolar
+License: CC-BY-SA-4.0
+Comment: Derived from works by Michael Zahniser (under the same license).
 
 Files:
  images/icon/gat?turret*

--- a/copyright
+++ b/copyright
@@ -625,7 +625,7 @@ Comment:
 Files:
  images/land/station48*
 Copyright: Miquel Parera
-License: UNSPLASH
+License: Unsplash
 Comment:
  Taken from https://archive.is/UjGht. This image was uploaded to
  unsplash.com after June 2017, so it is subject to the

--- a/copyright
+++ b/copyright
@@ -51,12 +51,6 @@ License: CC-BY-SA-4.0
 Comment: Derived from works by Christian Rhodes (under the same license).
 
 Files:
- images/ship/pointedstick?vanguard*
-Copyright: Maximilian Korber
-License: CC-BY-SA-4.0
-Comment: Derived from works by Nate Graham (under the same license).
-
-Files:
  images/effect/railspark*
  images/projectile/tinyflare*
  images/outfit/*engines?hai*
@@ -1821,7 +1815,6 @@ Files:
  images/outfit/savagery?pike*
  images/outfit/scrap?cell*
  images/outfit/skirmish?battery*
- images/outfit/*torch?thruster?vi*
  images/outfit/*torch?thruster?vi*
  images/outfit/tractor?beam*
  images/outfit/warforge?battery*


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported on the debian bugtracker: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1061241

## Summary
 - Moved around file stanzas to make more generic entries come first
 - Added a short name for Unsplash License
 - Moved explanations from the Comment fields to the License fields for `public-domain` assets, as mandated by the specs

There are also a large number of redundant patterns that we don't actually need, but they don't do any harm and aren't technically in violation of any standard I know of.

## TODO
 - [x] Find out who actually owns `images/land/station46*`, as it's listed as both `public-domain` and as unsplash by `Brune Thethe`.
 - [x] `sounds/torpedo?hit.wav` is listed as `public-domain`, but there is no explanation (which is mandatory).
