### PR TITLE
fix(ui): Don't draw name tooltips for ships hidden under the shop sidebar footer

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -767,7 +767,7 @@ void ShopPanel::DrawShipsSidebar()
 
 		shipZones.emplace_back(point, Point(ICON_TILE, ICON_TILE), ship.get());
 
-		if(shipZones.back().Contains(mouse))
+		if(mouse.Y() < Screen::Bottom() - BUTTON_HEIGHT && shipZones.back().Contains(mouse))
 		{
 			shipName = ship->Name();
 			hoverPoint = shipZones.back().TopLeft();


### PR DESCRIPTION
## Bug Summary
Currently, if you have a lot of ships and your fleet list in the shop sidebar becomes so long that some ships go behind the footer, the name / warning tooltips are still displayed when you're hovering over the hidden ships, which blocks the credits tooltip.

## Screenshots
Before:
![tooltip_before](https://github.com/endless-sky/endless-sky/assets/108272452/a87a5de5-7d25-4035-912a-117eeff4ef6b)
After:
![tooltip_after](https://github.com/endless-sky/endless-sky/assets/108272452/f75b8375-2aa7-4bb8-8556-3b2c522902ce)

## Testing Done
See the above screenshots.

## Save File
Just buy a hundred ships and remove their hyperdrives.

## Performance Impact
N/A