### PR TITLE
fix(bug?): Disabled hails are now sent passively

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1519,7 +1519,7 @@ bool Ship::CanSendHail(const PlayerInfo &player, bool allowUntranslated) const
 		return false;
 
 	// Make sure this ship is able to send a hail.
-	if(IsDisabled() || !Crew() || Cloaking() >= 1. || GetPersonality().IsMute())
+	if(!Crew() || Cloaking() >= 1. || GetPersonality().IsMute())
 		return false;
 
 	// Ships that don't share a language with the player shouldn't communicate when hailed directly.


### PR DESCRIPTION
**Bug fix?**
This PR addresses something Hurl brought up and I thought it was a very good point (I was talking to myself)

## Summary
Disabled hails (`friendly disabled hail`, `hostile disabled hail`) are not sent passively; you can only ever see them in the hail panel when you directly hail them. This removes that restriction.

## Screenshots
<img width="538" alt="Screenshot 2024-02-24 at 9 02 01 PM" src="https://github.com/endless-sky/endless-sky/assets/115441627/2b0c7433-05b5-4ad2-a1a4-5c9f5ebbcb61">

## Testing Done
I waited in Pherkad to see the disabled hails of Militia and Pirate ships.

## Notes
Hurl was saying that pirates probably shouldn't taunt you if they're disabled. It's because the pirate government doesn't use their unique disabled hails; I can add new ones in another PR.

I am aware of #5442; would it be too naïve to think it could be solved by removing those lines? I am not sure of the interaction that happens if a government has no hail phrases at all (but I can test that)