### PR TITLE
Remove the forced-default disabled hails from Government

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -22,6 +22,8 @@ government "Alpha"
 government "Author"
 	"player reputation" 1
 	"bribe" 0
+	"friendly disabled hail" "friendly disabled"
+	"hostile disabled hail" "hostile disabled"
 
 government "Bad Trip"
 	swizzle 0
@@ -124,6 +126,7 @@ government "Bounty"
 	"player reputation" -1000
 	"fine" 0
 	"hostile hail" "hostile bounty"
+	"hostile disabled hail" "hostile disabled"
 
 government "Bounty (Disguised)"
 	"display name" "Merchant"
@@ -131,7 +134,9 @@ government "Bounty (Disguised)"
 	"player reputation" 1
 	"fine" 0
 	"friendly hail" "friendly civilian"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile bounty"
+	"hostile disabled hail" "hostile disabled"
 	"penalty for"
 		assist 0
 		disable 0
@@ -148,6 +153,7 @@ government "Bounty Hunter"
 	"bribe" .2
 	"fine" 0
 	"hostile hail" "hostile bounty hunter"
+	"hostile disabled hail" "hostile disabled"
 
 government "Bounty Hunter that Won't Enter Hai Space"
 	"display name" "Bounty Hunter"
@@ -158,6 +164,7 @@ government "Bounty Hunter that Won't Enter Hai Space"
 	"bribe" .2
 	"fine" 0
 	"hostile hail" "hostile bounty hunter"
+	"hostile disabled hail" "hostile disabled"
 
 government "Coalition"
 	swizzle 5
@@ -177,7 +184,9 @@ government "Deep"
 	"display name" "Deep Security"
 	swizzle 0
 	"player reputation" -1000
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile deep"
+	"hostile disabled hail" "hostile disabled"
 
 government "Deep Security"
 	swizzle 0
@@ -188,7 +197,9 @@ government "Deep Security"
 		"Pirate (Devil-Run Gang)" -.2
 		"Smuggler (Hai Trafficker)" .05
 	"friendly hail" "friendly deep"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile deep"
+	"hostile disabled hail" "hostile disabled"
 
 government "Derelict"
 	"fine" 0
@@ -236,7 +247,9 @@ government "Escort (Betraying)"
 		"Korath" -.01
 	"fine" 0
 	"friendly hail" "friendly civilian"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile pirate"
+	"hostile disabled hail" "hostile disabled"
 	
 government "Forest (Prey)"
 	# Indigenous creatures in large forest zones outside the Milky Way.
@@ -273,7 +286,9 @@ government "Free Worlds"
 		"Neutral" .1
 	"bribe" .1
 	"friendly hail" "friendly free worlds"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile free worlds"
+	"hostile disabled hail" "hostile disabled"
 	raid "pirate raid"
 
 government "Free Worlds that won't enter wormhole"
@@ -292,7 +307,9 @@ government "Free Worlds that won't enter wormhole"
 		"Neutral" .1
 	"bribe" .1
 	"friendly hail" "friendly free worlds"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile free worlds"
+	"hostile disabled hail" "hostile disabled"
 	raid "pirate raid"
 
 
@@ -556,7 +573,9 @@ government "Hai Merchant (Human)"
 		system "Wah Yoot"
 	"bribe" .02
 	"friendly hail" "friendly civilian"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile civilian"
+	"hostile disabled hail" "hostile disabled"
 
 color "governments: Hai (Unfettered)" .55 .27 .76
 
@@ -682,7 +701,9 @@ government "Independent"
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly civilian"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile civilian"
+	"hostile disabled hail" "hostile disabled"
 	raid "Large Southern Pirates"
 
 # A government used for "Independent" ships that the player is allowed to kill without consequences.
@@ -695,7 +716,9 @@ government "Independent (Killable)"
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly civilian"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile civilian"
+	"hostile disabled hail" "hostile disabled"
 
 government "Indigenous Lifeform"
 	# Nothing you do permanently angers indigenous creatures, because they are
@@ -911,7 +934,9 @@ government "Marauder"
 	"player reputation" 1
 	"bribe" .1
 	"fine" 0
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile pirate"
+	"hostile disabled hail" "hostile disabled"
 
 government "Merchant"
 	swizzle 5
@@ -924,7 +949,9 @@ government "Merchant"
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly civilian"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile civilian"
+	"hostile disabled hail" "hostile disabled"
 
 government "Merchant (Hijacked)"
 	"display name" "Merchant"
@@ -935,7 +962,9 @@ government "Merchant (Hijacked)"
 	"player reputation" 1
 	"fine" 0
 	"friendly hail" "friendly civilian"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile pirate"
+	"hostile disabled hail" "hostile disabled"
 	"penalty for"
 		assist 0
 		disable 0
@@ -956,7 +985,9 @@ government "Militia"
 		"Smuggler (Hai Trafficker)" .05
 	"bribe" .1
 	"friendly hail" "friendly militia"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile militia"
+	"hostile disabled hail" "hostile disabled"
 
 government "Navy Intelligence"
 	swizzle 0
@@ -966,6 +997,8 @@ government "Navy Intelligence"
 		"Syndicate" -.1
 		"Pirate" -.3
 		"Pirate (Devil-Run Gang)" -.3
+	"friendly disabled hail" "friendly disabled"
+	"hostile disabled hail" "hostile disabled"
 
 government "Navy (Oathkeeper)"
 	swizzle 0
@@ -986,7 +1019,9 @@ government "Navy (Oathkeeper)"
 		"Navy Intelligence" 1
 		"Republic Intelligence" 1
 	"friendly hail" "friendly navy"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile navy"
+	"hostile disabled hail" "hostile disabled"
 
 color "governments: Neutral" .84 .61 .37
 
@@ -1002,13 +1037,17 @@ government "Neutral"
 		"Smuggler (Hai Trafficker)" .05
 	"bribe" .05
 	"friendly hail" "friendly civilian"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile civilian"
+	"hostile disabled hail" "hostile disabled"
 	raid "pirate raid"
 
 government "Parrot"
 	swizzle 2
 	"player reputation" 1
 	"bribe" 0
+	"friendly disabled hail" "friendly disabled"
+	"hostile disabled hail" "hostile disabled"
 
 color "governments: Pirate" .78 0. 0.
 
@@ -1028,7 +1067,9 @@ government "Pirate"
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly pirate"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile pirate"
+	"hostile disabled hail" "hostile disabled"
 	raid "pirate raid"
 
 government "Pirate (Devil-Run Gang)"
@@ -1049,7 +1090,9 @@ government "Pirate (Devil-Run Gang)"
 	"bribe" .05
 	"fine" 0
 	"friendly hail" "friendly pirate"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile pirate"
+	"hostile disabled hail" "hostile disabled"
 
 government "Pirate (Rival)"
 	"display name" "Pirate"
@@ -1067,7 +1110,9 @@ government "Pirate (Rival)"
 	"bribe" 0
 	"fine" 0
 	"friendly hail" "friendly pirate"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile pirate"
+	"hostile disabled hail" "hostile disabled"
 	raid "pirate raid"
 
 color "governments: Pug" .99 .89 .70
@@ -1256,7 +1301,9 @@ government "Remnant"
 			scan 0
 	"provoked on scan"
 	"friendly hail" "remnant uncontacted"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "remnant uncontacted hostile"
+	"hostile disabled hail" "hostile disabled"
 
 government "Remnant (Research)"
 	"display name" "Remnant"
@@ -1280,7 +1327,9 @@ government "Remnant (Research)"
 	"foreign penalties for"
 		"Remnant"
 	"friendly hail" "remnant uncontacted"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "remnant uncontacted hostile"
+	"hostile disabled hail" "hostile disabled"
 
 color "governments: Republic" .91 .42 .09
 
@@ -1304,7 +1353,9 @@ government "Republic"
 		"Navy (Oathkeeper)" 1
 		"Neutral" .1
 	"friendly hail" "friendly navy"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile navy"
+	"hostile disabled hail" "hostile disabled"
 	raid "pirate raid"
 
 government "Republic Intelligence"
@@ -1336,7 +1387,9 @@ government "Republic that won't enter wormhole"
 		"Navy (Oathkeeper)" 1
 		"Neutral" .1
 	"friendly hail" "friendly navy"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile navy"
+	"hostile disabled hail" "hostile disabled"
 	raid "pirate raid"
 
 government "Republic (Friendly)"
@@ -1356,7 +1409,9 @@ government "Republic (Friendly)"
 		"Navy (Oathkeeper)" .01
 		"Neutral" .01
 	"friendly hail" "friendly navy"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile navy"
+	"hostile disabled hail" "hostile disabled"
 
 government "Rulei"
 	swizzle 0
@@ -1376,6 +1431,7 @@ government "Scar's Legion"
 	bribe 0
 	fine 0
 	"hostile hail" "hostile pirate"
+	"hostile disabled hail" "hostile disabled"
 
 government "Scar's Legion (Killable)"
 	"display name" "Scar's Legion"
@@ -1385,6 +1441,7 @@ government "Scar's Legion (Killable)"
 	bribe 0
 	fine 0
 	"hostile hail" "hostile pirate"
+	"hostile disabled hail" "hostile disabled"
 
 government "Sheragi"
 	swizzle 3
@@ -1399,7 +1456,9 @@ government "Smuggler (Hai Trafficker)"
 	"bribe" .1
 	"fine" 0
 	"friendly hail" "friendly civilian"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile pirate"
+	"hostile disabled hail" "hostile disabled"
 
 	# They just want to pass through the system alive, so they
 	# won't attack anyone unless they have to.
@@ -1427,7 +1486,9 @@ government "Syndicate"
 		"Korath" -.5
 	"bribe" .08
 	"friendly hail" "friendly syndicate"
+	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "hostile syndicate"
+	"hostile disabled hail" "hostile disabled"
 	raid "pirate raid"
 
 government "Syndicate (Extremist)"
@@ -1442,6 +1503,7 @@ government "Syndicate (Extremist)"
 	"bribe" 0
 	"fine" 0
 	"hostile hail" "hostile syndicate"
+	"hostile disabled hail" "hostile disabled"
 
 government "Team Blue"
 	swizzle 5

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1365,6 +1365,8 @@ government "Republic Intelligence"
 	"attitude toward"
 		"Pirate" -.3
 		"Pirate (Devil-Run Gang)" -.3
+	"friendly disabled hail" "friendly disabled"
+	"hostile disabled hail" "hostile disabled"
 
 government "Republic that won't enter wormhole"
 	"display name" Republic

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -410,12 +410,6 @@ void Government::Load(const DataNode &node)
 	if(reputationMin > reputationMax)
 		reputationMin = reputationMax;
 	SetReputation(Reputation());
-
-	// Default to the standard disabled hail messages.
-	if(!friendlyDisabledHail)
-		friendlyDisabledHail = GameData::Phrases().Get("friendly disabled");
-	if(!hostileDisabledHail)
-		hostileDisabledHail = GameData::Phrases().Get("hostile disabled");
 }
 
 


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #5442.

## Summary
Removed the lines from the end of the Government Load function that set the friendly and hostile disabled hails to the default phrases if none were provided.

Went through governments.txt and added the friendly and hostile disabled hails to any governments that 1. were already using the defaults and 2. where it made sense for them to continue using the defaults. Let me know if there's any I missed that you think should be using these hails, or any that I gave hails that you think shouldn't have them.

For any government without disabled hails specified, they will now say nothing if you hail them while they are disabled, assuming that you can also communicate with them.

## Testing Done
The code looks like it should work. \:)
But in all seriousness, the Government::GetHail already null checks the hail phrases and returns an empty string if no hail phrase is set for whatever hail state the government is in. This should work just fine.
