### PR TITLE
fix(content): Fix overlapping stars in Umbral system

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -32660,11 +32660,11 @@ system Umbral
 	fleet "Large Southern Pirates" 6000
 	object
 		sprite star/k0-old
-		distance 23.3222
+		distance 25
 		period 10.2313
 	object
 		sprite star/m0
-		distance 71.4243
+		distance 90
 		period 10.2313
 		offset 180
 	object


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses a [comment brought up](https://steamcommunity.com/app/404410/discussions/1/4304949638716477535/) on the steam forums.

## Summary
Umbral's binary stars are overlapping. This PR makes it so they don't do that.

Note: If we use scripts (mainly @Amazinite's) to re-do the map file in the future again, this will have to be re-adjusted.

## Screenshots
Before (too clingy):
![before](https://github.com/endless-sky/endless-sky/assets/93169396/9b43539b-c76a-4eb6-8e55-8ef8220427c6)

After (respecting boundaries):
![after happy](https://github.com/endless-sky/endless-sky/assets/93169396/f23dd85c-02c5-49be-a750-e190e9d482b8)

## Testing Done
In the wise words of another dev:

No