### PR TITLE
fix(crash): Fix game crash on short error messages

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 	// Ensure that we log errors to the errors.txt file.
 	Logger::SetLogErrorCallback([&hasErrors](const string &errorMessage) {
 		static const string PARSING_PREFIX = "Parsing: ";
-		if(errorMessage.substr(min(PARSING_PREFIX.length(), errorMessage.length())) != PARSING_PREFIX)
+		if(errorMessage.substr(0, PARSING_PREFIX.length()) != PARSING_PREFIX)
 			hasErrors = true;
 		Files::LogErrorToFile(errorMessage);
 	});

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -95,8 +95,7 @@ int main(int argc, char *argv[])
 	// Ensure that we log errors to the errors.txt file.
 	Logger::SetLogErrorCallback([&hasErrors](const string &errorMessage) {
 		static const string PARSING_PREFIX = "Parsing: ";
-		if(errorMessage.length() <= PARSING_PREFIX.length() || errorMessage.substr(PARSING_PREFIX.length())
-				!= PARSING_PREFIX)
+		if(errorMessage.substr(min(PARSING_PREFIX.length(), errorMessage.length())) != PARSING_PREFIX)
 			hasErrors = true;
 		Files::LogErrorToFile(errorMessage);
 	});

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -95,7 +95,8 @@ int main(int argc, char *argv[])
 	// Ensure that we log errors to the errors.txt file.
 	Logger::SetLogErrorCallback([&hasErrors](const string &errorMessage) {
 		static const string PARSING_PREFIX = "Parsing: ";
-		if(errorMessage.substr(PARSING_PREFIX.length()) != PARSING_PREFIX)
+		if(errorMessage.length() <= PARSING_PREFIX.length() || errorMessage.substr(PARSING_PREFIX.length())
+				!= PARSING_PREFIX)
 			hasErrors = true;
 		Files::LogErrorToFile(errorMessage);
 	});


### PR DESCRIPTION
**Bug fix**

This PR fixes a crash reported by @Arachi-Lover on discord.

## Summary
The game crashed when loading a save file. No longer crashes after this PR.

## Testing Done
I tested that the game no longer crashes when the save is loaded.

## Save File
[Arachi's save file](https://discord.com/channels/251118043411775489/536900466655887360/1211341115165380618)

## Performance Impact
N/A