### PR TITLE
fix(content): Add blocked message to Hai Film Crew 3

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -1761,6 +1761,7 @@ mission "Hai Film Crew 3"
 	description "Take Likeet's film crew home to their studio on <destination>, so that they can process the film they shot on <origin>. Payment is <payment>."
 	cargo "film equipment" 30
 	passengers 80
+	blocked "You have reached <origin>, but you need <capacity> in order to take on the next mission. Return here when you have the required space free."
 	source "Darkrest"
 	destination
 		attributes hai


### PR DESCRIPTION
**Bug fix**

## Summary
This mission failed to trigger silently when I didn't have enough space in 0.10.6. I added a 'blocked' line to make it visible the mission is blocked and not just disappearing. I'd appreciate a review to see if I fixed it right as I've never made an edit to this codebase before.

## Testing Done
Change introduced in local files first for testing.

## Save File
This save file can be used to test these changes:
[Avin Marr~3022-12-28.txt](https://github.com/endless-sky/endless-sky/files/14472435/Avin.Marr.3022-12-28.txt)
