### PR TITLE
feat(personality): `Quiet` personality

### DIFF
--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -64,6 +64,7 @@ namespace {
 		UNRESTRICTED,
 		RESTRICTED,
 		DECLOAKED,
+		QUIET,
 
 		// This must be last so it can be used for bounds checking.
 		LAST_ITEM_IN_PERSONALITY_TRAIT_ENUM
@@ -105,7 +106,8 @@ namespace {
 		{"ramming", RAMMING},
 		{"unrestricted", UNRESTRICTED},
 		{"restricted", RESTRICTED},
-		{"decloaked", DECLOAKED}
+		{"decloaked", DECLOAKED},
+		{"quiet", QUIET}
 	};
 
 	// Tokens that combine two or more flags.
@@ -430,6 +432,13 @@ bool Personality::IsMute() const
 bool Personality::IsDecloaked() const
 {
 	return flags.test(DECLOAKED);
+}
+
+
+
+bool Personality::IsQuiet() const
+{
+	return flags.test(QUIET);
 }
 
 

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -84,6 +84,7 @@ public:
 	bool IsMarked() const;
 	bool IsMute() const;
 	bool IsDecloaked() const;
+	bool IsQuiet() const;
 
 	// Current inaccuracy in this ship's targeting:
 	const Point &Confusion() const;
@@ -101,7 +102,7 @@ private:
 private:
 	// Make sure this matches the number of items in PersonalityTrait,
 	// or the build will fail.
-	static const int PERSONALITY_COUNT = 36;
+	static const int PERSONALITY_COUNT = 37;
 
 	bool isDefined = false;
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1519,7 +1519,7 @@ bool Ship::CanSendHail(const PlayerInfo &player, bool allowUntranslated) const
 		return false;
 
 	// Make sure this ship is able to send a hail.
-	if(IsDisabled() || !Crew() || Cloaking() >= 1. || GetPersonality().IsMute())
+	if(IsDisabled() || !Crew() || Cloaking() >= 1. || GetPersonality().IsMute() || GetPersonality().IsQuiet())
 		return false;
 
 	// Ships that don't share a language with the player shouldn't communicate when hailed directly.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1518,7 +1518,7 @@ bool Ship::CanSendHail(const PlayerInfo &player, bool allowUntranslated) const
 	if(!gov || IsYours())
 		return false;
 
-	// Make sure this ship is able to send a hail.
+	// Make sure this ship is able to send a hail message, unless it has the quiet or mute personality.
 	if(IsDisabled() || !Crew() || Cloaking() >= 1. || GetPersonality().IsMute() || GetPersonality().IsQuiet())
 		return false;
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1518,7 +1518,7 @@ bool Ship::CanSendHail(const PlayerInfo &player, bool allowUntranslated) const
 	if(!gov || IsYours())
 		return false;
 
-	// Make sure this ship is able to send a hail message, unless it has the quiet or mute personality.
+	// Make sure this ship is able to send a hail.
 	if(IsDisabled() || !Crew() || Cloaking() >= 1. || GetPersonality().IsMute() || GetPersonality().IsQuiet())
 		return false;
 


### PR DESCRIPTION
**Feature**
This PR addresses the feature described in #6052

## Summary
Creates a new personality, `quiet`, which does not send hails passively but will hail in the hail panel. Basically `mute` without the `(There is no response to your hail.)`

## Usage examples
See #6052

## Testing Done
I added this personality to all Merchant ships and went to Sol. After a minute on fast-forward, I only recieved hails from Republic ships. I then hailed a Merchant ship and I recieved a response.

## Performance Impact
Negligible?
