### PR TITLE
fix(bug): Give Vyrmeid atmosphere scan

### DIFF
--- a/data/vyrmeid/vyrmeid.txt
+++ b/data/vyrmeid/vyrmeid.txt
@@ -43,7 +43,7 @@ ship "Vyrmeid"
 		"thrust" 10
 		"turn" 120
 
-		"atmospheric scan" 1
+		"atmosphere scan" 1
 		"energy protection" 1
 		"ion protection" 1
 	outfits


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in https://github.com/endless-sky/endless-sky/issues/9894#issuecomment-1984197525

## Summary
The Vyrmeid has “atmospheric scan,” which does nothing. I think that it is supposed to have “atmosphere scan.”

## Testing Done
The Vyrmeid still don’t try to scan stellar objects, even when I’m cloaked. I think this is because a different personality overrides it.

## Save File
[Test Pilot~Vyrmeid.txt](https://github.com/endless-sky/endless-sky/files/14528962/Test.Pilot.Vyrmeid.txt)

