### PR TITLE
Don't consider the "Parsing: <file>" output when in debug mode errors when test parsing

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -94,7 +94,9 @@ int main(int argc, char *argv[])
 	bool hasErrors = false;
 	// Ensure that we log errors to the errors.txt file.
 	Logger::SetLogErrorCallback([&hasErrors](const string &errorMessage) {
-		hasErrors = true;
+		static const string PARSING_PREFIX = "Parsing: ";
+		if(errorMessage.substr(PARSING_PREFIX.length()) != PARSING_PREFIX)
+			hasErrors = true;
 		Files::LogErrorToFile(errorMessage);
 	});
 


### PR DESCRIPTION
**Bug fix**

## Summary
When launched with "-d -p", the game will always report errors even if no actual parsing errors were present.
This is because anything logged to the errors file is considered an error for the purpose of test parsing, but "-d" results in a list of all parsed data files being output and logged to the errors file.
This PR means those "Parsing: " lines are not considered errors (because they aren't) so running with "-d -p" now produces useful output.

## Testing Done
No.
